### PR TITLE
fix(metadata): automatically detect EXIF UserComment endianness & handle single-line formats

### DIFF
--- a/src/utils/encoding-helpers.ts
+++ b/src/utils/encoding-helpers.ts
@@ -56,10 +56,27 @@ export function decodeUserComment(buffer: Uint8Array): string {
   if (header.startsWith('ASCII')) return new TextDecoder('ascii').decode(content);
   if (header.startsWith('UTF8')) return new TextDecoder('utf-8').decode(content);
 
-  // For UNICODE header (old and new images), decode as UTF-16BE.
-  // The EXIF spec stores UNICODE UserComment as UCS-2/UTF-16 big-endian, which
-  // is also what our own encoder (encodeUserCommentUTF16BE) writes.
-  return new TextDecoder('utf-16be').decode(content).replace(/\0/g, '');
+  // Check for BOM (Byte Order Mark) for UTF-16
+  if (content.length >= 2) {
+    if (content[0] === 0xFE && content[1] === 0xFF) {
+      return new TextDecoder('utf-16be').decode(content.subarray(2)).replace(/\0/g, '');
+    }
+    if (content[0] === 0xFF && content[1] === 0xFE) {
+      return new TextDecoder('utf-16le').decode(content.subarray(2)).replace(/\0/g, '');
+    }
+  }
+
+  // Heuristic: count null bytes at even vs odd offsets to determine UTF-16 endianness
+  let evenZeros = 0;
+  let oddZeros = 0;
+  const limit = Math.min(content.length, 1000);
+  for (let i = 0; i + 1 < limit; i += 2) {
+    if (content[i] === 0) evenZeros++;
+    if (content[i + 1] === 0) oddZeros++;
+  }
+
+  const encoding = oddZeros > evenZeros ? 'utf-16le' : 'utf-16be';
+  return new TextDecoder(encoding).decode(content).replace(/\0/g, '');
 }
 
 const prefix = [0x55, 0x4e, 0x49, 0x43, 0x4f, 0x44, 0x45, 0x00]; // UNICODE\0

--- a/src/utils/metadata/__tests__/exif-parser.test.ts
+++ b/src/utils/metadata/__tests__/exif-parser.test.ts
@@ -202,4 +202,54 @@ describe('automaticMetadataProcessor - single-line and delimited metadata parsin
       { modelVersionId: 0, type: 'model', weight: 1.0 }
     ]);
   });
+
+  it('does not split the "Hires steps" parameter onto its own line', () => {
+    const rawMetadata = `masterpiece, best quality, 1girl
+Negative prompt: bad quality, worst quality
+Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 12345, Size: 512x768, Denoising strength: 0.4, Hires upscale: 2, Hires steps: 15, Hires upscaler: Latent`;
+    const exif = { generationDetails: rawMetadata, parameters: rawMetadata };
+
+    expect(automaticMetadataProcessor.canParse(exif)).toBe(true);
+
+    const result = automaticMetadataProcessor.parse(exif);
+    expect(result.prompt).toBe('masterpiece, best quality, 1girl');
+    // "Hires steps: 15" must not leak into the negative prompt as a second Steps line
+    expect(result.negativePrompt).toBe('bad quality, worst quality');
+    expect(result.steps).toBe('30');
+    expect(result.seed).toBe('12345');
+    expect(result['Hires steps']).toBe('15');
+    expect(result['Hires upscaler']).toBe('Latent');
+  });
+
+  it('does not split a "steps:" that appears inside the prompt of already-structured metadata', () => {
+    const rawMetadata = `tutorial diagram, steps: 1 2 3, colorful
+Negative prompt: ugly
+Steps: 25, Sampler: Euler, CFG scale: 7`;
+    const exif = { generationDetails: rawMetadata, parameters: rawMetadata };
+
+    expect(automaticMetadataProcessor.canParse(exif)).toBe(true);
+
+    const result = automaticMetadataProcessor.parse(exif);
+    expect(result.prompt).toBe('tutorial diagram, steps: 1 2 3, colorful');
+    expect(result.negativePrompt).toBe('ugly');
+    expect(result.steps).toBe('25');
+    expect(result.sampler).toBe('Euler');
+  });
+
+  it('normalizes a long delimiter run in linear time (no catastrophic backtracking)', () => {
+    // The delimiter run must NOT terminate in the keyword the regex is scanning for —
+    // otherwise the match succeeds immediately and even the old unbounded regex is fast.
+    // Here the run is followed by "Steps: 5" (so canParse's `Steps: ` gate passes and the
+    // guard does not bail, since Steps is inline), which means the "Negative prompt:" pass
+    // scans the entire run fruitlessly — the true catastrophic-backtracking case
+    // (~9s on the unbounded regex at this size).
+    const rawMetadata = `x${', '.repeat(50000)}Steps: 5`;
+    const exif = { generationDetails: rawMetadata, parameters: rawMetadata };
+
+    const start = Date.now();
+    automaticMetadataProcessor.canParse(exif);
+    const result = automaticMetadataProcessor.parse(exif);
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(result.steps).toBe('5');
+  });
 });

