### PR TITLE
feat(app-blocks): migrate to civit.ai domain (single-level wildcard)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -327,7 +327,7 @@ export const serverSchema = z.object({
   // App Blocks W2 (apps-as-repos). Optional so envs that don't run the
   // platform layer (PR previews without apps-pipeline wiring) still boot.
   //
-  // FORGEJO_BASE_URL          public root, e.g. https://forgejo.civitaic.com
+  // FORGEJO_BASE_URL          public root, e.g. https://forgejo.civitai.com
   // FORGEJO_ADMIN_TOKEN       Forgejo personal access token (admin) — used
   //                           by civitai-web to create repos / webhooks
   // FORGEJO_WEBHOOK_SECRET    HMAC shared secret between Forgejo → webhook
@@ -341,8 +341,10 @@ export const serverSchema = z.object({
   // APPS_KUBE_NAMESPACE       civitai-apps (where apply Jobs are created
   //                           on dp-1). Defaults to civitai-apps.
   // APPS_DOMAIN               public per-app subdomain root, e.g.
-  //                           apps.civitaic.com — used to build iframe.src
-  //                           validation in the webhook
+  //                           civit.ai — used to build iframe.src
+  //                           validation in the webhook. Defaults to civit.ai
+  //                           since CF universal SSL covers *.civit.ai
+  //                           single-level wildcard for free.
   FORGEJO_BASE_URL: z.string().url().optional(),
   FORGEJO_ADMIN_TOKEN: z.string().optional(),
   FORGEJO_WEBHOOK_SECRET: z.string().optional(),
@@ -350,5 +352,5 @@ export const serverSchema = z.object({
   APPS_TEKTON_TRIGGER_URL: z.string().url().optional(),
   APPS_TEKTON_TRIGGER_SECRET: z.string().optional(),
   APPS_KUBE_NAMESPACE: z.string().default('civitai-apps'),
-  APPS_DOMAIN: z.string().default('apps.civitaic.com'),
+  APPS_DOMAIN: z.string().default('civit.ai'),
 });

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -31,7 +31,7 @@ import { trpc } from '~/utils/trpc';
  * template, attaches a push webhook, and inserts a pending app_blocks
  * row. The developer then pushes code to the repo; the next push
  * triggers a Tekton build, then an apply Job, and the app is live at
- * <slug>.apps.civitaic.com.
+ * <slug>.civit.ai.
  *
  * v0 gate: requires `isModerator`. v1 (W5 + W1) opens to external
  * developers behind the moderator-review queue.
@@ -114,7 +114,7 @@ export default function SubmitAppPage() {
               <Stack gap="md">
                 <TextInput
                   label="Slug"
-                  description="Used for the repo name, k8s resources, and the public subdomain (<slug>.apps.civitaic.com). Lowercase a-z, 0-9, hyphens. 3-40 chars."
+                  description="Used for the repo name, k8s resources, and the public subdomain (<slug>.civit.ai). Lowercase a-z, 0-9, hyphens. 3-40 chars."
                   placeholder="generate-from-model"
                   value={slug}
                   onChange={(e) => setSlug(e.currentTarget.value.toLowerCase())}
@@ -169,7 +169,7 @@ export default function SubmitAppPage() {
                   </Text>
                   <Text size="sm" mb={6}>
                     3. The first successful build deploys the static bundle at{' '}
-                    <Code>{slug ? `${slug}.apps.civitaic.com` : '<slug>.apps.civitaic.com'}</Code>.
+                    <Code>{slug ? `${slug}.civit.ai` : '<slug>.civit.ai'}</Code>.
                   </Text>
                   <Text size="sm">
                     4. Update <Code>block.manifest.json</Code> in the new repo to install the
@@ -244,7 +244,7 @@ function SuccessCard({ app }: { app: SubmittedApp }) {
           <Text size="sm" fw={600}>
             Public URL (live after first successful build)
           </Text>
-          <Code block>{`https://${app.slug}.apps.civitaic.com/`}</Code>
+          <Code block>{`https://${app.slug}.civit.ai/`}</Code>
         </Stack>
         <Stack gap={4}>
           <Text size="sm" fw={600}>

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -187,7 +187,7 @@ export async function triggerApply(args: TriggerApplyArgs): Promise<{ name: stri
           containers: [
             {
               name: 'apply',
-              image: 'bitnami/kubectl:1.34',
+              image: 'alpine/k8s:1.34.0',
               imagePullPolicy: 'IfNotPresent',
               env: [
                 { name: 'SLUG', value: args.slug },

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -194,6 +194,7 @@ export async function triggerApply(args: TriggerApplyArgs): Promise<{ name: stri
                 { name: 'SHA', value: args.sha },
                 { name: 'IMAGE', value: args.imageRef },
                 { name: 'APP_BLOCK_ID', value: args.appBlockId },
+                { name: 'APPS_DOMAIN', value: env.APPS_DOMAIN },
               ],
               securityContext: {
                 allowPrivilegeEscalation: false,
@@ -215,6 +216,7 @@ export async function triggerApply(args: TriggerApplyArgs): Promise<{ name: stri
                   '      -e "s|\\${SHA}|${SHA}|g" \\',
                   '      -e "s|\\${IMAGE}|${IMAGE}|g" \\',
                   '      -e "s|\\${APP_BLOCK_ID}|${APP_BLOCK_ID}|g" \\',
+                  '      -e "s|\\${APPS_DOMAIN}|${APPS_DOMAIN}|g" \\',
                   '      /templates/app.yaml.tmpl > /tmp/rendered.yaml',
                   'fi',
                   'cat /tmp/rendered.yaml',

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -13,7 +13,7 @@
  * tightens to per-user OAuth tokens.
  *
  * Network shape: civitai-web → forgejo-http.forgejo.svc.cluster.local:3000
- * inside the cluster, or → https://forgejo.civitaic.com from a PR-preview
+ * inside the cluster, or → https://forgejo.civitai.com from a PR-preview
  * env that doesn't have direct cluster DNS. FORGEJO_BASE_URL handles both.
  */
 


### PR DESCRIPTION
## Summary
Switch App Blocks per-app subdomain from \`<slug>.apps.civitaic.com\` (two levels) to \`<slug>.civit.ai\` (single level). CF Universal SSL only covers single-level wildcards for free — two-level needs paid Advanced Certs at ~\$10/mo each.

Paired changes in datapacket-talos:
- ExternalDNS \`--domain-filter\` adds civit.ai (token rotated to one with both zones); commit pending
- \`civitai-apps/templates/app-templates-cm.yaml\` switches Host + dnsNames to \`\${SLUG}.\${APPS_DOMAIN}\`
- \`claudedocs/app-blocks-w2-tekton-pipeline.yaml\` parameterizes \`apps-domain\` + \`forgejo-base-url\` (defaults civit.ai + forgejo.civitai.com)
- Forgejo IngressRoute migration to \`forgejo.civitai.com\` with GitHub-org oauth2-auth gate (path-conditional so Tekton git clone bypasses)

## Test plan
- [ ] CI green
- [ ] After merge, civitai-pr-2319 rebuilds with APPS_DOMAIN default = civit.ai
- [ ] Update Forgejo \`civitai-apps/generate-from-model/block.manifest.json\` iframe.src to \`https://generate-from-model.civit.ai/\` (one-time content fix in repo)
- [ ] Push to generate-from-model → manifest validator accepts, Tekton build fires, apply Job creates IngressRoute/Cert/Service for \`generate-from-model.civit.ai\`
- [ ] ExternalDNS programs CF A record for the new host within ~2min
- [ ] cert-manager HTTP-01 issues LE cert
- [ ] \`curl https://generate-from-model.civit.ai/\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)