### PR TITLE
fix(perf): abort training epoch upstream fetch on client disconnect

### DIFF
--- a/src/pages/api/download/training/[modelVersionId].ts
+++ b/src/pages/api/download/training/[modelVersionId].ts
@@ -83,14 +83,30 @@ export default AuthedEndpoint(
       return res.status(404).json({ error: 'Epoch download URL not available' });
     }
 
+    // Abort the upstream fetch + stream when the client disconnects.
+    // Without this, a client hang or Traefik timeout leaves the pod streaming
+    // into a dead socket for minutes, holding an event-loop slot.
+    const abortController = new AbortController();
+    const onClientClose = () => abortController.abort();
+    req.on('close', onClientClose);
+
     // Fetch from orchestrator using server-side token (bypasses CORS)
-    const orchestratorResponse = await fetch(epochUrl, {
-      headers: {
-        Authorization: `Bearer ${env.ORCHESTRATOR_ACCESS_TOKEN}`,
-      },
-    });
+    let orchestratorResponse: Response;
+    try {
+      orchestratorResponse = await fetch(epochUrl, {
+        headers: {
+          Authorization: `Bearer ${env.ORCHESTRATOR_ACCESS_TOKEN}`,
+        },
+        signal: abortController.signal,
+      });
+    } catch (err) {
+      req.off('close', onClientClose);
+      if (abortController.signal.aborted) return res.end();
+      throw err;
+    }
 
     if (!orchestratorResponse.ok) {
+      req.off('close', onClientClose);
       return res
         .status(orchestratorResponse.status)
         .json({ error: 'Failed to fetch epoch from storage' });
@@ -110,17 +126,31 @@ export default AuthedEndpoint(
 
     const body = orchestratorResponse.body;
     if (!body) {
+      req.off('close', onClientClose);
       return res.status(500).json({ error: 'No response body from storage' });
     }
 
-    // Convert Web ReadableStream to Node.js Readable and pipe to response
+    // Convert Web ReadableStream to Node.js Readable and pipe to response.
+    // Destroy the stream on client disconnect so we stop reading from the orchestrator.
     const nodeStream = Readable.fromWeb(body as NodeReadableStream);
-    await new Promise<void>((resolve, reject) => {
-      nodeStream.pipe(res);
-      nodeStream.on('error', reject);
-      res.on('finish', resolve);
-      res.on('error', reject);
-    });
+    const onClientCloseStream = () => nodeStream.destroy();
+    req.on('close', onClientCloseStream);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        nodeStream.pipe(res);
+        nodeStream.on('error', (err) => {
+          // Aborted by client disconnect — not an error condition for us.
+          if (abortController.signal.aborted) return resolve();
+          reject(err);
+        });
+        res.on('finish', resolve);
+        res.on('error', reject);
+      });
+    } finally {
+      req.off('close', onClientClose);
+      req.off('close', onClientCloseStream);
+    }
   },
   ['GET']
 );


### PR DESCRIPTION
## Summary

- `/api/download/training/[modelVersionId]` proxies multi-GB `.safetensors` epoch files from the orchestrator. Without an `AbortController`, when Traefik times out the client at 30s (or the client just closes the tab), the pod-side `fetch` + `pipe` keeps reading from the orchestrator and writing into a dead socket for minutes — holding an event-loop slot the entire time.
- This PR wires `req` `"close"` events into an `AbortController` so client disconnect cleanly tears down both the upstream fetch and the response pipe.
- It does **not** fix the underlying design (proxying instead of redirecting to a pre-signed URL — that requires orchestrator-side changes); it stops the long tail of pod-slot saturation while that's pursued.

## Evidence

From a `/profile-dp` run on `civitai-dp-prod` (1h window, 2026-05-14):

- `GET /api/download/training/{id}` is the **#1 endpoint by P95 latency** at exactly 30,000ms — the Traefik backend response timeout.
- Top 10 slowest individual Tempo traces are **all** this endpoint, ranging 120s–578s wall-clock with **100% self-time and no child spans** (no Prisma/Redis spans → time spent in unstrumented streaming I/O).
- API service Traefik 5xx rate ~1.5/s and P99 ~2.3s — partly attributable to this endpoint's slot pressure under load.

## Changes

- Add `AbortController` and pass `signal` to the orchestrator `fetch`.
- Listen on `req` `"close"` to abort the controller and `nodeStream.destroy()`.
- Detach listeners in a `finally` block.
- Treat `AbortError` on the stream as `resolve()` rather than `reject()` — it's the expected outcome of a user navigating away, not a 500.

## Test plan

- [ ] Lint / type-check passes locally
- [ ] Trigger a training epoch download in dev, cancel client mid-stream, verify pod logs show clean teardown (no `socket hang up` retries on the upstream)
- [ ] Deploy to DP, re-run `/profile-dp`, confirm:
  - `/api/download/training/{id}` no longer appears in top 10 slowest Tempo traces with 100s+ self-times
  - P95 still ~30s for legitimate slow downloads (expected — this PR doesn't speed them up, just cleans them up)
  - API service 5xx rate decreases

## Follow-up (not in this PR)

- Pursue orchestrator-side pre-signed URL minting + `res.redirect(307, presignedUrl)` so the download bypasses the API pod entirely. That's the durable fix; this PR is the bleeding-stopper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)