### PR TITLE
fix(auth): forward reason param for PR preview switch-accounts

### DIFF
--- a/src/utils/auth-helpers.ts
+++ b/src/utils/auth-helpers.ts
@@ -45,7 +45,14 @@ export function handleSignIn(providerId: string, callbackUrl: string) {
       ? callbackUrl
       : `${window.location.origin}${callbackUrl.startsWith('/') ? callbackUrl : '/' + callbackUrl}`;
 
-    window.location.href = `${authProxyUrl}/login?returnUrl=${encodeURIComponent(fullCallbackUrl)}`;
+    const url = new URL(`${authProxyUrl}/login`);
+    url.searchParams.set('returnUrl', fullCallbackUrl);
+
+    // Forward reason param (e.g., switch-accounts) so auth proxy doesn't auto-redirect
+    const reason = new URLSearchParams(window.location.search).get('reason');
+    if (reason) url.searchParams.set('reason', reason);
+
+    window.location.href = url.toString();
   } else {
     // Normal flow: use NextAuth's built-in signIn
     signIn(providerId, { callbackUrl });


### PR DESCRIPTION
## Summary
- Fixes multi-account switching on PR preview environments (`pr-*.civitaic.com`)
- `handleSignIn()` now forwards `reason=switch-accounts` from the current URL when redirecting to the auth proxy (`auth.civitaic.com`)
- Without this, `auth.civitaic.com/login` SSR sees an existing session + no `reason` param and auto-redirects back, preventing the user from ever logging into a second account

## Root Cause
When on `pr-2008.civitaic.com/login?returnUrl=/&reason=switch-accounts`, clicking a provider button calls `handleSignIn` which redirected to `auth.civitaic.com/login?returnUrl=...` — dropping the `reason` param. Since `auth.civitaic.com` shares the session cookie (`.civitaic.com` domain), its SSR check at `login/index.tsx:29` would redirect back immediately instead of showing the login form.

## Test plan
- [ ] On a PR preview, log in with one account
- [ ] Click "Add Account" in the user menu (navigates to `/login?returnUrl=/&reason=switch-accounts`)
- [ ] Click a provider — should redirect to `auth.civitaic.com/login?returnUrl=...&reason=switch-accounts`
- [ ] Should see login form on auth.civitaic.com (not auto-redirect)
- [ ] Log in with second account — should redirect back to PR preview with new session
- [ ] Account switcher should show both accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)