### PR TITLE
fix(post): only restore unpublished posts on republish

### DIFF
--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -880,6 +880,12 @@ export const publishModelVersionById = async ({
         });
       }
 
+      // Only restore posts that were unpublished alongside this version. Without
+      // the `publishedAt IS NULL` guard, calling publish on an already-published
+      // version overwrites every attached post's publishedAt (and clears their
+      // prevPublishedAt metadata), letting an owner script repeated publish calls
+      // to keep bumping their old posts to the top of feeds. Mirrors the
+      // `WHERE "publishedAt" IS NOT NULL` guard in the unpublish path below.
       await tx.$executeRaw`
         UPDATE "Post"
         SET
@@ -891,6 +897,7 @@ export const publishModelVersionById = async ({
           "metadata" = "metadata" - 'unpublishedAt' - 'unpublishedBy' - 'prevPublishedAt'
         WHERE "userId" = ${updatedVersion.model.userId}
         AND "modelVersionId" = ${updatedVersion.id}
+        AND "publishedAt" IS NULL
       `;
 
       if (!currentVersion.model.publishedAt) {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2008,6 +2008,12 @@ export const publishModelById = async ({
           });
         }
 
+        // Only restore posts that were unpublished alongside the model. Without
+        // the `p."publishedAt" IS NULL` guard, calling publish on an
+        // already-published model overwrites every attached post's publishedAt
+        // (and clears their prevPublishedAt metadata), letting an owner script
+        // repeated publish calls to keep bumping their old posts to the top of
+        // feeds. Mirrors the unpublish path's `WHERE "publishedAt" IS NOT NULL`.
         await tx.$executeRaw`
           UPDATE "Post" p
           SET "publishedAt" = CASE
@@ -2020,6 +2026,7 @@ export const publishModelById = async ({
           WHERE mv.id = p."modelVersionId"
             AND p."userId" = ${model.userId}
             AND p."modelVersionId" IN (${Prisma.join(versionIds, ',')})
+            AND p."publishedAt" IS NULL
         `;
       }
       if (!republishing && !meta?.unpublishedBy) await updateModelLastVersionAt({ id, tx });


### PR DESCRIPTION
## Summary
- Calling `model.publish` / `modelVersion.publish` on an already-published model or version overwrote every attached post's `publishedAt` (and cleared their `prevPublishedAt`), letting an owner script repeated publish calls to bump old posts to the top of feeds. The owner-only `isOwnerOrModerator` guard does not block this — owners can keep republishing their own model versions to bump their own posts.
- Adds `AND "publishedAt" IS NULL` to the raw `UPDATE "Post"` in `publishModelVersionById` and `publishModelById`. Mirrors the existing `WHERE "publishedAt" IS NOT NULL` guard on the unpublish paths so the pair is symmetric: unpublish only nulls currently-published posts, republish only restores currently-null posts.

## Background
Spotted via user 4567205 (`Chumple`). Six of his posts (created 2025-07 → 2025-12) had `publishedAt` jumped to 2026-05-05 inside a 38-second window, all on different `modelVersionId`s, with `Post.updatedAt == createdAt` — i.e. they did not go through Prisma's `post.update` (which bumps `@updatedAt`); they came from the raw SQL inside `publishModelVersionById`. Pattern fits a script looping `modelVersion.publish` over the user's own versions. Several other accounts show the same shape at much larger scale (one user with 798 bumped posts).

## Why the symmetric guard
- `unpublishModelVersionById` / model unpublish set `publishedAt = NULL` only `WHERE "publishedAt" IS NOT NULL` — already-null posts are skipped so `prevPublishedAt` never gets clobbered with `null`.
- The publish counterpart had no such filter and recomputed `publishedAt` for every post attached to the version, including ones that were never unpublished. With `prevPublishedAt` absent on those rows, the COALESCE fell through to the freshly-coerced `NOW()`. Adding `AND "publishedAt" IS NULL` makes the pair symmetric and reduces the scope of republish to exactly the rows the previous unpublish touched.

## Test plan
- [ ] Unpublish a model version with published posts → posts get `publishedAt = NULL`, `prevPublishedAt` stashed.
- [ ] Republish the same version → posts return to their original `publishedAt` from `prevPublishedAt`.
- [ ] Call `modelVersion.publish` twice in a row on an already-published version → attached posts' `publishedAt` is unchanged on the second call (previously it was bumped to `NOW()`).
- [ ] Same matrix at the model level via `model.publish`.
- [ ] Scheduled publish flow (`process-scheduled-publishing` job) still works — it already has its own `p."publishedAt" IS NULL` guard, no change there.

## Follow-ups (not in this PR)
- Backfill: restore `Post.publishedAt = createdAt` (or recompute from `Image.scannedAt`) for posts where the shift looks scripted. Top offender list is in the investigation thread.
- `postCreateSchema` / `postUpdateSchema` accept arbitrary `publishedAt` with no upper bound. Worth capping (e.g. `now + 30 days`) so a malicious client can't bake a far-future schedule at create time. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)