### PR TITLE
Use current data to display models' starts count

### DIFF
--- a/src/components/ResourceReview/Summary/ResourceReviewSummary.tsx
+++ b/src/components/ResourceReview/Summary/ResourceReviewSummary.tsx
@@ -2,6 +2,8 @@ import { Stack, Group, Text, Rating, Progress, createStyles, Skeleton } from '@m
 import { createContext, useContext, Fragment } from 'react';
 import { ResourceReviewRatingTotals } from '~/types/router';
 import { trpc } from '~/utils/trpc';
+import { abbreviateNumber } from '~/utils/number-helpers';
+import { IconBadge } from '~/components/IconBadge/IconBadge';
 
 type ContextState = {
   count: number;
@@ -130,6 +132,39 @@ ResourceReviewSummary.Totals = function Totals() {
   );
 };
 
+ResourceReviewSummary.Simple = function Simple({
+  rating: initialRating,
+  count: initialCount,
+  onClick,
+}: {
+  rating?: number;
+  count?: number;
+  onClick: () => void;
+}) {
+  const { rating, count, loading } = useSummaryContext();
+  const roundedRating = roundRating(rating ?? initialRating ?? 0);
+  const { classes } = useStyles();
+
+  if (loading && initialRating === undefined && initialCount === undefined) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={0}>
+      <IconBadge
+        radius="sm"
+        color="gray"
+        size="lg"
+        icon={<Rating value={roundedRating} fractions={4} readOnly />}
+        sx={{ cursor: 'pointer' }}
+        onClick={onClick}
+      >
+        <Text className={classes.badgeText}>{abbreviateNumber(count ?? 0)}</Text>
+      </IconBadge>
+    </Stack>
+  );
+};
+
 const useStyles = createStyles((theme) => ({
   grid: {
     display: 'grid',
@@ -137,5 +172,12 @@ const useStyles = createStyles((theme) => ({
     alignItems: 'center',
     columnGap: theme.spacing.md,
     rowGap: 4,
+  },
+
+  badgeText: {
+    fontSize: theme.fontSizes.md,
+    [theme.fn.smallerThan('md')]: {
+      fontSize: theme.fontSizes.sm,
+    },
   },
 }));

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -98,6 +98,7 @@ import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { TrackView } from '~/components/TrackView/TrackView';
 import { AssociatedModels } from '~/components/AssociatedModels/AssociatedModels';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { ResourceReviewSummary } from '~/components/ResourceReview/Summary/ResourceReviewSummary';
 
 export const getServerSideProps = createServerSideProps({
   useSSG: true,
@@ -529,23 +530,16 @@ export default function ModelDetailsV2({
                     </LoginRedirect>
                   )}
                   {!model.locked && (
-                    <IconBadge
-                      radius="sm"
-                      color="gray"
-                      size="lg"
-                      icon={
-                        <Rating value={model.rank?.ratingAllTime ?? 0} fractions={4} readOnly />
-                      }
-                      sx={{ cursor: 'pointer' }}
-                      onClick={() => {
-                        if (!gallerySectionRef.current) return;
-                        scrollToTop(gallerySectionRef.current);
-                      }}
-                    >
-                      <Text className={classes.modelBadgeText}>
-                        {abbreviateNumber(model.rank?.ratingCountAllTime ?? 0)}
-                      </Text>
-                    </IconBadge>
+                    <ResourceReviewSummary modelId={model.id}>
+                      <ResourceReviewSummary.Simple
+                        rating={model.rank?.ratingAllTime}
+                        count={model.rank?.ratingCountAllTime}
+                        onClick={() => {
+                          if (!gallerySectionRef.current) return;
+                          scrollToTop(gallerySectionRef.current);
+                        }}
+                      />
+                    </ResourceReviewSummary>
                   )}
                   {inEarlyAccess && (
                     <IconBadge radius="sm" color="green" size="lg" icon={<IconClock size={18} />}>

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -126,6 +126,7 @@ export const getRatingTotals = async ({ modelVersionId, modelId }: GetRatingTota
     },
     { '1': 0, '2': 0, '3': 0, '4': 0, '5': 0 }
   );
+
   return transformed;
 };
 


### PR DESCRIPTION
Because of metrics run async, there's a possibility of mis-match between what we show in the header & the reviews tab. This will make it so we rely on the actual count. We shouldn't do it on the grid ofcs, but no reason not to have it on the models page.

Sample before the fix:
![image](https://github.com/civitai/civitai/assets/5957926/ba2330ab-09da-49b6-ac61-2a540b8727af)

Task: https://app.clickup.com/t/860qvufqb
