### PR TITLE
Use irr.imageId as the cursor

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -668,7 +668,7 @@ export const getAllImages = async ({
       if (!isGallery) AND.push(Prisma.sql`im."tippedAmountCount" > 0`);
     } else if (sort === ImageSort.Random) orderBy = 'ct."randomId" DESC';
     else {
-      if (from.indexOf(`irr`)) {
+      if (from.indexOf(`irr`) !== -1) {
         // Ensure to sort by irr.imageId when reading from imageResources to maximize index utilization
         orderBy = `irr."imageId" DESC`;
       } else {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -667,7 +667,14 @@ export const getAllImages = async ({
       orderBy = `im."tippedAmountCount" DESC, im."reactionCount" DESC, im."imageId"`;
       if (!isGallery) AND.push(Prisma.sql`im."tippedAmountCount" > 0`);
     } else if (sort === ImageSort.Random) orderBy = 'ct."randomId" DESC';
-    else orderBy = `i."id" DESC`;
+    else {
+      if (from.indexOf(`irr`)) {
+        // Ensure to sort by irr.imageId when reading from imageResources to maximize index utilization
+        orderBy = `irr."imageId" DESC`;
+      } else {
+        orderBy = `i."id" DESC`;
+      }
+    }
   }
 
   if (hidden) {


### PR DESCRIPTION
using irr.imageId enables pg to effectively use the ImageResource_modelVersionId_imageId index 