### PR TITLE
fix(model-version): suppress no-files publish gates for ExternalGeneration

### DIFF
--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -194,7 +194,10 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   const hashes = primaryFile?.hashes ?? [];
 
   const filesCount = version.files?.length;
-  const hasFiles = filesCount > 0;
+  // ExternalGeneration versions are intentionally file-less (routed via external engines),
+  // so publish/republish gates should treat them as having the required assets.
+  const isExternalGeneration = version.usageControl === ModelUsageControl.ExternalGeneration;
+  const hasFiles = filesCount > 0 || isExternalGeneration;
   const filesVisible = useMemo(
     () => version.files?.filter((f) => f.visibility === ModelFileVisibility.Public || isOwnerOrMod),
     [version.files, isOwnerOrMod]

--- a/src/components/Resource/Forms/PostUpsertForm2.tsx
+++ b/src/components/Resource/Forms/PostUpsertForm2.tsx
@@ -6,7 +6,7 @@ import { NotFound } from '~/components/AppLayout/NotFound';
 import { PostEdit } from '~/components/Post/EditV2/PostEdit';
 import { PostEditProvider } from '~/components/Post/EditV2/PostEditProvider';
 import { PostImageDropzone } from '~/components/Post/EditV2/PostImageDropzone';
-import { ModelStatus } from '~/shared/utils/prisma/enums';
+import { ModelStatus, ModelUsageControl } from '~/shared/utils/prisma/enums';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -65,7 +65,11 @@ export function PostUpsertForm2({
   const is404 = !data && !isInitialLoading && !isCreatePage;
   const loading = isInitialLoading && !isCreatePage;
   const isUploading = uploading > 0;
-  const hasFiles = !!modelVersion?.files?.length;
+  // ExternalGeneration versions are intentionally file-less (routed via external engines),
+  // so the no-files publish warning doesn't apply to them.
+  const isExternalGeneration =
+    modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
+  const hasFiles = !!modelVersion?.files?.length || isExternalGeneration;
   const confirmPublish = isUploading || !hasFiles;
   const confirmMessage = isUploading
     ? 'Files are still uploading. Publishing now will make your model visible, but downloads will not work until uploads finish. Continue?'


### PR DESCRIPTION
## Summary

Follow-up to #2217. Two more places in the UI were treating "missing files" as a publish problem, which doesn't apply to `ExternalGeneration` versions (intentionally file-less):

- **`PostUpsertForm2`** — the "this version doesn't have any files attached" confirm warning fired before publishing the post. Now skipped when `usageControl === ExternalGeneration`.
- **`ModelVersionDetails`** — both `showPublishButton` and `showRepublishPrivateButton` gates required `hasFiles`, so the publish/republish buttons were hidden on the model page for `ExternalGeneration` versions. Now treat these versions as having the required assets.

Both checks now also accept `ExternalGeneration` as a valid "fileless on purpose" state, mirroring the carve-outs already in `ModelVersionList`, `FilesProvider`, `Files.tsx`, the wizard navigation, and the daily reset cron.

## Test plan

- [ ] Mod creates an `ExternalGeneration` version → on the model page, "Publish" button appears (not hidden)
- [ ] Mod publishes the post for an `ExternalGeneration` version → no "no files attached" confirm modal blocks publish
- [ ] Mod opens an unpublished private `ExternalGeneration` version → "Republish" button appears
- [ ] Regular `Generation`/`Download` version with no files → still gets the existing warnings/gates (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)