### PR TITLE
fix(logging): stop flattening raw errors into Axiom schema

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -20,7 +20,7 @@ function logError({ error, name, details }: { error: Error; name: string; detail
       details,
       message: error.message,
       stack: error.stack,
-      cause: error.cause,
+      causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
     }).catch();
   } else {
     console.log(`Failed to get a connection to ${name}`);

--- a/src/pages/api/mod/ban-user.ts
+++ b/src/pages/api/mod/ban-user.ts
@@ -39,7 +39,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     logToAxiom({
       type: 'mod-ban-user-error',
       error: err.message,
-      cause: err.cause,
+      causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
       stack: err.stack,
     });
   }

--- a/src/pages/api/mod/remove-images.ts
+++ b/src/pages/api/mod/remove-images.ts
@@ -48,7 +48,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     logToAxiom({
       type: 'mod-remove-images-error',
       error: err.message,
-      cause: err.cause,
+      causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
       stack: err.stack,
     });
     res.status(500);

--- a/src/pages/api/mod/resource-training-v2.ts
+++ b/src/pages/api/mod/resource-training-v2.ts
@@ -51,7 +51,7 @@ export default ModEndpoint(async (req, res) => {
       message: 'Failed to update record',
       data: {
         error: err?.message,
-        cause: err?.cause,
+        causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
         stack: err?.stack,
         modelVersionId,
         workflowId,

--- a/src/pages/api/v1/model-versions/[id].ts
+++ b/src/pages/api/v1/model-versions/[id].ts
@@ -149,7 +149,7 @@ export default MixedAuthEndpoint(async function handler(
       type: 'error',
       name: 'api-model-version-details',
       message: error.message,
-      cause: error.cause,
+      causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       stack: error.stack,
     });
 

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -131,7 +131,7 @@ export default WebhookEndpoint(async (req, res) => {
           type: 'error',
           message: e.message,
           stack: e?.stack,
-          cause: e?.cause,
+          causeMessage: e?.cause instanceof Error ? e.cause.message : undefined,
         });
       }
       return res.status(400).send({ error: e.message });
@@ -314,7 +314,7 @@ async function logScanResultError({
     imageId: id,
     message,
     stack: error?.stack,
-    cause: error?.cause,
+    causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
   });
 }
 
@@ -457,7 +457,7 @@ async function checkModerationRules(image: GetImageReturn, tags: TagDetails[]) {
         data: {
           imageId: image.id,
           error: error.message,
-          cause: error.cause,
+          causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
           stack: error.stack,
         },
       })

--- a/src/pages/api/webhooks/model-scan-result.ts
+++ b/src/pages/api/webhooks/model-scan-result.ts
@@ -98,7 +98,7 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
               data: {
                 modelId: model.id,
                 error: error.message,
-                cause: error.cause,
+                causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
                 stack: error.stack,
               },
             })
@@ -132,7 +132,7 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
               data: {
                 modelId: model.id,
                 error: error.message,
-                cause: error.cause,
+                causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
                 stack: error.stack,
               },
             })

--- a/src/pages/api/webhooks/resource-training-v2/[modelVersionId].ts
+++ b/src/pages/api/webhooks/resource-training-v2/[modelVersionId].ts
@@ -133,7 +133,7 @@ export default WebhookEndpoint(async (req, res) => {
         const err = e as Error | undefined;
         logWebhook({
           message: 'Failed to update record',
-          data: { error: err?.message, cause: err?.cause, stack: err?.stack, status, workflowId },
+          data: { error: err?.message, causeMessage: err?.cause instanceof Error ? err.cause.message : undefined, stack: err?.stack, status, workflowId },
         });
         return res.status(500).json({ ok: false, error: err?.message, workflowId });
       }

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -80,7 +80,7 @@ import { updateUserScore } from '~/server/jobs/update-user-score';
 import { userDeletedCleanup } from '~/server/jobs/user-deleted-cleanup';
 import { expireStrikesJob, processTimedUnmutesJob } from '~/server/jobs/process-strikes';
 import { processEnqueuedComicPanelsJob } from '~/server/jobs/process-enqueued-comic-panels';
-import { logToAxiom } from '~/server/logging/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { createLogger } from '~/utils/logging';
@@ -213,7 +213,7 @@ export default WebhookEndpoint(async (req, res) => {
     res.status(200).json({ ok: true, pod, result: result ?? null });
   } catch (error) {
     log(`${name} failed: ${((Date.now() - jobStart) / 1000).toFixed(2)}s`, error);
-    axiom.error(`failed`, { duration: Date.now() - jobStart, error });
+    axiom.error(`failed`, { duration: Date.now() - jobStart, error: safeError(error) });
     res.status(500).json({ ok: false, pod, error, stack: (error as Error)?.stack });
   } finally {
     await unlock(name, noCheck);

--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -272,7 +272,7 @@ export class Tracker {
             name: 'Failed session',
             message: error.message,
             stack: error.stack,
-            cause: error.cause,
+            causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
           },
           'clickhouse'
         );
@@ -316,7 +316,7 @@ export class Tracker {
           details: { table, data: JSON.stringify(data) },
           message: error.message,
           stack: error.stack,
-          cause: error.cause,
+          causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
         },
         'clickhouse'
       ).catch();
@@ -347,7 +347,7 @@ export class Tracker {
           details: { table, data: JSON.stringify(data) },
           message: error.message,
           stack: error.stack,
-          cause: error.cause,
+          causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
         },
         'clickhouse'
       ).catch();

