### PR TITLE
chore(db): bump Prisma transaction timeout to 20s default

### DIFF
--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -48,7 +48,15 @@ const createPrismaClient = ({ readonly }: { readonly: boolean }): PrismaClient =
     });
   }
   const dbUrl = readonly ? env.DATABASE_REPLICA_URL : env.DATABASE_URL;
-  const options = { log, datasources: { db: { url: dbUrl } } } as Prisma.PrismaClientOptions;
+  const options = {
+    log,
+    datasources: { db: { url: dbUrl } },
+    // Bumped from Prisma defaults (maxWait 2s, timeout 5s) to avoid pods entering
+    // a "Transaction already closed: timeout was 5000 ms" failure loop during
+    // event-loop starvation on DP. Per-call overrides via prisma.$transaction(cb,
+    // { timeout: N }) still take precedence.
+    transactionOptions: { maxWait: 5000, timeout: 20000 },
+  } as Prisma.PrismaClientOptions;
   const prisma = new PrismaClient(options);
 
   // use with prisma-slow,prisma-showparams


### PR DESCRIPTION
## Summary

- Bump global Prisma `transactionOptions` default from `{ maxWait: 2000, timeout: 5000 }` (Prisma defaults) to `{ maxWait: 5000, timeout: 20000 }` for both write and read clients (single `createPrismaClient` factory in `src/server/db/client.ts`).
- Per-call overrides via `prisma.$transaction(cb, { timeout: N })` still take precedence, so existing explicit timeouts at call sites are unchanged.

## Why

Production DP pods periodically hit event-loop starvation and enter a tight failure loop logging:

```
Transaction API error: Transaction already closed: timeout was 5000 ms, however 30000+ ms passed
```

Once a pod gets into that state it consumes CPU without serving traffic until it's restarted. Bumping the default to 20s gives legit in-flight transactions room to finish (or fail more gracefully) under load instead of cascading.

This is a defensive fix, not a root-cause fix for the starvation itself.

## Risk / trade-offs

- A stuck-but-eventually-completing transaction now holds its row locks for up to 20s instead of 5s. In a healthy node that's invisible; under contention it could lengthen lock waits modestly. Worth it vs. the alternative of zombie pods.
- Edge runtime is not affected (this PrismaClient is only constructed inside `if (!env.IS_BUILD)` for the Node server).
- `maxWait` (time waiting to start an interactive tx) bumped 2s → 5s — same reasoning.

## Test plan

- [ ] Watch DP pod logs after deploy for the "Transaction already closed: timeout was 5000 ms" line — should drop to ~zero (replaced by either successful completion or a 20s timeout, which is much rarer).
- [ ] Confirm no regression in P95 transaction durations on healthy traffic (Tempo/spanmetrics on `prisma:client:operation`).
- [ ] Spot-check that explicit per-call `prisma.$transaction(cb, { timeout: N })` overrides still apply (e.g., long-running migrations / batch jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)