### PR TITLE
fix: pass backend field through upload hook for B2 registration

### DIFF
--- a/src/hooks/useS3Upload.tsx
+++ b/src/hooks/useS3Upload.tsx
@@ -36,6 +36,7 @@ type UploadResult = {
   key: string;
   name?: string;
   size?: number;
+  backend?: string;
 };
 
 type RequestOptions = {
@@ -144,7 +145,7 @@ export const useS3Upload: UseS3Upload = (options = {}) => {
       console.error(data.error);
       throw data.error;
     } else {
-      const { bucket, key, uploadId, urls } = data;
+      const { bucket, key, uploadId, urls, backend } = data;
 
       let currentXhr: XMLHttpRequest;
       const abort = () => {
@@ -270,7 +271,7 @@ export const useS3Upload: UseS3Upload = (options = {}) => {
         if (uploadStatus !== 'success') {
           updateFile({ status: uploadStatus, file: undefined });
           await abortUpload();
-          return { url: null, bucket, key };
+          return { url: null, bucket, key, backend };
         }
       }
 
@@ -280,13 +281,13 @@ export const useS3Upload: UseS3Upload = (options = {}) => {
       if (!resp.ok) {
         updateFile({ status: 'error', file: undefined });
         await abortUpload();
-        return { url: null, bucket, key };
+        return { url: null, bucket, key, backend };
       }
 
       updateFile({ status: 'success' });
 
       const url = urls[0].url.split('?')[0];
-      return { url, bucket, key, name: file.name, size: file.size };
+      return { url, bucket, key, name: file.name, size: file.size, backend };
     }
   };
 


### PR DESCRIPTION
## Summary
- The upload API returns a `backend` field indicating which storage backend was used (default or b2)
- `useS3Upload` hook was not extracting or returning this field
- This caused `FilesProvider` to never send `backend`/`s3Path` to `createFile`, breaking storage-resolver registration for B2 uploads

## Changes
- Add `backend` to `UploadResult` type
- Extract `backend` from API response in `useS3Upload`
- Return `backend` in all upload result paths

## Test plan
- [ ] Upload a model file with B2 Flipt flag enabled
- [ ] Verify file is registered in storage-resolver
- [ ] Verify download URL works

🤖 Generated with [Claude Code](https://claude.com/claude-code)