### PR TITLE
feat(oauth): RFC 7591 Dynamic Client Registration for MCP one-click auth

### DIFF
--- a/prisma/migrations/20260611120000_oauth_client_dcr_fields/migration.sql
+++ b/prisma/migrations/20260611120000_oauth_client_dcr_fields/migration.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- OAuth Dynamic Client Registration (RFC 7591) support fields.
+-- ============================================================================
+-- Adds two columns to "OauthClient":
+--   isDynamicallyRegistered  — true for clients created via the open /register
+--                              endpoint. Used by the GC job to scope cleanup of
+--                              stale, never-used DCR clients (and by the consent
+--                              screen to show the "not verified" warning).
+--   lastUsedAt               — last time a token was issued/used for this client.
+--                              Nullable; informational + future GC tuning.
+--
+-- Both are additive and backfill safely (defaults), so this is non-blocking on
+-- a live table.
+--
+-- !!! MANUAL APPLY REQUIRED !!!
+-- Per CLAUDE.md, migrations are NOT auto-run (no `prisma migrate deploy`).
+-- A human must run this SQL directly against each target DB (preview / staging
+-- / prod) via psql / retool / cnpg superuser. Do not rely on _prisma_migrations.
+-- ============================================================================
+
+ALTER TABLE "OauthClient"
+  ADD COLUMN IF NOT EXISTS "isDynamicallyRegistered" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "lastUsedAt" TIMESTAMP(3);

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2173,6 +2173,8 @@ model OauthClient {
   userId         Int
   user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   isVerified     Boolean        @default(false)
+  isDynamicallyRegistered Boolean @default(false)
+  lastUsedAt     DateTime?
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @default(now()) @updatedAt
   tokens         ApiKey[]

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -87,6 +87,11 @@ export const serverSchema = z.object({
   JOB_TOKEN: z.string(),
   WEBHOOK_URL: z.url().optional(),
   WEBHOOK_TOKEN: z.string(),
+  // Owner (system bot user) for OAuth Dynamic Client Registration (RFC 7591).
+  // When unset, the /register endpoint returns 503 temporarily_unavailable
+  // (fail-safe) rather than crashing. Justin must create the `oauth-dcr-bot`
+  // user and set this BEFORE DCR can go live. See oauth-client.service.ts.
+  OAUTH_DCR_OWNER_USER_ID: z.coerce.number().int().positive().optional(),
   UNAUTHENTICATED_DOWNLOAD: zc.booleanString,
   UNAUTHENTICATED_LIST_NSFW: zc.booleanString,
   LOGGING: commaDelimitedStringArray(),

--- a/src/pages/api/.well-known/oauth-authorization-server.ts
+++ b/src/pages/api/.well-known/oauth-authorization-server.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { buildOAuthServerMetadata } from '~/server/oauth/discovery-metadata';
+
+/**
+ * RFC 8414 — OAuth 2.0 Authorization Server Metadata.
+ *
+ * MCP clients and other modern OAuth clients probe this path (rather than the
+ * OIDC `/.well-known/openid-configuration`) to discover the registration,
+ * authorization, and token endpoints. We serve the same core metadata from a
+ * single builder so the two documents can't drift.
+ */
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Cache-Control', 'public, max-age=86400');
+  res.status(200).json(buildOAuthServerMetadata());
+}

--- a/src/pages/api/.well-known/openid-configuration.ts
+++ b/src/pages/api/.well-known/openid-configuration.ts
@@ -1,28 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { env } from '~/env/server';
-import { tokenScopeLabels } from '~/shared/constants/token-scope.constants';
+import { buildOAuthServerMetadata } from '~/server/oauth/discovery-metadata';
 
 export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  const issuer = env.NEXTAUTH_URL;
-
   res.setHeader('Cache-Control', 'public, max-age=86400');
   res.status(200).json({
-    issuer,
-    authorization_endpoint: `${issuer}/api/auth/oauth/authorize`,
-    token_endpoint: `${issuer}/api/auth/oauth/token`,
-    userinfo_endpoint: `${issuer}/api/auth/oauth/userinfo`,
-    revocation_endpoint: `${issuer}/api/auth/oauth/revoke`,
-    device_authorization_endpoint: `${issuer}/api/auth/oauth/device`,
-    response_types_supported: ['code'],
-    grant_types_supported: [
-      'authorization_code',
-      'refresh_token',
-      'client_credentials',
-      'urn:ietf:params:oauth:grant-type:device_code',
-    ],
-    code_challenge_methods_supported: ['S256'],
-    token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
-    scopes_supported: Object.keys(tokenScopeLabels),
+    ...buildOAuthServerMetadata(),
     subject_types_supported: ['public'],
     // Claims returned by the userinfo endpoint. `email`/`email_verified` and
     // the profile claims are released under the UserRead scope.

--- a/src/pages/api/auth/oauth/__tests__/register.test.ts
+++ b/src/pages/api/auth/oauth/__tests__/register.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCreateOauthClient, mockUserFindUnique, mockRateLimit } = vi.hoisted(() => ({
+  mockCreateOauthClient: vi.fn(),
+  mockUserFindUnique: vi.fn(),
+  mockRateLimit: vi.fn(),
+}));
+
+vi.mock('~/env/server', () => ({
+  env: { OAUTH_DCR_OWNER_USER_ID: 999, NEXTAUTH_URL: 'https://civitai.com' },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { user: { findUnique: mockUserFindUnique } },
+  dbWrite: {},
+}));
+
+vi.mock('~/server/oauth/rate-limit', () => ({
+  checkRegisterRateLimit: mockRateLimit,
+}));
+
+vi.mock('~/server/oauth/audit-log', () => ({ logOAuthEvent: vi.fn() }));
+
+vi.mock('~/server/services/oauth-client.service', () => ({
+  createOauthClient: mockCreateOauthClient,
+  DCR_GRANTS: ['authorization_code', 'refresh_token'],
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  addCorsHeaders: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('request-ip', () => ({ default: { getClientIp: () => '203.0.113.7' } }));
+
+import handler from '../register';
+
+function createMocks(body: unknown, method = 'POST') {
+  const req = { method, headers: {}, body, query: {} } as any;
+  let statusCode = 200;
+  let payload: any = undefined;
+  const headers: Record<string, unknown> = {};
+  const res: any = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: unknown) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimit.mockResolvedValue(true);
+  mockUserFindUnique.mockResolvedValue({ id: 999 });
+  mockCreateOauthClient.mockResolvedValue({
+    clientId: 'generated-client-id',
+    clientSecret: null,
+    redirectUris: ['https://app.example.com/cb'],
+    allowedOrigins: ['https://app.example.com'],
+    allowedScopes: 1,
+    grants: ['authorization_code', 'refresh_token'],
+    isConfidential: false,
+  });
+});
+
+describe('POST /register — happy path', () => {
+  it('returns 201 with a client_id and NO client_secret', async () => {
+    const { req, res } = createMocks({
+      redirect_uris: ['https://app.example.com/cb'],
+      client_name: 'My MCP App',
+      scope: 'models:read media:write',
+    });
+    await handler(req, res);
+
+    expect(res._status()).toBe(201);
+    const body = res._json();
+    expect(body.client_id).toBe('generated-client-id');
+    expect(body).not.toHaveProperty('client_secret');
+    expect(body.token_endpoint_auth_method).toBe('none');
+    expect(body.grant_types).toEqual(['authorization_code', 'refresh_token']);
+    expect(body.response_types).toEqual(['code']);
+    expect(typeof body.scope).toBe('string');
+  });
+
+  it('forces a public client with the DCR grants', async () => {
+    const { req, res } = createMocks({ redirect_uris: ['http://127.0.0.1:8080/cb'] });
+    await handler(req, res);
+    expect(mockCreateOauthClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isConfidential: false,
+        isDynamicallyRegistered: true,
+        userId: 999,
+      })
+    );
+  });
+});
+
+describe('POST /register — scope clamp', () => {
+  it('drops models:delete (cap excludes Delete scopes)', async () => {
+    const { req, res } = createMocks({
+      redirect_uris: ['https://app.example.com/cb'],
+      scope: 'models:read models:delete',
+    });
+    await handler(req, res);
+    expect(res._status()).toBe(201);
+    const passedScopes = mockCreateOauthClient.mock.calls[0][0].allowedScopes as number;
+    // ModelsDelete = 1<<4 = 16 must NOT be present; ModelsRead = 1<<2 = 4 must be.
+    expect(passedScopes & 16).toBe(0);
+    expect(passedScopes & 4).toBe(4);
+  });
+});
+
+describe('POST /register — redirect_uri allowlist', () => {
+  it('rejects non-loopback http with invalid_redirect_uri', async () => {
+    const { req, res } = createMocks({ redirect_uris: ['http://evil.example.com/cb'] });
+    await handler(req, res);
+    expect(res._status()).toBe(400);
+    expect(res._json().error).toBe('invalid_redirect_uri');
+    expect(mockCreateOauthClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects custom scheme', async () => {
+    const { req, res } = createMocks({ redirect_uris: ['myapp://cb'] });
+    await handler(req, res);
+    expect(res._status()).toBe(400);
+    expect(res._json().error).toBe('invalid_redirect_uri');
+  });
+});
+
+describe('POST /register — confidential / client_credentials rejection', () => {
+  it('rejects client_credentials grant', async () => {
+    const { req, res } = createMocks({
+      redirect_uris: ['https://app.example.com/cb'],
+      grant_types: ['client_credentials'],
+    });
+    await handler(req, res);
+    expect(res._status()).toBe(400);
+    expect(res._json().error).toBe('invalid_client_metadata');
+  });
+
+  it('rejects token_endpoint_auth_method other than none', async () => {
+    const { req, res } = createMocks({
+      redirect_uris: ['https://app.example.com/cb'],
+      token_endpoint_auth_method: 'client_secret_post',
+    });
+    await handler(req, res);
+    expect(res._status()).toBe(400);
+    expect(res._json().error).toBe('invalid_client_metadata');
+  });
+});
+
+describe('POST /register — rate limit', () => {
+  it('returns 429 when the IP limit is exceeded', async () => {
+    mockRateLimit.mockResolvedValue(false);
+    const { req, res } = createMocks({ redirect_uris: ['https://app.example.com/cb'] });
+    await handler(req, res);
+    expect(res._status()).toBe(429);
+    expect(res._json().error).toBe('rate_limit_exceeded');
+    expect(mockCreateOauthClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /register — owner not configured (fail-safe)', () => {
+  it('returns 503 temporarily_unavailable when the owner user is missing', async () => {
+    mockUserFindUnique.mockResolvedValue(null);
+    const { req, res } = createMocks({ redirect_uris: ['https://app.example.com/cb'] });
+    await handler(req, res);
+    expect(res._status()).toBe(503);
+    expect(res._json().error).toBe('temporarily_unavailable');
+  });
+});

--- a/src/pages/api/auth/oauth/authorize.ts
+++ b/src/pages/api/auth/oauth/authorize.ts
@@ -10,6 +10,7 @@ import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-
 import { logOAuthEvent } from '~/server/oauth/audit-log';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { buzzLimitSchema } from '~/server/schema/api-key.schema';
+import { isRegisteredRedirectUri } from '~/server/oauth/redirect-uri';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'OPTIONS') {
@@ -42,6 +43,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const params = req.method === 'GET' ? req.query : req.body;
 
+    // RFC 8707 Resource Indicators: accept-and-ignore the `resource` param in
+    // v1. We don't bind an audience or store it; the OAuth library treats
+    // unknown params as inert, so no special handling beyond not erroring.
+
     // Validate client exists
     const clientId = params.client_id as string;
     if (!clientId) {
@@ -57,9 +62,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .json({ error: 'invalid_client', error_description: 'Unknown client_id' });
     }
 
-    // Validate redirect_uri against registered URIs
+    // Validate redirect_uri against registered URIs. Loopback-aware: native
+    // apps (RFC 8252) bind an ephemeral loopback port unknowable at
+    // registration time, so for loopback hosts we match scheme+host+path and
+    // ignore the port; all other hosts require an exact match.
     const redirectUri = params.redirect_uri as string;
-    if (!redirectUri || !client.redirectUris.includes(redirectUri)) {
+    if (!redirectUri || !isRegisteredRedirectUri(redirectUri, client.redirectUris)) {
       return res.status(400).json({
         error: 'invalid_request',
         error_description: 'redirect_uri does not match any registered URI',

--- a/src/pages/api/auth/oauth/register.ts
+++ b/src/pages/api/auth/oauth/register.ts
@@ -1,0 +1,230 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import requestIp from 'request-ip';
+import { env } from '~/env/server';
+import { dbRead } from '~/server/db/client';
+import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
+import { checkRegisterRateLimit } from '~/server/oauth/rate-limit';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { isAllowedDcrRedirectUri } from '~/server/oauth/redirect-uri';
+import { createOauthClient, DCR_GRANTS } from '~/server/services/oauth-client.service';
+import {
+  TokenScope,
+  TokenScopePresets,
+  scopeNamesToBitmask,
+  bitmaskToScopeNames,
+  tokenScopeNameToFlag,
+} from '~/shared/constants/token-scope.constants';
+
+/**
+ * RFC 7591 — OAuth 2.0 Dynamic Client Registration.
+ *
+ * POST /api/auth/oauth/register
+ *
+ * Open + unauthenticated by design (enables MCP one-click auth), hardened with:
+ *   - IP rate limit: 5/hour AND 20/day (see rate-limit.ts).
+ *   - redirect_uri allowlist: https://<host> OR loopback http only.
+ *   - Forced public client: token_endpoint_auth_method=none, no secret,
+ *     grant_types limited to authorization_code + refresh_token.
+ *   - Scope cap: clamped to TokenScopePresets.MCPMaxAllowed (never Full, never
+ *     any Delete / SocialTip / AIServicesWrite / BountiesWrite). Even if a
+ *     client later requests more at /authorize, validateScope clamps to the
+ *     stored allowedScopes.
+ *   - Owner: a dedicated system user (env OAUTH_DCR_OWNER_USER_ID). If unset,
+ *     returns 503 temporarily_unavailable (fail-safe).
+ *
+ * Returns the RFC 7591 client information response (201).
+ */
+
+// RFC 7591 client metadata we accept. Unknown fields are ignored.
+const registerSchema = z.object({
+  // Required: at least one redirect URI.
+  redirect_uris: z.array(z.string()).min(1),
+  // Optional human-readable name shown on the consent screen.
+  client_name: z.string().min(1).max(128).optional(),
+  client_uri: z.string().url().optional(),
+  logo_uri: z.string().url().optional(),
+  // Space-delimited scope string (RFC 6749). Optional — defaults to MCPDefault.
+  scope: z.string().optional(),
+  // RFC 7591 allows these; we validate them against our forced-public policy.
+  grant_types: z.array(z.string()).optional(),
+  response_types: z.array(z.string()).optional(),
+  token_endpoint_auth_method: z.string().optional(),
+});
+
+function error(res: NextApiResponse, status: number, error: string, error_description: string) {
+  return res.status(status).json({ error, error_description });
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'OPTIONS') {
+    const shouldStop = addCorsHeaders(req, res, ['POST']);
+    if (shouldStop) return;
+  }
+
+  // Open registration is browser/agent-callable cross-origin; keep CORS open
+  // (no credentials — the response carries no secret).
+  addCorsHeaders(req, res, ['POST']);
+
+  if (req.method !== 'POST') {
+    return error(res, 405, 'invalid_request', 'Method not allowed');
+  }
+
+  const ip = requestIp.getClientIp(req) ?? '';
+
+  // Rate-limit by IP before any work.
+  const allowed = await checkRegisterRateLimit(res, ip || 'unknown');
+  if (!allowed) {
+    logOAuthEvent({ type: 'client.created', ip, metadata: { rateLimited: true, dcr: true } });
+    return res.status(429).json({
+      error: 'rate_limit_exceeded',
+      error_description: 'Too many registration requests. Please try again later.',
+    });
+  }
+
+  // Owner system user must be configured (fail-safe, not crash).
+  const ownerUserId = env.OAUTH_DCR_OWNER_USER_ID;
+  if (!ownerUserId) {
+    return error(
+      res,
+      503,
+      'temporarily_unavailable',
+      'Dynamic client registration is not currently available.'
+    );
+  }
+
+  // Parse + validate metadata.
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return error(
+      res,
+      400,
+      'invalid_client_metadata',
+      'Invalid registration metadata: ' + parsed.error.issues.map((i) => i.message).join('; ')
+    );
+  }
+  const meta = parsed.data;
+
+  // --- redirect_uri allowlist (RFC 7591 invalid_redirect_uri on violation) ---
+  for (const uri of meta.redirect_uris) {
+    if (!isAllowedDcrRedirectUri(uri)) {
+      return error(
+        res,
+        400,
+        'invalid_redirect_uri',
+        `redirect_uri not allowed: ${uri}. Only https URLs or http loopback (127.0.0.1, [::1], localhost) are permitted.`
+      );
+    }
+  }
+
+  // --- grant_types: force public auth-code + refresh; reject client_credentials ---
+  if (meta.grant_types) {
+    const requested = new Set(meta.grant_types);
+    if (requested.has('client_credentials') || requested.has('password')) {
+      return error(
+        res,
+        400,
+        'invalid_client_metadata',
+        'Only authorization_code and refresh_token grants are supported for dynamic registration.'
+      );
+    }
+    for (const g of requested) {
+      if (g !== 'authorization_code' && g !== 'refresh_token') {
+        return error(res, 400, 'invalid_client_metadata', `Unsupported grant_type: ${g}`);
+      }
+    }
+  }
+
+  // --- token_endpoint_auth_method: must be 'none' (public). ---
+  if (meta.token_endpoint_auth_method && meta.token_endpoint_auth_method !== 'none') {
+    return error(
+      res,
+      400,
+      'invalid_client_metadata',
+      "token_endpoint_auth_method must be 'none' (confidential clients are not supported via dynamic registration)."
+    );
+  }
+
+  // --- response_types: only 'code'. ---
+  if (meta.response_types) {
+    for (const rt of meta.response_types) {
+      if (rt !== 'code') {
+        return error(res, 400, 'invalid_client_metadata', `Unsupported response_type: ${rt}`);
+      }
+    }
+  }
+
+  // --- scope: parse canonical names, reject unknown, then clamp to cap ---
+  let requestedMask: number;
+  if (meta.scope != null && meta.scope.trim() !== '') {
+    const names = meta.scope.trim().split(/\s+/);
+    const unknown = names.filter((n) => tokenScopeNameToFlag[n] == null);
+    if (unknown.length > 0) {
+      return error(res, 400, 'invalid_client_metadata', `Unknown scope(s): ${unknown.join(', ')}`);
+    }
+    requestedMask = scopeNamesToBitmask(names);
+  } else {
+    requestedMask = TokenScopePresets.MCPDefault;
+  }
+
+  // Hard cap: clamp to MCP-safe mask. UserRead is always present as a baseline.
+  const cappedMask = (requestedMask & TokenScopePresets.MCPMaxAllowed) | TokenScope.UserRead;
+  const grantedScopeNames = bitmaskToScopeNames(cappedMask);
+
+  // Confirm the owner exists (cheap guard against a misconfigured env pointing
+  // at a deleted user — would otherwise FK-fail on insert).
+  const owner = await dbRead.user.findUnique({
+    where: { id: ownerUserId },
+    select: { id: true },
+  });
+  if (!owner) {
+    return error(
+      res,
+      503,
+      'temporarily_unavailable',
+      'Dynamic client registration is not currently available.'
+    );
+  }
+
+  try {
+    const result = await createOauthClient({
+      userId: ownerUserId,
+      name: meta.client_name ?? 'Unnamed Application',
+      description: '',
+      redirectUris: meta.redirect_uris,
+      // Public client: rely on the redirect-derived origins for the (rarely
+      // used) browser SPA case. Native/loopback clients send no Origin.
+      allowedOrigins: [],
+      isConfidential: false,
+      allowedScopes: cappedMask,
+      grants: [...DCR_GRANTS],
+      isDynamicallyRegistered: true,
+      logoUrl: meta.logo_uri ?? null,
+    });
+
+    logOAuthEvent({
+      type: 'client.created',
+      userId: ownerUserId,
+      clientId: result.clientId,
+      scope: cappedMask,
+      ip,
+      metadata: { dcr: true },
+    });
+
+    // RFC 7591 §3.2.1 client information response.
+    return res.status(201).json({
+      client_id: result.clientId,
+      // No client_secret — public client.
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      client_name: meta.client_name ?? 'Unnamed Application',
+      redirect_uris: result.redirectUris,
+      grant_types: result.grants,
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: grantedScopeNames.join(' '),
+    });
+  } catch (err: any) {
+    console.error('[oauth/register] failed:', err);
+    return error(res, 500, 'server_error', 'Failed to register client.');
+  }
+}

--- a/src/pages/api/auth/oauth/register.ts
+++ b/src/pages/api/auth/oauth/register.ts
@@ -37,20 +37,27 @@ import {
  */
 
 // RFC 7591 client metadata we accept. Unknown fields are ignored.
+// Bounded sizes throughout: this endpoint is open + unauthenticated, so every
+// field is capped to keep a single registration cheap to store.
 const registerSchema = z.object({
-  // Required: at least one redirect URI.
-  redirect_uris: z.array(z.string()).min(1),
+  // Required: at least one redirect URI. Capped so a single client can't bloat
+  // a row with thousands of URIs (the per-request throttle is per-IP only).
+  redirect_uris: z.array(z.string().url().max(2048)).min(1).max(10),
   // Optional human-readable name shown on the consent screen.
   client_name: z.string().min(1).max(128).optional(),
-  client_uri: z.string().url().optional(),
-  logo_uri: z.string().url().optional(),
+  client_uri: z.string().url().max(2048).optional(),
+  logo_uri: z.string().url().max(2048).optional(),
   // Space-delimited scope string (RFC 6749). Optional — defaults to MCPDefault.
-  scope: z.string().optional(),
+  scope: z.string().max(1024).optional(),
   // RFC 7591 allows these; we validate them against our forced-public policy.
-  grant_types: z.array(z.string()).optional(),
-  response_types: z.array(z.string()).optional(),
-  token_endpoint_auth_method: z.string().optional(),
+  grant_types: z.array(z.string().max(128)).max(10).optional(),
+  response_types: z.array(z.string().max(128)).max(10).optional(),
+  token_endpoint_auth_method: z.string().max(128).optional(),
 });
+
+// Open/unauthenticated endpoint: pin a tight body-size limit rather than relying
+// on the framework default.
+export const config = { api: { bodyParser: { sizeLimit: '16kb' } } };
 
 function error(res: NextApiResponse, status: number, error: string, error_description: string) {
   return res.status(status).json({ error, error_description });

--- a/src/pages/api/auth/oauth/token.ts
+++ b/src/pages/api/auth/oauth/token.ts
@@ -48,6 +48,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const allowed = await checkOAuthRateLimit(req, res, 'token', ip || 'unknown');
   if (!allowed) return sendRateLimitResponse(res);
 
+  // RFC 8707 Resource Indicators: the `resource` param (if present in the body)
+  // is accept-and-ignored in v1. The OAuth library treats unknown body params
+  // as inert, so we pass the body through unchanged — no audience binding.
   const request = new Request({
     method: req.method,
     headers: req.headers as Record<string, string>,
@@ -66,9 +69,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // with our wiring), so fail-closed with a fallback lookup rather than
     // defaulting to wildcard CORS and risking a cross-origin leak of a
     // public-client token response.
-    let attached = (request as Request & {
-      oauthClient?: { id: string; isConfidential: boolean; allowedOrigins: string[] };
-    }).oauthClient;
+    let attached = (
+      request as Request & {
+        oauthClient?: { id: string; isConfidential: boolean; allowedOrigins: string[] };
+      }
+    ).oauthClient;
     if (!attached) {
       const fallback =
         typeof clientId === 'string' && clientId !== 'unknown'

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -52,6 +52,7 @@ import type { Job } from '~/server/jobs/job';
 import { jobQueueJobs } from '~/server/jobs/job-queue';
 import { newOrderJobs } from '~/server/jobs/new-order-jobs';
 import { nextauthCleanup } from '~/server/jobs/next-auth-cleanup';
+import { oauthDcrCleanup } from '~/server/jobs/oauth-dcr-cleanup';
 import { syncEmailBlocklist } from '~/server/jobs/sync-email-blocklist';
 import { bountyJobs } from '~/server/jobs/prepare-bounties';
 import { leaderboardJobs } from '~/server/jobs/prepare-leaderboard';
@@ -143,6 +144,7 @@ export const jobs: Job[] = [
   cacheCleanup,
   rewardsAbusePrevention,
   nextauthCleanup,
+  oauthDcrCleanup,
   syncEmailBlocklist,
   applyTagRules,
   // processCreatorProgramImageGenerationRewards,

--- a/src/pages/login/oauth/authorize.tsx
+++ b/src/pages/login/oauth/authorize.tsx
@@ -16,8 +16,15 @@ import {
   Badge,
   List,
   Checkbox,
+  Alert,
 } from '@mantine/core';
-import { IconCheck, IconCoinFilled, IconShieldCheck, IconX } from '@tabler/icons-react';
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconCoinFilled,
+  IconShieldCheck,
+  IconX,
+} from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -97,6 +104,18 @@ export default function OAuthAuthorizePage() {
   // so showing the limit prompt makes no sense unless this scope is included.
   const requestsSpend = Flags.hasFlag(scope, TokenScope.AIServicesWrite);
 
+  // For dynamically-registered (RFC 7591) clients that Civitai has not verified,
+  // surface a prominent warning with the raw client name + redirect host so the
+  // user can judge whether they actually initiated this. A verified client
+  // (manually reviewed) is exempt.
+  const showUnverifiedWarning = client.isDynamicallyRegistered && !client.isVerified;
+  let redirectHost = '';
+  try {
+    redirectHost = redirectUri ? new URL(redirectUri).host : '';
+  } catch {
+    redirectHost = '';
+  }
+
   const handleApprove = async () => {
     setSubmitting(true);
     try {
@@ -165,6 +184,34 @@ export default function OAuthAuthorizePage() {
               </Text>
             )}
           </Stack>
+
+          {showUnverifiedWarning && (
+            <Alert
+              icon={<IconAlertTriangle size={18} />}
+              color="yellow"
+              variant="light"
+              title="This application is not verified by Civitai"
+            >
+              <Stack gap={4}>
+                <Text size="sm">
+                  <Text span fw={600}>
+                    {client.name}
+                  </Text>{' '}
+                  registered itself automatically and has not been reviewed by Civitai. Only
+                  continue if you started this connection yourself.
+                </Text>
+                {redirectHost && (
+                  <Text size="xs" c="dimmed">
+                    You will be redirected to{' '}
+                    <Text span fw={600}>
+                      {redirectHost}
+                    </Text>{' '}
+                    after authorizing.
+                  </Text>
+                )}
+              </Stack>
+            </Alert>
+          )}
 
           <Divider />
 

--- a/src/server/controllers/bountyEntry.controller.ts
+++ b/src/server/controllers/bountyEntry.controller.ts
@@ -17,7 +17,11 @@ import {
   getEntryById,
   upsertBountyEntry,
 } from '../services/bountyEntry.service';
-import type { UpsertBountyEntryInput } from '~/server/schema/bounty-entry.schema';
+import type {
+  SubmitBountyEntryInput,
+  UpsertBountyEntryInput,
+} from '~/server/schema/bounty-entry.schema';
+import { Currency, MediaType } from '~/shared/utils/prisma/enums';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
 import { getReactionsSelectV2 } from '~/server/selectors/reaction.selector';
 import { getBountyById } from '../services/bounty.service';
@@ -143,6 +147,41 @@ export const upsertBountyEntryHandler = async ({
     if (error instanceof TRPCError) throw error;
     throw throwDbError(error);
   }
+};
+
+/**
+ * Headless/agent (MCP) friendly bounty-entry submission. Assembles the full
+ * `upsert` input shape from minimal, already-uploaded refs and delegates to the
+ * existing upsertBountyEntryHandler so all validation, buzz/award checks, and
+ * tracking run through the same path. Kept on guardedProcedure like upsert; no
+ * buzz is spent on submission, so it does NOT need blockApiKeys.
+ */
+export const submitBountyEntryHandler = async ({
+  input,
+  ctx,
+}: {
+  input: SubmitBountyEntryInput;
+  ctx: ProtectedContext;
+}) => {
+  const { files, imageUuids, ...rest } = input;
+
+  const upsertInput: UpsertBountyEntryInput = {
+    ...rest,
+    files: files.map((f) => ({
+      id: f.id,
+      url: f.url,
+      name: f.name,
+      sizeKB: f.sizeKB,
+      metadata: {
+        unlockAmount: f.unlockAmount ?? 0,
+        currency: f.currency ?? Currency.BUZZ,
+        benefactorsOnly: f.benefactorsOnly ?? false,
+      },
+    })),
+    images: imageUuids.map((url) => ({ url, type: MediaType.image })),
+  };
+
+  return upsertBountyEntryHandler({ input: upsertInput, ctx });
 };
 
 export const awardBountyEntryHandler = async ({

--- a/src/server/controllers/chat.controller.ts
+++ b/src/server/controllers/chat.controller.ts
@@ -13,6 +13,7 @@ import type {
   GetMessageByIdInput,
   IsTypingInput,
   isTypingOutput,
+  MarkChatReadInput,
   ModifyUserInput,
   UpdateMessageInput,
   UserSettingsChat,
@@ -443,6 +444,52 @@ export const markAllAsReadHandler = async ({ ctx }: { ctx: ProtectedContext }) =
       where "ChatMember".id = data.id
       returning "chatId", "lastViewedMessageId"
     `;
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    else throw throwDbError(error);
+  }
+};
+
+/**
+ * Mark a single chat as read for the calling user. Resolves the caller's
+ * chatMember + the chat's latest message id server-side, then advances
+ * lastViewedMessageId. Gives per-chat read precision for headless/agent (MCP)
+ * callers (the website only exposes blanket markAllAsRead).
+ */
+export const markChatReadHandler = async ({
+  input,
+  ctx,
+}: {
+  input: MarkChatReadInput;
+  ctx: ProtectedContext;
+}) => {
+  try {
+    const { id: userId } = ctx.user;
+    const { chatId } = input;
+
+    const member = await dbWrite.chatMember.findFirst({
+      where: { chatId, userId, status: ChatMemberStatus.Joined },
+      select: { id: true, lastViewedMessageId: true },
+    });
+    if (!member) throw throwNotFoundError(`You are not a member of this chat`);
+
+    const latestMessage = await dbWrite.chatMessage.findFirst({
+      where: { chatId },
+      orderBy: { id: 'desc' },
+      select: { id: true },
+    });
+
+    // No messages yet, or already up to date — nothing to advance.
+    if (!latestMessage || member.lastViewedMessageId === latestMessage.id) {
+      return { chatId, lastViewedMessageId: member.lastViewedMessageId ?? null };
+    }
+
+    await dbWrite.chatMember.update({
+      where: { id: member.id },
+      data: { lastViewedMessageId: latestMessage.id },
+    });
+
+    return { chatId, lastViewedMessageId: latestMessage.id };
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/controllers/post.controller.ts
+++ b/src/server/controllers/post.controller.ts
@@ -11,6 +11,7 @@ import type { CollectionMetadataSchema } from '~/server/schema/collection.schema
 import type { VideoMetadata } from '~/server/schema/media.schema';
 import type {
   AddResourceToPostImageInput,
+  CreatePostWithImagesInput,
   PostCreateInput,
   RemoveResourceFromPostImageInput,
 } from '~/server/schema/post.schema';
@@ -23,6 +24,7 @@ import {
 import { sendMessagesToCollaborators } from '~/server/services/entity-collaborator.service';
 import { amIBlockedByUser } from '~/server/services/user.service';
 import {
+  handleLogError,
   throwAuthorizationError,
   throwBadRequestError,
   throwDbError,
@@ -47,6 +49,7 @@ import type {
   UpdatePostImageInput,
 } from './../schema/post.schema';
 import {
+  addPostImage,
   addPostTag,
   addResourceToPostImage,
   createPost,
@@ -125,6 +128,82 @@ export const createPostHandler = async ({
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
+  }
+};
+
+/**
+ * Composite create-with-images handler for headless/agent (MCP) use.
+ *
+ * Creates the post, attaches each image in order, and optionally publishes —
+ * all server-side — to eliminate the multi-round-trip + orphan-draft window the
+ * MCP previously handled client-side. Reuses the existing createPost / addPostImage
+ * services and the full updatePostHandler publish path (rewards, tracking,
+ * collection items, contest validation) for the publish step.
+ *
+ * No single DB transaction is feasible here: createPost, addPostImage (which
+ * triggers image ingestion + cache busting), and the publish path each manage
+ * their own writes/side-effects. Instead we do best-effort sequential work and,
+ * on any failure before returning, DELETE the created post so no orphan draft
+ * remains.
+ */
+export const createPostWithImagesHandler = async ({
+  input,
+  ctx,
+}: {
+  input: CreatePostWithImagesInput;
+  ctx: ProtectedContext;
+}) => {
+  const { images, publish, collectionId, ...createInput } = input;
+
+  // 1) Create the draft post (reuses createPostHandler for tracking + rewards
+  //    on the no-image publish path; we publish separately below once images
+  //    exist, so we always create as a draft here).
+  const post = await createPostHandler({
+    input: { ...createInput, collectionId },
+    ctx,
+  });
+
+  try {
+    // 2) Attach each image in order.
+    const sortedImages = [...images].sort((a, b) => a.index - b.index);
+    const attachedImageIds: number[] = [];
+    for (const image of sortedImages) {
+      const attached = await addPostImage({ ...image, postId: post.id, user: ctx.user });
+      attachedImageIds.push(attached.id);
+    }
+
+    // 3) Optionally publish. Route through updatePostHandler so the full publish
+    //    path runs (rewards, tracking, collaborator messages, collection items,
+    //    contest validation). updatePostHandler returns void, so we re-fetch the
+    //    post's published state afterward.
+    let publishedAt: Date | null = post.publishedAt ?? null;
+    if (publish) {
+      await updatePostHandler({
+        input: { id: post.id, publishedAt: new Date(), collectionId },
+        ctx,
+      });
+      const published = await dbWrite.post.findUnique({
+        where: { id: post.id },
+        select: { publishedAt: true },
+      });
+      publishedAt = published?.publishedAt ?? null;
+    }
+
+    return {
+      id: post.id,
+      title: post.title,
+      detail: post.detail,
+      modelVersionId: post.modelVersionId,
+      collectionId: post.collectionId,
+      publishedAt,
+      imageIds: attachedImageIds,
+      nsfwLevel: post.nsfwLevel,
+    };
+  } catch (error) {
+    // Roll back the orphan draft so no empty/partial post lingers.
+    await deletePost({ id: post.id, isModerator: ctx.user.isModerator }).catch(handleLogError);
+    if (error instanceof TRPCError) throw error;
+    throw throwDbError(error);
   }
 };
 

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -278,6 +278,41 @@ const verifyAvatar = (avatar: string) => {
   return false;
 };
 
+/**
+ * Cheap "whoami" for the authenticated caller, sourced entirely from the
+ * session/JWT (ctx.user) — no DB round-trip. Works with API-key auth. Returns
+ * the fields a headless/agent (MCP) caller needs to reason about its own
+ * account: identity, onboarding state (raw bitflag + decoded steps + an
+ * isOnboarded boolean), moderation/account flags, and tier/membership when
+ * cheaply available on the session.
+ *
+ * Note: does NOT use simpleUserSelect (which omits muted / isModerator /
+ * onboarding) — these come straight off the SessionUser.
+ */
+export const getSelfStatusHandler = ({ ctx }: { ctx: ProtectedContext }) => {
+  const { user } = ctx;
+
+  const onboardingSteps = Flags.instanceToArray(user.onboarding)
+    .map((flag) => OnboardingSteps[flag] as keyof typeof OnboardingSteps | undefined)
+    .filter((name): name is keyof typeof OnboardingSteps => !!name);
+
+  return {
+    id: user.id,
+    username: user.username ?? null,
+    onboarding: {
+      raw: user.onboarding,
+      completedSteps: onboardingSteps,
+      isOnboarded: Flags.hasFlag(user.onboarding, OnboardingComplete),
+    },
+    muted: !!user.muted,
+    isModerator: !!user.isModerator,
+    bannedAt: user.bannedAt ?? null,
+    deletedAt: user.deletedAt ?? null,
+    tier: user.tier ?? null,
+    subscriptionId: user.subscriptionId ?? null,
+  };
+};
+
 export const completeOnboardingHandler = async ({
   input,
   ctx,

--- a/src/server/jobs/oauth-dcr-cleanup.ts
+++ b/src/server/jobs/oauth-dcr-cleanup.ts
@@ -1,0 +1,42 @@
+import { createJob } from './job';
+import { dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+
+/**
+ * Garbage-collect stale Dynamically-Registered (RFC 7591) OAuth clients.
+ *
+ * Open registration means anyone can mint a client_id. To keep the table from
+ * filling with abandoned/never-completed registrations, delete DCR clients that:
+ *   - were created via /register (isDynamicallyRegistered = true), AND
+ *   - have issued ZERO tokens, AND
+ *   - have ZERO consents, AND
+ *   - are older than 48 hours.
+ *
+ * A client that a user actually authorized (has a consent or a live token) is
+ * never touched here — it's a real, in-use client. Cascade deletes handle any
+ * orphaned rows, though by definition these have none.
+ */
+const STALE_HOURS = 48;
+
+export const oauthDcrCleanup = createJob('oauth-dcr-cleanup', '15 * * * *', async () => {
+  const cutoff = new Date(Date.now() - STALE_HOURS * 60 * 60 * 1000);
+
+  const result = await dbWrite.oauthClient.deleteMany({
+    where: {
+      isDynamicallyRegistered: true,
+      createdAt: { lt: cutoff },
+      tokens: { none: {} },
+      consents: { none: {} },
+    },
+  });
+
+  if (result.count > 0) {
+    logToAxiom({
+      type: 'oauth-dcr-cleanup',
+      deleted: result.count,
+      olderThanHours: STALE_HOURS,
+    });
+  }
+
+  return { deleted: result.count };
+});

--- a/src/server/oauth/__tests__/redirect-uri.test.ts
+++ b/src/server/oauth/__tests__/redirect-uri.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isAllowedDcrRedirectUri,
+  redirectUriMatches,
+  isRegisteredRedirectUri,
+} from '~/server/oauth/redirect-uri';
+
+describe('isAllowedDcrRedirectUri — RFC 7591 DCR allowlist', () => {
+  it('accepts https URLs on any host', () => {
+    expect(isAllowedDcrRedirectUri('https://app.example.com/callback')).toBe(true);
+    expect(isAllowedDcrRedirectUri('https://example.com')).toBe(true);
+    expect(isAllowedDcrRedirectUri('https://sub.domain.io/a/b?x=1')).toBe(true);
+  });
+
+  it('accepts http loopback addresses (any port)', () => {
+    expect(isAllowedDcrRedirectUri('http://127.0.0.1/cb')).toBe(true);
+    expect(isAllowedDcrRedirectUri('http://127.0.0.1:8723/cb')).toBe(true);
+    expect(isAllowedDcrRedirectUri('http://[::1]:54321/callback')).toBe(true);
+    expect(isAllowedDcrRedirectUri('http://localhost:3000/oauth')).toBe(true);
+    expect(isAllowedDcrRedirectUri('http://localhost/oauth')).toBe(true);
+  });
+
+  it('rejects non-loopback http', () => {
+    expect(isAllowedDcrRedirectUri('http://app.example.com/cb')).toBe(false);
+    expect(isAllowedDcrRedirectUri('http://192.168.1.5/cb')).toBe(false);
+    expect(isAllowedDcrRedirectUri('http://example.com')).toBe(false);
+  });
+
+  it('rejects custom schemes and OOB', () => {
+    expect(isAllowedDcrRedirectUri('myapp://callback')).toBe(false);
+    expect(isAllowedDcrRedirectUri('com.example.app:/oauth')).toBe(false);
+    expect(isAllowedDcrRedirectUri('urn:ietf:wg:oauth:2.0:oob')).toBe(false);
+    expect(isAllowedDcrRedirectUri('data:text/html,evil')).toBe(false);
+    expect(isAllowedDcrRedirectUri('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects garbage and fragment-bearing URIs', () => {
+    expect(isAllowedDcrRedirectUri('not a url')).toBe(false);
+    expect(isAllowedDcrRedirectUri('')).toBe(false);
+    expect(isAllowedDcrRedirectUri('https://example.com/cb#frag')).toBe(false);
+  });
+});
+
+describe('redirectUriMatches — loopback-aware /authorize matching', () => {
+  it('matches loopback ignoring the port', () => {
+    expect(redirectUriMatches('http://127.0.0.1:54213/cb', 'http://127.0.0.1:8080/cb')).toBe(true);
+    expect(redirectUriMatches('http://localhost:9999/cb', 'http://localhost/cb')).toBe(true);
+    expect(redirectUriMatches('http://[::1]:1/cb', 'http://[::1]:2/cb')).toBe(true);
+  });
+
+  it('does not match loopback when the path differs', () => {
+    expect(redirectUriMatches('http://127.0.0.1:1/cb', 'http://127.0.0.1:2/other')).toBe(false);
+  });
+
+  it('does not match loopback when the scheme differs', () => {
+    expect(redirectUriMatches('https://localhost/cb', 'http://localhost/cb')).toBe(false);
+  });
+
+  it('requires exact match for non-loopback hosts', () => {
+    expect(redirectUriMatches('https://app.example.com/cb', 'https://app.example.com/cb')).toBe(
+      true
+    );
+    expect(
+      redirectUriMatches('https://app.example.com:8443/cb', 'https://app.example.com/cb')
+    ).toBe(false);
+  });
+
+  it('isRegisteredRedirectUri matches against any registered URI', () => {
+    const registered = ['https://a.com/cb', 'http://127.0.0.1:1/cb'];
+    expect(isRegisteredRedirectUri('http://127.0.0.1:5000/cb', registered)).toBe(true);
+    expect(isRegisteredRedirectUri('https://a.com/cb', registered)).toBe(true);
+    expect(isRegisteredRedirectUri('https://evil.com/cb', registered)).toBe(false);
+  });
+});

--- a/src/server/oauth/discovery-metadata.ts
+++ b/src/server/oauth/discovery-metadata.ts
@@ -1,0 +1,36 @@
+import { env } from '~/env/server';
+import { tokenScopeNameToFlag } from '~/shared/constants/token-scope.constants';
+
+/**
+ * Shared OAuth/OIDC server metadata, used by both the OIDC discovery document
+ * (`/.well-known/openid-configuration`) and the RFC 8414 authorization server
+ * metadata document (`/.well-known/oauth-authorization-server`).
+ *
+ * `scopes_supported` uses the CANONICAL scope NAMES (RFC 6749 string scopes),
+ * which is what the MCP server and DCR clients speak — NOT the internal bitmask
+ * labels. `full` is excluded from the advertised list (it's an internal
+ * umbrella, never requested by name over the wire).
+ */
+export function buildOAuthServerMetadata() {
+  const issuer = env.NEXTAUTH_URL;
+
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/api/auth/oauth/authorize`,
+    token_endpoint: `${issuer}/api/auth/oauth/token`,
+    userinfo_endpoint: `${issuer}/api/auth/oauth/userinfo`,
+    revocation_endpoint: `${issuer}/api/auth/oauth/revoke`,
+    registration_endpoint: `${issuer}/api/auth/oauth/register`,
+    device_authorization_endpoint: `${issuer}/api/auth/oauth/device`,
+    response_types_supported: ['code'],
+    grant_types_supported: [
+      'authorization_code',
+      'refresh_token',
+      'client_credentials',
+      'urn:ietf:params:oauth:grant-type:device_code',
+    ],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+    scopes_supported: Object.keys(tokenScopeNameToFlag).filter((name) => name !== 'full'),
+  };
+}

--- a/src/server/oauth/rate-limit.ts
+++ b/src/server/oauth/rate-limit.ts
@@ -17,6 +17,65 @@ const RATE_LIMITS: Record<string, RateLimitConfig> = {
 };
 
 /**
+ * Dynamic Client Registration (RFC 7591) is open + unauthenticated, so the
+ * register endpoint gets a stricter, multi-window IP limit: 5/hour AND 20/day.
+ * A request must pass BOTH windows. Tracked separately from RATE_LIMITS so the
+ * single-window helper above stays simple for the existing endpoints.
+ */
+const REGISTER_RATE_LIMITS: RateLimitConfig[] = [
+  { limit: 5, windowSeconds: 60 * 60 }, // 5 per hour per IP
+  { limit: 20, windowSeconds: 24 * 60 * 60 }, // 20 per day per IP
+];
+
+/**
+ * Multi-window sliding-window rate limiter for the open DCR /register endpoint.
+ * Keyed by IP. Returns true if the request is allowed by ALL windows.
+ * Sets X-RateLimit-* headers reflecting the most-constrained window and a
+ * Retry-After when blocked. Fails open if Redis is unavailable.
+ */
+export async function checkRegisterRateLimit(res: NextApiResponse, ip: string): Promise<boolean> {
+  const identifier = ip || 'unknown';
+
+  try {
+    let blocked = false;
+    let tightestRemaining = Infinity;
+    let blockedTtl = 0;
+    let headerLimit = REGISTER_RATE_LIMITS[0].limit;
+
+    for (const config of REGISTER_RATE_LIMITS) {
+      const key = `${RATE_LIMIT_PREFIX}:register:${config.windowSeconds}:${identifier}`;
+      const current = await (redis as any).incr(key);
+      if (current === 1) {
+        await (redis as any).expire(key, config.windowSeconds);
+      }
+      const remaining = config.limit - current;
+      if (remaining < tightestRemaining) {
+        tightestRemaining = remaining;
+        headerLimit = config.limit;
+      }
+      if (current > config.limit) {
+        const ttl = await (redis as any).ttl(key);
+        blocked = true;
+        blockedTtl = Math.max(blockedTtl, Math.max(0, ttl));
+      }
+    }
+
+    res.setHeader('X-RateLimit-Limit', headerLimit);
+    res.setHeader('X-RateLimit-Remaining', Math.max(0, tightestRemaining));
+
+    if (blocked) {
+      res.setHeader('Retry-After', blockedTtl);
+      res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + blockedTtl);
+      return false;
+    }
+    return true;
+  } catch {
+    // Fail open for rate limiting if Redis is unavailable.
+    return true;
+  }
+}
+
+/**
  * Simple sliding-window rate limiter for OAuth endpoints.
  * Returns true if the request should be allowed, false if rate limited.
  * Sets rate limit headers on the response.

--- a/src/server/oauth/redirect-uri.ts
+++ b/src/server/oauth/redirect-uri.ts
@@ -1,0 +1,89 @@
+/**
+ * redirect_uri policy + matching for the OAuth server.
+ *
+ * Two concerns live here:
+ *  1. `isAllowedDcrRedirectUri` — the RFC 7591 registration allowlist. DCR is
+ *     open and unauthenticated, so we only accept redirect targets that can't
+ *     be abused as an open redirector or exfiltration channel:
+ *       - https://<host>/...            (TLS, any host)
+ *       - http://127.0.0.1[:port]/...   (IPv4 loopback)
+ *       - http://[::1][:port]/...       (IPv6 loopback)
+ *       - http://localhost[:port]/...   (loopback hostname)
+ *     Rejected: non-loopback http, custom schemes, OOB
+ *     (urn:ietf:wg:oauth:2.0:oob), data:, javascript:, etc.
+ *
+ *  2. `redirectUriMatches` — loopback-aware match used at /authorize. Native
+ *     apps (per RFC 8252 §7.3) bind an ephemeral loopback port that the client
+ *     can't know at registration time, so for loopback hosts we match
+ *     scheme + host + path and IGNORE the port. For every other host we require
+ *     an exact string match (the pre-existing behavior).
+ */
+
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+
+function isLoopbackHostname(hostname: string): boolean {
+  // URL.hostname returns '[::1]' as '::1' (brackets stripped); normalize both.
+  return LOOPBACK_HOSTNAMES.has(hostname);
+}
+
+/**
+ * Validate a redirect_uri against the open-DCR allowlist.
+ * Returns true if acceptable for a dynamically-registered public client.
+ */
+export function isAllowedDcrRedirectUri(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+
+  // No fragment component is allowed in a redirect_uri (RFC 6749 §3.1.2).
+  if (parsed.hash) return false;
+
+  if (parsed.protocol === 'https:') {
+    // Any TLS host is fine; reject empty host.
+    return !!parsed.hostname;
+  }
+
+  if (parsed.protocol === 'http:') {
+    // http is ONLY allowed for loopback addresses.
+    return isLoopbackHostname(parsed.hostname);
+  }
+
+  // Custom schemes, urn: (OOB), data:, etc. are rejected.
+  return false;
+}
+
+/**
+ * Loopback-aware redirect_uri equality used at the /authorize endpoint to
+ * match the incoming redirect_uri against a client's registered URIs.
+ *
+ * - For loopback hosts: match scheme + host + path, ignore the port (RFC 8252).
+ * - For all other hosts: exact string match.
+ */
+export function redirectUriMatches(requested: string, registered: string): boolean {
+  let a: URL;
+  let b: URL;
+  try {
+    a = new URL(requested);
+    b = new URL(registered);
+  } catch {
+    // Fall back to exact string comparison if either side won't parse.
+    return requested === registered;
+  }
+
+  const bothLoopback = isLoopbackHostname(a.hostname) && isLoopbackHostname(b.hostname);
+  if (bothLoopback) {
+    return a.protocol === b.protocol && a.hostname === b.hostname && a.pathname === b.pathname;
+  }
+
+  return requested === registered;
+}
+
+/**
+ * Does any registered URI match the requested one (loopback-aware)?
+ */
+export function isRegisteredRedirectUri(requested: string, registered: string[]): boolean {
+  return registered.some((r) => redirectUriMatches(requested, r));
+}

--- a/src/server/oauth/token-helpers.ts
+++ b/src/server/oauth/token-helpers.ts
@@ -61,5 +61,12 @@ export async function createOAuthTokenPair(
     },
   });
 
+  // Mark the client as recently used. Fire-and-forget: this is informational
+  // (drives DCR GC tuning + admin visibility) and must never add latency to or
+  // fail the token grant. Errors are swallowed.
+  dbWrite.oauthClient
+    .update({ where: { id: clientId }, data: { lastUsedAt: now } })
+    .catch(() => undefined);
+
   return { accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt };
 }

--- a/src/server/routers/bountyEntry.router.ts
+++ b/src/server/routers/bountyEntry.router.ts
@@ -12,9 +12,13 @@ import {
   deleteBountyEntryHandler,
   getBountyEntryFilteredFilesHandler,
   getBountyEntryHandler,
+  submitBountyEntryHandler,
   upsertBountyEntryHandler,
 } from '~/server/controllers/bountyEntry.controller';
-import { upsertBountyEntryInputSchema } from '~/server/schema/bounty-entry.schema';
+import {
+  submitBountyEntryInputSchema,
+  upsertBountyEntryInputSchema,
+} from '~/server/schema/bounty-entry.schema';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import { dbWrite } from '~/server/db/client';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -58,6 +62,11 @@ export const bountyEntryRouter = router({
     .input(upsertBountyEntryInputSchema)
     .use(isFlagProtected('bounties'))
     .mutation(upsertBountyEntryHandler),
+  submit: guardedProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
+    .input(submitBountyEntryInputSchema)
+    .use(isFlagProtected('bounties'))
+    .mutation(submitBountyEntryHandler),
   award: protectedProcedure
     .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(getByIdSchema)

--- a/src/server/routers/chat.router.ts
+++ b/src/server/routers/chat.router.ts
@@ -8,6 +8,7 @@ import {
   getUserSettingsHandler,
   isTypingHandler,
   markAllAsReadHandler,
+  markChatReadHandler,
   modifyUserHandler,
   setUserSettingsHandler,
 } from '~/server/controllers/chat.controller';
@@ -17,6 +18,7 @@ import {
   getInfiniteMessagesInput,
   getMessageByIdInput,
   isTypingInput,
+  markChatReadInput,
   modifyUserInput,
   userSettingsChat,
 } from '~/server/schema/chat.schema';
@@ -48,6 +50,10 @@ export const chatRouter = router({
   markAllAsRead: protectedProcedure
     .meta({ requiredScope: TokenScope.SocialWrite })
     .mutation(markAllAsReadHandler),
+  markChatRead: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(markChatReadInput)
+    .mutation(markChatReadHandler),
   getInfiniteMessages: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .input(getInfiniteMessagesInput)

--- a/src/server/routers/oauth-client.router.ts
+++ b/src/server/routers/oauth-client.router.ts
@@ -1,13 +1,12 @@
 import { TRPCError } from '@trpc/server';
-import { v4 as uuidv4 } from 'uuid';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { createOauthClient } from '~/server/services/oauth-client.service';
 import {
   createOauthClientSchema,
   deleteOauthClientSchema,
-  deriveAllowedOriginsFromRedirectUris,
   getOauthClientByIdSchema,
   rotateOauthClientSecretSchema,
   updateOauthClientSchema,
@@ -28,6 +27,7 @@ export const oauthClientRouter = router({
           description: true,
           logoUrl: true,
           isVerified: true,
+          isDynamicallyRegistered: true,
           redirectUris: true,
           allowedOrigins: true,
           allowedScopes: true,
@@ -64,38 +64,19 @@ export const oauthClientRouter = router({
     .meta({ requiredScope: TokenScope.UserWrite })
     .input(createOauthClientSchema)
     .mutation(async ({ ctx, input }) => {
-      const clientId = uuidv4();
-      const clientSecret = input.isConfidential ? generateKey(48) : null;
-      const hashedSecret = clientSecret ? generateSecretHash(clientSecret) : null;
-
-      // Public clients depend on Origin pinning for token-endpoint identity;
-      // if the caller didn't supply explicit origins, fall back to the origin
-      // part of their redirect URIs so registration still produces a working
-      // client without forcing the user to type the same hosts twice.
-      const allowedOrigins =
-        input.allowedOrigins.length > 0
-          ? input.allowedOrigins
-          : deriveAllowedOriginsFromRedirectUris(input.redirectUris);
-
-      await dbWrite.oauthClient.create({
-        data: {
-          id: clientId,
-          secret: hashedSecret,
-          name: input.name,
-          description: input.description,
-          redirectUris: input.redirectUris,
-          allowedOrigins,
-          isConfidential: input.isConfidential,
-          allowedScopes: input.allowedScopes,
-          userId: ctx.user.id,
-        },
+      const result = await createOauthClient({
+        userId: ctx.user.id,
+        name: input.name,
+        description: input.description,
+        redirectUris: input.redirectUris,
+        allowedOrigins: input.allowedOrigins,
+        isConfidential: input.isConfidential,
+        allowedScopes: input.allowedScopes,
       });
 
-      logOAuthEvent({ type: 'client.created', userId: ctx.user.id, clientId });
-
       return {
-        clientId,
-        clientSecret, // Only returned once — shown to the developer
+        clientId: result.clientId,
+        clientSecret: result.clientSecret, // Only returned once — shown to the developer
       };
     }),
 

--- a/src/server/routers/post.router.ts
+++ b/src/server/routers/post.router.ts
@@ -7,6 +7,7 @@ import {
   addPostTagHandler,
   addResourceToPostImageHandler,
   createPostHandler,
+  createPostWithImagesHandler,
   deletePostHandler,
   getPostContestCollectionDetailsHandler,
   getPostHandler,
@@ -25,6 +26,7 @@ import { getByIdSchema } from './../schema/base.schema';
 import {
   addPostTagSchema,
   addResourceToPostImageInput,
+  createPostWithImagesSchema,
   getPostTagsSchema,
   postCreateSchema,
   postsQuerySchema,
@@ -106,6 +108,10 @@ export const postRouter = router({
     .meta({ requiredScope: TokenScope.MediaWrite })
     .input(postCreateSchema)
     .mutation(createPostHandler),
+  createWithImages: guardedProcedure
+    .meta({ requiredScope: TokenScope.MediaWrite })
+    .input(createPostWithImagesSchema)
+    .mutation(createPostWithImagesHandler),
   update: verifiedProcedure
     .meta({ requiredScope: TokenScope.MediaWrite })
     .input(postUpdateSchema)

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -11,6 +11,7 @@ import {
   getCreatorsHandler,
   getLeaderboardHandler,
   getNotificationSettingsHandler,
+  getSelfStatusHandler,
   getUserBookmarkCollectionsHandler,
   getUserByIdHandler,
   getUserCosmeticsHandler,
@@ -137,6 +138,9 @@ export const userRouter = router({
     .meta({ requiredScope: TokenScope.UserRead })
     .input(getByIdSchema)
     .query(getUserByIdHandler),
+  getSelfStatus: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .query(getSelfStatusHandler),
   getEngagedModels: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .query(getUserEngagedModelsHandler),

--- a/src/server/schema/bounty-entry.schema.ts
+++ b/src/server/schema/bounty-entry.schema.ts
@@ -29,3 +29,36 @@ export const upsertBountyEntryInputSchema = z.object({
     .min(1, 'At least one example image must be uploaded'),
   description: getSanitizedStringSchema().nullish(),
 });
+
+// Headless/agent (MCP) friendly bounty-entry submission. The full `upsert`
+// requires pre-built file descriptors (baseFileSchema + the unlock metadata)
+// and a fully-shaped images array, which is impractical to construct without
+// the website's upload UI. `submit` accepts minimal, already-uploaded refs and
+// the server assembles the required `upsert` shape from them.
+//
+// The caller must upload the file(s) to storage first and pass the resulting
+// `url` + `name` + `sizeKB`. Images are referenced by their uploaded UUID `url`.
+export type SubmitBountyEntryInput = z.infer<typeof submitBountyEntryInputSchema>;
+export const submitBountyEntryInputSchema = z.object({
+  id: z.number().optional(),
+  bountyId: z.number(),
+  description: getSanitizedStringSchema().nullish(),
+  ownRights: z.boolean().optional(),
+  // Already-uploaded files. metadata controls buzz-unlock pricing; default is a
+  // free (0 buzz), non-benefactor-only entry when unlock fields are omitted.
+  files: z
+    .array(
+      z.object({
+        id: z.number().optional(),
+        url: z.url().min(1, 'You must provide a file url'),
+        name: z.string().min(1),
+        sizeKB: z.number(),
+        unlockAmount: z.number().optional(),
+        currency: z.enum(Currency).optional(),
+        benefactorsOnly: z.boolean().optional(),
+      })
+    )
+    .min(1, 'At least one file must be provided'),
+  // Already-uploaded example image UUIDs.
+  imageUuids: z.array(z.string().uuid()).min(1, 'At least one example image must be provided'),
+});

--- a/src/server/schema/chat.schema.ts
+++ b/src/server/schema/chat.schema.ts
@@ -22,6 +22,15 @@ export const modifyUserInput = z.object({
   lastViewedMessageId: z.number().optional(),
 });
 
+// Per-chat read tracking for headless/agent (MCP) use. The website only exposes
+// blanket markAllAsRead and a low-level modifyUser (which requires the caller to
+// already know the latest message id). markChatRead resolves the caller's
+// chatMember + latest message id server-side and marks just that one chat read.
+export type MarkChatReadInput = z.infer<typeof markChatReadInput>;
+export const markChatReadInput = z.object({
+  chatId: z.number(),
+});
+
 export type CreateMessageInput = z.infer<typeof createMessageInput>;
 export const createMessageInput = z.object({
   chatId: z.number(),

--- a/src/server/schema/post.schema.ts
+++ b/src/server/schema/post.schema.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 import { constants } from '~/server/common/constants';
 import { PostSort } from '~/server/common/enums';
 import { baseQuerySchema, periodModeSchema } from '~/server/schema/base.schema';
-import { imageMetaSchema } from '~/server/schema/image.schema';
+import { imageMetaSchema, imageSchema } from '~/server/schema/image.schema';
 import { sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import { MediaType, MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { postgresSlugify } from '~/utils/string-helpers';
@@ -68,6 +68,25 @@ export const postUpdateSchema = z.object({
   publishedAt: z.date().optional(),
   collectionId: z.number().nullish(),
   collectionTagId: z.number().nullish(),
+});
+
+// Composite create-with-images input for headless/agent (MCP) use. Each image
+// reuses the shared imageSchema shape (without postId — the server fills it in
+// after creating the post) and requires an explicit ordering index. The post is
+// created, images are attached in order, and the post is optionally published in
+// a single server-side round-trip.
+export type CreatePostWithImagesInput = z.infer<typeof createPostWithImagesSchema>;
+export const createPostWithImagesSchema = z.object({
+  title: z.string().trim().nullish(),
+  detail: z.string().nullish(),
+  modelVersionId: z.number().nullish(),
+  tag: z.number().nullish(),
+  tags: commaDelimitedStringArray().optional(),
+  collectionId: z.number().optional(),
+  publish: z.boolean().optional(),
+  images: z
+    .array(imageSchema.omit({ postId: true, index: true }).extend({ index: z.number().min(0) }))
+    .min(1, 'At least one image must be provided'),
 });
 
 export type RemovePostTagInput = z.infer<typeof removePostTagSchema>;

--- a/src/server/services/oauth-client.service.ts
+++ b/src/server/services/oauth-client.service.ts
@@ -1,0 +1,104 @@
+import { v4 as uuidv4 } from 'uuid';
+import { dbWrite } from '~/server/db/client';
+import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
+import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { deriveAllowedOriginsFromRedirectUris } from '~/server/schema/oauth-client.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+export interface CreateOauthClientParams {
+  /** Owner of the client. tRPC `create` passes the current user; DCR passes the
+   * system bot user. */
+  userId: number;
+  name: string;
+  description?: string;
+  redirectUris: string[];
+  allowedOrigins?: string[];
+  /** Confidential clients get a generated secret; public clients get null. */
+  isConfidential: boolean;
+  allowedScopes: number;
+  /** Grant types for this client. Defaults to the auth-code + refresh pair. */
+  grants?: string[];
+  /** Set true for RFC 7591 dynamically-registered clients. */
+  isDynamicallyRegistered?: boolean;
+  /** Optional logo URL (only set via DCR / update flows). */
+  logoUrl?: string | null;
+}
+
+export interface CreateOauthClientResult {
+  clientId: string;
+  /** Plaintext secret — only returned once, only for confidential clients. */
+  clientSecret: string | null;
+  /** Final stored values, echoed back for callers that build a response body. */
+  redirectUris: string[];
+  allowedOrigins: string[];
+  allowedScopes: number;
+  grants: string[];
+  isConfidential: boolean;
+}
+
+/**
+ * Shared OAuth-client creation. Used by both the tRPC `oauthClient.create`
+ * mutation (developer-registered clients) and the RFC 7591 `/register`
+ * endpoint (dynamically-registered public clients).
+ *
+ * The caller is responsible for policy (who may create what scopes/grants);
+ * this service just persists exactly what it's told and handles secret
+ * generation + origin derivation.
+ */
+export async function createOauthClient(
+  params: CreateOauthClientParams
+): Promise<CreateOauthClientResult> {
+  const clientId = uuidv4();
+  const clientSecret = params.isConfidential ? generateKey(48) : null;
+  const hashedSecret = clientSecret ? generateSecretHash(clientSecret) : null;
+
+  // Public clients depend on Origin pinning for token-endpoint identity; if no
+  // explicit origins were supplied, fall back to the origin part of the
+  // redirect URIs so the client still works without typing hosts twice.
+  const allowedOrigins =
+    params.allowedOrigins && params.allowedOrigins.length > 0
+      ? params.allowedOrigins
+      : deriveAllowedOriginsFromRedirectUris(params.redirectUris);
+
+  const grants = params.grants ?? ['authorization_code', 'refresh_token'];
+
+  await dbWrite.oauthClient.create({
+    data: {
+      id: clientId,
+      secret: hashedSecret,
+      name: params.name,
+      description: params.description ?? '',
+      logoUrl: params.logoUrl ?? null,
+      redirectUris: params.redirectUris,
+      allowedOrigins,
+      grants,
+      isConfidential: params.isConfidential,
+      allowedScopes: params.allowedScopes,
+      userId: params.userId,
+      isDynamicallyRegistered: params.isDynamicallyRegistered ?? false,
+    },
+  });
+
+  logOAuthEvent({
+    type: 'client.created',
+    userId: params.userId,
+    clientId,
+    metadata: { isDynamicallyRegistered: params.isDynamicallyRegistered ?? false },
+  });
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUris: params.redirectUris,
+    allowedOrigins,
+    allowedScopes: params.allowedScopes,
+    grants,
+    isConfidential: params.isConfidential,
+  };
+}
+
+/** Default grants for a public DCR client — never client_credentials. */
+export const DCR_GRANTS = ['authorization_code', 'refresh_token'] as const;
+
+/** Scope mask cap for DCR clients (never Full). See TokenScopePresets.MCPMaxAllowed. */
+export { TokenScope };

--- a/src/shared/constants/__tests__/token-scope.test.ts
+++ b/src/shared/constants/__tests__/token-scope.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TokenScope,
+  TokenScopePresets,
+  scopeNamesToBitmask,
+  bitmaskToScopeNames,
+  tokenScopeNameToFlag,
+} from '~/shared/constants/token-scope.constants';
+
+describe('scopeNamesToBitmask / bitmaskToScopeNames', () => {
+  it('round-trips a representative set of canonical names', () => {
+    const names = ['user:read', 'models:read', 'media:write', 'social:write'];
+    const mask = scopeNamesToBitmask(names);
+    expect(mask).toBe(
+      TokenScope.UserRead | TokenScope.ModelsRead | TokenScope.MediaWrite | TokenScope.SocialWrite
+    );
+    expect(bitmaskToScopeNames(mask).sort()).toEqual([...names].sort());
+  });
+
+  it('round-trips every individual canonical scope name', () => {
+    for (const name of Object.keys(tokenScopeNameToFlag)) {
+      if (name === 'full') continue;
+      const mask = scopeNamesToBitmask([name]);
+      expect(bitmaskToScopeNames(mask)).toContain(name);
+    }
+  });
+
+  it('ignores unknown names in scopeNamesToBitmask', () => {
+    expect(scopeNamesToBitmask(['user:read', 'bogus:scope'])).toBe(TokenScope.UserRead);
+  });
+
+  it('bitmaskToScopeNames never emits "full"', () => {
+    expect(bitmaskToScopeNames(TokenScope.Full)).not.toContain('full');
+    // a full mask decomposes into all individual names
+    expect(bitmaskToScopeNames(TokenScope.Full)).toContain('models:delete');
+  });
+});
+
+describe('MCP scope cap policy', () => {
+  const cap = TokenScopePresets.MCPMaxAllowed;
+
+  it('excludes all Delete scopes', () => {
+    expect(cap & TokenScope.ModelsDelete).toBe(0);
+    expect(cap & TokenScope.MediaDelete).toBe(0);
+    expect(cap & TokenScope.ArticlesDelete).toBe(0);
+    expect(cap & TokenScope.BountiesDelete).toBe(0);
+  });
+
+  it('excludes buzz-spending scopes', () => {
+    expect(cap & TokenScope.SocialTip).toBe(0);
+    expect(cap & TokenScope.AIServicesWrite).toBe(0);
+    expect(cap & TokenScope.BountiesWrite).toBe(0);
+  });
+
+  it('never equals Full', () => {
+    expect(cap).not.toBe(TokenScope.Full);
+  });
+
+  it('clamps a models:delete request down to nothing extra (the cap drops it)', () => {
+    // Simulate the /register clamp: requested = models:read + models:delete.
+    const requested = TokenScope.ModelsRead | TokenScope.ModelsDelete;
+    const capped = (requested & cap) | TokenScope.UserRead;
+    expect(capped & TokenScope.ModelsDelete).toBe(0);
+    expect(capped & TokenScope.ModelsRead).toBe(TokenScope.ModelsRead);
+    expect(bitmaskToScopeNames(capped)).not.toContain('models:delete');
+    expect(bitmaskToScopeNames(capped)).toContain('models:read');
+  });
+
+  it('includes the expected safe write scopes', () => {
+    expect(cap & TokenScope.MediaWrite).toBe(TokenScope.MediaWrite);
+    expect(cap & TokenScope.ModelsWrite).toBe(TokenScope.ModelsWrite);
+    expect(cap & TokenScope.SocialWrite).toBe(TokenScope.SocialWrite);
+  });
+});

--- a/src/shared/constants/token-scope.constants.ts
+++ b/src/shared/constants/token-scope.constants.ts
@@ -93,6 +93,80 @@ export const tokenScopeLabels: Record<number, string> = {
   [TokenScope.VaultWrite]: 'Manage vault',
 };
 
+/**
+ * Canonical scope NAMES (RFC 6749 / OAuth space-delimited scope strings).
+ *
+ * This map is the SOURCE OF TRUTH for the wire-format scope names exposed in
+ * discovery metadata (`scopes_supported`) and accepted by Dynamic Client
+ * Registration (RFC 7591). The MCP server's advertised scope metadata MUST
+ * match these names exactly. `full` maps to the all-bits mask but is never
+ * granted to dynamically-registered (DCR) clients.
+ */
+export const tokenScopeNameToFlag: Record<string, number> = {
+  'user:read': TokenScope.UserRead,
+  'user:write': TokenScope.UserWrite,
+  'models:read': TokenScope.ModelsRead,
+  'models:write': TokenScope.ModelsWrite,
+  'models:delete': TokenScope.ModelsDelete,
+  'media:read': TokenScope.MediaRead,
+  'media:write': TokenScope.MediaWrite,
+  'media:delete': TokenScope.MediaDelete,
+  'articles:read': TokenScope.ArticlesRead,
+  'articles:write': TokenScope.ArticlesWrite,
+  'articles:delete': TokenScope.ArticlesDelete,
+  'bounties:read': TokenScope.BountiesRead,
+  'bounties:write': TokenScope.BountiesWrite,
+  'bounties:delete': TokenScope.BountiesDelete,
+  'ai:read': TokenScope.AIServicesRead,
+  'ai:write': TokenScope.AIServicesWrite,
+  'buzz:read': TokenScope.BuzzRead,
+  'collections:read': TokenScope.CollectionsRead,
+  'collections:write': TokenScope.CollectionsWrite,
+  'social:write': TokenScope.SocialWrite,
+  'social:tip': TokenScope.SocialTip,
+  'notifications:read': TokenScope.NotificationsRead,
+  'notifications:write': TokenScope.NotificationsWrite,
+  'vault:read': TokenScope.VaultRead,
+  'vault:write': TokenScope.VaultWrite,
+  full: TokenScope.Full,
+};
+
+/** Reverse map (single-bit flag -> canonical name). `full` is excluded so a
+ * full mask decomposes into its individual scope names rather than collapsing
+ * to the umbrella name. */
+const tokenFlagToScopeName: Record<number, string> = Object.fromEntries(
+  Object.entries(tokenScopeNameToFlag)
+    .filter(([name]) => name !== 'full')
+    .map(([name, flag]) => [flag, name])
+);
+
+/**
+ * Convert an array of canonical scope names into a combined bitmask.
+ * Unknown names are ignored (caller is responsible for rejecting them if the
+ * contract requires it — e.g. the registration endpoint).
+ */
+export function scopeNamesToBitmask(names: string[]): number {
+  let mask = 0;
+  for (const name of names) {
+    const flag = tokenScopeNameToFlag[name];
+    if (flag != null) mask |= flag;
+  }
+  return mask;
+}
+
+/**
+ * Convert a scope bitmask into the array of canonical scope names it contains,
+ * in the enum's declared order. Never emits `full`.
+ */
+export function bitmaskToScopeNames(mask: number): string[] {
+  const names: string[] = [];
+  for (const [flagStr, name] of Object.entries(tokenFlagToScopeName)) {
+    const flag = Number(flagStr);
+    if ((mask & flag) === flag && flag !== 0) names.push(name);
+  }
+  return names;
+}
+
 /** Convenience presets for the API key creation UI */
 export const TokenScopePresets = {
   ReadOnly:
@@ -129,6 +203,55 @@ export const TokenScopePresets = {
     TokenScope.AIServicesRead |
     TokenScope.BuzzRead,
   Full: TokenScope.Full,
+
+  /**
+   * Maximum scope mask a Dynamically-Registered (RFC 7591) client may ever be
+   * granted. This is the hard cap enforced at /register: even if the client
+   * later requests more at /authorize, `validateScope` clamps to the client's
+   * stored `allowedScopes`, which can never exceed this mask.
+   *
+   * EXCLUDED by policy (never available to DCR clients):
+   *  - All Delete scopes (Models/Media/Articles/Bounties)
+   *  - SocialTip (buzz spend)
+   *  - AIServicesWrite (buzz spend — generation/training/scanning)
+   *  - BountiesWrite (buzz spend — bounty creation)
+   */
+  MCPMaxAllowed:
+    TokenScope.UserRead |
+    TokenScope.ModelsRead |
+    TokenScope.MediaRead |
+    TokenScope.ArticlesRead |
+    TokenScope.BountiesRead |
+    TokenScope.BuzzRead |
+    TokenScope.CollectionsRead |
+    TokenScope.AIServicesRead |
+    TokenScope.NotificationsRead |
+    TokenScope.VaultRead |
+    TokenScope.MediaWrite |
+    TokenScope.ArticlesWrite |
+    TokenScope.CollectionsWrite |
+    TokenScope.SocialWrite |
+    TokenScope.NotificationsWrite |
+    TokenScope.ModelsWrite,
+
+  /**
+   * The scope set a freshly-registered MCP client is expected to request by
+   * default (read everything it can + the safe writes). Used for the consent
+   * pre-check / display default.
+   */
+  MCPDefault:
+    TokenScope.UserRead |
+    TokenScope.ModelsRead |
+    TokenScope.MediaRead |
+    TokenScope.ArticlesRead |
+    TokenScope.BountiesRead |
+    TokenScope.BuzzRead |
+    TokenScope.CollectionsRead |
+    TokenScope.AIServicesRead |
+    TokenScope.NotificationsRead |
+    TokenScope.VaultRead |
+    TokenScope.MediaWrite |
+    TokenScope.SocialWrite,
 } as const;
 
 /** Preset labels for the dropdown */
@@ -137,6 +260,8 @@ export const tokenScopePresetLabels: Record<keyof typeof TokenScopePresets, stri
   Creator: 'Creator',
   AIServices: 'AI Services',
   Full: 'Full Access',
+  MCPMaxAllowed: 'MCP (Max Allowed)',
+  MCPDefault: 'MCP (Default)',
 };
 
 /**

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -1696,6 +1696,8 @@ export interface OauthClient {
   userId: number;
   user?: User;
   isVerified: boolean;
+  isDynamicallyRegistered: boolean;
+  lastUsedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
   tokens?: ApiKey[];


### PR DESCRIPTION
## What

Adds **Dynamic Client Registration (RFC 7591)** + supporting OAuth metadata so MCP clients (Claude, Cursor) can one-click connect to the hosted Civitai MCP server (`mcp.civitai.com`) — user clicks Connect, logs into Civitai, grants scopes, done. No manual token paste, no manual app registration.

Pairs with the resource-server side already on [civitai-mcp-server](https://github.com/civitai/civitai-mcp-server) (`/.well-known/oauth-protected-resource` + 401 challenge).

## Changes
- **`POST /api/auth/oauth/register`** — open, unauthenticated RFC 7591 endpoint. Creates a **public PKCE client** (no secret) owned by a system user.
- **Discovery** — adds `registration_endpoint` + canonical scope names (`models:read`, `media:write`, …) to `/.well-known/openid-configuration`; new RFC 8414 `/.well-known/oauth-authorization-server` (shared builder, can't drift).
- **`authorize.ts`** — loopback-aware redirect matching (RFC 8252 ephemeral ports); non-loopback stays exact-match (no regression). Accepts + ignores RFC 8707 `resource` (v1).
- **Scope presets** — `scopeNamesToBitmask`/`bitmaskToScopeNames`; `MCPMaxAllowed` cap + `MCPDefault` consent pre-check.
- **Consent screen** — "unverified app" warning for dynamically-registered clients.
- **GC job** — reaps DCR clients with zero tokens + zero consents after 48h.

## Security posture (open registration is the risk surface — reviewed)
Independent adversarial security review: **ship, no critical/major.**
- **redirect_uri allowlist** uses the WHATWG URL parser (not regex) — passed every bypass attempt (homograph, octal/hex-IP loopback spoof, userinfo `@` tricks, control chars, non-http schemes all denied). `https://<host>` or `http://` loopback only.
- **Scope cap airtight** — DCR clients can never obtain `Full`, any `*:delete`, `social:tip`, `ai:write`, or `bounties:write` (buzz spend). Clamped at register AND re-clamped at every `/authorize` via `validateScope`.
- Forced public/PKCE clients; consent always shown; IP rate-limit 5/hr + 20/day; GC backstop verified non-starvable.
- Hardening from review applied: capped `redirect_uris` array (max 10) + per-field sizes + 16kb body limit.
- No SSRF (no server-side fetch of client URIs).

## ⚠️ Operational prerequisites before this goes live
1. **Apply the migration manually** (per our DB convention — NOT auto-run). Additive + backfill-safe:
   ```sql
   ALTER TABLE "OauthClient"
     ADD COLUMN IF NOT EXISTS "isDynamicallyRegistered" BOOLEAN NOT NULL DEFAULT false,
     ADD COLUMN IF NOT EXISTS "lastUsedAt" TIMESTAMP(3);
   ```
2. **Create the `oauth-dcr-bot` system user** and set `OAUTH_DCR_OWNER_USER_ID` to its id. Until set, `/register` returns `503 temporarily_unavailable` (fail-safe — can't ship half-wired). Confirm the User insert doesn't trigger onboarding/reward side effects you'd want suppressed for a non-human account.

## Verification
- `pnpm run typecheck` clean. OAuth tests green (38 incl. 22 new: redirect allowlist accept/reject, loopback port-ignore, scope clamp, register happy-path no-secret, client_credentials rejected, rate-limit 429, owner-missing 503).
- The `resource` param is inert by construction (authorize redirect is hand-built; only `code`+`state`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)