### PR TITLE
fix(articles): preserve user nsfwLevel choice without clamp

### DIFF
--- a/src/server/search-index/articles.search-index.ts
+++ b/src/server/search-index/articles.search-index.ts
@@ -103,11 +103,11 @@ const transformData = async ({
         tags: tags.map((articleTag) => articleTag.tag),
         coverImage: {
           ...coverImage,
-          // !important - when article `userNsfwLevel` equals article `nsfwLevel`, it's possible that the article `userNsfwLevel` is higher than the cover image `nsfwLevel`. In this case, we update the image to the higher `nsfwLevel` so that it will still pass through front end filters
-          nsfwLevel:
-            articleRecord.nsfwLevel === articleRecord.userNsfwLevel
-              ? articleRecord.nsfwLevel
-              : coverImage.nsfwLevel,
+          // Lift the cover image nsfwLevel to the article's aggregate so
+          // front-end filters (ImageGuard blur, browsingLevel mask) reflect
+          // the article's true rating whenever content images, userNsfwLevel,
+          // or the moderation floor raised it above the cover's own level.
+          nsfwLevel: Math.max(articleRecord.nsfwLevel ?? 0, coverImage.nsfwLevel ?? 0),
           meta: coverImage.meta as ImageMetaProps,
           tags: coverImage.tags.map((x) => x.tag),
         },

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -939,10 +939,14 @@ export const upsertArticle = async ({
     // article is guaranteed non-null here since the `if (id)` block above fetches it
     if (!article) throw throwNotFoundError();
 
-    // Auto-clamp userNsfwLevel to system floor instead of blocking edits
-    if (data.userNsfwLevel != null && !isModerator) {
-      data.userNsfwLevel = Math.max(data.userNsfwLevel, article.nsfwLevel);
-    }
+    // userNsfwLevel is the user's preference and is preserved verbatim. The
+    // effective article.nsfwLevel is derived by updateArticleNsfwLevels as
+    // GREATEST(userNsfwLevel, cover, content images, moderation floor), so
+    // writing a lower userNsfwLevel cannot leak content past filters — the
+    // higher signals keep nsfwLevel raised. When those signals later drop
+    // (images removed, moderation unactioned), nsfwLevel falls back to the
+    // user's original choice instead of being permanently anchored by a
+    // prior clamp.
 
     // Prevent owners from re-publishing articles unpublished for ToS violations
     if (


### PR DESCRIPTION
## Summary
- Drop the `upsertArticle` auto-clamp that bumped `userNsfwLevel` up to the current derived `article.nsfwLevel` on every edit. Once any image, text-moderation signal, or actioned NSFW report had raised the article, the user's own rating preference was silently overwritten on their next save and could never drop back — even after the triggering signal cleared.
- `userNsfwLevel` now round-trips verbatim. Safety is preserved because `updateArticleNsfwLevels` still derives the effective rating as `GREATEST(userNsfwLevel, cover, content images, moderation floor)`, so a lower user choice cannot leak content past filters while any raising signal is live. When those signals drop, `nsfwLevel` recomputes back to the user's original preference instead of being anchored forever by a ghost clamp artifact.
- Search-index cover-image lift was previously gated on `articleRecord.nsfwLevel === articleRecord.userNsfwLevel` — an invariant the clamp guaranteed post-edit. Without the clamp those can diverge, so the cover lift would stop firing whenever content/moderation raised the article. Replaced with an unconditional `Math.max(articleRecord.nsfwLevel, coverImage.nsfwLevel)`, mirroring the card-layer lift in `article.service.ts` so ImageGuard blur and browsingLevel masks still see the raised rating regardless of which signal lifted it.

## Test plan
- [ ] Create an article, set `userNsfwLevel = PG`, attach an R-rated scanned content image → `nsfwLevel` recomputes to R while `userNsfwLevel` stays PG in the edit form.
- [ ] Remove the R image, trigger recompute → `nsfwLevel` drops back to PG (previously stuck because clamp overwrote user choice on prior edit).
- [ ] Submit an NSFW report, action it → floor pins `nsfwLevel` to R regardless of `userNsfwLevel = PG`; unaction → drops back to user's PG.
- [ ] Article with `userNsfwLevel = PG` and content image = R appears correctly filtered in Meilisearch results (cover image record carries R, not PG).
- [ ] Moderator edit still bypasses any clamp behavior (no regression — clamp gate was already `!isModerator`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)