### PR TITLE
feat(post-edit): surface needsReview and minor flag on image cards

### DIFF
--- a/src/components/ImageGuard/ImageGuard2.tsx
+++ b/src/components/ImageGuard/ImageGuard2.tsx
@@ -76,6 +76,7 @@ const ImageGuardCtx = createContext<{
   nsfw: boolean;
   userId?: number;
   imageFlag?: string;
+  needsReview?: string | null;
 } | null>(null);
 
 function useImageGuardContext() {
@@ -93,7 +94,7 @@ function useImageGuard({ image, connectId, connectType }: UseImageGuardProps) {
   const { blurLevels } = useBrowsingLevelContext();
   const showImage = useShowImagesStore(useCallback((state) => state[image.id], [image.id]));
   const key = getConnectionKey({ connectType, connectId });
-  const { nsfwLevel = 0, tosViolation } = useImageStore(image);
+  const { nsfwLevel = 0, tosViolation, needsReview } = useImageStore(image);
   const blurNsfw = Flags.hasFlag(blurLevels, nsfwLevel);
 
   const showConnect = useShowConnectionStore(
@@ -118,8 +119,21 @@ function useImageGuard({ image, connectId, connectType }: UseImageGuardProps) {
       userId,
       imageFlag: image.minor ? 'Minor' : image.poi ? 'POI' : undefined,
       tosViolation,
+      needsReview: needsReview ?? null,
     }),
-    [safe, show, nsfwLevel, image.id, key, nsfw, userId, image.minor, image.poi, tosViolation]
+    [
+      safe,
+      show,
+      nsfwLevel,
+      image.id,
+      key,
+      nsfw,
+      userId,
+      image.minor,
+      image.poi,
+      tosViolation,
+      needsReview,
+    ]
   );
 }
 
@@ -245,7 +259,7 @@ function BlurToggle({
   alwaysVisible?: boolean;
 }) {
   const currentUser = useCurrentUser();
-  const { safe, show, browsingLevel, imageId, key, nsfw, userId, imageFlag } =
+  const { safe, show, browsingLevel, imageId, key, nsfw, userId, imageFlag, needsReview } =
     useImageGuardContext();
 
   const toggle = (event: React.MouseEvent<HTMLElement, MouseEvent>) =>
@@ -268,7 +282,9 @@ function BlurToggle({
     [nsfwClassName ? nsfwClassName : '']: nsfw,
   });
 
-  const showImageFlag = currentUser?.isModerator && imageFlag;
+  const isOwner = !!userId && currentUser?.id === userId;
+  const ownerCanSeeFlag = isOwner && !needsReview;
+  const showImageFlag = (currentUser?.isModerator || ownerCanSeeFlag) && imageFlag;
   const imageFlagRight = showImageFlag ? <ImageFlagSection label={imageFlag} /> : undefined;
   const imageFlagStyles = showImageFlag ? { section: imageFlagRightSectionStyles } : undefined;
 

--- a/src/components/Post/EditV2/PostEditSidebar.tsx
+++ b/src/components/Post/EditV2/PostEditSidebar.tsx
@@ -145,52 +145,41 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
       }
     );
 
-  const handleShowConfirmPublish = (date?: Date, reviewAcknowledged = false) => {
-    dialogStore.trigger({
-      component: ConfirmDialog,
-      props: {
-        title: params.confirmTitle,
-        message: params.confirmMessage ?? 'Are you sure you want to publish this post?',
-        onConfirm: () => handlePublish(date, false, reviewAcknowledged),
-      },
-    });
-  };
-
   const imagesInReview = useMemo(
     () => addedImages.filter((image) => !!image.needsReview),
     [addedImages]
   );
 
