### PR TITLE
fix(meili): wrap user-search Meili call under withMeili()

### DIFF
--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
 import { uniq } from 'lodash-es';
 import dayjs from '~/shared/utils/dayjs';
 import { CacheTTL, constants, USERS_SEARCH_INDEX } from '~/server/common/constants';
@@ -15,7 +16,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { logToAxiom } from '~/server/logging/client';
-import { searchClient } from '~/server/meilisearch/client';
+import { MeiliCallTimeoutError, searchClient, withMeili } from '~/server/meilisearch/client';
 import { dbReadFallbackCounter, userUpdateCounter } from '~/server/prom/client';
 import {
   articleMetrics,
@@ -251,11 +252,35 @@ export async function getUsersWithSearch({
   if (ids?.length) filters.push(`id IN [${ids.join(',')}]`);
   if (!!excludedUserIds?.length) filters.push(`id NOT IN [${excludedUserIds.join(',')}]`);
 
-  const results = await searchClient.index(USERS_SEARCH_INDEX).search<UserSearchResult>(query, {
-    limit: Math.round(limit * 1.5),
-    filter: filters.join(' AND '),
-    attributesToRetrieve: ['id', 'username', 'deletedAt', 'profilePicture', 'image'],
-  });
+  let results;
+  try {
+    // Narrow withMeili wrap to the SDK call only — this is a user-facing tRPC
+    // path (user.getAll). Under Meilisearch brownout an unwrapped .search() can
+    // hang ~30s, the same failure mode that bled api-primary to kubelet SIGKILL
+    // on 2026-05-29. Follow-up to PR #2351, which wrapped the image-feed call
+    // sites but missed this one.
+    results = await withMeili('search', () =>
+      searchClient!.index(USERS_SEARCH_INDEX).search<UserSearchResult>(query, {
+        limit: Math.round(limit * 1.5),
+        filter: filters.join(' AND '),
+        attributesToRetrieve: ['id', 'username', 'deletedAt', 'profilePicture', 'image'],
+      })
+    );
+  } catch (err) {
+    // Mirror image.getInfinite's handling: surface a fast 408 via TRPCError
+    // TIMEOUT so the client can retry instead of waiting on Traefik's 30s
+    // router timeout. tRPC v10 has no SERVICE_UNAVAILABLE / 503 code; TIMEOUT
+    // is the closest semantic match.
+    if (err instanceof MeiliCallTimeoutError) {
+      throw new TRPCError({
+        code: 'TIMEOUT',
+        message: 'User search is temporarily overloaded — please retry.',
+        cause: err,
+      });
+    }
+    throw err;
+  }
+
   return results.hits
     .filter((x) => !x.deletedAt)
     .map(({ deletedAt, profilePicture, image, ...user }) => ({


### PR DESCRIPTION
## Trigger

Residual coverage gap from the 2026-05-29 api-primary SIGKILL cascade that PR #2351 mitigated.

PR #2351 added the `withMeili(backend, fn)` SDK wrapper (2.5s per-call timeout + per-backend concurrency cap) and wrapped the three hottest image-feed call sites plus the `searchMetrics` health probe. A follow-up review surfaced one more user-facing unwrapped call site:

- `src/server/services/user.service.ts:255` — `searchClient.index(USERS_SEARCH_INDEX).search<UserSearchResult>(query, { ... })`

This is the `getUsersWithSearch` path behind the tRPC `user.getAll` handler (used by the username autocomplete / user search UI). Under Meilisearch brownout the bare SDK call can hang up to ~30s — the same failure mode that bled api-primary pods to kubelet SIGKILL on 2026-05-29.

## Fix

Wrap the single SDK call under `withMeili('search', ...)` and translate the typed `MeiliCallTimeoutError` into a `TRPCError({ code: 'TIMEOUT' })`. Pattern is byte-for-byte the same as `image.service.ts` — `getAllImagesIndex` catches `MeiliCallTimeoutError` from `getImagesFromSearch` and surfaces 408. No surrounding DB / Redis / cache code is wrapped — scope rules from PR #2351 respected (SDK call only).

| File | Change |
|---|---|
| `src/server/services/user.service.ts` | Wrap `searchClient.index(USERS_SEARCH_INDEX).search(...)` under `withMeili('search', ...)`; catch `MeiliCallTimeoutError` → `TRPCError code:'TIMEOUT'`; add `TRPCError` + `withMeili` + `MeiliCallTimeoutError` imports. |

Chose `TRPCError TIMEOUT` over graceful empty-array degrade because:
- `getUsersWithSearch` is called from `getAllUsersHandler` (a tRPC controller — `src/server/controllers/user.controller.ts:155`), wired into `userRouter.getAll` (`src/server/routers/user.router.ts:128-129`).
- `image.service.ts` uses the exact same pattern on the same tRPC class of path (`image.getInfinite` → `TRPCError TIMEOUT`). Consistency over creativity for a hot-fix.
- 408 lets the client UI distinguish "search is overloaded, retry" from "no users matched" — a silent empty-array would conflate the two.

## Risk

**Very low.**

- One additional unwrapped Meili SDK call site moves into the same wrapper / counter / histogram path PR #2351 introduced — no new behavior surface.
- Reuses the `'search'` backend limiter that already governs `feedsSearchClient` / `searchClient` calls; concurrency budget unchanged.
- Failure mode changes from "30s implicit hang → 504 from Traefik" to "explicit 408 from app within ~2.5s" — strictly better for the user and for the event loop.
- No DB / Redis / cache path is wrapped; the surrounding `filter` array build and the post-fetch `.filter(...).map(...).slice(...)` chain stay outside the limiter slot.

## Rollback

1. Tune the existing `MEILI_CALL_TIMEOUT_MS` / `MEILI_CALL_CONCURRENCY` ConfigMap entries (no deploy required) — same rollback levers as PR #2351.
2. Revert this single commit (1 file, 31 insertions / 6 deletions).

## Test plan

- [x] `pnpm typecheck` — zero new tsc errors on `user.service.ts` or `meilisearch/client.ts`; project-wide baseline preserved (5062 → 5062).
- [ ] Manual sanity: hit `user.getAll` (username autocomplete in nav / modlog UI) and confirm normal response.
- [ ] Deploy to canary; watch `civitai_app_meili_call_timeouts_total{backend="search"}` and `_duration_seconds{backend="search"}` for the new traffic shape.
- [ ] Confirm that under a forced Meili brownout, `user.getAll` returns 408 within ~2.5s instead of hanging until Traefik's 30s router timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)