### PR TITLE
Add support for temporary orchestration

### DIFF
--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -224,6 +224,7 @@ export default function TrainingSelectFile({
     moveAssetMutation.mutate(
       {
         url: fileUrl,
+        modelVersionId: modelVersion.id,
         modelId: model.id,
       },
       {

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -103,6 +103,17 @@ export const serverSchema = z.object({
   EXTERNAL_MODERATION_ENDPOINT: z.string().url().optional(),
   EXTERNAL_MODERATION_TOKEN: z.string().optional(),
   EXTERNAL_MODERATION_CATEGORIES: commaDelimitedStringObject().optional(),
+  ALT_ORCHESTRATION_ENDPOINT: z.string().url().optional(),
+  ALT_ORCHESTRATION_TOKEN: z.string().optional(),
+  ALT_ORCHESTRATION_TIMEFRAME: z.preprocess((value) => {
+    if (typeof value !== 'string') return null;
+
+    const [start, end] = value.split(',').map((x) => new Date(x))
+    return { start, end };
+  }, z.object({
+    start: z.date().optional(),
+    end: z.date().optional()
+  })).optional(),
 });
 
 /**

--- a/src/server/jobs/handle-long-trainings.ts
+++ b/src/server/jobs/handle-long-trainings.ts
@@ -1,11 +1,12 @@
 import { TrainingStatus } from '@prisma/client';
 import { isEmpty } from 'lodash-es';
+import { env } from '~/env/server.mjs';
 import { dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { refundTransaction } from '~/server/services/buzz.service';
 import { createTrainingRequest } from '~/server/services/training.service';
 import { withRetries } from '~/server/utils/errorHandling';
-import orchestratorCaller from '../http/orchestrator/orchestrator.caller';
+import { getOrchestratorCaller } from '../http/orchestrator/orchestrator.caller';
 import { createJob, getJobDate } from './job';
 
 const SUBMITTED_CHECK_INTERVAL = 10;
@@ -24,13 +25,13 @@ type JobStatus =
     };
 const failedState: JobStatus = { status: 'Failed' };
 
-async function getJobStatus(jobId: string, log: (message: string) => void) {
+async function getJobStatus(jobId: string, submittedAt: Date, log: (message: string) => void) {
   function fail(message: string) {
     log(message);
     return failedState;
   }
 
-  const eventResp = await orchestratorCaller.getEventById({
+  const eventResp = await getOrchestratorCaller(submittedAt).getEventById({
     id: jobId,
     descending: true,
     take: 1,
@@ -47,19 +48,20 @@ async function getJobStatus(jobId: string, log: (message: string) => void) {
   return { status, date: new Date(date) } as JobStatus;
 }
 
-const handleJob = async (
-  modelFileId: number,
-  modelVersionId: number,
-  trainingStatus: TrainingStatus,
-  jobId: string | null,
-  transactionId: string | null
-) => {
+async function handleJob({
+  modelFileId,
+  modelVersionId,
+  status,
+  jobId,
+  transactionId,
+  submittedAt,
+}: TrainingRunResult) {
   if (!jobId) {
     log(`No job ID`);
     return await requeueTraining();
   }
 
-  const job = await getJobStatus(jobId, log);
+  const job = await getJobStatus(jobId, submittedAt, log);
   if (job.status === 'Succeeded') {
     // Ensure we have our epochs...
     const ready = await hasEpochs();
@@ -90,10 +92,10 @@ const handleJob = async (
     }
   }
 
-  if (trainingStatus === 'Submitted') {
+  if (status === 'Submitted') {
     // - if it's not in the queue after 10 minutes, resubmit it
     if (minsDiff > SUBMITTED_CHECK_INTERVAL) {
-      const queueResponse = await orchestratorCaller.getJobById({ id: jobId });
+      const queueResponse = await getOrchestratorCaller(submittedAt).getJobById({ id: jobId });
       // If we found it in the queue, we're good
       if (
         queueResponse.ok &&
@@ -109,7 +111,7 @@ const handleJob = async (
     }
   }
 
-  if (trainingStatus === 'Processing') {
+  if (status === 'Processing') {
     // - if it hasn't gotten an update in 20 minutes, mark failed
     if (minsDiff > PROCESSING_CHECK_INTERVAL) {
       await updateStatus('Failed');
@@ -180,35 +182,40 @@ const handleJob = async (
   }
 
   //#endregion
-};
+}
 
 type TrainingRunResult = {
-  mf_id: number;
-  mv_id: number;
+  modelFileId: number;
+  modelVersionId: number;
   updated: string;
   status: TrainingStatus;
-  job_id: string | null;
-  transaction_id: string | null;
+  jobId: string | null;
+  transactionId: string | null;
+  submittedAt: Date;
 };
 
 export const handleLongTrainings = createJob('handle-long-trainings', `*/10 * * * *`, async () => {
   const [lastRun, setLastRun] = await getJobDate('handle-long-trainings');
   const oldTraining = await dbWrite.$queryRaw<TrainingRunResult[]>`
-    SELECT "ModelFile".id                  as                                                   mf_id,
-           "ModelVersion".id               as                                                   mv_id,
-           "ModelVersion"."trainingStatus" as                                                   status,
-           COALESCE("ModelFile"."metadata" -> 'trainingResults' ->> 'jobId',
-                    "ModelFile"."metadata" -> 'trainingResults' -> 'history' -> -1 ->> 'jobId') job_id,
-           "ModelFile"."metadata" -> 'trainingResults' ->> 'transactionId'                      transaction_id
-    FROM "ModelVersion"
-           JOIN "ModelFile" ON "ModelVersion".id = "ModelFile"."modelVersionId"
-           JOIN "Model" ON "Model".id = "ModelVersion"."modelId"
-    WHERE "ModelFile".type = 'Training Data'
-      AND "Model"."uploadType" = 'Trained'
-      AND "ModelVersion"."trainingStatus" in ('Processing', 'Submitted')
+    SELECT mf.id as "modelFileId",
+           mv.id as "modelVersionId",
+           mv."trainingStatus" as status,
+           COALESCE(mf."metadata" -> 'trainingResults' ->> 'jobId',
+                    mf."metadata" -> 'trainingResults' -> 'history' -> -1 ->> 'jobId') "jobId",
+           mf."metadata" -> 'trainingResults' ->> 'transactionId' "transactionId",
+           COALESCE(COALESCE(mf."metadata" -> 'trainingResults' ->> 'submittedAt',
+		                mf."metadata" -> 'trainingResults' -> 'history' -> 0 ->> 'time')::timestamp,
+		        mv."updatedAt"
+	        ) "submittedAt"
+    FROM "ModelVersion" mv
+    JOIN "ModelFile" mf ON mv.id = mf."modelVersionId"
+    JOIN "Model" m ON m.id = mv."modelId"
+    WHERE mf.type = 'Training Data'
+      AND m."uploadType" = 'Trained'
+      AND mv."trainingStatus" in ('Processing', 'Submitted')
       -- Hasn't had a recent update
-      AND "ModelVersion"."updatedAt" between '10/16/2023' and ${lastRun}
-    --  AND (("ModelFile".metadata -> 'trainingResults' -> 'start_time')::TEXT)::TIMESTAMP < (now() - interval '24 hours')
+      AND mv."updatedAt" between '10/16/2023' and ${lastRun}
+    --  AND ((mf.metadata -> 'trainingResults' -> 'start_time')::TEXT)::TIMESTAMP < (now() - interval '24 hours')
     ORDER BY mf_id desc;
   `;
 
@@ -228,9 +235,9 @@ export const handleLongTrainings = createJob('handle-long-trainings', `*/10 * * 
   });
 
   let successes = 0;
-  for (const { mf_id, mv_id, status, job_id, transaction_id } of oldTraining) {
+  for (const training of oldTraining) {
     try {
-      const success = await handleJob(mf_id, mv_id, status, job_id, transaction_id);
+      const success = await handleJob(training);
       if (success === true) successes += 1;
     } catch (e) {
       logJob({
@@ -238,8 +245,8 @@ export const handleLongTrainings = createJob('handle-long-trainings', `*/10 * * 
         data: {
           error: (e as Error)?.message,
           cause: (e as Error)?.cause,
-          jobId: job_id,
-          modelFileId: mf_id,
+          jobId: training.jobId,
+          modelFileId: training.modelFileId,
           important: true,
         },
       });

--- a/src/server/routers/training.router.ts
+++ b/src/server/routers/training.router.ts
@@ -18,6 +18,6 @@ export const trainingRouter = router({
   moveAsset: protectedProcedure
     .input(moveAssetInput)
     .use(isFlagProtected('imageTraining'))
-    .mutation(({ input }) => moveAsset(input)),
+    .mutation(({ input, ctx }) => moveAsset({ ...input, userId: ctx.user.id })),
   getModelBasic: publicProcedure.input(getByIdSchema).query(getModelData),
 });

--- a/src/server/schema/model-file.schema.ts
+++ b/src/server/schema/model-file.schema.ts
@@ -5,6 +5,7 @@ import { constants } from '~/server/common/constants';
 export type TrainingResults = z.infer<typeof trainingResultsSchema>;
 export const trainingResultsSchema = z.object({
   start_time: z.string().nullish(),
+  submittedAt: z.string().nullish(),
   end_time: z.string().nullish(),
   attempts: z.number().nullish(),
   jobId: z.string().nullish(),

--- a/src/server/schema/training.schema.ts
+++ b/src/server/schema/training.schema.ts
@@ -8,5 +8,6 @@ export const createTrainingRequestSchema = z.object({
 export type MoveAssetInput = z.infer<typeof moveAssetInput>;
 export const moveAssetInput = z.object({
   url: z.string().url(),
+  modelVersionId: z.number().positive(),
   modelId: z.number().positive(),
 });


### PR DESCRIPTION
You will need to add the following ENV to be able to utilize the temporary alternate orchestration.

```
ALT_ORCHESTRATION_TIMEFRAME=2024-01-01T00:00:00.000Z,2024-01-07T00:00:00.000Z
ALT_ORCHESTRATION_ENDPOINT
ALT_ORCHESTRATION_TOKEN
```

Orchestration for training submitted during the timeframe will go to the alternate endpoint utilizing the alternate token. 