### PR TITLE
build: raise Next.js build heap 6144->8192 (cold-build OOM fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,12 @@ COPY --from=deps /app/prisma/schema.prisma ./prisma/schema.prisma
 
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Node heap for the Next.js build. Default raised 6144 -> 8192: a cold build
+# (no warm .next/cache) peaks higher than an incremental one and OOMs at 6 GB on
+# newer commits. Build-arg so a builder with more memory can raise it further.
+ARG NODE_BUILD_MEM=8192
 RUN --mount=type=cache,target=/app/.next/cache \
-    SKIP_ENV_VALIDATION=1 IS_BUILD=true NODE_OPTIONS="--max_old_space_size=6144" pnpm run build
+    SKIP_ENV_VALIDATION=1 IS_BUILD=true NODE_OPTIONS="--max_old_space_size=${NODE_BUILD_MEM}" pnpm run build
 
 ##### RUNNER
 


### PR DESCRIPTION
## Why
The Next.js production build (`pnpm run build`) OOMs the Node heap at the hardcoded `--max_old_space_size=6144` on a **cold** Docker build (no warm `.next/cache`). An incremental build (warm cache) peaks lower and fits 6 GB; a cold build peaks higher and dies on newer commits.

This surfaced migrating the civitai Tekton builds to the DataPacket cluster: dp's buildkit cache starts cold, whereas the legacy dc-02-a builder had a warm `.next/cache`, so the OOM never showed there. PR-preview builds (cold per PR) fail; the release build (warm/cached) doesn't.

## What
- Default Node build heap **6144 → 8192**.
- Make it a build-arg (`NODE_BUILD_MEM`) so a builder with spare memory (e.g. worker-spare = 128 GiB) can raise it further without another code change.

No runtime impact — build stage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)