### PR TITLE
fix(home): reserve content height during home-block load to fix severe CLS (0.977)

### DIFF
--- a/src/components/Alerts/NavTidyNotice.tsx
+++ b/src/components/Alerts/NavTidyNotice.tsx
@@ -1,6 +1,7 @@
 import { Button, CloseButton, Popover, Text } from '@mantine/core';
 import { IconArrowRight, IconInfoCircle } from '@tabler/icons-react';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags, useFeatureFlagsReady } from '~/providers/FeatureFlagsProvider';
 import { trpc } from '~/utils/trpc';
@@ -58,6 +59,21 @@ export function NavTidyNotice() {
   // fetch lands. Defined immediately on the normal SSR-seeded path → no delay.
   const show = enabled && ready && !!settings && !isDismissed && hasHiddenNavItem;
 
+  // Open only AFTER the above-the-fold layout has settled. The popover is anchored
+  // to a subnav target; opening it during the initial layout-settle window made its
+  // dropdown paint while the target was still moving, registering a large layout
+  // shift (the dominant home-page CLS contributor). A short post-mount defer lets it
+  // paint once at its final position — no shift — without changing the nudge's intent.
+  const [opened, setOpened] = useState(false);
+  useEffect(() => {
+    if (!show) {
+      setOpened(false);
+      return;
+    }
+    const id = window.setTimeout(() => setOpened(true), 1500);
+    return () => window.clearTimeout(id);
+  }, [show]);
+
   const handleDismiss = () => dismissMutation.mutate({ alertId: ALERT_ID });
 
   if (!show) return null;
@@ -67,7 +83,7 @@ export function NavTidyNotice() {
       width={280}
       position="bottom-start"
       shadow="lg"
-      opened
+      opened={opened}
       // Stay put until the user explicitly closes it via the X — clicking away
       // or pressing Escape should not permanently dismiss the nudge.
       closeOnClickOutside={false}

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -1,17 +1,55 @@
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
 import React from 'react';
 import dynamic from 'next/dynamic';
+import { useAppContext } from '~/providers/AppProvider';
 
 const AnnouncementsCarousel = dynamic(
   () => import('~/components/Announcements/AnnouncementsCarousel')
 );
 
+// Approximate rendered height of a single announcement banner (the card uses an
+// image variant with `min-h-40` = 160px, plus the wrapper's `mb-3`). Used only to
+// reserve layout space so the banner's post-hydration appearance doesn't shove the
+// page content down (a large CLS source on the home page, which has a tall content
+// tree below the banner). Slightly under the real height by design — better to
+// reserve a touch less than to leave dead whitespace; the residual shift is small.
+const ANNOUNCEMENT_RESERVED_MIN_HEIGHT = 160;
+
 export function Announcements() {
   const { data } = useGetAnnouncements();
 
+  // `useGetAnnouncements` intentionally returns [] on the server AND the first
+  // client render (it gates on useIsClient to keep the localStorage `dismissed`
+  // set from causing a hydration mismatch), then surfaces the banner only after
+  // hydration — which is exactly what shifts the page. The SSR seed itself
+  // (useAppContext) IS available identically on the server and the first client
+  // render, so we can reserve the banner's height from it deterministically
+  // (no hydration mismatch) and let the real carousel fill that reserved space.
+  const { announcements: seed } = useAppContext();
+  const hasSeededAnnouncement = (seed?.length ?? 0) > 0;
+
   const announcements = data.filter((x) => !x.dismissed);
 
-  if (!announcements.length) return null;
+  // Reserve space when the SSR seed has an announcement, even before the
+  // post-hydration carousel renders. Once hydrated, if the user had dismissed
+  // every seeded announcement, the slot collapses (a minor upward adjustment in
+  // that edge case only); the common case (an active, undismissed announcement)
+  // sees the banner fill the already-reserved height with no shift.
+  // Pre-hydration (data === [] but a seed exists): render a same-width/margin
+  // placeholder that reserves the banner height, so when the carousel mounts
+  // post-hydration it fills the already-reserved slot instead of pushing the
+  // page content down.
+  if (!announcements.length) {
+    if (!hasSeededAnnouncement) return null;
+    return (
+      <div
+        aria-hidden
+        style={{ minHeight: ANNOUNCEMENT_RESERVED_MIN_HEIGHT }}
+        // eslint-disable-next-line tailwindcss/no-custom-classname
+        className="announcements-placeholder peer container mb-3"
+      />
+    );
+  }
 
   return <AnnouncementsCarousel />;
 }

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -1,55 +1,17 @@
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
 import React from 'react';
 import dynamic from 'next/dynamic';
-import { useAppContext } from '~/providers/AppProvider';
 
 const AnnouncementsCarousel = dynamic(
   () => import('~/components/Announcements/AnnouncementsCarousel')
 );
 
-// Approximate rendered height of a single announcement banner (the card uses an
-// image variant with `min-h-40` = 160px, plus the wrapper's `mb-3`). Used only to
-// reserve layout space so the banner's post-hydration appearance doesn't shove the
-// page content down (a large CLS source on the home page, which has a tall content
-// tree below the banner). Slightly under the real height by design — better to
-// reserve a touch less than to leave dead whitespace; the residual shift is small.
-const ANNOUNCEMENT_RESERVED_MIN_HEIGHT = 160;
-
 export function Announcements() {
   const { data } = useGetAnnouncements();
 
-  // `useGetAnnouncements` intentionally returns [] on the server AND the first
-  // client render (it gates on useIsClient to keep the localStorage `dismissed`
-  // set from causing a hydration mismatch), then surfaces the banner only after
-  // hydration — which is exactly what shifts the page. The SSR seed itself
-  // (useAppContext) IS available identically on the server and the first client
-  // render, so we can reserve the banner's height from it deterministically
-  // (no hydration mismatch) and let the real carousel fill that reserved space.
-  const { announcements: seed } = useAppContext();
-  const hasSeededAnnouncement = (seed?.length ?? 0) > 0;
-
   const announcements = data.filter((x) => !x.dismissed);
 
-  // Reserve space when the SSR seed has an announcement, even before the
-  // post-hydration carousel renders. Once hydrated, if the user had dismissed
-  // every seeded announcement, the slot collapses (a minor upward adjustment in
-  // that edge case only); the common case (an active, undismissed announcement)
-  // sees the banner fill the already-reserved height with no shift.
-  // Pre-hydration (data === [] but a seed exists): render a same-width/margin
-  // placeholder that reserves the banner height, so when the carousel mounts
-  // post-hydration it fills the already-reserved slot instead of pushing the
-  // page content down.
-  if (!announcements.length) {
-    if (!hasSeededAnnouncement) return null;
-    return (
-      <div
-        aria-hidden
-        style={{ minHeight: ANNOUNCEMENT_RESERVED_MIN_HEIGHT }}
-        // eslint-disable-next-line tailwindcss/no-custom-classname
-        className="announcements-placeholder peer container mb-3"
-      />
-    );
-  }
+  if (!announcements.length) return null;
 
   return <AnnouncementsCarousel />;
 }

--- a/src/components/HomeBlocks/HomeBlockSkeleton.tsx
+++ b/src/components/HomeBlocks/HomeBlockSkeleton.tsx
@@ -19,7 +19,9 @@ export function HomeBlockSkeleton({ rows = 2 }: { rows?: number }) {
   const count = ITEMS_PER_ROW * rows;
   return (
     <HomeBlockWrapper py={32}>
-      <div style={{ '--count': count, '--rows': rows } as React.CSSProperties}>
+      {/* aria-hidden: the placeholder cards are decorative; keep the empty
+          skeleton nodes out of the screen-reader tree during load. */}
+      <div aria-hidden style={{ '--count': count, '--rows': rows } as React.CSSProperties}>
         <Box mb="md">
           <Skeleton height={32} width={220} radius="sm" />
         </Box>

--- a/src/components/HomeBlocks/HomeBlockSkeleton.tsx
+++ b/src/components/HomeBlocks/HomeBlockSkeleton.tsx
@@ -1,0 +1,53 @@
+import { AspectRatio, Box, Skeleton } from '@mantine/core';
+import React from 'react';
+import { HomeBlockWrapper } from '~/components/HomeBlocks/HomeBlockWrapper';
+import classes from '~/components/HomeBlocks/HomeBlock.module.scss';
+
+const ITEMS_PER_ROW = 7;
+
+/**
+ * Layout-stable placeholder for a single grid-style home block (Collection /
+ * FeaturedCollections / FeaturedModelVersion). It reproduces the SAME markup the
+ * real blocks render while their own query is loading — a header bar plus a
+ * `classes.grid` of `rows × ITEMS_PER_ROW` AspectRatio 7/9 cards — so swapping in
+ * the real block (which shares the grid geometry) does not shift siblings.
+ *
+ * Rendered deterministically (no client-only / useInView state) so SSR and the
+ * first client render agree (no hydration mismatch).
+ */
+export function HomeBlockSkeleton({ rows = 2 }: { rows?: number }) {
+  const count = ITEMS_PER_ROW * rows;
+  return (
+    <HomeBlockWrapper py={32}>
+      <div style={{ '--count': count, '--rows': rows } as React.CSSProperties}>
+        <Box mb="md">
+          <Skeleton height={32} width={220} radius="sm" />
+        </Box>
+        <div className={classes.grid}>
+          {Array.from({ length: count }).map((_, index) => (
+            <AspectRatio ratio={7 / 9} key={index} className="m-2">
+              <Skeleton width="100%" />
+            </AspectRatio>
+          ))}
+        </div>
+      </div>
+    </HomeBlockWrapper>
+  );
+}
+
+/**
+ * A full-page home placeholder: a handful of grid-block skeletons matching the
+ * typical home layout (~6 blocks). Used in place of the absolute-positioned
+ * PageLoader (which reserves zero layout height) while the home-block LIST query
+ * loads, so the content container is present at ~final height on first paint
+ * instead of popping in from 0 (the dominant home-page CLS source).
+ */
+export function HomeBlocksSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <HomeBlockSkeleton key={index} />
+      ))}
+    </>
+  );
+}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -10,6 +10,7 @@ import { FeaturedCollectionsHomeBlock } from '~/components/HomeBlocks/FeaturedCo
 import { CosmeticShopSectionHomeBlock } from '~/components/HomeBlocks/CosmeticShopSectionHomeBlock';
 import { EventHomeBlock } from '~/components/HomeBlocks/EventHomeBlock';
 import { FeaturedModelVersionHomeBlock } from '~/components/HomeBlocks/FeaturedModelVersionHomeBlock';
