### PR TITLE
fix: notification DB statement_timeout startup param rejected by PgBouncer

### DIFF
--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -72,6 +72,15 @@ export function getClient(
     ? 'logical-pg'
     : 'node-pg';
 
+  // DO managed Postgres PgBouncer rejects statement_timeout as a startup parameter.
+  // For notification instances, we set it per-connection via SET instead.
+  const notifStatementTimeout =
+    instance === 'notificationRead'
+      ? (env.IS_DATAPACKET ? env.DATABASE_READ_TIMEOUT ?? 10000 : undefined)
+      : instance === 'notification'
+      ? env.DATABASE_WRITE_TIMEOUT
+      : undefined;
+
   const pool = new Pool({
     connectionString,
     connectionTimeoutMillis: env.IS_DATAPACKET
@@ -82,13 +91,23 @@ export function getClient(
     // trying this for leaderboard job
     idleTimeoutMillis: instance === 'primaryReadLong' ? 300_000 : env.DATABASE_POOL_IDLE_TIMEOUT,
     statement_timeout:
-      instance === 'notificationRead'
-        ? (env.IS_DATAPACKET ? env.DATABASE_READ_TIMEOUT ?? 10000 : undefined) // standby seems to not support this on DOKS
+      isNotification && env.IS_DATAPACKET
+        ? undefined // DP: set per-connection below (PgBouncer rejects startup param)
+        : instance === 'notificationRead'
+        ? undefined // DOKS: standby doesn't support this
         : instance === 'primaryRead'
         ? env.DATABASE_READ_TIMEOUT
         : env.DATABASE_WRITE_TIMEOUT,
     application_name: `${appBaseName}${env.PODNAME ? '-' + env.PODNAME : ''}`,
   }) as AugmentedPool;
+
+  // Set statement_timeout per-connection for notification instances on DP
+  // (can't use startup parameter with DO managed PgBouncer)
+  if (env.IS_DATAPACKET && isNotification && notifStatementTimeout) {
+    pool.on('connect', (client) => {
+      client.query(`SET statement_timeout = ${Number(notifStatementTimeout)}`).catch(() => {});
+    });
+  }
 
   pool.cancellableQuery = async function <R extends QueryResultRow = any>(
     sql: Prisma.Sql | string,


### PR DESCRIPTION
## Summary
- DO managed Postgres PgBouncer rejects `statement_timeout` as a startup parameter, causing `unsupported startup parameter: statement_timeout` errors on all notification endpoints from DP pods
- Moves `statement_timeout` for notification DB instances from Pool config (startup param) to a per-connection `SET` command via the pool's `connect` event
- Non-notification instances (primary, primaryRead, etc.) are unchanged

## Root Cause
DP pods couldn't reach the notification DB due to missing firewall rules (separate issue, fixed in DO console). Once connectivity was restored, the `node-pg` Pool was sending `statement_timeout` as a startup parameter which DO managed PgBouncer doesn't support — causing 100% of notification queries to fail with `unsupported startup parameter: statement_timeout`.

## Affected Endpoints
- `user.checkNotifications` (highest volume — ~132 errors/5min)
- `notification.getAllByUser`
- `notification.markRead`
- `reaction.toggle` (background notification creation)

## Test plan
- [ ] Verify notification endpoints return data instead of 500s on DP
- [ ] Verify `statement_timeout` still applies (query cancelled after 60s on DP read)
- [ ] Verify DOKS behavior unchanged (no `statement_timeout` set for notification instances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)