### PR TITLE
api/health: split liveness from readiness; fix redis cluster ping

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -96,22 +96,14 @@ const checkFns: Record<string, CancellableCheckFn> = {
     });
   },
 
-  // Redis checks - use simple ping (redis v5 doesn't support AbortSignal via commandOptions)
+  // Redis cluster client: skip explicit PING because redis@5 cluster client
+  // throws `Cannot read properties of undefined (reading 'connectPromise')`
+  // when a master is transiently re-establishing, even with isReady=true.
+  // isReady tracks topology + per-master connection state; it flips to
+  // false on real failures.
   async redis(signal: AbortSignal) {
     if (signal.aborted) return false;
-    try {
-      // For cluster, we need to check if it's ready first
-      const baseClient = redis as any;
-      if (baseClient.isReady === false) {
-        return false;
-      }
-      const res = await (redis as any).ping();
-      return res === 'PONG';
-    } catch (e) {
-      if (signal.aborted || (e as Error).name === 'AbortError') return false;
-      logError({ error: e as Error, name: 'redis', details: null });
-      return false;
-    }
+    return (redis as any).isReady === true;
   },
 
   async sysRedis(signal: AbortSignal) {

--- a/src/pages/api/live.ts
+++ b/src/pages/api/live.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getRandomInt } from '~/utils/number-helpers';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+// Liveness probe. Returns 200 if the Node.js process is alive and
+// the event loop is responsive. Intentionally has no dependency
+// calls (DB, Redis, ClickHouse, MeiliSearch) so a slow upstream
+// can't trigger kubelet to restart pods. Use /api/health for the
+// deep readiness check.
+export default WebhookEndpoint(async (_req: NextApiRequest, res: NextApiResponse) => {
+  return res.status(200).json({
+    podname: process.env.PODNAME ?? getRandomInt(100, 999),
+    version: process.env.version,
+    alive: true,
+  });
+});


### PR DESCRIPTION
## Summary

Two related fixes for civitai-web pod restart churn observed today on the DataPacket cluster (~85-230 restarts per pod over 2d on civitai-next, plus ~3500 redis-ping errors per 10m in Loki).

### 1. Add `/api/live` as a trivial liveness probe

`/api/live` returns 200 OK with podname/version and no dependency calls. `/api/health` continues to do the full deep check for readiness.

**Why**: Tempo traces showed `/api/health` floored at exactly **1500ms** on slow requests — every instrumented dep finished in ~10ms, then a ~1490ms idle gap, then completion. That floor is the `HEALTHCHECK_TIMEOUT` (1500ms default) hitting via `Promise.race` in `runCheckWithTimeout`.

Per-check failure rate over 15m on civitai-dp-prod (Prometheus):

| Check | Failures (15m) |
|---|---|
| **searchmetrics** | **1320** |
| redis | 2 |
| clickhouse, sysredis, pgread, pgwrite, read, write | 0 |

So the `metricsSearchClient.isHealthy()` call to MeiliSearch was hanging until the 1500ms ceiling → returning false → overall `healthy=false` → **HTTP 500**. Kubelet's `livenessProbe` counted those 500s as failures and killed pods. Restarting Node didn't fix MeiliSearch saturation, so the kills were pure churn.

Decoupling liveness from upstream health is the standard k8s pattern. Readiness checks (`/api/health`) keep doing the deep check so pods are removed from service when deps are broken — but kubelet won't restart them.

K8s manifests in `datapacket-talos` will be updated separately to switch `livenessProbe.httpGet.path` from `/api/health` to `/api/live` once this PR ships.

### 2. Remove explicit PING from the redis cluster check

`redis@5`'s cluster client throws \`Cannot read properties of undefined (reading 'connectPromise')\` when a master is transiently re-establishing, even with `isReady === true`. We were logging this ~6 times/sec across the fleet (~3500 errors per 10m in Loki).

`isReady` already tracks topology + per-master connection state and flips to `false` on real failures, so use it directly. Stops the log spam and the spurious health failures.

## Immediate stopgap already in place

As a bridge before this PR ships, the sysRedis key `system:features.non-critical-healthchecks` was set to `["searchMetrics"]`, which moves the MeiliSearch check to non-critical (still runs and reports per-check metric, but doesn't fail the overall response). The `civitai_app_healthcheck_overall` failure rate dropped from 1.1/s to 0.0/s within 2 minutes of the change.

That stopgap can be reverted after this PR + the k8s probe swap deploy.

## Test plan
- [ ] CI build passes
- [ ] Deploy through normal Flagger canary; verify `/api/live` returns 200 with token, 401 without
- [ ] Verify `/api/health` deep-check behavior unchanged
- [ ] Confirm `health-check:redis` log volume drops to ~0 after deploy (currently ~6/s)
- [ ] After k8s manifest swap (separate PR in datapacket-talos), verify `civitai_app_healthcheck_overall` no longer drives pod restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)