### PR TITLE
Dynamic import of he.js

### DIFF
--- a/src/utils/normalize-text.ts
+++ b/src/utils/normalize-text.ts
@@ -1,9 +1,19 @@
-import he from 'he';
+let heInitialized = false;
+let he: { decode: (str: string) => string } = { decode: (str: string) => str };
+function getHe() {
+  if (!heInitialized) {
+    heInitialized = true;
+    import('he').then((x) => {
+      he.decode = x.decode;
+    });
+  }
+
+  return he;
+}
 
 export function normalizeText(input?: string): string {
   if (!input) return '';
-  return he
-    .decode(input)
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
+  let result = input;
+  if (input.includes('&')) result = getHe().decode(input);
+  return result.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -1,6 +1,5 @@
 import { Air } from '@civitai/client';
 import { ModelType } from '@prisma/client';
-import he from 'he';
 import { truncate } from 'lodash-es';
 import slugify from 'slugify';
 import {
@@ -183,14 +182,6 @@ export function hashifyObject(obj: any) {
 
 export function trimNonAlphanumeric(str: string | null | undefined) {
   return str?.replace(/^[^\w]+|[^\w]+$/g, '');
-}
-
-export function normalizeText(input?: string): string {
-  if (!input) return '';
-  return he
-    .decode(input)
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
 }
 
 export function parseAIR(identifier: string) {


### PR DESCRIPTION
- Import only after it's needed

Unfortunately, this required a trade-off to avoid a massive number of down-stream changes... Basically, it won't work as expected the first time, but I think that's ok since it likely won't be needed the first time since we run the normalize text for a lot of things that don't include html entities.