### PR TITLE
fix(memberships): wire up dead onContinue prop so post-cancel Paddle refresh runs

### DIFF
--- a/src/components/Stripe/MembershipChangePrevention.tsx
+++ b/src/components/Stripe/MembershipChangePrevention.tsx
@@ -219,11 +219,14 @@ export const StripeCancelMembershipButton = ({
   onClose,
   hasUsedVaultStorage,
   onContinue,
+  onRefreshingChange,
 }: {
   onClose: () => void;
   hasUsedVaultStorage: boolean;
   onContinue?: () => void;
+  onRefreshingChange?: (refreshing: boolean) => void;
 }) => {
+  const [refreshing, setRefreshing] = useState(false);
   const { mutate, isLoading: connectingToStripe } =
     trpc.stripe.cancelSubscriptionWithFallback.useMutation({
       async onSuccess(data) {
@@ -231,13 +234,25 @@ export const StripeCancelMembershipButton = ({
           onClose();
           Router.push(data.url);
         } else {
-          onClose();
           showSuccessNotification({
             title: 'Subscription cancelled',
             message: 'Your subscription has been cancelled successfully.',
           });
           if (onContinue) {
-            Promise.resolve(onContinue()).catch(() => window.location.reload());
+            // Keep the modal mounted with a loading state until the async
+            // refresh resolves — closing first races the ~1-2s refresh and
+            // leaves the user on stale "still a member" UI with no spinner.
+            setRefreshing(true);
+            onRefreshingChange?.(true);
+            try {
+              await Promise.resolve(onContinue());
+              onClose();
+            } catch {
+              window.location.reload();
+            } finally {
+              setRefreshing(false);
+              onRefreshingChange?.(false);
+            }
           } else {
             window.location.reload();
           }
@@ -269,7 +284,7 @@ export const StripeCancelMembershipButton = ({
         }
       }}
       radius="xl"
-      loading={connectingToStripe}
+      loading={connectingToStripe || refreshing}
     >
       Proceed to Cancel
     </Button>
@@ -280,23 +295,38 @@ export const PaddleCancelMembershipButton = ({
   onClose,
   hasUsedVaultStorage,
   onContinue,
+  onRefreshingChange,
 }: {
   onClose: () => void;
   hasUsedVaultStorage: boolean;
   onContinue?: () => void;
+  onRefreshingChange?: (refreshing: boolean) => void;
 }) => {
+  const [refreshing, setRefreshing] = useState(false);
   const { cancelSubscription, cancelingSubscription } = useMutatePaddle();
   const handleCancelSubscription = () => {
     cancelSubscription({
-      onSuccess: (canceled) => {
+      onSuccess: async (canceled) => {
         if (canceled) {
-          onClose();
           showSuccessNotification({
             title: 'You have been successfully downgraded to our Free tier.',
             message: 'You will no longer be billed for your subscription',
           });
           if (onContinue) {
-            Promise.resolve(onContinue()).catch(() => window?.location.reload());
+            // Keep the modal mounted with a loading state until the async
+            // refresh resolves — closing first races the ~1-2s refresh and
+            // leaves the user on stale "still a member" UI with no spinner.
+            setRefreshing(true);
+            onRefreshingChange?.(true);
+            try {
+              await Promise.resolve(onContinue());
+              onClose();
+            } catch {
+              window?.location.reload();
+            } finally {
+              setRefreshing(false);
+              onRefreshingChange?.(false);
+            }
           } else {
             window?.location.reload();
           }
@@ -323,7 +353,7 @@ export const PaddleCancelMembershipButton = ({
         }
       }}
       radius="xl"
-      loading={cancelingSubscription}
+      loading={cancelingSubscription || refreshing}
     >
       Proceed to Cancel
     </Button>
@@ -334,6 +364,9 @@ export const CancelMembershipBenefitsModal = ({ onContinue }: { onContinue?: () 
   const features = useFeatureFlags();
   const dialog = useDialogContext();
   const handleClose = dialog.onClose;
+  // While a successful cancel's async refresh is in flight, keep the modal up
+  // and lock dismissal so the user can't escape into stale membership UI.
+  const [refreshing, setRefreshing] = useState(false);
   const [mainBuzzType] = useAvailableBuzz();
   const { vault, isLoading: vaultLoading } = useQueryVault();
   const { subscription, subscriptionLoading, subscriptionPaymentProvider } = useActiveSubscription({
@@ -348,6 +381,10 @@ export const CancelMembershipBenefitsModal = ({ onContinue }: { onContinue?: () 
   return (
     <Modal
       {...dialog}
+      onClose={refreshing ? () => undefined : dialog.onClose}
+      closeOnClickOutside={!refreshing}
+      closeOnEscape={!refreshing}
+      withCloseButton={!refreshing}
       size="md"
       title="You will lose the following if you cancel"
       radius="md"
@@ -379,6 +416,7 @@ export const CancelMembershipBenefitsModal = ({ onContinue }: { onContinue?: () 
                 onClose={handleClose}
                 hasUsedVaultStorage={hasUsedVaultStorage}
                 onContinue={onContinue}
+                onRefreshingChange={setRefreshing}
               />
             )}
             {subscriptionPaymentProvider === PaymentProvider.Paddle && (
@@ -386,9 +424,10 @@ export const CancelMembershipBenefitsModal = ({ onContinue }: { onContinue?: () 
                 onClose={handleClose}
                 hasUsedVaultStorage={hasUsedVaultStorage}
                 onContinue={onContinue}
+                onRefreshingChange={setRefreshing}
               />
             )}
-            <Button color="blue" onClick={handleClose} radius="xl">
+            <Button color="blue" onClick={handleClose} radius="xl" disabled={refreshing}>
               Don&rsquo;t cancel plan
             </Button>
           </Group>

--- a/src/components/Stripe/MembershipChangePrevention.tsx
+++ b/src/components/Stripe/MembershipChangePrevention.tsx
@@ -236,8 +236,11 @@ export const StripeCancelMembershipButton = ({
             title: 'Subscription cancelled',
             message: 'Your subscription has been cancelled successfully.',
           });
-          if (onContinue) onContinue();
-          else window.location.reload();
+          if (onContinue) {
+            Promise.resolve(onContinue()).catch(() => window.location.reload());
+          } else {
+            window.location.reload();
+          }
         }
       },
       onError(error) {
@@ -292,8 +295,11 @@ export const PaddleCancelMembershipButton = ({
             title: 'You have been successfully downgraded to our Free tier.',
             message: 'You will no longer be billed for your subscription',
           });
-          if (onContinue) onContinue();
-          else window?.location.reload();
+          if (onContinue) {
+            Promise.resolve(onContinue()).catch(() => window?.location.reload());
+          } else {
+            window?.location.reload();
+          }
         }
       },
     });

--- a/src/components/Stripe/MembershipChangePrevention.tsx
+++ b/src/components/Stripe/MembershipChangePrevention.tsx
@@ -246,12 +246,20 @@ export const StripeCancelMembershipButton = ({
             onRefreshingChange?.(true);
             try {
               await Promise.resolve(onContinue());
+              // Success path: onClose() unmounts this component, so any
+              // refreshing-state reset belongs only in catch (see below).
               onClose();
             } catch {
-              window.location.reload();
-            } finally {
+              // Outer fallback layer: onContinue is a generic () => void, so
+              // a callback that throws/rejects unguarded would otherwise strand
+              // the user on stale membership UI. (The inner layer lives in
+              // CancelMembershipAction.handleRefresh, whose own catch reloads
+              // on a failed refresh — this backstops any other onContinue.)
+              // Reset refreshing state here only: on the success path the
+              // modal is already unmounted, so resetting in finally was dead.
               setRefreshing(false);
               onRefreshingChange?.(false);
+              window.location.reload();
             }
           } else {
             window.location.reload();
@@ -320,12 +328,20 @@ export const PaddleCancelMembershipButton = ({
             onRefreshingChange?.(true);
             try {
               await Promise.resolve(onContinue());
+              // Success path: onClose() unmounts this component, so any
+              // refreshing-state reset belongs only in catch (see below).
               onClose();
             } catch {
-              window?.location.reload();
-            } finally {
+              // Outer fallback layer: onContinue is a generic () => void, so
+              // a callback that throws/rejects unguarded would otherwise strand
+              // the user on stale membership UI. (The inner layer lives in
+              // CancelMembershipAction.handleRefresh, whose own catch reloads
+              // on a failed refresh — this backstops any other onContinue.)
+              // Reset refreshing state here only: on the success path the
+              // modal is already unmounted, so resetting in finally was dead.
               setRefreshing(false);
               onRefreshingChange?.(false);
+              window?.location.reload();
             }
           } else {
             window?.location.reload();

--- a/src/components/Stripe/MembershipChangePrevention.tsx
+++ b/src/components/Stripe/MembershipChangePrevention.tsx
@@ -273,9 +273,11 @@ export const StripeCancelMembershipButton = ({
 export const PaddleCancelMembershipButton = ({
   onClose,
   hasUsedVaultStorage,
+  onContinue,
 }: {
   onClose: () => void;
   hasUsedVaultStorage: boolean;
+  onContinue?: () => void;
 }) => {
   const { cancelSubscription, cancelingSubscription } = useMutatePaddle();
   const handleCancelSubscription = () => {
@@ -287,7 +289,8 @@ export const PaddleCancelMembershipButton = ({
             title: 'You have been successfully downgraded to our Free tier.',
             message: 'You will no longer be billed for your subscription',
           });
-          window?.location.reload();
+          if (onContinue) onContinue();
+          else window?.location.reload();
         }
       },
     });
@@ -318,7 +321,7 @@ export const PaddleCancelMembershipButton = ({
   );
 };
 
-export const CancelMembershipBenefitsModal = () => {
+export const CancelMembershipBenefitsModal = ({ onContinue }: { onContinue?: () => void } = {}) => {
   const features = useFeatureFlags();
   const dialog = useDialogContext();
   const handleClose = dialog.onClose;
@@ -372,6 +375,7 @@ export const CancelMembershipBenefitsModal = () => {
               <PaddleCancelMembershipButton
                 onClose={handleClose}
                 hasUsedVaultStorage={hasUsedVaultStorage}
+                onContinue={onContinue}
               />
             )}
             <Button color="blue" onClick={handleClose} radius="xl">

--- a/src/components/Stripe/MembershipChangePrevention.tsx
+++ b/src/components/Stripe/MembershipChangePrevention.tsx
@@ -218,9 +218,11 @@ export function CancelMembershipFeedbackModal() {
 export const StripeCancelMembershipButton = ({
   onClose,
   hasUsedVaultStorage,
+  onContinue,
 }: {
   onClose: () => void;
   hasUsedVaultStorage: boolean;
+  onContinue?: () => void;
 }) => {
   const { mutate, isLoading: connectingToStripe } =
     trpc.stripe.cancelSubscriptionWithFallback.useMutation({
@@ -234,7 +236,8 @@ export const StripeCancelMembershipButton = ({
             title: 'Subscription cancelled',
             message: 'Your subscription has been cancelled successfully.',
           });
-          window.location.reload();
+          if (onContinue) onContinue();
+          else window.location.reload();
         }
       },
       onError(error) {
@@ -369,6 +372,7 @@ export const CancelMembershipBenefitsModal = ({ onContinue }: { onContinue?: () 
               <StripeCancelMembershipButton
                 onClose={handleClose}
                 hasUsedVaultStorage={hasUsedVaultStorage}
+                onContinue={onContinue}
               />
             )}
             {subscriptionPaymentProvider === PaymentProvider.Paddle && (


### PR DESCRIPTION
## Bug

`CancelMembershipAction` (`src/components/Subscriptions/CancelMembershipAction.tsx`) triggers `CancelMembershipBenefitsModal` like this:

```ts
dialogStore.trigger({
  component: CancelMembershipBenefitsModal,
  props: { onContinue: handleRefresh },
});
```

But `CancelMembershipBenefitsModal` (`src/components/Stripe/MembershipChangePrevention.tsx`) was declared with **no props** — `export const CancelMembershipBenefitsModal = () => { ... }`. The `onContinue` prop was therefore dead: `handleRefresh` (the Paddle `refreshSubscription()` + `currentUser.refresh()` flow) **silently never ran** after a membership cancel.

## Fix

Thread an optional `onContinue` callback through the modal:

- `CancelMembershipBenefitsModal` now accepts an optional `onContinue` prop.
- It passes `onContinue` down to `PaddleCancelMembershipButton` (and `StripeCancelMembershipButton`).
- The cancel buttons invoke `onContinue()` on a successful cancel; when no callback is supplied they fall back to `window.location.reload()` — preserving existing behavior for the other call site (`CancelMembershipFeedbackModal`, which triggers the modal without props).

Minimal, pattern-consistent change (sibling buttons in the same file already thread completion callbacks like `onContinue`/`onClose`).

## Defensive guard (post-review)

Both invocation sites (Stripe + Paddle) wrap the call as `Promise.resolve(onContinue()).catch(() => window.location.reload())`.

**This is future-proofing, not an active runtime safety net.** The current sole caller, `handleRefresh`, already wraps its own `refreshSubscription()`/`currentUser.refresh()` in `try/catch` and always resolves — it never throws or rejects, so the `.catch()` branch does not fire for any present caller. The guard exists so that if a *future* caller passes an `onContinue` that does throw synchronously or reject, the modal still falls back to a reload instead of leaving the user on stale membership UI. `onContinue` is a public optional prop on three exported components, so this is cheap insurance against a future regression rather than dead weight.

## ⚠️ Needs manual QA

The core premise of this PR — that `refreshSubscription()` + `currentUser.refresh()` **fully replaces** a page reload for membership UI updates — is **unverified**. After a successful cancel, manually confirm that *all* membership-dependent UI updates correctly without the reload, including (non-exhaustive): membership badge/tier indicator, billing/subscription settings page state, any feature-flag-gated UI tied to the subscription, vault storage UI, and navigation/header state. If any surface still shows stale membership data, the `onContinue` callback is insufficient and a reload (or additional cache invalidation) may still be required at that call site.

## Notes

- Caught during the #2306 audit, but the bug is pre-existing and independent of that PR.
- agent-authored — needs review.
