### PR TITLE
Migrate metric update queue to Redis

### DIFF
--- a/prisma/migrations/20240220204643_resource_review_recommended_system/migration.sql
+++ b/prisma/migrations/20240220204643_resource_review_recommended_system/migration.sql
@@ -10,9 +10,10 @@ ADD COLUMN     "thumbsUpCount" INTEGER NOT NULL DEFAULT 0;
 
 -- Update Resource Reviews
 ALTER TABLE "ResourceReview" ADD COLUMN     "recommended" BOOLEAN NOT NULL DEFAULT true;
-UPDATE "ResourceReview" SET "recommended" = false WHERE rating < 3;
+-- UPDATE "ResourceReview" SET "recommended" = false WHERE rating < 3;
 
 -- Update metrics
+/*
 INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "thumbsUpCount", "thumbsDownCount")
 SELECT
   mv.id,
@@ -53,8 +54,10 @@ JOIN "ModelVersion" mv ON rr."modelVersionId" = mv."id" -- confirm that model ve
 CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
 GROUP BY mv.id, tf.timeframe
 ON CONFLICT ("modelVersionId", timeframe) DO UPDATE SET "thumbsUpCount" = EXCLUDED."thumbsUpCount", "thumbsDownCount" = EXCLUDED."thumbsDownCount", "updatedAt" = now();
+*/
 
 -- Add missing model metrics
+ALTER TABLE "ModelMetric" ADD COLUMN "updatedAt" TIMESTAMP DEFAULT now();
 INSERT INTO "ModelMetric" ("modelId", timeframe, "updatedAt")
 SELECT
   id,

--- a/prisma/migrations/20240313071941_metric_updated_at/migration.sql
+++ b/prisma/migrations/20240313071941_metric_updated_at/migration.sql
@@ -1,0 +1,32 @@
+-- AlterTable
+ALTER TABLE "ArticleMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "BountyEntryMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "BountyMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "CollectionMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "ImageMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "PostMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "TagMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "UserMetric" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- DropTable
+DROP TABLE "MetricUpdateQueue";
+
+-- DropTable
+DROP TABLE "SearchIndexUpdateQueue";
+
+-- DropEnum
+DROP TYPE "SearchIndexUpdateQueueAction";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -345,6 +345,7 @@ model UserMetric {
   reviewCount       Int             @default(0)
   answerCount       Int             @default(0)
   answerAcceptCount Int             @default(0)
+  updatedAt         DateTime        @default(now())
 
   @@id([userId, timeframe])
 }
@@ -767,6 +768,7 @@ model ModelMetric {
   generationCount   Int             @default(0)
   thumbsUpCount     Int             @default(0)
   thumbsDownCount   Int             @default(0)
+  updatedAt         DateTime        @default(now())
 
   @@id([modelId, timeframe])
 }
@@ -787,6 +789,7 @@ model ModelVersionMetric {
   generationCount   Int             @default(0)
   thumbsUpCount     Int             @default(0)
   thumbsDownCount   Int             @default(0)
+  updatedAt         DateTime        @default(now())
 
   @@id([modelVersionId, timeframe])
 }
@@ -1111,6 +1114,7 @@ model PostMetric {
   heartCount     Int             @default(0)
   commentCount   Int             @default(0)
   collectedCount Int             @default(0)
+  updatedAt      DateTime        @default(now())
 
   @@id([postId, timeframe])
 }
@@ -1262,6 +1266,7 @@ model ImageMetric {
   tippedCount       Int             @default(0)
   tippedAmountCount Int             @default(0)
   viewCount         Int             @default(0)
+  updatedAt         DateTime        @default(now())
 
   @@id([imageId, timeframe])
 }
@@ -1273,6 +1278,7 @@ model CollectionMetric {
   followerCount    Int             @default(0)
   itemCount        Int             @default(0)
   contributorCount Int             @default(0)
+  updatedAt        DateTime        @default(now())
 
   @@id([collectionId, timeframe])
 }
@@ -1494,6 +1500,7 @@ model TagMetric {
   articleCount  Int             @default(0)
   hiddenCount   Int             @default(0)
   followerCount Int             @default(0)
+  updatedAt     DateTime        @default(now())
 
   @@id([tagId, timeframe])
 }
