### PR TITLE
feat: add S3_IMAGE_FORCE_PATH_STYLE env var for proxy support

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -69,6 +69,7 @@ export const serverSchema = z.object({
   S3_IMAGE_UPLOAD_REGION: z.string(),
   S3_IMAGE_UPLOAD_ENDPOINT: z.url(),
   S3_IMAGE_UPLOAD_BUCKET: z.string(),
+  S3_IMAGE_FORCE_PATH_STYLE: zc.booleanString.default(false),
   S3_IMAGE_UPLOAD_OVERRIDE: z.string().optional(),
   S3_IMAGE_UPLOAD_BUCKET_OLD: z.string().optional(),
   S3_IMAGE_CACHE_BUCKET: z.string().default(''),

--- a/src/utils/s3-client.ts
+++ b/src/utils/s3-client.ts
@@ -26,6 +26,7 @@ type S3ConstructorProps = {
   uploadSecret?: string;
   uploadEndpoint?: string;
   uploadRegion?: string;
+  forcePathStyle?: boolean;
 };
 type BaseS3MethodProps = { bucket: string; key: string };
 type MultipartUploadPart = {
@@ -43,6 +44,7 @@ function createS3Client({
   uploadSecret,
   uploadEndpoint,
   uploadRegion,
+  forcePathStyle,
 }: S3ConstructorProps) {
   const keys: string[] = [];
   if (!uploadKey) keys.push('uploadKey');
@@ -57,6 +59,7 @@ function createS3Client({
     },
     region: uploadRegion,
     endpoint: uploadEndpoint,
+    forcePathStyle,
   });
 }
 
@@ -254,4 +257,5 @@ export const imageS3Client = new S3Client({
   uploadSecret: env.S3_IMAGE_UPLOAD_SECRET,
   uploadEndpoint: env.S3_IMAGE_UPLOAD_ENDPOINT,
   uploadRegion: env.S3_IMAGE_UPLOAD_REGION,
+  forcePathStyle: env.S3_IMAGE_FORCE_PATH_STYLE,
 });

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -37,6 +37,7 @@ export function getS3Client(destination: S3Clients = 'model') {
       },
       region: env.S3_IMAGE_UPLOAD_REGION,
       endpoint: env.S3_IMAGE_UPLOAD_ENDPOINT,
+      forcePathStyle: env.S3_IMAGE_FORCE_PATH_STYLE,
     });
   }
 


### PR DESCRIPTION
Allows enabling path-style S3 URLs (/{bucket}/{key}) instead of virtual-hosted style ({bucket}.{endpoint}/{key}).

When S3_IMAGE_FORCE_PATH_STYLE=true, uploads go through proxies without requiring nested wildcard SSL certificates.
