### PR TITLE
postgres-query: add --notifications flag for the DP notifications-db

### DIFF
--- a/.claude/skills/postgres-query/SKILL.md
+++ b/.claude/skills/postgres-query/SKILL.md
@@ -22,6 +22,7 @@ node .claude/skills/postgres-query/query.mjs "SELECT * FROM \"User\" LIMIT 5"
 | `--explain` | Run EXPLAIN ANALYZE on the query |
 | `--writable` | Use primary database instead of read replica (requires user permission) |
 | `--data-packet` | Use the DataPacket replica (`DATABASE_DATA_PACKET_URL`) — read-only |
+| `--notifications` | Query the notifications-db (DataPacket) — read-only via SSH bastion (see setup below) |
 | `--timeout <s>`, `-t` | Query timeout in seconds (default: 30) |
 | `--file`, `-f` | Read query from a file |
 | `--json` | Output results as JSON |
@@ -39,6 +40,9 @@ node .claude/skills/postgres-query/query.mjs --explain "SELECT * FROM \"Model\" 
 # Override default 30s timeout for longer queries
 node .claude/skills/postgres-query/query.mjs --timeout 60 "SELECT ... (complex query)"
 
+# Query the notifications-db
+node .claude/skills/postgres-query/query.mjs --notifications "SELECT count(*) FROM \"Notification\""
+
 # Query from file
 node .claude/skills/postgres-query/query.mjs -f my-query.sql
 
@@ -53,12 +57,71 @@ node .claude/skills/postgres-query/query.mjs --json "SELECT id, username FROM \"
 | (default) | `DATABASE_REPLICA_URL` (falls back to `DATABASE_URL`) | Most queries — read-only main replica |
 | `--writable` | `DATABASE_URL` | Writes against primary; needs user permission |
 | `--data-packet` | `DATABASE_DATA_PACKET_URL` | Querying the DataPacket replica (read-only) |
