### PR TITLE
Fix for user preferences and 'Enable mature content' spontaneously resetting

### DIFF
--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -565,6 +565,15 @@ export const updateUserById = async ({
     await deleteBasicDataForUser(id);
   }
 
+  if (
+    data.showNsfw !== undefined ||
+    data.blurNsfw !== undefined ||
+    data.browsingLevel !== undefined ||
+    data.autoplayGifs !== undefined
+  ) {
+    await userSettingsCache.bust([id]);
+  }
+
   if (data.email && user.paddleCustomerId) {
     // Update the email in Paddle
     await updatePaddleCustomerEmail({
@@ -2135,6 +2144,7 @@ export async function updateContentSettings({
       data: { blurNsfw, showNsfw, browsingLevel, autoplayGifs },
     });
     userUpdateCounter?.inc({ location: 'user.service:updateUserContentSettings' });
+    await userSettingsCache.bust([userId]);
   }
   if (Object.keys(data).length > 0 || (domain === 'red' && browsingLevel !== undefined)) {
     const settings = await getUserSettings(userId);


### PR DESCRIPTION
# Fix for "Enable Mature Content" Setting Resetting

## The Issue
Users have been frequently reporting that their settings, particularly "Enable mature content," are spontaneously resetting on the site.

When investigating this issue, I traced it down to how the backend handles updating these preferences and its caching layer:
- The user's preferences are cached in a Redis-backed `userSettingsCache` for performance.
- When toggling a setting like "Enable mature content" (which maps to `showNsfw`), the backend `updateContentSettings` mutation successfully updates the user's row in the Postgres database.
- **The Bug:** If the user _only_ updated top-level boolean toggles (like `showNsfw` or `blurNsfw`) and not deep JSON settings, the service updated the database but completely bypassed the logic that invalidates the `userSettingsCache`.

Because the cache has a 4-hour time-to-live, the server continued to return the old, stale preference values for any subsequent requests. When the user's NextAuth session refreshed in the background or they refreshed the page, the frontend's `BrowserSettingsProvider` received the stale values from the server and applied them, silently reverting their toggle back to its previous state.

## The Fixes
I added code to explicitly bust the user settings cache immediately after updating the top-level database columns in two critical locations:

### 1. `updateContentSettings`
```diff
  if (
    blurNsfw !== undefined ||
    showNsfw !== undefined ||
    // Red domain we'll store in the settings.
    (browsingLevel !== undefined && domain !== 'red') ||
    autoplayGifs !== undefined
  ) {
    await dbWrite.user.update({
      where: { id: userId },
      data: { blurNsfw, showNsfw, browsingLevel, autoplayGifs },
    });
    userUpdateCounter?.inc({ location: 'user.service:updateUserContentSettings' });
+   await userSettingsCache.bust([userId]);
  }
```

### 2. `updateUserById`
There was a second location (`updateUserById`) that is used for general user profile updates (like toggling `autoplayGifs`) and legacy `updateBrowsingMode` actions, which also failed to bust the cache. I added a safeguard there as well:
```diff
  if (data.username !== undefined || data.deletedAt !== undefined || data.image !== undefined) {
    await deleteBasicDataForUser(id);
  }

+  if (
+    data.showNsfw !== undefined ||
+    data.blurNsfw !== undefined ||
+    data.browsingLevel !== undefined ||
+    data.autoplayGifs !== undefined
+  ) {
+    await userSettingsCache.bust([id]);
+  }
```

## Validation
With these changes, any endpoint that modifies top-level user settings guarantees that the `userSettingsCache` is invalidated. 
When the client refetches its settings or the background session sync occurs, it will retrieve the fresh boolean values from the database, preventing the UI toggles from spontaneously reverting.

> [!TIP]
> The next time a user toggles "Enable mature content", the settings will permanently persist for their browsing session.
