### PR TITLE
Add automatic cache array clean-up

### DIFF
--- a/src/pages/api/admin/test.ts
+++ b/src/pages/api/admin/test.ts
@@ -1,13 +1,5 @@
-import dayjs from 'dayjs';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { dbRead } from '~/server/db/client';
-import { eventEngine } from '~/server/events';
-import ncmecCaller from '~/server/http/ncmec/ncmec.caller';
-import { REDIS_KEYS } from '~/server/redis/client';
-import { getTopContributors } from '~/server/services/buzz.service';
 import { deleteImagesForModelVersionCache } from '~/server/services/image.service';
-import { getAllHiddenForUser } from '~/server/services/user-preferences.service';
-import { bustCachedArray } from '~/server/utils/cache-helpers';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/internal/redis-usage.ts
+++ b/src/pages/api/internal/redis-usage.ts
@@ -1,0 +1,27 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { redis } from '~/server/redis/client';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { formatBytes } from '~/utils/number-helpers';
+
+export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
+  const memoryByType: Record<string, number> = {};
+  const stream = redis.scanIterator({
+    MATCH: req.query.pattern as string,
+    COUNT: 10000,
+  });
+  const i = 0;
+  for await (const key of stream) {
+    const keyType = await redis.type(key);
+    const memoryUsage = (await redis.memoryUsage(key)) || 0;
+
+    // Accumulate memory usage by type
+    if (!memoryByType[keyType]) memoryByType[keyType] = 0;
+    memoryByType[keyType] += memoryUsage;
+  }
+
+  return res
+    .status(200)
+    .json([
+      ...Object.entries(memoryByType).map(([key, value]) => ({ key, value: formatBytes(value) })),
+    ]);
+});

