### PR TITLE
Set original quality of image in Post Details

### DIFF
--- a/src/components/Post/Detail/PostImages.tsx
+++ b/src/components/Post/Detail/PostImages.tsx
@@ -163,7 +163,7 @@ export function PostImages({
                           alt={image.name ?? undefined}
                           type={image.type}
                           width={width < maxWidth ? width : maxWidth}
-                          original={image.type === 'video'}
+                          original={true}
                           anim={safe}
                           html5Controls={shouldDisplayHtmlControls(image)}
                           videoRef={videoRef}


### PR DESCRIPTION
Description
-----------
Large resolution images (4k) appears blurry in the normal Post Detail view, which is the first view the user faces when clicking on  a post, and also the first view an user can engage with a reaction from the Post Infinite view. Due to the compression applied, the images appear blurry, which might lead the viewer to evaluate that the generation itself is blurry, and might engage with negative reaction ;( , or just no engage at all.

This patch just forces the original resolution for all media types for this view, to promote more positive engagement.

Patch Details
-------------
This is a completely blind patch, so I couldn't validate if it works. I couldn't setup the repo locally, the devcontainer just plain doesn't work, gen_seed.ts is full of errors and the db cannot be initialised, wasted 6h on this...
