### PR TITLE
perf(image): re-enable getAllImages query cache for model gallery paths

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -61,7 +61,7 @@ import {
 import type { RedisKeyTemplateSys } from '~/server/redis/client';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { imageMetricsCache } from '~/server/redis/entity-metric-populate';
-import { createCachedObject } from '~/server/utils/cache-helpers';
+import { createCachedObject, queryCacheRaw } from '~/server/utils/cache-helpers';
 import { createLruCache } from '~/server/utils/lru-cache';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type { CollectionMetadataSchema } from '~/server/schema/collection.schema';
@@ -1115,8 +1115,10 @@ export const getAllImages = async (
   const AND: Prisma.Sql[] = [Prisma.sql`i."postId" IS NOT NULL`];
   const WITH: Prisma.Sql[] = [];
   let orderBy: string;
-  // const cacheTags: string[] = [];
-  // let cacheTime = CacheTTL.xs;
+  const cacheTags: string[] = [];
+  // Default-deny: cache only enabled for safe, shareable paths (set explicitly below).
+  // Personalized/identity-leaking branches must keep cacheTime = 0.
+  let cacheTime = 0;
   const userId = user?.id;
   const isModerator = user?.isModerator ?? false;
   const includeCosmetics = include?.includes('cosmetics'); // TODO: This must be done similar to user cosmetics.
@@ -1172,7 +1174,7 @@ export const getAllImages = async (
     if (!userId) throw throwAuthorizationError();
     const imageIds = prefetchedHiddenImages?.map((x) => x.imageId) ?? [];
     if (imageIds.length) {
-      // cacheTime = 0;
+      cacheTime = 0; // per-user hidden image set
       AND.push(Prisma.sql`i."id" IN (${Prisma.join(imageIds)})`);
     } else {
       return { items: [], nextCursor: undefined };
@@ -1226,6 +1228,8 @@ export const getAllImages = async (
     AND.push(Prisma.sql`(p."publishedAt" IS NULL)`);
   } else if (!pending) {
     if (userId && !publishedOnly) {
+      // userId is bound into the SQL, so each user gets their own cache key —
+      // safe to cache, lower hit rate but no cross-user leakage.
       AND.push(Prisma.sql`(p."publishedAt" < now() OR p."userId" = ${userId})`);
     } else {
       AND.push(Prisma.sql`(p."publishedAt" < now())`);
@@ -1267,13 +1271,15 @@ export const getAllImages = async (
       // cacheTime = 0;
     } else if (modelVersionId) {
       AND.push(Prisma.sql`irr."modelVersionId" = ${modelVersionId}`);
-      // cacheTime = CacheTTL.day;
-      // cacheTags.push(`images-modelVersion:${modelVersionId}`);
+      // 10 min — model galleries can tolerate brief staleness; bust hooks in
+      // post.service.ts fire on image upload/update for the matching tag.
+      cacheTime = CacheTTL.md;
+      cacheTags.push(`images-modelVersion:${modelVersionId}`);
     } else if (modelId) {
       joins.push(`JOIN "ModelVersion" mv ON mv.id = irr."modelVersionId"`);
       AND.push(Prisma.sql`mv."modelId" = ${modelId}`);
-      // cacheTime = CacheTTL.day;
-      // cacheTags.push(`images-model:${modelId}`);
+      cacheTime = CacheTTL.md;
+      cacheTags.push(`images-model:${modelId}`);
     }
   }
 
@@ -1293,23 +1299,21 @@ export const getAllImages = async (
       // Prisma.sql`(i."userId" = ${targetUserId} OR i."postId" IN (SELECT id FROM collaboratingPosts))`
       Prisma.sql`i."userId" = ${targetUserId}`
     );
-    // Don't cache self queries
-    // cacheTime = 0;
-    // if (targetUserId !== userId) {
-    //   cacheTime = CacheTTL.day;
-    //   cacheTags.push(`images-user:${targetUserId}`);
-    // } else cacheTime = 0;
+    // user-gallery path: out of scope for this PR; future work could enable
+    // cache for targetUserId !== userId via an `images-user:${targetUserId}` tag.
+    cacheTime = 0;
   }
 
   // Filter only followed users
   // [x]
   if (userId && followed && prefetchedUserFollows?.length) {
-    // cacheTime = 0;
+    cacheTime = 0; // per-user follow set
     AND.push(Prisma.sql`i."userId" IN (${Prisma.join(prefetchedUserFollows)})`);
   }
 
   // Filter to specific tags
   if (tags?.length) {
+    cacheTime = 0; // tag combinations are high-cardinality; skip cache for now
     AND.push(Prisma.sql`i.id IN (
       SELECT "imageId"
       FROM "TagsOnImageDetails"
@@ -1330,7 +1334,10 @@ export const getAllImages = async (
   if (!!postIds?.length) AND.push(Prisma.sql`i."postId" IN (${Prisma.join(postIds)})`);
 
   // Filter to a specific image
-  if (imageId) AND.push(Prisma.sql`i.id = ${imageId}`);
+  if (imageId) {
+    cacheTime = 0; // single-image lookups don't benefit from caching
+    AND.push(Prisma.sql`i.id = ${imageId}`);
+  }
 
   if (sort === ImageSort.Random && !collectionId) {
     throw throwBadRequestError('Random sort requires a collectionId');
@@ -1439,7 +1446,10 @@ export const getAllImages = async (
     //   orderBy = `im."collectedCount" DESC, im."reactionCount" DESC, im."imageId"`;
     //   if (!isGallery) AND.push(Prisma.sql`im."collectedCount" > 0`);
     // }
-    if (sort === ImageSort.Random) orderBy = 'ct."sortKey" DESC, i."id" DESC';
+    if (sort === ImageSort.Random) {
+      cacheTime = 0; // random ordering should not be pinned by a cache
+      orderBy = 'ct."sortKey" DESC, i."id" DESC';
+    }
     // TODO this causes the app to spike
     // else if (sort === ImageSort.Oldest) {
     //   orderBy = 'i."sortAt" ASC';
@@ -1498,6 +1508,7 @@ export const getAllImages = async (
   if (prioritizeUser && !useModelVersionCache) {
     // [x]
     if (cursor) throw new Error('Cannot use cursor with prioritizedUserIds');
+    cacheTime = 0; // prioritizedUserIds reorders/filters per-caller
     if (modelVersionId) AND.push(Prisma.sql`p."modelVersionId" = ${modelVersionId}`);
 
     // If system user, show community images
@@ -1519,7 +1530,7 @@ export const getAllImages = async (
   }
 
   if (userId && !!reactions?.length) {
-    // cacheTime = 0;
+    cacheTime = 0; // per-user reaction filter
     // Use IN subquery - planner can start from reactions (small set per user) and join to images
     AND.push(Prisma.sql`i.id IN (
       SELECT ir."imageId" FROM "ImageReaction" ir
@@ -1554,6 +1565,7 @@ export const getAllImages = async (
   }
 
   if (pending && (isModerator || userId)) {
+    cacheTime = 0; // pending view is moderator/owner-scoped
     if (isModerator) {
       AND.push(Prisma.sql`((i."nsfwLevel" & ${browsingLevel}) != 0 OR i."nsfwLevel" = 0)`);
     } else if (userId) {
@@ -1655,13 +1667,21 @@ export const getAllImages = async (
       LIMIT ${limit + 1}
   `;
 
-  // Disable Prisma query
-  // if (!env.IMAGE_QUERY_CACHING) cacheTime = 0;
-  // const cacheable = queryCache(dbRead, 'getAllImages', 'v1');
-  // const rawImages = await cacheable<GetAllImagesRaw[]>(query, { ttl: cacheTime, tag: cacheTags });
-
-  const { rows: rawImages } = await withSpan('image:getAllImages:rawQuery', () =>
-    imageDb.query<GetAllImagesRaw>(query)
+  if (!env.IMAGE_QUERY_CACHING) cacheTime = 0;
+  // queryCacheRaw wraps imageDb.query so the dual-DB routing (write/datapacket/read)
+  // computed above is preserved while gaining Redis cache semantics.
+  // bustCacheTag('images-model:X' / 'images-modelVersion:X') is already wired in
+  // post.service.ts on image upload/update events.
+  const cacheable = queryCacheRaw(
+    async <Row,>(q: Prisma.Sql) => {
+      const { rows } = await imageDb.query(q as any);
+      return rows as Row[];
+    },
+    'getAllImages',
+    'v1'
+  );
+  const rawImages = await withSpan('image:getAllImages:rawQuery', () =>
+    cacheable<GetAllImagesRaw[]>(query, { ttl: cacheTime, tag: cacheTags })
   );
   // const rawImages = await dbRead.$queryRaw<GetAllImagesRaw[]>(query);
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1117,8 +1117,12 @@ export const getAllImages = async (
   let orderBy: string;
   const cacheTags: string[] = [];
   // Default-deny: cache only enabled for safe, shareable paths (set explicitly below).
-  // Personalized/identity-leaking branches must keep cacheTime = 0.
+  // Personalized branches set isPersonalized = true. Final cacheTime is forced to 0
+  // at the cache-wrapper site if isPersonalized — this makes the invariant
+  // ordering-independent so a personalization branch above the modelId/modelVersionId
+  // enable site (e.g. `hidden`) can't be silently re-enabled by a later branch.
   let cacheTime = 0;
+  let isPersonalized = false;
   const userId = user?.id;
   const isModerator = user?.isModerator ?? false;
   const includeCosmetics = include?.includes('cosmetics'); // TODO: This must be done similar to user cosmetics.
@@ -1174,7 +1178,7 @@ export const getAllImages = async (
     if (!userId) throw throwAuthorizationError();
     const imageIds = prefetchedHiddenImages?.map((x) => x.imageId) ?? [];
     if (imageIds.length) {
-      cacheTime = 0; // per-user hidden image set
+      isPersonalized = true; // per-user hidden image set
       AND.push(Prisma.sql`i."id" IN (${Prisma.join(imageIds)})`);
     } else {
       return { items: [], nextCursor: undefined };
@@ -1301,19 +1305,19 @@ export const getAllImages = async (
     );
     // user-gallery path: out of scope for this PR; future work could enable
     // cache for targetUserId !== userId via an `images-user:${targetUserId}` tag.
-    cacheTime = 0;
+    isPersonalized = true;
   }
 
   // Filter only followed users
   // [x]
   if (userId && followed && prefetchedUserFollows?.length) {
-    cacheTime = 0; // per-user follow set
+    isPersonalized = true; // per-user follow set
     AND.push(Prisma.sql`i."userId" IN (${Prisma.join(prefetchedUserFollows)})`);
   }
 
   // Filter to specific tags
   if (tags?.length) {
-    cacheTime = 0; // tag combinations are high-cardinality; skip cache for now
+    isPersonalized = true; // tag combinations are high-cardinality; skip cache for now
     AND.push(Prisma.sql`i.id IN (
       SELECT "imageId"
       FROM "TagsOnImageDetails"
@@ -1335,7 +1339,7 @@ export const getAllImages = async (
 
   // Filter to a specific image
   if (imageId) {
-    cacheTime = 0; // single-image lookups don't benefit from caching
+    isPersonalized = true; // single-image lookups don't benefit from caching
     AND.push(Prisma.sql`i.id = ${imageId}`);
   }
 
@@ -1447,7 +1451,7 @@ export const getAllImages = async (
     //   if (!isGallery) AND.push(Prisma.sql`im."collectedCount" > 0`);
     // }
     if (sort === ImageSort.Random) {
-      cacheTime = 0; // random ordering should not be pinned by a cache
+      isPersonalized = true; // random ordering should not be pinned by a cache
       orderBy = 'ct."sortKey" DESC, i."id" DESC';
     }
     // TODO this causes the app to spike
@@ -1508,7 +1512,7 @@ export const getAllImages = async (
   if (prioritizeUser && !useModelVersionCache) {
     // [x]
     if (cursor) throw new Error('Cannot use cursor with prioritizedUserIds');
-    cacheTime = 0; // prioritizedUserIds reorders/filters per-caller
+    isPersonalized = true; // prioritizedUserIds reorders/filters per-caller
     if (modelVersionId) AND.push(Prisma.sql`p."modelVersionId" = ${modelVersionId}`);
 
     // If system user, show community images
@@ -1530,7 +1534,7 @@ export const getAllImages = async (
   }
 
   if (userId && !!reactions?.length) {
-    cacheTime = 0; // per-user reaction filter
+    isPersonalized = true; // per-user reaction filter
     // Use IN subquery - planner can start from reactions (small set per user) and join to images
     AND.push(Prisma.sql`i.id IN (
       SELECT ir."imageId" FROM "ImageReaction" ir
@@ -1565,7 +1569,7 @@ export const getAllImages = async (
   }
 
   if (pending && (isModerator || userId)) {
-    cacheTime = 0; // pending view is moderator/owner-scoped
+    isPersonalized = true; // pending view is moderator/owner-scoped
     if (isModerator) {
       AND.push(Prisma.sql`((i."nsfwLevel" & ${browsingLevel}) != 0 OR i."nsfwLevel" = 0)`);
     } else if (userId) {
@@ -1667,6 +1671,11 @@ export const getAllImages = async (
       LIMIT ${limit + 1}
   `;
 
+  // Final invariant: any personalized branch above forces no-cache, regardless of
+  // ordering relative to the modelId/modelVersionId enable site. This prevents a
+  // future personalization branch added above the enable from being silently
+  // re-cached.
+  if (isPersonalized) cacheTime = 0;
   if (!env.IMAGE_QUERY_CACHING) cacheTime = 0;
   // queryCacheRaw wraps imageDb.query so the dual-DB routing (write/datapacket/read)
   // computed above is preserved while gaining Redis cache semantics.

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1268,7 +1268,7 @@ export const getAllImages = async (
     if (reviewId) {
       joins.push(`JOIN "ResourceReview" re ON re."modelVersionId" = irr."modelVersionId"`);
       AND.push(Prisma.sql`re."id" = ${reviewId}`);
-      // cacheTime = 0;
+      // reviewId joins ResourceReview — out of scope for this PR's cache enable.
     } else if (modelVersionId) {
       AND.push(Prisma.sql`irr."modelVersionId" = ${modelVersionId}`);
       // 10 min — model galleries can tolerate brief staleness; bust hooks in

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -1090,14 +1090,28 @@ export async function bustCachesForPosts(postIds: number | number[]) {
   const ids = Array.isArray(postIds) ? postIds : [postIds];
   // Use dbWrite — bustCachesForPosts runs immediately after image/post writes
   // so the replica may not yet reflect the post.modelVersionId we need.
-  const results = await dbWrite.$queryRaw<{ isShowcase: boolean; modelVersionId: number }[]>`
+  const results = await dbWrite.$queryRaw<
+    { isShowcase: boolean; modelVersionId: number; modelId: number }[]
+  >`
     SELECT m."userId" = p."userId" as "isShowcase",
-           p."modelVersionId"
+           p."modelVersionId",
+           mv."modelId"
     FROM "Post" p
            JOIN "ModelVersion" mv ON mv."id" = p."modelVersionId"
            JOIN "Model" m ON m."id" = mv."modelId"
     WHERE p."id" IN (${Prisma.join(ids)})
   `;
+
+  // Bust getAllImages model-gallery cache for ALL affected modelVersions/models —
+  // not just showcase posts. Deletion/moderation paths also call this, and stale
+  // gallery results for deleted/blocked images would defeat fast removal (e.g.
+  // DMCA, CSAM, policy moderation). Deduplicate to avoid redundant Redis ops.
+  const modelVersionIds = [...new Set(results.map((x) => x.modelVersionId))];
+  const modelIds = [...new Set(results.map((x) => x.modelId))];
+  await Promise.all([
+    ...modelVersionIds.map((mvId) => bustCacheTag(`images-modelVersion:${mvId}`)),
+    ...modelIds.map((mId) => bustCacheTag(`images-model:${mId}`)),
+  ]);
 
   const showcaseVersionIds = results.filter((x) => x.isShowcase).map((x) => x.modelVersionId);
   if (!showcaseVersionIds.length) return;

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -39,6 +39,35 @@ export function queryCache(db: PrismaClient, key: string, version?: string) {
   };
 }
 
+// Sibling of queryCache for callers that run raw queries through node-postgres
+// (pg-pool) instead of Prisma. Same Redis caching semantics, but takes a
+// query executor closure that returns rows directly. Used by getAllImages
+// where the query is dispatched to one of pgDbWrite | pgDbRead | datapacketDbRead
+// based on dual-DB routing logic that we can't push into a Prisma client.
+type RawQueryExecutor = <Row>(query: Prisma.Sql) => Promise<Row[]>;
+export function queryCacheRaw(executor: RawQueryExecutor, key: string, version?: string) {
+  return async function <T extends object[]>(query: Prisma.Sql, options?: cachedQueryOptions) {
+    if (options?.ttl === 0) return (await executor<T[number]>(query)) as unknown as T;
+
+    // this typing is not quite right, as we're creating redis keys on the fly here
+    const cacheKey = [key, version, hashifyObject(query).toString()]
+      .filter(isDefined)
+      .join(':') as RedisKeyTemplateCache;
+    const cachedData = await redis.packed.get<T>(cacheKey);
+    if (cachedData && options?.ttl !== 0) {
+      cacheHitCounter.inc({ cache_name: key, cache_type: 'queryCache' });
+      return cachedData ?? ([] as unknown as T);
+    }
+
+    cacheMissCounter.inc({ cache_name: key, cache_type: 'queryCache' });
+    const result = (await executor<T[number]>(query)) as unknown as T;
+    await redis.packed.set(cacheKey, result, { EX: options?.ttl });
+
+    if (options?.tag) await tagCacheKey(cacheKey, options?.tag);
+    return result;
+  };
+}
+
 async function tagCacheKey(key: string, tag: string | string[]) {
   const tags = Array.isArray(tag) ? tag : [tag];
   for (const tag of tags) {


### PR DESCRIPTION
## Summary

Re-enables the long-disabled Redis query cache for the `modelId` / `modelVersionId` code paths in `getAllImages`. This is the model-gallery query — it has been running uncached against PostgreSQL for the past 2 years.

**Production impact (`pg_stat_statements` on `cnpg-cluster-nvme0`):**
- Mean: 4,082 ms
- Stddev: 8,477 ms (bimodal — small models cached at the framework level somewhere, popular models hit the cold path)
- Max: 53,234 ms
- Total: ~2,878 sec per measurement window

The plan walks all `ImageResourceNew` rows for each `ModelVersion` of the requested model, joins to `Image` and `Post`, applies many filters, then sorts the full join result before `LIMIT 24`. For popular models with millions of image-resource rows, this is unavoidable per-request work — caching is the right mitigation.

## Background

Caching infrastructure here was always intended to exist:
- `bustCacheTag('images-model:X')` and `bustCacheTag('images-modelVersion:X')` are still being called from `post.service.ts` (5 callsites: lines 1072, 1080, 1282-1283, 1327) on image upload / update events
- Those calls have been firing into a non-existent cache since commit `7b8437a6c` (Feb 2024), which commented out the producer side as an apparent side-effect of a package-upgrade rollback

This PR restores the producer side of that contract.

## Changes

- **`cache-helpers.ts`**: New `queryCacheRaw` helper — sibling of `queryCache` that takes a query executor closure instead of a Prisma client. Required because `getAllImages` dispatches to one of `pgDbWrite | datapacketDbRead | pgDbRead` based on dual-DB routing logic that can't be expressed through Prisma's client API.

- **`image.service.ts`**: Default-deny — `cacheTime = 0` until a code path explicitly opts in. Only the `modelId` / `modelVersionId` branches enable caching (`CacheTTL.md` = 10 min) with the existing `images-model:` / `images-modelVersion:` bust tags. Personalized / identity-bound branches (`hidden`, `prioritizeUser`, `targetUserId`, `followed`, `tags`, `imageId`, `reactions`, `pending`, random sort) explicitly reset to 0 so caching can't leak across personalization layers if any of them activate alongside a modelId filter.

- The `IMAGE_QUERY_CACHING` env-var kill-switch (already in the schema) is honored — set to `false` to turn caching off without a redeploy if anything goes wrong.

## Cache hit rate expectations

- **Anonymous traffic**: high hit rate. `userId` is undefined → user-OR clauses are skipped at the SQL level → all anonymous users emit the same SQL string → same `hashifyObject(query)` → same cache key.
- **Logged-in users**: per-user cache keys (their `userId` gets embedded into OR clauses). Lower hit rate but no cross-user leakage.

## Out of scope (future PRs)

- User-gallery (`targetUserId`) caching — original commented code wanted a tagged 24h cache for non-self queries
- Tag combinations — high cardinality, needs a different strategy
- Public-share rewrite — could lift logged-in users to anonymous-tier cache hit rates by emitting userId-free SQL when the OR clauses are dead in context

## Test plan

- [ ] Smoke test: load a popular model gallery page (e.g. https://civitai.com/models/257749) and verify images load
- [ ] Smoke test: paginate through 3-4 pages, verify cursor works
- [ ] Smoke test: hit a model gallery, then immediately upload a new image to that model, then reload — verify the new image appears (`bustCacheTag` should fire)
- [ ] Watch Prometheus: `cache_hit_count_total{cache_name="getAllImages"}` and `cache_miss_count_total{cache_name="getAllImages"}` should start emitting non-zero values
- [ ] Watch `pg_stat_statements` on cnpg-cluster-nvme0 for queryid `3185566853498974672` — call rate should drop on cache hits, leaving only cold-cache calls
- [ ] If anything goes wrong, set `IMAGE_QUERY_CACHING=false` in env to immediately disable

🤖 Generated with [Claude Code](https://claude.com/claude-code)