### PR TITLE
perf(otel): drop Prisma + outgoing-HTTP instrumentation spans

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -113,7 +113,24 @@ if (!OTEL_ENABLED) {
       // Prometheus), and DB pool metrics are separate labeled gauges
       // (db/db-helpers.ts). So no dashboard depends on these spans. The custom
       // withSpan() instrumentation on specific hot calls is unaffected.
-      instrumentations: [new HttpInstrumentation()],
+      instrumentations: [
+        // HttpInstrumentation narrowed to INBOUND-only. The app makes many
+        // outbound client requests per request (orchestrator, S3, meilisearch,
+        // clickhouse, …); each outgoing client span is another async_hooks
+        // context.with + span alloc on the hot path — the same structural cost
+        // head sampling can't remove. ignoreOutgoingRequestHook returning true
+        // for every outgoing request suppresses those client spans while keeping
+        // incoming server-request spans (the per-request root span) intact.
+        // (instrumentation-http@0.213.0 also exposes
+        // disableOutgoingRequestInstrumentation, which skips patching outbound
+        // entirely; the ignore hook is used here to match the option named in the
+        // plan and keep the outbound code path patched for any future per-call
+        // allow-listing.) Tradeoff: we lose distributed-trace propagation to
+        // downstream services (no outbound traceparent spans). Accepted for the
+        // CPU win — an explicitly listed next lever. The custom withSpan()
+        // instrumentation on specific hot calls is unaffected.
+        new HttpInstrumentation({ ignoreOutgoingRequestHook: () => true }),
+      ],
     });
 
     sdk.start();

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -114,21 +114,22 @@ if (!OTEL_ENABLED) {
       // (db/db-helpers.ts). So no dashboard depends on these spans. The custom
       // withSpan() instrumentation on specific hot calls is unaffected.
       instrumentations: [
-        // HttpInstrumentation narrowed to INBOUND-only. The app makes many
-        // outbound client requests per request (orchestrator, S3, meilisearch,
-        // clickhouse, …); each outgoing client span is another async_hooks
-        // context.with + span alloc on the hot path — the same structural cost
-        // head sampling can't remove. ignoreOutgoingRequestHook returning true
-        // for every outgoing request suppresses those client spans while keeping
-        // incoming server-request spans (the per-request root span) intact.
+        // HttpInstrumentation narrowed to INBOUND-only. It only ever patched Node
+        // core http/https, so the affected outbound spans are the core-http
+        // clients (S3 via @aws-sdk, ClickHouse, axios/signals) — NOT orchestrator
+        // or meilisearch, which use fetch/undici and were never auto-instrumented
+        // (their visibility comes from manual withSpan()). Each remaining outgoing
+        // client span is another async_hooks context.with + span alloc on the hot
+        // path — the structural cost head sampling can't remove.
+        // ignoreOutgoingRequestHook returning true for every outgoing request
+        // suppresses those client spans (and their traceparent injection) while
+        // keeping incoming server-request spans (the per-request root) intact.
         // (instrumentation-http@0.213.0 also exposes
         // disableOutgoingRequestInstrumentation, which skips patching outbound
-        // entirely; the ignore hook is used here to match the option named in the
-        // plan and keep the outbound code path patched for any future per-call
-        // allow-listing.) Tradeoff: we lose distributed-trace propagation to
-        // downstream services (no outbound traceparent spans). Accepted for the
-        // CPU win — an explicitly listed next lever. The custom withSpan()
-        // instrumentation on specific hot calls is unaffected.
+        // entirely; the ignore hook is used here to keep the path patched for
+        // future per-call allow-listing.) Tradeoff: lost cross-service trace
+        // linkage for S3/ClickHouse — observability-only; nothing in the app reads
+        // traceparent functionally. The custom withSpan() spans are unaffected.
         new HttpInstrumentation({ ignoreOutgoingRequestHook: () => true }),
       ],
     });

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -14,7 +14,6 @@ import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs
 import { logs } from '@opentelemetry/api-logs';
 import { trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import { PrismaInstrumentation } from '@prisma/instrumentation';
 import { registerCpuProfiler } from '~/server/cpu-profiler';
 
 // Arm the on-demand, signal-triggered V8 CPU profiler. Zero steady-state
@@ -103,7 +102,18 @@ if (!OTEL_ENABLED) {
       // the CPU win; if per-command redis latency is needed later, add a
       // low-cardinality prom histogram around sendCommand (cheaper than a span —
       // no context.with / async_hooks propagation).
-      instrumentations: [new HttpInstrumentation(), new PrismaInstrumentation()],
+      //
+      // PrismaInstrumentation intentionally omitted for the same structural reason:
+      // it wraps every query on the hot DB path, and each query span pays the
+      // async_hooks context-propagation cost (context.with + span alloc) that head
+      // sampling can't remove — the context manager runs for every span regardless
+      // of the sampling decision. Observability tradeoff: this removes Prisma query
+      // spans, but the app's RED/latency dashboards are prom-client based
+      // (src/server/prom/client.ts), NOT OTEL spanmetrics (which aren't scraped into
+      // Prometheus), and DB pool metrics are separate labeled gauges
+      // (db/db-helpers.ts). So no dashboard depends on these spans. The custom
+      // withSpan() instrumentation on specific hot calls is unaffected.
+      instrumentations: [new HttpInstrumentation()],
     });
 
     sdk.start();


