### PR TITLE
Fixes for Image Resource Training Webhooks

### DIFF
--- a/src/pages/api/webhooks/image-resource-training.ts
+++ b/src/pages/api/webhooks/image-resource-training.ts
@@ -91,6 +91,7 @@ export default WebhookEndpoint(async (req, res) => {
     case 'Expire':
     case 'Claim':
     default:
+      return res.status(400).json({ ok: false, error: 'type not supported' });
   }
 
   return res.status(200).json({ ok: true });


### PR DESCRIPTION
Fix up the schema for incoming webhooks and handle more of webhook event types. Only `Expire` and `Claim` are not handled since we are not storing the `jobId` presently. Claim is not necessary to handle since `Update` will cover it and comes in within 1 minute. `Expire` woulbe good to handle in the future.