### PR TITLE
fix(tx): remove blocking I/O from awardBountyEntry + deleteVersionById transactions

### DIFF
--- a/src/server/services/bountyEntry.service.ts
+++ b/src/server/services/bountyEntry.service.ts
@@ -215,7 +215,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
   const benefactor = await dbWrite.$transaction(
     async (tx) => {
       // 1. Fetch entry details
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -238,7 +238,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
 
       logData.bountyId = entry.bountyId;
 
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -249,7 +249,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
 
       // 2. Validate entry has a user
       if (!entry.userId) {
-        await logToAxiom({
+        logToAxiom({
           ...logData,
           name: 'bounty-award',
           type: 'error',
@@ -260,7 +260,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
 
       // 3. Validate bounty is not already complete
       if (entry.bounty.complete) {
-        await logToAxiom({
+        logToAxiom({
           ...logData,
           name: 'bounty-award',
           type: 'error',
@@ -270,7 +270,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
       }
 
       // 4. Fetch benefactor details
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -286,7 +286,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
         },
       });
 
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -299,7 +299,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
 
       // 5. Validate benefactor hasn't already awarded
       if (benefactor.awardedToId) {
-        await logToAxiom({
+        logToAxiom({
           ...logData,
           name: 'bounty-award',
           type: 'error',
@@ -310,7 +310,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
       }
 
       // 6. Update benefactor with award
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -330,7 +330,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
         },
       });
 
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -338,7 +338,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
       }).catch(() => null);
 
       // 7. Create buzz transaction
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -449,7 +449,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
                 entityType: 'Bounty',
               },
             });
-            await logToAxiom({
+            logToAxiom({
               ...logData,
               name: 'bounty-award',
               type: 'info',
@@ -465,7 +465,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
       }
 
       // 8. Check if all benefactors have awarded (use tx context for consistency)
-      await logToAxiom({
+      logToAxiom({
         ...logData,
         name: 'bounty-award',
         type: 'info',
@@ -482,7 +482,7 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
 
       // 9. Mark bounty as complete only if ALL benefactors have awarded
       if (!unawardedBountyBenefactors) {
-        await logToAxiom({
+        logToAxiom({
           ...logData,
           name: 'bounty-award',
           type: 'info',
@@ -494,14 +494,14 @@ export const awardBountyEntry = async ({ id, userId }: { id: number; userId: num
           data: { complete: true },
         });
 
-        await logToAxiom({
+        logToAxiom({
           ...logData,
           name: 'bounty-award',
           type: 'info',
           message: 'Bounty marked as complete',
         }).catch(() => null);
       } else {
-        await logToAxiom({
+        logToAxiom({
           ...logData,
           name: 'bounty-award',
           type: 'info',

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -621,10 +621,28 @@ export const deleteVersionById = async ({ id }: GetByIdInput) => {
 
     const deleted = await tx.modelVersion.delete({ where: { id } });
     await updateModelLastVersionAt({ id: deleted.modelId, tx });
-    await deleteBidsForModelVersion({ modelVersionId: id });
 
     return deleted;
   });
+
+  // Post-commit: deleteBidsForModelVersion issues external Buzz refunds
+  // (buzzApiFetch + retries) and notifications. It runs on its own connection
+  // (no tx), so awaiting it inside the interactive transaction only added an
+  // external HTTP round-trip to the txn's wall-clock budget for no atomicity
+  // benefit — a Postgres rollback can't undo a refund that already hit the Buzz
+  // ledger. Behavior change: a refund failure no longer rolls back the version
+  // delete (the delete is already committed); it's best-effort + logged here,
+  // consistent with the other post-commit side effects below.
+  try {
+    await deleteBidsForModelVersion({ modelVersionId: id });
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'model-version-delete-bids',
+      message: `Failed to delete/refund bids for deleted model version ${id}`,
+      error,
+    });
+  }
 
   // Post-commit: Redis-level flags and cache busts must run only after the
   // Postgres transaction actually commits. Running them inside the txn would


### PR DESCRIPTION
## Context

Follow-up to the Prisma interactive-transaction audit prompted by #2375 (profile cover-image ingest). #2377 already swept the `ingestImage`-in-transaction class across article/bounty/bountyEntry/club/etc. This PR cleans up two remaining spots where **non-DB I/O still runs inside an interactive transaction**, consuming the txn's wall-clock budget ("Transaction already closed: a commit cannot be executed on an expired transaction") for no atomicity benefit.

Scope is deliberately the **safe subset** — logging + a no-`tx` refund call. The Buzz *charge/transaction* calls inside `createBounty` and `awardBountyEntry` are intentionally left for a separate, carefully-reviewed change (a Postgres rollback can't undo an external Buzz charge, so moving them needs charge→tx→refund-on-failure compensation logic).

## Changes

### `awardBountyEntry` (bountyEntry.service.ts)
The transaction body was instrumented with ~15 **awaited** `logToAxiom()` breadcrumbs — each an external Axiom HTTP POST adding a serial round-trip inside the 30s txn budget. They already carried `.catch(() => null)`, so this just **drops the `await`** → fire-and-forget, no longer blocking the transaction. Log signal preserved; ordering relative to DB ops is no longer guaranteed (fine for info breadcrumbs). The Buzz transaction calls inside the txn are **unchanged**.

### `deleteVersionById` (model-version.service.ts)
`deleteBidsForModelVersion` issues external Buzz **refunds** (`buzzApiFetch` + retries) + notifications and already runs on its **own connection** (no `tx`) — awaiting it inside the interactive txn only added an HTTP round-trip to the budget. Moved it into the **existing post-commit best-effort block** alongside the lag-flag / cache-bust / S3-cleanup steps.

**Behavior change (documented in-code):** a refund failure no longer rolls back the already-committed version delete; it's best-effort + logged, consistent with the sibling post-commit side effects. `deleteBidsForModelVersion` has its own retry logic.

## Testing
- `tsc --noEmit`: error-neutral vs baseline (8 pre-existing Prisma-client-drift errors in model-version.service.ts both before and after — unrelated to this diff; regenerated client clears them).
- No behavior change beyond the two documented relocations; both transactions retain their full DB-write set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)