### PR TITLE
fix(models): cascade nsfw flip to version rollups

### DIFF
--- a/prisma/migrations/20260519120000_fix_model_nsfw_flip_version_cascade/migration.sql
+++ b/prisma/migrations/20260519120000_fix_model_nsfw_flip_version_cascade/migration.sql
@@ -1,0 +1,52 @@
+-- Fix stale ModelVersion.nsfwLevel after Model.nsfw flips true->false.
+--
+-- Background:
+--   When Model.nsfw = true, updateModelVersionNsfwLevels stamps every
+--   ModelVersion.nsfwLevel to nsfwBrowsingLevelsFlag (60 = R|X|XXX|Blocked).
+--   The old trigger only enqueued a Model-level UpdateNsfwLevel job on
+--   nsfw flip, so when nsfw flipped back to false:
+--     - Model rollup runs updateModelNsfwLevels.
+--     - bit_or(mv.nsfwLevel) over (still-stale) versions = 60.
+--     - ELSE branch writes 60. WHERE clause finds no diff. Model frozen.
+--     - Versions never recompute -> Model.nsfwLevel & 32 stays set,
+--       model is hidden from .com search even though images are PG/PG-13.
+--
+-- Fix:
+--   When Model.nsfw is distinct from its previous value, enqueue a
+--   ModelVersion UpdateNsfwLevel job for every Published version under
+--   the model. The update-nsfw-levels cron processes versions before
+--   models in the same tick (see updateNsfwLevels batch order in
+--   src/server/services/nsfwLevels.service.ts), so version rollups land
+--   fresh before the model rollup reads them.
+--
+-- Also swap the existing `NEW."nsfw" != OLD."nsfw"` check to
+-- IS DISTINCT FROM for NULL-safe comparison.
+
+CREATE OR REPLACE FUNCTION update_model_nsfw_level()
+RETURNS TRIGGER AS $model_nsfw_level$
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    -- When a model is deleted, schedule removal of FKs (collectionItems)
+    PERFORM create_job_queue_record(OLD.id, 'Model', 'CleanUp');
+  -- On model publish, create a job to update the nsfw level of the related entities (collectionItems)
+  ELSIF ((NEW.status = 'Published' AND OLD.status != 'Published')
+         OR (NEW."nsfw" IS DISTINCT FROM OLD."nsfw" AND NEW.status = 'Published')) THEN
+    PERFORM create_job_queue_record(OLD."id", 'Model', 'UpdateNsfwLevel');
+    -- When Model.nsfw flips, the rollup that stamps every version to
+    -- nsfwBrowsingLevelsFlag (60) is stale: a true->false transition
+    -- leaves versions at 60, so bit_or of versions = 60 and the Model
+    -- rollup short-circuits at 60 forever. Enqueue version recomputes
+    -- so the next cron tick recomputes from actual image data first,
+    -- then re-rolls up to Model (batch order in updateNsfwLevels
+    -- processes versions before models in the same run).
+    IF NEW."nsfw" IS DISTINCT FROM OLD."nsfw" THEN
+      INSERT INTO "JobQueue" ("entityId", "entityType", "type")
+      SELECT mv.id, 'ModelVersion'::"EntityType", 'UpdateNsfwLevel'::"JobQueueType"
+      FROM "ModelVersion" mv
+      WHERE mv."modelId" = NEW.id AND mv.status = 'Published'
+      ON CONFLICT DO NOTHING;
+    END IF;
+  END IF;
+  RETURN NULL;
+END;
+$model_nsfw_level$ LANGUAGE plpgsql;

--- a/prisma/programmability/nsfw_level_update_triggers.sql
+++ b/prisma/programmability/nsfw_level_update_triggers.sql
@@ -100,8 +100,23 @@ BEGIN
     -- When a model is deleted, schedule removal of FKs (collectionItems)
     PERFORM create_job_queue_record(OLD.id, 'Model', 'CleanUp');
   -- On model publish, create a job to update the nsfw level of the related entities (collectionItems)
