### PR TITLE
perf(api): SSR-inject user.getFollowingUsers (~27/s off api-primary)

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -104,6 +104,7 @@ type CustomAppProps = {
   userFeatureFlags?: FeatureAccess;
   tosUpdate?: CheckTosUpdateResult;
   announcements?: AnnouncementsSeed;
+  following?: number[];
   seed: number;
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
@@ -128,6 +129,7 @@ function MyApp(props: CustomAppProps) {
       userFeatureFlags,
       tosUpdate,
       announcements,
+      following,
       seed = Date.now(),
       canIndex,
       hasAuthCookie,
@@ -184,6 +186,7 @@ function MyApp(props: CustomAppProps) {
       settings={settings}
       tosUpdate={tosUpdate}
       announcements={announcements}
+      following={following}
       region={region}
       domain={domain}
       host={host}
@@ -340,7 +343,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   // Read the verified-bot header set by botDetectionMiddleware.
   const verifiedBot = parseVerifiedBotHeader(request.headers[VERIFIED_BOT_HEADER]);
 
-  const { settings, session, tosUpdate, announcements } = await fetch(
+  const { settings, session, tosUpdate, announcements, following } = await fetch(
     `${baseUrl as string}/api/user/settings`,
     {
       headers: { ...request.headers } as HeadersInit,
@@ -350,6 +353,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       settings: UserContentSettings;
       tosUpdate?: CheckTosUpdateResult;
       announcements?: AnnouncementsSeed;
+      following?: number[];
       session: Session | null;
     } = await res.json();
     return data;
@@ -418,6 +422,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       userFeatureFlags,
       tosUpdate,
       announcements,
+      following,
       seed: Date.now(),
       hasAuthCookie,
       region,

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -3,6 +3,7 @@ import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { checkTosUpdate } from '~/server/services/content.service';
 import { getCurrentAnnouncements } from '~/server/services/announcement.service';
+import { getUserFollows } from '~/server/redis/caches';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 
 export default PublicEndpoint(
@@ -12,13 +13,14 @@ export default PublicEndpoint(
       // Use the content-settings view so SSR initialData matches the tRPC
       // getSettings response shape (JSON settings + User-column toggles).
       const settings = await getUserContentSettings(session?.user?.id ?? -1);
-      // tosUpdate + announcements both only need (session, settings) — compute
-      // them concurrently to keep this hot per-bootstrap route off the critical
-      // path. announcements swallows its own errors (`.catch`) so it can never
-      // reject the Promise.all and drop the critical settings/session payload;
-      // tosUpdate can still throw to the outer catch (preserving prior behaviour).
+      // tosUpdate + announcements + following all only need (session, settings) —
+      // compute them concurrently to keep this hot per-bootstrap route off the
+      // critical path. announcements + following swallow their own errors
+      // (`.catch`) so they can never reject the Promise.all and drop the critical
+      // settings/session payload; tosUpdate can still throw to the outer catch
+      // (preserving prior behaviour).
       const domainColor = getRequestDomainColor(req);
-      const [tosUpdate, announcements] = await Promise.all([
+      const [tosUpdate, announcements, following] = await Promise.all([
         // Compute the `content.checkTosUpdate` result here (server-only API route)
         // so `_app` getInitialProps can SSR-seed that query WITHOUT importing
         // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
@@ -39,11 +41,20 @@ export default PublicEndpoint(
         getCurrentAnnouncements({ domain: domainColor, userId: session?.user?.id }).catch(
           () => undefined
         ),
+        // SSR-seed the ambient, auth-gated `user.getFollowingUsers` query (fires
+        // on every logged-in bootstrap wherever a follow/notify button mounts).
+        // `getUserFollows` is the same redis-cached fn the resolver calls, so the
+        // seed is byte-identical (a `number[]` of followed userIds). Anon never
+        // fires this query (`enabled: !!currentUser`), so seed authed-only.
+        session?.user
+          ? getUserFollows(session.user.id).catch(() => undefined)
+          : Promise.resolve(undefined),
       ]);
       res.status(200).json({
         settings,
         tosUpdate,
         announcements,
+        following,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,
       });
     } catch (e) {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -20,6 +20,10 @@ type AppProviderProps = {
   // `useDomainColor()` key — this provider sits above FeatureFlagsProvider so it
   // can't compute that key itself.
   announcements?: AnnouncementsSeed;
+  // SSR-computed `user.getFollowingUsers` result (logged-in only) — the list of
+  // followed userIds. Seeds the query directly (fixed `undefined` key) so the
+  // ambient follow/notify buttons never fire it on bootstrap.
+  following?: number[];
   seed: number;
   canIndex: boolean;
   region: RegionInfo;
@@ -88,6 +92,7 @@ export function AppProvider({
   settings,
   tosUpdate,
   announcements,
+  following,
   domain,
   host,
   serverDomains,
@@ -113,6 +118,18 @@ export function AppProvider({
     enabled: !!tosUpdateInitial,
     staleTime: Infinity,
     gcTime: Infinity,
+  });
+  // Seed `user.getFollowingUsers` (the followed-userId list) from the SSR
+  // snapshot so the ambient follow/notify buttons read a primed cache and never
+  // fire it on bootstrap. The list only changes via the user's own follow/
+  // unfollow, which `FollowUserButton` already patches via optimistic `setData`
+  // — so the global `staleTime: Infinity` default is correct here (no external
+  // churn to refetch for). `enabled: !!following` skips the seed (and any
+  // self-heal fetch) only when there's no snapshot (anon never fires this query;
+  // a failed authed snapshot falls back to the consumers' own live fetch).
+  trpc.user.getFollowingUsers.useQuery(undefined, {
+    initialData: following,
+    enabled: !!following,
   });
   // Populate the module-level server domain map so `syncAccount(url)` can
   // resolve hosts to colors without pulling from React context.

--- a/tests/preview-ssr-inject.spec.ts
+++ b/tests/preview-ssr-inject.spec.ts
@@ -41,6 +41,7 @@ import { storageStatePath } from './preview-fixtures';
 const FEATURE_FLAGS_PROCEDURE = 'user.getFeatureFlags';
 const TOS_PROCEDURE = 'content.checkTosUpdate';
 const ANNOUNCEMENTS_PROCEDURE = 'announcement.getAnnouncements';
+const FOLLOWING_PROCEDURE = 'user.getFollowingUsers';
 
 // A core page a gate-passing user lands on directly (no /login bounce). Both
 // procedures fire on every logged-in bootstrap regardless of which page, so
@@ -327,6 +328,50 @@ test.describe('SSR-injected announcements (anonymous)', () => {
   // fetch" test above. The anon coverage that matters — seed present in
   // __NEXT_DATA__ and NO getAnnouncements request on bootstrap (the SSR-inject
   // contract) — is asserted in the test above.
+});
+
+/**
+ * Regression guard for the SSR-inject of `user.getFollowingUsers` (~27/s on
+ * api-primary). AUTH-GATED (the consumers gate on `enabled: !!currentUser`), so
+ * it NEVER fires anonymously — authed block only, like getFeatureFlags/tos.
+ * Seeded directly in AppProvider (fixed `undefined` key) and inheriting the
+ * global `staleTime: Infinity`, so a seeded query never refetches. The payload
+ * is a plain `number[]` of followed userIds — no Date/serialization subtlety, so
+ * the seed (JSON) and a live fetch (`result.data.json`) compare directly.
+ */
+test.describe('SSR-injected getFollowingUsers (logged-in)', () => {
+  test.use({ storageState: storageStatePath('mod') });
+
+  test('getFollowingUsers is seeded into __NEXT_DATA__ and not fetched on bootstrap', async ({
+    page,
+  }) => {
+    const trpcUrls = await collectTrpcRequests(page, AUTHED_LANDING);
+
+    const following = await readPageProp(page, 'following');
+    expect(following.present, 'following present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(Array.isArray(following.value), 'following seed is an array').toBe(true);
+
+    const followingRequests = trpcUrls.filter((u) => u.includes(FOLLOWING_PROCEDURE));
+    expect(
+      followingRequests,
+      `no ${FOLLOWING_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${followingRequests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
+  });
+
+  test('SSR seed byte-equals a live fetch', async ({ page }) => {
+    await page.goto(AUTHED_LANDING, { waitUntil: 'domcontentloaded' });
+
+    const seed = await readPageProp(page, 'following');
+    expect(seed.present, 'following seed present in __NEXT_DATA__').toBe(true);
+
+    const live = await fetchTrpcQueryJson(page, FOLLOWING_PROCEDURE);
+    expect(
+      seed.value,
+      'user.getFollowingUsers SSR seed must byte-equal a live resolver fetch'
+    ).toEqual(live);
+  });
 });
 
 /**

--- a/tests/preview-ssr-inject.spec.ts
+++ b/tests/preview-ssr-inject.spec.ts
@@ -371,6 +371,17 @@ test.describe('SSR-injected getFollowingUsers (logged-in)', () => {
       seed.value,
       'user.getFollowingUsers SSR seed must byte-equal a live resolver fetch'
     ).toEqual(live);
+
+    // The byte-equality above holds trivially for a user who follows nobody
+    // (`[] === []`) — surface the length so an all-empty run is visible (not a
+    // silent no-op), and when non-empty assert the payload is a number[] of
+    // userIds (mirrors the announcements test's non-empty shape check).
+    const ids = Array.isArray(seed.value) ? (seed.value as unknown[]) : [];
+    // eslint-disable-next-line no-console
+    console.log(`[ssr-inject] following seed length: ${ids.length}`);
+    for (const id of ids) {
+      expect(typeof id, 'following item is a userId (number)').toBe('number');
+    }
   });
 });
 


### PR DESCRIPTION
## What

Fourth volume cut in the api-primary bootstrap-tRPC effort (after #2464 browsingSettingsAddons/getSettings, #2471 getFeatureFlags+checkTosUpdate, #2477 announcements). `user.getFollowingUsers` — the followed-userId list — fires on every logged-in bootstrap wherever a follow/notify button mounts (~27/s on api-primary).

SSR-inject the result as React Query `initialData` so the per-bootstrap fetch never fires.

## Why this drops to ~0 (and is the cleanest cut yet)

The global QueryClient default is `staleTime: Infinity` (`src/utils/trpc.ts`). So the ~27/s is purely the **first-mount fetch** — `Infinity` only suppresses *re*fetch, not the initial fetch when there's no cached data. Seeding `initialData` removes it entirely, and unlike #2477 there's **no freshness trade-off**: the follow list only changes via the user's own follow/unfollow, which `FollowUserButton` already patches via optimistic `setData`. So `staleTime: Infinity` is correct here.

## How

| File | Change |
|---|---|
| `api/user/settings.ts` | Compute the seed via `getUserFollows(userId)` — the **same redis-cached fn the resolver calls**, so the seed is byte-identical (`number[]`). Added as a third concurrent leg of the existing `Promise.all` (authed-only, `.catch(() => undefined)` so it can't drop the critical settings/session payload). Computed in the API route — **not `_app`** — to avoid a client-bundle leak. |
| `_app.tsx` | Thread `following` through pageProps → `AppProvider` + `__NEXT_DATA__`. |
| `AppProvider.tsx` | Seed `trpc.user.getFollowingUsers.useQuery(undefined, { initialData: following, enabled: !!following })` directly (fixed `undefined` key, like `getSettings`/`tosUpdate`). `enabled: !!following` skips the seed when there's no snapshot — anon never fires this auth-gated query; a failed authed snapshot self-heals via the consumers' own live fetch. |
| `preview-ssr-inject.spec.ts` | Authed-only e2e (seeded-into-`__NEXT_DATA__`, not-fetched-on-bootstrap, seed-byte-equals-live-fetch). |

## No hydration concern (unlike #2477)

Follow-button state derives purely from the seed (`following.includes(userId)`) with no localStorage-derived state (unlike announcements' `dismissed`), so server and client-first-paint match. It actually **improves** SSR — correct follow state in the initial HTML instead of a "Follow"→"Following" flash. No `useIsClient` gate needed.

## Verification

- **Type-check / prettier / eslint**: clean (zero errors in touched files — the payload is `number[]`, no Prisma-model involvement, so none of the stale-local-Prisma `any` noise).
- **No client-bundle leak**: `getUserFollows` (redis/db) is imported only in the server API route; `_app`/`AppProvider` receive a plain `number[]` + a client tRPC seed (verified).
- **Pending (post-merge, same gate as prior cuts)**: preview `preview/smoke-tests` e2e, and prod confirmation via `civitai_app_trpc_procedure_duration_seconds_count{path="user.getFollowingUsers"}` dropping toward ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)