### PR TITLE
provide an example of buffered metrics

### DIFF
--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -206,7 +206,7 @@ async function updateVersionGenerationMetrics({
   ).map((x) => x.modelVersionId);
 
   const batches = chunk(versionIds, 5000);
-  const rows = 0;
+  let rows = 0;
   for (const batch of batches) {
     try {
       const affectedModelVersionsResponse = await ch.query({
@@ -269,7 +269,7 @@ async function updateVersionGenerationMetrics({
 
         const insertBatches = chunk(metrics, 1000);
         for (const insertBatch of insertBatches) {
-          await dbWrite.$executeRaw`
+          rows += await dbWrite.$executeRaw`
             INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "generationCount")
             ${insertBatch /* TODO: this is almost certainly not right */}
             ON CONFLICT ("modelVersionId", timeframe) DO UPDATE


### PR DESCRIPTION
When computing metrics, run queries against the read replica and buffer the results in the JS worker before writing them back.

This does not address `recreateRankTable`.