-  const handleShowReviewWarning = (date?: Date, confirmPublish = params.confirmPublish) => {
-    const count = imagesInReview.length;
-    const isPlural = count > 1;
+  const handleShowConfirmPublish = (date?: Date) => {
+    const reviewCount = imagesInReview.length;
+    const isPlural = reviewCount > 1;
+    const hasReview = reviewCount > 0;
     dialogStore.trigger({
       component: ConfirmDialog,
       props: {
-        title: 'Images pending review',
-        message: (
+        title: hasReview ? 'Images pending review' : params.confirmTitle,
+        message: hasReview ? (
           <>
             <Text>
-              {count} image{isPlural ? 's' : ''} in this post {isPlural ? 'are' : 'is'} currently
-              flagged for moderation review and will remain hidden from other users until approved.
+              {reviewCount} image{isPlural ? 's' : ''} in this post {isPlural ? 'are' : 'is'}{' '}
+              currently flagged for moderation review and will remain hidden from other users until
+              approved.
             </Text>
+            {params.confirmMessage && <Text mt="sm">{params.confirmMessage}</Text>}
             <Text mt="sm">Do you want to publish anyway?</Text>
           </>
+        ) : (
+          params.confirmMessage ?? 'Are you sure you want to publish this post?'
         ),
-        labels: { confirm: 'Publish anyway', cancel: 'Cancel' },
-        onConfirm: () => (confirmPublish ? handleShowConfirmPublish(date, true) : publish(date)),
+        labels: hasReview ? { confirm: 'Publish anyway', cancel: 'Cancel' } : undefined,
+        onConfirm: () => publish(date),
       },
     });
   };
 
-  const handlePublish = (
-    date?: Date,
-    confirmPublish = params.confirmPublish,
-    reviewAcknowledged = false
-  ) => {
-    if (!reviewAcknowledged && imagesInReview.length > 0)
-      return handleShowReviewWarning(date, confirmPublish);
-    confirmPublish ? handleShowConfirmPublish(date, reviewAcknowledged) : publish(date);
+  const handlePublish = (date?: Date, confirmPublish = params.confirmPublish) => {
+    const needsConfirm = confirmPublish || imagesInReview.length > 0;
+    needsConfirm ? handleShowConfirmPublish(date) : publish(date);
   };
 
   const handleScheduleClick = () => {

--- a/src/components/Post/EditV2/PostEditSidebar.tsx
+++ b/src/components/Post/EditV2/PostEditSidebar.tsx
@@ -156,7 +156,35 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
     });
   };
 
+  const imagesInReview = useMemo(
+    () => addedImages.filter((image) => !!image.needsReview),
+    [addedImages]
+  );
+
+  const handleShowReviewWarning = (date?: Date, confirmPublish = params.confirmPublish) => {
+    const count = imagesInReview.length;
+    const isPlural = count > 1;
+    dialogStore.trigger({
+      component: ConfirmDialog,
+      props: {
+        title: 'Images pending review',
+        message: (
+          <>
+            <Text>
+              {count} image{isPlural ? 's' : ''} in this post {isPlural ? 'are' : 'is'} currently
+              flagged for moderation review and will remain hidden from other users until approved.
+            </Text>
+            <Text mt="sm">Do you want to publish anyway?</Text>
+          </>
+        ),
+        labels: { confirm: 'Publish anyway', cancel: 'Cancel' },
+        onConfirm: () => (confirmPublish ? handleShowConfirmPublish(date) : publish(date)),
+      },
+    });
+  };
+
   const handlePublish = (date?: Date, confirmPublish = params.confirmPublish) => {
+    if (imagesInReview.length > 0) return handleShowReviewWarning(date, confirmPublish);
     confirmPublish ? handleShowConfirmPublish(date) : publish(date);
   };
 

--- a/src/components/Post/EditV2/PostEditSidebar.tsx
+++ b/src/components/Post/EditV2/PostEditSidebar.tsx
@@ -145,13 +145,13 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
       }
     );
 
-  const handleShowConfirmPublish = (date?: Date) => {
+  const handleShowConfirmPublish = (date?: Date, reviewAcknowledged = false) => {
     dialogStore.trigger({
       component: ConfirmDialog,
       props: {
         title: params.confirmTitle,
         message: params.confirmMessage ?? 'Are you sure you want to publish this post?',
-        onConfirm: () => handlePublish(date, false),
+        onConfirm: () => handlePublish(date, false, reviewAcknowledged),
       },
     });
   };
@@ -178,14 +178,19 @@ export function PostEditSidebar({ post }: { post: PostDetailEditable }) {
           </>
         ),
         labels: { confirm: 'Publish anyway', cancel: 'Cancel' },
-        onConfirm: () => (confirmPublish ? handleShowConfirmPublish(date) : publish(date)),
+        onConfirm: () => (confirmPublish ? handleShowConfirmPublish(date, true) : publish(date)),
       },
     });
   };
 
