### PR TITLE
perf(cache): increase modelVersionResource and userDownloads TTL on DP

### DIFF
--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1053,7 +1053,7 @@ export function getBaseModelFromResources(
 export const modelVersionResourceCache = createCachedObject<ModelVersionResourceCacheItem>({
   key: REDIS_KEYS.CACHES.MODEL_VERSION_RESOURCE_INFO,
   idKey: 'versionId',
-  ttl: CacheTTL.md,
+  ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.md,
   lookupFn: async (ids) => {
     const mvInfo = await dbRead.modelVersion.findMany({
       where: { id: { in: ids } },
@@ -1131,7 +1131,7 @@ type UserDownloadsCacheItem = {
 export const userDownloadsCache = createCachedObject<UserDownloadsCacheItem>({
   key: REDIS_KEYS.CACHES.USER_DOWNLOADS,
   idKey: 'userId',
-  ttl: CacheTTL.hour,
+  ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.hour,
   cacheNotFound: false,
   lookupFn: async (userIds) => {
     if (!clickhouse) return {};


### PR DESCRIPTION
## Summary
- Guard `modelVersionResourceCache` TTL with `IS_DATAPACKET` (md/600s → day on DP)
- Guard `userDownloadsCache` TTL with `IS_DATAPACKET` (hour → day on DP)

Both caches showed low hit ratios in DP profiling (48% and 54% respectively). Both have proper `.bust()` calls on write paths:
- `modelVersionResourceCache.bust()` in `refresh-auction-cache.ts` and `handle-auctions.ts`
- `userDownloadsCache.bust()` in `user.service.ts`

DOKS TTLs are unchanged.

## Test plan
- [ ] Verify type check passes
- [ ] Deploy to DP and check cache hit ratios improve via `/profile-dp`
- [ ] Verify no stale data issues on model version resource info or user downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)