### PR TITLE
feat(app-blocks): W4 v0 — isolated KV datastore (cnpg-cluster-apps)

### DIFF
--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -75,6 +75,19 @@ function failureSnapshot(err: unknown): BlockWorkflowSnapshot {
   };
 }
 
+// Reduce a thrown tRPC error to a single short string the block can surface.
+// TRPCClientError exposes `.message` which is already the server message
+// (apps.storage.* throws with explicit code + message strings); everything
+// else gets a generic fallback. Keep this conservative — the iframe is
+// untrusted and we don't want to leak server stack traces.
+function storageErrorMessage(err: unknown): string {
+  if (err && typeof err === 'object' && 'message' in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === 'string' && message.length > 0) return message;
+  }
+  return 'storage request failed';
+}
+
 /**
  * Renders a block inside a sandboxed iframe and drives the postMessage
  * lifecycle. Implements the @civitai/app-sdk/blocks v1 contract — see
@@ -616,6 +629,172 @@ export function IframeHost({ install, context, token, expiresAt }: IframeHostPro
     );
     return off;
   }, [onMessage, send, token, pollWorkflowMutation]);
+
+  // App Blocks KV datastore (W4-v0). Five host-mediated handlers; the
+  // iframe never sees the apps DB credentials. Every reply MUST come
+  // back with the same requestId — the block-side hook times out at
+  // 30s otherwise. Errors are reported as `error: <string>` on the
+  // result payload so the hook can reject; we never throw upward and
+  // strand the bridge.
+  const trpcUtils = trpc.useUtils();
+  const storageSetMutation = trpc.apps.storage.set.useMutation();
+  const storageDeleteMutation = trpc.apps.storage.delete.useMutation();
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'APP_STORAGE_GET',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.storage.get.fetch({
+            blockToken: token,
+            key: raw.key,
+          });
+          send('APP_STORAGE_GET_RESULT', { requestId, value: result.value });
+        } catch (err) {
+          send('APP_STORAGE_GET_RESULT', {
+            requestId,
+            value: null,
+            error: storageErrorMessage(err),
+          });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
+      'APP_STORAGE_SET',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await storageSetMutation.mutateAsync({
+            blockToken: token,
+            key: raw.key,
+            value: raw.value,
+          });
+          send('APP_STORAGE_SET_RESULT', {
+            requestId,
+            ok: true,
+            sizeBytes: result.sizeBytes,
+          });
+        } catch (err) {
+          send('APP_STORAGE_SET_RESULT', {
+            requestId,
+            ok: false,
+            error: storageErrorMessage(err),
+          });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, storageSetMutation]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'APP_STORAGE_DELETE',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await storageDeleteMutation.mutateAsync({
+            blockToken: token,
+            key: raw.key,
+          });
+          send('APP_STORAGE_DELETE_RESULT', {
+            requestId,
+            ok: true,
+            deleted: result.deleted,
+          });
+        } catch (err) {
+          send('APP_STORAGE_DELETE_RESULT', {
+            requestId,
+            ok: false,
+            deleted: false,
+            error: storageErrorMessage(err),
+          });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, storageDeleteMutation]);
+
+  useEffect(() => {
+    const off = onMessage<
+      | {
+          requestId?: unknown;
+          prefix?: unknown;
+          limit?: unknown;
+          cursor?: unknown;
+        }
+      | undefined
+    >('APP_STORAGE_LIST', async (raw) => {
+      if (!raw || typeof raw.requestId !== 'string') return;
+      const requestId = raw.requestId;
+      try {
+        const prefix = typeof raw.prefix === 'string' ? raw.prefix : undefined;
+        const limit =
+          typeof raw.limit === 'number' && Number.isFinite(raw.limit)
+            ? Math.min(Math.max(Math.floor(raw.limit), 1), 200)
+            : 50;
+        const cursor = typeof raw.cursor === 'string' ? raw.cursor : undefined;
+        const result = await trpcUtils.apps.storage.list.fetch({
+          blockToken: token,
+          prefix,
+          limit,
+          cursor,
+        });
+        send('APP_STORAGE_LIST_RESULT', {
+          requestId,
+          keys: result.keys.map((k) => ({
+            key: k.key,
+            updatedAt: k.updatedAt instanceof Date ? k.updatedAt.toISOString() : String(k.updatedAt),
+          })),
+          nextCursor: result.nextCursor,
+        });
+      } catch (err) {
+        send('APP_STORAGE_LIST_RESULT', {
+          requestId,
+          keys: [],
+          error: storageErrorMessage(err),
+        });
+      }
+    });
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown } | undefined>(
+      'APP_STORAGE_QUOTA',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.storage.getQuota.fetch({ blockToken: token });
+          send('APP_STORAGE_QUOTA_RESULT', {
+            requestId,
+            usedBytes: result.usedBytes,
+            rowCount: result.rowCount,
+            limitBytes: result.limitBytes,
+            limitRows: result.limitRows,
+          });
+        } catch (err) {
+          send('APP_STORAGE_QUOTA_RESULT', {
+            requestId,
+            usedBytes: 0,
+            rowCount: 0,
+            limitBytes: 0,
+            limitRows: 0,
+            error: storageErrorMessage(err),
+          });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
 
   useEffect(() => {
     if (status !== 'ready') return;

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -21,6 +21,12 @@ export const serverSchema = z.object({
   NOTIFICATION_DB_URL: z.url(),
   NOTIFICATION_DB_REPLICA_URL: z.url(),
   DATAPACKET_DATABASE_RO_URL: z.url().optional(),
+  // App Blocks W4-KV-v0 — connection to cnpg-cluster-apps (`apps` DB) where
+  // each approved app block gets an isolated schema. civitai-web is the only
+  // service with these creds; apps never see DB credentials directly. Optional
+  // so PR previews + dev environments that haven't provisioned the apps DB
+  // yet keep starting (the storage tRPC procedures throw cleanly when unset).
+  APPS_DATABASE_URL: z.url().optional(),
   DATABASE_CONNECTION_TIMEOUT: z.coerce.number().default(0),
   DATABASE_POOL_MAX: z.coerce.number().default(20),
   NOTIFICATION_POOL_MAX: z.coerce.number().optional(),

--- a/src/pages/api/admin/apps-storage-backfill.ts
+++ b/src/pages/api/admin/apps-storage-backfill.ts
@@ -1,0 +1,117 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { dbRead } from '~/server/db/client';
+import { appsDb } from '~/server/db/appsDb';
+import { AppStorageProvisioner } from '~/server/services/apps/storage-provision.service';
+import { sanitizeAppSlug } from '~/server/utils/apps-slug';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+/**
+ * App Blocks KV datastore backfill (W4-KV-v0). Walks every approved
+ * `app_blocks` row and provisions its schema + role idempotently.
+ *
+ * Primary call path for new apps is the W2 webhook (push → build →
+ * callback → provision). This endpoint is the safety net: re-run after
+ * any rollout that might have raced provisioning, or to recover from a
+ * cnpg-cluster-apps reset.
+ *
+ * Idempotent — every DDL statement in `AppStorageProvisioner.provision`
+ * is IF NOT EXISTS / DO-block guarded, and the quota seed uses ON
+ * CONFLICT. Safe to invoke at any cadence.
+ *
+ * Auth via the existing `WebhookEndpoint(?token=...)` gate (same as
+ * sibling admin endpoints).
+ *
+ * Usage:
+ *   GET /api/admin/apps-storage-backfill?token=<WEBHOOK_TOKEN>
+ *     → list which approved apps need provisioning (dry run).
+ *
+ *   GET /api/admin/apps-storage-backfill?token=...&apply=true
+ *     → provision the listed apps and return per-app status.
+ *
+ *   GET /api/admin/apps-storage-backfill?token=...&appBlockId=apb_xxx&apply=true
+ *     → provision a single app (manual one-off).
+ */
+export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
+  if (!appsDb) {
+    res
+      .status(503)
+      .json({ ok: false, error: 'APPS_DATABASE_URL not configured — apps datastore unavailable' });
+    return;
+  }
+
+  const apply = req.query.apply === 'true' || req.query.apply === '1';
+  const targetAppBlockId =
+    typeof req.query.appBlockId === 'string' && req.query.appBlockId.length > 0
+      ? req.query.appBlockId
+      : undefined;
+
+  // Pull approved apps. status='approved' is the W2 contract — pending /
+  // rejected apps don't get storage. Limit query to id + blockId; we
+  // don't need the manifest for provisioning.
+  const apps = await dbRead.appBlock.findMany({
+    where: {
+      status: 'approved',
+      ...(targetAppBlockId ? { id: targetAppBlockId } : {}),
+    },
+    select: { id: true, blockId: true, status: true },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  type Result = {
+    appBlockId: string;
+    blockId: string;
+    slug: string | null;
+    provisioned: boolean;
+    error?: string;
+  };
+
+  const results: Result[] = [];
+
+  for (const app of apps) {
+    const slug = sanitizeAppSlug(app.blockId);
+    if (!slug) {
+      results.push({
+        appBlockId: app.id,
+        blockId: app.blockId,
+        slug: null,
+        provisioned: false,
+        error: 'blockId does not normalize to a valid slug',
+      });
+      continue;
+    }
+
+    if (!apply) {
+      // Dry-run: just enumerate.
+      results.push({
+        appBlockId: app.id,
+        blockId: app.blockId,
+        slug,
+        provisioned: false,
+      });
+      continue;
+    }
+
+    try {
+      await AppStorageProvisioner.provision({ appBlockId: app.id, slug });
+      results.push({ appBlockId: app.id, blockId: app.blockId, slug, provisioned: true });
+    } catch (err) {
+      results.push({
+        appBlockId: app.id,
+        blockId: app.blockId,
+        slug,
+        provisioned: false,
+        error: err instanceof Error ? err.message : 'unknown error',
+      });
+    }
+  }
+
+  res.status(200).json({
+    ok: true,
+    apply,
+    appsConsidered: apps.length,
+    provisioned: results.filter((r) => r.provisioned).length,
+    failures: results.filter((r) => r.error).length,
+    results,
+  });
+});

