### PR TITLE
feat: log Axiom errors to stdout for DP Loki visibility

### DIFF
--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -18,6 +18,8 @@ export async function logToAxiom(data: MixedObject, datastream?: string) {
     if (!datastream) return;
 
     await axiom.ingestEvents(datastream, sendData);
+    if (process.env.LOG_ERRORS_TO_STDOUT === 'true')
+      console.error(JSON.stringify({ _axiom: datastream, ...sendData }));
   } else {
     console.log('logToAxiom', sendData);
   }


### PR DESCRIPTION
## Summary
- When `LOG_ERRORS_TO_STDOUT=true`, `logToAxiom` also emits errors via `console.error` so they appear in stdout → Alloy → Loki
- Gated by env var — only activates on DataPacket where TRPC errors are otherwise invisible in cluster observability (they only go to Axiom)
- The env var is already set in the DP configmap (civitai/talos-infra@f2f6b3e)

## Test plan
- [ ] Verify no behavior change on DOKS (env var is not set there)
- [ ] After merge + canary, check Loki for TRPC errors in `namespace="civitai-dp-prod"` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)