### PR TITLE
Fix A1111 metadata encoding for multibyte characters

### DIFF
--- a/src/utils/encoding-helpers.ts
+++ b/src/utils/encoding-helpers.ts
@@ -47,19 +47,6 @@ import { isDefined } from '~/utils/type-guards';
 //   return result;
 // }
 
-export function decodeUTF32LE(buffer: Uint8Array): string {
-  let result = '';
-  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-
-  for (let i = 0; i + 3 < buffer.byteLength; i += 4) {
-    const codePoint = view.getUint32(i, true); // little-endian
-    if (codePoint === 0) continue; // skip nulls/padding
-    result += String.fromCodePoint(codePoint);
-  }
-
-  return result;
-}
-
 export function decodeUserComment(buffer: Uint8Array): string {
   if (buffer.length < 8) return '';
 
@@ -69,8 +56,8 @@ export function decodeUserComment(buffer: Uint8Array): string {
   if (header.startsWith('ASCII')) return new TextDecoder('ascii').decode(content);
   if (header.startsWith('UTF8')) return new TextDecoder('utf-8').decode(content);
 
-  // For UNICODE header (old and new images), decode as UTF-32LE
-  return decodeUTF32LE(content);
+  // For UNICODE header (old and new images), decode as UTF-16LE
+  return new TextDecoder('utf-16le').decode(content).replace(/\0/g, '');
 }
 
 const prefix = [0x55, 0x4e, 0x49, 0x43, 0x4f, 0x44, 0x45, 0x00]; // UNICODE\0

--- a/src/utils/metadata/index.ts
+++ b/src/utils/metadata/index.ts
@@ -28,7 +28,7 @@ export async function ExifParser(file: File | string) {
 
   if (exif.UserComment) {
     // @ts-ignore - this is a hack to not have to rework our downstream code
-    exif.userComment = Int32Array.from(exif.UserComment);
+    exif.userComment = Uint8Array.from(exif.UserComment);
   }
 
   // Clone exif before each canParse to prevent cross-parser mutation


### PR DESCRIPTION
Resolves #1913

### Description
This fixes an issue where Chinese characters and other multibyte unicode characters embedded in A1111-compatible image metadata were mangled during parsing.

#### What Happened?
The root cause was how the `UserComment` tag from image Exif data was being processed. `exifreader` returned the raw `UserComment` (which holds the A1111 generation parameters) as an array of bytes. However, there was a workaround in `src/utils/metadata/index.ts` that cast this array to an `Int32Array`. 

This caused each 8-bit byte to be artificially padded out to 32 bits. Consequently, when the data was decoded in `src/utils/encoding-helpers.ts`, it was read in using `DataView` as 32-bit little-endian integers (`decodeUTF32LE`). This function basically just stripped zero bytes, which accidentally made the code perfectly decode ASCII characters encoded in `UTF-16LE` (where every other byte is a `0`). However, for actual multibyte characters like Chinese (e.g. `你好`), both bytes are non-zero, resulting in completely unrelated single-byte characters.

#### The Fix
1. **Removed the `Int32Array` hack**: Replaced it with `Uint8Array.from()`, preserving the original raw byte layout of the Exif tag data.
2. **Fixed Decoding**: Removed the faulty `decodeUTF32LE` function completely. Now, when the `UNICODE\0` header is detected, we properly parse the subsequent bytes using native `new TextDecoder('utf-16le')`.

#### Downstream Impacts
A previous comment on the `Int32Array` workaround mentioned not wanting to "rework our downstream code". However, a full repository trace confirmed this old cast was actually *breaking* downstream checks silently.

The downstream systems (the drawing and canvas image generation tools) use a helper function `isEncoded()` to check if they can just pass the original byte array back into the EXIF of the saved canvas image:
```typescript
export function isEncoded(value: any) {
  return value instanceof Uint8Array || value instanceof Uint32Array;
}
```

Because the old hack was improperly using `Int32Array`, `isEncoded` actually returned `false` every time. The downstream code would silently drop the original A1111 EXIF buffer and completely regenerate the parameters from scratch using the platform's own encoder. 

Now that we pass a correct `Uint8Array`, `isEncoded` will successfully validate the buffer, and the original A1111 byte-for-byte metadata will be safely preserved and written to the newly generated/edited canvas images without any loss of data.
