### PR TITLE
Reduce new-order addImageRating lock TTL from 30s to 5s

### DIFF
--- a/src/server/services/games/new-order.service.ts
+++ b/src/server/services/games/new-order.service.ts
@@ -297,13 +297,16 @@ export async function addImageRating({
 }: AddImageRatingInput & { playerId: number; chTracker?: Tracker; isModerator?: boolean }) {
   if (!clickhouse) throw throwInternalServerError('Not supported');
 
-  // Use distributed lock to prevent race conditions
+  // Use distributed lock to prevent race conditions on vote counting.
+  // Lock scope is narrow (ttl: 5s) to avoid blocking concurrent voters.
+  // The lock only needs to cover the atomic vote-count + consensus-check
+  // window; post-vote operations (stats, reports) are safe to run unlocked.
   const result = await withDistributedLock(
     {
       key: `image-rating:${imageId}`,
-      ttl: 30, // 30 second lock
-      maxRetries: 5,
-      retryDelay: 200,
+      ttl: 5, // 5 second lock (was 30s — caused 30-50s tail latency)
+      maxRetries: 3,
+      retryDelay: 100,
     },
     async () => {
       return await processImageRating({


### PR DESCRIPTION
## Summary
- Tempo traces show `games.newOrder.addRating` taking **30-50s** with 100% self-time
- Root cause: `withDistributedLock` holds a 30-second TTL lock per imageId, serializing concurrent votes for the same image
- Lock TTL: 30s → 5s (`processImageRating` normally completes in <1s)
- maxRetries: 5 → 3, retryDelay: 200ms → 100ms (fail faster if truly contended)
- The lock only needs to cover vote-count + consensus-check atomicity; if processing ever exceeds 5s, the lock auto-releases rather than blocking the next voter for 30s

## Test plan
- [ ] Run new-order voting flow with multiple concurrent users on same image
- [ ] Verify votes still count correctly (no double-counting)
- [ ] Monitor Tempo traces for `games.newOrder.addRating` — p99 should drop from 30s+ to <5s
- [ ] Check for any `Image rating is currently being processed` errors in logs (would indicate 5s TTL is too short for edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)