### PR TITLE
fix(profile): move cover-image ingestion outside the update transaction

### DIFF
--- a/src/server/services/user-profile.service.ts
+++ b/src/server/services/user-profile.service.ts
@@ -12,6 +12,7 @@ import type { ImageMetaProps } from '~/server/schema/image.schema';
 import { ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
 import { ingestImage } from '~/server/services/image.service';
+import { logToAxiom } from '~/server/logging/client';
 import type { UserMeta } from '~/server/schema/user.schema';
 import { getUserBanDetails } from '~/utils/user-helpers';
 import {
@@ -321,10 +322,25 @@ export const updateUserProfile = async ({
   // blocking external HTTP call to the image scanner; keeping it inside the
   // interactive transaction held the txn open past its 15s timeout whenever the
   // scanner was slow ("Transaction already closed: a commit cannot be executed
-  // on an expired transaction"). Ingestion is a fire-and-forget scanner enqueue
-  // that only needs the committed Image row, not transactional atomicity.
+  // on an expired transaction"). Ingestion only needs the committed Image row,
+  // not transactional atomicity with the profile write.
+  //
+  // Fire-and-forget on purpose: the profile is already saved, so a scanner
+  // outage must NOT bubble up as "error updating your profile" on a successful
+  // save. Recovery is guaranteed independently — the `trg_image_scan_queue`
+  // trigger enqueues an ImageScan JobQueue row on the Pending insert, which the
+  // `ingest-images` sweeper drains, so the cover image still gets scanned even
+  // if this inline enqueue fails.
   if (updatedCoverImage && updatedCoverImage.ingestion === ImageIngestionStatus.Pending) {
-    await ingestImage({ image: updatedCoverImage });
+    ingestImage({ image: updatedCoverImage }).catch((error) =>
+      logToAxiom({
+        name: 'user-profile-cover-ingest',
+        type: 'error',
+        userId,
+        imageId: updatedCoverImage.id,
+        message: error instanceof Error ? error.message : String(error),
+      })
+    );
   }
 
   await usersSearchIndex.queueUpdate([{ id: userId, action: SearchIndexUpdateQueueAction.Update }]);

--- a/src/server/services/user-profile.service.ts
+++ b/src/server/services/user-profile.service.ts
@@ -188,7 +188,7 @@ export const updateUserProfile = async ({
     userUpdateCounter?.inc({ location: 'user-profile.service:updateProfile' });
   }
 
-  await dbWrite.$transaction(
+  const { coverImage: updatedCoverImage } = await dbWrite.$transaction(
     async (tx) => {
       // const shouldUpdateCosmetics = badgeId !== undefined || nameplateId !== undefined;
       // const payloadCosmeticIds: number[] = [];
@@ -310,18 +310,22 @@ export const updateUserProfile = async ({
         },
       });
 
-      if (
-        updatedProfile.coverImage &&
-        updatedProfile.coverImage.ingestion === ImageIngestionStatus.Pending
-      ) {
-        await ingestImage({ image: updatedProfile.coverImage, tx });
-      }
+      return updatedProfile;
     },
     {
-      // Wait double of time because it might be a long transaction
       timeout: 15000,
     }
   );
+
+  // Ingest the cover image AFTER the transaction commits. ingestImage makes a
+  // blocking external HTTP call to the image scanner; keeping it inside the
+  // interactive transaction held the txn open past its 15s timeout whenever the
+  // scanner was slow ("Transaction already closed: a commit cannot be executed
+  // on an expired transaction"). Ingestion is a fire-and-forget scanner enqueue
+  // that only needs the committed Image row, not transactional atomicity.
+  if (updatedCoverImage && updatedCoverImage.ingestion === ImageIngestionStatus.Pending) {
+    await ingestImage({ image: updatedCoverImage });
+  }
 
   await usersSearchIndex.queueUpdate([{ id: userId, action: SearchIndexUpdateQueueAction.Update }]);
 

--- a/src/server/services/user-profile.service.ts
+++ b/src/server/services/user-profile.service.ts
@@ -333,13 +333,15 @@ export const updateUserProfile = async ({
   // if this inline enqueue fails.
   if (updatedCoverImage && updatedCoverImage.ingestion === ImageIngestionStatus.Pending) {
     ingestImage({ image: updatedCoverImage }).catch((error) =>
+      // Trailing .catch swallows Axiom-side rejections so a logging outage
+      // can't surface as an unhandledRejection (matches fail-open-log.ts).
       logToAxiom({
         name: 'user-profile-cover-ingest',
         type: 'error',
         userId,
         imageId: updatedCoverImage.id,
         message: error instanceof Error ? error.message : String(error),
-      })
+      }).catch(() => {})
     );
   }
 


### PR DESCRIPTION
## Problem

Users saving their profile with a **freshly-uploaded cover image** hit:

> There was an error updating your profile
> Transaction API error: Transaction already closed: A commit cannot be executed on an expired transaction. The timeout for this transaction was 15000 ms, however 30880 ms passed since the start of the transaction.

## Root cause

`updateUserProfile` (`src/server/services/user-profile.service.ts`) called `ingestImage({ image, tx })` **inside** the `dbWrite.$transaction(..., { timeout: 15000 })`. `ingestImage` (`image.service.ts`) makes a blocking external HTTP call to the image scanner (`createImageIngestionRequest` / `fetch(scanUrl)`). When the scanner is slow, that `fetch` holds the interactive transaction open past its 15 s budget, so Prisma expires it and the commit fails.

The error only fires when the cover image is newly uploaded (`ingestion === Pending`) — that's the only path that reaches `ingestImage`.

Bumping the timeout (as the Prisma error message suggests) only widens the window; it doesn't stop a hung scanner from holding a DB transaction open.

## Fix

Image ingestion is a fire-and-forget scanner enqueue that only needs the committed `Image` row, not transactional atomicity with the profile write. The transaction now returns the updated profile, and the cover image is ingested **after** commit. `ingestImage` already falls back to `dbWrite` when no `tx` is passed, so removing `tx` keeps its writes working on their own connection.

No behavior change for profiles without a new cover image. Net change: external HTTP call removed from the DB transaction's critical path.

## Testing

- `tsc --noEmit` clean for the touched file (pre-existing unrelated `event-engine-common` module-resolution errors in `image.service.ts` are not introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)