### PR TITLE
feat(telemetry): instrument generation funnel — Model_Create_Click, Image_Remix_Click, Generator_Submit

### DIFF
--- a/src/components/AppLayout/AppHeader/CreateMenu.tsx
+++ b/src/components/AppLayout/AppHeader/CreateMenu.tsx
@@ -13,6 +13,8 @@ import { useIsMobile } from '~/hooks/useIsMobile';
 import { imageGenerationDrawerZIndex } from '~/shared/constants/app-layout.constants';
 import { Currency } from '~/shared/utils/prisma/enums';
 import { useGenerationPanelStore } from '~/store/generation-panel.store';
+import { generationGraphPanel } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 
 const CreateMenuButtons = forwardRef<
   HTMLDivElement,
@@ -23,8 +25,29 @@ const CreateMenuButtons = forwardRef<
     onClick?: MouseEventHandler;
   }
 >(({ disabled, onMouseEnter, onMouseLeave, onClick }, ref) => {
+  const { trackAction } = useTrackEvent();
   const handleClick = () => {
-    useGenerationPanelStore.setState((state) => ({ opened: !state.opened }));
+    const wasOpen = useGenerationPanelStore.getState().opened;
+
+    if (!wasOpen) {
+      // Funnel telemetry — navbar Create click is a top-of-funnel entry-point.
+      // Route through generationGraphPanel.open() (no-input branch) so
+      // lastEntryAction is reset to 'direct' on a pivot from a stale remix/
+      // create state. Without this, every navbar click reuses the prior
+      // entry-action and attributes the next submit to the wrong source.
+      generationGraphPanel.open();
+      trackAction({
+        type: 'Model_Create_Click',
+        details: { source: 'create:navbar' },
+      }).catch(() => undefined);
+    } else {
+      // Closing the panel — preserve historical toggle behaviour. We only
+      // emit Model_Create_Click on open transitions to avoid double-counting.
+      // Route through generationGraphPanel.close() (not raw setState) so
+      // the lastEntryAction reset is explicit and symmetric with the open
+      // path — keeps all entry-action lifecycle in one code path.
+      generationGraphPanel.close();
+    }
   };
 
   return (

--- a/src/components/Cards/ToolCard.tsx
+++ b/src/components/Cards/ToolCard.tsx
@@ -4,12 +4,14 @@ import Link from 'next/link';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { EdgeMedia2 } from '~/components/EdgeMedia/EdgeMedia';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { generationGraphPanel } from '~/store/generation-graph.store';
 import type { ToolGetAllModel } from '~/types/router';
 import { slugit } from '~/utils/string-helpers';
 
 export function ToolCard({ data }: Props) {
   const sluggifiedName = slugit(data.name);
+  const { trackAction } = useTrackEvent();
 
   return (
     <Link
@@ -73,10 +75,18 @@ export function ToolCard({ data }: Props) {
           )}
           {data.alias && (
             <Button
-              data-activity="generate:tool"
+              data-activity="create:tool-card"
               onClick={(e: React.MouseEvent) => {
                 e.preventDefault();
                 e.stopPropagation();
+                // Top-of-funnel telemetry. ToolCard is rendered on the /tools
+                // index — clicking Generate opens the panel with no input
+                // (tool alias is resolved later). Same Create semantics as
+                // ToolBanner; distinguished by source tag for surface volume.
+                trackAction({
+                  type: 'Model_Create_Click',
+                  details: { source: 'create:tool-card' },
+                }).catch(() => undefined);
                 generationGraphPanel.open();
               }}
               fullWidth

--- a/src/components/Cards/components/RemixButton.tsx
+++ b/src/components/Cards/components/RemixButton.tsx
@@ -3,23 +3,75 @@ import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { GetGenerationDataInput } from '~/server/schema/generation.schema';
 import { generationGraphPanel } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 
 export function RemixButton({
   canGenerate,
   ...props
 }: GetGenerationDataInput & { canGenerate: boolean }) {
   const features = useFeatureFlags();
+  const { trackAction } = useTrackEvent();
   if (!features.imageGeneration || !canGenerate) return null;
+
+  const isRemix =
+    props.type === 'image' || props.type === 'video' || props.type === 'audio';
+
+  const handleClick = () => {
+    // Top-of-funnel telemetry. The component is named RemixButton but is
+    // overloaded — ImageCard uses it as a remix entry-point (image/video/audio
+    // source) while ModelCard uses it as a create entry-point (modelVersion).
+    // Discriminate on the input type so the funnel can split them.
+    //
+    // Note: `props.id` is typed `unknown` here because `GetGenerationDataInput`
+    // is the z.input<> of a `z.coerce.number()` schema — it accepts any
+    // coercible value. By the time this component renders the parent has
+    // already passed a number; `Number(...)` is a safe normalize. We narrow
+    // first with isFinite to avoid logging NaN if a caller ever passes junk.
+    if (isRemix && 'id' in props) {
+      const imageId = Number(props.id);
+      if (Number.isFinite(imageId)) {
+        trackAction({
+          type: 'Image_Remix_Click',
+          details: {
+            imageId,
+            imageType: props.type,
+            // RemixButton is rendered by Cards/ImageCard.tsx — HomeBlocks,
+            // Profile sections, ImageRemixOf details. `remix:image-card` is
+            // already used by Image/Infinite/ImagesCard.tsx, so we use a
+            // distinguishing tag here.
+            source: 'remix:image-card-home',
+          },
+        }).catch(() => undefined);
+      }
+    } else if (props.type === 'modelVersion') {
+      const modelVersionId = Number(props.id);
+      if (Number.isFinite(modelVersionId)) {
+        // Note: modelId is intentionally omitted — the ModelCard caller
+        // doesn't have ModelVersion.modelId in scope here. Dashboard queries
+        // wanting parent-model rollups should JOIN through ModelVersion.
+        // Documented in the Model_Create_Click schema doc-block as
+        // 'create:model-card emits without modelId'.
+        trackAction({
+          type: 'Model_Create_Click',
+          details: {
+            modelVersionId,
+            source: 'create:model-card',
+          },
+        }).catch(() => undefined);
+      }
+    }
+
+    generationGraphPanel.open(props);
+  };
+
   return (
     <HoverActionButton
-      label="Create"
+      label={isRemix ? 'Remix' : 'Create'}
       size={30}
       color="white"
       variant="filled"
-      data-activity="create:model-card"
-      onClick={() => {
-        generationGraphPanel.open(props);
-      }}
+      data-activity={isRemix ? 'remix:image-card-home' : 'create:model-card'}
+      onClick={handleClick}
     >
       <IconBrush stroke={2.5} size={16} />
     </HoverActionButton>

--- a/src/components/Generation/Form/GenForm.tsx
+++ b/src/components/Generation/Form/GenForm.tsx
@@ -1,14 +1,41 @@
-import type { FieldValues, UseFormReturn } from 'react-hook-form';
+import type { FieldValues } from 'react-hook-form';
 import { useGenerationContextStore } from '~/components/ImageGeneration/GenerationProvider';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import type { FormProps } from '~/libs/form';
 import { Form } from '~/libs/form';
+import { useGenerationGraphStore } from '~/store/generation-graph.store';
 import { showWarningNotification } from '~/utils/notifications';
+
+type GenFormProps<TInput extends FieldValues, TOutput extends FieldValues> = FormProps<
+  TInput,
+  TOutput
+> & {
+  /**
+   * Opt in to the rate-limited Generator_Submit telemetry emit. Default false.
+   *
+   * GenForm wraps two distinct call-site shapes:
+   *   1. GenerationForm2 (legacy) + VideoGenerationForm — full funnel
+   *      participants with success / validation-fail emits in their own
+   *      handleSubmit / handleSubmitError. They MUST opt in (track) so the
+   *      rate-limited stage is symmetric with the rest of their funnel.
+   *   2. Orchestrator modals (UpscaleImage, UpscaleVideo, BackgroundRemoval,
+   *      VideoInterpolation) — these have NO Generator_Submit instrumentation
+   *      of their own. Emitting only the rate-limited branch from here would
+   *      produce asymmetric data (only-blocked clicks visible, success +
+   *      validation-fail invisible) AND leak whatever lastEntryAction was
+   *      sitting on the panel store onto an upscale click. They stay opted
+   *      out until a follow-up PR instruments the orchestrator funnel as a
+   *      whole.
+   */
+  track?: boolean;
+};
 
 export function GenForm<
   TInput extends FieldValues = FieldValues,
   TOutput extends FieldValues = FieldValues
->({ children, onSubmit, ...props }: FormProps<TInput, TOutput>) {
+>({ children, onSubmit, track = false, ...props }: GenFormProps<TInput, TOutput>) {
   const generationContextStore = useGenerationContextStore();
+  const { trackAction } = useTrackEvent();
 
   return (
     <Form
@@ -16,6 +43,38 @@ export function GenForm<
       onSubmit={(payload) => {
         const snapshot = generationContextStore.getState();
         if (!snapshot.canGenerate) {
+          // Generation funnel telemetry — rate-limited branch. The outer
+          // handleSubmit in the form component never runs when canGenerate
+          // is false (we short-circuit below), so emit Generator_Submit
+          // here so the data team still sees these capacity-bounded clicks
+          // as a distinct funnel stage. fromAction comes from the panel
+          // store, same source as the happy-path event.
+          //
+          // formVersion is intentionally omitted: GenForm wraps both
+          // GenerationForm2 (legacy) and VideoGenerationForm (video) — no
+          // way to discriminate from this layer without a prop drill. The
+          // `isRateLimited: true` flag is the discriminator; the data team
+          // can filter on it directly.
+          //
+          // Gated on `track` so the orchestrator-modal call sites (which
+          // have no other funnel instrumentation) don't emit asymmetric
+          // rate-limited-only events. See GenFormProps.track docs above.
+          if (track) {
+            try {
+              const fromAction = useGenerationGraphStore.getState().lastEntryAction;
+              trackAction({
+                type: 'Generator_Submit',
+                details: {
+                  fromAction,
+                  isValid: false,
+                  isRateLimited: true,
+                },
+              }).catch(() => undefined);
+            } catch {
+              // Telemetry must never block UI.
+            }
+          }
+
           showWarningNotification({
             message:
               snapshot.requestsRemaining === 0

--- a/src/components/Generation/Video/VideoGenerationForm.tsx
+++ b/src/components/Generation/Video/VideoGenerationForm.tsx
@@ -32,6 +32,7 @@ import { LightricksFormInput } from '~/components/Generation/Video/LightricksFor
 import { Ltx2FormInput } from '~/components/Generation/Video/Ltx2FormInput';
 import { Veo3FormInput } from '~/components/Generation/Video/Veo3FormInput';
 import { generationGraphStore, useGenerationGraphStore } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { isNewFormOnly } from '~/shared/data-graph/generation/config/workflows';
 import { ecosystemByKey } from '~/shared/constants/basemodel.constants';
 import { WORKFLOW_TAGS, VID_QUANTITY_BY_TIER } from '~/shared/constants/generation.constants';
@@ -85,6 +86,7 @@ function buildGraphContext(status: {
 export function VideoGenerationForm({ engine }: { engine: OrchestratorEngine2 }) {
   const getState = useVideoGenerationStore((state) => state.getState);
   const storeData = useGenerationGraphStore((state) => state.data);
+  const { trackAction } = useTrackEvent();
 
   const config = useMemo(() => videoGenerationConfig2[engine], [engine]);
   const status = useGenerationStatus();
@@ -134,6 +136,39 @@ export function VideoGenerationForm({ engine }: { engine: OrchestratorEngine2 })
     if (isLoading || isLoadingDebounced) return;
     setError(undefined);
     const { cost = 0 } = getState();
+
+    // Generation funnel telemetry — clicked Generate (video form). We fire
+    // once after the inner graph.validate() resolves so isValid reflects
+    // the actual outcome (the outer RHF onSubmit already passed at this
+    // point). `formVersion: 'video'` discriminates from image legacy/new.
+    //
+    // `trackValid` guards the catch-block emit so a synchronous throw AFTER
+    // a success-emit (e.g. a downstream `mapDataToGraphInput` mutation or
+    // `mutate()` rejection) can't double-fire as a failure. We flip the
+    // flag immediately after each emit site so the guard is meaningful.
+    let trackValid = true;
+    const emitSubmit = (isValid: boolean, modelVersionId?: number) => {
+      try {
+        const fromAction = useGenerationGraphStore.getState().lastEntryAction;
+        trackAction({
+          type: 'Generator_Submit',
+          details: {
+            // modelVersionId: callers pass `model.id` from the graph snapshot
+            // (see `model = splitResourcesByType(...).model` below). The
+            // snapshot's `model` IS the Checkpoint resource node; .id on a
+            // resource node = ModelVersion.id, not the parent Model.id.
+            modelVersionId,
+            fromAction,
+            formVersion: 'video',
+            isValid,
+          },
+        }).catch(() => undefined);
+      } catch {
+        // Telemetry must never block a submission.
+      }
+      trackValid = false;
+    };
+
     try {
       const validated = config.validate(data);
       setIsLoadingDebounced(true);
@@ -168,10 +203,12 @@ export function VideoGenerationForm({ engine }: { engine: OrchestratorEngine2 })
         console.error('Graph validation failed:', result.errors);
         setError('Validation failed. Please check your inputs.');
         setIsLoadingDebounced(false);
+        emitSubmit(false, model?.id);
         return;
       }
 
       const graphData = result.data;
+      emitSubmit(true, model?.id);
 
       const { buzzType } = generationFormStore.getState();
       conditionalPerformTransaction(cost, () => {
@@ -182,11 +219,36 @@ export function VideoGenerationForm({ engine }: { engine: OrchestratorEngine2 })
         });
       });
     } catch (e: any) {
+      // config.validate() threw — count as a failed submit attempt unless
+      // we already emitted a success/failure for this submit cycle.
+      if (trackValid) emitSubmit(false);
       console.error(e);
     }
     setTimeout(() => {
       setIsLoadingDebounced(false);
     }, 1000);
+  }
+
+  // Generation funnel telemetry — RHF validation-fail branch. Mirrors the
+  // legacy form's handleSubmitError so video-form attempts that fail at the
+  // react-hook-form level (zod resolver, required fields) are still counted.
+  // The inner config.validate() + graph.validate() failures are already
+  // captured from handleSubmit's emitSubmit; this fires for failures that
+  // happen BEFORE handleSubmit runs.
+  function handleSubmitError() {
+    try {
+      const fromAction = useGenerationGraphStore.getState().lastEntryAction;
+      trackAction({
+        type: 'Generator_Submit',
+        details: {
+          fromAction,
+          formVersion: 'video',
+          isValid: false,
+        },
+      }).catch(() => undefined);
+    } catch {
+      // Telemetry must never block UI.
+    }
   }
 
   useEffect(() => {
@@ -238,6 +300,8 @@ export function VideoGenerationForm({ engine }: { engine: OrchestratorEngine2 })
       <GenForm
         form={form}
         onSubmit={handleSubmit}
+        onError={handleSubmitError}
+        track
         className="relative flex h-full flex-1 flex-col justify-between gap-2"
       >
         <div className="flex flex-col gap-3 px-2">

--- a/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
@@ -41,6 +41,7 @@ import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { ImagesAsPostModel } from '~/server/controllers/image.controller';
 import { generationGraphPanel } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { isDefined } from '~/utils/type-guards';
 import { SimpleImageCarousel } from '~/components/SimpleImageCarousel/SimpleImageCarousel';
 import classes from './ImagesAsPostsCard.module.css';
@@ -250,6 +251,7 @@ function ImagesAsPostsCardHeader({
 
 function ImagesAsPostsCardContent({ data }: { data: ImagesAsPostModel }) {
   const features = useFeatureFlags();
+  const { trackAction } = useTrackEvent();
   const postId = data.postId ?? undefined;
   const image = data.images[0];
   // Not wrapping in useCallback: the returned inner closure captures
@@ -258,6 +260,14 @@ function ImagesAsPostsCardContent({ data }: { data: ImagesAsPostModel }) {
   const handleRemixClick = (selectedImage: typeof image) => (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    trackAction({
+      type: 'Image_Remix_Click',
+      details: {
+        imageId: selectedImage.id,
+        imageType: selectedImage.type,
+        source: 'remix:model-gallery',
+      },
+    }).catch(() => undefined);
     generationGraphPanel.open({
       type: selectedImage.type,
       id: selectedImage.id,

--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -73,6 +73,7 @@ import { ReactionSettingsProvider } from '~/components/Reaction/ReactionSettings
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
 import { ShareButton } from '~/components/ShareButton/ShareButton';
 import { TrackView } from '~/components/TrackView/TrackView';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { VotableTags } from '~/components/VotableTags/VotableTags';
 import { useCarouselNavigation } from '~/hooks/useCarouselNavigation';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -114,6 +115,7 @@ const sharedIconProps: IconProps = {
 export function ImageDetail2() {
   const theme = useMantineTheme();
   const currentUser = useCurrentUser();
+  const { trackAction } = useTrackEvent();
   const {
     images,
     active,
@@ -185,7 +187,17 @@ export function ImageDetail2() {
         <Button
           {...sharedButtonProps}
           color="blue"
-          onClick={() => generationGraphPanel.open({ type: image.type, id: image.id })}
+          onClick={() => {
+            trackAction({
+              type: 'Image_Remix_Click',
+              details: {
+                imageId: image.id,
+                imageType: image.type,
+                source: 'remix:image',
+              },
+            }).catch(() => undefined);
+            generationGraphPanel.open({ type: image.type, id: image.id });
+          }}
           data-activity="remix:image"
         >
           <Group gap={4} wrap="nowrap">

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -29,6 +29,7 @@ import { useImageStore } from '~/store/image.store';
 import { useTourContext } from '~/components/Tours/ToursProvider';
 import { BlockedReason } from '~/server/common/enums';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import clsx from 'clsx';
 import classes from './ImagesCard.module.scss';
 
@@ -48,6 +49,7 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
   const features = useFeatureFlags();
   const { running, helpers } = useTourContext();
   const currentUser = useCurrentUser();
+  const { trackAction } = useTrackEvent();
 
   const image = useImageStore(data);
 
@@ -74,6 +76,20 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
       e.preventDefault();
       e.stopPropagation();
 
+      // Top-of-funnel telemetry — joined to orchestration.jobs.remixOfId
+      // downstream to compute remix-conversion. The source modelVersionId
+      // for the remix is resolved server-side by getGenerationData, so it's
+      // not available on the card; leave null and join via remixStore /
+      // orchestration.jobs at funnel-analysis time.
+      trackAction({
+        type: 'Image_Remix_Click',
+        details: {
+          imageId: image.id,
+          imageType: image.type,
+          source: 'remix:image-card',
+        },
+      }).catch(() => undefined);
+
       generationGraphPanel.open({
         type: image.type,
         id: image.id,
@@ -82,7 +98,7 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
       // Go to next step in tour when clicking
       if (running) helpers?.next();
     },
-    [image.type, image.id, running, helpers]
+    [image.type, image.id, running, helpers, trackAction]
   );
 
   const twCardStyle = useMemo(() => {

--- a/src/components/Image/Meta/ImageMetaPopoverLazy.tsx
+++ b/src/components/Image/Meta/ImageMetaPopoverLazy.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { ImageMeta } from '~/components/Image/DetailV2/ImageMeta';
 import { useMetadataCopy } from '~/hooks/useMetadataCopy';
 import { generationGraphPanel } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { trpc } from '~/utils/trpc';
 
 // export default function ImageMetaPopoverLazy({ imageId }: ImageMetaPopoverProps) {
@@ -43,6 +44,7 @@ export default function ImageMetaPopoverLazy({ imageId }: { imageId: number }) {
   const { data, isLoading } = trpc.image.getGenerationData.useQuery({ id: imageId });
   const { meta, canRemix, type = 'image' } = data ?? {};
   const { copy, copied } = useMetadataCopy(meta);
+  const { trackAction } = useTrackEvent();
 
   return (
     <Card withBorder className="flex w-96 max-w-full flex-col gap-3 rounded-xl">
@@ -82,7 +84,20 @@ export default function ImageMetaPopoverLazy({ imageId }: { imageId: number }) {
                 data-activity="remix:image-meta"
                 // @ts-ignore eslint-disable-next-line
                 onClick={() => {
-                  generationGraphPanel.open({ type, id: imageId ?? 0 });
+                  // Only act when we actually have an imageId — `imageId ?? 0`
+                  // would pollute the funnel with imageId=0 events AND fail
+                  // server-side at getGenerationData. Both calls share the
+                  // same guard so a falsy imageId is a complete no-op.
+                  if (!imageId) return;
+                  trackAction({
+                    type: 'Image_Remix_Click',
+                    details: {
+                      imageId,
+                      imageType: type,
+                      source: 'remix:image-meta',
+                    },
+                  }).catch(() => undefined);
+                  generationGraphPanel.open({ type, id: imageId });
                 }}
                 className="flex-1"
               >

--- a/src/components/ImageGeneration/GenerationForm/BaseModelSelect.tsx
+++ b/src/components/ImageGeneration/GenerationForm/BaseModelSelect.tsx
@@ -110,7 +110,15 @@ function BaseModelSelectModal({ type }: { type: MediaType }) {
 
   const handleSelect = (group: BaseModelGroup) => {
     const resource = generationConfig[group as GenerationConfigKey].checkpoint;
-    generationGraphPanel.open({ type: 'modelVersion', id: resource.id });
+    // Mid-session base-model swap — the user is already in the generator
+    // (the BaseModelSelect dialog only opens from inside the form). Pass
+    // `preserveEntryAction` so this in-panel re-entry doesn't overwrite the
+    // upstream attribution (e.g. a user who entered via Remix then changes
+    // base model should still submit with fromAction='remix', not 'create').
+    generationGraphPanel.open(
+      { type: 'modelVersion', id: resource.id },
+      { preserveEntryAction: true }
+    );
     dialog.onClose();
   };
 

--- a/src/components/ImageGeneration/GenerationForm/GenerationForm2.tsx
+++ b/src/components/ImageGeneration/GenerationForm/GenerationForm2.tsx
@@ -153,6 +153,7 @@ import { ModelType } from '~/shared/utils/prisma/enums';
 import { useGenerationGraphStore } from '~/store/generation-graph.store';
 import { useRemixStore } from '~/store/remix.store';
 import { useTipStore } from '~/store/tip.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import {
   mapDataToGraphInput,
   splitResourcesByType,
@@ -225,6 +226,7 @@ export function GenerationFormContent() {
   const { runTour, running, currentStep, helpers, setSteps, activeTour } = useTourContext();
   const loadingGeneratorData = useGenerationGraphStore((state) => state.loading);
   const remixOfId = useRemixStore((state) => state.data?.remixOfId);
+  const { trackAction } = useTrackEvent();
   const [loadingGenQueueRequests, hasGeneratedImages] = useGenerationContext((state) => [
     state.requestsLoading,
     state.hasGeneratedImages,
@@ -325,6 +327,37 @@ export function GenerationFormContent() {
       imageAnnotations,
       ...params
     } = data;
+
+    // Generation funnel telemetry — validation-pass branch. Fires before
+    // the buzz-transaction prompt so click-and-abandon (cancel at confirm
+    // dialog or insufficient-buzz fallout) is still captured. fromAction
+    // is taken from the panel store so the same submission can be joined
+    // back to the Model_Create_Click / Image_Remix_Click that opened the
+    // panel. `hasRemixOfId` reflects the actual remixOfId being sent on
+    // the request (passes the 0.75 similarity gate). `isValid=true` here;
+    // the validation-fail counterpart fires from handleSubmitError below.
+    try {
+      const fromAction = useGenerationGraphStore.getState().lastEntryAction;
+      const willSendRemixOfId = !!(remixSimilarity && remixSimilarity > 0.75 && remixOfId);
+      trackAction({
+        type: 'Generator_Submit',
+        details: {
+          // modelVersionId: form `model` IS the model-version resource, not the
+          // parent model id (resource nodes are versions; `.id` on a resource
+          // node = ModelVersion.id). The form field is named `model` for
+          // historical reasons; the schema field is named modelVersionId for
+          // accuracy. Don't be misled by the asymmetry.
+          modelVersionId: model?.id,
+          fromAction,
+          hasRemixOfId: willSendRemixOfId,
+          formVersion: 'legacy',
+          isValid: true,
+        },
+      }).catch(() => undefined);
+    } catch {
+      // Telemetry must never block a submission.
+    }
+
     let additionalResources = formResources ?? [];
     sanitizeParamsByWorkflowDefinition(params, workflowDefinition);
     const modelClone = clone(model);
@@ -435,6 +468,31 @@ export function GenerationFormContent() {
 
     if (filters.marker) {
       setFilters({ marker: undefined });
+    }
+  }
+
+  // Generation funnel telemetry — validation-fail branch. Fires when
+  // react-hook-form rejects a submit (required fields missing, prompt
+  // empty, etc.). Pairs with the `isValid: true` event in handleSubmit
+  // above so the data team has a complete attempt funnel and can spot
+  // UX traps where users click Generate but the form blocks them.
+  function handleSubmitError() {
+    try {
+      const fromAction = useGenerationGraphStore.getState().lastEntryAction;
+      const model = form.getValues('model') as { id?: number } | undefined;
+      trackAction({
+        type: 'Generator_Submit',
+        details: {
+          // modelVersionId: see same-named field in the success-path emit
+          // above — model.id IS the model-version id on the form snapshot.
+          modelVersionId: model?.id,
+          fromAction,
+          formVersion: 'legacy',
+          isValid: false,
+        },
+      }).catch(() => undefined);
+    } catch {
+      // Telemetry must never block UI.
     }
   }
 
@@ -566,6 +624,8 @@ export function GenerationFormContent() {
       <GenForm
         form={form}
         onSubmit={handleSubmit}
+        onError={handleSubmitError}
+        track
         className="relative flex flex-1 flex-col justify-between gap-2"
       >
         <Watch {...form} fields={['fluxMode', 'draft', 'workflow', 'sourceImage', 'images']}>

--- a/src/components/ImageMeta/ImageMeta.tsx
+++ b/src/components/ImageMeta/ImageMeta.tsx
@@ -22,6 +22,7 @@ import { isImageMetaOnSite } from '~/server/utils/image-onsite';
 import type { ImageGenerationProcess } from '~/shared/utils/prisma/enums';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import { generationGraphPanel } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { fromJson } from '~/utils/json-helpers';
 import { encodeMetadata } from '~/utils/metadata';
 import { titleCase } from '~/utils/string-helpers';
@@ -62,6 +63,7 @@ export function ImageMeta({
   hideSoftware,
 }: Props) {
   const flags = useFeatureFlags();
+  const { trackAction } = useTrackEvent();
 
   const metas = useMemo(() => {
     const long: MetaDisplay[] = [];
@@ -222,7 +224,23 @@ export function ImageMeta({
                 leftSection={<IconBrush size={16} />}
                 data-activity="remix:image-meta"
                 onClick={() => {
-                  generationGraphPanel.open({ type: 'image', id: imageId ?? 0 });
+                  // Only act when we actually have an imageId — `imageId ?? 0`
+                  // would pollute the funnel with imageId=0 events AND fail
+                  // server-side at getGenerationData. Track + open share the
+                  // same guard so a falsy imageId is a complete no-op for
+                  // the funnel; the `onCreateClick?.()` parent callback
+                  // still fires either way (preserves prior behavior).
+                  if (imageId) {
+                    trackAction({
+                      type: 'Image_Remix_Click',
+                      details: {
+                        imageId,
+                        imageType: 'image',
+                        source: 'remix:image-meta',
+                      },
+                    }).catch(() => undefined);
+                    generationGraphPanel.open({ type: 'image', id: imageId });
+                  }
                   onCreateClick?.();
                 }}
                 style={{ flex: 1 }}

--- a/src/components/Model/ModelCarousel/ModelCarousel.tsx
+++ b/src/components/Model/ModelCarousel/ModelCarousel.tsx
@@ -23,6 +23,7 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useTourContext } from '~/components/Tours/ToursProvider';
 import { ImageSort } from '~/server/common/enums';
 import { generationGraphPanel } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { BrowsingSettingsAddonsProvider } from '~/providers/BrowsingSettingsAddonsProvider';
 import { Embla } from '~/components/EmblaCarousel/EmblaCarousel';
 import { useContainerSmallerThan } from '~/components/ContainerProvider/useContainerSmallerThan';
@@ -53,6 +54,7 @@ export function ModelCarousel(props: Props) {
 function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10 }: Props) {
   const features = useFeatureFlags();
   const { running, helpers } = useTourContext();
+  const { trackAction } = useTrackEvent();
   const { images, flatData, isLoading } = useQueryImages({
     modelVersionId: modelVersionId,
     prioritizedUserIds: [modelUserId],
@@ -119,6 +121,16 @@ function ModelCarouselContent({ modelId, modelVersionId, modelUserId, limit = 10
                                 onClick={(e) => {
                                   e.preventDefault();
                                   e.stopPropagation();
+
+                                  trackAction({
+                                    type: 'Image_Remix_Click',
+                                    details: {
+                                      imageId: image.id,
+                                      imageType: image.type,
+                                      sourceModelVersionId: modelVersionId,
+                                      source: 'remix:model-carousel',
+                                    },
+                                  }).catch(() => undefined);
 
                                   generationGraphPanel.open({
                                     type: image.type,

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -492,6 +492,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
               {canGenerate && isOwnerOrMod && (
                 <GenerateButton
                   versionId={version.id}
+                  modelId={model.id}
                   wildcardSetId={version.wildcardSetId}
                   data-tour="model:create"
                   data-activity="create:model"
@@ -560,6 +561,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   {canGenerate ? (
                     <GenerateButton
                       versionId={version.id}
+                      modelId={model.id}
                       wildcardSetId={version.wildcardSetId}
                       data-tour="model:create"
                       data-activity="create:model"

--- a/src/components/Model/ModelVersions/ModelVersionEarlyAccessPurchase.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionEarlyAccessPurchase.tsx
@@ -137,6 +137,7 @@ export const ModelVersionEarlyAccessPurchase = ({
                   {resourceLabel}{' '}
                   <GenerateButton
                     versionId={modelVersionId}
+                    modelId={modelVersion?.model?.id}
                     data-activity="create:version-stat"
                     onClick={() => {
                       dialog.onClose();

--- a/src/components/Post/Detail/PostImages.tsx
+++ b/src/components/Post/Detail/PostImages.tsx
@@ -19,6 +19,7 @@ import type { VideoMetadata } from '~/server/schema/media.schema';
 import type { ImagesInfiniteModel } from '~/server/services/image.service';
 import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
 import { generationGraphPanel } from '~/store/generation-graph.store';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import type { PostContestCollectionItem } from '~/types/router';
 import classes from './PostImages.module.css';
 import clsx from 'clsx';
@@ -45,6 +46,7 @@ export function PostImages({
   const [showMore, setShowMore] = useState(false);
   const videoRef = useRef<EdgeVideoRef | null>(null);
   const features = useFeatureFlags();
+  const { trackAction } = useTrackEvent();
 
   if (isLoading)
     return (
@@ -113,10 +115,18 @@ export function PostImages({
                           size={30}
                           color="white"
                           variant="filled"
-                          data-activity="remix:image-card"
+                          data-activity="remix:post-image-card"
                           onClick={(e) => {
                             e.preventDefault();
                             e.stopPropagation();
+                            trackAction({
+                              type: 'Image_Remix_Click',
+                              details: {
+                                imageId: image.id,
+                                imageType: image.type,
+                                source: 'remix:post-image-card',
+                              },
+                            }).catch(() => undefined);
                             generationGraphPanel.open({
                               type: image.type,
                               id: image.id,

--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -53,6 +53,7 @@ const EpochRow = ({
   onPublishClick,
   loading,
   incomplete,
+  modelId,
   modelVersionId,
   canGenerate,
   isVideo,
@@ -65,6 +66,7 @@ const EpochRow = ({
   onPublishClick: (modelUrl: string) => void;
   loading?: boolean;
   incomplete?: boolean;
+  modelId: number;
   modelVersionId: number;
   canGenerate?: boolean;
   isVideo: boolean;
@@ -113,8 +115,10 @@ const EpochRow = ({
                 {/* TODO will this work? */}
                 <GenerateButton
                   versionId={modelVersionId}
+                  modelId={modelId}
                   disabled={!currentUser?.isMember && !currentUser?.isModerator}
                   epochNumber={epoch.epochNumber}
+                  data-activity="create:training-select"
                 />
               </SubscriptionRequiredBlock>
             )}
@@ -581,6 +585,7 @@ export default function TrainingSelectFile({
             onPublishClick={handleSubmit}
             loading={awaitInvalidate}
             incomplete={resultsLoading}
+            modelId={model.id}
             modelVersionId={modelVersion.id}
             canGenerate={features.privateModels && !!modelVersion.id && canGenerateWithEpochBool}
             isVideo={isVideo}
@@ -603,6 +608,7 @@ export default function TrainingSelectFile({
                   onPublishClick={handleSubmit}
                   loading={awaitInvalidate}
                   incomplete={resultsLoading}
+                  modelId={model.id}
                   modelVersionId={modelVersion.id}
                   canGenerate={
                     features.privateModels && !!modelVersion.id && canGenerateWithEpochBool

--- a/src/components/RunStrategy/GenerateButton.tsx
+++ b/src/components/RunStrategy/GenerateButton.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useGenerationPanelStore } from '~/store/generation-panel.store';
 import { generationGraphPanel } from '~/store/generation-graph.store';
 import { abbreviateNumber } from '~/utils/number-helpers';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 
 export function GenerateButton({
   iconOnly,
@@ -15,18 +16,47 @@ export function GenerateButton({
   onClick,
   epochNumber,
   versionId,
+  modelId,
   wildcardSetId,
   ...buttonProps
 }: Props) {
   const theme = useMantineTheme();
+  const { trackAction } = useTrackEvent();
 
   const opened = useGenerationPanelStore((state) => state.opened);
-  const onClickHandler = () => {
+  const onClickHandler = (e?: React.MouseEvent<HTMLElement>) => {
     if (generationPrice) {
       onPurchase?.();
       return;
     }
     if (mode === 'toggle' && opened) return generationGraphPanel.close();
+
+    // Top-of-funnel telemetry — fire-and-forget. Joined downstream to
+    // orchestration.jobs by userId + ts to compute view→click→submit→job
+    // conversion. `source` comes from data-activity on the rendered button
+    // (create:model | create:model-stat | create:model-card | ...) so
+    // entry-points can be split without an extra prop on every caller.
+    //
+    // Only treat this as an entry-point click when the button targets a
+    // specific resource. The same component is reused as the form-submit
+    // button inside the generator panel (no versionId/wildcardSetId/modelId);
+    // that submit fires Generator_Submit from the form handler instead, so
+    // we'd double-count if we tracked Model_Create_Click here too.
+    const isEntryPoint = versionId != null || wildcardSetId != null || modelId != null;
+    if (isEntryPoint) {
+      const dataActivityProp = (buttonProps as Record<string, unknown>)['data-activity'];
+      const source =
+        e?.currentTarget?.dataset?.activity ??
+        (typeof dataActivityProp === 'string' ? dataActivityProp : undefined);
+      trackAction({
+        type: 'Model_Create_Click',
+        details: {
+          modelId,
+          modelVersionId: versionId,
+          source,
+        },
+      }).catch(() => undefined);
+    }
 
     // Wildcards-type versions: short-circuit straight to the snippets node
     // — no `getGenerationData` round-trip required, since a wildcard set
@@ -123,6 +153,12 @@ type Props = Omit<ButtonProps, 'onClick' | 'children'> & {
   onClick?: () => void;
   epochNumber?: number;
   versionId?: number;
+  /**
+   * Parent model id, when known by the caller. Used for funnel telemetry
+   * (Model_Create_Click event) so we can attribute clicks back to the
+   * model entry-point even when only versionId is on the button.
+   */
+  modelId?: number;
   /**
    * When set, the button opens the panel directly with this wildcard set
    * id loaded into the snippets node. Takes precedence over `versionId`.

--- a/src/components/Tool/ToolBanner.tsx
+++ b/src/components/Tool/ToolBanner.tsx
@@ -6,6 +6,7 @@ import { useImageFilters } from '~/components/Image/image.utils';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { useQueryTools } from '~/components/Tool/tools.utils';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 import type { FilterKeys } from '~/providers/FiltersProvider';
 import { generationGraphPanel } from '~/store/generation-graph.store';
 import { slugit } from '~/utils/string-helpers';
@@ -26,6 +27,7 @@ export function ToolBanner({
   });
   const selected = tools?.find((x) => x.id === selectedId || slugit(x.name) === slug);
   const theme = useMantineTheme();
+  const { trackAction } = useTrackEvent();
 
   if (!tools || !selected) return null;
 
@@ -78,8 +80,18 @@ export function ToolBanner({
                     color="blue"
                     radius="xl"
                     rightSection={<IconBrush size={18} />}
-                    data-activity="generate:tool"
+                    data-activity="create:tool-banner"
                     onClick={() => {
+                      // Top-of-funnel telemetry. The Tool banner's Generate
+                      // button opens the panel with no input — semantically
+                      // a Create entry-point (the tool's alias gets resolved
+                      // into a prompt later). We don't have a modelVersionId
+                      // here (tools are a separate abstraction); the source
+                      // tag is what the dashboard joins on.
+                      trackAction({
+                        type: 'Model_Create_Click',
+                        details: { source: 'create:tool-banner' },
+                      }).catch(() => undefined);
                       generationGraphPanel.open();
                     }}
                   >

--- a/src/components/TrackView/track.utils.ts
+++ b/src/components/TrackView/track.utils.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { trpc } from '~/utils/trpc';
 import type {
   TrackActionInput,
@@ -10,17 +11,27 @@ export const useTrackEvent = () => {
   const { mutateAsync: trackAction } = trpc.track.addAction.useMutation();
   const { mutateAsync: trackSearch } = trpc.track.trackSearch.useMutation();
 
-  const handleTrackShare = (data: TrackShareInput) => {
-    return trackShare(data);
-  };
+  // React Query keeps `mutateAsync` identity stable across renders via
+  // internal refs, so these `useCallback` wrappers actually stabilize the
+  // returned handle for consumers. Downstream `useCallback` hooks that
+  // include `trackAction` in their deps (e.g. ImagesCard.handleRemixClick)
+  // won't re-invalidate every render. (Verify by checking React Query's
+  // mutation source if the assumption changes — useMutation returns
+  // mutateAsync bound to a ref, not a fresh closure per render.)
+  const handleTrackShare = useCallback(
+    (data: TrackShareInput) => trackShare(data),
+    [trackShare]
+  );
 
-  const handleTrackAction = (data: TrackActionInput) => {
-    return trackAction(data);
-  };
+  const handleTrackAction = useCallback(
+    (data: TrackActionInput) => trackAction(data),
+    [trackAction]
+  );
 
-  const handleTrackSearch = (data: TrackSearchInput) => {
-    return trackSearch(data);
-  };
+  const handleTrackSearch = useCallback(
+    (data: TrackSearchInput) => trackSearch(data),
+    [trackSearch]
+  );
 
   return {
     trackShare: handleTrackShare,

--- a/src/components/generation_v2/FormFooter.tsx
+++ b/src/components/generation_v2/FormFooter.tsx
@@ -54,7 +54,9 @@ import type { GenerationGraphTypes } from '~/shared/data-graph/generation';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { buzzSpendTypes } from '~/shared/constants/buzz.constants';
 import { Currency } from '~/shared/utils/prisma/enums';
+import { useGenerationContextStore } from '~/components/ImageGeneration/GenerationProvider';
 import { useGenerationFormStore } from '~/store/generation-form.store';
+import { showWarningNotification } from '~/utils/notifications';
 import { useTipStore } from '~/store/tip.store';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { numberWithCommas } from '~/utils/number-helpers';
@@ -90,8 +92,13 @@ import { useRemixOfId } from './hooks/useRemixOfId';
 import { remixStore } from '~/store/remix.store';
 import { useMetadataExtractionStore } from '~/store/metadata-extraction.store';
 import { useGeneratedItemWorkflows } from './hooks/useGeneratedItemWorkflows';
-import { generationGraphStore, REMIX_WORKFLOW_OVERRIDES } from '~/store/generation-graph.store';
+import {
+  generationGraphStore,
+  REMIX_WORKFLOW_OVERRIDES,
+  useGenerationGraphStore,
+} from '~/store/generation-graph.store';
 import { clearStorageForOutput } from './GenerationFormProvider';
+import { useTrackEvent } from '~/components/TrackView/track.utils';
 
 // =============================================================================
 // Helper Functions
@@ -797,6 +804,8 @@ export function FormFooter({ onSubmitSuccess }: { onSubmitSuccess?: () => void }
   const { resources: resourceData } = useResourceDataContext();
   const invalidateWhatIf = useInvalidateWhatIf();
   const membershipUpsell = useMembershipUpsell();
+  const { trackAction } = useTrackEvent();
+  const generationContextStore = useGenerationContextStore();
 
   // Get validation state from whatIf context
   const { canEstimateCost, validationErrors } = useWhatIfContext();
@@ -849,11 +858,104 @@ export function FormFooter({ onSubmitSuccess }: { onSubmitSuccess?: () => void }
   const clearWarning = () => setPromptWarning(null);
 
   const handleSubmit = async () => {
+    // Generation funnel telemetry — ordering matches legacy GenForm semantics.
+    //
+    // Legacy: RHF's `onError` fires BEFORE GenForm's `canGenerate` short-
+    // circuit, so a rate-limited+invalid submit collapses to isValid:false
+    // (never reaches the rate-limited branch). If v2 checked canGenerate
+    // first, the same case would collapse to isRateLimited:true — making
+    // `isRateLimited:true AND formVersion='new'` a strict superset of
+    // legacy. Run graph.validate() FIRST so the two paths agree on which
+    // signal wins in the overlap case.
+    //
+    // The v2 form's SubmitButton wires `onClick` directly (not through
+    // GenForm), so the GenForm canGenerate short-circuit never runs here —
+    // we mirror it inline below after validation passes.
+    //
+    // Exactly ONE Generator_Submit event is emitted per click:
+    //   - validation fails           → emit { isValid: false } and return
+    //   - validation passes + rate-limited → emit { isValid: true, isRateLimited: true } and return
+    //   - validation passes + not rate-limited → emit { isValid: true } and proceed
     const result = graph.validate();
+    const fromAction = useGenerationGraphStore.getState().lastEntryAction;
 
+    // Validation-fail branch. Pairs with the `isValid:true` emit below so the
+    // data team has a complete attempt funnel. We deliberately do NOT also
+    // check canGenerate here — matching legacy collapse where the validation
+    // failure is the only signal emitted.
     if (!result.success) {
+      try {
+        const submitSnapshot = graph.getSnapshot() as ResourceSnapshot;
+        trackAction({
+          type: 'Generator_Submit',
+          details: {
+            // modelVersionId: snapshot.model is the Checkpoint resource node;
+            // .id on a resource node IS ModelVersion.id, not the parent
+            // Model.id. The graph snapshot field is named `model` for
+            // historical reasons.
+            modelVersionId: submitSnapshot.model?.id,
+            fromAction,
+            hasRemixOfId: !!remixOfId,
+            formVersion: 'new',
+            isValid: false,
+          },
+        }).catch(() => undefined);
+      } catch {
+        // Telemetry must never block a submission.
+      }
       console.log('Validation failed:', result.errors);
       return;
+    }
+
+    // Rate-limited branch. Only reached when validation already passed
+    // (legacy parity: RHF rejects before GenForm checks canGenerate, so
+    // invalid+rate-limited collapses to isValid:false for both paths).
+    // Emits isValid:true + isRateLimited:true because the submit would
+    // have been valid; only the concurrent-request cap stopped it.
+    // `formVersion: 'new'` keeps this discriminable from the legacy /
+    // video rate-limit emits (which still emit isValid:false — they
+    // pre-date this ordering pass).
+    const contextSnapshot = generationContextStore.getState();
+    if (!contextSnapshot.canGenerate) {
+      try {
+        trackAction({
+          type: 'Generator_Submit',
+          details: {
+            fromAction,
+            formVersion: 'new',
+            isValid: true,
+            isRateLimited: true,
+          },
+        }).catch(() => undefined);
+      } catch {
+        // Telemetry must never block UI.
+      }
+      showWarningNotification({
+        message:
+          contextSnapshot.requestsRemaining === 0
+            ? `You are already generating at your limit: ${contextSnapshot.queued.length}`
+            : 'Request queued. Your generation request will begin shortly.',
+      });
+      return;
+    }
+
+    // Happy path — validation + rate-limit both clear. Emit Generator_Submit
+    // BEFORE the buzz-transaction prompt so click-and-abandon (cancel at
+    // confirm / insufficient-buzz) is still captured.
+    try {
+      const submitSnapshot = graph.getSnapshot() as ResourceSnapshot;
+      trackAction({
+        type: 'Generator_Submit',
+        details: {
+          modelVersionId: submitSnapshot.model?.id,
+          fromAction,
+          hasRemixOfId: !!remixOfId,
+          formVersion: 'new',
+          isValid: true,
+        },
+      }).catch(() => undefined);
+    } catch {
+      // Telemetry must never block a submission.
     }
 
     setSubmitError(undefined);

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -771,6 +771,7 @@ export default function ModelDetailsV2({
                   {latestGenerationVersion && (
                     <GenerateButton
                       versionId={latestGenerationVersion.id}
+                      modelId={model.id}
                       data-activity="create:model-stat"
                     >
                       <IconBadge radius="sm" size="lg" icon={<IconBrush size={18} />}>

--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -223,6 +223,11 @@ export const ActionType = [
   'CSAM_Help_Triggered',
   'ProfanitySearch',
   'BuzzLimit_Set',
+  // Generation funnel telemetry — top-of-funnel clicks + form submission.
+  // Joined to orchestration.jobs / images_created downstream by userId + ts.
+  'Model_Create_Click',
+  'Image_Remix_Click',
+  'Generator_Submit',
 ] as const;
 export type ActionType = (typeof ActionType)[number];
 

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -157,6 +157,233 @@ const profanitySearchSchema = z.object({
     .optional(),
 });
 
+// Generation funnel telemetry — top-of-funnel click events that feed into
+// the existing orchestration.jobs / images_created / PurchaseFunds_Confirm
+// downstream stages. See PR #2322 / civitai-observability-gaps dashboard.
+const modelCreateClickSchema = z.object({
+  type: z.literal('Model_Create_Click'),
+  details: z
+    .object({
+      modelId: z.number().optional(),
+      modelVersionId: z.number().optional(),
+      // Free-form entry-point tag (matches data-activity values on the
+      // GenerateButton). Canonical values as of pass 8:
+      //   create:model, create:model-stat, create:model-card,
+      //   create:version-stat, create:training-select, create:navbar,
+      //   create:tool-banner, create:tool-card
+      source: z.string().optional(),
+    })
+    .optional(),
+});
+
+const imageRemixClickSchema = z.object({
+  type: z.literal('Image_Remix_Click'),
+  details: z
+    .object({
+      imageId: z.number(),
+      // What the user clicked Remix on. Bounded to the three media types
+      // surfaced by GetGenerationDataInput; keep this enum tight so a typo
+      // or new value shows up at the schema layer rather than silently
+      // showing as `other` in downstream funnel queries.
+      imageType: z.enum(['image', 'video', 'audio']).optional(),
+      // The primary checkpoint version the remix will seed into the generator,
+      // when known on the client. Often unknown on infinite-scroll cards
+      // (resolved server-side by getGenerationData) — nullable on purpose.
+      sourceModelVersionId: z.number().nullish(),
+      // Free-form entry-point tag (matches data-activity values: remix:image,
+      // remix:image-card, remix:image-meta, etc.) — left as a string so new
+      // remix entry-points can be added without a schema bump.
+      source: z.string().optional(),
+    })
+    .optional(),
+});
+
+// Dashboard semantics for Generator_Submit — read before slicing the funnel:
+//
+//   isValid: true means "RHF validation + graph.validate() passed" — NOT
+//     "reached orchestration". Downstream sanitize/buzz/mutate failures
+//     (insufficient buzz, POI flag, mutate() rejection) still happen after
+//     isValid:true and are observable only via orchestration.jobs or the
+//     PurchaseFunds funnel.
+//
+//   isRateLimited: never co-emitted with the validation-fail signal. A submit
+//     that is BOTH rate-limited AND has an invalid prompt only emits
+//     isValid:false (no isRateLimited:true) — react-hook-form's onError
+//     fires before GenForm's onSubmit wrapper can run the canGenerate
+//     check (legacy), and v2's FormFooter explicitly runs graph.validate()
+//     before the canGenerate check to match (see FormFooter.tsx:handleSubmit).
+//     So the rate-limited path is unreachable from a validation-failed
+//     submit on every form path. Treat `isRateLimited:true` as the lower
+//     bound of capacity-bounded clicks, not the full set.
+//
+//     isValid value on rate-limited emits is path-dependent — the legacy
+//     image and video forms emit isValid:false (the GenForm wrapper writes
+//     it that way), while v2's FormFooter emits isValid:true (the submit
+//     would have validated; only the cap stopped it). Queries filtering
+//     `isRateLimited:true AND isValid:true` see ONLY v2; filtering
+//     `isRateLimited:true AND isValid:false` sees legacy + video. The
+//     dashboard should treat `isRateLimited:true` as the source of truth
+//     for "capacity-bounded click" and ignore `isValid` on those rows.
+//
+//   hasRemixOfId semantics:
+//      'legacy' and 'new' (v2): both gate on prompt similarity >= 0.75.
+//                v2 uses the `useRemixOfId()` hook (FormFooter.tsx:803),
+//                which returns `undefined` when below threshold; legacy
+//                applies the equivalent gate before mutate(). The hook
+//                feeds `!!remixOfId` into the emit at FormFooter.tsx:913,
+//                so an unsimilar remix correctly produces hasRemixOfId:false.
+//                The thresholds are identical — legacy ≡ v2 here.
+//      'video':  hasRemixOfId is NOT emitted (field absent in the details
+//                payload — see VideoGenerationForm.tsx:153-165, 241-252).
+//                Video form has no prompt-similarity hook yet; add when
+//                video remix analytics matter.
+//     A query GROUP BY hasRemixOfId is safe to roll up across formVersion
+//     'legacy' and 'new', but should EXCLUDE 'video' (the field is missing,
+//     not false) or split it out as its own bucket.
+//
+//   formVersion: absent on rate-limited emits from GenForm — the legacy
+//     image GenForm wrapper and VideoGenerationForm don't have a way to
+//     discriminate from the wrapping layer without a prop drill. v2's
+//     FormFooter rate-limit emit does include formVersion:'new'. So
+//     `isRateLimited:true AND formVersion missing` = legacy image or
+//     video form; `isRateLimited:true AND formVersion:'new'` = v2.
+//     Rate-limited GenForm emits are ONLY fired from the two opt-in call
+//     sites (`<GenForm track>` in GenerationForm2 + VideoGenerationForm);
+//     orchestrator modals (upscale / bg-removal / video-interpolation)
+//     deliberately omit the rate-limited emit so they don't produce
+//     asymmetric data — they have no success / validation-fail emits of
+//     their own. Treat upscale/bg-removal/interpolation as out of this
+//     funnel entirely until they get dedicated instrumentation.
+//
+//   source vs fromAction: Model_Create_Click{source:'create:navbar'} pairs
+//     to Generator_Submit{fromAction:'direct'}, NOT 'create'. The navbar
+//     Create button calls generationGraphPanel.open() with no input, which
+//     resolves entry-action to 'direct' via the no-input branch. Same
+//     pairing applies to source='create:tool-banner' and 'create:tool-card'
+//     — both open the panel with no input (the tool alias is resolved
+//     later, not at click time), so they also pair to fromAction='direct'.
+//     The remaining create:* sources (create:model, create:model-stat,
+//     create:model-card, create:version-stat, create:training-select)
+//     pair to fromAction='create'. The wildcard CTA on
+//     ModelVersionDetails.tsx emits source='create:model' too — wildcard
+//     is a runType branch in the form provider, not a source tag. If
+//     wildcard click→submit conversion ever becomes a question, the
+//     instrumentation needs to differentiate via wildcardSetId, not source.
+//     Per-source conversion queries against navbar/tool sources need:
+//       JOIN clicks ON click.userId = submit.userId
+//         WHERE click.source IN ('create:navbar','create:tool-banner','create:tool-card')
+//           AND submit.fromAction IN ('create','direct')
+//     The 'direct' bucket also contains non-click-attributed submits (panel
+//     re-open, /generate page direct visit), so navbar/tool conversion is
+//     an upper bound, not an exact count.
+//
+//     Note: source='create:version-stat' may emit with modelId=undefined
+//     during the parent component's loading race (the modelVersion fetch
+//     in ModelVersionEarlyAccessPurchase hasn't resolved yet, so
+//     modelVersion?.model?.id is undefined when the user clicks). Dashboard
+//     queries should treat 'create:version-stat AND modelId IS NULL' as
+//     expected, not as a data issue.
+//
+//     Note: source='create:model-card' (RemixButton on ModelCard) intentionally
+//     emits without modelId — the ModelCard caller doesn't have
+//     ModelVersion.modelId in scope. Aggregate to parent model via a
+//     ModelVersion lookup if you need model-level rollups.
+//
+//   Fetch-in-flight race: open({type:'image', id}) only writes
+//     lastEntryAction AFTER fetchGenerationData() resolves (generation-graph
+//     .store.ts:369-371). If a user clicks Remix and submits before the
+//     source fetch resolves, fromAction reflects the prior session's value
+//     (likely 'direct'), not 'remix'. RHF validation typically rejects
+//     these submits (isValid:false — the form is still in skeleton/loading
+//     state), so the visible artifact is a thin slice of
+//     `fromAction='direct', isValid=false` rows that should have been
+//     'remix'. Remix click→submit conversion will under-count by this
+//     narrow slice. Not worth fixing until it shows up as a measurable
+//     drift on the dashboard.
+//
+//   Orphan submits — known un-instrumented entry-points: several pre-existing
+//     call sites open the generation panel without emitting a paired
+//     Model_Create_Click / Image_Remix_Click, so their Generator_Submit rows
+//     have no joinable upstream click event:
+//       - pages/challenges/[id]/[[...slug]].tsx:154,1231 — challenge detail
+//         "Generate" buttons (top-of-page + per-model-version action)
+//       - components/Challenges/ChallengeInvitation.tsx:80,85 — challenge
+//         invite modal accept
+//       - components/Chopped/states/playing.tsx:288 — Chopped game's
+//         "Create submission" button
+//       - components/ImageGeneration/QueueItem.tsx:417-422 — in-queue
+//         "Generate with this resource" button (runType:'run' → fromAction:
+//         'create'; semantically a replay, but pre-existing — not changing
+//         in this pass)
+//       - components/generation_v2/inputs/MetadataExtractionPanel.tsx:170-179 —
+//         "Add resources" handler in the metadata-extraction drop-zone calls
+//         setData({runType:'run'}) (→ fromAction:'create') and opens the
+//         panel with no upstream click emit. Low volume vs the other
+//         orphan entry-points; instrumenting is follow-up scope.
+//       - components/Buzz/FeatureCards/FeatureCards.tsx:148 — Buzz feature
+//         card "Generate" entry. Opens the panel with no input (→ fromAction:
+//         'direct'). Not instrumented in this pass — entry-point is on the
+//         Buzz dashboard, semantically more of a marketing surface than the
+//         core create/remix funnel; instrumenting is follow-up scope.
+//     These produce Generator_Submit{fromAction:'create'} (or 'replay' for
+//     runType='run' from QueueItem) with no matching click row. Dashboard
+//     queries computing click→submit conversion should EITHER exclude
+//     orphan-submits via `WHERE EXISTS (matching click within session)` OR
+//     document the gap and treat the orphan slice as an additive baseline.
+//     Instrumenting these entry-points is follow-up scope.
+const generatorSubmitSchema = z.object({
+  type: z.literal('Generator_Submit'),
+  // `details` is marked required (not .optional()) so new callers can't
+  // silently emit a Generator_Submit with no payload — that would land in
+  // the funnel as an un-attributed row and skew every downstream query.
+  // Inside `details`, only `fromAction` is required; the rest (isValid,
+  // formVersion, isRateLimited, modelVersionId, hasRemixOfId) are advisory
+  // and may be omitted depending on form/path. The submit-schema's job is
+  // to enforce the entry-action discriminator, not to dictate which
+  // optional context fields each emitter chooses to populate.
+  details: z
+    .object({
+      // Checkpoint version that will run the job. May be undefined for
+      // multi-resource workflows where the checkpoint isn't picked yet.
+      modelVersionId: z.number().nullish(),
+      // Discriminator for joining back to the entry-point click event.
+      // Reflects the most-recent intentful entry, not session history — each
+      // open-with-input call (remix click, model-stat click, replay) overwrites
+      // the previous value; close() resets to 'direct'; navbar Create resets
+      // to 'direct' via the no-input branch. So a user who remixes then
+      // pivots to the navbar will see fromAction='direct' on the next submit,
+      // not 'remix'.
+      //
+      // 'remix'  — opened from an image/video (generationGraphPanel runType=remix)
+      // 'create' — opened from a model/modelVersion page or model card
+      // 'replay' — re-run from the queue / previous output
+      // 'direct' — opened from /generate or with no input (panel default)
+      fromAction: z.enum(['create', 'remix', 'replay', 'direct']),
+      // True when remixOfId is being sent on the request — gated by the
+      // 0.75 prompt-similarity threshold in BOTH legacy and v2 forms (v2
+      // via the `useRemixOfId()` hook). Absent on video-form emits — the
+      // video path has no similarity hook yet. See the doc-block above
+      // for the hasRemixOfId roll-up caveat.
+      hasRemixOfId: z.boolean().optional(),
+      // 'legacy' (GenerationForm2) | 'new' (generation_v2/FormFooter) |
+      // 'video' (Generation/Video/VideoGenerationForm)
+      formVersion: z.enum(['legacy', 'new', 'video']).optional(),
+      // False when the submit attempt failed validation (react-hook-form
+      // onError path or graph.validate() early return). The data team can
+      // split valid-vs-invalid attempts to spot UX traps where users click
+      // Generate but the form blocks them. Default true (omitted on success
+      // path is treated as valid by downstream).
+      isValid: z.boolean().optional(),
+      // True when the submit short-circuits because the user is at their
+      // concurrent-request limit (snapshot.canGenerate === false). Capacity-
+      // bounded clicks show up as a distinct funnel stage and aren't
+      // conflated with RHF validation failures (missing prompt, etc.).
+      // isValid on these rows is path-dependent (legacy/video: false,
+      // v2: true) — see the doc-block above for the dashboard caveat.
+      isRateLimited: z.boolean().optional(),
+    }),
+});
+
 export type TrackActionInput = z.infer<typeof trackActionSchema>;
 export const trackActionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('AddToBounty_Click') }),
@@ -175,4 +402,7 @@ export const trackActionSchema = z.discriminatedUnion('type', [
   membershipDowngradeSchema,
   csamHelpTriggeredSchema,
   profanitySearchSchema,
+  modelCreateClickSchema,
+  imageRemixClickSchema,
+  generatorSubmitSchema,
 ]);

--- a/src/store/__tests__/generation-graph.store.test.ts
+++ b/src/store/__tests__/generation-graph.store.test.ts
@@ -1,0 +1,406 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks — the store transitively imports trpc + several other zustand
+// stores that pull localStorage / next / etc. None of those are relevant to
+// the funnel-attribution logic under test, so stub them out with minimal
+// stand-ins. Anything *not* mocked here is exercised for real (zustand /
+// immer / the store module itself).
+// ---------------------------------------------------------------------------
+
+// trpc: only `generation.getGenerationData.query` is referenced from the store.
+// `fetchGenerationData` is the seam — tests override it directly via
+// vi.mock returning a controllable Promise per test.
+const fetchMock = vi.fn();
+vi.mock('~/utils/trpc', () => ({
+  trpcVanilla: {
+    generation: {
+      getGenerationData: {
+        query: (...args: unknown[]) => fetchMock(...args),
+      },
+    },
+  },
+}));
+
+// Panel store: only opened/view/previousView are touched, no setState side
+// effects matter to the funnel attribution logic.
+vi.mock('~/store/generation-panel.store', () => ({
+  useGenerationPanelStore: {
+    setState: vi.fn(),
+    getState: () => ({ view: 'generate', opened: false, previousView: undefined }),
+  },
+}));
+
+// Legacy form store: syncLegacyFormStore writes to setType/setEngine. No-op
+// in tests so we don't need to mock prisma enums or the form store state.
+vi.mock('~/store/generation-form.store', () => ({
+  generationFormStore: {
+    setType: vi.fn(),
+    setEngine: vi.fn(),
+    getState: () => ({ buzzType: undefined }),
+  },
+}));
+
+// Remix store: touches localStorage on import via the persist middleware.
+// Stub it out to avoid needing a DOM in the test env.
+vi.mock('~/store/remix.store', () => ({
+  remixStore: {
+    setRemix: vi.fn(),
+    clearRemix: vi.fn(),
+    getData: () => null,
+  },
+}));
+
+// Workflow + ecosystem helpers: syncLegacyFormStore consults these. Return
+// values that disable the legacy-sync codepath so we don't pull a megabyte of
+// shared constants into the test.
+vi.mock('~/shared/data-graph/generation/config/workflows', () => ({
+  getOutputTypeForWorkflow: () => 'image',
+  isNewFormOnly: () => false,
+}));
+
+vi.mock('~/shared/constants/basemodel.constants', () => ({
+  ecosystemByKey: new Map(),
+}));
+
+vi.mock('~/shared/utils/engine.utils', () => ({
+  getEngineFromEcosystem: () => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Imported after mocks are declared above (vitest hoists vi.mock calls).
+import { useGenerationGraphStore } from '~/store/generation-graph.store';
+
+function resetStore() {
+  useGenerationGraphStore.setState({
+    counter: 0,
+    loading: false,
+    data: undefined,
+    lastEntryAction: 'direct',
+    openSequence: 0,
+  });
+  fetchMock.mockReset();
+}
+
+beforeEach(() => {
+  resetStore();
+});
+
+afterEach(() => {
+  resetStore();
+});
+
+describe('useGenerationGraphStore — funnel attribution', () => {
+  it('starts with lastEntryAction = direct', () => {
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('direct');
+  });
+
+  it("open() with no input keeps lastEntryAction = 'direct' (no in-flight data)", async () => {
+    await useGenerationGraphStore.getState().open();
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('direct');
+  });
+
+  it("open({type:'image', id:1}) resolves to lastEntryAction = 'remix'", async () => {
+    fetchMock.mockResolvedValueOnce({
+      resources: [],
+      params: {},
+      remixOfId: undefined,
+    });
+    await useGenerationGraphStore.getState().open({ type: 'image', id: 1 } as any);
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+  });
+
+  it("open({type:'modelVersion', id:42}) resolves to lastEntryAction = 'create'", async () => {
+    fetchMock.mockResolvedValueOnce({
+      resources: [],
+      params: {},
+      remixOfId: undefined,
+    });
+    await useGenerationGraphStore.getState().open({ type: 'modelVersion', id: 42 } as any);
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('create');
+  });
+
+  it("open({type:'wildcard'}) resolves to lastEntryAction = 'create'", async () => {
+    await useGenerationGraphStore.getState().open({ type: 'wildcard', wildcardSetId: 7 });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('create');
+  });
+
+  it("setData({runType:'run'}) sets lastEntryAction = 'create'", () => {
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'run' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('create');
+  });
+
+  it("setData({runType:'remix'}) sets lastEntryAction = 'remix'", () => {
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'remix' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+  });
+
+  it("setData({runType:'replay'}) sets lastEntryAction = 'replay'", () => {
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'replay' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('replay');
+  });
+
+  // ----------- REGRESSION GUARDS -----------------------------------------
+
+  it("REGRESSION: setData({runType:'patch'}) preserves lastEntryAction", () => {
+    // First establish a non-default attribution.
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'remix' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+
+    // patch is a mid-session sub-flow; it MUST NOT overwrite attribution.
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'patch' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+  });
+
+  it("REGRESSION: setData({runType:'append'}) preserves lastEntryAction", () => {
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'remix' });
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'append' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+  });
+
+  it('REGRESSION: clearData() preserves lastEntryAction (form-provider race fix)', () => {
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'remix' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+
+    // clearData runs at open-time, BEFORE the user clicks Generate.
+    // It must NOT touch lastEntryAction or the submit telemetry will see
+    // the default 'direct' and lose its attribution to the entry click.
+    useGenerationGraphStore.getState().clearData();
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+    expect(useGenerationGraphStore.getState().data).toBeUndefined();
+  });
+
+  // ----------- SESSION-END -----------------------------------------------
+
+  it("close() resets lastEntryAction = 'direct'", () => {
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'remix' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+
+    useGenerationGraphStore.getState().close();
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('direct');
+  });
+
+  // ----------- CONCURRENT OPEN RACE --------------------------------------
+
+  it("concurrent open() race: later open's attribution wins, earlier fetch is discarded", async () => {
+    // Open A: image remix — fetch deferred via a manually-resolvable promise.
+    let resolveA: (v: unknown) => void = () => undefined;
+    const pendingA = new Promise((resolve) => {
+      resolveA = resolve;
+    });
+    fetchMock.mockReturnValueOnce(pendingA);
+
+    const openAPromise = useGenerationGraphStore
+      .getState()
+      .open({ type: 'image', id: 100 } as any);
+
+    // Open B: no-input navbar Create. Synchronous — runs to completion
+    // before A's fetch resolves.
+    await useGenerationGraphStore.getState().open();
+
+    // Attribution mid-race: B has won synchronously, lastEntryAction = 'direct'.
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('direct');
+
+    // Now resolve A's fetch — A's resolve path must detect the sequence bump
+    // and NO-OP rather than clobber B's 'direct' with 'remix'.
+    resolveA({ resources: [], params: {}, remixOfId: undefined });
+    await openAPromise;
+
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('direct');
+  });
+
+  it('concurrent open() race: failed earlier fetch does NOT reset attribution set by a later open', async () => {
+    // Open A: image remix — fetch will REJECT.
+    let rejectA: (e: unknown) => void = () => undefined;
+    const pendingA = new Promise((_, reject) => {
+      rejectA = reject;
+    });
+    fetchMock.mockReturnValueOnce(pendingA);
+
+    const openAPromise = useGenerationGraphStore
+      .getState()
+      .open({ type: 'image', id: 200 } as any)
+      .catch(() => undefined); // A's error must be swallowed by guard.
+
+    // Open B: modelVersion → lastEntryAction = 'create'.
+    fetchMock.mockResolvedValueOnce({ resources: [], params: {}, remixOfId: undefined });
+    await useGenerationGraphStore.getState().open({ type: 'modelVersion', id: 999 } as any);
+
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('create');
+
+    // A rejects after B has won. The catch block in open() must see the
+    // sequence mismatch and bail without resetting lastEntryAction to
+    // 'direct'.
+    rejectA(new Error('fetch aborted'));
+    await openAPromise;
+
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('create');
+  });
+
+  // ----------- LOADING-STUCK REGRESSION GUARDS ---------------------------
+
+  it("REGRESSION: superseded resolve path clears loading when no-input open() runs in between", async () => {
+    // Open A: image remix — fetch deferred via a manually-resolvable promise.
+    // A sets loading=true on entry.
+    let resolveA: (v: unknown) => void = () => undefined;
+    const pendingA = new Promise((resolve) => {
+      resolveA = resolve;
+    });
+    fetchMock.mockReturnValueOnce(pendingA);
+
+    const openAPromise = useGenerationGraphStore
+      .getState()
+      .open({ type: 'image', id: 300 } as any);
+
+    expect(useGenerationGraphStore.getState().loading).toBe(true);
+
+    // Open B: no-input navbar Create. Synchronous — bumps openSequence
+    // but does NOT touch loading on the legacy code path.
+    await useGenerationGraphStore.getState().open();
+
+    // Now resolve A's fetch. The bail-out must clear `loading` since B was
+    // synchronous and didn't own it; otherwise consumers stay stuck on a
+    // spinner until the next input-bearing open.
+    resolveA({ resources: [], params: {}, remixOfId: undefined });
+    await openAPromise;
+
+    expect(useGenerationGraphStore.getState().loading).toBe(false);
+  });
+
+  it('REGRESSION: superseded reject path clears loading when no-input open() runs in between', async () => {
+    let rejectA: (e: unknown) => void = () => undefined;
+    const pendingA = new Promise((_, reject) => {
+      rejectA = reject;
+    });
+    fetchMock.mockReturnValueOnce(pendingA);
+
+    const openAPromise = useGenerationGraphStore
+      .getState()
+      .open({ type: 'image', id: 400 } as any)
+      .catch(() => undefined);
+
+    expect(useGenerationGraphStore.getState().loading).toBe(true);
+
+    await useGenerationGraphStore.getState().open();
+
+    rejectA(new Error('fetch aborted'));
+    await openAPromise;
+
+    expect(useGenerationGraphStore.getState().loading).toBe(false);
+  });
+
+  it('REGRESSION: superseded bail does NOT clear loading while a sibling fetch is still in flight', async () => {
+    // Two pending input-bearing opens. A is superseded by B, but B's fetch
+    // is still awaiting — the bail-out must leave `loading` as true so
+    // consumers keep their spinner until B resolves.
+    let resolveA: (v: unknown) => void = () => undefined;
+    let resolveB: (v: unknown) => void = () => undefined;
+    const pendingA = new Promise((resolve) => {
+      resolveA = resolve;
+    });
+    const pendingB = new Promise((resolve) => {
+      resolveB = resolve;
+    });
+    fetchMock.mockReturnValueOnce(pendingA).mockReturnValueOnce(pendingB);
+
+    const openAPromise = useGenerationGraphStore
+      .getState()
+      .open({ type: 'image', id: 500 } as any);
+    const openBPromise = useGenerationGraphStore
+      .getState()
+      .open({ type: 'image', id: 501 } as any);
+
+    expect(useGenerationGraphStore.getState().loading).toBe(true);
+
+    // A's fetch resolves first (it's superseded by B). Bail should leave
+    // loading=true because B is still pending.
+    resolveA({ resources: [], params: {}, remixOfId: undefined });
+    await openAPromise;
+    expect(useGenerationGraphStore.getState().loading).toBe(true);
+
+    // Now B resolves — owns the success path, sets loading=false.
+    resolveB({ resources: [], params: {}, remixOfId: undefined });
+    await openBPromise;
+    expect(useGenerationGraphStore.getState().loading).toBe(false);
+  });
+
+  // ----------- WILDCARD RACE ---------------------------------------------
+
+  it("REGRESSION: wildcard open clears loading even when an image fetch is pending", async () => {
+    // Open A: image remix — fetch deferred via a manually-resolvable promise.
+    // A sets loading=true on entry and bumps inFlightFetchCount to 1.
+    let resolveA: (v: unknown) => void = () => undefined;
+    const pendingA = new Promise((resolve) => {
+      resolveA = resolve;
+    });
+    fetchMock.mockReturnValueOnce(pendingA);
+
+    const openAPromise = useGenerationGraphStore
+      .getState()
+      .open({ type: 'image', id: 600 } as any);
+
+    expect(useGenerationGraphStore.getState().loading).toBe(true);
+
+    // Open B: wildcard. Synchronous — bumps openSequence, clears loading
+    // unconditionally (the synchronous-input branch claims `loading=false`
+    // for the latest open), but does NOT decrement inFlightFetchCount (A
+    // owns that). After B runs: loading=false, A still pending.
+    await useGenerationGraphStore.getState().open({ type: 'wildcard', wildcardSetId: 11 });
+    expect(useGenerationGraphStore.getState().loading).toBe(false);
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('create');
+
+    // Resolve A's fetch. The bail-out detects the sequence mismatch and
+    // since inFlightFetchCount drops to 0, it would also try to clear
+    // loading — but loading is already false, so this should NO-OP cleanly.
+    // Critically: loading must STAY false (not flip back to true).
+    resolveA({ resources: [], params: {}, remixOfId: undefined });
+    await openAPromise;
+
+    expect(useGenerationGraphStore.getState().loading).toBe(false);
+  });
+
+  // ----------- CLEARDATA + OPEN ATTRIBUTION (NAVBAR SCENARIO) -----------
+
+  it("REGRESSION: setData(remix) then open() with no input → lastEntryAction = 'direct'", async () => {
+    // Simulate: user remixed an image (lastEntryAction='remix'), then
+    // clicked the navbar Create button (no-input open). The no-input branch
+    // must reset attribution to 'direct' so the next Generator_Submit
+    // pairs to the navbar click, NOT the prior remix. This locks in the
+    // docblock claim about navbar source pairing to fromAction='direct'.
+    useGenerationGraphStore.getState().setData({ params: {}, resources: [], runType: 'remix' });
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+
+    // clearData() preserves attribution per the form-provider race fix —
+    // important so we know the 'direct' write below comes from open(),
+    // not from clearData() incidentally resetting it.
+    useGenerationGraphStore.getState().clearData();
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+
+    // No-input open — should write 'direct'.
+    await useGenerationGraphStore.getState().open();
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('direct');
+  });
+
+  // ----------- preserveEntryAction FLAG ----------------------------------
+
+  it('REGRESSION: open({modelVersion}, {preserveEntryAction:true}) does NOT overwrite lastEntryAction', async () => {
+    // Establish a remix attribution upstream (e.g. user entered via Remix).
+    fetchMock.mockResolvedValueOnce({ resources: [], params: {}, remixOfId: undefined });
+    await useGenerationGraphStore.getState().open({ type: 'image', id: 1 } as any);
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+
+    // Mid-session base-model swap from inside the generator. With the
+    // preserveEntryAction flag, this MUST NOT clobber 'remix' to 'create'.
+    fetchMock.mockResolvedValueOnce({ resources: [], params: {}, remixOfId: undefined });
+    await useGenerationGraphStore
+      .getState()
+      .open({ type: 'modelVersion', id: 42 } as any, { preserveEntryAction: true });
+
+    expect(useGenerationGraphStore.getState().lastEntryAction).toBe('remix');
+  });
+});

--- a/src/store/generation-graph.store.ts
+++ b/src/store/generation-graph.store.ts
@@ -70,6 +70,21 @@ export interface GenerationGraphData {
   remixOfId?: number;
 }
 
+/**
+ * High-level discriminator describing how the panel was last opened.
+ *
+ * - 'create'  — opened from a model / modelVersion (Create button, model card)
+ * - 'remix'   — opened from a media item (image / video / audio remix click)
+ * - 'replay'  — re-run from the queue or a previous output
+ * - 'direct'  — opened with no input (panel default, /generate page, etc.)
+ *
+ * Tracked on the store so submit-time telemetry (Generator_Submit) can
+ * attribute submissions back to their entry-point click event. `data.runType`
+ * is cleared by the form provider on consumption, so we keep this lighter
+ * marker around until the next open / submit.
+ */
+export type GeneratorEntryAction = 'create' | 'remix' | 'replay' | 'direct';
+
 interface GenerationGraphState {
   /** Counter for change detection (increments on each setData) */
   counter: number;
@@ -77,14 +92,71 @@ interface GenerationGraphState {
   loading: boolean;
   /** Pending data to apply to the form */
   data?: GenerationGraphData;
-  /** Open the generation sidebar, optionally fetching data for a model/image */
-  open: (input?: GenerationGraphOpenInput) => Promise<void>;
+  /** Funnel-telemetry discriminator — see GeneratorEntryAction */
+  lastEntryAction: GeneratorEntryAction;
+  /**
+   * Monotonic open-sequence counter.
+   *
+   * Incremented synchronously at the start of every `open()` call (including
+   * the wildcard and no-input branches). Async input branches capture the
+   * sequence before awaiting the fetch and re-check it on resolve — if a
+   * later `open()` has bumped the sequence in the meantime, the older fetch
+   * aborts its state mutation instead of clobbering attribution.
+   *
+   * Protects against the concurrent-open race:
+   *   t0: user clicks Remix         → open({media}) → seq=1, fetch starts
+   *   t1: user clicks navbar Create → open()         → seq=2 sync, lastEntryAction='direct'
+   *   t2: t0 fetch resolves         → seq still 2 ≠ captured 1 → abort
+   *
+   * Without this guard, t2 would set lastEntryAction='remix' and clobber the
+   * navbar's 'direct' attribution that's already been observed by any submit
+   * happening between t1 and t2.
+   */
+  openSequence: number;
+  /**
+   * Open the generation sidebar, optionally fetching data for a model/image.
+   *
+   * `options.preserveEntryAction = true` skips the `lastEntryAction` write,
+   * which is important for mid-session re-entries (e.g. swapping the base
+   * model from inside the generator). Without it, an in-panel
+   * `open({type:'modelVersion', ...})` overwrites the upstream entry-action
+   * (e.g. 'remix') with 'create', so the eventual Generator_Submit attributes
+   * to the wrong funnel branch. The mirror carve-out exists in `setData` for
+   * the `patch`/`append` runTypes; this is its open()-side analog.
+   */
+  open: (
+    input?: GenerationGraphOpenInput,
+    options?: { preserveEntryAction?: boolean }
+  ) => Promise<void>;
   /** Close the generation sidebar */
   close: () => void;
   /** Set generation data for the form to consume */
   setData: (data: Omit<GenerationGraphData, 'runType'> & { runType?: RunType }) => void;
   /** Clear pending data (called by form provider after consuming) */
   clearData: () => void;
+}
+
+/**
+ * Map the internal store RunType onto the public funnel-telemetry shape.
+ *
+ * NOTE: callers MUST NOT invoke this with `runType === 'patch' | 'append'`.
+ * Those are mid-session sub-flows that need to *preserve* the previous
+ * entry-action, not overwrite it — `setData` short-circuits before calling
+ * this for patch/append. They are kept on the `RunType` union because they
+ * are still meaningful to the form provider's runType branch.
+ */
+function toEntryAction(runType: RunType): GeneratorEntryAction {
+  switch (runType) {
+    case 'remix':
+      return 'remix';
+    case 'replay':
+      return 'replay';
+    case 'run':
+    case 'wildcard':
+      return 'create';
+    default:
+      return 'direct';
+  }
 }
 
 // =============================================================================
@@ -157,6 +229,18 @@ function buildGenerationDataKey(input: GetGenerationDataInput): string {
  */
 const generationDataCache = new Map<string, Promise<GenerationData>>();
 
+/**
+ * Module-level counter of input-bearing `open()` calls currently awaiting a
+ * `fetchGenerationData` resolution. Read by the sequence-mismatch bail-out
+ * paths to decide whether resetting `loading = false` would stomp a newer
+ * fetch that is still pending. See `loading` field invariant in the store.
+ *
+ * NOTE: this is intentionally module-scoped (not store state) — it's an
+ * implementation detail of the concurrent-open race guard and has no
+ * meaning to subscribers.
+ */
+let inFlightFetchCount = 0;
+
 export function fetchGenerationData(input: GetGenerationDataInput): Promise<GenerationData> {
   const key = buildGenerationDataKey(input);
 
@@ -181,19 +265,33 @@ export function fetchGenerationData(input: GetGenerationDataInput): Promise<Gene
 
 export const useGenerationGraphStore = create<GenerationGraphState>()(
   devtools(
-    immer((set) => ({
+    immer((set, get) => ({
       counter: 0,
       loading: false,
       data: undefined,
+      lastEntryAction: 'direct' as GeneratorEntryAction,
+      openSequence: 0,
 
-      open: async (input) => {
+      open: async (input, options) => {
+        const preserveEntryAction = options?.preserveEntryAction === true;
+        // Increment sequence synchronously so any subsequent open() — even
+        // one that runs before this function's first await — supersedes us.
+        // Capture the local for use after the await to detect superseding.
+        let capturedSequence = 0;
+        set((state) => {
+          state.openSequence++;
+          capturedSequence = state.openSequence;
+        });
+
         useGenerationPanelStore.setState({ opened: true });
         if (input) {
           useGenerationPanelStore.setState({ view: 'generate' });
 
           // Wildcard entry point: no fetch required, just hand the
           // wildcardSetId to the form provider's `wildcard` runType branch
-          // which merges it into the snippets node.
+          // which merges it into the snippets node. Synchronous, so no
+          // sequence re-check needed — but we still bumped the counter above
+          // to invalidate any in-flight media/model fetches.
           if (input.type === 'wildcard') {
             set((state) => {
               state.data = {
@@ -201,6 +299,11 @@ export const useGenerationGraphStore = create<GenerationGraphState>()(
                 resources: [],
                 runType: 'wildcard',
               };
+              if (!preserveEntryAction) state.lastEntryAction = 'create';
+              // Wildcard is synchronous — clear loading so a superseded
+              // input-bearing open() that set loading=true earlier doesn't
+              // leave consumers stuck on a spinner.
+              state.loading = false;
               state.counter++;
             });
             return;
@@ -209,9 +312,33 @@ export const useGenerationGraphStore = create<GenerationGraphState>()(
           set((state) => {
             state.loading = true;
           });
+          inFlightFetchCount++;
 
           try {
             const result = await fetchGenerationData(input);
+
+            // Concurrent-open race guard. If another open() has run while
+            // we awaited, our captured sequence won't match the live one —
+            // bail without clobbering the newer open's attribution / data.
+            // See `openSequence` JSDoc above.
+            //
+            // Loading-flag invariant: only the latest open() owns `loading`.
+            // If we were the only in-flight fetch (count drops to 0 after
+            // we decrement) and `loading` is still true, the newer open()
+            // was synchronous (no-input / wildcard) and didn't touch it —
+            // we must clear it ourselves or consumers stay stuck on a
+            // spinner. If other fetches are still pending, leave `loading`
+            // alone — they'll resolve it on their own success path.
+            if (get().openSequence !== capturedSequence) {
+              inFlightFetchCount--;
+              if (inFlightFetchCount === 0 && get().loading) {
+                set((state) => {
+                  state.loading = false;
+                });
+              }
+              return;
+            }
+
             const isMedia = ['audio', 'image', 'video'].includes(input.type);
             const resources = result.resources.map(substituteResource);
 
@@ -239,19 +366,78 @@ export const useGenerationGraphStore = create<GenerationGraphState>()(
                 runType: isMedia ? 'remix' : 'run',
                 remixOfId: result.remixOfId,
               };
+              if (!preserveEntryAction) {
+                state.lastEntryAction = isMedia ? 'remix' : 'create';
+              }
               state.loading = false;
               state.counter++;
             });
+            inFlightFetchCount--;
           } catch (e) {
+            // If a newer open() has already taken over, swallow the error
+            // — we're not the active open anymore and have no right to
+            // mutate lastEntryAction on its behalf. Loading-flag invariant
+            // mirrors the resolve path: only clear `loading` when we were
+            // the last in-flight fetch.
+            if (get().openSequence !== capturedSequence) {
+              inFlightFetchCount--;
+              if (inFlightFetchCount === 0 && get().loading) {
+                set((state) => {
+                  state.loading = false;
+                });
+              }
+              return;
+            }
+            // Reset attribution on fetch failure so the next submit can't
+            // accidentally inherit a stale entry-action from this aborted
+            // open (e.g. user clicked Remix, fetch failed, user opens panel
+            // again with no input — should be 'direct', not 'remix').
+            //
+            // When `preserveEntryAction` is set, the caller is a mid-session
+            // re-entry that explicitly opted out of attribution writes — a
+            // failed in-panel base-model swap should NOT scrub the upstream
+            // entry-action from the funnel.
             set((state) => {
               state.loading = false;
+              if (!preserveEntryAction) state.lastEntryAction = 'direct';
             });
+            inFlightFetchCount--;
             throw e;
           }
+        } else {
+          // No input — user opened the panel directly (e.g. from /generate
+          // or the sidebar toggle). Preserve the previous entry-action when
+          // the panel is being re-opened mid-session; only reset to 'direct'
+          // if there's no in-flight data to attribute against. The
+          // synchronous openSequence++ above ensures any concurrent
+          // input-bearing open() that resolves AFTER us will see its
+          // captured sequence != live and abort, so this branch's
+          // attribution wins.
+          //
+          // Clear `loading` unconditionally: this branch is synchronous, so
+          // there's nothing to wait on. A superseded input-bearing open()
+          // that set loading=true would otherwise leave consumers stuck on
+          // a spinner (the bail-out path leaves `loading` alone when other
+          // fetches are still in flight — but here, there's no "us" to
+          // own loading, so claim the false-write for the latest open).
+          set((state) => {
+            if (!state.data && !preserveEntryAction) state.lastEntryAction = 'direct';
+            state.loading = false;
+          });
         }
       },
 
-      close: () => useGenerationPanelStore.setState({ opened: false }),
+      close: () => {
+        // Reset attribution at session-end so a stale entry-action can't leak
+        // into the next open. Submit happens BEFORE close in the happy path,
+        // so this is safe; opens without input then correctly resolve to
+        // 'direct' (the no-input branch in `open` preserves an in-flight
+        // action only when `state.data` is still set).
+        set((state) => {
+          state.lastEntryAction = 'direct';
+        });
+        useGenerationPanelStore.setState({ opened: false });
+      },
 
       setData: ({ params, resources, runType = 'replay', remixOfId }) => {
         // TEMPORARY: Sync legacy form store (remove with legacy generator)
@@ -272,11 +458,26 @@ export const useGenerationGraphStore = create<GenerationGraphState>()(
             runType,
             remixOfId,
           };
+          // Patch/append are sub-flows inside an already-open session
+          // (apply-workflow-to-result, append-to-upscale-batch, etc.).
+          // They MUST preserve the previous entry-action so the eventual
+          // Generator_Submit can still attribute back to the original
+          // create/remix/replay click. Only intentful entry-points
+          // (run/remix/replay/wildcard) overwrite lastEntryAction.
+          if (runType !== 'patch' && runType !== 'append') {
+            state.lastEntryAction = toEntryAction(runType);
+          }
           state.counter++;
         });
       },
 
       clearData: () => {
+        // NOTE: do NOT reset lastEntryAction here. All three form providers
+        // call clearData() immediately after consuming the pending data —
+        // which happens at open-time, long BEFORE the user clicks Generate.
+        // Resetting here destroyed the create/remix/replay attribution that
+        // Generator_Submit depends on. Reset lives in `close()` (session end)
+        // and on fetch-failure in `open()` instead.
         set((state) => {
           state.data = undefined;
         });


### PR DESCRIPTION
## Summary

The data team can measure the **bottom** of the generation funnel (`orchestration.jobs`, `images_created`, `PurchaseFunds_Confirm`, `CustomerSubscription`) but is **blind at the top**: the click event that opens the generator. The model-page proxy join shows median 0.76% / mean 5.4% viewer→generator conversion across 12K models, but per-button conversion is unmeasurable.

This PR wires three new `trackAction` event types so the funnel can be measured end-to-end:

```
entry-point click (Model_Create_Click | Image_Remix_Click)
  → Generator_Submit (clicked Generate in the form)
  → orchestration.jobs row             [already captured]
  → images_created row                 [already captured]
  → PurchaseFunds_Confirm event        [already captured]
  → CustomerSubscription created       [captured via PG federation]
```

Stages 3-6 already join cleanly via `userId`. Stages 1-2 are what this PR adds.

### The three new events

- **`Model_Create_Click`** — wired into `GenerateButton.onClickHandler` so it covers every Create entry-point in one place: model-page Create button, model-stat badge, model card Create, `ModelVersionDetails` publish/private flows, `ModelVersionEarlyAccessPurchase` trial CTA, `TrainingSelectFile` epoch CTA. The handler only fires when the button targets a specific resource (`versionId` / `modelId` / `wildcardSetId`) — the same component is reused as the form-submit button inside the generator panel and we'd double-count otherwise.

- **`Image_Remix_Click`** — wired at every remix entry-point: `ImagesCard`, `ImageDetail2`, `ImagesAsPostsCard`, `ModelCarousel`, `PostImages`, `ImageMeta`, `ImageMetaPopoverLazy`, and the `Cards/RemixButton` (which is overloaded as both image-remix and model-create depending on input type). Carries `imageId`, `imageType`, and a free-form `source` string matching the existing `data-activity` attribute.

- **`Generator_Submit`** — fired at the **start** of `handleSubmit` in all **three** form paths:
  - `GenerationForm2` (legacy) — fires on RHF validation pass with `isValid: true` AND from a new `onError` handler with `isValid: false` when validation fails.
  - `generation_v2/FormFooter` (new) — moved above the `graph.validate()` early return; `isValid` reflects `result.success`.
  - `Generation/Video/VideoGenerationForm` (video) — same pattern, covers both the inner `config.validate()` throw and `graph.validate()` early return; also wires `onError={handleSubmitError}` on the outer `GenForm` so RHF-level failures are captured (mirrors the legacy form).
  - `GenForm` (the wrapper used by legacy + video + Orchestrator modals) — fires `Generator_Submit` with `isRateLimited: true, isValid: false` when `snapshot.canGenerate === false` short-circuits the submit. `formVersion` is intentionally omitted at this layer since GenForm wraps three different form types.

  Carries `fromAction: 'create' | 'remix' | 'replay' | 'direct'` derived from a `lastEntryAction` marker on the graph store, `formVersion: 'legacy' | 'new' | 'video'` (omitted on the rate-limited path), `isValid: boolean`, and `isRateLimited: true` on the canGenerate short-circuit branch.

### Canonical `source` tag strings (for dashboard queries)

After review feedback the source tags are now reconciled with the code. Final set:

**`Model_Create_Click.details.source`** (read from `data-activity` on each rendered button):

| Source | Origin |
|---|---|
| `create:model` | `ModelVersionDetails` (publish / private flows) |
| `create:model-stat` | `pages/models/[id]/[[...slug]].tsx` (stat badge) |
| `create:model-card` | `Cards/RemixButton` (non-image branch) |
| `create:version-stat` | `ModelVersionEarlyAccessPurchase` (trial CTA) |
| `create:training-select` | `TrainingSelectFile` (epoch CTA) |
| `create:navbar` | `AppLayout/AppHeader/CreateMenu` |

**`Image_Remix_Click.details.source`**:

| Source | Origin |
|---|---|
| `remix:image` | `Image/DetailV2/ImageDetail2` (image detail page) |
| `remix:image-card` | `Image/Infinite/ImagesCard` (infinite-scroll image card) |
| `remix:image-card-home` | `Cards/RemixButton` (Cards/ImageCard overload — Home / Profile sections) |
| `remix:image-meta` | `Image/Meta/ImageMetaPopoverLazy` + `ImageMeta/ImageMeta` |
| `remix:model-carousel` | `Model/ModelCarousel` |
| `remix:model-gallery` | `Image/AsPosts/ImagesAsPostsCard` |
| `remix:post-image-card` | `Post/Detail/PostImages` |

These strings are stable now; `data-activity` attributes match the `source` field on the corresponding trackAction call (parity audited in commit `6e3a6dad3` — PostImages was the last hold-out: `data-activity` was `remix:image-card` against a `remix:post-image-card` event; now aligned). `create:navbar` is now actually instrumented (commit `6e3a6dad3` — previously documented but never emitted because `CreateMenu` toggled the panel store directly without going through `trackAction` or `generationGraphPanel.open()`). v2 form rate-limit (`formVersion='new' AND isRateLimited=true`) is now covered (commit `97d32a9b3` — previously absent because the v2 SubmitButton bypasses GenForm's canGenerate gate). (Future tightening to `z.enum([...])` deferred — left as `z.string()` to avoid a coupling that would slow down adding new entry-points; will revisit once the data team confirms the set is stable.)

> Note: `Generator_Submit.fromAction` reflects the **most-recent intentful entry**, not the session history. Each open-with-input call (remix click, model-stat click, replay) overwrites the previous value; `close()` resets to `'direct'`; navbar Create now also resets to `'direct'` via the no-input branch. So a user who remixes then pivots to the navbar will see `fromAction='direct'` on the next submit, not `'remix'`.

### Disclosed UI change

`Cards/RemixButton` hover label changed from `'Create'` → conditional `'Remix' | 'Create'` based on input type. The component is overloaded — ImageCard uses it as a remix entry-point (image/video/audio source) while ModelCard uses it as a create entry-point (modelVersion). The previous always-`'Create'` label was misleading on the image side; the new conditional reflects what the button actually does. `data-activity` follows the same discrimination.

### Why now

Once these events are live, the data team can:

- Compute `Model_Create_Click → Generator_Submit` conversion per entry-point.
- Compute `Image_Remix_Click → Generator_Submit` conversion to find click-and-abandon.
- Slice `Generator_Submit` by `isValid` to spot UX traps where users click Generate but the form blocks them.
- Slice `Generator_Submit` by `isRateLimited` to spot capacity-bounded clicks (distinct from validation failures).
- Join `Generator_Submit` (with `isValid=true`) → `orchestration.jobs` via `userId` + ts to spot valid submits that never produce a job (buzz reject, network error).
- Slice the full funnel by `fromAction` to compare remix vs from-scratch generation behavior all the way to purchase / subscription.

### Note on the `remixOfId` leak

The matching observability-gaps panel called out `orchestration.jobs.remixOfId` being ~0% populated (5 of 28M rows in 7d). That leak was already fixed by **#2309** (merged) — `workflow-step` metadata now carries `remixOfId` end-to-end. This PR is click-event-only.

### Regression caught + fixed during review

The 2026-05-26 review caught a critical regression introduced in commit `fa076c41f`: `clearData()` was resetting `lastEntryAction = 'direct'`. All three form providers call `clearData()` immediately after consuming the pending data (at open-time, BEFORE the user clicks Generate), which destroyed the create/remix/replay attribution. Fixed in `0239a13bb` — the reset now lives in `close()` (panel session-end) and the fetch-failure catch in `open()`. `clearData()` only clears the `data` field.

### Third-pass review fixes (post `0239a13bb`)

- `6e3a6dad3` — instrument `create:navbar` (was documented but never emitted, AND was leaking stale `lastEntryAction` across navbar pivots); align `PostImages.tsx` `data-activity` to `remix:post-image-card`.
- `355b3c267` — make `trackValid` guard in `VideoGenerationForm` actually guard. Was previously only flipped inside the catch block AFTER the only read site → dead code that implied protection it didn't provide. Now flipped immediately after each `emitSubmit(...)` call.
- `97d32a9b3` — add `isRateLimited: true` Generator_Submit path to v2 `FormFooter.handleSubmit`. v2 form bypasses GenForm entirely so the legacy rate-limit emit never fired for `formVersion='new'` users.
- `ab4b610e8` — thread `modelId` through `TrainingSelectFile` → `GenerateButton`; drop unused `UseFormReturn` import; document `Generator_Submit.fromAction` semantics in the schema comment.

### Files touched

- `src/server/schema/track.schema.ts` — 3 new discriminated-union variants. `Generator_Submit.details` now has `isValid`, `formVersion`, and `isRateLimited` optional fields.
- `src/server/clickhouse/client.ts` — 3 new `ActionType` allowlist entries.
- `src/store/generation-graph.store.ts` — new `lastEntryAction` marker + `GeneratorEntryAction` type + `toEntryAction(runType)` mapper. Reset lives in `close()` + on fetch failure (NOT in `clearData()`).
- `src/components/RunStrategy/GenerateButton.tsx` — Model_Create_Click + new `modelId` prop.
- `src/components/Cards/components/RemixButton.tsx` — discriminates remix vs create on input type; `source='remix:image-card-home'`. Hover label now `'Remix' | 'Create'`.
- 8 image-remix entry-point components.
- 3 form-submit handlers (`GenerationForm2`, `FormFooter`, `VideoGenerationForm`).
- `src/components/Generation/Form/GenForm.tsx` — rate-limited Generator_Submit emission.
- `src/pages/models/[id]/[[...slug]].tsx` + `ModelVersionDetails.tsx` + `ModelVersionEarlyAccessPurchase.tsx` + `TrainingSelectFile.tsx` — pass `modelId` / `data-activity` through.

## Dashboards that will auto-detect remediation

- `civitai-observability-gaps` -> "Model_Create_Click 7d [MISSING]"
- `civitai-observability-gaps` -> "Image_Remix_Click 7d [MISSING]"
- `civitai-observability-gaps` -> "orchestration.jobs.remixOfId populated % (7d)" (handled by #2309)

## Test plan

- [ ] Click Create on a model page -> check ClickHouse `actions` for `Model_Create_Click` with `modelId`, `modelVersionId`, `source='create:model-stat'`.
- [ ] Click Create on a model card / hover Create on a modelVersion in Cards/ImageCard -> `Model_Create_Click` with `source='create:model-card'`.
- [ ] Click Remix on an image card -> `Image_Remix_Click` with `imageId`, `imageType='image'`, `source='remix:image-card'`.
- [ ] Click Remix on RemixButton inside Cards/ImageCard (Home / Profile) -> `source='remix:image-card-home'`.
- [ ] Click Remix on image detail page -> `Image_Remix_Click` with `source='remix:image'`.
- [ ] Click Remix on ModelCarousel image -> `Image_Remix_Click` with `source='remix:model-carousel'`, `sourceModelVersionId` populated.
- [ ] Click Remix on ImagesAsPostsCard -> `source='remix:model-gallery'`.
- [ ] Click Remix on PostImages -> `source='remix:post-image-card'`.
- [ ] Click Generate after entering via Create -> `Generator_Submit` with `fromAction='create'`, `formVersion='legacy'` (or `'new'`), `isValid=true`.
- [ ] Click Generate with an empty prompt -> `Generator_Submit` with `isValid=false`.
- [ ] Click Generate after entering via Remix -> `Generator_Submit` with `fromAction='remix'`, `hasRemixOfId=true` when similarity passes 0.75 gate.
- [ ] **(Critical regression fix verification)** Click Remix -> form provider consumes data + calls clearData -> click Generate -> `Generator_Submit` STILL fires with `fromAction='remix'` (was destroyed before commit `0239a13bb`).
- [ ] Replay from queue -> `Generator_Submit` with `fromAction='replay'`.
- [ ] Open generator from `/generate` direct -> `Generator_Submit` with `fromAction='direct'`.
- [ ] Click Generate while at request-limit (canGenerate=false) -> `Generator_Submit` with `isRateLimited=true`, `isValid=false`.
- [ ] Click-and-abandon (cancel buzz confirm) -> `Generator_Submit` fires but no `orchestration.jobs` row.
- [ ] Verify v2 form submit fires `Generator_Submit` with `formVersion='new'`.
- [ ] Verify video form submit fires `Generator_Submit` with `formVersion='video'`. RHF-level failure also fires with `isValid=false`.
- [ ] Open panel via Remix, submit valid, close panel, open panel again with no input -> second submit fires with `fromAction='direct'` (close() resets attribution).

Generated with Claude Code

