### PR TITLE
fix(settings): stop mature-content toggle reverting after session refresh

### DIFF
--- a/src/components/CivitaiWrapped/CivitaiSessionProvider.tsx
+++ b/src/components/CivitaiWrapped/CivitaiSessionProvider.tsx
@@ -32,6 +32,13 @@ export function CivitaiSessionProvider({
   const { data: settings } = trpc.user.getSettings.useQuery();
   const settingsAllowAds = settings?.allowAds;
   const settingsDisableHidden = settings?.disableHidden;
+  // User-column toggles now ride the same React Query cache so
+  // `BrowserSettingsProvider`'s onSuccess can patch them in-place and avoid
+  // the stale-session race (where NextAuth session refresh lags behind the
+  // mutation and smart-merge flips the toggle back).
+  const settingsShowNsfw = settings?.showNsfw;
+  const settingsBlurNsfw = settings?.blurNsfw;
+  const settingsAutoplayGifs = settings?.autoplayGifs;
 
   const sessionUser = useMemo(() => {
     if (!user)
@@ -52,12 +59,14 @@ export function CivitaiSessionProvider({
       refresh: update,
       tier: user.tier ?? 'free',
       settings: {
-        showNsfw: user.showNsfw,
+        // Prefer the getSettings cache (patched instantly on mutation) over
+        // session.user (lagging behind until the JWT cookie is refreshed).
+        showNsfw: settingsShowNsfw ?? user.showNsfw,
         browsingLevel: isRestricted ? sfwBrowsingLevelsFlag : user.browsingLevel,
         disableHidden: settingsDisableHidden ?? disableHidden ?? true,
         allowAds: settingsAllowAds ?? !isMember ? true : false,
-        autoplayGifs: user.autoplayGifs ?? true,
-        blurNsfw: user.blurNsfw,
+        autoplayGifs: settingsAutoplayGifs ?? user.autoplayGifs ?? true,
+        blurNsfw: settingsBlurNsfw ?? user.blurNsfw,
       },
     };
     if (!allowMatureContent)
@@ -72,6 +81,9 @@ export function CivitaiSessionProvider({
     isRestricted,
     settingsAllowAds,
     settingsDisableHidden,
+    settingsShowNsfw,
+    settingsBlurNsfw,
+    settingsAutoplayGifs,
   ]);
 
   useEffect(() => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -51,7 +51,7 @@ import { IsClientProvider } from '~/providers/IsClientProvider';
 // import { PaypalProvider } from '~/providers/PaypalProvider';
 // import { StripeSetupSuccessProvider } from '~/providers/StripeProvider';
 import { ThemeProvider } from '~/providers/ThemeProvider';
-import type { UserSettingsSchema } from '~/server/schema/user.schema';
+import type { UserContentSettings } from '~/server/schema/user.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { ParsedCookies } from '~/shared/utils/cookies';
 import { parseCookies } from '~/shared/utils/cookies';
@@ -84,7 +84,7 @@ type CustomAppProps = {
   cookies: ParsedCookies;
   flags: FeatureAccess;
   seed: number;
-  settings: UserSettingsSchema;
+  settings: UserContentSettings;
   canIndex: boolean;
   hasAuthCookie: boolean;
   region: RegionInfo;
@@ -293,7 +293,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   const { settings, session } = await fetch(`${baseUrl as string}/api/user/settings`, {
     headers: { ...request.headers } as HeadersInit,
   }).then(async (res) => {
-    const data: { settings: UserSettingsSchema; session: Session | null } = await res.json();
+    const data: { settings: UserContentSettings; session: Session | null } = await res.json();
     return data;
   });
   // Pass this via the request so we can use it in SSR

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -1,4 +1,4 @@
-import { getUserSettings } from '~/server/services/user.service';
+import { getUserContentSettings } from '~/server/services/user.service';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 
@@ -6,7 +6,9 @@ export default PublicEndpoint(
   async function handler(req, res) {
     try {
       const session = await getServerAuthSession({ req, res });
-      const settings = await getUserSettings(session?.user?.id ?? -1);
+      // Use the content-settings view so SSR initialData matches the tRPC
+      // getSettings response shape (JSON settings + User-column toggles).
+      const settings = await getUserContentSettings(session?.user?.id ?? -1);
       res.status(200).json({
         settings,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
-import type { UserSettingsSchema } from '~/server/schema/user.schema';
+import type { UserContentSettings } from '~/server/schema/user.schema';
 import type { RegionInfo } from '~/server/utils/region-blocking';
 import type { ColorDomain, ServerDomains } from '~/shared/constants/domain.constants';
 import { setServerDomains } from '~/utils/sync-account';
@@ -7,7 +7,7 @@ import { trpc } from '~/utils/trpc';
 
 type AppProviderProps = {
   children: React.ReactNode;
-  settings: UserSettingsSchema;
+  settings: UserContentSettings;
   seed: number;
   canIndex: boolean;
   region: RegionInfo;

--- a/src/providers/BrowserSettingsProvider.tsx
+++ b/src/providers/BrowserSettingsProvider.tsx
@@ -11,7 +11,7 @@ import { devtools } from 'zustand/middleware';
 import type { NsfwLevel } from '~/server/common/enums';
 import type { ColorDomain } from '~/shared/constants/domain.constants';
 import { useDomainColor } from '~/hooks/useDomainColor';
-import type { UserSettingsSchema } from '~/server/schema/user.schema';
+import type { UserContentSettings } from '~/server/schema/user.schema';
 
 const Context = createContext<ContentSettingsStore | null>(null);
 
@@ -22,19 +22,29 @@ export function BrowserSettingsProvider({ children }: { children: React.ReactNod
   const queryUtils = trpc.useUtils();
   const { mutate } = trpc.user.updateContentSettings.useMutation({
     onSuccess: (_, variables) => {
-      const changedSettings: Partial<UserSettingsSchema> = {};
+      // Patch every confirmed field into the getSettings React Query cache so
+      // `CivitaiSessionProvider` sees the user's intent immediately, instead
+      // of the stale `session.user.*` values that live behind the JWT cookie
+      // until the next SignalR/session refresh. Without this the smart-merge
+      // below would read store==snapshot (both true) as "not dirty" and
+      // apply the stale server value, reverting the user's toggle.
+      const changedSettings: Partial<UserContentSettings> = {};
       if (variables.allowAds !== undefined) changedSettings.allowAds = variables.allowAds;
       if (variables.disableHidden !== undefined)
         changedSettings.disableHidden = variables.disableHidden;
+      if (variables.showNsfw !== undefined) changedSettings.showNsfw = variables.showNsfw;
+      if (variables.blurNsfw !== undefined) changedSettings.blurNsfw = variables.blurNsfw;
+      if (variables.autoplayGifs !== undefined)
+        changedSettings.autoplayGifs = variables.autoplayGifs;
 
       if (Object.keys(changedSettings).length === 0) return;
 
       // Cancel any in-flight getSettings refetch so a stale response
       // (e.g. triggered by window focus) can't overwrite this update.
       queryUtils.user.getSettings.cancel();
-      queryUtils.user.getSettings.setData(undefined, (old) => {
+      queryUtils.user.getSettings.setData(undefined, (old: UserContentSettings | undefined) => {
         if (!old) return old;
-        return { ...old, ...changedSettings } satisfies UserSettingsSchema;
+        return { ...old, ...changedSettings } satisfies UserContentSettings;
       });
     },
     onError: (error) => {

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -83,6 +83,7 @@ import {
   getUserList,
   getUserPurchasedRewards,
   getUsers,
+  getUserContentSettings,
   getUserSettings,
   setDismissedAlerts,
   getUsersWithSearch,
@@ -1343,9 +1344,10 @@ export const toggleUserFeatureFlagHandler = async ({
 export const getUserSettingsHandler = async ({ ctx }: { ctx: DeepNonNullable<Context> }) => {
   try {
     const { id } = ctx.user;
-    const settings = await getUserSettings(id);
+    // Return JSON settings *and* the User-column content toggles so the client
+    // can patch all of them in a single React Query cache on mutation success.
+    const settings = await getUserContentSettings(id);
 
-    // Limits it to the input type
     return settings;
   } catch (error) {
     throw throwDbError(error);

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -235,6 +235,18 @@ export type UserAssistantPersonality = z.infer<typeof userAssistantPersonality>;
 
 export type UserSettingsInput = z.input<typeof userSettingsSchema>;
 export type UserSettingsSchema = z.infer<typeof userSettingsSchema>;
+
+/**
+ * JSON user settings plus the handful of content-preference columns on the
+ * User table that we also expose through `user.getSettings`. These columns
+ * ride the same React Query cache so mutations can patch them in-place and
+ * avoid the stale-session race the JWT/session path is prone to.
+ */
+export type UserContentSettings = UserSettingsSchema & {
+  showNsfw?: boolean;
+  blurNsfw?: boolean;
+  autoplayGifs?: boolean | null;
+};
 export const userSettingsSchema = z.object({
   newsletterDialogLastSeenAt: z.coerce.date().nullish(),
   features: z.record(z.string(), z.boolean()).optional(),

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -48,6 +48,7 @@ import type {
   ToggleBanUser,
   ToggleUserBountyEngagementsInput,
   UpdateContentSettingsInput,
+  UserContentSettings,
   UserMeta,
   UserSettingsInput,
 } from '~/server/schema/user.schema';
@@ -1940,7 +1941,11 @@ export async function updateContentSettings({
 
     await setUserSetting(userId, { ...settings, ...removeEmpty(data) });
   }
-  refreshSession(userId).catch((err) => {
+  // Await so the refresh marker is set in Redis before this mutation returns.
+  // Otherwise the fire-and-forget can race the next API call / session read
+  // and hand back a stale session.user, which then overrides the user's
+  // toggle client-side via BrowserSettingsProvider's smart-merge.
+  await refreshSession(userId).catch((err) => {
     console.error('Failed to refresh session for user', userId, err);
   });
 }
@@ -1959,25 +1964,76 @@ export const getUserByPaddleCustomerId = async ({
 };
 
 // #region [user settings]
-const userSettingsCache = createCachedObject<UserSettingsSchema & { userId: number }>({
+// User-level content preference columns that we cache alongside the settings
+// JSON so the client can patch them in one place (see getUserContentSettings).
+// Public type `UserContentSettings` lives in `~/server/schema/user.schema` so
+// client code can import it without dragging the service module into the
+// browser bundle.
+type CachedUserSettings = UserSettingsSchema & {
+  userId: number;
+  showNsfw: boolean;
+  blurNsfw: boolean;
+  autoplayGifs: boolean | null;
+};
+
+const userSettingsCache = createCachedObject<CachedUserSettings>({
   key: REDIS_KEYS.USER.SETTINGS,
   idKey: 'userId',
   ttl: CacheTTL.hour * 4,
   staleWhileRevalidate: false,
   lookupFn: async (ids) => {
-    const settings = await dbWrite.$queryRaw<{ id: number; settings: UserSettingsSchema }[]>`
-    SELECT id, settings
+    const rows = await dbWrite.$queryRaw<
+      {
+        id: number;
+        settings: UserSettingsSchema | null;
+        showNsfw: boolean;
+        blurNsfw: boolean;
+        autoplayGifs: boolean | null;
+      }[]
+    >`
+    SELECT id, settings, "showNsfw", "blurNsfw", "autoplayGifs"
     FROM "User"
     WHERE id IN (${Prisma.join(ids)})
   `;
-    return Object.fromEntries(settings.map((x) => [x.id, { userId: x.id, ...x.settings }]));
+    return Object.fromEntries(
+      rows.map((x) => [
+        x.id,
+        {
+          userId: x.id,
+          ...((x.settings ?? {}) as UserSettingsSchema),
+          showNsfw: x.showNsfw,
+          blurNsfw: x.blurNsfw,
+          autoplayGifs: x.autoplayGifs,
+        },
+      ])
+    );
   },
 });
 
-export async function getUserSettings(id: number) {
+/**
+ * JSON-settings-only view. Used by internal callers (e.g. setUserSetting) that
+ * need to read the JSON blob and write it back without polluting it with the
+ * User-column fields.
+ */
+export async function getUserSettings(id: number): Promise<UserSettingsSchema> {
   const result = await userSettingsCache.fetch([id]);
-  const { userId, ...settings } = result[id] ?? {};
+  const raw = result[id];
+  if (!raw) return {};
+  const { userId, showNsfw, blurNsfw, autoplayGifs, ...settings } = raw;
   return settings;
+}
+
+/**
+ * Full content settings view (JSON settings + User-column preferences).
+ * Use this for the tRPC `user.getSettings` endpoint / SSR hydration so the
+ * client can patch all toggles in a single React Query cache.
+ */
+export async function getUserContentSettings(id: number): Promise<UserContentSettings> {
+  const result = await userSettingsCache.fetch([id]);
+  const raw = result[id];
+  if (!raw) return {};
+  const { userId, ...rest } = raw;
+  return rest;
 }
 
 export async function setUserSetting(userId: number, settings: UserSettingsInput) {


### PR DESCRIPTION
## Summary
- Moves `showNsfw` / `blurNsfw` / `autoplayGifs` into the `user.getSettings` React Query cache so `BrowserSettingsProvider.onSuccess` can patch them in-place — parallels the `disableHidden` / `allowAds` fix in c2f76c21d.
- Awaits `refreshSession` in `updateContentSettings` so the Redis refresh marker is set before the mutation returns (no more fire-and-forget racing the client).
- `CivitaiSessionProvider` now prefers the patched cache over `session.user.*` (with session fallback for bootstrap).

## Context
[ClickUp: Enable Mature content resets](https://app.clickup.com/t/868jc3g7w). Multiple users reported the _Enable mature content_ toggle flipping itself off within ~1 minute. Root cause is a race between mutation success and NextAuth session refresh — before the signal/cookie-refresh path updates the client session, a rebuild of `settings` produced stale values, and the smart-merge saw store == snapshot as "not dirty" and reapplied the stale session value back over the user's toggle.

## Safety on civitai.com (green)
The `if (!allowMatureContent)` override in `CivitaiSessionProvider` still forces `showNsfw: false` / `blurNsfw: true` / `browsingLevel: publicBrowsingLevelsFlag` on green, regardless of what the DB or getSettings cache contains. Server handlers (`orchestrator.router.ts`, `comics.router.ts`, etc.) still gate on `ctx.domain === 'green'`. `ModerationCard` is still hidden on green via `canViewNsfw`. Verified no new code path reads `getSettings.showNsfw` outside the two providers we control.

## Scope note
Intentionally left `browsingLevel` out of the `getSettings` extension — on civitai.red it's stored as `redBrowsingLevel` in the JSON column rather than `User.browsingLevel`, so folding it in cleanly needs domain-aware handling that deserves its own PR. Not the field users are reporting.

## Test plan
- [ ] Enable mature content on civitai.red → reload, navigate around → toggle stays on (previous behaviour: reverted within ~1 min)
- [ ] Disable mature content on civitai.red → toggle stays off
- [ ] Toggle `blur mature content` → persists
- [ ] Toggle `autoplay GIFs` on blue → persists
- [ ] On civitai.com (green) verify `ModerationCard` is still hidden, mature content stays hidden, feed filters unchanged even if the user has `showNsfw: true` in DB from red
- [ ] Typecheck + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)