### PR TITLE
fix(prompt-audit): restore counter accumulation after sysRedis wipe

### DIFF
--- a/src/pages/api/admin/clear-cache-by-pattern.ts
+++ b/src/pages/api/admin/clear-cache-by-pattern.ts
@@ -8,10 +8,13 @@ const schema = z.object({
   pattern: z.string().optional(),
   patterns: z.string().optional(),
   stream: z.string().optional(),
+  // Which Redis instance to target. Defaults to the main cache cluster.
+  target: z.enum(['main', 'sys']).optional(),
 });
 
 export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
   const parsed = schema.parse(req.query);
+  const target = parsed.target ?? 'main';
   const patterns = parsed.patterns
     ? parsed.patterns
         .split(',')
@@ -39,11 +42,15 @@ export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApi
       res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
     };
 
-    send('start', { patterns });
+    send('start', { patterns, target });
     const heartbeat = setInterval(() => res.write(': heartbeat\n\n'), 15000);
 
     try {
-      const results = await clearCacheByPatterns(patterns, (progress) => send('progress', progress));
+      const results = await clearCacheByPatterns(
+        patterns,
+        (progress) => send('progress', progress),
+        target
+      );
       const total = results.reduce((s, r) => s + r.cleared, 0);
       send('done', { total, perPattern: results });
     } catch (e) {
@@ -56,11 +63,11 @@ export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApi
   }
 
   if (patterns.length === 1) {
-    const cleared = await clearCacheByPattern(patterns[0]);
-    return res.status(200).json({ ok: true, cleared: cleared.length });
+    const cleared = await clearCacheByPattern(patterns[0], undefined, target);
+    return res.status(200).json({ ok: true, cleared: cleared.length, target });
   }
 
-  const results = await clearCacheByPatterns(patterns);
+  const results = await clearCacheByPatterns(patterns, undefined, target);
   const total = results.reduce((s, r) => s + r.cleared, 0);
-  return res.status(200).json({ ok: true, cleared: total, perPattern: results });
+  return res.status(200).json({ ok: true, cleared: total, target, perPattern: results });
 });

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -32,14 +32,21 @@ export interface BlockedPromptEntry {
   time: string;
 }
 
-const BLOCKED_PROMPTS_TTL = 60 * 60 * 24; // 24 hours — ClickHouse seed is a cold-start fallback only
+// Window over which we count blocked-prompt attempts toward the auto-mute threshold.
+// Doubles as the Redis TTL and as the ClickHouse seed window so that a cold start
+// (key missing / sysRedis wipe) rebuilds the counter with the same horizon it would
+// have had in steady state. Keeping these in lockstep prevents the previous behavior
+// where many users effectively accumulated forever in Redis but only recovered the
+// last 24h after a wipe.
+const BLOCKED_PROMPTS_WINDOW_DAYS = 30;
+const BLOCKED_PROMPTS_TTL = 60 * 60 * 24 * BLOCKED_PROMPTS_WINDOW_DAYS;
 const RESET_MARKER = '__RESET__';
 
 function getBlockedPromptsKey(userId: number) {
   return `${REDIS_SYS_KEYS.GENERATION.BLOCKED_PROMPTS}:${userId}` as const;
 }
 
-/** Seed the blocked prompts list from ClickHouse for today's violations */
+/** Seed the blocked prompts list from ClickHouse for the configured rolling window. */
 async function seedBlockedPromptsFromClickHouse(userId: number): Promise<void> {
   const key = getBlockedPromptsKey(userId);
   const { clickhouse } = await import('~/server/clickhouse/client');
@@ -60,7 +67,7 @@ async function seedBlockedPromptsFromClickHouse(userId: number): Promise<void> {
   }>`
     SELECT prompt, negativePrompt, source, remixOfId, time
     FROM prohibitedRequests
-    WHERE time > subtractHours(now(), 24) AND userId = ${userId}
+    WHERE time > subtractDays(now(), ${BLOCKED_PROMPTS_WINDOW_DAYS}) AND userId = ${userId}
     ORDER BY time ASC
   `;
 
@@ -110,17 +117,18 @@ async function addBlockedPrompt(userId: number, entry: BlockedPromptEntry): Prom
     await seedBlockedPromptsFromClickHouse(userId);
   }
 
-  // Check if list only contains reset marker - if so, remove it first
+  // Push the new entry first so the list is never empty during cleanup —
+  // an empty list would auto-delete the key in Redis and discard its TTL.
+  await sysRedis.lPush(key, JSON.stringify(entry));
+
+  // If the seeded list was just a reset marker, drop the marker now that we
+  // have a real entry. Using lRem (not del) preserves the TTL set by the seed.
   const currentEntries = await sysRedis.lRange(key, 0, -1);
