### PR TITLE
feat(oauth): scoped tokens, OAuth 2.0 server, per-subject buzz limits

### DIFF
--- a/docs/plans/oauth-developer-docs.md
+++ b/docs/plans/oauth-developer-docs.md
@@ -1,0 +1,345 @@
+# Civitai OAuth — Developer Guide
+
+## Overview
+
+Civitai supports OAuth 2.0 for third-party applications to authenticate users and access the Civitai API on their behalf. This guide covers how to register an application, implement the authorization flow, and use access tokens.
+
+## Quick Start
+
+1. Go to **Account Settings → OAuth Applications** and register your app
+2. Implement the **Authorization Code + PKCE** flow
+3. Exchange the authorization code for an access token
+4. Use the access token as a Bearer token in API requests
+
+## Registering an Application
+
+Visit your [Account Settings](/user/account) and scroll to the **OAuth Applications** section. Click **Register App** and fill in:
+
+- **App Name** — displayed to users on the consent screen
+- **Description** — what your app does
+- **Redirect URIs** — where users are sent after authorization (must be exact match, HTTPS required in production)
+- **Client Type**:
+  - **Confidential** — server-side apps that can keep a secret (you'll get a client secret)
+  - **Public** — SPAs, mobile apps, CLI tools (no client secret, PKCE provides security)
+- **Allowed Scopes** — the maximum permissions your app can request
+
+After registration, you'll receive a **Client ID** and (for confidential clients) a **Client Secret**. Save the secret — it won't be shown again.
+
+## Authorization Code Flow (with PKCE)
+
+PKCE (Proof Key for Code Exchange) is **required** for all authorization requests.
+
+### Step 1: Generate PKCE Values
+
+```javascript
+// Generate a random code_verifier (43-128 chars)
+const codeVerifier = crypto.randomBytes(32).toString('base64url');
+
+// Hash it to create the code_challenge
+const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+```
+
+### Step 2: Redirect User to Authorization
+
+```
+GET https://civitai.com/api/auth/oauth/authorize
+  ?client_id=YOUR_CLIENT_ID
+  &redirect_uri=https://yourapp.com/callback
+  &response_type=code
+  &scope=SCOPE_BITMASK
+  &state=RANDOM_STATE
+  &code_challenge=CODE_CHALLENGE
+  &code_challenge_method=S256
+```
+
+Parameters:
+
+- `client_id` — your app's client ID
+- `redirect_uri` — must exactly match a registered redirect URI
+- `response_type` — always `code`
+- `scope` — integer bitmask of requested permissions (see Scopes below)
+- `state` — random string for CSRF protection (required)
+- `code_challenge` — SHA-256 hash of your code_verifier, base64url-encoded
+- `code_challenge_method` — always `S256`
+
+The user will see a consent screen listing the requested permissions. If they approve, they'll be redirected to your `redirect_uri` with an authorization code.
+
+### Step 3: Exchange Code for Token
+
+```
+POST https://civitai.com/api/auth/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code=AUTHORIZATION_CODE
+&redirect_uri=https://yourapp.com/callback
+&client_id=YOUR_CLIENT_ID
+&client_secret=YOUR_CLIENT_SECRET  (confidential clients only)
+&code_verifier=ORIGINAL_CODE_VERIFIER
+```
+
+Response:
+
+```json
+{
+  "access_token": "civitai_abc123...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "civitai_def456...",
+  "scope": "33554431"
+}
+```
+
+### Step 4: Use the Access Token
+
+```
+GET https://civitai.com/api/auth/oauth/userinfo
+Authorization: Bearer civitai_abc123...
+```
+
+Or use it with any Civitai API/tRPC endpoint:
+
+```
+Authorization: Bearer civitai_abc123...
+```
+
+## Refreshing Tokens
+
+Access tokens expire after 1 hour. Use the refresh token to get a new one:
+
+```
+POST https://civitai.com/api/auth/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=refresh_token
+&refresh_token=civitai_def456...
+&client_id=YOUR_CLIENT_ID
+&client_secret=YOUR_CLIENT_SECRET  (confidential clients only)
+```
+
+The old access and refresh tokens are revoked, and new ones are issued.
+
+## Device Authorization Flow
+
+For CLI tools and devices without a browser:
+
+### Step 1: Request Device Code
+
+```
+POST https://civitai.com/api/auth/oauth/device
+Content-Type: application/x-www-form-urlencoded
+
+client_id=YOUR_CLIENT_ID
+&scope=SCOPE_BITMASK
+```
+
+Response:
+
+```json
+{
+  "device_code": "abc123...",
+  "user_code": "ABCD-EFGH",
+  "verification_uri": "https://civitai.com/login/oauth/device",
+  "verification_uri_complete": "https://civitai.com/login/oauth/device?code=ABCD-EFGH",
+  "expires_in": 900,
+  "interval": 5
+}
+```
+
+### Step 2: Display Code to User
+
+Show the user the `user_code` and `verification_uri`. They visit the URL in a browser and enter the code.
+
+### Step 3: Poll for Token
+
+Poll the token endpoint every `interval` seconds:
+
+```
+POST https://civitai.com/api/auth/oauth/device-token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:device_code
+&device_code=abc123...
+&client_id=YOUR_CLIENT_ID
+```
+
+Responses:
+
+- `authorization_pending` — user hasn't approved yet, keep polling
+- `access_denied` — user denied the request
+- `expired_token` — device code expired
+- Success — returns access token + refresh token
+
+## Client Credentials Flow
+
+For server-to-server communication (no user context):
+
+```
+POST https://civitai.com/api/auth/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=YOUR_CLIENT_ID
+&client_secret=YOUR_CLIENT_SECRET
+&scope=SCOPE_BITMASK
+```
+
+The token acts on behalf of the client owner's account, scoped to the client's allowed permissions.
+
+## Revoking Tokens
+
+```
+POST https://civitai.com/api/auth/oauth/revoke
+Content-Type: application/x-www-form-urlencoded
+
+token=civitai_abc123...
+&token_type_hint=access_token
+```
+
+Always returns 200, even if the token was already revoked.
+
+## Scopes
+
+Scopes are represented as a bitmask integer. Combine scopes with bitwise OR.
+
+| Scope              | Value        | Description                        |
+| ------------------ | ------------ | ---------------------------------- |
+| UserRead           | 1            | Read profile & settings            |
+| UserWrite          | 2            | Update profile & settings          |
+| ModelsRead         | 4            | Browse & download models           |
+| ModelsWrite        | 8            | Upload & edit models               |
+| ModelsDelete       | 16           | Delete models                      |
+| MediaRead          | 32           | View images, videos & posts        |
+| MediaWrite         | 64           | Upload media & create posts        |
+| MediaDelete        | 128          | Delete media & posts               |
+| ArticlesRead       | 256          | Read articles                      |
+| ArticlesWrite      | 512          | Create & edit articles             |
+| ArticlesDelete     | 1024         | Delete articles                    |
+| BountiesRead       | 2048         | View bounties                      |
+| BountiesWrite      | 4096         | Create & manage bounties           |
+| BountiesDelete     | 8192         | Delete bounties                    |
+| AIServicesRead     | 16384        | View generation & training history |
+| AIServicesWrite    | 32768        | Generate, train & scan             |
+| BuzzRead           | 65536        | View buzz balance & history        |
+| CollectionsRead    | 131072       | View collections                   |
+| CollectionsWrite   | 262144       | Manage collections                 |
+| SocialWrite        | 524288       | Follow, react, comment & review    |
+| SocialTip          | 1048576      | Tip other users                    |
+| NotificationsRead  | 2097152      | Read notifications                 |
+| NotificationsWrite | 4194304      | Manage notification preferences    |
+| VaultRead          | 8388608      | View vault                         |
+| VaultWrite         | 16777216     | Manage vault                       |
+| **Full**           | **33554431** | All permissions                    |
+
+### Common Scope Combinations
+
+| Use Case           | Scopes                                                                                                                               | Value                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| Read-only browsing | UserRead, ModelsRead, MediaRead, ArticlesRead, BountiesRead, BuzzRead, CollectionsRead, AIServicesRead, NotificationsRead, VaultRead | Combine with OR                  |
+| AI generation      | AIServicesWrite, AIServicesRead, BuzzRead                                                                                            | 16384 \| 32768 \| 65536 = 114688 |
+| Publishing         | ModelsWrite, MediaWrite, ArticlesWrite + all reads                                                                                   | Combine with OR                  |
+
+## Endpoints
+
+| Endpoint                                | Method | Description                            |
+| --------------------------------------- | ------ | -------------------------------------- |
+| `/api/auth/oauth/authorize`             | GET    | Start authorization flow               |
+| `/api/auth/oauth/token`                 | POST   | Exchange code for token, refresh token |
+| `/api/auth/oauth/userinfo`              | GET    | Get authenticated user profile         |
+| `/api/auth/oauth/revoke`                | POST   | Revoke a token                         |
+| `/api/auth/oauth/device`                | POST   | Start device authorization             |
+| `/api/auth/oauth/device-token`          | POST   | Poll for device token                  |
+| `/api/.well-known/openid-configuration` | GET    | OpenID Connect discovery               |
+
+## Rate Limits
+
+- Token endpoint: 20 requests/minute per client
+- Authorization endpoint: 10 requests/minute per user
+- Revocation endpoint: 20 requests/minute per client
+
+Rate limit headers are included in responses: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`.
+
+## Token Lifetime
+
+- Access tokens: 1 hour
+- Refresh tokens: 30 days
+- Authorization codes: 10 minutes
+- Device codes: 15 minutes
+
+## Security Best Practices
+
+1. **Always use PKCE** — required for all authorization code requests
+2. **Validate the `state` parameter** — prevent CSRF attacks
+3. **Store tokens securely** — never expose in URLs or client-side storage for confidential apps
+4. **Use short-lived access tokens** — refresh when they expire
+5. **Request minimal scopes** — only ask for what your app needs
+6. **Register exact redirect URIs** — no wildcards allowed
+
+## What tokens _cannot_ do
+
+Some Civitai actions are **only available to session-authenticated users**, regardless of token scope. Hitting these via a Bearer token returns `403 FORBIDDEN`:
+
+- Tipping (`buzz.tipUser`)
+- Bounty creation (`bounty.upsert`)
+- Cosmetic shop purchases (`cosmeticShop.purchaseShopItem`, `purchasableReward.purchase`)
+- Comic chapter purchases (`comics.purchaseChapterAccess`)
+- Event donations (`event.donate`, `donationGoal.donate`)
+- Auction bids (`auction.createBid`)
+- Paid AI judge reviews (`challenge.requestReview`)
+- Paid game starts (`games.chopped.start`)
+- Model version early-access purchases (`modelVersion.earlyAccessPurchase`)
+- Creator-program bank/extract/withdraw (`creator-program.*`)
+- Direct user-to-club buzz transfers (`buzz.depositClubFunds`)
+
+Buzz-spending operations that flow through the orchestrator (image generation, training, scanning, recommenders) **are** available to tokens — that's the entire point of the OAuth/API key surface. The orchestrator enforces buzz spend on its side using each token's per-subject budget.
+
+## /api/v1/me — token introspection
+
+Hitting `/api/v1/me` with a Bearer token returns the user's identity plus token-specific fields:
+
+```jsonc
+{
+  "id": 12345,
+  "username": "...",
+  "tier": "...",
+  "status": "active" | "muted" | "banned",
+  "isMember": false,
+  "subscriptions": [],
+
+  // Present only when authenticated via a non-Full token
+  "tokenScope": 4194303,
+  "subject":   { "type": "apiKey" | "oauth", "id": <number | string> },
+  "buzzLimit": [{ "type": "sliding", "limit": 5000, "window": "day", "unit": 1 }] | null
+}
+```
+
+`subject` is the `(type, id)` pair Civitai's orchestrator buckets buzz spend by:
+
+- For User-type API keys, `id` is the numeric `ApiKey.id`.
+- For OAuth-issued tokens, `id` is the `clientId` — stable across access-token refresh rotations, so spend tracking persists when the access token rotates.
+
+`buzzLimit` is `null` (or omitted) when the user has not configured a limit on this token. Otherwise it's an array of budgets that cap how much buzz this token may spend in the orchestrator.
+
+## Buzz spend limits — `BuzzBudget[]`
+
+Each entry in `buzzLimit` is one of three discriminated variants:
+
+```ts
+type BuzzBudget =
+  | { type: 'absolute'; currencies?: string[]; limit: number }
+  | {
+      type: 'sliding';
+      currencies?: string[];
+      limit: number;
+      window: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month';
+      unit: number;
+    }
+  | { type: 'rollover'; currencies?: string[]; limit: number; cron: string };
+```
+
+- **absolute** — hard cap, no time component.
+- **sliding** — rolling window of `unit × window` (e.g. `window: 'day', unit: 7` = rolling 7-day window).
+- **rollover** — calendar-based reset driven by a cron expression. Cron syntax matches Hangfire Cronos.
+- Optional `currencies` restricts the cap to specific buzz pools (e.g. `["yellow"]`).
+
+Civitai's UI today only exposes a single sliding budget (limit + day/week/month period), but the JSON shape supports the full set. Programmatic clients with a Full-scope key can set any combination via the tRPC `apiKey.setBuzzLimit` and `oauthConsent.setBuzzLimit` mutations. A token cannot modify the limit on its own subject — use a different management key or session auth.

--- a/docs/plans/oauth-resume-state.md
+++ b/docs/plans/oauth-resume-state.md
@@ -1,0 +1,89 @@
+# OAuth Scoped Tokens — Resume State (post-compaction)
+
+**Branch:** `feature/scoped-tokens` (force-pushed, rebased on latest main)
+**Backup branch:** `backup/scoped-tokens-pre-rebase` (sha 922d83160)
+
+## Where We Are
+
+All 4 phases shipped. 2 commits on top of main:
+
+1. `3a0618d83` — Squash-rebase of all OAuth/scoped-tokens work onto current main
+2. `c390396c9` — Partial router annotations (comment + model only)
+
+## Database State (already applied to prod)
+
+| Column / Table                                           | Status  |
+| -------------------------------------------------------- | ------- |
+| `ApiKey.tokenScope` (Int, default 33554431)              | applied |
+| `ApiKey.lastUsedAt` (timestamp, nullable)                | applied |
+| `ApiKey.clientId` (text, nullable, FK→OauthClient)       | applied |
+| `ApiKey.buzzLimit` (jsonb, nullable)                     | applied |
+| `ApiKeyType` enum: Access, Refresh added                 | applied |
+| `OauthClient` table (13 cols)                            | applied |
+| `OauthConsent` table (6 cols, unique on userId+clientId) | applied |
+
+## Code State
+
+### Done
+
+- `src/shared/constants/token-scope.constants.ts` — TokenScope enum, presets, labels, grid, getScopeLabel
+- `src/server/oauth/{model,server,constants,token-helpers,rate-limit,audit-log}.ts` — Full server impl
+- `src/pages/api/auth/oauth/{authorize,token,userinfo,revoke,device,device-token,device-approve,device-info}.ts`
+- `src/pages/api/.well-known/openid-configuration.ts`
+- `src/pages/login/oauth/{authorize,device}.tsx`
+- `src/server/routers/{oauth-client,oauth-consent}.router.ts` + registered in `index.ts`
+- `src/server/schema/{api-key,oauth-client}.schema.ts`
+- `src/server/services/api-key.service.ts` — accepts tokenScope
+- `src/server/auth/{bearer-token,get-server-auth-session}.ts` — load tokenScope/buzzLimit, thread via req.context
+- `src/server/createContext.ts` — tokenScope on context (default Full for session auth)
+- `src/server/trpc.ts` — `enforceTokenScope` middleware (fail-safe: scoped tokens denied on un-annotated endpoints)
+- `src/server/utils/server-side-helpers.ts` — tokenScope: Full for SSG
+- `src/pages/api/v1/me.ts` — returns tokenScope + buzzLimit when scoped
+- `src/components/Account/{OAuthAppsCard,ConnectedAppsCard,ApiKeyModal,ApiKeysCard}.tsx` — UI
+- `src/pages/user/account.tsx` — adds OAuthAppsCard + ConnectedAppsCard
+- 5 docs in `docs/plans/`: plan, checklist, review, developer guide, spend-limits design
+- Migrations: tokenScope/lastUsedAt, oauth tables, buzzLimit (all applied to prod)
+
+### Router annotations (.meta({ requiredScope }))
+
+- DONE: comment, model
+- TODO: 87 other routers in `src/server/routers/`. Skip `index.ts`, `base.ts`, `oauth-client.router.ts`, `oauth-consent.router.ts` (those don't need it).
+
+### Not built (deferred)
+
+- Spend limit UI in API key modal
+- Spend tracking mechanism (Redis counter per key)
+- Buzz transaction middleware enforcement
+- Old `KeyScope[]` column cleanup (after prod validation)
+- Agent delegation tokens (special type)
+- OIDC `scopes_supported` human-readable names
+- ScopeSelector UI extraction (cosmetic dedup)
+
+## Resume Steps
+
+1. `git checkout feature/scoped-tokens`
+2. `pnpm install` (in case deps drift)
+3. `pnpm run db:generate`
+4. Spawn 4 annotation agents in parallel (rate limits permitting). Per-agent prompt template in `docs/plans/oauth-scoped-tokens-checklist.md` — basically:
+   - Add `import { TokenScope } from '~/shared/constants/token-scope.constants';`
+   - Add `.meta({ requiredScope: TokenScope.X })` after procedure type before `.input()`/`.query()`/`.mutation()`
+   - Scopes: UserRead/Write, ModelsRead/Write/Delete, MediaRead/Write/Delete, ArticlesRead/Write/Delete, BountiesRead/Write/Delete, AIServicesRead/Write, BuzzRead, SocialWrite, SocialTip, CollectionsRead/Write, NotificationsRead/Write, VaultRead/Write, Full (mod/system)
+   - Special: `user.getToken` → Full (token mint)
+5. Typecheck
+6. Squash-commit annotations
+7. Update checklist
+8. Push
+
+## Open Design Questions (spend limits)
+
+See `docs/plans/spend-limits.md` — 5 questions for Justin + Koen:
+
+1. Redis counters vs DB queries for tracking
+2. Per-key vs per-user spend attribution
+3. Single daily limit vs multi-period
+4. Orchestrator enforcement — does Koen need to add it?
+5. Limits on all buzz spending or just specific types
+
+## Audit Status (from prior session)
+
+All critical/high findings fixed. Remaining low items documented in `docs/plans/oauth-scoped-tokens-review.md`.

--- a/docs/plans/oauth-scoped-tokens-checklist.md
+++ b/docs/plans/oauth-scoped-tokens-checklist.md
@@ -1,0 +1,335 @@
+# OAuth & Scoped Tokens — Implementation Checklist
+
+Reference: [oauth-scoped-tokens.md](./oauth-scoped-tokens.md)
+Review: [oauth-scoped-tokens-review.md](./oauth-scoped-tokens-review.md)
+
+---
+
+## Phase 1: Scoped Token Enforcement
+
+### 1.1 Define Token Scopes
+
+- [x] Create `src/shared/constants/token-scope.constants.ts` with `TokenScope` bitwise enum
+  - [x] All 25 scopes as powers of 2
+  - [x] `Full` composite value `(1 << 25) - 1`
+  - [x] Scope preset constants (ReadOnly, Creator, AIServices, FullAccess)
+  - [x] Human-readable label map for each scope (for UI display)
+  - [x] Scope-to-column mapping for the permissions table UI (Read / Write / Delete groupings)
+
+### 1.2 Database Migration
+
+- [x] Add `tokenScope Int @default(33554431)` column to `ApiKey` table (default = `Full`)
+- [x] Backfill all existing `ApiKey` rows with `Full` scope value (via NOT NULL DEFAULT)
+- [x] Add `lastUsedAt DateTime?` column to `ApiKey` table
+- [x] Keep old `scope KeyScope[]` column temporarily (remove in Phase 1.8)
+- [x] Run migration against dev/staging, verify no breakage
+
+### 1.3 Scope Enforcement Middleware
+
+- [x] Extend tRPC meta type to include `requiredScope: number` field
+- [x] Create scope-checking middleware in `src/server/trpc.ts`
+  - [x] Read `ctx.tokenScope` bitmask
+  - [x] Check `Flags.hasFlag(tokenScope, procedure.requiredScope)`
+  - [x] Return 403 with clear error message if scope missing
+  - [x] Session auth (NextAuth cookies) always treated as `Full`
+  - [x] Fail-safe: scoped tokens denied on un-annotated endpoints
+- [x] Update `getSessionFromBearerToken()` to load `tokenScope` from `ApiKey` record
+- [x] Attach `tokenScope` to the tRPC context object so middleware can read it
+
+### 1.4 Annotate All tRPC Procedures (~767 procedures, 83 routers)
+
+- [x] All 83 routers annotated with `.meta({ requiredScope: TokenScope.X })`
+- [x] Reviewed by 3 external models (Gemini 2.5 Pro, Gemini 3.1 Pro, GPT 5.1 Codex)
+- [x] Fail-open vulnerability identified and fixed (now fail-safe)
+- [x] `user.getToken` elevated to `Full` scope (prevents token minting via limited key)
+
+### 1.5 Audit Internal Key Creation
+
+- [x] Search all calls to `addApiKey` / key creation in services
+- [x] Identify hidden generation/orchestrator keys — all use `type: 'System'` with `scope: ['Generate']`
+- [x] Verify: internal keys get `Full` tokenScope via DB column default — no changes needed
+- [x] Callers audited: `orchestrator-key.ts`, `get-orchestrator-token.ts`, `admin/orchestrator/timings.ts`, `admin/orchestrator/index.ts`
+
+### 1.6 Update `/api/v1/me` Endpoint
+
+- [x] Modify the me handler to access tokenScope from req.context
+- [x] Add `tokenScope` (bitmask) to response when authenticated via scoped API key
+- [x] Add `buzzLimit` to response when authenticated via API key
+
+### 1.7 Update API Key UI
+
+- [x] Update `ApiKeyModal.tsx` — replace old scope multi-select with:
+  - [x] Preset dropdown (Read Only / Creator / AI Services / Full Access)
+  - [x] Permissions table (rows = resource categories, columns = Read / Write / Delete)
+  - [x] Preset selection fills checkboxes, user can customize
+- [x] Update `ApiKeysCard.tsx` — show scope summary badge and last used date per key
+- [x] Update `addApiKey` mutation to accept new scope bitmask
+- [x] Update `api-key.schema.ts` validation for new scope format
+- [ ] Optional expiration date picker on key creation (deferred — nice to have)
+
+### 1.8 Cleanup (deferred until validated in production)
+
+- [ ] Drop old `scope KeyScope[]` column from `ApiKey` table
+- [ ] Remove `KeyScope` enum from Prisma schema
+- [ ] Remove old scope references from service/controller code
+- [ ] Update any tests referencing old scope format
+
+### 1.9 `lastUsedAt` Tracking
+
+- [x] Update `getSessionFromBearerToken()` to fire async `lastUsedAt` update
+- [x] Use debounced update — at most once per hour per key (fire-and-forget)
+- [x] Display `lastUsedAt` in API key list UI
+
+---
+
+## Phase 2: OAuth Server
+
+### 2.1 Install Dependencies
+
+- [x] Add `@node-oauth/oauth2-server` package
+- [x] Verify compatibility with current Node.js version
+
+### 2.2 Database — OAuth Tables
+
+- [x] Create `OauthClient` table migration
+  - [x] `id` TEXT PK (UUID)
+  - [x] `secret` TEXT (hashed, nullable for public clients)
+  - [x] `name` TEXT
+  - [x] `description` TEXT
+  - [x] `logoUrl` TEXT?
+  - [x] `redirectUris` TEXT[]
+  - [x] `grants` TEXT[]
+  - [x] `allowedScopes` Int (bitmask)
+  - [x] `isConfidential` Boolean
+  - [x] `userId` Int FK → User
+  - [x] `isVerified` Boolean default false
+  - [x] `createdAt` / `updatedAt` timestamps
+- [x] Create `OauthConsent` table migration
+  - [x] `id` Serial PK
+  - [x] `userId` Int FK → User
+  - [x] `clientId` TEXT FK → OauthClient
+  - [x] `scope` Int (bitmask of consented scopes)
+  - [x] `createdAt` / `updatedAt` timestamps
+  - [x] Unique constraint on (userId, clientId)
+- [x] Add `ApiKeyType` enum values: `Access`, `Refresh` (keep existing `System`, `User`)
+- [x] Add `clientId TEXT?` FK column to `ApiKey` table
+- [x] Add Prisma models and relations
+- [x] Run migration
+
+### 2.3 OAuth Server Model
+
+- [x] Create `src/server/oauth/model.ts`
+  - [x] `getClient(clientId, clientSecret)` — fetch client, **validate secret hash** for confidential clients
+  - [x] `saveAuthorizationCode(code, client, user)` — store in Redis with hashed key, set expiry correctly
+  - [x] `getAuthorizationCode(code)` — fetch from Redis by hashed key
+  - [x] `revokeAuthorizationCode(code)` — delete from Redis
+  - [x] `saveToken(token, client, user)` — create ApiKey rows (Access + Refresh), hash tokens, set scope bitmask
+  - [x] `getAccessToken(accessToken)` — look up ApiKey by hashed token, check type = Access
+  - [x] `getRefreshToken(refreshToken)` — look up ApiKey by hashed token, check type = Refresh
+  - [x] `revokeToken(token)` — delete ApiKey row, also revoke associated access token
+  - [x] `validateScope(user, client, scope)` — check requested scope against client's `allowedScopes`
+  - [x] `verifyScope(token, scope)` — check token's scope bitmask via `Flags.hasFlag()`
+- [x] Token prefix: prepend `civitai_` to generated OAuth tokens for distinguishability
+- [x] Access token lifetime: 1 hour
+- [x] Refresh token lifetime: 30 days
+- [x] Auth code lifetime: 10 minutes
+
+### 2.4 OAuth Server Instance
+
+- [x] Create `src/server/oauth/server.ts` — instantiate OAuth2Server with model
+- [x] Configure `allowEmptyState: false`
+- [x] PKCE (S256) validated in authorize endpoint before issuing codes
+
+### 2.5 Authorization Endpoint
+
+- [x] Create `src/pages/api/auth/oauth/authorize.ts`
+  - [x] Require authenticated user (NextAuth session)
+  - [x] Validate `client_id`, `redirect_uri`, `response_type=code`, `scope`, `state`
+  - [x] Validate PKCE `code_challenge` + `code_challenge_method=S256`
+  - [x] Check `OauthConsent` — if user previously approved this client+scope, skip consent
+  - [x] Otherwise redirect to consent page with query params
+  - [x] Handle consent approval flow (save consent if "remember" checked)
+
+### 2.6 Consent Page
+
+- [x] Create `src/pages/login/oauth/authorize.tsx`
+  - [x] Fetch client details (name, logo, description) by `client_id`
+  - [x] Display requested scopes in human-readable form (uses tokenScopeLabels)
+  - [x] Show "Verified by Civitai" badge if `isVerified`
+  - [x] All-or-nothing: user accepts all requested scopes or declines entirely
+  - [x] "Remember this decision" checkbox
+  - [x] On approve: form POST to authorization endpoint with `approved=true` (CSRF-safe)
+  - [x] On decline: redirect back to client with `error=access_denied`
+  - [x] Handle unauthenticated users: redirect to login, then back to consent
+
+### 2.7 Token Endpoint
+
+- [x] Create `src/pages/api/auth/oauth/token.ts`
+  - [x] Handle `grant_type=authorization_code` — validate code + PKCE `code_verifier`
+  - [x] Handle `grant_type=refresh_token` — validate refresh token, rotate
+  - [x] Validate client secret for confidential clients (via model)
+  - [x] Return `{ access_token, token_type, expires_in, refresh_token, scope }`
+  - [x] Do NOT return user PII in token response
+
+### 2.8 UserInfo Endpoint
+
+- [x] Create `src/pages/api/auth/oauth/userinfo.ts`
+  - [x] Require valid access token with `UserRead` scope
+  - [x] Return user profile: `{ sub, id, username, image }`
+
+### 2.9 Token Revocation Endpoint
+
+- [x] Create `src/pages/api/auth/oauth/revoke.ts`
+  - [x] Accept `token` + `token_type_hint` (access_token or refresh_token)
+  - [x] Require authentication (session or client credentials) before deletion
+  - [x] Verify caller owns the token being revoked
+  - [x] Delete the ApiKey row
+  - [x] If revoking refresh token, also revoke all associated access tokens
+  - [x] Always return 200 (per RFC 7009, even if token not found)
+  - [x] Rate limited by IP (not client_id) to prevent bypass
+
+### 2.10 Redis Key Setup
+
+- [x] Add `OAUTH.AUTHORIZATION_CODES` key constant to Redis client
+- [x] Auth codes stored as Redis hash: key = hashed code, value = JSON (client, user, scope, PKCE challenge, redirectUri)
+- [x] Set expiry correctly on the hashed key (not the raw code — PR #1313 bug avoided)
+
+### 2.11 Developer Portal
+
+- [x] Create tRPC router: `oauth-client` with CRUD procedures
+  - [x] `create` — register new client, generate ID + secret
+  - [x] `getAll` — list user's clients
+  - [x] `getById` — client details
+  - [x] `update` — edit name, description, redirectUris, allowedScopes
+  - [x] `rotateSecret` — generate new secret, hash and store
+  - [x] `delete` — remove client + all associated tokens and consents
+- [x] Developer portal UI as OAuthAppsCard on account page
+  - [x] List user's registered OAuth apps
+  - [x] "Register New App" form with scope selector
+  - [x] Edit app details / rotate secret / delete
+  - [x] Show client ID + secret (once, with copy button)
+
+### 2.12 Rate Limiting
+
+- [x] Add rate limit on token endpoint (20 req/min per client_id)
+- [x] Add rate limit on authorization endpoint (10 req/min per user)
+- [x] Add rate limit on revocation endpoint (20 req/min per client_id)
+- [x] Rate limit headers (X-RateLimit-Limit, Remaining, Reset, Retry-After)
+
+### 2.13 Audit Logging
+
+- [x] Log OAuth events as structured JSON to stdout (for Axiom/log aggregation)
+- [x] Events: client.created/updated/deleted/secret_rotated, authorization.granted, token.issued/refreshed/revoked
+
+### 2.14 Per-Key Spend Limits
+
+- [x] Add `buzzLimit JSONB` column to `ApiKey` table (migration)
+- [x] Load buzzLimit in bearer token auth pipeline
+- [x] Include buzzLimit in `/api/v1/me` response for orchestrator enforcement
+- [ ] Add spend limit UI to API key creation/edit modal
+- [ ] Create spend tracking mechanism (Redis counter per key, reset on period boundary)
+- [ ] Enforce limits in buzz transaction middleware
+
+### 2.15 CORS for OAuth Endpoints
+
+- [x] Token endpoint has permissive CORS via `addCorsHeaders`
+- [x] UserInfo and revocation endpoints have CORS
+- [ ] Consider per-client CORS origin restrictions (future)
+
+---
+
+## Phase 3: Connected Apps & Management
+
+### 3.1 Connected Apps Page
+
+- [x] Create ConnectedAppsCard component on account page
+  - [x] List all apps user has authorized (from `OauthConsent` + active tokens)
+  - [x] Show: app name, verified badge, granted scopes badge, authorization date, active tokens
+  - [x] "Revoke Access" button per app — deletes all tokens for that client + consent record
+  - [x] Confirmation modal before revoking
+  - [x] Auto-hides when no connected apps
+
+### 3.2 Token Activity Tracking
+
+- [x] `lastUsedAt` tracking on all API key usage (Phase 1.9)
+- [x] Active token count shown in Connected Apps view
+- [x] Active token + consent counts shown in developer portal per-app view
+
+### 3.3 Developer Dashboard
+
+- [x] In developer portal, per-app stats:
+  - [x] Active token count
+  - [x] Total authorizations (consent count)
+
+---
+
+## Phase 4: Advanced Flows & Integrations
+
+### 4.1 Client Credentials Flow
+
+- [x] Implement `getUserFromClient` in OAuth model
+- [x] Only for confidential clients with `client_credentials` in `grants` array
+- [x] Token scoped to client's `allowedScopes` (user = client owner)
+
+### 4.2 Device Authorization Flow
+
+- [x] Implement device authorization endpoint (`/api/auth/oauth/device`)
+- [x] Implement device token polling endpoint (`/api/auth/oauth/device-token`)
+- [x] Implement device approval endpoint (`/api/auth/oauth/device-approve`)
+- [x] Device info endpoint (`/api/auth/oauth/device-info`) — look up app details by user code
+- [x] Device verification page (`/login/oauth/device`) — two-step: enter code → review app name/scopes → approve/deny
+- [x] Validates client grants array (`urn:ietf:params:oauth:grant-type:device_code`)
+- [x] Validates scope against client's `allowedScopes` at both initiation and token exchange
+- [x] Redis storage for device codes with TTL
+- [x] Use case: CLI tools, headless agents
+
+### 4.3 Agent Delegation Tokens
+
+- [ ] Special token type for AI agents (deferred — uses standard OAuth tokens + spend limits for now)
+- [ ] Additional rate limiting per agent token
+
+### 4.4 OpenID Connect Discovery
+
+- [x] Create `/api/.well-known/openid-configuration` endpoint
+- [x] Publish authorization, token, userinfo, revocation, device endpoint URLs
+- [x] Publish supported scopes, grant types, response types, code challenge methods
+
+### 4.5 Developer Documentation
+
+- [x] Create comprehensive developer guide (`docs/plans/oauth-developer-docs.md`) covering:
+  - [x] Overview of Civitai OAuth
+  - [x] Registering an app
+  - [x] Authorization code + PKCE flow walkthrough with code examples
+  - [x] Available scopes with bitmask values and common combinations
+  - [x] Token lifecycle (access, refresh, revocation)
+  - [x] UserInfo endpoint
+  - [x] Device authorization flow
+  - [x] Client credentials flow
+  - [x] Rate limits and security best practices
+- [ ] Publish as static page on the site (currently in docs/plans/)
+
+---
+
+## Security Hardening (from audits)
+
+### Applied
+
+- [x] Fail-safe middleware — scoped tokens denied on un-annotated endpoints
+- [x] Consent bypass blocked — `approved=true` only accepted via POST
+- [x] Redirect URI validated against registered URIs before use
+- [x] Scope defaults to 0 (not Full) for missing/invalid values
+- [x] Negative and overflow scope values rejected
+- [x] Constant-time secret comparison (`crypto.timingSafeEqual`) in model + revoke
+- [x] Device flow validates grants array and scope against allowedScopes
+- [x] Revoke requires authentication, rate limited by IP
+- [x] `user.getToken` requires Full scope (prevents token minting via limited key)
+- [x] Public clients can refresh tokens (OAuth 2.1 compliant)
+- [x] Shared `createOAuthTokenPair` helper prevents logic drift
+- [x] `userinfo.ts` fails safe — defaults scope to 0 when missing
+
+### Remaining (Low severity)
+
+- [ ] Extract ScopeSelector component from OAuthAppsCard for reuse in ApiKeyModal
+- [ ] OIDC `scopes_supported` uses numeric keys — consider human-readable names
+- [ ] Device-approve CSRF (mitigated by SameSite=Lax cookies)
+- [ ] Rate limit TOCTOU: `incr` + `expire` not atomic (use Lua script or SET NX EX)

--- a/docs/plans/oauth-scoped-tokens-review.md
+++ b/docs/plans/oauth-scoped-tokens-review.md
@@ -1,0 +1,131 @@
+# OAuth & Scoped Tokens — Review Checklist
+
+Items that need human review, testing, or validation before this feature is production-ready.
+
+---
+
+## UI Components to Review
+
+### API Key Management (Phase 1)
+
+- [ ] **ApiKeyModal** — New scope selection UI
+  - [ ] Preset dropdown works (Read Only / Creator / AI Services / Full Access)
+  - [ ] Permissions table shows correct checkboxes per resource
+  - [ ] Selecting a preset fills checkboxes correctly
+  - [ ] Customizing checkboxes after preset selection works
+  - [ ] Created key has correct `tokenScope` bitmask
+  - [ ] Old keys still work (backward compat)
+- [ ] **ApiKeysCard** — Updated key list
+  - [ ] Shows scope summary badge per key (Full Access / Read Only / Custom / etc.)
+  - [ ] Shows `lastUsedAt` date for keys that have been used
+  - [ ] Delete still works
+
+### OAuth Consent Page (Phase 2)
+
+- [ ] **`/login/oauth/authorize`** — Consent screen
+  - [ ] Shows app name and description (not raw client_id)
+  - [ ] Lists requested scopes in human-readable form
+  - [ ] "Verified by Civitai" badge shows for verified apps
+  - [ ] "Remember my decision" checkbox works
+  - [ ] Approve redirects back to client with auth code
+  - [ ] Deny redirects back with `error=access_denied`
+  - [ ] Unauthenticated users redirected to login first
+
+### Developer Portal (Phase 2) — NOT YET BUILT
+
+- [ ] Page at `/user/account/developers` or tab in account settings
+- [ ] Register new OAuth app form
+- [ ] List/edit/delete apps
+- [ ] Rotate client secret
+- [ ] Show client ID + secret (once)
+
+### Connected Apps (Phase 3) — NOT YET BUILT
+
+- [ ] Page at `/user/account#connected-apps`
+- [ ] List authorized apps with revoke button
+
+---
+
+## Backend Validation
+
+### Phase 1: Scoped Token Enforcement
+
+#### Database
+
+- [ ] Run migration `20260410124247_add_token_scope_to_api_key`
+  - Adds `tokenScope INT NOT NULL DEFAULT 33554431` and `lastUsedAt` to ApiKey
+- [ ] Verify all existing keys have `tokenScope = 33554431` (Full)
+
+#### Scope Enforcement
+
+- [ ] **Test: Full-scope API key can access everything** (existing behavior preserved)
+  - Create a key with Full scope → all tRPC procedures work as before
+- [ ] **Test: Scoped key is restricted**
+  - Create a key with only `ModelsRead` scope → can call `model.getById` → cannot call `model.upsert`
+- [ ] **Test: Scoped key blocked on un-annotated endpoints**
+  - A key with any non-Full scope hitting an un-annotated procedure gets 403
+- [ ] **Test: Session auth (cookie) always has Full scope**
+  - Browser users are never restricted by token scopes
+- [ ] **Test: lastUsedAt updates**
+  - Use an API key → `lastUsedAt` column updates (debounced to ~1 hour)
+
+#### /api/v1/me endpoint
+
+- [ ] With a scoped API key, response includes `tokenScope` field
+- [ ] With a Full-scope key or session cookie, `tokenScope` is NOT included
+- [ ] Orchestrator continues to work with existing keys
+
+### Phase 2: OAuth Server
+
+#### Database
+
+- [ ] Run migration `20260410140011_add_oauth_tables`
+  - Creates OauthClient, OauthConsent tables
+  - Adds Access/Refresh to ApiKeyType enum
+  - Adds clientId FK to ApiKey
+
+#### OAuth Flow (end-to-end)
+
+- [ ] **Register a test client** via tRPC `oauthClient.create`
+  - Record client_id and client_secret
+- [ ] **Authorization Code + PKCE flow**:
+  1. Generate PKCE code_verifier + code_challenge (S256)
+  2. GET `/api/auth/oauth/authorize?client_id=X&redirect_uri=Y&response_type=code&scope=Z&state=random&code_challenge=C&code_challenge_method=S256`
+  3. Should redirect to consent page (first time)
+  4. Approve → redirects to redirect_uri with `?code=ABC&state=random`
+  5. POST `/api/auth/oauth/token` with `grant_type=authorization_code&code=ABC&client_id=X&client_secret=S&code_verifier=V&redirect_uri=Y`
+  6. Response should include `access_token` (prefixed `civitai_`), `refresh_token`, `expires_in`, `scope`
+- [ ] **Access token works as bearer token**
+  - `Authorization: Bearer civitai_XXX` → authenticated, scoped requests work
+- [ ] **Refresh token flow**
+  - POST `/api/auth/oauth/token` with `grant_type=refresh_token&refresh_token=RT&client_id=X&client_secret=S`
+  - Get new access + refresh tokens, old ones revoked
+- [ ] **UserInfo endpoint**
+  - GET `/api/auth/oauth/userinfo` with bearer token → returns user profile
+  - Without `UserRead` scope → 403
+- [ ] **Token revocation**
+  - POST `/api/auth/oauth/revoke` with token → returns 200
+  - Token no longer works after revocation
+- [ ] **Security checks**:
+  - [ ] PKCE required — request without code_challenge is rejected
+  - [ ] State required — request without state is rejected
+  - [ ] Invalid client_secret for confidential client → rejected
+  - [ ] Wrong redirect_uri → rejected
+  - [ ] Expired auth code → rejected
+  - [ ] Expired access token → rejected
+  - [ ] Consent remembered — second auth for same client+scope skips consent page
+
+---
+
+## Items Deferred to Later
+
+These are noted but not blocking the current implementation:
+
+- **Phase 1.8**: Drop old `scope KeyScope[]` column — wait until new system is validated in production
+- **Phase 2.11**: Developer portal UI page — tRPC router exists, need the React page
+- **Phase 2.12**: Rate limiting on OAuth endpoints — operational hardening
+- **Phase 2.13**: Audit logging for OAuth events — operational hardening
+- **Phase 2.14**: Per-key buzz spend limits — separate feature
+- **Phase 2.15**: Per-client CORS origin restrictions — future enhancement
+- **Phase 3**: Connected apps page — user management UI
+- **Phase 4**: Client credentials flow, device auth, OIDC discovery, developer docs

--- a/docs/plans/oauth-scoped-tokens.md
+++ b/docs/plans/oauth-scoped-tokens.md
@@ -1,0 +1,473 @@
+# OAuth Server & Scoped Tokens Plan
+
+## Context
+
+Civitai needs a proper OAuth authorization server so third-party sites can implement "Log in with Civitai" and eventually "Publish to Civitai" capabilities. PR #1313 started this work ~2 years ago but was put on hold. The existing API key system has `KeyScope` (Read/Write/Generate) defined in the schema but **never enforced** — any API key has full access to everything the user can do.
+
+This plan covers:
+
+1. **Scoped tokens** — enforce granular permissions on all API keys and OAuth tokens
+2. **OAuth server** — built fresh, using PR #1313 as reference for architecture decisions
+3. **Token management** — improve the user-facing token experience
+4. **Third-party integrations** — enable "Publish to Civitai", open-source frontends, and agent delegation
+
+### Long-term direction
+
+Eventually, the OAuth system should become the primary auth mechanism for all Civitai clients — including first-party apps (mobile, extensions, subdomains). This would allow us to retire NextAuth over time. For now, NextAuth sessions continue to work for the main web app, but all new clients should use OAuth.
+
+---
+
+## Current State
+
+### What We Have
+
+- **API keys**: Stored as SHA-512 hashes in `ApiKey` table. Users create them via account settings with a name and scope selection (Read/Write/Generate). Keys are validated in `getSessionFromBearerToken()` → `getSessionUser()`.
+- **Scopes exist but aren't enforced**: The `KeyScope` enum has `Read`, `Write`, `Generate`, but no middleware or tRPC procedure checks these values against the operation being performed.
+- **NextAuth sessions**: JWT-based, 30-day max, tracked per-token in Redis with invalidation support. Currently used for subdomains too via shared session cookies.
+- **Token infrastructure**: `key-generator.ts` handles generation (32-char hex) and hashing (SHA-512 + NEXTAUTH_SECRET salt).
+- **Orchestrator integration**: Hidden API keys are created for users to authenticate directly with the orchestrator for generation. Third-party clients should be able to do the same via OAuth tokens.
+- **Flags utility**: Existing `Flags` class in `src/shared/utils/flags.ts` provides all bitwise operations (hasFlag, addFlag, removeFlag, intersects, etc.) — already used for NSFW levels and other systems.
+
+### What PR #1313 Established (Reference Only)
+
+The branch is too far behind to merge, but the architecture is sound and worth referencing:
+
+- `OauthClient` table (id, secret, name, redirectUris, grants, userId)
+- `ApiKeyType` expanded with `Access` and `Refresh` types
+- Authorization code flow using `@node-oauth/oauth2-server`
+- Auth codes stored in Redis, tokens as `ApiKey` rows
+- Consent page at `/login/oauth/authorize`
+
+### Critical Issues Found in PR #1313 (to avoid when rebuilding)
+
+1. **Client secret never validated** — `getClient()` ignores the `clientSecret` parameter
+2. **No PKCE** — vulnerable to code interception (required by OAuth 2.1)
+3. **No scope validation** — `validateScope` is commented out
+4. **Redis expiry bug** — expiry set on raw code field but stored under hashed key
+5. **No CSRF protection** — `allowEmptyState: true`
+6. **Consent screen shows raw client_id** instead of app name
+7. **Token response includes PII** — should use separate userinfo endpoint
+8. **Unique index on ApiKey.key dropped** inconsistently between migration and schema
+
+---
+
+## Proposed Scope System
+
+### Design Principles
+
+- Scopes are **hierarchical**: `models:write` implies `models:read`
+- Scopes are **resource-based**: tied to what you're accessing, not how
+- Every tRPC procedure gets a required scope annotation — aim for **full coverage from day one**
+- API keys and OAuth tokens both use the same scope system
+- Backward compatible: existing API keys + internally-created keys get `Full` scope
+- Scopes stored as a **bitwise integer** (single `Int` column) for efficiency — fits the existing `Flags` pattern
+
+### Scope Definitions (Bitwise Flags)
+
+```typescript
+enum TokenScope {
+  None = 0,
+
+  // Account & Profile
+  UserRead = 1 << 0, // 1       — Read own profile, settings, preferences
+  UserWrite = 1 << 1, // 2       — Update profile, settings, preferences
+
+  // Models & Resources
+  ModelsRead = 1 << 2, // 4       — Browse, search, download models
+  ModelsWrite = 1 << 3, // 8       — Upload, edit, publish, unpublish models
+  ModelsDelete = 1 << 4, // 16      — Delete own models
+
+  // Media & Posts (images, videos, posts — tightly coupled)
+  MediaRead = 1 << 5, // 32      — View images, videos, posts, galleries
+  MediaWrite = 1 << 6, // 64      — Upload images/videos, create/edit posts
+  MediaDelete = 1 << 7, // 128     — Delete own media/posts
+
+  // Articles
+  ArticlesRead = 1 << 8, // 256     — Read articles
+  ArticlesWrite = 1 << 9, // 512     — Create/edit articles
+  ArticlesDelete = 1 << 10, // 1024    — Delete own articles
+
+  // Bounties (write implicitly allows buzz spend for bounty creation)
+  BountiesRead = 1 << 11, // 2048    — View bounties and entries
+  BountiesWrite = 1 << 12, // 4096    — Create/edit bounties, submit entries
+  BountiesDelete = 1 << 13, // 8192    — Delete own bounties
+
+  // AI Services (generation, training, scanning — all orchestrator requests)
+  // Write implicitly allows buzz spend for orchestrator usage
+  AIServicesRead = 1 << 14, // 16384   — View generation/training history
+  AIServicesWrite = 1 << 15, // 32768   — Generate, train, scan via orchestrator
+
+  // Buzz (Currency)
+  BuzzRead = 1 << 16, // 65536   — View buzz balance and transaction history
+
+  // Collections & Interactions
+  CollectionsRead = 1 << 17, // 131072  — View own collections
+  CollectionsWrite = 1 << 18, // 262144  — Create/edit collections, add/remove items
+  SocialWrite = 1 << 19, // 524288  — Follow, react, comment, review
+  SocialTip = 1 << 20, // 1048576 — Tip other users (buzz spend for tips)
+
+  // Notifications
+  NotificationsRead = 1 << 21, // 2097152  — Read notifications
+  NotificationsWrite = 1 << 22, // 4194304  — Mark read, update preferences
+
+  // Vault
+  VaultRead = 1 << 23, // 8388608   — View vault contents
+  VaultWrite = 1 << 24, // 16777216  — Add/remove vault items
+
+  // Convenience composites
+  Full = (1 << 25) - 1, // All bits set — full access
+}
+```
+
+**25 scopes, fits in 32-bit integer** with 7 spare bits for future expansion.
+
+**Key design notes:**
+
+- **`Full`** is a single value (all bits set) — used as the default for existing keys, session auth, and internally-created keys. Avoids needing to enumerate all scopes.
+- **Buzz spend is implicit**, not a standalone scope:
+  - `AIServicesWrite` — implicitly spends buzz for generation, training, scanning
+  - `BountiesWrite` — implicitly spends buzz for bounty creation
+  - `SocialTip` — dedicated scope for tipping (buzz spend on tips)
+- **`MediaRead/Write/Delete`** covers images, videos, AND posts (they're tightly coupled)
+- **`AIServicesRead/Write`** covers all orchestrator operations: generation, training, scanning, and anything else added to orchestration
+- Adding a new scope is just adding a new bit position and a migration to update `Full`
+
+### Scope Bundles (Convenience Presets)
+
+The API key UI uses a preset dropdown that populates a permissions table. The table has columns for **Read**, **Write**, and **Delete**, with rows for each resource category. Selecting a preset fills in the checkboxes, but users can customize from there.
+
+| Preset          | Flags                                                                                                                                                    | Use Case                   |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| **Read Only**   | `UserRead \| ModelsRead \| MediaRead \| ArticlesRead \| BountiesRead \| BuzzRead \| CollectionsRead \| AIServicesRead \| NotificationsRead \| VaultRead` | Analytics, dashboards      |
+| **Creator**     | Read Only + `ModelsWrite \| MediaWrite \| ArticlesWrite \| BountiesWrite \| CollectionsWrite \| SocialWrite`                                             | Publishing tools           |
+| **AI Services** | `AIServicesWrite \| AIServicesRead \| BuzzRead`                                                                                                          | Generation/training agents |
+| **Full Access** | `Full`                                                                                                                                                   | Personal automation        |
+
+These presets are defined in code as constants, not in the database.
+
+### Per-Key Spend Limits
+
+For any key with buzz-spending scopes (`AIServicesWrite`, `BountiesWrite`, `SocialTip`), users can set spending caps:
+
+- Daily / weekly / monthly buzz limit
+- Stored on the `ApiKey` record
+- Enforced at both:
+  1. **Civitai middleware layer** — before processing buzz transactions via tRPC
+  2. **Orchestrator** — checks against the `/api/v1/me` endpoint response (see Orchestrator Integration section)
+- Especially important for agent delegation tokens
+
+### Scope Enforcement Architecture
+
+Scope enforcement focuses on **tRPC procedures** — the v1 REST APIs are read-only/public and don't need scoped access.
+
+```
+Request (Bearer token)
+  → getSessionFromBearerToken()
+    → look up ApiKey, load scope bitmask
+    → attach scope to session context
+  → tRPC procedure middleware
+    → Flags.hasFlag(session.scope, procedure.requiredScope)
+    → reject with 403 if missing
+```
+
+**Implementation approach:**
+
+- Add a `requiredScope` field to tRPC procedure metadata
+- Create a `scopedProcedure` wrapper (or extend existing `protectedProcedure`)
+- The middleware reads `ctx.session.scope` and checks via `Flags.hasFlag()`
+- For session auth (browser/NextAuth), treat as `Full` (no restrictions)
+- **Aim for full scope coverage immediately** — annotate all tRPC procedures with their required scope from the start
+- All existing API keys and internally-created keys (e.g., generation service keys) get `Full` scope so nothing breaks
+
+### Updating Internal Key Creation
+
+Currently, hidden API keys are created for orchestrator/generation use. These need to be updated to include the appropriate scope (`AIServicesWrite | AIServicesRead | BuzzRead` at minimum, or `Full` to maintain current behavior). Need to audit all places that call `addApiKey` or create keys programmatically.
+
+---
+
+## OAuth Server Design
+
+### Start Fresh, Reference PR #1313
+
+The PR #1313 branch is too far behind to merge. We'll build from scratch on `main`, keeping the same architectural decisions that were sound (auth codes in Redis, tokens as ApiKey rows, `@node-oauth/oauth2-server` library).
+
+### OAuth Flows to Support
+
+| Flow                          | Use Case                                                | Priority |
+| ----------------------------- | ------------------------------------------------------- | -------- |
+| **Authorization Code + PKCE** | Web apps, open-source frontends ("Log in with Civitai") | P0       |
+| **Refresh Token**             | Long-lived sessions                                     | P0       |
+| **Client Credentials**        | Server-to-server (trusted partners)                     | P1       |
+| **Device Authorization**      | CLI tools, agents                                       | P2       |
+
+**Key use case — open-source frontends**: Third-party or community-built UIs (e.g., custom generation interfaces) where:
+
+1. User authorizes via OAuth, token stored in browser localStorage
+2. Frontend calls Civitai tRPC/API directly with the token
+3. Frontend can also call orchestrator directly using the token (same pattern as our hidden API keys for generation)
+
+This means the OAuth token must be usable anywhere our current API keys work, including direct orchestrator auth.
+
+**Public clients (frontend-only, no server)**: The standard approach per OAuth 2.1 is PKCE-only authorization code flow with no client secret. The client is registered as `isConfidential: false`, and PKCE alone provides the security. Short-lived access tokens (1 hour) + refresh tokens ensure tokens in localStorage don't stay valid forever.
+
+### Key Components
+
+#### 1. Client Registration & Management
+
+**Database: `OauthClient` table**
+
+```
+id              TEXT PK (UUID)
+secret          TEXT (hashed, like API keys — null for public clients)
+name            TEXT
+description     TEXT
+logoUrl         TEXT?
+redirectUris    TEXT[]
+grants          TEXT[] (authorization_code, refresh_token, client_credentials)
+allowedScopes   INT (bitmask — max scopes this client can request)
+isConfidential  BOOLEAN (public vs confidential client)
+userId          INT FK → User (developer who registered it)
+isVerified      BOOLEAN (Civitai-reviewed apps get verified badge on consent)
+createdAt       TIMESTAMP
+updatedAt       TIMESTAMP
+```
+
+**Developer Portal (new page: `/user/account/developers`)**
+
+- Register new OAuth apps (open registration — no approval required)
+- View/edit app details, redirect URIs
+- Rotate client secrets
+- View usage stats (active tokens, total authorizations)
+
+#### 2. Authorization Endpoint (`/api/auth/oauth/authorize`)
+
+- Validate `client_id`, `redirect_uri`, `response_type`, `scope`, `state`
+- **Require PKCE**: `code_challenge` + `code_challenge_method` (S256 required)
+- **Require state**: CSRF protection mandatory
+- Redirect to consent page if user hasn't previously authorized this client+scope combo
+
+#### 3. Consent Page (`/login/oauth/authorize`)
+
+- Show app name, logo, description (not raw client_id)
+- List requested scopes in human-readable form
+- Show "Verified by Civitai" badge for reviewed apps
+- "Remember this decision" checkbox for trusted apps
+- Store consent records in `OauthConsent` table to skip re-authorization
+
+#### 4. Token Endpoint (`/api/auth/oauth/token`)
+
+- **Validate client secret** for confidential clients
+- **Validate PKCE code_verifier** against stored code_challenge
+- Issue access token (1 hour expiry) and refresh token (30 days)
+- Store as `ApiKey` rows with `type: Access/Refresh` and scope bitmask
+- **Do not include PII in token response** — use userinfo endpoint
+
+#### 5. UserInfo Endpoint (`/api/auth/oauth/userinfo`) — NEW
+
+- Standard OpenID Connect-style endpoint
+- Returns user profile based on token scopes
+- `UserRead` scope required
+
+#### 6. Token Revocation (`/api/auth/oauth/revoke`) — NEW
+
+- RFC 7009 compliant
+- Revoke access or refresh tokens
+- Also revoke from user's token management page
+
+### Security Requirements
+
+- **PKCE required** for all authorization code grants (not optional)
+- **Client secret validation** for confidential clients
+- **State parameter required** (CSRF protection)
+- **Redirect URI exact match** (no wildcards)
+- **Rate limiting** on token endpoint
+- **Short-lived access tokens** (1 hour, not 7 days like in PR #1313)
+- **Token rotation on refresh** — old access token revoked when new one is issued
+- Audit log for all OAuth events (authorization, token issue, revoke)
+
+---
+
+## Token Management Improvements
+
+### Updated API Key UI (`/user/account#api-keys`)
+
+**Current**: Name + scope multi-select (Read/Write/Generate)
+**Proposed**:
+
+- Name field
+- Preset dropdown (Read Only / Creator / Generator / Full Access)
+- Permissions table: rows = resource categories, columns = Read / Write / Delete
+  - Preset fills checkboxes, user can customize
+  - `Generate` maps to "Write" column conceptually
+- Optional expiration date picker
+- Optional buzz spend limit (daily/weekly/monthly)
+- Show last used timestamp in the key list
+- Show scopes summary per key
+
+### New: Connected Apps Page (`/user/account#connected-apps`)
+
+- List all third-party apps the user has authorized via OAuth
+- Show app name, logo, granted scopes, authorization date
+- Revoke access per app (deletes all tokens for that client)
+- View activity log per app
+
+### Database Changes
+
+**`ApiKey` table updates:**
+
+```
++ scope       Int           (bitmask, default = Full. Replaces old KeyScope[] enum)
++ clientId    TEXT? FK      (which OAuth client issued this, null for user-created)
++ lastUsedAt  TIMESTAMP?   (track usage)
++ buzzLimit   JSON?        ({ daily?: number, weekly?: number, monthly?: number })
+```
+
+**Migration strategy for existing keys:**
+
+- All existing keys get `Full` scope (single integer value with all bits set)
+- Default column value is `Full` so keys created during rollout work correctly against prod database
+- Old `scope KeyScope[]` column dropped after migration
+- Audit all internal key creation (generation service, etc.) to ensure they set appropriate scopes
+
+**New tables:**
+
+```sql
+CREATE TABLE "OauthClient" (
+  -- as described above
+);
+
+CREATE TABLE "OauthConsent" (
+  id          SERIAL PK,
+  "userId"    INT FK → User,
+  "clientId"  TEXT FK → OauthClient,
+  scope       INT,  -- bitmask of consented scopes
+  "createdAt" TIMESTAMP DEFAULT now(),
+  "updatedAt" TIMESTAMP DEFAULT now(),
+  UNIQUE("userId", "clientId")
+);
+```
+
+---
+
+## Publishing API
+
+For the "Publish to Civitai" use case, third-party clients need to create posts with images, upload models, etc. The primary use case is publishing images/posts.
+
+### Approach: tRPC for now, v2 later
+
+External clients call existing tRPC endpoints directly via their OAuth tokens. This works once OAuth + scopes ship. Future v2 API would be a cleaner REST surface hitting the service layer directly — potentially as a separate API server rather than more endpoints in this Next.js project.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Scoped Token Enforcement (Foundation)
+
+**Goal**: Make token scopes actually enforced. Ship the new scope system.
+
+1. Define `TokenScope` bitwise enum in `src/shared/constants/token-scopes.ts`
+2. Add `scope Int @default(Full)` column to `ApiKey` table
+   - Default to `Full` so all new keys (including ones created against prod DB during development) work correctly
+3. Migrate existing keys: all get `Full` scope
+4. Audit all internal key creation (generation service keys, etc.) — ensure they set correct scopes
+5. Add scope to tRPC procedure metadata: `.meta({ requiredScope: TokenScope.ModelsWrite })`
+6. Create middleware that checks `Flags.hasFlag(ctx.session.scope, procedure.requiredScope)`
+7. For session auth (browser/NextAuth), treat as `Full` (no restrictions)
+8. Annotate **all** tRPC procedures with required scopes from the start
+9. Update API key creation UI with preset dropdown + permissions table
+10. Add `lastUsedAt` tracking
+11. Drop old `KeyScope` enum and `scope` column after migration
+12. Identify orchestrator permission-check endpoint and include per-key spend limits
+
+### Phase 2: OAuth Server (Core)
+
+**Goal**: Ship a working, secure OAuth authorization code flow.
+
+1. Create `OauthClient` and `OauthConsent` tables + migration
+2. Implement OAuth server from scratch using `@node-oauth/oauth2-server`
+3. Build authorization, token, userinfo, and revocation endpoints
+4. Build consent page with proper app display
+5. Build developer portal for client registration
+6. Add rate limiting on token endpoint
+7. Add audit logging
+8. Add per-key buzz spend limits (UI + enforcement)
+
+### Phase 3: Connected Apps & Management
+
+**Goal**: Give users full control over their tokens and authorized apps.
+
+1. Build Connected Apps page
+2. Add token activity tracking
+3. Build app usage dashboard for developers
+
+### Phase 4: Advanced Flows & Integrations
+
+**Goal**: Enable open-source frontends, CLI tools, and agent delegation.
+
+1. Implement Client Credentials flow (open-source frontends, trusted partners)
+2. Implement Device Authorization flow (CLI tools, agents)
+3. Agent delegation tokens with spend caps
+4. OpenID Connect Discovery (`.well-known/openid-configuration`)
+
+---
+
+## Decisions Made
+
+| Question               | Decision                                                                                                                           |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Scope granularity      | media (images+videos+posts) together, articles separate, bounties separate                                                         |
+| Buzz spending          | Implicit — `AIServicesWrite` for orchestrator, `BountiesWrite` for bounties, `SocialTip` for tips. No standalone `BuzzSpend` scope |
+| Tips                   | Dedicated `SocialTip` scope, separate from `SocialWrite`                                                                           |
+| AI services            | `AIServicesRead/Write` covers all orchestrator ops (generation, training, scanning, etc.)                                          |
+| Existing API keys      | Grandfathered with `Full` scope                                                                                                    |
+| OAuth app registration | Open — anyone can register freely                                                                                                  |
+| Scope storage          | **Bitwise flags** (single Int column) — matches existing `Flags` pattern, efficient, easy to extend                                |
+| OAuth branch           | Start fresh on main, use PR #1313 as reference                                                                                     |
+| First-party apps       | Should use OAuth eventually (retire NextAuth long-term)                                                                            |
+| Publishing API         | tRPC for now, v2 service-layer API later (possibly separate server)                                                                |
+| Scope rollout          | Full coverage from day one, not incremental                                                                                        |
+| Default scope value    | `Full` — safe for prod DB development, single value for "everything on"                                                            |
+| Public clients         | PKCE-only auth code flow, no client secret, standard OAuth 2.1 approach                                                            |
+| Token prefix           | `civitai_` prefix on OAuth tokens for distinguishability                                                                           |
+| Consent UX             | All-or-nothing — user accepts all requested scopes or declines                                                                     |
+| CORS                   | OAuth token endpoint needs permissive CORS; per-client origin restrictions are future work                                         |
+| Developer docs         | Static markdown page on the site                                                                                                   |
+
+## Orchestrator Integration
+
+**Resolved**: The orchestrator checks user permissions via the `/api/v1/me` endpoint (`src/pages/api/v1/me.ts`). It doesn't do anything special with key types — it just calls this endpoint with the API key as a bearer token and uses the response to determine what the user can do.
+
+**Current response shape:**
+
+```json
+{
+  "id": 123,
+  "username": "user",
+  "tier": "member",
+  "status": "active",
+  "isMember": true,
+  "subscriptions": ["gold"]
+}
+```
+
+**What we need to add** (when the request is authenticated via API key, not session):
+
+```json
+{
+  ...existing fields,
+  "tokenScope": 33554431,      // bitmask of allowed scopes
+  "buzzLimit": {                // per-key spend limits (null if no limits)
+    "daily": 5000,
+    "weekly": null,
+    "monthly": 50000
+  }
+}
+```
+
+The `AuthedEndpoint` helper already resolves the session from either a cookie or bearer token. We need to:
+
+1. Pass the `ApiKey` record (not just the user) through to the handler when auth is via bearer token
+2. Include `tokenScope` and `buzzLimit` from the ApiKey in the response
+3. The orchestrator can then check `Flags.hasFlag(tokenScope, TokenScope.Generate)` and enforce spend limits on its side
+
+This means OAuth access tokens (which are stored as ApiKey rows) will work transparently with the orchestrator — no special handling needed.

--- a/docs/plans/spend-limits.md
+++ b/docs/plans/spend-limits.md
@@ -1,0 +1,182 @@
+# Per-Subject Buzz Spend Limits
+
+Final design as shipped on `feature/scoped-tokens`. Earlier revisions of
+this document captured the design dialogue with Koen and have been removed
+in favour of a single source of truth for what's in the codebase.
+
+## Summary
+
+API keys and OAuth tokens can spend buzz on behalf of a user. Users can cap
+that spend with a per-subject **buzz limit**. The orchestrator owns
+enforcement and rolling-window math; Civitai stores the limit, exposes it on
+`/api/v1/me`, busts the orchestrator's cache when the user edits, reads
+spend back per subject for UI display, and tells the orchestrator to delete
+its record when the user deletes a key or revokes an app.
+
+## Subjects
+
+A "subject" is the unit the orchestrator buckets spend by. Civitai sends an
+opaque `(type, id)` pair on every limit/spend operation:
+
+| `type`   | `id`                | Source                                       |
+| -------- | ------------------- | -------------------------------------------- |
+| `apiKey` | `ApiKey.id` (int)   | User-type API keys                           |
+| `oauth`  | `clientId` (string) | OAuth grants — stable across token rotations |
+
+The OAuth `clientId` is the right level for OAuth: refresh-token rotations
+issue new ApiKey rows but the consent (userId + clientId) is stable. Spend
+attaches to the consent, not the access token.
+
+## Limit shape — `BuzzBudget[]`
+
+`buzzLimit` is a JSONB array of budgets. `null` (or `[]`) means no limit.
+
+```ts
+type BuzzBudget =
+  | { type: 'absolute'; currencies?: string[]; limit: number }
+  | {
+      type: 'sliding';
+      currencies?: string[];
+      limit: number;
+      window: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month';
+      unit: number;
+    }
+  | { type: 'rollover'; currencies?: string[]; limit: number; cron: string };
+```
+
+- **absolute** — hard cap, no time component.
+- **sliding** — rolling window of `unit × window`. Civitai's UI exposes
+  this one (day/1, day/7, day/30 = the simple `day | week | month` periods).
+- **rollover** — calendar reset driven by a cron expression. Cron syntax
+  matches Hangfire Cronos (https://github.com/HangfireIO/Cronos).
+
+Helpers `simpleBuzzLimitToBudgets` / `budgetsToSimpleBuzzLimit` in
+`src/server/schema/api-key.schema.ts` round-trip the simple-UI form to the
+canonical array shape and back.
+
+## Storage
+
+| Column                         | Used for                               |
+| ------------------------------ | -------------------------------------- |
+| `ApiKey.buzzLimit JSONB`       | User-type API keys                     |
+| `OauthConsent.buzzLimit JSONB` | OAuth grants — stable across rotations |
+
+Both nullable; null = no limit. The OauthConsent column was added in
+migration `20260507165710_add_buzz_limit_to_oauth_consent`.
+
+## Auth pipeline
+
+`src/server/auth/bearer-token.ts` resolves the subject + buzzLimit at bearer
+auth time:
+
+- `apiKey.clientId == null` → `subject = { type: 'apiKey', id: apiKey.id }`,
+  limit = `apiKey.buzzLimit`
+- `apiKey.clientId != null` → `subject = { type: 'oauth', id: apiKey.clientId }`,
+  limit = consent's `buzzLimit` (looked up by `(userId, clientId)`)
+
+These thread through `req.context` → tRPC context → `/api/v1/me` response.
+
+## `/api/v1/me` shape (token-authenticated requests)
+
+```jsonc
+{
+  "id": 12345,
+  "username": "...",
+  "tier": "...",
+  "status": "active",
+  "isMember": false,
+  "subscriptions": [],
+
+  // present only when auth is via a non-Full token
+  "tokenScope": 4194303,
+  "subject":   { "type": "apiKey" | "oauth", "id": <number | string> },
+  "buzzLimit": [{ "type": "sliding", "limit": 5000, "window": "day", "unit": 1 }] // or null
+}
+```
+
+Session-authenticated requests don't get the token-specific fields.
+
+## Civitai ↔ Orchestrator contract
+
+All endpoints are RESTful under `/v1/manager/*` and use the existing system
+Civitai bearer (`ORCHESTRATOR_ACCESS_TOKEN`) for auth — the same pattern as
+flagged-consumers.
+
+| Method   | Path                                              | Purpose                                            |
+| -------- | ------------------------------------------------- | -------------------------------------------------- |
+| `GET`    | `/v1/manager/users/:userId/limits/auth/:type/:id` | Fetch spend snapshot for one subject. 404 = none.  |
+| `DELETE` | `/v1/manager/users/:userId/limits/auth/:type/:id` | Bust the orchestrator's cached limit for a subject |
+| `DELETE` | `/v1/manager/users/:userId/auth/:type/:id`        | Delete the orchestrator's record for a subject     |
+
+GET response shape:
+
+```jsonc
+{
+  "spend": <number>,
+  "buckets": [{ "ts": "<iso>", "amount": <number> }, ...]
+  // (additional fields tolerated)
+}
+```
+
+There's intentionally no batched "all subjects for user" endpoint. Koen
+stores subjects in Mongo with no deletion policy, so a list response would
+return entries Civitai has forgotten about. Civitai is the source of truth
+for which subjects exist; we fan out one GET per subject and only for
+subjects that have a limit set (filtering done in
+`apiKey.controller.getApiKeySpendHandler`).
+
+## Civitai-side mutations
+
+| Procedure                   | Effect                                                                                    |
+| --------------------------- | ----------------------------------------------------------------------------------------- |
+| `apiKey.setBuzzLimit`       | Updates `ApiKey.buzzLimit`, busts cache                                                   |
+| `oauthConsent.setBuzzLimit` | Updates `OauthConsent.buzzLimit`, busts cache                                             |
+| `apiKey.delete`             | Best-effort `DELETE …/auth/apiKey/:id` after the row is gone                              |
+| `oauthConsent.revokeApp`    | Best-effort `DELETE …/auth/oauth/:clientId` after the consent + tokens are gone           |
+| `apiKey.getSpend`           | Builds the user's subject list (filtered to those with a limit), fans out per-subject GET |
+
+Both `setBuzzLimit` mutations refuse to modify the limit on the calling
+token's own subject — a token can't raise or clear its own cap. Session
+auth and other tokens belonging to the same user can edit any limit.
+
+## UI
+
+`src/components/Account/ApiKeysCard.tsx` and
+`src/components/Account/ConnectedAppsCard.tsx` render keys and OAuth
+grants as cards. Each card shows:
+
+- Name + scope/type badge (header, with delete on the right)
+- Created date · last used (api keys only) · authorized date (oauth)
+- Inline spend bar + "spent / limit per period" link when a limit is set
+- "No limit" link when not (clickable to add)
+
+The shared `EditBuzzLimitModal` accepts a discriminated `subject` prop and
+routes to the correct mutation. The form exposes only the simple sliding
+budget today; setting an absolute or rollover budget requires hitting the
+mutation directly (e.g. via tRPC client). When the stored `buzzLimit` can't
+be expressed as a simple sliding budget, the card falls back to a "Custom
+limit" pill that opens the editor with empty form fields rather than
+showing a confused partial state.
+
+The OAuth Apps and Connected Apps surface lives behind the `oauth-apps`
+Flipt flag, mod-only by default. API keys card has a separate `apiKeys`
+flag (pre-existing).
+
+## Audit
+
+`BuzzLimit_Set` ActionType in `src/server/clickhouse/client.ts`. Both
+mutations fire `ctx.track.action(...)` on success with `subjectType`,
+`subjectId`, the new `buzzLimit`, and the calling token's `subject`. Used
+to retro answer "when did this user lower their cap" and "did they do it
+from the browser or via an agent token."
+
+## Self-modify protection summary
+
+- `apiKey.setBuzzLimit` rejects when `ctx.subject.type === 'apiKey' && ctx.subject.id === input.id`.
+- `oauthConsent.setBuzzLimit` rejects when `ctx.subject.type === 'oauth' && ctx.subject.id === input.clientId`.
+
+## Open follow-ups
+
+- Multi-budget editor in the UI (currently sliding-only)
+- Real end-to-end verification once Koen ships his side beyond
+  `orchestration-next.civitai.com`

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@next-auth/prisma-adapter": "^1.0.7",
     "@next/bundle-analyzer": "^15.0.3",
     "@next/third-parties": "^15.0.3",
+    "@node-oauth/oauth2-server": "^5.3.0",
     "@number-flow/react": "^0.5.7",
     "@okikio/sharedworker": "^1.1.0",
     "@openrouter/sdk": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@next/third-parties':
         specifier: ^15.0.3
         version: 15.4.6(next@14.2.31(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)
+      '@node-oauth/oauth2-server':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@number-flow/react':
         specifier: ^0.5.7
         version: 0.5.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2296,6 +2299,13 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@node-oauth/formats@1.0.0':
+    resolution: {integrity: sha512-DwSbLtdC8zC5B5gTJkFzJj5s9vr9SGzOgQvV9nH7tUVuMSScg0EswAczhjIapOmH3Y8AyP7C4Jv7b8+QJObWZA==}
+
+  '@node-oauth/oauth2-server@5.3.0':
+    resolution: {integrity: sha512-gPnLZesfXWleX3Mwq9hch3yY9AiekT+cl+c99BoK7Yf/DQEoxXsvuVDG/D0MrPkFbfiOdR96Z88ZYZJkvQ5lAw==}
+    engines: {node: '>=16.0.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4598,6 +4608,10 @@ packages:
     resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
 
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
@@ -7131,6 +7145,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   meilisearch@0.33.0:
     resolution: {integrity: sha512-bYPb9WyITnJfzf92e7QFK8Rc50DmshFWxypXCs3ILlpNh8pT15A7KSu9Xgnnk/K3G/4vb3wkxxtFS4sxNkWB8w==}
 
@@ -7257,9 +7275,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -9437,6 +9463,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
@@ -11938,6 +11968,14 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@node-oauth/formats@1.0.0': {}
+
+  '@node-oauth/oauth2-server@5.3.0':
+    dependencies:
+      '@node-oauth/formats': 1.0.0
+      basic-auth: 2.0.1
+      type-is: 2.0.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -14568,6 +14606,10 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.27: {}
+
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   bcp-47-match@2.0.3: {}
 
@@ -17699,6 +17741,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   meilisearch@0.33.0:
     dependencies:
       cross-fetch: 3.2.0
@@ -17986,9 +18030,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@4.0.0: {}
 
@@ -20475,6 +20525,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/prisma/migrations/20260410124247_add_token_scope_to_api_key/migration.sql
+++ b/prisma/migrations/20260410124247_add_token_scope_to_api_key/migration.sql
@@ -1,0 +1,5 @@
+-- Add tokenScope bitmask column to ApiKey (default = Full = 33554431)
+ALTER TABLE "ApiKey" ADD COLUMN "tokenScope" INTEGER NOT NULL DEFAULT 33554431;
+
+-- Add lastUsedAt tracking
+ALTER TABLE "ApiKey" ADD COLUMN "lastUsedAt" TIMESTAMP(3);

--- a/prisma/migrations/20260410140011_add_oauth_tables/migration.sql
+++ b/prisma/migrations/20260410140011_add_oauth_tables/migration.sql
@@ -1,0 +1,58 @@
+-- Add OAuth token types (idempotent — may already exist from prior migration)
+DO $$ BEGIN
+  ALTER TYPE "ApiKeyType" ADD VALUE IF NOT EXISTS 'Access';
+  ALTER TYPE "ApiKeyType" ADD VALUE IF NOT EXISTS 'Refresh';
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- OAuth Client registration
+CREATE TABLE "OauthClient" (
+    "id" TEXT NOT NULL,
+    "secret" TEXT,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "logoUrl" TEXT,
+    "redirectUris" TEXT[] NOT NULL DEFAULT '{}',
+    "grants" TEXT[] NOT NULL DEFAULT '{authorization_code,refresh_token}',
+    "allowedScopes" INTEGER NOT NULL DEFAULT 33554431,
+    "isConfidential" BOOLEAN NOT NULL DEFAULT true,
+    "userId" INTEGER NOT NULL,
+    "isVerified" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OauthClient_pkey" PRIMARY KEY ("id")
+);
+
+-- OAuth Consent records (remember user's authorization decision)
+CREATE TABLE "OauthConsent" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "scope" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OauthConsent_pkey" PRIMARY KEY ("id")
+);
+
+-- Link API keys to OAuth clients (null = user-created key)
+ALTER TABLE "ApiKey" ADD COLUMN "clientId" TEXT;
+
+-- Foreign keys
+ALTER TABLE "OauthClient" ADD CONSTRAINT "OauthClient_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "OauthConsent" ADD CONSTRAINT "OauthConsent_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "OauthConsent" ADD CONSTRAINT "OauthConsent_clientId_fkey"
+    FOREIGN KEY ("clientId") REFERENCES "OauthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_clientId_fkey"
+    FOREIGN KEY ("clientId") REFERENCES "OauthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Indexes
+CREATE UNIQUE INDEX "OauthConsent_userId_clientId_key" ON "OauthConsent"("userId", "clientId");
+CREATE INDEX "OauthClient_userId_idx" ON "OauthClient"("userId");
+CREATE INDEX "ApiKey_clientId_idx" ON "ApiKey"("clientId");

--- a/prisma/migrations/20260410152134_add_buzz_limit_to_api_key/migration.sql
+++ b/prisma/migrations/20260410152134_add_buzz_limit_to_api_key/migration.sql
@@ -1,0 +1,2 @@
+-- Per-key buzz spending limits (JSON: { daily?: number, weekly?: number, monthly?: number })
+ALTER TABLE "ApiKey" ADD COLUMN "buzzLimit" JSONB;

--- a/prisma/migrations/20260507165710_add_buzz_limit_to_oauth_consent/migration.sql
+++ b/prisma/migrations/20260507165710_add_buzz_limit_to_oauth_consent/migration.sql
@@ -1,0 +1,7 @@
+-- Per-grant buzz spend limit. The OAuth consent (userId + clientId) is the
+-- stable identifier across access-token rotations, so the limit lives here
+-- rather than on individual ApiKey rows. Civitai resolves the limit at bearer
+-- auth time: if the ApiKey carries a clientId (OAuth-issued), we fetch the
+-- limit from this column on the matching consent. User-type keys continue to
+-- use ApiKey.buzzLimit.
+ALTER TABLE "OauthConsent" ADD COLUMN "buzzLimit" JSONB;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -427,6 +427,8 @@ model User {
   saves                SavedModel[]
   imports              Import[]
   keys                 ApiKey[]
+  oauthClients         OauthClient[]
+  oauthConsents        OauthConsent[]
   links                UserLink[]
   comments             Comment[]
   commentReactions     CommentReaction[]
@@ -2115,18 +2117,61 @@ model KeyValue {
 enum ApiKeyType {
   System
   User
+  Access
+  Refresh
 }
 
 model ApiKey {
-  id        Int        @id @default(autoincrement())
-  key       String     @unique
-  name      String
-  scope     KeyScope[]
+  id         Int          @id @default(autoincrement())
+  key        String       @unique
+  name       String
+  tokenScope Int          @default(33554431) // Bitwise flags — default = Full (all scopes)
+  userId     Int
+  user       User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime     @default(now())
+  type       ApiKeyType   @default(User)
+  expiresAt  DateTime?
+  lastUsedAt DateTime?
+  clientId   String?
+  client     OauthClient? @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  buzzLimit  Json?        // { daily?: number, weekly?: number, monthly?: number }
+
+  @@index([clientId])
+}
+
+model OauthClient {
+  id             String         @id
+  secret         String?
+  name           String
+  description    String         @default("")
+  logoUrl        String?
+  redirectUris   String[]       @default([])
+  grants         String[]       @default(["authorization_code", "refresh_token"])
+  allowedScopes  Int            @default(33554431)
+  isConfidential Boolean        @default(true)
+  userId         Int
+  user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  isVerified     Boolean        @default(false)
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @default(now()) @updatedAt
+  tokens         ApiKey[]
+  consents       OauthConsent[]
+
+  @@index([userId])
+}
+
+model OauthConsent {
+  id        Int         @id @default(autoincrement())
   userId    Int
-  user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt DateTime   @default(now())
-  type      ApiKeyType @default(User)
-  expiresAt DateTime?
+  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  clientId  String
+  client    OauthClient @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  scope     Int
+  buzzLimit Json?
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @default(now()) @updatedAt
+
+  @@unique([userId, clientId])
 }
 
 model AdToken {
@@ -2136,12 +2181,6 @@ model AdToken {
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt DateTime  @default(now())
   expiresAt DateTime?
-}
-
-enum KeyScope {
-  Read
-  Write
-  Generate
 }
 
 model Comment {

--- a/src/components/Account/ApiKeyModal.tsx
+++ b/src/components/Account/ApiKeyModal.tsx
@@ -1,22 +1,69 @@
+import { useState } from 'react';
 import type { ModalProps } from '@mantine/core';
-import { Box, Button, Code, CopyButton, Group, Modal, Stack, Text } from '@mantine/core';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Code,
+  CopyButton,
+  Group,
+  Modal,
+  NumberInput,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  Text,
+} from '@mantine/core';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
 import type * as z from 'zod';
 import { Form, InputText, useForm } from '~/libs/form';
-import { addApiKeyInputSchema } from '~/server/schema/api-key.schema';
-import { KeyScope } from '~/shared/utils/prisma/enums';
+import { addApiKeyInputSchema, simpleBuzzLimitToBudgets } from '~/server/schema/api-key.schema';
+import {
+  TokenScope,
+  TokenScopePresets,
+  tokenScopePresetLabels,
+  tokenScopeGrid,
+} from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 import { LegacyActionIcon } from '../LegacyActionIcon/LegacyActionIcon';
 
 const schema = addApiKeyInputSchema;
 
+const presetOptions = (
+  Object.keys(tokenScopePresetLabels) as (keyof typeof TokenScopePresets)[]
+).map((key) => ({ value: key, label: tokenScopePresetLabels[key] }));
+
+function getPresetKey(tokenScope: number): string | null {
+  for (const [key, value] of Object.entries(TokenScopePresets)) {
+    if (tokenScope === value) return key;
+  }
+  return null;
+}
+
+const periodOptions = [
+  { value: 'day', label: 'Per 24 hours' },
+  { value: 'week', label: 'Per 7 days' },
+  { value: 'month', label: 'Per 30 days' },
+];
+
 export function ApiKeyModal({ ...props }: Props) {
+  const [tokenScope, setTokenScope] = useState<number>(TokenScope.Full);
+  const [preset, setPreset] = useState<string | null>('Full');
+  const [limitEnabled, setLimitEnabled] = useState(false);
+  const [limitAmount, setLimitAmount] = useState<number | ''>(5000);
+  const [limitPeriod, setLimitPeriod] = useState<'day' | 'week' | 'month'>('day');
+
   const form = useForm({
     schema,
     mode: 'onChange',
     shouldUnregister: false,
-    defaultValues: { name: '', scope: [KeyScope.Read, KeyScope.Write] },
+    defaultValues: {
+      name: '',
+      tokenScope: TokenScope.Full,
+    },
   });
   const queryUtils = trpc.useUtils();
 
@@ -36,13 +83,48 @@ export function ApiKeyModal({ ...props }: Props) {
       });
     },
   });
+
+  const updateTokenScope = (newScope: number) => {
+    setTokenScope(newScope);
+    setPreset(getPresetKey(newScope));
+    form.setValue('tokenScope', newScope);
+  };
+
+  const handlePresetChange = (value: string | null) => {
+    if (!value) return;
+    setPreset(value);
+    const newScope = TokenScopePresets[value as keyof typeof TokenScopePresets];
+    if (newScope != null) {
+      setTokenScope(newScope);
+      form.setValue('tokenScope', newScope);
+    }
+  };
+
+  const handleToggleFlag = (flag: number) => {
+    const newScope = Flags.toggleFlag(tokenScope, flag);
+    updateTokenScope(newScope);
+  };
+
   const handleSaveApiKey = (values: z.infer<typeof schema>) => {
-    mutate(values);
+    const buzzLimit =
+      limitEnabled && typeof limitAmount === 'number' && limitAmount > 0
+        ? simpleBuzzLimitToBudgets({ limit: limitAmount, period: limitPeriod })
+        : null;
+    mutate({
+      ...values,
+      tokenScope,
+      buzzLimit,
+    });
   };
 
   const handleClose = () => {
     form.reset();
     reset();
+    setTokenScope(TokenScope.Full);
+    setPreset('Full');
+    setLimitEnabled(false);
+    setLimitAmount(5000);
+    setLimitPeriod('day');
     props.onClose();
   };
 
@@ -52,6 +134,7 @@ export function ApiKeyModal({ ...props }: Props) {
       onClose={handleClose}
       closeOnClickOutside={!mutating}
       closeOnEscape={!mutating}
+      size="lg"
     >
       {apiKey ? (
         <Stack gap={4}>
@@ -87,6 +170,112 @@ export function ApiKeyModal({ ...props }: Props) {
               withAsterisk
               maxLength={64}
             />
+            <Select
+              label="Permission preset"
+              data={presetOptions}
+              value={preset}
+              onChange={handlePresetChange}
+              placeholder="Custom"
+              clearable={false}
+            />
+            <Box>
+              <Text size="sm" fw={500} mb={4}>
+                Permissions
+              </Text>
+              <Table withTableBorder withColumnBorders>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Resource</Table.Th>
+                    <Table.Th style={{ textAlign: 'center', width: 70 }}>Read</Table.Th>
+                    <Table.Th style={{ textAlign: 'center', width: 70 }}>Write</Table.Th>
+                    <Table.Th style={{ textAlign: 'center', width: 70 }}>Delete</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {tokenScopeGrid.map((row) => (
+                    <Table.Tr key={row.label}>
+                      <Table.Td>
+                        <Text size="sm">{row.label}</Text>
+                      </Table.Td>
+                      <Table.Td style={{ textAlign: 'center' }}>
+                        {'read' in row && row.read ? (
+                          <Checkbox
+                            checked={Flags.hasFlag(tokenScope, row.read)}
+                            onChange={() => handleToggleFlag(row.read)}
+                            styles={{ input: { cursor: 'pointer' } }}
+                          />
+                        ) : (
+                          <Text size="xs" c="dimmed">
+                            —
+                          </Text>
+                        )}
+                      </Table.Td>
+                      <Table.Td style={{ textAlign: 'center' }}>
+                        {'write' in row && row.write ? (
+                          <Checkbox
+                            checked={Flags.hasFlag(tokenScope, row.write)}
+                            onChange={() => handleToggleFlag(row.write)}
+                            styles={{ input: { cursor: 'pointer' } }}
+                          />
+                        ) : (
+                          <Text size="xs" c="dimmed">
+                            —
+                          </Text>
+                        )}
+                      </Table.Td>
+                      <Table.Td style={{ textAlign: 'center' }}>
+                        {'delete' in row && row.delete ? (
+                          <Checkbox
+                            checked={Flags.hasFlag(tokenScope, row.delete)}
+                            onChange={() => handleToggleFlag(row.delete)}
+                            styles={{ input: { cursor: 'pointer' } }}
+                          />
+                        ) : (
+                          <Text size="xs" c="dimmed">
+                            —
+                          </Text>
+                        )}
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            </Box>
+            <Box>
+              <Group justify="space-between" align="center" mb={4}>
+                <Text size="sm" fw={500}>
+                  Buzz spend limit
+                </Text>
+                <Switch
+                  size="sm"
+                  checked={limitEnabled}
+                  onChange={(e) => setLimitEnabled(e.currentTarget.checked)}
+                />
+              </Group>
+              <Text size="xs" c="dimmed" mb={limitEnabled ? 8 : 0}>
+                Caps how much buzz this key can spend in a rolling window. Enforced on the
+                orchestrator. Leave off for no limit.
+              </Text>
+              {limitEnabled && (
+                <Group grow>
+                  <NumberInput
+                    label="Limit"
+                    placeholder="Amount in buzz"
+                    min={1}
+                    value={limitAmount}
+                    onChange={(v) => setLimitAmount(typeof v === 'number' ? v : '')}
+                    thousandSeparator=","
+                  />
+                  <Select
+                    label="Window"
+                    data={periodOptions}
+                    value={limitPeriod}
+                    onChange={(v) => v && setLimitPeriod(v as 'day' | 'week' | 'month')}
+                    allowDeselect={false}
+                  />
+                </Group>
+              )}
+            </Box>
             <Group justify="space-between">
               <Button variant="default" disabled={mutating} onClick={handleClose}>
                 Cancel

--- a/src/components/Account/ApiKeysCard.tsx
+++ b/src/components/Account/ApiKeysCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { openConfirmModal } from '@mantine/modals';
 import { trpc } from '~/utils/trpc';
@@ -10,21 +11,74 @@ import {
   Button,
   Box,
   LoadingOverlay,
-  Table,
   Center,
   Paper,
+  Badge,
+  Progress,
+  UnstyledButton,
 } from '@mantine/core';
-import { IconPlus, IconTrash } from '@tabler/icons-react';
+import {
+  IconPlus,
+  IconTrash,
+  IconCoin,
+  IconCoinOff,
+  IconCalendar,
+  IconClock,
+} from '@tabler/icons-react';
 import { formatDate } from '~/utils/date-helpers';
 import { ApiKeyModal } from '~/components/Account/ApiKeyModal';
+import { EditBuzzLimitModal } from '~/components/Account/EditBuzzLimitModal';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { getScopeLabel } from '~/shared/constants/token-scope.constants';
+import { abbreviateNumber } from '~/utils/number-helpers';
+import type { BuzzLimit } from '~/server/schema/api-key.schema';
+import { budgetsToSimpleBuzzLimit } from '~/server/schema/api-key.schema';
+
+const periodLabels: Record<'day' | 'week' | 'month', string> = {
+  day: '24h',
+  week: '7d',
+  month: '30d',
+};
+
+function getScopeBadgeColor(label: string): string {
+  switch (label) {
+    case 'Full Access':
+      return 'red';
+    case 'Read Only':
+      return 'green';
+    case 'Creator':
+      return 'blue';
+    case 'AI Services':
+      return 'violet';
+    case 'Custom':
+      return 'yellow';
+    default:
+      return 'gray';
+  }
+}
 
 export function ApiKeysCard() {
   const utils = trpc.useUtils();
 
   const [opened, { toggle }] = useDisclosure(false);
+  const [editLimitFor, setEditLimitFor] = useState<{
+    id: number;
+    name: string;
+    buzzLimit: BuzzLimit | null;
+  } | null>(null);
 
   const { data: apiKeys = [], isLoading } = trpc.apiKey.getAllUserKeys.useQuery({});
+  const { data: spendEntries = [] } = trpc.apiKey.getSpend.useQuery(undefined, {
+    enabled: apiKeys.some((k) => !!k.buzzLimit),
+    staleTime: 30_000,
+  });
+
+  const spendMap = new Map<number, number>();
+  for (const entry of spendEntries) {
+    if (entry.type === 'apiKey' && typeof entry.id === 'number') {
+      spendMap.set(entry.id, entry.spend);
+    }
+  }
 
   const deleteApiKeyMutation = trpc.apiKey.delete.useMutation({
     async onSuccess() {
@@ -65,43 +119,114 @@ export function ApiKeysCard() {
         <Box mt="md" style={{ position: 'relative' }}>
           <LoadingOverlay visible={isLoading} />
           {apiKeys.length > 0 ? (
-            <Table highlightOnHover withTableBorder>
-              <Table.Thead>
-                <Table.Tr>
-                  <Table.Th>Name</Table.Th>
-                  <Table.Th>Created at</Table.Th>
-                  <Table.Th />
-                </Table.Tr>
-              </Table.Thead>
-              <Table.Tbody>
-                {apiKeys.map((apiKey, index) => (
-                  <Table.Tr key={index}>
-                    <Table.Td>
-                      <Text
-                        size="sm"
-                        lineClamp={1}
-                        title={apiKey.name}
-                        style={{ maxWidth: 180, wordBreak: 'break-all' }}
-                      >
-                        {apiKey.name}
-                      </Text>
-                    </Table.Td>
-                    <Table.Td>{formatDate(apiKey.createdAt)}</Table.Td>
-                    <Table.Td>
-                      <Group justify="flex-end">
+            <Stack gap="sm">
+              {apiKeys.map((apiKey) => {
+                const scopeLabel = getScopeLabel(apiKey.tokenScope);
+                const buzzLimit = apiKey.buzzLimit as BuzzLimit | null;
+                const hasLimit = !!buzzLimit && buzzLimit.length > 0;
+                const spend = hasLimit ? spendMap.get(apiKey.id) ?? 0 : 0;
+                const openLimitEditor = () =>
+                  setEditLimitFor({ id: apiKey.id, name: apiKey.name, buzzLimit });
+
+                const simpleLimit = budgetsToSimpleBuzzLimit(buzzLimit);
+                return (
+                  <Paper key={apiKey.id} withBorder p="md" radius="md">
+                    <Stack gap="xs">
+                      {/* Header row: name + scope inline, delete on right */}
+                      <Group justify="space-between" align="center" wrap="nowrap">
+                        <Group gap="xs" wrap="nowrap" style={{ minWidth: 0, flex: 1 }}>
+                          <Text
+                            fw={600}
+                            size="sm"
+                            lineClamp={1}
+                            title={apiKey.name}
+                            style={{ minWidth: 0 }}
+                          >
+                            {apiKey.name}
+                          </Text>
+                          <Badge size="sm" variant="light" color={getScopeBadgeColor(scopeLabel)}>
+                            {scopeLabel}
+                          </Badge>
+                        </Group>
                         <LegacyActionIcon
                           variant="subtle"
                           color="red"
                           onClick={() => handleDeleteApiKey(apiKey.id)}
+                          title="Delete API key"
                         >
-                          <IconTrash size="16" stroke={1.5} />
+                          <IconTrash size={16} stroke={1.5} />
                         </LegacyActionIcon>
                       </Group>
-                    </Table.Td>
-                  </Table.Tr>
-                ))}
-              </Table.Tbody>
-            </Table>
+
+                      {/* Meta row: created · last used · spend limit (inline) */}
+                      <Group gap="md" wrap="nowrap" align="center">
+                        <Group gap={4} wrap="nowrap">
+                          <IconCalendar size={12} color="var(--mantine-color-dimmed)" />
+                          <Text size="xs" c="dimmed">
+                            {formatDate(apiKey.createdAt)}
+                          </Text>
+                        </Group>
+                        <Group gap={4} wrap="nowrap">
+                          <IconClock size={12} color="var(--mantine-color-dimmed)" />
+                          <Text size="xs" c="dimmed">
+                            {apiKey.lastUsedAt ? formatDate(apiKey.lastUsedAt) : 'Never used'}
+                          </Text>
+                        </Group>
+                        {hasLimit && simpleLimit ? (
+                          (() => {
+                            const pct = Math.min(100, (spend / simpleLimit.limit) * 100);
+                            return (
+                              <UnstyledButton
+                                onClick={openLimitEditor}
+                                title="Edit spend limit"
+                                style={{ flex: 1, minWidth: 0 }}
+                              >
+                                <Group gap={4} wrap="nowrap">
+                                  <IconCoin size={12} color="var(--mantine-color-dimmed)" />
+                                  <Progress
+                                    value={pct}
+                                    size="sm"
+                                    color={pct > 90 ? 'red' : pct > 60 ? 'yellow' : 'blue'}
+                                    style={{ flex: 1, minWidth: 40 }}
+                                  />
+                                  <Text
+                                    size="xs"
+                                    c={pct > 90 ? 'red' : 'dimmed'}
+                                    style={{ whiteSpace: 'nowrap', textDecoration: 'underline' }}
+                                  >
+                                    {abbreviateNumber(spend)} /{' '}
+                                    {abbreviateNumber(simpleLimit.limit)} per{' '}
+                                    {periodLabels[simpleLimit.period]}
+                                  </Text>
+                                </Group>
+                              </UnstyledButton>
+                            );
+                          })()
+                        ) : hasLimit ? (
+                          <UnstyledButton onClick={openLimitEditor} title="Edit spend limit">
+                            <Group gap={4} wrap="nowrap">
+                              <IconCoin size={12} color="var(--mantine-color-dimmed)" />
+                              <Text size="xs" c="dimmed" style={{ textDecoration: 'underline' }}>
+                                Custom limit
+                              </Text>
+                            </Group>
+                          </UnstyledButton>
+                        ) : (
+                          <UnstyledButton onClick={openLimitEditor} title="Set a spend limit">
+                            <Group gap={4} wrap="nowrap">
+                              <IconCoinOff size={12} color="var(--mantine-color-dimmed)" />
+                              <Text size="xs" c="dimmed" style={{ textDecoration: 'underline' }}>
+                                No limit
+                              </Text>
+                            </Group>
+                          </UnstyledButton>
+                        )}
+                      </Group>
+                    </Stack>
+                  </Paper>
+                );
+              })}
+            </Stack>
           ) : (
             <Paper radius="md" mt="lg" p="lg" style={{ position: 'relative' }} withBorder>
               <Center>
@@ -117,6 +242,15 @@ export function ApiKeysCard() {
         </Box>
       </Card>
       <ApiKeyModal title="Create API Key" opened={opened} onClose={toggle} />
+      {editLimitFor && (
+        <EditBuzzLimitModal
+          opened={!!editLimitFor}
+          onClose={() => setEditLimitFor(null)}
+          subject={{ type: 'apiKey', id: editLimitFor.id }}
+          name={editLimitFor.name}
+          initialLimit={editLimitFor.buzzLimit}
+        />
+      )}
     </>
   );
 }

--- a/src/components/Account/ConnectedAppsCard.tsx
+++ b/src/components/Account/ConnectedAppsCard.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { openConfirmModal } from '@mantine/modals';
+import { trpc } from '~/utils/trpc';
+import {
+  Text,
+  Card,
+  Stack,
+  Group,
+  Title,
+  Box,
+  LoadingOverlay,
+  Center,
+  Paper,
+  Badge,
+  Progress,
+  UnstyledButton,
+} from '@mantine/core';
+import {
+  IconPlugConnected,
+  IconTrash,
+  IconShieldCheck,
+  IconCalendar,
+  IconCoin,
+  IconCoinOff,
+} from '@tabler/icons-react';
+import { formatDate } from '~/utils/date-helpers';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { getScopeLabel } from '~/shared/constants/token-scope.constants';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { abbreviateNumber } from '~/utils/number-helpers';
+import { EditBuzzLimitModal } from '~/components/Account/EditBuzzLimitModal';
+import type { BuzzLimit } from '~/server/schema/api-key.schema';
+import { budgetsToSimpleBuzzLimit } from '~/server/schema/api-key.schema';
+
+const periodLabels: Record<'day' | 'week' | 'month', string> = {
+  day: '24h',
+  week: '7d',
+  month: '30d',
+};
+
+export function ConnectedAppsCard() {
+  const utils = trpc.useUtils();
+  const [editLimitFor, setEditLimitFor] = useState<{
+    clientId: string;
+    name: string;
+    buzzLimit: BuzzLimit | null;
+  } | null>(null);
+  const { data: apps = [], isLoading } = trpc.oauthConsent.getConnectedApps.useQuery();
+  const { data: spendEntries = [] } = trpc.apiKey.getSpend.useQuery(undefined, {
+    enabled: apps.some((a) => !!a.buzzLimit),
+    staleTime: 30_000,
+  });
+  const spendMap = new Map<string, number>();
+  for (const entry of spendEntries) {
+    if (entry.type === 'oauth' && typeof entry.id === 'string') {
+      spendMap.set(entry.id, entry.spend);
+    }
+  }
+  const revokeMutation = trpc.oauthConsent.revokeApp.useMutation({
+    onSuccess: () => {
+      utils.oauthConsent.getConnectedApps.invalidate();
+      showSuccessNotification({ message: 'App access revoked' });
+    },
+    onError: (error) => {
+      showErrorNotification({ error: new Error(error.message) });
+    },
+  });
+
+  const handleRevoke = (clientId: string, appName: string) => {
+    openConfirmModal({
+      title: 'Revoke App Access',
+      children: (
+        <Text size="sm">
+          Are you sure you want to revoke access for <strong>{appName}</strong>? This will
+          disconnect the app and delete all its tokens. You&apos;ll need to re-authorize if you want
+          to use it again.
+        </Text>
+      ),
+      labels: { confirm: 'Revoke Access', cancel: 'Cancel' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => revokeMutation.mutate({ clientId }),
+    });
+  };
+
+  if (apps.length === 0 && !isLoading) return null;
+
+  return (
+    <Card withBorder>
+      <Stack>
+        <Group justify="space-between">
+          <Group gap="xs">
+            <IconPlugConnected size={20} />
+            <Title order={4}>Connected Apps</Title>
+          </Group>
+        </Group>
+
+        <Box pos="relative">
+          <LoadingOverlay visible={isLoading} />
+          {apps.length === 0 ? (
+            <Center p="xl">
+              <Text c="dimmed">No connected apps</Text>
+            </Center>
+          ) : (
+            <Stack gap="sm">
+              {apps.map((app) => {
+                const buzzLimit = app.buzzLimit as BuzzLimit | null;
+                const hasLimit = !!buzzLimit && buzzLimit.length > 0;
+                const simpleLimit = budgetsToSimpleBuzzLimit(buzzLimit);
+                const spend = hasLimit ? spendMap.get(app.clientId) ?? 0 : 0;
+                const openLimitEditor = () =>
+                  setEditLimitFor({ clientId: app.clientId, name: app.name, buzzLimit });
+
+                return (
+                  <Paper key={app.clientId} withBorder p="md" radius="md">
+                    <Stack gap="xs">
+                      {/* Header: name + scope badge inline, revoke on right */}
+                      <Group justify="space-between" align="center" wrap="nowrap">
+                        <Group gap="xs" wrap="nowrap" style={{ minWidth: 0, flex: 1 }}>
+                          <Text
+                            fw={600}
+                            size="sm"
+                            lineClamp={1}
+                            title={app.name}
+                            style={{ minWidth: 0 }}
+                          >
+                            {app.name}
+                          </Text>
+                          {app.isVerified && (
+                            <IconShieldCheck size={14} color="var(--mantine-color-green-6)" />
+                          )}
+                          <Badge size="sm" variant="light">
+                            {getScopeLabel(app.scope)}
+                          </Badge>
+                        </Group>
+                        <LegacyActionIcon
+                          color="red"
+                          variant="subtle"
+                          onClick={() => handleRevoke(app.clientId, app.name)}
+                          loading={revokeMutation.isPending}
+                          title="Revoke access"
+                        >
+                          <IconTrash size={16} />
+                        </LegacyActionIcon>
+                      </Group>
+
+                      {/* Meta line: authorized date · spend limit (inline) */}
+                      <Group gap="md" wrap="nowrap" align="center">
+                        <Group gap={4} wrap="nowrap">
+                          <IconCalendar size={12} color="var(--mantine-color-dimmed)" />
+                          <Text size="xs" c="dimmed">
+                            {formatDate(app.authorizedAt)}
+                          </Text>
+                        </Group>
+                        {hasLimit && simpleLimit ? (
+                          (() => {
+                            const pct = Math.min(100, (spend / simpleLimit.limit) * 100);
+                            return (
+                              <UnstyledButton
+                                onClick={openLimitEditor}
+                                title="Edit spend limit"
+                                style={{ flex: 1, minWidth: 0 }}
+                              >
+                                <Group gap={4} wrap="nowrap">
+                                  <IconCoin size={12} color="var(--mantine-color-dimmed)" />
+                                  <Progress
+                                    value={pct}
+                                    size="sm"
+                                    color={pct > 90 ? 'red' : pct > 60 ? 'yellow' : 'blue'}
+                                    style={{ flex: 1, minWidth: 40 }}
+                                  />
+                                  <Text
+                                    size="xs"
+                                    c={pct > 90 ? 'red' : 'dimmed'}
+                                    style={{ whiteSpace: 'nowrap', textDecoration: 'underline' }}
+                                  >
+                                    {abbreviateNumber(spend)} /{' '}
+                                    {abbreviateNumber(simpleLimit.limit)} per{' '}
+                                    {periodLabels[simpleLimit.period]}
+                                  </Text>
+                                </Group>
+                              </UnstyledButton>
+                            );
+                          })()
+                        ) : hasLimit ? (
+                          <UnstyledButton onClick={openLimitEditor} title="Edit spend limit">
+                            <Group gap={4} wrap="nowrap">
+                              <IconCoin size={12} color="var(--mantine-color-dimmed)" />
+                              <Text size="xs" c="dimmed" style={{ textDecoration: 'underline' }}>
+                                Custom limit
+                              </Text>
+                            </Group>
+                          </UnstyledButton>
+                        ) : (
+                          <UnstyledButton onClick={openLimitEditor} title="Set a spend limit">
+                            <Group gap={4} wrap="nowrap">
+                              <IconCoinOff size={12} color="var(--mantine-color-dimmed)" />
+                              <Text size="xs" c="dimmed" style={{ textDecoration: 'underline' }}>
+                                No limit
+                              </Text>
+                            </Group>
+                          </UnstyledButton>
+                        )}
+                      </Group>
+
+                      {app.description && (
+                        <Text size="xs" c="dimmed" lineClamp={2}>
+                          {app.description}
+                        </Text>
+                      )}
+                    </Stack>
+                  </Paper>
+                );
+              })}
+            </Stack>
+          )}
+        </Box>
+      </Stack>
+      {editLimitFor && (
+        <EditBuzzLimitModal
+          opened={!!editLimitFor}
+          onClose={() => setEditLimitFor(null)}
+          subject={{ type: 'oauth', clientId: editLimitFor.clientId }}
+          name={editLimitFor.name}
+          initialLimit={editLimitFor.buzzLimit}
+        />
+      )}
+    </Card>
+  );
+}

--- a/src/components/Account/EditBuzzLimitModal.tsx
+++ b/src/components/Account/EditBuzzLimitModal.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { Button, Group, Modal, NumberInput, Select, Stack, Switch, Text } from '@mantine/core';
+import type { BuzzLimit, SimpleBuzzLimit } from '~/server/schema/api-key.schema';
+import { budgetsToSimpleBuzzLimit, simpleBuzzLimitToBudgets } from '~/server/schema/api-key.schema';
+import { trpc } from '~/utils/trpc';
+import { showErrorNotification } from '~/utils/notifications';
+
+const periodOptions = [
+  { value: 'day', label: 'Per 24 hours' },
+  { value: 'week', label: 'Per 7 days' },
+  { value: 'month', label: 'Per 30 days' },
+];
+
+type Subject = { type: 'apiKey'; id: number } | { type: 'oauth'; clientId: string };
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+  subject: Subject;
+  name: string;
+  initialLimit: BuzzLimit | null;
+};
+
+/**
+ * Generic spend-limit editor for both User-type API keys and OAuth-issued
+ * grants. The simple UI exposes a single sliding budget (limit + period); we
+ * map to the canonical `BuzzLimit` (BuzzBudget[]) on save and back on load.
+ * If the stored buzzLimit can't be expressed as a simple sliding budget (for
+ * example a power user set up multiple budgets via the API), the modal
+ * defaults the form fields to "no limit" and a warning could be added later.
+ */
+export function EditBuzzLimitModal({ opened, onClose, subject, name, initialLimit }: Props) {
+  const utils = trpc.useUtils();
+  const initialSimple: SimpleBuzzLimit | null = budgetsToSimpleBuzzLimit(initialLimit);
+  const [enabled, setEnabled] = useState(!!initialSimple);
+  const [amount, setAmount] = useState<number | ''>(initialSimple?.limit ?? 5000);
+  const [period, setPeriod] = useState<'day' | 'week' | 'month'>(initialSimple?.period ?? 'day');
+
+  const apiKeyMutation = trpc.apiKey.setBuzzLimit.useMutation({
+    onSuccess() {
+      utils.apiKey.getAllUserKeys.invalidate();
+      utils.apiKey.getSpend.invalidate();
+      onClose();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to update limit',
+        error: new Error(error.message),
+      });
+    },
+  });
+
+  const consentMutation = trpc.oauthConsent.setBuzzLimit.useMutation({
+    onSuccess() {
+      utils.oauthConsent.getConnectedApps.invalidate();
+      utils.apiKey.getSpend.invalidate();
+      onClose();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to update limit',
+        error: new Error(error.message),
+      });
+    },
+  });
+
+  const isLoading = apiKeyMutation.isLoading || consentMutation.isLoading;
+
+  const handleSave = () => {
+    const simple: SimpleBuzzLimit | null =
+      enabled && typeof amount === 'number' && amount > 0 ? { limit: amount, period } : null;
+    const buzzLimit = simpleBuzzLimitToBudgets(simple);
+
+    if (subject.type === 'apiKey') {
+      apiKeyMutation.mutate({ id: subject.id, buzzLimit });
+    } else {
+      consentMutation.mutate({ clientId: subject.clientId, buzzLimit });
+    }
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={`Spend limit — ${name}`}
+      size="md"
+      closeOnClickOutside={!isLoading}
+      closeOnEscape={!isLoading}
+    >
+      <Stack>
+        <Group justify="space-between" align="center">
+          <Text size="sm" fw={500}>
+            Limit enabled
+          </Text>
+          <Switch
+            size="sm"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.currentTarget.checked)}
+          />
+        </Group>
+        <Text size="xs" c="dimmed">
+          Caps how much buzz this {subject.type === 'apiKey' ? 'key' : 'app'} can spend in a rolling
+          window. Enforced on the orchestrator. Saving here invalidates the orchestrator&apos;s
+          cached limit so the new value takes effect on the next request.
+        </Text>
+        {enabled && (
+          <Group grow>
+            <NumberInput
+              label="Limit"
+              placeholder="Amount in buzz"
+              min={1}
+              value={amount}
+              onChange={(v) => setAmount(typeof v === 'number' ? v : '')}
+              thousandSeparator=","
+            />
+            <Select
+              label="Window"
+              data={periodOptions}
+              value={period}
+              onChange={(v) => v && setPeriod(v as 'day' | 'week' | 'month')}
+              allowDeselect={false}
+            />
+          </Group>
+        )}
+        <Group justify="space-between">
+          <Button variant="default" onClick={onClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} loading={isLoading}>
+            Save
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/Account/OAuthAppsCard.tsx
+++ b/src/components/Account/OAuthAppsCard.tsx
@@ -1,0 +1,773 @@
+import { useState } from 'react';
+import { useDisclosure } from '@mantine/hooks';
+import { openConfirmModal } from '@mantine/modals';
+import {
+  Text,
+  Card,
+  Stack,
+  Group,
+  Title,
+  Button,
+  Box,
+  LoadingOverlay,
+  Table,
+  Center,
+  Paper,
+  Badge,
+  Modal,
+  TextInput,
+  Textarea,
+  Radio,
+  Select,
+  Checkbox,
+  Code,
+  CopyButton,
+} from '@mantine/core';
+import {
+  IconPlus,
+  IconTrash,
+  IconEdit,
+  IconRefresh,
+  IconCheck,
+  IconClipboard,
+  IconCalendar,
+  IconKey,
+  IconHash,
+  IconCopy,
+} from '@tabler/icons-react';
+import { formatDate } from '~/utils/date-helpers';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import {
+  TokenScope,
+  TokenScopePresets,
+  tokenScopePresetLabels,
+  tokenScopeGrid,
+} from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
+
+const presetOptions = (
+  Object.keys(tokenScopePresetLabels) as (keyof typeof TokenScopePresets)[]
+).map((key) => ({ value: key, label: tokenScopePresetLabels[key] }));
+
+function getPresetKey(tokenScope: number): string | null {
+  for (const [key, value] of Object.entries(TokenScopePresets)) {
+    if (tokenScope === value) return key;
+  }
+  return null;
+}
+
+function ScopeSelector({
+  tokenScope,
+  onChange,
+}: {
+  tokenScope: number;
+  onChange: (scope: number) => void;
+}) {
+  const preset = getPresetKey(tokenScope);
+
+  const handlePresetChange = (value: string | null) => {
+    if (!value) return;
+    const newScope = TokenScopePresets[value as keyof typeof TokenScopePresets];
+    if (newScope != null) onChange(newScope);
+  };
+
+  const handleToggleFlag = (flag: number) => {
+    onChange(Flags.toggleFlag(tokenScope, flag));
+  };
+
+  return (
+    <>
+      <Select
+        label="Permission preset"
+        data={presetOptions}
+        value={preset}
+        onChange={handlePresetChange}
+        placeholder="Custom"
+        clearable={false}
+      />
+      <Box>
+        <Text size="sm" fw={500} mb={4}>
+          Permissions
+        </Text>
+        <Table withTableBorder withColumnBorders>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Resource</Table.Th>
+              <Table.Th style={{ textAlign: 'center', width: 70 }}>Read</Table.Th>
+              <Table.Th style={{ textAlign: 'center', width: 70 }}>Write</Table.Th>
+              <Table.Th style={{ textAlign: 'center', width: 70 }}>Delete</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {tokenScopeGrid.map((row) => (
+              <Table.Tr key={row.label}>
+                <Table.Td>
+                  <Text size="sm">{row.label}</Text>
+                </Table.Td>
+                <Table.Td style={{ textAlign: 'center' }}>
+                  {'read' in row && row.read ? (
+                    <Checkbox
+                      checked={Flags.hasFlag(tokenScope, row.read)}
+                      onChange={() => handleToggleFlag(row.read)}
+                      styles={{ input: { cursor: 'pointer' } }}
+                    />
+                  ) : (
+                    <Text size="xs" c="dimmed">
+                      —
+                    </Text>
+                  )}
+                </Table.Td>
+                <Table.Td style={{ textAlign: 'center' }}>
+                  {'write' in row && row.write ? (
+                    <Checkbox
+                      checked={Flags.hasFlag(tokenScope, row.write)}
+                      onChange={() => handleToggleFlag(row.write)}
+                      styles={{ input: { cursor: 'pointer' } }}
+                    />
+                  ) : (
+                    <Text size="xs" c="dimmed">
+                      —
+                    </Text>
+                  )}
+                </Table.Td>
+                <Table.Td style={{ textAlign: 'center' }}>
+                  {'delete' in row && row.delete ? (
+                    <Checkbox
+                      checked={Flags.hasFlag(tokenScope, row.delete)}
+                      onChange={() => handleToggleFlag(row.delete)}
+                      styles={{ input: { cursor: 'pointer' } }}
+                    />
+                  ) : (
+                    <Text size="xs" c="dimmed">
+                      —
+                    </Text>
+                  )}
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      </Box>
+    </>
+  );
+}
+
+function SecretDisplay({
+  clientId,
+  clientSecret,
+  onClose,
+}: {
+  clientId: string;
+  clientSecret: string;
+  onClose: () => void;
+}) {
+  return (
+    <Stack>
+      <Text fw={500}>Application registered successfully</Text>
+      <Box>
+        <Text size="sm" fw={500} mb={4}>
+          Client ID
+        </Text>
+        <CopyButton value={clientId}>
+          {({ copied, copy }) => (
+            <Box pos="relative" onClick={copy} style={{ cursor: 'pointer' }}>
+              <Code block color={copied ? 'green' : undefined}>
+                {copied ? 'Copied' : clientId}
+              </Code>
+              <LegacyActionIcon
+                className="absolute right-2 top-1/2 -translate-y-1/2"
+                variant="transparent"
+                color="gray"
+              >
+                {copied ? <IconCheck /> : <IconClipboard />}
+              </LegacyActionIcon>
+            </Box>
+          )}
+        </CopyButton>
+      </Box>
+      <Box>
+        <Text size="sm" fw={500} mb={4}>
+          Client Secret
+        </Text>
+        <CopyButton value={clientSecret}>
+          {({ copied, copy }) => (
+            <Box pos="relative" onClick={copy} style={{ cursor: 'pointer' }}>
+              <Code block color={copied ? 'green' : undefined}>
+                {copied ? 'Copied' : clientSecret}
+              </Code>
+              <LegacyActionIcon
+                className="absolute right-2 top-1/2 -translate-y-1/2"
+                variant="transparent"
+                color="gray"
+              >
+                {copied ? <IconCheck /> : <IconClipboard />}
+              </LegacyActionIcon>
+            </Box>
+          )}
+        </CopyButton>
+      </Box>
+      <Text size="xs" fw={500} c="red.5">
+        Save the client secret now — you will not be able to see it again.
+      </Text>
+      <Group justify="flex-end">
+        <Button onClick={onClose}>Done</Button>
+      </Group>
+    </Stack>
+  );
+}
+
+function RegisterAppModal({ opened, onClose }: { opened: boolean; onClose: () => void }) {
+  const utils = trpc.useUtils();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [redirectUrisText, setRedirectUrisText] = useState('');
+  const [isConfidential, setIsConfidential] = useState(true);
+  const [tokenScope, setTokenScope] = useState(TokenScope.Full);
+  const [result, setResult] = useState<{ clientId: string; clientSecret: string } | null>(null);
+  const [uriError, setUriError] = useState<string | null>(null);
+
+  const createMutation = trpc.oauthClient.create.useMutation({
+    onSuccess(data) {
+      utils.oauthClient.getAll.invalidate();
+      setResult({
+        clientId: data.clientId,
+        clientSecret: data.clientSecret ?? '',
+      });
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to register application',
+        error: new Error(error.message),
+      });
+    },
+  });
+
+  const resetForm = () => {
+    setName('');
+    setDescription('');
+    setRedirectUrisText('');
+    setIsConfidential(true);
+    setTokenScope(TokenScope.Full);
+    setResult(null);
+    setUriError(null);
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
+
+  const parseRedirectUris = (): string[] | null => {
+    const uris = redirectUrisText
+      .split('\n')
+      .map((u) => u.trim())
+      .filter(Boolean);
+    if (uris.length === 0) {
+      setUriError('At least one redirect URI is required');
+      return null;
+    }
+    for (const uri of uris) {
+      try {
+        new URL(uri);
+      } catch {
+        setUriError(`Invalid URL: ${uri}`);
+        return null;
+      }
+    }
+    setUriError(null);
+    return uris;
+  };
+
+  const handleSubmit = () => {
+    const uris = parseRedirectUris();
+    if (!uris) return;
+    if (!name.trim()) return;
+
+    createMutation.mutate({
+      name: name.trim(),
+      description: description.trim(),
+      redirectUris: uris,
+      isConfidential,
+      allowedScopes: tokenScope,
+    });
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      title="Register OAuth Application"
+      size="lg"
+      closeOnClickOutside={!createMutation.isLoading}
+      closeOnEscape={!createMutation.isLoading}
+    >
+      {result ? (
+        <SecretDisplay
+          clientId={result.clientId}
+          clientSecret={result.clientSecret}
+          onClose={handleClose}
+        />
+      ) : (
+        <Stack>
+          <TextInput
+            label="App name"
+            placeholder="My Application"
+            required
+            maxLength={128}
+            value={name}
+            onChange={(e) => setName(e.currentTarget.value)}
+          />
+          <Textarea
+            label="Description"
+            placeholder="A brief description of your application"
+            maxLength={500}
+            value={description}
+            onChange={(e) => setDescription(e.currentTarget.value)}
+          />
+          <Textarea
+            label="Redirect URIs"
+            description="One URI per line"
+            placeholder={'https://example.com/callback\nhttps://example.com/auth/callback'}
+            required
+            minRows={3}
+            value={redirectUrisText}
+            onChange={(e) => {
+              setRedirectUrisText(e.currentTarget.value);
+              setUriError(null);
+            }}
+            error={uriError}
+          />
+          <Radio.Group
+            label="Client type"
+            value={isConfidential ? 'confidential' : 'public'}
+            onChange={(val) => setIsConfidential(val === 'confidential')}
+          >
+            <Stack gap="xs" mt="xs">
+              <Radio value="confidential" label="Confidential (server-side app)" />
+              <Radio value="public" label="Public (SPA / mobile)" />
+            </Stack>
+          </Radio.Group>
+          <ScopeSelector tokenScope={tokenScope} onChange={setTokenScope} />
+          <Group justify="space-between">
+            <Button variant="default" onClick={handleClose} disabled={createMutation.isLoading}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              loading={createMutation.isLoading}
+              disabled={!name.trim()}
+            >
+              Register App
+            </Button>
+          </Group>
+        </Stack>
+      )}
+    </Modal>
+  );
+}
+
+function EditAppModal({
+  opened,
+  onClose,
+  client,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  client: {
+    id: string;
+    name: string;
+    description: string | null;
+    redirectUris: string[];
+    allowedScopes: number;
+  };
+}) {
+  const utils = trpc.useUtils();
+  const [name, setName] = useState(client.name);
+  const [description, setDescription] = useState(client.description ?? '');
+  const [redirectUrisText, setRedirectUrisText] = useState(client.redirectUris.join('\n'));
+  const [tokenScope, setTokenScope] = useState(client.allowedScopes);
+  const [uriError, setUriError] = useState<string | null>(null);
+
+  const updateMutation = trpc.oauthClient.update.useMutation({
+    onSuccess() {
+      utils.oauthClient.getAll.invalidate();
+      onClose();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to update application',
+        error: new Error(error.message),
+      });
+    },
+  });
+
+  const parseRedirectUris = (): string[] | null => {
+    const uris = redirectUrisText
+      .split('\n')
+      .map((u) => u.trim())
+      .filter(Boolean);
+    if (uris.length === 0) {
+      setUriError('At least one redirect URI is required');
+      return null;
+    }
+    for (const uri of uris) {
+      try {
+        new URL(uri);
+      } catch {
+        setUriError(`Invalid URL: ${uri}`);
+        return null;
+      }
+    }
+    setUriError(null);
+    return uris;
+  };
+
+  const handleSubmit = () => {
+    const uris = parseRedirectUris();
+    if (!uris) return;
+    if (!name.trim()) return;
+
+    updateMutation.mutate({
+      id: client.id,
+      name: name.trim(),
+      description: description.trim(),
+      redirectUris: uris,
+      allowedScopes: tokenScope,
+    });
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Edit OAuth Application"
+      size="lg"
+      closeOnClickOutside={!updateMutation.isLoading}
+      closeOnEscape={!updateMutation.isLoading}
+    >
+      <Stack>
+        <TextInput
+          label="App name"
+          placeholder="My Application"
+          required
+          maxLength={128}
+          value={name}
+          onChange={(e) => setName(e.currentTarget.value)}
+        />
+        <Textarea
+          label="Description"
+          placeholder="A brief description of your application"
+          maxLength={500}
+          value={description}
+          onChange={(e) => setDescription(e.currentTarget.value)}
+        />
+        <Textarea
+          label="Redirect URIs"
+          description="One URI per line"
+          placeholder={'https://example.com/callback'}
+          required
+          minRows={3}
+          value={redirectUrisText}
+          onChange={(e) => {
+            setRedirectUrisText(e.currentTarget.value);
+            setUriError(null);
+          }}
+          error={uriError}
+        />
+        <ScopeSelector tokenScope={tokenScope} onChange={setTokenScope} />
+        <Group justify="space-between">
+          <Button variant="default" onClick={onClose} disabled={updateMutation.isLoading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} loading={updateMutation.isLoading} disabled={!name.trim()}>
+            Save Changes
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+export function OAuthAppsCard() {
+  const utils = trpc.useUtils();
+  const [registerOpened, { open: openRegister, close: closeRegister }] = useDisclosure(false);
+  const [editClient, setEditClient] = useState<{
+    id: string;
+    name: string;
+    description: string | null;
+    redirectUris: string[];
+    allowedScopes: number;
+  } | null>(null);
+  const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
+
+  const { data: clients = [], isLoading } = trpc.oauthClient.getAll.useQuery();
+
+  const deleteMutation = trpc.oauthClient.delete.useMutation({
+    onSuccess() {
+      utils.oauthClient.getAll.invalidate();
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to delete application',
+        error: new Error(error.message),
+      });
+    },
+  });
+
+  const rotateMutation = trpc.oauthClient.rotateSecret.useMutation({
+    onSuccess(data) {
+      setRotatedSecret(data.clientSecret);
+    },
+    onError(error) {
+      showErrorNotification({
+        title: 'Failed to rotate secret',
+        error: new Error(error.message),
+      });
+    },
+  });
+
+  const handleDelete = (id: string, name: string) => {
+    openConfirmModal({
+      title: 'Delete OAuth Application',
+      children: (
+        <Stack gap="xs">
+          <Text size="sm">
+            Are you sure you want to delete <strong>{name}</strong>?
+          </Text>
+          <Text size="sm" c="red">
+            This will revoke all tokens and disconnect all users.
+          </Text>
+        </Stack>
+      ),
+      centered: true,
+      labels: { confirm: 'Delete Application', cancel: 'Cancel' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => deleteMutation.mutate({ id }),
+    });
+  };
+
+  const handleRotateSecret = (id: string, name: string) => {
+    openConfirmModal({
+      title: 'Rotate Client Secret',
+      children: (
+        <Stack gap="xs">
+          <Text size="sm">
+            Generate a new client secret for <strong>{name}</strong>?
+          </Text>
+          <Text size="sm" c="red">
+            The old secret will be immediately invalidated. Any integrations using it will stop
+            working.
+          </Text>
+        </Stack>
+      ),
+      centered: true,
+      labels: { confirm: 'Rotate Secret', cancel: 'Cancel' },
+      confirmProps: { color: 'orange' },
+      onConfirm: () => rotateMutation.mutate({ id }),
+    });
+  };
+
+  return (
+    <>
+      <Card withBorder>
+        <Stack gap={0}>
+          <Group align="start" justify="space-between">
+            <Title order={2}>OAuth Applications</Title>
+            <Button
+              size="compact-sm"
+              leftSection={<IconPlus size={14} stroke={1.5} />}
+              onClick={openRegister}
+            >
+              Register App
+            </Button>
+          </Group>
+          <Text c="dimmed" size="sm">
+            Register OAuth applications to allow third-party integrations to access the Civitai API
+            on behalf of users.
+          </Text>
+        </Stack>
+        <Box mt="md" style={{ position: 'relative' }}>
+          <LoadingOverlay visible={isLoading} />
+          {clients.length > 0 ? (
+            <Stack gap="sm">
+              {clients.map((client) => (
+                <Paper key={client.id} withBorder p="md" radius="md">
+                  <Stack gap="xs">
+                    {/* Header line: name + type badges + actions on right (same flex container) */}
+                    <Group justify="space-between" align="center" wrap="nowrap">
+                      <Group gap="xs" wrap="nowrap" style={{ minWidth: 0, flex: 1 }}>
+                        <Text
+                          fw={600}
+                          size="sm"
+                          lineClamp={1}
+                          title={client.name}
+                          style={{ minWidth: 0 }}
+                        >
+                          {client.name}
+                        </Text>
+                        <Badge
+                          size="sm"
+                          variant="light"
+                          color={client.isConfidential ? 'blue' : 'gray'}
+                        >
+                          {client.isConfidential ? 'Confidential' : 'Public'}
+                        </Badge>
+                        {client.isVerified && (
+                          <Badge size="sm" variant="light" color="green">
+                            Verified
+                          </Badge>
+                        )}
+                      </Group>
+                      <Group gap="xs" wrap="nowrap">
+                        <LegacyActionIcon
+                          variant="subtle"
+                          color="blue"
+                          onClick={() =>
+                            setEditClient({
+                              id: client.id,
+                              name: client.name,
+                              description: client.description,
+                              redirectUris: client.redirectUris,
+                              allowedScopes: client.allowedScopes,
+                            })
+                          }
+                          title="Edit"
+                        >
+                          <IconEdit size={16} stroke={1.5} />
+                        </LegacyActionIcon>
+                        {client.isConfidential && (
+                          <LegacyActionIcon
+                            variant="subtle"
+                            color="orange"
+                            onClick={() => handleRotateSecret(client.id, client.name)}
+                            title="Rotate secret"
+                          >
+                            <IconRefresh size={16} stroke={1.5} />
+                          </LegacyActionIcon>
+                        )}
+                        <LegacyActionIcon
+                          variant="subtle"
+                          color="red"
+                          onClick={() => handleDelete(client.id, client.name)}
+                          title="Delete"
+                        >
+                          <IconTrash size={16} stroke={1.5} />
+                        </LegacyActionIcon>
+                      </Group>
+                    </Group>
+
+                    {/* Meta line: date · token count · client ID (copyable) */}
+                    <Group gap="md" wrap="wrap" align="center">
+                      <Group gap={4} wrap="nowrap">
+                        <IconCalendar size={12} color="var(--mantine-color-dimmed)" />
+                        <Text size="xs" c="dimmed">
+                          {formatDate(client.createdAt)}
+                        </Text>
+                      </Group>
+                      <Group gap={4} wrap="nowrap">
+                        <IconKey size={12} color="var(--mantine-color-dimmed)" />
+                        <Text size="xs" c="dimmed">
+                          {client._count.tokens} {client._count.tokens === 1 ? 'token' : 'tokens'}
+                        </Text>
+                      </Group>
+                      <Group gap={4} wrap="nowrap" style={{ minWidth: 0, flex: 1 }}>
+                        <IconHash size={12} color="var(--mantine-color-dimmed)" />
+                        <Text
+                          size="xs"
+                          c="dimmed"
+                          ff="monospace"
+                          lineClamp={1}
+                          style={{ minWidth: 0 }}
+                          title={client.id}
+                        >
+                          {client.id}
+                        </Text>
+                        <CopyButton value={client.id}>
+                          {({ copied, copy }) => (
+                            <LegacyActionIcon
+                              size="xs"
+                              variant="subtle"
+                              color={copied ? 'green' : 'gray'}
+                              onClick={copy}
+                              title={copied ? 'Copied!' : 'Copy client ID'}
+                            >
+                              {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                            </LegacyActionIcon>
+                          )}
+                        </CopyButton>
+                      </Group>
+                    </Group>
+
+                    {client.description ? (
+                      <Text size="xs" c="dimmed" lineClamp={2}>
+                        {client.description}
+                      </Text>
+                    ) : null}
+                  </Stack>
+                </Paper>
+              ))}
+            </Stack>
+          ) : (
+            <Paper radius="md" mt="lg" p="lg" style={{ position: 'relative' }} withBorder>
+              <Center>
+                <Stack gap={2}>
+                  <Text fw="bold">No OAuth applications registered yet</Text>
+                  <Text size="sm" c="dimmed">
+                    Register your first OAuth application to enable third-party integrations.
+                  </Text>
+                </Stack>
+              </Center>
+            </Paper>
+          )}
+        </Box>
+      </Card>
+
+      <RegisterAppModal opened={registerOpened} onClose={closeRegister} />
+
+      {editClient && (
+        <EditAppModal
+          opened={!!editClient}
+          onClose={() => setEditClient(null)}
+          client={editClient}
+        />
+      )}
+
+      {/* Rotated secret display modal */}
+      <Modal
+        opened={!!rotatedSecret}
+        onClose={() => setRotatedSecret(null)}
+        title="New Client Secret"
+        centered
+      >
+        {rotatedSecret && (
+          <Stack>
+            <CopyButton value={rotatedSecret}>
+              {({ copied, copy }) => (
+                <Box pos="relative" onClick={copy} style={{ cursor: 'pointer' }}>
+                  <Code block color={copied ? 'green' : undefined}>
+                    {copied ? 'Copied' : rotatedSecret}
+                  </Code>
+                  <LegacyActionIcon
+                    className="absolute right-2 top-1/2 -translate-y-1/2"
+                    variant="transparent"
+                    color="gray"
+                  >
+                    {copied ? <IconCheck /> : <IconClipboard />}
+                  </LegacyActionIcon>
+                </Box>
+              )}
+            </CopyButton>
+            <Text size="xs" c="red.5" fw={500}>
+              Save the new client secret now — you will not be able to see it again.
+            </Text>
+            <Group justify="flex-end">
+              <Button onClick={() => setRotatedSecret(null)}>Done</Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/src/pages/api/.well-known/openid-configuration.ts
+++ b/src/pages/api/.well-known/openid-configuration.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '~/env/server';
+import { tokenScopeLabels } from '~/shared/constants/token-scope.constants';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const issuer = env.NEXTAUTH_URL;
+
+  res.setHeader('Cache-Control', 'public, max-age=86400');
+  res.status(200).json({
+    issuer,
+    authorization_endpoint: `${issuer}/api/auth/oauth/authorize`,
+    token_endpoint: `${issuer}/api/auth/oauth/token`,
+    userinfo_endpoint: `${issuer}/api/auth/oauth/userinfo`,
+    revocation_endpoint: `${issuer}/api/auth/oauth/revoke`,
+    device_authorization_endpoint: `${issuer}/api/auth/oauth/device`,
+    response_types_supported: ['code'],
+    grant_types_supported: [
+      'authorization_code',
+      'refresh_token',
+      'client_credentials',
+      'urn:ietf:params:oauth:grant-type:device_code',
+    ],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+    scopes_supported: Object.keys(tokenScopeLabels),
+    subject_types_supported: ['public'],
+  });
+}

--- a/src/pages/api/admin/orchestrator/index.ts
+++ b/src/pages/api/admin/orchestrator/index.ts
@@ -19,7 +19,6 @@ export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApi
       name: generationServiceCookie.name,
       // make the db token live just slightly longer than the cookie token
       maxAge: generationServiceCookie.maxAge + 5,
-      scope: ['Generate'],
       type: 'System',
       userId: user.id,
     });

--- a/src/pages/api/admin/orchestrator/timings.ts
+++ b/src/pages/api/admin/orchestrator/timings.ts
@@ -20,7 +20,6 @@ export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApi
       name: generationServiceCookie.name,
       // make the db token live just slightly longer than the cookie token
       maxAge: generationServiceCookie.maxAge + 5,
-      scope: ['Generate'],
       type: 'System',
       userId: user.id,
     });

--- a/src/pages/api/auth/oauth/authorize.ts
+++ b/src/pages/api/auth/oauth/authorize.ts
@@ -1,0 +1,190 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Request, Response } from '@node-oauth/oauth2-server';
+import requestIp from 'request-ip';
+import { oauthServer } from '~/server/oauth/server';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
+import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { buzzLimitSchema } from '~/server/schema/api-key.schema';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'OPTIONS') {
+    addCorsHeaders(req, res, ['GET', 'POST'], { allowCredentials: true });
+    return;
+  }
+
+  // Consent approval MUST come via POST (from the consent form), not GET
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // User must be authenticated (via session cookie)
+    const session = await getServerAuthSession({ req, res });
+    if (!session?.user) {
+      const returnUrl = encodeURIComponent(req.url ?? '/');
+      return res.redirect(`/login?returnUrl=${returnUrl}`);
+    }
+
+    // Rate limit by user ID
+    const allowed = await checkOAuthRateLimit(req, res, 'authorize', session.user.id.toString());
+    if (!allowed) return sendRateLimitResponse(res);
+
+    const params = req.method === 'GET' ? req.query : req.body;
+
+    // Validate client exists
+    const clientId = params.client_id as string;
+    if (!clientId) {
+      return res
+        .status(400)
+        .json({ error: 'invalid_request', error_description: 'Missing client_id' });
+    }
+
+    const client = await dbRead.oauthClient.findUnique({ where: { id: clientId } });
+    if (!client) {
+      return res
+        .status(400)
+        .json({ error: 'invalid_client', error_description: 'Unknown client_id' });
+    }
+
+    // Validate redirect_uri against registered URIs
+    const redirectUri = params.redirect_uri as string;
+    if (!redirectUri || !client.redirectUris.includes(redirectUri)) {
+      return res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'redirect_uri does not match any registered URI',
+      });
+    }
+
+    // PKCE is required
+    if (!params.code_challenge || !params.code_challenge_method) {
+      return res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'PKCE required: provide code_challenge and code_challenge_method=S256',
+      });
+    }
+    if (params.code_challenge_method !== 'S256') {
+      return res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'Only S256 code_challenge_method is supported',
+      });
+    }
+
+    // State is required (CSRF protection)
+    if (!params.state) {
+      return res
+        .status(400)
+        .json({ error: 'invalid_request', error_description: 'state parameter is required' });
+    }
+
+    // Validate and clamp scope
+    const rawScope = parseInt(params.scope as string, 10);
+    if (isNaN(rawScope) || rawScope < 0 || rawScope > TokenScope.Full) {
+      return res
+        .status(400)
+        .json({ error: 'invalid_scope', error_description: 'Invalid scope value' });
+    }
+    const requestedScope = rawScope;
+
+    // Check consent — approval MUST come via POST only (prevents CSRF/bypass via GET params)
+    const isApproval = req.method === 'POST' && params.approved === 'true';
+
+    const existingConsent = await dbRead.oauthConsent.findUnique({
+      where: { userId_clientId: { userId: session.user.id, clientId } },
+    });
+
+    if (isApproval) {
+      // User approved from the consent page — save consent if "remember" checked
+      const shouldRemember = params.remember === 'true';
+
+      // The consent screen optionally collects a buzz spend limit when the
+      // requested scope includes AIServicesWrite. Body field is JSON-encoded
+      // BuzzBudget[] (or empty for "no limit"); validate via the same schema
+      // the rest of the codebase uses so a malformed input is rejected here
+      // instead of silently corrupting the stored consent.
+      let parsedBuzzLimit: Awaited<ReturnType<typeof buzzLimitSchema.parseAsync>> | null = null;
+      const rawBuzzLimit = typeof params.buzz_limit === 'string' ? params.buzz_limit.trim() : '';
+      if (rawBuzzLimit) {
+        let json: unknown;
+        try {
+          json = JSON.parse(rawBuzzLimit);
+        } catch {
+          return res.status(400).json({
+            error: 'invalid_request',
+            error_description: 'buzz_limit is not valid JSON',
+          });
+        }
+        const result = buzzLimitSchema.safeParse(json);
+        if (!result.success) {
+          return res.status(400).json({
+            error: 'invalid_request',
+            error_description: 'buzz_limit failed validation',
+          });
+        }
+        parsedBuzzLimit = result.data;
+      }
+
+      if (shouldRemember) {
+        await dbWrite.oauthConsent.upsert({
+          where: { userId_clientId: { userId: session.user.id, clientId } },
+          create: {
+            userId: session.user.id,
+            clientId,
+            scope: requestedScope,
+            buzzLimit: parsedBuzzLimit ?? undefined,
+          },
+          update: { scope: requestedScope, buzzLimit: parsedBuzzLimit ?? null },
+        });
+      }
+    } else if (!existingConsent || existingConsent.scope !== requestedScope) {
+      // No prior consent (or scope changed) — redirect to consent page
+      const consentUrl = new URL('/login/oauth/authorize', process.env.NEXTAUTH_URL);
+      for (const [key, value] of Object.entries(params)) {
+        if (typeof value === 'string') consentUrl.searchParams.set(key, value);
+      }
+      return res.redirect(consentUrl.toString());
+    }
+
+    // Issue authorization code
+    const request = new Request({
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      query: {},
+      body: {
+        ...params,
+        response_type: 'code',
+      },
+    });
+
+    const response = new Response(res);
+    const code = await oauthServer.authorize(request, response, {
+      authenticateHandler: {
+        handle: () => ({ id: session.user!.id }),
+      },
+    });
+
+    const ip = requestIp.getClientIp(req) ?? '';
+    logOAuthEvent({
+      type: 'authorization.granted',
+      userId: session.user!.id,
+      clientId,
+      scope: requestedScope,
+      ip,
+    });
+
+    // Use validated redirect_uri (from our check, not raw params)
+    const redirectUrl = new URL(redirectUri);
+    redirectUrl.searchParams.set('code', code.authorizationCode);
+    redirectUrl.searchParams.set('state', params.state as string);
+    return res.redirect(redirectUrl.toString());
+  } catch (err: any) {
+    const status = err.statusCode || err.code || 500;
+    return res.status(typeof status === 'number' ? status : 500).json({
+      error: err.name || 'server_error',
+      error_description: err.message,
+    });
+  }
+}

--- a/src/pages/api/auth/oauth/device-approve.ts
+++ b/src/pages/api/auth/oauth/device-approve.ts
@@ -1,0 +1,74 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import requestIp from 'request-ip';
+
+const DEVICE_CODE_KEY = REDIS_KEYS.OAUTH.DEVICE_CODES;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const session = await getServerAuthSession({ req, res });
+  if (!session?.user) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  const { user_code } = req.body;
+  if (!user_code) {
+    return res
+      .status(400)
+      .json({ error: 'invalid_request', error_description: 'Missing user_code' });
+  }
+
+  // Look up device code from user code
+  const deviceCode = await redis.packed.hGet<string>(
+    REDIS_KEYS.OAUTH.DEVICE_USER_CODES,
+    user_code.toUpperCase()
+  );
+
+  if (!deviceCode) {
+    return res
+      .status(400)
+      .json({ error: 'invalid_code', error_description: 'Invalid or expired code' });
+  }
+
+  // Get device code data
+  const data = await redis.packed.hGet<{
+    clientId: string;
+    userCode: string;
+    scope: string;
+    status: string;
+    userId: number | null;
+    expiresAt: string;
+  }>(DEVICE_CODE_KEY, deviceCode);
+
+  if (!data || data.status !== 'pending') {
+    return res
+      .status(400)
+      .json({ error: 'invalid_code', error_description: 'Code already used or expired' });
+  }
+
+  // Approve — update the device code with user info
+  await redis.packed.hSet(DEVICE_CODE_KEY, deviceCode, {
+    ...data,
+    status: 'approved',
+    userId: session.user.id,
+  });
+
+  // Clean up user code reverse lookup
+  await redis.hDel(REDIS_KEYS.OAUTH.DEVICE_USER_CODES, user_code.toUpperCase());
+
+  logOAuthEvent({
+    type: 'authorization.granted',
+    userId: session.user.id,
+    clientId: data.clientId,
+    scope: parseInt(data.scope, 10),
+    ip: requestIp.getClientIp(req) ?? '',
+    metadata: { grant_type: 'device_code' },
+  });
+
+  return res.status(200).json({ success: true });
+}

--- a/src/pages/api/auth/oauth/device-info.ts
+++ b/src/pages/api/auth/oauth/device-info.ts
@@ -1,0 +1,81 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { dbRead } from '~/server/db/client';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { tokenScopeLabels } from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
+
+/**
+ * Look up device code info by user code — returns app name, description, and requested scopes.
+ * Used by the device verification page to show what the user is authorizing.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const session = await getServerAuthSession({ req, res });
+  if (!session?.user) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  const { user_code } = req.body;
+  if (!user_code) {
+    return res
+      .status(400)
+      .json({ error: 'invalid_request', error_description: 'Missing user_code' });
+  }
+
+  // Look up device code from user code
+  const deviceCode = await redis.packed.hGet<string>(
+    REDIS_KEYS.OAUTH.DEVICE_USER_CODES,
+    user_code.toUpperCase()
+  );
+
+  if (!deviceCode) {
+    return res
+      .status(400)
+      .json({ error: 'invalid_code', error_description: 'Invalid or expired code' });
+  }
+
+  // Get device code data
+  const data = await redis.packed.hGet<{
+    clientId: string;
+    scope: string;
+    status: string;
+  }>(REDIS_KEYS.OAUTH.DEVICE_CODES, deviceCode);
+
+  if (!data || data.status !== 'pending') {
+    return res
+      .status(400)
+      .json({ error: 'invalid_code', error_description: 'Code already used or expired' });
+  }
+
+  // Get client details
+  const client = await dbRead.oauthClient.findUnique({
+    where: { id: data.clientId },
+    select: { name: true, description: true, logoUrl: true, isVerified: true },
+  });
+
+  if (!client) {
+    return res
+      .status(400)
+      .json({ error: 'invalid_code', error_description: 'Unknown application' });
+  }
+
+  // Parse scopes into human-readable list
+  const scope = parseInt(data.scope, 10) || 0;
+  const scopeList = Object.entries(tokenScopeLabels)
+    .filter(([bit]) => Flags.hasFlag(scope, parseInt(bit)))
+    .map(([, label]) => label);
+
+  return res.status(200).json({
+    client: {
+      name: client.name,
+      description: client.description,
+      logoUrl: client.logoUrl,
+      isVerified: client.isVerified,
+    },
+    scopes: scopeList,
+  });
+}

--- a/src/pages/api/auth/oauth/device-token.ts
+++ b/src/pages/api/auth/oauth/device-token.ts
@@ -1,0 +1,117 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
+import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { createOAuthTokenPair } from '~/server/oauth/token-helpers';
+import { ACCESS_TOKEN_TTL } from '~/server/oauth/constants';
+import { Flags } from '~/shared/utils/flags';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { dbRead } from '~/server/db/client';
+import requestIp from 'request-ip';
+
+const DEVICE_CODE_KEY = REDIS_KEYS.OAUTH.DEVICE_CODES;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const shouldStop = addCorsHeaders(req, res, ['POST']);
+  if (shouldStop) return;
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { grant_type, device_code, client_id } = req.body;
+
+  if (grant_type !== 'urn:ietf:params:oauth:grant-type:device_code') {
+    return res.status(400).json({ error: 'unsupported_grant_type' });
+  }
+
+  if (!device_code || !client_id) {
+    return res.status(400).json({ error: 'invalid_request' });
+  }
+
+  // Rate limit
+  const allowed = await checkOAuthRateLimit(req, res, 'token', client_id);
+  if (!allowed) return sendRateLimitResponse(res);
+
+  // Look up device code
+  const data = await redis.packed.hGet<{
+    clientId: string;
+    userCode: string;
+    scope: string;
+    status: 'pending' | 'approved' | 'denied';
+    userId: number | null;
+    expiresAt: string;
+  }>(DEVICE_CODE_KEY, device_code);
+
+  if (!data) {
+    return res
+      .status(400)
+      .json({ error: 'expired_token', error_description: 'Device code expired' });
+  }
+
+  if (data.clientId !== client_id) {
+    return res.status(400).json({ error: 'invalid_grant' });
+  }
+
+  if (new Date(data.expiresAt) < new Date()) {
+    await redis.hDel(DEVICE_CODE_KEY, device_code);
+    return res.status(400).json({ error: 'expired_token' });
+  }
+
+  if (data.status === 'denied') {
+    await redis.hDel(DEVICE_CODE_KEY, device_code);
+    return res.status(400).json({ error: 'access_denied' });
+  }
+
+  if (data.status === 'pending') {
+    return res.status(400).json({ error: 'authorization_pending' });
+  }
+
+  // status === 'approved' — issue tokens via shared helper
+  if (!data.userId) {
+    return res.status(400).json({ error: 'server_error' });
+  }
+
+  const rawScope = parseInt(data.scope, 10);
+  if (isNaN(rawScope) || rawScope < 0 || rawScope > TokenScope.Full) {
+    return res.status(400).json({ error: 'invalid_scope' });
+  }
+  const scope = rawScope;
+
+  // Validate scope against client's allowedScopes
+  const client = await dbRead.oauthClient.findUnique({
+    where: { id: client_id },
+    select: { allowedScopes: true },
+  });
+  if (client && !Flags.hasFlag(client.allowedScopes, scope)) {
+    return res
+      .status(400)
+      .json({
+        error: 'invalid_scope',
+        error_description: 'Requested scope exceeds client permissions',
+      });
+  }
+
+  const pair = await createOAuthTokenPair(data.userId, client_id, scope);
+
+  // Clean up device code
+  await redis.hDel(DEVICE_CODE_KEY, device_code);
+
+  logOAuthEvent({
+    type: 'token.issued',
+    userId: data.userId,
+    clientId: client_id,
+    scope,
+    ip: requestIp.getClientIp(req) ?? '',
+    metadata: { grant_type: 'device_code' },
+  });
+
+  return res.status(200).json({
+    access_token: pair.accessToken,
+    token_type: 'Bearer',
+    expires_in: ACCESS_TOKEN_TTL,
+    refresh_token: pair.refreshToken,
+    scope: scope.toString(),
+  });
+}

--- a/src/pages/api/auth/oauth/device.ts
+++ b/src/pages/api/auth/oauth/device.ts
@@ -1,0 +1,108 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { randomBytes, randomInt } from 'crypto';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { dbRead } from '~/server/db/client';
+import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
+import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
+import { DEVICE_CODE_TTL, DEVICE_POLL_INTERVAL } from '~/server/oauth/constants';
+import { Flags } from '~/shared/utils/flags';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { env } from '~/env/server';
+
+const DEVICE_CODE_KEY = REDIS_KEYS.OAUTH.DEVICE_CODES;
+
+function generateUserCode(): string {
+  // 8-char alphanumeric code, grouped as XXXX-XXXX for readability.
+  // Using `crypto.randomInt(chars.length)` instead of `randomBytes() % len`
+  // avoids modulo bias — safe regardless of alphabet size, since
+  // randomInt does rejection sampling internally. Today the alphabet is 32
+  // chars (a power of 2, so a plain modulo would also be unbiased), but the
+  // rejection-sampling path is robust if the alphabet ever changes.
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // No I/O/0/1 to avoid confusion
+  let code = '';
+  for (let i = 0; i < 8; i++) {
+    code += chars[randomInt(chars.length)];
+  }
+  return `${code.slice(0, 4)}-${code.slice(4)}`;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const shouldStop = addCorsHeaders(req, res, ['POST']);
+  if (shouldStop) return;
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { client_id, scope } = req.body;
+
+  if (!client_id) {
+    return res
+      .status(400)
+      .json({ error: 'invalid_request', error_description: 'Missing client_id' });
+  }
+
+  // Rate limit
+  const allowed = await checkOAuthRateLimit(req, res, 'token', client_id);
+  if (!allowed) return sendRateLimitResponse(res);
+
+  // Validate client
+  const client = await dbRead.oauthClient.findUnique({ where: { id: client_id } });
+  if (!client) {
+    return res.status(400).json({ error: 'invalid_client', error_description: 'Unknown client' });
+  }
+
+  // Verify client supports device flow
+  if (!client.grants.includes('urn:ietf:params:oauth:grant-type:device_code')) {
+    return res
+      .status(400)
+      .json({
+        error: 'unauthorized_client',
+        error_description: 'Client not authorized for device flow',
+      });
+  }
+
+  // Validate scope early (also validated at token exchange, but fail fast for UX)
+  const requestedScope = parseInt(scope as string, 10) || 0;
+  if (requestedScope < 0 || requestedScope > TokenScope.Full) {
+    return res.status(400).json({ error: 'invalid_scope' });
+  }
+  if (requestedScope > 0 && !Flags.hasFlag(client.allowedScopes, requestedScope)) {
+    return res
+      .status(400)
+      .json({
+        error: 'invalid_scope',
+        error_description: 'Requested scope exceeds client permissions',
+      });
+  }
+
+  // Generate codes
+  const deviceCode = randomBytes(32).toString('hex');
+  const userCode = generateUserCode();
+
+  // Store in Redis
+  await redis.packed.hSet(DEVICE_CODE_KEY, deviceCode, {
+    clientId: client_id,
+    userCode,
+    scope: requestedScope.toString(),
+    status: 'pending', // pending | approved | denied
+    userId: null,
+    expiresAt: new Date(Date.now() + DEVICE_CODE_TTL * 1000).toISOString(),
+  });
+  await redis.hExpire(DEVICE_CODE_KEY, deviceCode, DEVICE_CODE_TTL);
+
+  // Also store a reverse lookup: userCode -> deviceCode
+  await redis.packed.hSet(REDIS_KEYS.OAUTH.DEVICE_USER_CODES, userCode, deviceCode);
+  await redis.hExpire(REDIS_KEYS.OAUTH.DEVICE_USER_CODES, userCode, DEVICE_CODE_TTL);
+
+  const baseUrl = env.NEXTAUTH_URL;
+
+  return res.status(200).json({
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: `${baseUrl}/login/oauth/device`,
+    verification_uri_complete: `${baseUrl}/login/oauth/device?code=${userCode}`,
+    expires_in: DEVICE_CODE_TTL,
+    interval: DEVICE_POLL_INTERVAL,
+  });
+}

--- a/src/pages/api/auth/oauth/revoke.ts
+++ b/src/pages/api/auth/oauth/revoke.ts
@@ -1,0 +1,101 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { timingSafeEqual } from 'crypto';
+import requestIp from 'request-ip';
+import { dbWrite } from '~/server/db/client';
+import { generateSecretHash } from '~/server/utils/key-generator';
+import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
+import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const shouldStop = addCorsHeaders(req, res, ['POST']);
+  if (shouldStop) return;
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { token, token_type_hint, client_id, client_secret } = req.body;
+
+  if (!token) {
+    return res
+      .status(400)
+      .json({ error: 'invalid_request', error_description: 'Missing token parameter' });
+  }
+
+  // Authenticate the caller — require either a valid session or client credentials
+  const session = await getServerAuthSession({ req, res });
+  let authenticatedUserId: number | null = session?.user?.id ?? null;
+
+  // If no session, require client_id + client_secret
+  if (!authenticatedUserId && client_id) {
+    const client = await dbWrite.oauthClient.findUnique({
+      where: { id: client_id },
+      select: { userId: true, secret: true, isConfidential: true },
+    });
+    if (client?.isConfidential && client.secret && client_secret) {
+      const hashedSecret = generateSecretHash(client_secret);
+      if (timingSafeEqual(Buffer.from(hashedSecret), Buffer.from(client.secret))) {
+        authenticatedUserId = client.userId;
+      }
+    }
+  }
+
+  // Rate limit by IP (not client_id, to prevent bypass)
+  const ip = requestIp.getClientIp(req) ?? 'unknown';
+  const allowed = await checkOAuthRateLimit(req, res, 'revoke', ip);
+  if (!allowed) return sendRateLimitResponse(res);
+
+  try {
+    const hash = generateSecretHash(token);
+
+    const types =
+      token_type_hint === 'refresh_token'
+        ? ['Refresh' as const, 'Access' as const]
+        : ['Access' as const, 'Refresh' as const];
+
+    for (const type of types) {
+      const apiKey = await dbWrite.apiKey.findFirst({
+        where: { key: hash, type },
+        select: { id: true, clientId: true, userId: true, type: true },
+      });
+
+      if (apiKey) {
+        // Must be authenticated to revoke tokens
+        if (!authenticatedUserId) {
+          break; // Silently ignore per RFC 7009 — don't reveal token existence
+        }
+        // Can only revoke your own tokens
+        if (apiKey.userId !== authenticatedUserId) {
+          break; // Silently ignore per RFC 7009
+        }
+
+        logOAuthEvent({
+          type: 'token.revoked',
+          userId: apiKey.userId,
+          clientId: apiKey.clientId ?? undefined,
+          ip,
+        });
+
+        await dbWrite.apiKey.delete({ where: { id: apiKey.id } });
+
+        if (apiKey.type === 'Refresh' && apiKey.clientId) {
+          await dbWrite.apiKey.deleteMany({
+            where: {
+              clientId: apiKey.clientId,
+              userId: apiKey.userId,
+              type: 'Access',
+            },
+          });
+        }
+        break;
+      }
+    }
+
+    // Per RFC 7009: always return 200
+    return res.status(200).json({});
+  } catch {
+    return res.status(200).json({});
+  }
+}

--- a/src/pages/api/auth/oauth/token.ts
+++ b/src/pages/api/auth/oauth/token.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Request, Response } from '@node-oauth/oauth2-server';
+import requestIp from 'request-ip';
+import { oauthServer } from '~/server/oauth/server';
+import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
+import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { ACCESS_TOKEN_TTL } from '~/server/oauth/constants';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Token endpoint needs permissive CORS (called from third-party domains)
+  const shouldStop = addCorsHeaders(req, res, ['POST']);
+  if (shouldStop) return;
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const clientId = req.body?.client_id ?? 'unknown';
+  const ip = requestIp.getClientIp(req) ?? '';
+
+  // Rate limit by client_id
+  const allowed = await checkOAuthRateLimit(req, res, 'token', clientId);
+  if (!allowed) return sendRateLimitResponse(res);
+
+  try {
+    const request = new Request({
+      method: req.method,
+      headers: req.headers as Record<string, string>,
+      query: req.query as Record<string, string>,
+      body: req.body,
+    });
+
+    const response = new Response(res);
+
+    const token = await oauthServer.token(request, response);
+
+    const grantType = req.body?.grant_type;
+    logOAuthEvent({
+      type: grantType === 'refresh_token' ? 'token.refreshed' : 'token.issued',
+      userId: typeof token.user?.id === 'number' ? token.user.id : undefined,
+      clientId,
+      scope: token.scope
+        ? parseInt(Array.isArray(token.scope) ? token.scope[0] : token.scope, 10)
+        : undefined,
+      ip,
+    });
+
+    return res.status(200).json({
+      access_token: token.accessToken,
+      token_type: 'Bearer',
+      expires_in: token.accessTokenLifetime ?? ACCESS_TOKEN_TTL,
+      refresh_token: token.refreshToken,
+      scope: token.scope,
+    });
+  } catch (err: any) {
+    const status = err.statusCode || err.code || 500;
+    return res.status(typeof status === 'number' ? status : 500).json({
+      error: err.name || 'server_error',
+      error_description: err.message,
+    });
+  }
+}

--- a/src/pages/api/auth/oauth/userinfo.ts
+++ b/src/pages/api/auth/oauth/userinfo.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
+import { Flags } from '~/shared/utils/flags';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const shouldStop = addCorsHeaders(req, res, ['GET']);
+  if (shouldStop) return;
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Extract bearer token
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) {
+    return res
+      .status(401)
+      .json({ error: 'invalid_token', error_description: 'Missing bearer token' });
+  }
+
+  const token = auth.slice(7);
+  const session = await getSessionFromBearerToken(token);
+
+  if (!session?.user) {
+    return res
+      .status(401)
+      .json({ error: 'invalid_token', error_description: 'Invalid or expired token' });
+  }
+
+  // Requires UserRead scope — deny if scope is missing (fail-safe for bearer tokens)
+  const tokenScope = 'tokenScope' in session ? ((session as any).tokenScope as number) : 0;
+  if (!Flags.hasFlag(tokenScope, TokenScope.UserRead)) {
+    return res.status(403).json({
+      error: 'insufficient_scope',
+      error_description: 'Token does not have UserRead scope',
+    });
+  }
+
+  const user = session.user;
+
+  return res.status(200).json({
+    sub: user.id.toString(),
+    id: user.id,
+    username: user.username,
+    image: user.image,
+  });
+}

--- a/src/pages/api/user/orchestrator-key.ts
+++ b/src/pages/api/user/orchestrator-key.ts
@@ -17,7 +17,6 @@ export default AuthedEndpoint(
 
       const key = await addApiKey({
         name,
-        scope: ['Generate'],
         type: 'System',
         userId: user.id,
       });

--- a/src/pages/api/v1/me.ts
+++ b/src/pages/api/v1/me.ts
@@ -2,12 +2,18 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import type { SessionUser } from 'next-auth';
 
 import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export default AuthedEndpoint(async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
   user: SessionUser
 ) {
+  const context = (req as any).context ?? {};
+  const tokenScope: number | undefined = context.tokenScope;
+  const buzzLimit = context.buzzLimit ?? null;
+  const subject = context.subject ?? null;
+
   res.send({
     id: user.id,
     username: user.username,
@@ -15,5 +21,12 @@ export default AuthedEndpoint(async function handler(
     status: user.bannedAt ? 'banned' : user.muted ? 'muted' : 'active',
     isMember: user.tier ? user.tier !== 'free' : false,
     subscriptions: Object.keys(user.subscriptions ?? {}),
+    // Token-specific fields (only present when auth is via API key/OAuth token).
+    // `subject` carries the (type, id) pair the orchestrator buckets spend by.
+    // For OAuth-issued tokens the id is the clientId (stable across refresh
+    // rotations); for User-type keys it's the ApiKey row id.
+    ...(tokenScope !== undefined && tokenScope !== TokenScope.Full
+      ? { tokenScope, buzzLimit, subject }
+      : {}),
   });
 });

--- a/src/pages/login/oauth/authorize.tsx
+++ b/src/pages/login/oauth/authorize.tsx
@@ -1,0 +1,246 @@
+import {
+  Box,
+  Button,
+  Card,
+  Center,
+  Container,
+  Divider,
+  Group,
+  Loader,
+  NumberInput,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  Title,
+  Badge,
+  List,
+  Checkbox,
+} from '@mantine/core';
+import { IconCheck, IconCoinFilled, IconShieldCheck, IconX } from '@tabler/icons-react';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { TokenScope, tokenScopeLabels } from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
+import { simpleBuzzLimitToBudgets } from '~/server/schema/api-key.schema';
+import { trpc } from '~/utils/trpc';
+
+const periodOptions = [
+  { value: 'day', label: 'Per 24 hours' },
+  { value: 'week', label: 'Per 7 days' },
+  { value: 'month', label: 'Per 30 days' },
+];
+
+export default function OAuthAuthorizePage() {
+  const router = useRouter();
+  const currentUser = useCurrentUser();
+  const [remember, setRemember] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [limitEnabled, setLimitEnabled] = useState(true);
+  const [limitAmount, setLimitAmount] = useState<number | ''>(5000);
+  const [limitPeriod, setLimitPeriod] = useState<'day' | 'week' | 'month'>('day');
+
+  const clientId = router.query.client_id as string;
+  const scope = parseInt(router.query.scope as string, 10) || 0;
+  const redirectUri = router.query.redirect_uri as string;
+  const state = router.query.state as string;
+  const responseType = router.query.response_type as string;
+  const codeChallenge = router.query.code_challenge as string;
+  const codeChallengeMethod = router.query.code_challenge_method as string;
+
+  // Fetch client details
+  const { data: client, isLoading } = trpc.oauthClient.getById.useQuery(
+    { id: clientId },
+    { enabled: !!clientId }
+  );
+
+  if (!currentUser) {
+    // Redirect to login
+    const returnUrl = encodeURIComponent(router.asPath);
+    router.replace(`/login?returnUrl=${returnUrl}`);
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <Center h="100vh">
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (!client) {
+    return (
+      <Container size="xs" py="xl">
+        <Card withBorder p="xl">
+          <Stack align="center" gap="md">
+            <IconX size={48} color="red" />
+            <Title order={3}>Invalid Application</Title>
+            <Text c="dimmed">The application you are trying to authorize was not found.</Text>
+          </Stack>
+        </Card>
+      </Container>
+    );
+  }
+
+  // Parse requested scopes into human-readable list
+  const requestedScopes = Object.entries(tokenScopeLabels)
+    .filter(([bit]) => Flags.hasFlag(scope, parseInt(bit)))
+    .map(([, label]) => label);
+
+  // The only token-driven buzz spend Civitai allows flows through the
+  // orchestrator (generation, training, scanning), gated by AIServicesWrite.
+  // Every other buzz-spending procedure on the site is `blockApiKeys: true`,
+  // so showing the limit prompt makes no sense unless this scope is included.
+  const requestsSpend = Flags.hasFlag(scope, TokenScope.AIServicesWrite);
+
+  const handleApprove = async () => {
+    setSubmitting(true);
+    try {
+      // Submit approval via POST (required by the authorize endpoint for security)
+      const form = document.createElement('form');
+      form.method = 'POST';
+      form.action = '/api/auth/oauth/authorize';
+
+      const buzzLimit =
+        requestsSpend && limitEnabled && typeof limitAmount === 'number' && limitAmount > 0
+          ? simpleBuzzLimitToBudgets({ limit: limitAmount, period: limitPeriod })
+          : null;
+
+      const fields: Record<string, string> = {
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        response_type: responseType,
+        scope: scope.toString(),
+        state,
+        code_challenge: codeChallenge,
+        code_challenge_method: codeChallengeMethod,
+        remember: remember ? 'true' : 'false',
+        approved: 'true',
+        // JSON-encoded BuzzBudget[] for the consent record, or empty for "no limit"
+        buzz_limit: buzzLimit ? JSON.stringify(buzzLimit) : '',
+      };
+
+      for (const [name, value] of Object.entries(fields)) {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.value = value;
+        form.appendChild(input);
+      }
+
+      document.body.appendChild(form);
+      form.submit();
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeny = () => {
+    // Redirect back to client with access_denied error
+    const url = new URL(redirectUri);
+    url.searchParams.set('error', 'access_denied');
+    url.searchParams.set('error_description', 'The user denied the authorization request');
+    if (state) url.searchParams.set('state', state);
+    window.location.href = url.toString();
+  };
+
+  return (
+    <Container size="xs" py="xl">
+      <Card withBorder p="xl">
+        <Stack gap="lg">
+          <Stack align="center" gap="xs">
+            <Title order={3}>Authorize {client.name}</Title>
+            {client.isVerified && (
+              <Badge leftSection={<IconShieldCheck size={14} />} color="green" variant="light">
+                Verified by Civitai
+              </Badge>
+            )}
+            {client.description && (
+              <Text c="dimmed" size="sm" ta="center">
+                {client.description}
+              </Text>
+            )}
+          </Stack>
+
+          <Divider />
+
+          <Stack gap="xs">
+            <Text fw={500}>This application is requesting access to your account:</Text>
+            <List spacing="xs" size="sm" icon={<IconCheck size={16} color="green" />}>
+              {requestedScopes.map((label) => (
+                <List.Item key={label}>{label}</List.Item>
+              ))}
+            </List>
+          </Stack>
+
+          {requestsSpend && (
+            <>
+              <Divider />
+              <Stack gap="xs">
+                <Group justify="space-between" align="center">
+                  <Group gap={6}>
+                    <IconCoinFilled size={16} color="var(--mantine-color-yellow-6)" />
+                    <Text fw={500} size="sm">
+                      Limit how much buzz this app can spend
+                    </Text>
+                  </Group>
+                  <Switch
+                    checked={limitEnabled}
+                    onChange={(e) => setLimitEnabled(e.currentTarget.checked)}
+                  />
+                </Group>
+                <Text size="xs" c="dimmed">
+                  This app is asking for AI services access, which lets it spend buzz on generation,
+                  training, or scanning. Setting a rolling limit caps how much it can spend in any
+                  window — you can change or remove the limit later in your account settings.
+                </Text>
+                {limitEnabled && (
+                  <Group grow>
+                    <NumberInput
+                      label="Limit"
+                      placeholder="Amount in buzz"
+                      min={1}
+                      value={limitAmount}
+                      onChange={(v) => setLimitAmount(typeof v === 'number' ? v : '')}
+                      thousandSeparator=","
+                    />
+                    <Select
+                      label="Window"
+                      data={periodOptions}
+                      value={limitPeriod}
+                      onChange={(v) => v && setLimitPeriod(v as 'day' | 'week' | 'month')}
+                      allowDeselect={false}
+                    />
+                  </Group>
+                )}
+              </Stack>
+            </>
+          )}
+
+          <Divider />
+
+          <Checkbox
+            label="Remember my decision for this application"
+            checked={remember}
+            onChange={(e) => setRemember(e.currentTarget.checked)}
+          />
+
+          <Group grow>
+            <Button variant="default" onClick={handleDeny} disabled={submitting}>
+              Deny
+            </Button>
+            <Button onClick={handleApprove} loading={submitting}>
+              Authorize
+            </Button>
+          </Group>
+
+          <Text size="xs" c="dimmed" ta="center">
+            Signed in as {currentUser.username}
+          </Text>
+        </Stack>
+      </Card>
+    </Container>
+  );
+}

--- a/src/pages/login/oauth/device.tsx
+++ b/src/pages/login/oauth/device.tsx
@@ -1,0 +1,218 @@
+import {
+  Badge,
+  Button,
+  Card,
+  Container,
+  Divider,
+  Group,
+  List,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { IconCheck, IconDeviceMobile, IconShieldCheck, IconX } from '@tabler/icons-react';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+
+interface DeviceAppInfo {
+  client: {
+    name: string;
+    description: string;
+    logoUrl: string | null;
+    isVerified: boolean;
+  };
+  scopes: string[];
+}
+
+export default function DeviceAuthorizePage() {
+  const router = useRouter();
+  const currentUser = useCurrentUser();
+  const [code, setCode] = useState((router.query.code as string) ?? '');
+  const [status, setStatus] = useState<
+    'input' | 'loading' | 'review' | 'approving' | 'success' | 'error'
+  >('input');
+  const [error, setError] = useState('');
+  const [appInfo, setAppInfo] = useState<DeviceAppInfo | null>(null);
+
+  if (!currentUser) {
+    const returnUrl = encodeURIComponent(router.asPath);
+    router.replace(`/login?returnUrl=${returnUrl}`);
+    return null;
+  }
+
+  // Step 1: Look up the code to get app info
+  const handleLookup = async () => {
+    if (!code.trim()) return;
+    setStatus('loading');
+
+    try {
+      const res = await fetch('/api/auth/oauth/device-info', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_code: code.trim().toUpperCase() }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error_description || 'Invalid or expired code');
+        setStatus('error');
+        return;
+      }
+
+      const data: DeviceAppInfo = await res.json();
+      setAppInfo(data);
+      setStatus('review');
+    } catch {
+      setError('Something went wrong');
+      setStatus('error');
+    }
+  };
+
+  // Step 2: Approve after reviewing
+  const handleApprove = async () => {
+    setStatus('approving');
+
+    try {
+      const res = await fetch('/api/auth/oauth/device-approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_code: code.trim().toUpperCase() }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error_description || 'Authorization failed');
+        setStatus('error');
+        return;
+      }
+
+      setStatus('success');
+    } catch {
+      setError('Something went wrong');
+      setStatus('error');
+    }
+  };
+
+  const handleDeny = () => {
+    setAppInfo(null);
+    setStatus('input');
+    setCode('');
+  };
+
+  return (
+    <Container size="xs" py="xl">
+      <Card withBorder p="xl">
+        <Stack gap="lg" align="center">
+          {status === 'success' ? (
+            <>
+              <IconCheck size={48} color="green" />
+              <Title order={3}>Device Authorized</Title>
+              <Text c="dimmed" ta="center">
+                You can close this page and return to your device.
+              </Text>
+            </>
+          ) : status === 'error' ? (
+            <>
+              <IconX size={48} color="red" />
+              <Title order={3}>Authorization Failed</Title>
+              <Text c="dimmed" ta="center">
+                {error}
+              </Text>
+              <Button
+                onClick={() => {
+                  setStatus('input');
+                  setError('');
+                  setAppInfo(null);
+                }}
+              >
+                Try Again
+              </Button>
+            </>
+          ) : status === 'review' || status === 'approving' ? (
+            <>
+              <IconDeviceMobile size={48} />
+              <Stack align="center" gap="xs">
+                <Title order={3}>Authorize {appInfo?.client.name}</Title>
+                {appInfo?.client.isVerified && (
+                  <Badge leftSection={<IconShieldCheck size={14} />} color="green" variant="light">
+                    Verified by Civitai
+                  </Badge>
+                )}
+                {appInfo?.client.description && (
+                  <Text c="dimmed" size="sm" ta="center">
+                    {appInfo.client.description}
+                  </Text>
+                )}
+              </Stack>
+
+              <Divider w="100%" />
+
+              <Stack gap="xs" w="100%">
+                <Text fw={500} size="sm">
+                  This device is requesting access to your account:
+                </Text>
+                {appInfo?.scopes && appInfo.scopes.length > 0 ? (
+                  <List spacing="xs" size="sm" icon={<IconCheck size={16} color="green" />}>
+                    {appInfo.scopes.map((label) => (
+                      <List.Item key={label}>{label}</List.Item>
+                    ))}
+                  </List>
+                ) : (
+                  <Text size="sm" c="dimmed">
+                    No specific permissions requested
+                  </Text>
+                )}
+              </Stack>
+
+              <Divider w="100%" />
+
+              <Group grow w="100%">
+                <Button variant="default" onClick={handleDeny} disabled={status === 'approving'}>
+                  Deny
+                </Button>
+                <Button onClick={handleApprove} loading={status === 'approving'}>
+                  Authorize Device
+                </Button>
+              </Group>
+
+              <Text size="xs" c="dimmed" ta="center">
+                Signed in as {currentUser.username}
+              </Text>
+            </>
+          ) : (
+            <>
+              <IconDeviceMobile size={48} />
+              <Title order={3}>Connect a Device</Title>
+              <Text c="dimmed" ta="center">
+                Enter the code shown on your device to authorize it with your Civitai account.
+              </Text>
+              <TextInput
+                value={code}
+                onChange={(e) => setCode(e.currentTarget.value)}
+                placeholder="XXXX-XXXX"
+                size="lg"
+                w="100%"
+                styles={{
+                  input: { textAlign: 'center', letterSpacing: '0.15em', fontWeight: 600 },
+                }}
+              />
+              <Button
+                fullWidth
+                onClick={handleLookup}
+                loading={status === 'loading'}
+                disabled={!code.trim()}
+              >
+                Continue
+              </Button>
+              <Text size="xs" c="dimmed" ta="center">
+                Signed in as {currentUser.username}
+              </Text>
+            </>
+          )}
+        </Stack>
+      </Card>
+    </Container>
+  );
+}

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import { AccountsCard } from '~/components/Account/AccountsCard';
 import { ApiKeysCard } from '~/components/Account/ApiKeysCard';
+import { OAuthAppsCard } from '~/components/Account/OAuthAppsCard';
+import { ConnectedAppsCard } from '~/components/Account/ConnectedAppsCard';
 import { SocialProfileCard } from '~/components/Account/SocialProfileCard';
 import { DeleteCard } from '~/components/Account/DeleteCard';
 
@@ -25,7 +27,7 @@ import dynamic from 'next/dynamic';
 const NotificationsCard = dynamic(() => import('~/components/Account/NotificationsCard'));
 
 export default function Account() {
-  const { apiKeys, canViewNsfw, strikes } = useFeatureFlags();
+  const { apiKeys, oauthApps, canViewNsfw, strikes } = useFeatureFlags();
   const currentUser = useCurrentUser();
 
   return (
@@ -54,6 +56,8 @@ export default function Account() {
           {/* {buzz && <UserReferralCodesCard />} */}
           <NotificationsCard />
           {apiKeys && <ApiKeysCard />}
+          {oauthApps && <OAuthAppsCard />}
+          {oauthApps && <ConnectedAppsCard />}
           {strikes && <StrikesCard />}
           <RefreshSessionCard />
           <DeleteCard />

--- a/src/server/auth/bearer-token.ts
+++ b/src/server/auth/bearer-token.ts
@@ -1,10 +1,66 @@
 import type { Session } from 'next-auth';
 import { getSessionUser } from './session-user';
 import { generateSecretHash } from '~/server/utils/key-generator';
+import { dbRead, dbWrite } from '~/server/db/client';
+import type { Subject } from '~/server/http/orchestrator/api-key-spend';
+import type { BuzzLimit } from '~/server/schema/api-key.schema';
+
+const LAST_USED_DEBOUNCE_MS = 60 * 60 * 1000; // 1 hour — don't update more frequently than this
 
 export async function getSessionFromBearerToken(key: string) {
   const token = generateSecretHash(key.trim());
-  const user = (await getSessionUser({ token })) as Session['user'];
+
+  // Look up the API key to get userId, tokenScope, and buzzLimit
+  const now = new Date();
+  const apiKey = await dbWrite.apiKey.findFirst({
+    where: { key: token, OR: [{ expiresAt: { gte: now } }, { expiresAt: null }] },
+    select: {
+      id: true,
+      userId: true,
+      tokenScope: true,
+      lastUsedAt: true,
+      buzzLimit: true,
+      clientId: true,
+    },
+  });
+  if (!apiKey) return null;
+
+  // Update lastUsedAt (debounced — at most once per hour, fire-and-forget)
+  if (!apiKey.lastUsedAt || now.getTime() - apiKey.lastUsedAt.getTime() > LAST_USED_DEBOUNCE_MS) {
+    dbWrite.apiKey.update({ where: { id: apiKey.id }, data: { lastUsedAt: now } }).catch(() => {});
+  }
+
+  const user = (await getSessionUser({ userId: apiKey.userId })) as Session['user'];
   if (!user) return null;
-  return { user } as Session;
+
+  // Resolve subject + buzzLimit. OAuth-issued tokens use the consent
+  // (userId + clientId) as the stable identifier across access-token rotations
+  // and read their limit from OauthConsent. User-type API keys use the
+  // ApiKey row's own id and buzzLimit.
+  let subject: Subject;
+  let buzzLimit: BuzzLimit | null;
+  if (apiKey.clientId) {
+    subject = { type: 'oauth', id: apiKey.clientId };
+    const consent = await dbRead.oauthConsent.findUnique({
+      where: { userId_clientId: { userId: apiKey.userId, clientId: apiKey.clientId } },
+      select: { buzzLimit: true },
+    });
+    buzzLimit = (consent?.buzzLimit as BuzzLimit | null) ?? null;
+  } else {
+    subject = { type: 'apiKey', id: apiKey.id };
+    buzzLimit = (apiKey.buzzLimit as BuzzLimit | null) ?? null;
+  }
+
+  return {
+    user,
+    apiKeyId: apiKey.id,
+    subject,
+    tokenScope: apiKey.tokenScope,
+    buzzLimit,
+  } as Session & {
+    apiKeyId: number;
+    subject: Subject;
+    tokenScope: number;
+    buzzLimit: BuzzLimit | null;
+  };
 }

--- a/src/server/auth/get-server-auth-session.ts
+++ b/src/server/auth/get-server-auth-session.ts
@@ -64,7 +64,16 @@ export const getServerAuthSession = async ({
 
   if (!req.context) req.context = {};
   if (token) {
-    if (!req.context?.session) req.context.session = await getSessionFromBearerToken(token);
+    if (!req.context?.session) {
+      const result = await getSessionFromBearerToken(token);
+      req.context.session = result;
+      if (result && 'tokenScope' in result) {
+        req.context.tokenScope = result.tokenScope;
+        req.context.buzzLimit = (result as any).buzzLimit ?? null;
+        req.context.apiKeyId = (result as any).apiKeyId ?? null;
+        req.context.subject = (result as any).subject ?? null;
+      }
+    }
     return req.context.session as Session | null;
   }
   try {

--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -221,6 +221,7 @@ export const ActionType = [
   'Membership_Downgrade',
   'CSAM_Help_Triggered',
   'ProfanitySearch',
+  'BuzzLimit_Set',
 ] as const;
 export type ActionType = (typeof ActionType)[number];
 

--- a/src/server/controllers/api-key.controller.ts
+++ b/src/server/controllers/api-key.controller.ts
@@ -5,15 +5,20 @@ import type {
   DeleteAPIKeyInput,
   GetAPIKeyInput,
   GetUserAPIKeysInput,
+  SetBuzzLimitInput,
 } from '~/server/schema/api-key.schema';
 import {
   addApiKey,
   deleteApiKey,
   getApiKey,
   getUserApiKeys,
+  setApiKeyBuzzLimit,
 } from '~/server/services/api-key.service';
 import { preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { throwDbError, throwNotFoundError } from '~/server/utils/errorHandling';
+import { dbRead } from '~/server/db/client';
+import { getBuzzSpendForSubjects, type Subject } from '~/server/http/orchestrator/api-key-spend';
+import { generationServiceCookie } from '~/shared/constants/generation.constants';
 
 export async function getApiKeyHandler({ input }: { input: GetAPIKeyInput }) {
   const { id } = input;
@@ -54,6 +59,97 @@ export async function addApiKeyHandler({
   await preventReplicationLag('userApiKeys', user.id);
 
   return apiKey;
+}
+
+export async function setBuzzLimitHandler({
+  ctx,
+  input,
+}: {
+  ctx: DeepNonNullable<Context>;
+  input: SetBuzzLimitInput;
+}) {
+  const { user } = ctx;
+
+  // Self-modify guard: a token must not be able to raise/clear the limit on
+  // its own subject. Session auth (subject == null) is unaffected.
+  const subject = (ctx as unknown as { subject?: { type: string; id: number | string } | null })
+    .subject;
+  if (subject && subject.type === 'apiKey' && subject.id === input.id) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'A token cannot modify its own spend limit. Use a different key or session auth.',
+    });
+  }
+
+  // Verify the key belongs to the requesting user before mutating.
+  const existing = await dbRead.apiKey.findFirst({
+    where: { id: input.id, userId: user.id, type: 'User' },
+    select: { id: true },
+  });
+  if (!existing) throw throwNotFoundError(`No api key with id ${input.id} on your account`);
+
+  const updated = await setApiKeyBuzzLimit({
+    id: input.id,
+    userId: user.id,
+    buzzLimit: input.buzzLimit,
+  });
+  await preventReplicationLag('userApiKeys', user.id);
+
+  // Audit trail in ClickHouse `actions`. Fire-and-forget. Captures who
+  // changed which subject's limit and what the new value is — useful when
+  // diagnosing "why did my agent suddenly stop generating" later.
+  ctx.track
+    .action({
+      type: 'BuzzLimit_Set',
+      details: {
+        subjectType: 'apiKey',
+        subjectId: input.id,
+        buzzLimit: input.buzzLimit,
+        viaSubject: (ctx as unknown as { subject?: unknown }).subject ?? null,
+      },
+    })
+    .catch(() => {});
+
+  return updated;
+}
+
+export async function getApiKeySpendHandler({ ctx }: { ctx: DeepNonNullable<Context> }) {
+  const { user } = ctx;
+  try {
+    // Build the subject list from the user's User-type API keys plus their
+    // OAuth consents — *only* those with a buzzLimit configured. Subjects
+    // without a limit have nothing to display in the UI and would just
+    // generate 404s on the orchestrator side.
+    const [apiKeys, consents] = await Promise.all([
+      dbRead.apiKey.findMany({
+        where: { userId: user.id, type: 'User' },
+        select: { id: true, name: true, buzzLimit: true },
+      }),
+      dbRead.oauthConsent.findMany({
+        where: { userId: user.id },
+        select: { clientId: true, buzzLimit: true },
+      }),
+    ]);
+
+    const hasLimit = (raw: unknown) =>
+      Array.isArray(raw) ? raw.length > 0 : raw != null && typeof raw === 'object'; // legacy { limit, period } shape
+
+    const subjects: Subject[] = [
+      ...apiKeys
+        .filter((k) => k.name !== generationServiceCookie.name && hasLimit(k.buzzLimit))
+        .map((k): Subject => ({ type: 'apiKey', id: k.id })),
+      ...consents
+        .filter((c) => hasLimit(c.buzzLimit))
+        .map((c): Subject => ({ type: 'oauth', id: c.clientId })),
+    ];
+
+    if (subjects.length === 0) return [];
+    return await getBuzzSpendForSubjects(user.id, subjects);
+  } catch (err) {
+    // The orchestrator endpoint may be unreachable / not yet deployed in some
+    // environments — return an empty list rather than failing the page render.
+    return [];
+  }
 }
 
 export async function deleteApiKeyHandler({

--- a/src/server/createContext.ts
+++ b/src/server/createContext.ts
@@ -9,6 +9,7 @@ import { createCallerFactory } from '@trpc/server';
 import { appRouter } from '~/server/routers';
 import { Fingerprint } from '~/server/utils/fingerprint';
 import { getAllServerHosts, getRequestDomainColor } from '~/server/utils/server-domain';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 type CacheSettings = {
   browserTTL?: number;
@@ -69,6 +70,16 @@ export const createContext = async ({
   res.once('finish', detach);
   res.once('close', detach);
 
+  // tokenScope: from bearer token auth (stored on req.context by getServerAuthSession).
+  // Session auth (cookies) gets Full scope — no restrictions for browser users.
+  const tokenScope = ((req as any).context?.tokenScope as number) ?? TokenScope.Full;
+  const apiKeyId = ((req as any).context?.apiKeyId as number | null) ?? null;
+  const subject =
+    ((req as any).context?.subject as
+      | { type: 'apiKey'; id: number }
+      | { type: 'oauth'; id: string }
+      | null) ?? null;
+
   return {
     user: session?.user,
     acceptableOrigin,
@@ -81,6 +92,9 @@ export const createContext = async ({
     req,
     domain,
     signal: abortController.signal,
+    tokenScope,
+    apiKeyId,
+    subject,
   };
 };
 
@@ -108,6 +122,9 @@ export const publicApiContext2 = async (req: NextApiRequest, res: NextApiRespons
     // Non-client-facing context — use an always-open signal so downstream
     // callers that expect AbortSignal have a valid value.
     signal: new AbortController().signal,
+    tokenScope: TokenScope.Full,
+    apiKeyId: null,
+    subject: null,
   });
 };
 

--- a/src/server/http/orchestrator/api-key-spend.ts
+++ b/src/server/http/orchestrator/api-key-spend.ts
@@ -1,0 +1,159 @@
+import { env } from '~/env/server';
+
+/**
+ * Civitai → orchestrator helpers for per-subject buzz spend tracking.
+ *
+ * The orchestrator owns spend enforcement and rolling-window math. Civitai
+ * stores limits, exposes them on /api/v1/me, invalidates the orchestrator's
+ * cache when a limit changes, and reads spend back per subject for UI
+ * display.
+ *
+ * A "subject" is an opaque (type, id) pair from the orchestrator's POV:
+ *  - `apiKey` + numeric ApiKey.id   — for User-type API keys
+ *  - `oauth`  + clientId (string)   — for OAuth-issued tokens (the consent
+ *                                     is the stable identifier across
+ *                                     access-token rotations)
+ *
+ * Endpoints (Koen, 2026-05-07):
+ *
+ *   GET    /v1/manager/users/:userId/limits/auth/:type/:id
+ *     →   { ...spend / budget data for this subject }
+ *     404 → no spend / limit data for this subject (treat as zero)
+ *
+ *   DELETE /v1/manager/users/:userId/limits/auth/:type/:id
+ *     →   204 — invalidates the orchestrator's cache for this subject
+ *
+ * Auth: bearer with `ORCHESTRATOR_ACCESS_TOKEN` (the same Civitai system key
+ * used by other `/v1/manager/*` integrations like flagged-consumers).
+ */
+
+import type { Subject, SubjectType } from '~/server/schema/api-key.schema';
+export type { Subject, SubjectType };
+
+const baseUrl = () => env.ORCHESTRATOR_ENDPOINT ?? '';
+
+function authPath(userId: number, subject: Subject) {
+  return `/v1/manager/users/${userId}/limits/auth/${subject.type}/${encodeURIComponent(
+    String(subject.id)
+  )}`;
+}
+
+function subjectPath(userId: number, subject: Subject) {
+  return `/v1/manager/users/${userId}/auth/${subject.type}/${encodeURIComponent(
+    String(subject.id)
+  )}`;
+}
+
+async function orchestratorFetch(path: string, init?: RequestInit) {
+  if (!env.ORCHESTRATOR_ENDPOINT || !env.ORCHESTRATOR_ACCESS_TOKEN) {
+    throw new Error('Orchestrator endpoint or access token not configured');
+  }
+  const url = `${baseUrl()}${path}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${env.ORCHESTRATOR_ACCESS_TOKEN}`,
+    ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+  };
+  return fetch(url, { ...init, headers: { ...headers, ...init?.headers } });
+}
+
+/**
+ * Invalidate the orchestrator's cached limit for a subject. Called when the
+ * user edits the buzz limit on a key or connected app so the next request
+ * from that subject re-fetches via /api/v1/me.
+ */
+export async function bustBuzzLimitCache(args: {
+  userId: number;
+  subject: Subject;
+}): Promise<void> {
+  const response = await orchestratorFetch(authPath(args.userId, args.subject), {
+    method: 'DELETE',
+  });
+  // 404 is fine — nothing to invalidate. Other non-2xx is a real error.
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      `Orchestrator DELETE limits/auth failed: ${response.status} ${response.statusText}`
+    );
+  }
+}
+
+export type BuzzSpendBucket = { ts: string; amount: number };
+
+/**
+ * Per-subject spend snapshot returned by the orchestrator. Shape echoed back
+ * to the UI: type + id locate the subject; spend is the total in the current
+ * tracked window(s); buckets are the ts/amount pairs for charting.
+ */
+export type BuzzSpendEntry = {
+  type: SubjectType;
+  id: number | string;
+  spend: number;
+  buckets: BuzzSpendBucket[];
+};
+
+/**
+ * Fetch the orchestrator's spend snapshot for a single subject. Returns null
+ * on 404 (no spend / no limit tracked yet) so the caller can treat absence
+ * uniformly with empty results.
+ */
+export async function getBuzzLimitForSubject(args: {
+  userId: number;
+  subject: Subject;
+}): Promise<BuzzSpendEntry | null> {
+  const response = await orchestratorFetch(authPath(args.userId, args.subject));
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(
+      `Orchestrator GET limits/auth failed: ${response.status} ${response.statusText}`
+    );
+  }
+  const body = (await response.json()) as Partial<BuzzSpendEntry>;
+  return {
+    type: args.subject.type,
+    id: args.subject.id,
+    spend: body.spend ?? 0,
+    buckets: body.buckets ?? [],
+  };
+}
+
+/**
+ * Fan-out fetch — one GET per subject, in parallel, swallow individual
+ * failures so a single orchestrator hiccup doesn't blank the whole UI.
+ *
+ * Confirmed with Koen 2026-05-07: no batched list endpoint coming. He stores
+ * subjects in Mongo with no deletion policy, so a list response would return
+ * stale entries Civitai has forgotten about. Civitai is the source of truth
+ * for which subjects exist; per-subject GETs are simpler and just as fast.
+ * Caller is expected to filter the subject list to ones with limits set
+ * before calling, so unlimited keys/consents don't generate 404 traffic.
+ */
+export async function getBuzzSpendForSubjects(
+  userId: number,
+  subjects: Subject[]
+): Promise<BuzzSpendEntry[]> {
+  const results = await Promise.all(
+    subjects.map((subject) => getBuzzLimitForSubject({ userId, subject }).catch(() => null))
+  );
+  return results.filter((r): r is BuzzSpendEntry => r !== null);
+}
+
+/**
+ * Delete the orchestrator's stored record for a subject — called when the
+ * user deletes the underlying API key (so the subject is gone) or revokes a
+ * connected app (so the OAuth consent is gone). Best-effort: 404 means
+ * already absent, anything else is logged but doesn't fail the user
+ * mutation.
+ *
+ * Endpoint (Koen, 2026-05-07):
+ *   DELETE /v1/manager/users/:userId/auth/:type/:id
+ *     →   204 — subject removed (or never existed)
+ */
+export async function deleteAuthSubject(args: { userId: number; subject: Subject }): Promise<void> {
+  const response = await orchestratorFetch(subjectPath(args.userId, args.subject), {
+    method: 'DELETE',
+  });
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      `Orchestrator DELETE auth subject failed: ${response.status} ${response.statusText}`
+    );
+  }
+}

--- a/src/server/oauth/audit-log.ts
+++ b/src/server/oauth/audit-log.ts
@@ -1,0 +1,39 @@
+import { dbWrite } from '~/server/db/client';
+
+export type OAuthEventType =
+  | 'client.created'
+  | 'client.updated'
+  | 'client.deleted'
+  | 'client.secret_rotated'
+  | 'authorization.granted'
+  | 'authorization.denied'
+  | 'token.issued'
+  | 'token.refreshed'
+  | 'token.revoked';
+
+interface OAuthAuditEvent {
+  type: OAuthEventType;
+  userId?: number;
+  clientId?: string;
+  scope?: number;
+  ip?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Log OAuth events for audit trail.
+ *
+ * Currently logs to the application logger. In the future, this could
+ * write to a dedicated audit table or ClickHouse for queryability.
+ *
+ * Fire-and-forget — never blocks the request.
+ */
+export function logOAuthEvent(event: OAuthAuditEvent): void {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    ...event,
+  };
+
+  // Log as structured JSON for log aggregation (Axiom, etc.)
+  console.log(`[oauth-audit] ${JSON.stringify(entry)}`);
+}

--- a/src/server/oauth/constants.ts
+++ b/src/server/oauth/constants.ts
@@ -1,0 +1,6 @@
+export const OAUTH_TOKEN_PREFIX = 'civitai_';
+export const ACCESS_TOKEN_TTL = 60 * 60; // 1 hour
+export const REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60; // 30 days
+export const AUTH_CODE_TTL = 10 * 60; // 10 minutes
+export const DEVICE_CODE_TTL = 15 * 60; // 15 minutes
+export const DEVICE_POLL_INTERVAL = 5; // seconds

--- a/src/server/oauth/model.ts
+++ b/src/server/oauth/model.ts
@@ -1,0 +1,246 @@
+import type {
+  AuthorizationCode,
+  Client,
+  RefreshToken,
+  Token,
+  User,
+} from '@node-oauth/oauth2-server';
+import { createHash, timingSafeEqual } from 'crypto';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { generateSecretHash } from '~/server/utils/key-generator';
+import { Flags } from '~/shared/utils/flags';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { ACCESS_TOKEN_TTL, AUTH_CODE_TTL, REFRESH_TOKEN_TTL } from './constants';
+import { createOAuthTokenPair } from './token-helpers';
+
+/** Hash auth code for Redis storage (separate from API key hashing) */
+function hashCode(code: string): string {
+  return createHash('sha256').update(code).digest('hex');
+}
+
+/** Convert scope bitmask to/from the library's string-based scope */
+function scopeToString(scope: number): string[] {
+  return [scope.toString()];
+}
+
+function stringToScope(scope: string | string[] | undefined): number {
+  if (!scope) return 0;
+  const str = Array.isArray(scope) ? scope[0] : scope;
+  const parsed = parseInt(str, 10);
+  if (isNaN(parsed) || parsed < 0 || parsed > TokenScope.Full) return 0;
+  return parsed;
+}
+
+// Combined model interface — the library accepts any object with these methods
+export const oauthModel = {
+  // ─── Client ─────────────────────────────────────────────────
+
+  async getClient(clientId: string, clientSecret: string | null): Promise<Client | false> {
+    const client = await dbRead.oauthClient.findUnique({ where: { id: clientId } });
+    if (!client) return false;
+
+    // The library passes `null` from the authorize handler (client_secret is not
+    // sent on /authorize per OAuth spec) and a string (or undefined) from the
+    // token handler. Only validate the secret when the library actually had one
+    // to pass — i.e. the token-endpoint code path.
+    if (clientSecret !== null) {
+      if (client.isConfidential) {
+        if (!clientSecret || !client.secret) return false;
+        const hashedSecret = generateSecretHash(clientSecret);
+        if (!timingSafeEqual(Buffer.from(hashedSecret), Buffer.from(client.secret))) return false;
+      }
+    }
+
+    return {
+      id: client.id,
+      grants: client.grants,
+      redirectUris: client.redirectUris,
+      accessTokenLifetime: ACCESS_TOKEN_TTL,
+      refreshTokenLifetime: REFRESH_TOKEN_TTL,
+      allowedScopes: client.allowedScopes,
+      isConfidential: client.isConfidential,
+    } as Client;
+  },
+
+  // ─── Authorization Code ─────────────────────────────────────
+
+  async saveAuthorizationCode(
+    code: AuthorizationCode,
+    client: Client,
+    user: User
+  ): Promise<AuthorizationCode> {
+    const hashedCode = hashCode(code.authorizationCode);
+    const scopeValue = Array.isArray(code.scope) ? code.scope[0] : String(code.scope ?? '0');
+
+    const data = {
+      clientId: client.id,
+      userId: user.id,
+      scope: scopeValue,
+      redirectUri: code.redirectUri,
+      codeChallenge: code.codeChallenge,
+      codeChallengeMethod: code.codeChallengeMethod,
+      expiresAt: code.expiresAt.toISOString(),
+    };
+
+    await redis.packed.hSet(REDIS_KEYS.OAUTH.AUTHORIZATION_CODES, hashedCode, data);
+    await redis.hExpire(REDIS_KEYS.OAUTH.AUTHORIZATION_CODES, hashedCode, AUTH_CODE_TTL);
+
+    return { ...code, client, user };
+  },
+
+  async getAuthorizationCode(authorizationCode: string): Promise<AuthorizationCode | false> {
+    const hashedCode = hashCode(authorizationCode);
+    const data = await redis.packed.hGet<{
+      clientId: string;
+      userId: number;
+      scope: string;
+      redirectUri: string;
+      codeChallenge?: string;
+      codeChallengeMethod?: string;
+      expiresAt: string;
+    }>(REDIS_KEYS.OAUTH.AUTHORIZATION_CODES, hashedCode);
+
+    if (!data) return false;
+
+    const client = await dbRead.oauthClient.findUnique({ where: { id: data.clientId } });
+    if (!client) return false;
+
+    return {
+      authorizationCode,
+      expiresAt: new Date(data.expiresAt),
+      redirectUri: data.redirectUri,
+      scope: [data.scope],
+      codeChallenge: data.codeChallenge,
+      codeChallengeMethod: data.codeChallengeMethod,
+      client: { id: client.id, grants: client.grants, redirectUris: client.redirectUris } as Client,
+      user: { id: data.userId },
+    } as unknown as AuthorizationCode;
+  },
+
+  async revokeAuthorizationCode(code: AuthorizationCode): Promise<boolean> {
+    const hashedCode = hashCode(code.authorizationCode);
+    await redis.hDel(REDIS_KEYS.OAUTH.AUTHORIZATION_CODES, hashedCode);
+    return true;
+  },
+
+  // ─── Tokens ─────────────────────────────────────────────────
+
+  async saveToken(token: Token, client: Client, user: User): Promise<Token> {
+    const scope = stringToScope(token.scope as unknown as string);
+
+    const pair = await createOAuthTokenPair(user.id, client.id, scope);
+
+    return {
+      accessToken: pair.accessToken,
+      accessTokenExpiresAt: pair.accessTokenExpiresAt,
+      refreshToken: pair.refreshToken,
+      refreshTokenExpiresAt: pair.refreshTokenExpiresAt,
+      scope: scopeToString(scope),
+      client,
+      user,
+    } as Token;
+  },
+
+  async getAccessToken(accessToken: string): Promise<Token | false> {
+    const hash = generateSecretHash(accessToken);
+    const now = new Date();
+
+    const apiKey = await dbRead.apiKey.findFirst({
+      where: {
+        key: hash,
+        type: 'Access',
+        OR: [{ expiresAt: { gte: now } }, { expiresAt: null }],
+      },
+      select: { userId: true, tokenScope: true, expiresAt: true, clientId: true },
+    });
+
+    if (!apiKey) return false;
+
+    return {
+      accessToken,
+      accessTokenExpiresAt: apiKey.expiresAt ?? undefined,
+      scope: scopeToString(apiKey.tokenScope),
+      client: { id: apiKey.clientId ?? '' } as Client,
+      user: { id: apiKey.userId },
+    } as unknown as Token;
+  },
+
+  async getRefreshToken(refreshToken: string): Promise<RefreshToken | false> {
+    const hash = generateSecretHash(refreshToken);
+    const now = new Date();
+
+    const apiKey = await dbRead.apiKey.findFirst({
+      where: {
+        key: hash,
+        type: 'Refresh',
+        OR: [{ expiresAt: { gte: now } }, { expiresAt: null }],
+      },
+      select: { userId: true, tokenScope: true, expiresAt: true, clientId: true },
+    });
+
+    if (!apiKey) return false;
+
+    return {
+      refreshToken,
+      refreshTokenExpiresAt: apiKey.expiresAt ?? undefined,
+      scope: scopeToString(apiKey.tokenScope),
+      client: { id: apiKey.clientId ?? '' } as Client,
+      user: { id: apiKey.userId },
+    } as unknown as RefreshToken;
+  },
+
+  async revokeToken(token: RefreshToken): Promise<boolean> {
+    const hash = generateSecretHash(token.refreshToken);
+    const deleted = await dbWrite.apiKey.deleteMany({ where: { key: hash, type: 'Refresh' } });
+
+    // Also revoke all access tokens for this client+user
+    if (token.client?.id && token.user?.id) {
+      await dbWrite.apiKey.deleteMany({
+        where: {
+          clientId: token.client.id,
+          userId:
+            typeof token.user.id === 'number' ? token.user.id : parseInt(String(token.user.id)),
+          type: 'Access',
+        },
+      });
+    }
+
+    return deleted.count > 0;
+  },
+
+  // ─── Client Credentials ─────────────────────────────────────
+
+  async getUserFromClient(client: Client): Promise<User | false> {
+    // For client_credentials grant, the "user" is the client owner
+    const oauthClient = await dbRead.oauthClient.findUnique({
+      where: { id: client.id },
+      select: { userId: true, grants: true },
+    });
+
+    if (!oauthClient || !oauthClient.grants.includes('client_credentials')) {
+      return false;
+    }
+
+    return { id: oauthClient.userId };
+  },
+
+  // ─── Scope Validation ──────────────────────────────────────
+
+  async validateScope(_user: User, client: Client, scope: string[]): Promise<string[] | false> {
+    const requestedScope = stringToScope(scope);
+    const allowedScopes = (client as any).allowedScopes ?? TokenScope.Full;
+
+    if (!Flags.hasFlag(allowedScopes, requestedScope)) {
+      return false;
+    }
+
+    return scopeToString(requestedScope);
+  },
+
+  async verifyScope(token: Token, scope: string | string[]): Promise<boolean> {
+    const tokenScope = stringToScope(token.scope as unknown as string);
+    const requiredScope = stringToScope(scope as unknown as string);
+    return Flags.hasFlag(tokenScope, requiredScope);
+  },
+};

--- a/src/server/oauth/rate-limit.ts
+++ b/src/server/oauth/rate-limit.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { redis } from '~/server/redis/client';
+
+const RATE_LIMIT_PREFIX = 'oauth:rate-limit';
+
+interface RateLimitConfig {
+  /** Max requests allowed in the window */
+  limit: number;
+  /** Window size in seconds */
+  windowSeconds: number;
+}
+
+const RATE_LIMITS: Record<string, RateLimitConfig> = {
+  token: { limit: 20, windowSeconds: 60 }, // 20 req/min per client
+  authorize: { limit: 10, windowSeconds: 60 }, // 10 req/min per user
+  revoke: { limit: 20, windowSeconds: 60 }, // 20 req/min per client
+};
+
+/**
+ * Simple sliding-window rate limiter for OAuth endpoints.
+ * Returns true if the request should be allowed, false if rate limited.
+ * Sets rate limit headers on the response.
+ */
+export async function checkOAuthRateLimit(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  endpoint: keyof typeof RATE_LIMITS,
+  identifier: string
+): Promise<boolean> {
+  const config = RATE_LIMITS[endpoint];
+  if (!config) return true;
+
+  const key = `${RATE_LIMIT_PREFIX}:${endpoint}:${identifier}`;
+
+  try {
+    // Rate limit keys are dynamic (per client/user), cast to bypass typed key system
+    const current = await (redis as any).incr(key);
+
+    // Set expiry on first request in window
+    if (current === 1) {
+      await (redis as any).expire(key, config.windowSeconds);
+    }
+
+    // Set rate limit headers
+    const ttl = await (redis as any).ttl(key);
+    res.setHeader('X-RateLimit-Limit', config.limit);
+    res.setHeader('X-RateLimit-Remaining', Math.max(0, config.limit - current));
+    res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + Math.max(0, ttl));
+
+    if (current > config.limit) {
+      res.setHeader('Retry-After', Math.max(0, ttl));
+      return false;
+    }
+
+    return true;
+  } catch {
+    // If Redis fails, allow the request (fail open for rate limiting)
+    return true;
+  }
+}
+
+/**
+ * Helper to send a 429 Too Many Requests response
+ */
+export function sendRateLimitResponse(res: NextApiResponse): void {
+  res.status(429).json({
+    error: 'rate_limit_exceeded',
+    error_description: 'Too many requests. Please try again later.',
+  });
+}

--- a/src/server/oauth/server.ts
+++ b/src/server/oauth/server.ts
@@ -1,0 +1,13 @@
+import OAuth2Server from '@node-oauth/oauth2-server';
+import { oauthModel } from './model';
+
+export const oauthServer = new OAuth2Server({
+  model: oauthModel,
+  accessTokenLifetime: 60 * 60, // 1 hour
+  refreshTokenLifetime: 30 * 24 * 60 * 60, // 30 days
+  allowEmptyState: false,
+  requireClientAuthentication: {
+    authorization_code: false, // PKCE handles security for public clients
+    refresh_token: false, // Public clients (SPAs) need to refresh without a secret
+  },
+});

--- a/src/server/oauth/token-helpers.ts
+++ b/src/server/oauth/token-helpers.ts
@@ -1,0 +1,60 @@
+import { dbWrite } from '~/server/db/client';
+import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
+import { OAUTH_TOKEN_PREFIX, ACCESS_TOKEN_TTL, REFRESH_TOKEN_TTL } from './constants';
+
+interface TokenPair {
+  accessToken: string;
+  accessTokenExpiresAt: Date;
+  refreshToken: string;
+  refreshTokenExpiresAt: Date;
+}
+
+/**
+ * Create an OAuth access + refresh token pair stored as ApiKey rows.
+ * Used by both the OAuth model (saveToken) and device authorization flow.
+ */
+export async function createOAuthTokenPair(
+  userId: number,
+  clientId: string,
+  scope: number
+): Promise<TokenPair> {
+  const now = new Date();
+
+  // Access token
+  const accessToken = OAUTH_TOKEN_PREFIX + generateKey(36);
+  const accessHash = generateSecretHash(accessToken);
+  const accessTokenExpiresAt = new Date(now.getTime() + ACCESS_TOKEN_TTL * 1000);
+
+  await dbWrite.apiKey.create({
+    data: {
+      key: accessHash,
+      name: `oauth:${clientId}`,
+      scope: [],
+      tokenScope: scope,
+      userId,
+      type: 'Access',
+      expiresAt: accessTokenExpiresAt,
+      clientId,
+    },
+  });
+
+  // Refresh token
+  const refreshToken = OAUTH_TOKEN_PREFIX + generateKey(36);
+  const refreshHash = generateSecretHash(refreshToken);
+  const refreshTokenExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL * 1000);
+
+  await dbWrite.apiKey.create({
+    data: {
+      key: refreshHash,
+      name: `oauth-refresh:${clientId}`,
+      scope: [],
+      tokenScope: scope,
+      userId,
+      type: 'Refresh',
+      expiresAt: refreshTokenExpiresAt,
+      clientId,
+    },
+  });
+
+  return { accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt };
+}

--- a/src/server/orchestrator/get-orchestrator-token.ts
+++ b/src/server/orchestrator/get-orchestrator-token.ts
@@ -25,7 +25,6 @@ export async function getOrchestratorToken(userId: number, ctx: Context) {
       name: generationServiceCookie.name,
       // make the db token live just slightly longer than the cookie token
       maxAge: generationServiceCookie.maxAge + 5,
-      scope: ['Generate'],
       type: 'System',
       userId,
     });

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -803,6 +803,11 @@ export const REDIS_KEYS = {
     COUNT: 'generation:count',
     BLOCKED_PROMPTS: 'generation:blocked-prompts',
   },
+  OAUTH: {
+    AUTHORIZATION_CODES: 'packed:oauth:authorization-codes',
+    DEVICE_CODES: 'packed:oauth:device-codes',
+    DEVICE_USER_CODES: 'packed:oauth:device-user-codes',
+  },
   SYSTEM: {
     MODERATED_TAGS: 'packed:system:moderated_tags',
     TAG_RULES: 'system:tag-rules',

--- a/src/server/routers/account.router.ts
+++ b/src/server/routers/account.router.ts
@@ -6,8 +6,14 @@ import {
 } from '~/server/controllers/account.controller';
 import { getByIdSchema } from '~/server/schema/base.schema';
 import { protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const accountRouter = router({
-  getAll: protectedProcedure.query(getUserAccountsHandler),
-  delete: protectedProcedure.input(getByIdSchema).mutation(deleteAccountHandler),
+  getAll: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserAccountsHandler),
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(getByIdSchema)
+    .mutation(deleteAccountHandler),
 });

--- a/src/server/routers/announcement.router.ts
+++ b/src/server/routers/announcement.router.ts
@@ -12,6 +12,7 @@ import {
 } from '~/server/services/announcement.service';
 import { getByIdSchema } from '~/server/schema/base.schema';
 import { applyRequestDomainColor } from '~/server/middleware.trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const announcementRouter = router({
   upsertAnnouncement: moderatorProcedure
@@ -21,6 +22,7 @@ export const announcementRouter = router({
     .input(getByIdSchema)
     .mutation(({ input }) => deleteAnnouncement(input.id)),
   getAnnouncements: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getCurrentAnnouncementsSchema.optional())
     .use(applyRequestDomainColor)
     .query(({ ctx, input }) => getCurrentAnnouncements({ ...input, userId: ctx.user?.id })),

--- a/src/server/routers/answer.router.ts
+++ b/src/server/routers/answer.router.ts
@@ -17,6 +17,7 @@ import {
 } from '~/server/trpc';
 import { dbRead } from '~/server/db/client';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -43,15 +44,26 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 });
 
 export const answerRouter = router({
-  getById: publicProcedure.input(getByIdSchema).query(getAnswerDetailHandler),
-  getAll: publicProcedure.input(getAnswersSchema).query(getAnswersHandler),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getAnswerDetailHandler),
+  getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getAnswersSchema)
+    .query(getAnswersHandler),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(upsertAnswerSchema)
     .use(isOwnerOrModerator)
     .mutation(upsertAnswerHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteAnswerHandler),
-  vote: protectedProcedure.input(answerVoteSchema).mutation(setAnswerVoteHandler),
+  vote: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(answerVoteSchema)
+    .mutation(setAnswerVoteHandler),
 });

--- a/src/server/routers/apiKey.router.ts
+++ b/src/server/routers/apiKey.router.ts
@@ -2,19 +2,42 @@ import {
   addApiKeyHandler,
   deleteApiKeyHandler,
   getApiKeyHandler,
+  getApiKeySpendHandler,
   getUserApiKeysHandler,
+  setBuzzLimitHandler,
 } from '~/server/controllers/api-key.controller';
 import {
   addApiKeyInputSchema,
   getApiKeyInputSchema,
   deleteApiKeyInputSchema,
   getUserApiKeysInputSchema,
+  setBuzzLimitInputSchema,
 } from '~/server/schema/api-key.schema';
 import { protectedProcedure, publicProcedure, router, verifiedProcedure } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const apiKeyRouter = router({
-  verifyKey: publicProcedure.input(getApiKeyInputSchema).query(getApiKeyHandler),
-  getAllUserKeys: protectedProcedure.input(getUserApiKeysInputSchema).query(getUserApiKeysHandler),
-  add: verifiedProcedure.input(addApiKeyInputSchema).mutation(addApiKeyHandler),
-  delete: protectedProcedure.input(deleteApiKeyInputSchema).mutation(deleteApiKeyHandler),
+  verifyKey: publicProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(getApiKeyInputSchema)
+    .query(getApiKeyHandler),
+  getAllUserKeys: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(getUserApiKeysInputSchema)
+    .query(getUserApiKeysHandler),
+  getSpend: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(getApiKeySpendHandler),
+  add: verifiedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(addApiKeyInputSchema)
+    .mutation(addApiKeyHandler),
+  setBuzzLimit: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(setBuzzLimitInputSchema)
+    .mutation(setBuzzLimitHandler),
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(deleteApiKeyInputSchema)
+    .mutation(deleteApiKeyHandler),
 });

--- a/src/server/routers/article.router.ts
+++ b/src/server/routers/article.router.ts
@@ -35,6 +35,7 @@ import { CacheTTL } from '~/server/common/constants';
 import { dbRead } from '~/server/db/client';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import { isModerator } from '~/server/routers/base.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -58,52 +59,66 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 
 export const articleRouter = router({
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
     .input(getInfiniteArticlesSchema)
     .query(({ input, ctx }) =>
       getArticles({ ...input, sessionUser: ctx?.user, include: ['cosmetics'] })
     ),
   getCivitaiNews: publicProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
     .use(edgeCacheIt({ ttl: CacheTTL.sm }))
     .query(() => getCivitaiNews()),
-  getEvents: publicProcedure.query(() => getCivitaiEvents()),
-  getById: publicProcedure.input(getByIdSchema).query(({ input, ctx }) =>
-    getArticleById({
-      ...input,
-      userId: ctx.user?.id,
-      isModerator: ctx.user?.isModerator,
-    })
-  ),
+  getEvents: publicProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
+    .query(() => getCivitaiEvents()),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
+    .input(getByIdSchema)
+    .query(({ input, ctx }) =>
+      getArticleById({
+        ...input,
+        userId: ctx.user?.id,
+        isModerator: ctx.user?.isModerator,
+      })
+    ),
   getMyDraftArticles: protectedProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
     .input(getAllQuerySchema)
     .use(isFlagProtected('articles'))
     .query(({ input, ctx }) => getDraftArticlesByUserId({ ...input, userId: ctx.user.id })),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.ArticlesWrite })
     .input(upsertArticleInput)
     .use(isFlagProtected('articleCreate'))
     .use(rateLimit(articleRateLimits, (input: UpsertArticleInput) => !input.id))
     .mutation(upsertArticleHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.ArticlesDelete })
     .input(getByIdSchema)
     .use(isFlagProtected('articleCreate'))
     .mutation(({ input, ctx }) =>
       deleteArticleById({ ...input, userId: ctx.user.id, isModerator: ctx.user.isModerator })
     ),
   unpublish: protectedProcedure
+    .meta({ requiredScope: TokenScope.ArticlesWrite })
     .input(unpublishArticleSchema)
     .use(isFlagProtected('articles'))
     .use(isOwnerOrModerator)
     .mutation(unpublishArticleHandler),
   restore: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(restoreArticleSchema)
     .use(isFlagProtected('articles'))
     .use(isModerator)
     .mutation(restoreArticleHandler),
   rescan: protectedProcedure
+    .meta({ requiredScope: TokenScope.ArticlesWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('articleImageScanning'))
     .use(isOwnerOrModerator)
     .mutation(({ input, ctx }) => rescanArticle({ ...input, isModerator: ctx.user.isModerator })),
   getScanStatus: publicProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
     .input(getByIdSchema)
     .use(isFlagProtected('articleImageScanning'))
     .query(({ input }) => getArticleScanStatus(input)),

--- a/src/server/routers/auction.router.ts
+++ b/src/server/routers/auction.router.ts
@@ -26,34 +26,44 @@ import {
   router,
 } from '~/server/trpc';
 import { getAllowedAccountTypes } from '~/server/utils/buzz-helpers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const auctionProcedure = protectedProcedure.use(isFlagProtected('auctions'));
 
 // .use(edgeCacheIt({ ttl: CacheTTL.hour }))
 
 export const auctionRouter = router({
-  getAll: publicProcedure.query(getAllAuctions),
+  getAll: publicProcedure.meta({ requiredScope: TokenScope.BountiesRead }).query(getAllAuctions),
   getBySlug: publicProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
     .input(getAuctionBySlugInput)
     .query(({ input }) => getAuctionBySlug(input)),
-  getMyBids: auctionProcedure.query(({ ctx }) => getMyBids({ userId: ctx.user.id })),
-  getMyRecurringBids: auctionProcedure.query(({ ctx }) =>
-    getMyRecurringBids({ userId: ctx.user.id })
-  ),
-  createBid: auctionProcedure.input(createBidInput).mutation(({ input, ctx }) =>
-    createBid({
-      ...input,
-      userId: ctx.user.id,
-      accountTypes: getAllowedAccountTypes(ctx.features),
-    })
-  ),
+  getMyBids: auctionProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
+    .query(({ ctx }) => getMyBids({ userId: ctx.user.id })),
+  getMyRecurringBids: auctionProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
+    .query(({ ctx }) => getMyRecurringBids({ userId: ctx.user.id })),
+  createBid: auctionProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite, blockApiKeys: true })
+    .input(createBidInput)
+    .mutation(({ input, ctx }) =>
+      createBid({
+        ...input,
+        userId: ctx.user.id,
+        accountTypes: getAllowedAccountTypes(ctx.features),
+      })
+    ),
   deleteBid: auctionProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(deleteBidInput)
     .mutation(({ input, ctx }) => deleteBid({ ...input, userId: ctx.user.id })),
   deleteRecurringBid: auctionProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(deleteBidInput)
     .mutation(({ input, ctx }) => deleteRecurringBid({ ...input, userId: ctx.user.id })),
   togglePauseRecurringBid: auctionProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(togglePauseRecurringBidInput)
     .mutation(({ input, ctx }) => togglePauseRecurringBid({ ...input, userId: ctx.user.id })),
   modGetAuctionBases: moderatorProcedure

--- a/src/server/routers/auth.router.ts
+++ b/src/server/routers/auth.router.ts
@@ -1,14 +1,19 @@
 import { router, publicProcedure, protectedProcedure } from '~/server/trpc';
 import { getProviders } from 'next-auth/react';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const authRouter = router({
-  getUser: publicProcedure.query(({ ctx }) => ctx.user),
-  getSecretMessage: protectedProcedure.query(
-    () => 'You are logged in and can see this secret message!'
-  ),
-  getProviders: publicProcedure.query(() =>
-    getProviders().then((data) =>
-      data ? Object.values(data).filter((x) => x.type === 'oauth') : []
-    )
-  ),
+  getUser: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => ctx.user),
+  getSecretMessage: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(() => 'You are logged in and can see this secret message!'),
+  getProviders: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(() =>
+      getProviders().then((data) =>
+        data ? Object.values(data).filter((x) => x.type === 'oauth') : []
+      )
+    ),
 });

--- a/src/server/routers/blocklist.router.ts
+++ b/src/server/routers/blocklist.router.ts
@@ -10,6 +10,7 @@ import {
   removeBlocklistItems,
   upsertBlocklist,
 } from '~/server/services/blocklist.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const blocklistRouter = router({
   upsertBlocklist: moderatorProcedure

--- a/src/server/routers/bounty.router.ts
+++ b/src/server/routers/bounty.router.ts
@@ -30,6 +30,7 @@ import {
 } from '~/server/schema/bounty.schema';
 import { dbWrite } from '~/server/db/client';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -54,41 +55,50 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 
 export const bountyRouter = router({
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
     .input(getInfiniteBountySchema)
     .use(isFlagProtected('bounties'))
     .query(getInfiniteBountiesHandler),
   getById: publicProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
     .input(getByIdSchema)
     .use(isFlagProtected('bounties'))
     .query(getBountyHandler),
   getEntries: publicProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
     .input(getBountyEntriesInputSchema)
     .use(isFlagProtected('bounties'))
     .query(getBountyEntriesHandler),
   getBenefactors: publicProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
     .input(getByIdSchema)
     .use(isFlagProtected('bounties'))
     .query(getBountyBenefactorsHandler),
   create: guardedProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(createBountyInputSchema)
     .use(isFlagProtected('bounties'))
     .mutation(createBountyHandler),
   update: guardedProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(updateBountyInputSchema)
     .use(isFlagProtected('bounties'))
     .use(isOwnerOrModerator)
     .mutation(updateBountyHandler),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite, blockApiKeys: true })
     .input(upsertBountyInputSchema)
     .use(isFlagProtected('bounties'))
     .use(isOwnerOrModerator)
     .mutation(upsertBountyHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.BountiesDelete })
     .input(getByIdSchema)
     .use(isFlagProtected('bounties'))
     .use(isOwnerOrModerator)
     .mutation(deleteBountyHandler),
   addBenefactorUnitAmount: protectedProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(addBenefactorUnitAmountInputSchema)
     .use(isFlagProtected('bounties'))
     .mutation(addBenefactorUnitAmountHandler),

--- a/src/server/routers/bountyEntry.router.ts
+++ b/src/server/routers/bountyEntry.router.ts
@@ -17,6 +17,7 @@ import {
 import { upsertBountyEntryInputSchema } from '~/server/schema/bounty-entry.schema';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import { dbWrite } from '~/server/db/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -43,22 +44,27 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 
 export const bountyEntryRouter = router({
   getById: publicProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
     .input(getByIdSchema)
     .use(isFlagProtected('bounties'))
     .query(getBountyEntryHandler),
   getFiles: publicProcedure
+    .meta({ requiredScope: TokenScope.BountiesRead })
     .input(getByIdSchema)
     .use(isFlagProtected('bounties'))
     .query(getBountyEntryFilteredFilesHandler),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(upsertBountyEntryInputSchema)
     .use(isFlagProtected('bounties'))
     .mutation(upsertBountyEntryHandler),
   award: protectedProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('bounties'))
     .mutation(awardBountyEntryHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.BountiesDelete })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .use(isFlagProtected('bounties'))

--- a/src/server/routers/build-guide.router.ts
+++ b/src/server/routers/build-guide.router.ts
@@ -1,6 +1,9 @@
 import { publicProcedure, router } from '~/server/trpc';
 import { getBuildGuides } from '~/server/services/build-guide.services';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const buildGuideRouter = router({
-  getAll: publicProcedure.query(() => getBuildGuides()),
+  getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.ArticlesRead })
+    .query(() => getBuildGuides()),
 });

--- a/src/server/routers/buzz-withdrawal-request.router.ts
+++ b/src/server/routers/buzz-withdrawal-request.router.ts
@@ -16,9 +16,11 @@ import {
   updateBuzzWithdrawalRequestSchema,
 } from '../schema/buzz-withdrawal-request.schema';
 import { isFlagProtected, moderatorProcedure, protectedProcedure, router } from '../trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const buzzWithdrawalRequestRouter = router({
   getPaginatedOwned: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getPaginatedOwnedBuzzWithdrawalRequestSchema)
     .use(isFlagProtected('creatorsProgram'))
     .query(getPaginatedOwnedBuzzWithdrawalRequestsHandler),
@@ -27,10 +29,12 @@ export const buzzWithdrawalRequestRouter = router({
     .use(isFlagProtected('creatorsProgram'))
     .query(getPaginatedBuzzWithdrawalRequestsHandler),
   create: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(createBuzzWithdrawalRequestSchema)
     .use(isFlagProtected('creatorsProgram'))
     .mutation(createBuzzWithdrawalRequestHandler),
   cancel: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(getByIdStringSchema)
     .use(isFlagProtected('creatorsProgram'))
     .mutation(cancelBuzzWithdrawalRequestHandler),
@@ -38,17 +42,19 @@ export const buzzWithdrawalRequestRouter = router({
     .input(updateBuzzWithdrawalRequestSchema)
     .use(isFlagProtected('creatorsProgram'))
     .mutation(updateBuzzWithdrawalRequestHandler),
-  getServiceStatus: protectedProcedure.query(async () => {
-    const status = buzzWithdrawalRequestServiceStatusSchema.parse(
-      JSON.parse(
-        (await sysRedis.hGet(
-          REDIS_SYS_KEYS.SYSTEM.FEATURES,
-          REDIS_SYS_KEYS.BUZZ_WITHDRAWAL_REQUEST.STATUS
-        )) ?? '{}'
-      )
-    );
+  getServiceStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(async () => {
+      const status = buzzWithdrawalRequestServiceStatusSchema.parse(
+        JSON.parse(
+          (await sysRedis.hGet(
+            REDIS_SYS_KEYS.SYSTEM.FEATURES,
+            REDIS_SYS_KEYS.BUZZ_WITHDRAWAL_REQUEST.STATUS
+          )) ?? '{}'
+        )
+      );
 
-    return status as BuzzWithdrawalRequestServiceStatus;
-  }),
+      return status as BuzzWithdrawalRequestServiceStatus;
+    }),
   // update:
 });

--- a/src/server/routers/buzz.router.ts
+++ b/src/server/routers/buzz.router.ts
@@ -36,66 +36,93 @@ import {
   getUserBuzzAccounts,
 } from '~/server/services/buzz.service';
 import { guardedProcedure, isFlagProtected, protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const buzzProcedure = protectedProcedure.use(isFlagProtected('buzz'));
 
 export const buzzRouter = router({
-  getUserAccount: buzzProcedure.query(getUserAccountHandler),
+  getUserAccount: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
+    .query(getUserAccountHandler),
   // getBuzzAccount: buzzProcedure.input(getBuzzAccountSchema).query(getBuzzAccountHandler),
-  getBuzzAccount: buzzProcedure.query(({ ctx }) => getUserBuzzAccounts({ userId: ctx.user.id })),
+  getBuzzAccount: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
+    .query(({ ctx }) => getUserBuzzAccounts({ userId: ctx.user.id })),
   // TODO.buzz: add another endpoint only available for mods to fetch transactions from other users
   getUserTransactions: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(getUserBuzzTransactionsSchema)
     .query(getUserTransactionsHandler),
   tipUser: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialTip, blockApiKeys: true })
     .use(isFlagProtected('buzz'))
     .input(userBuzzTransactionInputSchema)
     .mutation(createBuzzTipTransactionHandler),
   completeStripeBuzzPurchase: buzzProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(completeStripeBuzzPurchaseTransactionInput)
     .mutation(completeStripeBuzzPurchaseHandler),
   getAccountTransactions: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(getBuzzAccountTransactionsSchema)
     .query(getBuzzAccountTransactionsHandler),
   withdrawClubFunds: buzzProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(clubTransactionSchema)
     .use(isFlagProtected('clubs'))
     .mutation(withdrawClubFundsHandler),
   depositClubFunds: buzzProcedure
+    .meta({ blockApiKeys: true })
     .input(clubTransactionSchema)
     .use(isFlagProtected('clubs'))
     .mutation(depositClubFundsHandler),
   getClaimStatus: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(getByIdStringSchema)
     .query(({ input, ctx }) => getClaimStatus({ ...input, userId: ctx.user.id })),
   claim: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(getByIdStringSchema)
     .mutation(({ input, ctx }) => claimBuzz({ ...input, userId: ctx.user.id })),
-  getUserMultipliers: buzzProcedure.query(getUserMultipliersHandler),
-  claimDailyBoostReward: buzzProcedure.mutation(claimDailyBoostRewardHandler),
-  getEarnPotential: buzzProcedure.input(getEarnPotentialSchema).query(({ input, ctx }) => {
-    if (!ctx.user.isModerator) input.userId = ctx.user.id;
-    if (!input.username && !input.userId) input.userId = ctx.user.id;
-    return getEarnPotential(input);
-  }),
-  getPoolForecast: buzzProcedure.input(getEarnPotentialSchema).query(({ input, ctx }) => {
-    if (!ctx.user.isModerator) input.userId = ctx.user.id;
-    if (!input.username && !input.userId) input.userId = ctx.user.id;
-    return getPoolForecast(input);
-  }),
+  getUserMultipliers: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
+    .query(getUserMultipliersHandler),
+  claimDailyBoostReward: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
+    .mutation(claimDailyBoostRewardHandler),
+  getEarnPotential: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
+    .input(getEarnPotentialSchema)
+    .query(({ input, ctx }) => {
+      if (!ctx.user.isModerator) input.userId = ctx.user.id;
+      if (!input.username && !input.userId) input.userId = ctx.user.id;
+      return getEarnPotential(input);
+    }),
+  getPoolForecast: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
+    .input(getEarnPotentialSchema)
+    .query(({ input, ctx }) => {
+      if (!ctx.user.isModerator) input.userId = ctx.user.id;
+      if (!input.username && !input.userId) input.userId = ctx.user.id;
+      return getPoolForecast(input);
+    }),
   getDailyBuzzCompensation: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(getDailyBuzzCompensationInput)
     .query(getDailyCompensationRewardHandler),
   claimWatchedAdReward: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(claimWatchedAdRewardSchema)
     .mutation(({ input, ctx }) =>
       claimWatchedAdReward({ ...input, userId: ctx.user.id, ip: ctx.ip })
     ),
   getTransactionsReport: protectedProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(getTransactionsReportSchema)
     .query(getTransactionsReportHandler),
   // Multi-account transaction endpoints
   previewMultiAccountTransaction: buzzProcedure
+    .meta({ requiredScope: TokenScope.BuzzRead })
     .input(previewMultiAccountTransactionInput.omit({ fromAccountId: true }))
     .query(previewMultiAccountTransactionHandler),
 });

--- a/src/server/routers/challenge.router.ts
+++ b/src/server/routers/challenge.router.ts
@@ -61,65 +61,76 @@ import {
   playgroundPickWinners,
 } from '~/server/services/challenge.service';
 import { getJudgeCommentForImage } from '~/server/services/commentsv2.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 // Router definition
 export const challengeRouter = router({
   // Get paginated list of challenges
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getInfiniteChallengesSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input, ctx }) => getInfiniteChallenges({ ...input, currentUserId: ctx.user?.id })),
 
   // Get single challenge by ID (public — sensitive fields stripped)
   getById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input }) => getChallengeDetail(input.id)),
 
   // Get upcoming challenge themes for preview widget
   getUpcomingThemes: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getUpcomingThemesSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input }) => getUpcomingThemes(input.count)),
 
   // Get challenge winners
   getWinners: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getChallengeWinnersSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input }) => getChallengeWinners(input.challengeId)),
 
   // Get completed challenges with inline winners for previous winners page
   getCompletedWithWinners: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getCompletedChallengesWithWinnersSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input }) => getCompletedChallengesWithWinners(input)),
 
   // Get winner cooldown status for current user on a challenge
   getWinnerCooldownStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getWinnerCooldownStatusSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input, ctx }) => getWinnerCooldownStatus(input.challengeId, ctx.user.id)),
 
   // Get current user's entry count for a challenge
   getUserEntryCount: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getUserEntryCountSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input, ctx }) => getUserEntryCount(input.challengeId, ctx.user.id)),
 
   // Pay to guarantee entries get reviewed by the AI judge
   requestReview: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite, blockApiKeys: true })
     .input(requestReviewSchema)
     .use(isFlagProtected('challengePlatform'))
     .mutation(({ input, ctx }) => requestReview(input.challengeId, input.imageIds, ctx.user.id)),
 
   // Get user's unjudged entries for paid review selection
   getUserUnjudgedEntries: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getUserUnjudgedEntriesSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input, ctx }) => getUserUnjudgedEntries(input.challengeId, ctx.user.id)),
 
   // Check image eligibility for a challenge
   checkEntryEligibility: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(checkEntryEligibilitySchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input }) => checkImageEligibility(input.challengeId, input.imageIds)),
@@ -178,6 +189,7 @@ export const challengeRouter = router({
 
   // Public: Get active challenge events for featured section
   getActiveEvents: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .use(isFlagProtected('challengePlatform'))
     .query(() => getActiveEvents()),
 
@@ -201,6 +213,7 @@ export const challengeRouter = router({
 
   // Public: Get judge's comment on a specific image
   getJudgeComment: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ imageId: z.number(), judgeUserId: z.number() }))
     .use(isFlagProtected('challengePlatform'))
     .query(({ input }) => getJudgeCommentForImage(input)),

--- a/src/server/routers/changelog.router.ts
+++ b/src/server/routers/changelog.router.ts
@@ -15,9 +15,11 @@ import {
   updateChangelog,
 } from '~/server/services/changelog.service';
 import { isFlagProtected, moderatorProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const changelogRouter = router({
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getChangelogsInput)
     .use(applyRequestDomainColor)
     .query(({ input, ctx }) =>
@@ -39,10 +41,12 @@ export const changelogRouter = router({
     .use(isFlagProtected('changelogEdit'))
     .mutation(({ input }) => deleteChangelog(input)),
   getAllTags: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getChangelogsInput.pick({ domain: true }).optional())
     .use(applyRequestDomainColor)
     .query(({ input }) => getAllTags(input)),
   getLatest: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getChangelogsInput.pick({ domain: true }).optional())
     .use(applyRequestDomainColor)
     .use(edgeCacheIt({ ttl: CacheTTL.xs }))

--- a/src/server/routers/chat.router.ts
+++ b/src/server/routers/chat.router.ts
@@ -21,23 +21,51 @@ import {
   userSettingsChat,
 } from '~/server/schema/chat.schema';
 import { guardedProcedure, protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 // nb: muted users can perform read actions but no communication actions (except responding to mod chat)
 
 export const chatRouter = router({
-  getUserSettings: protectedProcedure.query(getUserSettingsHandler),
-  setUserSettings: protectedProcedure.input(userSettingsChat).mutation(setUserSettingsHandler),
-  getAllByUser: protectedProcedure.query(getChatsForUserHandler),
-  createChat: guardedProcedure.input(createChatInput).mutation(createChatHandler),
+  getUserSettings: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserSettingsHandler),
+  setUserSettings: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(userSettingsChat)
+    .mutation(setUserSettingsHandler),
+  getAllByUser: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getChatsForUserHandler),
+  createChat: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(createChatInput)
+    .mutation(createChatHandler),
   // addUser: guardedProcedure.input(addUsersInput).mutation(addUsersHandler),
-  modifyUser: protectedProcedure.input(modifyUserInput).mutation(modifyUserHandler),
-  markAllAsRead: protectedProcedure.mutation(markAllAsReadHandler),
+  modifyUser: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(modifyUserInput)
+    .mutation(modifyUserHandler),
+  markAllAsRead: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .mutation(markAllAsReadHandler),
   getInfiniteMessages: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getInfiniteMessagesInput)
     .query(getInfiniteMessagesHandler),
-  getMessageById: protectedProcedure.input(getMessageByIdInput).query(getMessageByIdHandler),
-  createMessage: protectedProcedure.input(createMessageInput).mutation(createMessageHandler),
+  getMessageById: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getMessageByIdInput)
+    .query(getMessageByIdHandler),
+  createMessage: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(createMessageInput)
+    .mutation(createMessageHandler),
   // updateMessage: guardedProcedure.input(updateMessageInput).mutation(updateMessageHandler),
-  isTyping: protectedProcedure.input(isTypingInput).mutation(isTypingHandler),
-  getUnreadCount: protectedProcedure.query(getUnreadMessagesForUserHandler),
+  isTyping: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(isTypingInput)
+    .mutation(isTypingHandler),
+  getUnreadCount: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUnreadMessagesForUserHandler),
 });

--- a/src/server/routers/club.router.ts
+++ b/src/server/routers/club.router.ts
@@ -25,53 +25,70 @@ import {
   userContributingClubsHandler,
 } from '~/server/controllers/club.controller';
 import { getByEntitySchema, getByIdSchema } from '~/server/schema/base.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const clubRouter = router({
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getInfiniteClubSchema)
     .use(isFlagProtected('clubs'))
     .query(getInfiniteClubsHandler),
-  getById: publicProcedure.input(getByIdSchema).use(isFlagProtected('clubs')).query(getClubHandler),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getByIdSchema)
+    .use(isFlagProtected('clubs'))
+    .query(getClubHandler),
   userContributingClubs: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .use(isFlagProtected('clubs'))
     .query(userContributingClubsHandler),
   upsert: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(upsertClubInput)
     .use(isFlagProtected('createClubs'))
     .mutation(upsertClubHandler),
   getTiers: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getClubTiersInput)
     .use(isFlagProtected('clubs'))
     .query(getClubTiersHandler),
   upsertTier: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(upsertClubTierInput)
     .use(isFlagProtected('clubs'))
     .mutation(upsertClubTierHandler),
   deleteTier: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('clubs'))
     .mutation(deleteClubTierHandler),
   upsertResource: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(upsertClubResourceInput)
     .use(isFlagProtected('clubs'))
     .mutation(upsertClubResourceHandler),
   updateResource: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(updateClubResourceInput)
     .use(isFlagProtected('clubs'))
     .mutation(updateClubResourceHandler),
   removeResource: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(removeClubResourceInput)
     .use(isFlagProtected('clubs'))
     .mutation(removeClubResourceHandler),
   resourceDetails: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getByEntitySchema)
     .use(isFlagProtected('clubs'))
     .query(getClubResourceDetailsHandler),
   getPaginatedClubResources: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getPaginatedClubResourcesSchema)
     .use(isFlagProtected('clubs'))
     .query(getPaginatedClubResourcesHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('createClubs'))
     .mutation(deleteClubHandler),

--- a/src/server/routers/clubAdmin.router.ts
+++ b/src/server/routers/clubAdmin.router.ts
@@ -19,6 +19,7 @@ import {
 } from '~/server/controllers/clubAdmin.controller';
 import { throwAuthorizationError, throwBadRequestError } from '../utils/errorHandling';
 import { userContributingClubs } from '../services/club.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, input, next }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -44,35 +45,42 @@ const isOwnerOrModerator = middleware(async ({ ctx, input, next }) => {
 
 export const clubAdminRouter = router({
   getInvitesPaged: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getPagedClubAdminInviteSchema)
     .use(isFlagProtected('clubs'))
     .use(isOwnerOrModerator)
     .query(getPagedClubAdminInvitesHandler),
   getAdminsPaged: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getPagedClubAdminSchema)
     .use(isFlagProtected('clubs'))
     .use(isOwnerOrModerator)
     .query(getPagedClubAdminsHandler),
   upsertInvite: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(upsertClubAdminInviteInput)
     .use(isFlagProtected('clubs'))
     .use(isOwnerOrModerator)
     .mutation(upsertClubAdminInviteHandler),
   deleteInvite: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(deleteClubAdminInviteInput)
     .use(isFlagProtected('clubs'))
     .use(isOwnerOrModerator)
     .mutation(deleteClubAdminInviteHandler),
   acceptInvite: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(acceptClubAdminInviteInput)
     .use(isFlagProtected('clubs'))
     .mutation(acceptClubAdminInviteHandler),
   update: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(updateClubAdminInput)
     .use(isFlagProtected('clubs'))
     .use(isOwnerOrModerator)
     .mutation(updateClubAdminHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(deleteClubAdminInput)
     .use(isFlagProtected('clubs'))
     .use(isOwnerOrModerator)

--- a/src/server/routers/clubMembership.router.ts
+++ b/src/server/routers/clubMembership.router.ts
@@ -1,4 +1,5 @@
 import { isFlagProtected, protectedProcedure, router } from '../trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 import {
   toggleClubMembershipStatusInput,
   clubMembershipOnClubInput,
@@ -20,34 +21,42 @@ import {
 
 export const clubMembershipRouter = router({
   getInfinite: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getInfiniteClubMembershipsSchema)
     .use(isFlagProtected('clubs'))
     .query(getInfiniteClubMembershipsHandler),
   createClubMembership: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(createClubMembershipInput)
     .use(isFlagProtected('clubs'))
     .mutation(createClubMembershipHandler),
   updateClubMembership: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(updateClubMembershipInput)
     .use(isFlagProtected('clubs'))
     .mutation(updateClubMembershipHandler),
   getClubMembershipOnClub: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(clubMembershipOnClubInput)
     .use(isFlagProtected('clubs'))
     .query(getClubMembershipOnClubHandler),
   removeAndRefundMember: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(ownerRemoveClubMembershipInput)
     .use(isFlagProtected('clubs'))
     .mutation(removeAndRefundMemberHandler),
   togglePauseBilling: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(ownerRemoveClubMembershipInput)
     .use(isFlagProtected('clubs'))
     .mutation(clubOwnerTogglePauseBillingHandler),
   cancelClubMembership: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(toggleClubMembershipStatusInput)
     .use(isFlagProtected('clubs'))
     .mutation(cancelClubMembershipHandler),
   restoreClubMembership: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(toggleClubMembershipStatusInput)
     .use(isFlagProtected('clubs'))
     .mutation(restoreClubMembershipHandler),

--- a/src/server/routers/clubPost.router.ts
+++ b/src/server/routers/clubPost.router.ts
@@ -13,25 +13,31 @@ import {
   getResourceDetailsForClubPostCreationHandler,
   upsertClubPostHandler,
 } from '~/server/controllers/clubPost.controller';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const clubPostRouter = router({
   getById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .use(isFlagProtected('clubs'))
     .query(getClubPostByIdHandler),
   getInfiniteClubPosts: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getInfiniteClubPostsSchema)
     .use(isFlagProtected('clubs'))
     .query(getInfiniteClubPostsHandler),
   upsertClubPost: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(upsertClubPostInput)
     .use(isFlagProtected('clubs'))
     .mutation(upsertClubPostHandler),
   resourcePostCreateDetails: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(clubPostResourceInput)
     .use(isFlagProtected('clubs'))
     .query(getResourceDetailsForClubPostCreationHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('clubs'))
     .mutation(deleteClubPostHandler),

--- a/src/server/routers/coinbase.router.ts
+++ b/src/server/routers/coinbase.router.ts
@@ -5,14 +5,17 @@ import {
 } from '~/server/controllers/coinbase.controller';
 import { createBuzzChargeSchema, createCodeOrderSchema } from '~/server/schema/coinbase.schema';
 import { isFlagProtected, protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const coinbaseRouter = router({
-  getStatus: protectedProcedure.query(getStatus),
+  getStatus: protectedProcedure.meta({ requiredScope: TokenScope.Full }).query(getStatus),
   createBuzzOrder: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(createBuzzChargeSchema)
     .use(isFlagProtected('coinbasePayments'))
     .mutation(createBuzzOrderHandler),
   createCodeOrder: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(createCodeOrderSchema)
     .use(isFlagProtected('coinbasePayments'))
     .mutation(createCodeOrderHandler),

--- a/src/server/routers/collection.router.ts
+++ b/src/server/routers/collection.router.ts
@@ -53,6 +53,7 @@ import {
 } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import { getYoutubeAuthUrl } from '~/server/youtube/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -80,74 +81,92 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 
 export const collectionRouter = router({
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getAllCollectionsInfiniteSchema)
     .use(isFlagProtected('profileCollections'))
     .query(getAllCollectionsInfiniteHandler),
   getAllUser: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getAllUserCollectionsInputSchema)
     .use(isFlagProtected('collections'))
     .query(getAllUserCollectionsHandler),
   getById: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getByIdSchema)
     .use(isFlagProtected('collections'))
     .query(getCollectionByIdHandler),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(upsertCollectionInput)
     .use(isOwnerOrModerator)
     .mutation(upsertCollectionHandler),
   updateCoverImage: guardedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(updateCollectionCoverImageInput)
     .mutation(updateCollectionCoverImageHandler),
   saveItem: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(saveCollectionItemInputSchema)
     .use(isFlagProtected('collections'))
     .mutation(saveItemHandler),
   follow: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(followCollectionInputSchema)
     .use(isFlagProtected('collections'))
     .mutation(followHandler),
   unfollow: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(followCollectionInputSchema)
     .use(isFlagProtected('collections'))
     .mutation(unfollowHandler),
   getUserCollectionItemsByItem: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getUserCollectionItemsByItemSchema)
     .use(isFlagProtected('collections'))
     .query(getUserCollectionItemsByItemHandler),
   getAllCollectionItems: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getAllCollectionItemsSchema)
     .use(isFlagProtected('collections'))
     .query(collectionItemsInfiniteHandler),
   updateCollectionItemsStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(updateCollectionItemsStatusInput)
     .use(isFlagProtected('collections'))
     .mutation(updateCollectionItemsStatusHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('collections'))
     .use(isOwnerOrModerator)
     .mutation(deleteUserCollectionHandler),
   bulkSaveItems: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(bulkSaveCollectionItemsInput)
     .use(isFlagProtected('collections'))
     .mutation(bulkSaveItemsHandler),
   addSimpleImagePost: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(addSimpleImagePostInput)
     .use(isFlagProtected('collections'))
     .mutation(addSimpleImagePostHandler),
   getPermissionDetails: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getCollectionPermissionDetails)
     .use(isFlagProtected('collections'))
     .query(getPermissionDetailsHandler),
   removeFromCollection: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(removeCollectionItemInput)
     .use(isFlagProtected('collections'))
     .mutation(removeCollectionItemHandler),
   setItemScore: guardedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(setItemScoreInput)
     .use(isFlagProtected('collections'))
     .mutation(setItemScoreHandler),
   updateCollectionItemNSFWLevel: guardedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(setCollectionItemNsfwLevelInput)
     .use(isFlagProtected('collections'))
     .mutation(setCollectionItemNsfwLevelHandler),
@@ -163,11 +182,13 @@ export const collectionRouter = router({
     .input(enableCollectionYoutubeSupportInput)
     .mutation(enableCollectionYoutubeSupportHandler),
   getEntryCount: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
     .input(getByIdSchema)
     .query(({ input, ctx }: { input: GetByIdInput; ctx: { user: { id: number } } }) => {
       return getCollectionEntryCount({ collectionId: input.id, userId: ctx.user.id });
     }),
   joinCollectionAsManager: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(getByIdSchema)
     .mutation(joinCollectionAsManagerHandler),
 });

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -94,6 +94,7 @@ import { getImageUploadBackend } from '~/utils/s3-utils';
 import { registerMediaLocation } from '~/server/services/storage-resolver';
 import { env } from '~/env/server';
 import { randomUUID } from 'crypto';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 // Feature flag gate — all procedures require the comicCreator flag
 const comicFlag = isFlagProtected('comicCreator');
@@ -198,7 +199,9 @@ const DEFAULT_COMIC_MODEL = 'NanoBanana2';
 const DEFAULT_ASPECT_RATIO = '3:4';
 
 function getComicModelConfig(baseModel?: string | null) {
-  return COMIC_MODEL_CONFIG[baseModel ?? DEFAULT_COMIC_MODEL] ?? COMIC_MODEL_CONFIG[DEFAULT_COMIC_MODEL];
+  return (
+    COMIC_MODEL_CONFIG[baseModel ?? DEFAULT_COMIC_MODEL] ?? COMIC_MODEL_CONFIG[DEFAULT_COMIC_MODEL]
+  );
 }
 
 function getAspectRatioDimensions(
@@ -262,9 +265,7 @@ async function submitComicGeneration({
   });
 
   const versionId = versionIdOverride ?? modelConfig.versionId;
-  const cappedImages = images
-    ? capReferenceImages(images, modelConfig.maxReferenceImages)
-    : null;
+  const cappedImages = images ? capReferenceImages(images, modelConfig.maxReferenceImages) : null;
 
   const tags = isGreen ? ['comics', 'green'] : ['comics'];
 
@@ -307,7 +308,10 @@ async function submitComicGeneration({
  * On green: logged-in users see PG + PG13; logged-out users see PG only.
  */
 function stripNsfwPanelImages(
-  chapters: { nsfwLevel: number; panels: { imageUrl: string | null; image?: { nsfwLevel: number } | null }[] }[],
+  chapters: {
+    nsfwLevel: number;
+    panels: { imageUrl: string | null; image?: { nsfwLevel: number } | null }[];
+  }[],
   loggedIn: boolean
 ) {
   const passesSfwGate = loggedIn ? hasSafeBrowsingLevel : hasPublicBrowsingLevel;
@@ -317,8 +321,8 @@ function stripNsfwPanelImages(
       const panelNsfw = panel.image
         ? !passesSfwGate(panel.image.nsfwLevel)
         : panel.imageUrl
-          ? true // Has image URL but no Image record — assume NSFW to be safe
-          : chapterHasNsfw;
+        ? true // Has image URL but no Image record — assume NSFW to be safe
+        : chapterHasNsfw;
       if (panelNsfw && panel.imageUrl) {
         (panel as any).imageUrl = null;
       }
@@ -378,9 +382,7 @@ function sendComicPanelSignal(
     imageUrl?: string | null;
   }
 ) {
-  signalClient
-    .send({ userId, target: SignalMessages.ComicPanelUpdate, data })
-    .catch(() => {}); // Fire-and-forget
+  signalClient.send({ userId, target: SignalMessages.ComicPanelUpdate, data }).catch(() => {}); // Fire-and-forget
 }
 
 // Middleware to check project ownership
@@ -622,7 +624,7 @@ const bulkCreatePanelsSchema = z.object({
       z.object({
         // For generation mode (text prompt -> image)
         prompt: z.string().max(2000).optional(),
-              // For upload/enhance mode (source image -> comic panel)
+        // For upload/enhance mode (source image -> comic panel)
         sourceImageUrl: z.string().optional(),
         sourceImageWidth: z.number().int().positive().optional(),
         sourceImageHeight: z.number().int().positive().optional(),
@@ -720,7 +722,9 @@ async function assertCanGrantEarlyAccess({
   }
   if (timeframe > maxDays) {
     throw throwBadRequestError(
-      `Early access timeframe exceeds your current limit of ${maxDays} day${maxDays === 1 ? '' : 's'}.`
+      `Early access timeframe exceeds your current limit of ${maxDays} day${
+        maxDays === 1 ? '' : 's'
+      }.`
     );
   }
   const active = await getUserEarlyAccessChapters(ctx.user.id);
@@ -728,9 +732,7 @@ async function assertCanGrantEarlyAccess({
     userMeta: ctx.user.meta as any,
     features: ctx.features,
   });
-  const otherActive = excludeChapterId
-    ? active.filter((c) => c.id !== excludeChapterId)
-    : active;
+  const otherActive = excludeChapterId ? active.filter((c) => c.id !== excludeChapterId) : active;
   if (otherActive.length >= maxActive) {
     throw throwBadRequestError(
       `You already have ${otherActive.length} chapter${
@@ -939,71 +941,74 @@ async function createSinglePanel(args: {
 
 export const comicsRouter = router({
   // Projects
-  getMyProjects: comicProtectedProcedure.query(async ({ ctx }) => {
-    const projects = await dbRead.comicProject.findMany({
-      where: {
-        userId: ctx.user.id,
-        status: ComicProjectStatus.Active,
-      },
-      include: {
-        coverImage: { select: { id: true, url: true, nsfwLevel: true } },
-        heroImage: { select: { id: true, url: true, nsfwLevel: true } },
-        chapters: {
-          include: {
-            _count: { select: { panels: true } },
-            panels: {
-              take: 1,
-              orderBy: { position: 'asc' },
-              select: { imageUrl: true },
-            },
-          },
-          orderBy: { position: 'asc' },
+  getMyProjects: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .query(async ({ ctx }) => {
+      const projects = await dbRead.comicProject.findMany({
+        where: {
+          userId: ctx.user.id,
+          status: ComicProjectStatus.Active,
         },
-      },
-      orderBy: { updatedAt: 'desc' },
-    });
+        include: {
+          coverImage: { select: { id: true, url: true, nsfwLevel: true } },
+          heroImage: { select: { id: true, url: true, nsfwLevel: true } },
+          chapters: {
+            include: {
+              _count: { select: { panels: true } },
+              panels: {
+                take: 1,
+                orderBy: { position: 'asc' },
+                select: { imageUrl: true },
+              },
+            },
+            orderBy: { position: 'asc' },
+          },
+        },
+        orderBy: { updatedAt: 'desc' },
+      });
 
-    return projects.map((p) => {
-      const panelCount = p.chapters.reduce((sum, ch) => sum + ch._count.panels, 0);
-      const thumbnailUrl =
-        p.chapters.flatMap((ch) => ch.panels).find((panel) => panel.imageUrl)?.imageUrl ?? null;
+      return projects.map((p) => {
+        const panelCount = p.chapters.reduce((sum, ch) => sum + ch._count.panels, 0);
+        const thumbnailUrl =
+          p.chapters.flatMap((ch) => ch.panels).find((panel) => panel.imageUrl)?.imageUrl ?? null;
 
-      // On green, strip NSFW cover/hero/thumbnail images so the card is still
-      // visible and navigable but doesn't display mature imagery. This route is
-      // protected so the viewer is always logged in — allow PG + PG13.
-      const coverImage =
-        ctx.features.isGreen && p.coverImage && !hasSafeBrowsingLevel(p.coverImage.nsfwLevel)
-          ? null
-          : p.coverImage;
-      const heroImage =
-        ctx.features.isGreen && p.heroImage && !hasSafeBrowsingLevel(p.heroImage.nsfwLevel)
-          ? null
-          : p.heroImage;
-      const safeThumbnailUrl =
-        ctx.features.isGreen && Flags.intersects(p.nsfwLevel, nsfwBrowsingLevelsFlag)
-          ? null
-          : thumbnailUrl;
+        // On green, strip NSFW cover/hero/thumbnail images so the card is still
+        // visible and navigable but doesn't display mature imagery. This route is
+        // protected so the viewer is always logged in — allow PG + PG13.
+        const coverImage =
+          ctx.features.isGreen && p.coverImage && !hasSafeBrowsingLevel(p.coverImage.nsfwLevel)
+            ? null
+            : p.coverImage;
+        const heroImage =
+          ctx.features.isGreen && p.heroImage && !hasSafeBrowsingLevel(p.heroImage.nsfwLevel)
+            ? null
+            : p.heroImage;
+        const safeThumbnailUrl =
+          ctx.features.isGreen && Flags.intersects(p.nsfwLevel, nsfwBrowsingLevelsFlag)
+            ? null
+            : thumbnailUrl;
 
-      return {
-        id: p.id,
-        name: p.name,
-        description: p.description,
-        coverImage,
-        heroImage,
-        nsfwLevel: p.nsfwLevel,
-        panelCount,
-        thumbnailUrl: safeThumbnailUrl,
-        createdAt: p.createdAt,
-        updatedAt: p.updatedAt,
-      };
-    });
-  }),
+        return {
+          id: p.id,
+          name: p.name,
+          description: p.description,
+          coverImage,
+          heroImage,
+          nsfwLevel: p.nsfwLevel,
+          panelCount,
+          thumbnailUrl: safeThumbnailUrl,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+        };
+      });
+    }),
 
   // Lightweight project shell — project metadata + references + chapter list
   // with precomputed `panelCount` / `hasInProgressPanels`, but NO full panel
   // rows. Use this when the page only needs the chapter list (sidebar, model
   // info, references) and will load actual panels through `getChapter`.
   getProjectShell: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getProjectSchema)
     .query(async ({ ctx, input }) => {
       const project = await dbWrite.comicProject.findUnique({
@@ -1076,6 +1081,7 @@ export const comicsRouter = router({
 
   // Full panel data for a single chapter. Pair with `getProjectShell`.
   getChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getChapterSchema)
     .query(async ({ ctx, input }) => {
       // Owner check via the parent project — chapters don't store userId.
@@ -1115,6 +1121,7 @@ export const comicsRouter = router({
     }),
 
   getProjectForReader: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getProjectSchema)
     .query(async ({ ctx, input }) => {
       const project = await dbRead.comicProject.findUnique({
@@ -1177,6 +1184,7 @@ export const comicsRouter = router({
 
   // Public queries — no auth required
   getPublicProjects: comicPublicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(
       z.object({
         limit: z.number().int().min(1).max(50).default(20),
@@ -1241,8 +1249,7 @@ export const comicsRouter = router({
       // against this cap, so a hand-crafted request with a higher level
       // can't bypass the domain rule.
       const greenCap = ctx.user ? sfwBrowsingLevelsFlag : publicBrowsingLevelsFlag;
-      const requested =
-        browsingLevel != null && browsingLevel > 0 ? browsingLevel : null;
+      const requested = browsingLevel != null && browsingLevel > 0 ? browsingLevel : null;
       const effectiveBrowsingLevel = ctx.features.isGreen
         ? requested != null
           ? requested & greenCap
@@ -1429,6 +1436,7 @@ export const comicsRouter = router({
     }),
 
   getPublicProjectForReader: comicPublicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ id: z.number().int() }))
     .query(async ({ input, ctx }) => {
       const isOwnerOrMod = ctx.user != null;
@@ -1631,6 +1639,7 @@ export const comicsRouter = router({
    * - Smart create (bulk panels)
    */
   getGenerationCostEstimate: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(
       z
         .object({
@@ -1774,27 +1783,30 @@ export const comicsRouter = router({
       }
     }),
 
-  getPromptEnhanceCostEstimate: comicProtectedProcedure.query(async ({ ctx }) => {
-    try {
-      const token = await getOrchestratorToken(ctx.user.id, ctx);
-      return orchestratorChatCompletionCost({
-        token,
-        model: 'gpt-4o-mini',
-        messages: [
-          { role: 'system', content: 'You enhance prompts.' },
-          { role: 'user', content: 'A sample prompt for cost estimation.' },
-        ],
-        maxTokens: 512,
-        currencies: getAllowedAccountTypes(ctx.features, ['blue']),
-      });
-    } catch (error) {
-      console.error('Comics getPromptEnhanceCostEstimate failed:', error);
-      return { cost: 0, ready: false };
-    }
-  }),
+  getPromptEnhanceCostEstimate: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(async ({ ctx }) => {
+      try {
+        const token = await getOrchestratorToken(ctx.user.id, ctx);
+        return orchestratorChatCompletionCost({
+          token,
+          model: 'gpt-4o-mini',
+          messages: [
+            { role: 'system', content: 'You enhance prompts.' },
+            { role: 'user', content: 'A sample prompt for cost estimation.' },
+          ],
+          maxTokens: 512,
+          currencies: getAllowedAccountTypes(ctx.features, ['blue']),
+        });
+      } catch (error) {
+        console.error('Comics getPromptEnhanceCostEstimate failed:', error);
+        return { cost: 0, ready: false };
+      }
+    }),
 
   /** Enhances a prompt via LLM and returns the enhanced text without generating an image. */
   enhancePromptText: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -1865,26 +1877,29 @@ export const comicsRouter = router({
       return { enhancedPrompt };
     }),
 
-  getPlanChapterCostEstimate: comicProtectedProcedure.query(async ({ ctx }) => {
-    try {
-      const token = await getOrchestratorToken(ctx.user.id, ctx);
-      return orchestratorChatCompletionCost({
-        token,
-        model: 'gpt-4o-mini',
-        messages: [
-          { role: 'system', content: 'You plan comic panels.' },
-          { role: 'user', content: 'A sample story for cost estimation.' },
-        ],
-        maxTokens: 2048,
-        currencies: getAllowedAccountTypes(ctx.features, ['blue']),
-      });
-    } catch (error) {
-      console.error('Comics getPlanChapterCostEstimate failed:', error);
-      return { cost: 0, ready: false };
-    }
-  }),
+  getPlanChapterCostEstimate: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(async ({ ctx }) => {
+      try {
+        const token = await getOrchestratorToken(ctx.user.id, ctx);
+        return orchestratorChatCompletionCost({
+          token,
+          model: 'gpt-4o-mini',
+          messages: [
+            { role: 'system', content: 'You plan comic panels.' },
+            { role: 'user', content: 'A sample story for cost estimation.' },
+          ],
+          maxTokens: 2048,
+          currencies: getAllowedAccountTypes(ctx.features, ['blue']),
+        });
+      } catch (error) {
+        console.error('Comics getPlanChapterCostEstimate failed:', error);
+        return { cost: 0, ready: false };
+      }
+    }),
 
   createProject: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(createProjectSchema)
     .mutation(async ({ ctx, input }) => {
       const project = await dbWrite.comicProject.create({
@@ -1940,6 +1955,7 @@ export const comicsRouter = router({
     }),
 
   deleteProject: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaDelete })
     .input(getProjectSchema)
     .mutation(async ({ ctx, input }) => {
       const project = await dbRead.comicProject.findUnique({
@@ -1963,6 +1979,7 @@ export const comicsRouter = router({
     }),
 
   updateProject: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updateProjectSchema)
     .mutation(async ({ ctx, input }) => {
       const project = await dbRead.comicProject.findUnique({
@@ -2027,6 +2044,7 @@ export const comicsRouter = router({
 
   // Chapters
   createChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(createChapterSchema)
     .use(isProjectOwner)
     .mutation(async ({ input }) => {
@@ -2050,6 +2068,7 @@ export const comicsRouter = router({
     }),
 
   updateChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updateChapterSchema)
     .mutation(async ({ ctx, input }) => {
       const chapter = await dbRead.comicChapter.findUnique({
@@ -2073,6 +2092,7 @@ export const comicsRouter = router({
     }),
 
   deleteChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaDelete })
     .input(deleteChapterSchema)
     .mutation(async ({ ctx, input }) => {
       const chapter = await dbRead.comicChapter.findUnique({
@@ -2108,7 +2128,10 @@ export const comicsRouter = router({
             if (remaining[i].position !== i) {
               await tx.comicChapter.update({
                 where: {
-                  projectId_position: { projectId: input.projectId, position: remaining[i].position },
+                  projectId_position: {
+                    projectId: input.projectId,
+                    position: remaining[i].position,
+                  },
                 },
                 data: { position: TEMP_OFFSET + i },
               });
@@ -2143,6 +2166,7 @@ export const comicsRouter = router({
     }),
 
   duplicatePanel: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(duplicatePanelSchema)
     .mutation(async ({ ctx, input }) => {
       const panel = await dbRead.comicPanel.findUnique({
@@ -2212,6 +2236,7 @@ export const comicsRouter = router({
     }),
 
   duplicateChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(duplicateChapterSchema)
     .use(isChapterOwner)
     .mutation(async ({ ctx, input }) => {
@@ -2266,7 +2291,12 @@ export const comicsRouter = router({
         // Phase 2: move from temp to final positions (+1)
         for (const ch of chaptersToShift) {
           await tx.comicChapter.update({
-            where: { projectId_position: { projectId: input.projectId, position: TEMP_OFFSET + ch.position } },
+            where: {
+              projectId_position: {
+                projectId: input.projectId,
+                position: TEMP_OFFSET + ch.position,
+              },
+            },
             data: { position: ch.position + 1 },
           });
         }
@@ -2321,6 +2351,7 @@ export const comicsRouter = router({
     }),
 
   reorderChapters: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(reorderChaptersSchema)
     .use(isProjectOwner)
     .mutation(async ({ input }) => {
@@ -2355,6 +2386,7 @@ export const comicsRouter = router({
   // References — single creation path (images added separately)
 
   createReference: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(createReferenceSchema)
     .mutation(async ({ ctx, input }) => {
       const reference = await dbWrite.comicReference.create({
@@ -2389,6 +2421,7 @@ export const comicsRouter = router({
 
   // Add reference images — creates Image records + join rows + triggers ingestion
   addReferenceImages: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(addReferenceImagesSchema)
     .mutation(async ({ ctx, input }) => {
       const reference = await dbRead.comicReference.findUnique({
@@ -2445,6 +2478,7 @@ export const comicsRouter = router({
 
   // Poll reference status — just return current status + images
   pollReferenceStatus: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ referenceId: z.number().int() }))
     .query(async ({ ctx, input }) => {
       // Use dbWrite for read-after-write consistency when polling after mutations
@@ -2475,6 +2509,7 @@ export const comicsRouter = router({
 
   // Panels — generation via createImageGen (model determined by project)
   createPanel: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(createPanelSchema)
     .use(isChapterOwner)
     .mutation(async ({ ctx, input }) => {
@@ -2612,10 +2647,7 @@ export const comicsRouter = router({
         await assertCanGenerate(token, ctx.user?.tier ?? 'free', 1);
       } catch (error) {
         // Re-throw known tRPC errors (e.g. queue full) as-is
-        if (
-          (error as any)?.code === 'BAD_REQUEST' ||
-          (error as any)?.code === 'TOO_MANY_REQUESTS'
-        )
+        if ((error as any)?.code === 'BAD_REQUEST' || (error as any)?.code === 'TOO_MANY_REQUESTS')
           throw error;
         throw throwBadRequestError(getOrchestratorErrorMessage(error));
       }
@@ -2763,31 +2795,35 @@ export const comicsRouter = router({
       }
     }),
 
-  updatePanel: comicProtectedProcedure.input(updatePanelSchema).mutation(async ({ ctx, input }) => {
-    // Verify ownership via chapter -> project
-    const panel = await dbRead.comicPanel.findUnique({
-      where: { id: input.panelId },
-      include: { chapter: { include: { project: { select: { userId: true } } } } },
-    });
+  updatePanel: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
+    .input(updatePanelSchema)
+    .mutation(async ({ ctx, input }) => {
+      // Verify ownership via chapter -> project
+      const panel = await dbRead.comicPanel.findUnique({
+        where: { id: input.panelId },
+        include: { chapter: { include: { project: { select: { userId: true } } } } },
+      });
 
-    if (!panel || panel.chapter.project.userId !== ctx.user.id) {
-      throw throwAuthorizationError();
-    }
+      if (!panel || panel.chapter.project.userId !== ctx.user.id) {
+        throw throwAuthorizationError();
+      }
 
-    const updated = await dbWrite.comicPanel.update({
-      where: { id: input.panelId },
-      data: {
-        status: input.status,
-        imageUrl: input.imageUrl,
-        civitaiJobId: input.civitaiJobId,
-        errorMessage: input.errorMessage,
-      },
-    });
+      const updated = await dbWrite.comicPanel.update({
+        where: { id: input.panelId },
+        data: {
+          status: input.status,
+          imageUrl: input.imageUrl,
+          civitaiJobId: input.civitaiJobId,
+          errorMessage: input.errorMessage,
+        },
+      });
 
-    return updated;
-  }),
+      return updated;
+    }),
 
   replacePanelImage: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(z.object({ panelId: z.number().int(), imageUrl: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const panel = await dbRead.comicPanel.findUnique({
@@ -2818,30 +2854,34 @@ export const comicsRouter = router({
       return updated;
     }),
 
-  deletePanel: comicProtectedProcedure.input(deletePanelSchema).mutation(async ({ ctx, input }) => {
-    // Verify ownership via chapter -> project
-    const panel = await dbRead.comicPanel.findUnique({
-      where: { id: input.panelId },
-      include: { chapter: { include: { project: { select: { userId: true } } } } },
-    });
+  deletePanel: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaDelete })
+    .input(deletePanelSchema)
+    .mutation(async ({ ctx, input }) => {
+      // Verify ownership via chapter -> project
+      const panel = await dbRead.comicPanel.findUnique({
+        where: { id: input.panelId },
+        include: { chapter: { include: { project: { select: { userId: true } } } } },
+      });
 
-    if (!panel || panel.chapter.project.userId !== ctx.user.id) {
-      throw throwAuthorizationError();
-    }
+      if (!panel || panel.chapter.project.userId !== ctx.user.id) {
+        throw throwAuthorizationError();
+      }
 
-    await dbWrite.comicPanel.delete({
-      where: { id: input.panelId },
-    });
+      await dbWrite.comicPanel.delete({
+        where: { id: input.panelId },
+      });
 
-    // Recalculate NSFW levels after panel removal
-    await updateComicNsfwLevels([panel.projectId]).catch((e) =>
-      console.error(`Failed to update NSFW levels after panel delete:`, e)
-    );
+      // Recalculate NSFW levels after panel removal
+      await updateComicNsfwLevels([panel.projectId]).catch((e) =>
+        console.error(`Failed to update NSFW levels after panel delete:`, e)
+      );
 
-    return { success: true };
-  }),
+      return { success: true };
+    }),
 
   reorderPanels: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(reorderPanelsSchema)
     .use(isChapterOwner)
     .mutation(async ({ input }) => {
@@ -2872,6 +2912,7 @@ export const comicsRouter = router({
 
   // Debug info for a panel's generation workflow
   getPanelDebugInfo: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ panelId: z.number().int() }))
     .query(async ({ ctx, input }) => {
       const panel = await dbRead.comicPanel.findUnique({
@@ -2990,6 +3031,7 @@ export const comicsRouter = router({
 
   // Poll panel generation status
   pollPanelStatus: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(z.object({ panelId: z.number().int() }))
     .query(async ({ ctx, input }) => {
       // Use dbWrite for read-after-write consistency when polling after mutations
@@ -3029,7 +3071,12 @@ export const comicsRouter = router({
         panel.status === ComicPanelStatus.Failed ||
         (panel.status === ComicPanelStatus.AwaitingSelection && !hasLockedCandidate)
       ) {
-        return { id: panel.id, status: panel.status, imageUrl: panel.imageUrl, errorMessage: panel.errorMessage };
+        return {
+          id: panel.id,
+          status: panel.status,
+          imageUrl: panel.imageUrl,
+          errorMessage: panel.errorMessage,
+        };
       }
 
       // Backstop timeout: orchestrator step timeout is 21 min, use 25 min as hard cap
@@ -3047,7 +3094,12 @@ export const comicsRouter = router({
           projectId: panel.projectId,
           status: updated.status,
         });
-        return { id: updated.id, status: updated.status, imageUrl: updated.imageUrl, errorMessage: updated.errorMessage };
+        return {
+          id: updated.id,
+          status: updated.status,
+          imageUrl: updated.imageUrl,
+          errorMessage: updated.errorMessage,
+        };
       }
 
       // Check orchestrator status
@@ -3329,12 +3381,15 @@ export const comicsRouter = router({
           let s3ImageKey: string;
           try {
             const imageResponse = await fetch(imageUrl);
-            if (!imageResponse.ok)
-              throw new Error(`Failed to download: ${imageResponse.status}`);
+            if (!imageResponse.ok) throw new Error(`Failed to download: ${imageResponse.status}`);
             const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
 
             s3ImageKey = randomUUID();
-            const { s3: s3Single, bucket: singleBucket, backend: singleBackend } = await getImageUploadBackend();
+            const {
+              s3: s3Single,
+              bucket: singleBucket,
+              backend: singleBackend,
+            } = await getImageUploadBackend();
             await s3Single.send(
               new PutObjectCommand({
                 Bucket: singleBucket,
@@ -3358,7 +3413,12 @@ export const comicsRouter = router({
               projectId: panel.projectId,
               status: ComicPanelStatus.Failed,
             });
-            return { id: panel.id, status: ComicPanelStatus.Failed, imageUrl: null, errorMessage: 'Image upload failed. Please regenerate.' };
+            return {
+              id: panel.id,
+              status: ComicPanelStatus.Failed,
+              imageUrl: null,
+              errorMessage: 'Image upload failed. Please regenerate.',
+            };
           }
 
           // Create Image record via standard pipeline (ingestion + flags)
@@ -3387,7 +3447,12 @@ export const comicsRouter = router({
             imageUrl: updated.imageUrl,
           });
 
-          return { id: updated.id, status: updated.status, imageUrl: updated.imageUrl, errorMessage: null };
+          return {
+            id: updated.id,
+            status: updated.status,
+            imageUrl: updated.imageUrl,
+            errorMessage: null,
+          };
         }
 
         if (workflow.status === 'succeeded' && !imageUrl) {
@@ -3405,7 +3470,12 @@ export const comicsRouter = router({
             status: updated.status,
             imageUrl: updated.imageUrl,
           });
-          return { id: updated.id, status: updated.status, imageUrl: updated.imageUrl, errorMessage: null };
+          return {
+            id: updated.id,
+            status: updated.status,
+            imageUrl: updated.imageUrl,
+            errorMessage: null,
+          };
         }
 
         if (workflow.status === 'failed' || workflow.status === 'canceled') {
@@ -3421,7 +3491,12 @@ export const comicsRouter = router({
             projectId: panel.projectId,
             status: updated.status,
           });
-          return { id: updated.id, status: updated.status, imageUrl: updated.imageUrl, errorMessage: updated.errorMessage };
+          return {
+            id: updated.id,
+            status: updated.status,
+            imageUrl: updated.imageUrl,
+            errorMessage: updated.errorMessage,
+          };
         }
       } catch (error) {
         // If we can't check the workflow, don't fail the poll - just return current state
@@ -3429,7 +3504,12 @@ export const comicsRouter = router({
       }
 
       // Still processing - return as-is
-      return { id: panel.id, status: panel.status, imageUrl: panel.imageUrl, errorMessage: panel.errorMessage };
+      return {
+        id: panel.id,
+        status: panel.status,
+        imageUrl: panel.imageUrl,
+        errorMessage: panel.errorMessage,
+      };
     }),
 
   // Lift the SFW-domain mature-content restriction on a single panel's
@@ -3726,6 +3806,7 @@ export const comicsRouter = router({
     }),
 
   selectPanelImage: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(
       z.object({
         panelId: z.number().int(),
@@ -3795,6 +3876,7 @@ export const comicsRouter = router({
 
   // Iterative panel editor — generate image without creating a panel record
   iterateGenerate: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(iterateGenerateSchema)
     .use(isProjectOwner)
     .mutation(async ({ ctx, input }) => {
@@ -3926,6 +4008,7 @@ export const comicsRouter = router({
 
   // Iterative panel editor — poll workflow status without panel involvement
   generateComicImage: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(
       z.object({
         prompt: z.string().min(1).max(2000),
@@ -3976,6 +4059,7 @@ export const comicsRouter = router({
     }),
 
   pollIterationStatus: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(
       z.object({
         workflowId: z.string().min(1),
@@ -3997,6 +4081,7 @@ export const comicsRouter = router({
 
   // Smart Create — Plan chapter panels via GPT
   planChapterPanels: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(planChapterPanelsSchema)
     .use(isProjectOwner)
     .mutation(async ({ ctx, input }) => {
@@ -4035,6 +4120,7 @@ export const comicsRouter = router({
 
   // Smart Create — Create chapter with all panels at once
   smartCreateChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(smartCreateChapterSchema)
     .use(isProjectOwner)
     .mutation(async ({ ctx, input }) => {
@@ -4088,16 +4174,17 @@ export const comicsRouter = router({
       });
       const projectRefIds = new Set(projectRefRows.map((r) => r.referenceId));
 
-      const projectRefs = projectRefIds.size > 0
-        ? await dbRead.comicReference.findMany({
-            where: {
-              id: { in: Array.from(projectRefIds) },
-              userId: ctx.user!.id,
-              status: ComicReferenceStatus.Ready,
-            },
-            select: { id: true, name: true },
-          })
-        : [];
+      const projectRefs =
+        projectRefIds.size > 0
+          ? await dbRead.comicReference.findMany({
+              where: {
+                id: { in: Array.from(projectRefIds) },
+                userId: ctx.user!.id,
+                status: ComicReferenceStatus.Ready,
+              },
+              select: { id: true, name: true },
+            })
+          : [];
 
       // Validate explicitly passed referenceIds belong to this project
       if (input.referenceIds && input.referenceIds.some((id) => !projectRefIds.has(id))) {
@@ -4110,10 +4197,7 @@ export const comicsRouter = router({
         prompt: input.storyDescription,
         references: projectRefs,
       });
-      const relevantRefIds = new Set([
-        ...storyMentionedIds,
-        ...(input.referenceIds ?? []),
-      ]);
+      const relevantRefIds = new Set([...storyMentionedIds, ...(input.referenceIds ?? [])]);
       const relevantRefs = projectRefs.filter((r) => relevantRefIds.has(r.id));
 
       // Pre-load reference images keyed by refId (only used for panels that @mention them)
@@ -4158,12 +4242,10 @@ export const comicsRouter = router({
           (id) => refImagesByRefId.get(id)?.images ?? []
         );
         const panelPrimaryRefName =
-          mentionedIds.length > 0
-            ? (refImagesByRefId.get(mentionedIds[0])?.referenceName ?? '')
-            : '';
-        const mentionedRefNames = mentionedIds.map(
-          (id) => refImagesByRefId.get(id)?.referenceName ?? ''
-        ).filter(Boolean);
+          mentionedIds.length > 0 ? refImagesByRefId.get(mentionedIds[0])?.referenceName ?? '' : '';
+        const mentionedRefNames = mentionedIds
+          .map((id) => refImagesByRefId.get(id)?.referenceName ?? '')
+          .filter(Boolean);
 
         // Submit immediately if slots are available, otherwise enqueue for the job
         const shouldEnqueue = remainingSlots <= 0;
@@ -4212,6 +4294,7 @@ export const comicsRouter = router({
   // ──── Phase 3: Publish/Unpublish ────
 
   publishChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -4287,10 +4370,11 @@ export const comicsRouter = router({
       // a config is set, so we have to write both this AND `availability`
       // — otherwise the paywall is invisible from the buyer's side.
       const eaActivatesAt = isScheduled ? input.scheduledAt! : new Date();
-      const earlyAccessEndsAt =
-        input.earlyAccessConfig
-          ? new Date(eaActivatesAt.getTime() + input.earlyAccessConfig.timeframe * 24 * 60 * 60 * 1000)
-          : null;
+      const earlyAccessEndsAt = input.earlyAccessConfig
+        ? new Date(
+            eaActivatesAt.getTime() + input.earlyAccessConfig.timeframe * 24 * 60 * 60 * 1000
+          )
+        : null;
 
       // Compute the next `availability`. When EA is being added we move
       // to `EarlyAccess`. When EA is being removed we revert to `Public`
@@ -4364,6 +4448,7 @@ export const comicsRouter = router({
     }),
 
   unpublishChapter: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(z.object({ projectId: z.number().int(), chapterPosition: z.number().int().min(0) }))
     .use(isChapterOwner)
     .mutation(async ({ ctx, input }) => {
@@ -4419,6 +4504,7 @@ export const comicsRouter = router({
     }),
 
   purchaseChapterAccess: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite, blockApiKeys: true })
     .input(
       z.object({
         chapterId: z.number().int(),
@@ -4520,6 +4606,7 @@ export const comicsRouter = router({
     }),
 
   updateChapterEarlyAccess: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -4611,6 +4698,7 @@ export const comicsRouter = router({
   // ──── Moderator Tools ────
 
   setTosViolation: comicModeratorProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(z.object({ id: z.number().int() }))
     .mutation(async ({ ctx, input }) => {
       const project = await dbRead.comicProject.findUnique({
@@ -4658,7 +4746,13 @@ export const comicsRouter = router({
     }),
 
   setProjectNsfwLevel: comicModeratorProcedure
-    .input(z.object({ id: z.number().int(), nsfwLevel: z.number().refine((n) => [1, 2, 4, 8, 16, 32].includes(n), 'Invalid NSFW level') }))
+    .meta({ requiredScope: TokenScope.Full })
+    .input(
+      z.object({
+        id: z.number().int(),
+        nsfwLevel: z.number().refine((n) => [1, 2, 4, 8, 16, 32].includes(n), 'Invalid NSFW level'),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       // Stamp every panel image with the moderator's chosen level. The
       // schema accepts only single-bit values (PG / PG-13 / R / X / XXX /
@@ -4694,6 +4788,7 @@ export const comicsRouter = router({
     }),
 
   setChapterNsfwLevel: comicModeratorProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -4734,6 +4829,7 @@ export const comicsRouter = router({
     }),
 
   moderatorUnpublishChapter: comicModeratorProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -4786,6 +4882,7 @@ export const comicsRouter = router({
   // ──── Phase 3: Comic Engagement (Follow/Hide) ────
 
   toggleComicEngagement: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -4832,6 +4929,7 @@ export const comicsRouter = router({
     }),
 
   getComicEngagement: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ projectId: z.number().int() }))
     .query(async ({ ctx, input }) => {
       const engagement = await dbRead.comicProjectEngagement.findUnique({
@@ -4844,6 +4942,7 @@ export const comicsRouter = router({
   // ──── Phase 3: Chapter Read Tracking (via engagement readChapters) ────
 
   markChapterRead: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(z.object({ projectId: z.number().int(), chapterPosition: z.number().int().min(0) }))
     .mutation(async ({ ctx, input }) => {
       const { projectId, chapterPosition } = input;
@@ -4861,6 +4960,7 @@ export const comicsRouter = router({
     }),
 
   getChapterReadStatus: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ projectId: z.number().int() }))
     .query(async ({ ctx, input }) => {
       const engagement = await dbRead.comicProjectEngagement.findUnique({
@@ -4871,6 +4971,7 @@ export const comicsRouter = router({
     }),
 
   markChapterUnread: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(z.object({ projectId: z.number().int(), chapterPosition: z.number().int().min(0) }))
     .mutation(async ({ ctx, input }) => {
       const { projectId, chapterPosition } = input;
@@ -4886,6 +4987,7 @@ export const comicsRouter = router({
   // ──── Enhance Panel: create from existing image, optionally with img2img ────
 
   enhancePanel: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(enhancePanelSchema)
     .use(isChapterOwner)
     .mutation(async ({ ctx, input }) => {
@@ -5044,7 +5146,12 @@ export const comicsRouter = router({
           where: { id: input.referencePanelId },
           include: { chapter: { select: { projectId: true } } },
         });
-        if (refPanel && refPanel.chapter.projectId === input.projectId && refPanel.status === ComicPanelStatus.Ready && refPanel.imageUrl) {
+        if (
+          refPanel &&
+          refPanel.chapter.projectId === input.projectId &&
+          refPanel.status === ComicPanelStatus.Ready &&
+          refPanel.imageUrl
+        ) {
           referencePanelImageUrl = refPanel.imageUrl;
           const refEdgeUrl = getEdgeUrl(refPanel.imageUrl, { original: true });
           allImages.push({ url: refEdgeUrl, width: panelWidth, height: panelHeight });
@@ -5153,6 +5260,7 @@ export const comicsRouter = router({
   // ──── Bulk Create Panels ────
 
   bulkCreatePanels: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(bulkCreatePanelsSchema)
     .use(isChapterOwner)
     .mutation(async ({ ctx, input }) => {
@@ -5319,11 +5427,11 @@ export const comicsRouter = router({
           );
           const panelPrimaryRefName =
             mentionedIds.length > 0
-              ? (refImagesByRefId.get(mentionedIds[0])?.referenceName ?? '')
+              ? refImagesByRefId.get(mentionedIds[0])?.referenceName ?? ''
               : '';
-          const mentionedRefNames = mentionedIds.map(
-            (id) => refImagesByRefId.get(id)?.referenceName ?? ''
-          ).filter(Boolean);
+          const mentionedRefNames = mentionedIds
+            .map((id) => refImagesByRefId.get(id)?.referenceName ?? '')
+            .filter(Boolean);
 
           // Prompt is used as-is — enhancement happens client-side
           const fullPrompt = panelDef.prompt;
@@ -5340,7 +5448,7 @@ export const comicsRouter = router({
 
           // For Qwen img2img, use the img2img version if available
           const bulkVersionId = panelDef.sourceImageUrl
-            ? (bulkModelConfig.img2imgVersionId ?? bulkModelConfig.versionId)
+            ? bulkModelConfig.img2imgVersionId ?? bulkModelConfig.versionId
             : bulkModelConfig.versionId;
           const { width: bulkPanelW, height: bulkPanelH } = getAspectRatioDimensions(
             panelDef.aspectRatio,
@@ -5457,11 +5565,11 @@ export const comicsRouter = router({
           );
           const panelPrimaryRefName =
             mentionedIds.length > 0
-              ? (refImagesByRefId.get(mentionedIds[0])?.referenceName ?? '')
+              ? refImagesByRefId.get(mentionedIds[0])?.referenceName ?? ''
               : '';
-          const mentionedRefNames = mentionedIds.map(
-            (id) => refImagesByRefId.get(id)?.referenceName ?? ''
-          ).filter(Boolean);
+          const mentionedRefNames = mentionedIds
+            .map((id) => refImagesByRefId.get(id)?.referenceName ?? '')
+            .filter(Boolean);
 
           const { width: txtPanelW, height: txtPanelH } = getAspectRatioDimensions(
             panelDef.aspectRatio,
@@ -5505,6 +5613,7 @@ export const comicsRouter = router({
   // ──── Phase 2: Create panel from existing Image (manual mode) ────
 
   createPanelFromImage: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -5569,6 +5678,7 @@ export const comicsRouter = router({
   // ──── Phase 4: Reference aliases ────
 
   getReference: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ referenceId: z.number().int() }))
     .query(async ({ ctx, input }) => {
       const reference = await dbRead.comicReference.findUnique({
@@ -5587,6 +5697,7 @@ export const comicsRouter = router({
     }),
 
   deleteReference: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaDelete })
     .input(deleteReferenceSchema)
     .mutation(async ({ ctx, input }) => {
       const reference = await dbRead.comicReference.findUnique({
@@ -5603,6 +5714,7 @@ export const comicsRouter = router({
     }),
 
   updateReference: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updateReferenceSchema)
     .mutation(async ({ ctx, input }) => {
       const reference = await dbRead.comicReference.findUnique({
@@ -5620,6 +5732,7 @@ export const comicsRouter = router({
     }),
 
   deleteReferenceImage: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaDelete })
     .input(z.object({ referenceId: z.number().int(), imageId: z.number().int() }))
     .mutation(async ({ ctx, input }) => {
       const reference = await dbRead.comicReference.findUnique({
@@ -5660,6 +5773,7 @@ export const comicsRouter = router({
     }),
 
   reorderReferenceImages: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(
       z.object({
         referenceId: z.number().int(),
@@ -5702,6 +5816,7 @@ export const comicsRouter = router({
     }),
 
   getUserReferences: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(
       z
         .object({
@@ -5728,6 +5843,7 @@ export const comicsRouter = router({
   // ──── Phase 7: Chapter Comments ────
 
   getChapterThread: comicPublicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ projectId: z.number().int(), chapterPosition: z.number().int().min(0) }))
     .query(async ({ input, ctx }) => {
       const thread = await dbRead.thread.findUnique({
@@ -5753,6 +5869,7 @@ export const comicsRouter = router({
     }),
 
   createChapterComment: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(
       z.object({
         projectId: z.number().int(),
@@ -5831,6 +5948,7 @@ export const comicsRouter = router({
   // ──── Project-scoped references ────
 
   addReferenceToProject: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(z.object({ projectId: z.number().int(), referenceId: z.number().int() }))
     .use(isProjectOwner)
     .mutation(async ({ ctx, input }) => {
@@ -5861,6 +5979,7 @@ export const comicsRouter = router({
     }),
 
   removeReferenceFromProject: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(z.object({ projectId: z.number().int(), referenceId: z.number().int() }))
     .use(isProjectOwner)
     .mutation(async ({ ctx, input }) => {
@@ -5875,6 +5994,7 @@ export const comicsRouter = router({
     }),
 
   getImportableReferences: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ projectId: z.number().int() }))
     .use(isProjectOwner)
     .query(async ({ ctx, input }) => {
@@ -5911,9 +6031,11 @@ export const comicsRouter = router({
    * Get the current queue status for the user.
    * Returns used slots, limit, available slots, and whether the user can generate.
    */
-  getQueueStatus: comicProtectedProcedure.query(async ({ ctx }) => {
-    const token = await getOrchestratorToken(ctx.user!.id, ctx);
-    const userTier = ctx.user?.tier ?? 'free';
-    return getUserQueueStatus(token, userTier);
-  }),
+  getQueueStatus: comicProtectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(async ({ ctx }) => {
+      const token = await getOrchestratorToken(ctx.user!.id, ctx);
+      const userTier = ctx.user?.tier ?? 'free';
+      return getUserQueueStatus(token, userTier);
+    }),
 });

--- a/src/server/routers/comment.router.ts
+++ b/src/server/routers/comment.router.ts
@@ -35,6 +35,7 @@ import {
   router,
 } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input }) => {
   if (!ctx?.user) throw new TRPCError({ code: 'UNAUTHORIZED' });
@@ -88,32 +89,57 @@ const isLocked = middleware(async ({ ctx, next, input }) => {
 });
 
 export const commentRouter = router({
-  getAll: publicProcedure.input(getAllCommentsSchema).query(getCommentsInfiniteHandler),
-  getById: publicProcedure.input(getByIdSchema).query(getCommentHandler),
-  getReactions: publicProcedure.input(getCommentReactionsSchema).query(getCommentReactionsHandler),
-  getCommentsById: publicProcedure.input(getByIdSchema).query(getCommentCommentsHandler),
-  getCommentsCount: publicProcedure.input(getByIdSchema).query(getCommentCommentsCountHandler),
+  getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getAllCommentsSchema)
+    .query(getCommentsInfiniteHandler),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getCommentHandler),
+  getReactions: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getCommentReactionsSchema)
+    .query(getCommentReactionsHandler),
+  getCommentsById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getCommentCommentsHandler),
+  getCommentsCount: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getCommentCommentsCountHandler),
   getCommentCountByModel: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getCommentCountByModelSchema)
     .query(({ input }) => getCommentCountByModel(input)),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(commentUpsertInput)
     .use(isOwnerOrModerator)
     .use(isLocked)
     .use(rateLimit(commentRateLimits))
     .mutation(upsertCommentHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteUserCommentHandler),
-  toggleReaction: protectedProcedure.input(toggleReactionInput).mutation(({ input, ctx }) =>
-    toggleReactionHandler({
-      ctx,
-      input: { entityType: 'commentOld', entityId: input.id, reaction: input.reaction },
-    })
-  ),
-  toggleHide: protectedProcedure.input(getByIdSchema).mutation(toggleHideCommentHandler),
+  toggleReaction: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(toggleReactionInput)
+    .mutation(({ input, ctx }) =>
+      toggleReactionHandler({
+        ctx,
+        input: { entityType: 'commentOld', entityId: input.id, reaction: input.reaction },
+      })
+    ),
+  toggleHide: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(getByIdSchema)
+    .mutation(toggleHideCommentHandler),
   toggleLock: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(toggleLockHandler),

--- a/src/server/routers/commentv2.router.ts
+++ b/src/server/routers/commentv2.router.ts
@@ -28,6 +28,7 @@ import { toggleHideCommentSchema } from '~/server/schema/commentv2.schema';
 import { rateLimit } from '~/server/middleware.trpc';
 import { commentRateLimits } from '~/server/schema/comment.schema';
 import { togglePinComment } from '~/server/services/commentsv2.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -50,25 +51,40 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 });
 
 export const commentv2Router = router({
-  getCount: publicProcedure.input(commentConnectorSchema).query(getCommentCountV2Handler),
-  getSingle: publicProcedure.input(getByIdSchema).query(getCommentHandler),
+  getCount: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(commentConnectorSchema)
+    .query(getCommentCountV2Handler),
+  getSingle: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getCommentHandler),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(upsertCommentv2Schema)
     .use(isOwnerOrModerator)
     .use(rateLimit(commentRateLimits))
     .mutation(upsertCommentV2Handler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteCommentV2Handler),
   getThreadDetails: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(commentConnectorSchema)
     .query(getCommentsThreadDetailsHandler),
-  getInfinite: publicProcedure.input(getCommentsInfiniteSchema).query(getCommentsInfiniteHandler),
+  getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getCommentsInfiniteSchema)
+    .query(getCommentsInfiniteHandler),
   toggleLockThread: moderatorProcedure
     .input(commentConnectorSchema)
     .mutation(toggleLockThreadDetailsHandler),
-  toggleHide: protectedProcedure.input(toggleHideCommentSchema).mutation(toggleHideCommentHandler),
+  toggleHide: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(toggleHideCommentSchema)
+    .mutation(toggleHideCommentHandler),
   togglePinned: moderatorProcedure
     .input(getByIdSchema)
     .mutation(({ input }) => togglePinComment({ id: input.id })),

--- a/src/server/routers/common.router.ts
+++ b/src/server/routers/common.router.ts
@@ -5,10 +5,15 @@ import {
   getEntityClubRequirementHandler,
   updateEntityAvailabilityHandler,
 } from '~/server/controllers/common.controller';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const commonRouter = router({
-  getEntityAccess: publicProcedure.input(getByEntitySchema).query(getEntityAccessHandler),
+  getEntityAccess: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getByEntitySchema)
+    .query(getEntityAccessHandler),
   getEntityClubRequirement: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getByEntitySchema)
     .query(getEntityClubRequirementHandler),
   updateAvailability: moderatorProcedure

--- a/src/server/routers/content.router.ts
+++ b/src/server/routers/content.router.ts
@@ -4,6 +4,7 @@ import { cacheIt } from '~/server/middleware.trpc';
 import { getMarkdownContent, getStaticContent } from '~/server/services/content.service';
 import { getUserSettings } from '~/server/services/user.service';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const slugSchema = z.object({
   slug: z.preprocess(
@@ -25,27 +26,31 @@ const tosFieldMap = {
 
 export const contentRouter = router({
   get: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(slugSchema)
     .query(({ input, ctx }) => getStaticContent({ ...input, ctx })),
   getMarkdown: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(z.object({ key: z.string() }))
     .query(({ input }) => getMarkdownContent(input)),
-  checkTosUpdate: protectedProcedure.query(async ({ ctx }) => {
-    const tos = await getStaticContent({ slug: ['tos'], ctx });
-    const userSettings = ctx.user ? await getUserSettings(ctx.user.id) : {};
+  checkTosUpdate: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .query(async ({ ctx }) => {
+      const tos = await getStaticContent({ slug: ['tos'], ctx });
+      const userSettings = ctx.user ? await getUserSettings(ctx.user.id) : {};
 
-    // Get domain color from request context to determine which ToS field to check
-    const domainColor = ctx.domain;
-    const tosFieldKey = tosFieldMap[domainColor as keyof typeof tosFieldMap] || 'tosLastSeenDate';
-    const userTosLastSeen = userSettings[tosFieldKey] as Date | undefined;
-    const tosLastMod = tos.lastmod ? new Date(tos.lastmod) : undefined;
+      // Get domain color from request context to determine which ToS field to check
+      const domainColor = ctx.domain;
+      const tosFieldKey = tosFieldMap[domainColor as keyof typeof tosFieldMap] || 'tosLastSeenDate';
+      const userTosLastSeen = userSettings[tosFieldKey] as Date | undefined;
+      const tosLastMod = tos.lastmod ? new Date(tos.lastmod) : undefined;
 
-    return {
-      hasUpdate: !userTosLastSeen || (tosLastMod && tosLastMod > userTosLastSeen),
-      lastmod: tosLastMod,
-      userLastSeen: userTosLastSeen,
-      domainColor,
-      tosFieldKey,
-    };
-  }),
+      return {
+        hasUpdate: !userTosLastSeen || (tosLastMod && tosLastMod > userTosLastSeen),
+        lastmod: tosLastMod,
+        userLastSeen: userTosLastSeen,
+        domainColor,
+        tosFieldKey,
+      };
+    }),
 });

--- a/src/server/routers/cosmetic-shop.router.ts
+++ b/src/server/routers/cosmetic-shop.router.ts
@@ -33,6 +33,7 @@ import {
   router,
   verifiedProcedure,
 } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const cosmeticShopRouter = router({
   // #region [Shop Items]
@@ -41,9 +42,12 @@ export const cosmeticShopRouter = router({
     .query(({ input }) => {
       return getPaginatedCosmeticShopItems(input);
     }),
-  getShopItemById: protectedProcedure.input(getByIdSchema).query(({ input }) => {
-    return getShopItemById(input);
-  }),
+  getShopItemById: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getByIdSchema)
+    .query(({ input }) => {
+      return getShopItemById(input);
+    }),
   upsertCosmetic: moderatorProcedure.input(upsertCosmeticInput).mutation(({ input }) => {
     return upsertCosmetic(input);
   }),
@@ -63,9 +67,12 @@ export const cosmeticShopRouter = router({
   getAllSections: moderatorProcedure.input(getAllCosmeticShopSections).query(({ input }) => {
     return getShopSections(input);
   }),
-  getSectionById: protectedProcedure.input(getByIdSchema).query(({ input }) => {
-    return getSectionById(input);
-  }),
+  getSectionById: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getByIdSchema)
+    .query(({ input }) => {
+      return getSectionById(input);
+    }),
   upsertShopSection: moderatorProcedure
     .input(upsertCosmeticShopSectionInput)
     .mutation(({ input, ctx }) => {
@@ -84,13 +91,17 @@ export const cosmeticShopRouter = router({
     }),
   // #endregion
   // #region [Public facing routes]
-  getShop: publicProcedure.input(getShopInput).query(({ input, ctx }) => {
-    return getShopSectionsWithItems({
-      ...input,
-      isModerator: ctx?.user?.isModerator,
-    });
-  }),
+  getShop: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getShopInput)
+    .query(({ input, ctx }) => {
+      return getShopSectionsWithItems({
+        ...input,
+        isModerator: ctx?.user?.isModerator,
+      });
+    }),
   purchaseShopItem: verifiedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite, blockApiKeys: true })
     .input(purchaseCosmeticShopItemInput)
     .mutation(({ input, ctx }) => {
       // Calculate domain-allowed account types at router level
@@ -102,12 +113,15 @@ export const cosmeticShopRouter = router({
         buzzType,
       });
     }),
-  getPreviewImages: protectedProcedure.input(getPreviewImagesInput).query(({ input, ctx }) => {
-    return getUserPreviewImagesForCosmetics({
-      userId: ctx.user.id,
-      features: ctx.features,
-      ...input,
-    });
-  }),
+  getPreviewImages: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getPreviewImagesInput)
+    .query(({ input, ctx }) => {
+      return getUserPreviewImagesForCosmetics({
+        userId: ctx.user.id,
+        features: ctx.features,
+        ...input,
+      });
+    }),
   // #endregion
 });

--- a/src/server/routers/cosmetic.router.ts
+++ b/src/server/routers/cosmetic.router.ts
@@ -7,18 +7,24 @@ import {
   unequipCosmetic,
 } from '~/server/services/cosmetic.service';
 import { moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const cosmeticRouter = router({
-  getById: protectedProcedure.input(getByIdSchema).query(({ input }) => {
-    return getCosmeticDetail(input);
-  }),
+  getById: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getByIdSchema)
+    .query(({ input }) => {
+      return getCosmeticDetail(input);
+    }),
   getPaged: moderatorProcedure.input(getPaginatedCosmeticsSchema).query(({ input }) => {
     return getPaginatedCosmetics(input);
   }),
   equipContentDecoration: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(equipCosmeticSchema)
     .mutation(({ input, ctx }) => equipCosmeticToEntity({ ...input, userId: ctx.user.id })),
   unequipCosmetic: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
     .input(equipCosmeticSchema)
     .mutation(({ input, ctx }) => unequipCosmetic({ ...input, userId: ctx.user.id })),
 });

--- a/src/server/routers/creator-program.router.ts
+++ b/src/server/routers/creator-program.router.ts
@@ -16,33 +16,49 @@ import {
   withdrawCash,
 } from '~/server/services/creator-program.service';
 import { protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const creatorProgramRouter = router({
-  getCreatorRequirements: protectedProcedure.query(({ ctx }) =>
-    getCreatorRequirements(ctx.user.id)
-  ),
-  joinCreatorsProgram: protectedProcedure.mutation(({ ctx }) => {
-    return joinCreatorsProgram(ctx.user.id);
-  }),
+  getCreatorRequirements: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getCreatorRequirements(ctx.user.id)),
+  joinCreatorsProgram: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .mutation(({ ctx }) => {
+      return joinCreatorsProgram(ctx.user.id);
+    }),
   getCompensationPool: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(compensationPoolInputSchema)
     .query(({ input }) => getCompensationPool(input)),
-  getCash: protectedProcedure.query(({ ctx }) => getCash(ctx.user.id)),
-  getBanked: protectedProcedure.query(({ ctx }) => {
+  getCash: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getCash(ctx.user.id)),
+  getBanked: protectedProcedure.meta({ requiredScope: TokenScope.UserRead }).query(({ ctx }) => {
     return getBanked(ctx.user.id);
   }),
-  getWithdrawalHistory: protectedProcedure.query(({ ctx }) => getWithdrawalHistory(ctx.user.id)),
+  getWithdrawalHistory: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getWithdrawalHistory(ctx.user.id)),
 
-  bankBuzz: protectedProcedure.input(bankBuzzSchema).mutation(({ ctx, input }) => {
-    return bankBuzz(ctx.user.id, input.amount, input.accountType);
-  }),
-  extractBuzz: protectedProcedure.mutation(({ ctx }) => {
-    return extractBuzz(ctx.user.id);
-  }),
-  withdrawCash: protectedProcedure.input(withdrawCashSchema).mutation(({ ctx, input }) => {
-    return withdrawCash(ctx.user.id, input.amount);
-  }),
-  getPrevMonthStats: protectedProcedure.query(() => {
+  bankBuzz: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full, blockApiKeys: true })
+    .input(bankBuzzSchema)
+    .mutation(({ ctx, input }) => {
+      return bankBuzz(ctx.user.id, input.amount, input.accountType);
+    }),
+  extractBuzz: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full, blockApiKeys: true })
+    .mutation(({ ctx }) => {
+      return extractBuzz(ctx.user.id);
+    }),
+  withdrawCash: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full, blockApiKeys: true })
+    .input(withdrawCashSchema)
+    .mutation(({ ctx, input }) => {
+      return withdrawCash(ctx.user.id, input.amount);
+    }),
+  getPrevMonthStats: protectedProcedure.meta({ requiredScope: TokenScope.Full }).query(() => {
     return getPrevMonthStats();
   }),
 });

--- a/src/server/routers/csam.router.ts
+++ b/src/server/routers/csam.router.ts
@@ -7,6 +7,7 @@ import {
   getImageResources,
 } from '~/server/services/csam.service';
 import { moderatorProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const csamRouter = router({
   getImageResources: moderatorProcedure

--- a/src/server/routers/daily-challenge.router.ts
+++ b/src/server/routers/daily-challenge.router.ts
@@ -3,12 +3,15 @@ import {
   getCurrentDailyChallenge,
 } from '~/server/services/daily-challenge.service';
 import { isFlagProtected, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const dailyChallengeRouter = router({
   getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .use(isFlagProtected('challengePlatform'))
     .query(() => getAllDailyChallenges()),
   getCurrent: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .use(isFlagProtected('challengePlatform'))
     .query(() => getCurrentDailyChallenge()),
 });

--- a/src/server/routers/donation-goal.router.ts
+++ b/src/server/routers/donation-goal.router.ts
@@ -2,13 +2,17 @@ import { donateToGoalInput } from '~/server/schema/donation-goal.schema';
 import { donateToGoal } from '~/server/services/donation-goal.service';
 import { protectedProcedure, router } from '~/server/trpc';
 import { getAllowedAccountTypes } from '~/server/utils/buzz-helpers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const donationGoalRouter = router({
-  donate: protectedProcedure.input(donateToGoalInput).mutation(({ input, ctx }) => {
-    return donateToGoal({
-      ...input,
-      userId: ctx.user.id,
-      buzzType: getAllowedAccountTypes(ctx.features)[0],
-    });
-  }),
+  donate: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialTip, blockApiKeys: true })
+    .input(donateToGoalInput)
+    .mutation(({ input, ctx }) => {
+      return donateToGoal({
+        ...input,
+        userId: ctx.user.id,
+        buzzType: getAllowedAccountTypes(ctx.features)[0],
+      });
+    }),
 });

--- a/src/server/routers/download.router.ts
+++ b/src/server/routers/download.router.ts
@@ -4,8 +4,14 @@ import {
   getUserDownloadsHandler,
   hideDownloadHandler,
 } from '~/server/controllers/download.controller';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const downloadRouter = router({
-  getAllByUser: protectedProcedure.query(getUserDownloadsHandler),
-  hide: protectedProcedure.input(hideDownloadInput).mutation(hideDownloadHandler),
+  getAllByUser: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .query(getUserDownloadsHandler),
+  hide: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(hideDownloadInput)
+    .mutation(hideDownloadHandler),
 });

--- a/src/server/routers/emerchantpay.router.ts
+++ b/src/server/routers/emerchantpay.router.ts
@@ -6,16 +6,19 @@ import {
 } from '~/server/controllers/emerchantpay.controller';
 import { getByIdStringSchema } from '~/server/schema/base.schema';
 import { createBuzzChargeSchema } from '~/server/schema/emerchantpay.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const emerchantpayRouter = router({
-  getStatus: publicProcedure.query(() => getStatus()),
+  getStatus: publicProcedure.meta({ requiredScope: TokenScope.Full }).query(() => getStatus()),
 
   createBuzzOrder: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(createBuzzChargeSchema)
     .use(isFlagProtected('emerchantpayPayments'))
     .mutation(({ input, ctx }) => createBuzzOrderHandler({ input, ctx })),
 
   getTransactionStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getByIdStringSchema)
     .query(({ input, ctx }) => getTransactionStatusHandler({ input, ctx })),
 });

--- a/src/server/routers/entity-collaborator.router.ts
+++ b/src/server/routers/entity-collaborator.router.ts
@@ -11,25 +11,32 @@ import {
   upsertEntityCollaborator,
 } from '~/server/services/entity-collaborator.service';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const entityCollaboratorRouter = router({
   upsert: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(upsertEntityCollaboratorInput)
     .mutation(({ input, ctx }) => upsertEntityCollaborator({ ...input, userId: ctx.user.id })),
   get: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getEntityCollaboratorsInput)
     .query(({ input, ctx }) =>
       getEntityCollaborators({ ...input, userId: ctx.user?.id, isModerator: ctx.user?.isModerator })
     ),
   remove: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(removeEntityCollaboratorInput)
     .mutation(({ input, ctx }) =>
       removeEntityCollaborator({ ...input, userId: ctx.user.id, isModerator: ctx.user.isModerator })
     ),
-  action: protectedProcedure.input(actionEntityCollaboratorInviteInput).mutation(({ input, ctx }) =>
-    actionEntityCollaborationInvite({
-      ...input,
-      userId: ctx.user.id,
-    })
-  ),
+  action: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
+    .input(actionEntityCollaboratorInviteInput)
+    .mutation(({ input, ctx }) =>
+      actionEntityCollaborationInvite({
+        ...input,
+        userId: ctx.user.id,
+      })
+    ),
 });

--- a/src/server/routers/event.router.ts
+++ b/src/server/routers/event.router.ts
@@ -16,38 +16,48 @@ import {
   getEventPartners,
 } from '~/server/services/event.service';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const eventRouter = router({
   getData: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(eventSchema)
     // .use(edgeCacheIt({ ttl: CacheTTL.lg }))
     .query(({ input }) => getEventData(input)),
   getTeamScores: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(eventSchema)
     .use(edgeCacheIt({ ttl: CacheTTL.xs }))
     .query(({ input }) => getTeamScores(input)),
   getTeamScoreHistory: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(teamScoreHistorySchema)
     .use(edgeCacheIt({ ttl: CacheTTL.xs }))
     .query(({ input }) => getTeamScoreHistory(input)),
   getCosmetic: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(eventSchema)
     .query(({ ctx, input }) => getEventCosmetic({ userId: ctx.user.id, ...input })),
   getPartners: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(eventSchema)
     .use(edgeCacheIt({ ttl: CacheTTL.day }))
     .query(({ input }) => getEventPartners(input)),
   getRewards: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(eventSchema)
     .use(edgeCacheIt({ ttl: CacheTTL.lg }))
     .query(({ input }) => getEventRewards(input)),
   activateCosmetic: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(eventSchema)
     .mutation(({ ctx, input }) => activateEventCosmetic({ userId: ctx.user.id, ...input })),
   donate: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialTip, blockApiKeys: true })
     .input(eventSchema.extend({ amount: z.number() }))
     .mutation(({ input, ctx }) => donate({ userId: ctx.user.id, ...input })),
   getDonors: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(eventSchema)
     .use(
       cacheIt({
@@ -63,6 +73,7 @@ export const eventRouter = router({
     )
     .query(({ input }) => getEventContributors(input)),
   getUserRank: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(eventSchema)
     .query(({ ctx, input }) => getUserRank({ userId: ctx.user.id, ...input })),
 });

--- a/src/server/routers/games.router.ts
+++ b/src/server/routers/games.router.ts
@@ -45,6 +45,7 @@ import {
 } from '~/server/trpc';
 import { NewOrderRankType } from '~/shared/utils/prisma/enums';
 import { generateToken } from '~/utils/string-helpers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const newGameSchema = z.object({
   themeIds: z.array(z.string()).min(1),
@@ -78,37 +79,42 @@ async function createGameInstance(code: string) {
 
 export const gamesRouter = router({
   chopped: router({
-    start: protectedProcedure.input(newGameSchema).mutation(async ({ ctx, input }) => {
-      const code = generateToken(GAME_TOKEN_LENGTH).toUpperCase();
-      const cost = ComputeCost(input);
-      const { transactionId } = await createBuzzTransaction({
-        fromAccountId: ctx.user.id,
-        toAccountId: 0,
-        amount: cost,
-        type: TransactionType.Purchase,
-        description: `Chopped game (${code}): ${input.themeIds.length} rounds + ${
-          input.includeAudio ? 'audio' : 'no audio'
-        }`,
-        externalTransactionId: 'chopped-' + code,
-      });
-      if (!transactionId) {
-        throw new Error('Failed to create transaction');
-      }
+    start: protectedProcedure
+      .meta({ requiredScope: TokenScope.SocialWrite, blockApiKeys: true })
+      .input(newGameSchema)
+      .mutation(async ({ ctx, input }) => {
+        const code = generateToken(GAME_TOKEN_LENGTH).toUpperCase();
+        const cost = ComputeCost(input);
+        const { transactionId } = await createBuzzTransaction({
+          fromAccountId: ctx.user.id,
+          toAccountId: 0,
+          amount: cost,
+          type: TransactionType.Purchase,
+          description: `Chopped game (${code}): ${input.themeIds.length} rounds + ${
+            input.includeAudio ? 'audio' : 'no audio'
+          }`,
+          externalTransactionId: 'chopped-' + code,
+        });
+        if (!transactionId) {
+          throw new Error('Failed to create transaction');
+        }
 
-      try {
-        await createGameInstance(code);
-      } catch (error) {
-        await refundTransaction(transactionId, 'Failed to create game instance');
-      }
+        try {
+          await createGameInstance(code);
+        } catch (error) {
+          await refundTransaction(transactionId, 'Failed to create game instance');
+        }
 
-      return { code };
-    }),
+        return { code };
+      }),
   }),
   newOrder: router({
     join: guardedProcedure
+      .meta({ requiredScope: TokenScope.SocialWrite })
       .use(isFlagProtected('newOrderGame'))
       .mutation(({ ctx }) => joinGame({ userId: ctx.user.id })),
     getPlayer: guardedProcedure
+      .meta({ requiredScope: TokenScope.MediaRead })
       .use(isFlagProtected('newOrderGame'))
       .query(({ ctx }) => getPlayerById({ playerId: ctx.user.id })),
     getPlayers: moderatorProcedure
@@ -116,12 +122,14 @@ export const gamesRouter = router({
       .use(isFlagProtected('newOrderGame'))
       .query(({ input }) => getPlayersInfinite({ ...input })),
     getImagesQueue: guardedProcedure
+      .meta({ requiredScope: TokenScope.MediaRead })
       .use(isFlagProtected('newOrderGame'))
       .input(getImagesQueueSchema.optional())
       .query(({ input, ctx }) =>
         getImagesQueue({ ...input, playerId: ctx.user.id, isModerator: ctx.user.isModerator })
       ),
     getHistory: guardedProcedure
+      .meta({ requiredScope: TokenScope.MediaRead })
       .input(getHistorySchema)
       .use(isFlagProtected('newOrderGame'))
       .query(({ input, ctx }) => getPlayerHistory({ ...input, playerId: ctx.user.id })),
@@ -134,6 +142,7 @@ export const gamesRouter = router({
       .use(isFlagProtected('newOrderGame'))
       .mutation(({ input }) => cleanseSmite({ ...input })),
     addRating: guardedProcedure
+      .meta({ requiredScope: TokenScope.SocialWrite })
       .input(addImageRatingSchema)
       .use(isFlagProtected('newOrderGame'))
       .mutation(({ input, ctx }) =>
@@ -145,6 +154,7 @@ export const gamesRouter = router({
         })
       ),
     resetCareer: guardedProcedure
+      .meta({ requiredScope: TokenScope.SocialWrite })
       .use(isFlagProtected('newOrderGame'))
       .mutation(({ ctx }) => resetPlayer({ playerId: ctx.user.id })),
     resetPlayerById: moderatorProcedure

--- a/src/server/routers/generation-preset.router.ts
+++ b/src/server/routers/generation-preset.router.ts
@@ -16,16 +16,37 @@ import {
   updateGenerationPresetInputSchema,
 } from '~/server/schema/generation-preset.schema';
 import { protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const generationPresetRouter = router({
   getForEcosystem: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(getPresetsForEcosystemInputSchema)
     .query(getForEcosystemHandler),
-  getOwn: protectedProcedure.query(getOwnHandler),
-  getAvailable: protectedProcedure.query(getAvailableHandler),
-  getById: protectedProcedure.input(getByIdSchema).query(getByIdHandler),
-  create: protectedProcedure.input(createGenerationPresetInputSchema).mutation(createHandler),
-  update: protectedProcedure.input(updateGenerationPresetInputSchema).mutation(updateHandler),
-  delete: protectedProcedure.input(getByIdSchema).mutation(deleteHandler),
-  reorder: protectedProcedure.input(reorderGenerationPresetsInputSchema).mutation(reorderHandler),
+  getOwn: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(getOwnHandler),
+  getAvailable: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(getAvailableHandler),
+  getById: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .input(getByIdSchema)
+    .query(getByIdHandler),
+  create: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
+    .input(createGenerationPresetInputSchema)
+    .mutation(createHandler),
+  update: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
+    .input(updateGenerationPresetInputSchema)
+    .mutation(updateHandler),
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
+    .input(getByIdSchema)
+    .mutation(deleteHandler),
+  reorder: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
+    .input(reorderGenerationPresetsInputSchema)
+    .mutation(reorderHandler),
 });

--- a/src/server/routers/generation.router.ts
+++ b/src/server/routers/generation.router.ts
@@ -32,6 +32,7 @@ import {
 } from '~/server/services/orchestrator/comfy/comfy.utils';
 import * as z from 'zod';
 import { getGenerationEngines } from '~/server/services/generation/engines';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const ecosystemConfigInputSchema = z.object({
   modOnlyEcosystems: z.array(z.string()),
@@ -44,34 +45,42 @@ const ecosystemConfigInputSchema = z.object({
 });
 
 export const generationRouter = router({
-  getGenerationEngines: publicProcedure.query(() => getGenerationEngines()),
-  getWorkflowDefinitions: publicProcedure.query(({ ctx }) =>
-    getWorkflowDefinitions().then((res) =>
-      res
-        .filter((x) => {
-          if (x.status === 'disabled') return false;
-          if (x.status === 'mod-only' && !ctx.user?.isModerator) return false;
-          return true;
-        })
-        .map(({ template, ...rest }) => rest)
-    )
-  ),
+  getGenerationEngines: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(() => getGenerationEngines()),
+  getWorkflowDefinitions: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(({ ctx }) =>
+      getWorkflowDefinitions().then((res) =>
+        res
+          .filter((x) => {
+            if (x.status === 'disabled') return false;
+            if (x.status === 'mod-only' && !ctx.user?.isModerator) return false;
+            return true;
+          })
+          .map(({ template, ...rest }) => rest)
+      )
+    ),
   setWorkflowDefinition: moderatorProcedure
     .input(z.any())
     .mutation(({ input }) => setWorkflowDefinition(input.key, input)),
   getResources: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(getGenerationResourcesSchema)
     .query(({ ctx, input }) => getGenerationResources({ ...input, user: ctx.user })),
   getGenerationData: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(getGenerationDataSchema)
     .query(({ input, ctx }) =>
       getGenerationData({ query: input, user: ctx.user, sfwOnly: ctx.features.isGreen })
     ),
   checkResourcesCoverage: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(checkResourcesCoverageSchema)
     .use(edgeCacheIt({ ttl: CacheTTL.sm }))
     .query(({ input }) => checkResourcesCoverage(input)),
   getStatus: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .use(edgeCacheIt({ ttl: CacheTTL.xs, tags: () => ['generation-status'] }))
     .query(() => getGenerationStatus()),
   getStatusModerator: moderatorProcedure.query(() => getGenerationStatus()),
@@ -84,7 +93,9 @@ export const generationRouter = router({
     )
     .use(purgeOnSuccess(['generation-status']))
     .mutation(({ input }) => setGenerationStatus(input)),
-  getGenerationConfig: publicProcedure.query(({ ctx }) => getGenerationConfig(ctx.user ?? {})),
+  getGenerationConfig: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(({ ctx }) => getGenerationConfig(ctx.user ?? {})),
   getEcosystemConfig: moderatorProcedure.query(async () => {
     // Strip the per-user `hasTestingAccess` field — the moderator UI edits the
     // raw operator-set config that gets persisted to Redis.
@@ -94,20 +105,26 @@ export const generationRouter = router({
   setEcosystemConfig: moderatorProcedure
     .input(ecosystemConfigInputSchema)
     .mutation(({ input }) => setGenerationEcosystemConfig(input)),
-  getUnavailableResources: publicProcedure.query(() => getUnavailableResources()),
+  getUnavailableResources: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(() => getUnavailableResources()),
   toggleUnavailableResource: moderatorProcedure
     .input(getByIdSchema)
     .mutation(({ input, ctx }) =>
       toggleUnavailableResource({ ...input, isModerator: ctx.user.isModerator })
     ),
-  getResourceDataByIds: publicProcedure.input(getResourceDataByIdsSchema).query(({ input, ctx }) =>
-    getResourceData(input.ids, {
-      user: ctx.user,
-      withPreview: true,
-      sfwOnly: ctx.features.isGreen,
-    })
-  ),
+  getResourceDataByIds: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .input(getResourceDataByIdsSchema)
+    .query(({ input, ctx }) =>
+      getResourceData(input.ids, {
+        user: ctx.user,
+        withPreview: true,
+        sfwOnly: ctx.features.isGreen,
+      })
+    ),
   resolveImageMeta: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(resolveImageMetaSchema)
     .query(({ input, ctx }) =>
       resolveImageMeta({ input, user: ctx.user, sfwOnly: ctx.features.isGreen })

--- a/src/server/routers/hidden-preferences.router.ts
+++ b/src/server/routers/hidden-preferences.router.ts
@@ -2,14 +2,17 @@ import { noEdgeCache } from '~/server/middleware.trpc';
 import { toggleHiddenSchema } from '~/server/schema/user-preferences.schema';
 import { getAllHiddenForUser, toggleHidden } from '~/server/services/user-preferences.service';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const hiddenPreferencesRouter = router({
   getHidden: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     // Prevents edge caching hidden preferences since they're being cache in redis already
     // NOTE: this is required because this endpoint is being forcefully cache in the browser wihout reason
     .use(noEdgeCache())
     .query(({ ctx }) => getAllHiddenForUser({ userId: ctx.user?.id })),
   toggleHidden: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(toggleHiddenSchema)
     .mutation(({ input, ctx }) => toggleHidden({ ...input, userId: ctx.user.id })),
 });

--- a/src/server/routers/home-block.router.ts
+++ b/src/server/routers/home-block.router.ts
@@ -27,31 +27,38 @@ import {
   toggleFeaturedCollectionInputSchema,
 } from '~/server/schema/home-block.schema';
 import { getByIdSchema } from '~/server/schema/base.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const homeBlockRouter = router({
   getHomeBlocks: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getHomeBlocksInputSchema)
     .use(isFlagProtected('alternateHome'))
     .use(noEdgeCache({ authedOnly: true }))
     .query(getHomeBlocksHandler),
   getSystemHomeBlocks: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getSystemHomeBlocksInputSchema)
     .use(isFlagProtected('alternateHome'))
     .query(getSystemHomeBlocksHandler),
   getHomeBlock: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getHomeBlockByIdInputSchema)
     .use(isFlagProtected('alternateHome'))
     .use(edgeCacheIt({ ttl: 60 }))
     .query(getHomeBlocksByIdHandler),
   createCollectionHomeBlock: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(createCollectionHomeBlockInputSchema)
     .use(isFlagProtected('alternateHome'))
     .mutation(createCollectionHomeBlockHandler),
   setHomeBlockOrder: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(setHomeBlocksOrderInput)
     .use(isFlagProtected('alternateHome'))
     .mutation(setHomeBlocksOrderHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('alternateHome'))
     .mutation(deleteUserHomeBlockHandler),

--- a/src/server/routers/image.router.ts
+++ b/src/server/routers/image.router.ts
@@ -46,6 +46,7 @@ import {
   verifiedProcedure,
 } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 import {
   getEntitiesCoverImageHandler,
   getImageContestCollectionDetailsHandler,
@@ -107,26 +108,38 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 // TODO.cleanup - remove unused router methods
 export const imageRouter = router({
   ingestArticleImages: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(z.array(z.object({ imageId: z.number(), articleId: z.number() })))
     .mutation(({ input }) => ingestArticleCoverImages(input)),
   moderate: moderatorProcedure.input(imageModerationSchema).mutation(moderateImageHandler),
   delete: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaDelete })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteImageHandler),
   setTosViolation: moderatorProcedure.input(setTosViolationSchema).mutation(setTosViolationHandler),
   getDetail: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .query(({ input }) => getImageDetail({ ...input })),
-  getInfinite: publicProcedure.input(getInfiniteImagesSchema).query(getInfiniteImagesHandler),
+  getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getInfiniteImagesSchema)
+    .query(getInfiniteImagesHandler),
   getImagesForModelVersion: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .query(({ input }) => getImagesForModelVersionCache([input.id])),
   getImagesAsPostsInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getInfiniteImagesSchema)
     .query(getImagesAsPostsInfiniteHandler),
-  get: publicProcedure.input(getImageSchema).query(getImageHandler),
+  get: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getImageSchema)
+    .query(getImageHandler),
   getResources: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .use(
       edgeCacheIt({
@@ -139,6 +152,7 @@ export const imageRouter = router({
     .mutation(({ input }) => removeImageResource(input)),
   rescan: moderatorProcedure.input(getByIdSchema).mutation(({ input }) => ingestImageById(input)),
   getEntitiesCoverImage: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getEntitiesCoverImage)
     .query(getEntitiesCoverImageHandler),
   getModeratorReviewQueue: moderatorProcedure
@@ -147,6 +161,7 @@ export const imageRouter = router({
   getModeratorReviewQueueCounts: moderatorProcedure.query(getImageModerationCounts),
   getModeratorPOITags: moderatorProcedure.query(() => getModeratorPOITags()),
   get404Images: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .use(edgeCacheIt({ ttl: CacheTTL.month }))
     .use(cacheIt({ ttl: CacheTTL.week }))
     .query(() => get404Images()),
@@ -154,6 +169,7 @@ export const imageRouter = router({
     .input(reportCsamImagesSchema)
     .mutation(({ input, ctx }) => reportCsamImages({ ...input, user: ctx.user, ip: ctx.ip })),
   updateImageNsfwLevel: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(updateImageNsfwLevelSchema)
     .mutation(handleUpdateImageNsfwLevel),
   getImageRatingRequests: moderatorProcedure
@@ -169,6 +185,7 @@ export const imageRouter = router({
     .input(downleveledReviewInput)
     .query(({ input, ctx }) => getDownleveledImages({ ...input, user: ctx.user })),
   getGenerationData: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     // TODO: Add edgeCacheIt back after fixing the cache invalidation.
     // .use(
@@ -181,30 +198,37 @@ export const imageRouter = router({
 
   // #region [tools]
   addTools: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(addOrRemoveImageToolsSchema)
     .mutation(({ input, ctx }) => addImageTools({ ...input, user: ctx.user })),
   removeTools: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(addOrRemoveImageToolsSchema)
     .mutation(({ input, ctx }) => removeImageTools({ ...input, user: ctx.user })),
   updateTools: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updateImageToolsSchema)
     .mutation(({ input, ctx }) => updateImageTools({ ...input, user: ctx.user })),
   // #endregion
 
   // #region [techniques]
   addTechniques: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(addOrRemoveImageTechniquesSchema)
     .mutation(({ input, ctx }) => addImageTechniques({ ...input, user: ctx.user })),
   removeTechniques: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(addOrRemoveImageTechniquesSchema)
     .mutation(({ input, ctx }) => removeImageTechniques({ ...input, user: ctx.user })),
   updateTechniques: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updateImageTechniqueSchema)
     .mutation(({ input, ctx }) => updateImageTechniques({ ...input, user: ctx.user })),
   // #endregion
 
   // #region [collections]
   getContestCollectionDetails: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .query(getImageContestCollectionDetailsHandler),
   // #endregion
@@ -219,20 +243,24 @@ export const imageRouter = router({
 
   // #region [thumbnail]
   setThumbnail: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(setVideoThumbnailSchema)
     .mutation(setVideoThumbnailController),
   // #endregion
 
   updateAccetableMinor: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updateImageAcceptableMinorSchema)
     .mutation(updateImageAcceptableMinorHandler),
   getMyImages: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getMyImagesInput)
     .query(({ input, ctx }) => getMyImages({ ...input, userId: ctx.user.id })),
   toggleImageFlag: moderatorProcedure
     .input(toggleImageFlagSchema)
     .mutation(({ input, ctx }) => toggleImageFlag({ ...input })),
   refreshImageResources: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(getByIdSchema)
     .mutation(({ input }) => refreshImageResources(input.id)),
 });

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -85,6 +85,8 @@ import { emerchantpayRouter } from './emerchantpay.router';
 import { comicsRouter } from './comics.router';
 import { strikeRouter } from '~/server/routers/strike.router';
 import { rewardsBonusEventRouter } from './rewards-bonus-event.router';
+import { oauthClientRouter } from '~/server/routers/oauth-client.router';
+import { oauthConsentRouter } from '~/server/routers/oauth-consent.router';
 
 export const appRouter = router({
   account: accountRouter,
@@ -173,6 +175,8 @@ export const appRouter = router({
   comics: comicsRouter,
   strike: strikeRouter,
   rewardsBonusEvent: rewardsBonusEventRouter,
+  oauthClient: oauthClientRouter,
+  oauthConsent: oauthConsentRouter,
 });
 
 // export type definition of API

--- a/src/server/routers/integration.router.ts
+++ b/src/server/routers/integration.router.ts
@@ -1,10 +1,14 @@
 import { airConfirmSchema } from '~/server/schema/integration.schema';
 import { confirmAir, getAirStatus } from '~/server/services/integration.service';
 import { protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const integrationRouter = router({
-  airStatus: protectedProcedure.query(({ ctx }) => getAirStatus(ctx.user.id)),
+  airStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getAirStatus(ctx.user.id)),
   airConfirm: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(airConfirmSchema)
     .mutation(({ input, ctx }) => confirmAir({ email: input.email, userId: ctx.user.id })),
 });

--- a/src/server/routers/leaderboard.router.ts
+++ b/src/server/routers/leaderboard.router.ts
@@ -12,16 +12,18 @@ import {
   getLeaderboardLegends,
 } from '~/server/services/leaderboard.service';
 import { publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const leaderboardEdgeCache = edgeCacheIt({
   ttl: CacheTTL.xs,
 });
 
 export const leaderboardRouter = router({
-  getLeaderboards: publicProcedure.query(({ ctx }) =>
-    getLeaderboards({ isModerator: ctx?.user?.isModerator ?? false })
-  ),
+  getLeaderboards: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .query(({ ctx }) => getLeaderboards({ isModerator: ctx?.user?.isModerator ?? false })),
   getLeaderboardPositions: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getLeaderboardPositionsSchema)
     .use(cacheIt({ ttl: CacheTTL.day, tags: () => ['leaderboard', 'leaderboard-positions'] }))
     .query(({ input, ctx }) =>
@@ -32,6 +34,7 @@ export const leaderboardRouter = router({
       })
     ),
   getLeaderboard: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getLeaderboardSchema)
     .use(
       cacheIt({
@@ -44,6 +47,7 @@ export const leaderboardRouter = router({
       getLeaderboard({ ...input, isModerator: ctx?.user?.isModerator ?? false })
     ),
   getLeadboardLegends: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getLeaderboardSchema)
     .use(
       cacheIt({

--- a/src/server/routers/model-file.router.ts
+++ b/src/server/routers/model-file.router.ts
@@ -14,15 +14,32 @@ import {
 } from '~/server/schema/model-file.schema';
 import { getRecentTrainingData } from '~/server/services/model-file.service';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const modelFileRouter = router({
-  getByVersionId: publicProcedure.input(getByIdSchema).query(getFilesByVersionIdHandler),
-  create: protectedProcedure.input(modelFileCreateSchema).mutation(createFileHandler),
-  update: protectedProcedure.input(modelFileUpdateSchema).mutation(updateFileHandler),
-  upsert: protectedProcedure.input(modelFileUpsertSchema).mutation(upsertFileHandler),
-  delete: protectedProcedure.input(getByIdSchema).mutation(deleteFileHandler),
+  getByVersionId: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getFilesByVersionIdHandler),
+  create: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
+    .input(modelFileCreateSchema)
+    .mutation(createFileHandler),
+  update: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
+    .input(modelFileUpdateSchema)
+    .mutation(updateFileHandler),
+  upsert: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
+    .input(modelFileUpsertSchema)
+    .mutation(upsertFileHandler),
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsDelete })
+    .input(getByIdSchema)
+    .mutation(deleteFileHandler),
   // deleteMany: protectedProcedure.input(deleteApiKeyInputSchema).mutation(deleteApiKeyHandler),
   getRecentTrainingData: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(recentTrainingDataSchema)
     .query(({ input, ctx }) => getRecentTrainingData({ ...input, userId: ctx.user.id })),
 });

--- a/src/server/routers/model-version.router.ts
+++ b/src/server/routers/model-version.router.ts
@@ -65,6 +65,7 @@ import {
 } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, input, next }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -89,88 +90,123 @@ const isOwnerOrModerator = middleware(async ({ ctx, input, next }) => {
 });
 
 export const modelVersionRouter = router({
-  getById: publicProcedure.input(getModelVersionSchema).query(getModelVersionHandler),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getModelVersionSchema)
+    .query(getModelVersionHandler),
   // Owner-only variant that reads from the primary DB. Used by the upload/edit
   // wizards and the files modal so a freshly-mutated file or linked-component
   // is immediately visible regardless of replication lag. Owner/moderator
   // middleware guards the primary-read load.
   getByIdForEdit: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getModelVersionSchema)
     .use(isOwnerOrModerator)
     .query(getModelVersionForEditHandler),
-  getOwner: publicProcedure.input(getByIdSchema).query(getModelVersionOwnerHandler),
-  getRunStrategies: publicProcedure.input(getByIdSchema).query(getModelVersionRunStrategiesHandler),
+  getOwner: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getModelVersionOwnerHandler),
+  getRunStrategies: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getModelVersionRunStrategiesHandler),
   getPopularity: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getModelVersionPopularityInput)
     .query(({ input }) => getModelVersionPopularity(input)),
   getPopularities: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getModelVersionsPopularityInput)
     .query(({ input }) => getModelVersionsPopularity(input)),
   getVersionsByIds: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getModelVersionsByIdsInput)
     .query(({ input }) => getVersionsByIds(input)),
   getExplorationPromptsById: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .query(({ input }) => getExplorationPromptsById(input)),
   toggleNotifyEarlyAccess: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('earlyAccessModel'))
     .mutation(toggleNotifyEarlyAccessHandler),
   setLinkedComponents: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(setLinkedComponentsSchema)
     .use(isOwnerOrModerator)
     .mutation(async ({ input }) => setLinkedComponents(input)),
   addLinkedComponent: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(addLinkedComponentSchema)
     .use(isOwnerOrModerator)
     .mutation(async ({ input }) => addLinkedComponent(input)),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(modelVersionUpsertSchema2)
     .use(isOwnerOrModerator)
     .mutation(upsertModelVersionHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsDelete })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteModelVersionHandler),
   publish: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(publishVersionSchema)
     .use(isOwnerOrModerator)
     .mutation(publishModelVersionHandler),
   unpublish: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(unpublishModelSchema)
     .use(isOwnerOrModerator)
     .mutation(unpublishModelVersionHandler),
   upsertExplorationPrompt: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(upsertExplorationPromptSchema)
     .use(isOwnerOrModerator)
     .mutation(({ input }) => upsertExplorationPrompt(input)),
   deleteExplorationPrompt: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(deleteExplorationPromptSchema)
     .use(isOwnerOrModerator)
     .mutation(({ input }) => deleteExplorationPrompt(input)),
   requestReview: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(requestReviewHandler),
   declineReview: moderatorProcedure.input(declineReviewSchema).mutation(declineReviewHandler),
   getModelVersionsByModelType: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getModelVersionByModelTypeSchema)
     .query(({ input }) => getModelVersionsByModelType(input)),
   earlyAccessModelVersionsOnTimeframe: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(earlyAccessModelVersionsOnTimeframeSchema)
     .query(earlyAccessModelVersionsOnTimeframeHandler),
   modelVersionsGeneratedImagesOnTimeframe: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(modelVersionsGeneratedImagesOnTimeframeSchema)
     .query(modelVersionGeneratedImagesOnTimeframeHandler),
-  getLicense: publicProcedure.input(getByIdSchema).query(getVersionLicenseHandler),
+  getLicense: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getVersionLicenseHandler),
   earlyAccessPurchase: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite, blockApiKeys: true })
     .input(modelVersionEarlyAccessPurchase)
     .mutation(modelVersionEarlyAccessPurchaseHandler),
-  donationGoals: publicProcedure.input(getByIdSchema).query(modelVersionDonationGoalsHandler),
+  donationGoals: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(modelVersionDonationGoalsHandler),
   getTrainingDetails: moderatorProcedure
     .input(getByIdSchema)
     .query(getModelVersionForTrainingReviewHandler),
   publishPrivateModelVersion: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(getByIdSchema)
     .mutation(publishPrivateModelVersionHandler),
   bustCache: moderatorProcedure.input(getByIdSchema).mutation(({ input }) => bustMvCache(input.id)),
@@ -184,10 +220,12 @@ export const modelVersionRouter = router({
     ])
   ),
   recheckTrainingStatus: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(recheckModelVersionTrainingStatusHandler),
   mergeVersions: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(mergeVersionsSchema)
     .mutation(({ input, ctx }) => mergeVersions({ ...input, userId: ctx.user.id })),
 });

--- a/src/server/routers/model.router.ts
+++ b/src/server/routers/model.router.ts
@@ -98,6 +98,7 @@ import {
   router,
 } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -129,114 +130,173 @@ const skipEdgeCache = middleware(async ({ input, ctx, next }) => {
 });
 
 export const modelRouter = router({
-  getById: publicProcedure.input(getModelByIdSchema).query(getModelHandler),
-  getOwner: publicProcedure.input(getByIdSchema).query(getModelOwnerHandler),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getModelByIdSchema)
+    .query(getModelHandler),
+  getOwner: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getModelOwnerHandler),
   getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getAllModelsSchema.extend({ page: z.never().optional() }))
     .use(skipEdgeCache)
     .use(edgeCacheIt({ ttl: 60 }))
     .query(getModelsInfiniteHandler),
   getAllPagedSimple: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getAllModelsSchema.extend({ cursor: z.never().optional() }))
     .use(cacheIt({ ttl: 60 }))
     .query(getModelsPagedSimpleHandler),
   getAllInfiniteSimple: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getSimpleModelsInfiniteSchema)
     .query(getSimpleModelsInfiniteHandler),
-  getVersions: publicProcedure.input(getModelVersionsSchema).query(getModelVersionsHandler),
-  getMyDraftModels: protectedProcedure.input(getAllQuerySchema).query(getMyDraftModelsHandler),
+  getVersions: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getModelVersionsSchema)
+    .query(getModelVersionsHandler),
+  getMyDraftModels: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getAllQuerySchema)
+    .query(getMyDraftModelsHandler),
   getMyTrainingModels: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead | TokenScope.AIServicesRead })
     .input(getMyTrainingModelsSchema)
     .query(getMyTrainingModelsHandler),
-  getMyAvailableModels: protectedProcedure.query(({ ctx }) =>
-    getAvailableModelsByUserId({ userId: ctx.user.id })
-  ),
+  getMyAvailableModels: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .query(({ ctx }) => getAvailableModelsByUserId({ userId: ctx.user.id })),
   getAvailableTrainingModels: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead | TokenScope.AIServicesRead })
     .input(limitOnly)
     .query(getAvailableTrainingModelsHandler),
   getRecentlyManuallyAdded: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(limitOnly)
     .query(({ ctx, input }) => getRecentlyManuallyAdded({ userId: ctx.user.id, ...input })),
   getRecentlyRecommended: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(limitOnly)
     .query(({ ctx, input }) => getRecentlyRecommended({ userId: ctx.user.id, ...input })),
   getRecentlyBid: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(limitOnly)
     .query(({ ctx, input }) => getRecentlyBid({ userId: ctx.user.id, ...input })),
-  getFeaturedModels: publicProcedure.query(() => getFeaturedModels()),
-  upsert: guardedProcedure.input(modelUpsertSchema).mutation(upsertModelHandler),
+  getFeaturedModels: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .query(() => getFeaturedModels()),
+  upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
+    .input(modelUpsertSchema)
+    .mutation(upsertModelHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsDelete })
     .input(deleteModelSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteModelHandler),
   publish: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(publishModelSchema)
     .use(isOwnerOrModerator)
     .mutation(publishModelHandler),
   unpublish: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(unpublishModelSchema)
     .use(isOwnerOrModerator)
     .mutation(unpublishModelHandler),
   // TODO - TEMP HACK for reporting modal
-  getModelReportDetails: publicProcedure.input(getByIdSchema).query(getModelReportDetailsHandler),
+  getModelReportDetails: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getModelReportDetailsHandler),
   getModelDetailsForReview: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .query(getModelDetailsForReviewHandler),
   restore: moderatorProcedure.input(getByIdSchema).mutation(restoreModelHandler),
-  getDownloadCommand: protectedProcedure.input(getDownloadSchema).query(getDownloadCommandHandler),
+  getDownloadCommand: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getDownloadSchema)
+    .query(getDownloadCommandHandler),
   reorderVersions: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(reorderModelVersionsSchema)
     .use(isOwnerOrModerator)
     .mutation(reorderModelVersionsHandler),
   toggleLock: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(toggleModelLockSchema)
     .use(isOwnerOrModerator)
     .mutation(toggleModelLockHandler),
   toggleLockComments: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(toggleModelLockSchema)
     .use(isOwnerOrModerator)
     .mutation(({ input }) => toggleLockComments(input)),
   getSimple: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .query(({ input, ctx }) => getSimpleModelWithVersions({ id: input.id, ctx })),
   requestReview: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(requestReviewHandler),
   declineReview: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(declineReviewSchema)
     .use(isOwnerOrModerator)
     .mutation(declineReviewHandler),
   changeMode: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(changeModelModifierSchema)
     .use(isOwnerOrModerator)
     .mutation(changeModelModifierHandler),
   getWithCategoriesSimple: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getModelsWithCategoriesSchema)
     .query(({ input }) => getAllModelsWithCategories(input)),
   setCategory: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(setModelsCategorySchema)
     .mutation(({ input, ctx }) => setModelsCategory({ ...input, userId: ctx.user?.id })),
   findResourcesToAssociate: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(findResourcesToAssociateSchema)
     .query(findResourcesToAssociateHandler),
   getAssociatedResourcesCardData: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getAssociatedResourcesSchema)
     .query(getAssociatedResourcesCardDataHandler),
   getAssociatedResourcesSimple: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getAssociatedResourcesSchema)
     .query(({ input }) => getAssociatedResourcesSimple(input)),
   setAssociatedResources: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(setAssociatedResourcesSchema)
     .mutation(({ input, ctx }) => setAssociatedResources(input, ctx.user)),
   rescan: moderatorProcedure.input(getByIdSchema).mutation(({ input }) => rescanModel(input)),
-  getModelsByHash: publicProcedure.input(modelByHashesInput).mutation(getModelByHashesHandler),
-  getTemplateFields: guardedProcedure.input(getByIdSchema).query(getModelTemplateFieldsHandler),
+  getModelsByHash: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(modelByHashesInput)
+    .mutation(getModelByHashesHandler),
+  getTemplateFields: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getModelTemplateFieldsHandler),
   getModelTemplateFieldsFromBounty: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .query(getModelTemplateFromBountyHandler),
-  getGallerySettings: publicProcedure.input(getByIdSchema).query(getModelGallerySettingsHandler),
+  getGallerySettings: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .query(getModelGallerySettingsHandler),
   updateGallerySettings: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(updateGallerySettingsSchema)
     .use(isOwnerOrModerator)
     .mutation(updateGallerySettingsHandler),
@@ -244,24 +304,30 @@ export const modelRouter = router({
     .input(toggleCheckpointCoverageSchema)
     .mutation(toggleCheckpointCoverageHandler),
   copyGallerySettings: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(copyGallerySettingsSchema)
     .use(isOwnerOrModerator)
     .mutation(copyGalleryBrowsingLevelHandler),
   getCollectionShowcase: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .query(getModelCollectionShowcaseHandler),
   setCollectionShowcase: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(setModelCollectionShowcaseSchema)
     .use(isOwnerOrModerator)
     .mutation(setModelCollectionShowcaseHandler),
   migrateToCollection: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(migrateResourceToCollectionSchema)
     .use(isOwnerOrModerator)
     .mutation(({ input }) => migrateResourceToCollection(input)),
   privateModelFromTraining: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(privateModelFromTrainingSchema)
     .mutation(privateModelFromTrainingHandler),
   publishPrivateModel: guardedProcedure
+    .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(publishPrivateModelSchema)
     .use(isOwnerOrModerator)
     .mutation(publishPrivateModelHandler),

--- a/src/server/routers/newsletter.router.ts
+++ b/src/server/routers/newsletter.router.ts
@@ -5,15 +5,23 @@ import {
   updateSubscription,
 } from '~/server/services/newsletter.service';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const newsletterRouter = router({
-  getSubscription: publicProcedure.query(({ ctx }) => getSubscription(ctx.user?.email)),
-  updateSubscription: publicProcedure.input(updateSubscriptionSchema).mutation(({ input, ctx }) =>
-    updateSubscription({
-      ...input,
-      email: input.email ?? ctx.user?.email,
-      userId: ctx.user?.id,
-    })
-  ),
-  postpone: protectedProcedure.mutation(({ ctx }) => postponeSubscription(ctx.user.id)),
+  getSubscription: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getSubscription(ctx.user?.email)),
+  updateSubscription: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(updateSubscriptionSchema)
+    .mutation(({ input, ctx }) =>
+      updateSubscription({
+        ...input,
+        email: input.email ?? ctx.user?.email,
+        userId: ctx.user?.id,
+      })
+    ),
+  postpone: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .mutation(({ ctx }) => postponeSubscription(ctx.user.id)),
 });

--- a/src/server/routers/notification.router.ts
+++ b/src/server/routers/notification.router.ts
@@ -9,15 +9,19 @@ import {
 } from '~/server/schema/notification.schema';
 import { markNotificationsRead } from '~/server/services/notification.service';
 import { protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const notificationRouter = router({
   getAllByUser: protectedProcedure
+    .meta({ requiredScope: TokenScope.NotificationsRead })
     .input(getUserNotificationsSchema.partial())
     .query(getUserNotificationsInfiniteHandler),
   markRead: protectedProcedure
+    .meta({ requiredScope: TokenScope.NotificationsWrite })
     .input(markReadNotificationInput)
     .mutation(({ input, ctx }) => markNotificationsRead({ ...input, userId: ctx.user.id })),
   updateUserSettings: protectedProcedure
+    .meta({ requiredScope: TokenScope.NotificationsWrite })
     .input(toggleNotificationSettingInput)
     .mutation(upsertUserNotificationSettingsHandler),
 });

--- a/src/server/routers/nowpayments.router.ts
+++ b/src/server/routers/nowpayments.router.ts
@@ -17,29 +17,36 @@ import { CacheTTL } from '~/server/common/constants';
 import { moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import * as z from 'zod';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const nowPaymentsRouter = router({
   // NOTE: This is a query with write side effects (creates address on first call).
   // Safe because the service layer uses distributed lock + DB dedup, so retries are idempotent.
   // Consider migrating to .mutation() with corresponding client-side useMutation() call.
   getDepositAddress: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getDepositAddressInputSchema)
     .query(getDepositAddressHandler),
   getDepositHistory: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(depositHistoryInputSchema)
     .query(getDepositHistoryHandler),
   getSupportedCurrencies: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .use(edgeCacheIt({ ttl: CacheTTL.hour }))
     .query(getSupportedCurrenciesHandler),
   getMinAmount: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getMinAmountInputSchema)
     .use(edgeCacheIt({ ttl: CacheTTL.hour }))
     .query(getMinAmountHandler),
   getBuzzConversionRate: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getBuzzConversionRateInputSchema)
     .use(edgeCacheIt({ ttl: CacheTTL.hour }))
     .query(getBuzzConversionRateHandler),
   reconcileMyDeposits: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .use(rateLimit({ limit: 1, period: 60 }))
     .mutation(reconcileUserDepositsHandler),
   reconcileUserDeposits: moderatorProcedure

--- a/src/server/routers/oauth-client.router.ts
+++ b/src/server/routers/oauth-client.router.ts
@@ -1,0 +1,145 @@
+import { TRPCError } from '@trpc/server';
+import { v4 as uuidv4 } from 'uuid';
+import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import {
+  createOauthClientSchema,
+  deleteOauthClientSchema,
+  getOauthClientByIdSchema,
+  rotateOauthClientSecretSchema,
+  updateOauthClientSchema,
+} from '~/server/schema/oauth-client.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+export const oauthClientRouter = router({
+  // Public: get client info by ID (used by consent page)
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getOauthClientByIdSchema)
+    .query(async ({ input }) => {
+      const client = await dbRead.oauthClient.findUnique({
+        where: { id: input.id },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          logoUrl: true,
+          isVerified: true,
+          redirectUris: true,
+          allowedScopes: true,
+        },
+      });
+      if (!client) throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
+      return client;
+    }),
+
+  // Get all clients owned by the current user
+  getAll: protectedProcedure.meta({ requiredScope: TokenScope.UserRead }).query(async ({ ctx }) => {
+    return dbRead.oauthClient.findMany({
+      where: { userId: ctx.user.id },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        logoUrl: true,
+        redirectUris: true,
+        grants: true,
+        allowedScopes: true,
+        isConfidential: true,
+        isVerified: true,
+        createdAt: true,
+        _count: { select: { tokens: true, consents: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }),
+
+  // Register a new OAuth client
+  create: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(createOauthClientSchema)
+    .mutation(async ({ ctx, input }) => {
+      const clientId = uuidv4();
+      const clientSecret = input.isConfidential ? generateKey(48) : null;
+      const hashedSecret = clientSecret ? generateSecretHash(clientSecret) : null;
+
+      await dbWrite.oauthClient.create({
+        data: {
+          id: clientId,
+          secret: hashedSecret,
+          name: input.name,
+          description: input.description,
+          redirectUris: input.redirectUris,
+          isConfidential: input.isConfidential,
+          allowedScopes: input.allowedScopes,
+          userId: ctx.user.id,
+        },
+      });
+
+      logOAuthEvent({ type: 'client.created', userId: ctx.user.id, clientId });
+
+      return {
+        clientId,
+        clientSecret, // Only returned once — shown to the developer
+      };
+    }),
+
+  // Update client details
+  update: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(updateOauthClientSchema)
+    .mutation(async ({ ctx, input }) => {
+      const client = await dbWrite.oauthClient.findFirst({
+        where: { id: input.id, userId: ctx.user.id },
+      });
+      if (!client) throw new TRPCError({ code: 'NOT_FOUND' });
+
+      const { id, ...data } = input;
+      const result = await dbWrite.oauthClient.update({ where: { id }, data });
+      logOAuthEvent({ type: 'client.updated', userId: ctx.user.id, clientId: id });
+      return result;
+    }),
+
+  // Rotate client secret
+  rotateSecret: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(rotateOauthClientSecretSchema)
+    .mutation(async ({ ctx, input }) => {
+      const client = await dbWrite.oauthClient.findFirst({
+        where: { id: input.id, userId: ctx.user.id, isConfidential: true },
+      });
+      if (!client) throw new TRPCError({ code: 'NOT_FOUND' });
+
+      const newSecret = generateKey(48);
+      const hashedSecret = generateSecretHash(newSecret);
+
+      await dbWrite.oauthClient.update({
+        where: { id: input.id },
+        data: { secret: hashedSecret },
+      });
+
+      logOAuthEvent({ type: 'client.secret_rotated', userId: ctx.user.id, clientId: input.id });
+
+      return { clientSecret: newSecret };
+    }),
+
+  // Delete a client and all associated tokens/consents
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(deleteOauthClientSchema)
+    .mutation(async ({ ctx, input }) => {
+      const client = await dbWrite.oauthClient.findFirst({
+        where: { id: input.id, userId: ctx.user.id },
+      });
+      if (!client) throw new TRPCError({ code: 'NOT_FOUND' });
+
+      // Cascade delete handles tokens and consents
+      await dbWrite.oauthClient.delete({ where: { id: input.id } });
+
+      logOAuthEvent({ type: 'client.deleted', userId: ctx.user.id, clientId: input.id });
+
+      return { success: true };
+    }),
+});

--- a/src/server/routers/oauth-consent.router.ts
+++ b/src/server/routers/oauth-consent.router.ts
@@ -1,0 +1,163 @@
+import { TRPCError } from '@trpc/server';
+import { protectedProcedure, router } from '~/server/trpc';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { buzzLimitSchema, type BuzzLimit } from '~/server/schema/api-key.schema';
+import { bustBuzzLimitCache, deleteAuthSubject } from '~/server/http/orchestrator/api-key-spend';
+import { logToAxiom, safeError } from '~/server/logging/client';
+import * as z from 'zod';
+
+export const oauthConsentRouter = router({
+  // Get all apps the user has authorized (connected apps)
+  getConnectedApps: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(async ({ ctx }) => {
+      const consents = await dbRead.oauthConsent.findMany({
+        where: { userId: ctx.user.id },
+        include: {
+          client: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              logoUrl: true,
+              isVerified: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      return consents.map((consent) => ({
+        clientId: consent.clientId,
+        name: consent.client.name,
+        description: consent.client.description,
+        logoUrl: consent.client.logoUrl,
+        isVerified: consent.client.isVerified,
+        scope: consent.scope,
+        buzzLimit: consent.buzzLimit as BuzzLimit | null,
+        authorizedAt: consent.createdAt,
+      }));
+    }),
+
+  // Set or clear the buzz spend limit for a connected app. The limit lives on
+  // the consent so it persists across access-token rotations — refresh-issued
+  // tokens for the same consent inherit it automatically.
+  setBuzzLimit: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(
+      z.object({
+        clientId: z.string(),
+        buzzLimit: buzzLimitSchema.nullable(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Self-modify guard: an OAuth-issued token must not be able to raise or
+      // clear the limit on the consent it was issued under. Session auth is
+      // unaffected.
+      const subject = (
+        ctx as unknown as {
+          subject?: { type: string; id: number | string } | null;
+        }
+      ).subject;
+      if (subject && subject.type === 'oauth' && subject.id === input.clientId) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message:
+            'An OAuth token cannot modify its own consent spend limit. Use a different key or session auth.',
+        });
+      }
+
+      const consent = await dbWrite.oauthConsent.findUnique({
+        where: { userId_clientId: { userId: ctx.user.id, clientId: input.clientId } },
+        select: { id: true },
+      });
+      if (!consent) throw new TRPCError({ code: 'NOT_FOUND' });
+
+      await dbWrite.oauthConsent.update({
+        where: { userId_clientId: { userId: ctx.user.id, clientId: input.clientId } },
+        data: { buzzLimit: input.buzzLimit ?? null },
+      });
+
+      // Best-effort bust-cache. The orchestrator caches limits by (type, id);
+      // for OAuth grants the id is the clientId (stable across access-token
+      // rotations). Failure is logged but doesn't fail the user mutation.
+      try {
+        await bustBuzzLimitCache({
+          userId: ctx.user.id,
+          subject: { type: 'oauth', id: input.clientId },
+        });
+      } catch (err) {
+        logToAxiom({
+          type: 'oauth.bust-cache.failed',
+          message: `bust-cache failed for oauth client ${input.clientId} user ${ctx.user.id}`,
+          error: safeError(err),
+        }).catch(() => {});
+      }
+
+      // Audit trail in ClickHouse `actions`. Fire-and-forget.
+      ctx.track
+        .action({
+          type: 'BuzzLimit_Set',
+          details: {
+            subjectType: 'oauth',
+            subjectId: input.clientId,
+            buzzLimit: input.buzzLimit,
+            viaSubject: (ctx as unknown as { subject?: unknown }).subject ?? null,
+          },
+        })
+        .catch(() => {});
+
+      return { success: true, buzzLimit: input.buzzLimit };
+    }),
+
+  // Revoke access for a connected app (delete all tokens + consent)
+  revokeApp: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(z.object({ clientId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const consent = await dbWrite.oauthConsent.findUnique({
+        where: { userId_clientId: { userId: ctx.user.id, clientId: input.clientId } },
+      });
+      if (!consent) throw new TRPCError({ code: 'NOT_FOUND' });
+
+      // Delete all tokens for this client+user
+      await dbWrite.apiKey.deleteMany({
+        where: {
+          userId: ctx.user.id,
+          clientId: input.clientId,
+          type: { in: ['Access', 'Refresh'] },
+        },
+      });
+
+      // Delete consent record
+      await dbWrite.oauthConsent.delete({
+        where: { userId_clientId: { userId: ctx.user.id, clientId: input.clientId } },
+      });
+
+      // Best-effort: tell the orchestrator the OAuth subject is gone so its
+      // stored spend record doesn't linger after the user revokes the app.
+      deleteAuthSubject({
+        userId: ctx.user.id,
+        subject: { type: 'oauth', id: input.clientId },
+      }).catch((err) => {
+        logToAxiom({
+          type: 'oauth.delete-subject.failed',
+          message: `delete-subject failed for oauth client ${input.clientId} user ${ctx.user.id}`,
+          error: safeError(err),
+        }).catch(() => {});
+      });
+
+      logOAuthEvent({
+        type: 'authorization.denied',
+        userId: ctx.user.id,
+        clientId: input.clientId,
+        metadata: { action: 'revoked_by_user' },
+      });
+
+      return { success: true };
+    }),
+
+  // (the limit-set audit fire is added on `setBuzzLimit` below)
+});

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -73,6 +73,7 @@ import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { getAllowedAccountTypes } from '../utils/buzz-helpers';
 import { getVideoMetadata } from '~/server/services/orchestrator/videoEnhancement';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 /**
  * Resolves the currencies to use for a generation request.
@@ -220,11 +221,13 @@ const ITERATE_MODEL_CONFIG: Record<
 
 export const orchestratorRouter = router({
   getVideoMetadata: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(z.object({ videoUrl: z.string() }))
     .query(({ ctx, input }) => getVideoMetadata(input)),
 
   // #region [prompt enhancement]
   enhancePrompt: orchestratorGuardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(promptEnhancementSchema)
     .mutation(({ ctx, input }) =>
       enhancePrompt({
@@ -238,6 +241,7 @@ export const orchestratorRouter = router({
     ),
   /** Generic workflow query by tags — used for prompt enhancement history, future text workflows, etc. */
   queryWorkflowsByTags: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(workflowQuerySchema)
     .query(async ({ ctx, input }) => {
       return queryWorkflows({
@@ -247,6 +251,7 @@ export const orchestratorRouter = router({
       });
     }),
   getWorkflow: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(workflowIdSchema)
     .query(({ ctx, input }) =>
       getWorkflow({ token: ctx.token, path: { workflowId: input.workflowId } })
@@ -255,18 +260,22 @@ export const orchestratorRouter = router({
 
   // #region [requests]
   deleteWorkflow: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(workflowIdSchema)
     .mutation(({ ctx, input }) => deleteWorkflow({ ...input, token: ctx.token })),
   cancelWorkflow: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(workflowIdSchema)
     .mutation(({ ctx, input }) => cancelWorkflow({ ...input, token: ctx.token })),
   updateWorkflow: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(workflowUpdateSchema)
     .mutation(({ ctx, input }) => updateWorkflow({ ...input, token: ctx.token })),
   // #endregion
 
   // #region [steps]
   patch: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(patchSchema)
     .mutation(async ({ ctx, input: { workflows, steps, tags, remove } }) => {
       // const toUpdate: { workflowId: string; patches: JsonPatchOperation[] }[] = [];
@@ -321,20 +330,24 @@ export const orchestratorRouter = router({
   // #endregion
 
   // #region [generated images]
-  queryGeneratedImages: orchestratorProcedure.input(workflowQuerySchema).query(({ ctx, input }) =>
-    queryGeneratedImageWorkflows2({
-      ...input,
-      token: ctx.token,
-      user: ctx.user,
-      tags: ctx.domain === 'green' ? [...input.tags, 'green'] : input.tags,
-      hideMatureContent: ctx.hideMatureContent,
-    })
-  ),
+  queryGeneratedImages: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .input(workflowQuerySchema)
+    .query(({ ctx, input }) =>
+      queryGeneratedImageWorkflows2({
+        ...input,
+        token: ctx.token,
+        user: ctx.user,
+        tags: ctx.domain === 'green' ? [...input.tags, 'green'] : input.tags,
+        hideMatureContent: ctx.hideMatureContent,
+      })
+    ),
   // #region [Generation Graph V2 endpoints]
   /**
    * Generate from graph - unified endpoint for all generation types
    */
   generateFromGraph: orchestratorGuardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(z.any())
     .mutation(async ({ ctx, input }) => {
       const {
@@ -385,48 +398,52 @@ export const orchestratorRouter = router({
   /**
    * What-if from graph - cost estimation for generation-graph inputs
    */
-  whatIfFromGraph: orchestratorGuardedProcedure.input(z.any()).query(async ({ ctx, input }) => {
-    const userTier = ctx.user.tier ?? 'free';
-    const { externalCtx, status } = await buildGenerationContext(userTier, ctx.features);
+  whatIfFromGraph: orchestratorGuardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .input(z.any())
+    .query(async ({ ctx, input }) => {
+      const userTier = ctx.user.tier ?? 'free';
+      const { externalCtx, status } = await buildGenerationContext(userTier, ctx.features);
 
-    if (!status.available && !ctx.user.isModerator) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: status.message ?? 'Generation is currently disabled',
-      });
-    }
+      if (!status.available && !ctx.user.isModerator) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: status.message ?? 'Generation is currently disabled',
+        });
+      }
 
-    try {
-      return await whatIfFromGraph({
-        input,
-        externalCtx,
-        userId: ctx.user.id,
-        isModerator: ctx.user.isModerator,
-        token: ctx.token,
-        experimental: ctx.experimental,
-        currencies: getAllowedAccountTypes(ctx.features, ['blue']),
-      });
-    } catch (e) {
-      logToAxiom({
-        name: 'what-if-from-graph',
-        type: 'error',
-        payload: input,
-        error:
-          e instanceof TRPCError
-            ? {
-                code: e.code,
-                name: e.name,
-                message: e.message,
-              }
-            : e,
-      }).catch();
-      throw e;
-    }
-  }),
+      try {
+        return await whatIfFromGraph({
+          input,
+          externalCtx,
+          userId: ctx.user.id,
+          isModerator: ctx.user.isModerator,
+          token: ctx.token,
+          experimental: ctx.experimental,
+          currencies: getAllowedAccountTypes(ctx.features, ['blue']),
+        });
+      } catch (e) {
+        logToAxiom({
+          name: 'what-if-from-graph',
+          type: 'error',
+          payload: input,
+          error:
+            e instanceof TRPCError
+              ? {
+                  code: e.code,
+                  name: e.name,
+                  message: e.message,
+                }
+              : e,
+        }).catch();
+        throw e;
+      }
+    }),
   // #endregion
 
   // #region [Image upload]
   imageUpload: orchestratorGuardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(z.object({ sourceImage: z.string() }))
     .mutation(({ ctx, input }) =>
       imageUpload({ token: ctx.token, allowMatureContent: ctx.allowMatureContent, ...input })
@@ -435,6 +452,7 @@ export const orchestratorRouter = router({
 
   // #region [image training]
   createTraining: orchestratorGuardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(imageTrainingRouterInputSchema)
     .mutation(async ({ ctx, input }) => {
       const { buzzType, ...rest } = input;
@@ -448,6 +466,7 @@ export const orchestratorRouter = router({
       return await createTrainingWorkflow(args);
     }),
   createTrainingWhatif: orchestratorProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(imageTrainingRouterWhatIfSchema)
     .query(async ({ ctx, input }) => {
       const args = {
@@ -494,6 +513,7 @@ export const orchestratorRouter = router({
       reviewConsumerStrikes({ consumerId: `civitai-${input.userId}`, moderatorId: ctx.user.id })
     ),
   statusUpdate: orchestratorGuardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(workflowIdSchema)
     .query(({ ctx, input }) =>
       getWorkflowStatusUpdate({ token: ctx.token, workflowId: input.workflowId })
@@ -502,6 +522,7 @@ export const orchestratorRouter = router({
   // ── Generic iterative image editor endpoints ──
 
   iterateGenerate: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(
       z.object({
         prompt: z.string().min(1).max(2000),
@@ -616,6 +637,7 @@ export const orchestratorRouter = router({
     }),
 
   getIterateCostEstimate: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(
       z.object({
         baseModel: z.string().nullish(),
@@ -720,6 +742,7 @@ export const orchestratorRouter = router({
     }),
 
   pollIterationStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(
       z.object({
         workflowId: z.string().min(1),

--- a/src/server/routers/paddle.router.ts
+++ b/src/server/routers/paddle.router.ts
@@ -20,26 +20,41 @@ import {
 } from '~/server/schema/paddle.schema';
 import { getByIdStringSchema } from '~/server/schema/base.schema';
 import { refreshSubscription } from '../services/paddle.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const paddleRouter = router({
   createBuzzPurchaseTransaction: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(transactionCreateSchema)
     .mutation(createBuzzPurchaseTransactionHandler),
   processCompleteBuzzTransaction: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getByIdStringSchema)
     .mutation(processCompleteBuzzTransactionHandler),
   updateSubscription: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(updateSubscriptionInputSchema)
     .mutation(updateSubscriptionPlanHandler),
   // cancelSubscription: protectedProcedure.mutation(cancelSubscriptionHandler),
-  cancelSubscription: protectedProcedure.mutation(cancelEmailHandler),
+  cancelSubscription: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .mutation(cancelEmailHandler),
   purchaseBuzzWithSubscription: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(transactionWithSubscriptionCreateSchema)
     .mutation(purchaseBuzzWithSubscriptionHandler),
-  getManagementUrls: protectedProcedure.query(getManagementUrlsHandler),
-  getOrCreateCustomer: protectedProcedure.mutation(getOrCreateCustomerHandler),
-  refreshSubscription: protectedProcedure.mutation(refreshSubscriptionHandler),
-  hasSubscription: protectedProcedure.query(hasPaddleSubscriptionHandler),
+  getManagementUrls: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(getManagementUrlsHandler),
+  getOrCreateCustomer: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .mutation(getOrCreateCustomerHandler),
+  refreshSubscription: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .mutation(refreshSubscriptionHandler),
+  hasSubscription: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(hasPaddleSubscriptionHandler),
   getAdjustmentsInfinite: moderatorProcedure
     .input(getPaddleAdjustmentsSchema)
     .query(getAdjustmentsInfiniteHandler),

--- a/src/server/routers/partner.router.ts
+++ b/src/server/routers/partner.router.ts
@@ -1,6 +1,9 @@
 import { router, publicProcedure } from '~/server/trpc';
 import { getAllPartners } from '~/server/services/partner.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const partnerRouter = router({
-  getAll: publicProcedure.query(() => getAllPartners()),
+  getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .query(() => getAllPartners()),
 });

--- a/src/server/routers/paypal.router.ts
+++ b/src/server/routers/paypal.router.ts
@@ -4,10 +4,15 @@ import {
 } from './../controllers/paypal.controller';
 import { router, protectedProcedure } from '~/server/trpc';
 import { paypalOrderSchema, paypalPurchaseBuzzSchema } from '../schema/paypal.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const paypalRouter = router({
   createBuzzOrder: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(paypalPurchaseBuzzSchema)
     .mutation(createBuzzOrderHandler),
-  processBuzzOrder: protectedProcedure.input(paypalOrderSchema).mutation(processBuzzOrderHandler),
+  processBuzzOrder: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(paypalOrderSchema)
+    .mutation(processBuzzOrderHandler),
 });

--- a/src/server/routers/post.router.ts
+++ b/src/server/routers/post.router.ts
@@ -39,6 +39,7 @@ import { addPostImage, getPostEditDetail } from './../services/post.service';
 import { guardedProcedure, publicProcedure, verifiedProcedure } from './../trpc';
 import { enqueueJobs } from '~/server/services/job-queue.service';
 import { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -89,58 +90,81 @@ const isImageOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => 
 
 export const postRouter = router({
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(postsQuerySchema)
     .use(applyUserPreferences)
     .query(getPostsInfiniteHandler),
-  get: publicProcedure.input(getByIdSchema).query(getPostHandler),
+  get: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getPostHandler),
   getEdit: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .query(({ ctx, input }) => getPostEditDetail({ ...input, user: ctx.user })),
-  create: guardedProcedure.input(postCreateSchema).mutation(createPostHandler),
+  create: guardedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
+    .input(postCreateSchema)
+    .mutation(createPostHandler),
   update: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(postUpdateSchema)
     .use(isOwnerOrModerator)
     .mutation(updatePostHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaDelete })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deletePostHandler),
   addImage: guardedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(imageSchema.extend({ postId: z.number() }))
     .mutation(({ ctx, input }) => addPostImage({ ...input, user: ctx.user })),
   updateImage: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updatePostImageSchema)
     .use(isImageOwnerOrModerator)
     .mutation(updatePostImageHandler),
   addResourceToImage: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(addResourceToPostImageInput)
     .use(isImageOwnerOrModerator)
     .mutation(addResourceToPostImageHandler),
   removeResourceFromImage: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(removeResourceFromPostImageInput)
     .use(isImageOwnerOrModerator)
     .mutation(removeResourceFromPostImageHandler),
   reorderImages: verifiedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(reorderPostImagesSchema)
     .use(isOwnerOrModerator)
     .mutation(reorderPostImagesHandler),
   getTags: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getPostTagsSchema)
     .use(applyUserPreferences)
     .query(getPostTagsHandler),
   addTag: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(addPostTagSchema)
     .use(isOwnerOrModerator)
     .mutation(addPostTagHandler),
   removeTag: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(removePostTagSchema)
     .use(isOwnerOrModerator)
     .mutation(removePostTagHandler),
-  getResources: publicProcedure.input(getByIdSchema).query(getPostResourcesHandler),
+  getResources: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getPostResourcesHandler),
   getContestCollectionDetails: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .query(getPostContestCollectionDetailsHandler),
   updateCollectionTagId: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
     .input(updatePostCollectionTagIdInput)
     .use(isOwnerOrModerator)
     .mutation(updatePostCollectionTagIdHandler),

--- a/src/server/routers/product-badge.router.ts
+++ b/src/server/routers/product-badge.router.ts
@@ -9,6 +9,7 @@ import {
   upsertProductBadge,
 } from '~/server/services/product-badge.service';
 import { moderatorProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const productBadgeRouter = router({
   getProductsWithBadges: moderatorProcedure.input(getProductsWithBadgesInput).query(({ input }) => {

--- a/src/server/routers/purchasable-reward.router.ts
+++ b/src/server/routers/purchasable-reward.router.ts
@@ -14,11 +14,15 @@ import {
 } from '~/server/services/purchasable-reward.service';
 import { moderatorProcedure, protectedProcedure, publicProcedure, router } from '~/server/trpc';
 import { getAllowedAccountTypes } from '~/server/utils/buzz-helpers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const purchasableRewardRouter = router({
-  getPaged: publicProcedure.input(getPaginatedPurchasableRewardsSchema).query(({ input, ctx }) => {
-    return getPaginatedPurchasableRewards({ ...input, userId: ctx?.user?.id });
-  }),
+  getPaged: publicProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .input(getPaginatedPurchasableRewardsSchema)
+    .query(({ input, ctx }) => {
+      return getPaginatedPurchasableRewards({ ...input, userId: ctx?.user?.id });
+    }),
   getModeratorPaged: moderatorProcedure
     .input(getPaginatedPurchasableRewardsModeratorSchema)
     .query(({ input }) => {
@@ -27,13 +31,16 @@ export const purchasableRewardRouter = router({
   upsert: moderatorProcedure.input(purchasableRewardUpsertSchema).mutation(({ input, ctx }) => {
     return purchasableRewardUpsert({ ...input, userId: ctx.user.id });
   }),
-  purchase: protectedProcedure.input(purchasableRewardPurchaseSchema).mutation(({ input, ctx }) => {
-    return purchasableRewardPurchase({
-      ...input,
-      userId: ctx.user.id,
-      buzzType: getAllowedAccountTypes(ctx.features)[0],
-    });
-  }),
+  purchase: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite, blockApiKeys: true })
+    .input(purchasableRewardPurchaseSchema)
+    .mutation(({ input, ctx }) => {
+      return purchasableRewardPurchase({
+        ...input,
+        userId: ctx.user.id,
+        buzzType: getAllowedAccountTypes(ctx.features)[0],
+      });
+    }),
   getById: moderatorProcedure.input(getByIdSchema).query(({ input }) => {
     return getPurchasableReward(input);
   }),

--- a/src/server/routers/question.router.ts
+++ b/src/server/routers/question.router.ts
@@ -18,6 +18,7 @@ import {
   getQuestionsHandler,
   upsertQuestionHandler,
 } from '~/server/controllers/question.controller';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -44,17 +45,26 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 });
 
 export const questionRouter = router({
-  getById: publicProcedure.input(getByIdSchema).query(getQuestionDetailHandler),
-  getPaged: publicProcedure.input(getQuestionsSchema).query(getQuestionsHandler),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(getQuestionDetailHandler),
+  getPaged: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getQuestionsSchema)
+    .query(getQuestionsHandler),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(upsertQuestionSchema)
     .use(isOwnerOrModerator)
     .mutation(upsertQuestionHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteQuestionHandler),
   setAnswer: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(setQuestionAnswerSchema)
     .use(isOwnerOrModerator)
     .mutation(setQuestionAnswerHandler),

--- a/src/server/routers/reaction.router.ts
+++ b/src/server/routers/reaction.router.ts
@@ -3,9 +3,11 @@ import { toggleReactionSchema, reactionRateLimits } from './../schema/reaction.s
 import { router, guardedProcedure } from '~/server/trpc';
 import { rateLimit } from '~/server/middleware.trpc';
 import { handleLogError } from '~/server/utils/errorHandling';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const reactionRouter = router({
   toggle: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(toggleReactionSchema)
     .use(rateLimit(reactionRateLimits))
     .mutation(({ ctx, input }) => {

--- a/src/server/routers/recommenders.router.ts
+++ b/src/server/routers/recommenders.router.ts
@@ -5,13 +5,16 @@ import {
 import { getByIdSchema } from '~/server/schema/base.schema';
 import { recommendationRequestSchema } from '~/server/schema/recommenders.schema';
 import { isFlagProtected, protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const recommendersRouter = router({
   getResourceRecommendations: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(recommendationRequestSchema)
     .use(isFlagProtected('recommenders'))
     .query(getRecommendedResourcesCardDataHandler),
   toggleResourceRecommendations: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(getByIdSchema)
     .use(isFlagProtected('recommenders'))
     .mutation(toggleResourceRecommendationHandler),

--- a/src/server/routers/redeemableCode.router.ts
+++ b/src/server/routers/redeemableCode.router.ts
@@ -20,17 +20,19 @@ import {
 } from '~/server/services/redeemableCode.service';
 import { cachedCounter } from '~/server/utils/cache-helpers';
 import { REDIS_KEYS } from '~/server/redis/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const redemptionCounter = cachedCounter(REDIS_KEYS.COUNTERS.REDEMPTION_ATTEMPTS);
 
 export const redeemableCodeRouter = router({
-  getMyPurchasedCodes: protectedProcedure.query(({ ctx }) =>
-    getMyPurchasedCodes({ userId: ctx.user.id })
-  ),
-  getMyConsumedMembershipCodes: protectedProcedure.query(({ ctx }) =>
-    getMyConsumedMembershipCodes({ userId: ctx.user.id })
-  ),
+  getMyPurchasedCodes: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(({ ctx }) => getMyPurchasedCodes({ userId: ctx.user.id })),
+  getMyConsumedMembershipCodes: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(({ ctx }) => getMyConsumedMembershipCodes({ userId: ctx.user.id })),
   getCodeByOrderId: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getCodeByOrderIdSchema)
     .query(({ input, ctx }) => getCodeByOrderId({ ...input, userId: ctx.user.id })),
   create: moderatorProcedure.input(createRedeemableCodeSchema).mutation(async ({ input, ctx }) => {
@@ -43,6 +45,7 @@ export const redeemableCodeRouter = router({
     await ctx.track.redeemableCode('delete', { code: input.code });
   }),
   consume: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(consumeRedeemableCodeSchema)
     .mutation(async ({ input, ctx }) => {
       const attempts = await redemptionCounter.incrementBy(ctx.user.id);

--- a/src/server/routers/referral.router.ts
+++ b/src/server/routers/referral.router.ts
@@ -14,6 +14,7 @@ import { ReferralRewardKind, ReferralRewardStatus } from '~/shared/utils/prisma/
 import { signalClient } from '~/utils/signal-client';
 import { SignalMessages } from '~/server/common/enums';
 import type { SubscriptionProductMetadata } from '~/server/schema/subscriptions.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const redeemInput = z.object({ offerIndex: z.number().int().min(0) });
 
@@ -63,129 +64,137 @@ async function generateCleanCode() {
 }
 
 export const referralRouter = router({
-  getDashboard: protectedProcedure.query(async ({ ctx }) => {
-    const userId = ctx.user.id;
-    // Fire-and-forget: backfill any milestones the user has earned but that
-    // weren't written yet (e.g. after the points-rebalance). awardMilestones
-    // is idempotent via a unique (userId, threshold) constraint.
-    awardMilestones(userId).catch(() => undefined);
-    const [
-      code,
-      balance,
-      recentRewards,
-      milestones,
-      redemptions,
-      conversionStats,
-      referralSub,
-      paidMembership,
-    ] = await Promise.all([
-      getOrCreateCode(userId),
-      getReferrerBalance(userId),
-      dbRead.referralReward.findMany({
-        where: {
-          userId,
-          kind: { in: [ReferralRewardKind.MembershipToken, ReferralRewardKind.BuzzKickback] },
-          status: { in: [ReferralRewardStatus.Pending, ReferralRewardStatus.Settled] },
-        },
-        orderBy: { earnedAt: 'desc' },
-        take: 25,
-        select: {
-          id: true,
-          kind: true,
-          status: true,
-          tokenAmount: true,
-          buzzAmount: true,
-          tierGranted: true,
-          earnedAt: true,
-          settledAt: true,
-          expiresAt: true,
-        },
-      }),
-      dbRead.referralMilestone.findMany({ where: { userId }, orderBy: { threshold: 'asc' } }),
-      dbRead.referralRedemption.findMany({
-        where: { userId },
-        orderBy: { createdAt: 'desc' },
-        take: 10,
-      }),
-      dbRead.userReferral.count({
-        where: {
-          userReferralCode: { userId },
-          firstPaidAt: { not: null },
-        },
-      }),
-      dbRead.customerSubscription.findFirst({
-        where: { userId, buzzType: 'referral' },
-        select: {
-          status: true,
-          currentPeriodStart: true,
-          currentPeriodEnd: true,
-          metadata: true,
-          product: { select: { metadata: true } },
-        },
-      }),
-      dbRead.customerSubscription.findFirst({
-        where: { userId, status: 'active', buzzType: { not: 'referral' } },
-        select: {
-          currentPeriodEnd: true,
-          product: { select: { metadata: true } },
-        },
-      }),
-    ]);
+  getDashboard: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(async ({ ctx }) => {
+      const userId = ctx.user.id;
+      // Fire-and-forget: backfill any milestones the user has earned but that
+      // weren't written yet (e.g. after the points-rebalance). awardMilestones
+      // is idempotent via a unique (userId, threshold) constraint.
+      awardMilestones(userId).catch(() => undefined);
+      const [
+        code,
+        balance,
+        recentRewards,
+        milestones,
+        redemptions,
+        conversionStats,
+        referralSub,
+        paidMembership,
+      ] = await Promise.all([
+        getOrCreateCode(userId),
+        getReferrerBalance(userId),
+        dbRead.referralReward.findMany({
+          where: {
+            userId,
+            kind: { in: [ReferralRewardKind.MembershipToken, ReferralRewardKind.BuzzKickback] },
+            status: { in: [ReferralRewardStatus.Pending, ReferralRewardStatus.Settled] },
+          },
+          orderBy: { earnedAt: 'desc' },
+          take: 25,
+          select: {
+            id: true,
+            kind: true,
+            status: true,
+            tokenAmount: true,
+            buzzAmount: true,
+            tierGranted: true,
+            earnedAt: true,
+            settledAt: true,
+            expiresAt: true,
+          },
+        }),
+        dbRead.referralMilestone.findMany({ where: { userId }, orderBy: { threshold: 'asc' } }),
+        dbRead.referralRedemption.findMany({
+          where: { userId },
+          orderBy: { createdAt: 'desc' },
+          take: 10,
+        }),
+        dbRead.userReferral.count({
+          where: {
+            userReferralCode: { userId },
+            firstPaidAt: { not: null },
+          },
+        }),
+        dbRead.customerSubscription.findFirst({
+          where: { userId, buzzType: 'referral' },
+          select: {
+            status: true,
+            currentPeriodStart: true,
+            currentPeriodEnd: true,
+            metadata: true,
+            product: { select: { metadata: true } },
+          },
+        }),
+        dbRead.customerSubscription.findFirst({
+          where: { userId, status: 'active', buzzType: { not: 'referral' } },
+          select: {
+            currentPeriodEnd: true,
+            product: { select: { metadata: true } },
+          },
+        }),
+      ]);
 
-    const activeTier = (
-      (referralSub?.product?.metadata ?? null) as {
-        tier?: string;
-      } | null
-    )?.tier;
-    const referralQueue =
-      (referralSub?.metadata as { referralQueue?: { tier: string; durationDays: number }[] } | null)
-        ?.referralQueue ?? [];
+      const activeTier = (
+        (referralSub?.product?.metadata ?? null) as {
+          tier?: string;
+        } | null
+      )?.tier;
+      const referralQueue =
+        (
+          referralSub?.metadata as {
+            referralQueue?: { tier: string; durationDays: number }[];
+          } | null
+        )?.referralQueue ?? [];
 
-    const paidMembershipTier = (
-      (paidMembership?.product?.metadata ?? null) as { tier?: string } | null
-    )?.tier;
+      const paidMembershipTier = (
+        (paidMembership?.product?.metadata ?? null) as { tier?: string } | null
+      )?.tier;
 
-    return {
-      code: code.code,
-      balance,
-      recentRewards,
-      milestones,
-      redemptions,
-      shopItems: constants.referrals.shopItems,
-      milestoneLadder: constants.referrals.milestones,
-      conversionCount: conversionStats,
-      referralGrant:
-        referralSub && activeTier && referralSub.status === 'active'
-          ? {
-              activeTier,
-              currentPeriodStart: referralSub.currentPeriodStart,
-              currentPeriodEnd: referralSub.currentPeriodEnd,
-              queue: referralQueue,
-            }
-          : null,
-      activeMembership:
-        paidMembershipTier && paidMembership
-          ? {
-              tier: paidMembershipTier,
-              currentPeriodEnd: paidMembership.currentPeriodEnd,
-            }
-          : null,
-    };
-  }),
+      return {
+        code: code.code,
+        balance,
+        recentRewards,
+        milestones,
+        redemptions,
+        shopItems: constants.referrals.shopItems,
+        milestoneLadder: constants.referrals.milestones,
+        conversionCount: conversionStats,
+        referralGrant:
+          referralSub && activeTier && referralSub.status === 'active'
+            ? {
+                activeTier,
+                currentPeriodStart: referralSub.currentPeriodStart,
+                currentPeriodEnd: referralSub.currentPeriodEnd,
+                queue: referralQueue,
+              }
+            : null,
+        activeMembership:
+          paidMembershipTier && paidMembership
+            ? {
+                tier: paidMembershipTier,
+                currentPeriodEnd: paidMembership.currentPeriodEnd,
+              }
+            : null,
+      };
+    }),
 
-  redeem: protectedProcedure.input(redeemInput).mutation(async ({ ctx, input }) => {
-    try {
-      return await redeemTokens({ userId: ctx.user.id, offerIndex: input.offerIndex });
-    } catch (err) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
-    }
-  }),
+  redeem: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(redeemInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await redeemTokens({ userId: ctx.user.id, offerIndex: input.offerIndex });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+    }),
 
-  getShopOffers: protectedProcedure.query(async () => {
+  getShopOffers: protectedProcedure.meta({ requiredScope: TokenScope.UserRead }).query(async () => {
     return getShopOffers();
   }),
 
-  getTierBonuses: publicProcedure.query(async () => {
+  getTierBonuses: publicProcedure.meta({ requiredScope: TokenScope.UserRead }).query(async () => {
     const products = await dbRead.product.findMany({ select: { metadata: true } });
     const monthlyBuzzByTier: Record<string, number> = {};
     const rewardsMultiplierByTier: Record<string, number> = {};
@@ -225,6 +234,7 @@ export const referralRouter = router({
   }),
 
   trackCheckoutView: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(z.object({ code: z.string() }))
     .mutation(async ({ input }) => {
       const code = await dbRead.userReferralCode.findUnique({

--- a/src/server/routers/report.router.ts
+++ b/src/server/routers/report.router.ts
@@ -21,9 +21,13 @@ import {
 } from '~/server/schema/report.schema';
 import { getAppealDetails } from '~/server/services/report.service';
 import { guardedProcedure, moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const reportRouter = router({
-  create: guardedProcedure.input(createReportInputSchema).mutation(createReportHandler),
+  create: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(createReportInputSchema)
+    .mutation(createReportHandler),
   getAll: moderatorProcedure.input(getReportsSchema).query(getReportsHandler),
   update: moderatorProcedure.input(updateReportSchema).mutation(updateReportHandler),
   setStatus: moderatorProcedure.input(setReportStatusSchema).mutation(setReportStatusHandler),
@@ -32,11 +36,16 @@ export const reportRouter = router({
     .mutation(bulkUpdateReportStatusHandler),
 
   // #region [appeal]
-  getRecentAppeals: protectedProcedure.input(getRecentAppealsSchema).query(getRecentAppealsHandler),
+  getRecentAppeals: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getRecentAppealsSchema)
+    .query(getRecentAppealsHandler),
   getAppealDetails: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getByIdSchema)
     .query(({ input }) => getAppealDetails({ ...input })),
   createAppeal: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(createEntityAppealSchema)
     .mutation(createEntityAppealHandler),
   resolveAppeal: moderatorProcedure.input(resolveAppealSchema).mutation(resolveEntityAppealHandler),

--- a/src/server/routers/research.router.ts
+++ b/src/server/routers/research.router.ts
@@ -6,6 +6,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
 import { cachedCounter } from '~/server/utils/cache-helpers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { calculateLevelProgression } from '~/server/utils/research-utils';
 import { queueNewRaterLevelWebhook } from '~/server/webhooks/research.webhooks';
 import { getRandomInt } from '~/utils/number-helpers';
@@ -123,79 +124,84 @@ async function getUserSanity(userId: number, sanityIds?: number[], refresh = fal
 }
 
 export const researchRouter = router({
-  raterGetStatus: protectedProcedure.query(async ({ ctx }) => {
-    const count = await ratingsCounter.get(ctx.user.id);
-    const sanityIds = await getSanityIds();
-    let sanityImages: RaterImage[] = [];
-    const { strikes, sane } = await getUserSanity(ctx.user.id, sanityIds);
-    if (sane && sanityIds.length) {
-      sanityImages = await dbRead.$queryRaw<RaterImage[]>`
+  raterGetStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(async ({ ctx }) => {
+      const count = await ratingsCounter.get(ctx.user.id);
+      const sanityIds = await getSanityIds();
+      let sanityImages: RaterImage[] = [];
+      const { strikes, sane } = await getUserSanity(ctx.user.id, sanityIds);
+      if (sane && sanityIds.length) {
+        sanityImages = await dbRead.$queryRaw<RaterImage[]>`
         SELECT i.id, i.url, null as "nsfwLevel"
         FROM "Image" i
         WHERE i.id IN (${Prisma.join(sanityIds)});
       `;
-    }
+      }
 
-    return { count, sanityImages, sane, strikes };
-  }),
-  raterGetImages: protectedProcedure.input(raterGetImagesSchema).query(async ({ ctx, input }) => {
-    // Get the user's current position
-    const userPosition = await getUserPosition(ctx.user.id);
-    const tracks = await sysRedis.hGetAll(REDIS_SYS_KEYS.RESEARCH.RATINGS_TRACKS);
-    const foundTrack = userPosition.trackId && tracks[userPosition.trackId];
-    if (!foundTrack) {
-      input.cursor = undefined; // Reset the cursor if we don't have a track
-      const trackIds = Object.keys(tracks);
-      userPosition.trackId = trackIds[getRandomInt(0, trackIds.length)];
-      userPosition.trackPosition = undefined;
-    }
-    const track = trackSchema.parse(JSON.parse(tracks[userPosition.trackId!]));
+      return { count, sanityImages, sane, strikes };
+    }),
+  raterGetImages: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(raterGetImagesSchema)
+    .query(async ({ ctx, input }) => {
+      // Get the user's current position
+      const userPosition = await getUserPosition(ctx.user.id);
+      const tracks = await sysRedis.hGetAll(REDIS_SYS_KEYS.RESEARCH.RATINGS_TRACKS);
+      const foundTrack = userPosition.trackId && tracks[userPosition.trackId];
+      if (!foundTrack) {
+        input.cursor = undefined; // Reset the cursor if we don't have a track
+        const trackIds = Object.keys(tracks);
+        userPosition.trackId = trackIds[getRandomInt(0, trackIds.length)];
+        userPosition.trackPosition = undefined;
+      }
+      const track = trackSchema.parse(JSON.parse(tracks[userPosition.trackId!]));
 
-    if (!userPosition.trackPosition) {
-      userPosition.trackPosition = track.startingPoint;
-      const [highestImageId] = await dbRead.$queryRaw<{ id: number }[]>`
+      if (!userPosition.trackPosition) {
+        userPosition.trackPosition = track.startingPoint;
+        const [highestImageId] = await dbRead.$queryRaw<{ id: number }[]>`
         SELECT MAX(rr."imageId") as id
         FROM research_ratings rr
         WHERE rr."userId" = ${ctx.user.id}
           AND rr."imageId" BETWEEN ${track.startingPoint} AND ${track.startingPoint + 300000}
           AND rr."createdAt" > ${track.startTime.toISOString()}::timestamp;
       `;
-      if (highestImageId?.id) userPosition.trackPosition = highestImageId.id;
-    }
+        if (highestImageId?.id) userPosition.trackPosition = highestImageId.id;
+      }
 
-    // Set the user's position if they don't have one
-    if (!foundTrack) {
-      const redisKey = `${REDIS_KEYS.RESEARCH.RATINGS_PROGRESS}:${ctx.user.id}` as const;
-      // two calls because it doesn't work with object
-      await redis.hSet(redisKey, 'currentTrack', userPosition.trackId!.toString());
-      await redis.hSet(
-        redisKey,
-        `track:${userPosition.trackId}`,
-        userPosition.trackPosition!.toString()
-      );
-      await redis.expire(redisKey, CacheTTL.week);
-    }
+      // Set the user's position if they don't have one
+      if (!foundTrack) {
+        const redisKey = `${REDIS_KEYS.RESEARCH.RATINGS_PROGRESS}:${ctx.user.id}` as const;
+        // two calls because it doesn't work with object
+        await redis.hSet(redisKey, 'currentTrack', userPosition.trackId!.toString());
+        await redis.hSet(
+          redisKey,
+          `track:${userPosition.trackId}`,
+          userPosition.trackPosition!.toString()
+        );
+        await redis.expire(redisKey, CacheTTL.week);
+      }
 
-    // Get the images
-    input.cursor ??= userPosition.trackPosition;
-    const where = [Prisma.sql`i.id > ${input.cursor}`];
-    if (track.filters?.tags?.length) {
-      where.push(Prisma.sql`EXISTS (
+      // Get the images
+      input.cursor ??= userPosition.trackPosition;
+      const where = [Prisma.sql`i.id > ${input.cursor}`];
+      if (track.filters?.tags?.length) {
+        where.push(Prisma.sql`EXISTS (
         SELECT 1 FROM "ImageTag" it
         WHERE it."imageId" = i.id
           AND it."tagId" IN (${Prisma.join(track.filters.tags)})
       )`);
-    }
+      }
 
-    if (track.filters?.misaligned) {
-      where.push(Prisma.sql`i."nsfwLevel" != i."aiNsfwLevel" AND i."aiNsfwLevel" > 0`);
-    }
+      if (track.filters?.misaligned) {
+        where.push(Prisma.sql`i."nsfwLevel" != i."aiNsfwLevel" AND i."aiNsfwLevel" > 0`);
+      }
 
-    if (track.filters?.ratingModel) {
-      where.push(Prisma.sql`i."aiModel" = ${track.filters.ratingModel}`);
-    }
+      if (track.filters?.ratingModel) {
+        where.push(Prisma.sql`i."aiModel" = ${track.filters.ratingModel}`);
+      }
 
-    const images = await dbRead.$queryRaw<RaterImage[]>`
+      const images = await dbRead.$queryRaw<RaterImage[]>`
       SELECT i.id, i.url, i."nsfwLevel"
       FROM "Image" i
       JOIN "Post" p ON i."postId" = p.id
@@ -207,12 +213,13 @@ export const researchRouter = router({
       LIMIT 30;
     `;
 
-    return {
-      images,
-      trackId: userPosition.trackId,
-    };
-  }),
+      return {
+        images,
+        trackId: userPosition.trackId,
+      };
+    }),
   raterSetRatings: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(raterSetRatingsSchema)
     .mutation(async ({ input, ctx }) => {
       const currentSanity = await getUserSanity(ctx.user.id);
@@ -256,14 +263,16 @@ export const researchRouter = router({
         await redis.expire(progressKey, CacheTTL.week);
       }
     }),
-  raterReset: protectedProcedure.mutation(async ({ ctx }) => {
-    await dbWrite.$queryRaw`
+  raterReset: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .mutation(async ({ ctx }) => {
+      await dbWrite.$queryRaw`
       INSERT INTO research_ratings_resets ("userId")
       VALUES (${ctx.user.id});
     `;
-    await redis.del(`${REDIS_KEYS.RESEARCH.RATINGS_PROGRESS}:${ctx.user.id}`);
-    ratingsCounter.clear(ctx.user.id);
-  }),
+      await redis.del(`${REDIS_KEYS.RESEARCH.RATINGS_PROGRESS}:${ctx.user.id}`);
+      ratingsCounter.clear(ctx.user.id);
+    }),
   raterGetSanityImages: moderatorProcedure.query(async () => {
     const sanityIds = await getSanityIds();
     const sanityImages = await dbRead.$queryRaw<SanityImage[]>`

--- a/src/server/routers/resourceReview.router.ts
+++ b/src/server/routers/resourceReview.router.ts
@@ -34,6 +34,7 @@ import {
 } from '~/server/services/resourceReview.service';
 import { moderatorProcedure } from '~/server/trpc';
 import { getByUsernameSchema } from '~/server/schema/user.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
   if (!ctx.user) throw throwAuthorizationError();
@@ -61,37 +62,51 @@ const isOwnerOrModerator = middleware(async ({ ctx, next, input = {} }) => {
 
 export const resourceReviewRouter = router({
   get: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .query(({ input, ctx }) =>
       getResourceReview({ ...input, userId: ctx.user?.id, isModerator: ctx.user?.isModerator })
     ),
   getUserResourceReview: protectedProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getUserResourceReviewSchema)
     .query(({ input, ctx }) => getUserResourceReview({ ...input, userId: ctx.user.id })),
   getInfinite: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getResourceReviewsInfiniteSchema)
     .query(({ input }) => getResourceReviewsInfinite(input)),
   getPaged: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getResourceReviewPagedSchema)
     .query(({ input, ctx }) => getPagedResourceReviews({ input, userId: ctx.user?.id })),
   getRatingTotals: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getRatingTotalsSchema)
     .query(({ input }) => getRatingTotals(input)),
   upsert: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(upsertResourceReviewSchema)
     .use(isOwnerOrModerator)
     .mutation(upsertResourceReviewHandler),
-  create: guardedProcedure.input(createResourceReviewSchema).mutation(createResourceReviewHandler),
+  create: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(createResourceReviewSchema)
+    .mutation(createResourceReviewHandler),
   update: guardedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(updateResourceReviewSchema)
     .use(isOwnerOrModerator)
     .mutation(updateResourceReviewHandler),
   delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .use(isOwnerOrModerator)
     .mutation(deleteResourceReviewHandler),
   toggleExclude: moderatorProcedure
     .input(getByIdSchema)
     .mutation(toggleExcludeResourceReviewHandler),
-  getUserRatingsTotal: publicProcedure.input(getByUsernameSchema).query(getUserRatingTotalHandler),
+  getUserRatingsTotal: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByUsernameSchema)
+    .query(getUserRatingTotalHandler),
 });

--- a/src/server/routers/rewards-bonus-event.router.ts
+++ b/src/server/routers/rewards-bonus-event.router.ts
@@ -10,6 +10,7 @@ import {
   upsertRewardsBonusEvent,
 } from '~/server/services/rewards-bonus-event.service';
 import { getByIdSchema } from '~/server/schema/base.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const rewardsBonusEventRouter = router({
   upsert: moderatorProcedure

--- a/src/server/routers/signals.router.ts
+++ b/src/server/routers/signals.router.ts
@@ -1,6 +1,9 @@
 import { getUserAccountHandler } from '~/server/controllers/signals.controller';
 import { protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const signalsRouter = router({
-  getToken: protectedProcedure.query(getUserAccountHandler),
+  getToken: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserAccountHandler),
 });

--- a/src/server/routers/strike.router.ts
+++ b/src/server/routers/strike.router.ts
@@ -16,14 +16,17 @@ import {
   voidStrikeSchema,
 } from '~/server/schema/strike.schema';
 import { isFlagProtected, moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const strikeRouter = router({
   // User endpoints
   getMyStrikes: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getMyStrikesSchema)
     .use(isFlagProtected('strikes'))
     .query(getMyStrikesHandler),
   getMyStrikeSummary: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .use(isFlagProtected('strikes'))
     .query(getMyStrikeSummaryHandler),
 

--- a/src/server/routers/stripe.router.ts
+++ b/src/server/routers/stripe.router.ts
@@ -12,34 +12,43 @@ import {
 } from './../controllers/stripe.controller';
 import { publicProcedure, router, protectedProcedure } from '~/server/trpc';
 import * as Schema from '../schema/stripe.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const stripeRouter = router({
   createCustomer: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(Schema.createCustomerSchema)
     .mutation(createCustomerHandler),
   createSubscriptionSession: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(Schema.createSubscribeSessionSchema)
     .mutation(createSubscriptionSessionHandler),
-  createManageSubscriptionSession: protectedProcedure.mutation(
-    createManageSubscriptionSessionHandler
-  ),
-  createCancelSubscriptionSession: protectedProcedure.mutation(
-    createCancelSubscriptionSessionHandler
-  ),
-  cancelSubscriptionWithFallback: protectedProcedure.mutation(
-    cancelSubscriptionWithFallbackHandler
-  ),
+  createManageSubscriptionSession: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .mutation(createManageSubscriptionSessionHandler),
+  createCancelSubscriptionSession: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .mutation(createCancelSubscriptionSessionHandler),
+  cancelSubscriptionWithFallback: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .mutation(cancelSubscriptionWithFallbackHandler),
   createDonateSession: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(Schema.createDonateSessionSchema)
     .mutation(createDonateSessionHandler),
-  getBuzzPackages: publicProcedure.query(getBuzzPackagesHandler),
+  getBuzzPackages: publicProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(getBuzzPackagesHandler),
   createBuzzSession: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(Schema.createBuzzSessionSchema)
     .mutation(createBuzzSessionHandler),
   getPaymentIntent: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(Schema.paymentIntentCreationSchema)
     .mutation(getPaymentIntentHandler),
   getSetupIntent: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(Schema.setupIntentCreateSchema)
     .query(getSetupIntentHandler),
 });

--- a/src/server/routers/subscriptions.router.ts
+++ b/src/server/routers/subscriptions.router.ts
@@ -16,22 +16,33 @@ import {
   unlockTokensForUser,
   getHistoricalPrepaidDeliveries,
 } from '~/server/services/subscriptions.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const subscriptionsRouter = router({
-  getPlans: publicProcedure.input(getPlansSchema).query(getPlansHandler),
+  getPlans: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getPlansSchema)
+    .query(getPlansHandler),
   getUserSubscription: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getUserSubscriptionSchema.partial().optional())
     .query(getUserSubscriptionHandler),
-  getAllUserSubscriptions: publicProcedure.query(getAllUserSubscriptionsHandler),
+  getAllUserSubscriptions: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getAllUserSubscriptionsHandler),
   claimPrepaidToken: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(claimPrepaidTokenSchema)
     .mutation(async ({ input, ctx }) => {
       return claimPrepaidToken({ tokenId: input.tokenId, userId: ctx.user.id });
     }),
-  claimAllPrepaidTokens: protectedProcedure.mutation(async ({ ctx }) => {
-    return claimAllPrepaidTokens({ userId: ctx.user.id });
-  }),
+  claimAllPrepaidTokens: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .mutation(async ({ ctx }) => {
+      return claimAllPrepaidTokens({ userId: ctx.user.id });
+    }),
   getHistoricalPrepaidDeliveries: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(z.object({ accountType: z.enum(['yellow', 'green']).default('yellow') }))
     .query(async ({ input, ctx }) => {
       return getHistoricalPrepaidDeliveries({

--- a/src/server/routers/system.router.ts
+++ b/src/server/routers/system.router.ts
@@ -8,16 +8,21 @@ import {
 import { edgeCacheIt } from '~/server/middleware.trpc';
 import { CacheTTL } from '~/server/common/constants';
 import { dbKV } from '~/server/db/db-helpers';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const systemRouter = router({
-  getLiveNow: publicProcedure.use(edgeCacheIt({ ttl: CacheTTL.xs })).query(() => getLiveNow()),
-  getBrowsingSettingAddons: publicProcedure.query(() => {
+  getLiveNow: publicProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .use(edgeCacheIt({ ttl: CacheTTL.xs }))
+    .query(() => getLiveNow()),
+  getBrowsingSettingAddons: publicProcedure.meta({ requiredScope: TokenScope.Full }).query(() => {
     return getBrowsingSettingAddons();
   }),
-  getLiveFeatureFlags: publicProcedure.query(() => {
+  getLiveFeatureFlags: publicProcedure.meta({ requiredScope: TokenScope.Full }).query(() => {
     return getLiveFeatureFlags();
   }),
   getDbKV: publicProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(z.object({ key: z.string() }))
     .use(edgeCacheIt({ ttl: CacheTTL.sm }))
     .query(async ({ input }) => {

--- a/src/server/routers/tag.router.ts
+++ b/src/server/routers/tag.router.ts
@@ -29,21 +29,29 @@ import {
 } from '~/server/schema/tag.schema';
 import { getTag, getTagsForReview } from '~/server/services/tag.service';
 import { moderatorProcedure, protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const tagRouter = router({
   getTagWithModelCount: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getTagByNameSchema)
     .query(getTagWithModelCountHandler),
-  getById: publicProcedure.input(getByIdSchema).query(({ input }) => getTag(input)),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getByIdSchema)
+    .query(({ input }) => getTag(input)),
   getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getTagsInput.optional())
     .use(applyUserPreferences)
     .use(cacheIt({ ttl: 60 }))
     .query(getAllTagsHandler),
   getHomeExcluded: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .use(edgeCacheIt({ ttl: 24 * 60 * 60 }))
     .query(getHomeExcludedTagsHandler),
   getTrending: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getTrendingTagsSchema)
     .use(applyUserPreferences)
     .query(getTrendingTagsHandler),
@@ -52,9 +60,18 @@ export const tagRouter = router({
     .use(edgeCacheIt({ ttl: CacheTTL.day }))
     .query(({ input }) => getTagsForReview(input)),
   getManagableTags: moderatorProcedure.query(getManagableTagsHandler),
-  getVotableTags: publicProcedure.input(getVotableTagsSchema).query(getVotableTagsHandler),
-  addTagVotes: protectedProcedure.input(addTagVotesSchema).mutation(addTagVotesHandler),
-  removeTagVotes: protectedProcedure.input(removeTagVotesSchema).mutation(removeTagVotesHandler),
+  getVotableTags: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getVotableTagsSchema)
+    .query(getVotableTagsHandler),
+  addTagVotes: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(addTagVotesSchema)
+    .mutation(addTagVotesHandler),
+  removeTagVotes: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(removeTagVotesSchema)
+    .mutation(removeTagVotesHandler),
   addTags: moderatorProcedure.input(adjustTagsSchema).mutation(addTagsHandler),
   disableTags: moderatorProcedure.input(adjustTagsSchema).mutation(disableTagsHandler),
   moderateTags: moderatorProcedure.input(moderateTagsSchema).mutation(moderateTagsHandler),

--- a/src/server/routers/technique.router.ts
+++ b/src/server/routers/technique.router.ts
@@ -2,7 +2,11 @@ import { CacheTTL } from '~/server/common/constants';
 import { edgeCacheIt } from '~/server/middleware.trpc';
 import { getAllTechniques } from '~/server/services/technique.service';
 import { publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const techniqueRouter = router({
-  getAll: publicProcedure.use(edgeCacheIt({ ttl: CacheTTL.hour })).query(() => getAllTechniques()),
+  getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .use(edgeCacheIt({ ttl: CacheTTL.hour }))
+    .query(() => getAllTechniques()),
 });

--- a/src/server/routers/tool.router.ts
+++ b/src/server/routers/tool.router.ts
@@ -3,9 +3,11 @@ import { edgeCacheIt } from '~/server/middleware.trpc';
 import { getAllToolsSchema } from '~/server/schema/tool.schema';
 import { getAllTools } from '~/server/services/tool.service';
 import { publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const toolRouter = router({
   getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(getAllToolsSchema.optional())
     .use(edgeCacheIt({ ttl: CacheTTL.hour }))
     .query(({ input }) => getAllTools(input)),

--- a/src/server/routers/track.router.ts
+++ b/src/server/routers/track.router.ts
@@ -5,16 +5,23 @@ import {
   addViewSchema,
 } from '~/server/schema/track.schema';
 import { publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const trackRouter = router({
-  addView: publicProcedure.input(addViewSchema).mutation(({ input, ctx }) => ctx.track.view(input)),
+  addView: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(addViewSchema)
+    .mutation(({ input, ctx }) => ctx.track.view(input)),
   trackShare: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(trackShareSchema)
     .mutation(({ input, ctx }) => ctx.track.share(input)),
   addAction: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(trackActionSchema)
     .mutation(({ input, ctx }) => ctx.track.action(input)),
   trackSearch: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(trackSearchSchema)
     .mutation(({ input, ctx }) => ctx.track.search(input)),
 });

--- a/src/server/routers/training.router.ts
+++ b/src/server/routers/training.router.ts
@@ -35,6 +35,7 @@ import {
   publicProcedure,
   router,
 } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const TRAINING_ANNOUNCEMENT_KEY = 'training-announcement';
 const announcementColors = ['yellow', 'red', 'blue', 'green', 'gray'] as const;
@@ -49,6 +50,7 @@ export const trainingRouter = router({
    * @deprecated for orchestrator v2
    */
   createRequest: guardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(createTrainingRequestSchema)
     .use(isFlagProtected('imageTraining'))
     .mutation(({ input, ctx }) => createTrainingRequest({ ...input, userId: ctx.user.id })),
@@ -56,20 +58,27 @@ export const trainingRouter = router({
    * @deprecated for orchestrator v2
    */
   createRequestDryRun: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(createTrainingRequestDryRunSchema)
     .use(isFlagProtected('imageTraining'))
     .query(({ input }) => createTrainingRequestDryRun({ ...input })),
 
   moveAsset: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(moveAssetInput)
     .use(isFlagProtected('imageTraining'))
     .mutation(({ input, ctx }) => moveAsset({ ...input, userId: ctx.user.id })),
-  getModelBasic: publicProcedure.input(getByIdSchema).query(getModelData),
+  getModelBasic: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .input(getByIdSchema)
+    .query(getModelData),
   autoTag: guardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(autoTagInput)
     .use(isFlagProtected('imageTraining'))
     .mutation(({ input, ctx }) => autoTagHandler({ ...input, userId: ctx.user.id })),
   autoCaption: guardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(autoCaptionInput)
     .use(isFlagProtected('imageTraining'))
     .mutation(({ input, ctx }) => autoCaptionHandler({ ...input, userId: ctx.user.id })),
@@ -82,6 +91,7 @@ export const trainingRouter = router({
   // Tagging/captioning is free; the orchestrator work is billed to the system token
   // and not the user, so each endpoint needs a per-user rate cap to prevent abuse.
   getAutoLabelUploadUrl: guardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(getAutoLabelUploadUrlSchema)
     .use(isFlagProtected('imageTraining'))
     .use(isFlagProtected('trainingAutoLabelOrchestrator'))
@@ -90,6 +100,7 @@ export const trainingRouter = router({
     .use(rateLimit({ limit: 1000, period: 60 }))
     .mutation(({ input, ctx }) => getAutoLabelUploadUrl({ ...input, userId: ctx.user.id })),
   submitAutoLabelWorkflow: guardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(submitAutoLabelWorkflowSchema)
     .use(isFlagProtected('imageTraining'))
     .use(isFlagProtected('trainingAutoLabelOrchestrator'))
@@ -98,6 +109,7 @@ export const trainingRouter = router({
     .use(rateLimit({ limit: 100, period: 60 }))
     .mutation(({ input, ctx }) => submitAutoLabelWorkflow({ ...input, userId: ctx.user.id })),
   getAutoLabelWorkflow: guardedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .input(getAutoLabelWorkflowSchema)
     .use(isFlagProtected('imageTraining'))
     .use(isFlagProtected('trainingAutoLabelOrchestrator'))
@@ -107,6 +119,7 @@ export const trainingRouter = router({
     .use(rateLimit({ limit: 1500, period: 60 }))
     .query(({ input, ctx }) => getAutoLabelWorkflow({ ...input, userId: ctx.user.id })),
   getStatus: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .use(isFlagProtected('imageTraining'))
     .use(edgeCacheIt({ ttl: CacheTTL.xs, tags: () => ['training-status'] }))
     .query(() => getTrainingServiceStatus()),
@@ -124,14 +137,17 @@ export const trainingRouter = router({
    * @deprecated for orchestrator v2
    */
   getJobEstStarts: protectedProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
     .use(isFlagProtected('imageTraining'))
     .query(({ ctx }) => getJobEstStartsHandler({ userId: ctx.user.id })),
 
   // Training page announcement (moderator-editable)
-  getAnnouncement: publicProcedure.query(async () => {
-    const announcement = await dbKV.get<TrainingAnnouncement>(TRAINING_ANNOUNCEMENT_KEY);
-    return announcement ?? null;
-  }),
+  getAnnouncement: publicProcedure
+    .meta({ requiredScope: TokenScope.AIServicesRead })
+    .query(async () => {
+      const announcement = await dbKV.get<TrainingAnnouncement>(TRAINING_ANNOUNCEMENT_KEY);
+      return announcement ?? null;
+    }),
 
   setAnnouncement: moderatorProcedure
     .input(trainingAnnouncementSchema)

--- a/src/server/routers/user-link.router.ts
+++ b/src/server/routers/user-link.router.ts
@@ -11,12 +11,23 @@ import {
   upsertUserLinkSchema,
 } from './../schema/user-link.schema';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const userLinkRouter = router({
-  getAll: publicProcedure.input(getUserLinksSchema).query(getUserLinksHandler),
+  getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getUserLinksSchema)
+    .query(getUserLinksHandler),
   upsertMany: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(upsertManyUserLinkSchema)
     .mutation(upsertManyUserLinksHandler),
-  upsert: protectedProcedure.input(upsertUserLinkSchema).mutation(upsertUserLinkHandler),
-  delete: protectedProcedure.input(getByIdSchema).mutation(deleteUserLinkHandler),
+  upsert: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(upsertUserLinkSchema)
+    .mutation(upsertUserLinkHandler),
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(getByIdSchema)
+    .mutation(deleteUserLinkHandler),
 });

--- a/src/server/routers/user-payment-configuration.router.ts
+++ b/src/server/routers/user-payment-configuration.router.ts
@@ -5,14 +5,16 @@ import {
   getTipaltiDashboardUrl,
 } from '../services/user-payment-configuration.service';
 import { getTipaltiDashbordUrlSchema } from '~/server/schema/user-payment-configuration.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const userPaymentConfigurationRouter = router({
-  get: protectedProcedure.query(getHandler),
-  getOnboardinLink: protectedProcedure.query(({ ctx }) =>
-    getStripeConnectOnboardingLink({ userId: ctx.user.id })
-  ),
+  get: protectedProcedure.meta({ requiredScope: TokenScope.Full }).query(getHandler),
+  getOnboardinLink: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(({ ctx }) => getStripeConnectOnboardingLink({ userId: ctx.user.id })),
 
   getTipaltiDashboardUrl: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(getTipaltiDashbordUrlSchema)
     .query(({ ctx, input }) =>
       getTipaltiDashboardUrl({ userId: ctx.user.id, type: input.type ?? 'setup' })

--- a/src/server/routers/user-profile.router.ts
+++ b/src/server/routers/user-profile.router.ts
@@ -16,12 +16,23 @@ import {
   showcaseItemSchema,
   userProfileUpdateSchema,
 } from '~/server/schema/user-profile.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const userProfileRouter = router({
-  get: publicProcedure.input(getUserProfileSchema).query(getUserProfileHandler),
-  overview: publicProcedure.input(getUserProfileSchema).query(getUserContentOverviewHandler),
-  update: guardedProcedure.input(userProfileUpdateSchema).mutation(updateUserProfileHandler),
+  get: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getUserProfileSchema)
+    .query(getUserProfileHandler),
+  overview: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getUserProfileSchema)
+    .query(getUserContentOverviewHandler),
+  update: guardedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(userProfileUpdateSchema)
+    .mutation(updateUserProfileHandler),
   addEntityToShowcase: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(showcaseItemSchema)
     .mutation(addEntityToShowcaseHandler),
 });

--- a/src/server/routers/user-referral-code.router.ts
+++ b/src/server/routers/user-referral-code.router.ts
@@ -9,11 +9,19 @@ import {
   upsertUserReferralCodesSchema,
 } from '~/server/schema/user-referral-code.schema';
 import { getByIdSchema } from '~/server/schema/base.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const userReferralCodeRouter = router({
-  getAll: protectedProcedure.input(getUserReferralCodesSchema).query(getUserReferralCodesHandler),
+  getAll: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getUserReferralCodesSchema)
+    .query(getUserReferralCodesHandler),
   upsert: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(upsertUserReferralCodesSchema)
     .mutation(upsertUserReferralCodeHandler),
-  delete: protectedProcedure.input(getByIdSchema).mutation(deleteUserReferralCodeHandler),
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(getByIdSchema)
+    .mutation(deleteUserReferralCodeHandler),
 });

--- a/src/server/routers/user-restriction.router.ts
+++ b/src/server/routers/user-restriction.router.ts
@@ -23,6 +23,7 @@ import { updateUserById } from '~/server/services/user.service';
 import { moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
 import { UserRestrictionStatus } from '~/shared/utils/prisma/enums';
 import { refreshSession } from '~/server/auth/session-invalidation';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const userRestrictionRouter = router({
   /**

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -108,9 +108,11 @@ import { createNotification } from '~/server/services/notification.service';
 import { NotificationCategory } from '~/server/common/enums';
 import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
 import { dbRead } from '~/server/db/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const userRouter = router({
   getCreator: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getUserByUsernameSchema)
     .use(
       edgeCacheIt({
@@ -123,29 +125,65 @@ export const userRouter = router({
       })
     )
     .query(getUserCreatorHandler),
-  getAll: publicProcedure.input(getAllUsersInput).query(getAllUsersHandler),
+  getAll: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getAllUsersInput)
+    .query(getAllUsersHandler),
   usernameAvailable: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getByUsernameSchema)
     .query(getUsernameAvailableHandler),
-  getById: publicProcedure.input(getByIdSchema).query(getUserByIdHandler),
-  getEngagedModels: protectedProcedure.query(getUserEngagedModelsHandler),
+  getById: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getByIdSchema)
+    .query(getUserByIdHandler),
+  getEngagedModels: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserEngagedModelsHandler),
   getEngagedModelVersions: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getByIdSchema)
     .query(getUserEngagedModelVersionsHandler),
-  getFollowingUsers: protectedProcedure.query(getUserFollowingListHandler),
+  getFollowingUsers: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserFollowingListHandler),
   // getHiddenUsers: protectedProcedure.query(getUserHiddenListHandler),
-  getTags: protectedProcedure.input(getUserTagsSchema.optional()).query(getUserTagsHandler),
-  getCreators: publicProcedure.input(getAllQuerySchema.partial()).query(getCreatorsHandler),
-  getNotificationSettings: protectedProcedure.query(getNotificationSettingsHandler),
-  getLists: publicProcedure.input(getByUsernameSchema).query(getUserListsHandler),
-  getList: publicProcedure.input(getUserListSchema).query(getUserListHandler),
-  getLeaderboard: publicProcedure.input(getAllQuerySchema).query(getLeaderboardHandler),
+  getTags: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getUserTagsSchema.optional())
+    .query(getUserTagsHandler),
+  getCreators: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getAllQuerySchema.partial())
+    .query(getCreatorsHandler),
+  getNotificationSettings: protectedProcedure
+    .meta({ requiredScope: TokenScope.NotificationsRead })
+    .query(getNotificationSettingsHandler),
+  getLists: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getByUsernameSchema)
+    .query(getUserListsHandler),
+  getList: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getUserListSchema)
+    .query(getUserListHandler),
+  getLeaderboard: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getAllQuerySchema)
+    .query(getLeaderboardHandler),
   getCosmetics: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getUserCosmeticsSchema.optional())
     .query(getUserCosmeticsHandler),
-  checkNotifications: protectedProcedure.query(checkUserNotificationsHandler),
-  update: guardedProcedure.input(userUpdateSchema).mutation(updateUserHandler),
+  checkNotifications: protectedProcedure
+    .meta({ requiredScope: TokenScope.NotificationsRead })
+    .query(checkUserNotificationsHandler),
+  update: guardedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(userUpdateSchema)
+    .mutation(updateUserHandler),
   requestEmailChange: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(requestEmailChangeSchema)
     .use(
       rateLimit({
@@ -157,13 +195,20 @@ export const userRouter = router({
     .mutation(async ({ input, ctx }) => {
       return requestEmailChange(ctx.user.id, input.newEmail);
     }),
-  validateEmailToken: publicProcedure.input(validateEmailTokenSchema).query(async ({ input }) => {
-    return validateEmailChangeToken(input.token);
-  }),
-  verifyEmailChange: publicProcedure.input(verifyEmailChangeSchema).mutation(async ({ input }) => {
-    return confirmEmailChange(input.token);
-  }),
+  validateEmailToken: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(validateEmailTokenSchema)
+    .query(async ({ input }) => {
+      return validateEmailChangeToken(input.token);
+    }),
+  verifyEmailChange: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(verifyEmailChangeSchema)
+    .mutation(async ({ input }) => {
+      return confirmEmailChange(input.token);
+    }),
   updateBrowsingMode: guardedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(updateBrowsingModeSchema)
     .mutation(async ({ input, ctx }) => {
       await updateUserById({
@@ -173,18 +218,31 @@ export const userRouter = router({
       });
       await refreshSession(ctx.user.id);
     }),
-  delete: protectedProcedure.input(deleteUserSchema).mutation(deleteUserHandler),
-  toggleFavorite: protectedProcedure.input(toggleFavoriteInput).mutation(toggleFavoriteHandler),
+  delete: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .input(deleteUserSchema)
+    .mutation(deleteUserHandler),
+  toggleFavorite: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(toggleFavoriteInput)
+    .mutation(toggleFavoriteHandler),
   toggleNotifyModel: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(toggleModelEngagementInput)
     .mutation(toggleNotifyModelHandler),
   completeOnboardingStep: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(userOnboardingSchema)
     .mutation(completeOnboardingHandler),
-  toggleFollow: verifiedProcedure.input(toggleFollowUserSchema).mutation(toggleFollowUserHandler),
+  toggleFollow: verifiedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(toggleFollowUserSchema)
+    .mutation(toggleFollowUserHandler),
   toggleMute: moderatorProcedure.input(getByIdSchema).mutation(toggleMuteHandler),
   toggleBan: moderatorProcedure.input(toggleBanUserSchema).mutation(toggleBanHandler),
-  getToken: protectedProcedure.query(({ ctx }) => ({ token: createToken(ctx.user.id) })),
+  getToken: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(({ ctx }) => ({ token: createToken(ctx.user.id) })),
   removeAllContent: moderatorProcedure.input(getByIdSchema).mutation(async ({ input, ctx }) => {
     await removeAllContent(input);
     ctx.track.userActivity({
@@ -192,67 +250,104 @@ export const userRouter = router({
       targetUserId: input.id,
     });
   }),
-  getArticleEngagement: protectedProcedure.query(({ ctx }) =>
-    getUserArticleEngagements({ userId: ctx.user.id })
-  ),
-  getBookmarkedArticles: protectedProcedure.query(({ ctx }) =>
-    getUserBookmarkedArticles({ userId: ctx.user.id })
-  ),
-  getBookmarkedModels: protectedProcedure.query(({ ctx }) =>
-    getUserBookmarkedModels({ userId: ctx.user.id })
-  ),
-  getBountyEngagement: protectedProcedure.query(({ ctx }) =>
-    getUserBountyEngagements({ userId: ctx.user.id })
-  ),
+  getArticleEngagement: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getUserArticleEngagements({ userId: ctx.user.id })),
+  getBookmarkedArticles: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getUserBookmarkedArticles({ userId: ctx.user.id })),
+  getBookmarkedModels: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getUserBookmarkedModels({ userId: ctx.user.id })),
+  getBountyEngagement: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(({ ctx }) => getUserBountyEngagements({ userId: ctx.user.id })),
   toggleArticleEngagement: verifiedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(toggleUserArticleEngagementSchema)
     .mutation(toggleArticleEngagementHandler),
   toggleBookmarkedArticle: verifiedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .mutation(({ ctx, input }) =>
       toggleBookmarkedArticle({ articleId: input.id, userId: ctx.user.id })
     ),
   toggleBountyEngagement: verifiedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
     .input(toggleUserBountyEngagementSchema)
     .mutation(toggleBountyEngagementHandler),
   userByReferralCode: publicProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(userByReferralCodeSchema)
     .query(userByReferralCodeHandler),
-  userRewardDetails: protectedProcedure.query(userRewardDetailsHandler),
+  userRewardDetails: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(userRewardDetailsHandler),
   cosmeticStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
     .input(getByIdSchema)
     .query(({ ctx, input }) => cosmeticStatus({ userId: ctx.user.id, id: input.id })),
-  claimCosmetic: protectedProcedure.input(getByIdSchema).mutation(claimCosmeticHandler),
+  claimCosmetic: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(getByIdSchema)
+    .mutation(claimCosmeticHandler),
   equipCosmetic: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(getByIdSchema)
     .mutation(({ ctx, input }) => equipCosmetic({ userId: ctx.user.id, cosmeticId: input.id })),
-  getPaymentMethods: protectedProcedure.query(getUserPaymentMethodsHandler),
+  getPaymentMethods: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
+    .query(getUserPaymentMethodsHandler),
   deletePaymentMethod: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .input(paymentMethodDeleteInput)
     .mutation(deleteUserPaymentMethodHandler),
-  getFeatureFlags: protectedProcedure.query(getUserFeatureFlagsHandler),
+  getFeatureFlags: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserFeatureFlagsHandler),
   toggleFeature: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(toggleFeatureInputSchema)
     .mutation(toggleUserFeatureFlagHandler),
-  getSettings: protectedProcedure.query(getUserSettingsHandler),
-  setSettings: protectedProcedure.input(setUserSettingsInput).mutation(setUserSettingHandler),
-  dismissAlert: protectedProcedure.input(dismissAlertSchema).mutation(dismissAlertHandler),
-  restoreAlert: protectedProcedure.input(restoreAlertSchema).mutation(restoreAlertHandler),
-  getBookmarkCollections: protectedProcedure.query(getUserBookmarkCollectionsHandler),
-  getUserPurchasedRewards: protectedProcedure.query(getUserPurchasedRewardsHandler),
+  getSettings: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserSettingsHandler),
+  setSettings: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(setUserSettingsInput)
+    .mutation(setUserSettingHandler),
+  dismissAlert: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(dismissAlertSchema)
+    .mutation(dismissAlertHandler),
+  restoreAlert: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .input(restoreAlertSchema)
+    .mutation(restoreAlertHandler),
+  getBookmarkCollections: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserBookmarkCollectionsHandler),
+  getUserPurchasedRewards: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getUserPurchasedRewardsHandler),
   setLeaderboardEligibility: moderatorProcedure
     .input(setLeaderboardEligbilitySchema)
     .mutation(setLeaderboardEligibilityHandler),
   ingestFingerprint: publicProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(computeDeviceFingerprintSchema)
     .mutation(({ input, ctx }) =>
       computeFingerprint({ fingerprint: input.fingerprint, userId: ctx.user?.id })
     ),
-  requestAdToken: verifiedProcedure.mutation(({ ctx }) => requestAdToken({ userId: ctx.user.id })),
+  requestAdToken: verifiedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
+    .mutation(({ ctx }) => requestAdToken({ userId: ctx.user.id })),
   updateContentSettings: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserWrite })
     .input(updateContentSettingsSchema)
     .mutation(({ input, ctx }) => updateContentSettings({ userId: ctx.user.id, ...input })),
   getTipaltiStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .use(isFlagProtected('userPaymentConfiguration'))
     .input(getByIdSchema)
     .query(async ({ input }) => {
@@ -263,6 +358,7 @@ export const userRouter = router({
       return { enabled: !!config?.tipaltiAccountId };
     }),
   enableTipalti: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .use(isFlagProtected('userPaymentConfiguration'))
     .input(getByIdSchema)
     .mutation(async ({ input }) => {
@@ -277,6 +373,7 @@ export const userRouter = router({
       await addSystemPermission('creatorsProgram', input.id);
     }),
   resetSubscriptionCaches: protectedProcedure
+    .meta({ requiredScope: TokenScope.Full })
     .use(isFlagProtected('userPaymentConfiguration'))
     .input(getByIdSchema)
     .mutation(async ({ input }) => {

--- a/src/server/routers/vault.router.ts
+++ b/src/server/routers/vault.router.ts
@@ -16,37 +16,48 @@ import {
 } from '~/server/services/vault.service';
 import { protectedProcedure, router } from '~/server/trpc';
 import { getByIdSchema } from '../schema/base.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const vaultRouter = router({
-  get: protectedProcedure.query(({ ctx }) => {
+  get: protectedProcedure.meta({ requiredScope: TokenScope.VaultRead }).query(({ ctx }) => {
     return getOrCreateVault({
       userId: ctx.user.id,
     });
   }),
-  getItemsPaged: protectedProcedure.input(getPaginatedVaultItemsSchema).query(({ input, ctx }) => {
-    return getPaginatedVaultItems({ ...input, userId: ctx.user.id });
-  }),
+  getItemsPaged: protectedProcedure
+    .meta({ requiredScope: TokenScope.VaultRead })
+    .input(getPaginatedVaultItemsSchema)
+    .query(({ input, ctx }) => {
+      return getPaginatedVaultItems({ ...input, userId: ctx.user.id });
+    }),
   isModelVersionInVault: protectedProcedure
+    .meta({ requiredScope: TokenScope.VaultRead })
     .input(vaultItemsAddModelVersionSchema)
     .query(({ input, ctx }) => {
       return isModelVersionInVault({ ...input, userId: ctx.user.id });
     }),
   toggleModelVersion: protectedProcedure
+    .meta({ requiredScope: TokenScope.VaultWrite })
     .input(vaultItemsAddModelVersionSchema)
     .mutation(({ input, ctx }) => {
       return toggleModelVersionOnVault({ ...input, userId: ctx.user.id });
     }),
   removeItemsFromVault: protectedProcedure
+    .meta({ requiredScope: TokenScope.VaultWrite })
     .input(vaultItemsRemoveModelVersionsSchema)
     .mutation(({ input, ctx }) => {
       return removeModelVersionsFromVault({ ...input, userId: ctx.user.id });
     }),
   updateItemsNotes: protectedProcedure
+    .meta({ requiredScope: TokenScope.VaultWrite })
     .input(vaultItemsUpdateNotesSchema)
     .mutation(({ input, ctx }) => {
       return updateVaultItemsNotes({ ...input, userId: ctx.user.id });
     }),
-  refreshItems: protectedProcedure.input(vaultItemsRefreshSchema).mutation(({ input, ctx }) => {
-    return refreshVaultItems({ ...input, userId: ctx.user.id });
-  }),
+  refreshItems: protectedProcedure
+    .meta({ requiredScope: TokenScope.VaultWrite })
+    .input(vaultItemsRefreshSchema)
+    .mutation(({ input, ctx }) => {
+      return refreshVaultItems({ ...input, userId: ctx.user.id });
+    }),
 });

--- a/src/server/routers/vimeo.router.ts
+++ b/src/server/routers/vimeo.router.ts
@@ -3,9 +3,11 @@ import type { GetByIdStringInput } from '~/server/schema/base.schema';
 import { getByIdStringSchema } from '~/server/schema/base.schema';
 import { publicProcedure, router } from '~/server/trpc';
 import { checkVideoAvailable } from '~/server/vimeo/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const vimeoRouter = router({
   checkVideoAvailable: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdStringSchema)
     .query(async ({ input }: { input: GetByIdStringInput }) => {
       if (!env.VIMEO_ACCESS_TOKEN) {

--- a/src/server/schema/api-key.schema.ts
+++ b/src/server/schema/api-key.schema.ts
@@ -1,4 +1,4 @@
-import { KeyScope } from '~/shared/utils/prisma/enums';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 import * as z from 'zod';
 
 export const getApiKeyInputSchema = z.object({ id: z.number() });
@@ -10,11 +10,128 @@ export const getUserApiKeysInputSchema = z.object({
 });
 export type GetUserAPIKeysInput = z.infer<typeof getUserApiKeysInputSchema>;
 
+/**
+ * Per-subject buzz spend budgets. The orchestrator owns enforcement; Civitai
+ * stores budgets and exposes them on /api/v1/me. The shape is intentionally
+ * flexible so we can grow into per-currency caps and calendar-rollover budgets
+ * without another contract revision.
+ *
+ *  - `absolute` — hard cap with no time component. Optional `currencies` to
+ *    restrict the cap to specific buzz pools.
+ *  - `sliding`  — rolling window of `unit` × `window` (e.g. 7 day = rolling
+ *    7-day window). What the simple UI ships today.
+ *  - `rollover` — calendar-based reset driven by a cron expression.
+ *
+ * Civitai's UI today only exposes a single `sliding` budget (limit + period),
+ * but the JSON column / API shape supports the full set so future surfaces
+ * (custom-limit power user UI, programmatic clients) don't need a migration.
+ */
+export const slidingWindowEnum = z.enum(['second', 'minute', 'hour', 'day', 'week', 'month']);
+export type SlidingWindow = z.infer<typeof slidingWindowEnum>;
+
+const absoluteBudgetSchema = z.object({
+  type: z.literal('absolute'),
+  currencies: z.array(z.string()).optional(),
+  limit: z.number().int().positive(),
+});
+
+const slidingBudgetSchema = z.object({
+  type: z.literal('sliding'),
+  currencies: z.array(z.string()).optional(),
+  limit: z.number().int().positive(),
+  window: slidingWindowEnum,
+  unit: z.number().int().positive(),
+});
+
+const rolloverBudgetSchema = z.object({
+  type: z.literal('rollover'),
+  currencies: z.array(z.string()).optional(),
+  limit: z.number().int().positive(),
+  cron: z.string().min(1),
+});
+
+export const buzzBudgetSchema = z.discriminatedUnion('type', [
+  absoluteBudgetSchema,
+  slidingBudgetSchema,
+  rolloverBudgetSchema,
+]);
+export type BuzzBudget = z.infer<typeof buzzBudgetSchema>;
+
+/**
+ * Per-subject buzz spend limit — an array of budgets. `null` (or column-null
+ * in the JSONB) means no limit at all. An empty array also means no limit.
+ */
+export const buzzLimitSchema = z.array(buzzBudgetSchema);
+export type BuzzLimit = z.infer<typeof buzzLimitSchema>;
+
+/**
+ * Simplified single-budget representation used by the current UI. Maps to a
+ * `sliding` budget with the period collapsed onto a `day` window.
+ */
+export type SimpleBuzzLimit = {
+  limit: number;
+  period: 'day' | 'week' | 'month';
+};
+
+const PERIOD_DAYS: Record<SimpleBuzzLimit['period'], number> = {
+  day: 1,
+  week: 7,
+  month: 30,
+};
+
+/**
+ * Convert the UI's simple {limit, period} form into the canonical
+ * `BuzzLimit` budgets array.
+ */
+export function simpleBuzzLimitToBudgets(simple: SimpleBuzzLimit | null): BuzzLimit | null {
+  if (!simple) return null;
+  return [
+    {
+      type: 'sliding',
+      limit: simple.limit,
+      window: 'day',
+      unit: PERIOD_DAYS[simple.period],
+    },
+  ];
+}
+
+/**
+ * Reverse mapping. Returns the simple representation if and only if the
+ * budgets array is exactly one currency-unscoped sliding budget that matches
+ * one of the simple periods. Otherwise null (treat as either "no limit" or
+ * "custom" depending on caller).
+ */
+export function budgetsToSimpleBuzzLimit(
+  budgets: BuzzLimit | null | undefined
+): SimpleBuzzLimit | null {
+  if (!budgets || budgets.length !== 1) return null;
+  const b = budgets[0];
+  if (b.type !== 'sliding') return null;
+  if (b.currencies && b.currencies.length > 0) return null;
+
+  if (b.window === 'day' && b.unit === 1) return { limit: b.limit, period: 'day' };
+  if (b.window === 'day' && b.unit === 7) return { limit: b.limit, period: 'week' };
+  if (b.window === 'day' && b.unit === 30) return { limit: b.limit, period: 'month' };
+  if (b.window === 'week' && b.unit === 1) return { limit: b.limit, period: 'week' };
+  if (b.window === 'month' && b.unit === 1) return { limit: b.limit, period: 'month' };
+  return null;
+}
+
 export const addApiKeyInputSchema = z.object({
-  scope: z.array(z.enum(KeyScope)),
   name: z.string(),
+  tokenScope: z.number().int().min(0).max(TokenScope.Full).default(TokenScope.Full),
+  buzzLimit: buzzLimitSchema.nullable().optional(),
 });
 export type AddAPIKeyInput = z.input<typeof addApiKeyInputSchema>;
+
+export const setBuzzLimitInputSchema = z.object({
+  id: z.number(),
+  buzzLimit: buzzLimitSchema.nullable(),
+});
+export type SetBuzzLimitInput = z.infer<typeof setBuzzLimitInputSchema>;
+
+export type SubjectType = 'apiKey' | 'oauth';
+export type Subject = { type: 'apiKey'; id: number } | { type: 'oauth'; id: string };
 
 export const deleteApiKeyInputSchema = z.object({ id: z.number() });
 export type DeleteAPIKeyInput = z.infer<typeof deleteApiKeyInputSchema>;

--- a/src/server/schema/oauth-client.schema.ts
+++ b/src/server/schema/oauth-client.schema.ts
@@ -1,0 +1,29 @@
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import * as z from 'zod';
+
+export const getOauthClientByIdSchema = z.object({ id: z.string() });
+export type GetOauthClientByIdInput = z.infer<typeof getOauthClientByIdSchema>;
+
+export const createOauthClientSchema = z.object({
+  name: z.string().min(1).max(128),
+  description: z.string().max(500).default(''),
+  redirectUris: z.array(z.string().url()).min(1),
+  isConfidential: z.boolean().default(true),
+  allowedScopes: z.number().int().min(0).max(TokenScope.Full).default(TokenScope.Full),
+});
+export type CreateOauthClientInput = z.infer<typeof createOauthClientSchema>;
+
+export const updateOauthClientSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1).max(128).optional(),
+  description: z.string().max(500).optional(),
+  redirectUris: z.array(z.string().url()).min(1).optional(),
+  allowedScopes: z.number().int().min(0).max(TokenScope.Full).optional(),
+});
+export type UpdateOauthClientInput = z.infer<typeof updateOauthClientSchema>;
+
+export const deleteOauthClientSchema = z.object({ id: z.string() });
+export type DeleteOauthClientInput = z.infer<typeof deleteOauthClientSchema>;
+
+export const rotateOauthClientSecretSchema = z.object({ id: z.string() });
+export type RotateOauthClientSecretInput = z.infer<typeof rotateOauthClientSecretSchema>;

--- a/src/server/services/api-key.service.ts
+++ b/src/server/services/api-key.service.ts
@@ -3,6 +3,7 @@ import { dbWrite, dbRead } from '~/server/db/client';
 import { getDbWithoutLag } from '~/server/db/db-lag-helpers';
 import type {
   AddAPIKeyInput,
+  BuzzLimit,
   DeleteAPIKeyInput,
   GetAPIKeyInput,
   GetUserAPIKeysInput,
@@ -10,12 +11,14 @@ import type {
 import { simpleUserSelect } from '~/server/selectors/user.selector';
 import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
 import { generationServiceCookie } from '~/shared/constants/generation.constants';
+import { bustBuzzLimitCache, deleteAuthSubject } from '~/server/http/orchestrator/api-key-spend';
+import { logToAxiom, safeError } from '~/server/logging/client';
 
 export function getApiKey({ id }: GetAPIKeyInput) {
   return dbRead.apiKey.findUnique({
     where: { id },
     select: {
-      scope: true,
+      tokenScope: true,
       user: { select: simpleUserSelect },
     },
   });
@@ -33,9 +36,11 @@ export async function getUserApiKeys({
     where: { userId, type: 'User' },
     select: {
       id: true,
-      scope: true,
+      tokenScope: true,
       name: true,
       createdAt: true,
+      lastUsedAt: true,
+      buzzLimit: true,
     },
   });
   return keys.filter((x) => x.name !== generationServiceCookie.name);
@@ -44,7 +49,8 @@ export async function getUserApiKeys({
 export async function addApiKey(
   {
     name,
-    scope,
+    tokenScope,
+    buzzLimit,
     userId,
     maxAge,
     type,
@@ -57,7 +63,8 @@ export async function addApiKey(
 
   await dbWrite.apiKey.create({
     data: {
-      scope,
+      tokenScope,
+      buzzLimit: buzzLimit ?? undefined,
       name,
       userId,
       key: secret,
@@ -67,6 +74,43 @@ export async function addApiKey(
   });
 
   return key;
+}
+
+export async function setApiKeyBuzzLimit({
+  id,
+  userId,
+  buzzLimit,
+}: {
+  id: number;
+  userId: number;
+  buzzLimit: BuzzLimit | null;
+}) {
+  // Caller already verified the key belongs to the user; this update is the
+  // source of truth that the orchestrator will re-fetch via /api/v1/me.
+  const updated = await dbWrite.apiKey.update({
+    where: { id, userId },
+    data: { buzzLimit: buzzLimit ?? null },
+    select: { id: true, userId: true, buzzLimit: true },
+  });
+
+  // Best-effort: invalidate the orchestrator's cached limit. Failure is logged
+  // but doesn't fail the user-facing mutation — the orchestrator's cache TTL
+  // will eventually pick up the new value.
+  try {
+    await bustBuzzLimitCache({
+      userId: updated.userId,
+      subject: { type: 'apiKey', id: updated.id },
+    });
+  } catch (err) {
+    // Axiom field cap: stick to known columns. Detail goes inside `error`.
+    logToAxiom({
+      type: 'oauth.bust-cache.failed',
+      message: `bust-cache failed for apiKey ${updated.id} user ${updated.userId}`,
+      error: safeError(err),
+    }).catch(() => {});
+  }
+
+  return updated;
 }
 
 export async function getTemporaryUserApiKey(
@@ -86,11 +130,23 @@ export async function getTemporaryUserApiKey(
   return key;
 }
 
-export function deleteApiKey({ id, userId }: DeleteAPIKeyInput & { userId: number }) {
-  return dbWrite.apiKey.deleteMany({
-    where: {
-      userId,
-      id,
-    },
+export async function deleteApiKey({ id, userId }: DeleteAPIKeyInput & { userId: number }) {
+  const result = await dbWrite.apiKey.deleteMany({
+    where: { userId, id },
   });
+
+  // Best-effort: tell the orchestrator the subject is gone so its Mongo
+  // doesn't accumulate dangling spend records. Skipped silently if the
+  // delete didn't actually match anything.
+  if (result.count > 0) {
+    deleteAuthSubject({ userId, subject: { type: 'apiKey', id } }).catch((err) => {
+      logToAxiom({
+        type: 'oauth.delete-subject.failed',
+        message: `delete-subject failed for apiKey ${id} user ${userId}`,
+        error: safeError(err),
+      }).catch(() => {});
+    });
+  }
+
+  return result;
 }

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -50,6 +50,7 @@ const featureFlags = createFeatureFlags({
   canWrite: ['public'],
   earlyAccessModel: ['public'],
   apiKeys: ['public'],
+  oauthApps: { availability: ['mod'], fliptKey: 'oauth-apps' },
   articles: ['public'],
   articleCreate: ['public'],
   adminTags: ['mod', 'granted'],

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -12,21 +12,36 @@ import {
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
-import {
-  parseVerifiedBotHeader,
-  VERIFIED_BOT_HEADER,
-} from '~/server/utils/bot-detection/header';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { parseVerifiedBotHeader, VERIFIED_BOT_HEADER } from '~/server/utils/bot-detection/header';
 import type { Context } from './createContext';
 
-const t = initTRPC.context<Context>().create({
-  transformer: {
-    serialize: (data: any) => withSpan('trpc:serialize:superjson', () => superjson.serialize(data)),
-    deserialize: superjson.deserialize.bind(superjson),
-  },
-  errorFormatter({ shape }) {
-    return shape;
-  },
-});
+export interface TRPCMeta {
+  /** Bitwise token scope required for this procedure. Checked against ctx.tokenScope. */
+  requiredScope?: number;
+  /**
+   * When true, this procedure cannot be invoked via API key or OAuth token,
+   * regardless of scope — only session auth (browser cookie) is allowed.
+   * Used for Civitai-side buzz-spending operations (tips, bounty creation,
+   * cosmetic purchases, etc.). Buzz spend through tokens is delegated entirely
+   * to the orchestrator.
+   */
+  blockApiKeys?: boolean;
+}
+
+const t = initTRPC
+  .context<Context>()
+  .meta<TRPCMeta>()
+  .create({
+    transformer: {
+      serialize: (data: any) =>
+        withSpan('trpc:serialize:superjson', () => superjson.serialize(data)),
+      deserialize: superjson.deserialize.bind(superjson),
+    },
+    errorFormatter({ shape }) {
+      return shape;
+    },
+  });
 
 export const { router, middleware } = t;
 /**
@@ -110,10 +125,49 @@ const applyDomainFeature = t.middleware((options) => {
   return next();
 });
 
+/**
+ * Token scope enforcement middleware (fail-safe).
+ * - Session auth (no apiKeyId) is always allowed through unless blockApiKeys is set.
+ * - Procedures without `.meta({ requiredScope })` implicitly require `TokenScope.Full`.
+ *   Scoped tokens are denied on un-annotated endpoints; session and full-access keys
+ *   pass through (subject to the blockApiKeys gate below).
+ * - blockApiKeys: when set, the procedure is forbidden for any API-key/OAuth-token
+ *   request regardless of scope. Used for buzz-spending operations that the
+ *   orchestrator owns; tokens have no business spending buzz on Civitai's side.
+ */
+const enforceTokenScope = t.middleware(({ ctx, meta, next }) => {
+  // blockApiKeys: deny any token-based request, regardless of scope. Session
+  // auth (apiKeyId === null) is unaffected.
+  if (meta?.blockApiKeys && ctx.apiKeyId != null) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'This action cannot be performed via API key or OAuth token.',
+    });
+  }
+
+  // Session auth (cookies) and full-access API keys pass through scope check
+  if (ctx.tokenScope === TokenScope.Full) {
+    return next();
+  }
+
+  // Default unannotated endpoints to requiring Full scope
+  const requiredScope = meta?.requiredScope ?? TokenScope.Full;
+
+  if (!Flags.hasFlag(ctx.tokenScope, requiredScope)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Your API key does not have the required scope for this action',
+    });
+  }
+
+  return next();
+});
+
 export const publicProcedure = t.procedure
   .use(isAcceptableOrigin)
   .use(enforceClientVersion)
-  .use(applyDomainFeature);
+  .use(applyDomainFeature)
+  .use(enforceTokenScope);
 
 /**
  * Reusable middleware to ensure

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -9,6 +9,7 @@ import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import { getFeatureFlagsAsync } from '~/server/services/feature-flags.service';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const getServerProxySSGHelpers = async (
   ctx: GetServerSidePropsContext,
@@ -30,7 +31,9 @@ export const getServerProxySSGHelpers = async (
       fingerprint: null as any,
       domain,
       signal: new AbortController().signal,
-      // Now we can properly get domain from the request
+      tokenScope: TokenScope.Full,
+      apiKeyId: null,
+      subject: null,
     },
     transformer: superjson,
   });

--- a/src/shared/constants/token-scope.constants.ts
+++ b/src/shared/constants/token-scope.constants.ts
@@ -1,0 +1,192 @@
+/**
+ * Token Scope — Bitwise flags for API key and OAuth token permissions.
+ *
+ * Each scope is a power of 2 so they can be combined with bitwise OR.
+ * Use `Flags.hasFlag(tokenScope, TokenScope.ModelsWrite)` to check.
+ *
+ * Buzz spending is implicit in the scopes that require it:
+ *  - AIServicesWrite (generation, training, scanning)
+ *  - BountiesWrite (bounty creation)
+ *  - SocialTip (tipping)
+ */
+export const TokenScope = {
+  None: 0,
+
+  // Account & Profile
+  UserRead: 1 << 0, // 1
+  UserWrite: 1 << 1, // 2
+
+  // Models & Resources
+  ModelsRead: 1 << 2, // 4
+  ModelsWrite: 1 << 3, // 8
+  ModelsDelete: 1 << 4, // 16
+
+  // Media & Posts (images, videos, posts)
+  MediaRead: 1 << 5, // 32
+  MediaWrite: 1 << 6, // 64
+  MediaDelete: 1 << 7, // 128
+
+  // Articles
+  ArticlesRead: 1 << 8, // 256
+  ArticlesWrite: 1 << 9, // 512
+  ArticlesDelete: 1 << 10, // 1024
+
+  // Bounties (write implicitly allows buzz spend for bounty creation)
+  BountiesRead: 1 << 11, // 2048
+  BountiesWrite: 1 << 12, // 4096
+  BountiesDelete: 1 << 13, // 8192
+
+  // AI Services — generation, training, scanning, all orchestrator requests
+  // Write implicitly allows buzz spend for orchestrator usage
+  AIServicesRead: 1 << 14, // 16384
+  AIServicesWrite: 1 << 15, // 32768
+
+  // Buzz (Currency)
+  BuzzRead: 1 << 16, // 65536
+
+  // Collections & Interactions
+  CollectionsRead: 1 << 17, // 131072
+  CollectionsWrite: 1 << 18, // 262144
+  SocialWrite: 1 << 19, // 524288 — follow, react, comment, review
+  SocialTip: 1 << 20, // 1048576 — tip other users (buzz spend)
+
+  // Notifications
+  NotificationsRead: 1 << 21, // 2097152
+  NotificationsWrite: 1 << 22, // 4194304
+
+  // Vault
+  VaultRead: 1 << 23, // 8388608
+  VaultWrite: 1 << 24, // 16777216
+
+  // All scopes
+  Full: (1 << 25) - 1, // 33554431
+} as const;
+
+export type TokenScopeValue = (typeof TokenScope)[keyof typeof TokenScope];
+
+/** Human-readable labels for each scope, used in UI */
+export const tokenScopeLabels: Record<number, string> = {
+  [TokenScope.UserRead]: 'Read profile & settings',
+  [TokenScope.UserWrite]: 'Update profile & settings',
+  [TokenScope.ModelsRead]: 'Browse & download models',
+  [TokenScope.ModelsWrite]: 'Upload & edit models',
+  [TokenScope.ModelsDelete]: 'Delete models',
+  [TokenScope.MediaRead]: 'View images, videos & posts',
+  [TokenScope.MediaWrite]: 'Upload media & create posts',
+  [TokenScope.MediaDelete]: 'Delete media & posts',
+  [TokenScope.ArticlesRead]: 'Read articles',
+  [TokenScope.ArticlesWrite]: 'Create & edit articles',
+  [TokenScope.ArticlesDelete]: 'Delete articles',
+  [TokenScope.BountiesRead]: 'View bounties',
+  [TokenScope.BountiesWrite]: 'Create & manage bounties',
+  [TokenScope.BountiesDelete]: 'Delete bounties',
+  [TokenScope.AIServicesRead]: 'View generation & training history',
+  [TokenScope.AIServicesWrite]: 'Generate, train & scan',
+  [TokenScope.BuzzRead]: 'View buzz balance & history',
+  [TokenScope.CollectionsRead]: 'View collections',
+  [TokenScope.CollectionsWrite]: 'Manage collections',
+  [TokenScope.SocialWrite]: 'Follow, react, comment & review',
+  [TokenScope.SocialTip]: 'Tip other users',
+  [TokenScope.NotificationsRead]: 'Read notifications',
+  [TokenScope.NotificationsWrite]: 'Manage notification preferences',
+  [TokenScope.VaultRead]: 'View vault',
+  [TokenScope.VaultWrite]: 'Manage vault',
+};
+
+/** Convenience presets for the API key creation UI */
+export const TokenScopePresets = {
+  ReadOnly:
+    TokenScope.UserRead |
+    TokenScope.ModelsRead |
+    TokenScope.MediaRead |
+    TokenScope.ArticlesRead |
+    TokenScope.BountiesRead |
+    TokenScope.BuzzRead |
+    TokenScope.CollectionsRead |
+    TokenScope.AIServicesRead |
+    TokenScope.NotificationsRead |
+    TokenScope.VaultRead,
+  Creator:
+    TokenScope.UserRead |
+    TokenScope.ModelsRead |
+    TokenScope.MediaRead |
+    TokenScope.ArticlesRead |
+    TokenScope.BountiesRead |
+    TokenScope.BuzzRead |
+    TokenScope.CollectionsRead |
+    TokenScope.AIServicesRead |
+    TokenScope.NotificationsRead |
+    TokenScope.VaultRead |
+    TokenScope.ModelsWrite |
+    TokenScope.MediaWrite |
+    TokenScope.ArticlesWrite |
+    TokenScope.BountiesWrite |
+    TokenScope.CollectionsWrite |
+    TokenScope.SocialWrite,
+  AIServices: TokenScope.AIServicesWrite | TokenScope.AIServicesRead | TokenScope.BuzzRead,
+  Full: TokenScope.Full,
+} as const;
+
+/** Preset labels for the dropdown */
+export const tokenScopePresetLabels: Record<keyof typeof TokenScopePresets, string> = {
+  ReadOnly: 'Read Only',
+  Creator: 'Creator',
+  AIServices: 'AI Services',
+  Full: 'Full Access',
+};
+
+/**
+ * Scope grid for the permissions table UI.
+ * Each row is a resource category with optional read/write/delete scope flags.
+ */
+export const tokenScopeGrid = [
+  { label: 'Profile & Settings', read: TokenScope.UserRead, write: TokenScope.UserWrite },
+  {
+    label: 'Models',
+    read: TokenScope.ModelsRead,
+    write: TokenScope.ModelsWrite,
+    delete: TokenScope.ModelsDelete,
+  },
+  {
+    label: 'Media & Posts',
+    read: TokenScope.MediaRead,
+    write: TokenScope.MediaWrite,
+    delete: TokenScope.MediaDelete,
+  },
+  {
+    label: 'Articles',
+    read: TokenScope.ArticlesRead,
+    write: TokenScope.ArticlesWrite,
+    delete: TokenScope.ArticlesDelete,
+  },
+  {
+    label: 'Bounties',
+    read: TokenScope.BountiesRead,
+    write: TokenScope.BountiesWrite,
+    delete: TokenScope.BountiesDelete,
+  },
+  { label: 'AI Services', read: TokenScope.AIServicesRead, write: TokenScope.AIServicesWrite },
+  { label: 'Buzz', read: TokenScope.BuzzRead },
+  { label: 'Collections', read: TokenScope.CollectionsRead, write: TokenScope.CollectionsWrite },
+  { label: 'Social', write: TokenScope.SocialWrite },
+  // SocialTip is intentionally hidden from the UI grid: tipping is a Civitai-side
+  // buzz-spend op and `buzz.tipUser` is gated by `blockApiKeys: true`, so granting
+  // the bit to a token would have no effect. The bit stays in the enum to keep
+  // the bitmask stable for any keys that were issued before this hide.
+  {
+    label: 'Notifications',
+    read: TokenScope.NotificationsRead,
+    write: TokenScope.NotificationsWrite,
+  },
+  { label: 'Vault', read: TokenScope.VaultRead, write: TokenScope.VaultWrite },
+] as const;
+
+/** Get a human-readable label for a tokenScope bitmask */
+export function getScopeLabel(tokenScope: number | null | undefined): string {
+  if (tokenScope == null) return 'Legacy';
+  if (tokenScope === TokenScope.Full) return 'Full Access';
+  if (tokenScope === TokenScopePresets.ReadOnly) return 'Read Only';
+  if (tokenScope === TokenScopePresets.Creator) return 'Creator';
+  if (tokenScope === TokenScopePresets.AIServices) return 'AI Services';
+  return 'Custom';
+}

--- a/src/shared/utils/prisma/enums.ts
+++ b/src/shared/utils/prisma/enums.ts
@@ -485,17 +485,11 @@ export type PartnerPricingModel = (typeof PartnerPricingModel)[keyof typeof Part
 export const ApiKeyType = {
   System: 'System',
   User: 'User',
+  Access: 'Access',
+  Refresh: 'Refresh',
 } as const;
 
 export type ApiKeyType = (typeof ApiKeyType)[keyof typeof ApiKeyType];
-
-export const KeyScope = {
-  Read: 'Read',
-  Write: 'Write',
-  Generate: 'Generate',
-} as const;
-
-export type KeyScope = (typeof KeyScope)[keyof typeof KeyScope];
 
 export const TagEngagementType = {
   Hide: 'Hide',

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -100,9 +100,7 @@ export type TagSource = "User" | "Rekognition" | "WD14" | "Computed" | "ImageHas
 
 export type PartnerPricingModel = "Duration" | "PerImage";
 
-export type ApiKeyType = "System" | "User";
-
-export type KeyScope = "Read" | "Write" | "Generate";
+export type ApiKeyType = "System" | "User" | "Access" | "Refresh";
 
 export type TagEngagementType = "Hide" | "Follow" | "Allow";
 
@@ -483,6 +481,8 @@ export interface User {
   saves?: SavedModel[];
   imports?: Import[];
   keys?: ApiKey[];
+  oauthClients?: OauthClient[];
+  oauthConsents?: OauthConsent[];
   links?: UserLink[];
   comments?: Comment[];
   commentReactions?: CommentReaction[];
@@ -1649,12 +1649,47 @@ export interface ApiKey {
   id: number;
   key: string;
   name: string;
-  scope: KeyScope[];
+  tokenScope: number;
   userId: number;
   user?: User;
   createdAt: Date;
   type: ApiKeyType;
   expiresAt: Date | null;
+  lastUsedAt: Date | null;
+  clientId: string | null;
+  client?: OauthClient | null;
+  buzzLimit: JsonValue | null;
+}
+
+export interface OauthClient {
+  id: string;
+  secret: string | null;
+  name: string;
+  description: string;
+  logoUrl: string | null;
+  redirectUris: string[];
+  grants: string[];
+  allowedScopes: number;
+  isConfidential: boolean;
+  userId: number;
+  user?: User;
+  isVerified: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  tokens?: ApiKey[];
+  consents?: OauthConsent[];
+}
+
+export interface OauthConsent {
+  id: number;
+  userId: number;
+  user?: User;
+  clientId: string;
+  client?: OauthClient;
+  scope: number;
+  buzzLimit: JsonValue | null;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface AdToken {


### PR DESCRIPTION
## Summary

End-to-end OAuth 2.0 + scoped API tokens + per-subject buzz spend limits. Builds on (but does not merge) abandoned PR #1313.

- **OAuth 2.0 server** — authorization code with PKCE, refresh, revoke, device flow, OIDC discovery
- **Token scopes** — bitwise `TokenScope` enum with 25 flags, presets, and a fail-safe `enforceTokenScope` middleware (un-annotated procedures default to requiring `Full`)
- **83 routers annotated** with `.meta({ requiredScope })`; 15 buzz-spending procedures gated with `blockApiKeys: true`
- **Per-subject buzz limits** — opaque `(type, id)` subject pair, `BuzzBudget[]` shape supporting absolute/sliding/rollover variants with optional currency filters, stored on `ApiKey` (User-type keys) or `OauthConsent` (OAuth grants — stable across access-token rotations)
- **Orchestrator integration** — Civitai stores limits + busts cache + cleans up subjects via `/v1/manager/users/:userId/{auth,limits/auth}/:type/:id`; orchestrator owns enforcement and rolling-window math
- **Account UI** — card-based ApiKeys, OAuthApps, and ConnectedApps surfaces with inline spend bars + an `EditBuzzLimitModal` shared across both subject types
- **Consent screen** — collects an optional buzz limit when the requested scope includes `AIServicesWrite`
- **OAuth Apps + Connected Apps gated behind the `oauth-apps` Flipt flag** (mod-only on ship)
- **Audit** — `BuzzLimit_Set` ActionType in the existing CH `actions` table

## DB migrations

One additive migration to apply on this PR:

- `20260507165710_add_buzz_limit_to_oauth_consent` — adds `buzzLimit JSONB` column. Safe additive change.

The legacy `scope KeyScope[]` column drop is deferred to a follow-up PR after this is stable in prod (rolling-deploy safety: old pods still have the column in their generated client).

## Test plan

- [ ] `pnpm typecheck` clean ✓
- [ ] `pnpm lint` clean ✓
- [ ] `pnpm prettier:check` clean ✓
- [ ] Apply migration `20260507165710_add_buzz_limit_to_oauth_consent` in prod
- [ ] Session auth — log in, browse models/images/account, confirm no regressions (every request goes through the new middleware)
- [ ] Create scoped API key with limit set — verify persisted in DB and shown on Account card
- [ ] Hit `/api/v1/me` with bearer — verify response includes `subject: { type, id }` and `buzzLimit` array
- [ ] Hit a `blockApiKeys: true` procedure (e.g. `buzz.tipUser`) via bearer — expect 403
- [ ] Hit a scope-gated procedure with insufficient scope — expect 403
- [ ] OAuth flow end-to-end via [civitai-oauth-demo](https://github.com/civitai/civitai-oauth-demo): authorize → consent (with limit setter when AIServicesWrite is requested) → token exchange → refresh → revoke
- [ ] Connected Apps card — set/edit/clear a limit, confirm orchestrator bust-cache fires
- [ ] Delete an API key / revoke an app — confirm orchestrator subject delete fires
- [ ] Verify `oauth-apps` Flipt flag — mod-only by default

## Coordination

- Koen ships orchestrator side to `orchestration-next.civitai.com` first; spend bars in UI light up once his prod is updated. Until then `apiKey.getSpend` falls back to empty array on fetch failure (no UI break).

## Related

- Demo client: `civitai/civitai-oauth-demo`
- Plan: `docs/plans/oauth-scoped-tokens.md`
- Spend-limits design: `docs/plans/spend-limits.md`
- Developer guide: `docs/plans/oauth-developer-docs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)