### PR TITLE
perf: increase model.getAll edge cache TTL on DataPacket

### DIFF
--- a/src/server/routers/model.router.ts
+++ b/src/server/routers/model.router.ts
@@ -1,4 +1,6 @@
 import * as z from 'zod';
+import { env } from '~/env/server';
+import { CacheTTL } from '~/server/common/constants';
 import {
   changeModelModifierHandler,
   copyGalleryBrowsingLevelHandler,
@@ -132,7 +134,7 @@ export const modelRouter = router({
   getAll: publicProcedure
     .input(getAllModelsSchema.extend({ page: z.never().optional() }))
     .use(skipEdgeCache)
-    .use(edgeCacheIt({ ttl: 60 }))
+    .use(edgeCacheIt({ ttl: env.IS_DATAPACKET ? CacheTTL.sm : 60 }))
     .query(getModelsInfiniteHandler),
   getAllPagedSimple: publicProcedure
     .input(getAllModelsSchema.extend({ cursor: z.never().optional() }))


### PR DESCRIPTION
## Summary
- Increases `model.getAll` edge cache TTL from 60s to 180s (`CacheTTL.sm`) on DataPacket deployments
- Uses `env.IS_DATAPACKET` guard — DOKS stays at 60s
- `model.getAll` is 16.3% of total DP load (10 req/s, 1.3s avg, 9.3s P95)

## Expected impact
Tripling cache lifetime reduces cache misses for common browse patterns. Estimated 30-40% reduction in endpoint load (~4-5% total load reduction).

## Verification
```promql
sum(rate(traces_spanmetrics_duration_milliseconds_sum{service_name="civitai-dp-prod", span_name="GET /api/trpc/model.getAll"}[5m])) / 1000
```
Should drop from ~12.5 to ~8.

## Test plan
- [ ] Verify model browsing works correctly on DP after deploy
- [ ] Confirm `skipEdgeCache` still bypasses cache for favorites/hidden queries
- [ ] Monitor spanmetrics for load reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)