### PR TITLE
fix(createContext): bind disconnect listener to res, prevent socket listener leak

### DIFF
--- a/src/server/createContext.ts
+++ b/src/server/createContext.ts
@@ -48,27 +48,21 @@ export const createContext = async ({
   const domain = getRequestDomainColor(req) ?? 'blue';
 
   // Abort downstream work (Meili, DB calls that plumb signal) when the client
-  // disconnects â€” e.g. when the image feed's slow-fetch timeout cancels a hung
+  // disconnects — e.g. when the image feed's slow-fetch timeout cancels a hung
   // request. Saves pod CPU on requests whose response will never be read.
   //
-  // Listening on the raw socket's 'end' event: Next.js pages router wraps
-  // req/res such that req/res 'close' events don't fire until the response
-  // finishes (useless for mid-handler cancellation). socket.end fires
-  // immediately when the client half-closes the connection, which is exactly
-  // what we need. Listener is removed as soon as the response finishes so we
-  // don't accumulate handlers on a keep-alive socket.
+  // Listen on `res` (per-request) rather than `req.socket` (long-lived,
+  // reused across keep-alive requests). `res.close` fires once when the
+  // underlying connection terminates OR after `res.end()` completes, covering
+  // both abnormal client disconnect and normal completion. Because `res` is
+  // per-request and not reused, the listener is reclaimed by GC when `res`
+  // becomes unreferenced — no manual detach needed, and no accumulation on
+  // the keep-alive socket.
   const abortController = new AbortController();
   const onDisconnect = () => {
     if (!res.writableEnded && !abortController.signal.aborted) abortController.abort();
   };
-  req.socket?.on('end', onDisconnect);
-  req.socket?.on('close', onDisconnect);
-  const detach = () => {
-    req.socket?.off('end', onDisconnect);
-    req.socket?.off('close', onDisconnect);
-  };
-  res.once('finish', detach);
-  res.once('close', detach);
+  res.once('close', onDisconnect);
 
   // tokenScope: from bearer token auth (stored on req.context by getServerAuthSession).
   // Session auth (cookies) gets Full scope â€” no restrictions for browser users.


### PR DESCRIPTION
## Summary

The Meilisearch disconnect propagation introduced in `1a8161495` registers an `onDisconnect` handler on `req.socket` (the long-lived keep-alive HTTP socket) and detaches it on `res.finish`/`res.close`. When a response terminates abnormally — HTTP/2 reset, client RST mid-response, upstream proxy timeout — neither event fires deterministically, the detach never runs, and the listener stays bound to a socket that serves many subsequent requests. Each leaked listener retains the entire tRPC context (`user`, `session`, `features`, `Tracker`, `abortController`) via closure.

**Production observation**: 22 SSR pods crossed 85% of `--max-old-space-size=4096` within ~6h of a clean deploy that reset heap baselines. Mean major-GC wall time across the SSR fleet went from 0.08% → 0.41% (5×). 23 OOM/heap-exhaust pod restarts in 13.5h, all on the two highest-density nodes. Per-endpoint P99 regressed `/user/{slug}` 7×, `/posts/{id}` 4.8×, `/models/{id}/{slug}` 2× — the work isn't slower, GC pauses are interleaving the request lifetime.

## Fix

Bind `onDisconnect` to `res.close` instead. `res` is per-request and not reused — GC reclaims it (and the listener) automatically when the request completes, no manual detach. `res.close` fires once on abnormal connection termination OR after `res.end()` completes, preserving the abort-on-disconnect behavior the original commit introduced.

## Caveat

The original commit comment claimed \`res.close\` in Next.js pages router fires only after the handler returns (too late to cancel an in-flight Meilisearch call). If that observation still holds for the current Next.js version, the Meilisearch cancellation path may regress for mid-handler aborts even though abnormal post-flush disconnects are still caught. The memory leak is fixed regardless. Worth validating in staging before relying on the \`ctx.signal\` cancellation feature for hot endpoints.

## Test plan

- [ ] Deploy to staging
- [ ] Verify SSR pod heap stops growing under steady-state traffic (monitor \`nodejs_heap_size_used_bytes{namespace=\"civitai-dp-prod-stage\"}\` over 4+ hours)
- [ ] Verify Meilisearch slow-fetch cancellation still triggers on client disconnect (curl + abort mid-response, check Meili request logs)
- [ ] Watch SSR P99 latency on \`/user/{slug}\` and \`/posts/{id}\` for regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)