### PR TITLE
ci(pr-check): gate the full vitest unit suite (857 tests)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -52,9 +52,54 @@ jobs:
       - name: Run typecheck
         run: pnpm run typecheck
 
-      # Gates the custom `no-io-in-transaction` ESLint rule (eslint-local-rules.js)
-      # via its RuleTester suite. Scoped to the rule's own test rather than the
-      # full `test:unit:run` suite, which currently has pre-existing failures and
-      # isn't yet CI-green.
+      # Fast targeted signal for the custom `no-io-in-transaction` ESLint rule
+      # (eslint-local-rules.js) via its RuleTester suite. Subsumed by the
+      # `unit-tests` job below (which runs the full vitest suite) but kept as a
+      # cheap early-fail within the typecheck job.
       - name: Test lint rules
         run: pnpm run test:lint-rules
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup SSH for submodules
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SUBMODULE_SSH_KEY }}
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable corepack and install pnpm
+        run: corepack enable && corepack prepare pnpm@10.28.1 --activate
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Full vitest suite (857 tests). Made CI-green by #2478; previously this ran
+      # report-only in the DP Tekton preview pipeline (unit-tests-task.yaml). The
+      # suite is unit-level — no DB/Redis services needed; Prisma client comes from
+      # the install postinstall, same as the typecheck job.
+      - name: Run unit tests
+        run: pnpm run test:unit:run


### PR DESCRIPTION
## What

Adds a `unit-tests` job to `.github/workflows/pr-check.yml` that runs the full `pnpm run test:unit:run` vitest suite (857 tests) on every PR.

## Why

The full suite was made CI-green by #2478, but `pr-check.yml` still ran only `typecheck` + the `no-io-in-transaction` lint-rule subset (the stale comment claimed the suite "isn't yet CI-green"). The full suite ran **report-only** in the DP Tekton preview pipeline (`unit-tests-task.yaml`). This makes the green suite actually block GitHub checks — deterministic, no preview flake.

## Notes

- Unit-level: no DB/Redis services needed; Prisma client comes from the install postinstall (same as the existing typecheck job).
- This PR's own `Unit Tests` check is the GH-Actions-env verification — if it's green here, the suite is genuinely CI-green in Actions (not just DP Tekton).
- **Making it a *required* check is a separate branch-protection toggle** on `main` — not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)