### PR TITLE
fix(tags): deduplicate tags in applyTagRules to prevent ON CONFLICT db errors

### DIFF
--- a/src/server/services/tagsOnImageNew.service.ts
+++ b/src/server/services/tagsOnImageNew.service.ts
@@ -118,7 +118,7 @@ async function updateImageNsfwLevels(args: { imageId: number; tagId: number }[])
 
 async function applyTagRules(args: TagsOnImageNewArgs[]) {
   const tagRules = await getTagRules();
-  return tagRules.reduce<TagsOnImageNewArgs[]>(
+  const applied = tagRules.reduce<TagsOnImageNewArgs[]>(
     (tags, rule) => {
       const index = tags.findIndex((x) => x.tagId === rule.toId);
       if (index === -1) return tags;
@@ -132,5 +132,15 @@ async function applyTagRules(args: TagsOnImageNewArgs[]) {
       return [...tags, { ...existing, tagId: rule.fromId, confidence: 70, source: 'Computed' }];
     },
     [...args]
+  );
+
+  return Object.values(
+    applied.reduce<Record<string, TagsOnImageNewArgs>>((acc, tag) => {
+      const key = `${tag.imageId}-${tag.tagId}`;
+      if (!acc[key] || (acc[key].confidence ?? 0) < (tag.confidence ?? 0)) {
+        acc[key] = tag;
+      }
+      return acc;
+    }, {})
   );
 }

--- a/src/server/services/tagsOnImageNew.service.ts
+++ b/src/server/services/tagsOnImageNew.service.ts
@@ -118,26 +118,29 @@ async function updateImageNsfwLevels(args: { imageId: number; tagId: number }[])
 
 async function applyTagRules(args: TagsOnImageNewArgs[]) {
   const tagRules = await getTagRules();
-  const applied = tagRules.reduce<TagsOnImageNewArgs[]>(
-    (tags, rule) => {
-      const index = tags.findIndex((x) => x.tagId === rule.toId);
-      if (index === -1) return tags;
 
-      const existing = tags[index];
-      if (rule.type === 'Replace') {
-        if (existing) tags[index] = { ...existing, tagId: rule.fromId };
-        return tags;
+  let applied = [...args];
+  for (const rule of tagRules) {
+    const nextTags: TagsOnImageNewArgs[] = [];
+    for (const tag of applied) {
+      if (tag.tagId === rule.toId) {
+        if (rule.type === 'Replace') {
+          nextTags.push({ ...tag, tagId: rule.fromId });
+        } else {
+          nextTags.push(tag);
+          nextTags.push({ ...tag, tagId: rule.fromId, confidence: 70, source: 'Computed' });
+        }
+      } else {
+        nextTags.push(tag);
       }
-
-      return [...tags, { ...existing, tagId: rule.fromId, confidence: 70, source: 'Computed' }];
-    },
-    [...args]
-  );
+    }
+    applied = nextTags;
+  }
 
   return Object.values(
     applied.reduce<Record<string, TagsOnImageNewArgs>>((acc, tag) => {
       const key = `${tag.imageId}-${tag.tagId}`;
-      if (!acc[key] || (acc[key].confidence ?? 0) < (tag.confidence ?? 0)) {
+      if (!acc[key]) {
         acc[key] = tag;
       }
       return acc;


### PR DESCRIPTION
### Description

This PR introduces an internal deduplication step to `applyTagRules` in `tagsOnImageNew.service.ts` to ensure that duplicate tags are not processed during batch insertion.

### Investigation & Root Cause

Currently, the orchestration pipeline can end up evaluating tag append/replace rules at two separate stages: once during the initial tagging pass (e.g., `processTags`) and again when the tags are finalized for database insertion via `insertTagsOnImageNew`.

If an `Append` rule triggers during the initial pass, the appended tag is correctly deduplicated by name and passed forward. However, when `applyTagRules` is called downstream, it evaluates the rules again. It matches the original tag and inadvertently appends the target tag a second time—even though the target tag is already present in the array from the first pass.

This results in the array containing duplicate `(imageId, tagId)` pairs. While this service currently inserts via per-row PL/pgSQL functions (`insert_tag_on_image` / `upsert_tag_on_image`) rather than a single bulk `INSERT ... ON CONFLICT DO UPDATE`, duplicate entries still lead to redundant writes and unintended data churn. Deduplicating them prevents these unnecessary database operations and avoids any risk of encountering multi-row constraint exceptions if batch approaches are used elsewhere.

### The Fix

By updating the `applyTagRules` function, we ensure that:
1. Rules are applied correctly to all matching tags across multiple images in a batch.
2. The final tag list is deduplicated based on the unique combination of `imageId` and `tagId` (keeping the first occurrence to preserve stable semantics such as source). 

This guarantees that the database layer does not process conflicting rows within the same payload.
