### PR TITLE
✨ feat: Add 'minor' field to Model schema and integrate into model details editor and generation service

### DIFF
--- a/prisma/migrations/20240610185726_add_minor_field/migration.sql
+++ b/prisma/migrations/20240610185726_add_minor_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Model" ADD COLUMN "minor" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -499,6 +499,7 @@ model Model {
   nsfw                Boolean         @default(false)
   tosViolation        Boolean         @default(false)
   poi                 Boolean         @default(false)
+  minor               Boolean         @default(false)
   userId              Int
   user                User            @relation("creator", fields: [userId], references: [id])
   status              ModelStatus     @default(Draft)

--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -58,6 +58,9 @@ const schema = modelUpsertSchema
   })
   .refine((data) => !(data.nsfw && data.poi), {
     message: 'Mature content depicting actual people is not permitted.',
+  })
+  .refine((data) => !(data.nsfw && data.minor), {
+    message: 'Mature content depicting minors is not permitted.',
   });
 const querySchema = z.object({
   category: z.preprocess(parseNumericString, z.number().optional()),
@@ -72,7 +75,7 @@ const commercialUseOptions: Array<{ value: CommercialUse; label: string }> = [
   { value: CommercialUse.Sell, label: 'Sell this model or merges' },
 ];
 
-const lockableProperties = ['nsfw', 'poi', 'category', 'tags'];
+const lockableProperties = ['nsfw', 'poi', 'minor', 'category', 'tags'];
 
 export function ModelUpsertForm({ model, children, onSubmit }: Props) {
   const router = useRouter();
@@ -376,6 +379,12 @@ export function ModelUpsertForm({ model, children, onSubmit }: Props) {
                   label="Is intended to produce mature themes"
                   disabled={isLocked('nsfw')}
                   description={isLockedDescription('category')}
+                />
+                <InputCheckbox
+                  name="minor"
+                  label="Depicts a minor"
+                  disabled={isLocked('minor')}
+                  description={isLockedDescription('minor')}
                 />
               </Stack>
             </Paper>

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -284,17 +284,16 @@ async function handleSuccess({ id, tags: incomingTags = [], source, context }: B
         WITH to_check AS (
           -- Check based on associated resources
           SELECT
-            COUNT(*) > 0 "poi",
-            COUNT(*) FILTER (WHERE m.minor) > 0 "minor"
+            SUM(IIF(b.poi, 1, 0)) > 0 "poi",
+            SUM(IIF(m.minor, 1, 0)) > 0 "minor"
           FROM "ImageResource" ir
           JOIN "ModelVersion" mv ON ir."modelVersionId" = mv.id
-          JOIN "Model" m ON m.id = mv.id
+          JOIN "Model" m ON m.id = mv."modelId"
           WHERE ir."imageId" = ${image.id} AND m.poi
           UNION
           -- Check based on associated bounties
           SELECT
-            SUM(IIF(b.poi, 1, 0)) > 0 "poi",
-            false as "minor"
+            SUM(IIF(b.poi, 1, 0)) > 0 "poi"
           FROM "Image" i
           JOIN "ImageConnection" ic ON ic."imageId" = i.id
           JOIN "Bounty" b ON ic."entityType" = 'Bounty' AND b.id = ic."entityId"
@@ -302,8 +301,7 @@ async function handleSuccess({ id, tags: incomingTags = [], source, context }: B
           UNION
           -- Check based on associated bounty entries
           SELECT
-            SUM(IIF(b.poi, 1, 0)) > 0 "poi",
-            false as "minor"
+            SUM(IIF(b.poi, 1, 0)) > 0 "poi"
           FROM "Image" i
           JOIN "ImageConnection" ic ON ic."imageId" = i.id
           JOIN "BountyEntry" be ON ic."entityType" = 'BountyEntry' AND be.id = ic."entityId"

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -288,12 +288,13 @@ async function handleSuccess({ id, tags: incomingTags = [], source, context }: B
             COUNT(*) FILTER (WHERE m.minor) > 0 "minor"
           FROM "ImageResource" ir
           JOIN "ModelVersion" mv ON ir."modelVersionId" = mv.id
-          JOIN "Model" m ON m.id = mv."modelId"
-          WHERE ir."imageId" = ${image.id}
+          JOIN "Model" m ON m.id = mv.id
+          WHERE ir."imageId" = ${image.id} AND m.poi
           UNION
           -- Check based on associated bounties
           SELECT
-            SUM(IIF(b.poi, 1, 0)) > 0 "poi"
+            SUM(IIF(b.poi, 1, 0)) > 0 "poi",
+            false as "minor"
           FROM "Image" i
           JOIN "ImageConnection" ic ON ic."imageId" = i.id
           JOIN "Bounty" b ON ic."entityType" = 'Bounty' AND b.id = ic."entityId"
@@ -301,7 +302,8 @@ async function handleSuccess({ id, tags: incomingTags = [], source, context }: B
           UNION
           -- Check based on associated bounty entries
           SELECT
-            SUM(IIF(b.poi, 1, 0)) > 0 "poi"
+            SUM(IIF(b.poi, 1, 0)) > 0 "poi",
+            false as "minor"
           FROM "Image" i
           JOIN "ImageConnection" ic ON ic."imageId" = i.id
           JOIN "BountyEntry" be ON ic."entityType" = 'BountyEntry' AND be.id = ic."entityId"

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -358,10 +358,13 @@ export const upsertModelHandler = async ({
 }) => {
   try {
     const { id: userId } = ctx.user;
-    const { nsfw, poi } = input;
+    const { nsfw, poi, minor } = input;
 
     if (nsfw && poi)
       throw throwBadRequestError('Mature content depicting actual people is not permitted.');
+
+    if (nsfw && minor)
+      throw throwBadRequestError('Mature content depicting minors is not permitted.');
 
     // Check tags for multiple categories
     const { tagsOnModels } = input;

--- a/src/server/schema/generation.schema.ts
+++ b/src/server/schema/generation.schema.ts
@@ -48,6 +48,7 @@ export const generationResourceSchema = z.object({
   minStrength: z.number().optional(),
   maxStrength: z.number().optional(),
   image: imageSchema.pick({ url: true }).optional(),
+  minor: z.boolean().optional(),
 
   // navigation props
   covered: z.boolean().optional(),

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -182,6 +182,7 @@ export const modelUpsertSchema = licensingSchema.extend({
   bountyId: z.number().optional(),
   nsfw: z.boolean().optional(),
   lockedProperties: z.string().array().optional(),
+  minor: z.boolean().default(false),
 });
 
 export type UpdateGallerySettingsInput = z.infer<typeof updateGallerySettingsSchema>;

--- a/src/server/selectors/generation.selector.ts
+++ b/src/server/selectors/generation.selector.ts
@@ -17,6 +17,7 @@ export const generationResourceSelect = Prisma.validator<Prisma.ModelVersionSele
       type: true,
       nsfw: true,
       poi: true,
+      minor: true,
     },
   },
 });

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -691,6 +691,11 @@ export const createGenerationRequest = async ({
   const isPromptNsfw = includesNsfw(params.prompt);
   nsfw ??= isPromptNsfw !== false;
 
+  const hasMinorResource = resourceData.some((resource) => resource.model.minor);
+  if (hasMinorResource) {
+    nsfw = false;
+  }
+
   // Disable nsfw if the prompt contains minor words
   // POI is handled via SPMs within the worker
   if (includesMinor(params.prompt)) nsfw = false;
@@ -940,6 +945,7 @@ const getImageGenerationData = async (id: number): Promise<Generation.Data> => {
       m.id "modelId",
       m.name "modelName",
       m.type "modelType",
+      m.minor,
       ir."hash",
       ir.strength,
       gc.covered

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -945,7 +945,6 @@ const getImageGenerationData = async (id: number): Promise<Generation.Data> => {
       m.id "modelId",
       m.name "modelName",
       m.type "modelType",
-      m.minor,
       ir."hash",
       ir.strength,
       gc.covered


### PR DESCRIPTION
### What's changed
- Added `minor` field to the Model schema in prisma.
- Updated the `ModelUpsertForm` to include a checkbox for `minor`.
- Added validation to prevent NSFW content depicting minors.
- Updated `generationResourceSelect` to include `minor` field.
- Modified `createGenerationRequest` to disable NSFW if any resource is marked as `minor`.
- Updated model controller to handle `minor` field.
- Adjusted zod schemas to include `minor` field.