### PR TITLE
security(app-blocks): flag-gate + replay-guard the build-callback webhook

### DIFF
--- a/docs/features/app-blocks-merge-audit-2026-06.md
+++ b/docs/features/app-blocks-merge-audit-2026-06.md
@@ -160,8 +160,12 @@ HMAC) is genuinely well-built and the dark boundary holds across routers/JWKS/mi
   the flag, so the k8s apply/deploy path could run independent of the kill switch; and the
   timestamp/nonce-less payload meant a captured signed callback could be replayed to
   re-trigger applies. Added: `isFlipt('app-blocks-enabled')` 503 gate + an `(appBlockId, sha)`
-  apply-path replay guard using an **atomic `SET NX EX`** (not `incrBy`+`expire`, which could
-  leave a permanent TTL-less key and wedge a sha), **fail-open** on Redis loss. TTL is **10m**
+  apply-path replay guard using the redis client's **`setNxKeepTtlWithEx`** primitive (atomic
+  Lua `SET NX`+`EXPIRE` returning a typed `boolean` — chosen over `redis.set(…,{NX,EX})` whose
+  return is fragile: the top-level `set` yields `'OK'`/`null` but `redis.packed.set` discards
+  it → `void`, so a refactor to the packed variant would silently no-op the guard; a boolean
+  primitive removes that class. Also not `incrBy`+`expire`, which could leave a permanent
+  TTL-less key and wedge a sha), **fail-open** on Redis loss. TTL is **10m**
   — sized to outlast the whole first attempt (~60s `triggerApply` + 6m `waitForApplyJob`) so
   the key can't expire mid-apply and let a late duplicate delete+restart the in-flight Job.
   The longer TTL doesn't suppress retries because **every failure path frees the slot

--- a/docs/features/app-blocks-merge-audit-2026-06.md
+++ b/docs/features/app-blocks-merge-audit-2026-06.md
@@ -139,3 +139,63 @@ the role list is only a Flipt-down fallback. The flag description itself documen
 **Before GA (turning it on):** H2 gate unification; iframe PII allowlist; showcase NSFW
 filter; git-push post-approval review + audit log; per-user buzz cap; rate-card sign-off
 before any payout wiring.
+
+---
+
+## Security audit (2026-06-13, dedicated security-engineer pass on shipped `5643eaba7`)
+
+A second, security-specialist audit of the **as-shipped** foundation (post-merge, live in
+prod, dark). It independently re-verified the panel audit's "hardened" claim against the
+live code and went deeper on the third-party-execution / auth / money surfaces.
+
+**Verdict: ✅ safe to remain dark · ⛔ No-Go for GA until the GA-blockers below are fixed.**
+No Critical/High issue is reachable by a non-moderator while the flag is off; the
+crypto/auth core (RS256 kid-pinned JWT, exact-origin mint, PKCE-S256 OAuth, sanitized KV
+schema isolation, lexical SSRF gate, source-window-pinned postMessage, timing-safe webhook
+HMAC) is genuinely well-built and the dark boundary holds across routers/JWKS/middleware/SSR.
+
+### Reachable while dark
+- **`build-callback` had no flag gate + no replay protection — FIXED in this change.**
+  Unlike its siblings (`git-push`, `workflow-completed`), `build-callback.ts` never checked
+  the flag, so the k8s apply/deploy path could run independent of the kill switch; and the
+  timestamp/nonce-less payload meant a captured signed callback could be replayed to
+  re-trigger applies. Added: `isFlipt('app-blocks-enabled')` 503 gate + a short-window
+  (15m) `(appBlockId, sha)` apply-path replay guard (fail-open on Redis loss). Handler-level
+  tests cover both. Durable cross-window replay protection still needs a caller-supplied
+  signed timestamp/nonce from the Tekton finally task — **infra follow-up**.
+- **INFO — H2 gate divergence confirmed** (fails safe; mod canary can't exercise the flow
+  server-side until context is threaded into the server gate — fix by threading, NOT a
+  global enable).
+
+### GA-blockers (reachable only after the flag is turned on)
+1. **🔴 HIGH — Showcase images bypass NSFW/browsing-level filtering.**
+   `showcase.service.ts` selects `nsfwLevel` but never filters on it and ignores the viewer
+   setting → explicit image URLs + prompts + seeds for an X-rated model are posted into the
+   third-party iframe (`BLOCK_INIT`) for any viewer, incl. opted-out / logged-out. Fix:
+   filter by browsing level / `viewerNsfwEnabled` (SFW-only for anon) before returning.
+2. **MEDIUM — `submit-version` CSRF (confirmed).** Prod session cookie is `sameSite:'none'`
+   (`next-auth-options.ts`) and `ModEndpoint` does no Origin/CSRF check; Next.js parses
+   `application/x-www-form-urlencoded`, so a cross-site form POST with a tricked mod's cookie
+   can submit a bundle. Pre-existing, app-wide `ModEndpoint` posture (not unique to this
+   route); dark-gated today. Fix: explicit same-origin/Origin check (ideally on `ModEndpoint`).
+3. **MEDIUM — Bundle ZIP zip-bomb.** `publish-request.service.ts` fully decompresses each
+   entry before size-checking; 2000 × 10 MiB ⇒ ~20 GiB from a 50 MiB upload → pod OOM.
+   (Zip-slip is NOT exploitable — jszip normalizes `..`, files go to Forgejo content API.)
+   Fix: running decompressed-byte ceiling.
+4. **MEDIUM — git-push trust-on-push** auto-approves + deploys live third-party code with no
+   mod re-review once a row exists (iframe.src/blockId stay pinned, but the served code
+   changes). Fix: gate post-approval pushes behind the review queue; restrict Forgejo write;
+   ship the deferred manifest/iframe.src/sha audit-log.
+5. **MEDIUM — BLOCK_INIT over-shares** `viewerNsfwEnabled`, `creatorUserId`, viewer
+   id/username/status to the publisher iframe. Transport is sound; data-minimization only.
+   Fix: allowlist-project the context before `send('BLOCK_INIT', …)`.
+6. **MEDIUM — Buzz cap is per-(user,block), not per-user aggregate**, and `recordBlockBuzzSpend`
+   can under-count on a Redis blip. Fix before wiring payouts + rate-card sign-off.
+
+### Confirmed safe (security-specialist verification)
+JWT verify (RS256 pinned, kid-scoped, iss/aud/exp/nbf/jti, strict claim typing, sub-overflow
+bounded) · token mint (exact same-origin, scope intersection, anon fail-closed strip, rate
+limits) · OAuth2/OIDC (PKCE-S256, redirect_uri exact-match, `appblk-` clients blocked from
+the interactive flow) · KV datastore (no SQLi; schema-name sanitized + re-validated;
+per-(block,user) isolation) · manifest SSRF gate · postMessage (origin + source-window
+pinned) · webhook HMAC (timing-safe, raw body).

