### PR TITLE
Fix Flux img2img button should be hidden when img2img is unavailable

### DIFF
--- a/src/components/ImageGeneration/GeneratedImage.tsx
+++ b/src/components/ImageGeneration/GeneratedImage.tsx
@@ -351,7 +351,7 @@ export function GeneratedImage({
               <IconHeart size={16} />
             </ActionIcon>
 
-            {!!img2imgWorkflows?.length && canRemix && (
+            {!!img2imgWorkflows?.length && canImg2Img && (
               <Menu
                 zIndex={400}
                 trigger="hover"


### PR DESCRIPTION
Fixes: Flux img2img (wand) button should be hidden when img2img is unavailable.