### PR TITLE
security(app-blocks): block cross-origin submit-version (CSRF)

### DIFF
--- a/src/pages/api/blocks/submit-version.ts
+++ b/src/pages/api/blocks/submit-version.ts
@@ -1,7 +1,9 @@
 import type { NextApiResponse } from 'next';
+import { isProd } from '~/env/other';
 import { submitVersionSchema } from '~/server/schema/blocks/publish-request.schema';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { ModEndpoint } from '~/server/utils/endpoint-helpers';
+import { isAllowedOriginRequest } from '~/server/utils/origin-helpers';
 
 /**
  * Dedicated upload route for the App Blocks W1 publish-request flow.
@@ -31,6 +33,20 @@ export const config = {
 
 export default ModEndpoint(
   async (req, res: NextApiResponse, user) => {
+    // CSRF guard. This raw route is wrapped in ModEndpoint (cookie-only auth)
+    // and bypasses the tRPC pipeline, so it never gets createContext's
+    // same-origin check. With the prod session cookie set to sameSite:'none',
+    // a cross-site HTML form POST in a logged-in mod's browser would otherwise
+    // submit a bundle with their cookie. Mirror createContext's posture: in
+    // prod, require the request to originate from an allowed host (no bearer
+    // exemption needed — ModEndpoint is cookie-only). The !isProd exemption
+    // keeps local dev and tests (which send no Origin) working, identical to
+    // createContext.
+    if (isProd && !isAllowedOriginRequest(req)) {
+      res.status(403).json({ message: 'Cross-origin request blocked' });
+      return;
+    }
+
     // H2: evaluate with the authenticated mod's context so the
     // `moderators`-segmented flag resolves ON for them (ModEndpoint has already
     // proven `user.isModerator` above). Mirrors enforceAppBlocksFlag.
@@ -58,7 +74,9 @@ export default ModEndpoint(
     try {
       bundleBuffer = Buffer.from(parsed.data.bundleBase64, 'base64');
     } catch (err) {
-      res.status(400).json({ message: `bundleBase64 is not valid base64: ${(err as Error).message}` });
+      res
+        .status(400)
+        .json({ message: `bundleBase64 is not valid base64: ${(err as Error).message}` });
       return;
     }
 

--- a/src/server/createContext.ts
+++ b/src/server/createContext.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { env } from '~/env/server';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { Tracker } from './clickhouse/client';
 import requestIp from 'request-ip';
@@ -7,7 +6,8 @@ import { isProd } from '~/env/other';
 import { getFeatureFlagsLazy } from '~/server/services/feature-flags.service';
 import { createCallerFactory } from '~/server/trpc';
 import { appRouter } from '~/server/routers';
-import { getAllServerHosts, getRequestDomainColor } from '~/server/utils/server-domain';
+import { getRequestDomainColor } from '~/server/utils/server-domain';
+import { isAllowedOriginRequest } from '~/server/utils/origin-helpers';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 type CacheSettings = {
@@ -18,31 +18,6 @@ type CacheSettings = {
   canCache?: boolean;
   skip: boolean;
 };
-
-function hostFromUrl(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  try {
-    return new URL(value).host.toLowerCase();
-  } catch {
-    return undefined;
-  }
-}
-
-// Allowlist of hosts permitted to issue cookie-authenticated cross-origin
-// requests. Built from server domains (primary + aliases), explicit
-// TRPC_ORIGINS, and NEXTAUTH_URL.
-const allowedOriginHosts = new Set<string>(
-  [...getAllServerHosts(), ...env.TRPC_ORIGINS.map(hostFromUrl), hostFromUrl(env.NEXTAUTH_URL)]
-    .filter((h): h is string => !!h)
-    .map((h) => h.toLowerCase())
-);
-
-// Origin preferred; Referer is the fallback for clients that suppress Origin.
-// Absent both, treat as untrusted — isAcceptableOrigin rejects the request.
-function isAllowedOriginRequest(req: NextApiRequest): boolean {
-  const sourceHost = hostFromUrl(req.headers.origin) ?? hostFromUrl(req.headers.referer);
-  return !!sourceHost && allowedOriginHosts.has(sourceHost);
-}
 
 export const createContext = async ({
   req,

--- a/src/server/utils/__tests__/origin-helpers.test.ts
+++ b/src/server/utils/__tests__/origin-helpers.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Unit coverage for the shared same-origin allowlist used by both the tRPC
+ * context (createContext) and the raw /api/blocks/submit-version route. The
+ * allowlist Set is built at module load, so the env + server-host inputs are
+ * mocked via vi.hoisted before the module under test is imported.
+ */
+
+const { mockEnv, mockHosts } = vi.hoisted(() => ({
+  mockEnv: {
+    TRPC_ORIGINS: ['https://trpc-allowed.example'] as string[],
+    NEXTAUTH_URL: 'https://auth.example',
+  },
+  mockHosts: ['civitai.com', 'Civitai.RED'] as string[],
+}));
+
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+vi.mock('~/server/utils/server-domain', () => ({
+  getAllServerHosts: () => mockHosts,
+}));
+
+import { hostFromUrl, isAllowedOriginRequest } from '../origin-helpers';
+
+function req(headers: { origin?: string; referer?: string }) {
+  return { headers };
+}
+
+describe('hostFromUrl', () => {
+  it('lowercases the host', () => {
+    expect(hostFromUrl('https://Civitai.COM/path')).toBe('civitai.com');
+  });
+
+  it('returns undefined for undefined / invalid input', () => {
+    expect(hostFromUrl(undefined)).toBeUndefined();
+    expect(hostFromUrl('not a url')).toBeUndefined();
+  });
+});
+
+describe('isAllowedOriginRequest', () => {
+  it('accepts a request whose Origin host is in the allowlist', () => {
+    expect(isAllowedOriginRequest(req({ origin: 'https://civitai.com' }))).toBe(true);
+  });
+
+  it('accepts hosts contributed by TRPC_ORIGINS and NEXTAUTH_URL', () => {
+    expect(isAllowedOriginRequest(req({ origin: 'https://trpc-allowed.example' }))).toBe(true);
+    expect(isAllowedOriginRequest(req({ origin: 'https://auth.example' }))).toBe(true);
+  });
+
+  it('rejects a foreign origin', () => {
+    expect(isAllowedOriginRequest(req({ origin: 'https://evil.example' }))).toBe(false);
+  });
+
+  it('rejects when both Origin and Referer are absent', () => {
+    expect(isAllowedOriginRequest(req({}))).toBe(false);
+  });
+
+  it('falls back to Referer when Origin is absent', () => {
+    expect(isAllowedOriginRequest(req({ referer: 'https://civitai.com/some/page' }))).toBe(true);
+    expect(isAllowedOriginRequest(req({ referer: 'https://evil.example/x' }))).toBe(false);
+  });
+
+  it('prefers Origin over Referer', () => {
+    // Foreign Origin must reject even when Referer would have passed.
+    expect(
+      isAllowedOriginRequest(
+        req({ origin: 'https://evil.example', referer: 'https://civitai.com' })
+      )
+    ).toBe(false);
+  });
+
+  it('compares hosts case-insensitively (both sides lowercased)', () => {
+    // Allowlist entry "Civitai.RED" is lowercased at build time; a mixed-case
+    // request host must still match.
+    expect(isAllowedOriginRequest(req({ origin: 'https://CIVITAI.red' }))).toBe(true);
+  });
+});

