### PR TITLE
fix(models): clamp lastVersionAt to non-future Published versions

### DIFF
--- a/prisma/migrations/20260501134900_backfill_model_last_version_at_future_dates/migration.sql
+++ b/prisma/migrations/20260501134900_backfill_model_last_version_at_future_dates/migration.sql
@@ -1,0 +1,22 @@
+-- Backfill Model.lastVersionAt for any rows that were poisoned with a future
+-- timestamp (e.g. from a Scheduled→Published transition that left publishedAt
+-- in the future). Recomputes from the latest Published version with a
+-- non-future publishedAt, matching the post-fix `updateModelLastVersionAt`
+-- behavior. The trg_sync_model_to_metric trigger propagates the corrected
+-- value into ModelMetric.lastVersionAt automatically.
+--
+-- Setting lastVersionAt back to NULL when no eligible Published version
+-- exists is intentional: it matches the `if (!modelVersion) return;`
+-- short-circuit in the application path and keeps the model out of the
+-- Newest feed until a real publish exists.
+
+UPDATE "Model" m
+SET "lastVersionAt" = (
+  SELECT MAX(mv."publishedAt")
+  FROM "ModelVersion" mv
+  WHERE mv."modelId" = m.id
+    AND mv.status = 'Published'
+    AND mv."publishedAt" IS NOT NULL
+    AND mv."publishedAt" <= NOW()
+)
+WHERE m."lastVersionAt" > NOW();

