### PR TITLE
fix: allow DoRA resources for Anima base model

### DIFF
--- a/src/shared/constants/base-model.constants.ts
+++ b/src/shared/constants/base-model.constants.ts
@@ -682,6 +682,19 @@ const baseModelGenerationConfig: BaseModelGenerationConfig[] = [
     ],
   },
   {
+    group: 'Anima',
+    support: [
+      {
+        modelTypes: [
+          ModelType.Checkpoint,
+          ModelType.LORA,
+          ModelType.DoRA,
+        ],
+        baseModels: ['Anima'],
+      },
+    ],
+  },
+  {
     group: 'Chroma',
     support: [
       {

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -882,8 +882,8 @@ export const ecosystemSupport: EcosystemSupport[] = [
   // HappyHorse - checkpoint only
   { ecosystemId: ECO.HappyHorse, supportType: 'generation', modelTypes: checkpointOnly },
 
-  // Anima - checkpoint, LORA generation, LORA training
-  { ecosystemId: ECO.Anima, supportType: 'generation', modelTypes: checkpointAndLora },
+  // Anima - checkpoint, LORA and DoRA generation, LORA training
+  { ecosystemId: ECO.Anima, supportType: 'generation', modelTypes: [ModelType.Checkpoint, ModelType.LORA, ModelType.DoRA] },
   { ecosystemId: ECO.Anima, supportType: 'training', modelTypes: loraOnly },
 
   // PonyV7 - checkpoint and LORA (based on AuraFlow)


### PR DESCRIPTION
Fixes #2342

This PR adds `ModelType.DoRA` to the generation support configuration for the `Anima` base model. This allows users to correctly select DoRA models as resources when uploading Anima-generated images.