### PR TITLE
docs(claude): ban stacked PRs in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,11 @@ const currentUser = useCurrentUser();
 3. Format code: `pnpm run prettier:write`
 4. Test changes locally
 
+### Stacked PRs — don't
+- **NEVER use stacked PRs** — base every PR directly on the integration branch (`main`, or a feature integration branch like `feat/...`), never on another open PR's branch. Stacked PRs silently mis-merge: a squash-merged parent doesn't retarget the child, so the child lands on the orphaned parent branch instead of the real base and its changes go missing.
+- If a change depends on an unmerged PR, **wait for that PR to merge, then branch off the updated base** — or fold both changes into a single PR.
+- (Bit us 2026-06-13: PR #2520's App Blocks W11 F5 was stacked on #2518 (F6) → #2520 squash-merged into the #2518 branch instead of `feat/app-blocks-main-v1`; corrected via #2525.)
+
 ## Common Patterns
 
 ### Infinite Scroll


### PR DESCRIPTION
Adds a **Stacked PRs — don't** rule to `CLAUDE.md` (under *Important Notes → Before Committing*): never base a PR on another open PR's branch; base every PR on the integration branch; if a change depends on an unmerged PR, wait for it to merge then branch off the updated base (or fold both into one PR).

**Why (2026-06-13):** App Blocks W11 PR #2520 (F5 replay) was stacked on #2518 (F6). #2518 was squash-merged into `feat/app-blocks-main-v1` with its branch left alive → GitHub didn't retarget #2520 → merging #2520 landed F5 on the orphaned #2518 branch, not `feat`. F5 was silently missing from the integration branch; corrected via #2525.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)