### PR TITLE
fix(model-file-scan): correct HiDream-O1 baseModel to match ecosystem key

### DIFF
--- a/prisma/migrations/20260520000000_fix_hidream_o1_basemodel/migration.sql
+++ b/prisma/migrations/20260520000000_fix_hidream_o1_basemodel/migration.sql
@@ -1,0 +1,18 @@
+-- Backfill ModelVersion.baseModel for HiDream-O1 LoRAs created via the
+-- training pipeline. src/utils/training.ts had `baseModel: 'HiDream O1'`
+-- (with a space) which doesn't match the canonical ecosystem key
+-- `HiDream-O1` from basemodel.constants.ts. stringifyAIR's try/catch over
+-- getRootEcosystem() silently kept the bad string, lowercased it, and
+-- emitted `urn:air:hidream o1:lora:civitai:...` to the orchestrator. AIR
+-- segments are colon-separated and don't allow spaces; the orchestrator's
+-- URN parser falls back to `unknown:unknown:...` and the scan workflow
+-- fails with HTTP 400 (`Resource ... does not exist or is not valid.`).
+-- This affected 100% of HiDream-O1 scan submissions since the ecosystem
+-- shipped on 2026-05-13. Fix the code in src/utils/training.ts and the
+-- already-persisted rows here. The scan-files-fallback job (5 min cadence)
+-- will pick up the affected ModelFile rows on its next tick and resubmit
+-- with the corrected baseModel; no explicit scanRequestedAt reset needed
+-- because that job already resets it after every transient failure.
+UPDATE "ModelVersion"
+SET "baseModel" = 'HiDream-O1'
+WHERE "baseModel" = 'HiDream O1';

--- a/src/utils/training.ts
+++ b/src/utils/training.ts
@@ -259,7 +259,13 @@ export const trainingModelInfo: {
     description:
       "HiDream.ai's 8B pixel-level unified transformer for text-to-image. Preview — settings, pricing, and results are subject to change.",
     air: 'urn:air:hidreamo1:checkpoint:civitai:2618495@2939946',
-    baseModel: 'HiDream O1',
+    // Must match the canonical ecosystem key in basemodel.constants.ts
+    // (`key: 'HiDream-O1'`). The value flows into ModelVersion.baseModel
+    // on training completion and is then consumed by stringifyAIR; a space
+    // here produces a malformed AIR (urn segments are colon-separated) and
+    // the orchestrator's URN parser falls back to `unknown`, failing the
+    // scan workflow with 400.
+    baseModel: 'HiDream-O1',
     isNew: true,
     aiToolkit: { ecosystem: 'hidream-o1' },
   },


### PR DESCRIPTION
## Summary

Fixes the model-file scanner stall reported in [868jprfqa](https://app.clickup.com/t/868jprfqa). One-character data fix plus a backfill migration.

## Root cause

`src/utils/training.ts:262` had `baseModel: 'HiDream O1'` (with a space) on the HiDream-O1 training-config entry. Every LoRA produced by HiDream-O1 training completion since the ecosystem shipped on 2026-05-13 got that string written to `ModelVersion.baseModel`.

When `createModelFileScanRequest` calls `stringifyAIR`:

```ts
let ecosystem = baseModel;
try {
  ecosystem = getRootEcosystem(baseModel).key;
} catch {}
// ...
return Air.stringify({ ecosystem: ecosystem.toLowerCase(), ... });
```

`getRootEcosystem('HiDream O1')` throws because the canonical ecosystem key in `basemodel.constants.ts` is `'HiDream-O1'` (with hyphen). The `try/catch` silently keeps the raw string, lowercases it, and `Air.stringify` emits `urn:air:hidream o1:lora:civitai:...`.

URN segments are colon-separated and don't allow spaces. The orchestrator's parser falls back to `urn:air:unknown:unknown:air:hidream@unknown` and rejects with HTTP 400 (`"Resource ... does not exist or is not valid."`). The dp-prod-jobs `model-file-scan` error log is 100% HiDream-O1 (211 errors / 4h / 3 pods sampled — zero non-HiDream errors).

## Why now?

The bug has been latent since 2026-05-13. **Phase 3** (`178bb19cc`) removed the legacy HTTP scanner path on 2026-05-11, making the orchestrator workflow the sole code path. As HiDream-O1 LoRA training throughput ramped up, the latent encoding bug surfaced as a scanner stall.

## Changes

**`src/utils/training.ts`** — change `'HiDream O1'` → `'HiDream-O1'` so new training completions write the canonical ecosystem-key value into `ModelVersion.baseModel`. Inline comment documents the contract so this doesn't drift again.

**`prisma/migrations/20260520000000_fix_hidream_o1_basemodel/migration.sql`** — backfill already-persisted rows:

```sql
UPDATE "ModelVersion"
SET "baseModel" = 'HiDream-O1'
WHERE "baseModel" = 'HiDream O1';
```

No explicit `ModelFile.scanRequestedAt` reset needed — the `scan-files-fallback` cron (5 min cadence) already resets `scanRequestedAt` to NULL on every transient failure (`scan-files.ts:99`), so affected files are continuously re-eligible. Within ~5 min of the migration running, the next tick will re-read `ModelVersion.baseModel`, emit a valid AIR, and submission will succeed.

## Test plan

- [ ] Local unit: `stringifyAIR({ baseModel: 'HiDream-O1', type: ModelType.LORA, modelId: 1, id: 1, fileId: 1 })` returns `urn:air:hidream-o1:lora:civitai:1@1+1`
- [ ] Pre-merge: query prod replica count to confirm migration target — `SELECT count(*) FROM "ModelVersion" WHERE "baseModel" = 'HiDream O1';` (matches the ClickUp's ~770 figure ± fresh uploads)
- [ ] Post-deploy verification:
  - `kubectl logs -n civitai-dp-prod -l app=civitai-dp-prod-jobs --since=10m | grep -c '"name":"model-file-scan"'` drops to 0 (or non-HiDream-O1 only)
  - `kubectl logs -n orchestration-poc -l app=orchestration-api --since=10m | grep "Streaming claim" | grep -oE "\(\\w+Job\)" | sort | uniq -c` shows `ModelClamScan` / `ModelHash` / `ModelParseMetadata` / `ModelPickleScan` claims appearing
  - Query the `ModelFile` backlog count drops over the next hour

## Follow-up (not in this PR)

The silent `try { ... } catch {}` in `stringifyAIR` is what let this rot for a week. A separate commit should log loudly (or throw) when `getRootEcosystem` falls through, so a `baseModel` typo surfaces at upload time, not at scan time six days later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)