### PR TITLE
Hide private resources from public feeds

### DIFF
--- a/src/components/Article/ArticleUpsertForm.tsx
+++ b/src/components/Article/ArticleUpsertForm.tsx
@@ -93,7 +93,6 @@ export function ArticleUpsertForm({ article }: Props) {
     tags: article?.tags.filter((tag) => !tag.isCategory) ?? [],
     cover: article?.cover ? { url: article.cover ?? '' } : { url: '' },
     clubs: article?.clubs ?? [],
-    unlisted: article?.unlisted ?? false,
   };
   const form = useForm({ schema, defaultValues, shouldUnregister: false });
   const clearStorage = useFormStorage({
@@ -101,18 +100,16 @@ export function ArticleUpsertForm({ article }: Props) {
     form,
     timeout: 1000,
     key: `article${article?.id ? `_${article?.id}` : 'new'}`,
-    watch: ({ content, cover, categoryId, nsfw, tags, title, unlisted }) => ({
+    watch: ({ content, cover, categoryId, nsfw, tags, title }) => ({
       content,
       cover,
       categoryId,
       nsfw,
       tags,
       title,
-      unlisted,
     }),
   });
 
-  const [unlisted] = form.watch(['unlisted']);
   const [publishing, setPublishing] = useState(false);
 
   const { data, isLoading: loadingCategories } = trpc.tag.getAll.useQuery({
@@ -227,26 +224,6 @@ export function ArticleUpsertForm({ article }: Props) {
                 </Group>
               }
             />
-            {features.clubs && hasClubs && (
-              <>
-                <Checkbox
-                  checked={!unlisted}
-                  onChange={() => {
-                    form.setValue('unlisted', !unlisted);
-                  }}
-                  label={
-                    <Stack>
-                      <Text>Visible to everyone</Text>
-                    </Stack>
-                  }
-                />
-                <Text size="xs">
-                  By marking this visible to everyone, a preview of this article will be displayed
-                  in the article feed for other users. If you want this article to only be visible
-                  to club members, uncheck this.
-                </Text>
-              </>
-            )}
             <InputSimpleImageUpload name="cover" label="Cover Image" withAsterisk />
             <InputSelect
               name="categoryId"

--- a/src/components/Post/Edit/EditPostClubs.tsx
+++ b/src/components/Post/Edit/EditPostClubs.tsx
@@ -36,7 +36,7 @@ export function EditPostClubs() {
 
   return (
     <Stack mt="lg">
-      <ManagePostUnlistedStatus />
+      {/* <ManagePostUnlistedStatus /> */}
       <Text size="sm" tt="uppercase" weight="bold">
         Make this resource part of a club
       </Text>

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -130,6 +130,11 @@ export const getArticles = async ({
       !!username &&
       postgresSlugify(sessionUser.username) === postgresSlugify(username);
 
+    // TODO.clubs: This is temporary until we are fine with displaying club stuff in public feeds.
+    // At that point, we should be relying more on unlisted status which is set by the owner.
+    const hidePrivateArticles =
+      !clubId && !username && !collectionId && !followed && !hidden && !favorites && !userIds;
+
     const AND: Prisma.Sql[] = [];
     const WITH: Prisma.Sql[] = [];
 
@@ -411,6 +416,9 @@ export const getArticles = async ({
 
     const items = articles
       .filter((a) => {
+        // This take prio over mod status just so mods can see the same as users.
+        if (hidePrivateArticles && a.availability === Availability.Private) return false;
+
         if (sessionUser?.isModerator || a.userId === sessionUser?.id) return true;
 
         // Hide posts where the user does not have permission.

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -153,7 +153,6 @@ export const getModelsRaw = async ({
   input,
   user: sessionUser,
   count,
-  ignoreListedStatus,
 }: {
   input: Omit<GetAllModelsOutput, 'limit' | 'page'> & {
     take?: number;
@@ -162,7 +161,6 @@ export const getModelsRaw = async ({
   // TODO: Likely we wanna remove session user all in all.
   user?: { id: number; isModerator?: boolean; username?: string };
   count?: boolean;
-  ignoreListedStatus?: boolean;
 }) => {
   const {
     user,
@@ -200,6 +198,10 @@ export const getModelsRaw = async ({
   let isPrivate = false;
   const AND: Prisma.Sql[] = [];
   const WITH: Prisma.Sql[] = [];
+
+  // TODO.clubs: This is temporary until we are fine with displaying club stuff in public feeds.
+  // At that point, we should be relying more on unlisted status which is set by the owner.
+  const hidePrivateModels = !clubId && !username && !user && !followed && !collectionId;
 
   if (query) {
     const lowerQuery = query?.toLowerCase();
@@ -474,17 +476,6 @@ export const getModelsRaw = async ({
     )`);
   }
 
-  if (!ignoreListedStatus) {
-    AND.push(
-      Prisma.sql`
-      (
-          m."unlisted" = false
-          ${Prisma.raw(sessionUser?.id ? `OR m."userId" = ${sessionUser?.id}` : '')}
-      )
-      `
-    );
-  }
-
   if (clubId) {
     WITH.push(Prisma.sql`
       "clubModels" AS (
@@ -514,18 +505,22 @@ export const getModelsRaw = async ({
     WHERE ${Prisma.join(AND, ' AND ')}
   `;
 
-  let modelVersionWhere: Prisma.Sql | undefined;
+  const modelVersionWhere: Prisma.Sql[] = [];
 
   if (!sessionUser?.isModerator || !status?.length) {
-    modelVersionWhere = Prisma.sql`mv."status" = ${ModelStatus.Published}::"ModelStatus"`;
+    modelVersionWhere.push(Prisma.sql`mv."status" = ${ModelStatus.Published}::"ModelStatus"`);
   }
 
   if (baseModels) {
-    modelVersionWhere = Prisma.sql`mv."baseModel" IN (${Prisma.join(baseModels, ',')})`;
+    modelVersionWhere.push(Prisma.sql`mv."baseModel" IN (${Prisma.join(baseModels, ',')})`);
   }
 
   if (!!modelVersionIds?.length) {
-    modelVersionWhere = Prisma.sql`mv."id" IN (${Prisma.join(modelVersionIds, ',')})`;
+    modelVersionWhere.push(Prisma.sql`mv."id" IN (${Prisma.join(modelVersionIds, ',')})`);
+  }
+
+  if (hidePrivateModels) {
+    modelVersionWhere.push(Prisma.sql`mv."availability" = 'Public'::"Availability"`);
   }
 
   const models = await dbRead.$queryRaw<(ModelRaw & { cursorId: string | bigint | null })[]>`
@@ -582,7 +577,11 @@ export const getModelsRaw = async ({
        FROM "ModelVersion" mv
 	     LEFT JOIN "GenerationCoverage" gc ON gc."modelVersionId" = mv."id"
 	     WHERE mv."modelId" = m."id"
-         ${modelVersionWhere ? Prisma.sql`AND ${modelVersionWhere}` : Prisma.sql``}
+         ${
+           modelVersionWhere.length > 0
+             ? Prisma.sql`AND ${Prisma.join(modelVersionWhere, ' AND ')}`
+             : Prisma.sql``
+         }
 		   ORDER BY mv."index" ASC LIMIT 1
       ) as "modelVersion",
 	    jsonb_build_object(
@@ -660,7 +659,6 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
   select,
   user: sessionUser,
   count = false,
-  ignoreListedStatus,
 }: {
   input: Omit<GetAllModelsOutput, 'limit' | 'page'> & {
     take?: number;
@@ -669,7 +667,6 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
   select: TSelect;
   user?: SessionUser;
   count?: boolean;
-  ignoreListedStatus?: boolean;
 }) => {
   const {
     take,
@@ -865,22 +862,6 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
           },
         },
       },
-    });
-  }
-
-  if (!ignoreListedStatus) {
-    // TODO: This might be more conditional than anything really.
-    AND.push({
-      OR: [
-        {
-          unlisted: false,
-        },
-        sessionUser
-          ? {
-              userId: sessionUser.id,
-            }
-          : undefined,
-      ].filter(isDefined),
     });
   }
 

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -100,7 +100,6 @@ export const getPostsInfinite = async ({
   browsingMode,
 }: Omit<PostsQueryInput, 'include'> & {
   user?: { id: number; isModerator?: boolean; username?: string };
-  ignoreListedStatus?: boolean;
   include?: string[];
 }) => {
   const AND = [Prisma.sql`1 = 1`];
@@ -122,6 +121,11 @@ export const getPostsInfinite = async ({
       cacheTags.push(`posts-user:${targetUser}`);
     }
   }
+
+  // TODO.clubs: This is temporary until we are fine with displaying club stuff in public feeds.
+  // At that point, we should be relying more on unlisted status which is set by the owner.
+  const hidePrivatePosts =
+    !clubId && !isOwnerRequest && !(!!user && followed) && !(collectionId && !!user?.id);
 
   // Filter only followed users
   if (!!user && followed) {
@@ -366,6 +370,11 @@ export const getPostsInfinite = async ({
     items: postsRaw
       // remove unlisted resources the user has no access to:
       .filter((p) => {
+        // Hide private posts from the main feed.
+        if (hidePrivatePosts && p.availability === Availability.Private) {
+          return false;
+        }
+
         // Allow mods and owners to view all.
         if (user?.isModerator || p.userId === user?.id) return true;
 


### PR DESCRIPTION
Basically removes the usage of unlisted and relies on the private/public status of resources. This will likely change in the future as clubs gain popularity and we wanna have their resources back in the feed, but to kick things off, we'll have them not display there.