### PR TITLE
[CU-8686njgwm] Fixes placement of resource review modal

### DIFF
--- a/src/components/AppLayout/AppHeader.tsx
+++ b/src/components/AppLayout/AppHeader.tsx
@@ -842,7 +842,7 @@ export function AppHeader({
                     ref={ref}
                   >
                     {/* Calculate maxHeight based off total viewport height minus header + footer + static menu options inside dropdown sizes */}
-                    <ScrollArea.Autosize maxHeight={'calc(100vh - 269px)'}>
+                    <ScrollArea.Autosize maxHeight={'calc(100dvh - 269px)'}>
                       <BuzzMenuItem mx={0} mt={0} textSize="sm" withAbbreviation={false} />
                       {burgerMenuItems}
                     </ScrollArea.Autosize>

--- a/src/components/ResourceReview/ResourceReviewCarousel.tsx
+++ b/src/components/ResourceReview/ResourceReviewCarousel.tsx
@@ -33,7 +33,7 @@ export function ResourceReviewCarousel({
   modelVersionId: number;
   reviewId: number;
 }) {
-  const { classes, theme } = useStyles();
+  const { classes } = useStyles();
   const mobile = useContainerSmallerThan('sm');
 
   const filters = {

--- a/src/components/ResourceReview/ResourceReviewDetail.tsx
+++ b/src/components/ResourceReview/ResourceReviewDetail.tsx
@@ -7,8 +7,6 @@ import {
   Text,
   Title,
   Badge,
-  Rating,
-  Box,
   Divider,
   CloseButton,
   Button,
@@ -34,12 +32,10 @@ import { Meta } from '~/components/Meta/Meta';
 import { truncate } from 'lodash-es';
 import { StarRating } from '../StartRating/StarRating';
 import { env } from '~/env/client.mjs';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 
 export function ResourceReviewDetail({ reviewId }: { reviewId: number }) {
   const router = useRouter();
   const isModelPage = !!router.query.id && !router.pathname.includes('/reviews');
-  const inModal = !!router.query.modal;
 
   const { data, isLoading } = trpc.resourceReview.get.useQuery({ id: reviewId });
   const { data: relatedPosts, isLoading: loadingRelatedPosts } = trpc.post.getInfinite.useQuery(
@@ -94,7 +90,7 @@ export function ResourceReviewDetail({ reviewId }: { reviewId: number }) {
         links={[{ href: `${env.NEXT_PUBLIC_BASE_URL}/reviews/${reviewId}`, rel: 'canonical' }]}
         schema={metaSchema}
       />
-      <Container mb="md">
+      <Container my="md" w="100%">
         <Stack>
           <Group position="apart" noWrap align="center">
             <Title order={3} sx={{ display: 'flex', alignItems: 'center', gap: 4 }}>
@@ -113,6 +109,7 @@ export function ResourceReviewDetail({ reviewId }: { reviewId: number }) {
 
             <Group spacing={4} noWrap>
               <ResourceReviewMenu
+                size="lg"
                 reviewId={reviewId}
                 userId={data.user.id}
                 review={{
@@ -121,11 +118,9 @@ export function ResourceReviewDetail({ reviewId }: { reviewId: number }) {
                   modelVersionId: data.modelVersion.id,
                 }}
               />
-              {inModal && (
-                <NavigateBack url={getModelWithVersionUrl(data)}>
-                  {({ onClick }) => <CloseButton onClick={onClick} size="lg" />}
-                </NavigateBack>
-              )}
+              <NavigateBack url={getModelWithVersionUrl(data)}>
+                {({ onClick }) => <CloseButton onClick={onClick} size="lg" />}
+              </NavigateBack>
             </Group>
           </Group>
           <Group spacing="xs" align="center">
@@ -166,7 +161,7 @@ export function ResourceReviewDetail({ reviewId }: { reviewId: number }) {
           reviewId={reviewId}
         />
       )}
-      <Container>
+      <Container pb="md" w="100%">
         <Stack>
           <Group spacing={4}>
             {!!relatedPosts?.items.length && (
@@ -211,17 +206,17 @@ export function ResourceReviewDetail({ reviewId }: { reviewId: number }) {
   );
 }
 
-function EditableRating({ id, rating }: { id: number; rating: number }) {
-  const { mutate, isLoading } = trpc.resourceReview.update.useMutation();
-  return (
-    <Rating
-      value={rating}
-      onChange={(value) => mutate({ id, rating: value })}
-      readOnly={isLoading}
-    />
-  );
-}
+// function EditableRating({ id, rating }: { id: number; rating: number }) {
+//   const { mutate, isLoading } = trpc.resourceReview.update.useMutation();
+//   return (
+//     <Rating
+//       value={rating}
+//       onChange={(value) => mutate({ id, rating: value })}
+//       readOnly={isLoading}
+//     />
+//   );
+// }
 
-function EditableDetails({ id, details }: { id: number; details?: string }) {
-  return <></>;
-}
+// function EditableDetails({ id, details }: { id: number; details?: string }) {
+//   return <></>;
+// }

--- a/src/components/ResourceReview/ResourceReviewModal.tsx
+++ b/src/components/ResourceReview/ResourceReviewModal.tsx
@@ -1,14 +1,12 @@
-import { Modal, Box } from '@mantine/core';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { ResourceReviewDetail } from '~/components/ResourceReview/ResourceReviewDetail';
+import { PageModal } from '../Dialog/Templates/PageModal';
 
 export default function ResourceReviewModal({ reviewId }: { reviewId: number }) {
   const dialog = useDialogContext();
   return (
-    <Modal {...dialog} withCloseButton={false} size={960} padding={0}>
-      <Box pt="xs" pb="xl">
-        <ResourceReviewDetail reviewId={reviewId} />
-      </Box>
-    </Modal>
+    <PageModal {...dialog} withCloseButton={false} fullScreen size={960} padding={0}>
+      <ResourceReviewDetail reviewId={reviewId} />
+    </PageModal>
   );
 }


### PR DESCRIPTION
* Made the ResourceReviewModal full screen
* Now it fits within the bounds of the main container, allowing the gen panel to be open right beside it

![image](https://github.com/civitai/civitai/assets/12631159/80e51a17-3573-4857-a20f-b7eb4587dd85)
