### PR TITLE
feat(observability): on-demand V8 CPU profiler via process signal

### DIFF
--- a/claudedocs/cpu-profile-capture.md
+++ b/claudedocs/cpu-profile-capture.md
@@ -26,9 +26,14 @@ armed from `src/instrumentation.node.ts`) uses the in-process `node:inspector`
 - **Zero steady-state overhead.** Nothing runs until the signal arrives.
 - **In-process** — does NOT require the inspector port (`:9229`) to be open.
 - **Safe** — a second signal during an in-flight capture is ignored; all work is
-  wrapped in try/catch so a profiling failure can never crash the process; the
-  capture timer is `unref`'d so it never blocks shutdown. Server-side (nodejs
-  runtime) only.
+  wrapped in try/catch so a profiling failure can never crash the process; an
+  invalid `CPU_PROFILE_SIGNAL` logs a warning and no-ops (it does not throw, so
+  it can never take down the OTEL bootstrap). The 25s capture timer is a normal
+  ref'd timer so the bounded capture actually fires even on an idle pod
+  (rehearsal/validation) — it cannot meaningfully delay shutdown given
+  `terminationGracePeriodSeconds: 60` + the 20s preStop. If a capture is
+  interrupted before the profile is written, a warning is logged (never silent).
+  Server-side (nodejs runtime) only.
 
 ### Signal choice (important)
 
@@ -48,7 +53,7 @@ that Kubernetes never sends. It is overridable via `CPU_PROFILE_SIGNAL`.
 
 | Env var               | Default     | Meaning                                  |
 | --------------------- | ----------- | ---------------------------------------- |
-| `CPU_PROFILE_SECONDS` | `25`        | Capture duration in seconds              |
+| `CPU_PROFILE_SECONDS` | `25`        | Capture duration in seconds (clamped to a max of 120) |
 | `CPU_PROFILE_SIGNAL`  | `SIGWINCH`  | Signal that triggers a capture           |
 | `CPU_PROFILE_DIR`     | `/tmp`      | Output directory (must be writable)      |
 
@@ -85,15 +90,29 @@ prints the exact filename and the retrieval command.
 ## How to retrieve
 
 `curl` is **absent** from the container, but `tar` is present, so `kubectl cp`
-works:
+works. Note `kubectl cp` strips/rejects a leading `/` on the source path, so the
+source is passed **without** the leading slash (this matches the path printed in
+the completion log line):
 
 ```bash
 FILE=$(kubectl exec -n civitai-dp-prod "$POD" -- sh -c 'ls -t /tmp/*.cpuprofile | head -1')
-kubectl cp "civitai-dp-prod/${POD}:${FILE}" "./$(basename "$FILE")"
+# strip the leading slash from the source path for kubectl cp:
+kubectl cp "civitai-dp-prod/${POD}:${FILE#/}" "./$(basename "$FILE")"
 ```
 
-(`kubectl cp` strips a leading `/`; if it complains, pass the path without the
-leading slash: `civitai-dp-prod/${POD}:tmp/...`.)
+(The completion log prints the source with the slash already stripped and a
+`<namespace>` placeholder — swap in the real namespace, which is
+`civitai-dp-prod` for prod, but differs for `civitai-next` / `civitai-app` /
+PR previews.)
+
+## Cleanup
+
+`.cpuprofile` files persist in the pod's `/tmp` until the pod restarts. After
+retrieving, remove them so they don't accumulate:
+
+```bash
+kubectl exec -n civitai-dp-prod "$POD" -- rm -f /tmp/cpu-*.cpuprofile
+```
 
 ## How to view
 

