### PR TITLE
feat: article ingestion status + manual rescan

### DIFF
--- a/docs/article-ingestion-status-proposal.md
+++ b/docs/article-ingestion-status-proposal.md
@@ -1,7 +1,7 @@
 # Article Ingestion Status — Design Proposal
 
 **Status**: Draft, pending implementation decision
-**Context**: Surfaced during review of [`article-scanning-rollout.md`](./article-scanning-rollout.md) on 2026-04-10
+**Context**: Surfaced during review of [`article-scanning-rollout.md`](./article-scanning-rollout.md) on 2026-04-10, updated 2026-04-12
 **Related**: civitai/civitai#1879 (`feature/scan-article-images`), [`article-content-scanning.md`](./article-content-scanning.md)
 
 ---
@@ -10,10 +10,11 @@
 
 Add an `ArticleIngestionStatus` enum + `Article.ingestion` column that mirrors how `Image.ingestion` already gates image serving. Non-owner, non-moderator article reads filter on `ingestion = 'Scanned'`. This:
 
-1. Closes the legacy-backfill Green exposure window (the real gap I missed in the initial gotchas review).
+1. ~~Closes the legacy-backfill Green exposure window~~ — **mitigated by deployment strategy** (see §"Gap 1" below). Backfills run against prod DB from staging before the production deploy, so legacy articles are already scanned when Green access turns on.
 2. Supersedes the accepted async text-scan window decision from 2026-04-10 — not by reversing it, but by offering a gating mechanism the earlier discussion didn't consider.
 3. Unifies image and text scan gating under a single predicate.
 4. Separates scan state (system) from publication state (user intent), which removes most of the awkwardness around `ArticleStatus.Processing`.
+5. Adds proper scan-lifecycle date tracking (`scanRequestedAt`, `scannedAt`) to Article, mirroring Image. Fixes the `contentScannedAt` misnomer and closes the gap where text-only articles have no scan timestamp at all.
 
 **Decision pending**: ship this as a followup (recommended) vs. absorb into the current PR (bigger scope, cleaner landing).
 
@@ -21,7 +22,14 @@ Add an `ArticleIngestionStatus` enum + `Article.ingestion` column that mirrors h
 
 ## The problem this solves
 
-### Gap 1 — Legacy backfill exposes unscanned content to Civitai Green
+### Gap 1 — Legacy backfill exposes unscanned content to Civitai Green (MITIGATED)
+
+> **2026-04-12 update**: This gap is closed by the deployment strategy. Both backfills will run against the prod DB from a staging environment *before* the production deploy ships `articles: ['public']`. By the time Green access turns on, every legacy article already has correct `ImageConnection` rows, recomputed `nsfwLevel` masks, and `EntityModeration` results. There is no window where unscanned legacy content is visible to Green.
+>
+> The original analysis below is preserved for context on why the gap existed in the first rollout sequence, but it is no longer a blocker.
+
+<details>
+<summary>Original analysis (preserved for context)</summary>
 
 The current rollout sequence (§4 of `article-scanning-rollout.md`) is:
 
@@ -34,6 +42,8 @@ Between steps 1 and 2, a legacy article's `nsfwLevel` is computed from **just** 
 So a legacy article with a PG cover, NSFW content images embedded in the body, and NSFW text currently has `nsfwLevel = PG`. After step 1 deploys, Civitai Green filters by `(nsfwLevel & publicBrowsingLevelsFlag) != 0` and happily serves that article. The backfills eventually fix it, but the entire legacy corpus is visible to Green at its **pre-scan** level for the duration of the backfill window.
 
 The commit message for `28b38c7dd` acknowledges that legacy masks are wrong and will be updated by the backfill. `article-scanning-rollout.md` §2.3 calls this out directly: "running `updateArticleNsfwLevels` over legacy articles (which happens implicitly when backfills complete) will change existing masks for any article that mixed PG + NSFW content images under the old code." Any article whose mask *changes* during the backfill was being served at the wrong level *before* the backfill ran. That's the leak window.
+
+</details>
 
 ### Gap 2 — The live text-scan window is still there
 
