### PR TITLE
fix(tracker): retry 5xx and log non-2xx responses from clickhouse tracker

### DIFF
--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -8,6 +8,7 @@ import { env } from '~/env/server';
 import type { NewOrderImageRatingStatus, NsfwLevel } from '~/server/common/enums';
 import type { AllModKeys } from '~/server/jobs/entity-moderation';
 import { logToAxiom } from '~/server/logging/client';
+import { sleep } from '~/utils/errorHandling';
 import type { AddImageRatingInput } from '~/server/schema/games/new-order.schema';
 import type { ProhibitedSources } from '~/server/schema/user.schema';
 import type { NsfwLevelDeprecated } from '~/shared/constants/browsingLevel.constants';
@@ -298,28 +299,84 @@ export class Tracker {
 
     const body =
       typeof data === 'function' ? data({ session: this.session, actor: this.actor }) : data;
+    const url = `${env.CLICKHOUSE_TRACKER_URL}/track/${table}`;
 
-    // Perform the clickhouse insert in the background
-    fetch(`${env.CLICKHOUSE_TRACKER_URL}/track/${table}`, {
-      method: 'POST',
-      body: JSON.stringify(body),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }).catch((e) => {
-      const error = e as Error;
+    // Fire-and-forget at the call site, but the inner attempt loop checks
+    // HTTP status (not just network errors) and retries 5xx with backoff.
+    // Prior version only handled network rejection from fetch(), so any
+    // 5xx response from the tracker — common when NATS publish ack times
+    // out — was silently dropped.
+    void this.sendWithRetry(url, body, table);
+  }
+
+  private async sendWithRetry(
+    url: string,
+    body: object,
+    table: string,
+    attempt = 1
+  ): Promise<void> {
+    const MAX_ATTEMPTS = 3;
+    const baseDelayMs = 250;
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (res.ok) return;
+
+      // 4xx: tracker rejected the payload. Retrying won't help. Log and bail.
+      if (res.status >= 400 && res.status < 500) {
+        const errBody = await res.text().catch(() => '');
+        logToAxiom(
+          {
+            type: 'warning',
+            name: 'Failed to track (4xx)',
+            details: { table, status: res.status, attempt, response: errBody.slice(0, 500) },
+            message: `Tracker returned ${res.status}`,
+          },
+          'clickhouse'
+        ).catch(() => {});
+        return;
+      }
+
+      // 5xx: transient — NATS publish timeout, JetStream rejection, etc.
+      if (attempt < MAX_ATTEMPTS) {
+        await sleep(baseDelayMs * 2 ** (attempt - 1) + Math.random() * baseDelayMs);
+        return this.sendWithRetry(url, body, table, attempt + 1);
+      }
+
+      const errBody = await res.text().catch(() => '');
       logToAxiom(
         {
           type: 'error',
-          name: 'Failed to track',
-          details: { table, data: JSON.stringify(data) },
+          name: 'Failed to track (5xx, exhausted)',
+          details: { table, status: res.status, attempts: attempt, response: errBody.slice(0, 500) },
+          message: `Tracker returned ${res.status} after ${attempt} attempts`,
+        },
+        'clickhouse'
+      ).catch(() => {});
+    } catch (e) {
+      const error = e as Error;
+      // Network-level failure. Retry the same as 5xx.
+      if (attempt < MAX_ATTEMPTS) {
+        await sleep(baseDelayMs * 2 ** (attempt - 1) + Math.random() * baseDelayMs);
+        return this.sendWithRetry(url, body, table, attempt + 1);
+      }
+      logToAxiom(
+        {
+          type: 'error',
+          name: 'Failed to track (network, exhausted)',
+          details: { table, attempts: attempt },
           message: error.message,
           stack: error.stack,
           cause: error.cause,
         },
         'clickhouse'
-      ).catch();
-    });
+      ).catch(() => {});
+    }
   }
 
   private async sendMany(


### PR DESCRIPTION
## Summary

Model-share's tracker client was silently dropping any HTTP 5xx response from `civitai-clickhouse-tracker`. `fetch().catch()` only fires on network errors — successful round-trips that return 503 (NATS publish ack timeout, default 5s) or 500 (JetStream rejection) fell through without a log line, and the event was lost.

The tracker upgrade made the server side durable via NATS JetStream, but the model-share client never noticed when the HTTP publish itself failed. This is the source of the residual ~30-40% per-image undercounts we observed on hot images while running the `entityMetricEvents` backfill: the backfill repaired the historical gap, but new live writes kept disappearing into 5xx responses.

## Changes

- `send()` now hands off to a new `sendWithRetry()` that inspects `response.status`:
  - **2xx** → success, return
  - **4xx** → log warning, do not retry (tracker rejected payload, retrying won't help)
  - **5xx** → exponential backoff retry up to 3 attempts (~250ms, 500ms, 1s + jitter)
  - **network error** → same retry policy as 5xx
- On final failure (3 attempts exhausted), emits a structured Axiom log under `Failed to track (5xx, exhausted)` or `Failed to track (network, exhausted)`, so drops become observable.
- Fire-and-forget at the call site is preserved via `void this.sendWithRetry(...)` — request handlers never block on tracker writes.

## Tradeoffs

- Loss is still possible if the model-share pod restarts mid-retry. Bounded to a few seconds rather than every single 5xx response. To eliminate this fully, the client would need a durable local queue (out of scope here).
- Retries add a small amount of background load. With backoff capped at 3 attempts and ~1s max delay, the worst-case extra traffic per event is bounded.

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Deploy to dev, monitor Axiom `clickhouse` dataset:
  - `Failed to track (5xx, exhausted)` count should be small (real outages only)
  - `Failed to track (4xx)` count should be ~0 (real client bugs)
- [ ] Compare PG `ImageReaction` count vs CH `entityMetricDailyAgg` for a few hot images over 24h — gap should be small / static, not accumulating

## Context

Related to the `civitai-scripts` reconciliation backfill that was needed to repair the historical gap. With this fix in place, future gaps stop accumulating; the backfill won't need to be re-run periodically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)