### PR TITLE
fix(api): restore modelId filter and engagement sort on /api/v1/images

### DIFF
--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -8,7 +8,11 @@ import { isProd } from '~/env/other';
 import { constants } from '~/server/common/constants';
 import { ImageSort } from '~/server/common/enums';
 import { buildFliptContext, getFeatureFlags } from '~/server/services/feature-flags.service';
-import { getAllImages, getAllImagesIndex, getImagesFromFeedSearch } from '~/server/services/image.service';
+import {
+  getAllImages,
+  getAllImagesIndex,
+  getImagesFromFeedSearch,
+} from '~/server/services/image.service';
 import { FLIPT_FEATURE_FLAGS, getFliptVariant } from '~/server/flipt/client';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
@@ -113,9 +117,10 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     );
     const useBitdex = bitdexMode === 'shadow' || bitdexMode === 'primary';
 
-    // Use legacy getAllImages for specific model/image lookups (unless BitDex active),
-    // BitDex getAllImagesIndex when flag is active, or feed search for index queries.
-    const useLegacyMethod = data.imageId || (!useBitdex && data.modelId);
+    // Always route modelId/imageId lookups through legacy getAllImages — BitDex
+    // and Meili feed search don't support filtering by modelId/imageId (they index
+    // postedToId/modelVersionId only), so they'd silently return the global feed.
+    const useLegacyMethod = data.imageId || data.modelId;
 
     const { items, nextCursor } = useLegacyMethod
       ? await getAllImages({

--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -125,6 +125,15 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     // requests flow through the search index so engagement sorts
     // (MostReactions/MostComments/MostCollected) work, since getAllImages's gallery
     // sort branches for those are currently disabled. Fixes #2134.
+    //
+    // KNOWN LIMITATION: when only `modelId` is passed (no `modelVersionId`), the
+    // legacy DB path is the only option, and its MostReactions/MostComments/
+    // MostCollected branches are intentionally commented out at
+    // image.service.ts:1414-1422 with a `// TODO this causes the app to spike`
+    // note. As a result, those sorts collapse to newest-by-id for `modelId`-only
+    // queries. Callers that need engagement-sorted galleries should also pass a
+    // specific `modelVersionId`, which routes through the search index where
+    // those sorts are honored.
     const useLegacyMethod = data.imageId || (data.modelId && !data.modelVersionId);
 
     const { items, nextCursor } = useLegacyMethod

--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -120,7 +120,12 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     // Always route modelId/imageId lookups through legacy getAllImages — BitDex
     // and Meili feed search don't support filtering by modelId/imageId (they index
     // postedToId/modelVersionId only), so they'd silently return the global feed.
-    const useLegacyMethod = data.imageId || data.modelId;
+    // When both modelId and modelVersionId are passed, modelId is redundant
+    // (getAllImages also silently ignores it via an `else if` chain) — let those
+    // requests flow through the search index so engagement sorts
+    // (MostReactions/MostComments/MostCollected) work, since getAllImages's gallery
+    // sort branches for those are currently disabled. Fixes #2134.
+    const useLegacyMethod = data.imageId || (data.modelId && !data.modelVersionId);
 
     const { items, nextCursor } = useLegacyMethod
       ? await getAllImages({


### PR DESCRIPTION
## Summary
Two related routing fixes on the public `/api/v1/images` endpoint:

1. **`?modelId=…` returns the global feed (#2126)** — the BitDex routing added in `11af194f5` sent `modelId` queries to `getAllImagesIndex` / `getImagesFromSearch`, which lists `modelId` in `cantProcess` (image.service.ts:2802-2810) and only logs it to Axiom. The filter was silently dropped and the endpoint returned the unfiltered global feed whenever the BitDex Flipt cohort was active. Mirrors the imageId fix from `d3c94cd6d`.

2. **`?modelId=…&modelVersionId=…` ignores engagement sort (#2134)** — when both IDs were passed, the request was forced to legacy `getAllImages`, whose `MostReactions` / `MostComments` / `MostCollected` gallery sort branches are commented out (image.service.ts:1414-1422, with a `// TODO this causes the app to spike` note). Since `modelVersionId` is strictly more specific than `modelId` — and `getAllImages` already silently drops `modelId` via an `else if` chain when both are set (image.service.ts:1250-1258) — we now let those requests flow through the search index path, which honors both `postedToId` filter and engagement sorts.

Final routing rule:
```ts
const useLegacyMethod = data.imageId || (data.modelId && !data.modelVersionId);
```

## Why #2126 was intermittent
BitDex is gated by the `BITDEX_IMAGE_SEARCH` Flipt flag. As the rollout cohort shifts, the same `?modelId=…` URL flips between working (legacy path) and broken (BitDex path) — matching user reports of "sometimes works, then breaks."

## Known limitation (worth flagging in the public API docs)
When only `modelId` is passed (no `modelVersionId`), the legacy DB path is the only available backend, and its `MostReactions` / `MostComments` / `MostCollected` branches are intentionally disabled at `image.service.ts:1414-1422` for performance reasons (`// TODO this causes the app to spike`). For `modelId`-only queries, those sort values are accepted but collapse to newest-by-id ordering.

**Workaround for callers:** also pass a specific `modelVersionId` — that routes through the search index, where engagement sorts are honored. The behavior is documented inline at the routing decision so it's not lost on future maintainers.

A proper fix for `modelId`-only engagement sorts would require either (a) re-enabling the disabled branches with the `ImageMetric` join properly indexed, or (b) expanding `modelId` to its `modelVersionId`s and querying the search index — both deserve their own PR with perf benchmarking.

Fixes #2126
Fixes #2134

## Test plan
- [x] `GET /api/v1/images?modelId=<known model>` with `BITDEX_IMAGE_SEARCH=primary` → results scoped to that model (pre-fix: global feed).
- [x] `GET /api/v1/images?modelId=<known model>` with `BITDEX_IMAGE_SEARCH=disabled` → still scoped (no regression).
- [x] `GET /api/v1/images?imageId=<id>` → still routed to legacy.
- [x] `GET /api/v1/images?modelVersionId=<id>` → still routed through BitDex/feed search; `Most Reactions`/`Most Comments` order differs from `Newest`.
- [x] `GET /api/v1/images?modelId=<id>&modelVersionId=<id>&sort=Most%20Reactions&period=AllTime` → returns the same image set as `modelVersionId` alone, ordered by reaction totals (the exact #2134 reproduction).
- [x] `GET /api/v1/images?modelId=<id>&sort=Most%20Reactions` (no version) → results scoped to model but ordered newest-by-id (documented limitation).
- [x] `GET /api/v1/images` plain → still hits BitDex/feed search when flag is on.
- [x] Pagination `&page=2` and `&cursor=…` → `nextPage` URLs still build correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)