### PR TITLE
security(app-blocks): gate git-push updates behind moderator review (no trust-on-push)

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -19,12 +19,12 @@ authenticated via short-lived RS256 JWTs scoped to a single block install.
 
 ## Tables
 
-| Table | Purpose | Notable invariants |
-|---|---|---|
-| `app_blocks` | Registry of every block across every app | `status='pending'` until moderated; `trustTier` and `renderMode` are server-controlled |
-| `model_block_installs` | Per-(model, slot) installs | Unique on `(model_id, app_block_id, slot_id)`; max 3 installs per slot |
-| `block_user_settings` | Per-(viewer, instance) prefs (Phase 2) | CASCADE on install delete + GDPR user delete |
-| `platform_default_blocks` | Promoted defaults | Filtered by `target_model_types` + content rating + ordered by `priority` |
+| Table                     | Purpose                                  | Notable invariants                                                                     |
+| ------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| `app_blocks`              | Registry of every block across every app | `status='pending'` until moderated; `trustTier` and `renderMode` are server-controlled |
+| `model_block_installs`    | Per-(model, slot) installs               | Unique on `(model_id, app_block_id, slot_id)`; max 3 installs per slot                 |
+| `block_user_settings`     | Per-(viewer, instance) prefs (Phase 2)   | CASCADE on install delete + GDPR user delete                                           |
+| `platform_default_blocks` | Promoted defaults                        | Filtered by `target_model_types` + content rating + ordered by `priority`              |
 
 ## Tokens
 
@@ -42,28 +42,28 @@ See `src/shared/constants/block-scope.constants.ts`. Each block scope maps
 to an OAuth bitmask bit (registration-time gate), plus a context-binding
 check at request time (`enforceContextBinding`).
 
-| Scope | Bind | Notes |
-|---|---|---|
-| `models:read:self` | `query.id == ctx.modelId` | |
-| `media:read:owned` | non-anon `sub` | |
-| `buzz:read:self` | non-anon `sub` | |
-| `social:tip:self` | non-anon `sub` | |
-| `user:read:self` | non-anon `sub` | `/api/v1/blocks/me` |
-| `ai:write:budgeted` | positive `buzzBudget` | |
+| Scope                            | Bind                                              | Notes                             |
+| -------------------------------- | ------------------------------------------------- | --------------------------------- |
+| `models:read:self`               | `query.id == ctx.modelId`                         |                                   |
+| `media:read:owned`               | non-anon `sub`                                    |                                   |
+| `buzz:read:self`                 | non-anon `sub`                                    |                                   |
+| `social:tip:self`                | non-anon `sub`                                    |                                   |
+| `user:read:self`                 | non-anon `sub`                                    | `/api/v1/blocks/me`               |
+| `ai:write:budgeted`              | positive `buzzBudget`                             |                                   |
 | `block:settings:read` / `:write` | `query.blockInstanceId == claims.blockInstanceId` | + caller-is-installer at issuance |
 
 Unknown scopes are rejected at runtime (deny-by-default in middleware).
 
 ## Routes
 
-| Route | Auth | Scope required |
-|---|---|---|
-| `POST /api/v1/block-tokens` | same-origin session | — (any approved install) |
-| `GET /api/v1/block-tokens/jwks` | public | — |
-| `GET /api/v1/blocks/me` | block JWT | `user:read:self` |
-| `GET /api/v1/models/[id]` | session OR block JWT | `models:read:self` (block path) |
-| `POST /api/v1/developer/block-manifests` | `JOB_TOKEN` | — |
-| `POST /api/internal/blocks/workflow-completed` | `JOB_TOKEN` + Flipt | — |
+| Route                                          | Auth                 | Scope required                  |
+| ---------------------------------------------- | -------------------- | ------------------------------- |
+| `POST /api/v1/block-tokens`                    | same-origin session  | — (any approved install)        |
+| `GET /api/v1/block-tokens/jwks`                | public               | —                               |
+| `GET /api/v1/blocks/me`                        | block JWT            | `user:read:self`                |
+| `GET /api/v1/models/[id]`                      | session OR block JWT | `models:read:self` (block path) |
+| `POST /api/v1/developer/block-manifests`       | `JOB_TOKEN`          | —                               |
+| `POST /api/internal/blocks/workflow-completed` | `JOB_TOKEN` + Flipt  | —                               |
 
 ## Feature flag
 
@@ -146,6 +146,45 @@ out of the request path on every generation.
 
 Phase 2/3 postMessage surfaces (`PURCHASE_BUZZ`, `NAVIGATE`, `TRACK_EVENT`)
 are not implemented in v1. The SDK should detect their absence gracefully.
+
+## Publish / review / deploy lifecycle (no trust on push)
+
+The build + deploy of new iframe code is gated entirely on **moderator
+approval**, never on a git push:
+
+1. **submitVersion** (dev) — uploads a ZIP bundle. Validates the manifest,
+   inserts an `app_block_publish_requests` row `status='pending'`, pushes the
+   bundle to the _review_ org (`civitai-apps-review/<slug>`, NOT the build
+   org). Nothing builds or deploys.
+2. **approveRequest** (moderator, `/apps/review`) — re-validates the manifest,
+   creates/updates the `app_blocks` row, commits the reviewed bundle to the
+   _build_ org (`civitai-apps/<slug>:main`), **stamps the committed sha onto
+   `app_blocks.current_version_sha`**, finalises the publish request
+   (`status='approved'`, `forgejo_commit_sha=<sha>`), and **triggers the Tekton
+   build itself**. → build-callback → apply Job → deploy.
+3. **git-push webhook** (`/api/internal/blocks/git-push`) — fires on every push
+   to `civitai-apps/<slug>:main`, including the moderator's commit from (2).
+   It **never auto-approves and never triggers a build**:
+   - If the pushed sha is the moderator-approved one
+     (`sha === current_version_sha`, or an `approved` publish request matches the
+     sha as a race backstop) → no-op; the deploy is already in flight from (2).
+   - Any **other** push (a direct push to the build repo by someone with Forgejo
+     write access — a _different trust domain_ than civitai moderation) is
+     treated as unreviewed: it is recorded as a `pending` publish request for the
+     pushed sha (the same review artifact a submitVersion produces) and **does
+     not deploy**. A moderator must approve it via (2) before it ships.
+
+This closes the trust-on-push hole: a signature-valid push can no longer ship
+arbitrary iframe code to a live, mod-page-embedded block. The HMAC signature,
+the `civitai-apps` org/repo gate, the `app-blocks-enabled` flag gate, and
+manifest validation are all still enforced on the webhook.
+
+> Note: a webhook-recorded pending request has empty bundle pointers
+> (`bundle_key=''`, `bundle_sha256=''`) — the webhook only receives the push
+> event + the manifest, not the ZIP. The reviewable artifact is the Forgejo repo
+> at `forgejo_commit_sha`; mods browse it directly. `approveRequest` approves
+> against the existing `app_blocks` row + re-commits the (already-present) repo
+> contents.
 
 ## Publisher-side notes
 

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -9,29 +9,37 @@ import {
   BlockManifestValidator,
   type AppContext,
 } from '~/server/services/block-manifest-validator.service';
