### PR TITLE
feat: Add audit trail for auto-mute scam actions

### DIFF
--- a/src/server/services/moderator.service.ts
+++ b/src/server/services/moderator.service.ts
@@ -39,7 +39,7 @@ type ImpersonateModActivity = {
 
 type UserModActivity = {
   entityType: 'user';
-  activity: 'setRewardsEligibility' | 'removeContent';
+  activity: 'setRewardsEligibility' | 'removeContent' | 'autoMuteScam';
 };
 
 type ModActivity = {


### PR DESCRIPTION
## Summary
- Track auto-mute actions in **ModActivity** (Postgres) with `entityType: 'user'`, `activity: 'autoMuteScam'` — queryable for monitoring false positives
- Track in **ClickHouse userActivities** with `type: 'Muted'` and detailed `source` field (account age, matched tags, deleted message count)
- New `'autoMuteScam'` activity added to `UserModActivity` type

## How to query
```sql
-- Postgres: Find all auto-muted users
SELECT * FROM "ModActivity"
WHERE activity = 'autoMuteScam'
ORDER BY "createdAt" DESC;
```

## Files Changed
| File | Change |
|------|--------|
| `src/server/services/moderator.service.ts` | Added `autoMuteScam` to `UserModActivity` activity union |
| `src/server/jobs/entity-moderation.ts` | Added `trackModActivity` + `tracker.userActivity` calls after auto-mute |

Follow-up to #2032. Requested by @chipshajen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)