### PR TITLE
Escape blocklist words in regex to avoid unwanted interpretation

### DIFF
--- a/src/utils/image-metadata.ts
+++ b/src/utils/image-metadata.ts
@@ -177,9 +177,10 @@ const encoders = {
 // #endregion
 
 // #region [audit]
+const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const blockedRegex = blocked.map((word) => ({
   word,
-  regex: new RegExp(`(^|\\s|\\(|\\))${word}(\\s|,|$|\\(|\\))`, 'm'),
+  regex: new RegExp(`(^|\\s|\\(|\\))${escapeRegex(word)}(\\s|,|$|\\(|\\))`, 'm'),
 }));
 export const auditMetaData = (meta: AsyncReturnType<typeof getMetadata>) => {
   const blockedFor = blockedRegex


### PR DESCRIPTION
`word` isn't escaped in the regex here (line 182):
https://github.com/civitai/civitai/blob/97a901b91486bdc65eb074d51eb04cef9c088236/src/utils/image-metadata.ts#L180-L183

As such, the blocklist word "2.yo" for example would unintentionally match the word "29yo" and flag it even though that wouldn't be a violation.

So in this PR I've escaped the words. I went with escaping all possible regex characters rather than just the period since there's a possibility other characters may be added into words in the blocklist (for e.g. "9+yo", "$ixyearold").