### PR TITLE
fix(games): correct getPlayerHistory pagination (composite keyset cursor)

### DIFF
--- a/src/server/schema/games/new-order.schema.ts
+++ b/src/server/schema/games/new-order.schema.ts
@@ -77,10 +77,24 @@ export const getHistorySchema = z.object({
   limit: z.number().optional().default(DEFAULT_PAGE_SIZE),
   cursor: z
     .object({
-      createdAt: z.coerce.date(),
+      // ClickHouse (JSONEachRow) serializes this DateTime as a bare
+      // "YYYY-MM-DD HH:MM:SS" with no zone; coercing that with `new Date()` would
+      // parse it as POD-LOCAL time. Force UTC so the keyset boundary is exact
+      // regardless of pod TZ (pods are UTC today — don't silently depend on it).
+      // An ISO/Z string or a Date instance passes through unchanged; anything
+      // unparseable fails z.coerce.date() → .catch() below → page 1.
+      createdAt: z.preprocess(
+        (v) =>
+          typeof v === 'string' && !/[zZ]|[+-]\d\d:?\d\d$/.test(v) ? `${v.replace(' ', 'T')}Z` : v,
+        z.coerce.date()
+      ),
       imageId: z.number(),
     })
-    .optional(),
+    .optional()
+    // A legacy (pre-deploy, Date-shaped) or otherwise-invalid cursor degrades to
+    // page 1 instead of a hard 400 — graceful across the canary window — and a
+    // crafted cursor can never reach the query (dropped here, never interpolated).
+    .catch(undefined),
   status: z
     .enum(NewOrderImageRatingStatus)
     .transform((val) => {

--- a/src/server/schema/games/new-order.schema.ts
+++ b/src/server/schema/games/new-order.schema.ts
@@ -67,14 +67,20 @@ const transformStatus = {
 
 export type GetHistoryInput = z.input<typeof getHistorySchema>;
 export type GetHistorySchema = z.infer<typeof getHistorySchema>;
-// Cursor is interpolated into a ClickHouse query downstream — must coerce to a
-// real Date so a crafted string cannot inject SQL. Previously any authed user
-// could read all KoNo players' rating history by sending a cursor like
-// `' OR 1=1 --` which would round-trip through `.union([..., z.string(), ...])`
-// untouched and land inside the `createdAt < '${cursor}'` template.
+// Keyset-pagination cursor: composite (createdAt, imageId) on the aggregated sort
+// key. Both fields are typed/validated before they're interpolated into the
+// ClickHouse query downstream — createdAt coerces to a real Date, imageId to a
+// number — so a crafted string cannot inject SQL. (Prior bug: a `' OR 1=1 --`
+// string cursor round-tripped untouched into the `createdAt < '${cursor}'`
+// template, letting any authed user read every KoNo player's history.)
 export const getHistorySchema = z.object({
   limit: z.number().optional().default(DEFAULT_PAGE_SIZE),
-  cursor: z.coerce.date().optional(),
+  cursor: z
+    .object({
+      createdAt: z.coerce.date(),
+      imageId: z.number(),
+    })
+    .optional(),
   status: z
     .enum(NewOrderImageRatingStatus)
     .transform((val) => {

--- a/src/server/services/games/new-order.service.ts
+++ b/src/server/services/games/new-order.service.ts
@@ -1878,15 +1878,21 @@ export async function getPlayerHistory({
     `userId = ${playerId}`,
     `createdAt >= parseDateTimeBestEffort('${player.startAt.toISOString()}')`,
   ];
-  // cursor is a Date (schema coerces). Wrap in parseDateTimeBestEffort() exactly
-  // like the lower bound above — ClickHouse can't implicitly coerce an ISO-8601
-  // string (with the `T`/ms/`Z`) to DateTime, so a bare `createdAt < '<iso>'`
-  // threw "Cannot convert string ... to type DateTime" and 500'd every page-2+
-  // history fetch (whenever a cursor is present).
-  if (cursor) AND.push(`createdAt < parseDateTimeBestEffort('${cursor.toISOString()}')`);
-
   const HAVING = [];
   if (status?.length) HAVING.push(`status IN ('${status.join("','")}')`);
+  // Keyset pagination on the AGGREGATE sort key (max(createdAt), imageId) via
+  // HAVING — NOT a raw-row `createdAt < cursor` in WHERE. Filtering raw rows by the
+  // cursor corrupts the per-image max(createdAt): it SKIPS a boundary image whose
+  // only rating is at the cursor second, and DUPLICATES a re-rated image whose
+  // older rows survive the prune (reappearing with a stale max). The tuple compare
+  // + matching (lastCreatedAt, imageId) ORDER BY gives gap/dup-free paging incl.
+  // same-second ties. Both cursor fields are schema-validated (Date + number) so
+  // this is injection-safe. (Cost: each page aggregates the player's window like
+  // page 1 — acceptable for a history view.)
+  if (cursor)
+    HAVING.push(
+      `(max(createdAt), imageId) < (parseDateTimeBestEffort('${cursor.createdAt.toISOString()}'), ${cursor.imageId})`
+    );
 
   const judgments = await clickhouse.$query<{
     imageId: number;
@@ -1909,13 +1915,19 @@ export async function getPlayerHistory({
     WHERE ${AND.join(' AND ')}
     GROUP BY imageId
     ${HAVING.length > 0 ? `HAVING ${HAVING.join(' AND ')}` : ''}
-    ORDER BY lastCreatedAt DESC
+    ORDER BY lastCreatedAt DESC, imageId DESC
     LIMIT ${limit + 1}
   `;
   if (judgments.length === 0) return { items: [], nextCursor: null };
 
-  let nextCursor: Date | null = null;
-  if (judgments.length > limit) nextCursor = judgments.pop()?.lastCreatedAt ?? null;
+  // Cursor = the LAST KEPT row's (createdAt, imageId), not the popped probe row —
+  // next page is HAVING (max(createdAt), imageId) < cursor, so it resumes strictly
+  // after this row with no skip/dup.
+  const hasMore = judgments.length > limit;
+  if (hasMore) judgments.pop();
+  const lastKept = judgments[judgments.length - 1];
+  const nextCursor =
+    hasMore && lastKept ? { createdAt: lastKept.lastCreatedAt, imageId: lastKept.imageId } : null;
 
   const imageIds = judgments.map((j) => j.imageId).sort();
   const images = await dbRead.image.findMany({


### PR DESCRIPTION
Fast-follow to #2513 (now merged). #2513 fixed the page-2 **500** (ClickHouse `Code 53` — couldn't coerce the bare ISO cursor to `DateTime`), which un-blocked page-2 and exposed a **pre-existing off-by-one** in the cursor logic that only manifested once page-2 actually executed.

## The bug (verified against live ClickHouse)
The page key is the per-image `max(createdAt)`, but the cursor filtered **raw rows** (`createdAt < cursor` in `WHERE`) using the **popped `(limit+1)`th** row's key with strict `<`. On real data (player 5044476) this:
- **Skips** the boundary image — its only rating at the cursor second is excluded by `<`, and it wasn't returned on page-1 either → it disappears from history entirely (demonstrated: `imageId 133688691 @19:22:55` on neither page);
- **Duplicates** a re-rated image whose older rows survive the raw-row prune and reappear on a later page with a stale `max`.

## The fix — proper keyset pagination on the aggregate sort key
- cursor is now composite `{ createdAt, imageId }` (both schema-validated → injection-safe, preserving #2513's prior fix);
- moved from raw-row `WHERE` to `HAVING (max(createdAt), imageId) < (cursorTs, cursorImageId)` so it can't corrupt the per-image `max`;
- `ORDER BY lastCreatedAt DESC, imageId DESC` (deterministic tiebreaker for same-second ratings);
- `nextCursor` = the **last kept** row's `(createdAt, imageId)`, not the popped probe row.

Client is unaffected (treats `nextCursor` opaquely via `getNextPageParam`).

## Verification (live ClickHouse)
- Proved the cursor round-trips with **zero TZ drift**: `parseDateTimeBestEffort('…T…Z') = toDateTime('… …')` → `exact_match=1` (column is `DateTime`, server TZ `UTC`, pods run `UTC`).
- page-1 keeps down to `19:54:57`; NEW page-2 **starts at `133690530 @19:54:56`** — the exact row the old scheme skipped. Contiguous, no gap, no dup.
- tsc: the cursor-shape change introduces **no** type errors anywhere (router/client included); the only `new-order.service.ts` errors are the pre-existing `@prisma/client`-not-generated baseline cascade (lines 1762/1764, above the change).

**Cost note:** moving the cursor to `HAVING` means each page aggregates the player's window like page 1 (no raw-row prune). Acceptable for a history view; flagging for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)