### PR TITLE
[CU-8689e6c36] Adds limits to earlyAccessConfig prices and goals

### DIFF
--- a/src/components/Model/ModelVersions/model-version.utils.ts
+++ b/src/components/Model/ModelVersions/model-version.utils.ts
@@ -6,6 +6,9 @@ import {
 } from '~/server/schema/model-version.schema';
 import { handleTRPCError, trpc } from '~/utils/trpc';
 
+export const MIN_DONATION_GOAL = 1000;
+export const MAX_DONATION_GOAL = 1000000;
+
 export const useQueryModelVersionsEngagement = (
   { modelId, versionId }: { modelId: number; versionId: number },
   options?: { enabled?: boolean }

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -11,9 +11,7 @@ import {
   Switch,
   Text,
   ThemeIcon,
-  Tooltip,
 } from '@mantine/core';
-import { NextLink } from '@mantine/next';
 import { Currency, ModelType, ModelVersionMonetizationType } from '@prisma/client';
 import { IconInfoCircle, IconQuestionMark } from '@tabler/icons-react';
 import { isEqual } from 'lodash';
@@ -25,13 +23,16 @@ import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { DismissibleAlert } from '~/components/DismissibleAlert/DismissibleAlert';
 import InputResourceSelectMultiple from '~/components/ImageGeneration/GenerationForm/ResourceSelectMultiple';
+import {
+  MAX_DONATION_GOAL,
+  MIN_DONATION_GOAL,
+} from '~/components/Model/ModelVersions/model-version.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import {
   Form,
   InputMultiSelect,
   InputNumber,
   InputRTE,
-  InputSegmentedControl,
   InputSelect,
   InputSwitch,
   InputText,
@@ -112,6 +113,17 @@ const schema = modelVersionUpsertSchema2
       return true;
     },
     { message: 'Max strength must be greater than min strength', path: ['settings.maxStrength'] }
+  )
+  .refine(
+    (data) => {
+      const { generationPrice, downloadPrice } = data.earlyAccessConfig ?? {};
+      if (generationPrice && downloadPrice) {
+        return generationPrice <= downloadPrice;
+      }
+
+      return true;
+    },
+    { message: 'Generation price cannot be greater than download price', path: ['generationPrice'] }
   );
 type Schema = z.infer<typeof schema>;
 
@@ -286,7 +298,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   const maxEarlyAccessModels = getMaxEarlyAccessModels({ userMeta: currentUser?.meta });
   const earlyAccessUnlockedDays = constants.earlyAccess.scoreTimeFrameUnlock
     // TODO: Update to model scores.
-    .map(([score, days]) =>
+    .map(([, days]) =>
       days <= getMaxEarlyAccessDays({ userMeta: currentUser?.meta }) ? days : null
     )
     .filter(isDefined);
@@ -482,7 +494,9 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
                             description=" How much buzz would you like to charge for your version download?"
                             min={100}
                             max={
-                              isPublished ? version?.earlyAccessConfig?.downloadPrice : undefined
+                              isPublished
+                                ? version?.earlyAccessConfig?.downloadPrice
+                                : MAX_DONATION_GOAL
                             }
                             step={100}
                             icon={<CurrencyIcon currency="BUZZ" size={16} />}
@@ -572,7 +586,8 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
                                   name="earlyAccessConfig.donationGoal"
                                   label="Donation Goal Amount"
                                   description="How much Buzz would you like to set as your donation goal? Early access purchases will count towards this goal. After publishing, you cannot change this value"
-                                  min={1000}
+                                  min={MIN_DONATION_GOAL}
+                                  max={MAX_DONATION_GOAL}
                                   step={100}
                                   icon={<CurrencyIcon currency="BUZZ" size={16} />}
                                   disabled={
@@ -620,8 +635,8 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
           {baseModel === 'SD 3' && (
             <Alert color="yellow" title="SD3 Unbanned">
               <Text>
-                Licensing concerns associated Stable Diffusion 3 have been resolved and it's been
-                unbanned. On-site generation with SD3 is unsupported.{' '}
+                Licensing concerns associated Stable Diffusion 3 have been resolved and it&apos;s
+                been unbanned. On-site generation with SD3 is unsupported.{' '}
                 <Text
                   variant="link"
                   td="underline"

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -7,6 +7,10 @@ import {
 } from '@prisma/client';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
+import {
+  MAX_DONATION_GOAL,
+  MIN_DONATION_GOAL,
+} from '~/components/Model/ModelVersions/model-version.utils';
 import { constants } from '~/server/common/constants';
 import { infiniteQuerySchema } from '~/server/schema/base.schema';
 
@@ -161,12 +165,12 @@ export type ModelVersionEarlyAccessConfig = z.infer<typeof modelVersionEarlyAcce
 export const modelVersionEarlyAccessConfigSchema = z.object({
   timeframe: z.number(),
   chargeForDownload: z.boolean().default(false),
-  downloadPrice: z.number().optional(),
+  downloadPrice: z.number().min(100).max(MAX_DONATION_GOAL).optional(),
   chargeForGeneration: z.boolean().default(false),
-  generationPrice: z.number().optional(),
+  generationPrice: z.number().min(50).optional(),
   generationTrialLimit: z.number().default(10),
   donationGoalEnabled: z.boolean().default(false),
-  donationGoal: z.number().optional(),
+  donationGoal: z.number().min(MIN_DONATION_GOAL).max(MAX_DONATION_GOAL).optional(),
   donationGoalId: z.number().optional(),
   originalPublishedAt: z.date().optional(),
 });


### PR DESCRIPTION
* Sets max download price and donation goal to one million buzz
* Sets generation price cap at download price as well

![image](https://github.com/user-attachments/assets/acaca5d7-7840-4ff6-8089-cf98468e6401)
