### PR TITLE
Add API to send message to ingestion service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.188.0",
         "@aws-sdk/lib-storage": "^3.188.0",
         "@aws-sdk/s3-request-presigner": "^3.188.0",
+        "@cloudamqp/amqp-client": "^2.1.1",
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/sortable": "^7.0.1",
         "@dnd-kit/utilities": "^3.2.0",
@@ -1873,6 +1874,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudamqp/amqp-client": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cloudamqp/amqp-client/-/amqp-client-2.1.1.tgz",
+      "integrity": "sha512-u4nOBfpBTEiohQ/ThJVLmHx+G7mUt1aTXsLqhGVZAnTnA1AZpq/ja1Lhx7equRuE48AhQKS/UDQpV+7grLEF4Q==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -13162,6 +13171,11 @@
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@cloudamqp/amqp-client": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cloudamqp/amqp-client/-/amqp-client-2.1.1.tgz",
+      "integrity": "sha512-u4nOBfpBTEiohQ/ThJVLmHx+G7mUt1aTXsLqhGVZAnTnA1AZpq/ja1Lhx7equRuE48AhQKS/UDQpV+7grLEF4Q=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/client-s3": "^3.188.0",
     "@aws-sdk/lib-storage": "^3.188.0",
     "@aws-sdk/s3-request-presigner": "^3.188.0",
+    "@cloudamqp/amqp-client": "^2.1.1",
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/sortable": "^7.0.1",
     "@dnd-kit/utilities": "^3.2.0",

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -59,7 +59,7 @@ export const serverSchema = z.object({
     const str = String(value);
     return str.split(',');
   }, z.array(z.string())),
-  IMAGE_INGESTION_MESSAGE_QUEUE_SERVER: z.string()
+  IMAGE_INGESTION_MESSAGE_QUEUE_SERVER: z.string().optional()
 });
 
 /**

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -59,6 +59,7 @@ export const serverSchema = z.object({
     const str = String(value);
     return str.split(',');
   }, z.array(z.string())),
+	IMAGE_INGESTION_MESSAGE_QUEUE_SERVER: z.string()
 });
 
 /**

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -59,7 +59,7 @@ export const serverSchema = z.object({
     const str = String(value);
     return str.split(',');
   }, z.array(z.string())),
-	IMAGE_INGESTION_MESSAGE_QUEUE_SERVER: z.string()
+  IMAGE_INGESTION_MESSAGE_QUEUE_SERVER: z.string()
 });
 
 /**

--- a/src/server/ingestion/client.ts
+++ b/src/server/ingestion/client.ts
@@ -1,0 +1,50 @@
+import { AMQPChannel, AMQPClient } from "@cloudamqp/amqp-client";
+import { env } from "~/env/server.mjs";
+import type { AMQPBaseClient } from "@cloudamqp/amqp-client/types/amqp-base-client";
+import { ingestionMessageSchema } from "../utils/image-ingestion";
+
+export const amqp = new AMQPClient(
+  env.IMAGE_INGESTION_MESSAGE_QUEUE_SERVER ?? "amqp://localhost"
+);
+
+let connection: AMQPBaseClient | undefined = undefined;
+
+export const tryConnect = async () => {
+  if (connection) {
+    return connection;
+  }
+  return amqp
+    .connect()
+    .then((conn) => {
+      connection = conn;
+      return conn;
+    })
+    .catch((err) => {
+      connection = undefined;
+      throw err;
+    });
+};
+
+export const tryDefaultChannel = () =>
+  tryConnect().then((conn) => getDefaultChannel(conn));
+
+export const getDefaultChannel = (conn?: AMQPBaseClient) =>
+  conn ? conn.channel() : connection?.channel();
+
+export const isConnected = () =>
+  connection === undefined ? false : connection.closed === false;
+
+/**
+ * Pass a basic message to a topic
+ * const channel = await tryDefaultChannel();
+ * await tryBasicPublish(channel, "ingestion", { source: {}, ... }));
+ */
+export const tryBasicPublish = async <T extends typeof ingestionMessageSchema>(
+  channel: AMQPChannel,
+	topic: string,
+  message: T
+): Promise<number> => {
+  return channel.basicPublish("amq.topic", topic, JSON.stringify(message), {
+    contentType: "application/json",
+  });
+};

--- a/src/server/ingestion/client.ts
+++ b/src/server/ingestion/client.ts
@@ -95,10 +95,12 @@ export const tryRPC = async (
           return;
         }
 
-				if (msg.properties.correlationId !== id) {
-					reject(`Could not validate the correlationId., ${msg.properties.correlationId}, ${id}`);
-					return;
-				}
+        if (msg.properties.correlationId !== id) {
+          reject(
+            `Could not validate the correlationId., ${msg.properties.correlationId}, ${id}`
+          );
+          return;
+        }
 
         const validation = await responseSchema.safeParseAsync(msg);
 

--- a/src/server/ingestion/client.ts
+++ b/src/server/ingestion/client.ts
@@ -41,7 +41,7 @@ export const isConnected = () =>
  */
 export const tryBasicPublish = async <T extends typeof ingestionMessageSchema>(
   channel: AMQPChannel,
-	topic: string,
+  topic: string,
   message: T
 ): Promise<number> => {
   return channel.basicPublish("amq.topic", topic, JSON.stringify(message), {

--- a/src/server/utils/image-ingestion.ts
+++ b/src/server/utils/image-ingestion.ts
@@ -1,0 +1,35 @@
+import z from "zod";
+import { tryBasicPublish, tryDefaultChannel } from "../ingestion/client";
+
+export const ingestionMessageSchema = z.object({
+  source: z.object({
+    type: z.string(),
+    name: z.string(),
+    id: z.number().gt(0),
+    url: z.string(),
+    user: z.object({
+      id: z.number().gt(0),
+      name: z.string(),
+    }),
+  }),
+  image: z.string(),
+  contentType: z.string().optional(),
+  action: z.string(),
+});
+
+/**
+ * Send message to image ingestion service
+ * imageIngestion({ source: {...}, ...})
+ */
+export const imageIngestion = async (
+  message: typeof ingestionMessageSchema
+) => {
+  const channel = await tryDefaultChannel();
+
+  // Could not connect to message queue
+  if (channel === undefined) {
+    return;
+  }
+
+  return tryBasicPublish(channel, "ingestion", message);
+};


### PR DESCRIPTION
@JustMaier 

Wanted this client to be lazy loaded connection and to allow you to boot the civitai without requiring a connection to the service.

```javascript
imageIngestion({"source":{"type":"civitai","name":"Civitai","id":1077690,"url":"","user":{"id":7424223,"name":"rockerBOO"}},"image":"https://imagecache.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/365dbfa8-1ea3-4fd8-1178-7e750e06c600/width=512/00747-774608077.png","contentType":"image/png", "action": "label"});
```
Action might be dropped, but currently is there. Not currently used. 

`IMAGE_INGESTION_MESSAGE_QUEUE_SERVER` added but not required. 