### PR TITLE
perf(flipt): memoize FeatureAccess per-request + build context once + drop dead flags

### DIFF
--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -10,7 +10,6 @@ export enum FLIPT_FEATURE_FLAGS {
 
   GIFT_CARD_VENDOR_WAIFU_WAY = 'gift-card-vendor-waifu-way',
   GIFT_CARD_VENDOR_LEWT_DROP = 'gift-card-vendor-lewt-drop',
-  GIFT_CARD_VENDOR_ROYAL_CD_KEYS = 'gift-card-vendor-royal-cd-keys',
   GIFT_CARD_VENDOR_CRYPTO = 'gift-card-vendor-crypto',
   IMAGE_TRAINING = 'image-training',
   VIDEO_TRAINING = 'video-training',
@@ -32,8 +31,6 @@ export enum FLIPT_FEATURE_FLAGS {
   IMAGE_TRAINING_RESULTS = 'image-training-results',
   CHALLENGE_PLATFORM_ENABLED = 'challenge-platform-enabled',
   B2_UPLOAD_DEFAULT = 'b2-upload-default',
-  B2_IMAGE_UPLOAD = 'b2-image-upload',
-  B2_TRAINING_UPLOAD = 'b2-training-upload',
   COMIC_CREATOR = 'comic-creator',
   GENERATION_PRESETS = 'generation-presets',
   GENERATION_TESTING = 'generation-testing',

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -343,7 +343,10 @@ export function buildFliptContext(user?: SessionUser): Record<string, string> {
 
 const hasFeature = (
   key: FeatureFlagKey,
-  { user, req, host = req?.headers.host }: FeatureAccessContext
+  { user, req, host = req?.headers.host }: FeatureAccessContext,
+  // Built once per getFeatureFlags call and threaded through — previously every
+  // flag rebuilt buildFliptContext(user) (N times/request).
+  fliptContext: Record<string, string>
 ) => {
   const feature = featureFlags[key];
   const { availability } = feature;
@@ -383,7 +386,7 @@ const hasFeature = (
     const fliptResult = _fliptModule.isFliptSync(
       feature.fliptKey,
       user ? String(user.id) : 'anonymous',
-      buildFliptContext(user)
+      fliptContext
     );
     if (fliptResult !== null) {
       if (isDev) {
@@ -429,13 +432,78 @@ const hasFeature = (
 // way against `false` and `undefined`. Removing a flag from the registry shrinks
 // `FeatureFlagKey`, which surfaces a type error at every consumer.
 export type FeatureAccess = Record<FeatureFlagKey, boolean>;
-export const getFeatureFlags = (ctx: FeatureAccessContext) => {
-  const keys = Object.keys(featureFlags) as FeatureFlagKey[];
 
+function computeFeatureFlags(ctx: FeatureAccessContext): FeatureAccess {
+  // Build the Flipt context once and reuse for every flag (was rebuilt per flag).
+  const fliptContext = buildFliptContext(ctx.user);
+  const keys = Object.keys(featureFlags) as FeatureFlagKey[];
   return keys.reduce<FeatureAccess>((acc, key) => {
-    if (hasFeature(key, ctx)) acc[key] = true;
+    if (hasFeature(key, ctx, fliptContext)) acc[key] = true;
     return acc;
   }, {} as FeatureAccess);
+}
+
+// getFeatureFlags is PURE given (user identity, host, region, live Flipt config):
+// same inputs => same FeatureAccess. It runs on every request that touches
+// ctx.features (the image feed does), evaluating ~all flags — each previously
+// rebuilding the Flipt context and calling isFliptSync. Memoize the whole result
+// with a short TTL so repeat requests from the same (user, host, region) — e.g.
+// one user scrolling the feed (many getInfinite calls) — skip the per-flag work.
+//
+// KEY COMPLETENESS IS A CORRECTNESS INVARIANT. The cache key must include EVERY
+// input hasFeature reads: user id/isModerator/tier/permissions, host (domain
+// gating), and the FULL region. Region gates compliance-sensitive
+// restricted-region features, so two different regions must NEVER share an entry
+// — the whole region object is serialized into the key to guarantee that. Live
+// Flipt config changes are bounded by the TTL (same staleness as the per-eval
+// cache in flipt/client.ts). Mutation-safety: the cached object is never handed
+// out — callers always get a shallow copy.
+const FEATURE_ACCESS_TTL_MS = 10_000;
+const FEATURE_ACCESS_MAX = 20_000;
+type FeatureAccessEntry = { value: FeatureAccess; expiresAt: number };
+let featureAccessCur = new Map<string, FeatureAccessEntry>();
+let featureAccessPrev = new Map<string, FeatureAccessEntry>();
+
+function featureAccessKey({ user, req, host = req?.headers.host }: FeatureAccessContext): string {
+  // In dev, checkRegionAccess bypasses region entirely, so it can't affect the
+  // result and is omitted from the key.
+  const region = isDev ? undefined : getRegion(req);
+  const u = user
+    ? `u:${user.id}:${user.isModerator ? 1 : 0}:${user.tier ?? 'free'}:${(user.permissions ?? [])
+        .slice()
+        .sort()
+        .join(',')}`
+    : 'anon';
+  return `${u}|h:${host ?? ''}|r:${region ? JSON.stringify(region) : ''}`;
+}
+
+export const getFeatureFlags = (ctx: FeatureAccessContext): FeatureAccess => {
+  const now = Date.now();
+  const key = featureAccessKey(ctx);
+
+  let entry = featureAccessCur.get(key);
+  if (entry) {
+    if (entry.expiresAt > now) return { ...entry.value };
+    featureAccessCur.delete(key);
+  }
+  entry = featureAccessPrev.get(key);
+  if (entry) {
+    if (entry.expiresAt > now) {
+      featureAccessPrev.delete(key);
+      featureAccessCur.set(key, entry); // promote so hot keys survive rotation
+      return { ...entry.value };
+    }
+    featureAccessPrev.delete(key);
+  }
+
+  const value = computeFeatureFlags(ctx);
+  // Generational rotation (bounds memory to ~2x MAX without a full-clear thrash).
+  if (featureAccessCur.size >= FEATURE_ACCESS_MAX) {
+    featureAccessPrev = featureAccessCur;
+    featureAccessCur = new Map();
+  }
+  featureAccessCur.set(key, { value, expiresAt: now + FEATURE_ACCESS_TTL_MS });
+  return { ...value };
 };
 
 export function getFeatureFlagsLazy(ctx: FeatureAccessContext) {

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -466,8 +466,9 @@ let featureAccessPrev = new Map<string, FeatureAccessEntry>();
 
 function featureAccessKey({ user, req, host = req?.headers.host }: FeatureAccessContext): string {
   // In dev, checkRegionAccess bypasses region entirely, so it can't affect the
-  // result and is omitted from the key.
-  const region = isDev ? undefined : getRegion(req);
+  // result and is omitted from the key. Also guard a nullish req (parity with
+  // checkRegionAccess's `if (req)`) so key construction never throws.
+  const region = isDev || !req ? undefined : getRegion(req);
   const u = user
     ? `u:${user.id}:${user.isModerator ? 1 : 0}:${user.tier ?? 'free'}:${(user.permissions ?? [])
         .slice()


### PR DESCRIPTION
## Why
A post-deploy CPU pin profile showed Flipt wasm eval still ~3% of busy CPU. Investigation found the dominant cost isn't the feed flags — it's **`getFeatureFlags`, which evaluates ~all 42 `fliptKey` flags on every request that touches `ctx.features`** (the image feed always does). Each flag rebuilt `buildFliptContext(user)` and called `isFliptSync`, and the per-user `entityId` defeats the per-eval cache under a high-cardinality user burst.

## Changes
1. **Build `buildFliptContext` once per `getFeatureFlags`** (was rebuilt per flag, ~42×/request) and thread it through `hasFeature`. Pure perf, no behavior change.
2. **Memoize the whole `getFeatureFlags` result** (10s TTL, generational cache). `getFeatureFlags` is pure given (user identity, host, region, live Flipt config), so a repeat request from the same `(user, host, region)` — e.g. one user scrolling the feed (many `getInfinite` calls) — skips all per-flag work.
3. **Remove 3 dead enum entries** (zero references anywhere): `B2_IMAGE_UPLOAD`, `B2_TRAINING_UPLOAD`, `GIFT_CARD_VENDOR_ROYAL_CD_KEYS`.

## ⚠️ Correctness invariant (please scrutinize)
The memo is only safe if the cache key includes **every** input `hasFeature` reads. The key includes:
- user `id` / `isModerator` / `tier` / sorted `permissions`
- `host` (domain/color gating)
- the **FULL region** object, JSON-serialized — **region gates compliance-sensitive restricted-region features, so two different regions must never share an entry.** Serializing the whole region guarantees a missed dimension can't leak.

Staleness from live Flipt-config changes is bounded by the 10s TTL (same as the per-eval cache in `flipt/client.ts`). A change to a user's tier/mod/permissions changes the key → fresh compute (no stale entitlement beyond the request it changes on). The cached object is never handed out — callers receive a shallow copy (mutation-safe). Memory is bounded ~2× `FEATURE_ACCESS_MAX` via generational rotation.

## Note
This doesn't reduce the **count** of 42 fliptKey flags — that needs ripping the dead *experiment* flags from the `fliptKey` table (needs live Flipt state / owner confirmation of which are dead). This PR makes the per-request cost near-zero on cache hits regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)