### PR TITLE
Personalized home page - nits

### DIFF
--- a/src/components/Collections/CollectionsLanding.tsx
+++ b/src/components/Collections/CollectionsLanding.tsx
@@ -35,13 +35,13 @@ export function CollectionsLanding() {
             sx={(theme) => ({
               zIndex: 11,
               [theme.fn.largerThan('sm')]: {
-                transform: 'translateX(50%)',
+                transform: 'translateX(-50%)',
                 left: '50%',
               },
             })}
             pos="absolute"
             top={0}
-            maw="400"
+            maw={400}
           >
             <Alert>
               <Stack spacing="xs">

--- a/src/components/HomeBlocks/AnnouncementHomeBlock.tsx
+++ b/src/components/HomeBlocks/AnnouncementHomeBlock.tsx
@@ -1,6 +1,6 @@
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
 import { HomeBlockMetaSchema } from '~/server/schema/home-block.schema';
-import { createStyles, Grid } from '@mantine/core';
+import { Box, createStyles, Grid } from '@mantine/core';
 import { AnnouncementHomeBlockAnnouncementItem } from '~/components/HomeBlocks/components/AnnouncementHomeBlockAnnouncementItem';
 import { useDismissedAnnouncements } from '~/hooks/useDismissedAnnouncements';
 import { useMemo } from 'react';
@@ -13,6 +13,7 @@ const useStyles = createStyles((theme) => ({
   root: {
     paddingTop: '32px',
     paddingBottom: '32px',
+
     background:
       theme.colorScheme === 'dark'
         ? theme.colors.dark[8]
@@ -83,19 +84,21 @@ export const AnnouncementHomeBlock = ({ homeBlockId }: Props) => {
 
   return (
     <HomeBlockWrapper className={classes.root}>
-      <HomeBlockHeaderMeta metadata={metadata} />
-      <Grid gutter="md">
-        {announcements.map((announcement, index) => {
-          return (
-            <Grid.Col key={announcement.id} xs={12} md={sizes[index]}>
-              <AnnouncementHomeBlockAnnouncementItem
-                onAnnouncementDismiss={onAnnouncementDismiss}
-                announcement={announcement}
-              />
-            </Grid.Col>
-          );
-        })}
-      </Grid>
+      <Box px="md">
+        <HomeBlockHeaderMeta metadata={metadata} />
+        <Grid gutter="md">
+          {announcements.map((announcement, index) => {
+            return (
+              <Grid.Col key={announcement.id} xs={12} md={sizes[index]}>
+                <AnnouncementHomeBlockAnnouncementItem
+                  onAnnouncementDismiss={onAnnouncementDismiss}
+                  announcement={announcement}
+                />
+              </Grid.Col>
+            );
+          })}
+        </Grid>
+      </Box>
     </HomeBlockWrapper>
   );
 };

--- a/src/components/HomeBlocks/CollectionHomeBlock.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlock.tsx
@@ -10,7 +10,7 @@ import {
   Popover,
   Anchor,
 } from '@mantine/core';
-import { Fragment } from 'react';
+import { Fragment, useMemo } from 'react';
 import {
   IconArrowRight,
   IconCategory,
@@ -29,7 +29,7 @@ import { ArticleCard } from '~/components/Cards/ArticleCard';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { CollectionHomeBlockSkeleton } from '~/components/HomeBlocks/CollectionHomeBlockSkeleton';
 import { trpc } from '~/utils/trpc';
-import { CollectionType, HomeBlockType } from '@prisma/client';
+import { shuffle } from '~/utils/array-helpers';
 
 const useStyles = createStyles<string, { count: number }>((theme, { count }) => {
   return {
@@ -117,15 +117,18 @@ export const CollectionHomeBlock = ({ homeBlockId }: Props) => {
   const currentUser = useCurrentUser();
   const isMobile = useIsMobile();
 
+  const { collection } = homeBlock || {};
+  const items = useMemo(() => shuffle(collection?.items ?? []).slice(0, 14), [collection?.items]);
+
   if (isLoading) {
     return <CollectionHomeBlockSkeleton />;
   }
 
-  if (!homeBlock || !homeBlock.collection) {
+  if (!homeBlock || !collection) {
     return null;
   }
 
-  const { metadata, collection } = homeBlock;
+  const { metadata } = homeBlock;
   const itemType = collection.items?.[0]?.type || 'model';
   const Icon = icons[itemType];
 
@@ -232,7 +235,7 @@ export const CollectionHomeBlock = ({ homeBlockId }: Props) => {
       </Box>
       <div className={classes.grid}>
         {useGrid && <div className={classes.gridMeta}>{MetaDataGrid}</div>}
-        {collection.items.map((item) => (
+        {items.map((item) => (
           <Fragment key={item.id}>
             {item.type === 'model' && <ModelCard data={item.data} />}
             {item.type === 'image' && <ImageCard data={item.data} collectionId={collection?.id} />}

--- a/src/components/HomeBlocks/CollectionHomeBlock.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlock.tsx
@@ -30,79 +30,82 @@ import { useIsMobile } from '~/hooks/useIsMobile';
 import { CollectionHomeBlockSkeleton } from '~/components/HomeBlocks/CollectionHomeBlockSkeleton';
 import { trpc } from '~/utils/trpc';
 import { shuffle } from '~/utils/array-helpers';
+import { useMasonryContainerContext } from '~/components/MasonryColumns/MasonryContainer';
 
-const useStyles = createStyles<string, { count: number }>((theme, { count }) => {
-  return {
-    title: {
-      fontSize: 32,
+const useStyles = createStyles<string, { count: number; columnCount: number }>(
+  (theme, { count, columnCount }) => {
+    return {
+      title: {
+        fontSize: 32,
 
-      [theme.fn.smallerThan('sm')]: {
-        fontSize: 28,
-      },
-    },
-
-    grid: {
-      display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr) )',
-      columnGap: theme.spacing.md,
-      paddingLeft: theme.spacing.md,
-      paddingRight: theme.spacing.md,
-      gridTemplateRows: `repeat(2, auto)`,
-      gridAutoRows: 0,
-      overflow: 'hidden',
-      marginTop: -theme.spacing.md,
-
-      '& > *': {
-        marginTop: theme.spacing.md,
-      },
-
-      [theme.fn.smallerThan('md')]: {
-        gridAutoFlow: 'column',
-        gridTemplateColumns: `repeat(${count / 2}, minmax(280px, 1fr) )`,
-        gridTemplateRows: `repeat(2, auto)`,
-        scrollSnapType: 'x mandatory',
-        overflowX: 'auto',
-      },
-
-      [theme.fn.smallerThan('sm')]: {
-        gridAutoFlow: 'column',
-        gridTemplateColumns: `repeat(${count}, 280px)`,
-        gridTemplateRows: 'auto',
-        scrollSnapType: 'x mandatory',
-        overflowX: 'auto',
-
-        '& > *': {
-          scrollSnapAlign: 'center',
+        [theme.fn.smallerThan('sm')]: {
+          fontSize: 28,
         },
       },
-    },
 
-    meta: {
-      display: 'none',
-      [theme.fn.smallerThan('md')]: {
-        display: 'block',
+      grid: {
+        display: 'grid',
+        gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
+        columnGap: theme.spacing.md,
+        paddingLeft: theme.spacing.md,
+        paddingRight: theme.spacing.md,
+        gridTemplateRows: `repeat(2, auto)`,
+        gridAutoRows: 0,
+        overflow: 'hidden',
+        marginTop: -theme.spacing.md,
+
+        '& > *': {
+          marginTop: theme.spacing.md,
+        },
+
+        [theme.fn.smallerThan('md')]: {
+          gridAutoFlow: 'column',
+          gridTemplateColumns: `repeat(${count / 2}, minmax(280px, 1fr) )`,
+          gridTemplateRows: `repeat(2, auto)`,
+          scrollSnapType: 'x mandatory',
+          overflowX: 'auto',
+        },
+
+        [theme.fn.smallerThan('sm')]: {
+          gridAutoFlow: 'column',
+          gridTemplateColumns: `repeat(${count}, 280px)`,
+          gridTemplateRows: 'auto',
+          scrollSnapType: 'x mandatory',
+          overflowX: 'auto',
+
+          '& > *': {
+            scrollSnapAlign: 'center',
+          },
+        },
       },
-    },
 
-    gridMeta: {
-      gridColumn: '1 / span 2',
-      display: 'flex',
-      flexDirection: 'column',
-
-      '& > *': {
-        flex: 1,
-      },
-
-      [theme.fn.smallerThan('md')]: {
+      meta: {
         display: 'none',
+        [theme.fn.smallerThan('md')]: {
+          display: 'block',
+        },
       },
-    },
 
-    expandButton: {
-      height: 34,
-    },
-  };
-});
+      gridMeta: {
+        gridColumn: '1 / span 2',
+        display: 'flex',
+        flexDirection: 'column',
+
+        '& > *': {
+          flex: 1,
+        },
+
+        [theme.fn.smallerThan('md')]: {
+          display: 'none',
+        },
+      },
+
+      expandButton: {
+        height: 34,
+      },
+    };
+  }
+);
 
 const icons = {
   model: IconCategory,
@@ -111,9 +114,21 @@ const icons = {
   article: IconFileText,
 };
 
-export const CollectionHomeBlock = ({ homeBlockId }: Props) => {
+export const CollectionHomeBlock = ({ ...props }: Props) => {
+  return (
+    <HomeBlockWrapper py={32} px={0}>
+      <CollectionHomeBlockContent {...props} />
+    </HomeBlockWrapper>
+  );
+};
+
+const CollectionHomeBlockContent = ({ homeBlockId }: Props) => {
+  const { columnCount } = useMasonryContainerContext();
   const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery({ id: homeBlockId });
-  const { classes, cx } = useStyles({ count: homeBlock?.collection?.items.length ?? 0 });
+  const { classes, cx } = useStyles({
+    count: homeBlock?.collection?.items.length ?? 0,
+    columnCount,
+  });
   const currentUser = useCurrentUser();
   const isMobile = useIsMobile();
 
@@ -229,7 +244,7 @@ export const CollectionHomeBlock = ({ homeBlockId }: Props) => {
     (!currentUser || metadata.descriptionAlwaysVisible);
 
   return (
-    <HomeBlockWrapper py={32} px={0} bleedRight>
+    <>
       <Box mb="md" px="md" className={cx({ [classes.meta]: useGrid })}>
         {MetaDataTop}
       </Box>
@@ -244,7 +259,7 @@ export const CollectionHomeBlock = ({ homeBlockId }: Props) => {
           </Fragment>
         ))}
       </div>
-    </HomeBlockWrapper>
+    </>
   );
 };
 

--- a/src/components/HomeBlocks/CollectionHomeBlock.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlock.tsx
@@ -43,7 +43,7 @@ const useStyles = createStyles<string, { count: number }>((theme, { count }) => 
 
     grid: {
       display: 'grid',
-      gridTemplateColumns: 'repeat( 4, minmax(280px, 1fr) )',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr) )',
       columnGap: theme.spacing.md,
       paddingLeft: theme.spacing.md,
       paddingRight: theme.spacing.md,
@@ -58,8 +58,10 @@ const useStyles = createStyles<string, { count: number }>((theme, { count }) => 
 
       [theme.fn.smallerThan('md')]: {
         gridAutoFlow: 'column',
-        gridTemplateColumns: 'repeat(2, minmax(280px, 1fr) )',
-        gridTemplateRows: 'auto',
+        gridTemplateColumns: `repeat(${count / 2}, minmax(280px, 1fr) )`,
+        gridTemplateRows: `repeat(2, auto)`,
+        scrollSnapType: 'x mandatory',
+        overflowX: 'auto',
       },
 
       [theme.fn.smallerThan('sm')]: {
@@ -77,7 +79,7 @@ const useStyles = createStyles<string, { count: number }>((theme, { count }) => 
 
     meta: {
       display: 'none',
-      [theme.fn.smallerThan('sm')]: {
+      [theme.fn.smallerThan('md')]: {
         display: 'block',
       },
     },
@@ -91,7 +93,7 @@ const useStyles = createStyles<string, { count: number }>((theme, { count }) => 
         flex: 1,
       },
 
-      [theme.fn.smallerThan('sm')]: {
+      [theme.fn.smallerThan('md')]: {
         display: 'none',
       },
     },

--- a/src/components/HomeBlocks/CollectionHomeBlockSkeleton.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlockSkeleton.tsx
@@ -1,26 +1,23 @@
-import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
 import { AspectRatio, Group, Skeleton, Stack } from '@mantine/core';
 
 export const CollectionHomeBlockSkeleton = () => {
   return (
-    <HomeBlockWrapper py="md">
-      <Group spacing={12}>
-        <Stack spacing={0} w="calc(50% - 12px)">
-          <Group>
-            <Skeleton width="30px" height="30px" mb={20} />{' '}
-            <Skeleton width="60%" height="30px" mb={20} />
-          </Group>
-          <Skeleton width="100%" height="15px" mb={10} />
-          <Skeleton width="100%" height="15px" mb={10} />
-          <Skeleton width="80%" height="15px" mb={10} />
-        </Stack>
-        <AspectRatio ratio={7 / 9} w="calc(25% - 12px)">
-          <Skeleton width="100%" height="430" />
-        </AspectRatio>
-        <AspectRatio ratio={7 / 9} w="calc(25% - 12px)">
-          <Skeleton width="100%" height="430" />
-        </AspectRatio>
-      </Group>
-    </HomeBlockWrapper>
+    <Group spacing={12}>
+      <Stack spacing={0} w="calc(50% - 12px)">
+        <Group>
+          <Skeleton width="30px" height="30px" mb={20} />{' '}
+          <Skeleton width="60%" height="30px" mb={20} />
+        </Group>
+        <Skeleton width="100%" height="15px" mb={10} />
+        <Skeleton width="100%" height="15px" mb={10} />
+        <Skeleton width="80%" height="15px" mb={10} />
+      </Stack>
+      <AspectRatio ratio={7 / 9} w="calc(25% - 12px)">
+        <Skeleton width="100%" height="430" />
+      </AspectRatio>
+      <AspectRatio ratio={7 / 9} w="calc(25% - 12px)">
+        <Skeleton width="100%" height="430" />
+      </AspectRatio>
+    </Group>
   );
 };

--- a/src/components/HomeBlocks/HomeBlockWrapper.tsx
+++ b/src/components/HomeBlocks/HomeBlockWrapper.tsx
@@ -1,4 +1,5 @@
 import { Container, ContainerProps, createStyles } from '@mantine/core';
+import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 
 const useStyles = createStyles((theme) => ({
   bleedRight: {
@@ -10,11 +11,9 @@ export const HomeBlockWrapper = ({ children, bleedRight, ...props }: Props) => {
   const { classes, cx } = useStyles();
 
   return (
-    <Container px={0} fluid {...props}>
-      <Container size="xl" className={cx({ [classes.bleedRight]: bleedRight })}>
-        {children}
-      </Container>
-    </Container>
+    <MasonryContainer px={0} fluid {...props}>
+      {children}
+    </MasonryContainer>
   );
 };
 

--- a/src/components/HomeBlocks/HomeBlockWrapper.tsx
+++ b/src/components/HomeBlocks/HomeBlockWrapper.tsx
@@ -1,7 +1,8 @@
 import { ContainerProps } from '@mantine/core';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
+import React from 'react';
 
-export const HomeBlockWrapper = ({ children, bleedRight, ...props }: Props) => {
+export const HomeBlockWrapper = ({ children, ...props }: Props) => {
   return (
     <MasonryContainer fluid {...props}>
       {children}

--- a/src/components/HomeBlocks/HomeBlockWrapper.tsx
+++ b/src/components/HomeBlocks/HomeBlockWrapper.tsx
@@ -1,17 +1,9 @@
-import { Container, ContainerProps, createStyles } from '@mantine/core';
+import { ContainerProps } from '@mantine/core';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 
-const useStyles = createStyles((theme) => ({
-  bleedRight: {
-    padding: 0,
-  },
-}));
-
 export const HomeBlockWrapper = ({ children, bleedRight, ...props }: Props) => {
-  const { classes, cx } = useStyles();
-
   return (
-    <MasonryContainer px={0} fluid {...props}>
+    <MasonryContainer fluid {...props}>
       {children}
     </MasonryContainer>
   );

--- a/src/components/HomeBlocks/LeaderboardsHomeBlock.tsx
+++ b/src/components/HomeBlocks/LeaderboardsHomeBlock.tsx
@@ -20,10 +20,16 @@ const useStyles = createStyles((theme) => ({
       theme.colorScheme === 'dark'
         ? theme.colors.dark[8]
         : theme.fn.darken(theme.colors.gray[0], 0.01),
+    paddingLeft: 0,
+    paddingRight: 0,
   },
   metadata: {
+    padding: theme.spacing.md,
+  },
+  carousel: {
+    padding: theme.spacing.md,
     [theme.fn.smallerThan('md')]: {
-      padding: theme.spacing.md,
+      padding: 0,
     },
   },
 }));
@@ -44,7 +50,7 @@ export const LeaderboardsHomeBlock = ({ homeBlockId }: Props) => {
   const metadata = homeBlock.metadata as HomeBlockMetaSchema;
 
   return (
-    <HomeBlockWrapper className={classes.root} bleedRight>
+    <HomeBlockWrapper className={classes.root}>
       <Box className={classes.metadata}>
         <HomeBlockHeaderMeta metadata={metadata} />
       </Box>
@@ -58,6 +64,7 @@ export const LeaderboardsHomeBlock = ({ homeBlockId }: Props) => {
           { maxWidth: 'md', slideSize: '50%', slideGap: 'md' },
           { maxWidth: 'sm', slideSize: '80%', slideGap: 'sm' },
         ]}
+        className={classes.carousel}
         includeGapInSize={true}
         styles={{
           control: {

--- a/src/components/HomeBlocks/ManageHomeBlocksModal.tsx
+++ b/src/components/HomeBlocks/ManageHomeBlocksModal.tsx
@@ -138,7 +138,11 @@ function ManageHomeBlocks({ onClose }: Props) {
   };
 
   const handleSave = () => {
-    const data = items.map((item, index) => ({ id: item.id, index, userId: item.userId }));
+    const data = items.map((item, index) => ({
+      id: item.id,
+      index,
+      userId: item.userId,
+    }));
     setHomeBlocksOrder({ homeBlocks: data });
   };
 

--- a/src/components/Model/model.utils.ts
+++ b/src/components/Model/model.utils.ts
@@ -37,7 +37,6 @@ export const useModelQueryParams = () => {
   return useMemo(() => {
     const result = modelQueryParamSchema.safeParse(query);
     const data: ModelQueryParams = result.success ? result.data : {};
-    console.log(data);
 
     return {
       ...data,

--- a/src/components/Model/model.utils.ts
+++ b/src/components/Model/model.utils.ts
@@ -27,6 +27,7 @@ const modelQueryParamSchema = z
     view: z.enum(['categories', 'feed']),
     section: z.enum(['published', 'draft']),
     collectionId: z.coerce.number(),
+    excludedImageTagIds: z.array(z.coerce.number()),
   })
   .partial();
 export type ModelQueryParams = z.output<typeof modelQueryParamSchema>;
@@ -36,6 +37,7 @@ export const useModelQueryParams = () => {
   return useMemo(() => {
     const result = modelQueryParamSchema.safeParse(query);
     const data: ModelQueryParams = result.success ? result.data : {};
+    console.log(data);
 
     return {
       ...data,

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Box, Center, Container, Group, Loader } from '@mantine/core';
+import { ActionIcon, Box, Center, Group, Loader, Title } from '@mantine/core';
 import { FullHomeContentToggle } from '~/components/HomeContentToggle/FullHomeContentToggle';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { trpc } from '~/utils/trpc';
@@ -17,6 +17,7 @@ import { constants } from '~/server/common/constants';
 import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
 import { ModelSort } from '~/server/common/enums';
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
+import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 
 export const getServerSideProps = createServerSideProps({
   resolver: async () => {
@@ -39,32 +40,33 @@ export default function Home() {
 
   return (
     <>
-      <Container size="xl" sx={{ overflow: 'hidden' }}>
-        <Group position="apart" noWrap>
-          <FullHomeContentToggle />
-          {user && (
-            <ActionIcon
-              size="sm"
-              variant="light"
-              color="dark"
-              onClick={() => openContext('manageHomeBlocks', {})}
-            >
-              <IconSettings />
-            </ActionIcon>
-          )}
-        </Group>
-      </Container>
-
-      {isLoading && (
-        <Center sx={{ height: 36 }} mt="md">
-          <Loader />
-        </Center>
-      )}
       <MasonryProvider
         columnWidth={constants.cardSizes.model}
         maxColumnCount={7}
         maxSingleColumnWidth={450}
       >
+        <MasonryContainer fluid sx={{ overflow: 'hidden' }}>
+          <Group position="apart" noWrap>
+            <FullHomeContentToggle />
+            {user && (
+              <ActionIcon
+                size="sm"
+                variant="light"
+                color="dark"
+                onClick={() => openContext('manageHomeBlocks', {})}
+              >
+                <IconSettings />
+              </ActionIcon>
+            )}
+          </Group>
+        </MasonryContainer>
+
+        {isLoading && (
+          <Center sx={{ height: 36 }} mt="md">
+            <Loader />
+          </Center>
+        )}
+
         {homeBlocks.map((homeBlock) => {
           switch (homeBlock.type) {
             case HomeBlockType.Collection:
@@ -80,11 +82,33 @@ export default function Home() {
           <HomeBlockWrapper py={32}>
             {displayModelsInfiniteFeed && (
               <IsClient>
-                <Box px="md">
+                <Box
+                  sx={(theme) => ({
+                    paddingLeft: theme.spacing.md,
+                    paddingRight: theme.spacing.md,
+
+                    [theme.fn.smallerThan('sm')]: {
+                      paddingLeft: 0,
+                      paddingRight: 0,
+                    },
+                  })}
+                >
+                  <Title
+                    sx={(theme) => ({
+                      fontSize: theme.headings.sizes.h1.fontSize,
+                      [theme.fn.smallerThan('md')]: {
+                        fontSize: theme.headings.sizes.h3.fontSize,
+                      },
+                    })}
+                  >
+                    Models
+                  </Title>
+
                   <ModelsInfinite
                     filters={{
                       period: MetricTimeframe.Month,
                       sort: ModelSort.HighestRated,
+                      excludedImageTagIds: [],
                     }}
                   />
                 </Box>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -15,7 +15,6 @@ import { ModelsInfinite } from '~/components/Model/Infinite/ModelsInfinite';
 import { IsClient } from '~/components/IsClient/IsClient';
 import { constants } from '~/server/common/constants';
 import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
-import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { ModelSort } from '~/server/common/enums';
 import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -28,6 +28,9 @@ export const getServerSideProps = createServerSideProps({
 
 export default function Home() {
   const { data: homeBlocks = [], isLoading } = trpc.homeBlock.getHomeBlocks.useQuery();
+  const { data: homeExcludedTags = [], isLoading: isLoadingExcludedTags } =
+    trpc.tag.getHomeExcluded.useQuery();
+
   const [displayModelsInfiniteFeed, setDisplayModelsInfiniteFeed] = useState(false);
   const { ref, inView } = useInView();
   const user = useCurrentUser();
@@ -80,7 +83,7 @@ export default function Home() {
 
         <Box ref={ref}>
           <HomeBlockWrapper py={32}>
-            {displayModelsInfiniteFeed && (
+            {displayModelsInfiniteFeed && !isLoadingExcludedTags && (
               <IsClient>
                 <Box
                   sx={(theme) => ({
@@ -108,7 +111,7 @@ export default function Home() {
                     filters={{
                       period: MetricTimeframe.Month,
                       sort: ModelSort.HighestRated,
-                      excludedImageTagIds: [],
+                      excludedImageTagIds: homeExcludedTags.map((tag) => tag.id),
                     }}
                   />
                 </Box>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -17,6 +17,7 @@ import { constants } from '~/server/common/constants';
 import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { ModelSort } from '~/server/common/enums';
+import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
 
 export const getServerSideProps = createServerSideProps({
   resolver: async () => {
@@ -76,19 +77,21 @@ export default function Home() {
           }
         })}
 
-        <Box ref={ref} mt="lg">
-          <MasonryContainer fluid>
+        <Box ref={ref}>
+          <HomeBlockWrapper py={32}>
             {displayModelsInfiniteFeed && (
               <IsClient>
-                <ModelsInfinite
-                  filters={{
-                    period: MetricTimeframe.Month,
-                    sort: ModelSort.HighestRated,
-                  }}
-                />
+                <Box px="md">
+                  <ModelsInfinite
+                    filters={{
+                      period: MetricTimeframe.Month,
+                      sort: ModelSort.HighestRated,
+                    }}
+                  />
+                </Box>
               </IsClient>
             )}
-          </MasonryContainer>
+          </HomeBlockWrapper>
         </Box>
       </MasonryProvider>
     </>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,15 +1,22 @@
-import { ActionIcon, Center, Container, Group, Loader } from '@mantine/core';
+import { ActionIcon, Box, Center, Container, Group, Loader } from '@mantine/core';
 import { FullHomeContentToggle } from '~/components/HomeContentToggle/FullHomeContentToggle';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { trpc } from '~/utils/trpc';
-import { HomeBlockType } from '@prisma/client';
+import { HomeBlockType, MetricTimeframe } from '@prisma/client';
 import { CollectionHomeBlock } from '~/components/HomeBlocks/CollectionHomeBlock';
 import { AnnouncementHomeBlock } from '~/components/HomeBlocks/AnnouncementHomeBlock';
 import { LeaderboardsHomeBlock } from '~/components/HomeBlocks/LeaderboardsHomeBlock';
 import { IconSettings } from '@tabler/icons-react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { openContext } from '~/providers/CustomModalsProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useInView } from 'react-intersection-observer';
+import { ModelsInfinite } from '~/components/Model/Infinite/ModelsInfinite';
+import { IsClient } from '~/components/IsClient/IsClient';
+import { constants } from '~/server/common/constants';
+import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
+import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
+import { ModelSort } from '~/server/common/enums';
 
 export const getServerSideProps = createServerSideProps({
   resolver: async () => {
@@ -20,7 +27,15 @@ export const getServerSideProps = createServerSideProps({
 
 export default function Home() {
   const { data: homeBlocks = [], isLoading } = trpc.homeBlock.getHomeBlocks.useQuery();
+  const [displayModelsInfiniteFeed, setDisplayModelsInfiniteFeed] = useState(false);
+  const { ref, inView } = useInView();
   const user = useCurrentUser();
+
+  useEffect(() => {
+    if (inView && !displayModelsInfiniteFeed) {
+      setDisplayModelsInfiniteFeed(true);
+    }
+  }, [inView, displayModelsInfiniteFeed, setDisplayModelsInfiniteFeed]);
 
   return (
     <>
@@ -45,16 +60,37 @@ export default function Home() {
           <Loader />
         </Center>
       )}
-      {homeBlocks.map((homeBlock) => {
-        switch (homeBlock.type) {
-          case HomeBlockType.Collection:
-            return <CollectionHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
-          case HomeBlockType.Announcement:
-            return <AnnouncementHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
-          case HomeBlockType.Leaderboard:
-            return <LeaderboardsHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
-        }
-      })}
+      <MasonryProvider
+        columnWidth={constants.cardSizes.model}
+        maxColumnCount={7}
+        maxSingleColumnWidth={450}
+      >
+        {homeBlocks.map((homeBlock) => {
+          switch (homeBlock.type) {
+            case HomeBlockType.Collection:
+              return <CollectionHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
+            case HomeBlockType.Announcement:
+              return <AnnouncementHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
+            case HomeBlockType.Leaderboard:
+              return <LeaderboardsHomeBlock key={homeBlock.id} homeBlockId={homeBlock.id} />;
+          }
+        })}
+
+        <Box ref={ref} mt="lg">
+          <MasonryContainer fluid>
+            {displayModelsInfiniteFeed && (
+              <IsClient>
+                <ModelsInfinite
+                  filters={{
+                    period: MetricTimeframe.Month,
+                    sort: ModelSort.HighestRated,
+                  }}
+                />
+              </IsClient>
+            )}
+          </MasonryContainer>
+        </Box>
+      </MasonryProvider>
     </>
   );
 }

--- a/src/server/controllers/home-block.controller.ts
+++ b/src/server/controllers/home-block.controller.ts
@@ -6,6 +6,7 @@ import {
   getHomeBlockData,
   getHomeBlocks,
   getSystemHomeBlocks,
+  HomeBlockWithData,
   setHomeBlocksOrder,
   upsertHomeBlock,
 } from '~/server/services/home-block.service';
@@ -18,7 +19,6 @@ import {
   GetHomeBlockByIdInputSchema,
   GetHomeBlocksInputSchema,
   GetSystemHomeBlocksInputSchema,
-  getSystemHomeBlocksInputSchema,
   HomeBlockMetaSchema,
   SetHomeBlocksOrderInputSchema,
 } from '~/server/schema/home-block.schema';
@@ -28,19 +28,6 @@ import { HomeBlockType } from '@prisma/client';
 import { GetByIdInput } from '~/server/schema/base.schema';
 import { TRPCError } from '@trpc/server';
 import { isDefined } from '~/utils/type-guards';
-
-type GetLeaderboardsWithResults = AsyncReturnType<typeof getLeaderboardsWithResults>;
-type GetAnnouncements = AsyncReturnType<typeof getAnnouncements>;
-type GetCollectionWithItems = AsyncReturnType<typeof getCollectionById> & {
-  items: AsyncReturnType<typeof getCollectionItemsByCollectionId>;
-};
-type HomeBlockWithData = Omit<AsyncReturnType<typeof getHomeBlocks>[number], 'metadata' | 'id'> & {
-  id: number;
-  metadata: HomeBlockMetaSchema;
-  collection?: GetCollectionWithItems;
-  leaderboards?: GetLeaderboardsWithResults;
-  announcements?: GetAnnouncements;
-};
 
 export const getHomeBlocksHandler = async ({
   ctx,
@@ -92,7 +79,6 @@ export const getSystemHomeBlocksHandler = async ({
 }): Promise<HomeBlockWithData[]> => {
   try {
     const homeBlocks = await getSystemHomeBlocks({ input });
-
     return homeBlocks;
   } catch (error) {
     throw throwDbError(error);

--- a/src/server/controllers/home-block.controller.ts
+++ b/src/server/controllers/home-block.controller.ts
@@ -28,6 +28,7 @@ import { HomeBlockType } from '@prisma/client';
 import { GetByIdInput } from '~/server/schema/base.schema';
 import { TRPCError } from '@trpc/server';
 import { isDefined } from '~/utils/type-guards';
+import { shuffle } from '~/utils/array-helpers';
 
 export const getHomeBlocksHandler = async ({
   ctx,

--- a/src/server/controllers/home-block.controller.ts
+++ b/src/server/controllers/home-block.controller.ts
@@ -10,10 +10,7 @@ import {
   setHomeBlocksOrder,
   upsertHomeBlock,
 } from '~/server/services/home-block.service';
-import {
-  getCollectionById,
-  getCollectionItemsByCollectionId,
-} from '~/server/services/collection.service';
+import { getCollectionById } from '~/server/services/collection.service';
 import {
   CreateCollectionHomeBlockInputSchema,
   GetHomeBlockByIdInputSchema,
@@ -22,13 +19,10 @@ import {
   HomeBlockMetaSchema,
   SetHomeBlocksOrderInputSchema,
 } from '~/server/schema/home-block.schema';
-import { getLeaderboardsWithResults } from '~/server/services/leaderboard.service';
-import { getAnnouncements } from '~/server/services/announcement.service';
 import { HomeBlockType } from '@prisma/client';
 import { GetByIdInput } from '~/server/schema/base.schema';
 import { TRPCError } from '@trpc/server';
 import { isDefined } from '~/utils/type-guards';
-import { shuffle } from '~/utils/array-helpers';
 
 export const getHomeBlocksHandler = async ({
   ctx,

--- a/src/server/controllers/tag.controller.ts
+++ b/src/server/controllers/tag.controller.ts
@@ -27,6 +27,7 @@ import { Context } from '~/server/createContext';
 import { dbRead } from '~/server/db/client';
 import { getFeatureFlags } from '~/server/services/feature-flags.service';
 import { trackModActivity } from '~/server/services/moderator.service';
+import { getHomeExcludedTags } from '~/server/services/system-cache';
 
 export const getTagWithModelCountHandler = ({ input: { name } }: { input: GetTagByNameInput }) => {
   try {
@@ -196,6 +197,15 @@ export const moderateTagsHandler = async ({
 export const deleteTagsHandler = async ({ input }: { input: DeleteTagsSchema }) => {
   try {
     await deleteTags(input);
+  } catch (error) {
+    throw throwDbError(error);
+  }
+};
+
+export const getHomeExcludedTagsHandler = async () => {
+  try {
+    const tags = await getHomeExcludedTags();
+    return tags;
   } catch (error) {
     throw throwDbError(error);
   }

--- a/src/server/routers/tag.router.ts
+++ b/src/server/routers/tag.router.ts
@@ -11,6 +11,7 @@ import {
   moderateTagsHandler,
   getManagableTagsHandler,
   deleteTagsHandler,
+  getHomeExcludedTagsHandler,
 } from '~/server/controllers/tag.controller';
 import { cacheIt } from '~/server/middleware.trpc';
 import { getByIdSchema } from '~/server/schema/base.schema';
@@ -66,6 +67,7 @@ export const tagRouter = router({
     .use(applyUserPreferences)
     .use(cacheIt({ ttl: 60 }))
     .query(getAllTagsHandler),
+  getHomeExcluded: publicProcedure.query(getHomeExcludedTagsHandler),
   getTrending: publicProcedure
     .input(getTrendingTagsSchema)
     .use(applyUserPreferences)

--- a/src/server/schema/home-block.schema.ts
+++ b/src/server/schema/home-block.schema.ts
@@ -53,14 +53,9 @@ export const getHomeBlocksInputSchema = z
 export type GetSystemHomeBlocksInputSchema = z.infer<typeof getSystemHomeBlocksInputSchema>;
 export const getSystemHomeBlocksInputSchema = z
   .object({
-    limit: z.number().default(8),
-    dismissed: z.array(z.number()).optional(),
     permanent: z.boolean().optional(),
-    withData: z.boolean().optional(),
   })
-  .merge(userPreferencesSchema)
-  .partial()
-  .default({ limit: 8 });
+  .partial();
 
 export type GetHomeBlockByIdInputSchema = z.infer<typeof getHomeBlockByIdInputSchema>;
 

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -44,7 +44,7 @@ export const getHomeBlocks = async <
     throw throwBadRequestError('You must be logged in to view your home blocks.');
   }
 
-  if (!hasCustomHomeBlocks) {
+  if (!hasCustomHomeBlocks && !ownedOnly && !ids) {
     // If the user doesn't have any custom home blocks, we can just return the default Civitai ones.
     return getSystemHomeBlocks({ input: {} });
   }

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -152,6 +152,9 @@ export async function getSystemHomeBlocksCached() {
   const systemHomeBlocksWithData: HomeBlockWithData[] = (
     await Promise.all(
       systemHomeBlocks.map((homeBlock) => {
+        // 14 * 4 because we show about 14 items max on home-page.
+        // Since we're shuffling, we want to make sure we have enough to show
+        // different ones.
         return getHomeBlockData({ homeBlock, input: { limit: 14 * 4 }, bypassCache: true });
       })
     )

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -168,3 +168,20 @@ export async function getSystemHomeBlocksCached() {
 
   return systemHomeBlocksWithData;
 }
+
+export async function getHomeExcludedTags() {
+  const cachedTags = await redis.get(`system:home-excluded-tags`);
+  if (cachedTags) return JSON.parse(cachedTags) as { id: number; name: string }[];
+
+  log('getting home excluded tags');
+  const tags = await dbWrite.tag.findMany({
+    where: { name: { in: ['1girl', 'anime', 'female', 'woman', 'clothing'] } },
+    select: { id: true, name: true },
+  });
+  await redis.set(`system:home-excluded-tags`, JSON.stringify(tags), {
+    EX: SYSTEM_CACHE_EXPIRY,
+  });
+
+  log('got home excluded tags');
+  return tags;
+}


### PR DESCRIPTION
Includes:
* Full width support
* Cache support for System Home Blocks (We're not caching user ones atm)
* Adds infinite models at the bottom of the home page
* Shuffle collections' data
* Clone all system blocks when the user initially adds collection to home block

![image](https://github.com/civitai/civitai/assets/5957926/ff1babfe-afc2-4d19-974c-d007cb7240f4)
