### PR TITLE
security(app-blocks): dual-secret HMAC rotation + activate ts replay leg (W11 F6+F5)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -416,7 +416,14 @@ export const serverSchema = z.object({
   FORGEJO_PUBLIC_URL: z.string().url().default('https://forgejo.civitai.com'),
   FORGEJO_ADMIN_TOKEN: z.string().optional(),
   FORGEJO_WEBHOOK_SECRET: z.string().optional(),
+  // F6 — optional second HMAC secret accepted during a zero-downtime rotation.
+  // verifyForgejoSignature (git-push.ts) / verifySignature (build-callback.ts)
+  // accept a signature valid under EITHER the current or the _NEXT secret. When
+  // unset, behaviour is identical to single-secret. Pairs with the talos-side
+  // APPS_TEKTON_TRIGGER_SECRET_NEXT to complete the three-secret rotation.
+  FORGEJO_WEBHOOK_SECRET_NEXT: z.string().optional(),
   BLOCK_BUILD_CALLBACK_SECRET: z.string().optional(),
+  BLOCK_BUILD_CALLBACK_SECRET_NEXT: z.string().optional(),
   APPS_TEKTON_TRIGGER_URL: z.string().url().optional(),
   APPS_TEKTON_TRIGGER_SECRET: z.string().optional(),
   APPS_KUBE_NAMESPACE: z.string().default('civitai-apps'),

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -50,7 +50,56 @@ type CallbackBody = {
   appBlockId?: string;
   imageRef?: string;
   status?: string; // "Succeeded" / "Failed" / "Cancelled" / ... per Tekton
+  // F5 — integer unix-epoch-SECONDS timestamp the SIGNER (the datapacket-talos
+  // app-blocks-callback Tekton task) stamps INSIDE the body BEFORE the HMAC, so
+  // it is covered by the signature. Validated for skew below. ABSENT/non-finite
+  // is ALLOWED (enforce-if-present rollout tolerance).
+  ts?: unknown;
 };
+
+// F5 — allowed clock skew between the callback signer and this receiver, in
+// seconds. The live talos callback task (app-blocks-pipeline.yaml) ALREADY
+// signs `ts`; this check activates that signal. A replayed callback carries its
+// original (now-stale) `ts` inside the signed body, so it fails this window.
+// 300s mirrors the trigger leg (app-blocks-trigger.py TS_SKEW_SECONDS=300).
+const TS_TOLERANCE_SECONDS = 300;
+
+/**
+ * Replay-freshness decision for the (already HMAC-verified) callback `ts` (F5).
+ *
+ * Reconciliation with the #2510 redis dedup: #2510 dedups the apply path on
+ * (appBlockId, sha) but (a) FAILS OPEN on a Redis error and (b) only covers a
+ * single 10-minute window — it is replay-de-dup, NOT cross-window freshness, and
+ * the #2510 comment itself flags "durable cross-window replay protection still
+ * needs a caller-supplied signed timestamp/nonce" as a follow-up. This is that
+ * follow-up: an HMAC-BOUND freshness check that does NOT fail open and bounds
+ * the replay window to ±300s regardless of Redis health. The two are
+ * complementary, not redundant.
+ *
+ *   - absent / null → allow (rollout tolerance — the signer leg is independent;
+ *     the live talos task already emits ts, so this is effectively always on in
+ *     prod, but enforce-if-present avoids a deploy-ordering outage).
+ *   - present + a finite number within ±TS_TOLERANCE_SECONDS of now → allow.
+ *   - present + non-finite / out-of-tolerance → reject.
+ *
+ * Pure + exported so the skew window is unit-tested without driving the handler.
+ */
+export function checkCallbackTimestamp(
+  ts: unknown,
+  nowSec: number = Math.floor(Date.now() / 1000)
+): { ok: true } | { ok: false; reason: string } {
+  if (ts === undefined || ts === null) return { ok: true }; // enforce-if-present
+  if (typeof ts !== 'number' || !Number.isFinite(ts)) {
+    return { ok: false, reason: 'ts present but not a finite number' };
+  }
+  if (Math.abs(nowSec - ts) > TS_TOLERANCE_SECONDS) {
+    return {
+      ok: false,
+      reason: `ts skew ${Math.abs(nowSec - ts)}s exceeds ${TS_TOLERANCE_SECONDS}s`,
+    };
+  }
+  return { ok: true };
+}
 
 function safeEqualHex(a: string, b: string): boolean {
   const A = Buffer.from(a, 'hex');
@@ -59,13 +108,32 @@ function safeEqualHex(a: string, b: string): boolean {
   return timingSafeEqual(A, B);
 }
 
-function verifySignature(rawBody: Buffer, header: unknown): boolean {
-  const secret = env.BLOCK_BUILD_CALLBACK_SECRET;
-  if (!secret) return false;
+export function verifySignature(rawBody: Buffer, header: unknown): boolean {
+  // F6 — dual-secret HMAC rotation window. Accept a signature that matches
+  // EITHER the current secret OR an optional BLOCK_BUILD_CALLBACK_SECRET_NEXT.
+  // To rotate with zero downtime: set _NEXT to the new secret, flip the Tekton
+  // callback signer to the new secret, then move the new value into
+  // BLOCK_BUILD_CALLBACK_SECRET and clear _NEXT. When _NEXT is unset this is
+  // byte-identical to the prior single-secret behaviour (fail-closed: no secret
+  // configured → false). Mirrors the BLOCK_TOKEN_PUBLIC_KEY_NEXT precedent.
   if (typeof header !== 'string' || header.length === 0) return false;
-  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
   const provided = header.replace(/^sha256=/, '');
-  return safeEqualHex(provided, expected);
+
+  // Filter empty/undefined BEFORE createHmac so we never compute an empty-key
+  // HMAC. No secret set at all → reject (fail-closed).
+  const secrets = [env.BLOCK_BUILD_CALLBACK_SECRET, env.BLOCK_BUILD_CALLBACK_SECRET_NEXT].filter(
+    (s): s is string => typeof s === 'string' && s.length > 0
+  );
+  if (secrets.length === 0) return false;
+
+  // Compute every candidate comparison (no boolean short-circuit) so timing
+  // doesn't leak which secret — current vs NEXT — was the matching one.
+  let matched = false;
+  for (const secret of secrets) {
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+    if (safeEqualHex(provided, expected)) matched = true;
+  }
+  return matched;
 }
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;
@@ -188,6 +256,25 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // Bind the accepted imageRef to THIS callback's own slug + sha (L-CALLBACK).
   if (!body.imageRef || body.imageRef !== expectedImageRef(body.slug, body.sha)) {
     res.status(400).json({ error: 'imageRef does not match slug/sha' });
+    return;
+  }
+
+  // F5 — replay-freshness on the (now HMAC-verified) `ts`. The signer stamps
+  // `ts` inside the signed body, so a replayed callback carries its original
+  // stale value and is rejected here. An absent `ts` is allowed for rollout
+  // tolerance (enforce-if-present). This is HMAC-bound defence-in-depth on top
+  // of the #2510 redis dedup, which fails OPEN and is only single-window — see
+  // checkCallbackTimestamp's doc comment for the reconciliation.
+  const tsCheck = checkCallbackTimestamp(body.ts);
+  if (!tsCheck.ok) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[build-callback] rejecting replayed/stale callback for ${body.slug}@${body.sha.slice(
+        0,
+        8
+      )}: ${tsCheck.reason}`
+    );
+    res.status(401).json({ error: 'Stale or invalid timestamp' });
     return;
   }
 

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -83,14 +83,38 @@ function safeEqualHex(a: string, b: string): boolean {
   return timingSafeEqual(A, B);
 }
 
-function verifyForgejoSignature(rawBody: Buffer, signatureHeader: unknown): boolean {
-  const secret = env.FORGEJO_WEBHOOK_SECRET;
-  if (!secret) return false;
+export function verifyForgejoSignature(rawBody: Buffer, signatureHeader: unknown): boolean {
+  // F6 — dual-secret HMAC rotation window. Accept a signature that matches
+  // EITHER the current secret OR an optional FORGEJO_WEBHOOK_SECRET_NEXT. To
+  // rotate with zero downtime: set _NEXT to the new secret, flip the Forgejo
+  // signer to the new secret, then move the new value into FORGEJO_WEBHOOK_SECRET
+  // and clear _NEXT. When _NEXT is unset this is byte-identical to the prior
+  // single-secret behaviour (fail-closed: no secret configured → false).
+  //
+  // This is the civitai-web leg of the three-secret zero-downtime rotation; the
+  // app-blocks-trigger receiver already dual-accepts APPS_TEKTON_TRIGGER_SECRET
+  // + _NEXT on the talos side (see HMAC-SECRET-ROTATION.md). Mirrors the
+  // BLOCK_TOKEN_PUBLIC_KEY_NEXT precedent in block-token.service.ts.
   if (typeof signatureHeader !== 'string' || signatureHeader.length === 0) return false;
-  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
   // Forgejo sends the header bare (no `sha256=` prefix); be tolerant either way.
   const provided = signatureHeader.replace(/^sha256=/, '');
-  return safeEqualHex(provided, expected);
+
+  // Filter empty/undefined BEFORE createHmac so we never compute an empty-key
+  // HMAC (which would be a usable, attacker-known key). No secret set at all →
+  // reject (fail-closed).
+  const secrets = [env.FORGEJO_WEBHOOK_SECRET, env.FORGEJO_WEBHOOK_SECRET_NEXT].filter(
+    (s): s is string => typeof s === 'string' && s.length > 0
+  );
+  if (secrets.length === 0) return false;
+
+  // Compute every candidate comparison (no boolean short-circuit) so timing
+  // doesn't leak which secret — current vs NEXT — was the matching one.
+  let matched = false;
+  for (const secret of secrets) {
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+    if (safeEqualHex(provided, expected)) matched = true;
+  }
+  return matched;
 }
 
 const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;

--- a/src/server/services/blocks/__tests__/apps-pipeline.triggerBuild.test.ts
+++ b/src/server/services/blocks/__tests__/apps-pipeline.triggerBuild.test.ts
@@ -1,0 +1,96 @@
+import { createHmac } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * F5 — trigger leg. triggerBuild() must stamp an integer unix-epoch-SECONDS
+ * `ts` INSIDE the JSON body BEFORE the HMAC, so the already-live (currently
+ * inert) app-blocks-trigger.py receiver's enforce-if-present ts skew check
+ * activates. Contract that MUST match the talos receiver exactly:
+ *   - field name `ts`
+ *   - integer seconds (not millis)
+ *   - covered by the X-AppBlocks-Trigger-Sig HMAC (signed body, not a header)
+ */
+
+const { TRIGGER_SECRET, mockEnv } = vi.hoisted(() => {
+  const TRIGGER_SECRET = 'trigger-secret';
+  return {
+    TRIGGER_SECRET,
+    mockEnv: {
+      APPS_TEKTON_TRIGGER_URL: 'http://trigger.example/trigger-build',
+      APPS_TEKTON_TRIGGER_SECRET: TRIGGER_SECRET,
+    } as Record<string, unknown>,
+  };
+});
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+
+import { triggerBuild } from '~/server/services/blocks/apps-pipeline.service';
+
+describe('triggerBuild ts replay leg (F5)', () => {
+  let captured: { url: string; body: string; sig: string } | null = null;
+
+  beforeEach(() => {
+    captured = null;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init: RequestInit) => {
+        captured = {
+          url,
+          body: String(init.body),
+          sig: String((init.headers as Record<string, string>)['X-AppBlocks-Trigger-Sig']),
+        };
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: async () => JSON.stringify({ pipelineRun: 'pr-abc' }),
+        } as unknown as Response;
+      })
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const baseArgs = {
+    slug: 'generate-from-model',
+    sha: 'a'.repeat(40),
+    appBlockId: 'apb_0123456789ABCDEFGHJKMNPQRS',
+    callbackUrl: 'https://civitai.com/api/internal/blocks/build-callback',
+  };
+
+  it('includes a finite integer ts (unix SECONDS) in the signed body', async () => {
+    const before = Math.floor(Date.now() / 1000);
+    await triggerBuild(baseArgs);
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(captured).not.toBeNull();
+    const parsed = JSON.parse(captured!.body) as { ts?: unknown };
+    expect(typeof parsed.ts).toBe('number');
+    expect(Number.isInteger(parsed.ts)).toBe(true);
+    // seconds (not millis): must be near "now in seconds", well below ms scale.
+    expect(parsed.ts as number).toBeGreaterThanOrEqual(before);
+    expect(parsed.ts as number).toBeLessThanOrEqual(after);
+  });
+
+  it('signs the EXACT body that carries ts (ts is covered by the HMAC)', async () => {
+    await triggerBuild(baseArgs);
+    const expectedSig = createHmac('sha256', TRIGGER_SECRET).update(captured!.body).digest('hex');
+    expect(captured!.sig).toBe(expectedSig);
+    // And the signed body really contains ts — re-deriving the sig over a
+    // ts-stripped body must NOT match, proving ts is inside the signed bytes.
+    const stripped = JSON.stringify({ ...JSON.parse(captured!.body), ts: undefined });
+    const strippedSig = createHmac('sha256', TRIGGER_SECRET).update(stripped).digest('hex');
+    expect(captured!.sig).not.toBe(strippedSig);
+  });
+
+  it('still sends the original fields alongside ts', async () => {
+    await triggerBuild(baseArgs);
+    const parsed = JSON.parse(captured!.body);
+    expect(parsed).toMatchObject({
+      slug: baseArgs.slug,
+      sha: baseArgs.sha,
+      appBlockId: baseArgs.appBlockId,
+      callbackUrl: baseArgs.callbackUrl,
+    });
+  });
+});

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -103,11 +103,19 @@ export async function triggerBuild(args: TriggerBuildArgs): Promise<{ name: stri
     throw new Error('APPS_TEKTON_TRIGGER_URL / APPS_TEKTON_TRIGGER_SECRET not configured');
   }
 
+  // F5 — replay-protection timestamp. Integer unix-epoch SECONDS, placed INSIDE
+  // the JSON body BEFORE the HMAC so it is covered by the signature and sent
+  // verbatim. The app-blocks-trigger receiver on talos ALREADY validates
+  // |now-ts| <= 300 ENFORCE-IF-PRESENT (app-blocks-trigger.py TS_SKEW_SECONDS),
+  // so adding it here activates that already-live (currently inert) check. Must
+  // match the receiver's contract exactly: field name `ts`, integer seconds.
+  const ts = Math.floor(Date.now() / 1000);
   const body = JSON.stringify({
     slug: args.slug,
     sha: args.sha,
     appBlockId: args.appBlockId,
     callbackUrl: args.callbackUrl,
+    ts,
   });
   const sig = createHmac('sha256', secret).update(body).digest('hex');
 

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -16,6 +16,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 const {
   SECRET,
+  mockEnvStore,
   mockFlag,
   mockRedis,
   mockSetNx,
@@ -27,8 +28,13 @@ const {
 } = vi.hoisted(() => {
   // nxResult: true = newly set (first time), false = key already present (replay).
   const mockRedis = { nxResult: true, nxThrows: false };
+  const SECRET = 'test-build-callback-secret';
   return {
-    SECRET: 'test-build-callback-secret',
+    SECRET,
+    // Mutable env backing store so dual-secret (F6) tests can set/clear
+    // BLOCK_BUILD_CALLBACK_SECRET[_NEXT] per case. Defaults to the single
+    // current secret so the existing handler tests are unchanged.
+    mockEnvStore: { BLOCK_BUILD_CALLBACK_SECRET: SECRET } as Record<string, unknown>,
     mockFlag: { enabled: true },
     mockRedis,
     // mirrors redis.setNxKeepTtlWithEx(key, value, ttl): Promise<boolean>
@@ -46,7 +52,7 @@ const {
 
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
 vi.mock('~/env/server', () => ({
-  env: new Proxy({ BLOCK_BUILD_CALLBACK_SECRET: SECRET } as Record<string, unknown>, {
+  env: new Proxy(mockEnvStore, {
     get(t, p: string) {
       if (p in t) return t[p];
       if (p === 'LOGGING') return '';
@@ -69,7 +75,11 @@ vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
 }));
 vi.mock('~/server/services/blocks/forgejo.service', () => ({ setCommitStatus: mockSetCommitStatus }));
 
-import { expectedImageRef } from '~/pages/api/internal/blocks/build-callback';
+import {
+  checkCallbackTimestamp,
+  expectedImageRef,
+  verifySignature,
+} from '~/pages/api/internal/blocks/build-callback';
 
 /**
  * L-CALLBACK coverage. The handler binds the accepted `imageRef` to ITS OWN
@@ -94,6 +104,104 @@ describe('build-callback imageRef binding', () => {
   });
   it('rejects a prefix-matching but unrelated repo', () => {
     expect(`ghcr.io/civitai/app-block-slug-a-evil:${SHA}` === expectedImageRef('slug-a', SHA)).toBe(false);
+  });
+});
+
+/**
+ * F6 — dual-secret HMAC rotation window. verifySignature must accept a
+ * signature computed under the CURRENT secret OR the optional *_NEXT secret, so
+ * the secret rotates without an outage. With _NEXT unset the behaviour is
+ * byte-identical to the prior single-secret implementation (fail-closed when no
+ * secret is configured / never an empty-key HMAC).
+ */
+describe('build-callback verifySignature dual-secret window (F6)', () => {
+  const body = Buffer.from('{"slug":"x","status":"Succeeded"}', 'utf8');
+  const sign = (secret: string) => createHmac('sha256', secret).update(body).digest('hex');
+
+  beforeEach(() => {
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET = undefined;
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET_NEXT = undefined;
+  });
+  afterEach(() => {
+    // Restore the default single-secret env for the handler tests below.
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET = SECRET;
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET_NEXT = undefined;
+  });
+
+  it('accepts a signature valid under the current secret', () => {
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET = 'current-secret';
+    expect(verifySignature(body, sign('current-secret'))).toBe(true);
+    expect(verifySignature(body, `sha256=${sign('current-secret')}`)).toBe(true);
+  });
+
+  it('accepts BOTH old and NEXT during rotation', () => {
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET = 'old-secret';
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET_NEXT = 'new-secret';
+    expect(verifySignature(body, sign('new-secret'))).toBe(true);
+    expect(verifySignature(body, sign('old-secret'))).toBe(true);
+  });
+
+  it('rejects a signature under neither secret', () => {
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET = 'old-secret';
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET_NEXT = 'new-secret';
+    expect(verifySignature(body, sign('attacker'))).toBe(false);
+  });
+
+  it('NEXT unset → identical single-secret behaviour', () => {
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET = 'only';
+    expect(verifySignature(body, sign('only'))).toBe(true);
+    expect(verifySignature(body, sign('other'))).toBe(false);
+  });
+
+  it('fails closed when NO secret is configured (never an empty-key HMAC)', () => {
+    expect(verifySignature(body, sign(''))).toBe(false);
+    expect(verifySignature(body, sign('anything'))).toBe(false);
+  });
+
+  it('ignores an empty-string secret (does not compute an empty-key HMAC)', () => {
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET = '';
+    mockEnvStore.BLOCK_BUILD_CALLBACK_SECRET_NEXT = 'real-next';
+    expect(verifySignature(body, sign(''))).toBe(false);
+    expect(verifySignature(body, sign('real-next'))).toBe(true);
+  });
+});
+
+/**
+ * F5 — callback `ts` replay-freshness window (pure helper). The signer stamps an
+ * integer unix-epoch-seconds `ts` inside the HMAC-signed body; this check is
+ * enforce-if-present (absent → allow for rollout) and rejects a stale/future or
+ * non-finite ts. HMAC-bound defence-in-depth on top of the #2510 redis dedup,
+ * which fails OPEN and is single-window only.
+ */
+describe('checkCallbackTimestamp (F5)', () => {
+  const NOW = 1_700_000_000; // fixed reference now (unix seconds)
+
+  it('allows an absent ts (enforce-if-present rollout tolerance)', () => {
+    expect(checkCallbackTimestamp(undefined, NOW)).toEqual({ ok: true });
+    expect(checkCallbackTimestamp(null, NOW)).toEqual({ ok: true });
+  });
+
+  it('allows a fresh ts within ±300s', () => {
+    expect(checkCallbackTimestamp(NOW, NOW)).toEqual({ ok: true });
+    expect(checkCallbackTimestamp(NOW - 299, NOW)).toEqual({ ok: true });
+    expect(checkCallbackTimestamp(NOW + 299, NOW)).toEqual({ ok: true });
+    expect(checkCallbackTimestamp(NOW - 300, NOW)).toEqual({ ok: true });
+  });
+
+  it('rejects a stale ts beyond -300s (the replay case)', () => {
+    const r = checkCallbackTimestamp(NOW - 301, NOW);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a future ts beyond +300s', () => {
+    const r = checkCallbackTimestamp(NOW + 301, NOW);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a present-but-non-finite ts', () => {
+    expect(checkCallbackTimestamp('1700000000', NOW).ok).toBe(false);
+    expect(checkCallbackTimestamp(NaN, NOW).ok).toBe(false);
+    expect(checkCallbackTimestamp(Infinity, NOW).ok).toBe(false);
   });
 });
 
@@ -261,5 +369,42 @@ describe('build-callback handler — flag gate + replay guard', () => {
     // mark was set (SET NX) then freed in the catch so a same-sha retry isn't wedged
     expect(mockSetNx).toHaveBeenCalledTimes(1);
     expect(mockRedisDel).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`));
+  });
+
+  // ---- F5: callback `ts` replay-freshness through the handler ----------------
+
+  it('applies on a fresh ts (present + within skew)', async () => {
+    const fresh = Math.floor(Date.now() / 1000);
+    const res = makeRes();
+    await invoke(signedReq({ ...validSuccessBody(), ts: fresh }), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, applied: true });
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1);
+  });
+
+  it('401s a stale (replayed) ts and never reaches the apply path', async () => {
+    const stale = Math.floor(Date.now() / 1000) - 3600; // 1h old → way outside 300s
+    const res = makeRes();
+    await invoke(signedReq({ ...validSuccessBody(), ts: stale }), res);
+    expect(res._status).toBe(401);
+    expect(mockTriggerApply).not.toHaveBeenCalled();
+    // dedup slot untouched — the ts gate is upstream of the redis mark.
+    expect(mockSetNx).not.toHaveBeenCalled();
+  });
+
+  it('applies when ts is absent (enforce-if-present rollout tolerance)', async () => {
+    const res = makeRes();
+    // validSuccessBody() carries no ts at all.
+    await invoke(signedReq(validSuccessBody()), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ applied: true });
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1);
+  });
+
+  it('401s a present-but-non-finite ts', async () => {
+    const res = makeRes();
+    await invoke(signedReq({ ...validSuccessBody(), ts: 'not-a-number' }), res);
+    expect(res._status).toBe(401);
+    expect(mockTriggerApply).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/api/internal/blocks/git-push.test.ts
+++ b/src/tests/api/internal/blocks/git-push.test.ts
@@ -1,15 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
 
 // The handler module imports ~/server/db/client (which inits Prisma at module
-// load and reads env.LOGGING.filter). We only exercise the pure
-// parseExpectedRepo helper, so stub the db + pipeline deps to keep the import
+// load and reads env.LOGGING.filter). The pure parseExpectedRepo +
+// verifyForgejoSignature tests don't touch the db, but the import side-effect
+// would still run — stub the db + pipeline + flipt deps to keep the import
 // side-effect-free.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   triggerBuild: vi.fn(),
 }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(async () => true) }));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  FORGEJO_ORG: 'civitai-apps',
