### PR TITLE
fix(chat): Resolve empty chat history regression in React Query v5

### DIFF
--- a/src/components/Chat/ChatShareModal.tsx
+++ b/src/components/Chat/ChatShareModal.tsx
@@ -84,9 +84,10 @@ export default function ChatShareModal(props: { message: string }) {
         produce((old) => {
           if (!old) return old;
 
-          const lastPage = old.pages[old.pages.length - 1];
-
-          lastPage.items.push(data);
+          // The backend returns messages grouped in chunks (pages). 
+          // `old.pages[0]` contains the newest chunk of messages.
+          const newestPage = old.pages[0];
+          newestPage.items.push(data);
         })
       );
 

--- a/src/components/Chat/ChatSignals.ts
+++ b/src/components/Chat/ChatSignals.ts
@@ -32,9 +32,12 @@ export const useChatNewMessageSignal = () => {
         produce((old) => {
           if (!old) return old;
 
-          const lastPage = old.pages[old.pages.length - 1];
-
-          lastPage.items.push(updated);
+          // The backend returns messages grouped in chunks (pages). 
+          // `old.pages[0]` contains the newest chunk of messages, while older messages 
+          // are appended to the end of the array during infinite scrolling.
+          // Therefore, new incoming messages must be appended to `pages[0]`.
+          const newestPage = old.pages[0];
+          newestPage.items.push(updated);
         })
       );
 

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -112,21 +112,25 @@ export function ExistingChat() {
   const [replyId, setReplyId] = useState<number | undefined>(undefined);
 
   // TODO there is a bug here. upon rejoining, you won't get a signal for the messages in the timespan between leaving and rejoining
-  const { data, fetchNextPage, isLoading, isRefetching, hasNextPage } =
+  const { data, fetchNextPage, isLoading, isRefetching, hasNextPage, isError, error } =
     trpc.chat.getInfiniteMessages.useInfiniteQuery(
       {
         chatId: existingChatId!,
       },
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor,
-        select: (data) => ({
-          pages: [...data.pages].reverse(),
-          pageParams: [...data.pageParams].reverse(),
-        }),
       }
     );
 
   const { data: allChatData, isLoading: allChatLoading } = trpc.chat.getAllByUser.useQuery();
