### PR TITLE
fix(browsing-addons): scope minor filter to NSFW, keep minor models reachable

### DIFF
--- a/src/components/Model/Gallery/ModelGallery.tsx
+++ b/src/components/Model/Gallery/ModelGallery.tsx
@@ -1,8 +1,10 @@
 import { useInView } from 'react-intersection-observer';
 import { BrowsingLevelProvider } from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import { HiddenPreferencesProvider } from '~/components/HiddenPreferences/HiddenPreferencesProvider';
 import type { ImagesAsPostsInfiniteProps } from '~/components/Image/AsPosts/ImagesAsPostsInfinite';
 import { ImagesAsPostsInfinite } from '~/components/Image/AsPosts/ImagesAsPostsInfinite';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
+import { BrowsingSettingsAddonsProvider } from '~/providers/BrowsingSettingsAddonsProvider';
 import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 
 export function ModelGallery(props: ImagesAsPostsInfiniteProps) {
@@ -13,13 +15,19 @@ export function ModelGallery(props: ImagesAsPostsInfiniteProps) {
     triggerOnce: true,
   });
 
+  const content = inView && <ImagesAsPostsInfinite {...props} />;
+
   return (
     <div ref={ref} className="min-h-80 w-full">
-      <BrowsingLevelProvider
-        forcedBrowsingLevel={props.model.minor ? publicBrowsingLevelsFlag : undefined}
-      >
-        {inView && <ImagesAsPostsInfinite {...props} />}
-      </BrowsingLevelProvider>
+      {props.model.minor ? (
+        <BrowsingLevelProvider forcedBrowsingLevel={publicBrowsingLevelsFlag}>
+          <BrowsingSettingsAddonsProvider>
+            <HiddenPreferencesProvider>{content || null}</HiddenPreferencesProvider>
+          </BrowsingSettingsAddonsProvider>
+        </BrowsingLevelProvider>
+      ) : (
+        content
+      )}
     </div>
   );
 }

--- a/src/components/Model/Gallery/ModelGallery.tsx
+++ b/src/components/Model/Gallery/ModelGallery.tsx
@@ -1,7 +1,9 @@
 import { useInView } from 'react-intersection-observer';
