### PR TITLE
Download History Changes

### DIFF
--- a/src/components/Downloads/DownloadList.tsx
+++ b/src/components/Downloads/DownloadList.tsx
@@ -1,53 +1,61 @@
-import { Stack, Text, MantineSize, Group, ActionIcon } from '@mantine/core';
+import { Stack, Text, MantineSize, Group, ActionIcon, Paper } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-
 import { DownloadGetAll } from '~/types/router';
 import { slugit } from '~/utils/string-helpers';
 
 export function DownloadList({ items, textSize = 'sm', onHideClick }: Props) {
   return (
-    <Stack spacing={0}>
+    <Stack spacing="sm">
       {items.map((download) => {
         const downloadDate = dayjs(download.downloadAt);
 
         return (
-          <Group key={download.modelVersion.id} noWrap>
-            <Link
-              href={`/models/${download.modelVersion.model.id}/${slugit(
-                download.modelVersion.model.name
-              )}`}
-              passHref
-              legacyBehavior
-            >
-              <Text
-                component="a"
-                sx={(theme) => ({
-                  flex: '1 !important',
-                  padding: theme.spacing.sm,
-                  ':hover': {
-                    backgroundColor:
-                      theme.colorScheme === 'dark'
-                        ? theme.fn.lighten(theme.colors.dark[4], 0.05)
-                        : theme.fn.darken(theme.colors.gray[0], 0.05),
-                  },
-                })}
+          <Paper
+            key={download.modelVersion.id}
+            shadow="xs"
+            p="md"
+            radius="md"
+            sx={(theme) => ({
+              backgroundColor:
+                theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[1],
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+            })}
+          >
+            {/* Text and Info */}
+            <Stack spacing={2} sx={{ flex: 1 }}>
+              {/* Model Name */}
+              <Link
+                href={`/models/${download.modelVersion.model.id}/${slugit(
+                  download.modelVersion.model.name
+                )}`}
+                passHref
+                legacyBehavior
               >
-                <Stack spacing={0}>
-                  <Text size={textSize} weight={500} lineClamp={2} sx={{ lineHeight: 1 }}>
-                    {download.modelVersion.model.name}: {download.modelVersion.name}
-                  </Text>
-                  <Text size="xs" color="dimmed">
-                    <abbr title={downloadDate.format()}>{downloadDate.fromNow()}</abbr>
-                  </Text>
-                </Stack>
+                <Text component="a" weight={600} size="md" sx={{ lineHeight: 1.2 }}>
+                  {download.modelVersion.model.name}
+                </Text>
+              </Link>
+
+              {/* Model Version Name */}
+              <Text size="sm" color="dimmed">
+                {download.modelVersion.name}
               </Text>
-            </Link>
+
+              {/* Download Date */}
+              <Text size="xs" color="dimmed">
+                <abbr title={downloadDate.format()}>{downloadDate.fromNow()}</abbr>
+              </Text>
+            </Stack>
+
+            {/* Delete Button */}
             <ActionIcon onClick={() => onHideClick(download)} radius="xl" color="red">
               <IconTrash size={16} />
             </ActionIcon>
-          </Group>
+          </Paper>
         );
       })}
     </Stack>


### PR DESCRIPTION
1st Pass of a Download History page enhancement. Couple of things I'd like to discuss pre-merge;

1.  Not entirely sure if DownloadList.tsx is used anywhere other than Downloads.tsx. I changed the layout to be more in-line with the Leaderboard, or Auction, card-style display.
2.  The filter - Obviously it will only filter on-screen items right now, keen to update in future to pull in much the same way as the Notifications filter.

Original:
![image](https://github.com/user-attachments/assets/ea264b70-2382-4212-af73-6271d31634ba)

Modified:
![image](https://github.com/user-attachments/assets/dfa1489c-6885-421b-89fe-841a99eeae05)
