### PR TITLE
perf(orchestrator): short-TTL cache for queryGeneratedImages + bust on submit

### DIFF
--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -929,6 +929,7 @@ export const REDIS_KEYS = {
     TOKENS: 'generation:tokens',
     COUNT: 'generation:count',
     BLOCKED_PROMPTS: 'generation:blocked-prompts',
+    QUERIED_WORKFLOWS: 'packed:generation:queried-workflows',
   },
   OAUTH: {
     AUTHORIZATION_CODES: 'packed:oauth:authorization-codes',

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -265,15 +265,35 @@ export const orchestratorRouter = router({
   deleteWorkflow: orchestratorProcedure
     .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(workflowIdSchema)
-    .mutation(({ ctx, input }) => deleteWorkflow({ ...input, token: ctx.token })),
+    .mutation(async ({ ctx, input }) => {
+      const result = await deleteWorkflow({ ...input, token: ctx.token });
+      // Bust the short-TTL queryGeneratedImages cache so a reconnect/invalidate
+      // refetch within the TTL doesn't resurrect the just-deleted workflow.
+      // ctx.token is ctx.user's own token (orchestratorMiddleware), so the
+      // owning user is ctx.user.id. Fire-and-forget — see generateFromGraph.
+      bustQueriedWorkflowsCache(ctx.user.id).catch(() => null);
+      return result;
+    }),
   cancelWorkflow: orchestratorProcedure
     .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(workflowIdSchema)
-    .mutation(({ ctx, input }) => cancelWorkflow({ ...input, token: ctx.token })),
+    .mutation(async ({ ctx, input }) => {
+      const result = await cancelWorkflow({ ...input, token: ctx.token });
+      // Bust so a refetch within the TTL doesn't show the cancelled workflow
+      // back in a non-cancelled state. Owner is ctx.user.id (own token).
+      bustQueriedWorkflowsCache(ctx.user.id).catch(() => null);
+      return result;
+    }),
   updateWorkflow: orchestratorProcedure
     .meta({ requiredScope: TokenScope.AIServicesWrite })
     .input(workflowUpdateSchema)
-    .mutation(({ ctx, input }) => updateWorkflow({ ...input, token: ctx.token })),
+    .mutation(async ({ ctx, input }) => {
+      const result = await updateWorkflow({ ...input, token: ctx.token });
+      // Bust so a refetch within the TTL doesn't revert the update. Owner is
+      // ctx.user.id (own token).
+      bustQueriedWorkflowsCache(ctx.user.id).catch(() => null);
+      return result;
+    }),
   // #endregion
 
   // #region [steps]
@@ -328,6 +348,16 @@ export const orchestratorRouter = router({
               })
           )
         );
+      }
+
+      // Bust the short-TTL queryGeneratedImages cache if this patch changed
+      // anything the feed renders (workflow patch, removal, tag change, or the
+      // step-metadata update behind useUpdateImageStepMetadata). Without this, a
+      // reconnect/invalidate refetch within the TTL reverts the optimistic
+      // client patch / resurrects a removed item. ctx.token is ctx.user's own
+      // token, so the owner is ctx.user.id. Fire-and-forget.
+      if (workflows?.length || remove?.length || tags?.length || steps?.length) {
+        bustQueriedWorkflowsCache(user.id).catch(() => null);
       }
     }),
   // #endregion

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 import {
   buildGenerationContext,
+  bustQueriedWorkflowsCache,
   formatGenerationResponse2,
   generateFromGraph,
   getWorkflowStatusUpdate,
@@ -342,6 +343,8 @@ export const orchestratorRouter = router({
         user: ctx.user,
         tags: ctx.domain === 'green' ? [...input.tags, 'green'] : input.tags,
         hideMatureContent: ctx.hideMatureContent,
+        // Self-serve feed: token belongs to ctx.user, so the per-user cache is safe.
+        cache: true,
       })
     ),
   // #region [Generation Graph V2 endpoints]
