### PR TITLE
perf(track): reuse resolved session in Tracker to cut duplicate auth on hot routes

### DIFF
--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -260,14 +260,20 @@ export class Tracker {
     userAgent: 'unknown',
   };
   private session: Session | null = null;
+  // True once the session has been resolved (either eagerly via the constructor
+  // or lazily on first track()). Distinguishes a genuinely-anonymous request
+  // (resolved to null) from one that simply hasn't fetched yet, so anonymous
+  // requests don't re-enter getServerAuthSession on every track() call.
+  private sessionResolved = false;
   private req: NextApiRequest | undefined;
   private res: NextApiResponse | undefined;
 
   private async resolveSession() {
-    if (!this.session && this.req && this.res) {
+    if (!this.sessionResolved && this.req && this.res) {
       try {
         await getServerAuthSession({ req: this.req, res: this.res }).then((session) => {
           this.session = session;
+          this.sessionResolved = true;
           this.actor.userId = session?.user?.id ?? this.actor.userId;
           return session;
         });
@@ -287,12 +293,29 @@ export class Tracker {
     }
   }
 
-  constructor(req?: NextApiRequest, res?: NextApiResponse) {
+  constructor(
+    req?: NextApiRequest,
+    res?: NextApiResponse,
+    // The tRPC context has already resolved the session before constructing a
+    // Tracker. Passing it in lets high-volume tracking routes (e.g. track.addView
+    // ~100/s on api-primary) skip the Tracker's own getServerAuthSession call.
+    // The win is specifically ANONYMOUS requests: getServerAuthSession memoizes
+    // into req.context.session, but a null (anon) session fails that truthy guard,
+    // so the lazy resolveSession() re-ran a full JWE decrypt on every track()
+    // call. Authenticated requests already cache-hit the memo. Omitting this arg
+    // keeps the legacy behavior: resolveSession() lazily fetches on first track().
+    session?: Session | null
+  ) {
     if (req && res) {
       this.req = req;
       this.res = res;
       this.actor.ip = requestIp.getClientIp(req) ?? this.actor.ip;
       this.actor.userAgent = req.headers['user-agent'] ?? this.actor.userAgent;
+    }
+    if (session !== undefined) {
+      this.session = session;
+      this.sessionResolved = true;
+      this.actor.userId = session?.user?.id ?? this.actor.userId;
     }
   }
 

--- a/src/server/createContext.ts
+++ b/src/server/createContext.ts
@@ -56,7 +56,12 @@ export const createContext = async ({
   // Bearer/API-key auth carries no cookies, so CSRF does not apply.
   const isBearerAuth = (req as any).context?.apiKeyId != null;
   const acceptableOrigin = !isProd || isBearerAuth || isAllowedOriginRequest(req);
-  const track = new Tracker(req, res);
+  // Pass the already-resolved session so high-volume tracking routes
+  // (e.g. track.addView ~100/s on api-primary) skip the Tracker's own
+  // getServerAuthSession call. Matters for ANONYMOUS requests: a null session
+  // isn't memoized by req.context.session, so the lazy path re-decrypted the
+  // JWE on every track() call (authenticated requests already cache-hit).
+  const track = new Tracker(req, res, session);
   const cache: CacheSettings | null = {
     browserTTL: session?.user ? 0 : 60,
     edgeTTL: session?.user ? 0 : 60,


### PR DESCRIPTION
## Problem
`track.addView` runs ~99/s on `api-primary` during the recurring pin waves. Tracing `track.addView` → `Tracker.send()` → `resolveSession()`: every call ran `getServerAuthSession({ req, res })`, even though the tRPC `createContext` had already resolved the session for that request.

**Scope correction (per audit):** `getServerAuthSession` memoizes into `req.context.session`, so **authenticated** requests already cache-hit on the Tracker's second call (no extra decrypt). The redundant work is **anonymous** requests — a `null` session fails the `if (req.context?.session)` truthy guard, so the lazy `resolveSession()` re-ran a full JWE decrypt (main-thread CPU) on *every* `track()` call.

(The HTTP POST to the ClickHouse tracker was already fire-and-forget via `void sendWithRetry`, so no insert work was ever on the request thread.)

## Change
- `Tracker` (`src/server/clickhouse/client.ts`): optional 3rd constructor arg `session`; a `sessionResolved` flag distinguishes a genuinely-anonymous request (resolved to `null`) from one not yet fetched, so anonymous requests stop re-decrypting on every `track()`.
- `createContext` (`src/server/createContext.ts:62`): passes the already-resolved `session` into the `Tracker`.

Backward-compatible: the arg is optional; the other ~18 `new Tracker(...)` call sites (incl. `publicApiContext`/`publicApiContext2`) are unchanged and keep lazy-fetch. View payloads (`session`/`actor`) are byte-identical.

## Audit (adversarial review) — no regressions
- **Session value equivalent** — same `getServerAuthSession({req,res})`, same `req`.
- **No Set-Cookie / token-refresh change** — those side effects live in `createContext`'s own auth call (untouched); the Tracker's removed call never re-fired them.
- **Bearer `req.context` (apiKeyId/tokenScope)** — populated by `createContext`'s call, not the Tracker's.
- **No race** — constructor sets `sessionResolved=true` synchronously before any `track()`.
- **No userId divergence** — no session/actor mutators exist after construction.

## Scope / impact (honest)
A per-request CPU cut for **anonymous `track.addView` only** — real but modest. **Not expected to stop the burst-concurrency pin waves on its own** (a 26% per-request CPU cut from disabling OTEL did not move them); the structural fix (in-pod parallelism / worker threads) is tracked separately.

## Validation & gaps
- Lint: 0 new errors on changed files. Typecheck: 0 errors in the two files (remaining noise is the known stale-Prisma-client-in-fresh-worktree artifact).
- **Test gap:** there is no test coverage for `Tracker` session handling (pre-existing) — this change rests on manual reasoning + the audit above.
- **Follow-up (deferred):** `publicApiContext`/`publicApiContext2` still construct `Tracker` without a session, so anon requests through those paths still re-decrypt. Not regressed by this PR; optimize only if those paths prove hot.
- **Prod verification pending:** confirm post-deploy that `getServerAuthSession` calls/req drop on anon `track.addView`. Deployed ≠ verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)