### PR TITLE
Add tensor metadata panel

### DIFF
--- a/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
+++ b/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
@@ -34,6 +34,13 @@ interface DownloadVariantDropdownProps {
   isLoadingAccess?: boolean;
   archived?: boolean;
   onPurchase?: () => void;
+  /**
+   * Optional controlled selection. When `onSelectFileId` is provided the parent
+   * owns the active-file state (so other panels, e.g. the Tensors panel, can
+   * follow the same selection). Otherwise the component manages it internally.
+   */
+  selectedFileId?: number | null;
+  onSelectFileId?: (fileId: number) => void;
 }
 
 export function DownloadVariantDropdown({
@@ -46,6 +53,8 @@ export function DownloadVariantDropdown({
   isLoadingAccess,
   archived,
   onPurchase,
+  selectedFileId: controlledFileId,
+  onSelectFileId,
 }: DownloadVariantDropdownProps) {
   const theme = useMantineTheme();
   const colorScheme = useComputedColorScheme('dark');
@@ -70,7 +79,15 @@ export function DownloadVariantDropdown({
 
   // Track user's explicit selection by id only; derive the active file from
   // the current files list so a stale id from a prior version is ignored.
-  const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
+  // Supports controlled mode so a parent can share the selection with other
+  // panels (e.g. the Tensors panel) that should follow the download choice.
+  const [internalFileId, setInternalFileId] = useState<number | null>(null);
+  const isControlled = typeof onSelectFileId === 'function';
+  const selectedFileId = isControlled ? controlledFileId ?? null : internalFileId;
+  const setSelectedFileId = (fileId: number) => {
+    if (isControlled) onSelectFileId!(fileId);
+    else setInternalFileId(fileId);
+  };
   const activeFile =
     modelFiles.find((f) => f.id === selectedFileId) ?? bestMatchFile ?? modelFiles[0];
 

--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -164,6 +164,11 @@ export function ModelTensorMetadata({ files, modelType, userPreferences, enabled
 function TensorMetadataContent({ data }: { data: ModelTensorAnalysis }) {
   const rows = useMemo(() => buildTensorDisplayRows(data.tensors), [data.tensors]);
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+  const recommendedVramBytes =
+    typeof data.vramEstimate?.recommendedVramBytes === 'number'
+      ? data.vramEstimate.recommendedVramBytes
+      : null;
+  const summaryColumns = data.vramEstimate ? (recommendedVramBytes != null ? 4 : 3) : 2;
 
   useEffect(() => {
     setExpandedGroups(
@@ -178,7 +183,7 @@ function TensorMetadataContent({ data }: { data: ModelTensorAnalysis }) {
   return (
     <Stack gap={0}>
       <SimpleGrid
-        cols={{ base: 2, sm: data.vramEstimate ? 3 : 2 }}
+        cols={{ base: 2, sm: summaryColumns }}
         spacing={0}
         style={{ borderBottom: '1px solid var(--mantine-color-default-border)' }}
       >
@@ -194,6 +199,14 @@ function TensorMetadataContent({ data }: { data: ModelTensorAnalysis }) {
             label="Est. min VRAM"
             value={formatBytes(data.vramEstimate.estimatedMinimumVramBytes, 1)}
             tooltip="Estimated checkpoint weight residency plus Comfy reserve. Actual inference memory depends on workflow settings."
+          />
+        )}
+        {data.vramEstimate && recommendedVramBytes != null && (
+          <SummaryItem
+            icon={<IconCpu size={16} />}
+            label="Recommended VRAM"
+            value={formatBytes(recommendedVramBytes, 1)}
+            tooltip="Estimated VRAM to keep checkpoint weights resident without dynamic offload, plus Comfy reserve."
           />
         )}
       </SimpleGrid>

--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -2,56 +2,50 @@ import {
   Accordion,
   Alert,
   Badge,
-  Box,
-  Collapse,
   Group,
-  ScrollArea,
-  Select,
-  SimpleGrid,
+  HoverCard,
   Skeleton,
   Stack,
-  Table,
   Text,
-  Tooltip,
   UnstyledButton,
   useComputedColorScheme,
   useMantineTheme,
 } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
-import {
-  IconChevronDown,
-  IconChevronRight,
-  IconCpu,
-  IconDatabase,
-  IconTable,
-} from '@tabler/icons-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { getPrimaryFile } from '~/server/utils/model-helpers';
 import type { ModelById } from '~/types/router';
 import { formatBytes, numberWithCommas } from '~/utils/number-helpers';
 import {
   buildTensorDisplayRows,
   inferTensorMetadataFormat,
-  supportsTensorVramEstimate,
   type ModelTensorAnalysis,
   type ModelTensorDisplayGroup,
-  type ModelTensorDisplayRow,
   type ModelTensorInfo,
 } from '~/utils/model-tensor-metadata';
 
 type FileType = ModelById['modelVersions'][number]['files'][number];
+type TensorSummary = Omit<ModelTensorAnalysis, 'tensors'>;
 
 type Props = {
   files: FileType[];
-  modelType: ModelById['type'];
   userPreferences?: UserFilePreferences;
+  /** Whether the accordion is currently open (drives the full tensor-list fetch). */
   enabled: boolean;
+  /** Active file id shared with the download variant picker (the panel follows it). */
+  selectedFileId?: number | null;
 };
 
-export function ModelTensorMetadata({ files, modelType, userPreferences, enabled }: Props) {
+const MIN_VRAM_INFO =
+  'Rough lower bound to run this model, estimated from its tensor sizes and precision plus typical runtime overhead. At this level weights are streamed onto the GPU as needed, so it runs but more slowly. Actual usage varies by the tool and settings you use.';
+const RECOMMENDED_VRAM_INFO =
+  'Rough target for smooth performance, estimated from its tensor sizes and precision plus typical runtime overhead. At this level the full set of weights can stay resident on the GPU at once. Actual usage varies by the tool and settings you use.';
+
+export function ModelTensorMetadata({ files, userPreferences, enabled, selectedFileId }: Props) {
   const theme = useMantineTheme();
   const colorScheme = useComputedColorScheme('dark');
-  const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
 
   const supportedFiles = useMemo(
     () => files.filter((file) => inferTensorMetadataFormat(file)),
@@ -62,22 +56,24 @@ export function ModelTensorMetadata({ files, modelType, userPreferences, enabled
     [supportedFiles, userPreferences]
   );
 
-  useEffect(() => {
-    if (!defaultFile) return;
-    if (!selectedFileId || !supportedFiles.some((file) => file.id === selectedFileId)) {
-      setSelectedFileId(defaultFile.id);
-    }
-  }, [defaultFile, selectedFileId, supportedFiles]);
-
+  // Follow the shared download selection when it points at a tensor-parseable
+  // file; otherwise fall back to this version's primary/default file.
   const selectedFile =
     supportedFiles.find((file) => file.id === selectedFileId) ?? defaultFile ?? null;
-  const canEstimateVram = supportsTensorVramEstimate({
-    modelType,
-    fileType: selectedFile?.type,
+
+  // Summary is always fetched (cheap, server-cached) so the closed header can
+  // show the VRAM range at a glance. The full tensor list is only fetched once
+  // the accordion is opened.
+  const summaryQuery = useQuery({
+    queryKey: ['model-file-tensor-metadata', selectedFile?.id, 'summary'],
+    queryFn: () => fetchTensorSummary(selectedFile!.id),
+    enabled: !!selectedFile,
+    staleTime: Infinity,
+    gcTime: 30 * 60 * 1000,
   });
 
-  const { data, error, isFetching, isLoading } = useQuery({
-    queryKey: ['model-file-tensor-metadata', selectedFile?.id],
+  const detailQuery = useQuery({
+    queryKey: ['model-file-tensor-metadata', selectedFile?.id, 'full'],
     queryFn: () => fetchTensorMetadata(selectedFile!.id),
     enabled: enabled && !!selectedFile,
     staleTime: Infinity,
@@ -86,28 +82,26 @@ export function ModelTensorMetadata({ files, modelType, userPreferences, enabled
 
   if (!supportedFiles.length) return null;
 
+  const vramEstimate = summaryQuery.data?.vramEstimate ?? null;
+  const tensorCount = summaryQuery.data?.tensorCount ?? null;
+
   return (
     <Accordion.Item value="tensor-metadata">
       <Accordion.Control>
         <Group justify="space-between" gap="xs" wrap="nowrap">
-          <Group gap="xs" wrap="nowrap">
-            <IconTable size={18} style={{ color: theme.colors.dark[2] }} />
-            <Text fw={500}>Tensors</Text>
+          <Group gap={6} wrap="nowrap">
+            Tensors
+            {tensorCount != null && (
+              <Badge size="sm" variant="light" color="gray">
+                {numberWithCommas(tensorCount)}
+              </Badge>
+            )}
           </Group>
           <Group gap={6} wrap="nowrap">
-            {data ? (
-              <>
-                <Badge size="sm" variant="light" color="gray">
-                  {numberWithCommas(data.tensorCount)}
-                </Badge>
-                {data.vramEstimate && (
-                  <Badge size="sm" variant="light" color="blue">
-                    {formatBytes(data.vramEstimate.estimatedMinimumVramBytes, 1)} est. min VRAM
-                  </Badge>
-                )}
-              </>
-            ) : isFetching ? (
-              <Skeleton width={88} height={18} radius="xl" />
+            {vramEstimate ? (
+              <VramSegmentedBadge vramEstimate={vramEstimate} />
+            ) : summaryQuery.isFetching ? (
+              <Skeleton width={150} height={20} radius="sm" />
             ) : null}
           </Group>
         </Group>
@@ -119,41 +113,43 @@ export function ModelTensorMetadata({ files, modelType, userPreferences, enabled
             backgroundColor: colorScheme === 'dark' ? '#1f2023' : theme.colors.gray[0],
           }}
         >
-          {supportedFiles.length > 1 && (
-            <Box
-              p="sm"
-              style={{
-                borderBottom: `1px solid ${
-                  colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                }`,
-              }}
-            >
-              <Select
-                size="xs"
-                label="File"
-                value={selectedFile?.id.toString() ?? null}
-                data={supportedFiles.map((file) => ({
-                  value: file.id.toString(),
-                  label: file.name,
-                }))}
-                onChange={(value) => setSelectedFileId(value ? Number(value) : null)}
-                searchable
-                allowDeselect={false}
-              />
-            </Box>
-          )}
-
-          {isLoading || (isFetching && !data) ? (
-            <Stack p="sm" gap="xs">
-              <Skeleton height={canEstimateVram ? 54 : 44} />
-              <Skeleton height={260} />
+          {detailQuery.isLoading || (detailQuery.isFetching && !detailQuery.data) ? (
+            <Stack gap={0}>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: GRID_COLUMNS,
+                  padding: '8px 12px',
+                  borderBottom: '1px solid var(--mantine-color-default-border)',
+                }}
+              >
+                <Skeleton height={10} width={56} />
+                <Skeleton height={10} width={44} />
+                <Skeleton height={10} width={56} />
+              </div>
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: GRID_COLUMNS,
+                    alignItems: 'center',
+                    height: ROW_HEIGHT,
+                    padding: '0 12px',
+                  }}
+                >
+                  <Skeleton height={12} width="85%" />
+                  <Skeleton height={12} width="60%" />
+                  <Skeleton height={12} width="50%" />
+                </div>
+              ))}
             </Stack>
-          ) : error ? (
+          ) : detailQuery.error ? (
             <Alert color="yellow" variant="light" m="sm">
-              {(error as Error).message}
+              {(detailQuery.error as Error).message}
             </Alert>
-          ) : data ? (
-            <TensorMetadataContent data={data} />
+          ) : detailQuery.data ? (
+            <TensorTable data={detailQuery.data} />
           ) : null}
         </Stack>
       </Accordion.Panel>
@@ -161,194 +157,238 @@ export function ModelTensorMetadata({ files, modelType, userPreferences, enabled
   );
 }
 
-function TensorMetadataContent({ data }: { data: ModelTensorAnalysis }) {
-  const rows = useMemo(() => buildTensorDisplayRows(data.tensors), [data.tensors]);
+function VramSegmentedBadge({
+  vramEstimate,
+}: {
+  vramEstimate: NonNullable<TensorSummary['vramEstimate']>;
+}) {
+  const hasRecommended = typeof vramEstimate.recommendedVramBytes === 'number';
+  const dividerColor = 'color-mix(in srgb, var(--mantine-color-blue-light-color) 25%, transparent)';
+
+  return (
+    <Group
+      gap={0}
+      wrap="nowrap"
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        borderRadius: 'var(--mantine-radius-sm)',
+        background: 'var(--mantine-color-blue-light)',
+        color: 'var(--mantine-color-blue-light-color)',
+        fontSize: 11,
+        fontWeight: 500,
+        lineHeight: 1,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span style={{ padding: '3px 8px', fontWeight: 700 }}>VRAM</span>
+      <VramSegment
+        label="min"
+        bytes={vramEstimate.estimatedMinimumVramBytes}
+        info={MIN_VRAM_INFO}
+        style={{ borderLeft: `1px solid ${dividerColor}` }}
+      />
+      {hasRecommended && (
+        <VramSegment
+          label="rec"
+          bytes={vramEstimate.recommendedVramBytes}
+          info={RECOMMENDED_VRAM_INFO}
+          style={{ borderLeft: `1px solid ${dividerColor}` }}
+        />
+      )}
+    </Group>
+  );
+}
+
+function VramSegment({
+  label,
+  bytes,
+  info,
+  style,
+}: {
+  label: string;
+  bytes: number;
+  info: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <HoverCard width={260} shadow="md" withArrow position="bottom-end" openDelay={100} withinPortal>
+      <HoverCard.Target>
+        <span style={{ padding: '3px 8px', cursor: 'help', ...style }}>
+          <span style={{ opacity: 0.75 }}>{label}</span> {formatBytes(bytes, 1)}
+        </span>
+      </HoverCard.Target>
+      <HoverCard.Dropdown>
+        <Text size="xs" c="dimmed">
+          {info}
+        </Text>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+}
+
+type VisibleRow =
+  | { kind: 'group'; group: ModelTensorDisplayGroup; expanded: boolean }
+  | { kind: 'tensor'; tensor: ModelTensorInfo; nested: boolean };
+
+const ROW_HEIGHT = 32;
+const GRID_COLUMNS = '58% 27% 15%';
+const MIN_TABLE_WIDTH = 520;
+
+function TensorTable({ data }: { data: ModelTensorAnalysis }) {
+  const displayRows = useMemo(() => buildTensorDisplayRows(data.tensors), [data.tensors]);
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
-  const recommendedVramBytes =
-    typeof data.vramEstimate?.recommendedVramBytes === 'number'
-      ? data.vramEstimate.recommendedVramBytes
-      : null;
-  const summaryColumns = data.vramEstimate ? (recommendedVramBytes != null ? 4 : 3) : 2;
 
   useEffect(() => {
     setExpandedGroups(
       Object.fromEntries(
-        rows
+        displayRows
           .filter((row) => row.type === 'group' && row.group.displayCount <= 3)
           .map((row) => [(row as { type: 'group'; group: ModelTensorDisplayGroup }).group.id, true])
       )
     );
-  }, [rows]);
+  }, [displayRows]);
+
+  // Flatten groups + expanded children into a single linear list so the whole
+  // thing can be virtualized. Only the rows in view get rendered, which keeps
+  // big groups (e.g. a 1.6k-tensor "model" group) instant to expand.
+  const visibleRows = useMemo<VisibleRow[]>(() => {
+    const out: VisibleRow[] = [];
+    for (const row of displayRows) {
+      if (row.type === 'tensor') {
+        out.push({ kind: 'tensor', tensor: row.tensor, nested: false });
+        continue;
+      }
+      const expanded = !!expandedGroups[row.group.id];
+      out.push({ kind: 'group', group: row.group, expanded });
+      if (expanded)
+        for (const tensor of row.group.tensors) out.push({ kind: 'tensor', tensor, nested: true });
+    }
+    return out;
+  }, [displayRows, expandedGroups]);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: visibleRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 12,
+  });
+
+  const toggleGroup = (id: string) =>
+    setExpandedGroups((current) => ({ ...current, [id]: !current[id] }));
 
   return (
-    <Stack gap={0}>
-      <SimpleGrid
-        cols={{ base: 2, sm: summaryColumns }}
-        spacing={0}
-        style={{ borderBottom: '1px solid var(--mantine-color-default-border)' }}
-      >
-        <SummaryItem
-          icon={<IconDatabase size={16} />}
-          label="Weights"
-          value={formatBytes(data.totalTensorBytes, 1)}
-        />
-        <SummaryItem label="Tensors" value={numberWithCommas(data.tensorCount)} />
-        {data.vramEstimate && (
-          <SummaryItem
-            icon={<IconCpu size={16} />}
-            label="Est. min VRAM"
-            value={formatBytes(data.vramEstimate.estimatedMinimumVramBytes, 1)}
-            tooltip="Estimated checkpoint weight residency plus Comfy reserve. Actual inference memory depends on workflow settings."
-          />
-        )}
-        {data.vramEstimate && recommendedVramBytes != null && (
-          <SummaryItem
-            icon={<IconCpu size={16} />}
-            label="Recommended VRAM"
-            value={formatBytes(recommendedVramBytes, 1)}
-            tooltip="Estimated VRAM to keep checkpoint weights resident without dynamic offload, plus Comfy reserve."
-          />
-        )}
-      </SimpleGrid>
-
-      <ScrollArea.Autosize mah={380} type="auto">
-        <Table
-          striped
-          highlightOnHover
-          verticalSpacing={4}
-          horizontalSpacing="sm"
-          style={{ minWidth: 560, tableLayout: 'fixed' }}
+    <div style={{ overflowX: 'auto' }}>
+      <div style={{ minWidth: MIN_TABLE_WIDTH }}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: GRID_COLUMNS,
+            padding: '6px 12px',
+            fontSize: 'var(--mantine-font-size-xs)',
+            fontWeight: 600,
+            borderBottom: '1px solid var(--mantine-color-default-border)',
+          }}
         >
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th style={{ width: '58%' }}>Tensors</Table.Th>
-              <Table.Th style={{ width: '27%' }}>Shape</Table.Th>
-              <Table.Th style={{ width: '15%' }}>Precision</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {rows.map((row) => {
-              if (row.type === 'tensor')
-                return <TensorRow key={row.tensor.name} tensor={row.tensor} />;
-
-              const expanded = !!expandedGroups[row.group.id];
+          <span>Tensors</span>
+          <span>Shape</span>
+          <span>Precision</span>
+        </div>
+        <div
+          ref={scrollRef}
+          style={{ maxHeight: 360, overflowY: 'auto', scrollbarGutter: 'stable' }}
+        >
+          <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+            {virtualizer.getVirtualItems().map((item) => {
+              const row = visibleRows[item.index];
               return (
-                <GroupRows
-                  key={row.group.id}
-                  row={row}
-                  expanded={expanded}
-                  onToggle={() =>
-                    setExpandedGroups((current) => ({
-                      ...current,
-                      [row.group.id]: !current[row.group.id],
-                    }))
-                  }
-                />
+                <div
+                  key={item.key}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: item.size,
+                    transform: `translateY(${item.start}px)`,
+                    display: 'grid',
+                    gridTemplateColumns: GRID_COLUMNS,
+                    alignItems: 'center',
+                    padding: '0 12px',
+                    background:
+                      item.index % 2
+                        ? 'color-mix(in srgb, var(--mantine-color-text) 4%, transparent)'
+                        : 'transparent',
+                  }}
+                >
+                  {row.kind === 'group' ? (
+                    <UnstyledButton
+                      onClick={() => toggleGroup(row.group.id)}
+                      style={{ gridColumn: '1 / -1', height: '100%' }}
+                    >
+                      <Group gap={6} wrap="nowrap" h="100%" w="100%">
+                        {row.expanded ? (
+                          <IconChevronDown size={14} style={{ flexShrink: 0 }} />
+                        ) : (
+                          <IconChevronRight size={14} style={{ flexShrink: 0 }} />
+                        )}
+                        <Text size="sm" truncate style={{ minWidth: 0, flexShrink: 1 }}>
+                          {row.group.name}
+                        </Text>
+                        <Badge size="xs" variant="light" color="gray" style={{ flexShrink: 0 }}>
+                          {numberWithCommas(row.group.displayCount)}
+                        </Badge>
+                      </Group>
+                    </UnstyledButton>
+                  ) : (
+                    <>
+                      <Text
+                        size="sm"
+                        pl={row.nested ? 'md' : 0}
+                        truncate
+                        title={row.tensor.name}
+                        style={{ minWidth: 0 }}
+                      >
+                        {row.tensor.name}
+                      </Text>
+                      <Text
+                        size="xs"
+                        c="dimmed"
+                        truncate
+                        title={formatShape(row.tensor.shape)}
+                        style={{ minWidth: 0 }}
+                      >
+                        {formatShape(row.tensor.shape)}
+                      </Text>
+                      <Text size="xs" c="dimmed" truncate style={{ minWidth: 0 }}>
+                        {row.tensor.dtype}
+                      </Text>
+                    </>
+                  )}
+                </div>
               );
             })}
-          </Table.Tbody>
-        </Table>
-      </ScrollArea.Autosize>
-    </Stack>
-  );
-}
-
-function SummaryItem({
-  icon,
-  label,
-  value,
-  tooltip,
-}: {
-  icon?: React.ReactNode;
-  label: string;
-  value: string;
-  tooltip?: string;
-}) {
-  return (
-    <Box p="sm">
-      <Group gap={6} wrap="nowrap">
-        {icon}
-        <Text size="xs" c="dimmed">
-          {label}
-        </Text>
-      </Group>
-      <Tooltip label={tooltip} disabled={!tooltip} withArrow>
-        <Text size="sm" fw={600} truncate>
-          {value}
-        </Text>
-      </Tooltip>
-    </Box>
-  );
-}
-
-function GroupRows({
-  row,
-  expanded,
-  onToggle,
-}: {
-  row: Extract<ModelTensorDisplayRow, { type: 'group' }>;
-  expanded: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <>
-      <Table.Tr>
-        <Table.Td colSpan={3}>
-          <UnstyledButton onClick={onToggle} style={{ width: '100%' }}>
-            <Group gap={4} wrap="nowrap">
-              {expanded ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
-              <Text size="sm" truncate>
-                {row.group.name} ({numberWithCommas(row.group.displayCount)})
-              </Text>
-            </Group>
-          </UnstyledButton>
-        </Table.Td>
-      </Table.Tr>
-      <Table.Tr style={{ display: expanded ? 'table-row' : 'none' }}>
-        <Table.Td colSpan={3} p={0}>
-          <Collapse in={expanded}>
-            <Table
-              verticalSpacing={4}
-              horizontalSpacing="sm"
-              style={{ minWidth: 560, tableLayout: 'fixed' }}
-            >
-              <Table.Tbody>
-                {row.group.tensors.map((tensor) => (
-                  <TensorRow key={tensor.name} tensor={tensor} nested />
-                ))}
-              </Table.Tbody>
-            </Table>
-          </Collapse>
-        </Table.Td>
-      </Table.Tr>
-    </>
-  );
-}
-
-function TensorRow({ tensor, nested = false }: { tensor: ModelTensorInfo; nested?: boolean }) {
-  return (
-    <Table.Tr>
-      <Table.Td style={{ width: '58%', maxWidth: 0 }}>
-        <Text size="sm" pl={nested ? 'md' : 0} truncate title={tensor.name}>
-          {tensor.name}
-        </Text>
-      </Table.Td>
-      <Table.Td style={{ width: '27%', maxWidth: 0 }}>
-        <Text size="xs" c="dimmed" truncate title={formatShape(tensor.shape)}>
-          {formatShape(tensor.shape)}
-        </Text>
-      </Table.Td>
-      <Table.Td style={{ width: '15%' }}>
-        <Text size="xs" c="dimmed" truncate>
-          {tensor.dtype}
-        </Text>
-      </Table.Td>
-    </Table.Tr>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 
 function formatShape(shape: number[]) {
   return `[${shape.map((dimension) => numberWithCommas(dimension)).join(', ')}]`;
+}
+
+async function fetchTensorSummary(fileId: number) {
+  const response = await fetch(`/api/v1/model-files/${fileId}/tensor-metadata?summaryOnly=true`);
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? 'Failed to load tensor metadata');
+  }
+
+  return (await response.json()) as TensorSummary;
 }
 
 async function fetchTensorMetadata(fileId: number) {

--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -240,14 +240,10 @@ function TensorTable({ data }: { data: ModelTensorAnalysis }) {
   const displayRows = useMemo(() => buildTensorDisplayRows(data.tensors), [data.tensors]);
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
 
+  // Default every group collapsed; reset when the selected file changes so a
+  // prior file's expanded groups don't linger.
   useEffect(() => {
-    setExpandedGroups(
-      Object.fromEntries(
-        displayRows
-          .filter((row) => row.type === 'group' && row.group.displayCount <= 3)
-          .map((row) => [(row as { type: 'group'; group: ModelTensorDisplayGroup }).group.id, true])
-      )
-    );
+    setExpandedGroups({});
   }, [displayRows]);
 
   // Flatten groups + expanded children into a single linear list so the whole

--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -1,0 +1,349 @@
+import {
+  Accordion,
+  Alert,
+  Badge,
+  Box,
+  Collapse,
+  Group,
+  ScrollArea,
+  Select,
+  SimpleGrid,
+  Skeleton,
+  Stack,
+  Table,
+  Text,
+  Tooltip,
+  UnstyledButton,
+  useComputedColorScheme,
+  useMantineTheme,
+} from '@mantine/core';
+import { useQuery } from '@tanstack/react-query';
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconCpu,
+  IconDatabase,
+  IconTable,
+} from '@tabler/icons-react';
+import { useEffect, useMemo, useState } from 'react';
+import { getPrimaryFile } from '~/server/utils/model-helpers';
+import type { ModelById } from '~/types/router';
+import { formatBytes, numberWithCommas } from '~/utils/number-helpers';
+import {
+  buildTensorDisplayRows,
+  inferTensorMetadataFormat,
+  supportsTensorVramEstimate,
+  type ModelTensorAnalysis,
+  type ModelTensorDisplayGroup,
+  type ModelTensorDisplayRow,
+  type ModelTensorInfo,
+} from '~/utils/model-tensor-metadata';
+
+type FileType = ModelById['modelVersions'][number]['files'][number];
+
+type Props = {
+  files: FileType[];
+  modelType: ModelById['type'];
+  userPreferences?: UserFilePreferences;
+  enabled: boolean;
+};
+
+export function ModelTensorMetadata({ files, modelType, userPreferences, enabled }: Props) {
+  const theme = useMantineTheme();
+  const colorScheme = useComputedColorScheme('dark');
+  const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
+
+  const supportedFiles = useMemo(
+    () => files.filter((file) => inferTensorMetadataFormat(file)),
+    [files]
+  );
+  const defaultFile = useMemo(
+    () => getPrimaryFile(supportedFiles, { metadata: userPreferences }) ?? supportedFiles[0],
+    [supportedFiles, userPreferences]
+  );
+
+  useEffect(() => {
+    if (!defaultFile) return;
+    if (!selectedFileId || !supportedFiles.some((file) => file.id === selectedFileId)) {
+      setSelectedFileId(defaultFile.id);
+    }
+  }, [defaultFile, selectedFileId, supportedFiles]);
+
+  const selectedFile =
+    supportedFiles.find((file) => file.id === selectedFileId) ?? defaultFile ?? null;
+  const canEstimateVram = supportsTensorVramEstimate({
+    modelType,
+    fileType: selectedFile?.type,
+  });
+
+  const { data, error, isFetching, isLoading } = useQuery({
+    queryKey: ['model-file-tensor-metadata', selectedFile?.id],
+    queryFn: () => fetchTensorMetadata(selectedFile!.id),
+    enabled: enabled && !!selectedFile,
+    staleTime: Infinity,
+    gcTime: 30 * 60 * 1000,
+  });
+
+  if (!supportedFiles.length) return null;
+
+  return (
+    <Accordion.Item value="tensor-metadata">
+      <Accordion.Control>
+        <Group justify="space-between" gap="xs" wrap="nowrap">
+          <Group gap="xs" wrap="nowrap">
+            <IconTable size={18} style={{ color: theme.colors.dark[2] }} />
+            <Text fw={500}>Tensors</Text>
+          </Group>
+          <Group gap={6} wrap="nowrap">
+            {data ? (
+              <>
+                <Badge size="sm" variant="light" color="gray">
+                  {numberWithCommas(data.tensorCount)}
+                </Badge>
+                {data.vramEstimate && (
+                  <Badge size="sm" variant="light" color="blue">
+                    {formatBytes(data.vramEstimate.estimatedMinimumVramBytes, 1)} est. min VRAM
+                  </Badge>
+                )}
+              </>
+            ) : isFetching ? (
+              <Skeleton width={88} height={18} radius="xl" />
+            ) : null}
+          </Group>
+        </Group>
+      </Accordion.Control>
+      <Accordion.Panel>
+        <Stack
+          gap={0}
+          style={{
+            backgroundColor: colorScheme === 'dark' ? '#1f2023' : theme.colors.gray[0],
+          }}
+        >
+          {supportedFiles.length > 1 && (
+            <Box
+              p="sm"
+              style={{
+                borderBottom: `1px solid ${
+                  colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
+                }`,
+              }}
+            >
+              <Select
+                size="xs"
+                label="File"
+                value={selectedFile?.id.toString() ?? null}
+                data={supportedFiles.map((file) => ({
+                  value: file.id.toString(),
+                  label: file.name,
+                }))}
+                onChange={(value) => setSelectedFileId(value ? Number(value) : null)}
+                searchable
+                allowDeselect={false}
+              />
+            </Box>
+          )}
+
+          {isLoading || (isFetching && !data) ? (
+            <Stack p="sm" gap="xs">
+              <Skeleton height={canEstimateVram ? 54 : 44} />
+              <Skeleton height={260} />
+            </Stack>
+          ) : error ? (
+            <Alert color="yellow" variant="light" m="sm">
+              {(error as Error).message}
+            </Alert>
+          ) : data ? (
+            <TensorMetadataContent data={data} />
+          ) : null}
+        </Stack>
+      </Accordion.Panel>
+    </Accordion.Item>
+  );
+}
+
+function TensorMetadataContent({ data }: { data: ModelTensorAnalysis }) {
+  const rows = useMemo(() => buildTensorDisplayRows(data.tensors), [data.tensors]);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setExpandedGroups(
+      Object.fromEntries(
+        rows
+          .filter((row) => row.type === 'group' && row.group.displayCount <= 3)
+          .map((row) => [(row as { type: 'group'; group: ModelTensorDisplayGroup }).group.id, true])
+      )
+    );
+  }, [rows]);
+
+  return (
+    <Stack gap={0}>
+      <SimpleGrid
+        cols={{ base: 2, sm: data.vramEstimate ? 3 : 2 }}
+        spacing={0}
+        style={{ borderBottom: '1px solid var(--mantine-color-default-border)' }}
+      >
+        <SummaryItem
+          icon={<IconDatabase size={16} />}
+          label="Weights"
+          value={formatBytes(data.totalTensorBytes, 1)}
+        />
+        <SummaryItem label="Tensors" value={numberWithCommas(data.tensorCount)} />
+        {data.vramEstimate && (
+          <SummaryItem
+            icon={<IconCpu size={16} />}
+            label="Est. min VRAM"
+            value={formatBytes(data.vramEstimate.estimatedMinimumVramBytes, 1)}
+            tooltip="Estimated checkpoint weight residency plus Comfy reserve. Actual inference memory depends on workflow settings."
+          />
+        )}
+      </SimpleGrid>
+
+      <ScrollArea.Autosize mah={380} type="auto">
+        <Table
+          striped
+          highlightOnHover
+          verticalSpacing={4}
+          horizontalSpacing="sm"
+          style={{ minWidth: 560, tableLayout: 'fixed' }}
+        >
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th style={{ width: '58%' }}>Tensors</Table.Th>
+              <Table.Th style={{ width: '27%' }}>Shape</Table.Th>
+              <Table.Th style={{ width: '15%' }}>Precision</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {rows.map((row) => {
+              if (row.type === 'tensor')
+                return <TensorRow key={row.tensor.name} tensor={row.tensor} />;
+
+              const expanded = !!expandedGroups[row.group.id];
+              return (
+                <GroupRows
+                  key={row.group.id}
+                  row={row}
+                  expanded={expanded}
+                  onToggle={() =>
+                    setExpandedGroups((current) => ({
+                      ...current,
+                      [row.group.id]: !current[row.group.id],
+                    }))
+                  }
+                />
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      </ScrollArea.Autosize>
+    </Stack>
+  );
+}
+
+function SummaryItem({
+  icon,
+  label,
+  value,
+  tooltip,
+}: {
+  icon?: React.ReactNode;
+  label: string;
+  value: string;
+  tooltip?: string;
+}) {
+  return (
+    <Box p="sm">
+      <Group gap={6} wrap="nowrap">
+        {icon}
+        <Text size="xs" c="dimmed">
+          {label}
+        </Text>
+      </Group>
+      <Tooltip label={tooltip} disabled={!tooltip} withArrow>
+        <Text size="sm" fw={600} truncate>
+          {value}
+        </Text>
+      </Tooltip>
+    </Box>
+  );
+}
+
+function GroupRows({
+  row,
+  expanded,
+  onToggle,
+}: {
+  row: Extract<ModelTensorDisplayRow, { type: 'group' }>;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <>
+      <Table.Tr>
+        <Table.Td colSpan={3}>
+          <UnstyledButton onClick={onToggle} style={{ width: '100%' }}>
+            <Group gap={4} wrap="nowrap">
+              {expanded ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+              <Text size="sm" truncate>
+                {row.group.name} ({numberWithCommas(row.group.displayCount)})
+              </Text>
+            </Group>
+          </UnstyledButton>
+        </Table.Td>
+      </Table.Tr>
+      <Table.Tr style={{ display: expanded ? 'table-row' : 'none' }}>
+        <Table.Td colSpan={3} p={0}>
+          <Collapse in={expanded}>
+            <Table
+              verticalSpacing={4}
+              horizontalSpacing="sm"
+              style={{ minWidth: 560, tableLayout: 'fixed' }}
+            >
+              <Table.Tbody>
+                {row.group.tensors.map((tensor) => (
+                  <TensorRow key={tensor.name} tensor={tensor} nested />
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Collapse>
+        </Table.Td>
+      </Table.Tr>
+    </>
+  );
+}
+
+function TensorRow({ tensor, nested = false }: { tensor: ModelTensorInfo; nested?: boolean }) {
+  return (
+    <Table.Tr>
+      <Table.Td style={{ width: '58%', maxWidth: 0 }}>
+        <Text size="sm" pl={nested ? 'md' : 0} truncate title={tensor.name}>
+          {tensor.name}
+        </Text>
+      </Table.Td>
+      <Table.Td style={{ width: '27%', maxWidth: 0 }}>
+        <Text size="xs" c="dimmed" truncate title={formatShape(tensor.shape)}>
+          {formatShape(tensor.shape)}
+        </Text>
+      </Table.Td>
+      <Table.Td style={{ width: '15%' }}>
+        <Text size="xs" c="dimmed" truncate>
+          {tensor.dtype}
+        </Text>
+      </Table.Td>
+    </Table.Tr>
+  );
+}
+
+function formatShape(shape: number[]) {
+  return `[${shape.map((dimension) => numberWithCommas(dimension)).join(', ')}]`;
+}
+
+async function fetchTensorMetadata(fileId: number) {
+  const response = await fetch(`/api/v1/model-files/${fileId}/tensor-metadata`);
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? 'Failed to load tensor metadata');
+  }
+
+  return (await response.json()) as ModelTensorAnalysis;
+}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -47,7 +47,7 @@ import type { TRPCClientErrorBase } from '@trpc/client';
 import type { TRPCDefaultErrorShape } from '@trpc/server';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { AdUnitSide_2 } from '~/components/Ads/AdUnit';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import {
@@ -226,6 +226,10 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
     ];
   }, [groupedFiles]);
   const tensorMetadataEnabled = detailAccordions.includes('tensor-metadata');
+
+  // Shared active-file selection: the download variant picker drives it, and the
+  // Tensors panel follows it (instead of having its own file selector).
+  const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
 
   // Check if this is a component-only model (no model files, only components)
   const isComponentOnlyModel =
@@ -825,6 +829,8 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                       versionId={version.id}
                       modelType={model.type}
                       userPreferences={user?.filePreferences}
+                      selectedFileId={selectedFileId}
+                      onSelectFileId={setSelectedFileId}
                       canDownload={canDownload}
                       downloadPrice={
                         !hasDownloadPermissions &&
@@ -1212,14 +1218,6 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   </Accordion.Panel>
                 </Accordion.Item>
               )}
-            {isDownloadable && modelFilesVisible.length > 0 && (
-              <ModelTensorMetadata
-                files={modelFilesVisible}
-                modelType={model.type}
-                userPreferences={user?.filePreferences}
-                enabled={tensorMetadataEnabled}
-              />
-            )}
             <Accordion.Item value="version-details">
               <Accordion.Control>
                 <Group justify="space-between">
@@ -1526,6 +1524,14 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                 </Stack>
               </Accordion.Panel>
             </Accordion.Item>
+            {isDownloadable && modelFilesVisible.length > 0 && (
+              <ModelTensorMetadata
+                files={modelFilesVisible}
+                userPreferences={user?.filePreferences}
+                enabled={tensorMetadataEnabled}
+                selectedFileId={selectedFileId}
+              />
+            )}
             {version.recommendedResources && version.recommendedResources.length > 0 && (
               <Accordion.Item value="recommended-resources">
                 <Accordion.Control>Recommended Resources</Accordion.Control>

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -80,6 +80,7 @@ import { ModelFileAlert } from '~/components/Model/ModelFileAlert/ModelFileAlert
 import { ModelHash } from '~/components/Model/ModelHash/ModelHash';
 import { ModelURN, URNExplanation } from '~/components/Model/ModelURN/ModelURN';
 import { DownloadVariantDropdown } from '~/components/Model/ModelVersions/DownloadVariantDropdown';
+import { ModelTensorMetadata } from '~/components/Model/ModelVersions/ModelTensorMetadata';
 import { ModelVersionPopularity } from '~/components/Model/ModelVersions/ModelVersionPopularity';
 import { ModelVersionReview } from '~/components/Model/ModelVersions/ModelVersionReview';
 import { RequiredComponentsSection } from '~/components/Model/ModelVersions/RequiredComponentsSection';
@@ -224,6 +225,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
       ...groupedFiles.otherFormatVariants,
     ];
   }, [groupedFiles]);
+  const tensorMetadataEnabled = detailAccordions.includes('tensor-metadata');
 
   // Check if this is a component-only model (no model files, only components)
   const isComponentOnlyModel =
@@ -1210,6 +1212,14 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   </Accordion.Panel>
                 </Accordion.Item>
               )}
+            {isDownloadable && modelFilesVisible.length > 0 && (
+              <ModelTensorMetadata
+                files={modelFilesVisible}
+                modelType={model.type}
+                userPreferences={user?.filePreferences}
+                enabled={tensorMetadataEnabled}
+              />
+            )}
             <Accordion.Item value="version-details">
               <Accordion.Control>
                 <Group justify="space-between">

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -1,9 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from 'next-auth';
 import * as z from 'zod';
+import { CacheTTL } from '~/server/common/constants';
 import { dbRead } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import { REDIS_KEYS } from '~/server/redis/client';
 import { getFileForModelVersion } from '~/server/services/file.service';
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
 import {
   inferTensorMetadataFormat,
@@ -66,12 +69,19 @@ export default MixedAuthEndpoint(async function handler(
       modelType: file.modelVersion.model.type,
       fileType: file.type,
     });
-    const analysis = await parseModelTensorMetadata({
-      url: fileResult.url,
-      format,
-      fileSizeBytes: file.sizeKB * 1024,
-      estimateVram,
-    });
+    // Tensor metadata is derived purely from immutable file content, so cache the parsed
+    // analysis by file id. Auth is still re-checked per request above via getFileForModelVersion.
+    const analysis = await fetchThroughCache(
+      `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${id}`,
+      () =>
+        parseModelTensorMetadata({
+          url: fileResult.url,
+          format,
+          fileSizeBytes: file.sizeKB * 1024,
+          estimateVram,
+        }),
+      { ttl: CacheTTL.month }
+    );
     res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
 
     if (summaryOnly) {

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -21,6 +21,8 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  res.setHeader('Cache-Control', 'private, no-store');
+
   const result = schema.safeParse(req.query);
   if (!result.success)
     return res.status(400).json({ error: z.prettifyError(result.error) ?? 'Invalid file id' });
@@ -45,7 +47,6 @@ export default MixedAuthEndpoint(async function handler(
     modelVersionId: file.modelVersionId,
     fileId: id,
     user,
-    resolveUrl: false,
   });
 
   if (fileResult.status !== 'success') {

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -1,0 +1,130 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Session } from 'next-auth';
+import * as z from 'zod';
+import { dbRead } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { getFileForModelVersion } from '~/server/services/file.service';
+import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
+import {
+  inferTensorMetadataFormat,
+  parseModelTensorMetadata,
+  supportsTensorVramEstimate,
+} from '~/utils/model-tensor-metadata';
+
+const schema = z.object({
+  id: z.preprocess((val) => Number(val), z.number()),
+  summaryOnly: z.preprocess((val) => val === 'true' || val === true, z.boolean().optional()),
+});
+
+export default MixedAuthEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: Session['user'] | undefined
+) {
+  const result = schema.safeParse(req.query);
+  if (!result.success)
+    return res.status(400).json({ error: z.prettifyError(result.error) ?? 'Invalid file id' });
+
+  const { id, summaryOnly } = result.data;
+  const file = await dbRead.modelFile.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      modelVersionId: true,
+      name: true,
+      type: true,
+      sizeKB: true,
+      metadata: true,
+      modelVersion: { select: { model: { select: { type: true } } } },
+    },
+  });
+
+  if (!file) return res.status(404).json({ error: 'File not found' });
+
+  const fileResult = await getFileForModelVersion({
+    modelVersionId: file.modelVersionId,
+    fileId: id,
+    user,
+    resolveUrl: false,
+  });
+
+  if (fileResult.status !== 'success') {
+    const statusCode = getStatusCode(fileResult.status);
+    return res.status(statusCode).json({ error: getErrorMessage(fileResult.status) });
+  }
+
+  const format = inferTensorMetadataFormat({
+    name: file.name,
+    metadata: file.metadata as BasicFileMetadata | null,
+  });
+  if (!format) return res.status(400).json({ error: 'File format is not supported' });
+
+  try {
+    const estimateVram = supportsTensorVramEstimate({
+      modelType: file.modelVersion.model.type,
+      fileType: file.type,
+    });
+    const analysis = await parseModelTensorMetadata({
+      url: fileResult.url,
+      format,
+      fileSizeBytes: file.sizeKB * 1024,
+      estimateVram,
+    });
+
+    if (summaryOnly) {
+      const { tensors, ...summary } = analysis;
+      return res.status(200).json(summary);
+    }
+
+    res.status(200).json(analysis);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logToAxiom({
+      name: 'model-file-tensor-metadata',
+      type: 'error',
+      message: err.message,
+      stack: err.stack,
+      fileId: id,
+      modelVersionId: file.modelVersionId,
+      format,
+    }).catch(() => undefined);
+
+    return res.status(422).json({ error: err.message });
+  }
+});
+
+function getStatusCode(
+  status: Exclude<Awaited<ReturnType<typeof getFileForModelVersion>>['status'], 'success'>
+) {
+  switch (status) {
+    case 'unauthorized':
+    case 'downloads-disabled':
+    case 'early-access':
+      return 403;
+    case 'archived':
+      return 410;
+    case 'not-found':
+      return 404;
+    default:
+      return 500;
+  }
+}
+
+function getErrorMessage(
+  status: Exclude<Awaited<ReturnType<typeof getFileForModelVersion>>['status'], 'success'>
+) {
+  switch (status) {
+    case 'unauthorized':
+      return 'Unauthorized';
+    case 'downloads-disabled':
+      return 'Downloads are disabled for this file';
+    case 'early-access':
+      return 'File is in early access';
+    case 'archived':
+      return 'Model archived, not available';
+    case 'not-found':
+      return 'File not found';
+    default:
+      return 'Error getting file';
+  }
+}

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -15,6 +15,7 @@ const schema = z.object({
   id: z.preprocess((val) => Number(val), z.number()),
   summaryOnly: z.preprocess((val) => val === 'true' || val === true, z.boolean().optional()),
 });
+const TENSOR_METADATA_CACHE_CONTROL = 'public, max-age=31536000, s-maxage=31536000, immutable';
 
 export default MixedAuthEndpoint(async function handler(
   req: NextApiRequest,
@@ -71,6 +72,7 @@ export default MixedAuthEndpoint(async function handler(
       fileSizeBytes: file.sizeKB * 1024,
       estimateVram,
     });
+    res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
 
     if (summaryOnly) {
       const { tensors, ...summary } = analysis;

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -981,6 +981,7 @@ export const REDIS_KEYS = {
     MODEL_TAGS: 'packed:caches:model-tags',
     IMAGE_TAGS: 'packed:caches:image-tags',
     MODEL_VERSION_RESOURCE_INFO: 'packed:caches:model-version-resource-info',
+    TENSOR_METADATA: 'packed:caches:tensor-metadata',
     IMAGE_RESOURCES: 'packed:caches:image-resources',
     USER_DOWNLOADS: 'packed:caches:user-downloads:v2',
     MOD_RULES: {

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -157,7 +157,6 @@ export const getFileForModelVersion = async ({
   user,
   noAuth,
   fileId,
-  resolveUrl = true,
 }: {
   modelVersionId: number;
   type?: ModelFileType;
@@ -173,7 +172,6 @@ export const getFileForModelVersion = async ({
   };
   noAuth?: boolean;
   fileId?: number;
-  resolveUrl?: boolean;
 }): Promise<ModelVersionFileResult> => {
   const modelVersion = await dbRead.modelVersion.findFirst({
     where: { id: modelVersionId },
@@ -320,20 +318,6 @@ export const getFileForModelVersion = async ({
     modelVersion,
     file,
   });
-  if (!resolveUrl) {
-    return {
-      status: 'success',
-      url: file.url,
-      fileId: file.id,
-      modelId: modelVersion.model.id,
-      modelVersionId,
-      nsfw: modelVersion.model.nsfw,
-      inEarlyAccess,
-      metadata: file.metadata as FileMetadata,
-      isDownloadable,
-    };
-  }
-
   try {
     const { url } = await resolveDownloadUrl(file.id, file.url, filename);
     return {

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -157,6 +157,7 @@ export const getFileForModelVersion = async ({
   user,
   noAuth,
   fileId,
+  resolveUrl = true,
 }: {
   modelVersionId: number;
   type?: ModelFileType;
@@ -172,6 +173,7 @@ export const getFileForModelVersion = async ({
   };
   noAuth?: boolean;
   fileId?: number;
+  resolveUrl?: boolean;
 }): Promise<ModelVersionFileResult> => {
   const modelVersion = await dbRead.modelVersion.findFirst({
     where: { id: modelVersionId },
@@ -318,6 +320,20 @@ export const getFileForModelVersion = async ({
     modelVersion,
     file,
   });
+  if (!resolveUrl) {
+    return {
+      status: 'success',
+      url: file.url,
+      fileId: file.id,
+      modelId: modelVersion.model.id,
+      modelVersionId,
+      nsfw: modelVersion.model.nsfw,
+      inEarlyAccess,
+      metadata: file.metadata as FileMetadata,
+      isDownloadable,
+    };
+  }
+
   try {
     const { url } = await resolveDownloadUrl(file.id, file.url, filename);
     return {

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -44,7 +44,9 @@ export type ModelTensorDisplayRow =
 
 export type ModelVramEstimate = {
   estimatedMinimumVramBytes: number;
+  recommendedVramBytes: number;
   residentWeightsBytes: number;
+  fullyResidentWeightsBytes: number;
   inferenceReserveBytes: number;
   extraReservedBytes: number;
   dynamicVramPageBytes: number;
@@ -188,11 +190,17 @@ function estimateComfyDynamicOffloadVram(tensors: ModelTensorInfo[]): ModelVramE
     Math.max(residentWeightsBytes, largestTensorBytes),
     COMFY_DYNAMIC_VRAM_PAGE_BYTES
   );
+  const fullyResidentWeightsBytes = roundUpToPage(
+    tensors.reduce((sum, tensor) => sum + tensor.sizeBytes, 0),
+    COMFY_DYNAMIC_VRAM_PAGE_BYTES
+  );
+  const baseReserveBytes = COMFY_INFERENCE_RESERVE_BYTES + COMFY_EXTRA_RESERVED_BYTES;
 
   return {
-    estimatedMinimumVramBytes:
-      residentWeightsBytes + COMFY_INFERENCE_RESERVE_BYTES + COMFY_EXTRA_RESERVED_BYTES,
+    estimatedMinimumVramBytes: residentWeightsBytes + baseReserveBytes,
+    recommendedVramBytes: fullyResidentWeightsBytes + baseReserveBytes,
     residentWeightsBytes,
+    fullyResidentWeightsBytes,
     inferenceReserveBytes: COMFY_INFERENCE_RESERVE_BYTES,
     extraReservedBytes: COMFY_EXTRA_RESERVED_BYTES,
     dynamicVramPageBytes: COMFY_DYNAMIC_VRAM_PAGE_BYTES,

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -1,0 +1,573 @@
+const MiB = 1024 * 1024;
+const GiB = 1024 * MiB;
+
+const SAFETENSORS_HEADER_LIMIT_BYTES = 64 * MiB;
+const GGUF_HEADER_READ_SIZES = [1 * MiB, 4 * MiB, 16 * MiB, 64 * MiB];
+
+const COMFY_INFERENCE_RESERVE_BYTES = Math.floor(0.8 * GiB);
+const COMFY_EXTRA_RESERVED_BYTES = 400 * MiB;
+const COMFY_DYNAMIC_VRAM_PAGE_BYTES = 32 * MiB;
+
+type FetchLike = typeof fetch;
+
+export type ModelTensorFormat = 'SafeTensor' | 'GGUF';
+export type ModelTensorVramSupport = {
+  modelType?: string | null;
+  fileType?: string | null;
+};
+
+export type ModelTensorInfo = {
+  name: string;
+  shape: number[];
+  dtype: string;
+  sizeBytes: number;
+};
+
+export type ModelTensorDtypeSummary = {
+  dtype: string;
+  count: number;
+  bytes: number;
+};
+
+export type ModelTensorDisplayGroup = {
+  id: string;
+  name: string;
+  displayCount: number;
+  tensorCount: number;
+  sizeBytes: number;
+  tensors: ModelTensorInfo[];
+};
+
+export type ModelTensorDisplayRow =
+  | { type: 'group'; group: ModelTensorDisplayGroup }
+  | { type: 'tensor'; tensor: ModelTensorInfo };
+
+export type ModelVramEstimate = {
+  estimatedMinimumVramBytes: number;
+  residentWeightsBytes: number;
+  inferenceReserveBytes: number;
+  extraReservedBytes: number;
+  dynamicVramPageBytes: number;
+};
+
+export type ModelTensorAnalysis = {
+  format: ModelTensorFormat;
+  tensorCount: number;
+  totalTensorBytes: number;
+  dtypeCounts: ModelTensorDtypeSummary[];
+  largestTensor: ModelTensorInfo | null;
+  vramEstimate: ModelVramEstimate | null;
+  tensors: ModelTensorInfo[];
+};
+
+type ParseModelTensorMetadataOptions = {
+  url: string;
+  format: ModelTensorFormat;
+  fileSizeBytes?: number;
+  estimateVram?: boolean;
+  signal?: AbortSignal;
+  fetchImpl?: FetchLike;
+};
+
+export async function parseModelTensorMetadata({
+  url,
+  format,
+  fileSizeBytes,
+  estimateVram = true,
+  signal,
+  fetchImpl = fetch,
+}: ParseModelTensorMetadataOptions): Promise<ModelTensorAnalysis> {
+  const tensors =
+    format === 'SafeTensor'
+      ? await parseSafetensorsTensors({ url, signal, fetchImpl })
+      : await parseGgufTensors({ url, fileSizeBytes, signal, fetchImpl });
+
+  return analyzeModelTensors(format, tensors, { estimateVram });
+}
+
+export function analyzeModelTensors(
+  format: ModelTensorFormat,
+  tensors: ModelTensorInfo[],
+  { estimateVram = true }: { estimateVram?: boolean } = {}
+): ModelTensorAnalysis {
+  const dtypeCounts = new Map<string, ModelTensorDtypeSummary>();
+  let totalTensorBytes = 0;
+  let largestTensor: ModelTensorInfo | null = null;
+
+  for (const tensor of tensors) {
+    totalTensorBytes += tensor.sizeBytes;
+    if (!largestTensor || tensor.sizeBytes > largestTensor.sizeBytes) largestTensor = tensor;
+
+    const summary = dtypeCounts.get(tensor.dtype) ?? {
+      dtype: tensor.dtype,
+      count: 0,
+      bytes: 0,
+    };
+    summary.count += 1;
+    summary.bytes += tensor.sizeBytes;
+    dtypeCounts.set(tensor.dtype, summary);
+  }
+
+  return {
+    format,
+    tensorCount: tensors.length,
+    totalTensorBytes,
+    dtypeCounts: [...dtypeCounts.values()].sort((a, b) => b.bytes - a.bytes),
+    largestTensor,
+    vramEstimate: estimateVram ? estimateComfyDynamicOffloadVram(tensors) : null,
+    tensors,
+  };
+}
+
+export function supportsTensorVramEstimate({ modelType, fileType }: ModelTensorVramSupport) {
+  return modelType === 'Checkpoint' && CHECKPOINT_WEIGHT_FILE_TYPES.has(fileType ?? '');
+}
+
+export function buildTensorDisplayRows(tensors: ModelTensorInfo[]): ModelTensorDisplayRow[] {
+  const topLevelGroups = new Map<string, ModelTensorInfo[]>();
+  for (const tensor of tensors) {
+    const groupName = getTopLevelGroupName(tensor.name);
+    const group = topLevelGroups.get(groupName) ?? [];
+    group.push(tensor);
+    topLevelGroups.set(groupName, group);
+  }
+
+  const emittedGroups = new Set<string>();
+  const rows: ModelTensorDisplayRow[] = [];
+
+  for (const tensor of tensors) {
+    const groupName = getTopLevelGroupName(tensor.name);
+    const groupTensors = topLevelGroups.get(groupName) ?? [tensor];
+
+    if (groupTensors.length <= 1) {
+      rows.push({ type: 'tensor', tensor });
+      continue;
+    }
+
+    if (emittedGroups.has(groupName)) continue;
+    emittedGroups.add(groupName);
+
+    rows.push({
+      type: 'group',
+      group: {
+        id: groupName,
+        name: groupName,
+        displayCount: getDisplayGroupCount(groupName, groupTensors),
+        tensorCount: groupTensors.length,
+        sizeBytes: groupTensors.reduce((sum, item) => sum + item.sizeBytes, 0),
+        tensors: groupTensors,
+      },
+    });
+  }
+
+  return rows;
+}
+
+export function inferTensorMetadataFormat(file: {
+  name?: string | null;
+  metadata?: BasicFileMetadata | null;
+}): ModelTensorFormat | null {
+  const format = file.metadata?.format;
+  if (format === 'SafeTensor' || format === 'GGUF') return format;
+
+  const lowerName = file.name?.toLowerCase() ?? '';
+  if (lowerName.endsWith('.safetensors') || lowerName.endsWith('.sft')) return 'SafeTensor';
+  if (lowerName.endsWith('.gguf')) return 'GGUF';
+
+  return null;
+}
+
+function estimateComfyDynamicOffloadVram(tensors: ModelTensorInfo[]): ModelVramEstimate {
+  const layerGroups = buildLayerGroups(tensors);
+  let residentWeightsBytes = 0;
+
+  for (const layer of layerGroups)
+    residentWeightsBytes = Math.max(residentWeightsBytes, layer.bytes);
+  const largestTensorBytes = Math.max(...tensors.map((tensor) => tensor.sizeBytes), 0);
+  residentWeightsBytes = roundUpToPage(
+    Math.max(residentWeightsBytes, largestTensorBytes),
+    COMFY_DYNAMIC_VRAM_PAGE_BYTES
+  );
+
+  return {
+    estimatedMinimumVramBytes:
+      residentWeightsBytes + COMFY_INFERENCE_RESERVE_BYTES + COMFY_EXTRA_RESERVED_BYTES,
+    residentWeightsBytes,
+    inferenceReserveBytes: COMFY_INFERENCE_RESERVE_BYTES,
+    extraReservedBytes: COMFY_EXTRA_RESERVED_BYTES,
+    dynamicVramPageBytes: COMFY_DYNAMIC_VRAM_PAGE_BYTES,
+  };
+}
+
+function buildLayerGroups(tensors: ModelTensorInfo[]) {
+  const groups = new Map<string, { name: string; bytes: number }>();
+
+  for (const tensor of tensors) {
+    const name = getLayerGroupName(tensor.name);
+    const group = groups.get(name) ?? { name, bytes: 0 };
+    group.bytes += tensor.sizeBytes;
+    groups.set(name, group);
+  }
+
+  return [...groups.values()];
+}
+
+function getTopLevelGroupName(name: string) {
+  return name.split('.')[0] || name;
+}
+
+function getLayerGroupName(name: string) {
+  const parts = name.split('.');
+  const numericIndex = parts.findIndex((part, index) => index > 0 && /^\d+$/.test(part));
+  if (numericIndex > 0) return parts.slice(0, numericIndex + 1).join('.');
+  return parts[0] || name;
+}
+
+function getDisplayGroupCount(groupName: string, tensors: ModelTensorInfo[]) {
+  const childSegments = tensors.map((tensor) => {
+    const suffix = tensor.name.slice(groupName.length + 1);
+    return suffix.split('.')[0];
+  });
+  const numericChildren = childSegments.filter((segment) => /^\d+$/.test(segment));
+  if (numericChildren.length === childSegments.length) return new Set(numericChildren).size;
+  return tensors.length;
+}
+
+function roundUpToPage(value: number, pageSize: number) {
+  if (value <= 0) return 0;
+  return Math.ceil(value / pageSize) * pageSize;
+}
+
+async function parseSafetensorsTensors({
+  url,
+  signal,
+  fetchImpl,
+}: Pick<ParseModelTensorMetadataOptions, 'url' | 'signal' | 'fetchImpl'>) {
+  const prefix = await fetchByteRange(url, 0, 7, { signal, fetchImpl });
+  const headerLength = readUint64LE(prefix, 0);
+  if (headerLength <= 0 || headerLength > SAFETENSORS_HEADER_LIMIT_BYTES) {
+    throw new Error('SafeTensor header is missing or too large to parse safely');
+  }
+
+  const headerBytes = await fetchByteRange(url, 8, 7 + headerLength, { signal, fetchImpl });
+  const header = JSON.parse(new TextDecoder().decode(headerBytes)) as Record<string, unknown>;
+  const tensors: ModelTensorInfo[] = [];
+
+  for (const [name, value] of Object.entries(header)) {
+    if (name === '__metadata__' || !isSafetensorEntry(value)) continue;
+
+    tensors.push({
+      name,
+      shape: value.shape,
+      dtype: normalizePrecision(value.dtype),
+      sizeBytes: getSafetensorSizeBytes(value),
+    });
+  }
+
+  return tensors;
+}
+
+function isSafetensorEntry(value: unknown): value is {
+  dtype: string;
+  shape: number[];
+  data_offsets?: [number, number];
+} {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as { dtype?: unknown; shape?: unknown; data_offsets?: unknown };
+  const offsetsValid =
+    entry.data_offsets == null ||
+    (Array.isArray(entry.data_offsets) &&
+      entry.data_offsets.length === 2 &&
+      entry.data_offsets.every((offset) => Number.isFinite(offset)));
+
+  return (
+    typeof entry.dtype === 'string' &&
+    Array.isArray(entry.shape) &&
+    entry.shape.every((dimension) => Number.isFinite(dimension)) &&
+    offsetsValid
+  );
+}
+
+function getSafetensorSizeBytes(entry: {
+  dtype: string;
+  shape: number[];
+  data_offsets?: [number, number];
+}) {
+  if (entry.data_offsets) {
+    const [start, end] = entry.data_offsets;
+    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) return end - start;
+  }
+
+  const dtypeBytes = SAFETENSORS_DTYPE_BYTES[normalizePrecision(entry.dtype)] ?? 0;
+  return getElementCount(entry.shape) * dtypeBytes;
+}
+
+async function parseGgufTensors({
+  url,
+  signal,
+  fetchImpl,
+}: Pick<ParseModelTensorMetadataOptions, 'url' | 'fileSizeBytes' | 'signal' | 'fetchImpl'>) {
+  let lastError: unknown;
+
+  for (const readSize of GGUF_HEADER_READ_SIZES) {
+    const bytes = await fetchByteRange(url, 0, readSize - 1, {
+      signal,
+      fetchImpl,
+      allowShort: true,
+    });
+
+    try {
+      return parseGgufHeader(bytes);
+    } catch (error) {
+      if (!(error instanceof NeedMoreBytesError)) throw error;
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error('GGUF header is too large to parse safely');
+}
+
+function parseGgufHeader(bytes: Uint8Array) {
+  const reader = new ByteReader(bytes);
+  const magic = reader.ascii(4);
+  if (magic !== 'GGUF') throw new Error('File is not a GGUF model');
+
+  reader.uint32(); // version
+  const tensorCount = reader.uint64();
+  const metadataCount = reader.uint64();
+
+  if (tensorCount > 1_000_000 || metadataCount > 1_000_000) {
+    throw new Error('GGUF header declares an unreasonable number of entries');
+  }
+
+  for (let i = 0; i < metadataCount; i++) {
+    reader.string();
+    skipGgufMetadataValue(reader, reader.uint32());
+  }
+
+  const tensors: ModelTensorInfo[] = [];
+  for (let i = 0; i < tensorCount; i++) {
+    const name = reader.string();
+    const dimensionCount = reader.uint32();
+    if (dimensionCount > 16) throw new Error('GGUF tensor has an invalid dimension count');
+
+    const shape: number[] = [];
+    for (let dimension = 0; dimension < dimensionCount; dimension++) shape.push(reader.uint64());
+
+    const ggmlType = reader.uint32();
+    reader.uint64(); // tensor data offset
+    const typeInfo = GGML_TYPES[ggmlType];
+
+    tensors.push({
+      name,
+      shape,
+      dtype: typeInfo?.name ?? `GGML_${ggmlType}`,
+      sizeBytes: typeInfo ? getGgmlTensorSizeBytes(shape, typeInfo) : 0,
+    });
+  }
+
+  return tensors;
+}
+
+function skipGgufMetadataValue(reader: ByteReader, valueType: number): void {
+  switch (valueType) {
+    case 0:
+    case 1:
+    case 7:
+      reader.skip(1);
+      return;
+    case 2:
+    case 3:
+      reader.skip(2);
+      return;
+    case 4:
+    case 5:
+    case 6:
+      reader.skip(4);
+      return;
+    case 8:
+      reader.string();
+      return;
+    case 9: {
+      const itemType = reader.uint32();
+      const itemCount = reader.uint64();
+      if (itemCount > 1_000_000) throw new Error('GGUF metadata array is too large');
+      for (let i = 0; i < itemCount; i++) skipGgufMetadataValue(reader, itemType);
+      return;
+    }
+    case 10:
+    case 11:
+    case 12:
+      reader.skip(8);
+      return;
+    default:
+      throw new Error(`Unsupported GGUF metadata value type ${valueType}`);
+  }
+}
+
+function getGgmlTensorSizeBytes(
+  shape: number[],
+  typeInfo: { blockSize: number; typeSize: number }
+) {
+  const [rowElements = 1, ...outerDimensions] = shape;
+  const rowBytes = Math.ceil(rowElements / typeInfo.blockSize) * typeInfo.typeSize;
+  const rowCount = outerDimensions.length ? getElementCount(outerDimensions) : 1;
+  return rowBytes * rowCount;
+}
+
+function getElementCount(shape: number[]) {
+  return shape.reduce((product, dimension) => product * dimension, 1);
+}
+
+async function fetchByteRange(
+  url: string,
+  start: number,
+  end: number,
+  {
+    signal,
+    fetchImpl = fetch,
+    allowShort = false,
+  }: { signal?: AbortSignal; fetchImpl?: FetchLike; allowShort?: boolean } = {}
+) {
+  const response = await fetchImpl(url, {
+    headers: { Range: `bytes=${start}-${end}` },
+    signal,
+  });
+
+  if (!response.ok) throw new Error(`Failed to fetch model metadata range: ${response.status}`);
+  if (response.status !== 206) {
+    throw new Error('Model host does not support byte-range requests');
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const expectedLength = end - start + 1;
+  if (!allowShort && bytes.length < expectedLength) {
+    throw new Error('Model metadata range response was shorter than expected');
+  }
+
+  return bytes;
+}
+
+function readUint64LE(bytes: Uint8Array, offset: number) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const low = view.getUint32(offset, true);
+  const high = view.getUint32(offset + 4, true);
+  const value = high * 2 ** 32 + low;
+  if (value > Number.MAX_SAFE_INTEGER) throw new Error('64-bit integer exceeds safe range');
+  return value;
+}
+
+function normalizePrecision(dtype: string) {
+  return dtype.toUpperCase();
+}
+
+class NeedMoreBytesError extends Error {}
+
+class ByteReader {
+  private offset = 0;
+  private readonly decoder = new TextDecoder();
+  private readonly view: DataView;
+
+  constructor(private readonly bytes: Uint8Array) {
+    this.view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  }
+
+  ascii(length: number) {
+    return new TextDecoder('ascii').decode(this.readBytes(length));
+  }
+
+  uint32() {
+    this.require(4);
+    const value = this.view.getUint32(this.offset, true);
+    this.offset += 4;
+    return value;
+  }
+
+  uint64() {
+    this.require(8);
+    const value = readUint64LE(this.bytes, this.offset);
+    this.offset += 8;
+    return value;
+  }
+
+  string() {
+    const length = this.uint64();
+    return this.decoder.decode(this.readBytes(length));
+  }
+
+  skip(length: number) {
+    this.require(length);
+    this.offset += length;
+  }
+
+  private readBytes(length: number) {
+    this.require(length);
+    const value = this.bytes.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return value;
+  }
+
+  private require(length: number) {
+    if (this.offset + length > this.bytes.length) throw new NeedMoreBytesError();
+  }
+}
+
+const SAFETENSORS_DTYPE_BYTES: Record<string, number> = {
+  F64: 8,
+  F32: 4,
+  F16: 2,
+  BF16: 2,
+  F8_E5M2: 1,
+  F8_E4M3: 1,
+  F8_E4M3FN: 1,
+  F8_E4M3FNUZ: 1,
+  I64: 8,
+  U64: 8,
+  I32: 4,
+  U32: 4,
+  I16: 2,
+  U16: 2,
+  I8: 1,
+  U8: 1,
+  BOOL: 1,
+};
+
+const CHECKPOINT_WEIGHT_FILE_TYPES = new Set(['Model', 'Pruned Model', 'UNet', 'Diffusion Model']);
+
+// Mirrors llama.cpp's current ggml_type enum and block sizes for GGUF tensor-info parsing.
+const GGML_TYPES: Record<number, { name: string; blockSize: number; typeSize: number }> = {
+  0: { name: 'F32', blockSize: 1, typeSize: 4 },
+  1: { name: 'F16', blockSize: 1, typeSize: 2 },
+  2: { name: 'Q4_0', blockSize: 32, typeSize: 18 },
+  3: { name: 'Q4_1', blockSize: 32, typeSize: 20 },
+  6: { name: 'Q5_0', blockSize: 32, typeSize: 22 },
+  7: { name: 'Q5_1', blockSize: 32, typeSize: 24 },
+  8: { name: 'Q8_0', blockSize: 32, typeSize: 34 },
+  9: { name: 'Q8_1', blockSize: 32, typeSize: 36 },
+  10: { name: 'Q2_K', blockSize: 256, typeSize: 84 },
+  11: { name: 'Q3_K', blockSize: 256, typeSize: 110 },
+  12: { name: 'Q4_K', blockSize: 256, typeSize: 144 },
+  13: { name: 'Q5_K', blockSize: 256, typeSize: 176 },
+  14: { name: 'Q6_K', blockSize: 256, typeSize: 210 },
+  15: { name: 'Q8_K', blockSize: 256, typeSize: 292 },
+  16: { name: 'IQ2_XXS', blockSize: 256, typeSize: 66 },
+  17: { name: 'IQ2_XS', blockSize: 256, typeSize: 74 },
+  18: { name: 'IQ3_XXS', blockSize: 256, typeSize: 98 },
+  19: { name: 'IQ1_S', blockSize: 256, typeSize: 50 },
+  20: { name: 'IQ4_NL', blockSize: 32, typeSize: 18 },
+  21: { name: 'IQ3_S', blockSize: 256, typeSize: 110 },
+  22: { name: 'IQ2_S', blockSize: 256, typeSize: 82 },
+  23: { name: 'IQ4_XS', blockSize: 256, typeSize: 136 },
+  24: { name: 'I8', blockSize: 1, typeSize: 1 },
+  25: { name: 'I16', blockSize: 1, typeSize: 2 },
+  26: { name: 'I32', blockSize: 1, typeSize: 4 },
+  27: { name: 'I64', blockSize: 1, typeSize: 8 },
+  28: { name: 'F64', blockSize: 1, typeSize: 8 },
+  29: { name: 'IQ1_M', blockSize: 256, typeSize: 56 },
+  30: { name: 'BF16', blockSize: 1, typeSize: 2 },
+  34: { name: 'TQ1_0', blockSize: 256, typeSize: 54 },
+  35: { name: 'TQ2_0', blockSize: 256, typeSize: 66 },
+  39: { name: 'MXFP4', blockSize: 32, typeSize: 17 },
+  40: { name: 'NVFP4', blockSize: 64, typeSize: 36 },
+  41: { name: 'Q1_0', blockSize: 128, typeSize: 18 },
+};


### PR DESCRIPTION
Adds a model file tensor metadata API and a model version details panel that reads SafeTensor and GGUF headers with byte range requests. Checkpoint primary weight files include an estimated minimum VRAM value based on Comfy dynamic offload reserves, while LoRA, VAE, text encoder, and additional resource files only expose tensor metadata without VRAM requirements. Validated with TypeScript and formatting checks.