### PR TITLE
fix(og): ship @vercel/og in standalone so /api/og stops 500ing

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -150,6 +150,22 @@ export default defineNextConfig(
       '/content/[[...slug]]': ['./src/static-content/**/*'],
       '/api/trpc/[trpc]': ['./src/static-content/**/*'],
       '/api/v1/content/[[...slug]]': ['./src/static-content/**/*'],
+      // /api/og uses next/og's `ImageResponse`, which on the nodejs runtime
+      // lazily require()s `next/dist/compiled/@vercel/og/index.node.js` (plus its
+      // resvg/yoga WASM + fonts). @vercel/nft cannot follow that dynamic require,
+      // so with output:'standalone' the file is DROPPED from the image and every
+      // origin (cache-miss) /api/og render throws `Cannot find module ...
+      // index.node.js` -> 500. This became the dominant app-500 source (~1.9/s)
+      // after the Next 16.2.7 upgrade; Cloudflare edge-caching of OG images masks
+      // it for popular entities. Force-include the whole compiled @vercel/og dir
+      // (entry + WASM + fonts) for this route. Two version-agnostic globs (no
+      // hardcoded next@<hash>): the symlinked path, plus the real pnpm path with a
+      // `next@*` wildcard in case globby doesn't follow the node_modules/next
+      // symlink. Whichever matches copies the files; a non-matching glob is a no-op.
+      '/api/og': [
+        './node_modules/next/dist/compiled/@vercel/og/**/*',
+        './node_modules/.pnpm/next@*/node_modules/next/dist/compiled/@vercel/og/**/*',
+      ],
     },
     experimental: {
       // scrollRestoration: true,

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -661,7 +661,12 @@ function FallbackCard() {
         }}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={`${baseUrl}/images/logo_dark_mode.png`} height={60} alt="" />
+        {/* satori requires an explicit width+height on remote <img> or it throws
+            "Image size cannot be determined" — which made FallbackCard itself 500,
+            so any missing entity (or any OgCard render error) hit the catch's
+            fallback and STILL returned 500. logo_dark_mode.png is 142x30 (≈4.733),
+            so width 284 keeps aspect at height 60. */}
+        <img src={`${baseUrl}/images/logo_dark_mode.png`} width={284} height={60} alt="" />
         <div style={{ display: 'flex', fontSize: 16, color: colors.textSecondary }}>
           The Home of Open-Source Generative AI
         </div>


### PR DESCRIPTION
## Problem

`/api/og` (OG/social-share image generator) returns **500 on ~100% of origin requests** — the dominant app-emitted 500 source on dp-prod at **~1.9/s (~74% of the app-500 floor)** since the Next 16.2.7 upgrade.

**Root cause:** `src/pages/api/og.tsx` renders via `next/og`'s `ImageResponse`, which on the nodejs runtime lazily `require()`s `next/dist/compiled/@vercel/og/index.node.js` (plus its `resvg.wasm`/`yoga.wasm` + fonts). `@vercel/nft` can't follow that dynamic require, so with `output: 'standalone'` the file is traced **out** of the deployed image. Every cache-miss render then throws:
```
OG image generation failed: Error: Cannot find module
'/app/node_modules/.pnpm/next@16.2.7_.../next/dist/compiled/@vercel/og/index.node.js'
```
→ the handler's catch returns `res.status(500)`.

Cloudflare edge-caching of OG images masked this for popular entities (cached 200s), but **cache-bypass returns 500 for every type** — verified on prod: `model`, `image`, `post`, `article` all 500 with `Cache-Control: no-cache`.

This was surfaced by the new `civitai_app_http_errors_total` counter's coverage reconciliation: the counter captured only ~26% of the Traefik 500 floor, and the ~74% gap traced to `/api/og` (a bare handler that bypasses the instrumented wrappers, so the counter is blind to it — the SSR-pool 500s were `/api/og`, not page renders).

## Fix

Add `/api/og` to `outputFileTracingIncludes` so the standalone build copies the compiled `@vercel/og` directory (entry + WASM + fonts). Two **version-agnostic** globs (no hardcoded `next@<hash>` — that would silently stop matching on a Next bump): the symlinked `node_modules/next/...` path and the real `.pnpm/next@*/...` path, to be robust to how globby resolves the pnpm symlink. A non-matching glob is a harmless no-op.

## Verification

⚠️ This is a build-packaging fix that **can't be fully verified without a standalone build** — `node --check` confirms config syntax only. **On the PR preview**, confirm a cache-busted request returns **200** (currently 500 at origin):
```
curl -s -o /dev/null -w '%{http_code}' -H 'Cache-Control: no-cache' \
  'https://pr-<N>.civitaic.com/api/og?type=model&id=4384&_cb=1'
```
And ideally confirm `index.node.js` is present under `.next/standalone/.../@vercel/og/` in the built image. Not yet runtime-verified.

## Follow-ups (separate, from the same investigation)
- Client-abort ("This operation was aborted") mislabeled as 500 on `/api/v1/images`, `/api/v1/models`, `image.getInfinite` (~0.43/s) → should be 499.
- `games.newOrder.getHistory` ClickHouse cursor not wrapped in `parseDateTimeBestEffort` (1-line bug).
- Instrument bare `/api/*` handlers (like this one) so the next such floor is auto-attributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)