### PR TITLE
Add publishedAt field to public API

### DIFF
--- a/src/server/selectors/modelVersion.selector.ts
+++ b/src/server/selectors/modelVersion.selector.ts
@@ -7,6 +7,7 @@ export const getModelVersionDetailsSelect = Prisma.validator<Prisma.ModelVersion
   name: true,
   createdAt: true,
   updatedAt: true,
+  publishedAt: true,
   trainedWords: true,
   trainingStatus: true,
   trainingDetails: true,


### PR DESCRIPTION
Small pull request to expose the publishedAt field to the public API so that it can be used to calculate when a model leaves Early Access
@rockerBOO 