### PR TITLE
fix(meili): wrap getModelsRaw search SDK call (hot-fix follow-up to #2351)

### DIFF
--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -136,6 +136,11 @@ export default MixedAuthEndpoint(async function handler(
         : undefined;
     } catch (e) {
       if (e instanceof MeiliCallTimeoutError) {
+        // Override the public cache headers set by MixedAuthEndpoint —
+        // without this Cloudflare caches the 408 and turns a transient
+        // Meili brownout into a sticky 408 wall for every other
+        // unauthenticated caller with the same query.
+        res.setHeader('Cache-Control', 'no-store');
         return res
           .status(408)
           .json({ error: 'Model search is temporarily overloaded — please retry.' });

--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -1,5 +1,6 @@
 import type { ModelHashType } from '~/shared/utils/prisma/enums';
 import { CollectionType, ModelFileVisibility, ModelModifier } from '~/shared/utils/prisma/enums';
+import type { SearchResponse } from 'meilisearch';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from 'next-auth';
 import * as z from 'zod';
@@ -23,7 +24,7 @@ import { getUserBookmarkCollections } from '~/server/services/user.service';
 import { safeDecodeURIComponent } from '~/utils/string-helpers';
 import { Flags } from '~/shared/utils/flags';
 import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
-import { searchClient } from '~/server/meilisearch/client';
+import { MeiliCallTimeoutError, searchClient, withMeili } from '~/server/meilisearch/client';
 import { isDefined } from '~/utils/type-guards';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 
@@ -107,18 +108,40 @@ export default MixedAuthEndpoint(async function handler(
   let meiliNextCursor: string | undefined;
   if (query) {
     const browsingLevelValues = Flags.instanceToArray(browsingLevel);
-    // Fetch IDs from Meilisearch
-    const meiliResult = await searchClient
-      ?.index(MODELS_SEARCH_INDEX)
-      .search<{ id: number }>(query, {
-        limit: limit ? limit + 1 : undefined,
-        filter: [
-          cursor ? `id < ${String(cursor)}` : undefined,
-          `nsfwLevel IN [${browsingLevelValues.join(',')}]`,
-        ].filter(isDefined),
-        attributesToRetrieve: ['id'],
-        sort: ['id:desc'],
-      });
+    // Fetch IDs from Meilisearch.
+    // Wrap the SDK call under withMeili('search', ...) so a backend brownout
+    // is bounded by MEILI_CALL_TIMEOUT_MS instead of bleeding the event loop
+    // until Traefik's 30s router timeout — same pattern as PR #2351 and the
+    // service-layer wrap in model.service.ts:getModelsRaw.
+    //
+    // The MeiliCallTimeoutError is caught HERE (not re-thrown as TRPCError)
+    // because handleEndpointError() does JSON.parse(apiError.message) on
+    // every TRPCError, which would crash on our plain-text timeout message.
+    // Returning res.status(408) directly avoids that landmine entirely.
+    let meiliResult: SearchResponse<{ id: number }> | undefined;
+    try {
+      const client = searchClient;
+      meiliResult = client
+        ? await withMeili('search', () =>
+            client.index(MODELS_SEARCH_INDEX).search<{ id: number }>(query, {
+              limit: limit ? limit + 1 : undefined,
+              filter: [
+                cursor ? `id < ${String(cursor)}` : undefined,
+                `nsfwLevel IN [${browsingLevelValues.join(',')}]`,
+              ].filter(isDefined),
+              attributesToRetrieve: ['id'],
+              sort: ['id:desc'],
+            })
+          )
+        : undefined;
+    } catch (e) {
+      if (e instanceof MeiliCallTimeoutError) {
+        return res
+          .status(408)
+          .json({ error: 'Model search is temporarily overloaded — please retry.' });
+      }
+      throw e;
+    }
 
     meiliNextCursor = meiliResult?.hits.pop()?.id.toString();
     searchIds = meiliResult?.hits?.map((hit: { id: number }) => hit.id) ?? [];

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -31,7 +31,7 @@ import {
 import { createProfanityFilter } from '~/libs/profanity-simple';
 import { isFlipt } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
-import { searchClient } from '~/server/meilisearch/client';
+import { MeiliCallTimeoutError, searchClient, withMeili } from '~/server/meilisearch/client';
 import { modelMetrics } from '~/server/metrics';
 import { withSpan } from '~/server/utils/otel-helpers';
 import {
@@ -304,9 +304,31 @@ export const getModelsRaw = async ({
       ].filter(isDefined),
     };
 
-    const results: SearchResponse<ModelSearchIndexRecord> = await searchClient
-      .index(MODELS_SEARCH_INDEX)
-      .search(query, request);
+    // Wrap the SDK call under withMeili('search', ...) so a backend brownout
+    // is bounded by MEILI_CALL_TIMEOUT_MS instead of bleeding the event loop
+    // until Traefik's 30s router timeout — same cascade pattern that bit
+    // image.getInfinite (PR #2351). Translate the timeout to a TRPCError
+    // TIMEOUT here (vs at each controller) so every getModelsRaw caller
+    // — models.getAll, recommenders, associated-resources, etc. — fails fast
+    // with a 408 instead of hanging on a slow Meili.
+    // searchClient was null-checked on the outer if; pin a local non-null
+    // reference so TS narrowing survives the closure boundary.
+    const client = searchClient;
+    let results: SearchResponse<ModelSearchIndexRecord>;
+    try {
+      results = await withMeili('search', () =>
+        client.index(MODELS_SEARCH_INDEX).search(query, request)
+      );
+    } catch (err) {
+      if (err instanceof MeiliCallTimeoutError) {
+        throw new TRPCError({
+          code: 'TIMEOUT',
+          message: 'Model search is temporarily overloaded — please retry.',
+          cause: err,
+        });
+      }
+      throw err;
+    }
 
     // console.log(results.hits);
     searchModelIds = results.hits.map((m) => m.id);


### PR DESCRIPTION
Hot-fix follow-up to #2351 (merged). Wraps the two remaining unwrapped Meili SDK calls reaching users (one tRPC, one REST) so a Meili backend brownout fails fast with a 408 instead of bleeding the event loop until Traefik's 30s router timeout.

## Trigger
Fresh cascade at 21:57 UTC (1,359 Meili 503s/5min) showed five tRPC paths bleeding. Audit also caught a public REST endpoint (`/api/v1/models`, used by the SD desktop client and external integrations) using the same unwrapped SDK path. Both wrapped now.

## Wrapped sites (after this PR)

| File | Line | Surface | Translation on `MeiliCallTimeoutError` |
|------|------|---------|----------------------------------------|
| `src/server/services/model.service.ts` | 307 (`getModelsRaw`) | tRPC (`models.getAll`, recommenders, associated-resources, model card data) | `TRPCError(TIMEOUT)` → handler propagates → 408 |
| `src/pages/api/v1/models/index.ts` | 111 (`MixedAuthEndpoint` handler) | REST (`/api/v1/models`, SD desktop client + external integrations) | Direct `res.status(408).json({ error: '...' })` |

The two wrap-call sites use the same narrow `withMeili('search', ...)` scope. They diverge only in how the timeout exits the request — see C2 below.

## Investigation (initial tRPC pass)

| Path | Meili involvement? | Decision |
|------|--------------------|----------|
| `image.getImagesAsPostsInfinite` | Yes — calls `getAllImagesIndex` → `getImagesFromSearch` (3 SDK call sites in `image.service.ts`). | **Already covered by #2351.** `getAllImagesIndex` already wraps `getImagesFromSearch` and catches `MeiliCallTimeoutError` → `TRPCError(TIMEOUT)` (lines 2074-2088 of `image.service.ts`). The `getImagesAsPostsInfiniteHandler` outer try/catch re-throws `TRPCError` cleanly. No change needed. |
| `user.getCreator` | No — `getUserCreator` is pure Postgres (User table + model count). | **Skip.** Error is a downstream symptom of event-loop bleed, not a Meili call. |
| `user.getSettings` | No — `getUserContentSettings` reads from `userSettingsCache` (PG-backed). | **Skip.** Not covered by #2358 either (#2358 targets `getUsersWithSearch` / `user.getAll` / `user.getCreators`, not `getSettings`/`getCreator`). |
| `recommenders.getResourceRecommendations` | Indirect — calls `getModelsRaw`, but the handler passes `modelVersionIds` not `query`, so the Meili branch (`if (query && searchClient && ...)`) never runs for this path. Other branches use pure Postgres + the HTTP recommenders caller. | **Skip the handler itself.** But while tracing it I found `getModelsRaw` does have an unwrapped Meili SDK call — see Fix (a). The 5,804 errors here are dominated by auth FORBIDDEN/UNAUTHORIZED (per your log report) — those aren't Meili. |
| `user.ingestFingerprint` | **Procedure not found in codebase.** Grepped `src/server/routers/`, `src/server/controllers/`, `src/pages/api/` — no `ingestFingerprint` procedure or REST handler exists. Likely a stale path name or analytics endpoint not in this repo. | **Skip — flag for log-trace re-verification.** |

## Fix (a) — tRPC path: `getModelsRaw`

`getModelsRaw` calls `searchClient.index(MODELS_SEARCH_INDEX).search(query, request)` when `query` is set. Until now this was an unwrapped Meili SDK call in the user-facing service tree. During a Meili brownout it bleeds the event loop on every model-search query — `models.getAll` from the search bar is the most obvious hot caller.

Wrapped under `withMeili('search', ...)` (same backend as the model search index) and translated `MeiliCallTimeoutError → TRPCError(TIMEOUT)` inside `getModelsRaw` itself so all callers — `getModelsInfiniteHandler`, `getRecommendedResourcesCardDataHandler`, `getAssociatedResourcesCardDataHandler`, `getModelsWithImagesAndModelVersions` — fail fast with a 408 instead of needing per-caller catches. All those handlers already have `if (error instanceof TRPCError) throw error` patterns, so the `TIMEOUT` propagates cleanly.

## Fix (b) — REST path: `/api/v1/models` (audit follow-up)

A separate audit on the "last user-facing site" claim above found this PR initially missed `src/pages/api/v1/models/index.ts:111`, which calls `searchClient.index(MODELS_SEARCH_INDEX).search<{ id: number }>(query, ...)` directly from the REST handler. This endpoint serves the SD desktop client and external integrations, so it's fully user-facing.

Wrapped under the same narrow `withMeili('search', ...)` scope, but the error-handling diverges:

- The handler returns `res.status(408).json({ error: 'Model search is temporarily overloaded — please retry.' })` **directly** instead of throwing a `TRPCError(TIMEOUT)`.
- **Why**: the audit identified C2 (latent landmine): `handleEndpointError()` in `src/server/utils/endpoint-helpers.ts:198` does `JSON.parse(apiError.message)` on every `TRPCError` it sees. The plain-text timeout message (`'Model search is temporarily overloaded — please retry.'`) is not valid JSON, so the REST path would crash on the `JSON.parse` and emit a 500 instead of a 408.
- C2 itself (the `JSON.parse` landmine) is **out of scope** for this PR and will be addressed separately. This PR just avoids triggering it from the wrapped code path.
- The existing try/catch in this handler only wraps `getModelsWithVersions`; the Meili call lives outside it, so the new catch is also narrow (pre-empts `handleEndpointError` only on the timeout path).

## Known shared-limiter interaction (I1)

`models.getAll` and `image.getInfinite` now both run under the `withMeili('search', ...)` limiter — a single 50-slot semaphore per pod on the `search` Meili backend. This is intentional:

- Both surfaces use the same Meili backend, so a real backend brownout *should* brown them out together — sharing the limiter is the most honest model of the underlying constraint.
- Both surfaces also share the `search` backend with `feeds-meilisearch`; under feeds-backend pressure they will both shed load together.
- Net effect: model-search and image-feed will degrade as a single surface during a Meili-side incident, which matches how the backend actually fails.

## Risk
- **Surface**: Two SDK calls, both well-isolated narrow wraps. Surrounding PG/cache/HTTP work is not accounted as Meili saturation.
- **TS narrowing fix**: `searchClient` is null-checked on outer `if`, but the wrap's closure breaks TS's narrowing. Fixed by pinning a local `const client = searchClient` reference. Behavior identical (closure captures the same non-null reference).
- **Backwards compat**: tRPC path: same shape change as #2351 (`MeiliCallTimeoutError → TRPCError(TIMEOUT)`), already aligned with client expectations. REST path: 408 with `{ error: '...' }` matches the existing 400/401/429 shapes in the same handler.

## Rollback
Revert these commits; the original code paths are restored. No data/state changes.

## Deferred — non-Meili paths still bleeding during cascade
These are surfaced for visibility but not addressed in this PR (non-Meili bleed is event-loop block, a symptom not a separate failure mode):

- **`recommenders.getResourceRecommendations` (5,804 errors/5min)** — dominated by auth FORBIDDEN/UNAUTHORIZED per the log report. Confirm by querying spanmetrics for the error category split; if a meaningful fraction are 5xx, the next dependency to investigate is `getRecommendations` (HTTP call to the recommenders service via `src/server/http/recommenders/recommenders.caller.ts`) which has no internal timeout wrap that I saw.
- **`user.ingestFingerprint` (2,125 errors/5min)** — does not exist as a tRPC procedure or REST handler in the repo on `origin/main` HEAD `77eb5fa05`. Suspect a stale log path or a procedure that lives outside this repo (analytics worker, edge function, etc). Worth re-tracing the log signature before assuming.
- **`user.getSettings` / `user.getCreator`** — pure PG/cache. Slowness here during a cascade indicates pg-pool exhaustion or event-loop block, not Meili. Probably resolves once Meili stops bleeding upstream.

## Deferred — separate PR
- **C2**: `src/server/utils/endpoint-helpers.ts:198` does `JSON.parse(apiError.message)` on every `TRPCError` that reaches `handleEndpointError`. Any REST handler that lets a `TRPCError` with a plain-text message propagate will crash on the parse. This PR routes around it for the new wrap site; a follow-up should fix `handleEndpointError` to handle non-JSON messages safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