--- a/docs/features/app-blocks-merge-audit-2026-06.md
+++ b/docs/features/app-blocks-merge-audit-2026-06.md
@@ -160,13 +160,19 @@ HMAC) is genuinely well-built and the dark boundary holds across routers/JWKS/mi
   the flag, so the k8s apply/deploy path could run independent of the kill switch; and the
   timestamp/nonce-less payload meant a captured signed callback could be replayed to
   re-trigger applies. Added: `isFlipt('app-blocks-enabled')` 503 gate + an `(appBlockId, sha)`
-  apply-path replay guard using an **atomic `SET NX EX`** (~7m, ≈ the 6m apply timeout +
-  margin — not `incrBy`+`expire`, which could leave a permanent TTL-less key and wedge a sha),
-  **fail-open** on Redis loss, with the watcher **clearing the slot on a definitive apply
-  failure** so a same-sha retry isn't suppressed. 14 handler-level tests cover the gate,
-  replay, fail-open, and clear-on-failure/timeout/success paths. Durable cross-window replay
-  protection still needs a caller-supplied signed timestamp/nonce from the Tekton finally
-  task — **infra follow-up**.
+  apply-path replay guard using an **atomic `SET NX EX`** (not `incrBy`+`expire`, which could
+  leave a permanent TTL-less key and wedge a sha), **fail-open** on Redis loss. TTL is **10m**
+  — sized to outlast the whole first attempt (~60s `triggerApply` + 6m `waitForApplyJob`) so
+  the key can't expire mid-apply and let a late duplicate delete+restart the in-flight Job.
+  The longer TTL doesn't suppress retries because **every failure path frees the slot
+  explicitly**: the watcher clears on a definitive apply failure, and the `triggerApply`
+  catch clears on a Job-creation failure (a 2nd-pass audit HIGH). TTL is only the backstop
+  for the can't-clear cases (apply `timeout` where the Job may still run; watcher-crash /
+  pod-restart). 15 handler-level tests cover the gate, replay, fail-open, trigger-throw-clear,
+  and clear-on-failure/timeout/success. Durable cross-window replay protection still needs a
+  caller-supplied signed timestamp/nonce from the Tekton finally task — **infra follow-up**.
+  **Follow-up:** sibling `workflow-completed.ts` still uses the non-atomic `incrBy`+`expire`
+  dedup this PR replaced — same wedge risk; align it for convention consistency.
 - **INFO — H2 gate divergence confirmed** (fails safe; mod canary can't exercise the flow
   server-side until context is threaded into the server gate — fix by threading, NOT a
   global enable).

--- a/docs/features/app-blocks-merge-audit-2026-06.md
+++ b/docs/features/app-blocks-merge-audit-2026-06.md
@@ -159,10 +159,14 @@ HMAC) is genuinely well-built and the dark boundary holds across routers/JWKS/mi
   Unlike its siblings (`git-push`, `workflow-completed`), `build-callback.ts` never checked
   the flag, so the k8s apply/deploy path could run independent of the kill switch; and the
   timestamp/nonce-less payload meant a captured signed callback could be replayed to
-  re-trigger applies. Added: `isFlipt('app-blocks-enabled')` 503 gate + a short-window
-  (15m) `(appBlockId, sha)` apply-path replay guard (fail-open on Redis loss). Handler-level
-  tests cover both. Durable cross-window replay protection still needs a caller-supplied
-  signed timestamp/nonce from the Tekton finally task — **infra follow-up**.
+  re-trigger applies. Added: `isFlipt('app-blocks-enabled')` 503 gate + an `(appBlockId, sha)`
+  apply-path replay guard using an **atomic `SET NX EX`** (~7m, ≈ the 6m apply timeout +
+  margin — not `incrBy`+`expire`, which could leave a permanent TTL-less key and wedge a sha),
+  **fail-open** on Redis loss, with the watcher **clearing the slot on a definitive apply
+  failure** so a same-sha retry isn't suppressed. 14 handler-level tests cover the gate,
+  replay, fail-open, and clear-on-failure/timeout/success paths. Durable cross-window replay
+  protection still needs a caller-supplied signed timestamp/nonce from the Tekton finally
+  task — **infra follow-up**.
 - **INFO — H2 gate divergence confirmed** (fails safe; mod canary can't exercise the flow
   server-side until context is threaded into the server gate — fix by threading, NOT a
   global enable).

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -4,6 +4,8 @@ import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
+import { isFlipt } from '~/server/flipt/client';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { setCommitStatus } from '~/server/services/blocks/forgejo.service';
 import { triggerApply, waitForApplyJob } from '~/server/services/blocks/apps-pipeline.service';
 
