### PR TITLE
orchestrator: in-memory cache + coalescing on cold-mint token path (Phase 1.6, HA migration prereq)

### DIFF
--- a/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
+++ b/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Coverage for orchestrator-token-cache. Specifically validates the two
+ * properties this module exists to provide:
+ *
+ *   1. Cache hit: a second call for the same userId within the TTL window
+ *      does not invoke the mint function.
+ *
+ *   2. In-flight coalescing: N concurrent first-time calls for the same
+ *      userId invoke the mint function exactly once. This is the
+ *      thundering-herd protection during a sysRedis failover; without
+ *      coalescing the LRU alone would leave a race window wide enough
+ *      to fire N DB INSERTs.
+ *
+ * Mocks `~/server/prom/client` to avoid pulling the global prom registry
+ * (which would error on duplicate registration across vitest workers).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+}));
+
+import { __testing, getOrMintCachedToken } from '../orchestrator-token-cache';
+
+describe('orchestrator-token-cache', () => {
+  beforeEach(() => {
+    __testing.clear();
+  });
+
+  afterEach(() => {
+    __testing.clear();
+  });
+
+  it('coalesces N concurrent same-user requests into a single mint call', async () => {
+    let mintCalls = 0;
+    const mint = vi.fn(async () => {
+      mintCalls += 1;
+      // Simulate DB latency so all 10 callers enter inflight before resolve.
+      await new Promise((r) => setTimeout(r, 10));
+      return `token-${mintCalls}`;
+    });
+
+    const userId = 42;
+    const N = 10;
+    const results = await Promise.all(
+      Array.from({ length: N }, () => getOrMintCachedToken(userId, mint))
+    );
+
+    expect(mintCalls).toBe(1);
+    expect(mint).toHaveBeenCalledTimes(1);
+    // All callers got the same token (the one mint-result was shared).
+    expect(new Set(results).size).toBe(1);
+    expect(results[0]).toBe('token-1');
+  });
+
+  it('serves repeat calls from cache without re-minting', async () => {
+    const mint = vi.fn(async () => 'cached-token');
+    const userId = 7;
+
+    const first = await getOrMintCachedToken(userId, mint);
+    const second = await getOrMintCachedToken(userId, mint);
+    const third = await getOrMintCachedToken(userId, mint);
+
+    expect(mint).toHaveBeenCalledTimes(1);
+    expect(first).toBe('cached-token');
+    expect(second).toBe('cached-token');
+    expect(third).toBe('cached-token');
+  });
+
+  it('mints independently for different userIds (no cross-user collision)', async () => {
+    let counter = 0;
+    const mint = vi.fn(async () => `token-${++counter}`);
+
+    const [a, b, c] = await Promise.all([
+      getOrMintCachedToken(1, mint),
+      getOrMintCachedToken(2, mint),
+      getOrMintCachedToken(3, mint),
+    ]);
+
+    expect(mint).toHaveBeenCalledTimes(3);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+
+  it('clears the in-flight slot on rejection so future calls can retry', async () => {
+    let attempt = 0;
+    const mint = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('transient db blip');
+      return 'recovered-token';
+    });
+
+    const userId = 99;
+    await expect(getOrMintCachedToken(userId, mint)).rejects.toThrow('transient db blip');
+    // Second call must NOT be wedged behind the rejected promise.
+    const recovered = await getOrMintCachedToken(userId, mint);
+    expect(recovered).toBe('recovered-token');
+    expect(mint).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
+++ b/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
@@ -83,6 +83,32 @@ describe('orchestrator-token-cache', () => {
     expect(new Set([a, b, c]).size).toBe(3);
   });
 
+  it('__testing.destroy() drops cache + inflight and leaves the module re-usable', async () => {
+    // Round-4 audit fix: `destroy()` is the HMR-safety / test-isolation
+    // hook that drops every entry in the LRUCache (and cancels the
+    // per-entry ttlAutopurge setTimeouts that anchor the cache instance
+    // reachable past intent). Verify it (a) clears cache size, (b)
+    // clears inflight, and (c) leaves the module usable for subsequent
+    // calls (it is NOT a destructive teardown — production code must
+    // never call this, but if it did the module must not be broken).
+    const mintA = vi.fn(async () => 'token-a');
+    await getOrMintCachedToken(1, mintA);
+    expect(__testing.size()).toEqual({ cache: 1, inflight: 0 });
+
+    __testing.destroy();
+    expect(__testing.size()).toEqual({ cache: 0, inflight: 0 });
+
+    // Module remains usable after destroy: a fresh call mints + caches
+    // again. This is the property that makes destroy() safe to call from
+    // both HMR-cleanup and the afterEach hook in the env-driven block
+    // below — neither path wants a one-shot teardown.
+    const mintB = vi.fn(async () => 'token-b');
+    const result = await getOrMintCachedToken(2, mintB);
+    expect(result).toBe('token-b');
+    expect(mintB).toHaveBeenCalledTimes(1);
+    expect(__testing.size()).toEqual({ cache: 1, inflight: 0 });
+  });
+
   it('clears the in-flight slot on rejection so future calls can retry', async () => {
     let attempt = 0;
     const mint = vi.fn(async () => {
@@ -107,7 +133,18 @@ describe('orchestrator-token-cache', () => {
 describe('orchestrator-token-cache — env-driven module init', () => {
   const ORIGINAL_ENV = { ...process.env };
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Drop the prior module instance's LRUCache + inflight before the
+    // next dynamic-import test. Without this, each `vi.resetModules()`
+    // leaves a ttlAutopurge-timer-anchored LRUCache reachable until its
+    // 50ms TTL drains — the round-4 audit measured ~6 leaked instances
+    // across this describe block.
+    try {
+      const mod = await import('../orchestrator-token-cache');
+      mod.__testing.destroy();
+    } catch {
+      /* ignore — the module may not have loaded for this test */
+    }
     // Restore env so subsequent tests/suites see a clean slate.
     process.env = { ...ORIGINAL_ENV };
     vi.resetModules();
@@ -201,13 +238,13 @@ describe('orchestrator-token-cache — env-driven module init', () => {
 
   it('awaits a slow mint with no timeout when ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS=0', async () => {
     // 0 = timeout disabled (pre-this-PR behaviour). Even a mint slower
-    // than the default 10s timeout must be awaited to completion.
+    // than the default 5s timeout must be awaited to completion.
     process.env.ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS = '0';
     vi.resetModules();
     const mod = await import('../orchestrator-token-cache');
 
     // Mint takes 100ms — far longer than the 50ms used in the timeout
-    // tests above. If the default-10s timeout were still active this
+    // tests above. If the default-5s timeout were still active this
     // would still pass; the load-bearing assertion is that 0 truly
     // disables the wrapping (no Promise.race overhead, no setTimeout).
     const mintSlow = vi.fn(async () => {

--- a/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
+++ b/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
@@ -149,6 +149,119 @@ describe('orchestrator-token-cache — env-driven module init', () => {
     mod.__testing.clear();
   });
 
+  it('rejects with timeout error when mint never settles (default behaviour with short MINT_TIMEOUT_MS)', async () => {
+    // 50ms timeout: tight enough to keep the test fast, long enough to
+    // be deterministic on CI even under jitter. We deliberately don't
+    // use vi.useFakeTimers() — the existing TTL test above documents
+    // that fake timers don't intercept lru-cache's perf source, and
+    // mixing real + fake timers makes the race semantics nondeterministic.
+    process.env.ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS = '50';
+    vi.resetModules();
+    const mod = await import('../orchestrator-token-cache');
+
+    // A mint that NEVER resolves — simulates a stuck Postgres failover
+    // or PgBouncer reserve_pool exhaustion. Without the timeout, the
+    // inflight slot would be held forever and same-user callers would
+    // attach to a dead promise.
+    const neverResolves = vi.fn(() => new Promise<string>(() => undefined));
+
+    const userId = 1;
+    await expect(mod.getOrMintCachedToken(userId, neverResolves)).rejects.toThrow(
+      /mint timed out after 50ms for user 1/
+    );
+
+    // The inflight slot MUST be empty after the timeout fired — the
+    // .finally() should have run regardless of which arm of the race won.
+    expect(mod.__testing.size()).toEqual({ cache: 0, inflight: 0 });
+
+    mod.__testing.clear();
+  });
+
+  it('clears the in-flight slot after a timeout so the next caller gets a fresh mint', async () => {
+    process.env.ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS = '50';
+    vi.resetModules();
+    const mod = await import('../orchestrator-token-cache');
+
+    const neverResolves = vi.fn(() => new Promise<string>(() => undefined));
+    const mintFast = vi.fn(async () => 'fresh-token');
+
+    const userId = 2;
+    // First call times out.
+    await expect(mod.getOrMintCachedToken(userId, neverResolves)).rejects.toThrow(
+      /mint timed out after 50ms/
+    );
+    // Second call must NOT be attached to the (still-pending) neverResolves
+    // promise — it must enter a fresh inflight with the fast mint.
+    const recovered = await mod.getOrMintCachedToken(userId, mintFast);
+    expect(recovered).toBe('fresh-token');
+    expect(mintFast).toHaveBeenCalledTimes(1);
+
+    mod.__testing.clear();
+  });
+
+  it('awaits a slow mint with no timeout when ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS=0', async () => {
+    // 0 = timeout disabled (pre-this-PR behaviour). Even a mint slower
+    // than the default 10s timeout must be awaited to completion.
+    process.env.ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS = '0';
+    vi.resetModules();
+    const mod = await import('../orchestrator-token-cache');
+
+    // Mint takes 100ms — far longer than the 50ms used in the timeout
+    // tests above. If the default-10s timeout were still active this
+    // would still pass; the load-bearing assertion is that 0 truly
+    // disables the wrapping (no Promise.race overhead, no setTimeout).
+    const mintSlow = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 100));
+      return 'slow-token';
+    });
+
+    const userId = 3;
+    const result = await mod.getOrMintCachedToken(userId, mintSlow);
+
+    expect(result).toBe('slow-token');
+    expect(mintSlow).toHaveBeenCalledTimes(1);
+
+    mod.__testing.clear();
+  });
+
+  it('rejects all coalesced concurrent callers on timeout, then accepts a fresh inflight', async () => {
+    process.env.ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS = '50';
+    vi.resetModules();
+    const mod = await import('../orchestrator-token-cache');
+
+    // Single neverResolves mint shared across 10 coalesced callers. Only
+    // the first caller actually invokes mint(); the other 9 attach to the
+    // inflight promise. When the timeout fires, ALL 10 must reject (they
+    // share the same rejected race-promise), and the inflight slot must
+    // be cleared so a subsequent caller mints fresh.
+    const neverResolves = vi.fn(() => new Promise<string>(() => undefined));
+
+    const userId = 4;
+    const N = 10;
+    const results = await Promise.allSettled(
+      Array.from({ length: N }, () => mod.getOrMintCachedToken(userId, neverResolves))
+    );
+
+    // All 10 rejected with the timeout error.
+    expect(results.every((r) => r.status === 'rejected')).toBe(true);
+    for (const r of results) {
+      if (r.status === 'rejected')
+        expect(String(r.reason)).toMatch(/mint timed out after 50ms for user 4/);
+    }
+    // mint() was only invoked once thanks to coalescing.
+    expect(neverResolves).toHaveBeenCalledTimes(1);
+    // Inflight slot is clean.
+    expect(mod.__testing.size()).toEqual({ cache: 0, inflight: 0 });
+
+    // Subsequent caller hits a brand-new inflight with a healthy mint.
+    const mintFast = vi.fn(async () => 'after-timeout-token');
+    const recovered = await mod.getOrMintCachedToken(userId, mintFast);
+    expect(recovered).toBe('after-timeout-token');
+    expect(mintFast).toHaveBeenCalledTimes(1);
+
+    mod.__testing.clear();
+  });
+
   it('disables cache + coalescing when ORCHESTRATOR_TOKEN_CACHE_MAX=0', async () => {
     process.env.ORCHESTRATOR_TOKEN_CACHE_MAX = '0';
     vi.resetModules();

--- a/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
+++ b/src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts
@@ -99,3 +99,94 @@ describe('orchestrator-token-cache', () => {
     expect(mint).toHaveBeenCalledTimes(2);
   });
 });
+
+// The TTL expiry + kill-switch tests need a different module instance with
+// different env at module-load time (TTL is read once, CACHE_DISABLED is
+// frozen at module load). vi.resetModules() + dynamic import gives us a
+// fresh module per test without polluting the suite above.
+describe('orchestrator-token-cache — env-driven module init', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    // Restore env so subsequent tests/suites see a clean slate.
+    process.env = { ...ORIGINAL_ENV };
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  it('expires cached entries after the configured TTL (re-mints on next call)', async () => {
+    // Short real TTL is more reliable than mocking `performance.now()`,
+    // which lru-cache v11 reads via the `defaultPerf` time source — that
+    // path is not always intercepted by vi.useFakeTimers({ toFake: [...] })
+    // and the contract risks silently regressing on lru-cache upgrades.
+    // 50ms is long enough to be deterministic on CI, short enough to keep
+    // the suite snappy.
+    process.env.ORCHESTRATOR_TOKEN_CACHE_TTL_MS = '50';
+    vi.resetModules();
+    const mod = await import('../orchestrator-token-cache');
+
+    let mintCalls = 0;
+    const mint = vi.fn(async () => `token-${++mintCalls}`);
+
+    const userId = 1;
+    const first = await mod.getOrMintCachedToken(userId, mint);
+    expect(first).toBe('token-1');
+    expect(mint).toHaveBeenCalledTimes(1);
+
+    // Within TTL: cache hit, no new mint.
+    const second = await mod.getOrMintCachedToken(userId, mint);
+    expect(second).toBe('token-1');
+    expect(mint).toHaveBeenCalledTimes(1);
+
+    // Wait past the TTL boundary.
+    await new Promise((r) => setTimeout(r, 75));
+
+    // After TTL: cache miss, mint runs again.
+    const third = await mod.getOrMintCachedToken(userId, mint);
+    expect(third).toBe('token-2');
+    expect(mint).toHaveBeenCalledTimes(2);
+
+    mod.__testing.clear();
+  });
+
+  it('disables cache + coalescing when ORCHESTRATOR_TOKEN_CACHE_MAX=0', async () => {
+    process.env.ORCHESTRATOR_TOKEN_CACHE_MAX = '0';
+    vi.resetModules();
+    const mod = await import('../orchestrator-token-cache');
+
+    expect(mod.__testing.isDisabled()).toBe(true);
+
+    let mintCalls = 0;
+    // Hold mint slow enough that, if coalescing were active, all 5 callers
+    // would share one inflight promise. Disabled mode must NOT coalesce.
+    // Capture the per-call ordinal *before* awaiting so the returned token
+    // is unique per invocation (otherwise all concurrent callers race past
+    // the increment and stamp the final value).
+    const mint = vi.fn(async () => {
+      mintCalls += 1;
+      const id = mintCalls;
+      await new Promise((r) => setTimeout(r, 10));
+      return `token-${id}`;
+    });
+
+    const userId = 5;
+    const N = 5;
+    const results = await Promise.all(
+      Array.from({ length: N }, () => mod.getOrMintCachedToken(userId, mint))
+    );
+
+    // Each concurrent caller hit `mint` independently — no coalescing.
+    expect(mint).toHaveBeenCalledTimes(N);
+    expect(mintCalls).toBe(N);
+    // Each got its own freshly-minted token.
+    expect(new Set(results).size).toBe(N);
+
+    // And there is no cache state retained between calls.
+    expect(mod.__testing.size()).toEqual({ cache: 0, inflight: 0 });
+
+    // A subsequent call also re-mints (no cache lookup).
+    const after = await mod.getOrMintCachedToken(userId, mint);
+    expect(after).toBe(`token-${N + 1}`);
+    expect(mint).toHaveBeenCalledTimes(N + 1);
+  });
+});

--- a/src/server/orchestrator/get-orchestrator-token.ts
+++ b/src/server/orchestrator/get-orchestrator-token.ts
@@ -50,6 +50,16 @@ export async function getOrchestratorToken(userId: number, ctx: Context) {
     // 60s TTL the worst-case DB rate is bounded by (active-users / 60s)
     // per pod, regardless of request volume. See
     // orchestrator-token-cache.ts for the full rationale.
+    //
+    // KNOWN BEHAVIOR: see orchestrator-token-cache.ts docstring — this
+    // cache is NOT invalidated by ban / logout / API-key-rotation. A
+    // revoked user keeps minting/using a valid orchestrator token for
+    // up to ORCHESTRATOR_TOKEN_CACHE_TTL_MS per pod across all ~220
+    // pods (api + jobs + ssr). The 401 handlers in
+    // src/server/services/orchestrator/{workflows,imageUpload,
+    // consumerBlobUpload,videoEnhancement}.ts only `throw` — they do
+    // not invalidate this cache or the sysRedis hash. Future
+    // moderation features must NOT assume cache-coherent revocation.
     token = await getOrMintCachedToken(userId, () =>
       getTemporaryUserApiKey({
         name: generationServiceCookie.name,

--- a/src/server/orchestrator/get-orchestrator-token.ts
+++ b/src/server/orchestrator/get-orchestrator-token.ts
@@ -15,7 +15,31 @@ type Context = {
 
 const TOKEN_STORE: 'redis' | 'cookie' = false ? 'cookie' : 'redis';
 
-export async function getOrchestratorToken(userId: number, ctx: Context) {
+type GetOrchestratorTokenOptions = {
+  /**
+   * Skip the per-pod LRU + in-flight coalescing layer in front of the
+   * DB cold-mint. Use this on CROSS-USER call paths — e.g. the
+   * `moderatorProcedure.queryUserGeneratedImages` handler at
+   * `routers/orchestrator.router.ts:543-555`, which mints a token for
+   * an arbitrary target user. Without this bypass, a compromised
+   * moderator account would leave per-target-user cache entries on
+   * every pod they touched, lingering up to
+   * `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` past account shutdown. Self-call
+   * paths (the user is minting for themselves) should leave this
+   * unset — they benefit from the amplification dampener.
+   *
+   * Even with `bypassCache=true`, the sysRedis hash writeback below
+   * still runs so other pods can hit the cross-pod cache on the next
+   * self-call. Only the per-pod cache is skipped.
+   */
+  bypassCache?: boolean;
+};
+
+export async function getOrchestratorToken(
+  userId: number,
+  ctx: Context,
+  options: GetOrchestratorTokenOptions = {}
+) {
   const redisKey = userId.toString();
   // Fail open on sysRedis: fall through to the getTemporaryUserApiKey
   // fallback path below by setting token=null on error. Catch is scoped
@@ -60,15 +84,17 @@ export async function getOrchestratorToken(userId: number, ctx: Context) {
     // consumerBlobUpload,videoEnhancement}.ts only `throw` — they do
     // not invalidate this cache or the sysRedis hash. Future
     // moderation features must NOT assume cache-coherent revocation.
-    token = await getOrMintCachedToken(userId, () =>
+    const mint = () =>
       getTemporaryUserApiKey({
         name: generationServiceCookie.name,
         // make the db token live just slightly longer than the cookie token
         maxAge: generationServiceCookie.maxAge + 5,
         type: 'System',
         userId,
-      })
-    );
+      });
+    // Cross-user mints (moderator path) must NOT populate the per-pod
+    // cache — Round-5 audit H2. See GetOrchestratorTokenOptions.bypassCache.
+    token = options.bypassCache ? await mint() : await getOrMintCachedToken(userId, mint);
     if (TOKEN_STORE === 'redis') {
       // Cache populate is best-effort: if sysRedis is down we still return
       // the freshly-minted token. Without this catch, the writeback would

--- a/src/server/orchestrator/get-orchestrator-token.ts
+++ b/src/server/orchestrator/get-orchestrator-token.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { env } from '~/env/server';
+import { getOrMintCachedToken } from '~/server/orchestrator/orchestrator-token-cache';
 import { REDIS_KEYS, sysRedis } from '~/server/redis/client';
 import { hSetWithTTL } from '~/server/redis/atomic';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -41,13 +42,23 @@ export async function getOrchestratorToken(userId: number, ctx: Context) {
 
   if (env.ORCHESTRATOR_MODE === 'dev') token = env.ORCHESTRATOR_ACCESS_TOKEN;
   if (!token) {
-    token = await getTemporaryUserApiKey({
-      name: generationServiceCookie.name,
-      // make the db token live just slightly longer than the cookie token
-      maxAge: generationServiceCookie.maxAge + 5,
-      type: 'System',
-      userId,
-    });
+    // Per-pod LRU + in-flight coalescing in front of the DB cold-mint.
+    // Caps the "sysRedis-unavailable" amplification documented at the
+    // token-mint-amplification fail-open subtype: without this, 80 pods
+    // × ~1k RPS × every auth'd request would translate to ~80k inserts/s
+    // + ~160k deleteMany/s on ApiKey during a sysRedis outage. With a
+    // 60s TTL the worst-case DB rate is bounded by (active-users / 60s)
+    // per pod, regardless of request volume. See
+    // orchestrator-token-cache.ts for the full rationale.
+    token = await getOrMintCachedToken(userId, () =>
+      getTemporaryUserApiKey({
+        name: generationServiceCookie.name,
+        // make the db token live just slightly longer than the cookie token
+        maxAge: generationServiceCookie.maxAge + 5,
+        type: 'System',
+        userId,
+      })
+    );
     if (TOKEN_STORE === 'redis') {
       // Cache populate is best-effort: if sysRedis is down we still return
       // the freshly-minted token. Without this catch, the writeback would

--- a/src/server/orchestrator/orchestrator-token-cache.ts
+++ b/src/server/orchestrator/orchestrator-token-cache.ts
@@ -11,9 +11,13 @@
  *   (a) sysRedis hGet failed (the original outage-amplification case),
  *   (b) first-ever auth for a user (the sysRedis hash field doesn't exist
  *       yet),
- *   (c) hourly TTL rotation when the cached hash field has expired,
- *   (d) cookie-mode flow (`TOKEN_STORE === 'cookie'`, where the cookie is
- *       absent / not yet set).
+ *   (c) hourly TTL rotation when the cached hash field has expired.
+ *
+ * (Cookie-mode flow exists in the source but is currently dead code:
+ * `TOKEN_STORE` at get-orchestrator-token.ts is statically `'redis'`
+ * because of an unconditional ternary, so the cookie else-branch is
+ * unreachable at runtime. If that gets flipped, the cookie-absent path
+ * also funnels through this cache.)
  *
  * So the cache runs on healthy steady-state traffic, NOT only during
  * outage windows. The primary motivation below remains amplification

--- a/src/server/orchestrator/orchestrator-token-cache.ts
+++ b/src/server/orchestrator/orchestrator-token-cache.ts
@@ -91,13 +91,18 @@
  * KNOWN BEHAVIOR (mint timeout)
  * -----------------------------
  * `mint()` is wrapped in `Promise.race` against a configurable timeout
- * (`ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS`, default 10s; 0 disables).
+ * (`ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS`, default 5s; 0 disables).
  * Without a timeout, a Postgres failover or PgBouncer reserve_pool
  * exhaustion could leave the `inflight` Map slot held by a promise that
  * never settles. Subsequent same-user callers would attach to that dead
  * promise forever. The timeout rejects the awaiting promise, which fires
  * the `.finally()` that clears the inflight slot so the next caller gets
  * a fresh attempt.
+ *
+ * Default 5_000ms — well below the 10s kubelet liveness probe timeout
+ * (a stalled mint that hits the timeout simultaneously with a probe
+ * would cascade into pod-eviction), well above ApiKey INSERT p99. Set
+ * to 0 to disable the timeout entirely (debug knob; not for prod).
  */
 
 import { LRUCache } from 'lru-cache';
@@ -132,10 +137,13 @@ const TTL_MS = readNonNegativeInt('ORCHESTRATOR_TOKEN_CACHE_TTL_MS', DEFAULT_TTL
 // Hard upper bound on how long we will await a `mint()` call before
 // rejecting and freeing the inflight slot. `0` disables the timeout
 // entirely (mint is awaited indefinitely — pre-this-PR behaviour). The
-// default (10s) is well above any healthy ApiKey INSERT P99 but well
-// below the kubelet liveness probe timeout, so a stalled mint won't
-// wedge the inflight slot past one health-check window.
-const DEFAULT_MINT_TIMEOUT_MS = 10_000;
+// default (5s) is well above any healthy ApiKey INSERT P99 but well
+// below the 10s kubelet liveness probe timeout — a stalled mint that
+// hits the timeout simultaneously with a probe would otherwise cascade
+// into pod eviction (the round-4 audit caught that 10s == probe timeout
+// risked synchronization). 5s leaves a 5s probe headroom while staying
+// well above any healthy mint duration.
+const DEFAULT_MINT_TIMEOUT_MS = 5_000;
 const MINT_TIMEOUT_MS = readNonNegativeInt(
   'ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS',
   DEFAULT_MINT_TIMEOUT_MS
@@ -261,5 +269,26 @@ export const __testing = {
   },
   isDisabled() {
     return CACHE_DISABLED;
+  },
+  // PR #2333 round-4: explicit cleanup for HMR safety in dev + test
+  // isolation. `LRUCache` with `ttl > 0` + `ttlAutopurge: true` registers
+  // a per-entry `setTimeout` on every `set()` to drive the autopurge.
+  // Those timers anchor the cache instance reachable for up to TTL_MS
+  // after the last write — under Next.js dev HMR, each edit to this
+  // module leaves the OLD `tokenCache` reachable until those timers
+  // drain, and under vitest's `vi.resetModules()` flow, each dynamic
+  // import leaves the prior module instance similarly anchored.
+  //
+  // `tokenCache.clear()` drops all entries (and cancels their pending
+  // ttlAutopurge `setTimeout`s — that is the load-bearing call here),
+  // and we also clear the `inflight` Map so awaiting promises don't
+  // keep the module reachable past intent.
+  //
+  // Production callers must NOT invoke this — it is purely a hook for
+  // HMR cleanup and test isolation. `__testing.clear()` is the public
+  // test-suite reset; `destroy()` is the "module is going away" hook.
+  destroy() {
+    tokenCache?.clear();
+    inflight.clear();
   },
 };

--- a/src/server/orchestrator/orchestrator-token-cache.ts
+++ b/src/server/orchestrator/orchestrator-token-cache.ts
@@ -1,0 +1,131 @@
+/**
+ * In-memory cache + in-flight coalescing for the cold-mint path of
+ * `getOrchestratorToken`. Sits in front of `getTemporaryUserApiKey` only —
+ * the sysRedis hot path remains the source of truth when healthy and is
+ * not cached here.
+ *
+ * Motivation
+ * ----------
+ * If sysRedis is unavailable (and during the 15–25s failover window of the
+ * HA migration, briefly it will be), every authenticated request that
+ * needs an orchestrator token falls through to
+ * `getTemporaryUserApiKey(userId)`. That function runs **1 INSERT + 2
+ * deleteMany** per call. At civitai-dp-prod scale (80 pods × ~1k RPS) a
+ * sustained sysRedis-down event would aim ~80k inserts/s and ~160k
+ * deletes/s at the primary — the "cold-mint amplification" failure mode
+ * tracked by the `sysredis-token-mint-amplification-warn` alert (see
+ * `logSysRedisFailOpen('token-mint-amplification', ...)` in
+ * `get-orchestrator-token.ts`).
+ *
+ * Two layers, both per-pod, both in-memory (deliberately not Redis — the
+ * whole point is to survive sysRedis being unavailable):
+ *
+ *   1. LRU cache (size-capped + TTL): cache `userId → token` for ~60s.
+ *      Cold-mint hits the DB at most once per user per 60s per pod.
+ *
+ *   2. In-flight promise coalescing: when N concurrent requests for the
+ *      same userId would all cold-mint at the same time, share one
+ *      promise. This is the actual thundering-herd protection during
+ *      failover; the LRU alone leaves a wide race window on first miss.
+ *
+ * Tradeoffs / safety notes
+ * ------------------------
+ *  - TTL is bounded well under the underlying API-key DB-side expiresAt
+ *    (`generationServiceCookie.maxAge + 5`, ~1h). The cached token cannot
+ *    outlive the row it represents.
+ *  - Cache is per-pod. A token minted on pod A is NOT visible on pod B.
+ *    That is correct — sysRedis is the cross-pod cache; this layer is
+ *    only an amplification dampener while sysRedis is degraded. Per-pod
+ *    isolation also caps blast radius (a poisoned cache entry can only
+ *    affect one pod's traffic).
+ *  - No cache invalidation API. Eviction is implicit-via-TTL. If a token
+ *    is revoked mid-cache-window the worst case is one stale token until
+ *    the entry expires; the orchestrator will reject it and the next
+ *    request mints fresh.
+ *  - Bounded memory: `max` entries × ~40 bytes/token ≈ 2 MB worst case.
+ */
+
+import { LRUCache } from 'lru-cache';
+import { cacheHitCounter, cacheMissCounter } from '~/server/prom/client';
+
+const CACHE_NAME = 'orchestrator-token-cold-mint';
+const CACHE_TYPE = 'lruCache';
+
+// 50k entries × ~60s TTL. With 80 pods, an active-user set in the low
+// thousands will round-trip each user to the DB roughly once per minute
+// per pod during sysRedis-down — a 60-100x reduction in DB load vs the
+// uncached fallback. Both knobs can be tuned via env without code change.
+const DEFAULT_MAX = 50_000;
+const DEFAULT_TTL_MS = 60_000;
+
+function readPositiveInt(envName: string, fallback: number): number {
+  const raw = process.env[envName];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+const tokenCache = new LRUCache<number, string>({
+  max: readPositiveInt('ORCHESTRATOR_TOKEN_CACHE_MAX', DEFAULT_MAX),
+  ttl: readPositiveInt('ORCHESTRATOR_TOKEN_CACHE_TTL_MS', DEFAULT_TTL_MS),
+});
+
+const inflight = new Map<number, Promise<string>>();
+
+/**
+ * Run `mint()` for `userId` with cache + coalescing.
+ *
+ * Caller contract: `mint` must be idempotent (we may share its result
+ * across all current callers for this userId). `getTemporaryUserApiKey`
+ * is — every call mints a fresh DB-backed key and trims older ones.
+ */
+export async function getOrMintCachedToken(
+  userId: number,
+  mint: () => Promise<string>
+): Promise<string> {
+  const cached = tokenCache.get(userId);
+  if (cached !== undefined) {
+    cacheHitCounter.inc({ cache_name: CACHE_NAME, cache_type: CACHE_TYPE });
+    return cached;
+  }
+
+  const pending = inflight.get(userId);
+  if (pending) {
+    // Coalesce: another request for this user is already minting. Share
+    // its promise. Still counts as a miss — the DB call is happening,
+    // we're just not duplicating it.
+    cacheMissCounter.inc({ cache_name: CACHE_NAME, cache_type: CACHE_TYPE });
+    return pending;
+  }
+
+  cacheMissCounter.inc({ cache_name: CACHE_NAME, cache_type: CACHE_TYPE });
+
+  const promise = (async () => {
+    try {
+      const token = await mint();
+      tokenCache.set(userId, token);
+      return token;
+    } finally {
+      // Always clear the in-flight slot, even on rejection — otherwise a
+      // single transient mint failure would wedge all future requests
+      // for this user behind a rejected promise.
+      inflight.delete(userId);
+    }
+  })();
+
+  inflight.set(userId, promise);
+  return promise;
+}
+
+// Test-only escape hatches. Kept on the module export so tests can clear
+// state between cases without poking module internals.
+export const __testing = {
+  clear() {
+    tokenCache.clear();
+    inflight.clear();
+  },
+  size() {
+    return { cache: tokenCache.size, inflight: inflight.size };
+  },
+};

--- a/src/server/orchestrator/orchestrator-token-cache.ts
+++ b/src/server/orchestrator/orchestrator-token-cache.ts
@@ -4,6 +4,23 @@
  * the sysRedis hot path remains the source of truth when healthy and is
  * not cached here.
  *
+ * When does the cache fire?
+ * -------------------------
+ * Any time `getOrchestratorToken`'s `if (!token)` branch executes — i.e.
+ * any `getTemporaryUserApiKey` invocation. That includes:
+ *   (a) sysRedis hGet failed (the original outage-amplification case),
+ *   (b) first-ever auth for a user (the sysRedis hash field doesn't exist
+ *       yet),
+ *   (c) hourly TTL rotation when the cached hash field has expired,
+ *   (d) cookie-mode flow (`TOKEN_STORE === 'cookie'`, where the cookie is
+ *       absent / not yet set).
+ *
+ * So the cache runs on healthy steady-state traffic, NOT only during
+ * outage windows. The primary motivation below remains amplification
+ * protection during a sysRedis outage (that's the worst-case load), but
+ * day-to-day this is also a per-pod dampener on first-auth and on every
+ * hourly rotation.
+ *
  * Motivation
  * ----------
  * If sysRedis is unavailable (and during the 15–25s failover window of the
@@ -58,18 +75,44 @@ const CACHE_TYPE = 'lruCache';
 const DEFAULT_MAX = 50_000;
 const DEFAULT_TTL_MS = 60_000;
 
-function readPositiveInt(envName: string, fallback: number): number {
+// Read a non-negative integer env var. Returns `fallback` only when the
+// env var is unset / non-numeric / negative. `0` is a valid explicit
+// value — for `ORCHESTRATOR_TOKEN_CACHE_MAX` it is the kill-switch
+// (CACHE_DISABLED below) and `LRUCache` requires `max >= 1` so the
+// constructor is also skipped when disabled.
+function readNonNegativeInt(envName: string, fallback: number): number {
   const raw = process.env[envName];
-  if (!raw) return fallback;
+  if (raw === undefined || raw === '') return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
   return Math.floor(parsed);
 }
 
-const tokenCache = new LRUCache<number, string>({
-  max: readPositiveInt('ORCHESTRATOR_TOKEN_CACHE_MAX', DEFAULT_MAX),
-  ttl: readPositiveInt('ORCHESTRATOR_TOKEN_CACHE_TTL_MS', DEFAULT_TTL_MS),
-});
+const MAX_ENTRIES = readNonNegativeInt('ORCHESTRATOR_TOKEN_CACHE_MAX', DEFAULT_MAX);
+const TTL_MS = readNonNegativeInt('ORCHESTRATOR_TOKEN_CACHE_TTL_MS', DEFAULT_TTL_MS);
+
+// Kill-switch. Computed once at module load so the hot path is a single
+// boolean check, not a per-call env read. To disable the cache in
+// production, set `ORCHESTRATOR_TOKEN_CACHE_MAX=0` and roll the pods.
+// `getOrMintCachedToken` then becomes a straight passthrough to `mint()`
+// (no caching, no coalescing) — useful as a no-redeploy kill-switch if
+// the cache itself is implicated in an incident.
+const CACHE_DISABLED = MAX_ENTRIES === 0;
+
+// Skip constructing the LRU at all when disabled — lru-cache rejects
+// `max: 0` at construction time, and there's no point allocating the
+// backing arrays we'll never touch.
+const tokenCache = CACHE_DISABLED
+  ? null
+  : new LRUCache<number, string>({
+      max: MAX_ENTRIES,
+      ttl: TTL_MS,
+      // Without this, expired entries linger in the LRU's internal arrays
+      // until they're touched or evicted by capacity pressure. That makes
+      // `cache.size` look pinned at `max` long after the active set has
+      // shrunk, which frustrates leak diagnostics from prom / heap dumps.
+      ttlAutopurge: true,
+    });
 
 const inflight = new Map<number, Promise<string>>();
 
@@ -84,6 +127,14 @@ export async function getOrMintCachedToken(
   userId: number,
   mint: () => Promise<string>
 ): Promise<string> {
+  // Kill-switch: when `ORCHESTRATOR_TOKEN_CACHE_MAX=0`, bypass both the
+  // cache AND the coalescing layer. N concurrent callers all hit `mint()`
+  // directly — same behaviour as before this module existed. No counters
+  // fire (cache is conceptually absent).
+  if (CACHE_DISABLED || !tokenCache) {
+    return mint();
+  }
+
   const cached = tokenCache.get(userId);
   if (cached !== undefined) {
     cacheHitCounter.inc({ cache_name: CACHE_NAME, cache_type: CACHE_TYPE });
@@ -122,10 +173,13 @@ export async function getOrMintCachedToken(
 // state between cases without poking module internals.
 export const __testing = {
   clear() {
-    tokenCache.clear();
+    tokenCache?.clear();
     inflight.clear();
   },
   size() {
-    return { cache: tokenCache.size, inflight: inflight.size };
+    return { cache: tokenCache?.size ?? 0, inflight: inflight.size };
+  },
+  isDisabled() {
+    return CACHE_DISABLED;
   },
 };

--- a/src/server/orchestrator/orchestrator-token-cache.ts
+++ b/src/server/orchestrator/orchestrator-token-cache.ts
@@ -62,31 +62,66 @@
  *  - No cache invalidation API. Eviction is implicit-via-TTL.
  *  - Bounded memory: `max` entries × ~40 bytes/token ≈ 2 MB worst case.
  *
- * KNOWN BEHAVIOR (ban / logout / API-key rotation)
- * ------------------------------------------------
- * This cache is NOT invalidated by any of the auth-revocation paths in
- * `src/server/services/orchestrator/`. The 401 handlers at
- *   - workflows.ts:58, workflows.ts:84, workflows.ts:154
- *   - imageUpload.ts:30
- *   - consumerBlobUpload.ts:27
- *   - videoEnhancement.ts:27
- * all `throw throwAuthorizationError(...)` and do nothing to either this
- * in-memory cache or the underlying sysRedis hash. A user banned, logged
- * out, or whose API key has been rotated at T0 will therefore keep
- * minting/holding a valid orchestrator token for up to
- * `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` on any pod whose cache they touched
- * — and this is per-pod across all ~220 pods (api ~80 + jobs ~10 + ssr
- * ~130). Worst-case fleet-wide window: TTL_MS × per-pod-staggered cache
- * lifetime. The previously claimed "orchestrator rejects, next request
- * mints fresh" self-healing behaviour does NOT exist — a 401 from the
- * orchestrator surfaces to the user as an auth error and the cache
- * entry is left in place until natural TTL eviction.
+ * KNOWN BEHAVIOR (ban / logout / API-key rotation / account-deletion)
+ * --------------------------------------------------------------------
+ * This cache is NOT invalidated by ANY of the auth-revocation paths in
+ * the codebase today. Specifically:
+ *
+ *   - The 401 handlers in `src/server/services/orchestrator/`:
+ *       workflows.ts:58, workflows.ts:84, workflows.ts:154,
+ *       imageUpload.ts:30, consumerBlobUpload.ts:27, videoEnhancement.ts:27
+ *     all `throw throwAuthorizationError(...)` and do nothing else.
+ *   - `signOut` next-auth callback (`pages/api/auth/[...nextauth].ts:68-73`)
+ *     invalidates the JWT and clears the encrypted cookie but does NOT
+ *     touch this cache or the sysRedis hash.
+ *   - `invalidateSession(userId)` (`server/auth/session-invalidation.ts`)
+ *     only writes to `REDIS_SYS_KEYS.SESSION.TOKEN_STATE`. Neither the
+ *     generation-token cache nor `REDIS_KEYS.GENERATION.TOKENS` is touched.
+ *   - `toggleBan` (`server/services/user.service.ts:1607`) calls
+ *     `invalidateSession` — inherits the same gap.
+ *   - `deleteUser` / GDPR account-deletion (`server/services/user.service.ts:944`)
+ *     scrubs PII and calls `invalidateSession` but does NOT delete the
+ *     `ApiKey` row with `name='generation-token'`. A deleted user's
+ *     orchestrator token stays valid in the DB until its `expiresAt`
+ *     (~1h) AND lingers in this in-memory cache for up to
+ *     `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` per pod.
+ *   - `deleteApiKey(id, userId)` (`server/services/api-key.service.ts:134`)
+ *     removes the DB row but the cache entry (and the sysRedis hash entry)
+ *     are independent and stay until natural TTL eviction.
+ *
+ * A revoked user therefore keeps minting/holding a valid orchestrator
+ * token for up to `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` on any pod whose
+ * cache they touched — and this is per-pod across all ~220 pods
+ * (api ~80 + jobs ~10 + ssr ~130). Worst-case fleet-wide window: TTL_MS
+ * × per-pod-staggered cache lifetime. The previously claimed
+ * "orchestrator rejects, next request mints fresh" self-healing
+ * behaviour does NOT exist — a 401 from the orchestrator surfaces to
+ * the user as an auth error and the cache entry is left in place until
+ * natural TTL eviction.
+ *
+ * Cross-user mints (the `moderatorProcedure.queryUserGeneratedImages`
+ * path at `routers/orchestrator.router.ts:543-555`) bypass this cache
+ * via the `bypassCache` arg on `getOrchestratorToken` — see the H2
+ * finding in `claudedocs/sysredis-pr2333-round5-audit-2026-06-16.md`.
+ * Without that bypass, a compromised moderator would leave per-target-user
+ * cache entries on every pod they touched.
  *
  * If invalidation latency matters for your use case, EITHER:
  *   - add an explicit `invalidate(userId)` call (export to be added)
- *     alongside the revocation, OR
+ *     alongside the revocation AND delete the underlying `ApiKey` row
+ *     where `name='generation-token' AND userId=X` — without the row
+ *     deletion, even a perfect cache invalidation leaves the token
+ *     valid at the orchestrator side until `expiresAt`, OR
  *   - shorten `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` to the maximum tolerable
  *     stale-window.
+ *
+ * Incident response: revoking ALL active orchestrator tokens for a user
+ * requires (a) `kubectl rollout restart` of `civitai-dp-prod-api`,
+ * `civitai-dp-prod` (SSR), and `civitai-dp-prod-jobs` to clear all
+ * per-pod caches, plus (b) `DELETE FROM "ApiKey" WHERE "userId" = X AND
+ * "name" = 'generation-token'` to invalidate any in-flight bearer tokens.
+ * Waiting ≥ `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` is an acceptable
+ * alternative to (a) for non-urgent cases.
  *
  * KNOWN BEHAVIOR (mint timeout)
  * -----------------------------

--- a/src/server/orchestrator/orchestrator-token-cache.ts
+++ b/src/server/orchestrator/orchestrator-token-cache.ts
@@ -59,11 +59,45 @@
  *    only an amplification dampener while sysRedis is degraded. Per-pod
  *    isolation also caps blast radius (a poisoned cache entry can only
  *    affect one pod's traffic).
- *  - No cache invalidation API. Eviction is implicit-via-TTL. If a token
- *    is revoked mid-cache-window the worst case is one stale token until
- *    the entry expires; the orchestrator will reject it and the next
- *    request mints fresh.
+ *  - No cache invalidation API. Eviction is implicit-via-TTL.
  *  - Bounded memory: `max` entries × ~40 bytes/token ≈ 2 MB worst case.
+ *
+ * KNOWN BEHAVIOR (ban / logout / API-key rotation)
+ * ------------------------------------------------
+ * This cache is NOT invalidated by any of the auth-revocation paths in
+ * `src/server/services/orchestrator/`. The 401 handlers at
+ *   - workflows.ts:58, workflows.ts:84, workflows.ts:154
+ *   - imageUpload.ts:30
+ *   - consumerBlobUpload.ts:27
+ *   - videoEnhancement.ts:27
+ * all `throw throwAuthorizationError(...)` and do nothing to either this
+ * in-memory cache or the underlying sysRedis hash. A user banned, logged
+ * out, or whose API key has been rotated at T0 will therefore keep
+ * minting/holding a valid orchestrator token for up to
+ * `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` on any pod whose cache they touched
+ * — and this is per-pod across all ~220 pods (api ~80 + jobs ~10 + ssr
+ * ~130). Worst-case fleet-wide window: TTL_MS × per-pod-staggered cache
+ * lifetime. The previously claimed "orchestrator rejects, next request
+ * mints fresh" self-healing behaviour does NOT exist — a 401 from the
+ * orchestrator surfaces to the user as an auth error and the cache
+ * entry is left in place until natural TTL eviction.
+ *
+ * If invalidation latency matters for your use case, EITHER:
+ *   - add an explicit `invalidate(userId)` call (export to be added)
+ *     alongside the revocation, OR
+ *   - shorten `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` to the maximum tolerable
+ *     stale-window.
+ *
+ * KNOWN BEHAVIOR (mint timeout)
+ * -----------------------------
+ * `mint()` is wrapped in `Promise.race` against a configurable timeout
+ * (`ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS`, default 10s; 0 disables).
+ * Without a timeout, a Postgres failover or PgBouncer reserve_pool
+ * exhaustion could leave the `inflight` Map slot held by a promise that
+ * never settles. Subsequent same-user callers would attach to that dead
+ * promise forever. The timeout rejects the awaiting promise, which fires
+ * the `.finally()` that clears the inflight slot so the next caller gets
+ * a fresh attempt.
  */
 
 import { LRUCache } from 'lru-cache';
@@ -94,6 +128,18 @@ function readNonNegativeInt(envName: string, fallback: number): number {
 
 const MAX_ENTRIES = readNonNegativeInt('ORCHESTRATOR_TOKEN_CACHE_MAX', DEFAULT_MAX);
 const TTL_MS = readNonNegativeInt('ORCHESTRATOR_TOKEN_CACHE_TTL_MS', DEFAULT_TTL_MS);
+
+// Hard upper bound on how long we will await a `mint()` call before
+// rejecting and freeing the inflight slot. `0` disables the timeout
+// entirely (mint is awaited indefinitely — pre-this-PR behaviour). The
+// default (10s) is well above any healthy ApiKey INSERT P99 but well
+// below the kubelet liveness probe timeout, so a stalled mint won't
+// wedge the inflight slot past one health-check window.
+const DEFAULT_MINT_TIMEOUT_MS = 10_000;
+const MINT_TIMEOUT_MS = readNonNegativeInt(
+  'ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS',
+  DEFAULT_MINT_TIMEOUT_MS
+);
 
 // Kill-switch. Computed once at module load so the hot path is a single
 // boolean check, not a per-call env read. To disable the cache in
@@ -157,14 +203,44 @@ export async function getOrMintCachedToken(
   cacheMissCounter.inc({ cache_name: CACHE_NAME, cache_type: CACHE_TYPE });
 
   const promise = (async () => {
+    // Track the timeout handle so we can cancel it as soon as mint()
+    // settles — otherwise a fast-resolving mint would still pin the
+    // setTimeout reference until the timeout fires (allocates a stale
+    // closure per mint, and prevents the GC from collecting the user's
+    // tail-state). `.unref()` is belt-and-suspenders for short-lived
+    // Node workers / scripts that import this module — the event loop
+    // shouldn't be held alive by an outstanding mint timeout.
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     try {
-      const token = await mint();
+      const mintPromise =
+        MINT_TIMEOUT_MS > 0
+          ? Promise.race<string>([
+              mint(),
+              new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(
+                  () =>
+                    reject(
+                      new Error(
+                        `getOrMintCachedToken: mint timed out after ${MINT_TIMEOUT_MS}ms for user ${userId}`
+                      )
+                    ),
+                  MINT_TIMEOUT_MS
+                );
+                // Do not hold the event loop open solely for this timer.
+                timeoutHandle.unref?.();
+              }),
+            ])
+          : mint();
+
+      const token = await mintPromise;
       tokenCache.set(userId, token);
       return token;
     } finally {
-      // Always clear the in-flight slot, even on rejection — otherwise a
-      // single transient mint failure would wedge all future requests
-      // for this user behind a rejected promise.
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      // Always clear the in-flight slot, even on rejection or timeout —
+      // otherwise a single transient mint failure (or a stuck Postgres
+      // failover that hits the MINT_TIMEOUT_MS guard above) would wedge
+      // all future requests for this user behind a dead promise.
       inflight.delete(userId);
     }
   })();

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -597,8 +597,12 @@ export const orchestratorRouter = router({
     .input(workflowQuerySchema.extend({ userId: z.number() }))
     .query(async ({ ctx, input }) => {
       const { userId, ...query } = input;
-      // Get token for the target user, not the moderator
-      const targetToken = await getOrchestratorToken(userId, ctx);
+      // Get token for the target user, not the moderator. bypassCache=true:
+      // this is a cross-user mint — populating the per-pod cache with the
+      // TARGET user's token off a MODERATOR session would leave 60s of
+      // recoverable per-target-user state on every pod a moderator touched.
+      // See orchestrator-token-cache.ts docstring (Round-5 audit H2).
+      const targetToken = await getOrchestratorToken(userId, ctx, { bypassCache: true });
       return queryGeneratedImageWorkflows2({
         ...query,
         token: targetToken,


### PR DESCRIPTION
## Summary

- **Problem**: `getOrchestratorToken` falls through to `getTemporaryUserApiKey` (1 INSERT + 2 deleteMany on `ApiKey`) on any call where the sysRedis hash field is missing — that includes the original outage case **and** first-ever auth, hourly TTL rotation, and cookie mode. The worst-case is a sysRedis-down event: at civitai-dp-prod scale (**~220 pods total** — api ~80 + jobs ~10 + ssr ~130, all of which call `getOrchestratorToken`) × ~1k RPS it would aim a sustained INSERT + deleteMany storm at the Postgres primary. The HA migration's 15–25s failover window guarantees this storm fires briefly. Existing alert `sysredis-token-mint-amplification-warn` detects it but doesn't mitigate.
- **Fix**: Per-pod in-memory two-layer dampener wrapped around the cold-mint path. The cache runs on **all** cold-mint calls (steady-state first-auth, hourly rotation, cookie mode, AND outage windows) — the primary motivation is still outage amplification protection because that is the worst-case load:
  1. **LRU cache** (50k entries, 60s TTL, `ttlAutopurge: true`): cold-mint hits DB at most once per user per 60s per pod
  2. **In-flight coalescing**: N concurrent first-time requests for the same userId share one mint promise (thundering-herd protection on first miss)
  3. **Mint timeout** (round-3 addition, round-4 default tightened): `mint()` wrapped in `Promise.race` against `ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS` (default **5s** as of round-4; was 10s). Without it, a stuck Postgres failover or PgBouncer reserve_pool exhaustion would pin the inflight slot indefinitely and same-user callers would attach to a dead promise. The timeout rejects the awaiting promise, which fires the `.finally()` that clears the inflight slot.
- **Expected DB load reduction during sysRedis outage**: with ~220 pods and a few thousand active users, sustained cold-mint INSERT rate drops from O(requests/s) to O(active_users / 60s / pod) — roughly **60–100x reduction**.
- **Knobs**: `ORCHESTRATOR_TOKEN_CACHE_MAX` / `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` / `ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS` tunable without redeploy.
  - Setting `ORCHESTRATOR_TOKEN_CACHE_MAX=0` is a hard kill-switch — `getOrMintCachedToken` becomes a straight passthrough to the original DB cold-mint with no cache and no coalescing.
  - `ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS` default is now **5_000ms** (round-4 audit dropped this from 10_000ms — 10s == kubelet liveness probe timeout, so a stalled mint that hit the timeout simultaneously with a probe would cascade into pod eviction; 5s leaves a 5s probe headroom). Setting to `0` disables the timeout entirely (pre-this-PR behaviour — mint awaited indefinitely; debug knob, not for prod).

## Background

The `token-mint-amplification` fail-open subtype (`src/server/redis/fail-open-log.ts`) was added in PR #2286 to surface this exact failure mode via Grafana Loki alert. Phase 1 of the sysRedis HA migration (PR civitai/civitai#2331, runbook §Phase 1.6 in `datapacket-talos`) brings sysRedis under Sentinel + failover-capable client; failover transients of 15–25s are expected during cutover and every subsequent primary loss. Without this cache, every failover would page the DB team. Phase 1.5 (sibling branch `zach/sysredis-atomic-hexpire`) handles the hSet+hExpire atomicity on the *write* path — explicitly disjoint from this PR's scope.

## Implementation notes

- Wraps **only** the `getTemporaryUserApiKey` cold-mint call. The sysRedis hot-path read and the hSet+hExpire writeback (lines 88–98 of `get-orchestrator-token.ts`) are untouched — Phase 1.5 modifies that block.
- Cache is per-pod / in-process by design. Putting this cache in Redis would defeat the purpose (the whole point is to survive Redis being unavailable). Per-pod isolation also caps poison-cache blast radius.
- Cache TTL (60s) is far under the underlying DB-side API-key `expiresAt` (`generationServiceCookie.maxAge + 5` ≈ 1h). Cached tokens cannot outlive the row they represent. No invalidation API — eviction is implicit via TTL.
- **KNOWN BEHAVIOR (ban / logout / API-key rotation)**: this cache is NOT invalidated by any of the 401 handlers in `src/server/services/orchestrator/` (`workflows.ts:58/84/154`, `imageUpload.ts:30`, `consumerBlobUpload.ts:27`, `videoEnhancement.ts:27`). All of them just `throw throwAuthorizationError(...)` — they do nothing to either the in-memory cache or the underlying sysRedis hash. A user banned/logged-out/rotated at T0 will keep minting/holding a valid orchestrator token for up to `ORCHESTRATOR_TOKEN_CACHE_TTL_MS` on any pod whose cache they touched — per-pod, across all ~220 pods. Worst-case fleet-wide window: TTL_MS × per-pod-staggered cache lifetime. Round-3 docstring + call-site comment now state this explicitly so future moderation features don't assume cache-coherent revocation. If invalidation latency matters, either add an explicit `invalidate(userId)` call alongside revocation or shorten the TTL.
- Inflight Map slot is cleared in `finally` so a transient mint rejection — or a mint that hits the new `ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS` guard — doesn't wedge all future calls for that user behind a dead promise (regression tests cover both paths).
- **Round-4 HMR safety**: `__testing.destroy()` added as an explicit cleanup hook for Next.js dev HMR and `vi.resetModules()` test isolation. `LRUCache` with `ttl > 0` + `ttlAutopurge: true` registers a per-entry `setTimeout` on every `set()`, which anchors the cache instance reachable for up to TTL_MS after the last write. Without `destroy()`, each dev-mode edit to this module (or each dynamic-import test in the env-driven block) leaks the prior `tokenCache` instance until those timers drain. `destroy()` clears the cache (cancelling the timers) and the inflight Map. Production callers must NOT invoke this — it is a test/HMR-only export.
- Uses the already-vendored `lru-cache@^11.2.2` (same package the rest of the repo uses via `src/server/utils/lru-cache.ts`). No new deps. Reuses existing `cacheHitCounter` / `cacheMissCounter` prom metrics with `cache_name="orchestrator-token-cold-mint"`.

## Test plan

- [x] Vitest unit suite (`src/server/orchestrator/__tests__/orchestrator-token-cache.test.ts`) — **11 tests, all passing**:
  - [x] Coalescing: 10 concurrent same-user calls → `mint` invoked exactly **1** time, all callers receive the same token
  - [x] Cache hit: 3 sequential same-user calls → `mint` invoked exactly **1** time
  - [x] Per-user isolation: 3 concurrent different-user calls → `mint` invoked **3** times, each gets a distinct token
  - [x] Reject does not wedge: first mint rejects → second call succeeds with fresh attempt (inflight slot cleared)
  - [x] TTL expiry: cached entry re-mints after `TTL + 1ms`
  - [x] Kill-switch: with `ORCHESTRATOR_TOKEN_CACHE_MAX=0`, N concurrent calls all hit `mint` (no cache, no coalescing)
  - [x] **Mint timeout fires** (round-3): never-resolving `mint` rejects with timeout error, inflight slot is empty after
  - [x] **Inflight slot cleared after timeout** (round-3): post-timeout, a fresh `mint` resolves cleanly (no attachment to the dead promise)
  - [x] **`ORCHESTRATOR_TOKEN_CACHE_MINT_TIMEOUT_MS=0` disables the timeout** (round-3): a 100ms mint awaits fully
  - [x] **Concurrent coalesce + timeout** (round-3): 10 coalesced callers all reject on timeout, then a subsequent caller hits a fresh inflight
  - [x] **`__testing.destroy()` drops cache + inflight and leaves the module re-usable** (round-4): verifies the HMR / test-isolation cleanup hook
- [x] `pnpm tsc --noEmit` clean on changed files (trunk has 900+ unrelated Prisma in-flight errors)
- [ ] Post-merge: watch `cache_hit_total{cache_name="orchestrator-token-cold-mint"}` / `cache_miss_total` ratio in production. Baseline expectation: low but non-zero hit rate at steady state (first-auth + hourly rotation), spiking to very high hit rate during any sysRedis fail-open event.
- [ ] Sentinel-failover smoke test (planned during Phase 2 cutover): induce sysRedis primary failover under synthetic auth-traffic load, confirm `apikey` insert rate stays bounded and `sysredis-token-mint-amplification-warn` resolves within the cache-TTL window after sysRedis recovers.

## Refs

- Phase 1 PR: civitai/civitai#2331
- Phase 1.5 sibling branch (atomic hSet+hExpire helper on the write path): `zach/sysredis-atomic-hexpire`
- Runbook: `clusters/production/apps/redis/` § Phase 1.6 in `datapacket-talos`
- Original fail-open audit: PR #2286

🤖 Generated with [Claude Code](https://claude.com/claude-code)