### PR TITLE
Emit PurchaseFunds_Confirm server-side from crypto purchase webhooks

### DIFF
--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -26,6 +26,7 @@ import type {
 } from '~/shared/utils/prisma/enums';
 import { createLogger } from '~/utils/logging';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { purchaseFundsConfirmSchema } from '~/server/schema/track.schema';
 
 export type CustomClickHouseClient = ClickHouseClient & {
   $query: <T extends object>(
@@ -469,17 +470,88 @@ export class Tracker {
     });
   }
 
-  public action(values: { type: ActionType; details?: any; userId?: number }) {
-    const { details, userId, ...rest } = values;
-    // `userId` is optional — when provided it overrides the actor-resolved
-    // userId. This is needed for server-side emits with no request session
-    // (e.g. payment webhooks) where the acting user is known explicitly.
-    // It spreads after `actorMeta` in `track()`, so the override is honored.
+  public action(values: { type: ActionType; details?: any }) {
+    const { details, ...rest } = values;
     return this.track('actions', {
       ...rest,
-      ...(userId != null ? { userId } : {}),
       details:
         details != null ? (typeof details === 'string' ? details : JSON.stringify(details)) : '',
+    });
+  }
+
+  /**
+   * Server-side, session-less variant of {@link action}.
+   *
+   * The request-bound `action()` deliberately has NO `userId` parameter — it
+   * resolves the actor from the request session, so a request-bound `Tracker`
+   * cannot be handed a foreign `userId` to spoof the acting user. Server-side
+   * emitters with no request session (payment webhooks, jobs) instead use this
+   * method, which *requires* `userId` explicitly.
+   *
+   * Unlike the ad-hoc `userId` override on `bounty()` / `bountyEntry()`, this
+   * path validates the full payload against the same zod schema the tRPC
+   * `track.addAction` endpoint enforces, so a future required-field change to
+   * the schema cannot silently desync server-side emits.
+   *
+   * Currently scoped to `PurchaseFunds_Confirm` (the only event with a
+   * server-side emit). Extend the validation switch when adding more.
+   *
+   * Fire-and-forget: never throws — a bad payload or transport failure is
+   * logged, not surfaced, so analytics can never block or fail its caller.
+   */
+  public actionAsSystem(values: {
+    userId: number;
+    type: ActionType;
+    details?: any;
+  }): void {
+    const { userId, type, details } = values;
+
+    // Validate against the shared schema before emitting. Keeps server-side
+    // emits in lockstep with the tRPC `track.addAction` contract.
+    let validated: { type: ActionType; details?: any };
+    switch (type) {
+      case 'PurchaseFunds_Confirm': {
+        const result = purchaseFundsConfirmSchema.safeParse({ type, details });
+        if (!result.success) {
+          logToAxiom(
+            {
+              type: 'error',
+              name: 'actionAsSystem payload validation failed',
+              details: { actionType: type, userId, error: result.error.message },
+              message: 'Server-side action emit failed schema validation',
+            },
+            'clickhouse'
+          ).catch(() => {});
+          return;
+        }
+        validated = result.data;
+        break;
+      }
+      default:
+        logToAxiom(
+          {
+            type: 'error',
+            name: 'actionAsSystem unsupported type',
+            details: { actionType: type, userId },
+            message: `actionAsSystem has no validator for action type "${type}"`,
+          },
+          'clickhouse'
+        ).catch(() => {});
+        return;
+    }
+
+    const { details: validatedDetails } = validated;
+    // `userId` spreads after `actorMeta` in `track()`, so it overrides the
+    // (zero) actor userId for this session-less Tracker.
+    void this.track('actions', {
+      type,
+      userId,
+      details:
+        validatedDetails != null
+          ? typeof validatedDetails === 'string'
+            ? validatedDetails
+            : JSON.stringify(validatedDetails)
+          : '',
     });
   }
 

--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -469,10 +469,15 @@ export class Tracker {
     });
   }
 
