### PR TITLE
fix(profanity): preserve URLs and tag markup when censoring HTML

### DIFF
--- a/src/components/RenderHtml/RenderHtml.tsx
+++ b/src/components/RenderHtml/RenderHtml.tsx
@@ -27,21 +27,38 @@ export function RenderHtml({
     if (withProfanityFilter && blurNsfw) {
       const profanityFilter = createProfanityFilter();
 
-      // Use regex to find and preserve mentions while filtering everything else
+      // Preserve mentions, URL-bearing attributes (href/src), and all tag markup
+      // so the filter only operates on visible text content.
       const mentionRegex = /<span[^>]*data-type="mention"[^>]*>.*?<\/span>/gi;
-      const mentions: string[] = [];
-      let mentionIndex = 0;
+      const urlAttrRegex = /\b(?:href|src)="[^"]*"/gi;
+      const tagRegex = /<[^>]+>/g;
 
-      // Extract mentions and replace with placeholders
+      const mentions: string[] = [];
       processedHtml = processedHtml.replace(mentionRegex, (match) => {
         mentions.push(match);
-        return `__MENTION_PLACEHOLDER_${mentionIndex++}__`;
+        return `__MENTION_PLACEHOLDER_${mentions.length - 1}__`;
       });
 
-      // Apply profanity filtering to the text without mentions
+      const urlAttrs: string[] = [];
+      processedHtml = processedHtml.replace(urlAttrRegex, (match) => {
+        urlAttrs.push(match);
+        return `__URLATTR_PLACEHOLDER_${urlAttrs.length - 1}__`;
+      });
+
+      const tags: string[] = [];
+      processedHtml = processedHtml.replace(tagRegex, (match) => {
+        tags.push(match);
+        return `__TAG_PLACEHOLDER_${tags.length - 1}__`;
+      });
+
       processedHtml = profanityFilter.clean(processedHtml);
 
-      // Restore mentions
+      tags.forEach((tag, index) => {
+        processedHtml = processedHtml.replace(`__TAG_PLACEHOLDER_${index}__`, tag);
+      });
+      urlAttrs.forEach((attr, index) => {
+        processedHtml = processedHtml.replace(`__URLATTR_PLACEHOLDER_${index}__`, attr);
+      });
       mentions.forEach((mention, index) => {
         processedHtml = processedHtml.replace(`__MENTION_PLACEHOLDER_${index}__`, mention);
       });

--- a/src/components/RenderHtml/RenderHtml.tsx
+++ b/src/components/RenderHtml/RenderHtml.tsx
@@ -22,46 +22,45 @@ export function RenderHtml({
   const blurNsfw = useBrowsingSettings((state) => state.blurNsfw);
 
   html = useMemo(() => {
-    // Apply profanity filtering if enabled, but skip mentions
     let processedHtml = html;
     if (withProfanityFilter && blurNsfw) {
       const profanityFilter = createProfanityFilter();
 
-      // Preserve mentions, URL-bearing attributes (href/src), and all tag markup
-      // so the filter only operates on visible text content.
+      // Preserve mentions (entire span + content) and all HTML tag markup so
+      // the filter only operates on visible text content. Capturing entire
+      // tags also protects href/src attribute values, since the whole opening
+      // tag is one match. The per-render nonce prevents collisions with any
+      // user-typed text that happens to look like a placeholder.
+      const nonce = Math.random().toString(36).slice(2, 12);
+      const mentionToken = (i: number) => `__pf${nonce}M${i}__`;
+      const tagToken = (i: number) => `__pf${nonce}T${i}__`;
+
       const mentionRegex = /<span[^>]*data-type="mention"[^>]*>.*?<\/span>/gi;
-      const urlAttrRegex = /\b(?:href|src)="[^"]*"/gi;
       const tagRegex = /<[^>]+>/g;
 
       const mentions: string[] = [];
       processedHtml = processedHtml.replace(mentionRegex, (match) => {
         mentions.push(match);
-        return `__MENTION_PLACEHOLDER_${mentions.length - 1}__`;
-      });
-
-      const urlAttrs: string[] = [];
-      processedHtml = processedHtml.replace(urlAttrRegex, (match) => {
-        urlAttrs.push(match);
-        return `__URLATTR_PLACEHOLDER_${urlAttrs.length - 1}__`;
+        return mentionToken(mentions.length - 1);
       });
 
       const tags: string[] = [];
       processedHtml = processedHtml.replace(tagRegex, (match) => {
         tags.push(match);
-        return `__TAG_PLACEHOLDER_${tags.length - 1}__`;
+        return tagToken(tags.length - 1);
       });
 
       processedHtml = profanityFilter.clean(processedHtml);
 
-      tags.forEach((tag, index) => {
-        processedHtml = processedHtml.replace(`__TAG_PLACEHOLDER_${index}__`, tag);
-      });
-      urlAttrs.forEach((attr, index) => {
-        processedHtml = processedHtml.replace(`__URLATTR_PLACEHOLDER_${index}__`, attr);
-      });
-      mentions.forEach((mention, index) => {
-        processedHtml = processedHtml.replace(`__MENTION_PLACEHOLDER_${index}__`, mention);
-      });
+      // Single-pass O(n) restore per type via global regex callback.
+      processedHtml = processedHtml.replace(
+        new RegExp(`__pf${nonce}T(\\d+)__`, 'g'),
+        (_, index) => tags[Number(index)] ?? ''
+      );
+      processedHtml = processedHtml.replace(
+        new RegExp(`__pf${nonce}M(\\d+)__`, 'g'),
+        (_, index) => mentions[Number(index)] ?? ''
+      );
     }
 
     return sanitizeHtml(processedHtml, {


### PR DESCRIPTION
## Summary
- The SFW censor in `RenderHtml` was running the profanity filter directly over raw HTML, replacing matching substrings anywhere in the markup — including `href`/`src` attribute values. URLs that legitimately contained a filtered substring (the Japanese word "shitagaki" in the reported article) were corrupted, breaking the link.
- Extended the existing mention placeholder pattern to also extract `href`/`src` attribute values and all remaining tag markup before invoking the filter, then restore them in reverse order. Visible text content is still censored, so plain-text profanity (including slur-shaped URLs pasted as bare text) cannot bypass the filter.

Refs: ClickUp [868jk888d](https://app.clickup.com/t/868jk888d), Freshdesk #65595

## Behavior
| Input | Result |
|-------|--------|
| `<a href="https://x.com/shitagaki">link</a>` | href intact, "link" filtered if profane |
| `<a href="https://x.com/shitagaki">https://x.com/shitagaki</a>` | href intact, display text censored to `https://x.com/****agaki` but link still clickable |
| Plain text `https://fuck-you-bitch.com` | censored — no bypass |
| `<strong>shitagaki</strong>` | text censored (intended) |
| `<span data-type="mention">@user</span>` | preserved |

## Test plan
- [ ] Enable Blur NSFW in browsing settings.
- [ ] Open https://civitai.com/articles/29826 and verify the comment link containing "shitagaki" renders with an intact `href` and is clickable.
- [ ] Post a comment containing a `<strong>` or `<em>` block with a profane word — verify the text inside the tag is still censored.
- [ ] Paste a bare-text URL with a profane domain — verify the censor still applies (no bypass).
- [ ] Verify mentions (`@username`) still render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)