### PR TITLE
perf(meilisearch/cleanup): use keyset pagination instead of offset

### DIFF
--- a/src/server/jobs/search-index-cleanup.ts
+++ b/src/server/jobs/search-index-cleanup.ts
@@ -8,14 +8,17 @@ export const searchIndexCleanupJob = createJob(
   async (jobContext) => {
     const results = await cleanupAllIndexes(null, {
       apply: true,
-      concurrency: 8,
       batch: 1000,
       jobContext,
       onError: ({ key, offset, error }) => {
+        // `offset === -1` is the sentinel for preflight or delete-phase
+        // errors (no scan cursor associated). Otherwise it's the cursor
+        // (last id seen) at the point of failure.
+        const phase = offset === -1 ? 'preflight/delete' : `cursor=${offset}`;
         logToAxiom({
           type: 'error',
           name: 'search-index-cleanup',
-          message: `batch error in ${key} at offset ${offset}: ${error.message}`,
+          message: `error in ${key} (${phase}): ${error.message}`,
         }).catch();
       },
     });

--- a/src/server/meilisearch/cleanup.ts
+++ b/src/server/meilisearch/cleanup.ts
@@ -11,7 +11,6 @@ import {
 } from '~/server/common/constants';
 import { searchClient } from '~/server/meilisearch/client';
 import type { JobContext } from '~/server/jobs/job';
-import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import {
   ArticleIngestionStatus,
   ArticleStatus,
@@ -164,6 +163,7 @@ export const CLEANUP_INDEXES: IndexConfig[] = [
 
 export type CleanupOptions = {
   apply: boolean;
+  /** Retained for backwards compatibility. Ignored under keyset pagination — scans are sequential by id. */
   concurrency?: number;
   batch?: number;
   maxBatches?: number;
@@ -204,7 +204,6 @@ export async function cleanupIndex(
   const index = searchClient.index(cfg.indexName);
 
   const batch = opts.batch ?? 1000;
-  const concurrency = opts.concurrency ?? 8;
   const maxBatches = opts.maxBatches ?? Infinity;
   const deleteChunkSize = opts.deleteChunkSize ?? 10000;
 
@@ -226,56 +225,178 @@ export async function cleanupIndex(
     // non-fatal
   }
 
-  let offset = 0;
-  let done = false;
+  // Preflight: keyset pagination needs `id` declared both filterable AND
+  // sortable on the index. If either is missing, the scan would 4xx every
+  // batch — bail out early with a logged error so the cron doesn't waste
+  // retries and the missing-setting cause is surfaced clearly.
+  try {
+    const indexSettings = await index.getSettings();
+    const filt = indexSettings.filterableAttributes ?? [];
+    const sort = indexSettings.sortableAttributes ?? [];
+    if (!filt.includes('id') || !sort.includes('id')) {
+      stats.errors += 1;
+      opts.onError?.({
+        key: cfg.key,
+        offset: -1,
+        error: new Error(
+          `index ${cfg.indexName} is missing required settings for keyset scan ` +
+            `(filterable has id=${filt.includes('id')}, sortable has id=${sort.includes('id')}). ` +
+            `Add 'id' to both lists in ${cfg.key}.search-index.ts and let onIndexSetup run.`
+        ),
+      });
+      return stats;
+    }
+  } catch (err) {
+    stats.errors += 1;
+    opts.onError?.({ key: cfg.key, offset: -1, error: err as Error });
+    return stats;
+  }
+
+  // Keyset (cursor) pagination over `id`. Per-call cost is O(batch) on
+  // Meilisearch regardless of depth — replaces offset pagination where
+  // deep pages were saturating LMDB read I/O on the search host.
+  let lastId = -1;
   const allStaleIds: number[] = [];
 
-  const generator = () => {
-    if (done || stats.batchesProcessed >= maxBatches) return null;
-    if (opts.jobContext?.status === 'canceled') return null;
-    const myOffset = offset;
-    offset += batch;
-    return async () => {
+  // Retry helper: run `fn` up to MAX_ATTEMPTS times with linear backoff.
+  // Re-throws immediately if the job is canceled mid-retry — otherwise the
+  // inner try/catch would treat the cancellation as a transient error and
+  // burn through the backoff before bailing.
+  const MAX_ATTEMPTS = 3;
+  const withRetries = async <T>(fn: () => Promise<T>): Promise<T> => {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      opts.jobContext?.checkIfCanceled();
       try {
-        opts.jobContext?.checkIfCanceled();
-        const page = await index.getDocuments<{ id: number }>({
-          fields: ['id'],
-          limit: batch,
-          offset: myOffset,
-        });
-        const docIds = page.results
-          .map((r) => r.id)
-          .filter((n): n is number => Number.isFinite(n));
-
-        if (docIds.length === 0) {
-          done = true;
-          return;
-        }
-
-        const validIds = await fetchValidIds(cfg, docIds);
-        const staleIds = docIds.filter((id) => !validIds.has(id));
-
-        stats.batchesProcessed += 1;
-        stats.idsScanned += docIds.length;
-        stats.staleFound += staleIds.length;
-
-        if (staleIds.length > 0) allStaleIds.push(...staleIds);
-
-        opts.onBatch?.({ key: cfg.key, offset: myOffset, scanned: docIds.length, stale: staleIds.length });
-
-        if (docIds.length < batch) done = true;
+        return await fn();
       } catch (err) {
-        stats.errors += 1;
-        opts.onError?.({ key: cfg.key, offset: myOffset, error: err as Error });
+        // If the job is no longer running, surface the canonical
+        // cancellation error (not the underlying fetch/PG error) so log
+        // handlers can distinguish "we stopped on purpose" from "we failed".
+        // `!== 'running'` mirrors `createJob.checkIfCanceled` exactly —
+        // catches both `canceled` and (theoretically) `finished`.
+        if (opts.jobContext && opts.jobContext.status !== 'running') {
+          opts.jobContext.checkIfCanceled();
+          throw err; // unreachable if checkIfCanceled threw, but kept for typing
+        }
+        lastErr = err;
+        if (attempt < MAX_ATTEMPTS) {
+          // Linear backoff: 1000ms, 1500ms.
+          await new Promise((r) => setTimeout(r, attempt * 500 + 500));
+        }
       }
-    };
+    }
+    throw lastErr;
   };
 
-  await limitConcurrency(generator, { limit: concurrency });
+  // Defensive cap: if Postgres fails for many batches in a row, abandon
+  // this index for the run rather than walking the whole id-space at
+  // ~2.5s per batch. The job lock would eventually cancel us anyway,
+  // but this short-circuits before we waste an hour.
+  const MAX_CONSECUTIVE_PG_FAILURES = 10;
+  let consecutivePgFailures = 0;
+
+  while (stats.batchesProcessed < maxBatches) {
+    if (opts.jobContext?.status === 'canceled') break;
+
+    // Retry transient errors on the Meili scan a few times before aborting
+    // the whole index. The original concurrent-offset code naturally
+    // tolerated a single bad batch (other concurrent batches still made
+    // progress); sequential keyset has no such redundancy.
+    //
+    // Note: `limit` is capped at the Meilisearch index `maxTotalHits`
+    // setting (default 1000). Bumping `batch` past 1000 without also
+    // raising `maxTotalHits` would silently truncate the page. Keyset
+    // would still advance correctly on the last returned id, so we
+    // wouldn't miss docs — just halve throughput.
+    let page: Awaited<ReturnType<typeof index.search<{ id: number }>>>;
+    try {
+      page = await withRetries(() =>
+        index.search<{ id: number }>('', {
+          filter: `id > ${lastId}`,
+          sort: ['id:asc'],
+          limit: batch,
+          attributesToRetrieve: ['id'],
+        })
+      );
+    } catch (err) {
+      // Cancellation surfaced from withRetries is a clean stop, not a failure.
+      if (opts.jobContext && opts.jobContext.status !== 'running') break;
+      stats.errors += 1;
+      opts.onError?.({ key: cfg.key, offset: lastId, error: err as Error });
+      // Out of retries — without advancing the cursor we'd loop on the same page.
+      break;
+    }
+
+    const docIds = page.hits
+      .map((r) => r.id)
+      .filter((n): n is number => Number.isFinite(n));
+
+    if (docIds.length === 0) break;
+
+    // Same retry envelope on the Postgres side. A connection blip or short
+    // replica-lag spike shouldn't drop ~10M docs of users cleanup.
+    try {
+      const validIds = await withRetries(() => fetchValidIds(cfg, docIds));
+      const staleIds = docIds.filter((id) => !validIds.has(id));
+
+      stats.batchesProcessed += 1;
+      stats.idsScanned += docIds.length;
+      stats.staleFound += staleIds.length;
+      consecutivePgFailures = 0;
+
+      if (staleIds.length > 0) allStaleIds.push(...staleIds);
+
+      // `offset` in the callback reports the cursor (last id seen before this batch).
+      opts.onBatch?.({ key: cfg.key, offset: lastId, scanned: docIds.length, stale: staleIds.length });
+    } catch (err) {
+      // Cancellation surfaced from withRetries is a clean stop, not a
+      // Postgres failure — don't pollute the consecutivePgFailures counter
+      // or log it as an error.
+      if (opts.jobContext && opts.jobContext.status !== 'running') break;
+      // Postgres-side error survived retries. Don't abandon the whole
+      // index for a single transient batch — advance the cursor and try
+      // the next page. We'll miss cleanup for the ids in this batch this
+      // run; the next nightly run will catch them. But cap consecutive
+      // failures so a hard outage doesn't grind through millions of ids.
+      stats.errors += 1;
+      consecutivePgFailures += 1;
+      opts.onError?.({ key: cfg.key, offset: lastId, error: err as Error });
+      if (consecutivePgFailures >= MAX_CONSECUTIVE_PG_FAILURES) {
+        opts.onError?.({
+          key: cfg.key,
+          offset: lastId,
+          error: new Error(
+            `aborting ${cfg.indexName} scan: ${consecutivePgFailures} consecutive Postgres errors`
+          ),
+        });
+        // ids come back sorted asc; advance cursor so a possible retry of
+        // the outer cron picks up where we left off.
+        lastId = docIds[docIds.length - 1];
+        break;
+      }
+    }
+
+    // ids come back sorted asc; advance cursor. Length is guaranteed > 0
+    // by the empty-check above, so the access is safe.
+    lastId = docIds[docIds.length - 1];
+
+    if (docIds.length < batch) break;
+  }
 
   if (opts.apply && allStaleIds.length > 0) {
     let chunkIdx = 0;
     for (let i = 0; i < allStaleIds.length; i += deleteChunkSize) {
+      // Bail before submitting more delete tasks if the job is no longer
+      // running. Without this, every remaining chunk logs a separate
+      // "Job has ended" error via the catch below — for a ~10M-doc index
+      // with hundreds of thousands of stale ids that's tens of duplicate
+      // Axiom errors per cancellation. (`!== 'running'` mirrors what
+      // `createJob.checkIfCanceled` actually throws on: status flipped to
+      // either `canceled` or `finished`. Phrased this way to avoid TS's
+      // control-flow narrowing inside the catch below, which would
+      // otherwise reject the equivalent `=== 'canceled'` comparison.)
+      if (opts.jobContext && opts.jobContext.status !== 'running') break;
       const chunk = allStaleIds.slice(i, i + deleteChunkSize);
       try {
         opts.jobContext?.checkIfCanceled();
@@ -283,6 +404,9 @@ export async function cleanupIndex(
         stats.deleted += chunk.length;
         opts.onDelete?.({ key: cfg.key, chunk: chunkIdx, ids: chunk.length });
       } catch (err) {
+        // Treat cancellation thrown mid-deleteDocuments as a clean stop,
+        // not an error. See the comment above for the !== 'running' form.
+        if (opts.jobContext && opts.jobContext.status !== 'running') break;
         stats.errors += 1;
         opts.onError?.({ key: cfg.key, offset: -1, error: err as Error });
       }

--- a/src/server/search-index/articles.search-index.ts
+++ b/src/server/search-index/articles.search-index.ts
@@ -52,7 +52,10 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
 
   console.log('onIndexSetup :: sortableFieldsAttributesTask created', sortableFieldsAttributesTask);
 
-  const filterableAttributes = ['tags.name', 'user.username', 'nsfwLevel'];
+  // `id` is required filterable for the keyset pagination scan in
+  // src/server/meilisearch/cleanup.ts. `id` is already declared in the
+  // updateSortableAttributes call above.
+  const filterableAttributes = ['id', 'tags.name', 'user.username', 'nsfwLevel'];
 
   if (
     // Meilisearch stores sorted.

--- a/src/server/search-index/bounties.search-index.ts
+++ b/src/server/search-index/bounties.search-index.ts
@@ -45,6 +45,8 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
 
   const sortableAttributes = [
     'createdAt',
+    // `id` required by the keyset cleanup scan (src/server/meilisearch/cleanup.ts).
+    'id',
     'stats.unitAmountCountAllTime',
     'stats.entryCountAllTime',
     'stats.favoriteCountAllTime',
@@ -66,6 +68,8 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
   }
 
   const filterableAttributes = [
+    // `id` required by the keyset cleanup scan (src/server/meilisearch/cleanup.ts).
+    'id',
     'user.username',
     'type',
     'details.baseModel',

--- a/src/server/search-index/comics.search-index.ts
+++ b/src/server/search-index/comics.search-index.ts
@@ -12,8 +12,15 @@ const MEILISEARCH_DOCUMENT_BATCH_SIZE = 1000;
 const INDEX_ID = COMICS_SEARCH_INDEX;
 
 const searchableAttributes = ['name', 'description', 'user.username'];
-const sortableAttributes = ['createdAt', 'updatedAt', 'stats.chapterCount', 'stats.followerCount'];
-const filterableAttributes = ['user.username', 'genre', 'nsfwLevel'];
+// `id` is in both lists for the keyset cleanup scan (src/server/meilisearch/cleanup.ts).
+const sortableAttributes = [
+  'createdAt',
+  'id',
+  'updatedAt',
+  'stats.chapterCount',
+  'stats.followerCount',
+];
+const filterableAttributes = ['id', 'user.username', 'genre', 'nsfwLevel'];
 const rankingRules = ['sort', 'words', 'typo', 'proximity', 'attribute', 'exactness'];
 
 const onIndexSetup = async ({ indexName }: { indexName: string }) => {


### PR DESCRIPTION
## Summary
- Replaces \`offset\`-based pagination in \`cleanupIndex\` with \`id\`-keyset (cursor) pagination using \`index.search('', { filter: 'id > X', sort: ['id:asc'], ... })\`.
- Each scan call is now O(batch) regardless of depth, instead of O(offset). For \`users_v3\` (10.9M docs) the previous deepest pages required Meilisearch to walk ~10M docs internally per call — that pressure on LMDB read pages contributed to sustained NVMe saturation on \`talos-uvh-ow7\` (the Meilisearch host) and the resulting P95 latency cascade into \`civitai-dp-prod-api-primary\` today.

## Scope note
\`CLEANUP_INDEXES\` (the array consumed by this function) covers \`models\`, \`articles\`, \`users\`, \`collections\`, \`bounties\`, \`tools\`, \`comics\` — it does **not** include \`images_v6\`. The biggest single win here is \`users_v3\` (10.9M docs); \`models_v9\` (642K) and the rest are too small to benefit much in absolute terms but get the same code path.

## Correctness
- \`id\` is set as filterable AND sortable on every index in \`CLEANUP_INDEXES\` (verified in \`src/server/search-index/*.search-index.ts\`).
- Loop terminates when a page returns < \`batch\` hits OR 0 hits.
- On error: aborts this index (returning without advancing cursor would infinite-loop on the same page).
- Cancel semantics (\`jobContext\`) preserved.

## Trade-off
- Concurrency goes from 8 → 1, because each batch depends on the previous batch's max id. In practice this is faster on deep scans (each call is now constant-time instead of degrading) — for \`users_v3\` estimate ~9 min wall time at 10.9k × ~50ms keyset calls.
- If we want concurrency back, we'd need to range-partition the id-space first (e.g. split into N segments and run keyset within each) — left out of scope here.
- \`opts.concurrency\` is now ignored; kept on the type for call-site compatibility.

## Test plan
- [ ] Verify the nightly \`search-index-cleanup\` job at 02:00 UTC completes within its 10-min lock window.
- [ ] Confirm the stale-id count reported per index matches historical runs (sanity check that we're scanning the whole index, not stopping early).
- [ ] Watch \`talos-uvh-ow7\` \`node_disk_io_time_weighted_seconds_total\` during the next nightly run — expect a flatter / shorter spike than usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)