### PR TITLE
Collections: Ensure it's possible to use an image as a cover image

### DIFF
--- a/src/server/controllers/collection.controller.ts
+++ b/src/server/controllers/collection.controller.ts
@@ -15,6 +15,7 @@ import {
   UpsertCollectionInput,
   AddSimpleImagePostInput,
   GetAllCollectionsInfiniteSchema,
+  UpdateCollectionCoverImageInput,
 } from '~/server/schema/collection.schema';
 import {
   saveItemInCollections,
@@ -31,6 +32,7 @@ import {
   bulkSaveItems,
   getAllCollections,
   CollectionItemExpanded,
+  updateCollectionCoverImage,
 } from '~/server/services/collection.service';
 import { TRPCError } from '@trpc/server';
 import { GetByIdInput, UserPreferencesInput } from '~/server/schema/base.schema';
@@ -224,6 +226,27 @@ export const upsertCollectionHandler = async ({
 
   try {
     const collection = await upsertCollection({ input: { ...input, userId: user.id } });
+
+    return collection;
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    throw throwDbError(error);
+  }
+};
+
+export const updateCollectionCoverImageHandler = async ({
+  input,
+  ctx,
+}: {
+  input: UpdateCollectionCoverImageInput;
+  ctx: DeepNonNullable<Context>;
+}) => {
+  const { user } = ctx;
+
+  try {
+    const collection = await updateCollectionCoverImage({
+      input: { ...input, userId: user.id, isModerator: user.isModerator },
+    });
 
     return collection;
   } catch (error) {

--- a/src/server/routers/collection.router.ts
+++ b/src/server/routers/collection.router.ts
@@ -10,6 +10,7 @@ import {
   getUserCollectionItemsByItemHandler,
   saveItemHandler,
   unfollowHandler,
+  updateCollectionCoverImageHandler,
   updateCollectionItemsStatusHandler,
   upsertCollectionHandler,
 } from '~/server/controllers/collection.controller';
@@ -25,6 +26,7 @@ import {
   getAllUserCollectionsInputSchema,
   getUserCollectionItemsByItemSchema,
   saveCollectionItemInputSchema,
+  updateCollectionCoverImageInput,
   updateCollectionItemsStatusInput,
   upsertCollectionInput,
 } from '~/server/schema/collection.schema';
@@ -76,6 +78,9 @@ export const collectionRouter = router({
     .use(isFlagProtected('collections'))
     .query(getCollectionByIdHandler),
   upsert: protectedProcedure.input(upsertCollectionInput).mutation(upsertCollectionHandler),
+  updateCoverImage: protectedProcedure
+    .input(updateCollectionCoverImageInput)
+    .mutation(updateCollectionCoverImageHandler),
   saveItem: protectedProcedure
     .input(saveCollectionItemInputSchema)
     .use(isFlagProtected('collections'))

--- a/src/server/schema/collection.schema.ts
+++ b/src/server/schema/collection.schema.ts
@@ -91,12 +91,19 @@ export const upsertCollectionInput = z
     name: z.string().max(30).nonempty(),
     description: z.string().max(300).nullish(),
     image: imageSchema.nullish(),
+    imageId: z.number().optional(),
     nsfw: z.boolean().optional(),
     read: z.nativeEnum(CollectionReadConfiguration).optional(),
     write: z.nativeEnum(CollectionWriteConfiguration).optional(),
     type: z.nativeEnum(CollectionType).default(CollectionType.Model),
   })
   .merge(collectionItemSchema);
+
+export type UpdateCollectionCoverImageInput = z.infer<typeof updateCollectionCoverImageInput>;
+export const updateCollectionCoverImageInput = z.object({
+  id: z.number(),
+  imageId: z.number(),
+});
 
 export type GetUserCollectionItemsByItemSchema = z.infer<typeof getUserCollectionItemsByItemSchema>;
 export const getUserCollectionItemsByItemSchema = collectionItemSchema

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -9,6 +9,7 @@ import {
   UpdateCollectionItemsStatusInput,
   UpsertCollectionInput,
   GetAllCollectionsInfiniteSchema,
+  UpdateCollectionCoverImageInput,
 } from '~/server/schema/collection.schema';
 import { SessionUser } from 'next-auth';
 import {
@@ -468,8 +469,19 @@ export const upsertCollection = async ({
 }: {
   input: UpsertCollectionInput & { userId: number };
 }) => {
-  const { userId, id, name, description, image, read, write, type, nsfw, ...collectionItem } =
-    input;
+  const {
+    userId,
+    id,
+    name,
+    description,
+    image,
+    imageId,
+    read,
+    write,
+    type,
+    nsfw,
+    ...collectionItem
+  } = input;
 
   if (id) {
     const updated = await dbWrite.collection.update({
@@ -481,22 +493,23 @@ export const upsertCollection = async ({
         nsfw,
         read,
         write,
-        image:
-          image !== undefined
-            ? image === null
-              ? { disconnect: true }
-              : {
-                  connectOrCreate: {
-                    where: { id: image.id ?? -1 },
-                    create: {
-                      ...image,
-                      meta: (image.meta as Prisma.JsonObject) ?? Prisma.JsonNull,
-                      userId,
-                      resources: undefined,
-                    },
+        image: imageId
+          ? { connect: { id: imageId } }
+          : image !== undefined
+          ? image === null
+            ? { disconnect: true }
+            : {
+                connectOrCreate: {
+                  where: { id: image.id ?? -1 },
+                  create: {
+                    ...image,
+                    meta: (image?.meta as Prisma.JsonObject) ?? Prisma.JsonNull,
+                    userId,
+                    resources: undefined,
                   },
-                }
-            : undefined,
+                },
+              }
+          : undefined,
       },
     });
     if (!updated) throw throwNotFoundError(`No collection with id ${id}`);
@@ -548,6 +561,35 @@ export const upsertCollection = async ({
   });
 
   return collection;
+};
+
+export const updateCollectionCoverImage = async ({
+  input,
+}: {
+  input: UpdateCollectionCoverImageInput & { userId: number; isModerator?: boolean };
+}) => {
+  const { id, imageId, userId, isModerator } = input;
+  const permission = await getUserCollectionPermissionsById({
+    id,
+    userId,
+    isModerator,
+  });
+
+  if (!permission.manage) {
+    return;
+  }
+
+  const updated = await dbWrite.collection.update({
+    select: { id: true, image: { select: { id: true, url: true, ingestion: true, type: true } } },
+    where: { id },
+    data: {
+      image: { connect: { id: imageId } },
+    },
+  });
+
+  if (!updated) throw throwNotFoundError(`No collection with id ${id}`);
+
+  return updated;
 };
 
 interface ModelCollectionItem {


### PR DESCRIPTION
Right now only enabled this on the Images' collections. Will look into other collection types as it makes sense to a degree for sure.

This also introduces the concept of ImageGuardContextProvider, which will allow us to manage the context menu from an outside perspective on Images. 