--- a/src/server/db/appsDb.ts
+++ b/src/server/db/appsDb.ts
@@ -1,0 +1,46 @@
+import { types } from 'pg';
+import { isProd } from '~/env/other';
+import { env } from '~/env/server';
+import type { AugmentedPool } from '~/server/db/db-helpers';
+import { getClient } from '~/server/db/db-helpers';
+
+declare global {
+  // eslint-disable-next-line no-var, vars-on-top
+  var globalAppsDb: AugmentedPool | undefined;
+}
+
+// Fix Dates — keep the same type-parser stance as notifDb.
+types.setTypeParser(types.builtins.TIMESTAMP, function (stringValue) {
+  return new Date(stringValue.replace(' ', 'T') + 'Z');
+});
+
+/**
+ * App Blocks KV datastore connection (cnpg-cluster-apps). civitai-web is
+ * the only service with credentials here; blocks themselves talk to this
+ * cluster only through host-mediated tRPC procedures
+ * (`apps.storage.{get,set,delete,list,getQuota}`).
+ *
+ * Optional: when `APPS_DATABASE_URL` is unset (PR previews, dev
+ * environments, the legacy stage cluster), `appsDb` is `null` and the
+ * tRPC procedures must throw cleanly rather than crash the import graph.
+ * Use `requireAppsDb()` at the procedure entry to surface a clear error.
+ */
+export let appsDb: AugmentedPool | null = null;
+
+if (!env.IS_BUILD && env.APPS_DATABASE_URL) {
+  if (isProd) {
+    appsDb = getClient({ instance: 'apps' });
+  } else {
+    if (!global.globalAppsDb) global.globalAppsDb = getClient({ instance: 'apps' });
+    appsDb = global.globalAppsDb;
+  }
+}
+
+export function requireAppsDb(): AugmentedPool {
+  if (!appsDb) {
+    throw new Error(
+      'APPS_DATABASE_URL is not configured — App Blocks KV datastore is unavailable in this environment.'
+    );
+  }
+  return appsDb;
+}

--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -43,7 +43,8 @@ type ClientInstanceType =
   | 'primaryReadLong'
   | 'notification'
   | 'notificationRead'
