### PR TITLE
test(unit): get the vitest suite green

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -61,6 +61,12 @@ vi.mock('@civitai/client', () => ({
 const TEST_ENV_DEFAULTS: Record<string, unknown> = {
   TIER_METADATA_KEY: 'tier',
   BUZZ_ENDPOINT: 'http://mock-buzz-endpoint',
+  // meilisearch/client.ts feeds this straight into pLimit() at module load —
+  // an undefined value makes p-limit throw "Expected concurrency to be a number".
+  // Mirror the production default (server-schema.ts: .default(50)).
+  MEILI_CALL_CONCURRENCY: 50,
+  // Same module-load pLimit() trap in signals/wrapper.ts (default 30).
+  SIGNALS_CALL_CONCURRENCY: 30,
   LOGGING: '',
   DATABASE_URL: 'postgres://user:pass@localhost:5432/db',
   NOTIFICATION_DB_URL: 'postgres://user:pass@localhost:5432/notif',
@@ -97,28 +103,53 @@ vi.mock('~/env/server', () => ({
 }));
 
 // Prevent prom/client from initializing real DB pools at module load.
+// A metric-shaped stub covering every prom-client surface our code touches
+// (Counter.inc, Gauge.inc/dec/set, Histogram.observe, and the .labels()/.startTimer()
+// helpers) so any registered metric — named export OR built via a register* factory
+// — is safe to call without a real prom-client registry.
+const promMetricStub = () => {
+  const child = { inc: vi.fn(), dec: vi.fn(), set: vi.fn(), observe: vi.fn() };
+  return {
+    inc: vi.fn(),
+    dec: vi.fn(),
+    set: vi.fn(),
+    observe: vi.fn(),
+    startTimer: vi.fn(() => vi.fn()),
+    labels: vi.fn(() => child),
+  };
+};
+
 vi.mock('~/server/prom/client', () => ({
-  registerCounter: vi.fn(() => ({ inc: vi.fn() })),
-  registerCounterWithLabels: vi.fn(() => ({ inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) })),
-  missingSignedAtCounter: { inc: vi.fn() },
-  newUserCounter: { inc: vi.fn() },
-  loginCounter: { inc: vi.fn() },
-  onboardingCompletedCounter: { inc: vi.fn() },
-  onboardingErrorCounter: { inc: vi.fn() },
-  leakingContentCounter: { inc: vi.fn() },
-  vaultItemProcessedCounter: { inc: vi.fn() },
-  vaultItemFailedCounter: { inc: vi.fn() },
-  rewardGivenCounter: { inc: vi.fn() },
-  rewardFailedCounter: { inc: vi.fn() },
-  clavataCounter: { inc: vi.fn() },
-  cacheHitCounter: { inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) },
-  cacheMissCounter: { inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) },
-  cacheRevalidateCounter: { inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) },
-  imagesFeedWithoutIndexCounter: { inc: vi.fn() },
-  creatorCompCreatorsPaidCounter: { inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) },
-  creatorCompAmountPaidCounter: { inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) },
-  userUpdateCounter: { inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) },
-  dbReadFallbackCounter: { inc: vi.fn(), labels: vi.fn(() => ({ inc: vi.fn() })) },
+  // Factory functions — modules call these at import time to build their metrics
+  // (e.g. meilisearch/client.ts, eventloop-longtask.ts). Each returns a stub.
+  registerCounter: vi.fn(promMetricStub),
+  registerCounterWithLabels: vi.fn(promMetricStub),
+  registerGaugeWithLabels: vi.fn(promMetricStub),
+  registerHistogram: vi.fn(promMetricStub),
+  registerInstrumentationMetric: vi.fn(promMetricStub),
+  // Named metric exports the real module ships.
+  missingSignedAtCounter: promMetricStub(),
+  newUserCounter: promMetricStub(),
+  loginCounter: promMetricStub(),
+  onboardingCompletedCounter: promMetricStub(),
+  onboardingErrorCounter: promMetricStub(),
+  leakingContentCounter: promMetricStub(),
+  vaultItemProcessedCounter: promMetricStub(),
+  vaultItemFailedCounter: promMetricStub(),
+  rewardGivenCounter: promMetricStub(),
+  rewardFailedCounter: promMetricStub(),
+  clavataCounter: promMetricStub(),
+  cacheHitCounter: promMetricStub(),
+  cacheMissCounter: promMetricStub(),
+  cacheRevalidateCounter: promMetricStub(),
+  trpcProcedureDuration: promMetricStub(),
+  imagesFeedWithoutIndexCounter: promMetricStub(),
+  creatorCompCreatorsPaidCounter: promMetricStub(),
+  creatorCompAmountPaidCounter: promMetricStub(),
+  licenseFeeCreatorsPaidCounter: promMetricStub(),
+  licenseFeeAmountPaidCounter: promMetricStub(),
+  userUpdateCounter: promMetricStub(),
+  dbReadFallbackCounter: promMetricStub(),
 }));
 
 // Mock logging

