### PR TITLE
fix(oauth): map userinfo name claim to username, not display name

### DIFF
--- a/src/pages/api/auth/oauth/userinfo.ts
+++ b/src/pages/api/auth/oauth/userinfo.ts
@@ -49,9 +49,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     sub: user.id.toString(),
     id: user.id,
     username: user.username,
-    // OIDC standard profile claims
+    // OIDC standard profile claims. `name` intentionally mirrors the username
+    // rather than `user.name`: the display name is only ever populated by our
+    // own OAuth ingestion from upstream providers (Google, etc.), is not
+    // user-settable, and we don't want to hand that PII to third-party apps.
     preferred_username: user.username ?? undefined,
-    name: user.name ?? user.username ?? undefined,
+    name: user.username ?? undefined,
     picture: user.image ?? undefined,
     image: user.image,
     ...(user.email ? { email: user.email, email_verified: !!user.emailVerified } : {}),


### PR DESCRIPTION
﻿Follow-up to #2378.

The OIDC `name` claim on `/api/auth/oauth/userinfo` fell back to `user.name` — the free-text display name that is **only ever populated by our own OAuth ingestion from upstream providers** (Google, etc.), is not user-settable, and isn't something we want to hand to third-party apps.

This maps `name` to the **username** instead (matching `preferred_username`), so userinfo never leaks the upstream display name. No other claim changes.

```diff
- name: user.name ?? user.username ?? undefined,
+ name: user.username ?? undefined,
```

Docs updated in companion PR civitai/civitai-developer-docs#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