--- a/src/server/events/index.ts
+++ b/src/server/events/index.ts
@@ -375,7 +375,7 @@ export const eventEngine = {
         name: 'event-donation-error',
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       });
     }
 

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -106,7 +106,7 @@ class FliptSingleton {
           {
             type: 'init-flipt-error',
             error: err.message,
-            cause: err.cause,
+            causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
             stack: err.stack,
           },
           'temp-search'

--- a/src/server/jobs/check-processing-resource-training-v2.ts
+++ b/src/server/jobs/check-processing-resource-training-v2.ts
@@ -58,7 +58,7 @@ export const checkProcessingResourceTrainingV2 = createJob(
             message: 'Failed to update record',
             data: {
               error: err?.message,
-              cause: err?.cause,
+              causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
               stack: err?.stack,
               workflowId,
             },

--- a/src/server/jobs/creators-program-jobs.ts
+++ b/src/server/jobs/creators-program-jobs.ts
@@ -242,7 +242,7 @@ export const creatorsProgramSettleCash = createJob(
         await logToAxiom({
           name: 'creator-program-settle-cash',
           type: 'creator-program-settle-cash',
-          error: e,
+          error: e instanceof Error ? e.message : String(e),
           positiveBalances,
         });
 

--- a/src/server/jobs/entity-moderation.ts
+++ b/src/server/jobs/entity-moderation.ts
@@ -474,7 +474,7 @@ const runClavata = async ({
           data: {
             error: error.message,
             name: error.name,
-            cause: error.cause,
+            causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
             stack: error.stack,
             code: error.code,
           },

--- a/src/server/jobs/full-image-existence.ts
+++ b/src/server/jobs/full-image-existence.ts
@@ -76,7 +76,7 @@ export const fullImageExistence = createJob(jobName, '40 6 * * *', async () => {
       name: 'Failed to check full image existence',
       message: error.message,
       stack: error.stack,
-      cause: error.cause,
+      causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
     }).catch();
   }
 });

--- a/src/server/jobs/handle-auctions.ts
+++ b/src/server/jobs/handle-auctions.ts
@@ -140,7 +140,7 @@ export const handleAuctions = createJob(jobName, '1 0 * * *', async ({ req }) =>
         type: 'error',
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       }).catch();
       throw error;
     }
@@ -309,7 +309,7 @@ const _handleWinnersForAuction = async (auctionRow: AuctionRow, winners: WinnerT
         type: 'error',
         message: `Failed to create featured models`,
         error: err.message,
-        cause: err.cause,
+        causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
         stack: err.stack,
       }).catch();
       return false;
@@ -395,7 +395,7 @@ const _handleWinnersForAuction = async (auctionRow: AuctionRow, winners: WinnerT
           message: `Failed to update checkpoint coverage`,
           data: { checkpoints },
           error: err.message,
-          cause: err.cause,
+          causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
           stack: err.stack,
         }).catch();
 
@@ -501,7 +501,7 @@ const _refundLosersForAuction = async (auctionRow: AuctionRow, losers: WinnerTyp
                 message: `Failed to refund bid`,
                 data: { tid },
                 error: err.message,
-                cause: err.cause,
+                causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
                 stack: err.stack,
               }).catch();
               return { transactionId: null };
