### PR TITLE
fix(comments): remove leftover fingerprint tracking from retool TOS path

### DIFF
--- a/src/pages/api/mod/retool/comment.ts
+++ b/src/pages/api/mod/retool/comment.ts
@@ -71,8 +71,7 @@ export default defineRetoolEndpoint('comment', {
     async handler(input, ctx) {
       ensureAtLeastOneList(input);
       const ip = requestIp.getClientIp(ctx.req) ?? undefined;
-      const fingerprint = (ctx.req.headers['x-fingerprint'] as string | undefined) ?? undefined;
-      const actor = { id: ctx.actor.id, ip, fingerprint };
+      const actor = { id: ctx.actor.id, ip };
 
       const v1 = input.commentIds?.length
         ? await bulkSetCommentTosViolation({ ids: input.commentIds, actor })

--- a/src/server/services/comment.service.ts
+++ b/src/server/services/comment.service.ts
@@ -241,7 +241,7 @@ export async function bulkSetCommentTosViolation({
   actor,
 }: {
   ids: number[];
-  actor: { id: number; ip?: string; fingerprint?: string };
+  actor: { id: number; ip?: string };
 }) {
   if (ids.length === 0) return { count: 0, notified: 0, rewardedReports: 0 };
 
@@ -267,7 +267,7 @@ export async function bulkSetCommentTosViolation({
       reports.map((report) =>
         reportAcceptedReward.apply(
           { userId: report.userId, reportId: report.id },
-          { ip: actor.ip, fingerprint: actor.fingerprint as never }
+          { ip: actor.ip }
         )
       )
     );

--- a/src/server/services/commentsv2.service.ts
+++ b/src/server/services/commentsv2.service.ts
@@ -125,7 +125,7 @@ export async function bulkSetCommentV2TosViolation({
   actor,
 }: {
   ids: number[];
-  actor: { id: number; ip?: string; fingerprint?: string };
+  actor: { id: number; ip?: string };
 }) {
   if (ids.length === 0) return { count: 0, notified: 0, rewardedReports: 0 };
 
@@ -163,7 +163,7 @@ export async function bulkSetCommentV2TosViolation({
       reports.map((report) =>
         reportAcceptedReward.apply(
           { userId: report.userId, reportId: report.id },
-          { ip: actor.ip, fingerprint: actor.fingerprint as never }
+          { ip: actor.ip }
         )
       )
     );


### PR DESCRIPTION
## Summary
PR #2258 (`chore/remove-device-fingerprint-tracking`) removed the `fingerprint` field from `reportAcceptedReward.apply`'s tracking arg and from device-fingerprint tracking everywhere else, but missed three call sites in the retool comment-TOS path:

- `src/server/services/comment.service.ts` — `bulkSetCommentTosViolation` actor type + call site
- `src/server/services/commentsv2.service.ts` — `bulkSetCommentV2TosViolation` actor type + call site
- `src/pages/api/mod/retool/comment.ts` — `removeAsTos` handler reading the `x-fingerprint` header and passing it through `actor`

The result is two TS2353 errors firing on every PR's Type Check job against `main`:

\`\`\`
src/server/services/comment.service.ts(270,27): error TS2353: Object literal may only specify known properties, and 'fingerprint' does not exist in type '{ ip?: string | undefined; }'.
src/server/services/commentsv2.service.ts(166,27): error TS2353: Object literal may only specify known properties, and 'fingerprint' does not exist in type '{ ip?: string | undefined; }'.
\`\`\`

The `as never` cast on `actor.fingerprint` was a workaround that TS still rejects because of object-literal excess property checking.

## Behavior
Unchanged. `reportAcceptedReward.apply` already ignored the field (its signature is `{ ip?: string }`), and the rest of the tracking pipeline has no fingerprint consumer.

## Test plan
- [ ] CI Type Check passes (the two TS2353 errors should disappear).
- [ ] No behavior change at runtime — retool moderator TOS removal still works identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)