### PR TITLE
[Feature] Wan 2.2 - Support for high/low safetensors uploads in one version.

### DIFF
--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -434,9 +434,9 @@ function FileEditForm({
     switch (extension) {
       case 'ckpt':
       case 'safetensors':
-        return ['Model', 'Negative', 'VAE'].includes(value);
+        return ['Model', 'Negative', 'VAE', 'Secondary Model'].includes(value);
       case 'pt':
-        return ['Model', 'Negative', 'VAE'].includes(value);
+        return ['Model', 'Negative', 'VAE', 'Secondary Model'].includes(value);
       case 'zip':
         return ['Training Data', 'Archive', 'Model'].includes(value);
       case 'yml':

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -482,7 +482,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
       '.yml',
       '.onnx',
     ],
-    acceptedModelFiles: ['Model', 'Config', 'Training Data'],
+    acceptedModelFiles: ['Model', 'Config', 'Training Data', 'Secondary Model'],
     maxFiles: 11,
   },
   MotionModule: {
@@ -502,7 +502,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
       '.yaml',
       '.yml',
     ],
-    acceptedModelFiles: ['Model', 'Text Encoder', 'Training Data'],
+    acceptedModelFiles: ['Model', 'Text Encoder', 'Training Data', 'Secondary Model'],
     maxFiles: 4,
   },
   DoRA: {
@@ -517,7 +517,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
       '.yaml',
       '.yml',
     ],
-    acceptedModelFiles: ['Model', 'Text Encoder', 'Training Data'],
+    acceptedModelFiles: ['Model', 'Text Encoder', 'Training Data', 'Secondary Model'],
     maxFiles: 4,
   },
   LoCon: {
@@ -532,7 +532,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
       '.yaml',
       '.yml',
     ],
-    acceptedModelFiles: ['Model', 'Text Encoder', 'Training Data'],
+    acceptedModelFiles: ['Model', 'Text Encoder', 'Training Data', 'Secondary Model'],
     maxFiles: 4,
   },
   Detection: {

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -61,6 +61,7 @@ export const constants = {
     'VAE',
     'Config',
     'Archive',
+    'Secondary Model',
   ],
   trainingMediaTypes: ['image', 'video'],
   trainingModelTypes: ['Character', 'Style', 'Concept', 'Effect'],


### PR DESCRIPTION
This PR adds a new type for model-like files called "Secondary Model", which allows uploading two paired safetensors files under the same version.
It is extremely handy for example in wan 2.2's high/low setting, where gens universally utilise both models simultaneously; whereas the current state of the code has these split across versions or in untraceable zips (which IMO shouldn't be allowed for models anyway given they're almost exclusively used for spam or to bypass the single model restriction in practice).

I initially considered a more elegant approach, of disabling the patch function `checkConflictingFiles` in `src/components/Resource/FilesProvider.txt`, which doesn't seem to work correctly anyway (doesn't actually check for identical size, can be bypassed), but since the download url ids files by version and filetype, it would require an unreasonable overhaul of the system to make it work. For example, this model has two different "model" type files, but only the -0008 one is accessible via the given download links.
https://civitai.com/api/v1/models/1910970
https://civitai.com/api/download/models/2162920
https://civitai.com/api/download/models/2162920?type=Model&format=SafeTensor

Meanwhile, adding a new type allows seamless references, and appears to require nothing more than adding these 7 lines, apart from perhaps adding it to the pgres db's enum as well. Far more obscure types have been supported since day one, for example 'Text Encoder' which appears to have been used less than 200 times throughout the site's history.