@@ -515,7 +515,7 @@ const _refundLosersForAuction = async (auctionRow: AuctionRow, losers: WinnerTyp
             message: `Failed to run refund`,
             data: { tid },
             error: err.message,
-            cause: err.cause,
+            causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
             stack: err.stack,
           }).catch();
 
@@ -673,7 +673,7 @@ const createRecurringBids = async (now: Dayjs) => {
           message: `Failed to handle recurring bid`,
           data: { recurringBid },
           error: err.message,
-          cause: err.cause,
+          causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
           stack: err.stack,
         }).catch();
       }

--- a/src/server/jobs/prepare-bounties.ts
+++ b/src/server/jobs/prepare-bounties.ts
@@ -85,7 +85,7 @@ const prepareBounties = createJob('prepare-bounties', '0 23 * * *', async () => 
               email: user.email,
               bountyId: id,
               error: error.message,
-              cause: error.cause,
+              causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
               stack: error.stack,
             },
           })
@@ -136,7 +136,7 @@ const prepareBounties = createJob('prepare-bounties', '0 23 * * *', async () => 
               email: user.email,
               bountyId: id,
               error: error.message,
-              cause: error.cause,
+              causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
               stack: error.stack,
             },
           })
@@ -310,7 +310,7 @@ const prepareBounties = createJob('prepare-bounties', '0 23 * * *', async () => 
                 email: user.email,
                 bountyId: id,
                 error: error.message,
-                cause: error.cause,
+                causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
                 stack: error.stack,
               },
             })
@@ -458,7 +458,7 @@ const prepareBounties = createJob('prepare-bounties', '0 23 * * *', async () => 
               email: user.email,
               bountyId: id,
               error: error.message,
-              cause: error.cause,
+              causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
               stack: error.stack,
             },
           })

--- a/src/server/jobs/send-notifications.ts
+++ b/src/server/jobs/send-notifications.ts
@@ -108,7 +108,7 @@ export const sendNotificationsJob = createJob('send-notifications', '*/1 * * * *
               details: { key },
               message: error.message,
               stack: error.stack,
-              cause: error.cause,
+              causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
             },
             'notifications'
           ).catch();
@@ -129,7 +129,7 @@ export const sendNotificationsJob = createJob('send-notifications', '*/1 * * * *
         name: 'Failed to send notifications',
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       },
       'notifications'
     ).catch();

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -10,6 +10,31 @@ const axiom = shouldConnect
     })
   : null;
 
