### PR TITLE
fix(test): repair git-push.gate.test typecheck (unblocks all PR previews)

### DIFF
--- a/src/tests/api/internal/blocks/git-push.gate.test.ts
+++ b/src/tests/api/internal/blocks/git-push.gate.test.ts
@@ -76,7 +76,7 @@ const {
       if (where.status === 'pending') return state.pendingPubReqForSha;
       return null;
     }),
-    mockPubReqCreate: vi.fn(async () => undefined),
+    mockPubReqCreate: vi.fn(async (_args: { data: Record<string, unknown> }) => undefined),
     mockPubReqUpdate: vi.fn(async () => undefined),
     mockPubReqUpdateMany: vi.fn(async () => ({ count: 0 })),
     mockNewUlid: vi.fn(() => '0123456789ABCDEFGHJKMNPQRS'),


### PR DESCRIPTION
## Problem
`main` is red: `pnpm run typecheck` fails on `src/tests/api/internal/blocks/git-push.gate.test.ts:221` with TS2493 + TS2352. This was introduced by #2524 (`58381010f`). Because the Tekton **preview / deploy** is gated on Type Check, **every open PR branched off main fails its preview build** (confirmed on #2528, #2529, #2530 — all fail the identical error in this untouched file).

## Root cause
`mockPubReqCreate: vi.fn(async () => undefined)` declares the mock with **zero parameters**, so `mock.calls[0][0]` (line 221) indexes an empty-tuple arg list (TS2493 "Tuple type '[]' has no element at index '0'") and casts the `undefined` return to `{ data: ... }` (TS2352).

## Fix
Give the mock its actual parameter (mirroring the sibling `mockPubReqFindFirst`), so `mock.calls[0][0]` is typed and the existing cast is sound.

```ts
- mockPubReqCreate: vi.fn(async () => undefined),
+ mockPubReqCreate: vi.fn(async (_args: { data: Record<string, unknown> }) => undefined),
```

## Verification
- Targeted `tsc --noEmit` reports **no errors** in `git-push.gate.test.ts` (CI's full typecheck only flagged this file; the local stale-Prisma-client noise in other files does not occur on CI).
- `vitest run` on the file: **10/10 pass**.

Test-only, one line. Once merged, the three App Blocks GA-blocker PRs (#2528/#2529/#2530) need `main` merged in to pick up the fix and get green previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)