### PR TITLE
fix: rename chat history 'direction' parameter to resolve TRPC v11 conflict

### DIFF
--- a/src/server/controllers/chat.controller.ts
+++ b/src/server/controllers/chat.controller.ts
@@ -497,7 +497,7 @@ export const getInfiniteMessagesHandler = async ({
       where: { chatId: input.chatId, ...dateLimit },
       take: input.limit + 1,
       cursor: input.cursor ? { id: input.cursor } : undefined,
-      orderBy: [{ id: input.direction }],
+      orderBy: [{ id: input.sortDirection }],
     });
 
     let nextCursor: number | undefined;
@@ -507,7 +507,7 @@ export const getInfiniteMessagesHandler = async ({
       nextCursor = nextItem?.id;
     }
 
-    if (input.direction === 'desc') {
+    if (input.sortDirection === 'desc') {
       items.reverse();
     }
 

--- a/src/server/schema/chat.schema.ts
+++ b/src/server/schema/chat.schema.ts
@@ -41,7 +41,7 @@ export type GetInfiniteMessagesInput = z.infer<typeof getInfiniteMessagesInput>;
 export const getInfiniteMessagesInput = infiniteQuerySchema.merge(
   z.object({
     chatId: z.number(),
-    direction: z.enum(['asc', 'desc']).optional().default('desc'),
+    sortDirection: z.enum(['asc', 'desc']).optional().default('desc'),
     // this is high for now because of issues with scrolling
     limit: z.coerce.number().min(1).default(1000),
   })


### PR DESCRIPTION
## Description
This PR resolves the critical regression where loading an existing chat in the `ExistingChat` component was failing with a Zod validation error:
`Invalid option: expected one of "asc"|"desc"` at `path: ["direction"]`.

### Context & Prior Failure
In the recent React Query v5 migration PR, we successfully refactored the frontend cache synchronization for the Chat History. However, a major conflict was missed because React Query's `pageParam` now includes a direction hint for infinite queries. TRPC's v11 adapter passes this `direction` parameter (with values `'forward'` or `'backward'`) into the query payload automatically, including on the initial fetch.

Because our backend `getInfiniteMessagesInput` schema explicitly defined `direction: z.enum(['asc', 'desc'])` to control sort ordering, Zod intercepted the injected `'forward'` value on initial load, failed to validate it against `['asc', 'desc']`, and caused the query to crash. This was likely missed during initial QA because local React Query caches masked the network failure—if a developer clicked into a chat they had previously loaded, the cached history would render instantly, hiding the background network crash.

### Changes Made
- Renamed the custom sort ordering property from `direction` to `sortDirection` in both `chat.schema.ts` and `chat.controller.ts`.
- This ensures our ascending/descending sorting logic remains perfectly intact while elegantly sidestepping the reserved parameter namespace used by TRPC v11 for pagination.
- **Frontend Audit Completed:** All frontend callers to `getInfiniteMessages` (specifically in `ExistingChat.tsx`) have been audited. The frontend never manually passed the `direction` argument and always relied on the schema's `default('desc')`. Therefore, no frontend files needed to be updated or refactored.
- Verified with `tsc` to ensure type safety remains intact.