### PR TITLE
Adds height diff to wide model cards

### DIFF
--- a/src/components/InfiniteModels/AmbientModelCard.tsx
+++ b/src/components/InfiniteModels/AmbientModelCard.tsx
@@ -182,12 +182,12 @@ export function AmbientModelCard({ data, width: itemWidth }: Props) {
     if (!image.width || !image.height) return 300;
     const width = itemWidth > 0 ? itemWidth : 300;
     const aspectRatio = image.width / image.height;
-    const imageHeight = Math.floor(width / aspectRatio);
+    const imageHeight = Math.floor(width / aspectRatio) + (aspectRatio >= 1 ? 60 : 0);
     return Math.min(imageHeight, 600);
   }, [itemWidth, image.width, image.height]);
 
   const modelText = (
-    <Text size={14} weight={500} color="white" style={{ flex: 1 }}>
+    <Text size={14} weight={500} color="white" style={{ flex: 1, lineHeight: 1 }}>
       {name}
     </Text>
   );
@@ -423,7 +423,7 @@ export function AmbientModelCard({ data, width: itemWidth }: Props) {
                         zIndex: 10,
                         borderRadius: '50%',
                       }}
-                      onClick={(e: any) => {
+                      onClick={(e: React.MouseEvent<HTMLDivElement>) => {
                         e.preventDefault();
                         e.stopPropagation();
                         push(`/user/${data.user.username}`);


### PR DESCRIPTION
### Description

- Updated AmbientModelCard component to add more height to cards with wide cover images, so the info content doesn't overlap the image

### Screenshots

![image](https://user-images.githubusercontent.com/12631159/217033070-ac91a4c1-cc4f-44de-893f-64ac800b1e14.png)