+  getRawFile: vi.fn(),
+  setCommitStatus: vi.fn(),
+}));
+vi.mock('~/server/services/block-manifest-validator.service', () => ({
+  BlockManifestValidator: { validate: vi.fn(() => ({ valid: true, errors: [] })) },
+}));
 
-import { parseExpectedRepo } from '~/pages/api/internal/blocks/git-push';
+// Mutable env mock so each test can set / clear FORGEJO_WEBHOOK_SECRET[_NEXT]
+// before exercising the dual-secret rotation window. vi.hoisted so the object
+// exists before the hoisted vi.mock factory runs.
+const mockEnv = vi.hoisted(() => ({}) as Record<string, unknown>);
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+
+import { parseExpectedRepo, verifyForgejoSignature } from '~/pages/api/internal/blocks/git-push';
 
 /**
  * M-WEBHOOK coverage. The git-push webhook is authenticated only by the
@@ -52,5 +71,81 @@ describe('parseExpectedRepo', () => {
 
   it('rejects an org with an empty slug', () => {
     expect(parseExpectedRepo('civitai-apps/', ORG)).toBeNull();
+  });
+});
+
+/**
+ * F6 — dual-secret HMAC rotation window. verifyForgejoSignature must accept a
+ * signature computed under the CURRENT secret OR the optional *_NEXT secret, so
+ * the secret can be rotated without an outage. With _NEXT unset the behaviour is
+ * byte-identical to the prior single-secret implementation (fail-closed when no
+ * secret is configured).
+ */
+describe('verifyForgejoSignature dual-secret window (F6)', () => {
+  const body = Buffer.from('{"ref":"refs/heads/main","after":"abc"}', 'utf8');
+  const sign = (secret: string) => createHmac('sha256', secret).update(body).digest('hex');
+
+  beforeEach(() => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = undefined;
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = undefined;
+  });
+  afterEach(() => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = undefined;
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = undefined;
+  });
+
+  it('accepts a signature valid under the current secret', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'current-secret';
+    expect(verifyForgejoSignature(body, sign('current-secret'))).toBe(true);
+  });
+
+  it('accepts the `sha256=` prefixed header form too', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'current-secret';
+    expect(verifyForgejoSignature(body, `sha256=${sign('current-secret')}`)).toBe(true);
+  });
+
+  it('accepts a signature valid under the NEXT secret (new signer) during rotation', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'old-secret';
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = 'new-secret';
+    // New signer (NEXT) is accepted...
+    expect(verifyForgejoSignature(body, sign('new-secret'))).toBe(true);
+    // ...AND the old signer is still accepted in the same window.
+    expect(verifyForgejoSignature(body, sign('old-secret'))).toBe(true);
+  });
+
+  it('rejects a signature under neither secret', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'old-secret';
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = 'new-secret';
+    expect(verifyForgejoSignature(body, sign('attacker-secret'))).toBe(false);
+  });
+
+  it('NEXT unset → identical single-secret behaviour (current accepted, others rejected)', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'only-secret';
+    expect(verifyForgejoSignature(body, sign('only-secret'))).toBe(true);
+    expect(verifyForgejoSignature(body, sign('other'))).toBe(false);
+  });
+
+  it('fails closed when NO secret is configured (never an empty-key HMAC)', () => {
+    // Neither secret set → must reject regardless of the provided signature,
+    // including a signature computed with an empty key.
+    expect(verifyForgejoSignature(body, sign(''))).toBe(false);
+    expect(verifyForgejoSignature(body, sign('anything'))).toBe(false);
+  });
+
+  it('ignores an empty-string secret (does not compute an empty-key HMAC)', () => {
+    // An empty-string FORGEJO_WEBHOOK_SECRET must be filtered out, so a
+    // signature computed with the empty key must NOT validate.
+    mockEnv.FORGEJO_WEBHOOK_SECRET = '';
+    mockEnv.FORGEJO_WEBHOOK_SECRET_NEXT = 'real-next';
+    expect(verifyForgejoSignature(body, sign(''))).toBe(false);
+    // The real NEXT secret still works.
+    expect(verifyForgejoSignature(body, sign('real-next'))).toBe(true);
+  });
+
+  it('rejects a missing / empty / non-string header', () => {
+    mockEnv.FORGEJO_WEBHOOK_SECRET = 'current-secret';
+    expect(verifyForgejoSignature(body, undefined)).toBe(false);
+    expect(verifyForgejoSignature(body, '')).toBe(false);
+    expect(verifyForgejoSignature(body, 42 as unknown)).toBe(false);
   });
 });


