### PR TITLE
fix(notifications): break pool-deadlock in cancel path + merge users array on upsert

### DIFF
--- a/src/server/db/db-helpers.ts
+++ b/src/server/db/db-helpers.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 import type { QueryResult, QueryResultRow } from 'pg';
-import { Pool } from 'pg';
+import { Client, Pool } from 'pg';
 import { performance } from 'node:perf_hooks';
 import client from 'prom-client';
 import { env } from '~/env/server';
@@ -230,10 +230,24 @@ export function getClient(
 
     const cancel = async () => {
       if (done) return;
-      const cancelConnection = await pool.connect();
-      await cancelConnection.query('SELECT pg_cancel_backend($1)', [pid]);
-      cancelConnection.release();
-      done = true;
+      // Issue the cancel via a fresh one-shot client outside the pool so that
+      // cancel() never blocks on pool.connect() when the pool is full. A saturated
+      // pool is exactly when cancellation is most urgent, so acquiring from the
+      // same pool would deadlock: every slot is occupied by a query that needs
+      // cancelling, and cancellation needs a slot to run.
+      // Do NOT set done=true here — the query's own .finally() owns that flag and
+      // the connection release. If cancelClient.connect() throws, the original query
+      // keeps running and .finally() will still release the connection correctly.
+      const cancelClient = new Client({
+        connectionString: pool.options.connectionString as string,
+        connectionTimeoutMillis: pool.options.connectionTimeoutMillis ?? 5000,
+      });
+      try {
+        await cancelClient.connect();
+        await cancelClient.query('SELECT pg_cancel_backend($1)', [pid]);
+      } finally {
+        cancelClient.end().catch(() => null);
+      }
     };
     const result = async () => {
       const { rows } = await query;

--- a/src/server/jobs/send-notifications.ts
+++ b/src/server/jobs/send-notifications.ts
@@ -111,7 +111,7 @@ export const sendNotificationsJob = createJob('send-notifications', '*/1 * * * *
                 //language=text
                 const updateQuery = Prisma.sql`
                 UPDATE "PendingNotification" pn
-                SET "users" = u.users::int[],
+                SET "users" = ARRAY(SELECT DISTINCT unnest(pn."users" || u.users::int[])),
                     "lastTriggered" = NOW()
                 FROM (VALUES
                   ${Prisma.join(
@@ -146,7 +146,7 @@ export const sendNotificationsJob = createJob('send-notifications', '*/1 * * * *
                         }, ${JSON.stringify(d.details)}::jsonb)`
                     )
                   )}
-                  ON CONFLICT (key) DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()
+                  ON CONFLICT (key) DO UPDATE SET "users" = ARRAY(SELECT DISTINCT unnest("PendingNotification"."users" || excluded."users")), "lastTriggered" = NOW()
                 `;
 
                   const insertResp = await notifDbWrite.cancellableQuery(insertQuery);

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -55,7 +55,7 @@ export const createNotification = async (data: CreateNotificationPendingRow) => 
     // where another writer inserts the same key between our UPDATE and INSERT.
     const updateResp = await notifDbWrite.cancellableQuery<{ id: number }>(Prisma.sql`
       UPDATE "PendingNotification"
-      SET "users" = ${'{' + targets.join(',') + '}'}::int[],
+      SET "users" = ARRAY(SELECT DISTINCT unnest("users" || ${'{' + targets.join(',') + '}'}::int[])),
           "lastTriggered" = NOW()
       WHERE "key" = ${data.key}
       RETURNING id
@@ -74,7 +74,7 @@ export const createNotification = async (data: CreateNotificationPendingRow) => 
           ${data.debounceSeconds}
         )
         ON CONFLICT (key)
-        DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()
+        DO UPDATE SET "users" = ARRAY(SELECT DISTINCT unnest("PendingNotification"."users" || excluded."users")), "lastTriggered" = NOW()
       `);
       await insertResp.result();
     }


### PR DESCRIPTION
## Problem

Poll-based notifications (comments, reactions, model milestones, etc.) stop firing intermittently and only recover after a pod restart. Buzz notifications (push-based via `createNotification()`) are unaffected.

### Root cause 1 — `cancellableQuery` pool deadlock

`cancel()` called `pool.connect()` to acquire a slot for `pg_cancel_backend`. Under pool saturation this deadlocked: every slot was held by a query waiting to be cancelled, and cancellation needed a free slot to run. The `send-notifications` job's in-process lock-refresh interval kept spinning indefinitely, making the job appear permanently running and blocking every subsequent cron tick with `'Job already running'`.

### Root cause 2 — `PendingNotification.users` array replaced instead of merged

All four upsert paths (UPDATE + ON CONFLICT in both `send-notifications.ts` and `notification.service.ts`) were doing `SET "users" = <new_array>`, wholesale replacing the existing array. A concurrent write for the same notification key silently dropped users from the earlier writer.

## Fix

**`db-helpers.ts`** — `cancel()` now opens a one-shot `pg.Client` outside the pool (bounded by `connectionTimeoutMillis`) to fire `pg_cancel_backend`. It never contends with the pool it's cancelling. The `done` flag is no longer set prematurely in `cancel()` — the query's own `.finally()` owns connection release, so a failed cancel attempt doesn't leak the pool slot.

**`send-notifications.ts` + `notification.service.ts`** — All four upsert paths now use `ARRAY(SELECT DISTINCT unnest(existing || new))` to merge and deduplicate the users array rather than replacing it.

## Testing

- Typecheck passes clean
- Happy path: `cancel()` is never called under normal load — zero behaviour change
- Timeout path: one short-lived out-of-pool connection per timed-out query, closed immediately in `finally`