### PR TITLE
fix(app-blocks): HMAC replay protection — ts tolerance + callback pending-run cross-check + delivery nonce (W11 F5)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -430,6 +430,13 @@ export const serverSchema = z.object({
   APPS_TEKTON_TRIGGER_SECRET: z.string().optional(),
   APPS_KUBE_NAMESPACE: z.string().default('civitai-apps'),
   APPS_DOMAIN: z.string().default('civit.ai'),
+  // App Blocks F5 (build-callback replay protection). When 'true' the
+  // build-callback handler REJECTS a callback whose pending-run marker is
+  // missing (the consume-once cross-check written by triggerBuild). Default
+  // (unset / not 'true') is report-only: a missing marker logs a warning and
+  // the callback continues, so the first deploy can roll without the
+  // datapacket-talos callback-task signer's `ts`/marker counterpart in place.
+  BLOCK_CALLBACK_REQUIRE_PENDING_RUN: z.string().optional(),
 
   // App Blocks W1 (publish-request flow). S3-compatible storage for
   // dev-uploaded ZIP bundles. Production points at ssd-minio-backups

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -4,8 +4,13 @@ import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
+import { sysRedis } from '~/server/redis/client';
 import { setCommitStatus } from '~/server/services/blocks/forgejo.service';
-import { triggerApply, waitForApplyJob } from '~/server/services/blocks/apps-pipeline.service';
+import {
+  callbackPendingRedisKey,
+  triggerApply,
+  waitForApplyJob,
+} from '~/server/services/blocks/apps-pipeline.service';
 
 /**
  * POST /api/internal/blocks/build-callback
@@ -48,7 +53,76 @@ type CallbackBody = {
   appBlockId?: string;
   imageRef?: string;
   status?: string; // "Succeeded" / "Failed" / "Cancelled" / ... per Tekton
+  // F5 — integer unix-second timestamp the SIGNER (datapacket-talos callback
+  // task) stamps into the body before HMAC. Validated for skew here. ABSENT is
+  // allowed (rollout tolerance — the signer adds it in its own PR).
+  ts?: unknown;
 };
+
+// F5 — allowed clock skew between the callback signer and this receiver, in
+// seconds. A replayed callback carries its original (now-stale) `ts` inside the
+// signed body, so it fails this window. 5 minutes mirrors the trigger leg.
+const TS_TOLERANCE_SECONDS = 300;
+
+/**
+ * Replay-tolerance decision for the (verified) callback `ts` (F5).
+ *   - absent → allow (rollout tolerance: the datapacket-talos callback-task
+ *     signer adds `ts` in its own PR; enforce-if-present avoids a
+ *     deploy-ordering outage).
+ *   - present + within ±TS_TOLERANCE_SECONDS of now → allow.
+ *   - present + a non-finite / out-of-tolerance value → reject.
+ * Pure + exported so the skew window is unit-tested without driving the handler.
+ */
+export function checkCallbackTimestamp(
+  ts: unknown,
+  nowSec: number = Math.floor(Date.now() / 1000)
+): { ok: true } | { ok: false; reason: string } {
+  if (ts === undefined || ts === null) return { ok: true }; // enforce-if-present
+  if (typeof ts !== 'number' || !Number.isFinite(ts)) {
+    return { ok: false, reason: 'ts present but not a finite number' };
+  }
+  if (Math.abs(nowSec - ts) > TS_TOLERANCE_SECONDS) {
+    return { ok: false, reason: `ts skew ${Math.abs(nowSec - ts)}s exceeds ${TS_TOLERANCE_SECONDS}s` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Consume the build-callback pending-run marker (F5 cross-check). GETDELs the
+ * `system:blocks:callback:pending:<slug>:<sha>:<appBlockId>` key written by
+ * triggerBuild — consume-once, so a replayed callback finds it already gone.
+ *
+ * Returns:
+ *   - 'consumed' — the marker existed and was deleted (genuine outstanding run).
+ *   - 'missing'  — no marker (replay, out-of-band callback, or a Redis blip on
+ *     the trigger side that never wrote it).
+ *   - 'unavailable' — Redis itself errored; the caller must NOT fail a legit
+ *     deploy on a Redis blip, so this is treated as "not enforced".
+ */
+export async function consumePendingRun(
+  slug: string,
+  sha: string,
+  appBlockId: string
+): Promise<'consumed' | 'missing' | 'unavailable'> {
+  const key = callbackPendingRedisKey(slug, sha, appBlockId);
+  try {
+    // GETDEL is atomic consume-once. The typed client wrapper doesn't expose
+    // getDel; call the underlying node-redis command (key shape is validated by
+    // callbackPendingRedisKey above).
+    const prior = await (sysRedis as unknown as {
+      getDel: (k: string) => Promise<string | null>;
+    }).getDel(key);
+    return prior == null ? 'missing' : 'consumed';
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[build-callback] pending-run GETDEL failed for ${slug}@${sha.slice(0, 8)} — treating as not-enforced: ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
+    return 'unavailable';
+  }
+}
 
 function safeEqualHex(a: string, b: string): boolean {
   const A = Buffer.from(a, 'hex');
@@ -141,6 +215,45 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   if (!body.imageRef || body.imageRef !== expectedImageRef(body.slug, body.sha)) {
     res.status(400).json({ error: 'imageRef does not match slug/sha' });
     return;
+  }
+
+  // F5 — replay tolerance on the (now HMAC-verified) `ts`. The signer stamps
+  // `ts` inside the signed body, so a replay carries its original stale value
+  // and is rejected here; an absent `ts` is allowed for rollout (the
+  // datapacket-talos callback-task signer adds it in its own PR).
+  const tsCheck = checkCallbackTimestamp(body.ts);
+  if (!tsCheck.ok) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[build-callback] rejecting replayed/stale callback for ${body.slug}@${body.sha.slice(
+        0,
+        8
+      )}: ${tsCheck.reason}`
+    );
+    res.status(401).json({ error: 'Stale or invalid timestamp' });
+    return;
+  }
+
+  // F5 — consume-once pending-run cross-check. triggerBuild records an
+  // outstanding (slug, sha, appBlockId) marker; GETDEL it here. This is the
+  // real replay teeth for the public-edge callback leg (a replay finds the
+  // marker already consumed/expired). Behavior on MISSING is gated:
+  //   - BLOCK_CALLBACK_REQUIRE_PENDING_RUN === 'true' → reject (409).
+  //   - default → log + CONTINUE (report-only first deploy).
+  // A Redis error ('unavailable') is never allowed to break a legit deploy.
+  const pending = await consumePendingRun(body.slug, body.sha, body.appBlockId);
+  if (pending === 'missing') {
+    const enforce = env.BLOCK_CALLBACK_REQUIRE_PENDING_RUN === 'true';
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[build-callback] no pending-run marker for ${body.slug}@${body.sha.slice(0, 8)} (${
+        body.appBlockId
+      }) — ${enforce ? 'REJECTING (enforce on)' : 'continuing (report-only)'}`
+    );
+    if (enforce) {
+      res.status(409).json({ error: 'No outstanding build run for this callback' });
+      return;
+    }
   }
 
   const succeeded = (body.status ?? '').toLowerCase() === 'succeeded';

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -264,240 +264,263 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  let payload: ForgejoPushPayload;
+  // F5-A (robust, future-proof): once the nonce is CLAIMED ('first'), ANY throw
+  // before we respond — the dbWrite.appBlock.update, triggerBuild, or any future
+  // un-awaited error — would otherwise return a 500 with the nonce still held,
+  // so Forgejo's same-X-Gitea-Delivery retry is swallowed as a "duplicate" and
+  // the build is permanently lost. Wrap the whole remaining handler body so a
+  // throw releases the nonce before propagating to withAxiom's 500. This
+  // replaces the brittle per-path releaseDeliveryNonce-on-throw approach that
+  // already missed the DB-update path once. The explicit releases that remain
+  // below are on transient EARLY-RETURN (non-throwing) 4xx paths so their
+  // redelivery can succeed; SUCCESS / duplicate-skip / non-main-ref deliberately
+  // KEEP the nonce.
   try {
-    payload = JSON.parse(rawBody.toString('utf8')) as ForgejoPushPayload;
-  } catch {
-    // Genuine failure response (4xx) — release the nonce so a Forgejo retry of
-    // the same delivery id is allowed (F5-A).
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'Invalid JSON' });
-    return;
-  }
-  if (payload.ref !== 'refs/heads/main') {
-    // Terminal legit-skip 200 — Forgejo will NOT retry this; KEEP the nonce.
-    res.status(200).json({ skipped: 'non-main branch', ref: payload.ref });
-    return;
-  }
+    let payload: ForgejoPushPayload;
+    try {
+      payload = JSON.parse(rawBody.toString('utf8')) as ForgejoPushPayload;
+    } catch {
+      // Genuine failure response (4xx) — release the nonce so a Forgejo retry of
+      // the same delivery id is allowed (F5-A).
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'Invalid JSON' });
+      return;
+    }
+    if (payload.ref !== 'refs/heads/main') {
+      // Terminal legit-skip 200 — Forgejo will NOT retry this; KEEP the nonce.
+      res.status(200).json({ skipped: 'non-main branch', ref: payload.ref });
+      return;
+    }
 