+import { HomeBlocksSkeleton } from '~/components/HomeBlocks/HomeBlockSkeleton';
 import { LeaderboardsHomeBlock } from '~/components/HomeBlocks/LeaderboardsHomeBlock';
 import { SocialHomeBlock } from '~/components/HomeBlocks/SocialHomeBlock';
 import ImagesInfinite from '~/components/Image/Infinite/ImagesInfinite';
@@ -18,7 +19,6 @@ import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
 import { ModelsInfinite } from '~/components/Model/Infinite/ModelsInfinite';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
-import { PageLoader } from '~/components/PageLoader/PageLoader';
 import { env } from '~/env/client';
 import { isProd } from '~/env/other';
 import { useInView } from '~/hooks/useInView';
@@ -57,10 +57,10 @@ export function Home() {
         alternate="/home"
       />
 
-      {isLoading ? (
-        <PageLoader />
-      ) : (
-        <div className={classes.container}>
+      <div className={classes.container}>
+        {isLoading ? (
+          <HomeBlocksSkeleton />
+        ) : (
           <BrowsingLevelProvider browsingLevel={sfwBrowsingLevelsFlag}>
             {homeBlocks.map((homeBlock, i) => {
               const showAds = i % 2 === 1 && i > 0;
@@ -107,127 +107,127 @@ export function Home() {
               );
             })}
           </BrowsingLevelProvider>
-          <BrowsingLevelProvider browsingLevel={publicBrowsingLevelsFlag}>
-            {env.NEXT_PUBLIC_UI_HOMEPAGE_IMAGES ? (
-              <Box ref={ref}>
-                <MasonryContainer py={32}>
-                  {displayModelsInfiniteFeed && !isLoadingExcludedTags && (
-                    <IsClient>
-                      <Group mb="md" justify="space-between">
-                        <Group>
-                          <Title className="text-2xl @sm:text-3xl">Images</Title>
-                          <Popover withArrow width={380}>
-                            <Popover.Target>
-                              <Box
-                                display="inline-block"
-                                style={{ lineHeight: 0.3, cursor: 'pointer' }}
-                                color="white"
-                              >
-                                <IconInfoCircle size={20} />
-                              </Box>
-                            </Popover.Target>
-                            <Popover.Dropdown maw="100%">
-                              <Text size="sm" mb="xs">
-                                Pre-filtered list of the highest rated images post by the community
-                                over the last week
-                              </Text>
-                            </Popover.Dropdown>
-                          </Popover>
-                        </Group>
-
-                        <Link legacyBehavior href="/images" passHref>
-                          <Button
-                            h={34}
-                            component="a"
-                            variant="subtle"
-                            rightSection={<IconArrowRight size={16} />}
-                          >
-                            View all
-                          </Button>
-                        </Link>
+        )}
+        <BrowsingLevelProvider browsingLevel={publicBrowsingLevelsFlag}>
+          {env.NEXT_PUBLIC_UI_HOMEPAGE_IMAGES ? (
+            <Box ref={ref}>
+              <MasonryContainer py={32}>
+                {displayModelsInfiniteFeed && !isLoadingExcludedTags && (
+                  <IsClient>
+                    <Group mb="md" justify="space-between">
+                      <Group>
+                        <Title className="text-2xl @sm:text-3xl">Images</Title>
+                        <Popover withArrow width={380}>
+                          <Popover.Target>
+                            <Box
+                              display="inline-block"
+                              style={{ lineHeight: 0.3, cursor: 'pointer' }}
+                              color="white"
+                            >
+                              <IconInfoCircle size={20} />
+                            </Box>
+                          </Popover.Target>
+                          <Popover.Dropdown maw="100%">
+                            <Text size="sm" mb="xs">
+                              Pre-filtered list of the highest rated images post by the community
+                              over the last week
+                            </Text>
+                          </Popover.Dropdown>
+                        </Popover>
                       </Group>
 
-                      <ImagesInfinite
-                        showAds
-                        filters={{
-                          // Required to override localStorage filters
-                          period: MetricTimeframe.Week,
-                          sort: ImageSort.MostReactions,
-                          types: undefined,
-                          hidden: undefined,
-                          followed: false,
-                          withMeta: true,
-                        }}
-                      />
-                    </IsClient>
-                  )}
-                </MasonryContainer>
-              </Box>
-            ) : (
-              <Box ref={ref}>
-                <MasonryContainer py={32}>
-                  {displayModelsInfiniteFeed && !isLoadingExcludedTags && (
-                    <IsClient>
-                      <Group mb="md" justify="space-between">
-                        <Group>
-                          <Title className="text-2xl @sm:text-3xl">Models</Title>
-                          <Popover withArrow width={380}>
-                            <Popover.Target>
-                              <Box
-                                display="inline-block"
-                                style={{ lineHeight: 0.3, cursor: 'pointer' }}
-                                color="white"
-                              >
-                                <IconInfoCircle size={20} />
-                              </Box>
-                            </Popover.Target>
-                            <Popover.Dropdown maw="100%">
-                              <Text size="sm" mb="xs">
-                                Pre-filtered list of models uploaded by the community that are the
-                                highest rated over the last week
-                              </Text>
-                            </Popover.Dropdown>
-                          </Popover>
-                        </Group>
+                      <Link legacyBehavior href="/images" passHref>
+                        <Button
+                          h={34}
+                          component="a"
+                          variant="subtle"
+                          rightSection={<IconArrowRight size={16} />}
+                        >
+                          View all
+                        </Button>
+                      </Link>
+                    </Group>
 
-                        <Link legacyBehavior href="/models" passHref>
-                          <Button
-                            h={34}
-                            component="a"
-                            variant="subtle"
-                            rightSection={<IconArrowRight size={16} />}
-                          >
-                            View all
-                          </Button>
-                        </Link>
+                    <ImagesInfinite
+                      showAds
+                      filters={{
+                        // Required to override localStorage filters
+                        period: MetricTimeframe.Week,
+                        sort: ImageSort.MostReactions,
+                        types: undefined,
+                        hidden: undefined,
+                        followed: false,
+                        withMeta: true,
+                      }}
+                    />
+                  </IsClient>
+                )}
+              </MasonryContainer>
+            </Box>
+          ) : (
+            <Box ref={ref}>
+              <MasonryContainer py={32}>
+                {displayModelsInfiniteFeed && !isLoadingExcludedTags && (
+                  <IsClient>
+                    <Group mb="md" justify="space-between">
+                      <Group>
+                        <Title className="text-2xl @sm:text-3xl">Models</Title>
+                        <Popover withArrow width={380}>
+                          <Popover.Target>
+                            <Box
+                              display="inline-block"
+                              style={{ lineHeight: 0.3, cursor: 'pointer' }}
+                              color="white"
+                            >
+                              <IconInfoCircle size={20} />
+                            </Box>
+                          </Popover.Target>
+                          <Popover.Dropdown maw="100%">
+                            <Text size="sm" mb="xs">
+                              Pre-filtered list of models uploaded by the community that are the
+                              highest rated over the last week
+                            </Text>
+                          </Popover.Dropdown>
+                        </Popover>
                       </Group>
 
-                      <ModelsInfinite
-                        showAds
-                        disableStoreFilters
-                        filters={{
-                          // excludedImageTagIds: homeExcludedTags.map((tag) => tag.id),
-                          excludedTagIds: homeExcludedTags.map((tag) => tag.id),
-                          // Required to override localStorage filters
-                          period: isProd ? MetricTimeframe.Week : MetricTimeframe.AllTime,
-                          sort: ModelSort.HighestRated,
-                          types: undefined,
-                          collectionId: undefined,
-                          earlyAccess: false,
-                          status: undefined,
-                          checkpointType: undefined,
-                          baseModels: undefined,
-                          hidden: undefined,
-                        }}
-                      />
-                    </IsClient>
-                  )}
-                </MasonryContainer>
-              </Box>
-            )}
-          </BrowsingLevelProvider>
-        </div>
-      )}
+                      <Link legacyBehavior href="/models" passHref>
+                        <Button
+                          h={34}
+                          component="a"
+                          variant="subtle"
+                          rightSection={<IconArrowRight size={16} />}
+                        >
+                          View all
+                        </Button>
+                      </Link>
+                    </Group>
+
+                    <ModelsInfinite
+                      showAds
+                      disableStoreFilters
+                      filters={{
+                        // excludedImageTagIds: homeExcludedTags.map((tag) => tag.id),
+                        excludedTagIds: homeExcludedTags.map((tag) => tag.id),
+                        // Required to override localStorage filters
+                        period: isProd ? MetricTimeframe.Week : MetricTimeframe.AllTime,
+                        sort: ModelSort.HighestRated,
+                        types: undefined,
+                        collectionId: undefined,
+                        earlyAccess: false,
+                        status: undefined,
+                        checkpointType: undefined,
+                        baseModels: undefined,
+                        hidden: undefined,
+                      }}
+                    />
+                  </IsClient>
+                )}
+              </MasonryContainer>
+            </Box>
+          )}
+        </BrowsingLevelProvider>
+      </div>
     </>
   );
 }

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -108,7 +108,12 @@ export function Home() {
             })}
           </BrowsingLevelProvider>
         )}
