### PR TITLE
Update collection for permissions query to a raw sql one for performance

### DIFF
--- a/src/server/controllers/collection.controller.ts
+++ b/src/server/controllers/collection.controller.ts
@@ -145,14 +145,6 @@ export const getAllUserCollectionsHandler = async ({
         ...input,
         userId: user.id,
       },
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        image: true,
-        read: true,
-        userId: true,
-      },
     });
 
     return collections;

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -262,7 +262,7 @@ export const getUserCollectionsWithPermissions = async <
 
   const queries: Prisma.Sql[] = [
     Prisma.sql`(
-      SELECT c."id", c."name", c."description", c."read", c."userId", c."write"
+      ${SELECT}
       FROM "Collection" c
       WHERE "userId" = ${userId} 
         ${AND.length > 0 ? Prisma.sql`AND ${Prisma.join(AND, ',')}` : Prisma.sql``}

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -249,7 +249,7 @@ export const getUserCollectionsWithPermissions = async <
 }: {
   input: GetAllUserCollectionsInputSchema & { userId: number };
 }) => {
-  const { userId, permissions, permission, contributingOnly } = input;
+  const { userId, permissions, permission, contributingOnly = true } = input;
   // By default, owned collections will be always returned
   const AND: Prisma.Sql[] = [];
   const SELECT: Prisma.Sql = Prisma.raw(

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -320,13 +320,18 @@ export const getUserCollectionsWithPermissions = async <
     ${Prisma.join(queries, ' UNION ')}
   `;
 
-  const images = await dbRead.image.findMany({
-    where: {
-      id: {
-        in: collections.map((c) => c.imageId).filter(isDefined),
-      },
-    },
-  });
+  const collectionImageIds = collections.map((c) => c.imageId).filter(isDefined);
+
+  const images =
+    collectionImageIds.length > 0
+      ? await dbRead.image.findMany({
+          where: {
+            id: {
+              in: collectionImageIds,
+            },
+          },
+        })
+      : [];
 
   // Return user collections first && add isOwner  property
   return collections


### PR DESCRIPTION
As per koen - this query is taking 12% of our total db usage. Using the proposed approach of unions here - feels much faster out of the gate.