### PR TITLE
Send remixOfId in workflow-step metadata (close remix instrumentation gap)

### DIFF
--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -942,8 +942,15 @@ export async function createWorkflowStepsFromGraph({
   }
 
   // Wrap with request-level concerns: priority, timeout, outputFormat
-  // isPrivateGeneration and remixOfId live on workflow.metadata, not per-step
-  // Intermediate steps (videoInterpolation) don't get outputFormat injected
+  // isPrivateGeneration lives on workflow.metadata, not per-step.
+  // `remixOfId` is ALSO copied onto each step's metadata: the orchestrator's
+  // `WorkflowStepHandler.GenerateJobsAsync` reads `workflowStep.Metadata["remixOfId"]`
+  // (not workflow-level metadata) to thread the remix source id into the job
+  // record → MongoDB `prod.jobs.Properties.remixOfId` → CDC → ClickHouse
+  // `orchestration.jobs`, which is what makes the remix product loop measurable.
+  // See civitai-orchestration#216. Kept on workflow.metadata as well for the
+  // app's own replay/normalization path (NormalizedWorkflowMetadata.remixOfId).
+  // Intermediate steps (videoInterpolation) don't get outputFormat injected.
   const wrappedSteps = steps.map((step) => ({
     $type: step.$type,
     input: {
@@ -952,7 +959,12 @@ export async function createWorkflowStepsFromGraph({
     },
     priority: data.priority,
     timeout,
-    metadata: isWhatIf ? undefined : (step.metadata as object),
+    metadata: isWhatIf
+      ? undefined
+      : ({
+          ...((step.metadata as object) ?? {}),
+          ...(remixOfId != null ? { remixOfId } : {}),
+        } as object),
   })) as WorkflowStepTemplate[];
 
   // Build workflow-level metadata — the form input snapshot for workflow-level


### PR DESCRIPTION
## The gap

The "remix" product loop is **unmeasurable**. `orchestration.jobs.remixOfId` in ClickHouse is ~100% empty — **11 non-null rows in 1.86B** of full table history (the single "non-empty" row is corrupt). We cannot manage a remix loop we cannot measure.

See the data analysis: `claudedocs/deep-dive-browse-to-generate.md` (datapacket-talos), §4 "Remix assessment".

## Receiving half: civitai-orchestration#216

The orchestration backend is **already wired** to carry `remixOfId`:

- `WorkflowStepHandler.GenerateJobsAsync` reads `workflowStep.Metadata["remixOfId"]` and copies it into `job.Properties["remixOfId"]`.
- That flows automatically to MongoDB `prod.jobs.Properties.remixOfId` → CDC → ClickHouse `orchestration.jobs`, and to the `GenericJobResult` ClickHouse tracker.

The orchestration investigation (civitai-orchestration#216) confirmed orchestration is a **pure pass-through** for `remixOfId` — it never infers or injects it. The column is empty because **civitai never puts `remixOfId` into the workflow-step `metadata`** when a user generates from a "Remix" affordance.

This PR is the civitai-side half. Companion: civitai-orchestration#216.

## What was actually broken

The client plumbing was already correct:

- A user clicks **Remix** → `fetchGenerationData` resolves the source id → `remixStore.setRemix(remixOfId, params)`.
- `useRemixOfId()` (in `generation_v2/FormFooter.tsx`) returns `remixOfId` gated on ≥75% prompt similarity, and threads it through `trpc.orchestrator.generateFromGraph` → the router → `generateFromGraph()` → `createWorkflowStepsFromGraph()`.

The break was **one layer deep** in `createWorkflowStepsFromGraph` (`orchestration-new.service.ts`): `remixOfId` was placed **only on workflow-level `metadata`**, never on per-step `metadata`. orchestration#216's `WorkflowStepHandler` reads `workflowStep.Metadata["remixOfId"]` — the per-step metadata — so it never saw it.

(The legacy `createTextToImage` / `createComfy` paths already put `remixOfId` on per-step `metadata`, but those functions have no live production callers — the graph path is the live path.)

## What this PR sends

Copies `remixOfId` onto each wrapped step's `metadata` when present, in the shape orchestration#216 expects:

```jsonc
{
  "$type": "textToImage",     // or comfy / imageGen / video step
  "input": { ... },
  "metadata": { "remixOfId": 12345678 }   // <-- now sent
}
```

Single change at the `wrappedSteps` mapper, so it covers **every** step type (the whole graph path funnels through it).

## Why it's additive / non-disruptive

- Workflow-level `metadata` **still** carries `remixOfId` for the app's own replay/normalization path (`NormalizedWorkflowMetadata.remixOfId`).
- The read-back normalizer (`formatStep`) is unchanged: standard-gen steps with no `params` still resolve `remixOfId` from `workflow.metadata`, preserving the existing two-layer metadata model. The new step-level `remixOfId` is consumed only by the orchestrator's `WorkflowStepHandler`.
- `WorkflowStep.Metadata` is a free-form `Dictionary<string, object>` (per orchestration#216) — adding a key is safe.

## Verification

Fresh worktree, no `node_modules` — not built locally; `pr-check.yml` CI validates. No app-side behavior change beyond the added metadata key.

---
Agent-authored from data analysis — needs review.