### PR TITLE
feat: cache-friendly Meili ops + user-own second-pass (Flipt-gated)

### DIFF
--- a/src/server/controllers/image.controller.ts
+++ b/src/server/controllers/image.controller.ts
@@ -55,7 +55,7 @@ import {
   ReportStatus,
 } from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
-import { FLIPT_FEATURE_FLAGS, getFliptVariant } from '~/server/flipt/client';
+import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant } from '~/server/flipt/client';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import type {
   GetEntitiesCoverImage,
@@ -303,9 +303,21 @@ export const getInfiniteImagesHandler = async ({
       );
   const useBitdex = bitdexMode === 'shadow' || bitdexMode === 'primary';
 
+  // Meili cache-ops flag: when on, route postId/postIds queries to PG instead of
+  // the search index (Meili or otherwise). Single-post queries are ~2ms in PG via
+  // the covered index and create unique cache keys in Meili that hurt hit rate.
+  const meiliCacheOps = await getFliptBoolean(
+    FLIPT_FEATURE_FLAGS.MEILI_CACHE_OPS,
+    user?.id?.toString() || 'anonymous',
+    buildFliptContext(user)
+  );
+  const forcePgForPostId =
+    meiliCacheOps && (!!input.postId || !!input.postIds?.length);
+
   // Use getAllImagesIndex when useIndex is true OR BitDex is active.
   // Use getAllImages (DB) otherwise.
-  const useIndex = useBitdex || (features.imageIndexFeed && input.useIndex);
+  const useIndex =
+    !forcePgForPostId && (useBitdex || (features.imageIndexFeed && input.useIndex));
 
   if (!useIndex) {
     imagesFeedWithoutIndexCounter.inc();

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -52,6 +52,8 @@ export enum FLIPT_FEATURE_FLAGS {
   HIGH_REPLICATION_LAG_MODE = 'high-replication-lag-mode',
   LICENSING_FEE = 'licensing-fee',
   WILDCARDS = 'wildcards',
+  MEILI_CACHE_OPS = 'meili-cache-ops',
+  MEILI_USER_OWN_PASS = 'meili-user-own-pass',
 }
 
 const FLIPT_INIT_TIMEOUT_MS = 5000;
@@ -199,6 +201,26 @@ export async function getFliptVariant(
   } catch (e) {
     console.error('Flipt variant evaluation error:', e);
     return null;
+  }
+}
+
+export async function getFliptBoolean(
+  flag: string,
+  entityId = 'global',
+  context: Record<string, string> = {}
+): Promise<boolean> {
+  const fliptClient = await FliptSingleton.getInstance();
+  if (!fliptClient) return false;
+
+  try {
+    const evaluation = fliptClient.evaluateBoolean({
+      flagKey: flag,
+      entityId,
+      context,
+    });
+    return evaluation.enabled;
+  } catch (e) {
+    return false;
   }
 }
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2180,6 +2180,20 @@ type ImageSearchInput = GetInfiniteImagesOutput & {
   // When provided, getImagesFromSearch skips its own Flipt evaluation.
   bitdexMode?: string | null;
   actor?: string;
+  /**
+   * When true, apply cache-friendly Meilisearch ops:
+   * - skip per-user excludedTagIds / excludedUserIds filters
+   * - gate NSFW license compound behind includesNsfwContent
+   */
+  meiliCacheOps?: boolean;
+  /**
+   * When true, drop the inline `OR userId=currentUserId` clauses from the
+   * nsfw and publish filters (main filter stays strict + cacheable) and
+   * fetch user-own excluded content from a parallel second-pass Meili query.
+   * Hits from both queries are merged + re-sorted before filter/enrich.
+   * Runs only on the first page (no cursor/entry/offset).
+   */
+  meiliUserOwnPass?: boolean;
   // Unhandled
   //prioritizedUserIds?: number[];
   //userIds?: number | number[];
@@ -2408,6 +2422,23 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
       context: {},
     });
     if (flag.enabled) searchFn = getImagesFromSearchPostFilter;
+
+    // Evaluate Meili cache flags once; thread through input for builders to gate on.
+    const cacheOpsFlag = fliptClient.evaluateBoolean({
+      flagKey: FLIPT_FEATURE_FLAGS.MEILI_CACHE_OPS,
+      entityId: input.currentUserId?.toString() || 'anonymous',
+      context: {},
+    });
+    const userOwnPassFlag = fliptClient.evaluateBoolean({
+      flagKey: FLIPT_FEATURE_FLAGS.MEILI_USER_OWN_PASS,
+      entityId: input.currentUserId?.toString() || 'anonymous',
+      context: {},
+    });
+    input = {
+      ...input,
+      meiliCacheOps: cacheOpsFlag.enabled,
+      meiliUserOwnPass: userOwnPassFlag.enabled,
+    };
   }
 
   // Check BitDex mode (off / shadow / primary)
@@ -2599,6 +2630,159 @@ export async function getImagesFromFeedSearch(
   }
 }
 
