### PR TITLE
perf(search-index): make users sync hourly and offset from models

### DIFF
--- a/src/server/jobs/search-index-sync.ts
+++ b/src/server/jobs/search-index-sync.ts
@@ -19,7 +19,11 @@ type SearchIndexSetKey = keyof typeof searchIndexSets;
 
 const cronTimeMap: Record<SearchIndexSetKey, string> = {
   models: '*/15 * * * *',
-  users: '*/15 * * * *',
+  // Hourly at :07. Username/profile search freshness budget is large
+  // (typeahead tolerates an hour of staleness fine), and offsetting from
+  // models's `*/15` (:00/:15/:30/:45) avoids both jobs firing on the same
+  // minute and contending for the Meilisearch write lock.
+  users: '7 * * * *',
   articles: '*/5 * * * *',
   images: '5 8 * * *',
   collections: '*/10 * * * *',


### PR DESCRIPTION
## Summary
- \`cronTimeMap.users\`: \`*/15 * * * *\` → \`7 * * * *\` (hourly at :07)
- Frequency drops 4×: every 15 min → every 60 min
- Offset to :07 so it never collides with models's \`*/15\` fires (:00, :15, :30, :45)

## Why this PR exists
After PR #2341 bumped users to \`*/15\` (matching models), both pools started firing on the same minute every cycle. Within 24h, models batch durations regressed from ~23s to **~101s** while task count was unchanged — strongly suggesting write-lock contention against Meilisearch.

Live task-queue snapshot (1h sample, 2026-05-29):

| index | tasks last 1h | sample batch duration | trend |
|---|---|---|---|
| \`users_v3\` | 12 ✅ | **27 s** (was 69 s pre-#2341) | improved |
| **\`models_v9\`** | 137 ✅ | **101 s** (was 23 s the day before) | **regressed ⚠️** |

## Why hourly is safe
Users search is typeahead / profile lookup. The freshness budget is:
- New user signed up → searchable within an hour ✅
- Username changed → search reflects within an hour ✅
- Profile picture / cosmetic updated → reflects within an hour ✅

Hourly is in family with other "low-urgency" search-index syncs (the daily images sync is */day for the same reason).

## Why :07 specifically
| minute | colliding jobs |
|---|---|
| :00 | models (\`*/15\`), articles (\`*/5\`), bounties/comics (\`*/5\`), collections (\`*/10\`), imageMetrics (\`*/1\`) |
| :07 | imageMetrics (\`*/1\`) only |

\`:07\` lands on a "cold" minute relative to the heavyweight indexers. \`imageMetrics\` is a tiny per-minute job that's harmless to share.

## Trade-off
None of consequence. Newly-signed-up users take up to 60 min instead of 15 min to appear in /users search. Affects no critical product flow.

## Test plan
- [ ] Post-deploy: verify \`users_v3\` tasks in the Meili \`/tasks\` queue drop to 1-4/h.
- [ ] **Watch for models batch duration recovery**: expect sample-dur back to ~23s within a day.
- [ ] Confirm \`talos-uvh-ow7\` \`node_disk_io_time_weighted_seconds_total\` rate continues its downward trend (currently ~420-470 baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)