### PR TITLE
feat(articles): add moderatorNsfwLevel override with edit-form picker

### DIFF
--- a/prisma/migrations/20260421132225_add_article_moderator_nsfw_level/migration.sql
+++ b/prisma/migrations/20260421132225_add_article_moderator_nsfw_level/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN "moderatorNsfwLevel" INTEGER;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2540,6 +2540,7 @@ model Article {
   unlisted         Boolean       @default(false)
   nsfwLevel        Int           @default(0)
   userNsfwLevel    Int           @default(0)
+  moderatorNsfwLevel Int?
   lockedProperties String[]      @default([])
   status           ArticleStatus @default(Draft)
 

--- a/src/components/Article/ArticleUpsertForm.tsx
+++ b/src/components/Article/ArticleUpsertForm.tsx
@@ -56,11 +56,17 @@ import { titleCase } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 
 const schema = upsertArticleInput
-  .omit({ coverImage: true, userNsfwLevel: true, lockedProperties: true })
+  .omit({
+    coverImage: true,
+    userNsfwLevel: true,
+    moderatorNsfwLevel: true,
+    lockedProperties: true,
+  })
   .extend({
     categoryId: z.number().min(0, 'Please select a valid category'),
     coverImage: imageSchema.refine((data) => !!data.url, { error: 'Please upload a cover image' }),
     userNsfwLevel: z.string().optional(),
+    moderatorNsfwLevel: z.string().optional(),
     lockedProperties: z.string().array().optional(),
   });
 const querySchema = z.object({
@@ -82,6 +88,13 @@ export const browsingLevelSelectOptions = browsingLevels.map((level) => ({
   label: browsingLevelLabels[level],
   value: String(level),
 }));
+
+// Moderator override picker prepends an Auto option (empty string = clear
+// override = fall back to GREATEST derivation on the server).
+const moderatorNsfwLevelSelectOptions = [
+  { label: 'Auto (derived from content)', value: '' },
+  ...browsingLevelSelectOptions,
+];
 
 export function ArticleUpsertForm({ article }: Props) {
   const currentUser = useCurrentUser();
@@ -105,6 +118,7 @@ export function ArticleUpsertForm({ article }: Props) {
       title: article?.title ?? '',
       content: article?.content ?? '',
       userNsfwLevel: article?.userNsfwLevel ? String(article.userNsfwLevel) : undefined,
+      moderatorNsfwLevel: article?.moderatorNsfwLevel ? String(article.moderatorNsfwLevel) : '',
       categoryId: article?.tags.find((tag) => tag.isCategory)?.id ?? defaultCategory,
       tags: article?.tags.filter((tag) => !tag.isCategory) ?? [],
       coverImage: article?.coverImage ?? null,
@@ -156,6 +170,7 @@ export function ArticleUpsertForm({ article }: Props) {
     tags: selectedTags,
     coverImage,
     userNsfwLevel,
+    moderatorNsfwLevel,
     lockedProperties,
     content,
     ...rest
@@ -178,6 +193,14 @@ export function ArticleUpsertForm({ article }: Props) {
             ? userNsfwLevel
               ? Number(userNsfwLevel)
               : 0
+            : undefined,
+          // moderatorNsfwLevel is gated server-side too, but only send it from
+          // the mod-only picker so non-mod payloads never carry the key.
+          // Empty string means "clear override" -> null.
+          moderatorNsfwLevel: currentUser?.isModerator
+            ? moderatorNsfwLevel
+              ? Number(moderatorNsfwLevel)
+              : null
             : undefined,
           tags,
           // publishedAt will be set server-side based on status
@@ -348,7 +371,44 @@ export function ArticleUpsertForm({ article }: Props) {
               }
               description="Your preferred rating. The final rating is the max of your choice, cover and content images, text moderation, and any actioned NSFW reports. Updates automatically when those signals change."
             />
-            {article?.nsfwLevel != null &&
+            {currentUser?.isModerator && (
+              <InputSelect
+                name="moderatorNsfwLevel"
+                data={moderatorNsfwLevelSelectOptions}
+                label={
+                  <Group gap={4} wrap="nowrap">
+                    <Text span fw={600}>
+                      Moderator Override
+                    </Text>
+                    <Text span c="dimmed" size="xs">
+                      (mod-only)
+                    </Text>
+                  </Group>
+                }
+                description="Pin the article to a specific rating regardless of scans, user preference, or reports. Select Auto to clear the override and return to content-derived rating."
+              />
+            )}
+            {article?.moderatorNsfwLevel != null &&
+              browsingLevelLabels[
+                article.moderatorNsfwLevel as keyof typeof browsingLevelLabels
+              ] && (
+                <Alert color="blue" py="xs">
+                  <Text size="xs">
+                    A moderator has set this article&apos;s rating to{' '}
+                    <Text span fw={600}>
+                      {
+                        browsingLevelLabels[
+                          article.moderatorNsfwLevel as keyof typeof browsingLevelLabels
+                        ]
+                      }
+                    </Text>
+                    . Your preferred rating is saved and will apply again if the override is
+                    cleared.
+                  </Text>
+                </Alert>
+              )}
+            {article?.moderatorNsfwLevel == null &&
+              article?.nsfwLevel != null &&
               article.nsfwLevel > (article.userNsfwLevel ?? 0) &&
               browsingLevelLabels[article.nsfwLevel as keyof typeof browsingLevelLabels] && (
                 <Alert color="yellow" py="xs">

--- a/src/server/schema/article.schema.ts
+++ b/src/server/schema/article.schema.ts
@@ -96,6 +96,7 @@ export const upsertArticleInput = z.object({
   coverImage: imageSchema.nullish(),
   tags: z.array(tagSchema).nullish(),
   userNsfwLevel: z.enum(NsfwLevel).default(NsfwLevel.PG),
+  moderatorNsfwLevel: z.enum(NsfwLevel).nullish(),
   publishedAt: z.date().nullish(),
   attachments: z.array(baseFileSchema).optional(),
   lockedProperties: z.string().array().optional(),

--- a/src/server/selectors/article.selector.ts
+++ b/src/server/selectors/article.selector.ts
@@ -10,6 +10,7 @@ export const articleDetailSelect = Prisma.validator<Prisma.ArticleSelect>()({
   createdAt: true,
   nsfwLevel: true,
   userNsfwLevel: true,
+  moderatorNsfwLevel: true,
   content: true,
   cover: true,
   updatedAt: true,

--- a/src/server/selectors/article.selector.ts
+++ b/src/server/selectors/article.selector.ts
@@ -5,12 +5,19 @@ import { getReactionsSelectV2 } from '~/server/selectors/reaction.selector';
 import { simpleTagSelect } from '~/server/selectors/tag.selector';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 
+// Shared select for article detail payloads. Intentionally omits
+// `moderatorNsfwLevel` — this shape is reused by the outbound webhook job
+// (`articleWebhooks` spreads `...article` into the third-party payload) and
+// by the Meilisearch indexer (`articleSelect` spreads `...articleDetailSelect`
+// into the index document), so anything exposed here leaks to external
+// consumers. `moderatorNsfwLevel` is an internal moderation signal; callers
+// that render the mod edit UI (`getArticleById`, `getModeratorArticles`)
+// extend this select explicitly with the override field instead.
 export const articleDetailSelect = Prisma.validator<Prisma.ArticleSelect>()({
   id: true,
   createdAt: true,
   nsfwLevel: true,
   userNsfwLevel: true,
-  moderatorNsfwLevel: true,
   content: true,
   cover: true,
   updatedAt: true,

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -688,7 +688,11 @@ export const getArticleById = async ({
             ]
           : undefined,
       },
-      select: articleDetailSelect,
+      // Include `moderatorNsfwLevel` here (not in the shared select) so the
+      // edit form can render the override banner / picker. The public article
+      // read payload is served by `getArticles`, not this function, so the
+      // field doesn't flow into external webhook / search-index payloads.
+      select: { ...articleDetailSelect, moderatorNsfwLevel: true },
     });
 
     if (!article) throw throwNotFoundError(`No article with id ${id}`);
@@ -993,19 +997,14 @@ export const upsertArticle = async ({
     }
 
     // moderatorNsfwLevel is the mod override layer that takes precedence over
-    // the GREATEST derivation (see updateArticleNsfwLevels). Determine whether
-    // anything in this save can move the derived nsfwLevel so we know to
-    // recompute post-commit — plain upsert doesn't normally trigger recompute,
-    // only the scan/text-mod/report webhooks do, so without this hook a mod's
-    // override or user preference change would sit dormant until something
-    // else kicked the pipeline.
+    // the GREATEST derivation (see updateArticleNsfwLevels). We still need to
+    // know when the override changed so the locked-properties set below can
+    // pin/unpin userNsfwLevel accordingly — the recompute itself happens
+    // unconditionally via updateArticleImageScanStatus post-commit.
     const moderatorOverrideChanged =
       !!isModerator &&
       data.moderatorNsfwLevel !== undefined &&
       data.moderatorNsfwLevel !== article.moderatorNsfwLevel;
-    const userNsfwLevelChanged =
-      data.userNsfwLevel !== undefined && data.userNsfwLevel !== article.userNsfwLevel;
-    const shouldRecomputeNsfwLevel = moderatorOverrideChanged || userNsfwLevelChanged;
 
     // When a mod sets an override, lock the user's picker so a subsequent
     // owner save can't quietly drift userNsfwLevel underneath it. When the
@@ -1114,14 +1113,6 @@ export const upsertArticle = async ({
 
     await preventReplicationLag('article', result.id);
     await preventReplicationLag('userArticles', result.userId);
-
-    // Recompute the derived nsfwLevel when the save touched any of its
-    // inputs. Scan / text-mod / report webhooks already call this on their
-    // own triggers; this hook covers the gap for direct edits so a mod
-    // override or userNsfwLevel change takes effect immediately.
-    if (shouldRecomputeNsfwLevel) {
-      await updateArticleNsfwLevels([result.id]);
-    }
 
     // remove old cover image
     if (article.coverId !== coverId && article.coverId) {
@@ -1529,7 +1520,9 @@ export async function getModeratorArticles({
     take: limit + 1,
     cursor: cursor ? { id: cursor } : undefined,
     where: { AND },
-    select: articleDetailSelect,
+    // Mod-only list — safe to surface the moderator override value alongside
+    // the regular detail fields. See note on `articleDetailSelect`.
+    select: { ...articleDetailSelect, moderatorNsfwLevel: true },
     orderBy: { createdAt: 'desc' },
   });
 

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -774,6 +774,11 @@ export const upsertArticle = async ({
     if (!isModerator) {
       // don't allow updating of locked properties
       for (const key of data.lockedProperties ?? []) delete data[key as keyof typeof data];
+      // moderatorNsfwLevel is a mod-only field. Silently strip it from
+      // non-moderator payloads rather than throwing: the form never exposes
+      // this control to owners, so a client sending it indicates either a
+      // stale client or an attempt to forge the override — either way, drop.
+      delete data.moderatorNsfwLevel;
     }
 
     // For updates, fetch article early so we can check cover image ownership and NSFW level
@@ -786,6 +791,9 @@ export const upsertArticle = async ({
       publishedAt: Date | null;
       status: string;
       nsfwLevel: number;
+      userNsfwLevel: number;
+      moderatorNsfwLevel: number | null;
+      lockedProperties: string[];
       metadata: Prisma.JsonValue;
       content: string | null;
     } | null = null;
@@ -801,6 +809,9 @@ export const upsertArticle = async ({
           publishedAt: true,
           status: true,
           nsfwLevel: true,
+          userNsfwLevel: true,
+          moderatorNsfwLevel: true,
+          lockedProperties: true,
           metadata: true,
           content: true,
         },
@@ -981,6 +992,35 @@ export const upsertArticle = async ({
       }
     }
 
+    // moderatorNsfwLevel is the mod override layer that takes precedence over
+    // the GREATEST derivation (see updateArticleNsfwLevels). Determine whether
+    // anything in this save can move the derived nsfwLevel so we know to
+    // recompute post-commit — plain upsert doesn't normally trigger recompute,
+    // only the scan/text-mod/report webhooks do, so without this hook a mod's
+    // override or user preference change would sit dormant until something
+    // else kicked the pipeline.
+    const moderatorOverrideChanged =
+      !!isModerator &&
+      data.moderatorNsfwLevel !== undefined &&
+      data.moderatorNsfwLevel !== article.moderatorNsfwLevel;
+    const userNsfwLevelChanged =
+      data.userNsfwLevel !== undefined && data.userNsfwLevel !== article.userNsfwLevel;
+    const shouldRecomputeNsfwLevel = moderatorOverrideChanged || userNsfwLevelChanged;
+
+    // When a mod sets an override, lock the user's picker so a subsequent
+    // owner save can't quietly drift userNsfwLevel underneath it. When the
+    // mod clears the override (sets back to null) we unlock the picker and
+    // the article returns to auto-derivation on the next recompute.
+    if (moderatorOverrideChanged) {
+      const lockedSet = new Set<string>(data.lockedProperties ?? article.lockedProperties ?? []);
+      if (data.moderatorNsfwLevel != null) {
+        lockedSet.add('userNsfwLevel');
+      } else {
+        lockedSet.delete('userNsfwLevel');
+      }
+      data.lockedProperties = Array.from(lockedSet);
+    }
+
     const republishing =
       (article.status === ArticleStatus.Unpublished && data.status === ArticleStatus.Published) ||
       !!article.publishedAt;
@@ -1074,6 +1114,14 @@ export const upsertArticle = async ({
 
     await preventReplicationLag('article', result.id);
     await preventReplicationLag('userArticles', result.userId);
+
+    // Recompute the derived nsfwLevel when the save touched any of its
+    // inputs. Scan / text-mod / report webhooks already call this on their
+    // own triggers; this hook covers the gap for direct edits so a mod
+    // override or userNsfwLevel change takes effect immediately.
+    if (shouldRecomputeNsfwLevel) {
+      await updateArticleNsfwLevels([result.id]);
+    }
 
     // remove old cover image
     if (article.coverId !== coverId && article.coverId) {

--- a/src/server/services/nsfwLevels.service.ts
+++ b/src/server/services/nsfwLevels.service.ts
@@ -355,12 +355,25 @@ export async function updateArticleNsfwLevels(articleIds: number[], tx?: Prisma.
         FROM "Article" a
         WHERE a.id IN (${Prisma.join(articleIds)})
       )
+      -- moderatorNsfwLevel is the moderator override and takes precedence over
+      -- every other signal when set. It can force the rating either direction:
+      -- mods can pin a wholesome article that got mis-scanned back down to PG,
+      -- or raise a borderline article that the auto-derivation undersold.
+      -- When null we fall back to GREATEST(userNsfwLevel, scanned images,
+      -- moderation floor) as before. A mod clearing the override (setting it
+      -- back to NULL) immediately returns the article to auto-derivation.
       UPDATE "Article" a
-      SET "nsfwLevel" = GREATEST(a."userNsfwLevel", level."nsfwLevel", mf."floor")
+      SET "nsfwLevel" = COALESCE(
+        a."moderatorNsfwLevel",
+        GREATEST(a."userNsfwLevel", level."nsfwLevel", mf."floor")
+      )
       FROM level
       JOIN moderation_floor mf ON mf.id = level.id
       WHERE level.id = a.id
-        AND GREATEST(a."userNsfwLevel", level."nsfwLevel", mf."floor") != a."nsfwLevel"
+        AND COALESCE(
+          a."moderatorNsfwLevel",
+          GREATEST(a."userNsfwLevel", level."nsfwLevel", mf."floor")
+        ) != a."nsfwLevel"
       RETURNING a.id;
     `);
   await articlesSearchIndex.queueUpdate(

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -1992,6 +1992,7 @@ export interface Article {
   unlisted: boolean;
   nsfwLevel: number;
   userNsfwLevel: number;
+  moderatorNsfwLevel: number | null;
   lockedProperties: string[];
   status: ArticleStatus;
   thread?: Thread | null;


### PR DESCRIPTION
## Summary
Moderators had no way to force an article's rating up or down before this PR. The maturity picker only wrote \`userNsfwLevel\`, and (a) \`upsert\` never kicked \`updateArticleNsfwLevels\` — only the image-scan, text-moderation, and report webhooks did — and (b) even after a recompute the \`GREATEST(userNsfwLevel, cover, content, moderation_floor)\` derivation meant a mod could only raise the rating, never lower one that had been overshot. Ally flagged an article stuck at R on red with no path to bring it back down.

This PR adds a dedicated \`moderatorNsfwLevel\` override layer.

### Changes
- **Schema / migration** — new nullable \`Article.moderatorNsfwLevel\` column.
- **\`updateArticleNsfwLevels\`** (raw SQL) — now writes \`COALESCE(moderatorNsfwLevel, GREATEST(userNsfwLevel, cover, content, moderation_floor))\`. Non-null override pins the rating bidirectionally; null falls back to the existing auto-derivation.
- **\`upsertArticle\`** —
  - Silently strips \`moderatorNsfwLevel\` from non-moderator payloads (the picker never ships to owners; a present key implies stale client or forgery).
  - Diffs incoming \`moderatorNsfwLevel\` and \`userNsfwLevel\` against the persisted values; when either changed, triggers \`updateArticleNsfwLevels\` post-commit. Closes the gap where direct edits sat dormant until an unrelated webhook kicked recompute.
  - Auto-manages \`lockedProperties\`: setting an override locks the owner's \`userNsfwLevel\` picker, clearing it unlocks.
- **\`ArticleUpsertForm\`** — mod-only \`InputSelect\` with an \"Auto (derived from content)\" option for clearing the override. A blue alert surfaces an active override to the owner and tells them their own preference is preserved. The existing yellow \"images raised it above your preference\" alert is gated on override being null so the two don't stack.
- **Search index + card cover lift** — unchanged. Both read \`article.nsfwLevel\`, which now already reflects the override via COALESCE.

### Conflict resolution
If a moderator pins an article at PG and a later actioned NSFW report would set the moderation floor to R, the override wins. This is intentional: a mod decision should not be quietly undone by user-report automation. To return to auto-behavior, the mod selects \"Auto\" in the picker.

## Test plan
- [ ] Mod opens an article stuck at R from an image scan, picks PG in Moderator Override, saves — rating flips to PG immediately (no wait for the next webhook), owner's userNsfwLevel unchanged, picker locks.
- [ ] Mod clears override (Auto) — rating recomputes back to the GREATEST of scan + user pref + floor, picker unlocks.
- [ ] Mod sets override to X on an article with cover=PG — rating becomes X, carries through to search-index + card view.
- [ ] Non-mod POSTs with \`moderatorNsfwLevel\` in the payload via a crafted request — server drops the key silently; persisted value unchanged.
- [ ] Actioning an NSFW report on an article with an override does not change the override. Unactioning a report on an unoverridden article still drops the floor as before.
- [ ] Owner edits an article whose \`userNsfwLevel\` was locked by a mod override — lockedProperties guard keeps their picker read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)