+import { BrowsingLevelProvider } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import type { ImagesAsPostsInfiniteProps } from '~/components/Image/AsPosts/ImagesAsPostsInfinite';
 import { ImagesAsPostsInfinite } from '~/components/Image/AsPosts/ImagesAsPostsInfinite';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 
 export function ModelGallery(props: ImagesAsPostsInfiniteProps) {
   const node = useScrollAreaRef();
@@ -13,7 +15,11 @@ export function ModelGallery(props: ImagesAsPostsInfiniteProps) {
 
   return (
     <div ref={ref} className="min-h-80 w-full">
-      {inView && <ImagesAsPostsInfinite {...props} />}
+      <BrowsingLevelProvider
+        forcedBrowsingLevel={props.model.minor ? publicBrowsingLevelsFlag : undefined}
+      >
+        {inView && <ImagesAsPostsInfinite {...props} />}
+      </BrowsingLevelProvider>
     </div>
   );
 }

--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -1,6 +1,7 @@
 import { Card, Center, Indicator, Loader, Stack } from '@mantine/core';
 import { IconBrush, IconInfoCircle } from '@tabler/icons-react';
 import { BrowsingLevelProvider } from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import { HiddenPreferencesProvider } from '~/components/HiddenPreferences/HiddenPreferencesProvider';
 import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
@@ -29,7 +30,13 @@ export function ModelCarousel(props: Props) {
   return (
     <BrowsingLevelProvider forcedBrowsingLevel={props.minor ? publicBrowsingLevelsFlag : undefined}>
       <BrowsingSettingsAddonsProvider>
-        <ModelCarouselContent {...props} />
+        {props.minor ? (
+          <HiddenPreferencesProvider>
+            <ModelCarouselContent {...props} />
+          </HiddenPreferencesProvider>
+        ) : (
+          <ModelCarouselContent {...props} />
+        )}
       </BrowsingSettingsAddonsProvider>
     </BrowsingLevelProvider>
   );

--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -1,6 +1,7 @@
 import { Card, Center, Indicator, Loader, Stack } from '@mantine/core';
 import { IconBrush, IconInfoCircle } from '@tabler/icons-react';
 import { BrowsingLevelProvider } from '~/components/BrowsingLevel/BrowsingLevelProvider';
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
 import { ImageContextMenu } from '~/components/Image/ContextMenu/ImageContextMenu';
@@ -26,7 +27,7 @@ import clsx from 'clsx';
 
 export function ModelCarousel(props: Props) {
   return (
-    <BrowsingLevelProvider>
+    <BrowsingLevelProvider forcedBrowsingLevel={props.minor ? publicBrowsingLevelsFlag : undefined}>
       <BrowsingSettingsAddonsProvider>
         <ModelCarouselContent {...props} />
       </BrowsingSettingsAddonsProvider>
@@ -191,4 +192,5 @@ type Props = {
   modelId: number;
   modelUserId: number;
   limit?: number;
+  minor?: boolean;
 };

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -474,6 +474,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
               modelVersionId={version.id}
               modelUserId={model.user.id}
               limit={CAROUSEL_LIMIT}
+              minor={model.minor}
             />
           )}
           {showRequestReview ? (
@@ -1359,9 +1360,9 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                           </Popover.Target>
                           <Popover.Dropdown>
                             <Text size="xs">
-                              The creator has issued a license fee. This amount is added on top
-                              of the standard generation cost for each image generated on Civitai
-                              with this resource.
+                              The creator has issued a license fee. This amount is added on top of
+                              the standard generation cost for each image generated on Civitai with
+                              this resource.
                             </Text>
                           </Popover.Dropdown>
                         </Popover>
@@ -1677,11 +1678,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
               <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
                 <Group gap={4} wrap="wrap" align="center">
                   <IconLicense size={16} />
-                  <Text
-                    size="xs"
-                    c="dimmed"
-                    style={{ whiteSpace: 'nowrap', lineHeight: 1.1 }}
-                  >
+                  <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap', lineHeight: 1.1 }}>
                     License{model.licenses.length > 0 ? 's' : ''}:
                   </Text>
                   {license && (
@@ -1763,6 +1760,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
               modelVersionId={version.id}
               modelUserId={model.user.id}
               limit={CAROUSEL_LIMIT}
+              minor={model.minor}
             />
           )}
           {model.description ? (

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -639,15 +639,6 @@ export default function ModelDetailsV2({
     return <NotFound />;
   }
 
-  if (model.minor && browsingSettingsAddons.settings.disableMinor) {
-    return (
-      <NotFound
-        title="Model not available with current settings"
-        message="This model is hidden when adult content filters are on. Disable X/XXX to view it."
-      />
-    );
-  }
-
   const image = versionImages.find((image) => getIsSafeBrowsingLevel(image.nsfwLevel));
   const imageUrl = image ? getEdgeUrl(image.url, { width: 1200 }) : undefined;
   const thumbsUpCount = model.rank?.thumbsUpCountAllTime ?? 0;

--- a/src/providers/BrowsingSettingsAddonsProvider.tsx
+++ b/src/providers/BrowsingSettingsAddonsProvider.tsx
@@ -67,6 +67,9 @@ export const BrowsingSettingsAddonsProvider = ({ children }: { children: React.R
           }
 
           if (apply) {
+            // booleans: last-explicit-wins. arrays: accumulate. A later rule
+            // setting disablePoi/disableMinor=false cannot undo excludedTagIds
+            // pushed by an earlier rule — scope rules narrowly instead.
             if (elem.disablePoi !== undefined) acc.disablePoi = elem.disablePoi;
             if (elem.disableMinor !== undefined) acc.disableMinor = elem.disableMinor;
             acc.excludedTagIds.push(...(elem.excludedTagIds ?? []));

--- a/src/providers/BrowsingSettingsAddonsProvider.tsx
+++ b/src/providers/BrowsingSettingsAddonsProvider.tsx
@@ -67,8 +67,8 @@ export const BrowsingSettingsAddonsProvider = ({ children }: { children: React.R
           }
 
           if (apply) {
-            acc.disablePoi = elem.disablePoi || acc.disablePoi;
-            acc.disableMinor = elem.disableMinor || acc.disableMinor;
+            if (elem.disablePoi !== undefined) acc.disablePoi = elem.disablePoi;
+            if (elem.disableMinor !== undefined) acc.disableMinor = elem.disableMinor;
             acc.excludedTagIds.push(...(elem.excludedTagIds ?? []));
             acc.excludedFooterLinks.push(...(elem.excludedFooterLinks ?? []));
             acc.generationDefaultValues = {

--- a/src/shared/constants/browsing-settings-addons.ts
+++ b/src/shared/constants/browsing-settings-addons.ts
@@ -20,25 +20,27 @@ export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
   {
     type: 'some',
     nsfwLevels: [NsfwLevel.PG, NsfwLevel.PG13, NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX],
-    excludedFooterLinks: [],
-    disableMinor: true,
     disablePoi: true,
     excludedTagIds: [
-      415792, // Clavata Celebrity
-      426772, // Clavata Celebrity
-      5351, //child
       5161, //actor
       5162, //actress
       5188, //celebrity
       5249, //real person
-      306619, //child present
-      5351, //child
-      154326, //toddler
-      161829, //male child
-      163032, //female child
       130818, //porn actress
       130820, //adult actress
       133182, //porn star
+    ],
+  },
+  {
+    type: 'some',
+    nsfwLevels: [NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX],
+    disableMinor: true,
+    excludedTagIds: [
+      5351, //child
+      306619, //child present
+      154326, //toddler
+      161829, //male child
+      163032, //female child
     ],
   },
 ] as const;

--- a/src/shared/constants/browsing-settings-addons.ts
+++ b/src/shared/constants/browsing-settings-addons.ts
@@ -22,6 +22,8 @@ export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
     nsfwLevels: [NsfwLevel.PG, NsfwLevel.PG13, NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX],
     disablePoi: true,
     excludedTagIds: [
+      415792, // Clavata Celebrity
+      426772, // Clavata Celebrity
       5161, //actor
       5162, //actress
       5188, //celebrity

--- a/src/shared/constants/browsing-settings-addons.ts
+++ b/src/shared/constants/browsing-settings-addons.ts
@@ -22,8 +22,6 @@ export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
     nsfwLevels: [NsfwLevel.PG, NsfwLevel.PG13, NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX],
     disablePoi: true,
     excludedTagIds: [
-      415792, // Clavata Celebrity
-      426772, // Clavata Celebrity
       5161, //actor
       5162, //actress
       5188, //celebrity


### PR DESCRIPTION
## Summary
- Split the broad `'some'` browsing-settings addon into two rules: a POI rule that applies to all browsing levels (PG → XXX) and a minor rule scoped to NSFW only (R/X/XXX). Restores intended behavior after the `system:browsing-setting-addons` sysRedis override was wiped — the default was applying `disableMinor: true` + child/minor `excludedTagIds` even for PG/PG13 browsers, hiding entire models.
- Switched the addon reducer to **last-explicit-wins** for `disablePoi` / `disableMinor` (`acc.x = elem.x || acc.x` → `if (elem.x !== undefined) acc.x = elem.x`). The old OR-merge made later override rules silently no-op (`false || true === true`).
- Removed the early `NotFound` on `model.minor && browsingSettingsAddons.settings.disableMinor` in `src/pages/models/[id]/[[...slug]].tsx`. Replaced with PG-cap enforcement: `ModelCarousel` and `ModelGallery` wrap their content in `<BrowsingLevelProvider forcedBrowsingLevel={publicBrowsingLevelsFlag}>` when `model.minor` is true, so minor-flagged models stay reachable with only their safe imagery visible.

## Why
`sysRedis` was wiped, dropping `system:browsing-setting-addons`. Default fallback in `DEFAULT_BROWSING_SETTINGS_ADDONS` had the minor filter scoped to all browsing levels including PG, so non-mod users couldn't see any model whose images were marked `minor: true` — the client filter (`useApplyHiddenPreferences`) dropped every minor image, leaving the model with zero images and removing it from the feed entirely. Mod-flagged minor models also returned a hard 404 on direct navigation.

## Test plan
- [x] PG-only browsing returns derived `disableMinor: false`, `disablePoi: true`, only POI tags excluded
- [x] PG+PG13 browsing same as above
- [x] R/X/XXX browsing returns `disableMinor: true`, `disablePoi: true`, both POI + minor tags excluded
- [x] Mod with `disableMinor: false` rule for PG/PG13 overrides correctly (reducer last-wins)
- [x] Minor-flagged model page loads (no 404) on civitai.red / civitai.com
- [x] Minor-flagged model's carousel + gallery show only PG images regardless of viewer's saved browsing level
- [x] Non-minor models unaffected — carousel/gallery still respect user browsing level
- [ ] Hard reload after deploy to flush `staleTime: Infinity` client cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)