### PR TITLE
fix: add dbWrite fallback for user-by-username lookups (CDC lag)

### DIFF
--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -206,10 +206,10 @@ export const getArticles = async ({
     }
 
     if (username) {
-      const targetUser = await dbRead.user.findUnique({
-        where: { username: username ?? '' },
-        select: { id: true },
-      });
+      const userFindArgs = { where: { username: username ?? '' }, select: { id: true } };
+      const targetUser =
+        (await dbRead.user.findUnique(userFindArgs)) ??
+        (await dbWrite.user.findUnique(userFindArgs));
 
       if (!targetUser) throw new Error('User not found');
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1018,7 +1018,9 @@ export const getAllImages = async (
         })
       : undefined,
     username && !targetUserId
-      ? dbRead.user.findUnique({ where: { username }, select: { id: true } })
+      ? dbRead.user
+          .findUnique({ where: { username }, select: { id: true } })
+          .then((u) => u ?? dbWrite.user.findUnique({ where: { username }, select: { id: true } }))
       : undefined,
     prioritizedUserIds?.length
       ? isFlipt('use-model-version-cache-for-images', modelVersionId?.toString(), {
@@ -2149,7 +2151,9 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   }
 
   if (username && !userId) {
-    const targetUser = await dbRead.user.findUnique({ where: { username }, select: { id: true } });
+    const targetUser =
+      (await dbRead.user.findUnique({ where: { username }, select: { id: true } })) ??
+      (await dbWrite.user.findUnique({ where: { username }, select: { id: true } }));
     if (!targetUser) throw new Error('User not found');
     userId = targetUser.id;
 
@@ -2685,7 +2689,9 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   }
 
   if (username && !userId) {
-    const targetUser = await dbRead.user.findUnique({ where: { username }, select: { id: true } });
+    const targetUser =
+      (await dbRead.user.findUnique({ where: { username }, select: { id: true } })) ??
+      (await dbWrite.user.findUnique({ where: { username }, select: { id: true } }));
     if (!targetUser) throw new Error('User not found');
     userId = targetUser.id;
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -408,10 +408,10 @@ export const getModelsRaw = async ({
   }
 
   if (username || user) {
-    const targetUser = await dbRead.user.findUnique({
-      where: { username: (username || user) ?? '' },
-      select: { id: true },
-    });
+    const userFindArgs = { where: { username: (username || user) ?? '' }, select: { id: true } };
+    const targetUser =
+      (await dbRead.user.findUnique(userFindArgs)) ??
+      (await dbWrite.user.findUnique(userFindArgs));
 
     if (!targetUser) throw new Error('User not found');
 

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -116,10 +116,10 @@ export const getResourceReviewsInfinite = async ({
   const orderBy: Prisma.Enumerable<Prisma.ResourceReviewOrderByWithRelationInput> = [];
 
   if (username) {
-    const targetUser = await dbRead.user.findUnique({
-      where: { username },
-      select: { id: true },
-    });
+    const userFindArgs = { where: { username }, select: { id: true } };
+    const targetUser =
+      (await dbRead.user.findUnique(userFindArgs)) ??
+      (await dbWrite.user.findUnique(userFindArgs));
 
     if (!targetUser) throw new Error('User not found');
 


### PR DESCRIPTION
## Summary
- DP reads from CNPG replica (CDC via Debezium/Kafka). Newly created users may not appear on the replica immediately, causing "User not found" 500 errors when looking up users by username.
- Adds `?? await dbWrite.user.findUnique(...)` fallback to 6 call sites across 4 files, so if `dbRead` returns null the primary is checked before throwing.
- Evidence: 26 errors/30m on DP vs 0 on DOKS at 15% traffic split — confirms CDC lag as root cause.

### Files changed
| File | Function | 
|------|----------|
| `model.service.ts` | `getModels()` |
| `resourceReview.service.ts` | `getResourceReviewsInfinite()` |
| `image.service.ts` | `getAllImages()` prefetch, `getImagesFromSearchPreFilter()`, `getImagesFromSearchPostFilter()` |
| `article.service.ts` | `getArticles()` |

## Test plan
- [ ] Verify no TypeScript errors introduced (`npx tsc --noEmit` on changed files)
- [ ] Deploy to DP and confirm "User not found" error rate drops to near-zero
- [ ] Verify normal user-by-username lookups still work (e.g. visiting a user profile page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)