-  // Verify the push came from the canonical build-trigger org and derive the
-  // slug from `repository.full_name` (`<org>/<slug>`) so org + slug are
-  // validated together — don't trust `repository.name` alone (M-WEBHOOK).
-  const expectedRepo = parseExpectedRepo(payload.repository?.full_name, FORGEJO_ORG);
-  if (!expectedRepo) {
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(403).json({
-      error: 'Unexpected or missing repository org',
-      fullName: payload.repository?.full_name ?? null,
+    // Verify the push came from the canonical build-trigger org and derive the
+    // slug from `repository.full_name` (`<org>/<slug>`) so org + slug are
+    // validated together — don't trust `repository.name` alone (M-WEBHOOK).
+    const expectedRepo = parseExpectedRepo(payload.repository?.full_name, FORGEJO_ORG);
+    if (!expectedRepo) {
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(403).json({
+        error: 'Unexpected or missing repository org',
+        fullName: payload.repository?.full_name ?? null,
+      });
+      return;
+    }
+    const slug = expectedRepo.slug;
+    const sha = payload.after;
+    if (!slug || !SLUG_RE.test(slug)) {
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'Invalid repo slug', slug });
+      return;
+    }
+    if (!sha || sha.length < 40) {
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'Invalid commit sha' });
+      return;
+    }
+
+    // Look up the app_blocks row by (appId, blockId). Under W1 the row is
+    // pre-created in `approveRequest` before this webhook fires; if it's
+    // missing the Forgejo commit raced ahead of the approve flow's DB
+    // insert, so bail with 404 and the mod can re-approve.
+    const appBlock = await dbRead.appBlock.findFirst({
+      where: { blockId: slug },
+      select: {
+        id: true,
+        appId: true,
+        blockId: true,
+        app: { select: { id: true, allowedScopes: true, allowedOrigins: true } },
+      },
     });
-    return;
-  }
-  const slug = expectedRepo.slug;
-  const sha = payload.after;
-  if (!slug || !SLUG_RE.test(slug)) {
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'Invalid repo slug', slug });
-    return;
-  }
-  if (!sha || sha.length < 40) {
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'Invalid commit sha' });
-    return;
-  }
+    if (!appBlock) {
+      // The Forgejo commit raced ahead of the approve flow's DB insert — this is
+      // genuinely retryable once the row lands, so release the nonce (F5-A).
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(404).json({ error: 'app_blocks row not found — re-run submitApp' });
+      return;
+    }
 
-  // Look up the app_blocks row by (appId, blockId). Under W1 the row is
-  // pre-created in `approveRequest` before this webhook fires; if it's
-  // missing the Forgejo commit raced ahead of the approve flow's DB
-  // insert, so bail with 404 and the mod can re-approve.
-  const appBlock = await dbRead.appBlock.findFirst({
-    where: { blockId: slug },
-    select: {
-      id: true,
-      appId: true,
-      blockId: true,
-      app: { select: { id: true, allowedScopes: true, allowedOrigins: true } },
-    },
-  });
-  if (!appBlock) {
-    // The Forgejo commit raced ahead of the approve flow's DB insert — this is
-    // genuinely retryable once the row lands, so release the nonce (F5-A).
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(404).json({ error: 'app_blocks row not found — re-run submitApp' });
-    return;
-  }
+    // Fetch the manifest at the new commit.
+    let manifestRaw: string;
+    try {
+      manifestRaw = await getRawFile({
+        slug,
+        ref: sha,
+        path: 'block.manifest.json',
+      });
+    } catch (e) {
+      await setCommitStatusSafe({
+        slug,
+        sha,
+        state: 'failure',
+        context: 'civitai/manifest-validation',
+        description: 'block.manifest.json missing or unreachable',
+      });
+      notifyModsOfWebhookFailure({
+        slug,
+        sha,
+        stage: 'fetch-manifest',
+        details: `block.manifest.json missing or unreachable: ${String(e).slice(0, 200)}`,
+      });
+      // Forgejo unreachable / transient fetch failure is the canonical F5-A case —
+      // release the nonce so the redelivery can re-fetch.
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'Cannot fetch manifest', detail: String(e).slice(0, 240) });
+      return;
+    }
 
-  // Fetch the manifest at the new commit.
-  let manifestRaw: string;
-  try {
-    manifestRaw = await getRawFile({
-      slug,
-      ref: sha,
-      path: 'block.manifest.json',
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(manifestRaw);
+    } catch {
+      await setCommitStatusSafe({
+        slug,
+        sha,
+        state: 'failure',
+        context: 'civitai/manifest-validation',
+        description: 'block.manifest.json is not valid JSON',
+      });
+      notifyModsOfWebhookFailure({
+        slug,
+        sha,
+        stage: 'parse-manifest',
+        details: 'block.manifest.json is not valid JSON',
+      });
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'Invalid manifest JSON' });
+      return;
+    }
+
+    const appContext: AppContext = {
+      allowedScopes: appBlock.app.allowedScopes ?? 0,
+      allowedOrigins: (appBlock.app.allowedOrigins ?? []).map((o: string) => o.toLowerCase()),
+    };
+    const validation = BlockManifestValidator.validate(manifest, appContext);
+    if (!validation.valid) {
+      await setCommitStatusSafe({
+        slug,
+        sha,
+        state: 'failure',
+        context: 'civitai/manifest-validation',
+        description: validation.errors.slice(0, 3).join('; '),
+      });
+      notifyModsOfWebhookFailure({
+        slug,
+        sha,
+        stage: 'manifest-validation',
+        details: validation.errors.slice(0, 5).join('; '),
+      });
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'Invalid manifest', details: validation.errors });
+      return;
+    }
+
+    // Cross-check the manifest blockId matches the repo slug — guards a
+    // typo where the developer renames the repo without updating the
+    // manifest (or vice-versa).
+    const parsedManifest = manifest as { blockId?: string; iframe?: { src?: string } };
+    if (parsedManifest.blockId !== slug) {
+      await setCommitStatusSafe({
+        slug,
+        sha,
+        state: 'failure',
+        context: 'civitai/manifest-validation',
+        description: `blockId in manifest (${parsedManifest.blockId}) must equal repo slug (${slug})`,
+      });
+      notifyModsOfWebhookFailure({
+        slug,
+        sha,
+        stage: 'blockId-slug-mismatch',
+        details: `manifest.blockId="${parsedManifest.blockId}" but repo slug="${slug}"`,
+      });
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'blockId / slug mismatch' });
+      return;
+    }
+
+    // Require canonical iframe.src host — must match <slug>.<APPS_DOMAIN>/
+    const expectedSrc = `https://${slug}.${env.APPS_DOMAIN}/`;
+    if (parsedManifest.iframe?.src !== expectedSrc) {
+      await setCommitStatusSafe({
+        slug,
+        sha,
+        state: 'failure',
+        context: 'civitai/manifest-validation',
+        description: `iframe.src must equal ${expectedSrc}`,
+      });
+      notifyModsOfWebhookFailure({
+        slug,
+        sha,
+        stage: 'iframe-src-mismatch',
+        details: `manifest.iframe.src="${parsedManifest.iframe?.src ?? ''}" but expected "${expectedSrc}"`,
+      });
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(400).json({ error: 'iframe.src mismatch' });
+      return;
+    }
+
+    // Upsert app_blocks with the new manifest + sha. v0 auto-approves on
+    // valid push; v1 (W1 mod review) gates this behind a queue.
+    await dbWrite.appBlock.update({
+      where: { id: appBlock.id },
+      data: {
+        manifest: manifest as object,
+        status: 'approved',
+        // The migration that adds current_version_sha / current_version_deployed_at
+        // / repo_url ships alongside this handler (Phase 4 SQL); these field
+        // names match the @map directives that get added.
+        currentVersionSha: sha,
+        version: (parsedManifest as { version?: string }).version ?? sha.slice(0, 7),
+      },
     });
