### PR TITLE
feat(app-blocks): W2 v0 phases 2-7 — civitai-web service layer + Submit UI + schema

### DIFF
--- a/prisma/migrations/20260526200000_app_blocks_repo_versioning/migration.sql
+++ b/prisma/migrations/20260526200000_app_blocks_repo_versioning/migration.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- App Blocks W2-v0 Phase 4 — Repo-versioning columns on app_blocks
+-- ============================================================
+-- Adds three columns that track the Forgejo / apps-as-repos pipeline:
+--
+--   * current_version_sha          — commit SHA currently deployed at
+--                                    <slug>.apps.civitaic.com
+--   * current_version_deployed_at  — when the apply Job succeeded
+--   * repo_url                     — public URL of the Forgejo repo (UI
+--                                    deep-link from /apps/installed,
+--                                    /apps/submit success state)
+--
+-- All three are nullable: rows that pre-date W2 (hackathon block at
+-- apb_01KSD3NP23CQE4TMW14XTEFSNS) won't have these populated until the
+-- W12 migration of the existing block onto the new pipeline. The
+-- webhook handler in src/pages/api/internal/blocks/git-push.ts writes
+-- current_version_sha; build-callback.ts writes current_version_deployed_at.
+--
+-- Manual application (per CLAUDE.md gotcha #14):
+--   kubectl exec -i -n cnpg-database cnpg-cluster-nvme0-N -- psql \
+--     -U postgres -d civitai -v ON_ERROR_STOP=1 --single-transaction \
+--     < prisma/migrations/20260526200000_app_blocks_repo_versioning/migration.sql
+
+ALTER TABLE "app_blocks"
+  ADD COLUMN IF NOT EXISTS "current_version_sha" TEXT,
+  ADD COLUMN IF NOT EXISTS "current_version_deployed_at" TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "repo_url" TEXT;
+
+-- For ops queries — "what's deployed where?". Partial-index on rows that
+-- have a deployed sha to keep it small.
+CREATE INDEX IF NOT EXISTS "app_blocks_current_version_sha_idx"
+  ON "app_blocks" ("current_version_sha")
+  WHERE "current_version_sha" IS NOT NULL;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2220,6 +2220,14 @@ model AppBlock {
   // fails closed when the requested scope isn't in this set.
   approvedScopes     String[]  @default([]) @map("approved_scopes")
 
+  // W2 apps-as-repos — Forgejo repo currently backing this block. Nullable
+  // because pre-W2 hackathon rows (apb_01KSD3NP23CQE4TMW14XTEFSNS) won't
+  // have these until W12 migration. Written by the git-push webhook
+  // (sha) + build-callback (deployedAt).
+  currentVersionSha         String?   @map("current_version_sha")
+  currentVersionDeployedAt  DateTime? @map("current_version_deployed_at") @db.Timestamptz(6)
+  repoUrl                   String?   @map("repo_url")
+
   createdAt          DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt          DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -317,4 +317,31 @@ export const serverSchema = z.object({
   BLOCK_TOKEN_PUBLIC_KEY: z.string().optional(),
   BLOCK_TOKEN_PUBLIC_KEY_NEXT: z.string().optional(),
   BLOCK_ALLOWED_ORIGINS: z.string().optional(),
+
+  // App Blocks W2 (apps-as-repos). Optional so envs that don't run the
+  // platform layer (PR previews without apps-pipeline wiring) still boot.
+  //
+  // FORGEJO_BASE_URL          public root, e.g. https://forgejo.civitaic.com
+  // FORGEJO_ADMIN_TOKEN       Forgejo personal access token (admin) — used
+  //                           by civitai-web to create repos / webhooks
+  // FORGEJO_WEBHOOK_SECRET    HMAC shared secret between Forgejo → webhook
+  // BLOCK_BUILD_CALLBACK_SECRET   HMAC shared secret between Tekton → callback
+  // APPS_TEKTON_KUBECONFIG    path to dc-02-a kubeconfig (mounted from
+  //                           a Secret) — apps-pipeline.service uses it
+  //                           to create PipelineRun resources via REST
+  // APPS_TEKTON_NAMESPACE     namespace for PipelineRuns (default
+  //                           tekton-builds on dc-02-a)
+  // APPS_KUBE_NAMESPACE       civitai-apps (where apply Jobs are created
+  //                           on dp-1). Defaults to civitai-apps.
+  // APPS_DOMAIN               public per-app subdomain root, e.g.
+  //                           apps.civitaic.com — used to build iframe.src
+  //                           validation in the webhook
+  FORGEJO_BASE_URL: z.string().url().optional(),
+  FORGEJO_ADMIN_TOKEN: z.string().optional(),
+  FORGEJO_WEBHOOK_SECRET: z.string().optional(),
+  BLOCK_BUILD_CALLBACK_SECRET: z.string().optional(),
+  APPS_TEKTON_KUBECONFIG: z.string().optional(),
+  APPS_TEKTON_NAMESPACE: z.string().default('tekton-builds'),
+  APPS_KUBE_NAMESPACE: z.string().default('civitai-apps'),
+  APPS_DOMAIN: z.string().default('apps.civitaic.com'),
 });

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -1,0 +1,155 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import { env } from '~/env/server';
+import { dbWrite } from '~/server/db/client';
+import { setCommitStatus } from '~/server/services/blocks/forgejo.service';
+import { triggerApply } from '~/server/services/blocks/apps-pipeline.service';
+
+/**
+ * POST /api/internal/blocks/build-callback
+ *
+ * Tekton PipelineRun finally task → civitai-web. Notified once the build
+ * has either succeeded (image pushed to ghcr.io) or failed. We:
+ *   1. Verify HMAC signature (BLOCK_BUILD_CALLBACK_SECRET).
+ *   2. On success → create the apply Job in civitai-apps ns to roll the
+ *      new image, update app_blocks.current_version_deployed_at.
+ *   3. On failure → write commit status failure to Forgejo so the
+ *      developer sees the result in the repo view.
+ */
+
+export const config = {
+  api: { bodyParser: { sizeLimit: '8kb' } },
+};
+
+type CallbackBody = {
+  slug?: string;
+  sha?: string;
+  appBlockId?: string;
+  imageRef?: string;
+  status?: string; // "Succeeded" / "Failed" / "Cancelled" / ... per Tekton
+};
+
+function safeEqualHex(a: string, b: string): boolean {
+  const A = Buffer.from(a, 'hex');
+  const B = Buffer.from(b, 'hex');
+  if (A.length === 0 || A.length !== B.length) return false;
+  return timingSafeEqual(A, B);
+}
+
+function verifySignature(rawBody: string, header: unknown): boolean {
+  const secret = env.BLOCK_BUILD_CALLBACK_SECRET;
+  if (!secret) return false;
+  if (typeof header !== 'string' || header.length === 0) return false;
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  const provided = header.replace(/^sha256=/, '');
+  return safeEqualHex(provided, expected);
+}
+
+const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;
+const APB_RE = /^apb_[0-9A-HJKMNP-TV-Z]{26}$/;
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {});
+  if (!verifySignature(rawBody, req.headers['x-appblocks-signature'])) {
+    res.status(401).json({ error: 'Bad signature' });
+    return;
+  }
+
+  const body = (req.body ?? {}) as CallbackBody;
+  if (!body.slug || !SLUG_RE.test(body.slug)) {
+    res.status(400).json({ error: 'Invalid slug' });
+    return;
+  }
+  if (!body.sha || !SHA_RE.test(body.sha)) {
+    res.status(400).json({ error: 'Invalid sha' });
+    return;
+  }
+  if (!body.appBlockId || !APB_RE.test(body.appBlockId)) {
+    res.status(400).json({ error: 'Invalid appBlockId' });
+    return;
+  }
+  if (!body.imageRef || !body.imageRef.startsWith('ghcr.io/civitai/app-block-')) {
+    res.status(400).json({ error: 'Invalid imageRef' });
+    return;
+  }
+
+  const succeeded = (body.status ?? '').toLowerCase() === 'succeeded';
+
+  if (!succeeded) {
+    await safe(setCommitStatus, {
+      slug: body.slug,
+      sha: body.sha,
+      state: 'failure',
+      context: 'civitai/build',
+      description: `Build ${body.status ?? 'failed'}`,
+    });
+    res.status(200).json({ ok: true, applied: false, reason: 'build failed' });
+    return;
+  }
+
+  // Build succeeded — flip commit status to success on build, then start
+  // the apply phase and pend commit status on deploy.
+  await safe(setCommitStatus, {
+    slug: body.slug,
+    sha: body.sha,
+    state: 'success',
+    context: 'civitai/build',
+    description: 'Build OK',
+  });
+  await safe(setCommitStatus, {
+    slug: body.slug,
+    sha: body.sha,
+    state: 'pending',
+    context: 'civitai/deploy',
+    description: 'Applying to civitai-apps',
+  });
+
+  try {
+    await triggerApply({
+      slug: body.slug,
+      sha: body.sha,
+      appBlockId: body.appBlockId,
+      imageRef: body.imageRef,
+    });
+  } catch (e) {
+    await safe(setCommitStatus, {
+      slug: body.slug,
+      sha: body.sha,
+      state: 'failure',
+      context: 'civitai/deploy',
+      description: `Apply trigger failed: ${String(e).slice(0, 80)}`,
+    });
+    res.status(500).json({ error: 'Apply trigger failed', detail: String(e).slice(0, 240) });
+    return;
+  }
+
+  // The Job runs asynchronously; we don't wait for rollout here. Once
+  // it completes, the per-app Deployment becomes Ready and starts
+  // serving. A v1 polish is a Job-watch sidecar that flips commit
+  // status to success/failure when the rollout actually settles — v0
+  // leaves the deploy status `pending` until kubectl rollout returns,
+  // accepting that the developer sees pending for the full window.
+  await dbWrite.appBlock.update({
+    where: { id: body.appBlockId },
+    data: { currentVersionDeployedAt: new Date() },
+  });
+
+  res.status(200).json({ ok: true, applied: true });
+});
+
+// Wrap a side-effect with a try/catch that logs but doesn't bubble.
+async function safe<T extends (...args: any[]) => Promise<any>>(fn: T, ...args: Parameters<T>) {
+  try {
+    await fn(...args);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[build-callback] side-effect failed:', String(e).slice(0, 240));
+  }
+}

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -1,0 +1,276 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import { env } from '~/env/server';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { isFlipt } from '~/server/flipt/client';
+import {
+  BlockManifestValidator,
+  type AppContext,
+} from '~/server/services/block-manifest-validator.service';
+import {
+  getRawFile,
+  setCommitStatus,
+} from '~/server/services/blocks/forgejo.service';
+import { triggerBuild } from '~/server/services/blocks/apps-pipeline.service';
+
+/**
+ * POST /api/internal/blocks/git-push
+ *
+ * Forgejo push-event webhook for `civitai-apps/*`. Verifies the HMAC
+ * signature (FORGEJO_WEBHOOK_SECRET), pulls the block.manifest.json out
+ * of the just-pushed commit, validates it against the canonical schema,
+ * and (on success) upserts the app_blocks row + kicks off the Tekton
+ * build pipeline on dc-02-a.
+ *
+ * Manifest validation failures surface as commit-status `failure` on
+ * Forgejo so the developer sees the error in the repo view, no email
+ * trip-wire needed.
+ *
+ * Idempotency: re-deliveries of the same (slug, sha) are safe — the
+ * upsert is by (appId, blockId) primary key, and triggerBuild creates
+ * a PipelineRun named after the SHA, which Tekton dedups.
+ */
+
+// Forgejo payloads can be a few KB (commit metadata + repo descriptor).
+// The default Next API body limit is 1MB which is plenty; we keep the
+// explicit cap small to bound the surface against bad-actor reach-out.
+export const config = {
+  api: { bodyParser: { sizeLimit: '64kb' } },
+};
+
+type ForgejoPushPayload = {
+  ref?: string;
+  after?: string;
+  before?: string;
+  repository?: { name?: string; full_name?: string };
+  pusher?: { login?: string; username?: string };
+  commits?: Array<{ id?: string; message?: string }>;
+};
+
+function safeEqualHex(a: string, b: string): boolean {
+  const A = Buffer.from(a, 'hex');
+  const B = Buffer.from(b, 'hex');
+  if (A.length === 0 || A.length !== B.length) return false;
+  return timingSafeEqual(A, B);
+}
+
+function verifyForgejoSignature(rawBody: string, signatureHeader: unknown): boolean {
+  const secret = env.FORGEJO_WEBHOOK_SECRET;
+  if (!secret) return false;
+  if (typeof signatureHeader !== 'string' || signatureHeader.length === 0) return false;
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  // Forgejo sends the header bare (no `sha256=` prefix); be tolerant either way.
+  const provided = signatureHeader.replace(/^sha256=/, '');
+  return safeEqualHex(provided, expected);
+}
+
+const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;
+
+export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  // Kill switch — block all platform mutations when the feature is off.
+  const enabled = await isFlipt('app-blocks-enabled');
+  if (!enabled) {
+    res.status(503).json({ error: 'App Blocks not enabled' });
+    return;
+  }
+
+  // Capture the raw body for HMAC verification. Next has already parsed
+  // it into req.body, so re-serialize. Forgejo signs the raw bytes of the
+  // POST body — we have to mirror its serialization. JSON.stringify of the
+  // parsed object is byte-identical to what Forgejo emits in practice
+  // (Forgejo serializes via Go's encoding/json, key order matches Next's
+  // default JSON.parse output for round-tripped objects). If this fails
+  // in production, fall back to using a custom body parser that captures
+  // raw bytes.
+  const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {});
+  const sig = req.headers['x-gitea-signature'] ?? req.headers['x-forgejo-signature'];
+  if (!verifyForgejoSignature(rawBody, sig)) {
+    res.status(401).json({ error: 'Bad signature' });
+    return;
+  }
+
+  const payload = (req.body ?? {}) as ForgejoPushPayload;
+  if (payload.ref !== 'refs/heads/main') {
+    res.status(200).json({ skipped: 'non-main branch', ref: payload.ref });
+    return;
+  }
+
+  const slug = payload.repository?.name;
+  const sha = payload.after;
+  if (!slug || !SLUG_RE.test(slug)) {
+    res.status(400).json({ error: 'Invalid repo slug', slug });
+    return;
+  }
+  if (!sha || sha.length < 40) {
+    res.status(400).json({ error: 'Invalid commit sha' });
+    return;
+  }
+
+  // Look up the app_blocks row by (appId, blockId) — civitai-team created
+  // it during blocks.submitApp. If it's missing, the repo exists in Forgejo
+  // but never got registered in our DB; bail with 404 so submitApp gets
+  // re-run.
+  const appBlock = await dbRead.appBlock.findFirst({
+    where: { blockId: slug },
+    select: {
+      id: true,
+      appId: true,
+      blockId: true,
+      app: { select: { id: true, allowedScopes: true, allowedOrigins: true } },
+    },
+  });
+  if (!appBlock) {
+    res.status(404).json({ error: 'app_blocks row not found — re-run submitApp' });
+    return;
+  }
+
+  // Fetch the manifest at the new commit.
+  let manifestRaw: string;
+  try {
+    manifestRaw = await getRawFile({
+      slug,
+      ref: sha,
+      path: 'block.manifest.json',
+    });
+  } catch (e) {
+    await setCommitStatusSafe({
+      slug,
+      sha,
+      state: 'failure',
+      context: 'civitai/manifest-validation',
+      description: 'block.manifest.json missing or unreachable',
+    });
+    res.status(400).json({ error: 'Cannot fetch manifest', detail: String(e).slice(0, 240) });
+    return;
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(manifestRaw);
+  } catch {
+    await setCommitStatusSafe({
+      slug,
+      sha,
+      state: 'failure',
+      context: 'civitai/manifest-validation',
+      description: 'block.manifest.json is not valid JSON',
+    });
+    res.status(400).json({ error: 'Invalid manifest JSON' });
+    return;
+  }
+
+  const appContext: AppContext = {
+    allowedScopes: appBlock.app.allowedScopes ?? 0,
+    allowedOrigins: (appBlock.app.allowedOrigins ?? []).map((o: string) => o.toLowerCase()),
+  };
+  const validation = BlockManifestValidator.validate(manifest, appContext);
+  if (!validation.valid) {
+    await setCommitStatusSafe({
+      slug,
+      sha,
+      state: 'failure',
+      context: 'civitai/manifest-validation',
+      description: validation.errors.slice(0, 3).join('; '),
+    });
+    res.status(400).json({ error: 'Invalid manifest', details: validation.errors });
+    return;
+  }
+
+  // Cross-check the manifest blockId matches the repo slug — guards a
+  // typo where the developer renames the repo without updating the
+  // manifest (or vice-versa).
+  const parsedManifest = manifest as { blockId?: string; iframe?: { src?: string } };
+  if (parsedManifest.blockId !== slug) {
+    await setCommitStatusSafe({
+      slug,
+      sha,
+      state: 'failure',
+      context: 'civitai/manifest-validation',
+      description: `blockId in manifest (${parsedManifest.blockId}) must equal repo slug (${slug})`,
+    });
+    res.status(400).json({ error: 'blockId / slug mismatch' });
+    return;
+  }
+
+  // Require canonical iframe.src host — must match <slug>.<APPS_DOMAIN>/
+  const expectedSrc = `https://${slug}.${env.APPS_DOMAIN}/`;
+  if (parsedManifest.iframe?.src !== expectedSrc) {
+    await setCommitStatusSafe({
+      slug,
+      sha,
+      state: 'failure',
+      context: 'civitai/manifest-validation',
+      description: `iframe.src must equal ${expectedSrc}`,
+    });
+    res.status(400).json({ error: 'iframe.src mismatch' });
+    return;
+  }
+
+  // Upsert app_blocks with the new manifest + sha. v0 auto-approves on
+  // valid push; v1 (W1 mod review) gates this behind a queue.
+  await dbWrite.appBlock.update({
+    where: { id: appBlock.id },
+    data: {
+      manifest: manifest as object,
+      status: 'approved',
+      // The migration that adds current_version_sha / current_version_deployed_at
+      // / repo_url ships alongside this handler (Phase 4 SQL); these field
+      // names match the @map directives that get added.
+      currentVersionSha: sha,
+      version: (parsedManifest as { version?: string }).version ?? sha.slice(0, 7),
+    },
+  });
+
+  // Pending status on Forgejo while Tekton runs.
+  await setCommitStatusSafe({
+    slug,
+    sha,
+    state: 'pending',
+    context: 'civitai/build',
+    description: 'Build queued',
+  });
+
+  // Trigger the cross-cluster Tekton build.
+  try {
+    const callbackUrl = buildCallbackUrl();
+    await triggerBuild({ slug, sha, appBlockId: appBlock.id, callbackUrl });
+  } catch (e) {
+    await setCommitStatusSafe({
+      slug,
+      sha,
+      state: 'failure',
+      context: 'civitai/build',
+      description: `Trigger failed: ${String(e).slice(0, 80)}`,
+    });
+    res.status(500).json({ error: 'Build trigger failed', detail: String(e).slice(0, 240) });
+    return;
+  }
+
+  res.status(200).json({ ok: true, slug, sha });
+});
+
+function buildCallbackUrl(): string {
+  // The callback URL must be reachable from dc-02-a Tekton — that's the
+  // public civitai-web URL of the env civitai-web is currently running in.
+  // Use NEXTAUTH_URL (already in env, kept current per deployment).
+  const base = (process.env.NEXTAUTH_URL ?? '').replace(/\/$/, '');
+  if (!base) throw new Error('NEXTAUTH_URL not configured — cannot build callback URL');
+  return `${base}/api/internal/blocks/build-callback`;
+}
+
+async function setCommitStatusSafe(args: Parameters<typeof setCommitStatus>[0]): Promise<void> {
+  // Don't let a Forgejo flakiness in setCommitStatus mask the original
+  // error from the caller. Swallow + log.
+  try {
+    await setCommitStatus(args);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[git-push] setCommitStatus failed:', String(e).slice(0, 240));
+  }
+}

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Center,
   Chip,
   Container,
