### PR TITLE
redis: add Sentinel client branch for system Redis (Phase 1, HA migration)

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -18,6 +18,10 @@ DATAPACKET_DATABASE_RO_URL=postgresql://postgres:postgres@localhost:15435/postgr
 # Redis
 REDIS_URL=redis://:redis@localhost:6379
 REDIS_SYS_URL=redis://:redis@localhost:6378
+# Optional: switch the `system` redis client to Sentinel mode. When set, REDIS_SYS_URL
+# is still parsed for credentials but the connection is established via Sentinel.
+# REDIS_SYS_SENTINELS=localhost:26379,localhost:26380,localhost:26381
+# REDIS_SYS_SENTINEL_NAME=mymaster
 
 # Logging
 LOGGING=prisma:error,prisma:warn,seed-metrics-search

--- a/.env-example
+++ b/.env-example
@@ -21,7 +21,7 @@ REDIS_SYS_URL=redis://:redis@localhost:6378
 # Optional: switch the `system` redis client to Sentinel mode. When set, REDIS_SYS_URL
 # is still parsed for credentials but the connection is established via Sentinel.
 # REDIS_SYS_SENTINELS=localhost:26379,localhost:26380,localhost:26381
-# REDIS_SYS_SENTINEL_NAME=mymaster
+# REDIS_SYS_SENTINEL_NAME=sysmaster   # production uses "sysmaster"; match the master group your Sentinel CR declares
 
 # Logging
 LOGGING=prisma:error,prisma:warn,seed-metrics-search

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -176,6 +176,9 @@ vi.mock('~/server/prom/client', () => ({
   appStorageOpsCounter: promMetricStub(),
   appStorageQuotaExceededCounter: promMetricStub(),
   appStorageLatencyHistogram: promMetricStub(),
+  // sysRedis sentinel observability counters (PR #2331 round-3).
+  sysredisSentinelTopologyChangesCounter: promMetricStub(),
+  sysredisSentinelClientErrorsCounter: promMetricStub(),
 }));
 
 // Mock logging

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -45,7 +45,10 @@ export const serverSchema = z.object({
   // pool. See claudedocs/sysredis-ha-migration-runbook.md (datapacket-talos)
   // for the rollout sequence.
   REDIS_SYS_SENTINELS: z.string().optional(), // comma-separated host:port list, e.g. "civitai-app-sysredis-sentinel.civitai-app-sysredis.svc.cluster.local:26379"
-  REDIS_SYS_SENTINEL_NAME: z.string().default('mymaster'), // master group name; set to "sysmaster" at deploy time
+  // Master group name. No default — the cluster uses "sysmaster", and the
+  // historical Sentinel default ("mymaster") would silently fail every lookup.
+  // The superRefine below makes this required whenever REDIS_SYS_SENTINELS is set.
+  REDIS_SYS_SENTINEL_NAME: z.string().optional(),
   REDIS_SYS_SENTINEL_PASSWORD: z.string().optional(), // only set if sentinel-auth is enabled (not initially)
   REDIS_TIMEOUT: z.preprocess((x) => (x ? parseInt(String(x)) : 5000), z.number().optional()),
   // Socket-level inactivity timeout (ms). Passed to node-redis `socket.socketTimeout`,
@@ -490,4 +493,18 @@ export const serverSchema = z.object({
   BUNDLE_S3_BUCKET: z.string().optional(),
   BUNDLE_S3_ACCESS_KEY_ID: z.string().optional(),
   BUNDLE_S3_SECRET_ACCESS_KEY: z.string().optional(),
+}).superRefine((env, ctx) => {
+  // Sentinel-mode for the system Redis client requires an explicit master group
+  // name. The live HA cluster uses `sysmaster`; the node-redis default
+  // (`mymaster`) silently produces a Sentinel that never resolves a master, so
+  // we refuse to start with REDIS_SYS_SENTINELS set but REDIS_SYS_SENTINEL_NAME
+  // missing. The non-sentinel path (REDIS_SYS_URL only) is unaffected.
+  if (env.REDIS_SYS_SENTINELS && !env.REDIS_SYS_SENTINEL_NAME) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['REDIS_SYS_SENTINEL_NAME'],
+      message:
+        'REDIS_SYS_SENTINEL_NAME is required when REDIS_SYS_SENTINELS is set (cluster uses "sysmaster")',
+    });
+  }
 });

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -38,6 +38,15 @@ export const serverSchema = z.object({
   REDIS_CLUSTER_NODES: z.string().optional(), // Comma-separated list of cluster node URLs for redundant discovery
   REDIS_CLUSTER_REFRESH_INTERVAL: z.coerce.number().default(30000), // Topology refresh interval in ms (default 30s)
   REDIS_SYS_URL: z.url(),
+  // Optional Sentinel-mode env vars for the `system` Redis client. When
+  // REDIS_SYS_SENTINELS is unset (default), the existing REDIS_SYS_URL path is
+  // used and behavior is unchanged. When set, src/server/redis/client.ts
+  // switches the system client to `createSentinel(...)` against this Sentinel
+  // pool. See claudedocs/sysredis-ha-migration-runbook.md (datapacket-talos)
+  // for the rollout sequence.
+  REDIS_SYS_SENTINELS: z.string().optional(), // comma-separated host:port list, e.g. "civitai-app-sysredis-sentinel.civitai-app-sysredis.svc.cluster.local:26379"
+  REDIS_SYS_SENTINEL_NAME: z.string().default('mymaster'), // master group name; set to "sysmaster" at deploy time
+  REDIS_SYS_SENTINEL_PASSWORD: z.string().optional(), // only set if sentinel-auth is enabled (not initially)
   REDIS_TIMEOUT: z.preprocess((x) => (x ? parseInt(String(x)) : 5000), z.number().optional()),
   // Socket-level inactivity timeout (ms). Passed to node-redis `socket.socketTimeout`,
   // which maps to net.Socket.setTimeout — an IDLE timer that fires when NO read OR

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -265,6 +265,15 @@ export const redisCommandDuration = registerHistogram({
 (globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
   redisCommandsInflight,
   redisCommandDuration,
+  // PR #2331 round-3: sentinel observability counters. Same bridge pattern so
+  // attachSysSentinelListeners can grab them without dragging prom-client's
+  // fs/cluster requires into the client bundle.
+  get sysredisSentinelTopologyChangesCounter() {
+    return sysredisSentinelTopologyChangesCounter;
+  },
+  get sysredisSentinelClientErrorsCounter() {
+    return sysredisSentinelClientErrorsCounter;
+  },
 };
 
 // Image feed metrics
@@ -370,6 +379,44 @@ export const appStorageLatencyHistogram = registerHistogramWithLabels({
   help: 'App Blocks KV procedure latency',
   labelNames: ['op'] as const,
   buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5],
+});
+
+// sysRedis Sentinel observability — Phase 4 cutover SRE-on-call uses these to
+// distinguish a real failover from steady-state sentinel chatter. Cardinality:
+// `type` is a small enum (master-change, +switch-master, etc.), `host` is bounded
+// by the sentinel/master/replica pod count (~3-6), `deployment` is per-pod (same
+// shape as Prometheus's own `pod` label).
+//
+// Override the PROM_PREFIX so the name maps to `civitai_sysredis_*` (matches the
+// dashboard naming requested in the audit) rather than `civitai_app_*`.
+const SYSREDIS_PREFIX = 'civitai_sysredis_';
+function registerSysredisCounter<T extends string>({
+  name,
+  help,
+  labelNames,
+}: {
+  name: string;
+  help: string;
+  labelNames: readonly T[];
+}) {
+  // HMR-safe registration (see registerCounterWithLabels above).
+  try {
+    return new client.Counter({ name: SYSREDIS_PREFIX + name, help, labelNames });
+  } catch (e) {
+    return client.register.getSingleMetric(SYSREDIS_PREFIX + name) as Counter<T>;
+  }
+}
+
+export const sysredisSentinelTopologyChangesCounter = registerSysredisCounter({
+  name: 'sentinel_topology_changes_total',
+  help: 'sysRedis sentinel topology-change events (failover, sentinel-set change, etc.)',
+  labelNames: ['type', 'host', 'deployment'] as const,
+});
+
+export const sysredisSentinelClientErrorsCounter = registerSysredisCounter({
+  name: 'sentinel_client_errors_total',
+  help: 'sysRedis sentinel sub-client errors (per-pod TCP/protocol errors against masters/replicas)',
+  labelNames: ['type', 'host', 'deployment'] as const,
 });
 
 // pgPoolAcquireHistogram is registered in src/server/db/db-helpers.ts, not here.

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -253,28 +253,14 @@ export const redisCommandDuration = registerHistogram({
   buckets: [0.001, 0.005, 0.025, 0.1, 0.5, 1, 2, 5, 10, 30],
 });
 
-// Bridge the redis metric handles to '~/server/redis/client' via globalThis,
-// WITHOUT that module statically importing this one. redis/client.ts is
-// client-bundle-reachable (`_app.tsx` → `system-cache.ts` → redis/client.ts) and
-// prom-client eagerly requires `fs`/`cluster` at load (defaultMetrics + cluster
-// aggregator), so a static `redis/client → prom/client` import edge breaks the
-// pages-router client webpack build. This module only ever loads server-side
-// (imported by trpc/api routes/instrumentation at startup), so publishing here is
-// safe and is in place before any real redis command runs. instrumentCommands()
-// reads `globalThis.__civitaiRedisMetrics` at command time.
-(globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
-  redisCommandsInflight,
-  redisCommandDuration,
-  // PR #2331 round-3: sentinel observability counters. Same bridge pattern so
-  // attachSysSentinelListeners can grab them without dragging prom-client's
-  // fs/cluster requires into the client bundle.
-  get sysredisSentinelTopologyChangesCounter() {
-    return sysredisSentinelTopologyChangesCounter;
-  },
-  get sysredisSentinelClientErrorsCounter() {
-    return sysredisSentinelClientErrorsCounter;
-  },
-};
+// The bridge to '~/server/redis/client' via globalThis.__civitaiRedisMetrics is
+// published below, AFTER the sysredisSentinel* counters are declared (search for
+// "__civitaiRedisMetrics ="). Placing it there lets us capture all four counter
+// values directly instead of behind getters — a getter that fired during
+// top-level eval (before the const declarations executed) would throw a
+// ReferenceError that the no-op fallback at the call site (optional chaining)
+// does NOT catch. No eager reader exists today; the bridge is consumed only
+// from function bodies in redis/client.ts at command/connect time.
 
 // Image feed metrics
 export const imagesFeedWithoutIndexCounter = registerCounter({
@@ -418,6 +404,27 @@ export const sysredisSentinelClientErrorsCounter = registerSysredisCounter({
   help: 'sysRedis sentinel sub-client errors (per-pod TCP/protocol errors against masters/replicas)',
   labelNames: ['type', 'host', 'deployment'] as const,
 });
+
+// Bridge the redis metric handles to '~/server/redis/client' via globalThis,
+// WITHOUT that module statically importing this one. redis/client.ts is
+// client-bundle-reachable (`_app.tsx` → `system-cache.ts` → redis/client.ts) and
+// prom-client eagerly requires `fs`/`cluster` at load (defaultMetrics + cluster
+// aggregator), so a static `redis/client → prom/client` import edge breaks the
+// pages-router client webpack build. This module only ever loads server-side
+// (imported by trpc/api routes/instrumentation at startup), so publishing here is
+// safe and is in place before any real redis command runs. instrumentCommands()
+// and attachSysSentinelListeners read `globalThis.__civitaiRedisMetrics` at
+// command/connect time.
+//
+// Placed AFTER all four counters declare so no getter indirection is needed
+// (and no TDZ surface — a getter that fires during top-level eval would throw
+// ReferenceError, which the no-op fallback at the call site does NOT catch).
+(globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
+  redisCommandsInflight,
+  redisCommandDuration,
+  sysredisSentinelTopologyChangesCounter,
+  sysredisSentinelClientErrorsCounter,
+};
 
 // pgPoolAcquireHistogram is registered in src/server/db/db-helpers.ts, not here.
 // Defining it here would create a module-init cycle (prom/client.ts imports

--- a/src/server/redis/__tests__/client.test.ts
+++ b/src/server/redis/__tests__/client.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The `redis` npm package opens TCP sockets at module load via getCacheClient()
+// at the bottom of client.ts. Stub the three factories to no-op event emitters
+// so the import is safe in the test environment.
+vi.mock('redis', () => {
+  const noopClient = () => {
+    const handlers: Record<string, Array<(...args: any[]) => void>> = {};
+    const client: any = {
+      on(event: string, cb: (...args: any[]) => void) {
+        (handlers[event] ??= []).push(cb);
+        return client;
+      },
+      connect: vi.fn(() => Promise.resolve()),
+      withTypeMapping: vi.fn(() => client),
+      // SCAN/COMMANDS exist as empty stubs — they're only invoked at runtime
+      // by code paths the listener tests don't touch.
+      scan: vi.fn(),
+      mGet: vi.fn(),
+      del: vi.fn(),
+      unlink: vi.fn(),
+    };
+    return client;
+  };
+  return {
+    createClient: vi.fn(noopClient),
+    createCluster: vi.fn(noopClient),
+    createSentinel: vi.fn(noopClient),
+    RESP_TYPES: { BLOB_STRING: 'BLOB_STRING' },
+  };
+});
+
+// Block resource-data / Flipt imports from running real-network init.
+vi.mock('~/server/flipt/client', () => ({
+  FLIPT_FEATURE_FLAGS: { REDIS_CLUSTER_ENHANCED_FAILOVER: 'redis_cluster_enhanced_failover' },
+  isFlipt: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { attachSysSentinelListeners } from '~/server/redis/client';
+
+/**
+ * Round-3 audit fix coverage:
+ *  - Listener wiring: attachSysSentinelListeners attaches both topology-change
+ *    and client-error handlers to the underlying client.
+ *  - Log shape: the destructured event.node.{host,port} fields appear in the
+ *    log string as bracketed key=value pairs so Loki regex can extract them.
+ *  - Counter increments: each event fires exactly one .inc() against the
+ *    correct counter with {type, host, deployment} labels.
+ *  - Null-safety: a missing event.node still produces a sensible '?' placeholder
+ *    log line and a 'unknown'/'?' label set (no crash, no NaN labels).
+ */
+
+type Handler = (event: any) => void;
+
+function makeFakeSentinel() {
+  const handlers = new Map<string, Handler>();
+  const on = vi.fn((event: string, listener: Handler) => {
+    handlers.set(event, listener);
+  });
+  return {
+    client: { on },
+    on,
+    emit(event: string, payload: any) {
+      const handler = handlers.get(event);
+      if (!handler) throw new Error(`No handler registered for ${event}`);
+      handler(payload);
+    },
+    handlers,
+  };
+}
+
+function makeFakeCounter() {
+  const inc = vi.fn();
+  const labels = vi.fn(() => ({ inc }));
+  return { labels, inc };
+}
+
+function makeCtx(deployment = 'civitai-dp-prod-primary-abc123') {
+  const log = vi.fn();
+  const topologyCounter = makeFakeCounter();
+  const errorCounter = makeFakeCounter();
+  return {
+    deployment,
+    log,
+    topologyCounter,
+    errorCounter,
+  };
+}
+
+describe('attachSysSentinelListeners', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listener wiring', () => {
+    it('attaches handlers for both topology-change and client-error', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      expect(sentinel.on).toHaveBeenCalledTimes(2);
+      expect(sentinel.on).toHaveBeenCalledWith('topology-change', expect.any(Function));
+      expect(sentinel.on).toHaveBeenCalledWith('client-error', expect.any(Function));
+      expect(sentinel.handlers.has('topology-change')).toBe(true);
+      expect(sentinel.handlers.has('client-error')).toBe(true);
+    });
+
+    it('does not attach any other listeners (no surprise side effects)', () => {
+      const sentinel = makeFakeSentinel();
+      attachSysSentinelListeners(sentinel.client, makeCtx());
+      // Exactly the two we expect — guards against drift adding a third
+      // listener with mismatched label cardinality.
+      expect(sentinel.handlers.size).toBe(2);
+    });
+  });
+
+  describe('log shape — topology-change', () => {
+    it('renders host, port, and type as bracketed key=value pairs', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      sentinel.emit('topology-change', {
+        type: 'master-change',
+        node: { host: '10.244.1.5', port: 6379 },
+      });
+
+      expect(ctx.log).toHaveBeenCalledTimes(1);
+      const msg = ctx.log.mock.calls[0]?.[0] as string;
+      expect(msg).toContain('Redis sentinel topology change');
+      expect(msg).toContain('type=master-change');
+      expect(msg).toContain('host=10.244.1.5');
+      expect(msg).toContain('port=6379');
+    });
+
+    it('passes the raw event through as a trailing log argument', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      const event = { type: 'master-change', node: { host: 'h', port: 1 }, extra: 'detail' };
+      sentinel.emit('topology-change', event);
+
+      // First arg = string, second arg = original event (preserves the
+      // existing pattern in client.ts of passing the full payload through).
+      expect(ctx.log.mock.calls[0]?.[1]).toBe(event);
+    });
+  });
+
+  describe('log shape — client-error', () => {
+    it('renders host, port, and type as bracketed key=value pairs', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      sentinel.emit('client-error', {
+        type: 'master',
+        node: { host: '10.244.2.7', port: 6379 },
+        error: new Error('ECONNRESET'),
+      });
+
+      expect(ctx.log).toHaveBeenCalledTimes(1);
+      const msg = ctx.log.mock.calls[0]?.[0] as string;
+      expect(msg).toContain('Redis sentinel sub-client error');
+      expect(msg).toContain('type=master');
+      expect(msg).toContain('host=10.244.2.7');
+      expect(msg).toContain('port=6379');
+    });
+
+    it('prefers event.error over the raw event for the trailing log argument', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      const error = new Error('ETIMEDOUT');
+      sentinel.emit('client-error', {
+        type: 'replica',
+        node: { host: 'h', port: 1 },
+        error,
+      });
+
+      // Loki + alert routing reads the trailing arg; error gives us stack info.
+      expect(ctx.log.mock.calls[0]?.[1]).toBe(error);
+    });
+  });
+
+  describe('counter increments', () => {
+    it('increments the topology counter with {type, host, deployment}', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx('civitai-dp-prod-primary-xyz');
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      sentinel.emit('topology-change', {
+        type: 'master-change',
+        node: { host: '10.244.1.5', port: 6379 },
+      });
+
+      expect(ctx.topologyCounter.labels).toHaveBeenCalledTimes(1);
+      expect(ctx.topologyCounter.labels).toHaveBeenCalledWith({
+        type: 'master-change',
+        host: '10.244.1.5',
+        deployment: 'civitai-dp-prod-primary-xyz',
+      });
+      expect(ctx.topologyCounter.inc).toHaveBeenCalledTimes(1);
+      // The error counter is untouched.
+      expect(ctx.errorCounter.labels).not.toHaveBeenCalled();
+    });
+
+    it('increments the error counter with {type, host, deployment}', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx('civitai-dp-prod-api-abc');
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      sentinel.emit('client-error', {
+        type: 'master',
+        node: { host: '10.244.2.7', port: 6379 },
+        error: new Error('ECONNRESET'),
+      });
+
+      expect(ctx.errorCounter.labels).toHaveBeenCalledTimes(1);
+      expect(ctx.errorCounter.labels).toHaveBeenCalledWith({
+        type: 'master',
+        host: '10.244.2.7',
+        deployment: 'civitai-dp-prod-api-abc',
+      });
+      expect(ctx.errorCounter.inc).toHaveBeenCalledTimes(1);
+      expect(ctx.topologyCounter.labels).not.toHaveBeenCalled();
+    });
+
+    it('increments once per event, not once per listener (no double-counting)', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      sentinel.emit('topology-change', {
+        type: 'master-change',
+        node: { host: 'h', port: 1 },
+      });
+      sentinel.emit('topology-change', {
+        type: '+switch-master',
+        node: { host: 'h', port: 1 },
+      });
+
+      expect(ctx.topologyCounter.inc).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('null-safety', () => {
+    it('handles an event with no node (topology-change)', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      // No throw on missing node — the destructure has to be guarded.
+      expect(() => sentinel.emit('topology-change', { type: 'sentinel-change' })).not.toThrow();
+
+      const msg = ctx.log.mock.calls[0]?.[0] as string;
+      expect(msg).toContain('host=?');
+      expect(msg).toContain('port=?');
+      expect(msg).toContain('type=sentinel-change');
+
+      expect(ctx.topologyCounter.labels).toHaveBeenCalledWith({
+        type: 'sentinel-change',
+        host: '?',
+        deployment: expect.any(String),
+      });
+      expect(ctx.topologyCounter.inc).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles an event with no node (client-error)', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      expect(() =>
+        sentinel.emit('client-error', { type: 'sentinel', error: new Error('boom') })
+      ).not.toThrow();
+
+      const msg = ctx.log.mock.calls[0]?.[0] as string;
+      expect(msg).toContain('host=?');
+      expect(msg).toContain('port=?');
+
+      expect(ctx.errorCounter.labels).toHaveBeenCalledWith({
+        type: 'sentinel',
+        host: '?',
+        deployment: expect.any(String),
+      });
+      expect(ctx.errorCounter.inc).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles a completely empty event ({}) without crashing', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      expect(() => sentinel.emit('topology-change', {})).not.toThrow();
+      expect(() => sentinel.emit('client-error', {})).not.toThrow();
+
+      // Both counters still fire so we don't silently lose error events to
+      // null-pointer guards.
+      expect(ctx.topologyCounter.inc).toHaveBeenCalledTimes(1);
+      expect(ctx.errorCounter.inc).toHaveBeenCalledTimes(1);
+
+      // The "unknown" type fallback IS the cardinality-budget escape valve.
+      expect(ctx.topologyCounter.labels).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'unknown', host: '?' })
+      );
+      expect(ctx.errorCounter.labels).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'unknown', host: '?' })
+      );
+    });
+
+    it('handles a null event without crashing', () => {
+      const sentinel = makeFakeSentinel();
+      const ctx = makeCtx();
+      attachSysSentinelListeners(sentinel.client, ctx);
+
+      expect(() => sentinel.emit('topology-change', null)).not.toThrow();
+      expect(() => sentinel.emit('client-error', null)).not.toThrow();
+      expect(ctx.topologyCounter.inc).toHaveBeenCalledTimes(1);
+      expect(ctx.errorCounter.inc).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -321,7 +321,9 @@ function getBaseClient(type: 'cache' | 'system') {
 
   const baseClient = isSysSentinel
     ? createSentinel({
-        name: env.REDIS_SYS_SENTINEL_NAME,
+        // Non-null assertion is safe: server-schema's superRefine rejects boot
+        // when REDIS_SYS_SENTINELS is set without REDIS_SYS_SENTINEL_NAME.
+        name: env.REDIS_SYS_SENTINEL_NAME!,
         sentinelRootNodes: env.REDIS_SYS_SENTINELS!.split(',').map((hp) => {
           const [host, port] = hp.trim().split(':');
           return { host, port: parseInt(port ?? '26379', 10) };
@@ -338,7 +340,10 @@ function getBaseClient(type: 'cache' | 'system') {
         masterPoolSize: 1,
         replicaPoolSize: 0,
         scanInterval: 10_000,
-        passthroughClientErrorEvents: true,
+        // Keep sub-client errors local — surfacing them here would flood the
+        // top-level `error` listener whenever a single sentinel/replica pod
+        // flaps. We log them explicitly via the `client-error` listener below.
+        passthroughClientErrorEvents: false,
         reserveClient: false,
       })
     : isCluster
@@ -366,6 +371,18 @@ function getBaseClient(type: 'cache' | 'system') {
   baseClient.on('connect', () => log(`Redis connected (${type})`));
   baseClient.on('reconnecting', () => log(`Redis reconnecting (${type})`));
   baseClient.on('ready', () => log(`Redis ready! (${type})`));
+
+  // Sentinel clients don't emit connect/reconnecting/ready — they expose
+  // topology-change (master/replica/sentinel set changed) and client-error
+  // (a sub-client errored). Surface both so failovers are visible in Loki.
+  if (isSysSentinel) {
+    baseClient.on('topology-change', (event: unknown) => {
+      log(`Redis sentinel topology change (${type})`, event);
+    });
+    baseClient.on('client-error', (event: unknown) => {
+      log(`Redis sentinel sub-client error (${type})`, event);
+    });
+  }
 
   // Cluster-specific event handlers for failover detection
   // Enhanced failover handling is gated behind FLIPT_FEATURE_FLAGS.REDIS_CLUSTER_ENHANCED_FAILOVER
@@ -756,14 +773,22 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
   };
 
   // Implement scanIterator for cluster - it doesn't exist natively on RedisCluster
-  // We need to scan each master node and yield results from all of them
+  // For Sentinel, scanIterator is also absent (the JS-only helper lives on
+  // RedisClient, not the Sentinel proxy); we replicate its scan loop manually
+  // using SCAN, which IS proxied to the current master.
   const baseClient = client as any;
 
-  // Save reference to the original scanIterator (exists on single client, not on cluster)
+  // Save reference to the original scanIterator (exists on single client only,
+  // not on cluster, not on sentinel).
   const originalScanIterator = baseClient.scanIterator?.bind(baseClient);
 
+  // Detect sentinel mode: the Sentinel proxy exposes getMasterNode but not
+  // scanIterator. Cluster exposes .masters. Single client exposes scanIterator.
+  const isSentinelClient =
+    typeof baseClient.getMasterNode === 'function' &&
+    typeof baseClient.scanIterator !== 'function';
+
   client.scanIterator = async function* (options) {
-    // Check if this is a cluster client (has masters property)
     if (baseClient.masters) {
       // Cluster mode: iterate through all master nodes
       const masters = await baseClient.masters;
@@ -771,6 +796,16 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
         const nodeClient = await baseClient.nodeClient(master);
         yield* nodeClient.scanIterator(options);
       }
+    } else if (isSentinelClient) {
+      // Sentinel mode: drive SCAN directly against the proxy. SCAN is part of
+      // the COMMANDS map and is routed to the master client lease, so this
+      // works without needing to borrow a raw client via .use(...).
+      let cursor = options?.cursor ?? '0';
+      do {
+        const reply = await baseClient.scan(cursor, options);
+        cursor = reply.cursor;
+        yield reply.keys;
+      } while (cursor !== '0');
     } else {
       // Single node mode: use original native scanIterator
       yield* originalScanIterator(options);

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -14,8 +14,8 @@ import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 // cluster aggregator), which the pages-router client webpack build cannot resolve
 // → "Module not found: Can't resolve 'cluster'/'fs'". The metrics are defined and
 // registered server-side in `~/server/prom/client` and published on `globalThis`
-// (`__civitaiRedisMetrics`); `instrumentCommands` reads that handle at command time
-// (server runtime only). See getRedisMetrics() below.
+// (`__civitaiRedisMetrics`); `instrumentCommands` and the sentinel listener attach
+// read that handle at runtime (server-only). See getRedisMetrics() below.
 
 export type RedisKeyStringsCache = Values<typeof REDIS_KEYS>;
 export type RedisKeyStringsSys = Values<typeof REDIS_SYS_KEYS>;
@@ -234,6 +234,61 @@ function triggerTopologyRediscovery(clusterClient: any, reason: string) {
 }
 
 /**
+ * Attach `topology-change` and `client-error` listeners to a Sentinel client.
+ *
+ * Extracted so it can be unit-tested without booting the full redis-client
+ * module (which pulls in prom/db init). Both listeners destructure
+ * event.node.{host,port} into a square-bracketed key/value list so Loki regex
+ * can extract per-pod identifiers, and increment per-event Prometheus counters
+ * labeled {type, host, deployment}.
+ *
+ * `deployment` is the running pod's HOSTNAME env (matches Prometheus's `pod`
+ * label); falls back to 'unknown' off-cluster.
+ */
+export function attachSysSentinelListeners(
+  client: { on: (event: string, listener: (e: any) => void) => unknown },
+  ctx: {
+    deployment: string;
+    log: (msg: string, ...rest: unknown[]) => void;
+    topologyCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
+    errorCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
+  }
+) {
+  client.on('topology-change', (event: any) => {
+    const { type: eventType, node } = event ?? {};
+    const host = node?.host ?? '?';
+    const port = node?.port ?? '?';
+    ctx.log(
+      `Redis sentinel topology change [type=${eventType ?? 'unknown'}, host=${host}, port=${port}]`,
+      event
+    );
+    ctx.topologyCounter
+      .labels({
+        type: String(eventType ?? 'unknown'),
+        host: String(host),
+        deployment: ctx.deployment,
+      })
+      .inc();
+  });
+  client.on('client-error', (event: any) => {
+    const { type: eventType, node, error } = event ?? {};
+    const host = node?.host ?? '?';
+    const port = node?.port ?? '?';
+    ctx.log(
+      `Redis sentinel sub-client error [type=${eventType ?? 'unknown'}, host=${host}, port=${port}]`,
+      error ?? event
+    );
+    ctx.errorCounter
+      .labels({
+        type: String(eventType ?? 'unknown'),
+        host: String(host),
+        deployment: ctx.deployment,
+      })
+      .inc();
+  });
+}
+
+/**
  * Parse cluster node URLs from environment variable.
  * Falls back to single URL if REDIS_CLUSTER_NODES is not set.
  */
@@ -342,7 +397,12 @@ function getBaseClient(type: 'cache' | 'system') {
         sentinelClientOptions: env.REDIS_SYS_SENTINEL_PASSWORD
           ? { password: env.REDIS_SYS_SENTINEL_PASSWORD, socket: socketConfig }
           : { socket: socketConfig },
-        masterPoolSize: 1,
+        // Pool size 2 (not 1) so the periodic PING heartbeat can run on a
+        // separate TCP connection from in-flight writes. With pool size 1, a
+        // slow EVAL (see PR #2332's atomic helper) head-of-line blocks the
+        // heartbeat, which can trip the kubelet readiness probe during normal
+        // load spikes.
+        masterPoolSize: 2,
         replicaPoolSize: 0,
         scanInterval: 10_000,
         // Keep sub-client errors local — surfacing them here would flood the
@@ -379,13 +439,24 @@ function getBaseClient(type: 'cache' | 'system') {
 
   // Sentinel clients don't emit connect/reconnecting/ready — they expose
   // topology-change (master/replica/sentinel set changed) and client-error
-  // (a sub-client errored). Surface both so failovers are visible in Loki.
+  // (a sub-client errored). Surface both so failovers are visible in Loki and
+  // queryable per-pod, and increment Prometheus counters alongside so Grafana
+  // can graph + alert. See attachSysSentinelListeners for the log/label shape.
   if (isSysSentinel) {
-    baseClient.on('topology-change', (event: unknown) => {
-      log(`Redis sentinel topology change (${type})`, event);
-    });
-    baseClient.on('client-error', (event: unknown) => {
-      log(`Redis sentinel sub-client error (${type})`, event);
+    // Look up the counters via the globalThis bridge instead of a static import
+    // — prom-client requires fs/cluster which breaks the client webpack bundle.
+    // By the time getBaseClient runs at server startup, '~/server/prom/client'
+    // has already loaded and populated the bridge. Fall back to no-op stubs in
+    // the off-chance the bridge isn't populated yet (logs still flow to Loki).
+    const metrics = getRedisMetrics();
+    const noopCounter = { labels: () => ({ inc: () => undefined }) };
+    attachSysSentinelListeners(baseClient, {
+      // process.env.HOSTNAME is the pod name in Kubernetes (matches the
+      // Prometheus `pod` label). Fall back to 'unknown' off-cluster.
+      deployment: process.env.HOSTNAME ?? 'unknown',
+      log,
+      topologyCounter: metrics?.sysredisSentinelTopologyChangesCounter ?? noopCounter,
+      errorCounter: metrics?.sysredisSentinelClientErrorsCounter ?? noopCounter,
     });
   }
 
@@ -572,6 +643,11 @@ function getBaseClient(type: 'cache' | 'system') {
 type RedisMetricsBridge = {
   redisCommandsInflight: { inc: (labels: { client: string }) => void; dec: (labels: { client: string }) => void };
   redisCommandDuration: { observe: (labels: { client: string }, value: number) => void };
+  // PR #2331 round-3: sentinel observability counters, exposed via the same
+  // bridge to avoid a static prom-client import edge in this client-bundle-
+  // reachable module. attachSysSentinelListeners reads them at attach time.
+  sysredisSentinelTopologyChangesCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
+  sysredisSentinelClientErrorsCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
 };
 
 // Server-runtime lookup of the prom metric handles WITHOUT a static import edge

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1,7 +1,7 @@
 import chunk from 'lodash-es/chunk';
 import { pack, unpack } from 'msgpackr';
 import type { RedisClientType, SetOptions } from 'redis';
-import { createClient, createCluster } from 'redis';
+import { createClient, createCluster, createSentinel } from 'redis';
 import { RESP_TYPES } from 'redis';
 import { isProd } from '~/env/other';
 import { env } from '~/env/server';
@@ -313,11 +313,35 @@ function getBaseClient(type: 'cache' | 'system') {
     `Redis ping interval (${type}) = ${pingInterval}ms (env REDIS_PING_INTERVAL_MS=${env.REDIS_PING_INTERVAL_MS}, socketTimeout=${socketTimeoutMs}ms)`
   );
 
-  // System redis is always a single node
+  // System redis is always a single node (or — when REDIS_SYS_SENTINELS is set —
+  // a Sentinel-discovered HA topology). See claudedocs/sysredis-ha-migration-runbook.md.
   // Cache redis can be either cluster or single node based on env.REDIS_CLUSTER
   const isCluster = type === 'cache' && env.REDIS_CLUSTER;
+  const isSysSentinel = type === 'system' && !!env.REDIS_SYS_SENTINELS;
 
-  const baseClient = isCluster
+  const baseClient = isSysSentinel
+    ? createSentinel({
+        name: env.REDIS_SYS_SENTINEL_NAME,
+        sentinelRootNodes: env.REDIS_SYS_SENTINELS!.split(',').map((hp) => {
+          const [host, port] = hp.trim().split(':');
+          return { host, port: parseInt(port ?? '26379', 10) };
+        }),
+        nodeClientOptions: {
+          // Reuse the password that's already extracted from REDIS_SYS_URL —
+          // the new HA cluster is provisioned with the same secret.
+          password: authConfig.password,
+          socket: socketConfig,
+        },
+        sentinelClientOptions: env.REDIS_SYS_SENTINEL_PASSWORD
+          ? { password: env.REDIS_SYS_SENTINEL_PASSWORD, socket: socketConfig }
+          : { socket: socketConfig },
+        masterPoolSize: 1,
+        replicaPoolSize: 0,
+        scanInterval: 10_000,
+        passthroughClientErrorEvents: true,
+        reserveClient: false,
+      })
+    : isCluster
     ? createCluster({
         // Use multiple root nodes for redundant topology discovery
         rootNodes: parseClusterNodes(connectionUrl),

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -333,6 +333,11 @@ function getBaseClient(type: 'cache' | 'system') {
           // the new HA cluster is provisioned with the same secret.
           password: authConfig.password,
           socket: socketConfig,
+          // Match the standalone path's PING heartbeat. Sentinel sub-clients
+          // are long-lived against each master/replica pod; without this, an
+          // idle connection through any intermediate LB or rolling-update of a
+          // sentinel pod can silently expire.
+          pingInterval,
         },
         sentinelClientOptions: env.REDIS_SYS_SENTINEL_PASSWORD
           ? { password: env.REDIS_SYS_SENTINEL_PASSWORD, socket: socketConfig }


### PR DESCRIPTION
## Summary
- Add an optional `createSentinel(...)` branch for the `system` Redis client, gated on a new optional `REDIS_SYS_SENTINELS` env var. Falls back to the existing `REDIS_SYS_URL` path when unset — zero behavior change in current deployments.
- Unblocks the Phase 4 cutover of the sysRedis HA migration. The new HA cluster (`civitai-app-sysredis` namespace on datapacket-talos) is already live and healthy with 3 redis + 3 sentinel pods across 3 nodes.
- Reuses the password already extracted from `REDIS_SYS_URL` (`authConfig.password`) so no separate `REDIS_SYS_PASSWORD` env var is needed — infra-side cluster is provisioned with the same secret.

## When the new path activates
Set per-pool at deploy time:
- `REDIS_SYS_SENTINELS=civitai-app-sysredis-sentinel.civitai-app-sysredis.svc.cluster.local:26379`
- `REDIS_SYS_SENTINEL_NAME=sysmaster`

## Not in this PR
Phase 1.5 (atomic HEXPIRE NX helper for the 6 `hSet`+`hExpire` race-prone pairs) and Phase 1.6 (in-memory cache / rate cap on `getOrchestratorToken`'s cold-mint path) are pre-HA-cutover hard prereqs, tracked separately to keep this PR small and verifiable.

## Test plan
- [x] `tsc --noEmit` is clean on `client.ts` and `server-schema.ts` (the 937 errors elsewhere in trunk are pre-existing Prisma in-flight noise)
- [ ] Without `REDIS_SYS_SENTINELS` set: existing `REDIS_SYS_URL` path is used; no behavior change in dev / preview
- [ ] With `REDIS_SYS_SENTINELS` set against a local docker-compose Sentinel stack: `ping()` + `hGet('system:permissions', '...')` succeed
- [ ] Kill the primary container in the local stack: client reconnects within `scanInterval` (10s) and routes to the promoted replica

## Refs
- Runbook: `datapacket-talos/claudedocs/sysredis-ha-migration-runbook.md` §Phase 1
- Operator-discovery: `datapacket-talos/claudedocs/sysredis-operator-discovery-2026-05-18.md`
- Handoff: `datapacket-talos/claudedocs/sysredis-ha-handoff-2026-05-27.md`
- Infra commits: `datapacket-talos@4fa1ff417` → `77fba892b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)