### PR TITLE
refactor(redis): collapse cache-only env.IS_DATAPACKET TTL gates in caches.ts

### DIFF
--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -37,9 +37,9 @@ export const tagIdsForImagesCache = createCachedObject<{
 }>({
   key: REDIS_KEYS.CACHES.TAG_IDS_FOR_IMAGES,
   idKey: 'imageId',
-  // Reduced from day to 8h on DP — 296B/key but ~16M keys/shard (~4.4 GiB).
+  // 8h TTL — 296B/key but ~16M keys/shard (~4.4 GiB).
   // With stale-while-revalidate, effective Redis EX = 16h.
-  ttl: env.IS_DATAPACKET ? CacheTTL.hour * 8 : CacheTTL.day,
+  ttl: CacheTTL.hour * 8,
   async lookupFn(imageId, fromWrite) {
     const imageIds = Array.isArray(imageId) ? imageId : [imageId];
     const db = fromWrite ? dbWrite : dbRead;
@@ -1118,10 +1118,10 @@ export const imageMetaCache = createCachedObject<ImageWithMeta>({
     `;
     return Object.fromEntries(images.map((x) => [x.id, x]));
   },
-  // Reduced from day to 4h on DP to prevent Redis OOM — image-meta is ~2.8KB/key
-  // and accounts for ~72% of Redis memory at scale (26 GiB/shard with 10M keys).
-  // With stale-while-revalidate, effective Redis EX = 8h.
-  ttl: env.IS_DATAPACKET ? CacheTTL.hour * 4 : CacheTTL.hour,
+  // 4h TTL to bound Redis memory — image-meta is ~2.8KB/key (~2.3 GiB / ~1% of
+  // the cluster per the 2026-06-09 keyspace audit; the tag caches are the heavy
+  // consumers, not this one). With stale-while-revalidate, effective Redis EX = 8h.
+  ttl: CacheTTL.hour * 4,
 });
 
 type ImageWithMetadata = {
@@ -1143,8 +1143,8 @@ export const imageMetadataCache = createCachedObject<ImageWithMetadata>({
     `;
     return Object.fromEntries(images.map((x) => [x.id, x]));
   },
-  // Reduced from day to 4h on DP — same rationale as imageMetaCache.
-  ttl: env.IS_DATAPACKET ? CacheTTL.hour * 4 : CacheTTL.hour,
+  // 4h TTL — same rationale as imageMetaCache.
+  ttl: CacheTTL.hour * 4,
 });
 
 export const thumbnailCache = createCachedObject<{
@@ -1458,7 +1458,7 @@ export function getBaseModelFromResources(
 export const modelVersionResourceCache = createCachedObject<ModelVersionResourceCacheItem>({
   key: REDIS_KEYS.CACHES.MODEL_VERSION_RESOURCE_INFO,
   idKey: 'versionId',
-  ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.md,
+  ttl: CacheTTL.day,
   lookupFn: async (ids, fromWrite) => {
     const db = fromWrite ? dbWrite : dbRead;
     const mvInfo = await db.modelVersion.findMany({
@@ -1537,7 +1537,7 @@ type UserDownloadsCacheItem = {
 export const userDownloadsCache = createCachedObject<UserDownloadsCacheItem>({
   key: REDIS_KEYS.CACHES.USER_DOWNLOADS,
   idKey: 'userId',
-  ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.hour,
+  ttl: CacheTTL.day,
   cacheNotFound: false,
   lookupFn: async (userIds) => {
     if (!clickhouse) return {};


### PR DESCRIPTION
Collapses the 5 remaining **pure-TTL, cache-only** `env.IS_DATAPACKET ? <A> : <B>` ternaries in `src/server/redis/caches.ts` to their DataPacket (`<A>`) branch, removing the env gate on those caches.

### Prod impact: none (verified no-op)
All four `civitai-dp-prod` deployments set `IS_DATAPACKET=true` (`deployment{,-api,-api-heavy,-jobs}.yaml`), and `zc.booleanString` parses `"true"`→`true`. **Prod was already on the `<A>` branch**, so effective prod TTLs are unchanged across all 5 caches. The only behavior change lands in non-DP envs (next/stage/app/PR-preview), which have no `IS_DATAPACKET` set → schema default `false` → previously on `<B>`.

| cache | non-prod before | non-prod after | effective EX (SWR×2) after |
|---|---|---|---|
| `tagIdsForImagesCache` | day | `hour*8` (shorter) | 16h |
| `imageMetaCache` | hour | `hour*4` | 8h |
| `imageMetadataCache` | hour | `hour*4` | 8h |
| `modelVersionResourceCache` | md (10m) | `day` | 48h |
| `userDownloadsCache` | hour | `day` | 48h |

The two longer ones (`modelVersionResource`, `userDownloads`) are bounded by explicit write-path invalidation (`bustUserDownloadsCache` on every download; `modelVersionResourceCache.refresh()` in the auction jobs), so non-prod freshness now relies on bust/refresh rather than a short TTL — acceptable.

Also fixes a **stale comment** on `imageMetaCache` that claimed it was "~72% of Redis memory" — the 2026-06-09 keyspace audit showed it's ~1% / ~2.3 GiB; the tag caches are the heavy consumers.

### ⚠️ `IS_DATAPACKET` is NOT fully retired — scope is deliberately cache-only
The flag remains in the env schema and still gates logic elsewhere. **Do not** mechanically collapse these in a "finish the job" follow-up:
- `server/db/db-helpers.ts` — **behavioral**: PgBouncer-vs-DOKS connection routing + per-connection `statement_timeout` (DP sets it post-connect; DOKS/local can't). Collapsing breaks non-DP DB connectivity.
- `server/utils/distributed-lock.ts:22` — lock-hold TTL (behavioral).

Two more **pure-TTL** sites of this exact shape were left out of this PR (scoped to `caches.ts`); they can follow in a separate cache-TTL PR: `server/services/model-file.service.ts:46`, `server/services/image.service.ts:4847`.

`env` import stays (`ORCHESTRATOR_ACCESS_TOKEN`). Follows #2453.

⚠️ Local `pnpm typecheck` not run (fresh worktree); changes are type-preserving constant swaps — please let CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)