### PR TITLE
feat(user): add restoreAccount mod procedure

### DIFF
--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -136,6 +136,7 @@ export type UserActivityType =
   | 'Registration'
   | 'Login'
   | 'Account closure'
+  | 'Account restoration'
   | 'Subscribe'
   | 'Cancel'
   | 'Donate'

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -29,6 +29,7 @@ import type {
   GetUserListSchema,
   GetUserTagsSchema,
   ReportProhibitedRequestInput,
+  RestoreUserInput,
   SetLeaderboardEligibilitySchema,
   SetUserSettingsInput,
   ToggleBanUser,
@@ -89,6 +90,7 @@ import {
   setDismissedAlerts,
   getUsersWithSearch,
   isUsernamePermitted,
+  restoreUser,
   setLeaderboardEligibility,
   setUserSetting,
   toggleBan,
@@ -531,6 +533,29 @@ export const deleteUserHandler = async ({
     });
 
     return user;
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    else throw throwDbError(error);
+  }
+};
+
+export const restoreUserHandler = async ({
+  ctx,
+  input,
+}: {
+  ctx: ProtectedContext;
+  input: RestoreUserInput;
+}) => {
+  const { id } = input;
+  try {
+    const result = await restoreUser(input);
+
+    await ctx.track.userActivity({
+      targetUserId: id,
+      type: 'Account restoration',
+    });
+
+    return result;
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -6,6 +6,7 @@ import {
   deleteUserPaymentMethodHandler,
   dismissAlertHandler,
   restoreAlertHandler,
+  restoreUserHandler,
   getAllUsersHandler,
   getCreatorsHandler,
   getLeaderboardHandler,
@@ -46,6 +47,7 @@ import {
   deleteUserSchema,
   dismissAlertSchema,
   restoreAlertSchema,
+  restoreUserSchema,
   getAllUsersInput,
   getByUsernameSchema,
   getUserByUsernameSchema,
@@ -238,6 +240,7 @@ export const userRouter = router({
     .mutation(toggleFollowUserHandler),
   toggleMute: moderatorProcedure.input(getByIdSchema).mutation(toggleMuteHandler),
   toggleBan: moderatorProcedure.input(toggleBanUserSchema).mutation(toggleBanHandler),
+  restoreAccount: moderatorProcedure.input(restoreUserSchema).mutation(restoreUserHandler),
   getToken: protectedProcedure
     .meta({ requiredScope: TokenScope.Full })
     .query(({ ctx }) => ({ token: createToken(ctx.user.id) })),

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -180,6 +180,14 @@ export const deleteUserSchema = z.object({
   removeModels: z.boolean().optional(),
 });
 
+export type RestoreUserInput = z.infer<typeof restoreUserSchema>;
+export const restoreUserSchema = z.object({
+  id: z.number(),
+  username: usernameSchema,
+  email: z.string().email(),
+  restoreModels: z.boolean().optional(),
+});
+
 export type GetUserCosmeticsSchema = z.infer<typeof getUserCosmeticsSchema>;
 export const getUserCosmeticsSchema = z.object({
   equipped: z.boolean().optional(),

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -11,6 +11,7 @@ import {
   NsfwLevel,
   SearchIndexUpdateQueueAction,
 } from '~/server/common/enums';
+import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 
 import { preventReplicationLag } from '~/server/db/db-lag-helpers';
@@ -44,6 +45,7 @@ import type {
   GetByUsernameSchema,
   GetUserCosmeticsSchema,
   GetUserListSchema,
+  RestoreUserInput,
   ToggleBanUser,
   ToggleUserBountyEngagementsInput,
   UpdateContentSettingsInput,
@@ -950,6 +952,81 @@ export async function setLeaderboardEligibility({ id, setTo }: { id: number; set
   `);
   userUpdateCounter?.inc({ location: 'user.service:setLeaderboardEligibility' });
 }
+
+/**
+ * Restore a soft-deleted user account (the inverse of deleteUser).
+ *
+ * deleteUser scrubs username, email, paddleCustomerId, image, profilePictureId from the User row
+ * and sets deletedAt. It also hard-deletes Account / Session / UserEngagement rows and reassigns
+ * the user's Models to userId = -1. We can only restore what survives the deletion: the User row's
+ * scrubbed fields (caller supplies them) and the orphaned Model ownership (via ClickHouse audit).
+ *
+ * Account (OAuth links) and Session rows are unrecoverable; the user signs in fresh post-restore
+ * (email magic-link or OAuth) which creates new rows.
+ */
+export const restoreUser = async ({
+  id,
+  username,
+  email,
+  restoreModels,
+}: RestoreUserInput) => {
+  const user = await dbWrite.user.findFirst({
+    where: { id },
+    select: { id: true, deletedAt: true },
+  });
+  if (!user) throw throwNotFoundError(`No user with id ${id}`);
+  if (!user.deletedAt) throw throwBadRequestError(`User ${id} is not deleted; nothing to restore`);
+
+  // Make sure the username and email aren't claimed by some other user since the closure.
+  const conflict = await dbWrite.user.findFirst({
+    where: { id: { not: id }, OR: [{ username }, { email }] },
+    select: { id: true, username: true, email: true },
+  });
+  if (conflict) {
+    throw throwBadRequestError(
+      `Cannot restore: username or email is already in use by user ${conflict.id}`
+    );
+  }
+
+  await dbWrite.user.update({
+    where: { id },
+    data: { deletedAt: null, username, email },
+  });
+
+  let modelsRestored = 0;
+  let restoredModelIds: number[] = [];
+  if (restoreModels) {
+    // The deletion path sets Model.userId = -1 (without touching status/deletedAt), so the
+    // historical owner-link is lost from Postgres. ClickHouse `modelEvents` still has the
+    // original userId per modelId, which is what we use to identify which orphans to reclaim.
+    const auditRows =
+      (await clickhouse?.$query<{ modelId: number }>(`
+        SELECT DISTINCT modelId
+        FROM modelEvents
+        WHERE userId = ${id}
+      `)) ?? [];
+    const auditIds = auditRows.map((r) => r.modelId);
+
+    if (auditIds.length > 0) {
+      const updated = await dbWrite.model.updateMany({
+        where: { id: { in: auditIds }, userId: -1 },
+        data: { userId: id },
+      });
+      modelsRestored = updated.count;
+
+      const restored = await dbWrite.model.findMany({
+        where: { id: { in: auditIds }, userId: id },
+        select: { id: true },
+      });
+      restoredModelIds = restored.map((m) => m.id);
+    }
+  }
+
+  userUpdateCounter?.inc({ location: 'user.service:restoreUser' });
+  await usersSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
+
+  return { id, username, email, modelsRestored, modelIds: restoredModelIds };
+};
 
 /** Soft delete will ban the user, unsubscribe the user, and restrict access to the user's models/images  */
 export async function softDeleteUser({ id, userId }: { id: number; userId: number }) {

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -988,42 +988,60 @@ export const restoreUser = async ({
     );
   }
 
-  await dbWrite.user.update({
-    where: { id },
-    data: { deletedAt: null, username, email },
-  });
-
-  let modelsRestored = 0;
-  let restoredModelIds: number[] = [];
+  // Look up the audited model ownership up front (ClickHouse lives outside Postgres).
+  let auditIds: number[] = [];
   if (restoreModels) {
-    // The deletion path sets Model.userId = -1 (without touching status/deletedAt), so the
-    // historical owner-link is lost from Postgres. ClickHouse `modelEvents` still has the
-    // original userId per modelId, which is what we use to identify which orphans to reclaim.
+    // `modelEvents.userId` is the actor of each event; for a model that's the original owner.
+    // The deletion path (removeModels:false) sets Model.userId = -1 without touching
+    // status/deletedAt, so we reclaim only those orphans. Models deleted via removeModels:true
+    // keep their userId and get status='Deleted' instead — they are intentionally NOT restored
+    // here, and a model with no tracked event won't appear, so reclaim is best-effort.
     const auditRows =
       (await clickhouse?.$query<{ modelId: number }>(`
         SELECT DISTINCT modelId
         FROM modelEvents
         WHERE userId = ${id}
       `)) ?? [];
-    const auditIds = auditRows.map((r) => r.modelId);
+    auditIds = auditRows.map((r) => r.modelId);
+  }
 
-    if (auditIds.length > 0) {
+  // Reclaim orphaned models BEFORE flipping deletedAt. We deliberately avoid wrapping the user and
+  // model writes in one transaction: a user can own thousands of models, and an interactive
+  // transaction would hold a connection + row locks open across the whole set (and risk Prisma's
+  // 5s timeout). The model reclaim is a single atomic UPDATE, so it doesn't need one. Doing it
+  // first also keeps the operation re-runnable — if it fails, deletedAt is still set, so a retry
+  // passes the guard above instead of being locked out.
+  let modelsRestored = 0;
+  let restoredModelIds: number[] = [];
+  if (restoreModels && auditIds.length > 0) {
+    // Capture the exact orphaned rows we're about to reclaim so the returned ids reflect what
+    // actually changed (rather than every audited model, some of which may not be orphaned).
+    const orphans = await dbWrite.model.findMany({
+      where: { id: { in: auditIds }, userId: -1 },
+      select: { id: true },
+    });
+    restoredModelIds = orphans.map((m) => m.id);
+
+    if (restoredModelIds.length > 0) {
       const updated = await dbWrite.model.updateMany({
-        where: { id: { in: auditIds }, userId: -1 },
+        where: { id: { in: restoredModelIds }, userId: -1 },
         data: { userId: id },
       });
       modelsRestored = updated.count;
-
-      const restored = await dbWrite.model.findMany({
-        where: { id: { in: auditIds }, userId: id },
-        select: { id: true },
-      });
-      restoredModelIds = restored.map((m) => m.id);
     }
   }
 
+  await dbWrite.user.update({
+    where: { id },
+    data: { deletedAt: null, username, email },
+  });
+
   userUpdateCounter?.inc({ location: 'user.service:restoreUser' });
   await usersSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
+  // deleteUser refreshes userBasicCache (username/deletedAt/image, 1-day TTL) after scrubbing the
+  // row; mirror that here so the restored identity is visible immediately instead of serving the
+  // stale "deleted" values until the cache expires.
+  await deleteBasicDataForUser(id);
 
   return { id, username, email, modelsRestored, modelIds: restoredModelIds };
 };


### PR DESCRIPTION
Inverse of deleteUser. Lets moderators undo a soft-deletion by clearing deletedAt, restoring caller-supplied username/email, and (optionally) reclaiming Models orphaned to userId=-1 via a ClickHouse modelEvents audit lookup. Tracks an 'Account restoration' userActivity event.

Companion CLI in civitai/support-agent (mod-actions skill) already wired to POST to this endpoint.