### PR TITLE
fix: fallback to primary DB for user lookup in createUserReferral

### DIFF
--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1636,10 +1636,13 @@ export const createUserReferral = async ({
   loginRedirectReason?: string;
   ip?: string;
 }) => {
-  const user = await dbRead.user.findUniqueOrThrow({
+  const findArgs = {
     where: { id },
     select: { id: true, referral: { select: { id: true, userReferralCodeId: true } } },
-  });
+  } as const;
+  const user = await dbRead.user.findUniqueOrThrow(findArgs).catch(() =>
+    dbWrite.user.findUniqueOrThrow(findArgs)
+  );
 
   if (!!user.referral?.userReferralCodeId || (!!user.referral && !userReferralCode)) {
     return;


### PR DESCRIPTION
## Summary
- During sign-in on the DataPacket deployment, `createUserReferral` calls `dbRead.user.findUniqueOrThrow()` which fails with `PrismaClientKnownRequestError` when the CNPG read replica hasn't replicated the newly created user yet
- Adds a `.catch()` fallback to `dbWrite` (DO primary DB) so the query succeeds even with replication lag
- Eliminates ~20 HTTP 500s per 15 minutes observed during 1% DP traffic split

## Test plan
- [ ] Deploy to DP staging and verify sign-in flow works
- [ ] Enable 1% traffic split and confirm SIGN_IN_EVENT_ERROR count drops to 0
- [ ] Verify no regression on DOKS (dbRead path still used first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)