### PR TITLE
fix(upload): always route training data to B2

### DIFF
--- a/src/pages/api/upload/index.ts
+++ b/src/pages/api/upload/index.ts
@@ -41,11 +41,10 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
     (type === UploadType.TrainingImages || type === UploadType.TrainingImagesTemp) &&
     env.S3_UPLOAD_B2_ENDPOINT
   ) {
-    const useB2 =
-      isPreview || (await isFlipt(FLIPT_FEATURE_FLAGS.B2_TRAINING_UPLOAD, String(userId)));
-    if (useB2) {
-      backend = 'b2';
-    }
+    // Always route training data to B2. The b2-training-upload Flipt flag was used
+    // for gradual rollout and is now globally enabled. Removing the flag dependency
+    // prevents silent R2 fallback when Flipt initialization fails.
+    backend = 'b2';
   }
 
   const key = `${type ?? UploadType.Default}/${userId}/${filename}.${generateToken(4)}${ext}`;


### PR DESCRIPTION
## Summary
- Training data uploads silently fell back to R2 when Flipt flag evaluation failed (timeout/circuit breaker)
- 141 uploads affected this week despite the `b2-training-upload` flag being globally enabled
- Remove the Flipt dependency — training data always routes to B2 when `S3_UPLOAD_B2_ENDPOINT` is configured

## Root cause
`isFlipt()` returns `false` on initialization failure (5s timeout) or during circuit breaker cooldown (30s). The upload handler treated this as "flag disabled" and routed to R2.

## Test plan
- [ ] Upload training data — verify it goes to B2 (URL contains `backblazeb2.com`)
- [ ] Verify training jobs complete successfully with B2-hosted training data

🤖 Generated with [Claude Code](https://claude.com/claude-code)