### PR TITLE
Add typescript react eslint formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
   "[sql]": {
     "editor.formatOnSave": false
   },
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
 }


### PR DESCRIPTION
Resolves issue with whitespace formatting on save in vcode.