### PR TITLE
fix(perf): stop sharing QueryClient across SSR requests

### DIFF
--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -1,5 +1,5 @@
 // src/utils/trpc.ts
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query';
 import type { CreateTRPCProxyClient, TRPCLink } from '@trpc/client';
 import { createTRPCProxyClient, httpLink, loggerLink } from '@trpc/client';
 import type { CreateTRPCNext } from '@trpc/next';
@@ -65,13 +65,57 @@ const headers: RequestHeaders = {
   'x-client': 'web',
 };
 
-export const queryClient = new QueryClient({
+/**
+ * Shared QueryClient config. Used by both the per-request server `QueryClient`
+ * (created by `@trpc/next` via `queryClientConfig` below) and the singleton
+ * browser `QueryClient` returned by `getQueryClient()` for callsites that
+ * import `queryClient` directly.
+ */
+const queryClientConfig: QueryClientConfig = {
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
       retry: 1,
       staleTime: Infinity,
     },
+  },
+};
+
+/**
+ * Browser-only QueryClient singleton.
+ *
+ * IMPORTANT: never construct this at module scope. Doing so on the server
+ * means every SSR request shares one `QueryCache`, which only ever grows.
+ * A heap snapshot from civitai-dp-prod on 2026-05-14 found 11,962 retained
+ * `Query` objects on a single pod traceable to a module-scope `QueryClient`.
+ *
+ * Callsites that import { queryClient } from this module run only in the
+ * browser (mutation `onSuccess` callbacks, event handlers, `useEffect`).
+ * Touching this on the server will throw to prevent the leak from coming back.
+ */
+let browserQueryClient: QueryClient | undefined;
+function getBrowserQueryClient(): QueryClient {
+  if (typeof window === 'undefined') {
+    throw new Error(
+      '[trpc] queryClient was accessed on the server. Use `useQueryClient()` ' +
+        'inside a component, or pass `queryClientConfig` to tRPC so a fresh ' +
+        'QueryClient is created per request.'
+    );
+  }
+  if (!browserQueryClient) browserQueryClient = new QueryClient(queryClientConfig);
+  return browserQueryClient;
+}
+
+/**
+ * Proxy preserves the existing `import { queryClient } from '~/utils/trpc'`
+ * call sites without forcing them to call a function. Property access is
+ * lazy, so the singleton is only created when first touched in the browser.
+ */
+export const queryClient: QueryClient = new Proxy({} as QueryClient, {
+  get(_target, prop, receiver) {
+    const client = getBrowserQueryClient();
+    const value = Reflect.get(client, prop, receiver);
+    return typeof value === 'function' ? value.bind(client) : value;
   },
 });
 
@@ -118,7 +162,16 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext, null> = createTRPC
     const isClient = typeof window !== 'undefined';
 
     return {
-      queryClient,
+      // On the browser, reuse the same singleton `QueryClient` that direct
+      // `import { queryClient }` callsites read/write — otherwise their
+      // `setQueriesData`/`cancelQueries` would target a different cache than
+      // the one `useQuery` hooks subscribe to.
+      //
+      // On the server, omit `queryClient` so `@trpc/next` falls through to
+      // `new QueryClient(config.queryClientConfig)` per request — the prior
+      // module-scope singleton accumulated 11,962 `Query` objects per pod
+      // (heap snapshot, civitai-dp-prod, 2026-05-14).
+      ...(isClient ? { queryClient: getBrowserQueryClient() } : { queryClientConfig }),
       transformer: superjson,
       links: [
         authedCacheBypassLink,


### PR DESCRIPTION
## Summary

`src/utils/trpc.ts` constructed a `new QueryClient()` at module scope and passed it to `createTRPCNext({ config: () => ({ queryClient, ... }) })`. On the server, `@trpc/next`'s `getQueryClient` returns the configured client as-is (`cfg.queryClient ?? new QueryClient(cfg.queryClientConfig)`), so every SSR request shared one `QueryCache` that only ever grew. This is the textbook \"module-scope QueryClient on the server\" leak.

## Evidence

V8 heap snapshot from a `civitai-dp-prod` pod (`dfq5d`, the *least*-pressured primary at 831 MiB heap_used) on **2026-05-14**:

- **2** `QueryClient` instances retained
- **2** `QueryCache` instances
- **11,962** `Query` objects in the shared cache
- **7,111** `queryFn` closures
- Retainer chain bottomed out at the `queryClient` named export of `src/utils/trpc.ts` (chunk 97592.js → ModuleWrap)

Most primary pods sit at **3.5–4.0 GiB heap_used** out of a 4096 MB `--max-old-space-size`, doing **0.8 major GCs/min** with peak GC time at **8.4% wall**. This leak is the root of that pressure.

## Fix

`src/utils/trpc.ts`:

1. Replace the module-scope `new QueryClient(...)` with a `queryClientConfig` constant.
2. **Server path** — pass `queryClientConfig` (not `queryClient`) to `createTRPCNext`. `@trpc/next` then falls through to `new QueryClient(config.queryClientConfig)` per request inside `WithTRPC`'s `useState` initializer (which fires once per server-side render).
3. **Browser path** — keep a single `QueryClient` instance, lazy-created on first access, and pass that *same* instance to `createTRPCNext` so the 18 callsites that `import { queryClient }` for `setQueriesData` / `cancelQueries` / `getQueriesData` continue to read/write the same cache the React tree's `useQuery` hooks subscribe to.
4. The exported `queryClient` is now a `Proxy` that throws if touched on the server, so this leak can't silently come back.

Mirrors the official TanStack Query / `@trpc/next` SSR pattern: per-request server clients, singleton browser client.

## Test plan

- [x] `tsc --noEmit` produces zero new errors in `src/utils/trpc.ts` (pre-existing errors in unrelated files are unchanged)
- [x] ESLint clean on `src/utils/trpc.ts` (only the two pre-existing `any` warnings remain)
- [ ] Smoke test in canary: load any tRPC-backed page, verify queries hydrate and mutations still update the in-memory cache
- [ ] Watch `nodejs_heap_size_used_bytes` on canary pods — expect a sharp drop in baseline heap and lower major GC frequency
- [ ] Re-snapshot heap after ≈30 min canary traffic and confirm `QueryClient` count returns to 1 (the browser-side singleton no longer applies on server) and `Query` retention scales with in-flight requests, not lifetime

## Notes for review

- `ssr: false` on `createTRPCNext` does **not** prevent this leak. With `ssr: false`, the trpc-next *prepass* is skipped, but `WithTRPC` still mounts on the server during `renderToString` and its `useState(() => getQueryClient(config))` initializer runs per request, returning the shared singleton.
- No callsite changes needed — the `queryClient` named export keeps the same identity *on the client*. The Proxy is transparent for normal property/method access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)