### PR TITLE
Filter challenges by user browsing level

### DIFF
--- a/src/components/Cards/ChallengeCard.tsx
+++ b/src/components/Cards/ChallengeCard.tsx
@@ -86,6 +86,7 @@ export function ChallengeCard({ data }: Props) {
     endsAt,
     status,
     source,
+    nsfwLevel,
     prizePool,
     entryCount,
     commentCount,
@@ -101,7 +102,7 @@ export function ChallengeCard({ data }: Props) {
         type: coverImage.type,
         width: coverImage.width ?? 512,
         height: coverImage.height ?? 512,
-        nsfwLevel: coverImage.nsfwLevel,
+        nsfwLevel, // Use challenge content level instead of image's own level
         hash: coverImage.hash,
         metadata: null,
       }

--- a/src/components/Challenge/ChallengeSubmitModal.tsx
+++ b/src/components/Challenge/ChallengeSubmitModal.tsx
@@ -52,6 +52,7 @@ import { WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import {
   parseBitwiseBrowsingLevel,
   browsingLevelLabels,
+  nsfwLevelColors,
   orchestratorNsfwLevelMap,
 } from '~/shared/constants/browsingLevel.constants';
 import { IMAGE_MIME_TYPE, VIDEO_MIME_TYPE } from '~/shared/constants/mime-types';
@@ -122,16 +123,6 @@ const useGeneratorStore = create<GeneratorStoreState>()(
 );
 
 // ---------------------------------------------------------------------------
-// Color mapping for NSFW levels
-// ---------------------------------------------------------------------------
-const nsfwLevelColors: Record<number, string> = {
-  [NsfwLevel.PG]: 'green',
-  [NsfwLevel.PG13]: 'yellow',
-  [NsfwLevel.R]: 'orange',
-  [NsfwLevel.X]: 'red',
-  [NsfwLevel.XXX]: 'grape',
-};
-
 // ---------------------------------------------------------------------------
 // Main Modal
 // ---------------------------------------------------------------------------

--- a/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
+++ b/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
@@ -58,10 +58,10 @@ export function ChallengeFiltersDropdown() {
   };
 
   // Count active filters (excluding defaults)
-  const isDefault =
+  const hasStatusDefault =
     statusFilter.length === defaultStatus.length &&
     defaultStatus.every((s) => statusFilter.includes(s));
-  const filterLength = isDefault ? 0 : 1;
+  const filterLength = hasStatusDefault ? 0 : 1;
 
   const target = (
     <Indicator

--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -633,6 +633,17 @@ function filterPreferences<
     case 'tools':
       // No need to apply hidden preferences to tools
       return { items: value, hidden };
+    case 'challenges':
+      const challenges = value.filter((challenge) => {
+        const isOwner = challenge.createdBy.id === currentUser?.id;
+        if ((isOwner || isModerator) && challenge.nsfwLevel === 0) return true;
+        if (!Flags.intersects(challenge.nsfwLevel, browsingLevel)) {
+          hidden.browsingLevel++;
+          return false;
+        }
+        return true;
+      });
+      return { items: challenges, hidden };
     default:
       throw new Error('unhandled hidden user preferences filter type');
   }
@@ -757,6 +768,12 @@ type BaseTool = {
   id: number;
 };
 
+type BaseChallenge = {
+  id: number;
+  nsfwLevel: number;
+  createdBy: { id: number };
+};
+
 export type BaseDataTypeMap = {
   images: BaseImage[];
   models: BaseModel[];
@@ -767,4 +784,5 @@ export type BaseDataTypeMap = {
   posts: BasePost[];
   tags: BaseTag[];
   tools: BaseTool[];
+  challenges: BaseChallenge[];
 };

--- a/src/components/UserAvatar/UserAvatarSimple.tsx
+++ b/src/components/UserAvatar/UserAvatarSimple.tsx
@@ -58,7 +58,7 @@ export function UserAvatarSimple({
   return (
     <UnstyledButton
       onClick={() => router.push(username ? `/user/${username}` : `/user?id=${id}`)}
-      className="flex items-center gap-2"
+      className="flex w-fit items-center gap-2"
     >
       {displayProfilePicture && (
         <div className="relative ">

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -75,6 +75,11 @@ import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { showSuccessNotification, showErrorNotification } from '~/utils/notifications';
 import { ChallengeSubmitModal } from '~/components/Challenge/ChallengeSubmitModal';
+import {
+  parseBitwiseBrowsingLevel,
+  browsingLevelLabels,
+  nsfwLevelColors,
+} from '~/shared/constants/browsingLevel.constants';
 import ImagesInfinite from '~/components/Image/Infinite/ImagesInfinite';
 import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
@@ -352,6 +357,23 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
                   >
                     {challenge.theme}
                   </IconBadge>
+                </>
+              )}
+
+              {/* Allowed content ratings */}
+              {challenge.allowedNsfwLevel > 0 && (
+                <>
+                  <Divider orientation="vertical" />
+                  <Group gap={4}>
+                    <Text size="xs" c="dimmed">
+                      Allowed Ratings:
+                    </Text>
+                    {parseBitwiseBrowsingLevel(challenge.allowedNsfwLevel).map((level) => (
+                      <Badge key={level} size="sm" color={nsfwLevelColors[level]} variant="filled">
+                        {browsingLevelLabels[level as keyof typeof browsingLevelLabels]}
+                      </Badge>
+                    ))}
+                  </Group>
                 </>
               )}
             </Group>

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -3,7 +3,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import { ChallengeSource, ChallengeStatus, CollectionMode } from '~/shared/utils/prisma/enums';
-import type { Prize } from './daily-challenge.utils';
+import { deriveChallengeNsfwLevel, type Prize } from './daily-challenge.utils';
 
 // =============================================================================
 // Challenge Table Helpers (New System)
@@ -297,7 +297,7 @@ export async function createChallengeRecord(input: CreateChallengeInput): Promis
       theme: input.theme,
       invitation: input.invitation,
       coverImageId: input.coverImageId,
-      nsfwLevel: input.nsfwLevel ?? 1,
+      nsfwLevel: input.nsfwLevel ?? deriveChallengeNsfwLevel(input.allowedNsfwLevel ?? 1),
       allowedNsfwLevel: input.allowedNsfwLevel ?? 1,
       modelVersionIds: input.modelVersionIds ?? [],
       judgingPrompt: input.judgingPrompt,

--- a/src/server/games/daily-challenge/daily-challenge.utils.ts
+++ b/src/server/games/daily-challenge/daily-challenge.utils.ts
@@ -1,6 +1,8 @@
 import { mergeWith } from 'lodash-es';
 import * as z from 'zod';
 import { dbRead } from '~/server/db/client';
+import { NsfwLevel } from '~/server/common/enums';
+import { Flags } from '~/shared/utils/flags';
 
 import { getDbWithoutLag } from '~/server/db/db-lag-helpers';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
@@ -322,6 +324,15 @@ export async function getChallengeTypeConfig(type: string | undefined) {
       winner: result.promptWinner,
     },
   } as ChallengeType;
+}
+
+/**
+ * Derive a challenge's nsfwLevel from its allowedNsfwLevel bitwise flags.
+ * Returns the highest allowed NsfwLevel (most mature content permitted).
+ * Example: allowedNsfwLevel = 7 (PG|PG13|R) → nsfwLevel = 4 (R)
+ */
+export function deriveChallengeNsfwLevel(allowedNsfwLevel: number): number {
+  return Flags.maxValue(allowedNsfwLevel) || NsfwLevel.PG;
 }
 
 export type Prize = {

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -20,6 +20,7 @@ import type {
 } from '~/server/games/daily-challenge/daily-challenge.utils';
 import {
   challengeToLegacyFormat,
+  deriveChallengeNsfwLevel,
   endChallenge,
   getActiveChallenges,
   getChallengeConfig,
@@ -304,7 +305,7 @@ async function createChallengeFromSelection(
     theme: challengeContent.theme,
     invitation: challengeContent.invitation,
     coverImageId,
-    nsfwLevel: 1,
+    nsfwLevel: deriveChallengeNsfwLevel(sfwBrowsingLevelsFlag),
     allowedNsfwLevel: sfwBrowsingLevelsFlag,
     modelVersionIds,
     collectionId: collection.id,

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -45,6 +45,8 @@ export type ChallengeListItem = {
   endsAt: Date;
   status: ChallengeStatus;
   source: ChallengeSource;
+  nsfwLevel: number;
+  allowedNsfwLevel: number;
   prizePool: number;
   entryCount: number;
   commentCount: number;
@@ -191,6 +193,7 @@ export const getInfiniteChallengesSchema = z.object({
   modelVersionId: z.number().optional(),
   includeEnded: z.boolean().default(false),
   excludeEventChallenges: z.boolean().default(false),
+  browsingLevel: z.number().optional(),
   limit: z.coerce.number().min(1).max(100).default(20),
 });
 

--- a/src/shared/constants/browsingLevel.constants.ts
+++ b/src/shared/constants/browsingLevel.constants.ts
@@ -141,6 +141,14 @@ export const getNsfwLevelDeprecatedReverseMapping = (level: number) => {
   return nsfwLevelReverseMapDeprecated[level as NsfwLevel] ?? NsfwLevelDeprecated.None;
 };
 
+export const nsfwLevelColors: Record<number, string> = {
+  [NsfwLevel.PG]: 'green',
+  [NsfwLevel.PG13]: 'yellow',
+  [NsfwLevel.R]: 'orange',
+  [NsfwLevel.X]: 'red',
+  [NsfwLevel.XXX]: 'grape',
+};
+
 export const votableTagColors = {
   [0]: { dark: { color: 'gray', shade: 5 }, light: { color: 'gray', shade: 3 } },
   [NsfwLevel.PG]: { dark: { color: 'gray', shade: 5 }, light: { color: 'gray', shade: 3 } },


### PR DESCRIPTION
## Summary
- Apply system-wide browsing level preferences to challenge feeds automatically (matching article filtering pattern)
- Add `challenges` case to `useApplyHiddenPreferences` for client-side NSFW filtering
- Inject `browsingLevel` into `useQueryChallenges` hook and apply hidden preferences on results
- Filter featured event challenges client-side via `useApplyHiddenPreferences`
- Remove redundant manual "Content Rating" filter dropdown (browsing level is now automatic)
- Simplify `deriveChallengeNsfwLevel` to use `Flags.maxValue`

## Test plan
- [x] Set browsing level to PG only → visit `/challenges` → R/X-rated challenges should be hidden
- [x] Set browsing level to all → visit `/challenges` → all challenges visible
- [x] Verify featured event challenge cards are also filtered by browsing level
- [x] Verify filter dropdown only shows "Status" section, no "Content Rating" section
- [x] Run `pnpm run typecheck` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)