### PR TITLE
Fix for categories restricting model tags, tags should be independent…

### DIFF
--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -307,9 +307,7 @@ export function ModelUpsertForm({ model, children, onSubmit }: Props) {
               }
               description="Search or create tags for your model"
               target={[TagTarget.Model]}
-              filter={(tag) =>
-                data && tag.name ? !data.items.map((cat) => cat.name).includes(tag.name) : true
-              }
+              filter={() => true}
             />
             <InputRTE
               name="description"


### PR DESCRIPTION
Fix for model categories restricting model tags, tags should be independent of categories.
Fixing: https://support.civitai.com/support/tickets/10565
Explainantion why tags need to be separated from categories:

1. A model can contain both character and style, or concept and style. While a category might be selected as "character" or "concept," users would still want to select "style" as a tag in such cases as well. I can provide a few examples of such models (there are many more): [example 1](https://civitai.com/models/353206?modelVersionId=400449), [example 2](https://civitai.com/models/725367/ominous-hourglass-flux).

2. People have to use misspelled versions of "style" or use "styles." It's clear that people want and need to use the tag "style", keeping deformed versions of "style" while restricting actually informative tags doesn’t help anyone and is self-defeating for Civitai.
![image](https://github.com/user-attachments/assets/00a38ead-11e3-4052-b063-fc9ebdb5fe95)

3. Categories and tags are two separate things. Categories are broad groups to associate the model with - which must be a single group in Civitai’s current conceptual design - to allow a simplification of the model into a single category. Tags provide a fine-grain description of the content of the model, which can include both "character" and "style" tags, to describe the content accurately, as I already mentioned in section 1. Tags are not mutually exclusive and should not be restricted by categories, as these are two separate conceptual elements on the site and should not conflict.

4. The restriction on tags forced by categories is counter-informative. The site forces model creators to hide important information and doesn’t allow users access to crucial information. Therefore, it should be considered a design bug and addressed as such.

5. The model creator is the one who created the model and knows best what it contains. Civitai imposing arbitrary restrictions on informative tags implies that Civitai claims to know better than the creator what the model is about and what it can do, which is clearly not the case.

6. Restrictions imposed by categories on tags require additional code that should not exist - removing it would be a simplification that helps reduce bugs and code maintenance.