### PR TITLE
perf(metrics): make route-duration histogram usable for heavy-route P99

### DIFF
--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -94,7 +94,12 @@ const imagesEndpointSchema = z.object({
 const { requestDurationSeconds } = ensureRegisterFeedImageExistenceCheckMetrics(client.register);
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const endTimer = requestDurationSeconds.startTimer({ route: 'api/v1/images' });
+  // Started AFTER param validation + the paging guard so cheap 400/429 rejects
+  // aren't recorded as ~0ms heavy requests, which would dilute the heavy-tail P99
+  // this metric exists to measure. (Also the correct slot for the bulkhead merge:
+  // the #2428 acquire goes immediately above this, so a 503-rejected request is
+  // never timed.) Ended in finally; `?.` because early returns leave it unstarted.
+  let endTimer: (() => void) | undefined;
   try {
     const reqParams = imagesEndpointSchema.safeParse(req.query);
     if (!reqParams.success) return res.status(400).json({ error: reqParams.error });
@@ -116,6 +121,8 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
 
       ({ skip } = getPagination(limit, page));
     }
+
+    endTimer = requestDurationSeconds.startTimer({ route: 'api/v1/images' });
 
     // Check if request is from restricted region and override browsing level
     const region = getRegion(req);
@@ -275,7 +282,7 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       code: trpcError.code,
     });
   } finally {
-    endTimer();
+    endTimer?.();
   }
 });
 

--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -8,7 +8,9 @@ import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { isProd } from '~/env/other';
 import { constants } from '~/server/common/constants';
 import { ImageSort } from '~/server/common/enums';
+import client from 'prom-client';
 import { buildFliptContext, getFeatureFlags } from '~/server/services/feature-flags.service';
+import { ensureRegisterFeedImageExistenceCheckMetrics } from '~/server/metrics/feed-image-existence-check.metrics';
 import { buildSearchActor } from '~/server/meilisearch/client';
 import {
   getAllImages,
@@ -84,7 +86,15 @@ const imagesEndpointSchema = z.object({
   flatMeta: booleanString().optional(),
 });
 
+// Reuse the shared images-search metrics bundle (idempotent registration on the
+// default registry that /api/metrics scrapes). This times the FULL REST handler
+// — including enrichment + JSON serialization, the actual pin cost — which the
+// inner getImagesFromSearch timer doesn't capture. route label keeps it queryable
+// alongside the search-fn timing without extra cardinality.
+const { requestDurationSeconds } = ensureRegisterFeedImageExistenceCheckMetrics(client.register);
+
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const endTimer = requestDurationSeconds.startTimer({ route: 'api/v1/images' });
   try {
     const reqParams = imagesEndpointSchema.safeParse(req.query);
     if (!reqParams.success) return res.status(400).json({ error: reqParams.error });
@@ -92,7 +102,8 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     const session = await getServerAuthSession({ req, res });
 
     // Handle pagination
-    const { limit, page, cursor, nsfw, browsingLevel, type, withMeta, flatMeta, ...data } = reqParams.data;
+    const { limit, page, cursor, nsfw, browsingLevel, type, withMeta, flatMeta, ...data } =
+      reqParams.data;
     let skip: number | undefined;
     const usingPaging = page && !cursor;
     if (usingPaging) {
@@ -263,6 +274,8 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       error: trpcError.message,
       code: trpcError.code,
     });
+  } finally {
+    endTimer();
   }
 });
 

--- a/src/server/metrics/feed-image-existence-check.metrics.ts
+++ b/src/server/metrics/feed-image-existence-check.metrics.ts
@@ -68,7 +68,10 @@ export function ensureRegisterFeedImageExistenceCheckMetrics(
     'images_search_request_duration_seconds',
     'Request duration in seconds',
     ['route'],
-    [0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5]
+    // Tail buckets (8-60s) added so the heavy-route pin window (the /api/v1/images
+    // REST handler + Meili search routinely block 8-23s under load) lands in real
+    // buckets instead of saturating +Inf, which made histogram_quantile blind above 5s.
+    [0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 8, 10, 15, 20, 30, 60]
   );
 
   /** Total number of IDs dropped after existence checks */


### PR DESCRIPTION
## Why
Sizing the heavy-route concurrency cap (#2428) and targeting tRPC-feed isolation (A Phase 2) both need a per-route P99 for the heavy image paths. The `images_search_request_duration_seconds` histogram **is** scraped (contrary to the prior handoff note) — but it was unusable for that purpose:

1. **Buckets capped at 5s.** Heavy-route requests block 8–23s under load, so they all collapsed into `+Inf` and `histogram_quantile` went blind exactly in the tail that matters. Confirmed live during the **2026-06-07 11:01 wave** (api-primary 504 peaked ~156/s, up to 13 pods pinned): `getImagesFromSearch` P99 read a flat **5.00s** — saturated at the ceiling.
2. **Only the inner `getImagesFromSearch` Meili fn was timed.** There was no histogram for the `/api/v1/images` REST request as a whole (the heavy pool's endpoint), and it excludes enrichment + JSON serialization — the actual pin cost.

## What
- **Extend buckets**: `[…, 3, 5]` → `[…, 3, 5, 8, 10, 15, 20, 30, 60]`. Same metric, idempotent registration on the default registry that `/api/metrics` scrapes.
- **Time the full `/api/v1/images` handler** under `route="api/v1/images"` on the same `requestDurationSeconds` metric (reused bundle, no new cardinality), wrapped in `finally` so both success and error paths record.

## Effect (after deploy)
`histogram_quantile(0.99, sum by(route,le)(rate(images_search_request_duration_seconds_bucket[5m])))` returns a real P99 by route (`api/v1/images` vs `getImagesFromSearch`), tail now visible up to 60s. Directly unblocks #2428 draft-blocker #1 and Phase 2 target selection.

## Risk
Low. Additive: extra histogram buckets + one `startTimer/endTimer` around an existing handler. No behavior change. Takes effect only after a deploy (metric definition lives in the running image).

## Test
`pnpm run lint` clean on both files (pre-existing `no-explicit-any` warnings only). Local typecheck is known-broken (stale Prisma client); CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)