+/**
+ * Extract only safe primitive fields from an error for logging.
+ *
+ * Logging raw error objects (especially from axios or AWS SDK) blows up the
+ * Axiom schema because each unique key in `.config`, `.headers`, `.cause`,
+ * `.$metadata`, `.config.data._readableState`, etc. becomes a separate field.
+ * Always pass errors through this helper before logging them.
+ */
+export function safeError(e: unknown): MixedObject | undefined {
+  if (e == null) return undefined;
+  if (e instanceof Error) {
+    const anyErr = e as any;
+    const cause = anyErr.cause;
+    return {
+      name: e.name,
+      message: e.message,
+      stack: e.stack,
+      code: anyErr.code,
+      causeMessage:
+        cause instanceof Error ? cause.message : cause != null ? String(cause) : undefined,
+    };
+  }
+  return { message: String(e) };
+}
+
 export async function logToAxiom(data: MixedObject, datastream?: string) {
   const sendData = { pod: env.PODNAME, ...data };
   if (isProd) {

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -7,7 +7,7 @@ import {
   queryGeneratedImageWorkflows2,
   whatIfFromGraph,
 } from '~/server/services/orchestrator/orchestration-new.service';
-import { logToAxiom } from '~/server/logging/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import { edgeCacheIt } from '~/server/middleware.trpc';
 import { generatorFeedbackReward } from '~/server/rewards';
 import {
@@ -391,15 +391,11 @@ export const orchestratorRouter = router({
       logToAxiom({
         name: 'what-if-from-graph',
         type: 'error',
-        payload: input,
+        payload: JSON.stringify(input),
         error:
           e instanceof TRPCError
-            ? {
-                code: e.code,
-                name: e.name,
-                message: e.message,
-              }
-            : e,
+            ? { code: e.code, name: e.name, message: e.message }
+            : safeError(e),
       }).catch();
       throw e;
     }

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -108,7 +108,7 @@ const getArticleStatsObject = async (data: { id: number }[]) => {
         name: 'Failed to getArticleStats',
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       },
       'article-stats'
     ).catch();

--- a/src/server/services/auction.service.ts
+++ b/src/server/services/auction.service.ts
@@ -529,7 +529,7 @@ export const createBid = async ({
         },
         message: err.message,
         stack: err.stack,
-        cause: err.cause,
+        causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
       }).catch();
       await withRetries(() =>
         refundMultiAccountTransaction({
@@ -733,7 +733,7 @@ export const deleteBidsForModel = async ({
             type: 'error',
             message: `Failed to refund user for removed bid`,
             stack: error.stack,
-            cause: error.cause,
+            causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
             data: { transactionId, message: error.message },
           }).catch();
         }
@@ -863,7 +863,7 @@ export const deleteBidsForModelVersion = async ({
             type: 'error',
             message: `Failed to refund user for removed bid`,
             stack: error.stack,
-            cause: error.cause,
+            causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
             data: { transactionId, message: error.message },
           }).catch();
         }

--- a/src/server/services/buzz-withdrawal-request.service.ts
+++ b/src/server/services/buzz-withdrawal-request.service.ts
@@ -678,7 +678,7 @@ export const updateBuzzWithdrawalRequest = async ({
           message: 'Failed to update withdrawal request',
           data: {
             requestId: req.id,
-            error: e,
+            error: e instanceof Error ? e.message : String(e),
           },
         });
 

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -629,7 +629,7 @@ export const purchaseCosmeticShopItem = async ({
           shopItemId,
           userId,
           transactionId,
-          error: e,
+          error: e instanceof Error ? e.message : String(e),
         },
       });
     }

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -772,7 +772,7 @@ export async function withdrawCash(userId: number, amount: number) {
       data: {},
     });
   } catch (e) {
-    await logToAxiom({ name: 'withdraw-cash', type: 'error', error: e, ...data, userId });
+    await logToAxiom({ name: 'withdraw-cash', type: 'error', error: e instanceof Error ? e.message : String(e), ...data, userId });
 
     // In case of error, we need to revert the transaction
     if (data.updated) {

--- a/src/server/services/games/new-order.service.ts
+++ b/src/server/services/games/new-order.service.ts
@@ -652,7 +652,7 @@ async function processImageRating({
           },
           message: error.message,
           stack: error.stack,
-          cause: error.cause,
+          causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
         },
         'clickhouse'
       ).catch();
@@ -1001,7 +1001,7 @@ export async function processFinalRatings() {
         },
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       },
       'clickhouse'
     ).catch();

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2999,7 +2999,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
       {
         type: 'search-error',
         error: err.message,
-        cause: err.cause,
+        causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
         input: removeEmpty(input),
         request,
       },
@@ -3903,7 +3903,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       {
         type: 'search-error',
         error: err.message,
-        cause: err.cause,
+        causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
         input: removeEmpty(input),
         request,
       },
@@ -3926,7 +3926,7 @@ const getImageMetricsObject = async (data: { id: number }[]) => {
         name: 'Failed to getImageMetrics',
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       },
       'clickhouse'
     ).catch();
@@ -7134,7 +7134,7 @@ export async function addSeenImageIds(imageIds: number[], maxSize = 10000) {
         {
           type: 'search-redis-error',
           error: err.message,
-          cause: err.cause,
+          causeMessage: err?.cause instanceof Error ? err.cause.message : undefined,
           stack: err.stack,
         },
         'temp-search'

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -537,7 +537,7 @@ export const upsertModelVersion = async ({
 
     // Run it in the background to avoid blocking the request.
     ingestModelById({ id: version.modelId }).catch((error) =>
-      logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: version.modelId })
+      logToAxiom({ type: 'error', name: 'model-ingestion', error: error instanceof Error ? error.message : String(error), modelId: version.modelId })
     );
 
     return version;
@@ -909,7 +909,7 @@ export const publishModelVersionById = async ({
 
   // Run it in the background to avoid blocking the request.
   ingestModelById({ id: version.modelId }).catch((error) =>
-    logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: version.modelId })
+    logToAxiom({ type: 'error', name: 'model-ingestion', error: error instanceof Error ? error.message : String(error), modelId: version.modelId })
   );
 
   return version;

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1723,7 +1723,7 @@ export const upsertModel = async (
       const parsedModel = ingestModelSchema.parse(result);
       // Run it in the background to prevent blocking the request
       ingestModel({ ...parsedModel }).catch((error) =>
-        logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: parsedModel.id })
+        logToAxiom({ type: 'error', name: 'model-ingestion', error: error instanceof Error ? error.message : String(error), modelId: parsedModel.id })
       );
     }
 
