### PR TITLE
fix(app-blocks): dual-secret HMAC rotation window for git-push + build-callback (W11 F6)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -393,7 +393,14 @@ export const serverSchema = z.object({
   // FORGEJO_ADMIN_TOKEN       Forgejo personal access token (admin) — used
   //                           by civitai-web to create repos / webhooks
   // FORGEJO_WEBHOOK_SECRET    HMAC shared secret between Forgejo → webhook
+  // FORGEJO_WEBHOOK_SECRET_NEXT   optional second secret accepted during a
+  //                           zero-downtime rotation (set NEXT to the new
+  //                           secret, flip the Forgejo signer to it, then
+  //                           drop the old from FORGEJO_WEBHOOK_SECRET).
   // BLOCK_BUILD_CALLBACK_SECRET   HMAC shared secret between Tekton → callback
+  // BLOCK_BUILD_CALLBACK_SECRET_NEXT  optional second secret accepted during a
+  //                           zero-downtime rotation (same OLD-or-NEW window
+  //                           as FORGEJO_WEBHOOK_SECRET_NEXT).
   // APPS_TEKTON_TRIGGER_URL   HTTP endpoint that creates PipelineRuns on
   //                           dc-02-a (the app-blocks-trigger receiver,
   //                           reached via the VPN proxy on dp-1). Example:
@@ -416,7 +423,9 @@ export const serverSchema = z.object({
   FORGEJO_PUBLIC_URL: z.string().url().default('https://forgejo.civitai.com'),
   FORGEJO_ADMIN_TOKEN: z.string().optional(),
   FORGEJO_WEBHOOK_SECRET: z.string().optional(),
+  FORGEJO_WEBHOOK_SECRET_NEXT: z.string().optional(),
   BLOCK_BUILD_CALLBACK_SECRET: z.string().optional(),
+  BLOCK_BUILD_CALLBACK_SECRET_NEXT: z.string().optional(),
   APPS_TEKTON_TRIGGER_URL: z.string().url().optional(),
   APPS_TEKTON_TRIGGER_SECRET: z.string().optional(),
   APPS_KUBE_NAMESPACE: z.string().default('civitai-apps'),

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -57,13 +57,30 @@ function safeEqualHex(a: string, b: string): boolean {
   return timingSafeEqual(A, B);
 }
 
-function verifySignature(rawBody: Buffer, header: unknown): boolean {
-  const secret = env.BLOCK_BUILD_CALLBACK_SECRET;
-  if (!secret) return false;
+export function verifySignature(rawBody: Buffer, header: unknown): boolean {
+  // Dual-acceptance rotation window (audit F6): accept a signature that matches
+  // EITHER the current secret OR an optional BLOCK_BUILD_CALLBACK_SECRET_NEXT.
+  // To rotate with zero downtime: set _NEXT to the new secret, flip the Tekton
+  // callback signer to the new secret, then move the new value into
+  // BLOCK_BUILD_CALLBACK_SECRET and clear _NEXT. When _NEXT is unset this is
+  // identical to single-secret behavior (fail-closed: no secret → false).
   if (typeof header !== 'string' || header.length === 0) return false;
-  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
   const provided = header.replace(/^sha256=/, '');
-  return safeEqualHex(provided, expected);
+
+  const secrets = [
+    env.BLOCK_BUILD_CALLBACK_SECRET,
+    env.BLOCK_BUILD_CALLBACK_SECRET_NEXT,
+  ].filter((s): s is string => typeof s === 'string' && s.length > 0);
+  if (secrets.length === 0) return false;
+
+  // Compute every candidate comparison (no boolean short-circuit) so we don't
+  // leak via timing which secret — current vs NEXT — was the matching one.
+  let matched = false;
+  for (const secret of secrets) {
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+    if (safeEqualHex(provided, expected)) matched = true;
+  }
+  return matched;
 }
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -75,14 +75,30 @@ function safeEqualHex(a: string, b: string): boolean {
   return timingSafeEqual(A, B);
 }
 
-function verifyForgejoSignature(rawBody: Buffer, signatureHeader: unknown): boolean {
-  const secret = env.FORGEJO_WEBHOOK_SECRET;
-  if (!secret) return false;
+export function verifyForgejoSignature(rawBody: Buffer, signatureHeader: unknown): boolean {
+  // Dual-acceptance rotation window (audit F6): accept a signature that
+  // matches EITHER the current secret OR an optional FORGEJO_WEBHOOK_SECRET_NEXT.
+  // To rotate with zero downtime: set _NEXT to the new secret, flip the Forgejo
+  // signer to the new secret, then move the new value into FORGEJO_WEBHOOK_SECRET
+  // and clear _NEXT. When _NEXT is unset this is identical to single-secret
+  // behavior (fail-closed: no secret → false).
   if (typeof signatureHeader !== 'string' || signatureHeader.length === 0) return false;
-  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
   // Forgejo sends the header bare (no `sha256=` prefix); be tolerant either way.
   const provided = signatureHeader.replace(/^sha256=/, '');
-  return safeEqualHex(provided, expected);
+
+  const secrets = [env.FORGEJO_WEBHOOK_SECRET, env.FORGEJO_WEBHOOK_SECRET_NEXT].filter(
+    (s): s is string => typeof s === 'string' && s.length > 0
+  );
+  if (secrets.length === 0) return false;
+
+  // Compute every candidate comparison (no boolean short-circuit) so we don't
+  // leak via timing which secret — current vs NEXT — was the matching one.
+  let matched = false;
+  for (const secret of secrets) {
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+    if (safeEqualHex(provided, expected)) matched = true;
+  }
+  return matched;
 }
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -1,15 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The handler module imports ~/server/db/client (Prisma init at module load).
-// We only exercise the pure expectedImageRef helper, so stub the db +
-// pipeline deps to keep the import side-effect-free.
+// We only exercise the pure expectedImageRef + verifySignature helpers, so stub
+// the db + pipeline deps to keep the import side-effect-free.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   triggerApply: vi.fn(),
   waitForApplyJob: vi.fn(),
 }));
 
-import { expectedImageRef } from '~/pages/api/internal/blocks/build-callback';
+// Mutable env mock so each test can set / clear
+// BLOCK_BUILD_CALLBACK_SECRET[_NEXT] to exercise the dual-acceptance rotation
+// window (F6). Overrides the global ~/env/server mock in src/__tests__/setup.ts
+// for this file. vi.hoisted so the object exists before the hoisted vi.mock
+// factory runs.
+const mockEnv = vi.hoisted(() => ({} as Record<string, string | undefined>));
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+
+import { expectedImageRef, verifySignature } from '~/pages/api/internal/blocks/build-callback';
 
 /**
  * L-CALLBACK coverage. The build-callback handler accepts an `imageRef` from
@@ -54,5 +63,64 @@ describe('build-callback imageRef binding', () => {
     const slug = 'slug-a';
     const sneaky = `ghcr.io/civitai/app-block-${slug}-evil:${SHA}`;
     expect(sneaky === expectedImageRef(slug, SHA)).toBe(false);
+  });
+});
+
+/**
+ * F6 — dual-secret HMAC rotation window. verifySignature must accept a
+ * signature computed under the CURRENT secret OR the optional *_NEXT secret, so
+ * BLOCK_BUILD_CALLBACK_SECRET can be rotated without dropping in-flight build
+ * callbacks. With _NEXT unset the behavior is unchanged (single-secret,
+ * fail-closed).
+ */
+describe('build-callback verifySignature dual-secret window (F6)', () => {
+  const body = Buffer.from(JSON.stringify({ slug: 'slug-a', status: 'Succeeded' }));
+  const sign = (secret: string, raw = body) =>
+    createHmac('sha256', secret).update(raw).digest('hex');
+
+  beforeEach(() => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = undefined;
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET_NEXT = undefined;
+  });
+  afterEach(() => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = undefined;
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET_NEXT = undefined;
+  });
+
+  it('accepts a signature valid under the current secret', () => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = 'current-secret';
+    expect(verifySignature(body, sign('current-secret'))).toBe(true);
+  });
+
+  it('accepts a signature valid under the NEXT secret (new signer) during rotation', () => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = 'old-secret';
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET_NEXT = 'new-secret';
+    expect(verifySignature(body, sign('new-secret'))).toBe(true);
+    // Old secret still accepted (in-flight callbacks from the old signer).
+    expect(verifySignature(body, sign('old-secret'))).toBe(true);
+  });
+
+  it('tolerates a sha256= prefix', () => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = 'old-secret';
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET_NEXT = 'new-secret';
+    expect(verifySignature(body, `sha256=${sign('new-secret')}`)).toBe(true);
+  });
+
+  it('rejects a NEXT-signed signature when NEXT is unset (unchanged single-secret behavior)', () => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = 'current-secret';
+    expect(verifySignature(body, sign('some-future-secret'))).toBe(false);
+  });
+
+  it('still rejects a garbage signature with both secrets set', () => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = 'old-secret';
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET_NEXT = 'new-secret';
+    expect(verifySignature(body, 'deadbeef')).toBe(false);
+    expect(verifySignature(body, '')).toBe(false);
+    expect(verifySignature(body, undefined)).toBe(false);
+    expect(verifySignature(body, sign('wrong-secret'))).toBe(false);
+  });
+
+  it('fails closed when no secret is configured (no current, no NEXT)', () => {
+    expect(verifySignature(body, sign('anything'))).toBe(false);
   });
 });

