### PR TITLE
fix(leaderboard): move URL-sync side effect into useEffect

### DIFF
--- a/src/pages/leaderboard/[id].tsx
+++ b/src/pages/leaderboard/[id].tsx
@@ -146,26 +146,31 @@ export default function Leaderboard() {
   const loadingLeaderboardResults =
     board === 'season' ? loadingLeaderboardSeason : loadingLeaderboardLegend;
 
-  if (
-    (selectedLeaderboard && selectedLeaderboard.id !== id) ||
-    (selectedPosition && selectedPosition !== urlPosition) ||
-    (!hasLegends && board === 'legend')
-  ) {
-    const shallow = selectedLeaderboard?.id === id && selectedPosition !== urlPosition;
+  // Sync the URL to the selected leaderboard/position. Must run as an effect:
+  // doing this during render calls router.replace() + setState mid-render,
+  // which re-triggers render before navigation settles -> "Too many re-renders".
+  useEffect(() => {
+    if (
+      (selectedLeaderboard && selectedLeaderboard.id !== id) ||
+      (selectedPosition && selectedPosition !== urlPosition) ||
+      (!hasLegends && board === 'legend')
+    ) {
+      const shallow = selectedLeaderboard?.id === id && selectedPosition !== urlPosition;
 
-    replace(
-      {
-        pathname: `/leaderboard/${selectedLeaderboard?.id}`,
-        hash: selectedPosition ? `${selectedPosition}` : undefined,
-        query: removeEmpty({
-          board: board === 'season' || (!hasLegends && board === 'legend') ? undefined : board,
-        }),
-      },
-      undefined,
-      { shallow }
-    );
-    setUrlPosition(selectedPosition);
-  }
+      replace(
+        {
+          pathname: `/leaderboard/${selectedLeaderboard?.id}`,
+          hash: selectedPosition ? `${selectedPosition}` : undefined,
+          query: removeEmpty({
+            board: board === 'season' || (!hasLegends && board === 'legend') ? undefined : board,
+          }),
+        },
+        undefined,
+        { shallow }
+      );
+      setUrlPosition(selectedPosition);
+    }
+  }, [selectedLeaderboard, id, selectedPosition, urlPosition, hasLegends, board, replace]);
 
   const endTime = useMemo(() => dayjs().utc().endOf('day').toDate(), []);
 


### PR DESCRIPTION
## Problem
Navigating between leaderboards threw `Too many re-renders. React limits the number of renders to prevent an infinite loop.` (Next 16 / React 19).

## Cause
The URL-sync block ran **during render**, calling `router.replace()` + `setUrlPosition()` directly in the component body. `replace()` re-rendered the component before navigation settled, the guard condition stayed true, and it fired again — infinite loop.

## Fix
Move the block into a `useEffect` (deps: `selectedLeaderboard, id, selectedPosition, urlPosition, hasLegends, board, replace`). Same logic, runs after commit instead of mid-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)