### PR TITLE
Emit Membership_Cancel server-side from Stripe subscription.deleted webhook

### DIFF
--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -26,7 +26,7 @@ import type {
 } from '~/shared/utils/prisma/enums';
 import { createLogger } from '~/utils/logging';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
-import { trackActionSchema } from '~/server/schema/track.schema';
+import { trackActionSchema, type TrackActionInput } from '~/server/schema/track.schema';
 
 export type CustomClickHouseClient = ClickHouseClient & {
   $query: <T extends object>(
@@ -500,7 +500,7 @@ export class Tracker {
    */
   public actionAsSystem(values: {
     userId: number;
-    type: ActionType;
+    type: TrackActionInput['type'];
     details?: any;
   }): void {
     const { userId, type, details } = values;

--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -26,7 +26,7 @@ import type {
 } from '~/shared/utils/prisma/enums';
 import { createLogger } from '~/utils/logging';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
-import { purchaseFundsConfirmSchema } from '~/server/schema/track.schema';
+import { trackActionSchema } from '~/server/schema/track.schema';
 
 export type CustomClickHouseClient = ClickHouseClient & {
   $query: <T extends object>(
@@ -489,12 +489,11 @@ export class Tracker {
    * method, which *requires* `userId` explicitly.
    *
    * Unlike the ad-hoc `userId` override on `bounty()` / `bountyEntry()`, this
-   * path validates the full payload against the same zod schema the tRPC
-   * `track.addAction` endpoint enforces, so a future required-field change to
-   * the schema cannot silently desync server-side emits.
-   *
-   * Currently scoped to `PurchaseFunds_Confirm` (the only event with a
-   * server-side emit). Extend the validation switch when adding more.
+   * path validates the full payload against `trackActionSchema` — the exact
+   * same zod schema the tRPC `track.addAction` endpoint enforces. That schema
+   * is a discriminated union keyed on `type`, so the correct per-action shape
+   * is selected automatically from `type`; a future required-field change to
+   * any action's schema cannot silently desync server-side emits.
    *
    * Fire-and-forget: never throws — a bad payload or transport failure is
    * logged, not surfaced, so analytics can never block or fail its caller.
@@ -506,41 +505,25 @@ export class Tracker {
   }): void {
     const { userId, type, details } = values;
 
-    // Validate against the shared schema before emitting. Keeps server-side
-    // emits in lockstep with the tRPC `track.addAction` contract.
-    let validated: { type: ActionType; details?: any };
-    switch (type) {
-      case 'PurchaseFunds_Confirm': {
-        const result = purchaseFundsConfirmSchema.safeParse({ type, details });
-        if (!result.success) {
-          logToAxiom(
-            {
-              type: 'error',
-              name: 'actionAsSystem payload validation failed',
-              details: { actionType: type, userId, error: result.error.message },
-              message: 'Server-side action emit failed schema validation',
-            },
-            'clickhouse'
-          ).catch(() => {});
-          return;
-        }
-        validated = result.data;
-        break;
-      }
-      default:
-        logToAxiom(
-          {
-            type: 'error',
-            name: 'actionAsSystem unsupported type',
-            details: { actionType: type, userId },
-            message: `actionAsSystem has no validator for action type "${type}"`,
-          },
-          'clickhouse'
-        ).catch(() => {});
-        return;
+    // Validate against the shared `track.addAction` schema before emitting.
+    // The discriminated union selects the right per-`type` schema (e.g.
+    // `PurchaseFunds_Confirm`, `Membership_Cancel`) automatically — no
+    // parallel server-side schema, no per-type switch to keep in sync.
+    const result = trackActionSchema.safeParse({ type, details });
+    if (!result.success) {
+      logToAxiom(
+        {
+          type: 'error',
+          name: 'actionAsSystem payload validation failed',
+          details: { actionType: type, userId, error: result.error.message },
+          message: 'Server-side action emit failed schema validation',
+        },
+        'clickhouse'
+      ).catch(() => {});
+      return;
     }
 
-    const { details: validatedDetails } = validated;
+    const validatedDetails = 'details' in result.data ? result.data.details : undefined;
     // `userId` spreads after `actorMeta` in `track()`, so it overrides the
     // (zero) actor userId for this session-less Tracker.
     void this.track('actions', {

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -120,6 +120,12 @@ const membershipCancelSchema = z.object({
     .object({
       reason: z.string(),
       from: z.string(),
+      // Origin of the cancellation. The server-side Stripe webhook emit
+      // (`Tracker.actionAsSystem`) sets this to `'stripe'`. Declared as an
+      // explicit optional field — not left to `.passthrough()` — so the
+      // contract is self-documenting and survives validation independently
+      // of `.passthrough()` and of PR #2306's draft client-side emit.
+      method: z.string().optional(),
     })
     .passthrough()
     .optional(),

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -98,11 +98,7 @@ const purchaseFundsCancelSchema = z.object({
   type: z.literal('PurchaseFunds_Cancel'),
   details: z.object({ step: z.number() }).optional(),
 });
-// Exported so server-side emitters (e.g. crypto payment webhooks via
-// `Tracker.actionAsSystem`) can validate their payload against the same shape
-// the tRPC `track.addAction` path enforces — keeps server emits from silently
-// desyncing if a required field is added here.
-export const purchaseFundsConfirmSchema = z.object({
+const purchaseFundsConfirmSchema = z.object({
   type: z.literal('PurchaseFunds_Confirm'),
   details: z
     .object({

--- a/src/server/services/stripe.service.ts
+++ b/src/server/services/stripe.service.ts
@@ -33,6 +33,7 @@ import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions
 import { TransactionType, buzzConstants } from '~/shared/constants/buzz.constants';
 import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
 import { userUpdateCounter } from '~/server/prom/client';
+import { Tracker } from '~/server/clickhouse/client';
 
 const baseUrl = getBaseUrl('green'); // Stripe lives in civitai green
 const log = createLogger('stripe', 'blue');
@@ -545,6 +546,54 @@ export const upsertSubscription = async (
     log('Subscription canceled immediately');
     await dbWrite.customerSubscription.delete({ where: { id: mainSubscription.id } });
     await invalidateSubscriptionCaches(user.id);
+
+    // Emit the `Membership_Cancel` analytics event server-side. The common
+    // Stripe cancellation path is a redirect to the Stripe billing portal —
+    // the cancellation completes off-site and civitai only learns about it
+    // via this `customer.subscription.deleted` webhook, so the client-side
+    // emit (PR #2306) structurally cannot capture it. Placed after the
+    // `customerSubscription.delete` above, inside the `mainSubscription`
+    // guard: a Stripe webhook retry arriving once the row is already gone
+    // hits the early `return` above and never reaches here, so it cannot
+    // double-count. `from` is the prior tier resolved from the deleted
+    // subscription's product metadata; `reason` is empty — the webhook
+    // carries no cancellation reason. `method: 'stripe'` keeps the row shape
+    // aligned with PR #2306's client-side `Membership_Cancel` emit.
+    //
+    // `actionAsSystem` (PR #2310) is the session-less emit path: it requires
+    // an explicit `userId` (unspoofable — there is no request session here),
+    // validates the payload against the shared `track.addAction` schema, and
+    // is fully fire-and-forget — it never throws. The `try/catch` here only
+    // guards the prior-tier `dbRead.product` lookup, so a transient DB error
+    // resolving `from` can never fail the cancellation webhook itself.
+    //
+    // `price.product` is `string | Stripe.Product`: Stripe returns the bare
+    // product id unless the request expanded it. This webhook does not
+    // expand (`getServerStripe` sets no `expand`, and `constructEvent`
+    // replays the raw delivered payload), but a future expansion would make
+    // an `as string` cast silently resolve to a `[object Object]`-shaped id
+    // and zero out tier attribution. Normalise both shapes defensively, the
+    // same way `upsertPriceRecord` already does for `price.product`.
+    try {
+      const canceledProductRef = subscription.items.data[0]?.price.product;
+      const canceledProductId =
+        typeof canceledProductRef === 'string' ? canceledProductRef : canceledProductRef?.id;
+      const canceledProduct = canceledProductId
+        ? await dbRead.product.findFirst({ where: { id: canceledProductId } })
+        : null;
+      const fromTier = subscriptionProductMetadataSchema.safeParse(canceledProduct?.metadata);
+      new Tracker().actionAsSystem({
+        type: 'Membership_Cancel',
+        userId: user.id,
+        details: {
+          from: fromTier.success ? fromTier.data.tier : '',
+          reason: '',
+          method: 'stripe',
+        },
+      });
+    } catch (err) {
+      log('Failed to track Membership_Cancel for stripe subscription cancellation', err);
+    }
     return;
   }
 

--- a/src/server/services/stripe.service.ts
+++ b/src/server/services/stripe.service.ts
@@ -560,6 +560,29 @@ export const upsertSubscription = async (
     // carries no cancellation reason. `method: 'stripe'` keeps the row shape
     // aligned with PR #2306's client-side `Membership_Cancel` emit.
     //
+    // GATING — count only *immediate* cancellations, never overcount:
+    // `customer.subscription.deleted` fires for two distinct cases, and the
+    // enclosing `cancel_at === null` check ALONE does not separate them:
+    //   1. Immediate cancel  — API/portal `cancel()` with no future date.
+    //   2. Period-end cancel — `cancel_at_period_end: true` was set earlier;
+    //      `deleted` fires later when the billing period actually elapses.
+    // Verified against Stripe v11 (the pinned major) semantics: once a
+    // period-end cancellation transitions to `status: canceled`, Stripe
+    // CLEARS `cancel_at` back to `null` (it is defined as "a date in the
+    // *future*" — the future date has now passed). So a period-end `deleted`
+    // event ALSO arrives with `cancel_at === null` and would fall into this
+    // branch — wrongly counted as an immediate cancel, breaking the
+    // "undercount only" guarantee.
+    // The reliable discriminator is `cancel_at_period_end`: its type doc is
+    // explicit that it reflects whether the subscription "will (if
+    // status=active) or DID (if status=canceled) cancel at the end of the
+    // current billing period" — i.e. it RETAINS `true` on the period-end
+    // `deleted` event, whereas an immediate cancel leaves it `false`. So we
+    // additionally require `cancel_at_period_end === false` before emitting.
+    // A period-end cancellation is a separate (already-anticipated) event
+    // and is intentionally not counted here; missing it keeps us on the
+    // safe side of the undercount guarantee.
+    //
     // `actionAsSystem` (PR #2310) is the session-less emit path: it requires
     // an explicit `userId` (unspoofable — there is no request session here),
     // validates the payload against the shared `track.addAction` schema, and
@@ -574,25 +597,29 @@ export const upsertSubscription = async (
     // an `as string` cast silently resolve to a `[object Object]`-shaped id
     // and zero out tier attribution. Normalise both shapes defensively, the
     // same way `upsertPriceRecord` already does for `price.product`.
-    try {
-      const canceledProductRef = subscription.items.data[0]?.price.product;
-      const canceledProductId =
-        typeof canceledProductRef === 'string' ? canceledProductRef : canceledProductRef?.id;
-      const canceledProduct = canceledProductId
-        ? await dbRead.product.findFirst({ where: { id: canceledProductId } })
-        : null;
-      const fromTier = subscriptionProductMetadataSchema.safeParse(canceledProduct?.metadata);
-      new Tracker().actionAsSystem({
-        type: 'Membership_Cancel',
-        userId: user.id,
-        details: {
-          from: fromTier.success ? fromTier.data.tier : '',
-          reason: '',
-          method: 'stripe',
-        },
-      });
-    } catch (err) {
-      log('Failed to track Membership_Cancel for stripe subscription cancellation', err);
+    if (subscription.cancel_at_period_end) {
+      log('Subscription deletion is a period-end cancellation; skipping Membership_Cancel emit');
+    } else {
+      try {
+        const canceledProductRef = subscription.items.data[0]?.price.product;
+        const canceledProductId =
+          typeof canceledProductRef === 'string' ? canceledProductRef : canceledProductRef?.id;
+        const canceledProduct = canceledProductId
+          ? await dbRead.product.findFirst({ where: { id: canceledProductId } })
+          : null;
+        const fromTier = subscriptionProductMetadataSchema.safeParse(canceledProduct?.metadata);
+        new Tracker().actionAsSystem({
+          type: 'Membership_Cancel',
+          userId: user.id,
+          details: {
+            from: fromTier.success ? fromTier.data.tier : '',
+            reason: '',
+            method: 'stripe',
+          },
+        });
+      } catch (err) {
+        log('Failed to track Membership_Cancel for stripe subscription cancellation', err);
+      }
     }
     return;
   }


### PR DESCRIPTION
## The gap

`Membership_Cancel` (ClickHouse `default.actions`) regressed in 2024 and has had zero rows since — membership churn is invisible from this analytics surface.

**#2306 covers the client side.** PR #2306 re-instrumented the in-app cancellation `onSuccess` handlers in `MembershipChangePrevention.tsx` (Stripe non-redirect fallback + Paddle).

**But the common Stripe cancellation path is a redirect to the Stripe billing portal.** `cancelSubscriptionWithFallback` normally returns `{ type: 'redirect', url }` and sends the user off-site. The cancellation completes there; civitai learns about it only via the `customer.subscription.deleted` webhook. There is no client-side success moment on that path, so a client-side `trackAction` is structurally impossible — #2306 explicitly scoped this out as needing a server-side webhook emit.

## What this PR adds (server-side)

Emits `Membership_Cancel` from the Stripe webhook handler at the point the membership is actually torn down.

- **`stripe.service.ts`** — in `upsertSubscription`, inside the immediate-cancel branch (`isCancelingSubscription && subscription.cancel_at === null`). This is the block reached by `customer.subscription.deleted` that actually deletes the `CustomerSubscription` row and downgrades the user to free.
- The `userId` is already resolved in this function (to find/delete the subscription) — that user id attributes the event.
- `details.from` is the prior tier, resolved from the deleted subscription's product metadata (`subscriptionProductMetadataSchema` → `tier`). `details.reason` is empty — the webhook carries no cancellation reason. `details.method` is `'stripe'`.

## Stacked on #2310

This PR **stacks on #2310** (base branch `fix/purchase-confirm-webhook-tracking`). #2310 is the designated owner of the shared server-side `Tracker` change: it added `Tracker.actionAsSystem({ userId, type, details })` — a session-less emit path that takes a required, unspoofable `userId` (no request session), validates the payload before emitting, and is fully fire-and-forget (never throws).

- The server-side emit here goes through **`actionAsSystem`** rather than independently duplicating a `Tracker.action()` `userId` override. The earlier revision of this PR carried a byte-identical copy of #2310's `Tracker.action()` change (cross-PR audit finding #1) — that duplication is dropped entirely, and `action()` is left at its original session-only signature.
- `actionAsSystem` schema selection is **generalised by action type.** #2310 originally validated every payload against the `PurchaseFunds_Confirm` schema specifically, which is wrong for a `Membership_Cancel` payload. `actionAsSystem` now validates against `trackActionSchema` — the exact discriminated union the tRPC `track.addAction` endpoint already enforces — so the correct per-`type` schema is selected automatically. No parallel server-side schema, no per-type switch to maintain.
- `actionAsSystem`'s `type` param is narrowed to `TrackActionInput['type']` — the union of action types the discriminated union actually covers — so passing a type with no schema variant fails at compile time instead of being silently dropped by the generalized `safeParse`.

## Pairs with #2306 — shape consistency

`details` uses `{ from, reason, method: 'stripe' }` — the **same field names and shape** as PR #2306's client-side `Membership_Cancel` emit (`method: 'stripe'` for the Stripe path, `'paddle'` for Paddle). ClickHouse rows from the client and server paths therefore align.

## Audit round 4 — `method` is now an explicit schema contract

Previously this PR relied on `membershipCancelSchema`'s `.passthrough()` to let `details.method` survive validation — an *undeclared* contract that also only became a "real" field once #2306 (still draft) landed. This revision adds `method: z.string().optional()` as an **explicit field** on `membershipCancelSchema` in `track.schema.ts`, so:

- the contract is self-documenting (not dependent on `.passthrough()` behaviour), and
- #2314 is **self-sufficient** — no longer dependent on #2306's merge timing.

The field is `optional()`, so the existing client-side emit is unaffected. **Note:** #2306 makes an identical addition. If both PRs land, this is a trivial one-line merge conflict — take either side; making it explicit here removes #2314's dependency on #2306.

## Audit finding (🟡) — expanded `price.product` object

The prior-tier lookup previously cast `subscription.items.data[0]?.price.product` with `as string`. `price.product` is `string | Stripe.Product` — in a `customer.subscription.deleted` payload an expanded product object would make the cast silently resolve to a `[object Object]`-shaped id and zero out tier attribution. It is now normalised both ways (`typeof product === 'string' ? product : product?.id`), mirroring how `upsertPriceRecord` already handles `price.product`. The webhook does not currently expand (`getServerStripe` configures no `expand`, and `constructEvent` replays the raw delivered payload), so this is a defensive fix.

## Double-emit guard

Stripe re-delivers webhooks. The emit is placed *after* the `customerSubscription.delete` and *inside* the existing `!mainSubscription` early-return guard: a retry that arrives once the row is already gone returns before reaching the emit, so it cannot double-count. This mirrors #2310's "emit only inside the block that performs the mutation" approach.

## Scope note — revived metric deliberately undercounts churn

A subscription cancelled at period end fires `customer.subscription.deleted` with `cancel_at_period_end === true` (and `cancel_at` cleared back to `null` once it transitions to `canceled`), so it falls into the same branch as an immediate cancel. The emit additionally requires `cancel_at_period_end === false`, so deferred end-of-period cancellations are **not** instrumented here — that avoids over-counting.

**Consequence: the revived `Membership_Cancel` metric is a deliberate churn *undercount*** — it captures immediate (billing-portal) cancellations but skips deferred end-of-period cancellations. Anyone reading this metric for churn analysis needs to be aware it is a lower bound, not total churn.

---

🤖 Agent-authored from data analysis — needs human review. Fresh worktree, no install/build run locally; relying on `pr-check.yml` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
