### PR TITLE
feat(generation): reusable selection store with shift-click range select

### DIFF
--- a/src/components/ImageGeneration/Feed.tsx
+++ b/src/components/ImageGeneration/Feed.tsx
@@ -2,10 +2,8 @@ import { Alert, Center, Loader, Stack, Text, Anchor } from '@mantine/core';
 import { IconInbox } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { GeneratedOutput } from '~/components/ImageGeneration/GeneratedOutput';
-import {
-  matchesMarkerTags,
-  useGetTextToImageRequestsImages,
-} from '~/components/ImageGeneration/utils/generationRequestHooks';
+import { useGeneratedRequestsContext } from '~/components/ImageGeneration/GeneratedRequestsProvider';
+import { matchesMarkerTags } from '~/components/ImageGeneration/utils/generationRequestHooks';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { useFiltersContext } from '~/providers/FiltersProvider';
 import { generationGraphPanel } from '~/store/generation-graph.store';
@@ -15,8 +13,15 @@ import classes from './Feed.module.scss';
 export function Feed() {
   const filters = useFiltersContext((state) => state.generation);
 
-  const { requests, markerTags, isLoading, fetchNextPage, hasNextPage, isRefetching, isError } =
-    useGetTextToImageRequestsImages();
+  const {
+    data: requests,
+    markerTags,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isRefetching,
+    isError,
+  } = useGeneratedRequestsContext();
 
   const images = useMemo(
     () =>

--- a/src/components/ImageGeneration/GeneratedImageActions.tsx
+++ b/src/components/ImageGeneration/GeneratedImageActions.tsx
@@ -2,11 +2,14 @@ import { Button, Checkbox, Menu, Tooltip } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import { IconDownload, IconTrash, IconWand } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
-import pLimit from 'p-limit';
 import { useMemo, useState } from 'react';
 import { SortFilter } from '~/components/Filters';
 import { MarkerFiltersDropdown } from '~/components/ImageGeneration/MarkerFiltersDropdown';
-import { orchestratorImageSelect } from '~/components/ImageGeneration/utils/generationImage.select';
+import {
+  useActions,
+  useSelection,
+} from '~/components/ImageGeneration/utils/generationImage.select';
+import { downloadGeneratedImages } from '~/components/ImageGeneration/utils/downloadGeneratedImages';
 import type { UpdateImageStepMetadataArgs } from '~/components/ImageGeneration/utils/generationRequestHooks';
 import {
   useGetTextToImageRequests,
@@ -15,8 +18,6 @@ import {
 import { useTourContext } from '~/components/Tours/ToursProvider';
 import { generationGraphPanel } from '~/store/generation-graph.store';
 import { orchestratorMediaTransmitter } from '~/store/post-image-transmitter.store';
-import { fetchBlob } from '~/utils/file-utils';
-import { getJSZip } from '~/utils/lazy';
 import { showErrorNotification, showWarningNotification } from '~/utils/notifications';
 import { removeEmpty } from '~/utils/object-helpers';
 import { trpc } from '~/utils/trpc';
@@ -31,7 +32,6 @@ import {
   applyBulkWorkflow,
 } from '~/components/generation_v2/hooks/useGeneratedItemWorkflows';
 
-const limit = pLimit(10);
 export function GeneratedImageActions({
   actionIconSize = 'lg',
   iconSize = 20,
@@ -43,8 +43,9 @@ export function GeneratedImageActions({
   const { data } = useGetTextToImageRequests();
   const { running, helpers, returnUrl } = useTourContext();
   const selectableImages = useMemo(() => data.flatMap((wf) => wf.succeededOutput), [data]);
-  const selected = orchestratorImageSelect.useSelection();
-  const deselect = () => orchestratorImageSelect.setSelected([]);
+  const selected = useSelection();
+  const { setSelected } = useActions();
+  const deselect = () => setSelected([]);
   const [zipping, setZipping] = useState(false);
 
   const { updateImages, isLoading } = useUpdateImageStepMetadata({
@@ -142,50 +143,13 @@ export function GeneratedImageActions({
 
   async function downloadSelected() {
     setZipping(true);
-    const zip = await getJSZip();
-    await Promise.all(
-      selected.map((image, index) =>
-        limit(async () => {
-          if (!image.url) return;
-          const blob = await fetchBlob(image.url);
-          if (!blob) return;
-          let name = image.id;
-          const createdAt = image.workflow.createdAt;
-          if (createdAt) {
-            const dateString = createdAt.toISOString().replaceAll(':', '.').split('.');
-            dateString.pop();
-            name = `${dateString.join('.')}_${index + 1}`;
-          }
-
-          const file = new File([blob], name);
-          const ext = blob.type.split('/')[1]?.replace('jpeg', 'jpg') || 'jpg';
-          zip.file(`${name}.${ext}`, file);
-        })
-      )
-    );
-
-    zip
-      .generateAsync({ type: 'blob' })
-      .then(async (blob) => {
-        const createdAt = new Date().getTime();
-        const blobFile = new File([blob], `images_${createdAt}.zip`, {
-          type: 'application/zip',
-        });
-
-        const a = document.createElement('a');
-        const href = URL.createObjectURL(blobFile);
-        a.href = href;
-        a.download = `images_${createdAt}.zip`;
-        a.target = '_blank ';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(href);
-        setZipping(false);
-      })
-      .catch(() => {
-        setZipping(false);
-      });
+    try {
+      await downloadGeneratedImages(selected);
+    } catch (e) {
+      showErrorNotification({ title: 'Failed to download images', error: e as Error });
+    } finally {
+      setZipping(false);
+    }
   }
 
   const imagesCount = selectableImages.length;
@@ -195,8 +159,8 @@ export function GeneratedImageActions({
   const indeterminate = selectedCount > 0 && !allChecked;
 
   const handleCheckboxClick = (checked: boolean) => {
-    if (!checked) orchestratorImageSelect.setSelected([]);
-    else orchestratorImageSelect.setSelected(selectableImages);
+    if (!checked) setSelected([]);
+    else setSelected(selectableImages);
   };
 
   const hasSelected = !!selectedCount;
@@ -276,6 +240,8 @@ function BulkWorkflowMenu({
   actionIconSize: MantineSpacing;
   iconSize: number;
 }) {
+  const { setSelected } = useActions();
+
   // Split selected by media type
   const selectedImages = useMemo(() => selected.filter((s) => s.type === 'image'), [selected]);
   const selectedVideos = useMemo(() => selected.filter((s) => s.type === 'video'), [selected]);
@@ -307,7 +273,7 @@ function BulkWorkflowMenu({
     const remaining = selected.filter(
       (img) => !consumedKeys.has(`${img.workflowId}:${img.stepName}:${img.id}`)
     );
-    orchestratorImageSelect.setSelected(remaining);
+    setSelected(remaining);
   };
 
   const hasImageWorkflows = selectedImages.length > 0 && bulkImageWorkflows.length > 0;

--- a/src/components/ImageGeneration/GeneratedOutputWrapper.tsx
+++ b/src/components/ImageGeneration/GeneratedOutputWrapper.tsx
@@ -6,7 +6,11 @@ import { useState } from 'react';
 
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { useGeneratedItemStore } from '~/components/Generation/stores/generated-item.store';
-import { orchestratorImageSelect } from '~/components/ImageGeneration/utils/generationImage.select';
+import {
+  useActions,
+  useIsSelected,
+  useIsSelecting,
+} from '~/components/ImageGeneration/utils/generationImage.select';
 import { useUpdateImageStepMetadata } from '~/components/ImageGeneration/utils/generationRequestHooks';
 import { useInViewDynamic } from '~/components/IntersectionObserver/IntersectionObserverProvider';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -30,30 +34,25 @@ export function GeneratedOutputWrapper({
   image: ImageBlob | VideoBlob | AudioBlob;
   isLightbox?: boolean;
   isActiveSlide?: boolean;
-  children: (props: {
-    onClick: () => void;
-    onLoaded: () => void;
-    loaded: boolean;
-  }) => ReactNode;
+  children: (props: { onClick: () => void; onLoaded: () => void; loaded: boolean }) => ReactNode;
 }) {
   const step = image.step;
   const request = image.workflow;
   const [ref, inView] = useInViewDynamic({ id: image.id });
-  const selected = orchestratorImageSelect.useIsSelected(image);
-  const isSelecting = orchestratorImageSelect.useIsSelecting();
+  const selected = useIsSelected(image);
+  const isSelecting = useIsSelecting();
   const [loaded, setLoaded] = useState(image.mediaType === 'audio');
 
   const { updateImages } = useUpdateImageStepMetadata();
+  const { select } = useActions();
   const { running, helpers } = useTourContext();
   const available = image.available;
 
-  const toggleSelect = (checked?: boolean) => orchestratorImageSelect.toggle(image, checked);
-
-  const handleClick = () => {
+  const handleClick = (e?: { shiftKey?: boolean }) => {
     if (!image || !available || isLightbox) return;
 
     if (isSelecting) {
-      handleToggleSelect();
+      handleToggleSelect(!selected, e?.shiftKey ?? false);
     } else {
       // Lazy import to avoid circular dependency
       import('./GeneratedOutputLightbox').then(({ default: GeneratedOutputLightbox }) => {
@@ -126,8 +125,8 @@ export function GeneratedOutputWrapper({
     );
   }
 
-  function handleToggleSelect(value = !selected) {
-    toggleSelect(value);
+  function handleToggleSelect(value = !selected, shiftKey = false) {
+    select(image, { checked: value, shiftKey });
     if (running && value) helpers?.next();
   }
 
@@ -173,25 +172,26 @@ export function GeneratedOutputWrapper({
               isLightbox ? 'max-h-[calc(100vh-76px)]' : 'max-h-full',
               isLightbox && !loaded && 'min-h-32 min-w-32'
             )}
-            style={
-              isLightbox && image.mediaType !== 'audio' ? undefined : { aspectRatio }
-            }
+            style={isLightbox && image.mediaType !== 'audio' ? undefined : { aspectRatio }}
           >
             {children({
               onClick: handleClick,
               onLoaded: () => setLoaded(true),
               loaded,
             })}
-            {isLightbox && !loaded && (
-              <Loader className="absolute inset-0 m-auto" size="lg" />
-            )}
+            {isLightbox && !loaded && <Loader className="absolute inset-0 m-auto" size="lg" />}
 
             {!isLightbox && !image.blockedReason && (
               <label className="absolute left-3 top-3" data-tour="gen:select">
                 <Checkbox
                   className={classes.checkbox}
                   checked={selected}
-                  onChange={(e) => handleToggleSelect(e.target.checked)}
+                  onChange={(e) =>
+                    handleToggleSelect(
+                      e.target.checked,
+                      (e.nativeEvent as MouseEvent).shiftKey ?? false
+                    )
+                  }
                 />
               </label>
             )}

--- a/src/components/ImageGeneration/GeneratedRequestsProvider.tsx
+++ b/src/components/ImageGeneration/GeneratedRequestsProvider.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+import { createContext, useContext, useMemo } from 'react';
+import { useRegisterOrder } from '~/components/ImageGeneration/utils/generationImage.select';
+import {
+  matchesMarkerTags,
+  useGetTextToImageRequests,
+} from '~/components/ImageGeneration/utils/generationRequestHooks';
+
+type GeneratedRequests = ReturnType<typeof useGetTextToImageRequests>;
+
+const GeneratedRequestsContext = createContext<GeneratedRequests | null>(null);
+
+/**
+ * Owns the generation workflow query for the Queue/Feed views and passes it down, so
+ * the two views share one fetch and one infinite-scroll cursor instead of each calling
+ * the hook. It also registers the single flat selection order (across all workflows, in
+ * render order) — the same order both views display — so shift-click range selection is
+ * consistent whether you're looking at the Queue or the Feed.
+ */
+export function GeneratedRequestsProvider({ children }: { children: ReactNode }) {
+  const result = useGetTextToImageRequests();
+  const { data, markerTags } = result;
+
+  useRegisterOrder(
+    'generated',
+    useMemo(
+      () =>
+        data.flatMap((request) =>
+          request.succeededOutput.filter((img) => matchesMarkerTags(img, markerTags))
+        ),
+      [data, markerTags]
+    )
+  );
+
+  return (
+    <GeneratedRequestsContext.Provider value={result}>{children}</GeneratedRequestsContext.Provider>
+  );
+}
+
+export function useGeneratedRequestsContext() {
+  const ctx = useContext(GeneratedRequestsContext);
+  if (!ctx)
+    throw new Error('useGeneratedRequestsContext must be used within a GeneratedRequestsProvider');
+  return ctx;
+}

--- a/src/components/ImageGeneration/GenerationTabs.tsx
+++ b/src/components/ImageGeneration/GenerationTabs.tsx
@@ -16,6 +16,11 @@ import type { ForwardRefExoticComponent, RefAttributes } from 'react';
 import React, { useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { GeneratedImageActions } from '~/components/ImageGeneration/GeneratedImageActions';
+import { GeneratedRequestsProvider } from '~/components/ImageGeneration/GeneratedRequestsProvider';
+import {
+  SelectionProvider,
+  generatedImageSelectStore,
+} from '~/components/ImageGeneration/utils/generationImage.select';
 import { SignalStatusNotification } from '~/components/Signals/SignalsProvider';
 import { ScrollArea } from '~/components/ScrollArea/ScrollArea';
 import { GenerationFormV2 } from '~/components/generation_v2';
@@ -85,6 +90,8 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
   );
 
   const View = isImageFeedSeparate ? tabs.generate.Component : tabs[view].Component;
+  // The Queue/Feed views share one workflow fetch + selection order via the provider.
+  const showResults = !isImageFeedSeparate && view !== 'generate';
   const tabEntries = Object.entries(tabs).filter(([key]) =>
     isImageFeedSeparate ? key !== 'generate' : true
   );
@@ -94,7 +101,7 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
   if (!isClient) return null;
 
   return (
-    <>
+    <SelectionProvider store={generatedImageSelectStore}>
       <SignalStatusNotification
         icon={<IconWifiOff size={20} stroke={2} />}
         // title={(status) => `Connection status: ${status}`}
@@ -185,8 +192,14 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
         </div>
         {view !== 'generate' && !isGeneratePage && <GeneratedImageActions />}
       </div>
-      <View />
-    </>
+      {showResults ? (
+        <GeneratedRequestsProvider>
+          <View />
+        </GeneratedRequestsProvider>
+      ) : (
+        <View />
+      )}
+    </SelectionProvider>
   );
 }
 

--- a/src/components/ImageGeneration/Queue.tsx
+++ b/src/components/ImageGeneration/Queue.tsx
@@ -2,7 +2,7 @@ import { Alert, Center, Loader, Stack, Text, Anchor } from '@mantine/core';
 import { IconCalendar, IconInbox } from '@tabler/icons-react';
 
 import { QueueItem } from '~/components/ImageGeneration/QueueItem';
-import { useGetTextToImageRequests } from '~/components/ImageGeneration/utils/generationRequestHooks';
+import { useGeneratedRequestsContext } from '~/components/ImageGeneration/GeneratedRequestsProvider';
 import { generationGraphPanel } from '~/store/generation-graph.store';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { useFiltersContext } from '~/providers/FiltersProvider';
@@ -20,7 +20,7 @@ export function Queue() {
     isRefetching,
     isError,
     error,
-  } = useGetTextToImageRequests();
+  } = useGeneratedRequestsContext();
 
   if (isError)
     return (

--- a/src/components/ImageGeneration/utils/downloadGeneratedImages.ts
+++ b/src/components/ImageGeneration/utils/downloadGeneratedImages.ts
@@ -1,0 +1,47 @@
+import pLimit from 'p-limit';
+import type { BlobData } from '~/shared/orchestrator/workflow-data';
+import { fetchBlob } from '~/utils/file-utils';
+import { getJSZip } from '~/utils/lazy';
+
+const limit = pLimit(10);
+
+/** Zip the given outputs and trigger a single browser download. */
+export async function downloadGeneratedImages(images: BlobData[]): Promise<void> {
+  const zip = await getJSZip();
+
+  await Promise.all(
+    images.map((image, index) =>
+      limit(async () => {
+        if (!image.url) return;
+        const blob = await fetchBlob(image.url);
+        if (!blob) return;
+
+        let name = image.id;
+        const createdAt = image.workflow.createdAt;
+        if (createdAt) {
+          const dateString = createdAt.toISOString().replaceAll(':', '.').split('.');
+          dateString.pop();
+          name = `${dateString.join('.')}_${index + 1}`;
+        }
+
+        const file = new File([blob], name);
+        const ext = blob.type.split('/')[1]?.replace('jpeg', 'jpg') || 'jpg';
+        zip.file(`${name}.${ext}`, file);
+      })
+    )
+  );
+
+  const blob = await zip.generateAsync({ type: 'blob' });
+  const ts = new Date().getTime();
+  const blobFile = new File([blob], `images_${ts}.zip`, { type: 'application/zip' });
+
+  const a = document.createElement('a');
+  const href = URL.createObjectURL(blobFile);
+  a.href = href;
+  a.download = `images_${ts}.zip`;
+  a.target = '_blank';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(href);
+}

--- a/src/components/ImageGeneration/utils/generationImage.select.ts
+++ b/src/components/ImageGeneration/utils/generationImage.select.ts
@@ -1,77 +1,26 @@
-import { useCallback } from 'react';
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { createSelectionContext, createSelectionStore } from '~/store/createSelectionStore';
 import type { BlobData } from '~/shared/orchestrator/workflow-data';
 
-// =============================================================================
-// Key helpers
-// =============================================================================
+const getKey = (image: BlobData) => `${image.workflowId}:${image.stepName}:${image.id}`;
 
-const makeKey = (image: { workflowId: string; stepName: string; id: string }) =>
-  `${image.workflowId}:${image.stepName}:${image.id}`;
+/**
+ * The default generated-image selection store instance. Provided to the Queue/Feed
+ * subtree via the exported {@link SelectionProvider}, and also used as the context's
+ * default so portaled consumers (the lightbox dialog, rendered outside the provider)
+ * resolve to the same instance. Exported for imperative/non-React access via
+ * `generatedImageSelectStore.actions`.
+ */
+export const generatedImageSelectStore = createSelectionStore<BlobData>({
+  getKey,
+  name: 'generated-image-select',
+});
 
-// =============================================================================
-// Store (plain zustand — no immer, BlobData has private fields)
-// =============================================================================
-
-interface OrchestratorImageSelectState {
-  selected: Record<string, BlobData>;
-}
-
-const initialState: OrchestratorImageSelectState = {
-  selected: {},
-};
-
-const useStore = create<OrchestratorImageSelectState>()(
-  devtools(() => initialState, { name: 'generated-image-select' })
-);
-
-// =============================================================================
-// Public API
-// =============================================================================
-
-export const orchestratorImageSelect = {
-  // ---------------------------------------------------------------------------
-  // Selection
-  // ---------------------------------------------------------------------------
-
-  useSelection: (): BlobData[] => {
-    const selected = useStore((state) => state.selected);
-    return Object.values(selected);
-  },
-
-  useIsSelected: (image: { workflowId: string; stepName: string; id: string }): boolean => {
-    const key = makeKey(image);
-    return useStore(useCallback((state) => !!state.selected[key], [key]));
-  },
-
-  useIsSelecting: (): boolean => {
-    return useStore((state) => Object.keys(state.selected).length > 0);
-  },
-
-  setSelected: (images: BlobData[]) => {
-    useStore.setState({
-      selected: Object.fromEntries(images.map((img) => [makeKey(img), img])),
-    });
-  },
-
-  toggle: (image: BlobData, value?: boolean) => {
-    const state = useStore.getState();
-    const key = makeKey(image);
-    const isSelected = !!state.selected[key];
-    const newValue = value ?? !isSelected;
-
-    if (newValue === isSelected) return;
-
-    if (newValue) {
-      useStore.setState({ selected: { ...state.selected, [key]: image } });
-    } else {
-      const { [key]: _, ...rest } = state.selected;
-      useStore.setState({ selected: rest });
-    }
-  },
-
-  getSelected: (): BlobData[] => {
-    return Object.values(useStore.getState().selected);
-  },
-};
+export const {
+  SelectionProvider,
+  useActions,
+  useSelection,
+  useIsSelected,
+  useIsSelecting,
+  useSelectedCount,
+  useRegisterOrder,
+} = createSelectionContext<BlobData>(generatedImageSelectStore);

--- a/src/pages/generate/index.tsx
+++ b/src/pages/generate/index.tsx
@@ -5,7 +5,12 @@ import { Page } from '~/components/AppLayout/Page';
 import { GenerationMutedNotice } from '~/components/Generation/GenerationMutedNotice';
 import { Feed } from '~/components/ImageGeneration/Feed';
 import { GeneratedImageActions } from '~/components/ImageGeneration/GeneratedImageActions';
+import { GeneratedRequestsProvider } from '~/components/ImageGeneration/GeneratedRequestsProvider';
 import { Queue } from '~/components/ImageGeneration/Queue';
+import {
+  SelectionProvider,
+  generatedImageSelectStore,
+} from '~/components/ImageGeneration/utils/generationImage.select';
 import { Meta } from '~/components/Meta/Meta';
 import { ScrollArea } from '~/components/ScrollArea/ScrollArea';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -50,48 +55,50 @@ function GeneratePage() {
 
   // desktop view
   return (
-    <>
-      <Meta title="Generate" deIndex />
+    <SelectionProvider store={generatedImageSelectStore}>
+      <GeneratedRequestsProvider>
+        <Meta title="Generate" deIndex />
 
-      <Tabs
-        variant="pills"
-        value={tabView}
-        onChange={(view) => {
-          // tab can be null
-          if (view) setView(view as 'generate' | 'queue' | 'feed');
-        }}
-        radius="xl"
-        color="gray"
-        classNames={{
-          root: 'flex flex-1 flex-col overflow-hidden',
-          panel: 'size-full',
-          list: 'w-full border-b border-b-gray-2 dark:border-b-dark-5',
-        }}
-        keepMounted={false}
-      >
-        <Tabs.List px="md" py="xs">
-          <Group justify="space-between" w="100%">
-            <Group align="flex-start" gap="xs">
-              <Tabs.Tab value="queue" leftSection={<IconClockHour9 size={16} />}>
-                Queue
-              </Tabs.Tab>
-              <Tabs.Tab value="feed" leftSection={<IconGridDots size={16} />}>
-                Feed
-              </Tabs.Tab>
+        <Tabs
+          variant="pills"
+          value={tabView}
+          onChange={(view) => {
+            // tab can be null
+            if (view) setView(view as 'generate' | 'queue' | 'feed');
+          }}
+          radius="xl"
+          color="gray"
+          classNames={{
+            root: 'flex flex-1 flex-col overflow-hidden',
+            panel: 'size-full',
+            list: 'w-full border-b border-b-gray-2 dark:border-b-dark-5',
+          }}
+          keepMounted={false}
+        >
+          <Tabs.List px="md" py="xs">
+            <Group justify="space-between" w="100%">
+              <Group align="flex-start" gap="xs">
+                <Tabs.Tab value="queue" leftSection={<IconClockHour9 size={16} />}>
+                  Queue
+                </Tabs.Tab>
+                <Tabs.Tab value="feed" leftSection={<IconGridDots size={16} />}>
+                  Feed
+                </Tabs.Tab>
+              </Group>
+              <GeneratedImageActions />
             </Group>
-            <GeneratedImageActions />
-          </Group>
-        </Tabs.List>
-        <ScrollArea scrollRestore={{ key: tabView }}>
-          <Tabs.Panel value="queue">
-            <Queue />
-          </Tabs.Panel>
-          <Tabs.Panel value="feed">
-            <Feed />
-          </Tabs.Panel>
-        </ScrollArea>
-      </Tabs>
-    </>
+          </Tabs.List>
+          <ScrollArea scrollRestore={{ key: tabView }}>
+            <Tabs.Panel value="queue">
+              <Queue />
+            </Tabs.Panel>
+            <Tabs.Panel value="feed">
+              <Feed />
+            </Tabs.Panel>
+          </ScrollArea>
+        </Tabs>
+      </GeneratedRequestsProvider>
+    </SelectionProvider>
   );
 }
 

--- a/src/store/createSelectionStore.ts
+++ b/src/store/createSelectionStore.ts
@@ -1,0 +1,246 @@
+import { createContext, createElement, useCallback, useContext, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { createStore, useStore } from 'zustand';
+import type { StoreApi } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+/**
+ * Reusable, list-oriented multi-select with Gmail-style shift-click range selection.
+ *
+ * Two layers, following the zustand "store factory + Context provider" pattern
+ * (https://zustand.docs.pmnd.rs/guides/initialize-state-with-props):
+ *
+ * - {@link createSelectionStore} builds a vanilla store *instance* (state + actions)
+ *   for one selectable surface. Use it directly as a module singleton, or pass the
+ *   instance to a provider for subtree-scoped selection.
+ * - {@link createSelectionContext} wraps an instance type with a `<Provider>` and
+ *   selector hooks. Selector hooks subscribe to a single slice each, so toggling one
+ *   row only re-renders that row — the targeted-update behavior plain React Context
+ *   can't give.
+ *
+ * Range selection resolves within a registered group (see `registerOrder`/
+ * `useRegisterOrder`), so a shift-range never bridges across separate grids.
+ */
+export interface SelectionState<T> {
+  selected: Record<string, T>;
+  /** Ordered item lists per render group, used to resolve shift-click ranges. */
+  orders: Record<string, T[]>;
+  /** Key of the last clicked item (plain or shift) — the anchor for range selection. */
+  anchorKey: string | null;
+}
+
+export interface SelectionActions<T> {
+  /** Toggle one item and make it the range-select anchor. */
+  toggle: (item: T, value?: boolean) => void;
+  /**
+   * Toggle `item` with shift-click range support (Gmail-style range toggle). On a
+   * shift-click the range between the anchor and `item` (inclusive) is toggled as a
+   * unit: if every item in it is already selected, the whole range is deselected;
+   * otherwise the whole range is selected. Falls back to {@link toggle} with no shift /
+   * no anchor / no common group.
+   */
+  select: (item: T, opts: { shiftKey: boolean; checked: boolean }) => void;
+  /** Add or remove many items at once. Programmatic — does not move the anchor. */
+  selectMany: (items: T[], value: boolean) => void;
+  /** Replace the entire selection. Clears the anchor. */
+  setSelected: (items: T[]) => void;
+  /** Clear the selection and anchor. */
+  clear: () => void;
+  /** Register a grid's ordered items under `groupId` (drives range resolution). */
+  registerOrder: (groupId: string, items: T[]) => void;
+  /** Remove a previously registered group. */
+  unregisterOrder: (groupId: string) => void;
+  /** Non-reactive snapshot of the selected items. */
+  getSelected: () => T[];
+}
+
+export type SelectionStore<T> = {
+  store: StoreApi<SelectionState<T>>;
+  actions: SelectionActions<T>;
+  getKey: (item: T) => string;
+};
+
+export function createSelectionStore<T>({
+  getKey,
+  name,
+}: {
+  /** Stable unique key for an item. */
+  getKey: (item: T) => string;
+  /** Optional devtools store name. */
+  name?: string;
+}): SelectionStore<T> {
+  const store = createStore<SelectionState<T>>()(
+    devtools(
+      (): SelectionState<T> => ({ selected: {}, orders: {}, anchorKey: null }),
+      name ? { name } : undefined
+    )
+  );
+
+  // Plain click: toggle the item, then make it the range-select anchor.
+  function toggleItem(item: T, value?: boolean) {
+    const state = store.getState();
+    const key = getKey(item);
+    const isSelected = !!state.selected[key];
+    const newValue = value ?? !isSelected;
+
+    let selected = state.selected;
+    if (newValue !== isSelected) {
+      if (newValue) selected = { ...selected, [key]: item };
+      else {
+        const { [key]: _removed, ...rest } = selected;
+        selected = rest;
+      }
+    }
+    store.setState({ selected, anchorKey: key });
+  }
+
+  const actions: SelectionActions<T> = {
+    toggle: toggleItem,
+
+    select: (item, { shiftKey, checked }) => {
+      const state = store.getState();
+      const targetKey = getKey(item);
+
+      if (shiftKey && state.anchorKey && state.anchorKey !== targetKey) {
+        for (const groupId in state.orders) {
+          const list = state.orders[groupId];
+          const anchorIndex = list.findIndex((x) => getKey(x) === state.anchorKey);
+          const targetIndex = list.findIndex((x) => getKey(x) === targetKey);
+          if (anchorIndex !== -1 && targetIndex !== -1) {
+            const [start, end] =
+              anchorIndex < targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
+            const range = list.slice(start, end + 1);
+            // Gmail range toggle: if the whole range is already selected, deselect it;
+            // if any item in it is unselected, select the entire range. The clicked item
+            // becomes the new anchor so consecutive shift-clicks chain from it.
+            const allSelected = range.every((rangeItem) => !!state.selected[getKey(rangeItem)]);
+            const selected = { ...state.selected };
+            for (const rangeItem of range) {
+              const rangeKey = getKey(rangeItem);
+              if (allSelected) delete selected[rangeKey];
+              else selected[rangeKey] = rangeItem;
+            }
+            store.setState({ selected, anchorKey: targetKey });
+            return;
+          }
+        }
+      }
+
+      toggleItem(item, checked);
+    },
+
+    selectMany: (items, value) => {
+      const state = store.getState();
+      if (value) {
+        const additions = Object.fromEntries(items.map((item) => [getKey(item), item]));
+        store.setState({ selected: { ...state.selected, ...additions } });
+      } else {
+        const removeKeys = new Set(items.map(getKey));
+        const rest = Object.fromEntries(
+          Object.entries(state.selected).filter(([key]) => !removeKeys.has(key))
+        );
+        store.setState({ selected: rest });
+      }
+    },
+
+    setSelected: (items) => {
+      const selected = Object.fromEntries(items.map((item) => [getKey(item), item]));
+      store.setState({ selected, anchorKey: null });
+    },
+
+    clear: () => store.setState({ selected: {}, anchorKey: null }),
+
+    registerOrder: (groupId, items) =>
+      store.setState((state) => ({ orders: { ...state.orders, [groupId]: items } })),
+
+    unregisterOrder: (groupId) =>
+      store.setState((state) => {
+        const { [groupId]: _removed, ...rest } = state.orders;
+        return { orders: rest };
+      }),
+
+    getSelected: () => Object.values(store.getState().selected),
+  };
+
+  return { store, actions, getKey };
+}
+
+/**
+ * Wrap a {@link SelectionStore} instance type with a Context provider and selector
+ * hooks. Pass a `defaultStore` so consumers rendered outside the provider (e.g. a
+ * dialog/lightbox portal) still resolve to a store instead of throwing.
+ */
+export function createSelectionContext<T>(defaultStore?: SelectionStore<T>) {
+  const Context = createContext<SelectionStore<T> | null>(null);
+
+  function SelectionProvider({
+    store,
+    children,
+  }: {
+    store: SelectionStore<T>;
+    children: ReactNode;
+  }) {
+    return createElement(Context.Provider, { value: store }, children);
+  }
+
+  function useApi(): SelectionStore<T> {
+    const api = useContext(Context) ?? defaultStore;
+    if (!api)
+      throw new Error(
+        'Selection hooks must be used within a SelectionProvider (or with a default).'
+      );
+    return api;
+  }
+
+  return {
+    SelectionProvider,
+
+    /** Stable action handlers for the resolved store instance. */
+    useActions: (): SelectionActions<T> => useApi().actions,
+
+    useSelection: (): T[] => {
+      const { store } = useApi();
+      // Subscribe to the `selected` slice (stable ref); derive the array in render so
+      // unrelated state changes (orders/anchor) don't trigger a re-render.
+      const selected = useStore(store, (state) => state.selected);
+      return Object.values(selected);
+    },
+
+    useIsSelected: (item: T): boolean => {
+      const { store, getKey } = useApi();
+      const key = getKey(item);
+      return useStore(
+        store,
+        useCallback((state: SelectionState<T>) => !!state.selected[key], [key])
+      );
+    },
+
+    useIsSelecting: (): boolean => {
+      const { store } = useApi();
+      return useStore(store, (state) => Object.keys(state.selected).length > 0);
+    },
+
+    useSelectedCount: (): number => {
+      const { store } = useApi();
+      return useStore(store, (state) => Object.keys(state.selected).length);
+    },
+
+    /**
+     * Register the calling grid's ordered (selectable) items under `groupId` for the
+     * component's lifetime. Exclude items the user can't select so a range never lands
+     * on one.
+     */
+    useRegisterOrder: (groupId: string, items: T[]) => {
+      const { actions, getKey } = useApi();
+      // Re-register only when the ordered key signature changes (array identity churns
+      // every render under infinite scroll).
+      const signature = items.map(getKey).join('|');
+      useEffect(() => {
+        actions.registerOrder(groupId, items);
+        return () => actions.unregisterOrder(groupId);
+        // `items` is tracked via `signature`, not by identity.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [groupId, signature, actions]);
+    },
+  };
+}


### PR DESCRIPTION
Add a generic, list-oriented multi-select store and adopt it for the generation Queue/Feed:

- createSelectionStore / createSelectionContext: a zustand vanilla-store factory + Context provider (store-factory pattern) with Gmail-style shift-click range toggle (select a range, or deselect it when fully selected), per-grid order registration, and selective subscriptions.
- generationImage.select is now an instance of the factory.
- GeneratedRequestsProvider owns the single workflow query and registers the flat selection order; Queue and Feed consume it instead of each fetching. Wired in GenerationTabs and the /generate page (under SelectionProvider).
- Extract downloadGeneratedImages util for the existing "download selected" zip flow.