### PR TITLE
User Account Refresh Session Buttton

### DIFF
--- a/src/components/Account/RefreshSessionCard.tsx
+++ b/src/components/Account/RefreshSessionCard.tsx
@@ -1,0 +1,26 @@
+import { Button, Card, Stack, Text, Title } from '@mantine/core';
+import { closeModal, openConfirmModal } from '@mantine/modals';
+import { useAccountContext } from '~/components/CivitaiWrapped/AccountProvider';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useRefreshSession } from '~/components/Stripe/memberships.util';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+export function RefreshSessionCard() {
+  const currentUser = useCurrentUser();
+  const { refreshSession } = useRefreshSession();
+
+  return (
+    <Card withBorder>
+      <Stack>
+        <Title order={2}>Refresh my Session</Title>
+        <Text size="sm">
+        Support may ask you to refresh your Civitai session. Click the button below to clear internal caches, which can help resolve minor issues without affecting your account data or settings.
+        </Text>
+        <Button variant="outline" color="blue" onClick={refreshSession}>
+          Refresh my Session
+        </Button>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -19,12 +19,11 @@ import { UserReferralCodesCard } from '~/components/Account/UserReferralCodesCar
 import { PaymentMethodsCard } from '~/components/Account/PaymentMethodsCard';
 import { UserPaymentConfigurationCard } from '~/components/Account/UserPaymentConfigurationCard';
 import { ContentControlsCard } from '~/components/Account/ContentControlsCard';
-import { useRefreshSession } from '~/components/Stripe/memberships.util';
+import { RefreshSessionCard } from '~/components/Account/RefreshSessionCard';
 
 export default function Account({ providers }: Props) {
   const { apiKeys, buzz, canViewNsfw } = useFeatureFlags();
   const currentUser = useCurrentUser();
-  const { refreshSession } = useRefreshSession();
 
   return (
     <>
@@ -51,13 +50,8 @@ export default function Account({ providers }: Props) {
           {/* {buzz && <UserReferralCodesCard />} */}
           <NotificationsCard />
           {apiKeys && <ApiKeysCard />}
+          <RefreshSessionCard />
           <DeleteCard />
-          <Divider label="Extras" />
-          <Group spacing="sm">
-            <Button variant="subtle" onClick={refreshSession}>
-              Refresh my session
-            </Button>
-          </Group>
         </Stack>
       </Container>
     </>


### PR DESCRIPTION
Moved the confusing Refresh session text button located under Delete Account into its own card with description, to stop the many "what does this do" questions from community.

![image](https://github.com/user-attachments/assets/68dd1782-833f-4709-a640-ad94510ba583)
