### PR TITLE
perf(images): snap edge-image widths to discrete ladder to reduce cache fragmentation

### DIFF
--- a/src/client-utils/__tests__/cf-images-utils.test.ts
+++ b/src/client-utils/__tests__/cf-images-utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// `cf-images-utils` reads `env.NEXT_PUBLIC_IMAGE_LOCATION` at call time. Stub the
+// client env module before importing the unit under test so we don't trip the
+// zod schema check in `~/env/client`.
+vi.mock('~/env/client', () => ({
+  env: {
+    NEXT_PUBLIC_IMAGE_LOCATION: 'https://image.test',
+  },
+}));
+
+import {
+  COMMON_IMAGE_WIDTHS,
+  getEdgeUrl,
+  snapWidthToCommonSize,
+} from '~/client-utils/cf-images-utils';
+
+describe('snapWidthToCommonSize', () => {
+  it('leaves widths that are exactly on the ladder unchanged', () => {
+    for (const size of COMMON_IMAGE_WIDTHS) {
+      expect(snapWidthToCommonSize(size)).toBe(size);
+    }
+  });
+
+  it('snaps widths below the bottom of the ladder up to the smallest ladder value', () => {
+    const smallest = COMMON_IMAGE_WIDTHS[0];
+    expect(snapWidthToCommonSize(1)).toBe(smallest);
+    expect(snapWidthToCommonSize(smallest - 1)).toBe(smallest);
+  });
+
+  it('snaps widths between ladder values up to the next ladder value', () => {
+    // Ladder is [96, 320, 450, 512, 800, 1200, 1600, 2200]
+    expect(snapWidthToCommonSize(97)).toBe(320);
+    expect(snapWidthToCommonSize(321)).toBe(450);
+    expect(snapWidthToCommonSize(451)).toBe(512);
+    expect(snapWidthToCommonSize(513)).toBe(800);
+    expect(snapWidthToCommonSize(801)).toBe(1200);
+    expect(snapWidthToCommonSize(1201)).toBe(1600);
+    expect(snapWidthToCommonSize(1601)).toBe(2200);
+  });
+
+  it('passes widths above the top of the ladder through unchanged', () => {
+    const top = COMMON_IMAGE_WIDTHS[COMMON_IMAGE_WIDTHS.length - 1];
+    expect(snapWidthToCommonSize(top + 1)).toBe(top + 1);
+    expect(snapWidthToCommonSize(5000)).toBe(5000);
+  });
+});
+
+describe('getEdgeUrl width snapping', () => {
+  const SRC = 'abc-image-uuid';
+
+  it('emits the snapped width for off-ladder values', () => {
+    // 451 is between 450 and 512 → snaps to 512.
+    const url = getEdgeUrl(SRC, { width: 451 });
+    expect(url).toContain('width=512');
+    expect(url).not.toContain('width=451');
+  });
+
+  it('preserves on-ladder widths verbatim', () => {
+    const url = getEdgeUrl(SRC, { width: 450 });
+    expect(url).toContain('width=450');
+  });
+
+  it('leaves over-ladder widths to the existing 1800 cap', () => {
+    // 2500 > top of ladder (2200) → snap is a no-op → existing cap clamps to 1800.
+    const url = getEdgeUrl(SRC, { width: 2500 });
+    expect(url).toContain('width=1800');
+  });
+
+  it('does not emit a width param when width is undefined', () => {
+    // No width and no height → `getEdgeUrl` defaults `original=true` and clears
+    // both dimensions; we expect no `width=` segment to leak through.
+    const url = getEdgeUrl(SRC);
+    expect(url).not.toMatch(/(^|[,/?])width=/);
+  });
+
+  it('does not snap height', () => {
+    const url = getEdgeUrl(SRC, { height: 451 });
+    expect(url).toContain('height=451');
+  });
+});

--- a/src/client-utils/cf-images-utils.ts
+++ b/src/client-utils/cf-images-utils.ts
@@ -33,6 +33,35 @@ const typeExtensions: Record<MediaType, string> = {
   audio: '.mp3',
 };
 
