### PR TITLE
feat(model-version): add ExternalGeneration for fileless API-backed models

### DIFF
--- a/prisma/migrations/20260428120000_add_external_generation_usage_control/migration.sql
+++ b/prisma/migrations/20260428120000_add_external_generation_usage_control/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ModelUsageControl" ADD VALUE 'ExternalGeneration';

--- a/prisma/migrations/20260428120100_generation_coverage_external_generation/migration.sql
+++ b/prisma/migrations/20260428120100_generation_coverage_external_generation/migration.sql
@@ -1,0 +1,62 @@
+DROP VIEW "GenerationCoverage";
+
+CREATE VIEW "GenerationCoverage"("modelId", "modelVersionId", covered) AS
+SELECT
+  m.id AS "modelId",
+  mv.id AS "modelVersionId",
+  TRUE AS covered
+FROM
+  "ModelVersion" mv
+  JOIN "Model" m ON m.id = mv."modelId"
+WHERE
+  -- ========================================
+  -- Ecosystem checkpoints: curated, always covered
+  -- ========================================
+  mv.id IN (SELECT id FROM "EcosystemCheckpoints")
+
+  -- ========================================
+  -- External generation: file-less mod-published versions routed via external
+  -- engines (e.g. NanoBanana, Seedream). Normal users can generate with these
+  -- via the dedicated engine UIs; canGenerate is unrestricted.
+  -- ========================================
+  OR (mv."usageControl" = 'ExternalGeneration' AND mv.status = 'Published')
+
+  -- ========================================
+  -- Everything else: shared conditions + type-specific logic
+  -- ========================================
+  OR (
+    NOT m.poi
+    AND (mv.status = 'Published'::"ModelStatus"
+      OR m.availability = 'Private'::"Availability"
+      OR m."uploadType" = 'Trained'::"ModelUploadType")
+    AND m."allowCommercialUse" && ARRAY['RentCivit'::"CommercialUse", 'Rent'::"CommercialUse", 'Sell'::"CommercialUse"]
+    AND EXISTS (
+      SELECT 1
+      FROM "ModelFile" mf
+      WHERE mf."modelVersionId" = mv.id
+        AND (
+          (mf."scannedAt" IS NOT NULL
+            AND mf.type = ANY (ARRAY['Model'::text, 'Pruned Model'::text, 'Negative'::text, 'VAE'::text]))
+          OR (mf.metadata -> 'trainingResults') IS NOT NULL
+        )
+    )
+    -- Base model must be in GenerationBaseModel (for non-upscaler types)
+    AND (mv."baseModel" IN (SELECT "baseModel" FROM "GenerationBaseModel")
+      OR m.type = 'Upscaler'::"ModelType")
+    -- Type-specific coverage
+    AND (
+      -- Checkpoints: Standard type + in CoveredCheckpoint
+      (m.type = 'Checkpoint'::"ModelType"
+        AND mv."baseModelType" = 'Standard'::text
+        AND mv.id IN (SELECT version_id FROM "CoveredCheckpoint"))
+      -- Addon types
+      OR m.type IN (
+          'LORA'::"ModelType",
+          'TextualInversion'::"ModelType",
+          'VAE'::"ModelType",
+          'LoCon'::"ModelType",
+          'DoRA'::"ModelType")
+      -- Upscalers: ecosystem-independent
+      OR m.type = 'Upscaler'::"ModelType"
+    )
+  );

--- a/prisma/migrations/20260428120100_generation_coverage_external_generation/migration.sql
+++ b/prisma/migrations/20260428120100_generation_coverage_external_generation/migration.sql
@@ -18,8 +18,10 @@ WHERE
   -- External generation: file-less mod-published versions routed via external
   -- engines (e.g. NanoBanana, Seedream). Normal users can generate with these
   -- via the dedicated engine UIs; canGenerate is unrestricted.
+  -- The NOT m.poi guard mirrors the catch-all branch so PoI models can't be
+  -- silently flipped into a covered/generatable state via the usageControl flag.
   -- ========================================
