### PR TITLE
[CU-8688vgt4y] Prevents edge caching hidden preferences endpoint

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -252,7 +252,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
     const loginRedirectReason = req.cookies['ref_login_redirect_reason'] as string;
 
     if (context.isNewUser) {
-      newUserCounter.inc();
+      newUserCounter?.inc();
       const tracker = new Tracker(req, res);
       await tracker.userActivity({
         type: 'Registration',
@@ -272,7 +272,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
         });
       }
     } else {
-      loginCounter.inc();
+      loginCounter?.inc();
     }
   };
 

--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -160,3 +160,11 @@ export function purgeOnSuccess(tags: string[]) {
     return result;
   });
 }
+
+export function noEdgeCache() {
+  return middleware(({ next, ctx }) => {
+    ctx.cache.edgeTTL = 0;
+    ctx.cache.browserTTL = 0;
+    return next();
+  });
+}

--- a/src/server/routers/hidden-preferences.router.ts
+++ b/src/server/routers/hidden-preferences.router.ts
@@ -6,7 +6,16 @@ import { getAllHiddenForUser, toggleHidden } from '~/server/services/user-prefer
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
 
 export const hiddenPreferencesRouter = router({
-  getHidden: publicProcedure.query(({ ctx }) => getAllHiddenForUser({ userId: ctx.user?.id })),
+  getHidden: publicProcedure
+    .use(async ({ ctx, next }) => {
+      // Prevents edge caching hidden preferences since they're being cache in redis already
+      // NOTE: this is required because this endpoint is being forcefully cache in the browser wihout reason
+      const result = await next();
+      ctx.cache.edgeTTL = 0;
+
+      return result;
+    })
+    .query(({ ctx }) => getAllHiddenForUser({ userId: ctx.user?.id })),
   toggleHidden: protectedProcedure
     .input(toggleHiddenSchema)
     .mutation(({ input, ctx }) => toggleHidden({ ...input, userId: ctx.user.id })),

--- a/src/server/routers/hidden-preferences.router.ts
+++ b/src/server/routers/hidden-preferences.router.ts
@@ -1,20 +1,13 @@
-import {
-  toggleHiddenSchema,
-  toggleHiddenTagsSchema,
-} from '~/server/schema/user-preferences.schema';
+import { noEdgeCache } from '~/server/middleware.trpc';
+import { toggleHiddenSchema } from '~/server/schema/user-preferences.schema';
 import { getAllHiddenForUser, toggleHidden } from '~/server/services/user-preferences.service';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
 
 export const hiddenPreferencesRouter = router({
   getHidden: publicProcedure
-    .use(async ({ ctx, next }) => {
-      // Prevents edge caching hidden preferences since they're being cache in redis already
-      // NOTE: this is required because this endpoint is being forcefully cache in the browser wihout reason
-      const result = await next();
-      ctx.cache.edgeTTL = 0;
-
-      return result;
-    })
+    // Prevents edge caching hidden preferences since they're being cache in redis already
+    // NOTE: this is required because this endpoint is being forcefully cache in the browser wihout reason
+    .use(noEdgeCache())
     .query(({ ctx }) => getAllHiddenForUser({ userId: ctx.user?.id })),
   toggleHidden: protectedProcedure
     .input(toggleHiddenSchema)

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -329,6 +329,7 @@ export async function getAllHiddenForUser({
     hiddenUsers: users.map((user) => ({ ...user, hidden: true })),
     hiddenTags: [...hiddenTags.map((tag) => ({ ...tag, hidden: true })), ...moderatedTags],
   } as HiddenPreferenceTypes;
+
   return result;
 }
 


### PR DESCRIPTION
Note ⚠️ : to test bug in prod [ ] Disable cache option in Browser network tab should be UNCHECKED

How to test BUG 🐛 

1. Go to /user/:userId/images?section=reactions
2. Hide an image
3. Log out
4. Log in again
5. When you are logged in, you should see recently hidden image

We noticed call `/api/trpc/hiddenPreferences.getHidden` is `Disk cache` in the size column in Network tab

After this solution 
1. Go to /user/:userId/images?section=reactions
2. Hide an image
3. Log out
4. Log in again
5. Hidden image should NOT appear 
 
Call `/api/trpc/hiddenPreferences.getHidden` SHOULT NOT be `Disk cache`