-  | 'datapacketRead';
+  | 'datapacketRead'
+  | 'apps';
 const instanceUrlMap: Record<ClientInstanceType, string> = {
   notification: env.NOTIFICATION_DB_URL,
   notificationRead: env.NOTIFICATION_DB_REPLICA_URL ?? env.NOTIFICATION_DB_URL,
@@ -51,6 +52,10 @@ const instanceUrlMap: Record<ClientInstanceType, string> = {
   primaryRead: env.DATABASE_REPLICA_URL ?? env.DATABASE_URL,
   primaryReadLong: env.DATABASE_REPLICA_LONG_URL ?? env.DATABASE_URL,
   datapacketRead: env.DATAPACKET_DATABASE_RO_URL ?? env.DATABASE_URL,
+  // App Blocks KV datastore — empty string sentinel when unset. appsDb
+  // never calls getClient unless APPS_DATABASE_URL is configured (see
+  // src/server/db/appsDb.ts).
+  apps: env.APPS_DATABASE_URL ?? '',
 };
 
 export function getClient(
@@ -70,6 +75,8 @@ export function getClient(
     ? 'notif-pg'
     : instance === 'datapacketRead'
     ? 'dp-read-pg'
+    : instance === 'apps'
+    ? 'apps-pg'
     : 'node-pg';
 
   // DO managed Postgres PgBouncer rejects statement_timeout as a startup parameter.

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -184,6 +184,34 @@ export const appStorageQuotaExceededCounter = registerCounterWithLabels({
   labelNames: ['app_block_id'] as const,
 });
 
+// Per-operation latency. Buckets sized for KV operations on a small CNPG
+// cluster (everything should land < 50ms in the happy path; outliers
+// beyond 250ms point at quota lookups blocked on a long write somewhere).
+function registerHistogramWithLabels<T extends string>(opts: {
+  name: string;
+  help: string;
+  labelNames: readonly T[];
+  buckets: number[];
+}) {
+  try {
+    return new client.Histogram({
+      name: PROM_PREFIX + opts.name,
+      help: opts.help,
+      labelNames: opts.labelNames as unknown as string[],
+      buckets: opts.buckets,
+    });
+  } catch {
+    return client.register.getSingleMetric(PROM_PREFIX + opts.name) as client.Histogram<T>;
+  }
+}
+
+export const appStorageLatencyHistogram = registerHistogramWithLabels({
+  name: 'app_blocks_storage_latency_seconds',
+  help: 'App Blocks KV procedure latency',
+  labelNames: ['op'] as const,
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5],
+});
+
 declare global {
   // eslint-disable-next-line no-var
   var pgGaugeInitialized: boolean;

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -164,6 +164,26 @@ export const blockBuzzAttributionWriteCounter = registerCounterWithLabels({
   labelNames: ['provider', 'scope', 'status'] as const,
 });
 
+// App Blocks KV datastore (W4-v0)
+// `op` ∈ get|set|delete|list|getQuota; `outcome` ∈ ok|unauthorized|
+// not_found|payload_too_large|quota_exceeded|error. Read-only counters
+// keep the procedure-side instrumentation cheap; heavier histograms hang
+// off a future per-app dashboard.
+export const appStorageOpsCounter = registerCounterWithLabels({
+  name: 'app_blocks_storage_ops_total',
+  help: 'App Blocks KV datastore tRPC operations',
+  labelNames: ['op', 'outcome'] as const,
+});
+
+// One quota-exceeded reject is interesting on its own (it means the
+// publisher hit the 50MB ceiling). Track per-app_block_id so we can
+// surface specific apps in alerts before they get bumped to v1.
+export const appStorageQuotaExceededCounter = registerCounterWithLabels({
+  name: 'app_blocks_storage_quota_exceeded_total',
+  help: 'App Blocks KV writes rejected because the app quota would be exceeded',
+  labelNames: ['app_block_id'] as const,
+});
+
 declare global {
   // eslint-disable-next-line no-var
   var pgGaugeInitialized: boolean;

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -1,0 +1,396 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Coverage for `apps.storage.{get,set,delete,list,getQuota}`. Mocks the
+ * pg pool + the block-token verifier so the router runs in-process and
+ * we can pin each auth/quota gate independently.
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockDbRead,
+  mockIsAppBlocksEnabled,
+  mockPool,
+  mockClient,
+  mockGetQuota,
+  mockLogToAxiom,
+} = vi.hoisted(() => {
+  const mockClient = {
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+    release: vi.fn(),
+  };
+  const mockPool = {
+    connect: vi.fn(async () => mockClient),
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+  };
+  return {
+    mockVerifyBlockToken: vi.fn(),
+    mockParseSubjectUserId: vi.fn(),
+    mockDbRead: {
+      appBlock: { findUnique: vi.fn() },
+    },
+    mockIsAppBlocksEnabled: vi.fn(async () => true),
+    mockPool,
+    mockClient,
+    mockGetQuota: vi.fn(),
+    mockLogToAxiom: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: mockDbRead,
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/server/db/appsDb', () => ({
+  requireAppsDb: () => mockPool,
+}));
+vi.mock('~/server/services/apps/storage-provision.service', () => ({
+  AppStorageProvisioner: {
+    getQuota: (...args: unknown[]) => mockGetQuota(...args),
+  },
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => mockLogToAxiom(...args),
+}));
+
+import { appsRouter } from '../apps.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function validClaims(over: Record<string, unknown> = {}) {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti_test',
+    blockId: 'generate-from-model',
+    appId: 'app_test',
+    blockInstanceId: 'mbi_inst',
+    ctx: { modelId: 7, slotId: 'model.sidebar_top' },
+    scopes: [],
+    ...over,
+  };
+}
+
+function fakeCtx() {
+  return {
+    acceptableOrigin: true,
+    user: undefined,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+beforeEach(() => {
+  mockVerifyBlockToken.mockReset();
+  mockParseSubjectUserId.mockReset();
+  mockDbRead.appBlock.findUnique.mockReset();
+  mockIsAppBlocksEnabled.mockReset();
+  mockPool.connect.mockClear();
+  mockPool.query.mockReset();
+  mockClient.query.mockReset();
+  mockClient.release.mockClear();
+  mockGetQuota.mockReset();
+  mockLogToAxiom.mockReset();
+
+  // Sane defaults the happy-path tests inherit.
+  mockIsAppBlocksEnabled.mockImplementation(async () => true);
+  mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
+  mockDbRead.appBlock.findUnique.mockResolvedValue({
+    id: 'apb_test',
+    status: 'approved',
+  });
+  mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+  mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
+  mockLogToAxiom.mockResolvedValue(undefined);
+});
+
+describe('apps.storage shared gates', () => {
+  it('rejects when the Flipt flag is dark', async () => {
+    mockIsAppBlocksEnabled.mockImplementationOnce(async () => false);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.get({ blockToken: 't', key: 'k' })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+  });
+
+  it('rejects an invalid block token with UNAUTHORIZED', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(null);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.get({ blockToken: 't', key: 'k' })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('rejects when the AppBlock row is missing (NOT_FOUND)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce(null);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.get({ blockToken: 't', key: 'k' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('rejects when the AppBlock status is not approved (FORBIDDEN)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce({
+      id: 'apb_pending',
+      status: 'pending',
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.get({ blockToken: 't', key: 'k' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('rejects a blockId that doesnt sanitize to a valid slug', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ blockId: '!!' }));
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce({
+      id: 'apb_test',
+      status: 'approved',
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.get({ blockToken: 't', key: 'k' })
+    ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+  });
+});
+
+describe('apps.storage.get', () => {
+  it('returns { value: null } for anon viewers (no per-anon storage in v0)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.get({ blockToken: 't', key: 'k' });
+    expect(out).toEqual({ value: null });
+    // anon path must not hit the DB pool
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('reads from the schema-scoped table and returns the stored value', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ value: { hello: 'world' } }],
+      rowCount: 1,
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.get({ blockToken: 't', key: 'lastPrompt' });
+    expect(out).toEqual({ value: { hello: 'world' } });
+
+    const sql = mockPool.query.mock.calls[0][0] as string;
+    const params = mockPool.query.mock.calls[0][1] as unknown[];
+    expect(sql).toContain('"app_generate_from_model".kv');
+    expect(params).toEqual(['mbi_inst', 42, 'lastPrompt']);
+  });
+
+  it('returns { value: null } when the key isnt set', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    expect(await caller.storage.get({ blockToken: 't', key: 'k' })).toEqual({ value: null });
+  });
+});
+
+describe('apps.storage.set', () => {
+  it('refuses anon writes', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversize values with PAYLOAD_TOO_LARGE', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    const big = 'x'.repeat(64 * 1024 + 1);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: big })
+    ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects writes that would cross the 50MB quota', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    // quota nearly full
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{ used_bytes: String(50 * 1024 * 1024 - 100), row_count: '1' }],
+        rowCount: 1,
+      })
+      // no existing row for this key
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'x'.repeat(500) })
+    ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE', message: /quota/ });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('happy path commits the upsert inside a SET LOCAL transaction', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query
+      // quota
+      .mockResolvedValueOnce({
+        rows: [{ used_bytes: '0', row_count: '0' }],
+        rowCount: 1,
+      })
+      // existing row
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.set({
+      blockToken: 't',
+      key: 'lastPrompt',
+      value: { v: 'cyberpunk cat' },
+    });
+    expect(out.ok).toBe(true);
+
+    const sqls = (mockClient.query.mock.calls as Array<[string, unknown?]>).map(
+      (call) => call[0]
+    );
+    expect(sqls[0]).toBe('BEGIN');
+    expect(sqls[sqls.length - 1]).toBe('COMMIT');
+    expect(sqls.some((s) => s.startsWith('SET LOCAL app.current_app_block_id'))).toBe(true);
+    expect(sqls.some((s) => s.includes('INSERT INTO "app_generate_from_model".kv'))).toBe(true);
+    expect(mockClient.release).toHaveBeenCalledOnce();
+  });
+
+  it('uses the net delta from an existing row to size the quota check', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    // Pretend used_bytes is the per-app limit; the only reason this write
+    // is allowed to land is the existing row's old size shrinks to the
+    // new value.
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{ used_bytes: String(50 * 1024 * 1024), row_count: '1' }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [{ size_bytes: 5000 }], rowCount: 1 });
+
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: 'short' })
+    ).resolves.toMatchObject({ ok: true });
+  });
+});
+
+describe('apps.storage.delete', () => {
+  it('refuses anon deletes', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(caller.storage.delete({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('reports deleted: false when nothing matched', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockClient.query.mockImplementation(async (sql: string) => {
+      if (sql.startsWith('DELETE')) return { rowCount: 0, rows: [] };
+      return { rowCount: 0, rows: [] };
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.delete({ blockToken: 't', key: 'k' });
+    expect(out).toEqual({ ok: true, deleted: false });
+  });
+
+  it('reports deleted: true when the row existed', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockClient.query.mockImplementation(async (sql: string) => {
+      if (sql.startsWith('DELETE')) return { rowCount: 1, rows: [] };
+      return { rowCount: 0, rows: [] };
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.delete({ blockToken: 't', key: 'k' });
+    expect(out).toEqual({ ok: true, deleted: true });
+  });
+});
+
+describe('apps.storage.list', () => {
+  it('returns empty for anon viewers', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.list({ blockToken: 't' });
+    expect(out).toEqual({ keys: [], nextCursor: undefined });
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('emits nextCursor only when the page filled', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        { key: 'a', updated_at: new Date('2026-01-01T00:00:00Z') },
+        { key: 'b', updated_at: new Date('2026-01-02T00:00:00Z') },
+      ],
+      rowCount: 2,
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.list({ blockToken: 't', limit: 2 });
+    expect(out.keys.map((k) => k.key)).toEqual(['a', 'b']);
+    expect(out.nextCursor).toBe(Buffer.from('b', 'utf8').toString('base64'));
+  });
+
+  it('omits nextCursor when partial page', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ key: 'a', updated_at: new Date() }],
+      rowCount: 1,
+    });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.list({ blockToken: 't', limit: 5 });
+    expect(out.nextCursor).toBeUndefined();
+  });
+
+  it('escapes LIKE wildcards in the user-supplied prefix', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await caller.storage.list({ blockToken: 't', prefix: '50%_off' });
+    const params = mockPool.query.mock.calls[0][1] as unknown[];
+    expect(params[2]).toBe('50\\%\\_off%');
+  });
+});
+
+describe('apps.storage.getQuota', () => {
+  it('proxies the provisioner snapshot + ships the v0 limits', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockGetQuota.mockResolvedValueOnce({ usedBytes: 12345, rowCount: 7 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.getQuota({ blockToken: 't' });
+    expect(out).toEqual({
+      usedBytes: 12345,
+      rowCount: 7,
+      limitBytes: 50 * 1024 * 1024,
+      limitRows: 1_000_000,
+    });
+    expect(mockGetQuota).toHaveBeenCalledWith({
+      slug: 'generate_from_model',
+      appBlockId: 'apb_test',
+    });
+  });
+
+  it('returns zeroes when the schema isnt provisioned yet', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockGetQuota.mockResolvedValueOnce(null);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.getQuota({ blockToken: 't' });
+    expect(out.usedBytes).toBe(0);
+    expect(out.rowCount).toBe(0);
+  });
+});

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -1,0 +1,398 @@
+// App Blocks tRPC root (W4-KV-v0).
+//
+// Mounted at `trpc.apps.*`. v0 ships a single sub-router (`storage`) for
+// the KV datastore. v1 will add `apps.sql.*` (arbitrary query under a
+// `storage:sql` scope) and `apps.migrate.*` (per-app schema migrations
+// from the repo's `migrations/` directory).
+//
+// Every procedure auth-gates on the block JWT — no civitai session is
+// involved. The iframe is never trusted with raw DB credentials or query
+// construction; it sends a typed bridge message, the host calls one of
+// these procedures, and the procedure scopes the read/write to the
+// resolved (app, instance, user) tuple.
+
+import { TRPCError } from '@trpc/server';
+import * as z from 'zod';
+import { dbRead } from '~/server/db/client';
+import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
+import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { AppStorageProvisioner } from '~/server/services/apps/storage-provision.service';
+import {
+  appStorageOpsCounter,
+  appStorageQuotaExceededCounter,
+} from '~/server/prom/client';
+import { logToAxiom } from '~/server/logging/client';
+import { requireAppsDb } from '~/server/db/appsDb';
+import { appSchemaIdent, sanitizeAppSlug } from '~/server/utils/apps-slug';
+import { middleware, publicProcedure, router } from '~/server/trpc';
+
+// 50 MB per-app quota. Soft-cap warnings + dynamic quotas are deferred
+// to v1; v0 hard-rejects writes that would cross this threshold.
+const APP_QUOTA_BYTES = 50 * 1024 * 1024;
+
+// 64 KB per individual KV value — a single oversized write can't burn
+// through quota on a single call. v1 SQL access removes this cap (quota
+// tracker becomes the only ceiling).
+const PER_VALUE_BYTE_CAP = 64 * 1024;
+
+// 1 million rows per app — companion budget to APP_QUOTA_BYTES. Trigger
+// keeps row_count current; gate runs on the cheap counter read.
+const APP_ROW_LIMIT = 1_000_000;
+
+const STORAGE_LOG = 'app-storage-trpc';
+
+const enforceAppBlocksFlag = middleware(async ({ next, type }) => {
+  if (await isAppBlocksEnabled()) return next();
+  // Mutations + queries both refuse when the flag is dark — anything else
+  // gives the block a misleading-success path. The block already gates
+  // its own UI on host signals, so a clean UNAUTHORIZED is fine.
+  if (type === 'query') {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+  }
+  throw new TRPCError({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+});
+
+/**
+ * Shared verify + resolve. Returns the validated tuple every storage
+ * procedure needs:
+ *  - userId  — null for anon (caller decides whether to allow)
+ *  - slug    — sanitized from claims.blockId, identifier-safe
+ *  - appBlockId — the AppBlock.id PK (quota row key)
+ *  - blockInstanceId — from claims, untouched
+ *
+ * Throws TRPCError UNAUTHORIZED on token failures, NOT_FOUND when the
+ * AppBlock has been deleted or isn't approved.
+ */
+async function resolveStorageContext(blockToken: string, op: StorageOp): Promise<{
+  userId: number | null;
+  slug: string;
+  appBlockId: string;
+  blockInstanceId: string;
+}> {
+  const claims = await verifyBlockToken(blockToken);
+  if (!claims) {
+    appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+  }
+  const slug = sanitizeAppSlug(claims.blockId);
+  if (!slug) {
+    appStorageOpsCounter.inc({ op, outcome: 'error' });
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'block id is not a valid storage slug',
+    });
+  }
+  const block = await dbRead.appBlock.findUnique({
+    where: { appId_blockId: { appId: claims.appId, blockId: claims.blockId } },
+    select: { id: true, status: true },
+  });
+  if (!block) {
+    appStorageOpsCounter.inc({ op, outcome: 'not_found' });
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'app block not found' });
+  }
+  if (block.status !== 'approved') {
+    appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'app block is not approved' });
+  }
+  const userId = parseSubjectUserId(claims.sub);
+  return {
+    userId,
+    slug,
+    appBlockId: block.id,
+    blockInstanceId: claims.blockInstanceId,
+  };
+}
+
+type StorageOp = 'get' | 'set' | 'delete' | 'list' | 'getQuota';
+
+const blockTokenInput = z.object({ blockToken: z.string().min(1) });
+
+const keyInput = z.string().min(1).max(200);
+
+export const appsStorageRouter = router({
+  /**
+   * Read a key for the (block_instance, user) tuple. Returns null when
+   * the key doesn't exist OR when the viewer is anon (no per-anon
+   * storage in v0). Treating anon as a clean-null lets blocks render
+   * defaults without a 401 round-trip.
+   */
+  get: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .input(blockTokenInput.extend({ key: keyInput }))
+    .query(async ({ input }) => {
+      const { userId, slug, blockInstanceId } = await resolveStorageContext(
+        input.blockToken,
+        'get'
+      );
+      if (userId == null) {
+        appStorageOpsCounter.inc({ op: 'get', outcome: 'ok' });
+        return { value: null as unknown };
+      }
+      const pool = requireAppsDb();
+      const rows = (
+        await pool.query<{ value: unknown }>(
+          `SELECT value FROM ${appSchemaIdent(slug)}.kv
+             WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+          [blockInstanceId, userId, input.key]
+        )
+      ).rows;
+      appStorageOpsCounter.inc({ op: 'get', outcome: 'ok' });
+      return { value: rows[0]?.value ?? null };
+    }),
+
+  /**
+   * Upsert a value. Validates 64KB per-value cap pre-flight, then checks
+   * the running quota; the trigger function updates the quota row after
+   * the write lands so subsequent calls see fresh used_bytes. Anon
+   * writers hit UNAUTHORIZED — anon viewers have no stable identifier
+   * to scope writes to.
+   */
+  set: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      blockTokenInput.extend({
+        key: keyInput,
+        // value is intentionally `unknown` here — the server-side cap is
+        // by byte-size, not by structural shape. Apps choose their own
+        // value schema; the cap keeps the per-write budget bounded.
+        value: z.unknown(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const { userId, slug, appBlockId, blockInstanceId } = await resolveStorageContext(
+        input.blockToken,
+        'set'
+      );
+      if (userId == null) {
+        appStorageOpsCounter.inc({ op: 'set', outcome: 'unauthorized' });
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'storage requires an authenticated viewer',
+        });
+      }
+
+      const serialized = JSON.stringify(input.value ?? null);
+      const byteSize = Buffer.byteLength(serialized, 'utf8');
+      if (byteSize > PER_VALUE_BYTE_CAP) {
+        appStorageOpsCounter.inc({ op: 'set', outcome: 'payload_too_large' });
+        throw new TRPCError({
+          code: 'PAYLOAD_TOO_LARGE',
+          message: `value exceeds ${PER_VALUE_BYTE_CAP / 1024}KB cap`,
+        });
+      }
+
+      const pool = requireAppsDb();
+      const schema = appSchemaIdent(slug);
+
+      // Pre-flight quota read. used_bytes already reflects all previous
+      // writes through the trigger. Worst case the gate is one write
+      // out of date (a near-simultaneous write from another tab); we
+      // accept a single value's overshoot in exchange for not holding a
+      // row lock for the duration of the write.
+      const quotaRows = (
+        await pool.query<{ used_bytes: string; row_count: string }>(
+          `SELECT used_bytes::text, row_count::text FROM ${schema}.quota WHERE app_block_id = $1`,
+          [appBlockId]
+        )
+      ).rows;
+      const usedBytes = Number(quotaRows[0]?.used_bytes ?? '0');
+      const rowCount = Number(quotaRows[0]?.row_count ?? '0');
+
+      // For an update we need the old size to know the net delta;
+      // skipping a pre-flight read on update would let an in-place
+      // shrink falsely fail the quota gate. Fetch it once cheaply.
+      const existing = (
+        await pool.query<{ size_bytes: number }>(
+          `SELECT size_bytes FROM ${schema}.kv
+            WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+          [blockInstanceId, userId, input.key]
+        )
+      ).rows;
+      const oldSize = existing[0]?.size_bytes ?? 0;
+      const isInsert = existing.length === 0;
+      const netDelta = byteSize - oldSize;
+
+      if (usedBytes + netDelta > APP_QUOTA_BYTES) {
+        appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        logToAxiom(
+          {
+            event: 'quota_exceeded',
+            appBlockId,
+            usedBytes,
+            attemptedBytes: byteSize,
+            key: input.key,
+          },
+          STORAGE_LOG
+        ).catch(() => {});
+        throw new TRPCError({
+          code: 'PAYLOAD_TOO_LARGE',
+          message: 'app quota exceeded',
+        });
+      }
+      if (isInsert && rowCount + 1 > APP_ROW_LIMIT) {
+        appStorageOpsCounter.inc({ op: 'set', outcome: 'quota_exceeded' });
+        appStorageQuotaExceededCounter.inc({ app_block_id: appBlockId });
+        throw new TRPCError({
+          code: 'PAYLOAD_TOO_LARGE',
+          message: 'app row limit exceeded',
+        });
+      }
+
+      // Single connection so SET LOCAL is bound to the same backend that
+      // runs the trigger. SET LOCAL ends with COMMIT/ROLLBACK.
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        // current_setting() in the trigger uses the GUC `app.current_app_block_id`.
+        // SET LOCAL has no parameter form — quote the literal via the regex-validated
+        // appBlockId. (We don't accept it from the user; it came out of the AppBlock
+        // PK lookup above.)
+        await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
+        await client.query(
+          `INSERT INTO ${schema}.kv (block_instance_id, user_id, key, value)
+           VALUES ($1, $2, $3, $4::jsonb)
+           ON CONFLICT (block_instance_id, user_id, key)
+           DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+          [blockInstanceId, userId, input.key, serialized]
+        );
+        await client.query('COMMIT');
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        appStorageOpsCounter.inc({ op: 'set', outcome: 'error' });
+        throw err;
+      } finally {
+        client.release();
+      }
+
+      appStorageOpsCounter.inc({ op: 'set', outcome: 'ok' });
+      return { ok: true as const, sizeBytes: byteSize };
+    }),
+
+  delete: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .input(blockTokenInput.extend({ key: keyInput }))
+    .mutation(async ({ input }) => {
+      const { userId, slug, appBlockId, blockInstanceId } = await resolveStorageContext(
+        input.blockToken,
+        'delete'
+      );
+      if (userId == null) {
+        appStorageOpsCounter.inc({ op: 'delete', outcome: 'unauthorized' });
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'storage requires an authenticated viewer',
+        });
+      }
+      const pool = requireAppsDb();
+      const schema = appSchemaIdent(slug);
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
+        const result = await client.query(
+          `DELETE FROM ${schema}.kv
+            WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+          [blockInstanceId, userId, input.key]
+        );
+        await client.query('COMMIT');
+        appStorageOpsCounter.inc({ op: 'delete', outcome: 'ok' });
+        return { ok: true as const, deleted: (result.rowCount ?? 0) > 0 };
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        appStorageOpsCounter.inc({ op: 'delete', outcome: 'error' });
+        throw err;
+      } finally {
+        client.release();
+      }
+    }),
+
+  /**
+   * Cursor-paginated key list for the (block_instance, user) tuple.
+   * Returns key + updated_at only — values are fetched on demand via
+   * `get(key)`. `cursor` is the base64 of the last key returned;
+   * `nextCursor` is undefined when fewer than `limit` rows came back.
+   */
+  list: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      blockTokenInput.extend({
+        prefix: z.string().max(200).optional(),
+        limit: z.number().int().min(1).max(200).default(50),
+        cursor: z.string().max(400).optional(),
+      })
+    )
+    .query(async ({ input }) => {
+      const { userId, slug, blockInstanceId } = await resolveStorageContext(
+        input.blockToken,
+        'list'
+      );
+      if (userId == null) {
+        appStorageOpsCounter.inc({ op: 'list', outcome: 'ok' });
+        return { keys: [], nextCursor: undefined as string | undefined };
+      }
+
+      const pool = requireAppsDb();
+      const afterKey = input.cursor
+        ? Buffer.from(input.cursor, 'base64').toString('utf8')
+        : '';
+      // % escape so a user-supplied prefix can't break out via wildcards
+      const escapedPrefix = (input.prefix ?? '').replace(/([\\%_])/g, '\\$1');
+      const prefixPattern = `${escapedPrefix}%`;
+
+      const rows = (
+        await pool.query<{ key: string; updated_at: Date }>(
+          `SELECT key, updated_at FROM ${appSchemaIdent(slug)}.kv
+             WHERE block_instance_id = $1 AND user_id = $2
+               AND key LIKE $3 ESCAPE '\\'
+               AND key > $4
+             ORDER BY key
+             LIMIT $5`,
+          [blockInstanceId, userId, prefixPattern, afterKey, input.limit]
+        )
+      ).rows;
+
+      const nextCursor =
+        rows.length === input.limit
+          ? Buffer.from(rows[rows.length - 1].key, 'utf8').toString('base64')
+          : undefined;
+
+      appStorageOpsCounter.inc({ op: 'list', outcome: 'ok' });
+      return {
+        keys: rows.map((r) => ({ key: r.key, updatedAt: r.updated_at })),
+        nextCursor,
+      };
+    }),
+
+  /**
+   * Diagnostic / future quota-aware UI. Returns the live quota row plus
+   * the v0 limits so a settings panel can show "used 12 MB of 50 MB"
+   * without hard-coding the cap on the client.
+   */
+  getQuota: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .input(blockTokenInput)
+    .query(async ({ input }) => {
+      const { slug, appBlockId } = await resolveStorageContext(input.blockToken, 'getQuota');
+      const quota = await AppStorageProvisioner.getQuota({ slug, appBlockId });
+      appStorageOpsCounter.inc({ op: 'getQuota', outcome: 'ok' });
+      return {
+        usedBytes: quota?.usedBytes ?? 0,
+        rowCount: quota?.rowCount ?? 0,
+        limitBytes: APP_QUOTA_BYTES,
+        limitRows: APP_ROW_LIMIT,
+      };
+    }),
+});
+
+export const appsRouter = router({
+  storage: appsStorageRouter,
+});
+
+// Postgres literal quoting — used ONLY for the regex-validated appBlockId
+// in the SET LOCAL GUC where $1 placeholders are not accepted. The
+// AppBlock.id format is `apb_<26 ULID chars>`; quote-doubling is
+// belt-and-suspenders since the AppBlock PK is server-issued.
+function pgQuoteLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -18,6 +18,7 @@ import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { AppStorageProvisioner } from '~/server/services/apps/storage-provision.service';
 import {
+  appStorageLatencyHistogram,
   appStorageOpsCounter,
   appStorageQuotaExceededCounter,
 } from '~/server/prom/client';