-import {
-  FORGEJO_ORG,
-  getRawFile,
-  setCommitStatus,
-} from '~/server/services/blocks/forgejo.service';
-import { triggerBuild } from '~/server/services/blocks/apps-pipeline.service';
+import { FORGEJO_ORG, getRawFile, setCommitStatus } from '~/server/services/blocks/forgejo.service';
 
 /**
  * POST /api/internal/blocks/git-push
  *
  * Forgejo push-event webhook for `civitai-apps/*`. Verifies the HMAC
  * signature (FORGEJO_WEBHOOK_SECRET), pulls the block.manifest.json out
- * of the just-pushed commit, validates it against the canonical schema,
- * and (on success) upserts the app_blocks row + kicks off the Tekton
- * build pipeline on dc-02-a.
+ * of the just-pushed commit, and validates it against the canonical schema.
+ *
+ * NO TRUST ON PUSH (v1 mod-review gate): a signature-valid push does NOT
+ * by itself approve or deploy anything. The build + deploy is triggered by
+ * `approveRequest` (the moderator path) when a mod approves a publish
+ * request; that approve stamps the approved sha onto
+ * `app_blocks.current_version_sha` BEFORE its commit fires this webhook, so:
+ *   - sha === app_blocks.current_version_sha → the moderator-approved,
+ *     in-flight deploy → no-op here (approveRequest already triggered it).
+ *   - any other sha → an UNREVIEWED direct push to civitai-apps/<slug> →
+ *     recorded as a `pending` publish request and left for moderator review.
+ *     It never auto-approves and never deploys.
+ *
+ * Forgejo write access is a different trust domain than civitai moderation,
+ * so this gate is what stops anyone with repo write from shipping arbitrary
+ * iframe code to a live, mod-page-embedded block.
  *
  * Manifest validation failures surface as commit-status `failure` on
  * Forgejo so the developer sees the error in the repo view, no email
  * trip-wire needed.
  *
  * Idempotency: re-deliveries of the same (slug, sha) are safe — the
- * upsert is by (appId, blockId) primary key, and triggerBuild creates
- * a PipelineRun named after the SHA, which Tekton dedups.
+ * approved-deploy case is a stable no-op, and the pending-review case
+ * refreshes the existing (slug, sha) pending row rather than stacking.
  */
 
 // HMAC verification requires raw request bytes — Forgejo signs the exact
@@ -99,10 +107,7 @@ const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;
  * others. Without this gate a signature-valid push to a same-slug repo in a
  * different org would drive a build + auto-approve of the canonical row.
  */
-export function parseExpectedRepo(
-  fullName: unknown,
-  expectedOrg: string
-): { slug: string } | null {
+export function parseExpectedRepo(fullName: unknown, expectedOrg: string): { slug: string } | null {
   if (typeof fullName !== 'string' || !fullName.includes('/')) return null;
   const [org, ...slugParts] = fullName.split('/');
   if (org !== expectedOrg) return null;
@@ -182,11 +187,48 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       id: true,
       appId: true,
       blockId: true,
+      currentVersionSha: true,
       app: { select: { id: true, allowedScopes: true, allowedOrigins: true } },
     },
   });
   if (!appBlock) {
     res.status(404).json({ error: 'app_blocks row not found — re-run submitApp' });
+    return;
+  }
+
+  // SECURITY (no trust-on-push): `approveRequest` is the ONLY path that may
+  // ship new iframe code to a live block. When a moderator approves a publish
+  // request it commits the reviewed bundle to civitai-apps/<slug>, stamps the
+  // resulting sha onto app_blocks.current_version_sha, AND triggers the Tekton
+  // build itself. The push it makes lands here too — but it is already the
+  // approved, in-flight deploy, so this webhook treats `sha ===
+  // appBlock.currentVersionSha` as a no-op (the build is already running).
+  //
+  // ANY OTHER push to civitai-apps/<slug>:main is, by construction, NOT
+  // moderator-approved (Forgejo write access is a different trust domain than
+  // civitai moderation). Such a push must NEVER auto-approve and NEVER deploy:
+  // we record it as a `pending` publish request — the same review artifact a
+  // submitVersion produces — and stop. A moderator then approves the new sha
+  // through the existing approveRequest → build → deploy path. This is the v1
+  // mod-review gate the original handler comment promised ("v0 auto-approves on
+  // valid push; v1 gates this behind a queue").
+  if (sha === appBlock.currentVersionSha) {
+    res.status(200).json({ ok: true, slug, sha, deploy: 'already-approved' });
+    return;
+  }
+  // Race backstop: approveRequest stamps current_version_sha and finalises the
+  // publish request (status='approved', forgejoCommitSha=sha) right after its
+  // commit — but its commit fires THIS webhook, so the webhook can in principle
+  // arrive in the narrow window before those writes land. An `approved` publish
+  // request for (slug, sha) is the same durable proof of moderator approval, so
+  // treat it as the in-flight approved deploy too (no-op). A direct attacker
+  // push has neither marker.
+  const approvedForThisSha = await dbRead.appBlockPublishRequest.findFirst({
+    where: { slug, status: 'approved', forgejoCommitSha: sha },
+    select: { id: true },
+  });
+  if (approvedForThisSha) {
+    res.status(200).json({ ok: true, slug, sha, deploy: 'already-approved' });
     return;
   }
 
@@ -296,68 +338,160 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       slug,
       sha,
       stage: 'iframe-src-mismatch',
-      details: `manifest.iframe.src="${parsedManifest.iframe?.src ?? ''}" but expected "${expectedSrc}"`,
+      details: `manifest.iframe.src="${
+        parsedManifest.iframe?.src ?? ''
+      }" but expected "${expectedSrc}"`,
     });
     res.status(400).json({ error: 'iframe.src mismatch' });
     return;
   }
 
-  // Upsert app_blocks with the new manifest + sha. v0 auto-approves on
-  // valid push; v1 (W1 mod review) gates this behind a queue.
-  await dbWrite.appBlock.update({
-    where: { id: appBlock.id },
-    data: {
+  // We only reach here for a push whose sha is NOT the moderator-approved,
+  // in-flight deploy (that case returned above). By construction this is an
+  // UNREVIEWED push straight to civitai-apps/<slug>:main. Do NOT touch
+  // app_blocks.status and do NOT trigger a build/deploy. Instead record (or
+  // refresh) a `pending` publish request for this sha so a moderator can
+  // review it via the existing /apps/review → approveRequest path, which is
+  // the only thing that may ship it to the live block.
+  //
+  // The manifest validated above is the source of truth for slug / version.
+  const reviewVersion = (parsedManifest as { version?: string }).version ?? sha.slice(0, 7);
+  try {
+    await recordPendingFromPush({
+      slug,
+      sha,
+      appBlockId: appBlock.id,
       manifest: manifest as object,
-      status: 'approved',
-      // The migration that adds current_version_sha / current_version_deployed_at
-      // / repo_url ships alongside this handler (Phase 4 SQL); these field
-      // names match the @map directives that get added.
-      currentVersionSha: sha,
-      version: (parsedManifest as { version?: string }).version ?? sha.slice(0, 7),
-    },
-  });
+      version: reviewVersion,
+    });
+  } catch (e) {
+    notifyModsOfWebhookFailure({
+      slug,
+      sha,
+      stage: 'record-pending-review',
+      details: `could not record pending review request: ${String(e).slice(0, 200)}`,
+    });
+    res
+      .status(500)
+      .json({ error: 'Could not record pending review request', detail: String(e).slice(0, 240) });
+    return;
+  }
 
-  // Pending status on Forgejo while Tekton runs.
+  // Surface the gate in Forgejo's commit view so a developer who pushed
+  // directly sees WHY nothing deployed.
   await setCommitStatusSafe({
     slug,
     sha,
     state: 'pending',
-    context: 'civitai/build',
-    description: 'Build queued',
+    context: 'civitai/review',
+    description: 'Awaiting moderator review — not deployed',
   });
 