-  OR (mv."usageControl" = 'ExternalGeneration' AND mv.status = 'Published')
+  OR (mv."usageControl" = 'ExternalGeneration' AND mv.status = 'Published' AND NOT m.poi)
 
   -- ========================================
   -- Everything else: shared conditions + type-specific logic

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -780,6 +780,7 @@ enum ModelUsageControl {
   Download
   Generation
   InternalGeneration
+  ExternalGeneration
 }
 
 enum ModelModifier {

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -52,7 +52,7 @@ import { isAndroidDevice } from '~/utils/device-helpers';
 import type { LinkedComponent } from '~/server/schema/model-file.schema';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
 import type { GenerationResource } from '~/shared/types/generation.types';
-import { ModelType } from '~/shared/utils/prisma/enums';
+import { ModelType, ModelUsageControl } from '~/shared/utils/prisma/enums';
 import { componentTypeConfig, getFileIconConfig } from '~/utils/file-display-helpers';
 
 // Small inline dropzone for adding files within a section
@@ -1010,7 +1010,8 @@ function FileEditForm({
 }
 
 export function UploadStepActions({ onBackClick, onNextClick }: ActionProps) {
-  const { startUpload, files, hasPending } = useFilesContext();
+  const { startUpload, files, hasPending, usageControl } = useFilesContext();
+  const isExternalGeneration = usageControl === ModelUsageControl.ExternalGeneration;
 
   return (
     <Group mt="xl" justify="flex-end">
@@ -1022,7 +1023,7 @@ export function UploadStepActions({ onBackClick, onNextClick }: ActionProps) {
           const allFailed = files.every(
             (file) => file.status === 'aborted' || file.status === 'error'
           );
-          const showConfirmModal = !files.length || allFailed;
+          const showConfirmModal = !isExternalGeneration && (!files.length || allFailed);
 
           if (showConfirmModal) {
             return openConfirmModal({

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -11,7 +11,7 @@ import { UploadType } from '~/server/common/enums';
 import type { ModelVersionById } from '~/server/controllers/model-version.controller';
 import { modelFileMetadataSchema } from '~/server/schema/model-file.schema';
 import type { ModelUpsertInput } from '~/server/schema/model.schema';
-import { ModelStatus, ModelType } from '~/shared/utils/prisma/enums';
+import { ModelStatus, ModelType, ModelUsageControl } from '~/shared/utils/prisma/enums';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import { getPrimaryFileTypes, primaryFileTypesByModelType } from '~/utils/file-display-helpers';
 import { getModelFileFormat } from '~/utils/file-helpers';
@@ -56,6 +56,7 @@ type FilesContextState = {
   linkedComponents: LinkedComponent[];
   modelId?: number;
   baseModel?: string;
+  usageControl?: ModelUsageControl | null;
   dropzoneConfig: DropzoneOptions;
   onDrop: (files: File[], defaultType?: ModelFileType, skipInference?: boolean) => void;
   startUpload: () => Promise<void>;
@@ -71,7 +72,10 @@ type FilesContextState = {
 
 type FilesProviderProps = {
   model?: Partial<ModelUpsertInput>;
-  version?: Pick<Partial<ModelVersionById>, 'id' | 'files' | 'baseModel' | 'linkedComponents'>;
+  version?: Pick<
+    Partial<ModelVersionById>,
+    'id' | 'files' | 'baseModel' | 'linkedComponents' | 'usageControl'
+  >;
   children: React.ReactNode;
 };
 
@@ -330,10 +334,14 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
       return false;
     }
 
+    // External-generation versions (mod-only, routed via external engines) intentionally
+    // ship without files; skip the component-count requirement for them.
+    const isExternalGeneration = version?.usageControl === ModelUsageControl.ExternalGeneration;
+
     // Check component-only model constraint (needs access to linkedComponents).
     // Skip for archive-primary model types (Workflows/Poses/Wildcards/Other) — their main file
     // is an archive/config, so they don't fit the "component-only" concept.
-    if (!model?.type || !archivePrimaryModelTypes.includes(model.type)) {
+    if (!isExternalGeneration && (!model?.type || !archivePrimaryModelTypes.includes(model.type))) {
       const primaryTypes = getPrimaryFileTypes(model?.type);
       const modelFiles = files.filter(
         (f) => f.type && (primaryTypes as readonly string[]).includes(f.type)
@@ -591,6 +599,7 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
         dropzoneConfig,
         modelId: model?.id,
         baseModel: version?.baseModel ?? undefined,
+        usageControl: version?.usageControl,
         validationCheck: checkValidation,
         addLinkedComponent,
         removeLinkedComponent,

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -414,13 +414,16 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
                         [ModelUsageControl.Download]: 'Download & On-Site Generation',
                         [ModelUsageControl.Generation]: 'On-Site Generation Only',
                         [ModelUsageControl.InternalGeneration]: 'Internal API Generation Only',
+                        [ModelUsageControl.ExternalGeneration]:
+                          'External API Generation (no files)',
                       },
                     }),
                   }))
                   .filter(
-                    // We don't want random people accessing this.
+                    // Mod-only options: hide unless already selected or user is a moderator.
                     (x) =>
-                      x.value !== ModelUsageControl.InternalGeneration ||
+                      (x.value !== ModelUsageControl.InternalGeneration &&
+                        x.value !== ModelUsageControl.ExternalGeneration) ||
                       x.value === usageControl ||
                       currentUser?.isModerator
                   )}

--- a/src/components/Resource/Wizard/ModelVersionWizard.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.tsx
@@ -71,12 +71,13 @@ const CreateSteps = ({
             model={modelData}
             version={modelVersion}
             onSubmit={(result) => {
-              if (editing) return goNext();
               const skipFiles = result?.usageControl === ModelUsageControl.ExternalGeneration;
               const nextStep = skipFiles ? 3 : 2;
               router
                 .replace(
-                  `/models/${result?.modelId}/model-versions/${result?.id}/wizard?step=${nextStep}`
+                  `/models/${result?.modelId}/model-versions/${result?.id}/wizard?step=${nextStep}`,
+                  undefined,
+                  editing ? { shallow: true } : undefined
                 )
                 .then();
             }}

--- a/src/components/Resource/Wizard/ModelVersionWizard.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.tsx
@@ -1,5 +1,10 @@
 import { Alert, Anchor, Button, Group, Stack, Stepper, Text, Title } from '@mantine/core';
-import { Availability, ModelUploadType, TrainingStatus } from '~/shared/utils/prisma/enums';
+import {
+  Availability,
+  ModelUploadType,
+  ModelUsageControl,
+  TrainingStatus,
+} from '~/shared/utils/prisma/enums';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import type { NextRouter } from 'next/router';
@@ -67,8 +72,12 @@ const CreateSteps = ({
             version={modelVersion}
             onSubmit={(result) => {
               if (editing) return goNext();
+              const skipFiles = result?.usageControl === ModelUsageControl.ExternalGeneration;
+              const nextStep = skipFiles ? 3 : 2;
               router
-                .replace(`/models/${result?.modelId}/model-versions/${result?.id}/wizard?step=2`)
+                .replace(
+                  `/models/${result?.modelId}/model-versions/${result?.id}/wizard?step=${nextStep}`
+                )
                 .then();
             }}
           >
@@ -276,6 +285,7 @@ export function ModelVersionWizard({ data }: Props) {
   };
 
   const hasFiles = modelVersion && !!modelVersion.files?.length;
+  const skipFiles = modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
 
   // Filter to posts belonging to the owner of the model
   const postId = modelVersion?.posts?.filter((post) => post.userId === modelData?.user.id)?.[0]?.id;
@@ -286,7 +296,7 @@ export function ModelVersionWizard({ data }: Props) {
 
     // redirect to correct step if missing values
     if (!isNew) {
-      if (!hasFiles)
+      if (!hasFiles && !skipFiles)
         router
           .replace(`/models/${id}/model-versions/${versionId}/wizard?step=2`, undefined, {
             shallow: true,
@@ -300,7 +310,7 @@ export function ModelVersionWizard({ data }: Props) {
           .then();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasFiles, id, isNew, versionId]);
+  }, [hasFiles, skipFiles, id, isNew, versionId]);
 
   return (
     <FilesProvider model={modelData} version={modelVersion}>

--- a/src/components/Resource/Wizard/ModelVersionWizard.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.tsx
@@ -36,6 +36,7 @@ const CreateSteps = ({
   goNext,
   router,
   postId,
+  skipFiles,
 }: {
   step: number;
   versionId?: string | string[];
@@ -45,6 +46,7 @@ const CreateSteps = ({
   goNext: () => void;
   router: NextRouter;
   postId: number | undefined;
+  skipFiles: boolean;
 }) => {
   const { getStatus: getUploadStatus } = useS3UploadStore();
   const { uploading, error, aborted } = getUploadStatus(
@@ -52,14 +54,19 @@ const CreateSteps = ({
   );
   const editing = !!modelVersion?.id;
 
+  // URL step → stepper-rendered index. When skipFiles=true the Files step (URL step 2)
+  // is omitted, so URL step 3 (post) collapses to rendered index 1.
+  const activeIndex = skipFiles && step >= 2 ? Math.max(0, step - 2) : step - 1;
+
   return (
     <Stepper
-      active={step - 1}
-      onStepClick={(step) =>
+      active={activeIndex}
+      onStepClick={(idx) => {
+        const urlStep = skipFiles && idx >= 1 ? idx + 2 : idx + 1;
         router.replace(
-          `/models/${modelData?.id}/model-versions/${versionId}/wizard?step=${step + 1}`
-        )
-      }
+          `/models/${modelData?.id}/model-versions/${versionId}/wizard?step=${urlStep}`
+        );
+      }}
       allowNextStepsSelect={false}
       size="sm"
       classNames={{ steps: 'container max-w-sm' }}
@@ -92,17 +99,19 @@ const CreateSteps = ({
           </ModelVersionUpsertForm>
         </div>
       </Stepper.Step>
-      <Stepper.Step
-        label="Upload files"
-        loading={uploading > 0}
-        color={error + aborted > 0 ? 'red' : undefined}
-      >
-        <div className="container flex max-w-sm flex-col gap-3">
-          <Title order={3}>Upload files</Title>
-          <Files />
-          <UploadStepActions onBackClick={goBack} onNextClick={goNext} />
-        </div>
-      </Stepper.Step>
+      {!skipFiles && (
+        <Stepper.Step
+          label="Upload files"
+          loading={uploading > 0}
+          color={error + aborted > 0 ? 'red' : undefined}
+        >
+          <div className="container flex max-w-sm flex-col gap-3">
+            <Title order={3}>Upload files</Title>
+            <Files />
+            <UploadStepActions onBackClick={goBack} onNextClick={goNext} />
+          </div>
+        </Stepper.Step>
+      )}
       <Stepper.Step label={postId ? 'Edit post' : 'Create a post'}>
         {modelVersion && modelData && (
           <PostUpsertForm2
@@ -354,6 +363,7 @@ export function ModelVersionWizard({ data }: Props) {
           goNext={goNext}
           router={router}
           postId={postId}
+          skipFiles={skipFiles}
         />
       )}
     </FilesProvider>

--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -14,7 +14,7 @@ import { PostUpsertForm2 } from '~/components/Resource/Forms/PostUpsertForm2';
 import TrainingSelectFile from '~/components/Resource/Forms/TrainingSelectFile';
 import { useIsChangingLocation } from '~/components/RouterTransition/RouterTransition';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { ModelUploadType, TrainingStatus } from '~/shared/utils/prisma/enums';
+import { ModelUploadType, ModelUsageControl, TrainingStatus } from '~/shared/utils/prisma/enums';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import type { ModelById } from '~/types/router';
 import { QS } from '~/utils/qs';
@@ -126,7 +126,20 @@ const CreateSteps = ({
           <ModelVersionUpsertForm
             model={model ?? templateFields ?? bountyFields}
             version={modelVersion ?? templateFields?.version ?? bountyFields?.version}
-            onSubmit={goNext}
+            onSubmit={(result) => {
+              // ExternalGeneration versions are file-less — jump directly to the post step.
+              if (result?.usageControl === ModelUsageControl.ExternalGeneration) {
+                router
+                  .replace(
+                    getWizardUrl({ id: modelId, step: 4, templateId, bountyId }),
+                    undefined,
+                    { shallow: true }
+                  )
+                  .then();
+                return;
+              }
+              goNext();
+            }}
           >
             {({ loading, canSave }) => (
               <Group mt="xl" justify="flex-end">
@@ -362,6 +375,8 @@ export function ModelWizard() {
 
       const hasVersions = model.modelVersions.length > 0;
       const hasFiles = model.modelVersions.some((version) => version.files.length > 0);
+      // File-less ExternalGeneration versions don't need the upload step.
+      const skipFiles = modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
 
       if (!hasVersions)
         router
@@ -369,7 +384,7 @@ export function ModelWizard() {
             shallow: true,
           })
           .then();
-      else if (!hasFiles)
+      else if (!hasFiles && !skipFiles)
         router
           .replace(getWizardUrl({ id, step: 3, templateId, bountyId, src }), undefined, {
             shallow: true,
@@ -383,7 +398,7 @@ export function ModelWizard() {
           .then();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, isNew, model, templateId, bountyId, src]);
+  }, [id, isNew, model, modelVersion, templateId, bountyId, src]);
 
   const postId = modelVersion?.posts[0]?.id;
 

--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -44,6 +44,7 @@ const CreateSteps = ({
   modelId,
   router,
   postId,
+  skipFiles,
 }: {
   step: number;
   model?: ModelWithTags;
@@ -53,6 +54,7 @@ const CreateSteps = ({
   modelId: number | undefined;
   router: NextRouter;
   postId: number | undefined;
+  skipFiles: boolean;
 }) => {
   const { getStatus: getUploadStatus } = useS3UploadStore();
   const { uploading, error, aborted } = getUploadStatus(
@@ -60,6 +62,10 @@ const CreateSteps = ({
   );
   const editing = !!model;
   const hasVersions = model && model.modelVersions.length > 0;
+
+  // URL step → stepper-rendered index. When skipFiles=true the Files step (URL step 3)
+  // is omitted, so URL step 4 (post) collapses to rendered index 2.
+  const activeIndex = skipFiles && step >= 3 ? Math.max(0, step - 2) : step - 1;
 
   const result = querySchema.safeParse(router.query);
   const templateId = result.success ? result.data.templateId : undefined;
@@ -85,12 +91,13 @@ const CreateSteps = ({
 
   return (
     <Stepper
-      active={step - 1}
-      onStepClick={(step) =>
-        router.replace(getWizardUrl({ id: modelId, step: step + 1, templateId }), undefined, {
+      active={activeIndex}
+      onStepClick={(idx) => {
+        const urlStep = skipFiles && idx >= 2 ? idx + 2 : idx + 1;
+        router.replace(getWizardUrl({ id: modelId, step: urlStep, templateId }), undefined, {
           shallow: true,
-        })
-      }
+        });
+      }}
       allowNextStepsSelect={false}
       size="sm"
       classNames={{ steps: 'container max-w-sm' }}
@@ -156,17 +163,19 @@ const CreateSteps = ({
       </Stepper.Step>
 
       {/* Step 3: Upload Files */}
-      <Stepper.Step
-        label="Upload files"
-        loading={uploading > 0}
-        color={error + aborted > 0 ? 'red' : undefined}
-      >
-        <div className="container flex max-w-sm flex-col gap-3">
-          <Title order={3}>Upload files</Title>
-          <Files />
-          <UploadStepActions onBackClick={goBack} onNextClick={goNext} />
-        </div>
-      </Stepper.Step>
+      {!skipFiles && (
+        <Stepper.Step
+          label="Upload files"
+          loading={uploading > 0}
+          color={error + aborted > 0 ? 'red' : undefined}
+        >
+          <div className="container flex max-w-sm flex-col gap-3">
+            <Title order={3}>Upload files</Title>
+            <Files />
+            <UploadStepActions onBackClick={goBack} onNextClick={goNext} />
+          </div>
+        </Stepper.Step>
+      )}
 
       <Stepper.Step label={postId ? 'Edit post' : 'Create a post'}>
         {model && modelVersion && (
@@ -367,6 +376,10 @@ export function ModelWizard() {
     }
   };
 
+  // File-less ExternalGeneration versions don't need the upload step. Hoisted so the
+  // CreateSteps stepper and the auto-redirect effect agree on the same step layout.
+  const skipFiles = modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
+
   useEffect(() => {
     // redirect to correct step if missing values
     if (!isNew) {
@@ -375,8 +388,6 @@ export function ModelWizard() {
 
       const hasVersions = model.modelVersions.length > 0;
       const hasFiles = model.modelVersions.some((version) => version.files.length > 0);
-      // File-less ExternalGeneration versions don't need the upload step.
-      const skipFiles = modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
 
       if (!hasVersions)
         router
@@ -479,6 +490,7 @@ export function ModelWizard() {
               step={step}
               router={router}
               postId={postId}
+              skipFiles={skipFiles}
             />
           )}
         </>

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -1,6 +1,10 @@
 import { TRPCError } from '@trpc/server';
 import type { BaseModelType } from '~/server/common/constants';
-import { type BaseModel, DEPRECATED_BASE_MODELS, isBaseModelGenerationSupported } from '~/shared/constants/basemodel.constants';
+import {
+  type BaseModel,
+  DEPRECATED_BASE_MODELS,
+  isBaseModelGenerationSupported,
+} from '~/shared/constants/basemodel.constants';
 import { baseModelLicenses, constants } from '~/server/common/constants';
 import type { Context } from '~/server/createContext';
 import { eventEngine } from '~/server/events';
@@ -231,13 +235,12 @@ const loadModelVersion = async ({
     const recommendedResourceIds = regularResources.map((x) => x.resource.id);
     const generationResources = await getResourceData(recommendedResourceIds, {
       user: ctx?.user,
-    }).then(
-      (data) =>
-        data.map((item) => {
-          const settings = (regularResources.find((x) => x.resource.id === item.id)?.settings ??
-            {}) as RecommendedSettingsSchema;
-          return { ...item, ...removeNulls(settings) };
-        })
+    }).then((data) =>
+      data.map((item) => {
+        const settings = (regularResources.find((x) => x.resource.id === item.id)?.settings ??
+          {}) as RecommendedSettingsSchema;
+        return { ...item, ...removeNulls(settings) };
+      })
     );
 
     if (!version) throw throwNotFoundError(`No version with id ${input.id}`);
@@ -327,6 +330,10 @@ export const upsertModelVersionHandler = async ({
 
     if (input.usageControl === ModelUsageControl.InternalGeneration && !ctx.user.isModerator) {
       throw throwBadRequestError('Only moderators can manage internal generation models');
+    }
+
+    if (input.usageControl === ModelUsageControl.ExternalGeneration && !ctx.user.isModerator) {
+      throw throwBadRequestError('Only moderators can manage external generation models');
     }
 
     if (input.trainingDetails === null) {
@@ -832,7 +839,7 @@ export async function queryModelVersionsForModeratorHandler({
 
   const workflowIds: string[] = [];
   const mappedItems = items.map(({ files, meta, ...version }) => {
-  const trainingFile = pickBestTrainingFile(files);
+    const trainingFile = pickBestTrainingFile(files);
     const trainingResults = (trainingFile?.metadata as FileMetadata)
       ?.trainingResults as TrainingResultsV2;
 
@@ -1002,9 +1009,7 @@ export async function publishPrivateModelVersionHandler({
         select: { id: true, metadata: true },
       })
     : [];
-  const selectedEpochUrl = freshFiles.some(
-    (f) => (f?.metadata as FileMetadata)?.selectedEpochUrl
-  );
+  const selectedEpochUrl = freshFiles.some((f) => (f?.metadata as FileMetadata)?.selectedEpochUrl);
 
   if (!selectedEpochUrl) {
     throw throwBadRequestError('No selected epoch found');

--- a/src/server/jobs/reset-to-draft-without-requirements.ts
+++ b/src/server/jobs/reset-to-draft-without-requirements.ts
@@ -9,6 +9,8 @@ export const resetToDraftWithoutRequirements = createJob(
   '43 2 * * *',
   async () => {
     // Get all published model versions that have no posts
+    // ExternalGeneration versions are excluded — their showcase posts may belong to
+    // accounts other than the model owner (orchestration / curated content).
     const modelVersionsWithoutPosts = await dbWrite.$queryRaw<{ modelVersionId: number }[]>`
       SELECT
         mv.id "modelVersionId"
@@ -18,6 +20,7 @@ export const resetToDraftWithoutRequirements = createJob(
         mv.status = 'Published'
         AND m.status = 'Published'
         AND m."userId" != -1
+        AND mv."usageControl" != 'ExternalGeneration'
         AND NOT EXISTS (SELECT 1 FROM "Post" p WHERE p."modelVersionId" = mv.id AND p."userId" = m."userId")
         AND m."deletedAt" IS NULL;
     `;
@@ -35,6 +38,8 @@ export const resetToDraftWithoutRequirements = createJob(
     }
 
     // Get all published model versions that have no files
+    // ExternalGeneration versions are excluded — they're routed through external
+    // engines (NanoBanana, Seedream, etc.) and intentionally have no model files.
     const modelVersionsWithoutFiles = await dbWrite.$queryRaw<{ modelVersionId: number }[]>`
       SELECT
         mv.id "modelVersionId"
@@ -43,6 +48,7 @@ export const resetToDraftWithoutRequirements = createJob(
       WHERE
         mv.status = 'Published'
         AND m."deletedAt" IS NULL
+        AND mv."usageControl" != 'ExternalGeneration'
         AND NOT EXISTS (SELECT 1 FROM "ModelFile" f WHERE f."modelVersionId" = mv.id);
     `;
     if (modelVersionsWithoutFiles.length) {

--- a/src/shared/utils/prisma/enums.ts
+++ b/src/shared/utils/prisma/enums.ts
@@ -210,6 +210,7 @@ export const ModelUsageControl = {
   Download: 'Download',
   Generation: 'Generation',
   InternalGeneration: 'InternalGeneration',
+  ExternalGeneration: 'ExternalGeneration',
 } as const;
 
 export type ModelUsageControl = (typeof ModelUsageControl)[keyof typeof ModelUsageControl];

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -38,7 +38,7 @@ export type CheckpointType = "Trained" | "Merge";
 
 export type ModelUploadType = "Created" | "Trained";
 
-export type ModelUsageControl = "Download" | "Generation" | "InternalGeneration";
+export type ModelUsageControl = "Download" | "Generation" | "InternalGeneration" | "ExternalGeneration";
 
 export type ModelModifier = "Archived" | "TakenDown";
 


### PR DESCRIPTION
## Summary

Lets moderators publish file-less model versions for API-backed external engines (NanoBanana, Seedream, ChatGPT-Images, etc.) without uploading a placeholder file. Adds a new `ModelUsageControl.ExternalGeneration` value as the signal — mod-only to set, but **non-mods can still use these models in the generator** (unlike `InternalGeneration`, which gates `canGenerate` to mods).

- New `ModelUsageControl.ExternalGeneration` enum value + Prisma migration
- `GenerationCoverage` view auto-covers Published `ExternalGeneration` versions (no manual `EcosystemCheckpoints` insert per new external engine)
- Wizard skips the "Upload files" step entirely for `ExternalGeneration` versions (both create and edit flows)
- `reset-to-draft-without-requirements` cron excludes `ExternalGeneration` from both the no-posts and no-files queries
- Mod-only to set in the form dropdown (`ModelVersionUpsertForm`) and on the tRPC upsert (`model-version.controller`)

## Why a new enum vs. reusing `InternalGeneration`?

`getResourceCanGenerate` at `src/server/services/generation/generation.service.ts:626-628` short-circuits `canGenerate` to `false` for non-mods on `InternalGeneration`. Reusing it would have hidden the model-page Generate button and resource-picker availability from normal users — the opposite of what we want for public API-backed models. `ExternalGeneration` is decoupled from that gate, so non-mods see `canGenerate = true` and can generate via both the model page and the dedicated engine UIs.

## Test plan

- [ ] As a moderator, create a new model + version, set Usage Control to "External API Generation (no files)", click Next — wizard skips to "Create a post" without forcing the Files step
- [ ] Complete the post and verify the version reaches `Published` status with zero `ModelFile` rows
- [ ] Edit the same version: wizard redirect lands on step 3, not step 2
- [ ] As a non-moderator, confirm the "External API Generation" option is hidden from the Usage Control dropdown
- [ ] As a non-moderator, attempt to upsert a version with `usageControl: 'ExternalGeneration'` via tRPC — should reject with "Only moderators can manage external generation models"
- [ ] After applying migrations, run `SELECT covered FROM "GenerationCoverage" WHERE "modelVersionId" = <id>` for a Published `ExternalGeneration` version — confirm `covered = true`
- [ ] Run the reset-to-draft cron's queries against a snapshot — confirm `ExternalGeneration` versions are excluded from both result sets
- [ ] As a non-moderator, confirm `canGenerate = true` and the model-page Generate button is visible for an `ExternalGeneration` version
- [ ] Sanity-check that pre-existing covered checkpoints (e.g. FLUX Dev `691639`) still resolve to `covered = true` — they go through the unchanged `EcosystemCheckpoints` branch

## Follow-up (out of scope)

- Wiring a new external engine still requires hand-editing `ITERATE_MODEL_CONFIG` in `orchestrator.router.ts` and `comics.router.ts` plus the orchestrator handler.
- If the existing example versions (`1903424 / 1951069 / 2563220`) are currently in `Draft` with `meta.unpublishedReason = "no-files"` from prior cron runs, a one-off republish is needed after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)