-  public action(values: { type: ActionType; details?: any }) {
-    const { details, ...rest } = values;
+  public action(values: { type: ActionType; details?: any; userId?: number }) {
+    const { details, userId, ...rest } = values;
+    // `userId` is optional — when provided it overrides the actor-resolved
+    // userId. This is needed for server-side emits with no request session
+    // (e.g. payment webhooks) where the acting user is known explicitly.
+    // It spreads after `actorMeta` in `track()`, so the override is honored.
     return this.track('actions', {
       ...rest,
+      ...(userId != null ? { userId } : {}),
       details:
         details != null ? (typeof details === 'string' ? details : JSON.stringify(details)) : '',
     });

--- a/src/server/http/nowpayments/nowpayments.schema.ts
+++ b/src/server/http/nowpayments/nowpayments.schema.ts
@@ -87,6 +87,10 @@ export namespace NOWPayments {
       outcome_amount: z.number().nullish(),
       outcome_currency: z.string().nullish(),
       actually_paid: z.union([z.number(), z.string()]).nullish(),
+      // Real fiat the customer paid, supplied on the payment-status response.
+      // Threaded into PurchaseFunds_Confirm so reconcile/recovery paths emit
+      // true fiat instead of the buzz-derived estimate.
+      actually_paid_at_fiat: z.number().nullish(),
       parent_payment_id: z.number().nullish(),
     })
     .passthrough();

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -996,6 +996,13 @@ export const REDIS_KEYS = {
     POTENTIAL_POOL_VALUE: 'buzz:potential-pool-value',
     EARNED: 'buzz:earned',
   },
+  CRYPTO: {
+    // Per-payment idempotency marker for the `PurchaseFunds_Confirm` analytics
+    // emit, so a completed crypto purchase produces exactly one revenue row
+    // regardless of how many `finished` webhook deliveries / reconcile reruns
+    // it receives. Suffixed with `:<provider>:<paymentId>` at the call site.
+    PURCHASE_CONFIRM_EMITTED: 'crypto:purchase-confirm-emitted',
+  },
   CREATOR_PROGRAM: {
     CAPS: 'packed:caches:creator-program:caps',
     CASH: 'packed:caches:creator-program:cash',

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -98,7 +98,11 @@ const purchaseFundsCancelSchema = z.object({
   type: z.literal('PurchaseFunds_Cancel'),
   details: z.object({ step: z.number() }).optional(),
 });
-const purchaseFundsConfirmSchema = z.object({
+// Exported so server-side emitters (e.g. crypto payment webhooks via
+// `Tracker.actionAsSystem`) can validate their payload against the same shape
+// the tRPC `track.addAction` path enforces — keeps server emits from silently
+// desyncing if a required field is added here.
+export const purchaseFundsConfirmSchema = z.object({
   type: z.literal('PurchaseFunds_Confirm'),
   details: z
     .object({

--- a/src/server/services/coinbase.service.ts
+++ b/src/server/services/coinbase.service.ts
@@ -171,27 +171,26 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
     // cover it. Reached only after a successful `grantBuzzPurchase`; duplicate
     // `charge:confirmed` webhooks throw on the transaction conflict before
     // this point, so it cannot double-count. `unitAmount` mirrors the client
-    // convention of 10 buzz = 1 cent. Fire-and-forget — analytics must never
-    // block or fail the buzz grant.
-    try {
-      await new Tracker().action({
-        type: 'PurchaseFunds_Confirm',
-        userId,
-        // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
-        // convention), NOT the actual fiat amount billed. Crypto / partial
-        // payments won't always settle to clean multiples of 10 buzz, so
-        // treat this figure as approximate for analytics purposes.
-        details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'coinbase' },
-      });
-    } catch (err) {
-      await log({
-        message: 'Failed to track PurchaseFunds_Confirm for coinbase buzz purchase',
-        userId,
-        buzzAmount,
-        orderId: internalOrderId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+    // convention of 10 buzz = 1 cent.
+    //
+    // `actionAsSystem` is the session-less server-side emit path: it requires
+    // an explicit `userId`, validates the payload against the shared zod
+    // schema, and never throws — it is fire-and-forget internally, so no
+    // try/catch is needed here (a wrapping catch would be unreachable).
+    new Tracker().actionAsSystem({
+      userId,
+      type: 'PurchaseFunds_Confirm',
+      // NOTE: `buzzAmount` here is the pre-multiplier *base* buzz the user
+      // purchased — not the credited total (base + any purchase-multiplier
+      // bonus). This is intentional: `PurchaseFunds_Confirm` is a revenue
+      // signal, and revenue tracks the base purchase, not bonus buzz.
+      //
+      // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
+      // convention), NOT the actual fiat amount billed. Crypto / partial
+      // payments won't always settle to clean multiples of 10 buzz, so
+      // treat this figure as approximate for analytics purposes.
+      details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'coinbase' },
+    });
 
     await log({
       message: 'Buzz purchase granted successfully',

--- a/src/server/services/coinbase.service.ts
+++ b/src/server/services/coinbase.service.ts
@@ -13,6 +13,7 @@ import { redeemableCodePurchaseEmail } from '~/server/email/templates/redeemable
 import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions.schema';
 import { createNotification } from '~/server/services/notification.service';
 import { NotificationCategory } from '~/server/common/enums';
+import { Tracker } from '~/server/clickhouse/client';
 
 const log = async (data: MixedObject) => {
   await logToAxiom({ name: 'coinbase-service', type: 'error', ...data }).catch();
@@ -160,6 +161,31 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
       await grantCosmetics({
         userId,
         cosmeticIds,
+      });
+    }
+
+    // Re-instrument the `PurchaseFunds_Confirm` analytics event for the
+    // Coinbase crypto purchase flow. Crypto purchases complete off-site and
+    // credit via this webhook — there is no client-side confirmation moment,
+    // so PR #2308 (which restored the Stripe + Paddle in-app emits) could not
+    // cover it. Reached only after a successful `grantBuzzPurchase`; duplicate
+    // `charge:confirmed` webhooks throw on the transaction conflict before
+    // this point, so it cannot double-count. `unitAmount` mirrors the client
+    // convention of 10 buzz = 1 cent. Fire-and-forget — analytics must never
+    // block or fail the buzz grant.
+    try {
+      await new Tracker().action({
+        type: 'PurchaseFunds_Confirm',
+        userId,
+        details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'coinbase' },
+      });
+    } catch (err) {
+      await log({
+        message: 'Failed to track PurchaseFunds_Confirm for coinbase buzz purchase',
+        userId,
+        buzzAmount,
+        orderId: internalOrderId,
+        error: err instanceof Error ? err.message : String(err),
       });
     }
 

--- a/src/server/services/coinbase.service.ts
+++ b/src/server/services/coinbase.service.ts
@@ -211,7 +211,7 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
     await log({
       message: 'Failed to process Coinbase webhook event',
       error: error instanceof Error ? error.message : String(error),
-      event,
+      eventData,
     });
     console.error('Error processing Coinbase webhook event:', error);
     throw error; // Re-throw to handle it upstream if needed

--- a/src/server/services/coinbase.service.ts
+++ b/src/server/services/coinbase.service.ts
@@ -162,8 +162,7 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
     // so PR #2308 (which restored the Stripe + Paddle in-app emits) could not
     // cover it. Reached only after a successful `grantBuzzPurchase`; duplicate
     // `charge:confirmed` webhooks throw on the transaction conflict before
-    // this point, so it cannot double-count. `unitAmount` mirrors the client
-    // convention of 10 buzz = 1 cent.
+    // this point, so it cannot double-count.
     //
     // This emit runs *immediately after the buzz grant succeeds and before
     // `grantCosmetics`* (audit finding #2): if `grantCosmetics` throws, control
@@ -176,6 +175,25 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
     // an explicit `userId`, validates the payload against the shared zod
     // schema, and never throws — it is fire-and-forget internally, so no
     // try/catch is needed here (a wrapping catch would be unreachable).
+    //
+    // `unitAmount` (review #3): the charge is created with a `fixed_price`
+    // `local_price` of `(unitAmount + COINBASE_FIXED_FEE) / 100` USD, so the
+    // amount the user actually agreed to pay is `local_price` — fee included.
+    // The webhook echoes that figure back as `pricing.local.amount` (USD
+    // string). Using it × 100 emits the *true total fiat billed* in cents,
+    // consistent with how the NOWPayments path now emits `actually_paid_at_fiat`
+    // and with the true billed fiat that card rows carry in this same
+    // ClickHouse column. The earlier `buzzAmount / 10` estimate excluded
+    // `COINBASE_FIXED_FEE`, so Coinbase rows under-reported fiat versus
+    // NOWPayments / card rows (silent today only because `COINBASE_FIXED_FEE`
+    // is currently 0 — this keeps the row correct if the fee is ever raised).
+    // The estimate remains a fallback for the unexpected case of a malformed /
+    // unparseable `pricing.local.amount`, so the field is never null.
+    const localPriceUsd = Number(eventData.pricing?.local?.amount);
+    const unitAmount =
+      Number.isFinite(localPriceUsd) && localPriceUsd > 0
+        ? Math.round(localPriceUsd * 100)
+        : Math.round(buzzAmount / 10);
     new Tracker().actionAsSystem({
       userId,
       type: 'PurchaseFunds_Confirm',
@@ -183,12 +201,7 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
       // purchased — not the credited total (base + any purchase-multiplier
       // bonus). This is intentional: `PurchaseFunds_Confirm` is a revenue
       // signal, and revenue tracks the base purchase, not bonus buzz.
-      //
-      // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
-      // convention), NOT the actual fiat amount billed. Crypto / partial
-      // payments won't always settle to clean multiples of 10 buzz, so
-      // treat this figure as approximate for analytics purposes.
-      details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'coinbase' },
+      details: { buzzAmount, unitAmount, method: 'coinbase' },
     });
 
     // Grant cosmetics last — non-critical, and must run AFTER the revenue emit

--- a/src/server/services/coinbase.service.ts
+++ b/src/server/services/coinbase.service.ts
@@ -177,6 +177,10 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
       await new Tracker().action({
         type: 'PurchaseFunds_Confirm',
         userId,
+        // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
+        // convention), NOT the actual fiat amount billed. Crypto / partial
+        // payments won't always settle to clean multiples of 10 buzz, so
+        // treat this figure as approximate for analytics purposes.
         details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'coinbase' },
       });
     } catch (err) {

--- a/src/server/services/coinbase.service.ts
+++ b/src/server/services/coinbase.service.ts
@@ -145,7 +145,7 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
       throw new Error('Invalid userId or buzzAmount from Coinbase webhook event');
     }
 
-    // Grant buzz/cosmetics
+    // Grant buzz
     const transactionId = await grantBuzzPurchase({
       userId,
       amount: buzzAmount,
@@ -156,14 +156,6 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
       type: 'info',
     });
 
-    const cosmeticIds = specialCosmeticRewards.crypto;
-    if (cosmeticIds.length > 0) {
-      await grantCosmetics({
-        userId,
-        cosmeticIds,
-      });
-    }
-
     // Re-instrument the `PurchaseFunds_Confirm` analytics event for the
     // Coinbase crypto purchase flow. Crypto purchases complete off-site and
     // credit via this webhook — there is no client-side confirmation moment,
@@ -172,6 +164,13 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
     // `charge:confirmed` webhooks throw on the transaction conflict before
     // this point, so it cannot double-count. `unitAmount` mirrors the client
     // convention of 10 buzz = 1 cent.
+    //
+    // This emit runs *immediately after the buzz grant succeeds and before
+    // `grantCosmetics`* (audit finding #2): if `grantCosmetics` throws, control
+    // jumps to the catch block, the webhook 409s on the already-granted buzz on
+    // retry, and the emit is never reached — a paid purchase that produces zero
+    // revenue rows. The cosmetic grant is non-critical, so the revenue signal
+    // must not be downstream of it.
     //
     // `actionAsSystem` is the session-less server-side emit path: it requires
     // an explicit `userId`, validates the payload against the shared zod
@@ -191,6 +190,17 @@ export const processBuzzOrder = async (eventData: Coinbase.WebhookEventSchema['e
       // treat this figure as approximate for analytics purposes.
       details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'coinbase' },
     });
+
+    // Grant cosmetics last — non-critical, and must run AFTER the revenue emit
+    // so a cosmetic-grant failure cannot strand a paid purchase without a
+    // PurchaseFunds_Confirm row (see the emit comment above).
+    const cosmeticIds = specialCosmeticRewards.crypto;
+    if (cosmeticIds.length > 0) {
+      await grantCosmetics({
+        userId,
+        cosmeticIds,
+      });
+    }
 
     await log({
       message: 'Buzz purchase granted successfully',

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -232,32 +232,58 @@ export const processDeposit = async (
         // crypto purchase flow. ~87% of buzz purchase volume is crypto, which
         // completes off-site and credits via this webhook — there is no
         // client-side confirmation moment, so PR #2308 (which restored the
-        // Stripe + Paddle in-app emits) could not cover it. Emitted only on a
-        // confirmed deposit with a fresh buzz grant, so webhook retries and
-        // reconciliation reruns (which short-circuit to `already_granted`)
-        // don't double-count. `unitAmount` mirrors the client convention of
-        // 10 buzz = 1 cent.
+        // Stripe + Paddle in-app emits) could not cover it.
+        //
+        // Gated to `webhookStatus === 'finished'` (review #1): NOWPayments can
+        // settle a payment in stages — a `partially_paid` webhook fires when
+        // the under-payment is credited, then a later `finished` webhook fires
+        // for the remainder. The remainder commonly arrives as a *separate*
+        // child `payment_id`, so its `np-deposit-<paymentId>` buzz grant does
+        // NOT 409 against the partial grant — it succeeds, reaches this block,
+        // and would emit a *second* `PurchaseFunds_Confirm` for one logical
+        // purchase. (Same-`payment_id` retries are already deduped: their
+        // grant 409s → `transactionId === 'already_granted'` → excluded by the
+        // guard above.) Emitting only on `finished` therefore yields exactly
+        // one revenue row per completed purchase. Buzz crediting itself is
+        // intentionally untouched and still happens on `partially_paid` via
+        // `isDepositComplete()` — a partial payment that never reaches
+        // `finished` legitimately gets buzz but does not produce a revenue
+        // event, which is correct (the purchase was not fully completed).
         //
         // `actionAsSystem` is the session-less server-side emit path: it
         // requires an explicit `userId`, validates the payload against the
         // shared zod schema, and never throws — it is fire-and-forget
         // internally, so no try/catch is needed here (a wrapping catch would
         // be unreachable).
-        new Tracker().actionAsSystem({
-          userId,
-          type: 'PurchaseFunds_Confirm',
-          // NOTE: `buzzAmount` here is the pre-multiplier *base* buzz the user
-          // purchased — `bonusBuzz` (the purchase-multiplier bonus) is tracked
-          // separately and intentionally excluded. `PurchaseFunds_Confirm` is
-          // a revenue signal, and revenue tracks the base purchase, not the
-          // bonus buzz granted on top.
-          //
-          // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
-          // convention), NOT the actual fiat amount billed. Crypto / partial
-          // payments won't always settle to clean multiples of 10 buzz, so
-          // treat this figure as approximate for analytics purposes.
-          details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'nowpayments' },
-        });
+        if (webhookStatus === 'finished') {
+          new Tracker().actionAsSystem({
+            userId,
+            type: 'PurchaseFunds_Confirm',
+            // NOTE: `buzzAmount` here is the pre-multiplier *base* buzz the
+            // user purchased — `bonusBuzz` (the purchase-multiplier bonus) is
+            // tracked separately and intentionally excluded. This event is a
+            // revenue signal, and revenue tracks the base purchase, not the
+            // bonus buzz granted on top.
+            //
+            // `unitAmount` is the real fiat NOWPayments settled, in cents
+            // (review #2). Card-purchase rows in this same ClickHouse column
+            // carry true billed fiat, so the prior `buzzAmount / 10` estimate
+            // (reverse-computed from settled crypto, fee-exclusive) was not
+            // summable alongside them. `actually_paid_at_fiat` is the fiat
+            // value the customer actually paid; converted from a decimal
+            // amount to integer cents to match the card convention. Falls back
+            // to the 10-buzz-per-cent estimate only if NOWPayments omits the
+            // fiat figure, so the field is never null.
+            details: {
+              buzzAmount,
+              unitAmount:
+                event.actually_paid_at_fiat != null
+                  ? Math.round(event.actually_paid_at_fiat * 100)
+                  : Math.round(buzzAmount / 10),
+              method: 'nowpayments',
+            },
+          });
+        }
       }
     }
   }

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -262,46 +262,6 @@ export const processDeposit = async (
             error: err instanceof Error ? err.message : String(err),
           });
         });
-
-        // Re-instrument the `PurchaseFunds_Confirm` analytics event for the
-        // crypto purchase flow. ~87% of buzz purchase volume is crypto, which
-        // completes off-site and credits via this webhook — there is no
-        // client-side confirmation moment, so PR #2308 (which restored the
-        // Stripe + Paddle in-app emits) could not cover it.
-        //
-        // Gated to `webhookStatus === 'finished'` (review #1): NOWPayments can
-        // settle a payment in stages — a `partially_paid` webhook fires when
-        // the under-payment is credited, then a later `finished` webhook fires
-        // for the remainder. The remainder commonly arrives as a *separate*
-        // child `payment_id`, so its `np-deposit-<paymentId>` buzz grant does
-        // NOT 409 against the partial grant — it succeeds, reaches this block,
-        // and would emit a *second* `PurchaseFunds_Confirm` for one logical
-        // purchase. (Same-`payment_id` retries are already deduped: their
-        // grant 409s → `transactionId === 'already_granted'` → excluded by the
-        // guard above.) Emitting only on `finished` therefore yields exactly
-        // one revenue row per completed purchase. Buzz crediting itself is
-        // intentionally untouched and still happens on `partially_paid` via
-        // `isDepositComplete()` — a partial payment that never reaches
-        // `finished` legitimately gets buzz but does not produce a revenue
-        // event, which is correct (the purchase was not fully completed).
-        //
-        // `actionAsSystem` is the session-less server-side emit path: it
-        // requires an explicit `userId`, validates the payload against the
-        // shared zod schema, and never throws — it is fire-and-forget
-        // internally, so no try/catch is needed here (a wrapping catch would
-        // be unreachable).
-        if (webhookStatus === 'finished') {
-          new Tracker().actionAsSystem({
-            userId,
-            type: 'PurchaseFunds_Confirm',
-            // Payload built by the shared `buildPurchaseConfirmDetails` helper
-            // so the live webhook path and every reconcile/recovery path emit
-            // identical rows — real `actually_paid_at_fiat` fiat in cents, with
-            // the buzz-derived estimate used only as a fallback. See the
-            // helper's docblock for the full rationale.
-            details: buildPurchaseConfirmDetails(buzzAmount, event.actually_paid_at_fiat),
-          });
-        }
       }
     }
   }