-  } catch (e) {
+
+    // Pending status on Forgejo while Tekton runs.
     await setCommitStatusSafe({
       slug,
       sha,
-      state: 'failure',
-      context: 'civitai/manifest-validation',
-      description: 'block.manifest.json missing or unreachable',
-    });
-    notifyModsOfWebhookFailure({
-      slug,
-      sha,
-      stage: 'fetch-manifest',
-      details: `block.manifest.json missing or unreachable: ${String(e).slice(0, 200)}`,
-    });
-    // Forgejo unreachable / transient fetch failure is the canonical F5-A case —
-    // release the nonce so the redelivery can re-fetch.
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'Cannot fetch manifest', detail: String(e).slice(0, 240) });
-    return;
-  }
-
-  let manifest: unknown;
-  try {
-    manifest = JSON.parse(manifestRaw);
-  } catch {
-    await setCommitStatusSafe({
-      slug,
-      sha,
-      state: 'failure',
-      context: 'civitai/manifest-validation',
-      description: 'block.manifest.json is not valid JSON',
-    });
-    notifyModsOfWebhookFailure({
-      slug,
-      sha,
-      stage: 'parse-manifest',
-      details: 'block.manifest.json is not valid JSON',
-    });
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'Invalid manifest JSON' });
-    return;
-  }
-
-  const appContext: AppContext = {
-    allowedScopes: appBlock.app.allowedScopes ?? 0,
-    allowedOrigins: (appBlock.app.allowedOrigins ?? []).map((o: string) => o.toLowerCase()),
-  };
-  const validation = BlockManifestValidator.validate(manifest, appContext);
-  if (!validation.valid) {
-    await setCommitStatusSafe({
-      slug,
-      sha,
-      state: 'failure',
-      context: 'civitai/manifest-validation',
-      description: validation.errors.slice(0, 3).join('; '),
-    });
-    notifyModsOfWebhookFailure({
-      slug,
-      sha,
-      stage: 'manifest-validation',
-      details: validation.errors.slice(0, 5).join('; '),
-    });
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'Invalid manifest', details: validation.errors });
-    return;
-  }
-
-  // Cross-check the manifest blockId matches the repo slug — guards a
-  // typo where the developer renames the repo without updating the
-  // manifest (or vice-versa).
-  const parsedManifest = manifest as { blockId?: string; iframe?: { src?: string } };
-  if (parsedManifest.blockId !== slug) {
-    await setCommitStatusSafe({
-      slug,
-      sha,
-      state: 'failure',
-      context: 'civitai/manifest-validation',
-      description: `blockId in manifest (${parsedManifest.blockId}) must equal repo slug (${slug})`,
-    });
-    notifyModsOfWebhookFailure({
-      slug,
-      sha,
-      stage: 'blockId-slug-mismatch',
-      details: `manifest.blockId="${parsedManifest.blockId}" but repo slug="${slug}"`,
-    });
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'blockId / slug mismatch' });
-    return;
-  }
-
-  // Require canonical iframe.src host — must match <slug>.<APPS_DOMAIN>/
-  const expectedSrc = `https://${slug}.${env.APPS_DOMAIN}/`;
-  if (parsedManifest.iframe?.src !== expectedSrc) {
-    await setCommitStatusSafe({
-      slug,
-      sha,
-      state: 'failure',
-      context: 'civitai/manifest-validation',
-      description: `iframe.src must equal ${expectedSrc}`,
-    });
-    notifyModsOfWebhookFailure({
-      slug,
-      sha,
-      stage: 'iframe-src-mismatch',
-      details: `manifest.iframe.src="${parsedManifest.iframe?.src ?? ''}" but expected "${expectedSrc}"`,
-    });
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(400).json({ error: 'iframe.src mismatch' });
-    return;
-  }
-
-  // Upsert app_blocks with the new manifest + sha. v0 auto-approves on
-  // valid push; v1 (W1 mod review) gates this behind a queue.
-  await dbWrite.appBlock.update({
-    where: { id: appBlock.id },
-    data: {
-      manifest: manifest as object,
-      status: 'approved',
-      // The migration that adds current_version_sha / current_version_deployed_at
-      // / repo_url ships alongside this handler (Phase 4 SQL); these field
-      // names match the @map directives that get added.
-      currentVersionSha: sha,
-      version: (parsedManifest as { version?: string }).version ?? sha.slice(0, 7),
-    },
-  });
-
-  // Pending status on Forgejo while Tekton runs.
-  await setCommitStatusSafe({
-    slug,
-    sha,
-    state: 'pending',
-    context: 'civitai/build',
-    description: 'Build queued',
-  });
-
-  // Trigger the cross-cluster Tekton build.
-  try {
-    const callbackUrl = buildCallbackUrl();
-    await triggerBuild({ slug, sha, appBlockId: appBlock.id, callbackUrl });
-  } catch (e) {
-    await setCommitStatusSafe({
-      slug,
-      sha,
-      state: 'failure',
+      state: 'pending',
       context: 'civitai/build',
-      description: `Trigger failed: ${String(e).slice(0, 80)}`,
+      description: 'Build queued',
     });
-    notifyModsOfWebhookFailure({
-      slug,
-      sha,
-      stage: 'trigger-build',
-      details: `triggerBuild() failed: ${String(e).slice(0, 200)}`,
-    });
-    // Headline F5-A case: triggerBuild threw (Tekton receiver down, HMAC drift,
-    // network). The build never started, so Forgejo's redelivery MUST be able to
-    // retry — release the nonce before the 5xx.
-    await releaseDeliveryNonce(deliveryHeader);
-    res.status(500).json({ error: 'Build trigger failed', detail: String(e).slice(0, 240) });
-    return;
-  }
 
-  // SUCCESS — keep the nonce so a duplicate of this *completed* delivery is
-  // deduped (the build is already in flight).
-  res.status(200).json({ ok: true, slug, sha });
+    // Trigger the cross-cluster Tekton build.
+    try {
+      const callbackUrl = buildCallbackUrl();
+      await triggerBuild({ slug, sha, appBlockId: appBlock.id, callbackUrl });
+    } catch (e) {
+      await setCommitStatusSafe({
+        slug,
+        sha,
+        state: 'failure',
+        context: 'civitai/build',
+        description: `Trigger failed: ${String(e).slice(0, 80)}`,
+      });
+      notifyModsOfWebhookFailure({
+        slug,
+        sha,
+        stage: 'trigger-build',
+        details: `triggerBuild() failed: ${String(e).slice(0, 200)}`,
+      });
+      // Headline F5-A case: triggerBuild threw (Tekton receiver down, HMAC drift,
+      // network). The build never started, so Forgejo's redelivery MUST be able to
+      // retry — release the nonce before the 5xx.
+      await releaseDeliveryNonce(deliveryHeader);
+      res.status(500).json({ error: 'Build trigger failed', detail: String(e).slice(0, 240) });
+      return;
+    }
+
+    // SUCCESS — keep the nonce so a duplicate of this *completed* delivery is
+    // deduped (the build is already in flight).
+    res.status(200).json({ ok: true, slug, sha });
+  } catch (err) {
+    // F5-A robustness: any throw after the nonce was claimed — the
+    // dbWrite.appBlock.update (DB blip / pool exhaustion / replica promotion),
+    // or any future un-awaited error between the claim and the success response
+    // — would otherwise leave the nonce held while withAxiom returns a 500,
+    // permanently swallowing Forgejo's same-id retry as a duplicate. Release the
+    // nonce before re-throwing so the retry can re-process. Best-effort release
+    // (swallows its own Redis errors), awaited before the throw propagates.
+    await releaseDeliveryNonce(deliveryHeader);
+    throw err;
+  }
 });
 
 function buildCallbackUrl(): string {

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -138,11 +138,33 @@ const GITPUSH_DELIVERY_TTL_SECONDS = 600;
 const DELIVERY_ID_RE = /^[A-Za-z0-9-]{1,64}$/;
 
 /**
+ * Build the Redis key for a delivery id, or null if the id is absent/malformed.
+ * Shared by checkDeliveryNonce (claim) and releaseDeliveryNonce (release). The
+ * templated return type narrows to the sysRedis key union so .set/.del typecheck.
+ */
+function deliveryNonceKey(
+  deliveryHeader: unknown
+): `${typeof REDIS_SYS_KEYS.BLOCKS.GITPUSH_DELIVERY}:${string}` | null {
+  const id = Array.isArray(deliveryHeader) ? deliveryHeader[0] : deliveryHeader;
+  if (typeof id !== 'string' || !DELIVERY_ID_RE.test(id)) return null;
+  return `${REDIS_SYS_KEYS.BLOCKS.GITPUSH_DELIVERY}:${id}`;
+}
+
+/**
  * Per-delivery dedup for Forgejo push webhooks (F5). SET NX EX on
  * `system:blocks:gitpush:delivery:<id>`: first delivery wins, a redelivery with
  * the same id is a duplicate. Returns 'first' (proceed), 'duplicate' (reject),
  * or 'skip' (header absent, or a Redis error — never block a legit push on a
  * Redis blip).
+ *
+ * F5-A — RETRY SAFETY: the nonce is CLAIMED here BEFORE downstream processing,
+ * but the handler RELEASES it (releaseDeliveryNonce) on every non-2xx response
+ * AFTER the claim, so a transient downstream failure (manifest fetch 400,
+ * triggerBuild 500, DB blip) that Forgejo re-delivers with the SAME id is
+ * retryable rather than permanently swallowed as a "duplicate". The nonce is
+ * KEPT on the success path so a duplicate of a *completed* delivery is still
+ * deduped, and on terminal legit-skip 200s (e.g. non-main ref) which Forgejo
+ * does not retry.
  *
  * HONEST LIMITATION: X-Gitea-Delivery is NOT covered by the body HMAC. This
  * catches naive duplicate re-deliveries but a determined replayer could swap
@@ -154,9 +176,8 @@ const DELIVERY_ID_RE = /^[A-Za-z0-9-]{1,64}$/;
 export async function checkDeliveryNonce(
   deliveryHeader: unknown
 ): Promise<'first' | 'duplicate' | 'skip'> {
-  const id = Array.isArray(deliveryHeader) ? deliveryHeader[0] : deliveryHeader;
-  if (typeof id !== 'string' || !DELIVERY_ID_RE.test(id)) return 'skip';
-  const key = `${REDIS_SYS_KEYS.BLOCKS.GITPUSH_DELIVERY}:${id}` as const;
+  const key = deliveryNonceKey(deliveryHeader);
+  if (key === null) return 'skip';
   try {
     // With NX, node-redis returns 'OK' when the key was set (first delivery)
     // and null when it already existed (duplicate). The typed wrapper narrows
@@ -174,6 +195,28 @@ export async function checkDeliveryNonce(
       }`
     );
     return 'skip';
+  }
+}
+
+/**
+ * F5-A — release a previously-claimed delivery nonce so Forgejo's retry of a
+ * transiently-failed delivery (same X-Gitea-Delivery id) is allowed to process
+ * instead of being swallowed as a duplicate. Best-effort: a Redis error here is
+ * swallowed (the worst case degrades to the pre-fix behavior — the retry is
+ * deduped — never a hard failure of the response path).
+ */
+export async function releaseDeliveryNonce(deliveryHeader: unknown): Promise<void> {
+  const key = deliveryNonceKey(deliveryHeader);
+  if (key === null) return;
+  try {
+    await sysRedis.del(key);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[git-push] delivery-nonce DEL failed — retry of this delivery may be deduped: ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
   }
 }
 
@@ -209,6 +252,11 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // with the handler's existing 200-skipped style). Header absent / Redis blip
   // → proceed (don't break a legit push). See checkDeliveryNonce for the honest
   // limitation: this header is NOT HMAC-covered.
+  //
+  // F5-A — the nonce is CLAIMED here but RELEASED (releaseDeliveryNonce) on every
+  // genuine non-2xx failure path below, so a transient downstream failure that
+  // Forgejo re-delivers with the same id is retryable rather than permanently
+  // swallowed. It is KEPT on success and on terminal legit-skip 200s.
   const deliveryHeader = req.headers['x-gitea-delivery'] ?? req.headers['x-forgejo-delivery'];
   const dedup = await checkDeliveryNonce(deliveryHeader);
   if (dedup === 'duplicate') {
@@ -220,10 +268,14 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   try {
     payload = JSON.parse(rawBody.toString('utf8')) as ForgejoPushPayload;
   } catch {
+    // Genuine failure response (4xx) — release the nonce so a Forgejo retry of
+    // the same delivery id is allowed (F5-A).
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'Invalid JSON' });
     return;
   }
   if (payload.ref !== 'refs/heads/main') {
+    // Terminal legit-skip 200 — Forgejo will NOT retry this; KEEP the nonce.
     res.status(200).json({ skipped: 'non-main branch', ref: payload.ref });
     return;
   }
