### PR TITLE
Update DeleteCard.tsx

### DIFF
--- a/src/components/Account/DeleteCard.tsx
+++ b/src/components/Account/DeleteCard.tsx
@@ -1,5 +1,5 @@
-import { Button, Card, Stack, Text, Title } from '@mantine/core';
-import { closeModal, openConfirmModal } from '@mantine/modals';
+import { useState } from 'react';
+import { Button, Card, Stack, Text, Title, TextInput, Modal, Group } from '@mantine/core';
 import { useAccountContext } from '~/components/CivitaiWrapped/AccountProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { showErrorNotification } from '~/utils/notifications';
@@ -17,50 +17,106 @@ export function DeleteCard() {
       showErrorNotification({ error: new Error(error.message) });
     },
   });
-  const handleDeleteAccount = () => {
-    openConfirmModal({
-      modalId: 'delete-confirm',
-      title: 'Delete your account',
-      children: 'Are you sure you want to delete your account? All data will be permanently lost.',
-      centered: true,
-      labels: { cancel: `Cancel`, confirm: `Yes, I am sure` },
-      confirmProps: { color: 'red' },
-      closeOnConfirm: false,
-      onConfirm: () =>
-        openConfirmModal({
-          modalId: 'wipe-confirm',
-          title: 'Wipe your models',
-          children:
-            'Do you want to delete all the models you have created along with your account?',
-          centered: true,
-          closeOnCancel: false,
-          closeOnConfirm: false,
-          labels: { cancel: 'Yes, wipe them', confirm: 'No, leave them up' },
-          confirmProps: { color: 'red', loading: deleteAccountMutation.isLoading },
-          cancelProps: { loading: deleteAccountMutation.isLoading },
-          onConfirm: () =>
-            currentUser ? deleteAccountMutation.mutateAsync({ id: currentUser.id }) : undefined,
-          onCancel: () =>
-            currentUser
-              ? deleteAccountMutation.mutateAsync({ id: currentUser.id, removeModels: true })
-              : undefined,
-          onClose: () => closeModal('delete-confirm'),
-        }),
-    });
+
+  // Separate state for each modal
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [wipeModalOpen, setWipeModalOpen] = useState(false);
+  const [confirmDeleteInput, setConfirmDeleteInput] = useState('');
+
+  const handleConfirmDelete = () => {
+    setDeleteModalOpen(false); // Close first modal
+    setTimeout(() => setWipeModalOpen(true), 200); // Ensure it doesn't re-trigger same modal
+  };
+
+  const handleWipeDecision = (wipeModels: boolean) => {
+    setWipeModalOpen(false);
+    if (currentUser) {
+      deleteAccountMutation.mutateAsync({ id: currentUser.id, removeModels: wipeModels });
+    }
+  };
+
+  const handleCancelAll = () => {
+    setWipeModalOpen(false); // Fully cancels the process
+    setConfirmDeleteInput(''); // Reset input field
   };
 
   return (
-    <Card withBorder>
-      <Stack>
-        <Title order={2}>Delete account</Title>
-        <Text size="sm">
-          Once you delete your account, there is no going back. Please be certain when taking this
-          action.
-        </Text>
-        <Button variant="outline" color="red" onClick={handleDeleteAccount}>
-          Delete your account
-        </Button>
-      </Stack>
-    </Card>
+    <>
+      {/* FIRST MODAL: Confirm account deletion */}
+      <Modal
+        opened={deleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        title="Delete your account"
+        centered
+      >
+        <Stack>
+          <Text>
+            Are you sure you want to delete your account? All data will be permanently lost.
+          </Text>
+          <Text>
+            Please type <b>DELETE</b> in the box below to confirm:
+          </Text>
+          <TextInput
+            placeholder="Type DELETE to confirm"
+            value={confirmDeleteInput}
+            onChange={(event) => setConfirmDeleteInput(event.currentTarget.value)}
+          />
+          {/* Buttons */}
+          <Group position="right">
+            <Button variant="outline" onClick={() => setDeleteModalOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              disabled={confirmDeleteInput.trim().toUpperCase() !== 'DELETE'}
+              onClick={handleConfirmDelete}
+            >
+              Yes, I am sure
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      {/* SECOND MODAL: Ask about wiping models */}
+      <Modal
+        opened={wipeModalOpen}
+        onClose={() => setWipeModalOpen(false)}
+        title="Wipe your models?"
+        centered
+      >
+        <Stack>
+          <Text>
+            Do you want to delete all the models you have created along with your account?
+          </Text>
+          <Group position="apart">
+            <Button variant="default" onClick={handleCancelAll}>
+              Stop! Go back!
+            </Button>
+            <Group>
+              <Button color="red" onClick={() => handleWipeDecision(true)}>
+                Yes
+              </Button>
+              <Button color="red" onClick={() => handleWipeDecision(false)}>
+                No
+              </Button>
+            </Group>
+          </Group>
+        </Stack>
+      </Modal>
+
+      {/* MAIN DELETE ACCOUNT BUTTON */}
+      <Card withBorder>
+        <Stack>
+          <Title order={2}>Delete account</Title>
+          <Text size="sm">
+            Once you delete your account, there is no going back. Please be certain when taking this
+            action.
+          </Text>
+          <Button variant="outline" color="red" onClick={() => setDeleteModalOpen(true)}>
+            Delete your account
+          </Button>
+        </Stack>
+      </Card>
+    </>
   );
 }


### PR DESCRIPTION
Updates the delete account flow to make accidental account deletions more difficult, requested by Support Desk.

New modal with disabled button until `DELETE` (case insensitive) is input;

![Screenshot 2025-01-29 133900](https://github.com/user-attachments/assets/be718cb4-10bb-4343-8a19-a14262e54fde)

![Screenshot 2025-01-29 133908](https://github.com/user-attachments/assets/fd594c0c-5940-4a71-9b65-ffc162fd7fa8)

Secondary modal for `Wipe your models` re-configured to offer a further cancellation option.

![Screenshot 2025-01-29 133914](https://github.com/user-attachments/assets/bdccbf0a-a63e-4670-b5e7-c875c761d2d9)
