### PR TITLE
feat(readiness): warmup-gated /api/ready to kill cold-start rollout cascade

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -48,9 +48,10 @@ registerLivenessHeartbeat();
 // /api/v1/images / tRPC / SSR request pays lazy-require + JIT on the single
 // loop thread → pin → 504/502/499 on every rollout. The warmer self-requests
 // the hot routes over localhost during startup and flips /api/ready's warm gate
-// only once warm (fail-open). It is gated by WARMUP_ENABLED (default true) and
-// uses the listener (so it self-imports lazily to avoid pulling fetch/route
-// code into the boot path needlessly).
+// only once warm (fail-open). It is OPT-IN via WARMUP_ENABLED (default FALSE —
+// runs ONLY when WARMUP_ENABLED='true', set on the dp-prod SSR/API/heavy pools;
+// elsewhere it no-ops + flips warm immediately). It self-imports lazily so the
+// fetch/route code isn't pulled into the boot path needlessly.
 //
 // CRITICAL: do NOT await this. register() must return so Next can start the
 // HTTP listener — the warmer needs that listener up to self-request, so

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -42,6 +42,26 @@ registerEventLoopLongTaskDetector();
 // the liveness history in datapacket-talos deployment-api.yaml.
 registerLivenessHeartbeat();
 
+// Kick the in-process route warmer (fire-and-forget). Next standalone
+// lazy-require()s each route on first hit; the dependency-only readiness probe
+// marks a pod Ready while every hot route is still cold, so the first real
+// /api/v1/images / tRPC / SSR request pays lazy-require + JIT on the single
+// loop thread → pin → 504/502/499 on every rollout. The warmer self-requests
+// the hot routes over localhost during startup and flips /api/ready's warm gate
+// only once warm (fail-open). It is gated by WARMUP_ENABLED (default true) and
+// uses the listener (so it self-imports lazily to avoid pulling fetch/route
+// code into the boot path needlessly).
+//
+// CRITICAL: do NOT await this. register() must return so Next can start the
+// HTTP listener — the warmer needs that listener up to self-request, so
+// awaiting here would deadlock boot. Any import/throw is swallowed: warmup must
+// never block or crash boot.
+void import('~/server/warmup')
+  .then((m) => m.runWarmup())
+  .catch((err) => {
+    console.error('[instrumentation.node] warmup kick failed (fail-open):', err);
+  });
+
 // Only enable OTEL if explicitly set AND endpoint is configured
 const OTEL_ENABLED = process.env.OTEL_ENABLED === 'true';
 const OTEL_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -235,25 +235,27 @@ function getOverallDeadlineMs() {
   return Math.min(env.HEALTHCHECK_TIMEOUT * 2, 8000);
 }
 
-export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
-  const podname = process.env.PODNAME ?? getRandomInt(100, 999);
-
-  // Create AbortController for all health checks
-  // This will be aborted when the client disconnects
-  const abortController = new AbortController();
-  const { signal } = abortController;
-
-  // Abort all checks when client disconnects
-  const onClose = () => {
-    if (!isProd) console.log('Health check request cancelled (client disconnected)');
-    abortController.abort();
-  };
-  res.on('close', onClose);
-
-  // Start the overall deadline at the TOP of the handler — before the
-  // config-fetch leg — so the timer bounds the WHOLE handler (config fetch +
-  // checks), not just the check phase. A slow/hung sysRedis config read can no
-  // longer consume the budget before checks even start.
+/**
+ * Run the full dependency-health check set and compute overall health.
+ *
+ * Extracted from the /api/health handler so /api/ready can reuse the EXACT
+ * same checks, env/sysRedis disable lists, per-check timeouts, overall
+ * deadline, and prom metrics — there is one source of truth for "are this
+ * pod's dependencies healthy". The only thing that stays in the handler is the
+ * HTTP wiring (res.on('close') → abort, status/json shaping); everything
+ * dependency-related lives here and is driven by the passed-in AbortSignal.
+ *
+ * The caller owns the signal so it can wire client-disconnect abort (the
+ * handler) or its own controller (ready route). Returns the per-check results
+ * map plus the computed `healthy` flag and whether the overall deadline fired.
+ */
+export async function runHealthChecks(
+  signal: AbortSignal
+): Promise<{ healthy: boolean; results: Record<CheckKey, boolean>; deadlineTimedOut: boolean }> {
+  // Start the overall deadline at the TOP — before the config-fetch leg — so
+  // the timer bounds the WHOLE run (config fetch + checks), not just the check
+  // phase. A slow/hung sysRedis config read can no longer consume the budget
+  // before checks even start.
   let deadlineTimedOut = false;
   let deadlineId: ReturnType<typeof setTimeout> | undefined;
   const overallDeadlineMs = getOverallDeadlineMs();
@@ -270,35 +272,10 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     // serial ones — and race the whole leg against the overall deadline so a
     // hung config read can't burn the budget before checks run. If the deadline
     // fires during the config fetch we degrade SAFELY: treat disabled and
-    // non-critical as empty, i.e. run ALL checks and suppress NOTHING. That is
-    // the conservative direction — a genuinely-stuck critical dependency still
-    // drives a 500 rather than being falsely suppressed; the only cost of a
-    // config-read stall is that we don't honor an operator's runtime
-    // disable/non-critical override for this one request.
+    // non-critical as empty, i.e. run ALL checks and suppress NOTHING.
     let disabledChecks: CheckKey[] = [...envDisabledChecks];
     let nonCriticalChecks: CheckKey[] = [];
     if (isProd) {
-      // Give the config-fetch leg its OWN bounded sub-budget so it can never
-      // structurally eat the whole overall deadline and leave the checks ~0ms
-      // (which would keep every check seeded `false` → a false 500 on a fully
-      // healthy pod). Each getHealthcheckConfig read is internally bounded by
-      // HEALTHCHECK_TIMEOUT, but the 8s hard-cap on overallDeadlineMs decouples
-      // that per-read ceiling from the total budget — if HEALTHCHECK_TIMEOUT is
-      // raised toward/over 8s, one config read alone could otherwise consume the
-      // entire deadline. Reserve a third of the deadline for the config leg so
-      // the majority of the budget is always available for the actual checks.
-      // But never make this sub-budget TIGHTER than pre-PR `main`, whose config
-      // read was bound by the full HEALTHCHECK_TIMEOUT: take whichever is
-      // LARGER. At the schema default (1500) `max(1500, 1000) = 1500` = parity
-      // with main (no regression); at prod's 5000 `max(5000, 2666) = 5000`.
-      // This `maxTimeout` is only getHealthcheckConfig's OWN internal
-      // self-timeout — the REAL ceiling on the config leg is the shared
-      // `deadlinePromise` it races at `Promise.race([configPromise,
-      // deadlinePromise])` below, so even when configReadTimeout >=
-      // overallDeadlineMs the config leg's wall-clock is still capped at
-      // overallDeadlineMs (8s prod) and can never push the total handler past
-      // the overall deadline. If the deadline fires first we still degrade
-      // safely (empty arrays → run all / suppress nothing).
       const configReadTimeout = Math.max(
         env.HEALTHCHECK_TIMEOUT,
         Math.floor(overallDeadlineMs / 3)
@@ -307,25 +284,11 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
         getHealthcheckConfig(REDIS_SYS_KEYS.SYSTEM.DISABLED_HEALTHCHECKS, configReadTimeout),
         getHealthcheckConfig(REDIS_SYS_KEYS.SYSTEM.NON_CRITICAL_HEALTHCHECKS, configReadTimeout),
       ]).then(([disabled, nonCritical]) => {
-        // Layer the runtime list on top of the static env list (union).
         disabledChecks = [...envDisabledChecks, ...disabled];
         nonCriticalChecks = nonCritical;
       });
       await Promise.race([configPromise, deadlinePromise]);
     }
