### PR TITLE
Move image buttons to square formation on narrow screen, adjust feed breakpoints

### DIFF
--- a/src/components/ImageGeneration/Feed.tsx
+++ b/src/components/ImageGeneration/Feed.tsx
@@ -137,10 +137,10 @@ const useStyles = createStyles((theme) => ({
     gap: theme.spacing.xs,
     gridTemplateColumns: '1fr',
 
-    [`@container (min-width: 440px)`]: {
+    [`@container (min-width: 290px)`]: {
       gridTemplateColumns: 'repeat(2, 1fr)',
     },
-    [`@container (min-width: 630px)`]: {
+    [`@container (min-width: 650px)`]: {
       gridTemplateColumns: 'repeat(3, 1fr)',
     },
     [`@container (min-width: 900px)`]: {

--- a/src/components/ImageGeneration/GeneratedImage.tsx
+++ b/src/components/ImageGeneration/GeneratedImage.tsx
@@ -472,6 +472,11 @@ const useStyles = createStyles((theme, _params, getRef) => {
       position: 'absolute',
       cursor: 'pointer',
       zIndex: 2,
+      alignItems: 'flex-end',
+
+      [theme.fn.smallerThan('xs')]: {
+        padding: 4,
+      },
     },
     iconBlocked: {
       [containerQuery.smallerThan(380)]: {
@@ -521,7 +526,10 @@ const useStyles = createStyles((theme, _params, getRef) => {
       padding: 4,
       transition: 'opacity .3s',
 
-      [theme.fn.smallerThan('sm')]: buttonBackground,
+      [`@container (max-width: 420px)`]: {
+        ...buttonBackground,
+        width: 68,
+      },
 
       ['button']: {
         opacity: 0,
@@ -530,7 +538,7 @@ const useStyles = createStyles((theme, _params, getRef) => {
           opacity: 1,
         },
 
-        [theme.fn.smallerThan('sm')]: {
+        [`@container (max-width: 420px)`]: {
           opacity: 1,
         },
       },


### PR DESCRIPTION
This allows 2-columns in the generator feed at a narrower screen width.