### PR TITLE
fix(images): invalidate image-cacher caches when deleting images

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -291,6 +291,11 @@ export const serverSchema = z.object({
   STORAGE_RESOLVER_INTERNAL_URL: z.string().optional(),
   STORAGE_RESOLVER_INTERNAL_TOKEN: z.string().optional(),
 
+  // Image-cacher invalidation endpoint (cluster-internal). Used to clear
+  // image-cacher's Redis L2 cache + Cloudflare cache after we delete an
+  // image from B2. Optional — if unset, invalidation is skipped.
+  IMAGE_CACHER_URL: z.url().optional(),
+
   // BitDex
   BITDEX_URL: z.string().optional().default(''),
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -40,7 +40,7 @@ import {
   type JudgeScore,
 } from '~/server/games/daily-challenge/daily-challenge.utils';
 import { poolCounters } from '~/server/games/new-order/utils';
-import { logToAxiom } from '~/server/logging/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { fetchDocumentsAbortable, metricsSearchClient } from '~/server/meilisearch/client';
 import { postMetrics } from '~/server/metrics';
@@ -247,6 +247,28 @@ export async function purgeResizeCache({ url }: { url: string }) {
     await imageS3Client.deleteManyObjects({
       bucket: env.S3_IMAGE_CACHE_BUCKET,
       keys,
+    });
+  }
+
+  // Best-effort: tell image-cacher to invalidate its caches for this UUID
+  // after the source-of-truth deletion (above) has succeeded. If this fails
+  // (network, image-cacher down, etc.) we accept up to 4d of stale L2 entries
+  // — no worse than today's behavior. Never block or throw the delete flow.
+  if (env.IMAGE_CACHER_URL && url) {
+    fetch(`${env.IMAGE_CACHER_URL}/admin/invalidate?imageKey=${encodeURIComponent(url)}`, {
+      method: 'POST',
+      // Invalidation must not slow down the delete flow.
+      signal: AbortSignal.timeout(2000),
+    }).catch((err) => {
+      logToAxiom({
+        type: 'warning',
+        name: 'image-cacher-invalidate',
+        message: 'image-cacher invalidate failed',
+        imageKey: url,
+        error: safeError(err),
+      }).catch(() => {
+        // swallow — best effort logging
+      });
     });
   }
 }


### PR DESCRIPTION
## Why

Image-cacher caches \"this file exists in B2 cache bucket\" entries in Redis
(L2, 4d TTL). When civitai-web deletes an image, `purgeResizeCache()`
removes the file variants from B2 — but image-cacher has no awareness this
happened. It keeps issuing 301 redirects to the now-deleted file.

Combined with our recent Cloudflare cache rule on `image.civitai.com` (which
caches 301s for 24h), this produces a 24h+ window of broken-image redirects
per deletion. Sampled stale rate is ~0.4% of L2 entries. Affects user
deletes, admin bulk delete, account deletion, post deletion, moderation.

## What

Adds a fire-and-forget `POST` to image-cacher's new `/admin/invalidate`
endpoint inside `purgeResizeCache()`, after the B2 DeleteObjects succeeds.

The endpoint clears image-cacher's Redis L2 entries by UUID prefix and
purges Cloudflare. It's best-effort — if image-cacher is unreachable, this
call fails silently (logged via `logToAxiom`) and behavior reverts to
today's stale-cache state. No worse than now.

Hooking inside `purgeResizeCache` (rather than each upstream caller)
means every delete path benefits with one change: `deleteImageFromS3`,
`deleteImageById`, `post.service` hideMeta path, account/post deletion,
moderation, admin bulk delete.

URL is from new env var `IMAGE_CACHER_URL`. Default cluster-internal
target: `http://civitai-image-cacher.civitai-image-cacher.svc.cluster.local`
(set in DP via the standard env-var workflow, separate PR/SOPS edit).

## Trade-offs

- **No auth** on the endpoint (cluster-internal Service, idempotent, no
  data loss risk). Auth deferred to v2 if needed.
- **L1 staleness window**: in-process MemoryCache on each image-cacher
  pod is NOT invalidated by the endpoint — up to 1h of stale L1 hits
  possible. Acceptable for v1; pub/sub-based broadcast deferred.
- **Best-effort**: we never block or fail the delete flow on
  invalidation errors. 2s timeout via AbortController.
- New \`IMAGE_CACHER_URL\` env var is optional; skipped if unset (local
  dev, PR-preview environments where image-cacher is unreachable).

## Test plan

- [ ] Set \`IMAGE_CACHER_URL\` on staging or one PR preview; exercise an
      image delete via tRPC; verify the invalidate call lands in
      image-cacher logs / metrics.
- [ ] Confirm B2 file is gone AND a fresh user request to that image
      returns 404 (not a stale 301 to a deleted object).
- [ ] Confirm with \`IMAGE_CACHER_URL\` unset, the delete flow proceeds
      normally with no errors (skip path).