### PR TITLE
fix(search): return 503 (not 500/408) when the search backend is unavailable

### DIFF
--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -11,7 +11,12 @@ import { ImageSort } from '~/server/common/enums';
 import client from 'prom-client';
 import { buildFliptContext, getFeatureFlags } from '~/server/services/feature-flags.service';
 import { ensureRegisterFeedImageExistenceCheckMetrics } from '~/server/metrics/feed-image-existence-check.metrics';
-import { buildSearchActor } from '~/server/meilisearch/client';
+import {
+  buildSearchActor,
+  isFailfastStatus,
+  MeiliCallTimeoutError,
+  MeilisearchFetchError,
+} from '~/server/meilisearch/client';
 import {
   getAllImages,
   getAllImagesIndex,
@@ -323,6 +328,28 @@ async function handleImagesRequest(req: NextApiRequest, res: NextApiResponse) {
       // fault. 499 keeps it out of the 5xx SLO + the http-errors counter. (Was the
       // top mislabeled-500 source on this endpoint.)
       if (!res.headersSent) res.status(499).end();
+      return;
+    }
+    // Meili saturation / timeout / upstream 5xx (feeds-proxy shed or backend
+    // brownout) → 503 SERVICE_UNAVAILABLE, retryable. Without this the raw
+    // MeiliCallTimeoutError / MeilisearchFetchError is not a TRPCError, so the
+    // generic mapping below defaults it to 500 — the dominant mislabeled-500
+    // source on this endpoint. no-store so an edge layer can't cache the error,
+    // Retry-After so clients/CF retry the (typically seconds-long) flap.
+    // Mirrors the tRPC image feed + the /api/v1/models handler. 4xx-other
+    // (malformed filter / auth) is NOT failfast-eligible and still bubbles to
+    // the generic mapping below.
+    if (
+      error instanceof MeiliCallTimeoutError ||
+      (error instanceof MeilisearchFetchError && isFailfastStatus(error.status))
+    ) {
+      if (!res.headersSent) {
+        res.setHeader('Cache-Control', 'no-store');
+        res.setHeader('Retry-After', '2');
+        res
+          .status(503)
+          .json({ error: 'Image search is temporarily overloaded — please retry.' });
+      }
       return;
     }
     const trpcError = error as TRPCError;

--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -137,12 +137,13 @@ export default MixedAuthEndpoint(async function handler(
     } catch (e) {
       if (e instanceof MeiliCallTimeoutError) {
         // Override the public cache headers set by MixedAuthEndpoint —
-        // without this Cloudflare caches the 408 and turns a transient
-        // Meili brownout into a sticky 408 wall for every other
+        // without this Cloudflare caches the 503 and turns a transient
+        // Meili brownout into a sticky 503 wall for every other
         // unauthenticated caller with the same query.
         res.setHeader('Cache-Control', 'no-store');
+        res.setHeader('Retry-After', '2');
         return res
-          .status(408)
+          .status(503)
           .json({ error: 'Model search is temporarily overloaded — please retry.' });
       }
       throw e;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2109,27 +2109,29 @@ export const getAllImagesIndex = async (
     ));
   } catch (err) {
     // Meilisearch saturation / timeout on the tRPC hot path (image.getInfinite).
-    // Surface as TRPCError TIMEOUT so the client returns 408 fast instead of
-    // bleeding until Traefik's 30s router timeout — which is what backed up
-    // the event loop and tipped api-primary into kubelet SIGKILL on 2026-05-29.
-    // tRPC v10 has no SERVICE_UNAVAILABLE / 503 code; TIMEOUT is the closest
-    // semantic match.
+    // Surface as TRPCError SERVICE_UNAVAILABLE (HTTP 503) so the client gets a
+    // fast, retryable response instead of bleeding until Traefik's 30s router
+    // timeout — which is what backed up the event loop and tipped api-primary
+    // into kubelet SIGKILL on 2026-05-29. 503 is the correct code for a
+    // transient backend brownout (was TIMEOUT/408 as a tRPC-v10 stopgap; v11
+    // has SERVICE_UNAVAILABLE).
     if (err instanceof MeiliCallTimeoutError) {
       throw new TRPCError({
-        code: 'TIMEOUT',
+        code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
         cause: err,
       });
     }
     // Upstream returned 408 (backend timeout) or 5xx (feeds-proxy shed /
-    // brownout). Same disposition as the timeout above — a retryable TIMEOUT
-    // so the client shows its retry banner with a friendly message, instead
-    // of a raw 500 ("Meilisearch fetch failed (503): ...") leaking to the UI.
+    // brownout). Same disposition as the timeout above — a retryable 503
+    // SERVICE_UNAVAILABLE so the client shows its retry banner with a friendly
+    // message, instead of a raw 500 ("Meilisearch fetch failed (503): ...")
+    // leaking to the UI.
     // Mirrors the user/model search REST handlers. 4xx-other (malformed
     // filter / auth) is NOT failfast-eligible and still bubbles as-is.
     if (err instanceof MeilisearchFetchError && isFailfastStatus(err.status)) {
       throw new TRPCError({
-        code: 'TIMEOUT',
+        code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
         cause: err,
       });
@@ -2773,23 +2775,23 @@ export async function getImagesFromFeedSearch(
     };
   } catch (err) {
     console.error('Error in getImagesFromFeedSearch:', err);
-    // Meili saturation / timeout → fail fast as TIMEOUT (HTTP 408) so the
-    // caller gets a fast, retryable response instead of bleeding 30s while
-    // Traefik gives up. tRPC v10 has no SERVICE_UNAVAILABLE / 503 code, so
-    // TIMEOUT (the closest semantic match) is used here.
+    // Meili saturation / timeout → fail fast as SERVICE_UNAVAILABLE (HTTP 503)
+    // so the caller gets a fast, retryable response instead of bleeding 30s
+    // while Traefik gives up. 503 is the correct transient-brownout code
+    // (was TIMEOUT/408 under tRPC v10, which lacked SERVICE_UNAVAILABLE).
     if (err instanceof MeiliCallTimeoutError) {
       throw new TRPCError({
-        code: 'TIMEOUT',
+        code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
         cause: err,
       });
     }
-    // 408/5xx from the upstream (or feeds-proxy) → retryable TIMEOUT, same as
+    // 408/5xx from the upstream (or feeds-proxy) → retryable 503, same as
     // the circuit-open path above. Keeps this path symmetric with
     // getAllImagesIndex even though it's REST-only and historically low-error.
     if (err instanceof MeilisearchFetchError && isFailfastStatus(err.status)) {
       throw new TRPCError({
-        code: 'TIMEOUT',
+        code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
         cause: err,
       });
@@ -4197,11 +4199,11 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     // makes the client treat it as end-of-feed (nextCursor undefined →
     // hasNextPage false → no retry), and during a brownout every feed does
     // the same, so switching feeds also shows "no results". Surface a
-    // retryable TIMEOUT instead so the existing SearchRetryBanner kicks in.
+    // retryable 503 instead so the existing SearchRetryBanner kicks in.
     // (A non-empty partial page still serves normally — degraded, not broken.)
     if (brokeOnUpstreamFailure && accumulatedHits.length === 0) {
       throw new TRPCError({
-        code: 'TIMEOUT',
+        code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
       });
     }

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -322,7 +322,7 @@ export const getModelsRaw = async ({
     } catch (err) {
       if (err instanceof MeiliCallTimeoutError) {
         throw new TRPCError({
-          code: 'TIMEOUT',
+          code: 'SERVICE_UNAVAILABLE',
           message: 'Model search is temporarily overloaded — please retry.',
           cause: err,
         });

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -269,13 +269,13 @@ export async function getUsersWithSearch({
       })
     );
   } catch (err) {
-    // Mirror image.getInfinite's handling: surface a fast 408 via TRPCError
-    // TIMEOUT so the client can retry instead of waiting on Traefik's 30s
-    // router timeout. tRPC v10 has no SERVICE_UNAVAILABLE / 503 code; TIMEOUT
-    // is the closest semantic match.
+    // Mirror image.getInfinite's handling: surface a fast, retryable 503 via
+    // TRPCError SERVICE_UNAVAILABLE so the client can retry instead of waiting
+    // on Traefik's 30s router timeout. (Was TIMEOUT/408 under tRPC v10, which
+    // lacked SERVICE_UNAVAILABLE; v11 has it.)
     if (err instanceof MeiliCallTimeoutError) {
       throw new TRPCError({
-        code: 'TIMEOUT',
+        code: 'SERVICE_UNAVAILABLE',
         message: 'User search is temporarily overloaded — please retry.',
         cause: err,
       });


### PR DESCRIPTION
## Why

The feeds-meilisearch pool is chronically flap-prone (page-cache thrash on the 720 GB LMDB index that doesn't fit in pod memory; ~155 health-flaps/6h). When it browns out, the API returned the **wrong status code**:

1. **`/api/v1/images` returned 500.** Its catch casts the error to `TRPCError` and calls `getHTTPStatusCodeFromError`, but a raw `MeiliCallTimeoutError` / `MeilisearchFetchError` isn't a `TRPCError`, so it defaulted to **500**. This is the **dominant mislabeled-500 source** on the endpoint (~0.2–0.3/s of the dp-prod app-500 floor). The tRPC image feed and `/api/v1/models` already mapped this off 500; `/api/v1/images` was simply never given the mapping.

2. **The paths that *did* remap used 408 (`TIMEOUT`)** — a deliberate stopgap, with a comment: *"tRPC v10 has no SERVICE_UNAVAILABLE / 503 code; TIMEOUT is the closest."* The repo is now on **`@trpc/server` v11**, which has `SERVICE_UNAVAILABLE` → 503. 408 means "the client was too slow to send its request" — semantically wrong for an upstream brownout. 503 ("service temporarily unable, retry later") is correct and conventionally carries `Retry-After`.

## What

- **`/api/v1/images`**: map `MeiliCallTimeoutError` / `MeilisearchFetchError`+`isFailfastStatus` → **503** + `Cache-Control: no-store` (so Cloudflare can't cache the error — the `/api/v1/models` handler learned this the hard way) + `Retry-After: 2`. 4xx-other (bad filter / auth) still bubbles to the generic mapping.
- **Flip the existing 408 → 503** across the tRPC image/model/user search paths and the `/api/v1/models` REST handler; retire the v10 comments.

## Honest scope

503 is still a 5xx — this is about **correctness + retryability**, not reducing the raw 5xx count:
- The **500 bucket now means real bugs**; transient search-unavailability is a 503 (a backend-health signal).
- 503 + `Retry-After` + `no-store` lets **Cloudflare and API clients retry** the (typically seconds-long) flap → fewer *user-visible* failures even though origin 5xx is reclassified.
- `SearchRetryBanner` fires on `isError` (any code), so the web client's retry UX is unaffected.

Companion to the feeds-proxy resilience change (meilisearch-proxy#10, deployed) which absorbs single-host flaps; this makes the *residual* unavailability honest + retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)