+
+  // Reversal is intentionally here in useMemo, not in useInfiniteQuery's select.
+  // Mutating pages + pageParams simultaneously inside select breaks RQ v5 cursor
+  // tracking and causes the hook to return empty data.
+  const allChats = useMemo(() => {
+    if (!data?.pages) return [];
+    return [...data.pages].reverse().flatMap((x) => x.items);
+  }, [data]);
 
   const thisChat = useMemo(
     () => allChatData?.find((c) => c.id === existingChatId),
@@ -445,6 +449,10 @@ export function ExistingChat() {
             {isRefetching || isLoading ? (
               <Center h="100%">
                 <Loader />
+              </Center>
+            ) : isError ? (
+              <Center h="100%">
+                <Text color="red">Error: {error?.message}</Text>
               </Center>
             ) : allChats.length > 0 ? (
               <Stack style={{ overflowWrap: 'break-word' }} gap={12}>

--- a/src/components/Chat/ExistingChat.tsx
+++ b/src/components/Chat/ExistingChat.tsx
@@ -127,9 +127,13 @@ export function ExistingChat() {
   // Reversal is intentionally here in useMemo, not in useInfiniteQuery's select.
   // Mutating pages + pageParams simultaneously inside select breaks RQ v5 cursor
   // tracking and causes the hook to return empty data.
-  const allChats = useMemo(() => {
+  // Note: We reverse the `pages` array (chunks) instead of the flattened array
+  // because the backend returns chunks in newest-to-oldest order, but the items 
+  // *inside* the chunks are correctly ordered chronologically. Reversing the 
+  // flattened array would break the internal chronological order of the messages.
+  const messagesChronological = useMemo(() => {
     if (!data?.pages) return [];
-    return [...data.pages].reverse().flatMap((x) => x.items);
+    return [...data.pages].reverse().flatMap((x) => x.items ?? []);
   }, [data]);
 
   const thisChat = useMemo(
@@ -258,12 +262,11 @@ export function ExistingChat() {
     });
   };
 
-  const allChats = useMemo(() => data?.pages.flatMap((x) => x.items) ?? [], [data]);
 
   useEffect(() => {
     // - on a new message or initial load, scroll to the bottom. on load more, don't scroll
 
-    if (!allChats.length) return;
+    if (!messagesChronological.length) return;
 
     // if (data.pages.length !== oldPagesLength.current) return;
     //
@@ -275,13 +278,13 @@ export function ExistingChat() {
     );
 
     if (!myMember) return;
-    const newestMessageId = allChats[allChats.length - 1].id;
+    const newestMessageId = messagesChronological[messagesChronological.length - 1].id;
     if ((myMember.lastViewedMessageId ?? 0) >= newestMessageId) return;
     changeLastViewed({
       chatMemberId: myMember.id,
       lastViewedMessageId: newestMessageId,
     }).catch();
-  }, [allChats, changeLastViewed, myMember]);
+  }, [messagesChronological, changeLastViewed, myMember]);
 
   useEffect(() => {
     setTypingStatus({});
@@ -454,7 +457,7 @@ export function ExistingChat() {
               <Center h="100%">
                 <Text color="red">Error: {error?.message}</Text>
               </Center>
-            ) : allChats.length > 0 ? (
+            ) : messagesChronological.length > 0 ? (
               <Stack style={{ overflowWrap: 'break-word' }} gap={12}>
                 {hasNextPage && (
                   <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching && hasNextPage}>
@@ -463,7 +466,7 @@ export function ExistingChat() {
                     </Center>
                   </InViewLoader>
                 )}
-                <DisplayMessages chats={allChats} setReplyId={setReplyId} />
+                <DisplayMessages chats={messagesChronological} setReplyId={setReplyId} />
               </Stack>
             ) : (
               <Center h="100%">
@@ -485,7 +488,7 @@ export function ExistingChat() {
                   <Group p="xs" wrap="nowrap">
                     <Text size="xs">Replying:</Text>
                     <Box style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>
-                      {allChats.find((ac) => ac.id === replyId)?.content ?? ''}
+                      {messagesChronological.find((ac) => ac.id === replyId)?.content ?? ''}
                     </Box>
                     <LegacyActionIcon onClick={() => setReplyId(undefined)} ml="auto">
                       <IconX size={14} />
@@ -531,11 +534,11 @@ export function ExistingChat() {
             <Alert color="yellow" icon={<IconAlertTriangle size={20} />} p="xs" mx="sm">
               <ScamWarningContent chatId={existingChatId!} />
             </Alert>
-            {allChats.length > 0 && (
-              <Text mb="md" p="sm" size="xs" italic align="center">{`"${allChats[0].content.slice(
+            {messagesChronological.length > 0 && (
+              <Text mb="md" p="sm" size="xs" italic align="center">{`"${messagesChronological[0].content.slice(
                 0,
                 70
-              )}${allChats[0].content.length > 70 ? '...' : ''}"`}</Text>
+              )}${messagesChronological[0].content.length > 70 ? '...' : ''}"`}</Text>
             )}
             <Text align="center">Join the chat?</Text>
             <Group p="sm" justify="center">


### PR DESCRIPTION
### Description
This PR resolves the "empty chat history" regression reported after the tRPC v11 migration. Prior to this fix, opening the chat window successfully loaded the list of prior chats, but selecting any existing conversation resulted in an empty history showing the "Start the conversation below!" prompt, despite messages existing in the database.

It also resolves a pre-existing signal cache bug where incoming WebSocket messages were appended to the oldest chunk instead of the newest chunk in the chat view.

### Root Cause Analysis & Fixes
1. **React Query v5 Footgun (`ExistingChat.tsx`)**: The exact point of failure for the empty history regression was isolated to the `select` option mutating `InfiniteData` arrays (specifically manipulating both `pages` and `pageParams` simultaneously). This breaks internal React Query v5 cursor tracking. 
   * **Fix**: The `select` block was completely removed from the `useInfiniteQuery` call. To maintain the correct bottom-up chronological message ordering, the array reversal was moved safely into the standard React `useMemo` hook downstream.
2. **Defensive Mapping (`ExistingChat.tsx`)**: Replaced `allChats` with `messagesChronological` for clarity, and added `flatMap(x => x.items ?? [])` to gracefully handle unexpected undefined arrays if the query shape ever unexpectedly changes.
3. **Hidden Signal Cache Bug (`ChatSignals.ts` & `ChatShareModal.tsx`)**: During code review, it was discovered that real-time signals were pushing new messages into `old.pages[old.pages.length - 1]`. Because infinite scroll appends older messages to the end of the array, `length - 1` is actually the oldest chunk. If a user scrolled up for history and *then* received a message, it would appear at the top of the chat instead of the bottom.
   * **Fix**: Updated `setInfiniteData` in both consumers to strictly push new incoming messages into `old.pages[0]` (the newest chunk).

### Validation
This change was validated against the codebase to ensure no other components rely on the `select`-mutated state. Real-time hooks have been fully updated.

Testing can be completed via the `civitai-deployment` dev environment spin-up triggered by this PR.
