### PR TITLE
refactor(redis): collapse the 2 remaining cache-only IS_DATAPACKET TTL gates

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -4844,7 +4844,7 @@ type CachedImagesForModelVersions = {
 export const imagesForModelVersionsCache = createCachedObject<CachedImagesForModelVersions>({
   key: REDIS_KEYS.CACHES.IMAGES_FOR_MODEL_VERSION,
   idKey: 'modelVersionId',
-  ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.sm,
+  ttl: CacheTTL.day,
   // The lookupFn filters on async-populated columns (i.nsfwLevel != 0,
   // i.needsReview IS NULL). A read between publish and ingestion-complete
   // returns zero rows. We still cache notFound to skip the requery cost on

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -1,7 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import { CacheTTL } from '~/server/common/constants';
-import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
@@ -43,7 +42,7 @@ async function fetchModelFilesForCache(ids: number[]) {
 export const filesForModelVersionCache = createCachedObject({
   key: REDIS_KEYS.CACHES.FILES_FOR_MODEL_VERSION,
   idKey: 'modelVersionId',
-  ttl: env.IS_DATAPACKET ? CacheTTL.day : CacheTTL.sm,
+  ttl: CacheTTL.day,
   async lookupFn(ids) {
     const files = await fetchModelFilesForCache(ids);
 


### PR DESCRIPTION
Follow-up to #2462 (the `caches.ts` sweep). Collapses the **two remaining pure-TTL** `env.IS_DATAPACKET ? day : sm` ternaries that live in service files to their DataPacket branch:

- `filesForModelVersionCache` (`model-file.service.ts`): `sm → CacheTTL.day`
- `imagesForModelVersionsCache` (`image.service.ts`): `sm → CacheTTL.day`

### Prod impact: none (verified no-op)
`civitai-dp-prod` sets `IS_DATAPACKET=true` in all four deployments, so prod was already on the `day` branch. Only non-DP envs (which default to `false`) change: `CacheTTL.sm` (10m) → `CacheTTL.day` (effective 48h with SWR). Same reasoning as #2462; both caches serve model-version data that's invalidated on write.

Also drops the now-orphaned `env` import in `model-file.service.ts` (this was its only use).

### Out of scope (intentionally not collapsed)
The remaining `IS_DATAPACKET` references are **behavioral, not TTL**, and must not be mechanically collapsed:
- `server/db/db-helpers.ts` — PgBouncer-vs-DOKS connection routing + per-connection `statement_timeout` (local/DOKS Postgres can't take the DP path).
- `server/utils/distributed-lock.ts` — lock-hold TTL.

A staged plan to fully retire the flag (including these) is being proposed separately.

⚠️ Local `pnpm typecheck` not run (fresh worktree); type-preserving constant swaps + one unused-import removal — please let CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)