### PR TITLE
Vault - API methods

### DIFF
--- a/src/pages/api/vault/check-vault.tsx
+++ b/src/pages/api/vault/check-vault.tsx
@@ -10,37 +10,36 @@ const schema = z.object({
   modelVersionIds: commaDelimitedNumberArray(),
 });
 
-export default AuthedEndpoint(async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-  user: SessionUser
-) {
-  const results = schema.safeParse(req.query);
-  if (!results.success)
-    return res.status(400).json({ error: `Could not parse provided model versions array.` });
+export default AuthedEndpoint(
+  async function handler(req: NextApiRequest, res: NextApiResponse, user: SessionUser) {
+    const results = schema.safeParse(req.query);
+    if (!results.success)
+      return res.status(400).json({ error: `Could not parse provided model versions array.` });
 
-  const modelVersionIds = results.data.modelVersionIds;
+    const modelVersionIds = results.data.modelVersionIds;
 
-  if (modelVersionIds.length === 0) {
-    return res.status(200).json([]);
-  }
+    if (modelVersionIds.length === 0) {
+      return res.status(200).json([]);
+    }
 
-  try {
-    const vaultItems = await dbRead.vaultItem.findMany({
-      where: {
-        vaultId: user.id,
-        modelVersionId: {
-          in: results.data.modelVersionIds,
+    try {
+      const vaultItems = await dbRead.vaultItem.findMany({
+        where: {
+          vaultId: user.id,
+          modelVersionId: {
+            in: results.data.modelVersionIds,
+          },
         },
-      },
-    });
-    return res.json(
-      modelVersionIds.map((v) => ({
-        modelVersionId: v,
-        vaultItem: vaultItems.find((vi) => vi.modelVersionId === v) ?? null,
-      }))
-    );
-  } catch (error) {
-    return res.status(500).json({ message: 'An unexpected error occurred', error });
-  }
-});
+      });
+      return res.json(
+        modelVersionIds.map((v) => ({
+          modelVersionId: v,
+          vaultItem: vaultItems.find((vi) => vi.modelVersionId === v) ?? null,
+        }))
+      );
+    } catch (error) {
+      return res.status(500).json({ message: 'An unexpected error occurred', error });
+    }
+  },
+  ['GET']
+);

--- a/src/pages/api/vault/check-vault.tsx
+++ b/src/pages/api/vault/check-vault.tsx
@@ -1,0 +1,45 @@
+import { TRPCError } from '@trpc/server';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { SessionUser } from 'next-auth';
+import { z } from 'zod';
+import { dbRead } from '~/server/db/client';
+import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+
+const schema = z.object({
+  modelVersionIds: z.array(z.coerce.number()),
+});
+
+export default AuthedEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: SessionUser
+) {
+  const results = schema.safeParse(req.query);
+  if (!results.success)
+    return res.status(400).json({ error: `Could not parse provided model versions array.` });
+
+  const modelVersionIds = results.data.modelVersionIds;
+
+  if (modelVersionIds.length === 0) {
+    return res.status(200).json([]);
+  }
+
+  try {
+    const vaultItems = await dbRead.vaultItem.findMany({
+      where: {
+        vaultId: user.id,
+        modelVersionId: {
+          in: results.data.modelVersionIds,
+        },
+      },
+    });
+    return res.json(
+      modelVersionIds.map((v) => ({
+        modelVersionId: v,
+        vaultItem: vaultItems.find((vi) => vi.modelVersionId === v) ?? null,
+      }))
+    );
+  } catch (error) {
+    return res.status(500).json({ message: 'An unexpected error occurred', error });
+  }
+});

