### PR TITLE
Prevents image uploads larger than 32mb

### DIFF
--- a/src/components/Image/ImageDropzone/ImageDropzone.tsx
+++ b/src/components/Image/ImageDropzone/ImageDropzone.tsx
@@ -78,7 +78,7 @@ export function ImageDropzone({
             {description}
             <Text size="sm" color="dimmed" inline mt={7}>
               {max ? `Attach up to ${max} files` : 'Attach as many files as you like'}
-              {`, each file should not exceed ${formatBytes(maxSize)}`}
+              {`, image files should not exceed ${formatBytes(maxSize)}`}
               {fileExtensions.length > 0 && `. Accepted file types: ${fileExtensions.join(', ')}`}
             </Text>
           </div>

--- a/src/components/Image/ImageDropzone/ImageDropzone.tsx
+++ b/src/components/Image/ImageDropzone/ImageDropzone.tsx
@@ -34,7 +34,7 @@ export function ImageDropzone({
     const hasLargeImageFiles = files.some(
       (file) => IMAGE_MIME_TYPE.includes(file.type as IMAGE_MIME_TYPE) && file.size > maxSize
     );
-    if (hasLargeImageFiles) return setError(`Files should not exceed ${formatBytes(maxSize)}`);
+    if (hasLargeImageFiles) return setError(`Images should not exceed ${formatBytes(maxSize)}`);
 
     setError('');
     onDrop?.(files.slice(0, max - count));

--- a/src/components/Image/ImageDropzone/ImageDropzone.tsx
+++ b/src/components/Image/ImageDropzone/ImageDropzone.tsx
@@ -1,7 +1,10 @@
-import { createStyles, Group, Text, useMantineTheme } from '@mantine/core';
+import { createStyles, Group, Input, Stack, Text } from '@mantine/core';
 import { Dropzone, DropzoneProps } from '@mantine/dropzone';
 import { IconPhoto, IconUpload, IconX } from '@tabler/icons-react';
+import { useState } from 'react';
+import { constants } from '~/server/common/constants';
 import { IMAGE_MIME_TYPE, MIME_TYPES } from '~/server/common/mime-types';
+import { formatBytes } from '~/utils/number-helpers';
 
 export function ImageDropzone({
   disabled: initialDisabled,
@@ -12,10 +15,12 @@ export function ImageDropzone({
   label,
   description,
   accept = IMAGE_MIME_TYPE,
+  maxSize = constants.imageUpload.maxFileSize,
   ...props
 }: Props) {
-  const theme = useMantineTheme();
-  const { classes, cx } = useStyles();
+  const { classes, cx, theme } = useStyles();
+
+  const [error, setError] = useState('');
 
   const canAddFiles = max - count > 0;
   const disabled = !canAddFiles || initialDisabled;
@@ -26,51 +31,59 @@ export function ImageDropzone({
     .map((type) => type.replace(/.*\//, '.'));
 
   const handleDrop = (files: File[]) => {
+    const hasLargeFile = files.some((file) => file.size > maxSize);
+    if (hasLargeFile) return setError(`Files should not exceed ${formatBytes(maxSize)}`);
+
+    setError('');
     onDrop?.(files.slice(0, max - count));
   };
 
   return (
-    <Dropzone
-      {...props}
-      accept={accept}
-      className={cx({ [classes.disabled]: disabled })}
-      classNames={{
-        root: hasError ? classes.error : undefined,
-      }}
-      disabled={!canAddFiles || disabled}
-      onDrop={handleDrop}
-    >
-      <Group position="center" spacing="xl" style={{ minHeight: 120, pointerEvents: 'none' }}>
-        <Dropzone.Accept>
-          <IconUpload
-            size={50}
-            stroke={1.5}
-            color={theme.colors[theme.primaryColor][theme.colorScheme === 'dark' ? 4 : 6]}
-          />
-        </Dropzone.Accept>
-        <Dropzone.Reject>
-          <IconX
-            size={50}
-            stroke={1.5}
-            color={theme.colors.red[theme.colorScheme === 'dark' ? 4 : 6]}
-          />
-        </Dropzone.Reject>
-        <Dropzone.Idle>
-          <IconPhoto size={50} stroke={1.5} />
-        </Dropzone.Idle>
+    <Stack spacing={5}>
+      <Dropzone
+        {...props}
+        accept={accept}
+        className={cx({ [classes.disabled]: disabled })}
+        classNames={{
+          root: hasError || !!error ? classes.error : undefined,
+        }}
+        disabled={!canAddFiles || disabled}
+        onDrop={handleDrop}
+      >
+        <Group position="center" spacing="xl" style={{ minHeight: 120, pointerEvents: 'none' }}>
+          <Dropzone.Accept>
+            <IconUpload
+              size={50}
+              stroke={1.5}
+              color={theme.colors[theme.primaryColor][theme.colorScheme === 'dark' ? 4 : 6]}
+            />
+          </Dropzone.Accept>
+          <Dropzone.Reject>
+            <IconX
+              size={50}
+              stroke={1.5}
+              color={theme.colors.red[theme.colorScheme === 'dark' ? 4 : 6]}
+            />
+          </Dropzone.Reject>
+          <Dropzone.Idle>
+            <IconPhoto size={50} stroke={1.5} />
+          </Dropzone.Idle>
 
-        <div>
-          <Text size="xl" inline>
-            {label ?? 'Drag images here or click to select files'}
-          </Text>
-          {description}
-          <Text size="sm" color="dimmed" inline mt={7}>
-            {max ? `Attach up to ${max} files` : 'Attach as many files as you like'}
-            {fileExtensions.length > 0 && `. Accepted file types: ${fileExtensions.join(', ')}`}
-          </Text>
-        </div>
-      </Group>
-    </Dropzone>
+          <div>
+            <Text size="xl" inline>
+              {label ?? 'Drag images here or click to select files'}
+            </Text>
+            {description}
+            <Text size="sm" color="dimmed" inline mt={7}>
+              {max ? `Attach up to ${max} files` : 'Attach as many files as you like'}
+              {`, each file should not exceed ${formatBytes(maxSize)}`}
+              {fileExtensions.length > 0 && `. Accepted file types: ${fileExtensions.join(', ')}`}
+            </Text>
+          </div>
+        </Group>
+      </Dropzone>
+      {error && <Input.Error>{error}</Input.Error>}
+    </Stack>
   );
 }
 

--- a/src/components/Image/ImageDropzone/ImageDropzone.tsx
+++ b/src/components/Image/ImageDropzone/ImageDropzone.tsx
@@ -31,8 +31,10 @@ export function ImageDropzone({
     .map((type) => type.replace(/.*\//, '.'));
 
   const handleDrop = (files: File[]) => {
-    const hasLargeFile = files.some((file) => file.size > maxSize);
-    if (hasLargeFile) return setError(`Files should not exceed ${formatBytes(maxSize)}`);
+    const hasLargeImageFiles = files.some(
+      (file) => IMAGE_MIME_TYPE.includes(file.type as IMAGE_MIME_TYPE) && file.size > maxSize
+    );
+    if (hasLargeImageFiles) return setError(`Files should not exceed ${formatBytes(maxSize)}`);
 
     setError('');
     onDrop?.(files.slice(0, max - count));

--- a/src/components/ProfileImageUpload/ProfileImageUpload.tsx
+++ b/src/components/ProfileImageUpload/ProfileImageUpload.tsx
@@ -2,26 +2,36 @@ import { Group, Input, InputWrapperProps, LoadingOverlay, Paper, Text } from '@m
 import { Dropzone, FileWithPath } from '@mantine/dropzone';
 import { useDidUpdate, useListState } from '@mantine/hooks';
 import produce from 'immer';
+import { useState } from 'react';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
+import { constants } from '~/server/common/constants';
 import { IMAGE_MIME_TYPE } from '~/server/common/mime-types';
+import { formatBytes } from '~/utils/number-helpers';
 
 type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> & {
   value?: string;
   onChange?: (value: string) => void;
   previewWidth?: number;
+  maxSize?: number;
 };
 
 export function ProfileImageUpload({
   value,
   onChange,
   previewWidth = 96,
+  maxSize = constants.imageUpload.maxFileSize,
   ...props
 }: SimpleImageUploadProps) {
   const { uploadToCF, files: imageFiles } = useCFImageUpload();
   const [files, filesHandlers] = useListState<CustomFile>(value ? [{ url: value }] : []);
+  const [error, setError] = useState('');
 
   const handleDrop = async (droppedFiles: FileWithPath[]) => {
+    const hasLargeFile = droppedFiles.some((file) => file.size > maxSize);
+    if (hasLargeFile) return setError(`File should not exceed ${formatBytes(maxSize)}`);
+
+    setError('');
     const toUpload = droppedFiles.map((file) => ({ url: URL.createObjectURL(file), file }));
     filesHandlers.setState((current) => [...toUpload.map((x) => ({ url: x.url, file: x.file }))]); //eslint-disable-line
     await Promise.all(
@@ -45,9 +55,11 @@ export function ProfileImageUpload({
     // don't disable the eslint-disable
   }, [files]); //eslint-disable-line
 
+  const hasError = !!props.error || !!error;
+
   return (
-    <Input.Wrapper {...props}>
-      <Group style={{ alignItems: 'stretch' }}>
+    <Input.Wrapper {...props} error={props.error ?? error}>
+      <Group style={{ alignItems: 'stretch', marginBottom: hasError ? 5 : undefined }}>
         {files.map((image, index) => {
           const match = imageFiles.find((file) => image.file === file.file);
           const { progress } = match ?? { progress: 0 };
@@ -79,15 +91,10 @@ export function ProfileImageUpload({
             alignItems: 'center',
           }}
           styles={(theme) => ({
-            root: !!props.error
-              ? {
-                  borderColor: theme.colors.red[6],
-                  marginBottom: theme.spacing.xs / 2,
-                }
-              : undefined,
+            root: hasError ? { borderColor: theme.colors.red[6] } : undefined,
           })}
         >
-          <Text color="dimmed">Drop image here</Text>
+          <Text color="dimmed">{`Drop image here, should not exceed ${formatBytes(maxSize)}`}</Text>
         </Dropzone>
       </Group>
     </Input.Wrapper>

--- a/src/libs/form/components/SimpleImageUpload.tsx
+++ b/src/libs/form/components/SimpleImageUpload.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   useMantineTheme,
 } from '@mantine/core';
-import { Dropzone, FileWithPath } from '@mantine/dropzone';
+import { Dropzone, DropzoneProps, FileWithPath } from '@mantine/dropzone';
 import { useDidUpdate } from '@mantine/hooks';
 import { MediaType } from '@prisma/client';
 import { IconPhoto, IconTrash, IconUpload, IconX } from '@tabler/icons-react';
@@ -19,21 +19,35 @@ import { useEffect, useState } from 'react';
 
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
+import imageUpload from '~/pages/api/image-upload';
+import { constants } from '~/server/common/constants';
 import { IMAGE_MIME_TYPE } from '~/server/common/mime-types';
+import { formatBytes } from '~/utils/number-helpers';
 
 type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> & {
   value?: string | { url: string };
   onChange?: (value: CustomFile | null) => void;
   previewWidth?: number;
+  maxSize?: number;
 };
 
-export function SimpleImageUpload({ value, onChange, ...props }: SimpleImageUploadProps) {
+export function SimpleImageUpload({
+  value,
+  onChange,
+  maxSize = constants.imageUpload.maxFileSize,
+  ...props
+}: SimpleImageUploadProps) {
   const theme = useMantineTheme();
   const { uploadToCF, files: imageFiles } = useCFImageUpload();
   // const [files, filesHandlers] = useListState<CustomFile>(value ? [{ url: value }] : []);
   const [image, setImage] = useState<CustomFile | undefined>();
+  const [error, setError] = useState('');
 
   const handleDrop = async (droppedFiles: FileWithPath[]) => {
+    const hasLargeFile = droppedFiles.some((file) => file.size > maxSize);
+    if (hasLargeFile) return setError(`Files should not exceed ${formatBytes(maxSize)}`);
+
+    setError('');
     const [file] = droppedFiles;
     const toUpload = { url: URL.createObjectURL(file), file };
     setImage((current) => ({
@@ -74,7 +88,7 @@ export function SimpleImageUpload({ value, onChange, ...props }: SimpleImageUplo
   const showLoading = match && match.progress < 100 && !image?.url;
 
   return (
-    <Input.Wrapper {...props}>
+    <Input.Wrapper {...props} error={props.error ?? error}>
       {showLoading ? (
         <Paper
           style={{ position: 'relative', marginTop: 5, width: '100%', height: 200 }}
@@ -118,14 +132,16 @@ export function SimpleImageUpload({ value, onChange, ...props }: SimpleImageUplo
           onDrop={handleDrop}
           accept={IMAGE_MIME_TYPE}
           maxFiles={1}
+          // maxSize={maxSize}
           mt={5}
           styles={(theme) => ({
-            root: !!props.error
-              ? {
-                  borderColor: theme.colors.red[6],
-                  marginBottom: theme.spacing.xs / 2,
-                }
-              : undefined,
+            root:
+              !!props.error || !!error
+                ? {
+                    borderColor: theme.colors.red[6],
+                    marginBottom: theme.spacing.xs / 2,
+                  }
+                : undefined,
           })}
         >
           <Dropzone.Accept>
@@ -151,7 +167,9 @@ export function SimpleImageUpload({ value, onChange, ...props }: SimpleImageUplo
           <Dropzone.Idle>
             <Group position="center" spacing="xs">
               <IconPhoto size={32} stroke={1.5} />
-              <Text color="dimmed">Drop image here</Text>
+              <Text color="dimmed">{`Drop image here, should not exceed ${formatBytes(
+                maxSize
+              )}`}</Text>
             </Group>
           </Dropzone.Idle>
         </Dropzone>

--- a/src/libs/form/components/SimpleImageUpload.tsx
+++ b/src/libs/form/components/SimpleImageUpload.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   useMantineTheme,
 } from '@mantine/core';
-import { Dropzone, DropzoneProps, FileWithPath } from '@mantine/dropzone';
+import { Dropzone, FileWithPath } from '@mantine/dropzone';
 import { useDidUpdate } from '@mantine/hooks';
 import { MediaType } from '@prisma/client';
 import { IconPhoto, IconTrash, IconUpload, IconX } from '@tabler/icons-react';
@@ -19,7 +19,6 @@ import { useEffect, useState } from 'react';
 
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
-import imageUpload from '~/pages/api/image-upload';
 import { constants } from '~/server/common/constants';
 import { IMAGE_MIME_TYPE } from '~/server/common/mime-types';
 import { formatBytes } from '~/utils/number-helpers';

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -168,6 +168,9 @@ export const constants = {
     styles: ['anime', 'cartoon', 'comics', 'manga'] as string[],
   },
   maxTrainingRetries: 2,
+  imageUpload: {
+    maxFileSize: 32 * 1024 ** 2, // 32MB
+  },
 } as const;
 
 export const POST_IMAGE_LIMIT = 20;

--- a/src/server/common/mime-types.ts
+++ b/src/server/common/mime-types.ts
@@ -31,6 +31,7 @@ export const MEDIA_TYPE: Record<string, MediaType> = {
 } as const;
 
 export const IMAGE_MIME_TYPE = [MIME_TYPES.png, MIME_TYPES.jpeg, MIME_TYPES.webp];
+export type IMAGE_MIME_TYPE = (typeof IMAGE_MIME_TYPE)[number];
 export const VIDEO_MIME_TYPE = [MIME_TYPES.mp4, MIME_TYPES.webm];
 export const AUDIO_MIME_TYPE = [MIME_TYPES.mp3, MIME_TYPES.wav];
 export const ZIP_MIME_TYPE = [MIME_TYPES.zip, MIME_TYPES.xZipCompressed, MIME_TYPES.xZipMultipart];


### PR DESCRIPTION
### Description

- Adds file size validation anywhere we allow image upload
- Displays an error message in the image upload input

<img width="1277" alt="Screenshot 2023-09-11 at 3 32 56 PM" src="https://github.com/civitai/civitai/assets/12631159/6e985db8-1f94-4826-ae76-0a8a72429951">

<img width="1264" alt="Screenshot 2023-09-11 at 3 33 35 PM" src="https://github.com/civitai/civitai/assets/12631159/550bf7d7-5965-4e9d-9d2e-003eb31ed491">
