### PR TITLE
fix(meili): also break gracefully on upstream 408/5xx, not just local timeout

### DIFF
--- a/src/server/meilisearch/__tests__/client.test.ts
+++ b/src/server/meilisearch/__tests__/client.test.ts
@@ -106,6 +106,23 @@ function makeDelayedFetch(delayMs: number, payload: unknown = { results: [] }) {
     });
 }
 
+/**
+ * Build a fetch-like function that immediately resolves with a non-ok HTTP
+ * response. fetchDocumentsAbortable's `if (!res.ok)` branch then throws a
+ * MeilisearchFetchError carrying the status + body. Used to verify that the
+ * post-filter catch shape branches correctly on 408/5xx (graceful break) vs
+ * 4xx-other (re-throw).
+ */
+function makeStatusFetch(status: number, body = '') {
+  return (_input: unknown, _init?: { signal?: AbortSignal }) =>
+    Promise.resolve({
+      ok: false,
+      status,
+      json: async () => ({}),
+      text: async () => body,
+    });
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('fetchDocumentsAbortable timeout safety net', () => {
@@ -186,7 +203,7 @@ describe('fetchDocumentsAbortable timeout safety net', () => {
     // getImagesFromSearchPostFilter catch block in image.service.ts. If
     // either side changes shape (e.g. the abort reason chain breaks) this
     // test catches it before prod sees the regression.
-    const { fetchDocumentsAbortable, FETCH_DOCUMENTS_TIMEOUT_MESSAGE, meiliFetchTimeoutTotal } =
+    const { fetchDocumentsAbortable, FETCH_DOCUMENTS_TIMEOUT_MESSAGE, meiliFetchFailfastTotal } =
       await import('~/server/meilisearch/client');
 
     global.fetch = makeDelayedFetch(5_000) as unknown as typeof fetch;
@@ -212,9 +229,10 @@ describe('fetchDocumentsAbortable timeout safety net', () => {
         err?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE ||
         (err?.name === 'AbortError' && err.cause?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE);
       if (isLocalTimeout) {
-        meiliFetchTimeoutTotal.inc({
+        meiliFetchFailfastTotal.inc({
           route: 'getImagesFromSearchPostFilter',
           iteration: String(iterationUnderTest),
+          reason: 'local-timeout',
         });
         brokeOut = true;
       } else {
@@ -226,6 +244,7 @@ describe('fetchDocumentsAbortable timeout safety net', () => {
     expect(incMock).toHaveBeenCalledWith({
       route: 'getImagesFromSearchPostFilter',
       iteration: '2',
+      reason: 'local-timeout',
     });
     expect(incMock).toHaveBeenCalledTimes(1);
   });
@@ -268,5 +287,304 @@ describe('fetchDocumentsAbortable timeout safety net', () => {
     if (err.name === 'AbortError' && err.cause?.message) {
       expect(err.cause.message).not.toBe('meili-fetch-timeout');
     }
+  });
+});
+
+// ─── Upstream-side fail-fast (PR follow-up to #2370) ────────────────────────
+//
+// The 5s local timer in #2370 caught the slow-fetch path, but post-deploy
+// telemetry showed the dominant failure mode is upstream returning 503
+// (civitai-feeds-proxy shed) or 408 (Meilisearch backend timeout). These
+// were re-throwing as bare Error from fetchDocumentsAbortable, so the
+// post-filter catch in image.service.ts didn't recognise them and the
+// 500 bubbled to clients → retry storm → cascade sustained.
+//
+// This block proves the new MeilisearchFetchError shape + the extended
+// post-filter catch handle the three upstream failure modes correctly,
+// AND that 4xx-other (e.g. 400 malformed filter) still re-throws.
+
+describe('fetchDocumentsAbortable upstream-side fail-fast', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    incMock.mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('throws MeilisearchFetchError on 503 with status + body preserved', async () => {
+    const { fetchDocumentsAbortable, MeilisearchFetchError } = await import(
+      '~/server/meilisearch/client'
+    );
+    global.fetch = makeStatusFetch(503, 'service overloaded') as unknown as typeof fetch;
+
+    let caught: unknown;
+    try {
+      await fetchDocumentsAbortable<unknown>(
+        'images',
+        { limit: 1 },
+        { host: 'http://meili-metrics.example', apiKey: 'test' }
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(MeilisearchFetchError);
+    const err = caught as InstanceType<typeof MeilisearchFetchError>;
+    expect(err.status).toBe(503);
+    expect(err.responseText).toBe('service overloaded');
+    // Message-format contract — Loki/dashboard queries depend on this prefix.
+    expect(err.message).toBe('Meilisearch fetch failed (503): service overloaded');
+  });
+
+  it('throws MeilisearchFetchError on 408 with status preserved', async () => {
+    const { fetchDocumentsAbortable, MeilisearchFetchError } = await import(
+      '~/server/meilisearch/client'
+    );
+    global.fetch = makeStatusFetch(408, '') as unknown as typeof fetch;
+
+    let caught: unknown;
+    try {
+      await fetchDocumentsAbortable<unknown>(
+        'images',
+        { limit: 1 },
+        { host: 'http://meili-metrics.example', apiKey: 'test' }
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(MeilisearchFetchError);
+    expect((caught as InstanceType<typeof MeilisearchFetchError>).status).toBe(408);
+  });
+
+  it('does NOT throw MeilisearchFetchError on a 2xx happy path', async () => {
+    const { fetchDocumentsAbortable } = await import('~/server/meilisearch/client');
+    const payload = { results: [{ id: 42 }] };
+    global.fetch = makeDelayedFetch(10, payload) as unknown as typeof fetch;
+
+    const result = await fetchDocumentsAbortable<{ id: number }>(
+      'images',
+      { limit: 1 },
+      { host: 'http://meili-metrics.example', apiKey: 'test' }
+    );
+
+    expect(result).toEqual(payload);
+  });
+
+  it('post-filter catch shape recognises 503 (upstream-overload) and breaks with the right reason label', async () => {
+    const {
+      fetchDocumentsAbortable,
+      MeilisearchFetchError,
+      isFailfastStatus,
+      failfastReasonForStatus,
+      meiliFetchFailfastTotal,
+      FETCH_DOCUMENTS_TIMEOUT_MESSAGE,
+    } = await import('~/server/meilisearch/client');
+
+    global.fetch = makeStatusFetch(503, 'service overloaded') as unknown as typeof fetch;
+
+    const iterationUnderTest = 3;
+    let brokeOut = false;
+    let reThrew = false;
+    try {
+      await fetchDocumentsAbortable<unknown>(
+        'images',
+        { limit: 100, offset: 200 },
+        { host: 'http://meili-metrics.example', apiKey: 'test' }
+      );
+    } catch (e) {
+      // Mirror the call-site catch from getImagesFromSearchPostFilter.
+      const err = e as Error & { name?: string; cause?: { message?: string } };
+      const isLocalTimeout =
+        err?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE ||
+        (err?.name === 'AbortError' && err.cause?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE);
+      if (isLocalTimeout) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: String(iterationUnderTest),
+          reason: 'local-timeout',
+        });
+        brokeOut = true;
+      } else if (e instanceof MeilisearchFetchError && isFailfastStatus(e.status)) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: String(iterationUnderTest),
+          reason: failfastReasonForStatus(e.status),
+        });
+        brokeOut = true;
+      } else {
+        reThrew = true;
+      }
+    }
+
+    expect(brokeOut).toBe(true);
+    expect(reThrew).toBe(false);
+    expect(incMock).toHaveBeenCalledWith({
+      route: 'getImagesFromSearchPostFilter',
+      iteration: '3',
+      reason: 'upstream-overload',
+    });
+    expect(incMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('post-filter catch shape recognises 408 (upstream-timeout)', async () => {
+    const {
+      fetchDocumentsAbortable,
+      MeilisearchFetchError,
+      isFailfastStatus,
+      failfastReasonForStatus,
+      meiliFetchFailfastTotal,
+      FETCH_DOCUMENTS_TIMEOUT_MESSAGE,
+    } = await import('~/server/meilisearch/client');
+
+    global.fetch = makeStatusFetch(408, '') as unknown as typeof fetch;
+
+    let brokeOut = false;
+    try {
+      await fetchDocumentsAbortable<unknown>(
+        'images',
+        { limit: 100 },
+        { host: 'http://meili-metrics.example', apiKey: 'test' }
+      );
+    } catch (e) {
+      const err = e as Error & { name?: string; cause?: { message?: string } };
+      const isLocalTimeout =
+        err?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE ||
+        (err?.name === 'AbortError' && err.cause?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE);
+      if (isLocalTimeout) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: '1',
+          reason: 'local-timeout',
+        });
+        brokeOut = true;
+      } else if (e instanceof MeilisearchFetchError && isFailfastStatus(e.status)) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: '1',
+          reason: failfastReasonForStatus(e.status),
+        });
+        brokeOut = true;
+      } else {
+        throw e;
+      }
+    }
+
+    expect(brokeOut).toBe(true);
+    expect(incMock).toHaveBeenCalledWith({
+      route: 'getImagesFromSearchPostFilter',
+      iteration: '1',
+      reason: 'upstream-timeout',
+    });
+  });
+
+  it('post-filter catch re-throws on 400 (malformed filter is a real bug, must bubble)', async () => {
+    const {
+      fetchDocumentsAbortable,
+      MeilisearchFetchError,
+      isFailfastStatus,
+      failfastReasonForStatus,
+      meiliFetchFailfastTotal,
+      FETCH_DOCUMENTS_TIMEOUT_MESSAGE,
+    } = await import('~/server/meilisearch/client');
+
+    global.fetch = makeStatusFetch(
+      400,
+      '{"message":"Invalid filter","code":"invalid_search_filter"}'
+    ) as unknown as typeof fetch;
+
+    let brokeOut = false;
+    let reThrown: unknown;
+    try {
+      await fetchDocumentsAbortable<unknown>(
+        'images',
+        { limit: 100 },
+        { host: 'http://meili-metrics.example', apiKey: 'test' }
+      );
+    } catch (e) {
+      const err = e as Error & { name?: string; cause?: { message?: string } };
+      const isLocalTimeout =
+        err?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE ||
+        (err?.name === 'AbortError' && err.cause?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE);
+      if (isLocalTimeout) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: '1',
+          reason: 'local-timeout',
+        });
+        brokeOut = true;
+      } else if (e instanceof MeilisearchFetchError && isFailfastStatus(e.status)) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: '1',
+          reason: failfastReasonForStatus(e.status),
+        });
+        brokeOut = true;
+      } else {
+        reThrown = e;
+      }
+    }
+
+    // 400 must NOT be swallowed — it indicates a real malformed-filter bug.
+    expect(brokeOut).toBe(false);
+    expect(reThrown).toBeInstanceOf(MeilisearchFetchError);
+    expect((reThrown as InstanceType<typeof MeilisearchFetchError>).status).toBe(400);
+    // The fail-fast counter MUST NOT have incremented on 4xx-other.
+    expect(incMock).not.toHaveBeenCalled();
+  });
+
+  it('post-filter catch shape recognises 502 (upstream-error — generic 5xx)', async () => {
+    const {
+      fetchDocumentsAbortable,
+      MeilisearchFetchError,
+      isFailfastStatus,
+      failfastReasonForStatus,
+      meiliFetchFailfastTotal,
+      FETCH_DOCUMENTS_TIMEOUT_MESSAGE,
+    } = await import('~/server/meilisearch/client');
+
+    global.fetch = makeStatusFetch(502, 'Bad Gateway') as unknown as typeof fetch;
+
+    let brokeOut = false;
+    try {
+      await fetchDocumentsAbortable<unknown>(
+        'images',
+        { limit: 100 },
+        { host: 'http://meili-metrics.example', apiKey: 'test' }
+      );
+    } catch (e) {
+      const err = e as Error & { name?: string; cause?: { message?: string } };
+      const isLocalTimeout =
+        err?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE ||
+        (err?.name === 'AbortError' && err.cause?.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE);
+      if (isLocalTimeout) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: '1',
+          reason: 'local-timeout',
+        });
+        brokeOut = true;
+      } else if (e instanceof MeilisearchFetchError && isFailfastStatus(e.status)) {
+        meiliFetchFailfastTotal.inc({
+          route: 'getImagesFromSearchPostFilter',
+          iteration: '1',
+          reason: failfastReasonForStatus(e.status),
+        });
+        brokeOut = true;
+      } else {
+        throw e;
+      }
+    }
+
+    expect(brokeOut).toBe(true);
+    expect(incMock).toHaveBeenCalledWith({
+      route: 'getImagesFromSearchPostFilter',
+      iteration: '1',
+      reason: 'upstream-error',
+    });
   });
 });

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -91,23 +91,105 @@ export const FETCH_DOCUMENTS_DEFAULT_TIMEOUT_MS = env.MEILI_FETCH_TIMEOUT_MS;
 export const FETCH_DOCUMENTS_TIMEOUT_MESSAGE = 'meili-fetch-timeout';
 
 /**
- * Counter incremented every time the local fetchDocumentsAbortable timer
- * fires. The `route` label identifies the caller (so we can separate the
- * pre-filter cascade from the post-filter iteration cascade); `iteration`
- * is meaningful for the post-filter loop and defaults to `"0"` everywhere
- * else.
+ * Reason label values for `meiliFetchFailfastTotal`. Each value describes a
+ * distinct backend-side failure mode that callers downstream of
+ * fetchDocumentsAbortable choose to fast-fail / break out of an iteration
+ * loop on. Kept as a const-as union so call-sites get type-checked.
+ *
+ *  - `local-timeout`     — the local 5s deadline fired before the upstream
+ *                          responded (PR #2370 — the original behaviour;
+ *                          preserved for backward-compat dashboards)
+ *  - `upstream-overload` — upstream returned HTTP 503 (civitai-feeds-proxy
+ *                          shed because MEILI_MAX_CONCURRENT was hit)
+ *  - `upstream-timeout`  — upstream returned HTTP 408 (Meilisearch backend
+ *                          page-cache thrashing past its own timeout)
+ *  - `upstream-error`    — any other 5xx (bad gateway, gateway timeout from
+ *                          Traefik to feeds-proxy, etc.)
+ */
+export type MeiliFetchFailfastReason =
+  | 'local-timeout'
+  | 'upstream-overload'
+  | 'upstream-timeout'
+  | 'upstream-error';
+
+/**
+ * Map an HTTP status returned by the upstream Meili backend (or its proxy)
+ * onto the fail-fast reason label. Callers should ONLY pass a status they
+ * already decided is "fast-fail eligible" (408 or 5xx); 4xx-other (400 bad
+ * filter, 401/403 auth) should re-throw at the call site and never reach
+ * this helper.
+ */
+export function failfastReasonForStatus(status: number): MeiliFetchFailfastReason {
+  if (status === 408) return 'upstream-timeout';
+  if (status === 503) return 'upstream-overload';
+  return 'upstream-error';
+}
+
+/**
+ * Does `status` qualify for graceful-break treatment by post-filter / future
+ * iteration-loop callers? True for 408 (upstream-side timeout) and any 5xx
+ * (upstream unavailable). False for 4xx-other (real client error — must
+ * bubble up so we don't silently hide malformed-filter / auth bugs).
+ */
+export function isFailfastStatus(status: number): boolean {
+  return status === 408 || status >= 500;
+}
+
+/**
+ * Counter incremented every time fetchDocumentsAbortable() fast-fails — i.e.
+ * the local timer fired OR the upstream returned a status code that callers
+ * treat as "backend unavailable, break gracefully". The `route` label
+ * identifies the caller (so we can separate the pre-filter cascade from the
+ * post-filter iteration cascade); `iteration` is meaningful for the
+ * post-filter loop and defaults to `"0"` everywhere else; `reason` carries
+ * the failure-mode label (see `MeiliFetchFailfastReason`).
+ *
+ * Renamed from `meili_fetch_timeout_total` (PR #2370) → `meili_fetch_failfast_total`
+ * because the counter is no longer timeout-specific: it now captures every
+ * fail-fast disposition fetchDocumentsAbortable surfaces. Dashboards keyed
+ * on the old name will go empty for a few minutes during the transition;
+ * the panel update lands in a follow-up commit in the datapacket-talos
+ * repo.
  *
  * Naming follows the prom-client wrapper's PROM_PREFIX convention — exposed
- * to Prometheus as `civitai_app_meili_fetch_timeout_total`.
+ * to Prometheus as `civitai_app_meili_fetch_failfast_total`.
  */