@@ -233,6 +285,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // validated together — don't trust `repository.name` alone (M-WEBHOOK).
   const expectedRepo = parseExpectedRepo(payload.repository?.full_name, FORGEJO_ORG);
   if (!expectedRepo) {
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(403).json({
       error: 'Unexpected or missing repository org',
       fullName: payload.repository?.full_name ?? null,
@@ -242,10 +295,12 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   const slug = expectedRepo.slug;
   const sha = payload.after;
   if (!slug || !SLUG_RE.test(slug)) {
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'Invalid repo slug', slug });
     return;
   }
   if (!sha || sha.length < 40) {
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'Invalid commit sha' });
     return;
   }
@@ -264,6 +319,9 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     },
   });
   if (!appBlock) {
+    // The Forgejo commit raced ahead of the approve flow's DB insert — this is
+    // genuinely retryable once the row lands, so release the nonce (F5-A).
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(404).json({ error: 'app_blocks row not found — re-run submitApp' });
     return;
   }
@@ -290,6 +348,9 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       stage: 'fetch-manifest',
       details: `block.manifest.json missing or unreachable: ${String(e).slice(0, 200)}`,
     });
+    // Forgejo unreachable / transient fetch failure is the canonical F5-A case —
+    // release the nonce so the redelivery can re-fetch.
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'Cannot fetch manifest', detail: String(e).slice(0, 240) });
     return;
   }
@@ -311,6 +372,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       stage: 'parse-manifest',
       details: 'block.manifest.json is not valid JSON',
     });
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'Invalid manifest JSON' });
     return;
   }
@@ -334,6 +396,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       stage: 'manifest-validation',
       details: validation.errors.slice(0, 5).join('; '),
     });
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'Invalid manifest', details: validation.errors });
     return;
   }
@@ -356,6 +419,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       stage: 'blockId-slug-mismatch',
       details: `manifest.blockId="${parsedManifest.blockId}" but repo slug="${slug}"`,
     });
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'blockId / slug mismatch' });
     return;
   }
@@ -376,6 +440,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       stage: 'iframe-src-mismatch',
       details: `manifest.iframe.src="${parsedManifest.iframe?.src ?? ''}" but expected "${expectedSrc}"`,
     });
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(400).json({ error: 'iframe.src mismatch' });
     return;
   }
@@ -422,10 +487,16 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       stage: 'trigger-build',
       details: `triggerBuild() failed: ${String(e).slice(0, 200)}`,
     });
+    // Headline F5-A case: triggerBuild threw (Tekton receiver down, HMAC drift,
+    // network). The build never started, so Forgejo's redelivery MUST be able to
+    // retry — release the nonce before the 5xx.
+    await releaseDeliveryNonce(deliveryHeader);
     res.status(500).json({ error: 'Build trigger failed', detail: String(e).slice(0, 240) });
     return;
   }
 
+  // SUCCESS — keep the nonce so a duplicate of this *completed* delivery is
+  // deduped (the build is already in flight).
   res.status(200).json({ ok: true, slug, sha });
 });
 

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -5,6 +5,7 @@ import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { isFlipt } from '~/server/flipt/client';
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import {
   BlockManifestValidator,
   type AppContext,
@@ -127,6 +128,55 @@ export function parseExpectedRepo(
   return { slug };
 }
 
+// TTL on the per-delivery dedup nonce. Comfortably longer than any sane Forgejo
+// webhook retry window, short enough not to accumulate keys.
+const GITPUSH_DELIVERY_TTL_SECONDS = 600;
+
+// X-Gitea-Delivery is Forgejo's per-delivery UUID. Bound the value we accept
+// into a Redis key (defensive — never key Redis on an unbounded attacker-
+// influenced header).
+const DELIVERY_ID_RE = /^[A-Za-z0-9-]{1,64}$/;
+
+/**
+ * Per-delivery dedup for Forgejo push webhooks (F5). SET NX EX on
+ * `system:blocks:gitpush:delivery:<id>`: first delivery wins, a redelivery with
+ * the same id is a duplicate. Returns 'first' (proceed), 'duplicate' (reject),
+ * or 'skip' (header absent, or a Redis error — never block a legit push on a
+ * Redis blip).
+ *
+ * HONEST LIMITATION: X-Gitea-Delivery is NOT covered by the body HMAC. This
+ * catches naive duplicate re-deliveries but a determined replayer could swap
+ * the header to a fresh value and bypass it. The strong replay protection is
+ * the two `ts` legs (trigger + callback) + the callback pending-run cross-check;
+ * a git-push replay is downgrade-only — it re-applies the same already-approved
+ * sha and is org/sha-gated (parseExpectedRepo + SLUG_RE + 40-hex sha).
+ */
+export async function checkDeliveryNonce(
+  deliveryHeader: unknown
+): Promise<'first' | 'duplicate' | 'skip'> {
+  const id = Array.isArray(deliveryHeader) ? deliveryHeader[0] : deliveryHeader;
+  if (typeof id !== 'string' || !DELIVERY_ID_RE.test(id)) return 'skip';
+  const key = `${REDIS_SYS_KEYS.BLOCKS.GITPUSH_DELIVERY}:${id}` as const;
+  try {
+    // With NX, node-redis returns 'OK' when the key was set (first delivery)
+    // and null when it already existed (duplicate). The typed wrapper narrows
+    // the return to the value type, so read it back as the raw reply.
+    const result = (await sysRedis.set(key, '1', {
+      NX: true,
+      EX: GITPUSH_DELIVERY_TTL_SECONDS,
+    })) as unknown as string | null;
+    return result === 'OK' ? 'first' : 'duplicate';
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[git-push] delivery-nonce SET NX failed — skipping dedup: ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
+    return 'skip';
+  }
+}
+
 export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
@@ -151,6 +201,18 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   const sig = req.headers['x-gitea-signature'] ?? req.headers['x-forgejo-signature'];
   if (!verifyForgejoSignature(rawBody, sig)) {
     res.status(401).json({ error: 'Bad signature' });
+    return;
+  }
+
+  // F5 — per-delivery dedup nonce (after HMAC so we don't fill Redis from
+  // unauthenticated probes). A duplicate X-Gitea-Delivery → skip (idempotent
+  // with the handler's existing 200-skipped style). Header absent / Redis blip
+  // → proceed (don't break a legit push). See checkDeliveryNonce for the honest
+  // limitation: this header is NOT HMAC-covered.
+  const deliveryHeader = req.headers['x-gitea-delivery'] ?? req.headers['x-forgejo-delivery'];
+  const dedup = await checkDeliveryNonce(deliveryHeader);
+  if (dedup === 'duplicate') {
+    res.status(200).json({ skipped: 'duplicate delivery' });
     return;
   }
 

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -923,6 +923,29 @@ export const REDIS_SYS_KEYS = {
      * on first write so the per-window key self-expires.
      */
     BUZZ_CAP: 'system:blocks:buzz-cap',
+    /**
+     * Build-chain replay protection (audit F5).
+     *
+     * CALLBACK_PENDING — consume-once marker for an outstanding Tekton build.
+     * Written `1` by triggerBuild() right after a successful trigger POST,
+     * keyed `system:blocks:callback:pending:${slug}:${sha}:${appBlockId}` with
+     * an 1800s TTL (> the 20m pipeline timeout). The build-callback handler
+     * GETDELs it (consume-once) once HMAC + ts checks pass: present → genuine
+     * outstanding run; missing → replay / out-of-band callback. This is the
+     * real replay teeth for the public-edge callback leg; enforcement is gated
+     * behind BLOCK_CALLBACK_REQUIRE_PENDING_RUN (report-only first deploy).
+     *
+     * GITPUSH_DELIVERY — per-delivery dedup nonce for Forgejo push webhooks,
+     * keyed `system:blocks:gitpush:delivery:${X-Gitea-Delivery}` via SET NX EX
+     * 600. A second delivery with the same id is rejected as a duplicate. NOTE:
+     * X-Gitea-Delivery is NOT covered by the body HMAC, so this catches naive
+     * duplicate re-deliveries but not a determined header-swapping replayer; the
+     * strong protection is the two `ts` legs + the callback cross-check, and a
+     * git-push replay is downgrade-only (re-applies the same already-approved,
+     * org/sha-gated sha).
+     */
+    CALLBACK_PENDING: 'system:blocks:callback:pending',
+    GITPUSH_DELIVERY: 'system:blocks:gitpush:delivery',
   },
 } as const;
 

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -97,10 +97,16 @@ export type TriggerBuildArgs = {
   callbackUrl: string;
 };
 
