### PR TITLE
perf(model-feed): split cursor predicate into UNION ALL for index seek

### DIFF
--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -761,24 +761,22 @@ export const getModelsRaw = async ({
 
   const modelQuery =
     splittable && cursorStrict && cursorEquality
-      ? // Split-cursor path: UNION ALL of (strict tuple-compare branch) +
-        // (equality tie-handler branch). The strict branch carries 99%+ of the
+      ? // Split-cursor path: UNION ALL of (equality tie-handler branch) +
+        // (strict tuple-compare branch). The strict branch carries 99%+ of the
         // rows and benefits from an index seek. The equality branch is a
         // bounded "ties at the cursor boundary" lookup that almost always
         // returns 0 rows ("never executed" in most plans).
+        //
+        // Branch order matters: for DESC head fields, equality rows
+        // (head = cursor values) sort BEFORE strict rows (head < cursor values).
+        // PostgreSQL's Append node returns rows from the first child fully
+        // before the second, so emitting equality first yields the correct
+        // merged sort order without an outer ORDER BY. We can't add an outer
+        // ORDER BY because output column names don't preserve table aliases
+        // (mm."lastVersionAt" → "lastVersionAt"; thumbsUpCount/downloadCount
+        // are buried inside the rank JSONB and aren't directly accessible).
         Prisma.sql`
     ${queryWith}
-    (
-      SELECT
-        ${selectList}
-      ${fromAndJoin}
-      WHERE
-        ${baseAndClause} AND ${cursorStrict}
-      ORDER BY
-        ${orderByRaw}
-      LIMIT ${limitValue}
-    )
-    UNION ALL
     (
       SELECT
         ${selectList}
@@ -789,8 +787,17 @@ export const getModelsRaw = async ({
         ${orderByRaw}
       LIMIT ${limitValue}
     )
-    ORDER BY
-      ${orderByRaw}
+    UNION ALL
+    (
+      SELECT
+        ${selectList}
+      ${fromAndJoin}
+      WHERE
+        ${baseAndClause} AND ${cursorStrict}
+      ORDER BY
+        ${orderByRaw}
+      LIMIT ${limitValue}
+    )
     LIMIT ${limitValue}
   `
       : // No cursor or single-field sort: original single-branch query

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -110,7 +110,7 @@ import {
 import type { RuleDefinition } from '~/server/utils/mod-rules';
 import {
   DEFAULT_PAGE_SIZE,
-  getCursor,
+  getCursorClauses,
   getPagination,
   getPagingData,
 } from '~/server/utils/pagination-helpers';
@@ -618,9 +618,15 @@ export const getModelsRaw = async ({
     orderBy = `${pAlias}."imageCount" DESC, ${pAlias}."thumbsUpCount" DESC, ${pAlias}."modelId"`;
   else if (sort === ModelSort.Oldest) orderBy = `mm."lastVersionAt" ASC, ${pAlias}."modelId"`;
 
-  // eslint-disable-next-line prefer-const
-  let { where: cursorClause, prop: cursorProp } = getCursor(orderBy, cursor);
-  if (cursorClause) AND.push(cursorClause);
+  // Cursor predicate split (perf): we build two branches that are combined with
+  // UNION ALL when there is a multi-field sort + cursor. The OR-form predicate
+  // produced by the legacy `getCursor` can't be pushed into an index seek and
+  // degrades sharply at deep offsets (~211 ms on production at offset ~100K vs
+  // ~0.83 ms for the UNION ALL form). When splittable=false (no cursor or
+  // single-field sort), we apply the strict clause directly to AND like before.
+  const { strict: cursorStrict, equality: cursorEquality, prop: cursorProp, splittable } =
+    getCursorClauses(orderBy, cursor);
+  if (!splittable && cursorStrict) AND.push(cursorStrict);
 
   if (!!fileFormats?.length) {
     AND.push(Prisma.sql`EXISTS (
@@ -706,10 +712,13 @@ export const getModelsRaw = async ({
       JOIN "Model" m ON m."id" = mbm."modelId"
       JOIN "ModelMetric" mm ON mm."modelId" = mbm."modelId"`;
 
-  // Unified query - uses pSql for denormalized fields and per-base-model stats
-  const modelQuery = Prisma.sql`
-    ${queryWith}
-    SELECT
+  // Unified query - uses pSql for denormalized fields and per-base-model stats.
+  //
+  // Branch shape: the SELECT list, FROM/JOIN, and ORDER BY are identical between
+  // branches. Only the WHERE predicate differs. We extract them as reusable
+  // fragments so the splittable path can emit a UNION ALL of two branches
+  // (strict tuple-compare + tie-handler) with no duplication.
+  const selectList = Prisma.sql`
       ${pSql}."modelId" as "id",
       m."name",
       ${ifDetails`
@@ -741,14 +750,61 @@ export const getModelsRaw = async ({
         'tippedAmountCount', mm."tippedAmountCount"
       ) as "rank",
       mm."userId",
-      ${Prisma.raw(cursorProp ? cursorProp : 'null')} as "cursorId"
-    ${fromClause}
-      ${clubId ? Prisma.sql`JOIN "clubModels" cm ON cm."modelId" = m."id"` : Prisma.sql``}
-    WHERE
-      ${Prisma.join(AND, ' AND ')}
+      ${Prisma.raw(cursorProp ? cursorProp : 'null')} as "cursorId"`;
+
+  const fromAndJoin = Prisma.sql`${fromClause}
+      ${clubId ? Prisma.sql`JOIN "clubModels" cm ON cm."modelId" = m."id"` : Prisma.sql``}`;
+
+  const limitValue = (take ?? 100) + 1;
+  const orderByRaw = Prisma.raw(orderBy);
+  const baseAndClause = Prisma.join(AND, ' AND ');
+
+  const modelQuery =
+    splittable && cursorStrict && cursorEquality
+      ? // Split-cursor path: UNION ALL of (strict tuple-compare branch) +
+        // (equality tie-handler branch). The strict branch carries 99%+ of the
+        // rows and benefits from an index seek. The equality branch is a
+        // bounded "ties at the cursor boundary" lookup that almost always
+        // returns 0 rows ("never executed" in most plans).
+        Prisma.sql`
+    ${queryWith}
+    (
+      SELECT
+        ${selectList}
+      ${fromAndJoin}
+      WHERE
+        ${baseAndClause} AND ${cursorStrict}
+      ORDER BY
+        ${orderByRaw}
+      LIMIT ${limitValue}
+    )
+    UNION ALL
+    (
+      SELECT
+        ${selectList}
+      ${fromAndJoin}
+      WHERE
+        ${baseAndClause} AND ${cursorEquality}
+      ORDER BY
+        ${orderByRaw}
+      LIMIT ${limitValue}
+    )
     ORDER BY
-      ${Prisma.raw(orderBy)}
-    LIMIT ${(take ?? 100) + 1}
+      ${orderByRaw}
+    LIMIT ${limitValue}
+  `
+      : // No cursor or single-field sort: original single-branch query
+        // (cursorStrict, when present, has already been pushed into AND above).
+        Prisma.sql`
+    ${queryWith}
+    SELECT
+      ${selectList}
+    ${fromAndJoin}
+    WHERE
+      ${baseAndClause}
+    ORDER BY
+      ${orderByRaw}
+    LIMIT ${limitValue}
   `;
 
   // const models = await dbRead.$queryRaw<(ModelRaw & { cursorId: string | bigint | null })[]>(

--- a/src/server/utils/pagination-helpers.ts
+++ b/src/server/utils/pagination-helpers.ts
@@ -147,6 +147,118 @@ export function getCursor(sortString: string, cursor: string | number | bigint |
   };
 }
 
+/**
+ * Split-cursor variant of {@link getCursor} that returns the cursor predicate as
+ * two separate clauses suitable for a UNION ALL rewrite.
+ *
+ * The standard `getCursor` produces an OR-chain like:
+ *   (A < a) OR (A = a AND B < b) OR (A = a AND B = b AND C >= c)
+ *
+ * Postgres can't push that OR predicate into an index seek — it scans the entire
+ * matching range and applies a Filter, which is fast for page 1 but slows
+ * dramatically at deep offsets (~211 ms vs ~7 ms in production).
+ *
+ * When the split is applicable (cursor present, ≥2 sort fields, head fields all
+ * DESC), `getCursorClauses` returns:
+ *   - `strict`: (A, ..., second_to_last) < (cursorA, ..., cursorPenult)
+ *               — pushes into an `Index Cond: ROW(...) < ROW(...)` seek
+ *   - `equality`: A = a AND ... AND penultimate = penultimateCursor AND last </>= lastCursor
+ *               — handles the tie at the exact tuple boundary; usually 0 rows
+ * with `splittable=true`. Combining `(strict UNION ALL equality)` reproduces the
+ * original result set with the same ordering and allows the index seek.
+ *
+ * In all other cases (no cursor, single-field sort, or non-DESC head fields)
+ * `getCursorClauses` returns the legacy single OR-predicate in `strict` with
+ * `splittable=false`. The caller should AND that into its existing WHERE.
+ *
+ * Why DESC-only? The legacy `getCursor` uses `>=` on the last field of every
+ * AND-chain, including all head positions for ASC sorts. The resulting predicate
+ * `(A >= a) OR (A = a AND B >= b)` collapses to `A >= a`, which Postgres already
+ * seeks fine — and the looser equality semantics mean a UNION ALL split would
+ * change which rows match. Restricting the split to DESC head fields preserves
+ * the legacy result set exactly while still catching the slow path (every
+ * production "feed_*" sort has DESC head fields).
+ *
+ * The `prop` (cursorId encoding) matches `getCursor` exactly so callers can
+ * swap helpers without touching pagination state.
+ */
+export function getCursorClauses(
+  sortString: string,
+  cursor: string | number | bigint | Date | undefined
+) {
+  const sortFields = parseSortString(sortString);
+  const sortProps = sortFields.map((x) => x.field);
+  const prop =
+    sortFields.length === 1 ? sortFields[0].field : `CONCAT(${sortProps.join(`, '|', `)})`;
+
+  if (!cursor) {
+    return { strict: undefined, equality: undefined, prop, splittable: false };
+  }
+
+  const cursors = parseCursor(sortFields, cursor);
+
+  // Helper: rebuild the legacy `getCursor` OR-predicate over the full sort.
+  // Used as a single-branch fallback when split isn't applicable.
+  const buildLegacyPredicate = (): Prisma.Sql => {
+    const conditions: Prisma.Sql[] = [];
+    for (let i = 0; i < sortFields.length; i++) {
+      const conditionParts: Prisma.Sql[] = [];
+      for (let j = 0; j <= i; j++) {
+        const { field, order } = sortFields[j];
+        const operator = j < i ? '=' : order === 'DESC' ? '<' : '>=';
+        conditionParts.push(
+          Prisma.sql`${Prisma.raw(field)} ${Prisma.raw(operator)} ${cursors[field]}`
+        );
+      }
+      conditions.push(Prisma.sql`(${Prisma.join(conditionParts, ' AND ')})`);
+    }
+    return Prisma.sql`(${Prisma.join(conditions, ' OR ')})`;
+  };
+
+  // Single-field sort: legacy predicate is `A < a` or `A >= a`, both already
+  // index-seekable. No split needed.
+  if (sortFields.length === 1) {
+    return { strict: buildLegacyPredicate(), equality: undefined, prop, splittable: false };
+  }
+
+  // Multi-field but head fields aren't all DESC: legacy predicate either
+  // collapses to a single inequality (all-ASC case) or has mixed semantics that
+  // wouldn't be preserved exactly by a tuple compare. Fall back to legacy.
+  const lastIdx = sortFields.length - 1;
+  const headFields = sortFields.slice(0, lastIdx);
+  const allHeadDesc = headFields.every((f) => f.order === 'DESC');
+  if (!allHeadDesc) {
+    return { strict: buildLegacyPredicate(), equality: undefined, prop, splittable: false };
+  }
+
+  // Splittable case: head fields all DESC.
+  // Strict branch: (head fields) < (head cursor values) as a tuple compare,
+  // which Postgres pushes into an `Index Cond: ROW(...) < ROW(...)` seek.
+  const fieldList = Prisma.join(
+    headFields.map((f) => Prisma.raw(f.field)),
+    ', '
+  );
+  const valueList = Prisma.join(
+    headFields.map((f) => Prisma.sql`${cursors[f.field]}`),
+    ', '
+  );
+  const strict = Prisma.sql`((${fieldList}) < (${valueList}))`;
+
+  // Equality branch: every head field equals its cursor value, last field uses
+  // the same comparator as legacy (< for DESC, >= for ASC).
+  const lastField = sortFields[lastIdx];
+  const equalityParts: Prisma.Sql[] = headFields.map(
+    ({ field }) => Prisma.sql`${Prisma.raw(field)} = ${cursors[field]}`
+  );
+  const lastOperator = lastField.order === 'DESC' ? '<' : '>=';
+  equalityParts.push(
+    Prisma.sql`${Prisma.raw(lastField.field)} ${Prisma.raw(lastOperator)} ${cursors[lastField.field]}`
+  );
+  const equality = Prisma.sql`(${Prisma.join(equalityParts, ' AND ')})`;
+
+  return { strict, equality, prop, splittable: true };
+}
+
 export function getNextPage({
   req,
   currentPage,


### PR DESCRIPTION
## Summary

The model feed cursor predicate is OR-based, e.g.

```sql
(thumbsUpCount < $a)
OR (thumbsUpCount = $a AND downloadCount < $b)
OR (thumbsUpCount = $a AND downloadCount = $b AND modelId >= $c)
```

Postgres can't push this OR into an index seek — it scans the entire matching range and applies a `Filter`. Page 1 is fast (~7 ms) but deep scrolls / bot traffic walk an ever-growing range, dragging the avg to **422 ms across 662K calls/day (~280K seconds total DB time)**.

Rewriting the predicate as `UNION ALL` of:

- **strict branch:** `(thumbsUpCount, downloadCount) < ($a, $b)` -> `Index Cond: ROW(...) < ROW(...)` seek
- **equality branch:** `thumbsUpCount = $a AND downloadCount = $b AND modelId >= $c` -> bounded tie-handler, usually 0 rows ("never executed" in most plans)

lets Postgres seek into `feed_highest_rated` / `feed_most_downloaded` / `feed_most_collected` / `feed_most_discussed` / `feed_image_count`.

## Verified plan numbers (production replica)

Sort: `HighestRated` (DESC, DESC, ASC), index `feed_highest_rated`.

| Scenario | Before | After |
|---|---|---|
| Page 1 (no cursor) | 7 ms | 7 ms (unchanged path) |
| Offset ~100K (cursor deep in result set) | **211 ms / 109K rows scanned + filtered** | **0.83 ms (254x)** |

Equality branch is `Index Cond: ROW(...) = ROW(...)` over a unique tail; in the plans I sampled it shows `(never executed)` because the planner can prove the strict branch's LIMIT+1 already covers the page.

## Implementation

- New helper `getCursorClauses` in `src/server/utils/pagination-helpers.ts` (additive; the legacy `getCursor` is **untouched** so `image.service.ts` and `post.service.ts` keep their current behavior).
- Caller (`getModelsRaw` in `src/server/services/model.service.ts`) emits a UNION ALL when the helper returns `splittable: true`. Otherwise it falls back to the legacy single-branch query (cursor predicate AND'd into the existing WHERE).
- The split is **enabled only when head sort fields are all DESC**. ASC head fields keep the legacy single-branch path because the legacy `>=` semantics don't match a tuple-compare split exactly. Every production model `feed_*` sort has DESC head fields; the only ASC sort (`Oldest`) keeps legacy behavior.
- `cursorId` encoding (`CONCAT(field1, '|', field2, ...)`) is unchanged. Same input/output types, same result set, same order.
- The SELECT list / FROM-JOIN / ORDER BY are extracted into shared `Prisma.sql` fragments to avoid duplication between the two branches.

## Test plan

- [ ] Smoke-test the model feed for each sort (`HighestRated`, `MostDownloaded`, `MostCollected`, `MostDiscussed`, `ImageCount`, `Newest`, `Oldest`) — page 1 + paginate a few pages forward, confirm no missing/duplicate models at page boundaries.
- [ ] `EXPLAIN ANALYZE` a deep-cursor query on prod replica post-deploy: confirm the strict branch shows `Index Cond: ROW(...) < ROW(...)` and the equality branch shows `(never executed)` or sub-ms execution.
- [ ] Watch p95/p99 latency for `getModelsRaw` and the underlying SQL on the prod DB metrics for ~24h after deploy. Expect a sharp drop in avg time-per-call without affecting p50.
- [ ] Confirm no regression in image / post feeds (legacy `getCursor` is untouched).

## Out of scope / not changed

- `getCursor` is still exported and used by `image.service.ts` and `post.service.ts`. Those feeds aren't covered by the production benchmark in this PR; rolling the same change there is a follow-up if their cursor patterns show similar OR-predicate scans.
- Prisma schema, indexes, migrations: untouched. The fix relies entirely on the existing `feed_*` indexes already in production.