### PR TITLE
fix: decouple post image resource limits from generator limits

### DIFF
--- a/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
+++ b/src/components/Post/EditV2/PostImageCards/AddedImage.tsx
@@ -43,10 +43,7 @@ import { dialogStore } from '~/components/Dialog/dialogStore';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { RefreshImageResources } from '~/components/Image/RefreshImageResources/RefreshImageResources';
 import { UnblockImage } from '~/components/Image/UnblockImage/UnblockImage';
-import {
-  isMadeOnSite,
-  useGenerationStatus,
-} from '~/components/ImageGeneration/GenerationForm/generation.utils';
+import { isMadeOnSite } from '~/components/ImageGeneration/GenerationForm/generation.utils';
 import { ResourceSelectMultiple } from '~/components/ImageGeneration/GenerationForm/ResourceSelectMultiple';
 import { BrowsingLevelBadge } from '~/components/BrowsingLevel/BrowsingLevelBadge';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
@@ -64,7 +61,7 @@ import { PostImageTool } from '~/components/Post/EditV2/Tools/PostImageTool';
 import { ImageToolsPopover } from '~/components/Post/EditV2/Tools/PostImageToolsPopover';
 import { VotableTags } from '~/components/VotableTags/VotableTags';
 import { useCurrentUserRequired } from '~/hooks/useCurrentUser';
-import { DEFAULT_EDGE_IMAGE_WIDTH } from '~/server/common/constants';
+import { DEFAULT_EDGE_IMAGE_WIDTH, POST_IMAGE_RESOURCE_LIMIT } from '~/server/common/constants';
 import type { NsfwLevel } from '~/server/common/enums';
 import { BlockedReason } from '~/server/common/enums';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
