### PR TITLE
Revert #2292 (searchCutoffMs) — based on wrong default-behavior assumption

### DIFF
--- a/src/server/meilisearch/util.ts
+++ b/src/server/meilisearch/util.ts
@@ -1,4 +1,4 @@
-import type { Index, IndexOptions, MeiliSearchErrorInfo, Task, MeiliSearch } from 'meilisearch';
+import type { IndexOptions, MeiliSearchErrorInfo, Task, MeiliSearch } from 'meilisearch';
 import { MeiliSearchTimeOutError } from 'meilisearch';
 import { searchClient, metricsSearchClient } from '~/server/meilisearch/client';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
@@ -287,30 +287,4 @@ export const processUserContentRemovalQueue = async () => {
   return { processed: entries.length };
 };
 
-/**
- * Set `searchCutoffMs` on an index. Without this, a single expensive query
- * (deep nested filter, large facet expansion, etc.) can hold a read lock
- * indefinitely while writebacks pile up — which has cost us NVMe saturation
- * cascades on the search host. Meilisearch returns partial results once the
- * cutoff is reached; the user-visible signal is an `estimatedTotalHits` and
- * a `processingTimeMs` close to the cutoff.
- *
- * The dedicated endpoint is `PUT /indexes/{uid}/settings/search-cutoff-ms`.
- * It exists on Meilisearch server >=1.8 but is not typed in meilisearch-js
- * v0.33, so we call it via the client's internal http request.
- */
-const setSearchCutoffMs = async ({ index, ms }: { index: Index; ms: number }) => {
-  const url = `indexes/${index.uid}/settings/search-cutoff-ms`;
-  const current = await index.httpRequest.get<number | null>(url).catch(() => null);
-  if (current === ms) return;
-  await index.httpRequest.put(url, ms);
-  console.log(`setSearchCutoffMs :: ${index.uid} -> ${ms}ms (was ${current ?? 'null'})`);
-};
-
-export {
-  swapIndex,
-  getOrCreateIndex,
-  onSearchIndexDocumentsCleanup,
-  waitForTasksWithRetries,
-  setSearchCutoffMs,
-};
+export { swapIndex, getOrCreateIndex, onSearchIndexDocumentsCleanup, waitForTasksWithRetries };

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -7,7 +7,7 @@ import type { NsfwLevel } from '~/server/common/enums';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead } from '~/server/db/client';
 import { searchClient as client, updateDocs } from '~/server/meilisearch/client';
-import { getOrCreateIndex, setSearchCutoffMs } from '~/server/meilisearch/util';
+import { getOrCreateIndex } from '~/server/meilisearch/util';
 import {
   tagCache,
   tagIdsForImagesCache,
@@ -101,14 +101,6 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
       updateFilterableAttributesTask
     );
   }
-
-  // images_v6 is the largest index (60M+ docs, ~740 GB on disk). Cap query
-  // time as a safety net against pathological queries — set well above the
-  // observed P95 (~9s during disk pressure, lower in normal state) so the
-  // long tail of legitimate facet-heavy queries on /search/images is not
-  // silently truncated. Per Meilisearch metrics over 24h, ~95% of meili
-  // queries finish under 10s; 15s here only catches truly runaway requests.
-  await setSearchCutoffMs({ index, ms: 15000 });
 
   console.log('onIndexSetup :: all tasks completed');
 };

--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -4,7 +4,7 @@ import type { TypoTolerance } from 'meilisearch';
 import { type BaseModel, isBaseModelGenerationSupported } from '~/shared/constants/basemodel.constants';
 import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 import { searchClient as client, updateDocs } from '~/server/meilisearch/client';
-import { getOrCreateIndex, setSearchCutoffMs } from '~/server/meilisearch/util';
+import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { modelTagCache } from '~/server/redis/caches';
 import { imagesForModelVersionsCache } from '~/server/services/image.service';
 import type { ModelFileMetadata } from '~/server/schema/model-file.schema';
@@ -142,10 +142,6 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     const updateTypoToleranceTask = await index.updateTypoTolerance(typoTolerance);
     console.log('onIndexSetup :: updateTypoToleranceTask created', updateTypoToleranceTask);
   }
-
-  // Safety net against pathological queries. Set above the observed tail
-  // so legitimate refinement queries on /models are unaffected.
-  await setSearchCutoffMs({ index, ms: 8000 });
 };
 
 type Model = Prisma.ModelGetPayload<{

--- a/src/server/search-index/users.search-index.ts
+++ b/src/server/search-index/users.search-index.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 import { USERS_SEARCH_INDEX } from '~/server/common/constants';
 import { updateDocs } from '~/server/meilisearch/client';
 
-import { getOrCreateIndex, setSearchCutoffMs } from '~/server/meilisearch/util';
+import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { getCosmeticsForUsers, getProfilePicturesForUsers } from '~/server/services/user.service';
 
@@ -72,10 +72,6 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
       updateFilterableAttributesTask
     );
   }
-
-  // 10.9M docs. Most queries are username typeahead (<100ms), but some
-  // refinement queries are slower. Set as a safety net well above P95.
-  await setSearchCutoffMs({ index, ms: 5000 });
 
   console.log('onIndexSetup :: all tasks completed');
 };


### PR DESCRIPTION
Reverts #2292.

## What was wrong with #2292
The PR assumed \`searchCutoffMs = null\` meant *"no time bound at all"*. **It does not.** Verified at the Meilisearch v1.15.0 source tag:

\`\`\`rust
// crates/milli/src/lib.rs:153
impl Default for TimeBudget {
    fn default() -> Self {
        Self::new(std::time::Duration::from_millis(1500))
    }
}

// crates/meilisearch/src/search/mod.rs:1019
let time_budget = match index.search_cutoff(&rtxn)? {
    Some(cutoff) => TimeBudget::new(Duration::from_millis(cutoff)),
    None => TimeBudget::default(),   // ← 1500ms
};
\`\`\`

So \`null\` already enforces a **1.5 s processing-time budget**. The 15000 / 8000 / 5000 ms values in #2292 would have **loosened** the implicit default by 3-10× once propagated.

## Why the wrong-default conclusion was reached
The original symptom was Meilisearch P95 of ~9.8 s in Traefik metrics. I read that as proof that individual queries were running multi-second, when actually it was wall-clock that included queue + write contention. \`searchCutoffMs\` only bounds \`processingTimeMs\`, not wall-clock — so it would never have fixed the observed problem.

## Live impact: none yet
Verified via Meilisearch API on \`meilisearch-0\`: \`searchCutoffMs\` is still \`null\` on all 9 indexes (images_v6, models_v9, users_v3, articles_v5, bounties_v3, collections_v3, comics_v1, tools_v2, metrics_models_v1). Because \`onIndexSetup\` is only invoked from the \`reset()\` path (UNRUNNABLE_JOB_CRON), not from the regular sync cron, the merged code never ran against the live indexes.

This revert is precautionary — to prevent a future index reset from applying the wrong values.

## What actually addresses the latency cascade
- #2290 (merged) — images_v6 sync hourly → daily
- #2298 (open) — models sync */5 → */15

Both reduce the queue/contention component of wall-clock, which is what was actually paging us.

## Test plan
- [ ] Confirm no regression — should be a strict reversion to pre-#2292 behavior, which is what's running in prod right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)