@@ -82,6 +84,34 @@ export function expectedImageRef(slug: string, sha: string): string {
   return `ghcr.io/civitai/app-block-${slug}:${sha}`;
 }
 
+// Replay guard (audit LOW). The callback payload carries no timestamp/nonce, so
+// a captured signature-valid request could be replayed to re-trigger the apply
+// Job indefinitely. Dedup the apply path on (appBlockId, sha) for a short
+// window — long enough to outlast an in-flight apply, far shorter than a rebuild
+// interval (~15m+), so a legitimate same-sha rebuild's self-heal callback (see
+// the watchApplyJobAndRecord note below) is unaffected. Durable cross-window
+// replay protection needs a caller-supplied signed timestamp/nonce from the
+// Tekton finally task (infra follow-up).
+const APPLY_DEDUP_TTL_SECONDS = 15 * 60;
+async function markApplyTriggered(appBlockId: string, sha: string): Promise<boolean> {
+  // Reuse the block rate-limit key family (same convention as workflow-completed).
+  const key = `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:apply:${appBlockId}:${sha}` as const;
+  try {
+    const count = await redis.incrBy(key as never, 1);
+    if (count === 1) {
+      await redis.expire(key as never, APPLY_DEDUP_TTL_SECONDS);
+      return true; // first time → trigger apply
+    }
+    return false; // duplicate / replay within the window
+  } catch {
+    // Fail OPEN: unlike workflow-completed (which fails closed to avoid
+    // double-billing), a Redis incident here must not block a real deploy.
+    // The HMAC secret + imageRef↔slug/sha binding already bound the blast
+    // radius, so losing replay-dedup during an outage is the lesser evil.
+    return true;
+  }
+}
+
 export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
@@ -98,6 +128,15 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
 
   if (!verifySignature(rawBody, req.headers['x-appblocks-signature'])) {
     res.status(401).json({ error: 'Bad signature' });
+    return;
+  }
+
+  // Kill switch: honour the appBlocks flag like the sibling webhooks
+  // (git-push, workflow-completed). When the substrate is dark, no legitimate
+  // build callback should fire — refuse so the apply/deploy chain can't run
+  // independent of the flag. Server-context Flipt eval, matching the siblings.
+  if (!(await isFlipt('app-blocks-enabled'))) {
+    res.status(503).json({ error: 'App Blocks not enabled' });
     return;
   }
 
@@ -137,6 +176,14 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       description: `Build ${body.status ?? 'failed'}`,
     });
     res.status(200).json({ ok: true, applied: false, reason: 'build failed' });
