### PR TITLE
test(preview): pre-warm all heavy pages + 2 retries (kill the slow-window flake)

### DIFF
--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -25,7 +25,11 @@ export default defineConfig({
   testMatch: /(^|\/)preview-.*\.(setup|spec)\.ts$/,
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  // 2 retries (was 1): the preview pod can hit a transient CPU-throttle window on a
+  // contended node; with pre-warm (preview-auth.setup.ts) covering cold-start, the
+  // residual flake is a mid-run slow window. A 2nd retry gives it another recovery
+  // chance so a slow window flakes-and-recovers instead of surfacing as a failure.
+  retries: process.env.CI ? 2 : 0,
   // Run SERIALLY. The preview is a single-replica, cold, resource-modest pod.
   // Concurrent loads of the heavy pages (/models, /images, /purchase/buzz,
   // /pricing, model detail) across multiple workers segfaulted it (exit 139),

--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -92,16 +92,38 @@ setup('mint preview sessions', async ({ request }) => {
   }
 
   // Warm the freshly-deployed preview before the suite so the first real test
-  // doesn't pay the full cold-SSR cost (Next warm-up + JIT + DB pools). Warm the
-  // HEAVY listing pages too, not just `/` — those are the slow ones. They must be
-  // warmed AUTHENTICATED: on a preview the gate 307s an UNauthenticated /models to
-  // /login, so an anon GET wouldn't touch the real /models render path. Use the
-  // gold (gate-passing) cookie. Sequential + non-fatal; the suite + retries cover
-  // any miss.
+  // doesn't pay the full cold-SSR cost (Next warm-up + JIT + DB pools). Each route
+  // JIT-compiles on its first hit, so we warm EVERY heavy SSR page the suite then
+  // navigates — cold-page timeouts were the dominant smoke flake (a slow-window
+  // page.goto exceeding the nav budget, then passing on retry once warm). They must
+  // be warmed AUTHENTICATED: on a preview the gate 307s an UNauthenticated request
+  // to /login, so an anon GET wouldn't touch the real render path. Sequential (one
+  // concurrent heavy SSR at a time — the single-replica pod OOM'd under parallel
+  // heavy loads) + non-fatal (.catch): a slow warm-up GET still triggers the
+  // server-side compile even if the client times out, and the suite + retries
+  // cover any miss.
   const gold = jwts.gold;
   if (gold) {
     const headers = { cookie: `${COOKIE_NAME}=${gold}` };
-    for (const path of ['/', '/models', '/images']) {
+    // gold (gate-passing paid member) reaches all non-mod heavy pages the suite hits.
+    for (const path of [
+      '/',
+      '/models',
+      '/images',
+      '/user/membership',
+      '/generate',
+      '/purchase/buzz',
+      '/pricing',
+    ]) {
+      await request.get(path, { timeout: 60_000, headers }).catch(() => {});
+    }
+  }
+  const mod = jwts.mod;
+  if (mod) {
+    // /moderator/* render only for a moderator (gold would be bounced), so warm the
+    // moderation-spec pages with the mod cookie.
+    const headers = { cookie: `${COOKIE_NAME}=${mod}` };
+    for (const path of ['/moderator/reports', '/moderator/images']) {
       await request.get(path, { timeout: 60_000, headers }).catch(() => {});
     }
   }

--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -84,6 +84,14 @@ async function mintStorageState(role: PreviewRole): Promise<string> {
 }
 
 setup('mint preview sessions', async ({ request }) => {
+  // This setup runs the cold-pod warm-up below: ~9 SEQUENTIAL heavy-SSR GETs (each
+  // capped at 60s) so one route compiles at a time (parallel heavy renders OOM the
+  // single-replica pod). On a genuinely cold pod the cumulative warm-up can exceed
+  // the suite's 90s per-test timeout — and a setup timeout SKIPS every dependent
+  // smoke test (worse than the flake we're fixing). So give just this setup a large
+  // ceiling. It's a CEILING, not the runtime: the setup still finishes as fast as
+  // the warm-ups actually take (~2s when the pod is already warm from verify-preview).
+  setup.setTimeout(480_000);
   if (!SECRET) throw new Error('NEXTAUTH_SECRET is required to mint preview sessions');
   if (!PREVIEW_URL) throw new Error('PREVIEW_URL is required for preview smoke tests');
   const jwts: Partial<Record<PreviewRole, string>> = {};


### PR DESCRIPTION
## What

Targets the **dominant smoke flake** — a cold/slow-window `page.goto` timeout on a heavy SSR page. The offending test rotates run-to-run (`/`, `/models`, `/user/membership`, `/generate`, `/purchase/buzz`, `/moderator/*`) depending on which heavy page the slow window happens to hit; root cause is the single-replica preview pod JIT-compiling a cold route and/or getting CPU-throttled on a contended node.

## Changes

1. **Pre-warm every heavy page the suite navigates** (`preview-auth.setup.ts`) — was only `/`, `/models`, `/images`. Each Next route JIT-compiles on its first hit, so warming them all up front removes the cold-start cost behind most flakes:
   - gold cookie → `/`, `/models`, `/images`, `/user/membership`, `/generate`, `/purchase/buzz`, `/pricing`
   - mod cookie → `/moderator/reports`, `/moderator/images` (these render only for a moderator)
   - Sequential (the single pod OOM'd under parallel heavy loads) + best-effort (`.catch`); a slow warm GET still triggers the server-side compile even if the client times out.

2. **`retries` 1 → 2** — a 2nd retry covers the residual *mid-run* slow window (vs cold-start), so a transient throttle flakes-and-recovers instead of surfacing as a failure.

## Why

Pairs with the 60s→90s timeout raise (#2480, merged). Pre-warm attacks the **cause** (cold routes); the extra retry is the backstop for mid-run contention. Together they target consistently-clean runs — the prerequisite for eventually flipping smoke-test to gating.

## Verification

- Isolated `tsc --noEmit` → EXIT 0.
- This PR's own preview run exercises the new warm-up (and the suite should run with no flaky/failed even if a window is slow). I'll confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)