### PR TITLE
fix: add dbWrite fallback for CDC-lagged findOrThrow queries

### DIFF
--- a/src/server/controllers/common.controller.ts
+++ b/src/server/controllers/common.controller.ts
@@ -15,7 +15,8 @@ import {
   hasEntityAccess,
 } from '~/server/services/common.service';
 import { throwBadRequestError, throwDbError } from '~/server/utils/errorHandling';
-import { dbRead } from '../db/client';
+import { dbRead, dbWrite } from '../db/client';
+import { dbReadFallbackCounter } from '~/server/prom/client';
 import {
   articlesSearchIndex,
   bountiesSearchIndex,
@@ -88,8 +89,10 @@ export const updateEntityAvailabilityHandler = async ({
     // Update search index:
     switch (entityType) {
       case 'ModelVersion':
-        const modelVersion = await dbRead.modelVersion.findUniqueOrThrow({
-          where: { id: entityId },
+        const findArgs = { where: { id: entityId } } as const;
+        const modelVersion = await dbRead.modelVersion.findUniqueOrThrow(findArgs).catch(() => {
+          dbReadFallbackCounter.inc({ entity: 'modelVersion', caller: 'updateEntityAvailabilityHandler' });
+          return dbWrite.modelVersion.findUniqueOrThrow(findArgs);
         });
 
         await modelsSearchIndex.queueUpdate([

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -131,6 +131,13 @@ export const userUpdateCounter = registerCounterWithLabels({
   labelNames: ['location'] as const,
 });
 
+// CDC replication lag fallback metrics
+export const dbReadFallbackCounter = registerCounterWithLabels({
+  name: 'dbread_fallback_total',
+  help: 'Number of times a dbRead query fell back to dbWrite due to CDC replication lag',
+  labelNames: ['entity', 'caller'] as const,
+});
+
 declare global {
   // eslint-disable-next-line no-var
   var pgGaugeInitialized: boolean;

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -12,6 +12,7 @@ import {
 } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { getDbWithoutLag, preventReplicationLag } from '~/server/db/db-lag-helpers';
+import { dbReadFallbackCounter } from '~/server/prom/client';
 import { logToAxiom } from '~/server/logging/client';
 import {
   dataForModelsCache,
@@ -763,7 +764,7 @@ export const publishModelVersionById = async ({
   if (publishedAt && publishedAt > new Date()) status = ModelStatus.Scheduled;
   else publishedAt = new Date();
 
-  const currentVersion = await dbRead.modelVersion.findUniqueOrThrow({
+  const versionFindArgs = {
     where: { id },
     select: {
       id: true,
@@ -781,7 +782,13 @@ export const publishModelVersionById = async ({
         },
       },
     },
-  });
+  } as const;
+  const currentVersion = await dbRead.modelVersion
+    .findUniqueOrThrow(versionFindArgs)
+    .catch(() => {
+      dbReadFallbackCounter.inc({ entity: 'modelVersion', caller: 'publishModelVersionById' });
+      return dbWrite.modelVersion.findUniqueOrThrow(versionFindArgs);
+    });
 
   // Validate NSFW + restricted base model combination
   if (
@@ -1480,7 +1487,7 @@ export const modelVersionDonationGoals = async ({
   userId?: number;
   isModerator?: boolean;
 }) => {
-  const version = await dbRead.modelVersion.findFirstOrThrow({
+  const donationFindArgs = {
     where: { id },
     select: {
       id: true,
@@ -1492,7 +1499,13 @@ export const modelVersionDonationGoals = async ({
         },
       },
     },
-  });
+  } as const;
+  const version = await dbRead.modelVersion
+    .findFirstOrThrow(donationFindArgs)
+    .catch(() => {
+      dbReadFallbackCounter.inc({ entity: 'modelVersion', caller: 'modelVersionDonationGoals' });
+      return dbWrite.modelVersion.findFirstOrThrow(donationFindArgs);
+    });
 
   const canSeeAllGoals = userId === version.model.userId || isModerator;
 

--- a/src/server/services/user-referral-code.service.ts
+++ b/src/server/services/user-referral-code.service.ts
@@ -1,5 +1,6 @@
 import randomstring from 'randomstring';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { dbReadFallbackCounter } from '~/server/prom/client';
 import { isModerator } from '~/server/routers/base.router';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 
@@ -50,7 +51,11 @@ export const upsertUserReferralCode = async ({
       },
     });
   } else {
-    const user = await dbRead.user.findUniqueOrThrow({ where: { id: userId } });
+    const findArgs = { where: { id: userId } } as const;
+    const user = await dbRead.user.findUniqueOrThrow(findArgs).catch(() => {
+      dbReadFallbackCounter.inc({ entity: 'user', caller: 'upsertUserReferralCode' });
+      return dbWrite.user.findUniqueOrThrow(findArgs);
+    });
     const generateString = (length = 3) =>
       randomstring.generate({
         length,

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -15,7 +15,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { logToAxiom } from '~/server/logging/client';
 import { searchClient } from '~/server/meilisearch/client';
-import { userUpdateCounter } from '~/server/prom/client';
+import { dbReadFallbackCounter, userUpdateCounter } from '~/server/prom/client';
 import {
   articleMetrics,
   imageMetrics,
@@ -1640,9 +1640,10 @@ export const createUserReferral = async ({
     where: { id },
     select: { id: true, referral: { select: { id: true, userReferralCodeId: true } } },
   } as const;
-  const user = await dbRead.user.findUniqueOrThrow(findArgs).catch(() =>
-    dbWrite.user.findUniqueOrThrow(findArgs)
-  );
+  const user = await dbRead.user.findUniqueOrThrow(findArgs).catch(() => {
+    dbReadFallbackCounter.inc({ entity: 'user', caller: 'createUserReferral' });
+    return dbWrite.user.findUniqueOrThrow(findArgs);
+  });
 
   if (!!user.referral?.userReferralCodeId || (!!user.referral && !userReferralCode)) {
     return;


### PR DESCRIPTION
## Summary
- Adds `.catch(() => dbWrite...)` fallback to 4 `findUniqueOrThrow`/`findFirstOrThrow` calls that fail on the DP read replica due to CDC replication lag
- Adds `civitai_app_dbread_fallback_total` Prometheus counter (labels: `entity`, `caller`) to track how often fallbacks trigger
- Retroactively adds the counter to the existing `createUserReferral` fallback from #2058

## Context
On the DP deployment, `DATABASE_REPLICA_URL` points to CNPG nvme0 replicated via Debezium/Kafka CDC (not Postgres streaming replication). Newly created/updated records may not appear on the replica for seconds, causing `findOrThrow` calls to return 500s. At 5% traffic split this is ~0.14% error rate (~7/min).

## Affected call sites
| File | Function | Entity |
|------|----------|--------|
| `user-referral-code.service.ts` | `upsertUserReferralCode` | user |
| `common.controller.ts` | `updateEntityAvailabilityHandler` | modelVersion |
| `model-version.service.ts` | `publishModelVersionById` | modelVersion |
| `model-version.service.ts` | `modelVersionDonationGoals` | modelVersion |
| `user.service.ts` | `createUserReferral` | user (counter added) |

## Monitoring
After deploy, query: `sum by (entity, caller) (rate(civitai_app_dbread_fallback_total[5m]))`

## Test plan
- [ ] Verify build passes
- [ ] After deploy to DP, check 5xx rate drops toward zero
- [ ] Verify Prometheus counter appears: `civitai_app_dbread_fallback_total`
- [ ] Monitor fallback rate to understand CDC lag patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)