--- a/src/pages/api/vault/check-vault.tsx
+++ b/src/pages/api/vault/check-vault.tsx
@@ -4,9 +4,10 @@ import { SessionUser } from 'next-auth';
 import { z } from 'zod';
 import { dbRead } from '~/server/db/client';
 import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { commaDelimitedNumberArray } from '~/utils/zod-helpers';
 
 const schema = z.object({
-  modelVersionIds: z.array(z.coerce.number()),
+  modelVersionIds: commaDelimitedNumberArray(),
 });
 
 export default AuthedEndpoint(async function handler(

--- a/src/pages/api/vault/get.tsx
+++ b/src/pages/api/vault/get.tsx
@@ -4,26 +4,25 @@ import { SessionUser } from 'next-auth';
 import { getOrCreateVault } from '~/server/services/vault.service';
 import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
 
-export default AuthedEndpoint(async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-  user: SessionUser
-) {
-  try {
-    const vault = await getOrCreateVault({ userId: user.id });
-    res.json({
-      vault,
-    });
-  } catch (error) {
-    const isTrpcError = error instanceof TRPCError;
-    if (isTrpcError) {
-      const trpcError = error as TRPCError;
-      if (trpcError.cause?.name === 'MEMBERSHIP_REQUIRED') {
-        res.status(200).json({ vault: null });
-        return;
+export default AuthedEndpoint(
+  async function handler(req: NextApiRequest, res: NextApiResponse, user: SessionUser) {
+    try {
+      const vault = await getOrCreateVault({ userId: user.id });
+      res.json({
+        vault,
+      });
+    } catch (error) {
+      const isTrpcError = error instanceof TRPCError;
+      if (isTrpcError) {
+        const trpcError = error as TRPCError;
+        if (trpcError.cause?.name === 'MEMBERSHIP_REQUIRED') {
+          res.status(200).json({ vault: null });
+          return;
+        }
       }
-    }
 
-    res.status(500).json({ message: 'An unexpected error occurred', error });
-  }
-});
+      res.status(500).json({ message: 'An unexpected error occurred', error });
+    }
+  },
+  ['GET']
+);

--- a/src/pages/api/vault/get.tsx
+++ b/src/pages/api/vault/get.tsx
@@ -10,7 +10,7 @@ export default AuthedEndpoint(async function handler(
   user: SessionUser
 ) {
   try {
-    const vault = getOrCreateVault({ userId: user.id });
+    const vault = await getOrCreateVault({ userId: user.id });
     res.json({
       vault,
     });

--- a/src/pages/api/vault/get.tsx
+++ b/src/pages/api/vault/get.tsx
@@ -1,0 +1,29 @@
+import { TRPCError } from '@trpc/server';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { SessionUser } from 'next-auth';
+import { getOrCreateVault } from '~/server/services/vault.service';
+import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+
+export default AuthedEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: SessionUser
+) {
+  try {
+    const vault = getOrCreateVault({ userId: user.id });
+    res.json({
+      vault,
+    });
+  } catch (error) {
+    const isTrpcError = error instanceof TRPCError;
+    if (isTrpcError) {
+      const trpcError = error as TRPCError;
+      if (trpcError.cause?.name === 'MEMBERSHIP_REQUIRED') {
+        res.status(200).json({ vault: null });
+        return;
+      }
+    }
+
+    res.status(500).json({ message: 'An unexpected error occurred', error });
+  }
+});

--- a/src/pages/api/vault/toggle-version.tsx
+++ b/src/pages/api/vault/toggle-version.tsx
@@ -1,0 +1,32 @@
+import { TRPCError } from '@trpc/server';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { SessionUser } from 'next-auth';
+import { z } from 'zod';
+import { getOrCreateVault, toggleModelVersionOnVault } from '~/server/services/vault.service';
+import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+
+const schema = z.object({
+  modelVersionId: z.coerce.number(),
+});
+
+export default AuthedEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: SessionUser
+) {
+  const results = schema.safeParse(req.query);
+  if (!results.success)
+    return res.status(400).json({ error: `Could not parse provided model version` });
+
+  try {
+    await toggleModelVersionOnVault({
+      userId: user.id,
+      modelVersionId: results.data.modelVersionId,
+    });
+    return res.json({
+      success: true,
+    });
+  } catch (error) {
+    return res.status(500).json({ message: 'An unexpected error occurred', error });
+  }
+});

--- a/src/pages/api/vault/toggle-version.tsx
+++ b/src/pages/api/vault/toggle-version.tsx
@@ -9,24 +9,23 @@ const schema = z.object({
   modelVersionId: z.coerce.number(),
 });
 
-export default AuthedEndpoint(async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-  user: SessionUser
-) {
-  const results = schema.safeParse(req.query);
-  if (!results.success)
-    return res.status(400).json({ error: `Could not parse provided model version` });
+export default AuthedEndpoint(
+  async function handler(req: NextApiRequest, res: NextApiResponse, user: SessionUser) {
+    const results = schema.safeParse(req.query);
+    if (!results.success)
+      return res.status(400).json({ error: `Could not parse provided model version` });
 
-  try {
-    await toggleModelVersionOnVault({
-      userId: user.id,
-      modelVersionId: results.data.modelVersionId,
-    });
-    return res.json({
-      success: true,
-    });
-  } catch (error) {
-    return res.status(500).json({ message: 'An unexpected error occurred', error });
-  }
-});
+    try {
+      await toggleModelVersionOnVault({
+        userId: user.id,
+        modelVersionId: results.data.modelVersionId,
+      });
+      return res.json({
+        success: true,
+      });
+    } catch (error) {
+      return res.status(500).json({ message: 'An unexpected error occurred', error });
+    }
+  },
+  ['POST']
+);

