### PR TITLE
fix: prevent random logouts from transient session refresh failures

### DIFF
--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -11,6 +11,7 @@ import {
   SearchIndexUpdateQueueAction,
 } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { withRetries } from '~/utils/errorHandling';
 
 import { preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { logToAxiom } from '~/server/logging/client';
@@ -766,123 +767,131 @@ export const updateAccountScope = async ({
 export const getSessionUser = async ({ userId, token }: { userId?: number; token?: string }) => {
   if (!userId && !token) return undefined;
 
-  // Get UserId from Token
-  if (!userId && token) {
-    const now = new Date();
-    const result = await dbWrite.apiKey.findFirst({
-      where: { key: token, OR: [{ expiresAt: { gte: now } }, { expiresAt: null }] },
-      select: { userId: true },
-    });
-    if (!result) return undefined;
-    userId = result.userId;
-  }
-  if (!userId) return undefined;
+  return withRetries(
+    async () => {
+      // Get UserId from Token
+      if (!userId && token) {
+        const now = new Date();
+        const result = await dbWrite.apiKey.findFirst({
+          where: { key: token, OR: [{ expiresAt: { gte: now } }, { expiresAt: null }] },
+          select: { userId: true },
+        });
+        if (!result) return undefined;
+        userId = result.userId;
+      }
+      if (!userId) return undefined;
 
-  // Get from cache
-  // ----------------------------------
-  const cacheKey = `${REDIS_KEYS.USER.SESSION}:${userId}` as const;
-  const cachedResult = await redis.packed.get<SessionUser | null>(cacheKey);
-  if (cachedResult && !('clearedAt' in cachedResult)) return cachedResult;
+      // Get from cache
+      // ----------------------------------
+      const cacheKey = `${REDIS_KEYS.USER.SESSION}:${userId}` as const;
+      const cachedResult = await redis.packed.get<SessionUser | null>(cacheKey);
+      if (cachedResult && !('clearedAt' in cachedResult)) return cachedResult;
 
-  // On cache miss get from database
-  // ----------------------------------
-  const where: Prisma.UserWhereInput = { deletedAt: null, id: userId };
+      // On cache miss get from database
+      // ----------------------------------
+      const where: Prisma.UserWhereInput = { deletedAt: null, id: userId };
 
-  // console.log(new Date().toISOString() + ' ::', 'running query');
-  // console.trace();
+      // console.log(new Date().toISOString() + ' ::', 'running query');
+      // console.trace();
 
-  // TODO switch from prisma, or try to make this a direct/raw query
-  const response = await dbWrite.user.findFirst({
-    where,
-    include: {
-      referral: { select: { id: true } },
-      profilePicture: {
-        select: {
-          id: true,
-          url: true,
-          // nsfw: true,
-          hash: true,
-          userId: true,
+      // TODO switch from prisma, or try to make this a direct/raw query
+      const response = await dbWrite.user.findFirst({
+        where,
+        include: {
+          referral: { select: { id: true } },
+          profilePicture: {
+            select: {
+              id: true,
+              url: true,
+              // nsfw: true,
+              hash: true,
+              userId: true,
+            },
+          },
         },
-      },
+      });
+
+      const subscription = await getUserSubscription({
+        userId,
+      });
+
+      if (!response) return undefined;
+
+      // nb: doing this because these fields are technically nullable, but prisma
+      // likes returning them as undefined. that messes with the typing.
+      const { banDetails, ...userMeta } = (response.meta ?? {}) as UserMeta;
+
+      const user = {
+        ...response,
+        image: response.image ?? undefined,
+        referral: response.referral ?? undefined,
+        name: response.name ?? undefined,
+        username: response.username ?? undefined,
+        email: response.email ?? undefined,
+        emailVerified: response.emailVerified ?? undefined,
+        isModerator: response.isModerator ?? undefined,
+        deletedAt: response.deletedAt ?? undefined,
+        customerId: response.customerId ?? undefined,
+        paddleCustomerId: response.paddleCustomerId ?? undefined,
+        subscriptionId: subscription?.id ?? undefined,
+        mutedAt: response.mutedAt ?? undefined,
+        bannedAt: response.bannedAt ?? undefined,
+        autoplayGifs: response.autoplayGifs ?? undefined,
+        leaderboardShowcase: response.leaderboardShowcase ?? undefined,
+        filePreferences: (response.filePreferences ?? undefined) as UserFilePreferences | undefined,
+        meta: userMeta,
+        banDetails: getUserBanDetails({ meta: userMeta }),
+      };
+
+      const { profilePicture, profilePictureId, publicSettings, settings, ...rest } = user;
+      const tier: UserTier | undefined =
+        subscription && ['active', 'trialing'].includes(subscription.status)
+          ? (subscription.product.metadata as any)[env.TIER_METADATA_KEY]
+          : undefined;
+      const memberInBadState =
+        (subscription &&
+          ['incomplete', 'incomplete_expired', 'past_due', 'unpaid'].includes(
+            subscription.status
+          )) ??
+        undefined;
+
+      const permissions: string[] = [];
+      const systemPermissions = await getSystemPermissions();
+      for (const [key, value] of Object.entries(systemPermissions)) {
+        if (value.includes(user.id)) permissions.push(key);
+      }
+
+      // let feedbackToken: string | undefined;
+      // if (!!user.username && !!user.email)
+      //   feedbackToken = createFeaturebaseToken(user as { username: string; email: string });
+
+      const userSettings = userSettingsSchema.safeParse(settings ?? {});
+
+      const sessionUser: SessionUser = {
+        ...rest,
+        image: profilePicture?.url ?? rest.image,
+        tier: tier !== 'free' ? tier : undefined,
+        permissions,
+        memberInBadState,
+        allowAds:
+          userSettings.success && userSettings.data.allowAds != null
+            ? userSettings.data.allowAds
+            : tier != null
+            ? false
+            : true,
+        redBrowsingLevel:
+          userSettings.success && userSettings.data.redBrowsingLevel != null
+            ? userSettings.data.redBrowsingLevel
+            : undefined,
+        // feedbackToken,
+      };
+      await redis.packed.set(cacheKey, sessionUser, { EX: CacheTTL.hour * 4 });
+
+      return sessionUser;
     },
-  });
-
-  const subscription = await getUserSubscription({
-    userId,
-  });
-
-  if (!response) return undefined;
-
-  // nb: doing this because these fields are technically nullable, but prisma
-  // likes returning them as undefined. that messes with the typing.
-  const { banDetails, ...userMeta } = (response.meta ?? {}) as UserMeta;
-
-  const user = {
-    ...response,
-    image: response.image ?? undefined,
-    referral: response.referral ?? undefined,
-    name: response.name ?? undefined,
-    username: response.username ?? undefined,
-    email: response.email ?? undefined,
-    emailVerified: response.emailVerified ?? undefined,
-    isModerator: response.isModerator ?? undefined,
-    deletedAt: response.deletedAt ?? undefined,
-    customerId: response.customerId ?? undefined,
-    paddleCustomerId: response.paddleCustomerId ?? undefined,
-    subscriptionId: subscription?.id ?? undefined,
-    mutedAt: response.mutedAt ?? undefined,
-    bannedAt: response.bannedAt ?? undefined,
-    autoplayGifs: response.autoplayGifs ?? undefined,
-    leaderboardShowcase: response.leaderboardShowcase ?? undefined,
-    filePreferences: (response.filePreferences ?? undefined) as UserFilePreferences | undefined,
-    meta: userMeta,
-    banDetails: getUserBanDetails({ meta: userMeta }),
-  };
-
-  const { profilePicture, profilePictureId, publicSettings, settings, ...rest } = user;
-  const tier: UserTier | undefined =
-    subscription && ['active', 'trialing'].includes(subscription.status)
-      ? (subscription.product.metadata as any)[env.TIER_METADATA_KEY]
-      : undefined;
-  const memberInBadState =
-    (subscription &&
-      ['incomplete', 'incomplete_expired', 'past_due', 'unpaid'].includes(subscription.status)) ??
-    undefined;
-
-  const permissions: string[] = [];
-  const systemPermissions = await getSystemPermissions();
-  for (const [key, value] of Object.entries(systemPermissions)) {
-    if (value.includes(user.id)) permissions.push(key);
-  }
-
-  // let feedbackToken: string | undefined;
-  // if (!!user.username && !!user.email)
-  //   feedbackToken = createFeaturebaseToken(user as { username: string; email: string });
-
-  const userSettings = userSettingsSchema.safeParse(settings ?? {});
-
-  const sessionUser: SessionUser = {
-    ...rest,
-    image: profilePicture?.url ?? rest.image,
-    tier: tier !== 'free' ? tier : undefined,
-    permissions,
-    memberInBadState,
-    allowAds:
-      userSettings.success && userSettings.data.allowAds != null
-        ? userSettings.data.allowAds
-        : tier != null
-        ? false
-        : true,
-    redBrowsingLevel:
-      userSettings.success && userSettings.data.redBrowsingLevel != null
-        ? userSettings.data.redBrowsingLevel
-        : undefined,
-    // feedbackToken,
-  };
-  await redis.packed.set(cacheKey, sessionUser, { EX: CacheTTL.hour * 4 });
-
-  return sessionUser;
+    2, // 2 retries = 3 total attempts
+    100 // 100ms initial retry delay
+  );
 };
 
 export const removeAllContent = async ({ id }: { id: number }) => {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,6 +1,6 @@
 import type { DefaultSession, DefaultUser } from 'next-auth';
 import type { UserTier } from '~/server/schema/user.schema';
-import type { User as PrismaUser } from '~/shared/utils/prisma/enums';
+import type { User as PrismaUser } from '~/shared/utils/prisma/models';
 import type { getUserBanDetails } from '~/utils/user-helpers';
 
 interface ExtendedUser {


### PR DESCRIPTION
- Add graceful degradation in session callback to distinguish between explicit invalidations and transient failures
- Return null from refreshToken only for explicit invalidations (clearedAt, invalid token hash)
- Keep existing session when refresh fails due to DB timeouts or connection issues
- Add retry logic to getSessionUser using existing withRetries utility (max 3 attempts)
- Initialize signedAt during token creation to prevent unnecessary immediate refreshes
- Add TTL to invalid tokens hash as defense-in-depth (complements hourly cleanup job)
- Fix signOut event not triggering by consolidating event handlers and removing override
- Clean up debug console.log statements