### PR TITLE
fix(liveness): on-event-loop heartbeat for an exec liveness probe (phase 1)

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -16,6 +16,7 @@ import { trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { registerCpuProfiler } from '~/server/cpu-profiler';
 import { registerEventLoopLongTaskDetector } from '~/server/eventloop-longtask';
+import { registerLivenessHeartbeat } from '~/server/liveness-heartbeat';
 
 // Arm the on-demand, signal-triggered V8 CPU profiler. Zero steady-state
 // overhead; only does work when signalled. Independent of OTEL so it is
@@ -32,6 +33,14 @@ registerCpuProfiler();
 // enabled by base armed mode. Independent of OTEL.
 // See src/server/eventloop-longtask.ts.
 registerEventLoopLongTaskDetector();
+
+// Write an on-the-event-loop liveness heartbeat file (epoch-seconds, every 2s)
+// for an EXEC liveness probe to read. Lets the kubelet tell a busy-but-alive
+// pinned pod (loop still flushing timers) from a truly-wedged one — retiring the
+// ~15min probe-tolerance band-aid that the httpGet `/api/live` liveness needed
+// because it's served by the same saturated loop. See liveness-heartbeat.ts and
+// the liveness history in datapacket-talos deployment-api.yaml.
+registerLivenessHeartbeat();
 
 // Only enable OTEL if explicitly set AND endpoint is configured
 const OTEL_ENABLED = process.env.OTEL_ENABLED === 'true';

--- a/src/server/liveness-heartbeat.ts
+++ b/src/server/liveness-heartbeat.ts
@@ -38,6 +38,7 @@ const HEARTBEAT_FILE = process.env.LIVENESS_HEARTBEAT_FILE ?? '/tmp/heartbeat';
 const HEARTBEAT_INTERVAL_MS = 2000;
 
 let started = false;
+let loggedError = false;
 
 export function registerLivenessHeartbeat() {
   if (started) return;
@@ -46,8 +47,17 @@ export function registerLivenessHeartbeat() {
   const write = () => {
     try {
       fs.writeFileSync(HEARTBEAT_FILE, String(Math.floor(Date.now() / 1000)));
-    } catch {
-      // best-effort — never throw from the heartbeat
+      loggedError = false;
+    } catch (err) {
+      // best-effort — never throw from the heartbeat. But a PERSISTENT failure
+      // (read-only /tmp, disk full) makes the file go stale, which under the
+      // phase-2 exec liveness probe REAPS the pod — and this log is the only
+      // in-app signal for that. Log once at the start of each failure streak
+      // (reset on the next success) so it's greppable without spamming.
+      if (!loggedError) {
+        loggedError = true;
+        console.error(`[liveness-heartbeat] failed to write ${HEARTBEAT_FILE}:`, err);
+      }
     }
   };
 

--- a/src/server/liveness-heartbeat.ts
+++ b/src/server/liveness-heartbeat.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+
+/**
+ * Liveness heartbeat for an EXEC liveness probe.
+ *
+ * The api pods run one Node process = one JS thread. Under CPU saturation the
+ * event loop pins, and an httpGet liveness probe (served by that SAME loop)
+ * times out — so the kubelet SIGKILLs a pod that is busy-but-ALIVE, which
+ * cold-restarts it and AMPLIFIES the wave (cold-start module compilation re-pins
+ * the loop → fails again → cascade). See the liveness history in
+ * datapacket-talos `deployment-api.yaml`. The prior mitigation just widened the
+ * probe tolerance to ~15min — a band-aid on a signal (probe-response latency)
+ * that fundamentally can't tell "busy" from "dead".
+ *
+ * This writes the current epoch-SECONDS to a file every 2s, ON the event loop.
+ * A k8s EXEC liveness probe then checks the file's staleness, e.g.:
+ *   sh -c '[ $(( $(date +%s) - $(cat /tmp/heartbeat) )) -lt <threshold> ]'
+ * A pinned-but-PROGRESSING loop still flushes this 2s timer well within the
+ * threshold → stays alive (no false kill). A TRULY wedged loop (deadlock or a
+ * runaway synchronous block) stops updating the file → it goes stale → the pod
+ * is reaped. That is the correct "tolerate busy, detect dead" semantics, with a
+ * real loop-liveness signal instead of probe-latency tolerance tuning.
+ *
+ * Epoch-SECONDS (not ms) because the runner image is node:20-alpine → busybox
+ * `date` has no `%N`; the probe reads seconds with `date +%s`.
+ *
+ * Implementation notes:
+ * - SYNC write: the whole write completes inside the timer callback, so the file
+ *   mtime/contents prove the loop actually executed this tick. An async write
+ *   would dispatch to the libuv threadpool (UV_THREADPOOL_SIZE=16) where it could
+ *   lag behind other I/O even while the loop is alive — masking loop liveness.
+ *   The payload is ~10 bytes to /tmp; cost is sub-millisecond every 2s.
+ * - Best-effort: a transient write error is swallowed (one missed tick is far
+ *   inside any sane probe threshold) so the heartbeat can never crash the process.
+ * - The timer is `unref()`d so it never keeps the process alive on its own.
+ */
+const HEARTBEAT_FILE = process.env.LIVENESS_HEARTBEAT_FILE ?? '/tmp/heartbeat';
+const HEARTBEAT_INTERVAL_MS = 2000;
+
+let started = false;
+
+export function registerLivenessHeartbeat() {
+  if (started) return;
+  started = true;
+
+  const write = () => {
+    try {
+      fs.writeFileSync(HEARTBEAT_FILE, String(Math.floor(Date.now() / 1000)));
+    } catch {
+      // best-effort — never throw from the heartbeat
+    }
+  };
+
+  // Write immediately so the file exists before the startup probe passes and
+  // liveness (which gates behind startup) begins checking it.
+  write();
+  const timer = setInterval(write, HEARTBEAT_INTERVAL_MS);
+  timer.unref();
+}


### PR DESCRIPTION
## What

**Phase 1 of the durable amplifier fix** for the api-primary 504-wave cascade.

The api pods run one Node process = one JS thread. Under CPU saturation the event loop pins, and the `httpGet /api/live` liveness probe — served by that **same** saturated loop — times out, so the kubelet SIGKILLs a pod that is busy-but-**alive**. Its cold restart re-pins the loop (cold-start module compilation) and **amplifies** the 504 wave. The current mitigation (`failureThreshold: 60`, ~15 min) is a band-aid on a signal — probe-response latency — that fundamentally can't tell *busy* from *dead*. The `deployment-api.yaml` liveness comment already flags the off-loop health server as the proper TODO.

This commit adds the heartbeat half of the real fix. It is **inert on its own** — nothing reads the file until the infra probe is flipped (phase 2) — so liveness behaviour is unchanged by this PR.

## How

`registerLivenessHeartbeat()` (wired into `instrumentation.node.ts` next to the existing cpu-profiler / longtask detector) writes epoch-**seconds** to `/tmp/heartbeat` every 2s, **on the event loop**. A follow-up infra change switches the liveness probe to an `exec` probe that checks the file's staleness:

```
sh -c 'V=$(cat /tmp/heartbeat 2>/dev/null); [ $(( $(date +%s) - ${V:-0} )) -lt 45 ]'
```

A pinned-but-**progressing** loop still flushes this 2s timer → heartbeat stays fresh → no false kill. A **truly wedged** loop stops updating the file → goes stale → reaped. That's the correct *"tolerate busy, detect dead"* semantics with no tolerance tuning — and it eliminates the false-kills that are the actual wave amplifier.

Implementation notes:
- **epoch-seconds** (not ms): the runner image is `node:20-alpine` → busybox `date` has no `%N`; the probe reads seconds with `date +%s`.
- **sync write**: the write completes inside the timer callback, so the file proves the loop executed this tick. An async write could lag in the libuv threadpool while the loop is alive, masking liveness. Payload is ~10 bytes; cost is sub-ms every 2s.
- **best-effort** (swallows write errors) + **unref'd** timer (never keeps the process alive on its own). Path overridable via `LIVENESS_HEARTBEAT_FILE`.

## Rollout (two phases — order matters)

1. **This PR** — ship the heartbeat writer. Verify it's live on pods:
   ```
   kubectl exec <pod> -n civitai-dp-prod -- sh -c 'V=$(cat /tmp/heartbeat); echo "age=$(( $(date +%s) - $V ))s"'   # 0–2s
   ```
2. **Infra (datapacket-talos, separate change)** — flip the `deployment-api.yaml` + `deployment-api-heavy.yaml` liveness from `httpGet` to the `exec` probe above (`periodSeconds: 15`, `failureThreshold: 8`, `timeoutSeconds: 5`). **Only after phase 1 is deployed and verified** — flipping first would mass-fail liveness (no heartbeat file yet). Conservative `45s / ft=8` for the first cutover (reaps a genuine wedge in ~2–3 min, zero false kills on busy pods); tighten after a live wave confirms the heartbeat stays fresh on a recovering pod.

## Verification
- prettier / eslint / typecheck clean.
- The probe shell expression tested against fresh / stale / missing / empty heartbeat (all correct; empty produces a clean reap, no arithmetic error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)