### PR TITLE
fix(createContext): bind disconnect listener to res, not req.socket

### DIFF
--- a/src/server/createContext.ts
+++ b/src/server/createContext.ts
@@ -48,27 +48,21 @@ export const createContext = async ({
   const domain = getRequestDomainColor(req) ?? 'blue';
 
   // Abort downstream work (Meili, DB calls that plumb signal) when the client
-  // disconnects â€” e.g. when the image feed's slow-fetch timeout cancels a hung
+  // disconnects — e.g. when the image feed's slow-fetch timeout cancels a hung
   // request. Saves pod CPU on requests whose response will never be read.
   //
-  // Listening on the raw socket's 'end' event: Next.js pages router wraps
-  // req/res such that req/res 'close' events don't fire until the response
-  // finishes (useless for mid-handler cancellation). socket.end fires
-  // immediately when the client half-closes the connection, which is exactly
-  // what we need. Listener is removed as soon as the response finishes so we
-  // don't accumulate handlers on a keep-alive socket.
+  // Listen on `res` (per-request) rather than `req.socket` (long-lived,
+  // reused across keep-alive requests). `res.close` fires once when the
+  // underlying connection terminates OR after `res.end()` completes, covering
+  // both abnormal client disconnect and normal completion. Because `res` is
+  // per-request and not reused, the listener is reclaimed by GC when `res`
+  // becomes unreferenced — no manual detach needed, and no accumulation on
+  // the keep-alive socket.
   const abortController = new AbortController();
   const onDisconnect = () => {
     if (!res.writableEnded && !abortController.signal.aborted) abortController.abort();
   };
-  req.socket?.on('end', onDisconnect);
-  req.socket?.on('close', onDisconnect);
-  const detach = () => {
-    req.socket?.off('end', onDisconnect);
-    req.socket?.off('close', onDisconnect);
-  };
-  res.once('finish', detach);
-  res.once('close', detach);
+  res.once('close', onDisconnect);
 
   // tokenScope: from bearer token auth (stored on req.context by getServerAuthSession).
   // Session auth (cookies) gets Full scope â€” no restrictions for browser users.


### PR DESCRIPTION
The disconnect handler introduced in 1a8161495 ("propagate client disconnect to Meilisearch") was registered on req.socket and detached on res.finish/res.close. req.socket is the long-lived keep-alive HTTP socket, reused across many requests. When a response terminates abnormally — HTTP/2 reset, mid-response client RST, upstream proxy timeout — neither finish nor close fires deterministically, so the detach never runs and the listener stays bound to the socket.

Each leaked listener retains its closure → res → abortController → the entire tRPC ctx (user, session, features, Tracker). Production observation: 22 SSR pods reached >85% of the 4 GiB max-old-space within ~6 hours of a deploy that reset heap baselines.

Bind onDisconnect to res.close instead. res is per-request and not reused, so the listener is reclaimed by GC when res becomes unreferenced — no manual detach, no accumulation on the keep-alive socket. res.close fires once on abnormal connection termination OR after res.end() completes, preserving the abort-on-disconnect behavior the original commit introduced.

NOTE: the original commit comment claimed res.close in Next.js pages router fires only after the handler returns (too late to cancel an in-flight Meilisearch call). If that observation still holds for the current Next.js version, the Meilisearch cancellation path may regress for mid-handler aborts even though abnormal post-flush disconnects are still caught. Worth validating in staging before relying on the ctx.signal cancellation feature for hot endpoints.