### PR TITLE
fix(model-file): delete S3 objects when files are deleted/updated

### DIFF
--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -137,16 +137,20 @@ export async function updateFile({
   });
   await deleteFilesForModelVersionCache(modelFile.modelVersionId);
 
-  // Clean up old S3 object after DB update succeeds (best-effort)
+  // Clean up old S3 object after DB update succeeds (best-effort).
+  // Terminal .catch on the chain so an Axiom-side rejection can't leak as
+  // an unhandled rejection in this fire-and-forget path.
   if (oldUrl) {
-    deleteModelFileObject(oldUrl).catch((error) =>
-      logToAxiom({
-        type: 'error',
-        name: 'model-file-delete-s3-object',
-        message: `Failed to delete old S3 object for file ${id}`,
-        error,
-      })
-    );
+    deleteModelFileObject(oldUrl)
+      .catch((error) =>
+        logToAxiom({
+          type: 'error',
+          name: 'model-file-delete-s3-object',
+          message: `Failed to delete old S3 object for file ${id}`,
+          error,
+        })
+      )
+      .catch(() => {});
   }
 
   // Merge committed updates back into the snapshot so the returned record
@@ -208,16 +212,20 @@ export async function deleteFile({
   const row = rows[0];
   if (row?.modelVersionId) await deleteFilesForModelVersionCache(row.modelVersionId);
 
-  // Clean up S3 object after DB delete succeeds (best-effort)
+  // Clean up S3 object after DB delete succeeds (best-effort).
+  // Terminal .catch on the chain so an Axiom-side rejection can't leak as
+  // an unhandled rejection in this fire-and-forget path.
   if (row && file.url) {
-    deleteModelFileObject(file.url).catch((error) =>
-      logToAxiom({
-        type: 'error',
-        name: 'model-file-delete-s3-object',
-        message: `Failed to delete S3 object for file ${id}`,
-        error,
-      })
-    );
+    deleteModelFileObject(file.url)
+      .catch((error) =>
+        logToAxiom({
+          type: 'error',
+          name: 'model-file-delete-s3-object',
+          message: `Failed to delete S3 object for file ${id}`,
+          error,
+        })
+      )
+      .catch(() => {});
   }
 
   return row ? { modelVersionId: row.modelVersionId, modelId: row.modelId } : undefined;

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -3,6 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { CacheTTL } from '~/server/common/constants';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type {
@@ -138,8 +139,13 @@ export async function updateFile({
 
   // Clean up old S3 object after DB update succeeds (best-effort)
   if (oldUrl) {
-    deleteModelFileObject(oldUrl).catch((err) =>
-      console.error(`Failed to delete old S3 object for file ${id}:`, err)
+    deleteModelFileObject(oldUrl).catch((error) =>
+      logToAxiom({
+        type: 'error',
+        name: 'model-file-delete-s3-object',
+        message: `Failed to delete old S3 object for file ${id}`,
+        error,
+      })
     );
   }
 
@@ -204,8 +210,13 @@ export async function deleteFile({
 
   // Clean up S3 object after DB delete succeeds (best-effort)
   if (row && file.url) {
-    deleteModelFileObject(file.url).catch((err) =>
-      console.error(`Failed to delete S3 object for file ${id}:`, err)
+    deleteModelFileObject(file.url).catch((error) =>
+      logToAxiom({
+        type: 'error',
+        name: 'model-file-delete-s3-object',
+        message: `Failed to delete S3 object for file ${id}`,
+        error,
+      })
     );
   }
 

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -18,6 +18,7 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import { ModelStatus, ModelUploadType } from '~/shared/utils/prisma/enums';
+import { deleteModelFileObject } from '~/utils/s3-utils';
 import { prepareFile } from '~/utils/file-helpers';
 
 export type ModelFileCached = AsyncReturnType<typeof fetchModelFilesForCache>[number];
@@ -113,6 +114,7 @@ export async function updateFile({
     where: { id, modelVersion: { model: !isModerator ? { userId } : undefined } },
     select: {
       id: true,
+      url: true,
       metadata: true,
       modelVersionId: true,
       sizeKB: true,
@@ -120,6 +122,9 @@ export async function updateFile({
     },
   });
   if (!modelFile) throw throwNotFoundError();
+
+  // If URL is changing, capture the old one for S3 cleanup
+  const oldUrl = inputData.url && inputData.url !== modelFile.url ? modelFile.url : undefined;
 
   metadata = metadata ? { ...(modelFile.metadata as Prisma.JsonObject), ...metadata } : undefined;
   await dbWrite.modelFile.updateMany({
@@ -130,6 +135,13 @@ export async function updateFile({
     },
   });
   await deleteFilesForModelVersionCache(modelFile.modelVersionId);
+
+  // Clean up old S3 object after DB update succeeds (best-effort)
+  if (oldUrl) {
+    deleteModelFileObject(oldUrl).catch((err) =>
+      console.error(`Failed to delete old S3 object for file ${id}:`, err)
+    );
+  }
 
   // Merge committed updates back into the snapshot so the returned record
   // reflects post-update state (e.g. `sizeKB` on a re-upload). `updateMany`
@@ -150,6 +162,7 @@ export async function deleteFile({
   const file = await dbWrite.modelFile.findFirst({
     where: { id, modelVersion: { model: !isModerator ? { userId } : undefined } },
     select: {
+      url: true,
       type: true,
       modelVersion: {
         select: {
@@ -188,6 +201,13 @@ export async function deleteFile({
 
   const row = rows[0];
   if (row?.modelVersionId) await deleteFilesForModelVersionCache(row.modelVersionId);
+
+  // Clean up S3 object after DB delete succeeds (best-effort)
+  if (row && file.url) {
+    deleteModelFileObject(file.url).catch((err) =>
+      console.error(`Failed to delete S3 object for file ${id}:`, err)
+    );
+  }
 
   return row ? { modelVersionId: row.modelVersionId, modelId: row.modelId } : undefined;
 }

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -128,8 +128,12 @@ export async function updateFile({
   const oldUrl = inputData.url && inputData.url !== modelFile.url ? modelFile.url : undefined;
 
   metadata = metadata ? { ...(modelFile.metadata as Prisma.JsonObject), ...metadata } : undefined;
-  await dbWrite.modelFile.updateMany({
-    where: { id },
+  // CAS guard on URL changes: only apply if the row's url is still what we read.
+  // Prevents two concurrent URL-changing updateFile calls from both scheduling a
+  // delete of the same captured `oldUrl`. Pure-metadata updates skip the guard
+  // so they aren't starved by url-change races.
+  const updateResult = await dbWrite.modelFile.updateMany({
+    where: oldUrl ? { id, url: modelFile.url } : { id },
     data: {
       ...inputData,
       metadata,
@@ -138,9 +142,13 @@ export async function updateFile({
   await deleteFilesForModelVersionCache(modelFile.modelVersionId);
 
   // Clean up old S3 object after DB update succeeds (best-effort).
+  // Only fires if our conditional update actually applied — otherwise another
+  // writer owns the oldUrl→newUrl transition and will (or already did) handle it.
   // Terminal .catch on the chain so an Axiom-side rejection can't leak as
-  // an unhandled rejection in this fire-and-forget path.
-  if (oldUrl) {
+  // an unhandled rejection in this fire-and-forget path. The refcount check
+  // inside deleteModelFileObject is the load-bearing safety: it skips the
+  // delete if any other ModelFile row still references the URL.
+  if (oldUrl && updateResult.count > 0) {
     deleteModelFileObject(oldUrl)
       .catch((error) =>
         logToAxiom({

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -176,11 +176,13 @@ export async function deleteFile({
   userId,
   isModerator,
 }: GetByIdInput & { userId: number; isModerator?: boolean }) {
-  // Check if deleting a training file for a model still in draft/training state
+  // Check if deleting a training file for a model still in draft/training state.
+  // Don't pull `url` here — it could change between this read and the DELETE
+  // below if a concurrent updateFile lands. We RETURN the url from DELETE
+  // instead, so the S3 cleanup always targets the URL that actually got removed.
   const file = await dbWrite.modelFile.findFirst({
     where: { id, modelVersion: { model: !isModerator ? { userId } : undefined } },
     select: {
-      url: true,
       type: true,
       modelVersion: {
         select: {
@@ -205,7 +207,9 @@ export async function deleteFile({
     );
   }
 
-  const rows = await dbWrite.$queryRaw<{ modelVersionId: number; modelId: number }[]>`
+  const rows = await dbWrite.$queryRaw<
+    { modelVersionId: number; modelId: number; url: string }[]
+  >`
     DELETE FROM "ModelFile" mf
     USING "ModelVersion" mv, "Model" m
     WHERE mf."modelVersionId" = mv.id
@@ -214,17 +218,22 @@ export async function deleteFile({
     ${isModerator ? Prisma.empty : Prisma.raw(`AND m."userId" = ${userId}`)}
     RETURNING
       mv.id as "modelVersionId",
-      m.id as "modelId"
+      m.id as "modelId",
+      mf.url as "url"
   `;
 
   const row = rows[0];
   if (row?.modelVersionId) await deleteFilesForModelVersionCache(row.modelVersionId);
 
   // Clean up S3 object after DB delete succeeds (best-effort).
+  // Use `row.url` (RETURNING from DELETE) — not the pre-DELETE snapshot — so a
+  // concurrent updateFile that swapped the URL doesn't cause us to delete the
+  // old (still-referenced) object while the row at the new URL is the one
+  // that actually got removed.
   // Terminal .catch on the chain so an Axiom-side rejection can't leak as
   // an unhandled rejection in this fire-and-forget path.
-  if (row && file.url) {
-    deleteModelFileObject(file.url)
+  if (row?.url) {
+    deleteModelFileObject(row.url)
       .catch((error) =>
         logToAxiom({
           type: 'error',

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -139,16 +139,27 @@ export async function updateFile({
       metadata,
     },
   });
+
+  // CAS lost: another writer swapped the URL between findUnique and updateMany.
+  // Surface the conflict instead of silently returning success — the caller
+  // needs to know their write did NOT apply. Skip the cache bust too, since
+  // we didn't change anything that would invalidate it.
+  if (oldUrl && updateResult.count === 0) {
+    throw throwBadRequestError(
+      'ModelFile URL was modified concurrently; retry your update'
+    );
+  }
+
   await deleteFilesForModelVersionCache(modelFile.modelVersionId);
 
   // Clean up old S3 object after DB update succeeds (best-effort).
-  // Only fires if our conditional update actually applied — otherwise another
-  // writer owns the oldUrl→newUrl transition and will (or already did) handle it.
-  // Terminal .catch on the chain so an Axiom-side rejection can't leak as
-  // an unhandled rejection in this fire-and-forget path. The refcount check
-  // inside deleteModelFileObject is the load-bearing safety: it skips the
-  // delete if any other ModelFile row still references the URL.
-  if (oldUrl && updateResult.count > 0) {
+  // Only fires when we actually swapped the URL on this call — pure-metadata
+  // updates have no oldUrl to clean up. Terminal .catch on the chain so an
+  // Axiom-side rejection can't leak as an unhandled rejection in this
+  // fire-and-forget path. The refcount check inside deleteModelFileObject is
+  // the load-bearing safety: it skips the delete if any other ModelFile row
+  // still references the URL.
+  if (oldUrl) {
     deleteModelFileObject(oldUrl)
       .catch((error) =>
         logToAxiom({

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -83,6 +83,7 @@ import { isDefined } from '~/utils/type-guards';
 import { ingestModelById, updateModelLastVersionAt } from './model.service';
 import { filesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
+import { deleteModelFileObjects } from '~/utils/s3-utils';
 import type { BaseModel, BaseModelGroup } from '~/shared/constants/basemodel.constants';
 import { getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
 import type { ImageMetadata } from '~/server/schema/media.schema';
@@ -572,6 +573,14 @@ export const upsertModelVersion = async ({
 };
 
 export const deleteVersionById = async ({ id }: GetByIdInput) => {
+  // Snapshot URLs before the cascade nukes ModelFile rows — we lose them otherwise.
+  const modelFileUrls = (
+    await dbWrite.modelFile.findMany({
+      where: { modelVersionId: id },
+      select: { url: true },
+    })
+  ).map((f) => f.url);
+
   const version = await dbWrite.$transaction(async (tx) => {
     const data = await tx.modelVersion.findFirstOrThrow({
       where: { id },
@@ -604,6 +613,20 @@ export const deleteVersionById = async ({ id }: GetByIdInput) => {
   // that never happened.
   await preventModelVersionLag(version.modelId, version.id);
   await bustMvCache(version.id, version.modelId);
+
+  // Post-commit S3 cleanup — only after Postgres confirms the delete stuck.
+  if (modelFileUrls.length > 0) {
+    try {
+      await deleteModelFileObjects(modelFileUrls);
+    } catch (error) {
+      logToAxiom({
+        type: 'error',
+        name: 'model-version-delete-s3-objects',
+        message: `Failed to delete S3 objects for model version ${id}`,
+        error,
+      });
+    }
+  }
 
   return version;
 };
@@ -2049,6 +2072,16 @@ export const mergeVersions = async ({
     }
   }
 
+  // Defensive snapshot: the merge moves files to the target before deleting source
+  // versions, so this should normally be empty — but if a file slipped past the
+  // updateMany (or a race added one), the cascade would orphan its S3 object.
+  const sourceFileUrls = (
+    await dbWrite.modelFile.findMany({
+      where: { modelVersionId: { in: sourceVersionIds } },
+      select: { url: true },
+    })
+  ).map((f) => f.url);
+
   await dbWrite.$transaction(
     async (tx) => {
       // 1. Remap file types and metadata if provided
@@ -2254,4 +2287,20 @@ export const mergeVersions = async ({
     preventReplicationLag('model', modelId),
     preventReplicationLag('modelVersion', targetVersionId),
   ]);
+
+  // Post-commit S3 cleanup for any stragglers the move missed.
+  if (sourceFileUrls.length > 0) {
+    try {
+      await deleteModelFileObjects(sourceFileUrls);
+    } catch (error) {
+      logToAxiom({
+        type: 'error',
+        name: 'model-version-merge-s3-objects',
+        message: `Failed to delete S3 objects for merged source versions ${sourceVersionIds.join(
+          ', '
+        )}`,
+        error,
+      });
+    }
+  }
 };

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -614,8 +614,29 @@ export const deleteVersionById = async ({ id }: GetByIdInput) => {
   // Postgres transaction actually commits. Running them inside the txn would
   // invalidate caches on rollback, and would publish a lag flag for a delete
   // that never happened.
-  await preventModelVersionLag(version.modelId, version.id);
-  await bustMvCache(version.id, version.modelId);
+  // Each step is independently best-effort: a Redis blip on the lag flag must
+  // NOT shortcut the cache bust or the S3 cleanup, otherwise we leak orphan
+  // objects in B2/R2 every time Redis hiccups during a delete.
+  try {
+    await preventModelVersionLag(version.modelId, version.id);
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'model-version-delete-prevent-lag',
+      message: `Failed to set lag flag for deleted model version ${id}`,
+      error,
+    });
+  }
+  try {
+    await bustMvCache(version.id, version.modelId);
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'model-version-delete-bust-cache',
+      message: `Failed to bust cache for deleted model version ${id}`,
+      error,
+    });
+  }
 
   // Post-commit S3 cleanup — only after Postgres confirms the delete stuck.
   if (modelFileUrls.length > 0) {

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -573,15 +573,18 @@ export const upsertModelVersion = async ({
 };
 
 export const deleteVersionById = async ({ id }: GetByIdInput) => {
-  // Snapshot URLs before the cascade nukes ModelFile rows — we lose them otherwise.
-  const modelFileUrls = (
-    await dbWrite.modelFile.findMany({
-      where: { modelVersionId: id },
-      select: { url: true },
-    })
-  ).map((f) => f.url);
+  // Populated inside the tx so the snapshot is consistent with the cascade.
+  let modelFileUrls: string[] = [];
 
   const version = await dbWrite.$transaction(async (tx) => {
+    // Snapshot URLs inside the tx — must read before the cascade nukes ModelFile rows.
+    modelFileUrls = (
+      await tx.modelFile.findMany({
+        where: { modelVersionId: id },
+        select: { url: true },
+      })
+    ).map((f) => f.url);
+
     const data = await tx.modelVersion.findFirstOrThrow({
       where: { id },
       select: {
@@ -2072,15 +2075,9 @@ export const mergeVersions = async ({
     }
   }
 
-  // Defensive snapshot: the merge moves files to the target before deleting source
-  // versions, so this should normally be empty — but if a file slipped past the
-  // updateMany (or a race added one), the cascade would orphan its S3 object.
-  const sourceFileUrls = (
-    await dbWrite.modelFile.findMany({
-      where: { modelVersionId: { in: sourceVersionIds } },
-      select: { url: true },
-    })
-  ).map((f) => f.url);
+  // Populated inside the tx after files are moved to the target — captures any
+  // file row that slipped past the move and would be orphaned by the cascade.
+  let sourceFileUrls: string[] = [];
 
   await dbWrite.$transaction(
     async (tx) => {
@@ -2113,6 +2110,16 @@ export const mergeVersions = async ({
         where: { modelVersionId: { in: sourceVersionIds } },
         data: { modelVersionId: targetVersionId },
       });
+
+      // Capture any file rows that slipped past the move — those are the ones the
+      // cascade in step 12 will actually orphan. Read inside the tx so the snapshot
+      // is consistent with the cascade.
+      sourceFileUrls = (
+        await tx.modelFile.findMany({
+          where: { modelVersionId: { in: sourceVersionIds } },
+          select: { url: true },
+        })
+      ).map((f) => f.url);
 
       // 3. Aggregate ModelVersionMetric stats
       const sourceMetrics = await tx.modelVersionMetric.findMany({

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
+import { deleteModelFileObjects } from '~/utils/s3-utils';
 import type { ManipulateType } from 'dayjs';
 import dayjs from '~/shared/utils/dayjs';
 import { isEmpty, uniq } from 'lodash-es';
@@ -1499,13 +1500,19 @@ export const permaDeleteModelById = async ({
         },
       });
 
+      // Collect ModelFile URLs before cascade delete removes the rows
+      const modelFileUrls = await tx.modelFile.findMany({
+        where: { modelVersion: { modelId: id } },
+        select: { url: true },
+      });
+
       const deletedModel = await tx.model.delete({ where: { id } });
-      return { deletedModel, imagesToDelete };
+      return { deletedModel, imagesToDelete, modelFileUrls: modelFileUrls.map((f) => f.url) };
     },
     { maxWait: 10000, timeout: 30000 }
   );
 
-  const { deletedModel, imagesToDelete } = deletionResult;
+  const { deletedModel, imagesToDelete, modelFileUrls } = deletionResult;
 
   if (deletedModel) {
     // Delete model bids
@@ -1520,6 +1527,12 @@ export const permaDeleteModelById = async ({
         ids: imagesToDelete.map((img) => img.id),
         action: SearchIndexUpdateQueueAction.Delete,
       });
+    }
+    // Clean up S3 objects for all deleted ModelFiles (best-effort)
+    if (modelFileUrls && modelFileUrls.length > 0) {
+      deleteModelFileObjects(modelFileUrls).catch((err) =>
+        console.error(`Failed to delete S3 objects for model ${id}:`, err)
+      );
     }
   }
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -3,7 +3,6 @@ import { TRPCError } from '@trpc/server';
 import type { ManipulateType } from 'dayjs';
 import { isEmpty, uniq } from 'lodash-es';
 import dayjs from '~/shared/utils/dayjs';
-import { deleteModelFileObjects } from '~/utils/s3-utils';
 import type { SearchParams, SearchResponse } from 'meilisearch';
 import type { SessionUser } from 'next-auth';
 import { env } from '~/env/server';
@@ -142,6 +141,7 @@ import {
 import { decreaseDate, isFutureDate } from '~/utils/date-helpers';
 import { prepareFile } from '~/utils/file-helpers';
 import { fromJson, toJson } from '~/utils/json-helpers';
+import { deleteModelFileObjects } from '~/utils/s3-utils';
 import { isDefined } from '~/utils/type-guards';
 import type {
   GetAssociatedResourcesInput,
@@ -1459,10 +1459,10 @@ export const permaDeleteModelById = async ({
 }) => {
   // Collect ModelFile URLs before the cascade delete — read-only, no need to
   // run inside the transaction. Doing this outside shrinks the 30s tx window.
-  // Safety: best-effort cleanup, so a row added/removed between read and tx
-  // commit just means a benign 404 on S3 delete.
+  // Use dbWrite (primary) so we don't miss recently-added rows due to CDC lag;
+  // this only runs once per admin-triggered perma-delete.
   const modelFileUrls = (
-    await dbRead.modelFile.findMany({
+    await dbWrite.modelFile.findMany({
       where: { modelVersion: { modelId: id } },
       select: { url: true },
     })

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1457,19 +1457,19 @@ export const permaDeleteModelById = async ({
 }: GetByIdInput & {
   userId: number;
 }) => {
-  // Collect ModelFile URLs before the cascade delete — read-only, no need to
-  // run inside the transaction. Doing this outside shrinks the 30s tx window.
-  // Use dbWrite (primary) so we don't miss recently-added rows due to CDC lag;
-  // this only runs once per admin-triggered perma-delete.
-  const modelFileUrls = (
-    await dbWrite.modelFile.findMany({
-      where: { modelVersion: { modelId: id } },
-      select: { url: true },
-    })
-  ).map((f) => f.url);
+  // Populated inside the tx so the snapshot is consistent with the cascade.
+  let modelFileUrls: string[] = [];
 
   const deletionResult = await dbWrite.$transaction(
     async (tx) => {
+      // Snapshot ModelFile URLs inside the tx — read before the cascade nukes the rows.
+      modelFileUrls = (
+        await tx.modelFile.findMany({
+          where: { modelVersion: { modelId: id } },
+          select: { url: true },
+        })
+      ).map((f) => f.url);
+
       const model = await tx.model.findUnique({
         where: { id },
         select: {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1,9 +1,9 @@
 import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
-import { deleteModelFileObjects } from '~/utils/s3-utils';
 import type { ManipulateType } from 'dayjs';
-import dayjs from '~/shared/utils/dayjs';
 import { isEmpty, uniq } from 'lodash-es';
+import dayjs from '~/shared/utils/dayjs';
+import { deleteModelFileObjects } from '~/utils/s3-utils';
 import type { SearchParams, SearchResponse } from 'meilisearch';
 import type { SessionUser } from 'next-auth';
 import { env } from '~/env/server';
@@ -1457,6 +1457,17 @@ export const permaDeleteModelById = async ({
 }: GetByIdInput & {
   userId: number;
 }) => {
+  // Collect ModelFile URLs before the cascade delete — read-only, no need to
+  // run inside the transaction. Doing this outside shrinks the 30s tx window.
+  // Safety: best-effort cleanup, so a row added/removed between read and tx
+  // commit just means a benign 404 on S3 delete.
+  const modelFileUrls = (
+    await dbRead.modelFile.findMany({
+      where: { modelVersion: { modelId: id } },
+      select: { url: true },
+    })
+  ).map((f) => f.url);
+
   const deletionResult = await dbWrite.$transaction(
     async (tx) => {
       const model = await tx.model.findUnique({
@@ -1500,19 +1511,13 @@ export const permaDeleteModelById = async ({
         },
       });
 
-      // Collect ModelFile URLs before cascade delete removes the rows
-      const modelFileUrls = await tx.modelFile.findMany({
-        where: { modelVersion: { modelId: id } },
-        select: { url: true },
-      });
-
       const deletedModel = await tx.model.delete({ where: { id } });
-      return { deletedModel, imagesToDelete, modelFileUrls: modelFileUrls.map((f) => f.url) };
+      return { deletedModel, imagesToDelete };
     },
     { maxWait: 10000, timeout: 30000 }
   );
 
-  const { deletedModel, imagesToDelete, modelFileUrls } = deletionResult;
+  const { deletedModel, imagesToDelete } = deletionResult;
 
   if (deletedModel) {
     // Delete model bids
@@ -1528,11 +1533,18 @@ export const permaDeleteModelById = async ({
         action: SearchIndexUpdateQueueAction.Delete,
       });
     }
-    // Clean up S3 objects for all deleted ModelFiles (best-effort)
-    if (modelFileUrls && modelFileUrls.length > 0) {
-      deleteModelFileObjects(modelFileUrls).catch((err) =>
-        console.error(`Failed to delete S3 objects for model ${id}:`, err)
-      );
+    // Clean up S3 objects for all deleted ModelFiles (admin-triggered, latency-tolerant → await).
+    if (modelFileUrls.length > 0) {
+      try {
+        await deleteModelFileObjects(modelFileUrls);
+      } catch (error) {
+        logToAxiom({
+          type: 'error',
+          name: 'model-perma-delete-s3-objects',
+          message: `Failed to delete S3 objects for model ${id}`,
+          error,
+        });
+      }
     }
   }
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1520,18 +1520,46 @@ export const permaDeleteModelById = async ({
   const { deletedModel, imagesToDelete } = deletionResult;
 
   if (deletedModel) {
-    // Delete model bids
-    await deleteBidsForModel({ modelId: deletedModel.id });
-    // Queue model search index updates
-    await modelsSearchIndex.queueUpdate([
-      { id: deletedModel.id, action: SearchIndexUpdateQueueAction.Delete },
-    ]);
-    // Queue image search index updates
-    if (imagesToDelete.length > 0) {
-      await queueImageSearchIndexUpdate({
-        ids: imagesToDelete.map((img) => img.id),
-        action: SearchIndexUpdateQueueAction.Delete,
+    // Each post-commit step is independently best-effort. The DB tx already
+    // committed, so a downstream failure in bid cleanup or search-index
+    // queueing must NOT shortcut the S3 cleanup — otherwise we leak orphan
+    // objects in B2/R2 every time one of these auxiliary services hiccups.
+    try {
+      await deleteBidsForModel({ modelId: deletedModel.id });
+    } catch (error) {
+      logToAxiom({
+        type: 'error',
+        name: 'model-perma-delete-bids',
+        message: `Failed to delete bids for model ${id}`,
+        error,
       });
+    }
+    try {
+      await modelsSearchIndex.queueUpdate([
+        { id: deletedModel.id, action: SearchIndexUpdateQueueAction.Delete },
+      ]);
+    } catch (error) {
+      logToAxiom({
+        type: 'error',
+        name: 'model-perma-delete-search-index',
+        message: `Failed to queue search index update for model ${id}`,
+        error,
+      });
+    }
+    if (imagesToDelete.length > 0) {
+      try {
+        await queueImageSearchIndexUpdate({
+          ids: imagesToDelete.map((img) => img.id),
+          action: SearchIndexUpdateQueueAction.Delete,
+        });
+      } catch (error) {
+        logToAxiom({
+          type: 'error',
+          name: 'model-perma-delete-image-search-index',
+          message: `Failed to queue image search index update for model ${id}`,
+          error,
+        });
+      }
     }
     // Clean up S3 objects for all deleted ModelFiles (admin-triggered, latency-tolerant → await).
     if (modelFileUrls.length > 0) {

--- a/src/utils/__tests__/s3-utils.test.ts
+++ b/src/utils/__tests__/s3-utils.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Override the global env mock with concrete S3/B2 endpoints so module-load
+// constants (s3Host, b2Host) resolve to predictable values. Any field we
+// don't override falls back to the global Proxy in src/__tests__/setup.ts.
+//
+// `vi.mock` is hoisted, so this lands before s3-utils' module-level
+// `new URL(env.S3_UPLOAD_ENDPOINT)` runs.
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    {
+      S3_UPLOAD_ENDPOINT: 'https://abcd1234.r2.cloudflarestorage.com',
+      S3_UPLOAD_BUCKET: 'civitai-modelfiles',
+      S3_UPLOAD_KEY: 'test-key',
+      S3_UPLOAD_SECRET: 'test-secret',
+      S3_UPLOAD_B2_ENDPOINT: 'https://s3.us-west-004.backblazeb2.com',
+      S3_UPLOAD_B2_ACCESS_KEY: 'b2-key',
+      S3_UPLOAD_B2_SECRET_KEY: 'b2-secret',
+      S3_UPLOAD_B2_BUCKET: 'civitai-modelfiles-b2',
+      S3_VAULT_BUCKET: 'civitai-vault',
+    } as Record<string, unknown>,
+    {
+      get(target, prop: string) {
+        if (prop in target) return target[prop];
+        return undefined;
+      },
+    }
+  ),
+}));
+
+// vi.hoisted() runs before vi.mock() factories so we can share state with
+// hoisted mocks. Without this, the mocks would reference uninitialized
+// top-level constants and crash at module-load time.
+const mocks = vi.hoisted(() => {
+  const findManyMock = vi.fn(async () => [] as { url: string; id: number }[]);
+  const deleteObjectCalls: { bucket: string; key: string }[] = [];
+  const deleteManyObjectsCalls: { bucket: string; keys: string[] }[] = [];
+  return { findManyMock, deleteObjectCalls, deleteManyObjectsCalls };
+});
+
+// Refcount check inside deleteModelFileObject(s) hits dbWrite.modelFile.findMany.
+// Default: 0 referenced rows → all URLs are "safe to delete".
+vi.mock('~/server/db/client', () => ({
+  dbWrite: {
+    modelFile: {
+      findMany: mocks.findManyMock,
+    },
+  },
+  dbRead: {},
+}));
+
+// Capture deleteObject / deleteManyObjects calls so we can assert which
+// (bucket, key) tuples actually reach the S3 client.
+vi.mock('@aws-sdk/client-s3', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-s3')>();
+  return {
+    ...actual,
+    S3Client: class {
+      send = vi.fn(
+        async (cmd: {
+          input?: {
+            Bucket?: string;
+            Key?: string;
+            Delete?: { Objects?: { Key?: string }[] };
+          };
+        }) => {
+          const Bucket = cmd?.input?.Bucket ?? '';
+          if (cmd?.input?.Delete?.Objects) {
+            mocks.deleteManyObjectsCalls.push({
+              bucket: Bucket,
+              keys: cmd.input.Delete.Objects.map((o) => o.Key ?? ''),
+            });
+            return { Errors: [] };
+          }
+          mocks.deleteObjectCalls.push({ bucket: Bucket, key: cmd?.input?.Key ?? '' });
+          return {};
+        }
+      );
+    },
+  };
+});
+
+import {
+  parseKey,
+  parseB2Url,
+  deleteModelFileObject,
+  deleteModelFileObjects,
+} from '~/utils/s3-utils';
+
+beforeEach(() => {
+  mocks.deleteObjectCalls.length = 0;
+  mocks.deleteManyObjectsCalls.length = 0;
+  mocks.findManyMock.mockReset();
+  mocks.findManyMock.mockResolvedValue([]);
+});
+
+describe('parseKey', () => {
+  const cases: { name: string; url: string; expected: { key: string; bucket?: string } }[] = [
+    {
+      name: 'virtual-host-style R2 (bucket subdomain)',
+      url: 'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/some/key.safetensors',
+      expected: { key: 'some/key.safetensors', bucket: 'civitai-prod-settled' },
+    },
+    {
+      name: 'path-style on configured S3 endpoint',
+      url: 'https://abcd1234.r2.cloudflarestorage.com/civitai-modelfiles/path/to/key.safetensors',
+      expected: { key: 'path/to/key.safetensors', bucket: 'civitai-modelfiles' },
+    },
+    {
+      name: 'malformed URL falls through to bare-key form',
+      url: 'not a url at all',
+      expected: { key: 'not a url at all' },
+    },
+  ];
+
+  for (const c of cases) {
+    it(c.name, () => {
+      expect(parseKey(c.url)).toEqual(c.expected);
+    });
+  }
+});
+
+describe('parseB2Url', () => {
+  it('parses public path-style B2 URL (s3.<region>.backblazeb2.com)', () => {
+    expect(
+      parseB2Url('https://s3.us-west-004.backblazeb2.com/civitai-modelfiles-b2/some/key.safetensors')
+    ).toEqual({ bucket: 'civitai-modelfiles-b2', key: 'some/key.safetensors' });
+  });
+
+  it('parses public virtual-host-style B2 URL', () => {
+    expect(
+      parseB2Url('https://civitai-modelfiles-b2.f004.backblazeb2.com/some/key.safetensors')
+    ).toEqual({ bucket: 'civitai-modelfiles-b2', key: 'some/key.safetensors' });
+  });
+
+  it('parses configured B2 endpoint (matches env.S3_UPLOAD_B2_ENDPOINT host)', () => {
+    expect(
+      parseB2Url('https://s3.us-west-004.backblazeb2.com/civitai-modelfiles-b2/k')
+    ).toEqual({ bucket: 'civitai-modelfiles-b2', key: 'k' });
+  });
+
+  it('returns null for malformed URLs', () => {
+    expect(parseB2Url('not a url')).toBeNull();
+  });
+
+  it('returns null for non-B2 URLs', () => {
+    expect(
+      parseB2Url('https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/key')
+    ).toBeNull();
+  });
+
+  it('returns null for path-style URL with no bucket segment', () => {
+    expect(parseB2Url('https://s3.us-west-004.backblazeb2.com/')).toBeNull();
+  });
+});
+
+describe('deleteModelFileObject — bucket allowlist gate', () => {
+  it('deletes from an allowlisted R2 bucket', async () => {
+    await deleteModelFileObject(
+      'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/key/file.safetensors'
+    );
+    expect(mocks.deleteObjectCalls).toEqual([
+      { bucket: 'civitai-prod-settled', key: 'key/file.safetensors' },
+    ]);
+  });
+
+  it('blocks delete to a non-allowlisted R2 bucket', async () => {
+    await deleteModelFileObject(
+      'https://attacker-bucket.abcd1234.r2.cloudflarestorage.com/victim.bin'
+    );
+    expect(mocks.deleteObjectCalls).toHaveLength(0);
+  });
+
+  it('blocks delete to S3_VAULT_BUCKET (intentionally excluded from allowlist)', async () => {
+    // Even though env.S3_VAULT_BUCKET is set, vault objects must be deleted
+    // exclusively via vault.service.ts — never via the ModelFile cleanup path.
+    await deleteModelFileObject(
+      'https://civitai-vault.abcd1234.r2.cloudflarestorage.com/secret/key.bin'
+    );
+    expect(mocks.deleteObjectCalls).toHaveLength(0);
+  });
+
+  it('skips when refcount check finds the URL still referenced', async () => {
+    mocks.findManyMock.mockResolvedValueOnce([
+      { url: 'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/k', id: 7 },
+    ]);
+    await deleteModelFileObject(
+      'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/k'
+    );
+    expect(mocks.deleteObjectCalls).toHaveLength(0);
+  });
+
+  it('returns silently for empty url', async () => {
+    await deleteModelFileObject('');
+    expect(mocks.deleteObjectCalls).toHaveLength(0);
+  });
+});
+
+describe('deleteModelFileObjects — bucket allowlist + grouping', () => {
+  it('groups by (backend, bucket) and skips non-allowlisted buckets', async () => {
+    await deleteModelFileObjects([
+      'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/a',
+      'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/b',
+      'https://civitai-prod.abcd1234.r2.cloudflarestorage.com/c',
+      'https://attacker.abcd1234.r2.cloudflarestorage.com/d',
+      'https://civitai-vault.abcd1234.r2.cloudflarestorage.com/e',
+      'https://s3.us-west-004.backblazeb2.com/civitai-modelfiles-b2/f',
+    ]);
+
+    // Each (backend, bucket) group → one DeleteObjects call. The two
+    // non-allowlisted urls (attacker, civitai-vault) must be filtered before
+    // any group is built.
+    const buckets = mocks.deleteManyObjectsCalls
+      .map((c) => `${c.bucket}:${c.keys.sort().join(',')}`)
+      .sort();
+    expect(buckets).toEqual([
+      'civitai-modelfiles-b2:f',
+      'civitai-prod-settled:a,b',
+      'civitai-prod:c',
+    ]);
+  });
+
+  it('handles empty input cleanly', async () => {
+    await deleteModelFileObjects([]);
+    expect(mocks.deleteManyObjectsCalls).toHaveLength(0);
+  });
+
+  it('drops urls when refcount check finds them still referenced', async () => {
+    mocks.findManyMock.mockResolvedValueOnce([
+      { url: 'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/a', id: 1 },
+    ]);
+    await deleteModelFileObjects([
+      'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/a',
+      'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/b',
+    ]);
+    expect(mocks.deleteManyObjectsCalls).toEqual([
+      { bucket: 'civitai-prod-settled', keys: ['b'] },
+    ]);
+  });
+});

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -217,15 +217,19 @@ export async function deleteModelFileObjects(urls: string[]) {
     group.keys.push(key);
   }
 
-  await Promise.all(
-    Array.from(groups.values()).map((group) =>
-      deleteManyObjects(
-        group.bucket,
-        group.keys,
-        group.backend === 'b2' ? getB2S3Client() : getS3Client()
-      )
-    )
-  );
+  // Resolve clients up-front so a missing-env throw in getB2S3Client doesn't
+  // skip the R2 group via a synchronous escape from inside .map().
+  // Use allSettled so one group's failure doesn't drop the others.
+  const tasks: Promise<unknown>[] = [];
+  for (const group of groups.values()) {
+    try {
+      const client = group.backend === 'b2' ? getB2S3Client() : getS3Client();
+      tasks.push(deleteManyObjects(group.bucket, group.keys, client));
+    } catch {
+      // B2 env not configured in this pod — skip B2 group, keep R2 deletes running.
+    }
+  }
+  await Promise.allSettled(tasks);
 }
 
 const DOWNLOAD_EXPIRATION = 60 * 60 * 24; // 24 hours

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -221,17 +221,34 @@ export async function deleteModelFileObjects(urls: string[]) {
   // Track bucket per task so partial-failure logs can attribute Errors back to a group.
   const tasks: { bucket: string; promise: ReturnType<typeof deleteManyObjects> }[] = [];
   for (const group of groups.values()) {
-    try {
-      const client = group.backend === 'b2' ? getB2S3Client() : getS3Client();
-      // S3/R2 DeleteObjects caps each call at 1000 keys — chunk to stay under the limit.
-      for (let i = 0; i < group.keys.length; i += 1000) {
-        tasks.push({
-          bucket: group.bucket,
-          promise: deleteManyObjects(group.bucket, group.keys.slice(i, i + 1000), client),
-        });
+    let client;
+    if (group.backend === 'b2') {
+      try {
+        client = getB2S3Client();
+      } catch {
+        // B2 env not configured in this pod — skip B2 group, keep R2 deletes running.
+        continue;
       }
-    } catch {
-      // B2 env not configured in this pod — skip B2 group, keep R2 deletes running.
+    } else {
+      try {
+        client = getS3Client();
+      } catch (error) {
+        // R2 must be configured in every pod — surface the failure rather than silently skip.
+        logToAxiom({
+          type: 'error',
+          name: 'model-file-delete-s3-objects-client-error',
+          bucket: group.bucket,
+          error,
+        });
+        continue;
+      }
+    }
+    // S3/R2 DeleteObjects caps each call at 1000 keys — chunk to stay under the limit.
+    for (let i = 0; i < group.keys.length; i += 1000) {
+      tasks.push({
+        bucket: group.bucket,
+        promise: deleteManyObjects(group.bucket, group.keys.slice(i, i + 1000), client),
+      });
     }
   }
 
@@ -239,7 +256,15 @@ export async function deleteModelFileObjects(urls: string[]) {
   const results = await Promise.allSettled(tasks.map((t) => t.promise));
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
-    if (result.status !== 'fulfilled') continue;
+    if (result.status === 'rejected') {
+      logToAxiom({
+        type: 'error',
+        name: 'model-file-delete-s3-objects-rejected',
+        bucket: tasks[i].bucket,
+        error: result.reason,
+      });
+      continue;
+    }
     const errors = result.value.Errors;
     if (!errors?.length) continue;
     logToAxiom({

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -166,6 +166,83 @@ export function deleteManyObjects(bucket: string, keys: string[], s3: S3Client |
   );
 }
 
+/**
+ * Delete the S3 object referenced by a ModelFile URL.
+ * Determines the correct backend (R2 or B2) and extracts the S3 key from the URL.
+ * Best-effort: callers should catch errors and log rather than blocking.
+ */
+export async function deleteModelFileObject(url: string) {
+  if (!url) return;
+
+  const isB2 = url.includes('backblazeb2.com');
+  const key = extractKeyFromModelFileUrl(url);
+  if (!key) return;
+
+  const s3Client = isB2 ? getB2S3Client() : getS3Client();
+  const bucket = isB2
+    ? env.S3_UPLOAD_B2_BUCKET ?? 'civitai-modelfiles'
+    : env.S3_UPLOAD_BUCKET;
+
+  await deleteObject(bucket, key, s3Client);
+}
+
+/**
+ * Batch-delete S3 objects for multiple ModelFile URLs.
+ * Groups by backend (R2 vs B2) and issues one batch delete per backend.
+ */
+export async function deleteModelFileObjects(urls: string[]) {
+  const r2Keys: string[] = [];
+  const b2Keys: string[] = [];
+
+  for (const url of urls) {
+    if (!url) continue;
+    const key = extractKeyFromModelFileUrl(url);
+    if (!key) continue;
+
+    if (url.includes('backblazeb2.com')) {
+      b2Keys.push(key);
+    } else {
+      r2Keys.push(key);
+    }
+  }
+
+  const promises: Promise<unknown>[] = [];
+
+  if (r2Keys.length > 0) {
+    promises.push(deleteManyObjects(env.S3_UPLOAD_BUCKET, r2Keys, getS3Client()));
+  }
+  if (b2Keys.length > 0) {
+    const b2Bucket = env.S3_UPLOAD_B2_BUCKET ?? 'civitai-modelfiles';
+    promises.push(deleteManyObjects(b2Bucket, b2Keys, getB2S3Client()));
+  }
+
+  await Promise.all(promises);
+}
+
+function extractKeyFromModelFileUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    let path = parsed.pathname.replace(/^\//, '');
+
+    // Strip known bucket prefixes for path-style URLs
+    const bucketPrefixes = [
+      'civitai-delivery-worker-prod',
+      'civitai-prod-settled',
+      'civitai-modelfiles',
+    ];
+    for (const prefix of bucketPrefixes) {
+      if (path.startsWith(prefix + '/')) {
+        path = path.slice(prefix.length + 1);
+        break;
+      }
+    }
+
+    return path || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 const DOWNLOAD_EXPIRATION = 60 * 60 * 24; // 24 hours
 const UPLOAD_EXPIRATION = 60 * 60 * 12; // 12 hours
 const FILE_CHUNK_SIZE = 100 * 1024 * 1024; // 100 MB

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -168,79 +168,64 @@ export function deleteManyObjects(bucket: string, keys: string[], s3: S3Client |
 
 /**
  * Delete the S3 object referenced by a ModelFile URL.
- * Determines the correct backend (R2 or B2) and extracts the S3 key from the URL.
+ * Resolves the correct backend (R2 vs B2) and bucket from the URL itself —
+ * never assumes a single bucket env var, since ModelFile URLs span historical
+ * R2 buckets (civitai-delivery-worker-prod, civitai-prod-settled, ...).
  * Best-effort: callers should catch errors and log rather than blocking.
  */
 export async function deleteModelFileObject(url: string) {
   if (!url) return;
-
-  const isB2 = url.includes('backblazeb2.com');
-  const key = extractKeyFromModelFileUrl(url);
-  if (!key) return;
-
-  const s3Client = isB2 ? getB2S3Client() : getS3Client();
-  const bucket = isB2
-    ? env.S3_UPLOAD_B2_BUCKET ?? 'civitai-modelfiles'
-    : env.S3_UPLOAD_BUCKET;
-
-  await deleteObject(bucket, key, s3Client);
+  const b2 = parseB2Url(url);
+  if (b2) return deleteObject(b2.bucket, b2.key, getB2S3Client());
+  const { key, bucket } = parseKey(url);
+  if (!key || !bucket) return;
+  await deleteObject(bucket, key);
 }
 
 /**
  * Batch-delete S3 objects for multiple ModelFile URLs.
- * Groups by backend (R2 vs B2) and issues one batch delete per backend.
+ * Groups by `(backend, bucket)` and issues one DeleteObjects call per group —
+ * S3 DeleteObjects is per-bucket, so different R2 buckets need separate calls.
  */
 export async function deleteModelFileObjects(urls: string[]) {
-  const r2Keys: string[] = [];
-  const b2Keys: string[] = [];
+  const groups = new Map<
+    string,
+    { backend: 'b2' | 'r2'; bucket: string; keys: string[] }
+  >();
 
   for (const url of urls) {
     if (!url) continue;
-    const key = extractKeyFromModelFileUrl(url);
-    if (!key) continue;
-
-    if (url.includes('backblazeb2.com')) {
-      b2Keys.push(key);
-    } else {
-      r2Keys.push(key);
-    }
-  }
-
-  const promises: Promise<unknown>[] = [];
-
-  if (r2Keys.length > 0) {
-    promises.push(deleteManyObjects(env.S3_UPLOAD_BUCKET, r2Keys, getS3Client()));
-  }
-  if (b2Keys.length > 0) {
-    const b2Bucket = env.S3_UPLOAD_B2_BUCKET ?? 'civitai-modelfiles';
-    promises.push(deleteManyObjects(b2Bucket, b2Keys, getB2S3Client()));
-  }
-
-  await Promise.all(promises);
-}
-
-function extractKeyFromModelFileUrl(url: string): string | undefined {
-  try {
-    const parsed = new URL(url);
-    let path = parsed.pathname.replace(/^\//, '');
-
-    // Strip known bucket prefixes for path-style URLs
-    const bucketPrefixes = [
-      'civitai-delivery-worker-prod',
-      'civitai-prod-settled',
-      'civitai-modelfiles',
-    ];
-    for (const prefix of bucketPrefixes) {
-      if (path.startsWith(prefix + '/')) {
-        path = path.slice(prefix.length + 1);
-        break;
+    const b2 = parseB2Url(url);
+    if (b2) {
+      const groupKey = `b2:${b2.bucket}`;
+      let group = groups.get(groupKey);
+      if (!group) {
+        group = { backend: 'b2', bucket: b2.bucket, keys: [] };
+        groups.set(groupKey, group);
       }
+      group.keys.push(b2.key);
+      continue;
     }
-
-    return path || undefined;
-  } catch {
-    return undefined;
+    const { key, bucket } = parseKey(url);
+    if (!key || !bucket) continue;
+    const groupKey = `r2:${bucket}`;
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = { backend: 'r2', bucket, keys: [] };
+      groups.set(groupKey, group);
+    }
+    group.keys.push(key);
   }
+
+  await Promise.all(
+    Array.from(groups.values()).map((group) =>
+      deleteManyObjects(
+        group.bucket,
+        group.keys,
+        group.backend === 'b2' ? getB2S3Client() : getS3Client()
+      )
+    )
+  );
 }
 
 const DOWNLOAD_EXPIRATION = 60 * 60 * 24; // 24 hours

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -15,6 +15,7 @@ import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { env } from '~/env/server';
 import { isFlipt, FLIPT_FEATURE_FLAGS } from '~/server/flipt/client';
+import { logToAxiom } from '~/server/logging/client';
 
 const missingEnvs = (): string[] => {
   const keys = [];
@@ -188,10 +189,7 @@ export async function deleteModelFileObject(url: string) {
  * S3 DeleteObjects is per-bucket, so different R2 buckets need separate calls.
  */
 export async function deleteModelFileObjects(urls: string[]) {
-  const groups = new Map<
-    string,
-    { backend: 'b2' | 'r2'; bucket: string; keys: string[] }
-  >();
+  const groups = new Map<string, { backend: 'b2' | 'r2'; bucket: string; keys: string[] }>();
 
   for (const url of urls) {
     if (!url) continue;
@@ -220,16 +218,38 @@ export async function deleteModelFileObjects(urls: string[]) {
   // Resolve clients up-front so a missing-env throw in getB2S3Client doesn't
   // skip the R2 group via a synchronous escape from inside .map().
   // Use allSettled so one group's failure doesn't drop the others.
-  const tasks: Promise<unknown>[] = [];
+  // Track bucket per task so partial-failure logs can attribute Errors back to a group.
+  const tasks: { bucket: string; promise: ReturnType<typeof deleteManyObjects> }[] = [];
   for (const group of groups.values()) {
     try {
       const client = group.backend === 'b2' ? getB2S3Client() : getS3Client();
-      tasks.push(deleteManyObjects(group.bucket, group.keys, client));
+      // S3/R2 DeleteObjects caps each call at 1000 keys — chunk to stay under the limit.
+      for (let i = 0; i < group.keys.length; i += 1000) {
+        tasks.push({
+          bucket: group.bucket,
+          promise: deleteManyObjects(group.bucket, group.keys.slice(i, i + 1000), client),
+        });
+      }
     } catch {
       // B2 env not configured in this pod — skip B2 group, keep R2 deletes running.
     }
   }
-  await Promise.allSettled(tasks);
+
+  // DeleteObjects returns 200 even when individual keys fail — surface those via Errors.
+  const results = await Promise.allSettled(tasks.map((t) => t.promise));
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status !== 'fulfilled') continue;
+    const errors = result.value.Errors;
+    if (!errors?.length) continue;
+    logToAxiom({
+      type: 'error',
+      name: 'model-file-delete-s3-objects-partial-failure',
+      bucket: tasks[i].bucket,
+      errorCount: errors.length,
+      sample: errors.slice(0, 10).map((e) => ({ key: e.Key, code: e.Code, message: e.Message })),
+    });
+  }
 }
 
 const DOWNLOAD_EXPIRATION = 60 * 60 * 24; // 24 hours

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -168,18 +168,76 @@ export function deleteManyObjects(bucket: string, keys: string[], s3: S3Client |
 }
 
 /**
+ * Allowlist of civitai-owned buckets that the cleanup helpers are permitted
+ * to delete from. Defense-in-depth: `ModelFile.url` is user-supplied and the
+ * schema only validates `z.url()`, so a malicious user could otherwise point
+ * `url` at an arbitrary R2/B2 bucket reachable by our credentials and trick
+ * the cleanup path into deleting it on next update/delete.
+ *
+ * Composed from:
+ *   1. Configured-bucket env vars (filtered to defined values).
+ *   2. Hardcoded legacy R2 bucket names that hold existing ModelFile rows but
+ *      are no longer referenced by any env var (historical writes).
+ */
+const MODEL_FILE_BUCKET_ALLOWLIST: ReadonlySet<string> = new Set(
+  [
+    env.S3_UPLOAD_BUCKET,
+    env.S3_UPLOAD_B2_BUCKET,
+    env.S3_VAULT_BUCKET,
+    // Default fallback used by getUploadBucket when S3_UPLOAD_B2_BUCKET is unset.
+    'civitai-modelfiles',
+    // Legacy R2 buckets that still hold real ModelFile rows.
+    'civitai-prod',
+    'civitai-prod-settled',
+    'civitai-delivery-worker-prod',
+    'civitai-delivery-worker-prod-2023-05-01',
+    'civitai-delivery-worker-prod-2023-10-01',
+  ].filter((b): b is string => typeof b === 'string' && b.length > 0)
+);
+
+function isAllowedModelFileBucket(bucket: string | undefined): bucket is string {
+  return !!bucket && MODEL_FILE_BUCKET_ALLOWLIST.has(bucket);
+}
+
+/**
  * Delete the S3 object referenced by a ModelFile URL.
  * Resolves the correct backend (R2 vs B2) and bucket from the URL itself —
  * never assumes a single bucket env var, since ModelFile URLs span historical
  * R2 buckets (civitai-delivery-worker-prod, civitai-prod-settled, ...).
  * Best-effort: callers should catch errors and log rather than blocking.
+ *
+ * Gated by MODEL_FILE_BUCKET_ALLOWLIST to prevent a user-supplied url from
+ * pointing the delete at an arbitrary bucket (defense in depth — schema
+ * validation is z.url() only).
  */
 export async function deleteModelFileObject(url: string) {
   if (!url) return;
   const b2 = parseB2Url(url);
-  if (b2) return deleteObject(b2.bucket, b2.key, getB2S3Client());
+  if (b2) {
+    if (!isAllowedModelFileBucket(b2.bucket)) {
+      logToAxiom({
+        type: 'warn',
+        name: 'model-file-delete-s3-object-blocked',
+        backend: 'b2',
+        bucket: b2.bucket,
+        url,
+      });
+      return;
+    }
+    return deleteObject(b2.bucket, b2.key, getB2S3Client());
+  }
   const { key, bucket } = parseKey(url);
   if (!key || !bucket) return;
+  if (!isAllowedModelFileBucket(bucket)) {
+    logToAxiom({
+      type: 'warn',
+      name: 'model-file-delete-s3-object-blocked',
+      backend: 'r2',
+      bucket,
+      url,
+    });
+    return;
+  }
   await deleteObject(bucket, key);
 }
 
@@ -195,6 +253,18 @@ export async function deleteModelFileObjects(urls: string[]) {
     if (!url) continue;
     const b2 = parseB2Url(url);
     if (b2) {
+      // Drop URLs targeting non-civitai buckets before they enter a group, so
+      // a poisoned ModelFile.url can't piggyback on a legit DeleteObjects call.
+      if (!isAllowedModelFileBucket(b2.bucket)) {
+        logToAxiom({
+          type: 'warn',
+          name: 'model-file-delete-s3-object-blocked',
+          backend: 'b2',
+          bucket: b2.bucket,
+          url,
+        });
+        continue;
+      }
       const groupKey = `b2:${b2.bucket}`;
       let group = groups.get(groupKey);
       if (!group) {
@@ -206,6 +276,16 @@ export async function deleteModelFileObjects(urls: string[]) {
     }
     const { key, bucket } = parseKey(url);
     if (!key || !bucket) continue;
+    if (!isAllowedModelFileBucket(bucket)) {
+      logToAxiom({
+        type: 'warn',
+        name: 'model-file-delete-s3-object-blocked',
+        backend: 'r2',
+        bucket,
+        url,
+      });
+      continue;
+    }
     const groupKey = `r2:${bucket}`;
     let group = groups.get(groupKey);
     if (!group) {

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -13,6 +13,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { dbWrite } from '~/server/db/client';
 import { env } from '~/env/server';
 import { isFlipt, FLIPT_FEATURE_FLAGS } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
@@ -200,6 +201,43 @@ function isAllowedModelFileBucket(bucket: string | undefined): bucket is string 
 }
 
 /**
+ * Filter `urls` to those that NO live ModelFile row references.
+ *
+ * Why this exists: `ModelFile.url` is validated only as `z.url()` — any URL the
+ * user submits is accepted. Without this check, a user can plant a row whose
+ * `url` matches a victim's S3 object, then delete their own row to hijack the
+ * delete. The bucket allowlist doesn't help here because both rows live in the
+ * same allowlisted bucket.
+ *
+ * Reads from `dbWrite` (primary) — these helpers run after the destructive DB
+ * op has committed, and we need post-commit consistency rather than a stale
+ * replica view (which would over-skip and create orphans).
+ */
+async function urlsSafeToDelete(urls: string[]): Promise<{ safe: string[]; skipped: number }> {
+  const candidates = urls.filter((u): u is string => typeof u === 'string' && u.length > 0);
+  if (candidates.length === 0) return { safe: [], skipped: 0 };
+  const referenced = await dbWrite.modelFile.findMany({
+    where: { url: { in: candidates } },
+    select: { url: true, id: true },
+  });
+  if (referenced.length === 0) return { safe: candidates, skipped: 0 };
+  const referencedSet = new Set<string>();
+  for (const { url } of referenced) referencedSet.add(url);
+  logToAxiom({
+    type: 'warn',
+    name: 'model-file-delete-s3-skipped-still-referenced',
+    skippedCount: referencedSet.size,
+    sample: referenced
+      .slice(0, 10)
+      .map(({ url, id }: { url: string; id: number }) => ({ url, refId: id })),
+  });
+  return {
+    safe: candidates.filter((u) => !referencedSet.has(u)),
+    skipped: referencedSet.size,
+  };
+}
+
+/**
  * Delete the S3 object referenced by a ModelFile URL.
  * Resolves the correct backend (R2 vs B2) and bucket from the URL itself —
  * never assumes a single bucket env var, since ModelFile URLs span historical
@@ -212,6 +250,12 @@ function isAllowedModelFileBucket(bucket: string | undefined): bucket is string 
  */
 export async function deleteModelFileObject(url: string) {
   if (!url) return;
+  // Refcount check: skip if any live ModelFile row still references this URL.
+  // Closes the user-supplied-url hijack: an attacker plants a row with
+  // url=victim's url, then deletes their own row. Without this check, the
+  // S3 cleanup would delete the victim's bytes.
+  const { safe } = await urlsSafeToDelete([url]);
+  if (safe.length === 0) return;
   const b2 = parseB2Url(url);
   if (b2) {
     if (!isAllowedModelFileBucket(b2.bucket)) {
@@ -247,10 +291,15 @@ export async function deleteModelFileObject(url: string) {
  * S3 DeleteObjects is per-bucket, so different R2 buckets need separate calls.
  */
 export async function deleteModelFileObjects(urls: string[]) {
+  // Refcount filter — drop URLs any live ModelFile row still references before
+  // grouping. Same hijack-prevention rationale as deleteModelFileObject.
+  // Done up-front so a poisoned URL can't piggyback on a legit DeleteObjects call.
+  const { safe } = await urlsSafeToDelete(urls);
+  if (safe.length === 0) return;
+
   const groups = new Map<string, { backend: 'b2' | 'r2'; bucket: string; keys: string[] }>();
 
-  for (const url of urls) {
-    if (!url) continue;
+  for (const url of safe) {
     const b2 = parseB2Url(url);
     if (b2) {
       // Drop URLs targeting non-civitai buckets before they enter a group, so

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -179,12 +179,18 @@ export function deleteManyObjects(bucket: string, keys: string[], s3: S3Client |
  *   1. Configured-bucket env vars (filtered to defined values).
  *   2. Hardcoded legacy R2 bucket names that hold existing ModelFile rows but
  *      are no longer referenced by any env var (historical writes).
+ *
+ * NOTE: `env.S3_VAULT_BUCKET` is intentionally excluded. Vault objects share
+ * keys with `VaultItem` rows and are deleted exclusively via `vault.service.ts`
+ * after a `VaultItem` row goes away. The ModelFile cleanup path has no business
+ * touching the vault bucket: `urlsSafeToDelete` only checks ModelFile refcounts,
+ * so a user-planted ModelFile.url pointing at a victim's vault object would
+ * pass the refcount check and orphan-delete the victim's bytes.
  */
 const MODEL_FILE_BUCKET_ALLOWLIST: ReadonlySet<string> = new Set(
   [
     env.S3_UPLOAD_BUCKET,
     env.S3_UPLOAD_B2_BUCKET,
-    env.S3_VAULT_BUCKET,
     // Default fallback used by getUploadBucket when S3_UPLOAD_B2_BUCKET is unset.
     'civitai-modelfiles',
     // Legacy R2 buckets that still hold real ModelFile rows.

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -360,8 +360,18 @@ export async function deleteModelFileObjects(urls: string[]) {
     if (group.backend === 'b2') {
       try {
         client = getB2S3Client();
-      } catch {
-        // B2 env not configured in this pod — skip B2 group, keep R2 deletes running.
+      } catch (error) {
+        // B2 env not configured in this pod (or partial config / SDK init bug).
+        // Skip the B2 group so R2 deletes keep running, but warn-log so we can
+        // distinguish "B2 disabled in this pod" (expected) from "B2 broken"
+        // (page-worthy) without grepping for silence.
+        logToAxiom({
+          type: 'warn',
+          name: 'model-file-delete-s3-b2-client-unavailable',
+          bucket: group.bucket,
+          keyCount: group.keys.length,
+          error,
+        });
         continue;
       }
     } else {


### PR DESCRIPTION
## Summary
- ModelFile operations (delete, update, cascade delete) never cleaned up R2/B2 S3 objects
- This created ~2.9M orphaned objects (~200 TB) over 2+ years
- Add S3 cleanup to deleteFile(), updateFile(), and permaDeleteModelById()
- S3 failures are best-effort (logged, don't block DB operations)

## Root cause
- `deleteFile()` runs DELETE FROM ModelFile but never calls deleteObject()
- `updateFile()` overwrites ModelFile.url without deleting old S3 key
- `permaDeleteModelById()` cascade-deletes ModelFile rows via Prisma but no S3 cleanup
- `deleteObject()` exists in s3-utils.ts but was only used by training data cleanup

## Changes
- `src/utils/s3-utils.ts`: Add `deleteModelFileObject()` and `deleteModelFileObjects()` helpers with URL-to-key extraction for R2 and B2 backends
- `src/server/services/model-file.service.ts`: Add S3 cleanup to `deleteFile()` and `updateFile()`
- `src/server/services/model.service.ts`: Collect ModelFile URLs before cascade delete in `permaDeleteModelById()`, then batch-delete S3 objects

## Test plan
- [ ] Delete a model file — verify S3 object is removed
- [ ] Update a model file URL — verify old S3 object is removed
- [ ] Permanently delete a model — verify all associated S3 objects are removed
- [ ] Verify S3 failure doesn't block the DB operation (error logged only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)