@@ -353,10 +350,9 @@ function Preview() {
 }
 
 const ResourceHeader = () => {
-  const status = useGenerationStatus();
   const { image, allowedResources, addResource, isAddingResource, canAdd } = useAddedImageContext();
 
-  const cantAdd = image.resourceHelper.length >= status.limits.resources;
+  const cantAdd = image.resourceHelper.length >= POST_IMAGE_RESOURCE_LIMIT;
 
   const [updateImage] = usePostEditStore((state) => [state.updateImage]);
 
@@ -402,7 +398,7 @@ const ResourceHeader = () => {
               </InfoPopover>
             </Box>
             <Tooltip
-              label={`Maximum resources reached (${status.limits.resources})`}
+              label={`Maximum resources reached (${POST_IMAGE_RESOURCE_LIMIT})`}
               disabled={!cantAdd}
             >
               <ResourceSelectMultiple
@@ -446,7 +442,6 @@ const ResourceHeader = () => {
 
 const ResourceRow = ({ resource, i }: { resource: ResourceHelper; i: number }) => {
   const { image, canAdd, otherImages } = useAddedImageContext();
-  const status = useGenerationStatus();
   const [updateImage] = usePostEditStore((state) => [state.updateImage]);
 
   const { modelId, modelName, modelType, modelVersionId, modelVersionName, detected } = resource;
@@ -455,7 +450,7 @@ const ResourceRow = ({ resource, i }: { resource: ResourceHelper; i: number }) =
     return otherImages
       .map((oi) => {
         // Skip if target image is at resource limit
-        if (oi.resourceHelper.length >= status.limits.resources) return null;
+        if (oi.resourceHelper.length >= POST_IMAGE_RESOURCE_LIMIT) return null;
         // Skip if target image already has this exact resource
         if (oi.resourceHelper.some((rh) => rh.modelVersionId === modelVersionId)) return null;
 
@@ -463,7 +458,7 @@ const ResourceRow = ({ resource, i }: { resource: ResourceHelper; i: number }) =
         return oi.id;
       })
       .filter(isDefined);
-  }, [modelVersionId, otherImages, status.limits.resources]);
+  }, [modelVersionId, otherImages]);
 
   const copyResourceMutation = trpc.post.addResourceToImage.useMutation({
     onSuccess: (resp) => {

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -467,7 +467,7 @@ export type ComponentFileType = (typeof componentFileTypes)[number];
 
 export const POST_IMAGE_LIMIT = 20;
 export const POST_TAG_LIMIT = 5;
-export const POST_IMAGE_RESOURCE_LIMIT = 20;
+export const POST_IMAGE_RESOURCE_LIMIT = 9;
 export const POST_MINIMUM_SCHEDULE_MINUTES = 60;
 export const CAROUSEL_LIMIT = 20;
 export const DEFAULT_EDGE_IMAGE_WIDTH = 450;

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -467,6 +467,7 @@ export type ComponentFileType = (typeof componentFileTypes)[number];
 
 export const POST_IMAGE_LIMIT = 20;
 export const POST_TAG_LIMIT = 5;
+export const POST_IMAGE_RESOURCE_LIMIT = 20;
 export const POST_MINIMUM_SCHEDULE_MINUTES = 60;
 export const CAROUSEL_LIMIT = 20;
 export const DEFAULT_EDGE_IMAGE_WIDTH = 450;

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -4,6 +4,7 @@ import type { SessionUser } from 'next-auth';
 import * as z from 'zod';
 import { isMadeOnSite } from '~/components/ImageGeneration/GenerationForm/generation.utils';
 import { env } from '~/env/server';
+import { POST_IMAGE_RESOURCE_LIMIT } from '~/server/common/constants';
 import { BlockedReason, PostSort, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
@@ -1251,44 +1252,10 @@ export const addResourceToPostImage = async ({
     throw throwBadRequestError('Cannot add resources to on-site generations.');
   }
 
-  const simpleResourceLimit = 8;
-  const baseAxiom = {
-    type: 'warning',
-    name: 'fetch-generation-status',
-    path: 'post.addResourceToImage',
-  };
-
-  let resourceLimit = simpleResourceLimit;
-  try {
-    const genStatus = await getGenerationStatus();
-    if (genStatus) {
-      const tier = user?.tier ?? 'free';
-      if (isDefined(genStatus.limits?.[tier]?.resources)) {
-        resourceLimit = genStatus.limits[tier].resources ?? simpleResourceLimit;
-      } else {
-        logToAxiom({
-          ...baseAxiom,
-          message: 'no resource limit found',
-        }).catch();
-      }
-    } else {
-      logToAxiom({
-        ...baseAxiom,
-        message: 'no gen status',
-      }).catch();
-    }
-  } catch (e: unknown) {
-    const error = e as Error;
-    logToAxiom({
-      ...baseAxiom,
-      message: error?.message,
-    }).catch();
-  }
-
   images.forEach((img) => {
     const numExistingResources = img.resourceHelper.length;
-    if (numExistingResources >= resourceLimit) {
-      throw throwBadRequestError(`Maximum resources reached (${resourceLimit})`);
+    if (numExistingResources >= POST_IMAGE_RESOURCE_LIMIT) {
+      throw throwBadRequestError(`Maximum resources reached (${POST_IMAGE_RESOURCE_LIMIT})`);
     }
   });
 

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -40,7 +40,6 @@ import {
 } from '~/server/services/collection.service';
 import { Limiter } from '~/server/utils/concurrency-helpers';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
-import { getGenerationStatus } from '~/server/services/generation/generation.service';
 import {
   createImage,
   createImageResources,


### PR DESCRIPTION
## Decouple Post Image Resource Limits from Generator Limits

### Root Cause Analysis
Previously, manual resource addition to uploaded images on posts was governed by the generator status limits (`status.limits.resources` in the frontend and `getGenerationStatus` in the backend).
These limits dynamically vary depending on the user's tier (e.g., free vs. paid) and system load, and were recently reduced to **3** to optimize GPU usage during generation.

Applying this generator-specific limit to uploaded/off-site post images was a regression (introduced in Dec 2024 via commit `4e5acc2da8`) because uploaded images do not consume GPU generation resources. This resulted in users being blocked from manually adding more than 3 resources to their uploaded images, displaying the tooltip `"Maximum resources reached (3)"`.

### Solution Details
This PR decouples the resource limit for uploaded/off-site post images from generator limits by introducing a static, dedicated limit for post resources:
1. **New Constant**: Added `POST_IMAGE_RESOURCE_LIMIT = 9` in `src/server/common/constants.ts`. This matches the pre-GPU-crunch limit that free/founder users had in the generator, which is reasonable for post image tagging.
2. **Server-Side Validation**: Updated `addResourceToPostImage` in `src/server/services/post.service.ts` to enforce `POST_IMAGE_RESOURCE_LIMIT` instead of querying `getGenerationStatus`.
3. **Frontend UI Integration**: Updated `src/components/Post/EditV2/PostImageCards/AddedImage.tsx` to reference `POST_IMAGE_RESOURCE_LIMIT` instead of `status.limits.resources`. The popover, copy-to-all checks, and tooltips now correctly reflect and enforce the new limit of 9.
4. **No UI Regression**: The visual collapse behavior ("Show All / Show Less" when displaying resources) remains untouched and continues to function exactly as before (collapsing when resources > 3).
5. **No Generator Impact**: This only affects uploaded/offsite images; on-site generated images and the actual image generator limits remain completely untouched.