### PR TITLE
fix: notification write pool exhaustion causing 30s timeouts

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -23,6 +23,7 @@ export const serverSchema = z.object({
   DATAPACKET_DATABASE_RO_URL: z.url().optional(),
   DATABASE_CONNECTION_TIMEOUT: z.coerce.number().default(0),
   DATABASE_POOL_MAX: z.coerce.number().default(20),
+  NOTIFICATION_POOL_MAX: z.coerce.number().optional(),
   DATABASE_POOL_IDLE_TIMEOUT: z.coerce.number().default(30000),
   DATABASE_READ_TIMEOUT: z.coerce.number().optional(),
   DATABASE_WRITE_TIMEOUT: z.coerce.number().optional(),

--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -87,7 +87,7 @@ export function getClient(
       ? env.DATABASE_CONNECTION_TIMEOUT || 5000
       : env.DATABASE_CONNECTION_TIMEOUT,
     min: 0,
-    max: env.DATABASE_POOL_MAX,
+    max: isNotification ? (env.NOTIFICATION_POOL_MAX ?? env.DATABASE_POOL_MAX) : env.DATABASE_POOL_MAX,
     // trying this for leaderboard job
     idleTimeoutMillis: instance === 'primaryReadLong' ? 300_000 : env.DATABASE_POOL_IDLE_TIMEOUT,
     statement_timeout:

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -164,6 +164,28 @@ export const markNotificationsRead = async ({
   all = false,
   category,
 }: MarkReadNotificationInput & { userId: number }) => {
+  // Fire-and-forget: the UI optimistically marks as read, so we don't need to
+  // block the response on the cross-Atlantic write to DO managed Postgres.
+  // Errors are logged but not surfaced to the user.
+  const writePromise = _markNotificationsReadImpl({ id, userId, all, category });
+  writePromise.catch((err) => {
+    logToAxiom({
+      type: 'warning',
+      name: 'notification.markRead',
+      message: `Failed to mark notifications read: ${(err as Error).message}`,
+      userId,
+      all,
+      category,
+    }).catch(() => {});
+  });
+};
+
+async function _markNotificationsReadImpl({
+  id,
+  userId,
+  all,
+  category,
+}: MarkReadNotificationInput & { userId: number; all: boolean }) {
   if (all) {
     if (category) {
       // Join only needed when filtering by category
@@ -220,7 +242,7 @@ export const markNotificationsRead = async ({
         notificationCache.decrementUser(userId, catData[0].category).catch(() => {});
     }
   }
-};
+}
 
 export const createUserNotificationSetting = async ({
   type,


### PR DESCRIPTION
## Summary
- **Separate notification pool size** via `NOTIFICATION_POOL_MAX` env var. Falls back to `DATABASE_POOL_MAX` when unset (DOKS unchanged). On DP, set to 5: `36 pods × 5 = 180` total connections vs current `36 × 20 = 720` competing for DO PgBouncer's ~47 backend slots.
- **Fire-and-forget `markNotificationsRead`** — the UI already optimistically marks notifications as read, so the TRPC response no longer blocks on the cross-Atlantic DB write. Errors logged to Axiom as warnings.
- **New env var**: `NOTIFICATION_POOL_MAX` (optional, `z.coerce.number().optional()`) — when unset, uses `DATABASE_POOL_MAX` for backwards compatibility.

## Context
`notification.markRead` has 14% error rate on DP with "Connection terminated due to connection timeout" — 304 occurrences/hour at 30% traffic. Root cause: 720 potential pg-pool connections (36 pods × 20 max) competing for DO managed Postgres PgBouncer's ~47 backend slots. Latency is bimodal (<1s or 30s) — classic connection acquisition starvation.

## Deployment Notes
After merging, set `NOTIFICATION_POOL_MAX=5` in the DP deployment secrets. No changes needed on DOKS — the fallback to `DATABASE_POOL_MAX` preserves current behavior.

## Test plan
- [ ] Verify DOKS builds (no new required env vars — `NOTIFICATION_POOL_MAX` is optional with fallback)
- [ ] Deploy to DP with `NOTIFICATION_POOL_MAX=5`
- [ ] Monitor `notification.markRead` error rate — should drop from 14% to ~0%
- [ ] Monitor Axiom for `notification.markRead` warning logs (fire-and-forget failures)
- [ ] Verify notifications still get marked as read in the DB (eventual consistency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)