### PR TITLE
fix: parallelize sequential awaits in post.addImage and user.update

### DIFF
--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -401,21 +401,28 @@ export const updateUserHandler = async ({
     if (!user) throw throwNotFoundError(`No user with id ${id}`);
 
     const payloadCosmeticIds: number[] = [];
+    const unequipPromises: Promise<unknown>[] = [];
     if (badgeId) payloadCosmeticIds.push(badgeId);
     else if (badgeId === null)
-      await unequipCosmeticByType({ userId: id, type: CosmeticType.Badge });
+      unequipPromises.push(unequipCosmeticByType({ userId: id, type: CosmeticType.Badge }));
 
     if (nameplateId) payloadCosmeticIds.push(nameplateId);
     else if (nameplateId === null)
-      await unequipCosmeticByType({ userId: id, type: CosmeticType.NamePlate });
+      unequipPromises.push(unequipCosmeticByType({ userId: id, type: CosmeticType.NamePlate }));
 
     if (profileDecorationId) payloadCosmeticIds.push(profileDecorationId);
     else if (profileDecorationId === null)
-      await unequipCosmeticByType({ userId: id, type: CosmeticType.ProfileDecoration });
+      unequipPromises.push(
+        unequipCosmeticByType({ userId: id, type: CosmeticType.ProfileDecoration })
+      );
 
     if (profileBackgroundId) payloadCosmeticIds.push(profileBackgroundId);
     else if (profileBackgroundId === null)
-      await unequipCosmeticByType({ userId: id, type: CosmeticType.ProfileBackground });
+      unequipPromises.push(
+        unequipCosmeticByType({ userId: id, type: CosmeticType.ProfileBackground })
+      );
+
+    await Promise.all(unequipPromises);
 
     const isSettingCosmetics = payloadCosmeticIds.length > 0;
 
@@ -445,9 +452,12 @@ export const updateUserHandler = async ({
       updateSource: 'updateUser',
     });
 
+    // Post-update operations — parallelize independent work
+    const postUpdatePromises: Promise<unknown>[] = [];
+
     // Delete old profilePic and ingest new one
     if (user.profilePictureId && profilePicture && user.profilePictureId !== profilePicture.id) {
-      await deleteImageById({ id: user.profilePictureId });
+      postUpdatePromises.push(deleteImageById({ id: user.profilePictureId }));
     }
 
     if (
@@ -455,35 +465,43 @@ export const updateUserHandler = async ({
       updatedUser.profilePictureId &&
       user.profilePictureId !== profilePicture?.id
     ) {
-      await ingestImage({
-        image: {
-          id: updatedUser.profilePictureId,
-          url: profilePicture.url,
-          type: profilePicture.type,
-          height: profilePicture.height,
-          width: profilePicture.width,
-        },
-      });
-      await deleteUserProfilePictureCache(id);
+      postUpdatePromises.push(
+        ingestImage({
+          image: {
+            id: updatedUser.profilePictureId,
+            url: profilePicture.url,
+            type: profilePicture.type,
+            height: profilePicture.height,
+            width: profilePicture.width,
+          },
+        }).then(() => deleteUserProfilePictureCache(id))
+      );
     }
 
-    if (isSettingCosmetics) await equipCosmetic({ userId: id, cosmeticId: payloadCosmeticIds });
+    if (isSettingCosmetics)
+      postUpdatePromises.push(equipCosmetic({ userId: id, cosmeticId: payloadCosmeticIds }));
 
     if (userReferralCode || source || landingPage) {
-      await createUserReferral({
-        id: updatedUser.id,
-        userReferralCode,
-        source,
-        landingPage,
-        ip: ctx.ip,
-      });
+      postUpdatePromises.push(
+        createUserReferral({
+          id: updatedUser.id,
+          userReferralCode,
+          source,
+          landingPage,
+          ip: ctx.ip,
+        })
+      );
     }
 
-    await usersSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
+    postUpdatePromises.push(
+      usersSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }])
+    );
 
     purgeCache({ tags: [`user-creator-${id}`] }).catch();
 
-    await refreshSession(id);
+    postUpdatePromises.push(refreshSession(id));
+
+    await Promise.all(postUpdatePromises);
 
     return updatedUser;
   } catch (error) {

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -1031,24 +1031,29 @@ export const addPostImage = async ({
   const [image] = await combinePostEditImageData([result], user);
 
   const modelVersionIds = image.resourceHelper.map((r) => r.modelVersionId).filter(isDefined);
-  // Cache Busting
-  await bustCacheTag(`images-user:${user.id}`);
-  if (!!modelVersionIds.length) {
-    for (const modelVersionId of modelVersionIds) {
-      await bustCacheTag(`images-modelVersion:${modelVersionId}`);
-    }
-
-    const modelVersions = await dbRead.modelVersion.findMany({
-      where: { id: { in: modelVersionIds } },
-      select: { modelId: true },
-    });
-    for (const modelVersion of modelVersions) {
-      await bustCacheTag(`images-model:${modelVersion.modelId}`);
-    }
+  // Cache Busting — parallelize independent operations
+  const cacheBustPromises: Promise<void>[] = [
+    bustCacheTag(`images-user:${user.id}`),
+    preventReplicationLag('postImages', props.postId),
+  ];
+  if (modelVersionIds.length) {
+    cacheBustPromises.push(
+      ...modelVersionIds.map((mvId) => bustCacheTag(`images-modelVersion:${mvId}`))
+    );
+    cacheBustPromises.push(
+      dbRead.modelVersion
+        .findMany({
+          where: { id: { in: modelVersionIds } },
+          select: { modelId: true },
+        })
+        .then((mvs) =>
+          Promise.all(mvs.map((mv) => bustCacheTag(`images-model:${mv.modelId}`)))
+        )
+        .then(() => undefined)
+    );
   }
-
-  await preventReplicationLag('postImages', props.postId);
-  await bustCachesForPosts(props.postId);
+  cacheBustPromises.push(bustCachesForPosts(props.postId));
+  await Promise.all(cacheBustPromises);
 
   return image;
 };


### PR DESCRIPTION
## Summary
- **post.addImage**: Parallelize cache busting loop — `bustCacheTag` per modelVersionId was sequential, now runs all busts + `preventReplicationLag` + `bustCachesForPosts` in `Promise.all`
- **user.update**: Parallelize cosmetic unequip calls (up to 4 sequential DB writes → `Promise.all`), and batch post-update operations (image deletion, ingestion, cosmetic equip, search index, session refresh) into `Promise.all`

## Profiling Data
- `post.addImage` P95: **25.5s**, P99: 29.1s (1.7 req/s, consuming 8.6 cores — 9% of all API compute)
- `user.update` P95: **28s**, P99: 29.6s
- Bimodal latency: <1s or 30s (hitting Traefik timeout ceiling)
- Root cause: sequential awaits in handler chains — each `bustCacheTag()` does `sMembers` + N `del` ops, serialized across multiple modelVersionIds

## Changes
### post.service.ts (`addPostImage`)
- Cache busting: user tag, per-modelVersion tags, per-model tags, `preventReplicationLag`, and `bustCachesForPosts` now all fire in parallel
- Model version lookup + its cache busts are chained with `.then()` to preserve dependency, but run concurrent with other busts

### user.controller.ts (`updateUserHandler`)
- Cosmetic unequip: up to 4 `unequipCosmeticByType` calls now batched in `Promise.all`
- Post-update: `deleteImageById`, `ingestImage` + cache clear, `equipCosmetic`, `createUserReferral`, `usersSearchIndex.queueUpdate`, and `refreshSession` all fire in parallel

## Test plan
- [x] `tsc --noEmit` passes (no new errors)
- [ ] After deploy: `post.addImage` P95 should drop from 25.5s to <5s
- [ ] After deploy: `user.update` P95 should drop from 28s to <5s
- [ ] Verify no data integrity issues — all parallelized operations are independent (no data dependencies between them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>