### PR TITLE
✨ feat: Add poi and minor indicator for mod

### DIFF
--- a/src/components/Cards/Cards.styles.ts
+++ b/src/components/Cards/Cards.styles.ts
@@ -138,6 +138,11 @@ export const useCardStyles = createStyles<string, { aspectRatio: number }>(
         },
       },
 
+      forMod: {
+        backgroundColor: theme.fn.rgba('#E0BBE4', 0.8), // Light violet color
+        color: theme.white,
+      },
+
       reactions: {
         borderRadius: theme.radius.sm,
         backgroundColor: theme.fn.rgba('#000', 0.31),

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -189,6 +189,9 @@ export function ModelCard({ data, forceInView }: Props) {
   const isArchived = data.mode === ModelModifier.Archived;
   const onSite = !!data.version.trainingStatus;
 
+  const isPOI = data.poi;
+  const isMinor = data.minor;
+
   const thumbsUpCount = data.rank?.thumbsUpCount ?? 0;
   const thumbsDownCount = data.rank?.thumbsDownCount ?? 0;
   const totalCount = thumbsUpCount + thumbsDownCount;
@@ -224,6 +227,28 @@ export function ModelCard({ data, forceInView }: Props) {
                       >
                         <Group spacing={4}>
                           <ImageGuard2.BlurToggle className={classes.chip} />
+                          {currentUser?.isModerator && isPOI && (
+                            <Badge
+                              className={cx(classes.infoChip, classes.chip, classes.forMod)}
+                              variant="light"
+                              radius="xl"
+                            >
+                              <Text color="white" size="xs" transform="capitalize">
+                                POI
+                              </Text>
+                            </Badge>
+                          )}
+                          {currentUser?.isModerator && isMinor && (
+                            <Badge
+                              className={cx(classes.infoChip, classes.chip, classes.forMod)}
+                              variant="light"
+                              radius="xl"
+                            >
+                              <Text color="white" size="xs" transform="capitalize">
+                                Minor
+                              </Text>
+                            </Badge>
+                          )}
                           <Badge
                             className={cx(classes.infoChip, classes.chip)}
                             variant="light"
@@ -232,6 +257,7 @@ export function ModelCard({ data, forceInView }: Props) {
                             <Text color="white" size="xs" transform="capitalize">
                               {getDisplayName(data.type)}
                             </Text>
+
                             {isSDXL && (
                               <>
                                 <Divider orientation="vertical" />
@@ -354,8 +380,8 @@ export function ModelCard({ data, forceInView }: Props) {
                             alt={
                               image.meta
                                 ? truncate((image.meta as ImageMetaProps).prompt, {
-                                    length: 125,
-                                  })
+                                  length: 125,
+                                })
                                 : undefined
                             }
                             type={image.type}
@@ -395,37 +421,37 @@ export function ModelCard({ data, forceInView }: Props) {
                     {(!!data.rank.downloadCount ||
                       !!data.rank.collectedCount ||
                       !!data.rank.tippedAmountCount) && (
-                      <Badge
-                        className={cx(classes.statChip, classes.chip)}
-                        variant="light"
-                        radius="xl"
-                      >
-                        <Group spacing={2}>
-                          <IconDownload size={14} strokeWidth={2.5} />
-                          <Text size="xs">{abbreviateNumber(data.rank.downloadCount)}</Text>
-                        </Group>
-                        <Group spacing={2}>
-                          <IconBookmark size={14} strokeWidth={2.5} />
-                          <Text size="xs">{abbreviateNumber(data.rank.collectedCount)}</Text>
-                        </Group>
-                        <Group spacing={2}>
-                          <IconMessageCircle2 size={14} strokeWidth={2.5} />
-                          <Text size="xs">{abbreviateNumber(data.rank.commentCount)}</Text>
-                        </Group>
-                        <InteractiveTipBuzzButton
-                          toUserId={data.user.id}
-                          entityType={'Model'}
-                          entityId={data.id}
+                        <Badge
+                          className={cx(classes.statChip, classes.chip)}
+                          variant="light"
+                          radius="xl"
                         >
                           <Group spacing={2}>
-                            <IconBolt size={14} strokeWidth={2.5} />
-                            <Text size="xs" tt="uppercase">
-                              {abbreviateNumber(data.rank.tippedAmountCount + tippedAmount)}
-                            </Text>
+                            <IconDownload size={14} strokeWidth={2.5} />
+                            <Text size="xs">{abbreviateNumber(data.rank.downloadCount)}</Text>
                           </Group>
-                        </InteractiveTipBuzzButton>
-                      </Badge>
-                    )}
+                          <Group spacing={2}>
+                            <IconBookmark size={14} strokeWidth={2.5} />
+                            <Text size="xs">{abbreviateNumber(data.rank.collectedCount)}</Text>
+                          </Group>
+                          <Group spacing={2}>
+                            <IconMessageCircle2 size={14} strokeWidth={2.5} />
+                            <Text size="xs">{abbreviateNumber(data.rank.commentCount)}</Text>
+                          </Group>
+                          <InteractiveTipBuzzButton
+                            toUserId={data.user.id}
+                            entityType={'Model'}
+                            entityId={data.id}
+                          >
+                            <Group spacing={2}>
+                              <IconBolt size={14} strokeWidth={2.5} />
+                              <Text size="xs" tt="uppercase">
+                                {abbreviateNumber(data.rank.tippedAmountCount + tippedAmount)}
+                              </Text>
+                            </Group>
+                          </InteractiveTipBuzzButton>
+                        </Badge>
+                      )}
                     {!data.locked && !!data.rank.thumbsUpCount && (
                       <Badge
                         className={cx(classes.statChip, classes.chip)}

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -543,14 +543,14 @@ export const getModelsRaw = async ({
       m."name",
       ${ifDetails`
         m."description",
-        m."poi",
-        m."minor",
         m."allowNoCredit",
         m."allowCommercialUse",
         m."allowDerivatives",
         m."allowDifferentLicense",
       `}
       m."type",
+      m."minor",
+      m."poi",
       m."nsfw",
       m."nsfwLevel",
       m."status",


### PR DESCRIPTION
### What's changed
- Moved querying `m.minor` and `m.poi` out of `ifDetails` conditional scope in `model.service.ts`.
- Render badge for minor and poi in moderator view.

![image](https://github.com/civitai/civitai/assets/34775928/934652fc-022c-499b-a938-d800f553d405)