-// TTL on the build-callback pending-run marker. Comfortably exceeds the ~20m
-// pipeline timeout so a slow-but-legit build's callback still finds its marker,
-// while a far-future replay finds it expired. See callbackPendingRedisKey.
-const CALLBACK_PENDING_TTL_SECONDS = 1800;
+// TTL on the build-callback pending-run marker (F5-C). The marker is written
+// when triggerBuild POSTs (PipelineRun *created*), so worst-case wall time =
+// queue/PVC-provision latency + the per-run pipeline timeout. That per-run
+// timeout is 20m (datapacket-talos app-blocks-trigger.py PipelineRun spec
+// `timeouts.pipeline: 20m`). The previous 1800s (30m) left only ~10m of headroom
+// for queue/provision — a queued-but-SUCCESSFUL build whose callback arrives
+// after expiry would 409 under enforce. 3600s (1h) gives comfortable margin over
+// (queue + 20m) while still letting a far-future replay find the marker expired.
+// See callbackPendingRedisKey.
+const CALLBACK_PENDING_TTL_SECONDS = 3600;
 
 /**
  * Redis key for the consume-once build-callback pending-run marker (F5).

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -33,6 +33,7 @@
 import { createHmac } from 'crypto';
 import { readFile } from 'node:fs/promises';
 import { env } from '~/env/server';
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 
 // ---------- shared HTTP helpers --------------------------------------------
 
@@ -96,6 +97,26 @@ export type TriggerBuildArgs = {
   callbackUrl: string;
 };
 
+// TTL on the build-callback pending-run marker. Comfortably exceeds the ~20m
+// pipeline timeout so a slow-but-legit build's callback still finds its marker,
+// while a far-future replay finds it expired. See callbackPendingRedisKey.
+const CALLBACK_PENDING_TTL_SECONDS = 1800;
+
+/**
+ * Redis key for the consume-once build-callback pending-run marker (F5).
+ * Written by triggerBuild() after a successful trigger, GETDEL'd by the
+ * build-callback handler. WIRE CONTRACT — the datapacket-talos reviewer + the
+ * callback handler must use the identical
+ * `system:blocks:callback:pending:${slug}:${sha}:${appBlockId}` shape.
+ */
+export function callbackPendingRedisKey(
+  slug: string,
+  sha: string,
+  appBlockId: string
+): `${typeof REDIS_SYS_KEYS.BLOCKS.CALLBACK_PENDING}:${string}` {
+  return `${REDIS_SYS_KEYS.BLOCKS.CALLBACK_PENDING}:${slug}:${sha}:${appBlockId}`;
+}
+
 export async function triggerBuild(args: TriggerBuildArgs): Promise<{ name: string }> {
   const url = env.APPS_TEKTON_TRIGGER_URL;
   const secret = env.APPS_TEKTON_TRIGGER_SECRET;
@@ -103,11 +124,18 @@ export async function triggerBuild(args: TriggerBuildArgs): Promise<{ name: stri
     throw new Error('APPS_TEKTON_TRIGGER_URL / APPS_TEKTON_TRIGGER_SECRET not configured');
   }
 
+  // F5 — replay tolerance. Stamp an integer unix-second `ts` INTO the body
+  // BEFORE signing so the datapacket-talos trigger.py receiver can reject a
+  // captured-and-replayed trigger by skew (|now - ts| > 300). Because `ts` is
+  // inside the signed bytes, a replay carries its original old `ts` and is
+  // caught — an attacker can't bump it without invalidating the HMAC.
+  const ts = Math.floor(Date.now() / 1000);
   const body = JSON.stringify({
     slug: args.slug,
     sha: args.sha,
     appBlockId: args.appBlockId,
     callbackUrl: args.callbackUrl,
+    ts,
   });
   const sig = createHmac('sha256', secret).update(body).digest('hex');
 
@@ -133,6 +161,28 @@ export async function triggerBuild(args: TriggerBuildArgs): Promise<{ name: stri
     // Receiver should always return JSON; if not, surface a clear error.
     throw new Error(`trigger response was not JSON: ${text.slice(0, 240)}`);
   }
+
+  // F5 — record the expected (slug, sha, appBlockId) so the eventual
+  // build-callback can prove it corresponds to an outstanding run (consume-once
+  // cross-check). Fire-and-forget: a Redis blip must NOT fail a legit build
+  // trigger — log + continue. The marker simply won't exist, which (with the
+  // default report-only gate) degrades to a warning on the callback side.
+  try {
+    await sysRedis.set(
+      callbackPendingRedisKey(args.slug, args.sha, args.appBlockId),
+      '1',
+      { EX: CALLBACK_PENDING_TTL_SECONDS }
+    );
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[apps-pipeline] failed to write callback pending-run marker for ${args.slug}@${args.sha.slice(
+        0,
+        8
+      )}: ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+
   return { name: parsed.pipelineRun ?? '' };
 }
 

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -5,9 +5,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // We only exercise the pure expectedImageRef + verifySignature helpers, so stub
 // the db + pipeline deps to keep the import side-effect-free.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+// callbackPendingRedisKey is a pure key builder used by consumePendingRun; the
+// real module pulls in env at import, so stub it with a deterministic key shape.
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   triggerApply: vi.fn(),
   waitForApplyJob: vi.fn(),
+  callbackPendingRedisKey: (slug: string, sha: string, appBlockId: string) =>
+    `system:blocks:callback:pending:${slug}:${sha}:${appBlockId}`,
+}));
+
+// Mockable sysRedis.getDel so the consume-once cross-check can be exercised.
+const mockGetDel = vi.hoisted(() => vi.fn());
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { getDel: mockGetDel },
+  REDIS_SYS_KEYS: { BLOCKS: { CALLBACK_PENDING: 'system:blocks:callback:pending' } },
 }));
 
 // Mutable env mock so each test can set / clear
@@ -18,7 +29,12 @@ vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
 const mockEnv = vi.hoisted(() => ({} as Record<string, string | undefined>));
 vi.mock('~/env/server', () => ({ env: mockEnv }));
 
-import { expectedImageRef, verifySignature } from '~/pages/api/internal/blocks/build-callback';
+import {
+  checkCallbackTimestamp,
+  consumePendingRun,
+  expectedImageRef,
+  verifySignature,
+} from '~/pages/api/internal/blocks/build-callback';
 
 /**
  * L-CALLBACK coverage. The build-callback handler accepts an `imageRef` from
@@ -122,5 +138,84 @@ describe('build-callback verifySignature dual-secret window (F6)', () => {
 
   it('fails closed when no secret is configured (no current, no NEXT)', () => {
     expect(verifySignature(body, sign('anything'))).toBe(false);
+  });
+});
+
+/**
+ * F5 — replay tolerance on the signed `ts`. The datapacket-talos callback-task
+ * signer stamps an integer unix-second `ts` INTO the HMAC-signed body. A replay
+ * carries its original stale `ts` and must be rejected; an absent `ts` must be
+ * allowed (rollout tolerance — enforce-if-present).
+ */
+describe('build-callback checkCallbackTimestamp (F5 ts tolerance)', () => {
+  const NOW = 1_700_000_000; // fixed reference second
+
+  it('accepts a fresh ts within the ±300s window', () => {
+    expect(checkCallbackTimestamp(NOW, NOW).ok).toBe(true);
+    expect(checkCallbackTimestamp(NOW - 299, NOW).ok).toBe(true);
+    expect(checkCallbackTimestamp(NOW + 299, NOW).ok).toBe(true);
+  });
+
+  it('rejects a stale ts (replayed callback) beyond the window', () => {
+    const r = checkCallbackTimestamp(NOW - 3600, NOW);
+    expect(r.ok).toBe(false);
+    const rFuture = checkCallbackTimestamp(NOW + 3600, NOW);
+    expect(rFuture.ok).toBe(false);
+  });
+
+  it('rejects exactly at the boundary + 1 second', () => {
+    expect(checkCallbackTimestamp(NOW - 301, NOW).ok).toBe(false);
+    expect(checkCallbackTimestamp(NOW + 301, NOW).ok).toBe(false);
+  });
+
+  it('ALLOWS an absent ts (rollout tolerance — signer adds it in its own PR)', () => {
+    expect(checkCallbackTimestamp(undefined, NOW).ok).toBe(true);
+    expect(checkCallbackTimestamp(null, NOW).ok).toBe(true);
+  });
+
+  it('rejects a non-finite / non-number ts', () => {
+    expect(checkCallbackTimestamp('1700000000', NOW).ok).toBe(false);
+    expect(checkCallbackTimestamp(Number.NaN, NOW).ok).toBe(false);
+    expect(checkCallbackTimestamp(Infinity, NOW).ok).toBe(false);
+  });
+});
+
+/**
+ * F5 — consume-once pending-run cross-check. triggerBuild records an outstanding
+ * (slug, sha, appBlockId); the callback GETDELs it. Present → consumed (genuine
+ * run). Missing → replay/out-of-band. Redis error → unavailable (never breaks a
+ * legit deploy). The enforce-vs-report-only decision on 'missing' lives in the
+ * handler and is gated by BLOCK_CALLBACK_REQUIRE_PENDING_RUN.
+ */
+describe('build-callback consumePendingRun (F5 cross-check)', () => {
+  const SHA = 'a'.repeat(40);
+  const APB = 'apb_0123456789ABCDEFGHJKMNPQ';
+
+  beforeEach(() => {
+    mockGetDel.mockReset();
+  });
+
+  it('consumes a present marker (genuine outstanding run)', async () => {
+    mockGetDel.mockResolvedValueOnce('1');
+    await expect(consumePendingRun('slug-a', SHA, APB)).resolves.toBe('consumed');
+    expect(mockGetDel).toHaveBeenCalledWith(
+      `system:blocks:callback:pending:slug-a:${SHA}:${APB}`
+    );
+  });
+
+  it('reports missing when the marker is absent (replay / out-of-band)', async () => {
+    mockGetDel.mockResolvedValueOnce(null);
+    await expect(consumePendingRun('slug-a', SHA, APB)).resolves.toBe('missing');
+  });
+
+  it('reports unavailable on a Redis error (never break a legit deploy)', async () => {
+    mockGetDel.mockRejectedValueOnce(new Error('redis down'));
+    await expect(consumePendingRun('slug-a', SHA, APB)).resolves.toBe('unavailable');
+  });
+
+  it('is consume-once: a second GETDEL of the same key returns missing', async () => {
+    mockGetDel.mockResolvedValueOnce('1').mockResolvedValueOnce(null);
+    await expect(consumePendingRun('slug-a', SHA, APB)).resolves.toBe('consumed');
+    await expect(consumePendingRun('slug-a', SHA, APB)).resolves.toBe('missing');
   });
 });

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -1,17 +1,33 @@
 import { createHmac } from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// withAxiom is a passthrough in tests.
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+
 // The handler module imports ~/server/db/client (Prisma init at module load).
