### PR TITLE
Seach index updates

### DIFF
--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -70,7 +70,6 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
 
   const updateRankingRulesTask = await index.updateRankingRules([
     'attribute',
-    'nsfw:asc',
     'metrics.weightedRating:desc',
     'words',
     'typo',

--- a/src/server/search-index/tags.search-index.ts
+++ b/src/server/search-index/tags.search-index.ts
@@ -21,6 +21,10 @@ const READ_BATCH_SIZE = 1000;
 const MEILISEARCH_DOCUMENT_BATCH_SIZE = 100;
 const INDEX_ID = 'tags';
 const SWAP_INDEX_ID = `${INDEX_ID}_NEW`;
+/*
+  Only tags above this threshold will be indexed.
+ */
+const MINIMUM_METRICS_COUNT = 10;
 
 const onIndexSetup = async ({ indexName }: { indexName: string }) => {
   if (!client) {
@@ -139,8 +143,6 @@ const onFetchItemsToIndex = async ({
       //perhaps posts + articles + model + imageCounts
       const metricsCount =
         metrics.articleCount + metrics.postCount + metrics.modelCount + metrics.imageCount;
-
-      const MINIMUM_METRICS_COUNT = 10;
 
       if (metricsCount < MINIMUM_METRICS_COUNT) {
         return null;


### PR DESCRIPTION
Does 2 things:
- Stops models from being sorted by NSFW
- Ensures tags only get indexed if at least 10 db items rely on it.