### PR TITLE
Fix mobile hamburger menu

### DIFF
--- a/src/components/AppLayout/AppHeader.tsx
+++ b/src/components/AppLayout/AppHeader.tsx
@@ -22,7 +22,6 @@ import {
   UnstyledButton,
   useMantineColorScheme,
 } from '@mantine/core';
-import { useClickOutside, useDisclosure } from '@mantine/hooks';
 import { NextLink } from '@mantine/next';
 import { Currency } from '@prisma/client';
 import {
@@ -68,6 +67,7 @@ import {
 } from 'react';
 import { BrowsingModeIcon, BrowsingModeMenu } from '~/components/BrowsingMode/BrowsingMode';
 import { CivitaiLinkPopover } from '~/components/CivitaiLink/CivitaiLinkPopover';
+import { ContainerProvider } from '~/components/ContainerProvider/ContainerProvider';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { useHomeSelection } from '~/components/HomeContentToggle/FullHomeContentToggle';
 import { ListSearch } from '~/components/ListSearch/ListSearch';
@@ -82,15 +82,13 @@ import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { constants } from '~/server/common/constants';
 import { deleteCookies } from '~/utils/cookies-helpers';
 import { LoginRedirectReason } from '~/utils/login-helpers';
 import { AutocompleteSearch } from '../AutocompleteSearch/AutocompleteSearch';
 import { openBuyBuzzModal } from '../Modals/BuyBuzzModal';
-import { UserBuzz } from '../User/UserBuzz';
 import { GenerateButton } from '../RunStrategy/GenerateButton';
-import { constants } from '~/server/common/constants';
-import { EventButton } from '~/components/EventButton/EventButton';
-import { ContainerProvider } from '~/components/ContainerProvider/ContainerProvider';
+import { UserBuzz } from '../User/UserBuzz';
 
 const HEADER_HEIGHT = 70;
 
@@ -251,9 +249,9 @@ export function AppHeader({
   const features = useFeatureFlags();
   const isMobile = useIsMobile();
 
-  const [burgerOpened, { open: openBurger, close: closeBurger }] = useDisclosure(false);
+  const [burgerOpened, setBurgerOpened] = useState(false);
   const [userMenuOpened, setUserMenuOpened] = useState(false);
-  const ref = useClickOutside(() => closeBurger());
+  // const ref = useClickOutside(() => setBurgerOpened(false));
   const searchRef = useRef<HTMLInputElement>(null);
   const { url: homeUrl } = useHomeSelection();
 
@@ -498,6 +496,7 @@ export function AppHeader({
       features.alternateHome,
       features.bounties,
       features.buzz,
+      features.clubs,
       router.asPath,
       theme,
     ]
@@ -514,7 +513,7 @@ export function AppHeader({
               <Anchor
                 variant="text"
                 className={cx(classes.link, { [classes.linkActive]: router.asPath === link.href })}
-                onClick={() => closeBurger()}
+                onClick={() => setBurgerOpened(false)}
                 rel={link.rel}
               >
                 {link.label}
@@ -532,7 +531,7 @@ export function AppHeader({
             item
           );
         }),
-    [classes, closeBurger, cx, links, mainActions, router.asPath]
+    [classes, setBurgerOpened, cx, links, mainActions, router.asPath]
   );
   const userMenuItems = useMemo(
     () =>
@@ -559,9 +558,9 @@ export function AppHeader({
   const onSearchDone = () => setShowSearch(false);
 
   const handleCloseMenu = useCallback(() => {
-    closeBurger();
+    setBurgerOpened(false);
     setUserMenuOpened(false);
-  }, [closeBurger]);
+  }, [setBurgerOpened]);
 
   useEffect(() => {
     if (showSearch && searchRef.current) {
@@ -669,7 +668,7 @@ export function AppHeader({
         <Grid.Col span="auto" pl={0}>
           <Group spacing="xs" noWrap>
             <Link href={homeUrl ?? '/'} passHref>
-              <Anchor variant="text" onClick={() => closeBurger()}>
+              <Anchor variant="text" onClick={() => setBurgerOpened(false)}>
                 <Logo />
               </Anchor>
             </Link>
@@ -737,7 +736,7 @@ export function AppHeader({
           {features.enhancedSearch ? (
             <>{renderSearchComponent({ onSearchDone, isMobile: false })}</>
           ) : (
-            <ListSearch onSearch={() => closeBurger()} />
+            <ListSearch onSearch={() => setBurgerOpened(false)} />
           )}
         </Grid.Col>
         <Grid.Col span="auto" className={classes.links} sx={{ justifyContent: 'flex-end' }}>
@@ -845,7 +844,7 @@ export function AppHeader({
             {currentUser && <NotificationBell />}
             <Burger
               opened={burgerOpened}
-              onMouseDown={!burgerOpened ? openBurger : undefined}
+              onClick={() => setBurgerOpened(!burgerOpened)}
               size="sm"
             />
             <Transition transition="scale-y" duration={200} mounted={burgerOpened}>
@@ -857,7 +856,7 @@ export function AppHeader({
                     shadow="md"
                     style={{ ...styles, borderLeft: 0, borderRight: 0 }}
                     radius={0}
-                    ref={ref}
+                    // ref={ref}
                   >
                     {/* Calculate maxHeight based off total viewport height minus header + footer + static menu options inside dropdown sizes */}
                     <ScrollArea.Autosize maxHeight={'calc(100dvh - 269px)'}>
@@ -900,7 +899,11 @@ export function AppHeader({
                             </BlurToggle>
                           )}
                           <Link href="/user/account">
-                            <ActionIcon variant="default" size="lg" onClick={closeBurger}>
+                            <ActionIcon
+                              variant="default"
+                              size="lg"
+                              onClick={() => setBurgerOpened(false)}
+                            >
                               <IconSettings stroke={1.5} />
                             </ActionIcon>
                           </Link>


### PR DESCRIPTION
pretty sure mantine's `clickOutside` handler is not working as expected with v5. also swapped from their disclosure to a more simple state, and now the hamburger menu opens and closes properly.