### PR TITLE
fix(model-file-scan): dedupe webhook callbacks + log modelVersionId

### DIFF
--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -778,6 +778,9 @@ export const REDIS_SYS_KEYS = {
   CACHES: {
     IMAGE_EXISTS: 'feed:image:exists',
   },
+  WEBHOOKS: {
+    MODEL_FILE_SCAN_PROCESSED: 'webhooks:model-file-scan:processed',
+  },
 } as const;
 
 // Cached data

--- a/src/server/services/__tests__/model-file-scan.service.test.ts
+++ b/src/server/services/__tests__/model-file-scan.service.test.ts
@@ -14,6 +14,7 @@ const {
   mockModelFileScanSubmissionError,
   mockLimitConcurrency,
   mockUnpublishModelById,
+  mockSetNxKeepTtlWithEx,
 } = vi.hoisted(() => {
   // Test-local copy of the real error class so rescanModel's instanceof
   // check resolves without importing the real orchestrator module.
@@ -67,6 +68,7 @@ const {
       for (const t of tasks) await t();
     }),
     mockUnpublishModelById: vi.fn().mockResolvedValue({}),
+    mockSetNxKeepTtlWithEx: vi.fn().mockResolvedValue(true),
   };
 });
 
@@ -133,6 +135,13 @@ vi.mock('~/server/utils/concurrency-helpers', () => ({
 // Stub the whole module to avoid loading its dep tree.
 vi.mock('~/server/services/model.service', () => ({
   unpublishModelById: mockUnpublishModelById,
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { setNxKeepTtlWithEx: mockSetNxKeepTtlWithEx },
+  REDIS_SYS_KEYS: {
+    WEBHOOKS: { MODEL_FILE_SCAN_PROCESSED: 'webhooks:model-file-scan:processed' },
+  },
 }));
 
 import {
@@ -273,13 +282,14 @@ describe('model-file-scan.service', () => {
     it('logs a warning and returns without writes when the file is not found', async () => {
       setupFileFound(null);
 
-      await applyScanOutcome({ fileId: 999 });
+      await applyScanOutcome({ fileId: 999, modelVersionId: 42 });
 
       expect(mockLogToAxiom).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'warning',
           name: 'apply-scan-outcome',
           fileId: 999,
+          modelVersionId: 42,
         }),
         'webhooks'
       );
@@ -511,6 +521,56 @@ describe('model-file-scan.service', () => {
       mockDbWrite.modelFile.update.mockResolvedValue({});
       mockDbWrite.$transaction.mockResolvedValue([]);
       mockDbWrite.modelFileHash.findMany.mockResolvedValue([]);
+      // Default: dedupe key acquired (first delivery for this workflow).
+      mockSetNxKeepTtlWithEx.mockResolvedValue(true);
+    });
+
+    it('suppresses duplicate callbacks for the same workflowId without side-effects', async () => {
+      // Second delivery: dedupe lock already held by first delivery.
+      mockSetNxKeepTtlWithEx.mockResolvedValueOnce(false);
+
+      await processModelFileScanResult(
+        makeReq({ workflowId: 'wf-dup', type: 'workflow', status: 'succeeded' })
+      );
+
+      expect(mockSetNxKeepTtlWithEx).toHaveBeenCalledWith(
+        'webhooks:model-file-scan:processed:wf-dup',
+        '1',
+        expect.any(Number)
+      );
+      // No orchestrator round-trip, no DB writes, no cache busts on duplicate.
+      expect(mockGetWorkflow).not.toHaveBeenCalled();
+      expect(mockDbWrite.modelFile.update).not.toHaveBeenCalled();
+      expect(mockDeleteFilesForModelVersionCache).not.toHaveBeenCalled();
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'info',
+          name: 'model-file-scan-result',
+          workflowId: 'wf-dup',
+          duplicate: true,
+        }),
+        'webhooks'
+      );
+    });
+
+    it('acquires the dedupe lock on first delivery and proceeds to process the workflow', async () => {
+      mockGetWorkflow.mockResolvedValue({
+        data: {
+          metadata: { fileId: 1, modelVersionId: 100 },
+          steps: [],
+        },
+      });
+
+      await processModelFileScanResult(
+        makeReq({ workflowId: 'wf-first', type: 'workflow', status: 'succeeded' })
+      );
+
+      expect(mockSetNxKeepTtlWithEx).toHaveBeenCalledWith(
+        'webhooks:model-file-scan:processed:wf-first',
+        '1',
+        expect.any(Number)
+      );
+      expect(mockGetWorkflow).toHaveBeenCalledTimes(1);
     });
 
     it('throws when the orchestrator returns no workflow data', async () => {

--- a/src/server/services/model-file-scan.service.ts
+++ b/src/server/services/model-file-scan.service.ts
@@ -8,6 +8,7 @@ import { requestScannerTasks } from '~/server/jobs/scan-files';
 import { internalOrchestratorClient } from '~/server/services/orchestrator/client';
 import { logToAxiom } from '~/server/logging/client';
 import { dataForModelsCache } from '~/server/redis/caches';
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { modelsSearchIndex } from '~/server/search-index';
 import { deleteFilesForModelVersionCache } from '~/server/services/model-file.service';
 import { unpublishModelById } from '~/server/services/model.service';
@@ -129,7 +130,13 @@ export async function applyScanOutcome(outcome: ScanOutcome): Promise<void> {
   });
   if (!file) {
     logToAxiom(
-      { type: 'warning', name: 'apply-scan-outcome', message: `File not found: ${fileId}`, fileId },
+      {
+        type: 'warning',
+        name: 'apply-scan-outcome',
+        message: `File not found: ${fileId}`,
+        fileId,
+        modelVersionId: outcome.modelVersionId,
+      },
       'webhooks'
     ).catch();
     return;
@@ -367,8 +374,39 @@ function derivePickleScanResult(
   return exitCodeToScanResult(output.exitCode);
 }
 
+// Webhook callbacks can fire more than once per workflow (orchestrator retries,
+// fan-out from multiple terminal event types). Dedupe on workflowId before any
+// side-effect so duplicate deliveries don't double-write DB rows, double-bump
+// `scanRequestedAt`, or double-invalidate caches. 1h TTL covers retry windows
+// while keeping the key cardinality bounded.
+const SCAN_CALLBACK_DEDUPE_TTL_SECONDS = 60 * 60;
+
 export async function processModelFileScanResult(req: NextApiRequest) {
   const event: WorkflowEvent = req.body;
+
+  if (event.workflowId) {
+    const dedupeKey =
+      `${REDIS_SYS_KEYS.WEBHOOKS.MODEL_FILE_SCAN_PROCESSED}:${event.workflowId}` as const;
+    const acquired = await sysRedis.setNxKeepTtlWithEx(
+      dedupeKey,
+      '1',
+      SCAN_CALLBACK_DEDUPE_TTL_SECONDS
+    );
+    if (!acquired) {
+      logToAxiom(
+        {
+          type: 'info',
+          name: 'model-file-scan-result',
+          message: `Duplicate callback suppressed for workflow ${event.workflowId}`,
+          workflowId: event.workflowId,
+          status: event.status,
+          duplicate: true,
+        },
+        'webhooks'
+      ).catch();
+      return;
+    }
+  }
 
   const { data } = await getWorkflow({
     client: internalOrchestratorClient,


### PR DESCRIPTION
## Summary
- Dedupe orchestrator scan-result callbacks on `workflowId` via `sysRedis.setNxKeepTtlWithEx` (1h TTL) so duplicate deliveries short-circuit before any DB write or cache invalidation
- Emit `model-file-scan-result` info event with `duplicate: true` for monitoring
- Include `modelVersionId` (from the `ScanOutcome` payload) in the `apply-scan-outcome` "File not found" warning — without it there's no way to identify the affected model in Axiom when the `ModelFile` row is already gone

## Why
Observed in prod 2026-05-08 → 2026-05-11 (Axiom, `webhooks` dataset):
- 9 `apply-scan-outcome` "File not found" warnings — 3 of 4 affected fileIds received **2 webhook callbacks each within ~30ms** (workflows `0-019e1696-...`, `0-019e16a0-...`, `0-019e16e4-...`)
- For 4 of the 6 fileIds we couldn't identify the affected model/version because the `ModelFile` row was hard-deleted and the warning didn't carry `modelVersionId`

## Test plan
- [x] `pnpm vitest run src/server/services/__tests__/model-file-scan.service.test.ts` — 61 passing
- [x] Added test: duplicate callback short-circuits (no `getWorkflow`, no DB write, no cache bust)
- [x] Added test: first delivery acquires lock and proceeds normally
- [x] Updated existing not-found test to assert `modelVersionId` is logged
- [ ] After deploy: confirm `duplicate: true` events appear in Axiom and `apply-scan-outcome` warnings include `modelVersionId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)