### PR TITLE
feat(app-blocks): dedicated app-blocks-pipeline-enabled flag for machine webhooks (Decision 1)

### DIFF
--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -4,8 +4,8 @@ import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbWrite } from '~/server/db/client';
-import { isFlipt } from '~/server/flipt/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
 import { setCommitStatus } from '~/server/services/blocks/forgejo.service';
 import { triggerApply, waitForApplyJob } from '~/server/services/blocks/apps-pipeline.service';
 
@@ -225,11 +225,13 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  // Kill switch: honour the appBlocks flag like the sibling webhooks
-  // (git-push, workflow-completed). When the substrate is dark, no legitimate
+  // Kill switch: honour the PIPELINE flag like the sibling webhooks
+  // (git-push, workflow-completed). When the pipeline is dark, no legitimate
   // build callback should fire — refuse so the apply/deploy chain can't run
-  // independent of the flag. Server-context Flipt eval, matching the siblings.
-  if (!(await isFlipt('app-blocks-enabled'))) {
+  // independent of the flag. Decision 1: gated on the dedicated global
+  // `app-blocks-pipeline-enabled` flag (NOT the mod-segmented user flag), so the
+  // pipeline can run for mod-approved blocks without enabling the user feature.
+  if (!(await isAppBlocksPipelineEnabled())) {
     res.status(503).json({ error: 'App Blocks not enabled' });
     return;
   }

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -4,7 +4,7 @@ import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { isFlipt } from '~/server/flipt/client';
+import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
 import {
   BlockManifestValidator,
   type AppContext,
@@ -146,8 +146,10 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  // Kill switch — block all platform mutations when the feature is off.
-  const enabled = await isFlipt('app-blocks-enabled');
+  // Kill switch — block all platform mutations when the pipeline is off.
+  // Decision 1: gated on the dedicated global `app-blocks-pipeline-enabled` flag
+  // (NOT the mod-segmented user flag) so the publish pipeline can run.
+  const enabled = await isAppBlocksPipelineEnabled();
   if (!enabled) {
     res.status(503).json({ error: 'App Blocks not enabled' });
     return;

--- a/src/pages/api/internal/blocks/workflow-completed.ts
+++ b/src/pages/api/internal/blocks/workflow-completed.ts
@@ -84,6 +84,14 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // refuse to record completions even if the orchestrator ships callbacks
   // ahead of Phase 3. Prevents phantom rows. Decision 1: gated on the dedicated
   // global `app-blocks-pipeline-enabled` flag (NOT the mod-segmented user flag).
+  //
+  // DECISION (revisit before Phase-3 billing): this is a RUNTIME billing/
+  // attribution callback, not a build event, yet it currently shares the build
+  // kill-switch `app-blocks-pipeline-enabled`. Harmless today (this handler is a
+  // scaffold with no billing + the orchestrator does not emit the callback yet),
+  // but once real billing lands here, flipping the build flag OFF would 503 these
+  // completions and silently drop Buzz attribution. Give it its OWN flag
+  // (e.g. `app-blocks-billing-enabled`) before Phase-3 billing wires real spend.
   const enabled = await isAppBlocksPipelineEnabled();
   if (!enabled) {
     res.status(503).json({ error: 'App Blocks not enabled' });

--- a/src/pages/api/internal/blocks/workflow-completed.ts
+++ b/src/pages/api/internal/blocks/workflow-completed.ts
@@ -4,8 +4,8 @@ import * as z from 'zod';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
 import { dbRead } from '~/server/db/client';
-import { isFlipt } from '~/server/flipt/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
 
 // H2 (audit-10): cap the orchestrator callback body. Realistic payloads are
 // a few hundred bytes (workflowId + blockInstanceId + buzzSpent).
@@ -56,9 +56,10 @@ function safeEqualHeader(provided: unknown, expected: string): boolean {
  * actual developer-revenue attribution and ClickHouse `block_workflows`
  * emission on top of this scaffold.
  *
- * L12 kill switch: a Flipt flag `app-blocks-enabled` gates this endpoint.
- * If the orchestrator ships callbacks before Phase 3 billing lands, the
- * flag stays off and we return 503 — no phantom completion records.
+ * L12 kill switch: the Flipt flag `app-blocks-pipeline-enabled` gates this
+ * endpoint (Decision 1 — the dedicated pipeline flag, not the mod-segmented
+ * user flag). If the orchestrator ships callbacks before Phase 3 billing lands,
+ * the flag stays off and we return 503 — no phantom completion records.
  */
 
 const BLOCK_INSTANCE_ID_RE = /^bki_[0-9A-HJKMNP-TV-Z]{26}$/;
@@ -79,10 +80,11 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  // L12: kill switch via Flipt. While the substrate is gated off in prod,
+  // L12: kill switch via Flipt. While the pipeline is gated off in prod,
   // refuse to record completions even if the orchestrator ships callbacks
-  // ahead of Phase 3. Prevents phantom rows.
-  const enabled = await isFlipt('app-blocks-enabled');
+  // ahead of Phase 3. Prevents phantom rows. Decision 1: gated on the dedicated
+  // global `app-blocks-pipeline-enabled` flag (NOT the mod-segmented user flag).
+  const enabled = await isAppBlocksPipelineEnabled();
   if (!enabled) {
     res.status(503).json({ error: 'App Blocks not enabled' });
     return;

--- a/src/server/services/__tests__/app-blocks-flag.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.test.ts
@@ -109,3 +109,30 @@ describe('isAppBlocksEnabled — machine/anonymous gates stay global (H2 scope)'
     await expect(isAppBlocksEnabled()).resolves.toBe(true);
   });
 });
+
+describe('isAppBlocksEnabled — no accidental repoint to the pipeline flag (Decision 1 regression)', () => {
+  // The user-facing gate MUST keep reading `app-blocks-enabled`. Decision 1 added
+  // a separate `app-blocks-pipeline-enabled` flag for the machine webhooks; this
+  // pins that the USER gate never silently moved onto the pipeline key (which
+  // would widen the user feature to whatever the global pipeline flag is set to).
+  it('per-user mod eval reads ONLY app-blocks-enabled, never app-blocks-pipeline-enabled', async () => {
+    const user = makeUser({ isModerator: true });
+    await expect(isAppBlocksEnabled({ user })).resolves.toBe(true);
+    // The only flag key the user gate ever evaluates is the user-facing one.
+    for (const call of mockIsFlipt.mock.calls) {
+      expect(call[0]).toBe('app-blocks-enabled');
+    }
+    expect(mockIsFlipt).not.toHaveBeenCalledWith(
+      'app-blocks-pipeline-enabled',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+  });
+
+  it('no-arg machine eval reads ONLY app-blocks-enabled (JWKS / withBlockScope path unchanged)', async () => {
+    await isAppBlocksEnabled();
+    expect(mockIsFlipt).toHaveBeenCalledWith('app-blocks-enabled');
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+  });
+});

--- a/src/server/services/__tests__/app-blocks-pipeline-flag.test.ts
+++ b/src/server/services/__tests__/app-blocks-pipeline-flag.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Decision 1 — dedicated PIPELINE flag.
+ *
+ * `isAppBlocksPipelineEnabled()` is the global (no-user) gate the build/publish
+ * webhooks (`build-callback`, `git-push`, `workflow-completed`) use. It MUST:
+ *   - evaluate the `app-blocks-pipeline-enabled` flag key (NOT the user-facing
+ *     `app-blocks-enabled` flag) — proving the pipeline is decoupled from the
+ *     mod-segmented user feature;
+ *   - eval GLOBALLY (no user context), mirroring how the machine webhooks have
+ *     always called Flipt;
+ *   - be FAIL-SAFE: when the pipeline flag is absent / off (the as-merged state,
+ *     since the flag is created in Flipt only AFTER this lands) it resolves
+ *     `false` → the pipeline stays dark.
+ *
+ * `isFlipt` is mocked PER-KEY so the assertions can prove the helper reads the
+ * pipeline key and ignores the user flag's state.
+ */
+
+const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
+
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: mockIsFlipt,
+}));
+
+import { isAppBlocksPipelineEnabled, APP_BLOCKS_PIPELINE_FLAG } from '../app-blocks-flag';
+
+// Per-key Flipt stand-in. Only `app-blocks-pipeline-enabled` can turn the
+// pipeline on; `app-blocks-enabled` (the user flag) being on must NOT leak in.
+function perKeyFlipt(state: { pipeline: boolean; user: boolean }) {
+  return async (flag: string): Promise<boolean> => {
+    if (flag === 'app-blocks-pipeline-enabled') return state.pipeline;
+    if (flag === 'app-blocks-enabled') return state.user;
+    return false; // unknown / absent flag → false (matches real isFlipt)
+  };
+}
+
+beforeEach(() => {
+  mockIsFlipt.mockReset();
+});
+
+describe('isAppBlocksPipelineEnabled — Decision 1 pipeline gate', () => {
+  it('exports the dedicated pipeline flag key', () => {
+    expect(APP_BLOCKS_PIPELINE_FLAG).toBe('app-blocks-pipeline-enabled');
+  });
+
+  it('reads the pipeline flag key with a GLOBAL eval (no user context)', async () => {
+    mockIsFlipt.mockImplementation(perKeyFlipt({ pipeline: true, user: false }));
+    await expect(isAppBlocksPipelineEnabled()).resolves.toBe(true);
+    // Only the flag key — entityId + context fall back to client.ts globals.
+    expect(mockIsFlipt).toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+    expect(mockIsFlipt).toHaveBeenCalledTimes(1);
+    // It must NEVER read the user-facing flag.
+    expect(mockIsFlipt).not.toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('stays OFF when ONLY the user-facing flag is on (decoupled — no leak)', async () => {
+    // Pipeline flag off, user flag on. The pipeline gate must still refuse.
+    mockIsFlipt.mockImplementation(perKeyFlipt({ pipeline: false, user: true }));
+    await expect(isAppBlocksPipelineEnabled()).resolves.toBe(false);
+  });
+
+  it('FAIL-SAFE: resolves false when the pipeline flag is absent (isFlipt → false)', async () => {
+    // Simulate a missing flag / unreachable Flipt: isFlipt returns false.
+    mockIsFlipt.mockResolvedValue(false);
+    await expect(isAppBlocksPipelineEnabled()).resolves.toBe(false);
+  });
+});

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -5,6 +5,24 @@ import { buildFliptContext } from '~/server/services/feature-flags.service';
 const APP_BLOCKS_FLAG = 'app-blocks-enabled';
 
 /**
+ * Dedicated GLOBAL flag for the build/publish/deploy PIPELINE (Decision 1).
+ *
+ * The user-facing `app-blocks-enabled` flag is base `enabled: false` with a
+ * `moderators` segment, so it only ever resolves `true` when evaluated WITH a
+ * moderator's context. The machine/pipeline webhooks have no user context and
+ * eval globally, so they could never pass that flag — the build/publish chain
+ * was permanently dark (build-callback 503, no mod-approved block could deploy).
+ *
+ * This separate global flag lets "can the pipeline run" move independently of
+ * "can users see blocks". It is evaluated globally (entityId='global', empty
+ * context), so it must be a plain base-`enabled` boolean (NOT segmented) to turn
+ * on. The flag does not exist yet — it is created in Flipt AFTER this merges, so
+ * the as-merged behaviour is unchanged: a missing flag → `isFlipt` returns
+ * `false` → the pipeline stays dark (the fail-safe invariant below).
+ */
+export const APP_BLOCKS_PIPELINE_FLAG = 'app-blocks-pipeline-enabled';
+
+/**
  * Server-side check for the App Blocks feature flag.
  *
  * The UI mount, the workflow-completed callback, every write endpoint, every
@@ -35,17 +53,26 @@ const APP_BLOCKS_FLAG = 'app-blocks-enabled';
  *   the SERVER-side `user.isModerator`, never a client-supplied value).
  *
  * - **Machine-to-machine / anonymous gates have NO user** and genuinely cannot
- *   evaluate a mod-segmented flag. The internal webhooks (`build-callback`,
- *   `git-push`, `workflow-completed`, the JOB_TOKEN-authed manifest registrar)
- *   and the JWKS public-key endpoint call this with no argument → the original
- *   GLOBAL eval (`entityId='global'`, empty context). They are deliberately
- *   left on the global path: the build/publish PIPELINE therefore still
- *   requires a GLOBAL enable of `app-blocks-enabled` to run. That is an
- *   intentional, separate decision — a future dedicated
- *   `app-blocks-pipeline-enabled` global flag should own the pipeline so the
- *   mod-segmented user flag and the machine pipeline flag can move
- *   independently. Until then, do NOT fabricate user context for the machine
- *   gates (the no-arg overload below preserves their existing behaviour).
+ *   evaluate a mod-segmented flag. They eval globally (`entityId='global'`,
+ *   empty context), which can never match the `moderators` segment. They split
+ *   into two groups:
+ *
+ *   1. The build/publish **PIPELINE** webhooks (`build-callback`, `git-push`,
+ *      `workflow-completed`) gate on the dedicated global
+ *      `app-blocks-pipeline-enabled` flag via `isAppBlocksPipelineEnabled()`
+ *      (Decision 1). This decouples "can the pipeline run" from the
+ *      mod-segmented user flag, so a mod-approved block can actually build and
+ *      deploy without globally enabling the user-facing feature.
+ *
+ *   2. The JWKS public-key endpoint and the `withBlockScope` token-verification
+ *      middleware (runtime, not build) still call the no-arg `isAppBlocksEnabled()`
+ *      → the original GLOBAL eval of `app-blocks-enabled`. Repointing those is a
+ *      separate decision (Decision 4); they are intentionally left as-is here.
+ *      The JOB_TOKEN-authed manifest registrar (`block-manifests`) likewise
+ *      stays on `isAppBlocksEnabled()` for now (out of this change's scope).
+ *
+ *   For all machine gates, do NOT fabricate user context (the no-arg overload
+ *   below, and the pipeline helper, preserve the global-eval behaviour).
  *
  * The FLAG_OVERRIDE/local-overrides env exists for unit tests + local dev that
  * need to flip the flag without standing up Flipt.
@@ -63,4 +90,24 @@ export async function isAppBlocksEnabled(opts?: { user?: SessionUser }): Promise
   // server-side `isModerator` that the `moderators` segment keys on.
   const user = opts.user;
   return isFlipt(APP_BLOCKS_FLAG, String(user.id), buildFliptContext(user));
+}
+
+/**
+ * GLOBAL gate for the build/publish/deploy PIPELINE webhooks (Decision 1).
+ *
+ * Evaluates the dedicated `app-blocks-pipeline-enabled` flag with no user
+ * context (entityId='global', empty context), mirroring how the machine
+ * webhooks have always called Flipt — only the flag KEY changes. This is
+ * decoupled from the mod-segmented user-facing `app-blocks-enabled` flag so the
+ * pipeline can run for mod-approved blocks without enabling the feature for
+ * users.
+ *
+ * Fail-safe: if `app-blocks-pipeline-enabled` does not exist (it is created in
+ * Flipt only AFTER this merges) or Flipt is unreachable, `isFlipt` returns
+ * `false` → the pipeline webhooks REFUSE (503) → the pipeline stays dark. So
+ * this change is a no-op on as-merged behaviour and cannot regress the gate
+ * open.
+ */
+export async function isAppBlocksPipelineEnabled(): Promise<boolean> {
+  return isFlipt(APP_BLOCKS_PIPELINE_FLAG);
 }

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -64,7 +64,16 @@ vi.mock('~/server/db/client', () => ({
   dbRead: {},
   dbWrite: { appBlock: { update: mockAppBlockUpdate } },
 }));
-vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(async () => mockFlag.enabled) }));
+// Per-key Flipt mock: the build-callback gate now reads the dedicated
+// `app-blocks-pipeline-enabled` PIPELINE flag (Decision 1), NOT the user-facing
+// `app-blocks-enabled`. Only the pipeline key reflects `mockFlag.enabled`; the
+// user flag is hard-false so a regression that repoints back to it would 503
+// even with the pipeline "on".
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: vi.fn(async (flag: string) =>
+    flag === 'app-blocks-pipeline-enabled' ? mockFlag.enabled : false
+  ),
+}));
 vi.mock('~/server/redis/client', () => ({
   redis: { setNxKeepTtlWithEx: mockSetNx, del: mockRedisDel },
   REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'blocks:token-rate-limit' } },
@@ -80,6 +89,9 @@ import {
   expectedImageRef,
   verifySignature,
 } from '~/pages/api/internal/blocks/build-callback';
+import { isFlipt } from '~/server/flipt/client';
+
+const mockedIsFlipt = vi.mocked(isFlipt);
 
 /**
  * L-CALLBACK coverage. The handler binds the accepted `imageRef` to ITS OWN
@@ -279,6 +291,21 @@ describe('build-callback handler — flag gate + replay guard', () => {
     await invoke(signedReq(validSuccessBody()), res);
     expect(res._status).toBe(503);
     expect(mockTriggerApply).not.toHaveBeenCalled();
+  });
+
+  it('gates on the PIPELINE flag key, not the user-facing flag (Decision 1)', async () => {
+    // pipeline flag on → proceeds; assert the gate evaluated the pipeline key
+    // and NEVER the user-facing `app-blocks-enabled`.
+    mockFlag.enabled = true;
+    const res = makeRes();
+    await invoke(signedReq(validSuccessBody()), res);
+    expect(mockedIsFlipt).toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+    expect(mockedIsFlipt).not.toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockedIsFlipt).not.toHaveBeenCalledWith('app-blocks-enabled');
   });
 
   it('401s on a bad signature before checking the flag', async () => {

--- a/src/tests/api/internal/blocks/git-push.gate.test.ts
+++ b/src/tests/api/internal/blocks/git-push.gate.test.ts
@@ -97,7 +97,15 @@ vi.mock('~/env/server', () => ({
     }
   ),
 }));
-vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(async () => mockFlag.enabled) }));
+// Per-key Flipt mock: git-push now gates on the dedicated
+// `app-blocks-pipeline-enabled` PIPELINE flag (Decision 1), NOT the user-facing
+// `app-blocks-enabled`. Only the pipeline key reflects the toggle; the user flag
+// is hard-false so a regression that repointed back to it would 503.
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: vi.fn(async (flag: string) =>
+    flag === 'app-blocks-pipeline-enabled' ? mockFlag.enabled : false
+  ),
+}));
 vi.mock('~/server/db/client', () => ({
   dbRead: {
     appBlock: { findFirst: mockAppBlockFindFirst, findUnique: mockAppBlockFindUnique },
@@ -125,6 +133,10 @@ vi.mock('~/server/utils/app-block-ids', () => ({ newUlid: mockNewUlid }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   triggerBuild: mockTriggerBuild,
 }));
+
+import { isFlipt } from '~/server/flipt/client';
+
+const mockedIsFlipt = vi.mocked(isFlipt);
 
 function validManifest(sha = NEW_SHA) {
   return {
@@ -302,13 +314,31 @@ describe('git-push webhook — no-trust-on-push gate', () => {
     expect(mockTriggerBuild).not.toHaveBeenCalled();
   });
 
-  it('503s when the app-blocks-enabled flag is off (kill switch) before any DB work', async () => {
+  it('503s when the pipeline flag is off (kill switch) before any DB work', async () => {
     state.flagEnabled = false;
     const res = makeRes();
     await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
     expect(res._status).toBe(503);
     expect(mockAppBlockFindFirst).not.toHaveBeenCalled();
     expect(mockPubReqCreate).not.toHaveBeenCalled();
+  });
+
+  it('gates on the PIPELINE flag key, not the user-facing flag (Decision 1)', async () => {
+    // flag on → proceeds past the gate (reaches DB / pending-review path).
+    state.flagEnabled = true;
+    const res = makeRes();
+    await invoke(signedReq(pushBody({ after: NEW_SHA })), res);
+    // Proceeded past the gate (no 503).
+    expect(res._status).not.toBe(503);
+    expect(mockAppBlockFindFirst).toHaveBeenCalled();
+    // Evaluated the dedicated pipeline key, never the user-facing one.
+    expect(mockedIsFlipt).toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+    expect(mockedIsFlipt).not.toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockedIsFlipt).not.toHaveBeenCalledWith('app-blocks-enabled');
   });
 
   it('rejects an invalid manifest (400) — no pending row, no build (manifest validation preserved)', async () => {

--- a/src/tests/api/internal/blocks/workflow-completed.gate.test.ts
+++ b/src/tests/api/internal/blocks/workflow-completed.gate.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Decision 1 — pipeline flag gate for POST /api/internal/blocks/workflow-completed.
+ *
+ * The orchestrator → civitai completion callback is gated by the dedicated
+ * global `app-blocks-pipeline-enabled` flag (NOT the mod-segmented user flag).
+ * These tests pin:
+ *   - pipeline flag OFF / absent → 503 "App Blocks not enabled", install lookup
+ *     + dedup never run (kill switch, fail-safe to dark);
+ *   - pipeline flag ON → the handler proceeds PAST the gate (reaches the install
+ *     lookup / dedup / 200 path);
+ *   - the gate reads the PIPELINE key, never the user-facing `app-blocks-enabled`.
+ *
+ * `isFlipt` is mocked PER-KEY (only `app-blocks-pipeline-enabled` reflects the
+ * toggle; `app-blocks-enabled` is hard-false) so a regression that repointed the
+ * gate back to the user flag would 503 even with the pipeline "on".
+ */
+
+const JOB_TOKEN = 'test-job-token';
+const BLOCK_INSTANCE_ID = 'bki_0123456789ABCDEFGHJKMNPQRS';
+const WORKFLOW_ID = 'wf_test_123';
+
+const { mockFlag, mockFindUnique, mockIncrBy, mockExpire } = vi.hoisted(() => ({
+  mockFlag: { enabled: true },
+  mockFindUnique: vi.fn(),
+  mockIncrBy: vi.fn(),
+  mockExpire: vi.fn(),
+}));
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ JOB_TOKEN } as Record<string, unknown>, {
+    get(t, p: string) {
+      if (p in t) return t[p];
+      if (p === 'LOGGING') return '';
+      return undefined;
+    },
+  }),
+}));
+// Per-key Flipt mock: only the pipeline key reflects mockFlag.enabled.
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: vi.fn(async (flag: string) =>
+    flag === 'app-blocks-pipeline-enabled' ? mockFlag.enabled : false
+  ),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { blockUserSubscription: { findUnique: mockFindUnique } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { incrBy: mockIncrBy, expire: mockExpire },
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'blocks:token-rate-limit' } },
+}));
+
+import { isFlipt } from '~/server/flipt/client';
+
+const mockedIsFlipt = vi.mocked(isFlipt);
+
+function makeReq(over: Partial<NextApiRequest> = {}): NextApiRequest {
+  return {
+    method: 'POST',
+    headers: { 'x-civitai-internal-token': JOB_TOKEN },
+    body: { workflowId: WORKFLOW_ID, blockInstanceId: BLOCK_INSTANCE_ID, buzzSpent: 0 },
+    ...over,
+  } as unknown as NextApiRequest;
+}
+
+function makeRes(): NextApiResponse & { _status: number; _body: any } {
+  const res = {
+    _status: 0,
+    _body: null as any,
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & { _status: number; _body: any };
+}
+
+async function invoke(req: NextApiRequest, res: NextApiResponse) {
+  const handler = (await import('~/pages/api/internal/blocks/workflow-completed')).default;
+  await handler(req, res);
+}
+
+describe('workflow-completed webhook — pipeline flag gate (Decision 1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlag.enabled = true;
+    // Default: valid install + first-time dedup so the ON path reaches 200.
+    mockFindUnique.mockResolvedValue({
+      id: 'sub_1',
+      targetModelIds: [7],
+      appBlockId: 'apb_1',
+    });
+    mockIncrBy.mockResolvedValue(1);
+    mockExpire.mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('503s when the pipeline flag is off — install lookup + dedup never run (kill switch)', async () => {
+    mockFlag.enabled = false;
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(503);
+    expect(res._body).toMatchObject({ error: 'App Blocks not enabled' });
+    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(mockIncrBy).not.toHaveBeenCalled();
+  });
+
+  it('proceeds PAST the gate when the pipeline flag is on (reaches the install/dedup path → 200)', async () => {
+    mockFlag.enabled = true;
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true });
+    // It got past the gate: install lookup + dedup ran.
+    expect(mockFindUnique).toHaveBeenCalledTimes(1);
+    expect(mockIncrBy).toHaveBeenCalledTimes(1);
+  });
+
+  it('gates on the PIPELINE flag key, never the user-facing app-blocks-enabled (Decision 1)', async () => {
+    mockFlag.enabled = true;
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(mockedIsFlipt).toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+    expect(mockedIsFlipt).not.toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockedIsFlipt).not.toHaveBeenCalledWith('app-blocks-enabled');
+  });
+
+  it('still rejects an unauthenticated caller (401) BEFORE the flag is consulted', async () => {
+    const res = makeRes();
+    await invoke(makeReq({ headers: { 'x-civitai-internal-token': 'wrong' } }), res);
+    expect(res._status).toBe(401);
+    expect(mockedIsFlipt).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

App Blocks **Decision 1**: introduce a dedicated global Flipt flag `app-blocks-pipeline-enabled` and repoint the three internal build/publish/deploy webhooks onto it, decoupling **"can the pipeline run"** from the user-facing **"can users see blocks"** gate.

## Why

The user-facing gate `app-blocks-enabled` is base `enabled:false` + a `moderators` segment, so it only resolves `true` when evaluated **with a moderator's context**. The three machine webhooks eval **globally with no user context**, so they can never pass that flag → the build/publish/deploy chain is permanently dark:
- `build-callback` returns 503 → the Tekton apply/deploy never fires
- no mod-approved block can ever deploy

## Change (minimal)

- `app-blocks-flag.ts`: add + export `APP_BLOCKS_PIPELINE_FLAG = 'app-blocks-pipeline-enabled'` and a parallel global helper `isAppBlocksPipelineEnabled()` (no-user global eval, mirroring how the webhooks already called Flipt — only the flag KEY changes).
- Repoint the 3 webhooks to `isAppBlocksPipelineEnabled()` (drop the raw `isFlipt('app-blocks-enabled')` literals). **Same refuse behaviour: all three 503 when the flag is off.**
  - `build-callback.ts:232`
  - `git-push.ts:150`
  - `workflow-completed.ts:85`

### Left as-is (out of scope)
- **User-facing gate** (`feature-flags.service.ts` `appBlocks.fliptKey`, the tRPC `enforceAppBlocksFlag` middleware, `submit-version`) — unchanged, stays on `app-blocks-enabled`.
- **JWKS** (`block-tokens/jwks.ts`) + **`withBlockScope`** (`block-scope.middleware.ts`) — runtime token verification, not the build pipeline; per the handoff this is a separate **Decision 4**. Left on `app-blocks-enabled`.
- **block-manifests** JOB_TOKEN registrar — also still on `app-blocks-enabled` (not one of the 3 named build webhooks).

## Fail-safe invariant (tested)

`app-blocks-pipeline-enabled` does **not exist in Flipt yet** — it is created **after** this merges. A missing flag / unreachable Flipt → `isFlipt` returns `false` → the webhooks **still 503** → the pipeline stays dark. **No as-merged behaviour change; cannot regress the gate open.**

## Tests

Per-key `isFlipt` mocks so each webhook is proven to read the **pipeline** key, not the user flag:
- `app-blocks-pipeline-flag.test.ts` (new): helper reads `app-blocks-pipeline-enabled` globally, fail-safe on absent flag, no leak from the user flag.
- `workflow-completed.gate.test.ts` (new): flag-off → 503 (install lookup + dedup never run); flag-on → proceeds past gate (200); gate reads pipeline key; 401 still precedes the flag.
- `build-callback.test.ts` + `git-push.gate.test.ts` (extended): per-key mock; new assertions that the gate reads the pipeline key and never the user flag.
- `app-blocks-flag.test.ts` (extended): **regression** — the user-facing gate reads ONLY `app-blocks-enabled`, never the pipeline key (no widening / no accidental repoint).

Local: `vitest run` on the 7 affected files → **77 passed**. Full `tsc`/`db:generate` not run in the worktree (stale Prisma); CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## ⚠️ Scope note (from adversarial audit)
**This unblocks the build/deploy pipeline + the W11 callback-leg `ts` verification — it does NOT make mod dogfooding of installed blocks functional end-to-end.** A deployed block's runtime JWT verification (`withBlockScope`), JWKS, and the manifest registrar still gate on the *dark* user flag `app-blocks-enabled` (global eval → false). So with the pipeline flag on, a mod-approved block **deploys but its tokens won't verify** until **Decision 4** repoints those runtime gates. Do not read "Decision 1 done" as "mods can use blocks."

Audit also flagged: `workflow-completed` (runtime billing/attribution) currently shares this *build* kill-switch — harmless now (scaffold, no orchestrator emitter) but give it its own `app-blocks-billing-enabled` flag before Phase-3 billing (marker added in `7930dc790`).