### PR TITLE
test: verify pr-preview pipeline HTTP code fix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 // Test PR preview pipeline verify fix - 20260128053829
+// Debug run 20260128060453


### PR DESCRIPTION
Testing the fix for the HTTP 000000 bug in pr-verify task. The bug was caused by concatenating curl's '000' output with the `|| echo "000"` fallback when connection fails.

This PR can be closed after verification.