### PR TITLE
Add bandwidth tracking to download events

### DIFF
--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -160,6 +160,7 @@ export default PublicEndpoint(
         nsfw: fileResult.nsfw,
         earlyAccess: fileResult.inEarlyAccess,
         time: now,
+        sizeKB: fileResult.sizeKB,
       });
 
       // Increment download count for user

--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -416,6 +416,7 @@ export class Tracker {
     nsfw: boolean;
     earlyAccess?: boolean;
     time?: Date;
+    sizeKB?: number | null;
   }) {
     return this.track('modelVersionEvents', values);
   }

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -252,6 +252,7 @@ export const getFileForModelVersion = async ({
         overrideName: true,
         type: true,
         metadata: true,
+        sizeKB: true,
         hashes: { select: { hash: true }, where: { type: 'SHA256' } },
       },
     });
@@ -280,6 +281,7 @@ export const getFileForModelVersion = async ({
       inEarlyAccess,
       metadata: file.metadata as FileMetadata,
       isDownloadable,
+      sizeKB: file.sizeKB,
     };
   } catch (error) {
     return { status: 'error' };
@@ -353,6 +355,7 @@ type ModelVersionFileResult =
       inEarlyAccess: boolean;
       metadata: FileMetadata;
       isDownloadable?: boolean;
+      sizeKB?: number | null;
     };
 
 type FileResult = {
@@ -365,4 +368,5 @@ type FileResult = {
     hash: string;
   }[];
   url: string;
+  sizeKB?: number | null;
 };


### PR DESCRIPTION
Track file size (sizeKB) in modelVersionEvents for bandwidth analytics. This enables monitoring of total downloaded bytes over time.

Changes:
- Add sizeKB to file query and return type in file.service.ts
- Extend modelVersionEvent tracker to accept sizeKB
- Pass sizeKB from download endpoint to ClickHouse tracker