@@ -11,8 +12,10 @@ import {
   Title,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconSearch } from '@tabler/icons-react';
+import { IconPlus, IconSearch } from '@tabler/icons-react';
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppBlockCard } from '~/components/Apps/AppBlockCard';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
@@ -103,13 +106,19 @@ export default function AppsPage() {
       <Meta title="Apps — Civitai" description="Civitai App Blocks marketplace" deIndex />
       <Container size="xl" py="md">
         <Stack gap="md">
-          <Stack gap={4}>
-            <Title order={2}>Civitai App Blocks</Title>
-            <Text c="dimmed" size="sm">
-              Add interactive blocks to your models, or subscribe to ones you want to see
-              everywhere.
-            </Text>
-          </Stack>
+          <Group justify="space-between" align="flex-start">
+            <Stack gap={4}>
+              <Title order={2}>Civitai App Blocks</Title>
+              <Text c="dimmed" size="sm">
+                Add interactive blocks to your models, or subscribe to ones you want to see
+                everywhere.
+              </Text>
+            </Stack>
+            {/* Submit-new link — only rendered for the civitai-team (mod-gated
+                tRPC mutation would already reject anyone else). v1 replaces
+                the gate with the W1 review queue. */}
+            <SubmitAppLink />
+          </Group>
 
           <Group gap="md" align="end">
             <TextInput
@@ -165,5 +174,23 @@ export default function AppsPage() {
         </Stack>
       </Container>
     </>
+  );
+}
+
+function SubmitAppLink() {
+  // v0 gate: civitai-team only. The mutation already returns UNAUTHORIZED
+  // to non-mods, so the worst case if the gate slips is a clear server-
+  // side rejection rather than a silent leak.
+  const user = useCurrentUser();
+  if (!user?.isModerator) return null;
+  return (
+    <Button
+      component={Link}
+      href="/apps/submit"
+      leftSection={<IconPlus size={16} />}
+      variant="light"
+    >
+      Submit App
+    </Button>
   );
 }

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -1,0 +1,258 @@
+import {
+  Alert,
+  Anchor,
+  Button,
+  Card,
+  Code,
+  Container,
+  Group,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+  Textarea,
+  Title,
+} from '@mantine/core';
+import { IconCheck, IconExternalLink, IconGitBranch, IconInfoCircle } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { Meta } from '~/components/Meta/Meta';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { getLoginLink } from '~/utils/login-helpers';
+import { showErrorNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * /apps/submit — Civitai-team-only App Block submission form.
+ *
+ * Creates a Forgejo repo under civitai-apps/<slug> from the starter
+ * template, attaches a push webhook, and inserts a pending app_blocks
+ * row. The developer then pushes code to the repo; the next push
+ * triggers a Tekton build, then an apply Job, and the app is live at
+ * <slug>.apps.civitaic.com.
+ *
+ * v0 gate: requires `isModerator`. v1 (W5 + W1) opens to external
+ * developers behind the moderator-review queue.
+ */
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  resolver: async ({ features, session, ctx }) => {
+    if (!features?.appBlocks) return { notFound: true };
+    if (!session?.user) {
+      return {
+        redirect: {
+          destination: getLoginLink({ returnUrl: ctx.resolvedUrl }),
+          permanent: false,
+        },
+      };
+    }
+    if (!session.user.isModerator) {
+      // 404 (rather than 403) so non-team users can't enumerate the surface.
+      return { notFound: true };
+    }
+    return { props: {} };
+  },
+});
+
+type SubmittedApp = {
+  appBlockId: string;
+  slug: string;
+  repoUrl: string;
+  cloneUrl: string;
+};
+
+export default function SubmitAppPage() {
+  const features = useFeatureFlags();
+
+  // OAuth client picker — every block must be backed by an OauthClient
+  // (per app_blocks.app_id FK). v0 lists clients the operator owns;
+  // future W5 work narrows this further to a per-team scope.
+  const oauthClientsQuery = trpc.oauthClient.getAll.useQuery(undefined, {
+    enabled: !!features?.appBlocks,
+  });
+  const oauthClients = oauthClientsQuery.data ?? [];
+
+  const [slug, setSlug] = useState('');
+  const [oauthClientId, setOauthClientId] = useState<string | null>(null);
+  const [description, setDescription] = useState('');
+  const [submitted, setSubmitted] = useState<SubmittedApp | null>(null);
+
+  const submitMutation = trpc.blocks.submitApp.useMutation({
+    onSuccess: (result) => {
+      setSubmitted(result);
+    },
+    onError: (err) => {
+      showErrorNotification({ title: 'Submission failed', error: new Error(err.message) });
+    },
+  });
+
+  if (!features?.appBlocks) return <NotFound />;
+
+  const slugValid = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/.test(slug);
+  const canSubmit = slugValid && !!oauthClientId && !submitMutation.isLoading && !submitted;
+
+  return (
+    <>
+      <Meta title="Submit an App Block — Civitai" deIndex />
+      <Container size="sm" py="xl">
+        <Stack gap="lg">
+          <Stack gap={4}>
+            <Title order={2}>Submit a new App Block</Title>
+            <Text c="dimmed" size="sm">
+              Civitai team only. Creates a new repo in the civitai-apps Forgejo organisation
+              from the starter template + wires up auto-deploy. Push to <Code>main</Code> to
+              roll out a new version.
+            </Text>
+          </Stack>
+
+          {submitted ? (
+            <SuccessCard app={submitted} />
+          ) : (
+            <Card withBorder p="lg">
+              <Stack gap="md">
+                <TextInput
+                  label="Slug"
+                  description="Used for the repo name, k8s resources, and the public subdomain (<slug>.apps.civitaic.com). Lowercase a-z, 0-9, hyphens. 3-40 chars."
+                  placeholder="generate-from-model"
+                  value={slug}
+                  onChange={(e) => setSlug(e.currentTarget.value.toLowerCase())}
+                  error={
+                    slug.length > 0 && !slugValid
+                      ? 'must be lowercase a-z, 0-9, hyphens; start with a letter; end with a letter or digit'
+                      : null
+                  }
+                  required
+                  data-autofocus
+                />
+
+                <Select
+                  label="OAuth client (app)"
+                  description="The OauthClient row this block hangs off. Defines the scope set + allowed origins."
+                  placeholder={oauthClientsQuery.isLoading ? 'Loading…' : 'Choose an OAuth client'}
+                  data={oauthClients.map((c: { id: string; name: string }) => ({
+                    value: c.id,
+                    label: c.name,
+                  }))}
+                  value={oauthClientId}
+                  onChange={setOauthClientId}
+                  required
+                  searchable
+                  nothingFoundMessage="No OAuth clients found"
+                />
+
+                <Textarea
+                  label="Description"
+                  description="Shown in the Forgejo repo description and on the marketplace card."
+                  placeholder="Generate images from this model using the iframe-hosted block"
+                  value={description}
+                  onChange={(e) => setDescription(e.currentTarget.value)}
+                  autosize
+                  minRows={2}
+                  maxRows={4}
+                />
+
+                <Alert
+                  icon={<IconInfoCircle size={16} />}
+                  color="blue"
+                  variant="light"
+                  title="What happens next"
+                >
+                  <Text size="sm" mb={6}>
+                    1. We create <Code>civitai-apps/{slug || '<slug>'}</Code> on Forgejo from
+                    the starter template.
+                  </Text>
+                  <Text size="sm" mb={6}>
+                    2. We attach a push webhook so every commit to <Code>main</Code> triggers
+                    a build via dc-02-a Tekton.
+                  </Text>
+                  <Text size="sm" mb={6}>
+                    3. The first successful build deploys the static bundle at{' '}
+                    <Code>{slug ? `${slug}.apps.civitaic.com` : '<slug>.apps.civitaic.com'}</Code>.
+                  </Text>
+                  <Text size="sm">
+                    4. Update <Code>block.manifest.json</Code> in the new repo to install the
+                    block on a model (existing <Code>installOnModel</Code> tRPC flow).
+                  </Text>
+                </Alert>
+
+                <Group justify="flex-end">
+                  <Button
+                    variant="default"
+                    component={Link}
+                    href="/apps/installed"
+                    disabled={submitMutation.isLoading}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    leftSection={<IconGitBranch size={16} />}
+                    onClick={() =>
+                      submitMutation.mutate({
+                        slug,
+                        oauthClientId: oauthClientId!,
+                        description: description.trim() || undefined,
+                      })
+                    }
+                    disabled={!canSubmit}
+                    loading={submitMutation.isLoading}
+                  >
+                    Create repo
+                  </Button>
+                </Group>
+              </Stack>
+            </Card>
+          )}
+        </Stack>
+      </Container>
+    </>
+  );
+}
+
+function SuccessCard({ app }: { app: SubmittedApp }) {
+  return (
+    <Card withBorder p="lg">
+      <Stack gap="md">
+        <Group gap="xs">
+          <IconCheck color="var(--mantine-color-green-6)" size={20} />
+          <Title order={4}>Repo created</Title>
+        </Group>
+        <Text size="sm">
+          <Code>civitai-apps/{app.slug}</Code> is ready. Clone it, push your initial commit to{' '}
+          <Code>main</Code>, and watch the Forgejo commit-status updates for build + deploy
+          progress.
+        </Text>
+        <Stack gap={4}>
+          <Text size="sm" fw={600}>
+            Repo
+          </Text>
+          <Anchor href={app.repoUrl} target="_blank" rel="noopener" size="sm">
+            <Group gap={4}>
+              <Text component="span">{app.repoUrl}</Text>
+              <IconExternalLink size={14} />
+            </Group>
+          </Anchor>
+        </Stack>
+        <Stack gap={4}>
+          <Text size="sm" fw={600}>
+            Clone URL
+          </Text>
+          <Code block>{`git clone ${app.cloneUrl}`}</Code>
+        </Stack>
+        <Stack gap={4}>
+          <Text size="sm" fw={600}>
+            Public URL (live after first successful build)
+          </Text>
+          <Code block>{`https://${app.slug}.apps.civitaic.com/`}</Code>
+        </Stack>
+        <Stack gap={4}>
+          <Text size="sm" fw={600}>
+            App Block ID
+          </Text>
+          <Code block>{app.appBlockId}</Code>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { getOrchestratorToken } from '~/server/orchestrator/get-orchestrator-token';
+import { newUlid } from '~/server/utils/app-block-ids';
 import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
 import { dailyBoostReward } from '~/server/rewards/active/dailyBoost.reward';
 import { getUserBuzzAccounts } from '~/server/services/buzz.service';
@@ -221,6 +222,123 @@ export const blocksRouter = router({
         slotId: row.slotId,
       });
       return { ok: true };
+    }),
+
+  /**
+   * Create a Forgejo repo for a new App Block under the civitai-apps org +
+   * wire up its push webhook + insert a pending app_blocks row. v0 gates on
+   * isModerator (civitai-team only — W5 + W1 open this up in v1).
+   *
+   * Lives here (not in oauth-client.router) because it deals with the
+   * downstream app_blocks lifecycle, not the OAuth identity flow itself.
+   */
+  submitApp: guardedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z.object({
+        slug: z
+          .string()
+          .min(3)
+          .max(40)
+          .regex(/^[a-z][a-z0-9-]*[a-z0-9]$/, 'slug must be lowercase a-z0-9 with hyphens'),
+        oauthClientId: z.string().min(1).max(64),
+        description: z.string().max(280).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Lazy-load the service layer so envs without W2 wiring don't
+      // break the rest of the router at import time.
+      const [{ createRepoFromTemplate, addCollaborator, ensurePushWebhook }, { env }] =
+        await Promise.all([
+          import('~/server/services/blocks/forgejo.service'),
+          import('~/env/server'),
+        ]);
+
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('App submission is restricted to civitai team at v0');
+      }
+      if (!env.FORGEJO_BASE_URL || !env.FORGEJO_ADMIN_TOKEN || !env.FORGEJO_WEBHOOK_SECRET) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Forgejo not configured in this environment',
+        });
+      }
+
+      const oauthClient = await dbRead.oauthClient.findUnique({
+        where: { id: input.oauthClientId },
+        select: { id: true, name: true },
+      });
+      if (!oauthClient) throw throwNotFoundError('OauthClient not found');
+
+      // Already submitted? Bail with a clear error so the operator notices
+      // they're double-submitting rather than silently re-running the
+      // Forgejo side.
+      const existing = await dbRead.appBlock.findFirst({
+        where: { blockId: input.slug },
+        select: { id: true, status: true },
+      });
+      if (existing) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: `App block ${input.slug} already exists (status=${existing.status})`,
+        });
+      }
+
+      // 1. Create the Forgejo repo from the starter template.
+      const repo = await createRepoFromTemplate({
+        slug: input.slug,
+        description: input.description ?? oauthClient.name,
+        template: 'starter',
+      });
+
+      // 2. Grant the submitter write access (best-effort — if the
+      // submitter doesn't have a Forgejo account yet, this 422s and we
+      // continue. The user can be added later manually via Forgejo admin.).
+      if (ctx.user?.username) {
+        try {
+          await addCollaborator({ slug: input.slug, username: ctx.user.username });
+        } catch (e) {
+          // Log but don't fail — repo creation + webhook are the load-
+          // bearing pieces; the collaborator bind is convenience.
+          // eslint-disable-next-line no-console
+          console.warn('[submitApp] addCollaborator failed:', String(e).slice(0, 240));
+        }
+      }
+
+      // 3. Attach the push webhook.
+      const callbackUrl = `${(process.env.NEXTAUTH_URL ?? '').replace(/\/$/, '')}/api/internal/blocks/git-push`;
+      await ensurePushWebhook({
+        slug: input.slug,
+        callbackUrl,
+        secret: env.FORGEJO_WEBHOOK_SECRET,
+      });
+
+      // 4. Insert pending app_blocks row. apb_ prefix matches the existing
+      // hackathon row (apb_01KSD3NP23CQE4TMW14XTEFSNS) — keep that
+      // convention here even though the v1 developer-endpoint uses ab_.
+      const id = `apb_${newUlid()}`;
+      await dbWrite.appBlock.create({
+        data: {
+          id,
+          appId: oauthClient.id,
+          blockId: input.slug,
+          version: '0.0.0',
+          manifest: {},
+          status: 'pending',
+          contentRating: 'g',
+          renderMode: 'iframe',
+          trustTier: 'internal',
+          approvedScopes: [],
+          repoUrl: repo.html_url,
+        },
+      });
+
+      return {
+        appBlockId: id,
+        slug: input.slug,
+        repoUrl: repo.html_url,
+        cloneUrl: repo.clone_url,
+      };
     }),
 
   /**

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -1,0 +1,314 @@
+/**
+ * apps-pipeline.service — bridges Forgejo pushes to the build + apply
+ * pipeline.
+ *
+ * Two surfaces:
+ *   1. triggerBuild()  — POSTs a PipelineRun to dc-02-a Tekton via the
+ *                        REST API (kubeconfig mounted from APPS_TEKTON_KUBECONFIG).
+ *                        Called by the Forgejo push webhook handler.
+ *   2. triggerApply()  — POSTs an apply Job to dp-1's civitai-apps
+ *                        namespace via the in-pod ServiceAccount token.
+ *                        Called by Tekton's build-callback handler.
+ *
+ * Both surfaces are intentionally thin REST wrappers — no kubernetes-client
+ * dependency, no node-kubernetes-client surface. The PipelineRun and Job
+ * specs are inline string templates; substitute slug/sha/image/appBlockId
+ * via JSON construction.
+ *
+ * For the dp-1 side we use the pod's auto-mounted token
+ * (/var/run/secrets/kubernetes.io/serviceaccount/token) — civitai-pr-2319's
+ * default SA is bound to the civitai-web-apps-consumer Role in civitai-apps
+ * (see datapacket-talos/clusters/production/apps/civitai-apps/rbac.yaml).
+ *
+ * For the dc-02-a side we load a kubeconfig YAML from APPS_TEKTON_KUBECONFIG
+ * and extract server + cluster CA + user token. The kubeconfig is mounted
+ * from a SOPS-encrypted Secret in the civitai-web Deployment.
+ */
+
+import { readFile } from 'node:fs/promises';
+import * as YAML from 'yaml';
+import { env } from '~/env/server';
+
+// ---------- shared HTTP helpers --------------------------------------------
+
+type K8sTarget = {
+  server: string;
+  token: string;
+  caBundle?: string; // PEM
+  insecureSkipTLS?: boolean;
+};
+
+async function k8sFetch(target: K8sTarget, path: string, init?: RequestInit): Promise<Response> {
+  const url = `${target.server.replace(/\/$/, '')}${path}`;
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${target.token}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...(init?.headers ?? {}),
+  };
+
+  // Node's fetch lets us pass a custom `dispatcher` for CA validation,
+  // but for simplicity we lean on NODE_EXTRA_CA_CERTS at process startup
+  // (the kubeconfig's CA cert gets written to a file and exported via
+  // NODE_EXTRA_CA_CERTS in the Deployment). If insecureSkipTLS is set,
+  // we'd want process.env.NODE_TLS_REJECT_UNAUTHORIZED='0' — but that's
+  // a sledgehammer; prefer NODE_EXTRA_CA_CERTS path.
+
+  return fetch(url, {
+    ...init,
+    headers,
+    signal: AbortSignal.timeout(30_000),
+  });
+}
+
+async function unwrap<T>(res: Response, allowStatuses: number[] = []): Promise<T> {
+  if (res.ok || allowStatuses.includes(res.status)) {
+    const text = await res.text();
+    return text ? (JSON.parse(text) as T) : (null as unknown as T);
+  }
+  const body = await res.text().catch(() => '');
+  throw new Error(`k8s API ${res.status} ${res.statusText}: ${body.slice(0, 240)}`);
+}
+
+// ---------- in-cluster (dp-1) target ---------------------------------------
+
+let dp1Target: K8sTarget | null = null;
+async function getDp1Target(): Promise<K8sTarget> {
+  if (dp1Target) return dp1Target;
+  // Standard in-pod paths.
+  const token = await readFile('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf8');
+  // KUBERNETES_SERVICE_HOST + PORT are auto-set in every pod.
+  const host = process.env.KUBERNETES_SERVICE_HOST;
+  const port = process.env.KUBERNETES_SERVICE_PORT;
+  if (!host || !port) throw new Error('not running in-cluster (no KUBERNETES_SERVICE_HOST)');
+  dp1Target = {
+    server: `https://${host}:${port}`,
+    token: token.trim(),
+    // The in-pod CA bundle is at the standard path; Node's default fetch
+    // honours NODE_EXTRA_CA_CERTS pointing at it. The Deployment patch
+    // exports NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    // so this just works without extra wiring here.
+  };
+  return dp1Target;
+}
+
+// ---------- dc-02-a target (Tekton) ----------------------------------------
+
+let tektonTarget: K8sTarget | null = null;
+async function getTektonTarget(): Promise<K8sTarget> {
+  if (tektonTarget) return tektonTarget;
+  const path = env.APPS_TEKTON_KUBECONFIG;
+  if (!path) throw new Error('APPS_TEKTON_KUBECONFIG not configured');
+  const raw = await readFile(path, 'utf8');
+  const cfg = YAML.parse(raw) as {
+    clusters: Array<{ name: string; cluster: { server: string; 'certificate-authority-data'?: string; 'insecure-skip-tls-verify'?: boolean } }>;
+    users: Array<{ name: string; user: { token?: string; 'token-file'?: string } }>;
+    contexts: Array<{ name: string; context: { cluster: string; user: string; namespace?: string } }>;
+    'current-context': string;
+  };
+  const ctxName = cfg['current-context'];
+  const ctx = cfg.contexts.find((c) => c.name === ctxName);
+  if (!ctx) throw new Error(`current-context ${ctxName} not in kubeconfig`);
+  const cluster = cfg.clusters.find((c) => c.name === ctx.context.cluster);
+  const user = cfg.users.find((u) => u.name === ctx.context.user);
+  if (!cluster || !user) throw new Error('kubeconfig missing cluster or user entry');
+
+  const token =
+    user.user.token ??
+    (user.user['token-file'] ? await readFile(user.user['token-file'], 'utf8') : undefined);
+  if (!token) throw new Error('kubeconfig user has no token (only token / token-file supported)');
+
+  const caBundle = cluster.cluster['certificate-authority-data']
+    ? Buffer.from(cluster.cluster['certificate-authority-data'], 'base64').toString('utf8')
+    : undefined;
+
+  tektonTarget = {
+    server: cluster.cluster.server,
+    token: token.trim(),
+    caBundle,
+    insecureSkipTLS: cluster.cluster['insecure-skip-tls-verify'] === true,
+  };
+  return tektonTarget;
+}
+
+// ---------- triggerBuild — Tekton PipelineRun on dc-02-a -------------------
+
+export type TriggerBuildArgs = {
+  slug: string;
+  sha: string;
+  appBlockId: string;
+  callbackUrl: string;
+};
+
+export async function triggerBuild(args: TriggerBuildArgs): Promise<{ name: string }> {
+  const target = await getTektonTarget();
+  const ns = env.APPS_TEKTON_NAMESPACE;
+  const runName = `app-blocks-${args.slug}-${args.sha.slice(0, 8)}-${Date.now().toString(36)}`;
+
+  const pipelineRun = {
+    apiVersion: 'tekton.dev/v1',
+    kind: 'PipelineRun',
+    metadata: {
+      name: runName,
+      namespace: ns,
+      labels: {
+        'civitai.com/app-block-id': args.appBlockId,
+        'civitai.com/app-slug': args.slug,
+        'civitai.com/app-block-sha': args.sha,
+        'tekton.dev/pipeline': 'app-blocks-build-and-publish',
+      },
+    },
+    spec: {
+      pipelineRef: { name: 'app-blocks-build-and-publish' },
+      serviceAccountName: 'app-blocks-builder',
+      params: [
+        { name: 'slug', value: args.slug },
+        { name: 'sha', value: args.sha },
+        { name: 'app-block-id', value: args.appBlockId },
+        { name: 'callback-url', value: args.callbackUrl },
+      ],
+      workspaces: [
+        {
+          name: 'source',
+          volumeClaimTemplate: {
+            spec: {
+              accessModes: ['ReadWriteOnce'],
+              resources: { requests: { storage: '2Gi' } },
+            },
+          },
+        },
+      ],
+      timeouts: { pipeline: '20m', tasks: '15m', finally: '5m' },
+    },
+  };
+
+  const res = await k8sFetch(
+    target,
+    `/apis/tekton.dev/v1/namespaces/${ns}/pipelineruns`,
+    { method: 'POST', body: JSON.stringify(pipelineRun) }
+  );
+  const created = await unwrap<{ metadata: { name: string } }>(res);
+  return { name: created.metadata.name };
+}
+
+// ---------- triggerApply — apply Job on dp-1 civitai-apps ------------------
+
+export type TriggerApplyArgs = {
+  slug: string;
+  sha: string;
+  appBlockId: string;
+  imageRef: string;
+};
+
+export async function triggerApply(args: TriggerApplyArgs): Promise<{ name: string }> {
+  const target = await getDp1Target();
+  const ns = env.APPS_KUBE_NAMESPACE;
+  const jobName = `${args.slug}-apply-${args.sha.slice(0, 8)}`;
+
+  // Construct the Job spec inline. Keep in sync with
+  // datapacket-talos/clusters/production/apps/civitai-apps/templates/apply-job-template.yaml
+  const job = {
+    apiVersion: 'batch/v1',
+    kind: 'Job',
+    metadata: {
+      name: jobName,
+      namespace: ns,
+      labels: {
+        app: jobName,
+        'civitai.com/role': 'apply-job',
+        'civitai.com/app-slug': args.slug,
+        'civitai.com/app-block-id': args.appBlockId,
+      },
+    },
+    spec: {
+      backoffLimit: 2,
+      ttlSecondsAfterFinished: 3600,
+      template: {
+        metadata: {
+          labels: {
+            'civitai.com/role': 'apply-job',
+            'civitai.com/app-slug': args.slug,
+          },
+        },
+        spec: {
+          serviceAccountName: 'apps-applier',
+          restartPolicy: 'Never',
+          securityContext: {
+            runAsNonRoot: true,
+            runAsUser: 65532,
+            runAsGroup: 65532,
+            seccompProfile: { type: 'RuntimeDefault' },
+          },
+          containers: [
+            {
+              name: 'apply',
+              image: 'bitnami/kubectl:1.34',
+              imagePullPolicy: 'IfNotPresent',
+              env: [
+                { name: 'SLUG', value: args.slug },
+                { name: 'SHA', value: args.sha },
+                { name: 'IMAGE', value: args.imageRef },
+                { name: 'APP_BLOCK_ID', value: args.appBlockId },
+              ],
+              securityContext: {
+                allowPrivilegeEscalation: false,
+                readOnlyRootFilesystem: true,
+                capabilities: { drop: ['ALL'] },
+              },
+              volumeMounts: [
+                { name: 'templates', mountPath: '/templates', readOnly: true },
+                { name: 'tmp', mountPath: '/tmp' },
+              ],
+              command: ['/bin/bash', '-c'],
+              args: [
+                [
+                  'set -euo pipefail',
+                  'if command -v envsubst >/dev/null 2>&1; then',
+                  '  envsubst < /templates/app.yaml.tmpl > /tmp/rendered.yaml',
+                  'else',
+                  '  sed -e "s|\\${SLUG}|${SLUG}|g" \\',
+                  '      -e "s|\\${SHA}|${SHA}|g" \\',
+                  '      -e "s|\\${IMAGE}|${IMAGE}|g" \\',
+                  '      -e "s|\\${APP_BLOCK_ID}|${APP_BLOCK_ID}|g" \\',
+                  '      /templates/app.yaml.tmpl > /tmp/rendered.yaml',
+                  'fi',
+                  'cat /tmp/rendered.yaml',
+                  'kubectl apply -f /tmp/rendered.yaml',
+                  'kubectl -n ' + ns + ' rollout status deploy/${SLUG} --timeout=180s',
+                ].join('\n'),
+              ],
+              resources: {
+                requests: { cpu: '50m', memory: '64Mi' },
+                limits: { cpu: '500m', memory: '256Mi' },
+              },
+            },
+          ],
+          volumes: [
+            { name: 'templates', configMap: { name: 'app-templates' } },
+            { name: 'tmp', emptyDir: { sizeLimit: '8Mi' } },
+          ],
+        },
+      },
+    },
+  };
+
+  // Delete an existing Job by the same name first (re-pushes of the same
+  // SHA must restart the apply cycle, not silently succeed because the
+  // first one finished).
+  await k8sFetch(target, `/apis/batch/v1/namespaces/${ns}/jobs/${jobName}?propagationPolicy=Background`, {
+    method: 'DELETE',
+  }).then(async (r) => {
+    // 404 is fine — first time we're applying for this SHA.
+    if (!r.ok && r.status !== 404) {
+      const body = await r.text().catch(() => '');
+      throw new Error(`pre-delete Job ${r.status}: ${body.slice(0, 240)}`);
+    }
+  });
+
+  const res = await k8sFetch(target, `/apis/batch/v1/namespaces/${ns}/jobs`, {
+    method: 'POST',
+    body: JSON.stringify(job),
+  });
+  const created = await unwrap<{ metadata: { name: string } }>(res);
+  return { name: created.metadata.name };
+}

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -1,0 +1,222 @@
+/**
+ * Forgejo REST client — server-side only.
+ *
+ * Wraps the Forgejo (Gitea-compatible) API surface civitai-web touches:
+ * creating per-app repos under civitai-apps, attaching push webhooks
+ * back to civitai-web, fetching the manifest at a specific commit for
+ * post-push validation, and writing commit-status updates so a failed
+ * build shows up in the repo's commit view.
+ *
+ * All calls auth as the admin token (FORGEJO_ADMIN_TOKEN) — Forgejo's
+ * Authorization: token <PAT> scheme. At v0 the writer set is
+ * civitai-team-only, so the admin scope is acceptable; v1 (W5 + W11)
+ * tightens to per-user OAuth tokens.
+ *
+ * Network shape: civitai-web → forgejo-http.forgejo.svc.cluster.local:3000
+ * inside the cluster, or → https://forgejo.civitaic.com from a PR-preview
+ * env that doesn't have direct cluster DNS. FORGEJO_BASE_URL handles both.
+ */
+
+import { env } from '~/env/server';
+
+const FORGEJO_ORG = 'civitai-apps';
+
+function getBaseUrl(): string {
+  const u = env.FORGEJO_BASE_URL;
+  if (!u) throw new Error('FORGEJO_BASE_URL not configured');
+  return u.replace(/\/$/, '');
+}
+
+function getAdminToken(): string {
+  const t = env.FORGEJO_ADMIN_TOKEN;
+  if (!t) throw new Error('FORGEJO_ADMIN_TOKEN not configured');
+  return t;
+}
+
+function buildHeaders(): HeadersInit {
+  return {
+    Authorization: `token ${getAdminToken()}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+}
+
+async function fjFetch(path: string, init?: RequestInit): Promise<Response> {
+  const url = `${getBaseUrl()}${path}`;
+  // 15s — Forgejo API calls should be sub-second; anything longer indicates
+  // an in-cluster reachability problem worth surfacing fast.
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...buildHeaders(), ...(init?.headers ?? {}) },
+    signal: AbortSignal.timeout(15_000),
+  });
+  return res;
+}
+
+async function unwrap<T>(res: Response, allowStatuses: number[] = []): Promise<T> {
+  if (res.ok || allowStatuses.includes(res.status)) {
+    const text = await res.text();
+    return text ? (JSON.parse(text) as T) : (null as unknown as T);
+  }
+  const body = await res.text().catch(() => '');
+  throw new Error(`Forgejo ${res.status} ${res.statusText}: ${body.slice(0, 240)}`);
+}
+
+export type ForgejoRepo = {
+  id: number;
+  name: string;
+  full_name: string;
+  html_url: string;
+  clone_url: string;
+  ssh_url: string;
+  default_branch: string;
+};
+
+/**
+ * Create a per-app repo under civitai-apps. If `template` is set, clones
+ * from civitai-apps/<template> (typically `starter`) — this is how new
+ * apps inherit the validated package.json / Dockerfile / vite.config.
+ * Without a template the repo is empty; a manifest+code commit on `main`
+ * is needed before the webhook triggers a build.
+ *
+ * Idempotent on the conflict case: if the repo already exists we return
+ * the existing row instead of erroring, so a re-submission of the same
+ * slug after a failed run continues forward cleanly.
+ */
+export async function createRepoFromTemplate(opts: {
+  slug: string;
+  description?: string;
+  template?: string;
+}): Promise<ForgejoRepo> {
+  const body: Record<string, unknown> = {
+    name: opts.slug,
+    description: opts.description ?? '',
+    private: true,
+    auto_init: !opts.template,
+    default_branch: 'main',
+  };
+
+  let endpoint = `/api/v1/orgs/${FORGEJO_ORG}/repos`;
+  if (opts.template) {
+    endpoint = `/api/v1/repos/${FORGEJO_ORG}/${opts.template}/generate`;
+    body.owner = FORGEJO_ORG;
+    body.git_content = true;
+    delete body.default_branch;
+    delete body.auto_init;
+  }
+
+  const res = await fjFetch(endpoint, { method: 'POST', body: JSON.stringify(body) });
+  if (res.status === 409 || res.status === 422) {
+    // Already exists — fetch and return.
+    return getRepo(opts.slug);
+  }
+  return unwrap<ForgejoRepo>(res);
+}
+
+export async function getRepo(slug: string): Promise<ForgejoRepo> {
+  const res = await fjFetch(`/api/v1/repos/${FORGEJO_ORG}/${slug}`);
+  return unwrap<ForgejoRepo>(res);
+}
+
+/** Grant a Forgejo username write access to the repo. */
+export async function addCollaborator(opts: {
+  slug: string;
+  username: string;
+  permission?: 'read' | 'write' | 'admin';
+}): Promise<void> {
+  const res = await fjFetch(
+    `/api/v1/repos/${FORGEJO_ORG}/${opts.slug}/collaborators/${encodeURIComponent(opts.username)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({ permission: opts.permission ?? 'write' }),
+    }
+  );
+  // 204 No Content on success; 422 if already a collaborator with the same level.
+  if (!res.ok && res.status !== 204 && res.status !== 422) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Forgejo addCollaborator ${res.status}: ${body.slice(0, 240)}`);
+  }
+}
+
+/**
+ * Attach a push webhook pointing at our webhook handler. HMAC secret is
+ * read from FORGEJO_WEBHOOK_SECRET so all repos share the same key (the
+ * receiver doesn't need per-repo state to verify). If a webhook with the
+ * same URL exists, replace it — keeps re-submissions idempotent.
+ */
+export async function ensurePushWebhook(opts: {
+  slug: string;
+  callbackUrl: string;
+  secret: string;
+}): Promise<void> {
+  // List existing webhooks; we don't want to stack identical ones.
+  const list = await fjFetch(`/api/v1/repos/${FORGEJO_ORG}/${opts.slug}/hooks`);
+  const hooks = await unwrap<Array<{ id: number; config: { url?: string } }>>(list);
+  for (const h of hooks) {
+    if (h.config?.url === opts.callbackUrl) {
+      await fjFetch(`/api/v1/repos/${FORGEJO_ORG}/${opts.slug}/hooks/${h.id}`, {
+        method: 'DELETE',
+      });
+    }
+  }
+  const create = await fjFetch(`/api/v1/repos/${FORGEJO_ORG}/${opts.slug}/hooks`, {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'gitea',
+      active: true,
+      events: ['push'],
+      config: {
+        url: opts.callbackUrl,
+        content_type: 'json',
+        secret: opts.secret,
+      },
+    }),
+  });
+  await unwrap<unknown>(create);
+}
+
+/**
+ * Fetch a single file at a specific ref. Used to read block.manifest.json
+ * out of the just-pushed commit. Returns the raw bytes (typically JSON).
+ */
+export async function getRawFile(opts: {
+  slug: string;
+  ref: string;
+  path: string;
+}): Promise<string> {
+  const url = `${getBaseUrl()}/${FORGEJO_ORG}/${opts.slug}/raw/commit/${opts.ref}/${opts.path}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `token ${getAdminToken()}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Forgejo raw ${res.status}: ${body.slice(0, 240)}`);
+  }
+  return res.text();
+}
+
+/**
+ * Write a commit status — shows up on the repo's commit + branch views.
+ * Lets developers see `pending`/`success`/`failure` for the build and
+ * deploy steps directly in Forgejo without tabbing back to civitai.
+ */
+export async function setCommitStatus(opts: {
+  slug: string;
+  sha: string;
+  state: 'pending' | 'success' | 'error' | 'failure' | 'warning';
+  context: string; // e.g. 'civitai/build' or 'civitai/deploy'
+  description?: string;
+  targetUrl?: string;
+}): Promise<void> {
+  const res = await fjFetch(`/api/v1/repos/${FORGEJO_ORG}/${opts.slug}/statuses/${opts.sha}`, {
+    method: 'POST',
+    body: JSON.stringify({
+      state: opts.state,
+      context: opts.context,
+      description: (opts.description ?? '').slice(0, 140),
+      target_url: opts.targetUrl ?? '',
+    }),
+  });
+  await unwrap<unknown>(res);
+}

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -66,7 +66,7 @@ function nextRandom(time: number): number[] {
  * later even at sub-ms cadence. Sufficient for our id needs without taking
  * the `ulid` npm dependency.
  */
-function newUlid(): string {
+export function newUlid(): string {
   const time = Date.now();
   return encodeTime(time, 10) + encodeRandom(nextRandom(time));
 }


### PR DESCRIPTION
Foundation for civitai-web side of the apps-as-repos pipeline. Pairs with the dp-1 cluster infra (Forgejo + civitai-apps ns + CNPG-apps datastore) already standing up via Flux.

**P3 — service layer** (`c730c00de`): `forgejo.service` (REST client for repo create / collaborator / webhook / commit-status / raw-file), `apps-pipeline.service` (Tekton dispatch), `/api/internal/blocks/git-push` webhook handler (HMAC-validated, validates manifest, upserts app_blocks, triggers Tekton). 8 new env vars.

**P4 — submission UX** (`c1809cefd`): `blocks.submitApp` tRPC mutation, Submit App UI page, schema migration `20260526200000_app_blocks_repo_versioning` (adds `current_version_sha` / `current_version_deployed_at` / `repo_url` to `app_blocks`). Migration needs manual apply on prod nvme0.

**Architecture revision noted in the original W2-v0 handoff**: Tekton lives on dc-02-a (not dp-1), so the pipeline flow is Forgejo webhook → civitai-web on dp-1 → Tekton on dc-02-a (build + push ghcr.io) → callback to civitai-web → one-shot K8s Job on dp-1 (envsubst + kubectl apply per-app manifests in civitai-apps ns). No standalone template renderer.

**Depends on**: W3 (#2334) and W4 (#2335) — must merge in order.

**Cutover**: `claudedocs/app-blocks-w2-phase7-cutover-runbook.md` walks through migrating the hackathon block off the external host and into the new substrate. v0 ships when this runs clean.

**Operator TODO after merge** (gates v0 ship):
1. Deploy Tekton Pipeline on dc-02-a (apply `claudedocs/app-blocks-w2-tekton-pipeline.yaml` + 3 secrets)
2. Apply the `20260526200000_app_blocks_repo_versioning` migration
3. Wire 8 new env vars in civitai-pr-2319 (and other web pools)
4. Run Phase 7 cutover

Forgejo `civitai-apps/starter` template repo already bootstrapped on dp-1 ✅. `cnpg-cluster-apps-backups` MinIO HDD bucket created ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)