-export const meiliFetchTimeoutTotal = registerCounterWithLabels({
-  name: 'meili_fetch_timeout_total',
+export const meiliFetchFailfastTotal = registerCounterWithLabels({
+  name: 'meili_fetch_failfast_total',
   help:
-    'fetchDocumentsAbortable() local timer fired before the upstream Meili ' +
-    'backend responded — the defensive cap that prevents event-loop stalls ' +
-    'from cascading into kubelet SIGKILL on civitai-dp-prod-api',
-  labelNames: ['route', 'iteration'] as const,
+    'fetchDocumentsAbortable() fast-fail events (local timer fired OR ' +
+    'upstream returned 408/5xx) — the defensive cap that prevents ' +
+    'event-loop stalls from cascading into kubelet SIGKILL on ' +
+    'civitai-dp-prod-api. `reason` distinguishes the failure mode.',
+  labelNames: ['route', 'iteration', 'reason'] as const,
 });
+
+/**
+ * Typed error thrown by fetchDocumentsAbortable() when the upstream Meili
+ * backend (or the civitai-feeds-proxy in front of it) returns a non-ok HTTP
+ * status code. Carries the status + response body verbatim so callers can
+ * pattern-match on `instanceof MeilisearchFetchError` + `.status` instead of
+ * string-matching the message.
+ *
+ * The 408 (upstream timeout) + 5xx (overload / bad gateway / unavailable)
+ * statuses are the ones that callers downstream of fetchDocumentsAbortable
+ * fast-fail on; 4xx other than 408 (400 malformed filter, 401/403 auth)
+ * indicate real client-side bugs and continue to propagate.
+ *
+ * Message format is intentionally preserved byte-for-byte from the prior
+ * bare-Error throw (`Meilisearch fetch failed (NNN): <body>`) — Loki
+ * queries / dashboards keyed on that prefix continue to match without
+ * change.
+ */
+export class MeilisearchFetchError extends Error {
+  readonly name = 'MeilisearchFetchError';
+  constructor(
+    public readonly status: number,
+    public readonly responseText: string
+  ) {
+    super(`Meilisearch fetch failed (${status}): ${responseText}`);
+  }
+}
 
 /**
  * Fetch documents via a raw HTTP call that honors an AbortSignal. The
@@ -196,7 +278,12 @@ export async function fetchDocumentsAbortable<T>(
         );
         if (!res.ok) {
           const text = await res.text().catch(() => '');
-          throw new Error(`Meilisearch fetch failed (${res.status}): ${text}`);
+          // Typed error so callers can `instanceof MeilisearchFetchError` and
+          // branch on `.status` (408/5xx → graceful break, 4xx-other → bubble)
+          // without string-matching the message. Message format unchanged so
+          // Loki/dashboard queries on `Meilisearch fetch failed (NNN):`
+          // continue to match.
+          throw new MeilisearchFetchError(res.status, text);
         }
         return withSpan(
           'image:meili:parse',

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -45,10 +45,13 @@ import { withSpan, withDetachedSpan } from '~/server/utils/otel-helpers';
 import {
   FETCH_DOCUMENTS_TIMEOUT_MESSAGE,
   MeiliCallTimeoutError,
+  MeilisearchFetchError,
   SEARCH_ACTOR_HEADER,
+  failfastReasonForStatus,
   fetchDocumentsAbortable,
   getMetricsSearchClient,
-  meiliFetchTimeoutTotal,
+  isFailfastStatus,
+  meiliFetchFailfastTotal,
   metricsSearchClient,
   withMeili,
   wrapMeilisearchClientWithLimiter,
@@ -4281,12 +4284,20 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       // getDocuments() can't be cancelled, so signal-less requests used to
       // hang the event loop on a slow backend.
       //
-      // Graceful break-on-timeout: if a single iteration trips the local
-      // deadline, return whatever's already accumulated rather than failing
-      // the whole request. iteration 1 → empty page; iteration ≥ 2 → degraded
-      // (partial) page with nextCursor cleared further below. Downstream
-      // handles either shape fine; the alternative (throwing) would hand the
-      // user a 408 instead of a usable feed.
+      // Graceful break-on-fast-fail: if a single iteration hits the local
+      // deadline OR the upstream signals unavailability (408/5xx), return
+      // whatever's already accumulated rather than failing the whole request.
+      // iteration 1 → empty page; iteration ≥ 2 → degraded (partial) page
+      // with nextCursor cleared further below. Downstream handles either
+      // shape fine; the alternative (throwing) would hand the user a 5xx
+      // instead of a usable feed, and clients would retry → load amplifies
+      // → cascade sustains.
+      //
+      // Status-code rationale:
+      //   - 408 (upstream-timeout)  → Meilisearch backend page-cache thrash
+      //   - 503 (upstream-overload) → civitai-feeds-proxy shed (MEILI_MAX_CONCURRENT)
+      //   - other 5xx               → upstream brownout / Traefik 504 / etc.
+      //   - 4xx-other (400/401/403) → real client error, MUST bubble up
       let results: ImageMetricsSearchIndexRecord[];
       try {
         const fetchResult = await fetchDocumentsAbortable<ImageMetricsSearchIndexRecord>(
@@ -4308,14 +4319,26 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
             (err as { cause?: { message?: string } })?.cause?.message ===
               FETCH_DOCUMENTS_TIMEOUT_MESSAGE);
         if (isLocalTimeout) {
-          meiliFetchTimeoutTotal.inc({
+          meiliFetchFailfastTotal.inc({
             route: 'getImagesFromSearchPostFilter',
             iteration: String(iteration),
+            reason: 'local-timeout',
           });
           // Fall out of the iteration loop with whatever's already in
           // accumulatedHits. The nextCursor / merge logic below handles the
           // partial / empty case (nextCursor cleared when mergedHits.length
           // <= limit).
+          break;
+        }
+        // Upstream-side fast-fail: 408 (proxy/backend timeout) or 5xx
+        // (overload / brownout / bad gateway). Same graceful-break shape
+        // as the local-timeout path; 4xx-other re-throws below.
+        if (e instanceof MeilisearchFetchError && isFailfastStatus(e.status)) {
+          meiliFetchFailfastTotal.inc({
+            route: 'getImagesFromSearchPostFilter',
+            iteration: String(iteration),
+            reason: failfastReasonForStatus(e.status),
+          });
           break;
         }
         throw e;


### PR DESCRIPTION
## Why

PR #2370 added a 5s hard timeout + graceful-break catch in
`getImagesFromSearchPostFilter` to keep `civitai-dp-prod-api-primary` pods
responsive when `civitai-feeds-proxy` / `search-meilisearch` goes slow.
The local timer works exactly as designed (~4.5% of post-filter
iterations / ~30 fires per minute in the first 24h), but post-deploy
telemetry shows a **second failure mode is now dominant** and the catch
doesn't recognise it:

```
Meilisearch fetch failed (503): service overloaded
Meilisearch fetch failed (408): 
```

* `civitai-feeds-proxy` returns **503** when its `MEILI_MAX_CONCURRENT=30`
  cap is hit — ~240k sheds/day measured in the first 24h post-#2370.
* `feeds-meilisearch-new-0` returns **408** when the page-cache thrashes
  on cold LMDB pages.
* Loki shows ~30 `Meilisearch fetch failed (503)` errors per minute at the
  moment we sampled.

Today these come back from `fetchDocumentsAbortable`'s `if (!res.ok) throw
new Error(...)` line as bare `Error` instances. PR #2370's catch only
matches `FETCH_DOCUMENTS_TIMEOUT_MESSAGE` / `AbortError` — so the upstream
5xx/408 path re-throws, bubbles up through trpc → 500/502, clients retry,
load amplifies, the cascade #2370 patched **partially returns**.

This PR extends the graceful-break behaviour to upstream-side
unavailability: 408 (proxy/backend timeout) + any 5xx (overload / brownout
/ bad gateway). It does NOT broaden into 4xx-other — 400 malformed
filter / 401/403 auth are real client bugs and must continue to bubble so
we don't silently mask them.

Refs: civitai/civitai#2370
Refs: `datapacket-talos` skill `feeds-meilisearch/SKILL.md` (cascade
known-issue)

## What changed

* **`src/server/meilisearch/client.ts`** — new typed error class
  `MeilisearchFetchError` carrying `.status` + `.responseText`. The
  message format is preserved byte-for-byte
  (`Meilisearch fetch failed (NNN): <body>`) so Loki queries and
  dashboards keyed on that prefix continue to match without change.
  `fetchDocumentsAbortable` throws the typed variant instead of bare
  `Error` on non-ok upstream — same wire behaviour, typed callers.

* **`src/server/meilisearch/client.ts`** — new `isFailfastStatus()` +
  `failfastReasonForStatus()` helpers + the `MeiliFetchFailfastReason`
  union encode the policy: 408 or any 5xx → graceful-break-eligible;
  4xx-other → re-throw. Centralised so future callers (e.g. a feeds-pre-
  filter follow-up, the `fetchMeiliUserOwnPass` site) can reuse the same
  decision without re-deriving it.

* **`src/server/meilisearch/client.ts`** — counter rename + label add:
  `meili_fetch_timeout_total{route, iteration}` →
  `meili_fetch_failfast_total{route, iteration, reason}`. The counter is
  no longer timeout-specific; it now captures every fail-fast disposition
  `fetchDocumentsAbortable` surfaces. `reason="local-timeout"` preserves
  the PR #2370 semantic; new label values are `upstream-overload` (503),
  `upstream-timeout` (408), `upstream-error` (other 5xx). Dashboard panel
  #32 in `datapacket-talos` lands a follow-up to track the new name —
  short empty-panel window is acceptable given the operational urgency.

* **`src/server/services/image.service.ts`** — extended the
  `getImagesFromSearchPostFilter` iteration-loop catch to also match
  `MeilisearchFetchError` with a fail-fast-eligible status, increment the
  counter with the right `reason` label, and `break` out of the loop with
  whatever's already accumulated. Same shape as the existing
  local-timeout branch. 4xx-other continues to re-throw.

  `getImagesFromSearchPreFilter` is intentionally NOT touched — PR #2370
  did not add a graceful catch there (the prefilter has no iteration loop
  / partial-results worth saving), and adding one is out of scope for
  this fix.

## Status-code rationale

| Status | Reason label         | Disposition | Why                                                |
|--------|----------------------|-------------|----------------------------------------------------|
| local timer | `local-timeout`  | break       | PR #2370 — defensive 5s deadline                   |
| 408    | `upstream-timeout`   | break       | Meilisearch backend timeout (page-cache thrash)    |
| 503    | `upstream-overload`  | break       | civitai-feeds-proxy shed (MEILI_MAX_CONCURRENT)    |
| 5xx (other) | `upstream-error` | break       | Traefik 504 / bad gateway / upstream brownout      |
| 4xx (not 408) | -              | **throw**   | Real client error — malformed filter, auth, etc.   |

The 4xx (non-408) case is the boundary I deliberately did NOT cross.
Swallowing a 400 from a malformed filter would silently degrade real
client-side bugs into empty feeds, which is much worse than the cascade
this PR exists to break.

## Test coverage

Six new + one updated test in
`src/server/meilisearch/__tests__/client.test.ts`:

1. **`MeilisearchFetchError` on 503** — mock upstream returning 503 +
   body `"service overloaded"`, assert thrown is `instanceof
   MeilisearchFetchError` with `.status === 503` and `.responseText ===
   "service overloaded"`. Also asserts the message-format contract
   (`Meilisearch fetch failed (503): service overloaded`) so future
   refactors don't break the Loki prefix.
2. **`MeilisearchFetchError` on 408** — same shape, status 408.
3. **2xx happy path doesn't throw** — defends the non-failure path.
4. **Post-filter catch matches 503 (upstream-overload)** — mirrors the
   `image.service.ts` catch logic, asserts break + counter increment with
   `reason: "upstream-overload"`.
5. **Post-filter catch matches 408 (upstream-timeout)** — same shape,
   `reason: "upstream-timeout"`.
6. **Post-filter catch matches 502 (upstream-error generic 5xx)** — same
   shape, `reason: "upstream-error"`. Defends against accidentally
   narrowing the policy to a status whitelist.
7. **Post-filter catch re-throws on 400** — proves the boundary holds:
   400 is `instanceof MeilisearchFetchError` but `isFailfastStatus(400)`
   returns false, so the catch falls through to re-throw. Also asserts
   the failfast counter does NOT increment on 4xx-other.

The existing PR #2370 tests (timeout fires within `timeoutMs`,
no-timeout happy path, caller-signal wins, post-filter local-timeout
catch shape) all still pass — the catch-shape contract test was updated
for the new counter name + `reason` label.

New `makeStatusFetch(status, body)` helper for non-ok cases;
`makeDelayedFetch` reused unchanged for the timeout/happy paths.

Pre-existing baseline TS errors in `event-engine-common` imports and
Prisma codegen are unrelated and reproduce on `main`. The two modified
files (`client.ts`, `client.test.ts`) typecheck clean; the catch-block
region in `image.service.ts` also typechecks clean.

## Risk

Minimal:

* The only catch-block behaviour change is broader matching on the same
  iteration loop — same `break`, same metric-inc shape, same downstream
  partial-page rendering.
* `MeilisearchFetchError` is a strictly additive typed wrapper —
  consumers that already inspect the message string see no change.
* Counter rename will leave the dashboard panel empty for a few minutes
  during transition; the panel update commits separately on the
  datapacket-talos side. Acceptable given the operational urgency.
* No SDK upgrades, no env var changes, no behaviour change in
  `getImagesFromSearchPreFilter`, no OTel span change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)