### PR TITLE
perf(trpc): swap superjson → devalue data transformer [DRAFT — NEEDS QA]

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -103,7 +103,9 @@ export default defineNextConfig(
             // removeConsole: true,
           }
         : {},
-    transpilePackages: [],
+    // devalue is ESM-only (the tRPC data transformer); transpile so the CJS
+    // server build can require it without ERR_REQUIRE_ESM.
+    transpilePackages: ['devalue'],
     experimental: {
       // scrollRestoration: true,
       cpus: 8,

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "cookies-next": "^2.1.1",
     "dayjs": "^1.11.12",
     "decimal.js": "^10.5.0",
+    "devalue": "^5.8.1",
     "discord-api-types": "^0.38.37",
     "discord.js": "^14.7.1",
     "dotenv": "^16.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,9 @@ importers:
       decimal.js:
         specifier: ^10.5.0
         version: 10.6.0
+      devalue:
+        specifier: ^5.8.1
+        version: 5.8.1
       discord-api-types:
         specifier: ^0.38.37
         version: 0.38.37
@@ -5368,6 +5371,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -15573,6 +15579,8 @@ snapshots:
   detect-libc@2.0.4: {}
 
   detect-node-es@1.1.0: {}
+
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:

--- a/src/server/services/buzz-withdrawal-request.service.ts
+++ b/src/server/services/buzz-withdrawal-request.service.ts
@@ -670,19 +670,24 @@ export const updateBuzzWithdrawalRequest = async ({
   return await Promise.all(
     requests.map(async (req) => {
       try {
-        // Worse case is we'll need to re-process it alone, hence nothing too bad. We'll just return the error.
-        return processRequest(req);
+        // `await` so the catch below actually fires (without it the rejection
+        // escapes to Promise.all and the log never runs).
+        return await processRequest(req);
       } catch (e) {
         await logToAxiom({
           type: 'update-buzz-withdrawal-request-error',
           message: 'Failed to update withdrawal request',
           data: {
             requestId: req.id,
-            error: e,
+            error: e instanceof Error ? e.message : String(e),
           },
         });
 
-        return e;
+        // Re-throw rather than `return e`: returning an Error instance is
+        // unserializable by the devalue tRPC transformer (→ 500). Throwing
+        // surfaces the failure via tRPC's error channel, matching the prior
+        // effective behavior (any failed request fails the mutation).
+        throw e;
       }
     })
   );

--- a/src/server/services/paddle.service.ts
+++ b/src/server/services/paddle.service.ts
@@ -1068,7 +1068,11 @@ export const getAdjustmentsInfinite = async ({
   }
 
   return {
-    items: data,
+    // Paddle SDK returns `Adjustment` class instances (with nested AdjustmentItem/
+    // TotalAdjustments/PayoutTotalsAdjustment instances). The devalue tRPC
+    // transformer is strict and throws on class instances → 500. Coerce to plain
+    // objects; faithful since the SDK stores all data on public enumerable fields.
+    items: JSON.parse(JSON.stringify(data)) as Adjustment[],
     nextCursor: nextItem?.id,
   };
 };

--- a/src/server/services/paddle.service.ts
+++ b/src/server/services/paddle.service.ts
@@ -787,7 +787,11 @@ export const cancelSubscriptionPlan = async ({ userId }: { userId: number }) => 
 
     return true;
   } catch (e) {
-    return new Error('Failed to cancel subscription');
+    // Throw (not return) the Error: callers use .catch()/try-catch and expect a
+    // rejection on failure, and returning an Error instance as success data is a
+    // latent bug — it serialized to `{}` under superjson and THROWS under devalue
+    // (the tRPC transformer can't serialize a non-POJO class instance).
+    throw new Error('Failed to cancel subscription');
   }
 };
 

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -1,8 +1,8 @@
 import { initTRPC, TRPCError } from '@trpc/server';
 import type { NextApiRequest } from 'next';
 import semver from 'semver';
-import superjson from 'superjson';
 import { OnboardingSteps } from '~/server/common/enums';
+import { trpcTransformer } from '~/shared/utils/trpc-transformer';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -36,8 +36,8 @@ const t = initTRPC
   .create({
     transformer: {
       serialize: (data: any) =>
-        withSpan('trpc:serialize:superjson', () => superjson.serialize(data)),
-      deserialize: superjson.deserialize.bind(superjson),
+        withSpan('trpc:serialize:devalue', () => trpcTransformer.serialize(data)),
+      deserialize: trpcTransformer.deserialize,
     },
     errorFormatter({ shape }) {
       return shape;

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -1,7 +1,7 @@
 import { createServerSideHelpers } from '@trpc/react-query/server';
 import type { GetServerSidePropsContext, GetServerSidePropsResult, Redirect } from 'next';
 import type { Session } from 'next-auth';
-import superjson from 'superjson';
+import { trpcTransformer } from '~/shared/utils/trpc-transformer';
 import { Tracker } from '~/server/clickhouse/client';
 
 import { appRouter } from '~/server/routers';
@@ -34,7 +34,7 @@ export const getServerProxySSGHelpers = async (
       apiKeyId: undefined,
       subject: undefined,
     },
-    transformer: superjson,
+    transformer: trpcTransformer,
   });
   return ssg;
 };

--- a/src/shared/utils/trpc-transformer.ts
+++ b/src/shared/utils/trpc-transformer.ts
@@ -1,0 +1,18 @@
+import { parse, stringify } from 'devalue';
+
+// Isomorphic tRPC data transformer (client + server MUST use this exact object).
+//
+// Replaces superjson with devalue: ~2.7x faster serialize / ~13x faster
+// deserialize on the Date-heavy feed payloads (superjson's plainer.js walker was
+// ~10% of busy main-thread CPU in a prod pin profile). devalue natively handles
+// Date, Map, Set, BigInt, RegExp, undefined, and repeated/circular references.
+//
+// ⚠️ devalue is STRICT: it THROWS on values it doesn't recognize — notably
+// non-builtin class instances (Prisma Decimal, dayjs objects, custom classes).
+// superjson silently coerced those to plain objects (lossy). Any tRPC procedure
+// that returns such a value must be changed to return a POJO/number/Date before
+// this can ship. This is the migration's main risk — see PR notes.
+export const trpcTransformer = {
+  serialize: (object: unknown) => stringify(object),
+  deserialize: (object: string) => parse(object),
+};

--- a/src/shared/utils/trpc-transformer.ts
+++ b/src/shared/utils/trpc-transformer.ts
@@ -14,5 +14,12 @@ import { parse, stringify } from 'devalue';
 // this can ship. This is the migration's main risk — see PR notes.
 export const trpcTransformer = {
   serialize: (object: unknown) => stringify(object),
-  deserialize: (object: string) => parse(object),
+  // devalue.parse() requires a string (it JSON.parses internally). tRPC hands
+  // deserialize a non-string when there's no serialized input to decode — e.g.
+  // a GET to a mutation with no `?input=`, or a no-input procedure — passing an
+  // empty object `{}`, which would become JSON.parse("[object Object]") → a
+  // bogus BAD_REQUEST. superjson tolerated this; devalue is strict. Only parse
+  // real (string) payloads; pass non-strings through so downstream zod handles
+  // absent/empty input normally.
+  deserialize: (object: unknown) => (typeof object === 'string' ? parse(object) : object),
 };

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -5,7 +5,7 @@ import { createTRPCClient, httpLink, loggerLink, splitLink } from '@trpc/client'
 import type { CreateTRPCNext } from '@trpc/next';
 import { createTRPCNext } from '@trpc/next';
 import type { NextPageContext } from 'next';
-import superjson from 'superjson';
+import { trpcTransformer } from '~/shared/utils/trpc-transformer';
 import type { AppRouter } from '~/server/routers';
 import { isDev } from '~/env/other';
 import { env } from '~/env/client';
@@ -59,8 +59,8 @@ function httpLinkWithLargeQuerySupport({
 }): TRPCLink<AppRouter> {
   return splitLink({
     condition: isLargeQuery,
-    true: httpLink({ transformer: superjson, url, methodOverride: 'POST', headers }),
-    false: httpLink({ transformer: superjson, url, headers }),
+    true: httpLink({ transformer: trpcTransformer, url, methodOverride: 'POST', headers }),
+    false: httpLink({ transformer: trpcTransformer, url, headers }),
   });
 }
 const headers: RequestHeaders = {
@@ -201,7 +201,7 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext> = createTRPCNext<A
   // v11: `createTRPCNext` requires the transformer at the top level of its options
   // (WithTRPCOptions intersects TransformerOptions). The link carries it too for the
   // actual wire (de)serialization.
-  transformer: superjson,
+  transformer: trpcTransformer,
   ssr: false,
 });
 


