### PR TITLE
Fix TypeScript type error in ImageSelectModal

### DIFF
--- a/src/components/Training/Form/ImageSelectModal.tsx
+++ b/src/components/Training/Form/ImageSelectModal.tsx
@@ -668,7 +668,8 @@ const ImageGridMedia = ({
     );
   }
 
-  const safeParsedMeta = imageMetaSchema.safeParse(img.params);
+  const safeParsedMeta =
+    type === 'generation' ? imageMetaSchema.safeParse(img.params) : null;
 
   return (
     <div
@@ -699,7 +700,7 @@ const ImageGridMedia = ({
       {type === 'generation' || !!img.meta ? (
         <div className="absolute bottom-2 right-2">
           <ImageMetaPopover
-            meta={type === 'generation' && safeParsedMeta.success ? safeParsedMeta.data : img.meta!}
+            meta={type === 'generation' && safeParsedMeta?.success ? safeParsedMeta.data : (img as UploadedImage).meta!}
             hideSoftware
           >
             <LegacyActionIcon variant="transparent" size="md">


### PR DESCRIPTION
## Summary
- Fixes TypeScript type error that was breaking CI builds
- `safeParsedMeta` was accessing `img.params` unconditionally, but `params` only exists on `GennedMedia` type
- Added type guard and proper type cast for fallback case

## Root Cause
Commit `feae76d2e` ("Safeparse meta on ImageSelectModal") introduced a type error by moving the `.safeParse()` call outside the type guard.

## Test plan
- [x] Verified `npm run typecheck` passes for ImageSelectModal.tsx
- [ ] CI build should succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)