### PR TITLE
perf(buzz): short-TTL cache for getBuzzAccount + bust on balance mutations

### DIFF
--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1059,6 +1059,7 @@ export const REDIS_KEYS = {
     POTENTIAL_POOL: 'buzz:potential-pool',
     POTENTIAL_POOL_VALUE: 'buzz:potential-pool-value',
     EARNED: 'buzz:earned',
+    ACCOUNT: 'buzz:account',
   },
   CREATOR_PROGRAM: {
     CAPS: 'packed:caches:creator-program:caps',

--- a/src/server/services/auction.service.ts
+++ b/src/server/services/auction.service.ts
@@ -20,7 +20,7 @@ import type { ModelMeta } from '~/server/schema/model.schema';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import {
   createMultiAccountBuzzTransaction,
-  getUserBuzzAccount,
+  getUserBuzzAccountByAccountTypesUncached,
   refundMultiAccountTransaction,
   refundTransaction,
 } from '~/server/services/buzz.service';
@@ -427,8 +427,7 @@ export const createBid = async ({
     if (mv.availability === Availability.Private)
       throw throwBadRequestError('Invalid model version.');
 
-    if (mv.status !== ModelStatus.Published)
-      throw throwBadRequestError('Invalid model version.');
+    if (mv.status !== ModelStatus.Published) throw throwBadRequestError('Invalid model version.');
 
     if (mv.model.status !== ModelStatus.Published)
       throw throwBadRequestError('Invalid model version.');
@@ -458,8 +457,12 @@ export const createBid = async ({
   }
 
   // - Go
-  const balanceData = await getUserBuzzAccount({ accountId: userId, accountTypes });
-  const balance = balanceData.reduce((acc, b) => acc + (b.balance ?? 0), 0);
+  // Spend-authorization gate: read UNCACHED. `createMultiAccountBuzzTransaction`
+  // has no in-app balance gate, so this pre-check is the only in-app guard. A
+  // cached (potentially ~6s-stale) balance must never authorize a spend, so this
+  // bypasses the cached `getUserBuzzAccount({ accountTypes })` read/display path.
+  const balanceData = await getUserBuzzAccountByAccountTypesUncached(userId, accountTypes);
+  const balance = Object.values(balanceData).reduce((acc, b) => acc + (b ?? 0), 0);
   if ((balance ?? 0) < amount) {
     throw throwInsufficientFundsError();
   }

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -125,7 +125,7 @@ async function getUserBuzzAccountByAccountType(
   return buzzApiFetch(`/account/${BuzzTypes.toApiType(accountType)}/${accountId}`);
 }
 
-export async function getUserBuzzAccountByAccountTypes<T extends BuzzAccountType>(
+async function fetchUserBuzzAccountByAccountTypes<T extends BuzzAccountType>(
   accountId: number,
   accountTypes: T[]
 ): Promise<BuzzAccountsResponse<T>> {
@@ -139,6 +139,47 @@ export async function getUserBuzzAccountByAccountTypes<T extends BuzzAccountType
     if (!type) return acc;
     return { ...acc, [type]: value };
   }, {} as BuzzAccountsResponse<T>);
+}
+
+// Builds a stable redis key per (accountId, requested accountTypes[]). accountTypes
+// is sorted so [a,b] and [b,a] map to the same key. The prefix MUST stay
+// `${REDIS_KEYS.BUZZ.ACCOUNT}:${accountId}:` so `bustBuzzAccountCache`'s
+// `${REDIS_KEYS.BUZZ.ACCOUNT}:${id}:*` pattern clears it.
+function getBuzzAccountTypesCacheKey(accountId: number, accountTypes: BuzzAccountType[]) {
+  return `${REDIS_KEYS.BUZZ.ACCOUNT}:${accountId}:ts:${[...accountTypes]
+    .sort()
+    .join(',')}` as const;
+}
+
+// `getUserBuzzAccountByAccountTypes` is the read/display path the live, very
+// high-frequency `buzz.getBuzzAccount` tRPC endpoint resolves to (router ->
+// getUserBuzzAccounts -> here), so it is otherwise uncached and surges against
+// the external buzz API (the confirmed root cause of API-pod CPU pin waves).
+// The cache lives HERE, not on `getUserBuzzAccount`, because the live endpoint
+// never goes through `getUserBuzzAccount`.
+//
+// IMPORTANT: the spend-authorization balance gate in `createBuzzTransaction`
+// reads `getUserBuzzAccountByAccountId` / `getUserBuzzAccountByAccountType`
+// (the byId/byType paths), which stay UNCACHED so a stale balance can never
+// gate a spend. Only this read/display path is cached.
+//
+// fetchThroughCache stores the entry with EX: ttl*2 and serves stale data while
+// a single holder refreshes (stale-while-revalidate), so the effective freshness
+// window is ~2x the TTL (~6s for TTL=3). It does not cache thrown errors (the
+// redis write only happens after fetchFn resolves), so error responses are never
+// cached. Every in-app balance mutation busts the account via
+// `bustBuzzAccountCache`; the TTL is the freshness net for out-of-app changes.
+const BUZZ_ACCOUNT_CACHE_TTL = 3; // seconds
+
+export async function getUserBuzzAccountByAccountTypes<T extends BuzzAccountType>(
+  accountId: number,
+  accountTypes: T[]
+): Promise<BuzzAccountsResponse<T>> {
+  return fetchThroughCache(
+    getBuzzAccountTypesCacheKey(accountId, accountTypes),
+    () => fetchUserBuzzAccountByAccountTypes(accountId, accountTypes),
+    { ttl: BUZZ_ACCOUNT_CACHE_TTL }
+  );
 }
 
 export async function getUserBuzzAccounts({ userId }: { userId: number }) {
@@ -155,33 +196,6 @@ async function fetchUserBuzzAccounts({
     : accountTypes
     ? getUserBuzzAccountByAccountTypes(accountId, accountTypes)
     : getUserBuzzAccountByAccountId(accountId);
-}
-
-// Short-TTL cache in front of the external buzz API. `buzz.getBuzzAccount` is
-// called on nearly every request and is otherwise uncached, so it surges and
-// hammers the external service (the confirmed root cause of API-pod CPU pin
-// waves). The TTL is intentionally tiny: it absorbs request bursts without
-// meaningfully delaying balance changes, and every in-app balance mutation
-// busts the cache for the affected account (see `bustBuzzAccountCache`). The
-// TTL is the freshness safety net for balance changes that originate outside
-// the app (e.g. rewards credited by other services) that app code can't bust.
-const BUZZ_ACCOUNT_CACHE_TTL = 3; // seconds
-
-// Builds a stable redis key per (accountId, requested account type/types). The
-// three request shapes (default account, single accountType, accountTypes[])
-// return different payload shapes, so they MUST NOT share a cache entry.
-// accountTypes is sorted so [a,b] and [b,a] map to the same key.
-function getBuzzAccountCacheKey({
-  accountId,
-  accountType,
-  accountTypes,
-}: GetUserBuzzAccountSchema) {
-  const variant = accountType
-    ? `t:${accountType}`
-    : accountTypes
-    ? `ts:${[...accountTypes].sort().join(',')}`
-    : 'default';
-  return `${REDIS_KEYS.BUZZ.ACCOUNT}:${accountId}:${variant}` as const;
 }
 
 // Busts every cached variant for the given account id(s). Mutations can't know
@@ -218,14 +232,11 @@ export async function getUserBuzzAccount({
   accountType,
   accountTypes,
 }: GetUserBuzzAccountSchema) {
-  // Cache the raw external fetch only. fetchThroughCache does not cache thrown
-  // errors (the fetchFn rejection propagates without writing redis), so error
-  // responses are never cached.
-  const data = await fetchThroughCache(
-    getBuzzAccountCacheKey({ accountId, accountType, accountTypes }),
-    () => fetchUserBuzzAccounts({ accountId, accountType, accountTypes }),
-    { ttl: BUZZ_ACCOUNT_CACHE_TTL }
-  );
+  // Caching lives one level down on `getUserBuzzAccountByAccountTypes` (the
+  // read/display path the live `buzz.getBuzzAccount` endpoint hits). The
+  // accountTypes branch below benefits from that cache automatically, while the
+  // accountType/accountId branches stay uncached to match the spend-gate reads.
+  const data = await fetchUserBuzzAccounts({ accountId, accountType, accountTypes });
 
   let res: (Omit<BuzzAccountResponse, 'lifetimeBalance'> & {
     accountType: BuzzAccountType;

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -51,7 +51,11 @@ import {
 import type { PaymentIntentMetadataSchema } from '~/server/schema/stripe.schema';
 import { createNotification } from '~/server/services/notification.service';
 import { logToAxiom } from '~/server/logging/client';
-import { createCachedObject, fetchThroughCache } from '~/server/utils/cache-helpers';
+import {
+  clearCacheByPattern,
+  createCachedObject,
+  fetchThroughCache,
+} from '~/server/utils/cache-helpers';
 import {
   throwBadRequestError,
   throwInsufficientFundsError,
@@ -153,12 +157,75 @@ async function fetchUserBuzzAccounts({
     : getUserBuzzAccountByAccountId(accountId);
 }
 
+// Short-TTL cache in front of the external buzz API. `buzz.getBuzzAccount` is
+// called on nearly every request and is otherwise uncached, so it surges and
+// hammers the external service (the confirmed root cause of API-pod CPU pin
+// waves). The TTL is intentionally tiny: it absorbs request bursts without
+// meaningfully delaying balance changes, and every in-app balance mutation
+// busts the cache for the affected account (see `bustBuzzAccountCache`). The
+// TTL is the freshness safety net for balance changes that originate outside
+// the app (e.g. rewards credited by other services) that app code can't bust.
+const BUZZ_ACCOUNT_CACHE_TTL = 3; // seconds
+
+// Builds a stable redis key per (accountId, requested account type/types). The
+// three request shapes (default account, single accountType, accountTypes[])
+// return different payload shapes, so they MUST NOT share a cache entry.
+// accountTypes is sorted so [a,b] and [b,a] map to the same key.
+function getBuzzAccountCacheKey({
+  accountId,
+  accountType,
+  accountTypes,
+}: GetUserBuzzAccountSchema) {
+  const variant = accountType
+    ? `t:${accountType}`
+    : accountTypes
+    ? `ts:${[...accountTypes].sort().join(',')}`
+    : 'default';
+  return `${REDIS_KEYS.BUZZ.ACCOUNT}:${accountId}:${variant}` as const;
+}
+
+// Busts every cached variant for the given account id(s). Mutations can't know
+// which (type/types) variants a caller cached, so we pattern-clear the account
+// namespace. Mutations are far rarer than reads, so the per-mutation SCAN is an
+// acceptable cost. Account id 0 is the system "bank" and is never read through
+// getBuzzAccount, so it's skipped.
+export async function bustBuzzAccountCache(accountIds: number | (number | undefined)[]) {
+  const ids = (Array.isArray(accountIds) ? accountIds : [accountIds]).filter(
+    (id): id is number => typeof id === 'number' && id > 0
+  );
+  const uniqueIds = [...new Set(ids)];
+  if (!uniqueIds.length) return;
+
+  await Promise.all(
+    uniqueIds.map((id) =>
+      clearCacheByPattern(`${REDIS_KEYS.BUZZ.ACCOUNT}:${id}:*`).catch((error) => {
+        logToAxiom(
+          {
+            name: 'bust-buzz-account-cache',
+            type: 'error',
+            accountId: id,
+            message: (error as Error)?.message ?? String(error),
+          },
+          'webhooks'
+        ).catch(() => null);
+      })
+    )
+  );
+}
+
 export async function getUserBuzzAccount({
   accountId,
   accountType,
   accountTypes,
 }: GetUserBuzzAccountSchema) {
-  const data = await fetchUserBuzzAccounts({ accountId, accountType, accountTypes });
+  // Cache the raw external fetch only. fetchThroughCache does not cache thrown
+  // errors (the fetchFn rejection propagates without writing redis), so error
+  // responses are never cached.
+  const data = await fetchThroughCache(
+    getBuzzAccountCacheKey({ accountId, accountType, accountTypes }),
+    () => fetchUserBuzzAccounts({ accountId, accountType, accountTypes }),
+    { ttl: BUZZ_ACCOUNT_CACHE_TTL }
+  );
 
   let res: (Omit<BuzzAccountResponse, 'lifetimeBalance'> & {
     accountType: BuzzAccountType;
@@ -386,6 +453,8 @@ export async function createBuzzTransaction({
     body,
   });
 
+  await bustBuzzAccountCache([payload.fromAccountId, toAccountId]);
+
   return data;
 }
 
@@ -496,6 +565,8 @@ export async function createBuzzTransactionMany(
     body,
   });
 
+  await bustBuzzAccountCache(transactions.flatMap((t) => [t.fromAccountId, t.toAccountId]));
+
   return data;
 }
 
@@ -569,6 +640,11 @@ export async function completeStripeBuzzTransaction({
       headers: { 'Content-Type': 'application/json' },
       body,
     });
+
+    // fromAccountId is the system bank (0) and is skipped by bustBuzzAccountCache;
+    // the blue-buzz sub-grant below goes through createBuzzTransaction, which
+    // busts its own accounts.
+    await bustBuzzAccountCache(userId);
 
     // Write transactionId immediately so any subsequent failure lets the retry
     // path skip the main grant via the early-return above.
@@ -658,6 +734,11 @@ export async function completeStripeBuzzTransaction({
   }
 }
 
+// NOTE: refundTransaction only receives a transactionId — the affected
+// from/to accounts are not available here (and the buzz API response doesn't
+// return them), so we cannot bust the account cache. The 3s TTL is the only
+// freshness guarantee for refunds. If precise busting is needed later, resolve
+// the accountIds via getTransactionByExternalId / a buzz-API lookup first.
 export async function refundTransaction(
   transactionId: string,
   description?: string,
@@ -693,9 +774,15 @@ export async function createMultiAccountBuzzTransaction(
     body,
   });
 
+  await bustBuzzAccountCache([input.fromAccountId, input.toAccountId]);
+
   return createMultiAccountBuzzTransactionResponse.parse(data);
 }
 
+// NOTE: refundMultiAccountTransaction is keyed by externalTransactionIdPrefix
+// and neither the input nor the buzz-API response include the affected
+// accountIds, so the account cache cannot be busted here. The 3s TTL is the
+// only freshness guarantee for these refunds.
 export async function refundMultiAccountTransaction(input: RefundMultiAccountTransactionInput) {
   const body = JSON.stringify(input);
 

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -186,6 +186,18 @@ export async function getUserBuzzAccounts({ userId }: { userId: number }) {
   return await getUserBuzzAccountByAccountTypes(userId, buzzSpendTypes);
 }
 
+// UNCACHED multi-type balance read for spend-authorization gates. Mirrors the
+// byId/byType uncached reads used by `createBuzzTransaction`'s gate: a spend must
+// never be authorized off a (potentially ~6s-stale) cached balance. Use this
+// instead of `getUserBuzzAccountByAccountTypes` / `getUserBuzzAccount({ accountTypes })`
+// when the read decides whether a spend is allowed (e.g. auction bid pre-check).
+export async function getUserBuzzAccountByAccountTypesUncached<T extends BuzzAccountType>(
+  accountId: number,
+  accountTypes: T[]
+): Promise<BuzzAccountsResponse<T>> {
+  return fetchUserBuzzAccountByAccountTypes(accountId, accountTypes);
+}
+
 async function fetchUserBuzzAccounts({
   accountId,
   accountType,


### PR DESCRIPTION
## Root cause

`buzz.getBuzzAccount` is called on nearly every request and was **uncached** — it hit the external buzz API directly on every call. During CPU pin waves it surges 4-5× (65 → 288 req/s). The aggregate per-request work (external fetch + superjson serialization + handler) saturates the single Node JS thread, which is the confirmed root cause of the API-pod CPU pin waves.

## Audit fix (cache was a no-op as originally shipped)

The first revision attached the cache to `getUserBuzzAccount` (singular). But the **live, high-frequency `buzz.getBuzzAccount` tRPC endpoint does not call it** — the handler that used it (`getBuzzAccountHandler`) is commented out. The live endpoint resolves:

```
buzz.getBuzzAccount (buzz.router.ts:48)
  -> getUserBuzzAccounts({ userId })            (buzz.service.ts)
    -> getUserBuzzAccountByAccountTypes(userId, buzzSpendTypes)   (the real external fetch)
```

…bypassing the cached function entirely, so the hot route stayed uncached and the change did nothing for its goal.

**Fix:** the cache now lives on `getUserBuzzAccountByAccountTypes` — the exact function the live endpoint hits. `getUserBuzzAccount`'s `accountTypes` branch routes through the same function, so it benefits automatically.

## Cache details

- **Layer**: `fetchThroughCache` wraps the raw external fetch (`fetchUserBuzzAccountByAccountTypes`), mirroring the `fetchThroughCache` pattern already used in `buzz.service.ts` (the potential-pool caches) — no new caching mechanism introduced. The transparent response shapes for all callers are preserved.
- **Key**: `buzz:account:<accountId>:ts:<sorted accountTypes>` — keyed on `(accountId, sorted accountTypes[])` so `[a,b]` and `[b,a]` share an entry, and different requested type-sets never collide. Prefix stays `buzz:account:<accountId>:` so the bust pattern matches.
- **TTL = 3 seconds** (`BUZZ_ACCOUNT_CACHE_TTL`). `fetchThroughCache` stores the entry with `EX: ttl*2` and serves stale data while a single holder refreshes (**stale-while-revalidate**), so the **effective freshness window is ~2× the TTL (~6s), not 3s**. It is intentionally tiny: it absorbs request bursts and is the freshness net for credits made by other services outside the app (e.g. rewards) that app code can't proactively bust.
- **Errors are never cached** — `fetchThroughCache` only writes redis after `fetchFn` resolves, so a rejection propagates without caching.

## Spend safety — byId/byType reads stay uncached

The spend-authorization balance gate inside `createBuzzTransaction` reads `getUserBuzzAccountByAccountId` / `getUserBuzzAccountByAccountType` (the byId/byType paths). These remain **uncached plain `buzzApiFetch` calls**, so no stale balance can gate a spend (no double-spend). Only the read/display `accountTypes` path is cached.

## Bust-on-mutation

Every in-app balance-mutating path busts the affected account(s) via `bustBuzzAccountCache(accountIds)`, which pattern-clears `buzz:account:<id>:*` (matches the `:ts:...` key). Account id `0` is the system "bank" (never read through getBuzzAccount) and is skipped.

| Path | Accounts busted |
|------|-----------------|
| `createBuzzTransaction` | `fromAccountId` + `toAccountId` — also transitively covers **tips** (`upsertBuzzTip`) and **`claimBuzz`** (both run through `createBuzzTransaction`) |
| `createBuzzTransactionMany` | all `fromAccountId`/`toAccountId` pairs |
| `completeStripeBuzzTransaction` | `toAccountId` (= userId); `fromAccountId` is bank `0`. Blue-buzz sub-grant runs through `createBuzzTransaction`, which busts itself |
| `createMultiAccountBuzzTransaction` | `fromAccountId` + `toAccountId` |

### Paths NOT busted (rely on the ~6s SWR window)

- **`refundTransaction`** — only receives a `transactionId`; neither input nor the buzz-API response exposes the affected accountIds.
- **`refundMultiAccountTransaction`** — keyed by `externalTransactionIdPrefix`; input and response contain no accountIds.

Both are covered by the TTL window. Documented inline. If precise busting is needed later, the accountIds can be resolved via `getTransactionByExternalId` / a buzz-API lookup first.

## Validation

- `tsc --noEmit`: the only `buzz.service.ts` errors are the pre-existing stale-Prisma-client `$queryRaw`/clickhouse typing errors that also exist on `main` (untyped-function/implicit-any). **No new type errors introduced** by this change. CI is authoritative.
- `eslint`: 0 errors on the changed files. Warnings are all pre-existing.
- `prettier --write` applied.

## Risk

This touches money (buzz balance). The biggest risk is staleness after a spend — mitigated by keeping the spend-gate reads uncached, bust-on-mutation for all in-app paths, and the ~6s SWR ceiling for the two refund paths and external credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