--- a/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
+++ b/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
@@ -303,13 +303,20 @@ describe('audit matching equivalence (gate vs brute-force)', () => {
     }
   });
 
-  it('includesPoi returns the same matched name as the reference', () => {
-    for (const p of corpus) {
-      expect(includesPoi(p), `includesPoi mismatch for: ${JSON.stringify(p)}`).toEqual(
-        refIncludesPoi(p)
-      );
-    }
-  });
+  // Brute-force POI equivalence over the full corpus is CPU-bound (the POI
+  // reference set is large); it correctly asserts but can exceed the 10s global
+  // testTimeout on a loaded CI runner. Give it room — logic is unchanged.
+  it(
+    'includesPoi returns the same matched name as the reference',
+    () => {
+      for (const p of corpus) {
+        expect(includesPoi(p), `includesPoi mismatch for: ${JSON.stringify(p)}`).toEqual(
+          refIncludesPoi(p)
+        );
+      }
+    },
+    60000
+  );
 
   it('getTagsFromPrompt returns the same tag set as the reference', () => {
     for (const p of corpus) {
@@ -351,12 +358,18 @@ describe('audit matching equivalence (gate vs brute-force)', () => {
     }
   });
 
-  it('highlight: poi gated highlight equals the un-gated reference', () => {
-    const poiRefRegexList = poiRefRegexes.map((x) => x.regex);
-    for (const p of [...corpus, ...youngCorpus]) {
-      const gated = poiCheckable.highlight(p, highlightFn);
-      const reference = refHighlight(p, poiRefRegexList, poiPreprocess, highlightFn);
-      expect(gated, `poi highlight mismatch for: ${JSON.stringify(p)}`).toBe(reference);
-    }
-  });
+  // Same CPU-bound POI brute-force shape as above — generous per-test timeout
+  // so a loaded runner does not flake it. Assertions are unchanged.
+  it(
+    'highlight: poi gated highlight equals the un-gated reference',
+    () => {
+      const poiRefRegexList = poiRefRegexes.map((x) => x.regex);
+      for (const p of [...corpus, ...youngCorpus]) {
+        const gated = poiCheckable.highlight(p, highlightFn);
+        const reference = refHighlight(p, poiRefRegexList, poiPreprocess, highlightFn);
+        expect(gated, `poi highlight mismatch for: ${JSON.stringify(p)}`).toBe(reference);
+      }
+    },
+    60000
+  );
 });


### PR DESCRIPTION
## Summary

`pnpm run test:unit:run` (the vitest unit suite, ~50 files) was **red and ungated** — `.github/workflows/pr-check.yml` runs only the single `test:lint-rules` case and explicitly skips the rest because the full suite failed. This PR makes the **full suite green** so it can be wired into CI.

**Every failure was a test-harness/env gap, not a product defect. No product code changed** — only the test setup file and one test's per-case timeout.

