### PR TITLE
feat(profile): add Report kebab to blocked-by-them card

### DIFF
--- a/src/components/Profile/ProfileLayout2.tsx
+++ b/src/components/Profile/ProfileLayout2.tsx
@@ -3,8 +3,12 @@ import { ProfileSidebar } from '~/components/Profile/ProfileSidebar';
 
 import React, { useCallback, useMemo, useRef } from 'react';
 
-import { Box, Text } from '@mantine/core';
-import { IconBan } from '@tabler/icons-react';
+import { Box, Menu, Text } from '@mantine/core';
+import { IconBan, IconDotsVertical, IconFlag } from '@tabler/icons-react';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
+import { openReportModal } from '~/components/Dialog/triggers/report';
+import { ReportEntity } from '~/shared/utils/report-helpers';
 import { Meta } from '~/components/Meta/Meta';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { env } from '~/env/client';
@@ -200,9 +204,34 @@ function BlockedByThemPanel({
   return (
     <div className="flex min-h-[calc(100vh-200px)] items-center justify-center">
       <div
-        className="flex w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-dark-4 md:flex-row"
+        className="relative flex w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-dark-4 md:flex-row"
         style={outerCardStyle}
       >
+        <Menu position="bottom-end" withinPortal>
+          <Menu.Target>
+            <LegacyActionIcon
+              variant="subtle"
+              color="gray"
+              radius="xl"
+              className="absolute right-3 top-3 z-20 text-gray-0/80 hover:bg-white/10 hover:text-white"
+              aria-label="Blocked user actions"
+            >
+              <IconDotsVertical size={18} />
+            </LegacyActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <LoginRedirect reason="report-user">
+              <Menu.Item
+                leftSection={<IconFlag size={14} stroke={1.5} />}
+                onClick={() =>
+                  openReportModal({ entityType: ReportEntity.User, entityId: user.id })
+                }
+              >
+                Report user
+              </Menu.Item>
+            </LoginRedirect>
+          </Menu.Dropdown>
+        </Menu>
         <div
           className="relative flex w-full flex-col items-center justify-center gap-4 overflow-hidden bg-gradient-to-b from-red-9/30 via-red-9/15 to-red-9/5 px-10 py-12 md:w-2/5 md:bg-gradient-to-br"
           onMouseMove={handleMouseMove}


### PR DESCRIPTION
## Summary
- The blocked-by-them screen suppresses the sidebar (and its `UserContextMenu`), so the viewer had no way to report the user who blocked them. Some users block moderators specifically to dodge oversight, so the victim must still be able to file a report.
- Adds a Mantine Menu kebab in the top-right of `BlockedByThemPanel` with a single "Report user" item that opens the existing report modal (`ReportEntity.User`).
- Intentionally minimal — Block/Unblock is already the panel's primary CTA, Hide is redundant, and moderator-only actions don't apply (mods bypass the block screen).

Follow-up to #2312.

## Test plan
- [x] `pnpm typecheck`
- [ ] As Peli86 visiting `/user/shoes22` (blocked-by), kebab appears top-right of the card.
- [ ] Clicking "Report user" opens the standard report modal.
- [ ] Submitting a report works against `shoes22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)