### PR TITLE
Fix misaligned carousel controls

### DIFF
--- a/src/components/Model/ModelDiscussion/ReviewDiscussionItem.tsx
+++ b/src/components/Model/ModelDiscussion/ReviewDiscussionItem.tsx
@@ -270,6 +270,7 @@ function ReviewCarousel({
           setRenderIndexes((indexes) => (!indexes.includes(index) ? [...indexes, index] : indexes));
         }}
         withIndicators={hasMultipleImages}
+        controlSize={32}
         styles={{
           indicators: {
             bottom: 8,
@@ -278,12 +279,6 @@ function ReviewCarousel({
             width: 16,
             height: 8,
             transition: 'width 250ms ease',
-          },
-          // Increase carousel control arrow size
-          control: {
-            width: 32,
-            height: 32,
-            borderRadius: '50%',
           },
         }}
       >

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -187,10 +187,6 @@ const useStyles = createStyles((theme) => ({
 
   // Increase carousel control arrow size
   control: {
-    minWidth: 56,
-    minHeight: 56,
-    borderRadius: '50%',
-
     svg: {
       width: 24,
       height: 24,
@@ -969,6 +965,7 @@ function ModelCarousel({
       align={latestVersion && latestVersion.images.length > 2 ? 'start' : 'center'}
       slidesToScroll={mobile ? 1 : 2}
       withControls={latestVersion && latestVersion.images.length > 2 ? true : false}
+      controlSize={56}
       loop
     >
       <ImageGuard


### PR DESCRIPTION
Just a small UI fix. Carousel controls are slightly misaligned (pointed out in #302).

There's no need to manually change the sizes of controls using CSS. Mantine's carousel already provides functionality for that (`controlSize`), and uses that value to do a few calculations to properly align the controls. So when you forcefully set the width and height, mantine is not aware of it and the controls end up misaligned.

You could verify this by setting it to a fairly large value like 150, it would end up very clearly misaligned, but if instead you use `controlSize`, it will be aligned regardless of how large the value is.