### PR TITLE
[CU-8688tk14q] Makes hidden users and hidden tags sections virtualized to improve performance

### DIFF
--- a/src/components/Account/HiddenTagsSection.tsx
+++ b/src/components/Account/HiddenTagsSection.tsx
@@ -1,9 +1,10 @@
-import { ActionIcon, Autocomplete, Badge, Card, Group, Loader, Stack, Text } from '@mantine/core';
+import { ActionIcon, Autocomplete, Badge, Card, Loader, Stack, Text } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import { uniqBy } from 'lodash-es';
 import { useMemo, useRef, useState } from 'react';
 import { ContentControls } from '~/components/Account/ContentControls';
+import { BasicMasonryGrid } from '~/components/MasonryGrid/BasicMasonryGrid';
 import { useHiddenPreferencesData, useToggleHiddenPreferences } from '~/hooks/hidden-preferences';
 import { TagSort } from '~/server/common/enums';
 
@@ -72,29 +73,13 @@ export function HiddenTagsSection({ withTitle = true }: { withTitle?: boolean })
         </Card.Section>
         <Card.Section inheritPadding py="md">
           <Stack spacing={5}>
-            {hiddenTags.length > 0 && (
-              <Group spacing={4}>
-                {hiddenTags.map((tag) => (
-                  <Badge
-                    key={tag.id}
-                    sx={{ paddingRight: 3 }}
-                    rightSection={
-                      <ActionIcon
-                        size="xs"
-                        color="blue"
-                        radius="xl"
-                        variant="transparent"
-                        onClick={() => handleToggleBlockedTag(tag)}
-                      >
-                        <IconX size={10} />
-                      </ActionIcon>
-                    }
-                  >
-                    {tag.name}
-                  </Badge>
-                ))}
-              </Group>
-            )}
+            <BasicMasonryGrid
+              items={hiddenTags}
+              render={TagBadge}
+              maxHeight={250}
+              columnGutter={4}
+              columnWidth={140}
+            />
             <Text color="dimmed" size="xs">
               {`We'll hide content with these tags throughout the site.`}
             </Text>
@@ -102,5 +87,34 @@ export function HiddenTagsSection({ withTitle = true }: { withTitle?: boolean })
         </Card.Section>
       </Card>
     </Stack>
+  );
+}
+
+function TagBadge({ data, width }: { data: { id: number; name: string }; width: number }) {
+  const toggleHiddenMutation = useToggleHiddenPreferences();
+
+  const handleToggleBlocked = async (tag: { id: number; name: string }) => {
+    await toggleHiddenMutation.mutateAsync({ kind: 'tag', data: [tag] });
+  };
+
+  return (
+    <Badge
+      key={data.id}
+      sx={{ paddingRight: 3 }}
+      w={width}
+      rightSection={
+        <ActionIcon
+          size="xs"
+          color="blue"
+          radius="xl"
+          variant="transparent"
+          onClick={() => handleToggleBlocked(data)}
+        >
+          <IconX size={10} />
+        </ActionIcon>
+      }
+    >
+      {data.name ?? '[deleted]'}
+    </Badge>
   );
 }

--- a/src/components/Account/HiddenUsersSection.tsx
+++ b/src/components/Account/HiddenUsersSection.tsx
@@ -1,7 +1,8 @@
-import { ActionIcon, Autocomplete, Badge, Card, Group, Loader, Stack, Text } from '@mantine/core';
+import { ActionIcon, Autocomplete, Badge, Card, Loader, Stack, Text } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import { useRef, useState } from 'react';
+import { BasicMasonryGrid } from '~/components/MasonryGrid/BasicMasonryGrid';
 import { useHiddenPreferencesData, useToggleHiddenPreferences } from '~/hooks/hidden-preferences';
 
 import { trpc } from '~/utils/trpc';
@@ -58,34 +59,59 @@ export function HiddenUsersSection() {
       </Card.Section>
       <Card.Section inheritPadding py="md">
         <Stack spacing={5}>
-          {hiddenUsers.length > 0 && (
-            <Group spacing={4}>
-              {hiddenUsers.map((user) => (
-                <Badge
-                  key={user.id}
-                  sx={{ paddingRight: 3 }}
-                  rightSection={
-                    <ActionIcon
-                      size="xs"
-                      color="blue"
-                      radius="xl"
-                      variant="transparent"
-                      onClick={() => handleToggleBlocked(user)}
-                    >
-                      <IconX size={10} />
-                    </ActionIcon>
-                  }
-                >
-                  {user.username}
-                </Badge>
-              ))}
-            </Group>
-          )}
+          <BasicMasonryGrid
+            items={hiddenUsers}
+            render={UserBadge}
+            maxHeight={250}
+            columnGutter={4}
+            columnWidth={140}
+          />
           <Text color="dimmed" size="xs">
             {`We'll hide content from these users throughout the site.`}
           </Text>
         </Stack>
       </Card.Section>
     </Card>
+  );
+}
+
+function UserBadge({
+  data,
+  width,
+}: {
+  data: { id: number; username?: string | null };
+  width: number;
+}) {
+  const toggleHiddenMutation = useToggleHiddenPreferences();
+
+  const handleToggleBlocked = async ({
+    id,
+    username,
+  }: {
+    id: number;
+    username?: string | null;
+  }) => {
+    await toggleHiddenMutation.mutateAsync({ kind: 'user', data: [{ id, username }] });
+  };
+
+  return (
+    <Badge
+      key={data.id}
+      sx={{ paddingRight: 3 }}
+      w={width}
+      rightSection={
+        <ActionIcon
+          size="xs"
+          color="blue"
+          radius="xl"
+          variant="transparent"
+          onClick={() => handleToggleBlocked(data)}
+        >
+          <IconX size={10} />
+        </ActionIcon>
+      }
+    >
+      {data.username ?? '[deleted]'}
+    </Badge>
   );
 }