-
-    // Check if already cancelled before starting the expensive health checks
-    if (signal.aborted) {
-      res.off('close', onClose);
-      return;
-    }
-
-    // NOTE: if `deadlineTimedOut` is already true here the config fetch itself
-    // blew the budget. We still fall through to the check phase with empty
-    // config (run all / suppress nothing); the Promise.race below resolves
-    // immediately since the deadline already fired, and every check stays
-    // seeded `false` (counted as timed-out) so a stuck critical dependency
-    // still yields 500.
 
     const activeChecks = Object.entries(checkFns).filter(
       ([name]) => !disabledChecks.includes(name as CheckKey)
@@ -333,12 +296,8 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
 
     // Shared results map. Each check writes its own result as it resolves so
     // that if the overall deadline fires before Promise.all settles, we can
-    // still report (and respond on) whatever has resolved, treating the rest as
-    // timed-out rather than hanging the response.
+    // still report whatever has resolved, treating the rest as timed-out.
     const results = {} as Record<CheckKey, boolean>;
-    // Tracks which checks have recorded their own metrics, so the deadline path
-    // can account for the not-yet-resolved ones exactly once (a slow check's
-    // own .then()/.catch() may still run after we've responded).
     const settled = new Set<CheckKey>();
     for (const [name] of activeChecks) results[name as CheckKey] = false;
 
@@ -348,9 +307,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
           .then(({ result, outcome, durationSeconds }) => {
             if (settled.has(name as CheckKey)) return;
             settled.add(name as CheckKey);
-            // Existing per-check counter — preserved for Grafana dashboard back-compat.
             if (!result) counters[name as CheckKey]?.inc();
-            // New per-attempt outcome + duration metrics.
             healthcheckAttemptsCounter.inc({ name, result: outcome });
             healthcheckDurationHistogram.observe({ name }, durationSeconds);
             results[name as CheckKey] = result;
@@ -358,45 +315,21 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
           .catch(() => {
             if (settled.has(name as CheckKey)) return;
             settled.add(name as CheckKey);
-            // Defensive: runCheckWithTimeout already swallows inner errors,
-            // but if anything escapes treat as a failure for the attempts counter.
             healthcheckAttemptsCounter.inc({ name, result: 'failure' });
             results[name as CheckKey] = false;
           })
       )
     );
 
-    // Race the check phase against the SAME overall deadline started at the top
-    // of the handler. If a check's underlying client ignores its AbortSignal
-    // (e.g. undici TCP connect hang) AND somehow outlives runCheckWithTimeout's
-    // own race, this guarantees the handler still proceeds. Any check that
-    // hasn't written a result by now stays `false` (its slot was seeded above)
-    // — i.e. it is counted as timed-out, so a genuinely-stuck critical
-    // dependency still drives a 500.
+    // Race the check phase against the SAME overall deadline.
     await Promise.race([checksPromise, deadlinePromise]);
 
-    // Clean up the close listener
-    res.off('close', onClose);
-
-    // If cancelled, don't send response (connection is already closed)
-    if (signal.aborted) {
-      return;
-    }
-
     if (deadlineTimedOut) {
-      // Record the outcome for any checks that never resolved so the failure
-      // mode is visible in metrics rather than silently absorbed. `settled`
-      // ensures the check's own late callback can't also count it.
       for (const [name] of activeChecks) {
         if (settled.has(name as CheckKey)) continue;
         settled.add(name as CheckKey);
         healthcheckAttemptsCounter.inc({ name, result: 'timeout' });
         counters[name as CheckKey]?.inc();
-        // Also feed the duration histogram so these slow-brownout samples — the
-        // exact ones the dense 1-3.5s buckets exist to capture — aren't dropped,
-        // which would understate P95/P99 during an incident. The check outlived
-        // the overall deadline, so observe overallDeadlineMs as an at-least-
-        // this-slow lower bound. De-duped by the same `settled` guard.
         healthcheckDurationHistogram.observe({ name }, overallDeadlineMs / 1000);
       }
       logError({
@@ -411,17 +344,51 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     );
     if (!healthy) counters.overall?.inc();
 
-    return res.status(healthy ? 200 : 500).json({
-      podname,
-      version: process.env.version,
-      healthy,
-      ...results,
-    });
+    return { healthy, results, deadlineTimedOut };
   } finally {
     // Clear the deadline timer regardless of how we exit so it can't keep the
     // process from settling between requests.
     if (deadlineId !== undefined) clearTimeout(deadlineId);
   }
+}
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  const podname = process.env.PODNAME ?? getRandomInt(100, 999);
+
+  // Create AbortController for all health checks
+  // This will be aborted when the client disconnects
+  const abortController = new AbortController();
+  const { signal } = abortController;
+
+  // Abort all checks when client disconnects
+  const onClose = () => {
+    if (!isProd) console.log('Health check request cancelled (client disconnected)');
+    abortController.abort();
+  };
+  res.on('close', onClose);
+
+  // Check if already cancelled before starting the expensive checks.
+  if (signal.aborted) {
+    res.off('close', onClose);
+    return;
+  }
+
+  const { healthy, results } = await runHealthChecks(signal);
+
+  // Clean up the close listener
+  res.off('close', onClose);
+
+  // If cancelled, don't send response (connection is already closed)
+  if (signal.aborted) {
+    return;
+  }
+
+  return res.status(healthy ? 200 : 500).json({
+    podname,
+    version: process.env.version,
+    healthy,
+    ...results,
+  });
 });
 
 /**

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -162,7 +162,11 @@ const checkFns: Record<string, CancellableCheckFn> = {
     }
   },
 };
-type CheckKey =
+// Exported because it appears in the public signature of `runHealthChecks`
+// below (its `results` return type), which /api/ready imports. A module-private
+// name in an exported signature compiles under `next build` but errors under
+// `--declaration` and is fragile.
+export type CheckKey =
   | 'write'
   | 'read'
   | 'pgWrite'
@@ -290,6 +294,17 @@ export async function runHealthChecks(
       await Promise.race([configPromise, deadlinePromise]);
     }
 
+    // Mid-run abort short-circuit (client disconnected during the config-fetch
+    // leg). origin/main's handler had this guard inline; the extraction dropped
+    // it, so on the probe path — which fires every few seconds — a disconnect no
+    // longer stopped the (expensive) DB/Redis/Meili/CH check phase from running
+    // to completion. Bail before the checks run. The caller already treats
+    // `signal.aborted` after the call as "don't send a response", so the exact
+    // values here are inert — return the contract shape with empty results.
+    if (signal.aborted) {
+      return { healthy: false, results: {} as Record<CheckKey, boolean>, deadlineTimedOut };
+    }
+
     const activeChecks = Object.entries(checkFns).filter(
       ([name]) => !disabledChecks.includes(name as CheckKey)
     );
@@ -323,6 +338,14 @@ export async function runHealthChecks(
 
     // Race the check phase against the SAME overall deadline.
     await Promise.race([checksPromise, deadlinePromise]);
+
+    // Mid-run abort short-circuit (client disconnected during the check race) —
+    // the second of origin/main's two inline guards. Skip the deadline-fill +
+    // healthy computation + metric bookkeeping; the caller won't send a response
+    // anyway. Return whatever has resolved so far in the contract shape.
+    if (signal.aborted) {
+      return { healthy: false, results, deadlineTimedOut };
+    }
 
     if (deadlineTimedOut) {
       for (const [name] of activeChecks) {

--- a/src/pages/api/ready.ts
+++ b/src/pages/api/ready.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { isProd } from '~/env/other';
-import { isWarm } from '~/server/warmup';
+import { isWarm, getWarmState, getWarmDurationMs, didFailOpenTimeout } from '~/server/warmup';
 import { runHealthChecks } from '~/pages/api/health';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { getRandomInt } from '~/utils/number-helpers';
@@ -30,6 +30,14 @@ import { getRandomInt } from '~/utils/number-helpers';
 export default WebhookEndpoint(async (_req: NextApiRequest, res: NextApiResponse) => {
   const podname = process.env.PODNAME ?? getRandomInt(100, 999);
   const warm = isWarm();
+  // Surface warm observability in the body so an operator can tell a pod that
+  // truly warmed (warmState='warmed-ok') from one that only fail-open-timed-out
+  // (warmState='failopen-timeout', failOpenTimedOut=true) or one where the
+  // warmer is disabled on this pool (warmState='disabled'). Mirrors the
+  // civitai_warmup_state gauge.
+  const warmState = getWarmState();
+  const warmDurationMs = getWarmDurationMs();
+  const failOpenTimedOut = didFailOpenTimeout();
 
   // Skip the (relatively expensive) dependency checks until the pod is warm —
   // a not-yet-warm pod is never Ready regardless of dependency state, and we
@@ -41,6 +49,9 @@ export default WebhookEndpoint(async (_req: NextApiRequest, res: NextApiResponse
       version: process.env.version,
       ready: false,
       warm,
+      warmState,
+      warmDurationMs,
+      failOpenTimedOut,
     });
   }
 
@@ -71,6 +82,9 @@ export default WebhookEndpoint(async (_req: NextApiRequest, res: NextApiResponse
     version: process.env.version,
     ready,
     warm,
+    warmState,
+    warmDurationMs,
+    failOpenTimedOut,
     deps: results,
   });
 });

--- a/src/pages/api/ready.ts
+++ b/src/pages/api/ready.ts
@@ -1,0 +1,76 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { isProd } from '~/env/other';
+import { isWarm } from '~/server/warmup';
+import { runHealthChecks } from '~/pages/api/health';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { getRandomInt } from '~/utils/number-helpers';
+
+// Warmup-gated readiness probe.
+//
+// WHY: Next.js standalone lazy-`require()`s each route handler on its FIRST
+// request. The dependency-only /api/health probe marks a pod Ready as soon as
+// its DB/Redis/etc. are reachable — but at that instant every hot route is
+// still COLD. The kubelet then sends real /api/v1/images, tRPC image.getInfinite,
+// etc. to that pod; the first hit pays lazy-require + JIT compilation on the
+// single event-loop thread → the loop pins → 504/502/499 (the cold-start
+// cascade on every rollout). See the api-primary cascade history.
+//
+// This probe returns 200 only once BOTH are true:
+//   1. isWarm()  — the in-process warmer (src/server/warmup.ts) has finished
+//      self-requesting the hot routes (or fail-open-timed-out), so the JIT is
+//      settled and no real user request pays the cold tax.
+//   2. The same dependency checks /api/health runs are passing (reused via the
+//      exported runHealthChecks() — one source of truth, identical disable
+//      lists / per-check timeouts / overall deadline / prom metrics).
+//
+// Probes (startup + readiness) point HERE; liveness stays on /api/live. The
+// manifest probe-path change is a SEPARATE follow-up — this route must exist in
+// the running image BEFORE any probe is repointed at it, or every pod fails
+// startup. Same WebhookEndpoint `?token` gate as /api/health.
+export default WebhookEndpoint(async (_req: NextApiRequest, res: NextApiResponse) => {
+  const podname = process.env.PODNAME ?? getRandomInt(100, 999);
+  const warm = isWarm();
+
+  // Skip the (relatively expensive) dependency checks until the pod is warm —
+  // a not-yet-warm pod is never Ready regardless of dependency state, and we
+  // don't want startup-probe traffic adding DB/Redis load before the pod is
+  // even serving. Reuse the client-disconnect abort wiring from health.ts.
+  if (!warm) {
+    return res.status(503).json({
+      podname,
+      version: process.env.version,
+      ready: false,
+      warm,
+    });
+  }
+
+  const abortController = new AbortController();
+  const { signal } = abortController;
+  const onClose = () => {
+    if (!isProd) console.log('Ready check request cancelled (client disconnected)');
+    abortController.abort();
+  };
+  res.on('close', onClose);
+
+  if (signal.aborted) {
+    res.off('close', onClose);
+    return;
+  }
+
+  const { healthy, results } = await runHealthChecks(signal);
+
+  res.off('close', onClose);
+
+  if (signal.aborted) {
+    return;
+  }
+
+  const ready = warm && healthy;
+  return res.status(ready ? 200 : 503).json({
+    podname,
+    version: process.env.version,
+    ready,
+    warm,
+    deps: results,
+  });
+});

--- a/src/server/__tests__/warmup.test.ts
+++ b/src/server/__tests__/warmup.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import client from 'prom-client';
+
+// ---------------------------------------------------------------------------
+// WHY THIS TEST EXISTS
+//
+// PR #2490 (warmup-gated /api/ready) shipped with ZERO tests for warmup.ts. This
+// suite pins the statically-testable parts of the warm-state machine:
+//   - the disabled (opt-out) no-op path
+//   - the success path (all routes warmed → state 'warmed-ok')
+//   - the fail-open hard-timeout path (a hung warm → state 'failopen-timeout')
+//   - the per-request AbortSignal.timeout robustness fix (MEDIUM-1): a single
+//     hung route is abandoned, the OTHER routes still run, warmup completes
+//   - the globalThis pin contract (state lives on globalThis.__civitaiWarmState),
+//     so a regression that reverts to a module-local `let` is caught
+//
+// LIMITATION (cannot be covered by a unit test): the real bug the globalThis pin
+// guards against is the TWO-WEBPACK-GRAPH runtime crossing — runWarmup() flips the
+// flag in the instrumentation bundle's module copy while /api/ready reads the
+// request bundle's copy. Vitest loads ONE module graph, so we cannot reproduce the
+// cross-graph divergence here; we can only assert the contract that the state is
+// stored on the real V8 global (the mechanism that makes the cross-graph flip
+// visible). The cross-graph behaviour needs a live pod to verify.
+// ---------------------------------------------------------------------------
+
+// A real throwaway registry standing in for the cross-graph shared
+// `instrumentationRegistry`. The global src/__tests__/setup.ts mock of
+// ~/server/prom/client stubs registerInstrumentationMetric but does NOT export
+// instrumentationRegistry (which warmup.ts imports), so we override the mock here
+// with a shape that provides BOTH — mirroring the eventloop-longtask test pattern.
+// vi.hoisted so it's constructed before the hoisted vi.mock factory references it.
+const { warmTestRegistry } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const promClient = require('prom-client');
+  return { warmTestRegistry: new promClient.Registry() as client.Registry };
+});
+
+vi.mock('~/server/prom/client', () => {
+  function registerInstrumentationMetric<M extends client.Metric<string>>(
+    name: string,
+    factory: () => M
+  ): M {
+    const existing = warmTestRegistry.getSingleMetric(name);
+    if (existing) return existing as unknown as M;
+    return factory();
+  }
+  return {
+    instrumentationRegistry: warmTestRegistry,
+    registerInstrumentationMetric,
+    // Incidental helpers other instrumentation modules import; inert here.
+    registerCounter: () => ({ inc: vi.fn() }),
+    registerHistogram: () => ({ observe: vi.fn() }),
+  };
+});
+
+// env.NEXTAUTH_URL / env.WEBHOOK_TOKEN are read by warmup.ts. The global setup
+// proxy already supplies NEXTAUTH_URL='http://localhost:3000'; WEBHOOK_TOKEN
+// falls through to undefined which is fine for these tests.
+
+// Helper: a deferred promise that never resolves on its own — used to simulate a
+// hung fetch. We expose resolve so a test can release it if needed.
+function neverResolves<T = never>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+// A minimal Response-like stub the warmer treats as a 200 with a drainable body.
+function okResponse(status = 200) {
+  return { status, ok: status >= 200 && status < 300, text: () => Promise.resolve('') };
+}
+
+// Reset module + global state between tests. warmup.ts pins state on
+// globalThis.__civitaiWarmState and carries a module-local `started` guard, so we
+// must clear the global AND re-import the module fresh for each test.
+const ENV_KEYS = [
+  'WARMUP_ENABLED',
+  'WARMUP_ROUTES',
+  'WARMUP_TIMEOUT_MS',
+  'WARM_ITERATIONS',
+  'WARM_INITIAL_JITTER_MAX_MS',
+  'WARM_INTER_ROUTE_JITTER_MAX_MS',
+  'WARM_PER_REQUEST_TIMEOUT_MS',
+  'PORT',
+];
+
+function clearWarmEnv() {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+async function loadWarmup() {
+  vi.resetModules();
+  return import('~/server/warmup');
+}
+
+describe('warmup: state machine', () => {
+  beforeEach(() => {
+    // Fresh global warm state every test (warmup pins it on globalThis).
+    delete (globalThis as Record<string, unknown>).__civitaiWarmState;
+    clearWarmEnv();
+    // Disable jitter sleeps by default so timing-sensitive tests are deterministic.
+    process.env.WARM_INITIAL_JITTER_MAX_MS = '0';
+    process.env.WARM_INTER_ROUTE_JITTER_MAX_MS = '0';
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete (globalThis as Record<string, unknown>).__civitaiWarmState;
+    clearWarmEnv();
+  });
+
+  it('disabled path: WARMUP_ENABLED unset → no-op, isWarm()=true, state=disabled, no fetch', async () => {
+    // WARMUP_ENABLED is unset (cleared in beforeEach).
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmup = await loadWarmup();
+    await warmup.runWarmup();
+
+    expect(warmup.isWarm()).toBe(true);
+    expect(warmup.getWarmState()).toBe('disabled');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('disabled path: WARMUP_ENABLED=false behaves the same as unset', async () => {
+    process.env.WARMUP_ENABLED = 'false';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmup = await loadWarmup();
+    await warmup.runWarmup();
+
+    expect(warmup.isWarm()).toBe(true);
+    expect(warmup.getWarmState()).toBe('disabled');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('success path: enabled + 200 fetches → warmed-ok, isWarm()=true, durationMs set, fetch per route×iterations', async () => {
+    process.env.WARMUP_ENABLED = 'true';
+    // 2 explicit routes + 1 iteration each. Plus the waitForListener /api/live poll.
+    process.env.WARMUP_ROUTES = '/api/v1/images?limit=20,/';
+    process.env.WARM_ITERATIONS = '1';
+
+    const fetchMock = vi.fn(() => Promise.resolve(okResponse(200)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmup = await loadWarmup();
+    await warmup.runWarmup();
+
+    expect(warmup.isWarm()).toBe(true);
+    expect(warmup.getWarmState()).toBe('warmed-ok');
+    expect(warmup.getWarmDurationMs()).toBeTypeOf('number');
+    expect(warmup.getWarmDurationMs()).toBeGreaterThanOrEqual(0);
+
+    // Count fetches by URL kind: 1 /api/live listener poll + 1 per route.
+    const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+    const livePolls = calls.filter((u) => u.includes('/api/live')).length;
+    const routeWarms = calls.filter((u) => !u.includes('/api/live')).length;
+    expect(livePolls).toBeGreaterThanOrEqual(1); // listener became ready on first poll
+    expect(routeWarms).toBe(2); // 2 routes × 1 iteration
+  });
+
+  it('success path: WARM_ITERATIONS=2 warms each route twice', async () => {
+    process.env.WARMUP_ENABLED = 'true';
+    process.env.WARMUP_ROUTES = '/a,/b';
+    process.env.WARM_ITERATIONS = '2';
+
+    const fetchMock = vi.fn(() => Promise.resolve(okResponse(200)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmup = await loadWarmup();
+    await warmup.runWarmup();
+
+    expect(warmup.getWarmState()).toBe('warmed-ok');
+    const routeWarms = fetchMock.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => !u.includes('/api/live')).length;
+    expect(routeWarms).toBe(4); // 2 routes × 2 iterations
+  });
+
+  it('fail-open timeout path: a hung warm fetch + timer past WARMUP_TIMEOUT_MS → isWarm()=true, state=failopen-timeout', async () => {
+    vi.useFakeTimers();
+    process.env.WARMUP_ENABLED = 'true';
+    process.env.WARMUP_ROUTES = '/hang';
+    process.env.WARMUP_TIMEOUT_MS = '5000';
+    // Disable the per-request abort so the hang is what the hard timer races
+    // (otherwise the per-request timeout would abort the route first).
+    process.env.WARM_PER_REQUEST_TIMEOUT_MS = '0';
+
+    const hung = neverResolves<ReturnType<typeof okResponse>>();
+    // /api/live answers 200 immediately so we reach the route-warm loop; the
+    // route fetch then hangs forever.
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).includes('/api/live')) return Promise.resolve(okResponse(200));
+      return hung.promise;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmup = await loadWarmup();
+    const runPromise = warmup.runWarmup();
+
+    // Let the listener poll + reach the hung route fetch.
+    await vi.advanceTimersByTimeAsync(0);
+    // Not warm yet — the route is still hanging, hard timer hasn't fired.
+    expect(warmup.isWarm()).toBe(false);
+
+    // Advance past the hard fail-open timeout.
+    await vi.advanceTimersByTimeAsync(5001);
+
+    expect(warmup.isWarm()).toBe(true);
+    expect(warmup.getWarmState()).toBe('failopen-timeout');
+    expect(warmup.getWarmDurationMs()).toBeTypeOf('number');
+
+    // Release the hung fetch so the dangling promise settles; runWarmup's finally
+    // is a no-op once the timeout already flipped state.
+    hung.resolve(okResponse(200));
+    await vi.advanceTimersByTimeAsync(0);
+    await runPromise;
+    // State must remain failopen-timeout (finally must NOT overwrite it).
+    expect(warmup.getWarmState()).toBe('failopen-timeout');
+  });
+
+  it('per-request timeout (MEDIUM-1): one hung route is abandoned, the OTHER route still runs, warmup completes', async () => {
+    vi.useFakeTimers();
+    process.env.WARMUP_ENABLED = 'true';
+    process.env.WARMUP_ROUTES = '/hang,/ok';
+    process.env.WARM_ITERATIONS = '1';
+    process.env.WARM_PER_REQUEST_TIMEOUT_MS = '1000';
+    // Keep the hard fail-open timeout well above the per-request timeout so the
+    // per-request abort — not the hard timer — is what unblocks the loop.
+    process.env.WARMUP_TIMEOUT_MS = '60000';
+
+    let okWarmed = false;
+    // fetch honors the AbortSignal: when /hang is called with a signal, reject
+    // with a TimeoutError once the signal aborts (mirrors AbortSignal.timeout).
+    const fetchMock = vi.fn((url: string, init?: { signal?: AbortSignal }) => {
+      const u = String(url);
+      if (u.includes('/api/live')) return Promise.resolve(okResponse(200));
+      if (u.includes('/hang')) {
+        return new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              const err = new Error('The operation was aborted due to timeout');
+              err.name = 'TimeoutError';
+              reject(err);
+            });
+          }
+        });
+      }
+      // /ok route
+      okWarmed = true;
+      return Promise.resolve(okResponse(200));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmup = await loadWarmup();
+    const runPromise = warmup.runWarmup();
+
+    // Drive timers: listener poll → hung route fetch begins → per-request
+    // AbortSignal.timeout(1000) fires → /hang rejects → loop continues to /ok.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1001);
+    // Flush any remaining microtasks/timers so /ok runs and finally completes.
+    await vi.advanceTimersByTimeAsync(0);
+    await runPromise;
+
+    // The loop CONTINUED past the hung route: /ok was warmed.
+    expect(okWarmed).toBe(true);
+    expect(warmup.isWarm()).toBe(true);
+    // Completed naturally (per-request abort, not hard fail-open timeout).
+    expect(warmup.getWarmState()).toBe('warmed-ok');
+
+    // Assert the hung fetch was actually given an AbortSignal (the MEDIUM-1 fix).
+    const hangCall = fetchMock.mock.calls.find((c) => String(c[0]).includes('/hang'));
+    expect(hangCall).toBeDefined();
+    expect((hangCall?.[1] as { signal?: AbortSignal })?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('globalThis pin: warm state lives on globalThis.__civitaiWarmState (regression guard vs module-local let)', async () => {
+    process.env.WARMUP_ENABLED = 'true';
+    process.env.WARMUP_ROUTES = '/';
+    const fetchMock = vi.fn(() => Promise.resolve(okResponse(200)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const warmup = await loadWarmup();
+    await warmup.runWarmup();
+
+    // The state object the module's isWarm()/getWarmState() read MUST be the one
+    // pinned on the real V8 global. If a regression reverts to a module-local
+    // `let`, this global would stay at its initial value (or be absent) while the
+    // module reports warmed — catching the cross-graph-breaking regression.
+    const pinned = (globalThis as Record<string, unknown>).__civitaiWarmState as
+      | { ready: boolean; state: string; durationMs: number | null }
+      | undefined;
+    expect(pinned).toBeDefined();
+    expect(pinned?.ready).toBe(true);
+    expect(pinned?.state).toBe('warmed-ok');
+    // And the module's accessors agree with the pinned object.
+    expect(warmup.isWarm()).toBe(pinned?.ready);
+    expect(warmup.getWarmState()).toBe(pinned?.state);
+  });
+});

--- a/src/server/warmup.ts
+++ b/src/server/warmup.ts
@@ -21,7 +21,7 @@
 // bounded, and a hard overall timeout guarantees `warmReady` is set no matter
 // what (success, per-route errors, or timeout). A fail-open timeout still
 // flips warmReady=true (the pod becomes Ready) — it is made VISIBLE via the
-// `civitai_warmup_state` gauge + /api/ready body so an operator can tell a
+// `civitai_app_warmup_state` gauge + /api/ready body so an operator can tell a
 // truly-warmed pod from one that just timed out, not blocked.
 //
 // OPT-IN: WARMUP_ENABLED defaults to FALSE. The warmer no-ops + flips
@@ -37,20 +37,48 @@ import { env } from '~/env/server';
 import { registerInstrumentationMetric, instrumentationRegistry } from '~/server/prom/client';
 import client from 'prom-client';
 
-let warmReady = false;
-
-export const isWarm = () => warmReady;
-
-// Observable warm state — exposed both via Prometheus (civitai_warmup_state)
+// Observable warm state — exposed both via Prometheus (civitai_app_warmup_state)
 // and the /api/ready JSON body. These let an operator SEE whether a pod truly
 // warmed or just fail-open-timed-out, and how long warming took.
 export type WarmState = 'disabled' | 'in-progress' | 'warmed-ok' | 'failopen-timeout';
-let warmState: WarmState = 'in-progress';
-let warmDurationMs: number | null = null;
 
-export const getWarmState = (): WarmState => warmState;
-export const getWarmDurationMs = (): number | null => warmDurationMs;
-export const didFailOpenTimeout = (): boolean => warmState === 'failopen-timeout';
+// ---------------------------------------------------------------------------
+// Cross-graph shared warm state (CRITICAL — see prom/client.ts header)
+// ---------------------------------------------------------------------------
+//
+// WHY: Next.js compiles `instrumentation.ts` into a SEPARATE webpack bundle from
+// the API-route/pages bundle, so each graph gets its OWN copy of this module —
+// and thus its own module-level `let`. `runWarmup()` is invoked ONLY from the
+// instrumentation graph (instrumentation.node.ts), so it flips the warm flag in
+// the INSTRUMENTATION graph's copy. But `/api/ready`'s `isWarm()` reads the
+// REQUEST graph's copy — where a plain module-`let` would stay `false` FOREVER,
+// so /api/ready would return 503 permanently and repointing probes at it would
+// wedge every rollout. (Exactly the bug the metrics-pin in prom/client.ts was
+// added to fix — see registerInstrumentationMetric / __civitaiInstrumentationRegistry.)
+//
+// FIX: pin the warm state on `globalThis` (the real V8 global, shared across all
+// webpack bundles in the same Node process). Every reader (`isWarm`, `/api/ready`)
+// and every writer (`runWarmup` success/timeout, the disabled early-return,
+// `setWarmState`) goes through this ONE pinned object, so a flip in the
+// instrumentation graph is visible from the request graph.
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiWarmState:
+    | { ready: boolean; state: WarmState; durationMs: number | null }
+    | undefined;
+}
+
+const warm = (globalThis.__civitaiWarmState ??= {
+  ready: false,
+  state: 'in-progress',
+  durationMs: null,
+});
+
+export const isWarm = () => warm.ready;
+
+export const getWarmState = (): WarmState => warm.state;
+export const getWarmDurationMs = (): number | null => warm.durationMs;
+export const didFailOpenTimeout = (): boolean => warm.state === 'failopen-timeout';
 
 const LOG_PREFIX = '[warmup]';
 
@@ -70,34 +98,36 @@ const WARM_STATE_CODE: Record<WarmState, number> = {
 // visible from /metrics (scraped in the request graph). registerInstrumentationMetric
 // is HMR/dual-graph idempotent — it short-circuits to the existing instance
 // before re-constructing. See src/server/prom/client.ts.
+// Metric names use the shared PROM_PREFIX (civitai_app_*) like every other
+// instrumentation metric (see prom/client.ts PROM_PREFIX + eventloop-longtask.ts).
 const warmStateGauge = registerInstrumentationMetric(
-  'civitai_warmup_state',
+  'civitai_app_warmup_state',
   () =>
     new client.Gauge({
-      name: 'civitai_warmup_state',
+      name: 'civitai_app_warmup_state',
       help: 'In-process route-warmer state (0=disabled,1=in-progress,2=warmed-ok,3=failopen-timeout)',
       registers: [instrumentationRegistry],
     })
 );
 
 const warmDurationGauge = registerInstrumentationMetric(
-  'civitai_warmup_duration_seconds',
+  'civitai_app_warmup_duration_seconds',
   () =>
     new client.Gauge({
-      name: 'civitai_warmup_duration_seconds',
+      name: 'civitai_app_warmup_duration_seconds',
       help: 'Wall-clock seconds the in-process route warmer took to complete (or to fail-open timeout)',
       registers: [instrumentationRegistry],
     })
 );
 
 function setWarmState(state: WarmState) {
-  warmState = state;
+  warm.state = state;
   warmStateGauge.set(WARM_STATE_CODE[state]);
 }
 
-// Reflect the initial in-progress state on the gauge at module init so a scrape
-// before runWarmup() resolves still reports a value (not absent).
-warmStateGauge.set(WARM_STATE_CODE[warmState]);
+// Reflect the initial state on the gauge at module init so a scrape before
+// runWarmup() resolves still reports a value (not absent).
+warmStateGauge.set(WARM_STATE_CODE[warm.state]);
 
 // WebhookEndpoint/-style routes are token-gated; /api/live + /api/health use
 // env.WEBHOOK_TOKEN. Use the validated env accessor (same one health.ts /
@@ -189,7 +219,16 @@ const WARM_ITERATIONS = intFromEnv('WARM_ITERATIONS', 1);
 // hit the shared DB-replica / Meili in lockstep. Both an initial random delay
 // and a small inter-route delay are applied. Math.random is fine here (no
 // security/uniqueness requirement — just load smearing).
-const WARM_INITIAL_JITTER_MAX_MS = intFromEnv('WARM_INITIAL_JITTER_MAX_MS', 500);
+//
+// The INITIAL jitter ceiling is the load-smearing knob that matters: a ~75-pod
+// fleet all becoming listener-ready within ~1s of each other during a rollout
+// would, at a 500ms ceiling, fire their first HEAVY warm read (the feed query)
+// at the shared DB-replica / Meili inside a 500ms window — a pulse on backends
+// that are ALREADY stressed by the rollout. Default the ceiling to 10s so the
+// fleet spreads its first heavy hit over ~10s instead. Env-overridable per pool
+// (WARM_INITIAL_JITTER_MAX_MS). Inter-route jitter stays modest. (Open: the real
+// pulse must be validated on a canary rollout before fleet-wide enable.)
+const WARM_INITIAL_JITTER_MAX_MS = intFromEnv('WARM_INITIAL_JITTER_MAX_MS', 10_000);
 const WARM_INTER_ROUTE_JITTER_MAX_MS = intFromEnv('WARM_INTER_ROUTE_JITTER_MAX_MS', 500);
 const randomJitter = (maxMs: number) => (maxMs > 0 ? Math.floor(Math.random() * maxMs) : 0);
 
@@ -241,6 +280,12 @@ async function warmRoute(baseUrl: string, route: string): Promise<void> {
   );
 }
 
+// Double-run guard. Left module-local (NOT globalThis-pinned) deliberately:
+// runWarmup() is invoked ONLY from the instrumentation graph
+// (instrumentation.node.ts), so there is a single copy that matters. Even if a
+// second graph ever called it, both writes go through the shared globalThis
+// `warm` object, so a duplicate run is at worst a harmless extra warm pass — it
+// cannot corrupt the readiness state.
 let started = false;
 
 export async function runWarmup(): Promise<void> {
@@ -254,10 +299,19 @@ export async function runWarmup(): Promise<void> {
   // gate). This keeps the warmer (which executes the heavy feed query and could
   // hit a DEV DB on previews) off the pools it has no business warming.
   if (process.env.WARMUP_ENABLED !== 'true') {
-    console.log(
-      `${LOG_PREFIX} disabled (WARMUP_ENABLED!=='true') — marking warm immediately, no warm run`
+    // WARN (not log) + a distinct, alertable gauge value (state=disabled → 0).
+    // This is the silent-cold footgun guard: if a manifest repoints startup/
+    // readiness probes at /api/ready but FORGETS WARMUP_ENABLED=true on a
+    // warming pool, the warmer no-ops and /api/ready returns 200 on a COLD pod.
+    // The greppable per-pod WARN below + the disabled gauge value let an
+    // operator (and a Prometheus alert scoped to the SSR/API/heavy pools)
+    // detect that misconfig. Setting WARMUP_ENABLED=true and repointing the
+    // probes MUST be ONE atomic manifest change.
+    console.warn(
+      `${LOG_PREFIX} DISABLED (WARMUP_ENABLED!=='true') — no warm run; /api/ready will 200 on a COLD pod. ` +
+        `This is correct for non-warming pools (jobs/next/stage/app/previews); on an SSR/API/heavy pool it means a missed WARMUP_ENABLED=true.`
     );
-    warmReady = true;
+    warm.ready = true;
     setWarmState('disabled');
     return;
   }
@@ -276,13 +330,13 @@ export async function runWarmup(): Promise<void> {
   let timedOut = false;
   const timeoutId = setTimeout(() => {
     timedOut = true;
-    if (!warmReady) {
-      warmReady = true;
+    if (!warm.ready) {
+      warm.ready = true;
       // Record the fail-open: the pod IS now Ready (so a slow backend can't
       // wedge the rollout), but the warm path was NOT confirmed. This is the
-      // alertable state — visible on civitai_warmup_state=3 and /api/ready.
-      warmDurationMs = Date.now() - startedAt;
-      warmDurationGauge.set(warmDurationMs / 1000);
+      // alertable state — visible on civitai_app_warmup_state=3 and /api/ready.
+      warm.durationMs = Date.now() - startedAt;
+      warmDurationGauge.set(warm.durationMs / 1000);
       setWarmState('failopen-timeout');
       console.warn(`${LOG_PREFIX} hard timeout after ${timeoutMs}ms — marking warm (fail-open)`);
     }
@@ -333,18 +387,18 @@ export async function runWarmup(): Promise<void> {
     // Fail-open: flip warm at the end no matter what — success, per-route
     // errors, or partial completion. (If the hard timeout already flipped it,
     // this is a harmless no-op.)
-    warmReady = true;
+    warm.ready = true;
     // Record duration + final state. If the hard timeout already fired, leave
     // the failopen-timeout state/duration it set (don't overwrite with the
     // later natural-completion time). Otherwise the warm pass completed → mark
     // warmed-ok with its wall-clock.
     if (!timedOut) {
-      warmDurationMs = Date.now() - startedAt;
-      warmDurationGauge.set(warmDurationMs / 1000);
+      warm.durationMs = Date.now() - startedAt;
+      warmDurationGauge.set(warm.durationMs / 1000);
       setWarmState('warmed-ok');
     }
     console.log(
-      `${LOG_PREFIX} complete in ${Date.now() - startedAt}ms — warmReady=true, state=${warmState}${
+      `${LOG_PREFIX} complete in ${Date.now() - startedAt}ms — warmReady=true, state=${warm.state}${
         timedOut ? ' (via timeout)' : ''
       }`
     );

--- a/src/server/warmup.ts
+++ b/src/server/warmup.ts
@@ -19,23 +19,107 @@
 // FAIL-OPEN by design: a slightly-cold pod is far better than a wedged
 // rollout. Every request is wrapped in try/catch, the listener wait is
 // bounded, and a hard overall timeout guarantees `warmReady` is set no matter
-// what (success, per-route errors, or timeout). Disable entirely with
-// WARMUP_ENABLED=false (env, no code revert).
+// what (success, per-route errors, or timeout). A fail-open timeout still
+// flips warmReady=true (the pod becomes Ready) — it is made VISIBLE via the
+// `civitai_warmup_state` gauge + /api/ready body so an operator can tell a
+// truly-warmed pod from one that just timed out, not blocked.
+//
+// OPT-IN: WARMUP_ENABLED defaults to FALSE. The warmer no-ops + flips
+// warmReady=true immediately when disabled, so /api/ready behaves like a plain
+// dependency probe everywhere it isn't explicitly enabled. It is turned on
+// (WARMUP_ENABLED=true) ONLY on the SSR/API/heavy pools via the deployment
+// manifest — never on jobs / civitai-next / -stage / civitai-app / PR previews
+// (some of which point at the DEV DB).
 //
 // Server-side (nodejs runtime) only. Never imported on the edge/client.
+
+import { env } from '~/env/server';
+import { registerInstrumentationMetric, instrumentationRegistry } from '~/server/prom/client';
+import client from 'prom-client';
 
 let warmReady = false;
 
 export const isWarm = () => warmReady;
 
+// Observable warm state — exposed both via Prometheus (civitai_warmup_state)
+// and the /api/ready JSON body. These let an operator SEE whether a pod truly
+// warmed or just fail-open-timed-out, and how long warming took.
+export type WarmState = 'disabled' | 'in-progress' | 'warmed-ok' | 'failopen-timeout';
+let warmState: WarmState = 'in-progress';
+let warmDurationMs: number | null = null;
+
+export const getWarmState = (): WarmState => warmState;
+export const getWarmDurationMs = (): number | null => warmDurationMs;
+export const didFailOpenTimeout = (): boolean => warmState === 'failopen-timeout';
+
 const LOG_PREFIX = '[warmup]';
 
+// Numeric encoding for the gauge (Prometheus gauges are numeric):
+//   0 = disabled / not-applicable, 1 = in-progress, 2 = warmed-ok,
+//   3 = fail-open timeout (warm flipped on without confirmed warm path).
+const WARM_STATE_CODE: Record<WarmState, number> = {
+  disabled: 0,
+  'in-progress': 1,
+  'warmed-ok': 2,
+  'failopen-timeout': 3,
+};
+
+// Cross-graph shared registry: this module is imported from the instrumentation
+// webpack graph (instrumentation.node.ts -> import('~/server/warmup')), so the
+// metrics MUST land in the globalThis-pinned instrumentationRegistry to be
+// visible from /metrics (scraped in the request graph). registerInstrumentationMetric
+// is HMR/dual-graph idempotent — it short-circuits to the existing instance
+// before re-constructing. See src/server/prom/client.ts.
+const warmStateGauge = registerInstrumentationMetric(
+  'civitai_warmup_state',
+  () =>
+    new client.Gauge({
+      name: 'civitai_warmup_state',
+      help: 'In-process route-warmer state (0=disabled,1=in-progress,2=warmed-ok,3=failopen-timeout)',
+      registers: [instrumentationRegistry],
+    })
+);
+
+const warmDurationGauge = registerInstrumentationMetric(
+  'civitai_warmup_duration_seconds',
+  () =>
+    new client.Gauge({
+      name: 'civitai_warmup_duration_seconds',
+      help: 'Wall-clock seconds the in-process route warmer took to complete (or to fail-open timeout)',
+      registers: [instrumentationRegistry],
+    })
+);
+
+function setWarmState(state: WarmState) {
+  warmState = state;
+  warmStateGauge.set(WARM_STATE_CODE[state]);
+}
+
+// Reflect the initial in-progress state on the gauge at module init so a scrape
+// before runWarmup() resolves still reports a value (not absent).
+warmStateGauge.set(WARM_STATE_CODE[warmState]);
+
 // WebhookEndpoint/-style routes are token-gated; /api/live + /api/health use
-// env.WEBHOOK_TOKEN, whose prod value is `letsgethookie` (set via the deployment
-// manifest, not this repo). The warmer reads it from env so it works in any
-// environment; falls back to the known prod literal so a missing env var can't
-// silently break the listener-readiness probe.
-const WEBHOOK_TOKEN = process.env.WEBHOOK_TOKEN ?? 'letsgethookie';
+// env.WEBHOOK_TOKEN. Use the validated env accessor (same one health.ts /
+// ready.ts use) rather than a hardcoded literal fallback, so a rotated token
+// can't silently break the warmer's /api/live readiness poll.
+const WEBHOOK_TOKEN = env.WEBHOOK_TOKEN;
+
+// The app warming itself from its own canonical origin is a legitimate
+// first-party request, so send the headers that satisfy the tRPC origin gate.
+// isAllowedOriginRequest (src/server/createContext.ts) compares the Origin host
+// (falling back to Referer) against allowedOriginHosts, which is built from the
+// server domains + TRPC_ORIGINS + hostFromUrl(env.NEXTAUTH_URL). Sending
+// Origin: <NEXTAUTH_URL> (= https://civitai.com) therefore makes
+// acceptableOrigin=true → isAcceptableOrigin passes → the heavy resolver runs
+// (instead of UNAUTHORIZED 401). We deliberately do NOT send `x-client: web`:
+// needsUpdate() in trpc.ts returns false unless x-client === 'web', so omitting
+// it avoids the version/x-update-required branch entirely. Applied to ALL warm
+// requests (REST + tRPC + SSR) — the REST/SSR paths don't need it but it's
+// harmless and keeps one header set.
+const WARM_HEADERS: Record<string, string> = {
+  origin: env.NEXTAUTH_URL,
+};
 
 // superjson is the app's tRPC transformer (see src/utils/trpc.ts). A tRPC v11
 // GET query batch carries each op's input as `{ "<idx>": { "json": <input> } }`
@@ -93,7 +177,21 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 
 const LISTENER_POLL_INTERVAL_MS = 500;
 const LISTENER_WAIT_MS = 15_000;
-const WARM_ITERATIONS = 3;
+
+// One warm pass per route by default — enough to pay the lazy-require + JIT
+// settle on the hot path without a heavy backend pulse. Env-overridable
+// (WARM_ITERATIONS) if a pool wants more JIT settling at the cost of more
+// backend load. (Open runtime question: whether 1 iteration meaningfully
+// settles the JIT vs 3 — needs a real-pod before/after.)
+const WARM_ITERATIONS = intFromEnv('WARM_ITERATIONS', 1);
+
+// Jitter so a fleet of pods warming concurrently during a surge/rollout doesn't
+// hit the shared DB-replica / Meili in lockstep. Both an initial random delay
+// and a small inter-route delay are applied. Math.random is fine here (no
+// security/uniqueness requirement — just load smearing).
+const WARM_INITIAL_JITTER_MAX_MS = intFromEnv('WARM_INITIAL_JITTER_MAX_MS', 500);
+const WARM_INTER_ROUTE_JITTER_MAX_MS = intFromEnv('WARM_INTER_ROUTE_JITTER_MAX_MS', 500);
+const randomJitter = (maxMs: number) => (maxMs > 0 ? Math.floor(Math.random() * maxMs) : 0);
 
 // Poll /api/live until the HTTP listener answers 200, so self-requests don't
 // race the server coming up. Bounded — never block boot forever.
@@ -102,7 +200,7 @@ async function waitForListener(baseUrl: string): Promise<boolean> {
   const url = `${baseUrl}/api/live?token=${encodeURIComponent(WEBHOOK_TOKEN)}`;
   while (Date.now() < deadline) {
     try {
-      const res = await fetch(url, { method: 'GET' });
+      const res = await fetch(url, { method: 'GET', headers: WARM_HEADERS });
       if (res.ok) {
         // Drain the body so the connection can be reused/closed cleanly.
         await res.text().catch(() => undefined);
@@ -117,16 +215,16 @@ async function waitForListener(baseUrl: string): Promise<boolean> {
   return false;
 }
 
-// Warm a single route a few times to settle the JIT. Every error is swallowed
-// — a bad input or a transiently-down dependency must not crash boot or abort
-// the rest of the warmup.
+// Warm a single route (WARM_ITERATIONS passes, default 1) to settle the JIT.
+// Every error is swallowed — a bad input or a transiently-down dependency must
+// not crash boot or abort the rest of the warmup.
 async function warmRoute(baseUrl: string, route: string): Promise<void> {
   const url = `${baseUrl}${route}`;
   let lastStatus = 0;
   let errored = false;
   for (let i = 0; i < WARM_ITERATIONS; i++) {
     try {
-      const res = await fetch(url, { method: 'GET' });
+      const res = await fetch(url, { method: 'GET', headers: WARM_HEADERS });
       lastStatus = res.status;
       // Read the body so the handler runs to completion (the response stream is
       // part of the hot path we want JIT-compiled) and the socket frees up.
@@ -149,11 +247,18 @@ export async function runWarmup(): Promise<void> {
   if (started) return;
   started = true;
 
-  // Disable switch — flip warm immediately so /api/ready behaves like a plain
-  // dependency probe (no warm gate) without a code change.
-  if (process.env.WARMUP_ENABLED === 'false') {
-    console.log(`${LOG_PREFIX} disabled (WARMUP_ENABLED=false) — marking warm immediately`);
+  // Default OFF (opt-in). The warmer only runs when WARMUP_ENABLED === 'true'
+  // (set on the SSR/API/heavy dp-prod deployments). Everywhere else — jobs,
+  // civitai-next, -stage, civitai-app, PR previews — it no-ops and flips warm
+  // immediately so /api/ready behaves like a plain dependency probe (no warm
+  // gate). This keeps the warmer (which executes the heavy feed query and could
+  // hit a DEV DB on previews) off the pools it has no business warming.
+  if (process.env.WARMUP_ENABLED !== 'true') {
+    console.log(
+      `${LOG_PREFIX} disabled (WARMUP_ENABLED!=='true') — marking warm immediately, no warm run`
+    );
     warmReady = true;
+    setWarmState('disabled');
     return;
   }
 
@@ -173,6 +278,12 @@ export async function runWarmup(): Promise<void> {
     timedOut = true;
     if (!warmReady) {
       warmReady = true;
+      // Record the fail-open: the pod IS now Ready (so a slow backend can't
+      // wedge the rollout), but the warm path was NOT confirmed. This is the
+      // alertable state — visible on civitai_warmup_state=3 and /api/ready.
+      warmDurationMs = Date.now() - startedAt;
+      warmDurationGauge.set(warmDurationMs / 1000);
+      setWarmState('failopen-timeout');
       console.warn(`${LOG_PREFIX} hard timeout after ${timeoutMs}ms — marking warm (fail-open)`);
     }
   }, timeoutMs);
@@ -191,11 +302,26 @@ export async function runWarmup(): Promise<void> {
       );
     }
 
+    // Randomized initial delay so a fleet of pods that all become listener-ready
+    // at roughly the same instant during a rollout don't fire their first heavy
+    // warm read at the shared DB-replica / Meili in lockstep.
+    if (!timedOut) {
+      const initialJitter = randomJitter(WARM_INITIAL_JITTER_MAX_MS);
+      if (initialJitter > 0) await sleep(initialJitter);
+    }
+
     // Warm routes sequentially so we don't pile concurrent cold lazy-requires
     // onto the single event-loop thread (that would re-create the very pin
     // we're trying to avoid). Stop early if the hard timeout already fired.
+    // Small randomized inter-route delay further smears the backend load.
+    let first = true;
     for (const route of routes) {
       if (timedOut) break;
+      if (!first) {
+        const interJitter = randomJitter(WARM_INTER_ROUTE_JITTER_MAX_MS);
+        if (interJitter > 0) await sleep(interJitter);
+      }
+      first = false;
       await warmRoute(baseUrl, route);
     }
   } catch (err) {
@@ -208,8 +334,17 @@ export async function runWarmup(): Promise<void> {
     // errors, or partial completion. (If the hard timeout already flipped it,
     // this is a harmless no-op.)
     warmReady = true;
+    // Record duration + final state. If the hard timeout already fired, leave
+    // the failopen-timeout state/duration it set (don't overwrite with the
+    // later natural-completion time). Otherwise the warm pass completed → mark
+    // warmed-ok with its wall-clock.
+    if (!timedOut) {
+      warmDurationMs = Date.now() - startedAt;
+      warmDurationGauge.set(warmDurationMs / 1000);
+      setWarmState('warmed-ok');
+    }
     console.log(
-      `${LOG_PREFIX} complete in ${Date.now() - startedAt}ms — warmReady=true${
+      `${LOG_PREFIX} complete in ${Date.now() - startedAt}ms — warmReady=true, state=${warmState}${
         timedOut ? ' (via timeout)' : ''
       }`
     );

--- a/src/server/warmup.ts
+++ b/src/server/warmup.ts
@@ -290,8 +290,10 @@ async function warmRoute(baseUrl: string, route: string): Promise<void> {
       const res = await fetch(url, { method: 'GET', headers: WARM_HEADERS, signal });
       lastStatus = res.status;
       // Read the body so the handler runs to completion (the response stream is
-      // part of the hot path we want JIT-compiled) and the socket frees up.
-      await res.text().catch(() => undefined);
+      // part of the hot path we want JIT-compiled) and the socket frees up. If
+      // the body stream hangs and the shared signal aborts, let it throw to the
+      // outer catch (LOW-2) so the route is logged errored, not a false success.
+      await res.text();
     } catch (err) {
       errored = true;
       // AbortSignal.timeout aborts with a TimeoutError DOMException; surface it
@@ -357,7 +359,14 @@ export async function runWarmup(): Promise<void> {
   // ECONNREFUSED, $HOSTNAME → 200). Mirror that bind: use HOSTNAME when set
   // (k8s/standalone), fall back to loopback for local/dev where HOSTNAME is
   // unset and the server binds 0.0.0.0. WARM_HOST overrides if ever needed.
-  const host = process.env.WARM_HOST || process.env.HOSTNAME || '127.0.0.1';
+  const rawHost = process.env.WARM_HOST || process.env.HOSTNAME || '127.0.0.1';
+  // Self-defend against the wildcard-bind case: if HOSTNAME is set to a wildcard
+  // (`0.0.0.0`/`::`) — e.g. someone adds the common `HOSTNAME=0.0.0.0` Next-k8s
+  // bind workaround — the server binds all interfaces (loopback included) but a
+  // wildcard is NOT a valid CONNECT target on Linux/undici. Normalize it to
+  // loopback so the warmer can't silently revert to the inert-ECONNREFUSED bug.
+  const host =
+    rawHost === '0.0.0.0' || rawHost === '::' || rawHost === '[::]' ? '127.0.0.1' : rawHost;
   const baseUrl = `http://${host}:${port}`;
   const timeoutMs = intFromEnv('WARMUP_TIMEOUT_MS', 60_000);
   const startedAt = Date.now();

--- a/src/server/warmup.ts
+++ b/src/server/warmup.ts
@@ -350,10 +350,15 @@ export async function runWarmup(): Promise<void> {
   }
 
   const port = process.env.PORT ?? '3000';
-  // Always self-call over loopback regardless of the bind HOSTNAME (the
-  // standalone server binds 0.0.0.0 by default; 127.0.0.1 is always reachable
-  // in-pod and avoids any external DNS/hostname resolution).
-  const baseUrl = `http://127.0.0.1:${port}`;
+  // Self-call the host the standalone server ACTUALLY binds to. Next's
+  // server.js listens on `process.env.HOSTNAME || '0.0.0.0'`, and Kubernetes
+  // sets HOSTNAME to the POD NAME — so the server binds the pod-name interface
+  // ONLY and 127.0.0.1 is REFUSED (verified on a live preview pod: loopback →
+  // ECONNREFUSED, $HOSTNAME → 200). Mirror that bind: use HOSTNAME when set
+  // (k8s/standalone), fall back to loopback for local/dev where HOSTNAME is
+  // unset and the server binds 0.0.0.0. WARM_HOST overrides if ever needed.
+  const host = process.env.WARM_HOST || process.env.HOSTNAME || '127.0.0.1';
+  const baseUrl = `http://${host}:${port}`;
   const timeoutMs = intFromEnv('WARMUP_TIMEOUT_MS', 60_000);
   const startedAt = Date.now();
 

--- a/src/server/warmup.ts
+++ b/src/server/warmup.ts
@@ -232,6 +232,23 @@ const WARM_INITIAL_JITTER_MAX_MS = intFromEnv('WARM_INITIAL_JITTER_MAX_MS', 10_0
 const WARM_INTER_ROUTE_JITTER_MAX_MS = intFromEnv('WARM_INTER_ROUTE_JITTER_MAX_MS', 500);
 const randomJitter = (maxMs: number) => (maxMs > 0 ? Math.floor(Math.random() * maxMs) : 0);
 
+// Per-request hard timeout for a single warm fetch (MEDIUM-1). Without it a warm
+// read that hangs (a brown dependency that accepts the connection but never
+// responds) would leak its loopback socket for the pod's life and strand
+// warmState='in-progress' on that route forever — the per-route `await` would
+// never resolve. Readiness itself is NOT wedged (the independent fail-open
+// setTimeout(WARMUP_TIMEOUT_MS) still flips ready=true), so this is robustness,
+// not correctness. We bound EACH fetch with AbortSignal.timeout(perRouteMs)
+// (Node 20+) so a hung route is abandoned and the loop CONTINUES to the next.
+// 0 disables the per-request bound (falls back to no AbortSignal). Env-overridable
+// via WARM_PER_REQUEST_TIMEOUT_MS (default 10s).
+const WARM_PER_REQUEST_TIMEOUT_MS = intFromEnv('WARM_PER_REQUEST_TIMEOUT_MS', 10_000);
+
+// Build the AbortSignal for a single warm fetch. Returns undefined when the
+// per-request timeout is disabled (<=0) so we pass no signal in that case.
+const warmAbortSignal = (): AbortSignal | undefined =>
+  WARM_PER_REQUEST_TIMEOUT_MS > 0 ? AbortSignal.timeout(WARM_PER_REQUEST_TIMEOUT_MS) : undefined;
+
 // Poll /api/live until the HTTP listener answers 200, so self-requests don't
 // race the server coming up. Bounded — never block boot forever.
 async function waitForListener(baseUrl: string): Promise<boolean> {
@@ -263,14 +280,30 @@ async function warmRoute(baseUrl: string, route: string): Promise<void> {
   let errored = false;
   for (let i = 0; i < WARM_ITERATIONS; i++) {
     try {
-      const res = await fetch(url, { method: 'GET', headers: WARM_HEADERS });
+      // Per-request AbortSignal.timeout (MEDIUM-1): a hung warm read is aborted
+      // after WARM_PER_REQUEST_TIMEOUT_MS so it can't leak a socket or strand
+      // this route's await forever. The abort surfaces as a throw from fetch (or
+      // from res.text() if the body hangs) — caught below — and the caller's
+      // loop CONTINUES to the next route. Body drain shares the same signal so a
+      // hung body stream is also abandoned.
+      const signal = warmAbortSignal();
+      const res = await fetch(url, { method: 'GET', headers: WARM_HEADERS, signal });
       lastStatus = res.status;
       // Read the body so the handler runs to completion (the response stream is
       // part of the hot path we want JIT-compiled) and the socket frees up.
       await res.text().catch(() => undefined);
     } catch (err) {
       errored = true;
-      console.error(`${LOG_PREFIX} route warm error ${route}:`, (err as Error)?.message ?? err);
+      // AbortSignal.timeout aborts with a TimeoutError DOMException; surface it
+      // concisely so an operator can tell a per-request timeout from a real
+      // connection error. Either way we swallow it and continue.
+      const e = err as Error;
+      const aborted = e?.name === 'TimeoutError' || e?.name === 'AbortError';
+      console.warn(
+        `${LOG_PREFIX} route warm ${aborted ? 'timeout' : 'error'} ${route}` +
+          `${aborted ? ` (>${WARM_PER_REQUEST_TIMEOUT_MS}ms)` : ''}:`,
+        e?.message ?? err
+      );
     }
   }
   console.log(

--- a/src/server/warmup.ts
+++ b/src/server/warmup.ts
@@ -1,0 +1,217 @@
+// In-process route warmer for the Next.js standalone server.
+//
+// WHY: `output: 'standalone'` lazy-`require()`s each API/page route the FIRST
+// time it's hit. The dependency-only /api/health probe marks a pod Ready as
+// soon as its DB/Redis/etc. are reachable — but at that moment every hot route
+// is still COLD. The kubelet then routes real /api/v1/images, tRPC
+// image.getInfinite / image.getImagesAsPostsInfinite / model.getAll, and SSR
+// `/` traffic to the pod; the first hit pays lazy-require + JIT compilation on
+// the single event-loop thread, which pins the loop → 504/502/499 — the
+// cold-start cascade observed on every rollout.
+//
+// This module self-warms the hot routes via LOCALHOST requests during startup
+// and only flips `warmReady` true once warm (or a fail-open timeout fires).
+// The /api/ready probe gates on isWarm() so a pod isn't marked Ready until its
+// hot paths are JIT-settled. instrumentation.node.ts kicks runWarmup() as a
+// fire-and-forget (NOT awaited — register() must return so the HTTP listener
+// comes up, which the warmer needs to self-request).
+//
+// FAIL-OPEN by design: a slightly-cold pod is far better than a wedged
+// rollout. Every request is wrapped in try/catch, the listener wait is
+// bounded, and a hard overall timeout guarantees `warmReady` is set no matter
+// what (success, per-route errors, or timeout). Disable entirely with
+// WARMUP_ENABLED=false (env, no code revert).
+//
+// Server-side (nodejs runtime) only. Never imported on the edge/client.
+
+let warmReady = false;
+
+export const isWarm = () => warmReady;
+
+const LOG_PREFIX = '[warmup]';
+
+// WebhookEndpoint/-style routes are token-gated; /api/live + /api/health use
+// env.WEBHOOK_TOKEN, whose prod value is `letsgethookie` (set via the deployment
+// manifest, not this repo). The warmer reads it from env so it works in any
+// environment; falls back to the known prod literal so a missing env var can't
+// silently break the listener-readiness probe.
+const WEBHOOK_TOKEN = process.env.WEBHOOK_TOKEN ?? 'letsgethookie';
+
+// superjson is the app's tRPC transformer (see src/utils/trpc.ts). A tRPC v11
+// GET query batch carries each op's input as `{ "<idx>": { "json": <input> } }`
+// url-encoded under `?batch=1&input=`. We hand-build the minimal valid form
+// here (no react/trpc-client import on the server boot path) — superjson's
+// `{ json }` envelope is correct for plain JSON-safe inputs (no Date/Map/etc.).
+function buildTrpcBatchUrl(procedures: string[], inputs: unknown[]): string {
+  const input: Record<string, { json: unknown }> = {};
+  inputs.forEach((value, i) => {
+    input[String(i)] = { json: value };
+  });
+  const path = procedures.join(',');
+  return `/api/trpc/${path}?batch=1&input=${encodeURIComponent(JSON.stringify(input))}`;
+}
+
+// Default hot route list. These are idempotent GET reads ONLY — never a
+// mutating route. The same image runs the SSR / API / heavy pools, so warming
+// the superset on every pod is fine (reads are side-effect-free) and lets a
+// single image serve any pool. Ops can override per-pool via WARMUP_ROUTES.
+function defaultRoutes(): string[] {
+  return [
+    // Hot REST route (PublicEndpoint — no token needed).
+    '/api/v1/images?limit=20',
+    // Heavy tRPC procedures (image.getInfinite, image.getImagesAsPostsInfinite,
+    // model.getAll) batched into one GET, the form the web client uses. Minimal
+    // valid inputs — the schemas default the rest (limit/period/sort/etc.).
+    buildTrpcBatchUrl(
+      ['image.getInfinite', 'image.getImagesAsPostsInfinite', 'model.getAll'],
+      [{ limit: 20 }, { limit: 20 }, { limit: 20 }]
+    ),
+    // SSR catch-all — warms the SSR pool's page-render path.
+    '/',
+  ];
+}
+
+function getRoutes(): string[] {
+  const override = process.env.WARMUP_ROUTES;
+  if (override && override.trim().length > 0) {
+    return override
+      .split(',')
+      .map((r) => r.trim())
+      .filter((r) => r.length > 0);
+  }
+  return defaultRoutes();
+}
+
+function intFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const LISTENER_POLL_INTERVAL_MS = 500;
+const LISTENER_WAIT_MS = 15_000;
+const WARM_ITERATIONS = 3;
+
+// Poll /api/live until the HTTP listener answers 200, so self-requests don't
+// race the server coming up. Bounded — never block boot forever.
+async function waitForListener(baseUrl: string): Promise<boolean> {
+  const deadline = Date.now() + LISTENER_WAIT_MS;
+  const url = `${baseUrl}/api/live?token=${encodeURIComponent(WEBHOOK_TOKEN)}`;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { method: 'GET' });
+      if (res.ok) {
+        // Drain the body so the connection can be reused/closed cleanly.
+        await res.text().catch(() => undefined);
+        return true;
+      }
+      await res.text().catch(() => undefined);
+    } catch {
+      // listener not up yet — keep polling
+    }
+    await sleep(LISTENER_POLL_INTERVAL_MS);
+  }
+  return false;
+}
+
+// Warm a single route a few times to settle the JIT. Every error is swallowed
+// — a bad input or a transiently-down dependency must not crash boot or abort
+// the rest of the warmup.
+async function warmRoute(baseUrl: string, route: string): Promise<void> {
+  const url = `${baseUrl}${route}`;
+  let lastStatus = 0;
+  let errored = false;
+  for (let i = 0; i < WARM_ITERATIONS; i++) {
+    try {
+      const res = await fetch(url, { method: 'GET' });
+      lastStatus = res.status;
+      // Read the body so the handler runs to completion (the response stream is
+      // part of the hot path we want JIT-compiled) and the socket frees up.
+      await res.text().catch(() => undefined);
+    } catch (err) {
+      errored = true;
+      console.error(`${LOG_PREFIX} route warm error ${route}:`, (err as Error)?.message ?? err);
+    }
+  }
+  console.log(
+    `${LOG_PREFIX} warmed ${route} (${WARM_ITERATIONS}x, lastStatus=${lastStatus}${
+      errored ? ', errored' : ''
+    })`
+  );
+}
+
+let started = false;
+
+export async function runWarmup(): Promise<void> {
+  if (started) return;
+  started = true;
+
+  // Disable switch — flip warm immediately so /api/ready behaves like a plain
+  // dependency probe (no warm gate) without a code change.
+  if (process.env.WARMUP_ENABLED === 'false') {
+    console.log(`${LOG_PREFIX} disabled (WARMUP_ENABLED=false) — marking warm immediately`);
+    warmReady = true;
+    return;
+  }
+
+  const port = process.env.PORT ?? '3000';
+  // Always self-call over loopback regardless of the bind HOSTNAME (the
+  // standalone server binds 0.0.0.0 by default; 127.0.0.1 is always reachable
+  // in-pod and avoids any external DNS/hostname resolution).
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const timeoutMs = intFromEnv('WARMUP_TIMEOUT_MS', 60_000);
+  const startedAt = Date.now();
+
+  // Hard fail-open timer: whatever happens, the pod becomes Ready-eligible
+  // after timeoutMs. Better a slightly-cold pod than a rollout wedged on a
+  // warmer that hangs (e.g. a dependency the warm reads touch is brown).
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    if (!warmReady) {
+      warmReady = true;
+      console.warn(`${LOG_PREFIX} hard timeout after ${timeoutMs}ms — marking warm (fail-open)`);
+    }
+  }, timeoutMs);
+  timeoutId.unref?.();
+
+  try {
+    const routes = getRoutes();
+    console.log(
+      `${LOG_PREFIX} starting — baseUrl=${baseUrl}, timeoutMs=${timeoutMs}, routes=${routes.length}`
+    );
+
+    const listenerUp = await waitForListener(baseUrl);
+    if (!listenerUp) {
+      console.warn(
+        `${LOG_PREFIX} listener not ready after ${LISTENER_WAIT_MS}ms — warming anyway (fail-open)`
+      );
+    }
+
+    // Warm routes sequentially so we don't pile concurrent cold lazy-requires
+    // onto the single event-loop thread (that would re-create the very pin
+    // we're trying to avoid). Stop early if the hard timeout already fired.
+    for (const route of routes) {
+      if (timedOut) break;
+      await warmRoute(baseUrl, route);
+    }
+  } catch (err) {
+    // Defensive: nothing above should throw (each leg is guarded), but a throw
+    // here must NOT prevent the ready flip below.
+    console.error(`${LOG_PREFIX} unexpected error:`, (err as Error)?.message ?? err);
+  } finally {
+    clearTimeout(timeoutId);
+    // Fail-open: flip warm at the end no matter what — success, per-route
+    // errors, or partial completion. (If the hard timeout already flipped it,
+    // this is a harmless no-op.)
+    warmReady = true;
+    console.log(
+      `${LOG_PREFIX} complete in ${Date.now() - startedAt}ms — warmReady=true${
+        timedOut ? ' (via timeout)' : ''
+      }`
+    );
+  }
+}


### PR DESCRIPTION
## Problem

Next.js standalone (`output: 'standalone'`) **lazy-`require()`s each route handler on its first request**. The current readiness probe (`/api/health?...&startup=true`) is **dependency-only** — the `startup` query param is a no-op (nothing reads it). So a pod is marked Ready and pulled into the LB **while every hot route is still cold**.

The first real `/api/v1/images`, tRPC `image.getInfinite` / `image.getImagesAsPostsInfinite` / `model.getAll`, or SSR `/` request then pays **lazy-require + JIT compilation on the single event-loop thread** → the loop pins → `504/502/499`. This is the **cold-start cascade observed on every rollout** (see the api-primary cascade history).

## Fix: warm before Ready

Each pod **self-warms its hot routes via localhost requests during startup** and only reports Ready once warm.

### Files

- **`src/server/warmup.ts`** (new) — `runWarmup()`:
  - **OPT-IN**: gated by `WARMUP_ENABLED`, default **false**. Runs only when `WARMUP_ENABLED='true'`; everywhere else it no-ops + flips warm-ready immediately so `/api/ready` still works (plain dependency probe).
  - Self-calls over `http://127.0.0.1:${PORT}` (loopback regardless of bind `HOSTNAME`).
  - **Sends `Origin: <NEXTAUTH_URL>` on every warm request** so the heavy tRPC procedures actually execute (see C1 below) instead of 401ing.
  - **Waits for the listener**: polls `GET /api/live?token=…` until 200 (~500ms interval, ~15s bound — never blocks forever).
  - **Warms the hot routes** (GET only, never mutating): `/api/v1/images?limit=20`, a superjson tRPC GET batch hitting `image.getInfinite,image.getImagesAsPostsInfinite,model.getAll`, and the SSR catch-all `/`. `WARM_ITERATIONS` default **1** (env-overridable). Route list overridable via `WARMUP_ROUTES`.
  - **Jitter**: randomized initial delay + inter-route delay so a fleet warming concurrently during a rollout doesn't hit the shared DB-replica / Meili in lockstep.
  - **Every request `try/catch` wrapped**; **fail-open hard timeout** `WARMUP_TIMEOUT_MS` (default 60000) + a `finally` block guarantee warm-ready flips **true no matter what**.
  - **Observability**: Prometheus gauges `civitai_app_warmup_state` (0=disabled, 1=in-progress, 2=warmed-ok, 3=failopen-timeout) and `civitai_app_warmup_duration_seconds`, registered into the cross-graph `instrumentationRegistry` (scraped by `/api/metrics`, same pattern as the event-loop long-task metrics). A fail-open timeout is now **visible/alertable** (state=3), not silent.
  - `isWarm()` / `getWarmState()` / `getWarmDurationMs()` / `didFailOpenTimeout()` accessors, backed by a **globalThis-pinned** warm state (see C-1 below).

- **`src/pages/api/ready.ts`** (new) — returns **200** iff `isWarm()` **AND** the dependency checks pass; **503** otherwise. Body includes `warmState`, `warmDurationMs`, `failOpenTimedOut` so an operator can tell a truly-warmed pod from a fail-open-timed-out one (and a `disabled`-pool pod). Same `WebhookEndpoint` `?token` gate as `/api/health`.

- **`src/pages/api/health.ts`** — extracted the dependency-check machinery into exported **`runHealthChecks(signal)`** so `/api/health` and `/api/ready` share one source of truth. **`/api/health` HTTP behavior is unchanged.**

- **`src/instrumentation.node.ts`** — fire-and-forget kick (not awaited; `register()` must return so Next starts the listener the warmer needs).

## First adversarial-audit fixes (commit `a72d75cbe`)

- **C1 (CRITICAL) — warm tRPC was 401ing.** The hot procedures go through `publicProcedure` → `isAcceptableOrigin`, which throws `UNAUTHORIZED` when `isProd && !isAllowedOriginRequest(req)`. Fix: send `Origin: <env.NEXTAUTH_URL>` on **all** warm requests so `acceptableOrigin=true` → the resolver executes. Deliberately no `x-client: web` (avoids the `needsUpdate` / `x-update-required` branch).
- **M1 — hot procedures confirmed** (`model.getAll`/`image.getInfinite`/`image.getImagesAsPostsInfinite` are the live feeds; `getAllInfiniteSimple` is auth-only and correctly not warmed).
- **H2 — default OFF, opt-in per pool.**
- **C2 + H1 — observability + load pulse** (warm-state/duration gauges + `/api/ready` body fields; `WARM_ITERATIONS` default 1 + jitter).
- **M2 — no hardcoded prod token** (reads `env.WEBHOOK_TOKEN`).
- **H3 — corrected follow-up.**

## Second adversarial-audit fixes (commit `49789ce5c`)

- **C-1 (CRITICAL — the feature was a rollout-wedge).** Next compiles `instrumentation.ts` into a **separate webpack bundle** from the API/pages bundle; each has its own module copy, and only `globalThis`-pinned state crosses. `runWarmup()` is called **only** from `instrumentation.node.ts` (the instrumentation graph), so it flipped the warm flag in that graph's copy — but `/api/ready`'s `isWarm()` reads the **request** graph's copy, where a plain module-`let` stays `false` **forever** → `/api/ready` returns **503 permanently** → repointing probes wedges **every** rollout. (The author already `globalThis`-pinned the *metrics* for exactly this reason — `__civitaiInstrumentationRegistry` — but left the readiness state un-pinned.) **Fix:** move the warm state onto `globalThis.__civitaiWarmState ??= { ready, state, durationMs }`, mirroring the metrics-pin pattern. **All** writers (`runWarmup` success in `finally`, the fail-open timeout handler, the `disabled` early-return, `setWarmState`) and **all** readers (`isWarm`/`getWarmState`/`getWarmDurationMs`/`didFailOpenTimeout`, hence `/api/ready`) now go through that one pinned object. The `started` double-run guard stays module-local on purpose (`runWarmup` is invoked from one graph; even a duplicate call is a harmless extra pass since both writes hit the shared object).
  - ⚠️ **Runtime correctness — that `/api/ready` ever returns 200 on a warmed pod — can only be PROVEN on a live pod.** This is the **must-verify-before-probe-repoint** item.
- **H-1 (HIGH — silent-cold footgun).** `WARMUP_ENABLED=false` → warmer no-ops and reports warm-ready, so `/api/ready` returns **200 on a cold pod**. That's *correct* for non-warming pools, but if a manifest repoints probes at `/api/ready` and **forgets `WARMUP_ENABLED=true`** on a warming pool, you get a silent healthy-looking cold pod. **Fix (observability/process, not changing the 200):** `disabled` is a distinct, alertable gauge value (`civitai_app_warmup_state=0`); boot now emits a clear, greppable per-pod **WARN** when warmup is disabled; `/api/ready` body already shows `warmState='disabled'`. **Repointing the probes and setting `WARMUP_ENABLED=true` on a pool MUST be ONE atomic manifest change.** Follow-up (datapacket-talos, documented only): add a Prometheus alert on `civitai_app_warmup_state=0` scoped to the SSR/API/heavy pools.
- **H-2 (HIGH — backend load pulse).** `WARM_INITIAL_JITTER_MAX_MS=500` is too small for a ~75-pod fleet — pods warm near-simultaneously and pulse the shared DB-replica/Meili during a rollout (when they're already stressed). **Fix:** default the **initial** jitter ceiling to **10000ms** (env-overridable) so the fleet spreads its first heavy warm hit over ~10s. `WARM_ITERATIONS=1` and the modest inter-route jitter are unchanged. The real pulse must be validated on a **canary rollout** before fleet-wide enable.
- **M-1 (metric naming).** Renamed `civitai_warmup_state` / `civitai_warmup_duration_seconds` → **`civitai_app_warmup_state`** / **`civitai_app_warmup_duration_seconds`** to match the `PROM_PREFIX` (`civitai_app_*`) every sibling instrumentation metric uses (`prom/client.ts`, `eventloop-longtask.ts`). **Any dashboard/alert panel must use the new `civitai_app_warmup_*` names.**
- **M-2 (health refactor dropped mid-run abort short-circuits).** `origin/main`'s handler had two in-run `if (signal.aborted) return` guards (after the config-fetch leg, and after the checks race) so a client disconnect stopped work early. The extraction into `runHealthChecks` dropped them, so on the probe path (fires every few seconds) it always ran config-fetch + the full DB/Redis/Meili/CH checks to completion even when aborted. **Fix:** re-added both early returns **inside `runHealthChecks`**, returning the existing contract shape (`{ healthy, results, deadlineTimedOut }`); the callers already skip sending a response when `signal.aborted`, so the returned values are inert. `/api/health` HTTP behavior unchanged.
- **L-1 (private type in exported signature).** `runHealthChecks`'s exported signature referenced the module-private `CheckKey` type (compiles under `next build`, errors under `--declaration`). **Fix:** `export type CheckKey`.

## Third pass — MEDIUM-1 per-request timeout + first tests (commit `7be782d5c`)

- **MEDIUM-1 (robustness — per-request timeout on warm fetches).** The warm `fetch` in `warmRoute` had **no per-request timeout/AbortSignal**. A hung warm read (a brown dependency that accepts the connection but never responds) would **leak one loopback socket for the pod's life** and strand that route's `await` (warmState stuck `in-progress` on that route). Readiness was **never** wedged — the independent fail-open `setTimeout(WARMUP_TIMEOUT_MS)` still flips `ready=true` — so this is **robustness, not correctness**. **Fix:** each warm `fetch` now gets an `AbortSignal.timeout(WARM_PER_REQUEST_TIMEOUT_MS)` (Node 20+; new env, **default 10000ms**, `0` disables). On per-request timeout/abort the error is caught by `warmRoute`'s **existing** try/catch (the abort surfaces as a `TimeoutError`/`AbortError` throw from `fetch`), logged concisely, and the caller's loop **CONTINUES to the next route** — the whole warmup is not aborted. The success-path body drain shares the same signal; the overall `finally` (clearTimeout + final state log) is unchanged.
- **Tests (the PR shipped with ZERO).** New vitest unit suite `src/server/__tests__/warmup.test.ts` pins the statically-testable warm-state machine: **disabled** no-op path (no fetch, state `disabled`), **success** path (state `warmed-ok`, durationMs set, fetch per route×iterations), **fail-open hard-timeout** path (a hung warm + advanced fake timers → state `failopen-timeout`), **per-request timeout (MEDIUM-1)** (one hung route abandoned, the **other** route still warmed, loop continued, and the hung fetch is asserted to have received an `AbortSignal`), and the **globalThis pin** contract (state read directly off `globalThis.__civitaiWarmState` — a regression that reverts to a module-local `let` is caught). It overrides the global `setup.ts` prom mock with a local one that supplies `instrumentationRegistry` (the global mock doesn't export it — the audit flagged this), mirroring the `eventloop-longtask` test pattern.
  - **What the tests CANNOT cover:** the actual **two-webpack-graph runtime crossing** (the C-1 bug) — vitest loads one module graph, so the cross-graph divergence can't be reproduced here. The test pins the *contract* (state on the real V8 global); the cross-graph behaviour still needs a **live pod** to verify (see open item C-1).
  - **Run result:** `pnpm vitest run src/server/__tests__/warmup.test.ts` → **7 passed** (1 file, ~1.2s) in the worktree.

## Fail-open behavior

Warmup can never wedge a rollout: bounded listener wait, **per-request `AbortSignal.timeout` (`WARM_PER_REQUEST_TIMEOUT_MS`, default 10s — MEDIUM-1)**, per-request `try/catch`, a hard `WARMUP_TIMEOUT_MS`, and a `finally` that always sets warm-ready true. The timeout is **visible** (`civitai_app_warmup_state=3`, `/api/ready` `failOpenTimedOut=true`) rather than silent. Default OFF; enable per-pool. (After C-1, the warm flag is shared across webpack graphs so the request-graph `/api/ready` actually observes the flip — subject to the live-pod verification above.)

## ⚠️ REQUIRED FOLLOW-UP (separate datapacket-talos change, do NOT do it here)

Once this image is **built + deployed to civitai-dp-prod**, in **ONE atomic manifest change** per pool (H-1):

1. **Repoint ONLY `startupProbe` + `readinessProbe`** from `/api/health?…&startup=true` → **`/api/ready?token=letsgethookie`** on `deployment.yaml`, `deployment-api.yaml`, `deployment-api-heavy.yaml`.
2. **Set `WARMUP_ENABLED=true`** on those same SSR/API/api-heavy deployments **in the same commit** (the warmer defaults **off** — repoint without it = silent cold-pod no-op, exactly the H-1 footgun).
3. **Leave liveness EXACTLY as-is** (the PR #2487 heartbeat — **not** httpGet `/api/live`). Do **not** touch it.
4. Keep `startupProbe` `failureThreshold` **30×5s = 150s** (≥ the warm budget) and `minReadySeconds 90`.
5. **Only after** verifying warm-before-Ready on a **canary** rollout, raise `maxSurge` **2% → 8%**.
6. Add a Prometheus alert on **`civitai_app_warmup_state == 0`** (disabled) scoped to the SSR/API/heavy pools, to catch a future pool that repoints probes but loses `WARMUP_ENABLED=true`.

**Do not repoint the probes before this image is live** — pointing `startupProbe`/`readinessProbe` at `/api/ready` before the route exists in the running image fails startup on every pod and wedges the rollout. **And do not repoint before the C-1 live-pod check below.**

## Typecheck / lint (honest)

- **Lint** (`eslint`): **clean** (0 errors) for all changed files including this pass's `warmup.ts` + `warmup.test.ts`. The worktree's own eslint is broken (circular `.eslintrc.js` config under `eslint@8.57.1`), so eslint was run via the main civitai clone (`eslint@8.22.0`) by copying the changed files in, linting, then restoring the clone to a verified-clean `git status` — same workaround as the prior passes. `warmup.ts` → **0** problems. `warmup.test.ts` hits the **same** `parserOptions.project`/tsconfig-include parsing error as **every existing committed `src/server/__tests__/*.test.ts`** (e.g. `eventloop-longtask.test.ts`) — a pre-existing env quirk (test files aren't in the lint tsconfig project), **not** a defect in the new test.
- **Typecheck** (`tsc --noEmit`): the changed files produce **zero** errors. Full-tree `tsc` was run; filtering strictly to `src/server/warmup.ts` and `src/server/__tests__/warmup.test.ts` yields **0** errors in both. `AbortSignal.timeout` resolves (DOM lib is in `tsconfig.lib`). The only full-tree errors are the pre-existing `.prisma/client` Prisma-404 degradation (local NixOS env fails Prisma client generation) — byte-identical on baseline, unrelated to this change.

## OPEN runtime-verification items (need a live pod — NOT proven statically)

1. **C-1: `/api/ready` returns 200 on a warmed pod.** That the globalThis-pinned warm flip in the instrumentation graph is observed by `/api/ready` in the request graph is reasoned from the metrics-pin precedent, **not** observed. **MUST verify on a running pod before repointing any probe** (`/api/ready` 503→200 after warm; `[warmup] complete … state=warmed-ok` log).
2. **C1 (1st audit): warm tRPC returns 200 + heavy path executes** (`[warmup] warmed … lastStatus=200`, resolver in traces/DB).
3. **H-2: real backend pulse.** That a ~75-pod fleet's first heavy warm read is meaningfully smeared by the 10s initial jitter (and doesn't pulse the DB-replica/Meili) is unmeasured — validate on a **canary** rollout before fleet-wide enable.
4. **Whether 1 iteration meaningfully JIT-warms** vs 3 — needs a real-pod first-request-latency before/after.
5. **Probe-flip + 5xx-flat on rollout** — unverified until the follow-up manifest change lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

