### PR TITLE
Fix #2085: [Usability]: Limited access to generation data (prompts) f...

### DIFF
--- a/src/components/Profile/Sections/ShowcaseSection.tsx
+++ b/src/components/Profile/Sections/ShowcaseSection.tsx
@@ -1,6 +1,8 @@
 import type { ProfileSectionProps } from '~/components/Profile/ProfileSection';
 import { ProfileSection, ProfileSectionPreview } from '~/components/Profile/ProfileSection';
-import { IconHeart } from '@tabler/icons-react';
+import { IconArrowRight, IconHeart } from '@tabler/icons-react';
+import { Button, Text } from '@mantine/core';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
 import React, { useMemo } from 'react';
 import type { ShowcaseItemSchema } from '~/server/schema/user-profile.schema';
 import { trpc } from '~/utils/trpc';
@@ -63,7 +65,22 @@ export const ShowcaseSection = ({ user }: ProfileSectionProps) => {
         (isLoading ? (
           <ProfileSectionPreview rowCount={2} />
         ) : (
-          <ProfileSection title="Showcase" icon={<IconHeart />}>
+          <ProfileSection
+            title="Showcase"
+            icon={<IconHeart />}
+            action={
+              <Link legacyBehavior href={`/user/${user.username}/images`} passHref>
+                <Button
+                  h={34}
+                  component="a"
+                  variant="subtle"
+                  rightSection={<IconArrowRight size={16} />}
+                >
+                  <Text inherit>View all</Text>
+                </Button>
+              </Link>
+            }
+          >
             <ShowcaseGrid
               itemCount={showcaseItems.length}
               rows={2}

--- a/src/components/Profile/ShowcaseItemsInput.tsx
+++ b/src/components/Profile/ShowcaseItemsInput.tsx
@@ -1,12 +1,13 @@
 import type { InputWrapperProps } from '@mantine/core';
-import { Box, Button, Center, Input, Loader, Paper, Stack, Text } from '@mantine/core';
+import { ActionIcon, Box, Button, Center, Input, Loader, Paper, Stack, Text } from '@mantine/core';
 import React, { useMemo, useState } from 'react';
 import { useDidUpdate } from '@mantine/hooks';
 import type { ShowcaseItemSchema } from '~/server/schema/user-profile.schema';
 import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
 import { trpc } from '~/utils/trpc';
 import { GenericImageCard } from '~/components/Cards/GenericImageCard';
-import { IconTrash } from '@tabler/icons-react';
+import { IconExternalLink, IconTrash } from '@tabler/icons-react';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { isEqual } from 'lodash-es';
 import type { DragEndEvent, UniqueIdentifier } from '@dnd-kit/core';
 import { DndContext, PointerSensor, rectIntersection, useSensor, useSensors } from '@dnd-kit/core';
@@ -171,11 +172,44 @@ export const ShowcaseItemsInput = ({
                       );
                     }
 
+                    const itemUrl = (() => {
+                      switch (item.entityType) {
+                        case 'Model':
+                          return `/models/${item.entityId}`;
+                        case 'Image':
+                          return `/images/${item.entityId}`;
+                        case 'Collection':
+                          return `/collections/${item.entityId}`;
+                        case 'Bounty':
+                          return `/bounties/${item.entityId}`;
+                        default:
+                          return null;
+                      }
+                    })();
+
                     return (
                       <SortableItem key={key} id={key}>
                         <Box pos="relative">
                           <GenericImageCard {...item} image={coverImage} disabled />
                           {removeBtn}
+                          {itemUrl && (
+                            <ActionIcon
+                              component={Link}
+                              href={itemUrl}
+                              target="_blank"
+                              size="sm"
+                              variant="filled"
+                              color="gray"
+                              style={{
+                                position: 'absolute',
+                                bottom: 6,
+                                right: 6,
+                                zIndex: 10,
+                              }}
+                            >
+                              <IconExternalLink size={12} />
+                            </ActionIcon>
+                          )}
                         </Box>
                       </SortableItem>
                     );


### PR DESCRIPTION
Closes #2085

Adds a "View all" link to the Showcase profile section and external link buttons to each item in the Manage Showcase editor.

## Changes

**`src/components/Profile/Sections/ShowcaseSection.tsx`**
- Passes an `action` prop to `<ProfileSection>` containing a Mantine `Button` (variant `subtle`, `h={34}`) with an `IconArrowRight` icon that links to `/user/${user.username}/images`, giving profile visitors a direct path to all showcase images beyond the visible two-row grid.

**`src/components/Profile/ShowcaseItemsInput.tsx`**
- Adds an `itemUrl` resolver (lines ~172–184) that maps each `ShowcaseItemSchema` `entityType` (`Model`, `Image`, `Collection`, `Bounty`) to its canonical route.
- Renders a small `ActionIcon` (`size="sm"`, `variant="filled"`, `color="gray"`) positioned absolutely at `bottom: 6, right: 6` on each card when `itemUrl` is non-null, opening the entity in a new tab via `IconExternalLink`. This sits alongside the existing remove button without layout changes to `SortableItem` or `GenericImageCard`.

## Motivation

The Showcase section hard-caps visible images at two rows (~8 items depending on screen width), with no escape hatch to see the rest. Users managing a Showcase with more than 8 entries had no way to open an image's detail page from the editor — requiring a manual search through hundreds of uploads to retrieve prompts or generation metadata. The "View all" button resolves the first problem; the per-card external link resolves the second.

## Testing

- Open a profile with more than 8 showcase items; confirm the "View all" button appears in the section header and navigates to `/user/<username>/images`.
- Open **Customize Profile → Manage Showcase** with a mix of `Image`, `Model`, `Collection`, and `Bounty` showcase entries; confirm each card shows the external-link icon and opens the correct route in a new tab.
- Confirm that entries with an unrecognized `entityType` (the `default: null` branch) render no icon and produce no JS errors.
- Confirm the remove button (`IconTrash`) position is unaffected by the new icon.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*