### PR TITLE
fix(health): treat cluster isReady=undefined as not-ready

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -100,9 +100,14 @@ const checkFns: Record<string, CancellableCheckFn> = {
   async redis(signal: AbortSignal) {
     if (signal.aborted) return false;
     try {
-      // For cluster, we need to check if it's ready first
+      // RedisCluster does not expose `isReady` (only RedisClient does), so a
+      // strict `=== false` check is a silent no-op for cluster mode and lets
+      // ping() run before slot discovery completes — which throws
+      // `Cannot read properties of undefined (reading 'connectPromise')`
+      // from inside node-redis cluster-slots. Treat any non-truthy isReady
+      // (undefined or false) as not ready.
       const baseClient = redis as any;
-      if (baseClient.isReady === false) {
+      if (!baseClient.isReady) {
         return false;
       }
       const res = await (redis as any).ping();
@@ -118,7 +123,7 @@ const checkFns: Record<string, CancellableCheckFn> = {
     if (signal.aborted) return false;
     try {
       const baseClient = sysRedis as any;
-      if (baseClient.isReady === false) {
+      if (!baseClient.isReady) {
         return false;
       }
       const res = await (sysRedis as any).ping();


### PR DESCRIPTION
## Summary

Production `civitai-dp-prod` pods are intermittently failing `/api/health` readiness probes with:

```
health-check:redis: Cannot read properties of undefined (reading 'connectPromise')
```

## Root cause

`src/pages/api/health.ts` guards Redis `ping()` with:

```ts
if (baseClient.isReady === false) return false;
```

The strict `=== false` check is **a silent no-op for cluster mode**. The cache client on DP is a `RedisCluster` instance, and `RedisCluster` does not expose `isReady` (only the single `RedisClient` does). So `baseClient.isReady` is `undefined`, the guard is skipped, and `ping()` runs while the cluster's slot map is still empty (just-connected pod).

When `ping()` hits an empty cluster, node-redis calls `nodeClient(this.getRandomNode())` → `getRandomNode()` returns `undefined` → `nodeClient(undefined)` throws inside `@redis/client/dist/lib/cluster/cluster-slots.js:214`:

```js
nodeClient(node) {
  return (node.connectPromise ?? node.client ?? this.#createNodeClient(node));
}
```

The error is caught and logged, but `/api/health` returns unhealthy → readiness flaps every time a pod starts → cascades that show up as latency spikes and brief load redistribution. Worst during rolling restarts (deploys, OOM cycles, drains).

## The bug is latent — has been on `main` since the cluster migration (#1876)

It just fires loudly during rolling restarts. Commit `5e414125b` (Sunday 2026-05-09) triggered a fleet-wide rolling restart which made it visible across many pods at once.

## Fix

Replace `baseClient.isReady === false` with `!baseClient.isReady` so:
- `undefined` (cluster, before discovery) → returns false (not ready)
- `false` (single client, disconnected) → returns false (not ready)
- `true` (either, ready) → proceeds to `ping()`

Applied to both `redis` (cache cluster) and `sysRedis` (single client, defensive).

## Test plan

- [ ] CI passes
- [ ] After merge + deploy, watch civitai-dp-prod Loki for `name="health-check:redis"` error volume — should drop to zero
- [ ] Watch readiness flapping during the next rolling restart — should be clean
- [ ] Existing `for: 1m` on `CivitaiDpProdHealthCheckFailing` alert still works since the function still returns `false` when not ready

## Out of scope

The orchestrator P95 slowness on `imageUpload`/`enhancePrompt` (separately reported Monday peak) is unrelated and likely a downstream service issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)