### PR TITLE
fix(training-data): derive s3Path server-side + fix Axiom name collision

### DIFF
--- a/src/pages/api/admin/temp/backfill-b2-file-locations.ts
+++ b/src/pages/api/admin/temp/backfill-b2-file-locations.ts
@@ -34,38 +34,10 @@ import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 import { booleanString } from '~/utils/zod-helpers';
+import { parseB2Url } from '~/utils/s3-utils';
 import { registerFileLocation } from '~/utils/storage-resolver';
 
 const log = createLogger('backfill-b2-file-locations', 'cyan');
-
-// Parse a B2 URL structurally — avoids depending on `env.S3_UPLOAD_B2_ENDPOINT`
-// being set in whichever pod runs this admin endpoint (the helpers in s3-utils
-// silently return false/empty if that env is missing or shaped differently).
-// Handles both B2 URL styles:
-//   Path-style:         https://s3.<region>.backblazeb2.com/<bucket>/<key>
-//   Virtual-host style: https://<bucket>.s3.<region>.backblazeb2.com/<key>
-function parseB2Url(rawUrl: string): { bucket: string; key: string } | null {
-  let url: URL;
-  try {
-    url = new URL(rawUrl);
-  } catch {
-    return null;
-  }
-  if (!url.hostname.endsWith('.backblazeb2.com')) return null;
-
-  if (url.hostname.startsWith('s3.')) {
-    const parts = url.pathname.split('/').filter(Boolean);
-    if (parts.length < 2) return null;
-    return { bucket: parts[0], key: parts.slice(1).join('/') };
-  }
-
-  const dotIdx = url.hostname.indexOf('.');
-  if (dotIdx <= 0) return null;
-  const bucket = url.hostname.slice(0, dotIdx);
-  const key = url.pathname.replace(/^\/+/, '');
-  if (!key) return null;
-  return { bucket, key };
-}
 
 const querySchema = z.object({
   dryRun: booleanString().default(true),

--- a/src/server/controllers/model-file.controller.ts
+++ b/src/server/controllers/model-file.controller.ts
@@ -14,6 +14,7 @@ import {
 } from '~/server/services/model-file.service';
 import { logToAxiom, safeError } from '~/server/logging/client';
 import { handleLogError, throwDbError, throwNotFoundError } from '~/server/utils/errorHandling';
+import { parseB2Url } from '~/utils/s3-utils';
 import { registerFileLocation } from '~/utils/storage-resolver';
 
 // Wraps registerFileLocation so a resolver outage or misconfig becomes a
@@ -41,10 +42,13 @@ async function safeRegisterFileLocation(params: {
       sizeKb,
     });
   } catch (err) {
+    // `...safeError(err)` spreads a `name: 'Error'` (JS Error.name), so it
+    // must come BEFORE our `name` literal or the event is hidden under a
+    // generic name in Axiom.
     logToAxiom({
       type: 'error',
-      name: 'register-file-location-failed',
       ...safeError(err),
+      name: 'register-file-location-failed',
       op,
       fileId,
       modelVersionId,
@@ -55,6 +59,24 @@ async function safeRegisterFileLocation(params: {
       sizeKb,
     }).catch(handleLogError);
   }
+}
+
+/**
+ * Derive the s3 path for a B2 registration. Prefers the explicit `s3Path`
+ * from the client payload, falls back to parsing the committed URL. The
+ * fallback covers users running stale client bundles that don't yet send
+ * `s3Path` on the tRPC upsert — training pages live for hours during a run,
+ * so a frontend deploy can take a long time to reach every open tab.
+ */
+function resolveB2Path(args: {
+  backend: string | undefined;
+  s3Path: string | undefined;
+  url: string | undefined | null;
+}): string | null {
+  if (args.backend !== 'b2') return null;
+  if (args.s3Path) return args.s3Path;
+  if (!args.url) return null;
+  return parseB2Url(args.url)?.key ?? null;
 }
 
 export const getFilesByVersionIdHandler = async ({ input }: { input: GetByIdInput }) => {
@@ -97,14 +119,15 @@ export const createFileHandler = async ({
 
     // Register with storage-resolver for B2 uploads so downloads work.
     // Awaited so the location is registered before scan-files can trigger.
-    if (backend === 'b2' && s3Path) {
+    const resolvedPath = resolveB2Path({ backend, s3Path, url: createInput.url });
+    if (resolvedPath) {
       await safeRegisterFileLocation({
         op: 'create',
         userId: ctx.user.id,
         fileId: file.id,
         modelVersionId: file.modelVersion.id,
         modelId: file.modelVersion.modelId,
-        s3Path,
+        s3Path: resolvedPath,
         sizeKb: input.sizeKB,
       });
     }
@@ -138,14 +161,15 @@ export const updateFileHandler = async ({
 
     // Re-register with storage-resolver when the file was re-uploaded to B2
     // (e.g. training data re-uploads), so downloads resolve to the new path.
-    if (backend === 'b2' && s3Path) {
+    const resolvedPath = resolveB2Path({ backend, s3Path, url: updateInput.url });
+    if (resolvedPath) {
       await safeRegisterFileLocation({
         op: 'update',
         userId: ctx.user.id,
         fileId: result.id,
         modelVersionId: result.modelVersionId,
         modelId: result.modelVersion.modelId,
-        s3Path,
+        s3Path: resolvedPath,
         sizeKb: updateInput.sizeKB ?? result.sizeKB ?? 0,
       });
     }

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -335,10 +335,12 @@ export const getFileForModelVersion = async ({
     // Both storage-resolver and delivery-worker fallback rejected this file —
     // usually an un-registered `file_locations` row on a bucket the
     // delivery-worker doesn't know. Log so the leak is visible in production.
+    // safeError includes `name: 'Error'` which must be spread BEFORE our
+    // literal `name` or the event name gets overwritten.
     logToAxiom({
       type: 'error',
-      name: 'resolve-download-url-failed',
       ...safeError(err),
+      name: 'resolve-download-url-failed',
       fileId: file.id,
       modelId: modelVersion.model.id,
       modelVersionId,

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -279,6 +279,49 @@ export function isB2Url(url: string): boolean {
   }
 }
 
+/**
+ * Extract `{ bucket, key }` from a Backblaze B2 URL. Primary check is the
+ * `*.backblazeb2.com` hostname pattern, which works without any env config
+ * (important for admin scripts running in pods that don't set
+ * `S3_UPLOAD_B2_ENDPOINT`). If the primary check fails, we fall back to
+ * matching against the configured endpoint so custom proxies / non-public
+ * endpoints still parse correctly when the env IS set.
+ *
+ * Accepts path-style (`https://s3.<region>.backblazeb2.com/<bucket>/<key>`)
+ * and virtual-host style (`https://<bucket>.s3.<region>.backblazeb2.com/<key>`).
+ * Returns `null` if neither check recognizes the URL.
+ */
+export function parseB2Url(rawUrl: string): { bucket: string; key: string } | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const matchesPublicPattern = url.hostname.endsWith('.backblazeb2.com');
+  const matchesConfiguredHost = b2Host !== null && url.hostname === b2Host;
+  if (!matchesPublicPattern && !matchesConfiguredHost) return null;
+
+  // Path-style endpoint → bucket is the first path segment.
+  // We treat any `s3.*` hostname as path-style, and also whatever shape the
+  // configured endpoint advertises (exact hostname match).
+  const isPathStyle = url.hostname.startsWith('s3.') || matchesConfiguredHost;
+  if (isPathStyle) {
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    return { bucket: parts[0], key: parts.slice(1).join('/') };
+  }
+
+  // Virtual-host style → first hostname label is the bucket.
+  const dotIdx = url.hostname.indexOf('.');
+  if (dotIdx <= 0) return null;
+  const bucket = url.hostname.slice(0, dotIdx);
+  const key = url.pathname.replace(/^\/+/, '');
+  if (!key) return null;
+  return { bucket, key };
+}
+
 export async function getGetUrl(
   s3Url: string,
   { s3, expiresIn = DOWNLOAD_EXPIRATION, fileName, bucket }: GetObjectOptions = {}


### PR DESCRIPTION
## Summary

Follow-up to #2203. Post-deploy verification showed new B2 training uploads **still** 404'd on download:

- 197 `s3-upload` events for `training-images` with `backend: "b2"` in 6h (uploads work)
- **0** `register-file-location-failed` / `-skipped` events (registration path never ran)
- **6,635** download 404s under a generic `name: "Error"` bucket in Axiom

Two independent bugs caused this:

### 1. Users on stale client bundles
Training pages live for hours during a run, so a frontend deploy can take a long time to reach every open tab. My PR #2203 relied on the client sending the new `s3Path` field on the tRPC upsert — for users still on the pre-deploy JS, `s3Path` was `undefined`, the `backend === 'b2' && s3Path` guard failed, and the server silently skipped registration. Fix: derive `s3Path` from the committed file URL server-side when the client didn't send one. Stale clients now register correctly.

### 2. Axiom `name` field collision
`safeError(err)` returns `{ name: 'Error', message, stack, ... }` (the JS `Error.name`). Spreading it **after** the literal `name: 'resolve-download-url-failed'` overwrote my custom name — so every instance of this event landed under the generic `name: "Error"` bucket, invisible to a targeted search. Reordering the spread fixes it.

## Changes

- `src/utils/s3-utils.ts` — add `parseB2Url` helper. Primary match is the `*.backblazeb2.com` hostname pattern (env-free; works in admin pods without `S3_UPLOAD_B2_ENDPOINT`). Falls back to matching the configured endpoint when it IS set, covering custom proxies / non-public B2 fronts.
- `src/server/controllers/model-file.controller.ts` — new `resolveB2Path()` helper picks the client-sent `s3Path` if present, otherwise derives it from the URL. Both `createFileHandler` and `updateFileHandler` use it. Also fixes the `safeError` spread order in `safeRegisterFileLocation`.
- `src/server/services/file.service.ts` — same `safeError` spread fix for the `resolve-download-url-failed` event.
- `src/pages/api/admin/temp/backfill-b2-file-locations.ts` — drop the inlined URL parser, reuse the shared helper.

## Test plan

- [ ] Upload training data with a **freshly-loaded** page → verify a `register-file-location-*` event fires (success = no event, failure = `register-file-location-failed` under the correct `name`).
- [ ] Download the uploaded file → 302 to signed B2 URL.
- [ ] Repeat with a stale page (keep a tab open, deploy, then upload) → registration should still fire via the URL-derived fallback path.
- [ ] Axiom query: `['civitai-prod'] | where name in ('resolve-download-url-failed','register-file-location-failed','register-file-location-skipped')` should return rows under the correct names (currently returns 0).
- [ ] Dry-run the backfill again → `candidates` should be ~45k (was 0 in the previous dry run because the old `isB2Url` dependency was broken in-pod).

## Notes

Once this deploys and we confirm new uploads register, the backfill is safe to run (`dryRun=false&concurrency=3`) to repair everything that fell through the cracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)