### PR TITLE
fix(comments): hidden comments modal pagination for models

### DIFF
--- a/src/components/CommentsV2/HiddenCommentsModal.tsx
+++ b/src/components/CommentsV2/HiddenCommentsModal.tsx
@@ -1,12 +1,13 @@
 import { Button, Center, Loader, Modal, Stack, Text } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { Comment } from '~/components/CommentsV2/Comment/Comment';
 import { RootThreadProvider } from '~/components/CommentsV2/CommentsProvider';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
-
-import { ModelDiscussionV2 } from '~/components/Model/ModelDiscussion/ModelDiscussionV2';
+import { CommentDiscussionItem } from '~/components/Model/ModelDiscussion/CommentDiscussionItem';
+import { ReviewSort } from '~/server/common/enums';
+import { trpc } from '~/utils/trpc';
 
 type CommentEntityType =
   | 'model'
@@ -44,12 +45,54 @@ export default function HiddenCommentsModal({
           environment. Moderated for respectful and relevant discussions.
         </AlertWithIcon>
         {entityType === 'model' ? (
-          <ModelDiscussionV2 modelId={entityId} onlyHidden />
+          <HiddenModelCommentsContent modelId={entityId} />
         ) : (
           <HiddenCommentsContent entityType={entityType} entityId={entityId} userId={userId} />
         )}
       </Stack>
     </Modal>
+  );
+}
+
+function HiddenModelCommentsContent({ modelId }: { modelId: number }) {
+  const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
+    trpc.comment.getAll.useInfiniteQuery(
+      { modelId, limit: 20, sort: ReviewSort.Newest, hidden: true },
+      { getNextPageParam: (lastPage) => lastPage.nextCursor, keepPreviousData: false }
+    );
+
+  const comments = useMemo(() => data?.pages.flatMap((x) => x.comments) ?? [], [data?.pages]);
+
+  if (isLoading) {
+    return (
+      <Center mt="xl">
+        <Loader type="bars" />
+      </Center>
+    );
+  }
+
+  if (!comments.length) {
+    return <Text>No hidden comments</Text>;
+  }
+
+  return (
+    <Stack>
+      {comments.map((comment) => (
+        <CommentDiscussionItem key={comment.id} data={comment} />
+      ))}
+      {hasNextPage && (
+        <Center>
+          <Button
+            onClick={() => fetchNextPage()}
+            loading={isFetchingNextPage}
+            variant="subtle"
+            size="md"
+          >
+            Load More Comments
+          </Button>
+        </Center>
+      )}
+    </Stack>
   );
 }
 


### PR DESCRIPTION
## Summary
- Hidden comments modal for models stopped rendering new pages past the initial batch.
- Root cause: `ModelDiscussionV2` renders `MasonryGrid2`, which relies on window scroll (`useScroller(offset)` + `useWindowSize` + window-positioned `containerRef`). Inside a Mantine `Modal`, the scroll happens on the modal body, so `scrollTop` stays at 0 and masonic never positions/renders items beyond the initial viewport — even though `comment.getAll` keeps returning valid `nextCursor` pages.
- Fix: render hidden model comments as a plain `<Stack>` of `<CommentDiscussionItem>` with a manual Load More button (matches the existing non-model branch). No masonry inside the modal.

Scope is intentionally limited to the modal — `ModelDiscussionV2` on the actual model page is untouched and still uses masonry there (window scroll context is valid).

ClickUp: https://app.clickup.com/t/868jup35t

## Test plan
- [x] Open a model with many hidden comments (e.g. https://civitai.com/models/897413/big-love).
- [x] Click "See N more hidden comments" to open the modal.
- [x] Verify first page of hidden comments renders.
- [x] Click "Load More Comments" repeatedly and confirm new comments append each time (no blank space).
- [x] Verify non-model entity types (post, article, image, bounty, etc.) still show their hidden-comments modal unchanged.
- [x] Verify the main model discussion page layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)