### PR TITLE
fix(notifications): stop burning PendingNotification sequence ids

### DIFF
--- a/src/server/jobs/send-notifications.ts
+++ b/src/server/jobs/send-notifications.ts
@@ -77,23 +77,56 @@ export const sendNotificationsJob = createJob('send-notifications', '*/1 * * * *
             if (!isEmpty(pendingData)) {
               const batches = chunk(Object.values(pendingData), batchSize);
               for (const batch of batches) {
+                // UPDATE-first to avoid burning sequence ids on existing keys.
+                // For a multi-row INSERT ... ON CONFLICT, Postgres calls nextval() for every
+                // row in the VALUES list before the conflict check, so a 5000-row batch where
+                // every row conflicts burns 5000 ids. Splitting into UPDATE + INSERT-on-miss
+                // burns ids only for keys that don't already exist.
+
                 //language=text
-                const insertQuery = Prisma.sql`
-                INSERT INTO "PendingNotification" (key, type, category, users, details)
-                VALUES
-                ${Prisma.join(
-                  batch.map(
-                    (d) =>
-                      Prisma.sql`(${d.key}, ${d.type}, ${d.category}, ${
-                        '{' + d.users.join(',') + '}'
-                      }, ${JSON.stringify(d.details)}::jsonb)`
-                  )
-                )}
-                ON CONFLICT (key) DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()
+                const updateQuery = Prisma.sql`
+                UPDATE "PendingNotification" pn
+                SET "users" = u.users::int[],
+                    "lastTriggered" = NOW()
+                FROM (VALUES
+                  ${Prisma.join(
+                    batch.map((d) => Prisma.sql`(${d.key}, ${'{' + d.users.join(',') + '}'})`)
+                  )}
+                ) AS u(key, users)
+                WHERE pn."key" = u.key
+                RETURNING pn."key"
               `;
 
-                const resp = await notifDbWrite.cancellableQuery(insertQuery);
-                await resp.result();
+                const updateResp = await notifDbWrite.cancellableQuery<{ key: string }>(
+                  updateQuery
+                );
+                const updatedKeys = new Set((await updateResp.result()).map((r) => r.key));
+
+                const toInsert = batch.filter((d) => !updatedKeys.has(d.key));
+                if (toInsert.length) {
+                  // ON CONFLICT (key) DO UPDATE handles two narrow races:
+                  //   1. another writer inserted this key between our UPDATE and INSERT
+                  //   2. consumer deleted a row between our UPDATE matching it and now
+                  // Both are bounded — race-loser burns 1 id, much better than the prior 5000.
+
+                  //language=text
+                  const insertQuery = Prisma.sql`
+                  INSERT INTO "PendingNotification" (key, type, category, users, details)
+                  VALUES
+                  ${Prisma.join(
+                    toInsert.map(
+                      (d) =>
+                        Prisma.sql`(${d.key}, ${d.type}, ${d.category}, ${
+                          '{' + d.users.join(',') + '}'
+                        }, ${JSON.stringify(d.details)}::jsonb)`
+                    )
+                  )}
+                  ON CONFLICT (key) DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()
+                `;
+
+                  const insertResp = await notifDbWrite.cancellableQuery(insertQuery);
+                  await insertResp.result();
+                }
               }
             }
 

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -50,20 +50,34 @@ export const createNotification = async (data: CreateNotificationPendingRow) => 
     // If the user has this notification type disabled, don't create a notification.
     if (targets.length === 0) return;
 
-    const insResp = await notifDbWrite.cancellableQuery(Prisma.sql`
-      INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds")
-      VALUES (
-        ${data.key},
-        ${data.type},
-        ${data.category}::"NotificationCategory",
-        ${'{' + targets.join(',') + '}'},
-        ${JSON.stringify(data.details)}::jsonb,
-        ${data.debounceSeconds}
-      )
-      ON CONFLICT (key)
-      DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()
+    // UPDATE-first to avoid burning a sequence id when the key already exists.
+    // INSERT ... ON CONFLICT (key) DO UPDATE in the fallback handles the cross-writer race
+    // where another writer inserts the same key between our UPDATE and INSERT.
+    const updateResp = await notifDbWrite.cancellableQuery<{ id: number }>(Prisma.sql`
+      UPDATE "PendingNotification"
+      SET "users" = ${'{' + targets.join(',') + '}'}::int[],
+          "lastTriggered" = NOW()
+      WHERE "key" = ${data.key}
+      RETURNING id
     `);
-    await insResp.result();
+    const updated = await updateResp.result();
+
+    if (updated.length === 0) {
+      const insertResp = await notifDbWrite.cancellableQuery(Prisma.sql`
+        INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds")
+        VALUES (
+          ${data.key},
+          ${data.type},
+          ${data.category}::"NotificationCategory",
+          ${'{' + targets.join(',') + '}'},
+          ${JSON.stringify(data.details)}::jsonb,
+          ${data.debounceSeconds}
+        )
+        ON CONFLICT (key)
+        DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()
+      `);
+      await insertResp.result();
+    }
   } catch (e) {
     const error = e as Error;
     logToAxiom(


### PR DESCRIPTION
Replace `INSERT ... ON CONFLICT (key) DO UPDATE` with UPDATE-first pattern. Postgres calls nextval() for every row in a multi-row INSERT before checking conflicts, so a 5000-row batch where every row conflicts burned 5000 sequence ids. Splitting into UPDATE (no nextval) + INSERT-on-miss burns ids only for genuinely new keys.

The fallback INSERT keeps ON CONFLICT (key) DO UPDATE for cross-writer race safety -- race-losers still burn 1 id, but that's bounded vs. the prior structural burn.

Affects two writers:
- send-notifications.ts: bulk UPDATE FROM (VALUES ...) RETURNING key, then INSERT only the unmatched keys
- notification.service.ts createNotification(): single-row UPDATE RETURNING id, then INSERT if 0 rows updated

club.service.ts uses uuid() in the key so it never conflicts -- no change needed there.

Behavior is preserved: same fields are updated on conflict (users, lastTriggered), same race characteristics, same error handling. Only the sequence-id consumption pattern changes.