### PR TITLE
fix: fallback to Tool Name when Engine alias check fails

### DIFF
--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -995,6 +995,9 @@ export const addPostImage = async ({
   const { name: sourceName, homepage: sourceHomepage } = meta?.external?.source ?? {};
   if (meta && 'engine' in meta) {
     toolId = (await getToolByAlias(meta.engine as string))?.id;
+    if (!toolId) {
+      toolId = (await getToolByName(meta.engine as string))?.id;
+    }
   } else if (sourceName || sourceHomepage) {
     if (sourceName) {
       toolId = (await getToolByName(sourceName))?.id;


### PR DESCRIPTION
When parsing image metadata during upload, the backend assigns a `Tool` by checking if `meta.engine` matches a Tool's `alias`.

However, if a Tool (e.g. ComfyUI) does not have an alias configured in the database, the match fails and `toolId` remains undefined. Crucially, because this logic is contained in an `if` statement with an `else if`, a failed alias check currently causes the ingestion flow to **skip the Tool Name fallback check entirely**.

This PR fixes this oversight by adding a simple fallback to `getToolByName()` directly underneath the alias check. This guarantees that tools without database aliases can still automatically map successfully when their proper name is supplied in the EXIF engine tag.