-  const handlePublish = (date?: Date, confirmPublish = params.confirmPublish) => {
-    if (imagesInReview.length > 0) return handleShowReviewWarning(date, confirmPublish);
-    confirmPublish ? handleShowConfirmPublish(date) : publish(date);
+  const handlePublish = (
+    date?: Date,
+    confirmPublish = params.confirmPublish,
+    reviewAcknowledged = false
+  ) => {
+    if (!reviewAcknowledged && imagesInReview.length > 0)
+      return handleShowReviewWarning(date, confirmPublish);
+    confirmPublish ? handleShowConfirmPublish(date, reviewAcknowledged) : publish(date);
   };
 
   const handleScheduleClick = () => {

--- a/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
+++ b/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
@@ -19,6 +19,7 @@ import {
 } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import {
+  IconAlertTriangle,
   IconArrowBackUp,
   IconCopyPlus,
   IconChevronDown,
@@ -35,6 +36,7 @@ import {
 import { getQueryKey } from '@trpc/react-query';
 import { remove, uniq } from 'lodash-es';
 import React, { createContext, useContext, useMemo, useState } from 'react';
+import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { openSetBrowsingLevelModal } from '~/components/Dialog/triggers/set-browsing-level';
 import { dialogStore } from '~/components/Dialog/dialogStore';
@@ -108,6 +110,8 @@ type State = {
   otherImages: PostEditImageDetail[];
   allowedResources: AllowedResource[];
   isPendingManualAssignment: boolean;
+  needsReview: string | null;
+  isMinor: boolean;
   onDelete: () => void;
   onEditMetaClick: () => void;
   isDeleting: boolean;
@@ -181,7 +185,8 @@ export function AddedImage({ image }: { image: PostEditImageDetail }) {
     state.post?.id,
   ]);
 
-  const { id, meta, blockedFor, ingestion, nsfwLevel, hideMeta, type } = storedImage;
+  const { id, meta, blockedFor, ingestion, nsfwLevel, hideMeta, type, needsReview } = storedImage;
+  const minor = image.minor ?? false;
   const otherImages = images
     .map((img) => (img.type === 'added' ? img.data : null))
     .filter(isDefined)
@@ -200,6 +205,7 @@ export function AddedImage({ image }: { image: PostEditImageDetail }) {
   const isScanned = ingestion === ImageIngestionStatus.Scanned;
   const isPendingManualAssignment = ingestion === ImageIngestionStatus.PendingManualAssignment;
   const isBlocked = false;
+  const isMinor = minor && !needsReview;
   const canAdd = canAddFunc(type, meta);
   // #endregion
 
@@ -295,6 +301,8 @@ export function AddedImage({ image }: { image: PostEditImageDetail }) {
         canAdd,
         otherImages,
         allowedResources,
+        needsReview: needsReview ?? null,
+        isMinor,
         onDelete: handleDelete,
         onEditMetaClick: handleEditMetaClick,
         isDeleting: deleteImageMutation.isLoading,
@@ -607,6 +615,8 @@ function EditDetail() {
     isUpdating,
     toggleHidePrompt,
     isPendingManualAssignment,
+    needsReview,
+    isMinor,
   } = useAddedImageContext();
   const postId = usePostEditStore((state) => state.post?.id);
   const updateImage = usePostEditStore((state) => state.updateImage);
@@ -649,6 +659,30 @@ function EditDetail() {
     <div className="relative @container">
       <div className={`flex flex-col gap-3 p-3  ${!showPreview ? '@sm:gap-4 @sm:p-6' : ''}`}>
         <LoadingOverlay visible={isDeleting} />
+        {needsReview && (
+          <AlertWithIcon
+            icon={<IconAlertTriangle size={20} />}
+            color="yellow"
+            iconColor="yellow"
+            title={needsReview === 'appeal' ? 'Under appeal' : 'Flagged for review'}
+            size="sm"
+          >
+            {needsReview === 'appeal'
+              ? `Your appeal has been submitted, but the image will remain hidden until it's reviewed by our moderators.`
+              : `This image won't be visible to other users until it's reviewed by our moderators.`}
+          </AlertWithIcon>
+        )}
+        {isMinor && (
+          <AlertWithIcon
+            icon={<IconAlertTriangle size={20} />}
+            color="yellow"
+            iconColor="yellow"
+            title="Flagged as minor"
+            size="sm"
+          >
+            This image has been flagged as containing a minor and has restricted visibility.
+          </AlertWithIcon>
+        )}
         <div
           className={`flex flex-row-reverse flex-wrap gap-3 ${
             !showPreview ? '@sm:flex-nowrap @sm:gap-6' : ''
@@ -1116,8 +1150,10 @@ function EditDetail() {
 
 function PostImage() {
   const { showPreview } = usePostPreviewContext();
-  const { image, isBlocked, onDelete, isDeleting, onEditMetaClick } = useAddedImageContext();
-  const { metadata, url, type, id, nsfwLevel } = image;
+  const { image, isBlocked, onDelete, isDeleting, onEditMetaClick, needsReview, isMinor } =
+    useAddedImageContext();
+  const { metadata, url, type, id, nsfwLevel, poi } = image;
+  const imageFlag = isMinor ? 'Minor' : !needsReview && poi ? 'POI' : undefined;
   return (
     <div className={`relative`}>
       <div
@@ -1140,14 +1176,21 @@ function PostImage() {
       </div>
       <div className="absolute inset-x-0 top-0 z-10 h-12 bg-gradient-to-b from-black opacity-25" />
       {!!nsfwLevel && (
-        <BrowsingLevelBadge
-          browsingLevel={nsfwLevel}
-          size="lg"
-          onClick={
-            !isBlocked ? () => openSetBrowsingLevelModal({ imageId: id, nsfwLevel }) : undefined
-          }
-          className={`absolute left-2 top-2 z-20 ${!isBlocked ? 'cursor-pointer' : ''}`}
-        />
+        <div className="absolute left-2 top-2 z-20 flex items-center gap-1">
+          <BrowsingLevelBadge
+            browsingLevel={nsfwLevel}
+            size="lg"
+            onClick={
+              !isBlocked ? () => openSetBrowsingLevelModal({ imageId: id, nsfwLevel }) : undefined
+            }
+            className={!isBlocked ? 'cursor-pointer' : ''}
+          />
+          {imageFlag && (
+            <Badge size="lg" color="yellow" variant="filled">
+              {imageFlag}
+            </Badge>
+          )}
+        </div>
       )}
       <div className="absolute right-2 top-2 z-20 flex gap-1">
         <Menu withArrow position="bottom-end">


### PR DESCRIPTION
## Summary
- Surface "Flagged for review" / "Under appeal" alert on PostEdit image cards (mirrors Image Detail page)
- Surface "Flagged as minor" alert when `minor` is set and review is complete
- Add pre-publish ConfirmDialog when any image in the post is pending moderation review
- Allow owners (not just moderators) to see the MINOR/POI flag badge once review is complete, both on Image Detail and on PostEdit image preview

ClickUp: https://app.clickup.com/t/868jqmn00

## Changes
- `src/components/Post/EditV2/PostImageCards/AddedImage.tsx` — surface `needsReview` + `minor` via context, render `AlertWithIcon` at top of card, append MINOR/POI badge beside `BrowsingLevelBadge` on image preview
- `src/components/Post/EditV2/PostEditSidebar.tsx` — `handlePublish` intercepts when `imagesInReview.length > 0` and shows a ConfirmDialog before continuing
- `src/components/ImageGuard/ImageGuard2.tsx` — `showImageFlag` now allows owner (gated on `!needsReview`); exposes `needsReview` through context; exports `ImageFlagSection` + `imageFlagRightSectionStyles` for reuse

## Test plan
- [ ] Open a post with an image that has `needsReview` set → see "Flagged for review" alert at top of card
- [ ] Open a post with an image that has `minor=true` and `needsReview=null` → see "Flagged as minor" alert + MINOR badge beside browsing-level badge
- [ ] Attempt to publish a post containing any `needsReview` image → confirmation modal appears warning that images will remain hidden
- [ ] As image owner, navigate to image detail of a `minor` image with no `needsReview` → MINOR badge visible next to browsing-level badge
- [ ] As image owner, on an image with `needsReview` set → MINOR badge hidden (owner shouldn't see flag while review is pending)
- [ ] Moderator behavior unchanged (sees MINOR/POI badge regardless of `needsReview`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)