### PR TITLE
fix(ingestion): decouple ingestImage from interactive transactions globally

### DIFF
--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import type { ManipulateType } from 'dayjs';
 import { truncate } from 'lodash-es';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import type { NsfwLevel } from '~/server/common/enums';
 import { ImageConnectionType, NotificationCategory } from '~/server/common/enums';
 import { ArticleSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
@@ -1690,14 +1691,19 @@ export async function linkArticleContentImages({
 
   if (imagesToIngest.length > 0) {
     // TODO.articleImageScan: remove the lowPriority flag
-    for (const img of imagesToIngest) {
+    const tasks = imagesToIngest.map((img) => () =>
       ingestImage({ image: img, lowPriority: true, userId }).catch((error) => {
-        handleLogError(error, 'article-image-ingestion', {
+        logToAxiom({
+          name: 'article-image-ingest',
+          type: 'error',
           articleId,
-          imageIds: [img.id],
-        });
-      });
-    }
+          userId,
+          imageId: img.id,
+          message: error instanceof Error ? error.message : String(error),
+        }).catch(() => {});
+      })
+    );
+    limitConcurrency(tasks, 5).catch(() => {});
   }
 
   return { orphanedImageIds };

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -1564,11 +1564,12 @@ export async function linkArticleContentImages({
 }): Promise<{ orphanedImageIds: number[] }> {
   const contentImages = getContentMedia(content);
 
-  const orphanedImageIds = await dbWrite.$transaction(async (tx) => {
+  const { orphanedImageIds, imagesToIngest } = await dbWrite.$transaction(async (tx) => {
     const imageUrls = contentImages.map((img) => img.url);
 
     // Track content image IDs for orphan detection
     let contentImageIds: number[] = [];
+    let imagesToIngest: { id: number; url: string; ingestion?: ImageIngestionStatus }[] = [];
 
     if (!cleanupOnly) {
       // Batch query: Get all existing images in one query
@@ -1631,18 +1632,7 @@ export async function linkArticleContentImages({
       const pendingExistingImages = existingImages.filter(
         (img) => img.ingestion === ImageIngestionStatus.Pending
       );
-      const imagesToIngest = [...newlyCreatedImages, ...pendingExistingImages];
-      if (imagesToIngest.length > 0) {
-        // TODO.articleImageScan: remove the lowPriority flag
-        for (const img of imagesToIngest) {
-          await ingestImage({ image: img, lowPriority: true, userId, tx }).catch((error) => {
-            handleLogError(error, 'article-image-ingestion', {
-              articleId,
-              imageIds: newlyCreatedImages.map((i) => i.id),
-            });
-          });
-        }
-      }
+      imagesToIngest = [...newlyCreatedImages, ...pendingExistingImages];
     } else {
       // In cleanupOnly mode, we still need to know which images are in the current content
       // so we can detect orphans. Query by URL to get their IDs.
@@ -1683,6 +1673,7 @@ export async function linkArticleContentImages({
     }
 
     // Find truly orphaned images (no connections to ANY entity)
+    let trulyOrphanedIds: number[] = [];
     if (orphanedIds.length > 0) {
       const trulyOrphaned = await tx.image.findMany({
         where: {
@@ -1691,11 +1682,23 @@ export async function linkArticleContentImages({
         },
         select: { id: true },
       });
-      return trulyOrphaned.map((img) => img.id);
+      trulyOrphanedIds = trulyOrphaned.map((img) => img.id);
     }
 
-    return [];
+    return { orphanedImageIds: trulyOrphanedIds, imagesToIngest };
   });
+
+  if (imagesToIngest.length > 0) {
+    // TODO.articleImageScan: remove the lowPriority flag
+    for (const img of imagesToIngest) {
+      ingestImage({ image: img, lowPriority: true, userId }).catch((error) => {
+        handleLogError(error, 'article-image-ingestion', {
+          articleId,
+          imageIds: [img.id],
+        });
+      });
+    }
+  }
 
   return { orphanedImageIds };
 }

--- a/src/server/services/bounty.service.ts
+++ b/src/server/services/bounty.service.ts
@@ -17,7 +17,7 @@ import {
   getUserBuzzAccount,
   refundMultiAccountTransaction,
 } from '~/server/services/buzz.service';
-import { createEntityImages, updateEntityImages } from '~/server/services/image.service';
+import { createEntityImages, updateEntityImages, ingestImage } from '~/server/services/image.service';
 import { decreaseDate, startOfDay } from '~/utils/date-helpers';
 import type { NsfwLevel } from '../common/enums';
 import { BountySort, BountyStatus } from '../common/enums';
@@ -189,6 +189,8 @@ export const createBounty = async ({
   const startsAt = startOfDay(incomingStartsAt, { utc: true });
   const expiresAt = startOfDay(incomingExpiresAt, { utc: true });
 
+  let imagesToIngest: { id: number; url: string }[] = [];
+
   const bounty = await dbWrite.$transaction(
     async (tx) => {
       const bounty = await tx.bounty.create({
@@ -230,7 +232,7 @@ export const createBounty = async ({
       }
 
       if (images) {
-        await createEntityImages({
+        imagesToIngest = await createEntityImages({
           images,
           tx,
           userId,
@@ -280,6 +282,20 @@ export const createBounty = async ({
     { maxWait: 10000, timeout: 30000 }
   );
 
+  if (imagesToIngest.length > 0) {
+    for (const img of imagesToIngest) {
+      ingestImage({ image: img }).catch((error) => {
+        logToAxiom({
+          name: 'bounty-image-ingest',
+          type: 'error',
+          userId,
+          imageId: img.id,
+          message: error instanceof Error ? error.message : String(error),
+        }).catch(() => {});
+      });
+    }
+  }
+
   if (bounty.userId) {
     await userBountyCountCache.refresh(bounty.userId);
   }
@@ -303,6 +319,8 @@ export const updateBountyById = async ({
   // Convert dates to UTC for storing
   const startsAt = startOfDay(incomingStartsAt, { utc: true });
   const expiresAt = startOfDay(incomingExpiresAt, { utc: true });
+
+  let imagesToIngest: { id: number; url: string }[] = [];
 
   const bounty = await dbWrite.$transaction(
     async (tx) => {
@@ -377,7 +395,7 @@ export const updateBountyById = async ({
       }
 
       if (images) {
-        await updateEntityImages({
+        imagesToIngest = await updateEntityImages({
           images,
           tx,
           entityId: bounty.id,
@@ -390,6 +408,20 @@ export const updateBountyById = async ({
     },
     { maxWait: 10000, timeout: 30000 }
   );
+
+  if (imagesToIngest.length > 0) {
+    for (const img of imagesToIngest) {
+      ingestImage({ image: img }).catch((error) => {
+        logToAxiom({
+          name: 'bounty-image-ingest',
+          type: 'error',
+          userId,
+          imageId: img.id,
+          message: error instanceof Error ? error.message : String(error),
+        }).catch(() => {});
+      });
+    }
+  }
 
   if (bounty?.userId) {
     await userBountyCountCache.refresh(bounty?.userId);

--- a/src/server/services/bountyEntry.service.ts
+++ b/src/server/services/bountyEntry.service.ts
@@ -16,6 +16,7 @@ import {
   createEntityImages,
   invalidateManyImageExistence,
   updateEntityImages,
+  ingestImage,
 } from '~/server/services/image.service';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { dbRead, dbWrite } from '../db/client';
@@ -112,7 +113,10 @@ export const upsertBountyEntry = async ({
   userId,
 }: UpsertBountyEntryInput & { userId: number }) => {
   if (description) await throwOnBlockedLinkDomain(description);
-  return dbWrite.$transaction(async (tx) => {
+  
+  let imagesToIngest: { id: number; url: string }[] = [];
+
+  const result = await dbWrite.$transaction(async (tx) => {
     if (id) {
       const [awarded] = await getBountyEntryEarnedBuzz({ ids: [id] });
 
@@ -134,7 +138,7 @@ export const upsertBountyEntry = async ({
       }
 
       if (images) {
-        await updateEntityImages({
+        imagesToIngest = await updateEntityImages({
           images,
           tx,
           userId,
@@ -164,7 +168,7 @@ export const upsertBountyEntry = async ({
       }
 
       if (images) {
-        await createEntityImages({
+        imagesToIngest = await createEntityImages({
           images,
           tx,
           userId,
@@ -180,6 +184,22 @@ export const upsertBountyEntry = async ({
       return entry;
     }
   });
+
+  if (imagesToIngest.length > 0) {
+    for (const img of imagesToIngest) {
+      ingestImage({ image: img }).catch((error) => {
+        logToAxiom({
+          name: 'bounty-entry-image-ingest',
+          type: 'error',
+          userId,
+          imageId: img.id,
+          message: error instanceof Error ? error.message : String(error),
+        }).catch(() => {});
+      });
+    }
+  }
+
+  return result;
 };
 
 export const awardBountyEntry = async ({ id, userId }: { id: number; userId: number }) => {

--- a/src/server/services/bountyEntry.service.ts
+++ b/src/server/services/bountyEntry.service.ts
@@ -113,7 +113,7 @@ export const upsertBountyEntry = async ({
   userId,
 }: UpsertBountyEntryInput & { userId: number }) => {
   if (description) await throwOnBlockedLinkDomain(description);
-  
+
   let imagesToIngest: { id: number; url: string }[] = [];
 
   const result = await dbWrite.$transaction(async (tx) => {

--- a/src/server/services/club.service.ts
+++ b/src/server/services/club.service.ts
@@ -4,6 +4,7 @@ import { isEqual } from 'lodash-es';
 import { v4 as uuid } from 'uuid';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbReadFallbackCounter } from '~/server/prom/client';
+import { logToAxiom } from '~/server/logging/client';
 import { notifDbWrite } from '~/server/db/notifDb';
 import { pgDbRead } from '~/server/db/pgDb';
 import type { GetByIdInput } from '~/server/schema/base.schema';
@@ -27,7 +28,7 @@ import {
   entityOwnership,
   entityRequiresClub,
 } from '~/server/services/common.service';
-import { createEntityImages } from '~/server/services/image.service';
+import { createEntityImages, ingestImage } from '~/server/services/image.service';
 import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
 import { getPagingData } from '~/server/utils/pagination-helpers';
 import { isDefined } from '~/utils/type-guards';
@@ -206,6 +207,20 @@ export const updateClub = async ({
     userId,
   });
 
+  if (createdImages.length > 0) {
+    for (const img of createdImages) {
+      ingestImage({ image: img }).catch((error) => {
+        logToAxiom({
+          name: 'club-image-ingest',
+          type: 'error',
+          userId,
+          imageId: img.id,
+          message: error instanceof Error ? error.message : String(error),
+        }).catch(() => {});
+      });
+    }
+  }
+
   const club = await dbWrite.club.update({
     where: { id },
     data: {
@@ -293,6 +308,20 @@ export const createClub = async ({
     userId,
   });
 
+  if (createdImages.length > 0) {
+    for (const img of createdImages) {
+      ingestImage({ image: img }).catch((error) => {
+        logToAxiom({
+          name: 'club-image-ingest',
+          type: 'error',
+          userId,
+          imageId: img.id,
+          message: error instanceof Error ? error.message : String(error),
+        }).catch(() => {});
+      });
+    }
+  }
+
   const club = await dbWrite.club.create({
     data: {
       ...data,
@@ -353,6 +382,18 @@ export const upsertClubTier = async ({
         images: [coverImage],
       })
     : [];
+
+  if (imageRecord) {
+    ingestImage({ image: imageRecord }).catch((error) => {
+      logToAxiom({
+        name: 'club-tier-image-ingest',
+        type: 'error',
+        userId,
+        imageId: imageRecord.id,
+        message: error instanceof Error ? error.message : String(error),
+      }).catch(() => {});
+    });
+  }
 
   if (data.id) {
     const existingClubTier = await dbRead.clubTier.findUnique({

--- a/src/server/services/clubPost.service.ts
+++ b/src/server/services/clubPost.service.ts
@@ -7,8 +7,9 @@ import type {
 } from '~/server/schema/club.schema';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbReadFallbackCounter } from '~/server/prom/client';
+import { logToAxiom } from '~/server/logging/client';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
-import { createEntityImages, getImagesForPosts } from '~/server/services/image.service';
+import { createEntityImages, getImagesForPosts, ingestImage } from '~/server/services/image.service';
 import { userContributingClubs } from '~/server/services/club.service';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type { GetModelsWithImagesAndModelVersions } from './model.service';
@@ -199,6 +200,18 @@ export const upsertClubPost = async ({
           images: [coverImage],
         })
       : [];
+
+  if (createdCoverImage) {
+    ingestImage({ image: createdCoverImage }).catch((error) => {
+      logToAxiom({
+        name: 'club-post-image-ingest',
+        type: 'error',
+        userId: userClub.userId,
+        imageId: createdCoverImage.id,
+        message: error instanceof Error ? error.message : String(error),
+      }).catch(() => {});
+    });
+  }
 
   if (input.id) {
     const post = await dbClient.clubPost.update({

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -27,7 +27,7 @@ import {
   refundTransaction,
 } from '~/server/services/buzz.service';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
-import { createEntityImages, getAllImages } from '~/server/services/image.service';
+import { createEntityImages, getAllImages, ingestImage } from '~/server/services/image.service';
 import { withRetries } from '~/server/utils/errorHandling';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import {
@@ -285,6 +285,18 @@ export const upsertCosmeticShopSection = async ({
         images: [image],
       })
     : [];
+
+  if (imageRecord) {
+    ingestImage({ image: imageRecord }).catch((error) => {
+      logToAxiom({
+        name: 'cosmetic-shop-image-ingest',
+        type: 'error',
+        userId,
+        imageId: imageRecord.id,
+        message: error instanceof Error ? error.message : String(error),
+      }).catch(() => {});
+    });
+  }
 
   if (!image && !id) {
     throw new Error('Image is required to create a new section');

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -5649,9 +5649,6 @@ export const createEntityImages = async ({
       const tasks = batch.map((image) => () => createImageResources({ imageId: image.id, tx }));
       await limitConcurrency(tasks, 10);
     }
-
-    const tasks = batch.map((image) => () => ingestImage({ image, tx }));
-    await limitConcurrency(tasks, 10);
   }
 
   if (entityType && entityId) {
@@ -5926,6 +5923,13 @@ export const updateEntityImages = async ({
   );
 
   const links = [...newLinkedImages.map((i) => i.id)];
+  let imageRecords: {
+    id: number;
+    url: string;
+    type: MediaType;
+    width: number | null;
+    height: number | null;
+  }[] = [];
 
   if (newImages.length > 0) {
     await dbClient.image.createMany({
@@ -5937,7 +5941,7 @@ export const updateEntityImages = async ({
       })),
     });
 
-    const imageRecords = await dbClient.image.findMany({
+    imageRecords = await dbClient.image.findMany({
       select: { id: true, url: true, type: true, width: true, height: true },
       where: {
         url: { in: newImages.map((i) => i.url) },
@@ -5955,8 +5959,6 @@ export const updateEntityImages = async ({
       if (shouldAddImageResources) {
         await Promise.all(batch.map((image) => createImageResources({ imageId: image.id, tx })));
       }
-
-      await Promise.all(batch.map((image) => ingestImage({ image, tx })));
     }
   }
 
@@ -5970,6 +5972,8 @@ export const updateEntityImages = async ({
       })),
     });
   }
+
+  return imageRecords;
 };
 
 const imageReviewQueueJoinMap = {

--- a/src/server/services/purchasable-reward.service.ts
+++ b/src/server/services/purchasable-reward.service.ts
@@ -19,7 +19,8 @@ import {
   purchasableRewardDetailsModerator,
 } from '~/server/selectors/purchasableReward.selector';
 import { createMultiAccountBuzzTransaction } from '~/server/services/buzz.service';
-import { createEntityImages } from '~/server/services/image.service';
+import { logToAxiom } from '~/server/logging/client';
+import { createEntityImages, ingestImage } from '~/server/services/image.service';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import { PurchasableRewardUsage } from '~/shared/utils/prisma/enums';
@@ -155,6 +156,18 @@ export const purchasableRewardUpsert = async ({
         images: [coverImage],
       })
     : [];
+
+  if (imageRecord) {
+    ingestImage({ image: imageRecord }).catch((error) => {
+      logToAxiom({
+        name: 'purchasable-reward-image-ingest',
+        type: 'error',
+        userId,
+        imageId: imageRecord.id,
+        message: error instanceof Error ? error.message : String(error),
+      }).catch(() => {});
+    });
+  }
 
   if (!input.id) {
     // Create:


### PR DESCRIPTION
## Problem

Just like in PR #2375, calls to `ingestImage` (which makes an external HTTP request) were being executed *inside* Prisma interactive transactions across several services.

When the image scanner orchestrator experienced latency, these `fetch` calls hung, holding the interactive transactions open well past their timeout budgets and leading to database errors (e.g. `Transaction already closed: A commit cannot be executed on an expired transaction`). 

## Fix

Image ingestion is a fire-and-forget scanner enqueue that only needs the committed `Image` row. It does not require transactional atomicity with the parent entity write.

This PR mirrors the fix from PR #2375 across the rest of the codebase by decoupling the `ingestImage` calls from their parent transactions:
1. In `article.service.ts` (`linkArticleContentImages`), the images to ingest are returned from the transaction and `ingestImage` is called iteratively afterward.
2. In `image.service.ts` (`createEntityImages` and `updateEntityImages`), the inline `ingestImage` calls are removed. The functions now return the created `imageRecords` so the callers can execute the ingestion.
3. Callers of `updateEntityImages` and `createEntityImages` (e.g., `bounty.service.ts`, `bountyEntry.service.ts`, `club.service.ts`, `clubPost.service.ts`, `cosmetic-shop.service.ts`, and `purchasable-reward.service.ts`) now extract the returned `imageRecords` and safely invoke `ingestImage` post-commit.

## Self-Audit / Review Findings

This PR was carefully audited against the following edge cases:

- **Recovery Net**: Even though `ingestImage` no longer uses `await` (fire-and-forget), this is safe because the Postgres `trg_image_scan_queue` trigger provides a recovery net for sweeping un-scanned images.
- **`createEntityImages` Callers (Latency Fix)**: Because the internal inline ingestion was removed from `createEntityImages`, we ran a global audit of its callers. We explicitly updated `cosmetic-shop.service.ts`, `clubPost.service.ts`, `club.service.ts`, and `purchasable-reward.service.ts` to immediately capture the returned array and manually fire `ingestImage`. This prevents these models from silently missing inline ingestion and suffering the latency hit of waiting for the fallback sweeper.
- **Unhandled Rejection Guards**: All `logToAxiom` calls inside the decoupled `ingestImage(...).catch(...)` blocks are properly suffixed with `.catch(() => {})` to prevent unhandled promise rejections during Axiom degraded states.
- **Article `cleanupOnly` Mode**: We verified that when `linkArticleContentImages` runs with `cleanupOnly === true`, the `imagesToIngest` array correctly stays empty, matching previous behavior and preventing accidental rescans.
- **Logging Fidelity**: The new iterative `ingestImage` loops log errors per single `imageId`, providing better granular monitoring in Axiom than the old batch logging.

## Testing

`tsc --noEmit` verified cleanly against the updated files (ignoring pre-existing unrelated typing issues in `image.service.ts` from `event-engine-common`).
