### PR TITLE
Re-instrument PurchaseFunds_Confirm analytics event

### DIFF
--- a/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
+++ b/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
@@ -1176,11 +1176,13 @@ const StripePaymentForm = ({
         // double-counting completions. onSuccess is intentionally left
         // unguarded — it runs every time and is idempotent on the server.
         // The emit reads buzz-specific fields off `metadata` (buzzAmount,
-        // unitAmount). The StripePaymentForm is a shared component, so guard the
-        // emit on the discriminated-union `type` — only fire for buzz purchases
-        // so a future non-buzz caller does not produce a silently zod-rejected
-        // (or zero-valued) PurchaseFunds_Confirm event.
-        if (!hasTrackedConfirmRef.current && metadata.type === 'buzzPurchase') {
+        // unitAmount). The StripePaymentForm is a shared component, so only emit
+        // once we have payment metadata to read those fields from. Both metadata
+        // `type` values ('buzzPurchase' and 'clubMembershipPayment') carry the
+        // same buzzAmount/unitAmount shape, so a presence check is sufficient —
+        // the previous `=== 'buzzPurchase'` check narrowed nothing and would
+        // have silently dropped a legitimate clubMembershipPayment purchase.
+        if (!hasTrackedConfirmRef.current && metadata.type !== undefined) {
           hasTrackedConfirmRef.current = true;
 
           // On the confirm path `payment_method` is the expanded PaymentMethod

--- a/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
+++ b/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
@@ -79,6 +79,7 @@ import { syncAccount } from '~/utils/sync-account';
 import { buzzConstants } from '~/shared/constants/buzz.constants';
 import { getAccountTypeLabel } from '~/utils/buzz';
 import { openGreenPurchaseAcknowledgement } from '~/components/Stripe/GreenPurchaseAcknowledgement';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 
 type SelectablePackage = Pick<Price, 'id' | 'unitAmount'> & { buzzAmount?: number | null };
 
@@ -111,6 +112,7 @@ const BuzzPurchasePaymentButton = ({
   const paymentProvider = usePaymentProvider();
   const currentUser = useCurrentUser();
   const buzzConfig = useBuzzCurrencyConfig(buzzType);
+  const { trackAction } = useTrackEvent();
 
   const successMessage = useMemo(
     () =>
@@ -225,6 +227,12 @@ const BuzzPurchasePaymentButton = ({
         successMessage,
         onSuccess: async (transactionId) => {
           await processCompleteBuzzTransaction({ id: transactionId });
+          // Re-instrument the purchase-completion analytics event for the
+          // Paddle flow. See claudedocs/deep-dive-monetization-funnel.md.
+          trackAction({
+            type: 'PurchaseFunds_Confirm',
+            details: { buzzAmount, unitAmount, method: 'paddle' },
+          }).catch(() => undefined);
           onPurchaseSuccess?.();
         },
       },
@@ -1133,6 +1141,7 @@ const StripeTransactionModal = ({
               onSuccess={onSuccess}
               onCancel={dialog.onClose}
               successMessage={successMessage}
+              metadata={metadata}
             />
           </Elements>
         )}
@@ -1146,16 +1155,36 @@ const StripePaymentForm = ({
   onSuccess,
   onCancel,
   successMessage,
+  metadata,
 }: {
   clientSecret: string;
   onSuccess?: (paymentIntentId: string) => Promise<void>;
   onCancel: () => void;
   successMessage?: React.ReactNode;
+  metadata: PaymentIntentMetadataSchema;
 }) => {
+  const { trackAction } = useTrackEvent();
   const { errorMessage, onConfirmPayment, processingPayment, paymentIntentStatus } =
     useStripeTransaction({
       clientSecret,
       onPaymentSuccess: async (paymentIntent) => {
+        // Re-instrument the purchase-completion analytics event. This emit
+        // regressed on 2024-08-30 when buzz purchases moved to redirect-based
+        // providers and the legacy StripeTransactionModal (which carried it)
+        // stopped being used. See claudedocs/deep-dive-monetization-funnel.md.
+        const paymentMethodType =
+          typeof paymentIntent.payment_method === 'object'
+            ? paymentIntent.payment_method?.type
+            : undefined;
+        trackAction({
+          type: 'PurchaseFunds_Confirm',
+          details: {
+            buzzAmount: metadata.buzzAmount,
+            unitAmount: metadata.unitAmount,
+            method: paymentMethodType ?? 'stripe',
+          },
+        }).catch(() => undefined);
+
         if (onSuccess) {
           await onSuccess(paymentIntent.id);
         }

--- a/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
+++ b/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
@@ -1175,18 +1175,27 @@ const StripePaymentForm = ({
         // path, so the emit is guarded by a one-shot ref to avoid
         // double-counting completions. onSuccess is intentionally left
         // unguarded — it runs every time and is idempotent on the server.
-        if (!hasTrackedConfirmRef.current) {
+        // The emit reads buzz-specific fields off `metadata` (buzzAmount,
+        // unitAmount). The StripePaymentForm is a shared component, so guard the
+        // emit on the discriminated-union `type` — only fire for buzz purchases
+        // so a future non-buzz caller does not produce a silently zod-rejected
+        // (or zero-valued) PurchaseFunds_Confirm event.
+        if (!hasTrackedConfirmRef.current && metadata.type === 'buzzPurchase') {
           hasTrackedConfirmRef.current = true;
 
           // On the confirm path `payment_method` is the expanded PaymentMethod
           // object (Stripe.js expands it via confirmParams.expand). On the
           // polling-resolution path it comes back as an unexpanded string ID —
-          // the client-side retrievePaymentIntent API cannot expand it — so
-          // fall back to payment_method_types[0] (e.g. 'card') for the method
-          // dimension instead of the generic provider name.
+          // the client-side retrievePaymentIntent API cannot expand it — and it
+          // may also be null. Only treat it as expanded when it is a non-null
+          // object; for a string ID, null, or undefined fall back to
+          // payment_method_types[0] (e.g. 'card') instead of the generic
+          // provider name. (typeof null === 'object', so the null check is
+          // required to avoid silently skipping the fallback.)
+          const pm = paymentIntent.payment_method;
           const paymentMethodType =
-            typeof paymentIntent.payment_method === 'object'
-              ? paymentIntent.payment_method?.type
+            typeof pm === 'object' && pm !== null
+              ? pm.type
               : paymentIntent.payment_method_types?.[0];
           trackAction({
             type: 'PurchaseFunds_Confirm',

--- a/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
+++ b/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
@@ -25,7 +25,7 @@ import {
   IconMoodDollar,
   IconTrendingUp,
 } from '@tabler/icons-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Fragment } from 'react';
 import PaddleTransactionModal from '~/components/Paddle/PaddleTransacionModal';
 import { useMutatePaddle } from '~/components/Paddle/util';
@@ -1157,6 +1157,11 @@ const StripePaymentForm = ({
   metadata: PaymentIntentMetadataSchema;
 }) => {
   const { trackAction } = useTrackEvent();
+  // PurchaseFunds_Confirm must fire at most once per payment. onPaymentSuccess
+  // can run more than once on the polling-resolution path (a poll tick may
+  // observe `succeeded` again before the interval is torn down), so the
+  // analytics emit is guarded by this one-shot ref.
+  const hasTrackedConfirmRef = useRef(false);
   const { errorMessage, onConfirmPayment, processingPayment, paymentIntentStatus } =
     useStripeTransaction({
       clientSecret,
@@ -1166,24 +1171,32 @@ const StripePaymentForm = ({
         // providers and the legacy StripeTransactionModal (which carried it)
         // stopped being used.
         //
-        // On the confirm path `payment_method` is the expanded PaymentMethod
-        // object (Stripe.js expands it via confirmParams.expand). On the
-        // polling-resolution path it comes back as an unexpanded string ID —
-        // the client-side retrievePaymentIntent API cannot expand it — so fall
-        // back to payment_method_types[0] (e.g. 'card') for an accurate method
-        // dimension instead of the generic provider name.
-        const paymentMethodType =
-          typeof paymentIntent.payment_method === 'object'
-            ? paymentIntent.payment_method?.type
-            : paymentIntent.payment_method_types?.[0];
-        trackAction({
-          type: 'PurchaseFunds_Confirm',
-          details: {
-            buzzAmount: metadata.buzzAmount,
-            unitAmount: metadata.unitAmount,
-            method: paymentMethodType ?? 'stripe',
-          },
-        }).catch(() => undefined);
+        // onPaymentSuccess can fire more than once on the polling-resolution
+        // path, so the emit is guarded by a one-shot ref to avoid
+        // double-counting completions. onSuccess is intentionally left
+        // unguarded — it runs every time and is idempotent on the server.
+        if (!hasTrackedConfirmRef.current) {
+          hasTrackedConfirmRef.current = true;
+
+          // On the confirm path `payment_method` is the expanded PaymentMethod
+          // object (Stripe.js expands it via confirmParams.expand). On the
+          // polling-resolution path it comes back as an unexpanded string ID —
+          // the client-side retrievePaymentIntent API cannot expand it — so
+          // fall back to payment_method_types[0] (e.g. 'card') for the method
+          // dimension instead of the generic provider name.
+          const paymentMethodType =
+            typeof paymentIntent.payment_method === 'object'
+              ? paymentIntent.payment_method?.type
+              : paymentIntent.payment_method_types?.[0];
+          trackAction({
+            type: 'PurchaseFunds_Confirm',
+            details: {
+              buzzAmount: metadata.buzzAmount,
+              unitAmount: metadata.unitAmount,
+              method: paymentMethodType ?? 'stripe',
+            },
+          }).catch(() => undefined);
+        }
 
         if (onSuccess) {
           await onSuccess(paymentIntent.id);

--- a/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
+++ b/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
@@ -1176,13 +1176,11 @@ const StripePaymentForm = ({
         // double-counting completions. onSuccess is intentionally left
         // unguarded — it runs every time and is idempotent on the server.
         // The emit reads buzz-specific fields off `metadata` (buzzAmount,
-        // unitAmount). The StripePaymentForm is a shared component, so only emit
-        // once we have payment metadata to read those fields from. Both metadata
-        // `type` values ('buzzPurchase' and 'clubMembershipPayment') carry the
-        // same buzzAmount/unitAmount shape, so a presence check is sufficient —
-        // the previous `=== 'buzzPurchase'` check narrowed nothing and would
-        // have silently dropped a legitimate clubMembershipPayment purchase.
-        if (!hasTrackedConfirmRef.current && metadata.type !== undefined) {
+        // unitAmount). Both metadata `type` values ('buzzPurchase' and
+        // 'clubMembershipPayment') carry the same buzzAmount/unitAmount shape,
+        // so no per-type narrowing is needed — `metadata` is always present and
+        // typed via PaymentIntentMetadataSchema.
+        if (!hasTrackedConfirmRef.current) {
           hasTrackedConfirmRef.current = true;
 
           // On the confirm path `payment_method` is the expanded PaymentMethod

--- a/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
+++ b/src/components/Buzz/BuzzPurchase/BuzzPurchaseImproved.tsx
@@ -112,7 +112,6 @@ const BuzzPurchasePaymentButton = ({
   const paymentProvider = usePaymentProvider();
   const currentUser = useCurrentUser();
   const buzzConfig = useBuzzCurrencyConfig(buzzType);
-  const { trackAction } = useTrackEvent();
 
   const successMessage = useMemo(
     () =>
@@ -227,12 +226,6 @@ const BuzzPurchasePaymentButton = ({
         successMessage,
         onSuccess: async (transactionId) => {
           await processCompleteBuzzTransaction({ id: transactionId });
-          // Re-instrument the purchase-completion analytics event for the
-          // Paddle flow. See claudedocs/deep-dive-monetization-funnel.md.
-          trackAction({
-            type: 'PurchaseFunds_Confirm',
-            details: { buzzAmount, unitAmount, method: 'paddle' },
-          }).catch(() => undefined);
           onPurchaseSuccess?.();
         },
       },
@@ -1171,11 +1164,18 @@ const StripePaymentForm = ({
         // Re-instrument the purchase-completion analytics event. This emit
         // regressed on 2024-08-30 when buzz purchases moved to redirect-based
         // providers and the legacy StripeTransactionModal (which carried it)
-        // stopped being used. See claudedocs/deep-dive-monetization-funnel.md.
+        // stopped being used.
+        //
+        // On the confirm path `payment_method` is the expanded PaymentMethod
+        // object (Stripe.js expands it via confirmParams.expand). On the
+        // polling-resolution path it comes back as an unexpanded string ID —
+        // the client-side retrievePaymentIntent API cannot expand it — so fall
+        // back to payment_method_types[0] (e.g. 'card') for an accurate method
+        // dimension instead of the generic provider name.
         const paymentMethodType =
           typeof paymentIntent.payment_method === 'object'
             ? paymentIntent.payment_method?.type
-            : undefined;
+            : paymentIntent.payment_method_types?.[0];
         trackAction({
           type: 'PurchaseFunds_Confirm',
           details: {


### PR DESCRIPTION
## The regression

The `PurchaseFunds_Confirm` analytics event **stopped being emitted on 2024-08-30**. It has 59,758 historical rows in ClickHouse `default.actions` and **zero in the last 365 days**. Its sibling `PurchaseFunds_Cancel` still emits normally — so the on-site Buzz-purchase funnel can currently see every abandon but never a completion, making every funnel dashboard read as a 100% leak.

ClickHouse confirms: `max(time)` for `PurchaseFunds_Confirm` = `2024-08-30 20:10:37`, last full month (2024-08) = 17,799 rows.

## What broke it

Git archaeology:

- The emit was introduced in `b4a7dd629` ("More event tracking for buzz and bounties") inside the **in-app Stripe `onConfirmPayment` callback** in `src/components/Modals/StripeTransactionModal.tsx`.
- Commit **`e58b4e0bc`** ("Redirect to green for buzz purchase and membership related actions", **2024-08-29 22:00 EDT** — i.e. 2024-08-30 UTC, matching the last event exactly) moved Buzz purchases to **redirect-based external payment providers**. Once the purchase completes off-site / via webhook, the in-app `onConfirmPayment` callback that carried the emit never fires again.
- The orphaned emit code lingered unused until `StripeTransactionModal.tsx` was deleted in `af2cd17bc` (2025-05-30).

This was **not** an intentional removal or replacement — the event was orphaned as a side effect of the payment-flow redesign. The `purchaseFundsConfirmSchema` and the ClickHouse `Enum16` entry both still exist; only the emit was lost.

## The fix

Re-add the `PurchaseFunds_Confirm` emit at the **one live in-app purchase-confirmation point** in `BuzzPurchase/BuzzPurchaseImproved.tsx`:

- **Stripe (green-buzz)** — `StripePaymentForm`'s `onPaymentSuccess` callback (fires when the payment intent reaches `succeeded`). `metadata` is threaded into `StripePaymentForm` so `buzzAmount`/`unitAmount` are available. `method` is read from the expanded `paymentIntent.payment_method.type` on the confirm path; on the polling-resolution path `payment_method` comes back as an unexpanded string ID (the client-side `retrievePaymentIntent` API cannot expand it), so it falls back to `payment_method_types[0]` (e.g. `card`), and finally to `"stripe"`.

The emit follows the existing `PurchaseFunds_Cancel` / `Tip_Confirm` `trackAction(...).catch(() => undefined)` pattern and conforms to `purchaseFundsConfirmSchema`.

### Coverage and scope

Client-side in-app confirmation only exists for the **Stripe green-buzz** flow, so that is the only place a `trackAction` emit can fire:

- **Stripe (green-buzz): covered here (client-side, this PR).**
- **Crypto — Coinbase / NOWPayments (the non-green path): covered server-side by #2310** (webhook emit). These flows redirect the user off-site and credit Buzz via webhook, so they have no client-side confirmation moment.
- **Paddle: not applicable.** An initial revision of this PR added a Paddle emit in `handlePaddleSubmit`'s `onSuccess` callback, but that path is **unreachable dead code** — `usePaymentProvider` never returns `Paddle`, and `handlePaddleSubmit` only renders in the green-buzz branch where `shouldUsePaddle` is always `false`. The dead Paddle emit (and its now-unused `useTrackEvent` hook) has been **removed** following an external code review.

Together, this PR (Stripe green-buzz, client-side) and #2310 (crypto, server-side) restore full `PurchaseFunds_Confirm` coverage for live Buzz-purchase flows.

---

Agent-authored from data analysis — needs human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)