### PR TITLE
feat(moderation): add Block user to content ellipsis menus

### DIFF
--- a/src/components/Cards/ModelCardContextMenu.tsx
+++ b/src/components/Cards/ModelCardContextMenu.tsx
@@ -5,6 +5,7 @@ import { AddArtFrameMenuItem } from '~/components/Decorations/AddArtFrameMenuIte
 import { openAddToCollectionModal } from '~/components/Dialog/triggers/add-to-collection';
 import { openBlockModelTagsModal } from '~/components/Dialog/triggers/block-model-tags';
 import { openReportModal } from '~/components/Dialog/triggers/report';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
 import { HideModelButton } from '~/components/HideModelButton/HideModelButton';
 import { HideUserButton } from '~/components/HideUserButton/HideUserButton';
 import { AddToCollectionMenuItem } from '~/components/MenuItems/AddToCollectionMenuItem';
@@ -133,6 +134,10 @@ export function ModelCardContextMenu({ data }: { data: UseQueryModelReturn[numbe
         {
           key: 'hide-button',
           component: <HideUserButton key="hide-button" as="menu-item" userId={data.user.id} />,
+        },
+        {
+          key: 'block-button',
+          component: <BlockUserButton key="block-button" as="menu-item" userId={data.user.id} />,
         },
         reportOption,
         reportImageOption,

--- a/src/components/CommentsV2/Comment/Comment.tsx
+++ b/src/components/CommentsV2/Comment/Comment.tsx
@@ -34,6 +34,8 @@ import {
 } from '~/components/CommentsV2/CommentsProvider';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { openReportModal } from '~/components/Dialog/triggers/report';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
+import { HideUserButton } from '~/components/HideUserButton/HideUserButton';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { LineClamp } from '~/components/LineClamp/LineClamp';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
@@ -243,6 +245,8 @@ export function CommentContent({
                   {comment.pinnedAt ? 'Unpin comment' : 'Pin comment'}
                 </Menu.Item>
               )}
+              <HideUserButton as="menu-item" userId={comment.user.id} />
+              <BlockUserButton userId={comment.user.id} as="menu-item" />
               {canReport && (
                 <LoginRedirect reason="report-model">
                   <Menu.Item

--- a/src/components/Image/ContextMenu/ImageMenuItems.tsx
+++ b/src/components/Image/ContextMenu/ImageMenuItems.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { AddArtFrameMenuItem } from '~/components/Decorations/AddArtFrameMenuItem';
 import { openAddToCollectionModal } from '~/components/Dialog/triggers/add-to-collection';
 import { openReportModal } from '~/components/Dialog/triggers/report';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
 import { HideImageButton } from '~/components/HideImageButton/HideImageButton';
 import { HideUserButton } from '~/components/HideUserButton/HideUserButton';
 import { useDeleteImage } from '~/components/Image/hooks/useDeleteImage';
@@ -120,6 +121,7 @@ export function ImageMenuItems(props: ImageContextMenuProps & { disableDelete?: 
           </LoginRedirect>
           <HideImageButton as="menu-item" imageId={imageId} />
           {_userId && <HideUserButton as="menu-item" userId={_userId} />}
+          {_userId && <BlockUserButton userId={_userId} as="menu-item" />}
         </>
       )}
       {isModerator && (

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/TopRightIcons.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/TopRightIcons.tsx
@@ -5,6 +5,7 @@ import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { CivitaiLinkManageButton } from '~/components/CivitaiLink/CivitaiLinkManageButton';
 import { openBlockModelTagsModal } from '~/components/Dialog/triggers/block-model-tags';
 import { openReportModal } from '~/components/Dialog/triggers/report';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
 import { HideModelButton } from '~/components/HideModelButton/HideModelButton';
 import { HideUserButton } from '~/components/HideUserButton/HideUserButton';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -33,6 +34,7 @@ export function TopRightIcons({
       .concat([
         <HideModelButton key="hide-model" as="menu-item" modelId={data.id} />,
         <HideUserButton key="hide-button" as="menu-item" userId={data.user.id} />,
+        <BlockUserButton key="block-button" as="menu-item" userId={data.user.id} />,
         <ReportMenuItem
           key="report-model"
           loginReason="report-model"

--- a/src/components/Model/Categories/ModelCategoryCard.tsx
+++ b/src/components/Model/Categories/ModelCategoryCard.tsx
@@ -29,6 +29,7 @@ import { CivitaiLinkManageButton } from '~/components/CivitaiLink/CivitaiLinkMan
 import { CivitaiTooltip } from '~/components/CivitaiWrapped/CivitaiTooltip';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { HideModelButton } from '~/components/HideModelButton/HideModelButton';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
 import { HideUserButton } from '~/components/HideUserButton/HideUserButton';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
@@ -237,6 +238,10 @@ function ModelCategoryCardContent({
         {
           key: 'hide-button',
           component: <HideUserButton key="hide-button" as="menu-item" userId={user.id} />,
+        },
+        {
+          key: 'block-button',
+          component: <BlockUserButton key="block-button" as="menu-item" userId={user.id} />,
         },
         reportOption,
         reportImageOption,

--- a/src/components/Model/ModelDiscussion/CommentDiscussionMenu.tsx
+++ b/src/components/Model/ModelDiscussion/CommentDiscussionMenu.tsx
@@ -16,6 +16,8 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { triggerRoutedDialog } from '~/components/Dialog/RoutedDialogLink';
 
 import { openReportModal } from '~/components/Dialog/triggers/report';
+import { BlockUserButton } from '~/components/HideUserButton/BlockUserButton';
+import { HideUserButton } from '~/components/HideUserButton/HideUserButton';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -219,16 +221,20 @@ export function CommentDiscussionMenu({
           </Menu.Item>
         )}
         {(!user || !isOwner) && (
-          <LoginRedirect reason="report-model">
-            <Menu.Item
-              leftSection={<IconFlag size={14} stroke={1.5} />}
-              onClick={() =>
-                openReportModal({ entityType: ReportEntity.Comment, entityId: comment.id })
-              }
-            >
-              Report
-            </Menu.Item>
-          </LoginRedirect>
+          <>
+            <HideUserButton as="menu-item" userId={comment.user.id} />
+            <BlockUserButton userId={comment.user.id} as="menu-item" />
+            <LoginRedirect reason="report-model">
+              <Menu.Item
+                leftSection={<IconFlag size={14} stroke={1.5} />}
+                onClick={() =>
+                  openReportModal({ entityType: ReportEntity.Comment, entityId: comment.id })
+                }
+              >
+                Report
+              </Menu.Item>
+            </LoginRedirect>
+          </>
         )}
       </Menu.Dropdown>
     </Menu>


### PR DESCRIPTION
## Summary
- Comment, image, and model card context menus surfaced Report and (in most cases) Hide user, but no quick Block. Users wanting to stop a griefer had to navigate to the offender's profile — friction, and impossible if the offender hid their content from feeds first.
- Ellie / Foxy Paladin flagged this on the comment ellipsis menu specifically. Applying the same fix everywhere with the same pattern.

## Surfaces updated
- CommentsV2 comment card (also added Hide user — was missing)
- Legacy model comment menu (also added Hide user — was missing)
- Image context menu
- Model card context menu
- Model category card
- Resource select modal top-right icons

`BlockUserButton` auto-hides for self, so no extra guards needed in any of the call sites.

## Test plan
- [x] `pnpm typecheck`
- [ ] On a comment from another user (CommentsV2 surface — e.g. an image's comment section), open kebab — see Hide user + Block user + Report.
- [ ] On a comment in legacy model discussion, same.
- [ ] On an image card in a feed, kebab shows Hide image + Hide user + Block user.
- [ ] On a model card, kebab shows Hide model + Hide user + Block user.
- [ ] Click Block from any surface — confirmation modal opens, mutation succeeds.
- [ ] Self-authored cards/comments — Block item does NOT appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)