### PR TITLE
test(preview): raise heavy-SSR/whatIf timeouts so slow windows flake, not hard-fail

### DIFF
--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -37,16 +37,20 @@ export default defineConfig({
   // and opens DB pools. The default 30s per-test timeout is too tight for that cold
   // first hit, so raise both the per-test and navigation timeouts. The setup project
   // also fires a warm-up request before the suite (preview-auth.setup.ts).
-  timeout: 60_000,
+  // 90s (was 60s): on a contended preview node the single-replica pod gets CPU-
+  // throttled and the heaviest SSR pages (/user/membership, /models) intermittently
+  // crossed the 60s ceiling (observed ~66s) — a slow window should flake-and-recover
+  // on retry, not hard-fail. 90s gives comfortable margin without masking a real hang.
+  timeout: 90_000,
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   use: {
     baseURL: PREVIEW_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // Align with the per-test timeout: a cold heavy-page (/models) goto can need
-    // most of the budget, and a 45s nav cap would fail it even though the test has
-    // 60s. The setup project also pre-warms /models + /images authenticated.
-    navigationTimeout: 60_000,
+    // most of the budget, and a tighter nav cap would fail it even though the test
+    // has 90s. The setup project also pre-warms /models + /images authenticated.
+    navigationTimeout: 90_000,
   },
   projects: [
     { name: 'preview-setup', testMatch: /(^|\/)preview-auth\.setup\.ts$/ },

--- a/tests/preview-generation.spec.ts
+++ b/tests/preview-generation.spec.ts
@@ -46,9 +46,14 @@ test.describe('generation cost quote (gold)', () => {
   // 1. Primary, network-based: whatIf fires on /generate load and quotes a cost.
   test('whatIfFromGraph fires on /generate and returns a numeric cost', async ({ page }) => {
     // Arm the response listener BEFORE navigating so an on-load fire isn't missed.
+    // 45s (was 25s): whatIf is the heaviest client-side flow — page load + hydrate +
+    // form init + resource resolve + orchestrator round-trip must all complete before
+    // it fires. On a CPU-throttled preview pod a slow window pushed this past 25s and
+    // it hard-failed (both attempts). 45s lets a slow window flake-and-recover; the
+    // orchestrator itself is fast (~57ms), so this never approaches 45s when healthy.
     const whatIfResponse = page.waitForResponse(
       (r) => r.url().includes(WHATIF_URL) && r.status() === 200,
-      { timeout: 25_000 }
+      { timeout: 45_000 }
     );
 
     const resp = await page.goto('/generate', { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## What

Raises the preview smoke suite's timeouts on the heaviest flows so a CPU-throttled slow window **flakes-and-recovers on retry** instead of **hard-failing**:

- `playwright.preview.config.ts`: per-test `timeout` and `navigationTimeout` **60s → 90s**
- `preview-generation.spec.ts`: whatIf `waitForResponse` **25s → 45s**

## Why

The preview is a single-replica pod (CPU req 1 / limit 2). On a contended node it gets CPU-throttled, and the heaviest flows intermittently crossed their ceilings and **hard-failed both attempts** (not just flaked):

- `/user/membership` and `/models` SSR `goto` — observed **~66s**, just past the 60s test+nav timeout.
- generation **whatIf** `waitForResponse` — the heaviest client-side chain (page load → hydrate → form init → resource resolve → orchestrator round-trip) pushed past **25s** under load.

This is the residual flake left after the preview-pod CPU bump (it reduced but didn't eliminate slow windows). It's what made the **report-only** smoke comment show ❌ on otherwise-clean PRs.

## These are margins, not masks

When healthy, none of these come close: the orchestrator `/health` is **~57ms** and `/generate` SSR is **~0.4s**. The higher ceilings only matter during a transient slow window — exactly when you want a flake-and-recover, not a hard fail. A genuinely hung test still fails (just at 90s instead of 60s).

## Why it matters

Removing the hard-fail mode on slow windows is the **prerequisite for ever flipping smoke-test to gating** (`exit 0` → `exit $RC`) — today a clean PR can intermittently post a smoke ❌, which would false-block under gating.

## Verification

- Isolated `tsc --noEmit` on the changed files → EXIT 0.
- Will be exercised by this PR's own preview run (and validated over subsequent real-PR runs that hit slow windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)