### PR TITLE
fix(meili+signals): swallow endTimer() exceptions in finally (EMERGENCY)

### DIFF
--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -496,7 +496,13 @@ async function runWithLimiter<T>(
       ]);
     } finally {
       if (timer) clearTimeout(timer);
-      endTimer();
+      // EMERGENCY 2026-05-30: see signals wrapper — a metric-observation
+      // error must never propagate into the app request path.
+      try {
+        endTimer();
+      } catch {
+        // intentionally swallowed
+      }
       if (key === 'search' || key === 'metricsSearch') {
         recordCallOutcome(key, isTrial, failedForCircuit);
       }

--- a/src/server/signals/wrapper.ts
+++ b/src/server/signals/wrapper.ts
@@ -317,7 +317,19 @@ export async function withSignals<T>(fn: () => Promise<T>): Promise<T> {
       ]);
     } finally {
       if (timer) clearTimeout(timer);
-      endTimer();
+      // EMERGENCY 2026-05-30: a metric-observation error MUST NOT propagate
+      // into the app request path. We observed prom-client Histogram.observe
+      // throwing `Cannot read properties of undefined (reading 'length')` at
+      // 22/s per pod on signals.getToken (PR #2366 deploy), turning every
+      // wrapped signals call into an INTERNAL_SERVER_ERROR — the exact
+      // cascade pattern the wrap was supposed to prevent. Root cause of the
+      // bad histogram state is still under investigation; this catch is the
+      // unconditional safety net so a broken observation can't kill traffic.
+      try {
+        endTimer();
+      } catch {
+        // intentionally swallowed
+      }
       recordCallOutcome(isTrial, failedForCircuit);
     }
   });


### PR DESCRIPTION
## Trigger

After PR #2366 deployed, civitai-dp-prod-api entered a chronic cascade:
- **6,551** `signals.getToken` requests in 5min returned INTERNAL_SERVER_ERROR
- Each error message: `Cannot read properties of undefined (reading 'length')`
- Stack traces pinned the throw to `prom-client@14.2.0 Histogram.observe → findBound`
- `this.upperBounds` was undefined despite the histogram being registered with a valid 17-entry buckets array

At ~22 requests/s × 49 pods, each error reified a full stack and POSTed to Axiom in the response hot path. The metric-observation bug WAS the cascade — replacing the upstream signals/Meili pressure that PR #2366 was designed to defend against.

## Fix

Wrap `endTimer()` in `try/catch` in both wrappers' `finally` blocks. A broken histogram observation is an observability bug, not a user-traffic bug.

## Risk

- Duration histogram visibility degrades until the underlying registration bug is found and this catch is narrowed
- The wrapper's other behavior (per-call timeout, concurrency cap, circuit breaker) is unaffected
- Other observability (counters: `_timeouts_total`, `_circuit_rejections_total`, `_circuit_trips_total`; gauges: `_call_active`, `_call_queue_depth`, `_circuit_state`) continues to work normally

## Rollback

Revert this commit. The cascade returns.

## Root cause TBD (deferred)

The deployed bundle DOES contain `signals_call_duration_seconds` registration with the full bucket array, but the Histogram instance returned at observe time has undefined `upperBounds`. Hypothesis: Next.js bundle-split causes two module copies to register a histogram with the same name; the surviving instance comes from a failed-registration fallback path in `registerHistogram` that returns `getSingleMetric()` without re-initializing buckets. Same pattern in `meiliCallDurationHistogram` hasn't fired in production (different bundle layout?), but the catch in `meilisearch/client.ts` is defensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)