### PR TITLE
obs: unsampled per-route 5xx counter for SLO attribution

### DIFF
--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -5,6 +5,7 @@ import { withAxiom } from '@civitai/next-axiom';
 import { isProd } from '~/env/other';
 import { createContext } from '~/server/createContext';
 import { logToAxiom, safeError } from '~/server/logging/client';
+import { recordTrpcError } from '~/server/prom/http-errors';
 import { appRouter } from '~/server/routers';
 
 export const config = {
@@ -40,6 +41,10 @@ const trpcHandler = createNextApiHandler({
     return Object.keys(headers).length > 0 ? { headers } : {};
   },
   onError: async ({ error, type, path, input, ctx, req }) => {
+    // Unsampled per-procedure 5xx attribution (no-ops for 4xx-class errors).
+    // Source of truth for the tRPC slice of the 5xx SLO; see http-errors.ts.
+    recordTrpcError(error, path);
+
     if (isProd) {
       // Auth-class rejections (FORBIDDEN / UNAUTHORIZED) are client-fault 4xx
       // responses — the status code already tells the caller + edge what

--- a/src/server/prom/http-errors.ts
+++ b/src/server/prom/http-errors.ts
@@ -1,29 +1,37 @@
 import client from 'prom-client';
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
-import type { TRPCError } from '@trpc/server';
+import { TRPCError } from '@trpc/server';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 // ---------------------------------------------------------------------------
-// Unsampled per-route 5xx attribution counter
+// Unsampled per-route APP-EMITTED 5xx attribution counter
 // ---------------------------------------------------------------------------
 //
-// WHY: there is no trustworthy way to attribute the 5xx floor to routes today.
+// WHY: there is no trustworthy way to attribute the app-500 floor to routes.
 //  - OTEL spanmetrics are HEAD-sampled (TraceIdRatioBasedSampler @ 0.1 in
-//    instrumentation.node.ts) AND their span_name is polluted by raw scanner URLs
-//    (`GET /&ved=...google...`), so the per-route 500 ranking is both 10%-sampled
-//    and cardinality-blown (~11k series for one service).
-//  - tRPC/API errors go to Axiom, which isn't queryable in Prometheus for an SLO.
+//    instrumentation.node.ts) AND their span_name is cardinality-blown by raw
+//    scanner URLs (`GET /&ved=...google...`, ~11k series for one service).
+//  - tRPC/API errors only reach Axiom, which isn't queryable in Prometheus.
 //
-// This counter is the unsampled source of truth for "which routes drive the 5xx
-// floor". It runs in the request path (NOT via a span processor), so trace
-// sampling does not apply — every 5xx is counted. See the decomposition in
-// datapacket-talos: claudedocs/dp-prod-error-latency-slo-characterization-2026-06-12.md
+// SCOPE (important): this counts 5xx that the APP ITSELF emits — i.e. the ~500
+// class. Edge/Traefik-generated 502/504 (event-loop pin, liveness SIGKILL,
+// gateway timeout on a hung upstream) never run app code, so a `finish` listener
+// can't see them and they are NOT counted here. Use the Traefik
+// `traefik_service_requests_total{code=~"5.."}` series as the full 5xx floor
+// denominator; this counter is the per-route source of truth for the app-500
+// slice of it. See datapacket-talos
+// claudedocs/dp-prod-error-latency-slo-characterization-2026-06-12.md (O1).
 //
 // HOT PATH: this codebase is main-thread-CPU sensitive (Redis/Prisma OTEL spans
 // were removed for exactly this reason). The only steady-state cost added per
 // request is registering one `res.once('finish')` closure + an integer compare;
-// the route-normalization work below runs ONLY on 5xx responses (~0.3% of
-// traffic), never on the 2xx hot path.
+// the route-normalization below runs ONLY on 5xx responses (~0.3% of traffic).
+//
+// INVARIANT: import this module ONLY from the request webpack graph (API routes /
+// pages). prom-client keeps a per-graph default registry, and `/api/metrics`
+// scrapes the request graph's. If an `instrumentation.*` import ever pulled this
+// into the instrumentation graph first, the counter would register into the wrong
+// registry and silently stop being scraped (the PR #2451 class of bug).
 
 const NAME = 'civitai_app_http_errors_total';
 
@@ -32,90 +40,113 @@ declare global {
   var __civitaiHttpErrorCounter: client.Counter<string> | undefined;
 }
 
-// Request-graph metric → default `client.register`, which `/api/metrics` scrapes.
-// Pin on globalThis so HMR re-evals / a second webpack graph reuse the one
+// Pin on globalThis so HMR re-evals / a second request-graph eval reuse the one
 // instance instead of throwing prom-client's duplicate-registration error (same
-// trap documented for instrumentationRegistry in src/server/prom/client.ts).
+// trap documented for instrumentationRegistry in src/server/prom/client.ts). The
+// `??` short-circuits BEFORE `new client.Counter`, so the constructor runs once.
 export const httpErrorCounter: client.Counter<string> =
   globalThis.__civitaiHttpErrorCounter ??
   (globalThis.__civitaiHttpErrorCounter = new client.Counter({
     name: NAME,
-    help: 'Count of 5xx HTTP responses by normalized route, status code, and kind (api|trpc). Unsampled; source of truth for per-route 5xx SLO attribution.',
+    help: 'Count of APP-EMITTED 5xx (~500-class) responses by normalized route, status, and kind (api|trpc). Unsampled. Does NOT include edge/Traefik 502/504 (the app never runs for those) — use Traefik code=~"5.." for the full floor. Per-route source of truth for the app-500 slice.',
     labelNames: ['route', 'status', 'kind'],
   }));
+
+type Kind = 'api' | 'trpc';
+
+// ---------------------------------------------------------------------------
+// Bounded distinct-route tracking (hard cardinality cap, grow-only, per kind)
+// ---------------------------------------------------------------------------
+//
+// Sized to cover the real route surface so legit routes are NEVER lost to
+// <overflow> — ~203 wrapped Pages-API route files and ~870 tRPC procedures. With
+// route params normalized and query-string keys excluded (see reconstructApiRoute),
+// nothing user-controlled can inflate this; only genuinely novel real routes
+// beyond the budget collapse. Per-kind so a tRPC error storm can't starve the API
+// budget (or vice-versa).
+const ROUTE_BUDGET: Record<Kind, number> = { api: 400, trpc: 1000 };
+const seenByKind: Record<Kind, Set<string>> = { api: new Set(), trpc: new Set() };
+
+function bounded(route: string, kind: Kind): string {
+  const seen = seenByKind[kind];
+  if (seen.has(route)) return route;
+  if (seen.size >= ROUTE_BUDGET[kind]) return `${kind} <overflow>`;
+  seen.add(route);
+  return route;
+}
 
 // ---------------------------------------------------------------------------
 // Route normalization (runs only on 5xx)
 // ---------------------------------------------------------------------------
-//
-// We can't read the route from the OTEL span (90% are non-recording under head
-// sampling). Instead reconstruct the Next route PATTERN from the request: Next
-// populates `req.query` with the dynamic route params, so replacing each param
-// VALUE in the path with `[key]` yields the file-route pattern
-// (e.g. `/api/download/training/[modelVersionId]`). A structural pass collapses
-// anything left (numeric ids, hashes, junk segments), and a hard distinct-label
-// cap is the final backstop so no input can ever blow up cardinality.
 
-const SEEN = new Set<string>();
-const MAX_DISTINCT_ROUTES = 300;
-
-function structuralCollapse(segment: string): string {
-  if (/^\d+$/.test(segment)) return ':id';
-  if (/^[0-9a-f]{16,}$/i.test(segment)) return ':hash';
-  if (segment.length > 48) return ':long';
-  if (/[^a-zA-Z0-9._[\]-]/.test(segment)) return ':param'; // contains query/junk chars
-  return segment;
+function collapseSegment(seg: string): string {
+  if (/^\d+$/.test(seg)) return ':id';
+  if (/^[0-9a-f]{16,}$/i.test(seg)) return ':hash';
+  if (seg.length > 40) return ':long';
+  // Defense-in-depth (M2): a leftover segment here SHOULD be a static route word —
+  // matched routes reach this code only for their literal path parts; dynamic
+  // segments are req.query route params and are replaced upstream by [key]. But
+  // guard against an un-replaced opaque token (e.g. a percent-encoding mismatch
+  // between req.url and the decoded req.query value) leaking verbatim into a label:
+  if (/[^a-zA-Z0-9._-]/.test(seg)) return ':param'; // query/junk chars
+  if (seg.length >= 16 && /[a-z]/.test(seg) && /[A-Z]/.test(seg) && /\d/.test(seg)) return ':token';
+  return seg;
 }
 
 function reconstructApiRoute(req: NextApiRequest): string {
   const method = (req.method ?? 'GET').toUpperCase();
-  let path: string;
+  let pathname: string;
+  let queryStringKeys: Set<string>;
   try {
-    path = new URL(req.url ?? '/', 'http://x').pathname;
+    const url = new URL(req.url ?? '/', 'http://x');
+    pathname = url.pathname;
+    queryStringKeys = new Set(url.searchParams.keys());
   } catch {
     return `${method} <bad-url>`;
   }
-  if (!path.startsWith('/api/')) return `${method} <non-api>`;
+  if (!pathname.startsWith('/api/')) return `${method} <non-api>`;
 
-  // Replace dynamic route-param values (whole segments only) with [key].
+  // Next merges the dynamic ROUTE params and the query string into a single
+  // req.query. The route params are exactly the keys NOT present in the URL's
+  // query string. We must only value-match against route params: matching against
+  // query-string values is attacker-controllable — appending `?j=v1` would rewrite
+  // the static `/v1` segment, splitting/poisoning route labels and exhausting the
+  // cardinality budget. Build an exact value→[key] map from route params only.
   const query = req.query ?? {};
+  const valueToParam = new Map<string, string>();
   for (const key of Object.keys(query)) {
+    if (queryStringKeys.has(key)) continue; // query-string param — not a route param
     const val = query[key];
     const values = Array.isArray(val) ? val : [val];
     for (const v of values) {
-      if (typeof v === 'string' && v.length >= 1 && path.includes(`/${v}`)) {
-        path = path.split(`/${v}`).join(`/[${key}]`);
-      }
+      if (typeof v === 'string' && v.length >= 1) valueToParam.set(v, `[${key}]`);
     }
   }
 
-  const segments = path.split('/').filter(Boolean).map(structuralCollapse).slice(0, 6);
+  // Replace by EXACT whole-segment equality (no substring `includes/split`).
+  const segments = pathname
+    .split('/')
+    .filter(Boolean)
+    .map((seg) => valueToParam.get(seg) ?? collapseSegment(seg))
+    .slice(0, 6);
   return `${method} /${segments.join('/')}`;
-}
-
-// Hard cardinality backstop: once we've observed MAX_DISTINCT_ROUTES patterns,
-// collapse any new one to `<overflow>` so a novel garbage stream can never grow
-// the series count without bound.
-function bounded(route: string, kindPrefix: string): string {
-  if (SEEN.has(route)) return route;
-  if (SEEN.size >= MAX_DISTINCT_ROUTES) return `${kindPrefix} <overflow>`;
-  SEEN.add(route);
-  return route;
 }
 
 /**
  * Attach a one-shot `finish` listener that records the response as a 5xx error
- * iff its final status is >= 500. Catches the error no matter how it was produced
- * (handleEndpointError, a direct `res.status(500)`, or an uncaught throw Next
- * turns into a default 500). Safe to call once per request from the endpoint
- * wrappers; a metric failure can never break the response.
+ * iff its final status is >= 500. Catches an app-emitted 5xx no matter how it was
+ * produced (handleEndpointError, a direct `res.status(500)`, or an uncaught throw
+ * Next turns into a default 500). NOTE: `finish` only fires when the app completes
+ * the response — client-aborted / hung / edge-timed-out requests (the 504 set) do
+ * not run this, by design (see the SCOPE note above). A metric failure can never
+ * break the response.
  */
 export function instrumentApiResponse(req: NextApiRequest, res: NextApiResponse): void {
   res.once('finish', () => {
     const status = res.statusCode;
     if (status < 500) return; // hot-path: 2xx/3xx/4xx do zero normalization work
     try {
-      const route = bounded(reconstructApiRoute(req), (req.method ?? 'GET').toUpperCase());
+      const route = bounded(reconstructApiRoute(req), 'api');
       httpErrorCounter.inc({ route, status: String(status), kind: 'api' });
     } catch {
       /* never throw from telemetry */
@@ -125,12 +156,14 @@ export function instrumentApiResponse(req: NextApiRequest, res: NextApiResponse)
 
 /**
  * Record a tRPC error as a 5xx by procedure path. The procedure path is already a
- * clean, low-cardinality label (e.g. `image.getInfinite`). 4xx-class tRPC errors
- * (BAD_REQUEST/NOT_FOUND/etc.) are ignored — only server-fault 5xx count toward
- * the SLO.
+ * clean, low-cardinality label (e.g. `image.getInfinite`). Only genuine TRPCErrors
+ * that map to >= 500 count — 4xx-class errors and any non-TRPCError cause passed by
+ * tRPC's streaming/jsonl error paths are ignored (the latter would otherwise be
+ * miscounted as 500 by getHTTPStatusCodeFromError's undefined→500 fallback).
  */
-export function recordTrpcError(error: TRPCError, path?: string): void {
+export function recordTrpcError(error: unknown, path?: string): void {
   try {
+    if (!(error instanceof TRPCError)) return;
     const status = getHTTPStatusCodeFromError(error);
     if (status < 500) return;
     const route = bounded(`trpc/${path ?? 'unknown'}`, 'trpc');

--- a/src/server/prom/http-errors.ts
+++ b/src/server/prom/http-errors.ts
@@ -1,0 +1,141 @@
+import client from 'prom-client';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import type { TRPCError } from '@trpc/server';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// ---------------------------------------------------------------------------
+// Unsampled per-route 5xx attribution counter
+// ---------------------------------------------------------------------------
+//
+// WHY: there is no trustworthy way to attribute the 5xx floor to routes today.
+//  - OTEL spanmetrics are HEAD-sampled (TraceIdRatioBasedSampler @ 0.1 in
+//    instrumentation.node.ts) AND their span_name is polluted by raw scanner URLs
+//    (`GET /&ved=...google...`), so the per-route 500 ranking is both 10%-sampled
+//    and cardinality-blown (~11k series for one service).
+//  - tRPC/API errors go to Axiom, which isn't queryable in Prometheus for an SLO.
+//
+// This counter is the unsampled source of truth for "which routes drive the 5xx
+// floor". It runs in the request path (NOT via a span processor), so trace
+// sampling does not apply — every 5xx is counted. See the decomposition in
+// datapacket-talos: claudedocs/dp-prod-error-latency-slo-characterization-2026-06-12.md
+//
+// HOT PATH: this codebase is main-thread-CPU sensitive (Redis/Prisma OTEL spans
+// were removed for exactly this reason). The only steady-state cost added per
+// request is registering one `res.once('finish')` closure + an integer compare;
+// the route-normalization work below runs ONLY on 5xx responses (~0.3% of
+// traffic), never on the 2xx hot path.
+
+const NAME = 'civitai_app_http_errors_total';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiHttpErrorCounter: client.Counter<string> | undefined;
+}
+
+// Request-graph metric → default `client.register`, which `/api/metrics` scrapes.
+// Pin on globalThis so HMR re-evals / a second webpack graph reuse the one
+// instance instead of throwing prom-client's duplicate-registration error (same
+// trap documented for instrumentationRegistry in src/server/prom/client.ts).
+export const httpErrorCounter: client.Counter<string> =
+  globalThis.__civitaiHttpErrorCounter ??
+  (globalThis.__civitaiHttpErrorCounter = new client.Counter({
+    name: NAME,
+    help: 'Count of 5xx HTTP responses by normalized route, status code, and kind (api|trpc). Unsampled; source of truth for per-route 5xx SLO attribution.',
+    labelNames: ['route', 'status', 'kind'],
+  }));
+
+// ---------------------------------------------------------------------------
+// Route normalization (runs only on 5xx)
+// ---------------------------------------------------------------------------
+//
+// We can't read the route from the OTEL span (90% are non-recording under head
+// sampling). Instead reconstruct the Next route PATTERN from the request: Next
+// populates `req.query` with the dynamic route params, so replacing each param
+// VALUE in the path with `[key]` yields the file-route pattern
+// (e.g. `/api/download/training/[modelVersionId]`). A structural pass collapses
+// anything left (numeric ids, hashes, junk segments), and a hard distinct-label
+// cap is the final backstop so no input can ever blow up cardinality.
+
+const SEEN = new Set<string>();
+const MAX_DISTINCT_ROUTES = 300;
+
+function structuralCollapse(segment: string): string {
+  if (/^\d+$/.test(segment)) return ':id';
+  if (/^[0-9a-f]{16,}$/i.test(segment)) return ':hash';
+  if (segment.length > 48) return ':long';
+  if (/[^a-zA-Z0-9._[\]-]/.test(segment)) return ':param'; // contains query/junk chars
+  return segment;
+}
+
+function reconstructApiRoute(req: NextApiRequest): string {
+  const method = (req.method ?? 'GET').toUpperCase();
+  let path: string;
+  try {
+    path = new URL(req.url ?? '/', 'http://x').pathname;
+  } catch {
+    return `${method} <bad-url>`;
+  }
+  if (!path.startsWith('/api/')) return `${method} <non-api>`;
+
+  // Replace dynamic route-param values (whole segments only) with [key].
+  const query = req.query ?? {};
+  for (const key of Object.keys(query)) {
+    const val = query[key];
+    const values = Array.isArray(val) ? val : [val];
+    for (const v of values) {
+      if (typeof v === 'string' && v.length >= 1 && path.includes(`/${v}`)) {
+        path = path.split(`/${v}`).join(`/[${key}]`);
+      }
+    }
+  }
+
+  const segments = path.split('/').filter(Boolean).map(structuralCollapse).slice(0, 6);
+  return `${method} /${segments.join('/')}`;
+}
+
+// Hard cardinality backstop: once we've observed MAX_DISTINCT_ROUTES patterns,
+// collapse any new one to `<overflow>` so a novel garbage stream can never grow
+// the series count without bound.
+function bounded(route: string, kindPrefix: string): string {
+  if (SEEN.has(route)) return route;
+  if (SEEN.size >= MAX_DISTINCT_ROUTES) return `${kindPrefix} <overflow>`;
+  SEEN.add(route);
+  return route;
+}
+
+/**
+ * Attach a one-shot `finish` listener that records the response as a 5xx error
+ * iff its final status is >= 500. Catches the error no matter how it was produced
+ * (handleEndpointError, a direct `res.status(500)`, or an uncaught throw Next
+ * turns into a default 500). Safe to call once per request from the endpoint
+ * wrappers; a metric failure can never break the response.
+ */
+export function instrumentApiResponse(req: NextApiRequest, res: NextApiResponse): void {
+  res.once('finish', () => {
+    const status = res.statusCode;
+    if (status < 500) return; // hot-path: 2xx/3xx/4xx do zero normalization work
+    try {
+      const route = bounded(reconstructApiRoute(req), (req.method ?? 'GET').toUpperCase());
+      httpErrorCounter.inc({ route, status: String(status), kind: 'api' });
+    } catch {
+      /* never throw from telemetry */
+    }
+  });
+}
+
+/**
+ * Record a tRPC error as a 5xx by procedure path. The procedure path is already a
+ * clean, low-cardinality label (e.g. `image.getInfinite`). 4xx-class tRPC errors
+ * (BAD_REQUEST/NOT_FOUND/etc.) are ignored — only server-fault 5xx count toward
+ * the SLO.
+ */
+export function recordTrpcError(error: TRPCError, path?: string): void {
+  try {
+    const status = getHTTPStatusCodeFromError(error);
+    if (status < 500) return;
+    const route = bounded(`trpc/${path ?? 'unknown'}`, 'trpc');
+    httpErrorCounter.inc({ route, status: String(status), kind: 'trpc' });
+  } catch {
+    /* never throw from telemetry */
+  }
+}

--- a/src/server/prom/http-errors.ts
+++ b/src/server/prom/http-errors.ts
@@ -48,7 +48,7 @@ export const httpErrorCounter: client.Counter<string> =
   globalThis.__civitaiHttpErrorCounter ??
   (globalThis.__civitaiHttpErrorCounter = new client.Counter({
     name: NAME,
-    help: 'Count of APP-EMITTED 5xx (~500-class) responses by normalized route, status, and kind (api|trpc). Unsampled. Does NOT include edge/Traefik 502/504 (the app never runs for those) — use Traefik code=~"5.." for the full floor. Per-route source of truth for the app-500 slice.',
+    help: 'Count of APP-EMITTED 5xx responses by normalized route, status, kind. UNSAMPLED. kind=api increments per RESPONSE (once per 5xx); kind=trpc increments per PROCEDURE-error (a batched request can increment several times) — account for this when summing. EDGE-generated 502/504 (event-loop pin, liveness SIGKILL, gateway timeout) are NOT counted: the app never runs for those — use Traefik code=~"5.." for the full floor. App-THROWN 5xx (incl. a TRPCError mapping to 502/503/504) ARE counted. Per-route source of truth for the app-emitted 5xx slice.',
     labelNames: ['route', 'status', 'kind'],
   }));
 
@@ -81,7 +81,11 @@ function bounded(route: string, kind: Kind): string {
 
 function collapseSegment(seg: string): string {
   if (/^\d+$/.test(seg)) return ':id';
-  if (/^[0-9a-f]{16,}$/i.test(seg)) return ':hash';
+  // 8+ hex (was 16+) so short hashes — e.g. the 10-char AutoV2 model hash — that
+  // slip past `[key]` replacement on a route-param/query-key collision collapse to
+  // :hash instead of leaking verbatim into a label. No static API route segment is
+  // 8+ pure-hex, so legit routes are unaffected.
+  if (/^[0-9a-f]{8,}$/i.test(seg)) return ':hash';
   if (seg.length > 40) return ':long';
   // Defense-in-depth (M2): a leftover segment here SHOULD be a static route word —
   // matched routes reach this code only for their literal path parts; dynamic

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -14,15 +14,30 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { generateSecretHash } from '~/server/utils/key-generator';
 import { getAllServerHosts } from '~/server/utils/server-domain';
 import type { Partner } from '~/shared/utils/prisma/models';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { isDefined } from '~/utils/type-guards';
 
 type AxiomAPIRequest = NextApiRequest & { log: Logger };
+
+// Single chokepoint every endpoint wrapper funnels through (in place of a bare
+// `withAxiom`). Records a `civitai_app_http_errors_total` sample for any 5xx
+// response — however it's produced — by attaching one `finish` listener. Steady-
+// state cost is one listener registration + an int compare; the route
+// normalization runs only on 5xx. See src/server/prom/http-errors.ts.
+function withApiMetrics(
+  handler: (req: AxiomAPIRequest, res: NextApiResponse) => Promise<void | NextApiResponse>
+) {
+  return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+    instrumentApiResponse(req, res);
+    return handler(req, res);
+  });
+}
 
 export function TokenSecuredEndpoint(
   token: string,
   handler: (req: AxiomAPIRequest, res: NextApiResponse) => Promise<void>
 ) {
-  return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     if (req.query.token !== token) {
       res.status(401).json({ error: 'Unauthorized' });
       return;
@@ -86,7 +101,7 @@ export function PublicEndpoint(
   handler: (req: AxiomAPIRequest, res: NextApiResponse) => Promise<void | NextApiResponse>,
   allowedMethods: string[] = ['GET']
 ) {
-  return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     const shouldStop = addCorsHeaders(req, res, allowedMethods);
     addPublicCacheHeaders(req, res);
     if (shouldStop) return;
@@ -102,7 +117,7 @@ export function AuthedEndpoint(
   ) => Promise<void | NextApiResponse>,
   allowedMethods: string[] = ['GET']
 ) {
-  return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     const shouldStop = addCorsHeaders(req, res, allowedMethods, { allowCredentials: true });
     if (shouldStop) return;
 
@@ -123,7 +138,7 @@ export function MixedAuthEndpoint(
   ) => Promise<void | NextApiResponse>,
   allowedMethods: string[] = ['GET']
 ) {
-  return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     if (!req.method || !allowedMethods.includes(req.method))
       return res.status(405).json({ error: 'Method not allowed' });
 
@@ -159,7 +174,7 @@ export function PartnerEndpoint(
   handler: (req: AxiomAPIRequest, res: NextApiResponse, partner: Partner) => Promise<void>,
   allowedMethods: string[] = ['GET']
 ) {
-  return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     if (!req.method || !allowedMethods.includes(req.method))
       return res.status(405).json({ error: 'Method not allowed' });
 
@@ -177,7 +192,7 @@ export function ModEndpoint(
   handler: (req: AxiomAPIRequest, res: NextApiResponse, user: SessionUser) => Promise<void>,
   allowedMethods: string[] = ['GET']
 ) {
-  return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  return withApiMetrics(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     if (!req.method || !allowedMethods.includes(req.method)) {
       res.setHeader('Allow', allowedMethods);
       return res.status(405).json({ error: 'Method not allowed' });

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -29,7 +29,10 @@ function withApiMetrics(
 ) {
   return withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     instrumentApiResponse(req, res);
-    return handler(req, res);
+    // `await` without returning so this closure is Promise<void> — withAxiom's
+    // AxiomApiHandler overload requires that, and withAxiom already discards a
+    // handler's return value (same shape the 6 wrappers below rely on).
+    await handler(req, res);
   });
 }
 


### PR DESCRIPTION
## What

Adds `civitai_app_http_errors_total{route, status, kind}` — an **unsampled** Prometheus counter that attributes every 5xx response to a normalized route. It's the source of truth for *which routes drive the app-emitted 500 slice* of the 5xx floor. (Edge/Traefik 502/504 run no app code and are not counted here — see the audit comment below; use Traefik `code=~"5.."` for the full floor.)

## Why

Per-route 500 attribution is currently impossible:
- **OTEL spanmetrics are head-sampled** (`TraceIdRatioBasedSampler` @ 0.1 in `instrumentation.node.ts`) **and** their `span_name` is cardinality-polluted by raw scanner URLs (`GET /&ved=...google...` → ~11k series for one service). So the per-route 500 ranking is both 10%-sampled and unusable.
- **tRPC/API errors only reach Axiom**, which isn't queryable in Prometheus for an SLO.

This blocks any data-driven work on the 5xx floor (dp-prod SSR sits ~0.47%, ~91% genuine app 500s).

## How

- **`src/server/prom/http-errors.ts`** (new): the counter + a **sampling-independent** route reconstruction. Because the OTEL span is non-recording for ~90% of requests under head sampling, we rebuild the Next route *pattern* from `req.query` (Next populates it with the dynamic route params → replace each param value in the path with `[key]`), with a structural collapse for ids/hashes/junk and a hard **300-distinct-route cardinality cap** as a backstop.
- **`src/server/utils/endpoint-helpers.ts`**: one `withApiMetrics` chokepoint that all 6 endpoint wrappers funnel through (in place of a bare `withAxiom`). Catches a 5xx however it's produced — `handleEndpointError`, a direct `res.status(500)`, or an uncaught throw.
- **`src/pages/api/trpc/[trpc].ts`**: per-procedure 5xx recording in `onError` (procedure path is already a clean label; 4xx-class errors are ignored).

## Hot-path cost

This codebase is main-thread-CPU sensitive (Redis/Prisma OTEL spans were removed for exactly this reason). The only steady-state cost added is **one `res.once('finish')` registration + an integer compare**. All route-normalization work runs **only when `statusCode >= 500`** (~0.3% of traffic) — never on the 2xx hot path. Telemetry failures can never throw into a response.

## Deployment

Lands in the default `client.register`, already exposed via `/api/metrics` and scraped by the existing ServiceMonitor (`honorLabels: true`) — **no manifest change needed**. The metric appears automatically once deployed.

Query once live:
```promql
topk(20, sum by (route)(rate(civitai_app_http_errors_total{status="500"}[6h])))
```

## Coverage / known gap

Captures all wrapper-based Pages-API routes + every tRPC procedure. **Does not yet capture** bare handlers that don't use a wrapper (e.g. `/api/og.tsx`) or SSR-page / unmatched-framework 500s — a fast-follow (those overlap with the separate "garbage URLs should 404 not 500" cleanup).

## Verification

Type-clean (the changed files produce no `tsc` errors). **Not yet runtime-verified** — needs a deploy to generate real 5xx and confirm the counter increments with sane route labels.

Context: datapacket-talos `claudedocs/dp-prod-error-latency-slo-characterization-2026-06-12.md` (item O1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
