### PR TITLE
fix(docker): bump base image alpine3.16 → alpine3.20 to unfreeze Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ##### DEPENDENCIES
 
-FROM node:20-alpine3.16 AS deps
+FROM node:20-alpine3.20 AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -23,7 +23,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
 
 ##### BUILDER
 
-FROM node:20-alpine3.16 AS builder
+FROM node:20-alpine3.20 AS builder
 ARG NEXT_PUBLIC_IMAGE_LOCATION
 ARG NEXT_PUBLIC_CONTENT_DECTECTION_LOCATION
 ARG NEXT_PUBLIC_MAINTENANCE_MODE
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/app/.next/cache \
 
 ##### RUNNER
 
-FROM node:20-alpine3.16 AS runner
+FROM node:20-alpine3.20 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- `node:20-alpine3.16` is a frozen Docker Hub tag (Alpine 3.16 went EOL May 2024), locking us at Node **20.2.0** (May 2023) and musl 1.2.3.
- This is the most likely cause of the recurring **SIGSEGV (exitCode=139)** crashes on civitai-dp-prod SSR pods — ~50/day across all SSR-eligible nodes on DP.
- Bumping to `alpine3.20` ships current Node 20.18+, openssl 3.0.13, and musl 1.2.5. Same major Node, same pnpm, same build steps — no app changes.

## Why this is the suspect

- **Prisma 6.13.0** (and its `libquery_engine-linux-musl.so.node`) was published ~14 months after this Node 20.2.0 build. Prisma's `engines: { node: '>=18.18' }` is satisfied on paper, but the native musl engine binary was compiled against a much newer Node ABI.
- All 50 SIGSEGVs in the last 26h are SSR pods — same image as the API pool, but SSR has longer-lived requests and more chance to hit the connection-close edge case.
- Loki has zero log lines from crashed pods in the seconds before exit — consistent with a native-code segfault leaving no time to flush.
- Correlates with the chronic `prisma:error Error in PostgreSQL connection: Error { kind: Closed, cause: None }` pattern in our logs — a known class of Prisma native engine instability.

## Test plan
- [ ] Build the new image and confirm Node version is current (`docker run --rm <image> node --version` should show ≥ 20.18)
- [ ] Smoke-test locally: `docker compose up`, hit a few SSR routes, verify no startup errors
- [ ] Roll out via Flagger canary on civitai-dp-prod and watch SIGSEGV count for 24h
  - Track: `kube_pod_container_status_last_terminated_exitcode == 139` for `civitai-dp-prod-primary-*`
  - Expected: drop from ~2/hr to ~0/hr
- [ ] Confirm the chronic `prisma:error Error { kind: Closed }` rate also drops or fully disappears
- [ ] If 24h soak is clean, the change applies equally to `civitai-app` and `civitai-next` deployments — they all build from this Dockerfile

## Risk
Low. Same Node major (20.x), same package manager (pnpm 10.28.1), same Alpine base. Newer musl + newer base packages. If anything regresses, revert the 3-line change and rebuild.