### PR TITLE
feat(blocks): auto-add per-app host to OauthClient.allowedOrigins on submitApp

### DIFF
--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -266,7 +266,7 @@ export const blocksRouter = router({
 
       const oauthClient = await dbRead.oauthClient.findUnique({
         where: { id: input.oauthClientId },
-        select: { id: true, name: true },
+        select: { id: true, name: true, allowedOrigins: true },
       });
       if (!oauthClient) throw throwNotFoundError('OauthClient not found');
 
@@ -313,7 +313,20 @@ export const blocksRouter = router({
         secret: env.FORGEJO_WEBHOOK_SECRET,
       });
 
-      // 4. Insert pending app_blocks row. apb_ prefix matches the existing
+      // 4. Add the per-app host to OauthClient.allowedOrigins so the
+      // git-push handler's iframe.src check accepts the manifest. Without
+      // this, the first push would 400 with "iframe.src rejected: origin
+      // ... not in OauthClient.allowedOrigins" and require a manual UPDATE.
+      const newOrigin = `https://${input.slug}.${env.APPS_DOMAIN}`;
+      const currentOrigins = oauthClient.allowedOrigins ?? [];
+      if (!currentOrigins.includes(newOrigin)) {
+        await dbWrite.oauthClient.update({
+          where: { id: oauthClient.id },
+          data: { allowedOrigins: [...currentOrigins, newOrigin] },
+        });
+      }
+
+      // 5. Insert pending app_blocks row. apb_ prefix matches the existing
       // hackathon row (apb_01KSD3NP23CQE4TMW14XTEFSNS) — keep that
       // convention here even though the v1 developer-endpoint uses ab_.
       const id = `apb_${newUlid()}`;


### PR DESCRIPTION
## Summary
Before this change, every new app block submission required a manual SQL step (`UPDATE \"OauthClient\" SET \"allowedOrigins\" = array_append(\"allowedOrigins\", 'https://<slug>.<APPS_DOMAIN>')`) before the Forgejo push pipeline would succeed. Without it, `git-push.ts`'s validator returned 400 with `iframe.src rejected: origin ... not in OauthClient.allowedOrigins`.

Bit twice during the W12 cutover (hackathon block had the OauthClient row but the origin was the old `*.apps.civitaic.com`; manual UPDATE both times).

## Change
`blocks.submitApp` now:
- Reads `allowedOrigins` on the OauthClient.
- Computes `https://${slug}.${APPS_DOMAIN}` (no trailing slash, matching how `git-push.ts` compares).
- Appends it via `dbWrite.oauthClient.update` if not already present.

Idempotent on resubmit (no-op if already there). Skipped on the existing-block CONFLICT path.

## Test plan
- [ ] Submit a new app via `/apps/submit` → row appears in `OauthClient.allowedOrigins`.
- [ ] First Forgejo push to the new repo succeeds without manual SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)