### PR TITLE
fix: reschedule model version reschedules attached posts

### DIFF
--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -943,12 +943,14 @@ export const publishModelVersionById = async ({
         });
       }
 
-      // Only restore posts that were unpublished alongside this version. Without
-      // the `publishedAt IS NULL` guard, calling publish on an already-published
-      // version overwrites every attached post's publishedAt (and clears their
-      // prevPublishedAt metadata), letting an owner script repeated publish calls
-      // to keep bumping their old posts to the top of feeds. Mirrors the
-      // `WHERE "publishedAt" IS NOT NULL` guard in the unpublish path below.
+      // Restore posts that were unpublished alongside this version, and re-target
+      // posts that are still scheduled (future publishedAt) so a reschedule of the
+      // version also reschedules its attached posts. The `publishedAt <= NOW()`
+      // exclusion preserves the anti-bump guard for already-public posts —
+      // without it, calling publish on an already-published version would
+      // overwrite every attached post's publishedAt and let an owner repeatedly
+      // bump old posts to the top of feeds. Mirrors the `WHERE "publishedAt" IS
+      // NOT NULL` guard in the unpublish path below.
       await tx.$executeRaw`
         UPDATE "Post"
         SET
@@ -960,7 +962,7 @@ export const publishModelVersionById = async ({
           "metadata" = "metadata" - 'unpublishedAt' - 'unpublishedBy' - 'prevPublishedAt'
         WHERE "userId" = ${updatedVersion.model.userId}
         AND "modelVersionId" = ${updatedVersion.id}
-        AND "publishedAt" IS NULL
+        AND ("publishedAt" IS NULL OR "publishedAt" > NOW())
       `;
 
       if (!currentVersion.model.publishedAt) {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2103,12 +2103,14 @@ export const publishModelById = async ({
           });
         }
 
-        // Only restore posts that were unpublished alongside the model. Without
-        // the `p."publishedAt" IS NULL` guard, calling publish on an
-        // already-published model overwrites every attached post's publishedAt
-        // (and clears their prevPublishedAt metadata), letting an owner script
-        // repeated publish calls to keep bumping their old posts to the top of
-        // feeds. Mirrors the unpublish path's `WHERE "publishedAt" IS NOT NULL`.
+        // Restore posts that were unpublished alongside the model, and re-target
+        // posts that are still scheduled (future publishedAt) so a reschedule of
+        // the model also reschedules its attached posts. The `publishedAt <= NOW()`
+        // exclusion preserves the anti-bump guard for already-public posts —
+        // without it, calling publish on an already-published model would
+        // overwrite every attached post's publishedAt and let an owner repeatedly
+        // bump old posts to the top of feeds. Mirrors the unpublish path's
+        // `WHERE "publishedAt" IS NOT NULL`.
         await tx.$executeRaw`
           UPDATE "Post" p
           SET "publishedAt" = CASE
@@ -2121,7 +2123,7 @@ export const publishModelById = async ({
           WHERE mv.id = p."modelVersionId"
             AND p."userId" = ${model.userId}
             AND p."modelVersionId" IN (${Prisma.join(versionIds, ',')})
-            AND p."publishedAt" IS NULL
+            AND (p."publishedAt" IS NULL OR p."publishedAt" > NOW())
         `;
       }
       if (!republishing && !meta?.unpublishedBy) await updateModelLastVersionAt({ id, tx });


### PR DESCRIPTION
## Summary
- Relaxes the `Post.publishedAt IS NULL` guard in `publishModelVersionById` (`src/server/services/model-version.service.ts:952`) and `publishModelById` (`src/server/services/model.service.ts:2112`) to `(publishedAt IS NULL OR publishedAt > NOW())`, so rescheduling a scheduled model/version also re-targets its attached scheduled posts.
- Preserves the anti-bump guard for already-public posts (`publishedAt <= NOW()`).

## Bug
Reported via [Freshdesk #66564](https://) → [ClickUp 868jvxj5r](https://app.clickup.com/t/868jvxj5r).

Repro:
1. Upload a resource with a description + images
2. Set it to a scheduled post
3. Reschedule it before it actually posts
4. Images still post at the original time

Root cause: on the first schedule, attached `Post.publishedAt` is NULL so the existing guard lets the SQL set it to the version's scheduled time. On reschedule, `Post.publishedAt` is already a future date so the `IS NULL` guard skips it — the version moves, the post stays.

## Test plan
- [ ] Schedule a model version + main post for T+2h; confirm `Post.publishedAt = T+2h`.
- [ ] Reschedule the version to T+4h via the publish mutation; confirm `Post.publishedAt = T+4h`.
- [ ] On an already-published post (`publishedAt < NOW()`), trigger publish again; confirm `Post.publishedAt` is NOT bumped (anti-bump guard intact).
- [ ] Verify the same behavior via the model-level publish path (`publishModelById`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)