### PR DESCRIPTION
Two OTEL CPU-reduction levers (follow-up to #2408 which dropped RedisInstrumentation). Single file `src/instrumentation.node.ts`, two independently-revertable commits.

## Rationale
A post-deploy pin CPU profile attributed ~16% of *busy* CPU to OTEL/instrumentation — async_hooks context-propagation (`context.with` + span alloc) that head sampling can't remove (the context manager runs per span regardless of the sampling decision). #2408 dropped the highest-frequency span source (Redis); this drops the next two.

## Commit 1 — drop `PrismaInstrumentation`
Removes Prisma query spans (one per query on the hot DB path). Mirrors #2408's pattern.

## Commit 2 — `HttpInstrumentation({ ignoreOutgoingRequestHook: () => true })`
Suppresses **outbound** client spans, keeps **inbound** server spans (`@opentelemetry/instrumentation-http@0.213.0`; `ignoreOutgoingRequestHook` verified in that version's types). Returning `true` skips span creation → avoids the `context.with`/async_hooks cost.

**Correction (per audit):** HttpInstrumentation only patches Node **core http/https**. So the dropped outbound spans are **S3 (@aws-sdk), ClickHouse, and axios/signals** — **NOT orchestrator or meilisearch**, which use `fetch`/undici and were never auto-instrumented (their span visibility comes entirely from manual `withSpan()`). The earlier "orchestrator/meili" framing was wrong.

## Observability trade-offs (verified harmless)
- Lost: Prisma query spans + S3/ClickHouse outbound client spans + outbound `traceparent` injection (cross-service trace linkage).
- **No functional consumer:** grep confirms nothing in-repo reads `traceparent`/propagation functionally; no downstream requires it. Loss is observability-only.
- **No dashboard breaks:** RED/latency are prom-client (`src/server/prom/client.ts`), DB pool is labeled gauges (`db/db-helpers.ts`); OTEL spanmetrics aren't scraped into Prometheus. No trace-based alerting/SLO/span-cost dashboards exist.
- Prisma `tracing` preview is **not** enabled (`schema.prisma` previewFeatures = `["metrics"]`), so no orphaned spans. Custom `withSpan()` spans (incl. meili/bitdex, which carry http attrs themselves) are unaffected and still parent off the retained inbound root.

## Audit verdict
Two adversarial audits → **SHIP-WITH-NITS**. No correctness/availability/request-path risk; clean independent revert per commit; `OTEL_ENABLED` kill-switch intact.

## ⚠️ Measurement caveat
OTEL span volume isn't in Prometheus, and #2408 (Redis, higher-frequency) showed **no steady-state CPU change** post-deploy. Treat the CPU win as a **hypothesis to validate via a fresh pin CPU profile** (compare OTEL/instrumentation self-time vs the ~16% baseline) — not a delivered steady-state result.

## Recommended follow-ups (not blocking)
- Remove now-dead `@prisma/instrumentation` + `@opentelemetry/instrumentation-redis` entries from `next.config.mjs` `serverComponentsExternalPackages`.
- If traces become a real debugging surface: inject `trace_id` into `logToAxiom` and add a `withSpan`/prom histogram around S3 + ClickHouse hot calls (the two downstreams that lost auto spans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)