### PR TITLE
Add Remix options to menu for Flux images

### DIFF
--- a/src/components/ImageGeneration/GeneratedImage.tsx
+++ b/src/components/ImageGeneration/GeneratedImage.tsx
@@ -223,8 +223,10 @@ export function GeneratedImage({
 
   if (!available) return <></>;
 
+  const isUpscale = step.params.workflow === 'img2img-upscale';
   const isFlux = getIsFlux(step.params.baseModel);
-  const canRemix = !isFlux && step.params.workflow !== 'img2img-upscale';
+  const canRemix = !isUpscale;
+  const canImg2Img = !isFlux && !isUpscale;
   const { params } = step;
 
   return (
@@ -298,7 +300,7 @@ export function GeneratedImage({
               >
                 Delete
               </Menu.Item>
-              {!!img2imgWorkflows?.length && canRemix && (
+              {!!img2imgWorkflows?.length && canImg2Img && (
                 <>
                   <Menu.Divider />
                   <Menu.Label>Image-to-image workflows</Menu.Label>


### PR DESCRIPTION
This change adds "Remix" and "Remix (with seed)" to the generated image menu for Flux images.
It maintains the unavailability of img2img for Flux, and the unavailability of remixing upscaled images.