--- a/src/tests/api/internal/blocks/git-push.test.ts
+++ b/src/tests/api/internal/blocks/git-push.test.ts
@@ -1,15 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The handler module imports ~/server/db/client (which inits Prisma at module
 // load and reads env.LOGGING.filter). We only exercise the pure
-// parseExpectedRepo helper, so stub the db + pipeline deps to keep the import
-// side-effect-free.
+// parseExpectedRepo + verifyForgejoSignature helpers, so stub the db + pipeline
+// deps to keep the import side-effect-free.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   triggerBuild: vi.fn(),
 }));
 
-import { parseExpectedRepo } from '~/pages/api/internal/blocks/git-push';
+// Mutable env mock so each test can set / clear FORGEJO_WEBHOOK_SECRET[_NEXT]
+// to exercise the dual-acceptance rotation window (F6). Overrides the global
+// ~/env/server mock in src/__tests__/setup.ts for this file. vi.hoisted so the
+// object exists before the hoisted vi.mock factory runs.
+const mockEnv = vi.hoisted(() => ({} as Record<string, string | undefined>));
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+
+import { parseExpectedRepo, verifyForgejoSignature } from '~/pages/api/internal/blocks/git-push';
 
 /**
  * M-WEBHOOK coverage. The git-push webhook is authenticated only by the
@@ -52,5 +60,65 @@ describe('parseExpectedRepo', () => {
 
   it('rejects an org with an empty slug', () => {
     expect(parseExpectedRepo('civitai-apps/', ORG)).toBeNull();
+  });
+});
+
+/**
+ * F6 — dual-secret HMAC rotation window. verifyForgejoSignature must accept a
+ * signature computed under the CURRENT secret OR the optional *_NEXT secret, so
+ * the secret can be rotated without an outage. With _NEXT unset the behavior is
+ * unchanged (single-secret, fail-closed).
+ */
+describe('verifyForgejoSignature dual-secret window (F6)', () => {
+  const body = Buffer.from(JSON.stringify({ ref: 'refs/heads/main', after: 'a'.repeat(40) }));
+  const sign = (secret: string, raw = body) =>
+    createHmac('sha256', secret).update(raw).digest('hex');
+
+  beforeEach(() => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = undefined;
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = undefined;
+  });
+  afterEach(() => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = undefined;
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = undefined;
+  });
+
+  it('accepts a signature valid under the current secret', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'current-secret';
+    expect(verifyForgejoSignature(body, sign('current-secret'))).toBe(true);
+  });
+
+  it('accepts a signature valid under the NEXT secret (new signer) during rotation', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'old-secret';
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = 'new-secret';
+    // Signed with the NEW secret — must be accepted while NEXT is set.
+    expect(verifyForgejoSignature(body, sign('new-secret'))).toBe(true);
+    // The old secret is still accepted too (in-flight builds from the old signer).
+    expect(verifyForgejoSignature(body, sign('old-secret'))).toBe(true);
+  });
+
+  it('tolerates a sha256= prefix on either secret', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'old-secret';
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = 'new-secret';
+    expect(verifyForgejoSignature(body, `sha256=${sign('new-secret')}`)).toBe(true);
+  });
+
+  it('rejects a NEXT-signed signature when NEXT is unset (unchanged single-secret behavior)', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'current-secret';
+    // NEXT unset — a signature under some other secret must NOT be accepted.
+    expect(verifyForgejoSignature(body, sign('some-future-secret'))).toBe(false);
+  });
+
+  it('still rejects a garbage signature with both secrets set', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'old-secret';
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = 'new-secret';
+    expect(verifyForgejoSignature(body, 'deadbeef')).toBe(false);
+    expect(verifyForgejoSignature(body, '')).toBe(false);
+    expect(verifyForgejoSignature(body, undefined)).toBe(false);
+    expect(verifyForgejoSignature(body, sign('wrong-secret'))).toBe(false);
+  });
+
+  it('fails closed when no secret is configured (no current, no NEXT)', () => {
+    expect(verifyForgejoSignature(body, sign('anything'))).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Closes the **W11 audit finding F6** for the civitai/civitai half: the two build-chain webhook RECEIVERS each verified the request HMAC against exactly ONE secret, so rotating that secret meant flipping the signer and the receiver simultaneously — any in-flight build during the window would 401.

This adds a zero-downtime **OLD-or-NEW dual-acceptance window** to each verifier, mirroring the existing `BLOCK_TOKEN_PUBLIC_KEY_NEXT` key-rotation pattern in `src/server/services/block-token.service.ts`.

## Changes

- **`src/pages/api/internal/blocks/git-push.ts`** — `verifyForgejoSignature` now accepts a signature matching EITHER `FORGEJO_WEBHOOK_SECRET` OR the optional `FORGEJO_WEBHOOK_SECRET_NEXT`.
- **`src/pages/api/internal/blocks/build-callback.ts`** — `verifySignature` now accepts EITHER `BLOCK_BUILD_CALLBACK_SECRET` OR the optional `BLOCK_BUILD_CALLBACK_SECRET_NEXT`.
- **`src/env/server-schema.ts`** — adds the two new vars as `z.string().optional()`.

Both verifiers **compute every candidate comparison (no boolean short-circuit)** so timing can't leak which secret matched, and each candidate keeps the existing length-checked constant-time `safeEqualHex` / `timingSafeEqual` compare. With `*_NEXT` unset, behavior is **identical to today**: single-secret, fail-closed (no secret → `false`).

## Rotation procedure (zero-downtime)

1. Set `*_NEXT` to the **new** secret (receiver now accepts old + new).
2. Flip the **signer** to the new secret — Forgejo webhook config for git-push; the Tekton callback task for build-callback.
3. Move the new value into the primary `*` var and **clear `*_NEXT`** (old secret no longer accepted).

## Scope / out of scope

- The **trigger RECEIVER** (`app-blocks-trigger.py`, `APPS_TEKTON_TRIGGER_SECRET`) is the third build-chain HMAC contract; its dual-secret window lands in a **separate datapacket-talos PR** (the receiver lives there, not in this repo).
- The **trigger SIGNER** (`apps-pipeline.service.ts`) stays single-secret and is intentionally untouched per the audit scope.
- F6 is the rotation half; replay protection (F5) is tracked separately.

## Tests

Extended `git-push.test.ts` and `build-callback.test.ts` with, for each receiver: (a) signature valid under the NEXT secret is accepted during rotation, (b) NEXT unset → single-secret behavior unchanged, (c) garbage / empty / wrong-secret signatures still rejected, plus fail-closed-when-no-secret. **23 tests pass** (`vitest run` on both files). `tsc --noEmit` reports no errors in any changed file (the repo has pre-existing unrelated typecheck errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)