### PR TITLE
feat(oauth): require Origin allowlist for public clients

### DIFF
--- a/prisma/migrations/20260518150000_add_oauth_allowed_origins/migration.sql
+++ b/prisma/migrations/20260518150000_add_oauth_allowed_origins/migration.sql
@@ -8,22 +8,36 @@
 -- clients.
 --
 -- For existing rows we backfill the allowedOrigins set from the origin part of
--- every redirectUri, so any currently-registered app continues to work without
--- a manual update from the owner. Confidential clients (the bulk of today's
--- traffic) skip the new check entirely.
-ALTER TABLE "OauthClient" ADD COLUMN "allowedOrigins" TEXT[] DEFAULT ARRAY[]::TEXT[];
+-- every redirectUri (lowercased host, default ports stripped) so any
+-- currently-registered app keeps working without a manual update. Custom-scheme
+-- URIs (e.g. myapp://) yield no origin and fall back to the empty default —
+-- owner must set via UI. Confidential clients (the bulk of today's traffic)
+-- skip the runtime check entirely.
+ALTER TABLE "OauthClient"
+  ADD COLUMN "allowedOrigins" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
 
 UPDATE "OauthClient"
 SET "allowedOrigins" = sub.origins
 FROM (
   SELECT
-    id,
+    "OauthClient".id,
     COALESCE(
       ARRAY(
         SELECT DISTINCT
-          regexp_replace(uri, '^(https?://[^/]+).*$', '\1')
-        FROM unnest("redirectUris") AS uri
-        WHERE uri ~ '^https?://[^/]+'
+          CASE
+            WHEN lo LIKE 'https://%:443' THEN regexp_replace(lo, ':443$', '')
+            WHEN lo LIKE 'http://%:80'   THEN regexp_replace(lo, ':80$', '')
+            ELSE lo
+          END
+        FROM (
+          -- `[^/?#]+` stops at the first /, ?, or # so URIs like
+          -- `https://example.com?foo=1` don't backfill `https://example.com?foo=1`
+          -- (browser Origin strips query/fragment). Case-insensitive on the
+          -- scheme so `HTTPS://...` URIs aren't skipped before lowercasing.
+          SELECT lower(regexp_replace(uri, '^(https?://[^/?#]+).*$', '\1')) AS lo
+          FROM unnest("redirectUris") AS uri
+          WHERE uri ~* '^https?://[^/?#]+'
+        ) AS normalized
       ),
       ARRAY[]::TEXT[]
     ) AS origins

--- a/prisma/migrations/20260518150000_add_oauth_allowed_origins/migration.sql
+++ b/prisma/migrations/20260518150000_add_oauth_allowed_origins/migration.sql
@@ -1,0 +1,32 @@
+-- Add per-client allowed-origins enforcement for OAuth public clients.
+--
+-- Public OAuth clients (isConfidential=false) currently rely on PKCE alone for
+-- token-exchange identity because /api/auth/oauth/token responds with
+-- Access-Control-Allow-Origin: *. This column lets us pin the token and revoke
+-- endpoints to a registered set of browser origins, closing the residual
+-- code-interception window that PKCE leaves open for browser-only public
+-- clients.
+--
+-- For existing rows we backfill the allowedOrigins set from the origin part of
+-- every redirectUri, so any currently-registered app continues to work without
+-- a manual update from the owner. Confidential clients (the bulk of today's
+-- traffic) skip the new check entirely.
+ALTER TABLE "OauthClient" ADD COLUMN "allowedOrigins" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+UPDATE "OauthClient"
+SET "allowedOrigins" = sub.origins
+FROM (
+  SELECT
+    id,
+    COALESCE(
+      ARRAY(
+        SELECT DISTINCT
+          regexp_replace(uri, '^(https?://[^/]+).*$', '\1')
+        FROM unnest("redirectUris") AS uri
+        WHERE uri ~ '^https?://[^/]+'
+      ),
+      ARRAY[]::TEXT[]
+    ) AS origins
+  FROM "OauthClient"
+) AS sub
+WHERE "OauthClient".id = sub.id;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2153,6 +2153,7 @@ model OauthClient {
   description    String         @default("")
   logoUrl        String?
   redirectUris   String[]       @default([])
+  allowedOrigins String[]       @default([])
   grants         String[]       @default(["authorization_code", "refresh_token"])
   allowedScopes  Int            @default(33554431)
   isConfidential Boolean        @default(true)

--- a/src/components/Account/OAuthAppsCard.tsx
+++ b/src/components/Account/OAuthAppsCard.tsx
@@ -218,15 +218,64 @@ function SecretDisplay({
   );
 }
 
+// Origin entries are exact-matched against the browser's `Origin` header, so
+// they must be a bare scheme://host[:port]. We pre-validate on the client to
+// give a fast inline error; the server enforces the same rule.
+function parseOriginList(
+  text: string
+): { value: string[]; error: string | null } {
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const cleaned: string[] = [];
+  for (const line of lines) {
+    try {
+      const url = new URL(line);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return { value: [], error: `Origin must use http(s): ${line}` };
+      }
+      if (line !== url.origin) {
+        return {
+          value: [],
+          error: `Origin must be scheme://host[:port] with no path: ${line}`,
+        };
+      }
+      cleaned.push(url.origin);
+    } catch {
+      return { value: [], error: `Invalid origin: ${line}` };
+    }
+  }
+  return { value: cleaned, error: null };
+}
+
+function deriveOriginsFromRedirectUrisClient(uris: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const uri of uris) {
+    try {
+      const origin = new URL(uri).origin;
+      if (origin === 'null' || seen.has(origin)) continue;
+      seen.add(origin);
+      out.push(origin);
+    } catch {
+      // ignore — URI was already validated
+    }
+  }
+  return out;
+}
+
 function RegisterAppModal({ opened, onClose }: { opened: boolean; onClose: () => void }) {
   const utils = trpc.useUtils();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [redirectUrisText, setRedirectUrisText] = useState('');
+  const [allowedOriginsText, setAllowedOriginsText] = useState('');
   const [isConfidential, setIsConfidential] = useState(true);
   const [tokenScope, setTokenScope] = useState(TokenScope.Full);
   const [result, setResult] = useState<{ clientId: string; clientSecret: string } | null>(null);
   const [uriError, setUriError] = useState<string | null>(null);
+  const [originError, setOriginError] = useState<string | null>(null);
 
   const createMutation = trpc.oauthClient.create.useMutation({
     onSuccess(data) {
@@ -248,10 +297,12 @@ function RegisterAppModal({ opened, onClose }: { opened: boolean; onClose: () =>
     setName('');
     setDescription('');
     setRedirectUrisText('');
+    setAllowedOriginsText('');
     setIsConfidential(true);
     setTokenScope(TokenScope.Full);
     setResult(null);
     setUriError(null);
+    setOriginError(null);
   };
 
   const handleClose = () => {
@@ -285,10 +336,24 @@ function RegisterAppModal({ opened, onClose }: { opened: boolean; onClose: () =>
     if (!uris) return;
     if (!name.trim()) return;
 
+    // Public clients require origins. If the user left the field blank, the
+    // server will backfill from redirectUris — mirror that here so the call
+    // site is the same in both branches.
+    const originsParsed = parseOriginList(allowedOriginsText);
+    if (originsParsed.error) {
+      setOriginError(originsParsed.error);
+      return;
+    }
+    const allowedOrigins =
+      originsParsed.value.length > 0
+        ? originsParsed.value
+        : deriveOriginsFromRedirectUrisClient(uris);
+
     createMutation.mutate({
       name: name.trim(),
       description: description.trim(),
       redirectUris: uris,
+      allowedOrigins,
       isConfidential,
       allowedScopes: tokenScope,
     });
@@ -339,6 +404,22 @@ function RegisterAppModal({ opened, onClose }: { opened: boolean; onClose: () =>
             }}
             error={uriError}
           />
+          <Textarea
+            label="Allowed origins"
+            description={
+              isConfidential
+                ? 'Optional. Used only if you later switch this app to a public client.'
+                : 'Required for public clients. One origin per line (e.g. https://app.example.com). Leave blank to derive from redirect URIs.'
+            }
+            placeholder={'https://app.example.com\nhttp://localhost:5173'}
+            minRows={2}
+            value={allowedOriginsText}
+            onChange={(e) => {
+              setAllowedOriginsText(e.currentTarget.value);
+              setOriginError(null);
+            }}
+            error={originError}
+          />
           <Radio.Group
             label="Client type"
             value={isConfidential ? 'confidential' : 'public'}
@@ -380,6 +461,7 @@ function EditAppModal({
     name: string;
     description: string | null;
     redirectUris: string[];
+    allowedOrigins: string[];
     allowedScopes: number;
   };
 }) {
@@ -387,8 +469,12 @@ function EditAppModal({
   const [name, setName] = useState(client.name);
   const [description, setDescription] = useState(client.description ?? '');
   const [redirectUrisText, setRedirectUrisText] = useState(client.redirectUris.join('\n'));
+  const [allowedOriginsText, setAllowedOriginsText] = useState(
+    client.allowedOrigins.join('\n')
+  );
   const [tokenScope, setTokenScope] = useState(client.allowedScopes);
   const [uriError, setUriError] = useState<string | null>(null);
+  const [originError, setOriginError] = useState<string | null>(null);
 
   const updateMutation = trpc.oauthClient.update.useMutation({
     onSuccess() {
@@ -429,11 +515,18 @@ function EditAppModal({
     if (!uris) return;
     if (!name.trim()) return;
 
+    const originsParsed = parseOriginList(allowedOriginsText);
+    if (originsParsed.error) {
+      setOriginError(originsParsed.error);
+      return;
+    }
+
     updateMutation.mutate({
       id: client.id,
       name: name.trim(),
       description: description.trim(),
       redirectUris: uris,
+      allowedOrigins: originsParsed.value,
       allowedScopes: tokenScope,
     });
   };
@@ -476,6 +569,18 @@ function EditAppModal({
           }}
           error={uriError}
         />
+        <Textarea
+          label="Allowed origins"
+          description="One origin per line (e.g. https://app.example.com). Enforced for public clients."
+          placeholder={'https://app.example.com'}
+          minRows={2}
+          value={allowedOriginsText}
+          onChange={(e) => {
+            setAllowedOriginsText(e.currentTarget.value);
+            setOriginError(null);
+          }}
+          error={originError}
+        />
         <ScopeSelector tokenScope={tokenScope} onChange={setTokenScope} />
         <Group justify="space-between">
           <Button variant="default" onClick={onClose} disabled={updateMutation.isLoading}>
@@ -498,6 +603,7 @@ export function OAuthAppsCard() {
     name: string;
     description: string | null;
     redirectUris: string[];
+    allowedOrigins: string[];
     allowedScopes: number;
   } | null>(null);
   const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
@@ -630,6 +736,7 @@ export function OAuthAppsCard() {
                               name: client.name,
                               description: client.description,
                               redirectUris: client.redirectUris,
+                              allowedOrigins: client.allowedOrigins ?? [],
                               allowedScopes: client.allowedScopes,
                             })
                           }

--- a/src/pages/api/auth/oauth/__tests__/token.test.ts
+++ b/src/pages/api/auth/oauth/__tests__/token.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Minimal NextApiRequest/Response stand-in. Same shape used in
+// retool-endpoint.test.ts so behaviour stays consistent across OAuth tests.
+function createMocks({
+  method = 'POST',
+  headers = {},
+  body = {},
+  query = {},
+}: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  query?: Record<string, string>;
+}) {
+  const req = { method, headers, body, query } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown = undefined;
+  const responseHeaders: Record<string, string> = {};
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: unknown) {
+      payload = body;
+      return res;
+    },
+    setHeader(key: string, value: string) {
+      responseHeaders[key] = value;
+    },
+    end() {
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getHeaders: () => responseHeaders,
+  };
+  return { req, res };
+}
+
+const { mockFindUnique, mockOauthToken, mockLogEvent } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockOauthToken: vi.fn(),
+  mockLogEvent: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { oauthClient: { findUnique: mockFindUnique } },
+}));
+
+vi.mock('~/server/oauth/server', () => ({
+  oauthServer: { token: mockOauthToken },
+}));
+
+vi.mock('~/server/oauth/rate-limit', () => ({
+  checkOAuthRateLimit: vi.fn().mockResolvedValue(true),
+  sendRateLimitResponse: vi.fn(),
+}));
+
+vi.mock('~/server/oauth/audit-log', () => ({
+  logOAuthEvent: mockLogEvent,
+}));
+
+vi.mock('~/server/oauth/constants', () => ({
+  ACCESS_TOKEN_TTL: 3600,
+}));
+
+// addCorsHeaders pulls in the full server env. Stub it to a behaviour-only
+// double so we don't drag the real env loader into a unit test.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  addCorsHeaders: (
+    req: { method?: string },
+    res: { setHeader: (k: string, v: string) => void; status: (n: number) => { end: () => void } },
+    methods: string[]
+  ) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', methods.join(', '));
+    if (req.method === 'OPTIONS') {
+      res.status(200).end();
+      return true;
+    }
+    return false;
+  },
+}));
+
+vi.mock('request-ip', () => ({
+  default: { getClientIp: () => '127.0.0.1' },
+}));
+
+// `@node-oauth/oauth2-server` constructs Request/Response objects with internal
+// validation we don't care about for this unit. Stub them to passthrough shells.
+vi.mock('@node-oauth/oauth2-server', () => ({
+  Request: class {
+    constructor(public init: unknown) {}
+  },
+  Response: class {
+    constructor(public res: unknown) {}
+  },
+}));
+
+// Import after mocks so the handler picks them up.
+import handler from '../token';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/auth/oauth/token — origin enforcement', () => {
+  it('returns 200 for a public client when Origin is in allowedOrigins', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'pub-1',
+      isConfidential: false,
+      allowedOrigins: ['https://app.example.com'],
+    });
+    mockOauthToken.mockResolvedValue({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      scope: '1',
+      user: { id: 42 },
+      accessTokenLifetime: 3600,
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { origin: 'https://app.example.com' },
+      body: { client_id: 'pub-1', grant_type: 'authorization_code' },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('https://app.example.com');
+    expect(res._getHeaders()['Vary']).toBe('Origin');
+    expect(res._getHeaders()['Access-Control-Allow-Credentials']).toBe('true');
+    expect(mockLogEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'origin.rejected' })
+    );
+  });
+
+  it('returns 403 for a public client when Origin is not in allowedOrigins', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'pub-1',
+      isConfidential: false,
+      allowedOrigins: ['https://app.example.com'],
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { origin: 'https://evil.example.com' },
+      body: { client_id: 'pub-1', grant_type: 'authorization_code' },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect((res._getJSONData() as { error: string }).error).toBe('origin_not_allowed');
+    expect(mockOauthToken).not.toHaveBeenCalled();
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'origin.rejected', clientId: 'pub-1' })
+    );
+  });
+
+  it('returns 403 for a public client when Origin header is missing', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'pub-1',
+      isConfidential: false,
+      allowedOrigins: ['https://app.example.com'],
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {},
+      body: { client_id: 'pub-1', grant_type: 'authorization_code' },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockOauthToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps wildcard CORS for confidential clients regardless of Origin', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'conf-1',
+      isConfidential: true,
+      allowedOrigins: [],
+    });
+    mockOauthToken.mockResolvedValue({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      scope: '1',
+      user: { id: 42 },
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {},
+      body: { client_id: 'conf-1', grant_type: 'authorization_code' },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    // The stubbed addCorsHeaders always emits the wildcard.
+    expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('*');
+  });
+
+  it('keeps wildcard CORS for confidential clients even when an Origin is sent', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'conf-1',
+      isConfidential: true,
+      allowedOrigins: [],
+    });
+    mockOauthToken.mockResolvedValue({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      scope: '1',
+      user: { id: 42 },
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { origin: 'https://random.example.com' },
+      body: { client_id: 'conf-1', grant_type: 'authorization_code' },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('*');
+  });
+
+  it('returns 405 for non-POST/OPTIONS methods', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it('handles OPTIONS preflight without touching the client lookup', async () => {
+    const { req, res } = createMocks({ method: 'OPTIONS' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/api/auth/oauth/__tests__/token.test.ts
+++ b/src/pages/api/auth/oauth/__tests__/token.test.ts
@@ -127,7 +127,11 @@ describe('POST /api/auth/oauth/token — origin enforcement', () => {
     // Simulate what oauthModel.getClient does: stash the client on the
     // Request so the handler can read it back for CORS.
     mockOauthToken.mockImplementation(async (request: any) => {
-      request.oauthClient = { id: 'pub-1', isConfidential: false };
+      request.oauthClient = {
+        id: 'pub-1',
+        isConfidential: false,
+        allowedOrigins: ['https://app.example.com'],
+      };
       return {
         accessToken: 'at',
         refreshToken: 'rt',

--- a/src/pages/api/auth/oauth/__tests__/token.test.ts
+++ b/src/pages/api/auth/oauth/__tests__/token.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OriginNotAllowedError } from '~/server/oauth/errors';
 
 // Minimal NextApiRequest/Response stand-in. Same shape used in
 // retool-endpoint.test.ts so behaviour stays consistent across OAuth tests.
@@ -39,10 +40,10 @@ function createMocks({
   return { req, res };
 }
 
-const { mockFindUnique, mockOauthToken, mockLogEvent } = vi.hoisted(() => ({
-  mockFindUnique: vi.fn(),
+const { mockOauthToken, mockLogEvent, mockFindUnique } = vi.hoisted(() => ({
   mockOauthToken: vi.fn(),
   mockLogEvent: vi.fn(),
+  mockFindUnique: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('~/server/db/client', () => ({
@@ -66,8 +67,8 @@ vi.mock('~/server/oauth/constants', () => ({
   ACCESS_TOKEN_TTL: 3600,
 }));
 
-// addCorsHeaders pulls in the full server env. Stub it to a behaviour-only
-// double so we don't drag the real env loader into a unit test.
+// addCorsHeaders pulls in the full server env. Stub to behaviour-only so the
+// unit doesn't drag the real env loader in.
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   addCorsHeaders: (
     req: { method?: string },
@@ -89,10 +90,25 @@ vi.mock('request-ip', () => ({
 }));
 
 // `@node-oauth/oauth2-server` constructs Request/Response objects with internal
-// validation we don't care about for this unit. Stub them to passthrough shells.
+// validation we don't care about for this unit. Stub them to passthrough shells
+// that preserve the headers field so handler/model can read it.
 vi.mock('@node-oauth/oauth2-server', () => ({
   Request: class {
-    constructor(public init: unknown) {}
+    headers: Record<string, string>;
+    body: unknown;
+    method: string;
+    query: Record<string, string>;
+    constructor(init: {
+      headers: Record<string, string>;
+      body: unknown;
+      method: string;
+      query: Record<string, string>;
+    }) {
+      this.headers = init.headers;
+      this.body = init.body;
+      this.method = init.method;
+      this.query = init.query;
+    }
   },
   Response: class {
     constructor(public res: unknown) {}
@@ -107,18 +123,18 @@ beforeEach(() => {
 });
 
 describe('POST /api/auth/oauth/token — origin enforcement', () => {
-  it('returns 200 for a public client when Origin is in allowedOrigins', async () => {
-    mockFindUnique.mockResolvedValue({
-      id: 'pub-1',
-      isConfidential: false,
-      allowedOrigins: ['https://app.example.com'],
-    });
-    mockOauthToken.mockResolvedValue({
-      accessToken: 'at',
-      refreshToken: 'rt',
-      scope: '1',
-      user: { id: 42 },
-      accessTokenLifetime: 3600,
+  it('returns 200 + per-origin CORS for a public client on success', async () => {
+    // Simulate what oauthModel.getClient does: stash the client on the
+    // Request so the handler can read it back for CORS.
+    mockOauthToken.mockImplementation(async (request: any) => {
+      request.oauthClient = { id: 'pub-1', isConfidential: false };
+      return {
+        accessToken: 'at',
+        refreshToken: 'rt',
+        scope: '1',
+        user: { id: 42 },
+        accessTokenLifetime: 3600,
+      };
     });
 
     const { req, res } = createMocks({
@@ -131,18 +147,16 @@ describe('POST /api/auth/oauth/token — origin enforcement', () => {
     expect(res._getStatusCode()).toBe(200);
     expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('https://app.example.com');
     expect(res._getHeaders()['Vary']).toBe('Origin');
-    expect(res._getHeaders()['Access-Control-Allow-Credentials']).toBe('true');
+    expect(res._getHeaders()['Access-Control-Allow-Credentials']).toBeUndefined();
     expect(mockLogEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'origin.rejected' })
     );
   });
 
-  it('returns 403 for a public client when Origin is not in allowedOrigins', async () => {
-    mockFindUnique.mockResolvedValue({
-      id: 'pub-1',
-      isConfidential: false,
-      allowedOrigins: ['https://app.example.com'],
-    });
+  it('returns 403 + logs origin.rejected when getClient throws OriginNotAllowedError', async () => {
+    mockOauthToken.mockRejectedValue(
+      new OriginNotAllowedError('pub-1', 'https://evil.example.com')
+    );
 
     const { req, res } = createMocks({
       method: 'POST',
@@ -153,41 +167,27 @@ describe('POST /api/auth/oauth/token — origin enforcement', () => {
 
     expect(res._getStatusCode()).toBe(403);
     expect((res._getJSONData() as { error: string }).error).toBe('origin_not_allowed');
-    expect(mockOauthToken).not.toHaveBeenCalled();
+    // No CORS header set on a rejected origin — browser surfaces a network
+    // error rather than reading the 403 body.
+    expect(res._getHeaders()['Access-Control-Allow-Origin']).toBeUndefined();
     expect(mockLogEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'origin.rejected', clientId: 'pub-1' })
+      expect.objectContaining({
+        type: 'origin.rejected',
+        clientId: 'pub-1',
+        metadata: expect.objectContaining({ origin: 'https://evil.example.com', endpoint: 'token' }),
+      })
     );
   });
 
-  it('returns 403 for a public client when Origin header is missing', async () => {
-    mockFindUnique.mockResolvedValue({
-      id: 'pub-1',
-      isConfidential: false,
-      allowedOrigins: ['https://app.example.com'],
-    });
-
-    const { req, res } = createMocks({
-      method: 'POST',
-      headers: {},
-      body: { client_id: 'pub-1', grant_type: 'authorization_code' },
-    });
-    await handler(req as never, res as never);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(mockOauthToken).not.toHaveBeenCalled();
-  });
-
-  it('keeps wildcard CORS for confidential clients regardless of Origin', async () => {
-    mockFindUnique.mockResolvedValue({
-      id: 'conf-1',
-      isConfidential: true,
-      allowedOrigins: [],
-    });
-    mockOauthToken.mockResolvedValue({
-      accessToken: 'at',
-      refreshToken: 'rt',
-      scope: '1',
-      user: { id: 42 },
+  it('keeps wildcard CORS for confidential clients on success', async () => {
+    mockOauthToken.mockImplementation(async (request: any) => {
+      request.oauthClient = { id: 'conf-1', isConfidential: true };
+      return {
+        accessToken: 'at',
+        refreshToken: 'rt',
+        scope: '1',
+        user: { id: 42 },
+      };
     });
 
     const { req, res } = createMocks({
@@ -198,21 +198,18 @@ describe('POST /api/auth/oauth/token — origin enforcement', () => {
     await handler(req as never, res as never);
 
     expect(res._getStatusCode()).toBe(200);
-    // The stubbed addCorsHeaders always emits the wildcard.
     expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('*');
   });
 
   it('keeps wildcard CORS for confidential clients even when an Origin is sent', async () => {
-    mockFindUnique.mockResolvedValue({
-      id: 'conf-1',
-      isConfidential: true,
-      allowedOrigins: [],
-    });
-    mockOauthToken.mockResolvedValue({
-      accessToken: 'at',
-      refreshToken: 'rt',
-      scope: '1',
-      user: { id: 42 },
+    mockOauthToken.mockImplementation(async (request: any) => {
+      request.oauthClient = { id: 'conf-1', isConfidential: true };
+      return {
+        accessToken: 'at',
+        refreshToken: 'rt',
+        scope: '1',
+        user: { id: 42 },
+      };
     });
 
     const { req, res } = createMocks({
@@ -226,16 +223,66 @@ describe('POST /api/auth/oauth/token — origin enforcement', () => {
     expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('*');
   });
 
+  it('falls back to wildcard CORS on non-origin errors so callers can read the error body', async () => {
+    const err = Object.assign(new Error('Invalid grant'), {
+      name: 'invalid_grant',
+      statusCode: 400,
+    });
+    mockOauthToken.mockRejectedValue(err);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {},
+      body: { client_id: 'conf-1', grant_type: 'authorization_code' },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('*');
+    expect((res._getJSONData() as { error: string }).error).toBe('invalid_grant');
+  });
+
   it('returns 405 for non-POST/OPTIONS methods', async () => {
     const { req, res } = createMocks({ method: 'GET' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(405);
   });
 
-  it('handles OPTIONS preflight without touching the client lookup', async () => {
+  it('handles OPTIONS preflight without invoking the OAuth server', async () => {
     const { req, res } = createMocks({ method: 'OPTIONS' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(200);
-    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(mockOauthToken).not.toHaveBeenCalled();
+  });
+
+  it('fails closed with a fallback lookup if the OAuth library skipped stashing', async () => {
+    // Simulate a library/grant where getClient didn't run with our wiring —
+    // no oauthClient is attached. Handler must do a fallback DB lookup and
+    // pick the correct CORS policy rather than defaulting to wildcard.
+    mockOauthToken.mockResolvedValue({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      scope: '1',
+      user: { id: 42 },
+      accessTokenLifetime: 3600,
+    });
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'pub-1',
+      isConfidential: false,
+      allowedOrigins: ['https://app.example.com'],
+    });
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { origin: 'https://app.example.com' },
+      body: { client_id: 'pub-1', grant_type: 'authorization_code' },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'pub-1' } })
+    );
+    expect(res._getHeaders()['Access-Control-Allow-Origin']).toBe('https://app.example.com');
   });
 });

--- a/src/pages/api/auth/oauth/authorize.ts
+++ b/src/pages/api/auth/oauth/authorize.ts
@@ -23,11 +23,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    // User must be authenticated (via session cookie)
+    // User must be authenticated (via session cookie).
+    // Use 303 so a POST from the consent form is downgraded to a GET to /login —
+    // Next.js's res.redirect() defaults to 307 which would preserve the POST method.
     const session = await getServerAuthSession({ req, res });
     if (!session?.user) {
       const returnUrl = encodeURIComponent(req.url ?? '/');
-      return res.redirect(`/login?returnUrl=${returnUrl}`);
+      return res.redirect(303, `/login?returnUrl=${returnUrl}`);
     }
 
     // Rate limit by user ID
@@ -141,12 +143,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
       }
     } else if (!existingConsent || existingConsent.scope !== requestedScope) {
-      // No prior consent (or scope changed) — redirect to consent page
+      // No prior consent (or scope changed) — redirect to consent page.
+      // Use 303 so the browser always follows with GET, matching the consent
+      // page's expectation of query-string params (regardless of how we arrived).
       const consentUrl = new URL('/login/oauth/authorize', process.env.NEXTAUTH_URL);
       for (const [key, value] of Object.entries(params)) {
         if (typeof value === 'string') consentUrl.searchParams.set(key, value);
       }
-      return res.redirect(consentUrl.toString());
+      return res.redirect(303, consentUrl.toString());
     }
 
     // Issue authorization code
@@ -176,11 +180,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ip,
     });
 
-    // Use validated redirect_uri (from our check, not raw params)
+    // Use validated redirect_uri (from our check, not raw params).
+    // RFC 6749 §4.1.2 specifies a GET redirect back to the client. Next.js's
+    // res.redirect() defaults to 307, which preserves the POST method and 405s
+    // on standard OAuth callbacks that only define GET handlers — so force 303
+    // to coerce the browser to GET the redirect_uri.
     const redirectUrl = new URL(redirectUri);
     redirectUrl.searchParams.set('code', code.authorizationCode);
     redirectUrl.searchParams.set('state', params.state as string);
-    return res.redirect(redirectUrl.toString());
+    return res.redirect(303, redirectUrl.toString());
   } catch (err: any) {
     const status = err.statusCode || err.code || 500;
     return res.status(typeof status === 'number' ? status : 500).json({

--- a/src/pages/api/auth/oauth/authorize.ts
+++ b/src/pages/api/auth/oauth/authorize.ts
@@ -29,7 +29,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const session = await getServerAuthSession({ req, res });
     if (!session?.user) {
       const returnUrl = encodeURIComponent(req.url ?? '/');
-      return res.redirect(303, `/login?returnUrl=${returnUrl}`);
+      // Don't `return res.redirect(...)` — res.redirect returns the res
+      // object, and a non-undefined handler return value triggers Next.js's
+      // "API handler should not return a value, received object" warning.
+      res.redirect(303, `/login?returnUrl=${returnUrl}`);
+      return;
     }
 
     // Rate limit by user ID
@@ -150,7 +154,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       for (const [key, value] of Object.entries(params)) {
         if (typeof value === 'string') consentUrl.searchParams.set(key, value);
       }
-      return res.redirect(303, consentUrl.toString());
+      res.redirect(303, consentUrl.toString());
+      return;
     }
 
     // Issue authorization code
@@ -188,7 +193,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const redirectUrl = new URL(redirectUri);
     redirectUrl.searchParams.set('code', code.authorizationCode);
     redirectUrl.searchParams.set('state', params.state as string);
-    return res.redirect(303, redirectUrl.toString());
+    res.redirect(303, redirectUrl.toString());
+    return;
   } catch (err: any) {
     const status = err.statusCode || err.code || 500;
     return res.status(typeof status === 'number' ? status : 500).json({

--- a/src/pages/api/auth/oauth/revoke.ts
+++ b/src/pages/api/auth/oauth/revoke.ts
@@ -48,7 +48,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // Public clients with an Origin header must match the registered allowlist.
   // A missing Origin is allowed (native/mobile public clients don't send
-  // one); same policy as oauthModel.getClient on /token.
+  // one); same policy as oauthModel.getClient on /token. Defense-in-depth:
+  // we check `client.allowedOrigins.includes(origin)` here too — the echo
+  // below should never go out for an unverified origin.
   if (client && !client.isConfidential && origin) {
     if (!client.allowedOrigins.includes(origin)) {
       logOAuthEvent({

--- a/src/pages/api/auth/oauth/revoke.ts
+++ b/src/pages/api/auth/oauth/revoke.ts
@@ -11,8 +11,8 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
 
-  // Preflights stay permissive — we can't know whether the caller is public
-  // or confidential until we see the client_id on the actual POST.
+  // Preflight stays permissive — we can't classify the caller until we see the
+  // client_id on the actual POST.
   if (req.method === 'OPTIONS') {
     const shouldStop = addCorsHeaders(req, res, ['POST']);
     if (shouldStop) return;
@@ -23,40 +23,56 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const { token, token_type_hint, client_id, client_secret } = req.body;
+  const ip = requestIp.getClientIp(req) ?? 'unknown';
 
-  // Mirror the token endpoint: public clients must come from a registered
-  // origin. Confidential clients keep the existing wildcard CORS.
-  let isConfidentialClient = true;
-  if (typeof client_id === 'string') {
-    const lookedUp = await dbRead.oauthClient.findUnique({
-      where: { id: client_id },
-      select: { id: true, isConfidential: true, allowedOrigins: true },
-    });
-    if (lookedUp) {
-      isConfidentialClient = lookedUp.isConfidential;
-      if (!lookedUp.isConfidential) {
-        if (!origin || !lookedUp.allowedOrigins.includes(origin)) {
-          logOAuthEvent({
-            type: 'origin.rejected',
-            clientId: lookedUp.id,
-            ip: requestIp.getClientIp(req) ?? undefined,
-            metadata: { origin: origin ?? null, endpoint: 'revoke' },
-          });
-          return res.status(403).json({
-            error: 'origin_not_allowed',
-            error_description:
-              'Origin is not in the registered allowedOrigins for this client.',
-          });
-        }
-        res.setHeader('Access-Control-Allow-Origin', origin);
-        res.setHeader('Vary', 'Origin');
-        res.setHeader('Access-Control-Allow-Credentials', 'true');
-        res.setHeader('Access-Control-Allow-Headers', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'POST');
-      }
+  // Rate-limit by IP before any DB work so a malicious origin can't drive cost
+  // via repeated lookups + audit-log writes.
+  const allowed = await checkOAuthRateLimit(req, res, 'revoke', ip);
+  if (!allowed) return sendRateLimitResponse(res);
+
+  // Single lookup covers both origin enforcement (public clients) and secret
+  // validation (confidential clients without an authenticated session).
+  const client =
+    typeof client_id === 'string'
+      ? await dbRead.oauthClient.findUnique({
+          where: { id: client_id },
+          select: {
+            id: true,
+            userId: true,
+            secret: true,
+            isConfidential: true,
+            allowedOrigins: true,
+          },
+        })
+      : null;
+
+  // Public clients with an Origin header must match the registered allowlist.
+  // A missing Origin is allowed (native/mobile public clients don't send
+  // one); same policy as oauthModel.getClient on /token.
+  if (client && !client.isConfidential && origin) {
+    if (!client.allowedOrigins.includes(origin)) {
+      logOAuthEvent({
+        type: 'origin.rejected',
+        clientId: client.id,
+        ip,
+        metadata: { origin, endpoint: 'revoke' },
+      });
+      return res.status(403).json({
+        error: 'origin_not_allowed',
+        error_description:
+          'Origin is not in the registered allowedOrigins for this client.',
+      });
     }
-  }
-  if (isConfidentialClient) {
+    // Per-origin CORS for approved public-client browser callers. No
+    // Allow-Credentials — public clients use Bearer tokens, not cookies.
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Headers', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST');
+  } else {
+    // Confidential, unknown, or no-Origin (native) caller — keep wildcard
+    // CORS. Native callers ignore CORS; browser callers without an Origin
+    // header are non-XHR and don't read response headers anyway.
     addCorsHeaders(req, res, ['POST']);
   }
 
@@ -66,28 +82,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .json({ error: 'invalid_request', error_description: 'Missing token parameter' });
   }
 
-  // Authenticate the caller — require either a valid session or client credentials
+  // Authenticate the caller — require either a valid session or client credentials.
   const session = await getServerAuthSession({ req, res });
   let authenticatedUserId: number | null = session?.user?.id ?? null;
 
-  // If no session, require client_id + client_secret
-  if (!authenticatedUserId && client_id) {
-    const client = await dbWrite.oauthClient.findUnique({
-      where: { id: client_id },
-      select: { userId: true, secret: true, isConfidential: true },
-    });
-    if (client?.isConfidential && client.secret && client_secret) {
-      const hashedSecret = generateSecretHash(client_secret);
-      if (timingSafeEqual(Buffer.from(hashedSecret), Buffer.from(client.secret))) {
-        authenticatedUserId = client.userId;
-      }
+  if (
+    !authenticatedUserId &&
+    client?.isConfidential &&
+    client.secret &&
+    client_secret
+  ) {
+    const hashedSecret = generateSecretHash(client_secret);
+    if (timingSafeEqual(Buffer.from(hashedSecret), Buffer.from(client.secret))) {
+      authenticatedUserId = client.userId;
     }
   }
-
-  // Rate limit by IP (not client_id, to prevent bypass)
-  const ip = requestIp.getClientIp(req) ?? 'unknown';
-  const allowed = await checkOAuthRateLimit(req, res, 'revoke', ip);
-  if (!allowed) return sendRateLimitResponse(res);
 
   try {
     const hash = generateSecretHash(token);

--- a/src/pages/api/auth/oauth/revoke.ts
+++ b/src/pages/api/auth/oauth/revoke.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { timingSafeEqual } from 'crypto';
 import requestIp from 'request-ip';
-import { dbWrite } from '~/server/db/client';
+import { dbRead, dbWrite } from '~/server/db/client';
 import { generateSecretHash } from '~/server/utils/key-generator';
 import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
@@ -9,14 +9,56 @@ import { logOAuthEvent } from '~/server/oauth/audit-log';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const shouldStop = addCorsHeaders(req, res, ['POST']);
-  if (shouldStop) return;
+  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
+
+  // Preflights stay permissive — we can't know whether the caller is public
+  // or confidential until we see the client_id on the actual POST.
+  if (req.method === 'OPTIONS') {
+    const shouldStop = addCorsHeaders(req, res, ['POST']);
+    if (shouldStop) return;
+  }
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
   const { token, token_type_hint, client_id, client_secret } = req.body;
+
+  // Mirror the token endpoint: public clients must come from a registered
+  // origin. Confidential clients keep the existing wildcard CORS.
+  let isConfidentialClient = true;
+  if (typeof client_id === 'string') {
+    const lookedUp = await dbRead.oauthClient.findUnique({
+      where: { id: client_id },
+      select: { id: true, isConfidential: true, allowedOrigins: true },
+    });
+    if (lookedUp) {
+      isConfidentialClient = lookedUp.isConfidential;
+      if (!lookedUp.isConfidential) {
+        if (!origin || !lookedUp.allowedOrigins.includes(origin)) {
+          logOAuthEvent({
+            type: 'origin.rejected',
+            clientId: lookedUp.id,
+            ip: requestIp.getClientIp(req) ?? undefined,
+            metadata: { origin: origin ?? null, endpoint: 'revoke' },
+          });
+          return res.status(403).json({
+            error: 'origin_not_allowed',
+            error_description:
+              'Origin is not in the registered allowedOrigins for this client.',
+          });
+        }
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Vary', 'Origin');
+        res.setHeader('Access-Control-Allow-Credentials', 'true');
+        res.setHeader('Access-Control-Allow-Headers', '*');
+        res.setHeader('Access-Control-Allow-Methods', 'POST');
+      }
+    }
+  }
+  if (isConfidentialClient) {
+    addCorsHeaders(req, res, ['POST']);
+  }
 
   if (!token) {
     return res

--- a/src/pages/api/auth/oauth/token.ts
+++ b/src/pages/api/auth/oauth/token.ts
@@ -79,7 +79,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           : null;
       attached = fallback ?? undefined;
     }
-    if (attached && !attached.isConfidential && origin) {
+    // Defense-in-depth: only echo the request Origin when it's actually in
+    // the client's allowlist. `oauthModel.getClient` already throws
+    // OriginNotAllowedError on a mismatch, so on the normal success path this
+    // is redundant — but if the fallback dbRead path runs (library wiring
+    // change) or anything else slips through, we don't want to echo an
+    // unverified origin and defeat the new pinning.
+    if (
+      attached &&
+      !attached.isConfidential &&
+      origin &&
+      attached.allowedOrigins.includes(origin)
+    ) {
       setPublicClientCors(res, origin);
     } else {
       addCorsHeaders(req, res, ['POST']);
@@ -124,6 +135,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // wildcard CORS so confidential / unknown-client callers can read the
     // structured error body. Public clients lose the ability to read the body
     // cross-origin here, but error bodies don't leak token material.
+    console.error('[oauth/token] handler error:', err);
     addCorsHeaders(req, res, ['POST']);
     const status = err.statusCode || err.code || 500;
     return res.status(typeof status === 'number' ? status : 500).json({

--- a/src/pages/api/auth/oauth/token.ts
+++ b/src/pages/api/auth/oauth/token.ts
@@ -6,38 +6,29 @@ import { dbRead } from '~/server/db/client';
 import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { OriginNotAllowedError } from '~/server/oauth/errors';
 import { ACCESS_TOKEN_TTL } from '~/server/oauth/constants';
 
 /**
- * Set per-origin CORS headers for a validated public client. Public clients
- * have no client_secret, so the browser Origin is the only signal that lets
- * us refuse a code-exchange attempt from an unregistered site after a code
- * has been intercepted. The wildcard CORS we use for confidential clients
- * would defeat that, hence the explicit echo here.
+ * Per-origin CORS for a validated public client. The browser Origin is the
+ * only signal that lets us refuse a code-exchange attempt from an unregistered
+ * site after a code has been intercepted, so the wildcard CORS we keep for
+ * confidential clients would defeat that — hence the explicit echo here.
+ *
+ * No `Access-Control-Allow-Credentials`: public OAuth clients use Bearer
+ * tokens, not cookies, and dropping it reduces the chance that civitai session
+ * cookies are sent cross-origin if an SPA opts into `credentials: 'include'`.
  */
-function setPublicClientCors(req: NextApiRequest, res: NextApiResponse, origin: string) {
+function setPublicClientCors(res: NextApiResponse, origin: string) {
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Vary', 'Origin');
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Headers', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST');
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
-
-  // The token endpoint is called from third-party origins. For confidential
-  // clients we keep the existing wildcard CORS — `client_secret` is the auth
-  // boundary, the browser can't see it, and any extra browser-side restriction
-  // would just break legitimate server-to-server callers that still happen to
-  // send an Origin. For public clients we replace `*` with the validated
-  // Origin so the browser refuses cross-origin token exchanges that don't
-  // match the registered allowlist.
-  //
-  // We can't know confidential-vs-public until we've looked up the client by
-  // id, which we can only do for the actual POST (the preflight has no body).
-  // So preflight stays permissive; the real request does the per-client work
-  // below.
+  // Preflight stays permissive — we can't classify confidential vs public
+  // until we see the client_id on the actual POST.
   if (req.method === 'OPTIONS') {
     const shouldStop = addCorsHeaders(req, res, ['POST']);
     if (shouldStop) return;
@@ -49,63 +40,50 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const clientId = req.body?.client_id ?? 'unknown';
   const ip = requestIp.getClientIp(req) ?? '';
+  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
 
-  // Rate limit by client_id (runs before the origin check so a malicious
-  // origin can't bypass the limiter by being rejected early).
-  const allowed = await checkOAuthRateLimit(req, res, 'token', clientId);
+  // Rate-limit by IP before any DB work. Keying on client_id would let an
+  // attacker rotate through random ids to get a fresh bucket each request,
+  // bypassing the limiter and driving unbounded model-layer lookups.
+  const allowed = await checkOAuthRateLimit(req, res, 'token', ip || 'unknown');
   if (!allowed) return sendRateLimitResponse(res);
 
-  // Look up the client up front so we can tailor CORS + origin enforcement
-  // to its type. A miss here falls through to oauthServer.token which will
-  // produce the canonical `invalid_client` error.
-  let isConfidential = true;
-  if (typeof clientId === 'string' && clientId !== 'unknown') {
-    const client = await dbRead.oauthClient.findUnique({
-      where: { id: clientId },
-      select: { id: true, isConfidential: true, allowedOrigins: true },
-    });
-    if (client) {
-      isConfidential = client.isConfidential;
-      if (!client.isConfidential) {
-        if (!origin || !client.allowedOrigins.includes(origin)) {
-          logOAuthEvent({
-            type: 'origin.rejected',
-            clientId: client.id,
-            ip,
-            metadata: { origin: origin ?? null, endpoint: 'token' },
-          });
-          // No CORS headers on rejection — the browser will surface a network
-          // error to the offending page rather than a structured 403, which is
-          // the intended UX for an unregistered origin.
-          return res.status(403).json({
-            error: 'origin_not_allowed',
-            error_description:
-              'Origin is not in the registered allowedOrigins for this client.',
-          });
-        }
-        // Per-origin CORS for approved public clients.
-        setPublicClientCors(req, res, origin);
-      }
-    }
-  }
-
-  // Confidential clients (or unknown client_id — let the OAuth server emit
-  // the canonical error) keep the existing wildcard CORS behaviour.
-  if (isConfidential) {
-    addCorsHeaders(req, res, ['POST']);
-  }
+  const request = new Request({
+    method: req.method,
+    headers: req.headers as Record<string, string>,
+    query: req.query as Record<string, string>,
+    body: req.body,
+  });
+  const response = new Response(res);
 
   try {
-    const request = new Request({
-      method: req.method,
-      headers: req.headers as Record<string, string>,
-      query: req.query as Record<string, string>,
-      body: req.body,
-    });
-
-    const response = new Response(res);
-
     const token = await oauthServer.token(request, response);
+
+    // `oauthModel.getClient` attaches the looked-up client to the Request so
+    // the handler can drive CORS without a second DB lookup. If the stash is
+    // missing on a successful token grant something has changed inside the
+    // OAuth library (e.g. a new grant type that doesn't go through getClient
+    // with our wiring), so fail-closed with a fallback lookup rather than
+    // defaulting to wildcard CORS and risking a cross-origin leak of a
+    // public-client token response.
+    let attached = (request as Request & {
+      oauthClient?: { id: string; isConfidential: boolean; allowedOrigins: string[] };
+    }).oauthClient;
+    if (!attached) {
+      const fallback =
+        typeof clientId === 'string' && clientId !== 'unknown'
+          ? await dbRead.oauthClient.findUnique({
+              where: { id: clientId },
+              select: { id: true, isConfidential: true, allowedOrigins: true },
+            })
+          : null;
+      attached = fallback ?? undefined;
+    }
+    if (attached && !attached.isConfidential && origin) {
+      setPublicClientCors(res, origin);
+    } else {
+      addCorsHeaders(req, res, ['POST']);
+    }
 
     const grantType = req.body?.grant_type;
     logOAuthEvent({
@@ -126,6 +104,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       scope: token.scope,
     });
   } catch (err: any) {
+    if (err instanceof OriginNotAllowedError) {
+      logOAuthEvent({
+        type: 'origin.rejected',
+        clientId: err.clientId,
+        ip,
+        metadata: { origin: err.origin ?? null, endpoint: 'token' },
+      });
+      // Intentionally no CORS on a rejected origin — the browser surfaces a
+      // network error to the offending page rather than a structured 403,
+      // which is the intended UX for unregistered origins.
+      return res.status(403).json({
+        error: 'origin_not_allowed',
+        error_description: err.message,
+      });
+    }
+
+    // Other errors (invalid_grant, invalid_client, server_error) — default to
+    // wildcard CORS so confidential / unknown-client callers can read the
+    // structured error body. Public clients lose the ability to read the body
+    // cross-origin here, but error bodies don't leak token material.
+    addCorsHeaders(req, res, ['POST']);
     const status = err.statusCode || err.code || 500;
     return res.status(typeof status === 'number' ? status : 500).json({
       error: err.name || 'server_error',

--- a/src/pages/api/auth/oauth/token.ts
+++ b/src/pages/api/auth/oauth/token.ts
@@ -2,15 +2,46 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { Request, Response } from '@node-oauth/oauth2-server';
 import requestIp from 'request-ip';
 import { oauthServer } from '~/server/oauth/server';
+import { dbRead } from '~/server/db/client';
 import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
 import { ACCESS_TOKEN_TTL } from '~/server/oauth/constants';
 
+/**
+ * Set per-origin CORS headers for a validated public client. Public clients
+ * have no client_secret, so the browser Origin is the only signal that lets
+ * us refuse a code-exchange attempt from an unregistered site after a code
+ * has been intercepted. The wildcard CORS we use for confidential clients
+ * would defeat that, hence the explicit echo here.
+ */
+function setPublicClientCors(req: NextApiRequest, res: NextApiResponse, origin: string) {
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+  res.setHeader('Access-Control-Allow-Headers', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST');
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  // Token endpoint needs permissive CORS (called from third-party domains)
-  const shouldStop = addCorsHeaders(req, res, ['POST']);
-  if (shouldStop) return;
+  const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
+
+  // The token endpoint is called from third-party origins. For confidential
+  // clients we keep the existing wildcard CORS — `client_secret` is the auth
+  // boundary, the browser can't see it, and any extra browser-side restriction
+  // would just break legitimate server-to-server callers that still happen to
+  // send an Origin. For public clients we replace `*` with the validated
+  // Origin so the browser refuses cross-origin token exchanges that don't
+  // match the registered allowlist.
+  //
+  // We can't know confidential-vs-public until we've looked up the client by
+  // id, which we can only do for the actual POST (the preflight has no body).
+  // So preflight stays permissive; the real request does the per-client work
+  // below.
+  if (req.method === 'OPTIONS') {
+    const shouldStop = addCorsHeaders(req, res, ['POST']);
+    if (shouldStop) return;
+  }
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -19,9 +50,50 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const clientId = req.body?.client_id ?? 'unknown';
   const ip = requestIp.getClientIp(req) ?? '';
 
-  // Rate limit by client_id
+  // Rate limit by client_id (runs before the origin check so a malicious
+  // origin can't bypass the limiter by being rejected early).
   const allowed = await checkOAuthRateLimit(req, res, 'token', clientId);
   if (!allowed) return sendRateLimitResponse(res);
+
+  // Look up the client up front so we can tailor CORS + origin enforcement
+  // to its type. A miss here falls through to oauthServer.token which will
+  // produce the canonical `invalid_client` error.
+  let isConfidential = true;
+  if (typeof clientId === 'string' && clientId !== 'unknown') {
+    const client = await dbRead.oauthClient.findUnique({
+      where: { id: clientId },
+      select: { id: true, isConfidential: true, allowedOrigins: true },
+    });
+    if (client) {
+      isConfidential = client.isConfidential;
+      if (!client.isConfidential) {
+        if (!origin || !client.allowedOrigins.includes(origin)) {
+          logOAuthEvent({
+            type: 'origin.rejected',
+            clientId: client.id,
+            ip,
+            metadata: { origin: origin ?? null, endpoint: 'token' },
+          });
+          // No CORS headers on rejection — the browser will surface a network
+          // error to the offending page rather than a structured 403, which is
+          // the intended UX for an unregistered origin.
+          return res.status(403).json({
+            error: 'origin_not_allowed',
+            error_description:
+              'Origin is not in the registered allowedOrigins for this client.',
+          });
+        }
+        // Per-origin CORS for approved public clients.
+        setPublicClientCors(req, res, origin);
+      }
+    }
+  }
+
+  // Confidential clients (or unknown client_id — let the OAuth server emit
+  // the canonical error) keep the existing wildcard CORS behaviour.
+  if (isConfidential) {
+    addCorsHeaders(req, res, ['POST']);
+  }
 
   try {
     const request = new Request({

--- a/src/server/oauth/__tests__/model.test.ts
+++ b/src/server/oauth/__tests__/model.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OriginNotAllowedError } from '~/server/oauth/errors';
+
+const { mockFindUnique } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { oauthClient: { findUnique: mockFindUnique } },
+  dbWrite: { apiKey: {} },
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: { packed: {}, hExpire: vi.fn(), hDel: vi.fn() },
+  REDIS_KEYS: { OAUTH: {} },
+}));
+
+vi.mock('~/server/utils/key-generator', () => ({
+  generateSecretHash: (s: string) => `hash:${s}`,
+}));
+
+vi.mock('~/server/oauth/constants', () => ({
+  ACCESS_TOKEN_TTL: 3600,
+  AUTH_CODE_TTL: 600,
+  REFRESH_TOKEN_TTL: 2592000,
+}));
+
+vi.mock('~/server/oauth/token-helpers', () => ({
+  createOAuthTokenPair: vi.fn(),
+}));
+
+vi.mock('~/shared/utils/flags', () => ({ Flags: { hasFlag: () => true } }));
+vi.mock('~/shared/constants/token-scope.constants', () => ({ TokenScope: { Full: 33554431 } }));
+
+import { oauthModel } from '../model';
+
+const baseClient = {
+  id: 'pub-1',
+  isConfidential: false,
+  secret: null,
+  grants: ['authorization_code', 'refresh_token'],
+  redirectUris: ['https://app.example.com/cb'],
+  allowedOrigins: ['https://app.example.com'],
+  allowedScopes: 33554431,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// Token-exchange requests are detected by the presence of `grant_type` in
+// the body. Authorize-flow requests have `response_type` instead.
+const tokenExchangeBody = { grant_type: 'authorization_code', code: 'abc' };
+const authorizeBody = { response_type: 'code', code_challenge: 'x' };
+
+describe('oauthModel.getClient — origin enforcement', () => {
+  it('returns enriched Client and stashes record on Request when origin matches', async () => {
+    mockFindUnique.mockResolvedValue(baseClient);
+    const request: any = {
+      headers: { origin: 'https://app.example.com' },
+      body: tokenExchangeBody,
+    };
+
+    const client = await oauthModel.getClient('pub-1', null, request);
+
+    expect(client).toMatchObject({ id: 'pub-1', isConfidential: false });
+    expect(request.oauthClient).toMatchObject({
+      id: 'pub-1',
+      allowedOrigins: ['https://app.example.com'],
+    });
+  });
+
+  it('throws OriginNotAllowedError when public client Origin is not allowlisted', async () => {
+    mockFindUnique.mockResolvedValue(baseClient);
+    const request: any = {
+      headers: { origin: 'https://evil.example.com' },
+      body: tokenExchangeBody,
+    };
+
+    await expect(oauthModel.getClient('pub-1', null, request)).rejects.toBeInstanceOf(
+      OriginNotAllowedError
+    );
+  });
+
+  it('allows public client request with no Origin header (native/mobile path)', async () => {
+    // Native/mobile public clients don't send an Origin. We still want them
+    // to share an OAuth client with their browser SPA counterpart so the
+    // end user only consents once.
+    mockFindUnique.mockResolvedValue(baseClient);
+    const request: any = { headers: {}, body: tokenExchangeBody };
+
+    const client = await oauthModel.getClient('pub-1', null, request);
+    expect(client).toMatchObject({ id: 'pub-1', isConfidential: false });
+  });
+
+  it('throws OriginNotAllowedError when a browser sends an Origin not on the allowlist (empty allowlist)', async () => {
+    // Owner registered no origins but a browser still calls in with one —
+    // can't be a legitimate registered SPA, reject.
+    mockFindUnique.mockResolvedValue({ ...baseClient, allowedOrigins: [] });
+    const request: any = {
+      headers: { origin: 'https://random.example.com' },
+      body: tokenExchangeBody,
+    };
+
+    await expect(oauthModel.getClient('pub-1', null, request)).rejects.toBeInstanceOf(
+      OriginNotAllowedError
+    );
+  });
+
+  it('skips origin enforcement for confidential clients', async () => {
+    mockFindUnique.mockResolvedValue({
+      ...baseClient,
+      isConfidential: true,
+      secret: 'hash:s3cret',
+      allowedOrigins: [],
+    });
+    const request: any = {
+      headers: { origin: 'https://random.example.com' },
+      body: tokenExchangeBody,
+    };
+
+    const client = await oauthModel.getClient('conf-1', 's3cret', request);
+    expect(client).toMatchObject({ isConfidential: true });
+  });
+
+  it('skips origin enforcement when called without a request (legacy authorize callers)', async () => {
+    mockFindUnique.mockResolvedValue(baseClient);
+
+    const client = await oauthModel.getClient('pub-1', null);
+    expect(client).toMatchObject({ id: 'pub-1' });
+  });
+
+  it('allows native client with no Origin even when allowlist is empty', async () => {
+    // No allowlist configured + no Origin (native PKCE call) — must pass.
+    mockFindUnique.mockResolvedValue({ ...baseClient, allowedOrigins: [] });
+    const request: any = { headers: {}, body: tokenExchangeBody };
+
+    const client = await oauthModel.getClient('native-1', null, request);
+    expect(client).toMatchObject({ id: 'pub-1', isConfidential: false });
+  });
+
+  it('skips origin enforcement on the authorize flow (no grant_type in body)', async () => {
+    mockFindUnique.mockResolvedValue(baseClient);
+    // /authorize constructs a synthetic Request with no Origin header. The
+    // public-client check must not fire here — the flow is a top-level
+    // browser nav, not an XHR.
+    const request: any = {
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: authorizeBody,
+    };
+
+    const client = await oauthModel.getClient('pub-1', null, request);
+    expect(client).toMatchObject({ id: 'pub-1', isConfidential: false });
+  });
+
+  it('returns false when the client does not exist', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const client = await oauthModel.getClient('nope', null, { headers: {} } as any);
+    expect(client).toBe(false);
+  });
+
+  it('returns false for confidential client with wrong secret', async () => {
+    mockFindUnique.mockResolvedValue({
+      ...baseClient,
+      isConfidential: true,
+      secret: 'hash:right',
+    });
+    const client = await oauthModel.getClient('conf-1', 'wrong', { headers: {} } as any);
+    expect(client).toBe(false);
+  });
+});

--- a/src/server/oauth/audit-log.ts
+++ b/src/server/oauth/audit-log.ts
@@ -9,7 +9,8 @@ export type OAuthEventType =
   | 'authorization.denied'
   | 'token.issued'
   | 'token.refreshed'
-  | 'token.revoked';
+  | 'token.revoked'
+  | 'origin.rejected';
 
 interface OAuthAuditEvent {
   type: OAuthEventType;

--- a/src/server/oauth/errors.ts
+++ b/src/server/oauth/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Thrown from `oauthModel.getClient` when a public client's request Origin
+ * isn't in the client's registered `allowedOrigins`. Caught by the /token
+ * handler to emit a structured 403 + `origin.rejected` audit log without a
+ * pre-library DB lookup.
+ */
+export class OriginNotAllowedError extends Error {
+  constructor(public clientId: string, public origin: string | undefined) {
+    super('Origin is not in the registered allowedOrigins for this client.');
+    this.name = 'OriginNotAllowedError';
+  }
+}

--- a/src/server/oauth/model.ts
+++ b/src/server/oauth/model.ts
@@ -77,7 +77,9 @@ export const oauthModel = {
     // server-side with synthetic headers) but it's a top-level browser nav,
     // not an XHR, so PKCE alone handles its security boundary. Detect
     // token-exchange by the presence of `grant_type` in the request body —
-    // only set on /token and /revoke.
+    // set on /api/auth/oauth/token requests. /revoke uses
+    // `token`/`token_type_hint` per RFC 7009 and doesn't go through this
+    // model at all (it's hand-coded against dbRead.oauthClient directly).
     const body = request ? (request as Request & { body?: unknown }).body : undefined;
     const isTokenExchange =
       body !== null &&

--- a/src/server/oauth/model.ts
+++ b/src/server/oauth/model.ts
@@ -2,6 +2,7 @@ import type {
   AuthorizationCode,
   Client,
   RefreshToken,
+  Request,
   Token,
   User,
 } from '@node-oauth/oauth2-server';
@@ -13,6 +14,7 @@ import { Flags } from '~/shared/utils/flags';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { ACCESS_TOKEN_TTL, AUTH_CODE_TTL, REFRESH_TOKEN_TTL } from './constants';
 import { createOAuthTokenPair } from './token-helpers';
+import { OriginNotAllowedError } from './errors';
 
 /** Hash auth code for Redis storage (separate from API key hashing) */
 function hashCode(code: string): string {
@@ -36,7 +38,11 @@ function stringToScope(scope: string | string[] | undefined): number {
 export const oauthModel = {
   // ─── Client ─────────────────────────────────────────────────
 
-  async getClient(clientId: string, clientSecret: string | null): Promise<Client | false> {
+  async getClient(
+    clientId: string,
+    clientSecret: string | null,
+    request?: Request
+  ): Promise<Client | false> {
     const client = await dbRead.oauthClient.findUnique({ where: { id: clientId } });
     if (!client) return false;
 
@@ -50,6 +56,47 @@ export const oauthModel = {
         const hashedSecret = generateSecretHash(clientSecret);
         if (!timingSafeEqual(Buffer.from(hashedSecret), Buffer.from(client.secret))) return false;
       }
+    }
+
+    // For public clients on the token-exchange path, enforce the per-client
+    // origin allowlist — but only when the request actually carries an
+    // Origin header. Confidential clients skip this entirely; their auth
+    // boundary is `client_secret`, not the browser.
+    //
+    // Policy: an Origin that *is* sent must be in the registered allowlist.
+    // A missing Origin is allowed because:
+    //   - Native/mobile PKCE clients don't send one — they're public clients
+    //     too and must work through the same /token endpoint as browser SPAs.
+    //   - A browser that mysteriously strips its own Origin is already
+    //     compromised at a level where this check can't help.
+    // This also lets a single OAuth client back both a browser SPA (covered
+    // by the allowlist) and a native app (covered by the no-Origin branch)
+    // so end users don't have to consent twice.
+    //
+    // The /authorize flow also calls getClient with a Request (constructed
+    // server-side with synthetic headers) but it's a top-level browser nav,
+    // not an XHR, so PKCE alone handles its security boundary. Detect
+    // token-exchange by the presence of `grant_type` in the request body —
+    // only set on /token and /revoke.
+    const body = request ? (request as Request & { body?: unknown }).body : undefined;
+    const isTokenExchange =
+      body !== null &&
+      typeof body === 'object' &&
+      typeof (body as { grant_type?: unknown }).grant_type === 'string';
+    if (request && !client.isConfidential && isTokenExchange) {
+      const headers = (request as Request).headers;
+      const origin =
+        headers && typeof headers.origin === 'string' ? (headers.origin as string) : undefined;
+      if (origin && !client.allowedOrigins.includes(origin)) {
+        throw new OriginNotAllowedError(client.id, origin);
+      }
+    }
+
+    // Stash the looked-up client on the Request so the handler can drive
+    // post-success CORS without a second DB lookup. The OAuth library treats
+    // `request` as an opaque carrier, so attaching a property is safe.
+    if (request) {
+      (request as Request & { oauthClient?: typeof client }).oauthClient = client;
     }
 
     return {

--- a/src/server/routers/oauth-client.router.ts
+++ b/src/server/routers/oauth-client.router.ts
@@ -7,6 +7,7 @@ import { logOAuthEvent } from '~/server/oauth/audit-log';
 import {
   createOauthClientSchema,
   deleteOauthClientSchema,
+  deriveAllowedOriginsFromRedirectUris,
   getOauthClientByIdSchema,
   rotateOauthClientSecretSchema,
   updateOauthClientSchema,
@@ -28,6 +29,7 @@ export const oauthClientRouter = router({
           logoUrl: true,
           isVerified: true,
           redirectUris: true,
+          allowedOrigins: true,
           allowedScopes: true,
         },
       });
@@ -45,6 +47,7 @@ export const oauthClientRouter = router({
         description: true,
         logoUrl: true,
         redirectUris: true,
+        allowedOrigins: true,
         grants: true,
         allowedScopes: true,
         isConfidential: true,
@@ -65,6 +68,15 @@ export const oauthClientRouter = router({
       const clientSecret = input.isConfidential ? generateKey(48) : null;
       const hashedSecret = clientSecret ? generateSecretHash(clientSecret) : null;
 
+      // Public clients depend on Origin pinning for token-endpoint identity;
+      // if the caller didn't supply explicit origins, fall back to the origin
+      // part of their redirect URIs so registration still produces a working
+      // client without forcing the user to type the same hosts twice.
+      const allowedOrigins =
+        input.allowedOrigins.length > 0
+          ? input.allowedOrigins
+          : deriveAllowedOriginsFromRedirectUris(input.redirectUris);
+
       await dbWrite.oauthClient.create({
         data: {
           id: clientId,
@@ -72,6 +84,7 @@ export const oauthClientRouter = router({
           name: input.name,
           description: input.description,
           redirectUris: input.redirectUris,
+          allowedOrigins,
           isConfidential: input.isConfidential,
           allowedScopes: input.allowedScopes,
           userId: ctx.user.id,

--- a/src/server/schema/__tests__/oauth-client.schema.test.ts
+++ b/src/server/schema/__tests__/oauth-client.schema.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createOauthClientSchema,
+  updateOauthClientSchema,
+  deriveAllowedOriginsFromRedirectUris,
+} from '../oauth-client.schema';
+
+describe('createOauthClientSchema', () => {
+  const validBase = {
+    name: 'My App',
+    description: 'desc',
+    redirectUris: ['https://example.com/cb'],
+  };
+
+  it('accepts valid scheme://host[:port] origins', () => {
+    const result = createOauthClientSchema.safeParse({
+      ...validBase,
+      allowedOrigins: ['https://example.com', 'http://localhost:5173', 'https://app.example.com:8443'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('defaults allowedOrigins to []', () => {
+    const result = createOauthClientSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.allowedOrigins).toEqual([]);
+  });
+
+  it('rejects origins with a trailing path', () => {
+    const result = createOauthClientSchema.safeParse({
+      ...validBase,
+      allowedOrigins: ['https://example.com/'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects origins with a path segment', () => {
+    const result = createOauthClientSchema.safeParse({
+      ...validBase,
+      allowedOrigins: ['https://example.com/callback'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects origins with a query string', () => {
+    const result = createOauthClientSchema.safeParse({
+      ...validBase,
+      allowedOrigins: ['https://example.com?foo=bar'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects origins with a fragment', () => {
+    const result = createOauthClientSchema.safeParse({
+      ...validBase,
+      allowedOrigins: ['https://example.com#x'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    const result = createOauthClientSchema.safeParse({
+      ...validBase,
+      allowedOrigins: ['ftp://example.com'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects plain non-URL strings', () => {
+    const result = createOauthClientSchema.safeParse({
+      ...validBase,
+      allowedOrigins: ['example.com'],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateOauthClientSchema', () => {
+  it('treats allowedOrigins as optional', () => {
+    const result = updateOauthClientSchema.safeParse({ id: 'abc' });
+    expect(result.success).toBe(true);
+  });
+
+  it('validates allowedOrigins when provided', () => {
+    const result = updateOauthClientSchema.safeParse({
+      id: 'abc',
+      allowedOrigins: ['https://example.com/oops'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an empty array (to clear the allowlist)', () => {
+    const result = updateOauthClientSchema.safeParse({
+      id: 'abc',
+      allowedOrigins: [],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('deriveAllowedOriginsFromRedirectUris', () => {
+  it('returns unique origins preserving input order', () => {
+    const origins = deriveAllowedOriginsFromRedirectUris([
+      'https://example.com/cb',
+      'https://example.com/cb2',
+      'https://other.example.com/cb',
+    ]);
+    expect(origins).toEqual(['https://example.com', 'https://other.example.com']);
+  });
+
+  it('keeps the port when present', () => {
+    const origins = deriveAllowedOriginsFromRedirectUris(['http://localhost:5173/auth/cb']);
+    expect(origins).toEqual(['http://localhost:5173']);
+  });
+
+  it('skips malformed URIs', () => {
+    const origins = deriveAllowedOriginsFromRedirectUris([
+      'not a url',
+      'https://example.com/cb',
+    ]);
+    expect(origins).toEqual(['https://example.com']);
+  });
+
+  it('returns [] for an empty input', () => {
+    expect(deriveAllowedOriginsFromRedirectUris([])).toEqual([]);
+  });
+});

--- a/src/server/schema/oauth-client.schema.ts
+++ b/src/server/schema/oauth-client.schema.ts
@@ -4,10 +4,32 @@ import * as z from 'zod';
 export const getOauthClientByIdSchema = z.object({ id: z.string() });
 export type GetOauthClientByIdInput = z.infer<typeof getOauthClientByIdSchema>;
 
+// Origins are exact-matched against the request `Origin` header for public
+// clients, so they must be a scheme + host (+ optional port) with no path,
+// query, fragment, or trailing slash — exactly the shape browsers send.
+const originSchema = z
+  .string()
+  .url()
+  .refine(
+    (value) => {
+      try {
+        const parsed = new URL(value);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+        // Reject anything with a path/search/hash so the registered value
+        // matches `req.headers.origin` byte-for-byte.
+        return value === parsed.origin;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'Origin must be scheme://host[:port] with no path, query, or fragment' }
+  );
+
 export const createOauthClientSchema = z.object({
   name: z.string().min(1).max(128),
   description: z.string().max(500).default(''),
   redirectUris: z.array(z.string().url()).min(1),
+  allowedOrigins: z.array(originSchema).default([]),
   isConfidential: z.boolean().default(true),
   allowedScopes: z.number().int().min(0).max(TokenScope.Full).default(TokenScope.Full),
 });
@@ -18,9 +40,34 @@ export const updateOauthClientSchema = z.object({
   name: z.string().min(1).max(128).optional(),
   description: z.string().max(500).optional(),
   redirectUris: z.array(z.string().url()).min(1).optional(),
+  allowedOrigins: z.array(originSchema).optional(),
   allowedScopes: z.number().int().min(0).max(TokenScope.Full).optional(),
 });
 export type UpdateOauthClientInput = z.infer<typeof updateOauthClientSchema>;
+
+/**
+ * Default `allowedOrigins` derived from a list of redirect URIs — the origin
+ * part of each URI, de-duplicated, preserving input order. Used as a fallback
+ * at registration time and as the backfill for the schema migration so we
+ * never break a currently-registered client on rollout.
+ */
+export function deriveAllowedOriginsFromRedirectUris(redirectUris: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const uri of redirectUris) {
+    try {
+      const origin = new URL(uri).origin;
+      if (origin === 'null') continue; // file://, data:, etc.
+      if (seen.has(origin)) continue;
+      seen.add(origin);
+      result.push(origin);
+    } catch {
+      // Ignore malformed URIs — they would have failed the redirectUris schema
+      // first, but stay defensive in case this is called on existing rows.
+    }
+  }
+  return result;
+}
 
 export const deleteOauthClientSchema = z.object({ id: z.string() });
 export type DeleteOauthClientInput = z.infer<typeof deleteOauthClientSchema>;

--- a/src/server/schema/oauth-client.schema.ts
+++ b/src/server/schema/oauth-client.schema.ts
@@ -56,8 +56,12 @@ export function deriveAllowedOriginsFromRedirectUris(redirectUris: string[]): st
   const result: string[] = [];
   for (const uri of redirectUris) {
     try {
-      const origin = new URL(uri).origin;
-      if (origin === 'null') continue; // file://, data:, etc.
+      const parsed = new URL(uri);
+      // originSchema only permits http/https. Filter here so the derive helper
+      // never produces an entry the schema would reject.
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue;
+      const origin = parsed.origin;
+      if (origin === 'null') continue;
       if (seen.has(origin)) continue;
       seen.add(origin);
       result.push(origin);

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -1680,6 +1680,7 @@ export interface OauthClient {
   description: string;
   logoUrl: string | null;
   redirectUris: string[];
+  allowedOrigins: string[];
   grants: string[];
   allowedScopes: number;
   isConfidential: boolean;


### PR DESCRIPTION
## Summary

Adds per-client allowed-origins enforcement to the OAuth server so public-client browser-only flows (PKCE without `client_secret`) can be locked to specific registered origins, instead of relying on permissive `Access-Control-Allow-Origin: *`.

Surfaced while building `civitai/civitai-app-starters` — full design doc and rationale: [handoff-oauth-domain-limits.md](https://github.com/civitai/civitai-app-starters/blob/main/docs/working/handoff-oauth-domain-limits.md).

## What changes

- **Schema:** new `OauthClient.allowedOrigins String[]` field (NOT NULL, default `[]`). Migration backfills existing clients with the origin part of each registered `redirectUri`, normalized (lowercase host, default `:443`/`:80` ports stripped, `[^/?#]+` to stop at path/query/fragment, case-insensitive scheme match) so they line up with browser-sent Origin headers. Custom-scheme URIs (e.g. `myapp://`) backfill empty; owner sets via UI.
- **API:** `oauthClient.create` / `oauthClient.update` accept `allowedOrigins`. UI control (textarea) added to the Register / Edit OAuth App modals in `OAuthAppsCard.tsx`.
- **Token endpoint** (`/api/auth/oauth/token`): for `isConfidential=false` clients, validates the request `Origin` against `client.allowedOrigins`. Rejects with `403 origin_not_allowed` on a mismatch. A *missing* Origin is allowed (native/mobile PKCE clients don't send one, and lets one OAuth client back both a browser SPA and a native app with a single consent). Replaces wildcard CORS with per-origin echo (`Access-Control-Allow-Origin: <origin>`, `Vary: Origin`). **No `Access-Control-Allow-Credentials`** — public clients use Bearer tokens, not cookies. Confidential clients keep existing wildcard behaviour.
- **Revoke endpoint** (`/api/auth/oauth/revoke`): same origin policy for public clients. Consolidates two pre-existing `findUnique` calls into one; rate-limit moved ahead of the origin check so rejected origins can't spam the audit log.
- **Single-lookup architecture:** origin enforcement lives inside `oauthModel.getClient`. The model stashes the resolved client on the OAuth library's `Request` so the handler drives CORS off it without a second DB hit. Gated on `body.grant_type` presence so the `/authorize` flow (top-level browser nav, no Origin) doesn't 403 every public-client consent. Handler has a fail-closed fallback lookup if the library wiring ever changes.
- **Rate limiting:** `/token` now keys on IP (was `client_id` — random-id rotation was bypassing the bucket).
- **Audit log:** new `origin.rejected` event type, logged with offending origin + endpoint when a public-client request is rejected.

## Why

For a public-client SPA without a `client_secret`, security collapses to:
- PKCE binds the code to the original `code_verifier` — code interception protection ✅
- Registered `redirect_uri` exact match — arbitrary callback prevention ✅ (already enforced)
- Registered `Origin` — arbitrary cross-site token exchange prevention ❌ (this PR)

Without origin enforcement, a malicious site can race a token exchange with an intercepted code after a redirect. PKCE makes the attack hard (`code_verifier` is the secret) but adding origin checks closes the gap and lets the docs recommend public-client browser-only flow for low-risk apps. The starters repo's M7 (`react-pwa-static` / `svelte-pwa-static`) depends on this.

## Test plan

- [x] Schema unit tests — accept/reject `allowedOrigins` shapes (15 tests).
- [x] Token endpoint handler tests — public client + good Origin → success, bad Origin → 403, confidential client behaviour unchanged, fail-closed fallback when stash missing (8 tests).
- [x] OAuth model tests — `getClient` origin enforcement, native (no-Origin) passthrough, authorize-flow gating, secret validation (10 tests).
- [x] `pnpm typecheck` — zero net-new errors vs `origin/main`.
- [x] `pnpm test:unit` — 33/33 new tests pass.

## Out of scope (follow-ups)

- **tRPC / `/api/v1/*` CORS for browser SPAs:** browser-based public clients can hit `/token` but can't actually call resource endpoints cross-origin because those don't echo allowlisted origins. Public clients are officially native/server only for now; browser SPAs work end-to-end only once resource-server CORS is gated by `allowedOrigins`.
- **Confidential-client owner-only restriction:** option to scope a confidential client to its owner's user account (opt-in `singleUser` flag) so a leaked secret can't be used to phish other users. Separate PR.
- **Per-client rate limit on `origin.rejected` events.**

## Files touched

- `prisma/schema.full.prisma`
- `prisma/migrations/20260518150000_add_oauth_allowed_origins/migration.sql`
- `src/server/schema/oauth-client.schema.ts`
- `src/server/routers/oauth-client.router.ts`
- `src/server/oauth/audit-log.ts`
- `src/server/oauth/errors.ts` (new — `OriginNotAllowedError` sentinel)
- `src/server/oauth/model.ts`
- `src/pages/api/auth/oauth/token.ts`
- `src/pages/api/auth/oauth/revoke.ts`
- `src/pages/api/auth/oauth/authorize.ts` (303 redirects + Next.js return-value cleanup)
- `src/components/Account/OAuthAppsCard.tsx`
- `src/server/schema/__tests__/oauth-client.schema.test.ts`
- `src/pages/api/auth/oauth/__tests__/token.test.ts`
- `src/server/oauth/__tests__/model.test.ts` (new)

## Heads-up

Windows `prisma generate` hit a known DLL-rename quirk during local testing. Types still generated and committed. If reviewers see stale Prisma client types after pulling: restart dev server + `pnpm db:generate`.