### PR TITLE
fix(comments): article report deep links open reported comment

### DIFF
--- a/src/components/Article/Detail/ArticleDetailComments.tsx
+++ b/src/components/Article/Detail/ArticleDetailComments.tsx
@@ -44,9 +44,7 @@ export function ArticleDetailComments({ articleId, userId }: ArticleDetailCommen
               <Stack gap={0}>
                 <Group justify="space-between">
                   <Group gap="md">
-                    <Title order={2} id="comments">
-                      Comments
-                    </Title>
+                    <Title order={2}>Comments</Title>
                     {hiddenCount > 0 && !isLoading && (
                       <Button
                         variant="subtle"

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -18,7 +18,7 @@ import { IconAlertCircle, IconBolt, IconBookmark, IconShare3 } from '@tabler/ico
 import dayjs from '~/shared/utils/dayjs';
 import { truncate } from 'lodash-es';
 import type { InferGetServerSidePropsType } from 'next';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useRouter } from 'next/router';
 import * as z from 'zod';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
@@ -154,13 +154,12 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
   // Force eager mount when the URL targets the comments section, so deep links
   // (#comments, ?highlight=, mod report redirects) load comments on first paint
   // instead of waiting for the user to scroll into the IntersectionObserver.
+  // Derived per-render so it stays in sync with router state across navigations
+  // (the page component instance is reused by _app without a key).
   const router = useRouter();
-  const [forceEagerComments, setForceEagerComments] = useState(() => !!router.query.highlight);
-  useEffect(() => {
-    if (typeof window !== 'undefined' && window.location.hash === '#comments') {
-      setForceEagerComments(true);
-    }
-  }, []);
+  const forceEagerComments =
+    !!router.query.highlight ||
+    (typeof window !== 'undefined' && window.location.hash === '#comments');
 
   const { blockedUsers } = useHiddenPreferencesData();
   const isBlocked = blockedUsers.find((u) => u.id === article?.user.id);

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -18,7 +18,8 @@ import { IconAlertCircle, IconBolt, IconBookmark, IconShare3 } from '@tabler/ico
 import dayjs from '~/shared/utils/dayjs';
 import { truncate } from 'lodash-es';
 import type { InferGetServerSidePropsType } from 'next';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 import * as z from 'zod';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { NotFound } from '~/components/AppLayout/NotFound';
@@ -69,7 +70,7 @@ import { formatDate } from '~/utils/date-helpers';
 import { showErrorNotification } from '~/utils/notifications';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { removeEmpty } from '~/utils/object-helpers';
-import { parseNumericString } from '~/utils/query-string-helpers';
+import { buildPassthroughQuery, parseNumericString } from '~/utils/query-string-helpers';
 import { removeTags, slugit } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { isDefined } from '~/utils/type-guards';
@@ -107,13 +108,17 @@ export const getServerSideProps = createServerSideProps({
         const correctSlug = slugit(article.title);
         const currentSlug = result.data.slug?.join('/');
         if (currentSlug !== correctSlug) {
-          // 308 when no slug was supplied (bare-id URLs are a stable canonical
-          // mapping); 307 when the slug is wrong (article rename can happen
-          // again, so don't let browsers cache the redirect).
-          const permanent = !currentSlug;
+          const queryString = buildPassthroughQuery(ctx.query);
+          // 308 only for bare-id → slug canonical mapping with no query string,
+          // because some browsers cache 308 keyed on path only and drop the
+          // query on subsequent hits (which strands deep-link params from
+          // /comments/v2/<id> and notification redirects). 307 anywhere a
+          // query is involved or the slug differs — those redirects are
+          // request-specific and should not be cached.
+          const permanent = !currentSlug && !queryString;
           return {
             redirect: {
-              destination: `/articles/${result.data.id}/${correctSlug}`,
+              destination: `/articles/${result.data.id}/${correctSlug}${queryString}`,
               permanent,
             },
           };
@@ -145,6 +150,17 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
     rootMargin: '100px', // Start loading when 100px away from viewport (reduced from 400px; this delays loading and may worsen perceived performance)
     threshold: 0.1, // Trigger when 10% of the element is visible
   });
+
+  // Force eager mount when the URL targets the comments section, so deep links
+  // (#comments, ?highlight=, mod report redirects) load comments on first paint
+  // instead of waiting for the user to scroll into the IntersectionObserver.
+  const router = useRouter();
+  const [forceEagerComments, setForceEagerComments] = useState(() => !!router.query.highlight);
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.location.hash === '#comments') {
+      setForceEagerComments(true);
+    }
+  }, []);
 
   const { blockedUsers } = useHiddenPreferencesData();
   const isBlocked = blockedUsers.find((u) => u.id === article?.user.id);
@@ -492,8 +508,8 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
             />
           </ContainerGrid2.Col>
         </ContainerGrid2>
