### PR TITLE
fix(reports): stop auto-flipping Collection.nsfw on user reports

### DIFF
--- a/src/server/services/nsfwLevels.service.ts
+++ b/src/server/services/nsfwLevels.service.ts
@@ -439,8 +439,8 @@ export async function updateBountyEntryNsfwLevels(bountyEntryIds: number[]) {
 // Precedence:
 //   1. metadata.forcedBrowsingLevel set → map forced bits to bucket
 //   2. otherwise → two-probe scan of ACCEPTED items
-// Collection.nsfw boolean is ignored — it's auto-flipped by user NSFW reports
-// (report.service.ts) so it's not a reliable signal of collection content.
+// Collection.nsfw boolean is ignored — it's a legacy flag and not a reliable
+// signal of collection content.
 const COLLECTION_NSFW_BUCKET = 28; // R|X|XXX
 export async function updateCollectionsNsfwLevels(collectionIds: number[]) {
   if (!collectionIds.length) return;

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -19,11 +19,7 @@ import type {
   ResolveAppealInput,
 } from '~/server/schema/report.schema';
 import { ReportEntity } from '~/shared/utils/report-helpers';
-import {
-  collectionsSearchIndex,
-  imagesMetricsSearchIndex,
-  imagesSearchIndex,
-} from '~/server/search-index';
+import { imagesMetricsSearchIndex, imagesSearchIndex } from '~/server/search-index';
 import {
   createBuzzTransaction,
   createMultiAccountBuzzTransaction,
@@ -236,12 +232,6 @@ export const createReport = async ({
             }),
           ]);
 
-          break;
-        case ReportEntity.Collection:
-          await tx.collection.update({ where: { id }, data: { nsfw: true } });
-          await collectionsSearchIndex.queueUpdate([
-            { id, action: SearchIndexUpdateQueueAction.Update },
-          ]);
           break;
         case ReportEntity.Article:
           // Defer the nsfwLevel recompute until after the tx commits so the


### PR DESCRIPTION
## Summary
- A single user NSFW report against a Collection was being `statusOverride`'d to `Actioned` and flipping `Collection.nsfw = true` with no moderator review (`src/server/services/report.service.ts`). Home-block / home-page Buzz Beggars Board (collection `id=3870938`) hit this.
- Drop the `ReportEntity.Collection` case from the NSFW-report handler. `Collection.nsfwLevel` (computed from items or `metadata.forcedBrowsingLevel` in `updateCollectionsNsfwLevels`) stays the authoritative signal; mods can still action reports via the existing queue.
- Updated stale comment in `nsfwLevels.service.ts` that referenced the removed auto-flip.
- Stale `nsfw=true` on the Beggars Board collection was cleared directly in prod (`UPDATE "Collection" SET nsfw=false WHERE id=3870938`).

## Test plan
- [ ] Submit a user NSFW report against a test collection; verify `Collection.nsfw` stays `false` and the report lands for mod review.
- [ ] Confirm home page renders "Buzz Beggars Board" home block on civitai.com / ziptai.com.
- [ ] `pnpm run typecheck` — clean.