--- a/src/components/MasonryGrid/BasicMasonryGrid.tsx
+++ b/src/components/MasonryGrid/BasicMasonryGrid.tsx
@@ -1,0 +1,101 @@
+import { ScrollArea } from '@mantine/core';
+import { useElementSize } from '@mantine/hooks';
+import { useMasonry, UseMasonryOptions, usePositioner, useResizeObserver } from 'masonic';
+import { useState, useLayoutEffect } from 'react';
+
+/**
+ * Taken from https://github.com/jaredLunde/mini-virtual-list/blob/5791a19581e25919858c43c37a2ff0eabaf09bfe/src/index.tsx#L414
+ */
+const useScroller = <T extends HTMLElement = HTMLElement>(
+  ref: React.MutableRefObject<T | null>
+): { scrollTop: number; isScrolling: boolean } => {
+  const [isScrolling, setIsScrolling] = useState(false);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  useLayoutEffect(() => {
+    const { current } = ref;
+    let tick: number | undefined;
+
+    if (current) {
+      const handleScroll = () => {
+        if (tick) return;
+        tick = window.requestAnimationFrame(() => {
+          setScrollTop(current.scrollTop);
+          tick = void 0;
+        });
+      };
+
+      current.addEventListener('scroll', handleScroll);
+      return () => {
+        current.removeEventListener('scroll', handleScroll);
+        if (tick) window.cancelAnimationFrame(tick);
+      };
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref.current]);
+
+  useLayoutEffect(() => {
+    setIsScrolling(true);
+    const to = window.setTimeout(() => {
+      // This is here to prevent premature bail outs while maintaining high resolution
+      // unsets. Without it there will always bee a lot of unnecessary DOM writes to style.
+      setIsScrolling(false);
+    }, 1000 / 6);
+    return () => window.clearTimeout(to);
+  }, [scrollTop]);
+
+  return { scrollTop, isScrolling };
+};
+
+/**
+ * Use this when you need just a list of virtualized items in a grid
+ */
+export function BasicMasonryGrid<T>({
+  maxHeight,
+  render,
+  items,
+  columnGutter,
+  columnWidth,
+  maxColumnCount = 4,
+  ...props
+}: Props<T>) {
+  const { ref: containerRef, width, height } = useElementSize<HTMLDivElement>();
+  const positioner = usePositioner({ width, columnGutter, columnWidth, maxColumnCount }, [
+    items.length,
+  ]);
+  const resizeObserver = useResizeObserver(positioner);
+  const { scrollTop, isScrolling } = useScroller(containerRef);
+
+  const MasonryList = useMasonry({
+    items,
+    render,
+    positioner,
+    resizeObserver,
+    scrollTop,
+    isScrolling,
+    height,
+    overscanBy: 5,
+    ...props,
+  });
+
+  return (
+    <ScrollArea.Autosize
+      viewportRef={containerRef}
+      maxHeight={maxHeight}
+      style={{ position: 'relative', width: '100%' }}
+      type="hover"
+    >
+      {MasonryList}
+    </ScrollArea.Autosize>
+  );
+}
+
+type Props<T> = Omit<
+  UseMasonryOptions<T>,
+  'scrollTop' | 'positioner' | 'resizeObserver' | 'isScrolling' | 'height'
+> & {
+  maxHeight: number;
+  maxColumnCount?: number;
+  columnWidth?: number;
+  columnGutter?: number;
+};


### PR DESCRIPTION
### Description

* Used masonry grid to take advantage of list virtualization to avoid rendering large lists all at once
* Changed list style visually

**Before**

![image](https://github.com/civitai/civitai/assets/12631159/6ebacd07-2fc4-471b-ab3f-41b4f739d479)

**After**

![image](https://github.com/civitai/civitai/assets/12631159/72711bd7-eeb4-4b02-92ff-688765834aef)
