### PR TITLE
fix(articles): clarify maturity rating notice in edit form

### DIFF
--- a/src/components/Article/ArticleUpsertForm.tsx
+++ b/src/components/Article/ArticleUpsertForm.tsx
@@ -346,7 +346,7 @@ export function ArticleUpsertForm({ article }: Props) {
                   <ContentPolicyLink size="xs" variant="text" c="dimmed" td="underline" />
                 </Group>
               }
-              description="Final rating = max of your selection, cover image, and any content images. Image scans can raise it but never lower it."
+              description="Your preferred rating. The final rating is the max of your choice, cover and content images, text moderation, and any actioned NSFW reports. Updates automatically when those signals change."
             />
             {article?.nsfwLevel != null &&
               article.nsfwLevel > (article.userNsfwLevel ?? 0) &&
@@ -357,9 +357,25 @@ export function ArticleUpsertForm({ article }: Props) {
                     <Text span fw={600}>
                       {browsingLevelLabels[article.nsfwLevel as keyof typeof browsingLevelLabels]}
                     </Text>{' '}
-                    because the cover image or content images were scanned at that level. Your
-                    selection above is respected as a floor but cannot lower the rating below what
-                    the scanned images require.
+                    because an image, text-moderation scan, or an actioned NSFW report raised it
+                    above your preference
+                    {article.userNsfwLevel &&
+                    browsingLevelLabels[
+                      article.userNsfwLevel as keyof typeof browsingLevelLabels
+                    ] ? (
+                      <>
+                        {' '}
+                        of{' '}
+                        <Text span fw={600}>
+                          {
+                            browsingLevelLabels[
+                              article.userNsfwLevel as keyof typeof browsingLevelLabels
+                            ]
+                          }
+                        </Text>
+                      </>
+                    ) : null}
+                    . Your selection is saved and will apply again if those signals clear.
                   </Text>
                 </Alert>
               )}


### PR DESCRIPTION
## Summary
Follow-up to #2179 (merged) - the new \`userNsfwLevel\` semantics need the edit-form copy to match.

- \`Maturity Level\` picker description now names all four signals that can raise the final rating (cover image, content images, text moderation, actioned NSFW reports) and notes the rating updates when those signals change.
- Yellow mismatch alert (shown when \`article.nsfwLevel > userNsfwLevel\`) stops implying the cause is always images, calls out text-mod + reports, surfaces the user's preserved preference value, and reassures them it will reapply if the raising signal clears - matching the GREATEST-based recompute from #2179.

## Test plan
- [ ] Open an article in edit mode where images/mod raised \`nsfwLevel\` above \`userNsfwLevel\` - yellow alert names the correct rating and the user's preserved preference.
- [ ] Same scenario with \`userNsfwLevel = 0\` (unset) - alert omits the \"preference of X\" clause gracefully.
- [ ] Article where user choice matches system rating - no alert shown.
- [ ] Moderator edit still sees the picker enabled (no regression on lock handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)