### PR TITLE
fix(api): populate image feed stats from metrics cache

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2653,6 +2653,8 @@ export async function getImagesFromFeedSearch(
 
     const feedResult = await feed.populatedQuery(feedInput as FeedQueryInput<ImageQueryInput>);
 
+    const imageMetrics = await getImageMetricsObject(feedResult.items);
+
     // Transform PopulatedImage to match getAllImagesIndex return type
     // Remove extra fields that PopulatedImage has but getAllImagesIndex doesn't
     const transformedItems: ImagesInfiniteModel[] = feedResult.items.map((img) => {
@@ -2706,6 +2708,7 @@ export async function getImagesFromFeedSearch(
       }));
 
       // Return structure matching getAllImagesIndex
+      const match = imageMetrics[img.id];
       return {
         ...rest,
         nsfwLevel: img.nsfwLevel as NsfwLevel,
@@ -2713,6 +2716,19 @@ export async function getImagesFromFeedSearch(
         availability: img.availability ?? Availability.Public,
         reactions: transformedReactions,
         tags: transformedTags,
+        stats: {
+          likeCountAllTime: match?.reactionLike ?? 0,
+          laughCountAllTime: match?.reactionLaugh ?? 0,
+          heartCountAllTime: match?.reactionHeart ?? 0,
+          cryCountAllTime: match?.reactionCry ?? 0,
+
+          commentCountAllTime: match?.comment ?? 0,
+          collectedCountAllTime: match?.collection ?? 0,
+          tippedAmountCountAllTime: match?.buzz ?? 0,
+
+          dislikeCountAllTime: 0,
+          viewCountAllTime: 0,
+        },
       };
     });
 


### PR DESCRIPTION
The public API for images was returning 0 for all statistics because the new event-engine-common feed framework (`getImagesFromFeedSearch`) was not fetching the detailed metrics from the Clickhouse/Redis cache. This updates the feed transformation layer to correctly fetch and format the stats object exactly like `getAllImagesIndex` does.

Fixes #2066
Fixes #1925