### PR TITLE
Feature/custom homepage  home block loading

### DIFF
--- a/src/components/HomeBlocks/AnnouncementHomeBlock.tsx
+++ b/src/components/HomeBlocks/AnnouncementHomeBlock.tsx
@@ -1,13 +1,13 @@
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
-import { HomeBlockGetAll } from '~/types/router';
 import { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
 import { createStyles, Grid } from '@mantine/core';
 import { AnnouncementHomeBlockAnnouncementItem } from '~/components/HomeBlocks/components/AnnouncementHomeBlockAnnouncementItem';
 import { useDismissedAnnouncements } from '~/hooks/useDismissedAnnouncements';
 import { useMemo } from 'react';
 import { HomeBlockHeaderMeta } from '~/components/HomeBlocks/components/HomeBlockHeaderMeta';
+import { trpc } from '~/utils/trpc';
 
-type Props = { homeBlock: HomeBlockGetAll[number] };
+type Props = { homeBlockId: number };
 
 const useStyles = createStyles((theme) => ({
   root: {
@@ -20,15 +20,17 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
-export const AnnouncementHomeBlock = ({ homeBlock }: Props) => {
+export const AnnouncementHomeBlock = ({ homeBlockId }: Props) => {
   const { classes } = useStyles();
+  const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery({ id: homeBlockId });
+
   const announcementIds = useMemo(
-    () => (homeBlock.announcements ? homeBlock.announcements.map((item) => item.id) : []),
-    [homeBlock.announcements]
+    () => (homeBlock?.announcements ? homeBlock.announcements.map((item) => item.id) : []),
+    [homeBlock?.announcements]
   );
   const { dismissed, onAnnouncementDismiss } = useDismissedAnnouncements(announcementIds);
 
-  if (!homeBlock.announcements) {
+  if (!homeBlock || !homeBlock.announcements || isLoading) {
     return null;
   }
 

--- a/src/components/HomeBlocks/CollectionHomeBlock.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlock.tsx
@@ -27,6 +27,7 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { PostCard } from '~/components/Cards/PostCard';
 import { ArticleCard } from '~/components/Cards/ArticleCard';
 import { useIsMobile } from '~/hooks/useIsMobile';
+import { CollectionHomeBlockSkeleton } from '~/components/HomeBlocks/CollectionHomeBlockSkeleton';
 
 const useStyles = createStyles<string, { count: number }>((theme, { count }) => {
   return {
@@ -219,6 +220,10 @@ export const CollectionHomeBlock = ({ homeBlock }: Props) => {
     metadata.description &&
     !metadata.stackedHeader &&
     (!currentUser || metadata.descriptionAlwaysVisible);
+
+  if (true) {
+    return <CollectionHomeBlockSkeleton />;
+  }
 
   return (
     <HomeBlockWrapper py={32} px={0} bleedRight>

--- a/src/components/HomeBlocks/CollectionHomeBlockSkeleton.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlockSkeleton.tsx
@@ -1,0 +1,23 @@
+import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
+import { AspectRatio, Group, Skeleton, Stack } from '@mantine/core';
+
+export const CollectionHomeBlockSkeleton = () => {
+  return (
+    <HomeBlockWrapper py="md">
+      <Group spacing={12}>
+        <Stack spacing={0} w="calc(50% - 12px)">
+          <Skeleton width="60%" height="50px" mb={20} />
+          <Skeleton width="100%" height="10px" mb={10} />
+          <Skeleton width="100%" height="10px" mb={10} />
+          <Skeleton width="80%" height="10px" mb={10} />
+        </Stack>
+        <AspectRatio ratio={7 / 9} w="calc(25% - 12px)">
+          <Skeleton width="100%" height="430" />
+        </AspectRatio>
+        <AspectRatio ratio={7 / 9} w="calc(25% - 12px)">
+          <Skeleton width="100%" height="430" />
+        </AspectRatio>
+      </Group>
+    </HomeBlockWrapper>
+  );
+};

--- a/src/components/HomeBlocks/CollectionHomeBlockSkeleton.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlockSkeleton.tsx
@@ -6,10 +6,13 @@ export const CollectionHomeBlockSkeleton = () => {
     <HomeBlockWrapper py="md">
       <Group spacing={12}>
         <Stack spacing={0} w="calc(50% - 12px)">
-          <Skeleton width="60%" height="50px" mb={20} />
-          <Skeleton width="100%" height="10px" mb={10} />
-          <Skeleton width="100%" height="10px" mb={10} />
-          <Skeleton width="80%" height="10px" mb={10} />
+          <Group>
+            <Skeleton width="30px" height="30px" mb={20} />{' '}
+            <Skeleton width="60%" height="30px" mb={20} />
+          </Group>
+          <Skeleton width="100%" height="15px" mb={10} />
+          <Skeleton width="100%" height="15px" mb={10} />
+          <Skeleton width="80%" height="15px" mb={10} />
         </Stack>
         <AspectRatio ratio={7 / 9} w="calc(25% - 12px)">
           <Skeleton width="100%" height="430" />

--- a/src/components/HomeBlocks/LeaderboardHomeBlockSkeleton.tsx
+++ b/src/components/HomeBlocks/LeaderboardHomeBlockSkeleton.tsx
@@ -1,0 +1,27 @@
+import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
+import { AspectRatio, Group, Skeleton } from '@mantine/core';
+
+export const LeaderboardsHomeBlockSkeleton = () => {
+  return (
+    <HomeBlockWrapper py="md">
+      <Skeleton width="10%" height={20} mb={10} />
+      <Skeleton width="40%" height={20} mb={10} />
+      <Skeleton width="30%" height={20} mb={30} />
+
+      <Group spacing={12}>
+        <AspectRatio ratio={1} w="calc(25% - 12px)">
+          <Skeleton width="100%" height="120" />
+        </AspectRatio>
+        <AspectRatio ratio={1} w="calc(25% - 12px)">
+          <Skeleton width="100%" height="120" />
+        </AspectRatio>
+        <AspectRatio ratio={1} w="calc(25% - 12px)">
+          <Skeleton width="100%" height="120" />
+        </AspectRatio>
+        <AspectRatio ratio={1} w="calc(25% - 12px)">
+          <Skeleton width="100%" height="120" />
+        </AspectRatio>
+      </Group>
+    </HomeBlockWrapper>
+  );
+};

--- a/src/components/HomeBlocks/LeaderboardsHomeBlock.tsx
+++ b/src/components/HomeBlocks/LeaderboardsHomeBlock.tsx
@@ -1,5 +1,4 @@
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
-import { HomeBlockGetAll } from '~/types/router';
 import { Box, Button, Card, createStyles, Divider, Group, Stack, Text } from '@mantine/core';
 import { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
 import Link from 'next/link';
@@ -8,8 +7,10 @@ import { LeaderHomeBlockCreatorItem } from '~/components/HomeBlocks/components/L
 import { Fragment } from 'react';
 import { IconArrowRight } from '@tabler/icons-react';
 import { HomeBlockHeaderMeta } from '~/components/HomeBlocks/components/HomeBlockHeaderMeta';
+import { LeaderboardsHomeBlockSkeleton } from '~/components/HomeBlocks/LeaderboardHomeBlockSkeleton';
+import { trpc } from '~/utils/trpc';
 
-type Props = { homeBlock: HomeBlockGetAll[number] };
+type Props = { homeBlockId: number };
 
 const useStyles = createStyles((theme) => ({
   root: {
@@ -27,10 +28,15 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
-export const LeaderboardsHomeBlock = ({ homeBlock }: Props) => {
+export const LeaderboardsHomeBlock = ({ homeBlockId }: Props) => {
   const { classes } = useStyles();
+  const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery({ id: homeBlockId });
 
-  if (!homeBlock.leaderboards || homeBlock.leaderboards.length === 0) {
+  if (isLoading) {
+    return <LeaderboardsHomeBlockSkeleton />;
+  }
+
+  if (!homeBlock || !homeBlock.leaderboards || homeBlock.leaderboards.length === 0) {
     return null;
   }
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -30,11 +30,11 @@ export default function Home() {
       {homeBlocks.map((homeBlock) => {
         switch (homeBlock.type) {
           case HomeBlockType.Collection:
-            return <CollectionHomeBlock key={homeBlock.id} homeBlock={homeBlock} />;
+            return <CollectionHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
           case HomeBlockType.Announcement:
-            return <AnnouncementHomeBlock key={homeBlock.id} homeBlock={homeBlock} />;
+            return <AnnouncementHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
           case HomeBlockType.Leaderboard:
-            return <LeaderboardsHomeBlock key={homeBlock.id} homeBlock={homeBlock} />;
+            return <LeaderboardsHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
         }
       })}
     </>

--- a/src/server/controllers/home-block.controller.ts
+++ b/src/server/controllers/home-block.controller.ts
@@ -1,5 +1,5 @@
 import { Context } from '~/server/createContext';
-import { throwDbError } from '~/server/utils/errorHandling';
+import { throwDbError, throwNotFoundError } from '~/server/utils/errorHandling';
 import {
   getHomeBlockById,
   getHomeBlockData,
@@ -66,7 +66,7 @@ export const getHomeBlocksByIdHandler = async ({
     });
 
     if (!homeBlock) {
-      throw throwDbError('Home block not found');
+      throw throwNotFoundError('Home block not found');
     }
 
     return homeBlock;

--- a/src/server/controllers/home-block.controller.ts
+++ b/src/server/controllers/home-block.controller.ts
@@ -1,14 +1,20 @@
 import { Context } from '~/server/createContext';
 import { throwDbError } from '~/server/utils/errorHandling';
-import { getHomeBlocks } from '~/server/services/home-block.service';
+import {
+  getHomeBlockById,
+  getHomeBlockData,
+  getHomeBlocks,
+} from '~/server/services/home-block.service';
 import {
   getCollectionById,
   getCollectionItemsByCollectionId,
 } from '~/server/services/collection.service';
-import { GetHomeBlocksInputSchema, HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
-import { HomeBlockType } from '@prisma/client';
+import {
+  GetHomeBlockByIdInputSchema,
+  GetHomeBlocksInputSchema,
+  HomeBlockMetaSchema,
+} from '~/server/schema/home-block.schema';
 import { isDefined } from '~/utils/type-guards';
-import { UserPreferencesInput } from '~/server/middleware.trpc';
 import { getLeaderboardsWithResults } from '~/server/services/leaderboard.service';
 import { getAnnouncements } from '~/server/services/announcement.service';
 
@@ -40,112 +46,30 @@ export const getHomeBlocksHandler = async ({
       },
     });
 
-    const homeBlocksWithData: HomeBlockWithData[] = (
-      await Promise.all(
-        homeBlocks
-          .map(async (homeBlock) => {
-            const metadata: HomeBlockMetaSchema = (homeBlock.metadata || {}) as HomeBlockMetaSchema;
+    return homeBlocks;
+  } catch (error) {
+    throw throwDbError(error);
+  }
+};
 
-            switch (homeBlock.type) {
-              case HomeBlockType.Collection: {
-                if (!metadata.collection || !metadata.collection.id) {
-                  return null;
-                }
+export const getHomeBlocksByIdHandler = async ({
+  ctx,
+  input,
+}: {
+  ctx: Context;
+  input: GetHomeBlockByIdInputSchema;
+}): Promise<HomeBlockWithData> => {
+  try {
+    const homeBlock = await getHomeBlockById({
+      ...input,
+      ctx,
+    });
 
-                const collection = await getCollectionById({
-                  input: { id: metadata.collection.id },
-                });
+    if (!homeBlock) {
+      throw throwDbError('Home block not found');
+    }
 
-                if (!collection) {
-                  return null;
-                }
-
-                const items = await getCollectionItemsByCollectionId({
-                  ctx,
-                  input: {
-                    ...(input as UserPreferencesInput),
-                    collectionId: collection.id,
-                    // TODO.home-blocks: Set item limit as part of the input?
-                    limit: metadata.collection.limit,
-                  },
-                });
-
-                return {
-                  ...homeBlock,
-                  metadata,
-                  collection: {
-                    ...collection,
-                    items,
-                  },
-                };
-              }
-              case HomeBlockType.Leaderboard: {
-                if (!metadata.leaderboards) {
-                  return null;
-                }
-
-                const leaderboardIds = metadata.leaderboards.map((leaderboard) => leaderboard.id);
-
-                const leaderboardsWithResults = await getLeaderboardsWithResults({
-                  ids: leaderboardIds,
-                  isModerator: ctx.user?.isModerator || false,
-                });
-
-                return {
-                  ...homeBlock,
-                  metadata,
-                  leaderboards: leaderboardsWithResults.sort((a, b) => {
-                    if (!metadata.leaderboards) {
-                      return 0;
-                    }
-
-                    const aIndex =
-                      metadata.leaderboards.find((item) => item.id === a.id)?.index ?? 0;
-                    const bIndex =
-                      metadata.leaderboards.find((item) => item.id === b.id)?.index ?? 0;
-
-                    return aIndex - bIndex;
-                  }),
-                };
-              }
-              case HomeBlockType.Announcement: {
-                if (!metadata.announcements) {
-                  return null;
-                }
-
-                const announcementIds = metadata.announcements.ids;
-                const announcements = await getAnnouncements({
-                  ids: announcementIds,
-                  dismissed: input.dismissed,
-                  limit: metadata.announcements.limit,
-                  user: ctx.user,
-                });
-
-                if (!announcements.length) {
-                  // If the user cleared all announcements in home block, do not display this block.
-                  return null;
-                }
-
-                return {
-                  ...homeBlock,
-                  metadata,
-                  announcements: announcements.sort((a, b) => {
-                    const aIndex = a.metadata.index ?? 999;
-                    const bIndex = b.metadata.index ?? 999;
-
-                    return aIndex - bIndex;
-                  }),
-                };
-              }
-              default:
-                return { ...homeBlock, metadata };
-            }
-          })
-          .filter(isDefined)
-      )
-    ).filter(isDefined);
-
-    return homeBlocksWithData;
+    return homeBlock;
   } catch (error) {
     throw throwDbError(error);
   }

--- a/src/server/routers/home-block.router.ts
+++ b/src/server/routers/home-block.router.ts
@@ -1,7 +1,13 @@
 import { isFlagProtected, publicProcedure, router } from '~/server/trpc';
-import { getHomeBlocksHandler } from '~/server/controllers/home-block.controller';
+import {
+  getHomeBlocksByIdHandler,
+  getHomeBlocksHandler,
+} from '~/server/controllers/home-block.controller';
 import { applyUserPreferences } from '~/server/middleware.trpc';
-import { getHomeBlocksInputSchema } from '~/server/schema/home-block.schema';
+import {
+  getHomeBlocksInputSchema,
+  getHomeBlockByIdInputSchema,
+} from '~/server/schema/home-block.schema';
 
 export const homeBlockRouter = router({
   getHomeBlocks: publicProcedure
@@ -9,4 +15,9 @@ export const homeBlockRouter = router({
     .use(isFlagProtected('alternateHome'))
     .use(applyUserPreferences())
     .query(getHomeBlocksHandler),
+  getHomeBlock: publicProcedure
+    .input(getHomeBlockByIdInputSchema)
+    .use(isFlagProtected('alternateHome'))
+    .use(applyUserPreferences())
+    .query(getHomeBlocksByIdHandler),
 });

--- a/src/server/schema/home-block.schema.ts
+++ b/src/server/schema/home-block.schema.ts
@@ -46,3 +46,12 @@ export const getHomeBlocksInputSchema = z
   .merge(userPreferencesSchema)
   .partial()
   .default({ limit: 8 });
+
+export type GetHomeBlockByIdInputSchema = z.infer<typeof getHomeBlockByIdInputSchema>;
+
+export const getHomeBlockByIdInputSchema = z
+  .object({
+    id: z.number(),
+  })
+  .merge(userPreferencesSchema)
+  .partial();

--- a/src/server/schema/home-block.schema.ts
+++ b/src/server/schema/home-block.schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { userPreferencesSchema } from '~/server/middleware.trpc';
+import { getByIdSchema } from '~/server/schema/base.schema';
 
 export type HomeBlockMetaSchema = z.infer<typeof homeBlockMetaSchema>;
 
@@ -49,9 +50,4 @@ export const getHomeBlocksInputSchema = z
 
 export type GetHomeBlockByIdInputSchema = z.infer<typeof getHomeBlockByIdInputSchema>;
 
-export const getHomeBlockByIdInputSchema = z
-  .object({
-    id: z.number(),
-  })
-  .merge(userPreferencesSchema)
-  .partial();
+export const getHomeBlockByIdInputSchema = getByIdSchema.merge(userPreferencesSchema).partial();

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -1,5 +1,18 @@
 import { dbRead } from '~/server/db/client';
-import { Prisma } from '@prisma/client';
+import { HomeBlockType, Prisma } from '@prisma/client';
+import {
+  GetHomeBlockByIdInputSchema,
+  GetHomeBlocksInputSchema,
+  HomeBlockMetaSchema,
+} from '~/server/schema/home-block.schema';
+import { UserPreferencesInput } from '~/server/middleware.trpc';
+import {
+  getCollectionById,
+  getCollectionItemsByCollectionId,
+} from '~/server/services/collection.service';
+import { getLeaderboardsWithResults } from '~/server/services/leaderboard.service';
+import { getAnnouncements } from '~/server/services/announcement.service';
+import { Context } from '~/server/createContext';
 
 export const getHomeBlocks = <TSelect extends Prisma.HomeBlockSelect = Prisma.HomeBlockSelect>({
   select,
@@ -10,4 +23,133 @@ export const getHomeBlocks = <TSelect extends Prisma.HomeBlockSelect = Prisma.Ho
     select,
     orderBy: { index: 'asc' },
   });
+};
+
+export const getHomeBlockById = async ({
+  id,
+  ctx,
+  ...input
+}: GetHomeBlockByIdInputSchema & { ctx: Context }) => {
+  const homeBlock = await dbRead.homeBlock.findUniqueOrThrow({
+    select: {
+      id: true,
+      metadata: true,
+      type: true,
+    },
+    where: {
+      id,
+    },
+  });
+
+  return getHomeBlockData({ homeBlock, ctx, input });
+};
+
+export const getHomeBlockData = async ({
+  homeBlock,
+  ctx,
+  input,
+}: {
+  homeBlock: {
+    id: number;
+    metadata?: HomeBlockMetaSchema | Prisma.JsonValue;
+    type: HomeBlockType;
+  };
+  ctx: Context;
+  input: GetHomeBlocksInputSchema;
+}) => {
+  const metadata: HomeBlockMetaSchema = (homeBlock.metadata || {}) as HomeBlockMetaSchema;
+
+  switch (homeBlock.type) {
+    case HomeBlockType.Collection: {
+      if (!metadata.collection || !metadata.collection.id) {
+        return null;
+      }
+
+      const collection = await getCollectionById({
+        input: { id: metadata.collection.id },
+      });
+
+      if (!collection) {
+        return null;
+      }
+
+      const items = await getCollectionItemsByCollectionId({
+        ctx,
+        input: {
+          ...(input as UserPreferencesInput),
+          collectionId: collection.id,
+          // TODO.home-blocks: Set item limit as part of the input?
+          limit: metadata.collection.limit,
+        },
+      });
+
+      return {
+        ...homeBlock,
+        type: HomeBlockType.Collection,
+        metadata,
+        collection: {
+          ...collection,
+          items,
+        },
+      };
+    }
+    case HomeBlockType.Leaderboard: {
+      if (!metadata.leaderboards) {
+        return null;
+      }
+
+      const leaderboardIds = metadata.leaderboards.map((leaderboard) => leaderboard.id);
+
+      const leaderboardsWithResults = await getLeaderboardsWithResults({
+        ids: leaderboardIds,
+        isModerator: ctx.user?.isModerator || false,
+      });
+
+      return {
+        ...homeBlock,
+        metadata,
+        leaderboards: leaderboardsWithResults.sort((a, b) => {
+          if (!metadata.leaderboards) {
+            return 0;
+          }
+
+          const aIndex = metadata.leaderboards.find((item) => item.id === a.id)?.index ?? 0;
+          const bIndex = metadata.leaderboards.find((item) => item.id === b.id)?.index ?? 0;
+
+          return aIndex - bIndex;
+        }),
+      };
+    }
+    case HomeBlockType.Announcement: {
+      if (!metadata.announcements) {
+        return null;
+      }
+
+      const announcementIds = metadata.announcements.ids;
+      const announcements = await getAnnouncements({
+        ids: announcementIds,
+        dismissed: input.dismissed,
+        limit: metadata.announcements.limit,
+        user: ctx.user,
+      });
+
+      if (!announcements.length) {
+        // If the user cleared all announcements in home block, do not display this block.
+        return null;
+      }
+
+      return {
+        ...homeBlock,
+        metadata,
+        announcements: announcements.sort((a, b) => {
+          const aIndex = a.metadata.index ?? 999;
+          const bIndex = b.metadata.index ?? 999;
+
+          return aIndex - bIndex;
+        }),
+      };
+    }
+    default:
+      return { ...homeBlock, metadata };
+  }
 };

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -76,6 +76,7 @@ export type LeaderboardGetModel = LeaderboardRouter['getLeaderboard'][number];
 
 type HomeBlockRouter = RouterOutput['homeBlock'];
 export type HomeBlockGetAll = HomeBlockRouter['getHomeBlocks'];
+export type HomeBlockGetById = HomeBlockRouter['getHomeBlock'];
 
 type CollectionRouter = RouterOutput['collection'];
 export type CollectionGetAllUserModel = CollectionRouter['getAllUser'][number];


### PR DESCRIPTION
Each home block is now loaded async on a block-by-block basis which should be significantly faster when opening the home page. 

**Note:** Didn't add an skeleton for the announcements page because it is technically possible it never pops up if the user doens't have announcements, so I'd rather it pop out of nowhere than go away from existance imho. 

![image](https://github.com/civitai/civitai/assets/5957926/bbef7678-5df5-4d4b-9854-46d6826a4268)