@@ -120,24 +121,29 @@ export const appsStorageRouter = router({
     .use(enforceAppBlocksFlag)
     .input(blockTokenInput.extend({ key: keyInput }))
     .query(async ({ input }) => {
-      const { userId, slug, blockInstanceId } = await resolveStorageContext(
-        input.blockToken,
-        'get'
-      );
-      if (userId == null) {
+      const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'get' });
+      try {
+        const { userId, slug, blockInstanceId } = await resolveStorageContext(
+          input.blockToken,
+          'get'
+        );
+        if (userId == null) {
+          appStorageOpsCounter.inc({ op: 'get', outcome: 'ok' });
+          return { value: null as unknown };
+        }
+        const pool = requireAppsDb();
+        const rows = (
+          await pool.query<{ value: unknown }>(
+            `SELECT value FROM ${appSchemaIdent(slug)}.kv
+               WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+            [blockInstanceId, userId, input.key]
+          )
+        ).rows;
         appStorageOpsCounter.inc({ op: 'get', outcome: 'ok' });
-        return { value: null as unknown };
+        return { value: rows[0]?.value ?? null };
+      } finally {
+        stopTimer();
       }
-      const pool = requireAppsDb();
-      const rows = (
-        await pool.query<{ value: unknown }>(
-          `SELECT value FROM ${appSchemaIdent(slug)}.kv
-             WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
-          [blockInstanceId, userId, input.key]
-        )
-      ).rows;
-      appStorageOpsCounter.inc({ op: 'get', outcome: 'ok' });
-      return { value: rows[0]?.value ?? null };
     }),
 
   /**
@@ -159,6 +165,8 @@ export const appsStorageRouter = router({
       })
     )
     .mutation(async ({ input }) => {
+      const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'set' });
+      try {
       const { userId, slug, appBlockId, blockInstanceId } = await resolveStorageContext(
         input.blockToken,
         'set'
@@ -266,44 +274,77 @@ export const appsStorageRouter = router({
       }
 
       appStorageOpsCounter.inc({ op: 'set', outcome: 'ok' });
+      logToAxiom(
+        {
+          event: 'set',
+          appBlockId,
+          blockInstanceId,
+          userId,
+          key: input.key,
+          sizeBytes: byteSize,
+          isInsert,
+        },
+        STORAGE_LOG
+      ).catch(() => {});
       return { ok: true as const, sizeBytes: byteSize };
+      } finally {
+        stopTimer();
+      }
     }),
 
   delete: publicProcedure
     .use(enforceAppBlocksFlag)
     .input(blockTokenInput.extend({ key: keyInput }))
     .mutation(async ({ input }) => {
-      const { userId, slug, appBlockId, blockInstanceId } = await resolveStorageContext(
-        input.blockToken,
-        'delete'
-      );
-      if (userId == null) {
-        appStorageOpsCounter.inc({ op: 'delete', outcome: 'unauthorized' });
-        throw new TRPCError({
-          code: 'UNAUTHORIZED',
-          message: 'storage requires an authenticated viewer',
-        });
-      }
-      const pool = requireAppsDb();
-      const schema = appSchemaIdent(slug);
-      const client = await pool.connect();
+      const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'delete' });
       try {
-        await client.query('BEGIN');
-        await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
-        const result = await client.query(
-          `DELETE FROM ${schema}.kv
-            WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
-          [blockInstanceId, userId, input.key]
+        const { userId, slug, appBlockId, blockInstanceId } = await resolveStorageContext(
+          input.blockToken,
+          'delete'
         );
-        await client.query('COMMIT');
-        appStorageOpsCounter.inc({ op: 'delete', outcome: 'ok' });
-        return { ok: true as const, deleted: (result.rowCount ?? 0) > 0 };
-      } catch (err) {
-        await client.query('ROLLBACK').catch(() => {});
-        appStorageOpsCounter.inc({ op: 'delete', outcome: 'error' });
-        throw err;
+        if (userId == null) {
+          appStorageOpsCounter.inc({ op: 'delete', outcome: 'unauthorized' });
+          throw new TRPCError({
+            code: 'UNAUTHORIZED',
+            message: 'storage requires an authenticated viewer',
+          });
+        }
+        const pool = requireAppsDb();
+        const schema = appSchemaIdent(slug);
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+          await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
+          const result = await client.query(
+            `DELETE FROM ${schema}.kv
+              WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
+            [blockInstanceId, userId, input.key]
+          );
+          await client.query('COMMIT');
+          appStorageOpsCounter.inc({ op: 'delete', outcome: 'ok' });
+          const deleted = (result.rowCount ?? 0) > 0;
+          if (deleted) {
+            logToAxiom(
+              {
+                event: 'delete',
+                appBlockId,
+                blockInstanceId,
+                userId,
+                key: input.key,
+              },
+              STORAGE_LOG
+            ).catch(() => {});
+          }
+          return { ok: true as const, deleted };
+        } catch (err) {
+          await client.query('ROLLBACK').catch(() => {});
+          appStorageOpsCounter.inc({ op: 'delete', outcome: 'error' });
+          throw err;
+        } finally {
+          client.release();
+        }
       } finally {
-        client.release();
+        stopTimer();
       }
     }),
 
@@ -323,45 +364,50 @@ export const appsStorageRouter = router({
       })
     )
     .query(async ({ input }) => {
-      const { userId, slug, blockInstanceId } = await resolveStorageContext(
-        input.blockToken,
-        'list'
-      );
-      if (userId == null) {
+      const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'list' });
+      try {
+        const { userId, slug, blockInstanceId } = await resolveStorageContext(
+          input.blockToken,
+          'list'
+        );
+        if (userId == null) {
+          appStorageOpsCounter.inc({ op: 'list', outcome: 'ok' });
+          return { keys: [], nextCursor: undefined as string | undefined };
+        }
+
+        const pool = requireAppsDb();
+        const afterKey = input.cursor
+          ? Buffer.from(input.cursor, 'base64').toString('utf8')
+          : '';
+        // % escape so a user-supplied prefix can't break out via wildcards
+        const escapedPrefix = (input.prefix ?? '').replace(/([\\%_])/g, '\\$1');
+        const prefixPattern = `${escapedPrefix}%`;
+
+        const rows = (
+          await pool.query<{ key: string; updated_at: Date }>(
+            `SELECT key, updated_at FROM ${appSchemaIdent(slug)}.kv
+               WHERE block_instance_id = $1 AND user_id = $2
+                 AND key LIKE $3 ESCAPE '\\'
+                 AND key > $4
+               ORDER BY key
+               LIMIT $5`,
+            [blockInstanceId, userId, prefixPattern, afterKey, input.limit]
+          )
+        ).rows;
+
+        const nextCursor =
+          rows.length === input.limit
+            ? Buffer.from(rows[rows.length - 1].key, 'utf8').toString('base64')
+            : undefined;
+
         appStorageOpsCounter.inc({ op: 'list', outcome: 'ok' });
-        return { keys: [], nextCursor: undefined as string | undefined };
+        return {
+          keys: rows.map((r) => ({ key: r.key, updatedAt: r.updated_at })),
+          nextCursor,
+        };
+      } finally {
+        stopTimer();
       }
-
-      const pool = requireAppsDb();
-      const afterKey = input.cursor
-        ? Buffer.from(input.cursor, 'base64').toString('utf8')
-        : '';
-      // % escape so a user-supplied prefix can't break out via wildcards
-      const escapedPrefix = (input.prefix ?? '').replace(/([\\%_])/g, '\\$1');
-      const prefixPattern = `${escapedPrefix}%`;
-
-      const rows = (
-        await pool.query<{ key: string; updated_at: Date }>(
-          `SELECT key, updated_at FROM ${appSchemaIdent(slug)}.kv
-             WHERE block_instance_id = $1 AND user_id = $2
-               AND key LIKE $3 ESCAPE '\\'
-               AND key > $4
-             ORDER BY key
-             LIMIT $5`,
-          [blockInstanceId, userId, prefixPattern, afterKey, input.limit]
-        )
-      ).rows;
-
-      const nextCursor =
-        rows.length === input.limit
-          ? Buffer.from(rows[rows.length - 1].key, 'utf8').toString('base64')
-          : undefined;
-
-      appStorageOpsCounter.inc({ op: 'list', outcome: 'ok' });
-      return {
-        keys: rows.map((r) => ({ key: r.key, updatedAt: r.updated_at })),
-        nextCursor,
-      };
     }),
 
   /**
@@ -373,15 +419,20 @@ export const appsStorageRouter = router({
     .use(enforceAppBlocksFlag)
     .input(blockTokenInput)
     .query(async ({ input }) => {
-      const { slug, appBlockId } = await resolveStorageContext(input.blockToken, 'getQuota');
-      const quota = await AppStorageProvisioner.getQuota({ slug, appBlockId });
-      appStorageOpsCounter.inc({ op: 'getQuota', outcome: 'ok' });
-      return {
-        usedBytes: quota?.usedBytes ?? 0,
-        rowCount: quota?.rowCount ?? 0,
-        limitBytes: APP_QUOTA_BYTES,
-        limitRows: APP_ROW_LIMIT,
-      };
+      const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'getQuota' });
+      try {
+        const { slug, appBlockId } = await resolveStorageContext(input.blockToken, 'getQuota');
+        const quota = await AppStorageProvisioner.getQuota({ slug, appBlockId });
+        appStorageOpsCounter.inc({ op: 'getQuota', outcome: 'ok' });
+        return {
+          usedBytes: quota?.usedBytes ?? 0,
+          rowCount: quota?.rowCount ?? 0,
+          limitBytes: APP_QUOTA_BYTES,
+          limitRows: APP_ROW_LIMIT,
+        };
+      } finally {
+        stopTimer();
+      }
     }),
 });
 

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -91,6 +91,7 @@ import { strikeRouter } from '~/server/routers/strike.router';
 import { rewardsBonusEventRouter } from './rewards-bonus-event.router';
 import { oauthClientRouter } from '~/server/routers/oauth-client.router';
 import { oauthConsentRouter } from '~/server/routers/oauth-consent.router';
+import { appsRouter } from '~/server/routers/apps.router';
 
 export const appRouter = router({
   account: accountRouter,
@@ -185,6 +186,7 @@ export const appRouter = router({
   oauthConsent: oauthConsentRouter,
   scannerReview: scannerReviewRouter,
   blocks: blocksRouter,
+  apps: appsRouter,
 });
 
 // export type definition of API

--- a/src/server/services/apps/__tests__/storage-provision.service.test.ts
+++ b/src/server/services/apps/__tests__/storage-provision.service.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the AppStorageProvisioner. Focus is on the contract with
+ * the pg client (idempotent DDL, txn boundaries, slug validation) — the
+ * actual SQL is exercised end-to-end in a per-PR integration smoke that
+ * lives outside this fast unit suite.
+ */
+
+const { mockClient, mockPool, capturedQueries } = vi.hoisted(() => {
+  type Capture = { sql: string; params?: unknown[] };
+  const capturedQueries: Capture[] = [];
+  const mockClient = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      capturedQueries.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    }),
+    release: vi.fn(),
+  };
+  const mockPool = {
+    connect: vi.fn(async () => mockClient),
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+  };
+  return { mockClient, mockPool, capturedQueries };
+});
+
+vi.mock('~/server/db/appsDb', () => ({
+  requireAppsDb: () => mockPool,
+}));
+
+import { AppStorageProvisioner } from '../storage-provision.service';
+
+beforeEach(() => {
+  mockClient.query.mockClear();
+  mockClient.release.mockClear();
+  mockPool.connect.mockClear();
+  mockPool.query.mockClear();
+  capturedQueries.length = 0;
+});
+
+describe('AppStorageProvisioner.provision', () => {
+  it('rejects an invalid slug before touching the pool', async () => {
+    await expect(
+      AppStorageProvisioner.provision({ appBlockId: 'apb_x', slug: 'bad-slug' })
+    ).rejects.toThrow(/invalid slug/);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty appBlockId', async () => {
+    await expect(
+      AppStorageProvisioner.provision({ appBlockId: '', slug: 'generate_from_model' })
+    ).rejects.toThrow(/appBlockId required/);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('wraps DDL in a transaction and releases the client', async () => {
+    await AppStorageProvisioner.provision({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+    });
+    const sqlLines = capturedQueries.map((q) => q.sql.trim().split('\n')[0]);
+    expect(sqlLines[0]).toBe('BEGIN');
+    expect(sqlLines[sqlLines.length - 1]).toBe('COMMIT');
+    expect(mockClient.release).toHaveBeenCalledOnce();
+  });
+
+  it('issues every DDL statement with the quoted per-slug identifier', async () => {
+    await AppStorageProvisioner.provision({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+    });
+    const joined = capturedQueries.map((q) => q.sql).join('\n');
+    expect(joined).toContain('"app_generate_from_model"');
+    expect(joined).toContain('"app_generate_from_model_role"');
+    // Spot-check the core shape lands
+    expect(joined).toContain('CREATE SCHEMA IF NOT EXISTS "app_generate_from_model"');
+    expect(joined).toContain('CREATE TABLE IF NOT EXISTS "app_generate_from_model".kv');
+    expect(joined).toContain('CREATE TABLE IF NOT EXISTS "app_generate_from_model".quota');
+    expect(joined).toContain('CREATE OR REPLACE FUNCTION "app_generate_from_model".kv_quota_trigger()');
+    expect(joined).toContain('CREATE TRIGGER kv_quota_trg');
+  });
+
+  it('seeds the quota row with the provided appBlockId via a parameterized insert', async () => {
+    await AppStorageProvisioner.provision({
+      appBlockId: 'apb_seed_value',
+      slug: 'generate_from_model',
+    });
+    const insert = capturedQueries.find((q) =>
+      q.sql.includes('INSERT INTO "app_generate_from_model".quota')
+    );
+    expect(insert).toBeDefined();
+    expect(insert?.params).toEqual(['apb_seed_value']);
+    expect(insert?.sql).toContain('ON CONFLICT (app_block_id) DO NOTHING');
+  });
+
+  it('rolls back when a statement throws + still releases the client', async () => {
+    let nth = 0;
+    mockClient.query.mockImplementation(async (sql: string) => {
+      nth++;
+      if (sql.startsWith('CREATE TABLE IF NOT EXISTS "app_generate_from_model".kv')) {
+        throw new Error('boom');
+      }
+      capturedQueries.push({ sql });
+      return { rows: [], rowCount: 0 };
+    });
+
+    await expect(
+      AppStorageProvisioner.provision({
+        appBlockId: 'apb_test',
+        slug: 'generate_from_model',
+      })
+    ).rejects.toThrow(/boom/);
+    expect(capturedQueries.map((q) => q.sql.trim().split('\n')[0])).toContain('ROLLBACK');
+    expect(mockClient.release).toHaveBeenCalledOnce();
+    expect(nth).toBeGreaterThan(0);
+  });
+});
+
+describe('AppStorageProvisioner.deprovision', () => {
+  it('rejects an invalid slug', async () => {
+    await expect(
+      AppStorageProvisioner.deprovision({ slug: '!!' })
+    ).rejects.toThrow(/invalid slug/);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('drops schema + role inside a transaction', async () => {
+    await AppStorageProvisioner.deprovision({ slug: 'generate_from_model' });
+    const sqls = capturedQueries.map((q) => q.sql);
+    expect(sqls.some((s) => s.startsWith('BEGIN'))).toBe(true);
+    expect(sqls.some((s) => s.startsWith('COMMIT'))).toBe(true);
+    expect(sqls.some((s) => s.includes('DROP SCHEMA IF EXISTS "app_generate_from_model" CASCADE'))).toBe(true);
+    expect(sqls.some((s) => s.includes('DROP ROLE "app_generate_from_model_role"'))).toBe(true);
+    expect(mockClient.release).toHaveBeenCalledOnce();
+  });
+});
+
+describe('AppStorageProvisioner.getQuota', () => {
+  it('returns null when the schema has not been provisioned', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 });
+
+    const result = await AppStorageProvisioner.getQuota({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns a zero quota when the schema exists but the seed row is missing', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const result = await AppStorageProvisioner.getQuota({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+    });
+    expect(result).toEqual({ usedBytes: 0, rowCount: 0 });
+  });
+
+  it('coerces bigint text to number', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+      .mockResolvedValueOnce({
+        rows: [{ used_bytes: '12345', row_count: '7' }],
+        rowCount: 1,
+      });
+
+    const result = await AppStorageProvisioner.getQuota({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+    });
+    expect(result).toEqual({ usedBytes: 12345, rowCount: 7 });
+  });
+});

--- a/src/server/services/apps/storage-provision.service.ts
+++ b/src/server/services/apps/storage-provision.service.ts
@@ -1,0 +1,250 @@
+// App Blocks KV datastore provisioning (W4-KV-v0).
+//
+// Each approved app block gets:
+//   - schema `app_<slug>`
+//   - table `app_<slug>.kv` (block_instance_id, user_id, key, value jsonb, sizes, timestamps)
+//   - table `app_<slug>.quota` (app_block_id, used_bytes, row_count)
+//   - trigger function + trigger on kv to keep quota in sync
+//   - dedicated role `app_<slug>_role` (NOLOGIN) with schema-scoped grants
+//
+// Idempotency: every DDL statement uses IF NOT EXISTS, the role creation
+// uses a DO block, and the quota seed row uses ON CONFLICT DO NOTHING. The
+// W2 webhook handler calls provision() on every approved version push; the
+// backfill job (P7) calls it on every approved app_block row. Either path
+// is safe to repeat.
+//
+// Slug safety: slugs are validated through `isValidAppSlug` before any DDL
+// touches them. Identifiers can't be parameterized via $1 in Postgres, so
+// the regex (`^[a-z][a-z0-9_]{2,40}$`) is the load-bearing safety boundary.
+
+import { requireAppsDb } from '~/server/db/appsDb';
+import {
+  appRoleIdent,
+  appSchemaIdent,
+  isValidAppSlug,
+} from '~/server/utils/apps-slug';
+
+export type ProvisionOpts = {
+  appBlockId: string;
+  slug: string;
+};
+
+export const AppStorageProvisioner = {
+  /**
+   * Idempotent. Creates schema + tables + role + quota seed for an app block.
+   * Called from W2-v0's webhook handler after manifest validation lands +
+   * before flipping `app_blocks.status` to 'approved', and from the
+   * backfill job that ensures every approved app has a schema.
+   */
+  async provision({ appBlockId, slug }: ProvisionOpts): Promise<void> {
+    if (!isValidAppSlug(slug)) {
+      throw new Error(`AppStorageProvisioner.provision: invalid slug ${JSON.stringify(slug)}`);
+    }
+    if (typeof appBlockId !== 'string' || appBlockId.length === 0) {
+      throw new Error(`AppStorageProvisioner.provision: appBlockId required`);
+    }
+
+    const schema = appSchemaIdent(slug); // "app_<slug>"
+    const role = appRoleIdent(slug);     // "app_<slug>_role"
+
+    const pool = requireAppsDb();
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      await client.query(`CREATE SCHEMA IF NOT EXISTS ${schema}`);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.kv (
+          block_instance_id text NOT NULL,
+          user_id integer NOT NULL,
+          key text NOT NULL,
+          value jsonb NOT NULL,
+          size_bytes integer GENERATED ALWAYS AS (octet_length(value::text)) STORED,
+          created_at timestamptz DEFAULT now() NOT NULL,
+          updated_at timestamptz DEFAULT now() NOT NULL,
+          PRIMARY KEY (block_instance_id, user_id, key)
+        )
+      `);
+
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS kv_user_idx ON ${schema}.kv (user_id, block_instance_id)`
+      );
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS kv_updated_idx ON ${schema}.kv (updated_at)`
+      );
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.quota (
+          app_block_id text PRIMARY KEY,
+          used_bytes bigint NOT NULL DEFAULT 0,
+          row_count bigint NOT NULL DEFAULT 0,
+          updated_at timestamptz DEFAULT now() NOT NULL
+        )
+      `);
+
+      // Trigger function — quota row is keyed on app_block_id pulled from
+      // session-local `app.current_app_block_id`. tRPC procedures must
+      // `SET LOCAL app.current_app_block_id = ...` in the same txn as the
+      // INSERT/UPDATE/DELETE that fires this trigger; if the GUC is unset,
+      // current_setting('app.current_app_block_id', true) returns null and
+      // the UPDATE no-ops (we accept slight quota drift over a hard failure
+      // on the user write path — the periodic recompute in P7 reconciles).
+      await client.query(`
+        CREATE OR REPLACE FUNCTION ${schema}.kv_quota_trigger() RETURNS trigger AS $fn$
+        DECLARE
+          v_app_block_id text := current_setting('app.current_app_block_id', true);
+        BEGIN
+          IF v_app_block_id IS NULL OR v_app_block_id = '' THEN
+            RETURN NULL;
+          END IF;
+          IF TG_OP = 'INSERT' THEN
+            UPDATE ${schema}.quota
+               SET used_bytes = used_bytes + NEW.size_bytes,
+                   row_count  = row_count + 1,
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id;
+          ELSIF TG_OP = 'UPDATE' THEN
+            UPDATE ${schema}.quota
+               SET used_bytes = used_bytes + (NEW.size_bytes - OLD.size_bytes),
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id;
+          ELSIF TG_OP = 'DELETE' THEN
+            UPDATE ${schema}.quota
+               SET used_bytes = used_bytes - OLD.size_bytes,
+                   row_count  = row_count - 1,
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id;
+          END IF;
+          RETURN NULL;
+        END $fn$ LANGUAGE plpgsql
+      `);
+
+      // Drop+recreate the trigger so changes to the function body land
+      // without orphaning an old binding. The function body is immutable
+      // text per schema so this is a no-op for already-provisioned apps.
+      await client.query(`DROP TRIGGER IF EXISTS kv_quota_trg ON ${schema}.kv`);
+      await client.query(`
+        CREATE TRIGGER kv_quota_trg
+        AFTER INSERT OR UPDATE OR DELETE ON ${schema}.kv
+        FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_quota_trigger()
+      `);
+
+      // Per-app role — IF NOT EXISTS exists for CREATE ROLE only on PG 15+
+      // CNPG image; we use the DO block guard for portability.
+      await client.query(`
+        DO $do$
+        BEGIN
+          IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ${quoteLiteral(`app_${slug}_role`)}) THEN
+            CREATE ROLE ${role} NOLOGIN;
+          END IF;
+        END $do$
+      `);
+      await client.query(`GRANT USAGE ON SCHEMA ${schema} TO ${role}`);
+      await client.query(
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${schema} TO ${role}`
+      );
+      await client.query(`GRANT USAGE ON ALL SEQUENCES IN SCHEMA ${schema} TO ${role}`);
+
+      // Future tables in this schema (none today, but v1 SQL upgrade will
+      // add them) auto-inherit the same grants.
+      await client.query(`
+        ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema}
+          GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${role}
+      `);
+      await client.query(`
+        ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema}
+          GRANT USAGE ON SEQUENCES TO ${role}
+      `);
+
+      await client.query(
+        `INSERT INTO ${schema}.quota (app_block_id) VALUES ($1) ON CONFLICT (app_block_id) DO NOTHING`,
+        [appBlockId]
+      );
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  },
+
+  /**
+   * Drop schema + role entirely. Called when an app block is permanently
+   * deleted (NOT when deactivated — deactivated apps keep their schema in
+   * case they are reactivated). CASCADE drops every table the schema
+   * contains, including their grant references on the per-app role, so
+   * `DROP ROLE` after the CASCADE is safe.
+   */
+  async deprovision({ slug }: { slug: string }): Promise<void> {
+    if (!isValidAppSlug(slug)) {
+      throw new Error(`AppStorageProvisioner.deprovision: invalid slug ${JSON.stringify(slug)}`);
+    }
+    const schema = appSchemaIdent(slug);
+    const role = appRoleIdent(slug);
+
+    const pool = requireAppsDb();
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+      await client.query(`
+        DO $do$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ${quoteLiteral(`app_${slug}_role`)}) THEN
+            DROP ROLE ${role};
+          END IF;
+        END $do$
+      `);
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  },
+
+  /**
+   * Look up the live used_bytes + row_count for an app. Returns null when
+   * the schema hasn't been provisioned yet (caller usually treats that as
+   * "0 bytes, 0 rows" + a provision-on-demand follow-up).
+   */
+  async getQuota({
+    appBlockId,
+    slug,
+  }: ProvisionOpts): Promise<{ usedBytes: number; rowCount: number } | null> {
+    if (!isValidAppSlug(slug)) {
+      throw new Error(`AppStorageProvisioner.getQuota: invalid slug ${JSON.stringify(slug)}`);
+    }
+    const schema = appSchemaIdent(slug);
+    const pool = requireAppsDb();
+    // information_schema lookup avoids a relation-doesn't-exist error
+    // when an unprovisioned slug slips through.
+    const schemaExists = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1) AS exists`,
+      [`app_${slug}`]
+    );
+    if (!schemaExists.rows[0]?.exists) return null;
+
+    const result = await pool.query<{ used_bytes: string; row_count: string }>(
+      `SELECT used_bytes::text, row_count::text FROM ${schema}.quota WHERE app_block_id = $1`,
+      [appBlockId]
+    );
+    if (result.rows.length === 0) return { usedBytes: 0, rowCount: 0 };
+    return {
+      usedBytes: Number(result.rows[0].used_bytes ?? '0'),
+      rowCount: Number(result.rows[0].row_count ?? '0'),
+    };
+  },
+};
+
+// Safe SQL literal for identifiers we still need to compare via text (e.g.
+// `pg_roles.rolname = '...'`). Doubles single quotes; the slug regex
+// prevents any other escape chars from reaching here, but this keeps the
+// quoting defensible if the caller's contract slips.
+function quoteLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}

