### PR TITLE
feat(db): histogram for pg Pool acquire latency

### DIFF
--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -1,8 +1,10 @@
 import { Prisma } from '@prisma/client';
 import type { QueryResult, QueryResultRow } from 'pg';
 import { Pool } from 'pg';
+import { performance } from 'node:perf_hooks';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
+import { pgPoolAcquireHistogram } from '~/server/prom/client';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 
@@ -114,6 +116,30 @@ export function getClient(
       client.query(`SET statement_timeout = ${Number(readTimeout)}`).catch(() => {});
     });
   }
+
+  // Wrap pool.connect() to record acquire latency. The pg.Pool `acquire` event fires
+  // when a client is handed out — it does NOT tell you how long the caller awaited.
+  // Timing around the await is the only way to see queue-wait time, which is the
+  // signal we want during pool-saturation incidents.
+  const originalConnect = pool.connect.bind(pool) as typeof pool.connect;
+  pool.connect = (async (...args: Parameters<typeof pool.connect>) => {
+    const start = performance.now();
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const conn = await (originalConnect as any)(...args);
+      pgPoolAcquireHistogram.observe(
+        { pool: instance, result: 'ok' },
+        (performance.now() - start) / 1000
+      );
+      return conn;
+    } catch (e) {
+      pgPoolAcquireHistogram.observe(
+        { pool: instance, result: 'err' },
+        (performance.now() - start) / 1000
+      );
+      throw e;
+    }
+  }) as typeof pool.connect;
 
   pool.cancellableQuery = async function <R extends QueryResultRow = any>(
     sql: Prisma.Sql | string,

--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -2,11 +2,38 @@ import { Prisma } from '@prisma/client';
 import type { QueryResult, QueryResultRow } from 'pg';
 import { Pool } from 'pg';
 import { performance } from 'node:perf_hooks';
+import client from 'prom-client';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
-import { pgPoolAcquireHistogram } from '~/server/prom/client';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
+
+// Histogram for pg Pool acquire latency. Defined here (not in prom/client.ts)
+// to avoid a module-init cycle: prom/client.ts imports pgDb/notifDb/datapacketDb,
+// which import db-helpers. If db-helpers also imported a const from prom/client.ts,
+// webpack's CJS-style chunking can leave that binding in a Temporal Dead Zone
+// during module init — observed as "Cannot access 'S' before initialization" +
+// V8 heap OOM on PR-preview 2322 (commit 664aa4c2e).
+//
+// prom-client itself has no cycle back into our code, so importing it directly
+// is safe. Unprefixed name matches the existing node_postgres_pool_* gauges in
+// prom/client.ts so dashboards correlate on the same metric family.
+const PG_POOL_ACQUIRE_HISTOGRAM_NAME = 'node_postgres_pool_acquire_duration_seconds';
+const pgPoolAcquireHistogram = (() => {
+  try {
+    return new client.Histogram({
+      name: PG_POOL_ACQUIRE_HISTOGRAM_NAME,
+      help: 'Time spent awaiting a connection from a pg.Pool, by pool instance and result',
+      labelNames: ['pool', 'result'] as const,
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    });
+  } catch {
+    // HMR re-registration: prom-client throws on duplicate; reuse the existing one
+    return client.register.getSingleMetric(PG_POOL_ACQUIRE_HISTOGRAM_NAME) as client.Histogram<
+      'pool' | 'result'
+    >;
+  }
+})();
 
 const log = createLogger('pgDb', 'blue');
 

--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -121,24 +121,44 @@ export function getClient(
   // when a client is handed out — it does NOT tell you how long the caller awaited.
   // Timing around the await is the only way to see queue-wait time, which is the
   // signal we want during pool-saturation incidents.
+  //
+  // pool.connect has two forms: Promise (no args) and callback ((err, client, done) => ...).
+  // Pool.prototype.query uses the CALLBACK form internally, so any pool.query(...) caller
+  // (including the /api/health probe) routes through here via that path. The async wrap
+  // resolves immediately for the callback form (pg-pool returns undefined synchronously),
+  // so we must wrap the callback itself to time when the client is actually delivered.
   const originalConnect = pool.connect.bind(pool) as typeof pool.connect;
-  pool.connect = (async (...args: Parameters<typeof pool.connect>) => {
+  pool.connect = ((...args: Parameters<typeof pool.connect>) => {
     const start = performance.now();
-    try {
+    const elapsedSeconds = () => (performance.now() - start) / 1000;
+
+    // Callback form: pool.connect((err, client, done) => ...)
+    if (typeof args[0] === 'function') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const conn = await (originalConnect as any)(...args);
-      pgPoolAcquireHistogram.observe(
-        { pool: instance, result: 'ok' },
-        (performance.now() - start) / 1000
-      );
-      return conn;
-    } catch (e) {
-      pgPoolAcquireHistogram.observe(
-        { pool: instance, result: 'err' },
-        (performance.now() - start) / 1000
-      );
-      throw e;
+      const cb = args[0] as (err: Error | undefined, client: any, done: any) => void;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (originalConnect as any)((err: Error | undefined, client: any, done: any) => {
+        pgPoolAcquireHistogram.observe(
+          { pool: instance, result: err ? 'err' : 'ok' },
+          elapsedSeconds()
+        );
+        cb(err, client, done);
+      });
     }
+
+    // Promise form: await pool.connect()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (originalConnect as any)(...args).then(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (conn: any) => {
+        pgPoolAcquireHistogram.observe({ pool: instance, result: 'ok' }, elapsedSeconds());
+        return conn;
+      },
+      (e: unknown) => {
+        pgPoolAcquireHistogram.observe({ pool: instance, result: 'err' }, elapsedSeconds());
+        throw e;
+      }
+    );
   }) as typeof pool.connect;
 
   pool.cancellableQuery = async function <R extends QueryResultRow = any>(

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -36,22 +36,25 @@ export function registerHistogram<T extends string = string>({
   help,
   labelNames,
   buckets,
+  prefix = PROM_PREFIX,
 }: {
   name: string;
   help: string;
   labelNames?: readonly T[];
-  buckets?: number[];
+  buckets?: readonly number[];
+  prefix?: string;
 }) {
   // Do this to deal with HMR in nextjs
+  const fullName = prefix + name;
   try {
     return new client.Histogram({
-      name: PROM_PREFIX + name,
+      name: fullName,
       help,
       labelNames: labelNames ? [...labelNames] : undefined,
-      buckets,
+      buckets: buckets ? [...buckets] : undefined,
     });
   } catch (e) {
-    return client.register.getSingleMetric(PROM_PREFIX + name) as Histogram<T>;
+    return client.register.getSingleMetric(fullName) as Histogram<T>;
   }
 }
 
@@ -175,6 +178,24 @@ export const dbReadFallbackCounter = registerCounterWithLabels({
   name: 'dbread_fallback_total',
   help: 'Number of times a dbRead query fell back to dbWrite due to CDC replication lag',
   labelNames: ['entity', 'caller'] as const,
+});
+
+// Buckets for pg Pool acquire latency in seconds.
+// Range covers sub-1ms healthy through 10s pathological — useful for diagnosing
+// pool waits during incidents like the 2026-05-21+ api-primary restart waves where
+// HAProxy backend_connect_time jittered to >1s under getInfiniteImages load.
+export const PG_POOL_ACQUIRE_BUCKETS = [
+  0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+] as const;
+
+export const pgPoolAcquireHistogram = registerHistogram({
+  name: 'node_postgres_pool_acquire_duration_seconds',
+  help: 'Time spent awaiting a connection from a pg.Pool, by pool instance and result',
+  labelNames: ['pool', 'result'] as const,
+  buckets: PG_POOL_ACQUIRE_BUCKETS,
+  // Match the unprefixed naming used by the existing node_postgres_pool_* gauges below
+  // so dashboards can correlate on the same metric family.
+  prefix: '',
 });
 
 declare global {

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -180,23 +180,10 @@ export const dbReadFallbackCounter = registerCounterWithLabels({
   labelNames: ['entity', 'caller'] as const,
 });
 
-// Buckets for pg Pool acquire latency in seconds.
-// Range covers sub-1ms healthy through 10s pathological — useful for diagnosing
-// pool waits during incidents like the 2026-05-21+ api-primary restart waves where
-// HAProxy backend_connect_time jittered to >1s under getInfiniteImages load.
-export const PG_POOL_ACQUIRE_BUCKETS = [
-  0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
-] as const;
-
-export const pgPoolAcquireHistogram = registerHistogram({
-  name: 'node_postgres_pool_acquire_duration_seconds',
-  help: 'Time spent awaiting a connection from a pg.Pool, by pool instance and result',
-  labelNames: ['pool', 'result'] as const,
-  buckets: PG_POOL_ACQUIRE_BUCKETS,
-  // Match the unprefixed naming used by the existing node_postgres_pool_* gauges below
-  // so dashboards can correlate on the same metric family.
-  prefix: '',
-});
+// pgPoolAcquireHistogram is registered in src/server/db/db-helpers.ts, not here.
+// Defining it here would create a module-init cycle (prom/client.ts imports
+// pgDb → db-helpers, which would import this histogram back), which webpack's
+// CJS chunking can break with a TDZ error at runtime.
 
 declare global {
   // eslint-disable-next-line no-var


### PR DESCRIPTION
## Summary

Adds a `node_postgres_pool_acquire_duration_seconds` Prometheus histogram (labels: `pool`, `result`) measuring how long callers wait to acquire a connection from each `pg.Pool` — primary, primaryRead, primaryReadLong, notification, notificationRead, datapacketRead.

Wired in the single `getClient` factory in `src/server/db/db-helpers.ts` by wrapping `pool.connect`, so it covers every pool created in the app with no per-call-site instrumentation.

## Why

Follow-up to the recurring civitai-dp-prod api-primary restart-wave investigation (2026-05-21 → 2026-05-24). We have point-in-time gauges (`node_postgres_pool_total_count`, `_idle_count`, `_waiting_count`) but no latency histogram, so during the wave we couldn't tell whether callers were *queueing on the pool* — only that some `waitingCount` was nonzero at scrape time. The pg.Pool `acquire` event also doesn't help: it fires when a client is handed out, not when the await started.

Timing around the await is the only way to see queue-wait time and bound the contribution from pool saturation when these waves recur.

## Scope / what this PR is not

- Independent of and complementary to **#2321** (`civitai_app_healthcheck_duration_seconds` for HTTP `/api/health` paths). Different layer — that one measures the health endpoint's own latency; this one measures the pool acquire it depends on.
- Independent of the in-flight `getInfiniteImagesRaw` statement-timeout PR (different file, different concern).
- No new npm dependencies — `prom-client` and `pg` are already in `package.json`.
- No refactor of existing pool definitions, no change to gauges, no change to `/api/health`.

## Diagnostic PromQL

```promql
# p99 acquire latency per pool, last 1m
histogram_quantile(0.99,
  sum by (le, pool) (
    rate(node_postgres_pool_acquire_duration_seconds_bucket[1m])
  )
)
```

```promql
# Acquire error rate per pool
sum by (pool) (rate(node_postgres_pool_acquire_duration_seconds_count{result="err"}[5m]))
```

```promql
# Fraction of acquires taking >250ms (early-warning band)
sum by (pool) (rate(node_postgres_pool_acquire_duration_seconds_bucket{le="+Inf"}[5m]))
  -
sum by (pool) (rate(node_postgres_pool_acquire_duration_seconds_bucket{le="0.25"}[5m]))
```

## Buckets

`[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]` seconds. Denser through the 25-500ms band where pool saturation typically first shows up, with explicit 1s/2.5s/5s/10s anchors to bracket pathological cases. Distinct from #2321's bucket layout because pool-acquire latency lives in a different range than HTTP health-check latency.

## Implementation notes

- The histogram uses an unprefixed name (no `civitai_app_` prefix) to co-locate with the existing `node_postgres_pool_*` gauges in Prometheus.
- A new `registerHistogram` helper in `prom/client.ts` mirrors the existing `registerCounter` / `registerCounterWithLabels` HMR-safe pattern.
- `pool.connect` wrap preserves the function signature via `typeof pool.connect`; both the no-arg promise form and the callback overload work unchanged.
- Histogram error path observes the same `(now - start) / 1000` so failed acquires (e.g. `connectionTimeoutMillis` exceeded) also show up in the distribution under `result="err"`.

## Test plan

- [ ] After deploy, confirm `node_postgres_pool_acquire_duration_seconds_count` increases with traffic in Prometheus
- [ ] Verify all 6 pool labels appear: `primary`, `primaryRead`, `primaryReadLong`, `notification`, `notificationRead`, `datapacketRead`
- [ ] Verify `result="ok"` dominates and `result="err"` is rare / matches connection-timeout incidents
- [ ] Add Grafana panel for p50/p95/p99 per pool to the existing pool-health dashboard alongside `_waiting_count`