### PR TITLE
fix(observability): emit eventloop-longtask Prom metrics into the scraped registry

### DIFF
--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -20,12 +20,14 @@ if (!global.collectMetricsInitialized) {
     register: client.register,
     labels,
   });
-  // Apply the same default labels (e.g. podname) to the cross-graph instrumentation
-  // registry so its series (eventloop long-task metrics) carry podname like every
-  // other app metric — otherwise per-pod attribution on those series is lost.
-  instrumentationRegistry.setDefaultLabels(labels);
   global.collectMetricsInitialized = true;
 }
+
+// NOTE: the instrumentation-registry metrics (eventloop long-task) intentionally do
+// NOT set an app-side `podname` default label. Like every other custom app metric
+// (trpc_procedure_duration, cache_hit_total, …) they get per-pod identity from
+// Prometheus' scrape-time `pod` label (honorLabels: true in the ServiceMonitor); an
+// app-emitted `podname` here would be redundant and inconsistent with the siblings.
 
 const handler = WebhookEndpoint(async (_, res: NextApiResponse) => {
   const metrics = await client.register.metrics();

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -20,6 +20,10 @@ if (!global.collectMetricsInitialized) {
     register: client.register,
     labels,
   });
+  // Apply the same default labels (e.g. podname) to the cross-graph instrumentation
+  // registry so its series (eventloop long-task metrics) carry podname like every
+  // other app metric — otherwise per-pod attribution on those series is lost.
+  instrumentationRegistry.setDefaultLabels(labels);
   global.collectMetricsInitialized = true;
 }
 

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -2,6 +2,7 @@ import type { NextApiResponse } from 'next';
 import { EOL } from 'os';
 import client from 'prom-client';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { instrumentationRegistry } from '~/server/prom/client';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 const labels: Record<string, string> = {};
