### PR TITLE
feat(images): dedicated post.getImages endpoint off the heavy feed surface

### DIFF
--- a/docs/plans/per-domain-getimages.md
+++ b/docs/plans/per-domain-getimages.md
@@ -1,0 +1,168 @@
+# Per-domain `getImages` endpoints — stop client-controlled `useIndex` from exposing the un-indexed DB feed
+
+## Problem
+
+`image.getInfinite` and `image.getImagesAsPostsInfinite` are both `heavyProcedure` (per-pod
+bulkhead + the heavy edge limits). Their input carries a **client-controlled** `useIndex` flag
+(`src/server/schema/image.schema.ts:346`). The server picks the data path off that flag
+(`src/server/controllers/image.controller.ts:308`):
+
+- `useIndex` truthy (or BitDex active) → `getAllImagesIndex` (Meilisearch — the scalable path)
+- falsy / unset → `getAllImages` (raw Postgres feed path — the expensive one)
+
+Two consequences:
+
+1. **Abuse surface.** It is just an API request. Anyone can call `image.getInfinite` with
+   `useIndex: false` and arbitrary filters to force the un-indexed Postgres path — exactly the
+   load the bulkhead and edge limits exist to shed. There is no Meilisearch backing to absorb it.
+2. **Accidental self-DoS for legit users.** Post viewing legitimately needs the DB path (postId
+   lookups aren't well served by the index), so it rides the same heavily-limited feed procedure.
+   Opening ~10 post pages in a minute — or a few refreshes / client retries while something is
+   slow — trips the limit by accident.
+
+**Root cause: the index-vs-DB decision is a client input, not a server policy.**
+
+## Goal / principle
+
+> No public endpoint exposes the un-indexed `getAllImages` path with client-controlled filters.
+> The generic feed is **always** index-backed. The handful of queries that genuinely need the DB
+> path (narrow, cheap, or owner-scoped) each get a **dedicated, server-pinned endpoint** that sets
+> its own filters and is not on the heavy feed surface.
+
+`useIndex` stops being part of any public input contract. The server decides per endpoint.
+
+## Why the index can't just serve everything
+
+`getAllImagesIndex` cannot serve these filters today (the `skipBitdex` list,
+`image.controller.ts:291`):
+
+- `postId` / `postIds` — specific-post lookups (covered index in PG, ~2ms; unique cache keys hurt index cache hit rate)
+- `collectionId` — needs relational joins through `CollectionItem`
+- `reactions` — per-user reaction data isn't in the index (needs `ImageReaction` subquery)
+- `prioritizedUserIds` — index has no user-prioritization yet (TODO in `getAllImagesIndex`)
+
+Every caller that depends on one of these must move off the generic feed procedure **before** we
+can lock the generic procedure to index-only.
+
+## Design
+
+### New per-domain endpoints (server-pinned to the DB path)
+
+Each wraps the existing `getAllImages` / `getImagesAsPostsInfinite` service fn under the covers,
+pins its own filter set server-side, and lives on a normal `publicProcedure` (cheap queries — no
+heavy bulkhead). Per Justin: don't worry about rate-limit tiers for these.
+
+| Endpoint                                                               | Pinned filter                           | Replaces (callsite)                                                   |
+| ---------------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------------------- |
+| `post.getImages`                                                       | `postId` (from input)                   | `PostDetail.tsx:120`, image detail when `postId`                      |
+| `collection.getImages` (or keep on collection router)                  | `collectionId`                          | `collections/[collectionId]/review.tsx` (via `ImagesAsPostsInfinite`) |
+| reacted-images endpoint (`user.getReactedImages` / `image.getReacted`) | `reactions` + `userId=self`             | `UserMediaInfinite.tsx:169` "My Reactions" tab                        |
+| model-showcase endpoint (or extend `getImagesForModelVersion`)         | `modelVersionId` + `prioritizedUserIds` | `ModelCarousel.tsx:58`                                                |
+
+Naming TBD — see open questions. `@justin:` \*
+
+### Lock the generic feed to index-only
+
+Once the table above is migrated:
+
+- Drop `useIndex` from `getInfiniteImagesSchema` (public contract).
+- In `getInfiniteImagesHandler` / `getImagesAsPostsInfiniteHandler`, force the index path
+  (`useIndex = true` server-side; BitDex logic unchanged).
+- Reject (or strip) the DB-only filters — `postId`, `collectionId`, `reactions`,
+  `prioritizedUserIds` — on the generic feed input so they can't be smuggled in to force a fallback.
+- Keep the `imagesFeedWithoutIndexCounter` metric to confirm the DB path goes to ~0 on the generic
+  endpoint post-rollout.
+
+## Callsite audit
+
+`useQueryImages` / `image.getInfinite` / `image.getImagesAsPostsInfinite` consumers:
+
+### Index-safe — leave on generic feed (already `useIndex` or index-servable filters)
+
+- `pages/images/index.tsx:28` — browse feed (`useIndex`)
+- `pages/videos/index.tsx:31` — browse feed (`useIndex`)
+- `pages/tools/[slug].tsx:91` — tool feed (`useIndex`)
+- `components/Profile/Sections/MyImagesSection.tsx:46` — `useIndex: true`
+- `components/ResourceReview/ResourceReviewCarousel.tsx:40` — `useIndex: true`
+- `components/Image/DetailV2/ImageRemixesDetails.tsx:18` — `useIndex: true`
+- `components/Image/Infinite/UserMediaInfinite.tsx:169` — `useIndex={!viewingReactions}` (the
+  non-reactions branch stays here; the reactions branch moves — see below)
+- generic `ImagesInfinite` browse (store filters: sort/period/types/tags/baseModels) — index-servable
+
+### DB-needed — must migrate to a dedicated endpoint
+
+- `components/Post/Detail/PostDetail.tsx:120` — `{ postId }` → **`post.getImages`**
+- `pages/collections/[collectionId]/review.tsx` (via `ImagesAsPostsInfinite`) — `collectionId` → **`collection.getImages`**
+- `components/Image/Infinite/UserMediaInfinite.tsx` reactions tab — `reactions` + self `userId` → **reacted-images endpoint**
+- `components/Model/ModelCarousel/ModelCarousel.tsx:58` — `modelVersionId` + `prioritizedUserIds` → **model-showcase endpoint** (or implement `prioritizedUserIds` in `getAllImagesIndex` and keep it on the index)
+
+### Special case — `components/Image/Detail/ImageDetailProvider.tsx:85`
+
+The image detail viewer **replays the source feed's filters** to drive prev/next navigation
+(`{ ...filters, userId, postId, browsingLevel }`). Its query shape is whatever feed the user came
+from — could be index-servable (modelId/username/tags) **or** DB-only (postId/collectionId/reactions).
+
+After the split it must **route to the matching endpoint by filter shape**: postId → `post.getImages`,
+collectionId → `collection.getImages`, reactions → reacted endpoint, else → generic index feed. This
+is the most involved migration; the carousel must paginate consistently with the originating feed.
+`@justin:` \* worth confirming we still want full prev/next continuity in every entry context, or if
+some (e.g. opening a single post image) can fall back to post-scoped pagination only.
+
+### REST `/api/v1/images` (`src/pages/api/v1/images/index.ts:196`)
+
+Public REST handler has its own `useIndex` / `getAllImages` branch. Same abuse surface as the tRPC
+feed. Decide: force index-only here too, or pin the DB path to a whitelist of cheap filters
+(imageId/modelId lookups it already special-cases at `:170`). `@justin:` \*
+
+## Phased rollout
+
+1. **Phase 1 — `post.getImages` + migrate post viewing.** Stand up `post.getImages`, point
+   `PostDetail` (and the `postId` branch of `ImageDetailProvider`) at it, update the SSG prefetch in
+   `pages/posts/[postId]/[[...postSlug]].tsx:48`. Post viewing leaves the heavy surface immediately.
+2. **Phase 2 — remaining DB-only callsites.** `collection.getImages`, reacted-images, model-showcase.
+3. **Phase 3 — lock down.** Drop `useIndex` from the public schema, force index on the generic feed
+   procedures + REST handler, reject DB-only filters. Watch `imagesFeedWithoutIndexCounter`.
+
+Phases 1 and 2 are independently shippable and non-breaking (additive endpoints). Phase 3 is the
+behavior change and the security win.
+
+## Open questions for `@justin:` \*
+
+1. Endpoint names: `post.getImages`, `collection.getImages`, `user.getReactedImages`,
+   model-showcase — happy with these, or a different home (e.g. all under `image.*` namespaced)? @justin: These are good
+2. Model showcase: dedicated DB endpoint, or invest in `prioritizedUserIds` support inside
+   `getAllImagesIndex` so the carousel stays index-backed? @justin: If these are db backed now, let's keep them that way.
+3. REST `/api/v1/images`: force index-only, or keep a cheap-filter whitelist for the DB path? @justin: Force index-only, throw on params that are not supported without index. (please list them for me below so I can consider)
+
+   `@ai:` Params that force the legacy/DB path on `/api/v1/images` today (i.e. **not** index-servable):
+
+   - `imageId` — single-image lookup (`:187` `useLegacyMethod`)
+   - `modelId` **without** `modelVersionId` — model gallery (`:187`; engagement sorts already collapse to newest-by-id, `image.service.ts:1414-1422`)
+   - `postId` / `postIds` — post images (`skipBitdex`)
+   - `collectionId` — `CollectionItem` join (`skipBitdex`)
+   - `reactions` — needs `ImageReaction` subquery + auth (`skipBitdex`)
+   - `prioritizedUserIds` — no user-prioritization in index yet (`skipBitdex`)
+
+   **Caution before we hard-throw here:** unlike the internal tRPC feed, `/api/v1/images` is the
+   **public documented API**. `imageId`, `postId`, and `modelId` are legitimate, advertised
+   lookups that external integrations rely on — and they're _narrow, cheap covered-index queries_,
+   not the broad full-feed scan that is the actual abuse vector. Throwing on them would break real
+   integrations for no load benefit. Recommend: **whitelist the narrow lookups** (`imageId`,
+   `postId`/`postIds`, `modelId`+`modelVersionId`) onto the DB path, and force index-only for
+   everything broad. Throw only when a _broad_ feed query carries a DB-forcing param it can't honor.
+   This is a Phase 3 / REST decision — flagging now, not touching it in Phase 1. `@ai:` \*
+
+4. `ImageDetailProvider`: full prev/next continuity from every source feed, or acceptable to scope
+   pagination in some entry contexts? @justin: Not sure I understand. Why does this change?
+
+   `@ai:` It only changes **at Phase 3**, and only _because_ of the lockdown — not in Phase 1.
+   Today the detail viewer reuses `image.getInfinite` with the **same filters as the feed you
+   clicked in from** so its prev/next carousel paginates through that exact set. While the DB path
+   stays available (Phases 1-2) nothing breaks. Once Phase 3 locks `image.getInfinite` to index-only
+   and rejects `postId`/`collectionId`/`reactions`, the viewer's existing call would 400 for those
+   source feeds — so at that point it must route to the matching new endpoint by filter shape. My
+   question was just: when you open an image _from a post_, is it fine for prev/next to walk only
+   that post's images (simple — reuse `post.getImages`), vs. trying to reconstruct the original
+   broad feed. Not relevant to Phase 1; I'll re-raise it when we scope Phase 3. `@ai:` \*
+
+5. Scope of this first PR: just Phase 1 (`post.getImages` + post viewing), then iterate? @justin: Yes, start with post, then once reviewed, we'll open another

--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -11,7 +11,7 @@ import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsPro
 import type { FilterKeys } from '~/providers/FiltersProvider';
 import { useFiltersContext } from '~/providers/FiltersProvider';
 import { ImageSort } from '~/server/common/enums';
-import type { GetInfiniteImagesInput } from '~/server/schema/image.schema';
+import type { GetInfiniteImagesInput, GetPostImagesInput } from '~/server/schema/image.schema';
 import { baseModels } from '~/shared/constants/basemodel.constants';
 import { MediaType, MetricTimeframe, ReviewReactions } from '~/shared/utils/prisma/enums';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -205,6 +205,71 @@ export const useQueryImages = (
     isLoading: isLoading || loadingPreferences,
     debugRetryActive,
     debugDelayMs,
+    ...rest,
+  };
+};
+
+// Post image carousel — hits the dedicated, DB-backed `post.getImages`
+// endpoint instead of the heavy `image.getInfinite` feed. Same post-processing
+// (dedup + hidden preferences) as useQueryImages. See
+// docs/plans/per-domain-getimages.md.
+export const useQueryPostImages = (
+  filters: GetPostImagesInput,
+  options?: { keepPreviousData?: boolean; enabled?: boolean; applyHiddenPreferences?: boolean }
+) => {
+  const { applyHiddenPreferences = true, ...queryOptions } = options ?? {};
+  const browsingSettingsAddons = useBrowsingSettingsAddons();
+
+  const excludedTagIds = [
+    ...(filters.excludedTagIds ?? []),
+    ...(browsingSettingsAddons.settings.excludedTagIds ?? []),
+  ].filter(isDefined);
+
+  const { data, isLoading, ...rest } = trpc.post.getImages.useInfiniteQuery(
+    {
+      ...filters,
+      excludedTagIds,
+      // OR-merge with the addon so either source can flag the filter (mirrors
+      // useQueryImages).
+      disablePoi: !!filters.disablePoi || browsingSettingsAddons.settings.disablePoi,
+      disableMinor: !!filters.disableMinor || browsingSettingsAddons.settings.disableMinor,
+    },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      trpc: { context: { skipBatch: true }, abortOnUnmount: true },
+      retry: 0,
+      ...withPlaceholderData(queryOptions),
+    }
+  );
+
+  const flatData = useMemo(() => {
+    const allItems = data?.pages.flatMap((x) => (!!x ? x.items : [])) ?? [];
+    const seenIds = new Set<number>();
+    const dedupedItems: typeof allItems = [];
+    for (const item of allItems) {
+      if (!seenIds.has(item.id)) {
+        seenIds.add(item.id);
+        dedupedItems.push(item);
+      }
+    }
+    return dedupedItems;
+  }, [data]);
+
+  const { items, loadingPreferences, hiddenCount } = useApplyHiddenPreferences({
+    type: 'images',
+    data: flatData,
+    showHidden: !!filters.hidden,
+    disabled: !applyHiddenPreferences,
+    isRefetching: rest.isRefetching,
+  });
+
+  return {
+    data,
+    flatData,
+    images: items,
+    removedImages: hiddenCount,
+    fetchedImages: flatData?.length,
+    isLoading: isLoading || loadingPreferences,
     ...rest,
   };
 };

