### PR TITLE
api/health: hotfix - relax redis check to fail only on explicit isReady=false

### DIFF
--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -98,12 +98,12 @@ const checkFns: Record<string, CancellableCheckFn> = {
 
   // Redis cluster client: skip explicit PING because redis@5 cluster client
   // throws `Cannot read properties of undefined (reading 'connectPromise')`
-  // when a master is transiently re-establishing, even with isReady=true.
-  // isReady tracks topology + per-master connection state; it flips to
-  // false on real failures.
+  // when a master is transiently re-establishing. isReady is the canonical
+  // signal — but be lenient: treat only explicit `false` as failure, since
+  // it can briefly read undefined during topology refresh / cold start.
   async redis(signal: AbortSignal) {
     if (signal.aborted) return false;
-    return (redis as any).isReady === true;
+    return (redis as any)?.isReady !== false;
   },
 
   async sysRedis(signal: AbortSignal) {


### PR DESCRIPTION
## Summary

Hotfix follow-up to #2278.

The strict \`(redis as any).isReady === true\` check from #2278 was too strict — it returned **false** during transient cluster states (topology refresh, cold start, a master transiently re-establishing). This drove the \`civitai_app_healthcheck_redis\` counter from ~2 failures per 15m (pre-#2278 baseline) to **571 failures per 10m** on the new image, breaking startup probes on every fresh pod.

Effect on today's rollout: Flagger rejected the #2278 image on the API canary (status \`Failed\` at 17:19 UTC). New pods kept hitting startup probe \`HTTP 500\` and never reached ready. Traffic stayed on the prior image — no user impact — but the rollout was stuck.

## Change

\`\`\`diff
-    return (redis as any).isReady === true;
+    return (redis as any)?.isReady !== false;
\`\`\`

Treats \`true\` and \`undefined\` (transient init) as healthy. Only explicit \`false\` (real failure) returns false. Optional chaining guards the case where \`redis\` itself isn't yet assigned at module load.

## Test plan
- [ ] After merge + image build, watch \`civitai_app_healthcheck_redis\` — should return to ~0 failures/10m
- [ ] Confirm Flagger canary completes for civitai-dp-prod-api and civitai-dp-prod (currently stuck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)