### PR TITLE
fix(subscriptions): re-enable Redis cache for getHistoricalPrepaidDeliveries (p99 ~29s → 504s)

### DIFF
--- a/src/server/services/subscriptions.service.ts
+++ b/src/server/services/subscriptions.service.ts
@@ -964,14 +964,14 @@ export const getHistoricalPrepaidDeliveries = async ({
   //      (date, fromAccountId, toAccountId); the date filter limits the scan. The byToAccount
   //      projection exists but can't be used with SharedReplacingMergeTree.
   // Cache aggressively since legacy txns are historical and don't change.
-  // const cacheKey =
-  //   `${REDIS_KEYS.SYSTEM.BLOCKLIST}:prepaid-deliveries:${userId}:${accountType}:v2` as RedisKeyTemplateCache;
-  // try {
-  //   const cached = await redis.get(cacheKey);
-  //   if (cached) return JSON.parse(cached) as PrepaidToken[];
-  // } catch {
-  //   // Redis down — fall through to ClickHouse
-  // }
+  const cacheKey =
+    `${REDIS_KEYS.SYSTEM.BLOCKLIST}:prepaid-deliveries:${userId}:${accountType}:v2` as RedisKeyTemplateCache;
+  try {
+    const cached = await redis.get(cacheKey);
+    if (cached) return JSON.parse(cached) as PrepaidToken[];
+  } catch {
+    // Redis down — fall through to ClickHouse
+  }
 
   const membershipPromise = clickhouse.$query<{
     date: string;
@@ -1017,7 +1017,6 @@ export const getHistoricalPrepaidDeliveries = async ({
       : Promise.resolve([] as never[]);
 
   const [membershipRows, legacyRows] = await Promise.all([membershipPromise, legacyPromise]);
-  console.log(legacyRows, 'asadasd');
   // Pull the YYYY-MM period out of `civitai-membership:YYYY-MM:...` or
   // `annual-sub-payment-YYYY-MM:...` so we can label the token by month.
   const formatPeriod = (yyyyMm: string | undefined): string | undefined => {
@@ -1135,11 +1134,11 @@ export const getHistoricalPrepaidDeliveries = async ({
   });
 
   // Cache for 1 hour — historical/migration txns don't change
-  // try {
-  //   await redis.set(cacheKey, JSON.stringify(tokens), { EX: CacheTTL.hour });
-  // } catch {
-  //   // Redis down — result still returned
-  // }
+  try {
+    await redis.set(cacheKey, JSON.stringify(tokens), { EX: CacheTTL.hour });
+  } catch {
+    // Redis down — result still returned
+  }
 
   return tokens;
 };


### PR DESCRIPTION
## Problem
`subscriptions.getHistoricalPrepaidDeliveries` had **p99 ~29s**, hitting the gateway timeout and returning **504s under load**. The function runs a ~10s `buzzTransactions` ClickHouse scan (the table is sorted by `(date, fromAccountId, toAccountId)`; the `byToAccount` projection can't be used with `SharedReplacingMergeTree`, so the date window is the only thing keeping it tractable) on **every call** — because its Redis cache was commented out.

## Fix
The 1h Redis cache wrapping the query was already fully written (read + write paths) but **commented out**, with a stray `console.log(legacyRows, 'asadasd')` debug log left in. This PR simply:
- Re-enables the cache read path (early return on hit) and write path (1h TTL)
- Removes the `console.log(legacyRows, 'asadasd')` debug log

## Why was it commented out? (safe to re-enable)
Traced via `git log -S`: the cache was disabled in `15412b550` ("feat(membership): surface legacy annual + reward comp txns as virtual tokens") — the **same commit** that added the `asadasd` debug log and was actively building the new legacy-txn feature. It was disabled to see fresh ClickHouse results while iterating, **not** because of a correctness bug. The strongest signal: that same commit **bumped the cache key to `:v2`** — an intentional cache-bust for the new token shape, which only makes sense if the cache was always intended to come back on.

The cached data is **historical/immutable** (`membership_prepaid_deliveries` materialized-view rows + Paddle-era legacy txns bounded to May–Aug 2025), so a **1h TTL** (the original value) is appropriate. No staleness safeguard beyond the TTL is needed.

## Cache key (per-user, no cross-user leak)
```
{REDIS_KEYS.SYSTEM.BLOCKLIST}:prepaid-deliveries:{userId}:{accountType}:v2
```
Keyed on both `userId` and `accountType`, so prepaid data cannot leak across users.

## Validation
- `prettier --write` + `eslint` on the changed file: 0 errors (remaining warnings are pre-existing `no-explicit-any` in unrelated functions; the `console.log` warning is now gone)
- `typecheck`: pre-existing stale-Prisma-client errors repo-wide (`Prisma.sql` missing, cascading implicit-`any`); **none in the changed function region**. CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)