### PR TITLE
fix: bust model-version showcase image cache on scan / moderation flips

### DIFF
--- a/src/pages/api/admin/temp/bust-model-version-images-cache.ts
+++ b/src/pages/api/admin/temp/bust-model-version-images-cache.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { batchProcessor } from '~/server/db/db-helpers';
+import { pgDbRead } from '~/server/db/pgDb';
+import { deleteImagesForModelVersionCache } from '~/server/services/image.service';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+const schema = z.object({
+  concurrency: z.coerce.number().min(1).max(50).optional().default(10),
+  batchSize: z.coerce.number().min(1).optional().default(500),
+  start: z.coerce.number().min(0).optional().default(0),
+  end: z.coerce.number().min(0).optional(),
+  // How far back to look when selecting model versions to refresh.
+  sinceDays: z.coerce.number().min(0).max(365).optional().default(14),
+  // Optional comma-separated list of model version IDs to bust explicitly.
+  // When provided, overrides the sinceDays window.
+  ids: z
+    .string()
+    .optional()
+    .transform((v) =>
+      v
+        ? v
+            .split(',')
+            .map((s) => Number(s.trim()))
+            .filter((n) => Number.isFinite(n) && n > 0)
+        : undefined
+    ),
+});
+
+export default WebhookEndpoint(async (req, res) => {
+  console.time('BUST_MV_IMAGES_CACHE_TIMER');
+  await bustModelVersionImagesCache(req, res);
+  console.timeEnd('BUST_MV_IMAGES_CACHE_TIMER');
+  res.status(200).json({ finished: true });
+});
+
+async function bustModelVersionImagesCache(req: NextApiRequest, res: NextApiResponse) {
+  const params = schema.parse(req.query);
+
+  await batchProcessor({
+    params,
+    runContext: res,
+    batchFetcher: async (context) => {
+      const query = await pgDbRead.cancellableQuery<{ id: number }>(
+        `
+        SELECT mv.id
+        FROM "ModelVersion" mv
+        WHERE mv."publishedAt" > NOW() - (INTERVAL '1 day' * $1::int)
+        ORDER BY mv.id;
+      `,
+        [params.sinceDays]
+      );
+      context.cancelFns.push(query.cancel);
+      const results = await query.result();
+      return results.map((r) => r.id);
+    },
+    processor: async ({ batch, batchNumber, batchCount }) => {
+      if (!batch.length) return;
+      await deleteImagesForModelVersionCache(batch);
+      console.log(`Busted batch ${batchNumber} of ${batchCount} (${batch.length} model versions)`);
+    },
+  });
+}

