### PR TITLE
fix: increase contest-collection-items cache max and TTL

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -6610,8 +6610,8 @@ type ContestCollectionItem = {
 };
 const contestCollectionItemsCache = createLruCache({
   name: 'contest-collection-items',
-  max: 10_000,
-  ttl: 5 * 60 * 1000, // 5 minutes
+  max: 100_000,
+  ttl: 30 * 60 * 1000, // 30 minutes
   keyFn: (imageId: number) => `image:${imageId}`,
   fetchFn: async (imageId: number) => {
     return dbRead.$queryRaw<ContestCollectionItem[]>`


### PR DESCRIPTION
## Summary
- Increase `contestCollectionItemsCache` LRU max from 10K → 100K entries
- Increase TTL from 5 minutes → 30 minutes
- Contest collection data changes infrequently; current settings result in 1% hit ratio across 85 pods

## Profiling Data
- Cache hit ratio: **1%** (24.5 misses/s, near-zero hits/s)
- Every request through this code path pays the full DB cost (raw SQL query with JOINs)
- Memory impact: ~50MB per pod at capacity (acceptable within 5Gi container limit)

## Test plan
- [x] `tsc --noEmit` passes (no new errors)
- [ ] After deploy: monitor `contest-collection-items` cache hit ratio — should improve to >50%
- [ ] Re-run `/profile-dp` to verify improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>