### PR TITLE
[CU-8688tpuuk] fix: posts not showing image count

### DIFF
--- a/src/components/Reaction/Reactions.tsx
+++ b/src/components/Reaction/Reactions.tsx
@@ -46,7 +46,7 @@ export function PostReactions({
   imageCount?: number;
 } & GroupProps) {
   const total = Object.values(metrics).reduce((acc, val) => acc + (val ?? 0), 0);
-  if (total === 0) return null;
+  if (total === 0 && imageCount === 0) return null;
 
   return (
     <Group spacing="xs" sx={{ cursor: 'default' }} {...groupProps}>
@@ -58,12 +58,14 @@ export function PostReactions({
           </Text>
         </Group>
       )}
-      <Group spacing={4} align="center">
-        <IconHeart size={20} strokeWidth={2} />
-        <Text size="sm" weight={500} pr={2}>
-          {total}
-        </Text>
-      </Group>
+      {total > 0 && (
+        <Group spacing={4} align="center">
+          <IconHeart size={20} strokeWidth={2} />
+          <Text size="sm" weight={500} pr={2}>
+            {total}
+          </Text>
+        </Group>
+      )}
     </Group>
   );
 }


### PR DESCRIPTION
closes: https://app.clickup.com/t/8688tpuuk

**steps to reproduce error**
1. go to a profile's posts list: https://civitai.com/user/Kluknawa235/posts
2. Look for this post: https://civitai.com/user/Kluknawa235/posts
3. this posts doesn't have reactions, this is why no showing image count

**After this fix**

1. You should be able to see image count, but no reactions count because it doesn't have it.