### PR TITLE
feat(build): ship server source maps for prod CPU-profile de-minification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,21 +48,36 @@ RUN --mount=type=cache,target=/app/.next/cache \
 
 # Server source maps (.next/server/**/*.js.map) are emitted by the build
 # (productionBrowserSourceMaps -> turbopackSourceMaps) but @vercel/nft does NOT
-# trace sibling .map files into .next/standalone, so they'd be missing at runtime.
-# Collect ONLY the server-chunk maps into a structure-preserving staging dir so the
-# runner can overlay them onto the standalone tree without dragging in untraced .js
-# chunks. Maps are inert at runtime (loaded only by an inspector/stack resolver),
-# so this adds image size but no request-path cost.
+# trace sibling .map files into .next/standalone, so they never reach runtime.
+# Collect ONLY the server-chunk maps into a structure-preserving staging dir.
+# These are NOT shipped in the runtime image (they added ~761 MB to every prod
+# pod — too much for a debug aid). Instead they are published as a separate,
+# fetched-on-demand `maps` artifact image (see the `maps` target below + the
+# Tekton maps-publish step), keyed by the same tag as the runtime image, so a
+# `.cpuprofile` captured from image X can be de-minified offline against X's maps.
 # Build-chunk map filenames are content hashes (no spaces/newlines), so the
 # newline-delimited `tar -T -` files-from list is safe and works under both GNU tar
 # and busybox tar (alpine). `tar | tar` preserves the dir structure
-# (e.g. chunks/<hash>.js.map) so each map lands next to its .js in the runner.
+# (e.g. chunks/<hash>.js.map) so each map keeps its .next/server-relative path.
 # (Comments must stay OUTSIDE the RUN: Docker collapses the \-continuations into one
 # line, where an inline `#` would swallow the rest of the command.)
 RUN mkdir -p /app/server-maps && \
     cd /app/.next/server && \
     { find . -name '*.js.map' | tar -cf - -T - | tar -xf - -C /app/server-maps || true; } && \
     echo "Staged $(find /app/server-maps -name '*.js.map' | wc -l) server source maps ($(du -sh /app/server-maps | cut -f1))"
+
+##### MAPS ARTIFACT (fetched on-demand; NOT part of the runtime image)
+#
+# A minimal `FROM scratch` image holding ONLY the staged server source maps,
+# under /server-maps mirroring the .next/server tree. Published to a sibling
+# registry repo (ghcr.io/civitai/civitai-web-maps:<same-tag>) by the Tekton
+# maps-publish step using the SAME ghcr credentials as the runtime push — no new
+# secrets. It shares every builder layer with the runtime build, so building this
+# target is a buildkit cache hit plus one small layer; it is never pulled by a
+# running pod. The cpuprofile resolver fetches it on demand keyed by image tag
+# (scripts/resolve-cpuprofile.mjs --image ...).
+FROM scratch AS maps
+COPY --from=builder /app/server-maps/ /server-maps/
 
 ##### RUNNER
 
@@ -82,11 +97,9 @@ COPY --from=builder /app/package.json ./package.json
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-# Overlay server-chunk source maps that nft drops from the standalone trace.
-# Structure mirrors .next/server, so this lands each <chunk>.js.map next to the
-# <chunk>.js the standalone tree already shipped. Used offline by the cpuprofile
-# resolver — never read on the request path.
-COPY --from=builder --chown=nextjs:nodejs /app/server-maps/ ./.next/server/
+# NOTE: server source maps are intentionally NOT copied into the runtime image.
+# They are published as the separate `maps` target above (fetched on-demand by
+# the cpuprofile resolver), keeping the prod pod lean (~761 MB smaller).
 
 USER nextjs
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,24 @@ ARG NODE_BUILD_MEM=8192
 RUN --mount=type=cache,target=/app/.next/cache \
     SKIP_ENV_VALIDATION=1 IS_BUILD=true NODE_OPTIONS="--max_old_space_size=${NODE_BUILD_MEM}" pnpm run build
 
+# Server source maps (.next/server/**/*.js.map) are emitted by the build
+# (productionBrowserSourceMaps -> turbopackSourceMaps) but @vercel/nft does NOT
+# trace sibling .map files into .next/standalone, so they'd be missing at runtime.
+# Collect ONLY the server-chunk maps into a structure-preserving staging dir so the
+# runner can overlay them onto the standalone tree without dragging in untraced .js
+# chunks. Maps are inert at runtime (loaded only by an inspector/stack resolver),
+# so this adds image size but no request-path cost.
+# Build-chunk map filenames are content hashes (no spaces/newlines), so the
+# newline-delimited `tar -T -` files-from list is safe and works under both GNU tar
+# and busybox tar (alpine). `tar | tar` preserves the dir structure
+# (e.g. chunks/<hash>.js.map) so each map lands next to its .js in the runner.
+# (Comments must stay OUTSIDE the RUN: Docker collapses the \-continuations into one
+# line, where an inline `#` would swallow the rest of the command.)
+RUN mkdir -p /app/server-maps && \
+    cd /app/.next/server && \
+    { find . -name '*.js.map' | tar -cf - -T - | tar -xf - -C /app/server-maps || true; } && \
+    echo "Staged $(find /app/server-maps -name '*.js.map' | wc -l) server source maps ($(du -sh /app/server-maps | cut -f1))"
+
 ##### RUNNER
 
 FROM node:20-alpine3.20 AS runner
