### PR TITLE
Add Community Development Team article reference to contributing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </a>
 </div>
 
-## Table of Content
+## Table of Contents
 
 - [About the Project](#about-the-project)
   - [Tech Stack](#tech-stack)
@@ -50,7 +50,7 @@ First, make sure that you have the following installed on your machine:
 - Docker (for running the database)
 
 > We recommend you have installed `nvm` in order to set the right node version to run this project
->
+
 > ```sh
 > curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
 > ```

--- a/README.md
+++ b/README.md
@@ -58,32 +58,32 @@ First, make sure that you have the following installed on your machine:
 1. Clone the repository to your local machine.
 1. Run `npm install` in the project directory to install the necessary dependencies.
 1. Spin up required services with `docker-compose up -d`
-   * Note: In addition to postgres and redis, this will also run maildev for email and minio for s3 storage with all necessary buckets automatically created, minio and maildev are not strictly needed but are preferred for testing and development purposes.
+    * Note: In addition to postgres and redis, this will also run maildev for email and minio for s3 storage with all necessary buckets automatically created, minio and maildev are not strictly needed but are preferred for testing and development purposes.
 1. Create your `.env` by making a copy of the contents from `.env-example` file.
-   * Most default values are configured to work with the docker-compose setup, with the exception of the S3 upload key and secret. To generate those, navigate to the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file.
-   * Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
-   * Comment out or remove
-     * `CLICKHOUSE_HOST`
-     * `CLICKHOUSE_USERNAME`
-     * `CLICKHOUSE_PASSWORD`
-     *`CLICKHOUSE_TRACKER_URL`
-   *Add a random string of your choice to the email properties to allow user registration
-     * `EMAIL_USER`
-     * `EMAIL_PASS`
-     * `EMAIL_FROM` (Valid email format needed)
-   * Replace `ORCHESTRATOR_ENDPOINT` url with http://localhost
-   * Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to a random string of your choice. This functions as a bypass as stripe credentials are internal
-   * Add http://localhost as the value to the following fields
-     * `RESOURCE_RECOMMENDER_URL`
-     * `NOTIFICATION_DB_URL`
-     * `NOTIFICATION_DB_REPLICA_URL`
+    * Most default values are configured to work with the docker-compose setup, with the exception of the S3 upload key and secret. To generate those, navigate to the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file.
+    * Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
+    * Comment out or remove
+      * `CLICKHOUSE_HOST`
+      * `CLICKHOUSE_USERNAME`
+      * `CLICKHOUSE_PASSWORD`
+      * `CLICKHOUSE_TRACKER_URL`
+    * Add a random string of your choice to the email properties to allow user registration
+      * `EMAIL_USER`
+      * `EMAIL_PASS`
+      * `EMAIL_FROM` (Valid email format needed)
+    * Replace `ORCHESTRATOR_ENDPOINT` url with http://localhost
+    * Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to a random string of your choice. This functions as a bypass as stripe credentials are internal
+    * Add http://localhost as the value to the following fields
+      * `RESOURCE_RECOMMENDER_URL`
+      * `NOTIFICATION_DB_URL`
+      * `NOTIFICATION_DB_REPLICA_URL`
 1. Run `npm run db:migrate` to run all database migrations.
 1. Run `npm run db:generate` to generate the prisma client.
 1. Start the development server by running `npm run dev`.
 1. Visit the page `http://localhost:3000/api/webhooks/run-jobs?token=WEBHOOK_TOKEN&run=update-metrics` to start the metrics update job (make sure to substitute `WEBHOOK_TOKEN`)
 1. Finally, visit [http://localhost:3000](http://localhost:3000) to see the website.
-   * Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080).
-   * Also note that Cloudflare credentials are necessary in order for image uploads to work.
+    * Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080).
+    * Also note that Cloudflare credentials are necessary in order for image uploads to work.
 
 ### Important Scripts
 ```sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 </div>
 
 ## Table of Content
+
 - [About the Project](#about-the-project)
   - [Tech Stack](#tech-stack)
 - [Getting Started](#getting-started)
@@ -44,10 +45,12 @@ To get a local copy up and running follow these simple example steps.
 ### Prerequisites
 
 First, make sure that you have the following installed on your machine:
+
 - Node.js (version 18 or later)
 - Docker (for running the database)
 
 > We recommend you have installed `nvm` in order to set the right node version to run this project
+>
 > ```sh
 > curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
 > ```
@@ -57,34 +60,35 @@ First, make sure that you have the following installed on your machine:
 1. Clone the repository to your local machine.
 1. Run `npm install` in the project directory to install the necessary dependencies.
 1. Spin up required services with `docker-compose up -d`
-    * Note: In addition to postgres and redis, this will also run maildev for email and minio for s3 storage with all necessary buckets automatically created, minio and maildev are not strictly needed but are preferred for testing and development purposes.
+   - Note: In addition to postgres and redis, this will also run maildev for email and minio for s3 storage with all necessary buckets automatically created, minio and maildev are not strictly needed but are preferred for testing and development purposes.
 1. Create your `.env` by making a copy of the contents from `.env-example` file.
-    * Most default values are configured to work with the docker-compose setup, with the exception of the S3 upload key and secret. To generate those, navigate to the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file.
-    * Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
-    * Comment out or remove 
-      * `CLICKHOUSE_HOST`
-      * `CLICKHOUSE_USERNAME`
-      * `CLICKHOUSE_PASSWORD`
-      * `CLICKHOUSE_TRACKER_URL`
-    * Add a random string of your choice to the email properties to allow user registration
-      * `EMAIL_USER`
-      * `EMAIL_PASS`
-      * `EMAIL_FROM` (Valid email format needed)
-    * Replace `ORCHESTRATOR_ENDPOINT` url with http://localhost
-    * Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to a random string of your choice. This functions as a bypass as stripe credentials are internal
-    * Add http://localhost as the value to the following fields
-      * `RESOURCE_RECOMMENDER_URL`
-      * `NOTIFICATION_DB_URL`
-      * `NOTIFICATION_DB_REPLICA_URL`
+   - Most default values are configured to work with the docker-compose setup, with the exception of the S3 upload key and secret. To generate those, navigate to the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file.
+   - Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
+   - Comment out or remove
+     - `CLICKHOUSE_HOST`
+     - `CLICKHOUSE_USERNAME`
+     - `CLICKHOUSE_PASSWORD`
+     - `CLICKHOUSE_TRACKER_URL`
+   - Add a random string of your choice to the email properties to allow user registration
+     - `EMAIL_USER`
+     - `EMAIL_PASS`
+     - `EMAIL_FROM` (Valid email format needed)
+   - Replace `ORCHESTRATOR_ENDPOINT` url with http://localhost
+   - Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to a random string of your choice. This functions as a bypass as stripe credentials are internal
+   - Add http://localhost as the value to the following fields
+     - `RESOURCE_RECOMMENDER_URL`
+     - `NOTIFICATION_DB_URL`
+     - `NOTIFICATION_DB_REPLICA_URL`
 1. Run `npm run db:migrate` to run all database migrations.
 1. Run `npm run db:generate` to generate the prisma client.
 1. Start the development server by running `npm run dev`.
 1. Visit the page `http://localhost:3000/api/webhooks/run-jobs?token=WEBHOOK_TOKEN&run=update-metrics` to start the metrics update job (make sure to substitute `WEBHOOK_TOKEN`)
 1. Finally, visit [http://localhost:3000](http://localhost:3000) to see the website.
-    * Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080).
-    * Also note that Cloudflare credentials are necessary in order for image uploads to work.
+   - Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080).
+   - Also note that Cloudflare credentials are necessary in order for image uploads to work.
 
 ### Important Scripts
