### PR TITLE
fix(new-order): coerce getHistory cursor to Date to prevent SQL injection

### DIFF
--- a/src/server/schema/games/new-order.schema.ts
+++ b/src/server/schema/games/new-order.schema.ts
@@ -1,4 +1,3 @@
-import dayjs from '~/shared/utils/dayjs';
 import * as z from 'zod';
 import { newOrderConfig } from '~/server/common/constants';
 import { NewOrderDamnedReason, NewOrderImageRatingStatus, NsfwLevel } from '~/server/common/enums';
@@ -68,16 +67,14 @@ const transformStatus = {
 
 export type GetHistoryInput = z.input<typeof getHistorySchema>;
 export type GetHistorySchema = z.infer<typeof getHistorySchema>;
+// Cursor is interpolated into a ClickHouse query downstream — must coerce to a
+// real Date so a crafted string cannot inject SQL. Previously any authed user
+// could read all KoNo players' rating history by sending a cursor like
+// `' OR 1=1 --` which would round-trip through `.union([..., z.string(), ...])`
+// untouched and land inside the `createdAt < '${cursor}'` template.
 export const getHistorySchema = z.object({
   limit: z.number().optional().default(DEFAULT_PAGE_SIZE),
-  cursor: z
-    .union([z.bigint(), z.number(), z.string(), z.date()])
-    .transform((val) =>
-      typeof val === 'string' && dayjs(val, 'YYYY-MM-DDTHH:mm:ss.SSS[Z]', true).isValid()
-        ? new Date(val)
-        : val
-    )
-    .optional(),
+  cursor: z.coerce.date().optional(),
   status: z
     .enum(NewOrderImageRatingStatus)
     .transform((val) => {

--- a/src/server/services/games/new-order.service.ts
+++ b/src/server/services/games/new-order.service.ts
@@ -1806,8 +1806,8 @@ export async function getPlayerHistory({
     `userId = ${playerId}`,
     `createdAt >= parseDateTimeBestEffort('${player.startAt.toISOString()}')`,
   ];
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-  if (cursor) AND.push(`createdAt < '${cursor}'`);
+  // cursor is now guaranteed to be a Date (schema coerces); safe to ISO-format.
+  if (cursor) AND.push(`createdAt < '${cursor.toISOString()}'`);
 
   const HAVING = [];
   if (status?.length) HAVING.push(`status IN ('${status.join("','")}')`);


### PR DESCRIPTION
## Summary

`getHistorySchema.cursor` previously accepted `z.string()` via a union and only transformed strings that matched a strict dayjs format — any other string fell through unchanged and landed inside the ClickHouse `createdAt < '${cursor}'` template. Any authenticated user could read all Knights of New Order players' rating history by sending a cursor like `' OR 1=1 --`.

This change:
- Switches the cursor schema to `z.coerce.date()` so the value is always a `Date` by the time it reaches the service.
- Updates the service-side interpolation to call `.toISOString()` explicitly (and drops the `@typescript-eslint/restrict-template-expressions` disable that was hiding the issue).
- Removes the now-unused `dayjs` import from the schema file.

Extracted from the abandoned #2295. Should be merged independently of the auto-smite work in #2325 so it can be reviewed on its own and backported cleanly if needed.

## Test plan

- [ ] `pnpm typecheck` clean (no `restrict-template-expressions` regression)
- [ ] tRPC `newOrder.getHistory` with a valid ISO cursor still paginates as before
- [ ] tRPC `newOrder.getHistory` with a non-date cursor (e.g. `' OR 1=1 --`) returns a 400 from zod instead of leaking other users' rows
- [ ] tRPC `newOrder.getHistory` with no cursor still returns the first page

🤖 Generated with [Claude Code](https://claude.com/claude-code)