-        <BrowsingLevelProvider browsingLevel={publicBrowsingLevelsFlag}>
+        {/* Gated behind !isLoading so the lazy feed's useInView ref does not
+            mount during home-block load — otherwise it can fire inView early,
+            start the infinite-feed queries concurrently, and shift when the
+            skeleton swaps to real blocks. Restores main's load sequencing. */}
+        {!isLoading && (
+          <BrowsingLevelProvider browsingLevel={publicBrowsingLevelsFlag}>
           {env.NEXT_PUBLIC_UI_HOMEPAGE_IMAGES ? (
             <Box ref={ref}>
               <MasonryContainer py={32}>
@@ -226,7 +231,8 @@ export function Home() {
               </MasonryContainer>
             </Box>
           )}
-        </BrowsingLevelProvider>
+          </BrowsingLevelProvider>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Problem

Lighthouse CI measures the authed home page (`/`) at **CLS 0.977** ("poor" is >0.25). `/models` (0.134) and `/generate` (0.296) are fine, so it is home-specific.

Ruled out via the LH audits: web fonts (`font-display` perfect) and unsized images (`unsized-images` = 0). It is block-level content reflow.

## What this PR ships (two fixes)

### 1. Reserve home-block height during the block-list load (`src/pages/home/index.tsx` + `HomeBlockSkeleton.tsx`)
While `homeBlock.getHomeBlocks` loads, the page rendered `<PageLoader/>` (`absolute inset-0` → **zero layout height**). When the list resolved, the whole content tree popped in from 0, shifting the content container down. Replaced with a deterministic skeleton block layout in the same `.container`, reusing the existing `.grid` geometry the real blocks already render. SSR-safe (no client-only state).

### 2. Defer the NavTidyNotice popover open until layout settles (`src/components/Alerts/NavTidyNotice.tsx`)
A live layout-shift observer on the authed preview showed the **single largest shift was the `NavTidyNotice` popover** (~0.526): it renders `opened` as soon as `ready`+settings resolve, while the content above is still settling, so its dropdown paints then gets repositioned. Deferred `opened` to a short post-mount timeout so it paints once at its final position. **This is the proven win** — it dropped `/models` CLS from 0.134 → ~0.05 (stable across builds) and removed the popover's 0.526 shift in the instrumented probe.

## Verification (lhci-bot, authed ci-smoke-gold, desktop, median of 5)

| Build | commit | `/` CLS | `/models` CLS |
|---|---|---|---|
| baseline (main) | — | **0.977** | 0.134 |
| skeleton only | `1f58f6b` | 0.765 | 0.134 |
| + popover defer | `1f01b50` | 0.822 | **0.050** |
| this PR (final) | `00893fa` | **0.588** | 0.051 |

`/` improved 0.977 → 0.588, but **the home number is very high-variance** across builds (0.59–1.05) while `/models` is stable-low — see open items. An instrumented `LayoutShift` observer on the live preview measures the **deterministic** home shift at **~0.23** (down from ~0.66 with the popover); the extra in the LH median comes from an intermittent shifter under build-pool contention I could not reproduce.

## Open items (honest)

- **Announcement banner not addressed.** The remaining deterministic home shift (~0.115) is the announcement banner inserting ~160px post-hydration (it's gated to render only after hydration to avoid a `dismissed`-set hydration mismatch). I attempted an SSR-seed-keyed height reservation; it **oscillated** (the dynamic-import gap collapsed/re-expanded the slot) and made the LH number worse, so I **reverted it**. A correct fix needs reservation at the carousel level (no lazy-import gap) — recommend as a follow-up.
- **Home LH CLS is non-deterministic** on the contended single-replica preview pod; the median-of-5 is noisy for home specifically.
- Ad slots were investigated and are **not** a factor for this measurement (authed gold member → `adsEnabled=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