-// We only exercise the pure expectedImageRef + verifySignature helpers, so stub
-// the db + pipeline deps to keep the import side-effect-free.
-vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+// The pure helper tests don't touch the db; the handler-level tests below need
+// dbWrite.appBlock.update, so give it a mockable surface.
+const mockUpdate = vi.hoisted(() => vi.fn());
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: { appBlock: { update: mockUpdate } },
+}));
 // callbackPendingRedisKey is a pure key builder used by consumePendingRun; the
 // real module pulls in env at import, so stub it with a deterministic key shape.
+const mockTriggerApply = vi.hoisted(() => vi.fn());
+const mockWaitForApplyJob = vi.hoisted(() => vi.fn());
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
-  triggerApply: vi.fn(),
-  waitForApplyJob: vi.fn(),
+  triggerApply: mockTriggerApply,
+  waitForApplyJob: mockWaitForApplyJob,
   callbackPendingRedisKey: (slug: string, sha: string, appBlockId: string) =>
     `system:blocks:callback:pending:${slug}:${sha}:${appBlockId}`,
+}));
+
+const mockSetCommitStatus = vi.hoisted(() => vi.fn());
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  setCommitStatus: mockSetCommitStatus,
 }));
 
 // Mockable sysRedis.getDel so the consume-once cross-check can be exercised.
@@ -29,7 +45,7 @@ vi.mock('~/server/redis/client', () => ({
 const mockEnv = vi.hoisted(() => ({} as Record<string, string | undefined>));
 vi.mock('~/env/server', () => ({ env: mockEnv }));
 
-import {
+import handler, {
   checkCallbackTimestamp,
   consumePendingRun,
   expectedImageRef,
@@ -217,5 +233,130 @@ describe('build-callback consumePendingRun (F5 cross-check)', () => {
     mockGetDel.mockResolvedValueOnce('1').mockResolvedValueOnce(null);
     await expect(consumePendingRun('slug-a', SHA, APB)).resolves.toBe('consumed');
     await expect(consumePendingRun('slug-a', SHA, APB)).resolves.toBe('missing');
+  });
+});
+
+/**
+ * F5-T — HANDLER-LEVEL coverage that the pure-function tests can't reach: the
+ * enforce-vs-report-only branch on a MISSING pending-run marker, and the
+ * double-callback (consume-once) outcome. These drive the real handler so the
+ * 409-under-enforce and the GETDEL-consume path are exercised end to end.
+ */
+describe('build-callback handler — F5 pending-run enforcement', () => {
+  const SECRET = 'callback-secret';
+  const SLUG = 'generate-from-model';
+  const SHA = 'a'.repeat(40);
+  const APB = 'apb_01JABCDEFGHJKMNPQRSTVWXYZ0';
+  const PENDING_KEY = `system:blocks:callback:pending:${SLUG}:${SHA}:${APB}`;
+
+  function callbackBody(over: Record<string, unknown> = {}): Buffer {
+    return Buffer.from(
+      JSON.stringify({
+        slug: SLUG,
+        sha: SHA,
+        appBlockId: APB,
+        imageRef: expectedImageRef(SLUG, SHA),
+        status: 'Succeeded',
+        ...over,
+      })
+    );
+  }
+
+  function makeReq(raw: Buffer): NextApiRequest {
+    const stream = Readable.from([raw]) as unknown as NextApiRequest;
+    const sig = createHmac('sha256', SECRET).update(raw).digest('hex');
+    stream.method = 'POST';
+    stream.headers = { 'x-appblocks-signature': sig };
+    return stream;
+  }
+
+  function makeRes(): NextApiResponse & { _status: number; _body: unknown } {
+    const res = {
+      _status: 0,
+      _body: null as unknown,
+      status(this: any, n: number) {
+        this._status = n;
+        return this;
+      },
+      json(this: any, b: unknown) {
+        this._body = b;
+        return this;
+      },
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    };
+    return res as unknown as NextApiResponse & { _status: number; _body: unknown };
+  }
+
+  // In-memory store so GETDEL round-trips (present → consumed → missing).
+  let store: Set<string>;
+
+  beforeEach(() => {
+    store = new Set<string>();
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = SECRET;
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET_NEXT = undefined;
+    mockEnv.BLOCK_CALLBACK_REQUIRE_PENDING_RUN = undefined;
+
+    mockGetDel.mockReset();
+    mockGetDel.mockImplementation(async (key: string) => {
+      if (store.has(key)) {
+        store.delete(key);
+        return '1';
+      }
+      return null;
+    });
+
+    mockTriggerApply.mockReset();
+    mockTriggerApply.mockResolvedValue({ name: 'apply-job-1' });
+    mockWaitForApplyJob.mockReset();
+    // Background watcher: resolve fast so no unhandled rejection escapes.
+    mockWaitForApplyJob.mockResolvedValue('succeeded');
+    mockUpdate.mockReset();
+    mockUpdate.mockResolvedValue({});
+    mockSetCommitStatus.mockReset();
+    mockSetCommitStatus.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET = undefined;
+    mockEnv.BLOCK_BUILD_CALLBACK_SECRET_NEXT = undefined;
+    mockEnv.BLOCK_CALLBACK_REQUIRE_PENDING_RUN = undefined;
+  });
+
+  it('REJECTS a missing-marker callback with 409 when enforce is on', async () => {
+    mockEnv.BLOCK_CALLBACK_REQUIRE_PENDING_RUN = 'true';
+    // store is empty → marker missing.
+    const res = makeRes();
+    await handler(makeReq(callbackBody()), res);
+    expect(res._status).toBe(409);
+    expect(mockTriggerApply).not.toHaveBeenCalled();
+  });
+
+  it('CONTINUES (report-only) on a missing marker when enforce is unset', async () => {
+    // store empty → missing, but enforce flag unset → proceed to apply.
+    const res = makeRes();
+    await handler(makeReq(callbackBody()), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, applied: true });
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1);
+  });
+
+  it('double-callback: first consumes the marker + applies; second is missing → 409 under enforce', async () => {
+    mockEnv.BLOCK_CALLBACK_REQUIRE_PENDING_RUN = 'true';
+    store.add(PENDING_KEY); // genuine outstanding run from triggerBuild.
+
+    // First callback: marker present → consumed → applies.
+    const res1 = makeRes();
+    await handler(makeReq(callbackBody()), res1);
+    expect(res1._status).toBe(200);
+    expect(res1._body).toMatchObject({ ok: true, applied: true });
+    expect(store.has(PENDING_KEY)).toBe(false); // consume-once.
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1);
+
+    // Second callback for the same (slug,sha,appBlockId): marker gone → 409.
+    const res2 = makeRes();
+    await handler(makeReq(callbackBody()), res2);
+    expect(res2._status).toBe(409);
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1); // no second apply.
   });
 });

--- a/src/tests/api/internal/blocks/git-push.test.ts
+++ b/src/tests/api/internal/blocks/git-push.test.ts
@@ -9,6 +9,14 @@ vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   triggerBuild: vi.fn(),
 }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn() }));
+
+// Mockable sysRedis.set so the F5 per-delivery dedup nonce can be exercised.
+const mockSet = vi.hoisted(() => vi.fn());
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { set: mockSet },
+  REDIS_SYS_KEYS: { BLOCKS: { GITPUSH_DELIVERY: 'system:blocks:gitpush:delivery' } },
+}));
 
 // Mutable env mock so each test can set / clear FORGEJO_WEBHOOK_SECRET[_NEXT]
 // to exercise the dual-acceptance rotation window (F6). Overrides the global
@@ -17,7 +25,11 @@ vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
 const mockEnv = vi.hoisted(() => ({} as Record<string, string | undefined>));
 vi.mock('~/env/server', () => ({ env: mockEnv }));
 
