### PR TITLE
Replace maxEntityTip with maxTipAmount for entity tipping

### DIFF
--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -126,7 +126,7 @@ export function InteractiveTipBuzzButton({
     setBuzzCounter((prevCounter) => {
       const [, step] = steps.find(([min]) => prevCounter >= min) ?? [0, 10];
       return Math.min(
-        buzzConstants.maxEntityTip,
+        buzzConstants.maxTipAmount,
         Math.min(currencyBalance ?? 0, prevCounter + step)
       );
     });
@@ -226,7 +226,7 @@ export function InteractiveTipBuzzButton({
   const processEnteredNumber = (value: string) => {
     let amount = Number(value);
     if (isNaN(amount) || amount < 1) amount = 1;
-    else if (amount > buzzConstants.maxEntityTip) amount = buzzConstants.maxEntityTip;
+    else if (amount > buzzConstants.maxTipAmount) amount = buzzConstants.maxTipAmount;
     else if (currencyBalance && amount > currencyBalance) amount = currencyBalance ?? 0;
     setBuzzCounter(amount);
 
@@ -287,7 +287,7 @@ export function InteractiveTipBuzzButton({
 
     if (startTimerTimeoutRef.current !== null) {
       // Was click
-      setBuzzCounter((x) => Math.min(buzzConstants.maxEntityTip, x + CLICK_AMOUNT));
+      setBuzzCounter((x) => Math.min(buzzConstants.maxTipAmount, x + CLICK_AMOUNT));
       clearTimeout(startTimerTimeoutRef.current);
       startTimerTimeoutRef.current = null;
 

--- a/src/server/schema/buzz.schema.ts
+++ b/src/server/schema/buzz.schema.ts
@@ -133,7 +133,7 @@ export const userBuzzTransactionInputSchema = buzzTransactionSchema
     if (
       ctx.value.entityType &&
       ['Image', 'Model', 'Article'].includes(ctx.value.entityType) &&
-      ctx.value.amount > buzzConstants.maxEntityTip
+      ctx.value.amount > buzzConstants.maxTipAmount
     ) {
       ctx.issues.push({
         code: 'custom',


### PR DESCRIPTION
## Summary
- Replaced `buzzConstants.maxEntityTip` (2,000) with `buzzConstants.maxTipAmount` (100,000,000) in server-side validation and client-side tip caps
- Users can now tip more than 2,000 buzz on Images, Models, and Articles
- The `maxEntityTip` constant is preserved in both constant files for easy rollback

## Changed files
- `src/server/schema/buzz.schema.ts` — server validation cap
- `src/components/Buzz/InteractiveTipBuzzButton.tsx` — hold-to-tip, manual entry, and click increment caps

## Test plan
- [x] Verify tipping more than 2,000 buzz on an Image works
- [x] Verify tipping more than 2,000 buzz on a Model works
- [x] Verify tipping more than 2,000 buzz on an Article works
- [x] Verify the SendTipModal still works correctly (already uses `maxTipAmount`)
- [x] Verify hold-to-tip, manual number entry, and click increment all respect the new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)