### PR TITLE
Tipping collaborators

### DIFF
--- a/src/components/Buzz/buzz.utils.ts
+++ b/src/components/Buzz/buzz.utils.ts
@@ -85,7 +85,7 @@ export const useBuzzTransaction = (opts?: {
   const tipUserMutation = trpc.buzz.tipUser.useMutation({
     onError(error) {
       showErrorNotification({
-        title: 'Looks like there was an error with your tip.',
+        title: 'Looks like there was an error sending your tip.',
         error: new Error(error.message),
       });
     },

--- a/src/components/Buzz/buzz.utils.ts
+++ b/src/components/Buzz/buzz.utils.ts
@@ -85,7 +85,7 @@ export const useBuzzTransaction = (opts?: {
   const tipUserMutation = trpc.buzz.tipUser.useMutation({
     onError(error) {
       showErrorNotification({
-        title: 'Error tipping user',
+        title: 'Looks like there was an error with your tip.',
         error: new Error(error.message),
       });
     },

--- a/src/components/Post/EditV2/Collaborators/PostCollaborators.tsx
+++ b/src/components/Post/EditV2/Collaborators/PostCollaborators.tsx
@@ -30,8 +30,8 @@ export const PostCollaboratorSelection = ({ post }: { post: PostDetailEditable }
       </Text>
       <Text size="sm" color="dimmed">
         Invite your teammates or collaborators to be shown on this post and get credit for it. If
-        they accept the invite, they it will be shown on their profile in addition to yours. Tipped
-        Buzz will be split equally. A maximum of {constants.entityCollaborators.maxCollaborators}
+        they accept the invite, it will be shown on their profile in addition to yours. Tipped Buzz
+        will be split equally. A maximum of {constants.entityCollaborators.maxCollaborators}
         collaborators can be invited.
       </Text>
       <QuickSearchDropdown

--- a/src/components/Post/EditV2/Collaborators/PostCollaborators.tsx
+++ b/src/components/Post/EditV2/Collaborators/PostCollaborators.tsx
@@ -26,12 +26,13 @@ export const PostCollaboratorSelection = ({ post }: { post: PostDetailEditable }
   return (
     <Stack spacing="xs">
       <Text size="lg" weight={500}>
-        Invite collaborators
+        Invite Collaborators
       </Text>
       <Text size="sm" color="dimmed">
-        If they accept, their user will be shown in the post &amp; image details accordingly. This
-        post &amp; images will also be shown in their profile. A maximum of{' '}
-        {constants.entityCollaborators.maxCollaborators} collaborators can be added.
+        Invite your teammates or collaborators to be shown on this post and get credit for it. If
+        they accept the invite, they it will be shown on their profile in addition to yours. Tipped
+        Buzz will be split equally. A maximum of {constants.entityCollaborators.maxCollaborators}
+        collaborators can be invited.
       </Text>
       <QuickSearchDropdown
         disableInitialSearch
@@ -52,7 +53,7 @@ export const PostCollaboratorSelection = ({ post }: { post: PostDetailEditable }
         dropdownItemLimit={25}
         showIndexSelect={false}
         startingIndex="users"
-        placeholder="Select users to collaborate with"
+        placeholder="Select community members to invite as a collaborator"
         filters={[
           { id: currentUser?.id },
           ...collaborators.map((c) => ({

--- a/src/server/controllers/buzz.controller.ts
+++ b/src/server/controllers/buzz.controller.ts
@@ -126,6 +126,10 @@ export async function createBuzzTipTransactionHandler({
     if (fromAccountId === input.toAccountId)
       throw throwBadRequestError('You cannot send buzz to the same account');
 
+    if (input.toAccountId === -1) {
+      throw throwBadRequestError('You cannot send buzz to the system account');
+    }
+
     const { entityType, entityId } = input;
     let targetUserIds: number[] = [input.toAccountId].filter(isDefined);
 

--- a/src/server/controllers/buzz.controller.ts
+++ b/src/server/controllers/buzz.controller.ts
@@ -131,7 +131,7 @@ export async function createBuzzTipTransactionHandler({
     }
 
     const { entityType, entityId } = input;
-    let targetUserIds: number[] = [input.toAccountId].filter(isDefined);
+    let targetUserIds: number[] = input.toAccountId ? [input.toAccountId] : [];
 
     if ((entityType === 'Post' || entityType === 'Image') && entityId) {
       // May have contributros, check this...
@@ -149,6 +149,14 @@ export async function createBuzzTipTransactionHandler({
 
         targetUserIds = [...new Set([...targetUserIds, ...collaboratorIds])].filter(isDefined);
       }
+    }
+
+    if (targetUserIds.length === 0) {
+      throw throwBadRequestError('No valid target users found');
+    }
+
+    if (targetUserIds.includes(fromAccountId)) {
+      throw throwBadRequestError('You cannot send buzz to the same account');
     }
 
     const amount = Math.floor(input.amount / targetUserIds.length);

--- a/src/server/controllers/buzz.controller.ts
+++ b/src/server/controllers/buzz.controller.ts
@@ -13,20 +13,27 @@ import {
 import {
   completeStripeBuzzTransaction,
   createBuzzTransaction,
+  createBuzzTransactionMany,
   getMultipliersForUser,
   getUserBuzzAccount,
   getUserBuzzTransactions,
+  upsertBuzzTip,
 } from '~/server/services/buzz.service';
 import {
   handleLogError,
   throwAuthorizationError,
   throwBadRequestError,
+  throwInsufficientFundsError,
 } from '../utils/errorHandling';
 import { DEFAULT_PAGE_SIZE } from '../utils/pagination-helpers';
 import { dbRead } from '~/server/db/client';
 import { userContributingClubs } from '../services/club.service';
-import { ClubAdminPermission } from '@prisma/client';
+import { ClubAdminPermission, EntityType } from '@prisma/client';
 import { dailyBoostReward } from '~/server/rewards/active/dailyBoost.reward';
+import { getEntityCollaborators } from '~/server/services/entity-collaborator.service';
+import { getImageById } from '~/server/services/image.service';
+import { v4 as uuid } from 'uuid';
+import { isDefined } from '~/utils/type-guards';
 
 export function getUserAccountHandler({ ctx }: { ctx: DeepNonNullable<Context> }) {
   try {
@@ -107,7 +114,7 @@ export function completeStripeBuzzPurchaseHandler({
   }
 }
 
-export function createBuzzTipTransactionHandler({
+export async function createBuzzTipTransactionHandler({
   input,
   ctx,
 }: {
@@ -119,11 +126,75 @@ export function createBuzzTipTransactionHandler({
     if (fromAccountId === input.toAccountId)
       throw throwBadRequestError('You cannot send buzz to the same account');
 
-    return createBuzzTransaction({
+    const { entityType, entityId } = input;
+    let targetUserIds: number[] = [input.toAccountId].filter(isDefined);
+
+    if ((entityType === 'Post' || entityType === 'Image') && entityId) {
+      // May have contributros, check this...
+      const collaboratorEntityType = EntityType.Post; // For the time being, only this is supported.
+      const collaboratorEntityId =
+        entityType === 'Post' ? entityId : (await getImageById({ id: entityId }))?.postId;
+
+      if (collaboratorEntityId && collaboratorEntityType) {
+        const collaborators = await getEntityCollaborators({
+          entityId: collaboratorEntityId,
+          entityType: collaboratorEntityType,
+        });
+
+        const collaboratorIds = collaborators.map((c) => c.user.id);
+
+        targetUserIds = [...new Set([...targetUserIds, ...collaboratorIds])].filter(isDefined);
+      }
+    }
+
+    const amount = Math.floor(input.amount / targetUserIds.length);
+    const finalAmount = amount * targetUserIds.length;
+
+    if (input.amount <= 0) {
+      throw throwBadRequestError('Amount must be greater than 0');
+    }
+
+    if (amount <= 0) {
+      throw throwBadRequestError('Could not split the amount between users');
+    }
+    // Confirm user funds:
+    const userAccount = await getUserBuzzAccount({ accountId: fromAccountId });
+    if ((userAccount.balance ?? 0) < finalAmount) {
+      throw throwInsufficientFundsError();
+    }
+
+    const sharedId = `tip-${uuid()}-${entityType}-${entityId}-by-${ctx.user.id}`;
+    const transactions = targetUserIds.map((toAccountId) => ({
       ...input,
       fromAccountId: ctx.user.id,
       type: TransactionType.Tip,
-    });
+      amount,
+      details: {
+        ...(input.details ?? {}),
+        targetUserIds,
+        originalAmount: input.amount,
+        // sharedId is a way to group transactions that are related to each other like contributor ones.
+        // This is not global by any means, but should let us know that these transactions are related.
+        sharedId,
+      },
+      toAccountId,
+      externalTransactionId: `${sharedId}-${toAccountId}`,
+    }));
+
+    // Now, create all transactions
+    const data = await createBuzzTransactionMany(transactions); // Now store these in the DB:
+
+    if (entityType && entityId) {
+      // TODO: We might wanna notify contributors, but hardly a priority right now imho.
+      await upsertBuzzTip({
+        ...transactions[0],
+        amount: finalAmount, // This is a total amount that was sent to all users.
+        entityType: entityType as string,
+        entityId: entityId as number,
+      });
+    }
+
+    return data;
   } catch (error) {
     throw getTRPCErrorFromUnknown(error);
   }

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -28,7 +28,6 @@ import { getServerStripe } from '~/server/utils/get-server-stripe';
 import { stripTime } from '~/utils/date-helpers';
 import { QS } from '~/utils/qs';
 import { getUserByUsername, getUsers } from './user.service';
-import { EntityCollaboratorStatus, EntityType } from '@prisma/client';
 
 type AccountType = 'User';
 

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -151,8 +151,6 @@ export async function createBuzzTransaction({
   fromAccountType?: BuzzAccountType;
   insufficientFundsErrorMsg?: string;
 }) {
-  const collaboratorIds: number[] = [];
-
   if (entityType && entityId && toAccountId === undefined) {
     const [{ userId } = { userId: undefined }] = await dbRead.$queryRawUnsafe<
       [{ userId?: number }]
@@ -191,21 +189,12 @@ export async function createBuzzTransaction({
     throw throwInsufficientFundsError(insufficientFundsErrorMsg);
   }
 
-  if (collaboratorIds.length > 0) {
-    amount = Math.floor(amount / (collaboratorIds.length + 1));
-
-    if (amount === 0) {
-      throw throwBadRequestError('Amount too low to split between collaborators');
-    }
-  }
-
   const body = JSON.stringify({
     ...payload,
     details: {
       ...(details ?? {}),
       entityId: entityId ?? details?.entityId,
       entityType: entityType ?? details?.entityType,
-      collaboratorIds,
     },
     amount,
     toAccountId,

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -222,22 +222,6 @@ export async function createBuzzTransaction({
 
   const data: { transactionId: string } = await response.json();
 
-  if (collaboratorIds.length > 0) {
-    const transactions = collaboratorIds.map((userId) => ({
-      ...payload,
-      details: {
-        ...(details ?? {}),
-        entityId: entityId ?? details?.entityId,
-        entityType: entityType ?? details?.entityType,
-      },
-      amount,
-      toAccountId: userId,
-      externalTransactionId: `collaborator-${userId}-${data.transactionId}`,
-    }));
-
-    await createBuzzTransactionMany(transactions);
-  }
-
   return data;
 }
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -280,6 +280,12 @@ export const getImageDetail = async ({ id }: GetByIdInput) => {
   });
 };
 
+export const getImageById = async ({ id }: GetByIdInput) => {
+  return await dbRead.image.findUnique({
+    where: { id },
+  });
+};
+
 export const ingestImageById = async ({ id }: GetByIdInput) => {
   const image = await dbRead.image.findUnique({
     where: { id },


### PR DESCRIPTION
Few things here:
- Adds support for a tip to be divided by collaborators if multiple are found

But more important than the above:
- Cleans up the **createBuzzTransaction** method from logic related to tipping. The controller will now handle this. I went through all calls of these method and the only place we care for `entityId & entityType` is when sending a Tip, so it made no sense to keep it in. Also found an old TODO to move the notification and whatnot, so took the time to do so. Seems to be working fine, but happy to hear some thoughts.