### PR TITLE
Add daily challenge fairness improvements

### DIFF
--- a/docs/features/daily-challenge.md
+++ b/docs/features/daily-challenge.md
@@ -1,0 +1,187 @@
+# Daily Challenge System
+
+This document explains how the daily challenge system works in Civitai. The system runs automated AI-powered creative challenges that feature community-created models, allowing users to compete for prizes by generating images using specific resources.
+
+## Architecture Overview
+
+The daily challenge system consists of several key components:
+
+- **Automated Jobs**: Three scheduled jobs handle challenge setup, entry processing, and winner selection
+- **LLM Integration**: GPT-4O powers content generation and entry scoring
+- **Scoring System**: Hybrid scoring combining AI judgment (75%) and community engagement (25%)
+- **Prize Distribution**: Automated Buzz rewards for winners and participation prizes
+
+## System Flow
+
+### Challenge Lifecycle
+
+1. **Setup Phase** (10 PM UTC daily): Creates new challenge with randomly selected model/resource
+2. **Active Phase** (24 hours): Users submit images, entries are continuously reviewed
+3. **Completion Phase** (Midnight UTC): Winners selected, prizes distributed, next challenge begins
+
+### Scheduled Jobs
+
+| Job | Schedule | Function |
+|-----|----------|----------|
+| `daily-challenge-setup` | `0 22 * * *` (10 PM UTC) | Creates upcoming challenges |
+| `daily-challenge-process-entries` | `*/10 * * * *` (Every 10 mins) | Reviews and scores entries |
+| `daily-challenge-pick-winners` | `0 0 * * *` (Midnight UTC) | Selects winners, distributes prizes |
+
+## LLM Integration
+
+The system uses GPT-4O for AI-powered content generation and scoring. LLM prompts are stored in the `ChallengeType` database table.
+
+### LLM Functions
+
+#### 1. Collection Details Generation
+- **Purpose**: Create metadata for the challenge collection
+- **Output**: Collection name and description based on the featured resource
+
+#### 2. Article Generation
+- **Purpose**: Create the challenge article/announcement
+- **Output**:
+  - Challenge title
+  - Markdown body content
+  - Invitation text to participate
+  - Theme (1-2 words, e.g., "SynthwavePunk")
+
+#### 3. Entry Review
+- **Purpose**: Score each submitted entry
+- **Triggered**: Every 10 minutes for new submissions
+- **Output**:
+  ```json
+  {
+    "score": {
+      "theme": 0-10,      // Adherence to challenge theme
+      "wittiness": 0-10,  // Cleverness of interpretation
+      "humor": 0-10,      // How funny/entertaining
+      "aesthetic": 0-10   // Visual quality and appeal
+    },
+    "reaction": "emoji",  // Laugh, Heart, Like, or Cry
+    "comment": "string",  // Detailed feedback on submission
+    "summary": "string"   // Concise 1-2 sentence description
+  }
+  ```
+- The comment and reaction are posted directly to the submitted image
+
+#### 4. Winner Selection
+- **Purpose**: Pick final winners from top candidates
+- **Input**: Top 10 scored entries with their summaries and scores
+- **Output**:
+  - List of winners with reasons for selection
+  - Description of the judging process
+  - Challenge outcome summary
+
+## Scoring System
+
+### Entry Validation
+
+Before scoring, each submission must pass automatic filtering:
+
+1. **Safe Content**: `nsfwLevel = 1` (SFW only)
+2. **Required Resource**: Image must use the featured model/resource
+3. **Recency**: Image created on or after challenge start date (prevents reusing old images)
+
+Entries failing any check are automatically rejected.
+
+### AI Scoring
+
+Each accepted entry receives scores in four dimensions (0-10 each):
+- **Theme**: How well the image matches the challenge theme
+- **Wittiness**: Cleverness of the creative interpretation
+- **Humor**: Entertainment value
+- **Aesthetic**: Visual quality and artistic merit
+
+### Final Ranking Formula
+
+```
+Weighted Rating = (AI Rating × 0.75) + (Engagement Score × 0.25)
+
+Where:
+- AI Rating = Average of [theme, wittiness, humor, aesthetic]
+- Engagement Score = Normalized sum of [views, comments, reactions]
+```
+
+The engagement score is normalized using min/max scaling to a 0-10 range across all entries.
+
+## Winner Selection Process
+
+### Selection Steps
+
+1. **Close Collection**: No new submissions accepted
+2. **Rank Entries**: Sort by weighted rating
+3. **Deduplicate**: One entry per user (top entry only)
+4. **Final Judgment**: Top 10 entries sent to LLM for final selection
+5. **Prize Distribution**: Winners receive Buzz rewards automatically
+6. **Notifications**: Winners notified via in-app notifications
+
+### Prize Structure
+
+| Position | Buzz | Points |
+|----------|------|--------|
+| 1st Place | 5,000 | 150 |
+| 2nd Place | 2,500 | 100 |
+| 3rd Place | 1,500 | 50 |
+
+**Participation Prize**: Users who submit 10+ valid entries receive 200 Buzz and 10 points.
+
+## Anti-Gaming Measures
+
+The system includes several mechanisms to ensure fair competition:
+
+- **User Cooldown**: Creators can only be featured every 14 days
+- **Resource Cooldown**: Each resource can only be featured every 90 days
+- **Entry Limits**: Maximum 2× the entry requirement per user (e.g., 20 entries for 10-entry requirement)
+- **Per-User Scored Cap**: Maximum 5 entries per user can be scored per challenge (`maxScoredPerUser: 5`), preventing volume-based advantage
+- **Best-Entry-Per-User Selection**: Final judgment considers only each user's single best-scoring entry, ensuring fair competition based on quality not quantity
+- **One Winner Per User**: Top 10 ensures diversity in final selection
+- **Image Recency**: Only images created during the challenge period qualify
+
+## Configuration
+
+Default challenge configuration:
+
+```typescript
+{
+  challengeType: 'world-morph',
+  userCooldown: '14 day',
+  resourceCooldown: '90 day',
+  prizes: [
+    { buzz: 5000, points: 150 },
+    { buzz: 2500, points: 100 },
+    { buzz: 1500, points: 50 }
+  ],
+  entryPrizeRequirement: 10,
+  entryPrize: { buzz: 200, points: 10 },
+  reviewAmount: { min: 2, max: 6 },
+  maxScoredPerUser: 5,          // Maximum entries that can be scored per user per challenge
+  finalReviewAmount: 10
+}
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/server/jobs/daily-challenge-processing.ts` | Main job logic (setup, review, winners) |
+| `src/server/games/daily-challenge/generative-content.ts` | LLM integrations |
+| `src/server/games/daily-challenge/daily-challenge.utils.ts` | Config and state management |
+| `src/server/services/daily-challenge.service.ts` | Service layer (API endpoints) |
+| `src/server/routers/daily-challenge.router.ts` | tRPC routes |
+| `src/server/notifications/challenge.notifications.ts` | Winner notifications |
+| `src/components/Challenges/challenge.utils.ts` | Frontend utilities |
+
+## Database Tables
+
+### ChallengeType
+Stores challenge type definitions and LLM prompts:
+- `promptSystemMessage`: Base system context
+- `promptCollection`: Collection generation instructions
+- `promptArticle`: Article generation instructions
+- `promptReview`: Entry scoring instructions
+- `promptWinner`: Winner selection instructions
+
+### Challenge State
+Challenge state and configuration are stored in Redis:
+- `REDIS_SYS_KEYS.DAILY_CHALLENGE.CONFIG`: Current configuration
+- Custom challenges can be set via Redis with automatic end date management

