### PR TITLE
feat(licensing-fee): inherit fee from base model version

### DIFF
--- a/prisma/migrations/20260522120000_add_base_model_licensing_fee/migration.sql
+++ b/prisma/migrations/20260522120000_add_base_model_licensing_fee/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "BaseModelLicensingFee" (
+    "baseModel" TEXT NOT NULL,
+    "modelType" "ModelType" NOT NULL,
+    "modelVersionId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BaseModelLicensingFee_pkey" PRIMARY KEY ("baseModel", "modelType")
+);
+
+-- CreateIndex
+CREATE INDEX "BaseModelLicensingFee_modelVersionId_idx" ON "BaseModelLicensingFee"("modelVersionId");
+
+-- AddForeignKey
+ALTER TABLE "BaseModelLicensingFee" ADD CONSTRAINT "BaseModelLicensingFee_modelVersionId_fkey" FOREIGN KEY ("modelVersionId") REFERENCES "ModelVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Seed: Anima checkpoint base model fee recipient (skipped if version absent, e.g. on staging/dev)
+INSERT INTO "BaseModelLicensingFee" ("baseModel", "modelType", "modelVersionId", "updatedAt")
+SELECT 'Anima', 'Checkpoint', 2945208, CURRENT_TIMESTAMP
+WHERE EXISTS (SELECT 1 FROM "ModelVersion" WHERE id = 2945208)
+ON CONFLICT ("baseModel", "modelType") DO NOTHING;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -1020,8 +1020,21 @@ model ModelVersion {
   ImageResourceNew        ImageResourceNew[]
   coveredCheckpoints      CoveredCheckpoint[]
   wildcardSet             WildcardSet?
+  baseModelLicensingFees  BaseModelLicensingFee[]
 
   @@index([modelId], type: Hash)
+}
+
+model BaseModelLicensingFee {
+  baseModel      String
+  modelType      ModelType
+  modelVersionId Int
+  modelVersion   ModelVersion @relation(fields: [modelVersionId], references: [id], onDelete: Cascade)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  @@id([baseModel, modelType])
+  @@index([modelVersionId])
 }
 
 enum LicensingFeeType {

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -57,6 +57,10 @@ type VersionRow = {
   licensingFee: number | null;
   licensingFeeType: LicensingFeeType | null;
   licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
+  baseLicensingFeeRecipientId: number | null;
+  baseLicensingFee: number | null;
+  baseLicensingFeeType: LicensingFeeType | null;
+  baseLicensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
   versionFlags: number;
   userFlags: number;
 };
@@ -106,6 +110,10 @@ export default MixedAuthEndpoint(async function handler(
       mv."licensingFee",
       mv."licensingFeeType",
       mv."licensingFeeSettlementCurrency",
+      bmlf."modelVersionId" AS "baseLicensingFeeRecipientId",
+      rmv."licensingFee" AS "baseLicensingFee",
+      rmv."licensingFeeType" AS "baseLicensingFeeType",
+      rmv."licensingFeeSettlementCurrency" AS "baseLicensingFeeSettlementCurrency",
       mv."flags" AS "versionFlags",
       u."flags" AS "userFlags",
       (
@@ -134,6 +142,9 @@ export default MixedAuthEndpoint(async function handler(
     FROM "ModelVersion" mv
     JOIN "Model" m ON m.id = mv."modelId"
     JOIN "User" u ON u.id = m."userId"
+    LEFT JOIN "BaseModelLicensingFee" bmlf
+      ON bmlf."baseModel" = mv."baseModel" AND bmlf."modelType" = m."type"
+    LEFT JOIN "ModelVersion" rmv ON rmv.id = bmlf."modelVersionId"
     WHERE ${Prisma.join(where, ' AND ')}
   `;
   if (!modelVersion) return res.status(404).json({ error: 'Model not found' });
@@ -252,14 +263,28 @@ export default MixedAuthEndpoint(async function handler(
     .map((fm) => fm.modelId)
     .includes(modelVersion.modelId);
 
-  const fee =
-    modelVersion.licensingFee != null && modelVersion.licensingFee > 0
-      ? {
-          amount: modelVersion.licensingFee,
-          type: lowerFirst(modelVersion.licensingFeeType ?? 'PerImageBuzz'),
-          settlementCurrency: lowerFirst(modelVersion.licensingFeeSettlementCurrency ?? 'Buzz'),
-        }
-      : undefined;
+  // Base-model rule wins over the version's own fee: derivatives inherit the
+  // base model's licensing, and the base version itself resolves to its own row.
+  const hasBaseRule =
+    modelVersion.baseLicensingFeeRecipientId != null &&
+    modelVersion.baseLicensingFee != null &&
+    modelVersion.baseLicensingFee > 0;
+  const hasOwnFee = modelVersion.licensingFee != null && modelVersion.licensingFee > 0;
+  const fee = hasBaseRule
+    ? {
+        amount: modelVersion.baseLicensingFee!,
+        type: lowerFirst(modelVersion.baseLicensingFeeType ?? 'PerImageBuzz'),
+        settlementCurrency: lowerFirst(modelVersion.baseLicensingFeeSettlementCurrency ?? 'Buzz'),
+        recipientModelVersionId: modelVersion.baseLicensingFeeRecipientId!,
+      }
+    : hasOwnFee
+    ? {
+        amount: modelVersion.licensingFee!,
+        type: lowerFirst(modelVersion.licensingFeeType ?? 'PerImageBuzz'),
+        settlementCurrency: lowerFirst(modelVersion.licensingFeeSettlementCurrency ?? 'Buzz'),
+        recipientModelVersionId: modelVersion.id,
+      }
+    : undefined;
 
   const payoutEnabled =
     !Flags.hasFlag(modelVersion.userFlags, UserFlag.DisablePayout) &&

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -265,6 +265,10 @@ export default MixedAuthEndpoint(async function handler(
 
   // Base-model rule wins over the version's own fee: derivatives inherit the
   // base model's licensing, and the base version itself resolves to its own row.
+  // TODO: support coexisting base-model + per-version fees (split payouts,
+  // additive amounts, derivative opt-out, etc.). Today the upsert path blocks
+  // children from setting their own fee when a rule covers them, so this branch
+  // only sees one or the other in practice.
   const hasBaseRule =
     modelVersion.baseLicensingFeeRecipientId != null &&
     modelVersion.baseLicensingFee != null &&

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -414,6 +414,28 @@ export const upsertModelVersionHandler = async ({
       if (!input.licensingFeeType) input.licensingFeeType = LicensingFeeType.PerImageBuzz;
       if (!input.licensingFeeSettlementCurrency)
         input.licensingFeeSettlementCurrency = LicensingFeeSettlementCurrency.Buzz;
+
+      // TODO: handle the case where both a base-model rule and a per-version fee
+      // exist (split payouts, additive fees, derivative opt-out, etc.). For now,
+      // a base-model rule fully owns the fee for its (baseModel, modelType) and
+      // child versions can't set their own.
+      const model = await dbRead.model.findUnique({
+        where: { id: input.modelId },
+        select: { type: true },
+      });
+      if (model) {
+        const baseRule = await dbRead.baseModelLicensingFee.findUnique({
+          where: {
+            baseModel_modelType: { baseModel: input.baseModel, modelType: model.type },
+          },
+          select: { modelVersionId: true },
+        });
+        if (baseRule && baseRule.modelVersionId !== input.id) {
+          throw throwBadRequestError(
+            'This base model already has a licensing fee. You cannot set a per-version fee on a derivative.'
+          );
+        }
+      }
     }
 
     const version = await upsertModelVersion({

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -901,6 +901,16 @@ export interface ModelVersion {
   ImageResourceNew?: ImageResourceNew[];
   coveredCheckpoints?: CoveredCheckpoint[];
   wildcardSet?: WildcardSet | null;
+  baseModelLicensingFees?: BaseModelLicensingFee[];
+}
+
+export interface BaseModelLicensingFee {
+  baseModel: string;
+  modelType: ModelType;
+  modelVersionId: number;
+  modelVersion?: ModelVersion;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface ModelVersionEngagement {


### PR DESCRIPTION
## Summary

- New `BaseModelLicensingFee` table maps `(baseModel, modelType)` to a recipient `ModelVersion` whose licensing config gets inherited by derivatives.
- `/api/v1/model-versions/mini/[id]` LEFT JOINs the rule + recipient version. `fee` now always carries `recipientModelVersionId` (own fee → version id; inherited → rule's recipient). Base-model rule wins over the derivative's own `licensingFee`.
- Seeds `('Anima', 'Checkpoint', 2945208)`, guarded by `EXISTS` so staging/dev without the version skip cleanly.

## Behavior

| Case | Fee source | `recipientModelVersionId` |
|---|---|---|
| Anima checkpoint v2945208 | rule (= itself) | 2945208 |
| Derivative checkpoint, `baseModel='Anima'` | rule → recipient's fee | 2945208 |
| Derivative LORA, `baseModel='Anima'` | none (rule is Checkpoint-only) | — |
| Unrelated version with own `licensingFee` | own | `mv.id` |

Add more rows (e.g. LORA) via SQL when ready; no admin UI yet.

## Out of scope

`resource-data.redis.ts`, `ResourceItemContent.tsx`, `ModelVersionDetails.tsx` still read mv-only `licensingFee`. In-app badges won't show inherited fees yet — orchestrator-facing mini endpoint is the only surface updated here. Follow-up PR if those displays should inherit too.

## Test plan

- [ ] Apply migration to staging, confirm table + Anima row created
- [ ] `GET /api/v1/model-versions/mini/2945208` → returns `fee.recipientModelVersionId: 2945208`
- [ ] `GET .../mini/<derivative checkpoint with baseModel=Anima>` → inherits fee, recipient = 2945208
- [ ] `GET .../mini/<derivative LORA with baseModel=Anima>` → no fee
- [ ] Existing version with own `licensingFee` and no matching rule → unchanged amount, `recipientModelVersionId = mv.id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)