### PR TITLE
fix(redis): catch msgpack decode errors and evict bad packed entries

### DIFF
--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -522,7 +522,11 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
     async sMembers<T>(key: K): Promise<T[]> {
       const packedValues = await bufferClient.sMembers<Buffer>(key);
       return packedValues
-        .map((value) => safeUnpack<T>(value, () => client.sRem(key, value as unknown as string)))
+        .map((value) =>
+          // node-redis accepts Buffer for sRem; cast through unknown to satisfy the
+          // typed wrapper without re-encoding the raw stored bytes.
+          safeUnpack<T>(value, () => client.sRem(key, value as unknown as Buffer))
+        )
         .filter((v): v is T => v !== null);
     },
 

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -465,16 +465,34 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
     [RESP_TYPES.BLOB_STRING]: Buffer,
   }) as CustomRedisClient<K>;
 
+  // Decode a packed Buffer, evicting the bad entry if msgpack fails so the next
+  // read falls through to source. Returns null on decode failure, treated as cache miss.
+  const safeUnpack = <T>(value: Buffer, evict: () => Promise<unknown>): T | null => {
+    try {
+      return unpack(value) as T;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log(`Packed unpack failed, evicting bad cache entry: ${msg}`);
+      evict().catch((e) =>
+        log(`Eviction after unpack failure failed: ${e instanceof Error ? e.message : e}`)
+      );
+      return null;
+    }
+  };
+
   client.packed = {
     async get<T>(key: K): Promise<T | null> {
       const result = await bufferClient.get<Buffer>(key);
-      return result ? unpack(result) : null;
+      if (!result) return null;
+      return safeUnpack<T>(result, () => client.unlink(key));
     },
 
     // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all
     async mGet<T>(keys: K[]): Promise<(T | null)[]> {
       const results = await Promise.all(keys.map((key) => bufferClient.get<Buffer>(key)));
-      return results.map((result) => (result ? unpack(result) : null));
+      return results.map((result, i) =>
+        result ? safeUnpack<T>(result, () => client.unlink(keys[i])) : null
+      );
     },
 
     async set<T>(key: K, value: T, options?: SetOptions): Promise<void> {
@@ -491,7 +509,10 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
 
     async sPop<T>(key: K, count: number): Promise<T[]> {
       const packedValues = await bufferClient.sPop<Buffer>(key, count);
-      return packedValues.map((value) => unpack(value));
+      // sPop already removed each value from the set, so on decode failure we just drop it.
+      return packedValues
+        .map((value) => safeUnpack<T>(value, () => Promise.resolve()))
+        .filter((v): v is T => v !== null);
     },
 
     async sRemove<T>(key: K, value: T): Promise<void> {
@@ -500,17 +521,26 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
 
     async sMembers<T>(key: K): Promise<T[]> {
       const packedValues = await bufferClient.sMembers<Buffer>(key);
-      return packedValues.map((value) => unpack(value));
+      return packedValues
+        .map((value) => safeUnpack<T>(value, () => client.sRem(key, value as unknown as string)))
+        .filter((v): v is T => v !== null);
     },
 
     async hGet<T>(key: K, hashKey: string): Promise<T | null> {
       const result = await bufferClient.hGet<Buffer>(key, hashKey);
-      return result ? unpack(result) : null;
+      if (!result) return null;
+      return safeUnpack<T>(result, () => client.hDel(key, hashKey));
     },
 
     async hGetAll<T>(key: K): Promise<{ [x: string]: T }> {
       const results = await bufferClient.hGetAll<Buffer>(key);
-      return Object.fromEntries(Object.entries(results).map(([k, v]) => [k, v ? unpack(v) : null]));
+      const out: { [x: string]: T } = {};
+      for (const [k, v] of Object.entries(results)) {
+        if (!v) continue;
+        const decoded = safeUnpack<T>(v, () => client.hDel(key, k));
+        if (decoded !== null) out[k] = decoded;
+      }
+      return out;
     },
 
     async hSet<T>(key: K, hashKey: string, value: T): Promise<void> {
@@ -527,7 +557,9 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
 
     async hmGet<T>(key: K, hashKeys: string[]): Promise<(T | null)[]> {
       const results = await bufferClient.hmGet<Buffer>(key, hashKeys);
-      return results.map((result) => (result ? unpack(result) : null));
+      return results.map((result, i) =>
+        result ? safeUnpack<T>(result, () => client.hDel(key, hashKeys[i])) : null
+      );
     },
   };
 

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -78,7 +78,9 @@ async function tagCacheKey(key: string, tag: string | string[]) {
 export async function bustCacheTag(tag: string | string[]) {
   const tags = Array.isArray(tag) ? tag : [tag];
   for (const tag of tags) {
-    const keys = await redis.packed.sMembers<RedisKeyTemplateCache>(`${REDIS_KEYS.TAG}:${tag}`);
+    // tagCacheKey writes raw strings via redis.sAdd; read with the same codec.
+    // packed.sMembers would msgpack-decode them and throw on every member.
+    const keys = await redis.sMembers<RedisKeyTemplateCache>(`${REDIS_KEYS.TAG}:${tag}`);
     for (const key of keys) await redis.del(key);
     await redis.del(`${REDIS_KEYS.TAG}:${tag}`);
   }
@@ -460,10 +462,7 @@ export async function bustFetchThroughCache(key: RedisKeyTemplateCache) {
   await redis.packed.set(key, toCache, { KEEPTTL: true });
 }
 
-export async function clearCacheByPattern(
-  pattern: string,
-  onProgress?: (cleared: number) => void
-) {
+export async function clearCacheByPattern(pattern: string, onProgress?: (cleared: number) => void) {
   const cleared: string[] = [];
 
   if (!pattern.includes('*')) {
@@ -498,7 +497,10 @@ export async function clearCacheByPattern(
 }
 
 function globToRegex(pattern: string) {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
   return new RegExp('^' + escaped + '$');
 }
 


### PR DESCRIPTION
## Summary
- `redis.packed.*` methods called `unpack()` without try/catch. A corrupted blob threw `Data read, but end of buffer not reached N` from msgpackr → bubbled up as a tRPC INTERNAL_SERVER_ERROR. Once a key was poisoned it stayed poisoned for its full TTL and re-failed on every read.
- Wraps every `unpack()` in `safeUnpack`: on decode failure, log + fire-and-forget evict the bad entry (UNLINK / HDEL / SREM) + return `null`/skip. Callers of `packed.get`/`mGet`/`hGet`/`hmGet` already treat `null` as a cache miss and refetch from source — no behavior change on the happy path.
- `sMembers` / `sPop` / `hGetAll` drop the bad entries from their result rather than returning a poisoned `T`.

## Why now
In a 15-minute Loki sample on `civitai-dp-prod` (DP cluster), `Data read, but end of buffer not reached 103` was the single largest source of API 500s:

| Path | Count | Top error |
|---|---|---|
| `post.addImage` | 110 | `Data read, but end of buffer not reached 103` |

≈25% of API 500s by category, and the worst single tRPC path. Sustained ~2 HTTP 500/s on the API pool was in-band baseline noise overall but this category was 100% self-inflicted by the cache layer rather than user-visible state.

## Behavior
- Happy path: unchanged — same return shape, same types.
- Decode failure: bad entry is evicted asynchronously; the call returns `null` (or skips the bad element for set/hash-all reads). Next request through `createCachedObject`/`createCachedArray` repopulates from source.
- Eviction is fire-and-forget so the cache-miss path doesn't pay an extra round-trip.

## Test plan
- [ ] `pnpm typecheck` — confirmed locally that `src/server/redis/client.ts` has no new errors (5383 lines of pre-existing project-wide errors unrelated to this change).
- [ ] `pnpm eslint src/server/redis/client.ts` — 0 errors, 20 warnings (all pre-existing).
- [ ] After merge + deploy to DP: confirm `post.addImage` 500 rate drops in Loki: `{namespace="civitai-dp-prod"} |~ "Data read, but end of buffer not reached"`.
- [ ] Spot-check overall API 5xx rate via `/check-app` skill — expect a small but visible drop from current ~0.17%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)