+| `--notifications` | `NOTIFICATION_DB_REPLICA_URL` | Querying notifications-db (read-only); requires SSH tunnel |
+
+## Querying the notifications-db (DataPacket)
+
+The notifications-db lives on the DataPacket cluster. Direct network access from your laptop isn't allowed — connect via the SSH bastion.
+
+### One-time setup
+
+1. Make sure your SSH public key has been added to the bastion. If you don't have access yet, ask zach to add your `~/.ssh/id_ed25519.pub` to:
+
+   `clusters/production/apps/notifications-db/secrets/bastion-ssh-keys.enc.yaml`
+
+2. Add an SSH config entry (`~/.ssh/config`) so the tunnel is one command:
+
+   ```
+   Host notif-bastion
+     HostName 185.180.13.69
+     Port 2223
+     User bastion
+     IdentityFile ~/.ssh/id_ed25519
+     # Tunnel local 5433 → cluster pgbouncer ro pooler
+     LocalForward 5433 pgbouncer-pooler-notifications-ro.cnpg-database.svc.cluster.local:5432
+     ServerAliveInterval 60
+   ```
+
+3. Add the connection string to your project `.env` (or `.claude/skills/postgres-query/.env`):
+
+   ```
+   NOTIFICATION_DB_REPLICA_URL=postgresql://notifications_readonly:<password>@127.0.0.1:5433/notification_prod?sslmode=disable
+   ```
+
+   Get the password from zach (it's stored in `bastion-pg-creds.enc.yaml` in the datapacket-talos repo). The same password is also preloaded inside the bastion's `.pgpass` for in-pod use.
+
+### Running queries
+
+```bash
+# 1. Open the SSH tunnel in one terminal (stays open)
+ssh notif-bastion
+
+#    The bastion's MOTD shows the available tables and tools.
+#    You can run ad-hoc psql in this terminal too — `psql` is preloaded
+#    with .pgpass and PGHOST/PGUSER env vars.
+
+# 2. In another terminal, run queries via the skill
+node .claude/skills/postgres-query/query.mjs --notifications \
+  "SELECT count(*) FROM \"Notification\""
+
+node .claude/skills/postgres-query/query.mjs --notifications --explain \
+  "SELECT * FROM \"UserNotification\" WHERE \"userId\" = 12345 ORDER BY \"createdAt\" DESC LIMIT 50"
+```
+
+### Available tables (read-only)
+
+- `Notification` — canonical notifications
+- `UserNotification` — per-user fanout (largest table)
+- `PendingNotification` — processing queue (often empty)
+
+The role `notifications_readonly` only has `SELECT`. Writes are also rejected at the pooler level (replica routing).
 
 ## Safety Features
 
 1. **Read-only by default**: Uses `DATABASE_REPLICA_URL` to prevent accidental writes
 2. **Write protection**: Blocks INSERT/UPDATE/DELETE/DROP unless `--writable` flag is used
-3. **Explicit permission required**: Before using `--writable`, you MUST ask the user for permission
+3. **Notifications is always read-only**: `--notifications` blocks writes client-side AND the database role/pooler reject them
+4. **Explicit permission required**: Before using `--writable`, you MUST ask the user for permission
 
 ## When to Use --writable
 

--- a/.claude/skills/postgres-query/query.mjs
+++ b/.claude/skills/postgres-query/query.mjs
@@ -74,6 +74,7 @@ let query = '';
 let explain = false;
 let writable = false;
 let dataPacket = false;
+let notifications = false;
 let jsonOutput = false;
 let quiet = false;
 let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
@@ -86,6 +87,8 @@ for (let i = 0; i < args.length; i++) {
     writable = true;
   } else if (arg === '--data-packet') {
     dataPacket = true;
+  } else if (arg === '--notifications') {
+    notifications = true;
   } else if (arg === '--json') {
     jsonOutput = true;
   } else if (arg === '--quiet' || arg === '-q') {
@@ -130,7 +133,11 @@ Examples:
 
 // Select connection string
 let connectionString;
-if (dataPacket) {
+if (notifications) {
+  // notifications-db on DataPacket (read-only via SSH bastion tunnel).
+  // Set NOTIFICATION_DB_REPLICA_URL in .env after starting the tunnel.
+  connectionString = process.env.NOTIFICATION_DB_REPLICA_URL;
+} else if (dataPacket) {
   connectionString = process.env.DATABASE_DATA_PACKET_URL;
 } else if (writable) {
   connectionString = process.env.DATABASE_URL;
@@ -139,17 +146,26 @@ if (dataPacket) {
 }
 
 if (!connectionString) {
-  console.error('Error: No database connection string found in environment');
+  if (notifications) {
+    console.error('Error: NOTIFICATION_DB_REPLICA_URL is not set. Start the SSH tunnel and add it to .env (see SKILL.md).');
+  } else {
+    console.error('Error: No database connection string found in environment');
+  }
   process.exit(1);
 }
 
 // Safety check for writable operations
-if (!writable) {
+// --notifications connects through a read-only role on a replica — writes
+// would fail anyway, but block them client-side so users get a clearer error.
+if (!writable || notifications) {
   const upperQuery = query.toUpperCase().trim();
   const writeOps = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE'];
   for (const op of writeOps) {
     if (upperQuery.startsWith(op)) {
-      console.error(`Error: Write operation detected (${op}). Use --writable flag to confirm.`);
+      const ctx = notifications
+        ? '--notifications is read-only (bastion routes through a replica).'
+        : 'Use --writable flag to confirm.';
+      console.error(`Error: Write operation detected (${op}). ${ctx}`);
       console.error('This requires explicit user permission as it modifies the database.');
       process.exit(1);
     }
@@ -168,11 +184,13 @@ async function main() {
     await client.connect();
 
     if (!quiet) {
-      const dbType = dataPacket
-        ? 'DATA-PACKET REPLICA (read-only)'
-        : writable
-          ? 'PRIMARY (writable)'
-          : 'REPLICA (read-only)';
+      const dbType = notifications
+        ? 'NOTIFICATIONS-DB REPLICA via bastion (read-only)'
+        : dataPacket
+          ? 'DATA-PACKET REPLICA (read-only)'
+          : writable
+            ? 'PRIMARY (writable)'
+            : 'REPLICA (read-only)';
       console.error(`Connected to ${dbType} (timeout: ${timeoutSeconds}s)\n`);
     }
 


### PR DESCRIPTION
Adds a --notifications flag that uses NOTIFICATION_DB_REPLICA_URL to query the notifications-db on DataPacket through the new SSH bastion.

The notifications-db cutover from DO managed Postgres → DP CNPG completed on 2026-04-29. Direct access from laptops is gated behind an SSH bastion (notifications-bastion in cnpg-database, exposed at 185.180.13.69:2223 via nginx-minio-proxy). The skill's SKILL.md now documents the SSH config + .env line devs need to set up.

The --notifications path is read-only at three layers:
  1. Client-side: query.mjs blocks INSERT/UPDATE/DELETE/etc.
  2. Pgbouncer: routes through the -ro pooler (replica)
  3. Postgres: the notifications_readonly role only has SELECT