### PR TITLE
feat(buzz): DB-backed Rewards Bonus Events with moderator UI

### DIFF
--- a/prisma/migrations/20260421082437_add_rewards_bonus_event/migration.sql
+++ b/prisma/migrations/20260421082437_add_rewards_bonus_event/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "RewardsBonusEvent" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "multiplier" INTEGER NOT NULL,
+    "articleId" INTEGER,
+    "bannerLabel" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "startsAt" TIMESTAMP(3),
+    "endsAt" TIMESTAMP(3),
+    "createdById" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RewardsBonusEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RewardsBonusEvent_enabled_startsAt_endsAt_idx" ON "RewardsBonusEvent"("enabled", "startsAt", "endsAt");
+
+-- AddForeignKey
+ALTER TABLE "RewardsBonusEvent" ADD CONSTRAINT "RewardsBonusEvent_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RewardsBonusEvent" ADD CONSTRAINT "RewardsBonusEvent_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -415,6 +415,7 @@ model User {
   challengeWins              ChallengeWinner[]
   challengeJudges            ChallengeJudge[]
   challengeEventsCreated     ChallengeEvent[]
+  rewardsBonusEventsCreated  RewardsBonusEvent[]             @relation("RewardsBonusEventCreator")
   strikes                     UserStrike[]                    @relation("userStrikes")
   issuedStrikes               UserStrike[]                    @relation("strikeIssuedBy")
   voidedStrikes               UserStrike[]                    @relation("strikeVoidedBy")
@@ -2340,6 +2341,25 @@ model Announcement {
   disabled  Boolean       @default(false)
 }
 