--- a/src/server/utils/__tests__/apps-slug.test.ts
+++ b/src/server/utils/__tests__/apps-slug.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appRoleIdent,
+  appSchemaIdent,
+  isValidAppSlug,
+  sanitizeAppSlug,
+} from '~/server/utils/apps-slug';
+
+describe('apps-slug', () => {
+  describe('isValidAppSlug', () => {
+    it('accepts a happy-path slug', () => {
+      expect(isValidAppSlug('generate_from_model')).toBe(true);
+    });
+
+    it('accepts the shortest allowed slug (3 chars)', () => {
+      expect(isValidAppSlug('abc')).toBe(true);
+    });
+
+    it('accepts the longest allowed slug (41 chars)', () => {
+      expect(isValidAppSlug('a' + 'b'.repeat(40))).toBe(true);
+      expect(isValidAppSlug('a' + 'b'.repeat(41))).toBe(false);
+    });
+
+    it('rejects empty + too-short slugs', () => {
+      expect(isValidAppSlug('')).toBe(false);
+      expect(isValidAppSlug('a')).toBe(false);
+      expect(isValidAppSlug('ab')).toBe(false);
+    });
+
+    it('rejects leading digit', () => {
+      expect(isValidAppSlug('1abc')).toBe(false);
+    });
+
+    it('rejects leading underscore', () => {
+      expect(isValidAppSlug('_abc')).toBe(false);
+    });
+
+    it('rejects uppercase', () => {
+      expect(isValidAppSlug('Abc')).toBe(false);
+      expect(isValidAppSlug('ABC123')).toBe(false);
+    });
+
+    it('rejects hyphens, spaces, quotes, and other SQL-relevant chars', () => {
+      expect(isValidAppSlug('abc-def')).toBe(false);
+      expect(isValidAppSlug('abc def')).toBe(false);
+      expect(isValidAppSlug("abc'def")).toBe(false);
+      expect(isValidAppSlug('abc"def')).toBe(false);
+      expect(isValidAppSlug('abc;def')).toBe(false);
+      expect(isValidAppSlug('abc--def')).toBe(false);
+      expect(isValidAppSlug('abc/*def*/')).toBe(false);
+    });
+
+    it('rejects unicode tricks', () => {
+      expect(isValidAppSlug('abc​')).toBe(false); // zero-width space
+      expect(isValidAppSlug('абв')).toBe(false); // Cyrillic
+    });
+
+    it('rejects non-strings', () => {
+      expect(isValidAppSlug(null)).toBe(false);
+      expect(isValidAppSlug(undefined)).toBe(false);
+      expect(isValidAppSlug(123 as unknown)).toBe(false);
+      expect(isValidAppSlug({} as unknown)).toBe(false);
+    });
+  });
+
+  describe('sanitizeAppSlug', () => {
+    it('passes through a valid slug', () => {
+      expect(sanitizeAppSlug('generate_from_model')).toBe('generate_from_model');
+    });
+
+    it('lowercases + replaces hyphens with underscore', () => {
+      expect(sanitizeAppSlug('Generate-From-Model')).toBe('generate_from_model');
+    });
+
+    it('collapses runs of non-alnum into a single underscore', () => {
+      expect(sanitizeAppSlug('a-_-b---c')).toBe('a_b_c');
+    });
+
+    it('strips leading/trailing underscores from the normalized form', () => {
+      expect(sanitizeAppSlug('--abc--')).toBe('abc');
+    });
+
+    it('returns null when normalization fails the regex', () => {
+      expect(sanitizeAppSlug('')).toBe(null);
+      expect(sanitizeAppSlug('!!')).toBe(null);
+      // becomes '1abc' which fails leading-digit
+      expect(sanitizeAppSlug('1-abc')).toBe(null);
+    });
+
+    it('is idempotent', () => {
+      const out = sanitizeAppSlug('Generate-From-Model');
+      expect(sanitizeAppSlug(out!)).toBe(out);
+    });
+
+    it('returns null for non-strings', () => {
+      expect(sanitizeAppSlug(null as unknown as string)).toBe(null);
+      expect(sanitizeAppSlug(undefined as unknown as string)).toBe(null);
+    });
+  });
+
+  describe('identifier helpers', () => {
+    it('produces quoted schema + role identifiers', () => {
+      expect(appSchemaIdent('generate_from_model')).toBe('"app_generate_from_model"');
+      expect(appRoleIdent('generate_from_model')).toBe('"app_generate_from_model_role"');
+    });
+
+    it('throws when invalid slug reaches the identifier helpers', () => {
+      expect(() => appSchemaIdent('invalid-slug')).toThrow(/invalid app slug/);
+      expect(() => appRoleIdent('')).toThrow(/invalid app slug/);
+      expect(() => appSchemaIdent('1bad')).toThrow(/invalid app slug/);
+    });
+  });
+});

