### PR TITLE
perf(image): parallelize getAllImagesIndex enrichment fetches (cut ~9 sequential Redis RTs to ~1)

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2130,21 +2130,25 @@ export const getAllImagesIndex = async (
     tagIdsVar,
   ] = await withSpan('image:getAllImagesIndex:parallelFetch', async () =>
     Promise.all([
-      // NOTE: original code uses `await` on each element below, which causes
-      // sequential evaluation. Preserving that behavior to keep this PR
-      // observability-only — see follow-up to actually parallelize.
-      await getBasicDataForUsers(userIds),
-      include?.includes('profilePictures') ? await getProfilePicturesForUsers(userIds) : undefined,
-      include?.includes('cosmetics') ? await getCosmeticsForUsers(userIds) : undefined,
+      // These enrichment fetches are independent (each takes pre-computed
+      // userIds/imageIds/videoIds/searchResults) and are issued WITHOUT awaiting
+      // each element so Promise.all runs them concurrently — node-redis pipelines
+      // the cache GETs queued in the same tick, collapsing ~9 sequential Redis
+      // round-trips into ~1 round-trip-time. The prior version awaited each
+      // element, forcing sequential evaluation (the span name was aspirational).
+      // Mirrors the concurrent block in getAllImages.
+      getBasicDataForUsers(userIds),
+      include?.includes('profilePictures') ? getProfilePicturesForUsers(userIds) : undefined,
+      include?.includes('cosmetics') ? getCosmeticsForUsers(userIds) : undefined,
       include?.includes('cosmetics')
-        ? await getCosmeticsForEntity({
+        ? getCosmeticsForEntity({
             ids: imageIds,
             entity: 'Image',
           })
         : undefined,
-      include?.includes('metaSelect') ? await getMetaForImages(imageIds) : undefined,
-      await getMetadataForImages(videoIds), // Only need this for videos
-      await getThumbnailsForImages(videoIds), // Only need this for videos
+      include?.includes('metaSelect') ? getMetaForImages(imageIds) : undefined,
+      getMetadataForImages(videoIds), // Only need this for videos
+      getThumbnailsForImages(videoIds), // Only need this for videos
       getImageMetricsObject(searchResults),
       // Fetch tagIds from cache so client-side hidden-tag filtering works.
       // Search results from BitDex don't include tagIds (too expensive to store),


### PR DESCRIPTION
## Why
Part of the prod API per-request **Redis round-trip reduction** — infra profiling of real pin waves shows the single-thread CPU saturation is driven by ~4 Redis round-trips/request (each an awaited async call + an OTEL span), not any one heavy endpoint. The image-index feed path is the worst offender.

## The bug
`getAllImagesIndex` (the BitDex/index feed path) wraps ~9 cache-enrichment fetches in `Promise.all`, but **`await`s each element** — so they evaluate **sequentially**. A prior PR left this observability-only with an explicit follow-up note:

```js
// NOTE: original code uses `await` on each element below, which causes
// sequential evaluation. Preserving that behavior ... see follow-up to actually parallelize.
```

So `image:getAllImagesIndex:parallelFetch` was a misnomer — ~9–10 Redis round-trips run in series per request.

## The fix
Remove the per-element `await` so `Promise.all` runs the fetches concurrently. node-redis pipelines the cache GETs queued in the same tick → ~9 sequential round-trips collapse to ~1 round-trip-time.

- The fetches are **independent** — each takes pre-computed `userIds`/`imageIds`/`videoIds`/`searchResults`; none consumes another's result. Verified.
- The sibling `getAllImages` (PG feed path) already does this exact block concurrently — this brings the index path in line.
- Read-only Redis fetches, so concurrent `Promise.all` reject-on-first-error semantics are equivalent to the prior sequential behavior (no side effects to unwind).

## Verification
- Edited region produces no type diagnostics; behavior-preserving except for concurrency (resolved tuple types unchanged). Full typecheck via CI (local Prisma client is stale — unrelated `Prisma.join` noise).
- Post-deploy: watch the `image:getAllImagesIndex:parallelFetch` span duration (should drop from sum-of-fetches to max-of-fetches), Redis ops/s, and the api-primary `Error/137`/504 rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)