### PR TITLE
test: App Blocks consent flow (scope-grant before buzz-spend)

### DIFF
--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -219,7 +219,7 @@ const featureFlags = createFeatureFlags({
   // App Blocks (Phase 1) — gates the BlockSlot mount on model pages. Off by
   // default until we ship publisher install UX + moderator approval workflow.
   // When off, BlockSlot renders nothing and no token-issuance traffic fires.
-  appBlocks: { availability: ['mod'], fliptKey: 'app-blocks-enabled' },
+  appBlocks: { availability: ['public'] },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];


### PR DESCRIPTION
Throwaway preview to validate the W5 A6 consent flow on a dev-DB preview: a logged-in viewer of a publisher-installed block must grant consent-gated scopes (ai:write:budgeted etc.) before the block can spend their buzz. Carries the appBlocks flag relaxed to public + the grantScopes un-gate (protectedProcedure). Branched off feat/app-blocks-main-v1. DO NOT MERGE — tear down after testing.