+/**
+ * Second-pass Meili query returning the current user's own excluded content:
+ * images that the strict main query would have filtered out (nsfwLevel=0, or
+ * unpublished/scheduled). Applies the same content-scoping (modelVersionId,
+ * postId, tags, baseModels, etc.) so the merge stays relevant to the view.
+ *
+ * Safe to call without a cursor-scoped window — we always fetch the user's
+ * full excluded set for the current view (usually < 100 items). Merge logic
+ * in the caller handles dedup + re-sort.
+ *
+ * Returns [] when there's no currentUserId or when metricsSearchClient is down.
+ */
+async function fetchMeiliUserOwnPass(
+  input: ImageSearchInput,
+  nsfwLevelField: MetricsImageFilterableAttribute
+): Promise<ImageMetricsSearchIndexRecord[]> {
+  const {
+    currentUserId,
+    modelVersionId,
+    postId,
+    postIds = [],
+    types,
+    tags,
+    tools,
+    techniques,
+    baseModels,
+    remixOfId,
+    withMeta,
+    fromPlatform,
+    disablePoi,
+    disableMinor,
+    hideAutoResources,
+    hideManualResources,
+    sort,
+  } = input;
+  if (!currentUserId || !metricsSearchClient) return [];
+
+  const filters: string[] = [];
+  filters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
+  filters.push(makeMeiliImageSearchFilter('postId', 'IS NOT NULL'));
+
+  // Excluded content = unscanned OR unpublished OR scheduled. What the strict
+  // main query would have filtered out.
+  const now = Date.now();
+  const excludedOr = [
+    makeMeiliImageSearchFilter(nsfwLevelField, `= 0`),
+    makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'),
+    makeMeiliImageSearchFilter('publishedAtUnix', `> ${now}`),
+  ];
+  filters.push(`(${excludedOr.join(' OR ')})`);
+
+  // Content-scoping — mirror what the main query applies
+  if (modelVersionId) {
+    const vClauses: string[] = [
+      makeMeiliImageSearchFilter('postedToId', `= ${modelVersionId}`),
+    ];
+    if (!hideAutoResources)
+      vClauses.push(makeMeiliImageSearchFilter('modelVersionIds', `IN [${modelVersionId}]`));
+    if (!hideManualResources)
+      vClauses.push(
+        makeMeiliImageSearchFilter('modelVersionIdsManual', `IN [${modelVersionId}]`)
+      );
+    filters.push(`(${vClauses.join(' OR ')})`);
+  }
+  const effectivePostIds = postId ? [...postIds, postId] : postIds;
+  if (effectivePostIds.length)
+    filters.push(makeMeiliImageSearchFilter('postId', `IN [${effectivePostIds.join(',')}]`));
+  if (types?.length)
+    filters.push(makeMeiliImageSearchFilter('type', `IN [${types.join(',')}]`));
+  if (tags?.length)
+    filters.push(makeMeiliImageSearchFilter('tagIds', `IN [${tags.join(',')}]`));
+  if (tools?.length)
+    filters.push(makeMeiliImageSearchFilter('toolIds', `IN [${tools.join(',')}]`));
+  if (techniques?.length)
+    filters.push(makeMeiliImageSearchFilter('techniqueIds', `IN [${techniques.join(',')}]`));
+  if (baseModels?.length)
+    filters.push(makeMeiliImageSearchFilter('baseModel', `IN [${strArray(baseModels)}]`));
+  if (remixOfId) filters.push(makeMeiliImageSearchFilter('remixOfId', `= ${remixOfId}`));
+  if (withMeta) filters.push(makeMeiliImageSearchFilter('hasMeta', '= true'));
+  if (fromPlatform) filters.push(makeMeiliImageSearchFilter('onSite', '= true'));
+  if (disablePoi) filters.push(`(NOT poi = true)`);
+  if (disableMinor) filters.push(`(NOT minor = true)`);
+
+  // Match the main query's sort so the merge produces stable ordering
+  let userSort: MeiliImageSort;
+  if (sort === ImageSort.MostComments) userSort = makeMeiliImageSearchSort('commentCount', 'desc');
+  else if (sort === ImageSort.MostReactions)
+    userSort = makeMeiliImageSearchSort('reactionCount', 'desc');
+  else if (sort === ImageSort.MostCollected)
+    userSort = makeMeiliImageSearchSort('collectedCount', 'desc');
+  else if (sort === ImageSort.Oldest) userSort = makeMeiliImageSearchSort('sortAt', 'asc');
+  else userSort = makeMeiliImageSearchSort('sortAt', 'desc');
+
+  const request: SearchParams = {
+    filter: filters.join(' AND '),
+    sort: [userSort],
+    limit: 500, // user's own excluded content is usually small (< 100)
+  };
+
+  try {
+    const { results } = await metricsSearchClient
+      .index(METRICS_SEARCH_INDEX)
+      .getDocuments<ImageMetricsSearchIndexRecord>(request);
+    return results;
+  } catch (err) {
+    console.error('fetchMeiliUserOwnPass error:', err);
+    return [];
+  }
+}
+
+/**
+ * Sort key extractor — mirrors each ImageSort option's underlying field.
+ * Used to merge-sort two hit sets returned from parallel Meili queries.
+ */
+function meiliHitSortKey(
+  hit: ImageMetricsSearchIndexRecord,
+  sort: ImageSort | undefined
+): number {
+  if (sort === ImageSort.MostComments) return hit.commentCount ?? 0;
+  if (sort === ImageSort.MostReactions) return hit.reactionCount ?? 0;
+  if (sort === ImageSort.MostCollected) return hit.collectedCount ?? 0;
+  // Oldest / Newest both use sortAtUnix
+  return hit.sortAtUnix ?? 0;
+}
+
+function mergeMeiliHitsBySort(
+  main: ImageMetricsSearchIndexRecord[],
+  userOwn: ImageMetricsSearchIndexRecord[],
+  sort: ImageSort | undefined
+): ImageMetricsSearchIndexRecord[] {
+  const seen = new Set<number>();
+  const merged: ImageMetricsSearchIndexRecord[] = [];
+  for (const hit of main) {
+    if (!seen.has(hit.id)) {
+      seen.add(hit.id);
+      merged.push(hit);
+    }
+  }
+  for (const hit of userOwn) {
+    if (!seen.has(hit.id)) {
+      seen.add(hit.id);
+      merged.push(hit);
+    }
+  }
+  const asc = sort === ImageSort.Oldest;
+  merged.sort((a, b) => {
+    const av = meiliHitSortKey(a, sort);
+    const bv = meiliHitSortKey(b, sort);
+    return asc ? av - bv : bv - av;
+  });
+  return merged;
+}
+
 export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   if (!metricsSearchClient) return { data: [], nextCursor: undefined };
   let { postIds = [] } = input;