+
 ```sh
 docker-compose up -d # Spin up db, redis, maildev, and minio
 
@@ -112,13 +116,15 @@ Don't forget to give the project a star! Thanks again!
 1. Commit your changes and push the branch to your forked repository.
 1. Open a pull request on our repository.
 
+If you would like to be more involved, consider joining the **Community Development Team**! For more information on the team as well as how to join, see [Calling All Developers: Join Civitai's Community Development Team](https://civitai.com/articles/7782).
+
 ## Sponsors
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website.
 
 ## License
-Apache License 2.0 - Please have a look at the [LICENSE](/LICENSE) for more details.
 
+Apache License 2.0 - Please have a look at the [LICENSE](/LICENSE) for more details.
 
 [contributors-shield]: https://img.shields.io/github/contributors/civitai/civitai.svg?style=for-the-badge
 [contributors-url]: https://github.com/civitai/civitai/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 </div>
 
 ## Table of Contents
-
 - [About the Project](#about-the-project)
   - [Tech Stack](#tech-stack)
 - [Getting Started](#getting-started)
@@ -45,7 +44,6 @@ To get a local copy up and running follow these simple example steps.
 ### Prerequisites
 
 First, make sure that you have the following installed on your machine:
-
 - Node.js (version 18 or later)
 - Docker (for running the database)
 
@@ -60,35 +58,34 @@ First, make sure that you have the following installed on your machine:
 1. Clone the repository to your local machine.
 1. Run `npm install` in the project directory to install the necessary dependencies.
 1. Spin up required services with `docker-compose up -d`
-   - Note: In addition to postgres and redis, this will also run maildev for email and minio for s3 storage with all necessary buckets automatically created, minio and maildev are not strictly needed but are preferred for testing and development purposes.
+   * Note: In addition to postgres and redis, this will also run maildev for email and minio for s3 storage with all necessary buckets automatically created, minio and maildev are not strictly needed but are preferred for testing and development purposes.
 1. Create your `.env` by making a copy of the contents from `.env-example` file.
-   - Most default values are configured to work with the docker-compose setup, with the exception of the S3 upload key and secret. To generate those, navigate to the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file.
-   - Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
-   - Comment out or remove
-     - `CLICKHOUSE_HOST`
-     - `CLICKHOUSE_USERNAME`
-     - `CLICKHOUSE_PASSWORD`
-     - `CLICKHOUSE_TRACKER_URL`
-   - Add a random string of your choice to the email properties to allow user registration
-     - `EMAIL_USER`
-     - `EMAIL_PASS`
-     - `EMAIL_FROM` (Valid email format needed)
-   - Replace `ORCHESTRATOR_ENDPOINT` url with http://localhost
-   - Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to a random string of your choice. This functions as a bypass as stripe credentials are internal
-   - Add http://localhost as the value to the following fields
-     - `RESOURCE_RECOMMENDER_URL`
-     - `NOTIFICATION_DB_URL`
-     - `NOTIFICATION_DB_REPLICA_URL`
+   * Most default values are configured to work with the docker-compose setup, with the exception of the S3 upload key and secret. To generate those, navigate to the minio web interface at [http://localhost:9000](http://localhost:9000) with the default username and password `minioadmin`, and then navigate to the "Access Keys" tab. Click "Create Access Key" and copy the generated key and secret into the `.env` file.
+   * Set `WEBHOOK_TOKEN` to a random string of your choice. This will be used to authenticate requests to the webhook endpoint.
+   * Comment out or remove
+     * `CLICKHOUSE_HOST`
+     * `CLICKHOUSE_USERNAME`
+     * `CLICKHOUSE_PASSWORD`
+     *`CLICKHOUSE_TRACKER_URL`
+   *Add a random string of your choice to the email properties to allow user registration
+     * `EMAIL_USER`
+     * `EMAIL_PASS`
+     * `EMAIL_FROM` (Valid email format needed)
+   * Replace `ORCHESTRATOR_ENDPOINT` url with http://localhost
+   * Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to a random string of your choice. This functions as a bypass as stripe credentials are internal
+   * Add http://localhost as the value to the following fields
+     * `RESOURCE_RECOMMENDER_URL`
+     * `NOTIFICATION_DB_URL`
+     * `NOTIFICATION_DB_REPLICA_URL`
 1. Run `npm run db:migrate` to run all database migrations.
 1. Run `npm run db:generate` to generate the prisma client.
 1. Start the development server by running `npm run dev`.
 1. Visit the page `http://localhost:3000/api/webhooks/run-jobs?token=WEBHOOK_TOKEN&run=update-metrics` to start the metrics update job (make sure to substitute `WEBHOOK_TOKEN`)
 1. Finally, visit [http://localhost:3000](http://localhost:3000) to see the website.
-   - Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080).
-   - Also note that Cloudflare credentials are necessary in order for image uploads to work.
+   * Note that account creation will run emails through maildev, which can be accessed at [http://localhost:1080](http://localhost:1080).
+   * Also note that Cloudflare credentials are necessary in order for image uploads to work.
 
 ### Important Scripts
-
 ```sh
 docker-compose up -d # Spin up db, redis, maildev, and minio
 
@@ -123,7 +120,6 @@ If you would like to be more involved, consider joining the **Community Developm
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website.
 
 ## License
-
 Apache License 2.0 - Please have a look at the [LICENSE](/LICENSE) for more details.
 
 [contributors-shield]: https://img.shields.io/github/contributors/civitai/civitai.svg?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ First, make sure that you have the following installed on your machine:
 - Docker (for running the database)
 
 > We recommend you have installed `nvm` in order to set the right node version to run this project
-
 > ```sh
 > curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
 > ```
@@ -121,6 +120,7 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 
 ## License
 Apache License 2.0 - Please have a look at the [LICENSE](/LICENSE) for more details.
+
 
 [contributors-shield]: https://img.shields.io/github/contributors/civitai/civitai.svg?style=for-the-badge
 [contributors-url]: https://github.com/civitai/civitai/graphs/contributors


### PR DESCRIPTION
# Background

I recently joined the Discord to ask about how to find opportunities to contribute to the codebase, and someone directed me to a recent article about the Community Development Team: https://civitai.com/articles/7782 . This information is currently not easy to find for those reading the contributing info.

# Summary

Added information to the `README.md` about the Community Development Team, along with a link to a recent article with more information.
