### PR TITLE
Add support to block tags and hide model from the feed

### DIFF
--- a/prisma/migrations/20230110213544_add_tag_engagment/migration.sql
+++ b/prisma/migrations/20230110213544_add_tag_engagment/migration.sql
@@ -1,0 +1,18 @@
+-- CreateEnum
+CREATE TYPE "TagEngagementType" AS ENUM ('Hide', 'Follow');
+
+-- CreateTable
+CREATE TABLE "TagEngagement" (
+    "userId" INTEGER NOT NULL,
+    "tagId" INTEGER NOT NULL,
+    "type" "TagEngagementType" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TagEngagement_pkey" PRIMARY KEY ("userId","tagId")
+);
+
+-- AddForeignKey
+ALTER TABLE "TagEngagement" ADD CONSTRAINT "TagEngagement_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TagEngagement" ADD CONSTRAINT "TagEngagement_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,7 @@ model User {
   commentV2Reactions   CommentV2Reaction[]
   answerVotes          AnswerVote[]
   downloads            DownloadHistory[]
+  tagsEngaged          TagEngagement[]
 }
 
 enum UserEngagementType {
@@ -539,6 +540,7 @@ model Tag {
 
   tagsOnModels   TagsOnModels[]
   TagsOnQuestion TagsOnQuestions[]
+  usersEngaged   TagEngagement[]
 
   @@unique([name, target])
 }
@@ -847,6 +849,22 @@ model CommentV2Reaction {
   updatedAt DateTime        @updatedAt
 
   @@unique([commentId, userId, reaction])
+}
+
+enum TagEngagementType {
+  Hide
+  Follow
+}
+
+model TagEngagement {
+  userId    Int
+  user      User              @relation(fields: [userId], references: [id])
+  tagId     Int
+  tag       Tag               @relation(fields: [tagId], references: [id])
+  type      TagEngagementType
+  createdAt DateTime          @default(now())
+
+  @@id([userId, tagId])
 }
 
 /// @view

--- a/src/components/Account/TagsCard.tsx
+++ b/src/components/Account/TagsCard.tsx
@@ -1,0 +1,127 @@
+import {
+  ActionIcon,
+  Autocomplete,
+  Badge,
+  Card,
+  Center,
+  Group,
+  Loader,
+  LoadingOverlay,
+  Paper,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { useDebouncedState } from '@mantine/hooks';
+import { IconSearch, IconX } from '@tabler/icons';
+
+import { trpc } from '~/utils/trpc';
+
+export function TagsCard() {
+  const queryUtils = trpc.useContext();
+  const [search, setSearch] = useDebouncedState('', 300);
+
+  const { data: blockedTags = [], isLoading: loadingBlockedTags } = trpc.user.getTags.useQuery({
+    type: 'Hide',
+  });
+  const { data, isLoading } = trpc.tag.getAll.useQuery(
+    {
+      entityType: 'Model',
+      query: search.trim(),
+    },
+    { enabled: !loadingBlockedTags }
+  );
+  const modelTags = data?.items.map(({ id, name }) => ({ id, value: name })) ?? [];
+
+  const toggleBlockedTagMutation = trpc.user.toggleBlockedTag.useMutation({
+    async onMutate({ tagId }) {
+      await queryUtils.user.getTags.cancel();
+
+      const prevBlockedTags = queryUtils.user.getTags.getData({ type: 'Hide' }) ?? [];
+      const removing = prevBlockedTags.some((tag) => tag.id === tagId);
+
+      queryUtils.user.getTags.setData({ type: 'Hide' }, (old = []) => {
+        if (removing) return old.filter((tag) => tag.id !== tagId);
+
+        const { tagsOnModels, ...addedTag } = data?.items.find((tag) => tag.id === tagId) ?? {
+          id: tagId,
+          name: '',
+        };
+        return [...old, addedTag];
+      });
+
+      return { prevBlockedTags };
+    },
+    async onSuccess() {
+      await queryUtils.model.getAll.invalidate();
+    },
+    onError(_error, _variables, context) {
+      queryUtils.user.getTags.setData({ type: 'Hide' }, context?.prevBlockedTags);
+    },
+    async onSettled() {
+      await queryUtils.user.getTags.invalidate({ type: 'Hide' });
+    },
+  });
+  const handleToggleBlockedTag = (tagId: number) => {
+    toggleBlockedTagMutation.mutate({ tagId });
+    setSearch('');
+  };
+
+  return (
+    <Card withBorder>
+      <Stack spacing={0}>
+        <Title order={2}>Blocked Tags</Title>
+        <Text color="dimmed" size="sm">
+          You will stop seeing models that contain tags you have blocked. Use the input below to
+          manage them.
+        </Text>
+      </Stack>
+      <Stack mt="md">
+        <Autocomplete
+          name="tag"
+          placeholder="Search tags to hide"
+          data={modelTags}
+          onChange={setSearch}
+          icon={isLoading ? <Loader size="xs" /> : <IconSearch size={14} />}
+          onItemSubmit={(item: { value: string; id: number }) => handleToggleBlockedTag(item.id)}
+          withinPortal
+        />
+        <Paper p="xs" radius="md" sx={{ position: 'relative' }} withBorder>
+          <LoadingOverlay visible={loadingBlockedTags} />
+          {blockedTags.length > 0 ? (
+            <Group spacing={4}>
+              {blockedTags.map((tag) => (
+                <Badge
+                  key={tag.id}
+                  sx={{ paddingRight: 3 }}
+                  rightSection={
+                    <ActionIcon
+                      size="xs"
+                      color="blue"
+                      radius="xl"
+                      variant="transparent"
+                      onClick={() => handleToggleBlockedTag(tag.id)}
+                    >
+                      <IconX size={10} />
+                    </ActionIcon>
+                  }
+                >
+                  {tag.name}
+                </Badge>
+              ))}
+            </Group>
+          ) : (
+            <Center>
+              <Stack spacing={2}>
+                <Text weight="bold">No blocked tags</Text>
+                <Text size="sm" color="dimmed">
+                  You can add tags by using the search input above.
+                </Text>
+              </Stack>
+            </Center>
+          )}
+        </Paper>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/InfiniteModels/InfiniteModels.tsx
+++ b/src/components/InfiniteModels/InfiniteModels.tsx
@@ -21,6 +21,7 @@ import {
 import { ModelStatus } from '@prisma/client';
 import { useWindowSize } from '@react-hook/window-size';
 import {
+  IconBan,
   IconCloudOff,
   IconDotsVertical,
   IconDownload,
@@ -89,6 +90,9 @@ export function InfiniteModels({
   const queryParams = result.success ? result.data : {};
 
   const { ref, inView } = useInView();
+
+  const { data: blockedTags } = trpc.user.getTags.useQuery({ type: 'Hide' });
+  const excludedTagIds = blockedTags?.map((tag) => tag.id);
   const {
     data,
     isLoading,
@@ -97,7 +101,7 @@ export function InfiniteModels({
     hasNextPage,
     // hasPreviousPage,
   } = trpc.model.getAll.useInfiniteQuery(
-    { ...filters, ...queryParams },
+    { ...filters, ...queryParams, excludedTagIds },
     {
       getNextPageParam: (lastPage) => (!!lastPage ? lastPage.nextCursor : 0),
       getPreviousPageParam: (firstPage) => (!!firstPage ? firstPage.nextCursor : 0),
@@ -401,7 +405,7 @@ const MasonryItem = ({
     <LoginRedirect reason="report-model" key="report">
       <Menu.Item
         icon={<IconFlag size={14} stroke={1.5} />}
-        onClick={(e: any) => {
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           e.preventDefault();
           e.stopPropagation();
           openContext('report', { type: ReportEntity.Model, entityId: id });
@@ -411,10 +415,26 @@ const MasonryItem = ({
       </Menu.Item>
     </LoginRedirect>
   );
-  const contextMenuItems: React.ReactNode[] = [];
-  if (currentUser?.id != user.id)
-    contextMenuItems.push(<HideUserButton key="hide-button" as="menu-item" userId={user.id} />);
-  if (currentUser?.id != user.id) contextMenuItems.push(reportOption);
+
+  const blockTagsOption = (
+    <Menu.Item
+      icon={<IconBan size={14} stroke={1.5} />}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        openContext('blockTags', { modelId: id });
+      }}
+    >
+      {`Block model's tags`}
+    </Menu.Item>
+  );
+  let contextMenuItems: React.ReactNode[] = [];
+  if (currentUser?.id !== user.id)
+    contextMenuItems = contextMenuItems.concat([
+      <HideUserButton key="hide-button" as="menu-item" userId={user.id} />,
+      reportOption,
+    ]);
+  if (currentUser) contextMenuItems.push(blockTagsOption);
 
   const isNew = data.createdAt > aDayAgo;
   const isUpdated = !isNew && data.lastVersionAt && data.lastVersionAt > aDayAgo;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,10 @@ import { getServerProxySSGHelpers } from '~/server/utils/getServerProxySSGHelper
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getServerAuthSession(context);
   const ssg = await getServerProxySSGHelpers(context);
-  if (session) await ssg.user.getFavoriteModels.prefetch(undefined);
+  if (session) {
+    await ssg.user.getFavoriteModels.prefetch(undefined);
+    await ssg.user.getTags.prefetch({ type: 'Hide' });
+  }
 
   return {
     props: {

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -553,7 +553,17 @@ export default function ModelDetail(props: InferGetServerSidePropsType<typeof ge
                     </Menu.Item>
                   </LoginRedirect>
                 )}
-                {currentUser && <HideUserButton as="menu-item" userId={model.user.id} />}
+                {currentUser && (
+                  <>
+                    <HideUserButton as="menu-item" userId={model.user.id} />
+                    <Menu.Item
+                      icon={<IconBan size={14} stroke={1.5} />}
+                      onClick={() => openContext('blockTags', { modelId: model.id })}
+                    >
+                      Block tags
+                    </Menu.Item>
+                  </>
+                )}
               </Menu.Dropdown>
             </Menu>
           </Group>
@@ -700,49 +710,24 @@ export default function ModelDetail(props: InferGetServerSidePropsType<typeof ge
               <DescriptionTable items={modelDetails} labelWidth="30%" />
               {model?.type === 'Checkpoint' && (
                 <Group position="apart" align="flex-start" style={{ flexWrap: 'nowrap' }}>
-                  <Group
-                    spacing={4}
-                    noWrap
-                    style={{ flex: 1, overflow: 'hidden' }}
-                    align="flex-start"
-                  >
+                  <Group spacing="xs" noWrap style={{ flex: 1, overflow: 'hidden' }}>
                     <IconLicense size={16} />
                     <Text
                       size="xs"
                       color="dimmed"
                       sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
                     >
-                      License{model?.licenses.length > 0 ? 's' : ''}:
-                    </Text>
-                    <Stack spacing={0}>
+                      License:{' '}
                       <Text
                         component="a"
                         href="https://huggingface.co/spaces/CompVis/stable-diffusion-license"
                         rel="nofollow"
                         td="underline"
                         target="_blank"
-                        size="xs"
-                        color="dimmed"
-                        sx={{ lineHeight: 1.1 }}
                       >
                         creativeml-openrail-m
                       </Text>
-                      {model?.licenses.map(({ url, name }) => (
-                        <Text
-                          key={name}
-                          component="a"
-                          rel="nofollow"
-                          href={url}
-                          td="underline"
-                          size="xs"
-                          color="dimmed"
-                          target="_blank"
-                          sx={{ lineHeight: 1.1 }}
-                        >
-                          {name}
-                        </Text>
-                      ))}
-                    </Stack>
+                    </Text>
                   </Group>
                   <PermissionIndicator spacing={5} size={28} permissions={model} />
                 </Group>

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -6,10 +6,11 @@ import React from 'react';
 import { AccountsCard } from '~/components/Account/AccountsCard';
 import { ApiKeysCard } from '~/components/Account/ApiKeysCard';
 import { CreatorCard } from '~/components/Account/CreatorCard';
-import { Meta } from '~/components/Meta/Meta';
 import { NotificationsCard } from '~/components/Account/NotificationsCard';
 import { ProfileCard } from '~/components/Account/ProfileCard';
 import { SettingsCard } from '~/components/Account/SettingsCard';
+import { TagsCard } from '~/components/Account/TagsCard';
+import { Meta } from '~/components/Meta/Meta';
 import { env } from '~/env/server.mjs';
 import { getServerAuthSession } from '~/server/utils/get-server-auth-session';
 import { getServerProxySSGHelpers } from '~/server/utils/getServerProxySSGHelpers';
@@ -33,6 +34,7 @@ export default function Account({ providers, isDev = false }: Props) {
           <SettingsCard />
           <NotificationsCard />
           <AccountsCard providers={providers} />
+          <TagsCard />
           {isDev && <ApiKeysCard />}
         </Stack>
       </Container>

--- a/src/routed-context/modals/BlockModelTags.tsx
+++ b/src/routed-context/modals/BlockModelTags.tsx
@@ -1,0 +1,100 @@
+import { Button, Center, Chip, Group, Loader, Modal, Stack, Text } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+
+import { createRoutedContext } from '~/routed-context/create-routed-context';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+export default createRoutedContext({
+  authGuard: true,
+  schema: z.object({
+    modelId: z.number(),
+  }),
+  Element: ({ context, props: { modelId } }) => {
+    const queryUtils = trpc.useContext();
+
+    const { data: blockedTags = [] } = trpc.user.getTags.useQuery({ type: 'Hide' });
+    const { data, isLoading } = trpc.tag.getAll.useQuery({
+      limit: 0,
+      entityType: 'Model',
+      modelId,
+    });
+    const modelTags = data?.items ?? [];
+    const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+    useEffect(() => {
+      if (blockedTags.length) setSelectedTags(blockedTags.map(({ id }) => String(id)));
+    }, [blockedTags]);
+
+    const { mutate, isLoading: mutatingBlockedTags } = trpc.user.batchBlockTags.useMutation({
+      async onSuccess() {
+        context.close();
+        await queryUtils.model.getAll.invalidate();
+        await queryUtils.user.getTags.invalidate({ type: 'Hide' });
+      },
+      onError(error) {
+        showErrorNotification({ error: new Error(error.message) });
+      },
+    });
+    const handleBlockTags = () => mutate({ tagIds: selectedTags.map(Number) });
+
+    return (
+      <Modal opened={context.opened} onClose={context.close} title="Block Tags">
+        {isLoading ? (
+          <Center p="lg">
+            <Loader size="lg" />
+          </Center>
+        ) : (
+          <Stack>
+            {modelTags.length > 0 ? (
+              <>
+                <Text size="sm" color="dimmed">
+                  Select the tags you want to add to your blocking list
+                </Text>
+                <Chip.Group
+                  spacing={4}
+                  position="center"
+                  value={selectedTags}
+                  onChange={setSelectedTags}
+                  multiple
+                >
+                  {modelTags.map((tag) => {
+                    const selected = selectedTags.includes(String(tag.id));
+
+                    return (
+                      <Chip
+                        key={tag.id}
+                        color={selected ? 'red' : undefined}
+                        value={String(tag.id)}
+                      >
+                        {tag.name}
+                      </Chip>
+                    );
+                  })}
+                </Chip.Group>
+                <Group position="apart">
+                  <Button variant="default" onClick={context.close}>
+                    Cancel
+                  </Button>
+                  <Button onClick={handleBlockTags} loading={mutatingBlockedTags}>
+                    Save
+                  </Button>
+                </Group>
+              </>
+            ) : (
+              <>
+                <Text>{`This model doesn't has any tags`}</Text>
+                <Group position="right">
+                  <Button variant="default" onClick={context.close}>
+                    Close
+                  </Button>
+                </Group>
+              </>
+            )}
+          </Stack>
+        )}
+      </Modal>
+    );
+  },
+});

--- a/src/routed-context/routed-context.provider.tsx
+++ b/src/routed-context/routed-context.provider.tsx
@@ -12,6 +12,7 @@ const ReviewThread = dynamic(() => import('~/routed-context/modals/ReviewThread'
 const CommentThread = dynamic(() => import('~/routed-context/modals/CommentThread'));
 const CommentEdit = dynamic(() => import('~/routed-context/modals/CommentEdit'));
 const Report = dynamic(() => import('~/routed-context/modals/Report'));
+const BlockModelTags = dynamic(() => import('~/routed-context/modals/BlockModelTags'));
 
 const dictionary = {
   modelVersionLightbox: ModelVersionLightbox,
@@ -22,6 +23,7 @@ const dictionary = {
   commentThread: CommentThread,
   commentEdit: CommentEdit,
   report: Report,
+  blockTags: BlockModelTags,
 };
 
 // function register<T extends Record<string, ComponentType>>(dictionary: T) {

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -26,7 +26,6 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
-import { getUserById } from '~/server/services/user.service';
 
 export type GetModelReturnType = AsyncReturnType<typeof getModelHandler>;
 export const getModelHandler = async ({ input, ctx }: { input: GetByIdInput; ctx: Context }) => {
@@ -54,19 +53,8 @@ export const getModelsInfiniteHandler = async ({
   input.limit = input.limit ?? 100;
   const take = input.limit + 1;
 
-  // Get blockedTags for currentUser to exclude from models query
-  let excludedTagIds: number[] | undefined;
-  if (ctx.user) {
-    const { id: userId } = ctx.user;
-    const user = await getUserById({
-      id: userId,
-      select: { tagsEngaged: { where: { type: 'Hide' }, select: { tagId: true } } },
-    });
-    excludedTagIds = user?.tagsEngaged.map(({ tagId }) => tagId);
-  }
-
   const { items } = await getModels({
-    input: { ...input, take, excludedTagIds },
+    input: { ...input, take },
     user: ctx.user,
     select: {
       id: true,

--- a/src/server/controllers/tag.controller.ts
+++ b/src/server/controllers/tag.controller.ts
@@ -17,14 +17,13 @@ export const getTagWithModelCountHandler = async ({
 
 export const getAllTagsHandler = async ({ input }: { input?: GetTagsInput }) => {
   try {
-    const { withModels = false, limit = DEFAULT_PAGE_SIZE, page, query, entityType } = input || {};
+    const { withModels = false, limit = DEFAULT_PAGE_SIZE, page } = input || {};
     const { take, skip } = getPagination(limit, page);
 
     const results = await getTags({
+      ...input,
       take,
       skip,
-      query,
-      target: entityType,
       select: {
         id: true,
         name: true,

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -5,6 +5,7 @@ import {
   getUserCreator,
   getUserFavoriteModelByModelId,
   getUserFavoriteModels,
+  getUserTags,
   getUserUnreadNotificationsCount,
   toggleBlockedTag,
   toggleFollowUser,
@@ -22,6 +23,7 @@ import {
   DeleteUserInput,
   ToggleBlockedTagSchema,
   GetUserTagsSchema,
+  BatchBlockTagsSchema,
 } from '~/server/schema/user.schema';
 import { simpleUserSelect } from '~/server/selectors/user.selector';
 import { deleteUser, getUserById, getUsers, updateUserById } from '~/server/services/user.service';
@@ -420,7 +422,7 @@ export const getUserTagsHandler = async ({
   }
 };
 
-export const toggleBlockedTagHandler = async ({
+export const toggleBlockedTagHandler = ({
   input,
   ctx,
 }: {
@@ -430,6 +432,41 @@ export const toggleBlockedTagHandler = async ({
   try {
     const { id: userId } = ctx.user;
     return toggleBlockedTag({ ...input, userId });
+  } catch (error) {
+    throw throwDbError(error);
+  }
+};
+
+export const batchBlockTagsHandler = async ({
+  input,
+  ctx,
+}: {
+  input: BatchBlockTagsSchema;
+  ctx: DeepNonNullable<Context>;
+}) => {
+  try {
+    const { id: userId } = ctx.user;
+    const { tagIds } = input;
+    const currentBlockedTags = await getUserTags({ userId, type: 'Hide' });
+    const blockedTagIds = currentBlockedTags.map(({ tagId }) => tagId);
+    const tagsToRemove = blockedTagIds.filter((id) => !tagIds.includes(id));
+
+    const updatedUser = await updateUserById({
+      id: userId,
+      data: {
+        tagsEngaged: {
+          deleteMany: { userId, tagId: { in: tagsToRemove } },
+          upsert: tagIds.map((tagId) => ({
+            where: { userId_tagId: { userId, tagId } },
+            update: { type: 'Hide' },
+            create: { type: 'Hide', tagId },
+          })),
+        },
+      },
+    });
+    if (!updatedUser) throw throwNotFoundError(`No user with id ${userId}`);
+
+    return updatedUser;
   } catch (error) {
     throw throwDbError(error);
   }

--- a/src/server/routers/tag.router.ts
+++ b/src/server/routers/tag.router.ts
@@ -1,7 +1,8 @@
-import { getTagWithModelCountHandler } from './../controllers/tag.controller';
-import { getTagByNameSchema } from './../schema/tag.schema';
-import { getAllTagsHandler } from '~/server/controllers/tag.controller';
-import { getTagsInput } from '~/server/schema/tag.schema';
+import {
+  getAllTagsHandler,
+  getTagWithModelCountHandler,
+} from '~/server/controllers/tag.controller';
+import { getTagByNameSchema, getTagsInput } from '~/server/schema/tag.schema';
 import { publicProcedure, router } from '~/server/trpc';
 
 export const tagRouter = router({

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -10,6 +10,7 @@ import {
   toggleFollowUserHandler,
   toggleHideUserHandler,
   toggleBlockedTagHandler,
+  batchBlockTagsHandler,
 } from '~/server/controllers/user.controller';
 import {
   deleteUserHandler,
@@ -31,6 +32,7 @@ import {
   deleteUserSchema,
   toggleBlockedTagSchema,
   getUserTagsSchema,
+  batchBlockTagsSchema,
 } from '~/server/schema/user.schema';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
 
@@ -57,4 +59,5 @@ export const userRouter = router({
   toggleBlockedTag: protectedProcedure
     .input(toggleBlockedTagSchema)
     .mutation(toggleBlockedTagHandler),
+  batchBlockTags: protectedProcedure.input(batchBlockTagsSchema).mutation(batchBlockTagsHandler),
 });

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -2,12 +2,14 @@ import {
   checkUserNotificationsHandler,
   getLeaderboardHandler,
   getNotificationSettingsHandler,
+  getUserTagsHandler,
   getUserCreatorHandler,
   getUserFollowingListHandler,
   getUserHiddenListHandler,
   getUserListsHandler,
   toggleFollowUserHandler,
   toggleHideUserHandler,
+  toggleBlockedTagHandler,
 } from '~/server/controllers/user.controller';
 import {
   deleteUserHandler,
@@ -27,6 +29,8 @@ import {
   toggleFollowUserSchema,
   userUpsertSchema,
   deleteUserSchema,
+  toggleBlockedTagSchema,
+  getUserTagsSchema,
 } from '~/server/schema/user.schema';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
 
@@ -37,6 +41,7 @@ export const userRouter = router({
   getFavoriteModels: protectedProcedure.query(getUserFavoriteModelsHandler),
   getFollowingUsers: protectedProcedure.query(getUserFollowingListHandler),
   getHiddenUsers: protectedProcedure.query(getUserHiddenListHandler),
+  getTags: protectedProcedure.input(getUserTagsSchema.optional()).query(getUserTagsHandler),
   getCreators: publicProcedure.input(getAllQuerySchema.partial()).query(getCreatorsHandler),
   getNotificationSettings: protectedProcedure.query(getNotificationSettingsHandler),
   getLists: publicProcedure.input(getByUsernameSchema).query(getUserListsHandler),
@@ -49,4 +54,7 @@ export const userRouter = router({
     .mutation(toggleFavoriteModelHandler),
   toggleFollow: protectedProcedure.input(toggleFollowUserSchema).mutation(toggleFollowUserHandler),
   toggleHide: protectedProcedure.input(toggleFollowUserSchema).mutation(toggleHideUserHandler),
+  toggleBlockedTag: protectedProcedure
+    .input(toggleBlockedTagSchema)
+    .mutation(toggleBlockedTagHandler),
 });

--- a/src/server/schema/base.schema.ts
+++ b/src/server/schema/base.schema.ts
@@ -4,7 +4,7 @@ export const getByIdSchema = z.object({ id: z.number() });
 export type GetByIdInput = z.infer<typeof getByIdSchema>;
 
 export const getAllQuerySchema = z.object({
-  limit: z.preprocess((val) => Number(val), z.number().min(0).max(200).default(20)),
+  limit: z.preprocess((val) => Number(val), z.number().min(0).max(200).default(20)).optional(),
   page: z.preprocess((val) => Number(val), z.number().min(1)).optional(),
   query: z.string().optional(),
 });

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -43,6 +43,7 @@ export const getAllModelsSchema = z.object({
     (val) => val === true || val === 'true',
     z.boolean().optional().default(false)
   ),
+  excludedTagIds: z.array(z.number()).optional(),
 });
 
 export type GetAllModelsInput = z.input<typeof getAllModelsSchema>;

--- a/src/server/schema/tag.schema.ts
+++ b/src/server/schema/tag.schema.ts
@@ -27,5 +27,6 @@ export const getTagsInput = getAllQuerySchema.extend({
     }, z.boolean().default(false))
     .optional(),
   entityType: z.nativeEnum(TagTarget),
+  modelId: z.number().optional(),
 });
 export type GetTagsInput = z.infer<typeof getTagsInput>;

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -1,4 +1,4 @@
-import { ModelFileFormat } from '@prisma/client';
+import { ModelFileFormat, TagEngagementType } from '@prisma/client';
 import { z } from 'zod';
 
 export const getUserByUsernameSchema = z.object({
@@ -29,6 +29,12 @@ export type ToggleFavoriteModelInput = z.infer<typeof toggleFavoriteModelInput>;
 
 export const toggleFollowUserSchema = z.object({ targetUserId: z.number() });
 export type ToggleFollowUserSchema = z.infer<typeof toggleFollowUserSchema>;
+
+export const getUserTagsSchema = z.object({ type: z.nativeEnum(TagEngagementType) });
+export type GetUserTagsSchema = z.infer<typeof getUserTagsSchema>;
+
+export const toggleBlockedTagSchema = z.object({ tagId: z.number() });
+export type ToggleBlockedTagSchema = z.infer<typeof toggleBlockedTagSchema>;
 
 export const getByUsernameSchema = z.object({ username: z.string() });
 export type GetByUsernameSchema = z.infer<typeof getByUsernameSchema>;

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -36,6 +36,9 @@ export type GetUserTagsSchema = z.infer<typeof getUserTagsSchema>;
 export const toggleBlockedTagSchema = z.object({ tagId: z.number() });
 export type ToggleBlockedTagSchema = z.infer<typeof toggleBlockedTagSchema>;
 
+export const batchBlockTagsSchema = z.object({ tagIds: z.array(z.number()) });
+export type BatchBlockTagsSchema = z.infer<typeof batchBlockTagsSchema>;
+
 export const getByUsernameSchema = z.object({ username: z.string() });
 export type GetByUsernameSchema = z.infer<typeof getByUsernameSchema>;
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -47,6 +47,7 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
     rating,
     favorites,
     hideNSFW,
+    excludedTagIds,
   },
   select,
   user: sessionUser,
@@ -80,6 +81,11 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
           },
         },
       ],
+    });
+  }
+  if (excludedTagIds) {
+    AND.push({
+      tagsOnModels: { every: { tagId: { notIn: excludedTagIds } } },
     });
   }
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -83,7 +83,7 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
       ],
     });
   }
-  if (excludedTagIds) {
+  if (excludedTagIds && !username) {
     AND.push({
       tagsOnModels: { every: { tagId: { notIn: excludedTagIds } } },
     });

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -1,6 +1,7 @@
-import { Prisma, TagTarget } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 import { prisma } from '~/server/db/client';
+import { GetTagsInput } from '~/server/schema/tag.schema';
 
 export const getTagWithModelCount = async ({ name }: { name: string }) => {
   return await prisma.tag.findFirst({
@@ -21,18 +22,18 @@ export const getTags = async <TSelect extends Prisma.TagSelect = Prisma.TagSelec
   select,
   take,
   skip,
-  target,
+  entityType,
   query,
-}: {
+  modelId,
+}: Partial<GetTagsInput> & {
   select: TSelect;
   take?: number;
   skip?: number;
-  target?: TagTarget;
-  query?: string;
 }) => {
   const where: Prisma.TagWhereInput = {
     name: query ? { contains: query, mode: 'insensitive' } : undefined,
-    target,
+    target: entityType,
+    tagsOnModels: modelId ? { some: { modelId } } : undefined,
   };
 
   const items = await prisma.tag.findMany({

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1,5 +1,5 @@
 import { throwNotFoundError } from '~/server/utils/errorHandling';
-import { Prisma } from '@prisma/client';
+import { Prisma, TagEngagementType } from '@prisma/client';
 
 import { prisma } from '~/server/db/client';
 import { GetByIdInput } from '~/server/schema/base.schema';
@@ -108,6 +108,10 @@ export const getUserFavoriteModelByModelId = ({
   modelId: number;
 }) => {
   return prisma.favoriteModel.findUnique({ where: { userId_modelId: { userId, modelId } } });
+};
+
+export const getUserTags = ({ userId, type }: { userId: number; type?: TagEngagementType }) => {
+  return prisma.tagEngagement.findMany({ where: { userId, type } });
 };
 
 export const getCreators = async <TSelect extends Prisma.UserSelect>({


### PR DESCRIPTION
### Description

- Updated prisma schema to support blocking/following tags by users
- Added new endpoints to get user tags and toggle between blocking tags
- Added a new settings card to manage blocked tags
- Updated getModels query to exclude models related to user's blocked tags

### Screenshots

![image](https://user-images.githubusercontent.com/12631159/211675003-9ce7d345-c1e5-4246-abdf-5e6471fc988d.png)

![image](https://user-images.githubusercontent.com/12631159/211912778-6d5ed049-c4f1-461b-a168-86f77adf8b8f.png)
