### PR TITLE
perf: fix heap/compute hotspots from 2026-04 frontend audit

### DIFF
--- a/docs/frontend-perf-audit-2026-04.md
+++ b/docs/frontend-perf-audit-2026-04.md
@@ -192,8 +192,16 @@ query cache. Needs source-map lookup to confirm.
    per card. Fixes `computeIntersections` churn and a detached-node vector.
    **Status: already done in this branch via `343778e1a ModelCard optimizations`
    (not yet in prod).**
-3. **Find and disconnect the stuck `PerformanceObserver`.** `grep "new PerformanceObserver"`;
-   one of them has `buffered: true` with no `disconnect()`.
+3. **~~Find and disconnect the stuck `PerformanceObserver`.~~** Investigated
+   — no `PerformanceObserver` registration in our source (`rg "new PerformanceObserver"` empty; no `web-vitals` / `@sentry` / `@vercel/analytics` /
+   `posthog` deps). The `+1,381 PerformanceEventTiming` retention is coming
+   from a third-party script, most likely Snigel's ad engine
+   (`adengine.snigelweb.com/.../adngin.js` was the #2 TimerInstall source and
+   regularly probes INP for bid quality) or a browser extension that was
+   loaded during the capture (React DevTools + Metamask content scripts were
+   present). **Status: not in our code — no fix available from our side.**
+   If we add our own perf instrumentation later, be sure to disconnect
+   observers on page unload.
 4. **Track down the 150 ms scroll debouncer.** Prime suspects: `MasonryProvider`
    scroll handler, `useBrowsingLevelDebounced`, any Mantine `useDebouncedValue`
    in a scroll-affected tree.

--- a/docs/frontend-perf-audit-2026-04.md
+++ b/docs/frontend-perf-audit-2026-04.md
@@ -217,11 +217,22 @@ query cache. Needs source-map lookup to confirm.
 ### P1
 
 5. **`React.memo` feed card components with stable prop references.** Avoids
-   re-rendering every card on unrelated store updates.
+   re-rendering every card on unrelated store updates. **Status: done in this
+   branch for ArticleCard, BountyCard, CollectionCard, ChallengeCard,
+   ComicCard, CreatorCardSimple. ModelCard/ImagesCard/PostsCard were already
+   memoized.**
 6. **Memoize inline Tabler icons** (or move to a sprite sheet). 1000 SVG trees
-   per 50-card feed is cheap to kill.
+   per 50-card feed is cheap to kill. **Status: deferred.** With P1.5 in place
+   icons only re-create on card mount (virtualizer scroll-in). True win
+   requires a sprite sheet — not a shallow edit. Track separately if feed
+   mount cost is still hot after these P0+P1 changes.
 7. **Audit `uW` observer (queryKey stability).** Either a source-map lookup or
    dev-build sanity check; look for `{ ... }` object literals in `queryKey`.
+   **Status: needs source-map — the minified `uW` name could be a Query,
+   QueryObserver, or MutationObserver from tRPC/React Query. Worth running
+   `pnpm build --profile` and inspecting the chunk, or spot-check hot hooks
+   (`useLiveMetric`, `useBuzzTippingStore`, `useReviewedModelIds`) for
+   `queryKey` stability.
 
 ### P2
 

