### PR TITLE
feat(markdown): Discord-style local timestamps (<t:UNIX:STYLE>)

### DIFF
--- a/src/components/Announcements/Announcement.tsx
+++ b/src/components/Announcements/Announcement.tsx
@@ -70,7 +70,7 @@ export function Announcement({
           <Title order={4}>{announcement.title}</Title>
           {moderatorActions}
         </div>
-        <CustomMarkdown allowedElements={['a']} unwrapDisallowed>
+        <CustomMarkdown allowedElements={['a', 'time']} unwrapDisallowed>
           {announcement.content}
         </CustomMarkdown>
         {actions && (

--- a/src/components/Announcements/Announcement.tsx
+++ b/src/components/Announcements/Announcement.tsx
@@ -70,7 +70,7 @@ export function Announcement({
           <Title order={4}>{announcement.title}</Title>
           {moderatorActions}
         </div>
-        <CustomMarkdown allowedElements={['a', 'time']} unwrapDisallowed>
+        <CustomMarkdown allowedElements={['a']} unwrapDisallowed>
           {announcement.content}
         </CustomMarkdown>
         {actions && (

--- a/src/components/Article/ArticleUpsertForm.tsx
+++ b/src/components/Article/ArticleUpsertForm.tsx
@@ -316,6 +316,7 @@ export function ArticleUpsertForm({ article }: Props) {
                 'video',
                 'polls',
                 'colors',
+                'timestamp',
               ]}
               withAsterisk
               stickyToolbar

--- a/src/components/Changelog/Changelogs.tsx
+++ b/src/components/Changelog/Changelogs.tsx
@@ -448,7 +448,15 @@ const CreateChangelog = ({
                 name="content"
                 label="Content"
                 editorSize="xl"
-                includeControls={['heading', 'formatting', 'list', 'link', 'media', 'colors']} // mentions, polls
+                includeControls={[
+                  'heading',
+                  'formatting',
+                  'list',
+                  'link',
+                  'media',
+                  'colors',
+                  'timestamp',
+                ]} // mentions, polls
                 withAsterisk
                 stickyToolbar
               />

--- a/src/components/LocalTimestamp/LocalTimestamp.tsx
+++ b/src/components/LocalTimestamp/LocalTimestamp.tsx
@@ -1,7 +1,11 @@
 import { Tooltip } from '@mantine/core';
 import { useEffect, useState } from 'react';
 import type { DiscordTimestampStyle } from '~/utils/timestamp-helpers';
-import { formatDiscordTimestamp, normalizeTimestampStyle } from '~/utils/timestamp-helpers';
+import {
+  formatDiscordTimestamp,
+  normalizeTimestampStyle,
+  unixSecondsToISO,
+} from '~/utils/timestamp-helpers';
 
 type Props = {
   /** Unix timestamp in seconds. */
@@ -37,7 +41,7 @@ export function LocalTimestamp({ value, style, className }: Props) {
 
   const display = formatDiscordTimestamp(seconds, resolvedStyle, { utc: !mounted });
   const fullLabel = formatDiscordTimestamp(seconds, 'F', { utc: !mounted });
-  const iso = new Date(seconds * 1000).toISOString();
+  const iso = unixSecondsToISO(seconds);
 
   return (
     <Tooltip label={fullLabel} withArrow withinPortal>

--- a/src/components/LocalTimestamp/LocalTimestamp.tsx
+++ b/src/components/LocalTimestamp/LocalTimestamp.tsx
@@ -23,6 +23,16 @@ export function LocalTimestamp({ value, style, className }: Props) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
+  // The relative style (`R`) is the only one that drifts over time, so tick it
+  // every 15s (matching DaysFromNow) to keep "in 2 hours" / "5 minutes ago"
+  // fresh. Other styles are static and set no timer.
+  const [, tick] = useState(0);
+  useEffect(() => {
+    if (resolvedStyle !== 'R') return;
+    const id = setInterval(() => tick((n) => n + 1), 15_000);
+    return () => clearInterval(id);
+  }, [resolvedStyle]);
+
   if (!Number.isFinite(seconds)) return null;
 
   const display = formatDiscordTimestamp(seconds, resolvedStyle, { utc: !mounted });

--- a/src/components/LocalTimestamp/LocalTimestamp.tsx
+++ b/src/components/LocalTimestamp/LocalTimestamp.tsx
@@ -1,0 +1,58 @@
+import { Tooltip } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import type { DiscordTimestampStyle } from '~/utils/timestamp-helpers';
+import {
+  DEFAULT_TIMESTAMP_STYLE,
+  formatDiscordTimestamp,
+  normalizeTimestampStyle,
+} from '~/utils/timestamp-helpers';
+
+type Props = {
+  /** Unix timestamp in seconds. */
+  value: number | string;
+  style?: DiscordTimestampStyle | string;
+  className?: string;
+};
+
+/**
+ * Renders a Discord-style `<t:UNIX:STYLE>` timestamp in the viewer's local
+ * timezone. To avoid hydration mismatches, the first render (server + client)
+ * uses a timezone-stable UTC string; after mount we swap to the visitor's
+ * local time. A tooltip always shows the full local date/time on hover.
+ */
+export function LocalTimestamp({ value, style, className }: Props) {
+  const seconds = typeof value === 'string' ? parseInt(value, 10) : value;
+  const resolvedStyle: DiscordTimestampStyle = normalizeTimestampStyle(style);
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!Number.isFinite(seconds)) return null;
+
+  const display = formatDiscordTimestamp(seconds, resolvedStyle, { utc: !mounted });
+  const fullLabel = formatDiscordTimestamp(seconds, 'F', { utc: !mounted });
+  const iso = new Date(seconds * 1000).toISOString();
+
+  return (
+    <Tooltip label={fullLabel} withArrow withinPortal>
+      <time
+        dateTime={iso}
+        data-type="timestamp"
+        data-value={seconds}
+        data-style={resolvedStyle}
+        suppressHydrationWarning
+        className={className}
+        style={{
+          backgroundColor: 'var(--mantine-color-blue-light)',
+          borderRadius: 4,
+          padding: '0 4px',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {display}
+      </time>
+    </Tooltip>
+  );
+}
+
+LocalTimestamp.defaultStyle = DEFAULT_TIMESTAMP_STYLE;

--- a/src/components/LocalTimestamp/LocalTimestamp.tsx
+++ b/src/components/LocalTimestamp/LocalTimestamp.tsx
@@ -1,11 +1,7 @@
 import { Tooltip } from '@mantine/core';
 import { useEffect, useState } from 'react';
 import type { DiscordTimestampStyle } from '~/utils/timestamp-helpers';
-import {
-  DEFAULT_TIMESTAMP_STYLE,
-  formatDiscordTimestamp,
-  normalizeTimestampStyle,
-} from '~/utils/timestamp-helpers';
+import { formatDiscordTimestamp, normalizeTimestampStyle } from '~/utils/timestamp-helpers';
 
 type Props = {
   /** Unix timestamp in seconds. */
@@ -54,5 +50,3 @@ export function LocalTimestamp({ value, style, className }: Props) {
     </Tooltip>
   );
 }
-
-LocalTimestamp.defaultStyle = DEFAULT_TIMESTAMP_STYLE;

--- a/src/components/Markdown/CustomMarkdown.tsx
+++ b/src/components/Markdown/CustomMarkdown.tsx
@@ -4,6 +4,8 @@ import ReactMarkdown from 'react-markdown';
 import type { Options } from 'react-markdown';
 import clsx from 'clsx';
 import ContentErrorBoundary from '~/components/ErrorBoundary/ContentErrorBoundary';
+import { LocalTimestamp } from '~/components/LocalTimestamp/LocalTimestamp';
+import { remarkTimestamp } from '~/components/Markdown/remark-timestamp';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 
 type CustomOptions = Options & {
@@ -19,12 +21,27 @@ export function CustomMarkdown({
   allowExternalVideo,
   components,
   className,
+  remarkPlugins,
   ...options
 }: CustomOptions) {
   const user = useCurrentUser();
 
+  // Discord-style `<t:UNIX:STYLE>` timestamp support is available in every
+  // markdown surface. Caller-provided remark plugins still run alongside it.
+  const mergedRemarkPlugins = [remarkTimestamp, ...(remarkPlugins ?? [])];
+
   const mergedComponents: Options['components'] = {
     ...components,
+    time: ({ node, ...props }) => {
+      const properties = (node?.properties ?? {}) as Record<string, unknown>;
+      if (properties.dataType !== 'timestamp') return <time {...props}>{props.children}</time>;
+      return (
+        <LocalTimestamp
+          value={String(properties.dataValue ?? '')}
+          style={properties.dataStyle as string | undefined}
+        />
+      );
+    },
     a: ({ node, href, ...props }) => {
       if (!href) return <a {...props}>{props.children}</a>;
       if (
@@ -85,6 +102,7 @@ export function CustomMarkdown({
     <ContentErrorBoundary>
       <ReactMarkdown
         {...options}
+        remarkPlugins={mergedRemarkPlugins}
         className={clsx(className, 'markdown-content')}
         components={mergedComponents}
       />

--- a/src/components/Markdown/CustomMarkdown.tsx
+++ b/src/components/Markdown/CustomMarkdown.tsx
@@ -31,13 +31,17 @@ export function CustomMarkdown({
   // markdown surface. Caller-provided remark plugins still run alongside it.
   const mergedRemarkPlugins = [remarkTimestamp, ...(remarkPlugins ?? [])];
 
-  // Many callers restrict `allowedElements` (e.g. `['a']`); with `unwrapDisallowed`
-  // that would strip the rendered `<time>` element and fall back to its raw UTC
-  // text. Always permit `time` so timestamps render in local time everywhere.
-  // When no allowlist is set, everything is allowed already, so leave it undefined.
-  const mergedAllowedElements = allowedElements
-    ? Array.from(new Set([...allowedElements, 'time']))
-    : undefined;
+  // Many callers restrict `allowedElements` (e.g. `['a']`), which drops the
+  // rendered `<time>` element (keeping only its raw UTC fallback text). Always
+  // permit `time` so timestamps render in local time everywhere. When no
+  // allowlist is set, everything is allowed already, so leave it undefined.
+  // react-markdown forbids passing both `allowedElements` and
+  // `disallowedElements`, so only set ours when the caller didn't opt into a
+  // denylist instead.
+  const mergedAllowedElements =
+    allowedElements && !options.disallowedElements
+      ? Array.from(new Set([...allowedElements, 'time']))
+      : undefined;
 
   const mergedComponents: Options['components'] = {
     ...components,

--- a/src/components/Markdown/CustomMarkdown.tsx
+++ b/src/components/Markdown/CustomMarkdown.tsx
@@ -22,6 +22,7 @@ export function CustomMarkdown({
   components,
   className,
   remarkPlugins,
+  allowedElements,
   ...options
 }: CustomOptions) {
   const user = useCurrentUser();
@@ -29,6 +30,14 @@ export function CustomMarkdown({
   // Discord-style `<t:UNIX:STYLE>` timestamp support is available in every
   // markdown surface. Caller-provided remark plugins still run alongside it.
   const mergedRemarkPlugins = [remarkTimestamp, ...(remarkPlugins ?? [])];
+
+  // Many callers restrict `allowedElements` (e.g. `['a']`); with `unwrapDisallowed`
+  // that would strip the rendered `<time>` element and fall back to its raw UTC
+  // text. Always permit `time` so timestamps render in local time everywhere.
+  // When no allowlist is set, everything is allowed already, so leave it undefined.
+  const mergedAllowedElements = allowedElements
+    ? Array.from(new Set([...allowedElements, 'time']))
+    : undefined;
 
   const mergedComponents: Options['components'] = {
     ...components,
@@ -103,6 +112,7 @@ export function CustomMarkdown({
       <ReactMarkdown
         {...options}
         remarkPlugins={mergedRemarkPlugins}
+        allowedElements={mergedAllowedElements}
         className={clsx(className, 'markdown-content')}
         components={mergedComponents}
       />

--- a/src/components/Markdown/remark-timestamp.ts
+++ b/src/components/Markdown/remark-timestamp.ts
@@ -1,0 +1,89 @@
+import {
+  DISCORD_TIMESTAMP_REGEX,
+  formatDiscordTimestamp,
+  normalizeTimestampStyle,
+} from '~/utils/timestamp-helpers';
+
+/**
+ * remark plugin that turns Discord-style `<t:UNIX:STYLE>` tags into a custom
+ * mdast node which remark-rehype emits as a `<time data-type="timestamp">`
+ * element. The element carries the raw unix/style values as data attributes so
+ * the React `time` component override (and the RenderHtml hydrator) can render
+ * the viewer's local time. A UTC fallback string is kept as the child text so
+ * non-component consumers still show a readable date.
+ *
+ * `<t:...>` is not valid inline HTML or an autolink in CommonMark, so remark
+ * leaves it inside text nodes for us to split here.
+ */
+export function remarkTimestamp() {
+  return (tree: any) => {
+    visit(tree, (node, index, parent) => {
+      if (node.type !== 'text' || !parent || typeof index !== 'number') return;
+      const value: string = node.value ?? '';
+      if (!value.includes('<t:')) return;
+
+      const regex = new RegExp(DISCORD_TIMESTAMP_REGEX.source, 'g');
+      const replacements: any[] = [];
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = regex.exec(value)) !== null) {
+        const [raw, secondsRaw, styleRaw] = match;
+        const seconds = parseInt(secondsRaw, 10);
+        if (!Number.isFinite(seconds)) continue;
+
+        if (match.index > lastIndex) {
+          replacements.push({ type: 'text', value: value.slice(lastIndex, match.index) });
+        }
+
+        const style = normalizeTimestampStyle(styleRaw);
+        const fallback = formatDiscordTimestamp(seconds, style, { utc: true });
+
+        replacements.push({
+          type: 'timestamp',
+          data: {
+            hName: 'time',
+            hProperties: {
+              dataType: 'timestamp',
+              dataValue: String(seconds),
+              dataStyle: style,
+              dateTime: new Date(seconds * 1000).toISOString(),
+            },
+            hChildren: [{ type: 'text', value: fallback }],
+          },
+        });
+
+        lastIndex = match.index + raw.length;
+      }
+
+      if (!replacements.length) return;
+      if (lastIndex < value.length) {
+        replacements.push({ type: 'text', value: value.slice(lastIndex) });
+      }
+
+      parent.children.splice(index, 1, ...replacements);
+      return index + replacements.length;
+    });
+  };
+}
+
+/** Minimal mdast walker (avoids adding a unist-util-visit dependency). */
+function visit(
+  node: any,
+  visitor: (node: any, index: number | null, parent: any | null) => number | void,
+  index: number | null = null,
+  parent: any | null = null
+): number | void {
+  const result = visitor(node, index, parent);
+  // When the visitor splices replacements in, it returns the next index to
+  // resume from so we don't re-scan freshly inserted nodes.
+  if (typeof result === 'number') return result;
+  const children = node?.children;
+  if (Array.isArray(children)) {
+    let i = 0;
+    while (i < children.length) {
+      const next = visit(children[i], visitor, i, node);
+      i = typeof next === 'number' ? next : i + 1;
+    }
+  }
+}

--- a/src/components/Markdown/remark-timestamp.ts
+++ b/src/components/Markdown/remark-timestamp.ts
@@ -2,6 +2,7 @@ import {
   DISCORD_TIMESTAMP_REGEX,
   formatDiscordTimestamp,
   normalizeTimestampStyle,
+  unixSecondsToISO,
 } from '~/utils/timestamp-helpers';
 
 /**
@@ -47,7 +48,7 @@ export function remarkTimestamp() {
               dataType: 'timestamp',
               dataValue: String(seconds),
               dataStyle: style,
-              dateTime: new Date(seconds * 1000).toISOString(),
+              dateTime: unixSecondsToISO(seconds),
             },
             hChildren: [{ type: 'text', value: fallback }],
           },

--- a/src/components/RenderHtml/RenderHtml.tsx
+++ b/src/components/RenderHtml/RenderHtml.tsx
@@ -1,6 +1,7 @@
 import type { TypographyStylesProviderProps } from '@mantine/core';
 import { useComputedColorScheme, lighten, darken } from '@mantine/core';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import { formatDiscordTimestamp, normalizeTimestampStyle } from '~/utils/timestamp-helpers';
 
 import { useThirdPartyConsent } from '~/components/Consent/consent.context';
 import { needsColorSwap } from '~/utils/html-helpers';
@@ -43,6 +44,7 @@ export function RenderHtml({
   const colorScheme = useComputedColorScheme('dark');
   const blurNsfw = useBrowsingSettings((state) => state.blurNsfw);
   const { allowed: thirdPartyAllowed } = useThirdPartyConsent();
+  const contentRef = useRef<HTMLDivElement>(null);
 
   html = useMemo(() => {
     let processedHtml = html;
@@ -190,9 +192,25 @@ export function RenderHtml({
     thirdPartyAllowed,
   ]);
 
+  // RenderHtml injects a raw HTML string, so Discord-style `<t:...>` timestamps
+  // arrive as `<time data-type="timestamp">` elements carrying a UTC fallback.
+  // Rewrite them to the viewer's local time once mounted on the client.
+  useEffect(() => {
+    const container = contentRef.current;
+    if (!container) return;
+    const nodes = container.querySelectorAll<HTMLTimeElement>('time[data-type="timestamp"]');
+    nodes.forEach((node) => {
+      const seconds = parseInt(node.getAttribute('data-value') ?? '', 10);
+      if (!Number.isFinite(seconds)) return;
+      const style = normalizeTimestampStyle(node.getAttribute('data-style'));
+      node.textContent = formatDiscordTimestamp(seconds, style);
+      node.title = formatDiscordTimestamp(seconds, 'F');
+    });
+  }, [html]);
+
   return (
     <TypographyStylesWrapper {...props} className={clsx(classes.htmlRenderer, className)}>
-      <div dangerouslySetInnerHTML={{ __html: html }} />
+      <div ref={contentRef} dangerouslySetInnerHTML={{ __html: html }} />
     </TypographyStylesWrapper>
   );
 }

--- a/src/components/RichTextEditor/InsertTimestampControl.tsx
+++ b/src/components/RichTextEditor/InsertTimestampControl.tsx
@@ -1,0 +1,108 @@
+import { Button, Group, Modal, Select, Stack, Text } from '@mantine/core';
+import { DateTimePicker } from '@mantine/dates';
+import type { RichTextEditorControlProps } from '@mantine/tiptap';
+import { RichTextEditor, useRichTextEditorContext } from '@mantine/tiptap';
+import { IconClockHour4 } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import type { Editor } from '@tiptap/react';
+import { dialogStore } from '~/components/Dialog/dialogStore';
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import type { DiscordTimestampStyle } from '~/utils/timestamp-helpers';
+import {
+  DEFAULT_TIMESTAMP_STYLE,
+  DISCORD_TIMESTAMP_STYLES,
+  formatDiscordTimestamp,
+} from '~/utils/timestamp-helpers';
+
+const controlTitle = 'Insert local timestamp';
+
+const STYLE_LABELS: Record<DiscordTimestampStyle, string> = {
+  t: 'Short time',
+  T: 'Long time',
+  d: 'Short date',
+  D: 'Long date',
+  f: 'Short date/time',
+  F: 'Long date/time',
+  R: 'Relative',
+};
+
+export function InsertTimestampControl(props: Props) {
+  const { editor } = useRichTextEditorContext();
+
+  const handleClick = () => {
+    dialogStore.trigger({
+      component: InsertTimestampModal,
+      props: { editor },
+    });
+  };
+
+  return (
+    <RichTextEditor.Control
+      {...props}
+      onClick={handleClick}
+      aria-label={controlTitle}
+      title={controlTitle}
+    >
+      <IconClockHour4 size={16} stroke={1.5} />
+    </RichTextEditor.Control>
+  );
+}
+
+type Props = Omit<RichTextEditorControlProps, 'icon' | 'onClick'>;
+
+function InsertTimestampModal({ editor }: { editor: Editor | null }) {
+  const dialog = useDialogContext();
+  const [date, setDate] = useState<Date>(() => new Date());
+  const [style, setStyle] = useState<DiscordTimestampStyle>(DEFAULT_TIMESTAMP_STYLE);
+
+  const styleOptions = useMemo(
+    () =>
+      DISCORD_TIMESTAMP_STYLES.map((value) => ({
+        value,
+        label: `${STYLE_LABELS[value]} — ${formatDiscordTimestamp(
+          Math.floor(date.getTime() / 1000),
+          value
+        )}`,
+      })),
+    [date]
+  );
+
+  const handleInsert = () => {
+    if (editor && date) {
+      editor.commands.setTimestamp({ value: Math.floor(date.getTime() / 1000), style });
+    }
+    dialog.onClose();
+  };
+
+  return (
+    <Modal title={controlTitle} {...dialog}>
+      <Stack>
+        <Text size="sm" c="dimmed">
+          Pick a moment and it renders in each viewer&apos;s local timezone.
+        </Text>
+        <DateTimePicker
+          label="Date & time (your local time)"
+          value={date}
+          onChange={(value) => value && setDate(new Date(value))}
+          popoverProps={{ withinPortal: true }}
+          clearable={false}
+        />
+        <Select
+          label="Format"
+          data={styleOptions}
+          value={style}
+          onChange={(value) => value && setStyle(value as DiscordTimestampStyle)}
+          comboboxProps={{ withinPortal: true }}
+        />
+        <Group justify="flex-end" mt="sm">
+          <Button variant="default" onClick={() => dialog.onClose()}>
+            Cancel
+          </Button>
+          <Button onClick={handleInsert} disabled={!date || !editor}>
+            Insert
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/RichTextEditor/RenderRichText.tsx
+++ b/src/components/RichTextEditor/RenderRichText.tsx
@@ -15,6 +15,8 @@ import { MentionNode } from '~/components/TipTap/MentionNode';
 import { InstagramNode } from '~/components/TipTap/InstagramNode';
 import { StrawPollNode } from '~/components/TipTap/StrawPollNode';
 import { CustomYoutubeNode } from '~/shared/tiptap/custom-youtube-node';
+import { TimestampNode } from '~/shared/tiptap/timestamp.node';
+import { LocalTimestamp } from '~/components/LocalTimestamp/LocalTimestamp';
 
 const extensions = [
   StarterKit.configure({ heading: false }),
@@ -26,6 +28,7 @@ const extensions = [
   InstagramNode,
   MentionNode,
   StrawPollNode,
+  TimestampNode,
 ];
 
 export function RenderRichText({ content }: { content: Record<string, any> }) {
@@ -37,6 +40,9 @@ export function RenderRichText({ content }: { content: Record<string, any> }) {
       options: {
         nodeMapping: {
           media: ({ node }) => <EdgeMediaComponent {...(node.attrs as any)} />,
+          timestamp: ({ node }) => (
+            <LocalTimestamp value={node.attrs.value} style={node.attrs.style} />
+          ),
           // For unconsented CA visitors, replace third-party embed nodes with a
           // placeholder so the iframe is never inserted in the DOM.
           ...(!allowed && {

--- a/src/components/RichTextEditor/RichTextEditorComponent.tsx
+++ b/src/components/RichTextEditor/RichTextEditorComponent.tsx
@@ -30,6 +30,8 @@ import { StrawPollNode } from '~/components/TipTap/StrawPollNode';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import { CustomImage } from '~/libs/tiptap/extensions/CustomImage';
 import { CustomYoutubeNode } from '~/shared/tiptap/custom-youtube-node';
+import { TimestampEditNode } from '~/components/TipTap/TimestampNode';
+import { InsertTimestampControl } from '~/components/RichTextEditor/InsertTimestampControl';
 
 // const mapEditorSizeHeight: Omit<Record<MantineSize, string>, 'xs'> = {
 //   sm: '30px',
@@ -135,6 +137,7 @@ export function RichTextEditor({
   const addMedia = addImages || addVideo;
   const addMentions = includeControls.includes('mentions');
   const addPolls = includeControls.includes('polls');
+  const addTimestamp = includeControls.includes('timestamp');
 
   const accepts = useMemo(() => {
     const accepts: MediaType[] = [];
@@ -208,6 +211,9 @@ export function RichTextEditor({
     if (addMentions)
       arr.push(MentionNode.configure({ suggestion: getSuggestions({ defaultSuggestions }) }));
     if (addPolls) arr.push(StrawPollNode);
+    // Always register the timestamp node so pasting/typing `<t:...>` converts
+    // anywhere; the toolbar insert button is gated by the `timestamp` control.
+    arr.push(TimestampEditNode);
 
     return arr;
   }, [
@@ -365,6 +371,11 @@ export function RichTextEditor({
                 <InsertStrawPollControl />
               </RTE.ControlsGroup>
             )}
+            {addTimestamp && (
+              <RTE.ControlsGroup>
+                <InsertTimestampControl />
+              </RTE.ControlsGroup>
+            )}
           </RTE.Toolbar>
         )}
 
@@ -415,7 +426,8 @@ type ControlType =
   | 'video'
   | 'mentions'
   | 'polls'
-  | 'colors';
+  | 'colors'
+  | 'timestamp';
 export type Props = Omit<RichTextEditorProps, 'editor' | 'children' | 'onChange'> &
   Pick<InputWrapperProps, 'label' | 'labelProps' | 'description' | 'withAsterisk' | 'error'> & {
     value?: string;

--- a/src/components/TipTap/TimestampNode.tsx
+++ b/src/components/TipTap/TimestampNode.tsx
@@ -1,0 +1,24 @@
+import type { ReactNodeViewProps } from '@tiptap/react';
+import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
+import { LocalTimestamp } from '~/components/LocalTimestamp/LocalTimestamp';
+import { TimestampNode } from '~/shared/tiptap/timestamp.node';
+
+/**
+ * Editor-side timestamp node: same schema as the shared `TimestampNode`, but
+ * with a React node view so authors see the rendered local time (as a chip)
+ * while editing instead of the raw `<t:...>` tag.
+ */
+export const TimestampEditNode = TimestampNode.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(TimestampEditComponent);
+  },
+});
+
+function TimestampEditComponent({ node }: ReactNodeViewProps<HTMLSpanElement>) {
+  const { value, style } = node.attrs as { value: string; style: string };
+  return (
+    <NodeViewWrapper as="span" data-drag-handle style={{ display: 'inline' }}>
+      <LocalTimestamp value={value} style={style} />
+    </NodeViewWrapper>
+  );
+}

--- a/src/shared/tiptap/extensions.ts
+++ b/src/shared/tiptap/extensions.ts
@@ -7,6 +7,7 @@ import { Instagram } from '~/libs/tiptap/extensions/Instagram';
 import { StrawPoll } from '~/libs/tiptap/extensions/StrawPoll';
 import { EdgeMediaNode } from '~/shared/tiptap/edge-media.node';
 import { CustomYoutubeNode } from '~/shared/tiptap/custom-youtube-node';
+import { TimestampNode } from '~/shared/tiptap/timestamp.node';
 
 export const tiptapExtensions = [
   StarterKit.configure({ heading: false }),
@@ -18,4 +19,5 @@ export const tiptapExtensions = [
   Instagram,
   Mention,
   StrawPoll,
+  TimestampNode,
 ];

--- a/src/shared/tiptap/timestamp.node.ts
+++ b/src/shared/tiptap/timestamp.node.ts
@@ -1,4 +1,4 @@
-import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import { InputRule, mergeAttributes, Node, nodePasteRule } from '@tiptap/core';
 import {
   DEFAULT_TIMESTAMP_STYLE,
   formatDiscordTimestamp,
@@ -92,14 +92,20 @@ export const TimestampNode = Node.create({
   },
 
   addInputRules() {
+    // NB: tiptap's `nodeInputRule` offsets the replacement to the first capture
+    // group, so it would only swap the digits and leave the surrounding `<t:`
+    // and `:t>` behind. Use a plain InputRule that replaces the whole match.
+    const type = this.type;
     return [
-      nodeInputRule({
+      new InputRule({
         find: inputRegex,
-        type: this.type,
-        getAttributes: (match) => ({
-          value: match[1],
-          style: normalizeTimestampStyle(match[2]),
-        }),
+        handler: ({ state, range, match }) => {
+          state.tr.replaceWith(
+            range.from,
+            range.to,
+            type.create({ value: match[1], style: normalizeTimestampStyle(match[2]) })
+          );
+        },
       }),
     ];
   },

--- a/src/shared/tiptap/timestamp.node.ts
+++ b/src/shared/tiptap/timestamp.node.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TIMESTAMP_STYLE,
   formatDiscordTimestamp,
   normalizeTimestampStyle,
+  unixSecondsToISO,
 } from '~/utils/timestamp-helpers';
 
 export interface TimestampAttributes {
@@ -21,8 +22,8 @@ declare module '@tiptap/core' {
 
 // Anchored variant for input rules (fires as the closing `>` is typed) and a
 // global variant for paste rules.
-const inputRegex = /<t:(-?\d{1,14})(?::([tTdDfFR]))?>$/;
-const pasteRegex = /<t:(-?\d{1,14})(?::([tTdDfFR]))?>/g;
+const inputRegex = /<t:(-?\d{1,12})(?::([tTdDfFR]))?>$/;
+const pasteRegex = /<t:(-?\d{1,12})(?::([tTdDfFR]))?>/g;
 
 /**
  * Tiptap node for Discord-style `<t:UNIX:STYLE>` timestamps. It serializes to a
@@ -63,7 +64,7 @@ export const TimestampNode = Node.create({
     const fallback = Number.isFinite(seconds)
       ? formatDiscordTimestamp(seconds, style, { utc: true })
       : '';
-    const dateTime = Number.isFinite(seconds) ? new Date(seconds * 1000).toISOString() : undefined;
+    const dateTime = unixSecondsToISO(seconds);
     return [
       'time',
       mergeAttributes(HTMLAttributes, { 'data-type': 'timestamp', datetime: dateTime }),

--- a/src/shared/tiptap/timestamp.node.ts
+++ b/src/shared/tiptap/timestamp.node.ts
@@ -1,0 +1,119 @@
+import { mergeAttributes, Node, nodeInputRule, nodePasteRule } from '@tiptap/core';
+import {
+  DEFAULT_TIMESTAMP_STYLE,
+  formatDiscordTimestamp,
+  normalizeTimestampStyle,
+} from '~/utils/timestamp-helpers';
+
+export interface TimestampAttributes {
+  value: string;
+  style: string;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    timestamp: {
+      /** Insert a Discord-style local timestamp at the current selection. */
+      setTimestamp: (attributes: { value: number | string; style?: string }) => ReturnType;
+    };
+  }
+}
+
+// Anchored variant for input rules (fires as the closing `>` is typed) and a
+// global variant for paste rules.
+const inputRegex = /<t:(-?\d{1,14})(?::([tTdDfFR]))?>$/;
+const pasteRegex = /<t:(-?\d{1,14})(?::([tTdDfFR]))?>/g;
+
+/**
+ * Tiptap node for Discord-style `<t:UNIX:STYLE>` timestamps. It serializes to a
+ * `<time data-type="timestamp">` element so it round-trips through stored HTML
+ * and the sanitizer, and renders in the viewer's local time (via the React
+ * node view in the editor, the static-renderer node mapping when viewing
+ * articles, or the RenderHtml hydrator for raw-HTML surfaces).
+ */
+export const TimestampNode = Node.create({
+  name: 'timestamp',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      value: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-value'),
+        renderHTML: (attributes) => ({ 'data-value': attributes.value }),
+      },
+      style: {
+        default: DEFAULT_TIMESTAMP_STYLE,
+        parseHTML: (element) => normalizeTimestampStyle(element.getAttribute('data-style')),
+        renderHTML: (attributes) => ({ 'data-style': normalizeTimestampStyle(attributes.style) }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'time[data-type="timestamp"]' }];
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    const seconds = parseInt(node.attrs.value, 10);
+    const style = normalizeTimestampStyle(node.attrs.style);
+    const fallback = Number.isFinite(seconds)
+      ? formatDiscordTimestamp(seconds, style, { utc: true })
+      : '';
+    const dateTime = Number.isFinite(seconds) ? new Date(seconds * 1000).toISOString() : undefined;
+    return [
+      'time',
+      mergeAttributes(HTMLAttributes, { 'data-type': 'timestamp', datetime: dateTime }),
+      fallback,
+    ];
+  },
+
+  renderText({ node }) {
+    const style = normalizeTimestampStyle(node.attrs.style);
+    return `<t:${node.attrs.value}:${style}>`;
+  },
+
+  addCommands() {
+    return {
+      setTimestamp:
+        (attributes) =>
+        ({ commands }) =>
+          commands.insertContent({
+            type: this.name,
+            attrs: {
+              value: String(attributes.value),
+              style: normalizeTimestampStyle(attributes.style),
+            },
+          }),
+    };
+  },
+
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: inputRegex,
+        type: this.type,
+        getAttributes: (match) => ({
+          value: match[1],
+          style: normalizeTimestampStyle(match[2]),
+        }),
+      }),
+    ];
+  },
+
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: pasteRegex,
+        type: this.type,
+        getAttributes: (match) => ({
+          value: match[1],
+          style: normalizeTimestampStyle(match[2]),
+        }),
+      }),
+    ];
+  },
+});

--- a/src/utils/html-sanitize-helpers.ts
+++ b/src/utils/html-sanitize-helpers.ts
@@ -23,6 +23,7 @@ const DEFAULT_ALLOWED_TAGS = [
   'h2',
   'h3',
   'hr',
+  'time',
   'edge-media',
 ];
 
@@ -53,6 +54,7 @@ export const DEFAULT_ALLOWED_ATTRIBUTES = {
   ],
   div: ['data-youtube-video', 'data-type'],
   span: ['class', 'data-type', 'data-id', 'data-label', 'style'],
+  time: ['datetime', 'data-type', 'data-value', 'data-style'],
   '*': ['id'],
   'edge-media': ['url', 'type', 'filename', 'className'],
 };

--- a/src/utils/timestamp-helpers.ts
+++ b/src/utils/timestamp-helpers.ts
@@ -33,8 +33,10 @@ const STYLE_FORMAT: Record<Exclude<DiscordTimestampStyle, 'R'>, string> = {
 };
 
 // Global (with /g) for scanning, anchored variants built where needed. Unix
-// seconds: 1-14 digits, optional leading minus for pre-epoch dates.
-export const DISCORD_TIMESTAMP_REGEX = /<t:(-?\d{1,14})(?::([tTdDfFR]))?>/g;
+// seconds: 1-12 digits, optional leading minus for pre-epoch dates. 12 digits
+// keeps `seconds * 1000` inside JS's valid Date range (±8.64e15 ms), so a tag
+// can never produce an out-of-range date that throws in `new Date().toISOString()`.
+export const DISCORD_TIMESTAMP_REGEX = /<t:(-?\d{1,12})(?::([tTdDfFR]))?>/g;
 
 export function isDiscordTimestampStyle(value: unknown): value is DiscordTimestampStyle {
   return (
@@ -60,4 +62,16 @@ export function formatDiscordTimestamp(
   const base = opts.utc ? dayjs.utc(seconds * 1000) : dayjs(seconds * 1000);
   if (style === 'R') return base.fromNow();
   return base.format(STYLE_FORMAT[style]);
+}
+
+/**
+ * ISO-8601 string for a unix-seconds value, or `undefined` when the value is
+ * outside JS's valid Date range. Guards `new Date(...).toISOString()`, which
+ * throws a RangeError on out-of-range input — important since the value comes
+ * from user-authored content.
+ */
+export function unixSecondsToISO(seconds: number): string | undefined {
+  if (!Number.isFinite(seconds)) return undefined;
+  const date = new Date(seconds * 1000);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 }

--- a/src/utils/timestamp-helpers.ts
+++ b/src/utils/timestamp-helpers.ts
@@ -61,9 +61,3 @@ export function formatDiscordTimestamp(
   if (style === 'R') return base.fromNow();
   return base.format(STYLE_FORMAT[style]);
 }
-
-/** Build a canonical `<t:UNIX:STYLE>` tag from a date + style. */
-export function buildDiscordTimestampTag(date: Date, style: DiscordTimestampStyle): string {
-  const seconds = Math.floor(date.getTime() / 1000);
-  return `<t:${seconds}:${style}>`;
-}

--- a/src/utils/timestamp-helpers.ts
+++ b/src/utils/timestamp-helpers.ts
@@ -1,0 +1,69 @@
+import dayjs from '~/shared/utils/dayjs';
+
+/**
+ * Discord-style timestamp tags: `<t:UNIX:STYLE>`
+ *
+ * `UNIX` is a Unix timestamp in *seconds* (not milliseconds). `STYLE` is an
+ * optional single-letter format flag. When omitted, Discord defaults to `f`.
+ *
+ * | Flag | Example output                     | dayjs format |
+ * |------|------------------------------------|--------------|
+ * | t    | 9:04 PM                            | LT           |
+ * | T    | 9:04:00 PM                         | LTS          |
+ * | d    | 06/11/2026                         | L            |
+ * | D    | June 11, 2026                      | LL           |
+ * | f    | June 11, 2026 9:04 PM (default)    | LLL          |
+ * | F    | Tuesday, June 11, 2026 9:04 PM     | LLLL         |
+ * | R    | in 2 hours / 5 minutes ago         | fromNow()    |
+ *
+ * The rendered value is always in the *viewer's* local timezone.
+ */
+export const DISCORD_TIMESTAMP_STYLES = ['t', 'T', 'd', 'D', 'f', 'F', 'R'] as const;
+export type DiscordTimestampStyle = (typeof DISCORD_TIMESTAMP_STYLES)[number];
+
+export const DEFAULT_TIMESTAMP_STYLE: DiscordTimestampStyle = 'f';
+
+const STYLE_FORMAT: Record<Exclude<DiscordTimestampStyle, 'R'>, string> = {
+  t: 'LT',
+  T: 'LTS',
+  d: 'L',
+  D: 'LL',
+  f: 'LLL',
+  F: 'LLLL',
+};
+
+// Global (with /g) for scanning, anchored variants built where needed. Unix
+// seconds: 1-14 digits, optional leading minus for pre-epoch dates.
+export const DISCORD_TIMESTAMP_REGEX = /<t:(-?\d{1,14})(?::([tTdDfFR]))?>/g;
+
+export function isDiscordTimestampStyle(value: unknown): value is DiscordTimestampStyle {
+  return (
+    typeof value === 'string' && DISCORD_TIMESTAMP_STYLES.includes(value as DiscordTimestampStyle)
+  );
+}
+
+export function normalizeTimestampStyle(value: unknown): DiscordTimestampStyle {
+  return isDiscordTimestampStyle(value) ? value : DEFAULT_TIMESTAMP_STYLE;
+}
+
+/**
+ * Format a Unix-seconds timestamp using a Discord style flag. Pass `utc: true`
+ * for a timezone-stable string (used for server render / hydration fallback so
+ * the markup matches on both sides before the client swaps to local time).
+ */
+export function formatDiscordTimestamp(
+  seconds: number,
+  style: DiscordTimestampStyle = DEFAULT_TIMESTAMP_STYLE,
+  opts: { utc?: boolean } = {}
+): string {
+  if (!Number.isFinite(seconds)) return '';
+  const base = opts.utc ? dayjs.utc(seconds * 1000) : dayjs(seconds * 1000);
+  if (style === 'R') return base.fromNow();
+  return base.format(STYLE_FORMAT[style]);
+}
+
+/** Build a canonical `<t:UNIX:STYLE>` tag from a date + style. */
+export function buildDiscordTimestampTag(date: Date, style: DiscordTimestampStyle): string {
+  const seconds = Math.floor(date.getTime() / 1000);
+  return `<t:${seconds}:${style}>`;
+}


### PR DESCRIPTION
## What

Adds support for **Discord-style timestamp tags** — `<t:UNIX:STYLE>` — that render in each viewer's **local timezone**. Drop a tag like `<t:1781233440:t>` and everyone sees the time in their own zone (e.g. `9:04 PM`).

Great for announcements, changelogs, and articles where we reference event times ("stream starts `<t:1781233440:f>`", "ends `<t:1781233440:R>`").

## Syntax

`<t:UNIX:STYLE>` — `UNIX` is seconds, `STYLE` is optional (defaults to `f`):

| Flag | Example | Meaning |
|------|---------|---------|
| `t` | 9:04 PM | Short time |
| `T` | 9:04:00 PM | Long time |
| `d` | 06/11/2026 | Short date |
| `D` | June 11, 2026 | Long date |
| `f` | June 11, 2026 9:04 PM | Short date/time (default) |
| `F` | Tuesday, June 11, 2026 9:04 PM | Long date/time |
| `R` | in 2 hours | Relative |

Matches Discord's format exactly, so tags can be copy/pasted between the two.

## Where it works (all three render paths)

1. **Markdown** (announcements, changelog) — a `remarkTimestamp` plugin parses the tag and renders the `LocalTimestamp` component.
2. **Tiptap RTE / articles** — a `timestamp` inline node with:
   - input + paste rules (type or paste `<t:...>` → it converts automatically)
   - a React node view so authors see the live local time while editing
   - a **toolbar button** with a date/time picker + format selector (added to the Article and Changelog editors)
3. **Raw HTML** (`RenderHtml`: comments, model descriptions) — `<time>` whitelisted in the sanitizer, plus a small client hydrator that swaps the UTC fallback to local time.

## Implementation notes

- Shared core: `src/utils/timestamp-helpers.ts` (regex, style→dayjs map, formatter) and `src/components/LocalTimestamp/LocalTimestamp.tsx` (used by every path).
- **No hydration mismatch**: server + first client render emit a timezone-stable UTC string; the component swaps to local time on mount. The stored/serialized markup always carries a readable UTC fallback, so non-JS consumers still see a date.
- Round-trips cleanly through stored article HTML and the sanitizer (`<time data-type="timestamp" data-value data-style>`).

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint` (changed files) ✅
- Prettier ✅

> [!NOTE]
> Not yet visually verified in a running editor/article — happy to spin up the dev server and attach screenshots of the toolbar picker + rendered output before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