@@ -1720,14 +1727,6 @@ model AnswerVote {
   createdAt DateTime @default(now())
 
   @@id([answerId, userId])
-}
-
-model MetricUpdateQueue {
-  type      String
-  id        Int
-  createdAt DateTime @default(now())
-
-  @@id([type, id])
 }
 
 model AnswerMetric {
@@ -2042,6 +2041,7 @@ model ArticleMetric {
   collectedCount    Int             @default(0)
   tippedCount       Int             @default(0)
   tippedAmountCount Int             @default(0)
+  updatedAt         DateTime        @default(now())
 
   @@id([articleId, timeframe])
 }
@@ -2424,6 +2424,7 @@ model BountyMetric {
   benefactorCount Int             @default(0)
   unitAmountCount Int             @default(0)
   commentCount    Int             @default(0)
+  updatedAt       DateTime        @default(now())
 
   @@id([bountyId, timeframe])
 }
@@ -2440,6 +2441,7 @@ model BountyEntryMetric {
   unitAmountCount   Int             @default(0)
   tippedCount       Int             @default(0)
   tippedAmountCount Int             @default(0)
+  updatedAt         DateTime        @default(now())
 
   @@id([bountyEntryId, timeframe])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2111,20 +2111,6 @@ model GenerationServiceProvider {
   @@id([name])
 }
 
-enum SearchIndexUpdateQueueAction {
-  Update
-  Delete
-}
-
-model SearchIndexUpdateQueue {
-  type      String
-  id        Int
-  createdAt DateTime                     @default(now())
-  action    SearchIndexUpdateQueueAction @default(Update)
-
-  @@id([type, id, action])
-}
-
 enum CollectionWriteConfiguration {
   Private
   Public

--- a/src/components/ImageGeneration/GenerationForm/generation.utils.ts
+++ b/src/components/ImageGeneration/GenerationForm/generation.utils.ts
@@ -184,7 +184,7 @@ export const getFormData = (
       // only use generationConfig for previous and new baseModels
       const config = Object.entries(generationConfig)
         .filter(([key]) => [baseModel, newBaseModel].includes(key as BaseModelSetType))
-        .map(([key, value]) => value);
+        .map(([, value]) => value);
 
       const shouldUpdate = !config.every(({ additionalResourceTypes }) => {
         return additionalResourceTypes.some(({ type, baseModelSet, baseModels }) => {
@@ -224,7 +224,7 @@ export const getFormData = (
       .filter((x) => x.modelType !== 'Checkpoint' && x.modelType !== 'VAE')
       .filter(resourceFilter);
   } else if (type === 'remix') {
-    formData.vae = resources.filter((x) => x.modelType === 'VAE')[0];
+    formData.vae = resources.find((x) => x.modelType === 'VAE') ?? formData.vae;
     formData.resources = resources
       .filter((x) => x.modelType !== 'Checkpoint' && x.modelType !== 'VAE')
       .filter(resourceFilter);
@@ -238,7 +238,9 @@ export const getFormData = (
         params?.baseModel
       );
     if (params.sampler)
-      formData.sampler = generation.samplers.includes(params.sampler as any)
+      formData.sampler = generation.samplers.includes(
+        params.sampler as (typeof generation.samplers)[number]
+      )
         ? params.sampler
         : undefined;
   }
@@ -258,7 +260,9 @@ export const getFormData = (
   }
 
   if (type !== 'remix') formData = removeEmpty(formData);
-  formData.resources = formData.resources?.length ? uniqBy(formData.resources, 'id') : undefined;
+  formData.resources = formData.resources?.length
+    ? uniqBy(formData.resources, 'id').slice(0, 9)
+    : undefined;
 
   return {
     ...formData,
@@ -280,14 +284,14 @@ export const getClosestAspectRatio = (width?: number, height?: number, baseModel
 export const getBaseModelSetKey = (baseModel?: string) => {
   if (!baseModel) return undefined;
   return Object.entries(baseModelSets).find(
-    ([key, baseModels]) => key === baseModel || baseModels.includes(baseModel as any)
+    ([key, baseModels]) => key === baseModel || baseModels.includes(baseModel as BaseModel)
   )?.[0] as BaseModelSetType | undefined;
 };
 
 export const getBaseModelSet = (baseModel?: string) => {
   if (!baseModel) return undefined;
   return Object.entries(baseModelSets).find(
-    ([key, set]) => key === baseModel || set.includes(baseModel as any)
+    ([key, set]) => key === baseModel || set.includes(baseModel as BaseModel)
   )?.[1];
 };
 

--- a/src/pages/api/admin/migrate-model-metrics.ts
+++ b/src/pages/api/admin/migrate-model-metrics.ts
@@ -202,7 +202,7 @@ function modelGenerationMetrics(ctx: MigrationContext) {
 
     console.log('Update model generation metrics ' + ctx.start + '-' + ctx.end);
     console.time('Fetch version generation metrics ' + ctx.start + '-' + ctx.end);
-    const metrics = await clickhouse.$query<GenerationMetrics>(`
+    const metrics = await clickhouse.$query<GenerationMetrics>`
       SELECT
           modelVersionId,
           sumIf(count, createdDate = current_date()) day,
@@ -213,7 +213,7 @@ function modelGenerationMetrics(ctx: MigrationContext) {
       FROM daily_resource_generation_counts
       WHERE modelVersionId IN (${versionIds.join(',')})
       GROUP BY modelVersionId
-    `);
+    `;
     const metricsJson = JSON.stringify(metrics);
     console.timeEnd('Fetch version generation metrics ' + ctx.start + '-' + ctx.end);
 

--- a/src/pages/api/mod/update-index.ts
+++ b/src/pages/api/mod/update-index.ts
@@ -1,7 +1,7 @@
-import { SearchIndexUpdateQueueAction } from '@prisma/client';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { MODELS_SEARCH_INDEX, USERS_SEARCH_INDEX } from '~/server/common/constants';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { inJobContext } from '~/server/jobs/job';
 import { modelsSearchIndex, usersSearchIndex } from '~/server/search-index';
 import { ModEndpoint } from '~/server/utils/endpoint-helpers';

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -1,14 +1,7 @@
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import * as z from 'zod';
 import { dbWrite } from '~/server/db/client';
-import {
-  ImageIngestionStatus,
-  Prisma,
-  SearchIndexUpdateQueueAction,
-  TagSource,
-  TagTarget,
-  TagType,
-} from '@prisma/client';
+import { ImageIngestionStatus, Prisma, TagSource, TagTarget, TagType } from '@prisma/client';
 import {
   auditMetaData,
   getTagsFromPrompt,
@@ -25,7 +18,7 @@ import { imagesSearchIndex } from '~/server/search-index';
 import { deleteUserProfilePictureCache } from '~/server/services/user.service';
 import { updateImageTagIdsForImages } from '~/server/services/image.service';
 import { signalClient } from '~/utils/signal-client';
-import { SignalMessages } from '~/server/common/enums';
+import { SignalMessages, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { scanJobsSchema } from '~/server/schema/image.schema';
 import { getTagRules } from '~/server/services/system-cache';
 import { uniqBy } from 'lodash-es';

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -208,3 +208,8 @@ export enum PurchasableRewardModeratorViewMode {
   History = 'History',
   Purchased = 'Purchased',
 }
+
+export enum SearchIndexUpdateQueueAction {
+  Update = 'Update',
+  Delete = 'Delete',
+}

--- a/src/server/controllers/common.controller.ts
+++ b/src/server/controllers/common.controller.ts
@@ -19,7 +19,8 @@ import {
   imagesSearchIndex,
   modelsSearchIndex,
 } from '../search-index';
-import { Availability, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Availability } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead } from '../db/client';
 
 export const getEntityAccessHandler = async ({

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -7,12 +7,11 @@ import {
   ModelType,
   ModelUploadType,
   Prisma,
-  SearchIndexUpdateQueueAction,
 } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { CommandResourcesAdd, ResourceType } from '~/components/CivitaiLink/shared-types';
 import { BaseModel, BaseModelType, ModelFileType, constants } from '~/server/common/constants';
-import { ModelSort } from '~/server/common/enums';
+import { ModelSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { Context } from '~/server/createContext';
 
 import { dbRead, dbWrite } from '~/server/db/client';

--- a/src/server/jobs/apply-voted-tags.ts
+++ b/src/server/jobs/apply-voted-tags.ts
@@ -2,7 +2,8 @@ import { createJob, getJobDate } from './job';
 import { dbWrite } from '~/server/db/client';
 import { constants } from '~/server/common/constants';
 import { imagesSearchIndex } from '~/server/search-index';
-import { Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { chunk, uniqBy } from 'lodash-es';
 import { updateImageTagIdsForImages } from '~/server/services/image.service';
 

--- a/src/server/jobs/update-metrics.ts
+++ b/src/server/jobs/update-metrics.ts
@@ -6,12 +6,16 @@ const metricSets = {
   users: [metrics.userMetrics],
   images: [metrics.imageMetrics],
   bounties: [metrics.bountyEntryMetrics, metrics.bountyMetrics],
-  clubs: [metrics.clubPostMetrics, metrics.clubMetrics],
+  clubs: [
+    // metrics.clubPostMetrics, metrics.clubMetrics // disable clubs
+  ],
   posts: [metrics.postMetrics],
   tags: [metrics.tagMetrics],
   collections: [metrics.collectionMetrics],
   articles: [metrics.articleMetrics],
-  other: [metrics.answerMetrics, metrics.questionMetrics],
+  other: [
+    // metrics.answerMetrics, metrics.questionMetrics // disable questions and answers
+  ],
 };
 
 export const metricJobs = Object.entries(metricSets).map(([name, metrics]) =>

--- a/src/server/metrics/answer.metrics.ts
+++ b/src/server/metrics/answer.metrics.ts
@@ -3,6 +3,9 @@ import { createMetricProcessor } from '~/server/metrics/base.metrics';
 export const answerMetrics = createMetricProcessor({
   name: 'Answer',
   async update({ db, lastUpdate }) {
+    return;
+    // Disabled for now
+
     await db.$executeRaw`
     WITH recent_engagements AS
     (

--- a/src/server/metrics/article.metrics.ts
+++ b/src/server/metrics/article.metrics.ts
@@ -1,6 +1,7 @@
 import { chunk } from 'lodash-es';
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { articlesSearchIndex } from '~/server/search-index';
 
 export const articleMetrics = createMetricProcessor({
@@ -358,7 +359,7 @@ export const articleMetrics = createMetricProcessor({
           SUM(IIF(aci."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_collected_count,
           SUM(IIF(aci."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_collected_count,
           SUM(IIF(aci."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_collected_count
-        FROM "CollectionItem" aci 
+        FROM "CollectionItem" aci
         JOIN "Collection" c ON aci."collectionId" = c."id" AND c."mode" IS NULL AND c."type" = 'Article'
         WHERE aci."articleId" IS NOT NULL
         GROUP BY aci."articleId"

--- a/src/server/metrics/article.metrics.ts
+++ b/src/server/metrics/article.metrics.ts
@@ -1,414 +1,46 @@
 import { chunk } from 'lodash-es';
-import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma } from '@prisma/client';
+import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { articlesSearchIndex } from '~/server/search-index';
+import { createLogger } from '~/utils/logging';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { executeRefresh, getAffected, snippets } from '~/server/metrics/metric-helpers';
+import dayjs from 'dayjs';
+
+const log = createLogger('metrics:article');
 
 export const articleMetrics = createMetricProcessor({
   name: 'Article',
-  async update({ db, ch, lastUpdate }) {
-    const affectedArticlesResponse = await ch.query({
-      query: `
-      SELECT DISTINCT entityId AS entityId
-      FROM views
-      WHERE type = 'ArticleView' AND time >= parseDateTimeBestEffortOrNull('${lastUpdate.toISOString()}')
-      `,
-      format: 'JSONEachRow',
-    });
-    const affectedArticles = (
-      (await affectedArticlesResponse?.json()) as { entityId: number }[]
-    ).map((x) => x.entityId);
+  async update(ctx) {
+    // Get the metric tasks
+    //---------------------------------------
+    const taskBatches = await Promise.all([
+      getReactionTasks(ctx),
+      getCommentTasks(ctx),
+      getCollectionTasks(ctx),
+      getBuzzTasks(ctx),
+      getEngagementTasks(ctx),
+      getViewTasks(ctx),
+    ]);
+    log('articleMetrics update', taskBatches.flat().length, 'tasks');
+    for (const tasks of taskBatches) await limitConcurrency(tasks, 5);
 
-    const batches = chunk(affectedArticles, 5000);
-    for (const batch of batches) {
-      try {
-        const viewedArticlesResponse = await ch.query({
-          query: `
-          SELECT
-            entityId,
-            SUM(if(uv.time >= subtractDays(now(), 1), 1, null)) AS viewsDay,
-            SUM(if(uv.time >= subtractDays(now(), 7), 1, null)) AS viewsWeek,
-            SUM(if(uv.time >= subtractMonths(now(), 1), 1, null)) AS viewsMonth,
-            SUM(if(uv.time >= subtractYears(now(), 1), 1, null)) AS viewsYear,
-            COUNT() AS viewsAll
-          FROM uniqueViews uv
-          WHERE type = 'ArticleView' AND entityId IN (${batch.join(',')})
-          GROUP BY entityId
-          `,
-          format: 'JSONEachRow',
-        });
-
-        const viewedArticles = (await viewedArticlesResponse?.json()) as ArticleViews[];
-        // We batch the affected articles up when sending it to the db
-        const batches = chunk(viewedArticles, 1000);
-        for (const batch of batches) {
-          const batchJson = JSON.stringify(batch);
-
-          await db.$executeRaw`
-            INSERT INTO "ArticleMetric" ("articleId", timeframe, "viewCount")
-            SELECT
-                a.entityId, a.timeframe, a.views
-            FROM
-            (
-                SELECT
-                    CAST(js::json->>'entityId' AS INT) AS entityId,
-                    tf.timeframe,
-                    CAST(
-                      CASE
-                        WHEN tf.timeframe = 'Day' THEN js::json->>'viewsDay'
-                        WHEN tf.timeframe = 'Week' THEN js::json->>'viewsWeek'
-                        WHEN tf.timeframe = 'Month' THEN js::json->>'viewsMonth'
-                        WHEN tf.timeframe = 'Year' THEN js::json->>'viewsYear'
-                        WHEN tf.timeframe = 'AllTime' THEN js::json->>'viewsAll'
-                      END
-                    AS int) as views
-                FROM json_array_elements(${batchJson}::json) js
-                CROSS JOIN (
-                    SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-                ) tf
-            ) a
-            WHERE
-              a.views IS NOT NULL
-              AND a.entityId IN (SELECT id FROM "Article")
-            ON CONFLICT ("articleId", timeframe) DO UPDATE
-              SET "viewCount" = EXCLUDED."viewCount";
-          `;
-        }
-      } catch (e) {
-        throw e;
-      }
-    }
-
-    // --------------------------------------------
-    // Update Other Metrics from DB
-    // --------------------------------------------
-
-    const recentEngagementSubquery = Prisma.sql`
-    WITH recent_engagements AS
-    (
-      SELECT
-        "articleId" AS id
-      FROM "ArticleReaction"
-      WHERE "createdAt" > ${lastUpdate}
-
-      UNION
-
-      SELECT t."articleId" as id
-      FROM "Thread" t
-      JOIN "CommentV2" c ON c."threadId" = t.id
-      WHERE t."articleId" IS NOT NULL AND c."createdAt" > ${lastUpdate}
-
-      UNION
-
-      SELECT
-        "articleId"
-      FROM "ArticleEngagement"
-      WHERE "createdAt" > ${lastUpdate}
-
-      UNION
-
-      SELECT ci."articleId" as id
-      FROM "CollectionItem" ci
-      WHERE ci."articleId" IS NOT NULL AND ci."createdAt" > ${lastUpdate}
-
-      UNION
-
-      SELECT bt."entityId" as id
-      FROM "BuzzTip" bt
-      WHERE bt."entityId" IS NOT NULL AND bt."entityType" = 'Article'
-        AND (bt."createdAt" > ${lastUpdate} OR bt."updatedAt" > ${lastUpdate})
-
-      UNION
-
-      SELECT
-        "id"
-      FROM "MetricUpdateQueue"
-      WHERE type = 'Article'
-    )
-    `;
-
-    await db.$executeRaw`
-    ${recentEngagementSubquery},
-    -- Get all affected
-    affected AS
-    (
-        SELECT DISTINCT
-            r.id
-        FROM recent_engagements r
-        JOIN "Article" a ON a.id = r.id
-        WHERE r.id IS NOT NULL
-    )
-    -- upsert metrics for all affected
-    -- perform a one-pass table scan producing all metrics for all affected
-    INSERT INTO "ArticleMetric" ("articleId", timeframe, "likeCount", "dislikeCount", "heartCount", "laughCount", "cryCount", "commentCount", "favoriteCount", "hideCount", "collectedCount", "tippedCount", "tippedAmountCount")
-    SELECT
-      m.id,
-      tf.timeframe,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN like_count
-        WHEN tf.timeframe = 'Year' THEN year_like_count
-        WHEN tf.timeframe = 'Month' THEN month_like_count
-        WHEN tf.timeframe = 'Week' THEN week_like_count
-        WHEN tf.timeframe = 'Day' THEN day_like_count
-      END AS like_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN dislike_count
-        WHEN tf.timeframe = 'Year' THEN year_dislike_count
-        WHEN tf.timeframe = 'Month' THEN month_dislike_count
-        WHEN tf.timeframe = 'Week' THEN week_dislike_count
-        WHEN tf.timeframe = 'Day' THEN day_dislike_count
-      END AS dislike_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN heart_count
-        WHEN tf.timeframe = 'Year' THEN year_heart_count
-        WHEN tf.timeframe = 'Month' THEN month_heart_count
-        WHEN tf.timeframe = 'Week' THEN week_heart_count
-        WHEN tf.timeframe = 'Day' THEN day_heart_count
-      END AS heart_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN laugh_count
-        WHEN tf.timeframe = 'Year' THEN year_laugh_count
-        WHEN tf.timeframe = 'Month' THEN month_laugh_count
-        WHEN tf.timeframe = 'Week' THEN week_laugh_count
-        WHEN tf.timeframe = 'Day' THEN day_laugh_count
-      END AS laugh_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN cry_count
-        WHEN tf.timeframe = 'Year' THEN year_cry_count
-        WHEN tf.timeframe = 'Month' THEN month_cry_count
-        WHEN tf.timeframe = 'Week' THEN week_cry_count
-        WHEN tf.timeframe = 'Day' THEN day_cry_count
-      END AS cry_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN comment_count
-        WHEN tf.timeframe = 'Year' THEN year_comment_count
-        WHEN tf.timeframe = 'Month' THEN month_comment_count
-        WHEN tf.timeframe = 'Week' THEN week_comment_count
-        WHEN tf.timeframe = 'Day' THEN day_comment_count
-      END AS comment_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN favorite_count
-        WHEN tf.timeframe = 'Year' THEN year_favorite_count
-        WHEN tf.timeframe = 'Month' THEN month_favorite_count
-        WHEN tf.timeframe = 'Week' THEN week_favorite_count
-        WHEN tf.timeframe = 'Day' THEN day_favorite_count
-      END AS favorite_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN hide_count
-        WHEN tf.timeframe = 'Year' THEN year_hide_count
-        WHEN tf.timeframe = 'Month' THEN month_hide_count
-        WHEN tf.timeframe = 'Week' THEN week_hide_count
-        WHEN tf.timeframe = 'Day' THEN day_hide_count
-      END AS hide_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN collected_count
-        WHEN tf.timeframe = 'Year' THEN year_collected_count
-        WHEN tf.timeframe = 'Month' THEN month_collected_count
-        WHEN tf.timeframe = 'Week' THEN week_collected_count
-        WHEN tf.timeframe = 'Day' THEN day_collected_count
-      END AS collected_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN tipped_count
-        WHEN tf.timeframe = 'Year' THEN year_tipped_count
-        WHEN tf.timeframe = 'Month' THEN month_tipped_count
-        WHEN tf.timeframe = 'Week' THEN week_tipped_count
-        WHEN tf.timeframe = 'Day' THEN day_tipped_count
-      END AS tipped_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN tipped_amount_count
-        WHEN tf.timeframe = 'Year' THEN year_tipped_amount_count
-        WHEN tf.timeframe = 'Month' THEN month_tipped_amount_count
-        WHEN tf.timeframe = 'Week' THEN week_tipped_amount_count
-        WHEN tf.timeframe = 'Day' THEN day_tipped_amount_count
-      END AS tipped_amount_count
-    FROM
-    (
-      SELECT
-        q.id,
-        COALESCE(r.heart_count, 0) AS heart_count,
-        COALESCE(r.year_heart_count, 0) AS year_heart_count,
-        COALESCE(r.month_heart_count, 0) AS month_heart_count,
-        COALESCE(r.week_heart_count, 0) AS week_heart_count,
-        COALESCE(r.day_heart_count, 0) AS day_heart_count,
-        COALESCE(r.laugh_count, 0) AS laugh_count,
-        COALESCE(r.year_laugh_count, 0) AS year_laugh_count,
-        COALESCE(r.month_laugh_count, 0) AS month_laugh_count,
-        COALESCE(r.week_laugh_count, 0) AS week_laugh_count,
-        COALESCE(r.day_laugh_count, 0) AS day_laugh_count,
-        COALESCE(r.cry_count, 0) AS cry_count,
-        COALESCE(r.year_cry_count, 0) AS year_cry_count,
-        COALESCE(r.month_cry_count, 0) AS month_cry_count,
-        COALESCE(r.week_cry_count, 0) AS week_cry_count,
-        COALESCE(r.day_cry_count, 0) AS day_cry_count,
-        COALESCE(r.dislike_count, 0) AS dislike_count,
-        COALESCE(r.year_dislike_count, 0) AS year_dislike_count,
-        COALESCE(r.month_dislike_count, 0) AS month_dislike_count,
-        COALESCE(r.week_dislike_count, 0) AS week_dislike_count,
-        COALESCE(r.day_dislike_count, 0) AS day_dislike_count,
-        COALESCE(r.like_count, 0) AS like_count,
-        COALESCE(r.year_like_count, 0) AS year_like_count,
-        COALESCE(r.month_like_count, 0) AS month_like_count,
-        COALESCE(r.week_like_count, 0) AS week_like_count,
-        COALESCE(r.day_like_count, 0) AS day_like_count,
-        COALESCE(c.comment_count, 0) AS comment_count,
-        COALESCE(c.year_comment_count, 0) AS year_comment_count,
-        COALESCE(c.month_comment_count, 0) AS month_comment_count,
-        COALESCE(c.week_comment_count, 0) AS week_comment_count,
-        COALESCE(c.day_comment_count, 0) AS day_comment_count,
-        COALESCE(ab.favorite_count, 0) AS favorite_count,
-        COALESCE(ab.year_favorite_count, 0) AS year_favorite_count,
-        COALESCE(ab.month_favorite_count, 0) AS month_favorite_count,
-        COALESCE(ab.week_favorite_count, 0) AS week_favorite_count,
-        COALESCE(ab.day_favorite_count, 0) AS day_favorite_count,
-        COALESCE(ae.hide_count, 0) AS hide_count,
-        COALESCE(ae.year_hide_count, 0) AS year_hide_count,
-        COALESCE(ae.month_hide_count, 0) AS month_hide_count,
-        COALESCE(ae.week_hide_count, 0) AS week_hide_count,
-        COALESCE(ae.day_hide_count, 0) AS day_hide_count,
-        COALESCE(ci.collected_count, 0) AS collected_count,
-        COALESCE(ci.year_collected_count, 0) AS year_collected_count,
-        COALESCE(ci.month_collected_count, 0) AS month_collected_count,
-        COALESCE(ci.week_collected_count, 0) AS week_collected_count,
-        COALESCE(ci.day_collected_count, 0) AS day_collected_count,
-        COALESCE(bt.tipped_count, 0) AS tipped_count,
-        COALESCE(bt.year_tipped_count, 0) AS year_tipped_count,
-        COALESCE(bt.month_tipped_count, 0) AS month_tipped_count,
-        COALESCE(bt.week_tipped_count, 0) AS week_tipped_count,
-        COALESCE(bt.day_tipped_count, 0) AS day_tipped_count,
-        COALESCE(bt.tipped_amount_count, 0) AS tipped_amount_count,
-        COALESCE(bt.year_tipped_amount_count, 0) AS year_tipped_amount_count,
-        COALESCE(bt.month_tipped_amount_count, 0) AS month_tipped_amount_count,
-        COALESCE(bt.week_tipped_amount_count, 0) AS week_tipped_amount_count,
-        COALESCE(bt.day_tipped_amount_count, 0) AS day_tipped_amount_count
-      FROM affected q
-      LEFT JOIN (
-        SELECT
-          ic."articleId" AS id,
-          COUNT(*) AS comment_count,
-          SUM(IIF(v."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_comment_count,
-          SUM(IIF(v."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_comment_count,
-          SUM(IIF(v."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_comment_count,
-          SUM(IIF(v."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_comment_count
-        FROM "Thread" ic
-        JOIN "CommentV2" v ON ic."id" = v."threadId"
-        WHERE ic."articleId" IS NOT NULL
-        GROUP BY ic."articleId"
-      ) c ON q.id = c.id
-      LEFT JOIN (
-        SELECT
-          "articleId" AS id,
-          SUM(1) AS favorite_count,
-          SUM(IIF(ci."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_favorite_count,
-          SUM(IIF(ci."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_favorite_count,
-          SUM(IIF(ci."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_favorite_count,
-          SUM(IIF(ci."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_favorite_count
-        FROM "CollectionItem" ci
-        JOIN "Collection" c ON ci."collectionId" = c."id"
-          AND c."mode" = 'Bookmark'
-          AND c."type" = 'Article'
-        WHERE ci."articleId" IS NOT NULL
-        GROUP BY "articleId"
-      ) ab ON q.id = ab.id
-      LEFT JOIN (
-        SELECT
-          "articleId" AS id,
-          SUM(IIF(type = 'Hide', 1, 0)) AS hide_count,
-          SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_hide_count,
-          SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_hide_count,
-          SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_hide_count,
-          SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_hide_count
-        FROM "ArticleEngagement"
-        GROUP BY "articleId"
-      ) ae ON q.id = ae.id
-      LEFT JOIN (
-        SELECT
-          ir."articleId" AS id,
-          SUM(IIF(ir.reaction = 'Heart', 1, 0)) AS heart_count,
-          SUM(IIF(ir.reaction = 'Heart' AND ir."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_heart_count,
-          SUM(IIF(ir.reaction = 'Heart' AND ir."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_heart_count,
-          SUM(IIF(ir.reaction = 'Heart' AND ir."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_heart_count,
-          SUM(IIF(ir.reaction = 'Heart' AND ir."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_heart_count,
-          SUM(IIF(ir.reaction = 'Like', 1, 0)) AS like_count,
-          SUM(IIF(ir.reaction = 'Like' AND ir."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_like_count,
-          SUM(IIF(ir.reaction = 'Like' AND ir."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_like_count,
-          SUM(IIF(ir.reaction = 'Like' AND ir."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_like_count,
-          SUM(IIF(ir.reaction = 'Like' AND ir."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_like_count,
-          SUM(IIF(ir.reaction = 'Dislike', 1, 0)) AS dislike_count,
-          SUM(IIF(ir.reaction = 'Dislike' AND ir."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_dislike_count,
-          SUM(IIF(ir.reaction = 'Dislike' AND ir."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_dislike_count,
-          SUM(IIF(ir.reaction = 'Dislike' AND ir."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_dislike_count,
-          SUM(IIF(ir.reaction = 'Dislike' AND ir."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_dislike_count,
-          SUM(IIF(ir.reaction = 'Cry', 1, 0)) AS cry_count,
-          SUM(IIF(ir.reaction = 'Cry' AND ir."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_cry_count,
-          SUM(IIF(ir.reaction = 'Cry' AND ir."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_cry_count,
-          SUM(IIF(ir.reaction = 'Cry' AND ir."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_cry_count,
-          SUM(IIF(ir.reaction = 'Cry' AND ir."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_cry_count,
-          SUM(IIF(ir.reaction = 'Laugh', 1, 0)) AS laugh_count,
-          SUM(IIF(ir.reaction = 'Laugh' AND ir."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_laugh_count,
-          SUM(IIF(ir.reaction = 'Laugh' AND ir."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_laugh_count,
-          SUM(IIF(ir.reaction = 'Laugh' AND ir."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_laugh_count,
-          SUM(IIF(ir.reaction = 'Laugh' AND ir."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_laugh_count
-        FROM "ArticleReaction" ir
-        GROUP BY ir."articleId"
-      ) r ON q.id = r.id
-      LEFT JOIN (
-        SELECT
-          aci."articleId" AS id,
-          COUNT(*) AS collected_count,
-          SUM(IIF(aci."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_collected_count,
-          SUM(IIF(aci."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_collected_count,
-          SUM(IIF(aci."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_collected_count,
-          SUM(IIF(aci."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_collected_count
-        FROM "CollectionItem" aci
-        JOIN "Collection" c ON aci."collectionId" = c."id" AND c."mode" IS NULL AND c."type" = 'Article'
-        WHERE aci."articleId" IS NOT NULL
-        GROUP BY aci."articleId"
-      ) ci ON q.id = ci.id
-      LEFT JOIN (
-        SELECT
-          abt."entityId" AS id,
-          COALESCE(COUNT(*), 0) AS tipped_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_tipped_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_tipped_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_tipped_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_tipped_count,
-          COALESCE(SUM(abt.amount), 0) AS tipped_amount_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '365 days'), abt.amount, 0)) AS year_tipped_amount_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '30 days'), abt.amount, 0)) AS month_tipped_amount_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '7 days'), abt.amount, 0)) AS week_tipped_amount_count,
-          SUM(IIF(abt."updatedAt" >= (NOW() - interval '1 days'), abt.amount, 0)) AS day_tipped_amount_count
-        FROM "BuzzTip" abt
-        WHERE abt."entityType" = 'Article' AND abt."entityId" IS NOT NULL
-        GROUP BY abt."entityId"
-      ) bt ON q.id = bt.id
-    ) m
-    CROSS JOIN (
-      SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-    ) tf
-    ON CONFLICT ("articleId", timeframe) DO UPDATE
-      SET "commentCount" = EXCLUDED."commentCount", "heartCount" = EXCLUDED."heartCount", "likeCount" = EXCLUDED."likeCount", "dislikeCount" = EXCLUDED."dislikeCount", "laughCount" = EXCLUDED."laughCount", "cryCount" = EXCLUDED."cryCount", "favoriteCount" = EXCLUDED."favoriteCount", "hideCount" = EXCLUDED."hideCount", "collectedCount" = EXCLUDED."collectedCount", "tippedCount" = EXCLUDED."tippedCount", "tippedAmountCount" = EXCLUDED."tippedAmountCount";
-  `;
-
-    const additionallyAffected: Array<{ id: number }> = await db.$queryRaw`
-      ${recentEngagementSubquery}
-      SELECT DISTINCT
-            a.id
-      FROM recent_engagements r
-      JOIN "Article" a ON a.id = r.id
-      WHERE r.id IS NOT NULL
-    `;
-
-    affectedArticles.push(...additionallyAffected.map((x) => x.id));
+    // Update the search index
+    //---------------------------------------
+    log('update search index');
     await articlesSearchIndex.queueUpdate(
-      [...new Set(affectedArticles)].map((id) => ({
+      [...ctx.affected].map((id) => ({
         id,
         action: SearchIndexUpdateQueueAction.Update,
       }))
     );
   },
-  async clearDay({ db }) {
-    await db.$executeRaw`
-      UPDATE "ArticleMetric" SET "heartCount" = 0, "likeCount" = 0, "dislikeCount" = 0, "laughCount" = 0, "cryCount" = 0, "commentCount" = 0, "viewCount" = 0, "collectedCount" = 0, "tippedCount" = 0, "tippedAmountCount" = 0 WHERE timeframe = 'Day';
+  async clearDay(ctx) {
+    await executeRefresh(ctx)`
+      UPDATE "ArticleMetric"
+        SET "heartCount" = 0, "likeCount" = 0, "dislikeCount" = 0, "laughCount" = 0, "cryCount" = 0, "commentCount" = 0, "viewCount" = 0, "collectedCount" = 0, "tippedCount" = 0, "tippedAmountCount" = 0
+      WHERE timeframe = 'Day'
+        AND "updatedAt" > date_trunc('day', now() - interval '1 day');
     `;
   },
   rank: {
@@ -418,11 +50,245 @@ export const articleMetrics = createMetricProcessor({
   },
 });
 
+async function getReactionTasks(ctx: MetricProcessorRunContext) {
+  log('getReactionTasks', ctx.lastUpdate);
+  const affected = await getAffected(ctx)`
+    -- get recent article reactions
+    SELECT
+      "articleId" AS id
+    FROM "ArticleReaction"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getReactionTasks', i + 1, 'of', tasks.length);
+
+    await executeRefresh(ctx)`
+      -- update article reaction metrics
+      INSERT INTO "ArticleMetric" ("articleId", timeframe, ${snippets.reactionMetricNames})
+      SELECT
+        r."articleId",
+        tf.timeframe,
+        ${snippets.reactionTimeframes()}
+      FROM "ArticleReaction" r
+      JOIN "Article" a ON a.id = r."articleId" -- ensure the article exists
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE r."articleId" IN (${ids})
+      GROUP BY r."articleId", tf.timeframe
+      ON CONFLICT ("articleId", timeframe) DO UPDATE
+        SET ${snippets.reactionMetricUpserts}, "updatedAt" = NOW()
+    `;
+    log('getReactionTasks', i + 1, 'of', tasks.length);
+  });
+
+  return tasks;
+}
+
+async function getCommentTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent article comments
+    SELECT t."articleId" as id
+    FROM "Thread" t
+    JOIN "CommentV2" c ON c."threadId" = t.id
+    WHERE t."articleId" IS NOT NULL AND c."createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getCommentTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update article comment metrics
+      INSERT INTO "ArticleMetric" ("articleId", timeframe, "commentCount")
+      SELECT
+        t."articleId",
+        tf.timeframe,
+        ${snippets.timeframeSum('c."createdAt"')}
+      FROM "Thread" t
+      JOIN "Article" a ON a.id = t."articleId" -- ensure the article exists
+      JOIN "CommentV2" c ON c."threadId" = t.id
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE t."articleId" IN (${ids})
+      GROUP BY t."articleId", tf.timeframe
+      ON CONFLICT ("articleId", timeframe) DO UPDATE
+        SET "commentCount" = EXCLUDED."commentCount", "updatedAt" = NOW()
+    `;
+    log('getCommentTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getCollectionTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent article collections
+    SELECT "articleId" as id
+    FROM "CollectionItem"
+    WHERE "articleId" IS NOT NULL AND "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getCollectionTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update article collection metrics
+      INSERT INTO "ArticleMetric" ("articleId", timeframe, "collectedCount")
+      SELECT
+        "articleId",
+        tf.timeframe,
+        ${snippets.timeframeSum('ci."createdAt"')}
+      FROM "CollectionItem" ci
+      JOIN "Article" a ON a.id = ci."articleId" -- ensure the article exists
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE ci."articleId" IN (${ids})
+      GROUP BY ci."articleId", tf.timeframe
+      ON CONFLICT ("articleId", timeframe) DO UPDATE
+        SET "collectedCount" = EXCLUDED."collectedCount", "updatedAt" = NOW()
+    `;
+    log('getCollectionTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getBuzzTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent article tips
+    SELECT "entityId" as id
+    FROM "BuzzTip"
+    WHERE "entityType" = 'Article' AND "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getBuzzTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update article tip metrics
+      INSERT INTO "ArticleMetric" ("articleId", timeframe, "tippedCount", "tippedAmountCount")
+      SELECT
+        "entityId",
+        tf.timeframe,
+        ${snippets.timeframeSum('bt."updatedAt"')} "tippedCount",
+        ${snippets.timeframeSum('bt."updatedAt"', 'amount')} "tippedAmountCount"
+      FROM "BuzzTip" bt
+      JOIN "Article" a ON a.id = bt."entityId" -- ensure the article exists
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "entityId" IN (${ids}) AND "entityType" = 'Article'
+      GROUP BY "entityId", tf.timeframe
+      ON CONFLICT ("articleId", timeframe) DO UPDATE
+        SET "tippedCount" = EXCLUDED."tippedCount", "tippedAmountCount" = EXCLUDED."tippedAmountCount", "updatedAt" = NOW()
+    `;
+    log('getBuzzTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getEngagementTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent article engagements
+    SELECT
+      "articleId"
+    FROM "ArticleEngagement"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getEngagementTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update article engagement metrics
+      INSERT INTO "ArticleMetric" ("articleId", timeframe, "hideCount")
+      SELECT
+        "articleId",
+        tf.timeframe,
+        ${snippets.timeframeSum('ae."createdAt"')} "hideCount"
+      FROM "ArticleEngagement" ae
+      JOIN "Article" a ON a.id = bt."entityId" -- ensure the article exists
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "articleId" IN (${ids}) AND ae.type = 'Hide'
+      GROUP BY "articleId", tf.timeframe
+      ON CONFLICT ("articleId", timeframe) DO UPDATE
+        SET "hideCount" = EXCLUDED."hideCount", "updatedAt" = NOW()
+    `;
+    log('getEngagementTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
 type ArticleViews = {
-  entityId: number;
-  viewsDay: string;
-  viewsWeek: string;
-  viewsMonth: string;
-  viewsYear: string;
-  viewsAll: string;
+  articleId: number;
+  day: number;
+  week: number;
+  month: number;
+  year: number;
+  all_time: number;
 };
+async function getViewTasks(ctx: MetricProcessorRunContext) {
+  const clickhouseSince = dayjs(ctx.lastUpdate).toISOString();
+  const viewed = await ctx.ch.$query<ArticleViews>`
+    WITH targets AS (
+      SELECT DISTINCT entityId AS entityId
+      FROM views
+      WHERE type = 'ArticleView'
+        AND time >= parseDateTimeBestEffortOrNull('${clickhouseSince}')
+    )
+    SELECT
+      entityId AS articleId,
+      SUM(if(uv.time >= subtractDays(now(), 1), 1, null)) AS day,
+      SUM(if(uv.time >= subtractDays(now(), 7), 1, null)) AS week,
+      SUM(if(uv.time >= subtractMonths(now(), 1), 1, null)) AS month,
+      SUM(if(uv.time >= subtractYears(now(), 1), 1, null)) AS year,
+      COUNT() AS all_time
+    FROM uniqueViews uv
+    WHERE type = 'ArticleView'
+      AND entityId IN (select entityId FROM targets)
+    GROUP BY entityId;
+  `;
+  ctx.addAffected(viewed.map((x) => x.articleId));
+
+  const tasks = chunk(viewed, 1000).map((batch, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getViewTasks', i + 1, 'of', tasks.length);
+    try {
+      const batchJson = JSON.stringify(batch);
+      await executeRefresh(ctx)`
+        -- update article view metrics
+        INSERT INTO "ArticleMetric" ("articleId", timeframe, "viewCount")
+        SELECT
+          "articleId",
+            timeframe,
+            views
+        FROM (
+            SELECT
+                CAST(js::json->>'entityId' AS INT) AS "articleId",
+                tf.timeframe,
+                CAST(
+                  CASE
+                    WHEN tf.timeframe = 'Day' THEN js::json->>'day'
+                    WHEN tf.timeframe = 'Week' THEN js::json->>'week'
+                    WHEN tf.timeframe = 'Month' THEN js::json->>'month'
+                    WHEN tf.timeframe = 'Year' THEN js::json->>'year'
+                    WHEN tf.timeframe = 'AllTime' THEN js::json->>'all_time'
+                  END
+                AS int) as views
+            FROM json_array_elements('${batchJson}'::json) js
+            CROSS JOIN (
+                SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
+            ) tf
+        ) a
+        WHERE a.views IS NOT NULL
+          AND a."articleId" IN (SELECT id FROM "Article")
+        ON CONFLICT ("articleId", timeframe) DO UPDATE
+          SET "viewCount" = EXCLUDED."viewCount",
+              "updatedAt" = NOW();
+      `;
+    } catch (err) {
+      throw err;
+    }
+    log('getViewTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}

--- a/src/server/metrics/bounty.metrics.ts
+++ b/src/server/metrics/bounty.metrics.ts
@@ -1,6 +1,7 @@
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
-import { bountiesSearchIndex, collectionsSearchIndex } from '~/server/search-index';
+import { Prisma } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { bountiesSearchIndex } from '~/server/search-index';
 
 export const bountyMetrics = createMetricProcessor({
   name: 'Bounty',
@@ -15,7 +16,7 @@ export const bountyMetrics = createMetricProcessor({
       WHERE ("createdAt" > ${lastUpdate})
 
       UNION
-      
+
       SELECT
         "bountyId" AS id
       FROM "BountyEntry"
@@ -29,12 +30,12 @@ export const bountyMetrics = createMetricProcessor({
       WHERE ("createdAt" > ${lastUpdate})
 
       UNION
-      
+
       SELECT t."bountyId" as id
       FROM "Thread" t
       JOIN "CommentV2" c ON c."threadId" = t.id
       WHERE t."bountyId" IS NOT NULL AND c."createdAt" > ${lastUpdate}
-      
+
       UNION
 
       SELECT
@@ -74,28 +75,28 @@ export const bountyMetrics = createMetricProcessor({
           WHEN tf.timeframe = 'Month' THEN month_favorite_count
           WHEN tf.timeframe = 'Week' THEN week_favorite_count
           WHEN tf.timeframe = 'Day' THEN day_favorite_count
-        END AS favorite_count, 
+        END AS favorite_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN track_count
           WHEN tf.timeframe = 'Year' THEN year_track_count
           WHEN tf.timeframe = 'Month' THEN month_track_count
           WHEN tf.timeframe = 'Week' THEN week_track_count
           WHEN tf.timeframe = 'Day' THEN day_track_count
-        END AS track_count, 
+        END AS track_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN entry_count
           WHEN tf.timeframe = 'Year' THEN year_entry_count
           WHEN tf.timeframe = 'Month' THEN month_entry_count
           WHEN tf.timeframe = 'Week' THEN week_entry_count
           WHEN tf.timeframe = 'Day' THEN day_entry_count
-        END AS entry_count, 
+        END AS entry_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN benefactor_count
           WHEN tf.timeframe = 'Year' THEN year_benefactor_count
           WHEN tf.timeframe = 'Month' THEN month_benefactor_count
           WHEN tf.timeframe = 'Week' THEN week_benefactor_count
           WHEN tf.timeframe = 'Day' THEN day_benefactor_count
-        END AS benefactor_count, 
+        END AS benefactor_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN unit_amount_count
           WHEN tf.timeframe = 'Year' THEN year_unit_amount_count
@@ -118,22 +119,22 @@ export const bountyMetrics = createMetricProcessor({
           COALESCE(be.year_favorite_count, 0) AS year_favorite_count,
           COALESCE(be.month_favorite_count, 0) AS month_favorite_count,
           COALESCE(be.week_favorite_count, 0) AS week_favorite_count,
-          COALESCE(be.day_favorite_count, 0) AS day_favorite_count, 
+          COALESCE(be.day_favorite_count, 0) AS day_favorite_count,
           COALESCE(be.track_count, 0) AS track_count,
           COALESCE(be.year_track_count, 0) AS year_track_count,
           COALESCE(be.month_track_count, 0) AS month_track_count,
           COALESCE(be.week_track_count, 0) AS week_track_count,
-          COALESCE(be.day_track_count, 0) AS day_track_count, 
+          COALESCE(be.day_track_count, 0) AS day_track_count,
           COALESCE(bentry.entry_count, 0) AS entry_count,
           COALESCE(bentry.year_entry_count, 0) AS year_entry_count,
           COALESCE(bentry.month_entry_count, 0) AS month_entry_count,
           COALESCE(bentry.week_entry_count, 0) AS week_entry_count,
-          COALESCE(bentry.day_entry_count, 0) AS day_entry_count, 
+          COALESCE(bentry.day_entry_count, 0) AS day_entry_count,
           COALESCE(bf.benefactor_count, 0) AS benefactor_count,
           COALESCE(bf.year_benefactor_count, 0) AS year_benefactor_count,
           COALESCE(bf.month_benefactor_count, 0) AS month_benefactor_count,
           COALESCE(bf.week_benefactor_count, 0) AS week_benefactor_count,
-          COALESCE(bf.day_benefactor_count, 0) AS day_benefactor_count, 
+          COALESCE(bf.day_benefactor_count, 0) AS day_benefactor_count,
           COALESCE(bf.unit_amount_count, 0) AS unit_amount_count,
           COALESCE(bf.year_unit_amount_count, 0) AS year_unit_amount_count,
           COALESCE(bf.month_unit_amount_count, 0) AS month_unit_amount_count,

--- a/src/server/metrics/club.metrics.ts
+++ b/src/server/metrics/club.metrics.ts
@@ -4,6 +4,9 @@ import { Prisma } from '@prisma/client';
 export const clubMetrics = createMetricProcessor({
   name: 'Club',
   async update({ db, lastUpdate }) {
+    return;
+    // Disabled for now
+
     const recentEngagementSubquery = Prisma.sql`
     -- Get all engagements that have happened since then that affect metrics
     WITH recent_engagements AS
@@ -54,7 +57,7 @@ export const clubMetrics = createMetricProcessor({
       INSERT INTO "ClubMetric" ("clubId", timeframe, "memberCount", "resourceCount", "clubPostCount")
       SELECT
         m.id,
-        tf.timeframe, 
+        tf.timeframe,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN member_count
           WHEN tf.timeframe = 'Year' THEN year_member_count
@@ -103,7 +106,7 @@ export const clubMetrics = createMetricProcessor({
               SUM(IIF(cm."startedAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_member_count,
               SUM(IIF(cm."startedAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_member_count,
               SUM(IIF(cm."startedAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_member_count,
-              SUM(IIF(cm."startedAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_member_count 
+              SUM(IIF(cm."startedAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_member_count
             FROM "ClubMembership" cm
             WHERE cm."expiresAt" IS NULL OR cm."expiresAt" > NOW()
             GROUP BY cm."clubId"
@@ -122,7 +125,7 @@ export const clubMetrics = createMetricProcessor({
           LEFT JOIN "Club" c ON ea."accessorId" = c.id AND ea."accessorType" = 'Club'
           LEFT JOIN "ClubTier" ct ON ea."accessorId" = ct."id" AND ea."accessorType" = 'ClubTier'
           WHERE  ea."accessorType" IN ('Club', 'ClubTier')
-            AND COALESCE(c.id, ct."clubId") IS NOT NULL  
+            AND COALESCE(c.id, ct."clubId") IS NOT NULL
           GROUP BY COALESCE(c.id, ct."clubId")
         ) ea ON ea."clubId" = a.id
         LEFT JOIN (
@@ -133,7 +136,7 @@ export const clubMetrics = createMetricProcessor({
             SUM(IIF(cp."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_club_post_count,
             SUM(IIF(cp."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_club_post_count,
             SUM(IIF(cp."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_club_post_count
-          FROM "ClubPost" cp 
+          FROM "ClubPost" cp
           GROUP BY cp."clubId"
         ) cp ON cp."clubId" = a.id
       ) m

--- a/src/server/metrics/clubPost.metrics.ts
+++ b/src/server/metrics/clubPost.metrics.ts
@@ -4,6 +4,9 @@ import { Prisma } from '@prisma/client';
 export const clubPostMetrics = createMetricProcessor({
   name: 'ClubPost',
   async update({ db, lastUpdate }) {
+    return;
+    // Disabled for now
+
     const recentEngagementSubquery = Prisma.sql`
     -- Get all engagements that have happened since then that affect metrics
     WITH recent_engagements AS
@@ -52,28 +55,28 @@ export const clubPostMetrics = createMetricProcessor({
           WHEN tf.timeframe = 'Month' THEN month_like_count
           WHEN tf.timeframe = 'Week' THEN week_like_count
           WHEN tf.timeframe = 'Day' THEN day_like_count
-        END AS like_count, 
+        END AS like_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN dislike_count
           WHEN tf.timeframe = 'Year' THEN year_dislike_count
           WHEN tf.timeframe = 'Month' THEN month_dislike_count
           WHEN tf.timeframe = 'Week' THEN week_dislike_count
           WHEN tf.timeframe = 'Day' THEN day_dislike_count
-        END AS dislike_count, 
+        END AS dislike_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN laugh_count
           WHEN tf.timeframe = 'Year' THEN year_laugh_count
           WHEN tf.timeframe = 'Month' THEN month_laugh_count
           WHEN tf.timeframe = 'Week' THEN week_laugh_count
           WHEN tf.timeframe = 'Day' THEN day_laugh_count
-        END AS laugh_count, 
+        END AS laugh_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN cry_count
           WHEN tf.timeframe = 'Year' THEN year_cry_count
           WHEN tf.timeframe = 'Month' THEN month_cry_count
           WHEN tf.timeframe = 'Week' THEN week_cry_count
           WHEN tf.timeframe = 'Day' THEN day_cry_count
-        END AS cry_count, 
+        END AS cry_count,
         CASE
           WHEN tf.timeframe = 'AllTime' THEN heart_count
           WHEN tf.timeframe = 'Year' THEN year_heart_count

--- a/src/server/metrics/collection.metrics.ts
+++ b/src/server/metrics/collection.metrics.ts
@@ -1,147 +1,39 @@
-import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma } from '@prisma/client';
+import { chunk } from 'lodash-es';
+import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
+import { executeRefresh, getAffected, snippets } from '~/server/metrics/metric-helpers';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { collectionsSearchIndex } from '~/server/search-index';
-// import { collectionSearchIndex } from '~/server/search-index';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { createLogger } from '~/utils/logging';
+
+const log = createLogger('metrics:collection');
 
 export const collectionMetrics = createMetricProcessor({
   name: 'Collection',
-  async update({ pg, lastUpdate, jobContext }) {
-    const query = await pg.cancellableQuery<{ id: number }>(Prisma.sql`
-      -- Get all engagements that have happened since then that affect metrics
-      WITH recent_engagements AS
-      (
-        SELECT
-          "collectionId" AS id
-        FROM "CollectionItem"
-        WHERE ("createdAt" > ${lastUpdate})
+  async update(ctx) {
+    // Get the metric tasks
+    //---------------------------------------
+    const taskBatches = await Promise.all([getItemTasks(ctx), getContributorTasks(ctx)]);
+    log('CollectionMetric update', taskBatches.flat().length, 'tasks');
+    for (const tasks of taskBatches) await limitConcurrency(tasks, 5);
 
-        UNION
-
-        SELECT
-          "collectionId" AS id
-        FROM "CollectionContributor"
-        WHERE ("createdAt" > ${lastUpdate})
-
-        UNION
-
-        SELECT
-          "id"
-        FROM "Collection"
-        WHERE ("createdAt" > ${lastUpdate})
-
-        UNION
-
-        SELECT
-          "id"
-        FROM "MetricUpdateQueue"
-        WHERE type = 'Collection'
-      ),
-      -- Get all affected
-      affected AS
-      (
-          SELECT DISTINCT
-              r.id
-          FROM recent_engagements r
-          JOIN "Collection" c ON c.id = r.id
-          WHERE r.id IS NOT NULL
-      )
-
-      -- upsert metrics for all affected
-      -- perform a one-pass table scan producing all metrics for all affected users
-      INSERT INTO "CollectionMetric" ("collectionId", timeframe, "followerCount", "itemCount", "contributorCount")
-      SELECT
-        m.id,
-        tf.timeframe,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN follower_count
-          WHEN tf.timeframe = 'Year' THEN year_follower_count
-          WHEN tf.timeframe = 'Month' THEN month_follower_count
-          WHEN tf.timeframe = 'Week' THEN week_follower_count
-          WHEN tf.timeframe = 'Day' THEN day_follower_count
-        END AS follower_count,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN item_count
-          WHEN tf.timeframe = 'Year' THEN year_item_count
-          WHEN tf.timeframe = 'Month' THEN month_item_count
-          WHEN tf.timeframe = 'Week' THEN week_item_count
-          WHEN tf.timeframe = 'Day' THEN day_item_count
-        END AS item_count,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN contributor_count
-          WHEN tf.timeframe = 'Year' THEN year_contributor_count
-          WHEN tf.timeframe = 'Month' THEN month_contributor_count
-          WHEN tf.timeframe = 'Week' THEN week_contributor_count
-          WHEN tf.timeframe = 'Day' THEN day_contributor_count
-        END AS contributor_count
-      FROM
-      (
-        SELECT
-          a.id,
-          COALESCE(cc.follower_count, 0) AS follower_count,
-          COALESCE(cc.year_follower_count, 0) AS year_follower_count,
-          COALESCE(cc.month_follower_count, 0) AS month_follower_count,
-          COALESCE(cc.week_follower_count, 0) AS week_follower_count,
-          COALESCE(cc.day_follower_count, 0) AS day_follower_count,
-          COALESCE(i.item_count, 0) AS item_count,
-          COALESCE(i.year_item_count, 0) AS year_item_count,
-          COALESCE(i.month_item_count, 0) AS month_item_count,
-          COALESCE(i.week_item_count, 0) AS week_item_count,
-          COALESCE(i.day_item_count, 0) AS day_item_count,
-          COALESCE(cc.contributor_count, 0) AS contributor_count,
-          COALESCE(cc.year_contributor_count, 0) AS year_contributor_count,
-          COALESCE(cc.month_contributor_count, 0) AS month_contributor_count,
-          COALESCE(cc.week_contributor_count, 0) AS week_contributor_count,
-          COALESCE(cc.day_contributor_count, 0) AS day_contributor_count
-        FROM affected a
-        LEFT JOIN (
-          SELECT
-              cc."collectionId",
-              SUM(IIF('VIEW' = ANY(cc.permissions), 1, 0)) follower_count,
-              SUM(IIF('VIEW' = ANY(cc.permissions) AND cc."createdAt" > now() - INTERVAL '1 year', 1, 0)) year_follower_count,
-              SUM(IIF('VIEW' = ANY(cc.permissions) AND cc."createdAt" > now() - INTERVAL '1 month', 1, 0)) month_follower_count,
-              SUM(IIF('VIEW' = ANY(cc.permissions) AND cc."createdAt" > now() - INTERVAL '1 week', 1, 0)) week_follower_count,
-              SUM(IIF('VIEW' = ANY(cc.permissions) AND cc."createdAt" > now() - INTERVAL '1 day', 1, 0)) day_follower_count,
-              SUM(IIF(('ADD' = ANY(cc.permissions) OR 'ADD_REVIEW' = ANY(cc.permissions)), 1, 0)) contributor_count,
-              SUM(IIF(('ADD' = ANY(cc.permissions) OR 'ADD_REVIEW' = ANY(cc.permissions)) AND cc."createdAt" > now() - INTERVAL '1 year', 1, 0)) year_contributor_count,
-              SUM(IIF(('ADD' = ANY(cc.permissions) OR 'ADD_REVIEW' = ANY(cc.permissions)) AND cc."createdAt" > now() - INTERVAL '1 month', 1, 0)) month_contributor_count,
-              SUM(IIF(('ADD' = ANY(cc.permissions) OR 'ADD_REVIEW' = ANY(cc.permissions)) AND cc."createdAt" > now() - INTERVAL '1 week', 1, 0)) week_contributor_count,
-              SUM(IIF(('ADD' = ANY(cc.permissions) OR 'ADD_REVIEW' = ANY(cc.permissions)) AND cc."createdAt" > now() - INTERVAL '1 day', 1, 0)) day_contributor_count
-          FROM "CollectionContributor" cc
-          GROUP BY cc."collectionId"
-        ) cc ON cc."collectionId" = a.id
-        LEFT JOIN (
-          SELECT
-            i."collectionId",
-            COUNT(*) item_count,
-            SUM(IIF(i."createdAt" > now() - INTERVAL '1 year', 1, 0)) year_item_count,
-            SUM(IIF(i."createdAt" > now() - INTERVAL '1 month', 1, 0)) month_item_count,
-            SUM(IIF(i."createdAt" > now() - INTERVAL '1 week', 1, 0)) week_item_count,
-            SUM(IIF(i."createdAt" > now() - INTERVAL '1 day', 1, 0)) day_item_count
-          FROM "CollectionItem" i
-          GROUP BY i."collectionId"
-        ) i ON i."collectionId" = a.id
-      ) m
-      CROSS JOIN (
-        SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-      ) tf
-      ON CONFLICT ("collectionId", timeframe) DO UPDATE
-        SET "followerCount" = EXCLUDED."followerCount", "itemCount" = EXCLUDED."itemCount", "contributorCount" = EXCLUDED."contributorCount", "createdAt" = now()
-      RETURNING "collectionId" as id;
-    `);
-    jobContext.on('cancel', query.cancel);
-    const affected = await query.result();
-
+    // Update the search index
+    //---------------------------------------
+    log('update search index');
     await collectionsSearchIndex.queueUpdate(
-      affected.map(({ id }) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
+      [...ctx.affected].map((id) => ({
+        id,
+        action: SearchIndexUpdateQueueAction.Update,
+      }))
     );
   },
-  async clearDay({ pg, jobContext }) {
-    const query = await pg.cancellableQuery(Prisma.sql`
-      UPDATE "CollectionMetric" SET "followerCount" = 0, "itemCount" = 0, "contributorCount" = 0 WHERE timeframe = 'Day' AND "createdAt" > date_trunc('day', now() - interval '1 day');
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+  async clearDay(ctx) {
+    await executeRefresh(ctx)`
+      UPDATE "CollectionMetric"
+        SET "followerCount" = 0, "itemCount" = 0, "contributorCount" = 0
+      WHERE timeframe = 'Day'
+        AND "createdAt" > date_trunc('day', now() - interval '1 day');
+    `;
   },
   rank: {
     table: 'CollectionRank',
@@ -149,3 +41,74 @@ export const collectionMetrics = createMetricProcessor({
     refreshInterval: 5 * 60 * 1000,
   },
 });
+
+async function getContributorTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent collection contributors
+    SELECT "collectionId" as id
+    FROM "CollectionContributor"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getContributorTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update collection contributor metrics
+      INSERT INTO "CollectionMetric" ("collectionId", timeframe, "followerCount", "contributorCount")
+      SELECT
+        "collectionId",
+        tf.timeframe,
+        ${snippets.timeframeSum(
+          '"createdAt"',
+          '1',
+          `'VIEW' = ANY(permissions)`
+        )} as "followerCount",
+        ${snippets.timeframeSum(
+          '"createdAt"',
+          '1',
+          `'ADD' = ANY(permissions)`
+        )} as "contributorCount"
+      FROM "CollectionContributor"
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "collectionId" IN (${ids})
+      GROUP BY "collectionId", tf.timeframe
+      ON CONFLICT ("collectionId", timeframe) DO UPDATE
+        SET "followerCount" = EXCLUDED."followerCount", "contributorCount" = EXCLUDED."contributorCount", "updatedAt" = NOW()
+    `;
+    log('getContributorTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getItemTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent collection items
+    SELECT "collectionId" as id
+    FROM "CollectionItem"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getItemTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update collection item metrics
+      INSERT INTO "CollectionMetric" ("collectionId", timeframe, "itemCount")
+      SELECT
+        "collectionId",
+        tf.timeframe,
+        ${snippets.timeframeSum('"createdAt"')} as "itemCount"
+      FROM "CollectionItem"
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "collectionId" IN (${ids})
+      GROUP BY "collectionId", tf.timeframe
+      ON CONFLICT ("collectionId", timeframe) DO UPDATE
+        SET "itemCount" = EXCLUDED."itemCount", "updatedAt" = NOW()
+    `;
+    log('getItemTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}

--- a/src/server/metrics/collection.metrics.ts
+++ b/src/server/metrics/collection.metrics.ts
@@ -1,5 +1,6 @@
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { collectionsSearchIndex } from '~/server/search-index';
 // import { collectionSearchIndex } from '~/server/search-index';
 

--- a/src/server/metrics/image.metrics.ts
+++ b/src/server/metrics/image.metrics.ts
@@ -1,5 +1,6 @@
 import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
-import { Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { imagesSearchIndex } from '~/server/search-index';
 import dayjs from 'dayjs';
 import { chunk } from 'lodash-es';

--- a/src/server/metrics/image.metrics.ts
+++ b/src/server/metrics/image.metrics.ts
@@ -1,38 +1,25 @@
 import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
-import { Prisma } from '@prisma/client';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { imagesSearchIndex } from '~/server/search-index';
 import dayjs from 'dayjs';
 import { chunk } from 'lodash-es';
-import { limitConcurrency, Task } from '~/server/utils/concurrency-helpers';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
+import { executeRefresh, getAffected, snippets } from '~/server/metrics/metric-helpers';
 
-const log = createLogger('metrics:post');
-
-type ImageMetricContext = MetricProcessorRunContext & {
-  addAffected: (id: number | number[]) => void;
-};
+const log = createLogger('metrics:image');
 
 export const imageMetrics = createMetricProcessor({
   name: 'Image',
   async update(ctx) {
-    // Prepare the context
-    const { pg, jobContext } = ctx;
-    const imageCtx = ctx as ImageMetricContext;
-    const affected = new Set<number>();
-    imageCtx.addAffected = (id) => {
-      if (Array.isArray(id)) id.forEach((x) => affected.add(x));
-      else affected.add(id);
-    };
-
     // Get the metric tasks
     //---------------------------------------
     const taskBatches = await Promise.all([
-      getReactionTasks(imageCtx),
-      getCommentTasks(imageCtx),
-      getCollectionTasks(imageCtx),
-      getBuzzTasks(imageCtx),
-      getViewTasks(imageCtx),
+      getReactionTasks(ctx),
+      getCommentTasks(ctx),
+      getCollectionTasks(ctx),
+      getBuzzTasks(ctx),
+      getViewTasks(ctx),
     ]);
     log('imageMetrics update', taskBatches.flat().length, 'tasks');
     for (const tasks of taskBatches) await limitConcurrency(tasks, 5);
@@ -41,7 +28,7 @@ export const imageMetrics = createMetricProcessor({
     //---------------------------------------
     log('update search index');
     await imagesSearchIndex.queueUpdate(
-      [...affected].map((id) => ({
+      [...ctx.affected].map((id) => ({
         id,
         action: SearchIndexUpdateQueueAction.Update,
       }))
@@ -50,7 +37,7 @@ export const imageMetrics = createMetricProcessor({
     // Update the age group of the metrics
     //---------------------------------------
     log('update age groups');
-    const updateAgeGroupsQuery = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       UPDATE "ImageMetric"
       SET "ageGroup" = CASE
           WHEN "createdAt" >= now() - interval '1 day' THEN 'Day'::"MetricTimeframe"
@@ -64,326 +51,200 @@ export const imageMetrics = createMetricProcessor({
         ("ageGroup" = 'Month' AND "createdAt" < now() - interval '1 month') OR
         ("ageGroup" = 'Week' AND "createdAt" < now() - interval '1 week') OR
         ("ageGroup" = 'Day' AND "createdAt" < now() - interval '1 day');
-    `);
-    jobContext.on('cancel', updateAgeGroupsQuery.cancel);
-    await updateAgeGroupsQuery.result();
+    `;
   },
-  async clearDay({ pg, jobContext }) {
+  async clearDay(ctx) {
     // Clear day of things updated in the last day
-    const clearDayQuery = await pg.cancellableQuery(Prisma.sql`
-      UPDATE "ImageMetric" SET "heartCount" = 0, "likeCount" = 0, "dislikeCount" = 0, "laughCount" = 0, "cryCount" = 0, "commentCount" = 0, "collectedCount" = 0, "tippedCount" = 0, "tippedAmountCount" = 0 WHERE timeframe = 'Day' AND "updatedAt" > date_trunc('day', now() - interval '1 day');
-    `);
-    jobContext.on('cancel', clearDayQuery.cancel);
-    await clearDayQuery.result();
+    await executeRefresh(ctx)`
+      UPDATE "ImageMetric"
+        SET "heartCount" = 0, "likeCount" = 0, "dislikeCount" = 0, "laughCount" = 0, "cryCount" = 0, "commentCount" = 0, "collectedCount" = 0, "tippedCount" = 0, "tippedAmountCount" = 0
+      WHERE timeframe = 'Day'
+        AND "updatedAt" > date_trunc('day', now() - interval '1 day');
+    `;
   },
 });
 
-async function getReactionTasks({ pg, lastUpdate, jobContext, ...ctx }: ImageMetricContext) {
-  log('getReactionTasks', lastUpdate);
-  const affectedQuery = await pg.cancellableQuery<{ id: number }>(Prisma.sql`
+async function getReactionTasks(ctx: MetricProcessorRunContext) {
+  log('getReactionTasks', ctx.lastUpdate);
+  const affected = await getAffected(ctx)`
     -- get recent image reactions
     SELECT
       "imageId" AS id
     FROM "ImageReaction"
-    WHERE "createdAt" > ${lastUpdate}
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
 
-    UNION
-
-    SELECT
-      "id"
-    FROM "MetricUpdateQueue"
-    WHERE type = 'Image'
-  `);
-  jobContext.on('cancel', affectedQuery.cancel);
-  const affected = await affectedQuery.result();
-  const ids = [...new Set(affected.map((x) => x.id))];
-  ctx.addAffected(ids);
-
-  const tasks = chunk(ids, 1000).map((ids, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getReactionTasks', i + 1, 'of', tasks.length);
 
-    const query = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       -- update image reaction metrics
-      INSERT INTO "ImageMetric" ("imageId", timeframe, "likeCount", "dislikeCount", "heartCount", "laughCount", "cryCount")
+      INSERT INTO "ImageMetric" ("imageId", timeframe, ${snippets.reactionMetricNames})
       SELECT
-        ir."imageId",
+        r."imageId",
         tf.timeframe,
-        SUM(CASE
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "likeCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "dislikeCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "heartCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "laughCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "cryCount"
-      FROM "ImageReaction" ir
-      JOIN "Image" i ON i.id = ir."imageId" -- ensure the image exists
+        ${snippets.reactionTimeframes()}
+      FROM "ImageReaction" r
+      JOIN "Image" i ON i.id = r."imageId" -- ensure the image exists
       CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
-      WHERE ir."imageId" IN (${Prisma.join(ids)})
-      GROUP BY ir."imageId", tf.timeframe
+      WHERE r."imageId" IN (${ids})
+      GROUP BY r."imageId", tf.timeframe
       ON CONFLICT ("imageId", timeframe) DO UPDATE
-        SET "heartCount" = EXCLUDED."heartCount", "likeCount" = EXCLUDED."likeCount", "dislikeCount" = EXCLUDED."dislikeCount", "laughCount" = EXCLUDED."laughCount", "cryCount" = EXCLUDED."cryCount", "updatedAt" = NOW()
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+        SET ${snippets.reactionMetricUpserts}, "updatedAt" = NOW()
+    `;
     log('getReactionTasks', i + 1, 'of', tasks.length, 'done');
   });
 
   return tasks;
 }
 
-async function getCommentTasks({ pg, lastUpdate, jobContext, ...ctx }: ImageMetricContext) {
-  const affectedQuery = await pg.cancellableQuery<{ id: number }>(Prisma.sql`
+async function getCommentTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
     -- get recent image comments
     SELECT t."imageId" as id
     FROM "Thread" t
     JOIN "CommentV2" c ON c."threadId" = t.id
-    WHERE t."imageId" IS NOT NULL AND c."createdAt" > ${lastUpdate}
+    WHERE t."imageId" IS NOT NULL AND c."createdAt" > '${ctx.lastUpdate}'
+  `;
 
-    UNION
-
-    SELECT
-      "id"
-    FROM "MetricUpdateQueue"
-    WHERE type = 'Image'
-  `);
-  jobContext.on('cancel', affectedQuery.cancel);
-  const affected = await affectedQuery.result();
-  const ids = [...new Set(affected.map((x) => x.id))];
-  ctx.addAffected(ids);
-
-  const tasks = chunk(ids, 1000).map((ids, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getCommentTasks', i + 1, 'of', tasks.length);
-    const query = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       -- update image comment metrics
       INSERT INTO "ImageMetric" ("imageId", timeframe, "commentCount")
       SELECT
         t."imageId",
         tf.timeframe,
-        SUM(CASE
-          WHEN tf.timeframe = 'AllTime' THEN 1
-          WHEN tf.timeframe = 'Year' AND c."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN tf.timeframe = 'Month' AND c."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN tf.timeframe = 'Week' AND c."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN tf.timeframe = 'Day' AND c."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END)
+        ${snippets.timeframeSum('c."createdAt"')}
       FROM "Thread" t
       JOIN "Image" i ON i.id = t."imageId" -- ensure the image exists
       JOIN "CommentV2" c ON c."threadId" = t.id
       CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
-      WHERE t."imageId" IN (${Prisma.join(ids)})
+      WHERE t."imageId" IN (${ids})
       GROUP BY t."imageId", tf.timeframe
       ON CONFLICT ("imageId", timeframe) DO UPDATE
         SET "commentCount" = EXCLUDED."commentCount", "updatedAt" = NOW()
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+    `;
     log('getCommentTasks', i + 1, 'of', tasks.length, 'done');
   });
 
   return tasks;
 }
 
-async function getCollectionTasks({ pg, lastUpdate, jobContext, ...ctx }: ImageMetricContext) {
-  const affectedQuery = await pg.cancellableQuery<{ id: number }>(Prisma.sql`
+async function getCollectionTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
     -- get recent image collections
     SELECT "imageId" as id
     FROM "CollectionItem"
-    WHERE "imageId" IS NOT NULL AND "createdAt" > ${lastUpdate}
+    WHERE "imageId" IS NOT NULL AND "createdAt" > '${ctx.lastUpdate}'
+  `;
 
-    UNION
-
-    SELECT
-      "id"
-    FROM "MetricUpdateQueue"
-    WHERE type = 'Image'
-  `);
-  jobContext.on('cancel', affectedQuery.cancel);
-  const affected = await affectedQuery.result();
-  const ids = [...new Set(affected.map((x) => x.id))];
-  ctx.addAffected(ids);
-
-  const tasks = chunk(ids, 1000).map((ids, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getCollectionTasks', i + 1, 'of', tasks.length);
-    const query = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       -- update image collection metrics
       INSERT INTO "ImageMetric" ("imageId", timeframe, "collectedCount")
       SELECT
         "imageId",
         tf.timeframe,
-        SUM(CASE
-          WHEN tf.timeframe = 'AllTime' THEN 1
-          WHEN tf.timeframe = 'Year' AND ci."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN tf.timeframe = 'Month' AND ci."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN tf.timeframe = 'Week' AND ci."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN tf.timeframe = 'Day' AND ci."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END)
+        ${snippets.timeframeSum('ci."createdAt"')}
       FROM "CollectionItem" ci
       JOIN "Image" i ON i.id = ci."imageId" -- ensure the image exists
       CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
-      WHERE ci."imageId" IN (${Prisma.join(ids)})
+      WHERE ci."imageId" IN (${ids})
       GROUP BY ci."imageId", tf.timeframe
       ON CONFLICT ("imageId", timeframe) DO UPDATE
         SET "collectedCount" = EXCLUDED."collectedCount", "updatedAt" = NOW()
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+    `;
     log('getCollectionTasks', i + 1, 'of', tasks.length, 'done');
   });
 
   return tasks;
 }
 
-async function getBuzzTasks({ pg, lastUpdate, jobContext, ...ctx }: ImageMetricContext) {
-  const affectedQuery = await pg.cancellableQuery<{ id: number }>(Prisma.sql`
+async function getBuzzTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
     -- get recent image tips
     SELECT "entityId" as id
     FROM "BuzzTip"
-    WHERE "entityType" = 'Image' AND "createdAt" > ${lastUpdate}
+    WHERE "entityType" = 'Image' AND "createdAt" > '${ctx.lastUpdate}'
+  `;
 
-    UNION
-
-    SELECT
-      "id"
-    FROM "MetricUpdateQueue"
-    WHERE type = 'Image'
-  `);
-  jobContext.on('cancel', affectedQuery.cancel);
-  const affected = await affectedQuery.result();
-  const ids = [...new Set(affected.map((x) => x.id))];
-  ctx.addAffected(ids);
-
-  const tasks = chunk(ids, 1000).map((ids, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getBuzzTasks', i + 1, 'of', tasks.length);
-    const query = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       -- update image tip metrics
       INSERT INTO "ImageMetric" ("imageId", timeframe, "tippedCount", "tippedAmountCount")
       SELECT
         "entityId",
         tf.timeframe,
-        SUM(CASE
-          WHEN tf.timeframe = 'AllTime' THEN 1
-          WHEN tf.timeframe = 'Year' AND bt."updatedAt" > (NOW() - interval '365 days') THEN 1
-          WHEN tf.timeframe = 'Month' AND bt."updatedAt" > (NOW() - interval '30 days') THEN 1
-          WHEN tf.timeframe = 'Week' AND bt."updatedAt" > (NOW() - interval '7 days') THEN 1
-          WHEN tf.timeframe = 'Day' AND bt."updatedAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "tippedCount",
-        SUM(CASE
-          WHEN tf.timeframe = 'AllTime' THEN "amount"
-          WHEN tf.timeframe = 'Year' AND bt."updatedAt" > (NOW() - interval '365 days') THEN "amount"
-          WHEN tf.timeframe = 'Month' AND bt."updatedAt" > (NOW() - interval '30 days') THEN "amount"
-          WHEN tf.timeframe = 'Week' AND bt."updatedAt" > (NOW() - interval '7 days') THEN "amount"
-          WHEN tf.timeframe = 'Day' AND bt."updatedAt" > (NOW() - interval '1 days') THEN "amount"
-          ELSE 0
-        END) "tippedAmountCount"
+        ${snippets.timeframeSum('bt."updatedAt"')} "tippedCount",
+        ${snippets.timeframeSum('bt."updatedAt"', 'amount')} "tippedAmountCount"
       FROM "BuzzTip" bt
       JOIN "Image" i ON i.id = bt."entityId" -- ensure the image exists
       CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
-      WHERE "entityId" IN (${Prisma.join(ids)}) AND "entityType" = 'Image'
+      WHERE "entityId" IN (${ids}) AND "entityType" = 'Image'
       GROUP BY "entityId", tf.timeframe
       ON CONFLICT ("imageId", timeframe) DO UPDATE
         SET "tippedCount" = EXCLUDED."tippedCount", "tippedAmountCount" = EXCLUDED."tippedAmountCount", "updatedAt" = NOW()
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+    `;
     log('getBuzzTasks', i + 1, 'of', tasks.length, 'done');
   });
 
   return tasks;
 }
 
-async function getViewTasks({ ch, pg, lastUpdate, jobContext, ...ctx }: ImageMetricContext) {
-  const clickhouseSince = dayjs(lastUpdate).toISOString();
-  const imageViews = await ch.query({
-    query: `
-        WITH targets AS (
-          SELECT
-            entityId
-          FROM views
-          WHERE entityType = 'Image'
-          AND time >= parseDateTimeBestEffortOrNull('${clickhouseSince}')
-        )
-        SELECT
-          entityId AS imageId,
-          sumIf(views, createdDate = current_date()) day,
-          sumIf(views, createdDate >= subtractDays(current_date(), 7)) week,
-          sumIf(views, createdDate >= subtractDays(current_date(), 30)) month,
-          sumIf(views, createdDate >= subtractYears(current_date(), 1)) year,
-          sum(views) all_time
-        FROM daily_views
-        WHERE entityId IN (select entityId FROM targets)
-          AND entityType = 'Image'
-        GROUP BY imageId;
-      `,
-    format: 'JSONEachRow',
-  });
+type ImageMetricView = {
+  imageId: number;
+  day: number;
+  week: number;
+  month: number;
+  year: number;
+  all_time: number;
+};
+async function getViewTasks(ctx: MetricProcessorRunContext) {
+  const clickhouseSince = dayjs(ctx.lastUpdate).toISOString();
+  const viewed = await ctx.ch.$query<ImageMetricView>`
+    WITH targets AS (
+      SELECT
+        entityId
+      FROM views
+      WHERE entityType = 'Image'
+      AND time >= parseDateTimeBestEffortOrNull('${clickhouseSince}')
+    )
+    SELECT
+      entityId AS imageId,
+      sumIf(views, createdDate = current_date()) day,
+      sumIf(views, createdDate >= subtractDays(current_date(), 7)) week,
+      sumIf(views, createdDate >= subtractDays(current_date(), 30)) month,
+      sumIf(views, createdDate >= subtractYears(current_date(), 1)) year,
+      sum(views) all_time
+    FROM daily_views
+    WHERE entityId IN (select entityId FROM targets)
+      AND entityType = 'Image'
+    GROUP BY imageId;
+  `;
+  ctx.addAffected(viewed.map((x) => x.imageId));
 
-  const viewedImages = (await imageViews?.json()) as [
-    {
-      imageId: number;
-      day: number;
-      week: number;
-      month: number;
-      year: number;
-      all_time: number;
-    }
-  ];
-  ctx.addAffected(viewedImages.map((x) => x.imageId));
-
-  const tasks = chunk(viewedImages, 1000).map((batch, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(viewed, 1000).map((batch, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getViewTasks', i + 1, 'of', tasks.length);
     try {
       const batchJson = JSON.stringify(batch);
-      const updateChunkQuery = await pg.cancellableQuery(Prisma.sql`
+      await executeRefresh(ctx)`
+        -- update image view metrics
         INSERT INTO "ImageMetric" ("imageId", timeframe, "viewCount")
         SELECT
-          imageId,
+          "imageId",
           timeframe,
           views
-        FROM
-        (
+        FROM (
             SELECT
-                CAST(mvs::json->>'imageId' AS INT) AS imageId,
+                CAST(mvs::json->>'imageId' AS INT) AS "imageId",
                 tf.timeframe,
                 CAST(
                   CASE
@@ -394,20 +255,18 @@ async function getViewTasks({ ch, pg, lastUpdate, jobContext, ...ctx }: ImageMet
                     WHEN tf.timeframe = 'AllTime' THEN mvs::json->>'all_time'
                   END
                 AS int) as views
-            FROM json_array_elements(${batchJson}::json) mvs
+            FROM json_array_elements('${batchJson}'::json) mvs
             CROSS JOIN (
                 SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
             ) tf
         ) im
-        JOIN "Image" i ON i.id = im.imageId -- ensure the image exists
+        JOIN "Image" i ON i.id = im."imageId" -- ensure the image exists
         WHERE im.views IS NOT NULL
-        AND im.imageId IN (SELECT id FROM "Image")
+        AND im."imageId" IN (SELECT id FROM "Image")
         ON CONFLICT ("imageId", timeframe) DO UPDATE
           SET "viewCount" = EXCLUDED."viewCount",
               "updatedAt" = NOW();
-      `);
-      jobContext.on('cancel', updateChunkQuery.cancel);
-      await updateChunkQuery.result();
+      `;
     } catch (err) {
       throw err;
     }

--- a/src/server/metrics/metric-helpers.ts
+++ b/src/server/metrics/metric-helpers.ts
@@ -1,0 +1,109 @@
+import { ReviewReactions } from '@prisma/client';
+import { AugmentedPool, templateHandler } from '~/server/db/pgDb';
+import { JobContext } from '~/server/jobs/job';
+import { MetricProcessorRunContext } from '~/server/metrics/base.metrics';
+
+export function getAffected(ctx: MetricProcessorRunContext) {
+  return templateHandler(async (sql) => {
+    const affectedQuery = await ctx.pg.cancellableQuery<{ id: number }>(sql);
+    ctx.jobContext.on('cancel', affectedQuery.cancel);
+    const affected = await affectedQuery.result();
+    const idsSet = new Set(ctx.queue);
+    affected.forEach((x) => idsSet.add(x.id));
+    const ids = [...idsSet].sort((a, b) => a - b);
+    ctx.addAffected(ids);
+
+    return ids;
+  });
+}
+
+export function executeRefresh(ctx: { pg: AugmentedPool; jobContext: JobContext }) {
+  return templateHandler(async (sql) => {
+    const query = await ctx.pg.cancellableQuery(sql);
+    ctx.jobContext.on('cancel', query.cancel);
+    await query.result();
+  });
+}
+
+function timeframeSum(
+  dateField: string,
+  value = '1',
+  additionalConditions = '',
+  timeframeAlias = 'tf'
+) {
+  const conditionCheck = additionalConditions ? `WHEN NOT (${additionalConditions}) THEN 0` : '';
+  additionalConditions =
+    additionalConditions && !additionalConditions.startsWith('AND')
+      ? `AND ${additionalConditions}`
+      : '';
+  return `
+    SUM(CASE
+      ${conditionCheck}
+      WHEN ${timeframeAlias}.timeframe = 'AllTime' THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Year' AND ${dateField} > (NOW() - interval '365 days') THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Month' AND ${dateField} > (NOW() - interval '30 days') THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Week' AND ${dateField} > (NOW() - interval '7 days') THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Day' AND ${dateField} > (NOW() - interval '1 days') THEN ${value}
+      ELSE 0
+    END)
+  `;
+}
+
+function timeframeCount(
+  dateField: string,
+  value: string,
+  additionalConditions = '',
+  timeframeAlias = 'tf'
+) {
+  const conditionCheck = additionalConditions ? `WHEN NOT (${additionalConditions}) THEN NULL` : '';
+  return `
+    COUNT(DISTINCT CASE
+      ${conditionCheck}
+      WHEN ${timeframeAlias}.timeframe = 'AllTime' THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Year' AND ${dateField} > (NOW() - interval '365 days') THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Month' AND ${dateField} > (NOW() - interval '30 days') THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Week' AND ${dateField} > (NOW() - interval '7 days') THEN ${value}
+      WHEN ${timeframeAlias}.timeframe = 'Day' AND ${dateField} > (NOW() - interval '1 days') THEN ${value}
+      ELSE NULL
+    END)
+  `;
+}
+
+function reactionTimeframe(
+  reaction: ReviewReactions,
+  reactionElementAlias = 'r',
+  timeframeAlias = 'tf'
+) {
+  return `
+    ${timeframeSum(
+      `${reactionElementAlias}."createdAt"`,
+      '1',
+      `${reactionElementAlias}.reaction = '${reaction}'`,
+      timeframeAlias
+    )} "${reaction.toLowerCase()}Count"
+  `;
+}
+
+function reactionTimeframes(reactionElementAlias = 'r', timeframeAlias = 'tf') {
+  return Object.keys(ReviewReactions)
+    .map((reaction) =>
+      reactionTimeframe(reaction as ReviewReactions, reactionElementAlias, timeframeAlias)
+    )
+    .join(',\n');
+}
+
+const reactionMetricNames = Object.keys(ReviewReactions)
+  .map((reaction) => `"${reaction.toLowerCase()}Count"`)
+  .join(', ');
+
+const reactionMetricUpserts = Object.keys(ReviewReactions)
+  .map((reaction) => `"${reaction.toLowerCase()}Count" = EXCLUDED."${reaction.toLowerCase()}Count"`)
+  .join(', ');
+
+export const snippets = {
+  reactionTimeframes,
+  timeframeSum,
+  timeframeCount,
+  reactionMetricNames,
+  reactionMetricUpserts,
+};

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -1,7 +1,8 @@
 import dayjs from 'dayjs';
 import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { modelsSearchIndex } from '~/server/search-index';
-import { Prisma, PrismaClient, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { chunk } from 'lodash-es';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -1,519 +1,243 @@
-import dayjs from 'dayjs';
 import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { modelsSearchIndex } from '~/server/search-index';
-import { Prisma, PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { chunk } from 'lodash-es';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { createLogger } from '~/utils/logging';
+import { templateHandler } from '~/server/db/pgDb';
+import { executeRefresh, snippets } from '~/server/metrics/metric-helpers';
+
+const log = createLogger('metrics:model');
+
+type ModelMetricContext = MetricProcessorRunContext & {
+  queuedModelVersions: number[];
+};
 
 export const modelMetrics = createMetricProcessor({
   name: 'Model',
-  async update(ctx) {
-    // If this is the first metric update of the day, recompute all recently affected metrics
-    // -------------------------------------------------------------------
-    const shouldFullRefresh = ctx.lastUpdate.getDate() !== new Date().getDate();
-    if (shouldFullRefresh) ctx.lastUpdate = dayjs(ctx.lastUpdate).subtract(1.5, 'day').toDate();
-
-    const updatedModelIds = new Set<number>();
-
-    for (const processor of modelMetricProcessors) {
-      ctx.jobContext.checkIfCanceled();
-      const processorUpdatedModelIds = await processor(ctx);
-      processorUpdatedModelIds.forEach((id) => updatedModelIds.add(id));
+  async update(ctxRaw) {
+    // Add the queued model versions to the context
+    //---------------------------------------
+    const ctx = ctxRaw as ModelMetricContext;
+    ctx.queuedModelVersions = [];
+    if (ctx.queue.length > 0) {
+      const queuedModelVersions = await ctx.db.$queryRaw<{ id: number }[]>`
+        SELECT id FROM "ModelVersion"
+        WHERE "modelId" IN (${Prisma.join(ctx.queue)})
+      `;
+      ctx.queuedModelVersions = queuedModelVersions.map((x) => x.id);
     }
 
-    if (updatedModelIds.size > 0) {
-      await modelsSearchIndex.queueUpdate(
-        [...updatedModelIds].map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
-      );
-    }
+    // Get the metric tasks
+    //---------------------------------------
+    const versionTasks = await Promise.all([
+      getDownloadTasks(ctx),
+      getGenerationTasks(ctx),
+      getVersionRatingTasks(ctx),
+    ]);
+    log('modelVersionMetrics update', versionTasks.flat().length, 'tasks');
+    for (const tasks of versionTasks) await limitConcurrency(tasks, 5);
+
+    const modelTasks = await Promise.all([
+      getModelRatingTasks(ctx),
+      getCommentTasks(ctx),
+      getCollectionTasks(ctx),
+      getBuzzTasks(ctx),
+      getVersionAggregationTasks(ctx),
+    ]);
+    log('modelMetrics update', modelTasks.flat().length, 'tasks');
+    for (const tasks of modelTasks) await limitConcurrency(tasks, 5);
+
+    // Update the search index
+    //---------------------------------------
+    log('update search index');
+    await modelsSearchIndex.queueUpdate(
+      [...ctx.affected].map((id) => ({
+        id,
+        action: SearchIndexUpdateQueueAction.Update,
+      }))
+    );
   },
   rank: {
-    async refresh(ctx) {
+    async refresh() {
       // Do nothing. Rank views are now not used.
     },
     refreshInterval: 60 * 1000,
   },
 });
 
-// #region [metrics]
-const modelMetricProcessors = [
-  updateVersionDownloadMetrics,
-  updateVersionGenerationMetrics,
-  updateVersionRatingMetrics,
-  updateModelRatingMetrics,
-  updateVersionCommentMetrics,
-  updateCollectMetrics,
-  updateTippedBuzzMetrics,
-  // updateVersionImageMetrics,
-  updateModelMetrics,
-];
+function getAffected(ctx: ModelMetricContext, type: 'Model' | 'ModelVersion') {
+  return templateHandler(async (sql) => {
+    const affectedQuery = await ctx.pg.cancellableQuery<{ id: number }>(sql);
+    ctx.jobContext.on('cancel', affectedQuery.cancel);
+    const affected = await affectedQuery.result();
+    const queue = type === 'Model' ? ctx.queue : ctx.queuedModelVersions;
+    const idsSet = new Set(queue);
+    affected.forEach((x) => idsSet.add(x.id));
+    const ids = [...idsSet].sort((a, b) => a - b);
+    if (type === 'Model') ctx.addAffected(ids);
 
-async function getModelIdFromVersions({
-  versionIds,
-  db,
-}: {
-  versionIds: Array<number>;
-  db: PrismaClient;
-}) {
-  const affectedModelIds: Set<number> = new Set();
-  const batches = chunk(versionIds, 500);
-  for (const batch of batches) {
-    const batchAffectedModels: Array<{ modelId: number }> =
-      await db.$queryRaw`SELECT "modelId" FROM "ModelVersion" WHERE "id" IN (${Prisma.join(
-        batch
-      )});`;
-
-    for (const { modelId } of batchAffectedModels) affectedModelIds.add(modelId);
-  }
-
-  return [...affectedModelIds];
-}
-
-async function updateVersionDownloadMetrics({
-  ch,
-  db,
-  jobContext,
-  lastUpdate,
-}: MetricProcessorRunContext) {
-  const clickhouseSince = dayjs(lastUpdate).toISOString();
-  const affectedVersionIdsResponse = await ch.query({
-    query: `
-      SELECT DISTINCT modelVersionId
-      FROM modelVersionEvents
-      WHERE type = 'Download'
-      AND time >= parseDateTimeBestEffortOrNull('${clickhouseSince}')
-    `,
-    format: 'JSONEachRow',
+    return ids;
   });
-  const versionIds = (
-    (await affectedVersionIdsResponse?.json()) as [
-      {
-        modelVersionId: number;
-      }
-    ]
-  ).map((x) => x.modelVersionId);
-
-  const batches = chunk(versionIds, 5000);
-  let rows = 0;
-  for (const batch of batches) {
-    try {
-      const affectedModelVersionsResponse = await ch.query({
-        query: `
-          SELECT
-            modelVersionId,
-            uniqMergeIf(users_state, createdDate = current_date()) day,
-            uniqMergeIf(users_state, createdDate >= subtractDays(current_date(),7)) week,
-            uniqMergeIf(users_state, createdDate >= subtractMonths(current_date(),1)) month,
-            uniqMergeIf(users_state, createdDate >= subtractYears(current_date(),1)) year,
-            uniqMerge(users_state) all_time
-          FROM daily_downloads_unique
-          WHERE modelVersionId IN (${batch.join(',')})
-          GROUP BY 1
-        `,
-        format: 'JSONEachRow',
-      });
-
-      const affectedModelVersions = (await affectedModelVersionsResponse?.json()) as [
-        {
-          modelVersionId: number;
-          day: string;
-          week: string;
-          month: string;
-          year: string;
-          all_time: string;
-        }
-      ];
-
-      // We batch the affected model versions up when sending it to the db
-      const batches = chunk(affectedModelVersions, 1000);
-      for (const batch of batches) {
-        jobContext.checkIfCanceled();
-        const batchJson = JSON.stringify(batch);
-
-        rows += await db.$executeRaw`
-          -- update version download metrics
-          INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "downloadCount")
-          SELECT
-              mvm.modelVersionId, mvm.timeframe, mvm.downloads
-          FROM
-          (
-              SELECT
-                  CAST(mvs::json->>'modelVersionId' AS INT) AS modelVersionId,
-                  tf.timeframe,
-                  CAST(
-                    CASE
-                      WHEN tf.timeframe = 'Day' THEN mvs::json->>'day'
-                      WHEN tf.timeframe = 'Week' THEN mvs::json->>'week'
-                      WHEN tf.timeframe = 'Month' THEN mvs::json->>'month'
-                      WHEN tf.timeframe = 'Year' THEN mvs::json->>'year'
-                      WHEN tf.timeframe = 'AllTime' THEN mvs::json->>'all_time'
-                    END
-                  AS int) as downloads
-              FROM json_array_elements(${batchJson}::json) mvs
-              CROSS JOIN (
-                  SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-              ) tf
-          ) mvm
-          WHERE mvm.downloads IS NOT NULL
-          AND mvm.modelVersionId IN (SELECT id FROM "ModelVersion")
-          ON CONFLICT ("modelVersionId", timeframe) DO UPDATE
-            SET "downloadCount" = EXCLUDED."downloadCount", "updatedAt" = now();
-        `;
-      }
-    } catch (e) {
-      throw e;
-    }
-  }
-  console.log('downloads', rows);
-
-  if (versionIds.length > 0) {
-    // Get affected models from version IDs:
-    return getModelIdFromVersions({ versionIds, db });
-  }
-
-  return [];
 }
 
-async function updateVersionGenerationMetrics({
-  ch,
-  db,
-  lastUpdate,
-  jobContext,
-}: MetricProcessorRunContext) {
-  const clickhouseSince = dayjs(lastUpdate).toISOString();
-  const affectedVersionIdsResponse = await ch.query({
-    query: `
-      SELECT DISTINCT modelVersionId
-      FROM  (
+type ModelVersionDownload = {
+  modelVersionId: number;
+  day: number;
+  week: number;
+  month: number;
+  year: number;
+  all_time: number;
+};
+async function getDownloadTasks(ctx: ModelMetricContext) {
+  const downloaded = await ctx.ch.$query<{ modelVersionId: number }>`
+    SELECT DISTINCT modelVersionId
+    FROM modelVersionEvents
+    WHERE type = 'Download'
+    AND time >= parseDateTimeBestEffortOrNull('${ctx.lastUpdate}');
+  `;
+  const affected = downloaded.map((x) => x.modelVersionId);
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getDownloadTasks', i + 1, 'of', tasks.length);
+    const downloads = await ctx.ch.$query<ModelVersionDownload>`
+      SELECT
+        modelVersionId,
+        uniqMergeIf(users_state, createdDate = current_date()) day,
+        uniqMergeIf(users_state, createdDate >= subtractDays(current_date(),7)) week,
+        uniqMergeIf(users_state, createdDate >= subtractMonths(current_date(),1)) month,
+        uniqMergeIf(users_state, createdDate >= subtractYears(current_date(),1)) year,
+        uniqMerge(users_state) all_time
+      FROM daily_downloads_unique
+      WHERE modelVersionId IN (${affected})
+      GROUP BY modelVersionId;
+    `;
+
+    ctx.jobContext.checkIfCanceled();
+    const downloadsJson = JSON.stringify(downloads);
+    await executeRefresh(ctx)`
+      INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "downloadCount")
+      SELECT
+          mvm.modelVersionId, mvm.timeframe, mvm.downloads
+      FROM
+      (
         SELECT
-          arrayJoin(resourcesUsed) as modelVersionId
-        FROM orchestration.textToImageJobs
-        WHERE createdAt >= parseDateTimeBestEffortOrNull('${clickhouseSince}')
-      )
-    `,
-    format: 'JSONEachRow',
-  });
-  const versionIds = (
-    (await affectedVersionIdsResponse?.json()) as [
-      {
-        modelVersionId: number;
-      }
-    ]
-  ).map((x) => x.modelVersionId);
-
-  const batches = chunk(versionIds, 5000);
-  let rows = 0;
-  for (const batch of batches) {
-    jobContext.checkIfCanceled();
-    try {
-      const affectedModelVersionsResponse = await ch.query({
-        query: `
-          SELECT
-              modelVersionId,
-              sumIf(count, createdDate = current_date()) day,
-              sumIf(count, createdDate >= subtractDays(current_date(), 7)) week,
-              sumIf(count, createdDate >= subtractMonths(current_date(), 1)) month,
-              sumIf(count, createdDate >= subtractYears(current_date(), 1)) year,
-              sum(count) all_time
-          FROM daily_resource_generation_counts
-          WHERE modelVersionId IN (${batch.join(',')})
-          GROUP BY modelVersionId
-        `,
-        format: 'JSONEachRow',
-      });
-
-      const affectedModelVersions = (await affectedModelVersionsResponse?.json()) as [
-        {
-          modelVersionId: number;
-          day: string;
-          week: string;
-          month: string;
-          year: string;
-          all_time: string;
-        }
-      ];
-
-      // We batch the affected model versions up when sending it to the db
-      const batches = chunk(affectedModelVersions, 1000);
-      for (const batch of batches) {
-        const batchJson = JSON.stringify(batch);
-
-        rows += await db.$executeRaw`
-          -- update version generation metrics
-          INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "generationCount")
-          SELECT
-              mvm.modelVersionId, mvm.timeframe, mvm.generations
-          FROM
-          (
-              SELECT
-                  CAST(mvs::json->>'modelVersionId' AS INT) AS modelVersionId,
-                  tf.timeframe,
-                  CAST(
-                    CASE
-                      WHEN tf.timeframe = 'Day' THEN mvs::json->>'day'
-                      WHEN tf.timeframe = 'Week' THEN mvs::json->>'week'
-                      WHEN tf.timeframe = 'Month' THEN mvs::json->>'month'
-                      WHEN tf.timeframe = 'Year' THEN mvs::json->>'year'
-                      WHEN tf.timeframe = 'AllTime' THEN mvs::json->>'all_time'
-                    END
-                  AS int) as generations
-              FROM json_array_elements(${batchJson}::json) mvs
-              CROSS JOIN (
-                  SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-              ) tf
-          ) mvm
-          WHERE mvm.generations IS NOT NULL
-          AND mvm.modelVersionId IN (SELECT id FROM "ModelVersion")
-          ON CONFLICT ("modelVersionId", timeframe) DO UPDATE
-            SET "generationCount" = EXCLUDED."generationCount", "updatedAt" = now();
-        `;
-      }
-    } catch (e) {
-      throw e;
-    }
-  }
-  console.log('generations', rows);
-
-  if (versionIds.length > 0) {
-    // Get affected models from version IDs:
-    return getModelIdFromVersions({ versionIds, db });
-  }
-
-  return [];
-}
-
-async function updateVersionRatingMetrics({
-  ch,
-  db,
-  lastUpdate,
-  jobContext,
-}: MetricProcessorRunContext) {
-  // Disabled clickhouse as it seems to be missing resource reviews somehow...
-  // const clickhouseSince = dayjs(lastUpdate).toISOString();
-  // const affectedModelVersionsResponse = await ch.query({
-  //   query: `
-  //     SELECT DISTINCT modelVersionId
-  //     FROM resourceReviews
-  //     WHERE time >= parseDateTimeBestEffortOrNull('${clickhouseSince}')
-  //   `,
-  //   format: 'JSONEachRow',
-  // });
-  // const affectedModelVersionsClickhouse = (await affectedModelVersionsResponse?.json()) as [
-  //   {
-  //     modelVersionId: number;
-  //   }
-  // ];
-  const modelVersionIds = new Set<number>();
-
-  const affectedModelVersionsDb = await db.$queryRaw<{ modelVersionId: number }[]>`
-    SELECT DISTINCT "modelVersionId"
-    FROM "ResourceReview"
-    WHERE "createdAt" > ${lastUpdate} OR "updatedAt" > ${lastUpdate}
-  `;
-  affectedModelVersionsDb.forEach(({ modelVersionId }) => modelVersionIds.add(modelVersionId));
-
-  const batches = chunk([...modelVersionIds], 500);
-  let rows = 0;
-  for (const batch of batches) {
-    jobContext.checkIfCanceled();
-    rows += await db.$executeRaw`
-      -- update version rating metrics
-      INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "thumbsUpCount", "thumbsDownCount")
-      SELECT
-        r."modelVersionId",
-        tf.timeframe,
-        COUNT(DISTINCT CASE
-          WHEN NOT recommended THEN NULL
-          WHEN timeframe = 'AllTime' THEN r."userId"
-          WHEN timeframe = 'Year' AND r."createdAt" > NOW() - interval '1 year' THEN r."userId"
-          WHEN timeframe = 'Month' AND r."createdAt" > NOW() - interval '1 month' THEN r."userId"
-          WHEN timeframe = 'Week' AND r."createdAt" > NOW() - interval '1 week' THEN r."userId"
-          WHEN timeframe = 'Day' AND r."createdAt" > NOW() - interval '1 day' THEN r."userId"
-        END) "thumbsUpCount",
-        COUNT(DISTINCT CASE
-          WHEN recommended THEN NULL
-          WHEN timeframe = 'AllTime' THEN r."userId"
-          WHEN timeframe = 'Year' AND r."createdAt" > NOW() - interval '1 year' THEN r."userId"
-          WHEN timeframe = 'Month' AND r."createdAt" > NOW() - interval '1 month' THEN r."userId"
-          WHEN timeframe = 'Week' AND r."createdAt" > NOW() - interval '1 week' THEN r."userId"
-          WHEN timeframe = 'Day' AND r."createdAt" > NOW() - interval '1 day' THEN r."userId"
-        END) "thumbsDownCount"
-      FROM "ResourceReview" r
-      CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
-      WHERE r.exclude = FALSE
-      AND r."tosViolation" = FALSE
-      AND r."modelVersionId" IN (${Prisma.join(batch)})
-      GROUP BY r."modelVersionId", tf.timeframe
-      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE SET "thumbsUpCount" = EXCLUDED."thumbsUpCount", "thumbsDownCount" = EXCLUDED."thumbsDownCount", "updatedAt" = now();
-    `;
-  }
-  console.log('ratings', rows);
-
-  if (modelVersionIds.size > 0) {
-    // Get affected models from version IDs:
-    return getModelIdFromVersions({ versionIds: [...modelVersionIds], db });
-  }
-
-  return [];
-}
-
-async function updateModelRatingMetrics({ db, lastUpdate, jobContext }: MetricProcessorRunContext) {
-  const modelIdSet = new Set<number>();
-
-  const affectedModelVersionsDb = await db.$queryRaw<{ modelId: number }[]>`
-    SELECT DISTINCT "modelId"
-    FROM "ResourceReview"
-    WHERE "createdAt" > ${lastUpdate} OR "updatedAt" > ${lastUpdate}
-  `;
-  affectedModelVersionsDb.forEach(({ modelId }) => modelIdSet.add(modelId));
-
-  let rows = 0;
-  const modelIds = [...modelIdSet];
-  const tasks = chunk(modelIds, 500).map((batch) => async () => {
-    jobContext.checkIfCanceled();
-    rows += await db.$executeRaw`
-      -- Migrate model thumbs up metrics
-      INSERT INTO "ModelMetric" ("modelId", timeframe, "thumbsUpCount", "thumbsDownCount")
-      SELECT
-        r."modelId",
-        tf.timeframe,
-        COUNT(DISTINCT CASE
-          WHEN NOT recommended THEN NULL
-          WHEN timeframe = 'Year' AND r."createdAt" > NOW() - interval '1 year' THEN r."userId"
-          WHEN timeframe = 'Month' AND r."createdAt" > NOW() - interval '1 month' THEN r."userId"
-          WHEN timeframe = 'Week' AND r."createdAt" > NOW() - interval '1 week' THEN r."userId"
-          WHEN timeframe = 'Day' AND r."createdAt" > NOW() - interval '1 day' THEN r."userId"
-          WHEN timeframe = 'AllTime' THEN r."userId"
-        END) "thumbsUpCount",
-        COUNT(DISTINCT CASE
-          WHEN recommended THEN NULL
-          WHEN timeframe = 'Year' AND r."createdAt" > NOW() - interval '1 year' THEN r."userId"
-          WHEN timeframe = 'Month' AND r."createdAt" > NOW() - interval '1 month' THEN r."userId"
-          WHEN timeframe = 'Week' AND r."createdAt" > NOW() - interval '1 week' THEN r."userId"
-          WHEN timeframe = 'Day' AND r."createdAt" > NOW() - interval '1 day' THEN r."userId"
-          WHEN timeframe = 'AllTime' THEN r."userId"
-        END) "thumbsDownCount"
-      FROM "ResourceReview" r
-      CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
-      WHERE r.exclude = FALSE
-      AND r."tosViolation" = FALSE
-      AND r."modelId" IN (${Prisma.join(batch)})
-      GROUP BY r."modelId", tf.timeframe
-      ON CONFLICT ("modelId", timeframe) DO UPDATE SET
-        "thumbsUpCount" = EXCLUDED."thumbsUpCount",
-        "thumbsDownCount" = EXCLUDED."thumbsDownCount",
-        "updatedAt" = now();
-    `;
-  });
-
-  await limitConcurrency(tasks, 3);
-  console.log('model ratings', rows);
-
-  return modelIds;
-}
-
-async function updateVersionCommentMetrics({
-  ch,
-  db,
-  lastUpdate,
-  jobContext,
-}: MetricProcessorRunContext) {
-  const clickhouseSince = dayjs(lastUpdate).toISOString();
-  const affectedModelsResponse = await ch.query({
-    query: `
-      SELECT DISTINCT entityId AS modelId
-      FROM comments
-      WHERE time >= parseDateTimeBestEffortOrNull('${clickhouseSince}')
-      AND type = 'Model'
-    `,
-    format: 'JSONEachRow',
-  });
-
-  const affectedModels = (await affectedModelsResponse?.json()) as [
-    {
-      modelId: number;
-    }
-  ];
-
-  const modelIds = affectedModels.map((x) => x.modelId);
-  const batches = chunk(modelIds, 500);
-  let rows = 0;
-  for (const batch of batches) {
-    jobContext.checkIfCanceled();
-    const batchJson = JSON.stringify(batch);
-
-    rows += await db.$executeRaw`
-      -- update version comment metrics
-      INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "commentCount")
-      SELECT
-          mv."id",
+          CAST(mvs::json->>'modelVersionId' AS INT) AS modelVersionId,
           tf.timeframe,
-          COALESCE(SUM(
-              CASE
-                  WHEN tf.timeframe = 'AllTime' THEN 1
-                  WHEN tf.timeframe = 'Year' THEN IIF(c."createdAt" >= NOW() - interval '1 year', 1, 0)
-                  WHEN tf.timeframe = 'Month' THEN IIF(c."createdAt" >= NOW() - interval '1 month', 1, 0)
-                  WHEN tf.timeframe = 'Week' THEN IIF(c."createdAt" >= NOW() - interval '1 week', 1, 0)
-                  WHEN tf.timeframe = 'Day' THEN IIF(c."createdAt" >= NOW() - interval '1 day', 1, 0)
-              END
-          ), 0)
-      FROM (
-          SELECT
-              c."modelId",
-              c."createdAt"
-          FROM "Comment" c
-          WHERE c."tosViolation" = false
-          AND c."modelId" = ANY (SELECT json_array_elements(${batchJson}::json)::text::integer)
-      ) c
-      JOIN "ModelVersion" mv ON c."modelId" = mv."modelId"
-      CROSS JOIN (
-        SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-      ) tf
-      GROUP BY mv.id, tf.timeframe
-      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE SET "commentCount" = EXCLUDED."commentCount", "updatedAt" = now();
+          CAST(
+            CASE
+              WHEN tf.timeframe = 'Day' THEN mvs::json->>'day'
+              WHEN tf.timeframe = 'Week' THEN mvs::json->>'week'
+              WHEN tf.timeframe = 'Month' THEN mvs::json->>'month'
+              WHEN tf.timeframe = 'Year' THEN mvs::json->>'year'
+              WHEN tf.timeframe = 'AllTime' THEN mvs::json->>'all_time'
+            END
+          AS int) as downloads
+        FROM json_array_elements('${downloadsJson}'::json) mvs
+        CROSS JOIN (
+            SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
+        ) tf
+      ) mvm
+      WHERE mvm.downloads IS NOT NULL
+      AND mvm.modelVersionId IN (SELECT id FROM "ModelVersion")
+      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE
+        SET "downloadCount" = EXCLUDED."downloadCount", "updatedAt" = now();
     `;
-  }
-  console.log('comments', rows);
 
-  return modelIds;
+    log('getDownloadTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
 }
 
-async function updateVersionImageMetrics({
-  db,
-  lastUpdate,
-  jobContext,
-}: MetricProcessorRunContext) {
-  const affected = await db.$queryRaw<{ modelVersionId: number }[]>`
+async function getGenerationTasks(ctx: ModelMetricContext) {
+  const generated = await ctx.ch.$query<{ modelVersionId: number }>`
+    SELECT DISTINCT modelVersionId
+    FROM  (
+      SELECT
+        arrayJoin(resourcesUsed) as modelVersionId
+      FROM orchestration.textToImageJobs
+      WHERE createdAt >= parseDateTimeBestEffortOrNull('${ctx.lastUpdate}')
+    )
+  `;
+  const affected = generated.map((x) => x.modelVersionId);
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getGenerationTasks', i + 1, 'of', tasks.length);
+    const generations = await ctx.ch.$query<{ modelVersionId: number; count: number }>`
+      SELECT
+          modelVersionId,
+          sumIf(count, createdDate = current_date()) day,
+          sumIf(count, createdDate >= subtractDays(current_date(), 7)) week,
+          sumIf(count, createdDate >= subtractMonths(current_date(), 1)) month,
+          sumIf(count, createdDate >= subtractYears(current_date(), 1)) year,
+          sum(count) all_time
+      FROM daily_resource_generation_counts
+      WHERE modelVersionId IN (${ids})
+      GROUP BY modelVersionId;
+    `;
+
+    ctx.jobContext.checkIfCanceled();
+    const generationsJson = JSON.stringify(generations);
+    await executeRefresh(ctx)`
+      INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "generationCount")
+      SELECT
+          mvm.modelVersionId, mvm.timeframe, mvm.generations
+      FROM
+      (
+          SELECT
+              CAST(mvs::json->>'modelVersionId' AS INT) AS modelVersionId,
+              tf.timeframe,
+              CAST(
+                CASE
+                  WHEN tf.timeframe = 'Day' THEN mvs::json->>'day'
+                  WHEN tf.timeframe = 'Week' THEN mvs::json->>'week'
+                  WHEN tf.timeframe = 'Month' THEN mvs::json->>'month'
+                  WHEN tf.timeframe = 'Year' THEN mvs::json->>'year'
+                  WHEN tf.timeframe = 'AllTime' THEN mvs::json->>'all_time'
+                END
+              AS int) as generations
+          FROM json_array_elements('${generationsJson}'::json) mvs
+          CROSS JOIN (
+              SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
+          ) tf
+      ) mvm
+      WHERE mvm.generations IS NOT NULL
+      AND mvm.modelVersionId IN (SELECT id FROM "ModelVersion")
+      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE
+        SET "generationCount" = EXCLUDED."generationCount", "updatedAt" = now();
+    `;
+
+    log('getGenerationTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getImageTasks(ctx: ModelMetricContext) {
+  const affected = await getAffected(ctx, 'ModelVersion')`
+    -- Get recent model image uploads
     SELECT DISTINCT
-      ir."modelVersionId"
+      ir."modelVersionId" as id
     FROM "Image" i
     JOIN "ImageResource" ir ON ir."imageId" = i.id AND ir."modelVersionId" IS NOT NULL
     JOIN "Post" p ON i."postId" = p.id
-    WHERE p."publishedAt" < now() AND p."publishedAt" > ${lastUpdate};
+    WHERE p."publishedAt" BETWEEN '${ctx.lastUpdate}' AND now();
   `;
 
-  const versionIds = affected.map((x) => x.modelVersionId);
-
-  const batches = chunk(versionIds, 500);
-  let rows = 0;
-  for (const batch of batches) {
-    jobContext.checkIfCanceled();
-    rows += await db.$executeRaw`
-      -- update version image metrics
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getImageTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update model image metrics
       INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "imageCount")
       SELECT
-          i."modelVersionId",
-          tf.timeframe,
-          COALESCE(SUM(
-            CASE
-              WHEN tf.timeframe = 'AllTime' THEN 1
-              WHEN tf.timeframe = 'Year' THEN IIF(i."publishedAt" >= NOW() - interval '1 year', 1, 0)
-              WHEN tf.timeframe = 'Month' THEN IIF(i."publishedAt" >= NOW() - interval '1 month', 1, 0)
-              WHEN tf.timeframe = 'Week' THEN IIF(i."publishedAt" >= NOW() - interval '1 week', 1, 0)
-              WHEN tf.timeframe = 'Day' THEN IIF(i."publishedAt" >= NOW() - interval '1 day', 1, 0)
-            END
-          ), 0)
+        "modelVersionId",
+        timeframe,
+        ${snippets.timeframeSum('i."publishedAt"')} "imageCount"
       FROM (
         SELECT
           ir."modelVersionId",
@@ -524,161 +248,224 @@ async function updateVersionImageMetrics({
         JOIN "Image" i ON i.id = ir."imageId" AND m."userId" != i."userId"
         JOIN "Post" p ON i."postId" = p.id AND p."publishedAt" IS NOT NULL AND p."publishedAt" < now()
         WHERE
-          mv.id IN (${Prisma.join(batch)}
+          mv.id IN (${ids})
       ) i
-      CROSS JOIN (
-        SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-      ) tf
-      GROUP BY i."modelVersionId", tf.timeframe
-      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE SET "imageCount" = EXCLUDED."imageCount", "updatedAt" = now();
+      CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
+      GROUP BY "modelVersionId", timeframe
+      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE
+        SET "imageCount" = EXCLUDED."imageCount", "updatedAt" = now();
     `;
-  }
-  console.log('images', rows);
+    log('getImageTasks', i + 1, 'of', tasks.length, 'done');
+  });
 
-  return getModelIdFromVersions({ versionIds, db });
+  return tasks;
 }
 
-async function updateCollectMetrics({ db, lastUpdate, jobContext }: MetricProcessorRunContext) {
-  const affected = await db.$queryRaw<{ modelId: number }[]>`
-    SELECT DISTINCT
-      "modelId"
-    FROM "CollectionItem"
-    WHERE "modelId" IS NOT NULL AND "createdAt" > ${lastUpdate};
+async function getVersionRatingTasks(ctx: ModelMetricContext) {
+  const affected = await getAffected(ctx, 'ModelVersion')`
+    -- get recent version reviews
+    SELECT "modelVersionId" as id
+    FROM "ResourceReview"
+    WHERE "createdAt" > '${ctx.lastUpdate}' OR "updatedAt" > '${ctx.lastUpdate}'
   `;
 
-  const modelIds = affected.map((x) => x.modelId);
-  console.log('collects', modelIds.length);
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getRatingTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update version rating metrics
+      INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "thumbsUpCount", "thumbsDownCount")
+      SELECT
+        r."modelVersionId",
+        tf.timeframe,
+        ${snippets.timeframeCount('r."createdAt"', 'r."userId"', 'recommended')} "thumbsUpCount",
+        ${snippets.timeframeCount(
+          'r."createdAt"',
+          'r."userId"',
+          'NOT recommended'
+        )} "thumbsDownCount"
+      FROM "ResourceReview" r
+      CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
+      WHERE r.exclude = FALSE
+        AND r."tosViolation" = FALSE
+        AND r."modelVersionId" IN (${ids})
+      GROUP BY r."modelVersionId", tf.timeframe
+      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE
+        SET "thumbsUpCount" = EXCLUDED."thumbsUpCount", "thumbsDownCount" = EXCLUDED."thumbsDownCount", "updatedAt" = now();
+    `;
+    log('getRatingTasks', i + 1, 'of', tasks.length, 'done');
+  });
 
-  const batches = chunk(modelIds, 500);
-  let rows = 0;
-  for (const batch of batches) {
-    jobContext.checkIfCanceled();
+  return tasks;
+}
 
-    rows += await db.$executeRaw`
+async function getModelRatingTasks(ctx: ModelMetricContext) {
+  const affected = await getAffected(ctx, 'Model')`
+    -- Get recent model reviews
+    SELECT "modelId" as id
+    FROM "ResourceReview"
+    WHERE "createdAt" > '${ctx.lastUpdate}' OR "updatedAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getRatingTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update model rating metrics
+      INSERT INTO "ModelMetric" ("modelId", timeframe, "thumbsUpCount", "thumbsDownCount")
+      SELECT
+        r."modelId",
+        tf.timeframe,
+        ${snippets.timeframeCount('r."createdAt"', 'r."userId"', 'recommended')} "thumbsUpCount",
+        ${snippets.timeframeCount(
+          'r."createdAt"',
+          'r."userId"',
+          'NOT recommended'
+        )} "thumbsDownCount"
+      FROM "ResourceReview" r
+      CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
+      WHERE r.exclude = FALSE
+        AND r."tosViolation" = FALSE
+        AND r."modelId" IN (${ids})
+      GROUP BY r."modelId", tf.timeframe
+      ON CONFLICT ("modelId", timeframe) DO UPDATE
+        SET "thumbsUpCount" = EXCLUDED."thumbsUpCount", "thumbsDownCount" = EXCLUDED."thumbsDownCount", "updatedAt" = now();
+    `;
+    log('getRatingTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getCommentTasks(ctx: ModelMetricContext) {
+  const commentEvents = await ctx.ch.$query<{ modelId: number }>`
+    SELECT DISTINCT entityId AS modelId
+    FROM comments
+    WHERE time >= parseDateTimeBestEffortOrNull('${ctx.lastUpdate}')
+    AND type = 'Model'
+  `;
+  const affected = [...new Set([...commentEvents.map((x) => x.modelId), ...ctx.queue])];
+  ctx.addAffected(affected);
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getCommentTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update model comment metrics
+      INSERT INTO "ModelMetric" ("modelId", timeframe, "commentCount")
+      SELECT
+          c."modelId",
+          tf.timeframe,
+          ${snippets.timeframeCount('c."createdAt"', 'c."userId"')} "commentCount"
+      FROM "Comment" c
+      CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
+      WHERE c."tosViolation" = false
+        AND c."modelId" IN (${ids})
+      GROUP BY mv.id, tf.timeframe
+      ON CONFLICT ("modelId", timeframe) DO UPDATE
+        SET "commentCount" = EXCLUDED."commentCount", "updatedAt" = now();
+    `;
+    log('getCommentTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getCollectionTasks(ctx: ModelMetricContext) {
+  const affected = await getAffected(ctx, 'Model')`
+    -- Get recent model collects
+    SELECT "modelId" as id
+    FROM "CollectionItem"
+    WHERE "modelId" IS NOT NULL AND "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getCollectionTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
       -- update model collect metrics
       INSERT INTO "ModelMetric" ("modelId", timeframe, "collectedCount")
       SELECT
         "modelId",
         timeframe,
-        COUNT(DISTINCT CASE
-          WHEN timeframe = 'AllTime' THEN c."addedById"
-          WHEN timeframe = 'Year' AND c."createdAt" > NOW() - interval '1 year' THEN c."addedById"
-          WHEN timeframe = 'Month' AND c."createdAt" > NOW() - interval '1 month' THEN c."addedById"
-          WHEN timeframe = 'Week' AND c."createdAt" > NOW() - interval '1 week' THEN c."addedById"
-          WHEN timeframe = 'Day' AND c."createdAt" > NOW() - interval '1 day' THEN c."addedById"
-        END) as "collectedCount"
+        ${snippets.timeframeCount('c."createdAt"', 'c."addedById"')} "collectedCount"
       FROM "CollectionItem" c
       CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
-      WHERE c."modelId" IN (${Prisma.join(batch)})
+      WHERE c."modelId" IN (${ids})
       GROUP BY "modelId", timeframe
-      ON CONFLICT ("modelId", timeframe) DO UPDATE SET "collectedCount" = EXCLUDED."collectedCount", "updatedAt" = now();
+      ON CONFLICT ("modelId", timeframe) DO UPDATE
+        SET "collectedCount" = EXCLUDED."collectedCount", "updatedAt" = now();
     `;
-  }
-  console.log('collects', rows);
+    log('getCollectionTasks', i + 1, 'of', tasks.length, 'done');
+  });
 
-  return modelIds;
+  return tasks;
 }
 
-async function updateTippedBuzzMetrics({ db, lastUpdate, jobContext }: MetricProcessorRunContext) {
-  const affected = await db.$queryRaw<{ modelId: number }[]>`
-    SELECT bt."entityId" as "modelId"
-    FROM "BuzzTip" bt
-    WHERE bt."entityId" IS NOT NULL AND bt."entityType" = 'Model'
-      AND (bt."createdAt" > ${lastUpdate} OR bt."updatedAt" > ${lastUpdate})
+async function getBuzzTasks(ctx: ModelMetricContext) {
+  const affected = await getAffected(ctx, 'Model')`
+    -- Get recent model tips
+    SELECT "entityId" as id
+    FROM "BuzzTip"
+    WHERE "entityId" IS NOT NULL AND "entityType" = 'Model'
+      AND ("createdAt" > '${ctx.lastUpdate}' OR "updatedAt" > '${ctx.lastUpdate}')
   `;
 
-  const modelIds = affected.map((x) => x.modelId);
-  console.log('tipped', modelIds.length);
-
-  const batches = chunk(modelIds, 1000);
-  let rows = 0;
-  for (const batch of batches) {
-    jobContext.checkIfCanceled();
-    const batchJson = JSON.stringify(batch);
-
-    rows += await db.$executeRaw`
-      -- update version buzz metrics
-      INSERT INTO "ModelVersionMetric" ("modelVersionId", timeframe, "tippedCount", "tippedAmountCount")
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getBuzzTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update model tip metrics
+      INSERT INTO "ModelMetric" ("modelId", timeframe, "tippedCount", "tippedAmountCount")
       SELECT
-        mv."id",
+        "entityId" as "modelId",
         tf.timeframe,
-        COALESCE(SUM(
-          CASE
-            WHEN tf.timeframe = 'AllTime' THEN 1
-            WHEN tf.timeframe = 'Year' THEN IIF(i."updatedAt" >= NOW() - interval '1 year', 1, 0)
-            WHEN tf.timeframe = 'Month' THEN IIF(i."updatedAt" >= NOW() - interval '1 month', 1, 0)
-            WHEN tf.timeframe = 'Week' THEN IIF(i."updatedAt" >= NOW() - interval '1 week', 1, 0)
-            WHEN tf.timeframe = 'Day' THEN IIF(i."updatedAt" >= NOW() - interval '1 day', 1, 0)
-          END
-        ), 0),
-        COALESCE(SUM(
-          CASE
-            WHEN tf.timeframe = 'AllTime' THEN i."amount"
-            WHEN tf.timeframe = 'Year' THEN IIF(i."updatedAt" >= NOW() - interval '1 year', i."amount", 0)
-            WHEN tf.timeframe = 'Month' THEN IIF(i."updatedAt" >= NOW() - interval '1 month', i."amount", 0)
-            WHEN tf.timeframe = 'Week' THEN IIF(i."updatedAt" >= NOW() - interval '1 week', i."amount", 0)
-            WHEN tf.timeframe = 'Day' THEN IIF(i."updatedAt" >= NOW() - interval '1 day', i."amount", 0)
-          END
-        ), 0)
-      FROM (
-        SELECT
-          "entityId" as "modelId",
-          bt."updatedAt",
-          bt."amount"
-        FROM "BuzzTip" bt
-        JOIN "Model" m ON m.id = bt."entityId"
-        WHERE bt."entityType" = 'Model' AND bt."entityId" IS NOT NULL
-            AND bt."entityId" = ANY (SELECT json_array_elements(${batchJson}::json)::text::integer)
-       ) i
-      JOIN "ModelVersion" mv ON mv."modelId" = i."modelId"
-      CROSS JOIN (
-        SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-      ) tf
-      GROUP BY mv."id", tf.timeframe
-      ON CONFLICT ("modelVersionId", timeframe) DO UPDATE SET "tippedCount" = EXCLUDED."tippedCount", "tippedAmountCount" = EXCLUDED."tippedAmountCount", "updatedAt" = now();
+        ${snippets.timeframeCount('bt."updatedAt"', 'bt."amount"')} "tippedCount",
+        ${snippets.timeframeSum('bt."updatedAt"', 'bt."amount"')} "tippedAmountCount"
+      FROM "BuzzTip" bt
+      CROSS JOIN ( SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe ) tf
+      WHERE bt."entityType" = 'Model' AND bt."entityId" IS NOT NULL
+        AND bt."entityId" IN (${ids})
+      GROUP BY "entityId", tf.timeframe
+      ON CONFLICT ("modelId", timeframe) DO UPDATE
+        SET "tippedCount" = EXCLUDED."tippedCount", "tippedAmountCount" = EXCLUDED."tippedAmountCount", "updatedAt" = now();
     `;
-  }
-  console.log('tipped', rows);
+    log('getBuzzTasks', i + 1, 'of', tasks.length, 'done');
+  });
 
-  return modelIds;
+  return tasks;
 }
 
-async function updateModelMetrics({ pg, lastUpdate, jobContext }: MetricProcessorRunContext) {
-  const rowsQuery = await pg.cancellableQuery(Prisma.sql`
-    INSERT INTO "ModelMetric" ("modelId", timeframe, "downloadCount", "commentCount", "imageCount", "tippedCount", "tippedAmountCount", "generationCount", "updatedAt")
-    WITH affected AS (
-      SELECT DISTINCT mv."modelId"
+async function getVersionAggregationTasks(ctx: ModelMetricContext) {
+  const affected = await getAffected(ctx, 'Model')`
+    SELECT mv."modelId" as id
+    FROM "ModelVersionMetric" mvm
+    JOIN "ModelVersion" mv ON mv.id = mvm."modelVersionId"
+    WHERE mvm."updatedAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getModelTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- Migrate model thumbs up metrics
+      INSERT INTO "ModelMetric" ("modelId", timeframe, "downloadCount", "imageCount", "generationCount", "updatedAt")
+      SELECT
+        mv."modelId",
+        mvm.timeframe,
+        SUM(mvm."downloadCount") "downloadCount",
+        SUM(mvm."imageCount") "imageCount",
+        SUM(mvm."generationCount") "generationCount",
+        now() "updatedAt"
       FROM "ModelVersionMetric" mvm
       JOIN "ModelVersion" mv ON mv.id = mvm."modelVersionId"
-      WHERE mvm."updatedAt" > ${lastUpdate}
-    )
-    SELECT
-      mv."modelId",
-      mvm.timeframe,
-      SUM(mvm."downloadCount") "downloadCount",
-      MAX(mvm."commentCount") "commentCount",
-      SUM(mvm."imageCount") "imageCount",
-      MAX(mvm."tippedCount") "tippedCount",
-      MAX(mvm."tippedAmountCount") "tippedAmountCount",
-      SUM(mvm."generationCount") "generationCount",
-      NOW() "updatedAt"
-    FROM "ModelVersionMetric" mvm
-    JOIN "ModelVersion" mv ON mvm."modelVersionId" = mv.id
-    WHERE mv."modelId" IN (SELECT "modelId" FROM affected)
-    GROUP BY mv."modelId", mvm.timeframe
-    ON CONFLICT ("modelId", timeframe) DO UPDATE SET
-      "downloadCount" = EXCLUDED."downloadCount",
-      "commentCount" = EXCLUDED."commentCount",
-      "imageCount" = EXCLUDED."imageCount",
-      "tippedCount" = EXCLUDED."tippedCount",
-      "tippedAmountCount" = EXCLUDED."tippedAmountCount",
-      "generationCount" = EXCLUDED."generationCount",
-      "updatedAt" = EXCLUDED."updatedAt";
-  `);
-  jobContext.on('cancel', rowsQuery.cancel);
-  const affectedModelsRows = await rowsQuery.result();
-  console.log('models', affectedModelsRows[0]);
+      WHERE mv."modelId" IN (${ids})
+      GROUP BY mv."modelId", mvm.timeframe
+      ON CONFLICT ("modelId", timeframe) DO UPDATE
+        SET "updatedAt" = now(), "downloadCount" = EXCLUDED."downloadCount", "imageCount" = EXCLUDED."imageCount", "generationCount" = EXCLUDED."generationCount";
+    `;
+    log('getModelTasks', i + 1, 'of', tasks.length, 'done');
+  });
 
-  return [];
+  return tasks;
 }
-// #endregion

--- a/src/server/metrics/post.metrics.ts
+++ b/src/server/metrics/post.metrics.ts
@@ -1,6 +1,6 @@
-import { Prisma } from '@prisma/client';
 import { chunk } from 'lodash-es';
 import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
+import { executeRefresh, getAffected, snippets } from '~/server/metrics/metric-helpers';
 import { limitConcurrency, Task } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 
@@ -17,13 +17,14 @@ export const postMetrics = createMetricProcessor({
     log('postMetrics update', tasks.length, 'tasks');
     await limitConcurrency(tasks, 5);
   },
-  async clearDay({ pg, jobContext }) {
+  async clearDay(ctx) {
     log('clearDay');
-    const query = await pg.cancellableQuery(Prisma.sql`
-      UPDATE "PostMetric" SET "heartCount" = 0, "likeCount" = 0, "dislikeCount" = 0, "laughCount" = 0, "cryCount" = 0, "commentCount" = 0, "collectedCount" = 0 WHERE timeframe = 'Day' AND "createdAt" > date_trunc('day', now() - interval '1 day');
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+    await executeRefresh(ctx)`
+      UPDATE "PostMetric"
+        SET "heartCount" = 0, "likeCount" = 0, "dislikeCount" = 0, "laughCount" = 0, "cryCount" = 0, "commentCount" = 0, "collectedCount" = 0
+      WHERE timeframe = 'Day'
+        AND "updatedAt" > date_trunc('day', now() - interval '1 day');
+    `;
   },
   rank: {
     table: 'PostRank',
@@ -48,190 +49,101 @@ export const postMetrics = createMetricProcessor({
   },
 });
 
-async function getReactionTasks({ pg, lastUpdate, jobContext }: MetricProcessorRunContext) {
-  log('getReactionTasks', lastUpdate);
-  const affectedQuery = await pg.cancellableQuery<{ id: number }>(Prisma.sql`
+async function getReactionTasks(ctx: MetricProcessorRunContext) {
+  log('getReactionTasks', ctx.lastUpdate);
+  const affected = await getAffected(ctx)`
     -- get recent post image reactions
     SELECT DISTINCT
       i."postId" AS id
     FROM "ImageReaction" ir
     JOIN "Image" i ON i.id = ir."imageId"
-    WHERE ir."createdAt" > ${lastUpdate}
+    WHERE ir."createdAt" > '${ctx.lastUpdate}'
+  `;
 
-    UNION
-
-    SELECT
-      "id"
-    FROM "MetricUpdateQueue"
-    WHERE type = 'Post'
-  `);
-  jobContext.on('cancel', affectedQuery.cancel);
-  const affected = await affectedQuery.result();
-  const affectedIds = affected.map((x) => x.id);
-
-  const tasks = chunk(affectedIds, 100).map((ids, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(affected, 100).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getReactionTasks', i + 1, 'of', tasks.length);
-    const query = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       -- update post reaction metrics
-      INSERT INTO "PostMetric" ("postId", timeframe, "likeCount", "dislikeCount", "heartCount", "laughCount", "cryCount")
+      INSERT INTO "PostMetric" ("postId", timeframe, ${snippets.reactionMetricNames})
       SELECT
         i."postId",
         tf.timeframe,
-        SUM(CASE
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Like' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "likeCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Dislike' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "dislikeCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Heart' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "heartCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Laugh' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "laughCount",
-        SUM(CASE
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'AllTime' THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Year' AND ir."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Month' AND ir."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Week' AND ir."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN ir.reaction = 'Cry' AND tf.timeframe = 'Day' AND ir."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END) "cryCount"
-      FROM "ImageReaction" ir
-      JOIN "Image" i ON i.id = ir."imageId"
+        ${snippets.reactionTimeframes()}
+      FROM "ImageReaction" r
+      JOIN "Image" i ON i.id = r."imageId"
       CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
-      WHERE i."postId" IN (${Prisma.join(ids)})
+      WHERE i."postId" IN (${ids})
       GROUP BY i."postId", tf.timeframe
       ON CONFLICT ("postId", timeframe) DO UPDATE
-        SET "heartCount" = EXCLUDED."heartCount", "likeCount" = EXCLUDED."likeCount", "dislikeCount" = EXCLUDED."dislikeCount", "laughCount" = EXCLUDED."laughCount", "cryCount" = EXCLUDED."cryCount", "createdAt" = NOW()
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+        SET ${snippets.reactionMetricUpserts}, "updatedAt" = NOW()
+    `;
     log('getReactionTasks', i + 1, 'of', tasks.length, 'done');
   });
 
   return tasks;
 }
 
-async function getCommentTasks({ pg, lastUpdate, jobContext }: MetricProcessorRunContext) {
-  const affectedQuery = await pg.cancellableQuery(Prisma.sql`
+async function getCommentTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
     -- get recent post comments
     SELECT DISTINCT
       t."postId" AS id
     FROM "Thread" t
     JOIN "CommentV2" c ON c."threadId" = t.id
-    WHERE t."postId" IS NOT NULL AND c."createdAt" > ${lastUpdate}
+    WHERE t."postId" IS NOT NULL AND c."createdAt" > '${ctx.lastUpdate}'
+  `;
 
-    UNION
-
-    SELECT
-      "id"
-    FROM "MetricUpdateQueue"
-    WHERE type = 'Post'
-  `);
-  jobContext.on('cancel', affectedQuery.cancel);
-  const affected = await affectedQuery.result();
-  const affectedIds = affected.map((x) => x.id);
-
-  const tasks = chunk(affectedIds, 100).map((ids, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(affected, 100).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getCommentTasks', i + 1, 'of', tasks.length);
-    const query = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       -- update post comment counts
       INSERT INTO "PostMetric" ("postId", timeframe, "commentCount")
       SELECT
-        ic."postId",
+        t."postId",
         tf.timeframe,
-        SUM(CASE
-          WHEN tf.timeframe = 'AllTime' THEN 1
-          WHEN tf.timeframe = 'Year' AND v."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN tf.timeframe = 'Month' AND v."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN tf.timeframe = 'Week' AND v."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN tf.timeframe = 'Day' AND v."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END)
-      FROM "Thread" ic
-      JOIN "CommentV2" v ON ic."id" = v."threadId"
+        ${snippets.timeframeSum('c."createdAt"')}
+      FROM "Thread" t
+      JOIN "CommentV2" c ON t."id" = c."threadId"
       CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
-      WHERE ic."postId" IS NOT NULL AND ic."postId" IN (${Prisma.join(ids)})
-      GROUP BY ic."postId", tf.timeframe
+      WHERE t."postId" IS NOT NULL AND t."postId" IN (${ids})
+      GROUP BY t."postId", tf.timeframe
       ON CONFLICT ("postId", timeframe) DO UPDATE
         SET "commentCount" = EXCLUDED."commentCount", "createdAt" = NOW()
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+    `;
     log('getCommentTasks', i + 1, 'of', tasks.length, 'done');
   });
 
   return tasks;
 }
 
-async function getCollectionTasks({ pg, lastUpdate, jobContext }: MetricProcessorRunContext) {
-  const affectedQuery = await pg.cancellableQuery(Prisma.sql`
+async function getCollectionTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
     -- get recent post collections
     SELECT DISTINCT
       "postId" AS id
     FROM "CollectionItem"
-    WHERE "createdAt" > ${lastUpdate}
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
 
-    UNION
-
-    SELECT
-      "id"
-    FROM "MetricUpdateQueue"
-    WHERE type = 'Post'
-  `);
-  jobContext.on('cancel', affectedQuery.cancel);
-  const affected = await affectedQuery.result();
-  const affectedIds = affected.map((x) => x.id);
-
-  const tasks = chunk(affectedIds, 100).map((ids, i) => async () => {
-    jobContext.checkIfCanceled();
+  const tasks = chunk(affected, 100).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
     log('getCollectionTasks', i + 1, 'of', tasks.length);
-    const query = await pg.cancellableQuery(Prisma.sql`
+    await executeRefresh(ctx)`
       -- update post collection counts
       INSERT INTO "PostMetric" ("postId", timeframe, "collectedCount")
       SELECT
-        pci."postId",
+        ci."postId",
         tf.timeframe,
-        SUM(CASE
-          WHEN tf.timeframe = 'AllTime' THEN 1
-          WHEN tf.timeframe = 'Year' AND pci."createdAt" > (NOW() - interval '365 days') THEN 1
-          WHEN tf.timeframe = 'Month' AND pci."createdAt" > (NOW() - interval '30 days') THEN 1
-          WHEN tf.timeframe = 'Week' AND pci."createdAt" > (NOW() - interval '7 days') THEN 1
-          WHEN tf.timeframe = 'Day' AND pci."createdAt" > (NOW() - interval '1 days') THEN 1
-          ELSE 0
-        END)
-      FROM "CollectionItem" pci
+        ${snippets.timeframeSum('ci."createdAt"')}
+      FROM "CollectionItem" ci
       CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
-      WHERE pci."postId" IS NOT NULL AND pci."postId" IN (${Prisma.join(ids)})
-      GROUP BY pci."postId", tf.timeframe
+      WHERE ci."postId" IS NOT NULL AND ci."postId" IN (${ids})
+      GROUP BY ci."postId", tf.timeframe
       ON CONFLICT ("postId", timeframe) DO UPDATE
         SET "collectedCount" = EXCLUDED."collectedCount", "createdAt" = NOW()
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+    `;
     log('getCollectionTasks', i + 1, 'of', tasks.length, 'done');
   });
 

--- a/src/server/metrics/question.metrics.ts
+++ b/src/server/metrics/question.metrics.ts
@@ -3,6 +3,8 @@ import { createMetricProcessor } from '~/server/metrics/base.metrics';
 export const questionMetrics = createMetricProcessor({
   name: 'Question',
   async update({ db, lastUpdate }) {
+    return;
+    // Disabled for now
     await db.$executeRaw`
     WITH recent_engagements AS
     (

--- a/src/server/metrics/tag.metrics.ts
+++ b/src/server/metrics/tag.metrics.ts
@@ -1,221 +1,45 @@
-import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma } from '@prisma/client';
+import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { tagsSearchIndex } from '~/server/search-index';
+import { createLogger } from '~/utils/logging';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { executeRefresh, getAffected, snippets } from '~/server/metrics/metric-helpers';
+import { chunk } from 'lodash-es';
+
+const log = createLogger('metrics:tag');
 
 export const tagMetrics = createMetricProcessor({
   name: 'Tag',
-  async update({ pg, lastUpdate, jobContext }) {
-    const query = await pg.cancellableQuery<{ id: number }>(Prisma.sql`
-      -- Get all engagements that have happened since then that affect metrics
-      WITH recent_engagements AS
-      (
-        SELECT
-          "tagId" AS id
-        FROM "Model" m
-        JOIN "TagsOnModels" tom ON tom."modelId" = m.id
-        WHERE (m."updatedAt" > ${lastUpdate})
+  async update(ctx) {
+    // Get the metric tasks
+    //---------------------------------------
+    const taskBatches = await Promise.all([
+      getEngagementTasks(ctx),
+      getModelTasks(ctx),
+      getImageTasks(ctx),
+      getPostTasks(ctx),
+      getArticleTasks(ctx),
+    ]);
+    log('tagMetrics update', taskBatches.flat().length, 'tasks');
+    for (const tasks of taskBatches) await limitConcurrency(tasks, 5);
 
-        UNION
-
-        SELECT
-          "tagId" AS id
-        FROM "TagEngagement"
-        WHERE ("createdAt" > ${lastUpdate})
-
-        UNION
-
-        SELECT
-          "tagId" AS id
-        FROM "Image" i
-        JOIN "TagsOnImage" toi ON toi."imageId" = i.id
-        WHERE (i."createdAt" > ${lastUpdate})
-
-        UNION
-
-        SELECT
-          "id"
-        FROM "MetricUpdateQueue"
-        WHERE type = 'Tag'
-      ),
-      -- Get all affected
-      affected AS
-      (
-          SELECT DISTINCT
-              r.id
-          FROM recent_engagements r
-          JOIN "Tag" t ON t.id = r.id
-          WHERE r.id IS NOT NULL
-      )
-
-      -- upsert metrics for all affected
-      -- perform a one-pass table scan producing all metrics for all affected users
-      INSERT INTO "TagMetric" ("tagId", timeframe, "followerCount", "hiddenCount", "modelCount", "imageCount", "postCount", "articleCount")
-      SELECT
-        m.id,
-        tf.timeframe,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN follower_count
-          WHEN tf.timeframe = 'Year' THEN year_follower_count
-          WHEN tf.timeframe = 'Month' THEN month_follower_count
-          WHEN tf.timeframe = 'Week' THEN week_follower_count
-          WHEN tf.timeframe = 'Day' THEN day_follower_count
-        END AS follower_count,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN hidden_count
-          WHEN tf.timeframe = 'Year' THEN year_hidden_count
-          WHEN tf.timeframe = 'Month' THEN month_hidden_count
-          WHEN tf.timeframe = 'Week' THEN week_hidden_count
-          WHEN tf.timeframe = 'Day' THEN day_hidden_count
-        END AS hidden_count,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN model_count
-          WHEN tf.timeframe = 'Year' THEN year_model_count
-          WHEN tf.timeframe = 'Month' THEN month_model_count
-          WHEN tf.timeframe = 'Week' THEN week_model_count
-          WHEN tf.timeframe = 'Day' THEN day_model_count
-        END AS model_count,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN image_count
-          WHEN tf.timeframe = 'Year' THEN year_image_count
-          WHEN tf.timeframe = 'Month' THEN month_image_count
-          WHEN tf.timeframe = 'Week' THEN week_image_count
-          WHEN tf.timeframe = 'Day' THEN day_image_count
-        END AS image_count,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN post_count
-          WHEN tf.timeframe = 'Year' THEN year_post_count
-          WHEN tf.timeframe = 'Month' THEN month_post_count
-          WHEN tf.timeframe = 'Week' THEN week_post_count
-          WHEN tf.timeframe = 'Day' THEN day_post_count
-        END AS post_count,
-        CASE
-          WHEN tf.timeframe = 'AllTime' THEN article_count
-          WHEN tf.timeframe = 'Year' THEN year_article_count
-          WHEN tf.timeframe = 'Month' THEN month_article_count
-          WHEN tf.timeframe = 'Week' THEN week_article_count
-          WHEN tf.timeframe = 'Day' THEN day_article_count
-        END AS article_count
-      FROM
-      (
-        SELECT
-          a.id,
-          COALESCE(ft.follower_count, 0) AS follower_count,
-          COALESCE(ft.year_follower_count, 0) AS year_follower_count,
-          COALESCE(ft.month_follower_count, 0) AS month_follower_count,
-          COALESCE(ft.week_follower_count, 0) AS week_follower_count,
-          COALESCE(ft.day_follower_count, 0) AS day_follower_count,
-          COALESCE(ft.hidden_count, 0) AS hidden_count,
-          COALESCE(ft.year_hidden_count, 0) AS year_hidden_count,
-          COALESCE(ft.month_hidden_count, 0) AS month_hidden_count,
-          COALESCE(ft.week_hidden_count, 0) AS week_hidden_count,
-          COALESCE(ft.day_hidden_count, 0) AS day_hidden_count,
-          COALESCE(r.model_count, 0) AS model_count,
-          COALESCE(r.year_model_count, 0) AS year_model_count,
-          COALESCE(r.month_model_count, 0) AS month_model_count,
-          COALESCE(r.week_model_count, 0) AS week_model_count,
-          COALESCE(r.day_model_count, 0) AS day_model_count,
-          COALESCE(i.image_count, 0) AS image_count,
-          COALESCE(i.year_image_count, 0) AS year_image_count,
-          COALESCE(i.month_image_count, 0) AS month_image_count,
-          COALESCE(i.week_image_count, 0) AS week_image_count,
-          COALESCE(i.day_image_count, 0) AS day_image_count,
-          COALESCE(p.post_count, 0) AS post_count,
-          COALESCE(p.year_post_count, 0) AS year_post_count,
-          COALESCE(p.month_post_count, 0) AS month_post_count,
-          COALESCE(p.week_post_count, 0) AS week_post_count,
-          COALESCE(p.day_post_count, 0) AS day_post_count,
-          COALESCE(art.article_count, 0) AS article_count,
-          COALESCE(art.year_article_count, 0) AS year_article_count,
-          COALESCE(art.month_article_count, 0) AS month_article_count,
-          COALESCE(art.week_article_count, 0) AS week_article_count,
-          COALESCE(art.day_article_count, 0) AS day_article_count
-        FROM affected a
-        LEFT JOIN (
-          SELECT
-            "tagId" id,
-            COUNT("modelId") model_count,
-            SUM(IIF(m."publishedAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_model_count,
-            SUM(IIF(m."publishedAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_model_count,
-            SUM(IIF(m."publishedAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_model_count,
-            SUM(IIF(m."publishedAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_model_count
-          FROM "TagsOnModels" tom
-          JOIN "Model" m ON m.id = tom."modelId"
-          GROUP BY "tagId"
-        ) r ON r.id = a.id
-        LEFT JOIN (
-          SELECT
-            "tagId" id,
-            COUNT("imageId") image_count,
-            SUM(IIF(i."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_image_count,
-            SUM(IIF(i."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_image_count,
-            SUM(IIF(i."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_image_count,
-            SUM(IIF(i."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_image_count
-          FROM "TagsOnImage" toi
-          JOIN "Image" i ON i.id = toi."imageId"
-          GROUP BY "tagId"
-        ) i ON i.id = a.id
-        LEFT JOIN (
-          SELECT
-            "tagId" id,
-            COUNT("postId") post_count,
-            SUM(IIF(p."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_post_count,
-            SUM(IIF(p."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_post_count,
-            SUM(IIF(p."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_post_count,
-            SUM(IIF(p."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_post_count
-          FROM "TagsOnPost" top
-          JOIN "Post" p ON p.id = top."postId"
-          GROUP BY "tagId"
-        ) p ON p.id = a.id
-        LEFT JOIN (
-          SELECT
-            "tagId" id,
-            COUNT("articleId") article_count,
-            SUM(IIF(a."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_article_count,
-            SUM(IIF(a."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_article_count,
-            SUM(IIF(a."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_article_count,
-            SUM(IIF(a."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_article_count
-          FROM "TagsOnArticle" toa
-          JOIN "Article" a ON a.id = toa."articleId"
-          GROUP BY "tagId"
-        ) art ON art.id = a.id
-        LEFT JOIN (
-          SELECT
-            "tagId"                                                                      AS id,
-            SUM(IIF(type = 'Follow', 1, 0))                                                     AS follower_count,
-            SUM(IIF(type = 'Follow' AND "createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_follower_count,
-            SUM(IIF(type = 'Follow' AND "createdAt" >= (NOW() - interval '30 days'), 1, 0))  AS month_follower_count,
-            SUM(IIF(type = 'Follow' AND "createdAt" >= (NOW() - interval '7 days'), 1, 0))   AS week_follower_count,
-            SUM(IIF(type = 'Follow' AND "createdAt" >= (NOW() - interval '1 days'), 1, 0))   AS day_follower_count,
-            SUM(IIF(type = 'Hide', 1, 0))                                                       AS hidden_count,
-            SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '365 days'), 1, 0))   AS year_hidden_count,
-            SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '30 days'), 1, 0))    AS month_hidden_count,
-            SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '7 days'), 1, 0))     AS week_hidden_count,
-            SUM(IIF(type = 'Hide' AND "createdAt" >= (NOW() - interval '1 days'), 1, 0))     AS day_hidden_count
-          FROM "TagEngagement"
-          GROUP BY "tagId"
-        ) ft ON a.id = ft.id
-      ) m
-      CROSS JOIN (
-        SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-      ) tf
-      ON CONFLICT ("tagId", timeframe) DO UPDATE
-        SET "followerCount" = EXCLUDED."followerCount", "modelCount" = EXCLUDED."modelCount", "hiddenCount" = EXCLUDED."hiddenCount", "postCount" = EXCLUDED."postCount", "imageCount" = EXCLUDED."imageCount", "articleCount" = EXCLUDED."articleCount", "createdAt" = NOW()
-      RETURNING "tagId" AS id;
-    `);
-    jobContext.on('cancel', query.cancel);
-    const affectedTags = await query.result();
-
+    // Update the search index
+    //---------------------------------------
+    log('update search index');
     await tagsSearchIndex.queueUpdate(
-      affectedTags.map((x) => ({ id: x.id, action: SearchIndexUpdateQueueAction.Update }))
+      [...ctx.affected].map((id) => ({
+        id,
+        action: SearchIndexUpdateQueueAction.Update,
+      }))
     );
   },
-  async clearDay({ pg, jobContext }) {
-    const query = await pg.cancellableQuery(Prisma.sql`
-      UPDATE "TagMetric" SET "followerCount" = 0, "modelCount" = 0, "hiddenCount" = 0, "postCount" = 0, "imageCount" = 0, "articleCount" = 0 WHERE timeframe = 'Day' AND "createdAt" > date_trunc('day', now() - interval '1 day');
-    `);
-    jobContext.on('cancel', query.cancel);
-    await query.result();
+  async clearDay(ctx) {
+    await executeRefresh(ctx)`
+      UPDATE "TagMetric"
+        SET "followerCount" = 0, "modelCount" = 0, "hiddenCount" = 0, "postCount" = 0, "imageCount" = 0, "articleCount" = 0
+      WHERE timeframe = 'Day'
+        AND "updatedAt" > date_trunc('day', now() - interval '1 day');
+    `;
   },
   rank: {
     table: 'TagRank',
@@ -223,3 +47,97 @@ export const tagMetrics = createMetricProcessor({
     refreshInterval: 5 * 60 * 1000,
   },
 });
+
+async function getEngagementTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent tag engagements
+    SELECT
+      "tagId" as id
+    FROM "TagEngagement"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getEngagementTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update tag engagement metrics
+      INSERT INTO "TagMetric" ("tagId", timeframe, "followerCount", "hiddenCount")
+      SELECT
+        "tagId",
+        tf.timeframe,
+        ${snippets.timeframeSum('e."createdAt"', '1', `e.type = 'Follow'`)} "followerCount",
+        ${snippets.timeframeSum('e."createdAt"', '1', `e.type = 'Hide'`)} "hiddenCount"
+      FROM "TagEngagement" e
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "tagId" IN (${ids})
+      GROUP BY "tagId", tf.timeframe
+      ON CONFLICT ("tagId", timeframe) DO UPDATE
+        SET "followerCount" = EXCLUDED."followerCount", "hiddenCount" = EXCLUDED."hiddenCount", "updatedAt" = NOW()
+    `;
+    log('getEngagementTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+const tagCountMap = {
+  Models: { id: 'modelId', table: 'TagsOnModels', column: 'modelCount', sourceTable: 'Model' },
+  Images: { id: 'imageId', table: 'TagsOnImage', column: 'imageCount', sourceTable: 'Image' },
+  Posts: { id: 'postId', table: 'TagsOnPost', column: 'postCount', sourceTable: 'Post' },
+  Articles: {
+    id: 'articleId',
+    table: 'TagsOnArticle',
+    column: 'articleCount',
+    sourceTable: 'Article',
+  },
+} as const;
+async function getTagCountTasks(ctx: MetricProcessorRunContext, entity: keyof typeof tagCountMap) {
+  const { id, table, column, sourceTable } = tagCountMap[entity];
+  const affected = await getAffected(ctx)`
+    -- get recent tag counts
+    SELECT
+      "tagId" AS id
+    FROM "${table}"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 500).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log(`get ${table} counts`, i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update tag count metrics
+      INSERT INTO "TagMetric" ("tagId", timeframe, "${column}")
+      SELECT
+        "tagId",
+        tf.timeframe,
+        ${snippets.timeframeSum('s."createdAt"')}
+      FROM "${table}" t
+      JOIN "${sourceTable}" s ON s.id = t."${id}"
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "tagId" IN (${ids})
+      GROUP BY "tagId", tf.timeframe
+      ON CONFLICT ("tagId", timeframe) DO UPDATE
+        SET "${column}" = EXCLUDED."${column}", "updatedAt" = NOW()
+    `;
+    log(`get ${table} counts`, i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getModelTasks(ctx: MetricProcessorRunContext) {
+  return getTagCountTasks(ctx, 'Models');
+}
+
+async function getImageTasks(ctx: MetricProcessorRunContext) {
+  return getTagCountTasks(ctx, 'Images');
+}
+
+async function getPostTasks(ctx: MetricProcessorRunContext) {
+  return getTagCountTasks(ctx, 'Posts');
+}
+
+async function getArticleTasks(ctx: MetricProcessorRunContext) {
+  return getTagCountTasks(ctx, 'Articles');
+}

--- a/src/server/metrics/tag.metrics.ts
+++ b/src/server/metrics/tag.metrics.ts
@@ -1,5 +1,6 @@
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { tagsSearchIndex } from '~/server/search-index';
 
 export const tagMetrics = createMetricProcessor({

--- a/src/server/metrics/user.metrics.ts
+++ b/src/server/metrics/user.metrics.ts
@@ -1,267 +1,43 @@
-import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma } from '@prisma/client';
+import { createMetricProcessor, MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { usersSearchIndex } from '~/server/search-index';
+import { createLogger } from '~/utils/logging';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { executeRefresh, getAffected, snippets } from '~/server/metrics/metric-helpers';
+import { chunk } from 'lodash-es';
+
+const log = createLogger('metrics:user');
 
 export const userMetrics = createMetricProcessor({
   name: 'User',
-  async update({ db, lastUpdate }) {
-    const recentEngagementSubquery = Prisma.sql`
-    -- Get all engagements that have happened since then that affect metrics
-    WITH recent_engagements AS
-    (
-      SELECT
-        a."userId" AS user_id
-      FROM "UserEngagement" a
-      WHERE (a."createdAt" > ${lastUpdate})
+  async update(ctx) {
+    // Get the metric tasks
+    //---------------------------------------
+    const taskBatches = await Promise.all([
+      getEngagementTasks(ctx),
+      getFollowingTasks(ctx),
+      getModelTasks(ctx),
+      getReviewTasks(ctx),
+    ]);
+    log('userMetrics update', taskBatches.flat().length, 'tasks');
+    for (const tasks of taskBatches) await limitConcurrency(tasks, 5);
 
-      UNION
-
-      SELECT
-        a."targetUserId" AS user_id
-      FROM "UserEngagement" a
-      WHERE (a."createdAt" > ${lastUpdate})
-
-      UNION
-
-      SELECT
-        "userId"
-      FROM "ModelVersion" mv
-      JOIN "Model" m ON mv."modelId" = m.id
-      WHERE (mv."createdAt" > ${lastUpdate} OR m."publishedAt" > ${lastUpdate})
-
-      UNION
-
-      SELECT
-        "userId"
-      FROM "ResourceReview" r
-      WHERE (r."createdAt" > ${lastUpdate})
-
-      UNION
-
-      SELECT
-        a2."userId"
-      FROM "AnswerVote" ar
-      JOIN "Answer" a2 ON a2.id = ar."answerId"
-      WHERE (ar."createdAt" > ${lastUpdate})
-
-      UNION
-
-      SELECT
-        "userId"
-      FROM "Answer" ar
-      WHERE "createdAt" > ${lastUpdate}
-
-      UNION
-
-      SELECT
-        "id"
-      FROM "MetricUpdateQueue"
-      WHERE type = 'User'
-    )
-    `;
-
-    await db.$executeRaw`
-    ${recentEngagementSubquery},
-    -- Get all affected users
-    affected_users AS
-    (
-        SELECT DISTINCT
-            r.user_id
-        FROM recent_engagements r
-        JOIN "User" u ON u.id = r.user_id
-        WHERE r.user_id IS NOT NULL
-    )
-
-    -- upsert metrics for all affected users
-    -- perform a one-pass table scan producing all metrics for all affected users
-    INSERT INTO "UserMetric" ("userId", timeframe, "followingCount", "followerCount", "hiddenCount", "uploadCount", "reviewCount", "answerCount", "answerAcceptCount")
-    SELECT
-      m.user_id,
-      tf.timeframe,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN following_count
-        WHEN tf.timeframe = 'Year' THEN year_following_count
-        WHEN tf.timeframe = 'Month' THEN month_following_count
-        WHEN tf.timeframe = 'Week' THEN week_following_count
-        WHEN tf.timeframe = 'Day' THEN day_following_count
-      END AS following_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN follower_count
-        WHEN tf.timeframe = 'Year' THEN year_follower_count
-        WHEN tf.timeframe = 'Month' THEN month_follower_count
-        WHEN tf.timeframe = 'Week' THEN week_follower_count
-        WHEN tf.timeframe = 'Day' THEN day_follower_count
-      END AS follower_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN hidden_count
-        WHEN tf.timeframe = 'Year' THEN year_hidden_count
-        WHEN tf.timeframe = 'Month' THEN month_hidden_count
-        WHEN tf.timeframe = 'Week' THEN week_hidden_count
-        WHEN tf.timeframe = 'Day' THEN day_hidden_count
-      END AS hidden_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN upload_count
-        WHEN tf.timeframe = 'Year' THEN year_upload_count
-        WHEN tf.timeframe = 'Month' THEN month_upload_count
-        WHEN tf.timeframe = 'Week' THEN week_upload_count
-        WHEN tf.timeframe = 'Day' THEN day_upload_count
-      END AS upload_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN review_count
-        WHEN tf.timeframe = 'Year' THEN year_review_count
-        WHEN tf.timeframe = 'Month' THEN month_review_count
-        WHEN tf.timeframe = 'Week' THEN week_review_count
-        WHEN tf.timeframe = 'Day' THEN day_review_count
-      END AS review_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN answer_count
-        WHEN tf.timeframe = 'Year' THEN year_answer_count
-        WHEN tf.timeframe = 'Month' THEN month_answer_count
-        WHEN tf.timeframe = 'Week' THEN week_answer_count
-        WHEN tf.timeframe = 'Day' THEN day_answer_count
-      END AS answer_count,
-      CASE
-        WHEN tf.timeframe = 'AllTime' THEN check_count
-        WHEN tf.timeframe = 'Year' THEN year_check_count
-        WHEN tf.timeframe = 'Month' THEN month_check_count
-        WHEN tf.timeframe = 'Week' THEN week_check_count
-        WHEN tf.timeframe = 'Day' THEN day_check_count
-      END AS check_count
-    FROM
-    (
-      SELECT
-        a.user_id,
-        COALESCE(fs.following_count, 0) AS following_count,
-        COALESCE(fs.year_following_count, 0) AS year_following_count,
-        COALESCE(fs.month_following_count, 0) AS month_following_count,
-        COALESCE(fs.week_following_count, 0) AS week_following_count,
-        COALESCE(fs.day_following_count, 0) AS day_following_count,
-        COALESCE(ft.follower_count, 0) AS follower_count,
-        COALESCE(ft.year_follower_count, 0) AS year_follower_count,
-        COALESCE(ft.month_follower_count, 0) AS month_follower_count,
-        COALESCE(ft.week_follower_count, 0) AS week_follower_count,
-        COALESCE(ft.day_follower_count, 0) AS day_follower_count,
-        COALESCE(ft.hidden_count, 0) AS hidden_count,
-        COALESCE(ft.year_hidden_count, 0) AS year_hidden_count,
-        COALESCE(ft.month_hidden_count, 0) AS month_hidden_count,
-        COALESCE(ft.week_hidden_count, 0) AS week_hidden_count,
-        COALESCE(ft.day_hidden_count, 0) AS day_hidden_count,
-        COALESCE(u.upload_count, 0) AS upload_count,
-        COALESCE(u.year_upload_count, 0) AS year_upload_count,
-        COALESCE(u.month_upload_count, 0) AS month_upload_count,
-        COALESCE(u.week_upload_count, 0) AS week_upload_count,
-        COALESCE(u.day_upload_count, 0) AS day_upload_count,
-        COALESCE(r.review_count, 0) AS review_count,
-        COALESCE(r.year_review_count, 0) AS year_review_count,
-        COALESCE(r.month_review_count, 0) AS month_review_count,
-        COALESCE(r.week_review_count, 0) AS week_review_count,
-        COALESCE(r.day_review_count, 0) AS day_review_count,
-        COALESCE(ans.answer_count, 0) AS answer_count,
-        COALESCE(ans.year_answer_count, 0) AS year_answer_count,
-        COALESCE(ans.month_answer_count, 0) AS month_answer_count,
-        COALESCE(ans.week_answer_count, 0) AS week_answer_count,
-        COALESCE(ans.day_answer_count, 0) AS day_answer_count,
-        COALESCE(ans.check_count, 0) AS check_count,
-        COALESCE(ans.year_check_count, 0) AS year_check_count,
-        COALESCE(ans.month_check_count, 0) AS month_check_count,
-        COALESCE(ans.week_check_count, 0) AS week_check_count,
-        COALESCE(ans.day_check_count, 0) AS day_check_count
-      FROM affected_users a
-      LEFT JOIN (
-        SELECT
-          ue."userId" AS user_id,
-          SUM(IIF(ue.type = 'Follow', 1, 0)) AS following_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_following_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_following_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_following_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_following_count
-        FROM "UserEngagement" ue
-        GROUP BY ue."userId"
-      ) fs ON a.user_id = fs.user_id
-      LEFT JOIN (
-        SELECT
-          ans."userId" AS user_id,
-          COUNT(*) answer_count,
-          SUM(IIF(ans."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_answer_count,
-          SUM(IIF(ans."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_answer_count,
-          SUM(IIF(ans."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_answer_count,
-          SUM(IIF(ans."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_answer_count,
-          SUM(ar."checkCountAllTime") check_count,
-          SUM(ar."checkCountDay") day_check_count,
-          SUM(ar."checkCountWeek") week_check_count,
-          SUM(ar."checkCountMonth") month_check_count,
-          SUM(ar."checkCountYear") year_check_count
-        FROM "AnswerRank" ar
-        JOIN "Answer" ans ON ans.id = ar."answerId"
-        GROUP BY ans."userId"
-      ) ans ON a.user_id = ans.user_id
-      LEFT JOIN (
-        SELECT
-          m2."userId" user_id,
-          COUNT(*) upload_count,
-          SUM(IIF(mv."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_upload_count,
-          SUM(IIF(mv."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_upload_count,
-          SUM(IIF(mv."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_upload_count,
-          SUM(IIF(mv."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_upload_count
-        FROM "ModelVersion" mv
-        JOIN "Model" m2 ON mv."modelId" = m2.id
-        WHERE m2.status = 'Published'
-        GROUP BY m2."userId"
-      ) u ON u.user_id = a.user_id
-      LEFT JOIN (
-        SELECT
-          rr."userId" user_id,
-          COUNT(*) review_count,
-          SUM(IIF(rr."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_review_count,
-          SUM(IIF(rr."createdAt" >= (NOW() - interval '30 days'), 1, 0)) AS month_review_count,
-          SUM(IIF(rr."createdAt" >= (NOW() - interval '7 days'), 1, 0)) AS week_review_count,
-          SUM(IIF(rr."createdAt" >= (NOW() - interval '1 days'), 1, 0)) AS day_review_count
-        FROM "ResourceReview" rr
-        JOIN "Model" m on rr."modelId" = m.id
-        WHERE m.status = 'Published'
-        GROUP BY rr."userId"
-      ) r ON r.user_id = a.user_id
-      LEFT JOIN (
-        SELECT
-          ue."targetUserId" AS user_id,
-          SUM(IIF(ue.type = 'Follow', 1, 0)) AS follower_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '365 days'), 1, 0)) AS year_follower_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '30 days'), 1, 0))  AS month_follower_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '7 days'), 1, 0))   AS week_follower_count,
-          SUM(IIF(ue.type = 'Follow' AND ue."createdAt" >= (NOW() - interval '1 days'), 1, 0))   AS day_follower_count,
-          SUM(IIF(ue.type = 'Hide', 1, 0)) AS hidden_count,
-          SUM(IIF(ue.type = 'Hide' AND ue."createdAt" >= (NOW() - interval '365 days'), 1, 0))   AS year_hidden_count,
-          SUM(IIF(ue.type = 'Hide' AND ue."createdAt" >= (NOW() - interval '30 days'), 1, 0))    AS month_hidden_count,
-          SUM(IIF(ue.type = 'Hide' AND ue."createdAt" >= (NOW() - interval '7 days'), 1, 0))     AS week_hidden_count,
-          SUM(IIF(ue.type = 'Hide' AND ue."createdAt" >= (NOW() - interval '1 days'), 1, 0))     AS day_hidden_count
-        FROM "UserEngagement" ue
-        GROUP BY ue."targetUserId"
-      ) ft ON a.user_id = ft.user_id
-    ) m
-    CROSS JOIN (
-      SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe
-    ) tf
-    ON CONFLICT ("userId", timeframe) DO UPDATE
-      SET "followerCount" = EXCLUDED."followerCount", "followingCount" = EXCLUDED."followingCount", "hiddenCount" = EXCLUDED."hiddenCount", "uploadCount" = EXCLUDED."uploadCount", "reviewCount" = EXCLUDED."reviewCount", "answerCount" = EXCLUDED."answerCount", "answerAcceptCount" = EXCLUDED."answerAcceptCount";
-  `;
-
-    const affectedUsers: Array<{ id: number }> = await db.$queryRaw`
-      ${recentEngagementSubquery}
-        SELECT DISTINCT
-            u.id
-        FROM recent_engagements r
-        JOIN "User" u ON u.id = r.user_id
-        WHERE r.user_id IS NOT NULL
-    `;
-
+    // Update the search index
+    //---------------------------------------
+    log('update search index');
     await usersSearchIndex.queueUpdate(
-      affectedUsers.map(({ id }) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
+      [...ctx.affected].map((id) => ({
+        id,
+        action: SearchIndexUpdateQueueAction.Update,
+      }))
     );
   },
-  async clearDay({ db }) {
-    await db.$executeRaw`
-      UPDATE "UserMetric" SET "followerCount" = 0, "followingCount" = 0, "hiddenCount" = 0, "uploadCount" = 0, "reviewCount" = 0, "answerCount" = 0, "answerAcceptCount" = 0 WHERE timeframe = 'Day';
+  async clearDay(ctx) {
+    await executeRefresh(ctx)`
+      UPDATE "UserMetric"
+        SET "followerCount" = 0, "followingCount" = 0, "hiddenCount" = 0, "uploadCount" = 0, "reviewCount" = 0, "answerCount" = 0, "answerAcceptCount" = 0
+      WHERE timeframe = 'Day'
+        AND "updatedAt" > date_trunc('day', now() - interval '1 day');
     `;
   },
   rank: {
@@ -271,3 +47,141 @@ export const userMetrics = createMetricProcessor({
     refreshInterval: 1000 * 60 * 60 * 24, // 24 hours
   },
 });
+
+async function getEngagementTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent user engagements
+    SELECT
+      "targetUserId" as id
+    FROM "UserEngagement"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getEngagementTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update tag engagement metrics
+      INSERT INTO "UserMetric" ("userId", timeframe, "followerCount", "hiddenCount")
+      SELECT
+        "targetUserId",
+        tf.timeframe,
+        ${snippets.timeframeSum('e."createdAt"', '1', `e.type = 'Follow'`)} "followerCount",
+        ${snippets.timeframeSum('e."createdAt"', '1', `e.type = 'Hide'`)} "hiddenCount"
+      FROM "UserEngagement" e
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "targetUserId" IN (${ids})
+      GROUP BY "targetUserId", tf.timeframe
+      ON CONFLICT ("userId", timeframe) DO UPDATE
+        SET "followerCount" = EXCLUDED."followerCount", "hiddenCount" = EXCLUDED."hiddenCount", "updatedAt" = NOW()
+    `;
+    log('getEngagementTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getFollowingTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent user engagements
+    SELECT
+      "userId" as id
+    FROM "UserEngagement"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getEngagementTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update tag engagement metrics
+      INSERT INTO "UserMetric" ("userId", timeframe, "followingCount")
+      SELECT
+        "userId",
+        tf.timeframe,
+        ${snippets.timeframeSum('e."createdAt"', '1', `e.type = 'Follow'`)} "followingCount"
+      FROM "UserEngagement" e
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "userId" IN (${ids})
+      GROUP BY "userId", tf.timeframe
+      ON CONFLICT ("userId", timeframe) DO UPDATE
+        SET "followingCount" = EXCLUDED."followingCount", "updatedAt" = NOW()
+    `;
+    log('getEngagementTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getModelTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent user published models
+    SELECT
+      m."userId" as id
+    FROM "ModelVersion" mv
+    JOIN "Model" m ON mv."modelId" = m.id
+    WHERE (mv."publishedAt" > '${ctx.lastUpdate}' AND mv."status" = 'Published')
+      OR (mv."publishedAt" <= '${ctx.lastUpdate}' AND mv."status" = 'Scheduled')
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getModelTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update published model user metrics
+      INSERT INTO "UserMetric" ("userId", timeframe, "uploadCount")
+      SELECT
+        "userId",
+        tf.timeframe,
+        ${snippets.timeframeSum('mv."publishedAt"')} "uploadCount"
+      FROM "ModelVersion" mv
+      JOIN "Model" m ON mv."modelId" = m.id
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "userId" IN (${ids})
+        AND (
+          (mv."publishedAt" > '${ctx.lastUpdate}' AND mv."status" = 'Published')
+          OR (mv."publishedAt" <= '${ctx.lastUpdate}' AND mv."status" = 'Scheduled')
+        )
+      GROUP BY "userId", tf.timeframe
+      ON CONFLICT ("userId", timeframe) DO UPDATE
+        SET "uploadCount" = EXCLUDED."uploadCount", "updatedAt" = NOW()
+    `;
+    log('getModelTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}
+
+async function getReviewTasks(ctx: MetricProcessorRunContext) {
+  const affected = await getAffected(ctx)`
+    -- get recent user reviews
+    SELECT
+      "userId" as id
+    FROM "ResourceReview"
+    WHERE "createdAt" > '${ctx.lastUpdate}'
+  `;
+
+  const tasks = chunk(affected, 1000).map((ids, i) => async () => {
+    ctx.jobContext.checkIfCanceled();
+    log('getReviewTasks', i + 1, 'of', tasks.length);
+    await executeRefresh(ctx)`
+      -- update user review metrics
+      INSERT INTO "UserMetric" ("userId", timeframe, "reviewCount")
+      SELECT
+        "userId",
+        tf.timeframe,
+        ${snippets.timeframeSum('rr."createdAt"')} "reviewCount"
+      FROM "ResourceReview" rr
+      JOIN "ModelVersion" mv on rr."modelVersionId" = mv.id
+      CROSS JOIN (SELECT unnest(enum_range(NULL::"MetricTimeframe")) AS timeframe) tf
+      WHERE "userId" IN (${ids})
+        AND mv.status = 'Published'
+      GROUP BY "userId", tf.timeframe
+      ON CONFLICT ("userId", timeframe) DO UPDATE
+        SET "reviewCount" = EXCLUDED."reviewCount", "updatedAt" = NOW()
+    `;
+    log('getReviewTasks', i + 1, 'of', tasks.length, 'done');
+  });
+
+  return tasks;
+}

--- a/src/server/metrics/user.metrics.ts
+++ b/src/server/metrics/user.metrics.ts
@@ -1,6 +1,7 @@
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
-import { Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
-import { tagsSearchIndex, usersSearchIndex } from '~/server/search-index';
+import { Prisma } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { usersSearchIndex } from '~/server/search-index';
 
 export const userMetrics = createMetricProcessor({
   name: 'User',

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -73,5 +73,8 @@ export const REDIS_KEYS = {
     TAGS_NEEDING_REVIEW: 'system:tags-needing-review',
     HOME_EXCLUDED_TAGS: 'system:home-excluded-tags',
   },
+  SEARCH_INDEX: {
+    BUCKETS: 'search-index:buckets',
+  },
   LIVE_NOW: 'live-now',
 } as const;

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -73,8 +73,8 @@ export const REDIS_KEYS = {
     TAGS_NEEDING_REVIEW: 'system:tags-needing-review',
     HOME_EXCLUDED_TAGS: 'system:home-excluded-tags',
   },
-  SEARCH_INDEX: {
-    BUCKETS: 'search-index:buckets',
+  QUEUES: {
+    BUCKETS: 'queues:buckets',
   },
   LIVE_NOW: 'live-now',
 } as const;

--- a/src/server/redis/queues.ts
+++ b/src/server/redis/queues.ts
@@ -1,0 +1,52 @@
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+
+async function getBucketNames(key: string) {
+  const currentBucket = await redis.hGet(REDIS_KEYS.SEARCH_INDEX.BUCKETS, key);
+  return currentBucket?.split(',') ?? [];
+}
+
+function getNewBucketName(key: string) {
+  return `${REDIS_KEYS.SEARCH_INDEX.BUCKETS}:${key}:${Date.now()}`;
+}
+
+export async function addToQueue(key: string, ids: number | number[] | Set<number>) {
+  if (!Array.isArray(ids)) {
+    if (ids instanceof Set) ids = Array.from(ids);
+    else ids = [ids];
+  }
+  const currentBuckets = await getBucketNames(key);
+  const targetBucket = currentBuckets[0] ?? getNewBucketName(key);
+  const content = ids.map((id) => id.toString());
+  await redis.sAdd(targetBucket, content);
+}
+
+export async function checkoutQueue(key: string) {
+  // Get the current buckets
+  const currentBuckets = await getBucketNames(key);
+
+  // Append new bucket
+  const newBucket = getNewBucketName(key);
+  await redis.hSet(REDIS_KEYS.SEARCH_INDEX.BUCKETS, key, [newBucket, ...currentBuckets].join(','));
+
+  // Fetch the content of the current buckets
+  const content = new Set<number>();
+  if (currentBuckets) {
+    for (const bucket of currentBuckets) {
+      const bucketContent = (await redis.sMembers(bucket))?.map((id) => parseInt(id)) ?? [];
+      for (const id of bucketContent) content.add(id);
+    }
+  }
+
+  return {
+    content: [...content],
+    commit: async () => {
+      // Remove the reference to the processed buckets
+      const existingBuckets = await getBucketNames(key);
+      const newBuckets = existingBuckets.filter((bucket) => !currentBuckets.includes(bucket));
+      await redis.hSet(REDIS_KEYS.SEARCH_INDEX.BUCKETS, key, newBuckets.join(','));
+
+      // Remove the processed buckets
+      await redis.del(currentBuckets);
+    },
+  };
+}

--- a/src/server/search-index/SearchIndexUpdate.ts
+++ b/src/server/search-index/SearchIndexUpdate.ts
@@ -1,33 +1,33 @@
-import { SearchIndexUpdateQueueAction } from '@prisma/client';
-import { chunk } from 'lodash';
-import { dbWrite } from '~/server/db/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { addToQueue, checkoutQueue } from '~/server/redis/queues';
 
-export abstract class SearchIndexUpdate {
-  static async queueUpdate({
-    indexName,
-    items,
-  }: {
-    indexName: string;
-    items: Array<{ id: number; action?: SearchIndexUpdateQueueAction }>;
-  }) {
-    if (!items.length) return;
-
-    console.log(
-      `createSearchIndexUpdateProcessor :: ${indexName} :: queueUpdate :: Called with ${items.length} items`
-    );
-
-    const batches = chunk(items, 500);
-    for (const batch of batches) {
-      await dbWrite.$executeRawUnsafe(`
-        INSERT INTO "SearchIndexUpdateQueue" ("type", "id", "action")
-        VALUES ${batch
-          .map(
-            ({ id, action }) =>
-              `('${indexName}', ${id}, '${action ?? SearchIndexUpdateQueueAction.Update}')`
-          )
-          .join(', ')}
-        ON CONFLICT ("type", "id", "action") DO NOTHING;
-    `);
-    }
+async function queueUpdate({
+  indexName,
+  items,
+}: {
+  indexName: string;
+  items: Array<{ id: number; action?: SearchIndexUpdateQueueAction }>;
+}) {
+  for (const type of Object.keys(SearchIndexUpdateQueueAction)) {
+    const typeItems = items.filter((i) => i.action === type).map(({ id }) => id);
+    if (!typeItems.length) continue;
+    await addToQueue(`${indexName}:${type}`, typeItems);
   }
 }
+
+async function getQueue(indexName: string, action: SearchIndexUpdateQueueAction) {
+  return await checkoutQueue(`${indexName}:${action}`);
+}
+
+async function clearQueue(indexName: string) {
+  for (const type of Object.keys(SearchIndexUpdateQueueAction)) {
+    const queue = await checkoutQueue(`${indexName}:${type}`);
+    await queue.commit();
+  }
+}
+
+export const SearchIndexUpdate = {
+  queueUpdate,
+  getQueue,
+  clearQueue,
+};

--- a/src/server/search-index/articles.search-index.ts
+++ b/src/server/search-index/articles.search-index.ts
@@ -5,7 +5,8 @@ import {
   createSearchIndexUpdateProcessor,
   SearchIndexRunContext,
 } from '~/server/search-index/base.search-index';
-import { Availability, Prisma, PrismaClient, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Availability, Prisma, PrismaClient } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { articleDetailSelect } from '~/server/selectors/article.selector';
 import { ARTICLES_SEARCH_INDEX } from '~/server/common/constants';
 import { isDefined } from '~/utils/type-guards';
@@ -187,15 +188,16 @@ const onIndexUpdate = async ({ db, lastUpdatedAt, indexName }: SearchIndexRunCon
   let offset = 0;
   const articlesTasks: EnqueuedTask[] = [];
 
-  const queuedItems = await db.searchIndexUpdateQueue.findMany({
-    select: {
-      id: true,
-    },
-    where: {
-      type: INDEX_ID,
-    },
-  });
+  const queuedUpdates = await SearchIndexUpdate.getQueue(
+    indexName,
+    SearchIndexUpdateQueueAction.Update
+  );
+  const queuedDeletes = await SearchIndexUpdate.getQueue(
+    indexName,
+    SearchIndexUpdateQueueAction.Delete
+  );
 
+  const toQueue = new Set<number>();
   while (true) {
     console.log(
       `onIndexUpdate :: fetching starting for ${indexName} range:`,
@@ -221,17 +223,14 @@ const onIndexUpdate = async ({ db, lastUpdatedAt, indexName }: SearchIndexRunCon
             },
             {
               id: {
-                in: queuedItems.map(({ id }) => id),
+                in: [...queuedUpdates.content, ...queuedDeletes.content],
               },
             },
           ],
     });
 
     if (toRequeue.length) {
-      SearchIndexUpdate.queueUpdate({
-        indexName,
-        items: toRequeue.map((x) => ({ id: x.id, action: SearchIndexUpdateQueueAction.Update })),
-      });
+      for (const item of toRequeue) toQueue.add(item.id);
     }
 
     console.log(
@@ -251,6 +250,15 @@ const onIndexUpdate = async ({ db, lastUpdatedAt, indexName }: SearchIndexRunCon
 
     offset += indexReadyRecords.length;
   }
+
+  // Queue requeued items
+  await SearchIndexUpdate.queueUpdate({
+    indexName,
+    items: [...toQueue].map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update })),
+  });
+
+  // Commit all queued updates and deletes
+  await Promise.all([queuedUpdates.commit, queuedDeletes.commit]);
 
   console.log('onIndexUpdate :: index update complete');
 };

--- a/src/server/search-index/bounties.search-index.ts
+++ b/src/server/search-index/bounties.search-index.ts
@@ -14,14 +14,15 @@ import {
   NsfwLevel,
   Prisma,
   PrismaClient,
-  SearchIndexUpdateQueueAction,
 } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { BOUNTIES_SEARCH_INDEX } from '~/server/common/constants';
 import { isDefined } from '~/utils/type-guards';
 import { dbRead } from '~/server/db/client';
 import { ImageMetadata } from '~/server/schema/media.schema';
 import { ImageModelWithIngestion, profileImageSelect } from '../selectors/image.selector';
 import { imageSelect } from '~/server/selectors/image.selector';
+import { SearchIndexUpdate } from '~/server/search-index/SearchIndexUpdate';
 
 const READ_BATCH_SIZE = 250; // 10 items per bounty are fetched for images. Careful with this number
 const MEILISEARCH_DOCUMENT_BATCH_SIZE = 1000;
@@ -389,40 +390,34 @@ const onFetchItemsToIndex = async ({
 };
 
 const onUpdateQueueProcess = async ({ db, indexName }: { db: PrismaClient; indexName: string }) => {
-  const queuedItems = await db.searchIndexUpdateQueue.findMany({
-    select: {
-      id: true,
-    },
-    where: { type: INDEX_ID, action: SearchIndexUpdateQueueAction.Update },
-  });
+  const queue = await SearchIndexUpdate.getQueue(indexName, SearchIndexUpdateQueueAction.Update);
 
   console.log(
     'onUpdateQueueProcess :: A total of ',
-    queuedItems.length,
+    queue.content.length,
     ' have been updated and will be re-indexed'
   );
 
-  const batchCount = Math.ceil(queuedItems.length / READ_BATCH_SIZE);
+  const batchCount = Math.ceil(queue.content.length / READ_BATCH_SIZE);
 
   const itemsToIndex: BountySearchIndexRecord[] = [];
 
   for (let batchNumber = 0; batchNumber < batchCount; batchNumber++) {
-    const batch = queuedItems.slice(
+    const batch = queue.content.slice(
       batchNumber * READ_BATCH_SIZE,
       batchNumber * READ_BATCH_SIZE + READ_BATCH_SIZE
     );
 
-    const itemIds = batch.map(({ id }) => id);
-
     const newItems = await onFetchItemsToIndex({
       db,
       indexName,
-      whereOr: [Prisma.sql`b.id IN (${Prisma.join(itemIds)})`],
+      whereOr: [Prisma.sql`b.id IN (${Prisma.join(batch)})`],
     });
 
     itemsToIndex.push(...newItems);
   }
 
+  await queue.commit();
   return itemsToIndex;
 };
 const onIndexUpdate = async ({ db, lastUpdatedAt, indexName }: SearchIndexRunContext) => {

--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -8,7 +8,6 @@ import {
   ModelStatus,
   Prisma,
   PrismaClient,
-  SearchIndexUpdateQueueAction,
 } from '@prisma/client';
 import { isEqual } from 'lodash';
 import { MODELS_SEARCH_INDEX, ModelFileType } from '~/server/common/constants';
@@ -25,6 +24,8 @@ import { ModelFileMetadata } from '~/server/schema/model-file.schema';
 import { withRetries } from '~/server/utils/errorHandling';
 import { getModelVersionsForSearchIndex } from '../selectors/modelVersion.selector';
 import { getUnavailableResources } from '../services/generation/generation.service';
+import { SearchIndexUpdate } from '~/server/search-index/SearchIndexUpdate';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 
 const RATING_BAYESIAN_M = 3.5;
 const RATING_BAYESIAN_C = 10;
@@ -405,20 +406,15 @@ const onFetchItemsToIndex = async ({
 };
 
 const onUpdateQueueProcess = async ({ db, indexName }: { db: PrismaClient; indexName: string }) => {
-  const queuedItems = await db.searchIndexUpdateQueue.findMany({
-    select: {
-      id: true,
-    },
-    where: { type: INDEX_ID, action: SearchIndexUpdateQueueAction.Update },
-  });
+  const queue = await SearchIndexUpdate.getQueue(indexName, SearchIndexUpdateQueueAction.Update);
 
   console.log(
     'onUpdateQueueProcess :: A total of ',
-    queuedItems.length,
+    queue.content.length,
     ' have been updated and will be re-indexed'
   );
 
-  const batchCount = Math.ceil(queuedItems.length / READ_BATCH_SIZE);
+  const batchCount = Math.ceil(queue.content.length / READ_BATCH_SIZE);
 
   const itemsToIndex: Awaited<ReturnType<typeof onFetchItemsToIndex>> = {
     indexReadyRecords: [],
@@ -426,23 +422,22 @@ const onUpdateQueueProcess = async ({ db, indexName }: { db: PrismaClient; index
   };
 
   for (let batchNumber = 0; batchNumber < batchCount; batchNumber++) {
-    const batch = queuedItems.slice(
+    const batch = queue.content.slice(
       batchNumber * READ_BATCH_SIZE,
       batchNumber * READ_BATCH_SIZE + READ_BATCH_SIZE
     );
 
-    const itemIds = batch.map(({ id }) => id);
-
     const { indexReadyRecords, indexRecordsWithImages } = await onFetchItemsToIndex({
       db,
       indexName,
-      whereOr: [{ id: { in: itemIds } }],
+      whereOr: [{ id: { in: batch } }],
     });
 
     itemsToIndex.indexReadyRecords.push(...indexReadyRecords);
     itemsToIndex.indexRecordsWithImages.push(...indexRecordsWithImages);
   }
 
+  await queue.commit();
   return itemsToIndex;
 };
 

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -5,9 +5,9 @@ import {
   CosmeticType,
   MetricTimeframe,
   Prisma,
-  SearchIndexUpdateQueueAction,
   TagTarget,
 } from '@prisma/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { TRPCError } from '@trpc/server';
 import { ManipulateType } from 'dayjs';
 import { truncate } from 'lodash-es';

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -27,7 +27,6 @@ import {
   MetricTimeframe,
   NsfwLevel,
   Prisma,
-  SearchIndexUpdateQueueAction,
 } from '@prisma/client';
 import {
   throwAuthorizationError,
@@ -49,6 +48,7 @@ import {
   ImageSort,
   ModelSort,
   PostSort,
+  SearchIndexUpdateQueueAction,
 } from '~/server/common/enums';
 import {
   deleteImageById,

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -19,7 +19,7 @@ import {
   throwRateLimitError,
   withRetries,
 } from '~/server/utils/errorHandling';
-import { Availability, ModelType, Prisma, SearchIndexUpdateQueueAction } from '@prisma/client';
+import { Availability, ModelType, Prisma } from '@prisma/client';
 import {
   GenerationResourceSelect,
   generationResourceSelect,
@@ -57,6 +57,7 @@ import { modelsSearchIndex } from '~/server/search-index';
 import { createLimiter } from '~/server/utils/rate-limiting';
 import { clickhouse } from '~/server/clickhouse/client';
 import dayjs from 'dayjs';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 
 export function parseModelVersionId(assetId: string) {
   const pattern = /^@civitai\/(\d+)$/;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -8,7 +8,6 @@ import {
   ReportReason,
   ReportStatus,
   ReviewReactions,
-  SearchIndexUpdateQueueAction,
 } from '@prisma/client';
 
 import { TRPCError } from '@trpc/server';
@@ -30,6 +29,7 @@ import {
   ImageUploadProps,
   UpdateImageInput,
 } from '~/server/schema/image.schema';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { articlesSearchIndex, imagesSearchIndex } from '~/server/search-index';
 import { ImageV2Model } from '~/server/selectors/imagev2.selector';
 import { imageTagCompositeSelect, simpleTagSelect } from '~/server/selectors/tag.selector';

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -7,7 +7,6 @@ import {
   ModelType,
   ModelUploadType,
   Prisma,
-  SearchIndexUpdateQueueAction,
   TagTarget,
 } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
@@ -17,7 +16,7 @@ import { SessionUser } from 'next-auth';
 
 import { env } from '~/env/server.mjs';
 import { BaseModel, BaseModelType, CacheTTL } from '~/server/common/constants';
-import { BrowsingMode, ModelSort } from '~/server/common/enums';
+import { BrowsingMode, ModelSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { Context } from '~/server/createContext';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { getDbWithoutLag, preventReplicationLag } from '~/server/db/db-helpers';

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -1,14 +1,7 @@
-import {
-  NsfwLevel,
-  Prisma,
-  SearchIndexUpdateQueueAction,
-  TagSource,
-  TagTarget,
-  TagType,
-} from '@prisma/client';
+import { NsfwLevel, Prisma, TagSource, TagTarget, TagType } from '@prisma/client';
 import { TagVotableEntityType, VotableTagModel } from '~/libs/tags';
 import { constants } from '~/server/common/constants';
-import { TagSort } from '~/server/common/enums';
+import { TagSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 
 import { dbRead, dbWrite } from '~/server/db/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -19,10 +19,9 @@ import {
   NsfwLevel,
   OnboardingStep,
   Prisma,
-  SearchIndexUpdateQueueAction,
   TagEngagementType,
 } from '@prisma/client';
-
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbWrite, dbRead } from '~/server/db/client';
 import { GetByIdInput } from '~/server/schema/base.schema';
 import {

--- a/src/utils/metadata/lists/blocklist-nsfw.json
+++ b/src/utils/metadata/lists/blocklist-nsfw.json
@@ -122,8 +122,6 @@
   "shota.con",
   "shota_con",
   "shotacon",
-  "slave",
-  "slaves",
   "smegma",
   "spic",
   "spics",


### PR DESCRIPTION
This pull request migrates the metric update queue from the current implementation to Redis. This change improves the performance and scalability of the metric update process.