### PR TITLE
Feature/Search: Queue update after metrics

### DIFF
--- a/src/server/search-index/articles.search-index.ts
+++ b/src/server/search-index/articles.search-index.ts
@@ -60,11 +60,6 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
 
   console.log('onIndexSetup :: sortableFieldsAttributesTask created', sortableFieldsAttributesTask);
 
-  await client.waitForTasks([
-    updateSearchableAttributesTask.taskUid,
-    sortableFieldsAttributesTask.taskUid,
-  ]);
-
   console.log('onIndexSetup :: all tasks completed');
 };
 

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -48,11 +48,6 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
 
   console.log('onIndexSetup :: sortableFieldsAttributesTask created', sortableFieldsAttributesTask);
 
-  await client.waitForTasks([
-    updateSearchableAttributesTask.taskUid,
-    sortableFieldsAttributesTask.taskUid,
-  ]);
-
   console.log('onIndexSetup :: all tasks completed');
 };
 


### PR DESCRIPTION
So, this is separate pretty much because it's more experiemental. Will add to the updateQueue everytime there's metrics run. Should make it so that we keep indexes updated at all times (or fairly constantly at least)