### PR TITLE
fix: resolve race conditions in image scan result handlers

### DIFF
--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -17,7 +17,6 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { getExplainSql } from '~/server/db/db-helpers';
 import { logToAxiom } from '~/server/logging/client';
 import { tagIdsForImagesCache } from '~/server/redis/caches';
-import { scanJobsSchema } from '~/server/schema/image.schema';
 import type { ImageMetadata, VideoMetadata } from '~/server/schema/media.schema';
 import { addImageToQueue } from '~/server/services/games/new-order.service';
 import { createImageTagsForReview } from '~/server/services/image-review.service';
@@ -157,21 +156,11 @@ export default WebhookEndpoint(async (req, res) => {
         });
         break;
       case Status.Unscannable:
-        const image = await dbWrite.image.findUnique({
-          where: { id: data.id },
-          select: { scanJobs: true },
-        });
-
-        const scanJobs = scanJobsSchema.parse(image?.scanJobs ?? {});
-        scanJobs.retryCount = scanJobs.retryCount ?? 0;
-        scanJobs.retryCount++;
-
-        await dbWrite.image.updateMany({
-          where: { id: data.id, ingestion: { in: pendingStates } },
-          data: {
-            ingestion: ImageIngestionStatus.Error,
-            scanJobs: scanJobs as any,
-          },
+        await updateImageScanJobs({
+          id: data.id,
+          ingestion: ImageIngestionStatus.Error,
+          incrementRetryCount: true,
+          whereIngestionIn: pendingStates,
         });
         break;
       case Status.Success:
@@ -747,16 +736,50 @@ async function updateImageScanJobs({
   ingestion,
   nsfwLevel,
   blockedFor,
+  incrementRetryCount,
+  whereIngestionIn,
 }: {
   id: number;
-  source: TagSource;
+  source?: TagSource;
   aiRating?: NsfwLevel;
   aiModel?: string;
   pHash?: bigint;
   ingestion?: ImageIngestionStatus;
   nsfwLevel?: NsfwLevel;
   blockedFor?: string;
+  incrementRetryCount?: boolean;
+  whereIngestionIn?: ImageIngestionStatus[];
 }) {
+  // Build scanJobs update SQL by composing jsonb operations
+  const scanJobsOps: { path: string; value: string }[] = [];
+  if (source) {
+    scanJobsOps.push({
+      path: `'{scans}'`,
+      value: `COALESCE("scanJobs"->'scans', '{}') || '{"${source}": ${Date.now()}}'::jsonb`,
+    });
+  }
+  if (incrementRetryCount) {
+    scanJobsOps.push({
+      path: `'{retryCount}'`,
+      value: `to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)`,
+    });
+  }
+  if (!scanJobsOps.length) {
+    throw new Error('updateImageScanJobs requires either source or incrementRetryCount');
+  }
+  // Nest jsonb_set calls: jsonb_set(jsonb_set(base, path1, val1), path2, val2)
+  const scanJobsSql = scanJobsOps.reduce(
+    (acc, op) => `jsonb_set(${acc}, ${op.path}, ${op.value})`,
+    `COALESCE("scanJobs", '{}')`
+  );
+
+  // Build WHERE clause dynamically
+  const whereConditions = [`id = ${id}`];
+  if (whereIngestionIn?.length) {
+    whereConditions.push(`ingestion IN (${whereIngestionIn.map((s) => `'${s}'`).join(', ')})`);
+  }
+  const whereClause = whereConditions.join(' AND ');
+
   const result = await dbWrite.$queryRawUnsafe<
     {
       scanJobs: { scans?: Record<string, TagSource> };
@@ -770,8 +793,8 @@ async function updateImageScanJobs({
       ${blockedFor ? `"blockedFor" = '${blockedFor}',` : ''}
       ${aiRating ? `"aiNsfwLevel" = ${aiRating},` : ''}
       ${aiModel ? `"aiModel" = '${aiModel}',` : ''}
-      "scanJobs" = jsonb_set(COALESCE("scanJobs", '{}'), '{scans}', COALESCE("scanJobs"->'scans', '{}') || '{"${source}": ${Date.now()}}'::jsonb)
-      WHERE id = ${id}
+      "scanJobs" = ${scanJobsSql}
+      WHERE ${whereClause}
       RETURNING "scanJobs", type;
     `);
 


### PR DESCRIPTION
## Summary
- Fixed read-modify-write race conditions in image scan result handlers that could cause `scanJobs.scans` data to be lost when multiple scan results arrive concurrently
- Replaced non-atomic scanJobs updates with atomic `jsonb_set` operations in three locations:
  1. Webhook Unscannable handler (`image-scan-result.ts`)
  2. Workflow failure handler (`image-scan-result.service.ts`)
  3. Workflow success handler (`image-scan-result.service.ts`)

## Test plan
- [ ] Verify images with multiple concurrent scan results complete properly
- [ ] Verify Unscannable status increments retryCount without losing scan data
- [ ] Verify workflow-based scans set workflowId without losing scan data

🤖 Generated with [Claude Code](https://claude.com/claude-code)