### PR TITLE
security(app-blocks): gate showcase images by viewer browsing level

### DIFF
--- a/docs/features/app-blocks-merge-audit-2026-06.md
+++ b/docs/features/app-blocks-merge-audit-2026-06.md
@@ -182,11 +182,23 @@ HMAC) is genuinely well-built and the dark boundary holds across routers/JWKS/mi
   global enable).
 
 ### GA-blockers (reachable only after the flag is turned on)
-1. **🔴 HIGH — Showcase images bypass NSFW/browsing-level filtering.**
-   `showcase.service.ts` selects `nsfwLevel` but never filters on it and ignores the viewer
-   setting → explicit image URLs + prompts + seeds for an X-rated model are posted into the
-   third-party iframe (`BLOCK_INIT`) for any viewer, incl. opted-out / logged-out. Fix:
-   filter by browsing level / `viewerNsfwEnabled` (SFW-only for anon) before returning.
+1. **🔴 HIGH — Showcase images bypass NSFW/browsing-level filtering — ✅ FIXED (PR #2517).**
+   `getModelShowcaseImages` now filters `nsfwLevel` against the viewer's allowed browsing
+   level (reusing the feed's `onlySelectableLevels` + `Flags.intersects` pattern), threading
+   viewer context from the router (`{ userId: ctx.user?.id, browsingLevel }`). Anon is
+   forced server-side to the platform's **public (PG)** level (`publicBrowsingLevelsFlag`,
+   matching `applyDomainFeature`), and the caller-supplied `browsingLevel` can't widen an
+   anon view. Audited; cache path verified leak-free (no server cache; anon responses are
+   identical so the edge cache can't replay NSFW to a SFW anon).
+   - **Follow-up (LOW, fail-safe):** the query fetches `take: 50` by reactions then filters
+     `nsfwLevel` in JS before the 6-image cap, so a SFW viewer on a model whose top-50 are
+     all NSFW can get an under-filled showcase even though SFW images exist past row 50.
+     Under-shows, never over-shows. Fix later: filter `nsfwLevel` in-query (`$queryRaw`
+     bitwise) or raise `take`.
+   - **Follow-up (LOW, cleanliness):** the service re-derives the level instead of trusting
+     the already-`applyDomainFeature`-capped `input.browsingLevel` — two gates to keep in
+     sync. Consider passing the capped input through, keeping the `userId`-null force as
+     defense-in-depth.
 2. **MEDIUM — `submit-version` CSRF (confirmed).** Prod session cookie is `sameSite:'none'`
    (`next-auth-options.ts`) and `ModEndpoint` does no Origin/CSRF check; Next.js parses
    `application/x-www-form-urlencoded`, so a cross-site form POST with a tricked mod's cookie

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -20,6 +20,7 @@ import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-s
 import { getBaseModelGroup, getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
 import { trpc } from '~/utils/trpc';
 import { deriveScopeFromInstanceId } from '~/server/schema/blocks/attribution.schema';
+import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 
 const BuyBuzzModal = dynamic(() => import('~/components/Modals/BuyBuzzModal'));
 // Login flow for anonymous-conversion (REQUEST_SIGN_IN). SSR-disabled to match
@@ -289,8 +290,14 @@ export function IframeHost({
   // a 5-min staleTime is fine since reactions move slowly within a session.
   const modelVersionId =
     typeof modelCtx.modelVersionId === 'number' ? modelCtx.modelVersionId : null;
+  // Send the viewer's current browsing level so the server only returns
+  // showcase images (URLs + gen-meta) the viewer is allowed to see. The
+  // server forces SFW for anon viewers and never trusts this to widen an
+  // anon view — this just lets a logged-in NSFW-opted-in viewer see the
+  // same NSFW showcase the model-page gallery would show them.
+  const browsingLevel = useBrowsingLevelDebounced();
   const showcaseQuery = trpc.blocks.getShowcaseImages.useQuery(
-    { modelVersionId: modelVersionId ?? 0 },
+    { modelVersionId: modelVersionId ?? 0, browsingLevel },
     { enabled: modelVersionId != null, staleTime: 5 * 60_000 }
   );
   const showcaseImages = showcaseQuery.data ?? [];

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -292,8 +292,8 @@ export function IframeHost({
     typeof modelCtx.modelVersionId === 'number' ? modelCtx.modelVersionId : null;
   // Send the viewer's current browsing level so the server only returns
   // showcase images (URLs + gen-meta) the viewer is allowed to see. The
-  // server forces SFW for anon viewers and never trusts this to widen an
-  // anon view — this just lets a logged-in NSFW-opted-in viewer see the
+  // server forces anon viewers to public (PG) and never trusts this to widen
+  // an anon view — this just lets a logged-in NSFW-opted-in viewer see the
   // same NSFW showcase the model-page gallery would show them.
   const browsingLevel = useBrowsingLevelDebounced();
   const showcaseQuery = trpc.blocks.getShowcaseImages.useQuery(

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1284,9 +1284,9 @@ export const blocksRouter = router({
       z.object({
         modelVersionId: z.number().int().positive(),
         // Viewer's requested browsing-level flags (bitwise NsfwLevel), as the
-        // model-page gallery sends them. Optional; the service forces SFW for
-        // anon viewers and never trusts this to widen an anon view. Logged-in
-        // viewers with no value fall back to SFW server-side.
+        // model-page gallery sends them. Optional; the service forces anon
+        // viewers to public (PG) and never trusts this to widen an anon view.
+        // Logged-in viewers with no value fall back to SFW server-side.
         browsingLevel: z.number().int().min(0).optional(),
       })
     )
@@ -1303,7 +1303,7 @@ export const blocksRouter = router({
       // Thread the viewer's browsing context so NSFW image URLs + their full
       // gen-meta (prompt/seed) aren't leaked into the third-party publisher
       // iframe for NSFW-opted-out or logged-out viewers. Anon (no ctx.user)
-      // is forced to SFW inside the service.
+      // is forced to public (PG) inside the service.
       return getModelShowcaseImages(input.modelVersionId, {
         userId: ctx.user?.id ?? null,
         browsingLevel: input.browsingLevel,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1280,7 +1280,16 @@ export const blocksRouter = router({
    */
   getShowcaseImages: publicProcedure
     .use(enforceAppBlocksFlag)
-    .input(z.object({ modelVersionId: z.number().int().positive() }))
+    .input(
+      z.object({
+        modelVersionId: z.number().int().positive(),
+        // Viewer's requested browsing-level flags (bitwise NsfwLevel), as the
+        // model-page gallery sends them. Optional; the service forces SFW for
+        // anon viewers and never trusts this to widen an anon view. Logged-in
+        // viewers with no value fall back to SFW server-side.
+        browsingLevel: z.number().int().min(0).optional(),
+      })
+    )
     .query(({ input, ctx }) => {
       // Gated by the `appBlocks` feature flag (availability ['mod'] in prod
       // today, 'public' once GA'd / on the anon-conversion preview), mirroring
@@ -1291,7 +1300,14 @@ export const blocksRouter = router({
       // a "no preview images" state) when the flag is off, so a non-eligible
       // caller leaks nothing and the slot degrades gracefully.
       if (!ctx.features.appBlocks) return [];
-      return getModelShowcaseImages(input.modelVersionId);
+      // Thread the viewer's browsing context so NSFW image URLs + their full
+      // gen-meta (prompt/seed) aren't leaked into the third-party publisher
+      // iframe for NSFW-opted-out or logged-out viewers. Anon (no ctx.user)
+      // is forced to SFW inside the service.
+      return getModelShowcaseImages(input.modelVersionId, {
+        userId: ctx.user?.id ?? null,
+        browsingLevel: input.browsingLevel,
+      });
     }),
 
   /**

--- a/src/server/services/blocks/__tests__/showcase.service.test.ts
+++ b/src/server/services/blocks/__tests__/showcase.service.test.ts
@@ -118,7 +118,8 @@ describe('getModelShowcaseImages', () => {
 
   // NsfwLevel bitwise flags (mirrors src/server/common/enums.ts):
   //   PG = 1, PG13 = 2, R = 4, X = 8, XXX = 16, Blocked = 32.
-  // SFW (the anon-forced level) = PG | PG13 = 3.
+  // Anon is forced to the platform public level = PG = 1 (matches the model-page
+  // gallery's anon gate); SFW (the logged-in fallback) = PG | PG13 = 3.
   const PG = 1;
   const PG13 = 2;
   const R = 4;
@@ -127,7 +128,7 @@ describe('getModelShowcaseImages', () => {
   const Blocked = 32;
 
   describe('browsing-level filtering (security: NSFW leak into publisher iframe)', () => {
-    it('anon viewer (no viewer arg) gets only SFW images — NSFW dropped', async () => {
+    it('anon viewer (no viewer arg) gets only public (PG) images — PG13+NSFW dropped', async () => {
       mockDbRead.imageResourceNew.findMany.mockResolvedValue([
         imageRow(1, 100, {}, { nsfwLevel: PG }),
         imageRow(2, 90, {}, { nsfwLevel: PG13 }),
@@ -135,18 +136,21 @@ describe('getModelShowcaseImages', () => {
         imageRow(4, 70, {}, { nsfwLevel: X }),
         imageRow(5, 60, {}, { nsfwLevel: XXX }),
       ]);
-      // No viewer → anon → SFW only (PG + PG13).
+      // No viewer → anon → public only (PG). PG13 is excluded too — anon must
+      // not see in the iframe a level the model-page gallery wouldn't show them.
       const result = await getModelShowcaseImages(99);
-      expect(result.map((i) => i.id)).toEqual([1, 2]);
+      expect(result.map((i) => i.id)).toEqual([1]);
     });
 
-    it('anon viewer cannot widen via a passed browsingLevel (forced SFW)', async () => {
+    it('anon viewer cannot widen via a passed browsingLevel (forced public/PG)', async () => {
       mockDbRead.imageResourceNew.findMany.mockResolvedValue([
         imageRow(1, 100, {}, { nsfwLevel: PG }),
-        imageRow(2, 90, {}, { nsfwLevel: X }),
-        imageRow(3, 80, {}, { nsfwLevel: XXX }),
+        imageRow(2, 95, {}, { nsfwLevel: PG13 }),
+        imageRow(3, 90, {}, { nsfwLevel: X }),
+        imageRow(4, 80, {}, { nsfwLevel: XXX }),
       ]);
-      // userId null but a wide browsingLevel requested — must be ignored.
+      // userId null but a wide browsingLevel requested — must be ignored; even
+      // PG13 is dropped (anon is capped to public/PG, not SFW).
       const result = await getModelShowcaseImages(99, {
         userId: null,
         browsingLevel: PG | PG13 | R | X | XXX,
@@ -244,12 +248,14 @@ describe('getModelShowcaseImages', () => {
         imageRow(107, 994, {}, { nsfwLevel: X }),
         imageRow(1, 50, {}, { nsfwLevel: PG }),
         imageRow(2, 40, {}, { nsfwLevel: PG }),
-        imageRow(3, 30, {}, { nsfwLevel: PG13 }),
+        imageRow(3, 30, {}, { nsfwLevel: PG }),
         imageRow(4, 20, {}, { nsfwLevel: PG }),
-        imageRow(5, 10, {}, { nsfwLevel: PG13 }),
+        imageRow(5, 10, {}, { nsfwLevel: PG }),
         imageRow(6, 5, {}, { nsfwLevel: PG }),
       ]);
-      const result = await getModelShowcaseImages(99); // anon → SFW
+      // anon → public (PG). The 7 high-reaction X images must be filtered out
+      // BEFORE the 6-image cap, so the lower-reaction PG images aren't starved.
+      const result = await getModelShowcaseImages(99);
       expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4, 5, 6]);
     });
   });

--- a/src/server/services/blocks/__tests__/showcase.service.test.ts
+++ b/src/server/services/blocks/__tests__/showcase.service.test.ts
@@ -116,6 +116,144 @@ describe('getModelShowcaseImages', () => {
     expect(result).toEqual([]);
   });
 
+  // NsfwLevel bitwise flags (mirrors src/server/common/enums.ts):
+  //   PG = 1, PG13 = 2, R = 4, X = 8, XXX = 16, Blocked = 32.
+  // SFW (the anon-forced level) = PG | PG13 = 3.
+  const PG = 1;
+  const PG13 = 2;
+  const R = 4;
+  const X = 8;
+  const XXX = 16;
+  const Blocked = 32;
+
+  describe('browsing-level filtering (security: NSFW leak into publisher iframe)', () => {
+    it('anon viewer (no viewer arg) gets only SFW images — NSFW dropped', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: PG }),
+        imageRow(2, 90, {}, { nsfwLevel: PG13 }),
+        imageRow(3, 80, {}, { nsfwLevel: R }),
+        imageRow(4, 70, {}, { nsfwLevel: X }),
+        imageRow(5, 60, {}, { nsfwLevel: XXX }),
+      ]);
+      // No viewer → anon → SFW only (PG + PG13).
+      const result = await getModelShowcaseImages(99);
+      expect(result.map((i) => i.id)).toEqual([1, 2]);
+    });
+
+    it('anon viewer cannot widen via a passed browsingLevel (forced SFW)', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: PG }),
+        imageRow(2, 90, {}, { nsfwLevel: X }),
+        imageRow(3, 80, {}, { nsfwLevel: XXX }),
+      ]);
+      // userId null but a wide browsingLevel requested — must be ignored.
+      const result = await getModelShowcaseImages(99, {
+        userId: null,
+        browsingLevel: PG | PG13 | R | X | XXX,
+      });
+      expect(result.map((i) => i.id)).toEqual([1]);
+    });
+
+    it('NSFW-disabled logged-in viewer (SFW level) is filtered to SFW only', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: PG }),
+        imageRow(2, 90, {}, { nsfwLevel: PG13 }),
+        imageRow(3, 80, {}, { nsfwLevel: R }),
+        imageRow(4, 70, {}, { nsfwLevel: X }),
+      ]);
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13,
+      });
+      expect(result.map((i) => i.id)).toEqual([1, 2]);
+    });
+
+    it('logged-in viewer with higher browsing levels gets the NSFW images', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: PG }),
+        imageRow(2, 90, {}, { nsfwLevel: R }),
+        imageRow(3, 80, {}, { nsfwLevel: X }),
+        imageRow(4, 70, {}, { nsfwLevel: XXX }),
+      ]);
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13 | R | X | XXX,
+      });
+      // All intersect the requested level → all returned (reaction order).
+      expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4]);
+    });
+
+    it('logged-in viewer sees only the levels they requested (R but not X)', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: PG }),
+        imageRow(2, 90, {}, { nsfwLevel: R }),
+        imageRow(3, 80, {}, { nsfwLevel: X }),
+      ]);
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13 | R,
+      });
+      expect(result.map((i) => i.id)).toEqual([1, 2]);
+    });
+
+    it('logged-in viewer with no/empty browsingLevel falls back to SFW (safe default)', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: PG13 }),
+        imageRow(2, 90, {}, { nsfwLevel: X }),
+      ]);
+      const result = await getModelShowcaseImages(99, { userId: 42 });
+      expect(result.map((i) => i.id)).toEqual([1]);
+    });
+
+    it('Blocked is stripped from a requested level (onlySelectableLevels)', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: PG }),
+        imageRow(2, 90, {}, { nsfwLevel: Blocked }),
+      ]);
+      // Even if a caller requests Blocked, it must not surface Blocked content.
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | Blocked,
+      });
+      expect(result.map((i) => i.id)).toEqual([1]);
+    });
+
+    it('unrated images (nsfwLevel = 0) are never surfaced, even to a wide viewer', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(1, 100, {}, { nsfwLevel: 0 }),
+        imageRow(2, 90, {}, { nsfwLevel: PG }),
+      ]);
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13 | R | X | XXX,
+      });
+      expect(result.map((i) => i.id)).toEqual([2]);
+    });
+
+    it('filters by nsfwLevel BEFORE the MAX cap so SFW images are not starved', async () => {
+      // 7 NSFW images with the highest reactions, then 6 SFW ones. A naive
+      // "slice then filter" would return [] for a SFW viewer; filtering first
+      // must yield the 6 SFW images.
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([
+        imageRow(101, 1000, {}, { nsfwLevel: X }),
+        imageRow(102, 999, {}, { nsfwLevel: X }),
+        imageRow(103, 998, {}, { nsfwLevel: X }),
+        imageRow(104, 997, {}, { nsfwLevel: X }),
+        imageRow(105, 996, {}, { nsfwLevel: X }),
+        imageRow(106, 995, {}, { nsfwLevel: X }),
+        imageRow(107, 994, {}, { nsfwLevel: X }),
+        imageRow(1, 50, {}, { nsfwLevel: PG }),
+        imageRow(2, 40, {}, { nsfwLevel: PG }),
+        imageRow(3, 30, {}, { nsfwLevel: PG13 }),
+        imageRow(4, 20, {}, { nsfwLevel: PG }),
+        imageRow(5, 10, {}, { nsfwLevel: PG13 }),
+        imageRow(6, 5, {}, { nsfwLevel: PG }),
+      ]);
+      const result = await getModelShowcaseImages(99); // anon → SFW
+      expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+  });
+
   describe('meta extraction', () => {
     async function getFirstMeta(meta: unknown) {
       mockDbRead.imageResourceNew.findMany.mockResolvedValue([imageRow(1, 10, meta)]);

--- a/src/server/services/blocks/showcase.service.ts
+++ b/src/server/services/blocks/showcase.service.ts
@@ -1,8 +1,53 @@
 import { Prisma } from '@prisma/client';
 import { dbRead } from '~/server/db/client';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { Flags } from '~/shared/utils/flags';
+import {
+  onlySelectableLevels,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
 
 const MAX_SHOWCASE_IMAGES = 6;
+
+/**
+ * Viewer browsing context, used to gate which showcase images (and their
+ * gen-meta) are surfaced to the block. Mirrors how the model-page image feed
+ * filters by `nsfwLevel` against the viewer's allowed browsing levels
+ * (see `getAllImages` in `src/server/services/image.service.ts`, which does
+ * `(i."nsfwLevel" & ${browsingLevel}) != 0` after `onlySelectableLevels`).
+ *
+ * SECURITY: this output is posted into the third-party publisher iframe via
+ * `BLOCK_INIT.context.showcaseImages` (IframeHost.tsx). Without this gate an
+ * X-rated model would leak explicit image URLs + full prompts/seeds to
+ * untrusted publisher code AND to viewers who opted out of NSFW (including
+ * logged-out viewers). Anon viewers are forced to SFW server-side; the
+ * caller-supplied `browsingLevel` is never trusted to widen an anon view.
+ */
+export interface ShowcaseViewer {
+  /** The viewer's user id, or null/undefined for anonymous / logged-out. */
+  userId?: number | null;
+  /**
+   * The viewer's requested browsing-level flags (bitwise `NsfwLevel`), as the
+   * model-page gallery sends them. Ignored for anon viewers (forced to SFW).
+   * When omitted for a logged-in viewer we fall back to SFW (safe default).
+   */
+  browsingLevel?: number;
+}
+
+/**
+ * Resolve the bitwise browsing-level flags a viewer is actually allowed to
+ * see, mirroring the model-page feed's gating but fail-closed:
+ *   - anonymous / logged-out  → SFW only (PG + PG13), regardless of what was
+ *     requested. Untrusted callers (and the iframe) can't widen this.
+ *   - logged-in               → the requested level, with unselectable bits
+ *     (Blocked) stripped via `onlySelectableLevels`. Missing / zero falls back
+ *     to SFW so a viewer with no settings yet never gets NSFW by default.
+ */
+function resolveAllowedBrowsingLevel(viewer?: ShowcaseViewer): number {
+  if (!viewer?.userId) return sfwBrowsingLevelsFlag;
+  const requested = onlySelectableLevels(viewer.browsingLevel ?? 0);
+  return requested > 0 ? requested : sfwBrowsingLevelsFlag;
+}
 
 /**
  * Bounded, public-safe view of a showcase image the block displays to
@@ -39,11 +84,20 @@ export interface ShowcaseImage {
  *   - tosViolation: false (defense in depth — Scanned alone is supposed
  *     to drop these, but enforce here too).
  *   - postId IS NOT NULL (orphaned images shouldn't show up).
+ *   - nsfwLevel intersects the viewer's allowed browsing levels (see
+ *     `resolveAllowedBrowsingLevel` / `ShowcaseViewer`). Anon → SFW only.
+ *     Images with `nsfwLevel = 0` (unrated / pending) never intersect and are
+ *     therefore excluded — the same fail-closed stance the feed takes for
+ *     non-own unrated content.
  *
  * Returns an empty array when the version has no images yet — block UI
  * renders a "no preview images" state rather than crashing.
  */
-export async function getModelShowcaseImages(modelVersionId: number): Promise<ShowcaseImage[]> {
+export async function getModelShowcaseImages(
+  modelVersionId: number,
+  viewer?: ShowcaseViewer
+): Promise<ShowcaseImage[]> {
+  const allowedBrowsingLevel = resolveAllowedBrowsingLevel(viewer);
   // ImageResourceNew is the live table; the legacy ImageResource was fully
   // migrated and is now empty (verified 2026-05-25: 0 rows vs 417M).
   const rows = await dbRead.imageResourceNew.findMany({
@@ -105,6 +159,11 @@ export async function getModelShowcaseImages(modelVersionId: number): Promise<Sh
     const img = row.image;
     if (!img || seen.has(img.id)) continue;
     seen.add(img.id);
+    // Browsing-level gate: drop any image whose nsfwLevel isn't in the
+    // viewer's allowed levels BEFORE the MAX cap, so a wall of NSFW top
+    // images doesn't starve a SFW viewer of the SFW ones further down.
+    // `Flags.intersects(0, …)` is false → unrated (nsfwLevel = 0) is excluded.
+    if (!Flags.intersects(img.nsfwLevel, allowedBrowsingLevel)) continue;
     const reactions = reactionByImage.get(img.id) ?? 0;
     flat.push({ img, reactions });
   }

--- a/src/server/services/blocks/showcase.service.ts
+++ b/src/server/services/blocks/showcase.service.ts
@@ -4,6 +4,7 @@ import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { Flags } from '~/shared/utils/flags';
 import {
   onlySelectableLevels,
+  publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 
@@ -20,15 +21,16 @@ const MAX_SHOWCASE_IMAGES = 6;
  * `BLOCK_INIT.context.showcaseImages` (IframeHost.tsx). Without this gate an
  * X-rated model would leak explicit image URLs + full prompts/seeds to
  * untrusted publisher code AND to viewers who opted out of NSFW (including
- * logged-out viewers). Anon viewers are forced to SFW server-side; the
- * caller-supplied `browsingLevel` is never trusted to widen an anon view.
+ * logged-out viewers). Anon viewers are forced to the platform's public (PG)
+ * level server-side; the caller-supplied `browsingLevel` is never trusted to
+ * widen an anon view.
  */
 export interface ShowcaseViewer {
   /** The viewer's user id, or null/undefined for anonymous / logged-out. */
   userId?: number | null;
   /**
    * The viewer's requested browsing-level flags (bitwise `NsfwLevel`), as the
-   * model-page gallery sends them. Ignored for anon viewers (forced to SFW).
+   * model-page gallery sends them. Ignored for anon viewers (forced to public).
    * When omitted for a logged-in viewer we fall back to SFW (safe default).
    */
   browsingLevel?: number;
@@ -37,14 +39,17 @@ export interface ShowcaseViewer {
 /**
  * Resolve the bitwise browsing-level flags a viewer is actually allowed to
  * see, mirroring the model-page feed's gating but fail-closed:
- *   - anonymous / logged-out  → SFW only (PG + PG13), regardless of what was
- *     requested. Untrusted callers (and the iframe) can't widen this.
+ *   - anonymous / logged-out  → public only (PG), regardless of what was
+ *     requested. This matches the platform's anon gate (`applyDomainFeature`
+ *     caps anon to `publicBrowsingLevelsFlag`), so the showcase can't surface
+ *     a level the model-page gallery wouldn't show that same anon viewer.
+ *     Untrusted callers (and the iframe) can't widen this.
  *   - logged-in               → the requested level, with unselectable bits
  *     (Blocked) stripped via `onlySelectableLevels`. Missing / zero falls back
  *     to SFW so a viewer with no settings yet never gets NSFW by default.
  */
 function resolveAllowedBrowsingLevel(viewer?: ShowcaseViewer): number {
-  if (!viewer?.userId) return sfwBrowsingLevelsFlag;
+  if (!viewer?.userId) return publicBrowsingLevelsFlag;
   const requested = onlySelectableLevels(viewer.browsingLevel ?? 0);
   return requested > 0 ? requested : sfwBrowsingLevelsFlag;
 }


### PR DESCRIPTION
## Finding (HIGH severity)

`getModelShowcaseImages` in `src/server/services/blocks/showcase.service.ts` filtered showcase images only by `ingestion: 'Scanned'`, `tosViolation: false`, `postId NOT NULL`. It **selected** `nsfwLevel` but **never filtered on it**, and it received no viewer context at all.

The result — image URL (via `getEdgeUrl`) plus **full `prompt`, `negativePrompt`, `seed`, etc.** — is returned by the `blocks.getShowcaseImages` tRPC procedure and posted into the **third-party publisher iframe** via `BLOCK_INIT` (`context.showcaseImages`, `IframeHost.tsx`).

**Impact:** on an X/XXX-rated model, any installed third-party block — for **any viewer, including NSFW-opted-out and logged-out users** — received explicit image URLs *plus their generation metadata*. This leaked NSFW content + prompts/seeds to untrusted publisher code and to viewers who explicitly opted out.

## Fix

Thread the viewer's browsing context (`userId` + requested `browsingLevel`) from the tRPC procedure (`ctx`) through to the service, and filter `nsfwLevel` against the viewer's allowed levels — reusing the codebase's canonical pattern from `getAllImages` (`src/server/services/image.service.ts`: `onlySelectableLevels` + `(i."nsfwLevel" & browsingLevel) != 0`, here expressed via `Flags.intersects`).

Behavior:
- **anon / logged-out → forced SFW** (`sfwBrowsingLevelsFlag` = PG|PG13). A caller-supplied `browsingLevel` can **never** widen an anon view.
- **logged-in → respects requested browsing level**, with `Blocked` stripped via `onlySelectableLevels`; missing/zero falls back to SFW (safe default).
- **`nsfwLevel = 0` (unrated/pending) never intersects → excluded** (fail-closed, matching the feed's stance for non-own unrated content).
- nsfwLevel filter runs **before** the `MAX_SHOWCASE_IMAGES` cap so a wall of NSFW top-reacted images can't starve a SFW viewer of the SFW ones beneath them.
- Existing `Scanned` / `tosViolation` / `postId` safety filters are unchanged.

Client (`IframeHost.tsx`) now sends `useBrowsingLevelDebounced()` alongside the query — the same hook the model-page image feed uses.

## Files changed
- `src/server/services/blocks/showcase.service.ts` — `ShowcaseViewer` type, `resolveAllowedBrowsingLevel`, nsfwLevel gate, new signature `getModelShowcaseImages(modelVersionId, viewer?)`.
- `src/server/routers/blocks.router.ts` — `getShowcaseImages` accepts optional `browsingLevel`, passes `{ userId: ctx.user?.id ?? null, browsingLevel }`.
- `src/components/AppBlocks/IframeHost.tsx` — sends the viewer's debounced browsing level.
- `src/server/services/blocks/__tests__/showcase.service.test.ts` — +9 browsing-level tests (19 total, green).

## Verification
`npx vitest run src/server/services/blocks/__tests__/showcase.service.test.ts` → **19 passed**. Covers: anon→SFW only, anon can't widen via passed level, NSFW-disabled viewer→SFW, higher-level viewer gets NSFW, level granularity (R but not X), no-level fallback→SFW, `Blocked` stripped, `nsfwLevel=0` excluded, filter-before-cap, and the existing Scanned/sort/dedupe/meta tests.

## Status
The `appBlocks` feature flag is **off in prod**, so this is **not a live incident** — but it is a **GA blocker** for the App Blocks feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>