--- a/src/server/controllers/model-file.controller.ts
+++ b/src/server/controllers/model-file.controller.ts
@@ -9,14 +9,15 @@ import {
 import {
   createFile,
   deleteFile,
-  getFilesByVersionIds,
+  getFilesForModelVersionCache,
   updateFile,
 } from '~/server/services/model-file.service';
 import { handleLogError, throwDbError, throwNotFoundError } from '~/server/utils/errorHandling';
 
 export const getFilesByVersionIdHandler = async ({ input }: { input: GetByIdInput }) => {
   try {
-    return await getFilesByVersionIds({ ids: [input.id] });
+    const data = await getFilesForModelVersionCache([input.id]);
+    return data[input.id];
   } catch (error) {
     throw throwDbError(error);
   }

--- a/src/server/jobs/cache-cleanup.ts
+++ b/src/server/jobs/cache-cleanup.ts
@@ -3,6 +3,7 @@ import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { CacheTTL } from '~/server/common/constants';
 import { mergeQueue } from '~/server/redis/queues';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import * as caches from '~/server/redis/caches';
 
 export const cacheCleanup = createJob('cache-cleanup', '0 */1 * * *', async () => {
   // Clean rate limit keys
@@ -34,4 +35,7 @@ export const cacheCleanup = createJob('cache-cleanup', '0 */1 * * *', async () =
     await mergeQueue(key);
   });
   await limitConcurrency(mergeTasks, 3);
+
+  // Clean up old caches
+  for (const cache of Object.values(caches)) await cache.cleanup();
 });

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1,0 +1,245 @@
+import { CosmeticEntity, CosmeticSource, CosmeticType, Prisma } from '@prisma/client';
+import { CacheTTL } from '~/server/common/constants';
+import { dbWrite, dbRead } from '~/server/db/client';
+import { REDIS_KEYS } from '~/server/redis/client';
+import { ContentDecorationCosmetic, WithClaimKey } from '~/server/selectors/cosmetic.selector';
+import {
+  GenerationResourceSelect,
+  generationResourceSelect,
+} from '~/server/selectors/generation.selector';
+import { ProfileImage } from '~/server/selectors/image.selector';
+import { ModelFileModel, modelFileSelect } from '~/server/selectors/modelFile.selector';
+import {
+  getImagesForModelVersion,
+  getTagIdsForImages,
+  ImagesForModelVersions,
+} from '~/server/services/image.service';
+import { reduceToBasicFileMetadata } from '~/server/services/model-file.service';
+import { CachedObject, createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
+
+export const tagIdsForImagesCache = createCachedObject<{ imageId: number; tags: number[] }>({
+  key: REDIS_KEYS.CACHES.TAG_IDS_FOR_IMAGES,
+  idKey: 'imageId',
+  ttl: CacheTTL.day,
+  async lookupFn(imageId, fromWrite) {
+    const imageIds = Array.isArray(imageId) ? imageId : [imageId];
+    const db = fromWrite ? dbWrite : dbRead;
+    const tags = await db.tagsOnImage.findMany({
+      where: { imageId: { in: imageIds }, disabled: false },
+      select: { tagId: true, imageId: true },
+    });
+
+    const result = tags.reduce((acc, { tagId, imageId }) => {
+      acc[imageId.toString()] ??= { imageId, tags: [] };
+      acc[imageId.toString()].tags.push(tagId);
+      return acc;
+    }, {} as Record<string, { imageId: number; tags: number[] }>);
+    return result;
+  },
+});
+
+type UserCosmeticLookup = {
+  userId: number;
+  cosmetics: {
+    cosmetic: {
+      id: number;
+      name: string;
+      type: CosmeticType;
+      data: Prisma.JsonValue;
+      source: CosmeticSource;
+    };
+    data: Prisma.JsonValue;
+  }[];
+};
+export const userCosmeticCache = createCachedObject<UserCosmeticLookup>({
+  key: REDIS_KEYS.CACHES.COSMETICS,
+  idKey: 'userId',
+  lookupFn: async (ids) => {
+    const userCosmeticsRaw = await dbRead.userCosmetic.findMany({
+      where: { userId: { in: ids }, equippedAt: { not: null }, equippedToId: null },
+      select: {
+        userId: true,
+        data: true,
+        cosmetic: { select: { id: true, data: true, type: true, source: true, name: true } },
+      },
+    });
+    const results = userCosmeticsRaw.reduce((acc, { userId, ...cosmetic }) => {
+      acc[userId] ??= { userId, cosmetics: [] };
+      acc[userId].cosmetics.push(cosmetic);
+      return acc;
+    }, {} as Record<number, UserCosmeticLookup>);
+    return results;
+  },
+  ttl: 60 * 60 * 24, // 24 hours
+});
+
+export const profilePictureCache = createCachedObject<ProfileImage>({
+  key: REDIS_KEYS.CACHES.PROFILE_PICTURES,
+  idKey: 'userId',
+  lookupFn: async (ids) => {
+    const profilePictures = await dbRead.$queryRaw<ProfileImage[]>`
+      SELECT
+        i.id,
+        i.name,
+        i.url,
+        i."nsfwLevel",
+        i.hash,
+        i."userId",
+        i.ingestion,
+        i.type,
+        i.width,
+        i.height,
+        i.metadata
+      FROM "User" u
+      JOIN "Image" i ON i.id = u."profilePictureId"
+      WHERE u.id IN (${Prisma.join(ids as number[])})
+    `;
+    return Object.fromEntries(profilePictures.map((x) => [x.userId, x]));
+  },
+  ttl: 60 * 60 * 24, // 24 hours
+});
+
+type CacheFilesForModelVersions = {
+  modelVersionId: number;
+  files: ModelFileModel[];
+};
+export const filesForModelVersionCache = createCachedObject<CacheFilesForModelVersions>({
+  key: REDIS_KEYS.CACHES.FILES_FOR_MODEL_VERSION,
+  idKey: 'modelVersionId',
+  ttl: CacheTTL.sm,
+  async lookupFn(ids) {
+    let files = await dbRead.modelFile.findMany({
+      where: { modelVersionId: { in: ids } },
+      select: modelFileSelect,
+    });
+    files =
+      files?.map(({ metadata, ...file }) => {
+        return {
+          ...file,
+          metadata: reduceToBasicFileMetadata(metadata),
+        };
+      }) ?? [];
+
+    const records: Record<number, CacheFilesForModelVersions> = {};
+    for (const file of files) {
+      if (!records[file.modelVersionId])
+        records[file.modelVersionId] = { modelVersionId: file.modelVersionId, files: [] };
+      records[file.modelVersionId].files.push(file);
+    }
+    return records;
+  },
+});
+
+type CachedImagesForModelVersions = {
+  modelVersionId: number;
+  images: ImagesForModelVersions[];
+};
+export const imagesForModelVersionsCache = createCachedObject<CachedImagesForModelVersions>({
+  key: REDIS_KEYS.CACHES.IMAGES_FOR_MODEL_VERSION,
+  idKey: 'modelVersionId',
+  ttl: CacheTTL.sm,
+  lookupFn: async (ids) => {
+    const images = await getImagesForModelVersion({ modelVersionIds: ids, imagesPerVersion: 20 });
+
+    const records: Record<number, CachedImagesForModelVersions> = {};
+    for (const image of images) {
+      if (!records[image.modelVersionId])
+        records[image.modelVersionId] = { modelVersionId: image.modelVersionId, images: [] };
+      records[image.modelVersionId].images.push(image);
+    }
+
+    return records;
+  },
+  appendFn: async (records) => {
+    const imageIds = [...records].flatMap((x) => x.images.map((i) => i.id));
+    const tagIdsVar = await getTagIdsForImages(imageIds);
+    for (const entry of records) {
+      for (const image of entry.images) {
+        image.tags = tagIdsVar?.[image.id]?.tags;
+      }
+    }
+  },
+});
+
+export const cosmeticEntityCaches = (() => {
+  const caches = Object.fromEntries(
+    Object.values(CosmeticEntity).map((entity) => [
+      entity as CosmeticEntity,
+      createCachedObject<WithClaimKey<ContentDecorationCosmetic>>({
+        key: `${REDIS_KEYS.CACHES.COSMETICS}:${entity}`,
+        idKey: 'equippedToId',
+        lookupFn: async (ids) => {
+          const entityCosmetics = await dbRead.$queryRaw<WithClaimKey<ContentDecorationCosmetic>[]>`
+            SELECT c.id, c.data, uc."equippedToId", uc."claimKey"
+            FROM "UserCosmetic" uc
+            JOIN "Cosmetic" c ON c.id = uc."cosmeticId"
+            WHERE uc."equippedToId" IN (${Prisma.join(ids as number[])})
+              AND uc."equippedToType" = '${Prisma.raw(entity)}'::"CosmeticEntity"
+              AND c.type = 'ContentDecoration';
+          `;
+          return Object.fromEntries(entityCosmetics.map((x) => [x.equippedToId, x]));
+        },
+        ttl: 60 * 60 * 24, // 24 hours
+      }),
+    ])
+  ) as Record<CosmeticEntity, CachedObject<WithClaimKey<ContentDecorationCosmetic>>>;
+  async function cleanup() {
+    for (const cache of Object.values(caches)) await cache.cleanup();
+  }
+  return {
+    ...caches,
+    cleanup,
+  };
+})();
+
+type CachedUserMultiplier = {
+  userId: number;
+  rewardsMultiplier: number;
+  purchasesMultiplier: number;
+};
+export const userMultipliersCache = createCachedObject<CachedUserMultiplier>({
+  key: REDIS_KEYS.CACHES.MULTIPLIERS_FOR_USER,
+  idKey: 'userId',
+  ttl: CacheTTL.day,
+  lookupFn: async (ids) => {
+    if (ids.length === 0) return {};
+
+    const multipliers = await dbRead.$queryRaw<CachedUserMultiplier[]>`
+      SELECT
+        cs."userId",
+        COALESCE((p.metadata->>'rewardsMultiplier')::float, 1) as "rewardsMultiplier",
+        COALESCE((p.metadata->>'purchasesMultiplier')::float, 1) as "purchasesMultiplier"
+      FROM "CustomerSubscription" cs
+      JOIN "Product" p ON p.id = cs."productId"
+      WHERE cs."userId" IN (${Prisma.join(ids)});
+    `;
+
+    const records: Record<number, CachedUserMultiplier> = Object.fromEntries(
+      multipliers.map((m) => [m.userId, m])
+    );
+    for (const userId of ids) {
+      if (records[userId]) continue;
+      records[userId] = { userId, rewardsMultiplier: 1, purchasesMultiplier: 1 };
+    }
+
+    return records;
+  },
+});
+
+export const resourceDataCache = createCachedArray<GenerationResourceSelect>({
+  key: REDIS_KEYS.GENERATION.RESOURCE_DATA,
+  idKey: 'id',
+  lookupFn: async (ids) => {
+    const dbResults = await dbRead.modelVersion.findMany({
+      where: { id: { in: ids as number[] } },
+      select: generationResourceSelect,
+    });
+
+    const results = dbResults.reduce((acc, result) => {
+      acc[result.id] = result;
+      return acc;
+    }, {} as Record<string, GenerationResourceSelect>);
+    return results;
+  },
+  ttl: CacheTTL.hour,
+});

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -52,11 +52,8 @@ export const REDIS_KEYS = {
     COUNT: 'download:count',
     LIMITS: 'download:limits',
   },
-  TAG_IDS_FOR_IMAGES: 'tagIdsForImages',
-  COSMETICS: 'cosmetics',
-  PROFILE_PICTURES: 'profile-pictures',
+
   BUZZ_EVENTS: 'buzz-events',
-  IMAGES_FOR_MODEL_VERSION: 'images-for-model-version',
   GENERATION: {
     RESOURCE_DATA: 'generation:resource-data',
     COUNT: 'generation:count',
@@ -80,6 +77,10 @@ export const REDIS_KEYS = {
   CACHES: {
     FILES_FOR_MODEL_VERSION: 'caches:files-for-model-version',
     MULTIPLIERS_FOR_USER: 'caches:multipliers-for-user',
+    TAG_IDS_FOR_IMAGES: 'caches:tagIdsForImages',
+    COSMETICS: 'caches:cosmetics',
+    PROFILE_PICTURES: 'caches:profile-pictures',
+    IMAGES_FOR_MODEL_VERSION: 'caches:images-for-model-version',
   },
   QUEUES: {
     BUCKETS: 'queues:buckets',

--- a/src/server/services/cosmetic.service.ts
+++ b/src/server/services/cosmetic.service.ts
@@ -1,18 +1,13 @@
 import { CosmeticEntity, Prisma } from '@prisma/client';
 import dayjs from 'dayjs';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { cosmeticEntityCaches } from '~/server/redis/caches';
 import { GetByIdInput } from '~/server/schema/base.schema';
 import { EquipCosmeticInput, GetPaginatedCosmeticsInput } from '~/server/schema/cosmetic.schema';
-import {
-  ContentDecorationCosmetic,
-  WithClaimKey,
-  simpleCosmeticSelect,
-} from '~/server/selectors/cosmetic.selector';
-import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
-import { REDIS_KEYS } from '~/server/redis/client';
-import { cachedObject, bustCachedArray } from '~/server/utils/cache-helpers';
 import { articlesSearchIndex, imagesSearchIndex, modelsSearchIndex } from '~/server/search-index';
-import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { simpleCosmeticSelect } from '~/server/selectors/cosmetic.selector';
+import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 
 export async function getCosmeticDetail({ id }: GetByIdInput) {
   const cosmetic = await dbRead.cosmetic.findUnique({
@@ -172,24 +167,7 @@ export async function getCosmeticsForEntity({
   entity: CosmeticEntity;
 }) {
   if (ids.length === 0) return {};
-
-  return await cachedObject<WithClaimKey<ContentDecorationCosmetic>>({
-    key: `${REDIS_KEYS.COSMETICS}:${entity}`,
-    idKey: 'equippedToId',
-    ids,
-    lookupFn: async (ids) => {
-      const entityCosmetics = await dbRead.$queryRaw<WithClaimKey<ContentDecorationCosmetic>[]>`
-        SELECT c.id, c.data, uc."equippedToId", uc."claimKey"
-        FROM "UserCosmetic" uc
-        JOIN "Cosmetic" c ON c.id = uc."cosmeticId"
-        WHERE uc."equippedToId" IN (${Prisma.join(ids as number[])})
-              AND uc."equippedToType" = '${Prisma.raw(entity)}'::"CosmeticEntity"
-              AND c.type = 'ContentDecoration';
-      `;
-      return Object.fromEntries(entityCosmetics.map((x) => [x.equippedToId, x]));
-    },
-    ttl: 60 * 60 * 24, // 24 hours
-  });
+  return await cosmeticEntityCaches[entity].fetch(ids);
 }
 
 export async function deleteEntityCosmeticCache({
@@ -199,5 +177,5 @@ export async function deleteEntityCosmeticCache({
   entityId: number;
   entityType: CosmeticEntity;
 }) {
-  await bustCachedArray(`${REDIS_KEYS.COSMETICS}:${entityType}`, 'equippedToId', entityId);
+  return await cosmeticEntityCaches[entityType].bust(entityId);
 }

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -7,8 +7,6 @@ import {
   ReportReason,
   ReportStatus,
   ReviewReactions,
-  TagSource,
-  TagType,
 } from '@prisma/client';
 
 import { TRPCError } from '@trpc/server';
@@ -17,43 +15,63 @@ import { SessionUser } from 'next-auth';
 import { isProd } from '~/env/other';
 import { env } from '~/env/server.mjs';
 import { VotableTagModel } from '~/libs/tags';
-import { BlockedReason, ImageScanType, ImageSort, NsfwLevel } from '~/server/common/enums';
+import { purgeCache } from '~/server/cloudflare/client';
+import { CacheTTL, constants } from '~/server/common/constants';
+import {
+  BlockedReason,
+  ImageScanType,
+  ImageSort,
+  NsfwLevel,
+  SearchIndexUpdateQueueAction,
+} from '~/server/common/enums';
+import { getImageGenerationProcess } from '~/server/common/model-helpers';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { pgDbRead } from '~/server/db/pgDb';
+import { postMetrics } from '~/server/metrics';
+import { leakingContentCounter } from '~/server/prom/client';
+import { imagesForModelVersionsCache, tagIdsForImagesCache } from '~/server/redis/caches';
+import { REDIS_KEYS } from '~/server/redis/client';
+import { GetByIdInput, UserPreferencesInput } from '~/server/schema/base.schema';
 import {
-  GetByIdInput,
-  InfiniteQueryInput,
-  PaginationInput,
-  UserPreferencesInput,
-} from '~/server/schema/base.schema';
-import {
+  AddOrRemoveImageToolsOutput,
   CreateImageSchema,
   GetEntitiesCoverImage,
   GetInfiniteImagesOutput,
   ImageEntityType,
+  ImageRatingReviewOutput,
   ImageReviewQueueInput,
   ImageUploadProps,
-  UpdateImageNsfwLevelOutput,
-  UpdateImageInput,
-  ImageRatingReviewOutput,
   ReportCsamImagesInput,
-  AddOrRemoveImageToolsOutput,
+  UpdateImageInput,
+  UpdateImageNsfwLevelOutput,
   UpdateImageToolsOutput,
 } from '~/server/schema/image.schema';
-import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { articlesSearchIndex, imagesSearchIndex } from '~/server/search-index';
+import { ContentDecorationCosmetic, WithClaimKey } from '~/server/selectors/cosmetic.selector';
+import { ImageResourceHelperModel } from '~/server/selectors/image.selector';
 import { ImageV2Model } from '~/server/selectors/imagev2.selector';
 import { imageTagCompositeSelect, simpleTagSelect } from '~/server/selectors/tag.selector';
+import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
+import { trackModActivity } from '~/server/services/moderator.service';
 import { bustCachesForPost, updatePostNsfwLevel } from '~/server/services/post.service';
+import { bulkSetReportStatus } from '~/server/services/report.service';
 import { getModeratedTags, getTagsNeedingReview } from '~/server/services/system-cache';
+import { getVotableTags2 } from '~/server/services/tag.service';
 import { getCosmeticsForUsers, getProfilePicturesForUsers } from '~/server/services/user.service';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { getPeriods } from '~/server/utils/enum-helpers';
 import {
   throwAuthorizationError,
   throwBadRequestError,
   throwDbError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
+import { getCursor } from '~/server/utils/pagination-helpers';
+import { sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import { Flags } from '~/shared/utils';
 import { logToDb } from '~/utils/logging';
+import { promptWordReplace } from '~/utils/metadata/audit';
+import { baseS3Client } from '~/utils/s3-client';
 import { isDefined } from '~/utils/type-guards';
 import {
   GetImageInput,
@@ -63,29 +81,6 @@ import {
   ingestImageSchema,
   isImageResource,
 } from './../schema/image.schema';
-import { ImageResourceHelperModel } from '~/server/selectors/image.selector';
-import { purgeCache } from '~/server/cloudflare/client';
-import { limitConcurrency } from '~/server/utils/concurrency-helpers';
-import { promptWordReplace } from '~/utils/metadata/audit';
-import { getCursor, getPagination } from '~/server/utils/pagination-helpers';
-import { bustCachedArray, cachedObject, queryCache } from '~/server/utils/cache-helpers';
-import { CacheTTL, constants } from '~/server/common/constants';
-import { getPeriods } from '~/server/utils/enum-helpers';
-import { bulkSetReportStatus } from '~/server/services/report.service';
-import { baseS3Client } from '~/utils/s3-client';
-import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
-import { getImageGenerationProcess } from '~/server/common/model-helpers';
-import { trackModActivity } from '~/server/services/moderator.service';
-import {
-  nsfwBrowsingLevelsArray,
-  sfwBrowsingLevelsFlag,
-} from '~/shared/constants/browsingLevel.constants';
-import { getVotableTags2 } from '~/server/services/tag.service';
-import { Flags } from '~/shared/utils';
-import { ContentDecorationCosmetic, WithClaimKey } from '~/server/selectors/cosmetic.selector';
-import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
-import { leakingContentCounter } from '~/server/prom/client';
-import { postMetrics } from '~/server/metrics';
 // TODO.ingestion - logToDb something something 'axiom'
 
 // no user should have to see images on the site that haven't been scanned or are queued for removal
@@ -1085,30 +1080,14 @@ export const getAllImages = async ({
   };
 };
 
-async function tagLookup(imageId: number | number[], fromWrite = false) {
-  const imageIds = Array.isArray(imageId) ? imageId : [imageId];
-  const db = fromWrite ? dbWrite : dbRead;
-  const tags = await db.tagsOnImage.findMany({
-    where: { imageId: { in: imageIds }, disabled: false },
-    select: { tagId: true, imageId: true },
-  });
-
-  const result = tags.reduce((acc, { tagId, imageId }) => {
-    acc[imageId.toString()] ??= { imageId, tags: [] };
-    acc[imageId.toString()].tags.push(tagId);
-    return acc;
-  }, {} as Record<string, { imageId: number; tags: number[] }>);
-  return result;
-}
-
 export async function getTagIdsForImages(imageIds: number[]) {
-  return await cachedObject<{ imageId: number; tags: number[] }>({
-    key: REDIS_KEYS.TAG_IDS_FOR_IMAGES,
-    idKey: 'imageId',
-    ids: imageIds,
-    ttl: CacheTTL.day,
-    lookupFn: tagLookup,
-  });
+  return await tagIdsForImagesCache.fetch(imageIds);
+}
+export async function clearImageTagIdsCache(imageId: number | number[]) {
+  await tagIdsForImagesCache.bust(imageId);
+}
+export async function updateImageTagIdsForImages(imageId: number | number[]) {
+  await tagIdsForImagesCache.refresh(imageId);
 }
 
 export async function getTagNamesForImages(imageIds: number[]) {
@@ -1139,27 +1118,6 @@ export async function getResourceIdsForImages(imageIds: number[]) {
     return acc;
   }, {} as Record<number, number[]>);
   return imageResources;
-}
-
-export async function clearImageTagIdsCache(imageId: number | number[]) {
-  const imageIds = Array.isArray(imageId) ? imageId : [imageId];
-  if (!imageIds.length) return;
-
-  await redis.hDel(
-    REDIS_KEYS.TAG_IDS_FOR_IMAGES,
-    imageIds.map((x) => x.toString())
-  );
-}
-
-export async function updateImageTagIdsForImages(imageId: number | number[]) {
-  const results = await tagLookup(imageId, true);
-  if (Object.keys(results).length === 0) return;
-
-  const cachedAt = Date.now();
-  const toCache = Object.fromEntries(
-    Object.entries(results).map(([key, x]) => [key, JSON.stringify({ ...x, cachedAt })])
-  );
-  await redis.hSet(REDIS_KEYS.TAG_IDS_FOR_IMAGES, toCache);
 }
 
 type GetImageRaw = GetAllImagesRaw & {
@@ -1327,7 +1285,7 @@ export const getImageResources = async ({ id }: GetByIdInput) => {
   return resources;
 };
 
-type ImagesForModelVersions = {
+export type ImagesForModelVersions = {
   id: number;
   userId: number;
   name: string;
@@ -1516,42 +1474,11 @@ export const getImagesForModelVersion = async ({
   return images;
 };
 
-type CachedImagesForModelVersions = {
-  modelVersionId: number;
-  images: ImagesForModelVersions[];
-};
 export async function getImagesForModelVersionCache(modelVersionIds: number[]) {
-  return await cachedObject<CachedImagesForModelVersions>({
-    key: REDIS_KEYS.IMAGES_FOR_MODEL_VERSION,
-    idKey: 'modelVersionId',
-    ids: modelVersionIds,
-    ttl: CacheTTL.sm,
-    lookupFn: async (ids) => {
-      const images = await getImagesForModelVersion({ modelVersionIds: ids, imagesPerVersion: 20 });
-
-      const records: Record<number, CachedImagesForModelVersions> = {};
-      for (const image of images) {
-        if (!records[image.modelVersionId])
-          records[image.modelVersionId] = { modelVersionId: image.modelVersionId, images: [] };
-        records[image.modelVersionId].images.push(image);
-      }
-
-      return records;
-    },
-    appendFn: async (records) => {
-      const imageIds = [...records].flatMap((x) => x.images.map((i) => i.id));
-      const tagIdsVar = await getTagIdsForImages(imageIds);
-      for (const entry of records) {
-        for (const image of entry.images) {
-          image.tags = tagIdsVar?.[image.id]?.tags;
-        }
-      }
-    },
-  });
+  return await imagesForModelVersionsCache.fetch(modelVersionIds);
 }
-
 export async function deleteImagesForModelVersionCache(modelVersionId: number) {
-  await bustCachedArray(REDIS_KEYS.IMAGES_FOR_MODEL_VERSION, 'modelVersionId', modelVersionId);
+  await imagesForModelVersionsCache.bust(modelVersionId);
 }
 
 export const getImagesForPosts = async ({

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -46,17 +46,15 @@ export async function bustCacheTag(tag: string | string[]) {
 
 type CachedLookupOptions<T extends object> = {
   key: string;
-  ids: number[];
   idKey: keyof T;
-  lookupFn: (ids: number[]) => Promise<Record<string, object>>;
+  lookupFn: (ids: number[], fromWrite?: boolean) => Promise<Record<string, object>>;
   appendFn?: (results: Set<T>) => Promise<void>;
   ttl?: number;
   debounceTime?: number;
   cacheNotFound?: boolean;
 };
-export async function cachedArray<T extends object>({
+export function createCachedArray<T extends object>({
   key,
-  ids,
   idKey,
   lookupFn,
   appendFn,
@@ -64,82 +62,122 @@ export async function cachedArray<T extends object>({
   debounceTime = 10,
   cacheNotFound = true,
 }: CachedLookupOptions<T>) {
-  if (!ids.length) return [];
-  const results = new Set<T>();
-  const cacheJsons = await redis.hmGet(key, ids.map(String));
-  const cacheArray = cacheJsons.filter((x) => x !== null).map((x) => JSON.parse(x));
-  const cache = Object.fromEntries(cacheArray.map((x) => [x[idKey], x]));
+  async function fetch(ids: number[]) {
+    const results = new Set<T>();
+    const cacheJsons = await redis.hmGet(key, ids.map(String));
+    const cacheArray = cacheJsons.filter((x) => x !== null).map((x) => JSON.parse(x));
+    const cache = Object.fromEntries(cacheArray.map((x) => [x[idKey], x]));
 
-  const cacheCutoff = Date.now() - ttl * 1000; // convert to ms (keeping ttl in seconds for redis similarity)
-  const cacheDebounceCutoff = Date.now() - debounceTime * 1000;
-  const cacheMisses = new Set<number>();
-  const dontCache = new Set<number>();
-  for (const id of [...new Set(ids)]) {
-    const cached = cache[id];
-    if (cached && cached.cachedAt > cacheCutoff) {
-      if (cached.notFound) continue;
-      if (cached.debounce) {
-        if (cached.cachedAt > cacheDebounceCutoff) dontCache.add(id);
-        cacheMisses.add(id);
-        continue;
-      }
-      results.add(cached);
-    } else cacheMisses.add(id);
-  }
-
-  if (dontCache.size > 0)
-    log(`${key}: Cache debounce - ${dontCache.size} items: ${[...dontCache].join(', ')}`);
-
-  // If we have cache misses, we need to fetch from the DB
-  if (cacheMisses.size > 0) {
-    log(`${key}: Cache miss - ${cacheMisses.size} items: ${[...cacheMisses].join(', ')}`);
-    const dbResults = await lookupFn([...cacheMisses] as typeof ids);
-
-    const toCache: Record<string, string> = {};
-    const toCacheNotFound: Record<string, string> = {};
-    const cachedAt = Date.now();
-    for (const id of cacheMisses) {
-      const result = dbResults[id];
-      if (!result) {
-        if (cacheNotFound)
-          toCacheNotFound[id] = JSON.stringify({ [idKey]: id, notFound: true, cachedAt });
-        continue;
-      }
-      results.add(result as T);
-      if (!dontCache.has(id)) toCache[id] = JSON.stringify({ ...result, cachedAt });
+    const cacheCutoff = Date.now() - ttl * 1000; // convert to ms (keeping ttl in seconds for redis similarity)
+    const cacheDebounceCutoff = Date.now() - debounceTime * 1000;
+    const cacheMisses = new Set<number>();
+    const dontCache = new Set<number>();
+    for (const id of [...new Set(ids)]) {
+      const cached = cache[id];
+      if (cached && cached.cachedAt > cacheCutoff) {
+        if (cached.notFound) continue;
+        if (cached.debounce) {
+          if (cached.cachedAt > cacheDebounceCutoff) dontCache.add(id);
+          cacheMisses.add(id);
+          continue;
+        }
+        results.add(cached);
+      } else cacheMisses.add(id);
     }
 
-    // then cache the results
-    if (Object.keys(toCache).length > 0) await redis.hSet(key, toCache);
+    if (dontCache.size > 0)
+      log(`${key}: Cache debounce - ${dontCache.size} items: ${[...dontCache].join(', ')}`);
 
-    // Use NX to avoid overwriting a value with a not found...
-    if (Object.keys(toCacheNotFound).length > 0)
-      for (const [id, value] of Object.entries(toCacheNotFound)) await redis.hSetNX(key, id, value);
+    // If we have cache misses, we need to fetch from the DB
+    if (cacheMisses.size > 0) {
+      log(`${key}: Cache miss - ${cacheMisses.size} items: ${[...cacheMisses].join(', ')}`);
+      const dbResults = await lookupFn([...cacheMisses] as typeof ids);
+
+      const toCache: Record<string, string> = {};
+      const toCacheNotFound: Record<string, string> = {};
+      const cachedAt = Date.now();
+      for (const id of cacheMisses) {
+        const result = dbResults[id];
+        if (!result) {
+          if (cacheNotFound)
+            toCacheNotFound[id] = JSON.stringify({ [idKey]: id, notFound: true, cachedAt });
+          continue;
+        }
+        results.add(result as T);
+        if (!dontCache.has(id)) toCache[id] = JSON.stringify({ ...result, cachedAt });
+      }
+
+      // then cache the results
+      if (Object.keys(toCache).length > 0) await redis.hSet(key, toCache);
+
+      // Use NX to avoid overwriting a value with a not found...
+      if (Object.keys(toCacheNotFound).length > 0)
+        for (const [id, value] of Object.entries(toCacheNotFound))
+          await redis.hSetNX(key, id, value);
+    }
+
+    if (appendFn) await appendFn(results);
+
+    return [...results];
   }
 
-  if (appendFn) await appendFn(results);
+  async function bust(id: number | number[]) {
+    const ids = Array.isArray(id) ? id : [id];
+    if (ids.length === 0) return;
 
-  return [...results];
+    const cachedAt = Date.now();
+    const toCache = Object.fromEntries(
+      ids.map((id) => [id, JSON.stringify({ [idKey]: id, cachedAt, debounce: true })])
+    ) as Record<string, string>;
+    await redis.hSet(key, toCache);
+    log(`Busted ${ids.length} ${key} items: ${ids.join(', ')}`);
+  }
+
+  async function refresh(id: number | number[]) {
+    if (!Array.isArray(id)) id = [id];
+
+    const results = await lookupFn(id, true);
+    const cachedAt = Date.now();
+    const toCache = Object.fromEntries(
+      Object.entries(results).map(([key, x]) => [key, JSON.stringify({ ...x, cachedAt })])
+    );
+    await redis.hSet(key, toCache);
+
+    const toRemove = id.filter((x) => !results[x]).map(String);
+    await redis.hDel(key, toRemove);
+  }
+
+  async function cleanup() {
+    const toRemove: string[] = [];
+    const cacheJsons = await redis.hGetAll(key);
+    const cacheCutoff = Date.now() - ttl * 1000;
+    for (const [id, cachedJson] of Object.entries(cacheJsons)) {
+      if (!cachedJson) toRemove.push(id);
+      else {
+        const cached = JSON.parse(cachedJson);
+        if (cached.cachedAt < cacheCutoff) toRemove.push(id);
+      }
+    }
+    if (toRemove.length > 0) await redis.hDel(key, toRemove);
+  }
+
+  return { fetch, bust, refresh, cleanup };
 }
+export type CachedArray<T extends object> = ReturnType<typeof createCachedArray<T>>;
 
-export async function bustCachedArray(key: string, idKey: string, id: number | number[]) {
-  const ids = Array.isArray(id) ? id : [id];
-  if (ids.length === 0) return;
+export function createCachedObject<T extends object>(lookupOptions: CachedLookupOptions<T>) {
+  const cachedArray = createCachedArray<T>(lookupOptions);
 
-  const cachedAt = Date.now();
-  const toCache = Object.fromEntries(
-    ids.map((id) => [id, JSON.stringify({ [idKey]: id, cachedAt, debounce: true })])
-  ) as Record<string, string>;
-  await redis.hSet(key, toCache);
-  log(`Busted ${ids.length} ${key} items: ${ids.join(', ')}`);
+  async function fetch(ids: number[]) {
+    const results = await cachedArray.fetch(ids);
+    return Object.fromEntries(
+      results.map((x) => [(x[lookupOptions.idKey] as number | string).toString(), x])
+    ) as Record<string, T>;
+  }
+
+  return { ...cachedArray, fetch };
 }
-
-export async function cachedObject<T extends object>(lookupOptions: CachedLookupOptions<T>) {
-  const results = await cachedArray<T>(lookupOptions);
-  return Object.fromEntries(
-    results.map((x) => [(x[lookupOptions.idKey] as number | string).toString(), x])
-  ) as Record<string, T>;
-}
+export type CachedObject<T extends object> = ReturnType<typeof createCachedObject<T>>;
 
 export type CachedCounterOptions = {
   ttl?: number;


### PR DESCRIPTION
Previously the TTL on cached arrays and objects only made it so that we fetched fresh data when the data exceeded the expiry date, this left a lot of stale data in redis.

This change makes them an entity that includes helpful functions like fetch, bust, refresh, and clean-up. We then use the clean-up function on an hourly basis to clean up stale cached data.

**Note**: When this is merged and deployed, we need to remove the following old caches after deploying:
- `tagIdsForImages`
- `cosmetics`
- `profile-pictures`
- `images-for-model-version`

These have all been moved to `caches:*` so that we can more easily assess the size of all caches at once.