### PR DESCRIPTION
> **DRAFT — do not merge on green CI alone. This is an app-wide serialization change that needs a runtime QA pass.**

## Why
superjson's `plainer.js` object-graph walker was **~10% of busy main-thread CPU** in a prod pin profile. superjson is pinned at **1.9.1** and there is no release that speeds up the walker. **devalue** (`stringify`/`parse`) is **~2.7× faster serialize / ~13× faster deserialize** (Rich Harris's benchmark vs 1.9.1) on the Date-heavy feed payloads, and natively handles `Date`/`Map`/`Set`/`BigInt`/`RegExp`/`undefined`.

## What changed
- New isomorphic transformer `src/shared/utils/trpc-transformer.ts` (client + server must use the exact same object).
- Wired into **every** site that agrees on the wire format: server `initTRPC`, client `httpLink` (×2, used by both `trpc` and `trpcVanilla`) + `createTRPCNext` top-level, and the **SSR** `createServerSideHelpers` (dehydrate/rehydrate).
- devalue is **ESM-only** → added to `next.config` `transpilePackages` to avoid `ERR_REQUIRE_ESM` in the CJS server build.
- superjson left in `package.json` for now; removable once verified.

## ⚠️ The migration risk — devalue is STRICT
superjson silently coerced unknown values (lossy); **devalue THROWS** on anything it doesn't recognize — notably **non-builtin class instances**: Prisma `Decimal`, `dayjs` objects, custom classes. Any tRPC procedure that returns such a value (today serialized lossily by superjson) will now **error**. CI build + typecheck validate ESM/transpile + types, but **they will not catch this** — it's runtime.

## Required QA before un-drafting
- [ ] Build passes (validates ESM transpile)
- [ ] Image feed (`getInfinite` / `getImagesAsPosts`) renders; Dates correct
- [ ] A representative set of **mutations** round-trip
- [ ] **SSR pages hydrate** without `Unable to transform response` / hydration mismatch
- [ ] Audit/spot-check endpoints that may return `Decimal` (buzz/payments) or `dayjs`/class instances — fix them to return POJO/number/Date
- [ ] Confirm `trpc:serialize:devalue` span time drops vs the old `trpc:serialize:superjson`

## Rollback
Single-commit revert restores superjson (client+server together). Keep superjson installed until this bakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)