### PR TITLE
perf: hot DP endpoint observability + parallel cache refreshes

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1646,7 +1646,9 @@ export const getAllImages = async (
   // const cacheable = queryCache(dbRead, 'getAllImages', 'v1');
   // const rawImages = await cacheable<GetAllImagesRaw[]>(query, { ttl: cacheTime, tag: cacheTags });
 
-  const { rows: rawImages } = await imageDb.query<GetAllImagesRaw>(query);
+  const { rows: rawImages } = await withSpan('image:getAllImages:rawQuery', () =>
+    imageDb.query<GetAllImagesRaw>(query)
+  );
   // const rawImages = await dbRead.$queryRaw<GetAllImagesRaw[]>(query);
 
   const imageIds = rawImages.map((i) => i.id);

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -1141,21 +1141,25 @@ export const updatePostImage = async (image: UpdatePostImageInput) => {
     },
     select: { id: true, url: true, userId: true },
   });
-  await imageMetadataCache.refresh(image.id);
-  await imageMetaCache.refresh(image.id);
+  // Parallelize independent cache refreshes — none read what others write.
+  // ingestImage stays sequential after: it does not read these caches but
+  // does have ordering relative to the dbWrite.image.update above.
+  const cacheRefreshPromises: Promise<unknown>[] = [
+    imageMetadataCache.refresh(image.id),
+    imageMetaCache.refresh(image.id),
+    userPostCountCache.refresh(result.userId),
+  ];
+  if (image.hideMeta && currentImage && currentImage.hideMeta !== image.hideMeta) {
+    cacheRefreshPromises.push(purgeResizeCache({ url: result.url }));
+  }
+  await Promise.all(cacheRefreshPromises);
 
   if (shouldIngest) {
     // Ensures a proper rescan of this image.
     await ingestImage({ image: result });
   }
 
-  // If changing hide meta, purge the resize cache so that we strip metadata
-  if (image.hideMeta && currentImage && currentImage.hideMeta !== image.hideMeta) {
-    await purgeResizeCache({ url: result.url });
-  }
-
   purgeImageGenerationDataCache(image.id);
