### PR TITLE
perf(redis): cut image-tags/image-resources DP TTLs + bound entitymetric increment

### DIFF
--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1311,7 +1311,11 @@ type ImageTagsCacheItem = {
 export const imageTagsCache = createCachedObject<ImageTagsCacheItem>({
   key: REDIS_KEYS.CACHES.IMAGE_TAGS,
   idKey: 'imageId',
-  ttl: CacheTTL.day,
+  // Reduced from day to 1h — this cache ran at ~50% of next-redis-cluster
+  // (~12.7M keys/shard × ~4.2KB full tag composites) yet had a 25.5% hit ratio
+  // (misses > hits): a 24h TTL bought nothing since entries were LRU-evicted long
+  // before reuse. SWR off → effective Redis EX = 1h. (2026-06-09 redis usage audit)
+  ttl: CacheTTL.hour,
   staleWhileRevalidate: false,
   lookupFn: async (ids, fromWrite) => {
     const db = fromWrite ? dbWrite : dbRead;
@@ -1397,7 +1401,10 @@ type ImageResourcesCacheItem = {
 export const imageResourcesCache = createCachedObject<ImageResourcesCacheItem>({
   key: REDIS_KEYS.CACHES.IMAGE_RESOURCES,
   idKey: 'imageId',
-  ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.sm,
+  // Reduced from day to 8h — 68.8% hit at ~728B/key × ~7.3M keys; with SWR on,
+  // the day TTL resided for 48h, generous for a sub-average-hit cache.
+  // Effective Redis EX = 16h. (2026-06-09 redis usage audit)
+  ttl: CacheTTL.hour * 8,
   lookupFn: async (ids, fromWrite) => {
     const imageIds = Array.isArray(ids) ? ids : [ids];
     if (imageIds.length === 0) return {};

--- a/src/server/redis/entity-metric.redis.ts
+++ b/src/server/redis/entity-metric.redis.ts
@@ -67,7 +67,15 @@ export class EntityMetricRedisClient {
     amount = 1
   ): Promise<number> {
     const key = this.getKey(entityType, entityId);
-    return await this.redis.hIncrBy(key, metricType, amount);
+    const result = await this.redis.hIncrBy(key, metricType, amount);
+    // Bound the key on the hot increment path too. setMetric/setMultipleMetrics
+    // set this TTL, but increment() previously left the key permanent — so any
+    // entitymetric:* key whose first/only touch was an increment (the hot
+    // reaction/comment path) never expired. Refreshing on each increment also
+    // gives a sliding TTL: the key lives while active, reaped 1h after the last
+    // touch. (2026-06-09 redis usage audit)
+    await this.redis.expire(key, EntityMetricRedisClient.METRIC_TTL_SECONDS);
+    return result;
   }
 
   async getMetric(


### PR DESCRIPTION
## Why
`next-redis-cluster` (the primary sharded cache) runs **permanently pinned at maxmemory** — ~107 GB used / ~107 GB cap, ~122M keys, 88% hit, evicting 270–510 keys/s/shard continuously. That continuous eviction also makes replica resyncs large and OOM-prone (it drove a partial shard outage on 2026-06-09).

A read-only keyspace audit (sampled the replicas + redis_exporter + app cache counters) found the pressure is **image→tag / image→resource caches**, not the `image-meta` cache we'd assumed (image-meta is ~1% of keys / ~2.3 GB with a 4h TTL). Full report: `datapacket-talos/claudedocs/redis-usage-analysis-2026-06-09.md`.

## Changes
TTLs are set directly (the `IS_DATAPACKET` env split is retired):
1. **`imageTagsCache` TTL `day` → `1h`** — the #1 offender. ~**50% of the entire cluster** (~12.7M keys/shard × ~4.2 KB full tag composites) at a **25.5% hit ratio (misses > hits)**. A 24h TTL bought nothing: entries were LRU-evicted long before reuse. Expected to reclaim **~20–40 GB** and likely end the maxmemory pinning on its own.
2. **`imageResourcesCache` TTL `day` → `8h`** (effective 16h with stale-while-revalidate, was 48h). 68.8% hit; the long hold was generous. ~2–3 GB.
3. **`EntityMetricRedisClient.increment()` — add `expire` after `hIncrBy`** (correctness). `setMetric`/`setMultipleMetrics` set a 1h TTL, but `increment()` left the key permanent, so `entitymetric:*` keys first touched by an increment (the hot reaction/comment path) never expired. Now a sliding 1h TTL (refreshed on each increment).

## Verification
- ⚠️ Local `pnpm typecheck` not run (fresh worktree, no `node_modules`). Changes are type-trivial: two `ttl:` constant swaps and an `expire()` call mirroring `setMetric()`. Please let CI confirm.
- After deploy, watch `redis_memory_used_bytes{namespace="next-redis-cluster"}`, the per-cache hit ratio (`civitai_app_cache_{hit,miss}_total`), and `redis_evicted_keys_total` over 24h.

## Follow-ups (not in this PR)
- **De-duplicate the three image→tag caches** (`image-tags` composites vs `tag-ids-for-images` tagId[] vs the `image:tagIds` hash) — ~9–24 GB more, structural.
- The `image:tagIds` hash + `metrics:Image` writers live in the feeds/search-index layer (not this repo).
- sysRedis `session:user-tokens2` key-level expire (hygiene).
- Instrument ioredis OTEL client spans (enables future trace-grounded cache decisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)