### PR TITLE
fix(metrics): break article.metrics circular import (Next 16 async-module TDZ → 500s)

### DIFF
--- a/src/server/metrics/article.metrics.ts
+++ b/src/server/metrics/article.metrics.ts
@@ -2,12 +2,19 @@ import { chunk } from 'lodash-es';
 import type { MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
-import { articlesSearchIndex } from '~/server/search-index';
+// NOTE: `articlesSearchIndex` ('~/server/search-index') and `articleStatCache`
+// ('~/server/redis/caches') are imported LAZILY inside update() rather than at the
+// top level. Statically they form a circular import back into this module; under
+// Next 16 / Turbopack these become async modules, which opened a cold-start window
+// where this module's `articleMetrics` export was read before it was assigned →
+// `ReferenceError: Cannot access 'S' before initialization` → 500s on api-heavy.
+// Both are only used at runtime inside update(), so deferring the import is safe and
+// breaks the cycle. These are the only two imports unique to article.metrics vs the
+// other 14 metric processors, which is why only this one threw.
 import { createLogger } from '~/utils/logging';
 import type { Task } from '~/server/utils/concurrency-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { executeRefresh, getAffected, getEntityMetricTasks } from '~/server/metrics/metric-helpers';
-import { articleStatCache } from '~/server/redis/caches';
 import type { ArticleMetric } from '~/shared/utils/prisma/models';
 import { templateHandler } from '~/server/db/db-helpers';
 
@@ -71,6 +78,8 @@ export const articleMetrics = createMetricProcessor({
     //---------------------------------------
     const affectedArticleIds = Object.keys(ctx.updates).map((id) => parseInt(id, 10));
     log('update search index', affectedArticleIds.length, 'articles');
+    // Lazy import — breaks the static circular import (see top-of-file note).
+    const { articlesSearchIndex } = await import('~/server/search-index');
     await articlesSearchIndex.queueUpdate(
       affectedArticleIds.map((id) => ({
         id,
@@ -82,6 +91,8 @@ export const articleMetrics = createMetricProcessor({
     //---------------------------------------
     log('bust article stat cache', affectedArticleIds.length, 'articles');
     if (affectedArticleIds.length > 0) {
+      // Lazy import — breaks the static circular import (see top-of-file note).
+      const { articleStatCache } = await import('~/server/redis/caches');
       await articleStatCache.bust(affectedArticleIds);
     }
   },


### PR DESCRIPTION
## Problem

dp-prod has been emitting `ReferenceError: Cannot access 'S' before initialization` from `Module.articleMetrics` (chunk `_1c47399._.js`) → `INTERNAL_SERVER_ERROR` (HTTP 500) on **api-heavy**, on article-related tRPC queries. Observed **10–35k errors/hour for ~24h**, surfacing as user-facing GET-500 amplitude spikes (peaks ~24/s, ~1–2% of apex GET traffic) that burst on freshly-scaled/cold api-heavy pods and self-resolve as each pod warms.

## Root cause

`article.metrics.ts` statically imports two modules that transitively import back into it — a **circular dependency**:
- `articlesSearchIndex` from `~/server/search-index`
- `articleStatCache` from `~/server/redis/caches`

Pre-Next-16 these were synchronous modules and the cycle was benign. Under **Next 16 / Turbopack** they compile to **async modules** (`e.a(async ...)`, awaiting their deps). The generated code is:

```js
e.s(["articleMetrics", () => S]);          // export getter
[...deps] = await p;                        // module awaits its deps
let ..., S = createMetricProcessor({...});  // S assigned only AFTER the await
```

This opens a **cold-start window**: the module factory registers the `articleMetrics` export getter `() => S` before the `await` resolves and `S` is assigned. A request that reads `articleMetrics` during that window (via the circular importer, on a cold pod) hits `S` in its temporal dead zone → ReferenceError → 500.

These two are the **only imports unique to `article.metrics` vs the other 14 metric processors** — which is exactly why only `articleMetrics` throws.

## Fix

Both symbols are used **only at runtime inside `update()`** (search-index `queueUpdate`, stat-cache `bust`), never at module-init — so defer them to lazy `await import()`. This removes them from the static import graph and breaks the cycle. Single file, +13/−2.

## Verification

⚠️ This failure is **Turbopack-chunking-dependent and can't be reproduced from source alone** — it needs a real build. Please verify on a preview / freshly-rolled api-heavy pod: article tRPC queries should no longer emit the `Cannot access 'S' before initialization` ReferenceError, and the dp-prod api-heavy 500 background (currently 10–35k/hr) should drop.

If this alone doesn't fully clear it, the fallback is to apply the same lazy-import treatment to any remaining cyclic edge, or to make the module non-async by breaking the transitive top-level-await chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)