### PR TITLE
Fix: Bundle static-content in standalone output (Fixes 500s/empty pages on ToS & Safety)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -322,6 +322,10 @@ export default defineNextConfig(
         },
       ];
     },
+    outputFileTracingIncludes: {
+      '/safety': ['./src/static-content/**/*'],
+      '/content/[[...slug]]': ['./src/static-content/**/*'],
+    },
     output: 'standalone',
   })
 );


### PR DESCRIPTION
### Description
This PR resolves the 500 errors occurring on legal and compliance pages (ToS, Privacy Policy, Safety) deployed via Next.js standalone mode. Next.js static analysis fails to trace dynamic `fs.readFileSync` calls, which prevented the `src/static-content` directory from being included in the deployment bundle.

### The Fix
This PR implements the idiomatic Next.js solution by explicitly configuring `outputFileTracingIncludes` in `next.config.mjs` to bundle the static markdown files at build time.

**Update**: Based on code review feedback, the glob scope has been tightened from a sledgehammer `/**` (which inflated the bundle size for every single unrelated backend route) down to the strictly required Next.js page paths:
* `'/safety'`: Directly targets the `/safety` route.
* `'/content/[[...slug]]'`: Directly targets the internal dynamic content route (handling `/content/2257`, `/content/tos`, etc.).

### Why the Exact Route Name Matters
The glob for dynamic routes *must* strictly match the internal Next.js page name (`/content/[[...slug]]`), rather than a wild URL glob (`/content/*`), in order to properly trace and map the files for that dynamic route's serverless function.

### Verification
Testing can be completed by spinning up the standalone dev environment and validating that paths like `/content/2257` or `/safety` successfully load the parsed markdown.
