### PR TITLE
fix(articles): Add validation for userNsfwLevel and moderator controls

### DIFF
--- a/src/server/schema/article.schema.ts
+++ b/src/server/schema/article.schema.ts
@@ -2,7 +2,7 @@ import { ArticleStatus, MetricTimeframe } from '~/shared/utils/prisma/enums';
 import * as z from 'zod';
 
 import { CacheTTL, constants } from '~/server/common/constants';
-import { ArticleSort } from '~/server/common/enums';
+import { ArticleSort, NsfwLevel } from '~/server/common/enums';
 import {
   baseQuerySchema,
   infiniteQuerySchema,
@@ -85,7 +85,7 @@ export const upsertArticleInput = z.object({
   }, 'Cannot be empty'),
   coverImage: imageSchema.nullish(),
   tags: z.array(tagSchema).nullish(),
-  userNsfwLevel: z.number().default(0),
+  userNsfwLevel: z.enum(NsfwLevel).default(NsfwLevel.PG),
   publishedAt: z.date().nullish(),
   attachments: z.array(baseFileSchema).optional(),
   lockedProperties: z.string().array().optional(),

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -798,6 +798,15 @@ export const upsertArticle = async ({
     const isOwner = article.userId === userId || isModerator;
     if (!isOwner) throw throwAuthorizationError('You cannot perform this action');
 
+    // Validate userNsfwLevel cannot be set below system rating (non-moderators only)
+    if (data.userNsfwLevel < article.nsfwLevel && !isModerator) {
+      throw throwBadRequestError(
+        `NSFW level cannot be set below the system rating (${
+          NsfwLevel[article.nsfwLevel]
+        }). You can only set it equal to or higher than the current level.`
+      );
+    }
+
     // Prevent owners from re-publishing articles unpublished for ToS violations
     if (
       article.status === ArticleStatus.UnpublishedViolation &&


### PR DESCRIPTION
## Summary
- Add server-side validation to prevent users from setting `userNsfwLevel` below the system-determined rating
- Update schema to use `NsfwLevel` enum instead of arbitrary number for type safety
- Add `lockedProperties` UI control for moderators in ArticleUpsertForm

## Changes

### Server-side validation (`article.service.ts`)
Users can no longer set `userNsfwLevel` below the system rating. For example, if the system rates an article as R (based on cover image), users can only set it to R, X, or XXX - not PG or PG13. Moderators bypass this restriction.

### Schema improvements (`article.schema.ts`)
Changed `userNsfwLevel` from `z.number().default(0)` to `z.enum(NsfwLevel).default(NsfwLevel.PG)` for proper type validation.

### Moderator controls (`ArticleUpsertForm.tsx`)
Added a "Locked properties" multi-select for moderators (similar to ModelUpsertForm) to lock `nsfw` and `userNsfwLevel` fields.

## Test plan
- [ ] Create an article with an R-rated cover image
- [ ] Try to set userNsfwLevel to PG - should get error
- [ ] Try to set userNsfwLevel to X - should succeed
- [ ] As moderator, verify lockedProperties control appears
- [ ] As moderator, lock userNsfwLevel and verify non-mod can't change it

🤖 Generated with [Claude Code](https://claude.com/claude-code)