### PR TITLE
fix: prevent stale notification counts after mark-as-read

### DIFF
--- a/src/server/notifications/notification-cache.ts
+++ b/src/server/notifications/notification-cache.ts
@@ -29,7 +29,7 @@ async function getUser(userId: number) {
 
 async function setUser(userId: number, counts: NotificationCategoryCount[]) {
   const key = getUserKey(userId);
-  for (const { category, count } of counts) await redis.hSetNX(key, category, count.toString());
+  for (const { category, count } of counts) await redis.hSet(key, category, count.toString());
   await slideExpiration(userId);
 }
 

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -132,19 +132,20 @@ export async function getUserNotificationCount({
   unread: boolean;
   category?: NotificationCategory;
 }) {
-  const cachedCount = await notificationCache.getUser(userId);
-  if (cachedCount) return cachedCount;
+  // Check lag key BEFORE cache — if a recent write is flagged for this user,
+  // bust the cache and query the primary to avoid returning stale counts.
+  const db = await getNotifDbWithoutLag('notification', userId);
+  if (db === notifDbWrite) {
+    await notificationCache.bustUser(userId);
+  } else {
+    const cachedCount = await notificationCache.getUser(userId);
+    if (cachedCount) return cachedCount;
+  }
 
   const AND = [Prisma.sql`un."userId" = ${userId}`];
   if (unread) AND.push(Prisma.sql`un.viewed IS FALSE`);
-  // else AND.push(Prisma.sql`un."createdAt" > NOW() - interval '1 month'`);
 
-  // this seems unused
   if (category) AND.push(Prisma.sql`n.category = ${category}::"NotificationCategory"`);
-
-  // Route to primary when markRead just wrote for this user — replica lag
-  // would otherwise repopulate the cache with stale unread counts.
-  const db = await getNotifDbWithoutLag('notification', userId);
   const query = await db.cancellableQuery<NotificationCategoryCount>(Prisma.sql`
     SELECT
       n.category,


### PR DESCRIPTION
## Summary

Fixes notification counts reappearing after "mark all read" and page refresh. Two interacting bugs in the read-after-write path:

- `getUserNotificationCount` checked the Redis cache **before** the replication lag key. Even with `REPLICATION_LAG_DELAY=60` correctly set, a stale cached count was returned without ever querying the primary DB. Now checks the lag key first — if a recent write is flagged (within 60s), busts the cache and queries the primary.

- `notification-cache.setUser` used `hSetNX` (set-if-not-exists), so fresh counts from a correct primary read could not overwrite stale cached entries. Changed to `hSet` so latest data always wins.

## Root cause

After the notification DB read/write split (reads → CNPG replica, writes → DO primary), the mark-as-read flow is:
1. Fire-and-forget write to DO + set Redis lag key + bust cache
2. On page refresh, `getUserNotificationCount` was hitting the cache (populated from a prior stale read) before checking whether a recent write occurred
3. Stale counts persisted for up to 1 week (`CacheTTL.week`) and `hSetNX` prevented correction

## Test plan

- [ ] Mark a single notification as read → refresh → should stay read
- [ ] "Mark all read" → refresh → count should remain 0
- [ ] "Mark all read" with category filter → refresh → that category's count should remain 0
- [ ] Verify no regression in notification count loading performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)