-  await userPostCountCache.refresh(result.userId);
 };
 
 export const addResourceToPostImage = async ({

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -5,6 +5,7 @@ import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { ToggleHiddenSchemaOutput } from '~/server/schema/user-preferences.schema';
 import { getModeratedTags } from '~/server/services/system-cache';
+import { withSpan } from '~/server/utils/otel-helpers';
 import { TagEngagementType, UserEngagementType } from '~/shared/utils/prisma/enums';
 
 const HIDDEN_CACHE_EXPIRY_BASE = 60 * 60 * 4; // 4 hours
@@ -263,6 +264,30 @@ const getAllHiddenForUsersCached = async ({
 }: {
   userId?: number;
 }) => {
+  // Batch the 8 cache reads through the documented `packed.mGet` API instead
+  // of 8 individual `redis.packed.get()` calls in `Promise.all`, and wrap in
+  // a span so spanmetrics can attribute the actual fan-out latency vs.
+  // post-processing / cache-miss DB fallbacks.
+  //
+  // Why mGet (not pipeline / cluster MULTI):
+  //   This is a Redis CLUSTER. The 7 user-preference keys do NOT share a hash
+  //   tag, and the 8th (SYSTEM.MODERATED_TAGS) is on a different shard, so a
+  //   real Redis MGET or cluster MULTI(routing) across them would CROSSSLOT
+  //   or require cross-shard coordination. `redis.packed.mGet` is the
+  //   cluster-safe wrapper (see redis/client.ts): it issues per-key GETs
+  //   internally and benefits from node-redis' per-shard cork/uncork TCP
+  //   pipelining. Functionally equivalent to the prior Promise.all, but
+  //   centralises future per-shard slot-grouping optimizations on one path.
+  const cacheKeys: RedisKeyTemplateCache[] = [
+    REDIS_KEYS.SYSTEM.MODERATED_TAGS,
+    HiddenTags.getKey({ userId }),
+    HiddenImages.getKey({ userId }),
+    HiddenModels.getKey({ userId }),
+    HiddenUsers.getKey({ userId }),
+    ImplicitHiddenImages.getKey({ userId }),
+    BlockedUsers.getKey({ userId }),
+    BlockedByUsers.getKey({ userId }),
+  ];
   const [
     cachedSystemHiddenTags,
     cachedHiddenTags,
@@ -272,16 +297,11 @@ const getAllHiddenForUsersCached = async ({
     cachedImplicitHiddenImages,
     cachedBlockedUsers,
     cachedBlockedByUsers,
-  ] = await Promise.all([
-    redis.packed.get(REDIS_KEYS.SYSTEM.MODERATED_TAGS),
-    redis.packed.get(HiddenTags.getKey({ userId })),
-    redis.packed.get(HiddenImages.getKey({ userId })),
-    redis.packed.get(HiddenModels.getKey({ userId })),
-    redis.packed.get(HiddenUsers.getKey({ userId })),
-    redis.packed.get(ImplicitHiddenImages.getKey({ userId })),
-    redis.packed.get(BlockedUsers.getKey({ userId })),
-    redis.packed.get(BlockedByUsers.getKey({ userId })),
-  ]);
+  ] = await withSpan(
+    'user-preferences:getAllHidden:redisFetch',
+    { keyCount: cacheKeys.length },
+    () => redis.packed.mGet(cacheKeys)
+  );
 
   const getModerationTags = async () =>
     (cachedSystemHiddenTags as AsyncReturnType<typeof getModeratedTags>) ??
@@ -323,16 +343,21 @@ const getAllHiddenForUsersCached = async ({
     (cachedBlockedByUsers as AsyncReturnType<typeof BlockedByUsers.get>) ??
     (await BlockedByUsers.get({ userId }));
 
+  // Resolve the 7 base preferences — each is a no-op if cached, otherwise
+  // hits the DB. Wrapped so we can attribute the cache-miss DB fallback
+  // latency separately from the redis fan-out above.
   const [moderatedTags, hiddenTags, images, models, users, blockedUsers, blockedByUsers] =
-    await Promise.all([
-      getModerationTags(),
-      getHiddenTags({ userId }),
-      getHiddenImages({ userId }),
-      getHiddenModels({ userId }),
-      getHiddenUsers({ userId }),
-      getBlockedUsers({ userId }),
-      getBlockedByUsers({ userId }),
-    ]);
+    await withSpan('user-preferences:getAllHidden:resolve', () =>
+      Promise.all([
+        getModerationTags(),
+        getHiddenTags({ userId }),
+        getHiddenImages({ userId }),
+        getHiddenModels({ userId }),
+        getHiddenUsers({ userId }),
+        getBlockedUsers({ userId }),
+        getBlockedByUsers({ userId }),
+      ])
+    );
 
   const [implicitImages] = await Promise.all([
     getHiddenImplicitImages({


### PR DESCRIPTION
## Summary
- **Fix 1 (`image.service.ts`)**: wrap the raw `imageDb.query<GetAllImagesRaw>` in `getAllImages` with `withSpan('image:getAllImages:rawQuery', ...)`. `image.getInfinite` P99 is ~2.17s with only ~206ms attributed across `parallelFetch` + `transform` — this exposes the dominant unaccounted self-time.
- **Fix 2 (`user-preferences.service.ts`)**: replace 8 individual `redis.packed.get()` calls in `Promise.all` with a single `redis.packed.mGet()` and wrap both the redis fan-out and the cache-miss DB fallback path in dedicated spans (`user-preferences:getAllHidden:redisFetch`, `user-preferences:getAllHidden:resolve`).
- **Fix 3 (`post.service.ts`)**: collapse the four sequential cache refreshes in `updatePostImage` (`imageMetadataCache.refresh`, `imageMetaCache.refresh`, `userPostCountCache.refresh`, conditional `purgeResizeCache`) into one `Promise.all`. Mirrors the pattern from #2173. Saves ~200-400ms per `post.update` call.

## Evidence (DP production spanmetrics)
- `image.getInfinite`: P99 2172ms, ~206ms attributed → ~1.9s hidden in raw SQL or post-processing.
- `trpc:middleware:applyUserPreferences`: P95 1305ms.
- `post.update`: ~1.4s self-time after the `dbWrite.image.update` due to sequential cache refreshes.

## Risk and honesty
- **Fix 1**: pure observability, zero behavior change.
- **Fix 2**: I inspected the existing code and the original premise (\"8 sequential redis calls\") does not match what's there — they are already concurrent inside `Promise.all`. Switching to `packed.mGet` is functionally equivalent today (its impl is `Promise.all(get)` internally) and avoids the CROSSSLOT trap that a real cluster `MGET` or `MULTI(routing)` would hit, since the keys are not hash-tagged. Do **not** expect a measurable P95 drop from this commit alone — the load-bearing change is the two new spans, which let us see where the 1305ms actually goes (redis fan-out vs cache-miss DB fallbacks vs middleware post-processing) before we invest in a hash-tag migration.
- **Fix 3**: verified `ingestImage` does not read from any of the parallelized caches and kept it sequential after the `Promise.all`. The conditional `purgeResizeCache` branch was folded into the parallel batch by pushing the conditional onto the array.

## Local validation
- `pnpm lint --quiet --file <each file>`: clean per file.
- `pnpm tsc --noEmit`: pre-existing Prisma typing errors in many files (unchanged), no new errors introduced by these edits.
- Pre-commit hook is a ToS-only no-op.

## Test plan
- [ ] CI passes (jest tests if any)
- [ ] After deploy: verify `image:getAllImages:rawQuery` span appears in Tempo for DP and shows P99 close to 1.9s
- [ ] Verify `user-preferences:getAllHidden:redisFetch` and `:resolve` spans surface the actual 1305ms breakdown
- [ ] Verify `post.updateImage` self-time after `dbWrite.image.update` drops by ~200-400ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)