### PR TITLE
fix(signals): stop reconnect storm from triggering fleet-wide refetch spike

### DIFF
--- a/src/components/Signals/SignalsProvider.tsx
+++ b/src/components/Signals/SignalsProvider.tsx
@@ -126,18 +126,24 @@ export const useSignalTopic = (topic: TopicString | undefined, notify?: boolean)
 // fleet-wide reconnect produced tens of thousands of synchronized refetches in
 // a single ~10s window — saturating the API's single Node thread (CPU-pin /
 // 504 / Error-137 waves). To flatten that spike below the pin threshold we:
-//   1. Spread the post-reconnect refetch across MINUTES with a heavily jittered
-//      per-client delay, instead of a tight ~10s window.
-//   2. Skip the refetch entirely for short blips — live state already arrives
-//      via signal `setData` deltas (see useBuzz.ts `onBalanceUpdate`), so a
-//      sub-threshold disconnect cannot have lost meaningful state.
+//   1. Spread the post-reconnect refetch across a jittered per-client delay
+//      window instead of a tight ~10s window.
+//   2. Skip the heavy `orchestrator.queryGeneratedImages` refetch for short
+//      blips — it self-heals via a 60s poll, so a sub-threshold disconnect
+//      cannot have lost durable state. `buzz.getBuzzAccount` is exempt from
+//      that gate (it has no polling fallback — a lost `BuzzUpdate` would stick
+//      forever) and is always invalidated on reconnect, but still rides the
+//      jittered debounce so it stays cheap.
 //
 // Jitter window for the reconnect-driven invalidate. A uniform random delay in
 // [MIN, MAX] per client turns a synchronized fleet spike into refetches spread
-// over ~2 minutes. The lower bound stays well above zero so even clients that
-// land on the same delay bucket don't all fire at t≈0.
-const RECONNECT_INVALIDATE_DELAY_MIN_MS = 60_000;
-const RECONNECT_INVALIDATE_DELAY_MAX_MS = 180_000;
+// over a full minute. The lower bound stays well above zero so even clients that
+// land on the same delay bucket don't all fire at t≈0. We keep the band as
+// narrow as the spike-flattening allows so post-outage staleness (worst case ≈
+// MAX) stays low — 30-90s smears the fleet across a 60s window while capping
+// staleness at ~90s rather than ~3 minutes.
+const RECONNECT_INVALIDATE_DELAY_MIN_MS = 30_000;
+const RECONNECT_INVALIDATE_DELAY_MAX_MS = 90_000;
 
 // Minimum disconnect duration before a reconnect is allowed to invalidate.
 // Live balance/generation deltas are pushed continuously via signal and applied
