### PR TITLE
Replace Image table scanning with JobQueue for blocked image deletion

### DIFF
--- a/prisma/migrations/20260113194750_add_blocked_image_delete_job_queue/migration.sql
+++ b/prisma/migrations/20260113194750_add_blocked_image_delete_job_queue/migration.sql
@@ -1,0 +1,45 @@
+-- Add BlockedImageDelete to JobQueueType enum
+ALTER TYPE "JobQueueType" ADD VALUE 'BlockedImageDelete';
+
+-- Create trigger function for blocked image delete queue
+-- This adds images to the queue when they become blocked and need to be deleted
+-- The delete job will process them after the retention period (7 days)
+CREATE OR REPLACE FUNCTION blocked_image_delete_queue_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- On UPDATE when ingestion changes to Blocked
+  IF (TG_OP = 'UPDATE' AND NEW.ingestion = 'Blocked'
+      AND (OLD.ingestion IS DISTINCT FROM NEW.ingestion)) THEN
+    -- Only queue images that will actually be deleted (not AiNotVerified which is handled differently)
+    IF (NEW."blockedFor" IS NULL OR NEW."blockedFor" != 'AiNotVerified') THEN
+      PERFORM create_job_queue_record(NEW.id, 'Image', 'BlockedImageDelete');
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger on Image table
+CREATE OR REPLACE TRIGGER trg_blocked_image_delete_queue
+  AFTER UPDATE OF ingestion ON "Image"
+  FOR EACH ROW
+  EXECUTE FUNCTION blocked_image_delete_queue_trigger();
+
+-- Backfill: Queue existing blocked images that are past the retention period
+-- Since there's no index on Blocked status, we'll do a conditional backfill
+-- that only inserts images past the 7-day cutoff to avoid queueing images
+-- that shouldn't be deleted yet. This may take a while but is a one-time operation.
+--
+-- Note: We use ON CONFLICT DO NOTHING to handle any duplicates
+INSERT INTO "JobQueue" ("entityId", "entityType", "type")
+SELECT i.id, 'Image'::"EntityType", 'BlockedImageDelete'::"JobQueueType"
+FROM "Image" i
+WHERE i.ingestion = 'Blocked'::"ImageIngestionStatus"
+  AND i."blockedFor" IS DISTINCT FROM 'AiNotVerified'
+  AND (
+    (i."blockedFor" = 'moderated' AND i."updatedAt" <= NOW() - INTERVAL '7 days')
+    OR
+    (i."blockedFor" IS DISTINCT FROM 'moderated' AND i."createdAt" <= NOW() - INTERVAL '7 days')
+  )
+ON CONFLICT DO NOTHING;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -3344,6 +3344,7 @@ enum JobQueueType {
   UpdateSearchIndex
   CleanIfEmpty
   ModerationRequest
+  BlockedImageDelete
 }
 
 model JobQueue {

--- a/src/shared/utils/prisma/enums.ts
+++ b/src/shared/utils/prisma/enums.ts
@@ -732,6 +732,7 @@ export const JobQueueType = {
   UpdateSearchIndex: 'UpdateSearchIndex',
   CleanIfEmpty: 'CleanIfEmpty',
   ModerationRequest: 'ModerationRequest',
+  BlockedImageDelete: 'BlockedImageDelete',
 } as const;
 
 export type JobQueueType = (typeof JobQueueType)[keyof typeof JobQueueType];

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -150,7 +150,7 @@ export type PurchasableRewardUsage = "SingleUse" | "MultiUse";
 
 export type EntityType = "Image" | "Post" | "Article" | "Bounty" | "BountyEntry" | "ModelVersion" | "Model" | "Collection" | "Comment" | "CommentV2" | "User" | "UserProfile" | "ResourceReview" | "ChatMessage";
 
-export type JobQueueType = "CleanUp" | "UpdateMetrics" | "UpdateNsfwLevel" | "UpdateSearchIndex" | "CleanIfEmpty" | "ModerationRequest";
+export type JobQueueType = "CleanUp" | "UpdateMetrics" | "UpdateNsfwLevel" | "UpdateSearchIndex" | "CleanIfEmpty" | "ModerationRequest" | "BlockedImageDelete";
 
 export type VaultItemStatus = "Pending" | "Stored" | "Failed";
 
@@ -615,6 +615,7 @@ export interface Model {
   threads?: Thread[];
   resourceReviews?: ResourceReview[];
   metricsDaily?: ModelMetricDaily[];
+  baseModelMetrics?: ModelBaseModelMetric[];
   associatedFrom?: ModelAssociations[];
   associations?: ModelAssociations[];
   collectionItems?: CollectionItem[];
@@ -835,6 +836,22 @@ export interface ModelVersionMetric {
   thumbsUpCount: number;
   thumbsDownCount: number;
   earnedAmount: number;
+  updatedAt: Date;
+}
+
+export interface ModelBaseModelMetric {
+  model?: Model;
+  modelId: number;
+  baseModel: string;
+  thumbsUpCount: number;
+  downloadCount: number;
+  imageCount: number;
+  status: ModelStatus;
+  availability: Availability;
+  nsfwLevel: number;
+  mode: ModelModifier | null;
+  poi: boolean;
+  minor: boolean;
   updatedAt: Date;
 }
 


### PR DESCRIPTION
## Summary

This PR applies the same JobQueue pattern from #1948 to the `removeBlockedImages` job, which was timing out due to full table scans on the 102M row Image table (no index exists for `ingestion = 'Blocked'`).

- Adds `BlockedImageDelete` to `JobQueueType` enum
- Creates a trigger that queues images when `ingestion` changes to `Blocked`
- Updates the job to pull from `JobQueue` instead of scanning the Image table
- Backfills existing blocked images past the 7-day retention period

**⚠️ Note: The migration has not been run yet and will need to be executed before merging.**

## Test plan

- [ ] Run migration in staging/prod
- [ ] Verify trigger queues new blocked images
- [ ] Verify job processes queue correctly and deletes images past retention
- [ ] Monitor job execution time to confirm timeout is resolved

🤖 Generated with [Claude Code](https://claude.ai/code)