-  if (currentEntries.length === 1 && currentEntries[0] === RESET_MARKER) {
-    await sysRedis.del(key);
+  if (currentEntries.includes(RESET_MARKER)) {
+    await sysRedis.lRem(key, 0, RESET_MARKER);
   }
 
-  await sysRedis.lPush(key, JSON.stringify(entry));
-  // Don't reset TTL here — let the key expire on its natural schedule
-  // so re-seeding from ClickHouse keeps the rolling 24h window accurate.
-
-  // Return count (lLen is faster than fetching all entries)
+  // Marker has been removed above, so lLen now equals the real violation count.
   return await sysRedis.lLen(key);
 }
 
@@ -379,9 +387,10 @@ async function reportProhibitedRequest(options: {
         },
       });
 
+      const muteDate = new Date();
       await updateUserById({
         id: userId,
-        data: { muted: true },
+        data: { muted: true, mutedAt: muteDate, muteConfirmedAt: muteDate },
         updateSource: 'promptAuditing:autoMute',
       });
 

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -3,8 +3,18 @@ import { chunk } from 'lodash-es';
 import { CacheTTL } from '~/server/common/constants';
 import { logToAxiom } from '~/server/logging/client';
 import { cacheHitCounter, cacheMissCounter, cacheRevalidateCounter } from '~/server/prom/client';
-import type { RedisKeyTemplateCache } from '~/server/redis/client';
-import { redis, REDIS_KEYS } from '~/server/redis/client';
+import type { RedisKeyTemplateCache, RedisKeyTemplates } from '~/server/redis/client';
+import { redis, REDIS_KEYS, sysRedis } from '~/server/redis/client';
+
+export type CacheTarget = 'main' | 'sys';
+
+// The clearCacheByPattern* helpers use only the cross-client methods
+// (scanIterator, del); typed as `any` here to bridge the cache vs sys key-template
+// generics without forcing every caller to know which client they're hitting.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getCacheClient(target: CacheTarget = 'main'): any {
+  return target === 'sys' ? sysRedis : redis;
+}
 import { sleep } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 import { hashifyObject } from '~/utils/string-helpers';
@@ -462,30 +472,35 @@ export async function bustFetchThroughCache(key: RedisKeyTemplateCache) {
   await redis.packed.set(key, toCache, { KEEPTTL: true });
 }
 
