### PR TITLE
fix(api): reject arity-mismatched pagination cursors as 400 + log silent 500s

### DIFF
--- a/src/server/utils/endpoint-helpers.ts
+++ b/src/server/utils/endpoint-helpers.ts
@@ -238,6 +238,21 @@ export function handleEndpointError(res: NextApiResponse, e: unknown) {
     return res.status(status).json(body);
   } else {
     const error = e as Error;
+    // This branch increments the http-errors counter (via the wrapper's
+    // instrumentApiResponse) but historically logged nothing, so any
+    // non-TRPCError throw inside a wrapped handler — e.g. an unguarded
+    // TypeError — was counted yet completely un-attributable in logs (it took
+    // a live repro to find one such silent 500). Emit class + truncated message
+    // so the next one is attributable from Loki. Class + message only (no
+    // stack, query, or body) to stay PII-light + low-cardinality, and wrapped
+    // so telemetry can never break the error response.
+    try {
+      console.error(
+        `[handleEndpointError] unhandled ${error?.name ?? 'Error'}: ${String(
+          error?.message ?? ''
+        ).slice(0, 300)}`
+      );
+    } catch {}
     return res.status(500).json({ message: 'An unexpected error occurred', error: error.message });
   }
 }

--- a/src/server/utils/pagination-helpers.ts
+++ b/src/server/utils/pagination-helpers.ts
@@ -3,6 +3,7 @@ import dayjs from '~/shared/utils/dayjs';
 import type { NextApiRequest } from 'next';
 import { isProd } from '~/env/other';
 import type { PaginationInput } from '~/server/schema/base.schema';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { QS } from '~/utils/qs';
 
 export const DEFAULT_PAGE_SIZE = 20;
@@ -105,6 +106,20 @@ function parseCursor(fields: SortField[], cursor: string | number | Date | bigin
     return { [fields[0].field]: cursor };
 
   const values = cursor.split('|');
+  // A cursor whose token count doesn't match the sort's field arity is
+  // malformed — typically a stale or hand-built cursor, or one carried across a
+  // deploy that changed the sort's `orderBy` field count. Reject as 400 rather
+  // than crashing on the next line's `values[i].includes(...)` (undefined →
+  // TypeError), which fell through to handleEndpointError's unlogged 500 branch
+  // — a silent, unattributable floor. NOTE: this guards arity only; it does NOT
+  // validate token contents, so an empty/NaN token (e.g. CONCAT(NULL,'|',id) →
+  // '|id' for a NULL sort column) still passes and parses to NaN — a separate,
+  // pre-existing issue, not addressed here.
+  if (values.length !== fields.length) {
+    throwBadRequestError(
+      `Invalid cursor: expected ${fields.length} value(s) for this sort, received ${values.length}`
+    );
+  }
   const result: Record<string, number | Date> = {};
   for (let i = 0; i < fields.length; i++) {
     const value = values[i];


### PR DESCRIPTION
## Root cause (reproduced live)

`GET /api/v1/models` carried a steady **~0.16/s of silent 500s** (top non-search source of the dp-prod app-500 floor). Traced to `parseCursor` (`pagination-helpers.ts`): when a `?cursor=` has **fewer `|`-tokens than the sort's field count**, `values[i]` is `undefined` and `value.includes('-')` throws a bare `TypeError`. Because it's a plain `Error` (not a `TRPCError`), it fell through `handleEndpointError`'s `else` branch → `res.status(500)` — which **incremented the counter but logged nothing**, so it was counted yet completely un-attributable.

The field arity shifts with the `sort` param **and** the `base-model-feed-metrics` Flipt flag, so even a once-valid client cursor (stale paginator / scraper / mid-session flag flip) can start crashing — explaining the steady, input-dependent, log-silent floor.

Reproduced inside an `api-primary` pod against the deployed image:
- `?cursor=10` on a 3-field sort → **500** (`Cannot read properties of undefined (reading 'includes')`); after fix → **400**.
- `?cursor=10|20|30` (matching arity) → **200**, unchanged.

## Changes

1. **`parseCursor`** — reject an arity-mismatched cursor as **400 `BAD_REQUEST`** (`throwBadRequestError`) instead of crashing. A malformed/stale cursor is a client error; this takes it out of the 5xx bucket with an honest, actionable status. Lives in the shared `parseCursor`, so it covers both `getCursor` and `getCursorClauses`. Purely a guard — no behavior change for well-formed cursors.
2. **`handleEndpointError`** — the non-`TRPCError` `else` branch now logs `class + truncated message` to stderr/Loki. This is the actual observability fix: it's the single line that hid the bug above, and it makes the *next* silent 500 attributable. Class + message only (no stack/query/body) for PII-safety + low cardinality; wrapped in try/catch so telemetry can never break the response. Bounded by the existing 5xx rate (~0.28/s).

## Notes
- `handleEndpointError` is a **shared terminal catch** (many wrapped endpoints) — the log fires on every non-TRPCError 500 app-wide. Kept deliberately minimal/PII-light for that reason.
- Deploys to dp-prod via the `release` branch (not `main`).
- Alternative considered: graceful-degrade (build a partial keyset predicate from the tokens present) — friendlier for in-flight clients across a flag flip, but more code in the hot pagination SQL path with subtle correctness implications. Chose the lower-risk 400 (strictly better than the current 500). Easy to switch if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)