### PR TITLE
fix(filters): PG-13 toggle and moderator chips work across feeds

### DIFF
--- a/src/components/Image/AsPosts/ImagesAsPostsInfinite.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsInfinite.tsx
@@ -40,6 +40,8 @@ import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useDomainColor } from '~/hooks/useDomainColor';
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
 import type { ModelById } from '~/types/router';
 import { removeEmpty } from '~/utils/object-helpers';
@@ -91,7 +93,16 @@ export function ImagesAsPostsInfinite({
     [imageFilters, selectedVersionId, model.id, username, showHidden]
   );
 
-  const browsingLevel = useBrowsingLevelDebounced();
+  const rawBrowsingLevel = useBrowsingLevelDebounced();
+  const domainColor = useDomainColor();
+  // On the green (SFW) domain we default to PG only for model galleries.
+  // Users opt in to PG-13 via the feed filter; otherwise narrow the forced
+  // domain cap (sfwBrowsingLevelsFlag = PG | PG-13) down to PG. Mirrors the
+  // logic in ImagesInfinite.tsx so behavior is consistent across feeds.
+  const capToPublic = domainColor === 'green' && !filters.includePG13;
+  const browsingLevel = capToPublic
+    ? Flags.intersection(rawBrowsingLevel, publicBrowsingLevelsFlag)
+    : rawBrowsingLevel;
   const { gallerySettings } = useGallerySettings({ modelId: model.id });
   let intersection = browsingLevel;
   if (gallerySettings?.level) {

--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -58,7 +58,7 @@ export function MediaFiltersDropdown({
   // Anonymous users on green are hard-capped to PG by the domain rule, so the
   // toggle would be a no-op for them. Only logged-in users actually have
   // PG-13 access to opt in/out of.
-  const showPG13Toggle = isGreen && filterType !== 'modelImages' && !!currentUser;
+  const showPG13Toggle = isGreen && !!currentUser;
 
   const [opened, setOpened] = useState(false);
 
@@ -98,27 +98,31 @@ export function MediaFiltersDropdown({
     (showPG13Toggle && mergedFilters.includePG13 ? 1 : 0);
 
   const clearFilters = useCallback(() => {
+    // All values must be `undefined` so `removeEmpty` strips them from the URL
+    // (when onChange writes to query params) and from the Zustand store. Using
+    // `false` here would leave keys like `?withMeta=false` on the URL, and
+    // `period: AllTime` would leave `?period=AllTime`.
     const reset = {
       types: undefined,
-      withMeta: false,
-      requiringMeta: false,
-      hidden: false,
-      fromPlatform: false,
-      notPublished: false,
-      scheduled: false,
-      hideManualResources: false,
-      hideAutoResources: false,
-      tools: [],
-      techniques: [],
-      period: MetricTimeframe.AllTime,
-      baseModels: [],
-      remixesOnly: false,
-      nonRemixesOnly: false,
-      disablePoi: false,
-      disableMinor: false,
-      poiOnly: false,
-      minorOnly: false,
-      includePG13: false,
+      withMeta: undefined,
+      requiringMeta: undefined,
+      hidden: undefined,
+      fromPlatform: undefined,
+      notPublished: undefined,
+      scheduled: undefined,
+      hideManualResources: undefined,
+      hideAutoResources: undefined,
+      tools: undefined,
+      techniques: undefined,
+      period: undefined,
+      baseModels: undefined,
+      remixesOnly: undefined,
+      nonRemixesOnly: undefined,
+      disablePoi: undefined,
+      disableMinor: undefined,
+      poiOnly: undefined,
+      minorOnly: undefined,
+      includePG13: undefined,
     };
 
     if (onChange) onChange(reset);
@@ -280,13 +284,13 @@ export function MediaFiltersDropdown({
                 <span>Minor</span>
               </FilterChip>
               <FilterChip
-                checked={mergedFilters.poiOnly}
+                checked={mergedFilters.disablePoi}
                 onChange={(checked) => handleChange({ disablePoi: checked })}
               >
                 <span>Disable POI</span>
               </FilterChip>
               <FilterChip
-                checked={mergedFilters.minorOnly}
+                checked={mergedFilters.disableMinor}
                 onChange={(checked) => handleChange({ disableMinor: checked })}
               >
                 <span>Disable Minor</span>

--- a/src/components/Image/Infinite/ImagesInfinite.tsx
+++ b/src/components/Image/Infinite/ImagesInfinite.tsx
@@ -80,7 +80,10 @@ export function ImagesInfiniteContent({
   // On the green (SFW) domain we default to PG only on image/video feeds.
   // Users opt in to PG-13 via the feed filter; otherwise narrow the forced
   // domain cap (sfwBrowsingLevelsFlag = PG | PG-13) down to PG.
-  const capToPublic = domainColor === 'green' && !imageFilters.includePG13;
+  // Read from merged `filters` (not just the Zustand store) so callers that
+  // pass `filterOverrides` via URL params (Collection, UserMediaInfinite)
+  // still drive the cap correctly.
+  const capToPublic = domainColor === 'green' && !filters.includePG13;
   const browsingLevel = capToPublic
     ? Flags.intersection(rawBrowsingLevel, publicBrowsingLevelsFlag)
     : rawBrowsingLevel;

--- a/src/components/Image/Infinite/UserMediaInfinite.tsx
+++ b/src/components/Image/Infinite/UserMediaInfinite.tsx
@@ -122,6 +122,7 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                     tools,
                     techniques,
                     requiringMeta,
+                    notPublished,
                   }}
                   filterType={isVideo ? 'videos' : 'images'}
                   onChange={(filters) => replace(filters)}

--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -141,8 +141,12 @@ export const useQueryImages = (
     {
       ...filters,
       excludedTagIds,
-      disablePoi: browsingSettingsAddons.settings.disablePoi,
-      disableMinor: browsingSettingsAddons.settings.disableMinor,
+      // OR-merge with the addon so either source can flag the filter.
+      // Mods always have addon = false (BrowsingSettingsAddonsProvider), so
+      // the chip controls them. Non-mods don't see the chip; the addon
+      // value flows through untouched.
+      disablePoi: !!filters.disablePoi || browsingSettingsAddons.settings.disablePoi,
+      disableMinor: !!filters.disableMinor || browsingSettingsAddons.settings.disableMinor,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -88,6 +88,13 @@ export const imagesQueryParamSchema = z
     withMeta: booleanString().optional(),
     requiringMeta: booleanString(),
     remixOfId: numericString(),
+    includePG13: booleanString().optional(),
+    poiOnly: booleanString(),
+    minorOnly: booleanString(),
+    disablePoi: booleanString(),
+    disableMinor: booleanString(),
+    remixesOnly: booleanString(),
+    nonRemixesOnly: booleanString(),
   })
   .partial();
 


### PR DESCRIPTION
## Summary

Fixes a cluster of bugs in the media filter dropdown across image feeds (`/images`, `/videos`, `/tools/[slug]`, user profile media, collections, model galleries).

Reported via ClickUp [868jjpjh2](https://app.clickup.com/t/868jjpjh2) (".com filter modifier doesn't work") plus follow-up issues found while investigating.

### What was broken
- **Include PG-13** toggle was a no-op on the Collection page and the user profile media feed because the green-domain cap was read from the Zustand store while those routes write to URL params.
- **Include PG-13** wasn't even available on the model gallery (`modelImages`).
- The model gallery feed didn't cap browsing level to PG on green at all.
- **Disable POI** / **Disable Minor** chips mirrored the `poiOnly` / `minorOnly` state keys, so they looked checked/unchecked based on the wrong filter.
- **POI / Minor / Disable POI / Disable Minor / Remixes Only / Originals Only** chips no-opped entirely on UserMedia (and any other route writing via `onChange` → URL) because those keys were missing from `imagesQueryParamSchema`, so the schema-validated `replace()` stripped them before they hit the URL.
- **Not Published** chip required multiple clicks after the popover closed because the destructure in `UserMediaInfinite` pulled `notPublished` out of `query` before spreading into the dropdown's `query` prop, leaving the chip in Mantine's uncontrolled mode (`checked={undefined}` → internal state diverged from URL).
- **Clear filters** wrote `?hideAutoResources=false&hideManualResources=false&fromPlatform=false&hidden=false&notPublished=false&period=AllTime&scheduled=false&withMeta=false&requiringMeta=false` to the URL instead of stripping everything.

### What changed
- `ImagesInfinite` / `ImagesAsPostsInfinite` — read `includePG13` from the merged `filters` value so URL-driven routes drive the cap.
- `ImagesAsPostsInfinite` — same green-domain PG default + PG-13 opt-in as `ImagesInfinite`.
- `MediaFiltersDropdown` — show Include PG-13 on `modelImages`; fix Disable POI / Disable Minor `checked` props.
- `MediaFiltersDropdown.clearFilters` — reset all values to `undefined` so `removeEmpty` strips them from URL + store.
- `imagesQueryParamSchema` — add `includePG13`, `poiOnly`, `minorOnly`, `disablePoi`, `disableMinor`, `remixesOnly`, `nonRemixesOnly`.
- `UserMediaInfinite` — pass `notPublished` through to the dropdown's `query` prop.

## Test plan
- [x] Logged-in user on green at `/images`: Include PG-13 toggle off → only PG; on → PG + PG-13.
- [x] Same on `/videos`, `/tools/[slug]`, `/user/<name>/images`, `/user/<name>/videos`, `/collections/<id>`, `/models/<id>`.
- [x] Logged-in moderator on `/user/<name>/images`: POI, Minor, Disable POI, Disable Minor, Not Published, Scheduled, Remixes Only, Originals Only each toggle on the first click, persist in URL, and toggle off cleanly on the second click.
- [x] Disable POI / Disable Minor chips visually reflect their own state, not POI / Minor.
- [x] Clear filters button removes all related query string params (URL ends up clean of `withMeta`, `period`, `hidden`, `fromPlatform`, `scheduled`, `notPublished`, `hideAutoResources`, `hideManualResources`, `requiringMeta`, `includePG13`, `poiOnly`, `minorOnly`, `disablePoi`, `disableMinor`, `remixesOnly`, `nonRemixesOnly`).
- [x] Logged-out user on green: PG only everywhere; no PG-13 toggle visible.
- [x] Blue / red domains: no regressions (toggle hidden, no cap applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)