--- a/claudedocs/cpu-profile-capture.md
+++ b/claudedocs/cpu-profile-capture.md
@@ -79,8 +79,37 @@ kubectl exec -n civitai-dp-prod "$POD" -- kill -WINCH 1
 kubectl logs -n civitai-dp-prod "$POD" --tail=20 | grep cpu-profiler
 ```
 
+> **Do not** run an external `:9229` heap snapshot (the cluster `heap-snapshot`
+> skill / `kill -USR1 1`) and a CPU profile on the same pod at the same time —
+> both drive the V8 inspector `Profiler` domain and may error.
+
 The capture runs for `CPU_PROFILE_SECONDS` (default 25s). The completion log line
 prints the exact filename and the retrieval command.
+
+### What this profile captures (and a wedged-loop caveat)
+
+This profiler captures **cumulative / multi-turn** event-loop saturation — many
+JS turns adding up to a pinned core over the capture window — which is the
+actual incident class here (the API pods peg ~1.0 core across a traffic wave,
+not in one giant synchronous call). It samples the running stack across that
+window, so it shows the functions that dominate self-time over all those turns.
+
+A single unyielding **synchronous** turn is the one case it can miss: the signal
+handler only runs when the event loop next yields, so a loop wedged inside one
+long synchronous turn can **delay or entirely prevent the handler from
+starting**. After firing the signal, **confirm the `capture started` log line
+appears**:
+
+```bash
+kubectl logs -n civitai-dp-prod "$POD" --tail=20 | grep 'capture started'
+```
+
+If it does **not** appear and `kubectl top pods` still shows the pod pinned at
+~1.0 core, the loop is wedged in a single long synchronous turn and the profiler
+cannot start — **that itself is a finding** (it narrows the cause to one
+unyielding turn rather than cumulative saturation; investigate with a different
+tool, e.g. an external `:9229` profile attached before the wedge, or code review
+of suspect synchronous paths).
 
 ## Where the file lands
 

--- a/claudedocs/cpu-profile-capture.md
+++ b/claudedocs/cpu-profile-capture.md
@@ -1,0 +1,118 @@
+# On-demand V8 CPU profiling for civitai-web pods
+
+Capture a real V8 CPU profile from a running civitai-dp-prod (or any civitai-web)
+pod that is CPU-saturating the single Node thread, so we can see which JS
+functions actually burn the CPU during a saturation wave.
+
+## Why this exists
+
+civitai-dp-prod API pods periodically peg the Node main thread at ~1.0 core
+during traffic waves. The event loop then can't answer health probes in time
+and the pod is SIGKILLed. The CPU consumer is **not** visible in any
+instrumented span (the slow image feeds are I/O-bound on Meilisearch; superjson
+is ~10ms). The only way to identify it is a V8 CPU profile taken on a saturated
+pod.
+
+The deployment previously had **no** CPU-profile mechanism — `NODE_OPTIONS` only
+carried `--heapsnapshot-signal=SIGUSR2` (heap, not CPU).
+
+## Mechanism
+
+A signal handler registered at server startup (in `src/server/cpu-profiler.ts`,
+armed from `src/instrumentation.node.ts`) uses the in-process `node:inspector`
+`Session` API: `Profiler.enable` → `Profiler.start` → wait `CPU_PROFILE_SECONDS`
+→ `Profiler.stop` → write the `.cpuprofile` JSON to disk.
+
+- **Zero steady-state overhead.** Nothing runs until the signal arrives.
+- **In-process** — does NOT require the inspector port (`:9229`) to be open.
+- **Safe** — a second signal during an in-flight capture is ignored; all work is
+  wrapped in try/catch so a profiling failure can never crash the process; the
+  capture timer is `unref`'d so it never blocks shutdown. Server-side (nodejs
+  runtime) only.
+
+### Signal choice (important)
+
+The obvious signals are both taken on these pods:
+
+- **SIGUSR2** is claimed by Node's `--heapsnapshot-signal=SIGUSR2` flag.
+- **SIGUSR1** is Node's built-in "open the inspector port" signal. The cluster
+  `heap-snapshot` skill relies on it: `kubectl exec <pod> -- kill -USR1 1` opens
+  `:9229`, then drives `HeapProfiler.takeHeapSnapshot` over CDP. Registering a
+  userland `SIGUSR1` listener would **override** that default and break heap
+  snapshots.
+
+So the default trigger is **`SIGWINCH`** — a no-op for a non-TTY server process
+that Kubernetes never sends. It is overridable via `CPU_PROFILE_SIGNAL`.
+
+## Tunables (env vars, no rebuild needed)
+
+| Env var               | Default     | Meaning                                  |
+| --------------------- | ----------- | ---------------------------------------- |
+| `CPU_PROFILE_SECONDS` | `25`        | Capture duration in seconds              |
+| `CPU_PROFILE_SIGNAL`  | `SIGWINCH`  | Signal that triggers a capture           |
+| `CPU_PROFILE_DIR`     | `/tmp`      | Output directory (must be writable)      |
+
+`/tmp` is the right default: the container's cwd (`/app`) is **read-only** in
+the Next.js standalone image (this is also why heap snapshots go to `/tmp`).
+`/tmp` is writable and `tar` is present in the image, so `kubectl cp` works.
+
+## How to trigger
+
+PID 1 is the Node process in these pods.
+
+```bash
+POD=$(kubectl get pods -n civitai-dp-prod -l app=civitai-dp-prod-api \
+  --field-selector status.phase=Running -o name | head -1 | cut -d/ -f2)
+
+# (optional) pick the hottest pod instead:
+kubectl top pods -n civitai-dp-prod --sort-by=cpu | head
+
+# Fire the capture (default SIGWINCH). The handler logs start + the exact path.
+kubectl exec -n civitai-dp-prod "$POD" -- kill -WINCH 1
+
+# Watch for the start/complete log lines (they include the full file path):
+kubectl logs -n civitai-dp-prod "$POD" --tail=20 | grep cpu-profiler
+```
+
+The capture runs for `CPU_PROFILE_SECONDS` (default 25s). The completion log line
+prints the exact filename and the retrieval command.
+
+## Where the file lands
+
+`/tmp/cpu-<podname>-<ISO8601>.cpuprofile` inside the pod, e.g.
+`/tmp/cpu-civitai-dp-prod-api-7499d9d7f-d9khv-2026-06-03T13-52-01-123Z.cpuprofile`.
+
+## How to retrieve
+
+`curl` is **absent** from the container, but `tar` is present, so `kubectl cp`
+works:
+
+```bash
+FILE=$(kubectl exec -n civitai-dp-prod "$POD" -- sh -c 'ls -t /tmp/*.cpuprofile | head -1')
+kubectl cp "civitai-dp-prod/${POD}:${FILE}" "./$(basename "$FILE")"
+```
+
+(`kubectl cp` strips a leading `/`; if it complains, pass the path without the
+leading slash: `civitai-dp-prod/${POD}:tmp/...`.)
+
+## How to view
+
+- **Chrome DevTools**: open DevTools → **Performance** tab → "Load profile…" →
+  select the `.cpuprofile`. The bottom-up / call-tree views show self-time hot
+  functions.
+- **speedscope**: drag the file onto <https://speedscope.app> (runs fully
+  client-side). The "Left Heavy" view is the fastest way to spot the dominant
+  CPU consumer.
+
+## Deployment wiring (datapacket-talos)
+
+To override the duration without a rebuild, add to the API deployment's `env:`
+in `clusters/production/apps/civitai-dp-prod/deployment-api.yaml`:
+
+```yaml
+- name: CPU_PROFILE_SECONDS
+  value: "30"
+```
+
+No NODE_OPTIONS change is required — the profiler arms itself from the
+instrumentation hook on every server start.

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -12,6 +12,12 @@ import { trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { PrismaInstrumentation } from '@prisma/instrumentation';
 import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
+import { registerCpuProfiler } from '~/server/cpu-profiler';
+
+// Arm the on-demand, signal-triggered V8 CPU profiler. Zero steady-state
+// overhead; only does work when signalled. Independent of OTEL so it is
+// always available for live incident capture. See src/server/cpu-profiler.ts.
+registerCpuProfiler();
 
 // Only enable OTEL if explicitly set AND endpoint is configured
 const OTEL_ENABLED = process.env.OTEL_ENABLED === 'true';

--- a/src/server/cpu-profiler.ts
+++ b/src/server/cpu-profiler.ts
@@ -1,0 +1,159 @@
+// On-demand V8 CPU profiler, triggered by a process signal.
+//
+// WHY: civitai-dp-prod API pods periodically CPU-saturate the single Node
+// thread (p95 pod CPU = 1.0 core) during traffic waves, starving the event
+// loop until liveness probes fail and the pod is SIGKILLed. The CPU consumer
+// is not visible in any instrumented span. A real V8 CPU profile from a
+// saturated pod is the only way to see which JS functions burn the CPU.
+//
+// This registers a signal handler that, on demand, captures a `.cpuprofile`
+// (Chrome DevTools / speedscope format) via the in-process `node:inspector`
+// Session API and writes it to a retrievable, writable directory. It does
+// ZERO work until signalled — no steady-state overhead.
+//
+// SIGNAL CHOICE: SIGUSR2 is already claimed by Node's `--heapsnapshot-signal`
+// flag, and SIGUSR1 is Node's built-in "open the inspector port" signal that
+// the cluster heap-snapshot tooling relies on (`kill -USR1 1` opens :9229,
+// which `HeapProfiler.takeHeapSnapshot` is then driven over). Registering a
+// userland SIGUSR1 listener would OVERRIDE that default and break heap
+// snapshots. So the default trigger is SIGWINCH — a no-op for a non-TTY
+// server process that Kubernetes never sends — and the signal is overridable
+// via CPU_PROFILE_SIGNAL for operators who know what they are doing.
+//
+// Server-side (nodejs runtime) only. Never imported on the edge/client.
+
+import inspector from 'node:inspector';
+import { writeFile } from 'node:fs/promises';
+import { hostname } from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_SIGNAL = 'SIGWINCH';
+const DEFAULT_DURATION_SECONDS = 25;
+const DEFAULT_OUTPUT_DIR = '/tmp';
+
+let capturing = false;
+
+function resolveSignal(): NodeJS.Signals {
+  const raw = (process.env.CPU_PROFILE_SIGNAL || DEFAULT_SIGNAL).trim();
+  return raw as NodeJS.Signals;
+}
+
+function resolveDurationMs(): number {
+  const raw = process.env.CPU_PROFILE_SECONDS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  const seconds = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DURATION_SECONDS;
+  return seconds * 1000;
+}
+
+function resolveOutputDir(): string {
+  return (process.env.CPU_PROFILE_DIR || DEFAULT_OUTPUT_DIR).trim();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    // unref so a pending capture never holds the process open on shutdown.
+    setTimeout(resolve, ms).unref();
+  });
+}
+
+/**
+ * Run a single CPU profile capture using an in-process inspector Session.
+ * Resolves once the .cpuprofile has been written (or rejects on failure).
+ * Does NOT need the inspector port (:9229) to be open.
+ */
+async function captureProfile(): Promise<string> {
+  const durationMs = resolveDurationMs();
+  const outputDir = resolveOutputDir();
+  const pod = process.env.HOSTNAME || hostname();
+  const iso = new Date().toISOString().replace(/[:.]/g, '-');
+  const filePath = path.join(outputDir, `cpu-${pod}-${iso}.cpuprofile`);
+
+  const session = new inspector.Session();
+
+  // Promisified inspector.Session#post — the callback form is the only API.
+  const post = <T>(method: string, params?: Record<string, unknown>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      // The typings only expose specific method overloads; cast through unknown
+      // to keep this generic without fighting the union of literal signatures.
+      (
+        session.post as unknown as (
+          m: string,
+          p: Record<string, unknown> | undefined,
+          cb: (err: Error | null, res: T) => void
+        ) => void
+      )(method, params, (err, res) => (err ? reject(err) : resolve(res)));
+    });
+
+  try {
+    session.connect();
+
+    await post('Profiler.enable');
+    await post('Profiler.start');
+
+    console.log(`[cpu-profiler] capture started: duration=${durationMs / 1000}s -> ${filePath}`);
+
+    await delay(durationMs);
+
+    const { profile } = await post<{ profile: unknown }>('Profiler.stop');
+
+    await writeFile(filePath, JSON.stringify(profile), 'utf8');
+
+    console.log(
+      `[cpu-profiler] capture complete: wrote ${filePath}. ` +
+        `Retrieve with: kubectl cp civitai-dp-prod/${pod}:${filePath} ./${path.basename(
+          filePath
+        )} ` +
+        `then open in Chrome DevTools (Performance > Load profile) or https://speedscope.app`
+    );
+
+    return filePath;
+  } finally {
+    try {
+      await post('Profiler.disable');
+    } catch {
+      // best-effort cleanup
+    }
+    try {
+      session.disconnect();
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+/**
+ * Register the on-demand CPU profiler signal handler.
+ * Safe to call once at server startup. No-op off the nodejs runtime.
+ */
+export function registerCpuProfiler(): void {
+  if (process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME !== 'nodejs') {
+    return;
+  }
+
+  const signal = resolveSignal();
+
+  process.on(signal, () => {
+    if (capturing) {
+      console.log(
+        `[cpu-profiler] ${signal} received but a capture is already in progress; ignoring.`
+      );
+      return;
+    }
+
+    capturing = true;
+    captureProfile()
+      .catch((err) => {
+        // A profiling failure must never crash the process.
+        console.error('[cpu-profiler] capture failed:', err);
+      })
+      .finally(() => {
+        capturing = false;
+      });
+  });
+
+  console.log(
+    `[cpu-profiler] armed: send ${signal} to PID 1 to capture a ` +
+      `${resolveDurationMs() / 1000}s CPU profile to ${resolveOutputDir()} ` +
+      `(override with CPU_PROFILE_SIGNAL / CPU_PROFILE_SECONDS / CPU_PROFILE_DIR)`
+  );
+}

--- a/src/server/cpu-profiler.ts
+++ b/src/server/cpu-profiler.ts
@@ -174,8 +174,8 @@ async function captureProfile(): Promise<string> {
     }
     if (!wrote) {
       console.warn(
-        `[cpu-profiler] capture interrupted: no profile written to ${filePath} ` +
-          `(capture aborted before Profiler.stop, e.g. by shutdown).`
+        `[cpu-profiler] CPU profile capture did not complete (inspector or write error); ` +
+          `no profile written to ${filePath}.`
       );
     }
     try {

--- a/src/server/cpu-profiler.ts
+++ b/src/server/cpu-profiler.ts
@@ -29,7 +29,42 @@ import path from 'node:path';
 
 const DEFAULT_SIGNAL = 'SIGWINCH';
 const DEFAULT_DURATION_SECONDS = 25;
+const MAX_DURATION_SECONDS = 120;
 const DEFAULT_OUTPUT_DIR = '/tmp';
+
+// Known Node.js signal names that can be the target of a userland process.on
+// listener. A bogus CPU_PROFILE_SIGNAL must not throw ERR_UNKNOWN_SIGNAL at
+// arm-time (that would take down the whole instrumentation register()).
+const KNOWN_SIGNALS = new Set<string>([
+  'SIGHUP',
+  'SIGINT',
+  'SIGQUIT',
+  'SIGILL',
+  'SIGTRAP',
+  'SIGABRT',
+  'SIGBUS',
+  'SIGFPE',
+  'SIGUSR1',
+  'SIGUSR2',
+  'SIGSEGV',
+  'SIGPIPE',
+  'SIGALRM',
+  'SIGTERM',
+  'SIGCHLD',
+  'SIGCONT',
+  'SIGTSTP',
+  'SIGTTIN',
+  'SIGTTOU',
+  'SIGURG',
+  'SIGXCPU',
+  'SIGXFSZ',
+  'SIGVTALRM',
+  'SIGPROF',
+  'SIGWINCH',
+  'SIGIO',
+  'SIGPWR',
+  'SIGSYS',
+]);
 
 let capturing = false;
 
@@ -38,10 +73,20 @@ function resolveSignal(): NodeJS.Signals {
   return raw as NodeJS.Signals;
 }
 
+function resolvePodName(): string {
+  // PODNAME is injected explicitly by the deployment (metadata.name);
+  // HOSTNAME is the implicit fallback, then the OS hostname.
+  return process.env.PODNAME || process.env.HOSTNAME || hostname();
+}
+
 function resolveDurationMs(): number {
   const raw = process.env.CPU_PROFILE_SECONDS;
   const parsed = raw ? Number.parseInt(raw, 10) : NaN;
-  const seconds = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DURATION_SECONDS;
+  let seconds = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DURATION_SECONDS;
+  // Clamp (don't throw) so a fat-fingered env can't request a multi-minute profile.
+  if (seconds > MAX_DURATION_SECONDS) {
+    seconds = MAX_DURATION_SECONDS;
+  }
   return seconds * 1000;
 }
 
@@ -49,11 +94,17 @@ function resolveOutputDir(): string {
   return (process.env.CPU_PROFILE_DIR || DEFAULT_OUTPUT_DIR).trim();
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    // unref so a pending capture never holds the process open on shutdown.
-    setTimeout(resolve, ms).unref();
+function delay(ms: number): { promise: Promise<void>; timer: NodeJS.Timeout } {
+  let timer!: NodeJS.Timeout;
+  const promise = new Promise<void>((resolve) => {
+    // NOT unref'd: a bounded capture timer must actually fire even on an idle
+    // pod (rehearsal/validation), otherwise the loop drains, the timer never
+    // fires, and Profiler.stop + write silently never happen. A 25s ref'd timer
+    // cannot meaningfully delay shutdown (terminationGracePeriodSeconds: 60 +
+    // 20s preStop).
+    timer = setTimeout(resolve, ms);
   });
+  return { promise, timer };
 }
 
 /**
@@ -64,11 +115,15 @@ function delay(ms: number): Promise<void> {
 async function captureProfile(): Promise<string> {
   const durationMs = resolveDurationMs();
   const outputDir = resolveOutputDir();
-  const pod = process.env.HOSTNAME || hostname();
+  const pod = resolvePodName();
   const iso = new Date().toISOString().replace(/[:.]/g, '-');
   const filePath = path.join(outputDir, `cpu-${pod}-${iso}.cpuprofile`);
 
   const session = new inspector.Session();
+  // Track whether we actually wrote a profile so an interrupted capture
+  // (shutdown / timer cleared) is never silent.
+  let wrote = false;
+  let captureTimer: NodeJS.Timeout | undefined;
 
   // Promisified inspector.Session#post — the callback form is the only API.
   const post = <T>(method: string, params?: Record<string, unknown>): Promise<T> =>
@@ -92,22 +147,37 @@ async function captureProfile(): Promise<string> {
 
     console.log(`[cpu-profiler] capture started: duration=${durationMs / 1000}s -> ${filePath}`);
 
-    await delay(durationMs);
+    const { promise, timer } = delay(durationMs);
+    captureTimer = timer;
+    await promise;
 
     const { profile } = await post<{ profile: unknown }>('Profiler.stop');
 
     await writeFile(filePath, JSON.stringify(profile), 'utf8');
+    wrote = true;
 
+    // kubectl cp strips/rejects a leading slash on the source path, so pass the
+    // path without it. The namespace differs across deployments
+    // (civitai-dp-prod / civitai-next / civitai-app / PR previews), so leave it
+    // as a placeholder for the operator to fill in.
+    const cpSource = filePath.replace(/^\/+/, '');
     console.log(
       `[cpu-profiler] capture complete: wrote ${filePath}. ` +
-        `Retrieve with: kubectl cp civitai-dp-prod/${pod}:${filePath} ./${path.basename(
-          filePath
-        )} ` +
+        `Retrieve with: kubectl cp <namespace>/${pod}:${cpSource} ./${path.basename(filePath)} ` +
         `then open in Chrome DevTools (Performance > Load profile) or https://speedscope.app`
     );
 
     return filePath;
   } finally {
+    if (captureTimer) {
+      clearTimeout(captureTimer);
+    }
+    if (!wrote) {
+      console.warn(
+        `[cpu-profiler] capture interrupted: no profile written to ${filePath} ` +
+          `(capture aborted before Profiler.stop, e.g. by shutdown).`
+      );
+    }
     try {
       await post('Profiler.disable');
     } catch {
@@ -126,34 +196,50 @@ async function captureProfile(): Promise<string> {
  * Safe to call once at server startup. No-op off the nodejs runtime.
  */
 export function registerCpuProfiler(): void {
-  if (process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME !== 'nodejs') {
-    return;
-  }
+  // Arm-time failures must never reject the caller (the OTEL instrumentation
+  // register()). Wrap the whole body so any unexpected error logs and no-ops.
+  try {
+    if (process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME !== 'nodejs') {
+      return;
+    }
 
-  const signal = resolveSignal();
+    const signal = resolveSignal();
 
-  process.on(signal, () => {
-    if (capturing) {
-      console.log(
-        `[cpu-profiler] ${signal} received but a capture is already in progress; ignoring.`
+    // An unknown signal name would make process.on(signal, …) throw
+    // ERR_UNKNOWN_SIGNAL. Validate first and no-op (don't arm) rather than
+    // throw, so a bogus CPU_PROFILE_SIGNAL can't take down OTEL on boot.
+    if (!KNOWN_SIGNALS.has(signal)) {
+      console.warn(
+        `[cpu-profiler] not armed: CPU_PROFILE_SIGNAL="${signal}" is not a known Node signal; ignoring.`
       );
       return;
     }
 
-    capturing = true;
-    captureProfile()
-      .catch((err) => {
-        // A profiling failure must never crash the process.
-        console.error('[cpu-profiler] capture failed:', err);
-      })
-      .finally(() => {
-        capturing = false;
-      });
-  });
+    process.on(signal, () => {
+      if (capturing) {
+        console.log(
+          `[cpu-profiler] ${signal} received but a capture is already in progress; ignoring.`
+        );
+        return;
+      }
 
-  console.log(
-    `[cpu-profiler] armed: send ${signal} to PID 1 to capture a ` +
-      `${resolveDurationMs() / 1000}s CPU profile to ${resolveOutputDir()} ` +
-      `(override with CPU_PROFILE_SIGNAL / CPU_PROFILE_SECONDS / CPU_PROFILE_DIR)`
-  );
+      capturing = true;
+      captureProfile()
+        .catch((err) => {
+          // A profiling failure must never crash the process.
+          console.error('[cpu-profiler] capture failed:', err);
+        })
+        .finally(() => {
+          capturing = false;
+        });
+    });
+
+    console.log(
+      `[cpu-profiler] armed: send ${signal} to PID 1 to capture a ` +
+        `${resolveDurationMs() / 1000}s CPU profile to ${resolveOutputDir()} ` +
+        `(override with CPU_PROFILE_SIGNAL / CPU_PROFILE_SECONDS / CPU_PROFILE_DIR)`
+    );
+  } catch (err) {
+    console.error('[cpu-profiler] failed to arm; continuing without CPU profiler:', err);
+  }
 }


### PR DESCRIPTION
## Why

civitai-dp-prod API pods periodically CPU-saturate the single Node thread (p95 pod CPU = 1.0 core) during traffic waves. The event loop then can't answer health probes in time and the pod is SIGKILLed. The CPU consumer is **not** visible in any instrumented span (the slow image feeds are I/O-bound on Meilisearch; superjson is ~10ms). Only a real V8 CPU profile from a saturated pod will reveal which JS functions burn the CPU.

The deployment previously had **no** CPU-profile mechanism — `NODE_OPTIONS` only carried `--heapsnapshot-signal=SIGUSR2` (heap, not CPU).

## What

A signal-triggered, in-process V8 CPU profiler with **zero steady-state overhead** (nothing runs until signalled):

- **`src/server/cpu-profiler.ts`** — on signal, uses the in-process `node:inspector` `Session` API (`Profiler.enable` → `start` → wait → `stop`) and writes a `.cpuprofile` to a writable dir.
  - Re-entrancy guarded (a second signal mid-capture is ignored).
  - Fully `try/catch`-wrapped — a profiling failure can never crash the process; `registerCpuProfiler()` self-protects so an arm-time error can never reject instrumentation `register()` and take OTEL down on boot.
  - An invalid `CPU_PROFILE_SIGNAL` logs a warning and no-ops (does not throw `ERR_UNKNOWN_SIGNAL`).
  - Capture timer is a normal **ref'd** timer so the bounded 25s capture fires even on an idle pod (rehearsal/validation); it cannot meaningfully delay shutdown (`terminationGracePeriodSeconds: 60` + 20s preStop). An interrupted capture logs a warning rather than failing silently.
  - `CPU_PROFILE_SECONDS` is clamped to a 120s max.
  - Server-side (`nodejs` runtime) only.
  - In-process — does **not** require the inspector port (`:9229`) to be open.
- Armed from **`src/instrumentation.node.ts`** (the existing Next.js server bootstrap hook), independent of OTEL so it's always available.
- Tunable without a rebuild via env:

  | Env var | Default | Meaning |
  |---|---|---|
  | `CPU_PROFILE_SECONDS` | `25` | Capture duration (max 120) |
  | `CPU_PROFILE_SIGNAL` | `SIGWINCH` | Trigger signal |
  | `CPU_PROFILE_DIR` | `/tmp` | Output dir (must be writable) |

## Signal choice (important)

The task suggested SIGUSR1, but in the live container both obvious signals are taken:

- **SIGUSR2** → claimed by `--heapsnapshot-signal=SIGUSR2`.
- **SIGUSR1** → Node's built-in "open the inspector port" signal. The cluster `heap-snapshot` tooling depends on it (`kubectl exec <pod> -- kill -USR1 1` opens `:9229`, then drives `HeapProfiler.takeHeapSnapshot` over CDP). Registering a userland `SIGUSR1` listener would **override** that default and break heap snapshots.

So the default trigger is **`SIGWINCH`** — a no-op for a non-TTY server process that Kubernetes never sends — overridable via `CPU_PROFILE_SIGNAL`.

## Retrieval

`curl` is **absent** from the standalone image, but `tar` **is** present and `/tmp` is writable (cwd `/app` is read-only — same reason heap snapshots go to `/tmp`), so `kubectl cp` works. Note `kubectl cp` strips/rejects a leading `/` on the source path, so it's passed without the leading slash (matching what the completion log prints):

```bash
POD=$(kubectl get pods -n civitai-dp-prod -l app=civitai-dp-prod-api -o name | head -1 | cut -d/ -f2)
kubectl exec -n civitai-dp-prod "$POD" -- kill -WINCH 1          # fire (default 25s)
kubectl logs -n civitai-dp-prod "$POD" --tail=20 | grep cpu-profiler   # logs the exact path
FILE=$(kubectl exec -n civitai-dp-prod "$POD" -- sh -c 'ls -t /tmp/*.cpuprofile | head -1')
kubectl cp "civitai-dp-prod/${POD}:${FILE#/}" "./$(basename "$FILE")"
# cleanup after retrieval:
kubectl exec -n civitai-dp-prod "$POD" -- rm -f /tmp/cpu-*.cpuprofile
```

(The completion log prints a `<namespace>` placeholder in its `kubectl cp` hint — swap in the real namespace; it's `civitai-dp-prod` for prod but differs for `civitai-next` / `civitai-app` / PR previews.)

View in Chrome DevTools (Performance → Load profile) or drag onto https://speedscope.app.

Full runbook: `claudedocs/cpu-profile-capture.md`.

## Audit fixes (this revision)

An independent audit flagged: (1) the capture timer was `unref`'d → a quiet/rehearsal pod or mid-SIGTERM capture could silently never write; (2) the logged `kubectl cp` command had a leading-slash source and a hardcoded namespace, so it wasn't copy-pasteable; (3) a bogus `CPU_PROFILE_SIGNAL` threw at arm-time and took OTEL down on boot. All addressed, plus explicit `PODNAME` preference and a `CPU_PROFILE_SECONDS` max clamp.

## Typecheck

`tsc --noEmit` produces **no** errors in the new/changed files (`cpu-profiler.ts`, `instrumentation.node.ts`). The repo's `main` is not clean under `tsc` (~5060 pre-existing errors in unrelated files); this PR adds zero (baseline vs. branch error lists are byte-identical). node_modules was symlinked from the primary clone to run the typecheck (consistent with prior PRs from this worktree setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