--- a/src/server/utils/apps-slug.ts
+++ b/src/server/utils/apps-slug.ts
@@ -1,0 +1,58 @@
+// Slug sanitization for the App Blocks KV datastore (W4-KV-v0).
+//
+// Each approved app block is given a Postgres schema named `app_<slug>`
+// in the cnpg-cluster-apps cluster. The slug is derived from the manifest
+// blockId at submission time and validated against a tight regex so it
+// can be safely concatenated into DDL (identifiers can't be parameterized
+// via $1 placeholders).
+//
+// Rules — must match `^[a-z][a-z0-9_]{2,40}$`:
+// - Lowercase only (Postgres identifier folding would otherwise quote)
+// - First char must be a letter (so the schema name `app_<slug>` is a
+//   simple identifier)
+// - 3-41 chars total (long enough to be readable, short enough to keep
+//   the fully-qualified `"app_<slug>".kv` quotation tidy)
+// - Alphanumerics + underscore only — no hyphens; PG treats them as ops
+
+const APP_SLUG_RE = /^[a-z][a-z0-9_]{2,40}$/;
+
+/**
+ * Normalize a raw blockId to a candidate slug. Lowercases + replaces
+ * any non-alphanumeric char with `_`. Returns null if the result fails
+ * `isValidAppSlug`. Idempotent: passing an already-valid slug returns
+ * the same string.
+ */
+export function sanitizeAppSlug(input: string): string | null {
+  if (typeof input !== 'string') return null;
+  const lowered = input.toLowerCase();
+  const replaced = lowered.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return isValidAppSlug(replaced) ? replaced : null;
+}
+
+/**
+ * Strict validation gate — every DDL site must verify a slug with this
+ * before interpolating it. Returns false for null/undefined/non-string.
+ */
+export function isValidAppSlug(input: unknown): input is string {
+  return typeof input === 'string' && APP_SLUG_RE.test(input);
+}
+
+/**
+ * Quote-and-return the schema identifier. Slug must be validated first.
+ * Throws if the slug doesn't pass — the throw is a fail-shut to catch
+ * upstream code paths that skipped validation. Never use the slug
+ * unwrapped in DDL elsewhere.
+ */
+export function appSchemaIdent(slug: string): string {
+  if (!isValidAppSlug(slug)) {
+    throw new Error(`invalid app slug: ${JSON.stringify(slug)}`);
+  }
+  return `"app_${slug}"`;
+}
+
+export function appRoleIdent(slug: string): string {
+  if (!isValidAppSlug(slug)) {
+    throw new Error(`invalid app slug: ${JSON.stringify(slug)}`);
+  }
+  return `"app_${slug}_role"`;
+}


