### PR TITLE
feat(scanner): add regex shadow detector and complete incest derivation

### DIFF
--- a/src/components/Moderator/ScannerPolicySidebar.tsx
+++ b/src/components/Moderator/ScannerPolicySidebar.tsx
@@ -1,0 +1,110 @@
+import { Alert, Badge, Box, Group, List, Stack, Text, ThemeIcon, Title } from '@mantine/core';
+import { IconAlertTriangle, IconCheck, IconX } from '@tabler/icons-react';
+import { getScannerLabelPolicy } from '~/components/Moderator/scannerLabelPolicies';
+
+/**
+ * Sidebar shown on the focused-review page. Displays the moderator-friendly
+ * policy summary for the current label so the reviewer always has the rules
+ * in view while verdicting.
+ */
+export function ScannerPolicySidebar({ label }: { label: string }) {
+  const policy = getScannerLabelPolicy(label);
+
+  if (!policy) {
+    return (
+      <Box style={{ width: 440 }}>
+        <Stack gap="xs" p="md">
+          <Title order={4} style={{ fontFamily: 'monospace' }}>
+            {label}
+          </Title>
+          <Alert color="gray">No moderator policy summary on file for this label yet.</Alert>
+        </Stack>
+      </Box>
+    );
+  }
+
+  return (
+    <Box style={{ width: 440 }}>
+      <Stack gap="md" p="md">
+        <Stack gap={4}>
+          <Text c="dimmed" size="xs" tt="uppercase" fw={500}>
+            Policy
+          </Text>
+          <Title order={3} style={{ fontFamily: 'monospace' }}>
+            {policy.title}
+          </Title>
+        </Stack>
+
+        <Box>
+          <Badge variant="light" color="blue" size="sm" mb={6}>
+            Catch
+          </Badge>
+          <Text size="sm">{policy.catch}</Text>
+        </Box>
+
+        <PolicySection
+          heading="Should fire on"
+          color="green"
+          icon={<IconCheck size={12} />}
+          items={policy.shouldFire}
+        />
+
+        <PolicySection
+          heading="Should NOT fire on"
+          color="red"
+          icon={<IconX size={12} />}
+          items={policy.shouldNotFire}
+        />
+
+        {policy.gotchas && policy.gotchas.length > 0 && (
+          <PolicySection
+            heading="Gotchas"
+            color="yellow"
+            icon={<IconAlertTriangle size={12} />}
+            items={policy.gotchas}
+          />
+        )}
+
+        <Text size="xs" c="dimmed">
+          Only the <strong>positive prompt</strong> decides the verdict — terms appearing only in
+          the negative prompt are avoidance signals.
+        </Text>
+      </Stack>
+    </Box>
+  );
+}
+
+function PolicySection({
+  heading,
+  color,
+  icon,
+  items,
+}: {
+  heading: string;
+  color: string;
+  icon: React.ReactNode;
+  items: string[];
+}) {
+  if (items.length === 0) return null;
+  return (
+    <Box>
+      <Group gap={6} mb={6}>
+        <ThemeIcon variant="light" color={color} size="sm" radius="xl">
+          {icon}
+        </ThemeIcon>
+        <Text size="xs" tt="uppercase" fw={600} c={color}>
+          {heading}
+        </Text>
+      </Group>
+      <List size="sm" spacing={4} listStyleType="disc" withPadding>
+        {items.map((item, i) => (
+          <List.Item key={i}>
+            <Text size="sm" component="span">
+              {item}
+            </Text>
+          </List.Item>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/src/components/Moderator/scannerLabelPolicies.ts
+++ b/src/components/Moderator/scannerLabelPolicies.ts
@@ -1,0 +1,272 @@
+/**
+ * Moderator-facing policy summaries for each scanner label.
+ *
+ * Plain-English version of the XGuard prompt-mode policies. Used by the
+ * focused-review sidebar so moderators see what each label is supposed to
+ * catch while they're verdicting items.
+ *
+ * Keep in sync with docs/features/scanner-moderator-guide.md.
+ */
+export type ScannerLabelPolicy = {
+  /** Display name shown at the top of the sidebar. */
+  title: string;
+  /** One-sentence "what should this catch" summary. */
+  catch: string;
+  /** Bullets describing what should fire the label. */
+  shouldFire: string[];
+  /** Bullets describing what should NOT fire the label. */
+  shouldNotFire: string[];
+  /** Optional gotchas / common confusion points. */
+  gotchas?: string[];
+};
+
+/**
+ * Keyed by the lowercase label slug used in the audit URL
+ * (e.g. /moderator/scanner-audit/prompt/young → key `young`).
+ */
+export const SCANNER_LABEL_POLICIES: Record<string, ScannerLabelPolicy> = {
+  young: {
+    title: 'Young',
+    catch: 'Prompts that describe, assert, or imply a person under 18.',
+    shouldFire: [
+      'Explicit youth terms: child, kid, toddler, shota, loli, cub, schoolgirl, schoolboy, elementary student, aged down',
+      'Any explicit age under 18 (16 years old, 12yo, etc.)',
+      'Foreign-language youth terms (Vietnamese học sinh, Russian девочка, Japanese 女子高生)',
+      'Sexual content framing a participant as a parent’s child (mom and son, father and daughter)',
+    ],
+    shouldNotFire: [
+      'An explicit adult age (18+, 21, 25, adult, mature, MILF, elderly) overrides implicit youth signals',
+      'young adult, young man, young woman, young actor — adult vocabulary unless an under-18 age is also asserted',
+      'Art style alone (anime, cartoon, chibi, stylized) — explicit content in anime style is NOT Young without explicit youth terms',
+      'Adult body archetypes & fashion: petite, shortstack, small frame, cute face, lolita fashion (as a fashion descriptor)',
+      'Size descriptors on non-bodies (small house, tiny car)',
+      'Tags 1girl, 1boy, 2girls, 2boys alone',
+      'Anthro characters (anthro, furry, dog girl, cat girl, kemono, monster girl) with adult body proportions',
+      'A character’s franchise — judge by what the prompt says, not the franchise’s audience',
+      'Parenthetical age tags inside franchise context (e.g. "kama (teenager) (fate)") — these are character-design markers, not asserted ages',
+    ],
+    gotchas: [
+      'Anime style is not a youth signal by itself.',
+      '"Petite" / "small" describing an adult is fine.',
+      'Pokemon/anime names with anime style are fictional, not real minors.',
+    ],
+  },
+
+  suggestive: {
+    title: 'Suggestive',
+    catch:
+      'Sexually-charged content — anything from suggestive posing through fully explicit. Explicit is a subset of Suggestive.',
+    shouldFire: [
+      'Suggestive posing, sensual framing, sexual undertones, implied sex',
+      'Lingerie or swimwear in a sexualized context',
+      'Revealing or partial-coverage clothing in a sexualized context',
+      'All explicit sexual content (nudity, visible genitals, sex acts) — fires Explicit too',
+    ],
+    shouldNotFire: [
+      'Medical, anatomical, biological descriptions without sexual framing',
+      'Swimwear in genuinely non-sexual contexts (beach, athletic swim competition, modest fashion)',
+      'Standard portraiture, fashion photography, glamour photography without explicit sexual framing',
+      'Exposed shoulders or partial clothing without sexual framing',
+      'Business / professional / casual portraits',
+      'Body-shape descriptors alone (curvy, hourglass, large breasts, thick thighs, toned, muscular) without sexualized posing, sexualized framing, or revealing-in-sexual-context clothing',
+      'Anthro / furry / feral characters without depicted sex acts, visible genitals, sexual fluids, or sexualized posing',
+      'Terms appearing only in the NEGATIVE prompt — those are avoidance signals',
+    ],
+    gotchas: [
+      'The distinguishing factor is sexualized framing, not the clothing itself. Bikini at swim meet ≠ bikini in sensual bedroom pose.',
+      'If the prompt is Explicit, Suggestive should fire too. Suggestive without Explicit means "sexual undertones but no actual explicit elements."',
+      'Body shape ≠ sexualized content. A "curvy clothed body" alone is not Suggestive.',
+    ],
+  },
+
+  explicit: {
+    title: 'Explicit',
+    catch: 'Hard sexual content — visible explicit anatomy, depicted sex acts, or sexual fluids.',
+    shouldFire: [
+      'Visible genitals (pussy, penis, anus, vulva)',
+      'Visible nipples in sexualized framing',
+      'Depicted sex acts (masturbation, intercourse, oral sex, anal sex)',
+      'Explicit sexual fluids (cum, ejaculation, squirting)',
+      'Unambiguous nudity depicted in a sexual manner',
+    ],
+    shouldNotFire: [
+      'Suggestive but non-explicit: implied sex, lingerie, sensual posing, revealing clothing without visible genitals or depicted acts (that’s Suggestive, not Explicit)',
+      'Body-shape descriptors alone (large breasts, thick thighs, cleavage, wide hips, curvy, hourglass, toned, muscular) — even paired with revealing-but-clothed attire',
+      'Topless or artistic nudity without sexualized framing',
+      'Anthro characters without depicted sex acts, visible genitals, or sexual fluids',
+      'Explicit terms appearing ONLY in the negative prompt (those are avoidance signals)',
+    ],
+    gotchas: [
+      'A "curvy clothed body" is NOT Explicit. Body shape ≠ nudity.',
+      'Nudity itself remains explicit-triggering when present — the body-shape carve-out only covers clothed cases.',
+      'A prompt with bikini, pussy, nude, cum in the negative is trying to prevent explicit content — sec.',
+    ],
+  },
+
+  celebrity: {
+    title: 'Celebrity',
+    catch: 'Prompts using the name of a globally-famous real living or historical person.',
+    shouldFire: [
+      'Unambiguous real-name references a general audience would immediately recognize (Taylor Swift, Barack Obama, Cristiano Ronaldo, Beyoncé, Elon Musk, Albert Einstein, Marilyn Monroe)',
+      'AND no fictional-context marker is present',
+    ],
+    shouldNotFire: [
+      'The "[Name] from [franchise]" pattern — the "from" makes the name fictional (Pitt from Kid Icarus, Cloud from Final Fantasy)',
+      'Any reference to anime, manga, cartoon, video game, comic, manhwa, JRPG, MMO, gacha, fantasy RPG',
+      'Style tags: anime style, anime screencap, game CG, pixel art, cartoon style',
+      'Franchise/title references — even ones you don’t recognize (Pokemon, Genshin, Final Fantasy, My Little Pony, Poppy Playtime, Kid Icarus, Zelda)',
+      'Character-feature tags: catgirl, dragon girl, monster girl, demon, elf, succubus, magical girl, mecha, robot, android',
+      'LoRA trigger words / opaque identifiers (MaiSchool, Lewdlemage, HelenSynthExl, expressiveH)',
+      'Original characters, OCs, fan-fiction characters, fursonas',
+      'First-name-only references (Sarah, John) without globally-famous-real-person context',
+      'Side characters, supporting characters, villains in fictional series',
+    ],
+    gotchas: [
+      'Default to sec. The vast majority of named characters in prompts are fictional.',
+      'Capitalized name-shaped strings are usually LoRA triggers, not celebrity references.',
+      'If you don’t recognize a name, it’s almost certainly an OC or fictional character.',
+    ],
+  },
+
+  familial: {
+    title: 'Familial',
+    catch:
+      'A family/blood relationship between two or more people in the prompt. This is an atomic detector — sexual content is irrelevant to this label; the derived "Incest" label combines Familial with sexual signals.',
+    shouldFire: [
+      'A family-relation term describing a relationship BETWEEN people: "mom and son", "father and daughter", "two siblings", "stepmom and stepson"',
+      'Step-relatives between people: stepmom + stepson, stepsister + stepbrother',
+      'Explicit family terms paired with another person: mother, father, mom, dad, son, daughter, brother, sister, sibling, twin, aunt, uncle, cousin, niece, nephew, grandmother, grandfather, etc.',
+    ],
+    shouldNotFire: [
+      'A single person tagged with a family role and no other family member present: "mommy aesthetic", "MILF", "DILF", "older sister character archetype", "father figure"',
+      '"Sister" / "brother" / "mother" / "father" as endearment, friendship, religious or character-archetype context: "sister of the convent", "brother in arms", "soul sister", "big sister type" (anime archetype)',
+      'No family-relation term in the prompt',
+      'Family relation in non-sexual scenes (still fires Familial; only the derived Incest label requires the sexual context too)',
+    ],
+    gotchas: [
+      'Familial is intentionally independent of sexual content. It fires whenever there is a family pair, even in a wholesome family portrait. The derived Incest label only fires when Familial AND Suggestive/Explicit both fire.',
+      'A single "mommy" or "MILF" with no other family member is NOT Familial — Familial requires the relationship to be between people.',
+    ],
+  },
+
+  incest: {
+    title: 'Incest (derived)',
+    catch:
+      'Sexual content involving family relations. This is a DERIVED label — it fires automatically when the atomic Familial label AND (Suggestive OR Explicit) both trigger. There is no standalone Incest model; you are reviewing the combination.',
+    shouldFire: [
+      'A family-relation term (mother, father, mom, dad, son, daughter, brother, sister, sibling, twin, aunt, uncle, cousin, grandparent, niece, nephew) PLUS a sexual context',
+      'Step-relatives (stepmom, stepdad, stepsister, stepbrother) in a sexual context',
+    ],
+    shouldNotFire: [
+      'Non-sexual family content: family portraits, mother-and-child scenes, sibling interactions, parenting scenes',
+      '"Sister" / "brother" used as endearment, friendship, or religious context (sister of the convent, brother in arms, soul sister)',
+      'Family relations in SFW, comedic, or narrative contexts',
+      'Fictional sibling characters in non-sexual situations',
+    ],
+  },
+
+  nonconsent: {
+    title: 'Non-Consent',
+    catch: 'Explicit non-consent framing in sexual content.',
+    shouldFire: [
+      'Literal terms: rape, raped, raping, non-consensual, noncon, non-con, forced sex, sexual assault, molested, molesting',
+      'Incapacitation in sexual context: drugged, unconscious, asleep, passed out, comatose paired with sexual activity',
+    ],
+    shouldNotFire: [
+      'Sexual content alone — sexual content is not a non-consent signal',
+      'BDSM, bondage, rough sex, restraints, ropes, gags, struggling, crying, tears — without one of the explicit non-consent terms',
+      'The word "forced" alone (forced perspective, forced into a corner, forced to smile)',
+      'Suggestive content without sexual non-consent framing',
+    ],
+    gotchas: [
+      'BDSM aesthetics ≠ non-consent. The policy targets explicit non-consent framing, not bondage imagery.',
+    ],
+  },
+
+  gore: {
+    title: 'Gore',
+    catch: 'Extreme graphic violence with anatomical detail.',
+    shouldFire: [
+      'Dismemberment, mutilation, evisceration, decapitation',
+      'Exposed internal organs, severed limbs, visible bone or viscera, intestines, brain matter',
+      'Gore-spray, catastrophic bodily injury',
+    ],
+    shouldNotFire: [
+      'Mild or stylized violence: combat scenes, fistfights, scrapes, bruises, action-movie violence',
+      'Controlled blood splatter without anatomical exposure',
+      'Horror, action, fantasy contexts without graphic anatomical injury',
+      'Monsters, scary scenes, horror atmosphere alone',
+      'Medical, surgical, anatomical study, or autopsy contexts framed as educational/clinical',
+      'Special-effects makeup, costume, prosthetic, zombie cosmetic, halloween imagery',
+      'Blood alone — bloody sword, bloody clothing, blood splatter without anatomical exposure',
+      '"Bloody" used metaphorically (bloody mary cocktail, bloody mess as exasperation)',
+    ],
+  },
+
+  bestiality: {
+    title: 'Bestiality',
+    catch: 'Sexual activity between a real animal and a human.',
+    shouldFire: [
+      'Sexual content depicting a real (non-anthropomorphic, non-fictional) animal in physical form with a human',
+    ],
+    shouldNotFire: [
+      'Anthro / furry / fictional anthro / monster girl / demi-human / slime girl / dog girl / cat girl / wolf girl / fox girl / sergal / kemono — humanoid, not real animals',
+      'Pokemon, Digimon, My Little Pony, Sonic, Zootopia, Kemono Friends, Helluva Boss — fictional anthro',
+      'Specific Pokemon by name (steenee, sylveon, lopunny, cinderace, lucario, eevee) are anthro/fictional',
+      'Sex position names (doggystyle, doggy style, cowgirl, missionary, reverse cowgirl) are HUMAN positions',
+      'Generic animal mentions (dog, horse, wolf) in non-sexual contexts (pet, scenery, accessory)',
+      'Animal-feature tags (dog ears, cat ears, tail, fur) on otherwise-human characters — kemonomimi/anthro',
+    ],
+    gotchas: [
+      'doggystyle is a HUMAN sex position. It is not bestiality.',
+      'Pokemon are not real animals.',
+    ],
+  },
+
+  diaper: {
+    title: 'Diaper',
+    catch: 'Explicit diaper / ABDL content.',
+    shouldFire: [
+      'Literal terms: diaper, diapers, pamper, pampers, ABDL, adult baby, padded underwear, or unambiguous synonyms',
+    ],
+    shouldNotFire: [
+      'Youth content alone (loli, child, chibi, schoolgirl, young, cute, pigtails) — that’s Young, not Diaper',
+      'Belly-focused content (stuffed belly, big belly, bloated belly)',
+      'Other body fluids or bathroom-adjacent terms (urine, scat) — separate labels',
+      'Femboy, futanari, fetish content without explicit diaper terms',
+    ],
+  },
+
+  urine: {
+    title: 'Urine',
+    catch: 'Urine / urination / piss content.',
+    shouldFire: ['urine, urination, piss, piss play and unambiguous synonyms'],
+    shouldNotFire: [
+      'Other bodily fluids: cum, semen, sweat, saliva, drool, tears, female ejaculation, squirt — unless urine is also explicitly requested',
+      'Bathroom or toilet imagery alone without an explicit urine reference',
+    ],
+  },
+
+  scat: {
+    title: 'Scat',
+    catch: 'Feces / excrement / scat fetish content.',
+    shouldFire: ['Explicit feces, excrement, or scat references'],
+    shouldNotFire: ['"squirt" alone — that’s a separate label'],
+  },
+
+  menstruation: {
+    title: 'Menstruation',
+    catch: 'Menstruation or period blood imagery.',
+    shouldFire: ['Explicit menstruation or period blood requests'],
+    shouldNotFire: [],
+  },
+};
+
+/**
+ * Look up a policy by URL label slug. Returns undefined for unknown labels
+ * (e.g. legacy labels, mode-specific labels like `nsfw` that don't have a
+ * moderator-facing policy yet).
+ */
+export function getScannerLabelPolicy(label: string): ScannerLabelPolicy | undefined {
+  return SCANNER_LABEL_POLICIES[label.toLowerCase()];
+}

--- a/src/pages/api/testing/xguard-test.ts
+++ b/src/pages/api/testing/xguard-test.ts
@@ -1,0 +1,160 @@
+/**
+ * XGuard policy-iteration debug endpoint.
+ * =============================================================================
+ *
+ * Hidden testing route guarded by WEBHOOK_TOKEN via `?token=` query param.
+ *
+ * Submits a synchronous-wait XGuard scan against a single test prompt with
+ * optional per-label policy/threshold/action overrides. In prompt mode it
+ * ALSO runs the regex-based atomic-label detector (scanner-label-regex.ts)
+ * against the positive prompt and returns both XGuard and regex results so
+ * test scripts can compare them directly.
+ *
+ * Usage:
+ *   POST /api/testing/xguard-test?token=$WEBHOOK_TOKEN
+ *   Content-Type: application/json
+ *   Body: {
+ *     "mode": "prompt" | "text",
+ *     "positivePrompt": "...",        // when mode=prompt
+ *     "negativePrompt": "...",        // when mode=prompt (optional)
+ *     "text": "...",                  // when mode=text
+ *     "labels": ["young"],            // restrict which labels to evaluate
+ *     "labelOverrides": [             // optional candidate policy overrides
+ *       {
+ *         "label": "Young",
+ *         "action": "Scan",
+ *         "threshold": 0.5,
+ *         "policy": "- x: Civitai ..."
+ *       }
+ *     ],
+ *     "regexLabels": ["familial"],    // optional: which regex labels to run.
+ *                                     //   Default: all labels in SCANNER_LABEL_REGEX.
+ *                                     //   Pass [] to skip the regex pass entirely.
+ *     "wait": 30                       // seconds to wait for orchestrator
+ *   }
+ *
+ * Response:
+ *   {
+ *     workflowId, status,
+ *     output: XGuardModerationOutput,       // raw model results
+ *     regexResults: LabelMatchResult[]      // regex-detector results
+ *                                           // (only set when mode=prompt; null otherwise)
+ *   }
+ *
+ * No EM row is written, no audit log entry — pure fire-and-forget against
+ * the model, plus a deterministic regex pass that runs locally in-process.
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { createXGuardModerationRequest } from '~/server/services/orchestrator/orchestrator.service';
+import {
+  matchLabels,
+  SCANNER_LABEL_REGEX,
+  type LabelMatchResult,
+} from '~/server/services/scanner-label-regex';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+const labelOverrideSchema = z.object({
+  label: z.string().min(1),
+  action: z.string().min(1),
+  threshold: z.number().min(0).max(1),
+  policy: z.string().min(1),
+});
+
+const schema = z.discriminatedUnion('mode', [
+  z.object({
+    mode: z.literal('prompt'),
+    positivePrompt: z.string().min(1),
+    negativePrompt: z.string().optional(),
+    instructions: z.string().optional(),
+    labels: z.array(z.string()).optional(),
+    labelOverrides: z.array(labelOverrideSchema).optional(),
+    regexLabels: z.array(z.string()).optional(),
+    wait: z.number().int().min(1).max(120).default(30),
+  }),
+  z.object({
+    mode: z.literal('text'),
+    text: z.string().min(1),
+    labels: z.array(z.string()).optional(),
+    labelOverrides: z.array(labelOverrideSchema).optional(),
+    wait: z.number().int().min(1).max(120).default(30),
+  }),
+]);
+
+export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request', issues: parsed.error.issues });
+  }
+  const input = parsed.data;
+
+  try {
+    const common = {
+      labels: input.labels,
+      labelOverrides: input.labelOverrides,
+      wait: input.wait,
+      // Suppress the standard audit-write callback — debug requests shouldn't
+      // land in `scanner_label_results` and pollute the production audit log.
+      callbackUrl: null as null,
+      recordForReview: false,
+    };
+
+    // Run the regex matcher in parallel with the XGuard call. Prompt mode only —
+    // the regex labels are designed for image-generation prompts; text mode has
+    // a different semantic surface and we don't want to leak misleading regex
+    // results into text-scan responses.
+    let regexResults: LabelMatchResult[] | null = null;
+    if (input.mode === 'prompt') {
+      const requested =
+        input.regexLabels !== undefined ? input.regexLabels : Object.keys(SCANNER_LABEL_REGEX);
+      if (requested.length > 0) {
+        try {
+          regexResults = matchLabels(requested, input.positivePrompt);
+        } catch (regexErr) {
+          // Surface the typo (unknown label) rather than silently dropping.
+          return res.status(400).json({
+            error: `regex matcher error: ${(regexErr as Error).message}`,
+          });
+        }
+      } else {
+        regexResults = [];
+      }
+    }
+
+    const result =
+      input.mode === 'prompt'
+        ? await createXGuardModerationRequest({
+            mode: 'prompt',
+            positivePrompt: input.positivePrompt,
+            negativePrompt: input.negativePrompt,
+            instructions: input.instructions,
+            ...common,
+          })
+        : await createXGuardModerationRequest({
+            mode: 'text',
+            content: input.text,
+            ...common,
+          });
+
+    if (!result?.id) {
+      return res.status(502).json({ error: 'orchestrator did not return a workflow id' });
+    }
+
+    // Pull the step output off the (now-completed, since we used wait) workflow.
+    const steps = (result as { steps?: Array<Record<string, unknown>> }).steps ?? [];
+    const xguardStep = steps.find((s) => s.$type === 'xGuardModeration');
+    const output = (xguardStep as { output?: unknown })?.output;
+
+    return res.status(200).json({
+      workflowId: result.id,
+      status: (result as { status?: string }).status,
+      output,
+      regexResults,
+    });
+  } catch (e) {
+    const error = e as Error;
+    return res.status(500).json({ error: error.message, stack: error.stack });
+  }
+});

--- a/src/pages/moderator/scanner-audit/[mode]/[label].tsx
+++ b/src/pages/moderator/scanner-audit/[mode]/[label].tsx
@@ -58,6 +58,7 @@ import {
   modeToScanner,
   type ScannerAuditMode,
 } from '~/components/Moderator/ScannerAuditLayout';
+import { ScannerPolicySidebar } from '~/components/Moderator/ScannerPolicySidebar';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import type { Scanner } from '~/server/schema/scanner-review.schema';
 import type { AggregatedScanRow } from '~/server/services/scanner-review.service';
@@ -109,25 +110,9 @@ function FocusedRunLayout({ children }: { children: ReactElement }) {
 
 function FocusedRunSidebarMount() {
   const router = useRouter();
-  const modeParam = Array.isArray(router.query.mode) ? router.query.mode[0] : router.query.mode;
   const labelParam = Array.isArray(router.query.label) ? router.query.label[0] : router.query.label;
-  const lookbackDays = router.query.lookbackDays ? Number(router.query.lookbackDays) : undefined;
-  const validMode = isValidMode(modeParam) ? modeParam : null;
-
-  const { data } = trpc.scannerReview.focusedRun.useQuery(
-    {
-      scanner: validMode ? modeToScanner(validMode) : 'xguard_text',
-      label: labelParam ?? '',
-      lookbackDays,
-      limit: 50,
-    },
-    { enabled: !!validMode && !!labelParam, refetchOnWindowFocus: false }
-  );
-  const items = data?.items ?? [];
-  const { cursor, setCursor } = useFocusedCursor();
-
-  if (items.length === 0) return null;
-  return <ProgressSidebar items={items} cursor={cursor} onJump={setCursor} />;
+  if (!labelParam) return null;
+  return <ScannerPolicySidebar label={labelParam} />;
 }
 
 function ScannerAuditFocusedPage() {
@@ -745,104 +730,6 @@ function ActionFooter({
           Yes
         </Button>
       </Group>
-    </Box>
-  );
-}
-
-const SIDEBAR_MATCHED_TERMS_MAX = 4;
-
-function ProgressSidebar({
-  items,
-  cursor,
-  onJump,
-}: {
-  items: AggregatedScanRow[];
-  cursor: number;
-  onJump: (idx: number) => void;
-}) {
-  // AppLayout's `right` slot already wraps this in an <aside> with
-  // `scroll-area` (overflow handling) and a left border — we just set width.
-  return (
-    <Box style={{ width: 320 }}>
-      <Stack gap={2} p="md">
-        <Group justify="space-between" mb="xs">
-          <Text fw={600}>Run</Text>
-          <Text size="xs" c="dimmed">
-            {cursor + 1} of {items.length}
-          </Text>
-        </Group>
-        {items.map((it, idx) => {
-          const isCurrent = idx === cursor;
-          const isPast = idx < cursor;
-          const matched = [
-            ...it.matchedText,
-            ...it.matchedPositivePrompt,
-            ...it.matchedNegativePrompt,
-          ];
-          const matchedVisible = matched.slice(0, SIDEBAR_MATCHED_TERMS_MAX);
-          const matchedOverflow = matched.length - matchedVisible.length;
-          return (
-            <Box
-              key={`${it.contentHash}-${it.version}`}
-              onClick={() => onJump(idx)}
-              p="xs"
-              style={{
-                cursor: 'pointer',
-                borderRadius: 4,
-                background: isCurrent ? 'var(--mantine-color-blue-9)' : 'transparent',
-                opacity: isPast ? 0.55 : 1,
-              }}
-            >
-              <Group gap="xs" wrap="nowrap" align="flex-start">
-                <Box
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: '50%',
-                    marginTop: 6,
-                    background: isPast
-                      ? 'var(--mantine-color-gray-6)'
-                      : it.triggered === 1
-                      ? 'var(--mantine-color-red-6)'
-                      : 'var(--mantine-color-gray-5)',
-                    flexShrink: 0,
-                  }}
-                />
-                <Stack gap={4} style={{ minWidth: 0, flex: 1 }}>
-                  <Text size="xs" c="dimmed">
-                    {it.score.toFixed(3)}
-                    {it.threshold !== null && ` / ${it.threshold.toFixed(2)}`}
-                  </Text>
-                  {matched.length > 0 ? (
-                    <Group gap={4} wrap="wrap">
-                      {matchedVisible.map((t, i) => (
-                        <Badge
-                          key={`${t}-${i}`}
-                          size="xs"
-                          variant="light"
-                          color="orange"
-                          styles={{ root: { textTransform: 'none', fontWeight: 500 } }}
-                        >
-                          {t}
-                        </Badge>
-                      ))}
-                      {matchedOverflow > 0 && (
-                        <Text size="xs" c="dimmed">
-                          +{matchedOverflow}
-                        </Text>
-                      )}
-                    </Group>
-                  ) : (
-                    <Text size="xs" c="dimmed" lineClamp={1}>
-                      {it.contentHash.slice(0, 12)}
-                    </Text>
-                  )}
-                </Stack>
-              </Group>
-            </Box>
-          );
-        })}
-      </Stack>
     </Box>
   );
 }

--- a/src/server/services/__tests__/scanner-derived-labels.service.test.ts
+++ b/src/server/services/__tests__/scanner-derived-labels.service.test.ts
@@ -88,7 +88,7 @@ describe('applyDerivedLabels', () => {
   describe('derivation (csam = young AND any sexual signal)', () => {
     it('does not synthesize csam without young', () => {
       const out = applyDerivedLabels(
-        [row('explicit', 1), row('sexual', 1)],
+        [row('explicit', 1), row('suggestive', 1)],
         'prompt'
       );
       expect(out.map((r) => r.label)).not.toContain('csam');
@@ -114,14 +114,6 @@ describe('applyDerivedLabels', () => {
       expect(csam!.score).toBe(0.6);
     });
 
-    it('synthesizes csam when young + sexual triggered', () => {
-      const out = applyDerivedLabels(
-        [row('young', 1), row('sexual', 1)],
-        'prompt'
-      );
-      expect(out.find((r) => r.label === 'csam')).toBeDefined();
-    });
-
     it('synthesizes csam when young + suggestive triggered (no explicit)', () => {
       const out = applyDerivedLabels(
         [row('young', 1), row('suggestive', 1)],
@@ -133,14 +125,17 @@ describe('applyDerivedLabels', () => {
     });
 
     it('prefers the first matching any-of input', () => {
-      // both sexual and suggestive triggered — derivation picks the first
-      // listed match (sexual) per the requiresAnyOf array order
+      // both suggestive and explicit triggered — derivation picks the first
+      // listed match (suggestive) per the requiresAnyOf array order. (Note:
+      // when both fire, suggestive is normally suppressed by the
+      // explicit-dominates-suggestive rule, but derivation reads the
+      // PRE-suppression set, so suggestive is still visible here.)
       const out = applyDerivedLabels(
-        [row('young', 1), row('sexual', 1), row('suggestive', 1)],
+        [row('young', 1), row('suggestive', 1), row('explicit', 1)],
         'prompt'
       );
       const csam = out.find((r) => r.label === 'csam');
-      expect(csam!.derivedFrom).toEqual(['young', 'sexual']);
+      expect(csam!.derivedFrom).toEqual(['young', 'suggestive']);
     });
 
     it('text mode also accepts nsfw as the sexual signal', () => {
@@ -167,6 +162,60 @@ describe('applyDerivedLabels', () => {
         'prompt'
       );
       expect(out.find((r) => r.label === 'csam')).toBeUndefined();
+    });
+  });
+
+  describe('derivation (incest = familial AND any sexual signal)', () => {
+    it('does not synthesize incest without familial', () => {
+      const out = applyDerivedLabels([row('explicit', 1), row('suggestive', 1)], 'prompt');
+      expect(out.map((r) => r.label)).not.toContain('incest');
+    });
+
+    it('does not synthesize incest without any sexual signal', () => {
+      const out = applyDerivedLabels([row('familial', 1)], 'prompt');
+      expect(out.map((r) => r.label)).not.toContain('incest');
+    });
+
+    it('synthesizes incest when familial + explicit triggered', () => {
+      const out = applyDerivedLabels(
+        [row('familial', 1, 0.7), row('explicit', 1, 0.9)],
+        'prompt'
+      );
+      const incest = out.find((r) => r.label === 'incest');
+      expect(incest).toBeDefined();
+      expect(incest!.synthetic).toBe(true);
+      expect(incest!.triggered).toBe(1);
+      expect(incest!.derivedFrom).toEqual(['familial', 'explicit']);
+      expect(incest!.score).toBe(0.7); // min of contributing scores
+    });
+
+    it('synthesizes incest when familial + suggestive triggered (no explicit)', () => {
+      const out = applyDerivedLabels(
+        [row('familial', 1), row('suggestive', 1)],
+        'prompt'
+      );
+      const incest = out.find((r) => r.label === 'incest');
+      expect(incest).toBeDefined();
+      expect(incest!.derivedFrom).toEqual(['familial', 'suggestive']);
+    });
+
+    it('strips an input incest row when the rule does not fire', () => {
+      // Incest is now a derivation-owned name. A raw `incest` row in the
+      // input (e.g. from a stale XGuard scan before Familial was added)
+      // should be stripped if the rule doesn't fire.
+      const out = applyDerivedLabels([row('incest', 1)], 'prompt');
+      expect(out.find((r) => r.label === 'incest')).toBeUndefined();
+    });
+
+    it('replaces an input incest row with a freshly-derived one', () => {
+      const out = applyDerivedLabels(
+        [row('incest', 1), row('familial', 1), row('explicit', 1)],
+        'prompt'
+      );
+      const incests = out.filter((r) => r.label === 'incest');
+      expect(incests).toHaveLength(1);
+      expect(incests[0].synthetic).toBe(true);
+      expect(incests[0].derivedFrom).toEqual(['familial', 'explicit']);
     });
   });
 
@@ -209,9 +258,8 @@ describe('applyDerivedLabels', () => {
       expect(out.find((r) => r.label === 'suggestive')).toBeUndefined();
       // explicit kept
       expect(out.find((r) => r.label === 'explicit')).toBeDefined();
-      // csam derived — explicit comes before suggestive in requiresAnyOf
-      // (sexual, suggestive, explicit), but sexual didn't trigger, suggestive
-      // is first matching, so derivedFrom should be [young, suggestive]
+      // csam derived — requiresAnyOf is [suggestive, explicit], suggestive is
+      // first matching, so derivedFrom should be [young, suggestive]
       const csam = out.find((r) => r.label === 'csam');
       expect(csam).toBeDefined();
       expect(csam!.derivedFrom).toEqual(['young', 'suggestive']);
@@ -243,7 +291,7 @@ describe('applyDerivedLabels', () => {
 
     it('preserves empty arrays correctly', () => {
       const out = applyDerivedLabels(
-        [row('young', 1), row('sexual', 1)],
+        [row('young', 1), row('suggestive', 1)],
         'prompt'
       );
       const csam = out.find((r) => r.label === 'csam')!;

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -198,6 +198,16 @@ type XGuardModerationArgs = {
    * metadata only — not stored in the ClickHouse audit table. */
   userId?: number;
   labels?: string[];
+  /** Per-label policy/threshold/action overrides for this single request.
+   * Merges with the orchestrator's default registry. Useful for debug /
+   * policy-tuning paths (e.g. `/api/testing/xguard-test`) where we want to
+   * evaluate a candidate policy without modifying the live registry. */
+  labelOverrides?: Array<{
+    label: string;
+    action: string;
+    threshold: number;
+    policy: string;
+  }>;
   /** Override the default audit-result callback URL. Omit to use the standard
    * `/api/webhooks/text-moderation-result` endpoint (which is what makes audit
    * rows land in `scanner_label_results`). Pass `null` to suppress the
@@ -237,6 +247,7 @@ export async function createXGuardModerationRequest(args: XGuardModerationArgs) 
     entityId,
     userId,
     labels,
+    labelOverrides,
     callbackUrl,
     wait,
     priority = 'normal',
@@ -303,7 +314,8 @@ export async function createXGuardModerationRequest(args: XGuardModerationArgs) 
           mode: 'text' as const,
           text: args.content,
           labels,
-          storeFullResponse: true,
+          labelOverrides,
+          storeFullResponse: false,
         }
       : {
           mode: 'prompt' as const,
@@ -311,7 +323,8 @@ export async function createXGuardModerationRequest(args: XGuardModerationArgs) 
           negativePrompt: args.negativePrompt ?? null,
           instructions: args.instructions ?? null,
           labels,
-          storeFullResponse: true,
+          labelOverrides,
+          storeFullResponse: false,
         };
 
   // The orchestrator submit can either return `{ data: null, error }` for a

--- a/src/server/services/scanner-audit.service.ts
+++ b/src/server/services/scanner-audit.service.ts
@@ -20,6 +20,7 @@ import {
   type DerivedLabelInput,
   type DerivedLabelMode,
 } from '~/server/services/scanner-derived-labels.service';
+import { matchAllLabels, REGEX_VERSION } from '~/server/services/scanner-label-regex';
 
 /**
  * Age-classifier topK band names that count as minor. Includes Teenager 13-20
@@ -161,6 +162,84 @@ async function insertRows({
 }
 
 /**
+ * Cheap script-detection gate for the regex shadow pass. Returns true when
+ * the text is plausibly English (mostly Latin script). Non-English prompts
+ * skip the regex matcher — the regex term lists are English-only by design;
+ * see docs/features/scanner-label-architecture.md for the tiered detection
+ * plan.
+ */
+function isLikelyEnglishForRegex(text: string): boolean {
+  if (!text) return false;
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+  const nonLatin = text.match(
+    /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Cyrillic}\p{Script=Arabic}\p{Script=Hangul}\p{Script=Devanagari}\p{Script=Thai}\p{Script=Hebrew}]/gu
+  );
+  if (!nonLatin) return true;
+  return nonLatin.length / text.length < 0.05; // <5% non-Latin chars = treat as English
+}
+
+/**
+ * Shadow-write: compare regex-detector output to XGuard for each atomic
+ * label and persist the comparison to `scanner_regex_shadow_results` for
+ * later audit. Phase 1 of the regex-rollout plan in
+ * docs/features/scanner-label-architecture.md — does not change the audit
+ * data the moderator queue sees.
+ *
+ * Fire-and-forget: any failure here is logged to Axiom but does not
+ * propagate. We never block the main audit write on regex shadow data.
+ */
+async function writeRegexShadowComparison(args: {
+  workflowId: string;
+  contentHash: string;
+  scanner: 'xguard_prompt' | 'xguard_text';
+  positivePrompt: string;
+  xguardLabels: LabelRowSeed[];
+  scannedAt: Date;
+}) {
+  if (!clickhouse) return;
+  if (!isLikelyEnglishForRegex(args.positivePrompt)) return;
+
+  try {
+    const regexResults = matchAllLabels(args.positivePrompt);
+    if (regexResults.length === 0) return;
+
+    const rows = regexResults.map((r) => {
+      const xg = args.xguardLabels.find((l) => l.label === r.label);
+      return {
+        workflowId: args.workflowId,
+        contentHash: args.contentHash,
+        scanner: args.scanner,
+        label: r.label,
+        regexMatched: r.matched ? 1 : 0,
+        regexReason: r.reason,
+        regexMatchedTerms: r.matchedTerms,
+        regexVersion: REGEX_VERSION,
+        xguardTriggered: xg ? xg.triggered : null,
+        xguardScore: xg?.score ?? null,
+        xguardThreshold: xg?.threshold ?? null,
+        xguardPolicyHash: xg?.version ?? null,
+        scannedAt: args.scannedAt,
+      };
+    });
+
+    await clickhouse.insert({
+      table: 'scanner_regex_shadow_results',
+      values: rows,
+      format: 'JSONEachRow',
+    });
+  } catch (e) {
+    const error = e as Error;
+    await logToAxiom({
+      name: 'scanner-regex-shadow-write-failed',
+      type: 'error',
+      message: error.message,
+      workflowId: args.workflowId,
+      contentHash: args.contentHash,
+    });
+  }
+}
+
+/**
  * Pull the per-label results off a succeeded XGuard workflow and write them
  * to the audit log. No-op if `metadata.recordForReview` isn't set, or if no
  * xGuardModeration step output is present.
@@ -219,6 +298,22 @@ export async function recordXGuardScanFromWorkflow(workflow: Workflow) {
 
   const entityType = (workflow.metadata.entityType as string | undefined) ?? '';
   const entityIdRaw = workflow.metadata.entityId as number | string | undefined;
+
+  // Phase 1 (shadow mode) regex comparison. Doesn't change what's recorded
+  // to scanner_label_results — purely an analytical sidecar in
+  // scanner_regex_shadow_results so we can audit regex accuracy vs XGuard on
+  // real production traffic before flipping the regex authoritative. Prompt
+  // mode + English-only; see writeRegexShadowComparison.
+  if (mode === 'prompt' && workflow.id && input.positivePrompt) {
+    void writeRegexShadowComparison({
+      workflowId: workflow.id,
+      contentHash,
+      scanner: 'xguard_prompt',
+      positivePrompt: input.positivePrompt,
+      xguardLabels: labels,
+      scannedAt: workflow.completedAt ?? new Date(),
+    });
+  }
 
   // Apply derived-label rules — suppress redundant rows (e.g. `suggestive`
   // when `explicit` also triggered) and synthesize computed rows (e.g.

--- a/src/server/services/scanner-derived-labels.service.ts
+++ b/src/server/services/scanner-derived-labels.service.ts
@@ -51,7 +51,7 @@ type DerivationRule = {
   /** All labels in this list must have triggered for the rule to fire. */
   requires: string[];
   /** At least one label in this list must have triggered. (Used for
-   * AND-of-ORs derivations like csam = young AND (sexual OR explicit). */
+   * AND-of-ORs derivations like csam = young AND (suggestive OR explicit). */
   requiresAnyOf?: string[];
 };
 
@@ -71,7 +71,16 @@ const PROMPT_RULES: RuleSet = {
     {
       emit: 'csam',
       requires: ['young'],
-      requiresAnyOf: ['sexual', 'suggestive', 'explicit'],
+      requiresAnyOf: ['suggestive', 'explicit'],
+    },
+    {
+      // Incest is now derived: the `familial` atomic label detects a family
+      // relation between people, and we require sexual content (suggestive
+      // or explicit) to co-fire. The old standalone `incest` XGuard label
+      // over-fired on any prompt containing a family-relation word.
+      emit: 'incest',
+      requires: ['familial'],
+      requiresAnyOf: ['suggestive', 'explicit'],
     },
   ],
 };
@@ -86,7 +95,7 @@ const TEXT_RULES: RuleSet = {
       // signal — derivation accepts it alongside suggestive/explicit so
       // legacy text-mode content scanned before the Suggestive/Explicit
       // labels landed still gets a synthetic csam if nsfw co-fires.
-      requiresAnyOf: ['nsfw', 'sexual', 'suggestive', 'explicit'],
+      requiresAnyOf: ['nsfw', 'suggestive', 'explicit'],
     },
   ],
 };

