### PR TITLE
fix(beehiiv): handle API failures gracefully instead of throwing 500s

### DIFF
--- a/src/server/integrations/beehiiv.ts
+++ b/src/server/integrations/beehiiv.ts
@@ -31,6 +31,7 @@ async function beehiivRequest({
     method,
     headers,
     body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(5000),
   })
     .then((res) => res.json())
     .catch((err) => {
@@ -91,48 +92,57 @@ const getSubscription = newsletterHandler(async (email: string) => {
     return JSON.parse(subscriptionCache) as Subscription | undefined;
   }
 
-  const subscriptions = await beehiivRequest({
-    endpoint: `publications/${env.NEWSLETTER_ID}/subscriptions`,
-    method: 'GET',
-    body: { email },
-  });
-  const subscription = subscriptions?.data?.[0] as Subscription | undefined;
-  await redis.set(getRedisKey(email), JSON.stringify(subscription ?? 'not-subscribed'), {
-    EX: CacheTTL.day,
-  });
-  return subscription;
+  try {
+    const subscriptions = await beehiivRequest({
+      endpoint: `publications/${env.NEWSLETTER_ID}/subscriptions`,
+      method: 'GET',
+      body: { email },
+    });
+    const subscription = subscriptions?.data?.[0] as Subscription | undefined;
+    await redis.set(getRedisKey(email), JSON.stringify(subscription ?? 'not-subscribed'), {
+      EX: CacheTTL.day,
+    });
+    return subscription;
+  } catch (err) {
+    log('Failed to get subscription for', email, (err as Error).message);
+    return undefined;
+  }
 });
 
 const setSubscription = newsletterHandler(
   async ({ email, subscribed }: { email: string; subscribed: boolean }) => {
-    const subscription = await getSubscription(email);
-    if (!subscription && !subscribed) return;
-    const active = subscription?.status === 'active';
+    try {
+      const subscription = await getSubscription(email);
+      if (!subscription && !subscribed) return;
+      const active = subscription?.status === 'active';
 
-    if (!active) {
-      if (!subscribed) return;
-      await beehiivRequest({
-        endpoint: `publications/${env.NEWSLETTER_ID}/subscriptions`,
-        method: 'POST',
-        body: {
-          email,
-          reactivate_existing: true,
-          utm_source: 'Civitai',
-          utm_medium: 'organic',
-          utm_campaign: 'Civitai',
-        },
-      });
-    } else {
-      if (subscribed) return;
-      await beehiivRequest({
-        endpoint: `publications/${env.NEWSLETTER_ID}/subscriptions/${subscription.id}`,
-        method: 'PATCH',
-        body: {
-          unsubscribe: !subscribed,
-        },
-      });
+      if (!active) {
+        if (!subscribed) return;
+        await beehiivRequest({
+          endpoint: `publications/${env.NEWSLETTER_ID}/subscriptions`,
+          method: 'POST',
+          body: {
+            email,
+            reactivate_existing: true,
+            utm_source: 'Civitai',
+            utm_medium: 'organic',
+            utm_campaign: 'Civitai',
+          },
+        });
+      } else {
+        if (subscribed) return;
+        await beehiivRequest({
+          endpoint: `publications/${env.NEWSLETTER_ID}/subscriptions/${subscription.id}`,
+          method: 'PATCH',
+          body: {
+            unsubscribe: !subscribed,
+          },
+        });
+      }
+      await redis.del(getRedisKey(email));
+    } catch (err) {
+      log('Failed to set subscription for', email, (err as Error).message);
     }
-    await redis.del(getRedisKey(email));
   }
 );
 


### PR DESCRIPTION
## Summary
- Add `AbortSignal.timeout(5000)` to beehiiv fetch calls to prevent indefinite hangs
- Wrap `getSubscription` in try/catch — returns `undefined` (not subscribed) on failure instead of 500
- Wrap `setSubscription` in try/catch — logs error and returns silently instead of 500

Newsletter subscription status is non-critical. When beehiiv's API is unreachable or slow, users should not see a 500 error — they should just see "not subscribed" as a graceful default.

## Evidence
Found via DP migration monitoring at 15% traffic. Loki logs showed `INTERNAL_SERVER_ERROR: Error calling https://api.beehiiv.com/... fetch failed` propagating as unhandled 500s to users. Same error occurs on DOKS at lower volume.

## Test plan
- [ ] Verify newsletter subscription check still works when beehiiv is healthy
- [ ] Verify a beehiiv timeout/failure returns graceful default instead of 500
- [ ] Verify set subscription failure is logged but does not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)