### PR TITLE
fix(warmup): use filesystem flag instead of module-scoped boolean

### DIFF
--- a/src/server/utils/warmup.ts
+++ b/src/server/utils/warmup.ts
@@ -1,11 +1,12 @@
+import fs from 'fs';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
 import { redis, sysRedis } from '~/server/redis/client';
 
-let warmedUp = false;
+const WARMUP_FLAG = '/tmp/warmup-complete';
 
 export function isWarmedUp() {
-  return warmedUp;
+  return fs.existsSync(WARMUP_FLAG);
 }
 
 export async function runWarmup() {
@@ -25,18 +26,12 @@ export async function runWarmup() {
     (redis as any).ping(),
     (sysRedis as any).ping(),
 
-    // Self-fetch a tRPC endpoint to JIT-compile the hot middleware chain
-    fetch(
-      'http://localhost:3000/api/trpc/homeBlock.getAll?input=' +
-        encodeURIComponent(JSON.stringify({ json: {} }))
-    ).catch(() => {}),
-
     // Pre-warm entity metrics cache
     import('~/server/redis/entity-metric-populate').then((m) =>
       m.preWarmEntityMetrics('Image', 1000)
     ),
   ]);
 
-  warmedUp = true;
+  fs.writeFileSync(WARMUP_FLAG, String(Date.now()));
   console.log(`[warmup] Complete in ${Date.now() - start}ms`);
 }


### PR DESCRIPTION
## Summary
- Fixes the warmup gate from civitai/civitai#2193 which took prod offline
- The module-scoped `warmedUp` boolean was set in the instrumentation worker but checked in API route workers — different Node.js processes don't share module state, so `isWarmedUp()` always returned `false`
- Replaces with `/tmp/warmup-complete` file flag that works across process boundaries
- Removes the self-fetch warmup (server isn't listening when instrumentation runs)

## What happened
PR #2193 added a warmup gate that returned 503 on `/api/health` until warmup completed. The boolean flag was set in `instrumentation.node.ts` (main process) but read in API route handlers (worker processes). All pods permanently failed readiness probes → 0 available pods → full outage.

## Test plan
- [ ] Verify `[warmup] Complete` appears in pod logs
- [ ] Verify `/tmp/warmup-complete` file exists in container after warmup
- [ ] Verify readiness probe returns 200 after warmup (once readiness probe is switched back from `&startup=true` bypass)
- [ ] Test that pods without the file (fresh start) correctly return 503 until warmup runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)