### PR TITLE
feat(licensing-fee): surface inherited fee in UI

### DIFF
--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -1323,54 +1323,75 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         />
                       </Group>
                     )}
-                  {/* Generation License Fee */}
-                  {!!version.licensingFee && version.licensingFee > 0 && (
-                    <Group
-                      justify="space-between"
-                      px="md"
-                      py={10}
-                      style={{
-                        borderBottom: `1px solid ${
-                          colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                        }`,
-                      }}
-                    >
-                      <Text size="sm" c="dimmed">
-                        Generation License Fee
-                      </Text>
-                      <Group gap={4} wrap="nowrap">
-                        <CurrencyIcon currency="BUZZ" size={16} />
-                        <Text size="sm">{numberWithCommas(version.licensingFee)} / image</Text>
-                        <Popover
-                          width={260}
-                          shadow="md"
-                          withArrow
-                          position="top"
-                          opened={feeInfoOpened}
-                          onChange={feeInfoHandlers.close}
-                        >
-                          <Popover.Target>
-                            <ActionIcon
-                              size="xs"
-                              variant="subtle"
-                              color="gray"
-                              onClick={feeInfoHandlers.toggle}
-                              aria-label="License fee info"
-                            >
-                              <IconInfoSquareRounded size={18} />
-                            </ActionIcon>
-                          </Popover.Target>
-                          <Popover.Dropdown>
-                            <Text size="xs">
-                              The creator has issued a license fee. This amount is added on top of
-                              the standard generation cost for each image generated on Civitai with
-                              this resource.
-                            </Text>
-                          </Popover.Dropdown>
-                        </Popover>
+                  {/* Generation License Fee — own fee, or inherited from base model */}
+                  {(() => {
+                    const inherited = version.inheritedLicensingFee;
+                    const ownAmount = !inherited ? version.licensingFee ?? 0 : 0;
+                    const feeAmount = inherited ? inherited.amount : ownAmount;
+                    if (feeAmount <= 0) return null;
+                    return (
+                      <Group
+                        justify="space-between"
+                        px="md"
+                        py={10}
+                        style={{
+                          borderBottom: `1px solid ${
+                            colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
+                          }`,
+                        }}
+                      >
+                        <Text size="sm" c="dimmed">
+                          Generation License Fee
+                        </Text>
+                        <Group gap={4} wrap="nowrap">
+                          <CurrencyIcon currency="BUZZ" size={16} />
+                          <Text size="sm">{numberWithCommas(feeAmount)} / image</Text>
+                          <Popover
+                            width={260}
+                            shadow="md"
+                            withArrow
+                            position="top"
+                            opened={feeInfoOpened}
+                            onChange={feeInfoHandlers.close}
+                          >
+                            <Popover.Target>
+                              <ActionIcon
+                                size="xs"
+                                variant="subtle"
+                                color="gray"
+                                onClick={feeInfoHandlers.toggle}
+                                aria-label="License fee info"
+                              >
+                                <IconInfoSquareRounded size={18} />
+                              </ActionIcon>
+                            </Popover.Target>
+                            <Popover.Dropdown>
+                              {inherited ? (
+                                <Text size="xs">
+                                  This resource inherits a license fee from its base model,{' '}
+                                  <Anchor
+                                    href={`/models/${inherited.recipientModelId}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                  >
+                                    {inherited.recipientModelName}
+                                  </Anchor>
+                                  . The fee is added on top of the standard generation cost for each
+                                  image generated with this resource.
+                                </Text>
+                              ) : (
+                                <Text size="xs">
+                                  The creator has issued a license fee. This amount is added on top
+                                  of the standard generation cost for each image generated on
+                                  Civitai with this resource.
+                                </Text>
+                              )}
+                            </Popover.Dropdown>
+                          </Popover>
+                        </Group>
                       </Group>
-                    </Group>
-                  )}
+                    );
+                  })()}
                   {/* Reviews */}
                   <Group
                     justify="space-between"

--- a/src/components/generation_v2/inputs/ResourceItemContent.tsx
+++ b/src/components/generation_v2/inputs/ResourceItemContent.tsx
@@ -228,23 +228,42 @@ export function ResourceItemContent({
                 Epoch {epochDetails.epochNumber}
               </Badge>
             )}
-            {!!resource.licensingFee && resource.licensingFee > 0 && (
-              <HoverCard position="bottom" withArrow width={220}>
-                <HoverCard.Target>
-                  <CurrencyBadge
-                    unitAmount={resource.licensingFee}
-                    currency="BUZZ"
-                    size="xs"
-                    className="shrink-0 cursor-help"
-                  />
-                </HoverCard.Target>
-                <HoverCard.Dropdown>
-                  <Text size="sm">
-                    License fee charged per image when using this resource for generation.
-                  </Text>
-                </HoverCard.Dropdown>
-              </HoverCard>
-            )}
+            {(() => {
+              const inherited = resource.inheritedLicensingFee;
+              const feeAmount = inherited ? inherited.amount : resource.licensingFee ?? 0;
+              if (feeAmount <= 0) return null;
+              return (
+                <HoverCard position="bottom" withArrow width={220}>
+                  <HoverCard.Target>
+                    <CurrencyBadge
+                      unitAmount={feeAmount}
+                      currency="BUZZ"
+                      size="xs"
+                      className="shrink-0 cursor-help"
+                    />
+                  </HoverCard.Target>
+                  <HoverCard.Dropdown>
+                    <Text size="sm">
+                      {inherited ? (
+                        <>
+                          License fee inherited from base model{' '}
+                          <Anchor
+                            href={`/models/${inherited.recipientModelId}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {inherited.recipientModelName}
+                          </Anchor>
+                          . Charged per image when using this resource for generation.
+                        </>
+                      ) : (
+                        'License fee charged per image when using this resource for generation.'
+                      )}
+                    </Text>
+                  </HoverCard.Dropdown>
+                </HoverCard>
+              );
+            })()}
             {isSfwOnly && (
               <HoverCard position="bottom" withArrow width={200}>
                 <HoverCard.Target>

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -45,6 +45,7 @@ import {
   updateModelVersionById,
   upsertModelVersion,
 } from '~/server/services/model-version.service';
+import { bustBaseModelLicensingFeeCache } from '~/server/services/base-model-licensing-fee.service';
 import { getModel, updateModelEarlyAccessDeadline } from '~/server/services/model.service';
 import { trackModActivity } from '~/server/services/moderator.service';
 import {
@@ -443,6 +444,13 @@ export const upsertModelVersionHandler = async ({
       trainingDetails: input.trainingDetails,
     });
     if (!version) throw throwNotFoundError(`No model version with id ${input.id as number}`);
+
+    // The base-model fee cache snapshots the recipient version's licensingFee.
+    // Bust whenever a versions's licensingFee is touched so the rule cache picks
+    // up the new amount (and any newly-zeroed fees stop showing as inherited).
+    if (input.licensingFee !== undefined) {
+      await bustBaseModelLicensingFeeCache();
+    }
 
     // Just update early access deadline if updating the model version
     if (input.id)

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -394,13 +394,19 @@ export const upsertModelVersionHandler = async ({
       );
     }
 
+    const previousFeeState = input.id
+      ? await dbRead.modelVersion.findUnique({
+          where: { id: input.id },
+          select: {
+            licensingFee: true,
+            licensingFeeType: true,
+            licensingFeeSettlementCurrency: true,
+          },
+        })
+      : null;
+
     if (input.licensingFee != null && input.licensingFee > 0) {
-      const existing = input.id
-        ? await dbRead.modelVersion.findUnique({
-            where: { id: input.id },
-            select: { licensingFee: true, licensingFeeSettlementCurrency: true },
-          })
-        : null;
+      const existing = previousFeeState;
       const hadExistingFee = !!existing?.licensingFee && existing.licensingFee > 0;
       if (!ctx.features.licensingFee && !ctx.user.isModerator && !hadExistingFee) {
         throw throwBadRequestError('License fees are not enabled for your account.');
@@ -446,10 +452,25 @@ export const upsertModelVersionHandler = async ({
     if (!version) throw throwNotFoundError(`No model version with id ${input.id as number}`);
 
     // The base-model fee cache snapshots the recipient version's licensingFee.
-    // Bust whenever a versions's licensingFee is touched so the rule cache picks
-    // up the new amount (and any newly-zeroed fees stop showing as inherited).
-    if (input.licensingFee !== undefined) {
-      await bustBaseModelLicensingFeeCache();
+    // Bust narrowly: only when this version is referenced by a rule and one of
+    // the cached fee fields actually changed. New versions can't be recipients
+    // yet, so we skip the bust entirely for them.
+    if (input.id) {
+      const feeChanged =
+        (input.licensingFee !== undefined &&
+          input.licensingFee !== previousFeeState?.licensingFee) ||
+        (input.licensingFeeType !== undefined &&
+          input.licensingFeeType !== previousFeeState?.licensingFeeType) ||
+        (input.licensingFeeSettlementCurrency !== undefined &&
+          input.licensingFeeSettlementCurrency !==
+            previousFeeState?.licensingFeeSettlementCurrency);
+      if (feeChanged) {
+        const isRecipient = !!(await dbRead.baseModelLicensingFee.findFirst({
+          where: { modelVersionId: input.id },
+          select: { baseModel: true },
+        }));
+        if (isRecipient) await bustBaseModelLicensingFeeCache();
+      }
     }
 
     // Just update early access deadline if updating the model version
@@ -526,6 +547,14 @@ export const upsertModelVersionHandler = async ({
 
 export const deleteModelVersionHandler = async ({ input }: { input: GetByIdInput }) => {
   try {
+    // FK ON DELETE CASCADE drops any BaseModelLicensingFee rows pointing at this
+    // version. The rule cache holds those by value, so bust if a rule referenced
+    // this version (checked before delete since the row is gone after).
+    const wasRecipient = !!(await dbRead.baseModelLicensingFee.findFirst({
+      where: { modelVersionId: input.id },
+      select: { baseModel: true },
+    }));
+
     const version = await deleteVersionById(input);
     if (!version) throw throwNotFoundError(`No model version with id ${input.id}`);
 
@@ -535,6 +564,7 @@ export const deleteModelVersionHandler = async ({ input }: { input: GetByIdInput
     });
 
     await dataForModelsCache.refresh(version.modelId);
+    if (wasRecipient) await bustBaseModelLicensingFeeCache();
 
     return version;
   } catch (error) {

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -65,6 +65,7 @@ import { getDownloadFilename, getFilesByEntity } from '~/server/services/file.se
 import { getImagesForModelVersion } from '~/server/services/image.service';
 import {
   buildLicensingFeeLookup,
+  bustBaseModelLicensingFeeCache,
   getBaseModelLicensingFeeRules,
 } from '~/server/services/base-model-licensing-fee.service';
 import { bustMvCache, getLinkedVaeIds } from '~/server/services/model-version.service';
@@ -736,6 +737,14 @@ export const deleteModelHandler = async ({
     const { id, permanently } = input;
     if (permanently && !ctx.user.isModerator) throw throwAuthorizationError();
 
+    // Soft-delete sets ModelVersion.deletedAt, which is filtered out by the
+    // rule cache query. Permanent delete cascades into BaseModelLicensingFee.
+    // Either way, bust if any of this model's versions was a recipient.
+    const wasRecipient = !!(await dbRead.baseModelLicensingFee.findFirst({
+      where: { modelVersion: { modelId: id } },
+      select: { baseModel: true },
+    }));
+
     const deleteModel = permanently ? permaDeleteModelById : deleteModelById;
     const model = await deleteModel({ id, userId: ctx.user.id, isModerator: ctx.user.isModerator });
     if (!model) throw throwNotFoundError(`No model with id ${id}`);
@@ -747,6 +756,7 @@ export const deleteModelHandler = async ({
     });
 
     await dataForModelsCache.refresh(id);
+    if (wasRecipient) await bustBaseModelLicensingFeeCache();
 
     return model;
   } catch (error) {

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -63,6 +63,10 @@ import { getCollectionById, getCollectionItemCount } from '~/server/services/col
 import { hasEntityAccess } from '~/server/services/common.service';
 import { getDownloadFilename, getFilesByEntity } from '~/server/services/file.service';
 import { getImagesForModelVersion } from '~/server/services/image.service';
+import {
+  buildLicensingFeeLookup,
+  getBaseModelLicensingFeeRules,
+} from '~/server/services/base-model-licensing-fee.service';
 import { bustMvCache, getLinkedVaeIds } from '~/server/services/model-version.service';
 import {
   copyGallerySettingsToAllModelsByUser,
@@ -281,6 +285,9 @@ export const getModelHandler = async ({
         });
     }
 
+    const licensingFeeRules = await getBaseModelLicensingFeeRules();
+    const lookupInheritedFee = buildLicensingFeeLookup(licensingFeeRules);
+
     const mappedVersions = filteredVersions.map((version) => {
       let earlyAccessDeadline = features.earlyAccessModel ? version.earlyAccessEndsAt : undefined;
       if (earlyAccessDeadline && new Date() > earlyAccessDeadline) earlyAccessDeadline = undefined;
@@ -333,9 +340,12 @@ export const getModelHandler = async ({
 
       const versionMetrics = version.metrics[0];
 
+      const inheritedLicensingFee = lookupInheritedFee(version.baseModel, model.type, version.id);
+
       return {
         ...version,
         metrics: undefined,
+        inheritedLicensingFee,
         rank: {
           generationCountAllTime: versionMetrics?.generationCount ?? 0,
           downloadCountAllTime: versionMetrics?.downloadCount ?? 0,

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -900,6 +900,7 @@ export const REDIS_KEYS = {
     BLOCKED_BY_USERS: 'packed:caches:blocked-by-users',
     BASIC_USERS: 'packed:caches:basic-users',
     BASIC_TAGS: 'packed:caches:basic-tags',
+    BASE_MODEL_LICENSING_FEE_RULES: 'packed:caches:base-model-licensing-fee-rules',
     ENTITY_AVAILABILITY: {
       MODEL_VERSIONS: 'packed:caches:entity-availability:model-versions',
     },

--- a/src/server/services/base-model-licensing-fee.service.ts
+++ b/src/server/services/base-model-licensing-fee.service.ts
@@ -35,6 +35,9 @@ const CACHE_KEY = REDIS_KEYS.CACHES.BASE_MODEL_LICENSING_FEE_RULES;
 const CACHE_TTL = CacheTTL.hour;
 
 async function fetchRules(): Promise<BaseModelLicensingFeeRule[]> {
+  // Only surface rules whose recipient is a live, publicly-visible model+version.
+  // If the recipient is unpublished, deleted, or private we drop the rule rather
+  // than leak its name/id through `inheritedLicensingFee` on derivatives.
   const rows = await dbRead.$queryRaw<RuleRow[]>`
     SELECT
       bmlf."baseModel",
@@ -48,7 +51,14 @@ async function fetchRules(): Promise<BaseModelLicensingFeeRule[]> {
     FROM "BaseModelLicensingFee" bmlf
     JOIN "ModelVersion" rmv ON rmv.id = bmlf."modelVersionId"
     JOIN "Model" rm ON rm.id = rmv."modelId"
-    WHERE rmv."licensingFee" IS NOT NULL AND rmv."licensingFee" > 0
+    WHERE rmv."licensingFee" IS NOT NULL
+      AND rmv."licensingFee" > 0
+      AND rmv."status" = 'Published'
+      AND rmv."deletedAt" IS NULL
+      AND rmv."availability" <> 'Private'
+      AND rm."status" = 'Published'
+      AND rm."deletedAt" IS NULL
+      AND rm."availability" <> 'Private'
   `;
   return rows.map((r) => ({
     baseModel: r.baseModel,

--- a/src/server/services/base-model-licensing-fee.service.ts
+++ b/src/server/services/base-model-licensing-fee.service.ts
@@ -1,0 +1,102 @@
+import { CacheTTL } from '~/server/common/constants';
+import { dbRead } from '~/server/db/client';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+import type {
+  LicensingFeeSettlementCurrency,
+  LicensingFeeType,
+  ModelType,
+} from '~/shared/utils/prisma/enums';
+
+export type BaseModelLicensingFeeRule = {
+  baseModel: string;
+  modelType: ModelType;
+  recipientModelVersionId: number;
+  recipientModelId: number;
+  recipientModelName: string;
+  amount: number;
+  type: LicensingFeeType;
+  settlementCurrency: LicensingFeeSettlementCurrency;
+};
+
+export type InheritedLicensingFee = Omit<BaseModelLicensingFeeRule, 'baseModel' | 'modelType'>;
+
+type RuleRow = {
+  baseModel: string;
+  modelType: ModelType;
+  recipientModelVersionId: number;
+  recipientModelId: number;
+  recipientModelName: string;
+  licensingFee: number;
+  licensingFeeType: LicensingFeeType | null;
+  licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
+};
+
+const CACHE_KEY = REDIS_KEYS.CACHES.BASE_MODEL_LICENSING_FEE_RULES;
+const CACHE_TTL = CacheTTL.hour;
+
+async function fetchRules(): Promise<BaseModelLicensingFeeRule[]> {
+  const rows = await dbRead.$queryRaw<RuleRow[]>`
+    SELECT
+      bmlf."baseModel",
+      bmlf."modelType",
+      bmlf."modelVersionId" AS "recipientModelVersionId",
+      rm.id                  AS "recipientModelId",
+      rm.name                AS "recipientModelName",
+      rmv."licensingFee",
+      rmv."licensingFeeType",
+      rmv."licensingFeeSettlementCurrency"
+    FROM "BaseModelLicensingFee" bmlf
+    JOIN "ModelVersion" rmv ON rmv.id = bmlf."modelVersionId"
+    JOIN "Model" rm ON rm.id = rmv."modelId"
+    WHERE rmv."licensingFee" IS NOT NULL AND rmv."licensingFee" > 0
+  `;
+  return rows.map((r) => ({
+    baseModel: r.baseModel,
+    modelType: r.modelType,
+    recipientModelVersionId: r.recipientModelVersionId,
+    recipientModelId: r.recipientModelId,
+    recipientModelName: r.recipientModelName,
+    amount: r.licensingFee,
+    type: r.licensingFeeType ?? ('PerImageBuzz' as LicensingFeeType),
+    settlementCurrency:
+      r.licensingFeeSettlementCurrency ?? ('Buzz' as LicensingFeeSettlementCurrency),
+  }));
+}
+
+export async function getBaseModelLicensingFeeRules(): Promise<BaseModelLicensingFeeRule[]> {
+  const cached = await redis.packed.get<BaseModelLicensingFeeRule[]>(CACHE_KEY);
+  if (cached) return cached;
+  const rules = await fetchRules();
+  await redis.packed.set(CACHE_KEY, rules, { EX: CACHE_TTL });
+  return rules;
+}
+
+export async function bustBaseModelLicensingFeeCache() {
+  await redis.del(CACHE_KEY);
+}
+
+export type LicensingFeeLookup = (
+  baseModel: string,
+  modelType: ModelType,
+  versionId: number
+) => InheritedLicensingFee | null;
+
+export function buildLicensingFeeLookup(rules: BaseModelLicensingFeeRule[]): LicensingFeeLookup {
+  const byKey = new Map<string, BaseModelLicensingFeeRule>();
+  for (const r of rules) byKey.set(`${r.baseModel}:${r.modelType}`, r);
+  return (baseModel, modelType, versionId) => {
+    const rule = byKey.get(`${baseModel}:${modelType}`);
+    if (!rule) return null;
+    // Recipient version IS the source of the fee — surfaces its own fee instead
+    // of "inherited from self" on the recipient's own detail page.
+    if (rule.recipientModelVersionId === versionId) return null;
+    return {
+      recipientModelVersionId: rule.recipientModelVersionId,
+      recipientModelId: rule.recipientModelId,
+      recipientModelName: rule.recipientModelName,
+      amount: rule.amount,
+      type: rule.type,
+      settlementCurrency: rule.settlementCurrency,
+    };
+  };
+}

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -27,6 +27,11 @@ import type { ModelFileCached } from '~/server/services/model-file.service';
 import { getFilesForModelVersionCache } from '~/server/services/model-file.service';
 import type { GenerationResourceDataModel } from '~/server/redis/resource-data.redis';
 import { resourceDataCache } from '~/server/redis/resource-data.redis';
+import {
+  buildLicensingFeeLookup,
+  getBaseModelLicensingFeeRules,
+  type LicensingFeeLookup,
+} from '~/server/services/base-model-licensing-fee.service';
 import { getFeaturedModels } from '~/server/services/model.service';
 import { getLinkedVaeIds } from '~/server/services/model-version.service';
 import { imagesForModelVersionsCache } from '~/server/services/image.service';
@@ -909,6 +914,8 @@ export async function getResourceData(
 
   const unavailableResources = await getUnavailableResources();
   const featuredModels = await getFeaturedModels();
+  const licensingFeeRules = await getBaseModelLicensingFeeRules();
+  const lookupInheritedFee: LicensingFeeLookup = buildLicensingFeeLookup(licensingFeeRules);
   // sfwOnly is set upstream from ctx.features.isGreen, so reuse it as the
   // isGreen signal for the nsfwIds gate inside getResourceCanGenerate.
   const ecosystemConfig = await getGenerationEcosystemConfig(user, { isGreen: sfwOnly });
@@ -943,6 +950,8 @@ export async function getResourceData(
       delete item.model.minor;
     }
 
+    const inheritedLicensingFee = lookupInheritedFee(item.baseModel, item.model.type, item.id);
+
     return {
       ...item,
       minStrength: settings?.minStrength ?? -1,
@@ -953,6 +962,7 @@ export async function getResourceData(
       epochNumber,
       isOwnedByUser,
       isPrivate,
+      inheritedLicensingFee,
     };
   }
 

--- a/src/shared/types/generation.types.ts
+++ b/src/shared/types/generation.types.ts
@@ -26,6 +26,20 @@ export type GenerationResourceBase = {
   epochNumber?: number;
   /** Per-image license fee in Buzz set by the model version owner */
   licensingFee?: number | null;
+  /**
+   * Resolved license fee inherited from the version's base model (e.g. an
+   * Anima checkpoint derivative inherits Anima's fee). Null when the version
+   * itself is the recipient or no base-model rule matches; in those cases
+   * `licensingFee` is the source of truth.
+   */
+  inheritedLicensingFee?: {
+    amount: number;
+    type: string;
+    settlementCurrency: string;
+    recipientModelVersionId: number;
+    recipientModelId: number;
+    recipientModelName: string;
+  } | null;
   // settings
   clipSkip?: number;
   minStrength: number;


### PR DESCRIPTION
## Summary

Surfaces the inherited licensing fee everywhere we display licensing fees in the UI, with a tight cache so we don't add per-page DB overhead.

- New `base-model-licensing-fee.service` — one Redis-cached SQL query (1h TTL) that pulls every rule joined with its recipient version + model.
- Callers build a `Map<\`\${baseModel}:\${modelType}\`, Rule>` once per request and do O(1) lookups per resource. No per-page JOIN added to existing queries.
- `inheritedLicensingFee` is stamped on:
  - each version in `model.getById` (powers `ModelVersionDetails`)
  - each `GenerationResource` from `getResourceData` (powers the generation panel resource picker and anywhere else that consumes the cache)
- Rule cache busts on any per-version `licensingFee` edit, so recipient fee changes propagate next read.

## Behavior

| Surface | Old | New |
|---|---|---|
| Model details fee row | own fee only | own ?? inherited; popover links to source model |
| Generation resource badge | own fee only | own ?? inherited; HoverCard links to source model |
| Recipient version itself | own fee | unchanged (rule resolves to self -> null inherited) |

## Performance

- Rule set is tiny (one row per supported `(baseModel, modelType)` combo). One query per hour per Redis cluster.
- All resolution is in-process hash lookup. No JOINs added to hot paths.
- Cache bust path: any model-version upsert that touches `licensingFee` invalidates the rule blob. Effective for both recipient-version edits and the upsert-time block that already prevents derivative override.

## Test plan

- [ ] Visit Anima model 2945208 details page -> license fee row shown using its own fee, popover renders standard copy
- [ ] Visit an Anima-derivative checkpoint -> fee row shows inherited amount, popover links to Anima
- [ ] Visit an Anima-derivative LORA -> no fee row (rule is Checkpoint-only)
- [ ] Generation panel pick an Anima-derivative checkpoint -> badge shows inherited amount, HoverCard links to Anima
- [ ] Edit the recipient version's fee -> rule cache bust flushes, next page render reflects new amount

## Follow-ups

The TODO in `mini/[id].ts` (handle base-rule + per-version fee coexistence) still stands. Nothing in this PR locks in that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)