### PR TITLE
fix(image-feed): make scheduled filter opt-in for non-mods

### DIFF
--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -231,6 +231,16 @@ export function MediaFiltersDropdown({
           >
             <span>Made On-site</span>
           </FilterChip>
+          {currentUser && !isModerator && (
+            <FilterChip
+              checked={!!mergedFilters.scheduled}
+              onChange={(checked) => handleChange({ scheduled: checked ? checked : undefined })}
+            >
+              <Tooltip label="Show your scheduled posts in feeds">
+                <span>Scheduled</span>
+              </Tooltip>
+            </FilterChip>
+          )}
           <FilterChip
             checked={mergedFilters.nonRemixesOnly}
             onChange={(checked) => {
@@ -298,7 +308,7 @@ export function MediaFiltersDropdown({
                 <span>Disable Minor</span>
               </FilterChip>
               <FilterChip
-                checked={mergedFilters.notPublished}
+                checked={!!mergedFilters.notPublished}
                 onChange={(checked) =>
                   handleChange({ notPublished: checked ? checked : undefined })
                 }
@@ -306,7 +316,7 @@ export function MediaFiltersDropdown({
                 <span>Not Published</span>
               </FilterChip>
               <FilterChip
-                checked={mergedFilters.scheduled}
+                checked={!!mergedFilters.scheduled}
                 onChange={(checked) => handleChange({ scheduled: checked ? checked : undefined })}
               >
                 <span>Scheduled</span>

--- a/src/components/Image/Infinite/UserMediaInfinite.tsx
+++ b/src/components/Image/Infinite/UserMediaInfinite.tsx
@@ -41,6 +41,7 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
       techniques = [],
       requiringMeta = false,
       notPublished = undefined,
+      scheduled = undefined,
       ...query
     },
   } = useImageQueryParams();
@@ -123,6 +124,7 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                     techniques,
                     requiringMeta,
                     notPublished,
+                    scheduled,
                   }}
                   filterType={isVideo ? 'videos' : 'images'}
                   onChange={(filters) => replace(filters)}
@@ -155,6 +157,7 @@ export function UserMediaInfinite({ type = MediaType.image }: { type: MediaType 
                   userId: viewingReactions ? undefined : user.id,
                   username: viewingReactions ? undefined : username,
                   notPublished,
+                  scheduled,
                   followed,
                   baseModels,
                   tools,

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1720,7 +1720,7 @@ export const getAllImages = async (
   // bustCacheTag('images-model:X' / 'images-modelVersion:X') is already wired in
   // post.service.ts on image upload/update events.
   const cacheable = queryCacheRaw(
-    async <Row,>(q: Prisma.Sql) => {
+    async <Row>(q: Prisma.Sql) => {
       const { rows } = await imageDb.query(q as any);
       return rows as Row[];
     },
@@ -2277,8 +2277,13 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
           BlockedReason.AiNotVerified,
         ].map(_str)
       ),
-      _eq('isPublished', _bool(false)),
     ];
+    // Own scheduled/unpublished content only surfaces when the caller opts in
+    // via `scheduled` or `notPublished`. BitDex `isPublished=false` covers both
+    // (no separate scheduled vs unpublished signal), so the gate is unified.
+    if (input.scheduled || input.notPublished) {
+      ownExcludedClauses.push(_eq('isPublished', _bool(false)));
+    }
     if (input.disablePoi) ownExcludedClauses.push(_eq('poi', _bool(true)));
 
     // Unscoped second pass — fetch ALL of user's excluded content regardless of
@@ -2684,10 +2689,15 @@ async function fetchMeiliUserOwnPass(
   const excludedOr: string[] = [
     makeMeiliImageSearchFilter(nsfwLevelField, `= 0`) as string,
     makeMeiliImageSearchFilter('publishedAtUnix', 'NOT EXISTS') as string,
-    makeMeiliImageSearchFilter('publishedAtUnix', `> ${now}`) as string,
     `availability = ${Availability.Private}`,
     `blockedFor IN [${blockedReasonList}]`,
   ];
+  // Own scheduled content is included in the second-pass only when the caller
+  // opted in via the `scheduled` flag. Without opt-in, owners no longer see
+  // their own scheduled images pinned to feeds.
+  if (input.scheduled) {
+    excludedOr.push(makeMeiliImageSearchFilter('publishedAtUnix', `> ${now}`) as string);
+  }
   if (disablePoi) excludedOr.push('poi = true');
   filters.push(`(${excludedOr.join(' OR ')})`);
 
@@ -2781,6 +2791,13 @@ function contentScopeUserOwnHits(
   if (remixOfId) scoped = scoped.filter((h) => h.remixOfId === remixOfId);
   if (withMeta) scoped = scoped.filter((h) => h.hasMeta === true);
   if (fromPlatform) scoped = scoped.filter((h) => h.onSite === true);
+  // Defense-in-depth: drop own scheduled/unpublished hits when the caller did
+  // not opt in via `scheduled` or `notPublished`. Belt-and-suspenders against
+  // a stale second-pass query forgetting to gate the publish clause.
+  if (!input.scheduled && !input.notPublished) {
+    const nowSec = Math.floor(Date.now() / 1000);
+    scoped = scoped.filter((h) => h.publishedAtUnix != null && h.publishedAtUnix <= nowSec);
+  }
   return scoped;
 }
 
@@ -3085,12 +3102,12 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
       filters.push(`(${publishedFilters.join(' OR ')})`);
     }
   } else {
-    // Users should only see published stuff or things they own
-    // convert to minutes for better caching
-    const publishedFilters = [
-      makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`),
-    ];
-    if (!input.meiliUserOwnPass && currentUserId) {
+    // Non-mod path. By default, strict published-only — owners no longer see
+    // their own scheduled/unpublished content pinned to feeds. The `scheduled`
+    // flag is opt-in: when set, OR-in the owner carve-out so the user-own
+    // second pass surfaces own scheduled hits.
+    const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
+    if (!input.meiliUserOwnPass && currentUserId && scheduled) {
       publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
     }
     filters.push(`(${publishedFilters.join(' OR ')})`);
@@ -3197,8 +3214,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
 
     // User-own-pass mode: run main query + user-own query in parallel, then merge.
     // Only runs on the first page (no cursor/entry/offset) to keep merge simple.
-    const runUserOwnPass =
-      !!input.meiliUserOwnPass && !!currentUserId && !entry && !offset;
+    const runUserOwnPass = !!input.meiliUserOwnPass && !!currentUserId && !entry && !offset;
 
     // Use the abortable raw fetch when a signal is available so client
     // disconnects (e.g. the feed's slow-fetch timeout) actually cancel the
@@ -3964,14 +3980,22 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     }
   } else if (userId) {
     const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
-    // For own user's content, allow seeing scheduled/notPublished content
-    if (!input.meiliUserOwnPass && currentUserId && userId === currentUserId) {
+    // For own user's profile view, only surface own scheduled content when the
+    // caller explicitly opted in via the `scheduled` flag. Without opt-in, the
+    // strict published filter applies even to own profile.
+    if (!input.meiliUserOwnPass && currentUserId && userId === currentUserId && scheduled) {
       publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
     }
     filters.push(`(${publishedFilters.join(' OR ')})`);
   } else {
-    // General feed queries - apply published filter for caching
-    filters.push(makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`));
+    // General feed queries - strict published filter for caching by default.
+    // When `scheduled` is opt-in, OR-in the owner carve-out so own scheduled
+    // hits surface in the main feed.
+    const publishedFilters = [makeMeiliImageSearchFilter('publishedAtUnix', `<= ${snappedNow}`)];
+    if (!input.meiliUserOwnPass && currentUserId && scheduled) {
+      publishedFilters.push(makeMeiliImageSearchFilter('userId', `= ${currentUserId}`));
+    }
+    filters.push(`(${publishedFilters.join(' OR ')})`);
   }
 
   if (types?.length) filters.push(makeMeiliImageSearchFilter('type', `IN [${types.join(',')}]`));
@@ -4128,10 +4152,12 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
         // User can see their own blocked content
         if (hit.blockedFor && !isOwnContent) return false;
 
-        // User can see their own scheduled or unpublished content
+        // Own scheduled/unpublished content only passes when the caller opted
+        // in via `scheduled` or `notPublished`. Without opt-in, even owners
+        // get the strict published filter applied.
         if (
           (!hit.publishedAtUnix || hit.publishedAtUnix > snappedNow) &&
-          (!isOwnContent || notPublished === false)
+          !(isOwnContent && (input.scheduled || input.notPublished))
         )
           return false;
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2794,9 +2794,11 @@ function contentScopeUserOwnHits(
   // Defense-in-depth: drop own scheduled/unpublished hits when the caller did
   // not opt in via `scheduled` or `notPublished`. Belt-and-suspenders against
   // a stale second-pass query forgetting to gate the publish clause.
+  // `publishedAtUnix` is stored in ms (`publishedAt.getTime()`) to match the
+  // rest of the publish filter logic which compares against `snappedNow` in ms.
   if (!input.scheduled && !input.notPublished) {
-    const nowSec = Math.floor(Date.now() / 1000);
-    scoped = scoped.filter((h) => h.publishedAtUnix != null && h.publishedAtUnix <= nowSec);
+    const nowMs = Date.now();
+    scoped = scoped.filter((h) => h.publishedAtUnix != null && h.publishedAtUnix <= nowMs);
   }
   return scoped;
 }


### PR DESCRIPTION
## Summary

- Image owners previously saw their own scheduled images pinned to the top of every feed they visited (main, profile, model gallery) with no way to dismiss. Privacy boundary was intact — only the owner saw their own scheduled content, but the UX was broken.
- Exposes the existing mod-only `Scheduled` chip to all logged-in users as an opt-in toggle. Default off → strict published filter. Toggle on → owner's scheduled content surfaces.
- Mod cross-user `Scheduled` behavior preserved (still gated to moderator section).

ClickUp: https://app.clickup.com/t/868jp80pu

## Changes

**UI (`MediaFiltersDropdown.tsx`)**
- New `Scheduled` chip in the general Modifiers section, gated `currentUser && !isModerator`, with a tooltip explaining the opt-in behavior.
- Existing mod-section chip preserved (gated `isModerator`).
- Coerced `checked` to strict boolean on `scheduled` + `notPublished` chips — Mantine `useUncontrolled` was falling back to internal state when `checked={undefined}`, breaking visual toggle-off.

**Server (`image.service.ts`)**
- `fetchMeiliUserOwnPass`: `publishedAtUnix > now` clause in the excluded-OR is now gated by `input.scheduled`. Other own-excluded categories (unpublished/private/blocked/unscanned/poi) unchanged.
- `fetchBitdexPrimary` second-pass: `isPublished=false` clause gated by `input.scheduled || input.notPublished` (BitDex `isPublished` doesn't distinguish scheduled vs draft).
- `contentScopeUserOwnHits`: defense-in-depth — drops scheduled/unpublished hits when neither flag is set.
- Meili PreFilter + PostFilter non-mod publish branches (`else if (userId)` and `else` general-feed): `OR userId = currentUserId` carve-out now only added when `scheduled === true`.
- PostFilter accumulation loop: own scheduled/unpublished hits only pass when `isOwnContent && (scheduled || notPublished)`.

**Profile view leak fix (`UserMediaInfinite.tsx`)**
- Destructures `scheduled` from URL query and threads it explicitly to `MediaFiltersDropdown` query prop and `ImagesInfinite` filters prop. Prevents stale Zustand `image-filters` localStorage from a prior session from overriding the off state on profile views (mirrors the existing pattern for `notPublished`).

## Test plan

- [x] Non-mod logged-in user with at least one scheduled post:
  - [x] `/images` (main feed) default → own scheduled not visible.
  - [x] `/user/<self>/images` default → own scheduled not visible.
  - [x] Open Filters dropdown → "Scheduled" chip visible in Modifiers (not in Moderator section), tooltip reads "Show your scheduled posts in feeds".
  - [x] Toggle Scheduled on → URL gets `?scheduled=true`, own scheduled appears in feed.
  - [x] Toggle Scheduled off → URL clears `?scheduled`, own scheduled disappears, chip visual flips back.
  - [x] Click "Clear all filters" → chip visual flips back to off, URL clears, scheduled hidden.
- [x] Mod regression:
  - [x] Open Filters → "Scheduled" chip appears in Moderator section (not in Modifiers).
  - [x] Toggle Scheduled on → cross-user scheduled posts surface in feed.
  - [x] Toggle off → strict published feed restored, chip visual flips.
- [x] Anonymous regression:
  - [x] Logged-out `/images` → no "Scheduled" chip anywhere, no scheduled content in feed.
- [x] Indexing-lag check:
  - [x] As non-mod, publish a fresh post → confirm it appears in `/images` within the normal indexing window. The non-mod main-filter `OR userId = currentUserId` carve-out only applies when `scheduled=true`, so freshly-published content must come through the standard Meili `publishedAtUnix <= now` filter.
- [x] Stale localStorage check:
  - [x] Set `image-filters` localStorage entry to `{"scheduled":true}` manually → reload `/user/<self>/images` → own scheduled should NOT be visible (URL override wins), chip should be off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)