@@ -153,7 +159,13 @@ const RECONNECT_INVALIDATE_MIN_DISCONNECT_MS = 10_000;
 
 export function SignalProvider({ children }: { children: React.ReactNode }) {
   const queryUtils = trpc.useUtils();
-  const prevStatusRef = useRef<SignalStatus | null>(null);
+  // Previous connection state, tracked INSIDE `onStateChange` (not at render
+  // time). A render-committed ref lags the event stream — two `connection:state`
+  // messages in one tick would both read the same stale value, corrupting the
+  // disconnect-gap measurement and potentially leaving `disconnectedAtRef`
+  // stale. Updating it as the last line of the handler keeps the gate logic
+  // independent of React's render-commit ordering.
+  const prevStateRef = useRef<SignalStatus | null>(null);
   const hasConnectedAtLeastOnceRef = useRef(false);
   // Timestamp of when we last LEFT the 'connected' state (transitioned to
   // 'reconnecting' or 'closed'). Used to compute how long the client was
@@ -173,7 +185,6 @@ export function SignalProvider({ children }: { children: React.ReactNode }) {
   const debounce = useDebouncer(reconnectInvalidateDelayRef.current);
 
   const [status, setStatus] = useState<SignalStatus | null>(null);
-  prevStatusRef.current = status ?? null;
   // Refcount of active `useSignalTopic` subscribers per topic. Only the
   // 0→1 transition calls `worker.topicRegister`; only the 1→0 transition
   // unsubscribes — so duplicate subscribers don't cause one another to lose
@@ -195,34 +206,51 @@ export function SignalProvider({ children }: { children: React.ReactNode }) {
 
   const worker = useSignalsWorker({
     onStateChange: ({ state }) => {
-      const prevStatus = prevStatusRef.current;
+      const prevState = prevStateRef.current;
       const hasConnectedAtLeastOnce = hasConnectedAtLeastOnceRef.current;
 
       // Record when we leave 'connected' so we can measure the disconnect gap
       // on the next reconnect. Only set on the first transition away from
       // 'connected' (don't overwrite on reconnecting → closed) so the gap
       // reflects the full outage, not just the last leg of it.
-      if (prevStatus === 'connected' && state !== 'connected') {
+      if (prevState === 'connected' && state !== 'connected') {
         disconnectedAtRef.current = Date.now();
       }
 
-      if (prevStatus !== state && state === 'connected' && hasConnectedAtLeastOnce) {
+      if (prevState !== state && state === 'connected' && hasConnectedAtLeastOnce) {
         const disconnectedAt = disconnectedAtRef.current;
         const disconnectedMs = disconnectedAt !== null ? Date.now() - disconnectedAt : Infinity;
-        // Only invalidate if the client was disconnected long enough to have
-        // plausibly missed live `setData` deltas. Short blips already have
-        // accurate state, so skip them to avoid the synchronized fleet storm.
-        if (disconnectedMs >= RECONNECT_INVALIDATE_MIN_DISCONNECT_MS) {
-          debounce(() => {
-            queryUtils.buzz.getBuzzAccount.invalidate();
+        const longDisconnect = disconnectedMs >= RECONNECT_INVALIDATE_MIN_DISCONNECT_MS;
+
+        // Buzz balance has NO polling fallback (staleTime: Infinity,
+        // refetchOnWindowFocus: false — see useBuzz.ts); its only live source is
+        // the `BuzzUpdate` signal applied via `setData`. A push lost during even
+        // a sub-10s blip would leave the balance silently wrong forever, so we
+        // ALWAYS invalidate buzz on a genuine reconnect regardless of disconnect
+        // duration. This stays cheap: the query is cached (PR #2434) and the
+        // invalidate still rides the widened+jittered debounce below, so the
+        // fleet spike stays flattened.
+        //
+        // `orchestrator.queryGeneratedImages` self-heals via a 60s poll (see
+        // useGenerationSignalUpdate.ts), so it keeps the 10s disconnect-duration
+        // gate — skip the heavier refetch for short blips. Fail-safe: an
+        // unknown/null disconnect duration (Infinity) still invalidates.
+        debounce(() => {
+          queryUtils.buzz.getBuzzAccount.invalidate();
+          if (longDisconnect) {
             queryUtils.orchestrator.queryGeneratedImages.invalidate();
-          });
-        }
+          }
+        });
+
         disconnectedAtRef.current = null;
       }
 
       if (state === 'connected') hasConnectedAtLeastOnceRef.current = true;
       setStatus(state);
+      // Track previous state in-handler as the LAST step so the gate above never
+      // depends on render-commit ordering. Set on every transition so it can't
+      // go stale across rapid flaps.
+      prevStateRef.current = state;
     },
   });
 

--- a/src/components/Signals/SignalsProvider.tsx
+++ b/src/components/Signals/SignalsProvider.tsx
@@ -119,12 +119,58 @@ export const useSignalTopic = (topic: TopicString | undefined, notify?: boolean)
   }, [topic, notify, registerTopic, releaseTopic]);
 };
 
-const SIGNAL_DATA_REFRESH_DEBOUNCE = 10;
+// On a signal-hub disruption, ALL connected clients drop and reconnect within
+// the same few seconds (the worker's `withAutomaticReconnect` backoff schedule
+// starts at 0). Previously each reconnect invalidated `buzz.getBuzzAccount` and
+// `orchestrator.queryGeneratedImages` after only an ~8-15s debounce, so a
+// fleet-wide reconnect produced tens of thousands of synchronized refetches in
+// a single ~10s window — saturating the API's single Node thread (CPU-pin /
+// 504 / Error-137 waves). To flatten that spike below the pin threshold we:
+//   1. Spread the post-reconnect refetch across MINUTES with a heavily jittered
+//      per-client delay, instead of a tight ~10s window.
+//   2. Skip the refetch entirely for short blips — live state already arrives
+//      via signal `setData` deltas (see useBuzz.ts `onBalanceUpdate`), so a
+//      sub-threshold disconnect cannot have lost meaningful state.
+//
+// Jitter window for the reconnect-driven invalidate. A uniform random delay in
+// [MIN, MAX] per client turns a synchronized fleet spike into refetches spread
+// over ~2 minutes. The lower bound stays well above zero so even clients that
+// land on the same delay bucket don't all fire at t≈0.
+const RECONNECT_INVALIDATE_DELAY_MIN_MS = 60_000;
+const RECONNECT_INVALIDATE_DELAY_MAX_MS = 180_000;
+
+// Minimum disconnect duration before a reconnect is allowed to invalidate.
+// Live balance/generation deltas are pushed continuously via signal and applied
+// with `setData` while connected, so a brief disconnect can't have dropped
+// meaningful state. The worker reconnects with backoff [0,2,10,18,...]s and the
+// hub keeps group memberships briefly; a disconnect shorter than this almost
+// certainly missed no pushes, so refetching would be pure wasted load. We pick
+// 10s as a conservative floor: long enough to skip the common instant/near-
+// instant reconnects that drive the storm, short enough that any disconnect
+// where pushes could realistically have been missed still triggers a refetch
+// (which is then spread by the jitter above). When in doubt we still invalidate.
+const RECONNECT_INVALIDATE_MIN_DISCONNECT_MS = 10_000;
+
 export function SignalProvider({ children }: { children: React.ReactNode }) {
   const queryUtils = trpc.useUtils();
   const prevStatusRef = useRef<SignalStatus | null>(null);
   const hasConnectedAtLeastOnceRef = useRef(false);
-  const debounce = useDebouncer((SIGNAL_DATA_REFRESH_DEBOUNCE + getRandomInt(-2, 5)) * 1000);
+  // Timestamp of when we last LEFT the 'connected' state (transitioned to
+  // 'reconnecting' or 'closed'). Used to compute how long the client was
+  // actually disconnected when it returns to 'connected'.
+  const disconnectedAtRef = useRef<number | null>(null);
+  // Pick a single random delay per client, stable across renders. Spreading the
+  // delay across clients (not re-rolling it per render) is what flattens the
+  // fleet-wide refetch spike; a stable value also keeps `useDebouncer`'s
+  // memoized callback/cleanup from churning on every render.
+  const reconnectInvalidateDelayRef = useRef<number>();
+  if (reconnectInvalidateDelayRef.current === undefined) {
+    reconnectInvalidateDelayRef.current = getRandomInt(
+      RECONNECT_INVALIDATE_DELAY_MIN_MS,
+      RECONNECT_INVALIDATE_DELAY_MAX_MS
+    );
+  }
+  const debounce = useDebouncer(reconnectInvalidateDelayRef.current);
 
   const [status, setStatus] = useState<SignalStatus | null>(null);
   prevStatusRef.current = status ?? null;
@@ -151,11 +197,28 @@ export function SignalProvider({ children }: { children: React.ReactNode }) {
     onStateChange: ({ state }) => {
       const prevStatus = prevStatusRef.current;
       const hasConnectedAtLeastOnce = hasConnectedAtLeastOnceRef.current;
+
+      // Record when we leave 'connected' so we can measure the disconnect gap
+      // on the next reconnect. Only set on the first transition away from
+      // 'connected' (don't overwrite on reconnecting → closed) so the gap
+      // reflects the full outage, not just the last leg of it.
+      if (prevStatus === 'connected' && state !== 'connected') {
+        disconnectedAtRef.current = Date.now();
+      }
+
       if (prevStatus !== state && state === 'connected' && hasConnectedAtLeastOnce) {
-        debounce(() => {
-          queryUtils.buzz.getBuzzAccount.invalidate();
-          queryUtils.orchestrator.queryGeneratedImages.invalidate();
-        });
+        const disconnectedAt = disconnectedAtRef.current;
+        const disconnectedMs = disconnectedAt !== null ? Date.now() - disconnectedAt : Infinity;
+        // Only invalidate if the client was disconnected long enough to have
+        // plausibly missed live `setData` deltas. Short blips already have
+        // accurate state, so skip them to avoid the synchronized fleet storm.
+        if (disconnectedMs >= RECONNECT_INVALIDATE_MIN_DISCONNECT_MS) {
+          debounce(() => {
+            queryUtils.buzz.getBuzzAccount.invalidate();
+            queryUtils.orchestrator.queryGeneratedImages.invalidate();
+          });
+        }
+        disconnectedAtRef.current = null;
       }
 
       if (state === 'connected') hasConnectedAtLeastOnceRef.current = true;


### PR DESCRIPTION
## Root cause

A **SignalR reconnect storm causes a synchronized fleet-wide refetch storm.**

`staleTime: Infinity` is the global React Query default (`src/utils/trpc.ts:83`), so queries only refetch on explicit `invalidate()`. On every signal reconnect, `SignalProvider`'s `onStateChange` handler called `invalidate()` on **`buzz.getBuzzAccount`** and **`orchestrator.queryGeneratedImages`**, debounced only ~8-15s.

When the signal hub/worker has a disruption, the worker reconnects with backoff `[0,2,10,18,30,45,60,90]` (`src/utils/signals/worker.ts`) — backoff[0] = 0 — plus a zombie-heartbeat forced reconnect. So **ALL connected clients drop and reconnect near-simultaneously** → all invalidate → tens of thousands of refetches land inside the same ~10s window → aggregate per-request CPU saturates the single Node thread → pods pin (504 / Error-137 waves).

**Prod fingerprint (verified):** `buzz.getBuzzAccount` (66 → 290/s) and `orchestrator.queryGeneratedImages` (4 → 10/s) surge in **lockstep** on these reconnect events.

## Fix (immediate, low-risk mitigation)

Changes are in the shared `onStateChange` handler, so they cover **all** reconnect-invalidated routes:

1. **Widen + heavily jitter the reconnect-invalidate debounce.** Replaced the ~8-15s debounce with a per-client uniform random delay in **`[30s, 90s]`** (`RECONNECT_INVALIDATE_DELAY_MIN_MS` / `RECONNECT_INVALIDATE_DELAY_MAX_MS`). The delay is rolled **once per client** and held stable across renders (via a ref) — so a synchronized fleet reconnect is smeared across a 60s window instead of stacking into one ~10s window, flattening the spike below the pin threshold while capping post-outage staleness at ~90s. (Keeping the value stable also stops `useDebouncer`'s memoized callback/cleanup from churning every render, which the previous inline-random call did.)

2. **Gate the heavy generations refetch on disconnect duration.** We record a timestamp on the first transition **away** from `connected` (→ `reconnecting`/`closed`), and on the return to `connected` compute the gap. **`orchestrator.queryGeneratedImages`** is only invalidated if the client was disconnected **>= 10s** (`RECONNECT_INVALIDATE_MIN_DISCONNECT_MS`); short blips skip it (it self-heals via a 60s poll in `useGenerationSignalUpdate.ts`). **`buzz.getBuzzAccount` is exempt from the gate and always invalidated on reconnect** — see audit fix H2 below. Both still ride the jittered debounce.

### Correctness of the disconnect-duration gate

- Live balance/generation state is pushed continuously over the signal and applied with `setData` while connected (see `useBuzz.ts` `onBalanceUpdate` for `buzz:update`). The reconnect `invalidate()` exists **only to catch deltas missed during an actual disconnect** — not to refresh otherwise-live state.
- A near-instant reconnect (backoff[0] = 0) or a sub-few-second blip almost never loses generation state, and generations re-sync on their 60s poll regardless — so gating that heavier refetch on a 10s floor is pure savings.
- **When in doubt we still invalidate** — `disconnectedAt === null` (e.g. initial connect path) is treated as `Infinity`, i.e. always-invalidate. The timestamp is set on the *first* transition out of `connected` so the gap reflects the full outage, not just the last reconnecting→connected leg.

## Audit fixes (applied in follow-up commit)

- **H2 (HIGH) — buzz exempt from the duration gate.** `buzz.getBuzzAccount` has **no polling fallback** (`staleTime: Infinity`, `refetchOnWindowFocus: false`); its only live source is the `BuzzUpdate` signal applied via `setData` (`useBuzz.ts`). A push lost during a sub-10s blip would leave the balance **silently wrong forever**. The reconnect handling is now split so buzz is **always** invalidated on a genuine reconnect (regardless of disconnect duration), while `orchestrator.queryGeneratedImages` keeps the 10s gate. Both still ride the widened+jittered debounce, so always-invalidating buzz stays cheap (cached by #2434 + jitter-spread).

- **H1 (HIGH) — fixed the lagging `prevState` ref.** Previous connection state was tracked via a ref assigned at React render-time, which lags the event stream — two `connection:state` messages in one tick both read the same stale value, corrupting the disconnect-gap measurement and potentially leaving `disconnectedAtRef` stale. It is now tracked **inside `onStateChange`** via `prevStateRef`, set as the **last line** of the handler, independent of render-commit ordering. `disconnectedAtRef` is consistently set-on-disconnect / cleared-on-qualifying-reconnect.

- **M1 (MEDIUM) — narrowed the delay band** from `[60s, 180s]` to `[30s, 90s]`, capping worst-case post-outage staleness at ~90s (was ~3 min) while still smearing the fleet across a 60s independent-jitter window.

## Follow-up (ideal fix — NOT in this PR)

Push an authoritative balance/state snapshot to the client on resubscribe and apply it via `setData` — **zero refetches** on reconnect. The widen + jitter + duration-gate here is the safe immediate mitigation; the snapshot-on-resubscribe is the real long-term fix and should be done server-side.

## Testing / verification notes

- `eslint` on the changed file: 0 errors (2 pre-existing `no-explicit-any` warnings on untouched lines 94/103).
- `prettier --write` applied.
- Local `typecheck` in this worktree is broken by a missing/stale generated Prisma client (5059 `implicitly any` errors across the whole repo, none referencing `SignalsProvider.tsx`) — this is the known worktree state; **CI typecheck is authoritative.**
- The reconnect path itself was **not runtime-tested** (cannot reproduce a hub disruption locally). The logic is verified by walking the state-transition flow (`worker.ts` `onreconnecting`/`onreconnected`/`onclose` → `connection:state` → `useSignalsWorker` → `onStateChange`) across: first connect (no invalidate), normal reconnect, closed→connected, rapid same-tick flaps, and zombie-heartbeat / no-op transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
