### PR TITLE
perf(redis): cut imagesForModelVersions cache TTL 24h→18h to relieve next-redis-cluster LRU pressure

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -4844,7 +4844,16 @@ type CachedImagesForModelVersions = {
 export const imagesForModelVersionsCache = createCachedObject<CachedImagesForModelVersions>({
   key: REDIS_KEYS.CACHES.IMAGES_FOR_MODEL_VERSION,
   idKey: 'modelVersionId',
-  ttl: CacheTTL.day,
+  // Largest per-key bucket on next-redis-cluster (~5 KiB/value, ~843k keys
+  // ≈ 4.2 GiB). With staleWhileRevalidate the effective Redis EX is ttl*2, so
+  // the old CacheTTL.day produced ~48h live keys and kept shards 0/1 pinned at
+  // ~98% (shard 0 actively evicting). Halved to 12h (EX ~24h) to relieve LRU
+  // pressure. Safe because SWR serves the stale value while revalidating under
+  // a lock (no user-facing latency on the heavy lookup query), and real
+  // showcase changes are handled by explicit bust()/refresh(), not TTL expiry —
+  // the TTL is a freshness floor, not the correctness mechanism. Tradeoff: the
+  // expensive multi-join lookupFn revalidates ~2x more often in the background.
+  ttl: CacheTTL.hour * 12,
   // The lookupFn filters on async-populated columns (i.nsfwLevel != 0,
   // i.needsReview IS NULL). A read between publish and ingestion-complete
   // returns zero rows. We still cache notFound to skip the requery cost on

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -4846,19 +4846,25 @@ export const imagesForModelVersionsCache = createCachedObject<CachedImagesForMod
   idKey: 'modelVersionId',
   // Largest per-key bucket on next-redis-cluster (~5 KiB/value, ~843k keys
   // ≈ 4.2 GiB). With staleWhileRevalidate the effective Redis EX is ttl*2, so
-  // the old CacheTTL.day produced ~48h live keys and kept shards 0/1 pinned at
-  // ~98% (shard 0 actively evicting). Halved to 12h (EX ~24h) to relieve LRU
-  // pressure. Safe because SWR serves the stale value while revalidating under
-  // a lock (no user-facing latency on the heavy lookup query), and real
-  // showcase changes are handled by explicit bust()/refresh(), not TTL expiry —
-  // the TTL is a freshness floor, not the correctness mechanism. Tradeoff: the
-  // expensive multi-join lookupFn revalidates ~2x more often in the background.
-  ttl: CacheTTL.hour * 12,
+  // the old CacheTTL.day produced ~48h live keys while shards 0/1 sat at ~98%.
+  // Cut to 18h (EX ~36h) to trim resident memory.
+  // NOTE — this is a memory-vs-load tradeoff, NOT free background work: on a
+  // stale hit the lock WINNER runs lookupFn inline/awaited (cache-helpers, the
+  // setNxKeepTtlWithEx path); only lock losers serve the stale value. So a
+  // shorter TTL makes the expensive Image×Post×ModelVersion×Model lookup run
+  // proportionally more often in the FOREGROUND, on the same read replica
+  // implicated in the api-primary healthcheck-timeout cascade. 18h adds ~33%
+  // revalidation vs ~100% at 12h — watch cacheRevalidate rate + replica query
+  // cost on rollout. Reclaim on the LRU-saturated shards is unproven (allkeys-
+  // lru may already evict keys before 36h). Correctness is unaffected: real
+  // showcase changes go through bust()/refresh(), not TTL expiry — TTL is only
+  // a freshness floor.
+  ttl: CacheTTL.hour * 18,
   // The lookupFn filters on async-populated columns (i.nsfwLevel != 0,
   // i.needsReview IS NULL). A read between publish and ingestion-complete
   // returns zero rows. We still cache notFound to skip the requery cost on
   // versions that are genuinely empty, but cap the lifetime so a transient
-  // empty doesn't pin the model out of feeds for the full 1-day TTL.
+  // empty doesn't pin the model out of feeds for the full main TTL.
   notFoundTtl: CacheTTL.xs,
   // staleWhileRevalidate: false, // We might want to enable this later otherwise there will be a delay after a creator updates their showcase images...
   lookupFn: async (ids, fromWrite) => {

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -1795,7 +1795,7 @@ export const bustMvCache = async (
   await resourceDataCache.bust(versionIds);
   await bustOrchestratorModelCache(versionIds, userId);
   await modelVersionAccessCache.refresh(versionIds);
-  // Refresh imagesForModelVersionsCache too — TTL is up to 1 day on Datapacket,
+  // Refresh imagesForModelVersionsCache too — TTL is up to ~36h on Datapacket,
   // so a stale `images: []` entry from the publish race will hide the model
   // from feeds (the feed render drops items with no images for non-self
   // viewers) until the next image upload or natural expiry.


### PR DESCRIPTION
## What

Reduce the `imagesForModelVersionsCache` TTL on Datapacket: `CacheTTL.day` → `CacheTTL.hour * 18`.

With `staleWhileRevalidate`, the effective Redis `EX` is `ttl * 2`, so live-key lifetime drops **~48h → ~36h**.

## Why

`next-redis-cluster` is under memory pressure — 2 of 3 shards pinned at ~98% maxmemory (`allkeys-lru`, actively evicting). This is the **largest per-key bucket** (~5 KiB/value, ~843k keys ≈ **4.2 GiB**) with the longest observed TTLs (up to ~43.5h live).

## ⚠️ This is a memory-vs-load tradeoff, not free background work

An adversarial review corrected the original framing. In this codebase, `staleWhileRevalidate` does **not** revalidate purely in the background:

- On a stale hit, callers race for a per-key cross-pod Redis lock (`cache-helpers.ts`, `setNxKeepTtlWithEx`).
- The lock **winner** runs `lookupFn` **inline and awaited** — it blocks the response on the expensive `Image×Post×ModelVersion×Model CROSS JOIN LATERAL`. Only lock **losers** serve the stale value.

So a shorter TTL crosses the stale boundary more often → the heavy query runs proportionally more often **in the foreground**, on the **read replica that is the documented root of the api-primary healthcheck-timeout SIGKILL cascade**.

**That's why this is 18h, not 12h:** 18h adds ~33% more revalidation vs ~100% at 12h, while still cutting resident memory.

## Caveats / what to watch on rollout

- **Reclaim on the saturated shards is unproven.** With `allkeys-lru` already evicting, keys may be reaped before even 36h — so the win may land mostly on the cold shard. **Confirm with data**: `cacheRevalidate` rate for `packed:caches:images-for-model-version-2` + read-replica query cost, before/after.
- Keep a fast revert ready; watch replica p95 on hot endpoints (model cards, feeds, search-index, generation, downloads, auctions).

## Safety (verified by review)

- **Correctness is unaffected** — real showcase changes go through explicit `bust()`/`refresh()` (which repopulate from primary via `preventReplicationLagBatch`), not TTL expiry. TTL is only a freshness floor.
- `notFoundTtl` (60s negative cache) is independent of the main TTL — unchanged.
- Units verified: `CacheTTL.hour * 18 = 64800s = 18h`.

Draft pending the revalidation/replica-cost data above. Reviewer with replica-headroom knowledge should sign off on 18h vs holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
