### PR TITLE
perf(metrics/model): debounce search-index enqueue to 15-min cadence

### DIFF
--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -6,7 +6,7 @@ import { templateHandler } from '~/server/db/db-helpers';
 import type { MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
 import { executeRefresh } from '~/server/metrics/metric-helpers';
-import { REDIS_KEYS } from '~/server/redis/client';
+import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { modelsSearchIndex } from '~/server/search-index';
 import { bustFetchThroughCache } from '~/server/utils/cache-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
@@ -114,13 +114,70 @@ export const modelMetrics = createMetricProcessor({
 
     // Update the search index
     //---------------------------------------
-    log('update search index');
-    await modelsSearchIndex.queueUpdate(
-      [...ctx.affected].map((id) => ({
-        id,
-        action: SearchIndexUpdateQueueAction.Update,
-      }))
+    // The metric job runs every minute and `ctx.affected` is dominated
+    // by `getVersionAggregationTasks` — any model whose ModelVersionMetric
+    // updatedAt changed in the last minute (downloads / generations etc.).
+    // On production that's ~1,900 distinct model ids per minute, even though
+    // only ~35 of those reflect a user-visible mutation. The models search-
+    // index sync cron is `*/15`, so queueing every minute generates 15×
+    // more work than the consumer can drain and the backlog grows forever.
+    //
+    // Accumulate affected ids into a Redis SET (deduplicates across ticks)
+    // and only flush to the search-index queue every ~15 minutes. The
+    // service-layer queueUpdate calls in model.service / model-version.service
+    // for genuine mutations (publish, edit, tag changes, etc.) are unaffected
+    // and still hit the search-index queue immediately on the user's request.
+    if (ctx.affected.size > 0) {
+      log('accumulate search index updates', ctx.affected.size);
+      await sysRedis.sAdd(
+        REDIS_SYS_KEYS.INDEX_UPDATES.MODEL_METRIC_AFFECTED,
+        [...ctx.affected].map(String)
+      );
+    }
+
+    const FLUSH_INTERVAL_MS = 15 * 60 * 1000;
+    const lastFlushStr = await sysRedis.get(
+      REDIS_SYS_KEYS.INDEX_UPDATES.MODEL_METRIC_LAST_FLUSH
     );
+    const lastFlush = lastFlushStr ? new Date(lastFlushStr).getTime() : 0;
+    const shouldFlush = Date.now() - lastFlush >= FLUSH_INTERVAL_MS;
+
+    if (shouldFlush) {
+      const pendingRaw = await sysRedis.sMembers(
+        REDIS_SYS_KEYS.INDEX_UPDATES.MODEL_METRIC_AFFECTED
+      );
+      // Mark the flush before draining so a crash mid-flush doesn't
+      // double-queue.
+      //
+      // Trade-off: if the process dies between the SET drain and the
+      // queueUpdate call, those ids stall in the search index until a
+      // NEW mvm.updatedAt change re-touches them (the mvm cursor is
+      // independent — it advances even for runs whose flush succeeds).
+      // For cold/idle models that may be hours. Accept this because
+      // (a) crash-window is small, (b) the next genuine user mutation
+      // re-indexes via the untouched service-layer path, (c) metric-
+      // drift staleness on the search doc is by definition cosmetic.
+      await sysRedis.set(
+        REDIS_SYS_KEYS.INDEX_UPDATES.MODEL_METRIC_LAST_FLUSH,
+        new Date().toISOString()
+      );
+      if (pendingRaw.length > 0) {
+        await sysRedis.del(REDIS_SYS_KEYS.INDEX_UPDATES.MODEL_METRIC_AFFECTED);
+        log('flush search index updates', pendingRaw.length);
+        // Chunk so a runaway accumulator (e.g. a Postgres mvm backfill
+        // bumping every row's updatedAt) doesn't push a single multi-MB
+        // request into the search-index queue path.
+        const QUEUE_CHUNK_SIZE = 5000;
+        for (const slice of chunk(pendingRaw, QUEUE_CHUNK_SIZE)) {
+          await modelsSearchIndex.queueUpdate(
+            slice.map((id) => ({
+              id: Number(id),
+              action: SearchIndexUpdateQueueAction.Update,
+            }))
+          );
+        }
+      }
+    }
   },
   rank: {
     async refresh() {

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -719,6 +719,12 @@ export const REDIS_SYS_KEYS = {
   },
   INDEX_UPDATES: {
     IMAGE_METRIC: 'index-updates:image-metric',
+    // Accumulator for models-index re-index requests originating in the
+    // per-minute model-metrics job. Flushed into the search-index queue
+    // on a 15-min cadence (matches the search-index sync cron) to avoid
+    // generating ~15× more re-index work than the consumer can drain.
+    MODEL_METRIC_AFFECTED: 'index-updates:model-metric-affected',
+    MODEL_METRIC_LAST_FLUSH: 'index-updates:model-metric-last-flush',
   },
   QUEUES: {
     BUCKETS: 'queues:buckets',


### PR DESCRIPTION
## Summary
The model-metrics job (`*/1 * * * *`) was queueing **~1,900 distinct `modelId`s for search-index re-index every minute**, but the consumer cron (`*/15`) can only drain ~30 batches per cycle. Result: permanent backlog, sustained NVMe pressure on `talos-uvh-ow7`, and the models batch wall-time we've been chasing across PRs #2290/#2291/#2298/#2341/#2347 (peaks of 41-101s, growing).

This PR debounces the metric-job's enqueue path to a 15-min cadence using a Redis SET accumulator. Service-layer `queueUpdate` calls for genuine user mutations (publish, edit, tag changes) are untouched and continue to enqueue immediately.

## Root cause
`getVersionAggregationTasks` in `src/server/metrics/model.metrics.ts:630` finds every model whose `ModelVersionMetric.updatedAt > ctx.lastUpdate`. Any download or generation event bumps that timestamp. Live replica probe:

| metric | value |
|---|---|
| distinct modelIds via mvm.updatedAt (last 1 min) | **1,914** |
| distinct modelIds via ResourceReview (last 1 min) | 34 |
| rows in ModelVersionMetric updated (last 1 min) | 2,117 |
| **Model.updatedAt actual user-mutation changes (last 1 min)** | **35** |

So ~98% of the search-index re-index volume is metric drift that doesn't reflect anything a user can see on the model card.

## What this change does

1. New Redis keys under `REDIS_SYS_KEYS.INDEX_UPDATES`:
   - `MODEL_METRIC_AFFECTED` (SET of pending modelIds)
   - `MODEL_METRIC_LAST_FLUSH` (timestamp cursor)
2. Every metric tick: `SADD` affected ids → naturally dedupes across the 15-min window
3. Flush check: `now - lastFlush >= 15min` → drain SET, push to `modelsSearchIndex.queueUpdate` in chunks of 5,000 (defensive cap against backfill scenarios that touch every row)
4. Flush cursor is written **before** queue drain to avoid double-queue on crash. Trade-off: if process dies between SET drain and `queueUpdate`, those ids stall until a new `mvm.updatedAt` change re-touches the affected models — for cold/idle models that can be hours. Accepted because (a) crash window is small, (b) genuine user mutations re-index via the untouched service-layer path, (c) metric-drift staleness on the search doc is by definition cosmetic.

## What this change does NOT touch

- Service-layer `queueUpdate` calls for genuine mutations (publish, edit, tag, NSFW, cosmetic, scan webhook). Real user changes still hit the search-index queue immediately — same as today. (Visibility in the actual index is still bounded by the `*/15` consumer cron, but that's true for everything that goes through that queue.)
- The metric job's primary work (writing ModelMetric / ModelVersionMetric tables). Stats freshness on user-facing surfaces (download counts on model cards etc.) is unchanged.
- Other indexes' metric pipelines (`image.metrics.ts`, `user.metrics.ts`, etc.). Worth a follow-up audit but separate.
- `model-collection.metrics.ts:36`. Per prior investigation that source is small (`*/5` cron, gated on `ctx.affected.size > 0`). Leave alone.

## Expected effect

- **~15× cut** in models_v9 search-index queue pressure
- Models batch `sample-dur` should drop back toward ~23s (pre-collision baseline)
- `talos-uvh-ow7` `io_weight` should drop meaningfully below the current 400-500 baseline
- Sort-field staleness on `/models` is unchanged: the consumer cron is already `*/15`

## Test plan
- [ ] Post-deploy: Meilisearch `/tasks` queue for `models_v9` shows ~2-4 `documentAdditionOrUpdate` tasks per 15-min window (was 30+).
- [ ] Models batch `sample-dur` recovers toward ~23s within an hour or two.
- [ ] `talos-uvh-ow7` `node_disk_io_time_weighted_seconds_total` rate drops on the next 24h trend.
- [ ] No regression in `/models` search sort behavior (Most Downloaded / Top Liked / etc.).

## Investigation backstory
PRs in this series: #2290 (images daily) → #2291 (cleanup keyset) → #2298 (models */15) → #2341 (users */15) → #2347 (users hourly). Each cut consumer-side load. This PR finally goes after the *producer* — which is where the actual volume lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)