### PR TITLE
perf(search-index): drop images_v6 sync from hourly to daily

### DIFF
--- a/src/server/jobs/search-index-sync.ts
+++ b/src/server/jobs/search-index-sync.ts
@@ -21,7 +21,7 @@ const cronTimeMap: Record<SearchIndexSetKey, string> = {
   models: '*/5 * * * *',
   users: '*/10 * * * *',
   articles: '*/5 * * * *',
-  images: '5 */1 * * *',
+  images: '5 8 * * *',
   collections: '*/10 * * * *',
   bounties: '*/5 * * * *',
   imageMetrics: '*/1 * * * *',


### PR DESCRIPTION
## Summary
- Changes the `images` search-index sync cron from `5 */1 * * *` (hourly) to `5 8 * * *` (daily, 08:05 UTC).
- Each hourly cycle currently takes ~50 minutes on the production Meilisearch (\`meilisearch-0\` in \`meilisearch\` namespace, \`images_v6\` = 60.7M docs / 744 GB LMDB). The instance is effectively never idle, driving sustained NVMe saturation on \`talos-uvh-ow7\` (io_weight peaked at 1983 today; threshold for the cluster's existing critical alert is 10).
- Triggered the \`DP Prod: P95 Latency Critical\` pager on \`civitai-dp-prod-api-primary\` today (peak P95 22.5s) when client-side \`MeiliSearchCommunicationError: Request Timeout\` cascaded into Node liveness failures and SIGKILL restarts.

## Why this is safe
- Comment at \`src/server/search-index/images.search-index.ts:307-308\` states the index is kept "solely for the purpose of managing deletes / queued updates" — the primary read paths use the separate \`metrics_images_v1\` feeds cluster.
- The only consumer of \`images_v6\` is the \`/search/images\` page.
- Cluster Traefik service for this Meilisearch only sees 36–53 req/s end-user load.

## Trade-off
- New IDs / image-metadata updates on \`/search/images\` can be up to 24h stale.
- If that's unacceptable, step back to \`5 */6 * * *\` (every 6h) for ~83% I/O reduction instead of ~95%, or \`5 */4 * * *\` (every 4h) for ~75%.

## Test plan
- [ ] Confirm with @civitai/search-owners that 24h staleness on \`/search/images\` is acceptable.
- [ ] Post-deploy: verify \`talos-uvh-ow7\` NVMe \`node_disk_io_time_weighted_seconds_total\` rate drops back to baseline outside the 08:05 UTC window.
- [ ] Post-deploy: verify next 08:05 UTC run completes within historical ~50 min budget (it will catch up 24h of deltas, not 1h, so may take longer on first cycle — monitor).
- [ ] Confirm no regression in P95 on \`civitai-dp-prod-api-primary\` Traefik service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)