### PR TITLE
feat(nav): events nav toggle + tidy-up notice; restore posts gate

### DIFF
--- a/src/components/Alerts/NavTidyNotice.tsx
+++ b/src/components/Alerts/NavTidyNotice.tsx
@@ -1,0 +1,111 @@
+import { Button, CloseButton, Popover, Text } from '@mantine/core';
+import { IconArrowRight, IconInfoCircle } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { trpc } from '~/utils/trpc';
+
+const ALERT_ID = 'nav-tidy-notice';
+
+/**
+ * Floating popover that appears right under the sub nav, where the Posts /
+ * Events tabs used to live, letting users know they were tidied away and can
+ * be turned back on from their account settings. Mirrors the dismiss pattern
+ * used by {@link ./YellowBuzzMigrationNotice}.
+ */
+export function NavTidyNotice() {
+  const currentUser = useCurrentUser();
+  const features = useFeatureFlags();
+
+  const enabled = !!currentUser;
+  // AppProvider seeds `user.getSettings` with SSR initialData and the global
+  // `staleTime: Infinity` prevents refetching — so `data` is truthy immediately
+  // with potentially stale `dismissedAlerts`. Gate on `isFetched` (only true
+  // after a real network fetch resolves) and force a refetch via `staleTime: 0`.
+  const { data: settings, isFetched: settingsFetched } = trpc.user.getSettings.useQuery(undefined, {
+    enabled,
+    staleTime: 0,
+  });
+  const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
+
+  const utils = trpc.useUtils();
+  const dismissMutation = trpc.user.dismissAlert.useMutation({
+    onMutate: async () => {
+      await utils.user.getSettings.cancel();
+      const prev = utils.user.getSettings.getData();
+      utils.user.getSettings.setData(undefined, (old) => ({
+        ...old,
+        dismissedAlerts: [...(old?.dismissedAlerts ?? []), ALERT_ID],
+      }));
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
+    },
+  });
+
+  // Only nudge users who actually have one of the tidied items hidden.
+  const hasHiddenNavItem = !features.postsNavItem || !features.eventsNavItem;
+  const show = enabled && settingsFetched && !isDismissed && hasHiddenNavItem;
+
+  const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
+
+  if (!show) return null;
+
+  return (
+    <Popover
+      width={280}
+      position="bottom-start"
+      shadow="lg"
+      opened
+      onChange={(opened) => {
+        if (!opened) handleDismiss();
+      }}
+      withArrow
+      arrowSize={10}
+    >
+      <Popover.Target>
+        <div className="inline-flex cursor-help text-yellow-7" aria-label="Navigation updated">
+          <IconInfoCircle size={18} />
+        </div>
+      </Popover.Target>
+      <Popover.Dropdown className="border border-yellow-9/30 p-0">
+        <div className="flex flex-col gap-2 p-3">
+          <div className="flex items-start justify-between gap-2">
+            <Text size="sm" fw={600} style={{ color: '#f59f00' }}>
+              We tidied up the nav
+            </Text>
+            <CloseButton
+              size="xs"
+              variant="subtle"
+              color="gray"
+              radius="xl"
+              onClick={handleDismiss}
+              aria-label="Dismiss"
+              className="shrink-0"
+            />
+          </div>
+
+          <Text size="xs" c="dimmed" lh={1.4}>
+            We trimmed a few items from the navigation to keep things simple. Miss Posts or Events?
+            You can turn them back on anytime in your settings.
+          </Text>
+
+          <Button
+            component={Link}
+            href="/user/account#settings"
+            onClick={handleDismiss}
+            variant="light"
+            color="yellow"
+            size="compact-xs"
+            radius="xl"
+            rightSection={<IconArrowRight size={12} />}
+            className="self-start"
+          >
+            Manage in settings
+          </Button>
+        </div>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/src/components/Alerts/NavTidyNotice.tsx
+++ b/src/components/Alerts/NavTidyNotice.tsx
@@ -58,9 +58,10 @@ export function NavTidyNotice() {
       position="bottom-start"
       shadow="lg"
       opened
-      onChange={(opened) => {
-        if (!opened) handleDismiss();
-      }}
+      // Stay put until the user explicitly closes it via the X — clicking away
+      // or pressing Escape should not permanently dismiss the nudge.
+      closeOnClickOutside={false}
+      closeOnEscape={false}
       withArrow
       arrowSize={10}
     >
@@ -94,7 +95,6 @@ export function NavTidyNotice() {
           <Button
             component={Link}
             href="/user/account#settings"
-            onClick={handleDismiss}
             variant="light"
             color="yellow"
             size="compact-xs"

--- a/src/components/AppLayout/SubNav.tsx
+++ b/src/components/AppLayout/SubNav.tsx
@@ -10,6 +10,7 @@ import { PostFeedFilters } from '~/components/Filters/FeedFilters/PostFeedFilter
 import { VideoFeedFilters } from '~/components/Filters/FeedFilters/VideoFeedFilters';
 import { ToolFeedFilters } from '~/components/Filters/FeedFilters/ToolFeedFilters';
 import { ManageHomepageButton } from '~/components/HomeBlocks/ManageHomepageButton';
+import { NavTidyNotice } from '~/components/Alerts/NavTidyNotice';
 import { HomeTabs } from '~/components/HomeContentToggle/HomeContentToggle';
 import { ToolImageFeedFilters } from '~/components/Filters/FeedFilters/ToolImageFeedFilters';
 import clsx from 'clsx';
@@ -39,6 +40,7 @@ export function SubNav2() {
       })}
     >
       <HomeTabs />
+      <NavTidyNotice />
       {section?.component}
     </div>
   );

--- a/src/components/HomeContentToggle/HomeContentToggle.tsx
+++ b/src/components/HomeContentToggle/HomeContentToggle.tsx
@@ -121,6 +121,7 @@ export function filterHomeOptions(features: FeatureAccess) {
         key === 'challenges' && !features.challengePlatform,
         key === 'comics' && !features.comicCreator,
         key === 'posts' && !features.postsNavItem,
+        key === 'events' && !features.eventsNavItem,
       ].some((b) => b)
   );
 }

