### PR TITLE
Fix/generation copy update

### DIFF
--- a/src/components/ImageGeneration/GeneratedImageActions.tsx
+++ b/src/components/ImageGeneration/GeneratedImageActions.tsx
@@ -210,7 +210,7 @@ export function GeneratedImageActions({
               <IconTrash size={iconSize} />
             </ActionIcon>
           </Tooltip>
-          <Tooltip label="Post images to earn buzz!">
+          <Tooltip label="Post your generations to earn buzz!">
             <Button
               color="blue"
               size="sm"

--- a/src/components/ImageGeneration/Queue.tsx
+++ b/src/components/ImageGeneration/Queue.tsx
@@ -71,7 +71,7 @@ export function Queue() {
     <div className="flex flex-col gap-2 px-3">
       <Text size="xs" color="dimmed" mt="xs">
         <IconCalendar size={14} style={{ display: 'inline', marginTop: -3 }} strokeWidth={2} />{' '}
-        Images are kept in the generator for 30 days.
+        Creations are kept in the Generator for 30 days. Download or Post them to your Profile to save them!
       </Text>
       <div className="flex flex-col gap-2">
         {data.map((request) =>


### PR DESCRIPTION
Two updates to generator copy to move away from image-centric language. The 30 day warning is now longer, can you confirm this string will look ok on mobile (couldn't test!), or is it too long?