### PR TITLE
audit follow-ups: og fallback cache TTL + counter coverage doc

### DIFF
--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -711,11 +711,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const buffer = Buffer.from(await imageResponse.arrayBuffer());
 
     res.setHeader('Content-Type', 'image/png');
-    res.setHeader(
-      'Cache-Control',
-      'public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400'
-    );
-    res.setHeader('CDN-Cache-Control', 'max-age=604800');
+    if (data) {
+      // Real entity card → long edge cache.
+      res.setHeader(
+        'Cache-Control',
+        'public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400'
+      );
+      res.setHeader('CDN-Cache-Control', 'max-age=604800');
+    } else {
+      // Missing/deleted/unpublished/NSFW entity → generic fallback card. Cache SHORT
+      // (mirror the catch-block fallback) so a later-published or replica-lagged
+      // entity isn't pinned to the generic card at the CF edge for up to 7 days.
+      res.setHeader('Cache-Control', 'public, max-age=3600, s-maxage=3600');
+    }
     res.send(buffer);
   } catch (error) {
     console.error('OG image generation failed:', error);

--- a/src/server/prom/http-errors.ts
+++ b/src/server/prom/http-errors.ts
@@ -48,7 +48,7 @@ export const httpErrorCounter: client.Counter<string> =
   globalThis.__civitaiHttpErrorCounter ??
   (globalThis.__civitaiHttpErrorCounter = new client.Counter({
     name: NAME,
-    help: 'Count of APP-EMITTED 5xx responses by normalized route, status, kind. UNSAMPLED. kind=api increments per RESPONSE (once per 5xx); kind=trpc increments per PROCEDURE-error (a batched request can increment several times) — account for this when summing. EDGE-generated 502/504 (event-loop pin, liveness SIGKILL, gateway timeout) are NOT counted: the app never runs for those — use Traefik code=~"5.." for the full floor. App-THROWN 5xx (incl. a TRPCError mapping to 502/503/504) ARE counted. Per-route source of truth for the app-emitted 5xx slice.',
+    help: 'Count of APP-EMITTED 5xx responses by normalized route, status, kind. UNSAMPLED. kind=api increments per RESPONSE (once per 5xx); kind=trpc increments per PROCEDURE-error (a batched request can increment several times) — account for this when summing. EDGE-generated 502/504 (event-loop pin, liveness SIGKILL, gateway timeout) are NOT counted: the app never runs for those — use Traefik code=~"5.." for the full floor. App-THROWN 5xx (incl. a TRPCError mapping to 502/503/504) ARE counted. COVERAGE: only routes using the 6 endpoint-helper wrappers (Public/Authed/MixedAuth/Mod/Partner/TokenSecured→withApiMetrics) + tRPC are instrumented; bare custom handlers — notably the payment webhooks (stripe/paddle/coinbase/nowpayments/tipalti/emerchantpay), auth/[...nextauth], oauth/*, and upload/* — are NOT, so their 5xx show in Traefik only. Treat this as the app-emitted 5xx slice for WRAPPED routes, not the whole app.',
     labelNames: ['route', 'status', 'kind'],
   }));
 


### PR DESCRIPTION
Two small follow-ups from the cross-PR adversarial audit of the app-500 floor work (#2501/#2509). Both LOW/MEDIUM, neither blocking; doing them now while it's fresh.

### 1. `/api/og` — short-cache the missing-entity fallback (MEDIUM)
The null-data fallback (missing / deleted / unpublished / all-NSFW entity) renders `FallbackCard` **inside the try block**, so it inherited the *success* cache headers (`s-maxage=604800` + `CDN-Cache-Control: max-age=604800` = 7 days). A deleted/unpublished or replica-lagged entity therefore serves the generic Civitai card at the CF edge for up to a week, unbustable short of a purge. Fix: branch the cache headers on `data` — real entity keeps the long edge cache; the fallback gets a short TTL (`max-age=3600, s-maxage=3600`, mirroring the catch-block fallback). (Found by the #2509 re-audit; the catch-block fallback already used the short TTL — only the try-block null path was long-cached.)

### 2. `civitai_app_http_errors_total` — document the coverage boundary (LOW)
The counter help claimed "source of truth for the app-emitted 5xx slice," but ~40 of ~240 API routes are bare custom handlers that bypass the 6 endpoint-helper wrappers — notably the **payment webhooks** (stripe/paddle/coinbase/nowpayments/tipalti/emerchantpay), `auth/[...nextauth]`, `oauth/*`, `upload/*`. Their 5xx are invisible to the counter (Traefik-only). Documented the boundary in the help text so a quiet counter isn't misread as "no webhook 500s." (Found by the #2501 re-audit.) Actually instrumenting those bare handlers — esp. the revenue-critical payment webhooks — is a worthwhile larger follow-up, but they have bespoke response/signature logic and warrant their own change.

### Verification
Type-clean (diffs isolated; the `og.tsx`/baseline `implicitly-any` noise is the `@prisma/client`-not-generated cascade on the dev host). The og cache change is a header-only behavior change (verifiable post-deploy: missing-entity `/api/og` should return `Cache-Control: ...s-maxage=3600`); the counter change is help-text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)