### PR TITLE
fix(new-order): chunk SADD + UNLINK to stop blocking Redis shard

### DIFF
--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -51,6 +51,7 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
     | 'hSet'
     | 'hmGet'
     | 'del'
+    | 'unlink'
     | 'exists'
     | 'expire'
     | 'expireAt'
@@ -140,6 +141,9 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
   ): Promise<T[]>;
   // Wrapped to avoid CROSSSLOT errors - deletes keys individually with Promise.all when array
   del(key: K | K[]): Promise<number>;
+  // Wrapped to avoid CROSSSLOT errors - unlinks keys individually with Promise.all when array.
+  // Prefer over del for large keys (sets/hashes) — UNLINK frees memory in a background thread.
+  unlink(key: K | K[]): Promise<number>;
   exists(key: K | K[]): Promise<number>;
   expire(key: K, seconds: number, mode?: 'NX' | 'XX' | 'GT' | 'LT'): Promise<boolean>;
   expireAt(key: K, timestamp: number | Date, mode?: 'NX' | 'XX' | 'GT' | 'LT'): Promise<boolean>;
@@ -580,6 +584,15 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
     if (!Array.isArray(key)) key = [key];
 
     const results = await Promise.all(key.map((k) => originalDel(k)));
+    return results.reduce((sum, count) => sum + count, 0);
+  };
+
+  // Wrap unlink to avoid CROSSSLOT errors - unlink keys individually when array
+  const originalUnlink = baseClient.unlink?.bind(baseClient);
+  client.unlink = async function (key: K | K[]): Promise<number> {
+    if (!Array.isArray(key)) key = [key];
+
+    const results = await Promise.all(key.map((k) => originalUnlink(k)));
     return results.reduce((sum, count) => sum + count, 0);
   };
 

--- a/src/server/services/games/new-order.service.ts
+++ b/src/server/services/games/new-order.service.ts
@@ -1447,7 +1447,16 @@ async function ensureRatedImagesCache({
   // Always populate the set with a sentinel '0' so EXISTS returns true on next call.
   // Real image IDs are always > 0, so the sentinel never interferes with SMISMEMBER checks.
   const members = imageIds.length > 0 ? ['0', ...imageIds.map(String)] : ['0'];
-  await redis.multi().sAdd(key, members).expire(key, CacheTTL.day).exec();
+
+  // Chunk the SADD so a heavy rater (>100K rated images) doesn't block the Redis shard
+  // for tens of ms. Each chunk is its own command (NOT inside MULTI/EXEC) so Redis can
+  // interleave other clients' commands between chunks. Sequential await keeps the burst
+  // small and predictable.
+  const CHUNK_SIZE = 1000;
+  for (let i = 0; i < members.length; i += CHUNK_SIZE) {
+    await redis.sAdd(key, members.slice(i, i + CHUNK_SIZE));
+  }
+  await redis.expire(key, CacheTTL.day);
 
   return key;
 }
@@ -1477,7 +1486,10 @@ export async function clearRatedImages(userId: number) {
   if (!redis) return;
 
   const key = `${REDIS_KEYS.NEW_ORDER.RATED}:${userId}` as const;
-  await redis.del(key);
+  // UNLINK is non-blocking: returns immediately, frees memory in a background thread.
+  // Daily-reset job fans this across all players via Promise.all; with DEL on
+  // 100K-element sets that stampedes the shard.
+  await redis.unlink(key);
 }
 
 export async function addImageToQueue({


### PR DESCRIPTION
## Summary
- `ensureRatedImagesCache` now chunks the bulk SADD (1000 args/chunk, sequential, no MULTI/EXEC) so heavy raters (up to 131K rated images) no longer block the Redis cluster shard for tens of ms on cache miss.
- `clearRatedImages` uses UNLINK instead of DEL — non-blocking, frees memory in a background thread. Fixes the daily-reset DEL stampede.
- Adds `unlink` to the typed Redis wrapper (mirrors how `del` is wired).

## Why
When a Redis shard is blocked, every other key hashed to it queues behind. We've been seeing **simultaneous P95 spikes across image:getAllImages:parallelFetch (7.8s), image:getAllImages:transform (5.7s), and trpc:middleware:applyUserPreferences (6.2s)** every time `games.newOrder.addRating` P95 spikes (18.3s at 22:31Z, 17.1s at 23:16Z on 2026-05-11). The slowlog on `next-redis-cluster-leader-1` showed back-to-back `SADD new-order:rated:<userId>` entries with 18K–131K arguments and `DEL` entries up to 72ms.

This is the chronic OPT-3 bottleneck originally identified 2026-03-09 — finally root-caused and fixed at the Redis-traffic-shape level rather than the spent-on-the-wire level.

## Test plan
- [ ] Local: existing tests around `ensureRatedImagesCache` / `clearRatedImages` still pass
- [ ] Staging: rate-an-image flow works end-to-end; queue refresh on a known heavy rater succeeds
- [ ] Post-deploy on prod:
  - [ ] `SLOWLOG GET` on `next-redis-cluster-leader-1` no longer shows `SADD new-order:rated:*` with >1000 args
  - [ ] `histogram_quantile(0.95, sum by (le) (rate(traces_spanmetrics_duration_milliseconds_bucket{span_name=~".*addRating.*"}[5m])))` stays under ~2s, no more 18s spikes
  - [ ] `image:getAllImages:parallelFetch` P95 stops co-spiking with addRating activity
  - [ ] Daily reset job runs without a Redis latency hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)