### PR TITLE
fix(scan-files): prevent 504 timeout on model.rescan

### DIFF
--- a/src/server/jobs/scan-files.ts
+++ b/src/server/jobs/scan-files.ts
@@ -31,7 +31,7 @@ export const scanFilesJob = createJob('scan-files', '*/5 * * * *', async () => {
   const sent: number[] = [];
   const failed: number[] = [];
   for (const file of files) {
-    const result = await requestScannerTasks({ file });
+    const result = await requestScannerTasks({ file, retryOnFailure: true });
     if (result === 'sent') sent.push(file.id);
     else if (result === 'not-found') failed.push(file.id);
     // 'error' = scanner issue, don't mark as non-existent, just skip
@@ -54,12 +54,15 @@ type ScannerRequest = {
   file: FileScanRequest;
   tasks?: ScannerTask[] | ScannerTask;
   lowPriority?: boolean;
+  /** When true, waits 60s and retries if URL resolution fails (for background jobs only). */
+  retryOnFailure?: boolean;
 };
 
 export async function requestScannerTasks({
   file: { id: fileId, url: s3Url },
   tasks = ['Scan', 'Hash', 'ParseMetadata'],
   lowPriority = false,
+  retryOnFailure = false,
 }: ScannerRequest): Promise<'sent' | 'not-found' | 'error'> {
   if (!env.SCANNING_ENDPOINT) {
     console.log('Skipping file scanning');
@@ -104,19 +107,25 @@ export async function requestScannerTasks({
     // Fall back to delivery worker using the S3 URL directly.
     try {
       ({ url: fileUrl } = await getDownloadUrl(s3Url));
-    } catch {
-      // Both failed — wait 60s and retry once (covers registration sync lag)
-      await new Promise((r) => setTimeout(r, 60_000));
-      try {
-        fileUrl = await resolveFileUrl();
-      } catch (retryError) {
+    } catch (fallbackError) {
+      if (retryOnFailure) {
+        // Background job: wait 60s and retry once (covers registration sync lag)
+        await new Promise((r) => setTimeout(r, 60_000));
+        try {
+          fileUrl = await resolveFileUrl();
+        } catch {
+          // Retry also failed
+        }
+      }
+      if (fileUrl === s3Url) {
+        // Still unresolved after all attempts
         logToAxiom(
           {
             type: 'error',
             name: 'request-scanner-tasks',
             message: `Failed to get download url for file ${fileId} (${s3Url})`,
-            error: retryError instanceof Error ? retryError.message : String(retryError),
-            stack: retryError instanceof Error ? retryError.stack : undefined,
+            error: fallbackError instanceof Error ? fallbackError.message : String(fallbackError),
+            stack: fallbackError instanceof Error ? fallbackError.stack : undefined,
           },
           'webhooks'
         ).catch();


### PR DESCRIPTION
## Summary
The 60s retry delay in `requestScannerTasks()` (added in 223eacfcb) blocks HTTP requests when called from `model.rescan`, causing 504 gateway timeouts for models whose files can't be resolved by storage-resolver.

## Root cause
`rescanModel()` in model.service.ts calls `requestScannerTasks()` per file with `limitConcurrency(tasks, 10)`. If storage-resolver returns 404 for any file and delivery-worker fallback also fails, the 60s wait blocks the entire batch. For models with N unresolvable files, total wait = `ceil(N/10) × 60s`, easily exceeding the upstream gateway timeout.

We hit this with model 2501324 — one of its files was one of 5 files from model_id=4944 that were missing from storage-resolver's `file_locations` table due to the classifyFile() bug in the seed job (fixed separately in civitai/storage-resolver#1 and manually re-registered). The rescan endpoint blocked 60s, exceeded the gateway timeout, and returned 504.

## Fix
Add a `retryOnFailure` option (default `false`) to `requestScannerTasks`. Only the background cron job (`scanFilesJob`) passes `retryOnFailure: true`. Synchronous callers (`model.rescan`, `mod/clean-up`) now fail fast without the 60s wait.

This preserves the sync-lag handling for new uploads (cron picks them up on next run anyway) while preventing HTTP timeouts on the rescan endpoint.

## Test plan
- [ ] Trigger `model.rescan` on a model with unresolvable files — should complete in seconds
- [ ] Verify background scan-files cron still retries after 60s for resolvable-after-sync files
- [ ] Verify model 2501324 rescan completes successfully (root cause is fixed separately by re-registering the 5 B2 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)