### PR TITLE
fix(buzz): degrade buzz reads to primary when read-replica connection is down

### DIFF
--- a/src/server/db/__tests__/db-lag-helpers.test.ts
+++ b/src/server/db/__tests__/db-lag-helpers.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The repo's slim-generated Prisma client does not expose the error constructors
+// at runtime, so we model the shapes (name / code / message) the engine emits.
+function prismaError({ name, code, message }: { name?: string; code?: string; message?: string }) {
+  const err = new Error(message ?? name ?? code ?? 'error');
+  if (name) err.name = name;
+  if (code) (err as Error & { code?: string }).code = code;
+  return err;
+}
+
+// db-lag-helpers reads env at module load and imports flipt/redis transitively;
+// stub the side-effectful dependencies so the unit under test is isolated.
+const { mockDbRead, mockDbWrite, mockFallbackInc } = vi.hoisted(() => ({
+  mockDbRead: { tag: 'read' } as unknown as Record<string, unknown>,
+  mockDbWrite: { tag: 'write' } as unknown as Record<string, unknown>,
+  mockFallbackInc: vi.fn(),
+}));
+
+vi.mock('~/env/server', () => ({
+  env: { REPLICATION_LAG_DELAY: 0 },
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/db/notifDb', () => ({ notifDbRead: {}, notifDbWrite: {} }));
+vi.mock('~/server/flipt/client', () => ({
+  FLIPT_FEATURE_FLAGS: { HIGH_REPLICATION_LAG_MODE: 'high-replication-lag-mode' },
+  isFliptSync: () => false,
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn() },
+  REDIS_KEYS: { LAG_HELPER: 'lag-helper' },
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('~/server/prom/client', () => ({
+  dbReadFallbackCounter: { inc: mockFallbackInc },
+}));
+
+import { isDbConnectionError, readWithReplicaFallback } from '~/server/db/db-lag-helpers';
+
+describe('isDbConnectionError', () => {
+  it('treats PrismaClientInitializationError as a connection error', () => {
+    const err = prismaError({ name: 'PrismaClientInitializationError', message: 'cannot reach db' });
+    expect(isDbConnectionError(err)).toBe(true);
+    expect(
+      isDbConnectionError(prismaError({ name: 'PrismaClientRustPanicError', message: 'panic' }))
+    ).toBe(true);
+  });
+
+  it('treats known connection error codes as connection errors', () => {
+    for (const code of ['P1001', 'P1002', 'P1008', 'P1017', 'P2024']) {
+      const err = prismaError({ name: 'PrismaClientKnownRequestError', code, message: 'conn' });
+      expect(isDbConnectionError(err)).toBe(true);
+    }
+  });
+
+  it('treats the incident "kind: Closed" socket message as a connection error', () => {
+    expect(isDbConnectionError(new Error('PostgreSQL connection: Error { kind: Closed }'))).toBe(
+      true
+    );
+    expect(isDbConnectionError(new Error('Connection terminated unexpectedly'))).toBe(true);
+    expect(isDbConnectionError(new Error('connect ECONNREFUSED 10.0.0.1:6432'))).toBe(true);
+  });
+
+  it('does NOT treat genuine query errors (e.g. unique violation) as connection errors', () => {
+    const err = prismaError({
+      name: 'PrismaClientKnownRequestError',
+      code: 'P2002',
+      message: 'unique constraint',
+    });
+    expect(isDbConnectionError(err)).toBe(false);
+  });
+
+  it('does not misclassify arbitrary errors', () => {
+    expect(isDbConnectionError(new Error('relation does not exist'))).toBe(false);
+    expect(isDbConnectionError(undefined)).toBe(false);
+    expect(isDbConnectionError('boom')).toBe(false);
+  });
+});
+
+describe('readWithReplicaFallback', () => {
+  beforeEach(() => {
+    mockFallbackInc.mockClear();
+  });
+
+  it('reads from the replica (RO) connection on the happy path', async () => {
+    const read = vi.fn(async (db: unknown) => (db === mockDbRead ? 'ro-result' : 'rw-result'));
+
+    const result = await readWithReplicaFallback(read as never, {
+      entity: 'userMultiplier',
+      caller: 'test',
+    });
+
+    expect(result).toBe('ro-result');
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(read).toHaveBeenCalledWith(mockDbRead);
+    expect(mockFallbackInc).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the primary (RW) connection on a connection-level failure', async () => {
+    const connErr = new Error('PostgreSQL connection: Error { kind: Closed }');
+    const read = vi.fn(async (db: unknown) => {
+      if (db === mockDbRead) throw connErr;
+      return 'rw-result';
+    });
+
+    const result = await readWithReplicaFallback(read as never, {
+      entity: 'userMultiplier',
+      caller: 'test',
+    });
+
+    expect(result).toBe('rw-result');
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(read).toHaveBeenNthCalledWith(1, mockDbRead);
+    expect(read).toHaveBeenNthCalledWith(2, mockDbWrite);
+    expect(mockFallbackInc).toHaveBeenCalledWith({ entity: 'userMultiplier', caller: 'test' });
+  });
+
+  it('rethrows genuine query errors without falling back', async () => {
+    const queryErr = prismaError({
+      name: 'PrismaClientKnownRequestError',
+      code: 'P2002',
+      message: 'unique',
+    });
+    const read = vi.fn(async (db: unknown) => {
+      if (db === mockDbRead) throw queryErr;
+      return 'rw-result';
+    });
+
+    await expect(
+      readWithReplicaFallback(read as never, { entity: 'userMultiplier', caller: 'test' })
+    ).rejects.toBe(queryErr);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(mockFallbackInc).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/db/db-lag-helpers.ts
+++ b/src/server/db/db-lag-helpers.ts
@@ -1,7 +1,10 @@
+import type { PrismaClient } from '@prisma/client';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { notifDbRead, notifDbWrite } from '~/server/db/notifDb';
 import { FLIPT_FEATURE_FLAGS, isFliptSync } from '~/server/flipt/client';
+import { logToAxiom } from '~/server/logging/client';
+import { dbReadFallbackCounter } from '~/server/prom/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 
 type LaggingType =
@@ -86,6 +89,123 @@ export async function preventModelVersionLagBatch(
 
 export const preventModelVersionLag = (modelId: number, versionId: number) =>
   preventModelVersionLagBatch(modelId, versionId);
+
+// Prisma error codes that indicate the connection/pool — not the query — failed.
+// P1001 can't reach DB · P1002 reached but timed out · P1008 operation timed out ·
+// P1017 server closed the connection · P2024 timed out fetching a connection from the pool.
+const PRISMA_CONNECTION_ERROR_CODES = new Set(['P1001', 'P1002', 'P1008', 'P1017', 'P2024']);
+
+// Substrings seen in the engine-level message when the underlying socket drops.
+// Driven by the 2026-06-06 incident, where the buzz read-replica's RO PgBouncer
+// pooler had zero backends and reads surfaced as `PostgreSQL connection: Error { kind: Closed }`.
+const CONNECTION_ERROR_MESSAGE_FRAGMENTS = [
+  'kind: closed',
+  'connection closed',
+  'connection terminated',
+  'connection refused',
+  'econnrefused',
+  'econnreset',
+  'server has closed the connection',
+  'timed out fetching a new connection from the connection pool',
+  'connection pool timeout',
+];
+
+// Prisma error class names that always indicate a connection/engine failure
+// (not a query failure). We match on `.name` rather than `instanceof` because the
+// repo's slim-generated client does not expose the error constructors on the
+// `Prisma` namespace at runtime, so `instanceof Prisma.X` is unreliable here.
+const PRISMA_CONNECTION_ERROR_NAMES = new Set([
+  'PrismaClientInitializationError',
+  'PrismaClientRustPanicError',
+]);
+
+/**
+ * Detects connection-LEVEL failures (the read connection/pool is unavailable),
+ * as opposed to genuine query failures (constraint violations, bad SQL, NOT_FOUND).
+ * Only connection-level failures are safe to transparently retry on the primary.
+ *
+ * Detection is duck-typed (by `.name`, `.code`, and message fragments) rather than
+ * via `instanceof`, because this repo's slim-generated Prisma client does not expose
+ * the error constructors at runtime.
+ */
+export function isDbConnectionError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+
+  const name =
+    'name' in error && typeof (error as { name: unknown }).name === 'string'
+      ? (error as { name: string }).name
+      : '';
+  if (PRISMA_CONNECTION_ERROR_NAMES.has(name)) return true;
+
+  const code =
+    'code' in error && typeof (error as { code: unknown }).code === 'string'
+      ? (error as { code: string }).code
+      : '';
+  if (code && PRISMA_CONNECTION_ERROR_CODES.has(code)) return true;
+
+  // Some errors (PrismaClientUnknownRequestError, raw node-postgres errors) only
+  // carry the detail in the message — inspect it for known connection-failure fragments.
+  const message =
+    'message' in error && (error as { message: unknown }).message != null
+      ? String((error as { message: unknown }).message).toLowerCase()
+      : '';
+  if (!message) return false;
+  return CONNECTION_ERROR_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment));
+}
+
+/**
+ * Runs a read against the read-replica (RO) connection and, ONLY when that
+ * connection itself is unavailable, transparently retries the same read against
+ * the primary (write/RW) connection.
+ *
+ * Normal operation is unchanged: reads still go to the replica for offload. The
+ * fallback fires solely on a connection-level failure (pool/socket closed,
+ * refused, or pool-acquire timeout) — never on a genuine query error, which is
+ * re-thrown unchanged so callers still see real failures.
+ *
+ * Motivated by the 2026-06-06 incident: a maintenance window took down the node
+ * hosting BOTH the buzz read-replica and its RO PgBouncer pooler, leaving the RO
+ * service with zero backends. Buzz reads (e.g. the multipliers query behind
+ * buzz.getBuzzAccount, which fires on essentially every authenticated request)
+ * threw `PostgreSQL connection: Error { kind: Closed }` and surfaced as
+ * INTERNAL_SERVER_ERROR for ~19% of API traffic until ops manually repointed the
+ * RO pooler at the primary. This helper degrades gracefully instead.
+ *
+ * @param read   Performs the read using the supplied client; called first with
+ *               dbRead, and — only on a connection failure — again with dbWrite.
+ * @param caller Label for the dbread_fallback_total metric (entity is `buzz`-style).
+ */
+export async function readWithReplicaFallback<T>(
+  read: (db: PrismaClient) => Promise<T>,
+  { entity, caller }: { entity: string; caller: string }
+): Promise<T> {
+  // When read and write share a client there is no separate RO connection to fall
+  // back from — run directly and let any error propagate.
+  if (dbRead === dbWrite) return read(dbRead);
+
+  try {
+    return await read(dbRead);
+  } catch (error) {
+    if (!isDbConnectionError(error)) throw error;
+
+    dbReadFallbackCounter.inc({ entity, caller });
+    logToAxiom(
+      {
+        type: 'warning',
+        name: 'db-read-replica-fallback',
+        message: 'Read-replica connection unavailable; falling back to primary',
+        entity,
+        caller,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'db-logs'
+    ).catch(() => {
+      /* best-effort */
+    });
+
+    return read(dbWrite);
+  }
+}
 
 // Same as getDbWithoutLag / getDbWithoutLagBatch but for the notifDb pool.
 export async function getNotifDbWithoutLag(type?: LaggingType, id?: number | string) {

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -190,10 +190,11 @@ export const userUpdateCounter = registerCounterWithLabels({
   labelNames: ['location'] as const,
 });
 
-// CDC replication lag fallback metrics
+// dbRead → dbWrite fallback metrics. Covers both read-after-write CDC replication
+// lag fallbacks AND read-replica connection-unavailable fallbacks (see readWithReplicaFallback).
 export const dbReadFallbackCounter = registerCounterWithLabels({
   name: 'dbread_fallback_total',
-  help: 'Number of times a dbRead query fell back to dbWrite due to CDC replication lag',
+  help: 'Number of times a dbRead query fell back to dbWrite (CDC replication lag or read-replica connection unavailable)',
   labelNames: ['entity', 'caller'] as const,
 });
 

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1,4 +1,5 @@
 import type { ResourceInfo } from '@civitai/client';
+import type { PrismaClient } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import { env } from '~/env/server';
 import type { BaseModelType } from '~/server/common/constants';
@@ -6,7 +7,7 @@ import { CacheTTL } from '~/server/common/constants';
 import type { NsfwLevel } from '~/server/common/enums';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { getDbWithoutLagBatch } from '~/server/db/db-lag-helpers';
+import { getDbWithoutLagBatch, readWithReplicaFallback } from '~/server/db/db-lag-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
@@ -240,10 +241,9 @@ export const userMultipliersCache = createCachedObject<CachedUserMultiplier>({
     const goodIds = ids.filter(isDefined);
     if (!goodIds.length) return {};
 
-    const db = fromWrite ? dbWrite : dbRead;
     // Get the highest tier subscription for each user
     // Tier priority: founder > gold > silver > bronze > free
-    const multipliers = await db.$queryRaw<CachedUserMultiplier[]>`
+    const runQuery = (db: PrismaClient) => db.$queryRaw<CachedUserMultiplier[]>`
       WITH ranked_subscriptions AS (
         SELECT
           cs."userId",
@@ -292,6 +292,19 @@ export const userMultipliersCache = createCachedObject<CachedUserMultiplier>({
       LEFT JOIN ranked_subscriptions rs ON u.id = rs."userId" AND rs.rn = 1
       WHERE u.id IN (${Prisma.join(goodIds)});
     `;
+
+    // This read fires on essentially every authenticated request (it backs
+    // getMultipliersForUser → buzz.getBuzzAccount). When read-after-write
+    // consistency is required we go straight to the primary; otherwise we read
+    // from the replica but transparently fall back to the primary if the
+    // read-replica connection itself is unavailable (the 2026-06-06 buzz-db-ro
+    // outage), instead of throwing a 500.
+    const multipliers = fromWrite
+      ? await runQuery(dbWrite)
+      : await readWithReplicaFallback(runQuery, {
+          entity: 'userMultiplier',
+          caller: 'userMultipliersCache',
+        });
 
     const records: Record<number, CachedUserMultiplier> = Object.fromEntries(
       multipliers.map((m) => [m.userId, m])


### PR DESCRIPTION
## Incident (2026-06-06)

A datacenter maintenance window took down a Kubernetes node that hosted **both** the buzz database read-replica **and** its read-only (RO) PgBouncer pooler. The CNPG `buzz-db-ro` service was left with **zero backends**, so the app's buzz **read** path had nowhere to send queries.

The result: `buzz.getBuzzAccount` (which fires on essentially every authenticated request) threw `TRPCError: INTERNAL_SERVER_ERROR` with an underlying `prisma:error ... PostgreSQL connection: Error { kind: Closed }`, for **~19% of `civitai-dp-prod-api` traffic**, until ops manually repointed the RO pooler at the primary.

## Root cause

The buzz DB uses a split RW/RO setup: writes + critical reads go to the primary (`dbWrite` / `DATABASE_URL`), while high-volume reads are offloaded to the read-replica (`dbRead` / `DATABASE_REPLICA_URL`) for latency. There was **no fallback** when the RO connection itself becomes unavailable — a connection-level RO outage turned straight into user-facing 500s. We can't permanently route all buzz reads to the primary (the replica is load-bearing for read latency), so we need graceful degradation only on RO-connection failure.

## What this change does

- Adds `readWithReplicaFallback` + `isDbConnectionError` to `src/server/db/db-lag-helpers.ts` (the canonical read-routing module, alongside the existing replication-lag helpers).
  - `readWithReplicaFallback(read, { entity, caller })` runs `read(dbRead)` and, **only** when that fails with a **connection-level** error, transparently retries `read(dbWrite)` and returns the result.
  - Connection-level errors = Prisma `P1001`/`P1002`/`P1008`/`P1017`/`P2024`, `PrismaClientInitializationError` / `PrismaClientRustPanicError`, or an engine/socket message containing `kind: Closed`, `connection closed/terminated/refused`, `ECONNREFUSED`/`ECONNRESET`, or pool-acquire timeout.
  - **Genuine query errors** (constraint violations, bad SQL, NOT_FOUND, etc.) are **re-thrown unchanged** — they are never silently retried on the primary.
  - Detection is duck-typed (by `.name` / `.code` / message), because this repo's slim-generated Prisma client does **not** expose the error constructors on the `Prisma` namespace at runtime, so `instanceof Prisma.X` is unreliable here (the existing `errorHandling.ts` `instanceof Prisma.PrismaClientKnownRequestError` checks have the same latent problem — see "Reviewer, please check" below).
- Applies it to the buzz read path: `userMultipliersCache.lookupFn` in `src/server/redis/caches.ts` (this query backs `getMultipliersForUser` → the buzz account flow, and is the Prisma-backed read that fires the incident's `kind: Closed` error).
- **Normal offload is preserved**: reads still go to the replica first; the fallback fires only on RO-connection failure. The existing read-after-write (`fromWrite`) path is untouched and still goes straight to the primary.
- Reuses the existing `dbReadFallbackCounter` (`dbread_fallback_total`) metric and emits a `db-read-replica-fallback` warning log so the degraded mode is observable. Updated the metric `help` text to reflect that it now also counts connection-unavailable fallbacks (previously only CDC-lag fallbacks).
- Adds focused unit tests (`src/server/db/__tests__/db-lag-helpers.test.ts`) for the classifier (connection vs query errors) and the fallback behavior (happy path → replica; conn failure → primary + counter; query error → rethrow).

## Validation

- New unit test: **8/8 pass** (`vitest run src/server/db/__tests__/db-lag-helpers.test.ts`).
- Typecheck: `db-lag-helpers.ts` and the test compile with **zero** errors; `caches.ts` error signatures are **byte-identical** between `origin/main` and this branch (diff verified) — i.e. this PR introduces **no new** type errors. (Note: a full repo `tsc --noEmit` in this dev environment emits thousands of pre-existing `Prisma.join`/`JsonValue` errors because the locally-installed Prisma client is the *slim* generation; that is an environment artifact unrelated to this change.)
- Lint: the 3 changed source files lint clean. The test file hits the same "tsconfig does not include this file" parsing error that **every** existing `__tests__/*.test.ts` file hits (test files are excluded from the lint tsconfig project; `next lint` skips them) — not introduced here.

## ⚠️ Reviewer, please check (opened as draft for this reason)

1. **Scope/intent**: The incident report names `buzz.getBuzzAccount` as the failing read, but in *this* repo that tRPC procedure resolves to a **pure HTTP** call to `BUZZ_ENDPOINT` (`getUserBuzzAccounts` → `buzzApiFetch`), which cannot emit a `prisma:error`. The Prisma-backed buzz read that *does* fire on essentially every authenticated request — and is the realistic source of the `kind: Closed` error in the logs — is the multipliers query (`userMultipliersCache.lookupFn`, via `getMultipliersForUser`). I scoped the fix there. **Please confirm this is the right buzz read** — if the incident's 500s actually came from a different buzz read (or the buzz microservice's own DB layer rather than the civitai app), the helper is correct but the call-site may need to move/expand.
2. **Other buzz/hot reads**: `readWithReplicaFallback` is a small, reusable helper. If you want the same protection on other hot reads that hit `dbRead` directly (not just the multipliers cache), we can wrap them in a follow-up — I kept the blast radius to the one incident-relevant call-site rather than touching all 173 `dbRead` callers.
3. **Error-classifier coverage**: the connection-error fragment list is best-effort. If your Prisma/pg version emits a different message for the RO-pooler-empty case, add the fragment to `CONNECTION_ERROR_MESSAGE_FRAGMENTS`. (Separately: the duck-typed detection sidesteps the fact that `instanceof Prisma.PrismaClientKnownRequestError` is always-false at runtime against the slim client — worth a look in `errorHandling.ts` too, out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)