-export async function clearCacheByPattern(pattern: string, onProgress?: (cleared: number) => void) {
+export async function clearCacheByPattern(
+  pattern: string,
+  onProgress?: (cleared: number) => void,
+  target: CacheTarget = 'main'
+) {
+  const client = getCacheClient(target);
   const cleared: string[] = [];
 
   if (!pattern.includes('*')) {
-    await redis.del(pattern as RedisKeyTemplateCache);
+    await client.del(pattern);
     cleared.push(pattern);
     onProgress?.(cleared.length);
     return cleared;
   }
 
   // Use cluster's scanIterator which handles scanning all nodes
-  log('Scanning cache with pattern:', pattern);
-  const stream = redis.scanIterator({ MATCH: pattern, COUNT: 10000 });
+  log('Scanning cache with pattern:', pattern, 'target:', target);
+  const stream = client.scanIterator({ MATCH: pattern, COUNT: 10000 });
 
   for await (const keys of stream) {
-    const newKeys = (keys as RedisKeyTemplateCache[]).filter((key) => !cleared.includes(key));
+    const newKeys = (keys as RedisKeyTemplates[]).filter((key) => !cleared.includes(key));
     log('Total keys:', cleared.length, 'Adding:', newKeys.length);
     if (newKeys.length === 0) continue;
 
     const batches = chunk(newKeys, 10000);
     for (let i = 0; i < batches.length; i++) {
       log('Clearing batch:', i + 1, 'of', batches.length);
-      // Delete keys one at a time to avoid CROSSSLOT errors
-      await Promise.all(batches[i].map((key) => redis.del(key)));
+      // Delete keys one at a time to avoid CROSSSLOT errors on the main cluster.
+      await Promise.all(batches[i].map((key) => client.del(key)));
       cleared.push(...batches[i]);
       log('Cleared batch:', i + 1, 'of', batches.length);
       onProgress?.(cleared.length);
@@ -513,8 +528,10 @@ export type ClearCacheByPatternsProgress = {
 // tests each key against every pattern regex. Replaces N full SCANs with 1.
 export async function clearCacheByPatterns(
   patterns: string[],
-  onProgress?: (progress: ClearCacheByPatternsProgress) => void
+  onProgress?: (progress: ClearCacheByPatternsProgress) => void,
+  target: CacheTarget = 'main'
 ) {
+  const client = getCacheClient(target);
   const perPattern = patterns.map((pattern) => ({
     pattern,
     regex: globToRegex(pattern),
@@ -526,17 +543,17 @@ export async function clearCacheByPatterns(
 
   // Fast path for exact keys — no scan needed.
   for (const p of exact) {
-    await redis.del(p.pattern as RedisKeyTemplateCache);
+    await client.del(p.pattern as RedisKeyTemplates);
     p.cleared.push(p.pattern);
   }
 
   if (globbed.length > 0) {
-    log('Scanning cache for', globbed.length, 'patterns in a single pass');
-    const stream = redis.scanIterator({ MATCH: '*', COUNT: 10000 });
+    log('Scanning cache for', globbed.length, 'patterns in a single pass, target:', target);
+    const stream = client.scanIterator({ MATCH: '*', COUNT: 10000 });
 
     for await (const keys of stream) {
-      const toDelete: RedisKeyTemplateCache[] = [];
-      for (const key of keys as RedisKeyTemplateCache[]) {
+      const toDelete: RedisKeyTemplates[] = [];
+      for (const key of keys as RedisKeyTemplates[]) {
         for (const p of globbed) {
           if (p.regex.test(key)) {
             p.cleared.push(key);
@@ -549,7 +566,7 @@ export async function clearCacheByPatterns(
 
       const batches = chunk(toDelete, 10000);
       for (const batch of batches) {
-        await Promise.all(batch.map((key) => redis.del(key)));
+        await Promise.all(batch.map((key) => client.del(key)));
       }
       const total = perPattern.reduce((s, p) => s + p.cleared.length, 0);
       onProgress?.({


### PR DESCRIPTION
## Summary
- Auto-mute counter dropped to near-zero after the sysRedis wipe because pre-existing keys held data indefinitely (via a TTL-strip bug) while the ClickHouse cold-start seed only replayed the last 24h. Result: UserRestriction creation went from ~37-49/day to 3/day on May 15.
- Widen the blocked-prompts window to 30d (shared between TTL and CH seed query) so cold-start and steady-state use the same horizon.
- Fix the TTL-strip bug in `addBlockedPrompt` by swapping `del + lPush` for `lPush + lRem`, preserving the seed's TTL when clearing the reset marker.
- Auto-mute path now sets `mutedAt` and `muteConfirmedAt`. The Jan 2026 migration removed the DB trigger that auto-filled `mutedAt`, leaving every auto-muted user with `muted=true, mutedAt=null`.
- Extend `clearCacheByPattern[s]` and the admin endpoint with a `target: 'main' | 'sys'` option so we can wipe `generation:blocked-prompts:*` from sysRedis after deploy.

## Investigation evidence
- `prohibitedRequests` volume in ClickHouse stayed normal (360-505/day on May 14-15 vs. 400-1100 baseline) — users are still attempting blocked prompts at the usual rate.
- `UserRestriction` creates collapsed: typical 37-49/day → 22 on May 14 (partial) → 3 on May 15.
- Sample muted users in the DB had `muted=true, mutedAt=null`, confirming the auto-mute path was the source of the recent rows and that it never set `mutedAt`.
- sysRedis `info` reported `Uptime: 1 days`, lining up with the reported wipe.

## Recovery plan (post-merge)
1. Deploy this branch.
2. Wipe stale partial keys created under the buggy code so users get re-seeded under the fixed logic:
   ```
   curl "https://civitai.com/api/admin/clear-cache-by-pattern?token=$WEBHOOK_TOKEN & pattern=generation:blocked-prompts:* & target=sys & stream=1"
   ```
   Stream mode (`stream=1`) is recommended; the sysRedis keyspace is ~1.5M keys and Cloudflare will 502 a non-SSE response.
3. Watch the daily `UserRestriction` create count return toward the ~40/day baseline.

## Test plan
- [ ] Mock-mute a test user via the prompt-audit flow and confirm `mutedAt` / `muteConfirmedAt` are populated.
- [ ] Trigger a cold-start violation for a user with prior ClickHouse history and confirm the Redis list reflects the seeded 30d window plus the new entry.
- [ ] Verify the `?target=sys` endpoint path actually scans/deletes from sysRedis (smoke test against a throwaway pattern in staging).
- [ ] Confirm existing callers of `clearCacheByPattern` (session-invalidation, creator-program) keep their `main` target behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)