--- a/src/server/services/scanner-label-regex.ts
+++ b/src/server/services/scanner-label-regex.ts
@@ -1,0 +1,869 @@
+/**
+ * Regex term lists for atomic scanner labels.
+ *
+ * Each entry is data-only — the consuming detector implementation lives
+ * elsewhere. The structure is meant to be readable AND machine-consumable.
+ *
+ * Design rules:
+ *   - `triggers`: plain whole-word terms. The consumer wraps each with a
+ *     whole-word boundary like /(?<![a-z0-9])TERM(?![a-z0-9])/i so substrings
+ *     don't false-match (e.g. "cub" should not match inside "incubus").
+ *   - `phrasePatterns`: multi-word phrase patterns. Whitespace in the source
+ *     should match `\s+` at consume time so weight syntax like "(young:1.4)"
+ *     normalizes correctly.
+ *   - `carveOutPatterns`: regex patterns (no delimiters) that match
+ *     false-positive contexts. The consumer MATCHES-AND-STRIPS these from the
+ *     prompt BEFORE looking for triggers. Order: strip carve-outs → look for
+ *     triggers.
+ *   - `pairPhraseConnectors`, `pluralImpliesPair`, `soloUnambiguous`,
+ *     `possessivePronouns`: structured fields for Familial-style detection
+ *     where the label requires a relation between two entities, not just one
+ *     keyword. Other labels leave these undefined.
+ *
+ * All patterns are case-insensitive at consume time. Normalize prompts to
+ * lowercase before matching (and strip weight syntax: "(term:1.4)" → "term").
+ *
+ * Multilingual coverage is intentionally NOT included here. Non-English
+ * prompts should be routed to an LLM fallback per the tiered detection plan
+ * in docs/features/scanner-label-architecture.md. Maintain this file only
+ * for English vocabulary; LLM handles the rest.
+ */
+
+/**
+ * Version stamp for the regex term lists. Bump whenever any of the per-label
+ * specs change (terms added/removed, carve-outs updated). The version is
+ * stored alongside each match in `scanner_regex_shadow_results` so audit
+ * queries can correlate a change in agreement rate with a known version bump.
+ *
+ * Format: `regex-v<N>` where N is a monotonic integer. Don't reuse numbers.
+ */
+export const REGEX_VERSION = 'regex-v1';
+
+export interface LabelRegexSpec {
+  /** Plain whole-word terms. Each gets wrapped with whole-word boundaries. */
+  triggers: string[];
+  /** Multi-word phrase patterns (whitespace becomes \s+). */
+  phrasePatterns?: string[];
+  /** Regex patterns to strip from the prompt BEFORE trigger matching. */
+  carveOutPatterns?: string[];
+  /** Pair connectors for "X and Y" pair detection (Familial-style). */
+  pairPhraseConnectors?: string[];
+  /** Plural terms that ALONE imply a multi-person relationship. */
+  pluralImpliesPair?: string[];
+  /** Single terms that unambiguously imply a relation to another person. */
+  soloUnambiguous?: string[];
+  /** Possessive pronouns that pair with a relation noun ("her nephew"). */
+  possessivePronouns?: string[];
+  /** Human-readable notes on tricky cases. */
+  notes?: string;
+}
+
+// ============================================================================
+// FAMILIAL
+// Fires when the prompt explicitly identifies a family or blood relationship
+// BETWEEN two or more people. A single person tagged with a family role
+// (e.g. "mommy aesthetic", "MILF") does NOT fire — Familial requires a pair.
+// ============================================================================
+export const FAMILIAL: LabelRegexSpec = {
+  triggers: [
+    // Parents
+    'mother',
+    'father',
+    'mom',
+    'dad',
+    'mommy',
+    'daddy',
+    'momma',
+    'poppa',
+    'papa',
+    'parent',
+    'parents',
+    // Children
+    'son',
+    'daughter',
+    'sons',
+    'daughters',
+    'child',
+    'children',
+    'kid',
+    'kids',
+    // Siblings
+    'brother',
+    'sister',
+    'brothers',
+    'sisters',
+    'sibling',
+    'siblings',
+    'bro',
+    'sis',
+    'twin',
+    'twins',
+    // Extended
+    'aunt',
+    'uncle',
+    'cousin',
+    'cousins',
+    'niece',
+    'nephew',
+    'grandmother',
+    'grandfather',
+    'grandma',
+    'grandpa',
+    'granny',
+    'gramps',
+    'granddaughter',
+    'grandson',
+    'grandchild',
+    'grandchildren',
+    // Step-relatives
+    'stepmom',
+    'stepdad',
+    'stepson',
+    'stepdaughter',
+    'stepsister',
+    'stepbrother',
+    'step-mom',
+    'step-dad',
+    'step-son',
+    'step-daughter',
+    'step-sister',
+    'step-brother',
+    'stepmother',
+    'stepfather',
+    'step-mother',
+    'step-father',
+    'stepfamily',
+    // In-laws
+    'mother-in-law',
+    'father-in-law',
+    'sister-in-law',
+    'brother-in-law',
+    'son-in-law',
+    'daughter-in-law',
+  ],
+  pluralImpliesPair: [
+    'sisters',
+    'brothers',
+    'siblings',
+    'twins',
+    'parents',
+    'children',
+    'kids',
+    'sons',
+    'daughters',
+    'cousins',
+    'grandchildren',
+  ],
+  soloUnambiguous: [
+    // These imply a relation to another person by definition
+    'nephew',
+    'niece',
+    'stepson',
+    'stepdaughter',
+    'step-son',
+    'step-daughter',
+    'stepmom',
+    'stepdad',
+    'step-mom',
+    'step-dad',
+    'stepmother',
+    'stepfather',
+    'step-mother',
+    'step-father',
+    'stepsister',
+    'stepbrother',
+    'step-sister',
+    'step-brother',
+    'granddaughter',
+    'grandson',
+    'grandchild',
+  ],
+  possessivePronouns: ['her', 'his', 'their', 'my', 'your', 'our'],
+  pairPhraseConnectors: [
+    'and',
+    '&',
+    'with',
+    'seducing',
+    'seduced by',
+    'fucking',
+    'sucking',
+    'kissing',
+    'loving',
+    'touching',
+    'holding',
+    'hugging',
+    'on top of',
+    'beneath',
+  ],
+  carveOutPatterns: [
+    // Religious
+    'sister of the (convent|church|order|cross|sisterhood)',
+    'sisters of the (convent|church|order|cross|sisterhood)',
+    'brother(s)? of the (church|order|monastery|brotherhood)',
+    '(holy|reverend) (mother|father|sister|brother)',
+    '(mother|father) (superior|abbot|abbess)',
+    // Military / oath idioms
+    'brother(s)?[\\s-]in[\\s-]arm(s)?',
+    'sister(s)?[\\s-]in[\\s-]arm(s)?',
+    'soul sister',
+    'soul brother',
+    'sister(s)? in spirit',
+    'blood brother(s)?', // sworn-brotherhood idiom
+    // Mentor / archetype framing
+    'father figure',
+    'mother figure',
+    'big[\\s-]sister[\\s-]type',
+    'big[\\s-]brother[\\s-]type',
+    'little[\\s-]sister[\\s-]type',
+    'little[\\s-]brother[\\s-]type',
+    '(older|elder|big|little) sister archetype',
+    '(older|elder|big|little) brother archetype',
+    'motherly (smile|figure|love|warmth|hug)',
+    'fatherly (smile|figure|love|warmth|hug)',
+    '(big|little) sister(s)? energy',
+    '(big|little) brother(s)? energy',
+    // Standalone roleplay archetypes (don't imply a paired family member)
+    // Note: leaving "MILF", "DILF", "mommy", "daddy" as standalone terms in
+    // the trigger list is fine because Familial requires 2+ family terms by
+    // default. These solo-only cases will not fire unless paired.
+  ],
+  notes:
+    'Familial requires a relationship between two people. A single family-role tag (mommy, MILF) without a paired family member does not fire — the detector should require 2+ distinct family terms, OR a plural-implies-pair, OR a solo-unambiguous term (nephew etc.), OR a possessive-pair phrase ("her sister"), OR a pair-phrase ("X and Y"). The MILF/DILF case is handled by the same arithmetic: "MILF" alone is one term, not two.',
+};
+
+// ============================================================================
+// NON-CONSENT KEYWORD (atomic component)
+// Detects literal non-consent terminology. Fires REGARDLESS of sexual context
+// at the atomic level — the derivation rule (NC-keyword AND sexual) gates the
+// final NonConsent label. Mods reviewing the keyword atom may see fires in
+// non-sexual prompts too; the derived NonConsent label only fires when
+// Suggestive or Explicit also fires.
+// ============================================================================
+export const NONCONSENT_KEYWORD: LabelRegexSpec = {
+  triggers: [
+    'rape',
+    'raped',
+    'raping',
+    'rapes',
+    'rapist',
+    'noncon',
+    'noncons',
+    'molested',
+    'molesting',
+    'molestation',
+    // Incapacitation terms — the derivation rule pairs these with sexual signal,
+    // so they're safe at the atomic level. Without the AND-sexual gate they'd
+    // over-fire on "passed out drunk", "asleep on couch" etc.
+    'drugged',
+    'comatose',
+    'unconscious',
+  ],
+  phrasePatterns: [
+    'non-consensual',
+    'non consensual',
+    'forced sex',
+    'forced into sex',
+    'forced to have sex',
+    'sexual assault',
+    'sexually assaulted',
+    'assaulted sexually',
+    'sex against will',
+    'without consent',
+    'against her will',
+    'against his will',
+    'against their will',
+    // Incapacitation phrase patterns
+    'passed out',
+    'knocked out',
+    'asleep and', // "asleep and being..." — biases toward NC framing
+  ],
+  carveOutPatterns: [
+    // "forced" used in non-sexual senses
+    'forced perspective',
+    'forced into a corner',
+    'forced to smile',
+    'forced laughter',
+    'forced expression',
+    'forced into hiding',
+    'forced into battle',
+    'forced into combat',
+    'forced into action',
+    'forced march',
+    'forced entry',
+    // "drugged" in non-sexual contexts is hard to disambiguate via regex
+    // alone; rely on the AND-sexual derivation rule to filter.
+  ],
+  notes:
+    'The keyword "rape" appears in legitimate contexts too — fan-fiction warnings, news headlines, songs ("Rape Me" by Nirvana), historical references. The derived NonConsent label gates on AND-sexual to filter most. Even so, NonConsent has a contextual problem (consensual roleplay using NC words) that no purely-lexical detector can solve — pair with two-stage classification or score-tiered review for the full fix. See architecture doc.',
+};
+
+// ============================================================================
+// DIAPER / ABDL
+// Literal diaper-fetish terms.
+// ============================================================================
+export const DIAPER: LabelRegexSpec = {
+  triggers: [
+    'diaper',
+    'diapers',
+    'diapered',
+    'pamper',
+    'pampers',
+    'abdl',
+    'ddlg', // Daddy Dom / Little Girl — closely diaper-adjacent
+    'omutsu', // Japanese for diaper
+    'nappy',
+    'nappies', // British English
+  ],
+  phrasePatterns: [
+    'adult baby',
+    'padded underwear',
+    'padded pants',
+    'pull[\\s-]up(s)?', // "pull-ups" the brand; sometimes ambiguous, but in fetish prompts usually means diaper
+    'diaper change',
+    'diaper rash',
+    'diaper fetish',
+    'wet diaper',
+    'soggy diaper',
+    'soiled diaper',
+    'messy diaper',
+    'dirty diaper',
+    'crinkly diaper',
+    'thick diaper',
+  ],
+  carveOutPatterns: [
+    // "pampered" alone (luxury / spoiled context)
+    'pampered (life|lifestyle|princess|royalty|guest)',
+    'pampering (massage|spa|treatment)',
+    // Pull-ups can mean exercise
+    'pull[\\s-]up(s)? exercise',
+    'pull[\\s-]ups? workout',
+    // Nappy used to describe hair texture (not a fetish term in that context)
+    'nappy hair',
+  ],
+  notes:
+    'Diaper is a tight, closed-vocabulary fetish label. The LLM was firing on youth-coded prompts ("loli, baby") that have no actual diaper content. A pure literal-term match should eliminate that class of FP.',
+};
+
+// ============================================================================
+// MENSTRUATION
+// Literal period / menstrual-blood terms.
+// ============================================================================
+export const MENSTRUATION: LabelRegexSpec = {
+  triggers: ['menstruation', 'menstrual', 'menstruating', 'menses', 'tampon', 'tampons', 'maxipad'],
+  phrasePatterns: [
+    'period blood',
+    'period stain',
+    'period sex',
+    'menstrual blood',
+    'menstrual cycle', // ambiguous but rare outside of biology context
+    'on (her|my|their) period',
+    'first period',
+    'bloody pad',
+    'sanitary pad',
+    'menstrual pad',
+    'menstrual fluid',
+  ],
+  carveOutPatterns: [
+    // "Period" used as a time word (very common in non-menstruation contexts)
+    'period (drama|piece|costume|setting|piece|clothing|attire|outfit|movie|film)',
+    'time period',
+    'period of time',
+    '(victorian|edwardian|elizabethan|roman|medieval|renaissance|baroque|gothic) period',
+    '(jurassic|cretaceous|triassic) period',
+    'historical period',
+    'long period',
+    'short period',
+    'school period',
+    'lunch period',
+    'grace period',
+    'pay period',
+    'punctuation period',
+    'cooling period',
+    'rest period',
+    'waiting period',
+    'transition period',
+  ],
+  notes:
+    '"Period" is the trickiest term — it has many non-menstrual uses. Note that this label triggers on `tampon`/`menstrual` etc. so the bare word `period` is not even in the trigger list; only specific menstrual phrases (period blood, on her period) are. The carve-outs above defend against false matches if `period` is later added as a trigger.',
+};
+
+// ============================================================================
+// SCAT
+// Literal scat/feces fetish content.
+// ============================================================================
+export const SCAT: LabelRegexSpec = {
+  triggers: [
+    'scat',
+    'feces',
+    'fecal',
+    'poop',
+    'pooping',
+    'pooped',
+    'coprophilia',
+    'coprophagia',
+    'coprophilic',
+  ],
+  phrasePatterns: [
+    'scat play',
+    'scat fetish',
+    'scat porn',
+    'human waste',
+    'human feces',
+    'eating shit',
+    'shit eating',
+    'shitty diaper', // overlap with diaper but stronger scat signal
+    'shitting (on|in|herself|himself)',
+  ],
+  carveOutPatterns: [
+    // "Scat" is also a music style and a vocal technique
+    'scat (singer|singing|music|jazz|solo|vocals|vocalist|melody|improvisation)',
+    'jazz scat',
+    'vocal scat',
+    'scat[\\s-]style',
+    // "Shit" as slang is extremely common; deliberately NOT in triggers to avoid
+    // the flood of slang FPs. Specific phrasePatterns above catch fetish usage.
+    // "poop deck" (nautical)
+    'poop deck',
+  ],
+  notes:
+    'The bare word "shit" is intentionally NOT a trigger because it appears constantly as slang. Fetish usage requires multi-word context ("eating shit", "scat play") which is captured in phrasePatterns. The "scat" music carve-out is significant — jazz/vocal context is a frequent FP source.',
+};
+
+// ============================================================================
+// URINE
+// Urine / urination / piss-play fetish content.
+// ============================================================================
+export const URINE: LabelRegexSpec = {
+  triggers: [
+    'urine',
+    'urinating',
+    'urination',
+    'piss',
+    'pissing',
+    'omorashi', // anime term for desperate-to-urinate
+  ],
+  phrasePatterns: [
+    'piss play',
+    'urine play',
+    'golden shower',
+    'watersports (fetish|sex)', // disambiguate from kayaking etc
+    'desperate to (pee|urinate)',
+    'wetting (herself|himself|themselves|pants)',
+    'pee (play|fetish)',
+    'pissed (on|over|in)', // covers "pissed on her", "pissed in the bottle"
+    // Pee alone is too generic — but pee in fetish context is specific
+    'pee (porn|drinking|kink)',
+    'piss drinking',
+    'piss bottle',
+  ],
+  carveOutPatterns: [
+    // "Pissed" as British/American slang for angry
+    'pissed off',
+    'pissed at',
+    'pissed (about|because|when|that)',
+    'so pissed',
+    // Watersports as an actual sport
+    '(kayaking|surfing|paddleboarding|sailing|swimming) watersports',
+    'watersports (championship|tournament|competition|olympics)',
+    // "Pee" can be a name or initial
+    'cee pee',
+    'jay pee',
+    'em pee',
+  ],
+  notes:
+    '"Piss" / "pissed" is one of the most ambiguous terms — both fetish AND British slang for anger. The trigger keeps the bare term but the carve-outs strip the most common slang patterns first. "Pee" alone is too generic; only context phrasePatterns (piss play, pee drinking) fire.',
+};
+
+// ============================================================================
+// BESTIALITY
+// Sexual content between a real (non-anthropomorphic) animal and a human.
+// Closed core list with extensive carve-outs for anthro/furry/Pokemon/sex-position-name false positives.
+// ============================================================================
+export const BESTIALITY: LabelRegexSpec = {
+  triggers: [
+    'bestiality',
+    'beastiality',
+    'bestial',
+    'beastial',
+    'zoophilia',
+    'zoophile',
+    'zoophilic',
+  ],
+  phrasePatterns: [
+    'animal sex',
+    'sex with (a |an |the )?(dog|horse|cat|wolf|donkey|cow|bull|pig|goat|sheep|cattle|stallion|mare|stag)',
+    '(dog|horse|cat|wolf|donkey|cow|bull|pig|goat|sheep|stallion|mare) (mating|breeding) with (a |the )?(woman|man|human|girl|boy)',
+    '(woman|man|girl|boy|human) (mating|breeding) with (a |an |the )?(dog|horse|cat|wolf|donkey|cow|bull|pig|goat|sheep|stallion|mare)',
+    'human and (a |an |the )?(real|live) (dog|horse|cat|wolf|donkey|cow|bull|pig|goat|sheep) (sex|fucking|mating|breeding)',
+  ],
+  carveOutPatterns: [
+    // Anthropomorphic / furry — these are NOT real animals
+    'anthro(\\w+)?',
+    'anthropomorphic',
+    'furry',
+    'kemono',
+    'kemonomimi',
+    '(dog|cat|wolf|fox|bunny|rabbit|mouse|horse|dragon|sergal) girl',
+    '(dog|cat|wolf|fox|bunny|rabbit|mouse|horse|dragon|sergal) boy',
+    'monster girl',
+    'monster boy',
+    'slime girl',
+    'demi-human',
+    'demihuman',
+    'centaur(ess)?',
+    'lamia',
+    'naga',
+    'harpy',
+    'mermaid',
+    'merman',
+    'merfolk',
+    // Animal-feature tags on otherwise-human characters
+    '(dog|cat|wolf|fox|rabbit|horse) ears',
+    '(dog|cat|wolf|fox|rabbit) tail',
+    'animal ears',
+    'fur(ry)? body',
+    'fluffy tail',
+    // Pokemon franchise names — fictional creatures, not real animals
+    'pokemon',
+    'pikachu',
+    'charizard',
+    'eevee',
+    'sylveon',
+    'lopunny',
+    'cinderace',
+    'lucario',
+    'gardevoir',
+    'mewtwo',
+    'mew\\b',
+    'snorlax',
+    'rapidash',
+    'ponyta',
+    'zoroark',
+    'meowth',
+    'persian',
+    'arcanine',
+    'growlithe',
+    'vaporeon',
+    'jolteon',
+    'flareon',
+    'espeon',
+    'umbreon',
+    'leafeon',
+    'glaceon',
+    'steenee',
+    // Other fictional anthro franchises
+    'digimon',
+    'my little pony',
+    'mlp\\b',
+    'sonic the hedgehog',
+    'sonic\\b',
+    'zootopia',
+    'kemono friends',
+    'helluva boss',
+    'hazbin hotel',
+    'beastars',
+    // Sex position names that contain animal words — HUMAN positions, not bestiality
+    'doggystyle',
+    'doggy style',
+    'doggy-style',
+    'cowgirl',
+    'reverse cowgirl',
+    'missionary',
+    'pony[\\s-]?play', // BDSM pony-play is human roleplay, not bestiality
+    // "Animal" used in non-sexual scene context
+    '(stuffed|plush|toy) (dog|cat|horse|wolf|rabbit)',
+    '(dog|cat|horse|wolf|rabbit) (toy|plush|stuffed)',
+    '(painting|portrait|photo) of (a |the )?(dog|cat|horse|wolf|rabbit)',
+  ],
+  notes:
+    'Bestiality is the trickiest closed-vocabulary label because the literal terms (bestiality, zoophilia) are rare; the harder cases require detecting "real animal + human + sexual" together. The phrasePatterns try to catch explicit pair phrases; the long carve-out list defends against the largest classes of FPs (anthro/furry/Pokemon/sex-position-names). Even with these, this label is borderline — if FP rate stays high in production telemetry, consider keeping a thin LLM second-pass for cases that match the broad phrase patterns but might be carved-out anthro content.',
+};
+
+// ============================================================================
+// Index — single export for consumers
+// ============================================================================
+export const SCANNER_LABEL_REGEX: Record<string, LabelRegexSpec> = {
+  familial: FAMILIAL,
+  'nonconsent-keyword': NONCONSENT_KEYWORD,
+  diaper: DIAPER,
+  menstruation: MENSTRUATION,
+  scat: SCAT,
+  urine: URINE,
+  bestiality: BESTIALITY,
+};
+
+// ============================================================================
+// Detector — runs a single label's regex spec against a prompt string and
+// returns whether it matched and (for debugging) why.
+//
+// Algorithm:
+//   1. Normalize the text (lowercase, strip weight syntax, collapse whitespace).
+//   2. Strip carve-out patterns from the normalized text so trigger matching
+//      doesn't see false-positive contexts.
+//   3. Check phrasePatterns first (multi-word patterns are more specific
+//      than bare words — "forced sex" should match before "forced" elsewhere).
+//   4. For labels that have structured pair-detection fields
+//      (pluralImpliesPair / soloUnambiguous / possessivePronouns /
+//      pairPhraseConnectors): apply Familial-style pair logic — fire when
+//      the text contains a clear two-person relation, not just a single
+//      family-role word.
+//   5. For simple labels: fire on any whole-word trigger match.
+//
+// Returns a structured result with the reason a label fired (or didn't) so
+// the consumer can surface the match for moderator review and debugging.
+// ============================================================================
+
+export interface LabelMatchResult {
+  /** The label name that was checked. */
+  label: string;
+  /** Whether the regex spec considers this label to be triggered. */
+  matched: boolean;
+  /** Why it matched (or what kind of negative result). Human-readable. */
+  reason: string;
+  /** Specific terms / phrases that matched. Empty if not matched. */
+  matchedTerms: string[];
+  /** The normalized text that was actually checked (post carve-out strip). */
+  normalizedText: string;
+}
+
+const ESCAPE_REGEX_CHARS = /[.*+?^${}()|[\]\\]/g;
+
+function escapeRegex(s: string): string {
+  return s.replace(ESCAPE_REGEX_CHARS, '\\$&');
+}
+
+/** Lowercase, strip weight syntax, flatten brackets, collapse whitespace. */
+export function normalizePromptForRegex(text: string): string {
+  if (!text) return '';
+  let s = text.toLowerCase();
+  // (term:1.4) → term — A1111-style weight syntax
+  s = s.replace(/\(([^()]+?):\s*-?\d+(?:\.\d+)?\)/g, '$1');
+  // Flatten remaining brackets/parens to spaces so weight syntax remnants
+  // don't break whole-word boundaries (e.g. "(young)" → " young ").
+  s = s.replace(/[[\](){}]+/g, ' ');
+  s = s.replace(/\s+/g, ' ');
+  return s.trim();
+}
+
+/** Build a whole-word regex for a single term. */
+function buildWholeWordPattern(term: string): RegExp {
+  return new RegExp(`(?<![a-z0-9])${escapeRegex(term)}(?![a-z0-9])`, 'i');
+}
+
+/** Build a phrase pattern that allows flexible whitespace between words. */
+function buildPhrasePattern(phraseSource: string): RegExp {
+  // The phraseSource may already contain regex meta-characters intended
+  // by the author (e.g. "non[\\s-]consensual"). We do NOT escape those —
+  // we just normalize internal whitespace to \s+ so weight syntax doesn't
+  // break us.
+  const normalized = phraseSource.replace(/\s+/g, '\\s+');
+  return new RegExp(`(?<![a-z0-9])${normalized}(?![a-z0-9])`, 'i');
+}
+
+/** Strip carve-out matches from the text so trigger matching doesn't see them. */
+function stripCarveOuts(text: string, patterns: string[] | undefined): string {
+  if (!patterns || patterns.length === 0) return text;
+  let out = text;
+  for (const pattern of patterns) {
+    const re = new RegExp(pattern, 'gi');
+    out = out.replace(re, ' ');
+  }
+  // Collapse whitespace introduced by replacements
+  return out.replace(/\s+/g, ' ').trim();
+}
+
+/** First trigger that matches the text, or null. */
+function findTriggerMatch(text: string, triggers: string[]): string | null {
+  for (const term of triggers) {
+    if (buildWholeWordPattern(term).test(text)) return term;
+  }
+  return null;
+}
+
+/** First phrase pattern that matches, or null. */
+function findPhraseMatch(text: string, phrases: string[] | undefined): string | null {
+  if (!phrases || phrases.length === 0) return null;
+  for (const phrase of phrases) {
+    if (buildPhrasePattern(phrase).test(text)) return phrase;
+  }
+  return null;
+}
+
+/**
+ * Familial-style pair detection. Returns the reason if a pair is detected,
+ * or null otherwise.
+ */
+function detectPair(
+  text: string,
+  spec: LabelRegexSpec
+): { reason: string; matched: string } | null {
+  // 1. Pair-phrase: "X CONNECTOR Y" where X and Y are both triggers
+  if (spec.pairPhraseConnectors && spec.pairPhraseConnectors.length > 0) {
+    const triggers = spec.triggers.map(escapeRegex).join('|');
+    const connectors = spec.pairPhraseConnectors.map(escapeRegex).join('|');
+    const pairRegex = new RegExp(
+      `(?<![a-z0-9])(${triggers})\\s+(${connectors})\\s+(${triggers})(?![a-z0-9])`,
+      'i'
+    );
+    const m = text.match(pairRegex);
+    if (m) return { reason: 'pair-phrase', matched: m[0] };
+  }
+
+  // 2. Plural-implies-pair: a single plural family term implies 2+ people
+  if (spec.pluralImpliesPair) {
+    for (const plural of spec.pluralImpliesPair) {
+      if (buildWholeWordPattern(plural).test(text)) {
+        return { reason: `plural-implies-pair:${plural}`, matched: plural };
+      }
+    }
+  }
+
+  // 3. Solo-unambiguous: terms like "nephew" that inherently imply a relation
+  if (spec.soloUnambiguous) {
+    for (const solo of spec.soloUnambiguous) {
+      if (buildWholeWordPattern(solo).test(text)) {
+        return { reason: `solo-unambiguous:${solo}`, matched: solo };
+      }
+    }
+  }
+
+  // 4. Possessive: "her nephew", "his sister"
+  if (spec.possessivePronouns && spec.possessivePronouns.length > 0) {
+    const pronouns = spec.possessivePronouns.map(escapeRegex).join('|');
+    const targets = spec.triggers.map(escapeRegex).join('|');
+    const possessiveRegex = new RegExp(
+      `(?<![a-z0-9])(${pronouns})\\s+(${targets})(?![a-z0-9])`,
+      'i'
+    );
+    const m = text.match(possessiveRegex);
+    if (m) return { reason: `possessive:${m[0]}`, matched: m[0] };
+  }
+
+  // 5. Two distinct triggers in the same prompt
+  const distinct = new Set<string>();
+  for (const term of spec.triggers) {
+    if (buildWholeWordPattern(term).test(text)) {
+      distinct.add(term);
+      if (distinct.size >= 2) {
+        return {
+          reason: `two-distinct:${[...distinct].join(',')}`,
+          matched: [...distinct].join('+'),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Run a single label's spec against already-normalized text. */
+function matchSpecAgainstNormalized(
+  label: string,
+  spec: LabelRegexSpec,
+  normalized: string
+): LabelMatchResult {
+  const stripped = stripCarveOuts(normalized, spec.carveOutPatterns);
+
+  // 1. Phrase patterns first (most specific)
+  const phraseMatch = findPhraseMatch(stripped, spec.phrasePatterns);
+  if (phraseMatch) {
+    return {
+      label,
+      matched: true,
+      reason: `phrase:${phraseMatch}`,
+      matchedTerms: [phraseMatch],
+      normalizedText: stripped,
+    };
+  }
+
+  // 2. Pair detection for labels with structured pair fields
+  const hasPairFields =
+    !!spec.pluralImpliesPair ||
+    !!spec.soloUnambiguous ||
+    !!spec.possessivePronouns ||
+    !!spec.pairPhraseConnectors;
+  if (hasPairFields) {
+    const pair = detectPair(stripped, spec);
+    if (pair) {
+      return {
+        label,
+        matched: true,
+        reason: pair.reason,
+        matchedTerms: [pair.matched],
+        normalizedText: stripped,
+      };
+    }
+    return {
+      label,
+      matched: false,
+      reason: 'no-pair-detected',
+      matchedTerms: [],
+      normalizedText: stripped,
+    };
+  }
+
+  // 3. Simple labels: any single trigger match fires
+  const triggerMatch = findTriggerMatch(stripped, spec.triggers);
+  if (triggerMatch) {
+    return {
+      label,
+      matched: true,
+      reason: `trigger:${triggerMatch}`,
+      matchedTerms: [triggerMatch],
+      normalizedText: stripped,
+    };
+  }
+
+  return {
+    label,
+    matched: false,
+    reason: 'no-trigger-or-phrase',
+    matchedTerms: [],
+    normalizedText: stripped,
+  };
+}
+
+/**
+ * Detect whether the given text matches multiple labels' regex specs.
+ * Normalizes the text once (lowercase + strip weight syntax) and runs the
+ * per-label carve-out + trigger / pair detection for each label against the
+ * shared normalized text.
+ *
+ * Returns results in the same order as the `labels` input. Throws on unknown
+ * labels — pass only names that exist in SCANNER_LABEL_REGEX.
+ */
+export function matchLabels(labels: string[], text: string): LabelMatchResult[] {
+  // Validate all labels up-front so callers fail fast on typos rather than
+  // partway through the loop.
+  for (const label of labels) {
+    if (!(label in SCANNER_LABEL_REGEX)) {
+      throw new Error(
+        `Unknown scanner-regex label "${label}". Known: ${Object.keys(SCANNER_LABEL_REGEX).join(
+          ', '
+        )}`
+      );
+    }
+  }
+
+  const normalized = normalizePromptForRegex(text);
+  return labels.map((label) =>
+    matchSpecAgainstNormalized(label, SCANNER_LABEL_REGEX[label], normalized)
+  );
+}
+
+/**
+ * Single-label convenience wrapper around `matchLabels`. Use `matchLabels`
+ * directly when checking multiple labels on the same text to avoid
+ * re-normalizing the prompt.
+ */
+export function matchLabel(label: string, text: string): LabelMatchResult {
+  return matchLabels([label], text)[0];
+}
+
+/**
+ * Detect against ALL labels defined in SCANNER_LABEL_REGEX. Convenience for
+ * the common "run every regex label and see what fires" use case.
+ */
+export function matchAllLabels(text: string): LabelMatchResult[] {
+  return matchLabels(Object.keys(SCANNER_LABEL_REGEX), text);
+}


### PR DESCRIPTION
Adds a regex-based atomic-label detector (familial, nonconsent-keyword, diaper, scat, urine, menstruation, bestiality) that runs alongside XGuard in shadow mode. Per-scan comparisons land in a new ClickHouse table (scanner_regex_shadow_results) for later audit. No change to the moderator queue — shadow data is sidecar only, with a 90-day TTL and English-only gating via cheap script detection.

Completes the incest derivation by adding the rule (familial ∧ (suggestive ∨ explicit)) to scanner-derived-labels. The Familial atomic label is already in the XGuard registry; this commit ensures incest rows continue to be emitted now that the standalone Incest scan has been removed.

Requires applying scanner_regex_shadow_results DDL to ClickHouse before deploy. Shadow writes are fire-and-forget — failures log to Axiom and don't block the main audit write path.