### PR TITLE
feat(login): gate email on alias hosts

### DIFF
--- a/src/components/Login/LoginContent.tsx
+++ b/src/components/Login/LoginContent.tsx
@@ -48,7 +48,12 @@ export function LoginContent(args: {
   // Skip if currentHost isn't known — encoding an empty host into the
   // returnUrl would produce `https:///...` and break the post-login redirect.
   const greenDomain = useServerDomains().green;
-  const { domain: domainFlags, host: currentHost, availableOAuthProviders } = useAppContext();
+  const {
+    domain: domainFlags,
+    host: currentHost,
+    serverDomains: serverDomainConfigs,
+    availableOAuthProviders,
+  } = useAppContext();
   const isOnGreen = domainFlags.green;
   const civitaiLoginHref =
     !isOnGreen && currentHost
@@ -57,9 +62,28 @@ export function LoginContent(args: {
         )}`
       : undefined;
 
+  // Detect alias-host case: current host is registered for a color but is NOT
+  // that color's primary. On alias hosts we suppress every login surface
+  // except the green-bounce button so all auth happens on the canonical
+  // primary and syncs back via sync-account.
+  const isOnAlias = (() => {
+    if (!currentHost) return false;
+    const normalized = currentHost.toLowerCase();
+    for (const cfg of Object.values(serverDomainConfigs)) {
+      if (!cfg) continue;
+      if (cfg.primary === normalized) return false;
+      if (cfg.aliases.includes(normalized)) return true;
+    }
+    return false;
+  })();
+
   // Filter the static provider list down to providers with credentials
   // configured for the active host (computed server-side per request).
-  const availableProviders = providers.filter((p) => availableOAuthProviders.includes(p.id));
+  // On alias hosts, suppress entirely so the green-bounce button is the
+  // only login path.
+  const availableProviders = isOnAlias
+    ? []
+    : providers.filter((p) => availableOAuthProviders.includes(p.id));
 
   useEffect(() => {
     if (reason) {
@@ -151,8 +175,17 @@ export function LoginContent(args: {
               }}
             />
           ))}
-          <Text className="py-2 text-center text-sm font-semibold">Or continue with Email</Text>
-          <EmailLogin returnUrl={returnUrl} size="md" status={status} onStatusChange={setStatus} />
+          {!isOnAlias && (
+            <>
+              <Text className="py-2 text-center text-sm font-semibold">Or continue with Email</Text>
+              <EmailLogin
+                returnUrl={returnUrl}
+                size="md"
+                status={status}
+                onStatusChange={setStatus}
+              />
+            </>
+          )}
         </div>
       ) : (
         <Alert

--- a/src/server/auth/next-auth-options.ts
+++ b/src/server/auth/next-auth-options.ts
@@ -24,6 +24,7 @@ import { refreshToken, clearTokenRefreshMarker } from '~/server/auth/token-refre
 import { refreshSession } from '~/server/auth/session-invalidation';
 import {
   getRequestDomainColor,
+  isAliasHost,
   oauthProviderIds,
   resolveOAuthCredentialsForHost,
   type OAuthProviderId,
@@ -538,14 +539,20 @@ export function createAuthOptions(req?: AuthedRequest): NextAuthOptions {
       (reqHostname !== 'localhost' ? '.' : '') + reqHostname;
   }
 
-  // Filter OAuth providers to those with credentials configured for this host.
-  // Alias hosts only see providers with explicit per-alias credentials — no
-  // fallback to the global default. Primary hosts keep the legacy fallback.
-  // Run on every request with a host (not gated on domainColor) so unknown
-  // hosts get the same filter that signin/callback would apply downstream.
+  // Filter providers based on host:
+  // - OAuth providers (discord/github/google/reddit): require credentials
+  //   configured for this host. Alias hosts need an explicit alias-keyed
+  //   credential; primary hosts keep the legacy global fallback.
+  // - Email provider: hidden on alias hosts. The magic-link flow would
+  //   otherwise create a session scoped to the alias and bypass the
+  //   intended sync-from-primary model.
+  // Other providers (account-switch, token-login, testing-login) pass
+  // through unchanged regardless of host.
   const host = req.headers.host;
   if (host) {
+    const onAlias = isAliasHost(host);
     options.providers = options.providers.filter((provider) => {
+      if (provider.id === 'email') return !onAlias;
       if (!oauthProviderIds.includes(provider.id as OAuthProviderId)) return true;
       return resolveOAuthCredentialsForHost(provider.id as OAuthProviderId, host) !== null;
     });

--- a/src/server/utils/server-domain.ts
+++ b/src/server/utils/server-domain.ts
@@ -83,6 +83,24 @@ export function isPrimaryHost(host: string): boolean {
 }
 
 /**
+ * True if `host` resolves to a color but is NOT that color's primary —
+ * i.e. it's a registered alias host. Used to suppress login surfaces that
+ * should only run on the canonical primaries (e.g. email magic-link, which
+ * would otherwise create a session scoped to the alias and bypass the
+ * intended sync-from-primary flow).
+ */
+export function isAliasHost(host: string): boolean {
+  const normalized = host.toLowerCase();
+  for (const color of colorDomainNames) {
+    const cfg = serverDomainMap[color];
+    if (!cfg) continue;
+    if (cfg.primary === normalized) return false;
+    if (cfg.aliases.includes(normalized)) return true;
+  }
+  return false;
+}
+
+/**
  * Resolve OAuth credentials for `provider` on `host`.
  *
  * - Primary hosts: prefer the per-color override


### PR DESCRIPTION
## Summary

Suppress every login surface on alias hosts except the green-bounce button. On an alias (e.g. civitai.blue resolving to the blue color), the email magic-link flow would otherwise create a session scoped to the alias and bypass the intended "auth on the canonical primary, sync back via sync-account" model.

- `LoginContent`: hides the email form + "Or continue with Email" heading on alias hosts. OAuth providers also force-suppressed on alias regardless of whether alias-keyed creds happen to be configured.
- `next-auth-options`: filters the email provider out of options when the request host is an alias, so a direct POST to `/api/auth/signin/email` also fails. Defense in depth.
- `server-domain`: new `isAliasHost(host)` helper.

## Test plan

- [ ] Visit alias host (`civitai-dev.cyan` locally or `civitai.blue` in prod). Login page shows only the "civitai-dev.green" / `civitai.green` bounce button.
- [ ] OAuth provider buttons absent on alias.
- [ ] Email form + "Or continue with Email" heading absent on alias.
- [ ] Direct POST to `/api/auth/signin/email` from alias host returns no provider error.
- [ ] Primary hosts (civitai.com, civitai.green, civitai.red) unchanged — full provider list + email login still rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)