### PR TITLE
fix(endpoint-helpers): defensive JSON.parse for TRPCError.message

### DIFF
--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -195,9 +195,20 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
   if (e instanceof TRPCError) {
     const apiError = e as TRPCError;
     const status = getHTTPStatusCodeFromError(apiError);
-    const parsedError = JSON.parse(apiError.message);
-
-    return res.status(status).json(parsedError);
+    // Older Zod-validation TRPCErrors stuff a JSON-encoded issue array into
+    // `message`; many newer call sites (incl. `withMeili`'s
+    // MeiliCallTimeoutError → TRPCError mapping) pass a plain string. Falling
+    // through to JSON.parse on a plain string throws SyntaxError, escapes
+    // uncaught, and turns a transient 408/503 into a Next.js default 500 —
+    // the opposite of fail-fast. Try the parse, fall back to a one-shot
+    // { message } envelope on failure.
+    let body: unknown;
+    try {
+      body = JSON.parse(apiError.message);
+    } catch {
+      body = { message: apiError.message };
+    }
+    return res.status(status).json(body);
   } else {
     const error = e as Error;
     return res.status(500).json({ message: 'An unexpected error occurred', error: error.message });


### PR DESCRIPTION
## Trigger

Audit of PR #2360 (and retroactively #2351 / #2358) flagged a latent landmine in `src/server/utils/endpoint-helpers.ts:198` — `JSON.parse(apiError.message)` on every TRPCError. Plain-string messages crash `handleEndpointError`, escaping uncaught and turning a clean 408 into a default Next.js 500.

The current `withMeili` pattern surfaces plain-string `TRPCError({ code: 'TIMEOUT', message: '<English text>' })` from three merged PRs:
- #2351 `image.service.ts:2082-2087` (image-feed)
- #2358 `user.service.ts:259` (user-search)
- #2360 `model.service.ts:316` (model-search)

Today the three live wraps are reached only from tRPC callers (which never touch `handleEndpointError`), so the bug hasn't fired in prod. But the REST wrap in #2360 (`/api/v1/models:125`) chose raw `res.status(408)` specifically to avoid this code path — without this fix the pattern remains a footgun for any future REST caller of those service functions.

## Fix

Defensive parse: try, fall back to `{ message: apiError.message }` envelope on `SyntaxError`. Backwards-compatible with the existing Zod-validation TRPCError flow (which stuffs a JSON-encoded issue array into `message`).

```ts
let body: unknown;
try {
  body = JSON.parse(apiError.message);
} catch {
  body = { message: apiError.message };
}
return res.status(status).json(body);
```

## Risk

- **Response shape for plain-string TRPCErrors changes from raw JSON to `{ message: "..." }`** — this only affects code paths that previously crashed 500. No caller depends on the crashed shape.
- Zod-validation TRPCError path is unchanged (JSON.parse succeeds, parsed value returned as before).
- No throw-handler interaction (`handleEndpointError` was already inside outer try/catch wrappers in every call site).

## Rollback

Revert this commit. The landmine returns but no live path currently hits it.

## Deferred

None. This is the surgical fix for audit-flagged C2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)