### PR TITLE
feat: Update site meta titles and descriptions for better SEO

### DIFF
--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -50,11 +50,11 @@ export function Home() {
   return (
     <>
       <Meta
-        title="Civitai: The Home of Open-Source Generative AI"
-        description="Explore thousands of high-quality Stable Diffusion & Flux models, share your AI-generated art, and engage with a vibrant community of creators"
+        title="Civitai | Discover and Create AI Art"
+        description="Explore thousands of free Stable Diffusion & Flux models, create and share AI-generated art, and join the world's largest community of generative AI creators."
         links={[
-          { href: `${env.NEXT_PUBLIC_BASE_URL}/`, rel: 'canonical' },
-          { href: `${env.NEXT_PUBLIC_BASE_URL}/home`, rel: 'alternate' },
+          { href: `${env.NEXT_PUBLIC_BASE_URL as string}/`, rel: 'canonical' },
+          { href: `${env.NEXT_PUBLIC_BASE_URL as string}/home`, rel: 'alternate' },
         ]}
       />
 

--- a/src/pages/images/index.tsx
+++ b/src/pages/images/index.tsx
@@ -16,9 +16,9 @@ export default Page(
     return (
       <>
         <Meta
-          title="Civitai Gallery | AI-Generated Art Showcase"
-          description="See the latest art created by the generative AI art community and delve into the inspirations and prompts behind their work"
-          links={[{ href: `${env.NEXT_PUBLIC_BASE_URL}/images`, rel: 'canonical' }]}
+          title="AI Art Gallery | Civitai"
+          description="Explore millions of AI-generated images created with Stable Diffusion, Flux, and other models. Discover prompts, techniques, and inspiration."
+          links={[{ href: `${env.NEXT_PUBLIC_BASE_URL as string}/images`, rel: 'canonical' }]}
         />
         {/* <ToolBanner /> */}
         <MasonryContainer className="min-h-full">

--- a/src/pages/models/index.tsx
+++ b/src/pages/models/index.tsx
@@ -19,8 +19,8 @@ function ModelsPage() {
   return (
     <>
       <Meta
-        title="Civitai Models | Discover Free Stable Diffusion & Flux Models"
-        description="Browse from thousands of free Stable Diffusion & Flux models, spanning unique anime art styles, immersive 3D renders, stunning photorealism, and more"
+        title="AI Models | Civitai"
+        description="Browse thousands of free Stable Diffusion & Flux models, LoRAs, checkpoints, and embeddings. The largest collection of AI image generation resources."
         links={[{ href: `${env.NEXT_PUBLIC_BASE_URL as string}/models`, rel: 'canonical' }]}
       />
 

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -15,8 +15,8 @@ function PostsPage() {
   return (
     <>
       <Meta
-        title="Civitai Posts | Explore Community-Created Content with Custom AI Resources"
-        description="Discover engaging posts from our growing community on Civitai, featuring unique and creative content generated with custom Stable Diffusion & Flux AI resources crafted by talented community members."
+        title="Community Posts | Civitai"
+        description="Discover creative posts from our community featuring AI art created with Stable Diffusion, Flux, and other models. Find tutorials, showcases, and inspiration."
         links={[{ href: `${env.NEXT_PUBLIC_BASE_URL as string}/posts`, rel: 'canonical' }]}
       />
       <MasonryContainer>

--- a/src/pages/tag/[tagname].tsx
+++ b/src/pages/tag/[tagname].tsx
@@ -34,9 +34,9 @@ export default function TagPage({
   return (
     <>
       <Meta
-        title={`${tag?.name} Stable Diffusion & Flux AI Models | Civitai`}
-        description={`Browse ${tag?.name} Stable Diffusion & Flux models, checkpoints, hypernetworks, textual inversions, embeddings, Aesthetic Gradients, and LORAs`}
-        links={[{ href: `${env.NEXT_PUBLIC_BASE_URL}/tag/${tagname}`, rel: 'canonical' }]}
+        title={`${tag?.name} AI Models | Civitai`}
+        description={`Browse ${tag?.name} Stable Diffusion & Flux models, LoRAs, checkpoints, embeddings, and more for AI image generation.`}
+        links={[{ href: `${env.NEXT_PUBLIC_BASE_URL as string}/tag/${tagname}`, rel: 'canonical' }]}
         deIndex={tag?.unfeatured ?? false}
       />
       {tag && (


### PR DESCRIPTION
## Summary
- Broaden page titles for brand positioning (e.g., "AI Models | Civitai" instead of "Civitai Models | Discover Free Stable Diffusion & Flux Models")
- Keep Stable Diffusion & Flux keywords in descriptions for SEO value
- Updated pages: home, models, images, posts, and tag pages

## Changes

| Page | Old Title | New Title |
|------|-----------|-----------|
| Home | "Civitai: The Home of Open-Source Generative AI" | "Civitai \| Discover and Create AI Art" |
| Models | "Civitai Models \| Discover Free Stable Diffusion & Flux Models" | "AI Models \| Civitai" |
| Gallery | "Civitai Gallery \| AI-Generated Art Showcase" | "AI Art Gallery \| Civitai" |
| Posts | "Civitai Posts \| Explore Community-Created Content..." | "Community Posts \| Civitai" |
| Tags | "${tag} Stable Diffusion & Flux AI Models \| Civitai" | "${tag} AI Models \| Civitai" |

## SEO Strategy
**Hybrid approach**: 
- Titles → Broader brand positioning
- Descriptions → Keep SD/Flux keywords for search traffic

## Test plan
- [ ] Run `npm run dev` and verify pages load correctly
- [ ] Check browser dev tools → Elements → `<head>` to confirm meta tags
- [ ] Test with SEO preview tool (metatags.io) to verify appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)