### PR TITLE
fix: preserve original publishedAt date when republishing model versions

### DIFF
--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1860,6 +1860,7 @@ export const publishModelById = async ({
             modelVersionIds: versionIds,
             publishedAt: !republishing ? publishedAt : undefined,
             tx,
+            republishing,
           });
         } else if (status === ModelStatus.Scheduled) {
           // Schedule model versions:
@@ -1873,7 +1874,7 @@ export const publishModelById = async ({
           UPDATE "Post"
           SET "publishedAt" = CASE
                                 WHEN "metadata" ->> 'prevPublishedAt' IS NOT NULL
-                                  THEN to_timestamp("metadata" ->> 'prevPublishedAt', 'YYYY-MM-DD"T"HH24:MI:SS.MS')
+                                  THEN ("metadata" ->> 'prevPublishedAt')::timestamptz
                                 ELSE ${publishedAt}
             END,
               "metadata"    = "metadata" - 'unpublishedAt' - 'unpublishedBy' - 'prevPublishedAt'


### PR DESCRIPTION
## Summary
- Fixes bug where republishing a model version would reset the `Post.publishedAt` date to the current time instead of preserving the original date
- This caused republished content to appear at the top of feeds as if it were new content

## Root Cause
When a model version is unpublished, the system correctly stores `prevPublishedAt` in metadata. However, on republish:
1. The `process-scheduled-publishing` job directly set `Post.publishedAt = mv.publishedAt` without checking for `prevPublishedAt`
2. `publishModelVersionsWithEarlyAccess` always set `publishedAt` even when republishing
3. Timestamp parsing used a specific format that could fail with timezone offsets

## Changes
- **process-scheduled-publishing.ts**: Added CASE statement to restore from `prevPublishedAt` if present, and clean up metadata
- **model-version.service.ts**: Added `republishing` parameter to `publishModelVersionsWithEarlyAccess` to conditionally skip setting `publishedAt`
- **model.service.ts**: Pass `republishing` flag to early access function
- **All files**: Changed `to_timestamp(..., 'YYYY-MM-DD"T"HH24:MI:SS.MS')` to `::timestamptz` for robust timestamp parsing

## Test plan
- [ ] Publish a model version, note the publishedAt date
- [ ] Unpublish the model version
- [ ] Republish the model version
- [ ] Verify Post.publishedAt matches the original date, not the republish date
- [ ] Test scheduled republish scenario (unpublish, schedule future republish, wait for job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)