### PR TITLE
feat: Add scam warning alert to chat DMs

### DIFF
--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -75,6 +75,28 @@ type TypingStatus = {
 
 const PStack = createPolymorphicComponent<'div', StackProps>(Stack);
 
+function ScamWarningContent({ chatId }: { chatId: number }) {
+  return (
+    <Text size="xs">
+      Beware of scam messages. Civitai staff will only message you from{' '}
+      <Text span c="red" fw={700}>
+        red-nameplate
+      </Text>{' '}
+      accounts and have a Civitai moderator badge next to their name (not the profile picture!). Do
+      not click unknown links or share payment info.{' '}
+      <Anchor
+        component="button"
+        type="button"
+        size="xs"
+        onClick={() => openReportModal({ entityType: ReportEntity.Chat, entityId: chatId })}
+      >
+        Report suspicious DMs
+      </Anchor>{' '}
+      immediately.
+    </Text>
+  );
+}
+
 export function ExistingChat() {
   const currentUser = useCurrentUser();
   const { worker } = useSignalContext();
@@ -417,26 +439,7 @@ export function ExistingChat() {
             p="xs"
             m="xs"
           >
-            <Text size="xs">
-              Beware of scam messages. Civitai staff will only message you from{' '}
-              <Text span c="red" fw={700}>
-                red-nameplate
-              </Text>{' '}
-              accounts and have a Civitai moderator badge next to their name (not the profile
-              picture!). Do not click unknown links or share payment info.{' '}
-              <Anchor
-                component="button"
-                type="button"
-                size="xs"
-                onClick={() =>
-                  existingChatId &&
-                  openReportModal({ entityType: ReportEntity.Chat, entityId: existingChatId })
-                }
-              >
-                Report suspicious DMs
-              </Anchor>{' '}
-              immediately.
-            </Text>
+            <ScamWarningContent chatId={existingChatId!} />
           </DismissibleAlert>
           <Box p="sm" style={{ flexGrow: 1, overflowY: 'auto' }} ref={lastReadRef}>
             {isRefetching || isLoading ? (
@@ -518,26 +521,7 @@ export function ExistingChat() {
         <Center h="100%">
           <Stack>
             <Alert color="yellow" icon={<IconAlertTriangle size={20} />} p="xs" mx="sm">
-              <Text size="xs">
-                Beware of scam messages. Civitai staff will only message you from{' '}
-                <Text span c="red" fw={700}>
-                  red-nameplate
-                </Text>{' '}
-                accounts and have a Civitai moderator badge next to their name (not the profile
-                picture!). Do not click unknown links or share payment info.{' '}
-                <Anchor
-                  component="button"
-                  type="button"
-                  size="xs"
-                  onClick={() =>
-                    existingChatId &&
-                    openReportModal({ entityType: ReportEntity.Chat, entityId: existingChatId })
-                  }
-                >
-                  Report suspicious DMs
-                </Anchor>{' '}
-                immediately.
-              </Text>
+              <ScamWarningContent chatId={existingChatId!} />
             </Alert>
             {allChats.length > 0 && (
               <Text mb="md" p="sm" size="xs" italic align="center">{`"${allChats[0].content.slice(


### PR DESCRIPTION
## Summary
- Adds a yellow scam warning alert in two chat locations: a **dismissible** alert at the top of active conversations and a **non-dismissible** alert on the join/invitation view
- Warning highlights red-nameplate accounts and the Civitai moderator badge as identifiers for legitimate staff
- "Report suspicious DMs" text is clickable and opens the existing report modal

## Test plan
- [x] Open the chat window with a pending invitation — confirm the yellow alert appears above the message preview
- [x] Join a conversation — confirm the dismissible alert shows at the top
- [x] Click "Report suspicious DMs" — confirm the report modal opens correctly
- [x] Dismiss the alert — confirm it stays dismissed across page reloads (localStorage)
- [x] Check dark/light mode rendering
- [x] Check mobile layout (container < 700px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)