## Before → After

| | Before | After |
|---|---|---|
| Test files | 2 failing (suite-load) | **50 passing** |
| Tests | — | **857 passing**, 1 skipped |
| typecheck (`tsc --noEmit`) | — | **0 errors** |

The 1 skip is pre-existing (`exif-parser.test.ts`, an `EXIF_NETWORK_TESTS=1`-gated network test) — not introduced here.

> Note on counts: on a correctly-installed tree the *visible* baseline was 2 suite-load failures, each masking further module-load errors behind it (they surface one at a time as you fix the prior). A **stale generated Prisma client** additionally produces 23 spurious assertion failures — make sure `db:generate` has run for the branch (see "Environment note").

## Failure taxonomy + fixes

All fixes are in `src/__tests__/setup.ts` (test bootstrap) and one timeout in `audit-matching-equivalence.test.ts`.

1. **Missing test-env defaults (env gap).** `meilisearch/client.ts` and `signals/wrapper.ts` call `pLimit(env.MEILI_CALL_CONCURRENCY)` / `pLimit(env.SIGNALS_CALL_CONCURRENCY)` at **module load**. The setup env Proxy didn't supply them → `undefined` → p-limit throws *"Expected concurrency to be a number from 1 and up"*, failing every suite that transitively imports those modules (e.g. `coinbase.service.test.ts` via `user.service`). Fix: add `MEILI_CALL_CONCURRENCY: 50` and `SIGNALS_CALL_CONCURRENCY: 30` to `TEST_ENV_DEFAULTS`, mirroring the `server-schema.ts` `.default()` values.

2. **Incomplete prom/client mock (test-harness gap).** The `~/server/prom/client` mock was missing exports the real module ships and that consumers build at import time: `registerGaugeWithLabels`, `registerHistogram`, `registerInstrumentationMetric` (factories used by `meilisearch/client.ts` and `eventloop-longtask.ts`), plus the `trpcProcedureDuration` / `licenseFee*` named metrics. vitest hard-errors on a missing mocked export. Fix: a single metric-shaped stub helper (`inc/dec/set/observe/labels/startTimer`) backs all factories + named exports, so the mock faithfully covers the real surface.

3. **Timeout-flaky tests (flaky, root-caused — not skipped).** The two CPU-bound POI brute-force equivalence cases in `audit-matching-equivalence.test.ts` assert correctly but run ~10–12s and intermittently exceeded the 10s **global** `testTimeout` on a loaded runner (they passed on quiet runs, timed out on busy ones). Fix: explicit **60s per-test timeout** on just those two cases. Assertions and logic are unchanged; nothing is skipped.

## Excluded / quarantined / structural decisions

- **None.** No tests excluded, skipped, `.only`'d, or deleted. No assertions loosened. No vitest project split needed — all 50 files are genuine unit tests (the DB/redis/external layers are already mocked in `setup.ts`). The one network test was already env-gated upstream.

## Real code bugs found

- **None.** Every failure was a harness/env gap. The product code under test was correct throughout — the suite simply couldn't load it. (The fixes do, however, make the suite robust against the real-default behavior of `MEILI_/SIGNALS_CALL_CONCURRENCY` and the full prom metric surface.)

## Environment note (NixOS)

`db:generate` must run against the branch's schema before the suite (a stale generated Prisma client → 23 spurious failures). On NixOS, point Prisma at the nix-store engines (`PRISMA_QUERY_ENGINE_LIBRARY` etc.) so generation works offline; on standard CI the upstream-fetched engines work as-is.

## Verification

- `pnpm run test:unit:run` → **exit 0**, 50 files / 857 tests pass — confirmed green on two consecutive runs (stability check).
- `pnpm run typecheck` → **exit 0**, 0 errors.
- `grep` for `.skip`/`.only`/`xit`/`xdescribe`/`it.todo` across changed files → none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)