--- a/prisma/migrations/20260501135000_tighten_sync_model_to_metric/migration.sql
+++ b/prisma/migrations/20260501135000_tighten_sync_model_to_metric/migration.sql
@@ -1,0 +1,123 @@
+-- Tighten the prod-side trg_sync_model_to_metric trigger.
+--
+-- Two changes:
+--   1. Refuse to propagate a future Model.lastVersionAt into ModelMetric.
+--      The Newest feed sorts on mm."lastVersionAt" DESC; a future value
+--      pins the model to the top until the date arrives. Defense in depth
+--      around updateModelLastVersionAt's `lte: new Date()` guard — even if
+--      another path writes a future Model.lastVersionAt, the feed table
+--      stays clean.
+--   2. Split the AFTER INSERT OR UPDATE trigger into two triggers so the
+--      UPDATE branch can carry a WHEN (...) clause that only fires when a
+--      synced column actually changed. Avoids ModelMetric write churn for
+--      every unrelated Model UPDATE (matches the trg_sync_model_to_base_model_metric
+--      pattern from 20260113170510_add_model_base_model_metric).
+
+CREATE OR REPLACE FUNCTION public.sync_model_to_metric()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO "ModelMetric" (
+            "modelId",
+            "downloadCount", "thumbsUpCount", "thumbsDownCount", "commentCount",
+            "collectedCount", "imageCount",
+            "tippedAmountCount", "tippedCount", "generationCount", "updatedAt",
+            "status", "availability", "mode", "nsfwLevel", "minor", "poi", "userId", "lastVersionAt"
+        )
+        VALUES (
+            NEW.id,
+            0, 0, 0, 0,
+            0, 0,
+            0, 0, 0, NOW(),
+            NEW."status", NEW."availability", NEW."mode", NEW."nsfwLevel", NEW."minor", NEW."poi", NEW."userId",
+            CASE
+                WHEN NEW."lastVersionAt" IS NULL OR NEW."lastVersionAt" <= NOW()
+                THEN NEW."lastVersionAt"
+                ELSE NULL
+            END
+        )
+        ON CONFLICT ("modelId") DO UPDATE
+        SET
+            "status"        = EXCLUDED."status",
+            "availability"  = EXCLUDED."availability",
+            "mode"          = EXCLUDED."mode",
+            "nsfwLevel"     = EXCLUDED."nsfwLevel",
+            "minor"         = EXCLUDED."minor",
+            "poi"           = EXCLUDED."poi",
+            "userId"        = EXCLUDED."userId",
+            "lastVersionAt" = CASE
+                WHEN EXCLUDED."lastVersionAt" IS NULL OR EXCLUDED."lastVersionAt" <= NOW()
+                THEN EXCLUDED."lastVersionAt"
+                ELSE "ModelMetric"."lastVersionAt"
+            END;
+
+        RETURN NEW;
+    END IF;
+
+    IF (TG_OP = 'UPDATE') THEN
+        INSERT INTO "ModelMetric" (
+            "modelId",
+            "downloadCount", "thumbsUpCount", "thumbsDownCount", "commentCount",
+            "collectedCount", "imageCount",
+            "tippedAmountCount", "tippedCount", "generationCount", "updatedAt",
+            "status", "availability", "mode", "nsfwLevel", "minor", "poi", "userId", "lastVersionAt"
+        )
+        VALUES (
+            NEW.id,
+            0, 0, 0, 0,
+            0, 0,
+            0, 0, 0, NOW(),
+            NEW."status", NEW."availability", NEW."mode", NEW."nsfwLevel", NEW."minor", NEW."poi", NEW."userId",
+            CASE
+                WHEN NEW."lastVersionAt" IS NULL OR NEW."lastVersionAt" <= NOW()
+                THEN NEW."lastVersionAt"
+                ELSE NULL
+            END
+        )
+        ON CONFLICT ("modelId") DO UPDATE
+        SET
+            "status"        = EXCLUDED."status",
+            "availability"  = EXCLUDED."availability",
+            "mode"          = EXCLUDED."mode",
+            "nsfwLevel"     = EXCLUDED."nsfwLevel",
+            "minor"         = EXCLUDED."minor",
+            "poi"           = EXCLUDED."poi",
+            "userId"        = EXCLUDED."userId",
+            "lastVersionAt" = CASE
+                WHEN EXCLUDED."lastVersionAt" IS NULL OR EXCLUDED."lastVersionAt" <= NOW()
+                THEN EXCLUDED."lastVersionAt"
+                ELSE "ModelMetric"."lastVersionAt"
+            END;
+
+        RETURN NEW;
+    END IF;
+
+    RETURN NULL;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_sync_model_to_metric ON "Model";
+DROP TRIGGER IF EXISTS trg_sync_model_to_metric_insert ON "Model";
+DROP TRIGGER IF EXISTS trg_sync_model_to_metric_update ON "Model";
+
+CREATE TRIGGER trg_sync_model_to_metric_insert
+AFTER INSERT ON "Model"
+FOR EACH ROW
+EXECUTE FUNCTION sync_model_to_metric();
+
+CREATE TRIGGER trg_sync_model_to_metric_update
+AFTER UPDATE ON "Model"
+FOR EACH ROW
+WHEN (
+  OLD.status          IS DISTINCT FROM NEW.status          OR
+  OLD.availability    IS DISTINCT FROM NEW.availability    OR
+  OLD.mode            IS DISTINCT FROM NEW.mode            OR
+  OLD."nsfwLevel"     IS DISTINCT FROM NEW."nsfwLevel"     OR
+  OLD.minor           IS DISTINCT FROM NEW.minor           OR
+  OLD.poi             IS DISTINCT FROM NEW.poi             OR
+  OLD."userId"        IS DISTINCT FROM NEW."userId"        OR
+  OLD."lastVersionAt" IS DISTINCT FROM NEW."lastVersionAt"
+)
+EXECUTE FUNCTION sync_model_to_metric();

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2489,8 +2489,14 @@ export async function updateModelLastVersionAt({
 }) {
   const dbClient = tx ?? dbWrite;
 
+  // lte: NOW() — never propagate a future publishedAt into lastVersionAt;
+  // a future value pins the model to the top of the Newest feed.
   const modelVersion = await dbClient.modelVersion.findFirst({
-    where: { modelId: id, status: ModelStatus.Published, publishedAt: { not: null } },
+    where: {
+      modelId: id,
+      status: ModelStatus.Published,
+      publishedAt: { not: null, lte: new Date() },
+    },
     select: { publishedAt: true },
     orderBy: { publishedAt: 'desc' },
   });


### PR DESCRIPTION
## Summary

Three changes, in migration order:

1. **`updateModelLastVersionAt` (`src/server/services/model.service.ts:2483`)** — adds `lte: new Date()` to the lookup so a Published `ModelVersion` row with a future `publishedAt` can never seed `Model.lastVersionAt`.
2. **Backfill migration (`20260501134900_backfill_model_last_version_at_future_dates`)** — recomputes `Model.lastVersionAt` for any row currently in the future (today: just model `2548973`).
3. **Trigger migration (`20260501135000_tighten_sync_model_to_metric`)** — replaces the prod-side `sync_model_to_metric()` function and splits the `AFTER INSERT OR UPDATE` trigger:
   - **Future-date clamp**: the `lastVersionAt` column in the upsert now keeps the existing `ModelMetric.lastVersionAt` when the incoming `NEW.lastVersionAt` is in the future, instead of overwriting with the bad value. Defense in depth around fix #1.
   - **WHEN clause on the UPDATE half**: the trigger now only fires when a synced column (`status`, `availability`, `mode`, `nsfwLevel`, `minor`, `poi`, `userId`, `lastVersionAt`) actually changes. Stops ModelMetric write churn from every unrelated `Model` UPDATE; matches the pattern used by `trg_sync_model_to_base_model_metric`.

## Why

ClickUp [868jfgvnm](https://app.clickup.com/t/868jfgvnm) — model `2548973` was stuck at the top of the Newest feed with the "Updated" badge, because `mm."lastVersionAt" = 2026-05-31` (about a month in the future).

Trace:

1. v2.0a (id `2901171`) was scheduled for May 31 → status `Scheduled`, `publishedAt = 2026-05-31`.
2. The version transitioned to `status = 'Published'` while keeping the future `publishedAt`. The exact path that produced this state isn't fully nailed down — `publishModelVersionsWithEarlyAccess` and `upsertModelVersion`'s update path both lack a `publishedAt <= NOW()` guard and either could have done it. Defense-in-depth fixes there are a separate followup.
3. `updateModelLastVersionAt` ran with that row eligible (Published + non-null publishedAt) and copied `publishedAt` straight into `Model.lastVersionAt`.
4. `reset-to-draft-without-requirements` (no-posts auto-unpublish) demoted the row back to Draft on May 1 — but it doesn't clear `publishedAt` and doesn't re-run the corrector. The future date stayed pinned on `Model.lastVersionAt`.
5. The prod-side `trg_sync_model_to_metric` trigger propagated `Model.lastVersionAt` → `ModelMetric.lastVersionAt`. The Newest feed (`mm."lastVersionAt" DESC` in `getModelsRaw`) sorted the model to the top.

Fix #1 closes the propagation step in the application path. Fix #3 closes it in the DB layer too — even if some future code path or manual SQL writes a future `Model.lastVersionAt`, the feed table can't be poisoned.

## Note: prod trigger drift

`sync_model_to_metric()` and `trg_sync_model_to_metric` exist in prod but **not in the repo today**. This PR's trigger migration is the first time they're checked in (via `CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS` so it's idempotent against the running prod definition). A fresh DB spun up from migrations will now have them.

## Followups (separate PRs)

- `prisma/programmability/model_triggers.sql` defines a `model_last_version_at_change` trigger that does **not** exist in prod — dead code; should be deleted (or installed with the same `<= NOW()` guard).
- `publishModelVersionsWithEarlyAccess` (`model-version.service.ts:723`) hardcodes `status: Published` regardless of `publishedAt`. Should refuse / clamp future dates.
- `upsertModelVersion` UPDATE path (`model-version.service.ts:474`) accepts `data.status = 'Published'` even when the row's current `publishedAt` is in the future. Should clamp `publishedAt` or reject the transition.

## Test plan

- [ ] Backfill migration runs cleanly against staging — should affect 1 row.
- [ ] After backfill: `SELECT m.id, m."lastVersionAt", mm."lastVersionAt" FROM "Model" m JOIN "ModelMetric" mm ON mm."modelId" = m.id WHERE m.id = 2548973` shows both columns at `2026-04-30 18:51:28` (the latest non-future Published version's publishedAt).
- [ ] Trigger migration runs cleanly; `\df sync_model_to_metric` shows the new function body, `\d "Model"` shows two triggers (`_insert`, `_update`).
- [ ] Confirm model `2548973` no longer pins to the top of the Newest feed.
- [ ] Schedule a new model version for a future date in staging, confirm `Model.lastVersionAt` and `ModelMetric.lastVersionAt` are **not** updated to the future date.
- [ ] Manually write a future date into `Model.lastVersionAt` for a test model; confirm `ModelMetric.lastVersionAt` is **not** poisoned (trigger refuses propagation).
- [ ] Trigger WHEN clause: an unrelated `Model` UPDATE (e.g. setting an unrelated field) does **not** generate a `ModelMetric` write — verifiable by `mm."updatedAt"` not advancing.
- [ ] Existing flows still work: publish a version with `publishedAt = now`, confirm `Model.lastVersionAt` and `ModelMetric.lastVersionAt` both update correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)