-  // Trigger the cross-cluster Tekton build.
-  try {
-    const callbackUrl = buildCallbackUrl();
-    await triggerBuild({ slug, sha, appBlockId: appBlock.id, callbackUrl });
-  } catch (e) {
-    await setCommitStatusSafe({
-      slug,
-      sha,
-      state: 'failure',
-      context: 'civitai/build',
-      description: `Trigger failed: ${String(e).slice(0, 80)}`,
+  // Ping mods that an unreviewed push is waiting in the queue.
+  notifyModsOfWebhookFailure({
+    slug,
+    sha,
+    stage: 'unreviewed-push',
+    details:
+      'Direct push to the canonical build repo recorded as a PENDING review request. ' +
+      'It will NOT build or deploy until a moderator approves it via /apps/review.',
+  });
+
+  res.status(202).json({ ok: true, slug, sha, status: 'pending-review', deployed: false });
+});
+
+/**
+ * Record (or refresh) a `pending` publish request for an unreviewed push to
+ * civitai-apps/<slug>:main. This is the no-trust-on-push gate: a direct push
+ * cannot auto-approve or deploy, so we capture it as the same kind of review
+ * artifact a submitVersion produces and leave it for a moderator.
+ *
+ * The bundle bytes are NOT available to the webhook (Forgejo only hands us the
+ * push event + the manifest at the sha), so this row's bundle pointers are left
+ * empty and a `forgejoCommitSha` is stored instead — a moderator reviews the
+ * code in the Forgejo repo directly. `approveRequest` already supports
+ * approving a `pending` request against the existing app_blocks row.
+ *
+ * Idempotent at the (slug, sha) level: a re-delivery of the same push event
+ * refreshes the existing pending row rather than stacking duplicates. Only ONE
+ * pending request per slug is allowed (matches the submitVersion invariant +
+ * the partial unique index), so a newer unreviewed sha supersedes an older
+ * still-pending one.
+ */
+async function recordPendingFromPush(args: {
+  slug: string;
+  sha: string;
+  appBlockId: string;
+  manifest: object;
+  version: string;
+}): Promise<void> {
+  const { newUlid } = await import('~/server/utils/app-block-ids');
+
+  // Already captured this exact (slug, sha) as pending? Refresh + done.
+  const existingForSha = await dbWrite.appBlockPublishRequest.findFirst({
+    where: { slug: args.slug, status: 'pending', forgejoCommitSha: args.sha },
+    select: { id: true },
+  });
+  if (existingForSha) {
+    await dbWrite.appBlockPublishRequest.update({
+      where: { id: existingForSha.id },
+      data: { manifest: args.manifest, version: args.version, appBlockId: args.appBlockId },
     });
-    notifyModsOfWebhookFailure({
-      slug,
-      sha,
-      stage: 'trigger-build',
-      details: `triggerBuild() failed: ${String(e).slice(0, 200)}`,
-    });
-    res.status(500).json({ error: 'Build trigger failed', detail: String(e).slice(0, 240) });
     return;
   }
 
-  res.status(200).json({ ok: true, slug, sha });
-});
+  // Supersede any OTHER still-pending request for this slug (older sha or a
+  // dev submitVersion) so the partial unique index (one pending per slug)
+  // doesn't reject the insert and the queue shows the newest unreviewed sha.
+  await dbWrite.appBlockPublishRequest.updateMany({
+    where: { slug: args.slug, status: 'pending' },
+    data: { status: 'withdrawn' },
+  });
 
-function buildCallbackUrl(): string {
-  // The callback URL must be reachable from dc-02-a Tekton — that's the
-  // public civitai-web URL of the env civitai-web is currently running in.
-  // Use NEXTAUTH_URL (already in env, kept current per deployment).
-  const base = (process.env.NEXTAUTH_URL ?? '').replace(/\/$/, '');
-  if (!base) throw new Error('NEXTAUTH_URL not configured — cannot build callback URL');
-  return `${base}/api/internal/blocks/build-callback`;
+  const ownerUserId = await resolvePushOwnerUserId(args.appBlockId);
+  const emptyFileSummary = { files: [], added: [], removed: [], changed: [] };
+  const manifestDiffSummary = {
+    kind: 'first-version' as const,
+    fields: Object.keys(args.manifest as Record<string, unknown>).sort(),
+  };
+
+  await dbWrite.appBlockPublishRequest.create({
+    data: {
+      id: `pubreq_${newUlid()}`,
+      appBlockId: args.appBlockId,
+      slug: args.slug,
+      submittedByUserId: ownerUserId,
+      version: args.version,
+      manifest: args.manifest,
+      // No bundle: the webhook doesn't receive the ZIP. The Forgejo repo at
+      // forgejoCommitSha IS the reviewable artifact; mods browse it directly.
+      bundleKey: '',
+      bundleSha256: '',
+      bundleSizeBytes: BigInt(0),
+      fileSummary: emptyFileSummary,
+      manifestDiffSummary,
+      status: 'pending',
+      forgejoCommitSha: args.sha,
+    },
+  });
+}
+
+/**
+ * Attribute the pending-review row to the app owner (the OauthClient.userId),
+ * falling back to the app block's own app relation. submittedByUserId is a
+ * required, FK-constrained column — we can't leave it null — and the app owner
+ * is the most meaningful actor for an unreviewed push to their repo.
+ */
+async function resolvePushOwnerUserId(appBlockId: string): Promise<number> {
+  const row = await dbRead.appBlock.findUnique({
+    where: { id: appBlockId },
+    select: { app: { select: { userId: true } } },
+  });
+  const userId = row?.app?.userId;
+  if (typeof userId !== 'number') {
+    throw new Error(`could not resolve owner userId for appBlock ${appBlockId}`);
+  }
+  return userId;
 }
 
 async function setCommitStatusSafe(args: Parameters<typeof setCommitStatus>[0]): Promise<void> {

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -33,6 +33,7 @@ const {
   mockS3Send,
   mockBundleBuffer,
   mockForgejo,
+  mockTriggerBuild,
   mockUlidSeq,
   mockNewUlid,
 } = vi.hoisted(() => {
@@ -52,7 +53,10 @@ const {
       oauthClient: { findUnique: vi.fn() },
     },
     mockDbWrite: {
-      appBlockPublishRequest: { create: vi.fn(), update: vi.fn() },
+      // `updateMany` added (no-trust-on-push fix): approveRequest now supersedes
+      // any stray pending review request the git-push webhook may have parked for
+      // the slug while racing the approve commit.
+      appBlockPublishRequest: { create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
       appBlock: { create: vi.fn(), update: vi.fn() },
       // `update` added 2026-06-02 (audit A1 fix): approveRequest now re-caps
       // the app-block OauthClient's allowedScopes to the manifest-derived
@@ -70,8 +74,15 @@ const {
       getBlobContent: vi.fn(),
       getRepo: vi.fn(),
       ensureReviewRepo: vi.fn(),
+      // setCommitStatus added (no-trust-on-push fix): approveRequest now drives
+      // the build trigger itself + pends/marks the commit status.
+      setCommitStatus: vi.fn(),
       reviewRepoUrl: vi.fn((slug: string) => `https://forgejo.example/civitai-apps-review/${slug}`),
     },
+    // apps-pipeline.service.triggerBuild — approveRequest now triggers the
+    // Tekton build directly (the git-push webhook no longer does). Mocked so
+    // approve tests don't reach the real cross-cluster HTTP client.
+    mockTriggerBuild: vi.fn(async () => ({ name: 'pipelinerun-mock' })),
     mockUlidSeq: ulidSeq,
     mockNewUlid: vi.fn(() => {
       ulidSeq.i += 1;
@@ -96,6 +107,13 @@ vi.mock('~/utils/bundle-s3', () => ({
 // resolves the path relative to the IMPORTING module, so we mock the resolved
 // absolute id that the service sees.
 vi.mock('~/server/services/blocks/forgejo.service', () => mockForgejo);
+
+// approveRequest does `await import('./apps-pipeline.service')` to trigger the
+// Tekton build directly (no-trust-on-push: the git-push webhook no longer
+// triggers builds). Mock the resolved absolute id the service sees.
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  triggerBuild: mockTriggerBuild,
+}));
 
 vi.mock('~/server/utils/app-block-ids', () => ({
   newUlid: mockNewUlid,
@@ -164,7 +182,7 @@ async function makeValidBundle(over: Record<string, unknown> = {}): Promise<Buff
   return makeBundle({
     [MANIFEST_PATH]: JSON.stringify(manifest(over)),
     'index.html': '<!doctype html><html><body>hi</body></html>',
-    'Dockerfile': 'FROM node:20',
+    Dockerfile: 'FROM node:20',
   });
 }
 
@@ -193,6 +211,15 @@ beforeEach(() => {
   mockS3Send.mockReset();
   mockBundleBuffer.current = null;
   mockNewUlid.mockClear();
+
+  // Defaults for the no-trust-on-push surfaces approveRequest now drives.
+  // (The reset loop above strips implementations, so these would otherwise
+  // return undefined and break `await`/`.catch()` chains in the service.)
+  mockForgejo.setCommitStatus.mockResolvedValue(undefined);
+  mockTriggerBuild.mockClear();
+  mockTriggerBuild.mockResolvedValue({ name: 'pipelinerun-mock' });
+  mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+  mockDbWrite.appBlock.update.mockResolvedValue(undefined);
 
   // Default: no pending conflict, no existing app block, user lookup OK.
   mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
@@ -357,9 +384,9 @@ describe('submitVersion', () => {
   it('rejects when iframe.src is missing', async () => {
     const { submitVersion } = await import('../publish-request.service');
     const buf = await makeValidBundle({ iframe: { minHeight: 300 } });
-    await expect(
-      submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })
-    ).rejects.toThrow(/manifest\.iframe\.src must be a string/);
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })).rejects.toThrow(
+      /manifest\.iframe\.src must be a string/
+    );
   });
 
   it('rejects HTTP iframe.src as mixed content', async () => {
@@ -367,9 +394,9 @@ describe('submitVersion', () => {
     const buf = await makeValidBundle({
       iframe: { src: 'http://hello.civit.ai/', minHeight: 300 },
     });
-    await expect(
-      submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })
-    ).rejects.toThrow(/must use https.*mixed content/i);
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })).rejects.toThrow(
+      /must use https.*mixed content/i
+    );
   });
 
   it('rejects malformed iframe.src URL', async () => {
@@ -377,19 +404,19 @@ describe('submitVersion', () => {
     const buf = await makeValidBundle({
       iframe: { src: 'not a url', minHeight: 300 },
     });
-    await expect(
-      submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })
-    ).rejects.toThrow(/is not a valid URL/);
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })).rejects.toThrow(
+      /is not a valid URL/
+    );
   });
 
-  it('rejects iframe.src hostname that doesn\'t match the per-app subdomain', async () => {
+  it("rejects iframe.src hostname that doesn't match the per-app subdomain", async () => {
     const { submitVersion } = await import('../publish-request.service');
     const buf = await makeValidBundle({
       iframe: { src: 'https://attacker.example/', minHeight: 300 },
     });
-    await expect(
-      submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })
-    ).rejects.toThrow(/host must be "hello\.civit\.ai"/);
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })).rejects.toThrow(
+      /host must be "hello\.civit\.ai"/
+    );
   });
 
   it('rejects leftover hackathon block-host URL pattern', async () => {
@@ -403,9 +430,9 @@ describe('submitVersion', () => {
         minHeight: 300,
       },
     });
-    await expect(
-      submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })
-    ).rejects.toThrow(/host must be "hello\.civit\.ai"/);
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })).rejects.toThrow(
+      /host must be "hello\.civit\.ai"/
+    );
   });
 
   it('rejects iframe.src with a non-root pathname', async () => {
@@ -416,9 +443,9 @@ describe('submitVersion', () => {
     const buf = await makeValidBundle({
       iframe: { src: 'https://hello.civit.ai/hello/', minHeight: 300 },
     });
-    await expect(
-      submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })
-    ).rejects.toThrow(/must point at the subdomain root.*pathname "\/hello\/"/);
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 42 })).rejects.toThrow(
+      /must point at the subdomain root.*pathname "\/hello\/"/
+    );
   });
 
   it('accepts the canonical iframe.src shape (https + matching subdomain + root path)', async () => {
@@ -535,7 +562,7 @@ describe('submitVersion', () => {
 
   it('Discord notify is invoked with the right shape on submission', async () => {
     const { submitVersion } = await import('../publish-request.service');
-    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 } as Response));
     vi.stubGlobal('fetch', fetchSpy);
 
     const buf = await makeValidBundle();
@@ -608,9 +635,9 @@ describe('withdrawRequest', () => {
       status: 'pending',
       submittedByUserId: 1,
     });
-    await expect(
-      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
-    ).rejects.toThrow(/can only withdraw your own/);
+    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
+      /can only withdraw your own/
+    );
   });
 
   it('throws for already-approved', async () => {
@@ -620,9 +647,9 @@ describe('withdrawRequest', () => {
       status: 'approved',
       submittedByUserId: 42,
     });
-    await expect(
-      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
-    ).rejects.toThrow(/cannot withdraw a request in status approved/);
+    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
+      /cannot withdraw a request in status approved/
+    );
   });
 
   it('throws for already-rejected', async () => {
@@ -632,17 +659,17 @@ describe('withdrawRequest', () => {
       status: 'rejected',
       submittedByUserId: 42,
     });
-    await expect(
-      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
-    ).rejects.toThrow(/cannot withdraw a request in status rejected/);
+    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
+      /cannot withdraw a request in status rejected/
+    );
   });
 
   it('throws when the request is not found', async () => {
     const { withdrawRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
-    await expect(
-      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
-    ).rejects.toThrow(/not found/);
+    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
+      /not found/
+    );
   });
 
   // H-2 regression — withdraw does NOT delete the S3 bundle. Long-tail