--- a/src/server/utils/origin-helpers.ts
+++ b/src/server/utils/origin-helpers.ts
@@ -1,0 +1,32 @@
+import { env } from '~/env/server';
+import { getAllServerHosts } from '~/server/utils/server-domain';
+
+export function hostFromUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).host.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+// Allowlist of hosts permitted to issue cookie-authenticated cross-origin
+// requests. Built from server domains (primary + aliases), explicit
+// TRPC_ORIGINS, and NEXTAUTH_URL.
+export const allowedOriginHosts = new Set<string>(
+  [...getAllServerHosts(), ...env.TRPC_ORIGINS.map(hostFromUrl), hostFromUrl(env.NEXTAUTH_URL)]
+    .filter((h): h is string => !!h)
+    .map((h) => h.toLowerCase())
+);
+
+// Origin preferred; Referer is the fallback for clients that suppress Origin.
+// Absent both, treat as untrusted — isAcceptableOrigin rejects the request.
+// Typed structurally (origin/referer only) so callers — the tRPC context and
+// raw Next API routes alike — can share this single allowlist without pulling
+// in heavier request types.
+export function isAllowedOriginRequest(req: {
+  headers: { origin?: string; referer?: string };
+}): boolean {
+  const sourceHost = hostFromUrl(req.headers.origin) ?? hostFromUrl(req.headers.referer);
+  return !!sourceHost && allowedOriginHosts.has(sourceHost);
+}

--- a/src/tests/api/blocks/submit-version.test.ts
+++ b/src/tests/api/blocks/submit-version.test.ts
@@ -18,7 +18,14 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  * handler body.
  */
 
-const { mockSession, mockEnv, mockIsAppBlocksEnabled, mockSubmitVersion } = vi.hoisted(() => ({
+const {
+  mockSession,
+  mockEnv,
+  mockOther,
+  mockIsAllowedOrigin,
+  mockIsAppBlocksEnabled,
+  mockSubmitVersion,
+} = vi.hoisted(() => ({
   mockSession: {
     value: null as { user: { id: number; isModerator?: boolean; bannedAt: Date | null } } | null,
   },
@@ -26,11 +33,22 @@ const { mockSession, mockEnv, mockIsAppBlocksEnabled, mockSubmitVersion } = vi.h
     BUNDLE_S3_ENDPOINT?: string;
     BUNDLE_S3_BUCKET?: string;
   },
+  // Toggle the isProd branch of the CSRF guard per-test.
+  mockOther: { isProd: false },
+  mockIsAllowedOrigin: vi.fn<(req: unknown) => boolean>(() => true),
   mockIsAppBlocksEnabled: vi.fn<() => Promise<boolean>>(async () => true),
   mockSubmitVersion: vi.fn<(...args: any[]) => Promise<any>>(),
 }));
 
 vi.mock('~/env/server', () => ({ env: mockEnv }));
+vi.mock('~/env/other', () => ({
+  get isProd() {
+    return mockOther.isProd;
+  },
+}));
+vi.mock('~/server/utils/origin-helpers', () => ({
+  isAllowedOriginRequest: mockIsAllowedOrigin,
+}));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
 }));