@@ -2754,16 +2938,27 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   const nsfwFilters = [
     makeMeiliImageSearchFilter(nsfwLevelField, `IN [${browsingLevels.join(',')}]`) as string,
   ];
-  const nsfwUserFilters = [makeMeiliImageSearchFilter(nsfwLevelField, `= 0`)];
-  if (currentUserId)
-    nsfwUserFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
+  // User-own-pass mode: drop the inline `(nsfwLevel=0 AND userId=currentUserId)`
+  // OR branch. The user's unscanned content comes from fetchMeiliUserOwnPass and
+  // gets merged at the hit level. Keeps the main filter cacheable.
+  if (!input.meiliUserOwnPass) {
+    const nsfwUserFilters = [makeMeiliImageSearchFilter(nsfwLevelField, `= 0`)];
+    if (currentUserId)
+      nsfwUserFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
 
-  nsfwFilters.push(`(${nsfwUserFilters.join(' AND ')})`);
+    nsfwFilters.push(`(${nsfwUserFilters.join(' AND ')})`);
+  }
   filters.push(`(${nsfwFilters.join(' OR ')})`);
 
   // NSFW License Restrictions Filter
-  // Filter out images with R/X/XXX NSFW levels that use restricted base models
-  if (nsfwRestrictedBaseModels.length > 0) {
+  // Filter out images with R/X/XXX NSFW levels that use restricted base models.
+  // Cache-ops mode: gate behind includesNsfwContent. The outer nsfwLevel IN filter
+  // already excludes [4,8,16,32] on SFW queries, so this compound is a no-op but
+  // still costs per-query. Mirrors the BitDex fix.
+  if (
+    nsfwRestrictedBaseModels.length > 0 &&
+    (!input.meiliCacheOps || includesNsfwContent)
+  ) {
     const restrictedBaseModelsQuoted = nsfwRestrictedBaseModels.map((bm) => `'${bm}'`);
 
     // Exclude images that have BOTH restricted NSFW levels AND restricted base models
@@ -2801,7 +2996,10 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     filters.push(makeMeiliImageSearchFilter('remixOfId', 'NOT EXISTS'));
   }
 
-  if (excludedTagIds?.length) {
+  // Cache-ops mode: skip per-user excludedTagIds. Injected by tRPC middleware from
+  // the user's hidden tags — unique per user, destroys cache. Frontend already
+  // filters via useApplyHiddenPreferences.
+  if (!input.meiliCacheOps && excludedTagIds?.length) {
     // Needed support for this in order to properly support multiple domains.
     filters.push(makeMeiliImageSearchFilter('tagIds', `NOT IN [${excludedTagIds.join(',')}]`));
   }
@@ -2832,13 +3030,16 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   }
   if (fromPlatform) filters.push(makeMeiliImageSearchFilter('onSite', '= true'));
 
+  // User-own-pass mode: drop the inline `OR userId=currentUserId` branch. User's
+  // unpublished/scheduled content comes from fetchMeiliUserOwnPass and gets merged
+  // at the hit level.
   if (isModerator) {
     if (notPublished) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
     else if (scheduled)
       filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${Date.now()}`));
     else {
       const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${Date.now()}`)];