--- a/src/pages/api/admin/temp/bust-model-version-images-cache.ts
+++ b/src/pages/api/admin/temp/bust-model-version-images-cache.ts
@@ -24,7 +24,10 @@ const schema = z.object({
             .map((s) => Number(s.trim()))
             .filter((n) => Number.isFinite(n) && n > 0)
         : undefined
-    ),
+    )
+    .refine((ids) => ids === undefined || ids.length > 0, {
+      message: 'ids must contain at least one valid positive numeric model version ID',
+    }),
 });
 
 export default WebhookEndpoint(async (req, res) => {

--- a/src/server/controllers/image.controller.ts
+++ b/src/server/controllers/image.controller.ts
@@ -37,6 +37,7 @@ import {
 import { getGallerySettingsByModelId } from '~/server/services/model.service';
 import { trackModActivity } from '~/server/services/moderator.service';
 import { createNotification } from '~/server/services/notification.service';
+import { bustCachesForPosts } from '~/server/services/post.service';
 import { amIBlockedByUser } from '~/server/services/user.service';
 import {
   throwAuthorizationError,
@@ -238,6 +239,7 @@ export const setTosViolationHandler = async ({
 
     if (image.pHash) await addBlockedImage({ hash: image.pHash, reason: BlockImageReason.TOS });
     await queueImageSearchIndexUpdate({ ids: [id], action: SearchIndexUpdateQueueAction.Delete });
+    if (image.postId) await bustCachesForPosts(image.postId);
 
     // Look up report details for violation type resolution
     const reportDetails = await getReportViolationDetailsForImages([id]);

--- a/src/server/jobs/audit-remix-sources.ts
+++ b/src/server/jobs/audit-remix-sources.ts
@@ -4,6 +4,7 @@ import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { extModeration } from '~/server/integrations/moderation';
 import { auditPromptEnriched } from '~/utils/metadata/audit';
 import { imageMetaOutput } from '~/server/schema/image.schema';
+import { bustCachesForPosts } from '~/server/services/post.service';
 import { createJob } from './job';
 
 const DEDUP_TTL = 60 * 60 * 24; // 24 hours — don't re-audit the same source image within a day
@@ -106,10 +107,13 @@ export const auditRemixSourcesJob = createJob(
 
         // 5. Flag for moderator review if problematic
         if (isProblematic) {
-          await dbWrite.image.update({
+          const updated = await dbWrite.image.update({
             where: { id: imageId },
             data: { needsReview: 'remixSource' },
+            select: { postId: true },
           });
+          // Flagged images need to disappear from the model-version showcase.
+          if (updated.postId) await bustCachesForPosts(updated.postId);
           flagged++;
         }
       } catch (error) {

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -36,7 +36,7 @@ import { createImageTagsForReview } from '~/server/services/image-review.service
 import { tagIdsForImagesCache } from '~/server/redis/caches';
 import type { MediaMetadata } from '~/server/schema/media.schema';
 import { deleteUserProfilePictureCache } from '~/server/services/user.service';
-import { updatePostNsfwLevel } from '~/server/services/post.service';
+import { bustCachesForPosts, updatePostNsfwLevel } from '~/server/services/post.service';
 import { updateComicNsfwLevelsForImage } from '~/server/services/nsfwLevels.service';
 import { queueImageSearchIndexUpdate } from '~/server/services/image.service';
 import { signalClient } from '~/utils/signal-client';
@@ -327,6 +327,9 @@ export async function processImageScanWorkflow({
       ids: [image.id],
       action: SearchIndexUpdateQueueAction.Delete,
     });
+    // A previously-cached Blocked image can still satisfy the showcase query
+    // filters (needsReview IS NULL, nsfwLevel != 0) so drop it from the showcase.
+    if (image.postId) await bustCachesForPosts(image.postId);
   }
   // handle scanned image updates
   else if (toUpdate.ingestion === ImageIngestionStatus.Scanned) {
@@ -338,7 +341,11 @@ export async function processImageScanWorkflow({
       await deleteUserProfilePictureCache(image.userId);
     }
 
-    if (image.postId) await updatePostNsfwLevel(image.postId);
+    if (image.postId) {
+      await updatePostNsfwLevel(image.postId);
+      // Without this, the showcase cache stays empty until its 24h TTL for any model version whose images hadn't scanned yet on first read.
+      await bustCachesForPosts(image.postId);
+    }
     await updateComicNsfwLevelsForImage(image.id);
 
     await queueImageSearchIndexUpdate({

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3,7 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { randomUUID } from 'crypto';
 import type { ManipulateType } from 'dayjs';
 import dayjs from '~/shared/utils/dayjs';
-import { chunk, truncate, uniqBy } from 'lodash-es';
+import { chunk, truncate, uniq, uniqBy } from 'lodash-es';
 import { MeiliSearch, type SearchParams } from 'meilisearch';
 import type { SessionUser } from 'next-auth';
 import { v4 as uuid } from 'uuid';
@@ -492,11 +492,14 @@ export async function handleUnblockImages({
       ),
     ]);
 
+    const postIds = uniq(images.map(({ postId }) => postId).filter(isDefined));
     await Promise.all([
       updateNsfwLevel(ids),
       queueImageSearchIndexUpdate({ ids, action: SearchIndexUpdateQueueAction.Update }),
       deleteImagTagsForReviewByImageIds(ids),
       bulkRemoveBlockedImages(images.map(({ pHash }) => pHash).filter(isDefined)),
+      // Unblock re-admits the image into the showcase query; bust so it reappears without waiting on TTL.
+      postIds.length ? bustCachesForPosts(postIds) : Promise.resolve(),
     ]);
 
     if (moderatorId) {
@@ -547,6 +550,7 @@ export async function handleBlockImages({
   });
   await Limiter({ batchSize: 100, limit: 10 }).process(images, async (images) => {
     const ids = images.map((x) => x.id);
+    const postIds = uniq(images.map(({ postId }) => postId).filter(isDefined));
     const invalidateExistence = invalidateManyImageExistence(ids);
 
     await Promise.all([
@@ -563,6 +567,8 @@ export async function handleBlockImages({
 
       queueImageSearchIndexUpdate({ ids, action: SearchIndexUpdateQueueAction.Delete }),
       invalidateExistence,
+      // Blocked images can still satisfy the showcase SQL filters; drop them now.
+      postIds.length ? bustCachesForPosts(postIds) : Promise.resolve(),
     ]);
     if (include?.includes('phash-block')) {
       await bulkAddBlockedImages({

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -498,9 +498,9 @@ export async function handleUnblockImages({
       queueImageSearchIndexUpdate({ ids, action: SearchIndexUpdateQueueAction.Update }),
       deleteImagTagsForReviewByImageIds(ids),
       bulkRemoveBlockedImages(images.map(({ pHash }) => pHash).filter(isDefined)),
-      // Unblock re-admits the image into the showcase query; bust so it reappears without waiting on TTL.
-      postIds.length ? bustCachesForPosts(postIds) : Promise.resolve(),
     ]);
+    // Bust after the writes above land so a concurrent reader can't refill the cache from pre-update rows.
+    if (postIds.length) await bustCachesForPosts(postIds);
 
     if (moderatorId) {
       await trackModActivity(moderatorId, {
@@ -567,9 +567,9 @@ export async function handleBlockImages({
 
       queueImageSearchIndexUpdate({ ids, action: SearchIndexUpdateQueueAction.Delete }),
       invalidateExistence,
-      // Blocked images can still satisfy the showcase SQL filters; drop them now.
-      postIds.length ? bustCachesForPosts(postIds) : Promise.resolve(),
     ]);
+    // Bust after the block write commits so a concurrent reader can't refill with the pre-block state.
+    if (postIds.length) await bustCachesForPosts(postIds);
     if (include?.includes('phash-block')) {
       await bulkAddBlockedImages({
         data: images

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -30,6 +30,7 @@ import { queueImageSearchIndexUpdate, updateNsfwLevel } from '~/server/services/
 import { updateArticleNsfwLevels } from '~/server/services/nsfwLevels.service';
 import { trackModActivity } from '~/server/services/moderator.service';
 import { createNotification } from '~/server/services/notification.service';
+import { bustCachesForPosts } from '~/server/services/post.service';
 import { addTagVotes } from '~/server/services/tag.service';
 import { throwAuthorizationError, throwNotFoundError } from '~/server/utils/errorHandling';
 import { getPagination, getPagingData } from '~/server/utils/pagination-helpers';
@@ -574,7 +575,7 @@ export async function resolveEntityAppeal({
       case EntityType.Image:
         try {
           // Update entity with needsReview = null
-          await dbWrite.image.update({
+          const updated = await dbWrite.image.update({
             where: { id: appeal.entityId },
             data: approved
               ? {
@@ -583,6 +584,7 @@ export async function resolveEntityAppeal({
                   ingestion: ImageIngestionStatus.Scanned,
                 }
               : { needsReview: null },
+            select: { postId: true },
           });
 
           if (approved) await updateNsfwLevel(appeal.entityId);
@@ -593,6 +595,9 @@ export async function resolveEntityAppeal({
               ? SearchIndexUpdateQueueAction.Update
               : SearchIndexUpdateQueueAction.Delete,
           });
+
+          // Either direction (approve/deny) changes needsReview; bust so the showcase reflects it.
+          if (updated.postId) await bustCachesForPosts(updated.postId);
         } catch (e) {
           // Image may have been deleted — log but continue resolving the appeal
           console.error(`Failed to update image ${appeal.entityId} for appeal ${appeal.id}: ${e}`);


### PR DESCRIPTION
## Summary
- Wires `bustCachesForPosts` into every ingestion / `needsReview` transition so the model-version showcase image cache (`imagesForModelVersionsCache`) can't stay stale for up to 24h after a publish.
- Adds a one-off admin endpoint to refresh entries that are currently stuck from before this fix ships.

## Bug
`imagesForModelVersionsCache` was getting populated with an empty image list when reads raced against a fresh publish (images still Pending, `nsfwLevel = 0`), and nothing was busting it afterward. In prod the TTL is 24h, so `model.getAll` ended up returning models with `images: []` — and because the controller filters zero-image models out for non-owner viewers, the model effectively disappeared from profile / home feeds.

## Changes

### Bust on every relevant flip (`src/server/...`)
- `image-scan-result.service.ts` — bust on both `Scanned` and `Blocked` terminal states in `processImageScanResult`.
- `image.service.ts` — bust after bulk moderation in `handleUnblockImages` and `handleBlockImages` (collects post ids first).
- `controllers/image.controller.ts` — bust after `setTosViolationHandler`'s single-image block.
- `report.service.ts` — bust after `resolveEntityAppeal` transitions `needsReview` either way.
- `jobs/audit-remix-sources.ts` — bust when an image is flagged `remixSource`.

`bustCachesForPosts` already filters to showcase posts (`post.userId === model.userId`), so it's safe to call on any image post.

### New admin endpoint
`POST /api/admin/temp/bust-model-version-images-cache` — batch-invalidates `imagesForModelVersionsCache` for recently-published model versions, so affected models surface fresh without waiting on TTL.

| Query param | Default | Notes |
|---|---|---|
| `sinceDays` | `14` | Model versions whose `publishedAt` is within this window |
| `ids` | — | Comma-separated MV ids; overrides `sinceDays` |
| `batchSize` | `500` | Passed through to `batchProcessor` |
| `concurrency` | `10` | Passed through to `batchProcessor` |

Uses `invalidate` semantics under the hood (`staleWhileRevalidate: true`), so next reader gets a fresh lookup without a thundering herd.

## Context
ClickUp [868jbk1zv](https://app.clickup.com/t/868jbk1zv) — Freshdesk ticket #64199. Investigation + trade-offs posted as the pinned comment on the ClickUp task.

## Test plan
- [ ] Upload a new model version with images; confirm showcase populates immediately after scanning completes (no 24h wait).
- [ ] Mod-block an image in an active showcase post; confirm it drops from `model.getAll` within seconds.
- [ ] Mod-unblock a previously blocked image; confirm it reappears.
- [ ] Resolve an image appeal (approved and denied); confirm the showcase reflects the new state.
- [ ] Hit `POST /api/admin/temp/bust-model-version-images-cache?ids=<one_affected_mv_id>` in staging and verify the next `model.getAll` for that profile returns populated images.
- [ ] Run the same endpoint with `?sinceDays=14` against one of the affected users from the ticket (user ids 7850088, 11862146, 431827) and confirm their models resurface.