--- a/src/components/Post/Detail/PostDetail.tsx
+++ b/src/components/Post/Detail/PostDetail.tsx
@@ -43,7 +43,7 @@ import {
   ExplainHiddenImages,
   useExplainHiddenImages,
 } from '~/components/Image/ExplainHiddenImages/ExplainHiddenImages';
-import { useQueryImages } from '~/components/Image/image.utils';
+import { useQueryPostImages } from '~/components/Image/image.utils';
 import { Gated } from '~/components/Gated/Gated';
 import { PageLoader } from '~/components/PageLoader/PageLoader';
 import { PostComments } from '~/components/Post/Detail/PostComments';
@@ -117,7 +117,7 @@ export function PostDetailContent({ postId }: Props) {
     flatData: unfilteredImages,
     images,
     isLoading: imagesLoading,
-  } = useQueryImages(
+  } = useQueryPostImages(
     {
       postId,
       pending: !!currentUser,

--- a/src/components/Post/EditV2/PostReorderImages.tsx
+++ b/src/components/Post/EditV2/PostReorderImages.tsx
@@ -134,6 +134,8 @@ export function ReorderImagesButton() {
     async onSuccess() {
       await queryUtils.model.getAll.invalidate();
       await queryUtils.image.getInfinite.invalidate();
+      // Post detail now reads from the dedicated post.getImages endpoint.
+      await queryUtils.post.getImages.invalidate();
     },
   });
   const previous = usePrevious(images);

--- a/src/pages/posts/[postId]/[[...postSlug]].tsx
+++ b/src/pages/posts/[postId]/[[...postSlug]].tsx
@@ -45,7 +45,7 @@ export const getServerSideProps = createServerSideProps({
       }
 
       await ssg?.post.get.prefetch({ id: postId });
-      await ssg?.image.getInfinite.prefetchInfinite({
+      await ssg?.post.getImages.prefetchInfinite({
         postId,
         pending: !!session?.user,
         withMeta: false,

--- a/src/server/controllers/image.controller.ts
+++ b/src/server/controllers/image.controller.ts
@@ -61,6 +61,7 @@ import type {
   GetEntitiesCoverImage,
   GetImageInput,
   GetInfiniteImagesOutput,
+  GetPostImagesOutput,
   ImageModerationSchema,
   ImageReviewQueueInput,
   SetTosViolationSchema,
@@ -340,6 +341,34 @@ export const getInfiniteImagesHandler = async ({
         dbTarget: features.datapacketRead ? 'datapacket' : 'read',
       });
     }
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    else throw throwDbError(error);
+  }
+};
+
+// Server-pinned post image carousel. Always runs the cheap covered-index DB
+// path (getAllImages with a required postId) — never the heavy index feed and
+// never client-selectable via useIndex. Lives off the heavyProcedure surface so
+// opening/refreshing post pages can't trip the feed rate limits.
+// See docs/plans/per-domain-getimages.md.
+export const getPostImagesHandler = async ({
+  input,
+  ctx,
+}: {
+  input: GetPostImagesOutput;
+  ctx: Context;
+}) => {
+  const { user, features } = ctx;
+  try {
+    return await getAllImages({
+      ...input,
+      user,
+      useCombinedNsfwLevel: !features.canViewNsfw,
+      headers: { src: 'getPostImagesHandler' },
+      include: [...input.include, 'tagIds'],
+      dbTarget: features.datapacketRead ? 'datapacket' : 'read',
+    });
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/routers/post.router.ts
+++ b/src/server/routers/post.router.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 import { dbWrite } from '~/server/db/client';
-import { imageSchema } from '~/server/schema/image.schema';
+import { getPostImagesSchema, imageSchema } from '~/server/schema/image.schema';
+import { getPostImagesHandler } from '~/server/controllers/image.controller';
 import { middleware, moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import {
@@ -159,6 +160,12 @@ export const postRouter = router({
     .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)
     .query(getPostResourcesHandler),
+  // Server-pinned post image carousel — DB-backed, off the heavy feed surface.
+  // See docs/plans/per-domain-getimages.md.
+  getImages: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(getPostImagesSchema)
+    .query(getPostImagesHandler),
   getContestCollectionDetails: publicProcedure
     .meta({ requiredScope: TokenScope.MediaRead })
     .input(getByIdSchema)

--- a/src/server/schema/image.schema.ts
+++ b/src/server/schema/image.schema.ts
@@ -398,6 +398,44 @@ export const getInfiniteImagesSchema = baseQuerySchema
     return value;
   });
 
+// Dedicated, server-pinned schema for the post image carousel. Unlike
+// getInfiniteImagesSchema it does NOT expose `useIndex` or any broad feed
+// filter — postId is required and the handler always runs the cheap covered-
+// index DB path. This keeps post viewing off the heavy, index-only feed
+// surface. See docs/plans/per-domain-getimages.md.
+export type GetPostImagesInput = z.input<typeof getPostImagesSchema>;
+export type GetPostImagesOutput = z.output<typeof getPostImagesSchema>;
+export const getPostImagesSchema = baseQuerySchema
+  .extend({
+    postId: z.number(),
+    limit: z.number().min(0).max(200).default(constants.galleryFilterDefaults.limit),
+    period: z.enum(MetricTimeframe).default(constants.galleryFilterDefaults.period),
+    periodMode: periodModeSchema,
+    sort: z.enum(ImageSort).default(constants.galleryFilterDefaults.sort),
+    withMeta: z.boolean().default(false),
+    withTags: z.boolean().optional(),
+    include: z.array(imageInclude).default((): ImageInclude[] => ['cosmetics']),
+    cursor: z
+      .union([z.bigint(), z.number(), z.string(), z.date()])
+      .transform((val) =>
+        typeof val === 'string' && dayjs(val, 'YYYY-MM-DDTHH:mm:ss.SSS[Z]', true).isValid()
+          ? new Date(val)
+          : val
+      )
+      .optional(),
+    pending: z.boolean().optional(),
+    hidden: z.boolean().optional(),
+    excludedTagIds: z.array(z.number()).optional(),
+    excludedUserIds: z.array(z.number()).optional(),
+    disablePoi: z.boolean().optional(),
+    disableMinor: z.boolean().optional(),
+  })
+  .transform((value) => {
+    if (value.withTags && !value.include.includes('tags')) value.include.push('tags');
+    if (value.withMeta && !value.include.includes('meta')) value.include.push('meta');
+    return value;
+  });
+
 export type GetImageInput = z.infer<typeof getImageSchema>;
 export const getImageSchema = z.object({
   id: z.number(),


### PR DESCRIPTION
## Why

Post viewing rides `image.getInfinite` — a `heavyProcedure` (rate-limited bulkhead). Whether that endpoint hits Meilisearch or raw Postgres is decided by a **client-controlled** `useIndex` flag; `postId` queries fall to the un-indexed `getAllImages` path. Two problems:

1. **Abuse surface** — anyone can send `useIndex:false` with arbitrary filters to force the expensive un-indexed Postgres path the limits exist to protect.
2. **Accidental self-DoS** — legit post viewing shares that heavy limit, so opening ~10 post pages in a minute (or a few refreshes / client retries) trips it by accident.

Root cause: the index-vs-DB decision is a client input, not a server policy.

## What (Phase 1 of [docs/plans/per-domain-getimages.md](docs/plans/per-domain-getimages.md))

Stand up a dedicated, server-pinned `post.getImages` tRPC procedure on a normal `publicProcedure`:

- `getPostImagesSchema` — `postId` **required**, no `useIndex`, no broad feed filters. Just pagination + browsing level + hidden-pref passthrough.
- `getPostImagesHandler` — always runs `getAllImages` (the cheap ~2ms covered-index postId query), mirroring the old DB branch of `getInfiniteImagesHandler` exactly (`user`, `useCombinedNsfwLevel`, `headers`, `include:[...input.include,'tagIds']`, `dbTarget`).
- Client: new `useQueryPostImages` hook (same dedup + hidden-prefs as `useQueryImages`); `PostDetail`, the SSG prefetch, and the editor-reorder invalidation migrated to it.

Same data path as before — only the procedure/rate-limit surface changes. Additive and non-breaking; the generic feed is untouched.

## Review notes

External (GPT) review raised two items, both addressed:

- **Rate-limit surface (by design):** `post.getImages` is intentionally off the heavy bulkhead — that's the point. The `postId` path is a narrow covered-index lookup, not the broad feed scan. Per product call, no rate-limit tier added here. Open to a light cap on `limit`/`include` if we want belt-and-suspenders.
- **Cache invalidation (audited, no regression):** the full set of `image.getInfinite` invalidations is 9 sites; only `PostReorderImages` drives the post carousel and it's mirrored. Image delete (`useDeleteImage`) and the NSFW-level modal — the mutations reachable from post detail — never invalidated `getInfinite` to begin with, so nothing goes more stale than before.

## Verification

- `pnpm typecheck` ✅
- `prettier` ✅

## Follow-ups (later PRs)

Phases 2-3 in the plan doc: `collection.getImages`, reacted-images, model-showcase endpoints; then lock the generic feed to index-only and drop `useIndex` from the public contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)