@@ -58,13 +68,29 @@ enum ArticleIngestionStatus {
 
 model Article {
   // ... existing fields
-  ingestion ArticleIngestionStatus @default(Pending)
+  contentScannedAt DateTime?              // repurposed: set when BOTH scans complete (was: set at image-link time)
+  ingestion        ArticleIngestionStatus @default(Pending)
+  scanRequestedAt  DateTime?              // when scan was first requested (image link + text submit)
 
   @@index([status, ingestion, nsfwLevel])  // supports the Green query shape
 }
 ```
 
-**Migration**: adds the column with `@default(Pending)`. Every existing article is `Pending` on schema apply — **every legacy article is immediately invisible to Civitai Green the moment the migration runs.** That's the safety property we want.
+These fields mirror `Image.scanRequestedAt` and `Image.scannedAt`. They give us:
+
+- **Filterability**: query for articles that were never scanned (`contentScannedAt IS NULL`), or that have been waiting too long (`scanRequestedAt < NOW() - INTERVAL '1 hour'` AND `ingestion = 'Pending'`).
+- **Observability**: measure scan latency (`contentScannedAt - scanRequestedAt`), find stuck articles, build dashboards.
+- **Parity with Image**: same semantics, same query patterns.
+
+#### `contentScannedAt` repurposed (not deprecated)
+
+The existing `contentScannedAt` field was previously set when `linkArticleContentImages` ran (i.e., when image *links* were created), not when scanning *completed*. Text-only articles never got it set at all.
+
+**New semantics**: `contentScannedAt` is now set **only** inside `recomputeArticleIngestion` when `ingestion` transitions to `Scanned` — meaning both image scans and text moderation have completed successfully. The name is now accurate: "when was this article's content actually scanned."
+
+`scanRequestedAt` replaces the old `contentScannedAt` write timing — it's set when `linkArticleContentImages` + `submitTextModeration` fire, tracking "when did we kick off scanning."
+
+**Migration**: adds two new fields (`ingestion`, `scanRequestedAt`). `ingestion` defaults to `Pending`. `contentScannedAt` keeps its column but its write sites are redirected. Every existing article is `Pending` on schema apply — **every legacy article is immediately invisible to Civitai Green the moment the migration runs** (if the serving gates are deployed with the migration). `scanRequestedAt` defaults to `NULL` for legacy articles and gets populated as backfills run.
 
 ### Serving-path gate
 
@@ -134,22 +160,34 @@ export async function recomputeArticleIngestion(articleId: number): Promise<void
     ? 'Scanned'
     : 'Pending';
 
+  const now = new Date();
   await dbWrite.article.update({
     where: { id: articleId },
-    data: { ingestion: next },
+    data: {
+      ingestion: next,
+      // Set scannedAt only on the transition to Scanned, and only if not already set
+      // (mirrors Image.scannedAt logic — preserves original scan date on rescans)
+      ...(next === 'Scanned' ? { scannedAt: now } : {}),
+    },
   });
 }
 ```
 
 **Important edge case**: a brand-new article with no content images and text moderation pending is `imageDone=true` (no images to wait on) but `textDone=false`, so it correctly stays `Pending`. Don't let the `noImages` shortcut mark it Scanned.
 
-**Call sites for the helper**:
+**Call sites for `recomputeArticleIngestion`** (sets `ingestion` + `scannedAt`):
 
 - `src/pages/api/webhooks/image-scan-result.ts` — after each image scan result is processed (it already queries which articles the image belongs to for the debounce logic)
 - `src/pages/api/webhooks/text-moderation-result.ts` — inside the `Article` entity handler, after `recordEntityModerationSuccess`/`Failure`
 - `src/server/services/article.service.ts` upsert path — after `linkArticleContentImages` + `submitTextModeration` (handles the "new article with no images, text pending" base case — writes `ingestion: Pending` explicitly)
 - `src/pages/api/admin/temp/migrate-article-images.ts` — at the end of each processed article
 - `src/pages/api/admin/temp/migrate-article-text-moderation.ts` — **not** strictly needed because the text backfill just submits to xGuard; the webhook handler is what updates state when xGuard responds
+
+**Call sites for `scanRequestedAt`** (set once when scanning is first kicked off):
+
+- `src/server/services/article.service.ts` upsert path — set `scanRequestedAt = new Date()` alongside the `linkArticleContentImages` + `submitTextModeration` calls. This is the "we started scanning" timestamp. Covers both image-bearing and text-only articles because text moderation always fires.
+- `src/pages/api/admin/temp/migrate-article-images.ts` — set `scanRequestedAt` for each legacy article as it's processed by the backfill (if not already set).
+- `src/pages/api/admin/temp/migrate-article-text-moderation.ts` — set `scanRequestedAt` for text-only legacy articles that have no content images and were missed by the image backfill.
 
 ### Option B — Two booleans (rejected)
 
@@ -183,15 +221,17 @@ Recommend **Path 1** for this followup. The vestigial enum value can be removed 
 
 ## Legacy backfill story
 
-The migration with `@default(Pending)` is the key mechanism:
+> **2026-04-12 update**: Since Gap 1 is mitigated by running backfills from staging against prod DB before deploy, the ingestion column is no longer the *primary* safety gate for legacy content. However, the `ingestion` column + date fields still provide long-term value: filterability, observability, and a self-gating mechanism for any future backfill or re-scan scenario.
 
-1. **Schema apply** — every existing article becomes `ingestion = Pending`. Civitai Green instantly loses visibility of the entire legacy corpus. No staged flag flip required; the migration itself is the safety gate.
-2. **Image backfill runs** — for each article: extract media, create `ImageConnection` rows, kick off image scans. At the end of each article, call `recomputeArticleIngestion(id)`. Articles with no content media transition toward `Scanned` if text side is also done; articles with content media stay `Pending` until the async image scans complete.
-3. **Image scan webhooks** — as each content image completes scanning, the webhook calls `recomputeArticleIngestion(articleId)`. Articles whose last image just finished (and whose text is already Succeeded) flip to `Scanned` and become visible to Green.
-4. **Text backfill runs in parallel** — submits each article to xGuard. The webhook handler (already live on this branch) calls `recomputeArticleIngestion` after processing the xGuard response. Articles whose text just finished (and whose images are already done) flip to `Scanned`.
-5. **Articles light up for Green one at a time**, as each finishes *both* sides. No cliff-edge "all of prod becomes visible at once" moment.
+The migration adds `ingestion` (default `Pending`), `scanRequestedAt` (default `NULL`), and `scannedAt` (default `NULL`) to every existing article.
 
-Compare to the operational mitigation I originally recommended (staged flag flip): that mitigation requires two deploys and a manual wait-for-backfill step, and gives you a single cliff where Green becomes visible. The ingestion refactor gives you gradual, self-gated exposure with one deploy.
+**Backfill flow** (run from staging against prod DB before production deploy):
+
+1. **Image backfill runs** — for each article: extract media, create `ImageConnection` rows, kick off image scans, set `scanRequestedAt = NOW()`. At the end of each article, call `recomputeArticleIngestion(id)`. Articles with no content media transition toward `Scanned` if text side is also done; articles with content media stay `Pending` until the async image scans complete.
+2. **Image scan webhooks** — as each content image completes scanning, the webhook calls `recomputeArticleIngestion(articleId)`. When the last scan finishes (and text is already Succeeded), `ingestion` flips to `Scanned` and `scannedAt` is set.
+3. **Text backfill runs in parallel** — submits each article to xGuard, sets `scanRequestedAt` if not already set (covers text-only articles). The webhook handler calls `recomputeArticleIngestion` after processing the xGuard response.
+4. **Articles light up for Green one at a time**, as each finishes *both* sides. No cliff-edge "all of prod becomes visible at once" moment.
+5. **Production deploy** ships with `articles: ['public']`. Legacy corpus is already scanned and has correct `ingestion`, `scannedAt`, and `nsfwLevel` values.
 
 ---
 
@@ -211,15 +251,16 @@ Authors don't see a Processing dialog. They don't experience any UX regression f
 
 | Area | Files | Rough lines |
 |---|---|---|
-| Schema migration | `prisma/schema.full.prisma`, generated migration SQL | ~20 |
-| Helper function | `src/server/services/article.service.ts` | ~50 |
-| Webhook wiring | `image-scan-result.ts`, `text-moderation-result.ts` | ~15 |
+| Schema migration | `prisma/schema.full.prisma`, generated migration SQL | ~25 |
+| Helper function | `src/server/services/article.service.ts` | ~55 |
+| Webhook wiring | `image-scan-result.ts`, `text-moderation-result.ts` | ~20 |
 | Serving gates | ~6 read sites + Meilisearch index filter | ~50 |
 | Remove Processing from auto-publish | `article.service.ts` `updateArticleImageScanStatus` | ~15 |
-| Upsert path wiring | `article.service.ts` create + update branches | ~15 |
+| Upsert path wiring + `scanRequestedAt` | `article.service.ts` create + update branches | ~20 |
 | Re-scan path | `article.service.ts` upsert status-flip logic | ~10 |
-| Backfill wiring | `migrate-article-images.ts` | ~10 |
-| Tests | new tests for `recomputeArticleIngestion` transitions | ~150 |
+| Backfill wiring + `scanRequestedAt` | `migrate-article-images.ts` | ~20 |
+| Repurpose `contentScannedAt` writes | `article.service.ts` (old writes → `scanRequestedAt`, new writes via helper) | ~5 |
+| Tests | new tests for `recomputeArticleIngestion` transitions + date fields | ~170 |
 
 A few hundred lines across ~15 files + one DB migration. Doable in a session or two of focused work. The existing parity test from the current PR (`src/utils/__tests__/article-extraction-parity.test.ts`) is unaffected.
 
@@ -239,64 +280,66 @@ A few hundred lines across ~15 files + one DB migration. Doable in a session or 
 
 6. **Index choice** — `@@index([status, ingestion, nsfwLevel])` is one option. The actual best index depends on query patterns. Check `getArticles` query plans before committing to a specific shape; a partial index on `(ingestion, nsfwLevel) WHERE status = 'Published'` might be better if most Green queries also filter to Published.
 
+7. **`contentScannedAt` on rescan** — when an author edits a Published article and triggers a rescan, `recomputeArticleIngestion` will overwrite `contentScannedAt` when the new scan completes. The old timestamp is lost. If we need history, consider keeping the old value and only overwriting on Scanned transition (current implementation). This means `contentScannedAt` always reflects "last time all scans were green."
+
 ---
 
 ## Two paths forward
 
-### Path A — Ship this PR as-is with staged flag flip, ingestion refactor as immediate followup (recommended)
+> **2026-04-12 decision**: Path B was chosen — the ingestion refactor is absorbed into the scanning PR on `feature/scan-article-images`. One clean landing with `ingestion` + `scanRequestedAt` + repurposed `contentScannedAt` available from the start.
 
-1. On `feature/scan-article-images`: change `articles` flag from `['public']` to `['blue','red','public']` (pre-branch state, no Green exposure).
-2. Merge and deploy. Code goes live; new-article image scan + text moderation + webhook enforcement all activate. Green still doesn't see articles.
-3. Run image backfill to completion.
-4. Run text-moderation backfill to completion.
-5. Flip `articles` to `['public']` in a small followup deploy. Green gains access to the now-scanned legacy corpus.
-6. **Immediately start the ingestion refactor** as a separate PR using this doc. Merge before the next meaningful feature work on articles so the scan gate is in place for future changes.
+### Implementation (Path B — absorbed into this PR)
 
-**Pros**: minimal scope for current PR, rollout can proceed this week, ingestion refactor gets the attention it deserves in its own review.
-**Cons**: two deploys instead of one, manual "wait for backfill" step, brief Green-disabled window for Civitai Green users who would otherwise see articles.
-
-### Path B — Absorb the ingestion refactor into this PR
-
-1. On `feature/scan-article-images`: add the schema, helper, webhook wiring, serving gates, all the things.
-2. Merge and deploy. Migration applies → every legacy article becomes `Pending` → Green sees nothing immediately.
-3. Backfills run. Articles light up one at a time as they finish both scan sides.
-4. No staged flag flip required.
-
-**Pros**: one clean landing, self-gated rollout, closes both the legacy gap and the live async window in one shot.
-**Cons**: significantly larger PR surface area (several hundred lines + DB migration + serving-path changes across many files), higher risk of missing a read site, need to re-review everything, delays the merge.
-
-### Decision criteria
-
-The single most important data point for choosing: **how many legacy articles are in prod?**
-
-- **If the corpus is small** (~tens of thousands): Path A is obviously fine. The backfill drains fast, the brief Green-disabled window is negligible, and the ingestion refactor can be cleaned up later without pressure.
-- **If the corpus is large** (hundreds of thousands or millions): Path B pays for itself because the self-gating eliminates the "wait for backfill" dance and gives operators a much nicer rollout experience. The one-clean-landing argument also gets stronger because you don't want to ship a rushed ingestion refactor on top of a rollout that's still settling.
-
-Run this before deciding:
-
-```sql
-SELECT
-  COUNT(*) AS total_articles,
-  COUNT(*) FILTER (WHERE status = 'Published') AS published,
-  COUNT(*) FILTER (WHERE status = 'Published' AND content != '') AS published_with_content,
-  COUNT(*) FILTER (WHERE status = 'Published' AND "contentScannedAt" IS NULL) AS unscanned_published
-FROM "Article";
-```
+1. Schema migration adds `ArticleIngestionStatus` enum, `ingestion` (default `Pending`), `scanRequestedAt` columns, and composite index.
+2. `recomputeArticleIngestion` helper derives ingestion state from `ImageConnection` + `Image.ingestion` and `EntityModeration` ground truth.
+3. Helper is called from: image scan webhook (`updateArticleImageScanStatus`), text moderation webhook (success + failure), and backfill (`migrate-article-images.ts`).
+4. Upsert paths set `scanRequestedAt` + `ingestion: Pending` instead of the old premature `contentScannedAt` write.
+5. Serving gates (`ingestion = 'Scanned'`) added to: `getArticles`, `getArticleById`, `getCivitaiNews`, Meilisearch index, OG endpoint. Owners and mods bypass.
+6. Run backfills from staging against prod DB. Articles light up to `Scanned` as both scan sides complete.
+7. Deploy. New articles are gated by `ingestion = 'Scanned'` from day one.
 
 ---
 
 ## Next-session checklist
 
-When picking this up fresh:
+Implementation status (2026-04-12):
 
-- [ ] Run the corpus-size query above to confirm Path A vs Path B.
-- [ ] Confirm the historical Green state — did `articles: ['public']` on `main` already mean Green sees articles, or is this branch opening Green access for the first time? Check git blame on `src/server/services/feature-flags.service.ts` for the `articles` entry. If Green already sees articles on `main`, the whole "legacy exposure" framing is softer because the corpus is already exposed; the concern narrows to "new leaks *enabled* by the branch", which is different.
-- [ ] Re-read the 2026-04-10 decision in `~/.claude/projects/-Users-hackstreetboy-Projects-civitai/memory/project_article_text_scan_window.md`. Confirm that this proposal genuinely doesn't re-open it — specifically verify that the author-facing UX stays "instant publish" (Open Question 1 above).
-- [ ] Decide between Path A and Path B based on corpus size + team appetite for scope.
-- [ ] If Path A: make the flag change on the branch, add a note to §4 of `article-scanning-rollout.md` documenting the staged flag flip procedure, and create a followup ticket/branch for the ingestion refactor.
-- [ ] If Path B: start with the schema migration commit, then the helper + webhook wiring commit, then the serving-gates commit (with a careful grep sweep for every article read site), then the Processing-removal commit. Each commit independently reviewable and rollback-able.
-- [ ] Either path: the §5.6 parity test (`src/utils/__tests__/article-extraction-parity.test.ts`) and §5.2 stale `Succeeded` re-enforcement fix are still on the table from the original gotchas review. Those can land independently of this proposal.
-- [ ] Either path: re-examine the `contentScannedAt` naming. The rename-for-clarity discussion is still outstanding from the earlier session.
+- [x] **Path B chosen and implemented** — ingestion refactor absorbed into the scanning PR.
+- [x] Schema: `ArticleIngestionStatus` enum, `ingestion` + `scanRequestedAt` fields, composite index, migration SQL.
+- [x] `recomputeArticleIngestion` helper — derives state from `ImageConnection` + `EntityModeration` ground truth.
+- [x] Webhook wiring — image scan (`updateArticleImageScanStatus`) + text moderation (success + failure paths).
+- [x] Upsert paths — `scanRequestedAt` + `ingestion: Pending` replaces old `contentScannedAt` writes.
+- [x] Serving gates — `getArticles`, `getArticleById`, `getCivitaiNews`, Meilisearch index, OG endpoint.
+- [x] Backfill wiring — `migrate-article-images.ts` uses `scanRequestedAt` + calls `recomputeArticleIngestion`.
+
+Still open:
+
+- [ ] Confirm the historical Green state — did `articles: ['public']` on `main` already mean Green sees articles? Check git blame on `src/server/services/feature-flags.service.ts`.
+- [ ] The §5.6 parity test (`src/utils/__tests__/article-extraction-parity.test.ts`) and §5.2 stale `Succeeded` re-enforcement fix are still on the table from the original gotchas review.
+- [ ] `ArticleScanStatus` UI component — may need updating to read `ingestion` instead of (or in addition to) `status === Processing`.
+- [ ] Processing auto-publish notification — currently fires on Processing → Published; consider whether it should also fire on ingestion → Scanned transition, or be dropped.
+- [ ] Run `pnpm run typecheck` to verify all type references resolve.
+
+---
+
+## User-triggered rescan
+
+With `Article.ingestion` in place, we can give authors a "request rescan" action for their own articles. This is useful when:
+
+- An article is stuck in `Pending` or `Error` due to a transient scan pipeline issue.
+- The author edited their article but scanning didn't re-trigger (e.g., content hash dedupe blocked re-moderation after an xGuard recalibration).
+- A moderator restored an article from `UnpublishedViolation` and the author wants to confirm it scans clean.
+
+**Proposed UX**: a button in the article edit form (visible when `ingestion` is not `Scanned`) that:
+
+1. Resets `ingestion = Rescan`, clears `scannedAt` (keeps `scanRequestedAt` for history), and sets a new `scanRequestedAt`.
+2. Re-runs `linkArticleContentImages` to pick up any image changes.
+3. Re-submits text moderation to xGuard (requires clearing the `contentHash` on `EntityModeration` for this article so the dedupe check doesn't skip it).
+4. The normal webhook flow calls `recomputeArticleIngestion` as results come back.
+
+**Rate limiting**: cap at N rescans per article per 24h to prevent abuse. Store count in `ArticleMetadata` or a simple Redis key.
+
+**Scope**: this is a followup feature, not part of the initial ingestion refactor. But the ingestion column and date fields make it trivial to implement later — without them, there's no clean way to track "rescan requested" vs "never scanned" vs "scan complete".
 
 ---
 

--- a/prisma/migrations/20260412192356_add_article_ingestion_status/migration.sql
+++ b/prisma/migrations/20260412192356_add_article_ingestion_status/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "ArticleIngestionStatus" AS ENUM ('Pending', 'Scanned', 'Blocked', 'Error', 'Rescan');
+
+-- AlterTable
+ALTER TABLE "Article"
+  ADD COLUMN "ingestion" "ArticleIngestionStatus" NOT NULL DEFAULT 'Pending',
+  ADD COLUMN "scanRequestedAt" TIMESTAMP(3);
+
+-- CreateIndex
+-- When running in production remember to use CONCURRENTLY to avoid locking the table for a long time
+CREATE INDEX "Article_status_ingestion_nsfwLevel_idx"
+  ON "Article" ("status", "ingestion", "nsfwLevel");

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2490,6 +2490,14 @@ enum ArticleStatus {
   Processing
 }
 
+enum ArticleIngestionStatus {
+  Pending
+  Scanned
+  Blocked
+  Error
+  Rescan
+}
+
 model Article {
   id               Int           @id @default(autoincrement())
   createdAt        DateTime?     @default(now())
@@ -2503,7 +2511,9 @@ model Article {
   coverId          Int?          @unique
   coverImage       Image?        @relation(fields: [coverId], references: [id], onDelete: SetNull)
   publishedAt      DateTime?
-  contentScannedAt DateTime?     // Last time article content was scanned for embedded images
+  contentScannedAt DateTime?              // Set when both image + text scans complete successfully
+  ingestion        ArticleIngestionStatus @default(Pending)
+  scanRequestedAt  DateTime?
   userId           Int
   user             User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   availability     Availability  @default(Public)
@@ -2523,6 +2533,8 @@ model Article {
   engagements     ArticleEngagement[]
   associations    ModelAssociations[]
   collectionItems CollectionItem[]
+
+  @@index([status, ingestion, nsfwLevel])
 }
 
 model PressMention {

--- a/src/components/Article/ArticleContextMenu.tsx
+++ b/src/components/Article/ArticleContextMenu.tsx
@@ -269,7 +269,7 @@ export function ArticleContextMenu({ article, ...props }: Props) {
             >
               Edit
             </Menu.Item>
-            {atDetailsPage && (
+            {atDetailsPage && features.articleImageScanning && (
               <Menu.Item
                 leftSection={
                   isRescanning ? <Loader size={14} /> : <IconRadar2 size={14} stroke={1.5} />

--- a/src/components/Article/ArticleContextMenu.tsx
+++ b/src/components/Article/ArticleContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   IconDotsVertical,
   IconFlag,
   IconPencil,
+  IconRadar2,
   IconRecycle,
   IconTrash,
 } from '@tabler/icons-react';
@@ -27,6 +28,7 @@ import { ToggleLockComments } from '../CommentsV2/ToggleLockComments';
 import { IconLock } from '@tabler/icons-react';
 import { ToggleSearchableMenuItem } from '../MenuItems/ToggleSearchableMenuItem';
 import { AddArtFrameMenuItem } from '~/components/Decorations/AddArtFrameMenuItem';
+import { useRescanArticle } from '~/hooks/useRescanArticle';
 import type { ArticleGetById } from '~/types/router';
 import { openAddToCollectionModal } from '~/components/Dialog/triggers/add-to-collection';
 import { openReportModal } from '~/components/Dialog/triggers/report';
@@ -52,6 +54,8 @@ export function ArticleContextMenu({ article, ...props }: Props) {
     ((atDetailsPage && article.status === ArticleStatus.Unpublished) ||
       article.status === ArticleStatus.UnpublishedViolation);
   const features = useFeatureFlags();
+
+  const { rescan: handleRescanArticle, isLoading: isRescanning } = useRescanArticle();
 
   const deleteArticleMutation = trpc.article.delete.useMutation();
   const handleDeleteArticle = () => {
@@ -265,6 +269,22 @@ export function ArticleContextMenu({ article, ...props }: Props) {
             >
               Edit
             </Menu.Item>
+            {atDetailsPage && (
+              <Menu.Item
+                leftSection={
+                  isRescanning ? <Loader size={14} /> : <IconRadar2 size={14} stroke={1.5} />
+                }
+                onClick={(e: React.MouseEvent) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleRescanArticle(article.id);
+                }}
+                disabled={isRescanning}
+                closeMenuOnClick={false}
+              >
+                Rescan
+              </Menu.Item>
+            )}
             {isModerator && (
               <ToggleLockComments entityId={article.id} entityType="article">
                 {({ toggle, locked, isLoading }) => {

--- a/src/components/Article/ArticleScanStatus.tsx
+++ b/src/components/Article/ArticleScanStatus.tsx
@@ -4,13 +4,15 @@
  * Displays real-time scanning progress for article content images with modern UI
  */
 
-import { Alert, Text, Group, Stack, Badge, Loader, Paper } from '@mantine/core';
-import { IconAlertCircle, IconCheck, IconShield } from '@tabler/icons-react';
+import { Alert, Button, Text, Group, Stack, Badge, Loader, Paper } from '@mantine/core';
+import { IconAlertCircle, IconCheck, IconRadar2, IconShield } from '@tabler/icons-react';
 import { useArticleScanStatus } from '~/hooks/useArticleScanStatus';
 import { useEffect } from 'react';
 import clsx from 'clsx';
 import { ArticleProblematicImages } from './ArticleProblematicImages';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useRescanArticle } from '~/hooks/useRescanArticle';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 interface ArticleScanStatusProps {
   articleId: number;
@@ -19,6 +21,8 @@ interface ArticleScanStatusProps {
 
 export function ArticleScanStatus({ articleId, onComplete }: ArticleScanStatusProps) {
   const features = useFeatureFlags();
+  const currentUser = useCurrentUser();
+  const { rescan: handleRescan, isLoading: isRescanning } = useRescanArticle();
   const { status, isLoading, error, isComplete, hasImages, progress } = useArticleScanStatus({
     articleId,
   });
@@ -72,6 +76,18 @@ export function ArticleScanStatus({ articleId, onComplete }: ArticleScanStatusPr
             blockedImages={status.images?.blocked || []}
             errorImages={status.images?.error || []}
           />
+          {currentUser && (
+            <Button
+              leftSection={<IconRadar2 size={16} />}
+              variant="light"
+              color="blue"
+              size="sm"
+              loading={isRescanning}
+              onClick={() => handleRescan(articleId)}
+            >
+              Rescan Article
+            </Button>
+          )}
         </Stack>
       );
     }

--- a/src/hooks/useRescanArticle.ts
+++ b/src/hooks/useRescanArticle.ts
@@ -1,0 +1,25 @@
+import { trpc } from '~/utils/trpc';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+
+export function useRescanArticle() {
+  const queryUtils = trpc.useUtils();
+
+  const { mutateAsync, isLoading } = trpc.article.rescan.useMutation({
+    async onSuccess(_data, variables) {
+      showSuccessNotification({ message: 'Article sent for rescan' });
+      await queryUtils.article.getScanStatus.invalidate({ id: variables.id });
+      await queryUtils.article.getById.invalidate({ id: variables.id });
+    },
+    onError(error) {
+      showErrorNotification({
+        error: new Error(error.message),
+        title: 'Could not rescan article',
+      });
+    },
+  });
+
+  return {
+    rescan: (articleId: number) => mutateAsync({ id: articleId }),
+    isLoading,
+  };
+}

--- a/src/pages/api/admin/temp/migrate-article-images.ts
+++ b/src/pages/api/admin/temp/migrate-article-images.ts
@@ -7,8 +7,9 @@ import { createLogger } from '~/utils/logging';
 import { booleanString } from '~/utils/zod-helpers';
 import { getContentMedia } from '~/server/services/article-content-cleanup.service';
 import type { ExtractedMedia } from '~/utils/article-helpers';
-import { ImageIngestionStatus } from '~/shared/utils/prisma/enums';
+import { ArticleIngestionStatus, ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { ImageConnectionType } from '~/server/common/enums';
+import { recomputeArticleIngestion } from '~/server/services/article.service';
 
 const log = createLogger('migrate-article-images', 'blue');
 
@@ -234,12 +235,22 @@ async function runImageScan(
               if (processedArticleIds.length > 0) {
                 await tx.article.updateMany({
                   where: { id: { in: processedArticleIds } },
-                  data: { contentScannedAt: new Date() },
+                  data: { scanRequestedAt: new Date() },
                 });
               }
             },
             { timeout: 60000, maxWait: 10000 }
           );
+
+          // Recompute ingestion status for each processed article
+          for (const articleId of articleMediaMap.keys()) {
+            try {
+              await recomputeArticleIngestion(articleId);
+            } catch (error) {
+              const msg = error instanceof Error ? error.message : 'Unknown error';
+              log(`⚠️  recomputeArticleIngestion failed for article ${articleId}: ${msg}`);
+            }
+          }
 
           log(
             `  Transaction complete: ${stats.imagesCreated} images, ${stats.connectionsCreated} connections`
@@ -251,23 +262,33 @@ async function runImageScan(
         }
       }
 
-      // Mark articles without images as scanned (exclude extraction failures so they can be retried)
+      // Mark articles without images and recompute their ingestion status
       const articlesWithoutImages = articleBatch.filter(
         (article) => !articleMediaMap.has(article.id) && !failedArticleIds.has(article.id)
       );
       if (articlesWithoutImages.length > 0) {
-        await dbWrite.article
-          .updateMany({
-            where: { id: { in: articlesWithoutImages.map((a) => a.id) } },
-            data: { contentScannedAt: new Date() },
-          })
-          .catch((error) => {
-            log(
-              `⚠️  Failed to mark ${articlesWithoutImages.length} articles: ${
-                error instanceof Error ? error.message : 'Unknown error'
-              }`
-            );
+        const ids = articlesWithoutImages.map((a) => a.id);
+        try {
+          await dbWrite.article.updateMany({
+            where: { id: { in: ids } },
+            data: { scanRequestedAt: new Date() },
           });
+        } catch (error) {
+          log(
+            `⚠️  Failed to mark ${articlesWithoutImages.length} articles: ${
+              error instanceof Error ? error.message : 'Unknown error'
+            }`
+          );
+        }
+
+        for (const articleId of ids) {
+          try {
+            await recomputeArticleIngestion(articleId);
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : 'Unknown error';
+            log(`⚠️  recomputeArticleIngestion failed for article ${articleId}: ${msg}`);
+          }
+        }
       }
 
       log(`[images] Batch complete (${Date.now() - batchStart}ms)`);

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { dbRead } from '~/server/db/client';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { getIsSafeBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
+import { ArticleIngestionStatus } from '~/shared/utils/prisma/enums';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { removeTags } from '~/utils/string-helpers';
@@ -181,7 +182,12 @@ async function fetchModelData(id: number): Promise<EntityData | null> {
 async function fetchArticleData(id: number): Promise<EntityData | null> {
   const [article, metric] = await Promise.all([
     dbRead.article.findFirst({
-      where: { id, publishedAt: { not: null }, tosViolation: false },
+      where: {
+        id,
+        publishedAt: { not: null },
+        tosViolation: false,
+        ingestion: ArticleIngestionStatus.Scanned,
+      },
       select: {
         title: true,
         content: true,

--- a/src/pages/api/webhooks/text-moderation-result.ts
+++ b/src/pages/api/webhooks/text-moderation-result.ts
@@ -10,6 +10,7 @@ import { dbWrite } from '~/server/db/client';
 import { NotificationCategory } from '~/server/common/enums';
 import { createNotification } from '~/server/services/notification.service';
 import { updateArticleNsfwLevels } from '~/server/services/nsfwLevels.service';
+import { recomputeArticleIngestion } from '~/server/services/article.service';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { ArticleStatus, EntityModerationStatus } from '~/shared/utils/prisma/enums';
 
@@ -62,6 +63,9 @@ const entityHandlers: Record<string, (result: TextModerationResult) => Promise<v
         });
       }
     }
+
+    // Recompute article ingestion status after text moderation result
+    await recomputeArticleIngestion(entityId);
   },
 };
 
@@ -156,6 +160,11 @@ export default WebhookEndpoint(async (req, res) => {
           entityType,
           entityId,
         });
+
+        // Recompute article ingestion status on text moderation failure
+        if (entityType === 'Article') {
+          await recomputeArticleIngestion(entityId);
+        }
         break;
       }
       default: {

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -58,7 +58,12 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { constants } from '~/server/common/constants';
 import { unpublishReasons, type UnpublishReason } from '~/server/common/moderation-helpers';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
-import { ArticleEngagementType, ArticleStatus, Availability } from '~/shared/utils/prisma/enums';
+import {
+  ArticleEngagementType,
+  ArticleIngestionStatus,
+  ArticleStatus,
+  Availability,
+} from '~/shared/utils/prisma/enums';
 import { formatDate } from '~/utils/date-helpers';
 import { showErrorNotification } from '~/utils/notifications';
 import { abbreviateNumber } from '~/utils/number-helpers';
@@ -354,12 +359,14 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
                 </div>
               </AlertWithIcon>
             )}
-            {article.status === ArticleStatus.Processing && isOwner && (
-              <ArticleScanStatus
-                articleId={article.id}
-                onComplete={() => queryUtils.article.getById.invalidate({ id: article.id })}
-              />
-            )}
+            {isOwner &&
+              article.ingestion &&
+              article.ingestion !== ArticleIngestionStatus.Scanned && (
+                <ArticleScanStatus
+                  articleId={article.id}
+                  onComplete={() => queryUtils.article.getById.invalidate({ id: article.id })}
+                />
+              )}
           </Stack>
           <ContainerGrid2 gutter="xl">
             <ContainerGrid2.Col span={{ base: 12, sm: 8 }}>

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -943,6 +943,7 @@ export const REDIS_KEYS = {
   },
   ARTICLE: {
     SCAN_UPDATE: 'article:scan-update',
+    RESCAN: 'article:rescan',
   },
 } as const;
 

--- a/src/server/routers/article.router.ts
+++ b/src/server/routers/article.router.ts
@@ -23,6 +23,7 @@ import {
   getCivitaiEvents,
   getCivitaiNews,
   getDraftArticlesByUserId,
+  rescanArticle,
 } from '~/server/services/article.service';
 import {
   unpublishArticleHandler,
@@ -101,6 +102,11 @@ export const articleRouter = router({
     .use(isFlagProtected('articles'))
     .use(isModerator)
     .mutation(restoreArticleHandler),
+  rescan: protectedProcedure
+    .input(getByIdSchema)
+    .use(isFlagProtected('articleImageScanning'))
+    .use(isOwnerOrModerator)
+    .mutation(({ input, ctx }) => rescanArticle({ ...input, isModerator: ctx.user.isModerator })),
   getScanStatus: publicProcedure
     .input(getByIdSchema)
     .use(isFlagProtected('articleImageScanning'))

--- a/src/server/search-index/articles.search-index.ts
+++ b/src/server/search-index/articles.search-index.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 import { searchClient as client, updateDocs } from '~/server/meilisearch/client';
 import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
-import { ArticleStatus, Availability } from '~/shared/utils/prisma/enums';
+import { ArticleIngestionStatus, ArticleStatus, Availability } from '~/shared/utils/prisma/enums';
 import { articleDetailSelect } from '~/server/selectors/article.selector';
 import { ARTICLES_SEARCH_INDEX } from '~/server/common/constants';
 import { isDefined } from '~/utils/type-guards';
@@ -173,6 +173,7 @@ export const articlesSearchIndex = createSearchIndexUpdateProcessor({
       where: {
         publishedAt: { not: null },
         status: ArticleStatus.Published,
+        ingestion: ArticleIngestionStatus.Scanned,
         tosViolation: false,
         availability: { not: Availability.Unsearchable },
         id: batch.type === 'update' ? { in: batch.ids } : { gte: batch.startId, lte: batch.endId },

--- a/src/server/selectors/article.selector.ts
+++ b/src/server/selectors/article.selector.ts
@@ -37,6 +37,7 @@ export const articleDetailSelect = Prisma.validator<Prisma.ArticleSelect>()({
       collectedCountAllTime: true,
     },
   },
+  ingestion: true,
   availability: true,
   userId: true,
   coverImage: { select: imageSelect },

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -1080,10 +1080,11 @@ export const upsertArticle = async ({
           }
 
           if (scanContent) {
-            // Mark scan as requested after successfully linking images
+            // Content changed and images need re-scanning — use Rescan to distinguish
+            // user-edit-triggered rescans from initial pending scans.
             await dbWrite.article.update({
               where: { id },
-              data: { scanRequestedAt: new Date(), ingestion: ArticleIngestionStatus.Pending },
+              data: { scanRequestedAt: new Date(), ingestion: ArticleIngestionStatus.Rescan },
             });
           }
         } catch (e) {
@@ -1827,11 +1828,21 @@ export async function recomputeArticleIngestion(articleId: number): Promise<void
         next = ArticleIngestionStatus.Pending;
       }
 
+      // Only set contentScannedAt on the *transition* to Scanned (not if already Scanned)
+      // to preserve the original scan-completion timestamp for observability.
+      const current = await tx.article.findUniqueOrThrow({
+        where: { id: articleId },
+        select: { ingestion: true },
+      });
+
       await tx.article.update({
         where: { id: articleId },
         data: {
           ingestion: next,
-          ...(next === ArticleIngestionStatus.Scanned ? { contentScannedAt: new Date() } : {}),
+          ...(next === ArticleIngestionStatus.Scanned &&
+          current.ingestion !== ArticleIngestionStatus.Scanned
+            ? { contentScannedAt: new Date() }
+            : {}),
         },
       });
     },
@@ -1851,7 +1862,7 @@ const RESCAN_WINDOW_SECONDS = CacheTTL.day; // 24 hours
 /**
  * Rescan an article: re-queue all content images and re-submit text moderation.
  *
- * Resets ingestion to Pending, clears contentScannedAt, and lets the normal
+ * Resets ingestion to Rescan, clears contentScannedAt, and lets the normal
  * webhook flow (image scan + text moderation) drive the article back to a
  * terminal ingestion state via recomputeArticleIngestion.
  */
@@ -1885,11 +1896,16 @@ export async function rescanArticle({
   await dbWrite.article.update({
     where: { id },
     data: {
-      ingestion: ArticleIngestionStatus.Pending,
+      ingestion: ArticleIngestionStatus.Rescan,
       scanRequestedAt: new Date(),
       contentScannedAt: null,
     },
   });
+
+  // Remove from search index immediately — article should not be searchable while rescanning.
+  await articlesSearchIndex.queueUpdate([
+    { id, action: SearchIndexUpdateQueueAction.Update },
+  ]);
 
   // --- Re-link content images (picks up new images, queues Pending ones) ---
   if (article.content) {

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -9,6 +9,8 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { eventEngine } from '~/server/events';
 import { userArticleCountCache, articleStatCache } from '~/server/redis/caches';
 import { logToAxiom } from '~/server/logging/client';
+import { REDIS_KEYS, redis } from '~/server/redis/client';
+import { CacheTTL } from '~/server/common/constants';
 import type {
   ArticleMetadata,
   GetInfiniteArticlesSchema,
@@ -52,8 +54,10 @@ import { getPagination, getPagingData } from '~/server/utils/pagination-helpers'
 import type { CosmeticSource, CosmeticType } from '~/shared/utils/prisma/enums';
 import {
   ArticleEngagementType,
+  ArticleIngestionStatus,
   ArticleStatus,
   Availability,
+  EntityModerationStatus,
   ImageIngestionStatus,
   MetricTimeframe,
   TagTarget,
@@ -255,6 +259,13 @@ export const getArticles = async ({
     if (!isOwnerRequest) {
       if (!isMod) {
         AND.push(Prisma.sql`a."status" = ${ArticleStatus.Published}::"ArticleStatus"`);
+        if (userId) {
+          AND.push(
+            Prisma.sql`(a."ingestion" = 'Scanned'::"ArticleIngestionStatus" OR a."userId" = ${userId})`
+          );
+        } else {
+          AND.push(Prisma.sql`a."ingestion" = 'Scanned'::"ArticleIngestionStatus"`);
+        }
       }
       if (!!excludedUserIds?.length) {
         AND.push(Prisma.sql`a."userId" NOT IN (${Prisma.join(excludedUserIds, ',')})`);
@@ -565,6 +576,7 @@ export const getCivitaiNews = async () => {
     JOIN "Collection" c ON c.id = ci."collectionId"
     WHERE c.name IN ('Newsroom', 'Updates') AND c."userId" = -1 AND a."createdAt" > now() - '1 year'::interval
       AND a."publishedAt" IS NOT NULL AND a.status = 'Published'::"ArticleStatus"
+      AND a."ingestion" = 'Scanned'::"ArticleIngestionStatus"
       AND (a."nsfwLevel" & ${publicBrowsingLevelsFlag}) != 0
     ORDER BY a."createdAt" DESC
     LIMIT 10
@@ -637,7 +649,14 @@ export const getArticleById = async ({
       where: {
         id,
         OR: !isModerator
-          ? [{ publishedAt: { not: null }, status: ArticleStatus.Published }, { userId }]
+          ? [
+              {
+                publishedAt: { not: null },
+                status: ArticleStatus.Published,
+                ingestion: ArticleIngestionStatus.Scanned,
+              },
+              { userId },
+            ]
           : undefined,
       },
       select: articleDetailSelect,
@@ -853,10 +872,10 @@ export const upsertArticle = async ({
             coverId: result.coverId,
           });
 
-          // Mark article as scanned after successfully linking images
+          // Mark scan as requested after successfully linking images
           await dbWrite.article.update({
             where: { id: result.id },
-            data: { contentScannedAt: new Date() },
+            data: { scanRequestedAt: new Date(), ingestion: ArticleIngestionStatus.Pending },
           });
         } catch (e) {
           // Non-blocking: continue even if image linking fails, but log the error
@@ -1061,10 +1080,10 @@ export const upsertArticle = async ({
           }
 
           if (scanContent) {
-            // Mark article as scanned after successfully linking images
+            // Mark scan as requested after successfully linking images
             await dbWrite.article.update({
               where: { id },
-              data: { contentScannedAt: new Date() },
+              data: { scanRequestedAt: new Date(), ingestion: ArticleIngestionStatus.Pending },
             });
           }
         } catch (e) {
@@ -1733,5 +1752,212 @@ export async function updateArticleImageScanStatus(articleIds: number[]): Promis
       },
       { timeout: 30000, maxWait: 10000 }
     );
+
+    // Recompute article ingestion status after image scan processing
+    await recomputeArticleIngestion(articleId);
   }
+}
+
+/**
+ * Recompute Article.ingestion from ground truth (Image.ingestion + EntityModeration).
+ *
+ * This is the single source of truth for article ingestion state. Call it after:
+ * - Image scan webhooks (via updateArticleImageScanStatus)
+ * - Text moderation webhooks (success or failure)
+ * - Article upsert (to lock in Pending state)
+ * - Backfill completion per article
+ *
+ * Sets contentScannedAt when ingestion transitions to Scanned.
+ */
+export async function recomputeArticleIngestion(articleId: number): Promise<void> {
+  await dbWrite.$transaction(
+    async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${articleId})`;
+
+      // --- Image side ---
+      const connections = await tx.imageConnection.findMany({
+        where: { entityId: articleId, entityType: ImageConnectionType.Article },
+        include: { image: { select: { ingestion: true } } },
+      });
+
+      const totalImages = connections.length;
+      const scannedImages = connections.filter(
+        (c) => c.image.ingestion === ImageIngestionStatus.Scanned
+      ).length;
+      const blockedImages = connections.filter(
+        (c) => c.image.ingestion === ImageIngestionStatus.Blocked
+      ).length;
+      const errorImages = connections.filter(
+        (c) =>
+          c.image.ingestion === ImageIngestionStatus.Error ||
+          c.image.ingestion === ImageIngestionStatus.NotFound
+      ).length;
+
+      const imageBlocked = blockedImages > 0;
+      const imageError = errorImages > 0;
+      const imageDone =
+        totalImages === 0 || scannedImages + blockedImages + errorImages === totalImages;
+
+      // --- Text moderation side ---
+      const textModeration = await tx.entityModeration.findUnique({
+        where: { entityType_entityId: { entityType: 'Article', entityId: articleId } },
+        select: { status: true, blocked: true },
+      });
+
+      const textBlocked =
+        textModeration?.status === EntityModerationStatus.Succeeded &&
+        textModeration.blocked === true;
+      const textErrorStatuses: string[] = [
+        EntityModerationStatus.Failed,
+        EntityModerationStatus.Expired,
+        EntityModerationStatus.Canceled,
+      ];
+      const textError = !!textModeration && textErrorStatuses.includes(textModeration.status);
+      const textDone = textModeration?.status === EntityModerationStatus.Succeeded;
+
+      // --- Derive ingestion state ---
+      let next: ArticleIngestionStatus;
+      if (imageBlocked || textBlocked) {
+        next = ArticleIngestionStatus.Blocked;
+      } else if (imageError || textError) {
+        next = ArticleIngestionStatus.Error;
+      } else if (imageDone && textDone) {
+        next = ArticleIngestionStatus.Scanned;
+      } else {
+        next = ArticleIngestionStatus.Pending;
+      }
+
+      await tx.article.update({
+        where: { id: articleId },
+        data: {
+          ingestion: next,
+          ...(next === ArticleIngestionStatus.Scanned ? { contentScannedAt: new Date() } : {}),
+        },
+      });
+    },
+    { timeout: 30000, maxWait: 10000 }
+  );
+
+  // Sync search index — the index filters on ingestion = 'Scanned', so any
+  // ingestion state change must be reflected (add when Scanned, remove otherwise).
+  await articlesSearchIndex.queueUpdate([
+    { id: articleId, action: SearchIndexUpdateQueueAction.Update },
+  ]);
+}
+
+const RESCAN_LIMIT = 3;
+const RESCAN_WINDOW_SECONDS = CacheTTL.day; // 24 hours
+
+/**
+ * Rescan an article: re-queue all content images and re-submit text moderation.
+ *
+ * Resets ingestion to Pending, clears contentScannedAt, and lets the normal
+ * webhook flow (image scan + text moderation) drive the article back to a
+ * terminal ingestion state via recomputeArticleIngestion.
+ */
+export async function rescanArticle({
+  id,
+  isModerator,
+}: GetByIdInput & { isModerator?: boolean }): Promise<void> {
+  // --- Rate limit (owners only, mods bypass) ---
+  const cacheKey = `${REDIS_KEYS.ARTICLE.RESCAN}:${id}` as const;
+  if (!isModerator) {
+    const attempts = (await redis.packed.get<number[]>(cacheKey)) ?? [];
+    const cutoff = Date.now() - RESCAN_WINDOW_SECONDS * 1000;
+    const recentAttempts = attempts.filter((t) => t > cutoff);
+
+    if (recentAttempts.length >= RESCAN_LIMIT) {
+      throw new TRPCError({
+        code: 'TOO_MANY_REQUESTS',
+        message: `This article can only be rescanned ${RESCAN_LIMIT} times per day. Please try again later.`,
+      });
+    }
+  }
+
+  // --- Fetch article ---
+  const article = await dbRead.article.findUnique({
+    where: { id },
+    select: { id: true, userId: true, content: true, title: true, coverId: true },
+  });
+  if (!article) throw throwNotFoundError(`No article with id ${id}`);
+
+  // --- Reset ingestion state ---
+  await dbWrite.article.update({
+    where: { id },
+    data: {
+      ingestion: ArticleIngestionStatus.Pending,
+      scanRequestedAt: new Date(),
+      contentScannedAt: null,
+    },
+  });
+
+  // --- Re-link content images (picks up new images, queues Pending ones) ---
+  if (article.content) {
+    await linkArticleContentImages({
+      articleId: id,
+      content: article.content,
+      userId: article.userId,
+      coverId: article.coverId,
+    });
+  }
+
+  // --- Re-queue already-processed images for rescan ---
+  const connections = await dbRead.imageConnection.findMany({
+    where: { entityId: id, entityType: ImageConnectionType.Article },
+    include: { image: { select: { id: true, url: true, ingestion: true } } },
+  });
+
+  for (const conn of connections) {
+    if (conn.image.ingestion === ImageIngestionStatus.Pending) continue;
+    await ingestImage({ image: conn.image, lowPriority: true, userId: article.userId }).catch(
+      (err) => {
+        handleLogError(err, 'article-rescan-image', { articleId: id, imageId: conn.image.id });
+      }
+    );
+  }
+
+  // --- Clear content hash and re-submit text moderation ---
+  await dbWrite.entityModeration.updateMany({
+    where: { entityType: 'Article', entityId: id },
+    data: { contentHash: null },
+  });
+
+  if (article.content) {
+    const textForModeration = [article.title, removeTags(article.content)]
+      .filter(Boolean)
+      .join(' ');
+
+    await submitTextModeration({
+      entityType: 'Article',
+      entityId: id,
+      content: textForModeration,
+      labels: ['nsfw'],
+    }).catch((e) => {
+      logToAxiom({
+        type: 'error',
+        name: 'article-rescan-text-moderation',
+        message: (e as Error).message,
+        articleId: id,
+      }).catch();
+    });
+  }
+
+  // --- Record rate limit attempt ---
+  const attempts = (await redis.packed.get<number[]>(cacheKey)) ?? [];
+  attempts.push(Date.now());
+  const cutoff = Date.now() - RESCAN_WINDOW_SECONDS * 1000;
+  await redis.packed.set(
+    cacheKey,
+    attempts.filter((t) => t > cutoff)
+  );
+  await redis.expire(cacheKey, RESCAN_WINDOW_SECONDS);
+
+  // --- Log for observability ---
+  logToAxiom({
+    type: 'info',
+    name: 'article-rescan',
+    articleId: id,
+    imageCount: connections.length,
+    isModerator,
+  }).catch();
 }

--- a/src/shared/utils/prisma/enums.ts
+++ b/src/shared/utils/prisma/enums.ts
@@ -521,6 +521,16 @@ export const ArticleStatus = {
 
 export type ArticleStatus = (typeof ArticleStatus)[keyof typeof ArticleStatus];
 
+export const ArticleIngestionStatus = {
+  Pending: 'Pending',
+  Scanned: 'Scanned',
+  Blocked: 'Blocked',
+  Error: 'Error',
+  Rescan: 'Rescan',
+} as const;
+
+export type ArticleIngestionStatus = (typeof ArticleIngestionStatus)[keyof typeof ArticleIngestionStatus];
+
 export const ArticleEngagementType = {
   Favorite: 'Favorite',
   Hide: 'Hide',

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -108,6 +108,8 @@ export type BuzzAccountType = "user" | "generation" | "club" | "green" | "fakere
 
 export type ArticleStatus = "Draft" | "Published" | "Unpublished" | "UnpublishedViolation" | "Processing";
 
+export type ArticleIngestionStatus = "Pending" | "Scanned" | "Blocked" | "Error" | "Rescan";
+
 export type ArticleEngagementType = "Favorite" | "Hide";
 
 export type GenerationSchedulers = "EulerA" | "Euler" | "LMS" | "Heun" | "DPM2" | "DPM2A" | "DPM2SA" | "DPM2M" | "DPMSDE" | "DPMFast" | "DPMAdaptive" | "LMSKarras" | "DPM2Karras" | "DPM2AKarras" | "DPM2SAKarras" | "DPM2MKarras" | "DPMSDEKarras" | "DDIM";
@@ -1964,6 +1966,8 @@ export interface Article {
   coverImage?: Image | null;
   publishedAt: Date | null;
   contentScannedAt: Date | null;
+  ingestion: ArticleIngestionStatus;
+  scanRequestedAt: Date | null;
   userId: number;
   user?: User;
   availability: Availability;


### PR DESCRIPTION
## Summary
- Adds `ArticleIngestionStatus` enum (`Pending`/`Scanned`/`Blocked`/`Error`) with DB migration, gating non-owner/non-mod article visibility on `ingestion = Scanned`
- Implements user-triggered article rescan: re-queues all content images and re-submits text moderation, with per-article rate limiting (3/day for owners, mods bypass)
- Syncs search index on ingestion state changes via `recomputeArticleIngestion`

## Changes

### Ingestion status infrastructure
- New `Article.ingestion` column + migration (`20260412192356`)
- Serving-path gates in `getArticles`, `getArticleById`, `getCivitaiNews`, OG image, and Meilisearch index
- Text moderation webhook calls `recomputeArticleIngestion` on success/failure
- `recomputeArticleIngestion` now triggers `articlesSearchIndex.queueUpdate` after state transitions

### Manual rescan feature
- `rescanArticle()` service function: resets ingestion to Pending, re-links content images, re-queues already-processed images with `lowPriority`, clears `EntityModeration.contentHash` and re-submits to xGuard
- `article.rescan` tRPC mutation with `isOwnerOrModerator` middleware + `articleImageScanning` feature flag
- `useRescanArticle` hook with cache invalidation (restarts scan status polling)
- "Rescan" menu item in `ArticleContextMenu` (detail page, owner/mod only)
- "Rescan Article" button in `ArticleScanStatus` when images have errors/blocks
- Scan status component now shows for any non-Scanned ingestion state (not just Processing status)

## Test plan
- [ ] Verify article detail page shows "Rescan" in context menu for owners and moderators
- [ ] Trigger rescan and confirm success notification, scan status component appears with progress
- [ ] Verify rate limiting: 4th rescan within 24h as owner returns error
- [ ] Verify moderators bypass rate limit
- [ ] Confirm non-owner/non-mod users cannot see or trigger rescan
- [ ] Verify blocked/error state shows "Rescan Article" button in scan status component
- [ ] Confirm search index updates when ingestion state changes (article appears/disappears from search)
- [ ] Run `pnpm run typecheck` to verify type correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)