### PR TITLE
test(preview): cover the article authoring write path (article.upsert)

### DIFF
--- a/tests/preview-article.spec.ts
+++ b/tests/preview-article.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+import { trpcMutation, trpcQuery, uniqueToken } from './preview-trpc';
+
+/**
+ * Mutation smoke: the article authoring write path (article.upsert) — a distinct
+ * content type (the /articles section) not otherwise covered by the suite.
+ *
+ * Fully API-driven + per-run self-seeded (same pattern as preview-engagement /
+ * preview-collections): the tester creates its OWN article carrying a unique
+ * token, reads it back by id to prove it persisted, then best-effort deletes it.
+ * No dependency on shared content, no collision on the dev clone across concurrent
+ * previews (each run's article is unique; we never touch a shared entity — unlike
+ * e.g. a follow edge, which would be a shared row).
+ *
+ * Runs as `tester` (free member that PASSES the preview gate). article.upsert is a
+ * guardedProcedure (onboarding-complete + not muted — ci-smoke `tester` is seeded
+ * with onboarding=15) gated by isFlagProtected('articleCreate'); that flag is
+ * `['public']` (feature-flags.service.ts), available to every logged-in user, so
+ * the fixture passes. article.getById is publicProcedure; article.delete is a
+ * protectedProcedure (owner may delete).
+ *
+ * Verified tRPC shapes (civitai repo, paths relative to civitai/src):
+ *  - article.upsert    guarded; input upsertArticleInput (article.schema.ts:90):
+ *    `title` (z.string().min(1).max(100)) + non-empty sanitized `content` are the
+ *    only required fields, everything else optional. upsertArticleHandler →
+ *    upsertArticle returns the created article incl. numeric `.id`. (No publishedAt
+ *    => it stays a draft, which is fine — we verify by id, not by listing.)
+ *  - article.getById   public; input getByIdSchema ({ id: number }); returns the
+ *    article (getArticleById) incl. `.title` — we assert our token survived into it.
+ *  - article.delete    protected; input getByIdSchema ({ id }); owner-only cleanup.
+ */
+
+const ROLE = 'tester' as const;
+
+test.describe('tester authors an article (mutation flow)', () => {
+  test.use({ storageState: storageStatePath(ROLE) });
+
+  test('article.upsert creates a draft, verified by getById read-back', async ({ page }) => {
+    // Warm the request context against the preview origin so page.request shares the
+    // auth cookie + a real navigated origin (preview-trpc stamps Origin/Referer for
+    // the CSRF gate, but navigating once is the safe baseline). domcontentloaded
+    // only: NEVER networkidle — the app's background traffic never idles.
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const token = uniqueToken('article'); // ~31 chars, well under the 100-char title cap
+
+    // 1. Create a draft article carrying the unique token in its title + content.
+    const article = await trpcMutation<{ id: number } | null>(page.request, 'article.upsert', {
+      title: token,
+      content: `<p>${token}</p>`,
+    });
+    expect(typeof article?.id, 'article.upsert should return a numeric article id').toBe('number');
+
+    // 2. DETERMINISTIC read-back: fetch the article by id and assert our token
+    // survived into the stored title — proves the write persisted, not just 200-OK'd.
+    const fetched = await trpcQuery<{ title?: string } | null>(page.request, 'article.getById', {
+      id: article!.id,
+    });
+    expect(fetched?.title, 'getById should return the article with our seeded title').toBe(token);
+
+    // 3. Best-effort cleanup so repeated runs don't accrete draft articles on the
+    // shared dev clone. A delete failure must not fail the authoring assertions
+    // above, which are the point of this spec.
+    try {
+      await trpcMutation(page.request, 'article.delete', { id: article!.id });
+    } catch {
+      // The create + read-back already passed; leftover-draft cleanup is non-critical.
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `tests/preview-article.spec.ts` — covers **article authoring** (`article.upsert`), a distinct content type (the `/articles` section) the suite didn't touch.

## How (self-contained, per-run seeded — same pattern as `preview-engagement`/`collections`)

1. `article.upsert { title: token, content: '<p>token</p>' }` → tester's own draft article (numeric id).
2. **Deterministic read-back:** `article.getById { id }` → assert the seeded `token` survived into the stored `title` (proves the write persisted, not just 200-OK'd).
3. Best-effort `article.delete { id }` cleanup.

## Reachability / isolation

- Runs as the gate-passing `ci-smoke-tester`. `article.upsert` is guarded (tester `onboarding=15` clears it); `isFlagProtected('articleCreate')` and the flag is `['public']` (all logged-in users), so the fixture passes.
- **No shared-entity collision** — each run's article is unique (a follow edge or similar shared row was deliberately avoided). **Report-only.**

## Verification

- Isolated `tsc --noEmit` → EXIT 0; discovered by `playwright.preview.config.ts`.
- Validated live by this PR's own preview run (read-back is the real check — I'll confirm green, and iterate if the `getById` shape surprises, per prior specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)