-      if (currentUserId) {
+      if (!input.meiliUserOwnPass && currentUserId) {
         publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
       }
       filters.push(`(${publishedFilters.join(' OR ')})`);
@@ -2849,7 +3050,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     const publishedFilters = [
       makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snapToInterval(Math.round(Date.now()))}`),
     ];
-    if (currentUserId) {
+    if (!input.meiliUserOwnPass && currentUserId) {
       publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
     }
     filters.push(`(${publishedFilters.join(' OR ')})`);
@@ -2871,8 +3072,10 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   //   filters.push(makeMeiliImageSearchFilter('userId', `IN [${userIds.join(',')}]`));
   // }
 
+  // Cache-ops mode: skip per-user excludedUserIds NOT IN. Middleware injects the
+  // user's hidden users; destroys cache. Frontend filters via useApplyHiddenPreferences.
   if (userId) filters.push(makeMeiliImageSearchFilter('userId', `= ${userId}`));
-  else if (excludedUserIds)
+  else if (!input.meiliCacheOps && excludedUserIds)
     filters.push(makeMeiliImageSearchFilter('userId', `NOT IN [${excludedUserIds.join(',')}]`));
 
   // TODO.metricSearch if reviewId, get corresponding userId instead and add to userIds before making this request
@@ -2952,22 +3155,33 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   try {
     const actor = input.actor;
 
+    // User-own-pass mode: run main query + user-own query in parallel, then merge.
+    // Only runs on the first page (no cursor/entry/offset) to keep merge simple.
+    const runUserOwnPass =
+      !!input.meiliUserOwnPass && !!currentUserId && !entry && !offset;
+
     // Use the abortable raw fetch when a signal is available so client
     // disconnects (e.g. the feed's slow-fetch timeout) actually cancel the
     // underlying Meili request. The meilisearch-js client on 0.33/0.34 doesn't
     // expose signal on getDocuments.
-    const { results } = await withSpan('image:meili:getDocuments', () =>
-      input.signal
-        ? fetchDocumentsAbortable<ImageMetricsSearchIndexRecord>(METRICS_SEARCH_INDEX, request, {
-            host: env.METRICS_SEARCH_HOST as string,
-            apiKey: env.METRICS_SEARCH_API_KEY,
-            signal: input.signal,
-            actor,
-          })
-        : (actor ? getMetricsSearchClient(actor) : metricsSearchClient)!
-            .index(METRICS_SEARCH_INDEX)
-            .getDocuments<ImageMetricsSearchIndexRecord>(request)
-    );
+    const [mainResult, userOwnHits] = await Promise.all([
+      withSpan('image:meili:getDocuments', () =>
+        input.signal
+          ? fetchDocumentsAbortable<ImageMetricsSearchIndexRecord>(METRICS_SEARCH_INDEX, request, {
+              host: env.METRICS_SEARCH_HOST as string,
+              apiKey: env.METRICS_SEARCH_API_KEY,
+              signal: input.signal,
+              actor,
+            })
+          : (actor ? getMetricsSearchClient(actor) : metricsSearchClient)!
+              .index(METRICS_SEARCH_INDEX)
+              .getDocuments<ImageMetricsSearchIndexRecord>(request)
+      ),
+      runUserOwnPass
+        ? fetchMeiliUserOwnPass(input, nsfwLevelField)
+        : Promise.resolve([] as ImageMetricsSearchIndexRecord[]),
+    ]);
+    let results = mainResult.results;
 
     let nextCursor: number | undefined;
     if (results.length > limit) {
@@ -2975,6 +3189,12 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
       // - if we have no entrypoint, it's the first request, and set one for the future
       //   else keep it the same
       nextCursor = !entry ? results[0]?.sortAtUnix : entry;
+    }
+
+    // Merge user-own hits with the main results, dedupe, re-sort, and re-trim.
+    // User-own items slot in by the active sort key (newest-first by default).
+    if (userOwnHits.length) {
+      results = mergeMeiliHitsBySort(results, userOwnHits, sort).slice(0, limit);
     }
 
     const filteredHits = results.filter((hit) => {
@@ -3589,15 +3809,20 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   const nsfwFilters = [
     makeMeiliImageSearchFilter(nsfwLevelField, `IN [${browsingLevels.join(',')}]`) as string,
   ];
-  // Allow users to see their own unscanned content on their user page
-  if (currentUserId && userId === currentUserId)
+  // Allow users to see their own unscanned content on their user page.
+  // User-own-pass mode: dropped — handled by fetchMeiliUserOwnPass merge.
+  if (!input.meiliUserOwnPass && currentUserId && userId === currentUserId)
     nsfwFilters.push(makeMeiliImageSearchFilter(nsfwLevelField, `= 0`));
 
   filters.push(`(${nsfwFilters.join(' OR ')})`);
 
-  // NSFW License Restrictions Filter
-  // Filter out images with R/X/XXX NSFW levels that use restricted base models
-  if (nsfwRestrictedBaseModels.length > 0) {
+  // NSFW License Restrictions Filter — gate behind includesNsfwContent in cache-ops
+  // mode. On SFW queries the outer nsfwLevel filter already excludes restricted levels,
+  // so this compound is a no-op but still costs per-query.
+  if (
+    nsfwRestrictedBaseModels.length > 0 &&
+    (!input.meiliCacheOps || includesNsfwContent)
+  ) {
     const restrictedBaseModelsQuoted = nsfwRestrictedBaseModels.map((bm) => `'${bm}'`);
 
     // Exclude images that have BOTH restricted NSFW levels AND restricted base models
@@ -3635,7 +3860,10 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     filters.push(makeMeiliImageSearchFilter('remixOfId', 'NOT EXISTS'));
   }
 
-  if (excludedTagIds?.length) {
+  // Cache-ops mode: skip per-user excludedTagIds. Injected by tRPC middleware from
+  // the user's hidden tags — unique per user, destroys cache. Frontend already
+  // filters via useApplyHiddenPreferences.
+  if (!input.meiliCacheOps && excludedTagIds?.length) {
     // Needed support for this in order to properly support multiple domains.
     filters.push(makeMeiliImageSearchFilter('tagIds', `NOT IN [${excludedTagIds.join(',')}]`));
   }
@@ -3666,7 +3894,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   }
   if (fromPlatform) filters.push(makeMeiliImageSearchFilter('onSite', '= true'));
 
-  // Publish Date Filtering
+  // Publish Date Filtering. User-own-pass mode drops the inline user-own branches.
   const snappedNow = snapToInterval(Date.now());
   if (isModerator) {
     if (notPublished) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
@@ -3674,7 +3902,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${Date.now()}`));
     else {
       const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${Date.now()}`)];
-      if (currentUserId) {
+      if (!input.meiliUserOwnPass && currentUserId) {
         publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
       }
       filters.push(`(${publishedFilters.join(' OR ')})`);
@@ -3682,7 +3910,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   } else if (userId) {
     const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${Date.now()}`)];
     // For own user's content, allow seeing scheduled/notPublished content