-  ELSIF ((NEW.status = 'Published' AND OLD.status != 'Published') OR (NEW."nsfw" != OLD."nsfw" AND NEW.status = 'Published')) THEN
+  ELSIF ((NEW.status = 'Published' AND OLD.status != 'Published')
+         OR (NEW."nsfw" IS DISTINCT FROM OLD."nsfw" AND NEW.status = 'Published')) THEN
     PERFORM create_job_queue_record(OLD."id", 'Model', 'UpdateNsfwLevel');
+    -- When Model.nsfw flips, the rollup that stamps every version to
+    -- nsfwBrowsingLevelsFlag (60) is stale: a true->false transition
+    -- leaves versions at 60, so bit_or of versions = 60 and the Model
+    -- rollup short-circuits at 60 forever. Enqueue version recomputes
+    -- so the next cron tick recomputes from actual image data first,
+    -- then re-rolls up to Model (batch order in updateNsfwLevels
+    -- processes versions before models in the same run).
+    IF NEW."nsfw" IS DISTINCT FROM OLD."nsfw" THEN
+      INSERT INTO "JobQueue" ("entityId", "entityType", "type")
+      SELECT mv.id, 'ModelVersion'::"EntityType", 'UpdateNsfwLevel'::"JobQueueType"
+      FROM "ModelVersion" mv
+      WHERE mv."modelId" = NEW.id AND mv.status = 'Published'
+      ON CONFLICT DO NOTHING;
+    END IF;
   END IF;
   RETURN NULL;
 END;