@@ -869,9 +896,7 @@ describe('listApprovedRequests', () => {
 
   it('attaches reviewRepoUrl per row so the read-only modal can link to Forgejo', async () => {
     const { listApprovedRequests } = await import('../publish-request.service');
-    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
-      row({ slug: 'hello-world' }),
-    ]);
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([row({ slug: 'hello-world' })]);
     const result = await listApprovedRequests({});
     expect(result.items[0].reviewRepoUrl).toBe(
       'https://forgejo.example/civitai-apps-review/hello-world'
@@ -962,9 +987,7 @@ describe('listRejectedRequests', () => {
 
   it('attaches reviewRepoUrl per row so the read-only modal can link to Forgejo', async () => {
     const { listRejectedRequests } = await import('../publish-request.service');
-    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
-      row({ slug: 'spammy' }),
-    ]);
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([row({ slug: 'spammy' })]);
     const result = await listRejectedRequests({});
     expect(result.items[0].reviewRepoUrl).toBe(
       'https://forgejo.example/civitai-apps-review/spammy'
@@ -1027,6 +1050,26 @@ describe('approveRequest', () => {
     expect(mockDbWrite.appBlock.create).toHaveBeenCalledOnce();
     expect(mockForgejo.commitFiles).toHaveBeenCalledOnce();
     expect(mockDbWrite.appBlockPublishRequest.update).toHaveBeenCalledOnce();
+
+    // no-trust-on-push: the FIRST DEPLOY is unaffected, but the build is now
+    // triggered by approveRequest itself (the git-push webhook no longer
+    // triggers builds). The committed sha is stamped onto current_version_sha
+    // (the webhook's approval marker) and the Tekton build is kicked.
+    expect(mockDbWrite.appBlock.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { currentVersionSha: 'commit_sha_abc' } })
+    );
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+    expect(mockTriggerBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'hello', sha: 'commit_sha_abc' })
+    );
+    // Any stray pending review request the webhook may have parked for the slug
+    // while racing this approve is superseded (withdrawn).
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ slug: 'hello', status: 'pending' }),
+        data: { status: 'withdrawn' },
+      })
+    );
 
     // OauthClient gets the slug-scoped allowedOrigins + a deterministic id
     // (post C-2 fix). The deterministic id is what makes retries idempotent.
@@ -1114,8 +1157,23 @@ describe('approveRequest', () => {
     expect(mockDbWrite.oauthClient.create).not.toHaveBeenCalled();
     expect(mockForgejo.createRepoFromTemplate).not.toHaveBeenCalled();
     expect(mockForgejo.ensurePushWebhook).not.toHaveBeenCalled();
-    expect(mockDbWrite.appBlock.update).toHaveBeenCalledOnce();
+    // Two appBlock.update calls now: (1) refresh manifest/version/scopes, then
+    // (2) stamp current_version_sha = the committed sha (no-trust-on-push: this
+    // is the moderator-approval marker the git-push webhook keys its gate off).
+    expect(mockDbWrite.appBlock.update).toHaveBeenCalledTimes(2);
+    const shaStamp = mockDbWrite.appBlock.update.mock.calls.find(
+      (c: any[]) => c[0]?.data?.currentVersionSha !== undefined
+    );
+    expect(shaStamp?.[0]).toMatchObject({
+      where: { id: 'apb_existing' },
+      data: { currentVersionSha: 'commit_sha_abc' },
+    });
     expect(mockForgejo.commitFiles).toHaveBeenCalledOnce();
+    // approveRequest now triggers the Tekton build itself (the webhook no
+    // longer does) with the committed sha + the existing app block id.
+    expect(mockTriggerBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'hello', sha: 'commit_sha_abc', appBlockId: 'apb_existing' })
+    );
 
     // A1 fix: the existing OauthClient's ceiling is re-capped to the derived
     // bitmask + forced to grants:[] on every subsequent approve — self-heals
