### PR TITLE
perf: make refreshSession non-blocking in updateContentSettings

### DIFF
--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1937,7 +1937,9 @@ export async function updateContentSettings({
 
     await setUserSetting(userId, { ...settings, ...removeEmpty(data) });
   }
-  await refreshSession(userId);
+  refreshSession(userId).catch((err) => {
+    console.error('Failed to refresh session for user', userId, err);
+  });
 }
 
 export const getUserByPaddleCustomerId = async ({


### PR DESCRIPTION
## Summary
- Makes `refreshSession(userId)` fire-and-forget in `updateContentSettings`
- Previously awaited, averaging 15.2s per request (iterates all user sessions in Redis)
- User doesn't need to wait for session refresh — DB updates are still awaited

## Expected impact
Response time drops from ~15s to <500ms. Load contribution drops from 2.9 s/s to ~0.1 s/s (~3% total load reduction).

## Verification
```promql
histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_duration_milliseconds_bucket{service_name="civitai-dp-prod", span_name="POST /api/trpc/user.updateContentSettings"}[5m])))
```
Should drop from ~15000ms to <500ms.

## Test plan
- [ ] Verify content settings update works correctly (NSFW blur, browsing level, etc.)
- [ ] Confirm sessions eventually refresh after settings change
- [ ] Check logs for any `Failed to refresh session` errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)