--- a/src/utils/metadata/__tests__/exif-parser.test.ts
+++ b/src/utils/metadata/__tests__/exif-parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ExifParser } from '~/utils/metadata';
 import { automaticMetadataProcessor } from '~/utils/metadata/automatic.metadata';
+import { decodeUserComment } from '~/utils/encoding-helpers';
 
 // TODO - create a suite of tests that uses images from civitai to test the different metadata parsers
 
@@ -80,5 +81,125 @@ describe('automaticMetadataProcessor - Civitai metadata with nested JSON', () =>
     expect(result['Size']).toBeUndefined();
     // Civitai metadata should be fully removed from details line, not leaking into other fields
     expect(result['Civitai metadata']).toBeUndefined();
+  });
+});
+
+describe('decodeUserComment - endianness and encoding', () => {
+  const prefix = [0x55, 0x4e, 0x49, 0x43, 0x4f, 0x44, 0x45, 0x00]; // "UNICODE\0"
+  const testString = 'Steps: 4, Sampler: Euler, Character: 中';
+
+  it('decodes UTF-16BE correctly (standard EXIF format)', () => {
+    // Encode testString in UTF-16BE
+    const content = [];
+    for (let i = 0; i < testString.length; i++) {
+      const code = testString.charCodeAt(i);
+      content.push((code >> 8) & 0xff);
+      content.push(code & 0xff);
+    }
+    const buffer = new Uint8Array(prefix.concat(content));
+    const result = decodeUserComment(buffer);
+    expect(result).toBe(testString);
+  });
+
+  it('decodes UTF-16LE correctly', () => {
+    // Encode testString in UTF-16LE
+    const content = [];
+    for (let i = 0; i < testString.length; i++) {
+      const code = testString.charCodeAt(i);
+      content.push(code & 0xff);
+      content.push((code >> 8) & 0xff);
+    }
+    const buffer = new Uint8Array(prefix.concat(content));
+    const result = decodeUserComment(buffer);
+    expect(result).toBe(testString);
+  });
+
+  it('decodes UTF-16BE with BOM correctly', () => {
+    // BOM: 0xFE, 0xFF
+    const content = [0xfe, 0xff];
+    for (let i = 0; i < testString.length; i++) {
+      const code = testString.charCodeAt(i);
+      content.push((code >> 8) & 0xff);
+      content.push(code & 0xff);
+    }
+    const buffer = new Uint8Array(prefix.concat(content));
+    const result = decodeUserComment(buffer);
+    expect(result).toBe(testString);
+  });
+
+  it('decodes UTF-16LE with BOM correctly', () => {
+    // BOM: 0xFF, 0xFE
+    const content = [0xff, 0xfe];
+    for (let i = 0; i < testString.length; i++) {
+      const code = testString.charCodeAt(i);
+      content.push(code & 0xff);
+      content.push((code >> 8) & 0xff);
+    }
+    const buffer = new Uint8Array(prefix.concat(content));
+    const result = decodeUserComment(buffer);
+    expect(result).toBe(testString);
+  });
+});
+
+describe('automaticMetadataProcessor - single-line and delimited metadata parsing', () => {
+  it('parses metadata with dot before Negative prompt and Steps', () => {
+    const rawMetadata = `Parameters                      : <lora:generic_lora_a:1> generic prompt text <lora:generic_lora_b:1> more prompt text.Negative prompt: negative prompt text, low quality.Steps: 24, Sampler: Euler a, Schedule type: Automatic, CFG scale: 4, Seed: 2366756367, Size: 640x980, Model hash: 23d793a158, Model: GenericModel, Wildcard prompt: "  <lora:generic_lora_a:1> generic prompt text <lora:generic_lora_b:1> more prompt text", Lora hashes: "generic_lora_a: bed61886a493", Version: v1.9.3`;
+    const exif = { generationDetails: rawMetadata, parameters: rawMetadata };
+
+    expect(automaticMetadataProcessor.canParse(exif)).toBe(true);
+
+    const result = automaticMetadataProcessor.parse(exif);
+    expect(result.prompt).toBe('<lora:generic_lora_a:1> generic prompt text <lora:generic_lora_b:1> more prompt text');
+    expect(result.negativePrompt).toBe('negative prompt text, low quality');
+    expect(result.steps).toBe('24');
+    expect(result.sampler).toBe('Euler a');
+    expect(result.cfgScale).toBe('4');
+    expect(result.seed).toBe('2366756367');
+    expect(result.width).toBe(640);
+    expect(result.height).toBe(980);
+    expect(result.Model).toBe('GenericModel');
+  });
+
+  it('parses metadata with comma-dot before Negative prompt and dot before Steps', () => {
+    const rawMetadata = `Parameters                      : A generic prompt text.,.Negative prompt: .Steps: 4, Sampler: Euler, CFG scale: 1.0, Seed: 1099633777240739, Size: 1088x1920, Model: generic_model_v1, Version: ComfyUI, Civitai resources: [{"modelName":"Generic Model","versionName":"v1","air":"urn:air:zimageturbo:checkpoint:civitai:12345@67890"}]`;
+    const exif = { generationDetails: rawMetadata, parameters: rawMetadata };
+
+    expect(automaticMetadataProcessor.canParse(exif)).toBe(true);
+
+    const result = automaticMetadataProcessor.parse(exif);
+    expect(result.prompt).toBe('A generic prompt text');
+    expect(result.negativePrompt).toBe('');
+    expect(result.steps).toBe('4');
+    expect(result.sampler).toBe('Euler');
+    expect(result.cfgScale).toBe('1.0');
+    expect(result.seed).toBe('1099633777240739');
+    expect(result.width).toBe(1088);
+    expect(result.height).toBe(1920);
+    expect(result.Model).toBe('generic_model_v1');
+    expect(result.civitaiResources).toEqual([
+      { modelVersionId: 0, type: 'model' }
+    ]);
+  });
+
+  it('parses metadata with triple-dot before Negative prompt and dot before Steps', () => {
+    const rawMetadata = `Parameters                      : A generic prompt text...Negative prompt: .Steps: 4, Sampler: Euler, CFG scale: 1.0, Seed: 521842852, Size: 1024x1024, Tool: ComfyUI, Technique: txt2img, Model: generic_model_v2, Version: ComfyUI, Civitai resources: [{"modelName":"Generic Model","versionName":"v2","air":"urn:air:flux2:checkpoint:civitai:12345@67890"},{"modelName":"Generic Lora","versionName":"v1.0","weight":1.0,"air":"urn:air:flux2:lora:civitai:11111@22222"}]`;
+    const exif = { generationDetails: rawMetadata, parameters: rawMetadata };
+
+    expect(automaticMetadataProcessor.canParse(exif)).toBe(true);
+
+    const result = automaticMetadataProcessor.parse(exif);
+    expect(result.prompt).toBe('A generic prompt text');
+    expect(result.negativePrompt).toBe('');
+    expect(result.steps).toBe('4');
+    expect(result.sampler).toBe('Euler');
+    expect(result.cfgScale).toBe('1.0');
+    expect(result.seed).toBe('521842852');
+    expect(result.width).toBe(1024);
+    expect(result.height).toBe(1024);
+    expect(result.Model).toBe('generic_model_v2');
+    expect(result.civitaiResources).toEqual([
+      { modelVersionId: 0, type: 'model' },
+      { modelVersionId: 0, type: 'model', weight: 1.0 }
+    ]);
   });
 });