@@ -25,6 +26,12 @@ if (!global.collectMetricsInitialized) {
 const handler = WebhookEndpoint(async (_, res: NextApiResponse) => {
   const metrics = await client.register.metrics();
 
+  // Metrics emitted from the instrumentation webpack graph (e.g. the event-loop
+  // long-task detector) live in a separate `client.register` than this request-graph
+  // one, so they must be scraped from the cross-graph shared `instrumentationRegistry`
+  // explicitly. See the WHY note on instrumentationRegistry in src/server/prom/client.ts.
+  const instrumentationMetrics = await instrumentationRegistry.metrics();
+
   const readMetrics = await dbRead.$metrics.prometheus({
     globalLabels: {
       ...labels,
@@ -39,7 +46,7 @@ const handler = WebhookEndpoint(async (_, res: NextApiResponse) => {
     },
   });
 
-  const result = [metrics, readMetrics, writeMetrics].join(EOL);
+  const result = [metrics, instrumentationMetrics, readMetrics, writeMetrics].join(EOL);
 
   res.setHeader('Content-type', client.register.contentType);
   res.send(result);

--- a/src/server/__tests__/eventloop-longtask-metrics.test.ts
+++ b/src/server/__tests__/eventloop-longtask-metrics.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import client from 'prom-client';
+
+// ---------------------------------------------------------------------------
+// WHY THIS TEST EXISTS
+//
+// The eventloop-longtask metrics shipped broken (civitai PR #2451): the Axiom log
+// line fired on every detected block, but the Prometheus counter stayed 0, the
+// histogram never exported, and the lag gauge never appeared. Root cause: the
+// metrics were registered in a DIFFERENT prom-client registry (the instrumentation
+// webpack graph's `client.register`) than the one /metrics scrapes (the request
+// graph's), so `.inc()`/`.observe()`/`collect()` updated objects nobody scraped.
+//
+// The fix registers all three metrics into a single globalThis-pinned
+// `instrumentationRegistry` and merges it into /metrics. This test proves the
+// emission path (recordDrift) actually mutates the REGISTERED metric — asserted by
+// reading the registry, NOT a throwaway mock — and that the gauge is registered and
+// collectable. The original test mocked prom/client with disposable `{inc: vi.fn()}`
+// objects, which is exactly why the bug got through.
+// ---------------------------------------------------------------------------
+
+// A real registry that stands in for the cross-graph shared `instrumentationRegistry`.
+// Using a real prom-client Registry (not a mock) is the whole point: it's the object
+// the assertions read, and the same object the module-under-test registers into.
+// vi.hoisted so it's initialized before the hoisted vi.mock factory references it.
+const { testRegistry } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const promClient = require('prom-client');
+  return { testRegistry: new promClient.Registry() as client.Registry };
+});
+
+// Override the global setup.ts mock of ~/server/prom/client with REAL registry
+// semantics, but WITHOUT importing the real module (which pulls in DB pools). The
+// shape mirrors the real exports the module-under-test uses.
+vi.mock('~/server/prom/client', () => {
+  function registerInstrumentationMetric<M extends client.Metric<string>>(
+    name: string,
+    factory: () => M
+  ): M {
+    const existing = testRegistry.getSingleMetric(name);
+    if (existing) return existing as unknown as M;
+    return factory();
+  }
+  return {
+    instrumentationRegistry: testRegistry,
+    registerInstrumentationMetric,
+    // Legacy helpers the module no longer uses, kept for any incidental import.
+    registerCounter: () => ({ inc: vi.fn() }),
+    registerHistogram: () => ({ observe: vi.fn() }),
+  };
+});
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  recordDrift,
+  classifyDrift,
+  __initEventLoopDelayGaugesForTests,
+  type DriftClassification,
+} from '~/server/eventloop-longtask';
+
+const PREFIX = 'civitai_app_';
+const COUNTER = PREFIX + 'eventloop_longtask_total';
+const SUSPENSION = PREFIX + 'eventloop_longtask_suspension_total';
+const HISTOGRAM = PREFIX + 'eventloop_longtask_duration_seconds';
+const GAUGE = PREFIX + 'eventloop_delay_ms';
+
+const block = (blockedMs: number): DriftClassification => ({ kind: 'block', blockedMs });
+const suspension = (gapMs: number): DriftClassification => ({ kind: 'suspension', gapMs });
+
+// Read the current value of a single child series from the shared registry. Reading
+// from the REGISTRY (not the metric object directly) is what proves the metric the
+// detector mutates is the one that gets scraped.
+async function counterValue(name: string): Promise<number> {
+  const metric = testRegistry.getSingleMetric(name) as client.Counter<string> | undefined;
+  if (!metric) return NaN;
+  const { values } = await metric.get();
+  return values.reduce((sum, v) => sum + v.value, 0);
+}
+
+async function histogramCount(name: string, label: string): Promise<number> {
+  const metric = testRegistry.getSingleMetric(name) as client.Histogram<string> | undefined;
+  if (!metric) return NaN;
+  const { values } = await metric.get();
+  // The _count series carries metricName + '_count' and the matching label set.
+  const countSeries = values.find(
+    (v) => v.metricName === `${name}_count` && v.labels.label === label
+  );
+  return countSeries?.value ?? 0;
+}
+
+describe('eventloop-longtask metrics: emission reaches the REGISTERED metric', () => {
+  const recordOpts = { logMinMs: 50, threshold: 50, logPerMin: 30 };
+
+  it('registers all three metrics in the shared instrumentation registry on import', () => {
+    // Importing the module evaluates the module-level metric construction.
+    expect(testRegistry.getSingleMetric(COUNTER)).toBeDefined();
+    expect(testRegistry.getSingleMetric(SUSPENSION)).toBeDefined();
+    expect(testRegistry.getSingleMetric(HISTOGRAM)).toBeDefined();
+  });
+
+  it('a detected block INCREMENTS the registered counter (the bug: it stayed 0)', async () => {
+    const before = await counterValue(COUNTER);
+    recordDrift(block(735), recordOpts); // 735ms — the exact prod log example
+    const after = await counterValue(COUNTER);
+    expect(after).toBe(before + 1);
+  });
+
+  it('a detected block OBSERVES the registered histogram (the bug: never exported)', async () => {
+    const before = await histogramCount(HISTOGRAM, 'unlabeled');
+    recordDrift(block(120), recordOpts);
+    const after = await histogramCount(HISTOGRAM, 'unlabeled');
+    expect(after).toBe(before + 1);
+
+    // And the histogram now exports at least one series via the registry scrape.
+    const scraped = await testRegistry.getSingleMetricAsString(HISTOGRAM);
+    expect(scraped).toContain(HISTOGRAM);
+    expect(scraped).toContain('label="unlabeled"');
+  });
+
+  it('multiple blocks accumulate on the registered counter', async () => {
+    const before = await counterValue(COUNTER);
+    recordDrift(block(60), recordOpts);
+    recordDrift(block(900), recordOpts);
+    recordDrift(block(51), recordOpts);
+    expect(await counterValue(COUNTER)).toBe(before + 3);
+  });
+
+  it('a suspension increments the suspension counter, NOT the block counter/histogram', async () => {
+    const blockBefore = await counterValue(COUNTER);
+    const histBefore = await histogramCount(HISTOGRAM, 'unlabeled');
+    const suspBefore = await counterValue(SUSPENSION);
+
+    recordDrift(suspension(8000), recordOpts);
+
+    expect(await counterValue(SUSPENSION)).toBe(suspBefore + 1);
+    expect(await counterValue(COUNTER)).toBe(blockBefore); // unchanged
+    expect(await histogramCount(HISTOGRAM, 'unlabeled')).toBe(histBefore); // unchanged
+  });
+
+  it('an ok (sub-threshold) result touches no metric', async () => {
+    const c = await counterValue(COUNTER);
+    const s = await counterValue(SUSPENSION);
+    recordDrift({ kind: 'ok', blockedMs: 10 }, recordOpts);
+    expect(await counterValue(COUNTER)).toBe(c);
+    expect(await counterValue(SUSPENSION)).toBe(s);
+  });
+
+  it('the recordDrift path matches what classifyDrift produces end-to-end', async () => {
+    // A real 320ms gap at tick=20 => block of 300ms => counter +1, histogram +1.
+    const cBefore = await counterValue(COUNTER);
+    const hBefore = await histogramCount(HISTOGRAM, 'unlabeled');
+    const classified = classifyDrift(1320, 1000, 20, 50, 5000);
+    expect(classified).toEqual({ kind: 'block', blockedMs: 300 });
+    recordDrift(classified, recordOpts);
+    expect(await counterValue(COUNTER)).toBe(cBefore + 1);
+    expect(await histogramCount(HISTOGRAM, 'unlabeled')).toBe(hBefore + 1);
+  });
+});
+
+describe('eventloop-longtask metrics: lag gauge is registered + collectable when armed', () => {
+  beforeAll(() => {
+    __initEventLoopDelayGaugesForTests();
+  });
+
+  it('registers civitai_app_eventloop_delay_ms in the shared registry', () => {
+    expect(testRegistry.getSingleMetric(GAUGE)).toBeDefined();
+  });
+
+  it('the gauge collect() hook runs on scrape and emits quantile series', async () => {
+    // metrics() triggers each metric's collect(); the gauge reads the live libuv
+    // histogram and sets p50/p90/p99/max/mean. This is the path that produced ZERO
+    // series before the fix.
+    const scraped = await testRegistry.getSingleMetricAsString(GAUGE);
+    expect(scraped).toContain(GAUGE);
+    expect(scraped).toContain('quantile="p50"');
+    expect(scraped).toContain('quantile="p99"');
+    expect(scraped).toContain('quantile="mean"');
+  });
+});

--- a/src/server/__tests__/eventloop-longtask.test.ts
+++ b/src/server/__tests__/eventloop-longtask.test.ts
@@ -5,9 +5,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // booting prom-client registries or the Axiom logger. These mocks are inert; the
 // tests here exercise the pure drift math and the disarmed-passthrough guarantee.
 // ---------------------------------------------------------------------------
+// The module-under-test registers its metrics into the cross-graph shared
+// `instrumentationRegistry`. Give it a real throwaway registry so the module imports
+// cleanly here; metric EMISSION is asserted against a real registry in the sibling
+// eventloop-longtask-metrics.test.ts. This suite focuses on drift math + the
+// disarmed-passthrough guarantee.
+const { driftTestRegistry } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const promClient = require('prom-client');
+  return { driftTestRegistry: new promClient.Registry() };
+});
+
 vi.mock('~/server/prom/client', () => ({
   registerCounter: () => ({ inc: vi.fn() }),
   registerHistogram: () => ({ observe: vi.fn() }),
+  instrumentationRegistry: driftTestRegistry,
+  registerInstrumentationMetric: (name: string, factory: () => unknown) => {
+    const existing = driftTestRegistry.getSingleMetric(name);
+    return existing ?? factory();
+  },
 }));
 
 vi.mock('~/server/logging/client', () => ({

--- a/src/server/eventloop-longtask.ts
+++ b/src/server/eventloop-longtask.ts
@@ -301,11 +301,13 @@ function initEventLoopDelayGauges(): void {
   // One labeled gauge emitting p50/p99/max/mean (ms). collect() reads the live
   // libuv histogram on each scrape — no per-event JS work.
   //
-  // Registered with `registers: []` so the constructor does NOT auto-add it to the
-  // default per-graph globalRegistry; we then register it into the cross-graph
-  // shared `instrumentationRegistry` via registerInstrumentationMetric (idempotent
-  // under HMR). The collect() hook fires when that shared registry is scraped, which
-  // /metrics does by merging it in.
+  // Registered directly into the cross-graph shared `instrumentationRegistry` (via
+  // `registers: [instrumentationRegistry]` below) instead of the default per-graph
+  // globalRegistry. registerInstrumentationMetric is the idempotent get-or-create
+  // guard (safe under HMR / dual-graph eval). The collect() hook fires when that
+  // shared registry is scraped, which /metrics reads in explicitly by
+  // string-concatenating its output (NOT Registry.merge — so it can't throw on a
+  // name clash).
   registerInstrumentationMetric(
     PROM_PREFIX + 'eventloop_delay_ms',
     () =>
@@ -314,7 +316,7 @@ function initEventLoopDelayGauges(): void {
         help: 'Event-loop delay (lag) distribution from perf_hooks.monitorEventLoopDelay, ms. This is the AUTHORITATIVE event-loop lag signal (C++ measured, no JS per-event cost).',
         labelNames: ['quantile'],
         // Register into the shared cross-graph registry (NOT the default per-graph
-        // globalRegistry) so the collect() hook fires when /metrics merges it in.
+        // globalRegistry) so the collect() hook fires when /metrics reads it in.
         registers: [instrumentationRegistry],
         collect() {
           const h = elDelayHistogram;

--- a/src/server/eventloop-longtask.ts
+++ b/src/server/eventloop-longtask.ts
@@ -49,8 +49,15 @@
 import { AsyncLocalStorage, createHook, type AsyncHook } from 'node:async_hooks';
 import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
 import client from 'prom-client';
-import { registerCounter, registerHistogram } from '~/server/prom/client';
+import { instrumentationRegistry, registerInstrumentationMetric } from '~/server/prom/client';
 import { logToAxiom } from '~/server/logging/client';
+
+// Prefix mirrors prom/client.ts's PROM_PREFIX so series names match the rest of the
+// app (civitai_app_*). We register these into the cross-graph `instrumentationRegistry`
+// (NOT the default per-graph `client.register`) because the detector's setInterval and
+// the delay gauge's collect() run in the instrumentation webpack graph, while /metrics
+// scrapes from the request graph — see the long WHY note on instrumentationRegistry.
+const PROM_PREFIX = 'civitai_app_';
 
 // ---------------------------------------------------------------------------
 // Config (env-tunable)
@@ -239,26 +246,44 @@ function installStackHook(sampleEvery: number, mapCap: number): void {
 // labels tier on, `label` is the same fixed tRPC-procedure / route enum that
 // trpc_procedure_duration already uses. Buckets target the 50ms..several-seconds
 // range that matters for pins.
-const longTaskHistogram = registerHistogram({
-  name: 'eventloop_longtask_duration_seconds',
-  help: 'Synchronous event-loop blocks over threshold, by attributed operation label. NOTE: drift-timer based — counts include GC pauses and (below the suspension cap) brief CPU-steal, not only JS blocks. The authoritative lag signal is civitai_app_eventloop_delay_ms.',
-  labelNames: ['label'] as const,
-  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
-});
+const longTaskHistogram = registerInstrumentationMetric(
+  PROM_PREFIX + 'eventloop_longtask_duration_seconds',
+  () =>
+    new client.Histogram({
+      name: PROM_PREFIX + 'eventloop_longtask_duration_seconds',
+      help: 'Synchronous event-loop blocks over threshold, by attributed operation label. NOTE: drift-timer based — counts include GC pauses and (below the suspension cap) brief CPU-steal, not only JS blocks. The authoritative lag signal is civitai_app_eventloop_delay_ms.',
+      labelNames: ['label'] as const,
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+      // Register into the shared cross-graph registry instead of the default
+      // (per-graph) globalRegistry, so the request-graph /metrics scrape sees the
+      // observes made from the instrumentation-graph detector loop.
+      registers: [instrumentationRegistry],
+    })
+);
 
 // Cheap always-armed count of detected long tasks (no label) — a single series
 // that's safe to alert on even if label cardinality is ever a concern.
-const longTaskCounter = registerCounter({
-  name: 'eventloop_longtask_total',
-  help: 'Total event-loop blocks detected over threshold (drift-timer based; includes GC pauses)',
-});
+const longTaskCounter = registerInstrumentationMetric(
+  PROM_PREFIX + 'eventloop_longtask_total',
+  () =>
+    new client.Counter({
+      name: PROM_PREFIX + 'eventloop_longtask_total',
+      help: 'Total event-loop blocks detected over threshold (drift-timer based; includes GC pauses)',
+      registers: [instrumentationRegistry],
+    })
+);
 
 // Count of gaps classified as process suspension (over the suspension cap) and
 // therefore NOT recorded as JS blocks — surfaces pod CPU-steal / VM suspend.
-const suspensionCounter = registerCounter({
-  name: 'eventloop_longtask_suspension_total',
-  help: 'Drift-timer gaps over the suspension cap, treated as process suspension (CPU-steal/VM suspend), not JS blocks',
-});
+const suspensionCounter = registerInstrumentationMetric(
+  PROM_PREFIX + 'eventloop_longtask_suspension_total',
+  () =>
+    new client.Counter({
+      name: PROM_PREFIX + 'eventloop_longtask_suspension_total',
+      help: 'Drift-timer gaps over the suspension cap, treated as process suspension (CPU-steal/VM suspend), not JS blocks',
+      registers: [instrumentationRegistry],
+    })
+);
 
 // monitorEventLoopDelay() histogram, surfaced as collect()-based gauges (matching
 // the pg-pool gauge pattern in prom/client.ts). Reset after each scrape so each
@@ -275,30 +300,37 @@ function initEventLoopDelayGauges(): void {
 
   // One labeled gauge emitting p50/p99/max/mean (ms). collect() reads the live
   // libuv histogram on each scrape — no per-event JS work.
-  const g = new client.Gauge({
-    name: 'civitai_app_eventloop_delay_ms',
-    help: 'Event-loop delay (lag) distribution from perf_hooks.monitorEventLoopDelay, ms. This is the AUTHORITATIVE event-loop lag signal (C++ measured, no JS per-event cost).',
-    labelNames: ['quantile'],
-    collect() {
-      const h = elDelayHistogram;
-      if (!h) return;
-      const toMs = (ns: number) => (Number.isFinite(ns) ? ns / 1e6 : 0);
-      this.set({ quantile: 'p50' }, toMs(h.percentile(50)));
-      this.set({ quantile: 'p90' }, toMs(h.percentile(90)));
-      this.set({ quantile: 'p99' }, toMs(h.percentile(99)));
-      this.set({ quantile: 'max' }, toMs(h.max));
-      this.set({ quantile: 'mean' }, toMs(h.mean));
-      // Reset so the next scrape window is independent (avoids max/p99 sticking
-      // at an all-time high forever after a single spike).
-      h.reset();
-    },
-  });
-  // Guard against double-registration under Next.js HMR.
-  try {
-    client.register.registerMetric(g);
-  } catch {
-    // already registered
-  }
+  //
+  // Registered with `registers: []` so the constructor does NOT auto-add it to the
+  // default per-graph globalRegistry; we then register it into the cross-graph
+  // shared `instrumentationRegistry` via registerInstrumentationMetric (idempotent
+  // under HMR). The collect() hook fires when that shared registry is scraped, which
+  // /metrics does by merging it in.
+  registerInstrumentationMetric(
+    PROM_PREFIX + 'eventloop_delay_ms',
+    () =>
+      new client.Gauge({
+        name: PROM_PREFIX + 'eventloop_delay_ms',
+        help: 'Event-loop delay (lag) distribution from perf_hooks.monitorEventLoopDelay, ms. This is the AUTHORITATIVE event-loop lag signal (C++ measured, no JS per-event cost).',
+        labelNames: ['quantile'],
+        // Register into the shared cross-graph registry (NOT the default per-graph
+        // globalRegistry) so the collect() hook fires when /metrics merges it in.
+        registers: [instrumentationRegistry],
+        collect() {
+          const h = elDelayHistogram;
+          if (!h) return;
+          const toMs = (ns: number) => (Number.isFinite(ns) ? ns / 1e6 : 0);
+          this.set({ quantile: 'p50' }, toMs(h.percentile(50)));
+          this.set({ quantile: 'p90' }, toMs(h.percentile(90)));
+          this.set({ quantile: 'p99' }, toMs(h.percentile(99)));
+          this.set({ quantile: 'max' }, toMs(h.max));
+          this.set({ quantile: 'mean' }, toMs(h.mean));
+          // Reset so the next scrape window is independent (avoids max/p99 sticking
+          // at an all-time high forever after a single spike).
+          h.reset();
+        },
+      })
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -388,6 +420,41 @@ export function classifyDrift(
   return { kind: 'block', blockedMs };
 }
 
+/**
+ * Apply a classified drift result to the Prometheus metrics (and, for blocks over
+ * the log floor, the rate-limited structured log). This is the bridge from the
+ * detector's setInterval to the REGISTERED metric instances — the path that was
+ * silently broken when the metrics were registered in a different (per-graph)
+ * registry than the one /metrics scrapes. Exported so a unit test can assert it
+ * actually increments/observes the registered metric without a real timer.
+ *
+ * Returns the resolved attribution label (or undefined for non-block results) to
+ * make the test assertions explicit; the timer ignores the return.
+ */
+export function recordDrift(
+  result: DriftClassification,
+  opts: { logMinMs: number; threshold: number; logPerMin: number }
+): string | undefined {
+  if (result.kind === 'suspension') {
+    // Descheduled pod / VM suspend / CPU-steal — NOT a JS block. Count it
+    // separately and skip the block histogram + log so we don't emit a fake
+    // multi-second block.
+    suspensionCounter.inc();
+    return undefined;
+  }
+  if (result.kind === 'block') {
+    const { blockedMs } = result;
+    const label = currentLabel();
+    longTaskCounter.inc();
+    longTaskHistogram.observe({ label }, blockedMs / 1000);
+    if (blockedMs >= opts.logMinMs) {
+      tryLog(blockedMs, label, opts.threshold, opts.logPerMin);
+    }
+    return label;
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Arm / detector loop
 // ---------------------------------------------------------------------------
@@ -441,20 +508,7 @@ export function registerEventLoopLongTaskDetector(): void {
       const result = classifyDrift(now, last, tickMs, threshold, suspendCapMs);
       last = now;
 
-      if (result.kind === 'suspension') {
-        // Descheduled pod / VM suspend / CPU-steal — NOT a JS block. Count it
-        // separately and skip the block histogram + log so we don't emit a fake
-        // multi-second block.
-        suspensionCounter.inc();
-      } else if (result.kind === 'block') {
-        const { blockedMs } = result;
-        const label = currentLabel();
-        longTaskCounter.inc();
-        longTaskHistogram.observe({ label }, blockedMs / 1000);
-        if (blockedMs >= logMinMs) {
-          tryLog(blockedMs, label, threshold, logPerMin);
-        }
-      }
+      recordDrift(result, { logMinMs, threshold, logPerMin });
 
       // Clear the sampled stack after each tick so a stale stack from a previous
       // tick can't be mis-attributed to a later block. Cheap no-op when stacks
@@ -500,4 +554,14 @@ export function __setLongTaskLabelsArmedForTests(value: boolean): () => void {
 /** Test-only: observe whether the ALS store is currently set (proves no .run()). */
 export function __hasActiveLabelStoreForTests(): boolean {
   return labelStorage.getStore() !== undefined;
+}
+
+/**
+ * Test-only: run the base-armed gauge init (monitorEventLoopDelay + the
+ * civitai_app_eventloop_delay_ms collect()-gauge) so a test can assert the gauge is
+ * registered in the scraped (instrumentation) registry without booting the whole
+ * detector via env. Idempotent — mirrors the base-armed init path.
+ */
+export function __initEventLoopDelayGaugesForTests(): void {
+  initEventLoopDelayGauges();
 }

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -7,6 +7,60 @@ import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb';
 import { bulkheadSnapshot } from '~/server/utils/request-bulkhead';
 
 const PROM_PREFIX = 'civitai_app_';
+
+// ---------------------------------------------------------------------------
+// Cross-graph shared registry (for instrumentation-time metrics)
+// ---------------------------------------------------------------------------
+//
+// WHY: Next.js compiles `instrumentation.ts` into a SEPARATE webpack bundle from
+// the API-route/pages bundle, and `prom-client` is NOT in `serverExternalPackages`
+// (next.config.mjs), so each bundle gets its own copy of the module — and thus its
+// own `client.register` (the prom-client `globalRegistry`). A metric created and
+// mutated from the instrumentation graph (e.g. the event-loop long-task detector's
+// `setInterval`) lands in the instrumentation graph's registry, while `/metrics`
+// (an API route) scrapes the request graph's registry. The two never meet, so the
+// counter/histogram/gauge appear registered-but-never-incremented (or never
+// exported) even though the emitting code runs. See the eventloop-longtask metrics
+// bug (civitai PR #2451).
+//
+// FIX: pin ONE `Registry` on `globalThis` (the real V8 global, shared across all
+// webpack bundles in the same Node process — the same mechanism the
+// `global.pgGaugeInitialized` guards below already rely on). Any metric created in
+// EITHER graph registers into this single object, and `/metrics` merges it into the
+// scrape. This is required only for metrics emitted from the instrumentation graph;
+// request-graph-only metrics already work because they emit + scrape in one graph.
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiInstrumentationRegistry: client.Registry | undefined;
+}
+
+export const instrumentationRegistry: client.Registry =
+  globalThis.__civitaiInstrumentationRegistry ??
+  (globalThis.__civitaiInstrumentationRegistry = new client.Registry());
+
+/**
+ * Get-or-create a metric in the cross-graph shared `instrumentationRegistry`,
+ * idempotently. Use this for any metric created or mutated from the instrumentation
+ * graph (`instrumentation.ts` subtree) so that `/metrics` — scraped from the request
+ * graph — can actually see it.
+ *
+ * The metric is created via `factory` which MUST construct it with
+ * `registers: [instrumentationRegistry]` (so it lands in the shared registry, not
+ * the default per-graph one). Because both webpack graphs eval the same module-level
+ * code against the SAME globalThis-pinned registry, the second graph (and HMR
+ * re-evals) would otherwise throw "already registered" inside the constructor — so we
+ * short-circuit to the existing instance BEFORE calling `factory`. Returns the single
+ * shared instance either way.
+ */
+export function registerInstrumentationMetric<M extends client.Metric<string>>(
+  name: string,
+  factory: () => M
+): M {
+  const existing = instrumentationRegistry.getSingleMetric(name);
+  if (existing) return existing as unknown as M;
+  return factory();
+}
+
 export function registerCounter({ name, help }: { name: string; help: string }) {
   // Do this to deal with HMR in nextjs
   try {


### PR DESCRIPTION
## Summary

The event-loop long-task detector (PR #2451) was **detecting blocks and logging them to Axiom correctly** — only the **Prometheus path was broken**. On armed pods (`EVENTLOOP_LONGTASK_THRESHOLD_MS=50`):

- `civitai_app_eventloop_longtask_total` — registered (~159 series across pods) but stayed **0**.
- `civitai_app_eventloop_longtask_duration_seconds` (histogram) — **never exported**.
- `civitai_app_eventloop_delay_ms` (lag gauge) — **never exported**, even though it should emit always-when-armed.

Meanwhile the structured Axiom log line (`{"name":"eventloop-longtask","durationMs":735,...}`) fired on every block. So the logging path worked; the metric `.inc()` / `.observe()` / gauge-`collect()` path never reached the registry Prometheus scrapes.

## Root cause (module-graph split)

Next.js compiles `instrumentation.ts` into a **separate webpack bundle** from the API-route/pages bundle, and `prom-client` is **not** in `serverExternalPackages` (`next.config.mjs`). So each bundle gets its own copy of `prom-client` — and thus its own default `client.register` (the prom-client `globalRegistry`).

- The detector's `setInterval` (`longTaskCounter.inc()` / `longTaskHistogram.observe()` at `eventloop-longtask.ts:452-453` pre-fix) and `initEventLoopDelayGauges()` run in the **instrumentation graph** → they mutate metrics in *that* graph's registry.
- `/metrics` (`src/pages/api/metrics.ts`) is an API route → it scrapes the **request graph's** `client.register`.

The two registries never meet.

The counter still showed **159 series at 0** because `eventloop-longtask.ts` is *also* imported by the request graph (`src/server/trpc.ts:13` and `src/pages/api/v1/images/index.ts:23`, for `runWithLongTaskLabel`). That re-evaluates the module-level `registerCounter()` / `registerHistogram()` in the **request-graph** registry — registering the series there (a no-label Counter eagerly exports its `0` child) but never incrementing them, since the timer only runs in the instrumentation graph. The histogram exports nothing until first `observe()` (which never happens in the request graph), and the gauge is only ever created by `initEventLoopDelayGauges()` in the instrumentation graph, so it never reaches the scraped registry at all.

### Working-metric comparison

`trpcProcedureDuration` (`prom/client.ts:165`) uses the **same** `registerHistogram` helper but works — because it is `.observe()`'d from `src/server/trpc.ts:221` (request graph) and scraped from the same request-graph `client.register`. Same graph → emit and scrape agree. The eventloop metrics emit from a *different* graph than they're scraped from. That's the entire bug.

## Fix

Register all three metrics into a single `Registry` **pinned on `globalThis`** (`instrumentationRegistry` in `prom/client.ts`). `globalThis` is the real V8 global, shared across every webpack bundle in the Node process — the same mechanism the existing `global.pgGaugeInitialized` / `global.heavyBulkheadGaugeInitialized` guards already rely on. `/metrics` merges that registry into the scrape output.

- Metrics are constructed with `registers: [instrumentationRegistry]` so they land only in the shared registry (verified: this does **not** also add them to the default registry, so no duplicate series).
- A get-or-create factory guard (`registerInstrumentationMetric`) short-circuits before the constructor runs, so the second graph's module-eval (and HMR) doesn't throw `"already registered"`.
- Metric **names, labels, and buckets are unchanged**: `civitai_app_eventloop_longtask_total`, `_suspension_total`, `_duration_seconds{label}`, `civitai_app_eventloop_delay_ms{quantile}`.
- All of #2451's tiering/overhead behavior is preserved (disarmed = zero-cost, base-armed = no async_hooks, labels/stacks opt-in). The per-tick emission was extracted into an exported `recordDrift()` purely so it can be unit-tested without a real timer; the timer now calls it.

## Test

New `src/server/__tests__/eventloop-longtask-metrics.test.ts` asserts **against a real `prom-client` Registry** (not a throwaway mock) that:
- all three metrics are registered in the shared registry on import;
- a detected block **increments the registered counter** and **observes the registered histogram** (read back via `registry.getSingleMetric(...).get()` / `getSingleMetricAsString`);
- a suspension hits only the suspension counter, leaving the block counter/histogram untouched;
- the lag gauge is registered and its `collect()` hook emits `quantile=` series on scrape.

This is the coverage gap that let the bug ship — the prior test mocked `~/server/prom/client` with disposable `{ inc: vi.fn() }` objects, so it never exercised the real registry.

## Validation

- `npx vitest run` — 21 passed (12 existing + 9 new).
- `pnpm run lint` — clean on the changed source files (the test-file `parserOptions.project` parse error is pre-existing/environmental and also affects the original test).
- `pnpm run typecheck` — no new errors in the touched files; remaining errors are the known stale-Prisma-client cascade present on `main` at HEAD too.

## Note

The Axiom structured logging was **always working** in prod — this PR fixes only the Prometheus emission path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)