@@ -108,6 +126,8 @@ describe('POST /api/blocks/submit-version', () => {
     mockSession.value = MOD;
     mockEnv.BUNDLE_S3_ENDPOINT = 'https://s3.example';
     mockEnv.BUNDLE_S3_BUCKET = 'bundles';
+    mockOther.isProd = false;
+    mockIsAllowedOrigin.mockReturnValue(true);
     mockIsAppBlocksEnabled.mockResolvedValue(true);
     mockSubmitVersion.mockReset();
     mockSubmitVersion.mockResolvedValue(SERVICE_RESULT);
@@ -150,6 +170,25 @@ describe('POST /api/blocks/submit-version', () => {
     await invoke(makeReq({ body: { bundleBase64 } }), res);
     expect(res._status).toBe(503);
     expect(mockSubmitVersion).not.toHaveBeenCalled();
+  });
+
+  it('403s a prod cross-origin POST and does not call the service (CSRF guard)', async () => {
+    mockOther.isProd = true;
+    mockIsAllowedOrigin.mockReturnValue(false);
+    const res = makeRes();
+    await invoke(makeReq({ body: { bundleBase64 } }), res);
+    expect(res._status).toBe(403);
+    expect(res._body).toEqual({ message: 'Cross-origin request blocked' });
+    expect(mockSubmitVersion).not.toHaveBeenCalled();
+  });
+
+  it('lets a prod same-origin POST through to the service (CSRF guard)', async () => {
+    mockOther.isProd = true;
+    mockIsAllowedOrigin.mockReturnValue(true);
+    const res = makeRes();
+    await invoke(makeReq({ body: { bundleBase64 } }), res);
+    expect(res._status).toBe(200);
+    expect(mockSubmitVersion).toHaveBeenCalledTimes(1);
   });
 
   it('412s when bundle storage is not configured', async () => {


### PR DESCRIPTION
## App Blocks GA-blocker — CSRF on the bundle-submit route

`src/pages/api/blocks/submit-version.ts` is a raw Next API route wrapped in `ModEndpoint`. It bypasses the tRPC pipeline, so it never received the same-origin check that `createContext` enforces for every tRPC call (`!isProd || isBearerAuth || isAllowedOriginRequest(req)`). In prod the NextAuth session cookie is `sameSite:'none'`, and Next.js parses `application/x-www-form-urlencoded` bodies — so a cross-site HTML form POST executed in a logged-in moderator's browser would submit a bundle with their cookie. That's a CSRF. It is dark-gated by the `appBlocks` flag today, but a confirmed **App Blocks GA-blocker**.

## Fix

- **New shared module** `src/server/utils/origin-helpers.ts` exporting `hostFromUrl`, `allowedOriginHosts`, and `isAllowedOriginRequest` — moved verbatim from `createContext`. A security allowlist must be a single source of truth, not duplicated (drift risk). The `req` param is typed structurally (`{ headers: { origin?; referer? } }`) so both the tRPC context and raw API routes can share it.
- **`createContext` refactored** to import from the new module and delete its local copies. **Pure, behavior-preserving** — `createContext` is the hottest auth path (~100/s on api-primary), so only the import boundary changed. The call site is byte-for-byte identical:
  ```ts
  const acceptableOrigin = !isProd || isBearerAuth || isAllowedOriginRequest(req);
  ```
- **`submit-version` gated** on the same check, mirroring `createContext`'s posture exactly:
  ```ts
  if (isProd && !isAllowedOriginRequest(req)) {
    res.status(403).json({ message: 'Cross-origin request blocked' });
    return;
  }
  ```
  Uses the same `isProd` source as `createContext` (`~/env/other`). The `!isProd` exemption keeps local dev + tests working. No bearer exemption needed (ModEndpoint is cookie-only).

**Route-scoped, not ModEndpoint-wide**, on purpose: non-browser mod callers (retool / curl / scripts) that send no Origin header keep working. The 27 other ModEndpoint routes are untouched; the new helper is reusable for any route that wants to opt in later.

## Tests

- `src/server/utils/__tests__/origin-helpers.test.ts` (9 cases): allowed host passes; foreign origin rejects; missing both origin+referer rejects; referer fallback; Origin preferred over Referer; case-insensitive host match; TRPC_ORIGINS / NEXTAUTH_URL contributions.
- `src/tests/api/blocks/submit-version.test.ts` extended: a prod cross-origin POST → 403 and the service is NOT called; a prod same-origin POST still reaches the service.

`npx vitest run` on both files: **21 passed (9 + 12)**.

CI is authoritative for typecheck (the worktree has no node_modules and `tsc` is unreliable here due to a stale Prisma client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>