@@ -1134,7 +1192,9 @@ describe('approveRequest', () => {
     const { approveRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
     mockDbRead.appBlock.findFirst.mockResolvedValue(null);
-    mockForgejo.createRepoFromTemplate.mockRejectedValue(new Error('Forgejo 500 Internal Server Error'));
+    mockForgejo.createRepoFromTemplate.mockRejectedValue(
+      new Error('Forgejo 500 Internal Server Error')
+    );
 
     await expect(
       approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 })
@@ -1337,10 +1397,21 @@ describe('approveRequest', () => {
 
     expect(result.isFirstVersion).toBe(true);
     expect(result.appBlockId).toBe('apb_collision');
-    // The recovery path refreshes the existing AppBlock's manifest so the
-    // row converges to the new content.
-    expect(mockDbWrite.appBlock.update).toHaveBeenCalledOnce();
+    // Two appBlock.update calls: (1) the P2002 recovery path refreshes the
+    // existing AppBlock's manifest so the row converges to the new content,
+    // then (2) step 6 stamps current_version_sha = the committed sha.
+    expect(mockDbWrite.appBlock.update).toHaveBeenCalledTimes(2);
+    const shaStamp = mockDbWrite.appBlock.update.mock.calls.find(
+      (c: any[]) => c[0]?.data?.currentVersionSha !== undefined
+    );
+    expect(shaStamp?.[0]).toMatchObject({
+      where: { id: 'apb_collision' },
+      data: { currentVersionSha: 'commit_sha_abc' },
+    });
     expect(mockForgejo.commitFiles).toHaveBeenCalledOnce();
+    expect(mockTriggerBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ sha: 'commit_sha_abc', appBlockId: 'apb_collision' })
+    );
   });
 
   // C-2 fix verification — non-P2002 errors are NOT swallowed. If the
@@ -1586,9 +1657,7 @@ describe('backfillPublishRequest', () => {
       appBlockId: 'apb_existing',
       bundleSizeBytes: 12345n,
     });