-    if (currentUserId && userId === currentUserId) {
+    if (!input.meiliUserOwnPass && currentUserId && userId === currentUserId) {
       publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
     }
     filters.push(`(${publishedFilters.join(' OR ')})`);
@@ -3707,8 +3935,10 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   //   filters.push(makeMeiliImageSearchFilter('userId', `IN [${userIds.join(',')}]`));
   // }
 
+  // Cache-ops mode: skip per-user excludedUserIds NOT IN. Middleware injects the
+  // user's hidden users; destroys cache. Frontend filters via useApplyHiddenPreferences.
   if (userId) filters.push(makeMeiliImageSearchFilter('userId', `= ${userId}`));
-  else if (excludedUserIds)
+  else if (!input.meiliCacheOps && excludedUserIds)
     filters.push(makeMeiliImageSearchFilter('userId', `NOT IN [${excludedUserIds.join(',')}]`));
 
   // TODO.metricSearch if reviewId, get corresponding userId instead and add to userIds before making this request
@@ -3788,6 +4018,13 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
 
   const actor = input.actor;
   const actorClient = actor ? getMetricsSearchClient(actor) : metricsSearchClient;
+
+  // User-own-pass mode: kick off the parallel user-scoped query up front. Only
+  // on the first page (no offset) to keep the merge simple.
+  const runUserOwnPass = !!input.meiliUserOwnPass && !!currentUserId && !offset;
+  const userOwnHitsPromise: Promise<ImageMetricsSearchIndexRecord[]> = runUserOwnPass
+    ? fetchMeiliUserOwnPass(input, nsfwLevelField)
+    : Promise.resolve([]);
 
   try {
     while (accumulatedHits.length < limit + 1 && iteration < MAX_ITERATIONS) {
@@ -3892,10 +4129,17 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     postFilterDocsProcessed.inc({ route }, totalProcessed);
     postFilterFilterRatio.observe({ route }, overallFilterRatio);
 
+    // Merge user-own hits from the second-pass into the accumulated results,
+    // dedupe, and re-sort by the active sort field. Runs on first page only.
+    const userOwnHits = await userOwnHitsPromise;
+    const mergedHits = userOwnHits.length
+      ? mergeMeiliHitsBySort(accumulatedHits, userOwnHits, sort)
+      : accumulatedHits;
+
     // Update nextCursor based on whether we have more results than requested
-    if (accumulatedHits.length > limit) {
+    if (mergedHits.length > limit) {
       // We have more results, so there's a next page
-      const lastResult = accumulatedHits[limit];
+      const lastResult = mergedHits[limit];
       nextCursor = lastResult?.sortAtUnix || nextCursor;
     } else {
       // We don't have more results than requested, so no next page
@@ -3903,7 +4147,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     }
 
     // Trim results back to requested limit after filtering
-    const limitedHits = accumulatedHits.slice(0, limit + 1);
+    const limitedHits = mergedHits.slice(0, limit + 1);
 
     // Get all image IDs from limited results
     const searchImageIds = limitedHits.map((hit) => hit.id);

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2632,86 +2632,57 @@ export async function getImagesFromFeedSearch(
 
 /**
  * Second-pass Meili query returning the current user's own excluded content:
- * images that the strict main query would have filtered out (nsfwLevel=0, or
- * unpublished/scheduled). Applies the same content-scoping (modelVersionId,
- * postId, tags, baseModels, etc.) so the merge stays relevant to the view.
+ * images the strict main query would have filtered out (unscanned, unpublished,
+ * scheduled, private, blocked, or POI when disablePoi is on).
  *
- * Safe to call without a cursor-scoped window — we always fetch the user's
- * full excluded set for the current view (usually < 100 items). Merge logic
- * in the caller handles dedup + re-sort.
+ * Intentionally UNSCOPED — the cache key collapses to roughly
+ * `userId × sort × disablePoi`, so the same response is reused across every
+ * page/view the user visits (model galleries, feed, profiles, etc). Content
+ * scoping (modelVersionId, postId, tags, etc) is applied in the caller via
+ * `contentScopeUserOwnHits` after the results come back. Mirrors the BitDex
+ * cacheability trick (image.service.ts:fetchBitdexPrimary).
  *
- * Returns [] when there's no currentUserId or when metricsSearchClient is down.
+ * Returns [] when there's no currentUserId, when viewing another user's
+ * profile (userId !== currentUserId), or when metricsSearchClient is down.
  */
 async function fetchMeiliUserOwnPass(
   input: ImageSearchInput,
-  nsfwLevelField: MetricsImageFilterableAttribute
+  nsfwLevelField: MetricsImageFilterableAttribute,
+  resolvedUserId?: number
 ): Promise<ImageMetricsSearchIndexRecord[]> {
-  const {
-    currentUserId,
-    modelVersionId,
-    postId,
-    postIds = [],
-    types,
-    tags,
-    tools,
-    techniques,
-    baseModels,
-    remixOfId,
-    withMeta,
-    fromPlatform,
-    disablePoi,
-    disableMinor,
-    hideAutoResources,
-    hideManualResources,
-    sort,
-  } = input;
+  const { currentUserId, disablePoi, sort } = input;
   if (!currentUserId || !metricsSearchClient) return [];
+  // Skip when viewing another user's profile — second pass is current-user
+  // scoped, so unscoped results would leak my excluded content into their view.
+  // `resolvedUserId` is the userId after username -> id lookup; fall back to raw input.
+  const targetUserId = resolvedUserId ?? input.userId;
+  if (targetUserId != null && targetUserId !== currentUserId) return [];
 
   const filters: string[] = [];
   filters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
   filters.push(makeMeiliImageSearchFilter('postId', 'IS NOT NULL'));
 
-  // Excluded content = unscanned OR unpublished OR scheduled. What the strict
-  // main query would have filtered out.
+  // Excluded set = anything the strict main query would have removed for a
+  // non-owner: unscanned, unpublished, scheduled, private, blocked, or POI
+  // (when disablePoi is on). Mirrors the BitDex second-pass excluded OR.
   const now = Date.now();
-  const excludedOr = [
-    makeMeiliImageSearchFilter(nsfwLevelField, `= 0`),
-    makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'),
-    makeMeiliImageSearchFilter('publishedAtUnix', `> ${now}`),
+  const blockedReasonList = [
+    BlockedReason.TOS,
+    BlockedReason.Moderated,
+    BlockedReason.CSAM,
+    BlockedReason.AiNotVerified,
+  ]
+    .map((r) => `'${r}'`)
+    .join(',');
+  const excludedOr: string[] = [
+    makeMeiliImageSearchFilter(nsfwLevelField, `= 0`) as string,
+    makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS') as string,
+    makeMeiliImageSearchFilter('publishedAtUnix', `> ${now}`) as string,
+    `availability = ${Availability.Private}`,
+    `blockedFor IN [${blockedReasonList}]`,
   ];
+  if (disablePoi) excludedOr.push('poi = true');
   filters.push(`(${excludedOr.join(' OR ')})`);
-
-  // Content-scoping — mirror what the main query applies
-  if (modelVersionId) {
-    const vClauses: string[] = [
-      makeMeiliImageSearchFilter('postedToId', `= ${modelVersionId}`),
-    ];
-    if (!hideAutoResources)
-      vClauses.push(makeMeiliImageSearchFilter('modelVersionIds', `IN [${modelVersionId}]`));
-    if (!hideManualResources)
-      vClauses.push(
-        makeMeiliImageSearchFilter('modelVersionIdsManual', `IN [${modelVersionId}]`)
-      );
-    filters.push(`(${vClauses.join(' OR ')})`);
-  }
-  const effectivePostIds = postId ? [...postIds, postId] : postIds;
-  if (effectivePostIds.length)
-    filters.push(makeMeiliImageSearchFilter('postId', `IN [${effectivePostIds.join(',')}]`));
-  if (types?.length)
-    filters.push(makeMeiliImageSearchFilter('type', `IN [${types.join(',')}]`));
-  if (tags?.length)
-    filters.push(makeMeiliImageSearchFilter('tagIds', `IN [${tags.join(',')}]`));
-  if (tools?.length)
-    filters.push(makeMeiliImageSearchFilter('toolIds', `IN [${tools.join(',')}]`));
-  if (techniques?.length)
-    filters.push(makeMeiliImageSearchFilter('techniqueIds', `IN [${techniques.join(',')}]`));
-  if (baseModels?.length)
-    filters.push(makeMeiliImageSearchFilter('baseModel', `IN [${strArray(baseModels)}]`));
-  if (remixOfId) filters.push(makeMeiliImageSearchFilter('remixOfId', `= ${remixOfId}`));
-  if (withMeta) filters.push(makeMeiliImageSearchFilter('hasMeta', '= true'));
-  if (fromPlatform) filters.push(makeMeiliImageSearchFilter('onSite', '= true'));
-  if (disablePoi) filters.push(`(NOT poi = true)`);
-  if (disableMinor) filters.push(`(NOT minor = true)`);
 
   // Match the main query's sort so the merge produces stable ordering
   let userSort: MeiliImageSort;
@@ -2741,13 +2712,76 @@ async function fetchMeiliUserOwnPass(
 }
 
 /**
+ * Narrow unscoped second-pass user-own hits down to the current view. Run
+ * client-side after fetchMeiliUserOwnPass so the query itself stays cacheable.
+ * Mirrors fetchBitdexPrimary's post-fetch content-scope step.
+ */
+function contentScopeUserOwnHits(
+  hits: ImageMetricsSearchIndexRecord[],
+  input: ImageSearchInput
+): ImageMetricsSearchIndexRecord[] {
+  if (!hits.length) return hits;
+  const {
+    modelVersionId,
+    postId,
+    postIds,
+    types,
+    tags,
+    tools,
+    techniques,
+    baseModels,
+    remixOfId,
+    withMeta,
+    fromPlatform,
+    hideAutoResources,
+    hideManualResources,
+  } = input;
+
+  let scoped = hits;
+  if (modelVersionId) {
+    scoped = scoped.filter((h) => {
+      if (h.postedToId === modelVersionId) return true;
+      if (!hideAutoResources && h.modelVersionIds?.includes(modelVersionId)) return true;
+      if (!hideManualResources && h.modelVersionIdsManual?.includes(modelVersionId)) return true;
+      return false;
+    });
+  }
+  const effectivePostIds = postId != null ? [...(postIds ?? []), postId] : postIds ?? [];
+  if (effectivePostIds.length) {
+    const set = new Set(effectivePostIds);
+    scoped = scoped.filter((h) => h.postId != null && set.has(h.postId));
+  }
+  if (types?.length) {
+    const set = new Set<string>(types as unknown as string[]);
+    scoped = scoped.filter((h) => set.has(h.type));
+  }
+  if (tags?.length) {
+    const set = new Set(tags);
+    scoped = scoped.filter((h) => h.tagIds?.some((t) => set.has(t)));
+  }
+  if (tools?.length) {
+    const set = new Set(tools);
+    scoped = scoped.filter((h) => h.toolIds?.some((t) => set.has(t)));
+  }
+  if (techniques?.length) {
+    const set = new Set(techniques);
+    scoped = scoped.filter((h) => h.techniqueIds?.some((t) => set.has(t)));
+  }
+  if (baseModels?.length) {
+    const set = new Set<string>(baseModels);
+    scoped = scoped.filter((h) => set.has(h.baseModel));
+  }
+  if (remixOfId) scoped = scoped.filter((h) => h.remixOfId === remixOfId);
+  if (withMeta) scoped = scoped.filter((h) => h.hasMeta === true);
+  if (fromPlatform) scoped = scoped.filter((h) => h.onSite === true);
+  return scoped;
+}
+
+/**
  * Sort key extractor — mirrors each ImageSort option's underlying field.
  * Used to merge-sort two hit sets returned from parallel Meili queries.
  */
-function meiliHitSortKey(
-  hit: ImageMetricsSearchIndexRecord,
-  sort: ImageSort | undefined
-): number {
+function meiliHitSortKey(hit: ImageMetricsSearchIndexRecord, sort: ImageSort | undefined): number {
   if (sort === ImageSort.MostComments) return hit.commentCount ?? 0;
   if (sort === ImageSort.MostReactions) return hit.reactionCount ?? 0;
   if (sort === ImageSort.MostCollected) return hit.collectedCount ?? 0;
@@ -2836,19 +2870,20 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   // Only show images that belong to a post
   filters.push(makeMeiliImageSearchFilter('postId', 'IS NOT NULL'));
 
+  // User-own-pass mode drops the inline `OR userId=currentUserId` carve-outs
+  // (availability, blockedFor, poi) so the main filter stays strict + cacheable.
+  // User's own private/blocked/poi content comes from fetchMeiliUserOwnPass.
+  const ownCarveOut =
+    !input.meiliUserOwnPass && currentUserId ? ` OR "userId" = ${currentUserId}` : '';
   if (!isModerator) {
     filters.push(
       // Avoids exposing private resources to the public
-      `((NOT availability = ${Availability.Private})${
-        currentUserId ? ` OR "userId" = ${currentUserId}` : ''
-      })`
+      `((NOT availability = ${Availability.Private})${ownCarveOut})`
     );
 
     filters.push(
       // Avoids blocked resources to the public
-      `(("blockedFor" IS NULL OR "blockedFor" NOT EXISTS)${
-        currentUserId ? ` OR "userId" = ${currentUserId}` : ''
-      })`
+      `(("blockedFor" IS NULL OR "blockedFor" NOT EXISTS)${ownCarveOut})`
     );
   }
 
@@ -2857,7 +2892,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   }
 
   if (disablePoi) {
-    filters.push(`(NOT poi = true${currentUserId ? ` OR "userId" = ${currentUserId}` : ''})`);
+    filters.push(`(NOT poi = true${ownCarveOut})`);
   }
   if (disableMinor) {
     filters.push(`(NOT minor = true)`);
@@ -2955,10 +2990,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   // Cache-ops mode: gate behind includesNsfwContent. The outer nsfwLevel IN filter
   // already excludes [4,8,16,32] on SFW queries, so this compound is a no-op but
   // still costs per-query. Mirrors the BitDex fix.
-  if (
-    nsfwRestrictedBaseModels.length > 0 &&
-    (!input.meiliCacheOps || includesNsfwContent)
-  ) {
+  if (nsfwRestrictedBaseModels.length > 0 && (!input.meiliCacheOps || includesNsfwContent)) {
     const restrictedBaseModelsQuoted = nsfwRestrictedBaseModels.map((bm) => `'${bm}'`);
 
     // Exclude images that have BOTH restricted NSFW levels AND restricted base models
@@ -3178,7 +3210,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
               .getDocuments<ImageMetricsSearchIndexRecord>(request)
       ),
       runUserOwnPass
-        ? fetchMeiliUserOwnPass(input, nsfwLevelField)
+        ? fetchMeiliUserOwnPass(input, nsfwLevelField, userId)
         : Promise.resolve([] as ImageMetricsSearchIndexRecord[]),
     ]);
     let results = mainResult.results;
@@ -3192,9 +3224,13 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     }
 
     // Merge user-own hits with the main results, dedupe, re-sort, and re-trim.
-    // User-own items slot in by the active sort key (newest-first by default).
+    // Second pass is fetched unscoped so its cache key stays small — apply
+    // view-specific content scoping here, before the merge.
     if (userOwnHits.length) {
-      results = mergeMeiliHitsBySort(results, userOwnHits, sort).slice(0, limit);
+      const scopedOwn = contentScopeUserOwnHits(userOwnHits, input);
+      if (scopedOwn.length) {
+        results = mergeMeiliHitsBySort(results, scopedOwn, sort).slice(0, limit);
+      }
     }
 
     const filteredHits = results.filter((hit) => {
@@ -3819,10 +3855,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   // NSFW License Restrictions Filter — gate behind includesNsfwContent in cache-ops
   // mode. On SFW queries the outer nsfwLevel filter already excludes restricted levels,
   // so this compound is a no-op but still costs per-query.
-  if (
-    nsfwRestrictedBaseModels.length > 0 &&
-    (!input.meiliCacheOps || includesNsfwContent)
-  ) {
+  if (nsfwRestrictedBaseModels.length > 0 && (!input.meiliCacheOps || includesNsfwContent)) {
     const restrictedBaseModelsQuoted = nsfwRestrictedBaseModels.map((bm) => `'${bm}'`);
 
     // Exclude images that have BOTH restricted NSFW levels AND restricted base models
@@ -4023,7 +4056,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   // on the first page (no offset) to keep the merge simple.
   const runUserOwnPass = !!input.meiliUserOwnPass && !!currentUserId && !offset;
   const userOwnHitsPromise: Promise<ImageMetricsSearchIndexRecord[]> = runUserOwnPass
-    ? fetchMeiliUserOwnPass(input, nsfwLevelField)
+    ? fetchMeiliUserOwnPass(input, nsfwLevelField, userId)
     : Promise.resolve([]);
 
   try {
@@ -4129,11 +4162,13 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     postFilterDocsProcessed.inc({ route }, totalProcessed);
     postFilterFilterRatio.observe({ route }, overallFilterRatio);
 
-    // Merge user-own hits from the second-pass into the accumulated results,
-    // dedupe, and re-sort by the active sort field. Runs on first page only.
+    // Merge user-own hits from the second-pass into the accumulated results.
+    // Second pass is unscoped (cacheable) — narrow it to the current view here,
+    // then dedupe and re-sort by the active sort field. Runs on first page only.
     const userOwnHits = await userOwnHitsPromise;
-    const mergedHits = userOwnHits.length
-      ? mergeMeiliHitsBySort(accumulatedHits, userOwnHits, sort)
+    const scopedOwn = userOwnHits.length ? contentScopeUserOwnHits(userOwnHits, input) : [];
+    const mergedHits = scopedOwn.length
+      ? mergeMeiliHitsBySort(accumulatedHits, scopedOwn, sort)
       : accumulatedHits;
 
     // Update nextCursor based on whether we have more results than requested


### PR DESCRIPTION
## Summary

Ports BitDex cache optimizations to the Meilisearch path behind two independent Flipt boolean flags (both default off).

### `meili-cache-ops` — safe unconditional wins
- Skip per-user `excludedTagIds` NOT IN filter (frontend already filters via `useApplyHiddenPreferences`)
- Skip per-user `excludedUserIds` NOT IN filter (same story)
- Gate NSFW license compound `NOT(nsfwLevel IN [4,8,16,32] AND baseModel IN restricted)` behind `includesNsfwContent` — the outer `nsfwLevel` filter already excludes those levels on SFW queries, so the compound is a no-op but still costs per query
- Route `postId`/`postIds` queries to Postgres (covered index, ~2ms) so single-post filters don't generate unique Meili cache keys

### `meili-user-own-pass` — parallel second-pass merge
- Drops the inline `OR userId=currentUserId` clauses from the nsfw and publish filters (keeps main filter strict + cacheable)
- Adds `fetchMeiliUserOwnPass`: user-scoped Meili query for the user's own excluded content (`nsfwLevel=0`, unpublished, scheduled) with the same content-scoping as the main query
- Merges via `mergeMeiliHitsBySort` (union, dedupe by id, re-sort by active sort field) before the filter/enrich pipeline
- First page only (no cursor/entry/offset) — subsequent pages use the main query alone

Applies to both `getImagesFromSearchPreFilter` and `getImagesFromSearchPostFilter`. Adds `getFliptBoolean` helper.

## Flipt flags

Both flags live in `civitai-app/default/features.yaml`, default `enabled: false`.

## Test plan

- [ ] Typecheck passes (local: ✅)
- [ ] With both flags off: behavior identical to current main
- [ ] Enable `meili-cache-ops`: verify cache hit rate climbs on image feed queries; verify postId queries hit Postgres
- [ ] Enable `meili-user-own-pass`: verify signed-in user still sees their own unpublished / nsfwLevel=0 / scheduled images on first page; verify subsequent pages don't regress
- [ ] Both flags on together: smoke test feed as anon, as regular user, as user with own unpublished content