### PR TITLE
Fix Redis Cluster failover handling with proactive topology refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ local/
 nul
 
 scripts/local-dev/
+.direnv

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -28,6 +28,8 @@ export const serverSchema = z.object({
   DATABASE_WRITE_TIMEOUT: z.coerce.number().optional(),
   REDIS_URL: z.url(),
   REDIS_CLUSTER: z.preprocess((x) => x === 'true', z.boolean().default(false)),
+  REDIS_CLUSTER_NODES: z.string().optional(), // Comma-separated list of cluster node URLs for redundant discovery
+  REDIS_CLUSTER_REFRESH_INTERVAL: z.coerce.number().default(30000), // Topology refresh interval in ms (default 30s)
   REDIS_SYS_URL: z.url(),
   REDIS_TIMEOUT: z.preprocess((x) => (x ? parseInt(String(x)) : 5000), z.number().optional()),
   NODE_ENV: z.enum(['development', 'test', 'production']),

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -6,6 +6,7 @@ export enum FLIPT_FEATURE_FLAGS {
   FEED_IMAGE_EXISTENCE = 'feed-image-existence',
   ENTITY_METRIC_NO_CACHE_BUST = 'entity-metric-no-cache-bust',
   FEED_POST_FILTER = 'feed-fetch-filter-in-post',
+  REDIS_CLUSTER_ENHANCED_FAILOVER = 'redis-cluster-enhanced-failover',
 }
 
 class FliptSingleton {

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -7,6 +7,7 @@ import { isProd } from '~/env/other';
 import { env } from '~/env/server';
 import { createLogger } from '~/utils/logging';
 import { slugit } from '~/utils/string-helpers';
+import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 
 export type RedisKeyStringsCache = Values<typeof REDIS_KEYS>;
 export type RedisKeyStringsSys = Values<typeof REDIS_SYS_KEYS>;
@@ -180,6 +181,51 @@ declare global {
 
 const log = createLogger('redis', 'green');
 
+// Track topology refresh intervals for cleanup
+const clusterRefreshIntervals = new Map<string, NodeJS.Timeout>();
+
+/**
+ * Trigger topology rediscovery on a cluster client.
+ * Uses internal _slots.rediscover() method - this is undocumented but stable.
+ * See: https://github.com/redis/node-redis/issues/2806
+ */
+function triggerTopologyRediscovery(client: any, reason: string) {
+  try {
+    if (client._slots?.rediscover) {
+      log(`Triggering topology rediscovery: ${reason}`);
+      client._slots.rediscover().catch((err: Error) => {
+        log(`Topology rediscovery failed: ${err.message}`);
+      });
+    }
+  } catch (err) {
+    // Silently ignore if rediscover is not available
+  }
+}
+
+/**
+ * Parse cluster node URLs from environment variable.
+ * Falls back to single URL if REDIS_CLUSTER_NODES is not set.
+ */
+function parseClusterNodes(fallbackUrl: string): { url: string }[] {
+  if (env.REDIS_CLUSTER_NODES) {
+    const nodes = env.REDIS_CLUSTER_NODES.split(',')
+      .map((nodeUrl) => nodeUrl.trim())
+      .filter(Boolean)
+      .map((nodeUrl) => {
+        const url = new URL(nodeUrl);
+        return { url: `${url.protocol}//${url.host}` };
+      });
+
+    if (nodes.length > 0) {
+      log(`Using ${nodes.length} cluster root nodes from REDIS_CLUSTER_NODES`);
+      return nodes;
+    }
+  }
+
+  log('Using single cluster root node from REDIS_URL');
+  return [{ url: fallbackUrl }];
+}
+
 function getBaseClient(type: 'cache' | 'system') {
   log(`Creating Redis client (${type})`);
 
@@ -209,14 +255,16 @@ function getBaseClient(type: 'cache' | 'system') {
 
   const baseClient = isCluster
     ? createCluster({
-        rootNodes: [
-          {
-            url: connectionUrl,
-            socket: socketConfig,
-            pingInterval,
-          },
-        ],
-        defaults: authConfig,
+        // Use multiple root nodes for redundant topology discovery
+        rootNodes: parseClusterNodes(connectionUrl),
+        defaults: {
+          ...authConfig,
+          socket: socketConfig,
+          pingInterval,
+        },
+        // Increase max redirections for stability during failover
+        // Default is 16, we increase to handle longer failover scenarios
+        maxCommandRedirections: 32,
       })
     : createClient({
         url: connectionUrl,
@@ -225,10 +273,118 @@ function getBaseClient(type: 'cache' | 'system') {
         pingInterval,
       });
 
+  // Common event handlers
   baseClient.on('error', (err: Error) => log(`Redis Error`, err));
   baseClient.on('connect', () => log('Redis connected'));
   baseClient.on('reconnecting', () => log('Redis reconnecting'));
   baseClient.on('ready', () => log('Redis ready!'));
+
+  // Cluster-specific event handlers for failover detection
+  // Enhanced failover handling is gated behind FLIPT_FEATURE_FLAGS.REDIS_CLUSTER_ENHANCED_FAILOVER
+  // The flag uses the "is-next" segment (hostname == next.civitai.com) to enable by default on next
+  if (isCluster) {
+    // Extract hostname for Flipt context (used for segment matching)
+    const getFliptHostname = (): string => {
+      try {
+        // NEXTAUTH_URL contains the full URL like https://next.civitai.com
+        const nextAuthUrl = env.NEXTAUTH_URL;
+        if (nextAuthUrl) {
+          return new URL(nextAuthUrl).hostname;
+        }
+      } catch {
+        // Ignore URL parsing errors
+      }
+      return 'unknown';
+    };
+    const fliptHostname = getFliptHostname();
+    const fliptContext = { hostname: fliptHostname };
+    log(`Flipt context for enhanced failover flag: hostname=${fliptHostname}`);
+
+    // Helper to check feature flag before triggering rediscovery
+    const maybeRediscover = async (reason: string) => {
+      const isEnhancedFailoverEnabled = await isFlipt(
+        FLIPT_FEATURE_FLAGS.REDIS_CLUSTER_ENHANCED_FAILOVER,
+        'redis-cluster', // entityId
+        fliptContext // context for segment matching
+      );
+      if (isEnhancedFailoverEnabled) {
+        triggerTopologyRediscovery(baseClient, reason);
+      }
+    };
+
+    // Triggered when a specific node encounters an error
+    baseClient.on('node-error', (err: Error, node: any) => {
+      const nodeAddr = node?.address || node?.url || 'unknown';
+      log(`Redis node error [${nodeAddr}]: ${err.message}`);
+      // Trigger topology rediscovery when a node fails (if feature enabled)
+      maybeRediscover(`node-error on ${nodeAddr}`);
+    });
+
+    // Triggered when a node disconnects
+    // This is critical for detecting failovers where the old master goes down
+    baseClient.on('node-disconnect', (node: any) => {
+      const nodeAddr = node?.address || node?.url || 'unknown';
+      log(`Redis node disconnected: ${nodeAddr}`);
+      // Trigger topology rediscovery to find the new master (if feature enabled)
+      maybeRediscover(`node-disconnect on ${nodeAddr}`);
+    });
+
+    // Triggered when a node reconnects
+    baseClient.on('node-connect', (node: any) => {
+      const nodeAddr = node?.address || node?.url || 'unknown';
+      log(`Redis node connected: ${nodeAddr}`);
+    });
+
+    // Triggered when a node is ready
+    baseClient.on('node-ready', (node: any) => {
+      const nodeAddr = node?.address || node?.url || 'unknown';
+      log(`Redis node ready: ${nodeAddr}`);
+    });
+
+    // Set up periodic topology refresh after client is ready and feature flag is checked
+    // This ensures we don't rely solely on MOVED/ASK errors for discovery
+    // See: https://github.com/redis/node-redis/issues/2806
+    baseClient.once('ready', async () => {
+      const isEnhancedFailoverEnabled = await isFlipt(
+        FLIPT_FEATURE_FLAGS.REDIS_CLUSTER_ENHANCED_FAILOVER,
+        'redis-cluster', // entityId
+        fliptContext // context for segment matching
+      );
+
+      if (!isEnhancedFailoverEnabled) {
+        log('Enhanced cluster failover handling is DISABLED (feature flag off)');
+        return;
+      }
+
+      log('Enhanced cluster failover handling is ENABLED');
+
+      const refreshInterval = env.REDIS_CLUSTER_REFRESH_INTERVAL;
+      if (refreshInterval > 0) {
+        const intervalId = setInterval(() => {
+          triggerTopologyRediscovery(baseClient, 'periodic refresh');
+        }, refreshInterval);
+
+        // Store interval for cleanup
+        clusterRefreshIntervals.set(type, intervalId);
+
+        // Wrap close to clean up interval
+        const originalClose = baseClient.close?.bind(baseClient);
+        if (originalClose) {
+          (baseClient as any).close = async () => {
+            const interval = clusterRefreshIntervals.get(type);
+            if (interval) {
+              clearInterval(interval);
+              clusterRefreshIntervals.delete(type);
+              log(`Cleared topology refresh interval for ${type}`);
+            }
+            return originalClose();
+          };
+        }
+
+        log(`Topology refresh scheduled every ${refreshInterval}ms`);
+      }
+    });
+  }
 
   // Don't await here - let connection happen in background
   // The client will queue commands until connected


### PR DESCRIPTION
After migrating to Redis Cluster, the app would hold stale connections after a failover because node-redis only refreshes topology on MOVED/ASK errors. If the old master goes down before responding, the client never discovers the new topology.

Changes:
- Add cluster-specific event handlers (node-error, node-disconnect) that trigger topology rediscovery when nodes fail
- Add periodic topology refresh (default 30s) to catch missed failovers
- Support multiple root nodes via REDIS_CLUSTER_NODES env var for redundant discovery during startup
- Increase maxCommandRedirections from 16 to 32 for longer failovers

New environment variables:
- REDIS_CLUSTER_NODES: Comma-separated list of cluster node URLs
- REDIS_CLUSTER_REFRESH_INTERVAL: Topology refresh interval in ms (default 30000)

Addresses: https://github.com/redis/node-redis/issues/2806