### PR TITLE
ops: throttle models search-index cron 2m → 5m

### DIFF
--- a/src/server/jobs/search-index-sync.ts
+++ b/src/server/jobs/search-index-sync.ts
@@ -18,7 +18,7 @@ const searchIndexSets = {
 type SearchIndexSetKey = keyof typeof searchIndexSets;
 
 const cronTimeMap: Record<SearchIndexSetKey, string> = {
-  models: '*/2 * * * *',
+  models: '*/5 * * * *',
   users: '*/10 * * * *',
   articles: '*/5 * * * *',
   images: '5 */1 * * *',


### PR DESCRIPTION
## Summary
- Slow `search-index-sync-models` cron from `*/2 * * * *` to `*/5 * * * *` to relieve sustained disk-write pressure on the `meilisearch-0` instance (DataPacket node `talos-uvh-ow7`).
- Each cron tick produces one Meilisearch commit per index; lower cadence batches more queue entries per commit, cutting disk flushes proportionally without changing what gets indexed.

## Why
Cluster investigation today found `meilisearch-0` writing 200+ MB/s sustained to a single NVMe also hosting Talos `/var`, with write latency 1.1–2.3s (vs <1ms baseline). Cascading 408s on meilisearch and 502/504s on co-tenant `civitai-advertising-primary` pods. The dominant writer was `models_v9`, fed by this cron + ~30 producer call sites that enqueue to a Redis SET-backed queue (already de-duplicated per cycle in `src/server/redis/queues.ts`). Halving the cron rate is the cheapest, most reversible producer-side relief.

Full handoff doc: `claudedocs/meilisearch-node-saturation-handoff.md` in the talos-infra repo.

## Trade-off
Model search results stale ≤5 min instead of ≤2 min. Other indexes (users, articles, images, collections, bounties, imageMetrics, comics) unchanged.

## Test plan
- [ ] After deploy, verify `talos-uvh-ow7` `nvme0n1` write latency drops below 100ms sustained (Prometheus: `rate(node_disk_write_time_seconds_total{instance="192.168.10.3:9100",device="nvme0n1"}[5m]) / rate(node_disk_writes_completed_total{...}[5m]) * 1000`)
- [ ] `civitai-advertising-primary` 502/504 rate in Traefik returns to baseline (~0/s)
- [ ] Model search continues to surface newly-published / freshly-edited models within ~5 min (manual spot-check)
- [ ] No spike in Meilisearch task queue depth (`kubectl exec -n meilisearch meilisearch-0 -c meilisearch -- curl -s localhost:7700/tasks?statuses=enqueued`) — should be flat-to-lower, not climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)