### PR TITLE
fix: restore unfiltered image feed when using withMeta=true on v1 API

### DIFF
--- a/src/pages/api/v1/images/__tests__/index.test.ts
+++ b/src/pages/api/v1/images/__tests__/index.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// 1. Hoisted mocks for API and Service dependencies
+const {
+  mockGetAllImages,
+  mockGetAllImagesIndex,
+  mockGetImagesFromFeedSearch,
+  mockImageMetaCacheFetch,
+  mockGetServerAuthSession,
+  mockGetFeatureFlags,
+  mockGetFliptVariant,
+} = vi.hoisted(() => ({
+  mockGetAllImages: vi.fn(),
+  mockGetAllImagesIndex: vi.fn(),
+  mockGetImagesFromFeedSearch: vi.fn(),
+  mockImageMetaCacheFetch: vi.fn(),
+  mockGetServerAuthSession: vi.fn(),
+  mockGetFeatureFlags: vi.fn(),
+  mockGetFliptVariant: vi.fn(),
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  getAllImages: mockGetAllImages,
+  getAllImagesIndex: mockGetAllImagesIndex,
+  getImagesFromFeedSearch: mockGetImagesFromFeedSearch,
+}));
+
+vi.mock('~/server/redis/caches', () => ({
+  imageMetaCache: {
+    fetch: mockImageMetaCacheFetch,
+  },
+}));
+
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: mockGetServerAuthSession,
+}));
+
+vi.mock('~/server/services/feature-flags.service', () => ({
+  getFeatureFlags: mockGetFeatureFlags,
+  buildFliptContext: vi.fn(),
+}));
+
+vi.mock('~/server/flipt/client', () => ({
+  FLIPT_FEATURE_FLAGS: {
+    BITDEX_IMAGE_SEARCH: 'bitdex-image-search',
+  },
+  getFliptVariant: mockGetFliptVariant,
+}));
+
+vi.mock('~/client-utils/cf-images-utils', () => ({
+  getEdgeUrl: (url: string) => `https://cf-images.com/${url}`,
+}));
+
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: vi.fn().mockReturnValue('US'),
+  isRegionRestricted: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('~/server/meilisearch/client', () => ({
+  buildSearchActor: vi.fn().mockReturnValue('mock-actor'),
+}));
+
+vi.mock('request-ip', () => ({
+  default: { getClientIp: () => '127.0.0.1' },
+}));
+
+// Mock PublicEndpoint to be a simple passthrough wrapper
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => handler,
+}));
+
+// 2. Import the handler after the mocks are defined
+import handler from '../index';
+
+// 3. Helper to mock NextApiRequest/Response
+function createMocks({ query = {} }: { query?: Record<string, string | string[]> }) {
+  const req = {
+    method: 'GET',
+    headers: {},
+    query,
+  } as unknown as NextApiRequest;
+
+  let statusCode = 200;
+  let payload: any = undefined;
+
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      payload = body;
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+  } as unknown as NextApiResponse & { _getStatusCode: () => number; _getJSONData: () => any };
+
+  return { req, res };
+}
+
+// 4. Test Suite
+describe('/api/v1/images API Handler', () => {
+  const mockImagesResult = {
+    items: [
+      {
+        id: 100,
+        url: 'test-uuid',
+        hash: 'U36kF+Z#',
+        width: 832,
+        height: 1216,
+        nsfwLevel: 1,
+        type: 'image',
+        createdAt: new Date('2026-03-04T16:10:46.428Z'),
+        postId: 27016856,
+        stats: {
+          cryCountAllTime: 4,
+          laughCountAllTime: 7,
+          likeCountAllTime: 154,
+          dislikeCountAllTime: 0,
+          heartCountAllTime: 47,
+          commentCountAllTime: 1,
+        },
+        user: {
+          username: 'forest919',
+        },
+        baseModel: 'Anima',
+        modelVersionIds: [2653283],
+      },
+    ],
+    nextCursor: 'cursor_val',
+  };
+
+  const mockMetaResult = {
+    100: {
+      id: 100,
+      meta: {
+        Model: 'anima-preview',
+        cfgScale: 4,
+        prompt: 'masterpiece, best quality',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerAuthSession.mockResolvedValue(null);
+    mockGetFeatureFlags.mockReturnValue({ datapacketRead: false, canViewNsfw: false });
+    mockGetFliptVariant.mockResolvedValue('off'); // Default to Meili feed search
+    mockGetImagesFromFeedSearch.mockResolvedValue(mockImagesResult);
+    mockGetAllImagesIndex.mockResolvedValue(mockImagesResult);
+    mockGetAllImages.mockResolvedValue(mockImagesResult);
+    mockImageMetaCacheFetch.mockResolvedValue(mockMetaResult);
+  });
+
+  it('should return meta: null by default (when withMeta is false) and NOT fetch from cache', async () => {
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.items[0].meta).toBeNull();
+    expect(mockImageMetaCacheFetch).not.toHaveBeenCalled();
+
+    // Verify search service call had withMeta = false to prevent search index filtering
+    expect(mockGetImagesFromFeedSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        withMeta: false,
+      })
+    );
+  });
+
+  it('should return flat shape by default when withMeta=true on default search/feed query path', async () => {
+    const { req, res } = createMocks({ query: { limit: '10', withMeta: 'true' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.items[0].meta).toEqual({
+      Model: 'anima-preview',
+      cfgScale: 4,
+      prompt: 'masterpiece, best quality',
+    });
+    expect(mockGetImagesFromFeedSearch).toHaveBeenCalled();
+  });
+
+  it('should return nested wrapper shape by default when withMeta=true on legacy query path (e.g. imageId)', async () => {
+    const { req, res } = createMocks({ query: { imageId: '100', withMeta: 'true' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.items[0].meta).toEqual({
+      id: 100,
+      meta: {
+        Model: 'anima-preview',
+        cfgScale: 4,
+        prompt: 'masterpiece, best quality',
+      },
+    });
+    expect(mockGetAllImages).toHaveBeenCalled();
+  });
+
+  it('should return nested shape when flatMeta=false is explicitly passed, regardless of path', async () => {
+    const { req, res } = createMocks({ query: { limit: '10', withMeta: 'true', flatMeta: 'false' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.items[0].meta).toEqual({
+      id: 100,
+      meta: {
+        Model: 'anima-preview',
+        cfgScale: 4,
+        prompt: 'masterpiece, best quality',
+      },
+    });
+  });
+
+  it('should return flat shape when flatMeta=true is explicitly passed, regardless of path', async () => {
+    const { req, res } = createMocks({ query: { imageId: '100', withMeta: 'true', flatMeta: 'true' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.items[0].meta).toEqual({
+      Model: 'anima-preview',
+      cfgScale: 4,
+      prompt: 'masterpiece, best quality',
+    });
+  });
+});

--- a/src/pages/api/v1/images/__tests__/index.test.ts
+++ b/src/pages/api/v1/images/__tests__/index.test.ts
@@ -235,4 +235,75 @@ describe('/api/v1/images API Handler', () => {
       prompt: 'masterpiece, best quality',
     });
   });
+
+  it('should return consistent nested wrapper for data-less images (meta: null, not bare null)', async () => {
+    // Image has no meta in cache — the wrapper shape must still be emitted, not bare null
+    mockImageMetaCacheFetch.mockResolvedValue({ 100: { id: 100, meta: undefined } });
+    const { req, res } = createMocks({ query: { imageId: '100', withMeta: 'true', flatMeta: 'false' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    // Must be the wrapper shape, not bare null
+    expect(data.items[0].meta).toEqual({ id: 100, meta: null });
+  });
+
+  it('should return null (not a wrapper) for data-less images in flat mode', async () => {
+    mockImageMetaCacheFetch.mockResolvedValue({ 100: { id: 100, meta: undefined } });
+    const { req, res } = createMocks({ query: { limit: '10', withMeta: 'true', flatMeta: 'true' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.items[0].meta).toBeNull();
+  });
+
+  it('should route to getAllImagesIndex when BitDex Flipt variant is shadow', async () => {
+    mockGetFliptVariant.mockResolvedValue('shadow');
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetAllImagesIndex).toHaveBeenCalled();
+    expect(mockGetImagesFromFeedSearch).not.toHaveBeenCalled();
+    expect(mockGetAllImages).not.toHaveBeenCalled();
+  });
+
+  it('should route to getAllImagesIndex when BitDex Flipt variant is primary', async () => {
+    mockGetFliptVariant.mockResolvedValue('primary');
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetAllImagesIndex).toHaveBeenCalled();
+    expect(mockGetImagesFromFeedSearch).not.toHaveBeenCalled();
+    expect(mockGetAllImages).not.toHaveBeenCalled();
+  });
+
+  it('should pass withMeta:false to getAllImages on legacy path regardless of query param', async () => {
+    const { req, res } = createMocks({ query: { imageId: '100', withMeta: 'true' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetAllImages).toHaveBeenCalledWith(
+      expect.objectContaining({ withMeta: false })
+    );
+  });
+
+  it('should pass withMeta:false to getAllImagesIndex on BitDex path regardless of query param', async () => {
+    mockGetFliptVariant.mockResolvedValue('shadow');
+    const { req, res } = createMocks({ query: { limit: '10', withMeta: 'true' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetAllImagesIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ withMeta: false })
+    );
+  });
 });

--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -15,6 +15,7 @@ import {
   getAllImagesIndex,
   getImagesFromFeedSearch,
 } from '~/server/services/image.service';
+import { imageMetaCache } from '~/server/redis/caches';
 import { FLIPT_FEATURE_FLAGS, getFliptVariant } from '~/server/flipt/client';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
@@ -80,6 +81,7 @@ const imagesEndpointSchema = z.object({
   baseModels: commaDelimitedEnumArray([...baseModels]).optional(),
   withMeta: booleanString().default(false),
   requiringMeta: booleanString().optional(),
+  flatMeta: booleanString().optional(),
 });
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -90,7 +92,7 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     const session = await getServerAuthSession({ req, res });
 
     // Handle pagination
-    const { limit, page, cursor, nsfw, browsingLevel, type, withMeta, ...data } = reqParams.data;
+    const { limit, page, cursor, nsfw, browsingLevel, type, withMeta, flatMeta, ...data } = reqParams.data;
     let skip: number | undefined;
     const usingPaging = page && !cursor;
     if (usingPaging) {
@@ -151,17 +153,13 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
           limit,
           skip,
           cursor,
-          // Only fetch the (large, ~2.8KB/key) meta blob when the caller asks
-          // for it via withMeta. Previously metaSelect was hardcoded, so every
-          // request paid the imageMetaCache fetch + JSON serialization even when
-          // withMeta=false (the default) and the meta was discarded client-side.
-          include: withMeta
-            ? ['metaSelect', 'tagIds', 'profilePictures']
-            : ['tagIds', 'profilePictures'],
+          // Only fetch tagIds and profilePictures here; metaSelect is fetched
+          // on-demand in the controller below to avoid query filtering.
+          include: ['tagIds', 'profilePictures'],
           periodMode: 'published',
           headers: { src: '/api/v1/images' },
           browsingLevel: _browsingLevel,
-          withMeta,
+          withMeta: false,
           user: session?.user,
           disableMinor: true,
           disablePoi: true,
@@ -175,16 +173,10 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
           limit,
           skip,
           cursor,
-          // Only fetch the (large, ~2.8KB/key) meta blob when the caller asks
-          // for it via withMeta. Previously metaSelect was hardcoded, so every
-          // request paid the imageMetaCache fetch + JSON serialization even when
-          // withMeta=false (the default) and the meta was discarded client-side.
-          include: withMeta
-            ? ['metaSelect', 'tagIds', 'profilePictures']
-            : ['tagIds', 'profilePictures'],
+          include: ['tagIds', 'profilePictures'],
           periodMode: 'published',
           browsingLevel: _browsingLevel,
-          withMeta,
+          withMeta: false,
           user: session?.user,
           useCombinedNsfwLevel: !features.canViewNsfw,
           disableMinor: true,
@@ -199,16 +191,10 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
           limit,
           skip,
           cursor,
-          // Only fetch the (large, ~2.8KB/key) meta blob when the caller asks
-          // for it via withMeta. Previously metaSelect was hardcoded, so every
-          // request paid the imageMetaCache fetch + JSON serialization even when
-          // withMeta=false (the default) and the meta was discarded client-side.
-          include: withMeta
-            ? ['metaSelect', 'tagIds', 'profilePictures']
-            : ['tagIds', 'profilePictures'],
+          include: ['tagIds', 'profilePictures'],
           periodMode: 'published',
           browsingLevel: _browsingLevel,
-          withMeta,
+          withMeta: false,
           currentUserId: session?.user?.id,
           isModerator: session?.user?.isModerator,
           useCombinedNsfwLevel: !features.canViewNsfw,
@@ -216,6 +202,11 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
           disablePoi: true,
           actor,
         });
+
+    let imageMetas: Record<number, { id: number; meta?: any }> = {};
+    if (withMeta && items.length > 0) {
+      imageMetas = await imageMetaCache.fetch(items.map((img) => img.id));
+    }
 
     const metadata: Metadata = {
       nextCursor,
@@ -251,7 +242,13 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
             heartCount: image.stats?.heartCountAllTime ?? 0,
             commentCount: image.stats?.commentCountAllTime ?? 0,
           },
-          meta: image.meta ?? null,
+          meta: withMeta
+            ? (imageMetas[image.id]?.meta
+              ? (flatMeta !== undefined
+                ? (flatMeta ? imageMetas[image.id].meta : { id: image.id, meta: imageMetas[image.id].meta })
+                : (useLegacyMethod ? { id: image.id, meta: imageMetas[image.id].meta } : imageMetas[image.id].meta))
+              : null)
+            : null,
           username: image.user.username,
           baseModel: image.baseModel,
           modelVersionIds: image.modelVersionIds,

--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -242,13 +242,12 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
             heartCount: image.stats?.heartCountAllTime ?? 0,
             commentCount: image.stats?.commentCountAllTime ?? 0,
           },
-          meta: withMeta
-            ? (imageMetas[image.id]?.meta
-              ? (flatMeta !== undefined
-                ? (flatMeta ? imageMetas[image.id].meta : { id: image.id, meta: imageMetas[image.id].meta })
-                : (useLegacyMethod ? { id: image.id, meta: imageMetas[image.id].meta } : imageMetas[image.id].meta))
-              : null)
-            : null,
+          meta: (() => {
+            if (!withMeta) return null;
+            const imageMeta = imageMetas[image.id]?.meta ?? null;
+            const useFlat = flatMeta !== undefined ? flatMeta : !useLegacyMethod;
+            return useFlat ? imageMeta : { id: image.id, meta: imageMeta };
+          })(),
           username: image.user.username,
           baseModel: image.baseModel,
           modelVersionIds: image.modelVersionIds,


### PR DESCRIPTION
## Description

This PR resolves issues with image metadata retrieval on the public `/api/v1/images` endpoint related to [Issue #2421](https://github.com/civitai/civitai/issues/2421).

As of commit `2a4f4a1c4`, image metadata (`meta`) defaults to `null` unless the caller explicitly passes `withMeta=true`. This is the expected behavior to keep response payload sizes optimal. However, if a caller *does* request metadata using `withMeta=true`, it previously filtered the entire feed to only show images that contain metadata, which was unintended.

This PR restores the unfiltered feed and preserves backward compatibility of metadata shapes.

### Root Cause
Passing `withMeta=true` was propagated down to MeiliSearch and BitDex feeds, which used it as an index query filter (`hasMeta = true`). This filtered out any images in the search index that lacked metadata.

### Resolution
1. **On-Demand Cache Fetching**: Omitted `withMeta: true` from the search index / legacy database queries (forcing `withMeta: false` at query execution), preventing indexing engines from filtering the image feed.
2. **Post-Query Batching**: Fetched metadata on-demand in a single parallel batch using `imageMetaCache.fetch(imageIds)` after primary items are returned.
3. **Backward-Compatible Shape Mapping**:
   - `flatMeta` query parameter is now optional.
   - If `flatMeta` is explicitly passed (as `true` or `false`), its value is honored for all paths.
   - If `flatMeta` is omitted (default), the shape is determined by the query path to match prior behavior:
     - Legacy DB queries (`useLegacyMethod` is `true`) return the **nested** shape (`{ id, meta: { ... } }`).
     - Feed-search / BitDex queries (`useLegacyMethod` is `false`) return the **flat** metadata shape directly.
   - For data-less images in nested mode, the response consistently emits `{ id, meta: null }` rather than bare `null`, ensuring a uniform shape within a single response regardless of whether metadata is present.
4. **Vitest Unit Tests**: Added a unit test suite in `src/pages/api/v1/images/__tests__/index.test.ts` covering: default behavior, conditional flat/nested shapes, explicit `flatMeta` overrides, data-less image shape consistency, BitDex `shadow`/`primary` routing, and `withMeta:false` passthrough to all three backends (11 tests).

### Behavior changes to note
- `withMeta=true` no longer filters the result set to images that have metadata — it controls whether the `meta` field is populated, nothing more. Callers who relied on `withMeta=true` as an implicit `hasMeta` filter will now receive unfiltered results with `meta: null` for images without metadata.
- The default `meta` shape (nested vs flat) depends on internal routing (`useLegacyMethod`), which can shift as the `BITDEX_IMAGE_SEARCH` Flipt flag rolls out. `flatMeta=true/false` is the stable escape hatch for callers who need a guaranteed shape.

> **Documentation note:** These two behavior changes (`withMeta` semantics and the `flatMeta` param) should be reflected in the public `/api/v1/images` API reference. The docs don't live in this repo and we don't have write access — flagging for maintainers to update.

Addresses #2421