### PR TITLE
perf(training): switch getMyTrainingModels from dbWrite to dbRead

### DIFF
--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -1758,5 +1758,7 @@ export async function updateModelVersionTrainingStatus({
     }),
   ]);
 
+  await preventReplicationLag('modelVersion', id);
+
   return updatedVersion;
 }

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2215,14 +2215,14 @@ export const getTrainingModelsByUserId = async <TSelect extends Prisma.ModelVers
       break;
   }
 
-  const items = await dbWrite.modelVersion.findMany({
+  const items = await dbRead.modelVersion.findMany({
     select,
     skip,
     take,
     where,
     orderBy,
   });
-  const count = await dbWrite.modelVersion.count({ where });
+  const count = await dbRead.modelVersion.count({ where });
 
   return getPagingData({ items, count }, take, page);
 };

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2215,14 +2215,16 @@ export const getTrainingModelsByUserId = async <TSelect extends Prisma.ModelVers
       break;
   }
 
-  const items = await dbRead.modelVersion.findMany({
-    select,
-    skip,
-    take,
-    where,
-    orderBy,
-  });
-  const count = await dbRead.modelVersion.count({ where });
+  const [items, count] = await Promise.all([
+    dbRead.modelVersion.findMany({
+      select,
+      skip,
+      take,
+      where,
+      orderBy,
+    }),
+    dbRead.modelVersion.count({ where }),
+  ]);
 
   return getPagingData({ items, count }, take, page);
 };


### PR DESCRIPTION
## Summary
- Switch `getTrainingModelsByUserId` from `dbWrite` to `dbRead` — on DP, `dbWrite` goes cross-DC to DO managed Postgres while `dbRead` hits local CNPG nvme0, contributing to **P95=961ms** for `model.getMyTrainingModels`
- Add missing `preventReplicationLag('modelVersion', id)` call in `updateModelVersionTrainingStatus` so individual version reads fall back to write DB for 60s after a training status change
- Safe because `getDraftModelsByUserId` already uses `dbRead` for similar draft content, and training jobs take minutes/hours making 60s CDC lag negligible

Related: https://app.clickup.com/t/868ja7rex

## Test plan
- [ ] Verify training models list loads correctly on DP
- [ ] Submit a training job, confirm status updates still appear within ~60s
- [ ] Monitor `model.getMyTrainingModels` P95 latency in spanmetrics after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)