### PR TITLE
Fix bug where no models show up  on homepage briefly after a new model is posted

### DIFF
--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -208,7 +208,7 @@ export const getModelsInfiniteHandler = async ({
   return {
     nextCursor,
     items: items.map(({ modelVersions, reportStats, publishedAt, hashes, ...model }) => {
-      const rank = model.rank as Record<string, number>;
+      const rank = model.rank; // NOTE: null before metrics kick in
       const latestVersion = modelVersions[0];
       const { tags, ...image } = latestVersion.images[0]?.image ?? {};
       const earlyAccess =
@@ -223,11 +223,11 @@ export const getModelsInfiniteHandler = async ({
         ...model,
         hashes: hashes.map((hash) => hash.hash.toLowerCase()),
         rank: {
-          downloadCount: rank[`downloadCount${input.period}`],
-          favoriteCount: rank[`favoriteCount${input.period}`],
-          commentCount: rank[`commentCount${input.period}`],
-          ratingCount: rank[`ratingCount${input.period}`],
-          rating: rank[`rating${input.period}`],
+          downloadCount: rank?.[`downloadCount${input.period}`] ?? 0,
+          favoriteCount: rank?.[`favoriteCount${input.period}`] ?? 0,
+          commentCount: rank?.[`commentCount${input.period}`] ?? 0,
+          ratingCount: rank?.[`ratingCount${input.period}`] ?? 0,
+          rating: rank?.[`rating${input.period}`] ?? 0,
         },
         image,
         earlyAccess,


### PR DESCRIPTION
Here, the model rank could be null (before metrics kick in), and it is in fact null, then tRPC would throw a type error complaining that it tried to access properties of a null variable.

This causes no models to be shown on the homepage, at least not until metrics kick in. (I was able to reproduce this myself)

In other words, for a brief moment (longest 1min), if a model is posted then there is a possibility that no models would be shown on the homepage.

I went with zero-ing the values since they probably would be zero in the brief moments after they were posted anyway. And it doesn't matter too much anyway because after metrics kick in, the 'actual' values will be shown.

I suspect this might be related to #275?