### PR TITLE
feat(telemetry): instrument BitDex + Flipt + Meili child spans inside getAllImagesIndex

### DIFF
--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -1,4 +1,4 @@
-import { withSpan } from '~/server/utils/otel-helpers';
+import { withSpan, safeUrl } from '~/server/utils/otel-helpers';
 
 export type Value = { Integer: number } | { Bool: boolean } | { String: string };
 
@@ -58,11 +58,12 @@ export async function queryBitdex(
     console.log('[BitDex] query:', JSON.stringify(body));
     const start = Date.now();
     const url = `${BITDEX_URL}/api/indexes/${indexName}/query`;
+    const urlAttr = safeUrl(url);
     const res = await withSpan(
       'bitdex:http:fetch',
       {
         'http.method': 'POST',
-        'http.url': url,
+        'http.url': urlAttr,
         'bitdex.namespace': indexName,
       },
       () =>
@@ -82,7 +83,7 @@ export async function queryBitdex(
     const result = await withSpan(
       'bitdex:http:parse',
       {
-        'http.url': url,
+        'http.url': urlAttr,
         'http.status_code': res.status,
         'bitdex.namespace': indexName,
       },

--- a/src/server/bitdex/client.ts
+++ b/src/server/bitdex/client.ts
@@ -1,3 +1,5 @@
+import { withSpan } from '~/server/utils/otel-helpers';
+
 export type Value = { Integer: number } | { Bool: boolean } | { String: string };
 
 export type FilterClause =
@@ -55,19 +57,37 @@ export async function queryBitdex(
 
     console.log('[BitDex] query:', JSON.stringify(body));
     const start = Date.now();
-    const res = await fetch(`${BITDEX_URL}/api/indexes/${indexName}/query`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
+    const url = `${BITDEX_URL}/api/indexes/${indexName}/query`;
+    const res = await withSpan(
+      'bitdex:http:fetch',
+      {
+        'http.method': 'POST',
+        'http.url': url,
+        'bitdex.namespace': indexName,
+      },
+      () =>
+        fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        })
+    );
     clearTimeout(timeout);
     if (!res.ok) {
       const errText = await res.text().catch(() => '');
       console.error(`[BitDex] Query failed ${res.status} (${Date.now() - start}ms): ${errText.slice(0, 500)}`);
       return null;
     }
-    const result = await res.json();
+    const result = await withSpan(
+      'bitdex:http:parse',
+      {
+        'http.url': url,
+        'http.status_code': res.status,
+        'bitdex.namespace': indexName,
+      },
+      () => res.json()
+    );
     console.log('[BitDex] result:', JSON.stringify({
       ms: Date.now() - start,
       matched: result.total_matched,

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -5,7 +5,7 @@ import { env } from '~/env/server';
 import { createLogger } from '~/utils/logging';
 import { sleep } from '~/server/utils/errorHandling';
 import type { JobContext } from '~/server/jobs/job';
-import { withSpan } from '~/server/utils/otel-helpers';
+import { withSpan, safeUrl } from '~/server/utils/otel-helpers';
 
 const log = createLogger('search', 'green');
 
@@ -71,11 +71,12 @@ export async function fetchDocumentsAbortable<T>(
 ): Promise<ResourceResults<T[]>> {
   const { host, apiKey, signal, actor } = options;
   const url = `${host}/indexes/${indexName}/documents/fetch`;
+  const urlAttr = safeUrl(url);
   const res = await withSpan(
     'image:meili:http',
     {
       'http.method': 'POST',
-      'http.url': url,
+      'http.url': urlAttr,
       'image.meili.index': indexName,
     },
     () =>
@@ -97,7 +98,7 @@ export async function fetchDocumentsAbortable<T>(
   return withSpan(
     'image:meili:parse',
     {
-      'http.url': url,
+      'http.url': urlAttr,
       'http.status_code': res.status,
       'image.meili.index': indexName,
     },

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -5,6 +5,7 @@ import { env } from '~/env/server';
 import { createLogger } from '~/utils/logging';
 import { sleep } from '~/server/utils/errorHandling';
 import type { JobContext } from '~/server/jobs/job';
+import { withSpan } from '~/server/utils/otel-helpers';
 
 const log = createLogger('search', 'green');
 
@@ -69,21 +70,39 @@ export async function fetchDocumentsAbortable<T>(
   options: { host: string; apiKey?: string; signal?: AbortSignal; actor?: string }
 ): Promise<ResourceResults<T[]>> {
   const { host, apiKey, signal, actor } = options;
-  const res = await fetch(`${host}/indexes/${indexName}/documents/fetch`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
-      ...(actor ? { [SEARCH_ACTOR_HEADER]: actor } : {}),
+  const url = `${host}/indexes/${indexName}/documents/fetch`;
+  const res = await withSpan(
+    'image:meili:http',
+    {
+      'http.method': 'POST',
+      'http.url': url,
+      'image.meili.index': indexName,
     },
-    body: JSON.stringify(params),
-    signal,
-  });
+    () =>
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+          ...(actor ? { [SEARCH_ACTOR_HEADER]: actor } : {}),
+        },
+        body: JSON.stringify(params),
+        signal,
+      })
+  );
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Meilisearch fetch failed (${res.status}): ${text}`);
   }
-  return (await res.json()) as ResourceResults<T[]>;
+  return withSpan(
+    'image:meili:parse',
+    {
+      'http.url': url,
+      'http.status_code': res.status,
+      'image.meili.index': indexName,
+    },
+    async () => (await res.json()) as ResourceResults<T[]>
+  );
 }
 
 const RETRY_LIMIT = 5;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -41,7 +41,7 @@ import {
 } from '~/server/games/daily-challenge/daily-challenge.utils';
 import { poolCounters } from '~/server/games/new-order/utils';
 import { logToAxiom, safeError } from '~/server/logging/client';
-import { withSpan } from '~/server/utils/otel-helpers';
+import { withSpan, withDetachedSpan } from '~/server/utils/otel-helpers';
 import {
   SEARCH_ACTOR_HEADER,
   fetchDocumentsAbortable,
@@ -2565,9 +2565,15 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
 
   // Shadow mode: run the same fetchBitdexPrimary path (cacheable filters + second pass)
   // that primary uses, compare results against Meili, but serve Meili results.
+  //
+  // The shadow span is detached (its own root with a Link back to the user-request
+  // trace) because shadow work intentionally outlives the user-facing return.
+  // Keeping it as an active child of image:getAllImagesIndex:search would produce
+  // a child span whose end-time is past its parent's, which confuses parent-
+  // duration interpretation in trace UIs.
   if (bitdexMode === 'shadow') {
     const meiliElapsed = Date.now() - meiliStart;
-    withSpan('image:bitdex:shadow', { 'bitdex.mode': 'shadow' }, () =>
+    void withDetachedSpan('image:bitdex:shadow', { 'bitdex.mode': 'shadow' }, () =>
       fetchBitdexPrimary(input)
         .then((bitdexResult) => {
           if (bitdexResult) {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2488,8 +2488,14 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
 
 export async function getImagesFromSearch(input: ImageSearchInput) {
   let searchFn = getImagesFromSearchPreFilter;
-  const fliptClient = await FliptSingleton.getInstance();
-  if (fliptClient) {
+  // Wrap Flipt feature-flag evaluation so the trace shows whether per-request
+  // flag fetch is contributing to the parent span's latency. Includes the
+  // FliptSingleton.getInstance() handshake plus the three evaluateBoolean
+  // calls (FEED_POST_FILTER, MEILI_CACHE_OPS, MEILI_USER_OWN_PASS).
+  input = await withSpan('image:flipt:eval', async () => {
+    const fliptClient = await FliptSingleton.getInstance();
+    if (!fliptClient) return input;
+
     const flag = fliptClient.evaluateBoolean({
       flagKey: FLIPT_FEATURE_FLAGS.FEED_POST_FILTER,
       entityId: input.currentUserId?.toString() || 'anonymous',
@@ -2508,19 +2514,19 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
       entityId: input.currentUserId?.toString() || 'anonymous',
       context: {},
     });
-    input = {
+    return {
       ...input,
       meiliCacheOps: cacheOpsFlag.enabled,
       meiliUserOwnPass: userOwnPassFlag.enabled,
     };
-  }
+  });
 
   // Check BitDex mode (off / shadow / primary)
   // Use buildFliptContext (same as comics) so both 'moderators' (isModerator=true)
   // and 'testers' (userId in list) segments match correctly.
   // Reuse the controller's pre-evaluated value when present (it queries the same
   // flag with the same entityId+context) to avoid a duplicate Flipt round-trip.
-  const bitdexMode =
+  const bitdexMode = await withSpan('image:flipt:bitdexMode', async () =>
     input.bitdexMode !== undefined
       ? input.bitdexMode
       : await getFliptVariant(
@@ -2531,7 +2537,8 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
               ? ({ id: input.currentUserId, isModerator: input.isModerator } as SessionUser)
               : undefined
           )
-        );
+        )
+  );
   console.log('[BitDex] flipt mode:', JSON.stringify(bitdexMode), 'user:', input.currentUserId);
 
   // Primary mode: bypass Meili entirely, query BitDex directly with full docs.
@@ -2539,7 +2546,11 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
   // Post-filter re-adds the user's own private/blocked/poi/unpublished content.
   if (bitdexMode === 'primary') {
     try {
-      const result = await fetchBitdexPrimary(input);
+      const result = await withSpan(
+        'image:bitdex:primary',
+        { 'bitdex.mode': 'primary' },
+        () => fetchBitdexPrimary(input)
+      );
       if (result) return { ...result, source: 'bitdex' as const };
       console.log('[BitDex] PRIMARY returned no results, falling through to Meili');
     } catch (err) {
@@ -2556,31 +2567,33 @@ export async function getImagesFromSearch(input: ImageSearchInput) {
   // that primary uses, compare results against Meili, but serve Meili results.
   if (bitdexMode === 'shadow') {
     const meiliElapsed = Date.now() - meiliStart;
-    fetchBitdexPrimary(input)
-      .then((bitdexResult) => {
-        if (bitdexResult) {
-          compareBitdexResults({
-            bitdexIds: bitdexResult.data.map((d) => d.id),
-            meiliIds: result.data.map((i: { id: number }) => i.id),
-            bitdexTotalMatched: bitdexResult.data.length,
-            meiliTotalMatched: result.data.length,
-            bitdexElapsedMs: 0, // timing not available from fetchBitdexPrimary
-            meiliElapsedMs: meiliElapsed,
-            sort: input.sort ?? 'Newest',
-            hasPeriod: !!input.period,
-            hasFilters: !!(
-              input.tags?.length ||
-              input.types?.length ||
-              input.userId ||
-              input.withMeta ||
-              input.fromPlatform ||
-              input.baseModels?.length ||
-              input.postId
-            ),
-          });
-        }
-      })
-      .catch((err) => recordBitdexError(err));
+    withSpan('image:bitdex:shadow', { 'bitdex.mode': 'shadow' }, () =>
+      fetchBitdexPrimary(input)
+        .then((bitdexResult) => {
+          if (bitdexResult) {
+            compareBitdexResults({
+              bitdexIds: bitdexResult.data.map((d) => d.id),
+              meiliIds: result.data.map((i: { id: number }) => i.id),
+              bitdexTotalMatched: bitdexResult.data.length,
+              meiliTotalMatched: result.data.length,
+              bitdexElapsedMs: 0, // timing not available from fetchBitdexPrimary
+              meiliElapsedMs: meiliElapsed,
+              sort: input.sort ?? 'Newest',
+              hasPeriod: !!input.period,
+              hasFilters: !!(
+                input.tags?.length ||
+                input.types?.length ||
+                input.userId ||
+                input.withMeta ||
+                input.fromPlatform ||
+                input.baseModels?.length ||
+                input.postId
+              ),
+            });
+          }
+        })
+        .catch((err) => recordBitdexError(err))
+    );
   }
 
   return { ...result, source: 'meili' as const };

--- a/src/server/utils/otel-helpers.ts
+++ b/src/server/utils/otel-helpers.ts
@@ -1,4 +1,4 @@
-import { trace, SpanStatusCode } from '@opentelemetry/api';
+import { trace, context, ROOT_CONTEXT, SpanStatusCode } from '@opentelemetry/api';
 
 const tracer = trace.getTracer('civitai-app');
 
@@ -38,4 +38,54 @@ export function withSpan<T>(
       throw e;
     }
   });
+}
+
+// Variant of withSpan for work that outlives the current active span — e.g.
+// fire-and-forget shadow comparators that intentionally continue running after
+// the user-facing request has returned. Starts a new root span (no parent) with
+// a Link back to the current active span so trace search can still correlate
+// them. Without this, the shadow span would close after its parent, producing
+// child end-times past parent end-times in trace UIs.
+export function withDetachedSpan<T>(
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const parentSpanContext = trace.getActiveSpan()?.spanContext();
+  const span = tracer.startSpan(
+    name,
+    {
+      attributes: attrs,
+      links: parentSpanContext ? [{ context: parentSpanContext }] : [],
+    },
+    ROOT_CONTEXT
+  );
+  return context.with(trace.setSpan(ROOT_CONTEXT, span), async () => {
+    try {
+      const result = await fn();
+      span.end();
+      return result;
+    } catch (e) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.recordException(e as Error);
+      span.end();
+      throw e;
+    }
+  });
+}
+
+// Strip credentials and query string from a URL before stamping it as an
+// `http.url` span attribute. Trace storage is shared and not credential-aware;
+// don't ship anything in URL components that you wouldn't want in a dashboard.
+// Returns the original string verbatim if URL parsing fails (no surprises).
+export function safeUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    u.username = '';
+    u.password = '';
+    u.search = '';
+    return u.toString();
+  } catch {
+    return raw;
+  }
 }


### PR DESCRIPTION
## Why

The cascade investigation in `datapacket-talos/claudedocs/api-primary-cascade-handoff-2026-05-26.md` pinned a **30-second blackbox** inside the `image:getAllImagesIndex:search` span. A representative slow trace showed only Redis-HGETALL (~2ms), Axiom POSTs (~60ms / ~175ms), and superjson serialize (~0ms) as children — meaning ~29.7s of work happens inside code paths that were never wrapped in `withSpan`.

P99 numbers from 2026-05-28 15:50 UTC:
- `POST /api/trpc/orchestrator.imageUpload`: **29.2s**
- `GET /api/trpc/image.getImagesAsPostsInfinite`: **17.7s**
- `GET /api/v1/models`: **8.2s**

Without child spans we can't tell whether the long-tail latency lives in HTTP wait to feeds-proxy/BitDex, in response parsing, in Flipt eval, or in JS hydration. This PR closes that diagnostic gap.

## What changed

Always-on `withSpan` wrappers added around the previously uninstrumented code paths inside `getImagesFromSearch` (`src/server/services/image.service.ts`) and `queryBitdex` (`src/server/bitdex/client.ts`), plus a split of the existing Meili fetch into HTTP vs parse children inside `fetchDocumentsAbortable` (`src/server/meilisearch/client.ts`):

| Span name | Wraps | Attributes |
|---|---|---|
| `image:flipt:eval` | `FliptSingleton.getInstance()` + 3 `evaluateBoolean` calls (FEED_POST_FILTER, MEILI_CACHE_OPS, MEILI_USER_OWN_PASS) | — |
| `image:flipt:bitdexMode` | `getFliptVariant(BITDEX_IMAGE_SEARCH, ...)` lookup | — |
| `image:bitdex:primary` | `fetchBitdexPrimary(input)` on the primary branch | `bitdex.mode=primary` |
| `image:bitdex:shadow` | `fetchBitdexPrimary(input)` on the shadow (fire-and-forget) branch | `bitdex.mode=shadow` |
| `bitdex:http:fetch` | underlying `fetch()` inside `queryBitdex` | `http.method`, `http.url`, `bitdex.namespace` |
| `bitdex:http:parse` | `res.json()` inside `queryBitdex` | `http.url`, `http.status_code`, `bitdex.namespace` |
| `image:meili:http` | `fetch()` inside `fetchDocumentsAbortable` | `http.method`, `http.url`, `image.meili.index` |
| `image:meili:parse` | `res.json()` inside `fetchDocumentsAbortable` | `http.url`, `http.status_code`, `image.meili.index` |

The existing `image:meili:getDocuments` span continues to wrap the outer SDK call. Its abortable branch now emits the new `image:meili:http` + `image:meili:parse` children; the `meilisearch-js` SDK branch remains a single span since the SDK doesn't expose hooks for the split.

OTel semantic conventions used where they exist (`http.method`, `http.url`, `http.status_code`); other attributes are namespaced under `bitdex.*` or `image.meili.*`.

## Out of scope

- The `parallelFetch` sequential-`await` perf bug at `image.service.ts:2104-2106` — the in-code comment already flags it as a follow-up; this PR is observability-only.
- Splitting the SDK (non-abortable) Meili path into http+parse. Would require either a SDK upgrade with hooks or replacing the SDK path entirely with `fetchDocumentsAbortable` everywhere. Punted to keep this PR small.
- Internals of `getImagesFromSearchPreFilter` / `getImagesFromSearchPostFilter` (lines ~2913, ~3815) — out of scope per the session spec.
- No feature flags, no retry tuning, no caches added.
- No refactors. The existing `console.log('[BitDex] flipt mode:', ...)` line is preserved (it's referenced by cascade-investigation greps).

## Verification

1. After Tekton build → Flux image automation → Flagger canary completes, query Tempo for a slow trace of `GET /api/trpc/image.getImagesAsPostsInfinite` (current P99 baseline 17.7s) — confirm new child spans appear under `image:getAllImagesIndex:search`.
2. Pull a fast trace too — confirm new spans appear on healthy traces (not just slow/failure ones).
3. Diagnostic outcomes:
   - Time concentrated in `image:bitdex:primary` → next debug target is BitDex backend.
   - Time concentrated in `image:meili:http` → next debug target is feeds-proxy (Cloudflare Worker) or upstream MeiliSearch.
   - Time concentrated in `image:meili:parse` or `image:getAllImagesIndex:transform` → CPU work in our Node process.
   - Time concentrated in `image:flipt:eval` → unexpected per-request Flipt overhead.

## Risk

Minimal. `withSpan` overhead is a single `tracer.startActiveSpan` call plus an attribute setter — submillisecond and already in use across many existing spans. No runtime behavior changes; the closures preserve the original control flow (Flipt eval still optional, BitDex shadow path still fire-and-forget, fall-through-to-Meili on BitDex primary error still intact). TypeScript typecheck on the three changed files passes with zero new errors (pre-existing repo errors are unrelated to this PR).

## Reference

- Cascade investigation handoff: `claudedocs/api-primary-cascade-handoff-2026-05-26.md` (datapacket-talos)
- `withSpan` helper: `src/server/utils/otel-helpers.ts`