+model RewardsBonusEvent {
+  id          Int       @id @default(autoincrement())
+  name        String
+  description String?
+  multiplier  Int       /// Stored as multiplier * 10. e.g. 15 = 1.5x (50% MORE), 20 = 2x, 30 = 3x, 40 = 4x. Minimum effective value 10 (no bonus).
+  articleId   Int?
+  article     Article?  @relation(fields: [articleId], references: [id], onDelete: SetNull)
+  bannerLabel String?
+  enabled     Boolean   @default(false)
+  startsAt    DateTime?
+  endsAt      DateTime?
+  createdById Int
+  createdBy   User      @relation("RewardsBonusEventCreator", fields: [createdById], references: [id], onDelete: Restrict)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([enabled, startsAt, endsAt])
+}
+
 enum CosmeticType {
   Badge
   NamePlate
@@ -2523,16 +2543,17 @@ model Article {
   lockedProperties String[]      @default([])
   status           ArticleStatus @default(Draft)
 
-  thread          Thread?
-  reactions       ArticleReaction[]
-  tags            TagsOnArticle[]
-  reports         ArticleReport[]
-  metrics         ArticleMetric[]
-  rank            ArticleRank?
-  stats           ArticleStat?
-  engagements     ArticleEngagement[]
-  associations    ModelAssociations[]
-  collectionItems CollectionItem[]
+  thread             Thread?
+  reactions          ArticleReaction[]
+  tags               TagsOnArticle[]
+  reports            ArticleReport[]
+  metrics            ArticleMetric[]
+  rank               ArticleRank?
+  stats              ArticleStat?
+  engagements        ArticleEngagement[]
+  associations       ModelAssociations[]
+  collectionItems    CollectionItem[]
+  rewardsBonusEvents RewardsBonusEvent[]
 
   @@index([status, ingestion, nsfwLevel])
 }

--- a/src/components/Buzz/RewardsBonusBanner.tsx
+++ b/src/components/Buzz/RewardsBonusBanner.tsx
@@ -10,13 +10,15 @@ export function RewardsBonusBanner() {
   const { multipliers, multipliersLoading } = useUserMultipliers();
 
   const bonus = multipliers.globalRewardsBonus;
+  const event = multipliers.rewardsBonusEvent;
 
   if (!currentUser || multipliersLoading || bonus <= 1) return null;
 
   // For 2x+, show as "2x" (people like the multiplier framing).
   // For fractional like 1.5x, show as "50% more" (reads bigger).
-  const bonusLabel =
-    bonus >= 2 ? `${formatMultiplier(bonus)}` : `${((bonus - 1) * 100).toFixed(0)}% MORE`;
+  const multiplierLabel =
+    bonus >= 2 ? `${formatMultiplier(bonus)} BUZZ` : `${((bonus - 1) * 100).toFixed(0)}% MORE BUZZ`;
+  const headline = event?.bannerLabel?.trim() || 'BONUS REWARDS ACTIVE';
 
   const handleClick = () => {
     dialogStore.trigger({
@@ -42,9 +44,9 @@ export function RewardsBonusBanner() {
       <div className="relative flex items-center gap-2 text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.4)]">
         <IconSparkles size={16} />
         <IconBolt size={16} fill="currentColor" />
-        <span className="tracking-wide">BONUS REWARDS ACTIVE</span>
+        <span className="tracking-wide">{headline}</span>
         <span className="rounded-full bg-black/25 px-2.5 py-0.5 text-xs font-bold">
-          {bonusLabel} BUZZ
+          {multiplierLabel}
         </span>
         <IconBolt size={16} fill="currentColor" />
         <IconSparkles size={16} />

--- a/src/components/Buzz/RewardsBonusInfoModal.tsx
+++ b/src/components/Buzz/RewardsBonusInfoModal.tsx
@@ -1,8 +1,9 @@
-import { Button, Divider, Modal, Stack, Text, ThemeIcon } from '@mantine/core';
-import { IconBolt, IconSparkles, IconArrowRight } from '@tabler/icons-react';
+import { Button, Group, Modal, Stack, Text, ThemeIcon } from '@mantine/core';
+import { IconBolt, IconSparkles, IconArrowRight, IconBook2 } from '@tabler/icons-react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useUserMultipliers } from '~/components/Buzz/useBuzz';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import { formatMultiplier } from '~/utils/buzz';
 
 type Props = Record<string, never>;
@@ -15,17 +16,33 @@ export default function RewardsBonusInfoModal(_props: Props) {
   const totalMultiplier = multipliers.rewardsMultiplier;
   const baseMultiplier = multipliers.baseRewardsMultiplier;
   const hasSubscriptionBonus = baseMultiplier > 1;
+  const event = multipliers.rewardsBonusEvent;
 
   const bonusLabel =
     globalBonus >= 2
       ? formatMultiplier(globalBonus)
       : `${((globalBonus - 1) * 100).toFixed(0)}%`;
 
+  const headline = event?.name || 'BONUS REWARDS ACTIVE';
+
   return (
-    <Modal {...dialog} size="sm" radius="lg" withCloseButton>
+    <Modal
+      {...dialog}
+      size="sm"
+      radius="lg"
+      withCloseButton
+      closeButtonProps={{
+        className:
+          'bg-black/40 text-white hover:bg-black/60 border border-white/20 backdrop-blur-sm',
+      }}
+      classNames={{
+        header: 'absolute right-0 top-0 z-10 min-h-0 bg-transparent p-2',
+        body: 'pt-0',
+      }}
+    >
       <Stack align="center" gap="md" pb="sm">
-        {/* Hero section */}
-        <div className="relative flex items-center justify-center overflow-hidden rounded-xl px-6 py-5 motion-reduce:animate-none">
+        {/* Hero section (full-bleed to modal edges) */}
+        <div className="relative -mx-4 flex items-center justify-center self-stretch overflow-hidden px-6 py-5 motion-reduce:animate-none">
           <div className="absolute inset-0 animate-gradient-shift bg-gradient-to-r from-amber-700 via-amber-500 to-amber-700 bg-[length:200%_100%] motion-reduce:animate-none" />
           <div className="absolute inset-0 animate-shimmer bg-gradient-to-r from-transparent via-white/20 to-transparent bg-[length:200%_100%] motion-reduce:animate-none" />
           <div className="relative flex flex-col items-center gap-2">
@@ -36,8 +53,14 @@ export default function RewardsBonusInfoModal(_props: Props) {
               </ThemeIcon>
               <IconSparkles size={24} />
             </div>
-            <Text size="xl" fw={800} c="white" className="drop-shadow-[0_1px_3px_rgba(0,0,0,0.3)]">
-              BONUS REWARDS ACTIVE
+            <Text
+              size="xl"
+              fw={800}
+              c="white"
+              ta="center"
+              className="drop-shadow-[0_1px_3px_rgba(0,0,0,0.3)]"
+            >
+              {headline}
             </Text>
           </div>
         </div>
@@ -45,21 +68,26 @@ export default function RewardsBonusInfoModal(_props: Props) {
         <Stack gap="xs" align="center" px="sm">
           <Text size="lg" fw={700} ta="center">
             All reward earnings are boosted by{' '}
-            <Text span c="yellow.5" fw={800}>
+            <Text span c="yellow.5" fw={900} size="2rem">
               {bonusLabel}
             </Text>
-            !
           </Text>
 
-          <Text size="sm" c="dimmed" ta="center">
-            Every Blue Buzz reward you earn during this bonus period is automatically multiplied.
-          </Text>
+          {event?.description ? (
+            <div className="markdown-content text-center text-sm text-[var(--mantine-color-dimmed)]">
+              <CustomMarkdown allowedElements={['a', 'strong', 'em', 'p', 'br']} unwrapDisallowed>
+                {event.description}
+              </CustomMarkdown>
+            </div>
+          ) : (
+            <Text size="sm" c="dimmed" ta="center">
+              Every Blue Buzz reward you earn during this bonus period is automatically multiplied.
+            </Text>
+          )}
         </Stack>
 
-        <Divider w="100%" />
-
         {/* Multiplier breakdown */}
-        <Stack gap={4} w="100%" px="sm">
+        <Stack gap={4} w="100%">
           {hasSubscriptionBonus && (
             <div className="flex items-center justify-between rounded-md bg-gray-1 px-3 py-2 dark:bg-dark-5">
               <Text size="sm">Your membership bonus</Text>
@@ -84,18 +112,31 @@ export default function RewardsBonusInfoModal(_props: Props) {
           </div>
         </Stack>
 
-        <Button
-          component={Link}
-          href="/user/buzz-dashboard?buzzType=blue#rewards"
-          onClick={() => dialog.onClose()}
-          fullWidth
-          size="md"
-          variant="gradient"
-          gradient={{ from: 'yellow.6', to: 'orange.5' }}
-          rightSection={<IconArrowRight size={18} />}
-        >
-          View Ways to Earn
-        </Button>
+        <Group gap="xs" w="100%" grow>
+          {event?.articleId ? (
+            <Button
+              component={Link}
+              href={`/articles/${event.articleId}`}
+              onClick={() => dialog.onClose()}
+              size="md"
+              variant="default"
+              leftSection={<IconBook2 size={18} />}
+            >
+              Learn more
+            </Button>
+          ) : null}
+          <Button
+            component={Link}
+            href="/user/buzz-dashboard?buzzType=blue#rewards"
+            onClick={() => dialog.onClose()}
+            size="md"
+            variant="gradient"
+            gradient={{ from: 'yellow.6', to: 'orange.5' }}
+            rightSection={<IconArrowRight size={18} />}
+          >
+            How to Earn
+          </Button>
+        </Group>
       </Stack>
     </Modal>
   );

--- a/src/components/Buzz/useBuzz.ts
+++ b/src/components/Buzz/useBuzz.ts
@@ -71,6 +71,7 @@ export const useUserMultipliers = () => {
       rewardsMultiplier: 1,
       baseRewardsMultiplier: 1,
       globalRewardsBonus: 1,
+      rewardsBonusEvent: null,
     },
     isLoading,
   } = trpc.buzz.getUserMultipliers.useQuery(undefined, {

--- a/src/components/Moderation/ModerationNav.tsx
+++ b/src/components/Moderation/ModerationNav.tsx
@@ -54,6 +54,10 @@ export function ModerationNav() {
           hidden: !features.announcements,
         },
         {
+          label: 'Rewards Bonus Events',
+          href: '/moderator/rewards-bonus-events',
+        },
+        {
           label: 'Code Gifts',
           href: '/moderator/code-gifts',
         },

--- a/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
+++ b/src/components/RewardsBonusEvent/RewardsBonusEventEditModal.tsx
@@ -1,0 +1,213 @@
+import { Button, Modal, Stack } from '@mantine/core';
+import { DatePickerInput } from '@mantine/dates';
+import { useMemo } from 'react';
+import { Controller } from 'react-hook-form';
+import * as z from 'zod';
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import {
+  Form,
+  InputCheckbox,
+  InputSelect,
+  InputText,
+  InputTextArea,
+  useForm,
+} from '~/libs/form';
+import {
+  REWARDS_BONUS_MULTIPLIER_OPTIONS,
+  type UpsertRewardsBonusEventSchema,
+} from '~/server/schema/rewards-bonus-event.schema';
+import dayjs from '~/shared/utils/dayjs';
+import { fromDisplayUTC, toDisplayUTC } from '~/utils/date-helpers';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+const multiplierLabels: Record<number, string> = {
+  15: '50% more (1.5x)',
+  20: '2x',
+  30: '3x',
+  40: '4x',
+};
+
+const multiplierOptions = REWARDS_BONUS_MULTIPLIER_OPTIONS.map((value) => ({
+  value: String(value),
+  label: multiplierLabels[value] ?? `${value / 10}x`,
+}));
+
+const schema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(120),
+  description: z.string().trim().max(5000).optional(),
+  multiplier: z.string(),
+  articleUrl: z.string().optional(),
+  bannerLabel: z.string().trim().max(60).optional(),
+  enabled: z.boolean().default(false),
+  startsAt: z.date().nullish(),
+  endsAt: z.date().nullish(),
+});
+
+function extractArticleId(input?: string | null): number | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/\/articles\/(\d+)/);
+  if (match) return Number(match[1]);
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+  return null;
+}
+
+export function RewardsBonusEventEditModal({
+  event,
+}: {
+  event?: {
+    id?: number;
+    name?: string;
+    description?: string | null;
+    multiplier?: number;
+    articleId?: number | null;
+    bannerLabel?: string | null;
+    enabled?: boolean;
+    startsAt?: Date | null;
+    endsAt?: Date | null;
+  };
+}) {
+  const dialog = useDialogContext();
+  const queryUtils = trpc.useUtils();
+
+  const defaultMultiplier = event?.multiplier ?? 20;
+  const form = useForm({
+    schema,
+    defaultValues: {
+      name: event?.name ?? '',
+      description: event?.description ?? '',
+      multiplier: String(defaultMultiplier),
+      articleUrl: event?.articleId ? `/articles/${event.articleId}` : '',
+      bannerLabel: event?.bannerLabel ?? '',
+      enabled: event?.enabled ?? false,
+      startsAt: event?.startsAt ? toDisplayUTC(event.startsAt) : undefined,
+      endsAt: event?.endsAt ? toDisplayUTC(event.endsAt) : undefined,
+    },
+  });
+
+  const title = useMemo(
+    () => (event?.id ? 'Edit Rewards Bonus Event' : 'Create Rewards Bonus Event'),
+    [event?.id]
+  );
+
+  const { mutate, isLoading } = trpc.rewardsBonusEvent.upsert.useMutation({
+    onSuccess: () => {
+      queryUtils.rewardsBonusEvent.getPaged.invalidate();
+      queryUtils.buzz.getUserMultipliers.invalidate();
+      showSuccessNotification({ message: 'Rewards bonus event saved' });
+      dialog.onClose();
+    },
+    onError: (error) => {
+      showErrorNotification({ title: 'Could not save event', error: new Error(error.message) });
+    },
+  });
+
+  function handleSubmit(data: z.infer<typeof schema>) {
+    const startsAt = data.startsAt
+      ? dayjs.utc(fromDisplayUTC(data.startsAt)).startOf('day').toDate()
+      : null;
+    const endsAt = data.endsAt
+      ? dayjs.utc(fromDisplayUTC(data.endsAt)).endOf('day').toDate()
+      : null;
+
+    const payload: UpsertRewardsBonusEventSchema = {
+      id: event?.id,
+      name: data.name.trim(),
+      description: data.description?.trim() || null,
+      multiplier: Number(data.multiplier),
+      articleId: extractArticleId(data.articleUrl),
+      bannerLabel: data.bannerLabel?.trim() || null,
+      enabled: data.enabled,
+      startsAt,
+      endsAt,
+    };
+    mutate(payload);
+  }
+
+  return (
+    <Modal {...dialog} title={title} size="lg">
+      <Form form={form} onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <InputText
+          name="name"
+          label="Name"
+          description="Shown at the top of the info modal. e.g. Transition Thank-You Bonus"
+          withAsterisk
+        />
+        <InputTextArea
+          name="description"
+          label="Description"
+          description="Shown in the info modal. Supports markdown (paragraphs, **bold**, *italic*, [links](/url), line breaks)."
+          autosize
+          minRows={3}
+        />
+        <InputSelect
+          name="multiplier"
+          label="Multiplier"
+          description="Global Blue Buzz reward multiplier while this event is active."
+          data={multiplierOptions}
+          withAsterisk
+        />
+        <InputText
+          name="articleUrl"
+          label="Article link"
+          description="Paste a Civitai article URL or the article ID. We'll extract the ID and link it from the info modal as a 'Learn more' button. Works on both civitai.com and civitai.red."
+          placeholder="https://civitai.com/articles/28936"
+        />
+        <InputText
+          name="bannerLabel"
+          label="Banner label override"
+          description="Overrides the default 'BONUS REWARDS ACTIVE' text in the site-wide banner. Leave blank to use the default."
+          placeholder="e.g. HOLIDAY BONUS or TRANSITION THANK-YOU"
+        />
+        <div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
+          <Controller
+            control={form.control}
+            name="startsAt"
+            render={({ field }) => (
+              <DatePickerInput
+                label="Starts at"
+                placeholder="No start date"
+                value={field.value ?? null}
+                onChange={(v) => field.onChange(v ?? null)}
+                clearable
+              />
+            )}
+          />
+          <Controller
+            control={form.control}
+            name="endsAt"
+            render={({ field }) => {
+              const startsAtValue = form.watch('startsAt');
+              const today = dayjs().startOf('day').toDate();
+              const minEndDate =
+                startsAtValue && startsAtValue.getTime() > today.getTime()
+                  ? startsAtValue
+                  : today;
+              return (
+                <DatePickerInput
+                  label="Ends at"
+                  placeholder="No end date"
+                  value={field.value ?? null}
+                  onChange={(v) => field.onChange(v ?? null)}
+                  minDate={minEndDate}
+                  clearable
+                />
+              );
+            }}
+          />
+        </div>
+        <InputCheckbox
+          name="enabled"
+          label="Enabled (must also be within the start/end window to be active)"
+        />
+        <Stack gap="xs" pt="sm">
+          <Button type="submit" loading={isLoading}>
+            Save
+          </Button>
+        </Stack>
+      </Form>
+    </Modal>
+  );
+}

--- a/src/pages/moderator/rewards-bonus-events.tsx
+++ b/src/pages/moderator/rewards-bonus-events.tsx
@@ -1,0 +1,185 @@
+import { Badge, Button, Center, Container, Group, Pagination, Stack, Table, Text, Title } from '@mantine/core';
+import { IconPencil, IconPlus, IconTrash } from '@tabler/icons-react';
+import { useRouter } from 'next/router';
+import * as z from 'zod';
+import { Meta } from '~/components/Meta/Meta';
+import { dialogStore } from '~/components/Dialog/dialogStore';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { PageLoader } from '~/components/PageLoader/PageLoader';
+import { PopConfirm } from '~/components/PopConfirm/PopConfirm';
+import { RewardsBonusEventEditModal } from '~/components/RewardsBonusEvent/RewardsBonusEventEditModal';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { formatDate } from '~/utils/date-helpers';
+import { trpc } from '~/utils/trpc';
+
+const querySchema = z.object({ page: z.coerce.number().default(1) });
+
+function formatMultiplier(stored: number): string {
+  const value = stored / 10;
+  if (value < 2) return `${Math.round((value - 1) * 100)}% more (${value}x)`;
+  return `${value}x`;
+}
+
+function isActive(event: {
+  enabled: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+}): boolean {
+  if (!event.enabled) return false;
+  const now = Date.now();
+  const starts = event.startsAt ? new Date(event.startsAt).getTime() : -Infinity;
+  const ends = event.endsAt ? new Date(event.endsAt).getTime() : Infinity;
+  return starts <= now && now <= ends;
+}
+
+export default function RewardsBonusEventsPage() {
+  const router = useRouter();
+  const { page } = querySchema.parse(router.query);
+  const currentUser = useCurrentUser();
+  const queryUtils = trpc.useUtils();
+
+  const { data, isLoading } = trpc.rewardsBonusEvent.getPaged.useQuery(
+    { page },
+    { enabled: !!currentUser?.isModerator }
+  );
+
+  const deleteMutation = trpc.rewardsBonusEvent.delete.useMutation({
+    onSuccess: () => {
+      queryUtils.rewardsBonusEvent.getPaged.invalidate();
+      queryUtils.buzz.getUserMultipliers.invalidate();
+    },
+  });
+
+  function openEdit(event?: Parameters<typeof RewardsBonusEventEditModal>[0]['event']) {
+    dialogStore.trigger({
+      component: RewardsBonusEventEditModal,
+      props: { event },
+    });
+  }
+
+  function handlePage(value: number) {
+    router.replace({ query: { ...router.query, page: value } }, undefined, { shallow: true });
+  }
+
+  if (!currentUser?.isModerator) {
+    return (
+      <Center py="xl">
+        <Text>Access denied. You do not have permission to access this page.</Text>
+      </Center>
+    );
+  }
+
+  return (
+    <>
+      <Meta title="Rewards Bonus Events - Moderator" deIndex />
+      <Container size="lg" py="md">
+        <Stack gap="md">
+          <Group justify="space-between" align="center">
+            <Stack gap={0}>
+              <Title order={2}>Rewards Bonus Events</Title>
+              <Text size="sm" c="dimmed">
+                Site-wide multipliers on Blue Buzz rewards. Highest-multiplier active event wins.
+              </Text>
+            </Stack>
+            <Button leftSection={<IconPlus size={16} />} onClick={() => openEdit()}>
+              New Event
+            </Button>
+          </Group>
+
+          {isLoading ? (
+            <PageLoader />
+          ) : !data || data.items.length === 0 ? (
+            <Center py="xl">
+              <Text c="dimmed">No rewards bonus events yet.</Text>
+            </Center>
+          ) : (
+            <Table striped withTableBorder>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Status</Table.Th>
+                  <Table.Th>Name</Table.Th>
+                  <Table.Th>Multiplier</Table.Th>
+                  <Table.Th>Window</Table.Th>
+                  <Table.Th>Article</Table.Th>
+                  <Table.Th style={{ width: 100 }}>Actions</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {data.items.map((event) => {
+                  const active = isActive(event);
+                  return (
+                    <Table.Tr key={event.id}>
+                      <Table.Td>
+                        {active ? (
+                          <Badge color="green">Active</Badge>
+                        ) : event.enabled ? (
+                          <Badge color="yellow">Scheduled</Badge>
+                        ) : (
+                          <Badge color="gray">Disabled</Badge>
+                        )}
+                      </Table.Td>
+                      <Table.Td>
+                        <Stack gap={0}>
+                          <Text size="sm" fw={600}>
+                            {event.name}
+                          </Text>
+                          {event.bannerLabel ? (
+                            <Text size="xs" c="dimmed">
+                              Banner: {event.bannerLabel}
+                            </Text>
+                          ) : null}
+                        </Stack>
+                      </Table.Td>
+                      <Table.Td>{formatMultiplier(event.multiplier)}</Table.Td>
+                      <Table.Td>
+                        <Text size="xs">
+                          {event.startsAt ? formatDate(event.startsAt) : 'now'}
+                          {' → '}
+                          {event.endsAt ? formatDate(event.endsAt) : 'no end'}
+                        </Text>
+                      </Table.Td>
+                      <Table.Td>
+                        {event.articleId ? (
+                          <Text size="xs">
+                            <a href={`/articles/${event.articleId}`} target="_blank" rel="noreferrer">
+                              #{event.articleId}
+                            </a>
+                          </Text>
+                        ) : (
+                          <Text size="xs" c="dimmed">
+                            —
+                          </Text>
+                        )}
+                      </Table.Td>
+                      <Table.Td>
+                        <Group gap={4} wrap="nowrap">
+                          <LegacyActionIcon onClick={() => openEdit(event)}>
+                            <IconPencil size={16} />
+                          </LegacyActionIcon>
+                          <PopConfirm
+                            onConfirm={() => deleteMutation.mutate({ id: event.id })}
+                            withinPortal
+                          >
+                            <LegacyActionIcon loading={deleteMutation.isLoading} color="red">
+                              <IconTrash size={16} />
+                            </LegacyActionIcon>
+                          </PopConfirm>
+                        </Group>
+                      </Table.Td>
+                    </Table.Tr>
+                  );
+                })}
+              </Table.Tbody>
+            </Table>
+          )}
+
+          {data && data.totalPages > 1 && (
+            <Group justify="end">
+              <Pagination value={page} total={data.totalPages} onChange={handlePage} />
+            </Group>
+          )}
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -38,7 +38,6 @@ export enum FLIPT_FEATURE_FLAGS {
   WAN22_MULTI_STEP = 'wan22-multi-step',
   IMAGE_INDEX_FEED = 'image-index-feed',
   BITDEX_IMAGE_SEARCH = 'bitdex-image-search',
-  REWARDS_BONUS_MULTIPLIER = 'rewards-bonus-multiplier',
   // Routes ImageResourceNew reads to the writer (primary) instead of the read
   // replica while the DataPacket replica is missing historical backfill rows
   // for imageId < ~110M. Flip off once backfill is complete.

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -82,6 +82,7 @@ import { coinbaseRouter } from './coinbase.router';
 import { emerchantpayRouter } from './emerchantpay.router';
 import { comicsRouter } from './comics.router';
 import { strikeRouter } from '~/server/routers/strike.router';
+import { rewardsBonusEventRouter } from './rewards-bonus-event.router';
 
 export const appRouter = router({
   account: accountRouter,
@@ -167,6 +168,7 @@ export const appRouter = router({
   emerchantpay: emerchantpayRouter,
   comics: comicsRouter,
   strike: strikeRouter,
+  rewardsBonusEvent: rewardsBonusEventRouter,
 });
 
 // export type definition of API

--- a/src/server/routers/rewards-bonus-event.router.ts
+++ b/src/server/routers/rewards-bonus-event.router.ts
@@ -1,0 +1,27 @@
+import { router, moderatorProcedure } from '~/server/trpc';
+import {
+  getRewardsBonusEventsPagedSchema,
+  upsertRewardsBonusEventSchema,
+} from '~/server/schema/rewards-bonus-event.schema';
+import {
+  deleteRewardsBonusEvent,
+  getRewardsBonusEventById,
+  getRewardsBonusEventsPaged,
+  upsertRewardsBonusEvent,
+} from '~/server/services/rewards-bonus-event.service';
+import { getByIdSchema } from '~/server/schema/base.schema';
+
+export const rewardsBonusEventRouter = router({
+  upsert: moderatorProcedure
+    .input(upsertRewardsBonusEventSchema)
+    .mutation(({ input, ctx }) => upsertRewardsBonusEvent(input, ctx.user.id)),
+  delete: moderatorProcedure
+    .input(getByIdSchema)
+    .mutation(({ input }) => deleteRewardsBonusEvent(input.id)),
+  getById: moderatorProcedure
+    .input(getByIdSchema)
+    .query(({ input }) => getRewardsBonusEventById(input.id)),
+  getPaged: moderatorProcedure
+    .input(getRewardsBonusEventsPagedSchema)
+    .query(({ input }) => getRewardsBonusEventsPaged(input)),
+});

--- a/src/server/schema/rewards-bonus-event.schema.ts
+++ b/src/server/schema/rewards-bonus-event.schema.ts
@@ -1,0 +1,40 @@
+import * as z from 'zod';
+import { paginationSchema } from '~/server/schema/base.schema';
+
+export const REWARDS_BONUS_MULTIPLIER_OPTIONS = [15, 20, 30, 40] as const;
+export type RewardsBonusMultiplier = (typeof REWARDS_BONUS_MULTIPLIER_OPTIONS)[number];
+
+export function formatRewardsBonusMultiplierLabel(multiplier: number): string {
+  const value = multiplier / 10;
+  if (value < 2) return `${Math.round((value - 1) * 100)}% MORE BUZZ`;
+  if (multiplier % 10 === 0) return `${value}x BUZZ`;
+  return `${value.toFixed(1)}x BUZZ`;
+}
+
+export const multiplierSchema = z
+  .number()
+  .int()
+  .refine((v) => (REWARDS_BONUS_MULTIPLIER_OPTIONS as readonly number[]).includes(v), {
+    message: `Multiplier must be one of: ${REWARDS_BONUS_MULTIPLIER_OPTIONS.join(', ')}`,
+  });
+
+export type UpsertRewardsBonusEventSchema = z.infer<typeof upsertRewardsBonusEventSchema>;
+export const upsertRewardsBonusEventSchema = z
+  .object({
+    id: z.number().int().optional(),
+    name: z.string().trim().min(1).max(120),
+    description: z.string().trim().max(5000).nullish(),
+    multiplier: multiplierSchema,
+    articleId: z.number().int().positive().nullish(),
+    bannerLabel: z.string().trim().max(60).nullish(),
+    enabled: z.boolean().default(false),
+    startsAt: z.coerce.date().nullish(),
+    endsAt: z.coerce.date().nullish(),
+  })
+  .refine((v) => !v.startsAt || !v.endsAt || v.startsAt <= v.endsAt, {
+    message: 'Start date must be before end date',
+    path: ['endsAt'],
+  });
+
+export type GetRewardsBonusEventsPagedSchema = z.infer<typeof getRewardsBonusEventsPagedSchema>;
+export const getRewardsBonusEventsPagedSchema = paginationSchema;

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -185,22 +185,20 @@ export function getMultipliersForUserCache(userIds: number[]) {
 const MAX_GLOBAL_BONUS = 5;
 
 /**
- * Returns the global rewards bonus multiplier from the Flipt variant flag.
- * Use this for time-limited bonus events (e.g. double rewards weekend).
- * The variant key should be a numeric string like "2" for 2x, "1.5" for 1.5x.
- * Returns 1 when no bonus is active, Flipt is unavailable, or the value is invalid.
+ * Returns the global rewards bonus multiplier from the active RewardsBonusEvent.
+ * The event's `multiplier` column stores value * 10 (e.g. 20 = 2x, 5 = 0.5x).
+ * Returns 1 when no event is active or the value is invalid.
  * Capped at MAX_GLOBAL_BONUS to prevent config mistakes from breaking the economy.
  */
 export async function getGlobalRewardsBonusMultiplier(): Promise<number> {
   try {
-    const { getFliptVariant, FLIPT_FEATURE_FLAGS } = await import('~/server/flipt/client');
-    const variant = await getFliptVariant(FLIPT_FEATURE_FLAGS.REWARDS_BONUS_MULTIPLIER);
-    if (!variant) return 1;
+    const { getActiveRewardsBonusEvent } = await import(
+      '~/server/services/rewards-bonus-event.service'
+    );
+    const event = await getActiveRewardsBonusEvent();
+    if (!event) return 1;
 
-    const trimmed = variant.trim();
-    if (!/^\d+(\.\d+)?$/.test(trimmed)) return 1;
-
-    const parsed = Number(trimmed);
+    const parsed = event.multiplier / 10;
     if (!Number.isFinite(parsed) || parsed < 1) return 1;
 
     return Math.min(parsed, MAX_GLOBAL_BONUS);
@@ -215,13 +213,34 @@ export async function getMultipliersForUser(userId: number, refresh = false) {
   const multipliers = await getMultipliersForUserCache([userId]);
   const base = multipliers[userId] ?? { purchasesMultiplier: 1, rewardsMultiplier: 1, userId };
 
-  const globalRewardsBonus = await getGlobalRewardsBonusMultiplier();
+  const { getActiveRewardsBonusEvent } = await import(
+    '~/server/services/rewards-bonus-event.service'
+  );
+  const event = await getActiveRewardsBonusEvent();
+
+  const rawMultiplier = event ? event.multiplier / 10 : 1;
+  const globalRewardsBonus = Number.isFinite(rawMultiplier)
+    ? Math.min(Math.max(rawMultiplier, 1), MAX_GLOBAL_BONUS)
+    : 1;
 
   return {
     ...base,
     rewardsMultiplier: base.rewardsMultiplier * globalRewardsBonus,
     baseRewardsMultiplier: base.rewardsMultiplier,
     globalRewardsBonus,
+    rewardsBonusEvent:
+      event && globalRewardsBonus > 1
+        ? {
+            id: event.id,
+            name: event.name,
+            description: event.description,
+            articleId: event.articleId,
+            bannerLabel: event.bannerLabel,
+            multiplier: event.multiplier,
+            startsAt: event.startsAt,
+            endsAt: event.endsAt,
+          }
+        : null,
   };
 }
 

--- a/src/server/services/rewards-bonus-event.service.ts
+++ b/src/server/services/rewards-bonus-event.service.ts
@@ -1,0 +1,148 @@
+import { dbRead, dbWrite } from '~/server/db/client';
+import type {
+  GetRewardsBonusEventsPagedSchema,
+  UpsertRewardsBonusEventSchema,
+} from '~/server/schema/rewards-bonus-event.schema';
+import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
+
+const ENABLED_EVENTS_TTL_MS = 5 * 60 * 1000;
+
+export type ActiveRewardsBonusEvent = {
+  id: number;
+  name: string;
+  description: string | null;
+  multiplier: number;
+  articleId: number | null;
+  bannerLabel: string | null;
+  startsAt: Date | null;
+  endsAt: Date | null;
+};
+
+type CacheEntry = {
+  events: ActiveRewardsBonusEvent[];
+  expiresAt: number;
+};
+
+// Cache the list of `enabled: true` events, not the time-filtered result.
+// Time boundaries are evaluated against the current instant on every call so
+// that scheduled start/end transitions take effect immediately instead of
+// waiting for cache expiry.
+let enabledEventsCache: CacheEntry | null = null;
+
+function invalidateEnabledEventsCache() {
+  enabledEventsCache = null;
+}
+
+async function getEnabledEvents(): Promise<ActiveRewardsBonusEvent[]> {
+  const now = Date.now();
+  if (enabledEventsCache && enabledEventsCache.expiresAt > now) return enabledEventsCache.events;
+
+  const events = await dbRead.rewardsBonusEvent.findMany({
+    where: { enabled: true },
+    orderBy: [{ multiplier: 'desc' }, { createdAt: 'desc' }],
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      multiplier: true,
+      articleId: true,
+      bannerLabel: true,
+      startsAt: true,
+      endsAt: true,
+    },
+  });
+
+  enabledEventsCache = { events, expiresAt: now + ENABLED_EVENTS_TTL_MS };
+  return events;
+}
+
+export async function getActiveRewardsBonusEvent(): Promise<ActiveRewardsBonusEvent | null> {
+  const events = await getEnabledEvents();
+  const current = new Date();
+  return (
+    events.find(
+      (event) =>
+        (!event.startsAt || event.startsAt <= current) &&
+        (!event.endsAt || event.endsAt >= current)
+    ) ?? null
+  );
+}
+
+export async function upsertRewardsBonusEvent(
+  data: UpsertRewardsBonusEventSchema,
+  userId: number
+) {
+  const { id, ...fields } = data;
+  const payload = {
+    name: fields.name,
+    description: fields.description ?? null,
+    multiplier: fields.multiplier,
+    articleId: fields.articleId ?? null,
+    bannerLabel: fields.bannerLabel ?? null,
+    enabled: fields.enabled,
+    startsAt: fields.startsAt ?? null,
+    endsAt: fields.endsAt ?? null,
+  };
+
+  const result = id
+    ? await dbWrite.rewardsBonusEvent.update({ where: { id }, data: payload })
+    : await dbWrite.rewardsBonusEvent.create({
+        data: { ...payload, createdById: userId },
+      });
+
+  invalidateEnabledEventsCache();
+  return result;
+}
+
+export async function deleteRewardsBonusEvent(id: number) {
+  await dbWrite.rewardsBonusEvent.delete({ where: { id } });
+  invalidateEnabledEventsCache();
+}
+
+export async function getRewardsBonusEventById(id: number) {
+  return dbRead.rewardsBonusEvent.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      multiplier: true,
+      articleId: true,
+      bannerLabel: true,
+      enabled: true,
+      startsAt: true,
+      endsAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+}
+
+export async function getRewardsBonusEventsPaged(data: GetRewardsBonusEventsPagedSchema) {
+  const { limit = DEFAULT_PAGE_SIZE, page } = data ?? {};
+  const { take, skip } = getPagination(limit, page);
+
+  const [items, count] = await dbRead.$transaction([
+    dbRead.rewardsBonusEvent.findMany({
+      skip,
+      take,
+      orderBy: [{ enabled: 'desc' }, { startsAt: { sort: 'desc', nulls: 'last' } }, { id: 'desc' }],
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        multiplier: true,
+        articleId: true,
+        bannerLabel: true,
+        enabled: true,
+        startsAt: true,
+        endsAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+    dbRead.rewardsBonusEvent.count(),
+  ]);
+
+  return getPagingData({ items, count }, limit, page);
+}

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -502,6 +502,7 @@ export interface User {
   challengeWins?: ChallengeWinner[];
   challengeJudges?: ChallengeJudge[];
   challengeEventsCreated?: ChallengeEvent[];
+  rewardsBonusEventsCreated?: RewardsBonusEvent[];
   strikes?: UserStrike[];
   issuedStrikes?: UserStrike[];
   voidedStrikes?: UserStrike[];
@@ -1846,6 +1847,23 @@ export interface Announcement {
   disabled: boolean;
 }
 
+export interface RewardsBonusEvent {
+  id: number;
+  name: string;
+  description: string | null;
+  multiplier: number;
+  articleId: number | null;
+  article?: Article | null;
+  bannerLabel: string | null;
+  enabled: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+  createdById: number;
+  createdBy?: User;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface Cosmetic {
   id: number;
   name: string;
@@ -1986,6 +2004,7 @@ export interface Article {
   engagements?: ArticleEngagement[];
   associations?: ModelAssociations[];
   collectionItems?: CollectionItem[];
+  rewardsBonusEvents?: RewardsBonusEvent[];
 }
 
 export interface PressMention {


### PR DESCRIPTION
## Summary

- Replaces the `REWARDS_BONUS_MULTIPLIER` Flipt flag with a first-class `RewardsBonusEvent` model + moderator UI at `/moderator/rewards-bonus-events`
- Adds `name`, `description` (markdown), `bannerLabel` override, optional linked `articleId`, scheduled `startsAt`/`endsAt`, and `enabled` toggle
- Active event selected by highest multiplier within the enabled time window; banner + info modal auto-pick up name, description, multiplier, and article link

## What changed

- **Schema**: new `RewardsBonusEvent` table with index on `(enabled, startsAt, endsAt)`, FKs to `Article` (`ON DELETE SET NULL`) and `User` (`ON DELETE RESTRICT`). Multiplier stored as `Int * 10` (15, 20, 30, 40).
- **Service** (`rewards-bonus-event.service.ts`): 5 min in-process cache over the *enabled* list, with time-boundary filtering evaluated on every request so scheduled start/end transitions are not held back by the TTL. Invalidated on upsert/delete.
- **buzz.service.ts cutover**: `getGlobalRewardsBonusMultiplier` + `getMultipliersForUser` now read from the DB service. `rewardsBonusEvent` (name/description/bannerLabel/articleId/startsAt/endsAt) is returned alongside the multiplier so UI can render without another query.
- **Banner / Modal**: `bannerLabel` overrides the headline; modal title uses `name`, body renders `description` via `CustomMarkdown`, adds a secondary "Learn more" button linking to `/articles/{id}` when an article is attached. Hero is full-bleed to modal edges with a legible close button over the yellow.
- **Admin UI**: list + edit modal. Dropdown multiplier (50% / 2x / 3x / 4x). Article link accepts pasted URL or bare ID, extracted to an int so links work on both civitai.com and civitai.red. Date picker mirrors the challenges event pattern (`toDisplayUTC` / `fromDisplayUTC` + `dayjs.utc startOf/endOf`) so the stored instants are UTC midnight / UTC end-of-day regardless of the moderator's browser timezone. `endsAt` picker minimum is `max(today, startsAt)`.
- **Flipt**: `REWARDS_BONUS_MULTIPLIER` enum entry removed.
- **Cache invalidation**: moderator save invalidates the server cache AND the client's `buzz.getUserMultipliers` query so the editor sees the change without a refresh.
- **Validation**: zod `.refine` rejects inverted `startsAt > endsAt` windows.

## Test plan

- [x] Apply migration (`pnpm run db:migrate`) on a fresh DB, verify no issues
- [x] Visit `/moderator/rewards-bonus-events`, create an event with 2x, linked article, start today + end in 3 days, enabled; confirm banner + modal go live without a refresh
- [x] Toggle `enabled` off, confirm banner disappears (after tRPC invalidate fires)
- [x] Create two overlapping enabled events with different multipliers; confirm the higher multiplier wins
- [x] Try to save an event with `endsAt` before `startsAt`; confirm zod rejects with "Start date must be before end date" on the `endsAt` field
- [ ] Verify in DB that stored timestamps are `00:00:00.000Z` for `startsAt` and `23:59:59.999Z` for `endsAt` regardless of the picker's browser timezone
- [ ] Confirm non-moderators 401 on all four `rewardsBonusEvent.*` tRPC endpoints

## Review notes

External reviews by Gemini 3.1 Pro and GPT-5.4 were run before merge. Both flagged:
- Multi-replica cache divergence (accepted; acceptable given event cadence and 5 min TTL)
- Cache-boundary staleness (fixed: now caches enabled list, filters in-memory on each call)
- Missing `startsAt <= endsAt` validation (fixed: zod refine)

Lower-severity items (cache stampede dedupe, per-event DB check constraints, allowing edits to already-past events) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)