### PR TITLE
perf(api): cut ambient-bootstrap trpc volume on api-primary (~10%)

### DIFF
--- a/src/components/Alerts/MatureContentMigrationAlert.tsx
+++ b/src/components/Alerts/MatureContentMigrationAlert.tsx
@@ -72,7 +72,12 @@ export function MatureContentMigrationAlert() {
     if (el) el.style.opacity = '0';
   }, []);
 
-  if (!features.isGreen || !hasNsfwEnabled || !ready || isDismissed) return null;
+  // `!settings` guards the rare path where the SSR `/api/user/settings` snapshot
+  // failed (→ undefined initialData): the query self-heals via a mount fetch, and
+  // until it lands we must not render against undefined `dismissedAlerts` (which
+  // would briefly re-show an already-dismissed alert). On the normal SSR-seeded
+  // path `settings` is defined immediately, so this adds no delay or refetch.
+  if (!features.isGreen || !hasNsfwEnabled || !ready || !settings || isDismissed) return null;
 
   const redDomain = serverDomains.red;
   const redUrl = syncAccount(`//${redDomain}`);

--- a/src/components/Alerts/MatureContentMigrationAlert.tsx
+++ b/src/components/Alerts/MatureContentMigrationAlert.tsx
@@ -46,6 +46,14 @@ export function MatureContentMigrationAlert() {
     onError: (_err, _vars, ctx) => {
       if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
     },
+    // Reconcile with server truth after the optimistic update: the optimistic
+    // setData spreads `...old`, so if the cached base was incomplete (e.g. a
+    // failed SSR settings snapshot) it could persist a truncated settings
+    // object. Refetch once on dismiss to restore the full object + confirm the
+    // stored dismissedAlerts. One request per dismiss (rare) — not per mount.
+    onSettled: () => {
+      utils.user.getSettings.invalidate();
+    },
   });
 
   // Spotlight effect — ref + direct DOM to avoid re-renders on mouse move