--- a/docs/frontend-perf-audit-2026-04.md
+++ b/docs/frontend-perf-audit-2026-04.md
@@ -1,0 +1,247 @@
+# Frontend Performance Audit — April 2026
+
+Heap snapshot + Performance profile analysis of civitai.com during a brief feed
+scroll session. Captured 2026-04-22 by Justin (logged out, Chrome). Analyzed by
+Claude Code by parsing the raw snapshot/trace JSON (see
+`.claude/worktrees/perf-heap-fixes/docs/` and the scripts in `C:\tmp\perf-analysis`
+if you want to re-run).
+
+> **Caveat.** The capture was logged out — no websocket signals, no live
+> metrics, no chat, no notifications. Every number below is a floor, not a
+> ceiling. A logged-in capture will amplify the store/observer/animation paths.
+
+---
+
+## TL;DR
+
+- **+29MB heap after a brief scroll** (61MB → 90MB fresh → scroll).
+- **26,839 detached DOM nodes** (was 3). Real leak, not just churn.
+- **3,920 150-ms `setTimeout`s** installed in 102s (38/sec) from one app
+  chunk — a debouncer is being reset every scroll tick.
+- **One `requestAnimationFrame` loop runs at 60Hz the whole time** the feed is
+  open, driving `Layerize` (1,627×), `Paint` (4,189×).
+- Feed cards use the `@number-flow/react` library (`AnimatedCount` /
+  `LiveMetric`) for every metric. Each instance spawns a custom element +
+  ShadowRoot + ~10 digit spans + 4-6 `CSSStyleDeclaration`s.
+- A `PerformanceObserver` is running with `buffered: true` and never clears —
+  `PerformanceEventTiming` entries leak linearly.
+
+---
+
+## Heap diff: fresh → brief feed scroll
+
+| Metric | Fresh | After scroll | Δ |
+| --- | ---: | ---: | ---: |
+| Total self size | 61.3 MB | 90.4 MB | **+29.1 MB** |
+| Node count | 1,385,045 | 2,179,815 | +794,770 |
+| Detached DOM | 3 | **26,839** | +26,836 (+3.5 MB) |
+
+### Top size-growth constructors
+
+| Constructor | Δ count | Δ size |
+| --- | ---: | ---: |
+| `object::Object` | +174,919 | +5.24 MB |
+| `array::(object elements)` | +48,487 | +2.14 MB |
+| `object::uW` (minified) | +16,131 | +1.61 MB |
+| `array::(object properties)` | +10,526 | +1.54 MB |
+| `closure::` | +46,035 | +1.32 MB |
+| `object::system / Context` | +42,691 | +1.24 MB |
+| `native::Text` | +13,558 | +1.23 MB |
+| `native::CSSStyleDeclaration` | +19,365 | +1.13 MB |
+| `native::SVGPathElement` | +3,091 | +0.52 MB |
+| `native::V8EventListener` | +12,358 | +0.49 MB |
+| `native::DOMTokenList` | +7,077 | +0.41 MB |
+| `native::PerformanceEventTiming` | +1,381 | +0.36 MB |
+
+### AnimatedCount / NumberFlow footprint
+
+During the same scroll:
+
+- `ShadowRoot` 249 → 1,164 (+915)
+- `native::<span class="digit__num" inert style="--n: 0..9">` — each digit added
+  ~1,100–1,500 instances. Across 0–9 that is ~10k digit spans.
+- `native::<span class="AnimatedCount_wrapper__mdpqx">` 245 → 1,150 (+905)
+- `native::SVGAnimatedLength/Transform/String/Number/Rect/PreserveAspectRatio` —
+  each grew by ~4,100 (SVG icons inside `NumberFlow` shadow DOM + Tabler icons
+  on cards)
+
+The library is cool. It is extremely expensive at card-grid scale.
+
+---
+
+## CPU profile (102s trace)
+
+| Metric | Value |
+| --- | ---: |
+| Sum of X events | 102.1 s |
+| Long tasks (≥50 ms) | 91 |
+| Heaviest 6 tasks | 180–225 ms each (React commits, chunk `30548-*.js`) |
+| `scroll` events dispatched | 560 (avg 4.3 ms each, total 2.4 s) |
+| `rAF` service calls (`PageAnimator::serviceScriptedAnimations`) | 1,627 |
+| `Layerize` | 1,627× (7.9 s total) |
+| `Paint` | 4,189× (1.54 s total) |
+| `IntersectionObserver::computeIntersections` | 3,316 calls |
+
+### Timer churn
+
+Top `TimerInstall` callsites (102 s window):
+
+| Count | Timeout | Source |
+| ---: | ---: | --- |
+| **3,920** | 150 ms | `civitai.com/_next/static/chunks/30548-8821e4834a2871a8.js:4` |
+| 559 | 300 ms | `civitai.com/_next/static/chunks/pages/_app-4a3afcd97c94cf70.js:11` |
+| 68 | 100 ms | `_app-*.js:11` |
+| 41 | 500 / 5000 ms | Snigel ad engine |
+| 34 | — | 34 `requestAnimationFrame` registrations also bound to `_app-*.js:11` |
+
+4,718 timers installed, 479 fired, 10,344 removed. The ratio screams
+**debouncer reset storm**: almost every install gets cancelled and replaced.
+
+### EventDispatch breakdown
+
+| Type | Total | Count | Avg |
+| --- | ---: | ---: | ---: |
+| scroll | 2,401 ms | 560 | 4.3 ms |
+| wheel | 36 ms | 221 | 0.16 ms |
+| pointermove | 31 ms | 260 | 0.12 ms |
+| load | 21 ms | 292 | 0.07 ms |
+
+Scroll handlers are doing 4 ms of JS per event. That is where the 150 ms
+debouncer is getting reset 38 times per second.
+
+---
+
+## Root causes — what's actually going on
+
+### 1. NumberFlow in every card is a DOM bomb
+
+`src/components/Metrics/AnimatedCount.tsx` wraps `@number-flow/react`, which is
+a web component with shadow DOM and per-digit rAF animation. It is used via
+`LiveMetric` across 16 components, including `ArticleCard`, `ModelCard`,
+`ImagesCard`, `CreatorCardSimple`, `UserStatBadges`, `Reactions`,
+`ModelVersionDetails`. Each card renders 4–7 metrics. A 50-card feed = 200–350
+NumberFlow instances = 200–350 shadow roots, thousands of digit spans, a
+permanent 60Hz rAF loop.
+
+This is the #1 contributor to the `ShadowRoot`, `digit__num`, `CSSStyleDeclaration`,
+`Layerize`, and `Paint` growth.
+
+### 2. Per-card IntersectionObserver instead of shared
+
+`src/components/Metrics/MetricSubscriptionProvider.tsx:77-90` creates a brand
+new `IntersectionObserver` for every card. The repo already has a shared one
+(`src/components/IntersectionObserver/IntersectionObserverProvider.tsx`) that
+multiplexes observations through a single observer. Using the shared provider
+here would cut `computeIntersections` by ~30×.
+
+Equally important: per-card observers that aren't guaranteed to unsubscribe
+before the card unmounts are a likely source of the 26,839 detached nodes.
+
+### 3. 150 ms scroll debouncer in chunk `30548`
+
+Every scroll tick (560 over 102 s) resets a 150 ms `setTimeout`. That chunk is
+a big aggregated app chunk; the exact module will need a source-map lookup or
+`grep setTimeout.*150` with scroll-adjacent surrounding code. Candidates from
+the repo:
+
+- `MasonryProvider` + `useBrowsingLevelDebounced` recompute `items` in
+  `MasonryGridVirtual.tsx:61–78` whenever the debounced browsing level fires.
+- `createAdFeed` re-slots ads.
+- Any Mantine `useDebouncedValue(..., 150)` in a scroll-adjacent component.
+
+### 4. Stuck `PerformanceObserver`
+
+`PerformanceEventTiming` +1,381 entries per short session, +0.36 MB/session.
+Somewhere we registered `new PerformanceObserver({ type: 'event', buffered: true })`
+and never call `takeRecords()` or `disconnect()`. Classic observability leak —
+probably web-vitals instrumentation.
+
+### 5. Tabler icon explosion
+
+`SVGPathElement` +3,091, `SVGSVGElement` +1,040, 6 different `SVGAnimated*`
+growing +4,100 each. Every Tabler `<IconX />` is an inline SVG tree with
+animated attributes. Feed cards inline 15–25 icons each; no memoization, so
+they're re-created on every parent render. Mid-term fix: SVG sprite. Short
+term: `React.memo` the card.
+
+### 6. Minified `object::uW` (+16k, +1.6 MB)
+
+Most likely `@tanstack/react-query`'s `QueryObserver`. Suggests unstable
+`queryKey` shapes (object literals created per render) or unbounded infinite
+query cache. Needs source-map lookup to confirm.
+
+---
+
+## Fix plan (priority order)
+
+### P0
+
+1. **Gate `AnimatedCount` to visible cards.** Render a plain formatted number
+   when offscreen; only instantiate `NumberFlow` when the card is intersecting.
+   Halves DOM size and kills the always-on rAF loop.
+2. **Switch `MetricSubscriptionProvider` to the shared
+   `IntersectionObserverProvider`.** One observer for the feed instead of one
+   per card. Fixes `computeIntersections` churn and a detached-node vector.
+3. **Find and disconnect the stuck `PerformanceObserver`.** `grep "new PerformanceObserver"`;
+   one of them has `buffered: true` with no `disconnect()`.
+4. **Track down the 150 ms scroll debouncer.** Prime suspects: `MasonryProvider`
+   scroll handler, `useBrowsingLevelDebounced`, any Mantine `useDebouncedValue`
+   in a scroll-affected tree.
+
+### P1
+
+5. **`React.memo` feed card components with stable prop references.** Avoids
+   re-rendering every card on unrelated store updates.
+6. **Memoize inline Tabler icons** (or move to a sprite sheet). 1000 SVG trees
+   per 50-card feed is cheap to kill.
+7. **Audit `uW` observer (queryKey stability).** Either a source-map lookup or
+   dev-build sanity check; look for `{ ... }` object literals in `queryKey`.
+
+### P2
+
+8. Audit `useSignalTopic` cleanup when topic becomes undefined.
+9. Drop NumberFlow animation entirely for low-motion metrics (downloads, likes);
+   use CSS pulse on value change instead.
+10. `MasonryGridVirtual.tsx:61` — `useBrowsingLevelDebounced` + `adsReallyAreEnabled`
+    cause `items` recompute every debounce fire. Guard with `useMemo` key stability.
+
+---
+
+## Next capture (please)
+
+- Logged-in session, same pattern: fresh snapshot → 60 s feed scroll → second
+  snapshot → 60 s idle → third snapshot.
+- Same 30-60 s Performance trace, "scroll feed" only (no navigation) for
+  cleaner data.
+
+Expected amplification when logged in:
+
+- Signal websocket + `useMetricSignalsStore` deltas → every card re-renders on
+  every delta (even with `useShallow`, the `MetricSubscriptionContext.Provider`
+  value is new each render — see point 1 of P1 above).
+- Notification + chat signalr loops → more rAFs and timers.
+- `object::uW` and detached DOM will likely explode further.
+
+---
+
+## Reproducibility
+
+Raw artifacts live in `C:\Users\Zipp4\Downloads\perf\`:
+
+- `fresh.heapsnapshot` (125 MB)
+- `brief feed scroll.heapsnapshot` (196 MB)
+- `sitting for 5 minutes in background.heapsnapshot` (163 MB, **truncated —
+  unusable**)
+- `Trace-20260422T191137.json` (160 MB)
+
+Analyzer scripts in `C:\tmp\perf-analysis\`:
+
+- `analyze-heap.mjs` — aggregates nodes by (type, constructor), writes
+  `<name>.summary.json`.
+- `diff.mjs` — diffs two summary JSONs.
+- `analyze-trace.mjs` — event categories, long tasks, rendering pipeline.
+- `find-timer.mjs` — groups TimerFire by timerId, dumps TimerInstall stacks.
+- `timer-stats.mjs` — TimerInstall frequencies by callsite, rAF callsites,
+  EventDispatch by type, install/fire/remove counts.
+
+Run with `node --max-old-space-size=12288 analyze-heap.mjs <file>`.

--- a/docs/frontend-perf-audit-2026-04.md
+++ b/docs/frontend-perf-audit-2026-04.md
@@ -202,9 +202,17 @@ query cache. Needs source-map lookup to confirm.
    present). **Status: not in our code — no fix available from our side.**
    If we add our own perf instrumentation later, be sure to disconnect
    observers on page unload.
-4. **Track down the 150 ms scroll debouncer.** Prime suspects: `MasonryProvider`
-   scroll handler, `useBrowsingLevelDebounced`, any Mantine `useDebouncedValue`
-   in a scroll-affected tree.
+4. **~~Track down the 150 ms scroll debouncer.~~** Found it:
+   `@tanstack/virtual-core`'s scroll listener ends scrolling via an
+   internal `debounce(..., isScrollingResetDelay)` (default **150 ms**).
+   The scroll `handler` calls `fallback()` on every scroll event, which
+   resets the timer — reinstalling one `setTimeout(150)` per scroll tick.
+   The three `useVirtualizer` callsites (`MasonryGridVirtual`,
+   `MasonryColumnsVirtual`, `pages/user/downloads.tsx`) are the source of
+   the 3,920 timer installs. **Status: fixed in this branch — all three
+   now pass `useScrollendEvent: true`**, opting into the native `scrollend`
+   event (Chrome 114+, Firefox 109+, Safari 18.2+). virtual-core falls back
+   to the 150 ms debounce automatically on older browsers.
 
 ### P1
 

--- a/docs/frontend-perf-audit-2026-04.md
+++ b/docs/frontend-perf-audit-2026-04.md
@@ -10,6 +10,13 @@ if you want to re-run).
 > metrics, no chat, no notifications. Every number below is a floor, not a
 > ceiling. A logged-in capture will amplify the store/observer/animation paths.
 
+> **Branch offset.** `main` (what civitai.com runs) does NOT yet include
+> `343778e1a ModelCard optimizations` or the other unreleased work on this
+> branch. Some fixes described below are already landed in this branch
+> ahead of main — see "Status" markers. Relatedly, there is a separate
+> [feed-card-dom-audit.md](./feed-card-dom-audit.md) by Briant covering DOM
+> reduction + render cost at feed scale; the two audits are complementary.
+
 ---
 
 ## TL;DR
@@ -178,10 +185,13 @@ query cache. Needs source-map lookup to confirm.
 
 1. **Gate `AnimatedCount` to visible cards.** Render a plain formatted number
    when offscreen; only instantiate `NumberFlow` when the card is intersecting.
-   Halves DOM size and kills the always-on rAF loop.
+   Halves DOM size and kills the always-on rAF loop. **Status: done in this
+   branch (`perf(metrics): gate NumberFlow animation to visible cards`).**
 2. **Switch `MetricSubscriptionProvider` to the shared
    `IntersectionObserverProvider`.** One observer for the feed instead of one
    per card. Fixes `computeIntersections` churn and a detached-node vector.
+   **Status: already done in this branch via `343778e1a ModelCard optimizations`
+   (not yet in prod).**
 3. **Find and disconnect the stuck `PerformanceObserver`.** `grep "new PerformanceObserver"`;
    one of them has `buffered: true` with no `disconnect()`.
 4. **Track down the 150 ms scroll debouncer.** Prime suspects: `MasonryProvider`

--- a/src/components/Cards/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard.tsx
@@ -1,5 +1,5 @@
 import { Badge, Text } from '@mantine/core';
-import React from 'react';
+import React, { memo } from 'react';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { IconBolt, IconBookmark, IconEye, IconMessageCircle2 } from '@tabler/icons-react';
 import { slugit } from '~/utils/string-helpers';
@@ -23,13 +23,13 @@ const articleStatusBadge: Partial<Record<ArticleStatus, { label: string; color: 
   [ArticleStatus.UnpublishedViolation]: { label: 'Violation', color: 'red' },
 };
 
-export function ArticleCard({ data, aspectRatio }: Props) {
+export const ArticleCard = memo(function ArticleCard({ data, aspectRatio }: Props) {
   return (
     <MetricSubscriptionProvider entityType="Article" entityId={data.id}>
       <ArticleCardContent data={data} aspectRatio={aspectRatio} />
     </MetricSubscriptionProvider>
   );
-}
+});
 
 function ArticleCardContent({ data, aspectRatio }: Props) {
   const { id, title, coverImage, publishedAt, user, tags, stats, status } = data;

--- a/src/components/Cards/BountyCard.tsx
+++ b/src/components/Cards/BountyCard.tsx
@@ -9,7 +9,7 @@ import {
   IconSwords,
   IconViewfinder,
 } from '@tabler/icons-react';
-import React from 'react';
+import React, { memo } from 'react';
 import { useBountyEngagement } from '~/components/Bounty/bounty.utils';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { CurrencyBadge } from '~/components/Currency/CurrencyBadge';
@@ -32,7 +32,7 @@ const sharedBadgeProps: Omit<BadgeProps, 'children'> = {
   fw: 'bold',
 };
 
-export function BountyCard({ data }: Props) {
+export const BountyCard = memo(function BountyCard({ data }: Props) {
   const { id, name, images, type, expiresAt, stats, complete } = data;
   const image = images?.[0];
   const expired = expiresAt < new Date();
@@ -226,6 +226,6 @@ export function BountyCard({ data }: Props) {
       }
     />
   );
-}
+});
 
 type Props = { data: BountyGetAll[number] };

--- a/src/components/Cards/ChallengeCard.tsx
+++ b/src/components/Cards/ChallengeCard.tsx
@@ -1,5 +1,6 @@
 import type { BadgeProps } from '@mantine/core';
 import { Badge, Group, Text } from '@mantine/core';
+import { memo } from 'react';
 import {
   IconClockHour4,
   IconMessageCircle2,
@@ -76,7 +77,7 @@ function StatusBadge({ status, startsAt, endsAt }: StatusBadgeProps) {
   }
 }
 
-export function ChallengeCard({ data }: Props) {
+export const ChallengeCard = memo(function ChallengeCard({ data }: Props) {
   const {
     id,
     title,
@@ -218,7 +219,7 @@ export function ChallengeCard({ data }: Props) {
       }
     />
   );
-}
+});
 
 type StatusBadgeProps = Pick<ChallengeListItem, 'status' | 'startsAt' | 'endsAt'>;
 type Props = { data: ChallengeListItem };

--- a/src/components/Cards/CollectionCard.tsx
+++ b/src/components/Cards/CollectionCard.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, Badge, Text } from '@mantine/core';
+import { memo } from 'react';
 import { IconDotsVertical, IconLayoutGrid, IconUser } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { truncate } from 'lodash-es';
@@ -33,7 +34,7 @@ type ImageProps = {
   meta?: ImageMetaProps | null;
 };
 
-export function CollectionCard({ data }: Props) {
+export const CollectionCard = memo(function CollectionCard({ data }: Props) {
   const getCoverImages = () => {
     if (data.image) return [data.image];
 
@@ -122,7 +123,7 @@ export function CollectionCard({ data }: Props) {
       </div>
     </FeedCard>
   );
-}
+});
 
 type HeaderData = Pick<Props['data'], 'id' | 'userId' | 'type' | 'mode'>;
 

--- a/src/components/Cards/ComicCard.tsx
+++ b/src/components/Cards/ComicCard.tsx
@@ -1,4 +1,5 @@
 import { Badge, Text } from '@mantine/core';
+import { memo } from 'react';
 import { IconBook } from '@tabler/icons-react';
 import clsx from 'clsx';
 import cardClasses from '~/components/Cards/Cards.module.css';
@@ -12,7 +13,7 @@ import { slugit } from '~/utils/string-helpers';
 
 type ComicItem = RouterOutput['comics']['getPublicProjects']['items'][number];
 
-export function ComicCard({ data }: { data: ComicItem }) {
+export const ComicCard = memo(function ComicCard({ data }: { data: ComicItem }) {
   const coverImage = data.coverImage
     ? {
         ...data.coverImage,
@@ -66,4 +67,4 @@ export function ComicCard({ data }: { data: ComicItem }) {
       footerGradient
     />
   );
-}
+});

--- a/src/components/CreatorCard/CreatorCardSimple.tsx
+++ b/src/components/CreatorCard/CreatorCardSimple.tsx
@@ -1,4 +1,5 @@
 import { uniqBy } from 'lodash-es';
+import { memo } from 'react';
 import type { CardProps } from '@mantine/core';
 import {
   Box,
@@ -33,11 +34,12 @@ import classes from './CreatorCard.module.css';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import type { UserCreator } from '~/server/services/user.service';
 
-export const CreatorCardSimple = (props: CreatorCardSimpleProps) => (
+export const CreatorCardSimple = memo((props: CreatorCardSimpleProps) => (
   <MetricSubscriptionProvider entityType="User" entityId={props.user.id}>
     <CreatorCardSimpleContent {...props} />
   </MetricSubscriptionProvider>
-);
+));
+CreatorCardSimple.displayName = 'CreatorCardSimple';
 
 const CreatorCardSimpleContent = ({
   user,

--- a/src/components/MasonryColumns/MasonryColumnsVirtual.tsx
+++ b/src/components/MasonryColumns/MasonryColumnsVirtual.tsx
@@ -113,6 +113,9 @@ function VirtualColumn<TData>({
     gap: 16,
     scrollMargin,
     initialOffset: () => scrollAreaRef?.current?.scrollTop ?? 0,
+    // See MasonryGridVirtual for rationale — opts out of virtual-core's
+    // 150ms setTimeout debounce on every scroll tick.
+    useScrollendEvent: true,
   });
 
   return (

--- a/src/components/MasonryColumns/MasonryGridVirtual.tsx
+++ b/src/components/MasonryColumns/MasonryGridVirtual.tsx
@@ -112,6 +112,11 @@ export function MasonryGridVirtual<TData>({
     gap: rowGap,
     scrollMargin,
     initialOffset: () => scrollAreaRef?.current?.scrollTop ?? 0,
+    // Opt into the native `scrollend` event so virtual-core skips its
+    // internal 150ms setTimeout-based scroll-end debounce. That debounce was
+    // installing ~38 timers/sec during feed scroll (perf audit 2026-04).
+    // Falls back to the debounce automatically on browsers without scrollend.
+    useScrollendEvent: true,
   });
 
   if (!items.length) {

--- a/src/components/Metrics/AnimatedCount.tsx
+++ b/src/components/Metrics/AnimatedCount.tsx
@@ -7,11 +7,21 @@ const compactFormat: Format = {
   maximumFractionDigits: 1,
 };
 
+const compactFormatter = new Intl.NumberFormat('en-US', compactFormat);
+const fullFormatter = new Intl.NumberFormat('en-US');
+
 interface AnimatedCountProps {
   value: number;
   /** Use compact notation (1k, 1.2M). Default: true */
   abbreviate?: boolean;
   className?: string;
+  /**
+   * When false, renders a plain formatted number instead of the animated
+   * NumberFlow custom element. Feed cards pass `false` for offscreen rows
+   * to avoid ShadowRoot + rAF cost on hundreds of invisible metrics.
+   * Default: true (back-compat).
+   */
+  animate?: boolean;
 }
 
 /**
@@ -21,13 +31,22 @@ interface AnimatedCountProps {
  * Uses @number-flow/react for digit morphing and CSS animations
  * for visual feedback on value changes.
  */
-export function AnimatedCount({ value, abbreviate = true, className }: AnimatedCountProps) {
+export function AnimatedCount({
+  value,
+  abbreviate = true,
+  className,
+  animate = true,
+}: AnimatedCountProps) {
   const spanRef = useRef<HTMLSpanElement>(null);
   const prevRef = useRef(value);
   const [floatingDelta, setFloatingDelta] = useState<{ key: number; amount: number } | null>(null);
   const deltaKeyRef = useRef(0);
 
   useEffect(() => {
+    if (!animate) {
+      prevRef.current = value;
+      return;
+    }
     const delta = value - prevRef.current;
     if (delta > 0 && spanRef.current) {
       const el = spanRef.current;
@@ -41,7 +60,12 @@ export function AnimatedCount({ value, abbreviate = true, className }: AnimatedC
       setFloatingDelta({ key: deltaKeyRef.current, amount: delta });
     }
     prevRef.current = value;
-  }, [value]);
+  }, [value, animate]);
+
+  if (!animate) {
+    const formatter = abbreviate ? compactFormatter : fullFormatter;
+    return <span className={className}>{formatter.format(value)}</span>;
+  }
 
   return (
     <span ref={spanRef} className={`${classes.wrapper} ${className ?? ''}`}>

--- a/src/components/Metrics/LiveMetric.tsx
+++ b/src/components/Metrics/LiveMetric.tsx
@@ -1,6 +1,7 @@
 import { Text, type TextProps } from '@mantine/core';
 import { useLiveMetric } from './useLiveMetrics';
 import { AnimatedCount } from './AnimatedCount';
+import { useMetricSubscriptionContext } from './MetricSubscriptionProvider';
 import type { MetricEntityType, MetricType } from '~/components/Signals/metric-signals.types';
 
 interface LiveMetricProps extends Omit<TextProps, 'children'> {
@@ -37,10 +38,14 @@ export function LiveMetric({
   ...textProps
 }: LiveMetricProps) {
   const liveValue = useLiveMetric(entityType, entityId, metricType, baseValue);
+  // Only animate while the surrounding MetricSubscriptionProvider reports the
+  // card is visible. Offscreen cards render a plain formatted number — avoids
+  // hundreds of NumberFlow shadow roots + the 60Hz rAF loop they drive.
+  const { isSubscribed } = useMetricSubscriptionContext();
 
   return (
     <Text {...textProps}>
-      <AnimatedCount value={liveValue} abbreviate={abbreviate} />
+      <AnimatedCount value={liveValue} abbreviate={abbreviate} animate={isSubscribed} />
     </Text>
   );
 }

--- a/src/pages/user/downloads.tsx
+++ b/src/pages/user/downloads.tsx
@@ -68,6 +68,9 @@ export default function Downloads() {
       const download = filteredDownloads[index];
       return `${download.modelVersion.id}-${download.file?.id ?? 'no-file'}`;
     },
+    // See MasonryGridVirtual for rationale — opts out of virtual-core's
+    // 150ms setTimeout debounce on every scroll tick.
+    useScrollendEvent: true,
   });
 
   const hideDownloadMutation = trpc.download.hide.useMutation({


### PR DESCRIPTION
## Summary

Follow-up to a frontend heap + Chrome-trace audit of civitai.com (logged-out feed scroll, 2026-04-22). Full analysis in [docs/frontend-perf-audit-2026-04.md](../blob/perf/heap-audit-fixes/docs/frontend-perf-audit-2026-04.md).

Top findings in the capture:

- +29 MB heap after a brief scroll; **26,839 detached DOM nodes** (was 3).
- **3,920 `setTimeout(150ms)` installs in 102 s** (38/sec) — one per scroll tick per virtualizer.
- One always-on 60 Hz `rAF` loop driving `Layerize` 1,627× and `Paint` 4,189×.

## Fixes in this PR

- **`perf(metrics): gate NumberFlow animation to visible cards`** — `AnimatedCount` now accepts `animate` (default `true` for back-compat). `LiveMetric` reads `MetricSubscriptionContext.isSubscribed` and passes it through, so offscreen feed cards render a plain `Intl.NumberFormat` span instead of a `<number-flow>` custom element + ShadowRoot + per-digit rAF.
- **`perf(virtual): opt into native scrollend to kill 150ms scroll debouncer`** — `@tanstack/virtual-core` debounces scroll-end via `setTimeout(isScrollingResetDelay)` (default 150 ms), resetting the timer on every scroll tick. Passed `useScrollendEvent: true` to all three `useVirtualizer` callsites (`MasonryGridVirtual`, `MasonryColumnsVirtual`, `pages/user/downloads.tsx`). Native `scrollend` fires in Chrome 114+ / Firefox 109+ / Safari 18.2+; virtual-core auto-falls-back to the debounce on older browsers.
- **`perf(cards): memo feed card components`** — `ArticleCard`, `BountyCard`, `CollectionCard`, `ChallengeCard`, `ComicCard`, `CreatorCardSimple`. `ModelCard` / `ImagesCard` / `PostsCard` were already memoized.
- **docs** — audit writeup + task-status notes.

## Deliberately not in this PR

- **P0.3 stuck `PerformanceObserver`** — investigated, no `PerformanceObserver` registration in our source. Retained `PerformanceEventTiming` entries are coming from Snigel's ad engine or browser extensions loaded during the capture. Not actionable here.
- **P0.2 shared `IntersectionObserver` in `MetricSubscriptionProvider`** — already in this branch via `343778e1a "ModelCard optimizations"` (not yet in prod).
- **P1.6 Tabler icon sprite sheet** — deferred; not a shallow edit, and icons only re-create on virtualizer-driven card mount now that cards are memoized.
- **P1.7 `uW` QueryObserver audit** — needs source-map inspection of the prod chunk.

## Test plan

- [ ] Typecheck: `pnpm typecheck` (no new errors — only pre-existing `image.service.ts` `event-engine-common` import errors remain)
- [ ] Manual scroll a busy feed (models / images / articles) and confirm counts still animate when you stop on a card
- [ ] Capture a fresh logged-in trace/heap, verify: (a) `TimerInstall(150ms)` count drops sharply, (b) `ShadowRoot` count stays flat while scrolling, (c) detached-DOM growth shrinks
- [ ] Check user/downloads scroll still feels smooth
- [ ] Prettier + lint

Briant — tagging you since you own the feed-card-dom-audit work this overlaps with. Any pushback welcome; happy to split commits further or drop any of the card memoizations if they fight other in-flight changes on your side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)