### PR TITLE
security(app-blocks): unify server/client flag-gate context (H2)

### DIFF
--- a/src/pages/api/blocks/submit-version.ts
+++ b/src/pages/api/blocks/submit-version.ts
@@ -31,7 +31,10 @@ export const config = {
 
 export default ModEndpoint(
   async (req, res: NextApiResponse, user) => {
-    if (!(await isAppBlocksEnabled())) {
+    // H2: evaluate with the authenticated mod's context so the
+    // `moderators`-segmented flag resolves ON for them (ModEndpoint has already
+    // proven `user.isModerator` above). Mirrors enforceAppBlocksFlag.
+    if (!(await isAppBlocksEnabled({ user }))) {
       res.status(503).json({ message: 'App Blocks is not enabled' });
       return;
     }

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -18,7 +18,6 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import { BlockTokenService } from '~/server/services/block-token.service';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
-import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { getFeatureFlags } from '~/server/services/feature-flags.service';
 import { getAllServerHosts } from '~/server/utils/server-domain';
 import {
@@ -264,14 +263,14 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  // H-2: server-side feature-flag gate. The substrate ships dark; the UI
-  // mount + workflow callback aren't the only entry points an attacker
-  // could probe. 503 (Service Unavailable) is the right code: the surface
-  // exists but is intentionally off.
-  if (!(await isAppBlocksEnabled())) {
-    res.status(503).json({ error: 'App Blocks not enabled' });
-    return;
-  }
+  // H-2 / H2: the App Blocks feature-flag gate for this route is the PER-USER
+  // `getFeatureFlags({ user }).appBlocks` check below (after the session load).
+  // The previous GLOBAL pre-check here (`isAppBlocksEnabled()` with no user)
+  // could never match the live `moderators`-segmented flag, so it 503'd EVERY
+  // caller — including moderators — before the per-user gate ran (the H2
+  // divergence). Removing it lets the per-user gate be authoritative: a mod
+  // passes, a non-mod / anon caller is still refused (403) before any DB read.
+  // The cheap per-IP rate limit below still runs first to throttle probing.
 
   const parsed = requestSchema.safeParse(req.body ?? {});
   if (!parsed.success) {

--- a/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
+++ b/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * H2 — `enforceAppBlocksFlag` middleware threads the request user's context
+ * into the App Blocks flag gate.
+ *
+ * `isAppBlocksEnabled` is mocked with a FAITHFUL per-user implementation
+ * (mirrors the live `moderators`-segmented flag: ON only when the supplied
+ * user is a moderator). The test then drives the real blocks router so the
+ * middleware's `{ user: ctx.user }` wiring is what decides the outcome:
+ *   - moderator → query proceeds (registry consulted), mutation allowed;
+ *   - non-mod   → query returns [] (disabled), mutation UNAUTHORIZED;
+ *   - anon      → query returns [] (disabled), mutation UNAUTHORIZED.
+ *
+ * This is the no-widening invariant proven through the actual router path.
+ *
+ * The mock set mirrors `blocks.router.workflow.test.ts` — the heavy services
+ * (orchestrator, buzz, redis, registry, user.service) are stubbed so importing
+ * the router doesn't drag in the generated Prisma client / selectors (stale in
+ * a PR worktree).
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockListForModel,
+  mockInstallOnModel,
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetUserById,
+  mockGetUserBuzzAccounts,
+  mockLogToAxiom,
+  mockRedis,
+  mockSysRedis,
+  mockDbRead,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockListForModel: vi.fn(),
+  mockInstallOnModel: vi.fn(),
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockGetUserBuzzAccounts: vi.fn(),
+  mockLogToAxiom: vi.fn(async () => undefined),
+  mockRedis: { get: vi.fn(), set: vi.fn() },
+  mockSysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...a: unknown[]) => mockParseSubjectUserId(...a),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/textToImage/textToImage', () => ({
+  createTextToImageStep: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  getUserById: (...a: unknown[]) => mockGetUserById(...a),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: (...a: unknown[]) => mockGetUserBuzzAccounts(...a),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: (...a: unknown[]) => mockListForModel(...a),
+    installOnModel: (...a: unknown[]) => mockInstallOnModel(...a),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+// Faithful mod-segmented flag: ON iff the supplied user is a moderator. No user
+// (anon machine path) → false. Mirrors the live `app-blocks-enabled` rule.
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    // ctx.features.appBlocks mirrors the client gate. For the listForModel
+    // happy path we set it true for the mod so the registry is reached; the
+    // middleware gate is the unit under test.
+    features: { appBlocks: !!(user as { isModerator?: boolean })?.isModerator } as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockListForModel.mockReset();
+  mockListForModel.mockResolvedValue([{ id: 'blk_1' }]);
+  mockInstallOnModel.mockReset();
+  mockInstallOnModel.mockResolvedValue({ id: 'install_1' });
+});
+
+const listInput = { modelId: 7, slotId: 'model.sidebar_top' as const };
+
+describe('enforceAppBlocksFlag — query (listForModel)', () => {
+  it('moderator: gate passes, registry is consulted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.listForModel(listInput);
+    expect(result).toEqual([{ id: 'blk_1' }]);
+    expect(mockListForModel).toHaveBeenCalledTimes(1);
+    // Threaded the session user into the gate.
+    expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: modUser });
+  });
+
+  it('non-moderator: gate disables → [] (no-widening), registry NOT consulted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    const result = await caller.listForModel(listInput);
+    expect(result).toEqual([]);
+    expect(mockListForModel).not.toHaveBeenCalled();
+    expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: normalUser });
+  });
+
+  it('anonymous: gate disables → [] (no-widening), registry NOT consulted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.listForModel(listInput);
+    expect(result).toEqual([]);
+    expect(mockListForModel).not.toHaveBeenCalled();
+    expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: undefined });
+  });
+});
+
+describe('enforceAppBlocksFlag — mutation (installOnModel)', () => {
+  const installInput = { modelId: 7, appBlockId: 'app_1', slotId: 'model.sidebar_top' as const };
+
+  it('non-moderator: rejected before the mutation runs (no-widening)', async () => {
+    // moderatorProcedure also gates on isModerator; either gate refusing is
+    // acceptable — the invariant is that a non-mod cannot reach the mutation.
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.installOnModel(installInput)).rejects.toBeInstanceOf(TRPCError);
+    expect(mockInstallOnModel).not.toHaveBeenCalled();
+  });
+
+  it('anonymous: rejected', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.installOnModel(installInput)).rejects.toBeInstanceOf(TRPCError);
+    expect(mockInstallOnModel).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -60,8 +60,12 @@ const APP_ROW_LIMIT = 1_000_000;
 
 const STORAGE_LOG = 'app-storage-trpc';
 
-const enforceAppBlocksFlag = middleware(async ({ next, type }) => {
-  if (await isAppBlocksEnabled()) return next();
+// H2: evaluated with the request user's context (`ctx.user`) so the live
+// `moderators`-segmented Flipt flag resolves ON for a moderator and OFF for a
+// non-mod / anon caller — same eval the client gate uses. `ctx.user` is the
+// server-side session user, so `isModerator` can't be spoofed by the client.
+const enforceAppBlocksFlag = middleware(async ({ ctx, next, type }) => {
+  if (await isAppBlocksEnabled({ user: ctx.user })) return next();
   // Mutations + queries both refuse when the flag is dark — anything else
   // gives the block a misleading-success path. The block already gates
   // its own UI on host signals, so a clean UNAUTHORIZED is fine.

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -66,9 +66,14 @@ import type { SessionUser } from 'next-auth';
  *
  * The check runs first thing so a flag flip can shut the substrate down
  * without redeploying.
+ *
+ * H2: evaluated with the request user's context (`ctx.user`) so the live
+ * `moderators`-segmented Flipt flag resolves ON for a moderator and OFF for a
+ * non-mod / anon caller — same eval the client gate uses. `ctx.user` is the
+ * server-side session user, so `isModerator` can't be spoofed by the client.
  */
-const enforceAppBlocksFlag = middleware(async ({ next, type }) => {
-  if (await isAppBlocksEnabled()) return next();
+const enforceAppBlocksFlag = middleware(async ({ ctx, next, type }) => {
+  if (await isAppBlocksEnabled({ user: ctx.user })) return next();
   if (type === 'query') {
     // listForModel and friends — return empty rather than throw, so callers
     // that always render the slot don't surface an error.

--- a/src/server/services/__tests__/app-blocks-flag.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionUser } from 'next-auth';
+
+/**
+ * H2 — server/client flag-gate divergence.
+ *
+ * The live Flipt flag `app-blocks-enabled` is base `enabled: false` with a
+ * `moderators` segment that matches `isModerator == "true"`. These tests pin
+ * the contract that `isAppBlocksEnabled`:
+ *   - threads the request user's context into the Flipt eval, so a MODERATOR
+ *     resolves ON (the mod canary works server-side);
+ *   - keeps a NON-MODERATOR and an ANONYMOUS caller OFF (the no-widening
+ *     security invariant);
+ *   - preserves the original GLOBAL (no-context) eval for the no-arg machine /
+ *     anonymous gates (webhooks, JWKS) — they MUST NOT silently start passing.
+ *
+ * `isFlipt` is mocked with a faithful re-implementation of how the real flag
+ * evaluates so the assertions mirror production wiring rather than the gate's
+ * own branches. `buildFliptContext` is the REAL function (the same one the
+ * client gate uses) — that shared context builder is the anti-drift mechanism.
+ */
+
+const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
+
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: mockIsFlipt,
+}));
+
+import { isAppBlocksEnabled } from '../app-blocks-flag';
+
+// Faithful stand-in for the live `app-blocks-enabled` rule: base OFF, with a
+// `moderators` segment keyed on `context.isModerator === 'true'`. The no-arg
+// global eval (entityId='global', empty context) can never match the segment →
+// false, exactly as in prod.
+function fakeAppBlocksFlag(
+  flag: string,
+  _entityId = 'global',
+  context: Record<string, string> = {}
+): boolean {
+  if (flag !== 'app-blocks-enabled') return false;
+  // moderators segment match
+  return context.isModerator === 'true';
+}
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+  return { id: 123, username: 'u', isModerator: false, tier: 'free', ...over } as SessionUser;
+}
+
+beforeEach(() => {
+  mockIsFlipt.mockReset();
+  mockIsFlipt.mockImplementation(async (...args: Parameters<typeof fakeAppBlocksFlag>) =>
+    fakeAppBlocksFlag(...args)
+  );
+});
+
+describe('isAppBlocksEnabled — per-user gate (H2)', () => {
+  it('resolves ON for a moderator (mod canary works server-side)', async () => {
+    const user = makeUser({ isModerator: true });
+    await expect(isAppBlocksEnabled({ user })).resolves.toBe(true);
+
+    // Threaded the user's id as entityId + the mod context — same shape the
+    // client gate uses.
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      '123',
+      expect.objectContaining({ isModerator: 'true', userId: '123', isLoggedIn: 'true' })
+    );
+  });
+
+  it('resolves OFF for a non-moderator (no-widening invariant)', async () => {
+    const user = makeUser({ isModerator: false });
+    await expect(isAppBlocksEnabled({ user })).resolves.toBe(false);
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      '123',
+      expect.objectContaining({ isModerator: 'false' })
+    );
+  });
+
+  it('resolves OFF for an anonymous caller (no user → global eval, no segment match)', async () => {
+    await expect(isAppBlocksEnabled({ user: undefined })).resolves.toBe(false);
+    await expect(isAppBlocksEnabled()).resolves.toBe(false);
+  });
+
+  it('uses the SERVER-side isModerator, ignoring a client-spoofed value on the user object', async () => {
+    // A non-mod session user cannot become a mod by carrying extra props — the
+    // gate only reads `user.isModerator`. (Defense: the SessionUser is built
+    // server-side; this asserts the gate never trusts anything but that field.)
+    const user = makeUser({ isModerator: false });
+    // even if a caller tried to smuggle an isModerator-ish field, only the real
+    // SessionUser.isModerator drives buildFliptContext.
+    (user as unknown as Record<string, unknown>).is_moderator = 'true';
+    await expect(isAppBlocksEnabled({ user })).resolves.toBe(false);
+  });
+});
+
+describe('isAppBlocksEnabled — machine/anonymous gates stay global (H2 scope)', () => {
+  it('no-arg call performs the GLOBAL eval (entityId default, empty context)', async () => {
+    await isAppBlocksEnabled();
+    expect(mockIsFlipt).toHaveBeenCalledTimes(1);
+    // Called with only the flag key — entityId + context fall back to the
+    // client.ts defaults ('global', {}).
+    expect(mockIsFlipt).toHaveBeenCalledWith('app-blocks-enabled');
+  });
+
+  it('a globally-enabled flag turns the no-arg gate ON (pipeline global enable path)', async () => {
+    // Simulate a future GLOBAL enable: isFlipt returns true regardless of context.
+    mockIsFlipt.mockImplementation(async () => true);
+    await expect(isAppBlocksEnabled()).resolves.toBe(true);
+  });
+});

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -1,4 +1,6 @@
+import type { SessionUser } from 'next-auth';
 import { isFlipt } from '~/server/flipt/client';
+import { buildFliptContext } from '~/server/services/feature-flags.service';
 
 const APP_BLOCKS_FLAG = 'app-blocks-enabled';
 
@@ -16,9 +18,49 @@ const APP_BLOCKS_FLAG = 'app-blocks-enabled';
  *     (falls through to legacy auth path, never validates the token).
  *   - Mutations on the blocks router return UNAUTHORIZED.
  *
- * The Flipt key is the canonical name; the FLAG_OVERRIDE env exists for unit
- * tests that need to flip the flag without standing up Flipt.
+ * ## Per-user vs. global evaluation (H2)
+ *
+ * The live Flipt flag is base `enabled: false` with a `moderators` segment
+ * (`isModerator == "true"`). To resolve `true` for a moderator, the eval MUST
+ * carry that user's context — otherwise the segment can never match and the
+ * flag is off for everyone, including mods.
+ *
+ * - **User-facing gates** (the tRPC `enforceAppBlocksFlag` middleware, the
+ *   mod-only `submit-version` upload) have the request's SessionUser, so they
+ *   pass `{ user }` here. The flag is then evaluated with the SAME entityId +
+ *   context the client gate (`getFeatureFlags`/`buildFliptContext`) uses, so
+ *   client and server can't diverge: a mod gets the feature server-side too,
+ *   while a non-mod / anon user still resolves `false` (the no-widening
+ *   invariant — the segment only matches `isModerator == "true"`, and we use
+ *   the SERVER-side `user.isModerator`, never a client-supplied value).
+ *
+ * - **Machine-to-machine / anonymous gates have NO user** and genuinely cannot
+ *   evaluate a mod-segmented flag. The internal webhooks (`build-callback`,
+ *   `git-push`, `workflow-completed`, the JOB_TOKEN-authed manifest registrar)
+ *   and the JWKS public-key endpoint call this with no argument → the original
+ *   GLOBAL eval (`entityId='global'`, empty context). They are deliberately
+ *   left on the global path: the build/publish PIPELINE therefore still
+ *   requires a GLOBAL enable of `app-blocks-enabled` to run. That is an
+ *   intentional, separate decision — a future dedicated
+ *   `app-blocks-pipeline-enabled` global flag should own the pipeline so the
+ *   mod-segmented user flag and the machine pipeline flag can move
+ *   independently. Until then, do NOT fabricate user context for the machine
+ *   gates (the no-arg overload below preserves their existing behaviour).
+ *
+ * The FLAG_OVERRIDE/local-overrides env exists for unit tests + local dev that
+ * need to flip the flag without standing up Flipt.
  */
-export async function isAppBlocksEnabled(): Promise<boolean> {
-  return isFlipt(APP_BLOCKS_FLAG);
+export async function isAppBlocksEnabled(opts?: { user?: SessionUser }): Promise<boolean> {
+  // No user supplied → preserve the original global eval for the machine /
+  // anonymous gates (webhooks, JWKS). Their callers are unchanged.
+  if (!opts?.user) {
+    return isFlipt(APP_BLOCKS_FLAG);
+  }
+
+  // Per-user eval: reuse the client gate's context builder so the two gates
+  // share one context shape and can't drift. entityId is the user id (matching
+  // `getFeatureFlags`'s `hasFeature` Flipt call); context carries the
+  // server-side `isModerator` that the `moderators` segment keys on.
+  const user = opts.user;
+  return isFlipt(APP_BLOCKS_FLAG, String(user.id), buildFliptContext(user));
 }

--- a/src/tests/api/v1/block-tokens/index.test.ts
+++ b/src/tests/api/v1/block-tokens/index.test.ts
@@ -209,18 +209,45 @@ describe('POST /api/v1/block-tokens', () => {
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
-  it('H-2: returns 503 when the appBlocks flag is off', async () => {
-    const flagMod = await import('~/server/services/app-blocks-flag');
-    (flagMod.isAppBlocksEnabled as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      false
-    );
+  it('H2: refused (403) when appBlocks is unavailable to the caller — the PER-USER gate is authoritative', async () => {
+    // H2 fix: the route's App Blocks gate is now the per-user
+    // `getFeatureFlags({ user }).appBlocks` check, NOT a global
+    // `isAppBlocksEnabled()` pre-check (which 503'd everyone, incl. mods, because
+    // the global eval can't match the `moderators` segment). A caller for whom
+    // appBlocks is unavailable (here: anon / non-mod via the mock) is refused
+    // with 403 before any resolve/sign — and the now-removed global pre-check is
+    // not consulted.
+    const flagMod = await import('~/server/services/feature-flags.service');
+    (flagMod.getFeatureFlags as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      appBlocks: false,
+    });
     const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
     const req = makeReq({ origin: 'https://civitai.com', body: validBody() });
     const res = makeRes();
     await handler(req, res);
-    expect(res._status).toBe(503);
+    expect(res._status).toBe(403);
     expect(mockTokenService.sign).not.toHaveBeenCalled();
     expect(mockBlockRegistry.resolveBlockInstance).not.toHaveBeenCalled();
+  });
+
+  it('H2: a MODERATOR is granted the feature server-side (per-user gate ON) — mod canary works', async () => {
+    // The crux of the H2 fix: with the mod-segmented flag, a moderator must be
+    // able to mint server-side. getFeatureFlags resolves appBlocks:true for a
+    // mod (the mock mirrors the live flag). The handler then proceeds past the
+    // gate (it may still fail downstream on resolveBlockInstance, but it must
+    // NOT 403/503 at the flag gate).
+    mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const req = makeReq({ origin: 'https://civitai.com', body: validBody() });
+    const res = makeRes();
+    await handler(req, res);
+    // Not refused at the flag gate (403 'not available' / 503 'not enabled').
+    expect(res._status).not.toBe(503);
+    if (res._status === 403) {
+      expect((res._body as { error: string }).error).not.toMatch(/not available/i);
+    }
+    // The per-user gate let it through to the resolve step.
+    expect(mockBlockRegistry.resolveBlockInstance).toHaveBeenCalled();
   });
 
   it('H1: rejects cross-origin requests via exact-host match (no startsWith bypass)', async () => {


### PR DESCRIPTION
## Problem (H2 — server/client flag-gate divergence)

The Flipt flag `app-blocks-enabled` is base `enabled: false` with a `moderators` segment (matches `isModerator == "true"`).

- The **client** gate `getFeatureFlags({ user, req })` passes the user's context → the segment matches for a moderator → `appBlocks = true` → `BlockSlot` mounts.
- The **user-facing server gates** called `isAppBlocksEnabled()` → `isFlipt('app-blocks-enabled')` with the DEFAULT `entityId='global'` and EMPTY context → the `moderators` segment can never match → `false` for **everyone, including moderators**.

Net: App Blocks was fully OFF server-side even for mods. A mod's slot mounted, then every token mint 503'd, `listForModel` returned `[]`, and mutations were UNAUTHORIZED — there was no way to run the intended mod canary on `main` short of a global enable (the H1 risk). See `docs/features/app-blocks-merge-audit-2026-06.md` (H2).

## What changed

Thread the request user's context into the **user-facing** server gates so they evaluate the SAME `(entityId, context)` the client gate uses, reusing `buildFliptContext` — the shared builder is the anti-drift mechanism (the drift IS this bug).

- **`isAppBlocksEnabled(opts?: { user?: SessionUser })`** — with a user it evaluates `isFlipt(flag, String(user.id), buildFliptContext(user))`; **no-arg behaviour (global eval) is unchanged** so the machine/anon callers are untouched (optional param, no caller breakage).
- **`enforceAppBlocksFlag`** in both `blocks.router.ts` and `apps.router.ts` → pass `ctx.user`.
- **`submit-version.ts`** → pass the `ModEndpoint`-authenticated mod `user`.
- **`block-tokens/index.ts` (mint)** → removed the redundant global pre-session 503 pre-check. The per-user `getFeatureFlags({ user }).appBlocks` gate that already existed later in the handler is now authoritative: a mod passes, a non-mod/anon caller is refused with 403 (before any DB read; the cheap per-IP rate limit still runs first).

### Call sites switched to per-user context
| Call site | Why |
|---|---|
| `blocks.router.ts` `enforceAppBlocksFlag` | tRPC middleware; `ctx.user` available |
| `apps.router.ts` `enforceAppBlocksFlag` | tRPC middleware; `ctx.user` available |
| `pages/api/blocks/submit-version.ts` | `ModEndpoint` supplies the authenticated mod `user` |
| `pages/api/v1/block-tokens/index.ts` (mint) | removed redundant global pre-check; per-user `getFeatureFlags` gate is authoritative |

### Call sites deliberately LEFT on the global eval (conservative)
These have **no user** and genuinely cannot evaluate a mod-segmented flag — fabricating user context would be wrong:
| Call site | Why |
|---|---|
| `internal/blocks/build-callback.ts` | machine webhook (HMAC) |
| `internal/blocks/git-push.ts` | machine webhook (HMAC) |
| `internal/blocks/workflow-completed.ts` | machine webhook (HMAC) |
| `v1/developer/block-manifests.ts` | `JOB_TOKEN`-authed internal job, no user |
| `v1/block-tokens/jwks.ts` | public key surface, no user |
| `middleware/block-scope.middleware.ts` `withBlockScope` | block-JWT runtime; machine-ish — left untouched per audit guidance (see uncertainty below) |

**Documented decision (follow-up):** because the machine gates stay on the global eval, the **build/publish PIPELINE still requires a GLOBAL enable** of `app-blocks-enabled` to run. That is intentional and separate from the user-facing mod canary. A future dedicated **`app-blocks-pipeline-enabled` global flag** should own the pipeline so the mod-segmented user flag and the machine pipeline flag can move independently. This is documented in a code comment in `src/server/services/app-blocks-flag.ts`. No pipeline-flag design is guessed at here.

## No-widening invariant (security-critical) + how it's tested

The gate reads the **server-side `ctx.user.isModerator`** (the `SessionUser` is built server-side), never a client-supplied value. A non-mod or anonymous request still resolves `false`.

Tests (`npx vitest run`, all green):
- `src/server/services/__tests__/app-blocks-flag.test.ts` — mocks `isFlipt` to mirror the live mod-segmented flag (segment matches only `isModerator === 'true'`) and uses the REAL `buildFliptContext`:
  - moderator → ON (and the threaded entityId/context are asserted);
  - non-mod → OFF; anonymous (no user) → OFF;
  - a client-smuggled field on the user object does NOT widen (only `SessionUser.isModerator` drives the context);
  - no-arg call performs the GLOBAL eval (machine gate behaviour unchanged); a global enable turns the no-arg gate ON (pipeline path).
- `src/server/routers/__tests__/blocks.router.flag-gate.test.ts` — drives the real blocks router so the middleware's `{ user: ctx.user }` wiring decides: mod → `listForModel` consults the registry; non-mod/anon → `[]` and the registry is NOT consulted; `installOnModel` (mutation) rejected for non-mod/anon.
- `src/tests/api/v1/block-tokens/index.test.ts` — updated the former "503 global" assertion to the new per-user gate: an unavailable caller → 403 (no sign/resolve); added a moderator case proving the mint path is granted server-side (mod canary works).

Full run: **142 passed** across the 8 blocks-related suites (existing + new).

## Notes / for a human to confirm
- **`withBlockScope`** (block-JWT runtime middleware): left on the global eval. It runs at the edge before the JWT is verified and is machine-ish (no `ctx.user`); per the audit guidance I biased to NOT touching it. If mod dogfooding of *installed* blocks needs the per-user path (using the verified-JWT subject), that's a deliberate follow-up — flagging for confirmation.
- **Pipeline gate**: the build/publish pipeline staying on the global flag is the documented conservative choice (a dedicated `app-blocks-pipeline-enabled` flag is the future fix). Confirm this is the intended interim behaviour.
- CI will run the full typecheck (the PR worktree has a stale Prisma client / no node_modules, so a local full typecheck is unreliable — tests were run via a temporary `node_modules` symlink, removed before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
