### PR TITLE
Improve layout of generated image action buttons and marker filter control

### DIFF
--- a/src/components/ImageGeneration/GeneratedImageActions.tsx
+++ b/src/components/ImageGeneration/GeneratedImageActions.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Text, Tooltip, MantineNumberSize, Button, Checkbox } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { IconDownload, IconInfoCircle, IconSquareOff, IconTrash } from '@tabler/icons-react';
+import { useIsMobile } from '~/hooks/useIsMobile';
 import { useRouter } from 'next/router';
 import { orchestratorImageSelect } from '~/components/ImageGeneration/utils/generationImage.select';
 import {
@@ -39,6 +40,7 @@ export function GeneratedImageActions({
     downloadSelected,
     zipping,
   } = useGeneratedImageActions();
+  const isMobile = useIsMobile();
 
   const imagesCount = selectableImageIds.length;
   const selectedCount = selected.length;
@@ -61,7 +63,7 @@ export function GeneratedImageActions({
   const hasSelected = !!selectedCount;
 
   return (
-    <div className="flex items-center justify-between gap-6">
+    <div className={`flex items-center justify-between ${isMobile ? '' : 'gap-6'}`}>
       <MarkerFiltersDropdown />
 
       <Checkbox
@@ -70,6 +72,8 @@ export function GeneratedImageActions({
         onChange={(e) => handleCheckboxClick(e.currentTarget.checked)}
         label={!selectedCount ? 'Select all' : `${selectedCount} selected`}
         labelPosition="left"
+        mr={8}
+        styles={{ label: { paddingLeft: 8, paddingRight: 8, whiteSpace: 'nowrap' } }}
       />
       {hasSelected && (
         <div className="flex gap-2">
@@ -97,6 +101,7 @@ export function GeneratedImageActions({
             <Button
               color="blue"
               size="sm"
+              px={isMobile ? 8 : 18}
               h={34}
               onClick={postSelectedImages}
               loading={isMutating}

--- a/src/components/ImageGeneration/MarkerFiltersDropdown.tsx
+++ b/src/components/ImageGeneration/MarkerFiltersDropdown.tsx
@@ -3,7 +3,6 @@ import {
   Chip,
   ChipProps,
   createStyles,
-  Divider,
   Group,
   Indicator,
   Popover,
@@ -13,7 +12,13 @@ import {
   ScrollArea,
   ButtonProps,
 } from '@mantine/core';
-import { IconChevronDown, IconFilter, IconThumbUpFilled, IconThumbDownFilled, IconHeartFilled } from '@tabler/icons-react';
+import {
+  IconChevronDown,
+  IconFilter,
+  IconThumbUpFilled,
+  IconThumbDownFilled,
+  IconHeartFilled,
+} from '@tabler/icons-react';
 import { useState } from 'react';
 import { IsClient } from '~/components/IsClient/IsClient';
 import { MarkerFilterSchema, useFiltersContext } from '~/providers/FiltersProvider';
@@ -27,16 +32,14 @@ export function MarkerFiltersDropdown(props: Props) {
     setFilters: state.setMarkerFilters,
   }));
 
-  return (
-    <DumbMarkerFiltersDropdown {...props} filters={filters} setFilters={setFilters} />
-  );
+  return <DumbMarkerFiltersDropdown {...props} filters={filters} setFilters={setFilters} />;
 }
 
 const ICONS = {
   default: IconFilter,
   liked: IconThumbUpFilled,
   disliked: IconThumbDownFilled,
-  favorited: IconHeartFilled
+  favorited: IconHeartFilled,
 };
 
 function getIcon(type: MarkerType | undefined) {
@@ -120,7 +123,8 @@ export function DumbMarkerFiltersDropdown({
                   setMarker(checked ? marker : undefined);
                   setFilters({ marker: checked ? marker : undefined });
                 }}
-                {...chipProps}>
+                {...chipProps}
+              >
                 <Group spacing={4} noWrap>
                   <Icon size={16} /> {marker}
                 </Group>
@@ -129,7 +133,7 @@ export function DumbMarkerFiltersDropdown({
           })}
         </Group>
       </Stack>
-    </Stack >
+    </Stack>
   );
 
   if (mobile)

--- a/src/components/ImageGeneration/MarkerFiltersDropdown.tsx
+++ b/src/components/ImageGeneration/MarkerFiltersDropdown.tsx
@@ -12,6 +12,7 @@ import {
   ScrollArea,
   ButtonProps,
 } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import {
   IconChevronDown,
   IconFilter,
@@ -23,7 +24,6 @@ import { useState } from 'react';
 import { IsClient } from '~/components/IsClient/IsClient';
 import { MarkerFilterSchema, useFiltersContext } from '~/providers/FiltersProvider';
 import { containerQuery } from '~/utils/mantine-css-helpers';
-import { useIsMobile } from '~/hooks/useIsMobile';
 import { MarkerType } from '~/server/common/enums';
 
 export function MarkerFiltersDropdown(props: Props) {
@@ -49,7 +49,6 @@ function getIcon(type: MarkerType | undefined) {
 export function DumbMarkerFiltersDropdown({
   filters,
   setFilters,
-  filterMode = 'local',
   position = 'bottom-end',
   isFeed,
   ...buttonProps
@@ -58,7 +57,7 @@ export function DumbMarkerFiltersDropdown({
   setFilters: (filters: Partial<MarkerFilterSchema>) => void;
 }) {
   const { classes, cx, theme } = useStyles();
-  const mobile = useIsMobile({ breakpoint: 'xs' });
+  const mobile = useMediaQuery('(max-width: 576px)');
 
   const [opened, setOpened] = useState(false);
 


### PR DESCRIPTION
* Change marker filter control to open as popover, not drawer, when on desktop using media query rather than container query, as the viewport width is the critical factor in switching layout
* Remove space around generated image action buttons on mobile or when feed container is narrow