### PR TITLE
fix(training-data): register B2 uploads with storage-resolver

### DIFF
--- a/src/components/Training/Form/TrainingImages.tsx
+++ b/src/components/Training/Form/TrainingImages.tsx
@@ -1170,6 +1170,7 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
                     ? ModelFileVisibility.Sensitive
                     : ModelFileVisibility.Private,
                 metadata,
+                ...(result.backend === 'b2' ? { s3Path: result.key } : {}),
               });
             } catch (e: unknown) {
               setZipping(false);
@@ -1266,7 +1267,10 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
         if (i.label.length > 0) {
           // Validate each tag individually to avoid cross-tag false positives
           // (e.g. "school_uniform, 1girl" matching composed "school...girl" pattern)
-          const tags = i.label.split(',').map((t) => t.trim()).filter(Boolean);
+          const tags = i.label
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean);
           let hasInvalid = false;
           for (const tag of tags) {
             const { blockedFor, success } = auditPrompt(tag, undefined, isGreen);

--- a/src/pages/api/admin/temp/backfill-b2-file-locations.ts
+++ b/src/pages/api/admin/temp/backfill-b2-file-locations.ts
@@ -1,0 +1,181 @@
+/**
+ * Backfill file_locations for B2-hosted ModelFile rows.
+ * =============================================================================
+ *
+ * Hidden admin route. Guarded by WEBHOOK_TOKEN via `?token=` query param.
+ *
+ * Purpose: after `fca184298` routed training-data uploads to Backblaze B2 via
+ * feature flag, the `modelFile.upsert` client payload omitted `s3Path`, so
+ * `createFileHandler` silently skipped `registerFileLocation`. Result: B2
+ * training-data files had no row in storage-resolver `file_locations`, and
+ * downloads 404'd at both the resolver AND the delivery-worker fallback (the
+ * worker isn't configured for the `civitai-modelfiles` bucket).
+ *
+ * The client + update-handler fixes stop the leak for new uploads; this
+ * endpoint repairs existing rows by re-registering them with the resolver.
+ *
+ * Usage:
+ *   POST /api/admin/temp/backfill-b2-file-locations?token=$WEBHOOK_TOKEN
+ *
+ * Params (query):
+ *   dryRun      - default true. When true, report candidates without calling /register.
+ *   batchSize   - default 100. ModelFile rows per DB page.
+ *   concurrency - default 3. Parallel /register calls. Keep low; the resolver
+ *                 and B2 have their own rate limits and we don't want to stampede.
+ *   start       - default 0. Minimum ModelFile.id to consider (resume after abort).
+ *   end         - optional. Maximum ModelFile.id to consider.
+ *   fileType    - default 'Training Data'. Restrict to one ModelFile.type.
+ *                 Pass 'all' to attempt every B2-hosted file.
+ */
+
+import * as z from 'zod';
+import { dbRead } from '~/server/db/client';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { createLogger } from '~/utils/logging';
+import { booleanString } from '~/utils/zod-helpers';
+import { registerFileLocation } from '~/utils/storage-resolver';
+import { isB2Url, parseKey } from '~/utils/s3-utils';
+
+const log = createLogger('backfill-b2-file-locations', 'cyan');
+
+const querySchema = z.object({
+  dryRun: booleanString().default(true),
+  batchSize: z.coerce.number().min(1).max(1000).default(100),
+  concurrency: z.coerce.number().min(1).max(10).default(3),
+  start: z.coerce.number().optional().default(0),
+  end: z.coerce.number().optional(),
+  fileType: z.string().default('Training Data'),
+});
+
+type Stats = {
+  scanned: number;
+  registered: number;
+  skippedNonB2: number;
+  skippedNoKey: number;
+  failed: number;
+};
+
+export default WebhookEndpoint(async (req, res) => {
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: z.treeifyError(parsed.error) });
+  }
+  const params = parsed.data;
+  const startTime = Date.now();
+  const stats: Stats = {
+    scanned: 0,
+    registered: 0,
+    skippedNonB2: 0,
+    skippedNoKey: 0,
+    failed: 0,
+  };
+
+  try {
+    log(
+      `Starting${params.dryRun ? ' (DRY RUN)' : ''} | batchSize=${params.batchSize} ` +
+        `concurrency=${params.concurrency} start=${params.start} end=${params.end ?? 'MAX'} ` +
+        `fileType=${params.fileType}`
+    );
+
+    let cursor = params.start;
+    const endCap = params.end;
+
+    // Paginate by ModelFile.id ascending. Each page pulls `batchSize` rows that
+    // look B2-hosted, then fans out to the resolver under `concurrency` limit.
+    while (true) {
+      const files = await dbRead.modelFile.findMany({
+        where: {
+          id: { gte: cursor, ...(endCap !== undefined && { lte: endCap }) },
+          url: { contains: 'backblazeb2.com' },
+          ...(params.fileType !== 'all' && { type: params.fileType }),
+        },
+        select: {
+          id: true,
+          url: true,
+          sizeKB: true,
+          modelVersionId: true,
+          modelVersion: { select: { modelId: true } },
+        },
+        orderBy: { id: 'asc' },
+        take: params.batchSize,
+      });
+
+      if (files.length === 0) break;
+
+      stats.scanned += files.length;
+      const firstId = files[0].id;
+      const lastId = files[files.length - 1].id;
+
+      const tasks = files.map((file) => async () => {
+        // Guard against rows whose URL matched the substring but don't parse
+        // as B2 under the current `S3_UPLOAD_B2_ENDPOINT` config. Skip rather
+        // than register with the wrong backend.
+        if (!isB2Url(file.url)) {
+          stats.skippedNonB2++;
+          return;
+        }
+
+        const { key, bucket } = parseKey(file.url);
+        if (!key || !bucket) {
+          stats.skippedNoKey++;
+          return;
+        }
+
+        if (params.dryRun) {
+          stats.registered++;
+          return;
+        }
+
+        try {
+          await registerFileLocation({
+            fileId: file.id,
+            modelVersionId: file.modelVersionId,
+            modelId: file.modelVersion.modelId,
+            backend: 'backblaze',
+            path: key,
+            sizeKb: file.sizeKB ?? 0,
+          });
+          stats.registered++;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log(`  ⚠️  register failed for fileId=${file.id}: ${msg}`);
+          stats.failed++;
+        }
+      });
+
+      await limitConcurrency(tasks, params.concurrency);
+
+      const elapsedSec = (Date.now() - startTime) / 1000;
+      const rate = stats.scanned / Math.max(elapsedSec, 0.001);
+      log(
+        `[batch ${firstId}-${lastId}] ${files.length} scanned | ` +
+          `totals: ${stats.scanned} seen, ${stats.registered} registered, ` +
+          `${stats.skippedNonB2 + stats.skippedNoKey} skipped, ${stats.failed} failed | ` +
+          `${rate.toFixed(1)}/s | elapsed: ${elapsedSec.toFixed(1)}s`
+      );
+
+      cursor = lastId + 1;
+      if (endCap !== undefined && cursor > endCap) break;
+    }
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+    log(`Completed in ${duration}s`);
+
+    res.status(200).json({
+      ok: true,
+      dryRun: params.dryRun,
+      duration: `${duration}s`,
+      lastCursor: cursor,
+      result: stats,
+    });
+  } catch (error) {
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+    log(`Failed after ${duration}s:`, error);
+    res.status(500).json({
+      ok: false,
+      error: (error as Error).message,
+      stats,
+    });
+  }
+});

