### PR TITLE
Set javascript editor.defaultFormatter to dbaeumer.vscode-eslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,7 @@
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
 }


### PR DESCRIPTION
When formatting by esbenp.prettier-vscode is enabled globally in VSCode, it seems to reflect Prettier's default settings when saving .js files.

There were several possible fixes, including setting formatting in npm scripts, setting .eslintrc.js, and adding .prettierrc, but for now, I'm just going to add the javascript defaultFormatter to the .vscode/settings.json setting that applies to this project.

This should help non-core contributors when editing .js files.