### PR TITLE
fix(images-cache): don't negative-cache showcase image lookups

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -4468,6 +4468,11 @@ export const imagesForModelVersionsCache = createCachedObject<CachedImagesForMod
   key: REDIS_KEYS.CACHES.IMAGES_FOR_MODEL_VERSION,
   idKey: 'modelVersionId',
   ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.sm,
+  // A negative-cached miss right after publish (before image ingestion finishes
+  // setting nsfwLevel / clearing needsReview) hides the model from feeds for
+  // the full TTL. Re-querying every miss is cheap; a 48h sticky-empty card
+  // isn't.
+  cacheNotFound: false,
   // staleWhileRevalidate: false, // We might want to enable this later otherwise there will be a delay after a creator updates their showcase images...
   lookupFn: async (ids) => {
     const images = await getImagesForModelVersion({ modelVersionIds: ids, imagesPerVersion: 20 });


### PR DESCRIPTION
## Summary

`imagesForModelVersionsCache` was caching `{ notFound: true }` markers when its `lookupFn` returned zero rows during the post-publish / pre-ingestion window. With `staleWhileRevalidate: true` (default), the negative cache stuck for `ttl * 2 ≈ 48h` on Datapacket. The affected model then disappeared from feeds, showcases, and profile sections for two days, even after image ingestion completed.

The lookup filters on async-populated columns:
```sql
WHERE i."nsfwLevel" != 0
  AND i."needsReview" IS NULL
  AND i."acceptableMinor" = FALSE
```
A read fired between publish and image scan completion returns nothing — that empty result was being interpreted as authoritative.

## Why the existing bust hooks aren't sufficient

`image-scan-result.service.ts:360` already calls `bustCachesForPosts(image.postId)` on ingestion completion, which routes through `deleteImagesForModelVersionCache` → `imagesForModelVersionsCache.bust(...)`. In the happy path this clears the negative entry. But the bust writes a 10-second debounce marker; the next read fires `lookupFn` against `dbRead`, and a brief replication-lag window can return the still-empty rowset and re-poison the entry.

## The fix

```diff
 export const imagesForModelVersionsCache = createCachedObject<CachedImagesForModelVersions>({
   key: REDIS_KEYS.CACHES.IMAGES_FOR_MODEL_VERSION,
   idKey: 'modelVersionId',
   ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.sm,
+  cacheNotFound: false,
```

`cacheNotFound: false` makes misses re-query on every fetch instead of locking in a sticky-empty result. Cost: one extra DB query per genuinely-empty version per request. That's negligible compared to a 48-hour visibility regression for newly-published content.

## Production evidence

Investigated two reports (Models 2529438 and 2577726) where models published in the last 24h were missing from the owner's profile.

For 2577726, the cache key `packed:caches:images-for-model-version-2:2895976` (the model's only version) held `{ notFound: true, cachedAt: 2026-04-26T20:52:04 }` — exactly **86 seconds after publish**. The DB had three Scanned images by the time we looked, but the `notFound` marker had ~26h left to live.

## Operational cleanup

After landing this PR, I ran a one-shot script against the production cache cluster (`next-redis-cluster`, 3 shards). It scans the prefix, decodes each msgpack value, and DELs only entries with `notFound: true`. Final tally:

```
scanned: 788,431
positive: 777,209
notFound: 11,222   ← ~1.4% poisoning rate
deleted: 6,969     ← lower than notFound found because some entries
                     repopulated as positive during the 35-min scan
```

The script isn't included here (one-shot operational tool); happy to attach if useful.

## Audit of other caches

Surveyed every `createCachedObject` / `createCachedArray` site for the same pattern (lookupFn filters on async-populated columns + `cacheNotFound: true` + `staleWhileRevalidate: true`).

Already protected with `cacheNotFound: false`:
- `dataForModelsCache`, `modelVersionAccessCache`, `articleStatCache`, `userDownloadsCache`, `cosmeticEntityCaches`, `userCapCache`, `resourceDataCache`

Vulnerable in theory but mitigated in practice by reliable bust/refresh hooks in the populating job (lower priority — race window is the replication-lag gap):
- `tagIdsForImagesCache`, `imageTagsCache` — busted by `tagsOnImageNew.service.ts`
- `modelTagCache` — refreshed by `model.service.ts` on tag updates
- `imageResourcesCache` — refreshed by image/post services
- `thumbnailCache` — refreshed by image service
- `postStatCache` — busted by post metric job
- `filesForModelVersionCache` — busted on every model file CRUD

True PK lookups (empty == permanently missing, negative cache is correct):
- `cosmeticCache`, `userBasicCache`, `userMultipliersCache`, `tagCache`, `imageMetaCache`, `imageMetadataCache`, `userSettingsCache`, `userCashCache`, `modelVersionResourceCache`, `earnedCache`

If we want to harden the second group too, the same one-line change would work — but I've kept this PR scoped to the cache we have a confirmed prod incident on.

## Test plan

- [ ] Confirm that newly-published models with images appear in their owner's profile within seconds (not 48h)
- [ ] Confirm that genuinely-empty versions (e.g., draft with no posts) don't blow up DB load via repeated misses — should still be cached positively once any image lands
- [ ] Verify other consumers of `imagesForModelVersionsCache.fetch` (showcase grids, feed cards) still serve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)