--- a/src/pages/api/admin/temp/backfill-b2-file-locations.ts
+++ b/src/pages/api/admin/temp/backfill-b2-file-locations.ts
@@ -35,9 +35,37 @@ import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 import { booleanString } from '~/utils/zod-helpers';
 import { registerFileLocation } from '~/utils/storage-resolver';
-import { isB2Url, parseKey } from '~/utils/s3-utils';
 
 const log = createLogger('backfill-b2-file-locations', 'cyan');
+
+// Parse a B2 URL structurally — avoids depending on `env.S3_UPLOAD_B2_ENDPOINT`
+// being set in whichever pod runs this admin endpoint (the helpers in s3-utils
+// silently return false/empty if that env is missing or shaped differently).
+// Handles both B2 URL styles:
+//   Path-style:         https://s3.<region>.backblazeb2.com/<bucket>/<key>
+//   Virtual-host style: https://<bucket>.s3.<region>.backblazeb2.com/<key>
+function parseB2Url(rawUrl: string): { bucket: string; key: string } | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (!url.hostname.endsWith('.backblazeb2.com')) return null;
+
+  if (url.hostname.startsWith('s3.')) {
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    return { bucket: parts[0], key: parts.slice(1).join('/') };
+  }
+
+  const dotIdx = url.hostname.indexOf('.');
+  if (dotIdx <= 0) return null;
+  const bucket = url.hostname.slice(0, dotIdx);
+  const key = url.pathname.replace(/^\/+/, '');
+  if (!key) return null;
+  return { bucket, key };
+}
 
 const querySchema = z.object({
   dryRun: booleanString().default(true),
@@ -110,16 +138,16 @@ export default WebhookEndpoint(async (req, res) => {
       const lastId = files[files.length - 1].id;
 
       const tasks = files.map((file) => async () => {
-        // Guard against rows whose URL matched the substring but don't parse
-        // as B2 under the current `S3_UPLOAD_B2_ENDPOINT` config. Skip rather
-        // than register with the wrong backend.
-        if (!isB2Url(file.url)) {
+        const parsed = parseB2Url(file.url);
+        if (!parsed) {
+          // URL had `backblazeb2.com` in it but didn't parse as a recognizable
+          // B2 URL shape — treat as non-B2 rather than registering with a
+          // guessed backend/path.
           stats.skippedNonB2++;
           return;
         }
-
-        const { key, bucket } = parseKey(file.url);
-        if (!key || !bucket) {
+        const { key } = parsed;
+        if (!key) {
           stats.skippedNoKey++;
           return;
         }

--- a/src/pages/api/admin/temp/backfill-b2-file-locations.ts
+++ b/src/pages/api/admin/temp/backfill-b2-file-locations.ts
@@ -50,7 +50,8 @@ const querySchema = z.object({
 
 type Stats = {
   scanned: number;
-  registered: number;
+  candidates: number; // rows that would be registered (dry run accounting)
+  registered: number; // rows actually registered with the resolver
   skippedNonB2: number;
   skippedNoKey: number;
   failed: number;
@@ -65,6 +66,7 @@ export default WebhookEndpoint(async (req, res) => {
   const startTime = Date.now();
   const stats: Stats = {
     scanned: 0,
+    candidates: 0,
     registered: 0,
     skippedNonB2: 0,
     skippedNoKey: 0,
@@ -123,7 +125,7 @@ export default WebhookEndpoint(async (req, res) => {
         }
 
         if (params.dryRun) {
-          stats.registered++;
+          stats.candidates++;
           return;
         }
 
@@ -151,8 +153,8 @@ export default WebhookEndpoint(async (req, res) => {
       log(
         `[batch ${firstId}-${lastId}] ${files.length} scanned | ` +
           `totals: ${stats.scanned} seen, ${stats.registered} registered, ` +
-          `${stats.skippedNonB2 + stats.skippedNoKey} skipped, ${stats.failed} failed | ` +
-          `${rate.toFixed(1)}/s | elapsed: ${elapsedSec.toFixed(1)}s`
+          `${stats.candidates} candidates, ${stats.skippedNonB2 + stats.skippedNoKey} skipped, ` +
+          `${stats.failed} failed | ${rate.toFixed(1)}/s | elapsed: ${elapsedSec.toFixed(1)}s`
       );
 
       cursor = lastId + 1;

--- a/src/server/controllers/model-file.controller.ts
+++ b/src/server/controllers/model-file.controller.ts
@@ -12,8 +12,50 @@ import {
   getFilesForModelVersionCache,
   updateFile,
 } from '~/server/services/model-file.service';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import { handleLogError, throwDbError, throwNotFoundError } from '~/server/utils/errorHandling';
 import { registerFileLocation } from '~/utils/storage-resolver';
+
+// Wraps registerFileLocation so a resolver outage or misconfig becomes a
+// logged warning instead of a silent download-breaker. A missing row in
+// `file_locations` means /resolve returns 404 and the delivery-worker fallback
+// only knows the primary bucket, so the file becomes un-downloadable.
+async function safeRegisterFileLocation(params: {
+  op: 'create' | 'update';
+  userId: number;
+  fileId: number;
+  modelVersionId: number;
+  modelId: number;
+  s3Path: string;
+  sizeKb: number;
+}) {
+  const { op, userId, fileId, modelVersionId, modelId, s3Path, sizeKb } = params;
+  const backend = 'backblaze';
+  try {
+    await registerFileLocation({
+      fileId,
+      modelVersionId,
+      modelId,
+      backend,
+      path: s3Path,
+      sizeKb,
+    });
+  } catch (err) {
+    logToAxiom({
+      type: 'error',
+      name: 'register-file-location-failed',
+      ...safeError(err),
+      op,
+      fileId,
+      modelVersionId,
+      modelId,
+      userId,
+      backend,
+      path: s3Path,
+      sizeKb,
+    }).catch(handleLogError);
+  }
+}
 
 export const getFilesByVersionIdHandler = async ({ input }: { input: GetByIdInput }) => {
   try {
@@ -56,18 +98,15 @@ export const createFileHandler = async ({
     // Register with storage-resolver for B2 uploads so downloads work.
     // Awaited so the location is registered before scan-files can trigger.
     if (backend === 'b2' && s3Path) {
-      try {
-        await registerFileLocation({
-          fileId: file.id,
-          modelVersionId: file.modelVersion.id,
-          modelId: file.modelVersion.modelId,
-          backend: 'backblaze',
-          path: s3Path,
-          sizeKb: input.sizeKB,
-        });
-      } catch (err) {
-        console.error('Failed to register file location with storage-resolver:', err);
-      }
+      await safeRegisterFileLocation({
+        op: 'create',
+        userId: ctx.user.id,
+        fileId: file.id,
+        modelVersionId: file.modelVersion.id,
+        modelId: file.modelVersion.modelId,
+        s3Path,
+        sizeKb: input.sizeKB,
+      });
     }
 
     ctx.track
@@ -89,11 +128,28 @@ export const updateFileHandler = async ({
   ctx: DeepNonNullable<Context>;
 }) => {
   try {
+    const { backend, s3Path, ...updateInput } = input;
+
     const result = await updateFile({
-      ...input,
+      ...updateInput,
       userId: ctx.user.id,
       isModerator: ctx.user.isModerator,
     });
+
+    // Re-register with storage-resolver when the file was re-uploaded to B2
+    // (e.g. training data re-uploads), so downloads resolve to the new path.
+    if (backend === 'b2' && s3Path) {
+      await safeRegisterFileLocation({
+        op: 'update',
+        userId: ctx.user.id,
+        fileId: result.id,
+        modelVersionId: result.modelVersionId,
+        modelId: result.modelVersion.modelId,
+        s3Path,
+        sizeKb: updateInput.sizeKB ?? result.sizeKB ?? 0,
+      });
+    }
+
     ctx.track
       .modelFile({ type: 'Update', id: input.id, modelVersionId: result.modelVersionId })
       .catch(handleLogError);

--- a/src/server/schema/model-file.schema.ts
+++ b/src/server/schema/model-file.schema.ts
@@ -141,6 +141,8 @@ export const modelFileUpdateSchema = z.object({
   modelVersionId: z.number().optional(), // nb: this should probably not be an option here
   visibility: z.enum(ModelFileVisibility).optional(),
   metadata: modelFileMetadataSchema.optional(),
+  backend: z.string().optional(),
+  s3Path: z.string().optional(),
 });
 
 export type ModelFileUpsertInput = z.infer<typeof modelFileUpsertSchema>;

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -13,6 +13,7 @@ import {
   ModelType,
   ModelUsageControl,
 } from '~/shared/utils/prisma/enums';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import { resolveDownloadUrl } from '~/utils/delivery-worker';
 import { removeEmpty } from '~/utils/object-helpers';
 import { filenamize, replaceInsensitive } from '~/utils/string-helpers';
@@ -330,7 +331,21 @@ export const getFileForModelVersion = async ({
       metadata: file.metadata as FileMetadata,
       isDownloadable,
     };
-  } catch (error) {
+  } catch (err) {
+    // Both storage-resolver and delivery-worker fallback rejected this file —
+    // usually an un-registered `file_locations` row on a bucket the
+    // delivery-worker doesn't know. Log so the leak is visible in production.
+    logToAxiom({
+      type: 'error',
+      name: 'resolve-download-url-failed',
+      ...safeError(err),
+      fileId: file.id,
+      modelId: modelVersion.model.id,
+      modelVersionId,
+      fileUrl: file.url,
+      fileType: file.type,
+      userId: user?.id,
+    }).catch(() => undefined);
     return { status: 'error' };
   }
 };

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -105,11 +105,19 @@ export async function updateFile({
   metadata,
   userId,
   isModerator,
+  backend: _backend,
+  s3Path: _s3Path,
   ...inputData
 }: ModelFileUpdateInput & { userId: number; isModerator?: boolean }) {
   const modelFile = await dbWrite.modelFile.findUnique({
     where: { id, modelVersion: { model: !isModerator ? { userId } : undefined } },
-    select: { id: true, metadata: true, modelVersionId: true },
+    select: {
+      id: true,
+      metadata: true,
+      modelVersionId: true,
+      sizeKB: true,
+      modelVersion: { select: { modelId: true } },
+    },
   });
   if (!modelFile) throw throwNotFoundError();
 

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -131,9 +131,13 @@ export async function updateFile({
   });
   await deleteFilesForModelVersionCache(modelFile.modelVersionId);
 
+  // Merge committed updates back into the snapshot so the returned record
+  // reflects post-update state (e.g. `sizeKB` on a re-upload). `updateMany`
+  // doesn't return the updated row, and we don't want a second round-trip.
   return {
     ...modelFile,
     metadata,
+    ...(inputData.sizeKB !== undefined ? { sizeKB: inputData.sizeKB } : {}),
   };
 }
 

--- a/src/utils/storage-resolver.ts
+++ b/src/utils/storage-resolver.ts
@@ -1,4 +1,5 @@
 import { env } from '~/env/server';
+import { logToAxiom } from '~/server/logging/client';
 
 export async function registerFileLocation(params: {
   fileId: number;
@@ -9,7 +10,14 @@ export async function registerFileLocation(params: {
   sizeKb: number;
 }) {
   if (!env.STORAGE_RESOLVER_INTERNAL_URL || !env.STORAGE_RESOLVER_INTERNAL_TOKEN) {
-    console.warn('Storage resolver internal URL/token not configured, skipping registration');
+    // Surface misconfig to Axiom — silently skipping here breaks downloads
+    // just as surely as a thrown error, and callers' catch blocks never fire.
+    logToAxiom({
+      type: 'warning',
+      name: 'register-file-location-skipped',
+      reason: 'storage-resolver-not-configured',
+      ...params,
+    }).catch(() => undefined);
     return;
   }
 


### PR DESCRIPTION
## Summary

Training data uploaded to B2 (behind the `B2_TRAINING_UPLOAD` Flipt flag) never landed in the storage-resolver's `file_locations`, so downloads 404'd at both the resolver and the delivery-worker fallback. Users report "Error getting file" when clicking *Download training data* on published LoRAs.

**Root cause:** `createFileHandler` guards registration on `backend === 'b2' && s3Path` — the training upload in `TrainingImages.tsx` was passing `backend` (via `...result`) but never `s3Path`, so `registerFileLocation()` silently skipped. `updateFileHandler` had no registration branch at all, so re-uploads stayed broken even if the first one had worked. The failure path was `console.error`-only, which is why this bug lived in prod for weeks.

See ClickUp: [868jca4jj — LoRA Training / Publishing Issues](https://app.clickup.com/t/868jca4jj)

## Changes

- `TrainingImages.tsx` — pass `s3Path: result.key` on B2 upserts (mirror `FilesProvider.tsx`)
- `modelFileUpdateSchema` — accept `backend`/`s3Path` so re-uploads can carry them
- `updateFileHandler` — register on B2 re-uploads
- Extract `safeRegisterFileLocation` helper so create + update share one code path
- Log `register-file-location-failed` and `resolve-download-url-failed` to Axiom with full context (fileId, modelVersionId, modelId, userId, backend, path) — silent failures here were how this shipped unnoticed
- `updateFile` service now strips `backend`/`s3Path` from DB writes and returns `sizeKB` + `modelVersion.modelId`
- `src/pages/api/admin/temp/backfill-b2-file-locations.ts` — `WebhookEndpoint`-guarded backfill for existing rows. Cursor-paginated, `limitConcurrency` over the resolver, dry-run by default, filters by `type` (default `Training Data`)

## Test plan

- [ ] Upload new training data with `B2_TRAINING_UPLOAD` enabled → verify a row lands in `file_locations` (Axiom: no `register-file-location-failed` events)
- [ ] Re-upload training data on an existing version → verify registration fires on the update path
- [ ] Download the uploaded training data via `/api/download/models/:id?fileId=:fid` → 302 to a signed B2 URL
- [ ] Dry-run the backfill: `POST /api/admin/temp/backfill-b2-file-locations?token=$WEBHOOK_TOKEN` → inspect candidate count
- [ ] Real backfill with conservative knobs: `dryRun=false&concurrency=3&batchSize=100` → watch Axiom for failures, confirm the original ticket's file (`/api/download/models/2884436?fileId=2764299`) downloads after registration
- [ ] Force a resolver failure (e.g. bad `STORAGE_RESOLVER_INTERNAL_TOKEN` in staging) → verify `register-file-location-failed` surfaces in Axiom with `op`, `fileId`, and the user/model context

## Follow-ups

- Once the backfill succeeds on prod, set an Axiom alert on `register-file-location-failed` so regressions surface immediately.
- The debug `console.log` statements I'd scattered across `delivery-worker.ts` and `file.service.ts` while investigating are removed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)