--- a/src/utils/metadata/automatic.metadata.ts
+++ b/src/utils/metadata/automatic.metadata.ts
@@ -131,15 +131,21 @@ function parseDetailsLine(line: string | undefined): Record<string, any> {
 
 export function normalizeGenerationDetails(details: string): string {
   if (!details) return '';
-  let clean = details.replace(/^Parameters\s*:\s*/, '');
+  const clean = details.replace(/^Parameters\s*:\s*/, '');
 
-  // Ensure "Negative prompt:" starts on its own line if it's currently on the same line.
-  clean = clean.replace(/(?<!\n)[ \t\r]*(?:,[ \t\r]*|\.[ \t\r]*)*Negative prompt:/gi, '\nNegative prompt:');
+  // If a "Steps:" line already exists, the metadata is already structured across lines —
+  // leave it untouched. This is what protects keywords that appear inside prompt text
+  // (e.g. "Hires steps:", or a prompt that literally says "steps:"). Only jammed
+  // single-line formats need fixing below.
+  if (/(^|\n)Steps: ?\d/.test(clean)) return clean;
 
-  // Ensure "Steps:" starts on its own line if it's currently on the same line.
-  clean = clean.replace(/(?<!\n)[ \t\r]*(?:,[ \t\r]*|\.[ \t\r]*)*Steps:(?=\s*\d+)/gi, '\nSteps:');
-
-  return clean;
+  // Put each section keyword on its own line. Split only when preceded by a real `,`/`.`
+  // delimiter (what the single-line formats use as separators). Keep every quantifier
+  // bounded ({0,7}, not *) so a crafted run of delimiters can't cause catastrophic
+  // backtracking (ReDoS) — this runs on untrusted uploaded image metadata.
+  return clean
+    .replace(/[ \t\r]{0,7}[.,][ \t\r.,]{0,7}(Negative prompt:)/gi, '\n$1')
+    .replace(/[ \t\r]{0,7}[.,][ \t\r.,]{0,7}(Steps:)(?=\s*\d)/gi, '\n$1');
 }
 // #endregion
 

--- a/src/utils/metadata/automatic.metadata.ts
+++ b/src/utils/metadata/automatic.metadata.ts
@@ -128,6 +128,19 @@ function parseDetailsLine(line: string | undefined): Record<string, any> {
 
   return result;
 }
+
+export function normalizeGenerationDetails(details: string): string {
+  if (!details) return '';
+  let clean = details.replace(/^Parameters\s*:\s*/, '');
+
+  // Ensure "Negative prompt:" starts on its own line if it's currently on the same line.
+  clean = clean.replace(/(?<!\n)[ \t\r]*(?:,[ \t\r]*|\.[ \t\r]*)*Negative prompt:/gi, '\nNegative prompt:');
+
+  // Ensure "Steps:" starts on its own line if it's currently on the same line.
+  clean = clean.replace(/(?<!\n)[ \t\r]*(?:,[ \t\r]*|\.[ \t\r]*)*Steps:(?=\s*\d+)/gi, '\nSteps:');
+
+  return clean;
+}
 // #endregion
 
 export const automaticMetadataProcessor = createMetadataProcessor({
@@ -140,7 +153,7 @@ export const automaticMetadataProcessor = createMetadataProcessor({
     }
 
     if (generationDetails?.includes('Steps: ')) {
-      exif.generationDetails = generationDetails;
+      exif.generationDetails = normalizeGenerationDetails(generationDetails);
       return true;
     }
 
@@ -151,7 +164,8 @@ export const automaticMetadataProcessor = createMetadataProcessor({
     const generationDetails = exif.generationDetails as string;
 
     if (!generationDetails) return metadata;
-    const metaLines = generationDetails.split('\n').filter((line) => line.trim() !== '');
+    const normalizedDetails = normalizeGenerationDetails(generationDetails);
+    const metaLines = normalizedDetails.split('\n').filter((line) => line.trim() !== '');
 
     // Remove templates
     for (const key of templateKeys) {


### PR DESCRIPTION
## Fix A1111 Metadata Parsing Regression (UTF-16 Endianness & Single-Line Formats)

### Summary

This PR fixes a critical regression in A1111 generation metadata parsing for JPEG and WebP images. 

### Background & Analysis

PR #2355 ("Fix A1111 metadata encoding for multibyte characters") replaced the old endian-agnostic byte-casting decoding mechanism with a strict UTF-16LE `TextDecoder` (which was subsequently changed to `utf-16be` in a follow-up commit).

While the original intention was to correctly support multibyte unicode characters (like Chinese or Emojis), forcing a single fixed-endianness decoder breaks metadata parsing for a significant portion of images:
1. **UTF-16 Endianness Variance**: Different generators (e.g. Stable Diffusion WebUI, ComfyUI, SwarmUI) and EXIF libraries (Pillow, piexif, exiftool) write EXIF `UserComment` tags using different endianness (UTF-16LE vs. UTF-16BE). A strict single-endianness decoder will fail to read the opposite endianness, producing garbled text that doesn't match the downstream `"Steps: "` parsing trigger.
2. **Single-Line Formatting**: Some ComfyUI workflows and image export processors output metadata on a single line with custom delimiters (e.g., `,.Negative prompt:` or `...Negative prompt:` and `.Steps:`) rather than standard newlines. When this happens, line-based split logic fails, putting all generation parameters into the negative prompt field and extracting no actual settings (steps, sampler, seed, etc.).

### Changes

1. **Auto-Detect Endianness** in `decodeUserComment` (`src/utils/encoding-helpers.ts`):
   - Checks for standard UTF-16 Byte Order Marks (BOM) (`0xFEFF` or `0xFFFE`) to determine endianness.
   - If no BOM is present, computes a zero-byte frequency heuristic: counts zero bytes at even vs. odd offsets. If more zeros exist at odd offsets, decodes as `utf-16le`; otherwise, defaults to `utf-16be`.
2. **Format Normalization** in `automaticMetadataProcessor` (`src/utils/metadata/automatic.metadata.ts`):
   - Cleans the `Parameters :` prefix.
   - Detects and converts inline delimiters before `Negative prompt:` and `Steps:` into newlines to ensure standard line-based parsing. Added a lookahead `(?=\s*\d+)` for `Steps:` to avoid matching the word "steps" in general sentences.
3. **Unit Tests**:
   - Added test cases in `exif-parser.test.ts` covering UTF-16BE/LE (with and without BOM) decoding and the single-line delimited formats with generic resources.