### PR DESCRIPTION
Re-ports two App Blocks HMAC-hardening fixes onto **`main`** (the live App Blocks branch). They were originally built against the now-dead `feat/app-blocks-main-v1` branch and got stranded there (#2518 / #2520). `main` has since diverged with its own security work (#2510, #2524), so this **re-applies the logic onto main's current files** — it is not a cherry-pick. Standalone PR (not stacked). The counterpart legs are already LIVE on datapacket-talos `trunk` via Flux and have been waiting for `main` to participate.

## F6 — dual-secret HMAC rotation (the real gap on main)

`src/pages/api/internal/blocks/git-push.ts` and `build-callback.ts` each verified against a **single** secret. They now accept a signature valid under **EITHER** the current secret **OR** an optional `*_NEXT` secret:

- `git-push.ts` → `FORGEJO_WEBHOOK_SECRET` + optional `FORGEJO_WEBHOOK_SECRET_NEXT`
- `build-callback.ts` → `BLOCK_BUILD_CALLBACK_SECRET` + optional `BLOCK_BUILD_CALLBACK_SECRET_NEXT`

Both verifiers compute the HMAC for **every** configured secret (no `||` short-circuit, so timing doesn't leak which secret matched), compare each constant-time with the existing length-checked `safeEqualHex`/`timingSafeEqual` helper, and accept if either matches. Empty/undefined secrets are filtered out **before** `createHmac` (never an empty-key HMAC). No secret set → reject (fail-closed). `_NEXT` unset → byte-identical to today. Both `*_NEXT` vars added to `src/env/server-schema.ts` as `z.string().optional()`. Mirrors the existing `BLOCK_TOKEN_PUBLIC_KEY_NEXT` rotation precedent in `block-token.service.ts`.

This **completes the three-secret zero-downtime rotation** — the other two legs are already on datapacket-talos `trunk`: the `app-blocks-trigger.py` receiver dual-accepts `APPS_TEKTON_TRIGGER_SECRET` + `_NEXT`, and the `HMAC-SECRET-ROTATION.md` runbook.

## F5 — activate the inert talos `ts` replay leg

Wire contract (matches the live talos side exactly): `ts` = integer **unix epoch seconds**, inside the HMAC-signed body, **300s** skew, **enforce-if-present** (absent/non-finite → allow for rollout safety).

- **Trigger leg (main is the SIGNER):** `apps-pipeline.service.ts` `triggerBuild()` now stamps `ts: Math.floor(Date.now()/1000)` into the JSON body **before** it is HMAC-signed → activates the already-live (currently inert) `app-blocks-trigger.py` ts skew check.
- **Callback leg (main is the RECEIVER):** the talos `app-blocks-callback` Tekton task already signs `ts` into the callback body. `build-callback.ts` now runs an enforce-if-present 300s skew check (`checkCallbackTimestamp`) after HMAC verify, before the apply path.

### Reconciliation with #2510 — decision: ADD the callback-leg ts check

I read #2510's mechanism: it dedups the apply path on `(appBlockId, sha)` via a redis `setNxKeepTtlWithEx` mark. It is **replay-de-dup, NOT freshness** — it **FAILS OPEN** on a Redis error (a real deploy must never be blocked by a Redis outage) and only covers a single 10-minute window. #2510's own comment explicitly flags *"durable cross-window replay protection still needs a caller-supplied signed timestamp/nonce from the Tekton finally task (infra follow-up)."*

The `ts` skew check **is that follow-up**: HMAC-bound freshness that does **not** fail open and bounds the replay window to ±300s regardless of Redis health. The two are **complementary, not redundant** — so I added the callback-leg ts check rather than skipping it.

I did **not** add the `BLOCK_CALLBACK_REQUIRE_PENDING_RUN` pending-run machinery — that was the dead feat-branch approach; main uses #2510 instead. (That env var is set on next/dp-prod but is inert on main — left as-is, out of scope.)

## Preservation

- **#2510** (redis `(appBlockId, sha)` dedup, fail-open) — untouched.
- **#2524** (git-push mod-gate / no-trust-on-push) — untouched.
- Raw-body HMAC (`bodyParser: false`) intact — which bytes are hashed is unchanged.

## Tests

Extended the existing handler tests and added one new file:
- `git-push.test.ts` — `verifyForgejoSignature` dual-secret (current / NEXT-during-rotation / neither / NEXT-unset / no-secret-fail-closed / empty-string-secret-filtered / bad-header).
- `build-callback.test.ts` — `verifySignature` dual-secret (same matrix); `checkCallbackTimestamp` pure (absent / fresh / stale / future / non-finite); handler ts present-fresh→apply, stale→401, absent→apply, non-finite→401.
- `apps-pipeline.triggerBuild.test.ts` (new) — `ts` is a finite integer in unix **seconds** and is covered by the `X-AppBlocks-Trigger-Sig` HMAC (a ts-stripped body produces a different sig).

**57 tests pass** across the 4 block test files. `tsc --noEmit` is clean on all changed files (the one pre-existing `git-push.gate.test.ts` tuple-typing tsc note is on `main` already and untouched here — that suite passes at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)