### PR TITLE
feat(image-feed): cap getInfiniteImagesRaw at 20s statement_timeout

### DIFF
--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -173,6 +173,49 @@ export function getClient(
   return pool;
 }
 
+/**
+ * Run a read-only query against the given pool with a server-side
+ * `statement_timeout` ceiling. Uses an explicit BEGIN READ ONLY / SET LOCAL
+ * / COMMIT so the timeout is scoped to this transaction even under PgBouncer
+ * transaction pooling.
+ *
+ * Accepts either a Prisma.Sql (preferred — the codebase's raw-query convention)
+ * or a (text, params) pair, matching the shape of pg's `Pool.query`.
+ *
+ * Throws pg error with code `'57014'` (query_canceled) on timeout — callers
+ * should catch and decide whether to surface, return an empty page, or retry.
+ *
+ * Note: `timeoutMs` is interpolated literally because PostgreSQL does not
+ * accept `$1`-parameterized values in `SET LOCAL`. The argument MUST be a
+ * trusted JS number — never user input. `Number(...)` is a defensive cast.
+ */
+export async function queryWithTimeout<R extends QueryResultRow = any>(
+  pool: Pool,
+  timeoutMs: number,
+  sql: Prisma.Sql | string,
+  params?: ReadonlyArray<unknown>
+): Promise<QueryResult<R>> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN READ ONLY');
+    await client.query(`SET LOCAL statement_timeout = ${Number(timeoutMs)}`);
+    let result: QueryResult<R>;
+    if (typeof sql === 'string') {
+      result = await client.query<R>(sql, params as unknown[] | undefined);
+    } else {
+      // Prisma.Sql carries its own params in `.values`; pass as QueryConfig
+      result = await client.query<R>({ text: sql.text, values: sql.values });
+    }
+    await client.query('COMMIT');
+    return result;
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => undefined);
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
 function formatSqlType(value: any): string {
   if (value instanceof Date) return value.toISOString();
   if (typeof value === 'object') {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -49,7 +49,7 @@ import {
   metricsSearchClient,
 } from '~/server/meilisearch/client';
 import { postMetrics } from '~/server/metrics';
-import { leakingContentCounter } from '~/server/prom/client';
+import { leakingContentCounter, registerCounterWithLabels } from '~/server/prom/client';
 import { imageOnSiteSql, isImageMetaOnSite } from '~/server/utils/image-onsite';
 import {
   getBaseModelFromResources,
@@ -1108,6 +1108,17 @@ export type ImagesInfiniteModel = AsyncReturnType<typeof getAllImages>['items'][
 // rather than surfacing a 500, with a structured axiom log for observability.
 const IMAGE_FEED_STATEMENT_TIMEOUT_MS = 20_000;
 
+// Increments when the image-feed query is server-side cancelled by the
+// statement_timeout ceiling above. Labelled by dbTarget so we can see
+// which pool the slow query landed on. Distinguished from pg_cancel_backend
+// or client AbortSignal cancellations by checking the error message — those
+// also use SQLSTATE 57014 but should propagate rather than fall back to empty.
+const imageFeedStatementTimeoutCounter = registerCounterWithLabels({
+  name: 'image_feed_statement_timeout_total',
+  help: 'getAllImages raw query cancelled by server-side statement_timeout',
+  labelNames: ['dbTarget'] as const,
+});
+
 export const getAllImages = async (
   input: GetAllImagesInput & {
     userId?: number;
@@ -1748,11 +1759,19 @@ export const getAllImages = async (
     );
   } catch (e) {
     const code = (e as { code?: string })?.code;
-    if (code === '57014') {
+    const message = (e as { message?: string })?.message ?? '';
+    // SQLSTATE 57014 (query_canceled) is shared by statement_timeout,
+    // pg_cancel_backend(), and client AbortSignal cancellation. Only the
+    // first should fall back to an empty page — the others must propagate
+    // so callers/observers see the cancellation. Postgres distinguishes
+    // them via the error message: "canceling statement due to statement timeout".
+    if (code === '57014' && message.includes('statement timeout')) {
       // Query exceeded IMAGE_FEED_STATEMENT_TIMEOUT_MS on the replica.
       // Return an empty page instead of surfacing a 500 — the feed is best-effort
       // and the UI handles `items: []` gracefully. Log to axiom so we can track
-      // frequency and identify pathological filter combinations.
+      // frequency and identify pathological filter combinations; also bump a
+      // counter so we can alert if the rate climbs.
+      imageFeedStatementTimeoutCounter.inc({ dbTarget });
       logToAxiom({
         name: 'getInfiniteImages:statement_timeout',
         type: 'warning',

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -215,7 +215,7 @@ const _or = (...cs: (FilterClause | null)[]): FilterClause => {
 };
 import { ensureRegisterFeedImageExistenceCheckMetrics } from '../metrics/feed-image-existence-check.metrics';
 import client from 'prom-client';
-import { getExplainSql } from '~/server/db/db-helpers';
+import { getExplainSql, queryWithTimeout } from '~/server/db/db-helpers';
 import { ImagesFeed } from '../../../event-engine-common/feeds';
 import { MetricService } from '../../../event-engine-common/services/metrics';
 import { CacheService } from '../../../event-engine-common/services/cache';
@@ -1097,6 +1097,17 @@ type GetAllImagesInput = GetInfiniteImagesOutput & {
   actor?: string;
 };
 export type ImagesInfiniteModel = AsyncReturnType<typeof getAllImages>['items'][0];
+
+// Per-call ceiling for the image-feed raw query. The `civitai` postgres role
+// has statement_timeout=0 (overriding the cluster's 300s), so a single slow
+// run of this query (mean 4.2s / max 115.8s, dominant source of replica
+// statement-timeout cancellations) can monopolize the replica's parallel-worker
+// budget, back up pgbouncer-ro, and cascade into api-primary health-check
+// failures. 20s is comfortably above p99 for healthy runs while bounding
+// pathological cases. On timeout the caller returns an empty page (graceful)
+// rather than surfacing a 500, with a structured axiom log for observability.
+const IMAGE_FEED_STATEMENT_TIMEOUT_MS = 20_000;
+
 export const getAllImages = async (
   input: GetAllImagesInput & {
     userId?: number;
@@ -1721,15 +1732,52 @@ export const getAllImages = async (
   // post.service.ts on image upload/update events.
   const cacheable = queryCacheRaw(
     async <Row>(q: Prisma.Sql) => {
-      const { rows } = await imageDb.query(q as any);
+      // Per-call statement_timeout ceiling — see IMAGE_FEED_STATEMENT_TIMEOUT_MS
+      // for rationale. The timeout fires server-side (pg error code 57014);
+      // we catch it at the call site below and return an empty page.
+      const { rows } = await queryWithTimeout(imageDb, IMAGE_FEED_STATEMENT_TIMEOUT_MS, q);
       return rows as Row[];
     },
     'getAllImages',
     'v1'
   );
-  const rawImages = await withSpan('image:getAllImages:rawQuery', () =>
-    cacheable<GetAllImagesRaw[]>(query, { ttl: cacheTime, tag: cacheTags })
-  );
+  let rawImages: GetAllImagesRaw[];
+  try {
+    rawImages = await withSpan('image:getAllImages:rawQuery', () =>
+      cacheable<GetAllImagesRaw[]>(query, { ttl: cacheTime, tag: cacheTags })
+    );
+  } catch (e) {
+    const code = (e as { code?: string })?.code;
+    if (code === '57014') {
+      // Query exceeded IMAGE_FEED_STATEMENT_TIMEOUT_MS on the replica.
+      // Return an empty page instead of surfacing a 500 — the feed is best-effort
+      // and the UI handles `items: []` gracefully. Log to axiom so we can track
+      // frequency and identify pathological filter combinations.
+      logToAxiom({
+        name: 'getInfiniteImages:statement_timeout',
+        type: 'warning',
+        message: `image feed query exceeded ${IMAGE_FEED_STATEMENT_TIMEOUT_MS}ms ceiling`,
+        details: {
+          timeoutMs: IMAGE_FEED_STATEMENT_TIMEOUT_MS,
+          dbTarget,
+          userId,
+          limit,
+          cursor: cursor ? String(cursor) : undefined,
+          sort,
+          period,
+          modelId,
+          modelVersionId,
+          collectionId,
+          postId,
+          username,
+          tagCount: tags?.length,
+          baseModelCount: baseModels?.length,
+        },
+      }).catch(() => undefined);
+      return { items: [], nextCursor: undefined };
+    }
+    throw e;
+  }
   // const rawImages = await dbRead.$queryRaw<GetAllImagesRaw[]>(query);
 
   const imageIds = rawImages.map((i) => i.id);


### PR DESCRIPTION
## Context

Durable fix for the api-primary restart-wave incident on civitai-dp-prod (2026-05-21 → 2026-05-24, ~25 spike-windows/day, `reason=Error exit=137` from kubelet SIGKILL on `/api/health` failures, not OOMKilled).

The replica raw query in `getAllImages` (image.service.ts → "getInfiniteImagesRaw" colloquially) has **mean 4.2s / max 115.8s** on the CNPG nvme0 read replica — **168 of 169** replica `statement_timeout` cancellations over the incident window are attributable to this single query. The `civitai` postgres role has `statement_timeout=0`, which overrides the cluster's 300s ceiling. A single slow run can monopolize the replica's `max_parallel_workers=32` budget for 5-9 minutes, back up `pgbouncer-pooler-nvme0-ro`, drive HAProxy `tcp-check connect` latency above 1s, and trip `/api/health` failures → liveness SIGKILL → 60-90s 502/504 storm during respawn.

This PR is the **durable per-call fix**. The symptom mitigation (raising HAProxy probe tolerance via `HEALTHCHECK_TIMEOUT` 1500ms → 5000ms) already shipped on the infra side in `datapacket-talos` commit `1e0984220`. Together they stop the cascade and give us headroom for future regressions.

## What this does

- Adds a new `queryWithTimeout(pool, timeoutMs, sql, params?)` helper in `src/server/db/db-helpers.ts` that wraps an arbitrary pg Pool query in:
  ```sql
  BEGIN READ ONLY;
  SET LOCAL statement_timeout = <ms>;
  <user query>;
  COMMIT;
  ```
  `SET LOCAL` scopes the timeout to the transaction, which is the only safe option under PgBouncer transaction pooling. Accepts either `Prisma.Sql` (matches the codebase's raw-query convention) or `(text, params)`.

- Wires it into `getAllImages` (image.service.ts) with a 20s ceiling (`IMAGE_FEED_STATEMENT_TIMEOUT_MS`). 20s is comfortably above p99 for healthy runs and well below the 30s Traefik upstream timeout where actual user impact starts.

- On pg error code `57014` (query_canceled), returns `{ items: [], nextCursor: undefined }` — the UI handles empty pages gracefully, so the user sees an empty feed (not a 500). Emits a structured `getInfiniteImages:statement_timeout` Axiom log with the inputs (filters, sort, cursor, dbTarget, etc.) so the team can monitor frequency and identify pathological filter combinations.

## What this does NOT do

- Does **not** change role-level `statement_timeout`. The per-call approach was deliberately chosen to scope the timeout to this one query — `ALTER ROLE civitai SET statement_timeout = '20s'` would have affected every read query (and even writes) on the role, which is a much bigger blast radius.
- Does **not** introduce a generic "wrap every read in a timeout" abstraction. The helper exists for callers that opt in; this PR opts in exactly one callsite.
- Does **not** make the timeout env-tunable. Hardcoded constant for now — env-configurability can come later if 20s turns out to be wrong.

## Verification path

The companion observability PR #2321 (already in flight) adds `civitai_app_healthcheck_duration_seconds` and `civitai_app_healthcheck_attempts_total{name, result}`. With both PRs deployed:

- **Pre-fix baseline (already captured):** 8-10 HAProxy `backend_connect_time_average` > 1s peaks/day; recurring 30-50min restart cadence on api-primary.
- **Post-fix expectation:** restart waves stop; `getInfiniteImages:statement_timeout` Axiom log appears at low single-digit frequency/hour as a tail-load shedding signal; HAProxy connect-time peaks fall back to pre-2026-05-21 baseline (1/day).

If the timeout fires too often (e.g. > 1% of feed requests), that signals either a regressed query plan on the replica or the 20s ceiling needs to be raised — both visible via the new Axiom event.

## Files changed

- `src/server/db/db-helpers.ts` — `+43 lines` — new `queryWithTimeout` helper.
- `src/server/services/image.service.ts` — `+53 / -5` — constant, callsite swap, try/catch with axiom log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)