### PR TITLE
test(preview): ride out transient search/cold-pod flakiness

### DIFF
--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -135,4 +135,47 @@ setup('mint preview sessions', async ({ request }) => {
       await request.get(path, { timeout: 60_000, headers }).catch(() => {});
     }
   }
+
+  // Search-readiness gate. The warm-up GETs above only trigger a route compile —
+  // they're fire-and-forget and don't ensure the SEARCH backend is actually
+  // serving. The image-search path (getAllImagesIndex -> the in-cluster feeds-proxy
+  // via METRICS_SEARCH_HOST) is intermittently flaky under concurrent preview-build
+  // load and 5xx's, which is what hard-fails /moderator/images (and the image feed).
+  // So before the suite runs, POLL a representative search-backed request until it
+  // serves 2xx, with real spacing to outlast a transient spike. Non-fatal: if it
+  // never readies we proceed and let the specs report honestly (a sustained search
+  // outage is a real signal, not something to hide). When search is healthy this
+  // returns on the first probe, so it adds ~nothing to a warm run.
+  async function waitForOk(path: string, cookie: string): Promise<boolean> {
+    const attempts = 12;
+    for (let i = 1; i <= attempts; i++) {
+      try {
+        const r = await request.get(path, { timeout: 20_000, headers: { cookie } });
+        if (r.ok()) return true;
+      } catch {
+        // network/timeout — treat as not-ready and keep polling
+      }
+      if (i < attempts) await new Promise((resolve) => setTimeout(resolve, 6_000));
+    }
+    return false;
+  }
+
+  if (gold) {
+    // The exact image-search path the image-feed + /moderator/images depend on
+    // (engagement sort routes through the search index).
+    const ready = await waitForOk(
+      '/api/v1/images?sort=Most%20Reactions&limit=1',
+      `${COOKIE_NAME}=${gold}`
+    );
+    if (!ready) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[preview-setup] image-search path not ready after polling — search-backed specs may flake'
+      );
+    }
+  }
+  if (mod) {
+    // Directly ready the /moderator/images render (mod-only, search-backed).
+    await waitForOk('/moderator/images', `${COOKIE_NAME}=${mod}`);
+  }
 });