@@ -64,6 +82,11 @@ COPY --from=builder /app/package.json ./package.json
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# Overlay server-chunk source maps that nft drops from the standalone trace.
+# Structure mirrors .next/server, so this lands each <chunk>.js.map next to the
+# <chunk>.js the standalone tree already shipped. Used offline by the cpuprofile
+# resolver — never read on the request path.
+COPY --from=builder --chown=nextjs:nodejs /app/server-maps/ ./.next/server/
 
 USER nextjs
 EXPOSE 3000

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -76,10 +76,25 @@ export default defineNextConfig(
       return config;
     },
     reactStrictMode: true,
-    // TEST: re-enabled to evaluate Turbopack source-map output (server + client).
-    // Safe now that the typed-scss-modules `*.module.scss.d.ts` files are removed
-    // (they previously crashed source-map generation). Note: Turbopack ignores
-    // `experimental.serverSourceMaps` (webpack-only); this is the only map lever it reads.
+    // Source maps for prod CPU-profile de-minification.
+    //
+    // Under Turbopack (our prod bundler, Next 16), the ONLY source-map lever is the
+    // experimental `turbopackSourceMaps` flag, whose build-time default IS
+    // `productionBrowserSourceMaps`. So setting this `true` turns on map emission for
+    // BOTH client (`.next/static/**/*.js.map`) and server (`.next/server/**/*.js.map`)
+    // chunks. Turbopack ignores `experimental.serverSourceMaps` (webpack-only) — that
+    // flag below only matters for the `next build --webpack` fallback path.
+    //
+    // Maps are inert at runtime: the Node server never loads a `.js.map` unless an
+    // inspector / error-stack resolver reads it, so there is NO request-path perf cost.
+    // They are NOT served to browsers for server chunks (those live in `.next/server`,
+    // which is not a static-served directory). Cost is build time + image size only.
+    //
+    // IMPORTANT: `output:'standalone'` traces required files via @vercel/nft, which
+    // follows `import`/`require`/`fs` — it does NOT trace sibling `.js.map` files, so
+    // the server maps are emitted to `.next/server` but DROPPED from `.next/standalone`.
+    // The Dockerfile re-copies `.next/server/**/*.js.map` into the runtime image
+    // explicitly (see the RUNNER stage) so prod profiles can be de-minified.
     productionBrowserSourceMaps: true,
     // Next.js i18n docs: https://nextjs.org/docs/advanced-features/i18n-routing
     i18n: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -93,8 +93,11 @@ export default defineNextConfig(
     // IMPORTANT: `output:'standalone'` traces required files via @vercel/nft, which
     // follows `import`/`require`/`fs` — it does NOT trace sibling `.js.map` files, so
     // the server maps are emitted to `.next/server` but DROPPED from `.next/standalone`.
-    // The Dockerfile re-copies `.next/server/**/*.js.map` into the runtime image
-    // explicitly (see the RUNNER stage) so prod profiles can be de-minified.
+    // The runtime image does NOT ship these maps (the RUNNER stage copies only
+    // standalone + static). The build instead publishes them as a separate
+    // `civitai-web-maps:<tag>` artifact (Dockerfile `maps` target + the pipeline),
+    // fetched on demand by `scripts/resolve-cpuprofile.mjs --image <tag>` to
+    // de-minify a captured profile — keeping the runtime image lean.
     productionBrowserSourceMaps: true,
     // Next.js i18n docs: https://nextjs.org/docs/advanced-features/i18n-routing
     i18n: {

--- a/scripts/resolve-cpuprofile.mjs
+++ b/scripts/resolve-cpuprofile.mjs
@@ -327,6 +327,9 @@ async function main() {
   }
 
   let resolver = null;
+  // try/finally so a fetched maps temp dir (can be ~hundreds of MB) is always
+  // cleaned up, even if resolution throws partway through.
+  try {
   if (args.resolve) {
     const sm = await loadSourceMapModule();
     const mapIndex = await indexMaps(mapsDir);
@@ -441,8 +444,10 @@ async function main() {
     }
   }
 
-  if (resolver) resolver.destroy();
-  if (fetchCleanup) await fetchCleanup();
+  } finally {
+    if (resolver) resolver.destroy();
+    if (fetchCleanup) await fetchCleanup();
+  }
 }
 
 main().catch((err) => {

--- a/scripts/resolve-cpuprofile.mjs
+++ b/scripts/resolve-cpuprofile.mjs
@@ -6,21 +6,40 @@
 // WHY: prod pods emit V8 `.cpuprofile`s to find what blocks the event loop, but the
 // standalone build's server chunks are minified, so frames read like
 // `p @ chunks/_0eaaij7._.js:4398:12` — unnameable. This tool loads the matching
-// `.js.map` files (now shipped in the image; see Dockerfile RUNNER stage) and rewrites
-// each frame's `(url, lineNumber, columnNumber)` back to its original
-// `source.ts:line:col` + original function name via the `source-map` package.
+// `.js.map` files and rewrites each frame's `(url, lineNumber, columnNumber)` back to
+// its original `source.ts:line:col` + original function name via `source-map`.
+//
+// Server source maps are NOT shipped in the runtime image (they added ~761 MB per
+// prod pod). They are published per build as a separate, fetched-on-demand artifact
+// image `ghcr.io/civitai/civitai-web-maps:<tag>` keyed by the SAME tag as the runtime
+// image. This tool can fetch that artifact for a given tag (`--image`) and resolve
+// against it, OR resolve against a local maps dir (`--maps`).
 //
 // USAGE:
+//   # Fetch the maps for the build that produced the profile, then resolve:
+//   node scripts/resolve-cpuprofile.mjs <profile.cpuprofile> --image <tag-or-ref> [options]
+//   # Or resolve against a local directory of .js.map files:
 //   node scripts/resolve-cpuprofile.mjs <profile.cpuprofile> --maps <dir-of-js.map> [options]
 //
 // OPTIONS:
-//   --maps <dir>        Directory to search recursively for `<chunk>.js.map` files.
-//                       In the deployed image this is `.next/server`. (required)
+//   --image <ref>       Fetch this build's server maps from the maps artifact image,
+//                       then resolve. <ref> may be a bare tag (e.g. v5.0.1806-datapacket
+//                       or 20260610123456-abc1234) — expanded against --maps-repo
+//                       (default ghcr.io/civitai/civitai-web-maps) — or a full
+//                       repo:tag reference. Requires `crane` (or `oras`) on PATH and
+//                       registry read auth (e.g. `crane auth login ghcr.io`, or a
+//                       docker config already logged in). Mutually exclusive with --maps.
+//   --maps-repo <repo>  Override the maps artifact repo used to expand a bare --image
+//                       tag (default ghcr.io/civitai/civitai-web-maps).
+//   --maps <dir>        Directory to search recursively for `<chunk>.js.map` files
+//                       (offline/local mode; e.g. an already-extracted maps tree).
 //   --top <n>           Show the N hottest self-time functions (default 25).
 //   --block             Run the "longest synchronous block" analysis (see below) and
 //                       print its stack, de-minified.
 //   --json              Emit the full resolved profile as JSON instead of a report.
 //   --no-resolve        Skip map resolution (raw frames) — useful to diff before/after.
+//
+// Exactly one of --image or --maps is required (unless --no-resolve).
 //
 // "Longest synchronous block": V8 sampling profiles record per-sample deltas
 // (`timeDeltas`). A run of consecutive samples that stay inside the same top-of-stack
@@ -31,10 +50,14 @@
 // V8 coordinate convention: callFrame.lineNumber / columnNumber are 0-based.
 // `source-map` originalPositionFor wants { line: 1-based, column: 0-based }.
 
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, stat, mkdtemp, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
+
+const DEFAULT_MAPS_REPO = 'ghcr.io/civitai/civitai-web-maps';
 
 // `source-map` is a direct dependency (package.json). Imported lazily so --no-resolve
 // and --help work even if it's somehow absent.
@@ -55,6 +78,8 @@ function parseArgs(argv) {
   const args = {
     profile: /** @type {string | null} */ (null),
     mapsDir: /** @type {string | null} */ (null),
+    image: /** @type {string | null} */ (null),
+    mapsRepo: DEFAULT_MAPS_REPO,
     top: 25,
     block: false,
     json: false,
@@ -63,6 +88,8 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--maps') args.mapsDir = argv[++i];
+    else if (a === '--image') args.image = argv[++i];
+    else if (a === '--maps-repo') args.mapsRepo = argv[++i];
     else if (a === '--top') args.top = Number(argv[++i]);
     else if (a === '--block') args.block = true;
     else if (a === '--json') args.json = true;
@@ -81,8 +108,66 @@ function parseArgs(argv) {
 
 function printHelp() {
   console.log(
-    'Usage: node scripts/resolve-cpuprofile.mjs <profile.cpuprofile> --maps <dir> [--top N] [--block] [--json] [--no-resolve]'
+    'Usage: node scripts/resolve-cpuprofile.mjs <profile.cpuprofile> (--image <tag-or-ref> | --maps <dir>)\n' +
+      '         [--maps-repo <repo>] [--top N] [--block] [--json] [--no-resolve]'
   );
+}
+
+// Resolve a bare tag to a full maps-image reference. A value that already contains
+// a '/' (a repo path) or starts with a registry host is treated as a full ref; a
+// bare tag is expanded against mapsRepo.
+function resolveImageRef(image, mapsRepo) {
+  if (image.includes('/')) return image; // already repo[:tag] or registry/repo:tag
+  // bare tag (possibly with a leading ':' someone added) -> repo:tag
+  const tag = image.startsWith(':') ? image.slice(1) : image;
+  return `${mapsRepo}:${tag}`;
+}
+
+// Fetch the server maps for a build into a fresh temp dir and return that dir.
+// Prefers `crane export` (single static binary, already cached in the Tekton build
+// node); falls back to `oras pull`. The maps artifact stores files under
+// /server-maps mirroring .next/server, so we return <tmp>/server-maps if present
+// (else <tmp>, so a differently-rooted artifact still resolves).
+//
+// Auth: relies on ambient registry auth — a docker config already logged in to the
+// registry (DOCKER_CONFIG / ~/.docker/config.json) or `crane auth login ghcr.io`.
+// No credentials are embedded here.
+async function fetchMapsImage(ref) {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'cpuprofile-maps-'));
+  const haveCrane = spawnSync('crane', ['version'], { stdio: 'ignore' }).status === 0;
+  const haveOras = !haveCrane && spawnSync('oras', ['version'], { stdio: 'ignore' }).status === 0;
+
+  if (!haveCrane && !haveOras) {
+    await rm(tmp, { recursive: true, force: true });
+    throw new Error(
+      "neither 'crane' nor 'oras' found on PATH. Install one " +
+        '(e.g. `go install github.com/google/go-containerregistry/cmd/crane@latest`) ' +
+        'or download a release binary, then ensure registry read auth is configured.'
+    );
+  }
+
+  console.error(`info: fetching maps artifact ${ref} via ${haveCrane ? 'crane' : 'oras'} ...`);
+  let res;
+  if (haveCrane) {
+    // `crane export` streams the image filesystem as a tar; pipe it into tar -x.
+    // Using a shell pipeline keeps memory flat for large map sets.
+    res = spawnSync('sh', ['-c', `crane export "${ref}" - | tar -x -C "${tmp}"`], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+  } else {
+    res = spawnSync('oras', ['pull', ref, '-o', tmp], { stdio: ['ignore', 'inherit', 'inherit'] });
+  }
+  if (res.status !== 0) {
+    await rm(tmp, { recursive: true, force: true });
+    throw new Error(
+      `failed to fetch maps artifact ${ref} (exit ${res.status}). ` +
+        'Check the tag exists in the maps repo and that registry read auth is configured.'
+    );
+  }
+
+  const nested = path.join(tmp, 'server-maps');
+  const dir = existsSync(nested) ? nested : tmp;
+  return { dir, cleanup: () => rm(tmp, { recursive: true, force: true }) };
 }
 
 // Recursively index every *.js.map under dir, keyed by the basename of the
@@ -209,8 +294,12 @@ async function main() {
     printHelp();
     process.exit(1);
   }
-  if (args.resolve && !args.mapsDir) {
-    console.error('error: --maps <dir> is required (or pass --no-resolve).');
+  if (args.image && args.mapsDir) {
+    console.error('error: pass only one of --image or --maps, not both.');
+    process.exit(1);
+  }
+  if (args.resolve && !args.mapsDir && !args.image) {
+    console.error('error: --image <tag-or-ref> or --maps <dir> is required (or pass --no-resolve).');
     process.exit(1);
   }
   if (args.mapsDir && !existsSync(args.mapsDir)) {
@@ -226,14 +315,25 @@ async function main() {
     process.exit(1);
   }
 
+  // If --image was given, fetch that build's maps artifact into a temp dir and
+  // resolve against it (cleaned up before we return).
+  let mapsDir = args.mapsDir;
+  let fetchCleanup = null;
+  if (args.resolve && args.image) {
+    const ref = resolveImageRef(args.image, args.mapsRepo);
+    const fetched = await fetchMapsImage(ref);
+    mapsDir = fetched.dir;
+    fetchCleanup = fetched.cleanup;
+  }
+
   let resolver = null;
   if (args.resolve) {
     const sm = await loadSourceMapModule();
-    const mapIndex = await indexMaps(args.mapsDir);
+    const mapIndex = await indexMaps(mapsDir);
     if (mapIndex.byChunkBasename.size === 0) {
-      console.error(`warn: no .js.map files found under ${args.mapsDir} — frames will be unresolved.`);
+      console.error(`warn: no .js.map files found under ${mapsDir} — frames will be unresolved.`);
     } else {
-      console.error(`info: indexed ${mapIndex.byChunkBasename.size} source maps under ${args.mapsDir}`);
+      console.error(`info: indexed ${mapIndex.byChunkBasename.size} source maps under ${mapsDir}`);
     }
     resolver = makeResolver(sm.SourceMapConsumer, mapIndex);
   }
@@ -276,6 +376,7 @@ async function main() {
     }));
     process.stdout.write(JSON.stringify({ nodes: out }, null, 2) + '\n');
     if (resolver) resolver.destroy();
+    if (fetchCleanup) await fetchCleanup();
     return;
   }
 
@@ -341,6 +442,7 @@ async function main() {
   }
 
   if (resolver) resolver.destroy();
+  if (fetchCleanup) await fetchCleanup();
 }
 
 main().catch((err) => {

--- a/scripts/resolve-cpuprofile.mjs
+++ b/scripts/resolve-cpuprofile.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+// @ts-check
+//
+// resolve-cpuprofile.mjs — de-minify V8 .cpuprofile stacks using server source maps.
+//
+// WHY: prod pods emit V8 `.cpuprofile`s to find what blocks the event loop, but the
+// standalone build's server chunks are minified, so frames read like
+// `p @ chunks/_0eaaij7._.js:4398:12` — unnameable. This tool loads the matching
+// `.js.map` files (now shipped in the image; see Dockerfile RUNNER stage) and rewrites
+// each frame's `(url, lineNumber, columnNumber)` back to its original
+// `source.ts:line:col` + original function name via the `source-map` package.
+//
+// USAGE:
+//   node scripts/resolve-cpuprofile.mjs <profile.cpuprofile> --maps <dir-of-js.map> [options]
+//
+// OPTIONS:
+//   --maps <dir>        Directory to search recursively for `<chunk>.js.map` files.
+//                       In the deployed image this is `.next/server`. (required)
+//   --top <n>           Show the N hottest self-time functions (default 25).
+//   --block             Run the "longest synchronous block" analysis (see below) and
+//                       print its stack, de-minified.
+//   --json              Emit the full resolved profile as JSON instead of a report.
+//   --no-resolve        Skip map resolution (raw frames) — useful to diff before/after.
+//
+// "Longest synchronous block": V8 sampling profiles record per-sample deltas
+// (`timeDeltas`). A run of consecutive samples that stay inside the same top-of-stack
+// leaf (no return to the scheduler) approximates an uninterrupted synchronous block.
+// We find the single longest such run and print its (de-minified) leaf stack — the
+// likely event-loop culprit.
+//
+// V8 coordinate convention: callFrame.lineNumber / columnNumber are 0-based.
+// `source-map` originalPositionFor wants { line: 1-based, column: 0-based }.
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+// `source-map` is a direct dependency (package.json). Imported lazily so --no-resolve
+// and --help work even if it's somehow absent.
+async function loadSourceMapModule() {
+  try {
+    return await import('source-map');
+  } catch {
+    console.error(
+      "error: the 'source-map' package is required for resolution.\n" +
+        '       run `pnpm add -D source-map` (it is already a dependency of this repo),\n' +
+        '       or pass --no-resolve to print raw frames.'
+    );
+    process.exit(1);
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    profile: /** @type {string | null} */ (null),
+    mapsDir: /** @type {string | null} */ (null),
+    top: 25,
+    block: false,
+    json: false,
+    resolve: true,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--maps') args.mapsDir = argv[++i];
+    else if (a === '--top') args.top = Number(argv[++i]);
+    else if (a === '--block') args.block = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--no-resolve') args.resolve = false;
+    else if (a === '-h' || a === '--help') {
+      printHelp();
+      process.exit(0);
+    } else if (!a.startsWith('-') && !args.profile) args.profile = a;
+    else {
+      console.error(`error: unexpected argument: ${a}`);
+      process.exit(1);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(
+    'Usage: node scripts/resolve-cpuprofile.mjs <profile.cpuprofile> --maps <dir> [--top N] [--block] [--json] [--no-resolve]'
+  );
+}
+
+// Recursively index every *.js.map under dir, keyed by the basename of the
+// chunk it maps (i.e. `<chunk>.js`). Turbopack/webpack name maps `<chunk>.js.map`.
+async function indexMaps(dir) {
+  /** @type {Map<string, string>} */
+  const byChunkBasename = new Map();
+  /** @type {Map<string, string>} */
+  const byMapBasename = new Map();
+
+  /** @param {string} d */
+  async function walk(d) {
+    let entries;
+    try {
+      entries = await readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) {
+        await walk(full);
+      } else if (e.isFile() && e.name.endsWith('.js.map')) {
+        const mapBase = e.name; // e.g. _0eaaij7._.js.map
+        const chunkBase = e.name.slice(0, -'.map'.length); // e.g. _0eaaij7._.js
+        // First write wins; collisions across dirs are rare for hashed chunk names.
+        if (!byChunkBasename.has(chunkBase)) byChunkBasename.set(chunkBase, full);
+        if (!byMapBasename.has(mapBase)) byMapBasename.set(mapBase, full);
+      }
+    }
+  }
+  await walk(dir);
+  return { byChunkBasename, byMapBasename };
+}
+
+// Extract the chunk basename from a frame url. Frame urls in the wild look like:
+//   /app/.next/server/chunks/_0eaaij7._.js
+//   file:///app/.next/server/chunks/27592.js
+//   chunks/src_17njnbr._.js
+//   27592.js
+// We reduce to the trailing `<name>.js` basename and look that up in the map index.
+function chunkBasenameFromUrl(url) {
+  if (!url) return null;
+  // strip query/hash and protocol
+  let u = url.replace(/[?#].*$/, '');
+  if (u.startsWith('file://')) u = u.slice('file://'.length);
+  const base = u.split('/').pop() || '';
+  if (!base.endsWith('.js')) return null;
+  // ignore node internals / non-chunk urls
+  if (u.startsWith('node:') || base === 'server.js') return null;
+  return base;
+}
+
+/**
+ * Build per-map SourceMapConsumer lazily and cache it. Returns a resolver fn that,
+ * given (chunkBasename, line0, col0), returns the original frame or null.
+ */
+function makeResolver(SourceMapConsumer, mapIndex) {
+  /** @type {Map<string, Promise<import('source-map').BasicSourceMapConsumer | null>>} */
+  const consumerCache = new Map();
+
+  /** @param {string} chunkBase */
+  function getConsumer(chunkBase) {
+    if (consumerCache.has(chunkBase)) return consumerCache.get(chunkBase);
+    const p = (async () => {
+      const mapPath = mapIndex.byChunkBasename.get(chunkBase);
+      if (!mapPath) return null;
+      try {
+        const raw = await readFile(mapPath, 'utf8');
+        const json = JSON.parse(raw);
+        return await new SourceMapConsumer(json);
+      } catch (err) {
+        console.error(`warn: failed to load map for ${chunkBase}: ${err.message}`);
+        return null;
+      }
+    })();
+    consumerCache.set(chunkBase, p);
+    return p;
+  }
+
+  /**
+   * @param {string} chunkBase
+   * @param {number} line0  0-based line (V8)
+   * @param {number} col0   0-based column (V8)
+   */
+  async function resolve(chunkBase, line0, col0) {
+    const consumer = await getConsumer(chunkBase);
+    if (!consumer) return null;
+    const pos = consumer.originalPositionFor({
+      line: (line0 ?? 0) + 1, // source-map is 1-based for lines
+      column: col0 ?? 0, // 0-based for columns (matches V8)
+      bias: SourceMapConsumer.LEAST_UPPER_BOUND,
+    });
+    if (pos.source == null && pos.line == null) return null;
+    return { source: pos.source, line: pos.line, column: pos.column, name: pos.name };
+  }
+
+  function destroy() {
+    for (const p of consumerCache.values()) {
+      Promise.resolve(p).then((c) => c && c.destroy && c.destroy());
+    }
+  }
+
+  return { resolve, destroy };
+}
+
+function formatFrame(original, callFrame) {
+  const rawFn = callFrame.functionName || '(anonymous)';
+  if (original) {
+    const fn = original.name || rawFn;
+    const loc = original.source
+      ? `${original.source}:${original.line ?? '?'}:${original.column ?? '?'}`
+      : '(unknown source)';
+    return `${fn} @ ${loc}`;
+  }
+  const url = callFrame.url || '';
+  const base = url ? url.split('/').pop() : '(native)';
+  return `${rawFn} @ ${base}:${callFrame.lineNumber ?? '?'}:${callFrame.columnNumber ?? '?'} [unresolved]`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.profile) {
+    printHelp();
+    process.exit(1);
+  }
+  if (args.resolve && !args.mapsDir) {
+    console.error('error: --maps <dir> is required (or pass --no-resolve).');
+    process.exit(1);
+  }
+  if (args.mapsDir && !existsSync(args.mapsDir)) {
+    console.error(`error: maps dir not found: ${args.mapsDir}`);
+    process.exit(1);
+  }
+
+  const profileRaw = await readFile(args.profile, 'utf8');
+  /** @type {{ nodes: any[], samples: number[], timeDeltas: number[] }} */
+  const profile = JSON.parse(profileRaw);
+  if (!Array.isArray(profile.nodes)) {
+    console.error('error: not a V8 .cpuprofile (missing `nodes` array).');
+    process.exit(1);
+  }
+
+  let resolver = null;
+  if (args.resolve) {
+    const sm = await loadSourceMapModule();
+    const mapIndex = await indexMaps(args.mapsDir);
+    if (mapIndex.byChunkBasename.size === 0) {
+      console.error(`warn: no .js.map files found under ${args.mapsDir} — frames will be unresolved.`);
+    } else {
+      console.error(`info: indexed ${mapIndex.byChunkBasename.size} source maps under ${args.mapsDir}`);
+    }
+    resolver = makeResolver(sm.SourceMapConsumer, mapIndex);
+  }
+
+  // Resolve every node's callFrame once, cache by node id.
+  /** @type {Map<number, { callFrame: any, original: any, label: string }>} */
+  const nodeInfo = new Map();
+  const byId = new Map(profile.nodes.map((n) => [n.id, n]));
+
+  for (const node of profile.nodes) {
+    const cf = node.callFrame || {};
+    let original = null;
+    if (resolver) {
+      const chunkBase = chunkBasenameFromUrl(cf.url);
+      if (chunkBase) {
+        original = await resolver.resolve(chunkBase, cf.lineNumber, cf.columnNumber);
+      }
+    }
+    nodeInfo.set(node.id, { callFrame: cf, original, label: formatFrame(original, cf) });
+  }
+
+  // --- self-time accounting (hottest leaves) ---
+  // Each sample attributes its timeDelta to the sampled (leaf) node's self time.
+  /** @type {Map<number, number>} */
+  const selfTime = new Map();
+  const samples = profile.samples || [];
+  const deltas = profile.timeDeltas || [];
+  for (let i = 0; i < samples.length; i++) {
+    const id = samples[i];
+    const dt = deltas[i] ?? 0;
+    selfTime.set(id, (selfTime.get(id) || 0) + dt);
+  }
+
+  if (args.json) {
+    const out = profile.nodes.map((n) => ({
+      id: n.id,
+      original: nodeInfo.get(n.id).original,
+      callFrame: n.callFrame,
+      selfTimeMicros: selfTime.get(n.id) || 0,
+    }));
+    process.stdout.write(JSON.stringify({ nodes: out }, null, 2) + '\n');
+    if (resolver) resolver.destroy();
+    return;
+  }
+
+  // ancestry map (child id -> parent id) for printing stacks
+  /** @type {Map<number, number>} */
+  const parentOf = new Map();
+  for (const node of profile.nodes) {
+    for (const child of node.children || []) parentOf.set(child, node.id);
+  }
+  /** @param {number} id */
+  function stackOf(id) {
+    const out = [];
+    let cur = id;
+    const seen = new Set();
+    while (cur != null && !seen.has(cur)) {
+      seen.add(cur);
+      const info = nodeInfo.get(cur);
+      if (info) out.push(info.label);
+      cur = parentOf.get(cur);
+    }
+    return out;
+  }
+
+  const totalMicros = deltas.reduce((a, b) => a + (b || 0), 0);
+  console.log(`\n=== CPU profile: ${path.basename(args.profile)} ===`);
+  console.log(`samples=${samples.length}  duration=${(totalMicros / 1000).toFixed(1)}ms\n`);
+
+  console.log(`--- Top ${args.top} self-time functions ---`);
+  const ranked = [...selfTime.entries()].sort((a, b) => b[1] - a[1]).slice(0, args.top);
+  for (const [id, micros] of ranked) {
+    const info = nodeInfo.get(id);
+    const pct = totalMicros ? ((micros / totalMicros) * 100).toFixed(1) : '?';
+    console.log(`  ${(micros / 1000).toFixed(1).padStart(8)}ms ${pct.padStart(5)}%  ${info ? info.label : id}`);
+  }
+
+  if (args.block) {
+    // Longest run of consecutive samples sharing the same leaf node id.
+    let bestLeaf = null;
+    let bestMicros = 0;
+    let curLeaf = null;
+    let curMicros = 0;
+    for (let i = 0; i < samples.length; i++) {
+      const id = samples[i];
+      const dt = deltas[i] ?? 0;
+      if (id === curLeaf) {
+        curMicros += dt;
+      } else {
+        curLeaf = id;
+        curMicros = dt;
+      }
+      if (curMicros > bestMicros) {
+        bestMicros = curMicros;
+        bestLeaf = curLeaf;
+      }
+    }
+    console.log(`\n--- Longest synchronous block ---`);
+    if (bestLeaf != null) {
+      console.log(`  duration=${(bestMicros / 1000).toFixed(1)}ms  leaf stack (innermost first):`);
+      for (const frame of stackOf(bestLeaf)) console.log(`    at ${frame}`);
+    } else {
+      console.log('  (no samples)');
+    }
+  }
+
+  if (resolver) resolver.destroy();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why
We capture V8 `.cpuprofile`s from prod pods to find what blocks the event loop, but the standalone build ships **zero server `.js.map` files**, so frames are minified and unnameable (e.g. `p @ src_17njnbr._.js:0`, `e0 @ _0eaaij7._.js:4398`). This makes server source maps available for de-minification **without bloating the runtime pod**, plus a resolver that maps `chunk.js:line:col` → original `file.ts:line` + function name.

## Approach: maps as a fetched-on-demand artifact (NOT in the runtime image)

An earlier revision of this PR overlaid all server `.js.map` into the runtime image. On the pr-2460 preview that added **761 MB to every prod pod** (11,305 maps; vs ~280 MB of actual `.js`) — far too much for a debug aid that's only needed offline. **Revised:** the maps are published as a separate artifact image and fetched on demand.

### Part A — emit server maps + a `maps` Dockerfile target
- **Bundler: Turbopack** (Next 16 default). Under Turbopack the source-map lever is `turbopackSourceMaps`, whose build-time default IS `productionBrowserSourceMaps` (already `true`), so `.next/server/**/*.js.map` are **already emitted**. `next.config.mjs` change is a comment-accuracy rewrite only.
- `output: 'standalone'` (via `@vercel/nft`) does **not** trace sibling `.map` files, so the builder still stages them (`find | tar | tar`, busybox-safe).
- **Runtime image stays lean:** the previous runtime-stage map `COPY` is reverted (drops ~761 MB back off every pod). Maps are exposed via a new **`FROM scratch AS maps`** target containing only `/server-maps`, which shares every builder layer (cache hit) and is published separately.

### Part B — publish (build pipeline, separate repo)
The Tekton pipeline (datapacket-talos PR https://github.com/civitai/talos-infra/pull/111) builds the `maps` target after the main build+push and pushes it to `ghcr.io/civitai/civitai-web-maps:<same-tag>`, reusing the existing ghcr creds, as a **non-fatal** step. Keyed by the exact image tag, so a profile from image X resolves against X's maps. **No new secrets.**

### Part C — resolver
`scripts/resolve-cpuprofile.mjs`:
- **`--image <tag-or-ref>`** (new): fetches that build's maps from `ghcr.io/civitai/civitai-web-maps:<tag>` via `crane export` (falls back to `oras pull`) into a temp dir, resolves, then cleans up. A bare tag is expanded against `--maps-repo` (default `ghcr.io/civitai/civitai-web-maps`); a full ref is used as-is. Relies on ambient registry read auth (docker config / `crane auth login ghcr.io`) — no embedded creds.
- **`--maps <dir>`** (existing): resolve against a local maps directory.
- Resolves each frame's `(url, lineNumber, columnNumber)` → original `{source, line, name}` via `source-map` (existing dep; V8 0-based coords handled). Ranks hottest self-time leaves and reconstructs the longest synchronous block, named. `--no-resolve` / `--json` retained.

## Verification
- Local `--maps` mode: synthetic map + profile → minified `e`/`o` frames resolved to `expensiveLoop` / `blockEventLoop` at original `src/orig.ts` positions.
- **End-to-end `--image` mode**: built a `FROM scratch` maps image with `crane append`, pushed it to a local registry, then `--image <ref>` fetched it (`crane export | tar -x`), detected the nested `/server-maps`, and de-minified the same frames. This exercises the exact artifact→fetch→resolve path the pipeline uses.
- `node --check` on the resolver passes. eslint/prettier scope to `src/**/*.{ts,tsx}`; this PR touches only `Dockerfile` + a build `.mjs`, so no TS gate applies (and no stale-Prisma typecheck noise).
- **Honest note:** end-to-end *prod* proof (resolving an actual prod profile) only comes after a maps-enabled build deploys and a fresh `.cpuprofile` is captured — existing prod profiles predate the maps artifact.

## Cost
- Runtime image: **~761 MB smaller** than the prior in-image revision (back to lean).
- Storage: the maps artifact lives in ghcr keyed by tag; pulled only on demand by the resolver, never by a pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