+// Discrete width ladder mirroring civitai-image-cacher's `ImageCacherOptions.CommonSizes`
+// (see appsettings.json in civitai-image-cacher). The cacher already snaps requested
+// widths up to the next ladder value server-side, but only AFTER admitting the unique
+// URL into its cache — costing one B2 Class C HEAD per unique width. By snapping
+// client-side to the same ladder we collapse cache cardinality before emission.
+//
+// Must stay in sync with the deployed cacher's CommonSizes. If the values diverge,
+// the snap simply becomes less effective (no correctness impact) — the cacher's
+// server-side snap remains the source of truth.
+export const COMMON_IMAGE_WIDTHS = [96, 320, 450, 512, 800, 1200, 1600, 2200] as const;
+
+/**
+ * Snap a requested width up to the next value in `COMMON_IMAGE_WIDTHS`.
+ *
+ * Behavior matches `ServeImageMiddleware.cs` in civitai-image-cacher:
+ *  - If the width is already in the ladder, leave it alone.
+ *  - Otherwise, return the first ladder value strictly greater than `width`.
+ *  - If no ladder value is greater (i.e. the request exceeds the ladder top),
+ *    return the original width unchanged so callers that explicitly oversized
+ *    aren't capped here. The existing 1800 cap in `getEdgeUrl` still applies.
+ */
+export function snapWidthToCommonSize(width: number): number {
+  for (const size of COMMON_IMAGE_WIDTHS) {
+    if (size === width) return width;
+    if (size > width) return size;
+  }
+  return width;
+}
+
 export function getEdgeUrl(
   src: string,
   {
@@ -62,6 +91,10 @@ export function getEdgeUrl(
     height = undefined;
   }
   // if(width && height) // TODO
+  // Snap width to the cacher's CommonSizes ladder *before* the 1800 cap so the cap
+  // remains the final word for over-ladder values. Height is not snapped — the
+  // cacher only snaps width.
+  if (width) width = snapWidthToCommonSize(width);
   if (width && width > 1800) width = 1800;
   if (height && height > 1000) height = 1000;
 


### PR DESCRIPTION
## Why

Widths in image URLs are currently derived continuously from each image's natural aspect ratio (e.g. `IMAGE_CARD_WIDTH * originalAspectRatio`), producing a unique URL per (card slot × aspect ratio) pair. The civitai-image-cacher already snaps to a discrete `ImageCacherOptions.CommonSizes` ladder server-side (see `ServeImageMiddleware.cs` lines ~73–85), but only **after** admitting each unique width into its cache, which costs one B2 Class C HEAD per unique width seen.

By snapping client-side to the same ladder before emission, we collapse that fragmentation. Audit estimate: ~5–10× cardinality reduction in the dominant card-traffic surface.

## What

- New `snapWidthToCommonSize(width)` helper exported from `src/client-utils/cf-images-utils.ts`
- Applied inside `getEdgeUrl` **before** the existing 1800 cap, so the cap remains the final word for over-ladder values
- Behavior matches the server-side snap exactly: if the width is on the ladder leave it alone; otherwise round up to the next ladder value; widths above the top of the ladder pass through unchanged so callers that explicitly oversize aren't capped here
- Height is **not** snapped (the cacher only snaps width)
- When width is undefined (the `original=true` path) no width param is emitted

## Ladder

`[96, 320, 450, 512, 800, 1200, 1600, 2200]` — taken from `Civitai.ImageCacher/appsettings.json` (`ImageCacherOptions.CommonSizes`). The deployed cacher manifest at `clusters/production/apps/civitai-image-cacher/deployment.yaml` does not set `ImageCacherOptions__CommonSizes` env vars, so the appsettings default is what's currently in production. Reviewer: please confirm. If this ever diverges from the cacher's deployed values, the snap simply becomes less effective (no correctness impact).

## Tests

Added `src/client-utils/__tests__/cf-images-utils.test.ts` (vitest) covering:

- on-ladder widths → unchanged
- below the bottom → snaps to smallest (96)
- between values → snaps up to next
- above the top → passes through unchanged
- undefined width → no width param emitted
- height not snapped
- `getEdgeUrl` integration: snapped output, on-ladder verbatim, over-ladder hits existing 1800 cap

`./node_modules/.bin/vitest run src/client-utils/__tests__/cf-images-utils.test.ts` → 9/9 passing. `tsc --noEmit` produces no new errors (pre-existing errors on `main` in unrelated files: `SeedreamVersion`, `air.ts`, `auto-label-orchestrator.ts`, `zImage.config.ts`). `next lint` clean on the modified file aside from a pre-existing `react-hooks/exhaustive-deps` warning unrelated to this change.

## Risk

Visual: a 451px container will request `width=512` (next ladder value) instead of `width=451`. The rendered display size is unchanged (CSS controls that). The transferred image is slightly larger; trade-off favors cache density at this corpus size (110M images × multiple formats).

No callers depend on the exact URL string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)