### PR TITLE
test(preview): ride out image-search 408 in the image-feed spec

### DIFF
--- a/tests/preview-image-feed.spec.ts
+++ b/tests/preview-image-feed.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { storageStatePath } from './preview-fixtures';
 import { trpcQuery } from './preview-trpc';
+import { retryFlaky } from './preview-retry';
 
 /**
  * Image-feed content smoke: the real /images browse feed actually renders content.
@@ -57,10 +58,16 @@ test.describe('images browse feed renders real content (tester)', () => {
     // background traffic never idles, so a networkidle nav hangs to timeout.
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
-    const data = await trpcQuery<{ items: Array<{ id: number }> }>(
-      page.request,
-      'image.getInfinite',
-      { limit: FEED_LIMIT }
+    // image.getInfinite is meili-backed via the shared in-cluster feeds-proxy, which
+    // intermittently returns HTTP 408 ("Image search is temporarily overloaded —
+    // please retry") under concurrent preview-build load. The app's own error tells
+    // us to retry; Playwright's whole-test retries fire within seconds (all <5s) so
+    // they don't outlast the overload. retryFlaky spaces the retries with backoff to
+    // ride it out — honest: a sustained overload still fails after the attempts.
+    const data = await retryFlaky('image.getInfinite feed', () =>
+      trpcQuery<{ items: Array<{ id: number }> }>(page.request, 'image.getInfinite', {
+        limit: FEED_LIMIT,
+      })
     );
 
     const items = data?.items ?? [];


### PR DESCRIPTION
## What

Wraps the image-feed spec's `image.getInfinite` query in `retryFlaky` so a transient image-search overload is ridden out instead of hard-failing.

## Why

`image.getInfinite` is meili-backed via the shared in-cluster `civitai-feeds-proxy`, which intermittently returns **HTTP 408 — "Image search is temporarily overloaded — please retry"** under concurrent preview-build load. This is the **same flaky search path** the #2495 resilience fix addressed for `whatIf` + `/moderator/images`, but the image-feed spec was missed — so it just hard-failed an unrelated PR (#2501, an obs counter change). All 3 of Playwright's whole-test retries fired in <5s — too fast to outlast the overload.

The app's own 408 explicitly says to retry; `retryFlaky` does it with backoff (honest — a sustained overload still fails after the attempts). Completes the resilience coverage across the search-dependent specs. Report-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
