### PR TITLE
fix: expand pg-pool prometheus metrics to all 6 pools

### DIFF
--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -1,6 +1,8 @@
 import type { Counter } from 'prom-client';
 import client from 'prom-client';
-import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
+import { datapacketDbRead } from '~/server/db/datapacketDb';
+import { notifDbRead, notifDbWrite } from '~/server/db/notifDb';
+import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb';
 
 const PROM_PREFIX = 'civitai_app_';
 export function registerCounter({ name, help }: { name: string; help: string }) {
@@ -184,6 +186,47 @@ if (!global.pgGaugeInitialized) {
     help: 'node postgres write waiting count',
     collect() {
       this.set(pgDbWrite.waitingCount);
+    },
+  });
+
+  // Labeled pool metrics for all pools
+  new client.Gauge({
+    name: 'node_postgres_pool_total_count',
+    help: 'Total connections in pg pool',
+    labelNames: ['pool'],
+    collect() {
+      this.set({ pool: 'read' }, pgDbRead?.totalCount ?? 0);
+      this.set({ pool: 'write' }, pgDbWrite?.totalCount ?? 0);
+      this.set({ pool: 'read_long' }, pgDbReadLong?.totalCount ?? 0);
+      this.set({ pool: 'notif_read' }, notifDbRead?.totalCount ?? 0);
+      this.set({ pool: 'notif_write' }, notifDbWrite?.totalCount ?? 0);
+      this.set({ pool: 'datapacket_read' }, datapacketDbRead?.totalCount ?? 0);
+    },
+  });
+  new client.Gauge({
+    name: 'node_postgres_pool_idle_count',
+    help: 'Idle connections in pg pool',
+    labelNames: ['pool'],
+    collect() {
+      this.set({ pool: 'read' }, pgDbRead?.idleCount ?? 0);
+      this.set({ pool: 'write' }, pgDbWrite?.idleCount ?? 0);
+      this.set({ pool: 'read_long' }, pgDbReadLong?.idleCount ?? 0);
+      this.set({ pool: 'notif_read' }, notifDbRead?.idleCount ?? 0);
+      this.set({ pool: 'notif_write' }, notifDbWrite?.idleCount ?? 0);
+      this.set({ pool: 'datapacket_read' }, datapacketDbRead?.idleCount ?? 0);
+    },
+  });
+  new client.Gauge({
+    name: 'node_postgres_pool_waiting_count',
+    help: 'Waiting connections in pg pool',
+    labelNames: ['pool'],
+    collect() {
+      this.set({ pool: 'read' }, pgDbRead?.waitingCount ?? 0);
+      this.set({ pool: 'write' }, pgDbWrite?.waitingCount ?? 0);
+      this.set({ pool: 'read_long' }, pgDbReadLong?.waitingCount ?? 0);
+      this.set({ pool: 'notif_read' }, notifDbRead?.waitingCount ?? 0);
+      this.set({ pool: 'notif_write' }, notifDbWrite?.waitingCount ?? 0);
+      this.set({ pool: 'datapacket_read' }, datapacketDbRead?.waitingCount ?? 0);
     },
   });
 


### PR DESCRIPTION
## Summary
- Add labeled Prometheus gauges (`node_postgres_pool_{total,idle,waiting}_count`) covering all 6 raw pg connection pools
- Previously only `pgDbRead` and `pgDbWrite` had metrics — `readLong`, `notifRead`, `notifWrite`, and `datapacketRead` were invisible
- Keeps existing unlabeled gauges for backwards compat with current dashboards

## Profiling Data
- `/profile-dp` showed "(no results)" for DB pool metrics, indicating incomplete coverage
- `post.addImage` P95=25.5s and `user.update` P95=28s suggest potential pool starvation, but we can't diagnose without per-pool visibility
- These new labeled metrics enable per-pool alerting and dashboard drill-downs

## Test plan
- [x] `tsc --noEmit` passes (no new errors)
- [ ] After deploy: verify `node_postgres_pool_total_count{pool="notif_write"}` appears in Prometheus
- [ ] Re-run `/profile-dp` — DB pool section should show results for all pools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>