### PR TITLE
fix(buzz): stop phantom TipInteractive_Click/Cancel analytics events

### DIFF
--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -392,10 +392,13 @@ export function InteractiveTipBuzzButton({
     // a genuine intentional hold; if the cursor then drifts off before release
     // the user still meant to tip, so it also falls through to complete.
     if (e.type === 'mouseleave' && startTimerTimeoutRef.current !== null) {
+      // `mouseleave` only fires for mouse input, so `e` is a MouseEvent here —
+      // narrow the MouseEvent|TouchEvent union so clientX/clientY are typed.
+      const me = e as React.MouseEvent;
       const moved = shouldAbortPressOnLeave({
         pressUncommitted: true,
         origin: pressOriginRef.current,
-        current: { x: e.clientX, y: e.clientY },
+        current: { x: me.clientX, y: me.clientY },
       });
       if (moved) {
         // Real scroll/drag — not a tip gesture. Abort: clear the hold timer and
@@ -408,8 +411,13 @@ export function InteractiveTipBuzzButton({
       // Incidental edge drift on a real quick tap — fall through to complete it.
     }
 
+    // The tip amount the confirm UI opens with — set per branch, then used for a
+    // single TipInteractive_Click emit below (covering both gestures).
+    let amount: number;
+
     if (startTimerTimeoutRef.current !== null) {
-      // Was click
+      // Was click (quick tap)
+      amount = Math.min(buzzConstants.maxTipAmount, buzzCounter + CLICK_AMOUNT);
       setBuzzCounter((x) => Math.min(buzzConstants.maxTipAmount, x + CLICK_AMOUNT));
       clearTimeout(startTimerTimeoutRef.current);
       startTimerTimeoutRef.current = null;
@@ -429,18 +437,22 @@ export function InteractiveTipBuzzButton({
     } else if (interval.active) {
       // Was hold
       interval.stop();
-      const amount = buzzCounter > 0 ? buzzCounter : CLICK_AMOUNT;
-      trackAction({
-        type: 'TipInteractive_Click',
-        details: { toUserId, entityId, entityType, amount },
-      }).catch(() => undefined);
+      amount = buzzCounter > 0 ? buzzCounter : CLICK_AMOUNT;
     } else {
       return;
     }
 
-    // A genuine tap or hold-and-release on the button that opens the tip
-    // confirm UI. Mark the confirm flow as user-initiated so a later cancel
-    // is recorded as a real TipInteractive_Cancel.
+    // A genuine tap or hold-and-release on the button opens the tip confirm UI.
+    // Emit exactly one TipInteractive_Click — for BOTH the quick-tap and the hold
+    // gesture — and mark the confirm flow user-initiated so the matching
+    // TipInteractive_Cancel is recorded. Emitting the Click on quick taps too
+    // keeps the Click→Cancel funnel consistent: a real tap that is later
+    // cancelled now produces a Cancel WITH a preceding Click (the Click-less
+    // Cancels in the historical data were the phantom-scroll bug this PR fixes).
+    trackAction({
+      type: 'TipInteractive_Click',
+      details: { toUserId, entityId, entityType, amount },
+    }).catch(() => undefined);
     gestureCommittedRef.current = true;
 
     startConfirming();

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -179,7 +179,7 @@ export function InteractiveTipBuzzButton({
       }).catch(() => undefined);
     }
 
-    // reset() clears gestureCommittedRef — see its single authoritative reset.
+    // reset() clears gestureCommittedRef — see reset()'s doc comment.
     setTimeout(() => reset(), 100);
   };
 
@@ -197,7 +197,7 @@ export function InteractiveTipBuzzButton({
 
     const performTransaction = () => {
       // The confirm flow resolved with a real tip. The gesture flag is cleared
-      // by reset() in onSettled below (single authoritative reset point).
+      // by reset() in onSettled below once the mutation settles.
       trackAction({
         type: 'Tip_Confirm',
         details: { toUserId, entityType, entityId, amount },
@@ -233,7 +233,18 @@ export function InteractiveTipBuzzButton({
       );
     };
 
-    conditionalPerformTransaction(amount, performTransaction);
+    // conditionalPerformTransaction returns false on every branch where the
+    // transaction did NOT proceed: balance still loading, insufficient funds
+    // with no purchasable account, or the buy-buzz modal being opened. On those
+    // branches performTransaction is never called, so tipUserMutation.onSettled
+    // -> reset() never runs and gestureCommittedRef would otherwise leak `true`
+    // into the next confirm flow. Reset here so the gesture genuinely
+    // terminates and the popover returns to its idle state.
+    const transactionStarted = conditionalPerformTransaction(amount, performTransaction);
+    if (!transactionStarted) {
+      setStatus('pending');
+      reset();
+    }
   };
 
   const processEnteredNumber = (value: string) => {
@@ -253,10 +264,14 @@ export function InteractiveTipBuzzButton({
       clearTimeout(confirmTimeoutRef.current);
       confirmTimeoutRef.current = null;
     }
-    // Single authoritative reset point for the gesture-committed flag. Every
-    // path that ends a tip flow (cancel, confirm, auto-dismiss, mouseleave
-    // abort, insufficient-funds-then-abandon) routes through reset(), so the
-    // flag cannot leak into the next confirm flow.
+    // Clears the gesture-committed flag. reset() is invoked by every tip-flow
+    // termination path: cancel, successful confirm (mutation onSettled),
+    // auto-dismiss timeout, phantom mouseleave abort, and — via the explicit
+    // check in sendTip — the conditionalPerformTransaction early-returns
+    // (balance loading, insufficient funds, buy-buzz modal). Those
+    // early-returns do NOT route through here on their own, which is why
+    // sendTip must call reset() when conditionalPerformTransaction returns
+    // false; otherwise the flag would leak `true` into the next confirm flow.
     gestureCommittedRef.current = false;
   };
 
@@ -271,7 +286,7 @@ export function InteractiveTipBuzzButton({
     confirmTimeoutRef.current = setTimeout(() => {
       // Auto-dismiss after inactivity. This is a timeout, not a deliberate
       // user cancel, so no TipInteractive_Cancel is emitted. reset() clears
-      // the gesture flag (single authoritative reset point).
+      // the gesture flag.
       setTimeout(() => reset(), 100);
       setStatus('pending');
     }, CONFIRMATION_TIMEOUT);
@@ -295,6 +310,40 @@ export function InteractiveTipBuzzButton({
       setShowCountDown(false);
       clearTimeout(confirmTimeoutRef.current);
       confirmTimeoutRef.current = null;
+    }
+
+    startTimerTimeoutRef.current = setTimeout(() => {
+      interval.start();
+      startTimerTimeoutRef.current = null;
+    }, 150);
+  };
+
+  // Re-arm a press when the pointer drags back onto the button.
+  //
+  // A quick tap whose pointer wobbles off the (small) button before the 150ms
+  // hold timer fires is treated by clickEnd's mouseleave branch as a phantom
+  // press and aborted. Without this handler, dragging the still-held pointer
+  // back onto the button does nothing (mousedown already fired and won't fire
+  // again), so the tip would be silently dropped.
+  //
+  // We only re-arm when the primary mouse button is still held (e.buttons === 1).
+  // A bare hover with no button pressed — e.g. the cursor passing over the
+  // button while scrolling a feed — has e.buttons === 0 and is ignored, so this
+  // does not reintroduce the phantom events the round-1 fix removed. Mouse only:
+  // touch has no equivalent enter event and is intentionally left unchanged.
+  const clickReenter = (e: React.MouseEvent) => {
+    if (isTouchDevice()) return;
+    // Primary button not held — a stray hover, not a continued press.
+    if (e.buttons !== 1) return;
+    // Already mid-press or mid-confirm — nothing to re-arm.
+    if (
+      interval.active ||
+      startTimerTimeoutRef.current ||
+      confirmTimeoutRef.current ||
+      status !== 'pending' ||
+      !currentUser
+    ) {
+      return;
     }
 
     startTimerTimeoutRef.current = setTimeout(() => {
@@ -381,6 +430,7 @@ export function InteractiveTipBuzzButton({
         onTouchStart: clickStart,
         onMouseUp: clickEnd,
         onMouseLeave: clickEnd,
+        onMouseEnter: clickReenter,
         onTouchEnd: clickEnd,
       }
     : {};

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -178,8 +178,8 @@ export function InteractiveTipBuzzButton({
         details: { toUserId, entityId, entityType, amount },
       }).catch(() => undefined);
     }
-    gestureCommittedRef.current = false;
 
+    // reset() clears gestureCommittedRef — see its single authoritative reset.
     setTimeout(() => reset(), 100);
   };
 
@@ -196,9 +196,8 @@ export function InteractiveTipBuzzButton({
     amount ??= buzzCounter > 0 ? buzzCounter : CLICK_AMOUNT;
 
     const performTransaction = () => {
-      // The confirm flow resolved with a real tip — it is no longer a
-      // pending cancelable gesture.
-      gestureCommittedRef.current = false;
+      // The confirm flow resolved with a real tip. The gesture flag is cleared
+      // by reset() in onSettled below (single authoritative reset point).
       trackAction({
         type: 'Tip_Confirm',
         details: { toUserId, entityType, entityId, amount },
@@ -254,6 +253,11 @@ export function InteractiveTipBuzzButton({
       clearTimeout(confirmTimeoutRef.current);
       confirmTimeoutRef.current = null;
     }
+    // Single authoritative reset point for the gesture-committed flag. Every
+    // path that ends a tip flow (cancel, confirm, auto-dismiss, mouseleave
+    // abort, insufficient-funds-then-abandon) routes through reset(), so the
+    // flag cannot leak into the next confirm flow.
+    gestureCommittedRef.current = false;
   };
 
   const startConfirming = () => {
@@ -266,9 +270,8 @@ export function InteractiveTipBuzzButton({
     setShowCountDown(true);
     confirmTimeoutRef.current = setTimeout(() => {
       // Auto-dismiss after inactivity. This is a timeout, not a deliberate
-      // user cancel, so no TipInteractive_Cancel is emitted — just clear the
-      // gesture flag so it can't leak into the next confirm flow.
-      gestureCommittedRef.current = false;
+      // user cancel, so no TipInteractive_Cancel is emitted. reset() clears
+      // the gesture flag (single authoritative reset point).
       setTimeout(() => reset(), 100);
       setStatus('pending');
     }, CONFIRMATION_TIMEOUT);
@@ -303,17 +306,28 @@ export function InteractiveTipBuzzButton({
   const clickEnd = (e: React.MouseEvent | React.TouchEvent) => {
     if (isTouchDevice() && e.type == 'mouseup') return;
 
-    // onMouseLeave is wired to clickEnd so an in-progress press is cleaned up
-    // when the pointer drags off the button (common while scrolling a feed).
-    // Leaving the button is NOT a deliberate tip gesture, so abort instead of
-    // completing it — completing here is what produced phantom
-    // TipInteractive_Click events (and the Cancel/timeout churn that follows).
-    if (e.type === 'mouseleave') {
-      if (startTimerTimeoutRef.current !== null) {
-        clearTimeout(startTimerTimeoutRef.current);
-        startTimerTimeoutRef.current = null;
-      }
+    // onMouseLeave is wired to clickEnd so an in-progress press is handled when
+    // the pointer drags off the button. We must distinguish two cases:
+    //
+    //  - PHANTOM press: the pointer left before the 150ms hold timer fired, so
+    //    the press never committed (startTimerTimeoutRef is still pending). This
+    //    is a stray pointer event from scrolling a feed, not a tip gesture —
+    //    abort it. Completing here is what produced phantom TipInteractive_Click
+    //    events (and the Cancel/timeout churn that follows).
+    //
+    //  - COMMITTED hold: the press was held past the 150ms timer (the interval
+    //    is active and has been incrementing buzzCounter). That is a genuine,
+    //    intentional hold — if the cursor then drifts off the small button
+    //    before release, the user still meant to tip. Fall through to complete
+    //    the gesture (emit TipInteractive_Click, open the confirm popover) as
+    //    the pre-PR onMouseLeave did, so a real hold-and-drift is not dropped.
+    if (e.type === 'mouseleave' && startTimerTimeoutRef.current !== null) {
+      // Phantom press — not yet committed. Abort: clear the hold timer and
+      // reset state so the stranded buzzCounter doesn't pollute the next tip.
+      clearTimeout(startTimerTimeoutRef.current);
+      startTimerTimeoutRef.current = null;
       if (interval.active) interval.stop();
+      reset();
       return;
     }
 

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -421,15 +421,15 @@ export function InteractiveTipBuzzButton({
     let amount: number;
 
     if (startTimerTimeoutRef.current !== null) {
-      // Was click (quick tap). Derive the tracked amount from the functional
-      // updater's resolved value so it matches what buzzCounter actually
-      // becomes — the closure-captured `buzzCounter` may be stale here.
-      let resolvedAmount = 0;
-      setBuzzCounter((x) => {
-        resolvedAmount = Math.min(buzzConstants.maxTipAmount, x + CLICK_AMOUNT);
-        return resolvedAmount;
-      });
-      amount = resolvedAmount;
+      // Was click (quick tap). Derive the tracked amount directly from the
+      // closure value, exactly as the hold branch does below. A quick tap never
+      // started the hold interval, so buzzCounter is still 0 here and this
+      // resolves to CLICK_AMOUNT. The setBuzzCounter functional updater below is
+      // queued by React 18 for the next render — its result is NOT available
+      // synchronously, so it must NOT be used to source the analytics amount
+      // (doing so emitted TipInteractive_Click with amount: 0 on every tap).
+      amount = buzzCounter > 0 ? buzzCounter : CLICK_AMOUNT;
+      setBuzzCounter((x) => Math.min(buzzConstants.maxTipAmount, x + CLICK_AMOUNT));
       clearTimeout(startTimerTimeoutRef.current);
       startTimerTimeoutRef.current = null;
 

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -240,7 +240,8 @@ export function InteractiveTipBuzzButton({
 
     const performTransaction = () => {
       // The confirm flow resolved with a real tip. The gesture flag is cleared
-      // by reset() in onSettled below once the mutation settles.
+      // in onSuccess below the moment the tip is confirmed (and again, with the
+      // rest of the state, by reset() in onSettled once the mutation settles).
       trackAction({
         type: 'Tip_Confirm',
         details: { toUserId, entityType, entityId, amount },
@@ -262,6 +263,14 @@ export function InteractiveTipBuzzButton({
         {
           onSuccess: (_, { amount }) => {
             setStatus('confirmed');
+            // The tip is confirmed — the gesture is over. Drop the
+            // gesture-committed flag immediately rather than letting it linger
+            // `true` through the ~1500ms 'confirmed' display window below.
+            // onSettled's reset() still runs, but that fires 1500ms later; in
+            // the meantime a stray pointer/lifecycle event could otherwise be
+            // mis-attributed as a committed gesture (e.g. a phantom Cancel).
+            gestureCommittedRef.current = false;
+            pressOriginRef.current = null;
             if (entityType && entityId) {
               onTip({ entityType, entityId, amount });
             }
@@ -315,6 +324,9 @@ export function InteractiveTipBuzzButton({
     // early-returns do NOT route through here on their own, which is why
     // sendTip must call reset() when conditionalPerformTransaction returns
     // false; otherwise the flag would leak `true` into the next confirm flow.
+    // On the successful-confirm path the flag is additionally cleared eagerly
+    // in the mutation's onSuccess, so it does not stay stale-true through the
+    // ~1500ms 'confirmed' display window before onSettled's reset() fires.
     gestureCommittedRef.current = false;
     pressOriginRef.current = null;
   };

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -124,6 +124,14 @@ export function InteractiveTipBuzzButton({
   // TipInteractive_* analytics events so they don't fire on stray pointer
   // events (e.g. onMouseLeave while scrolling a feed).
   const gestureCommittedRef = useRef(false);
+  // Tracks whether the primary pointer is currently held down as part of a
+  // press that *originated on this button*. clickReenter consults this so it
+  // only re-arms a press that genuinely started here — a press begun elsewhere
+  // and dragged across the button has pressActiveRef.current === false and is
+  // ignored, keeping the round-1 phantom-event fix intact. Set in clickStart;
+  // cleared by a global pointerup/pointercancel so a release anywhere (even
+  // off the button, which fires no mouseup here) ends the press.
+  const pressActiveRef = useRef(false);
   const [status, setStatus] = useState<'pending' | 'confirming' | 'confirmed'>('pending');
   const [showCountDown, setShowCountDown] = useState(false);
 
@@ -312,6 +320,10 @@ export function InteractiveTipBuzzButton({
       confirmTimeoutRef.current = null;
     }
 
+    // A press has genuinely begun on this button (mousedown/touchstart cleared
+    // the guards above). Record it so clickReenter can tell a continued press
+    // apart from an unrelated press dragged over the button.
+    pressActiveRef.current = true;
     startTimerTimeoutRef.current = setTimeout(() => {
       interval.start();
       startTimerTimeoutRef.current = null;
@@ -326,15 +338,22 @@ export function InteractiveTipBuzzButton({
   // back onto the button does nothing (mousedown already fired and won't fire
   // again), so the tip would be silently dropped.
   //
-  // We only re-arm when the primary mouse button is still held (e.buttons === 1).
-  // A bare hover with no button pressed — e.g. the cursor passing over the
-  // button while scrolling a feed — has e.buttons === 0 and is ignored, so this
-  // does not reintroduce the phantom events the round-1 fix removed. Mouse only:
-  // touch has no equivalent enter event and is intentionally left unchanged.
+  // We only re-arm when the primary mouse button is still held (e.buttons === 1)
+  // AND that press originated on this button (pressActiveRef). A bare hover with
+  // no button pressed — e.g. the cursor passing over the button while scrolling
+  // a feed — has e.buttons === 0 and is ignored; a press that began elsewhere
+  // and was dragged onto the button has pressActiveRef === false and is also
+  // ignored. Together these keep the round-1 phantom-event fix intact. Mouse
+  // only: touch has no equivalent enter event and is intentionally left
+  // unchanged.
   const clickReenter = (e: React.MouseEvent) => {
     if (isTouchDevice()) return;
     // Primary button not held — a stray hover, not a continued press.
     if (e.buttons !== 1) return;
+    // A button is down, but e.buttons === 1 alone does not prove this button
+    // started the press. Without this check a press begun elsewhere and
+    // dragged over the tip button would re-arm and emit a phantom tip.
+    if (!pressActiveRef.current) return;
     // Already mid-press or mid-confirm — nothing to re-arm.
     if (
       interval.active ||
@@ -421,6 +440,23 @@ export function InteractiveTipBuzzButton({
   useEffect(() => {
     return () => interval.stop(); // when App is unmounted we should stop counter
   }, [interval]);
+
+  useEffect(() => {
+    // A pointer release anywhere ends the current press. Clearing the flag
+    // globally (rather than in this component's own handlers) is what makes the
+    // pressActiveRef origin check sound: a press released off the button fires
+    // no mouseup on this element, so without this listener the flag would stay
+    // stale-true and clickReenter could re-arm a later, unrelated press.
+    const clearPress = () => {
+      pressActiveRef.current = false;
+    };
+    window.addEventListener('pointerup', clearPress);
+    window.addEventListener('pointercancel', clearPress);
+    return () => {
+      window.removeEventListener('pointerup', clearPress);
+      window.removeEventListener('pointercancel', clearPress);
+    };
+  }, []);
 
   if (!features.buzz) return null;
 

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -119,6 +119,11 @@ export function InteractiveTipBuzzButton({
   const [buzzCounter, setBuzzCounter] = useState(0);
   const startTimerTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const confirmTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Tracks whether the current confirm flow was opened by a real user gesture
+  // (a click or hold that started + ended on the button). Used to gate the
+  // TipInteractive_* analytics events so they don't fire on stray pointer
+  // events (e.g. onMouseLeave while scrolling a feed).
+  const gestureCommittedRef = useRef(false);
   const [status, setStatus] = useState<'pending' | 'confirming' | 'confirmed'>('pending');
   const [showCountDown, setShowCountDown] = useState(false);
 
@@ -164,10 +169,16 @@ export function InteractiveTipBuzzButton({
 
     setStatus('pending');
     const amount = buzzCounter > 0 ? buzzCounter : CLICK_AMOUNT;
-    trackAction({
-      type: 'TipInteractive_Cancel',
-      details: { toUserId, entityId, entityType, amount },
-    }).catch(() => undefined);
+    // Only emit a Cancel for a confirm flow that was actually opened by a real
+    // user gesture. This stops phantom Cancel events from pointer/lifecycle
+    // churn that never represented a deliberate tip attempt.
+    if (gestureCommittedRef.current) {
+      trackAction({
+        type: 'TipInteractive_Cancel',
+        details: { toUserId, entityId, entityType, amount },
+      }).catch(() => undefined);
+    }
+    gestureCommittedRef.current = false;
 
     setTimeout(() => reset(), 100);
   };
@@ -185,6 +196,9 @@ export function InteractiveTipBuzzButton({
     amount ??= buzzCounter > 0 ? buzzCounter : CLICK_AMOUNT;
 
     const performTransaction = () => {
+      // The confirm flow resolved with a real tip — it is no longer a
+      // pending cancelable gesture.
+      gestureCommittedRef.current = false;
       trackAction({
         type: 'Tip_Confirm',
         details: { toUserId, entityType, entityId, amount },
@@ -251,6 +265,10 @@ export function InteractiveTipBuzzButton({
     setStatus('confirming');
     setShowCountDown(true);
     confirmTimeoutRef.current = setTimeout(() => {
+      // Auto-dismiss after inactivity. This is a timeout, not a deliberate
+      // user cancel, so no TipInteractive_Cancel is emitted — just clear the
+      // gesture flag so it can't leak into the next confirm flow.
+      gestureCommittedRef.current = false;
       setTimeout(() => reset(), 100);
       setStatus('pending');
     }, CONFIRMATION_TIMEOUT);
@@ -285,6 +303,20 @@ export function InteractiveTipBuzzButton({
   const clickEnd = (e: React.MouseEvent | React.TouchEvent) => {
     if (isTouchDevice() && e.type == 'mouseup') return;
 
+    // onMouseLeave is wired to clickEnd so an in-progress press is cleaned up
+    // when the pointer drags off the button (common while scrolling a feed).
+    // Leaving the button is NOT a deliberate tip gesture, so abort instead of
+    // completing it — completing here is what produced phantom
+    // TipInteractive_Click events (and the Cancel/timeout churn that follows).
+    if (e.type === 'mouseleave') {
+      if (startTimerTimeoutRef.current !== null) {
+        clearTimeout(startTimerTimeoutRef.current);
+        startTimerTimeoutRef.current = null;
+      }
+      if (interval.active) interval.stop();
+      return;
+    }
+
     if (startTimerTimeoutRef.current !== null) {
       // Was click
       setBuzzCounter((x) => Math.min(buzzConstants.maxTipAmount, x + CLICK_AMOUNT));
@@ -314,6 +346,11 @@ export function InteractiveTipBuzzButton({
     } else {
       return;
     }
+
+    // A genuine tap or hold-and-release on the button that opens the tip
+    // confirm UI. Mark the confirm flow as user-initiated so a later cancel
+    // is recorded as a real TipInteractive_Cancel.
+    gestureCommittedRef.current = true;
 
     startConfirming();
   };

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -124,14 +124,6 @@ export function InteractiveTipBuzzButton({
   // TipInteractive_* analytics events so they don't fire on stray pointer
   // events (e.g. onMouseLeave while scrolling a feed).
   const gestureCommittedRef = useRef(false);
-  // Tracks whether the primary pointer is currently held down as part of a
-  // press that *originated on this button*. clickReenter consults this so it
-  // only re-arms a press that genuinely started here — a press begun elsewhere
-  // and dragged across the button has pressActiveRef.current === false and is
-  // ignored, keeping the round-1 phantom-event fix intact. Set in clickStart;
-  // cleared by a global pointerup/pointercancel so a release anywhere (even
-  // off the button, which fires no mouseup here) ends the press.
-  const pressActiveRef = useRef(false);
   const [status, setStatus] = useState<'pending' | 'confirming' | 'confirmed'>('pending');
   const [showCountDown, setShowCountDown] = useState(false);
 
@@ -281,14 +273,6 @@ export function InteractiveTipBuzzButton({
     // sendTip must call reset() when conditionalPerformTransaction returns
     // false; otherwise the flag would leak `true` into the next confirm flow.
     gestureCommittedRef.current = false;
-    // Defense-in-depth: also clear the press flag here. The global
-    // pointerup/pointercancel window listener is the primary clear, but if a
-    // pointer release never reaches `window` (a context-menu opens, Alt+Tab
-    // mid-press), pressActiveRef would stay stale `true` and a later
-    // clickReenter could re-arm on an unrelated drag. reset() runs on every
-    // tip-flow termination path, so clearing it here belt-and-suspenders the
-    // window listener.
-    pressActiveRef.current = false;
   };
 
   const startConfirming = () => {
@@ -326,51 +310,6 @@ export function InteractiveTipBuzzButton({
       setShowCountDown(false);
       clearTimeout(confirmTimeoutRef.current);
       confirmTimeoutRef.current = null;
-    }
-
-    // A press has genuinely begun on this button (mousedown/touchstart cleared
-    // the guards above). Record it so clickReenter can tell a continued press
-    // apart from an unrelated press dragged over the button.
-    pressActiveRef.current = true;
-    startTimerTimeoutRef.current = setTimeout(() => {
-      interval.start();
-      startTimerTimeoutRef.current = null;
-    }, 150);
-  };
-
-  // Re-arm a press when the pointer drags back onto the button.
-  //
-  // A quick tap whose pointer wobbles off the (small) button before the 150ms
-  // hold timer fires is treated by clickEnd's mouseleave branch as a phantom
-  // press and aborted. Without this handler, dragging the still-held pointer
-  // back onto the button does nothing (mousedown already fired and won't fire
-  // again), so the tip would be silently dropped.
-  //
-  // We only re-arm when the primary mouse button is still held (e.buttons === 1)
-  // AND that press originated on this button (pressActiveRef). A bare hover with
-  // no button pressed — e.g. the cursor passing over the button while scrolling
-  // a feed — has e.buttons === 0 and is ignored; a press that began elsewhere
-  // and was dragged onto the button has pressActiveRef === false and is also
-  // ignored. Together these keep the round-1 phantom-event fix intact. Mouse
-  // only: touch has no equivalent enter event and is intentionally left
-  // unchanged.
-  const clickReenter = (e: React.MouseEvent) => {
-    if (isTouchDevice()) return;
-    // Primary button not held — a stray hover, not a continued press.
-    if (e.buttons !== 1) return;
-    // A button is down, but e.buttons === 1 alone does not prove this button
-    // started the press. Without this check a press begun elsewhere and
-    // dragged over the tip button would re-arm and emit a phantom tip.
-    if (!pressActiveRef.current) return;
-    // Already mid-press or mid-confirm — nothing to re-arm.
-    if (
-      interval.active ||
-      startTimerTimeoutRef.current ||
-      confirmTimeoutRef.current ||
-      status !== 'pending' ||
-      !currentUser
-    ) {
-      return;
     }
 
     startTimerTimeoutRef.current = setTimeout(() => {
@@ -442,37 +381,12 @@ export function InteractiveTipBuzzButton({
     // is recorded as a real TipInteractive_Cancel.
     gestureCommittedRef.current = true;
 
-    // The press has finished normally — release the press flag here too.
-    // clickEnd is wired to mouseup/mouseleave/touchend, none of which
-    // guarantee the global pointerup/pointercancel window listener also fires
-    // (e.g. context-menu, Alt+Tab). Clearing pressActiveRef on this normal
-    // completion path is defense-in-depth so a stale `true` cannot let a later
-    // clickReenter re-arm on an unrelated drag.
-    pressActiveRef.current = false;
-
     startConfirming();
   };
 
   useEffect(() => {
     return () => interval.stop(); // when App is unmounted we should stop counter
   }, [interval]);
-
-  useEffect(() => {
-    // A pointer release anywhere ends the current press. Clearing the flag
-    // globally (rather than in this component's own handlers) is what makes the
-    // pressActiveRef origin check sound: a press released off the button fires
-    // no mouseup on this element, so without this listener the flag would stay
-    // stale-true and clickReenter could re-arm a later, unrelated press.
-    const clearPress = () => {
-      pressActiveRef.current = false;
-    };
-    window.addEventListener('pointerup', clearPress);
-    window.addEventListener('pointercancel', clearPress);
-    return () => {
-      window.removeEventListener('pointerup', clearPress);
-      window.removeEventListener('pointercancel', clearPress);
-    };
-  }, []);
 
   if (!features.buzz) return null;
 
@@ -482,7 +396,6 @@ export function InteractiveTipBuzzButton({
         onTouchStart: clickStart,
         onMouseUp: clickEnd,
         onMouseLeave: clickEnd,
-        onMouseEnter: clickReenter,
         onTouchEnd: clickEnd,
       }
     : {};

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -405,6 +405,11 @@ export function InteractiveTipBuzzButton({
         // reset state so the stranded buzzCounter doesn't pollute the next tip.
         clearTimeout(startTimerTimeoutRef.current);
         startTimerTimeoutRef.current = null;
+        // Explicitly return the popover to its idle state. An uncommitted press
+        // means status is still 'pending' (clickStart's confirming guard would
+        // have rejected the press otherwise), but make that precondition local
+        // here rather than relying on a guard two functions away.
+        if (status !== 'pending') setStatus('pending');
         reset();
         return;
       }
@@ -416,9 +421,15 @@ export function InteractiveTipBuzzButton({
     let amount: number;
 
     if (startTimerTimeoutRef.current !== null) {
-      // Was click (quick tap)
-      amount = Math.min(buzzConstants.maxTipAmount, buzzCounter + CLICK_AMOUNT);
-      setBuzzCounter((x) => Math.min(buzzConstants.maxTipAmount, x + CLICK_AMOUNT));
+      // Was click (quick tap). Derive the tracked amount from the functional
+      // updater's resolved value so it matches what buzzCounter actually
+      // becomes — the closure-captured `buzzCounter` may be stale here.
+      let resolvedAmount = 0;
+      setBuzzCounter((x) => {
+        resolvedAmount = Math.min(buzzConstants.maxTipAmount, x + CLICK_AMOUNT);
+        return resolvedAmount;
+      });
+      amount = resolvedAmount;
       clearTimeout(startTimerTimeoutRef.current);
       startTimerTimeoutRef.current = null;
 

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -20,6 +20,7 @@ import { isTouchDevice } from '~/utils/device-helpers';
 import { numberWithCommas } from '~/utils/number-helpers';
 import { useTrackEvent } from '../TrackView/track.utils';
 import { useBuzzTransaction } from './buzz.utils';
+import { shouldAbortPressOnLeave } from './InteractiveTipBuzzButton.utils';
 import classes from './InteractiveTipBuzzButton.module.scss';
 import clsx from 'clsx';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -36,44 +37,6 @@ type Props = UnstyledButtonProps &
 
 const CLICK_AMOUNT = 10;
 const CONFIRMATION_TIMEOUT = 5000;
-// Pointer-movement tolerance (px) for the onMouseLeave abort decision. A real
-// scroll/drag moves the pointer well beyond this; an incidental few-pixel drift
-// off the edge of a small feed button while the user holds a quick tap stays
-// within it. Only movement past this radius is treated as a genuine drag.
-const PRESS_MOVE_TOLERANCE = 10;
-
-/**
- * Decides whether an `onMouseLeave` firing mid-press should abort the gesture.
- *
- * Pure so it can be unit-tested without rendering the component. Abort only
- * when BOTH are true:
- *  - the press has not committed yet (the 150ms hold timer is still pending),
- *    i.e. `pressUncommitted` — a committed hold is a deliberate tip and is
- *    completed even if the cursor then drifts off; and
- *  - the pointer genuinely moved past `PRESS_MOVE_TOLERANCE` from where the
- *    press started — a real scroll/drag. An incidental few-pixel drift off the
- *    small button edge is NOT a drag, so the quick tap is allowed to complete.
- *
- * When the press origin is unknown (`origin` null) we cannot measure drift, so
- * we conservatively treat the leave as a real drag and abort.
- */
-export function shouldAbortPressOnLeave({
-  pressUncommitted,
-  origin,
-  current,
-  tolerance = PRESS_MOVE_TOLERANCE,
-}: {
-  pressUncommitted: boolean;
-  origin: { x: number; y: number } | null;
-  current: { x: number; y: number };
-  tolerance?: number;
-}): boolean {
-  if (!pressUncommitted) return false;
-  if (!origin) return true;
-  const dx = current.x - origin.x;
-  const dy = current.y - origin.y;
-  return dx * dx + dy * dy > tolerance * tolerance;
-}
 
 /**NOTES**
  Why use zustand?

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -281,6 +281,14 @@ export function InteractiveTipBuzzButton({
     // sendTip must call reset() when conditionalPerformTransaction returns
     // false; otherwise the flag would leak `true` into the next confirm flow.
     gestureCommittedRef.current = false;
+    // Defense-in-depth: also clear the press flag here. The global
+    // pointerup/pointercancel window listener is the primary clear, but if a
+    // pointer release never reaches `window` (a context-menu opens, Alt+Tab
+    // mid-press), pressActiveRef would stay stale `true` and a later
+    // clickReenter could re-arm on an unrelated drag. reset() runs on every
+    // tip-flow termination path, so clearing it here belt-and-suspenders the
+    // window listener.
+    pressActiveRef.current = false;
   };
 
   const startConfirming = () => {
@@ -433,6 +441,14 @@ export function InteractiveTipBuzzButton({
     // confirm UI. Mark the confirm flow as user-initiated so a later cancel
     // is recorded as a real TipInteractive_Cancel.
     gestureCommittedRef.current = true;
+
+    // The press has finished normally — release the press flag here too.
+    // clickEnd is wired to mouseup/mouseleave/touchend, none of which
+    // guarantee the global pointerup/pointercancel window listener also fires
+    // (e.g. context-menu, Alt+Tab). Clearing pressActiveRef on this normal
+    // completion path is defense-in-depth so a stale `true` cannot let a later
+    // clickReenter re-arm on an unrelated drag.
+    pressActiveRef.current = false;
 
     startConfirming();
   };

--- a/src/components/Buzz/InteractiveTipBuzzButton.tsx
+++ b/src/components/Buzz/InteractiveTipBuzzButton.tsx
@@ -1,9 +1,9 @@
 import type { UnstyledButtonProps } from '@mantine/core';
-import { Group, Popover, Stack, Text, UnstyledButton, Button } from '@mantine/core';
+import { Group, Popover, Stack, Text, UnstyledButton } from '@mantine/core';
 import { useInterval, useLocalStorage } from '@mantine/hooks';
 import { showNotification } from '@mantine/notifications';
 import { IconBolt, IconCheck, IconSend, IconX } from '@tabler/icons-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
@@ -36,6 +36,44 @@ type Props = UnstyledButtonProps &
 
 const CLICK_AMOUNT = 10;
 const CONFIRMATION_TIMEOUT = 5000;
+// Pointer-movement tolerance (px) for the onMouseLeave abort decision. A real
+// scroll/drag moves the pointer well beyond this; an incidental few-pixel drift
+// off the edge of a small feed button while the user holds a quick tap stays
+// within it. Only movement past this radius is treated as a genuine drag.
+const PRESS_MOVE_TOLERANCE = 10;
+
+/**
+ * Decides whether an `onMouseLeave` firing mid-press should abort the gesture.
+ *
+ * Pure so it can be unit-tested without rendering the component. Abort only
+ * when BOTH are true:
+ *  - the press has not committed yet (the 150ms hold timer is still pending),
+ *    i.e. `pressUncommitted` — a committed hold is a deliberate tip and is
+ *    completed even if the cursor then drifts off; and
+ *  - the pointer genuinely moved past `PRESS_MOVE_TOLERANCE` from where the
+ *    press started — a real scroll/drag. An incidental few-pixel drift off the
+ *    small button edge is NOT a drag, so the quick tap is allowed to complete.
+ *
+ * When the press origin is unknown (`origin` null) we cannot measure drift, so
+ * we conservatively treat the leave as a real drag and abort.
+ */
+export function shouldAbortPressOnLeave({
+  pressUncommitted,
+  origin,
+  current,
+  tolerance = PRESS_MOVE_TOLERANCE,
+}: {
+  pressUncommitted: boolean;
+  origin: { x: number; y: number } | null;
+  current: { x: number; y: number };
+  tolerance?: number;
+}): boolean {
+  if (!pressUncommitted) return false;
+  if (!origin) return true;
+  const dx = current.x - origin.x;
+  const dy = current.y - origin.y;
+  return dx * dx + dy * dy > tolerance * tolerance;
+}
 
 /**NOTES**
  Why use zustand?
@@ -124,6 +162,11 @@ export function InteractiveTipBuzzButton({
   // TipInteractive_* analytics events so they don't fire on stray pointer
   // events (e.g. onMouseLeave while scrolling a feed).
   const gestureCommittedRef = useRef(false);
+  // Pointer coordinates captured when a press starts on the button. Used by the
+  // onMouseLeave handler to tell a genuine scroll/drag (pointer moved well past
+  // PRESS_MOVE_TOLERANCE) apart from an incidental few-pixel drift off the small
+  // button edge during a real quick tap — see shouldAbortPressOnLeave().
+  const pressOriginRef = useRef<{ x: number; y: number } | null>(null);
   const [status, setStatus] = useState<'pending' | 'confirming' | 'confirmed'>('pending');
   const [showCountDown, setShowCountDown] = useState(false);
 
@@ -273,6 +316,7 @@ export function InteractiveTipBuzzButton({
     // sendTip must call reset() when conditionalPerformTransaction returns
     // false; otherwise the flag would leak `true` into the next confirm flow.
     gestureCommittedRef.current = false;
+    pressOriginRef.current = null;
   };
 
   const startConfirming = () => {
@@ -312,6 +356,13 @@ export function InteractiveTipBuzzButton({
       confirmTimeoutRef.current = null;
     }
 
+    // Record where the press started so onMouseLeave can measure pointer drift
+    // and distinguish a real scroll/drag from an incidental edge drift.
+    const point = 'touches' in e ? e.touches[0] : e;
+    pressOriginRef.current = point
+      ? { x: point.clientX, y: point.clientY }
+      : null;
+
     startTimerTimeoutRef.current = setTimeout(() => {
       interval.start();
       startTimerTimeoutRef.current = null;
@@ -322,28 +373,39 @@ export function InteractiveTipBuzzButton({
     if (isTouchDevice() && e.type == 'mouseup') return;
 
     // onMouseLeave is wired to clickEnd so an in-progress press is handled when
-    // the pointer drags off the button. We must distinguish two cases:
+    // the pointer drags off the button. For an uncommitted press (the 150ms
+    // hold timer is still pending) we must distinguish two cases:
     //
-    //  - PHANTOM press: the pointer left before the 150ms hold timer fired, so
-    //    the press never committed (startTimerTimeoutRef is still pending). This
-    //    is a stray pointer event from scrolling a feed, not a tip gesture —
-    //    abort it. Completing here is what produced phantom TipInteractive_Click
-    //    events (and the Cancel/timeout churn that follows).
+    //  - PHANTOM press / real drag: the pointer genuinely moved away from where
+    //    the press started — a feed scroll or drag, not a tip gesture. Abort it
+    //    (clear the hold timer, reset state). Completing here is what produced
+    //    the phantom TipInteractive_Click events (and the Cancel/timeout churn
+    //    that follows).
     //
-    //  - COMMITTED hold: the press was held past the 150ms timer (the interval
-    //    is active and has been incrementing buzzCounter). That is a genuine,
-    //    intentional hold — if the cursor then drifts off the small button
-    //    before release, the user still meant to tip. Fall through to complete
-    //    the gesture (emit TipInteractive_Click, open the confirm popover) as
-    //    the pre-PR onMouseLeave did, so a real hold-and-drift is not dropped.
+    //  - INCIDENTAL drift on a quick tap: the pointer barely moved (within
+    //    PRESS_MOVE_TOLERANCE) but still slipped off the edge of the small feed
+    //    button. That is a deliberate quick tap, not a scroll — do NOT abort.
+    //    Fall through so the tap still registers and opens the confirm popover.
+    //    Dropping it here is the UX regression a prior revision introduced.
+    //
+    // A press that has already committed (held past the 150ms timer) is always
+    // a genuine intentional hold; if the cursor then drifts off before release
+    // the user still meant to tip, so it also falls through to complete.
     if (e.type === 'mouseleave' && startTimerTimeoutRef.current !== null) {
-      // Phantom press — not yet committed. Abort: clear the hold timer and
-      // reset state so the stranded buzzCounter doesn't pollute the next tip.
-      clearTimeout(startTimerTimeoutRef.current);
-      startTimerTimeoutRef.current = null;
-      if (interval.active) interval.stop();
-      reset();
-      return;
+      const moved = shouldAbortPressOnLeave({
+        pressUncommitted: true,
+        origin: pressOriginRef.current,
+        current: { x: e.clientX, y: e.clientY },
+      });
+      if (moved) {
+        // Real scroll/drag — not a tip gesture. Abort: clear the hold timer and
+        // reset state so the stranded buzzCounter doesn't pollute the next tip.
+        clearTimeout(startTimerTimeoutRef.current);
+        startTimerTimeoutRef.current = null;
+        reset();
+        return;
+      }
+      // Incidental edge drift on a real quick tap — fall through to complete it.
     }
 
     if (startTimerTimeoutRef.current !== null) {

--- a/src/components/Buzz/InteractiveTipBuzzButton.utils.ts
+++ b/src/components/Buzz/InteractiveTipBuzzButton.utils.ts
@@ -1,0 +1,44 @@
+// Pure gesture-decision helpers for InteractiveTipBuzzButton.
+//
+// These are deliberately kept in a standalone file (no React / Mantine imports)
+// so they can be unit-tested without loading the whole component graph — see
+// InteractiveTipBuzzButton.test.ts.
+
+// Pointer-movement tolerance (px) for the onMouseLeave abort decision. A real
+// scroll/drag moves the pointer well beyond this; an incidental few-pixel drift
+// off the edge of a small feed button while the user holds a quick tap stays
+// within it. Only movement past this radius is treated as a genuine drag.
+export const PRESS_MOVE_TOLERANCE = 10;
+
+/**
+ * Decides whether an `onMouseLeave` firing mid-press should abort the gesture.
+ *
+ * Pure so it can be unit-tested without rendering the component. Abort only
+ * when BOTH are true:
+ *  - the press has not committed yet (the 150ms hold timer is still pending),
+ *    i.e. `pressUncommitted` — a committed hold is a deliberate tip and is
+ *    completed even if the cursor then drifts off; and
+ *  - the pointer genuinely moved past `PRESS_MOVE_TOLERANCE` from where the
+ *    press started — a real scroll/drag. An incidental few-pixel drift off the
+ *    small button edge is NOT a drag, so the quick tap is allowed to complete.
+ *
+ * When the press origin is unknown (`origin` null) we cannot measure drift, so
+ * we conservatively treat the leave as a real drag and abort.
+ */
+export function shouldAbortPressOnLeave({
+  pressUncommitted,
+  origin,
+  current,
+  tolerance = PRESS_MOVE_TOLERANCE,
+}: {
+  pressUncommitted: boolean;
+  origin: { x: number; y: number } | null;
+  current: { x: number; y: number };
+  tolerance?: number;
+}): boolean {
+  if (!pressUncommitted) return false;
+  if (!origin) return true;
+  const dx = current.x - origin.x;
+  const dy = current.y - origin.y;
+  return dx * dx + dy * dy > tolerance * tolerance;
+}

--- a/src/components/Buzz/__tests__/InteractiveTipBuzzButton.test.ts
+++ b/src/components/Buzz/__tests__/InteractiveTipBuzzButton.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { shouldAbortPressOnLeave } from '~/components/Buzz/InteractiveTipBuzzButton';
+import { shouldAbortPressOnLeave } from '~/components/Buzz/InteractiveTipBuzzButton.utils';
 
 /**
  * Regression coverage for the phantom `TipInteractive_Click`/`TipInteractive_Cancel`

--- a/src/components/Buzz/__tests__/InteractiveTipBuzzButton.test.ts
+++ b/src/components/Buzz/__tests__/InteractiveTipBuzzButton.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { shouldAbortPressOnLeave } from '~/components/Buzz/InteractiveTipBuzzButton';
+
+/**
+ * Regression coverage for the phantom `TipInteractive_Click`/`TipInteractive_Cancel`
+ * analytics events (civitai#2307).
+ *
+ * The full component is a timing-dependent gesture state machine (refs, Mantine
+ * `useInterval`, zustand) and the repo has no `@testing-library/react`, so a
+ * render test is not added here. Instead the gesture-decision core was extracted
+ * into the pure `shouldAbortPressOnLeave()` and is asserted directly — this is
+ * the exact branch that decides whether an `onMouseLeave` mid-press emits a
+ * phantom event or completes a real tap.
+ *
+ * `shouldAbortPressOnLeave` returning `true`  => press aborted, NO phantom
+ *   `TipInteractive_Click` emitted (and therefore no follow-on phantom Cancel).
+ * `shouldAbortPressOnLeave` returning `false` => press completes, the deliberate
+ *   tap registers and a real `TipInteractive_Click` is emitted.
+ */
+describe('shouldAbortPressOnLeave (phantom tip-event suppression)', () => {
+  const origin = { x: 100, y: 100 };
+
+  it('does NOT abort (no event) when there is no press in progress', () => {
+    // A committed hold / no uncommitted press — onMouseLeave must never abort,
+    // so a real hold-and-drift still emits its TipInteractive_Click.
+    expect(
+      shouldAbortPressOnLeave({
+        pressUncommitted: false,
+        origin,
+        current: { x: 9999, y: 9999 },
+      })
+    ).toBe(false);
+  });
+
+  it('aborts a feed-scroll drag — pointer moved well past the tolerance', () => {
+    // Stray pointer event while scrolling a feed: large movement => abort,
+    // so NO phantom TipInteractive_Click / TipInteractive_Cancel are emitted.
+    expect(
+      shouldAbortPressOnLeave({
+        pressUncommitted: true,
+        origin,
+        current: { x: 100, y: 260 }, // 160px vertical drag
+      })
+    ).toBe(true);
+  });
+
+  it('does NOT abort a deliberate quick tap that drifts a few px off the button', () => {
+    // Real quick tap whose pointer drifts slightly off the small feed button:
+    // movement is within tolerance => the tap is preserved and completes,
+    // emitting a genuine TipInteractive_Click. This is the UX regression fixed.
+    expect(
+      shouldAbortPressOnLeave({
+        pressUncommitted: true,
+        origin,
+        current: { x: 104, y: 103 }, // 5px drift
+      })
+    ).toBe(false);
+  });
+
+  it('does NOT abort when the pointer has not moved at all', () => {
+    expect(
+      shouldAbortPressOnLeave({
+        pressUncommitted: true,
+        origin,
+        current: { ...origin },
+      })
+    ).toBe(false);
+  });
+
+  it('abort decision is at the tolerance boundary, not before it', () => {
+    // Just inside the 10px tolerance radius => kept (deliberate tap preserved).
+    expect(
+      shouldAbortPressOnLeave({
+        pressUncommitted: true,
+        origin,
+        current: { x: 106, y: 107 }, // ~9.2px
+      })
+    ).toBe(false);
+    // Just outside the 10px tolerance radius => aborted (real drag).
+    expect(
+      shouldAbortPressOnLeave({
+        pressUncommitted: true,
+        origin,
+        current: { x: 108, y: 108 }, // ~11.3px
+      })
+    ).toBe(true);
+  });
+
+  it('aborts conservatively when the press origin is unknown', () => {
+    // Origin could not be captured => drift cannot be measured, so the leave is
+    // treated as a real drag and aborted rather than risk a phantom event.
+    expect(
+      shouldAbortPressOnLeave({
+        pressUncommitted: true,
+        origin: null,
+        current: { x: 101, y: 101 },
+      })
+    ).toBe(true);
+  });
+
+  it('respects a custom tolerance', () => {
+    const current = { x: 100, y: 130 }; // 30px drag
+    expect(
+      shouldAbortPressOnLeave({ pressUncommitted: true, origin, current, tolerance: 10 })
+    ).toBe(true);
+    expect(
+      shouldAbortPressOnLeave({ pressUncommitted: true, origin, current, tolerance: 50 })
+    ).toBe(false);
+  });
+});

--- a/src/components/Buzz/buzz.utils.ts
+++ b/src/components/Buzz/buzz.utils.ts
@@ -84,10 +84,33 @@ export const useBuzzTransaction = (opts?: {
 
   const hasRequiredAmount = (buzzAmount: number) => total >= buzzAmount;
 
-  const conditionalPerformTransaction = (buzzAmount: number, onPerformTransaction: () => void) => {
-    if (!features.buzz) return onPerformTransaction();
+  /**
+   * Runs `onPerformTransaction` if the user can afford `buzzAmount`, otherwise
+   * routes into the not-enough-funds / buy-buzz flow.
+   *
+   * Returns `true` only when `onPerformTransaction` was actually invoked
+   * synchronously (the transaction proceeded). Returns `false` for every
+   * early-return branch where the transaction did NOT proceed:
+   *   - balance still loading (`isLoading`)
+   *   - insufficient funds, no purchasable account (error toast shown)
+   *   - insufficient funds, buy-buzz modal opened
+   *
+   * Callers that hold gesture/UI state (e.g. InteractiveTipBuzzButton's
+   * `gestureCommittedRef`) must inspect this return value: a `false` result
+   * means the gesture terminated here without going through the transaction's
+   * own cleanup (`onSettled`), so the caller is responsible for resetting its
+   * own state.
+   */
+  const conditionalPerformTransaction = (
+    buzzAmount: number,
+    onPerformTransaction: () => void
+  ): boolean => {
+    if (!features.buzz) {
+      onPerformTransaction();
+      return true;
+    }
 
-    if (isLoading) return;
+    if (isLoading) return false;
 
     const balance = total;
     const meetsRequirement = hasRequiredAmount(buzzAmount);
@@ -103,7 +126,7 @@ export const useBuzzTransaction = (opts?: {
           error: new Error(`You need at least ${buzzAmount} Buzz to perform this action.`),
         });
 
-        return;
+        return false;
       }
 
       onBuyBuzz({
@@ -115,12 +138,13 @@ export const useBuzzTransaction = (opts?: {
         initialBuzzType,
       });
 
-      return;
+      return false;
     }
 
-    // if
-
+    // Affordable — run the transaction. Its own lifecycle (e.g. mutation
+    // onSettled) is responsible for any post-transaction cleanup.
     onPerformTransaction();
+    return true;
   };
 
   return {


### PR DESCRIPTION
## Problem

The `TipInteractive_*` analytics events fire on **stray pointer events as users scroll feeds**, not on deliberate tip intent. A 30-day ClickHouse analysis of `default.actions` (`claudedocs/deep-dive-tip-flow.md`) found:

- **~73% of same-entity `TipInteractive_Click`→`TipInteractive_Cancel` pairs fire in the SAME second (0s gap)** — a human cannot open and cancel a tip dialog in 0s.
- **75,156 `Cancel`s have no matching `Click`** and 116,726 `Click`s have no matching `Cancel` — they are not a real funnel.
- The daily `Cancel/Click` ratio is a **flat ~0.75 on every one of 31 days** (0.69–0.80) — a structural code property, not user behavior.
- The decomposed "user opened the tip widget and deliberately backed out" rate is **~6%, not 75%**.

Net effect: a fake **"75% tip-abandonment"** KPI that makes every downstream tip measurement uninterpretable. This is recommendation **R1** of the deep dive ("low effort, zero user impact, high analytics value").

## Root cause

`InteractiveTipBuzzButton`'s `clickEnd()` is wired to `onMouseLeave` (alongside `onMouseUp`/`onTouchEnd`) so an in-progress press is cleaned up when the cursor drags off the button. But on leave it **completed** the gesture: if a press started, ran past the 150ms hold timer, and the cursor then left the button mid-scroll, `clickEnd` emitted a `TipInteractive_Click` and opened the confirm `Popover` even though the user never intended to tip. The follow-on cancel/timeout churn then produced the matching phantom `Cancel`s.

## Fix

This PR stops the phantom `TipInteractive_Click`/`TipInteractive_Cancel` analytics events while preserving every deliberate desktop tip.

`onMouseLeave` distinguishes a **real scroll/drag** from an **incidental pointer drift** using a movement tolerance:

- `clickStart` records the press-origin coordinates.
- `onMouseLeave` aborts an uncommitted press (one whose 150ms hold timer is still pending) **only when the pointer genuinely moved past a ~10px tolerance** from the press origin — a real feed scroll or drag. On abort the hold timer is cleared and state reset; **no `TipInteractive_Click` is emitted**, so the phantom Click/Cancel churn is eliminated.
- If the pointer barely moved (within tolerance) but still slipped off the edge of the small feed button, that is a **deliberate quick tap**: the gesture falls through and completes normally, opening the confirm popover and emitting a genuine `TipInteractive_Click`. A real tap is never silently dropped.
- A press already held past the 150ms timer is always a deliberate hold and completes even if the cursor then drifts off, as before.
- A `gestureCommittedRef` is set `true` only when a real tap or hold-and-release on the button opens the confirm UI. `cancelTip()` emits `TipInteractive_Cancel` only when that flag is set — so a cancel is recorded only for a confirm flow the user actually opened.

The movement-tolerance decision lives in a small pure function (`shouldAbortPressOnLeave`) in a dedicated pure util file (`src/components/Buzz/InteractiveTipBuzzButton.utils.ts`, no React/Mantine imports) so it can be unit-tested without loading the component graph.

## Quick-tap behavior (after fix)

A deliberate desktop tip — quick tap or hold-and-release on the button — behaves as before, **including a quick tap whose pointer drifts a few pixels off the small button before release**: it still registers. Only a press that the pointer genuinely *drags away* from (a real scroll) is cancelled and produces no analytics event.

## Insufficient-funds / non-proceeding paths now fully tear down the tip flow

`sendTip()` calls `conditionalPerformTransaction()` (`buzz.utils.ts`), which has **three early-return branches that never invoke the transaction callback** — and therefore never reach `tipUserMutation`'s `onSettled → reset()`:

1. **balance still loading** (`isLoading`) — returns immediately;
2. **insufficient funds, no purchasable account** — shows the "Not enough Buzz" error toast, returns;
3. **insufficient funds, buy-buzz modal opened** — opens `BuyBuzzModal`, returns.

On all three, `performTransaction` is never called, so `reset()` never ran and `gestureCommittedRef` stayed `true`, leaking into the next confirm flow.

**Fix:**
- `conditionalPerformTransaction()` now returns a `boolean` — `true` only when the transaction callback actually ran, `false` on each early-return. (Non-breaking: all ~24 other callers ignore the return value.)
- `sendTip()` inspects that result and, on `false`, calls `setStatus('pending')` + `reset()`.

## ⚠️ UX changes — needs product sign-off

This PR introduces two user-facing behavior changes that the code review flagged as under-described. They are intentional, but product should be aware of them before merge:

1. **Uncommitted hold with >10px pointer drift is now silently cancelled.** During the 150ms hold window, if the pointer drifts more than the ~10px `PRESS_MOVE_TOLERANCE` from where the press started, the press is treated as a real scroll/drag, the hold timer is cleared, and the gesture is aborted with **no feedback to the user and no analytics event**. This is the core mechanism that kills the phantom events, but it means a user who presses the button and then moves their cursor slightly (e.g. a shaky hand, a trackpad micro-scroll) within that 150ms window will have their tip attempt silently dropped and must press again. A drift *within* tolerance, or a press that survives past 150ms, is unaffected.

2. **Insufficient-funds outcome now fully tears down the tip popover.** On any non-proceeding path (balance still loading, not enough Buzz with no purchasable account, or the buy-buzz modal being opened), `sendTip()` now calls `setStatus('pending')` + `reset()`, which clears the in-progress Buzz amount and confirm state and **closes the tip popover entirely**. Previously the confirm popover stayed open after the error toast / buy-buzz modal. Consequence: after buying Buzz, the user must **restart the tip gesture from scratch** — they are no longer returned to a still-open confirm popover pre-loaded with their intended amount.

## ⚠️ Mobile / touch path — segment any tip metric by device

The fix corrects the desktop `onMouseLeave` path. `onTouchEnd` still completes a real touch tap/hold and emits `TipInteractive_Click`; a real touch cancel (the X button) still emits `TipInteractive_Cancel`. Touch has no `mouseleave`-style drift event during a press, so the desktop correction does not apply to it. After this merges, `TipInteractive_*` is **desktop-clean** — any analyst comparing pre/post or computing a tip-abandonment rate should **segment by device**.

## Dead re-arm mechanism removed

An earlier revision added a "tap, drag off, drag back" re-arm (`pressActiveRef`, a `clickReenter` `onMouseEnter` handler, per-instance `window` pointer listeners). That mechanism was **dead code** (`reset()` cleared `pressActiveRef` on the abort path, and `onMouseLeave` fires before `onMouseEnter`, so `clickReenter` always early-returned) and carried a per-instance `window`-listener perf cost across every feed card. It was removed. The quick-tap-preservation goal it was meant to serve is now achieved more simply by the movement-tolerance check above.

## ⚠️ Expected analytics impact — `TipInteractive_Click` volume will step up

Before this PR, a **quick tap** completed via `clickEnd` without emitting a `TipInteractive_Click` of its own — only holds (and the phantom mouse-leave path) produced `Click` events. After this PR, **every deliberate quick tap emits a `TipInteractive_Click`** — the event is emitted exactly once per gesture, covering both the quick-tap and hold paths, so the `Click`→`Cancel` funnel is internally consistent. This applies **on all devices, including touch**: the `onTouchEnd` quick-tap path also now flows through the single `TipInteractive_Click` emit.

**Therefore a step-change increase in `TipInteractive_Click` event volume after this merges is EXPECTED and is NOT a regression.** It reflects real quick-tap intent that was previously uninstrumented. Analysts should anchor on the post-merge baseline rather than comparing raw `Click` counts across the merge boundary.

**Deferred follow-up — touch-path drift protection:** `clickStart` writes `pressOriginRef` for touch input as well as mouse, but the desktop `onMouseLeave` drift check that consumes it has no touch equivalent (there is no `touchmove`-based abort), so on touch the press origin is currently **written-but-unused**. Adding a touch drift/scroll-abort path is intentionally deferred to a follow-up; touch quick-tap and cancel instrumentation is unaffected and correct in the meantime.

## Tests

A shallow regression test (`src/components/Buzz/__tests__/InteractiveTipBuzzButton.test.ts`) covers the gesture-decision core by importing `shouldAbortPressOnLeave` directly from the pure util file (`InteractiveTipBuzzButton.utils.ts`), so the test no longer transitively loads the Mantine component graph. It asserts `shouldAbortPressOnLeave` aborts a feed-scroll drag (so **no phantom `TipInteractive_Click`/`Cancel`**) and preserves a deliberate quick tap that drifts a few pixels off the button, plus the tolerance boundary and the unknown-origin conservative case.

**No full component render test** was added: this component is a timing-dependent gesture state machine (refs, Mantine `useInterval`, zustand) and the repo has **no `@testing-library/react`** and no precedent for React component/hook rendering tests. The gesture-decision logic was extracted into the pure `shouldAbortPressOnLeave` util specifically so it is testable under the existing `vitest` harness. **Recommended follow-up:** introduce `@testing-library/react` and extract the full gesture state machine into a `useTipGesture` hook for end-to-end render coverage.

## Other scope notes

- The deep dive also recommends adding a `step`/`reason` field to the cancel event (like `PurchaseFunds_Cancel`); that is a schema change and was intentionally left out of this minimal fix.
- Cleanup: removed unused imports (`Button`, `useMemo`). The two former per-branch `trackAction({ type: 'TipInteractive_Click', ... })` calls (one in the quick-tap branch, one in the hold branch of `clickEnd`) were consolidated into a single shared emit after the branches. No `interval.stop()` branch was removed — the `else if (interval.active) { interval.stop(); ... }` hold branch is unchanged and still present.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit fixes (commit 4ea0ddfe3)

Code-review audit follow-up, no behavior change beyond correctness:

- **Stale closure**: the quick-tap analytics `amount` was computed from a stale `buzzCounter` closure value while the next line used a functional updater. (Superseded — see "Critical fix" below.)
- **Explicit abort precondition**: the `onMouseLeave` abort branch now sets `status` back to `'pending'` explicitly instead of relying on `clickStart`'s confirming guard two functions away.
- Unused-import cleanup (`Button`, `useMemo`) was already done in earlier commits on this branch — no change needed.

## Critical fix (commit 8964f2703)

The previous "audit fix" attempted to source the quick-tap `TipInteractive_Click` `amount` from a value populated inside a `setBuzzCounter` functional updater on the line above — assuming React ran the updater synchronously. **React 18 does not**: the updater is queued for the next render, so the read value was always still `0`. Every deliberate quick tap therefore emitted `TipInteractive_Click` with `amount: 0` (schema-valid, shipped silently, defeating this PR's own funnel goal).

The quick-tap branch now derives `amount` directly from the closure value using the exact pattern the hold branch already uses — `buzzCounter > 0 ? buzzCounter : CLICK_AMOUNT`. A quick tap never starts the hold interval, so `buzzCounter` is `0` and this resolves to `CLICK_AMOUNT`. The `setBuzzCounter` state update itself is kept; only the analytics-amount derivation is decoupled from its render-timing.


## Audit fix (commit fed98af66)

Code-review audit follow-up — `gestureCommittedRef` stale-true window.

The `gestureCommittedRef` flag — the gate the whole phantom-event fix
depends on — stayed `true` for the entire ~1500ms post-success
`'confirmed'` display window. `onSuccess` set `status='confirmed'` but the
flag was only cleared later by `reset()` inside `onSettled`'s nested 1500ms
`setTimeout`. During that window a stray pointer/lifecycle event could be
mis-attributed as a committed gesture (e.g. a phantom `TipInteractive_Cancel`).

**Fix:** clear `gestureCommittedRef` (and `pressOriginRef`) eagerly in the
tip mutation's `onSuccess` handler — once a tip is confirmed the gesture is
over, so the committed flag must drop immediately rather than lingering
through the confirmed-display window. `onSettled`'s `reset()` still runs and
remains the authoritative full teardown.

**Ref lifecycle (verified):** set `true` at the single `TipInteractive_Click`
emit in `clickEnd`; read in `cancelTip` to gate `TipInteractive_Cancel`;
cleared by `reset()` on every termination path (cancel, auto-dismiss
timeout, mouseleave abort, `sendTip` early-return, `onSettled`). The
successful-confirm path was the one route that left it stale-`true` between
`onSuccess` and `onSettled` — now closed; `onSuccess` is the correct and
complete place for the eager clear.

**Follow-up — test coverage:** the pure `shouldAbortPressOnLeave` helper is
unit-tested, but the stateful gesture-flag logic (`gestureCommittedRef`
set/clear lifecycle across `clickEnd`/`cancelTip`/`reset`/`onSuccess`/
`onSettled`) has **no test coverage**. A full RTL suite is out of scope here
(the repo has no `@testing-library/react`); extracting the gesture state
machine into a `useTipGesture` hook with render-level coverage would let the
stale-window class of bug be caught directly and is recommended as a
follow-up.

