### PR TITLE
fix(auth): downgrade JWT_SESSION_ERROR to warn log level

### DIFF
--- a/src/server/auth/next-auth-options.ts
+++ b/src/server/auth/next-auth-options.ts
@@ -133,12 +133,31 @@ type AuthedRequest = {
   };
 };
 
+// JWT session errors that are expected and non-actionable (expired tokens, corrupt cookies)
+const jwtSessionWarnCodes = new Set(['JWT_SESSION_ERROR']);
+
 export function createAuthOptions(req?: AuthedRequest): NextAuthOptions {
   const options: NextAuthOptions = {
     adapter: CustomPrismaAdapter(dbWrite),
     session: {
       strategy: 'jwt',
       maxAge: 30 * 24 * 60 * 60, // 30 days
+    },
+    logger: {
+      error(code, metadata) {
+        const message = metadata instanceof Error ? metadata.message : (metadata as any).error?.message ?? '';
+        if (jwtSessionWarnCodes.has(code)) {
+          console.warn(`[next-auth][warn][${code}]`, message);
+        } else {
+          console.error(`[next-auth][error][${code}]`, metadata);
+        }
+      },
+      warn(code) {
+        console.warn(`[next-auth][warn][${code}]`);
+      },
+      debug(code, metadata) {
+        if (isDev) console.log(`[next-auth][debug][${code}]`, metadata);
+      },
     },
     events: {
       createUser: async ({ user }) => {


### PR DESCRIPTION
## Summary
- Adds a custom NextAuth `logger` to `createAuthOptions()` that downgrades `JWT_SESSION_ERROR` from `console.error` to `console.warn`
- These errors (~60/hr in production) are expected — they come from expired tokens and corrupt cookies during normal JWT session lifecycle
- Reduces noise in Loki error log streams, making real errors easier to spot
- All other NextAuth errors remain at `error` level

## Details

The NextAuth `logger.error(code, metadata)` callback receives `code` as a string (e.g. `"JWT_SESSION_ERROR"`) and `metadata` as `Error | { error: Error }`. We check against a Set of known benign codes and route them to `console.warn` instead.

## Test plan
- [ ] Verify build passes
- [ ] After deploy, check Loki: `{namespace="civitai-dp-prod"} |~ "JWT_SESSION_ERROR"` should show `[warn]` prefix instead of `[error]`
- [ ] Verify other NextAuth errors (e.g. adapter failures) still log at error level

🤖 Generated with [Claude Code](https://claude.com/claude-code)