### PR TITLE
fix(recommenders): cheapen auth-error path

### DIFF
--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -56,6 +56,22 @@ const trpcHandler = createNextApiHandler({
   },
   onError: async ({ error, type, path, input, ctx, req }) => {
     if (isProd) {
+      // Auth-class rejections (FORBIDDEN / UNAUTHORIZED) are client-fault 4xx
+      // responses — the status code already tells the caller + edge what
+      // happened, and at scraper/bot scale these are the dominant noise in
+      // Axiom while providing zero diagnostic value. Skip the stack capture +
+      // JSON.stringify + ingest to cut event-loop pressure during the storm.
+      //
+      // Originally surfaced by recommenders.getResourceRecommendations (~5/s
+      // cluster-wide of "API key does not have the required scope"), but the
+      // gate applies uniformly to every auth-rejection path
+      // (isAcceptableOrigin, isAuthed, enforceTokenScope, isFlagProtected).
+      // Other tRPC errors (Meili timeouts, DB errors, etc.) keep full
+      // observability.
+      if (error.code === 'FORBIDDEN' || error.code === 'UNAUTHORIZED') {
+        return error;
+      }
+
       let axInput: string | undefined;
       if (!!input) {
         try {


### PR DESCRIPTION
## Trigger

`recommenders.getResourceRecommendations` was generating ~5 FORBIDDEN/s cluster-wide (1,453 in a 5-min window) plus 185 UNAUTHORIZED — bots/scrapers hitting an auth-gated endpoint. At 48 pods × N/s × (TRPCError construction + V8 stack capture + `JSON.stringify` of error+input+headers + `axiom.ingestEvents` network round-trip) per rejection, that path was measurable Node CPU work spent telling scrapers no, contributing to chronic event-loop pressure during the 2026-05-30 cascade investigation.

## Investigation

Every TRPCError funnels through the global `onError` hook in `src/pages/api/trpc/[trpc].ts`, which:
1. Builds a payload via `safeError()` — reads `e.stack` (V8 reifies)
2. `JSON.stringify`s the input
3. Awaits `axiom.ingestEvents()` (HTTP POST)

`FORBIDDEN`/`UNAUTHORIZED` are 4xx client-fault codes — the status already tells the caller and the edge what happened. No alerts or dashboards in `datapacket-talos` are keyed on the Axiom entry for this class. Pure overhead at bot scale.

## Fix

Single early-return guard at the top of the `onError` hook gating Axiom emission on `error.code !== 'FORBIDDEN' && !== 'UNAUTHORIZED'`. Catches every auth-rejection path uniformly:

- `isAcceptableOrigin` (UNAUTHORIZED — "Please use the public API instead")
- `isAuthed` (UNAUTHORIZED — logged-out)
- `enforceTokenScope` (FORBIDDEN — "API key does not have the required scope")
- `isFlagProtected` (FORBIDDEN — feature-flag denial)

Auth behaviour itself is **unchanged** — TRPCErrors are still constructed and returned to the caller. The user-facing `"Please use the public API instead: https://developer.civitai.com/"` copy in `isAcceptableOrigin` is untouched. Status codes still flow to the client and edge.

**Files**: `src/pages/api/trpc/[trpc].ts` (+16 LOC, single file)

## Risk

Low. Auth-rejection observability is removed cluster-wide (not just for recommenders), but:

- HTTP status codes remain visible in Traefik access logs
- tRPC error counters in Prometheus (path-tagged) keep firing
- Spanmetrics still observe the failing trace
- Non-auth errors (Meili timeouts, DB errors, etc.) keep full Axiom emission — gate is restricted to the two auth codes only

## Rollback

`git revert` this commit. No data migration, no config change, no schema change.

---

Follow-up to the ongoing 2026-05-30 chronic-brownout cascade investigation alongside `fix/signals-wrap`.