+    return;
+  }
+
+  // Replay guard: only run the apply path once per (appBlockId, sha) per
+  // window. A replayed success callback short-circuits here before triggering
+  // another apply Job or touching commit status.
+  if (!(await markApplyTriggered(body.appBlockId, body.sha))) {
+    res.status(200).json({ ok: true, applied: false, reason: 'duplicate callback (replay-guarded)' });
     return;
   }
 

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -86,29 +86,46 @@ export function expectedImageRef(slug: string, sha: string): string {
 
 // Replay guard (audit LOW). The callback payload carries no timestamp/nonce, so
 // a captured signature-valid request could be replayed to re-trigger the apply
-// Job indefinitely. Dedup the apply path on (appBlockId, sha) for a short
-// window — long enough to outlast an in-flight apply, far shorter than a rebuild
-// interval (~15m+), so a legitimate same-sha rebuild's self-heal callback (see
-// the watchApplyJobAndRecord note below) is unaffected. Durable cross-window
-// replay protection needs a caller-supplied signed timestamp/nonce from the
-// Tekton finally task (infra follow-up).
-const APPLY_DEDUP_TTL_SECONDS = 15 * 60;
-async function markApplyTriggered(appBlockId: string, sha: string): Promise<boolean> {
+// Job. Dedup the apply path on (appBlockId, sha) with an ATOMIC set-if-absent +
+// TTL (not incrBy-then-expire, which could leave a permanent TTL-less key on a
+// failed expire and wedge the sha forever). The window only needs to cover an
+// in-flight apply — `waitForApplyJob` times out at 6m (see apps-pipeline.service)
+// — plus a small margin, so a legitimate same-sha re-deploy after the apply
+// concludes isn't blocked; the watcher additionally clears the key on a
+// DEFINITIVE apply failure (see watchApplyJobAndRecord) so a retry is never
+// suppressed. Durable cross-window replay protection still needs a
+// caller-supplied signed timestamp/nonce from the Tekton finally task (infra
+// follow-up).
+const APPLY_DEDUP_TTL_SECONDS = 7 * 60; // ≈ apply timeout (6m) + 1m margin
+function applyDedupKey(appBlockId: string, sha: string): string {
   // Reuse the block rate-limit key family (same convention as workflow-completed).
-  const key = `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:apply:${appBlockId}:${sha}` as const;
+  return `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:apply:${appBlockId}:${sha}`;
+}
+async function markApplyTriggered(appBlockId: string, sha: string): Promise<boolean> {
   try {
-    const count = await redis.incrBy(key as never, 1);
-    if (count === 1) {
-      await redis.expire(key as never, APPLY_DEDUP_TTL_SECONDS);
-      return true; // first time → trigger apply
-    }
-    return false; // duplicate / replay within the window
+    const result = await redis.set(applyDedupKey(appBlockId, sha) as never, '1', {
+      NX: true,
+      EX: APPLY_DEDUP_TTL_SECONDS,
+    });
+    // NX returns the set value when newly written, null when the key already
+    // exists (replay). Test for null rather than a specific value so the
+    // wrapper's return-type quirk doesn't matter.
+    return result !== null;
   } catch {
     // Fail OPEN: unlike workflow-completed (which fails closed to avoid
     // double-billing), a Redis incident here must not block a real deploy.
     // The HMAC secret + imageRef↔slug/sha binding already bound the blast
     // radius, so losing replay-dedup during an outage is the lesser evil.
     return true;
+  }
+}
+async function clearApplyMark(appBlockId: string, sha: string): Promise<void> {
+  // Free the dedup slot after a definitive apply failure so a same-sha retry
+  // isn't suppressed within the TTL window. Best-effort; the TTL is the backstop.
+  try {
+    await redis.del(applyDedupKey(appBlockId, sha) as never);
+  } catch {
+    // swallow — the TTL will release the slot regardless.
   }
 }
 
@@ -277,7 +294,14 @@ async function watchApplyJobAndRecord(args: {
     } else {
       // Failure or timeout — leave the existing currentVersionDeployedAt
       // alone (it correctly reflects the LAST successful deploy, not the
-      // failed/in-flight one). Flip commit status so the dev sees red.
+      // failed/in-flight one). On a DEFINITIVE failure, free the replay-dedup
+      // slot so a same-sha retry isn't suppressed within the TTL window; on a
+      // 'timeout' leave it (the Job may still be running — let the TTL release
+      // it rather than race a re-trigger against an in-flight apply).
+      if (outcome === 'failed') {
+        await clearApplyMark(args.appBlockId, args.sha);
+      }
+      // Flip commit status so the dev sees red.
       await safe(setCommitStatus, {
         slug: args.slug,
         sha: args.sha,

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -88,15 +88,21 @@ export function expectedImageRef(slug: string, sha: string): string {
 // a captured signature-valid request could be replayed to re-trigger the apply
 // Job. Dedup the apply path on (appBlockId, sha) with an ATOMIC set-if-absent +
 // TTL (not incrBy-then-expire, which could leave a permanent TTL-less key on a
-// failed expire and wedge the sha forever). The window only needs to cover an
-// in-flight apply — `waitForApplyJob` times out at 6m (see apps-pipeline.service)
-// — plus a small margin, so a legitimate same-sha re-deploy after the apply
-// concludes isn't blocked; the watcher additionally clears the key on a
-// DEFINITIVE apply failure (see watchApplyJobAndRecord) so a retry is never
-// suppressed. Durable cross-window replay protection still needs a
-// caller-supplied signed timestamp/nonce from the Tekton finally task (infra
-// follow-up).
-const APPLY_DEDUP_TTL_SECONDS = 7 * 60; // ≈ apply timeout (6m) + 1m margin
+// failed expire and wedge the sha forever).
+//
+// TTL must outlast the WHOLE first attempt, not just the apply: the mark is set
+// before `triggerApply` (two k8s calls, ~60s of 30s-timeouts each) and
+// `waitForApplyJob` then runs a 6m budget — worst case ~7m. We use 10m so the
+// key can't expire mid-apply and let a late duplicate re-trigger (which would
+// delete + restart the in-flight Job). The longer TTL does NOT suppress
+// legitimate retries because every failure path frees the slot explicitly: the
+// watcher clears on a DEFINITIVE apply failure, and the `triggerApply` catch
+// clears on a Job-creation failure. The TTL is only the backstop for the
+// can't-clear cases (apply 'timeout' where the Job may still run, or a
+// watcher-crash / pod-restart). Durable cross-window replay protection still
+// needs a caller-supplied signed timestamp/nonce from the Tekton finally task
+// (infra follow-up).
+const APPLY_DEDUP_TTL_SECONDS = 10 * 60; // > worst-case first attempt (~60s trigger + 6m apply)
 function applyDedupKey(appBlockId: string, sha: string): string {
   // Reuse the block rate-limit key family (same convention as workflow-completed).
   return `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:apply:${appBlockId}:${sha}`;
@@ -230,6 +236,10 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       imageRef: body.imageRef,
     });
   } catch (e) {
+    // Job creation failed — no watcher will run to clear the dedup mark, so
+    // free it here or a transient k8s hiccup would wedge same-sha retries for
+    // the full TTL (symmetrical with the watcher's clear-on-failed).
+    await clearApplyMark(body.appBlockId, body.sha);
     await safe(setCommitStatus, {
       slug: body.slug,
       sha: body.sha,

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -86,9 +86,14 @@ export function expectedImageRef(slug: string, sha: string): string {
 
 // Replay guard (audit LOW). The callback payload carries no timestamp/nonce, so
 // a captured signature-valid request could be replayed to re-trigger the apply
-// Job. Dedup the apply path on (appBlockId, sha) with an ATOMIC set-if-absent +
-// TTL (not incrBy-then-expire, which could leave a permanent TTL-less key on a
-// failed expire and wedge the sha forever).
+// Job. Dedup the apply path on (appBlockId, sha) with the redis client's
+// purpose-built atomic primitive `setNxKeepTtlWithEx` — a single Lua
+// `SET NX` (+`EXPIRE`) that returns a typed `boolean` (true = newly set).
+// Deliberately NOT `redis.set(..., {NX,EX})` + a return-value check: the top-
+// level `set` returns 'OK'|null but `redis.packed.set` discards its result
+// (returns void), so interpreting the return is a foot-gun (a refactor to the
+// packed variant would silently turn the guard into a no-op). A boolean
+// primitive removes that whole class of bug.
 //
 // TTL must outlast the WHOLE first attempt, not just the apply: the mark is set
 // before `triggerApply` (two k8s calls, ~60s of 30s-timeouts each) and
@@ -109,14 +114,12 @@ function applyDedupKey(appBlockId: string, sha: string): string {
 }
 async function markApplyTriggered(appBlockId: string, sha: string): Promise<boolean> {
   try {
-    const result = await redis.set(applyDedupKey(appBlockId, sha) as never, '1', {
-      NX: true,
-      EX: APPLY_DEDUP_TTL_SECONDS,
-    });
-    // NX returns the set value when newly written, null when the key already
-    // exists (replay). Test for null rather than a specific value so the
-    // wrapper's return-type quirk doesn't matter.
-    return result !== null;
+    // true = newly set (first time → apply); false = key already present (replay).
+    return await redis.setNxKeepTtlWithEx(
+      applyDedupKey(appBlockId, sha) as never,
+      '1',
+      APPLY_DEDUP_TTL_SECONDS
+    );
   } catch {
     // Fail OPEN: unlike workflow-completed (which fails closed to avoid
     // double-billing), a Redis incident here must not block a real deploy.

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from 'crypto';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**
@@ -14,16 +14,34 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  * it, so the handler tests build a real signed body and drive the default export.
  */
 
-const { SECRET, mockFlag, mockRedis, mockTriggerApply, mockWaitApply, mockSetCommitStatus, mockAppBlockUpdate } =
-  vi.hoisted(() => ({
+const {
+  SECRET,
+  mockFlag,
+  mockRedis,
+  mockRedisSet,
+  mockRedisDel,
+  mockTriggerApply,
+  mockWaitApply,
+  mockSetCommitStatus,
+  mockAppBlockUpdate,
+} = vi.hoisted(() => {
+  // setResult: 'OK' = newly set (first time), null = key already present (replay).
+  const mockRedis = { setResult: 'OK' as 'OK' | null, setThrows: false };
+  return {
     SECRET: 'test-build-callback-secret',
     mockFlag: { enabled: true },
-    mockRedis: { incrByValue: 1 },
+    mockRedis,
+    mockRedisSet: vi.fn(async () => {
+      if (mockRedis.setThrows) throw new Error('redis down');
+      return mockRedis.setResult;
+    }),
+    mockRedisDel: vi.fn(async () => 1),
     mockTriggerApply: vi.fn<(...a: any[]) => Promise<{ name: string }>>(async () => ({ name: 'apply-job-1' })),
     mockWaitApply: vi.fn<(...a: any[]) => Promise<string>>(async () => 'succeeded'),
     mockSetCommitStatus: vi.fn(async () => undefined),
     mockAppBlockUpdate: vi.fn(async () => undefined),
-  }));
+  };
+});
 
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
 vi.mock('~/env/server', () => ({
@@ -41,10 +59,7 @@ vi.mock('~/server/db/client', () => ({
 }));
 vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(async () => mockFlag.enabled) }));
 vi.mock('~/server/redis/client', () => ({
-  redis: {
-    incrBy: vi.fn(async () => mockRedis.incrByValue),
-    expire: vi.fn(async () => true),
-  },
+  redis: { set: mockRedisSet, del: mockRedisDel },
   REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'blocks:token-rate-limit' } },
 }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
@@ -131,12 +146,22 @@ async function invoke(req: NextApiRequest, res: NextApiResponse) {
   await handler(req, res);
 }
 
+// Drain the fire-and-forget watchApplyJobAndRecord promise so it can't bleed
+// into the next test's mock assertions.
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
 describe('build-callback handler — flag gate + replay guard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFlag.enabled = true;
-    mockRedis.incrByValue = 1;
+    mockRedis.setResult = 'OK'; // default: first time → apply
+    mockRedis.setThrows = false;
     mockTriggerApply.mockResolvedValue({ name: 'apply-job-1' });
+    mockWaitApply.mockResolvedValue('succeeded');
+  });
+
+  afterEach(async () => {
+    await flush();
   });
 
   it('503s when the appBlocks flag is off — apply path never runs (kill switch)', async () => {
@@ -162,7 +187,7 @@ describe('build-callback handler — flag gate + replay guard', () => {
   });
 
   it('triggers the apply exactly once on the first success callback', async () => {
-    mockRedis.incrByValue = 1; // first time
+    mockRedis.setResult = 'OK'; // newly set → first time
     const res = makeRes();
     await invoke(signedReq(validSuccessBody()), res);
     expect(res._status).toBe(200);
@@ -174,12 +199,21 @@ describe('build-callback handler — flag gate + replay guard', () => {
   });
 
   it('short-circuits a replayed success callback without re-triggering apply', async () => {
-    mockRedis.incrByValue = 2; // duplicate within the dedup window
+    mockRedis.setResult = null; // SET NX found the key → replay within the window
     const res = makeRes();
     await invoke(signedReq(validSuccessBody()), res);
     expect(res._status).toBe(200);
     expect(res._body).toMatchObject({ applied: false, reason: 'duplicate callback (replay-guarded)' });
     expect(mockTriggerApply).not.toHaveBeenCalled();
+  });
+
+  it('fails OPEN on a Redis error — apply still runs so an outage cannot block a deploy', async () => {
+    mockRedis.setThrows = true;
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ applied: true });
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1);
   });
 
   it('does not consume the replay slot for a build-failure callback (no apply path)', async () => {
@@ -188,5 +222,31 @@ describe('build-callback handler — flag gate + replay guard', () => {
     expect(res._status).toBe(200);
     expect(res._body).toMatchObject({ applied: false });
     expect(mockTriggerApply).not.toHaveBeenCalled();
+    expect(mockRedisSet).not.toHaveBeenCalled(); // dedup slot untouched by a failure callback
+  });
+
+  it('clears the replay slot on a DEFINITIVE apply failure so a same-sha retry is not blocked', async () => {
+    mockWaitApply.mockResolvedValue('failed');
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    await flush(); // let the fire-and-forget watcher run
+    expect(mockRedisDel).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`));
+  });
+
+  it('does NOT clear the slot on apply timeout (the Job may still be running)', async () => {
+    mockWaitApply.mockResolvedValue('timeout');
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    await flush();
+    expect(mockRedisDel).not.toHaveBeenCalled();
+  });
+
+  it('records the deploy and keeps the slot on apply success', async () => {
+    mockWaitApply.mockResolvedValue('succeeded');
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    await flush();
+    expect(mockAppBlockUpdate).toHaveBeenCalledWith(expect.objectContaining({ where: { id: APB } }));
+    expect(mockRedisDel).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -1,58 +1,192 @@
-import { describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
-// The handler module imports ~/server/db/client (Prisma init at module load).
-// We only exercise the pure expectedImageRef helper, so stub the db +
-// pipeline deps to keep the import side-effect-free.
-vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
-vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
-  triggerApply: vi.fn(),
-  waitForApplyJob: vi.fn(),
+/**
+ * Coverage for POST /api/internal/blocks/build-callback:
+ *  - L-CALLBACK imageRef binding (pure `expectedImageRef` helper), and
+ *  - the security hardening added after the v1 audit: the `appBlocks` flag
+ *    kill-switch (503 when dark, matching git-push / workflow-completed) and
+ *    the apply-path replay guard (a captured signed callback can't re-trigger
+ *    the deploy Job within the dedup window).
+ *
+ * The handler reads the raw request stream (bodyParser is off) and HMAC-verifies
+ * it, so the handler tests build a real signed body and drive the default export.
+ */
+
+const { SECRET, mockFlag, mockRedis, mockTriggerApply, mockWaitApply, mockSetCommitStatus, mockAppBlockUpdate } =
+  vi.hoisted(() => ({
+    SECRET: 'test-build-callback-secret',
+    mockFlag: { enabled: true },
+    mockRedis: { incrByValue: 1 },
+    mockTriggerApply: vi.fn<(...a: any[]) => Promise<{ name: string }>>(async () => ({ name: 'apply-job-1' })),
+    mockWaitApply: vi.fn<(...a: any[]) => Promise<string>>(async () => 'succeeded'),
+    mockSetCommitStatus: vi.fn(async () => undefined),
+    mockAppBlockUpdate: vi.fn(async () => undefined),
+  }));
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ BLOCK_BUILD_CALLBACK_SECRET: SECRET } as Record<string, unknown>, {
+    get(t, p: string) {
+      if (p in t) return t[p];
+      if (p === 'LOGGING') return '';
+      return undefined;
+    },
+  }),
 }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: { appBlock: { update: mockAppBlockUpdate } },
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(async () => mockFlag.enabled) }));
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    incrBy: vi.fn(async () => mockRedis.incrByValue),
+    expire: vi.fn(async () => true),
+  },
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'blocks:token-rate-limit' } },
+}));
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  triggerApply: mockTriggerApply,
+  waitForApplyJob: mockWaitApply,
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({ setCommitStatus: mockSetCommitStatus }));
 
 import { expectedImageRef } from '~/pages/api/internal/blocks/build-callback';
 
 /**
- * L-CALLBACK coverage. The build-callback handler accepts an `imageRef` from
- * the Tekton pipeline. The pipeline always pushes the immutable
- * `ghcr.io/civitai/app-block-<slug>:<sha>`. The handler must bind the
- * accepted ref to ITS OWN slug + sha — a bare `app-block-` prefix check would
- * let a signature-valid callback for slug A carry `app-block-<B>:<sha>` and
- * deploy B's image onto A's row/Deployment, and would accept a mutable
- * `:latest` tag.
+ * L-CALLBACK coverage. The handler binds the accepted `imageRef` to ITS OWN
+ * slug + sha — a bare `app-block-` prefix check would let a signature-valid
+ * callback for slug A carry `app-block-<B>:<sha>` and deploy B's image onto A.
  */
 describe('build-callback imageRef binding', () => {
   const SHA = 'a'.repeat(40);
 
   it('accepts exactly the canonical (slug, sha) image', () => {
     const slug = 'generate-from-model';
-    const ref = expectedImageRef(slug, SHA);
-    expect(ref).toBe(`ghcr.io/civitai/app-block-${slug}:${SHA}`);
-    expect(ref === expectedImageRef(slug, SHA)).toBe(true);
+    expect(expectedImageRef(slug, SHA)).toBe(`ghcr.io/civitai/app-block-${slug}:${SHA}`);
   });
-
   it('rejects another slug under the same prefix', () => {
-    const ours = expectedImageRef('slug-a', SHA);
-    const theirs = `ghcr.io/civitai/app-block-slug-b:${SHA}`;
-    expect(ours === theirs).toBe(false);
-    // the handler compares body.imageRef !== expectedImageRef(body.slug, body.sha)
-    expect(theirs === expectedImageRef('slug-a', SHA)).toBe(false);
+    expect(`ghcr.io/civitai/app-block-slug-b:${SHA}` === expectedImageRef('slug-a', SHA)).toBe(false);
   });
-
   it('rejects a mutable :latest tag for our own slug', () => {
-    const slug = 'slug-a';
-    const latest = `ghcr.io/civitai/app-block-${slug}:latest`;
-    expect(latest === expectedImageRef(slug, SHA)).toBe(false);
+    expect(`ghcr.io/civitai/app-block-slug-a:latest` === expectedImageRef('slug-a', SHA)).toBe(false);
   });
-
   it('rejects a different sha for our own slug', () => {
-    const slug = 'slug-a';
-    const otherSha = 'b'.repeat(40);
-    expect(expectedImageRef(slug, otherSha) === expectedImageRef(slug, SHA)).toBe(false);
+    expect(expectedImageRef('slug-a', 'b'.repeat(40)) === expectedImageRef('slug-a', SHA)).toBe(false);
+  });
+  it('rejects a prefix-matching but unrelated repo', () => {
+    expect(`ghcr.io/civitai/app-block-slug-a-evil:${SHA}` === expectedImageRef('slug-a', SHA)).toBe(false);
+  });
+});
+
+// ---- handler: flag kill-switch + replay guard --------------------------------
+
+const SLUG = 'generate-from-model';
+const SHA = 'a'.repeat(40);
+const APB = 'apb_0123456789ABCDEFGHJKMNPQRS'; // matches APB_RE (apb_ + 26 Crockford)
+
+function signedReq(bodyObj: Record<string, unknown>): NextApiRequest {
+  const raw = Buffer.from(JSON.stringify(bodyObj), 'utf8');
+  const sig = 'sha256=' + createHmac('sha256', SECRET).update(raw).digest('hex');
+  return {
+    method: 'POST',
+    headers: { 'x-appblocks-signature': sig },
+    async *[Symbol.asyncIterator]() {
+      yield raw;
+    },
+  } as unknown as NextApiRequest;
+}
+
+function makeRes(): NextApiResponse & { _status: number; _body: any } {
+  const res = {
+    _status: 0,
+    _body: null as any,
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & { _status: number; _body: any };
+}
+
+const validSuccessBody = () => ({
+  slug: SLUG,
+  sha: SHA,
+  appBlockId: APB,
+  imageRef: `ghcr.io/civitai/app-block-${SLUG}:${SHA}`,
+  status: 'Succeeded',
+});
+
+async function invoke(req: NextApiRequest, res: NextApiResponse) {
+  const handler = (await import('~/pages/api/internal/blocks/build-callback')).default;
+  await handler(req, res);
+}
+
+describe('build-callback handler — flag gate + replay guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlag.enabled = true;
+    mockRedis.incrByValue = 1;
+    mockTriggerApply.mockResolvedValue({ name: 'apply-job-1' });
   });
 
-  it('rejects a prefix-matching but unrelated repo', () => {
-    const slug = 'slug-a';
-    const sneaky = `ghcr.io/civitai/app-block-${slug}-evil:${SHA}`;
-    expect(sneaky === expectedImageRef(slug, SHA)).toBe(false);
+  it('503s when the appBlocks flag is off — apply path never runs (kill switch)', async () => {
+    mockFlag.enabled = false;
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    expect(res._status).toBe(503);
+    expect(mockTriggerApply).not.toHaveBeenCalled();
+  });
+
+  it('401s on a bad signature before checking the flag', async () => {
+    const req = {
+      method: 'POST',
+      headers: { 'x-appblocks-signature': 'sha256=deadbeef' },
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.from(JSON.stringify(validSuccessBody()));
+      },
+    } as unknown as NextApiRequest;
+    const res = makeRes();
+    await invoke(req, res);
+    expect(res._status).toBe(401);
+    expect(mockTriggerApply).not.toHaveBeenCalled();
+  });
+
+  it('triggers the apply exactly once on the first success callback', async () => {
+    mockRedis.incrByValue = 1; // first time
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, applied: true });
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1);
+    expect(mockTriggerApply).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: SLUG, sha: SHA, appBlockId: APB })
+    );
+  });
+
+  it('short-circuits a replayed success callback without re-triggering apply', async () => {
+    mockRedis.incrByValue = 2; // duplicate within the dedup window
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ applied: false, reason: 'duplicate callback (replay-guarded)' });
+    expect(mockTriggerApply).not.toHaveBeenCalled();
+  });
+
+  it('does not consume the replay slot for a build-failure callback (no apply path)', async () => {
+    const res = makeRes();
+    await invoke(signedReq({ ...validSuccessBody(), status: 'Failed' }), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ applied: false });
+    expect(mockTriggerApply).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -18,22 +18,23 @@ const {
   SECRET,
   mockFlag,
   mockRedis,
-  mockRedisSet,
+  mockSetNx,
   mockRedisDel,
   mockTriggerApply,
   mockWaitApply,
   mockSetCommitStatus,
   mockAppBlockUpdate,
 } = vi.hoisted(() => {
-  // setResult: 'OK' = newly set (first time), null = key already present (replay).
-  const mockRedis = { setResult: 'OK' as 'OK' | null, setThrows: false };
+  // nxResult: true = newly set (first time), false = key already present (replay).
+  const mockRedis = { nxResult: true, nxThrows: false };
   return {
     SECRET: 'test-build-callback-secret',
     mockFlag: { enabled: true },
     mockRedis,
-    mockRedisSet: vi.fn(async () => {
-      if (mockRedis.setThrows) throw new Error('redis down');
-      return mockRedis.setResult;
+    // mirrors redis.setNxKeepTtlWithEx(key, value, ttl): Promise<boolean>
+    mockSetNx: vi.fn(async () => {
+      if (mockRedis.nxThrows) throw new Error('redis down');
+      return mockRedis.nxResult;
     }),
     mockRedisDel: vi.fn(async () => 1),
     mockTriggerApply: vi.fn<(...a: any[]) => Promise<{ name: string }>>(async () => ({ name: 'apply-job-1' })),
@@ -59,7 +60,7 @@ vi.mock('~/server/db/client', () => ({
 }));
 vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(async () => mockFlag.enabled) }));
 vi.mock('~/server/redis/client', () => ({
-  redis: { set: mockRedisSet, del: mockRedisDel },
+  redis: { setNxKeepTtlWithEx: mockSetNx, del: mockRedisDel },
   REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'blocks:token-rate-limit' } },
 }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
@@ -154,8 +155,8 @@ describe('build-callback handler — flag gate + replay guard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFlag.enabled = true;
-    mockRedis.setResult = 'OK'; // default: first time → apply
-    mockRedis.setThrows = false;
+    mockRedis.nxResult = true; // default: newly set → first time → apply
+    mockRedis.nxThrows = false;
     mockTriggerApply.mockResolvedValue({ name: 'apply-job-1' });
     mockWaitApply.mockResolvedValue('succeeded');
   });
@@ -187,7 +188,7 @@ describe('build-callback handler — flag gate + replay guard', () => {
   });
 
   it('triggers the apply exactly once on the first success callback', async () => {
-    mockRedis.setResult = 'OK'; // newly set → first time
+    mockRedis.nxResult = true; // newly set → first time
     const res = makeRes();
     await invoke(signedReq(validSuccessBody()), res);
     expect(res._status).toBe(200);
@@ -196,10 +197,12 @@ describe('build-callback handler — flag gate + replay guard', () => {
     expect(mockTriggerApply).toHaveBeenCalledWith(
       expect.objectContaining({ slug: SLUG, sha: SHA, appBlockId: APB })
     );
+    // Lock the dedup contract: atomic NX-set on the (appBlockId, sha) key with the TTL.
+    expect(mockSetNx).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`), '1', 600);
   });
 
   it('short-circuits a replayed success callback without re-triggering apply', async () => {
-    mockRedis.setResult = null; // SET NX found the key → replay within the window
+    mockRedis.nxResult = false; // setNxKeepTtlWithEx → false (key present) → replay within the window
     const res = makeRes();
     await invoke(signedReq(validSuccessBody()), res);
     expect(res._status).toBe(200);
@@ -208,7 +211,7 @@ describe('build-callback handler — flag gate + replay guard', () => {
   });
 
   it('fails OPEN on a Redis error — apply still runs so an outage cannot block a deploy', async () => {
-    mockRedis.setThrows = true;
+    mockRedis.nxThrows = true;
     const res = makeRes();
     await invoke(signedReq(validSuccessBody()), res);
     expect(res._status).toBe(200);
@@ -222,7 +225,7 @@ describe('build-callback handler — flag gate + replay guard', () => {
     expect(res._status).toBe(200);
     expect(res._body).toMatchObject({ applied: false });
     expect(mockTriggerApply).not.toHaveBeenCalled();
-    expect(mockRedisSet).not.toHaveBeenCalled(); // dedup slot untouched by a failure callback
+    expect(mockSetNx).not.toHaveBeenCalled(); // dedup slot untouched by a failure callback
   });
 
   it('clears the replay slot on a DEFINITIVE apply failure so a same-sha retry is not blocked', async () => {
@@ -256,7 +259,7 @@ describe('build-callback handler — flag gate + replay guard', () => {
     await invoke(signedReq(validSuccessBody()), res);
     expect(res._status).toBe(500);
     // mark was set (SET NX) then freed in the catch so a same-sha retry isn't wedged
-    expect(mockRedisSet).toHaveBeenCalledTimes(1);
+    expect(mockSetNx).toHaveBeenCalledTimes(1);
     expect(mockRedisDel).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`));
   });
 });

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -249,4 +249,14 @@ describe('build-callback handler — flag gate + replay guard', () => {
     expect(mockAppBlockUpdate).toHaveBeenCalledWith(expect.objectContaining({ where: { id: APB } }));
     expect(mockRedisDel).not.toHaveBeenCalled();
   });
+
+  it('clears the replay slot when triggerApply itself throws — no watcher runs, so the catch must free it', async () => {
+    mockTriggerApply.mockRejectedValue(new Error('k8s API down'));
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    expect(res._status).toBe(500);
+    // mark was set (SET NX) then freed in the catch so a same-sha retry isn't wedged
+    expect(mockRedisSet).toHaveBeenCalledTimes(1);
+    expect(mockRedisDel).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`));
+  });
 });


### PR DESCRIPTION
## What
Closes the one security gap from the post-merge audit of the App Blocks foundation (#2319 / `5643eaba7`) that was **reachable while the feature flag is off**.

`/api/internal/blocks/build-callback` — unlike its siblings `git-push` and `workflow-completed` — had:
- **no `appBlocks` flag gate** → the k8s apply/deploy path could run independent of the kill switch, and
- **no replay protection** → the timestamp/nonce-less HMAC-signed payload could be replayed to re-trigger applies.

(HMAC-secret-protected, so not exploitable without the secret — hence audit severity LOW — but the deploy path should honour the kill switch and not be replayable.)

## Changes
**(a) Fix** — `src/pages/api/internal/blocks/build-callback.ts`
- `isFlipt('app-blocks-enabled')` 503 kill switch (mirrors the sibling webhooks).
- Short-window (15m) `(appBlockId, sha)` apply-path replay guard — long enough to outlast an in-flight apply, far shorter than a rebuild interval so the self-heal callback is unaffected. **Fail-open** on Redis loss (a Redis blip must not block a real deploy; blast radius already bound by the HMAC secret + imageRef↔slug/sha binding).
- Durable cross-window replay protection still needs a caller-supplied signed timestamp/nonce from the Tekton finally task — noted in code as an infra follow-up.

**Tests** — `src/tests/api/internal/blocks/build-callback.test.ts`
- New handler-level cases: flag-off → 503 (apply never runs), bad-sig → 401, first success applies once, replayed success short-circuits, build-failure callback doesn't consume the replay slot. Existing `expectedImageRef` / L-CALLBACK cases retained. **10/10 pass locally.**

**(b) Docs** — `docs/features/app-blocks-merge-audit-2026-06.md`
- Records the dedicated security-engineer audit: verdict (safe to remain dark / No-Go for GA until blockers fixed), this fix, and the GA-blocker checklist (HIGH showcase NSFW leak; MEDIUM submit-version CSRF, ZIP zip-bomb, git-push trust-on-push, BLOCK_INIT PII over-share, per-app buzz cap) + confirmed-safe surfaces.

## Scope / risk
- Behaviour-preserving for legitimate Tekton callbacks when the flag is on; adds a 503 only when dark (no legitimate callback fires while dark) and a replay short-circuit.
- The remaining audit findings are **GA-blockers** (reachable only after the flag is turned on) and are tracked in the doc, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)