@@ -1951,7 +1951,7 @@ export const publishModelById = async ({
   if (!republishing) {
     const parsedModel = ingestModelSchema.parse(model);
     ingestModel({ ...parsedModel }).catch((error) =>
-      logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: parsedModel.id })
+      logToAxiom({ type: 'error', name: 'model-ingestion', error: error instanceof Error ? error.message : String(error), modelId: parsedModel.id })
     );
   }
 
@@ -3175,7 +3175,7 @@ export async function getFeaturedModels() {
       type: 'error',
       message: error.message,
       stack: error.stack,
-      cause: error.cause,
+      causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
     }).catch();
     return [];
   }

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -72,7 +72,7 @@ export const createNotification = async (data: CreateNotificationPendingRow) => 
         details: { key: data.key },
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       },
       'notifications'
     ).catch();

--- a/src/server/services/paddle.service.ts
+++ b/src/server/services/paddle.service.ts
@@ -938,7 +938,7 @@ export const updateSubscriptionPlan = async ({
           message: 'Failed to update subscription',
           userId,
           priceId,
-          error: e,
+          error: e instanceof Error ? e.message : String(e),
           stack: (e as Error)?.stack,
         });
 

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -128,7 +128,7 @@ const getPostStatsObject = async (data: { id: number }[]) => {
         name: 'Failed to getPostStats',
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       },
       'civitai-prod'
     );

--- a/src/server/utils/errorHandling.ts
+++ b/src/server/utils/errorHandling.ts
@@ -179,7 +179,7 @@ export function handleLogError(e: Error, name?: string) {
         name: name ?? error.name,
         message: error.message,
         stack: error.stack,
-        cause: error.cause,
+        causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       },
       'civitai-prod'
     ).catch();

--- a/src/server/utils/metric-helpers.ts
+++ b/src/server/utils/metric-helpers.ts
@@ -138,7 +138,7 @@ export const updateEntityMetric = async ({
     logError('Failed to increment metric', {
       data: logData,
       error: error.message,
-      cause: error.cause,
+      causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       stack: error.stack,
     });
   }
@@ -151,7 +151,7 @@ export const updateEntityMetric = async ({
     logError('Failed to queue metric into CH', {
       data: logData,
       error: error.message,
-      cause: error.cause,
+      causeMessage: error?.cause instanceof Error ? error.cause.message : undefined,
       stack: error.stack,
     });
   }


### PR DESCRIPTION
## Summary
- Axiom civitai-prod hit 1024 field limit (was 1026) and started rejecting events
- Root cause: raw axios / AWS SDK error objects were being flattened into hundreds of unique columns (`.config.data._readableState.*`, `.headers.*`, `.cause.socket.*`, `$metadata.*`)
- Adds `safeError()` helper in `server/logging/client.ts` that extracts only `{ name, message, stack, code, causeMessage }`
- Fixes the three biggest individual offenders and batch-replaces ~47 `cause: error.cause` sites + several raw `error: e` logs

## Top offenders found (pre-fix field counts)
| Count | Prefix | Cause |
|---|---|---|
| 224 | `fields.error.*` | `run-jobs/[[...run]].ts` passing raw `error` to `axiom.error()` via `@civitai/next-axiom` |
| 52 | `error.config.*` | axios `.config` (stream internals!) |
| 52 | `cause.config.*` | same via `error.cause` |
| 31 | `error.raw.*` | axios response body |
| 26 | `error.headers.*` | response headers as fields |
| 43 | `payload.params.*` | `orchestrator.router.ts` logging full `input` graph |

## Axiom cleanup
- Vacuumed civitai-prod: **1026 → 970 fields** (54 headroom)
- After this deploys, a follow-up vacuum will reclaim the rest
- Map-field configuration (to make this regression-proof) needs an Axiom token with dataset:update — current query token can't do it. Recommend @justmaier or ops configures `mapFields: ["fields.error","error","cause","payload","input"]` in Axiom UI → civitai-prod settings

## Test plan
- [ ] Deploy to stage, run a job that throws, verify error shows up in Axiom with `error.message` / `error.stack` / `error.causeMessage` instead of exploded fields
- [ ] Confirm no new fields appear under `fields.error.*`, `error.config.*`, `cause.config.*` prefixes after 24h in prod
- [ ] Re-run vacuum after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)