### PR TITLE
perf(images): use fixed width for profile cover images

### DIFF
--- a/src/components/Profile/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader.tsx
@@ -73,7 +73,7 @@ export function ProfileHeader({ username }: { username: string }) {
                     name={image.name ?? image.id.toString()}
                     alt={image.name ?? undefined}
                     type={image.type}
-                    width={Math.min(image.width ?? 1920, 1920)}
+                    width={1600}
                     style={{ maxWidth: '100%' }}
                     className="w-full max-w-full absolute-center"
                   />


### PR DESCRIPTION
## Why

Profile cover images currently request `width={Math.min(image.width ?? 1920, 1920)}`,
producing a unique URL per (profile × natural-image-width). Every profile becomes
a distinct cache entry on image-cacher's content-type cache, fragmenting an entire
high-traffic surface that should logically share one render slot.

Follow-up to #2238 (client-side width snapping). #2238 mitigated the
multiplicative fragmentation from card layouts; this kills the per-profile
fragmentation specifically.

## What

Hardcode `width={1600}`, which is on the cacher's CommonSizes ladder
(`[96, 320, 450, 512, 800, 1200, 1600, 2200]`) and below the 1800 internal
cap, so the URL is emitted exactly as the cacher prefers — no snapping,
no capping, one URL across all profiles.

## Risk

Visual: a profile whose stored cover is e.g. 1280px-wide will now request
`width=1600` — the cacher upscales to 1600 then the browser handles display
sizing. Trivial visual difference; transferred bytes increase moderately
on profiles with smaller stored covers but cache density gains compound.

No callers depend on the exact width value at the URL builder.

## Other call sites worth a follow-up (NOT changed in this PR)

A quick grep for similar `image.width ?? <const>` patterns flowing into
edge-image rendering surfaces:

- `src/components/Collections/Collection.tsx:612` — `width={collection.image.width ?? 1200}`
- `src/components/Post/Infinite/PostsInfinite.tsx:82` — `const width = image.width ?? 450`

Both look like the same shape (per-image natural width admitted before snap).
Left out of this PR to keep the change surgical; worth their own follow-ups
if the cardinality audit confirms they're hot.