@@ -369,6 +329,65 @@ export const processDeposit = async (
         message: 'Failed to upsert CryptoDeposit record',
         paymentId,
         error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  // Re-instrument the `PurchaseFunds_Confirm` analytics event for the crypto
+  // purchase flow. ~87% of buzz purchase volume is crypto, which completes
+  // off-site and credits via this webhook — there is no client-side
+  // confirmation moment, so PR #2308 (which restored the Stripe + Paddle in-app
+  // emits) could not cover it.
+  //
+  // The emit must fire EXACTLY ONCE per completed purchase, and it is
+  // deliberately decoupled from the buzz-grant dedup. A previous review round
+  // gated the emit to `webhookStatus === 'finished'` *inside* the
+  // `transactionId !== 'already_granted'` referral-kickback guard. That
+  // produced a zero-rows gap: NOWPayments can settle a payment in stages — a
+  // `partially_paid` webhook credits buzz (`isDepositComplete()` accepts
+  // `partially_paid`), then the *same* `payment_id` later reports `finished`.
+  // On that `finished` webhook the `np-deposit-<paymentId>` grant 409s against
+  // the partial grant → `transactionId === 'already_granted'` → the old guard
+  // excluded the emit entirely. Net: a fully completed purchase produced zero
+  // `PurchaseFunds_Confirm` rows — the exact undercount this PR exists to fix.
+  //
+  // Dedup is therefore handled here by a dedicated per-`payment_id` Redis
+  // marker (`SET NX`), independent of whether buzz was already granted:
+  //   - Emit only when `webhookStatus === 'finished'` (the purchase is fully
+  //     complete). A `partially_paid` that never reaches `finished` legitimately
+  //     gets buzz but produces no revenue row — correct, the purchase was not
+  //     completed.
+  //   - `SET NX` succeeds only on the FIRST `finished` delivery for this
+  //     `payment_id`, so duplicate `finished` webhooks and reconcile/retry
+  //     reruns are deduped. (The `CryptoDeposit.status` field cannot serve as
+  //     the marker: `isDepositComplete()` collapses `partially_paid` into a
+  //     `finished` row status, so a prior `partially_paid` is indistinguishable
+  //     from a prior `finished` by status alone.)
+  //   - 90-day TTL comfortably outlives any staged settlement while bounding
+  //     key growth.
+  // Gated on `!buzzGrantFailed` so a genuine grant failure (not a 409) emits no
+  // revenue row. If Redis is unavailable the `.catch()` falls through to
+  // emitting — better one guaranteed row than a silent zero on an outage.
+  //
+  // `actionAsSystem` is the session-less server-side emit path: it requires an
+  // explicit `userId`, validates the payload against the shared zod schema, and
+  // never throws — fire-and-forget, so no try/catch is needed around it.
+  if (webhookStatus === 'finished' && buzzAmount > 0 && !buzzGrantFailed) {
+    const emitDedupKey =
+      `${REDIS_KEYS.CRYPTO.PURCHASE_CONFIRM_EMITTED}:nowpayments:${paymentId}` as RedisKeyTemplateCache;
+    const firstEmit = await redis
+      .set(emitDedupKey, '1', { NX: true, EX: CacheTTL.day * 90 })
+      .catch(() => 'OK' as const); // Redis down → fall through and emit once
+    if (firstEmit) {
+      new Tracker().actionAsSystem({
+        userId,
+        type: 'PurchaseFunds_Confirm',
+        // Payload built by the shared `buildPurchaseConfirmDetails` helper so
+        // the live webhook path and every reconcile/recovery path emit
+        // identical rows — real `actually_paid_at_fiat` fiat in cents, with the
+        // buzz-derived estimate used only as a fallback. See the helper's
+        // docblock for the full rationale.
+        details: buildPurchaseConfirmDetails(buzzAmount, event.actually_paid_at_fiat),
       });
     }
   }

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -35,6 +35,41 @@ const log = async (data: MixedObject) => {
 /** Max number of concurrent requests when fetching min amounts for currencies */
 const MAX_CONCURRENT_MIN_AMOUNT_REQUESTS = 10;
 
+/**
+ * Build the `details` payload for a `PurchaseFunds_Confirm` analytics event
+ * from a NOWPayments crypto purchase.
+ *
+ * Single source of truth so the live webhook path AND every reconcile/recovery
+ * path (`reprocessDeposit`, `reconcileSinglePayment`, `retryFailedDeposits`,
+ * `reconcileUserDeposits`) emit identical, comparable rows:
+ *
+ * - `buzzAmount` — the pre-multiplier *base* buzz the user purchased. The
+ *   purchase-multiplier bonus is tracked separately and intentionally excluded;
+ *   this event is a revenue signal and revenue tracks the base purchase.
+ * - `unitAmount` — the real fiat NOWPayments settled, in integer cents
+ *   (`actually_paid_at_fiat` × 100). Card-purchase rows in this same ClickHouse
+ *   column carry true billed fiat, so the `buzzAmount / 10` estimate
+ *   (reverse-computed from settled crypto, fee-exclusive) is not summable
+ *   alongside them. The estimate is used ONLY as a fallback when NOWPayments
+ *   genuinely omits the fiat figure, so the field is never null.
+ *
+ * Earlier this helper was inlined only in the webhook path; the reconcile
+ * paths built their event objects without `actually_paid_at_fiat`, silently
+ * falling back to the estimate on every missed-webhook recovery and mixing
+ * true and estimated fiat in revenue dashboards.
+ */
+const buildPurchaseConfirmDetails = (
+  buzzAmount: number,
+  actuallyPaidAtFiat: number | null | undefined
+) => ({
+  buzzAmount,
+  unitAmount:
+    actuallyPaidAtFiat != null
+      ? Math.round(actuallyPaidAtFiat * 100)
+      : Math.round(buzzAmount / 10),
+  method: 'nowpayments' as const,
+});
+
 export const getDepositAddress = async (userId: number, chain = 'evm') => {
   // Use explicit config if available, otherwise fall back to chain name as targetCurrency
   const config = getChainConfig(chain) ?? {
@@ -259,29 +294,12 @@ export const processDeposit = async (
           new Tracker().actionAsSystem({
             userId,
             type: 'PurchaseFunds_Confirm',
-            // NOTE: `buzzAmount` here is the pre-multiplier *base* buzz the
-            // user purchased — `bonusBuzz` (the purchase-multiplier bonus) is
-            // tracked separately and intentionally excluded. This event is a
-            // revenue signal, and revenue tracks the base purchase, not the
-            // bonus buzz granted on top.
-            //
-            // `unitAmount` is the real fiat NOWPayments settled, in cents
-            // (review #2). Card-purchase rows in this same ClickHouse column
-            // carry true billed fiat, so the prior `buzzAmount / 10` estimate
-            // (reverse-computed from settled crypto, fee-exclusive) was not
-            // summable alongside them. `actually_paid_at_fiat` is the fiat
-            // value the customer actually paid; converted from a decimal
-            // amount to integer cents to match the card convention. Falls back
-            // to the 10-buzz-per-cent estimate only if NOWPayments omits the
-            // fiat figure, so the field is never null.
-            details: {
-              buzzAmount,
-              unitAmount:
-                event.actually_paid_at_fiat != null
-                  ? Math.round(event.actually_paid_at_fiat * 100)
-                  : Math.round(buzzAmount / 10),
-              method: 'nowpayments',
-            },
+            // Payload built by the shared `buildPurchaseConfirmDetails` helper
+            // so the live webhook path and every reconcile/recovery path emit
+            // identical rows — real `actually_paid_at_fiat` fiat in cents, with
+            // the buzz-derived estimate used only as a fallback. See the
+            // helper's docblock for the full rationale.
+            details: buildPurchaseConfirmDetails(buzzAmount, event.actually_paid_at_fiat),
           });
         }
       }
@@ -427,7 +445,9 @@ export const reprocessDeposit = async (paymentId: number) => {
     throw new Error(`Payment ${paymentId} has invalid order_id: ${orderId}`);
   }
 
-  // Build a webhook-like event from the GET response
+  // Build a webhook-like event from the GET response. `actually_paid_at_fiat`
+  // is threaded through so the PurchaseFunds_Confirm emit uses real fiat, not
+  // the buzz-derived estimate, on missed-webhook recoveries.
   const event: NOWPayments.WebhookEvent = {
     payment_id:
       typeof payment.payment_id === 'string'
@@ -437,6 +457,7 @@ export const reprocessDeposit = async (paymentId: number) => {
     order_id: payment.order_id,
     outcome_amount: payment.outcome_amount,
     actually_paid: payment.actually_paid ? Number(payment.actually_paid) : undefined,
+    actually_paid_at_fiat: payment.actually_paid_at_fiat,
     pay_currency: payment.pay_currency,
     pay_address: payment.pay_address,
     parent_payment_id: payment.parent_payment_id,
@@ -591,7 +612,8 @@ async function reconcileSinglePayment(
     };
   }
 
-  // Process the deposit
+  // Process the deposit. `actually_paid_at_fiat` is threaded through so the
+  // PurchaseFunds_Confirm emit uses real fiat, not the buzz-derived estimate.
   try {
     const event: NOWPayments.WebhookEvent = {
       payment_id: typeof paymentId === 'string' ? parseInt(paymentId, 10) : paymentId,
@@ -599,6 +621,7 @@ async function reconcileSinglePayment(
       order_id: payment.order_id,
       outcome_amount: payment.outcome_amount ?? undefined,
       actually_paid: payment.actually_paid ? Number(payment.actually_paid) : undefined,
+      actually_paid_at_fiat: payment.actually_paid_at_fiat,
       pay_currency: payment.pay_currency,
       pay_address: payment.pay_address,
       parent_payment_id: payment.parent_payment_id,
@@ -664,12 +687,15 @@ export const retryFailedDeposits = async () => {
         continue;
       }
 
+      // `actually_paid_at_fiat` threaded through so the retry-sweep recovery
+      // emits real fiat in PurchaseFunds_Confirm, not the buzz-derived estimate.
       const event: NOWPayments.WebhookEvent = {
         payment_id: numericId,
         payment_status: payment.payment_status,
         order_id: payment.order_id,
         outcome_amount: payment.outcome_amount,
         actually_paid: payment.actually_paid ? Number(payment.actually_paid) : undefined,
+        actually_paid_at_fiat: payment.actually_paid_at_fiat,
         pay_currency: payment.pay_currency,
         pay_address: payment.pay_address,
         parent_payment_id: payment.parent_payment_id,
@@ -967,12 +993,15 @@ export const reconcileUserDeposits = async (userId: number) => {
       }
 
       try {
+        // `actually_paid_at_fiat` threaded through so self-service
+        // reconciliation emits real fiat in PurchaseFunds_Confirm.
         const event: NOWPayments.WebhookEvent = {
           payment_id: numericId,
           payment_status: payment.payment_status,
           order_id: payment.order_id,
           outcome_amount: payment.outcome_amount,
           actually_paid: payment.actually_paid ? Number(payment.actually_paid) : undefined,
+          actually_paid_at_fiat: payment.actually_paid_at_fiat,
           pay_currency: payment.pay_currency,
           pay_address: payment.pay_address,
           parent_payment_id: payment.parent_payment_id,

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -242,6 +242,10 @@ export const processDeposit = async (
           await new Tracker().action({
             type: 'PurchaseFunds_Confirm',
             userId,
+            // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
+            // convention), NOT the actual fiat amount billed. Crypto / partial
+            // payments won't always settle to clean multiples of 10 buzz, so
+            // treat this figure as approximate for analytics purposes.
             details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'nowpayments' },
           });
         } catch (err) {

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -236,26 +236,28 @@ export const processDeposit = async (
         // confirmed deposit with a fresh buzz grant, so webhook retries and
         // reconciliation reruns (which short-circuit to `already_granted`)
         // don't double-count. `unitAmount` mirrors the client convention of
-        // 10 buzz = 1 cent. Fire-and-forget — analytics must never block or
-        // fail the deposit confirmation.
-        try {
-          await new Tracker().action({
-            type: 'PurchaseFunds_Confirm',
-            userId,
-            // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
-            // convention), NOT the actual fiat amount billed. Crypto / partial
-            // payments won't always settle to clean multiples of 10 buzz, so
-            // treat this figure as approximate for analytics purposes.
-            details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'nowpayments' },
-          });
-        } catch (err) {
-          await log({
-            message: 'Failed to track PurchaseFunds_Confirm for nowpayments deposit',
-            paymentId,
-            userId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
+        // 10 buzz = 1 cent.
+        //
+        // `actionAsSystem` is the session-less server-side emit path: it
+        // requires an explicit `userId`, validates the payload against the
+        // shared zod schema, and never throws — it is fire-and-forget
+        // internally, so no try/catch is needed here (a wrapping catch would
+        // be unreachable).
+        new Tracker().actionAsSystem({
+          userId,
+          type: 'PurchaseFunds_Confirm',
+          // NOTE: `buzzAmount` here is the pre-multiplier *base* buzz the user
+          // purchased — `bonusBuzz` (the purchase-multiplier bonus) is tracked
+          // separately and intentionally excluded. `PurchaseFunds_Confirm` is
+          // a revenue signal, and revenue tracks the base purchase, not the
+          // bonus buzz granted on top.
+          //
+          // `unitAmount` is a *derived estimate* in cents (10 buzz = 1 cent
+          // convention), NOT the actual fiat amount billed. Crypto / partial
+          // payments won't always settle to clean multiples of 10 buzz, so
+          // treat this figure as approximate for analytics purposes.
+          details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'nowpayments' },
+        });
       }
     }
   }

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -1,5 +1,6 @@
 import { env } from '~/env/server';
 import { logToAxiom } from '../logging/client';
+import { Tracker } from '~/server/clickhouse/client';
 import {
   getMultipliersForUser,
   getTransactionByExternalId,
@@ -226,6 +227,31 @@ export const processDeposit = async (
             error: err instanceof Error ? err.message : String(err),
           });
         });
+
+        // Re-instrument the `PurchaseFunds_Confirm` analytics event for the
+        // crypto purchase flow. ~87% of buzz purchase volume is crypto, which
+        // completes off-site and credits via this webhook — there is no
+        // client-side confirmation moment, so PR #2308 (which restored the
+        // Stripe + Paddle in-app emits) could not cover it. Emitted only on a
+        // confirmed deposit with a fresh buzz grant, so webhook retries and
+        // reconciliation reruns (which short-circuit to `already_granted`)
+        // don't double-count. `unitAmount` mirrors the client convention of
+        // 10 buzz = 1 cent. Fire-and-forget — analytics must never block or
+        // fail the deposit confirmation.
+        try {
+          await new Tracker().action({
+            type: 'PurchaseFunds_Confirm',
+            userId,
+            details: { buzzAmount, unitAmount: Math.round(buzzAmount / 10), method: 'nowpayments' },
+          });
+        } catch (err) {
+          await log({
+            message: 'Failed to track PurchaseFunds_Confirm for nowpayments deposit',
+            paymentId,
+            userId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## The gap

The `PurchaseFunds_Confirm` analytics event (ClickHouse `default.actions`) regressed on **2024-08-30** when buzz purchases moved to redirect-based payment providers — the in-app success callback that carried the emit stopped firing. It has 59,758 historical rows and **zero in the last 365 days**, so every on-site purchase-funnel dashboard reads as a 100% leak.

**#2308 covered the client side.** PR #2308 re-instrumented the two *in-app* confirmation points in `BuzzPurchaseImproved.tsx` — the Stripe `onPaymentSuccess` callback and the Paddle `onSuccess` callback.

**But ~87% of buzz purchase volume is crypto.** Per `claudedocs/deep-dive-monetization-funnel.md` (datapacket-talos ops repo), NOWPayments crypto carries **87% of purchase transactions / 90% of buzz delivered** (12,944 of 14,932 txns in a 30d window). Crypto purchases (NOWPayments, Coinbase) **complete off-site and credit buzz via a server-side webhook** — there is no client-side confirmation moment, so a client-side `trackAction` is structurally impossible there. #2308 explicitly scoped this out as needing a server-side emit.

## What this PR adds (server-side)

Emits `PurchaseFunds_Confirm` from the crypto purchase webhook handlers at the point buzz is credited:

- **`nowpayments.service.ts`** — in `processDeposit`, after the `CryptoDeposit` upsert. Deduped by a dedicated per-`payment_id` Redis marker (see round-4 below). `method: 'nowpayments'`.
- **`coinbase.service.ts`** — in `processBuzzOrder`, after `grantBuzzPurchase` returns and before `grantCosmetics`. Duplicate `charge:confirmed` webhooks throw on the buzz-transaction conflict *before* this point, so it cannot double-count. `method: 'coinbase'`.

### How the server-side emit works — `Tracker.actionAsSystem()`

`Tracker` (`src/server/clickhouse/client.ts`) is the same class behind the client's `trackAction` (`trpc.track.addAction` → `ctx.track.action`); its emit goes through `CLICKHOUSE_TRACKER_URL` → NATS → `civitai-clickhouse-tracker` → ClickHouse. `new Tracker()` with no request is an established server-side pattern (jobs, `model.service.ts`).

The gap: the request-bound `action()` resolves `userId` only from the request session, which a webhook has none of. Rather than make `action()` accept a `userId` (which would let any request-bound `Tracker` be handed a *foreign* `userId` and spoof the actor — and would also bypass the tRPC zod validation), this PR adds a **distinct, session-less method**:

```ts
Tracker.actionAsSystem({ userId: number; type: ActionType; details?: any }): void
```

- `userId` is **required** — there is no request session to fall back to, and the request-bound `action()` keeps **no** `userId` parameter at all, so it cannot be spoofed.
- The payload is **validated against the shared `purchaseFundsConfirmSchema`** (now exported from `track.schema.ts`) before it is sent — the same schema the tRPC `track.addAction` path enforces — so a future required-field change can't silently desync server-side emits.
- Fully fire-and-forget: validation failures and transport errors are logged, never thrown, so analytics can never block or fail the buzz grant.

`buzzAmount` is the pre-multiplier **base** buzz purchased (not the credited base+bonus total) — intentional and commented at each call site: the event is a revenue signal and revenue tracks the base purchase.

## Round 4 — review fixes

### 🟡 NOWPayments: `partial_paid` → `finished` zero-rows gap (the important one)

Round 1 gated the emit to fire only when `webhookStatus === 'finished'`, **inside** the existing `transactionId !== 'already_granted'` referral-kickback guard. That guard interacts badly with the buzz-grant dedup:

1. A NOWPayments payment reports `partially_paid` → buzz is granted (`isDepositComplete()` accepts `partially_paid`) → emit skipped (status is not `finished`).
2. The **same `payment_id`** later reports `finished` → the `np-deposit-<paymentId>` buzz grant 409s against the partial grant → `transactionId === 'already_granted'` → the emit, sitting inside the `!== 'already_granted'` guard, is **also skipped**.

Net: a fully completed purchase produced **zero `PurchaseFunds_Confirm` rows** — the exact silent undercount this PR exists to fix.

**Fix:** the emit is now **decoupled from the buzz-grant dedup** and moved out of the referral-kickback guard. It fires after the `CryptoDeposit` upsert, gated only on `webhookStatus === 'finished'` and `!buzzGrantFailed`. Idempotency is handled by a **dedicated per-`payment_id` Redis marker** (`REDIS_KEYS.CRYPTO.PURCHASE_CONFIRM_EMITTED:nowpayments:<paymentId>`, set via `SET NX` with a 90-day TTL):

- `SET NX` succeeds only on the **first** `finished` delivery for a given `payment_id`, so the emit fires exactly once — even when the buzz was already granted on an earlier `partially_paid` (`transactionId === 'already_granted'`).
- Duplicate `finished` webhook deliveries and reconcile/retry reruns find the marker already set and skip the emit.
- **Why not `CryptoDeposit.status`?** `isDepositComplete()` collapses `partially_paid` into a `finished` row status, so a prior `partially_paid` is indistinguishable from a prior `finished` by status alone — it cannot serve as a "first reached `finished`" marker. The Redis marker is keyed on the *webhook* status, which is the real distinguishing signal.
- 90-day TTL comfortably outlives any staged settlement while bounding key growth.
- If Redis is unavailable, the `.catch()` falls through to **emitting** — one guaranteed row beats a silent zero on an outage. (Worst case under a sustained Redis outage is a small over-count, which is the safer failure direction for a leak-detection metric.)

### Coinbase: `unitAmount` excluded the fixed fee (review #3)

The Coinbase emit used `buzzAmount / 10` as `unitAmount`, which excludes `COINBASE_FIXED_FEE` — so Coinbase rows under-reported fiat versus NOWPayments / card rows that carry true billed fiat in the same ClickHouse column.

The charge is created with a `fixed_price` `local_price` of `(unitAmount + COINBASE_FIXED_FEE) / 100` USD, and the webhook echoes that exact figure back as `pricing.local.amount`. The emit now uses `pricing.local.amount * 100` (true total fiat billed, fee included) — consistent with how the NOWPayments path emits `actually_paid_at_fiat`. It falls back to the `buzzAmount / 10` estimate only if `pricing.local.amount` is malformed, so the field is never null. (`COINBASE_FIXED_FEE` is currently `0`, so there is no live difference today — this keeps the row correct if the fee is ever raised.)

### Rebase

Branch rebased onto `origin/main` (was ~17 commits behind) — clean, no conflicts.

## Cross-PR coordination

This PR is the **single owner** of the `src/server/clickhouse/client.ts` change. PR #2314 is stacked on this branch and will be rebased after this push.

## Evidence

`claudedocs/deep-dive-monetization-funnel.md` (datapacket-talos ops repo) — Recommendation #1 and the processor breakdown in Part 2. Companion to #2308.

---

Agent-authored from data analysis — needs review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
