### PR TITLE
fix: Fall back to delivery worker for attachment downloads

### DIFF
--- a/src/utils/delivery-worker.ts
+++ b/src/utils/delivery-worker.ts
@@ -77,7 +77,14 @@ export async function resolveDownloadUrl(
   fileName?: string
 ): Promise<DownloadInfo> {
   if (isStorageResolverEnabled()) {
-    return getDownloadUrlByFileId(fileId, fileName);
+    try {
+      return await getDownloadUrlByFileId(fileId, fileName);
+    } catch {
+      // Fall back to delivery worker when the storage resolver doesn't have
+      // this file (e.g. File table records like BountyEntry attachments that
+      // aren't synced to file_locations).
+      return getDownloadUrl(fileUrl, fileName);
+    }
   }
   return getDownloadUrl(fileUrl, fileName);
 }


### PR DESCRIPTION
## Summary
- Attachment downloads (`/api/download/attachments/[fileId]`) were broken because the storage resolver only tracks `ModelFile` records, not generic `File` table records (BountyEntry attachments, article files, etc.)
- When the storage resolver returns a 404 for an unknown file, we now fall back to the legacy delivery worker which can resolve directly from the file URL

## Test plan
- [ ] Download a BountyEntry attachment file (e.g. `/api/download/attachments/581747`)
- [ ] Verify model file downloads still work through the storage resolver
- [ ] Verify fallback doesn't trigger for files that exist in the storage resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)