### PR TITLE
perf(trpc): cache global CLIENT version hash in-process (cut per-procedure sysRedis read)

### DIFF
--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -57,6 +57,24 @@ const isAcceptableOrigin = t.middleware(({ ctx: { user, acceptableOrigin }, next
   return next({ ctx: { user, acceptableOrigin } });
 });
 
+// The CLIENT hash is a single global key (forced-client-update version/date
+// gating), identical for every user and procedure. needsUpdate runs on EVERY
+// web-client tRPC procedure, and tRPC batches multiple procedures per HTTP
+// request, so an uncached hGetAll here is ~1 sysRedis round-trip PER PROCEDURE
+// across all web traffic. Cache it in-process with a short TTL: gating a
+// "refresh your browser" banner tolerates a few seconds of staleness trivially,
+// and this collapses thousands of reads/s into ~1 read / TTL / pod. Only
+// successful reads are cached, so the fail-open behavior below is preserved.
+const CLIENT_CONFIG_TTL_MS = 5_000;
+let clientConfigCache: { value: Record<string, string>; expiresAt: number } | null = null;
+async function getClientConfigCached(): Promise<Record<string, string>> {
+  const now = Date.now();
+  if (clientConfigCache && clientConfigCache.expiresAt > now) return clientConfigCache.value;
+  const client = await sysRedis.hGetAll(REDIS_SYS_KEYS.CLIENT);
+  clientConfigCache = { value: client, expiresAt: now + CLIENT_CONFIG_TTL_MS };
+  return client;
+}
+
 // TODO - figure out a better way to do this
 async function needsUpdate(req?: NextApiRequest) {
   const type = req?.headers['x-client'] as string;
@@ -69,7 +87,7 @@ async function needsUpdate(req?: NextApiRequest) {
   // would 500 every authenticated request during a sysRedis incident.
   let client: Record<string, string>;
   try {
-    client = await sysRedis.hGetAll(REDIS_SYS_KEYS.CLIENT);
+    client = await getClientConfigCached();
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'needsUpdate', err);
     return false;


### PR DESCRIPTION
## Why
Part of the prod API per-request **Redis round-trip reduction**. `needsUpdate()` (in `enforceClientVersion`, which runs on every web-client tRPC procedure) did `sysRedis.hGetAll(REDIS_SYS_KEYS.CLIENT)` on **every procedure** — and tRPC batches multiple procedures per HTTP request, so the same **global** forced-update version/date hash was re-read ~once per procedure across all web traffic (~1400 RPS). It only gates a "please refresh your browser" banner.

## Change
Cache the CLIENT hash in-process with a **5s TTL** (`getClientConfigCached`). Collapses thousands of reads/s into ~1 read per 5s per pod.

- Staleness of a few seconds is irrelevant for client-update gating.
- **Only successful reads are cached**, so the existing fail-open (sysRedis unreachable → don't force an update, don't 500 every request) is fully preserved — a throw still falls through to the `catch` and returns `false`.
- Per-process cache; the data is global config, so independent per-pod 5s staleness is fine.

## Verification
- The added `getClientConfigCached` produces no type diagnostics. (Local typecheck shows pre-existing, unrelated noise from a stale Prisma client and stale `@trpc` v11 types — e.g. `getRawInput` on the untouched `applyDomainFeature`; CI has the correct generated deps.)
- Post-deploy: sysRedis `hGetAll`/CLIENT read rate should drop sharply; confirm the `x-update-required` banner still appears within ~5s of bumping the CLIENT version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)