### PR TITLE
test(preview): browser smoke tests for deployed PR previews

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,9 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
-  testIgnore: 'example.spec.ts',
+  // preview-* run only under playwright.preview.config.ts (need PREVIEW_URL); the
+  // default `setup` project's *.setup.ts glob would otherwise pick them up.
+  testIgnore: ['example.spec.ts', '**/preview-*.ts'],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -26,11 +26,18 @@ export default defineConfig({
   // Modest parallelism: enough to not run 11 navigations serially, bounded so a
   // single-replica preview pod isn't hammered. (workers:1 would defeat fullyParallel.)
   workers: 4,
+  // A freshly-deployed preview is cold: the first SSR render of a heavy page (the
+  // homepage especially) can take 30-40s while the Next server warms, JIT-compiles,
+  // and opens DB pools. The default 30s per-test timeout is too tight for that cold
+  // first hit, so raise both the per-test and navigation timeouts. The setup project
+  // also fires a warm-up request before the suite (preview-auth.setup.ts).
+  timeout: 60_000,
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   use: {
     baseURL: PREVIEW_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    navigationTimeout: 45_000,
   },
   projects: [
     { name: 'preview-setup', testMatch: /preview-auth\.setup\.ts/ },

--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: 1,
+  // Modest parallelism: enough to not run 11 navigations serially, bounded so a
+  // single-replica preview pod isn't hammered. (workers:1 would defeat fullyParallel.)
+  workers: 4,
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   use: {
     baseURL: PREVIEW_URL,

--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for smoke-testing a DEPLOYED PR preview environment.
+ *
+ * Used by the datapacket-talos `pr-smoke-test` Tekton task, not local dev. Unlike
+ * playwright.config.ts there is no `webServer` — we hit the live preview at
+ * PREVIEW_URL (e.g. https://pr-1234.civitaic.com). Auth is minted by
+ * tests/preview-auth.setup.ts (no /testing/testing-login, which is dead under a
+ * production build). Requires env: PREVIEW_URL, NEXTAUTH_SECRET.
+ *
+ * Run: PREVIEW_URL=… NEXTAUTH_SECRET=… npx playwright test -c playwright.preview.config.ts
+ */
+
+const PREVIEW_URL = process.env.PREVIEW_URL;
+if (!PREVIEW_URL) {
+  throw new Error('PREVIEW_URL is required for playwright.preview.config.ts');
+}
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: /preview-(auth\.setup|smoke\.spec)\.ts/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  use: {
+    baseURL: PREVIEW_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'preview-setup', testMatch: /preview-auth\.setup\.ts/ },
+    {
+      name: 'preview-smoke',
+      testMatch: /preview-smoke\.spec\.ts/,
+      dependencies: ['preview-setup'],
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -1,0 +1,84 @@
+import { test as setup } from '@playwright/test';
+import fs from 'fs';
+import { encode } from 'next-auth/jwt';
+import { v4 as uuid } from 'uuid';
+import { PREVIEW_USERS, type PreviewRole, storageStatePath } from './preview-fixtures';
+
+/**
+ * Preview-environment auth setup.
+ *
+ * A deployed PR preview (IS_PREVIEW=true) is gated by preview-auth.middleware:
+ * unauthenticated -> /login, moderators pass, other logged-in users pass only
+ * if the Flipt `preview-site-access` `testers` segment matches them. The local
+ * `/testing/testing-login` flow (tests/auth.setup.ts) is DEAD against a preview
+ * because previews run NODE_ENV=production, which disables both the
+ * `testing-login` credentials provider and the `/testing/*` route.
+ *
+ * Instead we mint the NextAuth session cookie directly with the preview's
+ * shared NEXTAUTH_SECRET — the same `encode()` the app signs with, so JWE parity
+ * is guaranteed. The middleware reads `token.user` straight from the cookie (no
+ * DB round-trip), and the app's session callback fail-opens on an untracked
+ * token id, so a minted cookie yields a fully authenticated session. The backing
+ * User rows (and the gold subscription) are seeded into cnpg-cluster-dev by the
+ * datapacket-talos `seed-smoke-test-users` CronJob; ci-smoke-tester /
+ * ci-smoke-gold are in the flipt `testers` allowlist so they pass the gate.
+ *
+ * Only runs in the preview Playwright config (playwright.preview.config.ts);
+ * the default config ignores `preview-*` files.
+ */
+
+const SECRET = process.env.NEXTAUTH_SECRET;
+const PREVIEW_URL = process.env.PREVIEW_URL;
+const COOKIE_NAME = '__Secure-civitai-token'; // libs/auth.ts — https preview => __Secure- prefix
+const MAX_AGE_S = 30 * 24 * 60 * 60;
+
+async function mintStorageState(role: PreviewRole) {
+  const u = PREVIEW_USERS[role];
+
+  // token.user shape (ExtendedUser, src/types/next-auth.d.ts). id + isModerator
+  // drive the gate; the rest matches the seeded DB row so SSR treats it as a
+  // real logged-in user. ci-smoke-mod is the only moderator.
+  const user = {
+    id: u.id,
+    username: u.username,
+    email: `${u.username}@civitai.test`,
+    isModerator: u.isModerator,
+    tier: u.tier,
+    showNsfw: true,
+    blurNsfw: false,
+    browsingLevel: 1,
+    onboarding: 15, // OnboardingComplete (TOS|Profile|BrowsingLevels|Buzz)
+    muted: false,
+  };
+
+  const token = { user, sub: String(u.id), id: uuid(), signedAt: Date.now() };
+  const value = await encode({ token, secret: SECRET as string, maxAge: MAX_AGE_S });
+
+  const { hostname } = new URL(PREVIEW_URL as string);
+  const storageState = {
+    cookies: [
+      {
+        name: COOKIE_NAME,
+        value,
+        domain: hostname,
+        path: '/',
+        expires: Math.floor(Date.now() / 1000) + MAX_AGE_S,
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Lax' as const,
+      },
+    ],
+    origins: [],
+  };
+
+  fs.mkdirSync('tests/auth', { recursive: true });
+  fs.writeFileSync(storageStatePath(role), JSON.stringify(storageState, null, 2));
+}
+
+setup('mint preview sessions', async () => {
+  if (!SECRET) throw new Error('NEXTAUTH_SECRET is required to mint preview sessions');
+  if (!PREVIEW_URL) throw new Error('PREVIEW_URL is required for preview smoke tests');
+  for (const role of Object.keys(PREVIEW_USERS) as PreviewRole[]) {
+    await mintStorageState(role);
+  }
+});

--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -82,10 +82,17 @@ async function mintStorageState(role: PreviewRole) {
   fs.writeFileSync(storageStatePath(role), JSON.stringify(storageState, null, 2));
 }
 
-setup('mint preview sessions', async () => {
+setup('mint preview sessions', async ({ request }) => {
   if (!SECRET) throw new Error('NEXTAUTH_SECRET is required to mint preview sessions');
   if (!PREVIEW_URL) throw new Error('PREVIEW_URL is required for preview smoke tests');
   for (const role of Object.keys(PREVIEW_USERS) as PreviewRole[]) {
     await mintStorageState(role);
   }
+
+  // Warm the freshly-deployed preview before the suite runs so the first real
+  // test doesn't eat the full cold-SSR cost (Next server warm-up + JIT + DB pool
+  // open can push the homepage past the per-test timeout on a cold preview). An
+  // unauthenticated GET (which the gate 307s to /login) is enough to warm the
+  // server process; failures here are non-fatal — the suite + retries cover it.
+  await request.get('/', { timeout: 60_000, maxRedirects: 0 }).catch(() => {});
 });

--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -16,11 +16,18 @@ import { PREVIEW_USERS, type PreviewRole, storageStatePath } from './preview-fix
  *
  * Instead we mint the NextAuth session cookie directly with the preview's
  * shared NEXTAUTH_SECRET — the same `encode()` the app signs with, so JWE parity
- * is guaranteed. The middleware reads `token.user` straight from the cookie (no
- * DB round-trip), and the app's session callback fail-opens on an untracked
- * token id, so a minted cookie yields a fully authenticated session. The backing
- * User rows (and the gold subscription) are seeded into cnpg-cluster-dev by the
- * datapacket-talos `seed-smoke-test-users` CronJob; ci-smoke-tester /
+ * is guaranteed. Two distinct things then happen, and the distinction matters:
+ *   1. The GATE (preview-auth.middleware) reads `token.user` straight from the
+ *      cookie (no DB hit) — so the MINTED `id`/`isModerator` are what clear it.
+ *   2. SSR page renders call the session() callback → refreshToken(), which sees
+ *      an untracked token id and refreshes `token.user` from the DB
+ *      (getSessionUser). So past the gate, the SEEDED DB row — not the minted
+ *      fields — is the authoritative session user.
+ * Net: the minted cookie authenticates as the seeded user. The minted object
+ * below only needs `id` + `isModerator` (+ `tier` for the gate's Flipt context);
+ * the rest is informational and is superseded by the DB row on first render. The
+ * backing User rows (and the gold subscription) are seeded into cnpg-cluster-dev
+ * by the datapacket-talos `seed-smoke-test-users` CronJob; ci-smoke-tester /
  * ci-smoke-gold are in the flipt `testers` allowlist so they pass the gate.
  *
  * Only runs in the preview Playwright config (playwright.preview.config.ts);

--- a/tests/preview-fixtures.ts
+++ b/tests/preview-fixtures.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+
+/**
+ * Shared fixtures for the preview smoke tests. NOT a test file (Playwright
+ * forbids test files importing each other), so the setup + spec both import
+ * from here. Matched by the default config's `**\/preview-*.ts` testIgnore and
+ * excluded from the preview config's testMatch, so Playwright never treats it
+ * as a test.
+ */
+
+export type PreviewRole = 'mod' | 'tester' | 'gold' | 'restricted';
+
+// Must mirror datapacket-talos seed-smoke-test-users.yaml (fixed reserved ids)
+// and the flipt-state `testers` allowlist (tester + gold).
+export const PREVIEW_USERS: Record<
+  PreviewRole,
+  { id: number; username: string; isModerator: boolean; tier?: 'gold' }
+> = {
+  mod: { id: 2000000001, username: 'ci-smoke-mod', isModerator: true },
+  tester: { id: 2000000002, username: 'ci-smoke-tester', isModerator: false },
+  gold: { id: 2000000004, username: 'ci-smoke-gold', isModerator: false, tier: 'gold' },
+  restricted: { id: 2000000003, username: 'ci-smoke-restricted', isModerator: false },
+};
+
+export const storageStatePath = (role: PreviewRole) =>
+  path.join('tests/auth', `.preview-${role}.json`);

--- a/tests/preview-smoke.spec.ts
+++ b/tests/preview-smoke.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+
+/**
+ * Smoke tests for a deployed PR preview environment.
+ *
+ * Asserts the preview login gate (preview-auth.middleware) behaves per role and
+ * that core pages render for users who pass it. Runs only under
+ * playwright.preview.config.ts (needs PREVIEW_URL + the minted storage states).
+ */
+
+// Core pages every gate-passing user should be able to load.
+const CORE_PAGES = ['/', '/models', '/images'];
+
+// Roles that MUST clear the gate (mod via code, tester/gold via Flipt allowlist).
+const ALLOWED_ROLES = ['mod', 'tester', 'gold'] as const;
+
+for (const role of ALLOWED_ROLES) {
+  test.describe(`gate passes for ${role}`, () => {
+    test.use({ storageState: storageStatePath(role) });
+
+    for (const path of CORE_PAGES) {
+      test(`${role} loads ${path}`, async ({ page }) => {
+        const resp = await page.goto(path, { waitUntil: 'domcontentloaded' });
+        expect(resp?.status(), `HTTP status for ${path}`).toBeLessThan(400);
+        // Not bounced to either gate destination.
+        expect(page.url(), 'should not redirect to /login').not.toContain('/login');
+        expect(page.url(), 'should not redirect to /preview-restricted').not.toContain(
+          '/preview-restricted'
+        );
+      });
+    }
+  });
+}
+
+test.describe('gate denies a logged-in non-tester', () => {
+  test.use({ storageState: storageStatePath('restricted') });
+
+  test('restricted user is redirected to /preview-restricted', async ({ page }) => {
+    await page.goto('/models', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/preview-restricted/);
+  });
+});
+
+test.describe('gate denies anonymous', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('anonymous user is redirected to /login', async ({ page }) => {
+    await page.goto('/models', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/login/);
+  });
+});


### PR DESCRIPTION
## What

Adds a Playwright smoke suite that runs against a **deployed PR preview** URL and asserts the `IS_PREVIEW` login gate (`preview-auth.middleware`) behaves per role, plus that core pages render for users who pass it.

| Role | Fixture | Gate outcome asserted |
|---|---|---|
| mod | `ci-smoke-mod` (2000000001) | ✅ passes (code fast-path), `/` `/models` `/images` render |
| tester | `ci-smoke-tester` (2000000002) | ✅ passes (flipt `testers` allowlist) |
| gold | `ci-smoke-gold` (2000000004) | ✅ passes + `tier=gold` |
| restricted | `ci-smoke-restricted` (2000000003) | 🚫 → `/preview-restricted` |
| anonymous | — | 🚫 → `/login` |

## How auth works

The local `/testing/testing-login` flow is **dead against a preview** — previews run `NODE_ENV=production`, which disables both the `testing-login` provider and the `/testing/*` route. So `tests/preview-auth.setup.ts` mints the NextAuth session cookie directly with the preview's shared `NEXTAUTH_SECRET` via `next-auth/jwt` `encode()` (the same function the app signs with). The middleware reads `token.user` straight from the cookie, and the session callback fail-opens on an untracked token id → a fully authenticated session. Backing `User` rows (+ a gold subscription) are seeded into `cnpg-cluster-dev` out-of-band by a datapacket-talos CronJob; the two non-mod fixtures are added to the flipt `testers` allowlist (separate flipt-state PR).

## Scope / safety

- Runs **only** under the new `playwright.preview.config.ts` (requires `PREVIEW_URL`); the default config gains a one-line `testIgnore` for `preview-*`, so local `npm test` is unchanged.
- Driven from datapacket-talos Tekton as a **report-only** task initially (non-blocking commit status).
- No app/runtime code changed — test-harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)