### PR TITLE
Pass found models version to the user history

### DIFF
--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -657,7 +657,7 @@ export const getDownloadCommandHandler = async ({
       await dbWrite.$executeRaw`
         -- Update user history
         INSERT INTO "DownloadHistory" ("userId", "modelVersionId", "downloadAt", hidden)
-        VALUES (${userId}, ${modelVersionId}, ${now}, false)
+        VALUES (${userId}, ${modelVersion.id}, ${now}, false)
         ON CONFLICT ("userId", "modelVersionId") DO UPDATE SET "downloadAt" = excluded."downloadAt"
       `;
     }


### PR DESCRIPTION
Many of the model cards do not pass the model version when clicking the Download via Link button. As a result when we try to add it to the users download history it will fail because its undefined. However we do this so we can get the latest model when we do findFirst. This will use the found models version no matter what.

Alternatively we could always pass version so its the latest and greatest but that is basically achieved here. The only page that passes model version is the model page itself. Not sure if we have anything there that also allows downloading historical versions or not.