### PR TITLE
feat(filters): stage filter edits with Apply button to cut feed 429s

### DIFF
--- a/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
+++ b/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
@@ -119,18 +119,11 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
             header: { padding: '4px 8px' },
           }}
         >
-          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </IsClient>

--- a/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
+++ b/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
@@ -116,14 +116,22 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
           }}
           styles={{
             content: {
-              height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
+              display: 'flex',
+              flexDirection: 'column',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </IsClient>

--- a/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
+++ b/src/components/Article/Infinite/ArticleFiltersDropdown.tsx
@@ -1,18 +1,11 @@
 import type { ButtonProps } from '@mantine/core';
-import {
-  Button,
-  Divider,
-  Drawer,
-  Indicator,
-  Popover,
-  Stack,
-  useComputedColorScheme,
-  useMantineTheme,
-} from '@mantine/core';
+import { Divider, Drawer, Indicator, Popover, Stack, useMantineTheme } from '@mantine/core';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { IconFilter } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { PeriodFilter } from '~/components/Filters';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFiltersContext } from '~/providers/FiltersProvider';
 import type { ArticleQueryInput } from '~/server/schema/article.schema';
@@ -22,28 +15,37 @@ import { IsClient } from '~/components/IsClient/IsClient';
 export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Props) {
   const theme = useMantineTheme();
   const mobile = useIsMobile();
-  const colorScheme = useComputedColorScheme('dark');
-
-  const [opened, setOpened] = useState(false);
 
   const { filters, setFilters } = useFiltersContext((state) => ({
     filters: state.articles,
     setFilters: state.setArticleFilters,
   }));
 
-  const mergedFilters = query || filters;
+  const committedFilters = useMemo(() => query || filters, [query, filters]);
 
-  const filterLength =
-    mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0;
+  const handleApply = useCallback(
+    (next: typeof committedFilters) => {
+      if (onChange) onChange(next);
+      else setFilters(next);
+    },
+    [onChange, setFilters]
+  );
 
-  const clearFilters = useCallback(() => {
-    const reset = {
-      period: MetricTimeframe.AllTime,
-    };
-
+  const handleClear = useCallback(() => {
+    const reset = { period: MetricTimeframe.AllTime };
     if (onChange) onChange(reset);
     else setFilters(reset);
   }, [onChange, setFilters]);
+
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: handleApply,
+      onClear: handleClear,
+    });
+
+  const filterLength =
+    mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0;
 
   const target = (
     <Indicator
@@ -55,14 +57,14 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
       processing
       inline
     >
-      <FilterButton icon={IconFilter} onClick={() => setOpened((o) => !o)} active={opened}>
+      <FilterButton icon={IconFilter} onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
   );
 
-  const dropdown = (
-    <Stack gap="lg">
+  const dropdownBody = (
+    <Stack gap="lg" p="md">
       <Stack gap="md">
         <Divider
           label="Time period"
@@ -73,28 +75,24 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
             },
           }}
         />
-        {query?.period && onChange ? (
-          <PeriodFilter
-            type="articles"
-            variant="chips"
-            value={query.period}
-            onChange={(period) => onChange({ period })}
-          />
-        ) : (
-          <PeriodFilter type="articles" variant="chips" />
-        )}
+        <PeriodFilter
+          type="articles"
+          variant="chips"
+          value={mergedFilters.period ?? MetricTimeframe.AllTime}
+          onChange={(period) => patchPending({ period })}
+        />
       </Stack>
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all filters
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -103,7 +101,7 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           closeButtonProps={{
@@ -120,13 +118,20 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
             content: {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
-              overflowY: 'auto',
             },
-            body: { padding: 16, paddingTop: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
           }}
         >
-          {dropdown}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownFooter}
         </Drawer>
       </IsClient>
     );