--- a/src/server/services/vault.service.ts
+++ b/src/server/services/vault.service.ts
@@ -70,7 +70,10 @@ export const getOrCreateVault = async ({ userId }: { userId: number }) => {
   const isActiveSubscription = ['active', 'trialing'].includes(subscription?.status ?? 'inactive');
 
   if (!subscription || !isActiveSubscription)
-    throw throwBadRequestError('User does not have an active membership.');
+    throw throwBadRequestError(
+      'User does not have an active membership.',
+      new Error('MEMBERSHIP_REQUIRED')
+    );
 
   const tier: string | undefined = (subscription.product.metadata as any)[env.STRIPE_METADATA_KEY];
   type SubscriptionMetadata = {


### PR DESCRIPTION
3 new endpoints:
- `/vault/get`: Returns the user vault. Should be using this to check the storage status, and vault status. Vault will be null if the user does not have a membership and has **never** used the Vault feature.
- `vault/check-vault?modelVersionIds=1&modelVersionIds2`: Returns an array with each model version and - if found - a `vaultItem`. Sample result:
```json
[
  {
    "modelVersionId": 1500,
    "vaultItem": {
      "id": 36,
      "vaultId": 18085,
      "status": "Pending",
      "files": [
        {
          "id": 151,
          "url": "https://5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com/civitai-prod-settled/imported/ms-emoji-30img.11exuzyg.3pq.ckpt",
          "sizeKB": 2082867.794921875,
          "displayName": "Full Model fp16"
        }
      ],
      "modelVersionId": 1500,
      "modelId": 1401,
      "modelName": "2D to 3D Emoji",
      "versionName": "30img",
      "creatorId": 13487,
      "creatorName": "pixelpoint",
      "type": "Checkpoint",
      "baseModel": "SD 1.5",
      "category": "",
      "createdAt": "2022-12-15T17:31:33.598Z",
      "addedAt": "2024-03-14T15:37:45.061Z",
      "refreshedAt": null,
      "modelSizeKb": 2082867,
      "detailsSizeKb": 0,
      "imagesSizeKb": 0,
      "notes": null,
      "meta": {}
    }
  },
  {
    "modelVersionId": 2,
    "vaultItem": null
  }
]

```
- `/vault/toggle-version?modelVersionId=123`: Toggles a model version from the vault. Use only after knowing if the version is in the vault or not ideally.

A separate download API for vault items is already available:
`/api/download/vault/${vaultItem.id}?type=model&fileId=${f.id}`: Where `type='model/images/details'` and the vaultItem is taken from the response above.  The file is optional - by default it will download what we consider the "main" file (the 1st one), but if a model has multiple stored in the vault, we can and should present them as required.
