### PR TITLE
perf(search-index): bump users sync from every 10min to every 15min

### DIFF
--- a/src/server/jobs/search-index-sync.ts
+++ b/src/server/jobs/search-index-sync.ts
@@ -19,7 +19,7 @@ type SearchIndexSetKey = keyof typeof searchIndexSets;
 
 const cronTimeMap: Record<SearchIndexSetKey, string> = {
   models: '*/15 * * * *',
-  users: '*/10 * * * *',
+  users: '*/15 * * * *',
   articles: '*/5 * * * *',
   images: '5 8 * * *',
   collections: '*/10 * * * *',


### PR DESCRIPTION
## Summary
Change \`cronTimeMap.users\` from \`*/10 * * * *\` to \`*/15 * * * *\`.

## Why
\`users_v3\` batches are taking ~69s each on the production Meilisearch. With \`*/10\` that's only ~9 min of headroom per cycle, which shrinks further whenever disk contention pushes a single batch over 60s. Snapshot from the live task queue (1h sample):

| index | tasks last 1h | sample batch duration |
|---|---|---|
| \`models_v9\` (\`*/15\`) | 113 succeeded | ~23 s |
| **\`users_v3\` (\`*/10\`)** | **12 succeeded** | **~69 s** |
| \`articles_v5\` (\`*/5\`) | 12 succeeded | ~5 s |
| \`bounties_v3\` (\`*/5\`) | 7 succeeded | ~1.5 s |
| \`collections_v3\` (\`*/10\`) | 6 succeeded | ~1.5 s |

\`models\` was the same shape before #2298 bumped it to \`*/15\` — backlog growing because each batch was longer than the cron interval. This applies the same pattern to \`users\`.

## Operational context
NVMe \`io_weight\` on \`talos-uvh-ow7\` is currently 400-800, down from 1500-2000+ pre-fix (PRs #2290, #2298, #2291 in sequence) but still well above the cluster's critical alert threshold of 10. This is incremental — it won't close that gap on its own.

## Trade-off
Newly created users / username + profile edits take up to 15 min instead of 10 min to surface in users search. In family with \`collections\` (still \`*/10\`, likely a candidate for the same change later).

## Test plan
- [ ] Post-deploy: verify \`users_v3\` task enqueued/succeeded counts drop from ~12/h to ~4/h.
- [ ] Confirm \`talos-uvh-ow7\` \`node_disk_io_time_weighted_seconds_total\` rate drops outside the new sync windows.
- [ ] Sanity-check: a newly created username should show up in \`/users\` search within 15 min.

## Next lever (out of scope)
\`READ_BATCH_SIZE = 15000\` in \`users.search-index.ts\` is where most of the 69s wall time lives. Smaller batches would also help but it's a more invasive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)