--- a/src/components/Alerts/MatureContentMigrationAlert.tsx
+++ b/src/components/Alerts/MatureContentMigrationAlert.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef } from 'react';
 import { Button, CloseButton, Text, ThemeIcon } from '@mantine/core';
 import { IconArrowRight, IconPepper } from '@tabler/icons-react';
 import { useSession } from 'next-auth/react';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useFeatureFlags, useFeatureFlagsReady } from '~/providers/FeatureFlagsProvider';
 import { useServerDomains } from '~/providers/AppProvider';
 import { nsfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
@@ -19,16 +19,14 @@ export function MatureContentMigrationAlert() {
   // On green, the BrowserSettingsProvider forces showNsfw=false, so we
   // need the original values to know if the user would see NSFW elsewhere.
   const user = session?.user;
-  // `AppProvider` seeds `user.getSettings` with SSR `initialData` and the
-  // global `staleTime: Infinity` prevents refetching — so `data` is truthy
-  // immediately with potentially stale `dismissedAlerts`. Gate on `isFetched`
-  // (only true after a real network fetch resolves) so we never render based
-  // on the SSR snapshot, and force a refetch on mount via `staleTime: 0`.
-  // Gate on `!!user` so logged-out visits don't trigger a 401 against the
-  // protected procedure.
-  const { data: settings, isFetched } = trpc.user.getSettings.useQuery(undefined, {
+  const ready = useFeatureFlagsReady();
+  // `AppProvider` seeds `user.getSettings` with SSR `initialData`, and the
+  // dismiss mutation keeps the cache current via an optimistic update — so the
+  // SSR snapshot is authoritative for `dismissedAlerts` without a per-mount
+  // refetch. Gate visibility on `ready` (the per-user feature-flag overlay) so
+  // we don't flash against the anon `features.isGreen` value.
+  const { data: settings } = trpc.user.getSettings.useQuery(undefined, {
     enabled: !!user,
-    staleTime: 0,
   });
   const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
   const hasNsfwEnabled =
@@ -66,7 +64,7 @@ export function MatureContentMigrationAlert() {
     if (el) el.style.opacity = '0';
   }, []);
 
-  if (!features.isGreen || !hasNsfwEnabled || !isFetched || isDismissed) return null;
+  if (!features.isGreen || !hasNsfwEnabled || !ready || isDismissed) return null;
 
   const redDomain = serverDomains.red;
   const redUrl = syncAccount(`//${redDomain}`);

--- a/src/components/Alerts/NavTidyNotice.tsx
+++ b/src/components/Alerts/NavTidyNotice.tsx
@@ -41,6 +41,14 @@ export function NavTidyNotice() {
     onError: (_err, _vars, ctx) => {
       if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
     },
+    // Reconcile with server truth after the optimistic update: the optimistic
+    // setData spreads `...old`, so if the cached base was incomplete (e.g. a
+    // failed SSR settings snapshot) it could persist a truncated settings
+    // object. Refetch once on dismiss to restore the full object + confirm the
+    // stored dismissedAlerts. One request per dismiss (rare) — not per mount.
+    onSettled: () => {
+      utils.user.getSettings.invalidate();
+    },
   });
 
   // Only nudge users who actually have one of the tidied items hidden.

--- a/src/components/Alerts/NavTidyNotice.tsx
+++ b/src/components/Alerts/NavTidyNotice.tsx
@@ -53,7 +53,10 @@ export function NavTidyNotice() {
 
   // Only nudge users who actually have one of the tidied items hidden.
   const hasHiddenNavItem = !features.postsNavItem || !features.eventsNavItem;
-  const show = enabled && ready && !isDismissed && hasHiddenNavItem;
+  // `!!settings` guards the rare failed-SSR-snapshot path (undefined initialData):
+  // don't render against undefined `dismissedAlerts` until the self-healing mount
+  // fetch lands. Defined immediately on the normal SSR-seeded path → no delay.
+  const show = enabled && ready && !!settings && !isDismissed && hasHiddenNavItem;
 
   const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
 

--- a/src/components/Alerts/NavTidyNotice.tsx
+++ b/src/components/Alerts/NavTidyNotice.tsx
@@ -2,7 +2,7 @@ import { Button, CloseButton, Popover, Text } from '@mantine/core';
 import { IconArrowRight, IconInfoCircle } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useFeatureFlags, useFeatureFlagsReady } from '~/providers/FeatureFlagsProvider';
 import { trpc } from '~/utils/trpc';
 
 const ALERT_ID = 'nav-tidy-notice';
@@ -18,13 +18,12 @@ export function NavTidyNotice() {
   const features = useFeatureFlags();
 
   const enabled = !!currentUser;
-  // AppProvider seeds `user.getSettings` with SSR initialData and the global
-  // `staleTime: Infinity` prevents refetching — so `data` is truthy immediately
-  // with potentially stale `dismissedAlerts`. Gate on `isFetched` (only true
-  // after a real network fetch resolves) and force a refetch via `staleTime: 0`.
-  const { data: settings, isFetched: settingsFetched } = trpc.user.getSettings.useQuery(undefined, {
+  const ready = useFeatureFlagsReady();
+  // SSR-seeded `user.getSettings` + the dismiss mutation's optimistic cache
+  // update keep `dismissedAlerts` authoritative without a per-mount refetch.
+  // Gate visibility on `ready` (per-user flag overlay) instead.
+  const { data: settings } = trpc.user.getSettings.useQuery(undefined, {
     enabled,
-    staleTime: 0,
   });
   const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
 
@@ -46,7 +45,7 @@ export function NavTidyNotice() {
 
   // Only nudge users who actually have one of the tidied items hidden.
   const hasHiddenNavItem = !features.postsNavItem || !features.eventsNavItem;
-  const show = enabled && settingsFetched && !isDismissed && hasHiddenNavItem;
+  const show = enabled && ready && !isDismissed && hasHiddenNavItem;
 
   const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
 

--- a/src/components/Alerts/YellowBuzzMigrationNotice.tsx
+++ b/src/components/Alerts/YellowBuzzMigrationNotice.tsx
@@ -1,6 +1,6 @@
 import { Button, CloseButton, Popover, Text } from '@mantine/core';
 import { IconArrowRight } from '@tabler/icons-react';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useFeatureFlags, useFeatureFlagsReady } from '~/providers/FeatureFlagsProvider';
 import { useServerDomains } from '~/providers/AppProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { trpc } from '~/utils/trpc';
@@ -20,19 +20,13 @@ export function YellowBuzzMigrationNotice({ children }: { children: React.ReactN
   const serverDomains = useServerDomains();
 
   const enabled = !!currentUser && features.isGreen && features.buzz;
-  const { data: buzzAccounts, isFetched: buzzFetched } = trpc.buzz.getBuzzAccount.useQuery(
-    undefined,
-    { enabled, staleTime: 0 }
-  );
-  // AppProvider seeds `user.getSettings` with SSR initialData and the global
-  // `staleTime: Infinity` prevents refetching — so `data` is truthy immediately
-  // with potentially stale `dismissedAlerts`. Gate on `isFetched` (only true
-  // after a real network fetch resolves) so we never render based on the SSR
-  // snapshot, and force a refetch on mount via `staleTime: 0`.
-  const { data: settings, isFetched: settingsFetched } = trpc.user.getSettings.useQuery(undefined, {
-    enabled,
-    staleTime: 0,
-  });
+  const ready = useFeatureFlagsReady();
+  // Shares the `getBuzzAccount` cache with the global buzz display (signal-kept
+  // live) — no need to force a refetch here.
+  const { data: buzzAccounts } = trpc.buzz.getBuzzAccount.useQuery(undefined, { enabled });
+  // SSR-seeded `user.getSettings` + the dismiss mutation's optimistic cache
+  // update keep `dismissedAlerts` authoritative without a per-mount refetch.
+  const { data: settings } = trpc.user.getSettings.useQuery(undefined, { enabled });
   const isDismissed = (settings?.dismissedAlerts ?? []).includes(ALERT_ID);
 
   const utils = trpc.useUtils();
@@ -52,7 +46,7 @@ export function YellowBuzzMigrationNotice({ children }: { children: React.ReactN
   });
 
   const yellowBalance = buzzAccounts?.yellow ?? 0;
-  const show = enabled && buzzFetched && settingsFetched && !isDismissed && yellowBalance > 0;
+  const show = enabled && ready && !isDismissed && yellowBalance > 0;
 
   const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
 

--- a/src/components/Alerts/YellowBuzzMigrationNotice.tsx
+++ b/src/components/Alerts/YellowBuzzMigrationNotice.tsx
@@ -43,6 +43,14 @@ export function YellowBuzzMigrationNotice({ children }: { children: React.ReactN
     onError: (_err, _vars, ctx) => {
       if (ctx?.prev) utils.user.getSettings.setData(undefined, ctx.prev);
     },
+    // Reconcile with server truth after the optimistic update: the optimistic
+    // setData spreads `...old`, so if the cached base was incomplete (e.g. a
+    // failed SSR settings snapshot) it could persist a truncated settings
+    // object. Refetch once on dismiss to restore the full object + confirm the
+    // stored dismissedAlerts. One request per dismiss (rare) — not per mount.
+    onSettled: () => {
+      utils.user.getSettings.invalidate();
+    },
   });
 
   const yellowBalance = buzzAccounts?.yellow ?? 0;

--- a/src/components/Alerts/YellowBuzzMigrationNotice.tsx
+++ b/src/components/Alerts/YellowBuzzMigrationNotice.tsx
@@ -54,7 +54,10 @@ export function YellowBuzzMigrationNotice({ children }: { children: React.ReactN
   });
 
   const yellowBalance = buzzAccounts?.yellow ?? 0;
-  const show = enabled && ready && !isDismissed && yellowBalance > 0;
+  // `!!settings` guards the rare failed-SSR-snapshot path (undefined initialData):
+  // don't render against undefined `dismissedAlerts` until the self-healing mount
+  // fetch lands. Defined immediately on the normal SSR-seeded path → no delay.
+  const show = enabled && ready && !!settings && !isDismissed && yellowBalance > 0;
 
   const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
 

--- a/src/components/Chat/useChatEnabled.ts
+++ b/src/components/Chat/useChatEnabled.ts
@@ -1,31 +1,21 @@
-import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
-import { trpc } from '~/utils/trpc';
+import { useFeatureFlags, useFeatureFlagsReady } from '~/providers/FeatureFlagsProvider';
 
 /**
  * Whether chat UI should render for the current user.
  *
- * The chat enable/disable toggle lives in the user's settings. `features.chat`
- * (from `user.getFeatureFlags`) is the live, optimistic source for that toggle —
- * but that query is NOT SSR-seeded, so `chat` defaults to `true` until it
- * resolves. That makes the chat icon flash in and then back out for users who
- * have chat disabled. `user.getSettings` IS SSR-seeded (`AppProvider` passes
- * `initialData`), and its `isFetched` only flips true after the confirming
- * fetch — which, under tRPC request batching, lands together with
- * `getFeatureFlags`. Gating on it lets us wait until the user's chat setting is
- * known before rendering any chat UI, eliminating the flash.
+ * The chat enable/disable toggle lives in `features.chat` (from
+ * `user.getFeatureFlags`), which is NOT SSR-seeded, so `chat` defaults to the
+ * anon SSR value until the per-user overlay resolves. That makes the chat icon
+ * flash in and then back out for users who have chat disabled. Gate on
+ * `useFeatureFlagsReady()` — true once that overlay has settled (or there is no
+ * logged-in user) — so we render only when the user's chat setting is known.
  *
- * Logged-out callers (e.g. ShareButton) fall through to the stable SSR
- * `features.chat` value, which never flickers because there is no per-user
- * override query to overlay.
+ * Previously this forced a `user.getSettings` refetch (`staleTime: 0`) purely to
+ * observe when the batched flags fetch landed; reading readiness directly avoids
+ * that per-mount round-trip.
  */
 export function useChatEnabled() {
-  const currentUser = useCurrentUser();
   const features = useFeatureFlags();
-  const { isFetched } = trpc.user.getSettings.useQuery(undefined, {
-    enabled: !!currentUser,
-    staleTime: 0,
-  });
-  const ready = !currentUser || isFetched;
+  const ready = useFeatureFlagsReady();
   return ready && features.chat;
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,6 @@ import type { AppContext, AppProps } from 'next/app';
 import App from 'next/app';
 import Head from 'next/head';
 import type { ReactElement } from 'react';
-import React from 'react';
 import { AdsProvider } from '~/components/Ads/AdsProvider';
 import { AppLayout } from '~/components/AppLayout/AppLayout';
 import { BaseLayout } from '~/components/AppLayout/BaseLayout';
@@ -57,6 +56,7 @@ import { IsClientProvider } from '~/providers/IsClientProvider';
 import { ThemeProvider } from '~/providers/ThemeProvider';
 import type { UserContentSettings } from '~/server/schema/user.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
+import type { BrowsingSettingsAddon } from '~/shared/constants/browsing-settings-addons';
 import type { ParsedCookies } from '~/shared/utils/cookies';
 import { parseCookies } from '~/shared/utils/cookies';
 import { RegisterCatchNavigation } from '~/store/catch-navigation.store';
@@ -101,6 +101,7 @@ type CustomAppProps = {
   flags: FeatureAccess;
   seed: number;
   settings: UserContentSettings;
+  browsingSettingsAddons: BrowsingSettingsAddon[];
   canIndex: boolean;
   hasAuthCookie: boolean;
   region: RegionInfo;
@@ -123,6 +124,7 @@ function MyApp(props: CustomAppProps) {
       canIndex,
       hasAuthCookie,
       settings,
+      browsingSettingsAddons,
       region,
       domain,
       host,
@@ -207,7 +209,7 @@ function MyApp(props: CustomAppProps) {
                       <ErrorBoundary>
                         <BrowserSettingsProvider>
                           <BrowsingLevelProvider>
-                            <BrowsingSettingsAddonsProvider>
+                            <BrowsingSettingsAddonsProvider initialData={browsingSettingsAddons}>
                               <SignalsProviderStack>
                                 <ActivityReportingProvider>
                                   <ReferralsProvider {...cookies.referrals}>
@@ -342,6 +344,12 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     req: request,
   });
 
+  // SSR-inject the global (redis-cached, identical-for-all-users) browsing
+  // setting addons so the client provider doesn't fire a per-bootstrap
+  // `system.getBrowsingSettingAddons` round-trip on api-primary.
+  const { getBrowsingSettingAddons } = await import('~/server/services/system-cache');
+  const browsingSettingsAddons = await getBrowsingSettingAddons();
+
   if (session) {
     (appContext.ctx.req as any)['session'] = session;
   } else if (hasAuthCookie) {
@@ -359,6 +367,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       // cookieKeys: Object.keys(cookies),
       session,
       settings,
+      browsingSettingsAddons,
       flags,
       seed: Date.now(),
       hasAuthCookie,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -336,19 +336,24 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     const data: { settings: UserContentSettings; session: Session | null } = await res.json();
     return data;
   });
-  // Pass this via the request so we can use it in SSR
-  const { getFeatureFlagsAsync } = await import('~/server/services/feature-flags.service');
-  const flags = await getFeatureFlagsAsync({
-    user: session?.user,
-    host: request?.headers.host,
-    req: request,
-  });
-
-  // SSR-inject the global (redis-cached, identical-for-all-users) browsing
-  // setting addons so the client provider doesn't fire a per-bootstrap
-  // `system.getBrowsingSettingAddons` round-trip on api-primary.
-  const { getBrowsingSettingAddons } = await import('~/server/services/system-cache');
-  const browsingSettingsAddons = await getBrowsingSettingAddons();
+  // Pass these via the request so we can use them in SSR. Resolve the per-user
+  // feature flags and the global (redis-cached, identical-for-all-users) browsing
+  // setting addons in PARALLEL — neither depends on the other and both sit on
+  // every full render's critical path. SSR-injecting the addons keeps the
+  // `system.getBrowsingSettingAddons` round-trip off api-primary (it becomes
+  // `initialData` for the client provider).
+  const [{ getFeatureFlagsAsync }, { getBrowsingSettingAddons }] = await Promise.all([
+    import('~/server/services/feature-flags.service'),
+    import('~/server/services/system-cache'),
+  ]);
+  const [flags, browsingSettingsAddons] = await Promise.all([
+    getFeatureFlagsAsync({
+      user: session?.user,
+      host: request?.headers.host,
+      req: request,
+    }),
+    getBrowsingSettingAddons(),
+  ]);
 
   if (session) {
     (appContext.ctx.req as any)['session'] = session;

--- a/src/providers/BrowsingSettingsAddonsProvider.tsx
+++ b/src/providers/BrowsingSettingsAddonsProvider.tsx
@@ -26,11 +26,20 @@ export const useBrowsingSettingsAddons = () => {
   const context = useContext(BrowsingSettingsAddonsCtx);
   return context;
 };
-export const BrowsingSettingsAddonsProvider = ({ children }: { children: React.ReactNode }) => {
+export const BrowsingSettingsAddonsProvider = ({
+  children,
+  initialData,
+}: {
+  children: React.ReactNode;
+  // SSR-seeded global addon list. Sharing the query key, only the outermost
+  // provider needs it — nested mounts read the primed cache without refetching.
+  initialData?: BrowsingSettingsAddon[];
+}) => {
   const { data = DEFAULT_BROWSING_SETTINGS_ADDONS, isLoading } =
     trpc.system.getBrowsingSettingAddons.useQuery(undefined, {
       gcTime: Infinity,
       staleTime: Infinity,
+      initialData,
     });
   const currentUser = useCurrentUser();
   const browsingLevel = useBrowsingLevelDebounced();

--- a/src/providers/FeatureFlagsProvider.tsx
+++ b/src/providers/FeatureFlagsProvider.tsx
@@ -4,6 +4,12 @@ import { type FeatureAccess } from '~/server/services/feature-flags.service';
 import { trpc } from '~/utils/trpc';
 
 const FeatureFlagsCtx = createContext<FeatureAccess | null>(null);
+// Whether the per-user `getFeatureFlags` overlay has resolved. SSR seeds
+// host-level flags synchronously, but user-specific flags arrive via the
+// client query — consumers that would flash if they rendered against the
+// anon SSR flags (chat icon, migration alerts) gate on this instead of
+// forcing their own `getSettings` refetch.
+const FeatureFlagsReadyCtx = createContext<boolean>(true);
 
 export type UseFeatureFlagsReturn = ReturnType<typeof useFeatureFlags>;
 export const useFeatureFlags = () => {
@@ -11,6 +17,12 @@ export const useFeatureFlags = () => {
   if (!context) throw new Error('useFeatureFlags can only be used inside FeatureFlagsCtx');
   return context;
 };
+/**
+ * True once the per-user feature-flag overlay is known (or there is no logged-in
+ * user). Use to defer rendering UI whose visibility depends on user flags, so it
+ * doesn't flash against the anonymous SSR snapshot.
+ */
+export const useFeatureFlagsReady = () => useContext(FeatureFlagsReadyCtx);
 export const FeatureFlagsProvider = ({
   children,
   flags: initialFlags,
@@ -19,17 +31,19 @@ export const FeatureFlagsProvider = ({
   flags: FeatureAccess;
 }) => {
   const session = useSession();
-  // Ensures FE and BE feature flags are in sync for staging.
-  const host =
-    typeof location !== 'undefined'
-      ? (location?.host ?? '').replace('stage.', '').replace('dev.', '')
-      : '';
-  const [flags, setFlags] = useState(initialFlags);
+  const [flags] = useState(initialFlags);
 
-  const { data: userFeatures = {} as FeatureAccess } = trpc.user.getFeatureFlags.useQuery(
-    undefined,
-    { gcTime: Infinity, staleTime: Infinity, retry: 0, enabled: !!session.data }
-  );
+  const { data: userFeatures = {} as FeatureAccess, isFetched } =
+    trpc.user.getFeatureFlags.useQuery(undefined, {
+      gcTime: Infinity,
+      staleTime: Infinity,
+      retry: 0,
+      enabled: !!session.data,
+    });
+
+  // Logged-out (query disabled) → ready immediately on the complete SSR flags.
+  // Logged-in → ready once the user overlay has settled (success or error).
+  const ready = !session.data || isFetched;
 
   const featureFlags = useMemo(
     () => ({
@@ -39,5 +53,9 @@ export const FeatureFlagsProvider = ({
     [flags, userFeatures]
   );
 
-  return <FeatureFlagsCtx.Provider value={featureFlags}>{children}</FeatureFlagsCtx.Provider>;
+  return (
+    <FeatureFlagsCtx.Provider value={featureFlags}>
+      <FeatureFlagsReadyCtx.Provider value={ready}>{children}</FeatureFlagsReadyCtx.Provider>
+    </FeatureFlagsCtx.Provider>
+  );
 };

--- a/tests/preview-bootstrap.spec.ts
+++ b/tests/preview-bootstrap.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+
+/**
+ * Regression guard for PR #2464 (perf/cut-ambient-bootstrap-trpc-volume): cutting
+ * per-bootstrap tRPC volume on api-primary. Runs only under
+ * playwright.preview.config.ts (needs PREVIEW_URL).
+ *
+ * What this file CAN assert deterministically (and does):
+ *   1. ANON SSR-inject of `browsingSettingsAddons`. _app.getInitialProps now
+ *      fetches the redis-cached global addon list server-side and seeds it into
+ *      `__NEXT_DATA__.props.pageProps.browsingSettingsAddons`, passing it to
+ *      BrowsingSettingsAddonsProvider as `initialData`. So the client must NOT
+ *      fire `system.getBrowsingSettingAddons` on bootstrap. This fired for anon
+ *      in the old code, so it's verifiable WITHOUT login. The tRPC client is
+ *      non-batched (src/utils/trpc.ts httpLink), so the procedure name is in the
+ *      request path — a substring match on the URL is a reliable network probe.
+ *      The anon home page 307s to /login, but `_app` getInitialProps runs for
+ *      every page, so the SSR payload + provider mount happen on /login too.
+ *   2. The same SSR-inject for a logged-in (gate-passing) user.
+ *
+ * What is LEFT AS MANUAL (documented, not faked here — see checklist at bottom):
+ *   - "user.getSettings is no longer force-refetched per mount" by the four
+ *     ambient consumers (chat icon + 3 migration/nav alerts). getSettings fires
+ *     for many unrelated reasons during a session, so a count-based "did it
+ *     refetch?" assertion against a live preview is flaky and would be theatre.
+ *   - Chat-icon no-flash, alert render/dismiss/persist, and the
+ *     getFeatureFlags-error fail-open path. These are timing/visual and
+ *     user-state dependent; assert by hand.
+ */
+
+const ADDONS_PROCEDURE = 'system.getBrowsingSettingAddons';
+
+// A page that is reachable without clearing the preview gate. Anonymous traffic
+// 307s to /login, but _app.getInitialProps (and thus the SSR inject + provider
+// mount) still runs there — exactly the bootstrap path we want to probe.
+const ANON_LANDING = '/login';
+
+// A core page a gate-passing user lands on directly (no /login bounce).
+const AUTHED_LANDING = '/models';
+
+/**
+ * Navigate to `path`, recording every tRPC request URL seen during the load and
+ * for a short settle window after, then return them. We watch `request` (fired
+ * the moment the client issues it) so we catch the call even if it errors.
+ */
+async function collectTrpcRequests(
+  page: import('@playwright/test').Page,
+  path: string
+): Promise<string[]> {
+  const trpcUrls: string[] = [];
+  const onRequest = (req: import('@playwright/test').Request) => {
+    const url = req.url();
+    if (url.includes('/api/trpc/')) trpcUrls.push(url);
+  };
+  page.on('request', onRequest);
+  try {
+    await page.goto(path, { waitUntil: 'networkidle' });
+    // networkidle already waits out the bootstrap query burst; a small extra
+    // settle covers any deferred mount that fires just after idle.
+    await page.waitForTimeout(1500);
+  } finally {
+    page.off('request', onRequest);
+  }
+  return trpcUrls;
+}
+
+/** Read `__NEXT_DATA__.props.pageProps.browsingSettingsAddons` from the page. */
+async function readBrowsingSettingsAddons(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const el = document.getElementById('__NEXT_DATA__');
+    if (!el?.textContent) return { present: false, value: undefined as unknown };
+    const data = JSON.parse(el.textContent);
+    const value = data?.props?.pageProps?.browsingSettingsAddons;
+    return { present: typeof value !== 'undefined', value };
+  });
+}
+
+test.describe('SSR-injected browsingSettingsAddons (anonymous)', () => {
+  // Explicitly anonymous: no minted session cookie.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('addons are seeded into __NEXT_DATA__ and not fetched on bootstrap', async ({ page }) => {
+    const trpcUrls = await collectTrpcRequests(page, ANON_LANDING);
+
+    // (a) SSR payload carries the addon list.
+    const addons = await readBrowsingSettingsAddons(page);
+    expect(addons.present, 'browsingSettingsAddons present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(Array.isArray(addons.value), 'browsingSettingsAddons is a list').toBe(true);
+
+    // (b) The client never issues the now-SSR-injected procedure on bootstrap.
+    const addonRequests = trpcUrls.filter((u) => u.includes(ADDONS_PROCEDURE));
+    expect(
+      addonRequests,
+      `no ${ADDONS_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${addonRequests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
+  });
+});
+
+test.describe('SSR-injected browsingSettingsAddons (logged-in)', () => {
+  test.use({ storageState: storageStatePath('mod') });
+
+  test('addons are seeded and not fetched on bootstrap for a gate-passing user', async ({
+    page,
+  }) => {
+    const trpcUrls = await collectTrpcRequests(page, AUTHED_LANDING);
+
+    const addons = await readBrowsingSettingsAddons(page);
+    expect(addons.present, 'browsingSettingsAddons present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(Array.isArray(addons.value), 'browsingSettingsAddons is a list').toBe(true);
+
+    const addonRequests = trpcUrls.filter((u) => u.includes(ADDONS_PROCEDURE));
+    expect(
+      addonRequests,
+      `no ${ADDONS_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${addonRequests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
+  });
+});
+
+/**
+ * MANUAL CHECKLIST — behaviours of #2464 that are not auto-asserted above.
+ * (Auth IS supported by this harness, but these are timing/visual/state cases
+ * that would be flaky or no-op as live-preview assertions; verify by hand.)
+ *
+ *  [ ] Chat icon no-flash: logged-in user WITH chat disabled — the chat icon
+ *      must NOT appear-then-disappear on load. It should gate on
+ *      useFeatureFlagsReady() and only render once the user flag overlay settles.
+ *  [ ] No per-mount getSettings refetch: with the four ambient consumers mounted
+ *      (chat icon + MatureContentMigrationAlert + NavTidyNotice +
+ *      YellowBuzzMigrationNotice), client-side nav between pages must NOT trigger
+ *      a `user.getSettings` refetch per mount (they now read the SSR-seeded
+ *      cache + gate on useFeatureFlagsReady, not staleTime:0 + isFetched).
+ *  [ ] Alert render/dismiss/persist: a migration/nav alert renders from
+ *      dismissedAlerts, dismissing it fires exactly one getSettings refetch via
+ *      the new onSettled invalidate, and it stays dismissed across reloads.
+ *  [ ] getFeatureFlags error fail-open: if user.getFeatureFlags errors,
+ *      useFeatureFlagsReady() still flips true (gated on isFetched, which covers
+ *      success OR error), so chat/alerts are not stuck hidden.
+ */

--- a/tests/preview-bootstrap.spec.ts
+++ b/tests/preview-bootstrap.spec.ts
@@ -55,10 +55,13 @@ async function collectTrpcRequests(
   };
   page.on('request', onRequest);
   try {
-    await page.goto(path, { waitUntil: 'networkidle' });
-    // networkidle already waits out the bootstrap query burst; a small extra
-    // settle covers any deferred mount that fires just after idle.
-    await page.waitForTimeout(1500);
+    // NOT 'networkidle': the app keeps background requests alive (signals /
+    // polling / beacons), so the network never goes idle and goto would hang to
+    // the navigation timeout. We don't need it — the `request` listener above
+    // captures every tRPC call regardless of load state; a fixed settle window
+    // after DOMContentLoaded covers the bootstrap burst + any deferred mount.
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(2500);
   } finally {
     page.off('request', onRequest);
   }


### PR DESCRIPTION
Cuts ~140/s of ~1,433/s api-primary tRPC volume (~10%) by removing per-bootstrap overhead calls.

**user.getSettings (~106/s):** four ambient consumers (chat icon + 3 migration/nav alerts) forced `staleTime: 0` on every mount only to observe when the batched getFeatureFlags fetch landed (flash-avoidance). FeatureFlagsProvider now exposes `useFeatureFlagsReady()` (the per-user flag overlay already runs once/bootstrap); consumers gate on it and read dismissedAlerts from the SSR-seeded cache (kept current by the dismiss mutation's existing optimistic setData). Removes the per-mount round-trip + a forced getBuzzAccount refetch.

**system.getBrowsingSettingAddons (~35/s):** global + redis-cached. SSR-injected in _app getInitialProps as initialData to the outermost provider; client query no longer fires.

Each cut also drops that procedure's per-request middleware tax (auth, flag eval) off the single JS thread (the pin-wave bottleneck).

⚠️ Not yet runtime-verified — changes UI render-gating (chat icon + alert visibility). QA: confirm they still render (no flash) when authed and the per-procedure rate drops post-deploy.
Trade-off: cross-device alert dismissal won't reflect on an already-open tab until reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)