### PR TITLE
perf(image-search): snap remaining Date.now() sites in moderator + user-own branches

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -3065,12 +3065,13 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   // User-own-pass mode: drop the inline `OR userId=currentUserId` branch. User's
   // unpublished/scheduled content comes from fetchMeiliUserOwnPass and gets merged
   // at the hit level.
+  const snappedNow = snapToInterval(Math.round(Date.now()));
   if (isModerator) {
     if (notPublished) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
     else if (scheduled)
-      filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${Date.now()}`));
+      filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
     else {
-      const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${Date.now()}`)];
+      const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
       if (!input.meiliUserOwnPass && currentUserId) {
         publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
       }
@@ -3080,7 +3081,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     // Users should only see published stuff or things they own
     // convert to minutes for better caching
     const publishedFilters = [
-      makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snapToInterval(Math.round(Date.now()))}`),
+      makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`),
     ];
     if (!input.meiliUserOwnPass && currentUserId) {
       publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
@@ -3932,16 +3933,16 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   if (isModerator) {
     if (notPublished) filters.push(makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS'));
     else if (scheduled)
-      filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${Date.now()}`));
+      filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${snappedNow}`));
     else {
-      const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${Date.now()}`)];
+      const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
       if (!input.meiliUserOwnPass && currentUserId) {
         publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
       }
       filters.push(`(${publishedFilters.join(' OR ')})`);
     }
   } else if (userId) {
-    const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${Date.now()}`)];
+    const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
     // For own user's content, allow seeing scheduled/notPublished content
     if (!input.meiliUserOwnPass && currentUserId && userId === currentUserId) {
       publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2665,7 +2665,9 @@ async function fetchMeiliUserOwnPass(
   // Excluded set = anything the strict main query would have removed for a
   // non-owner: unscanned, unpublished, scheduled, private, blocked, or POI
   // (when disablePoi is on). Mirrors the BitDex second-pass excluded OR.
-  const now = Date.now();
+  // Snap to 60s so the cache key reuses across nearby requests — matches the
+  // pattern used by Pre/PostFilter publish filters.
+  const now = snapToInterval(Date.now());
   const blockedReasonList = [
     BlockedReason.TOS,
     BlockedReason.Moderated,


### PR DESCRIPTION
## Summary

#2171 introduced snapToInterval-based cache-friendly publish filters but missed six `Date.now()` sites in moderator and user-own branches of `getImagesFromSearchPreFilter` / `getImagesFromSearchPostFilter`. Each unsnapped `Date.now()` produces a unique filter string per request, defeating the meilisearch-proxy cache key on those paths.

Sites snapped:

**PreFilter** (`getImagesFromSearchPreFilter`):
- Moderator scheduled branch (L3071 pre-change): `publishedAtUnix > Date.now()` → `> snappedNow`
- Moderator regular-published branch (L3073): `publishedAtUnix <= Date.now()` → `<= snappedNow`
- Hoisted `snappedNow` declaration before the if/else so the non-moderator branch (already snapping inline) shares the same variable

**PostFilter** (`getImagesFromSearchPostFilter`) — `snappedNow` was already declared at L3931 but only the general-feed branch (L3952) used it:
- Moderator scheduled branch (L3935)
- Moderator regular-published branch (L3937)
- User-own branch (L3944) — when `userId` is set and viewing own content

## Trade-off

Same 60s cache window the non-moderator/general path already accepts — behavioral drift is at most 60s of stale publish/schedule state. Matches the cache window humans already see today on the non-moderator path.

## Test plan

- [ ] Verify proxy `meili_proxy_cache_hits_total / total` ratio increases on PostFilter routes and on moderator queries (low-volume but should now share cache slots with non-moderator queries when filter shapes match)
- [ ] Verify moderator can still see scheduled content correctly (60s drift acceptable)
- [ ] Verify own-content view (`userId === currentUserId`) still shows unpublished content

## Why this is a follow-up, not a change to #2171

#2171 is already merged and the architecture is correct — this is just sweeping the remaining unsnapped sites that the same approach should have covered.

## Origin

Discovered while comparing #2171 against a parallel WIP (closed PR #2294) that also tackled cache fragmentation. The unique cache-coverage gaps in moderator + user-own branches were the only material wins from that branch that weren't already captured by #2171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)