### PR TITLE
feat(moderator): service status page for gen/training toggles

### DIFF
--- a/.claude/skills/dev-server/scripts/daemon.mjs
+++ b/.claude/skills/dev-server/scripts/daemon.mjs
@@ -111,26 +111,40 @@ function generateSessionId() {
   return randomBytes(4).toString('hex');
 }
 
-// Update URL-related env vars to use the correct port
+// Update URL-related env vars to use the correct port.
+// Returns { envVars, overrides } where `overrides` lists the remapped vars for logging.
 function updateEnvUrlsForPort(envVars, port) {
   const defaultPort = 3000;
-  if (port === defaultPort) return envVars;
+  const overrides = [];
+  if (port === defaultPort) return { envVars, overrides };
 
-  // List of env vars that contain localhost URLs that need port updates
-  const urlVars = [
+  // localhost:3000 → localhost:<port> (keeps scheme/path intact)
+  const portUrlVars = [
     'NEXTAUTH_URL',
     'NEXTAUTH_URL_INTERNAL',
     'NEXT_PUBLIC_BASE_URL',
-    'SERVER_DOMAIN_BLUE', // This one uses domain:port format
+    'SERVER_DOMAIN_BLUE',
   ];
+  for (const varName of portUrlVars) {
+    if (envVars[varName] && envVars[varName].includes('localhost:3000')) {
+      const before = envVars[varName];
+      envVars[varName] = before.replace(/localhost:3000/g, `localhost:${port}`);
+      overrides.push(`${varName}: ${before} -> ${envVars[varName]}`);
+    }
+  }
 
-  for (const varName of urlVars) {
-    if (envVars[varName]) {
-      // Replace localhost:3000 with localhost:<port>
-      envVars[varName] = envVars[varName].replace(
-        /localhost:3000/g,
-        `localhost:${port}`
-      );
+  // If auth URLs point at a non-localhost host (e.g. civitai-dev.blue via an rgb-proxy
+  // that only backs the default port), OAuth cookies won't be scoped to this session's
+  // port. Force auth URLs to localhost:<port> so credentials-based logins (e.g. the
+  // /testing/testing-login page) work on secondary sessions without the user manually
+  // maintaining a per-worktree .env.
+  const localhostOverrideVars = ['NEXTAUTH_URL', 'NEXTAUTH_URL_INTERNAL', 'NEXT_PUBLIC_BASE_URL'];
+  const localhostUrl = `http://localhost:${port}`;
+  for (const varName of localhostOverrideVars) {
+    const current = envVars[varName];
+    if (current && !current.includes(`localhost:${port}`)) {
+      envVars[varName] = localhostUrl;
+      overrides.push(`${varName}: ${current} -> ${localhostUrl}`);
     }
   }
 
@@ -139,7 +153,7 @@ function updateEnvUrlsForPort(envVars, port) {
     envVars.NEXT_PUBLIC_BASE_URL = envVars.NEXTAUTH_URL;
   }
 
-  return envVars;
+  return { envVars, overrides };
 }
 
 // Load environment variables from .env file
@@ -265,7 +279,11 @@ class DevSession {
     let envVars = loadEnvFile(this.envPath);
 
     // Update URL-related env vars if using non-default port
-    envVars = updateEnvUrlsForPort(envVars, this.port);
+    const { envVars: remapped, overrides } = updateEnvUrlsForPort(envVars, this.port);
+    envVars = remapped;
+    for (const override of overrides) {
+      this.addLog('info', `Env remap: ${override}`);
+    }
 
     // Set PORT in environment
     envVars.PORT = String(this.port);

--- a/src/components/Moderation/ModerationNav.tsx
+++ b/src/components/Moderation/ModerationNav.tsx
@@ -29,6 +29,7 @@ export function ModerationNav() {
         { label: 'Articles', href: '/moderator/articles' },
         // { label: 'Tags', href: '/moderator/tags' },
         { label: 'Generation', href: '/moderator/generation' },
+        { label: 'Service Status', href: '/moderator/service-status' },
         // { label: 'Withdrawal Requests', href: '/moderator/buzz-withdrawal-requests' },
         {
           label: 'Cash Management',
@@ -75,7 +76,7 @@ export function ModerationNav() {
           href: '/moderator/auctions',
           hidden: !features.auctionsMod,
         },
-{
+        {
           label: 'Generator Restrictions',
           href: '/moderator/generation-restrictions',
           hidden: !features.csamReports,

--- a/src/pages/moderator/service-status.tsx
+++ b/src/pages/moderator/service-status.tsx
@@ -1,0 +1,243 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Container,
+  Group,
+  Loader,
+  Stack,
+  Switch,
+  Text,
+  Textarea,
+  Title,
+} from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { IconPhoto, IconSettings, IconSparkles } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+import { Meta } from '~/components/Meta/Meta';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { trpc } from '~/utils/trpc';
+
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  resolver: async ({ session }) => {
+    if (!session || !session.user?.isModerator)
+      return { redirect: { destination: '/', permanent: false } };
+
+    return { props: {} };
+  },
+});
+
+export default function ServiceStatusPage() {
+  return (
+    <>
+      <Meta title="Service Status" deIndex />
+      <Container size="md" py="xl">
+        <Stack gap="xl">
+          <Group gap="sm" align="center">
+            <IconSettings size={28} />
+            <Stack gap={0}>
+              <Title order={2}>Service Status</Title>
+              <Text c="dimmed" size="sm">
+                Enable or disable image generation and training. Set the message shown to users when
+                a service is unavailable.
+              </Text>
+            </Stack>
+          </Group>
+
+          <GenerationStatusCard />
+          <TrainingStatusCard />
+        </Stack>
+      </Container>
+    </>
+  );
+}
+
+function GenerationStatusCard() {
+  const utils = trpc.useUtils();
+  const { data, isLoading } = trpc.generation.getStatus.useQuery();
+  const [available, setAvailable] = useState(true);
+  const [message, setMessage] = useState('');
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (!data || dirty) return;
+    setAvailable(data.available);
+    setMessage(data.message ?? '');
+  }, [data, dirty]);
+
+  const setStatus = trpc.generation.setStatus.useMutation({
+    onSuccess: async () => {
+      await utils.generation.getStatus.invalidate();
+      setDirty(false);
+      showNotification({
+        title: 'Saved',
+        message: 'Image generation status updated',
+        color: 'green',
+      });
+    },
+    onError: (error) => {
+      showNotification({ title: 'Error', message: error.message, color: 'red' });
+    },
+  });
+
+  const handleSave = () => {
+    setStatus.mutate({ available, message: message.trim() ? message : null });
+  };
+
+  return (
+    <Card withBorder radius="md" p="lg">
+      <Stack gap="md">
+        <Group gap="sm" align="center" justify="space-between">
+          <Group gap="sm" align="center">
+            <IconPhoto size={20} />
+            <Title order={4}>Image Generation</Title>
+          </Group>
+          {!isLoading && data && (
+            <Badge color={data.available ? 'green' : 'red'} variant="light">
+              {data.available ? 'Available' : 'Unavailable'}
+            </Badge>
+          )}
+        </Group>
+
+        {isLoading ? (
+          <Group justify="center" py="md">
+            <Loader size="sm" />
+          </Group>
+        ) : (
+          <>
+            <Switch
+              checked={available}
+              onChange={(e) => {
+                setAvailable(e.currentTarget.checked);
+                setDirty(true);
+              }}
+              label={available ? 'Enabled' : 'Disabled'}
+              description="When disabled, users cannot start new image generations."
+            />
+            <Textarea
+              label="Status message"
+              description="Shown to users when generation is unavailable. Leave blank for no message."
+              placeholder="e.g. Image generation is temporarily down for maintenance."
+              value={message}
+              onChange={(e) => {
+                setMessage(e.currentTarget.value);
+                setDirty(true);
+              }}
+              minRows={2}
+              maxRows={6}
+              autosize
+              maxLength={2000}
+            />
+            {!available && !message.trim() && (
+              <Alert color="yellow" variant="light">
+                Generation is disabled but no message is set. Consider adding a message so users
+                know what is happening.
+              </Alert>
+            )}
+            <Group justify="flex-end">
+              <Button onClick={handleSave} loading={setStatus.isLoading} disabled={!dirty}>
+                Save
+              </Button>
+            </Group>
+          </>
+        )}
+      </Stack>
+    </Card>
+  );
+}
+
+function TrainingStatusCard() {
+  const utils = trpc.useUtils();
+  const { data, isLoading } = trpc.training.getStatus.useQuery();
+  const [available, setAvailable] = useState(true);
+  const [message, setMessage] = useState('');
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (!data || dirty) return;
+    setAvailable(data.available);
+    setMessage(data.message ?? '');
+  }, [data, dirty]);
+
+  const setStatus = trpc.training.setStatus.useMutation({
+    onSuccess: async () => {
+      await utils.training.getStatus.invalidate();
+      setDirty(false);
+      showNotification({
+        title: 'Saved',
+        message: 'Training status updated',
+        color: 'green',
+      });
+    },
+    onError: (error) => {
+      showNotification({ title: 'Error', message: error.message, color: 'red' });
+    },
+  });
+
+  const handleSave = () => {
+    setStatus.mutate({ available, message: message.trim() ? message : null });
+  };
+
+  return (
+    <Card withBorder radius="md" p="lg">
+      <Stack gap="md">
+        <Group gap="sm" align="center" justify="space-between">
+          <Group gap="sm" align="center">
+            <IconSparkles size={20} />
+            <Title order={4}>Training</Title>
+          </Group>
+          {!isLoading && data && (
+            <Badge color={data.available ? 'green' : 'red'} variant="light">
+              {data.available ? 'Available' : 'Unavailable'}
+            </Badge>
+          )}
+        </Group>
+
+        {isLoading ? (
+          <Group justify="center" py="md">
+            <Loader size="sm" />
+          </Group>
+        ) : (
+          <>
+            <Switch
+              checked={available}
+              onChange={(e) => {
+                setAvailable(e.currentTarget.checked);
+                setDirty(true);
+              }}
+              label={available ? 'Enabled' : 'Disabled'}
+              description="When disabled, users cannot start new training jobs."
+            />
+            <Textarea
+              label="Status message"
+              description="Shown to users when training is unavailable. Leave blank for no message."
+              placeholder="e.g. Training is paused while we investigate an issue."
+              value={message}
+              onChange={(e) => {
+                setMessage(e.currentTarget.value);
+                setDirty(true);
+              }}
+              minRows={2}
+              maxRows={6}
+              autosize
+              maxLength={2000}
+            />
+            {!available && !message.trim() && (
+              <Alert color="yellow" variant="light">
+                Training is disabled but no message is set. Consider adding a message so users know
+                what is happening.
+              </Alert>
+            )}
+            <Group justify="flex-end">
+              <Button onClick={handleSave} loading={setStatus.isLoading} disabled={!dirty}>
+                Save
+              </Button>
+            </Group>
+          </>
+        )}
+      </Stack>
+    </Card>
+  );
+}

--- a/src/server/routers/generation.router.ts
+++ b/src/server/routers/generation.router.ts
@@ -16,6 +16,7 @@ import {
   getResourceData,
   getUnavailableResources,
   resolveImageMeta,
+  setGenerationStatus,
   // textToImage,
   // textToImageTestRun,
   toggleUnavailableResource,
@@ -61,6 +62,14 @@ export const generationRouter = router({
   getStatus: publicProcedure
     .use(edgeCacheIt({ ttl: CacheTTL.xs }))
     .query(() => getGenerationStatus()),
+  setStatus: moderatorProcedure
+    .input(
+      z.object({
+        available: z.boolean(),
+        message: z.string().max(2000).nullish(),
+      })
+    )
+    .mutation(({ input }) => setGenerationStatus(input)),
   getGenerationConfig: publicProcedure
     .use(edgeCacheIt({ ttl: CacheTTL.xs }))
     .query(() => getGenerationConfig()),
@@ -70,15 +79,13 @@ export const generationRouter = router({
     .mutation(({ input, ctx }) =>
       toggleUnavailableResource({ ...input, isModerator: ctx.user.isModerator })
     ),
-  getResourceDataByIds: publicProcedure
-    .input(getResourceDataByIdsSchema)
-    .query(({ input, ctx }) =>
-      getResourceData(input.ids, {
-        user: ctx.user,
-        withPreview: true,
-        sfwOnly: ctx.features.isGreen,
-      })
-    ),
+  getResourceDataByIds: publicProcedure.input(getResourceDataByIdsSchema).query(({ input, ctx }) =>
+    getResourceData(input.ids, {
+      user: ctx.user,
+      withPreview: true,
+      sfwOnly: ctx.features.isGreen,
+    })
+  ),
   resolveImageMeta: publicProcedure
     .input(resolveImageMetaSchema)
     .query(({ input, ctx }) =>

--- a/src/server/routers/training.router.ts
+++ b/src/server/routers/training.router.ts
@@ -19,6 +19,7 @@ import {
   getJobEstStartsHandler,
   getTrainingServiceStatus,
   moveAsset,
+  setTrainingServiceStatus,
 } from '~/server/services/training.service';
 import {
   guardedProcedure,
@@ -70,6 +71,14 @@ export const trainingRouter = router({
     .use(isFlagProtected('imageTraining'))
     .use(edgeCacheIt({ ttl: CacheTTL.xs }))
     .query(() => getTrainingServiceStatus()),
+  setStatus: moderatorProcedure
+    .input(
+      z.object({
+        available: z.boolean(),
+        message: z.string().max(2000).nullish(),
+      })
+    )
+    .mutation(({ input }) => setTrainingServiceStatus(input)),
   /**
    * @deprecated for orchestrator v2
    */

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -231,6 +231,21 @@ export async function getGenerationStatus() {
   return status as GenerationStatus;
 }
 
+export async function setGenerationStatus(input: { available: boolean; message?: string | null }) {
+  const current = await getGenerationStatus();
+  const next: GenerationStatus = {
+    ...current,
+    available: input.available,
+    message: input.message ?? null,
+  };
+  await sysRedis.hSet(
+    REDIS_SYS_KEYS.SYSTEM.FEATURES,
+    REDIS_SYS_KEYS.GENERATION.STATUS,
+    JSON.stringify(next)
+  );
+  return next;
+}
+
 export type RemixOfProps = {
   id?: number;
   url?: string;

--- a/src/server/services/training.service.ts
+++ b/src/server/services/training.service.ts
@@ -252,6 +252,24 @@ export async function getTrainingServiceStatus() {
   return result.data as TrainingServiceStatus;
 }
 
+export async function setTrainingServiceStatus(input: {
+  available: boolean;
+  message?: string | null;
+}) {
+  const current = await getTrainingServiceStatus();
+  const next: TrainingServiceStatus = {
+    ...current,
+    available: input.available,
+    message: input.message ?? null,
+  };
+  await sysRedis.hSet(
+    REDIS_SYS_KEYS.SYSTEM.FEATURES,
+    REDIS_SYS_KEYS.TRAINING.STATUS,
+    JSON.stringify(next)
+  );
+  return next;
+}
+
 /**
  * @deprecated for orchestrator v2
  */


### PR DESCRIPTION
## Summary
- New `/moderator/service-status` page with two cards (Image Generation, Training). Each exposes an available toggle plus a status message textarea and writes directly to the Redis-backed status hashes (`system:features` → `generation:status`, `training:status`) already consumed by `getGenerationStatus` and `getTrainingServiceStatus`. Previously these values could only be changed by editing Redis by hand.
- Added `generation.setStatus` and `training.setStatus` tRPC mutations, both `moderatorProcedure`. Each setter preserves the existing `limits` / `charge` / `blockedModels` fields and only overwrites `available` and `message`.
- "Service Status" link added to the moderator dropdown (`ModerationNav`).
- Dev-server daemon now auto-remaps `NEXTAUTH_URL` / `NEXTAUTH_URL_INTERNAL` / `NEXT_PUBLIC_BASE_URL` to `http://localhost:<port>` for non-default-port sessions. Previously, when the shared `.env` pinned `NEXTAUTH_URL` to an rgb-proxy domain (`https://civitai-dev.blue`), secondary sessions couldn't log in because the OAuth cookie was scoped to the proxy domain instead of `localhost:<port>`.

## Test plan
- [ ] Log into a fresh mod session via `/testing/testing-login`, visit `/moderator/service-status`, toggle and save each card, confirm the status persists in Redis (`sysRedis HGET system:features generation:status`).
- [ ] Verify `generation.getStatus` / `training.getStatus` return the updated values for non-moderators.
- [ ] Confirm existing `limits` / `charge` / `blockedModels` values in Redis are preserved across saves (only `available` and `message` change).
- [ ] Confirm a non-moderator user gets redirected to `/` when hitting `/moderator/service-status`.
- [ ] Verify "Service Status" shows up in the moderator dropdown for mods.
- [ ] Start a second dev-server session on a non-default port and confirm login works without a per-worktree `.env` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)