### PR TITLE
perf(image): trim unused fields from the feed response

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1725,7 +1725,6 @@ export const getAllImages = async (
       i.height,
       i.hash,
       -- i.meta,
-      i."hideMeta",
       (
         CASE
           WHEN i.meta IS NULL OR jsonb_typeof(i.meta) = 'null' OR i."hideMeta" THEN FALSE
@@ -1744,24 +1743,19 @@ export const getAllImages = async (
       i."meta"->'extra'->'remixOfId' as "remixOfId",
       i."createdAt",
       GREATEST(p."publishedAt", i."scannedAt", i."createdAt") as "sortAt",
-      i."mimeType",
       i.type,
       i.metadata,
       i.ingestion,
       i."blockedFor",
-      i."scannedAt",
       i."needsReview",
       i."userId",
       i."postId",
-      p."title" "postTitle",
       i."index",
       p."publishedAt",
       p.metadata->>'unpublishedAt' "unpublishedAt",
       p."modelVersionId",
-      p."availability",
       i.minor,
       i.poi,
-      i."acceptableMinor",
       ${Prisma.raw(cursorProp ? cursorProp : 'null')} "cursorId"
       ${Prisma.raw(collectionId ? ', ct.note as "collectionItemNote"' : '')}
       ${queryFrom}
@@ -1930,17 +1924,18 @@ export const getAllImages = async (
     });
 
     const result: Array<
-      Omit<ImageV2Model, 'nsfwLevel' | 'metadata'> & {
+      // Trimmed from the feed response (zero client/v1 consumers): mimeType,
+      // scannedAt, postTitle (from ImageV2Model), plus hideMeta, availability,
+      // acceptableMinor (dropped from the SQL select above). See PR notes.
+      Omit<ImageV2Model, 'nsfwLevel' | 'metadata' | 'mimeType' | 'scannedAt' | 'postTitle'> & {
         // meta: ImageMetaProps | null; // TODO - don't fetch meta
         meta?: ImageMetaProps | null; // deprecated. Only used in v1 api endpoint
-        hideMeta: boolean; // TODO - remove references to this. Instead, use `hasMeta`
         hasMeta: boolean;
         tags?: VotableTagModel[] | undefined;
         tagIds?: number[];
         publishedAt?: Date | null;
         modelVersionId?: number | null;
         baseModel?: string | null; // TODO - remove
-        availability?: Availability;
         nsfwLevel: NsfwLevel;
         cosmetic?: WithClaimKey<ContentDecorationCosmetic> | null;
         metadata: ImageMetadata | VideoMetadata | null;
@@ -2188,7 +2183,28 @@ export const getAllImagesIndex = async (
   );
 
   const mergedData = withSpan('image:getAllImagesIndex:transform', () =>
-    searchResults.map(({ publishedAtUnix, ...sr }) => {
+    searchResults.map((searchResult) => {
+      // Strip fields trimmed from the feed response so the index path stays
+      // byte-for-byte identical to the PG path (getAllImages). These have zero
+      // client/v1 consumers; acceptableMinor/availability are moderation flags
+      // that should never have been on the wire. See PR notes.
+      const {
+        publishedAtUnix,
+        hideMeta: _hideMeta,
+        acceptableMinor: _acceptableMinor,
+        availability: _availability,
+        mimeType: _mimeType,
+        scannedAt: _scannedAt,
+        postTitle: _postTitle,
+        ...sr
+      } = searchResult as typeof searchResult & {
+        hideMeta?: unknown;
+        acceptableMinor?: unknown;
+        availability?: unknown;
+        mimeType?: unknown;
+        scannedAt?: unknown;
+        postTitle?: unknown;
+      };
       const thisUser = userDatas[sr.userId] ?? {};
       const reactions =
         userReactions?.[sr.id]?.map((r) => ({ userId: currentUserId as number, reaction: r })) ??
@@ -2233,18 +2249,14 @@ export const getAllImagesIndex = async (
         reactions,
         cosmetic: imageCosmetics?.[sr.id] ?? null,
         // TODO fix below
-        availability: Availability.Public,
         tags: [], // needed?
         name: null, // leave
-        scannedAt: null, // remove
-        mimeType: null, // need?
         ingestion:
           nsfwLevel === NsfwLevel.Blocked
             ? ImageIngestionStatus.Blocked
             : nsfwLevel === 0
             ? ImageIngestionStatus.NotFound
             : ImageIngestionStatus.Scanned, // add? maybe remove
-        postTitle: null, // remove
         meta,
         nsfwLevel,
         thumbnailUrl: thumbnail?.url,


### PR DESCRIPTION
## Goal

Reduce the image-feed tRPC payload (`image.getInfinite` → `ImagesInfiniteModel`) by removing fields with **zero grep-verified consumers**. A prod pin profile shows superjson's `plainer.js` walker at ~10% of busy CPU and GC at ~11%; the cost is dominated by the walker traversing large feed objects **field-by-field** plus the allocations/wire size they create. Fewer fields per record = fewer property visits in the walker + less GC + smaller wire, with no serializer-strictness risk.

Both feed paths were trimmed in lockstep so they return an identical shape:
- **PG path** — `getAllImages` (raw SQL select + result type)
- **Index path** — `getAllImagesIndex` (search-result spread + hardcoded re-adds)

## Fields removed (all provably DEAD on the feed item)

| Field | Type | Why DEAD | Evidence |
|---|---|---|---|
| `mimeType` | `string\|null` | No feed/card/detail/v1 consumer. Index path already returned `null`. | Only `.mimeType` hit is an upload form (`ChallengeSubmitModal`). |
| `scannedAt` | `Date\|null` | No feed/card/detail/v1 consumer. Index path already returned `null`. | `.scannedAt` hits are Bounty/Club cover images (different entity), webhook writers, mod endpoints. |
| `postTitle` | `string\|null` | No consumer. Index path already returned `null`; as-posts handler has it commented out (`// postTitle: image.postTitle`). | Only `.postTitle` hit is `params.postTitle` (dialog params) + a notification `details.postTitle`. |
| `hideMeta` | `boolean` | No feed/card/detail/v1 consumer; cards use `hasMeta`/`hasPositivePrompt`. Type was already annotated `// TODO - remove references to this. Instead, use hasMeta`. | `.hideMeta` hits are the post-edit form, collection cover images, and Meili search hits — none are `ImagesInfiniteModel`. |
| `availability` | `Availability` | No feed-item consumer anywhere. | All `.availability` hits are Model/Post/Collection/Shop/Training entities. Index path hardcoded `Availability.Public`. |
| `acceptableMinor` | `boolean` | No feed-item consumer; only the **detail** procedure (`image.get`) cache reads/writes it. Moderation flag — should not be on the public wire. | `old.acceptableMinor = …` mutates `queryUtils.image.get` (detail), not `getInfinite`. BitDex/Meili use it for internal *filtering* only. |

## Field classification (full enumeration of the feed item)

**USED — kept** (rendered or read in a client/server transform):

| Field | Consumer evidence |
|---|---|
| `id` | everywhere (keys, dialogs, dedupe in `useQueryImages`) |
| `url` | `EdgeMedia2` src, v1 API |
| `name` | `ImagesCard`/`AsPostsCard` alt text |
| `hash`, `width`, `height` | `MediaHash`, v1 API, metadata override |
| `nsfwLevel` | `useApplyHiddenPreferences`, ImageGuard2, v1 API |
| `type` | cards, video duration, `getSkipValue` |
| `metadata` | `EdgeMedia2`, video `duration` badge |
| `hasMeta`, `hasPositivePrompt` | remix button / meta popover gating |
| `onSite` | `OnsiteIndicator` |
| `remixOfId` | `ImagesCard`/`PostsCard` remix indicator |
| `ingestion`, `blockedFor`, `needsReview` | `ImagesCard` blocked/pending state, `ImageContextMenu`, `image.store` |
| `createdAt`, `sortAt`, `publishedAt` | as-posts handler sort + `DaysFromNow` in detail/as-posts |
| `index` | as-posts handler `images.sort`, `PostReorderImages` |
| `postId` | as-posts merge, card links, v1 API |
| `modelVersionId` | as-posts result, BitDex routing |
| `minor`, `poi` | hidden-prefs filter, ImageGuard2, mod menu, `disableBuzzTip` |
| `meta` | v1 REST API (gated by `withMeta`; tRPC feed already sends `null` unless `metaSelect` included) |
| `baseModel` | v1 REST API |
| `modelVersionIds`, `modelVersionIdsManual` | v1 API / `ImagesAsPostsCard` resource match |
| `stats.{like,laugh,heart,cry,dislike,tippedAmount,comment,collected,view}CountAllTime` | card `Reactions`/`Metrics`, as-posts sort, detail view, v1 API |
| `reactions` | `Reactions` component |
| `user{id,username,image,deletedAt,cosmetics,profilePicture}` | avatar, ownership, reactions targetUserId |
| `cosmetic` | `TwCosmeticWrapper`, card frame |
| `tags`, `tagIds` | `VotableTags`, hidden-tag filter (only fetched when `withTags`/`tagIds` in `include`) |
| `thumbnailUrl` | `EdgeMedia2` |
| `judgeScore` | `JudgeScoreBadge` |

**Note on heavy fields:** `meta` and `tags` are already conditional — the default feed `include` is `['cosmetics']` (+`tagIds` added by the handler), so the common feed path already sends `meta: null` and `tags: undefined`. No additional win available there without an API/consumer change.

## Removed vs. proposed-but-left

- **Removed:** the six DEAD fields above (both paths, identically).
- **Left as proposals (UNCERTAIN / would require consumer changes):** none in this PR. The remaining always-present fields are all USED; the heavy objects (`meta`, `tags`) are already gated by `include`.

## Both paths trimmed identically

- PG (`getAllImages`): removed the six columns from the raw SQL `SELECT` and from the `result` type annotation that defines `ImagesInfiniteModel`.
- Index (`getAllImagesIndex`): destructured `hideMeta`/`acceptableMinor`/`availability`/`mimeType`/`scannedAt`/`postTitle` out of the search-result spread and removed the hardcoded `null`/`Public` re-adds. Result objects are now byte-for-byte identical between the two paths.

## Estimated payload / walk reduction

Six fewer top-level properties per record. On a typical ~100-record feed page that is **~600 fewer property visits** in the superjson walker and ~600 fewer key strings on the wire per page. Per-field wire bytes are small (booleans + short enum/date strings; `mimeType`/`scannedAt`/`postTitle` were frequently `null` and already `null` on the index path), so the byte win is modest — the intended lever is **reduced walker self-time and fewer allocations**, not raw bytes.

## Measurement note

Judge via the **pin CPU profile** — superjson `plainer.js` walker self-time + GC share — not steady-state (~0.5%). This change reduces per-record field count on the hottest serialized payload in the app; expect a small but real reduction in walker self-time proportional to the ~6/N fewer fields traversed per record.

## Confidence it's behavior-preserving

High. No filtering / NSFW / ordering / cursor / dedupe logic touched. Every removed field was grep-verified to have zero live consumers across feed hooks (`useQueryImages`), the hidden-preferences hook, all feed/card/detail components (incl. `ImageDetail2`, which reads its image from the feed cache), the as-posts controller, and the v1 REST API. Local `pnpm typecheck` is unavailable in the worktree (no node_modules / stale Prisma) — CI is authoritative; the result-type was trimmed so TS will surface any missed consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
