### PR TITLE
test: anon App Blocks conversion preview

### DIFF
--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -207,7 +207,10 @@ const featureFlags = createFeatureFlags({
   // App Blocks (Phase 1) — gates the BlockSlot mount on model pages. Off by
   // default until we ship publisher install UX + moderator approval workflow.
   // When off, BlockSlot renders nothing and no token-issuance traffic fires.
-  appBlocks: { availability: ['mod'], fliptKey: 'app-blocks-enabled' },
+  // THROWAWAY PREVIEW ONLY (zach/app-blocks-anon-preview): relaxed to public +
+  // fliptKey dropped so anon/everyone gets appBlocks on this preview for the
+  // anonymous-conversion validation. DO NOT MERGE. Prod stays mod-only.
+  appBlocks: { availability: ['public'] },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];


### PR DESCRIPTION
Throwaway PR purely to stand up a **PR-preview** environment for validating the App Blocks anonymous-conversion flow end-to-end with a logged-out viewer.

## What this does
- Branches off `feat/app-blocks-main-v1` (inherits the anon-mint + `REQUEST_SIGN_IN` code from #2319 / commit `1eb0d8383`).
- The ONLY change: relaxes the `appBlocks` feature flag to `availability: ['public']` and drops its `fliptKey` **on this branch only**, so an anonymous caller passes the block-token mint gate and the `BlockSlot` renders for `viewer===null` on this preview.

## Isolation / safety
- Prod App Blocks stays **mod-only** — `feat/app-blocks-main-v1` and `main` are NOT modified.
- The global Flipt `app-blocks-enabled` flag is NOT changed.
- Targets the **dev DB** (no `preview-db/prod` label).

## DO NOT MERGE
This exists only to spin up `pr-<N>.civitaic.com` for manual + programmatic validation. Close it (and let the preview namespace GC) when validation is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)