### PR DESCRIPTION
Per-app isolated PostgreSQL datastore on a new CNPG cluster (`cnpg-cluster-apps`). KV-only at v0; SQL access deferred to v1.

**Storage substrate** (datapacket-talos commit `eb86f3a33`): new CNPG cluster on dp-1 with schema-per-app provisioning + per-app NOLOGIN role for isolation. Cluster live + healthy; backups verified to ssd-minio-backups (bucket created + bootstrap base backup completed 2026-05-27T14:58:16Z).

**Per-app provisioning** (`5c1aa8a98`): `AppStorageProvisioner` service idempotently creates `app_<slug>` schema + `kv` table + `quota` table + trigger + role grants. Imported by W2's webhook handler before flipping `app_blocks.status='approved'`.

**tRPC** (`40c2bc8d5`): `apps.storage.{get,set,delete,list,getQuota}` — block-JWT gated. 50MB/1M-row quota, 64KB per-value cap.

**SDK** (`@civitai/blocks-react@^0.4.0`): `useAppStorage()` hook + 5 message pairs in `@civitai/app-sdk@^0.6.0/blocks`.

**Host** (`c001501c5`): `IframeHost.tsx` storage message handlers.

**Observability** (`56e2f6b7a`): Prometheus latency histogram + audit log on every write.

**Admin** (`9076bab93`): `/api/admin/apps-storage-backfill` endpoint to provision schemas for already-approved apps.

**Post-merge ops**: SOPS-set `APPS_DATABASE_URL` on civitai-pr-2319 (and other web pools as needed). Backfill the hackathon block via admin endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)