### PR TITLE
Fixes a typo on the 404 page

### DIFF
--- a/src/components/AppLayout/NotFound.tsx
+++ b/src/components/AppLayout/NotFound.tsx
@@ -10,7 +10,7 @@ export function NotFound() {
       <Container size="xl" p="xl">
         <Stack align="center">
           <Title order={1}>404</Title>
-          <Text size="xl">The page you are looking for doesn&apos;t exists</Text>
+          <Text size="xl">The page you are looking for doesn&apos;t exist</Text>
           <Button component={NextLink} href="/">
             Go back home
           </Button>


### PR DESCRIPTION
Hello,

There was a simple typo in the 404 page:
It should say "doesn't exist", not "doesn't exists".