--- a/src/server/games/daily-challenge/daily-challenge.utils.ts
+++ b/src/server/games/daily-challenge/daily-challenge.utils.ts
@@ -27,6 +27,7 @@ const challengeConfigSchema = z.object({
     min: z.number(),
     max: z.number(),
   }),
+  maxScoredPerUser: z.number(),
   finalReviewAmount: z.number(),
   resourceCosmeticId: z.number().nullable(),
   articleTagId: z.number(),
@@ -47,6 +48,7 @@ export const dailyChallengeConfig: ChallengeConfig = {
   entryPrizeRequirement: 10,
   entryPrize: { buzz: 200, points: 10 } as Prize,
   reviewAmount: { min: 2, max: 6 },
+  maxScoredPerUser: 5,
   finalReviewAmount: 10,
   resourceCosmeticId: null,
   articleTagId: 128643, // Announcement.

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -383,6 +383,18 @@ async function reviewEntries() {
     const lastReviewedAt = new Date(Number(article.reviewedAt));
     log('Last reviewed at:', lastReviewedAt);
 
+    // Get count of already-scored entries per user for this challenge (for per-user cap)
+    const userScoredCounts = await dbWrite.$queryRaw<{ userId: number; count: bigint }[]>`
+    SELECT i."userId", COUNT(*) as count
+    FROM "CollectionItem" ci
+    JOIN "Image" i ON i.id = ci."imageId"
+    WHERE ci."collectionId" = ${currentChallenge.collectionId}
+    AND ci."tagId" = ${config.judgedTagId}
+    GROUP BY i."userId"
+  `;
+    const scoredCountMap = new Map(userScoredCounts.map((r) => [r.userId, Number(r.count)]));
+    log('Users with scored entries:', scoredCountMap.size);
+
     // Get entries approved since last reviewed
     const recentEntries = await dbWrite.$queryRaw<RecentEntry[]>`
     SELECT
@@ -408,12 +420,16 @@ async function reviewEntries() {
     for (const entry of shuffledEntries) {
       if (toReviewCount <= 0) break;
       if (reviewingUsers.has(entry.userId)) continue;
+      // Skip users who have already hit the per-user scored cap
+      const userScored = scoredCountMap.get(entry.userId) ?? 0;
+      if (userScored >= config.maxScoredPerUser) continue;
       toReview.push(entry);
+      reviewingUsers.add(entry.userId);
       toReviewCount--;
     }
     log('Entries to review:', toReview.length);
 
-    // Get forced to review entries
+    // Get forced to review entries (also respecting per-user cap)
     const requestReview = await dbWrite.$queryRaw<RecentEntry[]>`
     SELECT
       ci."imageId",
@@ -428,7 +444,14 @@ async function reviewEntries() {
     AND ci."tagId" = ${config.reviewMeTagId}
   `;
     log('Requested review:', requestReview.length);
-    toReview.push(...requestReview);
+    // Filter reviewMe entries to also respect per-user cap
+    for (const entry of requestReview) {
+      const userScored = scoredCountMap.get(entry.userId) ?? 0;
+      if (userScored >= config.maxScoredPerUser) continue;
+      if (reviewingUsers.has(entry.userId)) continue;
+      toReview.push(entry);
+      reviewingUsers.add(entry.userId);
+    }
 
     // Rate entries
     const tasks = toReview.map((entry) => async () => {
@@ -765,41 +788,56 @@ export async function getCoverOfModel(modelId: number) {
 }
 
 export async function getJudgedEntries(collectionId: number, config: ChallengeConfig) {
-  const judgedEntriesRaw = await dbRead.$queryRaw<Omit<JudgedEntry, 'engagement'>[]>`
-    SELECT
-      ci."imageId",
-      i."userId",
-      u."username",
-      ci.note
-    FROM "CollectionItem" ci
-    JOIN "Image" i ON i.id = ci."imageId"
-    JOIN "User" u ON u.id = i."userId"
-    WHERE ci."collectionId" = ${collectionId}
-    AND ci."tagId" = ${config.judgedTagId}
-    AND ci.note IS NOT NULL -- Since people can apply judged tag atm...
-    AND ci.status = 'ACCEPTED'
+  // Get each user's BEST entry only (by AI score), so users with many entries
+  // don't have an advantage over users with fewer entries
+  const userBestEntries = await dbRead.$queryRaw<Omit<JudgedEntry, 'engagement'>[]>`
+    WITH ranked AS (
+      SELECT
+        ci."imageId",
+        i."userId",
+        u."username",
+        ci.note,
+        ROW_NUMBER() OVER (
+          PARTITION BY i."userId"
+          ORDER BY (
+            (ci.note::json->'score'->>'theme')::float +
+            (ci.note::json->'score'->>'wittiness')::float +
+            (ci.note::json->'score'->>'humor')::float +
+            (ci.note::json->'score'->>'aesthetic')::float
+          ) DESC
+        ) as rn
+      FROM "CollectionItem" ci
+      JOIN "Image" i ON i.id = ci."imageId"
+      JOIN "User" u ON u.id = i."userId"
+      WHERE ci."collectionId" = ${collectionId}
+      AND ci."tagId" = ${config.judgedTagId}
+      AND ci.note IS NOT NULL
+      AND ci.status = 'ACCEPTED'
+    )
+    SELECT "imageId", "userId", username, note
+    FROM ranked
+    WHERE rn = 1
   `;
-  log('Judged entries:', judgedEntriesRaw?.length);
-  if (!judgedEntriesRaw.length) {
+  log('Users with judged entries:', userBestEntries?.length);
+  if (!userBestEntries.length) {
     return [];
   }
 
-  // Fetch engagement metrics from Redis
-  const imageIds = judgedEntriesRaw.map((entry) => entry.imageId);
+  // Fetch engagement metrics from Redis for best entries only
+  const imageIds = userBestEntries.map((entry) => entry.imageId);
   const metricsMap = await entityMetricRedis.getBulkMetrics('Image', imageIds);
 
   // Calculate engagement (sum of all metrics except Buzz)
-  const judgedEntriesWithEngagement = judgedEntriesRaw.map((entry) => {
+  const entriesWithEngagement = userBestEntries.map((entry) => {
     const metrics = metricsMap.get(entry.imageId);
-    // @ai: Using static helper to avoid object creation overhead
     const engagement = metrics ? EntityMetricsHelper.getTotalEngagement(metrics) : 0;
     return { ...entry, engagement };
   });
 
-  // Sort judged entries by (rating * 0.75) and (engagement * 0.25)
-  const maxEngagement = Math.max(...judgedEntriesWithEngagement.map((entry) => entry.engagement));
-  const minEngagement = Math.min(...judgedEntriesWithEngagement.map((entry) => entry.engagement));
-  const judgedEntries = judgedEntriesWithEngagement.map(({ note, engagement, ...entry }) => {
+  // Sort entries by (rating * 0.75) and (engagement * 0.25)
+  const maxEngagement = Math.max(...entriesWithEngagement.map((entry) => entry.engagement));
+  const minEngagement = Math.min(...entriesWithEngagement.map((entry) => entry.engagement));
+  const judgedEntries = entriesWithEngagement.map(({ note, engagement, ...entry }) => {
     const { score, summary } = JSON.parse(note);
     // Calculate average rating
     const rating = (score.theme + score.wittiness + score.humor + score.aesthetic) / 4;
@@ -815,19 +853,8 @@ export async function getJudgedEntries(collectionId: number, config: ChallengeCo
   });
   judgedEntries.sort((a, b) => b.weightedRating - a.weightedRating);
 
-  // Take top 10 entries per user
-  let toSend = config.finalReviewAmount;
-  const toFinalJudgment: typeof judgedEntries = [];
-  const finalJudgmentUsers = new Set<number>();
-  for (const entry of judgedEntries) {
-    if (toSend <= 0) break;
-    if (finalJudgmentUsers.has(entry.userId)) continue;
-    toFinalJudgment.push(entry);
-    finalJudgmentUsers.add(entry.userId);
-    toSend--;
-  }
-
-  return toFinalJudgment;
+  // Take top entries for final judgment (already one per user from the query)
+  return judgedEntries.slice(0, config.finalReviewAmount);
 }
 
 export async function startNextChallenge(config: ChallengeConfig) {


### PR DESCRIPTION
## Summary

This PR addresses an issue where users who submit many entries to daily challenges have a significant advantage over casual participants. Investigation revealed that some users (e.g., janxd with 80 scored entries per challenge) were winning ~57% of challenges due to volume-based advantage rather than quality.

### Changes

- **Per-user scored cap**: Added `maxScoredPerUser: 5` config to limit how many entries per user can be scored per challenge
- **Best-entry-per-user selection**: Modified `getJudgedEntries()` to use SQL window function to select only each user's highest-scoring entry for final judgment
- **Review filtering**: Updated `reviewEntries()` to skip users who have already reached the scoring cap
- **Documentation**: Added comprehensive documentation for the daily challenge system

### Impact

- Users at/over the cap (e.g., janxd with 20 scored entries) will be skipped in future review cycles
- Final judgment now considers each user's single best entry, not all their entries
- Levels the playing field between high-volume and casual participants

### Testing

- TypeScript compilation passes
- Integration tested against production data (read-only) via test endpoint
- Verified:
  - Each user appears exactly once in final judgment
  - Best-entry selection correctly picks highest-scoring entry
  - Cap logic correctly identifies users to skip

## Test plan

- [ ] Deploy to staging and monitor one full challenge cycle (24 hours)
- [ ] Verify users are capped at 5 scored entries
- [ ] Verify winner selection uses best-entry-per-user logic
- [ ] Check job logs for "Users with scored entries" count

🤖 Generated with [Claude Code](https://claude.com/claude-code)