### PR TITLE
Adds delete account card in the account page

### DIFF
--- a/src/components/Account/DeleteCard.tsx
+++ b/src/components/Account/DeleteCard.tsx
@@ -1,0 +1,66 @@
+import { Button, Card, Stack, Text, Title } from '@mantine/core';
+import { closeModal, openConfirmModal } from '@mantine/modals';
+import { signOut } from 'next-auth/react';
+
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+export function DeleteCard() {
+  const currentUser = useCurrentUser();
+
+  const deleteAccountMutation = trpc.user.delete.useMutation({
+    async onSuccess() {
+      await signOut();
+    },
+    onError(error) {
+      showErrorNotification({ error: new Error(error.message) });
+    },
+  });
+  const handleDeleteAccount = () => {
+    openConfirmModal({
+      modalId: 'delete-confirm',
+      title: 'Delete your account',
+      children: 'Are you sure you want to delete your account? All data will be permanently lost.',
+      centered: true,
+      labels: { cancel: `Cancel`, confirm: `Yes, I am sure` },
+      confirmProps: { color: 'red' },
+      closeOnConfirm: false,
+      onConfirm: () =>
+        openConfirmModal({
+          modalId: 'wipe-confirm',
+          title: 'Wipe your models',
+          children:
+            'Do you want to delete all the models you have created along with your account?',
+          centered: true,
+          closeOnCancel: false,
+          closeOnConfirm: false,
+          labels: { cancel: 'Yes, wipe them', confirm: 'No, leave them up' },
+          confirmProps: { color: 'red', loading: deleteAccountMutation.isLoading },
+          cancelProps: { loading: deleteAccountMutation.isLoading },
+          onConfirm: () =>
+            currentUser ? deleteAccountMutation.mutateAsync({ ...currentUser }) : undefined,
+          onCancel: () =>
+            currentUser
+              ? deleteAccountMutation.mutateAsync({ ...currentUser, removeModels: true })
+              : undefined,
+          onClose: () => closeModal('delete-confirm'),
+        }),
+    });
+  };
+
+  return (
+    <Card withBorder>
+      <Stack>
+        <Title order={2}>Delete account</Title>
+        <Text size="sm">
+          Once you delete your account, there is no going back. Please be certain when taking this
+          action.
+        </Text>
+        <Button variant="outline" color="red" onClick={handleDeleteAccount}>
+          Delete your account
+        </Button>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/Account/ProfileCard.tsx
+++ b/src/components/Account/ProfileCard.tsx
@@ -1,6 +1,7 @@
 import { Stack, Button, Alert, Card, Title } from '@mantine/core';
-import { useSession } from 'next-auth/react';
 import { z } from 'zod';
+
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { Form, InputProfileImageUpload, InputText, useForm } from '~/libs/form';
 import { reloadSession } from '~/utils/next-auth-helpers';
 import { showSuccessNotification } from '~/utils/notifications';
@@ -15,7 +16,7 @@ const schema = z.object({
 });
 
 export function ProfileCard() {
-  const { data: session } = useSession();
+  const currentUser = useCurrentUser();
   const utils = trpc.useContext();
 
   const { mutate, isLoading, error } = trpc.user.update.useMutation({
@@ -35,12 +36,12 @@ export function ProfileCard() {
   const form = useForm({
     schema,
     mode: 'onChange',
-    defaultValues: session?.user,
+    defaultValues: { ...currentUser },
   });
 
   return (
     <Card withBorder>
-      <Form form={form} onSubmit={(data) => mutate({ id: session?.user?.id, ...data })}>
+      <Form form={form} onSubmit={(data) => mutate({ id: currentUser?.id, ...data })}>
         <Stack>
           <Title order={2}>Profile</Title>
           {error && (

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { AccountsCard } from '~/components/Account/AccountsCard';
 import { ApiKeysCard } from '~/components/Account/ApiKeysCard';
 import { CreatorCard } from '~/components/Account/CreatorCard';
+import { DeleteCard } from '~/components/Account/DeleteCard';
 import { NotificationsCard } from '~/components/Account/NotificationsCard';
 import { ProfileCard } from '~/components/Account/ProfileCard';
 import { SettingsCard } from '~/components/Account/SettingsCard';
@@ -39,6 +40,7 @@ export default function Account({ providers, isDev = false }: Props) {
           <NotificationsCard />
           <AccountsCard providers={providers} />
           {apiKeys && <ApiKeysCard />}
+          <DeleteCard />
         </Stack>
       </Container>
     </>

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -153,10 +153,7 @@ export const deleteUserHandler = async ({
 
   try {
     const user = await deleteUser(input);
-
-    if (!user) {
-      throw throwNotFoundError(`No user with id ${id}`);
-    }
+    if (!user) throw throwNotFoundError(`No user with id ${id}`);
 
     return user;
   } catch (error) {

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -47,6 +47,6 @@ export type GetByUsernameSchema = z.infer<typeof getByUsernameSchema>;
 export type DeleteUserInput = z.infer<typeof deleteUserSchema>;
 export const deleteUserSchema = z.object({
   id: z.number(),
-  username: z.string(),
+  username: z.string().optional(),
   removeModels: z.boolean().optional(),
 });


### PR DESCRIPTION
### Description

- Added a new card at the bottom of the account page to let users delete their accounts
- Updated deleteUser service to use db transaction to delete/transfer user's models, then delete the user itself