-import { parseExpectedRepo, verifyForgejoSignature } from '~/pages/api/internal/blocks/git-push';
+import {
+  checkDeliveryNonce,
+  parseExpectedRepo,
+  verifyForgejoSignature,
+} from '~/pages/api/internal/blocks/git-push';
 
 /**
  * M-WEBHOOK coverage. The git-push webhook is authenticated only by the
@@ -120,5 +132,60 @@ describe('verifyForgejoSignature dual-secret window (F6)', () => {
 
   it('fails closed when no secret is configured (no current, no NEXT)', () => {
     expect(verifyForgejoSignature(body, sign('anything'))).toBe(false);
+  });
+});
+
+/**
+ * F5 — per-delivery dedup nonce. SET NX EX on the X-Gitea-Delivery id. First
+ * delivery wins ('first'); a redelivery with the same id is a 'duplicate'.
+ * Header absent / malformed / Redis error → 'skip' (never block a legit push).
+ * NOTE (honest limitation, documented in checkDeliveryNonce): X-Gitea-Delivery
+ * is NOT HMAC-covered, so this catches naive redeliveries only.
+ */
+describe('git-push checkDeliveryNonce (F5 delivery nonce)', () => {
+  beforeEach(() => {
+    mockSet.mockReset();
+  });
+
+  it("treats a new delivery id as 'first' (NX set succeeds → 'OK')", async () => {
+    mockSet.mockResolvedValueOnce('OK');
+    await expect(checkDeliveryNonce('delivery-uuid-1')).resolves.toBe('first');
+    expect(mockSet).toHaveBeenCalledWith(
+      'system:blocks:gitpush:delivery:delivery-uuid-1',
+      '1',
+      { NX: true, EX: 600 }
+    );
+  });
+
+  it("treats a repeated delivery id as 'duplicate' (NX returns null)", async () => {
+    mockSet.mockResolvedValueOnce(null);
+    await expect(checkDeliveryNonce('delivery-uuid-1')).resolves.toBe('duplicate');
+  });
+
+  it("skips when the delivery header is absent → 'skip' (no Redis call)", async () => {
+    await expect(checkDeliveryNonce(undefined)).resolves.toBe('skip');
+    await expect(checkDeliveryNonce(null)).resolves.toBe('skip');
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("skips a malformed / oversized delivery id → 'skip'", async () => {
+    await expect(checkDeliveryNonce('bad id with spaces')).resolves.toBe('skip');
+    await expect(checkDeliveryNonce('x'.repeat(65))).resolves.toBe('skip');
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("uses the first element when the header arrives as an array", async () => {
+    mockSet.mockResolvedValueOnce('OK');
+    await expect(checkDeliveryNonce(['delivery-uuid-2', 'ignored'])).resolves.toBe('first');
+    expect(mockSet).toHaveBeenCalledWith(
+      'system:blocks:gitpush:delivery:delivery-uuid-2',
+      '1',
+      { NX: true, EX: 600 }
+    );
+  });
+
+  it("skips on a Redis error → 'skip' (never block a legit push)", async () => {
+    mockSet.mockRejectedValueOnce(new Error('redis down'));
+    await expect(checkDeliveryNonce('delivery-uuid-3')).resolves.toBe('skip');
   });
 });

--- a/src/tests/api/internal/blocks/git-push.test.ts
+++ b/src/tests/api/internal/blocks/git-push.test.ts
@@ -361,6 +361,49 @@ describe('git-push handler — F5-A nonce release on downstream failure', () => 
     expect(store.has(DELIVERY_KEY)).toBe(true);
   });
 
+  it('releases the nonce when dbWrite.appBlock.update throws (R2-F5-A1), then re-processes on retry', async () => {
+    // R2-F5-A1 (the exact gap the per-path releases missed): the
+    // dbWrite.appBlock.update is reached AFTER the nonce is claimed and BEFORE
+    // triggerBuild. If it throws (DB blip / pool exhaustion / replica
+    // promotion), withAxiom returns a 500 — and without the outer try/catch the
+    // nonce stays held, so Forgejo's same-id retry is swallowed as a duplicate
+    // and the build is permanently lost. The handler must release the nonce on
+    // this throw too. This is the test that would have caught R2-F5-A1.
+    process.env.NEXTAUTH_URL = 'https://civitai.test';
+
+    // --- Delivery #1: the DB update throws (transient DB failure) -------------
+    mockUpdate.mockRejectedValueOnce(new Error('connection pool exhausted'));
+    const res1 = makeRes();
+    // withAxiom is a passthrough in tests, so the throw propagates out of the
+    // handler (in prod withAxiom turns it into a 500). Assert it's non-2xx by
+    // confirming the success/skip responses were NOT sent AND the throw escaped.
+    await expect(handler(makeReq(pushBody()), res1)).rejects.toThrow(
+      'connection pool exhausted'
+    );
+    // Non-2xx: the success 200 body was never written.
+    expect(res1._status).not.toBe(200);
+    expect(res1._body).toBeNull();
+    // The DB update threw before triggerBuild ran.
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+    // ... AND the nonce key was released so a retry is allowed.
+    expect(mockDel).toHaveBeenCalledWith(DELIVERY_KEY);
+    expect(store.has(DELIVERY_KEY)).toBe(false);
+
+    // --- Delivery #2: SAME id, DB recovered → must PROCESS (not skip) ---------
+    mockUpdate.mockResolvedValueOnce({});
+    mockTriggerBuild.mockResolvedValueOnce({ name: 'pr-3' });
+    const res2 = makeRes();
+    await handler(makeReq(pushBody()), res2);
+
+    expect(res2._status).toBe(200);
+    expect(res2._body).toMatchObject({ ok: true, slug: SLUG, sha: SHA });
+    // The retry actually drove the build (NOT swallowed as a duplicate).
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+    // The nonce is now held (success keeps it) so a 3rd identical delivery
+    // WOULD be deduped.
+    expect(store.has(DELIVERY_KEY)).toBe(true);
+  });
+
   it('KEEPS the nonce on success so a duplicate of a completed delivery is deduped', async () => {
     process.env.NEXTAUTH_URL = 'https://civitai.test';
     mockTriggerBuild.mockResolvedValue({ name: 'pr-2' });

--- a/src/tests/api/internal/blocks/git-push.test.ts
+++ b/src/tests/api/internal/blocks/git-push.test.ts
@@ -1,20 +1,55 @@
 import { createHmac } from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// The handler module imports ~/server/db/client (which inits Prisma at module
-// load and reads env.LOGGING.filter). We only exercise the pure
-// parseExpectedRepo + verifyForgejoSignature helpers, so stub the db + pipeline
-// deps to keep the import side-effect-free.
-vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
-vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
-  triggerBuild: vi.fn(),
-}));
-vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn() }));
+// withAxiom is a passthrough in tests (its closure is captured at module load,
+// and we don't need the Axiom transport for handler behaviour).
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
 
-// Mockable sysRedis.set so the F5 per-delivery dedup nonce can be exercised.
+// The handler module imports ~/server/db/client (which inits Prisma at module
+// load and reads env.LOGGING.filter). The pure parseExpectedRepo +
+// verifyForgejoSignature + checkDeliveryNonce tests don't touch the db, but the
+// handler-level retry-after-failure test (F5-A) does — so give dbRead/dbWrite
+// mockable surfaces here.
+const mockFindFirst = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findFirst: mockFindFirst } },
+  dbWrite: { appBlock: { update: mockUpdate } },
+}));
+
+const mockTriggerBuild = vi.hoisted(() => vi.fn());
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  triggerBuild: mockTriggerBuild,
+}));
+
+const mockIsFlipt = vi.hoisted(() => vi.fn());
+vi.mock('~/server/flipt/client', () => ({ isFlipt: mockIsFlipt }));
+
+// Forgejo side-effects (commit status + manifest fetch) — mockable so the
+// handler test can drive a manifest-fetch failure and a happy retry.
+const mockGetRawFile = vi.hoisted(() => vi.fn());
+const mockSetCommitStatus = vi.hoisted(() => vi.fn());
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  FORGEJO_ORG: 'civitai-apps',
+  getRawFile: mockGetRawFile,
+  setCommitStatus: mockSetCommitStatus,
+}));
+
+// Validator — default to valid; the handler test only needs the valid path.
+const mockValidate = vi.hoisted(() => vi.fn());
+vi.mock('~/server/services/block-manifest-validator.service', () => ({
+  BlockManifestValidator: { validate: mockValidate },
+}));
+
+// Mockable sysRedis.set + .del so the F5 per-delivery dedup nonce (claim +
+// F5-A release-on-failure) can be exercised at both the pure-fn and handler
+// level. The handler-level test asserts .del is called on a downstream failure.
 const mockSet = vi.hoisted(() => vi.fn());
+const mockDel = vi.hoisted(() => vi.fn());
 vi.mock('~/server/redis/client', () => ({
-  sysRedis: { set: mockSet },
+  sysRedis: { set: mockSet, del: mockDel },
   REDIS_SYS_KEYS: { BLOCKS: { GITPUSH_DELIVERY: 'system:blocks:gitpush:delivery' } },
 }));
 