-    mockForgejo.listRepoTree.mockResolvedValue(
-      new Map([['block.manifest.json', 'blob1']])
-    );
+    mockForgejo.listRepoTree.mockResolvedValue(new Map([['block.manifest.json', 'blob1']]));
     mockForgejo.getBlobContent.mockResolvedValue(Buffer.from(JSON.stringify(manifest())));
 
     const result = await backfillPublishRequest({
@@ -1603,9 +1672,9 @@ describe('backfillPublishRequest', () => {
   it('throws when the AppBlock row is missing', async () => {
     const { backfillPublishRequest } = await import('../publish-request.service');
     mockDbRead.appBlock.findFirst.mockResolvedValue(null);
-    await expect(
-      backfillPublishRequest({ slug: 'hello', reviewerUserId: 999 })
-    ).rejects.toThrow(/nothing to backfill/);
+    await expect(backfillPublishRequest({ slug: 'hello', reviewerUserId: 999 })).rejects.toThrow(
+      /nothing to backfill/
+    );
   });
 
   // M-4 regression — empty Forgejo repo throws the opaque "bundle is empty"
@@ -1624,8 +1693,8 @@ describe('backfillPublishRequest', () => {
     mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
     mockForgejo.listRepoTree.mockResolvedValue(new Map());
 
-    await expect(
-      backfillPublishRequest({ slug: 'hello', reviewerUserId: 999 })
-    ).rejects.toThrow(/empty/);
+    await expect(backfillPublishRequest({ slug: 'hello', reviewerUserId: 999 })).rejects.toThrow(
+      /empty/
+    );
   });
 });

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -100,8 +100,7 @@ function stableJsonStringify(value: unknown): string {
   const keys = Object.keys(value as Record<string, unknown>).sort();
   return `{${keys
     .map(
-      (k) =>
-        `${JSON.stringify(k)}:${stableJsonStringify((value as Record<string, unknown>)[k])}`
+      (k) => `${JSON.stringify(k)}:${stableJsonStringify((value as Record<string, unknown>)[k])}`
     )
     .join(',')}}`;
 }
@@ -238,10 +237,7 @@ export function computeManifestDiff(
       fields: Object.keys(currentManifest).sort(),
     };
   }
-  const allKeys = new Set([
-    ...Object.keys(currentManifest),
-    ...Object.keys(previousManifest),
-  ]);
+  const allKeys = new Set([...Object.keys(currentManifest), ...Object.keys(previousManifest)]);
   const added: string[] = [];
   const removed: string[] = [];
   const changed: Array<{ field: string; from: unknown; to: unknown }> = [];
@@ -388,9 +384,7 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
   const { bundleBuffer, submittedByUserId } = params;
 
   if (bundleBuffer.length > MAX_BUNDLE_SIZE_BYTES) {
-    throw new Error(
-      `bundle is ${bundleBuffer.length} bytes (max ${MAX_BUNDLE_SIZE_BYTES})`
-    );
+    throw new Error(`bundle is ${bundleBuffer.length} bytes (max ${MAX_BUNDLE_SIZE_BYTES})`);
   }
   if (bundleBuffer.length === 0) {
     throw new Error('bundle is empty');
@@ -411,7 +405,11 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
   if (typeof manifest.blockId !== 'string') {
     throw new Error('manifest.blockId must be a string');
   }
-  if (manifest.blockId.length < 3 || manifest.blockId.length > 40 || !SLUG_REGEX.test(manifest.blockId)) {
+  if (
+    manifest.blockId.length < 3 ||
+    manifest.blockId.length > 40 ||
+    !SLUG_REGEX.test(manifest.blockId)
+  ) {
     throw new Error(
       `manifest.blockId "${manifest.blockId}" must be 3-40 chars, lowercase a-z/0-9/hyphens, start with a letter, end with a letter or digit`
     );
@@ -860,23 +858,25 @@ export type ApproveRequestResult = {
  * Approve a pending publish request. End-to-end:
  *   1. (first version only) auto-create OauthClient owned by the submitter
  *   2. (first version only) create Forgejo repo from starter + webhook
- *   3. pre-insert app_blocks row (status='approved') so the downstream
- *      Forgejo webhook (existing git-push handler) finds it
+ *   3. pre-insert app_blocks row (status='approved')
  *   4. fetch bundle from MinIO, extract files
  *   5. commitFiles to Forgejo (single atomic commit, replaceAllFiles=true)
- *   6. update publish_request → status='approved'
+ *   6. stamp app_blocks.current_version_sha = the committed sha + finalise
+ *      publish_request → status='approved' (these are the moderator-approval
+ *      markers the git-push webhook keys its no-trust-on-push gate off)
+ *   7. trigger the Tekton build directly
  *
- * The Forgejo push webhook fires from step 5 and the existing git-push
- * handler takes over: validates manifest, updates app_blocks
- * (currentVersionSha), triggers Tekton build.
+ * NO TRUST ON PUSH: the git-push webhook fires from step 5 but no longer
+ * triggers builds. It only validates the manifest and either (a) no-ops
+ * because the sha matches the approval markers we just wrote, or (b) parks
+ * an unreviewed direct push as a pending review request. The deploy is owned
+ * entirely by this approve path (step 7).
  *
  * Partial-state risk: if step 5 fails after step 1-3 succeeded, the
  * OauthClient + app_blocks rows are orphaned. v0 surfaces this; v1
  * adds a compensation transaction.
  */
-export async function approveRequest(
-  params: ApproveRequestParams
-): Promise<ApproveRequestResult> {
+export async function approveRequest(params: ApproveRequestParams): Promise<ApproveRequestResult> {
   const [{ dbRead, dbWrite }, { newUlid }, { env }] = await Promise.all([
     import('~/server/db/client'),
     import('~/server/utils/app-block-ids'),
@@ -909,9 +909,7 @@ export async function approveRequest(
   }
 
   const manifest = request.manifest as Record<string, unknown>;
-  const manifestScopes = Array.isArray(manifest.scopes)
-    ? (manifest.scopes as string[])
-    : [];
+  const manifestScopes = Array.isArray(manifest.scopes) ? (manifest.scopes as string[]) : [];
   const manifestContentRating =
     typeof manifest.contentRating === 'string' ? manifest.contentRating : 'g';
   const manifestRenderMode =
@@ -995,8 +993,8 @@ export async function approveRequest(
         // the ceiling we'll actually persist below (we re-cap allowedScopes to
         // the derived value on every approve — see the appBlock.update path).
         allowedScopes: derivedOauthCeiling,
-        allowedOrigins: (existingAppBlock!.app.allowedOrigins ?? []).map(
-          (o: string) => o.toLowerCase()
+        allowedOrigins: (existingAppBlock!.app.allowedOrigins ?? []).map((o: string) =>
+          o.toLowerCase()
         ),
       };
   const validation = BlockManifestValidator.validate(manifest, validationCtx);
@@ -1088,7 +1086,10 @@ export async function approveRequest(
       template: 'starter',
     });
     repoUrl = repo.html_url;
-    const callbackUrl = `${(process.env.NEXTAUTH_URL ?? '').replace(/\/$/, '')}/api/internal/blocks/git-push`;
+    const callbackUrl = `${(process.env.NEXTAUTH_URL ?? '').replace(
+      /\/$/,
+      ''
+    )}/api/internal/blocks/git-push`;
     await ensurePushWebhook({
       slug: request.slug,
       callbackUrl,
@@ -1148,8 +1149,8 @@ export async function approveRequest(
     appBlockId = existingAppBlock.id;
     repoUrl = existingAppBlock.repoUrl ?? '';
     // Subsequent version: refresh manifest + version + approvedScopes
-    // on the existing row. currentVersionSha is updated by the
-    // git-push webhook after the upcoming Forgejo commit.
+    // on the existing row. currentVersionSha is stamped in step (6) below,
+    // right after the Forgejo commit returns the approved sha.
     await dbWrite.appBlock.update({
       where: { id: appBlockId },
       data: {
@@ -1182,9 +1183,8 @@ export async function approveRequest(
     (f) => !isPlatformOwnedPath(f.path)
   );
 
-  // (5) Atomic single-commit replacement of the repo contents. Fires
-  // exactly one Forgejo webhook → one git-push handler invocation →
-  // one Tekton build → one apply Job.
+  // (5) Atomic single-commit replacement of the repo contents on
+  // civitai-apps/<slug>. This commit fires the git-push webhook.
   const commitMessage = `Approved publish request ${request.id} — ${request.slug} v${request.version}`;
   const { sha: forgejoCommitSha } = await commitFiles({
     slug: request.slug,
@@ -1193,7 +1193,17 @@ export async function approveRequest(
     replaceAllFiles: true,
   });
 
-  // (6) Finalise the publish request.
+  // (6) Stamp the approved sha onto the app_blocks row and finalise the
+  // publish request. These two writes are the durable proof that THIS sha
+  // went through moderator review — the git-push webhook keys its
+  // no-trust-on-push gate off `current_version_sha` (and, as a race backstop,
+  // an `approved` publish request with this `forgejoCommitSha`). Any push
+  // whose sha is NOT this approved one is treated as unreviewed and parked in
+  // the review queue instead of deploying.
+  await dbWrite.appBlock.update({
+    where: { id: appBlockId },
+    data: { currentVersionSha: forgejoCommitSha },
+  });
   await dbWrite.appBlockPublishRequest.update({
     where: { id: request.id },
     data: {
@@ -1205,6 +1215,55 @@ export async function approveRequest(
       appBlockId,
     },
   });
+
+  // (6b) Supersede any OTHER request still 'pending' for this slug. If the
+  // git-push webhook raced ahead of (6) it may have parked a duplicate
+  // pending-review row for THIS approved sha; withdraw it (and any older
+  // pending submission) so the queue reflects that the slug is now approved.
+  // Scoped to NOT touch the row we just approved.
+  await dbWrite.appBlockPublishRequest.updateMany({
+    where: { slug: request.slug, status: 'pending', NOT: { id: request.id } },
+    data: { status: 'withdrawn' },
+  });
+
+  // (7) Trigger the Tekton build directly from the moderator-approve path.
+  // This is the ONLY thing that may ship code to a live block — the webhook
+  // no longer triggers builds (no-trust-on-push). triggerBuild creates a
+  // PipelineRun named after the sha, which Tekton dedups, so a webhook
+  // re-delivery cannot double-build.
+  const { triggerBuild } = await import('./apps-pipeline.service');
+  const { setCommitStatus } = await import('./forgejo.service');
+  const callbackUrl = `${(process.env.NEXTAUTH_URL ?? '').replace(
+    /\/$/,
+    ''
+  )}/api/internal/blocks/build-callback`;
+  try {
+    await setCommitStatus({
+      slug: request.slug,
+      sha: forgejoCommitSha,
+      state: 'pending',
+      context: 'civitai/build',
+      description: 'Build queued',
+    }).catch(() => undefined);
+    await triggerBuild({
+      slug: request.slug,
+      sha: forgejoCommitSha,
+      appBlockId,
+      callbackUrl,
+    });
+  } catch (err) {
+    await setCommitStatus({
+      slug: request.slug,
+      sha: forgejoCommitSha,
+      state: 'failure',
+      context: 'civitai/build',
+      description: `Trigger failed: ${String(err).slice(0, 80)}`,
+    }).catch(() => undefined);
+    throw new Error(
+      `approved + committed, but the build trigger failed: ${(err as Error).message}. ` +
+        `The new version will NOT deploy until the build is re-triggered (re-approve or re-push).`
+    );
+  }
 
   return {
     publishRequestId: request.id,
@@ -1284,7 +1343,10 @@ export async function backfillPublishRequest(
   for (let i = 0; i < entries.length; i += CONCURRENCY) {
     const batch = entries.slice(i, i + CONCURRENCY);
     const fetched = await Promise.all(
-      batch.map(async (e) => ({ path: e.path, content: await getBlobContent(params.slug, e.blobSha) }))
+      batch.map(async (e) => ({
+        path: e.path,
+        content: await getBlobContent(params.slug, e.blobSha),
+      }))
     );
     files.push(...fetched);
   }
@@ -1373,7 +1435,9 @@ export async function backfillPublishRequest(
       reviewedAt: new Date(),
       approvalNotes:
         params.approvalNotes ??
-        `Backfilled W1 migration from existing deployment at ${appBlock.currentVersionSha ?? '(unknown sha)'}`,
+        `Backfilled W1 migration from existing deployment at ${
+          appBlock.currentVersionSha ?? '(unknown sha)'
+        }`,
       forgejoCommitSha: appBlock.currentVersionSha ?? bundleSha256,
     },
   });

--- a/src/tests/api/internal/blocks/git-push.gate.test.ts
+++ b/src/tests/api/internal/blocks/git-push.gate.test.ts
@@ -1,0 +1,330 @@
+import { createHmac } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * No-trust-on-push coverage for POST /api/internal/blocks/git-push.
+ *
+ * The finding: a signature-valid Forgejo push to civitai-apps/<slug>:main for
+ * an already-approved block used to run
+ * `dbWrite.appBlock.update({ status: 'approved' })` + trigger the Tekton build —
+ * shipping unreviewed iframe code to a live, mod-page-embedded block. Forgejo
+ * write access is a different trust domain than civitai moderation.
+ *
+ * The fix: git-push NEVER auto-approves and NEVER deploys. The build is owned
+ * by approveRequest (the moderator path), which stamps the approved sha onto
+ * app_blocks.current_version_sha before its commit fires this webhook. So:
+ *   - sha === current_version_sha (or an `approved` publish request matches the
+ *     sha) → the in-flight moderator-approved deploy → no-op.
+ *   - any other sha → an UNREVIEWED direct push → recorded as a `pending`
+ *     publish request, no status flip, no build. A moderator must approve it.
+ *
+ * These tests drive the real default export with a real signed body (bodyParser
+ * is off, so the handler reads + HMAC-verifies the raw stream), mirroring the
+ * build-callback handler tests.
+ */
+
+const SECRET = 'test-forgejo-webhook-secret';
+const SLUG = 'generate-from-model';
+const APPROVED_SHA = 'a'.repeat(40);
+const NEW_SHA = 'b'.repeat(40);
+const APP_BLOCK_ID = 'apb_0123456789ABCDEFGHJKMNPQRS';
+
+const {
+  mockFlag,
+  mockGetRawFile,
+  mockSetCommitStatus,
+  mockValidate,
+  mockAppBlockFindFirst,
+  mockAppBlockFindUnique,
+  mockAppBlockUpdate,
+  mockPubReqFindFirst,
+  mockPubReqCreate,
+  mockPubReqUpdate,
+  mockPubReqUpdateMany,
+  mockNewUlid,
+  mockTriggerBuild,
+  state,
+} = vi.hoisted(() => {
+  const state = {
+    flagEnabled: true,
+    // app_blocks row returned by findFirst (null = not provisioned yet → 404)
+    appBlock: null as null | Record<string, unknown>,
+    // approved publish request match for (slug, sha) — race backstop
+    approvedPubReqForSha: null as null | { id: string },
+    // existing pending row for (slug, sha) — idempotent refresh
+    pendingPubReqForSha: null as null | { id: string },
+    // manifest served by Forgejo at the pushed sha
+    manifest: {} as Record<string, unknown>,
+    validation: { valid: true, errors: [] as string[] },
+  };
+  return {
+    state,
+    mockFlag: {
+      get enabled() {
+        return state.flagEnabled;
+      },
+    },
+    mockGetRawFile: vi.fn(async () => JSON.stringify(state.manifest)),
+    mockSetCommitStatus: vi.fn(async () => undefined),
+    mockValidate: vi.fn(() => state.validation),
+    mockAppBlockFindFirst: vi.fn(async () => state.appBlock),
+    mockAppBlockFindUnique: vi.fn(async () => ({ app: { userId: 77 } })),
+    mockAppBlockUpdate: vi.fn(async () => undefined),
+    mockPubReqFindFirst: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+      if (where.status === 'approved') return state.approvedPubReqForSha;
+      if (where.status === 'pending') return state.pendingPubReqForSha;
+      return null;
+    }),
+    mockPubReqCreate: vi.fn(async () => undefined),
+    mockPubReqUpdate: vi.fn(async () => undefined),
+    mockPubReqUpdateMany: vi.fn(async () => ({ count: 0 })),
+    mockNewUlid: vi.fn(() => '0123456789ABCDEFGHJKMNPQRS'),
+    mockTriggerBuild: vi.fn(async () => ({ name: 'pr-1' })),
+  };
+});
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    { FORGEJO_WEBHOOK_SECRET: SECRET, APPS_DOMAIN: 'civit.ai' } as Record<string, unknown>,
+    {
+      get(t, p: string) {
+        if (p in t) return t[p];
+        if (p === 'LOGGING') return '';
+        return undefined;
+      },
+    }
+  ),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(async () => mockFlag.enabled) }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    appBlock: { findFirst: mockAppBlockFindFirst, findUnique: mockAppBlockFindUnique },
+    appBlockPublishRequest: { findFirst: mockPubReqFindFirst },
+  },
+  dbWrite: {
+    appBlock: { update: mockAppBlockUpdate },
+    appBlockPublishRequest: {
+      findFirst: mockPubReqFindFirst,
+      create: mockPubReqCreate,
+      update: mockPubReqUpdate,
+      updateMany: mockPubReqUpdateMany,
+    },
+  },
+}));
+vi.mock('~/server/services/block-manifest-validator.service', () => ({
+  BlockManifestValidator: { validate: mockValidate },
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  FORGEJO_ORG: 'civitai-apps',
+  getRawFile: mockGetRawFile,
+  setCommitStatus: mockSetCommitStatus,
+}));
+vi.mock('~/server/utils/app-block-ids', () => ({ newUlid: mockNewUlid }));
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  triggerBuild: mockTriggerBuild,
+}));
+
+function validManifest(sha = NEW_SHA) {
+  return {
+    blockId: SLUG,
+    version: '0.2.0',
+    name: 'Generate From Model',
+    iframe: { src: `https://${SLUG}.civit.ai/` },
+    _sha: sha, // marker only; ignored by handler
+  };
+}
+
+function pushBody(opts: { ref?: string; fullName?: string; after?: string }) {
+  return {
+    ref: opts.ref ?? 'refs/heads/main',
+    after: opts.after ?? NEW_SHA,
+    before: '0'.repeat(40),
+    repository: { name: SLUG, full_name: opts.fullName ?? `civitai-apps/${SLUG}` },
+    pusher: { login: 'someone', username: 'someone' },
+    commits: [{ id: opts.after ?? NEW_SHA, message: 'update' }],
+  };
+}
+
+function signedReq(bodyObj: Record<string, unknown>, sigOverride?: string): NextApiRequest {
+  const raw = Buffer.from(JSON.stringify(bodyObj), 'utf8');
+  const sig = sigOverride ?? 'sha256=' + createHmac('sha256', SECRET).update(raw).digest('hex');
+  return {
+    method: 'POST',
+    headers: { 'x-forgejo-signature': sig },
+    async *[Symbol.asyncIterator]() {
+      yield raw;
+    },
+  } as unknown as NextApiRequest;
+}
+
+function makeRes(): NextApiResponse & { _status: number; _body: any } {
+  const res = {
+    _status: 0,
+    _body: null as any,
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & { _status: number; _body: any };
+}
+
+async function invoke(req: NextApiRequest, res: NextApiResponse) {
+  const handler = (await import('~/pages/api/internal/blocks/git-push')).default;
+  await handler(req, res);
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+describe('git-push webhook — no-trust-on-push gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.flagEnabled = true;
+    state.appBlock = {
+      id: APP_BLOCK_ID,
+      appId: `appblk-${SLUG}`,
+      blockId: SLUG,
+      currentVersionSha: APPROVED_SHA,
+      app: { id: `appblk-${SLUG}`, allowedScopes: 0, allowedOrigins: [`https://${SLUG}.civit.ai`] },
+    };
+    state.approvedPubReqForSha = null;
+    state.pendingPubReqForSha = null;
+    state.manifest = validManifest(NEW_SHA);
+    state.validation = { valid: true, errors: [] };
+  });
+
+  afterEach(async () => {
+    await flush();
+  });
+
+  // ---- the core fix --------------------------------------------------------
+
+  it('a NEW signed push to an existing approved block does NOT approve or deploy — it parks a PENDING review request', async () => {
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
+
+    // No deploy, no status flip to approved.
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+    expect(mockAppBlockUpdate).not.toHaveBeenCalled();
+
+    // A pending review artifact was created for the new sha.
+    expect(mockPubReqCreate).toHaveBeenCalledTimes(1);
+    const createArg = mockPubReqCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(createArg.data).toMatchObject({
+      slug: SLUG,
+      status: 'pending',
+      forgejoCommitSha: NEW_SHA,
+      appBlockId: APP_BLOCK_ID,
+    });
+
+    // Response signals pending-review, not deployed.
+    expect(res._status).toBe(202);
+    expect(res._body).toMatchObject({ status: 'pending-review', deployed: false });
+  });
+
+  it('the new pending push supersedes any older pending request for the slug (one-pending-per-slug)', async () => {
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
+    expect(mockPubReqUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ slug: SLUG, status: 'pending' }),
+        data: { status: 'withdrawn' },
+      })
+    );
+  });
+
+  it('a re-delivery of the SAME (slug, sha) push refreshes the existing pending row instead of stacking', async () => {
+    state.pendingPubReqForSha = { id: 'pubreq_existing' };
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+    expect(mockPubReqUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'pubreq_existing' } })
+    );
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  // ---- the moderator-approved deploy still no-ops cleanly ------------------
+
+  it('no-ops (no pending, no build) when the pushed sha is the approved current_version_sha', async () => {
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: APPROVED_SHA })), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ deploy: 'already-approved' });
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+    expect(mockAppBlockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('race backstop: no-ops when an approved publish request matches the pushed sha (current_version_sha not yet stamped)', async () => {
+    // Simulate the webhook racing ahead of approveRequest's current_version_sha
+    // write but after it finalised the publish request for this sha.
+    state.appBlock = { ...(state.appBlock as object), currentVersionSha: null } as Record<
+      string,
+      unknown
+    >;
+    state.approvedPubReqForSha = { id: 'pubreq_approved' };
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ deploy: 'already-approved' });
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  // ---- preserved gates -----------------------------------------------------
+
+  it('rejects a bad HMAC signature (401) before any DB work', async () => {
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA }), 'sha256=deadbeef'), res);
+    expect(res._status).toBe(401);
+    expect(mockAppBlockFindFirst).not.toHaveBeenCalled();
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a push from the wrong org/repo (403) — civitai-apps-review same-slug', async () => {
+    const res = makeRes();
+    await invoke(
+      signedReq(pushBody({ after: NEW_SHA, fullName: `civitai-apps-review/${SLUG}` })),
+      res
+    );
+    expect(res._status).toBe(403);
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('503s when the app-blocks-enabled flag is off (kill switch) before any DB work', async () => {
+    state.flagEnabled = false;
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
+    expect(res._status).toBe(503);
+    expect(mockAppBlockFindFirst).not.toHaveBeenCalled();
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid manifest (400) — no pending row, no build (manifest validation preserved)', async () => {
+    state.validation = { valid: false, errors: ['scopes: forbidden'] };
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
+    expect(res._status).toBe(400);
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-main branch pushes (200 skipped)', async () => {
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA, ref: 'refs/heads/dev' })), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ skipped: 'non-main branch' });
+    expect(mockPubReqCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The finding (MEDIUM, supply-chain)

`src/pages/api/internal/blocks/git-push.ts` (the Forgejo push webhook for `civitai-apps/<slug>`): for an **already-existing `app_blocks` row**, a signature-valid push to `refs/heads/main` ran `dbWrite.appBlock.update({ ... status: 'approved' ... })` and triggered the Tekton build → deploy — **with no re-entry through the moderator review queue**. The handler's own comment admitted "v0 auto-approves on valid push; v1 gates this behind a queue."

Once a block was approved once, every subsequent signed push shipped new iframe code to a live, mod-page-embedded block and silently re-marked it `approved`. **Anyone with Forgejo write access to that repo — a different trust domain than civitai moderators — could push arbitrary new iframe code with no review.** Manifest validation bounds scopes/origins/`iframe.src`, but the *code served* at the block's origin changed unreviewed.

## Lifecycle mapped (before the fix)

1. **submitVersion** (dev): validates manifest, inserts `app_block_publish_requests` row `status='pending'`, pushes the bundle to the **review** org (`civitai-apps-review/<slug>`). No deploy.
2. **approveRequest** (mod, `/apps/review`): re-validates manifest, creates/updates the `app_blocks` row (`status='approved'`), `commitFiles` to the **build** org (`civitai-apps/<slug>:main`). That commit fires the git-push webhook.
3. **git-push webhook**: fired by *any* push to `civitai-apps/<slug>:main`. It re-validated the manifest, flipped `app_blocks.status='approved'`, set `current_version_sha`, and triggered the Tekton build → build-callback → apply/deploy.

The webhook could not distinguish the mod's `commitFiles` (legit) from a direct attacker push (illegit) — both auto-approved + deployed. That is the trust-on-push hole.

## What changed

**No trust on push.** The git-push webhook no longer auto-approves or triggers any build. The build/deploy is owned entirely by the moderator `approveRequest` path:

- **`approveRequest` (`publish-request.service.ts`)** now, right after `commitFiles` returns the approved sha: stamps `app_blocks.current_version_sha = <sha>`, finalises the publish request (`status='approved'`, `forgejo_commit_sha=<sha>`), supersedes any stray `pending` request for the slug, and **triggers the Tekton build itself** (`triggerBuild`, moved here from the webhook). These writes are the durable proof that the sha went through moderator review.
- **`git-push.ts`** now, after the (preserved) manifest validation:
  - **no-ops** when the pushed sha is the moderator-approved one — `sha === current_version_sha`, or (race backstop) an `approved` publish request matches the sha. (The mod's commit lands here too; it's already the in-flight approved deploy.)
  - for **any other** push — an unreviewed direct push to the build repo — records (or refreshes) a `pending` publish request for the pushed sha (the same review artifact a `submitVersion` produces) and **stops**: no `status` flip, no build, `202 pending-review`. A moderator must approve it via `approveRequest` before it ships.

### Gates preserved
HMAC signature verification, the `civitai-apps` org/repo gate (`parseExpectedRepo`), the `app-blocks-enabled` flag kill-switch, and manifest validation all still run and still reject. The first-time provisioning path and the mod approve→build→deploy path are unaffected — the build is simply triggered from `approveRequest` instead of the webhook.

## Conservative decision + what I'd like a human to confirm

The precise intended mapping was genuinely ambiguous (the webhook was the deploy trigger for *both* the mod path and direct pushes, and couldn't tell them apart from the payload). I picked the option that **structurally cannot deploy third-party code without an explicit moderator approval**:

1. **Moved `triggerBuild` from the webhook into `approveRequest`.** This is a small, surgical move (not a pipeline redesign) and is the only way "deploy happens only when a moderator approves via `approveRequest`" can hold for both first and subsequent versions. Please confirm you're happy with the build trigger living on the approve path rather than the webhook.
2. **Webhook-recorded pending rows have empty bundle pointers** (`bundle_key=''`, `bundle_sha256=''`) — the webhook only receives the push event + the manifest, not the ZIP. The reviewable artifact is the Forgejo repo at `forgejo_commit_sha`. **Gap to confirm/triage:** `approveRequest` currently fetches the bundle from MinIO (`fetchAndExtractBundleFiles(bundleKey)`), so it cannot today approve a *webhook-recorded* pending row as-is (the bundle isn't in MinIO; the code is already in the build repo at that sha). The security property (never deploy unreviewed code) holds regardless. Approving a webhook-recorded pending row (e.g. reconstruct the bundle from Forgejo at the sha, à la `backfillPublishRequest`, or a dedicated approve-from-repo path) is left as a follow-up — flagging so a human decides whether to build that now.

## Out-of-scope follow-ups (documented, not built)

1. **Restrict Forgejo write access on `civitai-apps`** to the platform/CI identity only (infra/ops) — removes the attacker's foothold entirely; this code change is defence-in-depth on top.
2. **Full manifest/`iframe.src`/sha audit-log trail.** A minimal mod Discord ping on an unreviewed push + a `civitai/review` Forgejo commit status are added here; a durable audit-log table is the larger follow-up.
3. **Approve-from-repo path** for webhook-recorded pending rows (see decision #2 above).

## Tests

- New `src/tests/api/internal/blocks/git-push.gate.test.ts` (10 cases, drives the real handler with signed bodies): unreviewed push parks a `pending` request + no deploy + no status flip; supersede older pending; idempotent refresh of same (slug,sha); approved-sha no-op; approved-publish-request race-backstop no-op; bad signature → 401; wrong org (`civitai-apps-review`) → 403; flag off → 503; invalid manifest → 400; non-main → skipped.
- Extended `publish-request.orchestration.test.ts` (`approveRequest`): asserts the `current_version_sha` stamp, the `triggerBuild` call, and the pending-supersede on first-version, subsequent-version, and P2002-recovery paths.
- `npx vitest run` over the full blocks suite: **367 passed**. (CI runs the typecheck; this worktree lacks `node_modules`/a fresh Prisma client so a local full typecheck isn't reliable. `eslint` on the changed files reports 0 errors, only pre-existing-style warnings.)

> Note: `prettier --write` reformatted `publish-request.service.ts` and `app-blocks.md`; those files were already non-conformant before this PR, so the diff carries some whitespace-only reflow alongside the logic changes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
