### PR TITLE
fix(auto-label): harden orchestrator flow and

### DIFF
--- a/.claude/skills/civitai-orchestration/SKILL.md
+++ b/.claude/skills/civitai-orchestration/SKILL.md
@@ -254,7 +254,7 @@ Stored in `.claude/skills/civitai-orchestration/.env`:
 
 ```env
 CIVITAI_API_TOKEN=your_bearer_token
-CIVITAI_API_URL=https://orchestration-new.civitai.com
+CIVITAI_API_URL=https://orchestration.civitai.com
 ```
 
 ## API Reference

--- a/src/components/Training/Form/TrainingAutoLabelModal.tsx
+++ b/src/components/Training/Form/TrainingAutoLabelModal.tsx
@@ -38,7 +38,10 @@ import {
 import { getJSZip } from '~/utils/lazy';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { titleCase } from '~/utils/string-helpers';
-import { uploadAndSubmitAutoLabel } from '~/utils/training/auto-label-orchestrator';
+import {
+  type AutoLabelHandle,
+  uploadAndSubmitAutoLabel,
+} from '~/utils/training/auto-label-orchestrator';
 
 const overwrites: { [key in (typeof overwriteList)[number]]: string } = {
   ignore: 'Skip files with existing labels',
@@ -46,7 +49,34 @@ const overwrites: { [key in (typeof overwriteList)[number]]: string } = {
   overwrite: 'Overwrite existing labels',
 };
 
+// Legacy zip path bottlenecks past ~60 captioned files; the orchestrator path
+// chunks into batched workflows so the cap doesn't apply there.
 const maxImagesCaption = 60;
+// Browsers throttle concurrent fetches to one origin, but kicking off 500+
+// unbounded promises ties up memory holding all those blobs at once.
+const SOURCE_FETCH_CONCURRENCY = 6;
+
+// Track the in-flight orchestrator handle per model so a fresh submit can
+// cancel any prior run before it scribbles into the new run's labels.
+const inFlightHandles = new Map<number, AutoLabelHandle>();
+
+async function fetchWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      results[idx] = await task(items[idx]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 const useSubmitImages = ({
   modelId,
@@ -68,76 +98,185 @@ const useSubmitImages = ({
         ...(mediaType === 'video' ? defaultTrainingStateVideo : defaultTrainingState),
       }
   );
-  const { setAutoLabeling, updateImage } = trainingStore;
+  const { setAutoLabeling, mutateAutoLabeling, updateImage } = trainingStore;
 
   const filteredImages = imageList.filter((i) =>
     (type === 'caption' ? autoCaptioning : autoTagging).overwrite === 'ignore'
       ? i.label.length === 0
       : i
   );
-  const disabled = type === 'caption' && filteredImages.length > maxImagesCaption;
+  // Caption cap only applies on the legacy path — orchestrator handles arbitrary counts.
+  const disabled =
+    type === 'caption' &&
+    filteredImages.length > maxImagesCaption &&
+    !features.trainingAutoLabelOrchestrator;
 
   const submitViaOrchestrator = async () => {
-    // Materialize blobs from the same source URLs the legacy zip path used.
-    // Without the .ok check, a 403/404 HTML body would be uploaded as the "image".
-    const images = await Promise.all(
-      filteredImages.map(async (imgData) => {
-        const res = await fetch(imgData.url);
-        if (!res.ok) {
-          throw new Error(
-            `Failed to fetch ${getShortNameFromUrl(imgData)} (${res.status} ${res.statusText})`
-          );
-        }
-        return { filename: getShortNameFromUrl(imgData), blob: await res.blob() };
-      })
-    );
+    // Cancel any prior run for this model — without this, an old poll loop
+    // from a previous submit will keep firing onResult against the new run's
+    // store state and corrupt the new labels.
+    inFlightHandles.get(modelId)?.cancel();
+    inFlightHandles.delete(modelId);
+
+    // Stamp this run with a unique id so background callbacks from the prior
+    // run (which may still be mid-tick) can recognize they're stale.
+    const runId = Date.now() + Math.random();
 
     setAutoLabeling(modelId, mediaType, {
       url: null,
       isRunning: true,
-      total: images.length,
+      total: filteredImages.length,
       successes: 0,
       fails: [],
+      uploaded: 0,
+      phase: 'preparing',
+      uploadStartedAt: null,
+      runId,
     });
+
+    // Materialize blobs from the same source URLs the legacy zip path used,
+    // bounded so 500+ images don't all sit in memory at once. Bad URLs (e.g. CDN
+    // returning a 403 HTML page) are recorded as per-image failures rather than
+    // killing the whole run. Track failure reasons by image URL (collision-proof
+    // — short filenames can collide for duplicate uploads).
+    const failureReasons = new Map<string, string>();
+    const keyToFilename = new Map<string, string>(
+      filteredImages.map((i) => [i.url, getShortNameFromUrl(i)] as const)
+    );
+    const filenameFor = (key: string) => keyToFilename.get(key) ?? key;
+    const recordFailure = (key: string, reason: string) => {
+      if (key) failureReasons.set(key, reason);
+    };
+
+    type Sourced = { key: string; blob: Blob } | null;
+    const sourced = await fetchWithConcurrency<(typeof filteredImages)[number], Sourced>(
+      filteredImages,
+      SOURCE_FETCH_CONCURRENCY,
+      async (imgData) => {
+        const key = imgData.url;
+        try {
+          const res = await fetch(imgData.url);
+          if (!res.ok) {
+            recordFailure(key, `Source fetch failed (${res.status} ${res.statusText})`);
+            return null;
+          }
+          return { key, blob: await res.blob() };
+        } catch (err) {
+          recordFailure(key, err instanceof Error ? err.message : 'Source fetch failed');
+          return null;
+        }
+      }
+    );
+
+    // If the user kicked off a different run while we were fetching, drop ours.
+    if (useTrainingImageStore.getState()[modelId]?.autoLabeling.runId !== runId) return;
+
+    const images = sourced.filter((s): s is { key: string; blob: Blob } => s !== null);
+    // Push source-fetch failures into store immediately so the progress bar reflects them.
+    if (failureReasons.size > 0) {
+      mutateAutoLabeling(modelId, mediaType, (prev) => ({
+        fails: [...prev.fails, ...failureReasons.keys()],
+      }));
+    }
+
+    if (images.length === 0) {
+      const defaultState = mediaType === 'video' ? defaultTrainingStateVideo : defaultTrainingState;
+      setAutoLabeling(modelId, mediaType, { ...defaultState.autoLabeling });
+      showErrorNotification({
+        title: 'Auto-label failed',
+        error: new Error('Could not fetch any source images.'),
+      });
+      return;
+    }
 
     const overwriteMode = (type === 'caption' ? autoCaptioning : autoTagging).overwrite;
 
-    const onResult = (filename: string, label: string) => {
-      updateImage(modelId, mediaType, {
-        matcher: filename,
-        label,
-        appendLabel: overwriteMode === 'append',
+    // All store mutations are gated on runId — if the user reset the run (close,
+    // start fresh, etc.), the store's runId will differ and we no-op.
+    const guard = (apply: () => void) => {
+      if (useTrainingImageStore.getState()[modelId]?.autoLabeling.runId === runId) apply();
+    };
+
+    const onUploadStart = () => {
+      guard(() =>
+        mutateAutoLabeling(modelId, mediaType, () => ({
+          phase: 'uploading',
+          uploaded: 0,
+          uploadStartedAt: Date.now(),
+        }))
+      );
+    };
+    const onUploadProgress = (uploadedCount: number) => {
+      guard(() => mutateAutoLabeling(modelId, mediaType, () => ({ uploaded: uploadedCount })));
+    };
+    const onUploadComplete = () => {
+      guard(() => mutateAutoLabeling(modelId, mediaType, () => ({ phase: 'labeling' })));
+    };
+
+    const onResult = (key: string, label: string) => {
+      guard(() => {
+        updateImage(modelId, mediaType, {
+          matcher: filenameFor(key),
+          urlMatcher: key,
+          label,
+          appendLabel: overwriteMode === 'append',
+        });
+        mutateAutoLabeling(modelId, mediaType, (prev) => ({ successes: prev.successes + 1 }));
       });
-      const current = useTrainingImageStore.getState()[modelId]?.autoLabeling;
-      if (current) {
-        setAutoLabeling(modelId, mediaType, {
-          ...current,
-          successes: current.successes + 1,
-        });
-      }
     };
-    const onFailure = (filename: string) => {
-      if (!filename) return;
-      const current = useTrainingImageStore.getState()[modelId]?.autoLabeling;
-      if (current) {
-        setAutoLabeling(modelId, mediaType, {
-          ...current,
-          fails: [...current.fails, filename],
-        });
-      }
+    const onFailure = (key: string, reason: string) => {
+      recordFailure(key, reason);
+      if (!key) return;
+      guard(() =>
+        mutateAutoLabeling(modelId, mediaType, (prev) => ({ fails: [...prev.fails, key] }))
+      );
     };
-    const onDone = ({ successes, fails }: { successes: number; fails: string[] }) => {
+    const onFatal = (reason: string) => {
+      // Catastrophic poll/setup failure — surface as a real toast rather than
+      // hiding it in the per-image grouping.
+      guard(() =>
+        showErrorNotification({
+          title: 'Auto-label crashed',
+          error: new Error(reason),
+          autoClose: false,
+        })
+      );
+    };
+    const onDone = ({ successes, failedKeys }: { successes: number; failedKeys: string[] }) => {
+      // Drop late events from a stale run.
+      if (useTrainingImageStore.getState()[modelId]?.autoLabeling.runId !== runId) return;
+
       const labelNoun = type === 'caption' ? 'caption' : 'tag';
       const labelVerb = type === 'caption' ? 'Captioned' : 'Tagged';
-      const message = `${labelVerb} ${successes} image${successes === 1 ? '' : 's'}.${
-        fails.length > 0 ? ` Failures: ${fails.length}` : ''
-      }`;
+
+      // Group failure reasons so the user sees "5× content blocked" instead of
+      // a flat count or 50 toasts.
+      const reasonCounts = new Map<string, number>();
+      for (const key of failedKeys) {
+        const reason = failureReasons.get(key) ?? 'Unknown error';
+        reasonCounts.set(reason, (reasonCounts.get(reason) ?? 0) + 1);
+      }
+      const reasonSummary = Array.from(reasonCounts.entries())
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, 3)
+        .map(([reason, count]) => `${count}× ${reason}`)
+        .join('; ');
+
+      const headline = `${labelVerb} ${successes} image${successes === 1 ? '' : 's'}.`;
+      const failureText =
+        failedKeys.length > 0
+          ? ` ${failedKeys.length} failure${failedKeys.length === 1 ? '' : 's'}${
+              reasonSummary ? `: ${reasonSummary}` : ''
+            }`
+          : '';
+      const message = headline + failureText;
+
       if (successes === 0) {
         showErrorNotification({
           title: `Auto-${labelNoun} failed`,
           error: new Error(message),
         });
-      } else if (fails.length > 0) {
+      } else if (failedKeys.length > 0) {
         showErrorNotification({
           title: `Auto-${labelNoun} finished with errors`,
           error: new Error(message),
@@ -148,9 +287,9 @@ const useSubmitImages = ({
           message,
         });
       }
-      const defaultState =
-        mediaType === 'video' ? defaultTrainingStateVideo : defaultTrainingState;
+      const defaultState = mediaType === 'video' ? defaultTrainingStateVideo : defaultTrainingState;
       setAutoLabeling(modelId, mediaType, { ...defaultState.autoLabeling });
+      inFlightHandles.delete(modelId);
     };
 
     const postProcess = {
@@ -164,44 +303,61 @@ const useSubmitImages = ({
 
     // Polling continues after the modal closes — bail out cleanly if the user
     // resets the run from elsewhere (re-opens the modal, navigates away, etc.).
-    const isActive = () =>
-      useTrainingImageStore.getState()[modelId]?.autoLabeling.isRunning ?? false;
+    // Pair `isRunning` with `runId` so a fresh run's `isRunning: true` doesn't
+    // make a stale poll loop think it's still its own.
+    const isActive = () => {
+      const state = useTrainingImageStore.getState()[modelId]?.autoLabeling;
+      return !!state?.isRunning && state.runId === runId;
+    };
 
     try {
-      if (type === 'tag') {
-        await uploadAndSubmitAutoLabel({
-          modelId,
-          mediaType: mediaType ?? 'image',
-          type: 'tag',
-          images,
-          params: { threshold: autoTagging.threshold },
-          postProcess,
-          isActive,
-          onResult,
-          onFailure,
-          onDone,
-        });
+      const handle =
+        type === 'tag'
+          ? await uploadAndSubmitAutoLabel({
+              modelId,
+              mediaType: mediaType ?? 'image',
+              type: 'tag',
+              images,
+              params: { threshold: autoTagging.threshold },
+              postProcess,
+              isActive,
+              onUploadStart,
+              onUploadProgress,
+              onUploadComplete,
+              onResult,
+              onFailure,
+              onFatal,
+              onDone,
+            })
+          : await uploadAndSubmitAutoLabel({
+              modelId,
+              mediaType: mediaType ?? 'image',
+              type: 'caption',
+              images,
+              params: {
+                temperature: autoCaptioning.temperature,
+                maxNewTokens: autoCaptioning.maxNewTokens,
+              },
+              postProcess,
+              isActive,
+              onUploadStart,
+              onUploadProgress,
+              onUploadComplete,
+              onResult,
+              onFailure,
+              onFatal,
+              onDone,
+            });
+      // Only stash the handle if we're still the live run — otherwise a newer
+      // run's cancel could fire against our (now-stale) handle.
+      if (useTrainingImageStore.getState()[modelId]?.autoLabeling.runId === runId) {
+        inFlightHandles.set(modelId, handle);
       } else {
-        await uploadAndSubmitAutoLabel({
-          modelId,
-          mediaType: mediaType ?? 'image',
-          type: 'caption',
-          images,
-          params: {
-            temperature: autoCaptioning.temperature,
-            maxNewTokens: autoCaptioning.maxNewTokens,
-          },
-          postProcess,
-          isActive,
-          onResult,
-          onFailure,
-          onDone,
-        });
+        handle.cancel();
       }
     } catch (e) {
-      const defaultState =
-        mediaType === 'video' ? defaultTrainingStateVideo : defaultTrainingState;
-      setAutoLabeling(modelId, mediaType, { ...defaultState.autoLabeling });
+      const defaultState = mediaType === 'video' ? defaultTrainingStateVideo : defaultTrainingState;
+      guard(() => setAutoLabeling(modelId, mediaType, { ...defaultState.autoLabeling }));
       throw e;
     }
   };
@@ -255,11 +411,24 @@ const useSubmitImages = ({
       // The orchestrator flag overrides — when on, we always use the new flow,
       // regardless of what trainingAutoTag / trainingAutoCaption say.
       if (features.trainingAutoLabelOrchestrator) {
-        await submitViaOrchestrator();
+        // Hand off to the page-level progress card so the modal doesn't sit on
+        // "Sending data..." through the entire upload+submit phase. The first
+        // setAutoLabeling call inside submitViaOrchestrator runs synchronously
+        // (zustand) so the store flips to isRunning: true before we close.
+        void submitViaOrchestrator().catch((e) => {
+          // Cancellation is expected (e.g. user starts a new run) — don't toast.
+          if ((e as DOMException | undefined)?.name === 'AbortError') return;
+          showErrorNotification({
+            error: e instanceof Error ? e : new Error('Please try again'),
+            title: 'Failed to send data',
+            autoClose: false,
+          });
+        });
+        handleClose();
       } else {
         await submitViaLegacyZip();
+        handleClose();
       }
-      handleClose();
     } catch (e) {
       showErrorNotification({
         error: e instanceof Error ? e : new Error('Please try again'),
@@ -464,7 +633,12 @@ const AutoCaptionSection = ({
       }
   );
   const { setAutoCaptioning } = trainingStore;
-  const { loading, handleSubmit, numImages, disabled: limitReached } = useSubmitImages({
+  const {
+    loading,
+    handleSubmit,
+    numImages,
+    disabled: limitReached,
+  } = useSubmitImages({
     modelId,
     mediaType,
     handleClose,
@@ -486,8 +660,8 @@ const AutoCaptionSection = ({
           iconColor="red"
         >
           <Text>
-            Auto-captioning is temporarily unavailable. We&apos;re actively looking into it -
-            please check back soon.
+            Auto-captioning is temporarily unavailable. We&apos;re actively looking into it - please
+            check back soon.
           </Text>
         </AlertWithIcon>
       )}

--- a/src/components/Training/Form/TrainingAutoLabelModal.tsx
+++ b/src/components/Training/Form/TrainingAutoLabelModal.tsx
@@ -249,10 +249,16 @@ const useSubmitImages = ({
       const labelNoun = type === 'caption' ? 'caption' : 'tag';
       const labelVerb = type === 'caption' ? 'Captioned' : 'Tagged';
 
+      // Union the helper's failedKeys with any source-fetch failures recorded
+      // before submit — those never reach the helper, so they aren't in
+      // failedKeys but are very much real failures the user should see.
+      const allFailedKeys = new Set<string>(failedKeys);
+      for (const key of failureReasons.keys()) allFailedKeys.add(key);
+
       // Group failure reasons so the user sees "5× content blocked" instead of
       // a flat count or 50 toasts.
       const reasonCounts = new Map<string, number>();
-      for (const key of failedKeys) {
+      for (const key of allFailedKeys) {
         const reason = failureReasons.get(key) ?? 'Unknown error';
         reasonCounts.set(reason, (reasonCounts.get(reason) ?? 0) + 1);
       }
@@ -262,10 +268,11 @@ const useSubmitImages = ({
         .map(([reason, count]) => `${count}× ${reason}`)
         .join('; ');
 
+      const totalFails = allFailedKeys.size;
       const headline = `${labelVerb} ${successes} image${successes === 1 ? '' : 's'}.`;
       const failureText =
-        failedKeys.length > 0
-          ? ` ${failedKeys.length} failure${failedKeys.length === 1 ? '' : 's'}${
+        totalFails > 0
+          ? ` ${totalFails} failure${totalFails === 1 ? '' : 's'}${
               reasonSummary ? `: ${reasonSummary}` : ''
             }`
           : '';
@@ -276,7 +283,7 @@ const useSubmitImages = ({
           title: `Auto-${labelNoun} failed`,
           error: new Error(message),
         });
-      } else if (failedKeys.length > 0) {
+      } else if (totalFails > 0) {
         showErrorNotification({
           title: `Auto-${labelNoun} finished with errors`,
           error: new Error(message),

--- a/src/components/Training/Form/TrainingImages.tsx
+++ b/src/components/Training/Form/TrainingImages.tsx
@@ -90,6 +90,7 @@ import {
 import { ModelFileVisibility } from '~/shared/utils/prisma/enums';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import {
+  type AutoLabelType,
   defaultTrainingState,
   defaultTrainingStateVideo,
   getShortNameFromUrl,
@@ -1266,7 +1267,10 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
         if (i.label.length > 0) {
           // Validate each tag individually to avoid cross-tag false positives
           // (e.g. "school_uniform, 1girl" matching composed "school...girl" pattern)
-          const tags = i.label.split(',').map((t) => t.trim()).filter(Boolean);
+          const tags = i.label
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean);
           let hasInvalid = false;
           for (const tag of tags) {
             const { blockedFor, success } = auditPrompt(tag, undefined, isGreen);
@@ -1594,34 +1598,7 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
             )}
             {autoLabeling.isRunning && (
               <Paper className="bg-gray-0 dark:bg-dark-6" my="lg" p="md" withBorder>
-                <Stack>
-                  <Text>Running auto labeling...</Text>
-                  {autoLabeling.successes + autoLabeling.fails.length > 0 ? (
-                    <Progress.Root size="xl" radius="xl">
-                      <Progress.Section
-                        value={
-                          ((autoLabeling.successes + autoLabeling.fails.length) /
-                            autoLabeling.total) *
-                          100
-                        }
-                        striped
-                        animated
-                      >
-                        <Progress.Label>
-                          {`${autoLabeling.successes + autoLabeling.fails.length} / ${
-                            autoLabeling.total
-                          }`}
-                        </Progress.Label>
-                      </Progress.Section>
-                    </Progress.Root>
-                  ) : (
-                    <Progress.Root size="xl" radius="xl">
-                      <Progress.Section value={100} striped animated>
-                        <Progress.Label>Waiting for data...</Progress.Label>
-                      </Progress.Section>
-                    </Progress.Root>
-                  )}
-                </Stack>
+                <AutoLabelProgress autoLabeling={autoLabeling} />
               </Paper>
             )}
             {imageList.length > 0 && (
@@ -1938,6 +1915,76 @@ export const TrainingFormImages = ({ model }: { model: NonNullable<TrainingModel
         </Button>
       </Group>
     </>
+  );
+};
+
+const formatRemaining = (seconds: number) => {
+  if (!isFinite(seconds) || seconds <= 0) return '';
+  if (seconds < 60) return `~${Math.ceil(seconds)}s remaining`;
+  const minutes = Math.ceil(seconds / 60);
+  return `~${minutes}m remaining`;
+};
+
+const AutoLabelProgress = ({ autoLabeling }: { autoLabeling: AutoLabelType }) => {
+  const { phase, uploaded, total, successes, fails, uploadStartedAt } = autoLabeling;
+
+  // Pre-upload: source images are being fetched from CDN. Indeterminate bar
+  // since per-image progress isn't tracked here — and we don't want to start
+  // ticking the upload progress at 0/N for the whole fetch window.
+  if (phase === 'preparing') {
+    return (
+      <Stack>
+        <Text>Preparing images…</Text>
+        <Progress.Root size="xl" radius="xl">
+          <Progress.Section value={100} striped animated>
+            <Progress.Label>Reading source files</Progress.Label>
+          </Progress.Section>
+        </Progress.Root>
+      </Stack>
+    );
+  }
+
+  // Uploading. Show ETA only after a few uploads have completed so the
+  // estimate isn't based on a single noisy sample.
+  if (phase === 'uploading') {
+    const pct = total > 0 ? (uploaded / total) * 100 : 0;
+    let eta = '';
+    if (uploaded >= 3 && uploadStartedAt && uploaded < total) {
+      const elapsedMs = Date.now() - uploadStartedAt;
+      const msPerImage = elapsedMs / uploaded;
+      eta = formatRemaining(((total - uploaded) * msPerImage) / 1000);
+    }
+    return (
+      <Stack>
+        <Text>Uploading images{eta ? ` · ${eta}` : ''}</Text>
+        <Progress.Root size="xl" radius="xl">
+          <Progress.Section value={pct} striped animated>
+            <Progress.Label>{`${uploaded} / ${total}`}</Progress.Label>
+          </Progress.Section>
+        </Progress.Root>
+      </Stack>
+    );
+  }
+
+  // Labeling (orchestrator) or legacy zip path: same progress pattern.
+  const done = successes + fails.length;
+  return (
+    <Stack>
+      <Text>Running auto labeling…</Text>
+      {done > 0 ? (
+        <Progress.Root size="xl" radius="xl">
+          <Progress.Section value={(done / total) * 100} striped animated>
+            <Progress.Label>{`${done} / ${total}`}</Progress.Label>
+          </Progress.Section>
+        </Progress.Root>
+      ) : (
+        <Progress.Root size="xl" radius="xl">
+          <Progress.Section value={100} striped animated>
+            <Progress.Label>Waiting for data...</Progress.Label>
+          </Progress.Section>
+        </Progress.Root>
+      )}
+    </Stack>
   );
 };
 

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -66,6 +66,7 @@ import { processVaultItems } from '~/server/jobs/process-vault-items';
 import { pushDiscordMetadata } from '~/server/jobs/push-discord-metadata';
 import { refreshAuctionCache } from '~/server/jobs/refresh-auction-cache';
 import { removeOldDrafts } from '~/server/jobs/remove-old-drafts';
+import { reindexRecentScheduledImages } from '~/server/jobs/reindex-recent-scheduled-images';
 import { resetImageViewCounts } from '~/server/jobs/reset-image-view-counts';
 import { resetToDraftWithoutRequirements } from '~/server/jobs/reset-to-draft-without-requirements';
 import { resourceGenerationAvailability } from '~/server/jobs/resource-generation-availability';
@@ -102,6 +103,7 @@ export const jobs: Job[] = [
   addOnDemandRunStrategiesJob,
   deliverPurchasedCosmetics,
   deliverLeaderboardCosmetics,
+  reindexRecentScheduledImages,
   resetImageViewCounts,
   pushDiscordMetadata,
   applyVotedTags,

--- a/src/server/jobs/reindex-recent-scheduled-images.ts
+++ b/src/server/jobs/reindex-recent-scheduled-images.ts
@@ -1,0 +1,49 @@
+import { dbRead } from '~/server/db/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { imagesMetricsSearchIndex } from '~/server/search-index';
+import { createJob, UNRUNNABLE_JOB_CRON } from './job';
+
+// Manual / one-off job. Re-syncs the metrics_images_v1 index for images whose
+// parent post was (scheduled-)published recently. Some images weren't picked
+// up by the normal indexing path after scheduled publishing — see task
+// https://app.clickup.com/t/868jc90r3.
+//
+// Trigger via: /api/webhooks/run-jobs?run=reindex-recent-scheduled-images
+
+const DAYS_LOOKBACK = 3;
+
+export const reindexRecentScheduledImages = createJob(
+  'reindex-recent-scheduled-images',
+  UNRUNNABLE_JOB_CRON,
+  async (jobContext) => {
+    const since = new Date(Date.now() - DAYS_LOOKBACK * 24 * 60 * 60 * 1000);
+
+    // Images belonging to posts that were published in the lookback window
+    // through a ModelVersion (the scheduled-publishing flow only applies to
+    // posts linked to a ModelVersion).
+    const images = await dbRead.$queryRaw<{ id: number }[]>`
+      SELECT i.id
+      FROM "Image" i
+      JOIN "Post" p ON p.id = i."postId"
+      WHERE p."publishedAt" >= ${since}
+        AND p."publishedAt" IS NOT NULL
+        AND p."modelVersionId" IS NOT NULL
+    `;
+
+    if (!images.length) {
+      console.log('reindex-recent-scheduled-images :: no images to reindex');
+      return;
+    }
+
+    console.log(
+      `reindex-recent-scheduled-images :: reindexing ${images.length} images since ${since.toISOString()}`
+    );
+
+    const data = images.map(({ id }) => ({
+      id,
+      action: SearchIndexUpdateQueueAction.Update,
+    }));
+
+    await imagesMetricsSearchIndex.updateSync(data, jobContext);
+  }
+);

--- a/src/server/routers/training.router.ts
+++ b/src/server/routers/training.router.ts
@@ -2,13 +2,14 @@ import { z } from 'zod';
 import { CacheTTL } from '~/server/common/constants';
 import { getModelData } from '~/server/controllers/training.controller';
 import { dbKV } from '~/server/db/db-helpers';
-import { edgeCacheIt, purgeOnSuccess, rateLimit  } from '~/server/middleware.trpc';
+import { edgeCacheIt, purgeOnSuccess, rateLimit } from '~/server/middleware.trpc';
 import { getByIdSchema } from '~/server/schema/base.schema';
 import {
   autoCaptionInput,
   autoTagInput,
   createTrainingRequestDryRunSchema,
   createTrainingRequestSchema,
+  getAutoLabelUploadUrlSchema,
   getAutoLabelWorkflowSchema,
   moveAssetInput,
   submitAutoLabelWorkflowSchema,
@@ -81,12 +82,13 @@ export const trainingRouter = router({
   // Tagging/captioning is free; the orchestrator work is billed to the system token
   // and not the user, so each endpoint needs a per-user rate cap to prevent abuse.
   getAutoLabelUploadUrl: guardedProcedure
+    .input(getAutoLabelUploadUrlSchema)
     .use(isFlagProtected('imageTraining'))
     .use(isFlagProtected('trainingAutoLabelOrchestrator'))
     // Per-image: ~1000 images/min is the soft ceiling we want to allow for legitimate
     // use, so the cap matches that 1:1 (each image needs one presign).
     .use(rateLimit({ limit: 1000, period: 60 }))
-    .mutation(() => getAutoLabelUploadUrl()),
+    .mutation(({ input, ctx }) => getAutoLabelUploadUrl({ ...input, userId: ctx.user.id })),
   submitAutoLabelWorkflow: guardedProcedure
     .input(submitAutoLabelWorkflowSchema)
     .use(isFlagProtected('imageTraining'))

--- a/src/server/schema/training.schema.ts
+++ b/src/server/schema/training.schema.ts
@@ -38,17 +38,13 @@ export const autoCaptionInput = autoTagInput.merge(autoCaptionSchema.omit({ over
 
 // --- Auto-label v2 (orchestrator workflows) ---
 
-// Only accept blob URLs we just minted from the orchestrator's v2 blob endpoint.
-// Without this, any URL the orchestrator can reach (including internal IPs and
-// metadata services) becomes an SSRF vector via mediaUrl.
-const ORCHESTRATOR_BLOB_URL_PREFIX = 'https://orchestration-new.civitai.com/v2/consumer/blobs/';
-
+// The orchestrator accepts arbitrary image URLs for captioning/tagging, so we
+// only enforce sane URL shape here — HTTPS, length-capped, real URL.
 const autoLabelImageSchema = z.object({
   mediaUrl: z
     .url()
-    .refine((url) => url.startsWith(ORCHESTRATOR_BLOB_URL_PREFIX), {
-      message: 'mediaUrl must point to an orchestrator-issued blob',
-    }),
+    .max(2048)
+    .refine((u) => u.startsWith('https://'), { message: 'mediaUrl must be HTTPS' }),
   filename: z.string().min(1).max(256),
 });
 
@@ -80,8 +76,22 @@ export type SubmitAutoLabelWorkflowInput = z.infer<typeof submitAutoLabelWorkflo
 export const submitAutoLabelWorkflowSchema = z.object({
   modelId: z.number().positive(),
   mediaType: z.enum(['image', 'video']).default('image'),
-  images: z.array(autoLabelImageSchema).min(1).max(AUTO_LABEL_BATCH_SIZE),
+  images: z
+    .array(autoLabelImageSchema)
+    .min(1)
+    .max(AUTO_LABEL_BATCH_SIZE)
+    .refine((imgs) => new Set(imgs.map((i) => i.mediaUrl)).size === imgs.length, {
+      message: 'Duplicate mediaUrl in batch',
+    }),
   params: z.discriminatedUnion('type', [autoLabelTagParamsSchema, autoLabelCaptionParamsSchema]),
+});
+
+export type GetAutoLabelUploadUrlInput = z.infer<typeof getAutoLabelUploadUrlSchema>;
+export const getAutoLabelUploadUrlSchema = z.object({
+  // Scope every presign to a model the user owns — without this, any guarded
+  // user could mint unlimited uploads to the orchestrator's system-token blob
+  // store as free hosting.
+  modelId: z.number().positive(),
 });
 
 export type GetAutoLabelWorkflowInput = z.infer<typeof getAutoLabelWorkflowSchema>;

--- a/src/server/services/orchestrator/client.ts
+++ b/src/server/services/orchestrator/client.ts
@@ -11,11 +11,3 @@ export function createOrchestratorClient(token: string) {
 
 /** Used to perform orchestrator operations with the system user account */
 export const internalOrchestratorClient = createOrchestratorClient(env.ORCHESTRATOR_ACCESS_TOKEN);
-
-export function createOrchestratorClientNew(token: string) {
-  return createCivitaiClient({
-    baseUrl: 'https://orchestration-new.civitai.com',
-    env: env.ORCHESTRATOR_MODE === 'dev' ? 'dev' : 'prod',
-    auth: token,
-  });
-}

--- a/src/server/services/orchestrator/consumerBlobUpload.ts
+++ b/src/server/services/orchestrator/consumerBlobUpload.ts
@@ -3,7 +3,7 @@ import {
   handleError,
   type ConsumerBlobPresignResponse,
 } from '@civitai/client';
-import { createOrchestratorClientNew } from '~/server/services/orchestrator/client';
+import { createOrchestratorClient } from '~/server/services/orchestrator/client';
 import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
 
 export async function getConsumerBlobUploadUrlService({
@@ -11,7 +11,7 @@ export async function getConsumerBlobUploadUrlService({
 }: {
   token: string;
 }): Promise<ConsumerBlobPresignResponse> {
-  const client = createOrchestratorClientNew(token);
+  const client = createOrchestratorClient(token);
 
   const { data, error } = await getConsumerBlobUploadUrl({
     client,

--- a/src/server/services/orchestrator/imageUpload.ts
+++ b/src/server/services/orchestrator/imageUpload.ts
@@ -1,5 +1,5 @@
 import { NsfwLevel, handleError, invokeImageUploadStepTemplate } from '@civitai/client';
-import { createOrchestratorClientNew } from '~/server/services/orchestrator/client';
+import { createOrchestratorClient } from '~/server/services/orchestrator/client';
 import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
 import { isMature } from '~/shared/constants/orchestrator.constants';
 
@@ -12,7 +12,7 @@ export async function imageUpload({
   token: string;
   allowMatureContent?: boolean;
 }) {
-  const client = createOrchestratorClientNew(token);
+  const client = createOrchestratorClient(token);
 
   const { data, error } = await invokeImageUploadStepTemplate({
     client,

--- a/src/server/services/training.service.ts
+++ b/src/server/services/training.service.ts
@@ -678,6 +678,43 @@ type AutoLabelStepMetadata = {
   filename: string;
 };
 
+// Block obvious SSRF without restricting which public host hosts the image.
+// Captioning/tagging is supposed to work with any user-supplied image URL, so
+// we don't gate on a host allowlist — but we DO want to refuse hostnames that
+// resolve to private/loopback/link-local space, since the orchestrator runs
+// inside our network and would happily fetch internal services if asked.
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^169\.254\./, // link-local (incl. cloud metadata 169.254.169.254)
+  /^0\./,
+  /^::1$/,
+  /^fe80:/i,
+  /^fc/i, // unique local IPv6 (fc00::/7)
+  /^fd/i,
+];
+
+function assertSafeMediaUrls(urls: string[]) {
+  for (const raw of urls) {
+    let parsed: URL;
+    try {
+      parsed = new URL(raw);
+    } catch {
+      throw throwBadRequestError(`Invalid mediaUrl: ${raw.slice(0, 64)}`);
+    }
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+      throw throwBadRequestError('mediaUrl must be a plain HTTPS URL');
+    }
+    const host = parsed.hostname.replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+    if (PRIVATE_HOST_PATTERNS.some((re) => re.test(host))) {
+      throw throwBadRequestError('mediaUrl host is not reachable');
+    }
+  }
+}
+
 async function assertModelOwnership(modelId: number, userId: number) {
   const model = await dbRead.model.findUnique({
     where: { id: modelId },
@@ -732,6 +769,7 @@ export async function submitAutoLabelWorkflow({
   params,
 }: SubmitAutoLabelWorkflowInput & { userId: number }) {
   await assertModelOwnership(modelId, userId);
+  assertSafeMediaUrls(images.map((i) => i.mediaUrl));
 
   const steps: WorkflowStepTemplate[] = images.map((img, index) => {
     const stepMetadata: AutoLabelStepMetadata = { filename: img.filename };

--- a/src/server/services/training.service.ts
+++ b/src/server/services/training.service.ts
@@ -26,6 +26,7 @@ import type { TrainingDetailsObj } from '~/server/schema/model-version.schema';
 import type {
   AutoCaptionInput,
   AutoTagInput,
+  GetAutoLabelUploadUrlInput,
   GetAutoLabelWorkflowInput,
   MoveAssetInput,
   SubmitAutoLabelWorkflowInput,
@@ -711,7 +712,11 @@ function toOrchestratorError(error: unknown): never {
   }
 }
 
-export async function getAutoLabelUploadUrl() {
+export async function getAutoLabelUploadUrl({
+  userId,
+  modelId,
+}: GetAutoLabelUploadUrlInput & { userId: number }) {
+  await assertModelOwnership(modelId, userId);
   const { data, error } = await getConsumerBlobUploadUrl({
     client: internalOrchestratorClient,
   });

--- a/src/store/training.store.ts
+++ b/src/store/training.store.ts
@@ -23,7 +23,12 @@ export type ImageDataType = {
 };
 
 type UpdateImageDataType = Partial<ImageDataType> & {
+  /** Match an image by `getShortNameFromUrl()` (legacy zip path's response keys
+   *  the result by short filename). Use {@link UpdateImageDataType.urlMatcher}
+   *  instead when you have the original URL — short filenames can collide. */
   matcher: string;
+  /** Match an image by exact URL — collision-proof, prefer this. */
+  urlMatcher?: string;
   appendLabel?: boolean;
 };
 
@@ -100,6 +105,14 @@ export type AutoLabelType = {
   total: number;
   successes: number;
   fails: string[];
+  // Orchestrator v2 only — left at defaults for the legacy zip path.
+  uploaded: number;
+  phase: 'idle' | 'preparing' | 'uploading' | 'labeling';
+  uploadStartedAt: number | null;
+  // Stable id for the in-flight orchestrator run. Background work tagged with
+  // an old runId must drop its writes once the store flips to a new id (so a
+  // poll loop from a previous run can't scribble into a fresh run's labels).
+  runId: number | null;
 };
 
 type Attest = { status: boolean; error: string };
@@ -212,6 +225,14 @@ type TrainingImageStore = {
     mediaType: TrainingDetailsObj['mediaType'],
     data: Partial<AutoLabelType>
   ) => void;
+  /** Race-safe partial update — receives the previous state and returns a partial.
+   *  Use this from concurrent callbacks (e.g. multiple poll responses landing in
+   *  the same tick) so you don't read-modify-write past each other. */
+  mutateAutoLabeling: (
+    modelId: number,
+    mediaType: TrainingDetailsObj['mediaType'],
+    update: (prev: AutoLabelType) => Partial<AutoLabelType>
+  ) => void;
   setAutoTagging: (
     modelId: number,
     mediaType: TrainingDetailsObj['mediaType'],
@@ -298,6 +319,10 @@ const defaultTrainingStateBase: Omit<TrainingDataState, 'labelType' | 'initialLa
       total: 0,
       successes: 0,
       fails: [],
+      uploaded: 0,
+      phase: 'idle',
+      uploadStartedAt: null,
+      runId: null,
     },
     autoTagging: {
       overwrite: overwriteDefault,
@@ -347,14 +372,15 @@ export const useTrainingImageStore = create<TrainingImageStore>()(
     updateImage: (
       modelId,
       mediaType,
-      { matcher, url, name, type, label, appendLabel, invalidLabel, source }
+      { matcher, urlMatcher, url, name, type, label, appendLabel, invalidLabel, source }
     ) => {
       set((state) => {
         setModelState(state, modelId, mediaType);
 
         state[modelId]!.imageList = state[modelId]!.imageList.map((i) => {
-          const shortName = getShortNameFromUrl(i);
-          if (shortName === matcher) {
+          const matches =
+            urlMatcher !== undefined ? i.url === urlMatcher : getShortNameFromUrl(i) === matcher;
+          if (matches) {
             let newLabel = i.label;
             if (label !== undefined) {
               if (appendLabel && i.label.length > 0) {
@@ -459,6 +485,13 @@ export const useTrainingImageStore = create<TrainingImageStore>()(
         state[modelId]!.autoLabeling = { ...state[modelId]!.autoLabeling, ...labelData };
       });
     },
+    mutateAutoLabeling: (modelId, mediaType, update) => {
+      set((state) => {
+        setModelState(state, modelId, mediaType);
+        const current = state[modelId]!.autoLabeling;
+        state[modelId]!.autoLabeling = { ...current, ...update(current) };
+      });
+    },
     setAutoTagging: (modelId, mediaType, labelData) => {
       set((state) => {
         setModelState(state, modelId, mediaType);
@@ -549,6 +582,7 @@ export const trainingStore = {
   setInitialOwnRights: store.setInitialOwnRights,
   setInitialShareDataset: store.setInitialShareDataset,
   setAutoLabeling: store.setAutoLabeling,
+  mutateAutoLabeling: store.mutateAutoLabeling,
   setAutoTagging: store.setAutoTagging,
   setAutoCaptioning: store.setAutoCaptioning,
   addRun: store.addRun,

--- a/src/utils/training/auto-label-orchestrator.ts
+++ b/src/utils/training/auto-label-orchestrator.ts
@@ -67,8 +67,12 @@ export type AutoLabelHandle = {
 
 type SubmittedBatch = {
   workflowId: string;
-  // step.name (the unique batch index "0".."15") → caller's image key.
-  stepNameToKey: Map<string, string>;
+  // The caller's keys for every image in this batch. Used both to recognize
+  // which step.filename values belong to us and to mark the still-unreported
+  // ones as failed if the workflow times out.
+  keys: Set<string>;
+  // Keys we've already emitted onResult/onFailure for, so a retried poll tick
+  // doesn't double-report.
   reported: Set<string>;
 };
 
@@ -236,7 +240,7 @@ function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
  *  network/5xx through TRPCClientError; we treat anything that isn't a 4xx as
  *  retryable since the orchestrator endpoints are idempotent at this layer
  *  (presign mints a fresh URL, submit creates a fresh workflow id). */
-async function withRetry<T>(label: string, fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
+async function withRetry<T>(fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
   try {
     return await raceAbort(fn(), signal);
   } catch (err) {
@@ -244,15 +248,11 @@ async function withRetry<T>(label: string, fn: () => Promise<T>, signal: AbortSi
     const status = (err as { data?: { httpStatus?: number } })?.data?.httpStatus;
     if (status && status >= 400 && status < 500) throw err; // 4xx — caller error, no retry
     await sleep(RETRY_DELAY_MS, signal);
-    // Re-throw the original error on retry-fail so the caller's describeError
-    // can still introspect `data.zodError`. The label is just a tag we attach.
-    return raceAbort(fn(), signal).catch((retryErr) => {
-      if (isAbort(retryErr)) throw retryErr;
-      if (retryErr instanceof Error) {
-        retryErr.message = `${label}: ${retryErr.message}`;
-      }
-      throw retryErr;
-    });
+    // Re-throw the second attempt's error untouched so the caller's
+    // describeError() can still introspect `data.zodError` etc. We intentionally
+    // do NOT mutate the message — that would clobber the JSON shape parsers
+    // downstream rely on for friendly extraction.
+    return raceAbort(fn(), signal);
   }
 }
 
@@ -328,7 +328,6 @@ export async function uploadAndSubmitAutoLabel(
     if (!isStillActive()) return { ok: false, aborted: true, index, key: img.key };
     try {
       const { uploadUrl } = await withRetry(
-        'Presign request',
         () => trpcVanilla.training.getAutoLabelUploadUrl.mutate({ modelId: opts.modelId }),
         signal
       );
@@ -383,7 +382,6 @@ export async function uploadAndSubmitAutoLabel(
     let submission: { workflowId: string };
     try {
       submission = await withRetry(
-        'Workflow submit',
         () =>
           trpcVanilla.training.submitAutoLabelWorkflow.mutate({
             modelId: opts.modelId,
@@ -412,17 +410,12 @@ export async function uploadAndSubmitAutoLabel(
       continue;
     }
 
-    // Server names each step by its zero-based index in the resolved list. We
-    // mirror that here so the poll loop can map step.name → key. NOTE: this is
-    // a contract with the server — see submitAutoLabelWorkflow in
-    // training.service.ts. If the server stops naming steps by index, this
-    // breaks silently.
-    const stepNameToKey = new Map<string, string>();
-    resolved.forEach((r, idx) => stepNameToKey.set(`${idx}`, r.key));
-
+    // We send the caller's key as the step's `filename` (see service-side
+    // metadata). Track expected keys per workflow so the poll loop can match
+    // back via `step.filename` directly — no fragile index-as-name mapping.
     submittedBatches.push({
       workflowId: submission.workflowId,
-      stepNameToKey,
+      keys: new Set(resolved.map((r) => r.key)),
       reported: new Set(),
     });
   }
@@ -434,9 +427,9 @@ export async function uploadAndSubmitAutoLabel(
   const startedAt = Date.now();
 
   const markBatchUnreportedAsFailed = (batch: SubmittedBatch, reason: string) => {
-    for (const [stepName, key] of batch.stepNameToKey) {
-      if (batch.reported.has(stepName)) continue;
-      batch.reported.add(stepName);
+    for (const key of batch.keys) {
+      if (batch.reported.has(key)) continue;
+      batch.reported.add(key);
       recordFailure(key, reason);
     }
   };
@@ -459,8 +452,12 @@ export async function uploadAndSubmitAutoLabel(
       // Snapshot pending IDs for this tick so deletes during the forEach below
       // don't shift the index lookup we'd otherwise need to do later.
       const tickIds = Array.from(pending);
+      // raceAbort each query so a single hung tRPC call can't keep
+      // Promise.allSettled blocked past POLL_TIMEOUT_MS / cancellation.
       const results = await Promise.allSettled(
-        tickIds.map((workflowId) => trpcVanilla.training.getAutoLabelWorkflow.query({ workflowId }))
+        tickIds.map((workflowId) =>
+          raceAbort(trpcVanilla.training.getAutoLabelWorkflow.query({ workflowId }), signal)
+        )
       );
 
       // The await above released the event loop; cancellation may have fired
@@ -475,14 +472,15 @@ export async function uploadAndSubmitAutoLabel(
         if (!batch) return;
 
         for (const step of wf.steps) {
-          if (!step.name) continue;
-          if (batch.reported.has(step.name)) continue;
+          // Server echoes the key we sent in `step.filename`. If it's missing
+          // or doesn't belong to this batch, skip — could be a step we don't
+          // recognize (server changed schema) or a duplicate in the response.
+          const key = step.filename;
+          if (!key || !batch.keys.has(key)) continue;
+          if (batch.reported.has(key)) continue;
           if (!TERMINAL_STEP_STATUSES.has(step.status)) continue;
 
-          const key = batch.stepNameToKey.get(step.name);
-          if (!key) continue;
-
-          batch.reported.add(step.name);
+          batch.reported.add(key);
 
           if (step.status !== 'succeeded') {
             recordFailure(key, describeStepFailure(step));
@@ -510,7 +508,7 @@ export async function uploadAndSubmitAutoLabel(
         // Done if either the workflow itself reports terminal OR every step is
         // already reported. The OR-by-step path covers cases where the
         // orchestrator omits `status` on the workflow envelope.
-        const allStepsReported = batch.stepNameToKey.size === batch.reported.size;
+        const allStepsReported = batch.keys.size === batch.reported.size;
         if (TERMINAL_WORKFLOW_STATUSES.has(wf.status ?? '') || allStepsReported) {
           pending.delete(polledId);
         }

--- a/src/utils/training/auto-label-orchestrator.ts
+++ b/src/utils/training/auto-label-orchestrator.ts
@@ -12,13 +12,21 @@ import { trpcVanilla } from '~/utils/trpc';
 const POLL_INTERVAL_MS = 5000;
 // Hard ceiling so a stuck workflow can't poll forever.
 const POLL_TIMEOUT_MS = 20 * 60 * 1000;
+// Browsers cap at ~6 concurrent requests/origin; staying at 4 leaves headroom
+// for tRPC + image source fetches happening in parallel.
+const UPLOAD_CONCURRENCY = 4;
+// One bounded retry on transient network/5xx for presign + submit. Polling
+// already tolerates per-tick failures via Promise.allSettled.
+const RETRY_DELAY_MS = 1500;
 
 const TERMINAL_WORKFLOW_STATUSES = new Set(['succeeded', 'failed', 'expired', 'canceled']);
 const TERMINAL_STEP_STATUSES = new Set(['succeeded', 'failed', 'expired', 'canceled']);
 
 export type AutoLabelImageInput = {
-  /** Filename used to match the result back to the source image in the store. */
-  filename: string;
+  /** Stable per-image identifier — must be unique across the input list. The
+   *  caller picks this; passing the source URL is a good default since URLs
+   *  don't collide the way short filenames do. */
+  key: string;
   blob: Blob;
 };
 
@@ -33,10 +41,13 @@ type CommonOptions = {
    *  background work cleanly — used to cancel a poll loop when the user resets the
    *  store-level autoLabeling state (e.g. opens a fresh run, navigates away). */
   isActive?: () => boolean;
+  onUploadStart?: () => void;
   onUploadProgress?: (uploaded: number, total: number) => void;
-  onResult?: (filename: string, label: string) => void;
-  onFailure?: (filename: string, reason: string) => void;
-  onDone?: (summary: { successes: number; fails: string[] }) => void;
+  onUploadComplete?: () => void;
+  onResult?: (key: string, label: string) => void;
+  onFailure?: (key: string, reason: string) => void;
+  onFatal?: (reason: string) => void;
+  onDone?: (summary: { successes: number; failedKeys: string[] }) => void;
 };
 
 export type SubmitAutoLabelOptions =
@@ -56,10 +67,8 @@ export type AutoLabelHandle = {
 
 type SubmittedBatch = {
   workflowId: string;
-  // Map step.name (the unique batch index "0".."15") → filename. We dedup on step.name
-  // because two source images can collide on filename (e.g. duplicate uploads), and
-  // step.name is what we actually set when building the workflow.
-  stepNameToFilename: Map<string, string>;
+  // step.name (the unique batch index "0".."15") → caller's image key.
+  stepNameToKey: Map<string, string>;
   reported: Set<string>;
 };
 
@@ -68,24 +77,6 @@ const chunk = <T>(items: T[], size: number): T[][] => {
   for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
   return out;
 };
-
-async function uploadBlobToPresignedUrl(
-  uploadUrl: string,
-  blob: Blob,
-  signal?: AbortSignal
-): Promise<OrchestratorBlob> {
-  const response = await fetch(uploadUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': blob.type || 'application/octet-stream' },
-    body: blob,
-    signal,
-  });
-  if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new Error(`Blob upload failed (${response.status}): ${text}`);
-  }
-  return (await response.json()) as OrchestratorBlob;
-}
 
 const sleep = (ms: number, signal?: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
@@ -100,6 +91,187 @@ const sleep = (ms: number, signal?: AbortSignal) =>
     };
     signal?.addEventListener('abort', onAbort, { once: true });
   });
+
+/** Run `task` over `items` with at most `concurrency` in flight. Preserves
+ *  callsite ordering of returned results regardless of completion order. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  task: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      results[idx] = await task(items[idx], idx);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+/** RFC 7807 problem-details parser. The orchestrator returns
+ *  { type, title, status, detail, traceId } for things like content-policy hits;
+ *  surface `title` + `detail` rather than dumping JSON at the user. */
+function parseOrchestratorProblem(text: string, status: number): string {
+  try {
+    const body = JSON.parse(text) as {
+      title?: string;
+      detail?: string;
+      message?: string;
+    };
+    const parts = [body.title, body.detail].filter(
+      (p): p is string => typeof p === 'string' && p.length > 0
+    );
+    if (parts.length > 0) return parts.join(' — ');
+    if (typeof body.message === 'string' && body.message.length > 0) return body.message;
+  } catch {
+    // not JSON, fall through
+  }
+  // Truncate raw bodies (XML envelopes, HTML, etc.) so the toast stays usable.
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return `HTTP ${status}`;
+  return trimmed.length > 200 ? `${trimmed.slice(0, 200)}…` : trimmed;
+}
+
+class UploadError extends Error {
+  constructor(public readonly status: number, public readonly reason: string) {
+    super(reason);
+    this.name = 'UploadError';
+  }
+  /** True for cases that re-uploading won't help with — content policy etc. */
+  get isPermanent() {
+    return this.status === 422 || this.status === 415 || this.status === 413;
+  }
+}
+
+async function uploadBlobToPresignedUrl(
+  uploadUrl: string,
+  blob: Blob,
+  signal?: AbortSignal
+): Promise<OrchestratorBlob> {
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': blob.type || 'application/octet-stream' },
+    body: blob,
+    signal,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new UploadError(response.status, parseOrchestratorProblem(text, response.status));
+  }
+  return (await response.json()) as OrchestratorBlob;
+}
+
+const isAbort = (err: unknown) => (err as DOMException | undefined)?.name === 'AbortError';
+
+/** Translate tRPC / orchestrator errors into a single short, user-readable line.
+ *  tRPC stuffs the serialized zod issue array into `err.message`, so without
+ *  this users see things like
+ *    `[ { "code": "custom", "path": [...], "message": "..." }, ... ]`
+ *  in their toast. We prefer the structured `data.zodError` if present, then
+ *  fall back to the message — but if the message looks like JSON, we try to
+ *  pull a sensible summary out instead of dumping it. */
+function describeError(err: unknown): string {
+  if (typeof err === 'string') return err;
+  if (!(err instanceof Error)) return 'Unknown error';
+
+  const data = (err as { data?: { code?: string; zodError?: unknown } }).data;
+  const zodError = data?.zodError as
+    | {
+        formErrors?: string[];
+        fieldErrors?: Record<string, string[] | undefined>;
+      }
+    | undefined;
+  if (zodError) {
+    const fieldMessages = Object.values(zodError.fieldErrors ?? {})
+      .flat()
+      .filter((m): m is string => typeof m === 'string' && m.length > 0);
+    const firstMessage = fieldMessages[0] ?? zodError.formErrors?.[0];
+    if (firstMessage) return firstMessage;
+  }
+
+  const msg = err.message ?? '';
+  // tRPC sometimes puts the raw zod issue array straight into `message`.
+  // Try to pull the first issue's `message` field instead of dumping JSON.
+  if (msg.startsWith('[')) {
+    try {
+      const issues = JSON.parse(msg) as Array<{ message?: string }>;
+      const firstMessage = issues.find(
+        (i) => typeof i.message === 'string' && i.message.length > 0
+      )?.message;
+      if (firstMessage) return firstMessage;
+    } catch {
+      // not JSON — fall through
+    }
+    return 'Server rejected the request';
+  }
+  return msg.length > 200 ? `${msg.slice(0, 200)}…` : msg;
+}
+
+/** Race a promise against a signal so we don't await forever if `fn()` is hung
+ *  (server stall, dropped connection, etc.). The underlying call keeps running
+ *  in the background but we stop blocking the worker pool. */
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new DOMException('Aborted', 'AbortError'));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (v) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(v);
+      },
+      (e) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(e);
+      }
+    );
+  });
+}
+
+/** Wrap a tRPC call with one bounded retry on transient errors. tRPC surfaces
+ *  network/5xx through TRPCClientError; we treat anything that isn't a 4xx as
+ *  retryable since the orchestrator endpoints are idempotent at this layer
+ *  (presign mints a fresh URL, submit creates a fresh workflow id). */
+async function withRetry<T>(label: string, fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
+  try {
+    return await raceAbort(fn(), signal);
+  } catch (err) {
+    if (isAbort(err)) throw err;
+    const status = (err as { data?: { httpStatus?: number } })?.data?.httpStatus;
+    if (status && status >= 400 && status < 500) throw err; // 4xx — caller error, no retry
+    await sleep(RETRY_DELAY_MS, signal);
+    // Re-throw the original error on retry-fail so the caller's describeError
+    // can still introspect `data.zodError`. The label is just a tag we attach.
+    return raceAbort(fn(), signal).catch((retryErr) => {
+      if (isAbort(retryErr)) throw retryErr;
+      if (retryErr instanceof Error) {
+        retryErr.message = `${label}: ${retryErr.message}`;
+      }
+      throw retryErr;
+    });
+  }
+}
+
+/** Best-effort extraction of a friendly per-step failure reason from the
+ *  workflow payload. The shape varies by orchestrator version, so probe a few
+ *  spots; fall back to the status word. */
+function describeStepFailure(step: { status: string; error?: unknown; output?: unknown }): string {
+  const error = step.error as { message?: string; detail?: string; title?: string } | undefined;
+  if (error) {
+    const parts = [error.title, error.detail ?? error.message].filter(
+      (p): p is string => typeof p === 'string' && p.length > 0
+    );
+    if (parts.length > 0) return parts.join(' — ');
+  }
+  const output = step.output as { error?: string; message?: string } | null | undefined;
+  if (output?.error) return output.error;
+  if (output?.message) return output.message;
+  return step.status === 'failed' ? 'Step failed' : `Step ${step.status}`;
+}
 
 /**
  * Upload N images to the orchestrator, submit one workflow per batch (up to
@@ -128,77 +300,144 @@ export async function uploadAndSubmitAutoLabel(
 
   const isStillActive = () => !signal.aborted && (opts.isActive?.() ?? true);
 
-  const batches = chunk(opts.images, AUTO_LABEL_BATCH_SIZE);
   const totalImages = opts.images.length;
-
   let uploaded = 0;
   let successes = 0;
-  const fails: string[] = [];
+  // Set so a key never gets counted twice if e.g. submit fails AND a later
+  // poll-timeout sweep tries to mark the same key.
+  const failedKeys = new Set<string>();
+  const recordFailure = (key: string, reason: string) => {
+    if (!key || failedKeys.has(key)) return;
+    failedKeys.add(key);
+    opts.onFailure?.(key, reason);
+  };
   const submittedBatches: SubmittedBatch[] = [];
 
-  // ---- Phase A: upload + submit each batch sequentially. Submitting per-batch
-  // (instead of one giant workflow) keeps each workflow at ≤AUTO_LABEL_BATCH_SIZE
-  // steps so the orchestrator can schedule them concurrently, and isolates
-  // failures to a single batch instead of an entire run.
-  for (const batch of batches) {
-    if (!isStillActive()) throw new DOMException('Aborted', 'AbortError');
+  // ---- Phase A: upload everything concurrently. We presign + upload per image
+  // (idempotent on the orchestrator side) and only chunk into workflows after
+  // all uploads finish, so a slow upload doesn't block the UI from showing
+  // overall progress.
+  opts.onUploadStart?.();
 
-    const resolved: { mediaUrl: string; filename: string }[] = [];
-    for (const img of batch) {
-      if (!isStillActive()) throw new DOMException('Aborted', 'AbortError');
-      const { uploadUrl } = await trpcVanilla.training.getAutoLabelUploadUrl.mutate();
+  type UploadResult =
+    | { ok: true; index: number; mediaUrl: string; key: string }
+    | { ok: false; index: number; key: string }
+    | { ok: false; aborted: true; index: number; key: string };
+
+  const uploadOne = async (img: AutoLabelImageInput, index: number): Promise<UploadResult> => {
+    if (!isStillActive()) return { ok: false, aborted: true, index, key: img.key };
+    try {
+      const { uploadUrl } = await withRetry(
+        'Presign request',
+        () => trpcVanilla.training.getAutoLabelUploadUrl.mutate({ modelId: opts.modelId }),
+        signal
+      );
       const result = await uploadBlobToPresignedUrl(uploadUrl, img.blob, signal);
       if (!result.url) {
-        // Treat missing URL as a per-image failure rather than aborting the batch.
-        fails.push(img.filename);
-        opts.onFailure?.(img.filename, 'Upload returned no URL');
-        continue;
+        recordFailure(img.key, 'Upload returned no URL');
+        return { ok: false, index, key: img.key };
       }
-      resolved.push({ mediaUrl: result.url, filename: img.filename });
       uploaded += 1;
       opts.onUploadProgress?.(uploaded, totalImages);
+      return { ok: true, index, mediaUrl: result.url, key: img.key };
+    } catch (err) {
+      // Abort is expected on cancel — report as aborted, don't toast.
+      if (isAbort(err)) return { ok: false, aborted: true, index, key: img.key };
+      const reason = describeError(err);
+      recordFailure(img.key, reason);
+      return { ok: false, index, key: img.key };
+    }
+  };
+
+  const uploadResults = await mapWithConcurrency(opts.images, UPLOAD_CONCURRENCY, uploadOne);
+
+  // If we were aborted mid-upload, bail without firing onDone — the caller is
+  // tearing this run down (cancel button, fresh run, etc.) and shouldn't see
+  // a "labeled 0 images" toast.
+  if (signal.aborted) {
+    return {
+      workflowIds: [],
+      cancel: () => internal.abort(),
+    };
+  }
+
+  const succeededUploads = uploadResults.filter(
+    (r): r is Extract<UploadResult, { ok: true }> => r.ok
+  );
+
+  opts.onUploadComplete?.();
+
+  // ---- Phase B: submit batches. Per-batch (instead of one giant workflow)
+  // keeps each workflow at ≤AUTO_LABEL_BATCH_SIZE steps so the orchestrator
+  // can schedule them concurrently, and isolates failures to a single batch.
+  const batches = chunk(succeededUploads, AUTO_LABEL_BATCH_SIZE);
+
+  for (const batch of batches) {
+    if (!isStillActive()) {
+      return { workflowIds: [], cancel: () => internal.abort() };
+    }
+    if (batch.length === 0) continue;
+
+    const resolved = batch.map((b) => ({ mediaUrl: b.mediaUrl, filename: b.key, key: b.key }));
+
+    let submission: { workflowId: string };
+    try {
+      submission = await withRetry(
+        'Workflow submit',
+        () =>
+          trpcVanilla.training.submitAutoLabelWorkflow.mutate({
+            modelId: opts.modelId,
+            mediaType: opts.mediaType,
+            // Server takes filename for orchestrator metadata; we use the key
+            // value because it's already stable+unique. Display filenames are
+            // resolved client-side from the key.
+            images: resolved.map((r) => ({ mediaUrl: r.mediaUrl, filename: r.filename })),
+            params:
+              opts.type === 'tag'
+                ? { type: 'tag', threshold: opts.params.threshold }
+                : {
+                    type: 'caption',
+                    temperature: opts.params.temperature,
+                    maxNewTokens: opts.params.maxNewTokens,
+                  },
+          }),
+        signal
+      );
+    } catch (err) {
+      if (isAbort(err)) {
+        return { workflowIds: [], cancel: () => internal.abort() };
+      }
+      const reason = describeError(err);
+      for (const r of resolved) recordFailure(r.key, reason);
+      continue;
     }
 
-    if (resolved.length === 0) continue;
-
-    const submission = await trpcVanilla.training.submitAutoLabelWorkflow.mutate({
-      modelId: opts.modelId,
-      mediaType: opts.mediaType,
-      images: resolved,
-      params:
-        opts.type === 'tag'
-          ? { type: 'tag', threshold: opts.params.threshold }
-          : {
-              type: 'caption',
-              temperature: opts.params.temperature,
-              maxNewTokens: opts.params.maxNewTokens,
-            },
-    });
-
     // Server names each step by its zero-based index in the resolved list. We
-    // mirror that here so the poll loop can map step.name → filename.
-    const stepNameToFilename = new Map<string, string>();
-    resolved.forEach((r, idx) => stepNameToFilename.set(`${idx}`, r.filename));
+    // mirror that here so the poll loop can map step.name → key. NOTE: this is
+    // a contract with the server — see submitAutoLabelWorkflow in
+    // training.service.ts. If the server stops naming steps by index, this
+    // breaks silently.
+    const stepNameToKey = new Map<string, string>();
+    resolved.forEach((r, idx) => stepNameToKey.set(`${idx}`, r.key));
 
     submittedBatches.push({
       workflowId: submission.workflowId,
-      stepNameToFilename,
+      stepNameToKey,
       reported: new Set(),
     });
   }
 
-  // ---- Phase B: poll every workflow until all steps are terminal, applying
+  // ---- Phase C: poll every workflow until all steps are terminal, applying
   // post-processing as results land. Polling runs as a side effect; the caller
   // observes progress through the callbacks. The promise we return resolves as
   // soon as the submit phase is done so the UI can drop the spinner.
   const startedAt = Date.now();
 
   const markBatchUnreportedAsFailed = (batch: SubmittedBatch, reason: string) => {
-    for (const [stepName, filename] of batch.stepNameToFilename) {
+    for (const [stepName, key] of batch.stepNameToKey) {
       if (batch.reported.has(stepName)) continue;
       batch.reported.add(stepName);
-      fails.push(filename);
-      opts.onFailure?.(filename, reason);
+      recordFailure(key, reason);
     }
   };
 
@@ -221,10 +460,12 @@ export async function uploadAndSubmitAutoLabel(
       // don't shift the index lookup we'd otherwise need to do later.
       const tickIds = Array.from(pending);
       const results = await Promise.allSettled(
-        tickIds.map((workflowId) =>
-          trpcVanilla.training.getAutoLabelWorkflow.query({ workflowId })
-        )
+        tickIds.map((workflowId) => trpcVanilla.training.getAutoLabelWorkflow.query({ workflowId }))
       );
+
+      // The await above released the event loop; cancellation may have fired
+      // while we were waiting for tRPC. Bail before processing/emitting.
+      if (!isStillActive()) return;
 
       results.forEach((result, idx) => {
         const polledId = tickIds[idx];
@@ -238,14 +479,13 @@ export async function uploadAndSubmitAutoLabel(
           if (batch.reported.has(step.name)) continue;
           if (!TERMINAL_STEP_STATUSES.has(step.status)) continue;
 
-          const filename = batch.stepNameToFilename.get(step.name);
-          if (!filename) continue;
+          const key = batch.stepNameToKey.get(step.name);
+          if (!key) continue;
 
           batch.reported.add(step.name);
 
           if (step.status !== 'succeeded') {
-            fails.push(filename);
-            opts.onFailure?.(filename, `Step ${step.status}`);
+            recordFailure(key, describeStepFailure(step));
             continue;
           }
 
@@ -259,16 +499,19 @@ export async function uploadAndSubmitAutoLabel(
             label = applyCaptionPostProcess(rawCaption);
           }
 
-          if (label && isStillActive()) {
+          if (label) {
             successes += 1;
-            opts.onResult?.(filename, label);
-          } else if (!label) {
-            fails.push(filename);
-            opts.onFailure?.(filename, 'Empty result');
+            opts.onResult?.(key, label);
+          } else {
+            recordFailure(key, 'Empty result');
           }
         }
 
-        if (TERMINAL_WORKFLOW_STATUSES.has(wf.status ?? '')) {
+        // Done if either the workflow itself reports terminal OR every step is
+        // already reported. The OR-by-step path covers cases where the
+        // orchestrator omits `status` on the workflow envelope.
+        const allStepsReported = batch.stepNameToKey.size === batch.reported.size;
+        if (TERMINAL_WORKFLOW_STATUSES.has(wf.status ?? '') || allStepsReported) {
           pending.delete(polledId);
         }
       });
@@ -276,15 +519,24 @@ export async function uploadAndSubmitAutoLabel(
       if (pending.size > 0) await sleep(POLL_INTERVAL_MS, signal);
     }
 
-    if (isStillActive()) opts.onDone?.({ successes, fails });
+    if (isStillActive()) opts.onDone?.({ successes, failedKeys: Array.from(failedKeys) });
   };
 
-  poll().catch((err) => {
-    if ((err as DOMException)?.name === 'AbortError') return;
-    // Surface unexpected errors as a global failure marker.
-    opts.onFailure?.('', err instanceof Error ? err.message : String(err));
-    opts.onDone?.({ successes, fails });
-  });
+  // If every upload failed there's nothing to poll — emit done synchronously
+  // so the caller's spinner doesn't hang forever.
+  if (submittedBatches.length === 0) {
+    if (isStillActive()) opts.onDone?.({ successes, failedKeys: Array.from(failedKeys) });
+  } else {
+    poll().catch((err) => {
+      if (isAbort(err)) return;
+      // Catastrophic poll failure (not per-image): surface separately so the
+      // UI can show a real error toast instead of pretending it was a
+      // per-image failure.
+      const reason = describeError(err);
+      opts.onFatal?.(reason);
+      if (isStillActive()) opts.onDone?.({ successes, failedKeys: Array.from(failedKeys) });
+    });
+  }
 
   return {
     workflowIds: submittedBatches.map((b) => b.workflowId),


### PR DESCRIPTION
  surface friendly errors

  - Cancel any prior in-flight run on resubmit (module-level handle map) and gate background callbacks on a per-run id, so a stale poll loop cannot scribble into a fresh run's labels.
  - Race tRPC calls against the abort signal so a hung request cannot block the upload worker pool forever.
  - Switch helper API from filename to caller-supplied key (image URL) and add urlMatcher to the store's updateImage so duplicate-named uploads no longer label each other or double-count failures.
  - Use mutateAutoLabeling (read-modify-write inside immer) for all callback updates to avoid concurrent-tick counter drift.
  - Add a preparing phase rendered while source blobs are being read, so the progress card no longer shows 'Uploading 0/N' for the entire fetch window.
  - Stop showing 'Failed to send data' on user-initiated cancel; surface catastrophic poll failures via a new onFatal callback instead of faking a per-image failure.
  - Translate orchestrator validation errors into a single readable line (zodError fields, then message JSON parsing) instead of dumping the raw zod issue array into the toast.
  - Scope getAutoLabelUploadUrl to a model the user owns to prevent unscoped abuse of the system-token blob store.
  - Schema only enforces a sane HTTPS URL: captioning works with any image, no orchestrator-host requirement.
  - Read the new orchestrator client baseUrl from ORCHESTRATOR_ENDPOINT instead of hardcoding it.