### PR TITLE
fix(redeemableCode): compute subscription periods in UTC to avoid DST drift

### DIFF
--- a/src/server/services/__tests__/redeemableCode.service.test.ts
+++ b/src/server/services/__tests__/redeemableCode.service.test.ts
@@ -367,8 +367,10 @@ describe('redeemableCode.service', () => {
         await consumeRedeemableCode({ code: 'MB-TEST-1234', userId: 1 });
 
         // Verify period end is 3 months from currentPeriodStart (unitValue = 3, interval = month)
-        const periodStart = dayjs(createdSubscription.currentPeriodStart);
-        const periodEnd = dayjs(createdSubscription.currentPeriodEnd);
+        // Compare in UTC so the assertion is independent of the runner's local timezone /
+        // DST transitions (wrapping the dates in local-tz dayjs() makes diff() drift across DST).
+        const periodStart = dayjs.utc(createdSubscription.currentPeriodStart);
+        const periodEnd = dayjs.utc(createdSubscription.currentPeriodEnd);
         const monthsDiff = periodEnd.diff(periodStart, 'month');
         expect(monthsDiff).toBe(3);
       });

--- a/src/server/services/__tests__/redeemableCode.service.test.ts
+++ b/src/server/services/__tests__/redeemableCode.service.test.ts
@@ -366,13 +366,16 @@ describe('redeemableCode.service', () => {
 
         await consumeRedeemableCode({ code: 'MB-TEST-1234', userId: 1 });
 
-        // Verify period end is 3 months from currentPeriodStart (unitValue = 3, interval = month)
-        // Compare in UTC so the assertion is independent of the runner's local timezone /
-        // DST transitions (wrapping the dates in local-tz dayjs() makes diff() drift across DST).
-        const periodStart = dayjs.utc(createdSubscription.currentPeriodStart);
-        const periodEnd = dayjs.utc(createdSubscription.currentPeriodEnd);
-        const monthsDiff = periodEnd.diff(periodStart, 'month');
-        expect(monthsDiff).toBe(3);
+        // periodEnd must equal periodStart + 3 months (unitValue = 3, interval = month),
+        // computed in UTC. Exact-instant equality (not a coarse month-diff) so a 1-hour
+        // DST drift fails the assertion in EVERY timezone — matching the extension/upgrade
+        // guards. (A month-diff alone only flips for some TZ/season combinations and can
+        // silently pass through the drift.)
+        const expectedEnd = dayjs
+          .utc(createdSubscription.currentPeriodStart)
+          .add(3, 'month')
+          .toDate();
+        expect(createdSubscription.currentPeriodEnd.getTime()).toBe(expectedEnd.getTime());
       });
 
       it('should create N tokens where N equals unitValue, with first unlocked', async () => {

--- a/src/server/services/redeemableCode.service.ts
+++ b/src/server/services/redeemableCode.service.ts
@@ -458,7 +458,8 @@ export async function consumeRedeemableCode({
                     prepaids: {}, // Clear legacy counter — tokens array is now the source of truth
                   },
                   status: 'active',
-                  currentPeriodEnd: dayjs(activeUserMembership.currentPeriodEnd)
+                  currentPeriodEnd: dayjs
+                    .utc(activeUserMembership.currentPeriodEnd)
                     .add(
                       consumedCode.unitValue,
                       consumedCode.price.interval as 'day' | 'month' | 'year'
@@ -468,7 +469,7 @@ export async function consumeRedeemableCode({
               });
             } else if (consumedTierOrder > membershipTierOrder) {
               // Upgrade to higher tier: first token unlocked, rest locked
-              const now = dayjs();
+              const now = dayjs.utc();
               const proratedDays =
                 dayjs(activeUserMembership.currentPeriodEnd).diff(now, 'days') -
                 existingTokens.filter(
@@ -537,7 +538,7 @@ export async function consumeRedeemableCode({
 
         if (!activeUserMembership) {
           // New user: first token unlocked (user must claim manually), rest locked
-          const now = dayjs();
+          const now = dayjs.utc();
           const buzzAmount = Number(consumedProductMetadata.monthlyBuzz ?? 5000);
           const newTokens = createPrepaidTokens({
             count: consumedCode.unitValue,


### PR DESCRIPTION
## Problem

Two unit tests in `src/server/services/__tests__/redeemableCode.service.test.ts` fail on `main` when run in any DST-observing timezone (they pass in CI only because GitHub Actions runners are UTC):

- `Same Tier Extension > should extend currentPeriodEnd correctly`
- `Upgrade (User has lower tier) > should reset currentPeriodStart and compute new currentPeriodEnd on upgrade`

Both fail by **exactly one hour** (e.g. expected `1713175200000`, got `1713171600000`).

## Root cause — a real service bug, not test fragility

`consumeRedeemableCode` computed `currentPeriodStart` / `currentPeriodEnd` with **local-time** `dayjs(...)`:

```ts
const now = dayjs();                 // anchored to process TZ
now.add(unitValue, interval);        // preserves wall-clock, not the UTC instant
dayjs(currentPeriodEnd).add(...);    // same problem on extension
```

`.add(N, 'month')` on a local-time dayjs preserves the wall-clock time. When the period spans a DST transition, the wall clock is preserved but the **absolute UTC instant shifts by one hour** — so a subscription's period end drifts by an hour for any user in a DST-observing timezone. The tests already assert the correct UTC behavior (`dayjs.utc(...).add(...)`), which is why they expose the defect.

Reproduction under `TZ=America/New_York` (Feb 15 → Apr 15 crosses US DST start):

```
local .add(2,month): 1713135600000   (what the service produced — wrong)
utc   .add(2,month): 1713139200000   (correct, +1h)
```

## Fix

Switch all three subscription-period computations in the service to `dayjs.utc()` so boundaries are timezone- and DST-independent:

- same-tier extension (`dayjs(currentPeriodEnd)` → `dayjs.utc(currentPeriodEnd)`)
- tier upgrade (`const now = dayjs()` → `dayjs.utc()`)
- new subscription (`const now = dayjs()` → `dayjs.utc()`)

Also hardened one TZ-fragile test assertion (the new-user test re-wrapped the dates in **local** `dayjs()` and used `diff(...,'month')`, which floors to 2 across a DST transition such as Australia/Sydney even with correct dates). It now compares in `dayjs.utc()` — consistent with its sibling tests — and still asserts 3 months. No product behavior change there.

## Verification

`redeemableCode.service.test.ts` passes **27/27** under `TZ=UTC`, `America/New_York`, `Australia/Sydney`, and `Asia/Kolkata`. No regressions in the broader unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)