### PR TITLE
feat(reports): add Spam report reason

### DIFF
--- a/prisma/migrations/20260518133057_add_spam_report_reason/migration.sql
+++ b/prisma/migrations/20260518133057_add_spam_report_reason/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ReportReason" ADD VALUE 'Spam';

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -1273,6 +1273,7 @@ enum ReportReason {
   Claim
   CSAM
   Automated
+  Spam
 }
 
 enum ReportStatus {

--- a/src/components/Modals/ReportModal.tsx
+++ b/src/components/Modals/ReportModal.tsx
@@ -22,6 +22,7 @@ import { AdminAttentionForm } from '~/components/Report/AdminAttentionForm';
 import { ClaimForm } from '~/components/Report/ClaimForm';
 import { ArticleNsfwForm, ImageNsfwForm, ModelNsfwForm } from '~/components/Report/NsfwForm';
 import { OwnershipForm } from '~/components/Report/OwnershipForm';
+import { SpamForm } from '~/components/Report/SpamForm';
 import { TosViolationForm } from '~/components/Report/TosViolationForm';
 import { useVoteForTags } from '~/components/VotableTags/votableTag.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -108,6 +109,26 @@ const reports = [
     label: 'This uses my art',
     Element: OwnershipForm,
     availableFor: [ReportEntity.Model, ReportEntity.BountyEntry],
+  },
+  {
+    reason: ReportReason.Spam,
+    label: 'Spam',
+    Element: SpamForm,
+    availableFor: [
+      ReportEntity.Model,
+      ReportEntity.Comment,
+      ReportEntity.CommentV2,
+      ReportEntity.Image,
+      ReportEntity.ResourceReview,
+      ReportEntity.Article,
+      ReportEntity.Post,
+      ReportEntity.User,
+      ReportEntity.Collection,
+      ReportEntity.Bounty,
+      ReportEntity.BountyEntry,
+      ReportEntity.Chat,
+      ReportEntity.ComicProject,
+    ],
   },
 ];
 

--- a/src/components/Report/SpamForm.tsx
+++ b/src/components/Report/SpamForm.tsx
@@ -1,0 +1,14 @@
+import { createReportForm } from './create-report-form';
+import { InputTextArea } from '~/libs/form';
+import { reportSpamDetailsSchema } from '~/server/schema/report.schema';
+
+export const SpamForm = createReportForm({
+  schema: reportSpamDetailsSchema,
+  Element: () => (
+    <InputTextArea
+      name="comment"
+      label="Comment (optional)"
+      placeholder="Anything that helps moderators triage (link, account behavior, repeated posts, etc.)"
+    />
+  ),
+});

--- a/src/pages/moderator/reports.tsx
+++ b/src/pages/moderator/reports.tsx
@@ -71,6 +71,7 @@ export default function Reports() {
         ReportReason.Claim,
         ReportReason.Ownership,
         ReportReason.TOSViolation,
+        ReportReason.Spam,
         // ReportReason.Automated, // removing temporarily as per Seb
       ],
     },

--- a/src/server/schema/report.schema.ts
+++ b/src/server/schema/report.schema.ts
@@ -91,7 +91,6 @@ export const reportCsamSchema = baseSchema.extend({
 
 export const reportSpamSchema = baseSchema.extend({
   reason: z.literal(ReportReason.Spam),
-  details: reportSpamDetailsSchema,
 });
 
 export const reportAutomatedSchema = baseSchema.extend({

--- a/src/server/schema/report.schema.ts
+++ b/src/server/schema/report.schema.ts
@@ -33,6 +33,8 @@ export const reportAdminAttentionDetailsSchema = baseDetailSchema.extend({
   reason: z.string(),
 });
 
+export const reportSpamDetailsSchema = baseDetailSchema;
+
 export const reportAutomatedDetailsSchema = baseDetailSchema.extend({
   externalId: z.string(),
   externalType: z.enum(ExternalModerationType),
@@ -87,6 +89,11 @@ export const reportCsamSchema = baseSchema.extend({
   reason: z.literal(ReportReason.CSAM),
 });
 
+export const reportSpamSchema = baseSchema.extend({
+  reason: z.literal(ReportReason.Spam),
+  details: reportSpamDetailsSchema,
+});
+
 export const reportAutomatedSchema = baseSchema.extend({
   reason: z.literal(ReportReason.Automated),
   details: reportAutomatedDetailsSchema,
@@ -103,6 +110,7 @@ export const createReportInputSchema = z.discriminatedUnion('reason', [
   reportAdminAttentionSchema,
   reportCsamSchema,
   reportAutomatedSchema,
+  reportSpamSchema,
 ]);
 
 export type SetReportStatusInput = z.infer<typeof setReportStatusSchema>;

--- a/src/shared/utils/prisma/enums.ts
+++ b/src/shared/utils/prisma/enums.ts
@@ -336,6 +336,7 @@ export const ReportReason = {
   Claim: 'Claim',
   CSAM: 'CSAM',
   Automated: 'Automated',
+  Spam: 'Spam',
 } as const;
 
 export type ReportReason = (typeof ReportReason)[keyof typeof ReportReason];

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -68,7 +68,7 @@ export type MetricTimeframe = "Day" | "Week" | "Month" | "Year" | "AllTime";
 
 export type AssociationType = "Suggested";
 
-export type ReportReason = "TOSViolation" | "NSFW" | "Ownership" | "AdminAttention" | "Claim" | "CSAM" | "Automated";
+export type ReportReason = "TOSViolation" | "NSFW" | "Ownership" | "AdminAttention" | "Claim" | "CSAM" | "Automated" | "Spam";
 
 export type ReportStatus = "Pending" | "Processing" | "Actioned" | "Unactioned";
 


### PR DESCRIPTION
## Summary
- Adds `Spam` to the `ReportReason` Prisma enum + migration.
- New `SpamForm` (optional comment) wired into the Report dialog across 13 entity types (Model, Image, Post, Article, Comment/V2, ResourceReview, User, Collection, Bounty, BountyEntry, Chat, ComicProject).
- Mod queue default filter includes Spam; reports land at status `Pending`.
- `ViolationType.Spam` is intentionally kept for the mod-side unpublish flow.

Closes [868jne7my](https://app.clickup.com/t/868jne7my) — Freshdesk #65821 (NanashiAnon).

## Test plan
- [x] `pnpm run db:migrate` applies the new enum value
- [x] Report dialog shows `Spam` on each supported entity type
- [x] Submit a Spam report → row appears in `/moderator/reports` with reason `Spam`, status `Pending`
- [x] Reason filter dropdown lists `Spam`
- [x] ClickHouse `reports` table records `reason = 'Spam'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)