--- a/tests/preview-generation.spec.ts
+++ b/tests/preview-generation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { storageStatePath } from './preview-fixtures';
+import { retryFlaky } from './preview-retry';
 
 /**
  * Generation cost-quote e2e for a deployed PR preview.
@@ -45,33 +46,45 @@ test.describe('generation cost quote (gold)', () => {
 
   // 1. Primary, network-based: whatIf fires on /generate load and quotes a cost.
   test('whatIfFromGraph fires on /generate and returns a numeric cost', async ({ page }) => {
-    // Arm the response listener BEFORE navigating so an on-load fire isn't missed.
-    // 45s (was 25s): whatIf is the heaviest client-side flow — page load + hydrate +
-    // form init + resource resolve + orchestrator round-trip must all complete before
-    // it fires. On a CPU-throttled preview pod a slow window pushed this past 25s and
-    // it hard-failed (both attempts). 45s lets a slow window flake-and-recover; the
-    // orchestrator itself is fast (~57ms), so this never approaches 45s when healthy.
-    const whatIfResponse = page.waitForResponse(
-      (r) => r.url().includes(WHATIF_URL) && r.status() === 200,
-      { timeout: 45_000 }
+    // /generate is the heaviest SSR page; on a cold/contended single-replica preview
+    // pod the load+hydrate can exceed the whatIf wait, and Playwright's test-level
+    // retries fire within seconds — too fast to outlast a load spike. Retry the whole
+    // navigate+wait with backoff so a transient spike is ridden out (the assertion
+    // must still pass; a sustained failure surfaces after the attempts). Extend the
+    // per-test timeout to fit ~2 attempts of the 45s wait + navigation + backoff.
+    test.setTimeout(200_000);
+    const { body } = await retryFlaky(
+      'whatIf on /generate',
+      async () => {
+        // Arm the response listener BEFORE navigating so an on-load fire isn't missed.
+        // 45s: whatIf is the heaviest client-side flow — page load + hydrate + form
+        // init + resource resolve + orchestrator round-trip must complete before it
+        // fires. The orchestrator itself is fast (~57ms), so when healthy this never
+        // approaches 45s — the budget is for a cold-pod slow window.
+        const whatIfResponse = page.waitForResponse(
+          (r) => r.url().includes(WHATIF_URL) && r.status() === 200,
+          { timeout: 45_000 }
+        );
+
+        const resp = await page.goto('/generate', { waitUntil: 'domcontentloaded' });
+        expect(resp?.status(), 'HTTP status for /generate').toBeLessThan(400);
+
+        // Gate must not bounce a gold (paid) member.
+        expect(page.url(), 'should not redirect to /login').not.toContain('/login');
+        expect(page.url(), 'should not redirect to /preview-restricted').not.toContain(
+          '/preview-restricted'
+        );
+
+        // NOTE: relies on the default /generate form preselecting a valid model+workflow
+        // so whatIf fires without interaction. If a future default ships with no model
+        // preselected this will time out — see the UI-fallback note below.
+        const response = await whatIfResponse;
+        return { body: await response.json() };
+      },
+      { attempts: 2 }
     );
 
-    const resp = await page.goto('/generate', { waitUntil: 'domcontentloaded' });
-    expect(resp?.status(), 'HTTP status for /generate').toBeLessThan(400);
-
-    // Gate must not bounce a gold (paid) member.
-    expect(page.url(), 'should not redirect to /login').not.toContain('/login');
-    expect(page.url(), 'should not redirect to /preview-restricted').not.toContain(
-      '/preview-restricted'
-    );
-
-    // NOTE: relies on the default /generate form preselecting a valid model+workflow
-    // so whatIf fires without interaction. If a future default ships with no model
-    // preselected this will time out — see the UI-fallback test below for the signal.
-    const response = await whatIfResponse;
-    const body = await response.json();
     const total = extractCostTotal(body);
-
     expect(total, 'cost.total parsed from whatIfFromGraph response').not.toBeNull();
     expect(typeof total, 'cost.total is numeric').toBe('number');
     expect(total as number, 'cost.total is a non-negative quote').toBeGreaterThanOrEqual(0);

--- a/tests/preview-moderation.spec.ts
+++ b/tests/preview-moderation.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { storageStatePath } from './preview-fixtures';
 import { trpcMutation, trpcQuery, uniqueToken } from './preview-trpc';
+import { retryFlaky } from './preview-retry';
 
 /**
  * Moderation-surface tests for a deployed PR preview environment.
@@ -79,8 +80,15 @@ test.describe('moderation surface (mod)', () => {
   });
 
   test('/moderator/images renders the image review queue', async ({ page }) => {
-    const resp = await page.goto('/moderator/images', { waitUntil: 'domcontentloaded' });
-    expect(resp?.status(), 'HTTP status for /moderator/images').toBeLessThan(400);
+    // /moderator/images is image-search-backed (getModeratorReviewQueue ->
+    // getAllImagesIndex -> the in-cluster feeds-proxy), which intermittently 5xx's
+    // under concurrent preview-build load. Retry the navigation with backoff to ride
+    // out a transient search spike — honest: the page must still render < 400, and a
+    // sustained outage still fails after the attempts are exhausted.
+    await retryFlaky('/moderator/images navigation', async () => {
+      const resp = await page.goto('/moderator/images', { waitUntil: 'domcontentloaded' });
+      expect(resp?.status(), 'HTTP status for /moderator/images').toBeLessThan(400);
+    });
     assertGatePassed(page, '/moderator/images');
 
     // images.tsx is an infinite list off trpc.image.getModeratorReviewQueue. It

--- a/tests/preview-retry.ts
+++ b/tests/preview-retry.ts
@@ -1,0 +1,40 @@
+/**
+ * Bounded retry-with-backoff for riding out TRANSIENT preview-infra flakiness
+ * (the shared search backend — feeds-proxy/meili — intermittently 5xx's under
+ * concurrent preview-build load; cold-SSR page loads stall) WITHOUT masking a
+ * real failure: the wrapped step must still eventually succeed, and if every
+ * attempt fails the last error surfaces and the spec fails honestly.
+ *
+ * Why not rely on Playwright's `retries`: those re-run the WHOLE test within a
+ * few seconds of each other — too fast to outlast a load spike (the failing
+ * runs exhausted all 3 attempts in <10s). This retries the single flaky step
+ * with real spacing so a brief spike is ridden out.
+ *
+ * NOT a test file (excluded from the preview config testMatch).
+ */
+export async function retryFlaky<T>(
+  label: string,
+  fn: (attempt: number) => Promise<T>,
+  opts: { attempts?: number; backoffMs?: number } = {}
+): Promise<T> {
+  const attempts = opts.attempts ?? 3;
+  const backoffMs = opts.backoffMs ?? 6000;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      lastErr = err;
+      if (attempt < attempts) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[retryFlaky] "${label}" failed attempt ${attempt}/${attempts}; retrying in ${
+            backoffMs * attempt
+          }ms`
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoffMs * attempt));
+      }
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
## What

Makes the preview smoke suite resilient to the **two chronic false-fails** that turn every preview PR's `preview / smoke-tests` status red — `/moderator/images` and `whatIfFromGraph` — **without skipping** anything.

## Why

Verified against the live cluster: the shared search backend (in-cluster `civitai-feeds-proxy` via `METRICS_SEARCH_HOST`, which `getAllImagesIndex` / `/moderator/images` use) is healthy at rest (probed 10×, all 200s) but intermittently 5xx's **under concurrent preview-build load**; `/generate` SSR stalls on the cold single-replica pod. Playwright's test-level `retries` re-run within seconds — too fast to outlast a load spike — so both specs exhaust all 3 attempts and hard-fail.

## How (honest resilience, not skipping)

- `preview-auth.setup.ts` — a **search-readiness gate** after the warm-up: poll the image-search path (and `/moderator/images`) until 2xx with spacing, so the suite doesn't start mid-spike. Non-fatal — a sustained outage still surfaces.
- `preview-retry.ts` — shared `retryFlaky(label, fn, {attempts, backoffMs})`: bounded retry-with-backoff; the wrapped step must still pass or the last error throws.
- `preview-moderation.spec.ts` — retry the `/moderator/images` navigation on a transient 5xx.
- `preview-generation.spec.ts` — retry the whatIf navigate+wait (extended per-test timeout for ~2 attempts of the 45s wait).

Unblocks gate-readiness (these were the dominant chronic false-fails). Report-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
