### PR TITLE
fix(image-feed): tag feed-path Meili requests with X-Search-Actor

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -43,6 +43,7 @@ import { poolCounters } from '~/server/games/new-order/utils';
 import { logToAxiom, safeError } from '~/server/logging/client';
 import { withSpan } from '~/server/utils/otel-helpers';
 import {
+  SEARCH_ACTOR_HEADER,
   fetchDocumentsAbortable,
   getMetricsSearchClient,
   metricsSearchClient,
@@ -2537,6 +2538,9 @@ export async function getImagesFromFeedSearch(
         new MeiliSearch({
           host,
           apiKey,
+          requestConfig: input.actor
+            ? { headers: { [SEARCH_ACTOR_HEADER]: input.actor } }
+            : undefined,
         }) as IMeilisearch,
       clickhouse as IClickhouseClient,
       pgDbWrite as IDbClient,


### PR DESCRIPTION
## Summary

`getImagesFromFeedSearch` (in `src/server/services/image.service.ts`) was constructing its `MeiliSearch` client with no `requestConfig.headers`, so every `ImagesFeed.populatedQuery` request hit the meilisearch-proxy without `X-Search-Actor`. The proxy then routed via the `reason=no_actor` round-robin fallback instead of HRW-pinning the request to a single Meili replica.

Production proxy metrics showed **~68.5% of traffic missing the header**, all coming from this one call site. The companion `getImagesFromSearch` path was already wired up correctly in #2e70c78a0 via `getMetricsSearchClient(actor)` — this PR is the equivalent one-line wiring for the feed path that the original PR missed.

## Why the original PR missed it

#2e70c78a0 added the header via a per-actor MeiliSearch factory and threaded `input.actor` through the `ImageSearchInput` type. `getImagesFromSearch{PreFilter,PostFilter}` were updated to read `input.actor` and instantiate a header-tagged client via `getMetricsSearchClient(actor)`. `getImagesFromFeedSearch` uses a different construction shape — it passes a factory `({apiKey, host}) => new MeiliSearch(...)` into `ImagesFeed` — so it wasn't reachable via the `getMetricsSearchClient` helper, and the inline `new MeiliSearch` construction never got the equivalent treatment.

## The fix

Pass `requestConfig.headers[SEARCH_ACTOR_HEADER] = input.actor` into the inline MeiliSearch constructor when an actor is present (logged-in → `user:<id>`, anon → `anon:<sha256(ip|ua)[..16]>`). The cast to `IMeilisearch` narrows the interface but does not affect runtime behavior — the underlying `meilisearch-js` SDK applies `requestConfig.headers` to every request it issues, including the `ctx.index.search()` call at `event-engine-common/feeds/images.feed.ts:715`.

`input.actor` is built upstream in the same controllers updated by #2e70c78a0; no caller changes are needed.

## Expected effect

- Pinned-share (`reason=pinned`) lifts from ~31.5% toward 85-95%, the band that `/getInfinite` currently occupies in proxy metrics.
- Better per-replica cache locality on the feeds-meilisearch pair, which should show as a meaningful bump in cache hit rate on the proxy side.
- Untagged internal callers still send no header and round-robin as before.

Proxy-side mechanism: civitai/meilisearch-proxy#2.

## Test plan

- [ ] Typecheck passes (`npm run typecheck` — no new errors introduced near the edit; pre-existing unrelated errors in webhooks/types remain).
- [ ] After deploy, observe proxy metric `meili_proxy_requests_total{reason="no_actor"}` drop and `reason="pinned"` rise — feed-image-loop should account for the majority of the shift.
- [ ] Verify no regression in feed query latency (`feed_images.populatedQuery` Tempo spans).
- [ ] Spot-check Meili access logs on one replica for `X-Search-Actor` on a feed query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)