### PR TITLE
fix(notifications): route list read through replica-lag helper

### DIFF
--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -98,7 +98,8 @@ export async function getUserNotifications({
   if (cursor) AND.push(Prisma.sql`un."createdAt" < ${cursor}`);
   // else AND.push(Prisma.sql`un."createdAt" > NOW() - interval '1 month'`);
 
-  const query = await notifDbRead.cancellableQuery<NotificationsRaw>(Prisma.sql`
+  const db = await getNotifDbWithoutLag('notification', userId);
+  const query = await db.cancellableQuery<NotificationsRaw>(Prisma.sql`
     SELECT
       un.id,
       n.type,
@@ -181,7 +182,7 @@ export const markNotificationsRead = async ({
       userId,
       all,
       category,
-    }).catch(() => {});
+    }).catch(() => null);
   });
 };
 
@@ -207,7 +208,7 @@ async function _markNotificationsReadImpl({
           AND n."category" = ${category}::"NotificationCategory"
       `);
       await preventReplicationLag('notification', userId);
-      notificationCache.clearCategory(userId, category).catch(() => {});
+      notificationCache.clearCategory(userId, category).catch(() => null);
     } else {
       // No join needed - faster query
       await notifDbWrite.query(Prisma.sql`
@@ -219,7 +220,7 @@ async function _markNotificationsReadImpl({
           AND un.viewed IS FALSE
       `);
       await preventReplicationLag('notification', userId);
-      notificationCache.bustUser(userId).catch(() => {});
+      notificationCache.bustUser(userId).catch(() => null);
     }
   } else {
     const resp = await notifDbWrite.query(Prisma.sql`
@@ -248,7 +249,7 @@ async function _markNotificationsReadImpl({
       `);
       const catData = await catQuery.result();
       if (catData && catData.length)
-        notificationCache.decrementUser(userId, catData[0].category).catch(() => {});
+        notificationCache.decrementUser(userId, catData[0].category).catch(() => null);
     }
   }
 }

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -164,25 +164,97 @@ export async function getUserNotificationCount({
   return result;
 }
 
+// Per-user serialization queue. Rapid-click streams previously fanned out to
+// N concurrent pool.connect() acquisitions against the notif pool, which
+// starved it under load (46k "Connection terminated due to connection timeout"
+// warnings / week). Serializing per user caps in-flight writes to 1 per
+// active user without blocking the handler.
+const userWriteQueues = new Map<number, Promise<void>>();
+
+// Transient pg pool-acquire errors. These routinely succeed on retry once the
+// pool has a free slot; other errors are not retried.
+const TRANSIENT_WRITE_ERRORS = [
+  'Connection terminated due to connection timeout',
+  'timeout exceeded when trying to connect',
+  'Disconnects client',
+];
+
+// Retry tuning. Each pg pool.connect() itself waits up to ~5s, so combined
+// with these backoffs the full retry window spans ~15-20s — enough to
+// outlast a typical pool-saturation burst without hammering a stuck pool.
+// Backoff schedule: ~200-500ms, ~600-900ms, ~1800-2100ms between attempts.
+const MARK_READ_MAX_ATTEMPTS = 4;
+const MARK_READ_BACKOFF_BASE_MS = 200;
+const MARK_READ_BACKOFF_GROWTH = 3;
+const MARK_READ_BACKOFF_JITTER_MS = 300;
+
+function isTransientWriteError(err: unknown): boolean {
+  return err instanceof Error && TRANSIENT_WRITE_ERRORS.some((msg) => err.message.includes(msg));
+}
+
+// Runs the write with bounded retries on transient pool-acquire errors.
+// Always resolves: success and failure both emit a single `notification.markRead`
+// Axiom event with an `outcome` field. UI is already optimistic, so we never
+// surface errors upward.
+async function runMarkReadWithRetry(
+  input: MarkReadNotificationInput & { userId: number; all: boolean }
+): Promise<void> {
+  const { userId, all, category } = input;
+  for (let attempt = 1; attempt <= MARK_READ_MAX_ATTEMPTS; attempt++) {
+    try {
+      await _markNotificationsReadImpl(input);
+      if (attempt > 1) {
+        logToAxiom({
+          type: 'info',
+          name: 'notification.markRead',
+          message: `Marked notifications read after ${attempt} attempts`,
+          outcome: 'retrySuccess',
+          userId,
+          all,
+          category,
+          attempt,
+        }).catch(() => null);
+      }
+      return;
+    } catch (err) {
+      const transient = isTransientWriteError(err);
+      if (!transient || attempt === MARK_READ_MAX_ATTEMPTS) {
+        logToAxiom({
+          type: 'warning',
+          name: 'notification.markRead',
+          message: `Failed to mark notifications read: ${(err as Error).message}`,
+          outcome: transient ? 'retriesExhausted' : 'nonTransientError',
+          userId,
+          all,
+          category,
+          attempt,
+        }).catch(() => null);
+        return;
+      }
+      const backoff =
+        MARK_READ_BACKOFF_BASE_MS * MARK_READ_BACKOFF_GROWTH ** (attempt - 1) +
+        Math.random() * MARK_READ_BACKOFF_JITTER_MS;
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+    }
+  }
+}
+
 export const markNotificationsRead = async ({
   id,
   userId,
   all = false,
   category,
 }: MarkReadNotificationInput & { userId: number }) => {
-  // Fire-and-forget: the UI optimistically marks as read, so we don't need to
-  // block the response on the cross-Atlantic write to DO managed Postgres.
-  // Errors are logged but not surfaced to the user.
-  const writePromise = _markNotificationsReadImpl({ id, userId, all, category });
-  writePromise.catch((err) => {
-    logToAxiom({
-      type: 'warning',
-      name: 'notification.markRead',
-      message: `Failed to mark notifications read: ${(err as Error).message}`,
-      userId,
-      all,
-      category,
-    }).catch(() => null);
+  // Fire-and-forget: the UI optimistically marks as read, so we don't block
+  // on the cross-Atlantic write. Chained onto any in-flight write for this
+  // user so we never run >1 concurrent pool.connect() per user per pod.
+  const prev = userWriteQueues.get(userId) ?? Promise.resolve();
+  const next = prev.then(() => runMarkReadWithRetry({ id, userId, all, category }));
+  userWriteQueues.set(userId, next);
+  next.finally(() => {
+    // Only drop from the map if we're still the tail — a newer call may have
+    // taken our slot, in which case it owns the cleanup.
+    if (userWriteQueues.get(userId) === next) userWriteQueues.delete(userId);
   });
 };
 

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -4,7 +4,7 @@ import type { NotificationCategory } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { getNotifDbWithoutLag, preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { notifDbRead, notifDbWrite } from '~/server/db/notifDb';
-import { logToAxiom } from '~/server/logging/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import { populateNotificationDetails } from '~/server/notifications/detail-fetchers';
 import type { NotificationCategoryCount } from '~/server/notifications/notification-cache';
 import { notificationCache } from '~/server/notifications/notification-cache';
@@ -193,9 +193,11 @@ function isTransientWriteError(err: unknown): boolean {
 }
 
 // Runs the write with bounded retries on transient pool-acquire errors.
-// Always resolves: success and failure both emit a single `notification.markRead`
-// Axiom event with an `outcome` field. UI is already optimistic, so we never
-// surface errors upward.
+// Always resolves without surfacing errors upward because the UI is already
+// optimistic. Emits a `notification.markRead` Axiom event only for retry
+// success (`outcome: retrySuccess`) or terminal failure
+// (`outcome: retriesExhausted` / `nonTransientError`); first-attempt success
+// does not log an event.
 async function runMarkReadWithRetry(
   input: MarkReadNotificationInput & { userId: number; all: boolean }
 ): Promise<void> {
@@ -219,11 +221,13 @@ async function runMarkReadWithRetry(
     } catch (err) {
       const transient = isTransientWriteError(err);
       if (!transient || attempt === MARK_READ_MAX_ATTEMPTS) {
+        const errMessage = err instanceof Error ? err.message : String(err);
         logToAxiom({
           type: 'warning',
           name: 'notification.markRead',
-          message: `Failed to mark notifications read: ${(err as Error).message}`,
+          message: `Failed to mark notifications read: ${errMessage}`,
           outcome: transient ? 'retriesExhausted' : 'nonTransientError',
+          error: safeError(err),
           userId,
           all,
           category,


### PR DESCRIPTION
## Summary

Fixes the "Notifications Stuck" bug reports in [ClickUp 868j9kuqa](https://app.clickup.com/t/868j9kuqa) where marking notifications read didn't persist across refresh. Two complementary changes:

1. **Route the notification list read through the replica-lag helper** — closes the last read path that bypassed the per-user lag flag, so the feed reflects a markRead write during the 60s post-write window.
2. **Per-user serialization + bounded retry in `markNotificationsRead`** — addresses the 46k/week pool-acquire timeouts uncovered in Axiom that were silently preventing writes from landing in the first place.

## Change 1 — List read lag routing

Three prior fixes (`21c0e3ad1`, `3a4673c48`, `1ce7c4f1f`, `b8b8ed25f`) wired the badge count through the lag helper + primary routing, but `getUserNotifications` still used `notifDbRead` unconditionally. During the 60s lag window after a markRead, the feed refetch returned `un.viewed = FALSE` from the lagged replica → items reappeared unread on refresh.

```diff
-  const query = await notifDbRead.cancellableQuery<NotificationsRaw>(Prisma.sql`
+  const db = await getNotifDbWithoutLag('notification', userId);
+  const query = await db.cancellableQuery<NotificationsRaw>(Prisma.sql`
```

## Change 2 — Per-user serialization + bounded retry

Axiom investigation revealed **46,641 `notification.markRead` warnings in 7 days**, started abruptly 2026-04-20 22:45 UTC, **3,793 unique users affected per 24h**. 99.96% are pg pool-acquire timeouts (`"Connection terminated due to connection timeout"`) — the fire-and-forget write from `21c0e3ad1` was silently failing because rapid-click streams fanned out to N concurrent `pool.connect()` per user per pod, saturating the notif pool.

Two guardrails added:

- **`userWriteQueues: Map<userId, Promise>`** — each `markNotificationsRead` call chains onto the user's in-flight write, capping concurrent pool acquisitions to 1 per user per pod. Tail-identity cleanup guard ensures a newer call owns the slot without racing the older cleanup.
- **`runMarkReadWithRetry`** — 4 attempts with exponential backoff+jitter (~200-500ms / ~600-900ms / ~1800-2100ms), scoped to a whitelist of transient pool-acquire error messages only. Non-transient errors (e.g. Redis failure in `preventReplicationLag`) fall through on first attempt.

Telemetry is unified under a single `notification.markRead` Axiom event with an `outcome` field (`retrySuccess` | `retriesExhausted` | `nonTransientError`), so the retry distribution is visible in one query. First-attempt success does not log an event.

## Design notes

- **Memory safety of the Map**: independently reviewed. Live-set is bounded by `(calls/sec × latency)` per pod, worst case hundreds of entries / few MB. No unbounded growth risk.
- **Considered Redis/BullMQ queue**: decided against for this PR. The bottleneck is pool-acquire concurrency, not durability; markRead is non-critical; Redis adds latency and ops surface without addressing the actual mechanism. Path stays open if per-pod serialization proves insufficient.
- **Drive-by lint autofixes**: 4 `.catch(() => {}) → .catch(() => null)` hunks are from `no-empty-function` on save — semantically identical no-ops.

## Known follow-ups, not in this PR

- Verify `NOTIFICATION_POOL_MAX` is actually set in prod (Zac is checking). The separate-pool design from `21c0e3ad1` depends on it.
- `cancellableQuery.cancel()` is never called on the post-mark category SELECT, leaving orphan queries until `statement_timeout`. Pre-existing, minor pool-pressure contributor, better handled in a focused cleanup.

## Test plan

- [ ] Dev: log in as a test user with unread notifications, click one, hard refresh → item stays read.
- [ ] Dev: "Mark all read", hard refresh → list stays marked read.
- [ ] Dev: per-category mark read → only that category updates.
- [ ] After deploy: watch `notification.markRead` in Axiom. Expect the `warning`-type events to drop substantially; `info`-type `retrySuccess` events surface how often retries are earning their keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)