### PR TITLE
fix(api): treat client-abort as 499, not 500

### DIFF
--- a/src/pages/api/download/attachments/[fileId].ts
+++ b/src/pages/api/download/attachments/[fileId].ts
@@ -9,7 +9,7 @@ import { getDownloadUrl } from '~/utils/delivery-worker';
 import { getLoginLink } from '~/utils/login-helpers';
 import { getFileWithPermission } from '~/server/services/file.service';
 import { Tracker } from '~/server/clickhouse/client';
-import { handleLogError } from '~/server/utils/errorHandling';
+import { handleLogError, isClientAbortError } from '~/server/utils/errorHandling';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 
 const schema = z.object({
@@ -119,6 +119,10 @@ export default PublicEndpoint(
 
       res.redirect(url);
     } catch (err: unknown) {
+      if (isClientAbortError(err)) {
+        if (!res.headersSent) res.status(499).end();
+        return;
+      }
       const error = err as Error;
       console.error(`Error downloading file: ${file.url} - ${error.message}`);
       return res.status(500).json({ error: 'Error downloading file' });

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -6,6 +6,7 @@ import { isProd } from '~/env/other';
 import { createContext } from '~/server/createContext';
 import { logToAxiom, safeError } from '~/server/logging/client';
 import { recordTrpcError } from '~/server/prom/http-errors';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 import { appRouter } from '~/server/routers';
 
 export const config = {
@@ -41,6 +42,13 @@ const trpcHandler = createNextApiHandler({
     return Object.keys(headers).length > 0 ? { headers } : {};
   },
   onError: async ({ error, type, path, input, ctx, req }) => {
+    // Client disconnected mid-procedure (closed tab / scrolled the feed past /
+    // navigated away) — the request signal aborted and bubbled an AbortError that
+    // tRPC wrapped as INTERNAL_SERVER_ERROR. Not a server fault: skip BOTH the 5xx
+    // counter and the Axiom ingest (was ~0.07/s of mislabeled 500s, e.g.
+    // image.getInfinite). isClientAbortError walks error.cause for the wrapped abort.
+    if (isClientAbortError(error)) return error;
+
     // Unsampled per-procedure 5xx attribution (no-ops for 4xx-class errors).
     // Source of truth for the tRPC slice of the 5xx SLO; see http-errors.ts.
     recordTrpcError(error, path);

--- a/src/pages/api/v1/bugs.ts
+++ b/src/pages/api/v1/bugs.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicApiContext2 } from '~/server/createContext';
 import { logToAxiom } from '~/server/logging/client';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 
 const first = (v: string | string[] | undefined) => (Array.isArray(v) ? v[0] : v);
 
@@ -53,6 +54,10 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
 
     return res.status(200).json({ items, metadata: { nextCursor } });
   } catch (error) {
+    if (isClientAbortError(error)) {
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
       const parsedError = (() => {

--- a/src/pages/api/v1/bugs/[id].ts
+++ b/src/pages/api/v1/bugs/[id].ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicApiContext2 } from '~/server/createContext';
 import { logToAxiom } from '~/server/logging/client';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -21,6 +22,10 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     const bug = await apiCaller.bug.getById({ id });
     return res.status(200).json(bug);
   } catch (error) {
+    if (isClientAbortError(error)) {
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
       const parsedError = (() => {

--- a/src/pages/api/v1/content/[[...slug]].ts
+++ b/src/pages/api/v1/content/[[...slug]].ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicApiContext, publicApiContext2 } from '~/server/createContext';
 import { appRouter } from '~/server/routers';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
   // const apiCaller = appRouter.createCaller(publicApiContext(req, res));
@@ -12,6 +13,10 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     const result = await apiCaller.content.get({ slug: req.query.slug });
     return res.status(200).json(result);
   } catch (error: any) {
+    if (isClientAbortError(error)) {
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
     if (error instanceof TRPCError) return res.status(500).json({ error: error.cause });
     else return res.status(500).json({ error: 'Internal server error' });
   }

--- a/src/pages/api/v1/creators.ts
+++ b/src/pages/api/v1/creators.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { publicApiContext2 } from '~/server/createContext';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 import { getPaginationLinks } from '~/server/utils/pagination-helpers';
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -26,6 +27,11 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       },
     });
   } catch (error) {
+    if (isClientAbortError(error)) {
+      // Client disconnected mid-request — not a server fault. 499, not 500.
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
       const parsedError = JSON.parse(error.message);

--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -20,6 +20,7 @@ import {
 import { imageMetaCache } from '~/server/redis/caches';
 import { FLIPT_FEATURE_FLAGS, getFliptVariant } from '~/server/flipt/client';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
 import {
   acquireBulkheadSlot,
@@ -316,6 +317,14 @@ async function handleImagesRequest(req: NextApiRequest, res: NextApiResponse) {
       metadata,
     });
   } catch (error) {
+    if (isClientAbortError(error)) {
+      // Client disconnected mid-feed (closed tab / scrolled past / navigated). The
+      // Meili fetch's AbortSignal fired and bubbled a bare AbortError — not a server
+      // fault. 499 keeps it out of the 5xx SLO + the http-errors counter. (Was the
+      // top mislabeled-500 source on this endpoint.)
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
     const trpcError = error as TRPCError;
     const statusCode = getHTTPStatusCodeFromError(trpcError);
 

--- a/src/pages/api/v1/permissions/check.ts
+++ b/src/pages/api/v1/permissions/check.ts
@@ -4,6 +4,7 @@ import { EntityAccessPermission } from '~/server/common/enums';
 import { hasEntityAccess } from '~/server/services/common.service';
 import { getSessionUser } from '~/server/auth/session-user';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 import { commaDelimitedNumberArray, numericString } from '~/utils/zod-helpers';
 
 const schema = z.object({
@@ -51,6 +52,10 @@ export default PublicEndpoint(
 
       return res.json(data);
     } catch (error) {
+      if (isClientAbortError(error)) {
+        if (!res.headersSent) res.status(499).end();
+        return;
+      }
       return res.status(500).json({ message: 'An unexpected error occurred', error });
     }
   },

--- a/src/pages/api/v1/tags.ts
+++ b/src/pages/api/v1/tags.ts
@@ -6,6 +6,7 @@ import { publicApiContext2 } from '~/server/createContext';
 
 import { appRouter } from '~/server/routers';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 import { getPaginationLinks } from '~/server/utils/pagination-helpers';
 
 export default PublicEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -34,6 +35,11 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       },
     });
   } catch (error) {
+    if (isClientAbortError(error)) {
+      // Client disconnected mid-request — not a server fault. 499, not 500.
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
       const parsedError = JSON.parse(error.message);

--- a/src/pages/api/v1/users/index.ts
+++ b/src/pages/api/v1/users/index.ts
@@ -6,6 +6,7 @@ import { env } from '~/env/server';
 import { publicApiContext2 } from '~/server/createContext';
 import { getAllUsersInput } from '~/server/schema/user.schema';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 
 const schema = getAllUsersInput.extend({
   email: z.never().optional(),
@@ -27,6 +28,11 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       items: users ?? [],
     });
   } catch (error) {
+    if (isClientAbortError(error)) {
+      // Client disconnected mid-request — not a server fault. 499, not 500.
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
       const parsedError = JSON.parse(error.message);

--- a/src/server/prom/http-errors.ts
+++ b/src/server/prom/http-errors.ts
@@ -164,6 +164,13 @@ export function instrumentApiResponse(req: NextApiRequest, res: NextApiResponse)
  * that map to >= 500 count — 4xx-class errors and any non-TRPCError cause passed by
  * tRPC's streaming/jsonl error paths are ignored (the latter would otherwise be
  * miscounted as 500 by getHTTPStatusCodeFromError's undefined→500 fallback).
+ *
+ * KNOWN DIVERGENCE FROM TRAEFIK on the tRPC path: client aborts are skipped here
+ * (see the isClientAbortError guard in the tRPC onError), but tRPC's onError can't
+ * set an HTTP status, so the aborted procedure still returns 500 to the edge and
+ * Traefik DOES count it in `code=~"5.."`. So for aborts, kind=trpc reads slightly
+ * LOWER than Traefik (~0.07/s) — that's intentional, not a counter bug. The REST
+ * paths don't diverge (they emit a real 499). Don't "reconcile" this away.
  */
 export function recordTrpcError(error: unknown, path?: string): void {
   try {

--- a/src/server/utils/__tests__/errorHandling.test.ts
+++ b/src/server/utils/__tests__/errorHandling.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { isClientAbortError } from '~/server/utils/errorHandling';
+import { FETCH_DOCUMENTS_TIMEOUT_MESSAGE } from '~/server/meilisearch/client';
+
+describe('isClientAbortError', () => {
+  it('classifies a bare client AbortError (REST/Meili fetch path)', () => {
+    // undici shape on client disconnect: name=AbortError, the standard message
+    expect(isClientAbortError({ name: 'AbortError', message: 'This operation was aborted' })).toBe(
+      true
+    );
+  });
+
+  it('classifies the real prod tRPC shape (message at depth 0, name=TRPCError)', () => {
+    // Verified in prod Loki (12.9k/24h): tRPC copies cause.message onto the
+    // wrapper, so the NAME is TRPCError — the message check is load-bearing here.
+    expect(
+      isClientAbortError({ name: 'TRPCError', message: 'This operation was aborted' })
+    ).toBe(true);
+  });
+
+  it('classifies a tRPC-wrapped abort via the .cause chain', () => {
+    expect(
+      isClientAbortError({
+        name: 'TRPCError',
+        code: 'INTERNAL_SERVER_ERROR',
+        cause: { name: 'AbortError', message: 'This operation was aborted' },
+      })
+    ).toBe(true);
+  });
+
+  it('matches the alternate Node phrasing "The operation was aborted"', () => {
+    expect(isClientAbortError({ name: 'Error', message: 'The operation was aborted' })).toBe(true);
+  });
+
+  // ---- must NOT over-classify (these stay 5xx/408, never 499) ----
+
+  it('DRIFT GUARD: does NOT classify our local Meili-deadline abort as a client abort', () => {
+    // The local fetchDocumentsAbortable timer aborts with FETCH_DOCUMENTS_TIMEOUT_MESSAGE;
+    // if it surfaces as an AbortError-with-cause, the exclusion must still hold. This
+    // case fails if the duplicated literal in errorHandling.ts ever drifts from the
+    // exported constant — the whole reason the literal exists (circular-import avoidance).
+    expect(
+      isClientAbortError({
+        name: 'AbortError',
+        message: 'This operation was aborted',
+        cause: { message: FETCH_DOCUMENTS_TIMEOUT_MESSAGE },
+      })
+    ).toBe(false);
+    // and the plain-Error form of the same sentinel
+    expect(isClientAbortError({ name: 'Error', message: FETCH_DOCUMENTS_TIMEOUT_MESSAGE })).toBe(
+      false
+    );
+  });
+
+  it('does NOT classify an AbortSignal.timeout() TimeoutError as a client abort', () => {
+    // Server-side deadline: name=TimeoutError, message has a " due to timeout" suffix
+    // so the exact === checks fail. Must remain a server error.
+    expect(
+      isClientAbortError({ name: 'TimeoutError', message: 'The operation was aborted due to timeout' })
+    ).toBe(false);
+  });
+
+  it('does NOT classify genuine server errors as client aborts', () => {
+    expect(isClientAbortError({ name: 'MeiliSearchCommunicationError', message: 'fetch failed' })).toBe(
+      false
+    );
+    expect(isClientAbortError({ name: 'Error', message: 'boom' })).toBe(false);
+    expect(isClientAbortError({ name: 'TRPCError', code: 'NOT_FOUND', message: 'No image' })).toBe(
+      false
+    );
+    expect(isClientAbortError(null)).toBe(false);
+    expect(isClientAbortError(undefined)).toBe(false);
+  });
+});

--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -15,6 +15,7 @@ import { generateSecretHash } from '~/server/utils/key-generator';
 import { getAllServerHosts } from '~/server/utils/server-domain';
 import type { Partner } from '~/shared/utils/prisma/models';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 import { isDefined } from '~/utils/type-guards';
 
 type AxiomAPIRequest = NextApiRequest & { log: Logger };
@@ -210,6 +211,14 @@ export function ModEndpoint(
 }
 
 export function handleEndpointError(res: NextApiResponse, e: unknown) {
+  if (isClientAbortError(e)) {
+    // Client disconnected mid-request (closed tab / scrolled the feed past /
+    // navigated away), cancelling the request signal. Not a server fault: respond
+    // 499 (client closed request) so it stays out of the 5xx SLO + the
+    // civitai_app_http_errors_total counter and isn't logged as a spurious 500.
+    if (!res.headersSent) res.status(499).end();
+    return;
+  }
   if (e instanceof TRPCError) {
     const apiError = e as TRPCError;
     const status = getHTTPStatusCodeFromError(apiError);

--- a/src/server/utils/errorHandling.ts
+++ b/src/server/utils/errorHandling.ts
@@ -9,6 +9,44 @@ import { SourceMapConsumer } from 'source-map';
 import path from 'node:path';
 import fs from 'node:fs';
 
+// Local Meili-deadline sentinel — kept in sync with FETCH_DOCUMENTS_TIMEOUT_MESSAGE
+// in src/server/meilisearch/client.ts. Duplicated as a literal (not imported) on
+// purpose: client.ts already imports `sleep` from this module, so importing the
+// constant back would form a circular dependency (the class that produced the
+// article.metrics Next-16 TDZ → 500 regression). A server-side timeout is NOT a
+// client abort — it surfaces as a 408 elsewhere.
+const MEILI_LOCAL_TIMEOUT_MESSAGE = 'meili-fetch-timeout';
+
+/**
+ * True when an error is a CLIENT-side request abort — the browser closed the tab,
+ * scrolled the infinite feed past the in-flight page, or navigated away, cancelling
+ * the request's AbortSignal mid-fetch. These surface as a bare `AbortError`
+ * (DOMException) that, untreated, bubbles to a 500 even though the server did
+ * nothing wrong and there is no client left to receive a response.
+ *
+ * Walks the `.cause` chain because tRPC wraps the thrown error as
+ * `TRPCError{ cause }` and the Meili layer may wrap once more. Explicitly EXCLUDES
+ * our own local Meili deadline, which also manifests as an AbortError but is a
+ * server-side timeout (handled as 408), not a client disconnect.
+ */
+export function isClientAbortError(e: unknown): boolean {
+  let cur = e as { name?: string; message?: string; cause?: unknown } | undefined;
+  for (let depth = 0; depth < 4 && cur; depth++) {
+    const isAbort =
+      cur.name === 'AbortError' ||
+      cur.message === 'This operation was aborted' ||
+      cur.message === 'The operation was aborted';
+    if (isAbort) {
+      const causeMsg = (cur.cause as { message?: string } | undefined)?.message;
+      const isLocalTimeout =
+        cur.message === MEILI_LOCAL_TIMEOUT_MESSAGE || causeMsg === MEILI_LOCAL_TIMEOUT_MESSAGE;
+      return !isLocalTimeout;
+    }
+    cur = cur.cause as typeof cur;
+  }
+  return false;
+}
+
 const prismaErrorToTrpcCode: Record<string, TRPC_ERROR_CODE_KEY> = {
   P1008: 'TIMEOUT',
   P2000: 'BAD_REQUEST',


### PR DESCRIPTION
## Problem

When a client cancels a request mid-flight — closes the tab, scrolls the infinite image feed past the in-flight page, or navigates away — the request's `AbortSignal` fires and aborts the in-flight Meili fetch (`fetchDocumentsAbortable`). That rejects with a bare `AbortError` ("This operation was aborted"), which — untreated — bubbled all the way to a **500**, even though the server did nothing wrong and there's no client left to receive a response.

Per the dp-prod app-500 attribution (`civitai_app_http_errors_total`, from #2501), this is the **top mislabeled-500 source after `/api/og`**, ~0.43/s:
| route | rate |
|---|---|
| `GET /api/v1/images` | ~0.20/s |
| `GET /api/v1/models` | ~0.16/s |
| `trpc/image.getInfinite` | ~0.07/s |

The tell: the error log is exclusively `Error: This operation was aborted` on these routes, and it tracks user navigation, not server health.

## Fix

One deterministic helper + three central chokepoints — no per-call-site whack-a-mole:

- **`isClientAbortError(e)`** (`errorHandling.ts`): true for an `AbortError` (walking the `.cause` chain, since tRPC wraps the original throw as `TRPCError{cause}`) that is **not** our local Meili-deadline sentinel (`meili-fetch-timeout`, which is a *server-side* timeout already handled as 408). The sentinel is duplicated as a literal rather than imported because `meilisearch/client.ts` already imports `sleep` from this module — importing it back would form the circular dependency class that caused the recent `article.metrics` Next-16 TDZ → 500 regression (#2504).
- **`handleEndpointError`** (covers `/api/v1/models` + all its callers) and the **`/api/v1/images`** own catch: respond **499** (client closed request) instead of 500 — so it's excluded from the 5xx SLO, the `civitai_app_http_errors_total` counter (its `finish` listener only counts ≥500), and the error logs.
- **tRPC `onError`** (covers `image.getInfinite` + every procedure): skip both the counter and the Axiom ingest for client aborts.

Local Meili-timeout handling (408) is unchanged; only genuine client disconnects are reclassified.

## Verification

⚠️ Not yet runtime-verified — needs the PR preview. Plan: simulate a client abort against `/api/v1/images` (start a request, drop the connection) and confirm it no longer emits a 500 / increments the counter; confirm normal requests + the local-timeout 408 path are unaffected. I'll verify on the preview before recommending merge.

Builds on the app-500 floor work: #2501 (the counter) → #2509 (`/api/og`, the ~74% chunk) → this (the ~0.43/s client-abort slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)