### PR TITLE
feat(tips): add user/version flags to disable creator tips

### DIFF
--- a/prisma/migrations/20260508114648_add_user_modelversion_flags/migration.sql
+++ b/prisma/migrations/20260508114648_add_user_modelversion_flags/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN "flags" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "ModelVersion"
+  ADD COLUMN "flags" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -391,6 +391,7 @@ model User {
   blurNsfw                Boolean                @default(true)
   browsingLevel           Int                    @default(1)
   onboarding              Int                    @default(0)
+  flags                   Int                    @default(0)
   isModerator             Boolean?               @default(false)
   createdAt               DateTime               @default(now())
   deletedAt               DateTime?
@@ -991,6 +992,7 @@ model ModelVersion {
   uploadType           ModelUploadType   @default(Created)
   usageControl         ModelUsageControl @default(Download)
   earlyAccessTimeFrame Int               @default(0)
+  flags                Int               @default(0)
 
   licensingFee                   Int?
   licensingFeeType               LicensingFeeType?               @default(PerImageBuzz)

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -25,6 +25,9 @@ import type {
 } from '~/shared/utils/prisma/enums';
 import { Availability } from '~/shared/utils/prisma/enums';
 import { stringifyAIR } from '~/shared/utils/air';
+import { Flags } from '~/shared/utils/flags';
+import { UserFlag } from '~/shared/constants/user-flags.constants';
+import { ModelVersionFlag } from '~/shared/constants/model-version-flags.constants';
 
 const schema = z.object({
   id: z.coerce.number(),
@@ -56,6 +59,8 @@ type VersionRow = {
   licensingFee: number | null;
   licensingFeeType: LicensingFeeType | null;
   licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
+  versionFlags: number;
+  userFlags: number;
 };
 type FileRow = {
   id: number;
@@ -103,6 +108,8 @@ export default MixedAuthEndpoint(async function handler(
       mv."licensingFee",
       mv."licensingFeeType",
       mv."licensingFeeSettlementCurrency",
+      mv."flags" AS "versionFlags",
+      u."flags" AS "userFlags",
       (
         (
             mv."earlyAccessEndsAt" > NOW()
@@ -128,6 +135,7 @@ export default MixedAuthEndpoint(async function handler(
       ) AS "freeTrialLimit"
     FROM "ModelVersion" mv
     JOIN "Model" m ON m.id = mv."modelId"
+    JOIN "User" u ON u.id = m."userId"
     WHERE ${Prisma.join(where, ' AND ')}
   `;
   if (!modelVersion) return res.status(404).json({ error: 'Model not found' });
@@ -253,6 +261,10 @@ export default MixedAuthEndpoint(async function handler(
         }
       : undefined;
 
+  const creatorTips =
+    !Flags.hasFlag(modelVersion.userFlags, UserFlag.DisableTips) &&
+    !Flags.hasFlag(modelVersion.versionFlags, ModelVersionFlag.DisableTips);
+
   const data = {
     air,
     versionName: modelVersion.versionName,
@@ -277,6 +289,7 @@ export default MixedAuthEndpoint(async function handler(
     minor: modelVersion.minor,
     sfwOnly: modelVersion.sfwOnly,
     fee,
+    creatorTips,
   };
   res.status(200).json(data);
 });

--- a/src/shared/constants/model-version-flags.constants.ts
+++ b/src/shared/constants/model-version-flags.constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Model Version Flags — Bitwise opt-out / behavior flags stored on `ModelVersion.flags`.
+ *
+ * Each flag is a power of 2 so they can be combined with bitwise OR.
+ * Use `Flags.hasFlag(modelVersion.flags, ModelVersionFlag.DisableTips)` to check.
+ */
+export const ModelVersionFlag = {
+  None: 0,
+
+  /** This version opts out of creator tips (e.g. licensed models). */
+  DisableTips: 1 << 0, // 1
+} as const;
+
+export type ModelVersionFlagValue = (typeof ModelVersionFlag)[keyof typeof ModelVersionFlag];
+
+export const modelVersionFlagLabels: Record<number, string> = {
+  [ModelVersionFlag.DisableTips]: 'Disable creator tips',
+};

--- a/src/shared/constants/user-flags.constants.ts
+++ b/src/shared/constants/user-flags.constants.ts
@@ -1,0 +1,18 @@
+/**
+ * User Flags — Bitwise opt-out / behavior flags stored on `User.flags`.
+ *
+ * Each flag is a power of 2 so they can be combined with bitwise OR.
+ * Use `Flags.hasFlag(user.flags, UserFlag.DisableTips)` to check.
+ */
+export const UserFlag = {
+  None: 0,
+
+  /** User opts out of receiving creator tips on their content. */
+  DisableTips: 1 << 0, // 1
+} as const;
+
+export type UserFlagValue = (typeof UserFlag)[keyof typeof UserFlag];
+
+export const userFlagLabels: Record<number, string> = {
+  [UserFlag.DisableTips]: 'Disable creator tips',
+};

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -448,6 +448,7 @@ export interface User {
   blurNsfw: boolean;
   browsingLevel: number;
   onboarding: number;
+  flags: number;
   isModerator: boolean | null;
   createdAt: Date;
   deletedAt: Date | null;
@@ -866,6 +867,7 @@ export interface ModelVersion {
   uploadType: ModelUploadType;
   usageControl: ModelUsageControl;
   earlyAccessTimeFrame: number;
+  flags: number;
   licensingFee: number | null;
   licensingFeeType: LicensingFeeType | null;
   licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;


### PR DESCRIPTION
## Summary

Adds bitmask `flags Int` columns on `User` and `ModelVersion`. First bit (`DisableTips = 1 << 0`) opts the user / version out of creator tips. The `/api/v1/model-versions/mini/[id]` endpoint now returns a `creatorTips: boolean` field equal to `!user.DisableTips && !version.DisableTips` — orchestrator can read this to suppress the creator-tip flow.

Use cases:
- **User-level**: Civitai official account should never receive tips.
- **Version-level**: Licensed models (already charging a fee) should not also accept tips.

Pattern follows the existing `ApiKey.tokenScope` + `token-scope.constants.ts` precedent.

## Changes

- `prisma/schema.full.prisma`: `flags Int @default(0)` on `User` and `ModelVersion`
- `prisma/migrations/20260508114648_add_user_modelversion_flags/`: ALTER TABLE for both columns (NOT NULL DEFAULT 0)
- `src/shared/constants/user-flags.constants.ts`: new — `UserFlag.DisableTips`
- `src/shared/constants/model-version-flags.constants.ts`: new — `ModelVersionFlag.DisableTips`
- `src/pages/api/v1/model-versions/mini/[id].ts`: JOIN User, select both flag ints, expose `creatorTips` boolean

## Follow-ups (not in this PR)

- Admin / owner UI to toggle the flags
- Flip Civitai official account's `DisableTips` bit in prod
- Wire `creatorTips` consumer in orchestrator / generation form

## Test plan

- [ ] Apply migration on staging
- [ ] `curl /api/v1/model-versions/mini/<id>` returns `creatorTips: true` for an unflagged version
- [ ] Set `User.flags = 1` via SQL → response flips to `creatorTips: false`
- [ ] Reset user, set `ModelVersion.flags = 1` → response also `creatorTips: false`
- [ ] Confirm orchestrator behavior once consumer is wired

ClickUp: https://app.clickup.com/t/868jjggkk

🤖 Generated with [Claude Code](https://claude.com/claude-code)