### PR TITLE
perf(trpc): upgrade superjson 1.9.1 → 2.2.6

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -103,7 +103,7 @@ export default defineNextConfig(
             // removeConsole: true,
           }
         : {},
-    transpilePackages: [],
+    transpilePackages: ['superjson'],
     experimental: {
       // scrollRestoration: true,
       cpus: 8,

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "stacktrace-parser": "^0.1.10",
     "stream-to-blob": "^2.0.1",
     "stripe": "^11.6.0",
-    "superjson": "1.9.1",
+    "superjson": "^2.2.6",
     "trie-memoize": "^1.2.0",
     "unfurl.js": "^6.4.0",
     "unified": "^11.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,8 +566,8 @@ importers:
         specifier: ^11.6.0
         version: 11.18.0
       superjson:
-        specifier: 1.9.1
-        version: 1.9.1
+        specifier: ^2.2.6
+        version: 2.2.6
       trie-memoize:
         specifier: ^1.2.0
         version: 1.2.0
@@ -5075,9 +5075,9 @@ packages:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
     engines: {node: '>= 0.8'}
 
-  copy-anything@3.0.5:
-    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
-    engines: {node: '>=12.13'}
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
 
   core-js@3.45.0:
     resolution: {integrity: sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==}
@@ -6749,9 +6749,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
-  is-what@4.1.16:
-    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
-    engines: {node: '>=12.13'}
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -9306,9 +9306,9 @@ packages:
     peerDependencies:
       postcss: ^8.3.3
 
-  superjson@1.9.1:
-    resolution: {integrity: sha512-oT3HA2nPKlU1+5taFgz/HDy+GEaY+CWEbLzaRJVD4gZ7zMVVC4GDNFdgvAZt6/VuIk6D2R7RtPAiCHwmdzlMmg==}
-    engines: {node: '>=10'}
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
 
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
@@ -15301,9 +15301,9 @@ snapshots:
       depd: 2.0.0
       keygrip: 1.1.0
 
-  copy-anything@3.0.5:
+  copy-anything@4.0.5:
     dependencies:
-      is-what: 4.1.16
+      is-what: 5.5.0
 
   core-js@3.45.0: {}
 
@@ -17380,7 +17380,7 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
-  is-what@4.1.16: {}
+  is-what@5.5.0: {}
 
   is-wsl@3.1.0:
     dependencies:
@@ -20554,9 +20554,9 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  superjson@1.9.1:
+  superjson@2.2.6:
     dependencies:
-      copy-anything: 3.0.5
+      copy-anything: 4.0.5
 
   superstruct@2.0.2: {}
 


### PR DESCRIPTION
Replaces the closed devalue migration (#2410) with the lower-risk lever from the best-practice audit.

## Why
The API pins the single JS thread under load; a prod pin profile put superjson's `plainer.js` walker at ~10% of busy CPU on the Date-heavy feed. #2410 swapped to devalue, but:
- We're **3 majors behind** — running superjson **1.9.1**; current is **2.2.6** (actively maintained).
- **Every benchmark motivating devalue compared it only against superjson 1.x** — the stale version we run. superjson 2.x post-dates its serialization-perf work, so this is the honest test of "is the serializer the cost?" without devalue's downsides.

## Why this over devalue
| | superjson 2 | devalue (closed #2410) |
|---|---|---|
| Class instances (Decimal/dayjs/SDK/Error) | **coerces** (lenient, like 1.x) | **throws → 500** (per-route tax) |
| SSR full-page-500 risk on new return types | none | permanent surface |
| Wire format | `{json,meta,v:1}` (unchanged) | new (cross-deploy + empty-input bugs) |
| Code changes | version bump only | new transformer + 4 bug-fix rounds |
| ESM-only | yes (handled) | yes |

devalue caused repeated errors in practice (cancelSubscriptionPlan, paddle adjustments, withdrawal returns, and an `[object Object]` empty-input crash). superjson 2 keeps 1.x's leniency, so none of that recurs.

## Changes
- `package.json`: `superjson` `1.9.1` → `^2.2.6`
- `next.config.mjs`: add `superjson` to `transpilePackages` (v2 is ESM-only — its only breaking change; same mechanism devalue needed). No `require()` of superjson exists in `src/`.
- `pnpm-lock.yaml`: regenerated (superjson 2.2.6 + its transitive `copy-anything` 3→4, `is-what` 4→5).

## Verification
- v2 **default export intact** (`import superjson from 'superjson'`), `serialize`/`deserialize` round-trip Date + Map (tested against the installed 2.2.6).
- Wire format is identical `{json, meta, v:1}` → **cross-compatible with 1.x during the rolling deploy** (old client ↔ new server both ways).
- Existing transformer wiring unchanged (`src/server/trpc.ts`, `src/utils/trpc.ts`).
- ⚠️ Local `pnpm typecheck` is broken (stale Prisma client) — **CI is authoritative**. The real validation is the same as any transformer change: a production build + standalone boot + a logged-in SSR smoke (the ESM/`transpilePackages` path only matters in the prod CJS bundle).

## Measurement note
Per this effort's data, steady-state serializer cost is small (~0.5%); the ~10% is **pin-time**, so judge impact via a pin CPU profile (superjson `plainer.js`/`walker` self-time), not steady-state Prometheus. Higher-ceiling follow-up remains: epoch dates + no transformer on the feed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)