--- a/src/pages/api/testing/backfill-stale-nsfw-rollups.ts
+++ b/src/pages/api/testing/backfill-stale-nsfw-rollups.ts
@@ -1,0 +1,181 @@
+/**
+ * Debug endpoint for the Model.nsfw flip / ModelVersion.nsfwLevel stale rollup bug.
+ * =============================================================================
+ *
+ * Hidden testing route. Guarded by the WEBHOOK_TOKEN via `?token=` query param
+ * (see WebhookEndpoint). Not reachable without the secret; no public UI.
+ *
+ * Background:
+ *   When Model.nsfw was true, updateModelVersionNsfwLevels stamped every
+ *   ModelVersion.nsfwLevel to nsfwBrowsingLevelsFlag (60 = R|X|XXX|Blocked).
+ *   The Model trigger only enqueued a Model-level UpdateNsfwLevel job on
+ *   nsfw flip — versions never got recomputed. After Model.nsfw flipped
+ *   true->false, updateModelNsfwLevels did bit_or over (still-stale)
+ *   versions = 60, wrote 60 back to Model, and the model stayed
+ *   .com-hidden forever. The trigger fix in migration
+ *   20260519120000_fix_model_nsfw_flip_version_cascade prevents new
+ *   occurrences. This endpoint backfills the existing stuck rows by
+ *   enqueueing ModelVersion UpdateNsfwLevel jobs; the update-nsfw-levels
+ *   cron (`*\/1 * * * *`) processes them within ~5-10 minutes.
+ *
+ * Usage:
+ *   POST /api/testing/backfill-stale-nsfw-rollups?token=$WEBHOOK_TOKEN
+ *   Content-Type: application/json
+ *   Body: { "action": "<action>", ...params }
+ *
+ * Actions (see the switch below for authoritative param list):
+ *   count           - {modelId?}                  Preview how many models/versions are stuck (m.nsfw=false AND m.nsfwLevel & 32 != 0).
+ *   enqueue         - {limit?, modelId?, dryRun?} Insert ModelVersion UpdateNsfwLevel rows into JobQueue.
+ *                                                  - limit caps the number of versions enqueued (use for staged rollouts).
+ *                                                  - modelId scopes to one model for spot-fixes.
+ *                                                  - dryRun=true counts without writing.
+ *   verify          - {modelId?}                  Re-run the stored-vs-recomputed comparison; expect 0 mismatches after drain.
+ *
+ * Every write is gated by WEBHOOK_TOKEN. The enqueue action only writes into
+ * JobQueue (an ON CONFLICT DO NOTHING insert) — same path the trigger uses —
+ * so worst case is re-running an already-queued recompute.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+const actionSchema = z.enum(['count', 'enqueue', 'verify']);
+
+const schema = z
+  .object({
+    action: actionSchema,
+    modelId: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().max(50_000).optional(),
+    dryRun: z.coerce.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.action === 'verify' && data.limit !== undefined) {
+      ctx.addIssue({ code: 'custom', message: 'verify does not accept limit', path: ['limit'] });
+    }
+  });
+
+const STUCK_PREDICATE = `m.status = 'Published'
+    AND mv.status = 'Published'
+    AND NOT m.nsfw
+    AND m."nsfwLevel" & 32 != 0`;
+
+export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
+  const payload = schema.safeParse({ ...req.query, ...(req.body ?? {}) });
+  if (!payload.success) {
+    return res.status(400).json({ error: 'Invalid request', issues: payload.error.issues });
+  }
+  const input = payload.data;
+
+  switch (input.action) {
+    case 'count': {
+      const modelFilter = input.modelId ? `AND m.id = ${input.modelId}` : '';
+      const rows = await dbRead.$queryRawUnsafe<{ modelCount: bigint; versionCount: bigint }[]>(`
+        SELECT
+          COUNT(DISTINCT m.id)::bigint AS "modelCount",
+          COUNT(*)::bigint AS "versionCount"
+        FROM "ModelVersion" mv
+        JOIN "Model" m ON m.id = mv."modelId"
+        WHERE ${STUCK_PREDICATE} ${modelFilter}
+      `);
+      const { modelCount, versionCount } = rows[0] ?? {
+        modelCount: BigInt(0),
+        versionCount: BigInt(0),
+      };
+      return res.status(200).json({
+        action: 'count',
+        modelId: input.modelId ?? null,
+        modelCount: Number(modelCount),
+        versionCount: Number(versionCount),
+      });
+    }
+
+    case 'enqueue': {
+      const modelFilter = input.modelId ? `AND m.id = ${input.modelId}` : '';
+      const limitClause = input.limit ? `LIMIT ${input.limit}` : '';
+
+      if (input.dryRun) {
+        const rows = await dbRead.$queryRawUnsafe<{ count: bigint }[]>(`
+          SELECT COUNT(*)::bigint AS count FROM (
+            SELECT mv.id
+            FROM "ModelVersion" mv
+            JOIN "Model" m ON m.id = mv."modelId"
+            WHERE ${STUCK_PREDICATE} ${modelFilter}
+            ${limitClause}
+          ) s
+        `);
+        return res.status(200).json({
+          action: 'enqueue',
+          dryRun: true,
+          modelId: input.modelId ?? null,
+          limit: input.limit ?? null,
+          wouldEnqueue: Number(rows[0]?.count ?? BigInt(0)),
+        });
+      }
+
+      const inserted = await dbWrite.$queryRawUnsafe<{ id: number }[]>(`
+        INSERT INTO "JobQueue" ("entityId", "entityType", "type")
+        SELECT mv.id, 'ModelVersion'::"EntityType", 'UpdateNsfwLevel'::"JobQueueType"
+        FROM "ModelVersion" mv
+        JOIN "Model" m ON m.id = mv."modelId"
+        WHERE ${STUCK_PREDICATE} ${modelFilter}
+        ${limitClause}
+        ON CONFLICT DO NOTHING
+        RETURNING "entityId" AS id
+      `);
+      return res.status(200).json({
+        action: 'enqueue',
+        dryRun: false,
+        modelId: input.modelId ?? null,
+        limit: input.limit ?? null,
+        enqueued: inserted.length,
+        sampleVersionIds: inserted.slice(0, 10).map((r) => r.id),
+      });
+    }
+
+    case 'verify': {
+      const modelFilter = input.modelId ? `AND m.id = ${input.modelId}` : '';
+      // LATERAL so the bit_or subquery runs once per row instead of twice
+      // (correlated subqueries in both SELECT and WHERE are not deduped by
+      // the planner) — keeps verify scans bounded when the cohort is
+      // large and the cache is cold.
+      const rows = await dbRead.$queryRawUnsafe<
+        {
+          modelVersionId: number;
+          modelId: number;
+          storedNsfwLevel: number;
+          recomputedNsfwLevel: number;
+        }[]
+      >(`
+        SELECT
+          mv.id AS "modelVersionId",
+          m.id AS "modelId",
+          mv."nsfwLevel" AS "storedNsfwLevel",
+          r."recomputed" AS "recomputedNsfwLevel"
+        FROM "ModelVersion" mv
+        JOIN "Model" m ON m.id = mv."modelId"
+        JOIN LATERAL (
+          SELECT COALESCE(bit_or(i."nsfwLevel"), 0) AS "recomputed"
+          FROM "Post" p
+          JOIN "Image" i ON i."postId" = p.id
+          WHERE p."modelVersionId" = mv.id
+            AND p."userId" = m."userId"
+            AND p."publishedAt" IS NOT NULL
+            AND i."nsfwLevel" NOT IN (0, 32)
+        ) r ON TRUE
+        WHERE mv.status = 'Published'
+          AND m.status = 'Published'
+          ${modelFilter}
+          AND mv."nsfwLevel" != r."recomputed"
+        LIMIT 100
+      `);
+      return res.status(200).json({
+        action: 'verify',
+        modelId: input.modelId ?? null,
+        mismatchCount: rows.length,
+        sample: rows.slice(0, 20),
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Patches `update_model_nsfw_level()` trigger to enqueue `ModelVersion→UpdateNsfwLevel` jobs whenever `Model.nsfw` changes. Without this cascade, a `true→false` flip leaves every `ModelVersion.nsfwLevel` stamped at `nsfwBrowsingLevelsFlag` (60), so `bit_or` over versions rolls back to 60 forever and the model stays `.com`-hidden.
- Adds a hidden, `WEBHOOK_TOKEN`-gated debug endpoint at `src/pages/api/testing/backfill-stale-nsfw-rollups.ts` for backfilling the existing stuck cohort (~3,198 models / ~5,264 versions) via the same `JobQueue` path the cron uses.

## Files
- `prisma/programmability/nsfw_level_update_triggers.sql` — trigger body update + inline comment explaining the cascade.
- `prisma/migrations/20260519120000_fix_model_nsfw_flip_version_cascade/migration.sql` — `CREATE OR REPLACE FUNCTION` carrying the new body. No trigger rebind needed.
- `src/pages/api/testing/backfill-stale-nsfw-rollups.ts` — three actions: `count`, `enqueue` (with `dryRun` / `limit` / `modelId`), `verify` (LATERAL join to keep the comparison cheap on cold cache).

## Investigation
Full root-cause analysis in [ClickUp 868jne0uq](https://app.clickup.com/t/868jne0uq) — sub-bug B comment.

## Rollout
1. Deploy migration (`pnpm prisma migrate deploy`).
2. `POST /api/testing/backfill-stale-nsfw-rollups?token=$WEBHOOK_TOKEN` with `{action: 'count'}` → expect ~3,198 / ~5,264.
3. `{action: 'enqueue', dryRun: true}` → sanity check.
4. (Optional canary) `{action: 'enqueue', limit: 500}` → watch `update-nsfw-levels` cron drain in Axiom.
5. `{action: 'enqueue'}` → full backfill.
6. Wait ~5–10 min for cron drain. Drain may overrun a 1-min tick for 2–4 ticks during backfill (5K extra version recomputes); steady-state load unchanged.
7. `{action: 'verify'}` → expect `mismatchCount: 0`.

## Test plan
- [ ] Migration applies cleanly in staging.
- [ ] Toggle `Model.nsfw` true→false on a test model in staging; confirm the trigger enqueues one `JobQueue` row per Published version.
- [ ] Run `count` → `enqueue (dryRun)` → `enqueue` → `verify` against staging cohort; confirm `mismatchCount: 0` after cron drain.
- [ ] Spot-check one stuck model (e.g. 2479433 *Nekomusume*) in prod via `enqueue` with `modelId` — confirm `Model.nsfwLevel` drops from 60 to the expected `bit_or` (e.g. 15 for that model) after drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)