### PR TITLE
Include minio and maildev for local development

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,9 +3,11 @@
 # This file will be committed to version control, so make sure not to have any secrets in it.
 # If you are cloning this repo, create a copy of this file named `.env` and populate it with your secrets.
 # When adding additional env variables, the schema in /env/schema.mjs should be updated accordingly
+# The default values for Prisma, Redis, S3, and Email are set to work with the docker-compose setup
 
 # Prisma
 DATABASE_URL=postgresql://modelshare:postgres@localhost:5432/postgres?schema=public&connection_limit=5
+DATABASE_REPLICA_URL=postgresql://modelshare:postgres@localhost:5432/postgres?schema=public&connection_limit=5
 REDIS_URL=redis://:redis@localhost:6379
 
 # Logging
@@ -32,25 +34,26 @@ REDDIT_CLIENT_ID=
 REDDIT_CLIENT_SECRET=
 
 # File uploading
-S3_UPLOAD_KEY=
-S3_UPLOAD_SECRET=
-S3_UPLOAD_BUCKET=
-S3_UPLOAD_REGION=
-S3_UPLOAD_ENDPOINT=
-S3_SETTLED_BUCKET=
-S3_ORIGINS=
+S3_UPLOAD_KEY=REFER_TO_README
+S3_UPLOAD_SECRET=REFER_TO_README
+S3_UPLOAD_BUCKET=modelshare
+S3_UPLOAD_REGION=us-east-1
+S3_UPLOAD_ENDPOINT=http://localhost:9000
+S3_SETTLED_BUCKET=settled
+S3_ORIGINS=http://localhost:3000
+S3_FORCE_PATH_STYLE=true
 CF_IMAGES_TOKEN=
 CF_ACCOUNT_ID=
 
 # Client env vars
 NEXT_PUBLIC_IMAGE_LOCATION=
-NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION=
+NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION=https://publicstore.civitai.com/content_detection/model.json
 NEXT_PUBLIC_CIVITAI_LINK=https://link.civitai.com
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 
 # Email
-EMAIL_HOST=
-EMAIL_PORT=
+EMAIL_HOST=localhost
+EMAIL_PORT=1025
 EMAIL_USER=
 EMAIL_PASS=
 EMAIL_FROM=

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 
 postgres/data
 redis/data
+minio/

--- a/README.md
+++ b/README.md
@@ -56,14 +56,22 @@ First, make sure that you have the following installed on your machine:
 
 1. Clone the repository to your local machine.
 1. Run `npm install` in the project directory to install the necessary dependencies.
+1. Spin up required services with `docker-compose up -d`
+    * Note: In addition to postgres and redis, this will also run maildev for email and minio for s3 storage with all necessary buckets automatically created, minio and maildev are not strictly needed but are preferred for testing and development purposes.
 1. Create your `.env` by making a copy of the contents from `.env-example` file.
-1. Spin up the database with `docker-compose up -d`.
+    * Most default values are configured to work with the docker-compose setup, with the exception of the S3 upload key and secret. To generate those, navigate to the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file.
+    * Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
+1. Run `npm run db:migrate` to run all database migrations.
+1. Run `npm run db:generate` to generate the prisma client.
 1. Start the development server by running `npm run dev`.
-1. Visit [http://localhost:3000](http://localhost:3000).
+1. Visit the page `http://localhost:3000/api/webhooks/run-jobs?token=WEBHOOK_TOKEN&run=update-metrics` to start the metrics update job (make sure to substitute `WEBHOOK_TOKEN`)
+1. Finally, visit [http://localhost:3000](http://localhost:3000) to see the website.
+    * Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080).
+    * Also note that Cloudflare credentials are necessary in order for image uploads to work.
 
 ### Important Scripts
 ```sh
-docker-compose up -d # Spin up db and redis
+docker-compose up -d # Spin up db, redis, maildev, and minio
 
 npm run dev # Start the dev environment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,40 @@ services:
     volumes:
       - ./redis/data:/data
     restart: unless-stopped
+  minio:
+    image: minio/minio
+    container_name: minio
+    ports:
+      - 9000:9000
+      - 9001:9001
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    volumes:
+      - ./minio/data:/data
+    command: minio server /data --console-address ":9001"
+    restart: unless-stopped
+  createbuckets:
+    image: minio/mc
+    container_name: createbuckets
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add minio http://minio:9000 minioadmin minioadmin &&
+      /usr/bin/mc mb minio/modelshare &&
+      /usr/bin/mc policy set public minio/modelshare &&
+      /usr/bin/mc mb minio/settled &&
+      /usr/bin/mc policy set public minio/settled &&
+      exit 0"
+    restart: unless-stopped
+  maildev:
+    image: maildev/maildev
+    container_name: maildev
+    environment:
+      - MAILDEV_SMTP_PORT=1025
+      - MAILDEV_WEB_PORT=1080
+    ports:
+      - 1025:1025
+      - 1080:1080
+    restart: unless-stopped

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -42,6 +42,9 @@ export const serverSchema = z.object({
   S3_UPLOAD_ENDPOINT: z.string().url(),
   S3_UPLOAD_BUCKET: z.string(),
   S3_SETTLED_BUCKET: z.string(),
+  S3_FORCE_PATH_STYLE: z
+    .preprocess((val) => val === true || val === 'true', z.boolean())
+    .default(false),
   CF_ACCOUNT_ID: z.string(),
   CF_IMAGES_TOKEN: z.string(),
   JOB_TOKEN: z.string(),


### PR DESCRIPTION
These changes should make it easier for contributors to quickly spin up a development environment.

Most changes involved simply adding minio and maildev to the `docker-compose.yml` file.
* minio: This is used for S3 storage. The docker-compose file has things set up conveniently since it creates all the buckets without the user having to do anything.
* maildev: This is used for emails, any outgoing emails will be captured through this.

Another minor change was to introduce `S3_FORCE_PATH_STYLE`, this is needed since if we were to run minio locally, the URL would end up following a path style (e.g. `localhost:9000/bucket/key`) rather than a virtual host style (e.g. `bucket.s3.whatever.com/key`).
It's set to `false` by default (that's what you guys would use in production), but I let it be `true` in the example env, since that's intended to be used for development.

Finally, I of course updated the readme and mentioned a few things that weren't already documented and also updated the example env. I set default values in the env to match those used in the docker-compose file, so it's easier to work with.

I have tested these changes myself twice, once on my main machine and another time on another machine with a direct clone from my fork.  I've taken some [screenshots](https://imgur.com/a/CbtJ8O5) that showcase the results, in case there's any concerns whether this actually works.

Though do note that in the gallery I sent above, I had to mock cloudflare to get images working (these changes were obviously not committed). So while these changes hopefully are in the right direction, there's still a small barrier to running this "fully" locally, and that would be cloudflare.

 But in any case, at least with this, all one would need to do is follow the instructions and have cloudflare credentials (or be mad enough to mock cloudflare themselves)