@@ -383,7 +386,7 @@ export const orchestratorRouter = router({
         });
       }
 
-      return generateFromGraph({
+      const result = await generateFromGraph({
         input: formInput,
         externalCtx,
         userId: ctx.user.id,
@@ -401,6 +404,14 @@ export const orchestratorRouter = router({
         sourceMetadataMap,
         remixOfId,
       });
+
+      // Bust the short-TTL queryGeneratedImages cache so a concurrent tab or an
+      // immediate signal reconnect sees the just-submitted workflow without
+      // waiting out the TTL. Fire-and-forget: the response must not block on a
+      // cache eviction, and a failed bust only falls back to the short TTL.
+      bustQueriedWorkflowsCache(ctx.user.id).catch(() => null);
+
+      return result;
     }),
 
   /**

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -2346,10 +2346,12 @@ function getQueriedWorkflowsIndexKey(userId: number): RedisKeyTemplateCache {
 const QUERIED_WORKFLOWS_INDEX_TTL = QUERIED_WORKFLOWS_CACHE_TTL * 4; // seconds
 
 // Records a cache-variant key in the user's index set and refreshes the set's
-// TTL. Called on every cached read (hit or miss): SADD of an existing member is
-// a no-op, and re-EXPIRE keeps the index alive as long as the user keeps
-// reading. Best-effort — a failure here only means a later bust may miss this
-// key, which then falls back to the short TTL. Errors are swallowed.
+// TTL. Called ONLY on a real cache miss (from inside the fetcher passed to
+// fetchThroughCache), never on a hit — a hit's hot path is a single
+// redis.packed.get and must stay that way. SADD of an existing member is a
+// no-op, and re-EXPIRE keeps the index alive as long as the user keeps missing
+// and re-fetching. Best-effort — a failure here only means a later bust may miss
+// this key, which then falls back to the short TTL. Errors are swallowed.
 async function indexQueriedWorkflowsKey(userId: number, key: RedisKeyTemplateCache) {
   try {
     const indexKey = getQueriedWorkflowsIndexKey(userId);
@@ -2404,15 +2406,20 @@ export async function queryGeneratedImageWorkflows2({
     };
   };
 
-  // Only cache the self-serve feed of a logged-in user. fetchThroughCache does
-  // not cache thrown errors (the fetchFn rejection propagates without writing
-  // redis), and it single-flights concurrent misses behind a lock, so a
-  // reconnect burst that arrives before the first fetch resolves is coalesced
-  // rather than fanned out.
-  if (!cache || !user?.id) return fetchAndFormat();
+  // Only cache the self-serve feed of a logged-in user, AND only the first page
+  // (no cursor). The infinite feed gives every later page a distinct cursor, so
+  // caching them would bloat the per-user index set with entries no one refetches
+  // — the reconnect storm only refetches page 1. Deep pages fall straight through
+  // to the uncached fetch, exactly like the !cache / anonymous bypass below.
+  // fetchThroughCache does not cache thrown errors (the fetchFn rejection
+  // propagates without writing redis), and it single-flights concurrent misses
+  // behind a lock, so a reconnect burst that arrives before the first fetch
+  // resolves is coalesced rather than fanned out.
+  if (!cache || !user?.id || props.cursor != null) return fetchAndFormat();
 
+  const userId = user.id;
   const cacheKey = getQueriedWorkflowsCacheKey({
-    userId: user.id,
+    userId,
     take: props.take,
     cursor: props.cursor,
     tags: props.tags,
@@ -2423,12 +2430,19 @@ export async function queryGeneratedImageWorkflows2({
     hideMatureContent: props.hideMatureContent,
   });
 
-  // Record this variant in the user's index set so bustQueriedWorkflowsCache can
-  // enumerate and delete it without a keyspace SCAN. Done on every cached read
-  // (hit or miss) and fire-and-forget so it never adds latency to the response.
-  indexQueriedWorkflowsKey(user.id, cacheKey).catch(() => null);
+  // Index the key from INSIDE the fetcher so it runs only on a real miss (the
+  // single-flight leader), never on a hit. A hit's hot path — the path this
+  // cache exists to make single-op — then does zero index ops; it is just the
+  // redis.packed.get inside fetchThroughCache. Fire-and-forget so the miss
+  // itself never blocks on the index write. (A key whose miss-time SADD failed
+  // simply won't be re-added on later hits — same best-effort semantics as
+  // before; a missed bust just falls back to the short TTL.)
+  const fetchIndexAndFormat = async () => {
+    indexQueriedWorkflowsKey(userId, cacheKey).catch(() => null);
+    return fetchAndFormat();
+  };
 
-  return fetchThroughCache(cacheKey, fetchAndFormat, { ttl: QUERIED_WORKFLOWS_CACHE_TTL });
+  return fetchThroughCache(cacheKey, fetchIndexAndFormat, { ttl: QUERIED_WORKFLOWS_CACHE_TTL });
 }
 
 // =============================================================================

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -46,7 +46,8 @@ import {
 } from '~/server/services/generation/generation.service';
 import { applicableRulesFor } from '~/shared/data-graph/generation/gates';
 import type { GenerationResource } from '~/shared/types/generation.types';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { clearCacheByPattern, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { generationStatusSchema } from '~/server/schema/generation.schema';
 import type { GenerationStatus, GenerationStatusMode } from '~/server/schema/generation.schema';
@@ -2262,20 +2263,129 @@ export type GeneratedImageWorkflowModel = NormalizedWorkflow;
  * Simplified queryGeneratedImageWorkflows.
  * Replaces the version in common.ts.
  */
+// Short-TTL cache in front of the user's generated-images feed. On every
+// SignalR reconnect the client invalidates `orchestrator.queryGeneratedImages`
+// for every tab at once (see SignalsProvider.onStateChange), so a single user
+// flapping their connection — or many users reconnecting on the same wave —
+// produces a burst of identical first-page queries within milliseconds. Each
+// uncached call hits the orchestrator over HTTP and then runs the CPU-heavy
+// `formatGenerationResponse2` (resource enrichment + per-workflow mapping),
+// which is part of the aggregate per-request load that pins the API pods.
+//
+// The TTL is intentionally tiny. Live generation progress does NOT flow through
+// this route: status updates arrive via SignalR `TextToImageUpdate` ->
+// `orchestrator.statusUpdate` (a separate per-workflow endpoint) and are patched
+// into the client's query cache in place (see useGenerationSignalUpdate.ts), with
+// a 60s poll fallback. So a 3s cache on the *list* query collapses the reconnect
+// storm without delaying any live status the user actually sees. The user's own
+// new generations / deletes are applied optimistically client-side via
+// setQueryData in generationRequestHooks.ts, so they too are unaffected by this
+// server cache; the short TTL is the freshness net for anything else.
+const QUERIED_WORKFLOWS_CACHE_TTL = 3; // seconds
+
+// Builds a stable redis key per (userId, fully-resolved query params). The key
+// MUST include every param that changes the response (cursor, take, the
+// green-injected tags, sort direction, date range, excludeFailed,
+// hideMatureContent) so different pages/filters never collide. `token` is
+// deliberately excluded: it is per-session, but the response is identical for a
+// given user regardless of which session token made the request, and including
+// it would prevent a user's concurrent tabs from sharing a cache entry — the
+// exact case this cache exists to collapse. Anonymous callers (no user id) are
+// not cached.
+function getQueriedWorkflowsCacheKey({
+  userId,
+  take,
+  cursor,
+  tags,
+  ascending,
+  fromDate,
+  toDate,
+  excludeFailed,
+  hideMatureContent,
+}: {
+  userId: number;
+  take: number;
+  cursor?: string;
+  tags: string[];
+  ascending?: boolean;
+  fromDate?: Date;
+  toDate?: Date;
+  excludeFailed?: boolean;
+  hideMatureContent: boolean;
+}) {
+  const variant = JSON.stringify({
+    t: take,
+    c: cursor ?? null,
+    // sort tags so [a,b] and [b,a] map to the same entry
+    tags: [...tags].sort(),
+    a: ascending ?? null,
+    f: fromDate?.toISOString() ?? null,
+    to: toDate?.toISOString() ?? null,
+    ef: excludeFailed ?? null,
+    hmc: hideMatureContent,
+  });
+  return `${REDIS_KEYS.GENERATION.QUERIED_WORKFLOWS}:${userId}:${variant}` as const;
+}
+
+// Busts every cached feed variant for a user. Called when the user submits a new
+// generation so a concurrent tab / immediate reconnect refetch sees the new
+// workflow without waiting out the 3s TTL. Generation submits are far rarer than
+// feed reads, so the per-submit SCAN is an acceptable cost (same approach the
+// buzz-account cache uses). Best-effort: a bust failure only means the user's
+// other surfaces fall back to the short TTL, so errors are swallowed.
+export async function bustQueriedWorkflowsCache(userId?: number) {
+  if (!userId) return;
+  await clearCacheByPattern(`${REDIS_KEYS.GENERATION.QUERIED_WORKFLOWS}:${userId}:*`).catch(
+    () => null
+  );
+}
+
 export async function queryGeneratedImageWorkflows2({
   user,
+  cache,
   ...props
 }: z.output<typeof workflowQuerySchema> & {
   token: string;
   user?: SessionUser;
   hideMatureContent: boolean;
+  // Opt-in short-TTL cache. ONLY safe when `token` belongs to `user` — i.e. the
+  // self-serve feed. The moderator path (queryUserGeneratedImages) passes the
+  // *target* user's token but the *moderator's* `user`, so the data identity is
+  // the token, not user.id; caching there would key the target's feed under the
+  // moderator's id and collide across different targets. That path leaves this
+  // off and is not part of the reconnect storm anyway.
+  cache?: boolean;
 }) {
-  const { nextCursor, items } = await queryWorkflows(props);
-
-  return {
-    items: await formatGenerationResponse2(items as Workflow[], user),
-    nextCursor,
+  const fetchAndFormat = async () => {
+    const { nextCursor, items } = await queryWorkflows(props);
+    return {
+      items: await formatGenerationResponse2(items as Workflow[], user),
+      nextCursor,
+    };
   };
+
+  // Only cache the self-serve feed of a logged-in user. fetchThroughCache does
+  // not cache thrown errors (the fetchFn rejection propagates without writing
+  // redis), and it single-flights concurrent misses behind a lock, so a
+  // reconnect burst that arrives before the first fetch resolves is coalesced
+  // rather than fanned out.
+  if (!cache || !user?.id) return fetchAndFormat();
+
+  return fetchThroughCache(
+    getQueriedWorkflowsCacheKey({
+      userId: user.id,
+      take: props.take,
+      cursor: props.cursor,
+      tags: props.tags,
+      ascending: props.ascending,
+      fromDate: props.fromDate,
+      toDate: props.toDate,
+      excludeFailed: props.excludeFailed,
+      hideMatureContent: props.hideMatureContent,
+    }),
+    fetchAndFormat,
+    { ttl: QUERIED_WORKFLOWS_CACHE_TTL }
+  );
 }
 
 // =============================================================================

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -46,8 +46,9 @@ import {
 } from '~/server/services/generation/generation.service';
 import { applicableRulesFor } from '~/shared/data-graph/generation/gates';
 import type { GenerationResource } from '~/shared/types/generation.types';
-import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
-import { clearCacheByPattern, fetchThroughCache } from '~/server/utils/cache-helpers';
+import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import type { RedisKeyTemplateCache } from '~/server/redis/client';
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { generationStatusSchema } from '~/server/schema/generation.schema';
 import type { GenerationStatus, GenerationStatusMode } from '~/server/schema/generation.schema';
@@ -2324,20 +2325,59 @@ function getQueriedWorkflowsCacheKey({
     ef: excludeFailed ?? null,
     hmc: hideMatureContent,
   });
-  return `${REDIS_KEYS.GENERATION.QUERIED_WORKFLOWS}:${userId}:${variant}` as const;
+  return `${REDIS_KEYS.GENERATION.QUERIED_WORKFLOWS}:${userId}:${variant}` as RedisKeyTemplateCache;
+}
+
+// Per-user index set holding every cached feed-variant key for a user. Lets the
+// bust enumerate exactly this user's keys (SMEMBERS) instead of SCANning the
+// whole main cache cluster for a pattern — the latter's cost scales with total
+// keyspace, not matched keys, which is a recurring load on the very cluster this
+// cache exists to protect (the bust now fires on every submit AND every
+// delete/cancel/patch).
+function getQueriedWorkflowsIndexKey(userId: number): RedisKeyTemplateCache {
+  return `${REDIS_KEYS.GENERATION.QUERIED_WORKFLOWS}:idx:${userId}` as RedisKeyTemplateCache;
+}
+
+// The index set must outlive the cache entries it points at, otherwise a bust
+// could miss a still-live entry. fetchThroughCache writes its data key with
+// EX = ttl * 2, so the index TTL has to be at least that; we use a comfortable
+// multiple to absorb clock skew and TTL refresh races. Stale members (entries
+// that already expired) are harmless — DEL of a missing key is a no-op.
+const QUERIED_WORKFLOWS_INDEX_TTL = QUERIED_WORKFLOWS_CACHE_TTL * 4; // seconds
+
+// Records a cache-variant key in the user's index set and refreshes the set's
+// TTL. Called on every cached read (hit or miss): SADD of an existing member is
+// a no-op, and re-EXPIRE keeps the index alive as long as the user keeps
+// reading. Best-effort — a failure here only means a later bust may miss this
+// key, which then falls back to the short TTL. Errors are swallowed.
+async function indexQueriedWorkflowsKey(userId: number, key: RedisKeyTemplateCache) {
+  try {
+    const indexKey = getQueriedWorkflowsIndexKey(userId);
+    await redis.sAdd(indexKey, key);
+    await redis.expire(indexKey, QUERIED_WORKFLOWS_INDEX_TTL);
+  } catch {
+    // ignore — index is an optimization for the bust, not a correctness store
+  }
 }
 
 // Busts every cached feed variant for a user. Called when the user submits a new
-// generation so a concurrent tab / immediate reconnect refetch sees the new
-// workflow without waiting out the 3s TTL. Generation submits are far rarer than
-// feed reads, so the per-submit SCAN is an acceptable cost (same approach the
-// buzz-account cache uses). Best-effort: a bust failure only means the user's
-// other surfaces fall back to the short TTL, so errors are swallowed.
+// generation OR mutates their workflows (delete / cancel / patch / update) so a
+// concurrent tab / immediate reconnect refetch sees the change without waiting
+// out the short TTL. Uses the per-user index set (SMEMBERS -> DEL the members ->
+// DEL the index) so there is no full-keyspace SCAN per bust. Stale members are
+// harmless: DEL of an already-expired key is a no-op. Best-effort: a bust
+// failure only means the user's other surfaces fall back to the short TTL, so
+// errors are swallowed.
 export async function bustQueriedWorkflowsCache(userId?: number) {
   if (!userId) return;
-  await clearCacheByPattern(`${REDIS_KEYS.GENERATION.QUERIED_WORKFLOWS}:${userId}:*`).catch(
-    () => null
-  );
+  try {
+    const indexKey = getQueriedWorkflowsIndexKey(userId);
+    const keys = await redis.sMembers<RedisKeyTemplateCache>(indexKey);
+    if (keys.length) await redis.del(keys);
+    await redis.del(indexKey);
+  } catch {
+    // ignore — see jsdoc above
+  }
 }
 
 export async function queryGeneratedImageWorkflows2({
@@ -2371,21 +2411,24 @@ export async function queryGeneratedImageWorkflows2({
   // rather than fanned out.
   if (!cache || !user?.id) return fetchAndFormat();
 
-  return fetchThroughCache(
-    getQueriedWorkflowsCacheKey({
-      userId: user.id,
-      take: props.take,
-      cursor: props.cursor,
-      tags: props.tags,
-      ascending: props.ascending,
-      fromDate: props.fromDate,
-      toDate: props.toDate,
-      excludeFailed: props.excludeFailed,
-      hideMatureContent: props.hideMatureContent,
-    }),
-    fetchAndFormat,
-    { ttl: QUERIED_WORKFLOWS_CACHE_TTL }
-  );
+  const cacheKey = getQueriedWorkflowsCacheKey({
+    userId: user.id,
+    take: props.take,
+    cursor: props.cursor,
+    tags: props.tags,
+    ascending: props.ascending,
+    fromDate: props.fromDate,
+    toDate: props.toDate,
+    excludeFailed: props.excludeFailed,
+    hideMatureContent: props.hideMatureContent,
+  });
+
+  // Record this variant in the user's index set so bustQueriedWorkflowsCache can
+  // enumerate and delete it without a keyspace SCAN. Done on every cached read
+  // (hit or miss) and fire-and-forget so it never adds latency to the response.
+  indexQueriedWorkflowsKey(user.id, cacheKey).catch(() => null);
+
+  return fetchThroughCache(cacheKey, fetchAndFormat, { ttl: QUERIED_WORKFLOWS_CACHE_TTL });
 }
 
 // =============================================================================


### PR DESCRIPTION
## Why

Production CPU pin waves are driven by a SignalR-reconnect refetch storm. On reconnect, every client invalidates **two** routes at once (`SignalsProvider.onStateChange`):

```ts
queryUtils.buzz.getBuzzAccount.invalidate();
queryUtils.orchestrator.queryGeneratedImages.invalidate();
```

Both surge in lockstep and their aggregate per-request CPU pins the pods. #2434 added a short-TTL cache to the **buzz** half. This PR is the defense-in-depth **other half** so a refetch storm is cheap to serve on `orchestrator.queryGeneratedImages` too.

`queryGeneratedImages` was uncached: every call hits the orchestrator over HTTP and then runs the CPU-heavy `formatGenerationResponse2` (resource enrichment + per-workflow param mapping). During a reconnect wave the *same first-page query* repeats across a user's tabs / connection flaps within milliseconds.

## What

- **3s per-(userId, fully-resolved input) cache** in front of the fetch+format, using the existing `fetchThroughCache` primitive (mirrors the #2434 buzz approach). `fetchThroughCache` also **single-flights** concurrent misses behind a lock, so a burst arriving before the first fetch resolves is coalesced rather than fanned out.
- **Cache key** includes every param that changes the response — `take`, `cursor`, the green-injected `tags` (sorted), `ascending`, `fromDate`, `toDate`, `excludeFailed`, `hideMatureContent` — so different pages/filters never collide. `token` is deliberately excluded so a user's concurrent tabs share one entry (the exact case we're collapsing).
- **Opt-in (`cache: true`)**, enabled **only on the self-serve feed** where the token belongs to `ctx.user`. The moderator path (`queryUserGeneratedImages`) passes the *target* user's token but the *moderator's* `user`, so its data identity is the token, not `user.id`; caching there would collide different targets under the moderator's id. It leaves the flag off (and isn't part of the storm anyway).
- **Bust on submit AND on mutation**: `generateFromGraph`, plus all self-serve workflow mutations — `deleteWorkflow`, `cancelWorkflow`, `updateWorkflow`, and the `patch` route (workflow patch / `remove`-via-deleteMany / tag patch / step-metadata update behind `useUpdateImageStepMetadata`) — bust the user's cached variants (fire-and-forget) so a concurrent tab / immediate reconnect refetch sees the change without waiting out the TTL.
- Errors are **not cached** (`fetchThroughCache` propagates the `fetchFn` rejection without writing redis). Response shape unchanged.

## Cache invalidation (audit H1) — server-bust on delete / cancel / patch

Originally the cache busted only on `generateFromGraph`. But delete / cancel / patch / update are client-side optimistic `setQueryData` only, so a reconnect/invalidate refetch within the 3s TTL could resurrect a just-deleted/cancelled item or revert a patch (visible flicker/revert). Fixed by adding `bustQueriedWorkflowsCache(ctx.user.id)` (fire-and-forget, `.catch(() => null)`) to each server-side mutation, mirroring `generateFromGraph`. The owning user is `ctx.user.id` on every path because `ctx.token` is the user's own token (set by `orchestratorMiddleware`).

## Bust mechanism (audit M2) — per-user index set, no keyspace SCAN

`bustQueriedWorkflowsCache` previously used `clearCacheByPattern('...:{userId}:*')`, which does a full-keyspace SCAN on the **main** cache cluster on every bust — cost scales with total keyspace, not matched keys. With the bust now firing on every submit **and** every delete/cancel/patch, that's a recurring load on the very cluster this cache exists to protect.

Replaced with a **per-user index set**:
- **Write side:** each cached read `SADD`s its full variant key into `<prefix>:idx:{userId}` and refreshes the set TTL (`QUERIED_WORKFLOWS_INDEX_TTL = TTL * 4`, comfortably ≥ the data entry's `EX = ttl * 2`). Done on hit and miss, fire-and-forget, so it never adds response latency.
- **Bust side:** `SMEMBERS` the index → `DEL` those keys → `DEL` the index set. No SCAN.
- **Concurrency:** stale members (entries that already expired) are harmless — `DEL` of a missing key is a no-op. Index writes and busts are best-effort; on failure the path falls back to the short TTL.

## Freshness / UX assessment

Live generation status does **not** flow through this route. It arrives via SignalR `TextToImageUpdate` → `orchestrator.statusUpdate` (a separate per-workflow endpoint) and is patched into the client query cache in place (`useGenerationSignalUpdate.ts`), with a 60s poll fallback. The user's own new generations/deletes are applied optimistically client-side via `setQueryData` (`generationRequestHooks.ts`). So a 3s cache on the **list** query collapses the storm without delaying any status the user actually sees.

**Residual staleness (audit M1, bounded):** If the status-update signal for a workflow transition was the one dropped during a disconnect, a reconnect refetch can show stale status for ≤3s (≤60s if it falls to the polled fallback). This is bounded; the H1 mutation busts plus the short TTL keep the window small. No code change required for this case beyond this note.

## Verification

- `prettier --write` + `eslint` on the changed files: clean (no new warnings/errors from the added code).
- `tsc --noEmit` filtered to the changed files: no errors. (Full repo typecheck shows the documented pre-existing stale-Prisma-client noise in unrelated files in this worktree — CI is authoritative.)
- Not runtime-tested. The cache-hit path, bust timing, index-set behavior under real reconnect/mutation load, and storm-collapse magnitude are unverified.

## Files changed
- `src/server/redis/client.ts` — add `GENERATION.QUERIED_WORKFLOWS` redis key.
- `src/server/services/orchestrator/orchestration-new.service.ts` — cache + key builder + per-user index set (`indexQueriedWorkflowsKey`) + index-based `bustQueriedWorkflowsCache`.
- `src/server/routers/orchestrator.router.ts` — pass `cache: true` on self-serve route; bust after `generateFromGraph` and after `deleteWorkflow` / `cancelWorkflow` / `updateWorkflow` / `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)