### PR TITLE
fix: bypass storage resolver for article attachment downloads

### DIFF
--- a/src/pages/api/download/attachments/[fileId].ts
+++ b/src/pages/api/download/attachments/[fileId].ts
@@ -5,7 +5,7 @@ import * as z from 'zod';
 import { env } from '~/env/server';
 import { dbRead } from '~/server/db/client';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
-import { resolveDownloadUrl } from '~/utils/delivery-worker';
+import { getDownloadUrl } from '~/utils/delivery-worker';
 import { getLoginLink } from '~/utils/login-helpers';
 import { getFileWithPermission } from '~/server/services/file.service';
 import { Tracker } from '~/server/clickhouse/client';
@@ -106,7 +106,11 @@ export default PublicEndpoint(
     // }
 
     try {
-      const { url } = await resolveDownloadUrl(fileId, file.url, file.name);
+      // Use delivery worker directly — File table records are not synced to
+      // the storage resolver's file_locations table (which only tracks ModelFile).
+      // Using resolveDownloadUrl here would cause the storage resolver to match
+      // against a ModelFile with the same ID, serving the wrong file content.
+      const { url } = await getDownloadUrl(file.url, file.name);
 
       const tracker = new Tracker(req, res);
       tracker


### PR DESCRIPTION
## Summary
- Article attachment downloads were serving wrong file content when a `File.id` collided with a `ModelFile.id` in the storage resolver's `file_locations` table
- The storage resolver only tracks `ModelFile` records, not `File` table records (article attachments, bounty files), so it should never be consulted for attachment downloads
- Bypasses the storage resolver and uses the delivery worker directly, which resolves via the file's actual S3 URL

**Example**: On [this article](https://civitai.com/articles/24793), the `.json` workflow attachment was downloading a `.safetensors` model file because the attachment's `File.id` matched a `ModelFile.id` in `file_locations`

## Test plan
- [ ] Verify article attachment downloads serve the correct file content
- [ ] Verify model file downloads are unaffected (they still use `resolveDownloadUrl`)
- [ ] Test with the specific article (24793) to confirm the `.json` attachment downloads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)