### PR TITLE
feat: pass deploymentId in Flipt context for DP-only flag targeting

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -264,6 +264,7 @@ export const serverSchema = z.object({
 
   FLIPT_URL: z.string(),
   FLIPT_FETCHER_SECRET: z.string(),
+  FLIPT_DEPLOYMENT_ID: z.string().optional(),
 
   // B2 Upload (gated by Flipt flag)
   S3_UPLOAD_B2_ENDPOINT: z.string().optional(),

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -316,8 +316,9 @@ function getBaseClient(type: 'cache' | 'system') {
       return 'unknown';
     };
     const fliptHostname = getFliptHostname();
-    const fliptContext = { hostname: fliptHostname };
-    log(`Flipt context for enhanced failover flag: hostname=${fliptHostname}`);
+    const fliptContext: Record<string, string> = { hostname: fliptHostname };
+    if (env.FLIPT_DEPLOYMENT_ID) fliptContext.deploymentId = env.FLIPT_DEPLOYMENT_ID;
+    log(`Flipt context for enhanced failover flag: hostname=${fliptHostname}, deploymentId=${env.FLIPT_DEPLOYMENT_ID ?? 'unset'}`);
 
     // Helper to check feature flag before triggering rediscovery
     const maybeRediscover = async (reason: string) => {

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -292,6 +292,8 @@ export function buildFliptContext(user?: SessionUser): Record<string, string> {
   } else {
     ctx.isLoggedIn = 'false';
   }
+  const deploymentId = process.env.FLIPT_DEPLOYMENT_ID;
+  if (deploymentId) ctx.deploymentId = deploymentId;
   return ctx;
 }
 


### PR DESCRIPTION
## Summary
- Add `FLIPT_DEPLOYMENT_ID` to server env schema (optional string)
- Include `deploymentId` in `buildFliptContext()` when the env var is set
- Include `deploymentId` in Redis client Flipt context for enhanced failover flag evaluation

This enables the `is-datapacket` Flipt segment (added in civitai/flipt-state) to match requests originating from the DataPacket deployment, allowing flags like `redis-cluster-enhanced-failover` to be enabled on DP without affecting DOKS.

## How it works
1. DP deployment sets `FLIPT_DEPLOYMENT_ID=datapacket` (env var added in civitai/talos-infra)
2. App code passes `deploymentId: "datapacket"` in Flipt evaluation context
3. Flipt `is-datapacket` segment matches `deploymentId == "datapacket"`
4. Flags with `is-datapacket` in their rollout segments activate for DP only

## Test plan
- [ ] Verify DOKS deployment works without `FLIPT_DEPLOYMENT_ID` set (no behavior change)
- [ ] Verify DP deployment passes `deploymentId` in Flipt context
- [ ] Verify `redis-cluster-enhanced-failover` flag evaluates to `true` on DP via `is-datapacket` segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)