### PR TITLE
perf(image): route feed-path Flipt evals through memoized getFliptBoolean (completes #2394 coverage)

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -194,7 +194,7 @@ import { getImageS3Client } from '~/utils/s3-client';
 import { serverUploadImage, getB2ImageS3Client } from '~/utils/s3-utils';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
-import FliptSingleton, { FLIPT_FEATURE_FLAGS, getFliptVariant, isFlipt } from '../flipt/client';
+import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import { queryBitdex } from '~/server/bitdex/client';
 import type { FilterClause, SortClause, Value } from '~/server/bitdex/client';
@@ -2518,36 +2518,21 @@ async function fetchBitdexPrimary(input: ImageSearchInput) {
 export async function getImagesFromSearch(input: ImageSearchInput) {
   let searchFn = getImagesFromSearchPreFilter;
   // Wrap Flipt feature-flag evaluation so the trace shows whether per-request
-  // flag fetch is contributing to the parent span's latency. Includes the
-  // FliptSingleton.getInstance() handshake plus the three evaluateBoolean
-  // calls (FEED_POST_FILTER, MEILI_CACHE_OPS, MEILI_USER_OWN_PASS).
+  // flag fetch is contributing to the parent span's latency. Routes through
+  // getFliptBoolean instead of direct per-request wasm evaluateBoolean calls on
+  // this hot feed path — once the Flipt eval cache (PR #2394) lands these become
+  // memoized; today it's a behavior-preserving refactor. getFliptBoolean returns
+  // false on a missing/uninitialized client, matching the prior null-client
+  // fallthrough (flags default off → pre-filter).
   input = await withSpan('image:flipt:eval', async () => {
-    const fliptClient = await FliptSingleton.getInstance();
-    if (!fliptClient) return input;
-
-    const flag = fliptClient.evaluateBoolean({
-      flagKey: FLIPT_FEATURE_FLAGS.FEED_POST_FILTER,
-      entityId: input.currentUserId?.toString() || 'anonymous',
-      context: {},
-    });
-    if (flag.enabled) searchFn = getImagesFromSearchPostFilter;
-
-    // Evaluate Meili cache flags once; thread through input for builders to gate on.
-    const cacheOpsFlag = fliptClient.evaluateBoolean({
-      flagKey: FLIPT_FEATURE_FLAGS.MEILI_CACHE_OPS,
-      entityId: input.currentUserId?.toString() || 'anonymous',
-      context: {},
-    });
-    const userOwnPassFlag = fliptClient.evaluateBoolean({
-      flagKey: FLIPT_FEATURE_FLAGS.MEILI_USER_OWN_PASS,
-      entityId: input.currentUserId?.toString() || 'anonymous',
-      context: {},
-    });
-    return {
-      ...input,
-      meiliCacheOps: cacheOpsFlag.enabled,
-      meiliUserOwnPass: userOwnPassFlag.enabled,
-    };
+    const entityId = input.currentUserId?.toString() || 'anonymous';
+    const [postFilter, meiliCacheOps, meiliUserOwnPass] = await Promise.all([
+      getFliptBoolean(FLIPT_FEATURE_FLAGS.FEED_POST_FILTER, entityId),
+      getFliptBoolean(FLIPT_FEATURE_FLAGS.MEILI_CACHE_OPS, entityId),
+      getFliptBoolean(FLIPT_FEATURE_FLAGS.MEILI_USER_OWN_PASS, entityId),
+    ]);
+    if (postFilter) searchFn = getImagesFromSearchPostFilter;
+    return { ...input, meiliCacheOps, meiliUserOwnPass };
   });
 
   // Check BitDex mode (off / shadow / primary)
@@ -2636,21 +2621,14 @@ export async function getImagesFromFeedSearch(
   input: ImageSearchInput
 ): Promise<GetAllImagesIndexResult> {
   try {
-    // Evaluate feature flags before creating feed
-    let enableExistenceCheck = false;
-    const fliptClient = await FliptSingleton.getInstance();
-    if (fliptClient) {
-      try {
-        const flag = fliptClient.evaluateBoolean({
-          flagKey: FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
-          entityId: input.currentUserId?.toString() || 'anonymous',
-          context: {},
-        });
-        enableExistenceCheck = flag.enabled;
-      } catch (err) {
-        console.log('[getImagesFromFeedSearch] Flipt evaluation failed:', err);
-      }
-    }
+    // Evaluate feature flags before creating feed. Routed through getFliptBoolean
+    // (memoized once PR #2394's eval cache lands) instead of a direct per-request
+    // wasm eval; it swallows errors and returns false on a missing/uninitialized
+    // client, preserving the prior fail-safe default (existence check off).
+    const enableExistenceCheck = await getFliptBoolean(
+      FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
+      input.currentUserId?.toString() || 'anonymous'
+    );
 
     const feed = new ImagesFeed(
       ({ apiKey, host }: { apiKey: string; host: string }) => {
@@ -3434,17 +3412,13 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     const searchImageIds = filteredHits.map((hit) => hit.id);
     const filteredHitIds = [...new Set(searchImageIds)];
 
-    let cacheExistenceEnabled = false;
-
-    const fliptClient = await FliptSingleton.getInstance();
-    if (fliptClient) {
-      const flag = fliptClient.evaluateBoolean({
-        flagKey: FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
-        entityId: currentUserId?.toString() || 'anonymous',
-        context: {},
-      });
-      cacheExistenceEnabled = flag.enabled;
-    }
+    // Routed through getFliptBoolean (memoized once PR #2394's eval cache lands)
+    // instead of a direct per-request wasm eval; returns false on a missing/
+    // uninitialized client (existence check off), matching the prior default.
+    const cacheExistenceEnabled = await getFliptBoolean(
+      FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
+      currentUserId?.toString() || 'anonymous'
+    );
     ffRequestsTotal.inc({ route, enabled: String(cacheExistenceEnabled) });
 
     if (!cacheExistenceEnabled) {
@@ -4469,17 +4443,13 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     const searchImageIds = limitedHits.map((hit) => hit.id);
     const filteredHitIds = [...new Set(searchImageIds)];
 
-    let cacheExistenceEnabled = false;
-
-    const fliptClient = await FliptSingleton.getInstance();
-    if (fliptClient) {
-      const flag = fliptClient.evaluateBoolean({
-        flagKey: FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
-        entityId: currentUserId?.toString() || 'anonymous',
-        context: {},
-      });
-      cacheExistenceEnabled = flag.enabled;
-    }
+    // Routed through getFliptBoolean (memoized once PR #2394's eval cache lands)
+    // instead of a direct per-request wasm eval; returns false on a missing/
+    // uninitialized client (existence check off), matching the prior default.
+    const cacheExistenceEnabled = await getFliptBoolean(
+      FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
+      currentUserId?.toString() || 'anonymous'
+    );
     ffRequestsTotal.inc({ route, enabled: String(cacheExistenceEnabled) });
 
     if (!cacheExistenceEnabled) {


### PR DESCRIPTION
## Why
A fresh audit of the Flipt eval-cache PR **#2394** found its *motivating* hot path still does direct, un-memoized wasm `evaluateBoolean` calls — so the cache doesn't cover the highest-frequency evals. `getImagesFromSearch` + `getImagesFromFeedSearch` (and two index-feed sites) evaluate **6** flags per feed request directly on the client, bypassing the cache:
- `FEED_POST_FILTER`, `MEILI_CACHE_OPS`, `MEILI_USER_OWN_PASS` (getImagesFromSearch)
- `FEED_IMAGE_EXISTENCE` ×3 (feed-search + 2 index-feed paths)

## Change
Route all 6 through the public `getFliptBoolean` — **same `entityId`, same empty `context`**, so flag-segment evaluation is unchanged. Once #2394's eval cache lands, these become memoized.

- `getFliptBoolean` already returns `false` on a missing/uninitialized client and swallows eval errors, which matches each site's prior fail-safe default (flags off, existence-check off, pre-filter). **Behavior preserved.**
- The explicit `getInstance()` handshakes, null-checks, and one `try/catch` are no longer needed → **net −31 lines**; the 3 evals in `getImagesFromSearch` now run via `Promise.all`.
- `FliptSingleton` import dropped (now unused in this file).

### Behavior-change notes (minor, fail-safe direction)
- Two sites previously had **no** try/catch around the direct eval (would throw on a wasm error); they now get `false` via `getFliptBoolean`'s catch — strictly more robust.
- One site logged `[getImagesFromFeedSearch] Flipt evaluation failed` on error; that log is dropped (getFliptBoolean swallows silently). Tiny observability loss; the flags exist so eval errors are rare.

## Dependency / merge order
The **caching benefit is realized only after #2394 merges** (which adds the memoization to `getFliptBoolean`). On its own, this is a correct, behavior-preserving refactor with no downside either order.

## Verification
Edited regions clean; only the pre-existing stale-local-Prisma-client noise shows in local typecheck (unrelated `$queryRaw`/`Prisma.join` at top of file). CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)