### PR TITLE
Add new Minor Detection ingestion scan

### DIFF
--- a/prisma/migrations/20241220050455_minor_detection_tag_source/migration.sql
+++ b/prisma/migrations/20241220050455_minor_detection_tag_source/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "TagSource" ADD VALUE 'MinorDetection';

--- a/prisma/programmability/update_nsfw_level.sql
+++ b/prisma/programmability/update_nsfw_level.sql
@@ -23,7 +23,10 @@ BEGIN
     WHERE toi."imageId" = ANY(image_ids) AND toi."disabledAt" IS NULL
     GROUP BY toi."imageId"
   )
-  UPDATE "Image" i SET nsfw = il.nsfw, "nsfwLevel" = il."nsfwLevel"
+  UPDATE "Image" i SET
+    nsfw = il.nsfw,
+    "nsfwLevel" = il."nsfwLevel",
+    "review" = IIF((i."scanJobs"->'hasMinor')::boolean AND il."nsfwLevel" > 1 AND il."nsfwLevel" < 32, 'minor', i."review")
   FROM image_level il
   WHERE il."imageId" = i.id AND NOT i."nsfwLevelLocked" AND (il."nsfwLevel" != i."nsfwLevel" OR il.nsfw != i.nsfw) AND i.ingestion = 'Scanned' AND i."nsfwLevel" != 32;
 END;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1546,6 +1546,7 @@ enum TagSource {
   Computed
   ImageHash
   Hive
+  MinorDetection
 }
 
 model TagsOnImage {

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -59,6 +59,7 @@ const schema = z.object({
     .object({
       movie_rating: z.string().optional(),
       movie_rating_model_id: z.string().optional(),
+      hasMinor: z.boolean().optional(),
     })
     .nullish(),
 });
@@ -156,6 +157,27 @@ async function handleSuccess({ id, tags: incomingTags = [], source, context, has
       where: { id },
       data: { pHash: BigInt(hash), updatedAt: new Date() },
     });
+    return;
+  }
+
+  if (source === TagSource.MinorDetection) {
+    const update: Record<string, any> = {
+      [source]: Date.now(),
+    };
+    const additionalUpdates: string[] = [];
+    if (context?.hasMinor) {
+      update.hasMinor = true;
+      additionalUpdates.push(
+        `"reviewKey" = IIF(i."nsfwLevel" > ${NsfwLevel.PG} && i."nsfwLevel" < ${NsfwLevel.Blocked}, 'minor', i."reviewKey")`
+      );
+    }
+
+    await dbWrite.$executeRawUnsafe(`
+      UPDATE "Image" i SET
+        "scanJobs" = COALESCE("scanJobs", '{}') || '${JSON.stringify(update)}'::jsonb)
+        ${additionalUpdates ? `, ${additionalUpdates.join(', ')}` : ''}
+      WHERE id = ${id};
+    `);
     return;
   }
 

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -91,6 +91,7 @@ export enum ImageScanType {
   WD14,
   Hash,
   Hive,
+  MinorDetection,
 }
 
 export enum CommentV2Sort {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -458,6 +458,7 @@ const defaultScanTypes = [
     : [ImageScanType.Moderation, ImageScanType.Label]),
   ImageScanType.WD14,
   ImageScanType.Hash,
+  ImageScanType.MinorDetection,
 ];
 
 export const ingestImage = async ({

--- a/src/shared/utils/prisma/enums.ts
+++ b/src/shared/utils/prisma/enums.ts
@@ -355,6 +355,7 @@ export const TagSource = {
   Computed: 'Computed',
   ImageHash: 'ImageHash',
   Hive: 'Hive',
+  MinorDetection: 'MinorDetection',
 } as const;
 
 export type TagSource = (typeof TagSource)[keyof typeof TagSource];

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -76,7 +76,7 @@ export type TagType = "UserGenerated" | "Label" | "Moderation" | "System";
 
 export type TagsOnTagsType = "Parent" | "Replace" | "Append";
 
-export type TagSource = "User" | "Rekognition" | "WD14" | "Computed" | "ImageHash" | "Hive";
+export type TagSource = "User" | "Rekognition" | "WD14" | "Computed" | "ImageHash" | "Hive" | "MinorDetection";
 
 export type PartnerPricingModel = "Duration" | "PerImage";
 


### PR DESCRIPTION
Utilizes the newly added MinorDetection task in our image ingestion engine to flag things as `hasMinor` or not.