### PR TITLE
perf(api): only fetch image meta blob on /api/v1/images when withMeta=true

### DIFF
--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -151,7 +151,13 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
           limit,
           skip,
           cursor,
-          include: ['metaSelect', 'tagIds', 'profilePictures'],
+          // Only fetch the (large, ~2.8KB/key) meta blob when the caller asks
+          // for it via withMeta. Previously metaSelect was hardcoded, so every
+          // request paid the imageMetaCache fetch + JSON serialization even when
+          // withMeta=false (the default) and the meta was discarded client-side.
+          include: withMeta
+            ? ['metaSelect', 'tagIds', 'profilePictures']
+            : ['tagIds', 'profilePictures'],
           periodMode: 'published',
           headers: { src: '/api/v1/images' },
           browsingLevel: _browsingLevel,
@@ -169,7 +175,13 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
           limit,
           skip,
           cursor,
-          include: ['metaSelect', 'tagIds', 'profilePictures'],
+          // Only fetch the (large, ~2.8KB/key) meta blob when the caller asks
+          // for it via withMeta. Previously metaSelect was hardcoded, so every
+          // request paid the imageMetaCache fetch + JSON serialization even when
+          // withMeta=false (the default) and the meta was discarded client-side.
+          include: withMeta
+            ? ['metaSelect', 'tagIds', 'profilePictures']
+            : ['tagIds', 'profilePictures'],
           periodMode: 'published',
           browsingLevel: _browsingLevel,
           withMeta,
@@ -187,7 +199,13 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
           limit,
           skip,
           cursor,
-          include: ['metaSelect', 'tagIds', 'profilePictures'],
+          // Only fetch the (large, ~2.8KB/key) meta blob when the caller asks
+          // for it via withMeta. Previously metaSelect was hardcoded, so every
+          // request paid the imageMetaCache fetch + JSON serialization even when
+          // withMeta=false (the default) and the meta was discarded client-side.
+          include: withMeta
+            ? ['metaSelect', 'tagIds', 'profilePictures']
+            : ['tagIds', 'profilePictures'],
           periodMode: 'published',
           browsingLevel: _browsingLevel,
           withMeta,
@@ -233,7 +251,7 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
             heartCount: image.stats?.heartCountAllTime ?? 0,
             commentCount: image.stats?.commentCountAllTime ?? 0,
           },
-          meta: image.meta,
+          meta: image.meta ?? null,
           username: image.user.username,
           baseModel: image.baseModel,
           modelVersionIds: image.modelVersionIds,


### PR DESCRIPTION
## Why
Part of the prod API per-request CPU reduction effort (single-thread Node pods pinning under load → `Error/137` liveness-SIGKILL + 504 waves). CPU profiling flagged large per-image `meta` blobs (~2.8KB/key) as a serialization + GC cost.

Investigation showed the **tRPC feeds** (`getImagesAsPostsInfinite`, `getInfinite`) already do **not** fetch the meta blob — they lazy-load it via `getGenerationData`. The **only** caller that fetches it is the public REST `/api/v1/images`, which **hardcoded `metaSelect`** in all three fetch branches. So it fetched (`imageMetaCache`) and JSON-serialized the full meta blob on **every** request — even when `withMeta=false` (the default), where the meta is then discarded.

## Change
`src/pages/api/v1/images/index.ts`: gate `metaSelect` on the existing `withMeta` param. The blob is fetched + returned only when the caller opts in. The service already returns `meta: null` when `metaSelect` isn't in `include`, so the response shape is unchanged (`meta` is coerced to `null` to keep the key present).

## ⚠️ Behavior change (public API)
Callers reading `image.meta` **without** passing `withMeta=true` will now receive `null`. Callers already passing `withMeta=true` — the documented way to request meta — are **unaffected**.

This honors the param's intended semantics (the prior always-on behavior was an over-fetch from the hardcoded `metaSelect`), but it is a real contract change for external consumers who relied on meta being present by default. Flagging explicitly for review — if that's too aggressive, the alternative is to gate it behind a Flipt flag for staged rollout.

## Verification
- LSP clean. Full repo typecheck/lint not run locally (slow); CI covers it.
- Post-deploy: watch `/api/v1/images` p50/p95 CPU per request, `imageMetaCache` hit/fetch rate, `nodejs_gc_duration_seconds`, and the api-primary `Error/137` + 504 rate.

Companion low-risk internal perf changes (OTEL sampling + Flipt memoization) are in #2394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)