### PR TITLE
fix: prevent session refresh signal loop causing 57x spike in DELETE requests

### DIFF
--- a/src/server/auth/next-auth-options.ts
+++ b/src/server/auth/next-auth-options.ts
@@ -192,7 +192,8 @@ export function createAuthOptions(req?: AuthedRequest): NextAuthOptions {
         if (trigger === 'update') {
           // Clear cache first, then fetch fresh user data to avoid getting stale cached data
           // Also mark all user's tokens for refresh in case they have multiple sessions
-          await refreshSession(Number(token.sub));
+          // Don't send signal here - this IS the response to a signal, sending another would create a loop
+          await refreshSession(Number(token.sub), { sendSignal: false });
           // Now fetch fresh user data (cache is cleared, so this will hit the database)
           const freshUser = await getSessionUser({ userId: Number(token.sub) });
           if (freshUser) {

--- a/src/server/auth/session-invalidation.ts
+++ b/src/server/auth/session-invalidation.ts
@@ -40,9 +40,11 @@ async function sendSessionSignal(userId: number, type: 'refresh' | 'invalid') {
   }
 }
 
-export async function refreshSession(userId: number) {
+export async function refreshSession(userId: number, { sendSignal = true } = {}) {
   const userTokens = await updateSessionState(userId, 'refresh');
-  await sendSessionSignal(userId, 'refresh');
+  if (sendSignal) {
+    await sendSessionSignal(userId, 'refresh');
+  }
 
   log(`Refreshed session for user ${userId} - ${userTokens.length} token(s) marked for refresh`);
 }


### PR DESCRIPTION
## Summary

Fixes an infinite loop introduced in 8ea8cd4e9 that caused orchestrator DELETE requests to spike from ~7 rps to ~400 rps.

**The loop:**
```
refreshSession(userId)
├── clearSessionCache() → invalidateCivitaiUser()        ← DELETE #1
└── sendSessionSignal(userId) → signal to connected clients
    └── Client receives signal
        └── calls update() → jwt callback with trigger='update'
            └── refreshSession(userId)                   ← LOOP
```

**Impact:**
- 57x increase in DELETE `/v2/consumer/civitai/{userId}` requests
- Orchestration proxy connection pool exhaustion
- Intermittent 500 errors

## Changes

- Add optional `sendSignal` parameter to `refreshSession()` (defaults to `true`)
- Pass `{ sendSignal: false }` when called from jwt callback since that's already responding to a client-initiated refresh

## Test plan

- [ ] Verify session refresh still works (admin actions, subscription changes, etc.)
- [ ] Verify DELETE request rate returns to normal (~7 rps)
- [ ] Verify no infinite loops in browser network tab when session is refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)