### PR TITLE
fix(auth): redirect PR preview sign-in to login page

### DIFF
--- a/src/utils/auth-helpers.ts
+++ b/src/utils/auth-helpers.ts
@@ -21,10 +21,7 @@ function isPrPreview(): boolean {
 function getAuthProxyUrl(): string | undefined {
   // Try env var first, then fallback to hostname detection for PR previews
   // Using ?? ensures both branches are preserved in the bundle
-  return (
-    env.NEXT_PUBLIC_AUTH_PROXY_URL ??
-    (isPrPreview() ? PR_PREVIEW_AUTH_PROXY : undefined)
-  );
+  return env.NEXT_PUBLIC_AUTH_PROXY_URL ?? (isPrPreview() ? PR_PREVIEW_AUTH_PROXY : undefined);
 }
 
 /**
@@ -48,7 +45,7 @@ export function handleSignIn(providerId: string, callbackUrl: string) {
       ? callbackUrl
       : `${window.location.origin}${callbackUrl.startsWith('/') ? callbackUrl : '/' + callbackUrl}`;
 
-    window.location.href = `${authProxyUrl}/api/auth/signin/${providerId}?callbackUrl=${encodeURIComponent(fullCallbackUrl)}`;
+    window.location.href = `${authProxyUrl}/login?returnUrl=${encodeURIComponent(fullCallbackUrl)}`;
   } else {
     // Normal flow: use NextAuth's built-in signIn
     signIn(providerId, { callbackUrl });


### PR DESCRIPTION
## Summary
- `handleSignIn` was navigating via GET to `/api/auth/signin/{provider}` on the auth proxy, but NextAuth requires a POST with CSRF token to start OAuth flows
- The GET request was rejected with `error=google`, breaking all OAuth sign-in from PR preview environments (`pr-*.civitaic.com`)
- Redirects to `/login?returnUrl=...` instead, which `LoginContent` reads correctly and initiates a proper POST-based OAuth flow

## Root cause
```
$ curl -s -D- -o /dev/null 'https://auth.civitaic.com/api/auth/signin/google?callbackUrl=...'
HTTP/2 302
location: /login?callbackUrl=...&error=google
```
NextAuth treats GET to `/api/auth/signin/{provider}` as a failed sign-in and returns `error={provider}`.

## Test plan
- [ ] On the PR preview, click "Sign in with Google" — should redirect to auth.civitaic.com/login with the PR URL as returnUrl
- [ ] Complete sign-in on auth.civitaic.com — should redirect back to the PR preview, authenticated
- [ ] Verify Discord and GitHub sign-in also work from PR preview
- [ ] Verify sign-in on civitai.com (production) is unaffected (uses `signIn()` directly, doesn't hit this code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)