### PR TITLE
fix(blocks): verify HMAC over raw bytes, not re-serialized JSON

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -332,11 +332,12 @@ export const serverSchema = z.object({
   //                           by civitai-web to create repos / webhooks
   // FORGEJO_WEBHOOK_SECRET    HMAC shared secret between Forgejo → webhook
   // BLOCK_BUILD_CALLBACK_SECRET   HMAC shared secret between Tekton → callback
-  // APPS_TEKTON_KUBECONFIG    path to dc-02-a kubeconfig (mounted from
-  //                           a Secret) — apps-pipeline.service uses it
-  //                           to create PipelineRun resources via REST
-  // APPS_TEKTON_NAMESPACE     namespace for PipelineRuns (default
-  //                           tekton-builds on dc-02-a)
+  // APPS_TEKTON_TRIGGER_URL   HTTP endpoint that creates PipelineRuns on
+  //                           dc-02-a (the app-blocks-trigger receiver,
+  //                           reached via the VPN proxy on dp-1). Example:
+  //                           http://wireguard-proxy-service.civitai-submodel-proxy.svc.cluster.local:8088/trigger-build
+  // APPS_TEKTON_TRIGGER_SECRET   HMAC shared secret between civitai-web and
+  //                           the app-blocks-trigger receiver. 32-byte hex.
   // APPS_KUBE_NAMESPACE       civitai-apps (where apply Jobs are created
   //                           on dp-1). Defaults to civitai-apps.
   // APPS_DOMAIN               public per-app subdomain root, e.g.
@@ -346,8 +347,8 @@ export const serverSchema = z.object({
   FORGEJO_ADMIN_TOKEN: z.string().optional(),
   FORGEJO_WEBHOOK_SECRET: z.string().optional(),
   BLOCK_BUILD_CALLBACK_SECRET: z.string().optional(),
-  APPS_TEKTON_KUBECONFIG: z.string().optional(),
-  APPS_TEKTON_NAMESPACE: z.string().default('tekton-builds'),
+  APPS_TEKTON_TRIGGER_URL: z.string().url().optional(),
+  APPS_TEKTON_TRIGGER_SECRET: z.string().optional(),
   APPS_KUBE_NAMESPACE: z.string().default('civitai-apps'),
   APPS_DOMAIN: z.string().default('apps.civitaic.com'),
 });

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
@@ -18,9 +19,28 @@ import { triggerApply } from '~/server/services/blocks/apps-pipeline.service';
  *      developer sees the result in the repo view.
  */
 
+// HMAC verification needs the exact bytes Tekton hashed; Next's bodyParser
+// re-serializes JSON before our handler sees it, which can change byte
+// ordering / whitespace / numeric encoding. Read the raw stream ourselves.
 export const config = {
-  api: { bodyParser: { sizeLimit: '8kb' } },
+  api: { bodyParser: false },
 };
+
+const MAX_BODY_BYTES = 8 * 1024;
+
+async function readRawBody(req: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer);
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) {
+      throw new Error('payload too large');
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
 
 type CallbackBody = {
   slug?: string;
@@ -37,7 +57,7 @@ function safeEqualHex(a: string, b: string): boolean {
   return timingSafeEqual(A, B);
 }
 
-function verifySignature(rawBody: string, header: unknown): boolean {
+function verifySignature(rawBody: Buffer, header: unknown): boolean {
   const secret = env.BLOCK_BUILD_CALLBACK_SECRET;
   if (!secret) return false;
   if (typeof header !== 'string' || header.length === 0) return false;
@@ -56,13 +76,26 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {});
+  let rawBody: Buffer;
+  try {
+    rawBody = await readRawBody(req);
+  } catch {
+    res.status(413).json({ error: 'Payload too large' });
+    return;
+  }
+
   if (!verifySignature(rawBody, req.headers['x-appblocks-signature'])) {
     res.status(401).json({ error: 'Bad signature' });
     return;
   }
 
-  const body = (req.body ?? {}) as CallbackBody;
+  let body: CallbackBody;
+  try {
+    body = JSON.parse(rawBody.toString('utf8')) as CallbackBody;
+  } catch {
+    res.status(400).json({ error: 'Invalid JSON' });
+    return;
+  }
   if (!body.slug || !SLUG_RE.test(body.slug)) {
     res.status(400).json({ error: 'Invalid slug' });
     return;

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
@@ -32,12 +33,30 @@ import { triggerBuild } from '~/server/services/blocks/apps-pipeline.service';
  * a PipelineRun named after the SHA, which Tekton dedups.
  */
 
-// Forgejo payloads can be a few KB (commit metadata + repo descriptor).
-// The default Next API body limit is 1MB which is plenty; we keep the
-// explicit cap small to bound the surface against bad-actor reach-out.
+// HMAC verification requires raw request bytes — Forgejo signs the exact
+// pretty-printed JSON it emits (Go's encoding/json with indent), which is
+// NOT byte-identical to Next's JSON.stringify of the parsed object. Turn
+// off Next's body parser and read the stream ourselves so the bytes we
+// hash match the bytes Forgejo hashed.
 export const config = {
-  api: { bodyParser: { sizeLimit: '64kb' } },
+  api: { bodyParser: false },
 };
+
+const MAX_BODY_BYTES = 64 * 1024;
+
+async function readRawBody(req: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer);
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) {
+      throw new Error('payload too large');
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
 
 type ForgejoPushPayload = {
   ref?: string;
@@ -55,7 +74,7 @@ function safeEqualHex(a: string, b: string): boolean {
   return timingSafeEqual(A, B);
 }
 
-function verifyForgejoSignature(rawBody: string, signatureHeader: unknown): boolean {
+function verifyForgejoSignature(rawBody: Buffer, signatureHeader: unknown): boolean {
   const secret = env.FORGEJO_WEBHOOK_SECRET;
   if (!secret) return false;
   if (typeof signatureHeader !== 'string' || signatureHeader.length === 0) return false;
@@ -80,22 +99,27 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  // Capture the raw body for HMAC verification. Next has already parsed
-  // it into req.body, so re-serialize. Forgejo signs the raw bytes of the
-  // POST body — we have to mirror its serialization. JSON.stringify of the
-  // parsed object is byte-identical to what Forgejo emits in practice
-  // (Forgejo serializes via Go's encoding/json, key order matches Next's
-  // default JSON.parse output for round-tripped objects). If this fails
-  // in production, fall back to using a custom body parser that captures
-  // raw bytes.
-  const rawBody = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {});
+  let rawBody: Buffer;
+  try {
+    rawBody = await readRawBody(req);
+  } catch {
+    res.status(413).json({ error: 'Payload too large' });
+    return;
+  }
+
   const sig = req.headers['x-gitea-signature'] ?? req.headers['x-forgejo-signature'];
   if (!verifyForgejoSignature(rawBody, sig)) {
     res.status(401).json({ error: 'Bad signature' });
     return;
   }
 
-  const payload = (req.body ?? {}) as ForgejoPushPayload;
+  let payload: ForgejoPushPayload;
+  try {
+    payload = JSON.parse(rawBody.toString('utf8')) as ForgejoPushPayload;
+  } catch {
+    res.status(400).json({ error: 'Invalid JSON' });
+    return;
+  }
   if (payload.ref !== 'refs/heads/main') {
     res.status(200).json({ skipped: 'non-main branch', ref: payload.ref });
     return;

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -3,30 +3,35 @@
  * pipeline.
  *
  * Two surfaces:
- *   1. triggerBuild()  — POSTs a PipelineRun to dc-02-a Tekton via the
- *                        REST API (kubeconfig mounted from APPS_TEKTON_KUBECONFIG).
+ *   1. triggerBuild()  — POSTs a JSON payload to the app-blocks-trigger
+ *                        receiver on dc-02-a, which validates HMAC and
+ *                        creates a PipelineRun via its in-pod ServiceAccount.
+ *                        Reached via the dp-1 VPN proxy at
+ *                        wireguard-proxy-service.civitai-submodel-proxy.svc:8088.
  *                        Called by the Forgejo push webhook handler.
  *   2. triggerApply()  — POSTs an apply Job to dp-1's civitai-apps
  *                        namespace via the in-pod ServiceAccount token.
  *                        Called by Tekton's build-callback handler.
  *
  * Both surfaces are intentionally thin REST wrappers — no kubernetes-client
- * dependency, no node-kubernetes-client surface. The PipelineRun and Job
- * specs are inline string templates; substitute slug/sha/image/appBlockId
- * via JSON construction.
+ * dependency, no node-kubernetes-client surface. The Job spec is an inline
+ * string template; the PipelineRun spec lives entirely server-side in the
+ * trigger receiver.
  *
- * For the dp-1 side we use the pod's auto-mounted token
+ * For the dp-1 side (triggerApply) we use the pod's auto-mounted token
  * (/var/run/secrets/kubernetes.io/serviceaccount/token) — civitai-pr-2319's
  * default SA is bound to the civitai-web-apps-consumer Role in civitai-apps
  * (see datapacket-talos/clusters/production/apps/civitai-apps/rbac.yaml).
  *
- * For the dc-02-a side we load a kubeconfig YAML from APPS_TEKTON_KUBECONFIG
- * and extract server + cluster CA + user token. The kubeconfig is mounted
- * from a SOPS-encrypted Secret in the civitai-web Deployment.
+ * For the dc-02-a side (triggerBuild), the original W2 design parsed a
+ * kubeconfig and posted PipelineRuns directly to dc-02-a's API server.
+ * That doesn't work — dc-02-a's API is loopback-only (SSH-tunnel for
+ * operators). We switched to an HMAC-protected trigger receiver: see
+ * datapacket-talos/claudedocs/app-blocks-tekton-trigger/ for the manifest.
  */
 
+import { createHmac } from 'crypto';
 import { readFile } from 'node:fs/promises';
-import * as YAML from 'yaml';
 import { env } from '~/env/server';
 
 // ---------- shared HTTP helpers --------------------------------------------
@@ -34,8 +39,6 @@ import { env } from '~/env/server';
 type K8sTarget = {
   server: string;
   token: string;
-  caBundle?: string; // PEM
-  insecureSkipTLS?: boolean;
 };
 
 async function k8sFetch(target: K8sTarget, path: string, init?: RequestInit): Promise<Response> {
@@ -46,14 +49,6 @@ async function k8sFetch(target: K8sTarget, path: string, init?: RequestInit): Pr
     Accept: 'application/json',
     ...(init?.headers ?? {}),
   };
-
-  // Node's fetch lets us pass a custom `dispatcher` for CA validation,
-  // but for simplicity we lean on NODE_EXTRA_CA_CERTS at process startup
-  // (the kubeconfig's CA cert gets written to a file and exported via
-  // NODE_EXTRA_CA_CERTS in the Deployment). If insecureSkipTLS is set,
-  // we'd want process.env.NODE_TLS_REJECT_UNAUTHORIZED='0' — but that's
-  // a sledgehammer; prefer NODE_EXTRA_CA_CERTS path.
-
   return fetch(url, {
     ...init,
     headers,
@@ -92,46 +87,7 @@ async function getDp1Target(): Promise<K8sTarget> {
   return dp1Target;
 }
 
-// ---------- dc-02-a target (Tekton) ----------------------------------------
-
-let tektonTarget: K8sTarget | null = null;
-async function getTektonTarget(): Promise<K8sTarget> {
-  if (tektonTarget) return tektonTarget;
-  const path = env.APPS_TEKTON_KUBECONFIG;
-  if (!path) throw new Error('APPS_TEKTON_KUBECONFIG not configured');
-  const raw = await readFile(path, 'utf8');
-  const cfg = YAML.parse(raw) as {
-    clusters: Array<{ name: string; cluster: { server: string; 'certificate-authority-data'?: string; 'insecure-skip-tls-verify'?: boolean } }>;
-    users: Array<{ name: string; user: { token?: string; 'token-file'?: string } }>;
-    contexts: Array<{ name: string; context: { cluster: string; user: string; namespace?: string } }>;
-    'current-context': string;
-  };
-  const ctxName = cfg['current-context'];
-  const ctx = cfg.contexts.find((c) => c.name === ctxName);
-  if (!ctx) throw new Error(`current-context ${ctxName} not in kubeconfig`);
-  const cluster = cfg.clusters.find((c) => c.name === ctx.context.cluster);
-  const user = cfg.users.find((u) => u.name === ctx.context.user);
-  if (!cluster || !user) throw new Error('kubeconfig missing cluster or user entry');
-
-  const token =
-    user.user.token ??
-    (user.user['token-file'] ? await readFile(user.user['token-file'], 'utf8') : undefined);
-  if (!token) throw new Error('kubeconfig user has no token (only token / token-file supported)');
-
-  const caBundle = cluster.cluster['certificate-authority-data']
-    ? Buffer.from(cluster.cluster['certificate-authority-data'], 'base64').toString('utf8')
-    : undefined;
-
-  tektonTarget = {
-    server: cluster.cluster.server,
-    token: token.trim(),
-    caBundle,
-    insecureSkipTLS: cluster.cluster['insecure-skip-tls-verify'] === true,
-  };
-  return tektonTarget;
-}
-
-// ---------- triggerBuild — Tekton PipelineRun on dc-02-a -------------------
+// ---------- triggerBuild — HMAC POST to app-blocks-trigger -----------------
 
 export type TriggerBuildArgs = {
   slug: string;
@@ -141,54 +97,43 @@ export type TriggerBuildArgs = {
 };
 
 export async function triggerBuild(args: TriggerBuildArgs): Promise<{ name: string }> {
-  const target = await getTektonTarget();
-  const ns = env.APPS_TEKTON_NAMESPACE;
-  const runName = `app-blocks-${args.slug}-${args.sha.slice(0, 8)}-${Date.now().toString(36)}`;
+  const url = env.APPS_TEKTON_TRIGGER_URL;
+  const secret = env.APPS_TEKTON_TRIGGER_SECRET;
+  if (!url || !secret) {
+    throw new Error('APPS_TEKTON_TRIGGER_URL / APPS_TEKTON_TRIGGER_SECRET not configured');
+  }
 
-  const pipelineRun = {
-    apiVersion: 'tekton.dev/v1',
-    kind: 'PipelineRun',
-    metadata: {
-      name: runName,
-      namespace: ns,
-      labels: {
-        'civitai.com/app-block-id': args.appBlockId,
-        'civitai.com/app-slug': args.slug,
-        'civitai.com/app-block-sha': args.sha,
-        'tekton.dev/pipeline': 'app-blocks-build-and-publish',
-      },
-    },
-    spec: {
-      pipelineRef: { name: 'app-blocks-build-and-publish' },
-      serviceAccountName: 'app-blocks-builder',
-      params: [
-        { name: 'slug', value: args.slug },
-        { name: 'sha', value: args.sha },
-        { name: 'app-block-id', value: args.appBlockId },
-        { name: 'callback-url', value: args.callbackUrl },
-      ],
-      workspaces: [
-        {
-          name: 'source',
-          volumeClaimTemplate: {
-            spec: {
-              accessModes: ['ReadWriteOnce'],
-              resources: { requests: { storage: '2Gi' } },
-            },
-          },
-        },
-      ],
-      timeouts: { pipeline: '20m', tasks: '15m', finally: '5m' },
-    },
-  };
+  const body = JSON.stringify({
+    slug: args.slug,
+    sha: args.sha,
+    appBlockId: args.appBlockId,
+    callbackUrl: args.callbackUrl,
+  });
+  const sig = createHmac('sha256', secret).update(body).digest('hex');
 
-  const res = await k8sFetch(
-    target,
-    `/apis/tekton.dev/v1/namespaces/${ns}/pipelineruns`,
-    { method: 'POST', body: JSON.stringify(pipelineRun) }
-  );
-  const created = await unwrap<{ metadata: { name: string } }>(res);
-  return { name: created.metadata.name };
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-AppBlocks-Trigger-Sig': sig,
+    },
+    body,
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  const text = await res.text().catch(() => '');
+  if (!res.ok) {
+    throw new Error(`trigger ${res.status} ${res.statusText}: ${text.slice(0, 240)}`);
+  }
+
+  let parsed: { pipelineRun?: string } = {};
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Receiver should always return JSON; if not, surface a clear error.
+    throw new Error(`trigger response was not JSON: ${text.slice(0, 240)}`);
+  }
+  return { name: parsed.pipelineRun ?? '' };
 }
 
 // ---------- triggerApply — apply Job on dp-1 civitai-apps ------------------


### PR DESCRIPTION
## Summary

Closes the two **code-side** gaps blocking App Blocks W12 cutover (see [`datapacket-talos/claudedocs/app-blocks-w12-cutover-gaps-handoff-2026-05-27.md`](https://github.com/civitai/talos-infra/blob/trunk/claudedocs/app-blocks-w12-cutover-gaps-handoff-2026-05-27.md)). The third gap (Cloudflare DNS) is a manual zone edit and doesn't touch this repo.

### Gap 1 — Forgejo webhook delivery (raw-body HMAC)

The handoff doc misdiagnosed this as a Forgejo queue problem. Forgejo IS delivering — its `hook_task` table shows `is_delivered=1`, response body `{"error":"Bad signature"}`. The receiver was 401'ing.

Root cause: Next's `bodyParser` parses the JSON before our handler runs; `JSON.stringify(req.body)` produces compact JSON that differs byte-for-byte from Forgejo's pretty-printed Go-encoded body. HMAC over re-serialized bytes never matches.

Fix: same pattern as `stripe.ts`, `coinbase.ts`, `paddle.ts` — `bodyParser: false`, read raw stream into `Buffer`, verify HMAC against raw bytes, then `JSON.parse`. Body size still capped (64KB git-push, 8KB build-callback) to bound surface.

### Gap 3 — Cross-cluster build dispatch

W2-v0 had `apps-pipeline.service.ts` parse a kubeconfig and POST `PipelineRun` resources directly to dc-02-a's API server. That doesn't work — dc-02-a's API is loopback-only (SSH-tunnel for operators), so dp-1 pods can't reach it.

Fix: a thin Python receiver on dc-02-a (`app-blocks-trigger`, see [`datapacket-talos/claudedocs/app-blocks-tekton-trigger/`](https://github.com/civitai/talos-infra/tree/trunk/claudedocs/app-blocks-tekton-trigger)) listens on the WireGuard peer IP, validates HMAC, creates `PipelineRun` via its own in-pod SA. `triggerBuild()` becomes a simple HMAC-signed JSON POST through the existing dp-1 VPN proxy.

Env schema swap: dropped `APPS_TEKTON_KUBECONFIG` / `APPS_TEKTON_NAMESPACE`; added `APPS_TEKTON_TRIGGER_URL` / `APPS_TEKTON_TRIGGER_SECRET`.

## Deployed state (pre-merge, already wired)

- ✅ Forgejo queue restored to `level` (durable) — see [datapacket-talos trunk](https://github.com/civitai/talos-infra/commit/b5688cf28).
- ✅ dp-1 VPN proxy: port 8088 added + `strategy: Recreate` (commits [b42448be0](https://github.com/civitai/talos-infra/commit/b42448be0), [3172f407c](https://github.com/civitai/talos-infra/commit/3172f407c)).
- ✅ dc-02-a: `app-blocks-trigger` deployed in `tekton-builds` ns, hostNetwork on WG peer node, HMAC secret in place. Tested with a signed POST — `PipelineRun` `app-blocks-generate-from-model-f8aebf32-6b005a` was created successfully.
- ✅ `civitai-pr-2319` env updated with `APPS_TEKTON_TRIGGER_URL` + `APPS_TEKTON_TRIGGER_SECRET` (matching the dc-02-a secret).

Merging this PR triggers the civitai-pr-2319 image rebuild → the new code will use the env vars already in place → the next Forgejo push lands the full pipeline end-to-end.

## Test plan

- [ ] CI green (typecheck, lint).
- [ ] Merge → wait for PR preview image rebuild on `civitai-pr-2319`.
- [ ] Push an empty commit to `civitai-apps/generate-from-model` (via `kubectl port-forward` to Forgejo).
- [ ] Forgejo `hook_task` row: `is_succeed=1`, response body shows civitai-web returning 200.
- [ ] `kubectl -n civitai-pr-2319 logs deploy/civitai-web` shows a successful `/api/internal/blocks/git-push` POST.
- [ ] `kubectl -n tekton-builds -K dc-02-a get pipelineruns` shows a new `app-blocks-generate-from-model-*` PipelineRun within ~2s of the push.
- [ ] Pipeline runs to completion (~10min); build-callback fires; `app_blocks` row for `generate-from-model` reflects new SHA + `currentVersionDeployedAt`.

## Files

- `src/pages/api/internal/blocks/git-push.ts` — raw-body HMAC verify.
- `src/pages/api/internal/blocks/build-callback.ts` — same.
- `src/server/services/blocks/apps-pipeline.service.ts` — HTTP+HMAC trigger.
- `src/env/server-schema.ts` — env var swap.

## Rollback

Each layer is independently reversible (`git revert` this PR + revert the two datapacket-talos commits will fully restore the prior state). `apps-tekton-kubeconfig` Secret in `civitai-pr-2319` was already deleted as part of wiring, but recreating it from SOPS is a single `flux reconcile` away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)