### PR TITLE
fix(dp): add startup warmup gate to reduce canary promotion errors

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -95,3 +95,6 @@ if (!OTEL_ENABLED) {
     console.error('[instrumentation.node] Failed to initialize OTEL:', error);
   }
 }
+
+// Trigger startup warmup (non-blocking)
+import('./server/utils/warmup').then((m) => m.runWarmup()).catch(console.error);

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -10,6 +10,7 @@ import { metricsSearchClient } from '~/server/meilisearch/client';
 import { registerCounter } from '~/server/prom/client';
 import { redis, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { isWarmedUp } from '~/server/utils/warmup';
 import { getRandomInt } from '~/utils/number-helpers';
 
 function logError({ error, name, details }: { error: Error; name: string; details: unknown }) {
@@ -163,6 +164,11 @@ const counters = (() =>
   }, {} as Record<CheckKey | 'overall', client.Counter>))();
 
 export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  const isStartupCheck = req.query.startup === 'true';
+  if (!isStartupCheck && !isWarmedUp()) {
+    return res.status(503).json({ healthy: false, reason: 'warming up' });
+  }
+
   const podname = process.env.PODNAME ?? getRandomInt(100, 999);
 
   // Create AbortController for all health checks

--- a/src/server/utils/warmup.ts
+++ b/src/server/utils/warmup.ts
@@ -1,0 +1,42 @@
+import { dbRead, dbWrite } from '~/server/db/client';
+import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
+import { redis, sysRedis } from '~/server/redis/client';
+
+let warmedUp = false;
+
+export function isWarmedUp() {
+  return warmedUp;
+}
+
+export async function runWarmup() {
+  const start = Date.now();
+  console.log('[warmup] Starting...');
+
+  await Promise.allSettled([
+    // Prime Prisma connection pools
+    dbRead.$queryRaw`SELECT 1`,
+    dbWrite.$queryRaw`SELECT 1`,
+
+    // Prime pg connection pools
+    pgDbRead.query('SELECT 1'),
+    pgDbWrite.query('SELECT 1'),
+
+    // Ping Redis to establish topology
+    (redis as any).ping(),
+    (sysRedis as any).ping(),
+
+    // Self-fetch a tRPC endpoint to JIT-compile the hot middleware chain
+    fetch(
+      'http://localhost:3000/api/trpc/homeBlock.getAll?input=' +
+        encodeURIComponent(JSON.stringify({ json: {} }))
+    ).catch(() => {}),
+
+    // Pre-warm entity metrics cache
+    import('~/server/redis/entity-metric-populate').then((m) =>
+      m.preWarmEntityMetrics('Image', 1000)
+    ),
+  ]);
+
+  warmedUp = true;
+  console.log(`[warmup] Complete in ${Date.now() - start}ms`);
+}


### PR DESCRIPTION
## Summary
- Adds a startup warmup module (`src/server/utils/warmup.ts`) that primes DB connection pools, Redis cluster topology, V8 JIT (via self-fetch), and entity metrics cache on pod startup
- Gates `/api/health` readiness checks with 503 until warmup completes, preventing Kubernetes from routing traffic to cold pods
- Startup probe bypasses the gate via `?startup=true` query param so pods aren't killed during warmup

## Context
During Flagger canary promotions, all ~95 pods roll via RollingUpdate. New pods pass the readiness probe (was TCP, now HTTP per civitai/talos-infra@1a5a23b5) before they're actually warm — DB pools are empty (`min: 0`), Redis cluster topology isn't discovered, and V8 JIT is cold. This causes 502s (11.6/s) and P95 latency spikes to 18s+ during every deploy.

The infra-side changes (HTTP readiness probe, `minReadySeconds: 30`, `maxSurge: 25%`) are already deployed. This PR adds the app-side warmup gate — the final piece. Once merged, a corresponding deployment YAML change adds `&startup=true` to the startup probe path.

## What gets warmed

| Resource | How | Expected Time |
|----------|-----|---------------|
| DB pools | `SELECT 1` on Prisma + pg pools | ~50-200ms |
| Redis topology | `ping()` forces cluster slot discovery | ~100ms |
| V8 JIT | Self-fetch `/api/trpc/homeBlock.getAll` | ~2-5s |
| Entity metrics | `preWarmEntityMetrics('Image', 1000)` | ~3-10s |

## Test plan
- [ ] Deploy to DP staging/canary and verify pods report `[warmup] Starting...` and `[warmup] Complete in Xms` in logs
- [ ] Verify startup probe passes (pod starts successfully)
- [ ] Verify readiness probe returns 503 during warmup, then 200 after
- [ ] Monitor next canary promotion for reduced 502s and latency spikes
- [ ] Verify DOKS deployments are unaffected (warmup runs but no K8s probe changes there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)