### PR TITLE
perf(post): rewrite getInfinite cursor predicate as row-comparison

### DIFF
--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -373,12 +373,11 @@ export const getPostsInfinite = async ({
     }
 
     if (cursorId !== null) {
-      // Composite cursor: use keyset pagination for stable results
-      // (primary < cursor) OR (primary = cursor AND id < cursor_id)
+      // Composite cursor: row-comparison form lets postgres push the predicate
+      // into Index Cond on (primarySortProp DESC, id DESC) indexes. Equivalent
+      // to (primary < cursor) OR (primary = cursor AND id <= cursor_id).
       AND.push(
-        Prisma.sql`(${Prisma.raw(primarySortProp)} < ${primaryValue} OR (${Prisma.raw(
-          primarySortProp
-        )} = ${primaryValue} AND p.id <= ${cursorId}))`
+        Prisma.sql`(${Prisma.raw(primarySortProp)}, p.id) <= (${primaryValue}, ${cursorId})`
       );
     } else {
       // Legacy single cursor


### PR DESCRIPTION
## Summary

Rewrites the `getPostsInfinite` cursor predicate from OR-form to row-comparison form so postgres can push it into an `Index Cond` on `Post_feed_covering_idx (publishedAt DESC, id DESC)` instead of applying it as a `Filter`.

**Before:**
```sql
AND (p."publishedAt" < $2 OR (p."publishedAt" = $3 AND p.id <= $4))
```

**After:**
```sql
AND (p."publishedAt", p.id) <= ($2, $4)
```

Postgres expands `(a, b) <= (x, y)` to exactly the same boolean expression, but recognizes the composite-key form as a tuple comparison aligned with the index ordering, making it `Index Cond`-eligible.

## Why

This query was the **#1 by total exec time** in `pg_stat_statements` on `cnpg-cluster-nvme0` (DP write primary):
- ~6 second mean exec time
- ~3,800 calls per measurement window
- ~22,000+ seconds of total exec time per window

`EXPLAIN ANALYZE` with literal cursor values shows **~8ms** when the planner can use the covering index efficiently. The OR-form was preventing that path under most cursor parameter shapes.

The `Post_feed_covering_idx` was added in a prior optimization but adoption was poor without this app-side change. A redundant `Post_publishedAt_idx` was also dropped today (cnpg-cluster-nvme0); this PR is the application-side complement.

## Scope

Single file, single function. Searched `image.service.ts`, `model.service.ts`, and the rest of the codebase for the same OR-form cursor pattern — only one match (this one).

The rewrite generalizes correctly to the secondary sort modes (`MostComments`, `MostReactions`, `MostCollected`) since they share the same `(primarySortProp, id)` keyset shape.

## Test plan

- [ ] Smoke test the post browse feed (default sort = publishedAt DESC) and verify no duplicates / no skipped posts at page boundaries
- [ ] Smoke test secondary sorts: Most Comments, Most Reactions, Most Collected
- [ ] Smoke test draft-only mode (sorts by `createdAt` instead of `publishedAt`)
- [ ] Watch `pg_stat_statements` on cnpg-cluster-nvme0 post-deploy for queryid `8338692151433229733` — expect mean_exec_time to drop dramatically once the new query shape gets a fresh queryid
- [ ] Verify no rise in `dbReadFallbackCounter` or replica-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)