### PR TITLE
Skips batching for showcase items

### DIFF
--- a/src/components/Modals/StripeTransactionModal.tsx
+++ b/src/components/Modals/StripeTransactionModal.tsx
@@ -224,28 +224,25 @@ const { openModal, Modal } = createContextModal<Props>({
 
     const { isLoading: isLoadingPaymentMethods } = useUserPaymentMethods();
 
-    const {
-      data,
-      isLoading,
-      error,
-      mutate: getPaymentIntentMutation,
-    } = trpc.stripe.getPaymentIntent.useMutation();
+    const { data, isLoading, isFetching, error } = trpc.stripe.getPaymentIntent.useQuery(
+      {
+        unitAmount,
+        currency,
+        metadata,
+        paymentMethodTypes,
+        recaptchaToken: recaptchaToken as string,
+      },
+      {
+        enabled: !!unitAmount && !!currency && !!recaptchaToken,
+        refetchOnMount: 'always',
+        cacheTime: 0,
+        trpc: { context: { skipBatch: true } },
+      }
+    );
 
     const clientSecret = data?.clientSecret;
 
-    useEffect(() => {
-      if (!!unitAmount && !!currency && !!recaptchaToken && !isLoading && !data) {
-        getPaymentIntentMutation({
-          unitAmount,
-          currency,
-          metadata,
-          paymentMethodTypes,
-          recaptchaToken: recaptchaToken as string,
-        });
-      }
-    }, [unitAmount, currency, recaptchaToken, isLoading, data]);
-
-    if (isLoading || isLoadingPaymentMethods || isLoadingRecaptcha) {
+    if (isLoading || isFetching || isLoadingPaymentMethods || isLoadingRecaptcha) {
       return (
         <Center>
           <Loader variant="bars" />

--- a/src/components/Profile/Sections/ShowcaseSection.tsx
+++ b/src/components/Profile/Sections/ShowcaseSection.tsx
@@ -33,6 +33,7 @@ export const ShowcaseSection = ({ user }: ProfileSectionProps) => {
     {
       enabled: showcaseItems.length > 0 && inView,
       keepPreviousData: true,
+      trpc: { context: { skipBatch: true } },
     }
   );
   const {

--- a/src/components/Profile/ShowcaseItemsInput.tsx
+++ b/src/components/Profile/ShowcaseItemsInput.tsx
@@ -96,6 +96,7 @@ export const ShowcaseItemsInput = ({
     {
       enabled: sortedShowcaseItems.length > 0,
       keepPreviousData: true,
+      trpc: { context: { skipBatch: true } },
     }
   );
 

--- a/src/components/Stripe/StripePaymentMethodSetup.tsx
+++ b/src/components/Stripe/StripePaymentMethodSetup.tsx
@@ -18,7 +18,7 @@ export const StripePaymentMethodSetup = ({ paymentMethodTypes, ...props }: Props
 
   const { data, isLoading, isFetching } = trpc.stripe.getSetupIntent.useQuery(
     { paymentMethodTypes },
-    { refetchOnMount: 'always', cacheTime: 0 }
+    { refetchOnMount: 'always', cacheTime: 0, trpc: { context: { skipBatch: true } } }
   );
 
   const clientSecret = data?.clientSecret;

--- a/src/server/routers/stripe.router.ts
+++ b/src/server/routers/stripe.router.ts
@@ -34,7 +34,7 @@ export const stripeRouter = router({
     .mutation(createBuzzSessionHandler),
   getPaymentIntent: protectedProcedure
     .input(Schema.paymentIntentCreationSchema)
-    .mutation(getPaymentIntentHandler),
+    .query(getPaymentIntentHandler),
   getSetupIntent: protectedProcedure
     .input(Schema.setupIntentCreateSchema)
     .query(getSetupIntentHandler),


### PR DESCRIPTION
Also brings back using `useQuery` for getPaymentIntent. Works fine so long as we skip batching.