### PR TITLE
feat: show user ID on profile sidebar for moderators

### DIFF
--- a/src/components/Profile/ProfileSidebar.tsx
+++ b/src/components/Profile/ProfileSidebar.tsx
@@ -1,6 +1,5 @@
 import type { MantineSize } from '@mantine/core';
 import {
-  ActionIcon,
   Anchor,
   Box,
   Button,
@@ -43,6 +42,7 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { formatDate } from '~/utils/date-helpers';
 import { sortDomainLinks } from '~/utils/domain-link';
 import { trpc } from '~/utils/trpc';
+import { CopyButton } from '~/components/CopyButton/CopyButton';
 import { AlertWithIcon } from '../AlertWithIcon/AlertWithIcon';
 import type { BadgeCosmetic } from '~/server/selectors/cosmetic.selector';
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
@@ -241,6 +241,20 @@ export function ProfileSidebar({ username, className }: { username: string; clas
         <Text c="dimmed" size="sm">
           Joined {formatDate(user.createdAt)}
         </Text>
+        {currentUser?.isModerator && (
+          <CopyButton value={String(user.id)}>
+            {({ copied, copy, color }) => (
+              <Text
+                c={copied ? color : 'dimmed'}
+                size="sm"
+                className="cursor-pointer"
+                onClick={copy}
+              >
+                {copied ? 'Copied!' : `User ID: ${user.id}`}
+              </Text>
+            )}
+          </CopyButton>
+        )}
         {user?.bannedAt && (
           <Group>
             <Popover withArrow>


### PR DESCRIPTION
## Summary
- Adds a **User ID** display below the "Joined" date on user profile sidebars
- Only visible to moderators (`currentUser.isModerator`)
- Clicking the User ID copies it to clipboard using the existing `CopyButton` component

## Test plan
- [ ] Log in as a moderator and visit a user profile — verify User ID appears below join date
- [ ] Click the User ID text — verify it copies to clipboard and shows "Copied!" feedback
- [ ] Log in as a non-moderator — verify User ID is not visible
- [ ] Log out — verify User ID is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)