### PR TITLE
Fixed race condition where pong can happen before ping

### DIFF
--- a/src/utils/signals/worker.v1.2.ts
+++ b/src/utils/signals/worker.v1.2.ts
@@ -72,7 +72,6 @@ const getConnection = async ({ token }: { token: string }) => {
             if (pingInterval) clearInterval(pingInterval);
             return;
           }
-          await connection.send('ping');
           pingTimeout = setTimeout(async () => {
             console.log('timed out');
             if (!connection) return;
@@ -80,6 +79,7 @@ const getConnection = async ({ token }: { token: string }) => {
             connection = null;
             emitter.emit('connectionError', { message: 'ping timeout' });
           }, PING_TIMEOUT);
+          await connection.send('ping');
         }, PING_INTERVAL)
       : null;
     // Backend response with `Pong` to the `ping`


### PR DESCRIPTION
Awaiting the call to ping ensures that the call only returns after the server has had a chance to process the message. The server asynchronously will send the pong back to the browser. This is a race condition where the pong arrives before the internal could have been registered. 