--- a/src/components/HomeContentToggle/HomeContentToggle.tsx
+++ b/src/components/HomeContentToggle/HomeContentToggle.tsx
@@ -120,6 +120,7 @@ export function filterHomeOptions(features: FeatureAccess) {
         key === 'tools' && !features.toolSearch,
         key === 'challenges' && !features.challengePlatform,
         key === 'comics' && !features.comicCreator,
+        key === 'posts' && !features.postsNavItem,
       ].some((b) => b)
   );
 }

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -107,6 +107,13 @@ const featureFlags = createFeatureFlags({
     description: `Show the Posts item in the main site navigation.`,
     availability: ['public'],
   },
+  eventsNavItem: {
+    toggleable: true,
+    default: false,
+    displayName: 'Events in Navigation',
+    description: `Show the Events item in the main site navigation.`,
+    availability: ['public'],
+  },
   alternateHome: ['public'],
   collections: ['public'],
   air: {


### PR DESCRIPTION
## What

Follow-up to #2446 (Posts nav opt-in). Three things:

1. **Restores the Posts nav gate** that was reverted in `bc0ca19a9f` ("always show /posts").
2. **Adds an Events nav toggle** — `eventsNavItem` toggleable flag (default off), mirroring `postsNavItem`, so Events is opt-in too.
3. **Adds a "we tidied up the nav" notice** under the sub nav, pointing users to settings to turn Posts/Events back on.

## Commits

| Commit | Change |
|---|---|
| `a2fd5fd0` | Revert the revert — re-add `key === 'posts' && !features.postsNavItem` gate |
| `824d4302` | `eventsNavItem` toggleable flag + `filterHomeOptions` gate |
| `d2d763d6` | `NavTidyNotice` component + mount in `SubNav2` |
| `72ee535a` | Notice dismisses via the X button only (not click-away/Escape) |

## The notice (`NavTidyNotice.tsx`)

- Dismissible Mantine **Popover**, `position="bottom-start"` → renders right under the sub nav where the Posts/Events tabs used to sit.
- **Shows only** for logged-in users who have Posts **or** Events hidden, and haven't dismissed it.
- Copy: "We tidied up the nav... Miss Posts or Events? You can turn them back on anytime in your settings." → **Manage in settings** button → `/user/account#settings`.
- Mirrors `YellowBuzzMigrationNotice` dismiss persistence (`user.dismissAlert` → `dismissedAlerts`, alert id `nav-tidy-notice`).
- **X-only dismiss**: `closeOnClickOutside={false}` / `closeOnEscape={false}` so a stray click can't hide it forever.

## Test

- Log in with Posts/Events off in account settings → notice appears under the sub nav. Dismiss persists server-side; only the X dismisses.
- `pnpm typecheck`: clean for all changed files (only a pre-existing unrelated `mai.handler.ts` error on main).

## Notes

- No DB migration — toggleable flags persist to `User.settings` JSON via existing plumbing.
- Default-off means existing users won't see Events in nav until they opt in (same intent as Posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)