@@ -25,7 +60,7 @@ vi.mock('~/server/redis/client', () => ({
 const mockEnv = vi.hoisted(() => ({} as Record<string, string | undefined>));
 vi.mock('~/env/server', () => ({ env: mockEnv }));
 
-import {
+import handler, {
   checkDeliveryNonce,
   parseExpectedRepo,
   verifyForgejoSignature,
@@ -187,5 +222,160 @@ describe('git-push checkDeliveryNonce (F5 delivery nonce)', () => {
   it("skips on a Redis error → 'skip' (never block a legit push)", async () => {
     mockSet.mockRejectedValueOnce(new Error('redis down'));
     await expect(checkDeliveryNonce('delivery-uuid-3')).resolves.toBe('skip');
+  });
+});
+
+/**
+ * F5-A (the headline regression) — HANDLER-LEVEL. The delivery nonce is claimed
+ * BEFORE downstream processing. If a transient downstream failure (here:
+ * triggerBuild throwing) lands AFTER the claim, the handler MUST release the
+ * nonce so Forgejo's redelivery of the SAME X-Gitea-Delivery id can re-process
+ * the build — otherwise the build is permanently swallowed as a "duplicate"
+ * (a new availability hole). This is the test that would have caught F5-A.
+ *
+ * It drives the real handler (not just the pure helper) so it exercises the
+ * actual claim → fail → DEL → retry → process path.
+ */
+describe('git-push handler — F5-A nonce release on downstream failure', () => {
+  const SECRET = 'forgejo-secret';
+  const SLUG = 'generate-from-model';
+  const SHA = 'a'.repeat(40);
+  const DELIVERY_ID = 'retry-delivery-id-1';
+  const DELIVERY_KEY = `system:blocks:gitpush:delivery:${DELIVERY_ID}`;
+
+  function pushBody(): Buffer {
+    return Buffer.from(
+      JSON.stringify({
+        ref: 'refs/heads/main',
+        after: SHA,
+        repository: { name: SLUG, full_name: `civitai-apps/${SLUG}` },
+      })
+    );
+  }
+
+  function makeReq(raw: Buffer): NextApiRequest {
+    // The handler reads the raw stream via `for await (const chunk of req)`.
+    const stream = Readable.from([raw]) as unknown as NextApiRequest;
+    const sig = createHmac('sha256', SECRET).update(raw).digest('hex');
+    stream.method = 'POST';
+    stream.headers = {
+      'x-gitea-signature': sig,
+      'x-gitea-delivery': DELIVERY_ID,
+    };
+    return stream;
+  }
+
+  function makeRes(): NextApiResponse & { _status: number; _body: unknown } {
+    const res = {
+      _status: 0,
+      _body: null as unknown,
+      status(this: any, n: number) {
+        this._status = n;
+        return this;
+      },
+      json(this: any, b: unknown) {
+        this._body = b;
+        return this;
+      },
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    };
+    return res as unknown as NextApiResponse & { _status: number; _body: unknown };
+  }
+
+  // A tiny in-memory Redis stub so the nonce truly round-trips claim → del →
+  // re-claim across the two deliveries (the whole point of the regression test).
+  let store: Set<string>;
+
+  beforeEach(() => {
+    store = new Set<string>();
+    mockEnv.FORGEJO_WEBHOOK_SECRET = SECRET;
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = undefined;
+    mockEnv.APPS_DOMAIN = 'civitaiapps.com';
+
+    mockSet.mockReset();
+    mockDel.mockReset();
+    // SET NX semantics over the in-memory store.
+    mockSet.mockImplementation(async (key: string) => {
+      if (store.has(key)) return null;
+      store.add(key);
+      return 'OK';
+    });
+    mockDel.mockImplementation(async (key: string) => {
+      const had = store.delete(key);
+      return had ? 1 : 0;
+    });
+
+    mockIsFlipt.mockResolvedValue(true);
+    mockFindFirst.mockResolvedValue({
+      id: 'apb_0123456789ABCDEFGHJKMNPQ',
+      appId: 'app_1',
+      blockId: SLUG,
+      app: { id: 'app_1', allowedScopes: 0, allowedOrigins: [] },
+    });
+    mockUpdate.mockResolvedValue({});
+    mockGetRawFile.mockResolvedValue(
+      JSON.stringify({
+        blockId: SLUG,
+        version: '1.0.0',
+        iframe: { src: `https://${SLUG}.civitaiapps.com/` },
+      })
+    );
+    mockValidate.mockReturnValue({ valid: true, errors: [] });
+    mockSetCommitStatus.mockResolvedValue(undefined);
+    mockTriggerBuild.mockReset();
+  });
+
+  afterEach(() => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = undefined;
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = undefined;
+    mockEnv.APPS_DOMAIN = undefined;
+  });
+
+  it('releases the nonce on a triggerBuild failure, then re-processes the same delivery id on retry', async () => {
+    process.env.NEXTAUTH_URL = 'https://civitai.test';
+
+    // --- Delivery #1: triggerBuild throws (transient Tekton failure) ---------
+    mockTriggerBuild.mockRejectedValueOnce(new Error('tekton receiver down'));
+    const res1 = makeRes();
+    await handler(makeReq(pushBody()), res1);
+
+    // Non-2xx (the build trigger failed) ...
+    expect(res1._status).toBeGreaterThanOrEqual(400);
+    expect(res1._status).toBe(500);
+    // ... AND the nonce key was deleted so a retry is allowed.
+    expect(mockDel).toHaveBeenCalledWith(DELIVERY_KEY);
+    expect(store.has(DELIVERY_KEY)).toBe(false);
+
+    // --- Delivery #2: SAME id, failure cleared → must PROCESS (not skip) ------
+    mockTriggerBuild.mockResolvedValueOnce({ name: 'pr-1' });
+    const res2 = makeRes();
+    await handler(makeReq(pushBody()), res2);
+
+    expect(res2._status).toBe(200);
+    expect(res2._body).toMatchObject({ ok: true, slug: SLUG, sha: SHA });
+    // The retry actually drove the build (NOT swallowed as a duplicate).
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(2);
+    // And the nonce is now held (success path keeps it) so a 3rd identical
+    // delivery WOULD be deduped.
+    expect(store.has(DELIVERY_KEY)).toBe(true);
+  });
+
+  it('KEEPS the nonce on success so a duplicate of a completed delivery is deduped', async () => {
+    process.env.NEXTAUTH_URL = 'https://civitai.test';
+    mockTriggerBuild.mockResolvedValue({ name: 'pr-2' });
+
+    const res1 = makeRes();
+    await handler(makeReq(pushBody()), res1);
+    expect(res1._status).toBe(200);
+    expect(store.has(DELIVERY_KEY)).toBe(true);
+    expect(mockDel).not.toHaveBeenCalledWith(DELIVERY_KEY);
+
+    // Duplicate delivery of the completed run → 200 skipped, no second build.
+    const res2 = makeRes();
+    await handler(makeReq(pushBody()), res2);
+    expect(res2._status).toBe(200);
+    expect(res2._body).toMatchObject({ skipped: 'duplicate delivery' });
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## W11 audit finding F5 — HMAC replay protection (civitai half)

Closes the **F5** gap from the App Blocks W11 security audit (`datapacket-talos/claudedocs/app-blocks-w11-audit-findings.md`): none of the three build-chain HMAC contracts had a timestamp tolerance or per-delivery nonce, and build-callback had no pending-run cross-check, so a captured validly-signed request could be replayed (downgrade/rebuild of a prior already-approved sha).

**Stacks on #2518** (`zach/w11-f6-hmac-dual-secret`) — these edits build on the F6 dual-secret verifiers and do **not** weaken the `timingSafeEqual` HMAC checks. If #2518 merges first, rebase this onto `feat/app-blocks-main-v1`.

A **companion datapacket-talos PR** implements the other side of the wire contract: the `ts` SIGNER on the callback Tekton task and the `ts` RECEIVER (skew validation) in `trigger.py`.

### WIRE CONTRACT (must match the datapacket-talos side exactly)

- **tekton-trigger leg (this PR = SIGNER):** `triggerBuild` adds integer `ts = floor(Date.now()/1000)` to the JSON body **before** HMAC signing. `trigger.py` validates `|now - ts| > 300` → reject.
- **build-callback leg (this PR = RECEIVER):** after the existing HMAC verify, parse `ts` from the verified body and reject `401` when `ts` is present AND `|nowSec - ts| > 300`. If `ts` is **absent → ALLOW** (rollout tolerance; the datapacket-talos callback-task signer adds `ts` in its own PR — enforce-if-present avoids a deploy-ordering outage). `ts` is inside the signed body, so a replay carries its original stale `ts` and is caught.
- **callback pending-run cross-check (entirely civitai-side):**
  - `triggerBuild`: after a successful trigger POST, write Redis `system:blocks:callback:pending:<slug>:<sha>:<appBlockId>` = `"1"` TTL **1800s**. Fire-and-forget — a Redis failure logs + continues (never fails the trigger).
  - `build-callback`: after HMAC + ts pass, **GETDEL** that key (consume-once). Missing → reject `409` when `BLOCK_CALLBACK_REQUIRE_PENDING_RUN === 'true'`, else warn + continue (report-only first deploy). Redis error → treated as not-enforced.
- **git-push nonce (civitai-side):** read `X-Gitea-Delivery`, `SET NX EX 600` on `system:blocks:gitpush:delivery:<id>`; duplicate id → `200 skipped`. Header absent / Redis blip → skip.

### Exact Redis key formats (for the datapacket-talos reviewer)
```
system:blocks:callback:pending:<slug>:<sha>:<appBlockId>   # "1", TTL 1800s, GETDEL consume-once
system:blocks:gitpush:delivery:<X-Gitea-Delivery>          # "1", SET NX EX 600
```

### New env var
`BLOCK_CALLBACK_REQUIRE_PENDING_RUN` (optional, server schema). Default (unset / ≠ `'true'`) = report-only on a missing pending-run marker; `'true'` = enforce (`409`).

### Honest limitation (`X-Gitea-Delivery`)
`X-Gitea-Delivery` is **NOT** covered by the body HMAC. The nonce catches naive/duplicate redeliveries, but a determined replayer could swap the header to a fresh value. The strong replay protection is the two `ts` legs (trigger + callback) + the callback pending-run cross-check; a git-push replay is **downgrade-only** — it re-applies the same already-approved sha and is org/sha-gated (`parseExpectedRepo` + `SLUG_RE` + 40-hex sha).

### Backward-compatibility / rollout safety
Every new check is non-breaking if its counterpart is absent: enforce-if-present for `ts`, env-gated for the cross-check, skip-if-absent for the delivery header. App Blocks is mod-only + dark right now.

### Verification
- `vitest run` on the two block test files: **38 pass** (build-callback 20, git-push 18) — ts present+fresh/stale/absent, pending-run consumed/missing-enforce/missing-report/unavailable/consume-once, duplicate vs new delivery id, header-absent/malformed/array/Redis-error skip.
- `tsc --noEmit`: clean on all changed files (pre-existing unrelated repo errors ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)