@@ -138,12 +143,14 @@ export function ArticleFiltersDropdown({ query, onChange, ...buttonProps }: Prop
         position="bottom-end"
         shadow="md"
         radius={12}
-        onClose={() => setOpened(false)}
+        opened={opened}
+        onClose={close}
         middlewares={{ flip: true, shift: true }}
       >
         <Popover.Target>{target}</Popover.Target>
-        <Popover.Dropdown maw={468} p="md" w="100%">
-          {dropdown}
+        <Popover.Dropdown maw={468} p={0} w="100%">
+          {dropdownBody}
+          {dropdownFooter}
         </Popover.Dropdown>
       </Popover>
     </IsClient>

--- a/src/components/Article/Infinite/ArticlesInfinite.tsx
+++ b/src/components/Article/Infinite/ArticlesInfinite.tsx
@@ -1,7 +1,6 @@
 import { Button, Center, Loader, LoadingOverlay } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import { isEqual } from 'lodash-es';
-import { useEffect } from 'react';
+import { useRef } from 'react';
 import { useArticleFilters, useQueryArticles } from '~/components/Article/article.utils';
 import { ArticleCard } from '~/components/Cards/ArticleCard';
 import { EndOfFeed } from '~/components/EndOfFeed/EndOfFeed';
@@ -20,21 +19,18 @@ export function ArticlesInfinite({
 }: Props) {
   const articlesFilters = useArticleFilters();
 
-  const filters = disableStoreFilters
+  const computedFilters = disableStoreFilters
     ? filterOverrides
     : removeEmpty({ ...articlesFilters, ...filterOverrides });
-  const [debouncedFilters, cancel] = useDebouncedValue(filters, 500);
+  // Stabilize identity so query keys only update on real content change.
+  const filtersRef = useRef(computedFilters);
+  if (!isEqual(filtersRef.current, computedFilters)) filtersRef.current = computedFilters;
+  const filters = filtersRef.current;
 
   const { articles, fetchNextPage, hasNextPage, isRefetching, isFetching } = useQueryArticles(
-    debouncedFilters,
+    filters,
     { keepPreviousData: true }
   );
-
-  //#region [useEffect] cancel debounced filters
-  useEffect(() => {
-    if (isEqual(filters, debouncedFilters)) cancel();
-  }, [cancel, debouncedFilters, filters]);
-  //#endregion
 
   return (
     <>

--- a/src/components/Auction/AuctionFiltersDropdown.tsx
+++ b/src/components/Auction/AuctionFiltersDropdown.tsx
@@ -87,17 +87,10 @@ export const AuctionFiltersDropdown = ({ baseModels }: { baseModels: BaseModel[]
           position="bottom"
           classNames={{ ...classes }}
           styles={{
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
           }}
         >
-          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Auction/AuctionFiltersDropdown.tsx
+++ b/src/components/Auction/AuctionFiltersDropdown.tsx
@@ -1,18 +1,10 @@
-import {
-  Button,
-  Chip,
-  Divider,
-  Drawer,
-  Group,
-  Indicator,
-  Popover,
-  Stack,
-  useComputedColorScheme,
-} from '@mantine/core';
+import { Chip, Divider, Drawer, Group, Indicator, Popover, Stack } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import { FilterChip } from '~/components/Filters/FilterChip';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFiltersContext } from '~/providers/FiltersProvider';
 import { getDisplayName } from '~/utils/string-helpers';
@@ -20,24 +12,23 @@ import classes from './AuctionFiltersDropdown.module.scss';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 
 export const AuctionFiltersDropdown = ({ baseModels }: { baseModels: BaseModel[] }) => {
-  const colorScheme = useComputedColorScheme('dark');
   const mobile = useIsMobile();
-  const [opened, setOpened] = useState(false);
 
-  const { filters, setFilters } = useFiltersContext((state) => ({
+  const { filters: committedFilters, setFilters } = useFiltersContext((state) => ({
     filters: state.auctions,
     setFilters: state.setAuctionFilters,
   }));
 
-  const filterLength = filters.baseModels?.length ? 1 : 0;
+  const handleClear = useCallback(() => setFilters({ baseModels: undefined }), [setFilters]);
 
-  const clearFilters = useCallback(
-    () =>
-      setFilters({
-        baseModels: undefined,
-      }),
-    [setFilters]
-  );
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: setFilters,
+      onClear: handleClear,
+    });
+
+  const filterLength = mergedFilters.baseModels?.length ? 1 : 0;
 
   const target = (
     <Indicator
@@ -48,26 +39,19 @@ export const AuctionFiltersDropdown = ({ baseModels }: { baseModels: BaseModel[]
       disabled={!filterLength}
       inline
     >
-      <FilterButton
-        icon={IconFilter}
-        size="md"
-        onClick={() => setOpened((o) => !o)}
-        active={opened}
-      >
+      <FilterButton icon={IconFilter} size="md" onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
   );
 
-  const dropdown = (
-    <Stack gap="lg">
+  const dropdownBody = (
+    <Stack gap="lg" p="md">
       <Stack gap={0}>
         <Divider label="Base model" classNames={{ label: 'font-bold text-sm' }} mb="sm" />
         <Chip.Group
-          value={(filters.baseModels as string[]) ?? []}
-          onChange={(baseModels) =>
-            setFilters({ ...filters, baseModels: baseModels as BaseModel[] })
-          }
+          value={(mergedFilters.baseModels as string[]) ?? []}
+          onChange={(baseModels) => patchPending({ baseModels: baseModels as BaseModel[] })}
           multiple
         >
           <Group gap={8} my={4}>
@@ -79,17 +63,17 @@ export const AuctionFiltersDropdown = ({ baseModels }: { baseModels: BaseModel[]
           </Group>
         </Chip.Group>
       </Stack>
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -98,12 +82,23 @@ export const AuctionFiltersDropdown = ({ baseModels }: { baseModels: BaseModel[]
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           classNames={{ ...classes }}
+          styles={{
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
+          }}
         >
-          {dropdown}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownFooter}
         </Drawer>
       </>
     );
@@ -114,12 +109,14 @@ export const AuctionFiltersDropdown = ({ baseModels }: { baseModels: BaseModel[]
       position="bottom-end"
       shadow="md"
       radius={12}
-      onClose={() => setOpened(false)}
+      opened={opened}
+      onClose={close}
       middlewares={{ flip: true, shift: true }}
     >
       <Popover.Target>{target}</Popover.Target>
-      <Popover.Dropdown maw={468} p="md" w="100%">
-        {dropdown}
+      <Popover.Dropdown maw={468} p={0} w="100%">
+        {dropdownBody}
+        {dropdownFooter}
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/components/Auction/AuctionFiltersDropdown.tsx
+++ b/src/components/Auction/AuctionFiltersDropdown.tsx
@@ -87,10 +87,18 @@ export const AuctionFiltersDropdown = ({ baseModels }: { baseModels: BaseModel[]
           position="bottom"
           classNames={{ ...classes }}
           styles={{
-            body: { padding: 0, overflowY: 'auto' },
+            content: { display: 'flex', flexDirection: 'column' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Bounty/Infinite/BountiesInfinite.tsx
+++ b/src/components/Bounty/Infinite/BountiesInfinite.tsx
@@ -1,8 +1,7 @@
 import type { GetInfiniteBountySchema } from '~/server/schema/bounty.schema';
 import { Center, Loader, LoadingOverlay } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import { isEqual } from 'lodash-es';
-import { useEffect } from 'react';
+import { useRef } from 'react';
 import { EndOfFeed } from '~/components/EndOfFeed/EndOfFeed';
 import { NoContent } from '~/components/NoContent/NoContent';
 import { removeEmpty } from '~/utils/object-helpers';
@@ -14,19 +13,16 @@ import { InViewLoader } from '~/components/InView/InViewLoader';
 export function BountiesInfinite({ filters: filterOverrides, showEof = true }: Props) {
   const bountiesFilters = useBountyFilters();
 
-  const filters = removeEmpty({ ...bountiesFilters, ...filterOverrides });
-  const [debouncedFilters, cancel] = useDebouncedValue(filters, 500);
+  const computedFilters = removeEmpty({ ...bountiesFilters, ...filterOverrides });
+  // Stabilize identity so query keys only update on real content change.
+  const filtersRef = useRef(computedFilters);
+  if (!isEqual(filtersRef.current, computedFilters)) filtersRef.current = computedFilters;
+  const filters = filtersRef.current;
 
   const { bounties, fetchNextPage, hasNextPage, isRefetching, isFetching } = useQueryBounties(
-    debouncedFilters,
+    filters,
     { keepPreviousData: true }
   );
-
-  //#region [useEffect] cancel debounced filters
-  useEffect(() => {
-    if (isEqual(filters, debouncedFilters)) cancel();
-  }, [cancel, debouncedFilters, filters]);
-  //#endregion
 
   return (
     <>

--- a/src/components/Bounty/Infinite/BountyFiltersDropdown.tsx
+++ b/src/components/Bounty/Infinite/BountyFiltersDropdown.tsx
@@ -203,19 +203,12 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Bounty/Infinite/BountyFiltersDropdown.tsx
+++ b/src/components/Bounty/Infinite/BountyFiltersDropdown.tsx
@@ -1,25 +1,17 @@
 import type { ButtonProps } from '@mantine/core';
-import {
-  Popover,
-  Group,
-  Indicator,
-  Stack,
-  Divider,
-  Chip,
-  Button,
-  Drawer,
-  useComputedColorScheme,
-} from '@mantine/core';
+import { Popover, Group, Indicator, Stack, Divider, Chip, Drawer } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
 import { BountyType, MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { getDisplayName } from '~/utils/string-helpers';
 import { useFiltersContext } from '~/providers/FiltersProvider';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { BountyStatus } from '~/server/common/enums';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import { activeBaseModels } from '~/shared/constants/basemodel.constants';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { PeriodFilter } from '~/components/Filters';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import { FilterChip } from '~/components/Filters/FilterChip';
 
@@ -36,28 +28,17 @@ const checkSupportsBaseModel = (types: BountyType[]) => {
 };
 
 export function BountyFiltersDropdown({ ...buttonProps }: Props) {
-  const colorScheme = useComputedColorScheme('dark');
   const mobile = useIsMobile();
 
-  const [opened, setOpened] = useState(false);
-
-  const { filters, setFilters } = useFiltersContext((state) => ({
+  const { filters: committedFilters, setFilters } = useFiltersContext((state) => ({
     filters: state.bounties,
     setFilters: state.setBountyFilters,
   }));
 
-  const filterLength =
-    (filters.types?.length ?? 0) +
-    (filters.baseModels?.length ?? 0) +
-    // (!!filters.mode ? 1 : 0) +
-    (!!filters.status ? 1 : 0) +
-    (filters.period !== MetricTimeframe.AllTime ? 1 : 0);
-
-  const clearFilters = useCallback(
+  const handleClear = useCallback(
     () =>
       setFilters({
         types: undefined,
-        // mode: undefined,
         status: undefined,
         baseModels: undefined,
         period: MetricTimeframe.AllTime,
@@ -65,7 +46,20 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
     [setFilters]
   );
 
-  const showBaseModelFilter = checkSupportsBaseModel(filters.types ?? []);
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: setFilters,
+      onClear: handleClear,
+    });
+
+  const filterLength =
+    (mergedFilters.types?.length ?? 0) +
+    (mergedFilters.baseModels?.length ?? 0) +
+    (!!mergedFilters.status ? 1 : 0) +
+    (mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0);
+
+  const showBaseModelFilter = checkSupportsBaseModel(mergedFilters.types ?? []);
 
   const target = (
     <Indicator
@@ -76,14 +70,14 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
       disabled={!filterLength}
       inline
     >
-      <FilterButton icon={IconFilter} onClick={() => setOpened((o) => !o)} active={opened}>
+      <FilterButton icon={IconFilter} onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
   );
 
-  const dropdown = (
-    <Stack gap="lg">
+  const dropdownBody = (
+    <Stack gap="lg" p="md">
       <Stack gap="md">
         <Divider
           label="Time period"
@@ -94,7 +88,12 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
             },
           }}
         />
-        <PeriodFilter type="bounties" variant="chips" />
+        <PeriodFilter
+          type="bounties"
+          variant="chips"
+          value={mergedFilters.period ?? MetricTimeframe.AllTime}
+          onChange={(period) => patchPending({ period })}
+        />
       </Stack>
       <Stack gap="md">
         <Divider
@@ -107,13 +106,13 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
           }}
         />
         <Chip.Group
-          value={filters.types ?? []}
+          value={mergedFilters.types ?? []}
           onChange={(v: string[]) => {
             const types = v as BountyType[];
             const clearBaseModelFilter = !checkSupportsBaseModel(types);
-            setFilters({
+            patchPending({
               types,
-              baseModels: clearBaseModelFilter ? undefined : filters.baseModels,
+              baseModels: clearBaseModelFilter ? undefined : mergedFilters.baseModels,
             });
           }}
           multiple
@@ -139,9 +138,9 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
             }}
           />
           <Chip.Group
-            value={filters.baseModels ?? []}
+            value={mergedFilters.baseModels ?? []}
             onChange={(baseModels: string[]) =>
-              setFilters({ baseModels: baseModels as BaseModel[] })
+              patchPending({ baseModels: baseModels as BaseModel[] })
             }
             multiple
           >
@@ -155,22 +154,6 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
           </Chip.Group>
         </Stack>
       )}
-      {/* TODO.bounty: turn this on once we accept split bounties */}
-      {/* <Stack gap="md">
-        <Divider label="Bounty mode" labelProps={{ weight: 'bold', size: 'sm' }} />
-        <Group gap={8}>
-          {Object.values(BountyMode).map((mode, index) => (
-            <Chip
-              {...chipProps}
-              key={index}
-              checked={filters.mode === mode}
-              onChange={(checked) => setFilters({ mode: checked ? mode : undefined })}
-            >
-              <span>{getDisplayName(mode)}</span>
-            </Chip>
-          ))}
-        </Group>
-      </Stack> */}
       <Stack gap="md">
         <Divider
           label="Bounty status"
@@ -185,25 +168,25 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
           {Object.values(BountyStatus).map((status, index) => (
             <FilterChip
               key={index}
-              checked={filters.status === status}
-              onChange={(checked) => setFilters({ status: checked ? status : undefined })}
+              checked={mergedFilters.status === status}
+              onChange={(checked) => patchPending({ status: checked ? status : undefined })}
             >
               <span>{getDisplayName(status)}</span>
             </FilterChip>
           ))}
         </Group>
       </Stack>
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all filters
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -212,21 +195,28 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           styles={{
             content: {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
-              overflowY: 'auto',
             },
-            body: { padding: 16, paddingTop: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdown}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownFooter}
         </Drawer>
       </>
     );
@@ -237,12 +227,14 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
       position="bottom-end"
       shadow="md"
       radius={12}
-      onClose={() => setOpened(false)}
+      opened={opened}
+      onClose={close}
       middlewares={{ flip: true, shift: true }}
     >
       <Popover.Target>{target}</Popover.Target>
-      <Popover.Dropdown maw={468} p="md" w="100%">
-        {dropdown}
+      <Popover.Dropdown maw={468} p={0} w="100%">
+        {dropdownBody}
+        {dropdownFooter}
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/components/Bounty/Infinite/BountyFiltersDropdown.tsx
+++ b/src/components/Bounty/Infinite/BountyFiltersDropdown.tsx
@@ -200,15 +200,23 @@ export function BountyFiltersDropdown({ ...buttonProps }: Props) {
           position="bottom"
           styles={{
             content: {
-              height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
+              display: 'flex',
+              flexDirection: 'column',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
+++ b/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
@@ -1,20 +1,11 @@
-import {
-  Button,
-  Chip,
-  Divider,
-  Drawer,
-  Group,
-  Indicator,
-  Popover,
-  ScrollArea,
-  Stack,
-  useComputedColorScheme,
-} from '@mantine/core';
+import { Chip, Divider, Drawer, Group, Indicator, Popover, ScrollArea, Stack } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import { FilterChip } from '~/components/Filters/FilterChip';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { IsClient } from '~/components/IsClient/IsClient';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useIsMobile } from '~/hooks/useIsMobile';
@@ -53,38 +44,46 @@ export function parseParticipationQuery(
   return undefined;
 }
 
+type ChallengeFilterState = {
+  status: string[];
+  participation: ChallengeParticipation | undefined;
+};
+
 export function ChallengeFiltersDropdown() {
   const router = useRouter();
   const currentUser = useCurrentUser();
-  const colorScheme = useComputedColorScheme('dark');
   const mobile = useIsMobile();
-  const [opened, setOpened] = useState(false);
 
   const statusFilter = parseStatusQuery(router.query.status);
   const participationFilter = parseParticipationQuery(router.query.participation);
 
-  const handleStatusChange = (value: string[]) => {
-    // Prevent deselecting all options
-    if (value.length === 0) return;
-    router.replace(
-      { pathname: '/challenges', query: { ...router.query, status: value.join(',') } },
-      undefined,
-      { shallow: true }
-    );
-  };
+  const committedFilters = useMemo<ChallengeFilterState>(
+    () => ({ status: statusFilter, participation: participationFilter }),
+    [statusFilter, participationFilter]
+  );
 
-  const handleParticipationChange = (value: string | string[]) => {
-    const selected = Array.isArray(value) ? value[0] : value;
-    // Toggle: clicking the same chip deselects it
-    const newValue = selected === participationFilter ? undefined : selected;
-    router.replace(
-      { pathname: '/challenges', query: { ...router.query, participation: newValue || undefined } },
-      undefined,
-      { shallow: true }
-    );
-  };
+  const handleApply = useCallback(
+    (next: ChallengeFilterState) => {
+      // Prevent committing an empty status set — matches the legacy
+      // handleStatusChange guard that disallowed deselecting all options.
+      const status = next.status.length === 0 ? defaultStatus : next.status;
+      router.replace(
+        {
+          pathname: '/challenges',
+          query: {
+            ...router.query,
+            status: status.join(','),
+            participation: next.participation || undefined,
+          },
+        },
+        undefined,
+        { shallow: true }
+      );
+    },
+    [router]
+  );
 
-  const clearFilters = () => {
+  const handleClear = useCallback(() => {
     router.replace(
       {
         pathname: '/challenges',
@@ -93,13 +92,34 @@ export function ChallengeFiltersDropdown() {
       undefined,
       { shallow: true }
     );
+  }, [router]);
+
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: handleApply,
+      onClear: handleClear,
+    });
+
+  const handleStatusChange = (value: string[]) => {
+    // Mirror the legacy guard: never let the pending set go fully empty.
+    if (value.length === 0) return;
+    patchPending({ status: value });
   };
 
-  // Count active filters (excluding defaults)
+  const handleParticipationChange = (value: string | string[]) => {
+    const selected = Array.isArray(value) ? value[0] : value;
+    const newValue =
+      selected === mergedFilters.participation
+        ? undefined
+        : (selected as ChallengeParticipation | undefined);
+    patchPending({ participation: newValue });
+  };
+
   const hasStatusDefault =
-    statusFilter.length === defaultStatus.length &&
-    defaultStatus.every((s) => statusFilter.includes(s));
-  const hasParticipation = !!participationFilter;
+    mergedFilters.status.length === defaultStatus.length &&
+    defaultStatus.every((s) => mergedFilters.status.includes(s));
+  const hasParticipation = !!mergedFilters.participation;
   const filterLength = (hasStatusDefault ? 0 : 1) + (hasParticipation ? 1 : 0);
 
   const target = (
@@ -111,17 +131,17 @@ export function ChallengeFiltersDropdown() {
       disabled={!filterLength}
       inline
     >
-      <FilterButton icon={IconFilter} onClick={() => setOpened((o) => !o)} active={opened}>
+      <FilterButton icon={IconFilter} onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
   );
 
-  const dropdown = (
+  const dropdownBody = (
     <Stack gap={8} p="md">
       <Stack gap={0}>
         <Divider label="Status" className="text-sm font-bold" mb={4} />
-        <Chip.Group multiple value={statusFilter} onChange={handleStatusChange}>
+        <Chip.Group multiple value={mergedFilters.status} onChange={handleStatusChange}>
           <Group gap={8} mb={4}>
             {statusFilters.map((option) => (
               <FilterChip key={option.value} value={option.value}>
@@ -135,7 +155,10 @@ export function ChallengeFiltersDropdown() {
       {currentUser && (
         <Stack gap={0}>
           <Divider label="My Challenges" className="text-sm font-bold" mb={4} />
-          <Chip.Group value={participationFilter ?? ''} onChange={handleParticipationChange}>
+          <Chip.Group
+            value={mergedFilters.participation ?? ''}
+            onChange={handleParticipationChange}
+          >
             <Group gap={8} mb={4}>
               {participationFilters.map((option) => (
                 <FilterChip key={option.value} value={option.value}>
@@ -147,17 +170,17 @@ export function ChallengeFiltersDropdown() {
         </Stack>
       )}
 
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all filters
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -166,7 +189,7 @@ export function ChallengeFiltersDropdown() {
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           styles={{
@@ -174,12 +197,22 @@ export function ChallengeFiltersDropdown() {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdown}
+          <ScrollArea.Autosize type="hover" className="min-h-0 flex-1">
+            {dropdownBody}
+          </ScrollArea.Autosize>
+          {dropdownFooter}
         </Drawer>
       </IsClient>
     );
@@ -190,16 +223,18 @@ export function ChallengeFiltersDropdown() {
         zIndex={200}
         position="bottom-end"
         shadow="md"
-        onClose={() => setOpened(false)}
+        opened={opened}
+        onClose={close}
         middlewares={{ flip: true, shift: true }}
         withinPortal
         withArrow
       >
         <Popover.Target>{target}</Popover.Target>
         <Popover.Dropdown maw={468} p={0} w="100%">
-          <ScrollArea.Autosize mah="calc(90vh - var(--header-height) - 56px)" type="hover">
-            {dropdown}
+          <ScrollArea.Autosize mah="calc(90vh - var(--header-height) - 156px)" type="hover">
+            {dropdownBody}
           </ScrollArea.Autosize>
+          {dropdownFooter}
         </Popover.Dropdown>
       </Popover>
     </IsClient>

--- a/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
+++ b/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
@@ -197,21 +197,12 @@ export function ChallengeFiltersDropdown() {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          <ScrollArea.Autosize type="hover" className="min-h-0 flex-1">
-            {dropdownBody}
-          </ScrollArea.Autosize>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </IsClient>

--- a/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
+++ b/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
@@ -194,15 +194,23 @@ export function ChallengeFiltersDropdown() {
           position="bottom"
           styles={{
             content: {
-              height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
+              display: 'flex',
+              flexDirection: 'column',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </IsClient>

--- a/src/components/Changelog/ChangelogFiltersDropdown.tsx
+++ b/src/components/Changelog/ChangelogFiltersDropdown.tsx
@@ -1,19 +1,11 @@
-import {
-  Button,
-  Chip,
-  Divider,
-  Drawer,
-  Group,
-  Indicator,
-  Popover,
-  Stack,
-  useComputedColorScheme,
-} from '@mantine/core';
+import { Chip, Divider, Drawer, Group, Indicator, Popover, Stack } from '@mantine/core';
 import { DatePickerInput } from '@mantine/dates';
 import { IconFilter } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import { FilterChip } from '~/components/Filters/FilterChip';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { MultiSelectWrapper } from '~/libs/form/components/MultiSelectWrapper';
 import { useFiltersContext } from '~/providers/FiltersProvider';
@@ -46,21 +38,13 @@ const ChangelogTagSelect = ({
 
 export function ChangelogFiltersDropdown() {
   const mobile = useIsMobile();
-  const [opened, setOpened] = useState(false);
-  const colorScheme = useComputedColorScheme('dark');
 
-  const { filters, setFilters } = useFiltersContext((state) => ({
+  const { filters: committedFilters, setFilters } = useFiltersContext((state) => ({
     filters: state.changelogs,
     setFilters: state.setChangelogFilters,
   }));
 
-  const filterLength =
-    (filters.types?.length ? 1 : 0) +
-    (filters.tags?.length ? 1 : 0) +
-    (filters.dateBefore ? 1 : 0) +
-    (filters.dateAfter ? 1 : 0);
-
-  const clearFilters = useCallback(
+  const handleClear = useCallback(
     () =>
       setFilters({
         types: undefined,
@@ -71,6 +55,19 @@ export function ChangelogFiltersDropdown() {
     [setFilters]
   );
 
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: setFilters,
+      onClear: handleClear,
+    });
+
+  const filterLength =
+    (mergedFilters.types?.length ? 1 : 0) +
+    (mergedFilters.tags?.length ? 1 : 0) +
+    (mergedFilters.dateBefore ? 1 : 0) +
+    (mergedFilters.dateAfter ? 1 : 0);
+
   const target = (
     <Indicator
       offset={4}
@@ -80,30 +77,20 @@ export function ChangelogFiltersDropdown() {
       disabled={!filterLength}
       inline
     >
-      <FilterButton
-        icon={IconFilter}
-        size="md"
-        onClick={() => setOpened((o) => !o)}
-        active={opened}
-      >
+      <FilterButton icon={IconFilter} size="md" onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
   );
 
-  const dropdown = (
-    <Stack gap="lg">
+  const dropdownBody = (
+    <Stack gap="lg" p="md">
       <Stack gap="md">
         <Divider label="Types" className="text-sm font-bold" />
         <Chip.Group
           multiple
-          value={filters.types ?? []}
-          onChange={(types) => {
-            setFilters({
-              ...filters,
-              types: types as ChangelogType[],
-            });
-          }}
+          value={mergedFilters.types ?? []}
+          onChange={(types) => patchPending({ types: types as ChangelogType[] })}
         >
           <Group gap={8}>
             {Object.values(ChangelogType).map((type, index) => (
@@ -117,21 +104,16 @@ export function ChangelogFiltersDropdown() {
       <Stack gap="md">
         <Divider label="Tags" className="text-sm font-bold" />
         <ChangelogTagSelect
-          value={filters.tags ?? []}
-          onChange={(tags) => setFilters({ ...filters, tags })}
+          value={mergedFilters.tags ?? []}
+          onChange={(tags) => patchPending({ tags })}
         />
       </Stack>
       <Stack gap="md">
         <Divider label="Before" className="text-sm font-bold" />
         <DatePickerInput
           placeholder="Choose a date..."
-          value={filters.dateBefore ?? null}
-          onChange={(x) => {
-            setFilters({
-              ...filters,
-              dateBefore: x ?? undefined,
-            });
-          }}
+          value={mergedFilters.dateBefore ?? null}
+          onChange={(x) => patchPending({ dateBefore: x ?? undefined })}
           clearable
         />
       </Stack>
@@ -139,27 +121,22 @@ export function ChangelogFiltersDropdown() {
         <Divider label="After" className="text-sm font-bold" />
         <DatePickerInput
           placeholder="Choose a date..."
-          value={filters.dateAfter ?? null}
-          onChange={(x) => {
-            setFilters({
-              ...filters,
-              dateAfter: x ?? undefined,
-            });
-          }}
+          value={mergedFilters.dateAfter ?? null}
+          onChange={(x) => patchPending({ dateAfter: x ?? undefined })}
           clearable
         />
       </Stack>
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -168,21 +145,28 @@ export function ChangelogFiltersDropdown() {
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           styles={{
             content: {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
-              overflowY: 'auto',
             },
-            body: { padding: 16, paddingTop: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdown}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownFooter}
         </Drawer>
       </>
     );
@@ -193,13 +177,15 @@ export function ChangelogFiltersDropdown() {
       position="bottom-end"
       shadow="md"
       radius={12}
-      onClose={() => setOpened(false)}
+      opened={opened}
+      onClose={close}
       middlewares={{ flip: true, shift: true }}
       trapFocus
     >
       <Popover.Target>{target}</Popover.Target>
-      <Popover.Dropdown maw={468} p="md" w="100%">
-        {dropdown}
+      <Popover.Dropdown maw={468} p={0} w="100%">
+        {dropdownBody}
+        {dropdownFooter}
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/components/Changelog/ChangelogFiltersDropdown.tsx
+++ b/src/components/Changelog/ChangelogFiltersDropdown.tsx
@@ -150,15 +150,23 @@ export function ChangelogFiltersDropdown() {
           position="bottom"
           styles={{
             content: {
-              height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
+              display: 'flex',
+              flexDirection: 'column',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Changelog/ChangelogFiltersDropdown.tsx
+++ b/src/components/Changelog/ChangelogFiltersDropdown.tsx
@@ -153,19 +153,12 @@ export function ChangelogFiltersDropdown() {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Filters/StagedFiltersFooter.tsx
+++ b/src/components/Filters/StagedFiltersFooter.tsx
@@ -36,12 +36,7 @@ export function StagedFiltersFooter({
     <Stack
       gap="xs"
       className={clsx(
-        // Sticky bottom-0 pins the footer to the nearest scrolling ancestor.
-        // On desktop the footer is a sibling of the scrolling ScrollArea so
-        // sticky is inert (parent doesn't scroll); on mobile the Drawer body
-        // scrolls and the footer pins to its bottom, keeping Apply reachable
-        // without scrolling to the end of the filter list.
-        'sticky bottom-0 z-10 border-t border-gray-3 bg-white px-4 py-3 dark:border-dark-4 dark:bg-dark-7',
+        'border-t border-gray-3 bg-white px-4 py-3 dark:border-dark-4 dark:bg-dark-7',
         className
       )}
     >

--- a/src/components/Filters/StagedFiltersFooter.tsx
+++ b/src/components/Filters/StagedFiltersFooter.tsx
@@ -36,7 +36,12 @@ export function StagedFiltersFooter({
     <Stack
       gap="xs"
       className={clsx(
-        'border-t border-gray-3 bg-white px-4 py-3 dark:border-dark-4 dark:bg-dark-7',
+        // Sticky bottom-0 pins the footer to the nearest scrolling ancestor.
+        // On desktop the footer is a sibling of the scrolling ScrollArea so
+        // sticky is inert (parent doesn't scroll); on mobile the Drawer body
+        // scrolls and the footer pins to its bottom, keeping Apply reachable
+        // without scrolling to the end of the filter list.
+        'sticky bottom-0 z-10 border-t border-gray-3 bg-white px-4 py-3 dark:border-dark-4 dark:bg-dark-7',
         className
       )}
     >

--- a/src/components/Filters/StagedFiltersFooter.tsx
+++ b/src/components/Filters/StagedFiltersFooter.tsx
@@ -36,7 +36,7 @@ export function StagedFiltersFooter({
     <Stack
       gap="xs"
       className={clsx(
-        'border-t border-gray-3 bg-white px-4 py-3 dark:border-dark-4 dark:bg-dark-7',
+        'rounded-b-[inherit] border-t border-gray-3 bg-white px-4 py-3 dark:border-dark-4 dark:bg-dark-7',
         className
       )}
     >

--- a/src/components/Filters/StagedFiltersFooter.tsx
+++ b/src/components/Filters/StagedFiltersFooter.tsx
@@ -1,0 +1,63 @@
+import { Button, Group, Stack, useComputedColorScheme } from '@mantine/core';
+import clsx from 'clsx';
+
+export type StagedFiltersFooterProps = {
+  isDirty: boolean;
+  onApply: () => void;
+  onReset: () => void;
+  // When >0 and `onClear` is provided, the "Clear all filters" button shows
+  // below the Apply/Reset row. Matches the legacy footer behaviour each
+  // dropdown had before staging was introduced.
+  filterLength?: number;
+  onClear?: () => void;
+  applyLabel?: string;
+  resetLabel?: string;
+  className?: string;
+};
+
+// Renders edge-to-edge with its own padding, border-top, and background so it
+// reads as a footer band regardless of the surrounding scroll/non-scroll
+// container. Consumers must place this as a direct child of a `p=0` container
+// (Popover.Dropdown / Drawer body / Stack) so the band hugs the dropdown
+// edges; do not nest inside a padded Stack.
+export function StagedFiltersFooter({
+  isDirty,
+  onApply,
+  onReset,
+  filterLength = 0,
+  onClear,
+  applyLabel = 'Apply filters',
+  resetLabel = 'Reset',
+  className,
+}: StagedFiltersFooterProps) {
+  const colorScheme = useComputedColorScheme('dark');
+
+  return (
+    <Stack
+      gap="xs"
+      className={clsx(
+        'border-t border-gray-3 bg-white px-4 py-3 dark:border-dark-4 dark:bg-dark-7',
+        className
+      )}
+    >
+      <Group grow>
+        <Button variant="default" onClick={onReset} disabled={!isDirty}>
+          {resetLabel}
+        </Button>
+        <Button onClick={onApply} disabled={!isDirty}>
+          {applyLabel}
+        </Button>
+      </Group>
+      {filterLength > 0 && onClear && (
+        <Button
+          color="gray"
+          variant={colorScheme === 'dark' ? 'filled' : 'light'}
+          onClick={onClear}
+          fullWidth
+        >
+          Clear all filters
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/Filters/useStagedFilters.ts
+++ b/src/components/Filters/useStagedFilters.ts
@@ -1,0 +1,102 @@
+import { isEqual } from 'lodash-es';
+import { useCallback, useState } from 'react';
+
+export type UseStagedFiltersArgs<T extends object> = {
+  // Currently-committed filters (Zustand store, URL params, or local state).
+  committed: T;
+  // Commits pending filters to the source. Called on Apply.
+  onApply: (next: T) => void;
+  // Optional. Commits an empty/reset state to the source. Called on Clear.
+  onClear?: () => void;
+};
+
+export type UseStagedFiltersResult<T extends object> = {
+  opened: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  pending: T;
+  setPending: React.Dispatch<React.SetStateAction<T>>;
+  // Shallow-merges a partial patch into the pending state. Matches the shape
+  // of the per-dropdown `handleChange` callbacks the migration replaces.
+  patchPending: (patch: Partial<T>) => void;
+  // Pending while open, committed while closed — gives existing chip reads +
+  // indicator badge a single source of truth that auto-shows the preview
+  // count while the user is editing.
+  mergedFilters: T;
+  isDirty: boolean;
+  apply: () => void;
+  reset: () => void;
+  clearAndClose: () => void;
+};
+
+/**
+ * Stages filter edits in local state until the user hits Apply. Without
+ * staging, every chip toggle fires a feed request and rapid filter churn
+ * stacks heavy-image bulkhead slots server-side (see request-bulkhead.ts +
+ * heavyProcedure in src/server/trpc.ts), producing TOO_MANY_REQUESTS for the
+ * user and surrounding traffic. Used by feed filter dropdowns (images,
+ * models, articles, bounties, posts, etc.) so one user intent → one fetch.
+ */
+export function useStagedFilters<T extends object>({
+  committed,
+  onApply,
+  onClear,
+}: UseStagedFiltersArgs<T>): UseStagedFiltersResult<T> {
+  const [opened, setOpened] = useState(false);
+  const [pending, setPending] = useState<T>(committed);
+
+  const isDirty = !isEqual(pending, committed);
+  const mergedFilters = opened ? pending : committed;
+
+  const open = useCallback(() => {
+    setPending(committed);
+    setOpened(true);
+  }, [committed]);
+
+  const close = useCallback(() => {
+    // Discard pending on close — Apply is the only commit path.
+    setPending(committed);
+    setOpened(false);
+  }, [committed]);
+
+  const toggle = useCallback(() => {
+    setOpened((wasOpen) => {
+      setPending(committed);
+      return !wasOpen;
+    });
+  }, [committed]);
+
+  const patchPending = useCallback((patch: Partial<T>) => {
+    setPending((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const apply = useCallback(() => {
+    onApply(pending);
+    setOpened(false);
+  }, [onApply, pending]);
+
+  const reset = useCallback(() => {
+    setPending(committed);
+  }, [committed]);
+
+  const clearAndClose = useCallback(() => {
+    onClear?.();
+    setOpened(false);
+  }, [onClear]);
+
+  return {
+    opened,
+    open,
+    close,
+    toggle,
+    pending,
+    setPending,
+    patchPending,
+    mergedFilters,
+    isDirty,
+    apply,
+    reset,
+    clearAndClose,
+  };
+}

--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -393,15 +393,23 @@ export function MediaFiltersDropdown({
           position="bottom"
           styles={{
             content: {
-              height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
+              display: 'flex',
+              flexDirection: 'column',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -1,6 +1,5 @@
 import type { ButtonProps } from '@mantine/core';
 import {
-  Button,
   Chip,
   Divider,
   Drawer,
@@ -10,14 +9,15 @@ import {
   ScrollArea,
   Stack,
   Tooltip,
-  useComputedColorScheme,
   Group,
 } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import { PeriodFilter } from '~/components/Filters';
 import { FilterChip } from '~/components/Filters/FilterChip';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { TechniqueMultiSelect } from '~/components/Technique/TechniqueMultiSelect';
 import { ToolMultiSelect } from '~/components/Tool/ToolMultiSelect';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -48,7 +48,6 @@ export function MediaFiltersDropdown({
   style,
   ...buttonProps
 }: Props) {
-  const colorScheme = useComputedColorScheme('dark');
   const mobile = useIsMobile();
   const isClient = useIsClient();
   const currentUser = useCurrentUser();
@@ -60,8 +59,6 @@ export function MediaFiltersDropdown({
   // PG-13 access to opt in/out of.
   const showPG13Toggle = isGreen && !!currentUser;
 
-  const [opened, setOpened] = useState(false);
-
   const { filters, setFilters } = useFiltersContext((state) => ({
     filters: state[filterType],
     setFilters:
@@ -72,32 +69,17 @@ export function MediaFiltersDropdown({
         : state.setModelImageFilters,
   }));
 
-  const mergedFilters = query || filters;
+  const committedFilters = useMemo(() => query || filters, [query, filters]);
 
-  // maybe have individual filter length with labels next to them
+  const handleApply = useCallback(
+    (next: typeof committedFilters) => {
+      if (onChange) onChange(next);
+      else setFilters(next);
+    },
+    [onChange, setFilters]
+  );
 
-  const filterLength =
-    ('types' in mergedFilters && !hideMediaTypes ? mergedFilters.types?.length ?? 0 : 0) +
-    (mergedFilters.withMeta ? 1 : 0) +
-    (mergedFilters.requiringMeta ? 1 : 0) +
-    (mergedFilters.hidden ? 1 : 0) +
-    (mergedFilters.fromPlatform ? 1 : 0) +
-    (mergedFilters.hideManualResources ? 1 : 0) +
-    (mergedFilters.hideAutoResources ? 1 : 0) +
-    (mergedFilters.notPublished ? 1 : 0) +
-    (mergedFilters.scheduled ? 1 : 0) +
-    (!!mergedFilters.tools?.length ? 1 : 0) +
-    (!!mergedFilters.techniques?.length ? 1 : 0) +
-    (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
-    (!hideBaseModels ? mergedFilters.baseModels?.length ?? 0 : 0) +
-    (!!mergedFilters.remixesOnly || !!mergedFilters.nonRemixesOnly ? 1 : 0) +
-    (mergedFilters.poiOnly ? 1 : 0) +
-    (mergedFilters.minorOnly ? 1 : 0) +
-    (isModerator && mergedFilters.disablePoi ? 1 : 0) +
-    (isModerator && mergedFilters.disableMinor ? 1 : 0) +
-    (showPG13Toggle && mergedFilters.includePG13 ? 1 : 0);
-
-  const clearFilters = useCallback(() => {
+  const handleClear = useCallback(() => {
     // All values must be `undefined` so `removeEmpty` strips them from the URL
     // (when onChange writes to query params) and from the Zustand store. Using
     // `false` here would leave keys like `?withMeta=false` on the URL.
@@ -122,7 +104,6 @@ export function MediaFiltersDropdown({
       minorOnly: undefined,
       includePG13: undefined,
     };
-
     // `period` is special: the URL path needs `undefined` so `removeEmpty`
     // strips `?period=AllTime`, but the Zustand store needs `AllTime` so
     // `PeriodFilter` keeps rendering its chips (it returns null when period
@@ -131,8 +112,38 @@ export function MediaFiltersDropdown({
     else setFilters({ ...reset, period: MetricTimeframe.AllTime });
   }, [onChange, setFilters]);
 
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: handleApply,
+      onClear: handleClear,
+    });
+
+  // maybe have individual filter length with labels next to them
+
+  const filterLength =
+    ('types' in mergedFilters && !hideMediaTypes ? mergedFilters.types?.length ?? 0 : 0) +
+    (mergedFilters.withMeta ? 1 : 0) +
+    (mergedFilters.requiringMeta ? 1 : 0) +
+    (mergedFilters.hidden ? 1 : 0) +
+    (mergedFilters.fromPlatform ? 1 : 0) +
+    (mergedFilters.hideManualResources ? 1 : 0) +
+    (mergedFilters.hideAutoResources ? 1 : 0) +
+    (mergedFilters.notPublished ? 1 : 0) +
+    (mergedFilters.scheduled ? 1 : 0) +
+    (!!mergedFilters.tools?.length ? 1 : 0) +
+    (!!mergedFilters.techniques?.length ? 1 : 0) +
+    (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
+    (!hideBaseModels ? mergedFilters.baseModels?.length ?? 0 : 0) +
+    (!!mergedFilters.remixesOnly || !!mergedFilters.nonRemixesOnly ? 1 : 0) +
+    (mergedFilters.poiOnly ? 1 : 0) +
+    (mergedFilters.minorOnly ? 1 : 0) +
+    (isModerator && mergedFilters.disablePoi ? 1 : 0) +
+    (isModerator && mergedFilters.disableMinor ? 1 : 0) +
+    (showPG13Toggle && mergedFilters.includePG13 ? 1 : 0);
+
   const handleChange: Props['onChange'] = (value) => {
-    onChange ? onChange(value) : setFilters(value);
+    patchPending(value);
   };
 
   const target = (
@@ -147,7 +158,7 @@ export function MediaFiltersDropdown({
       <FilterButton
         {...buttonProps}
         icon={IconFilter}
-        onClick={() => setOpened((o) => !o)}
+        onClick={toggle}
         active={opened}
       >
         Filters
@@ -155,20 +166,16 @@ export function MediaFiltersDropdown({
     </Indicator>
   );
 
-  const dropdown = (
+  const dropdownBody = (
     <Stack gap="lg" p="md">
       <Stack gap="md">
         <Divider label="Time period" className="text-sm font-bold" mb={4} />
-        {query?.period && onChange ? (
-          <PeriodFilter
-            type={filterType}
-            variant="chips"
-            value={query.period}
-            onChange={(period) => onChange({ period })}
-          />
-        ) : (
-          <PeriodFilter type={filterType} variant="chips" />
-        )}
+        <PeriodFilter
+          type={filterType}
+          variant="chips"
+          value={mergedFilters.period ?? MetricTimeframe.AllTime}
+          onChange={(period) => handleChange({ period })}
+        />
       </Stack>
       <Stack gap="md">
         {!hideMediaTypes && (
@@ -362,17 +369,17 @@ export function MediaFiltersDropdown({
           comboboxProps={{ withinPortal: false }}
         />
       </Stack>
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all filters
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -381,21 +388,30 @@ export function MediaFiltersDropdown({
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           styles={{
             content: {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
-              overflowY: 'auto',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdown}
+          <ScrollArea.Autosize type="hover" className="min-h-0 flex-1">
+            {dropdownBody}
+          </ScrollArea.Autosize>
+          {dropdownFooter}
         </Drawer>
       </>
     );
@@ -406,15 +422,17 @@ export function MediaFiltersDropdown({
       position="bottom-end"
       shadow="md"
       radius={12}
-      onClose={() => setOpened(false)}
+      opened={opened}
+      onClose={close}
       middlewares={{ flip: true, shift: true }}
       withinPortal
     >
       <Popover.Target>{target}</Popover.Target>
       <Popover.Dropdown maw={468} p={0} w="100%">
-        <ScrollArea.Autosize type="hover" mah={'calc(90vh - var(--header-height) - 56px)'}>
-          {dropdown}
+        <ScrollArea.Autosize type="hover" mah={'calc(90vh - var(--header-height) - 156px)'}>
+          {dropdownBody}
         </ScrollArea.Autosize>
+        {dropdownFooter}
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -396,21 +396,12 @@ export function MediaFiltersDropdown({
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          <ScrollArea.Autosize type="hover" className="min-h-0 flex-1">
-            {dropdownBody}
-          </ScrollArea.Autosize>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Image/Infinite/ImagesInfinite.tsx
+++ b/src/components/Image/Infinite/ImagesInfinite.tsx
@@ -74,6 +74,7 @@ export function ImagesInfiniteContent({
   });
   showEof = showEof && filters.period !== MetricTimeframe.AllTime;
   const [debouncedFilters, cancel] = useDebouncedValue(filters, 500);
+  const infiniteQueryKey = useMemo(() => getQueryKey(trpc.image.getInfinite), []);
 
   const rawBrowsingLevel = useBrowsingLevelDebounced();
   const domainColor = useDomainColor();
@@ -108,6 +109,23 @@ export function ImagesInfiniteContent({
   }, [cancel, debouncedFilters, filters]);
   //#endregion
 
+  //#region [abort orphaned in-flight feed requests on filter change]
+  // When debouncedFilters change, the previous useInfiniteQuery observer
+  // unsubscribes and a new one subscribes under the new key. Any request
+  // already in flight for the old key keeps running server-side and holds a
+  // heavy-image bulkhead slot (see request-bulkhead.ts + heavyProcedure in
+  // src/server/trpc.ts) until it completes. Rapid filter changes stack these
+  // orphans and produce TOO_MANY_REQUESTS on subsequent users. Cancelling
+  // orphaned (observer-less) in-flight queries fires the AbortSignal that
+  // tRPC plumbs into the handler ctx, freeing the slot immediately.
+  useEffect(() => {
+    queryClient.cancelQueries({
+      queryKey: infiniteQueryKey,
+      predicate: (q) => q.getObserversCount() === 0 && q.state.fetchStatus === 'fetching',
+    });
+  }, [debouncedFilters, browsingLevel, infiniteQueryKey]);
+  //#endregion
+
   //#region [search retry] — any backend failure (Meili, API, network)
   const [retryAttempt, setRetryAttempt] = useState(0);
   const imagesCount = images.length;
@@ -131,7 +149,6 @@ export function ImagesInfiniteContent({
 
   //#region [slow fetch] — bad pods hang; show banner at 5s, abort at 15s
   const [isSlow, setIsSlow] = useState(false);
-  const infiniteQueryKey = useMemo(() => getQueryKey(trpc.image.getInfinite), []);
 
   // Depend on retryAttempt so every retry restarts the slow timer even when
   // isFetching doesn't visibly transition through false (cancel + refetch in

--- a/src/components/Image/Infinite/ImagesInfinite.tsx
+++ b/src/components/Image/Infinite/ImagesInfinite.tsx
@@ -1,5 +1,4 @@
 import { Button, Center, Group, Loader, LoadingOverlay } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import { getQueryKey } from '@trpc/react-query';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { isEqual } from 'lodash-es';
@@ -67,13 +66,16 @@ export function ImagesInfiniteContent({
   ...imageProviderProps
 }: ImagesInfiniteProps) {
   const imageFilters = useImageFilters(filterType);
-  const filters = removeEmpty({
+  const computedFilters = removeEmpty({
     ...(disableStoreFilters ? filterOverrides : { ...imageFilters, ...filterOverrides }),
     useIndex,
     withTags,
   });
+  // Stabilize identity so effects/query keys only fire on real content change.
+  const filtersRef = useRef(computedFilters);
+  if (!isEqual(filtersRef.current, computedFilters)) filtersRef.current = computedFilters;
+  const filters = filtersRef.current;
   showEof = showEof && filters.period !== MetricTimeframe.AllTime;
-  const [debouncedFilters, cancel] = useDebouncedValue(filters, 500);
   const infiniteQueryKey = useMemo(() => getQueryKey(trpc.image.getInfinite), []);
 
   const rawBrowsingLevel = useBrowsingLevelDebounced();
@@ -99,18 +101,12 @@ export function ImagesInfiniteContent({
     debugRetryActive,
     debugDelayMs,
   } = useQueryImages(
-    { ...debouncedFilters, browsingLevel, include: ['cosmetics'] },
+    { ...filters, browsingLevel, include: ['cosmetics'] },
     { keepPreviousData: true }
   );
 
-  //#region [useEffect] cancel debounced filters
-  useEffect(() => {
-    if (isEqual(filters, debouncedFilters)) cancel();
-  }, [cancel, debouncedFilters, filters]);
-  //#endregion
-
   //#region [abort orphaned in-flight feed requests on filter change]
-  // When debouncedFilters change, the previous useInfiniteQuery observer
+  // When filters change, the previous useInfiniteQuery observer
   // unsubscribes and a new one subscribes under the new key. Any request
   // already in flight for the old key keeps running server-side and holds a
   // heavy-image bulkhead slot (see request-bulkhead.ts + heavyProcedure in
@@ -123,7 +119,7 @@ export function ImagesInfiniteContent({
       queryKey: infiniteQueryKey,
       predicate: (q) => q.getObserversCount() === 0 && q.state.fetchStatus === 'fetching',
     });
-  }, [debouncedFilters, browsingLevel, infiniteQueryKey]);
+  }, [filters, browsingLevel, infiniteQueryKey]);
   //#endregion
 
   //#region [search retry] — any backend failure (Meili, API, network)
@@ -144,7 +140,7 @@ export function ImagesInfiniteContent({
   // Reset retry state when filters change (new query = fresh slate).
   useEffect(() => {
     setRetryAttempt(0);
-  }, [debouncedFilters, browsingLevel]);
+  }, [filters, browsingLevel]);
   //#endregion
 
   //#region [slow fetch] — bad pods hang; show banner at 5s, abort at 15s

--- a/src/components/Model/Infinite/ModelFiltersDropdown.tsx
+++ b/src/components/Model/Infinite/ModelFiltersDropdown.tsx
@@ -390,15 +390,23 @@ export function DumbModelFiltersDropdown({
           position="bottom"
           styles={{
             content: {
-              height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
+              display: 'flex',
+              flexDirection: 'column',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </IsClient>

--- a/src/components/Model/Infinite/ModelFiltersDropdown.tsx
+++ b/src/components/Model/Infinite/ModelFiltersDropdown.tsx
@@ -393,21 +393,12 @@ export function DumbModelFiltersDropdown({
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          <ScrollArea.Autosize type="hover" className="min-h-0 flex-1">
-            {dropdownBody}
-          </ScrollArea.Autosize>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </IsClient>

--- a/src/components/Model/Infinite/ModelFiltersDropdown.tsx
+++ b/src/components/Model/Infinite/ModelFiltersDropdown.tsx
@@ -1,6 +1,5 @@
 import type { ButtonProps, PopoverProps } from '@mantine/core';
 import {
-  Button,
   Chip,
   Divider,
   Drawer,
@@ -10,14 +9,15 @@ import {
   Popover,
   ScrollArea,
   Stack,
-  useComputedColorScheme,
 } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
 import type { CSSProperties } from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import { PeriodFilter } from '~/components/Filters';
 import { FilterChip } from '~/components/Filters/FilterChip';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { IsClient } from '~/components/IsClient/IsClient';
 import { useModelQueryParams } from '~/components/Model/model.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -73,7 +73,6 @@ export function DumbModelFiltersDropdown({
 }) {
   const currentUser = useCurrentUser();
   const isModerator = currentUser?.isModerator;
-  const colorScheme = useComputedColorScheme('dark');
   const flags = useFeatureFlags();
   const mobile = useIsMobile();
   const {
@@ -83,32 +82,21 @@ export function DumbModelFiltersDropdown({
     ...query
   } = useModelQueryParams();
 
-  const [opened, setOpened] = useState(false);
-
   const localMode = filterMode === 'local';
-  const mergedFilters = localMode ? filters : { ...query, period, hidden };
-  const showCheckpointType =
-    !mergedFilters.types?.length || mergedFilters.types.includes('Checkpoint');
+  const committedFilters = useMemo<Partial<ModelFilterSchema>>(
+    () => (localMode ? filters : { ...query, period, hidden }),
+    [localMode, filters, query, period, hidden]
+  );
 
-  const filterLength =
-    (mergedFilters.types?.length ?? 0) +
-    (mergedFilters.baseModels?.length ?? 0) +
-    (mergedFilters.status?.length ?? 0) +
-    (showCheckpointType && mergedFilters.checkpointType ? 1 : 0) +
-    (mergedFilters.earlyAccess ? 1 : 0) +
-    (mergedFilters.supportsGeneration ? 1 : 0) +
-    (mergedFilters.fromPlatform ? 1 : 0) +
-    (mergedFilters.isFeatured ? 1 : 0) +
-    (mergedFilters.hidden ? 1 : 0) +
-    (mergedFilters.fileFormats?.length ?? 0) +
-    (!!mergedFilters.availability ? 1 : 0) +
-    (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
-    (mergedFilters.poiOnly ? 1 : 0) +
-    (mergedFilters.minorOnly ? 1 : 0) +
-    (isModerator && mergedFilters.disablePoi ? 1 : 0) +
-    (isModerator && mergedFilters.disableMinor ? 1 : 0);
+  const handleApply = useCallback(
+    (next: Partial<ModelFilterSchema>) => {
+      if (localMode) setFilters(next);
+      else setQueryFilters(next);
+    },
+    [localMode, setFilters, setQueryFilters]
+  );
 
-  const clearFilters = useCallback(() => {
+  const handleClear = useCallback(() => {
     const reset = {
       types: undefined,
       baseModels: undefined,
@@ -141,10 +129,33 @@ export function DumbModelFiltersDropdown({
     setFilters(reset);
   }, [localMode, setFilters, setQueryFilters]);
 
-  const handleChange = (value: Partial<ModelFilterSchema>) => {
-    if (localMode) setFilters(value);
-    else setQueryFilters(value);
-  };
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: handleApply,
+      onClear: handleClear,
+    });
+
+  const showCheckpointType =
+    !mergedFilters.types?.length || mergedFilters.types.includes('Checkpoint');
+
+  const filterLength =
+    (mergedFilters.types?.length ?? 0) +
+    (mergedFilters.baseModels?.length ?? 0) +
+    (mergedFilters.status?.length ?? 0) +
+    (showCheckpointType && mergedFilters.checkpointType ? 1 : 0) +
+    (mergedFilters.earlyAccess ? 1 : 0) +
+    (mergedFilters.supportsGeneration ? 1 : 0) +
+    (mergedFilters.fromPlatform ? 1 : 0) +
+    (mergedFilters.isFeatured ? 1 : 0) +
+    (mergedFilters.hidden ? 1 : 0) +
+    (mergedFilters.fileFormats?.length ?? 0) +
+    (!!mergedFilters.availability ? 1 : 0) +
+    (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
+    (mergedFilters.poiOnly ? 1 : 0) +
+    (mergedFilters.minorOnly ? 1 : 0) +
+    (isModerator && mergedFilters.disablePoi ? 1 : 0) +
+    (isModerator && mergedFilters.disableMinor ? 1 : 0);
 
   const target = (
     <Indicator
@@ -155,31 +166,22 @@ export function DumbModelFiltersDropdown({
       disabled={!filterLength}
       inline
     >
-      <FilterButton icon={IconFilter} onClick={() => setOpened((o) => !o)} active={opened}>
+      <FilterButton icon={IconFilter} onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
   );
 
-  const dropdown = (
+  const dropdownBody = (
     <Stack gap={8} p="md">
       <Stack gap={0}>
         <Divider label="Time period" className="text-sm font-bold" mb={4} />
-        {!localMode ? (
-          <PeriodFilter
-            type="models"
-            variant="chips"
-            value={period}
-            onChange={(period) => setQueryFilters({ period })}
-          />
-        ) : (
-          <PeriodFilter
-            type="models"
-            variant="chips"
-            value={filters.period ?? MetricTimeframe.AllTime}
-            onChange={(period) => handleChange({ period })}
-          />
-        )}
+        <PeriodFilter
+          type="models"
+          variant="chips"
+          value={mergedFilters.period ?? MetricTimeframe.AllTime}
+          onChange={(period) => patchPending({ period })}
+        />
       </Stack>
       <Stack gap={0}>
         {currentUser?.isModerator && (
@@ -189,7 +191,7 @@ export function DumbModelFiltersDropdown({
             <Chip.Group
               value={mergedFilters.availability}
               onChange={(availability) =>
-                handleChange({
+                patchPending({
                   availability: availability as Availability,
                 })
               }
@@ -208,7 +210,7 @@ export function DumbModelFiltersDropdown({
         {currentUser?.isModerator && (
           <Chip.Group
             value={mergedFilters.status ?? []}
-            onChange={(status) => handleChange({ status: status as ModelStatus[] })}
+            onChange={(status) => patchPending({ status: status as ModelStatus[] })}
             multiple
           >
             <Group gap={8} mb={4}>
@@ -224,27 +226,27 @@ export function DumbModelFiltersDropdown({
         <Group gap={8} mb={4}>
           <FilterChip
             checked={mergedFilters.earlyAccess}
-            onChange={(checked) => handleChange({ earlyAccess: checked })}
+            onChange={(checked) => patchPending({ earlyAccess: checked })}
           >
             <span>Early Access</span>
           </FilterChip>
           {flags.imageGeneration && (
             <FilterChip
               checked={mergedFilters.supportsGeneration}
-              onChange={(checked) => handleChange({ supportsGeneration: checked })}
+              onChange={(checked) => patchPending({ supportsGeneration: checked })}
             >
               <span>On-site Generation</span>
             </FilterChip>
           )}
           <FilterChip
             checked={mergedFilters.fromPlatform}
-            onChange={(checked) => handleChange({ fromPlatform: checked })}
+            onChange={(checked) => patchPending({ fromPlatform: checked })}
           >
             <span>Made On-site</span>
           </FilterChip>
           <FilterChip
             checked={mergedFilters.isFeatured}
-            onChange={(checked) => handleChange({ isFeatured: checked })}
+            onChange={(checked) => patchPending({ isFeatured: checked })}
           >
             <span>Featured</span>
           </FilterChip>
@@ -254,7 +256,7 @@ export function DumbModelFiltersDropdown({
         <Divider label="Model types" className="text-sm font-bold" mb={4} />
         <Chip.Group
           value={mergedFilters.types ?? []}
-          onChange={(types) => handleChange({ types: types as ModelType[] })}
+          onChange={(types) => patchPending({ types: types as ModelType[] })}
           multiple
         >
           <Group gap={8} mb={4}>
@@ -273,7 +275,7 @@ export function DumbModelFiltersDropdown({
             <Chip.Group
               value={mergedFilters.checkpointType ?? 'all'}
               onChange={(value) =>
-                handleChange({
+                patchPending({
                   checkpointType: value !== 'all' ? (value as CheckpointType) : undefined,
                 })
               }
@@ -292,7 +294,7 @@ export function DumbModelFiltersDropdown({
             <Chip.Group
               value={mergedFilters.fileFormats ?? []}
               onChange={(fileFormats) =>
-                handleChange({ fileFormats: fileFormats as typeof availableFileFormats })
+                patchPending({ fileFormats: fileFormats as typeof availableFileFormats })
               }
               multiple
             >
@@ -312,7 +314,7 @@ export function DumbModelFiltersDropdown({
         <MultiSelect
           data={baseModelSelectData}
           value={(mergedFilters.baseModels as string[]) ?? []}
-          onChange={(baseModels) => handleChange({ baseModels: baseModels as BaseModel[] })}
+          onChange={(baseModels) => patchPending({ baseModels: baseModels as BaseModel[] })}
           placeholder="All Base Models"
           searchable={!isMobileDevice()}
           clearable
@@ -327,7 +329,7 @@ export function DumbModelFiltersDropdown({
             <>
               <FilterChip
                 checked={mergedFilters.hidden}
-                onChange={(checked) => handleChange({ hidden: checked })}
+                onChange={(checked) => patchPending({ hidden: checked })}
               >
                 <span>Hidden</span>
               </FilterChip>
@@ -338,25 +340,25 @@ export function DumbModelFiltersDropdown({
             <>
               <FilterChip
                 checked={mergedFilters.poiOnly}
-                onChange={(checked) => handleChange({ poiOnly: checked })}
+                onChange={(checked) => patchPending({ poiOnly: checked })}
               >
                 <span>POI</span>
               </FilterChip>
               <FilterChip
                 checked={mergedFilters.minorOnly}
-                onChange={(checked) => handleChange({ minorOnly: checked })}
+                onChange={(checked) => patchPending({ minorOnly: checked })}
               >
                 <span>Minor</span>
               </FilterChip>
               <FilterChip
                 checked={mergedFilters.poiOnly}
-                onChange={(checked) => handleChange({ disablePoi: checked })}
+                onChange={(checked) => patchPending({ disablePoi: checked })}
               >
                 <span>Disable POI</span>
               </FilterChip>
               <FilterChip
                 checked={mergedFilters.minorOnly}
-                onChange={(checked) => handleChange({ disableMinor: checked })}
+                onChange={(checked) => patchPending({ disableMinor: checked })}
               >
                 <span>Disable Minor</span>
               </FilterChip>
@@ -364,17 +366,17 @@ export function DumbModelFiltersDropdown({
           )}
         </Group>
       </Stack>
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all filters
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -383,7 +385,7 @@ export function DumbModelFiltersDropdown({
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           styles={{
@@ -391,12 +393,22 @@ export function DumbModelFiltersDropdown({
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdown}
+          <ScrollArea.Autosize type="hover" className="min-h-0 flex-1">
+            {dropdownBody}
+          </ScrollArea.Autosize>
+          {dropdownFooter}
         </Drawer>
       </IsClient>
     );
@@ -407,7 +419,8 @@ export function DumbModelFiltersDropdown({
         zIndex={200}
         position={position}
         shadow="md"
-        onClose={() => setOpened(false)}
+        opened={opened}
+        onClose={close}
         middlewares={{ flip: true, shift: true }}
         withinPortal
         withArrow
@@ -415,11 +428,12 @@ export function DumbModelFiltersDropdown({
         <Popover.Target>{target}</Popover.Target>
         <Popover.Dropdown maw={576} p={0} w="100%">
           <ScrollArea.Autosize
-            mah={maxPopoverHeight ?? 'calc(90vh - var(--header-height) - 56px)'}
+            mah={maxPopoverHeight ?? 'calc(90vh - var(--header-height) - 156px)'}
             type="hover"
           >
-            {dropdown}
+            {dropdownBody}
           </ScrollArea.Autosize>
+          {dropdownFooter}
         </Popover.Dropdown>
       </Popover>
     </IsClient>

--- a/src/components/Model/Infinite/ModelsInfinite.tsx
+++ b/src/components/Model/Infinite/ModelsInfinite.tsx
@@ -1,8 +1,7 @@
 import { Button, Center, Group, Loader, LoadingOverlay } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import { isEqual } from 'lodash-es';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import { useEffect } from 'react';
+import { useRef } from 'react';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { ModelCard } from '~/components/Cards/ModelCard';
 import { ModelCardContextProvider } from '~/components/Cards/ModelCardContext';
@@ -36,23 +35,20 @@ export function ModelsInfinite({
 
   const pending = currentUser !== null && filterOverrides.username === currentUser.username;
 
-  const filters = removeEmpty({
+  const computedFilters = removeEmpty({
     ...(disableStoreFilters ? filterOverrides : { ...modelFilters, ...filterOverrides }),
     pending,
   });
-  const [debouncedFilters, cancel] = useDebouncedValue(filters, 500);
+  // Stabilize identity so query keys only update on real content change.
+  const filtersRef = useRef(computedFilters);
+  if (!isEqual(filtersRef.current, computedFilters)) filtersRef.current = computedFilters;
+  const filters = filtersRef.current;
 
   const browsingLevel = useBrowsingLevelDebounced();
   const { models, fetchNextPage, hasNextPage, isRefetching, isFetching } = useQueryModels({
-    ...debouncedFilters,
+    ...filters,
     browsingLevel,
   });
-
-  //#region [useEffect] cancel debounced filters
-  useEffect(() => {
-    if (isEqual(filters, debouncedFilters)) cancel();
-  }, [debouncedFilters, filters]);
-  //#endregion
 
   return (
     <ModelCardContextProvider

--- a/src/components/Post/Infinite/PostFiltersDropdown.tsx
+++ b/src/components/Post/Infinite/PostFiltersDropdown.tsx
@@ -124,19 +124,12 @@ export function PostFiltersDropdown({
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
             },
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Post/Infinite/PostFiltersDropdown.tsx
+++ b/src/components/Post/Infinite/PostFiltersDropdown.tsx
@@ -121,15 +121,23 @@ export function PostFiltersDropdown({
           position="bottom"
           styles={{
             content: {
-              height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
+              display: 'flex',
+              flexDirection: 'column',
             },
-            body: { padding: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Post/Infinite/PostFiltersDropdown.tsx
+++ b/src/components/Post/Infinite/PostFiltersDropdown.tsx
@@ -1,19 +1,12 @@
 import type { ButtonProps } from '@mantine/core';
-import {
-  Button,
-  Divider,
-  Drawer,
-  Indicator,
-  Popover,
-  Stack,
-  Tooltip,
-  useComputedColorScheme,
-} from '@mantine/core';
+import { Divider, Drawer, Indicator, Popover, Stack, Tooltip } from '@mantine/core';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { IconFilter } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { PeriodFilter } from '~/components/Filters';
 import { FilterChip } from '~/components/Filters/FilterChip';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFiltersContext } from '~/providers/FiltersProvider';
@@ -27,37 +20,41 @@ export function PostFiltersDropdown({
   showScheduled = true,
   ...buttonProps
 }: Props) {
-  const colorScheme = useComputedColorScheme('dark');
   const mobile = useIsMobile();
   const currentUser = useCurrentUser();
   const isModerator = currentUser?.isModerator;
-
-  const [opened, setOpened] = useState(false);
 
   const { filters, setFilters } = useFiltersContext((state) => ({
     filters: state.posts,
     setFilters: state.setPostFilters,
   }));
 
-  const mergedFilters = query || filters;
+  const committedFilters = useMemo(() => query || filters, [query, filters]);
 
-  const filterLength =
-    (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
-    (showScheduled && mergedFilters.scheduled ? 1 : 0);
+  const handleApply = useCallback(
+    (next: typeof committedFilters) => {
+      if (onChange) onChange(next);
+      else setFilters(next);
+    },
+    [onChange, setFilters]
+  );
 
-  const clearFilters = useCallback(() => {
-    const reset = {
-      period: MetricTimeframe.AllTime,
-      scheduled: undefined,
-    };
-
+  const handleClear = useCallback(() => {
+    const reset = { period: MetricTimeframe.AllTime, scheduled: undefined };
     if (onChange) onChange(reset);
     else setFilters(reset);
   }, [onChange, setFilters]);
 
-  const handleChange: Props['onChange'] = (value) => {
-    onChange ? onChange(value) : setFilters(value);
-  };
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: handleApply,
+      onClear: handleClear,
+    });
+
+  const filterLength =
+    (mergedFilters.period && mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
+    (showScheduled && mergedFilters.scheduled ? 1 : 0);
 
   const target = (
     <Indicator
@@ -68,31 +65,22 @@ export function PostFiltersDropdown({
       disabled={!filterLength}
       inline
     >
-      <FilterButton
-        {...buttonProps}
-        icon={IconFilter}
-        onClick={() => setOpened((o) => !o)}
-        active={opened}
-      >
+      <FilterButton {...buttonProps} icon={IconFilter} onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
   );
 
-  const dropdown = (
-    <Stack gap="lg">
+  const dropdownBody = (
+    <Stack gap="lg" p="md">
       <Stack gap="md">
         <Divider label="Time period" className="text-sm font-bold" />
-        {query?.period && onChange ? (
-          <PeriodFilter
-            type="posts"
-            variant="chips"
-            value={query.period}
-            onChange={(period) => onChange({ period })}
-          />
-        ) : (
-          <PeriodFilter type="posts" variant="chips" />
-        )}
+        <PeriodFilter
+          type="posts"
+          variant="chips"
+          value={mergedFilters.period ?? MetricTimeframe.AllTime}
+          onChange={(period) => patchPending({ period })}
+        />
       </Stack>
       {showScheduled && currentUser && !isModerator && (
         <Stack gap="md">
@@ -100,7 +88,7 @@ export function PostFiltersDropdown({
           <div className="flex flex-wrap gap-2">
             <FilterChip
               checked={!!mergedFilters.scheduled}
-              onChange={(checked) => handleChange({ scheduled: checked })}
+              onChange={(checked) => patchPending({ scheduled: checked })}
             >
               <Tooltip label="Include your scheduled posts">
                 <span>Scheduled</span>
@@ -109,17 +97,17 @@ export function PostFiltersDropdown({
           </div>
         </Stack>
       )}
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all filters
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -128,21 +116,28 @@ export function PostFiltersDropdown({
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           styles={{
             content: {
               height: 'auto',
               maxHeight: 'calc(100dvh - var(--header-height))',
-              overflowY: 'auto',
             },
-            body: { padding: 16, paddingTop: 0, overflowY: 'auto' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
             header: { padding: '4px 8px' },
             close: { height: 32, width: 32, '& > svg': { width: 24, height: 24 } },
           }}
         >
-          {dropdown}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownFooter}
         </Drawer>
       </>
     );
@@ -153,12 +148,14 @@ export function PostFiltersDropdown({
       position="bottom-end"
       shadow="md"
       radius={12}
-      onClose={() => setOpened(false)}
+      opened={opened}
+      onClose={close}
       middlewares={{ flip: true, shift: true }}
     >
       <Popover.Target>{target}</Popover.Target>
-      <Popover.Dropdown maw={468} p="md" w="100%">
-        {dropdown}
+      <Popover.Dropdown maw={468} p={0} w="100%">
+        {dropdownBody}
+        {dropdownFooter}
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/components/Post/Infinite/PostsInfinite.tsx
+++ b/src/components/Post/Infinite/PostsInfinite.tsx
@@ -1,9 +1,8 @@
 import { Center, Loader, LoadingOverlay, Stack, Text, ThemeIcon } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { IconCloudOff } from '@tabler/icons-react';
 import { isEqual } from 'lodash-es';
-import React, { useEffect } from 'react';
+import React, { useRef } from 'react';
 
 import { EndOfFeed } from '~/components/EndOfFeed/EndOfFeed';
 import { FeedWrapper } from '~/components/Feed/FeedWrapper';
@@ -50,22 +49,18 @@ function PostsInfiniteContent({
   disableStoreFilters,
 }: PostsInfiniteProps) {
   const postFilters = usePostFilters();
-  const filters = disableStoreFilters
+  const computedFilters = disableStoreFilters
     ? filterOverrides
     : removeEmpty({ ...postFilters, ...filterOverrides });
+  // Stabilize identity so query keys only update on real content change.
+  const filtersRef = useRef(computedFilters);
+  if (!isEqual(filtersRef.current, computedFilters)) filtersRef.current = computedFilters;
+  const filters = filtersRef.current;
   showEof = showEof && filters.period !== MetricTimeframe.AllTime;
-  const [debouncedFilters, cancel] = useDebouncedValue(filters, 500);
 
-  const { posts, fetchNextPage, hasNextPage, isRefetching, isFetching } = useQueryPosts(
-    debouncedFilters,
-    { keepPreviousData: true }
-  );
-
-  //#region [useEffect] cancel debounced filters
-  useEffect(() => {
-    if (isEqual(filters, debouncedFilters)) cancel();
-  }, [cancel, debouncedFilters, filters]);
-  //#endregion
+  const { posts, fetchNextPage, hasNextPage, isRefetching, isFetching } = useQueryPosts(filters, {
+    keepPreviousData: true,
+  });
 
   return (
     <>

--- a/src/components/Tool/ToolFiltersDropdown.tsx
+++ b/src/components/Tool/ToolFiltersDropdown.tsx
@@ -1,18 +1,8 @@
 import type { ButtonProps } from '@mantine/core';
-import {
-  Button,
-  Chip,
-  Divider,
-  Drawer,
-  Group,
-  Indicator,
-  Popover,
-  Stack,
-  useComputedColorScheme,
-} from '@mantine/core';
+import { Chip, Divider, Drawer, Group, Indicator, Popover, Stack } from '@mantine/core';
 import { ToolType } from '~/shared/utils/prisma/enums';
 import { IconFilter } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFiltersContext } from '~/providers/FiltersProvider';
 import type { GetAllToolsSchema } from '~/server/schema/tool.schema';
@@ -20,37 +10,45 @@ import type { GetAllToolsSchema } from '~/server/schema/tool.schema';
 import { useIsClient } from '~/providers/IsClientProvider';
 import { FilterButton } from '~/components/Buttons/FilterButton';
 import { FilterChip } from '~/components/Filters/FilterChip';
+import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
+import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import styles from './ToolFiltersDropdown.module.scss';
 
 const toolTypes = Object.keys(ToolType);
 
 export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) {
-  const colorScheme = useComputedColorScheme('dark');
   const mobile = useIsMobile();
   const isClient = useIsClient();
-
-  const [opened, setOpened] = useState(false);
 
   const { filters, setFilters } = useFiltersContext((state) => ({
     filters: state.tools,
     setFilters: state.setToolFilters,
   }));
 
-  const mergedFilters = query || filters;
-  const filterLength = mergedFilters.type ? 1 : 0;
+  const committedFilters = useMemo(() => query || filters, [query, filters]);
 
-  const clearFilters = useCallback(() => {
-    const reset = {
-      type: undefined,
-    };
+  const handleApply = useCallback(
+    (next: typeof committedFilters) => {
+      if (onChange) onChange(next);
+      else setFilters(next);
+    },
+    [onChange, setFilters]
+  );
 
+  const handleClear = useCallback(() => {
+    const reset = { type: undefined };
     if (onChange) onChange(reset);
     else setFilters(reset);
   }, [onChange, setFilters]);
 
-  const handleChange: Props['onChange'] = (value) => {
-    onChange ? onChange(value) : setFilters(value);
-  };
+  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
+    useStagedFilters({
+      committed: committedFilters,
+      onApply: handleApply,
+      onClear: handleClear,
+    });
+
+  const filterLength = mergedFilters.type ? 1 : 0;
 
   const target = (
     <Indicator
@@ -62,12 +60,7 @@ export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) 
       classNames={{ root: 'leading-none', indicator: 'leading-relaxed	' }}
       inline
     >
-      <FilterButton
-        {...buttonProps}
-        icon={IconFilter}
-        onClick={() => setOpened((o) => !o)}
-        active={opened}
-      >
+      <FilterButton {...buttonProps} icon={IconFilter} onClick={toggle} active={opened}>
         Filters
       </FilterButton>
     </Indicator>
@@ -75,13 +68,13 @@ export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) 
 
   if (!isClient) return target;
 
-  const dropdown = (
-    <Stack gap="lg">
+  const dropdownBody = (
+    <Stack gap="lg" p="md">
       <Stack gap="md">
         <Divider label="Type" classNames={{ label: 'font-bold text-sm' }} />
         <Chip.Group
           value={mergedFilters.type}
-          onChange={(type) => handleChange({ type: type as ToolType })}
+          onChange={(type) => patchPending({ type: type as ToolType })}
         >
           <Group gap={8} my={4}>
             {toolTypes.map((tool, index) => (
@@ -92,17 +85,17 @@ export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) 
           </Group>
         </Chip.Group>
       </Stack>
-      {filterLength > 0 && (
-        <Button
-          color="gray"
-          variant={colorScheme === 'dark' ? 'filled' : 'light'}
-          onClick={clearFilters}
-          fullWidth
-        >
-          Clear all filters
-        </Button>
-      )}
     </Stack>
+  );
+
+  const dropdownFooter = (
+    <StagedFiltersFooter
+      isDirty={isDirty}
+      onApply={apply}
+      onReset={reset}
+      filterLength={filterLength}
+      onClear={clearAndClose}
+    />
   );
 
   if (mobile)
@@ -111,17 +104,27 @@ export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) 
         {target}
         <Drawer
           opened={opened}
-          onClose={() => setOpened(false)}
+          onClose={close}
           size="90%"
           position="bottom"
           classNames={{
             content: styles.content,
-            body: styles.body,
             header: styles.header,
             close: styles.close,
           }}
+          styles={{
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
+          }}
         >
-          {dropdown}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownFooter}
         </Drawer>
       </>
     );
@@ -132,12 +135,14 @@ export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) 
       position="bottom-end"
       shadow="md"
       radius={12}
-      onClose={() => setOpened(false)}
+      opened={opened}
+      onClose={close}
       middlewares={{ flip: true, shift: true }}
     >
       <Popover.Target>{target}</Popover.Target>
-      <Popover.Dropdown maw={468} p="md" w="100%">
-        {dropdown}
+      <Popover.Dropdown maw={468} p={0} w="100%">
+        {dropdownBody}
+        {dropdownFooter}
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/components/Tool/ToolFiltersDropdown.tsx
+++ b/src/components/Tool/ToolFiltersDropdown.tsx
@@ -113,17 +113,10 @@ export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) 
             close: styles.close,
           }}
           styles={{
-            body: {
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              flex: 1,
-              minHeight: 0,
-            },
+            body: { padding: 0, overflowY: 'auto' },
           }}
         >
-          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
+          {dropdownBody}
           {dropdownFooter}
         </Drawer>
       </>

--- a/src/components/Tool/ToolFiltersDropdown.tsx
+++ b/src/components/Tool/ToolFiltersDropdown.tsx
@@ -113,10 +113,18 @@ export function ToolFiltersDropdown({ query, onChange, ...buttonProps }: Props) 
             close: styles.close,
           }}
           styles={{
-            body: { padding: 0, overflowY: 'auto' },
+            content: { display: 'flex', flexDirection: 'column' },
+            body: {
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              flex: 1,
+              minHeight: 0,
+            },
           }}
         >
-          {dropdownBody}
+          <div className="min-h-0 flex-1 overflow-y-auto">{dropdownBody}</div>
           {dropdownFooter}
         </Drawer>
       </>


### PR DESCRIPTION
## Summary
- Filter dropdowns across feeds (Media, Model, Article, Bounty, Post, Tool, Changelog, Challenge, Auction) now stage chip toggles locally; one Apply commit = one feed request.
- Shared `useStagedFilters` hook + `StagedFiltersFooter` band. Footer pinned without overlapping the scroll body.
- `ImagesInfinite` cancels orphaned in-flight feed queries on filter change so the heavy-image bulkhead slot is freed via `AbortSignal`.

<img width="1019" height="827" alt="image" src="https://github.com/user-attachments/assets/4693d761-9b4c-467f-abb7-026b4b71a41d" />


## Test plan
- [x] Open Models / Images filter, toggle several chips fast — no network requests fire until Apply.
- [x] Apply commits one request; URL/store reflects pending state.
- [x] Close dropdown without Apply → pending discarded; reopen shows committed state.
- [x] Reset reverts pending to committed; Clear all filters commits empty + closes.
- [x] Scrolling popovers (Model, Media, Challenge) — scrollbar ends above footer; last filter row not hidden.
- [x] Mobile drawer — footer pinned at bottom; body scrolls under it.
- [x] Rapidly toggling sort/period chips outside the dropdown → only the latest request survives (others abort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)