-        <div ref={commentsRef}>
-          {commentsInView && (
+        <div id="comments" ref={commentsRef}>
+          {(commentsInView || forceEagerComments) && (
             <ArticleDetailComments articleId={article.id} userId={article.user.id} />
           )}
         </div>

--- a/src/pages/bounties/[id]/[[...slug]].tsx
+++ b/src/pages/bounties/[id]/[[...slug]].tsx
@@ -66,6 +66,7 @@ import {
 import { constants } from '~/server/common/constants';
 import type { Props as DescriptionTableProps } from '~/components/DescriptionTable/DescriptionTable';
 import { DescriptionTable } from '~/components/DescriptionTable/DescriptionTable';
+import { buildPassthroughQuery } from '~/utils/query-string-helpers';
 import { getDisplayName, slugit } from '~/utils/string-helpers';
 import { AttachmentCard } from '~/components/Article/Detail/AttachmentCard';
 import produce from 'immer';
@@ -120,9 +121,10 @@ export const getServerSideProps = createServerSideProps({
         const correctSlug = slugit(bounty.name);
         const currentSlug = result.data.slug?.join('/');
         if (correctSlug && currentSlug !== correctSlug) {
+          const queryString = buildPassthroughQuery(ctx.query);
           return {
             redirect: {
-              destination: `/bounties/${result.data.id}/${correctSlug}`,
+              destination: `/bounties/${result.data.id}/${correctSlug}${queryString}`,
               permanent: false,
             },
           };

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -75,6 +75,7 @@ import { useQueryChallenge } from '~/components/Challenge/challenge.utils';
 import { WinnerPodiumCard } from '~/components/Challenge/WinnerPodiumCard';
 import type { Props as DescriptionTableProps } from '~/components/DescriptionTable/DescriptionTable';
 import { DescriptionTable } from '~/components/DescriptionTable/DescriptionTable';
+import { buildPassthroughQuery } from '~/utils/query-string-helpers';
 import { getModelUrl, slugit } from '~/utils/string-helpers';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
@@ -179,9 +180,10 @@ export const getServerSideProps = createServerSideProps({
         const correctSlug = slugit(challenge.title);
         const currentSlug = result.data.slug?.join('/');
         if (currentSlug !== correctSlug) {
+          const queryString = buildPassthroughQuery(ctx.query);
           return {
             redirect: {
-              destination: `/challenges/${result.data.id}/${correctSlug}`,
+              destination: `/challenges/${result.data.id}/${correctSlug}${queryString}`,
               permanent: false,
             },
           };

--- a/src/pages/comments/v2/[id].tsx
+++ b/src/pages/comments/v2/[id].tsx
@@ -135,8 +135,11 @@ export const getServerSideProps = createServerSideProps({
       threadType: threadData.threadType,
       threadId: thread.id,
       commentId: commentV2.id,
-      commentParentType: commentV2.thread.comment?.id ? 'comment' : threadData.threadType,
-      commentParentId: commentV2.thread.comment?.id,
+      // Always pin the target comment as the thread root so it renders standalone via
+      // RootThreadProvider's activeComment path. Sidesteps cursor-paginated thread fetches
+      // (target may be on page N) and works uniformly for root and reply comments.
+      commentParentType: 'comment',
+      commentParentId: commentV2.id,
     });
 
     if (url) {

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -128,7 +128,14 @@ import {
   showWarningNotification,
 } from '~/utils/notifications';
 import { abbreviateNumber } from '~/utils/number-helpers';
-import { getDisplayName, getModelUrl, removeTags, slugit, splitUppercase } from '~/utils/string-helpers';
+import { buildPassthroughQuery } from '~/utils/query-string-helpers';
+import {
+  getDisplayName,
+  getModelUrl,
+  removeTags,
+  slugit,
+  splitUppercase,
+} from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { isNumber } from '~/utils/type-guards';
 
@@ -239,24 +246,13 @@ export const getServerSideProps = createServerSideProps({
         const correctSlug = slugit(model.name);
         const currentSlug = params.slug?.join('/');
         if (correctSlug && currentSlug !== correctSlug) {
-          // Preserve all inbound query params (dialog, commentId, highlight,
-          // modelVersionId, etc.) — Next.js merges path params into ctx.query
-          // for catch-all routes, so strip the path keys before re-serializing.
-          const passthrough = new URLSearchParams();
-          for (const [key, value] of Object.entries(ctx.query)) {
-            if (key === 'id' || key === 'slug') continue;
-            if (Array.isArray(value)) {
-              for (const v of value) passthrough.append(key, v);
-            } else if (value != null) {
-              passthrough.append(key, value);
-            }
-          }
-          const qs = passthrough.toString();
-          const queryString = qs ? `?${qs}` : '';
-          // 308 when no slug was supplied (bare-id URLs are a stable canonical
-          // mapping); 307 when the slug is wrong (model rename can happen
-          // again, so don't let browsers cache the redirect).
-          const permanent = !currentSlug;
+          const queryString = buildPassthroughQuery(ctx.query);
+          // 308 only for bare-id → slug canonical mapping with no query string.
+          // Some browsers cache 308 by path alone and drop the query on
+          // subsequent hits, which strands deep-link params (highlight=,
+          // commentParentType=, etc.). 307 anywhere a query is involved or the
+          // slug differs — request-specific, should not be cached.
+          const permanent = !currentSlug && !queryString;
           return {
             redirect: {
               destination: `/models/${id}/${correctSlug}${queryString}`,

--- a/src/utils/query-string-helpers.ts
+++ b/src/utils/query-string-helpers.ts
@@ -1,4 +1,29 @@
+import type { ParsedUrlQuery } from 'querystring';
 import { isDefined } from '~/utils/type-guards';
+
+/**
+ * Serialize a Next.js `ctx.query` object into a `?...`-prefixed query string,
+ * skipping the named path params. Use for catch-all canonical-slug redirects
+ * (e.g. `[id]/[[...slug]]`) to preserve inbound deep-link params like
+ * `?highlight=`, `?commentParentType=`, etc. Returns an empty string when no
+ * params remain after exclusion, so it can be concatenated unconditionally.
+ */
+export function buildPassthroughQuery(
+  query: ParsedUrlQuery,
+  exclude: readonly string[] = ['id', 'slug']
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (exclude.includes(key)) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) params.append(key, v);
+    } else if (value != null) {
+      params.append(key, value);
+    }
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
 
 export function parseNumericString(value: unknown) {
   return typeof value === 'string'


### PR DESCRIPTION
## Summary

- Mod queue "Open reported item" for article comment reports landed at the top of the article with no scroll, no comment load, and no highlight. Three compounding causes: lazy comment mount with anchor inside the gate, cursor-paginated threads (target may be on page N), and the canonical-slug redirect stripping the inbound query string.
- The redirect-strip bug also affected the bounties, challenges, and models catch-all routes, so any deep link routed through `/comments/v2/<id>` (mod reports, owner notifications, future consumers) was at risk.
- Fix is a four-part change with a shared helper. Behavior shift to flag: deep-linked comments now render in single-thread focus mode (with `ReturnToRootThread` to restore full view), which is the mechanism that fixes the pagination gap.

## Changes

- `src/pages/articles/[id]/[[...slug]].tsx`
  - Move `id="comments"` anchor onto the wrapper div so the browser can resolve `#comments` at first paint.
  - Force-eager mount `ArticleDetailComments` when `router.query.highlight` is set or `window.location.hash === '#comments'`.
  - Preserve query params in the canonical-slug redirect via `buildPassthroughQuery`. Downgrade to 307 when a query is present to dodge the 308 path-only cache trap.
- `src/components/Article/Detail/ArticleDetailComments.tsx`
  - Drop the duplicate `id="comments"` from `<Title>` (the wrapper now owns the anchor; duplicate IDs violate the HTML spec).
- `src/pages/comments/v2/[id].tsx`
  - Always pin the reported comment as the thread root (`commentParentType=comment`, `commentParentId=<reportedCommentId>`). `RootThreadProvider` fetches it standalone via `getSingle` and renders it as `activeComment`, sidestepping cursor pagination. The existing `ReturnToRootThread` button restores the full discussion.
- `src/pages/bounties/[id]/[[...slug]].tsx`, `src/pages/challenges/[id]/[[...slug]].tsx`, `src/pages/models/[id]/[[...slug]].tsx`
  - Preserve query params in their canonical-slug redirects via the shared helper.
- `src/utils/query-string-helpers.ts`
  - Add `buildPassthroughQuery(ctx.query, exclude?)` — serializes `ctx.query` into a `?...`-prefixed string with path keys (`id`, `slug` by default) excluded.

## Test plan

- [x] Mod queue: open an article comment report whose comment is a **root-level** thread comment on page 2+ of a busy article. Reported comment renders standalone under "Viewing thread for", with highlight CSS and `Return to root thread` visible.
- [x] Mod queue: open an article comment report whose comment is a **nested reply**. Same behavior; sub-replies (if any) load below.
- [ ] Cross-entity smoke: open `/comments/v2/<id>` for a post comment and an image comment. Redirect lands on entity page, reported comment renders standalone.
- [x] Plain `#comments` deep link (no `highlight`): visit `/articles/<id>#comments`. Page scrolls to comments section on first paint; comments mount eagerly.
- [x] No-deep-link regression: visit `/articles/<id>` normally. Lazy gate still in effect; comments only mount when user scrolls near them.
- [x] Canonical-slug redirect: visit `/articles/<bare-id>?highlight=<commentId>` (or any catch-all route with extra query params). Redirect to slugified URL preserves all query params.
- [x] Cache hygiene: test in incognito or with "Disable cache" on. Browsers that cached prior 308s with no query may need a manual cache flush before the new redirect takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)