### PR TITLE
fix(post): extract EXIF metadata server-side for headless/MCP image uploads

### DIFF
--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -82,6 +82,8 @@ import {
 } from '~/shared/utils/prisma/enums';
 import { isValidAIGeneration } from '~/utils/image-utils';
 import type { PreprocessFileReturnType } from '~/utils/media-preprocessors';
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getMetadata } from '~/utils/metadata';
 import { postgresSlugify } from '~/utils/string-helpers';
 import { isDefined } from '~/utils/type-guards';
 import { CacheTTL } from '../common/constants';
@@ -1131,6 +1133,20 @@ export const addPostImage = async ({
   const externalData = await parseExternalMetadata(externalDetailsUrl, user.id);
   if (externalData) {
     meta = { ...meta, external: externalData };
+  }
+
+  // If no meta was supplied (headless/MCP upload), try to extract it from the
+  // image EXIF. The image is already on the CDN at this point so we can fetch
+  // it by URL. We only do this when meta is absent to avoid overwriting
+  // caller-supplied values.
+  if (!meta && props.url && props.type !== MediaType.video) {
+    try {
+      const edgeUrl = getEdgeUrl(props.url, { original: true });
+      const extracted = await getMetadata(edgeUrl);
+      if (extracted && Object.keys(extracted).length > 0) meta = extracted;
+    } catch {
+      // Non-fatal — proceed without metadata rather than failing the upload
+    }
   }
 
   let toolId: number | undefined;


### PR DESCRIPTION
## Root cause

Generation metadata (prompt, seed, sampler, model, etc.) is never displayed on the site for images uploaded via the MCP or any headless API caller, even though the data is correctly embedded in the image file and visible after re-downloading.

The problem is that EXIF parsing only ever happened **client-side** in the browser:

```
preprocessFile(file) → getMetadata(File) → ExifParser → meta{}
```

The browser then sends the parsed `meta` alongside the image data when calling `post.addImage`.

The MCP follows a different path:
1. Calls `/api/v1/image-upload` to get a presigned S3 PUT URL
2. Uploads raw image bytes directly to S3
3. Calls `post.addImage` / `post.createWithImages` with `url`/`width`/`height` — but **no `meta`**

There is no step where the MCP reads EXIF, so `Image.meta` is always null in the DB.

## Fix

In `addPostImage`, when `meta` is absent and the image type is not video, fetch and parse EXIF server-side using the existing `getMetadata` utility. The image is already on the CDN at this point so we build its edge URL and pass it directly to `ExifParser` (which already supports URL strings via `ExifReader.load`).

```ts
if (!meta && props.url && props.type !== MediaType.video) {
  try {
    const edgeUrl = getEdgeUrl(props.url, { original: true });
    const extracted = await getMetadata(edgeUrl);
    if (extracted && Object.keys(extracted).length > 0) meta = extracted;
  } catch {
    // Non-fatal — proceed without metadata rather than failing the upload
  }
}
```

The extracted `meta` is then available to the tool/technique lookup that immediately follows, so `engine`/`process` fields are correctly resolved for headless uploads too — a bonus fix.

## Guard conditions

- Only runs when `meta` is null/empty — never overwrites caller-supplied values
- Skipped for video (EXIF parsers are image-only)
- Non-fatal: fetch/parse failure silently leaves `meta` null rather than failing the upload

## Callers audited

All three other callers of `addPostImage` already supply a populated `meta`, so the guard never fires for them:

| Caller | `meta` source |
|---|---|
| `post.router.ts` (browser tRPC) | Client-side `preprocessFile` |
| `collection.controller.ts` | Spread of `imageSchema` from browser |
| `model-version.service.ts` | `uploadImageFromUrl` already calls `getMetadata(imageUrl)` |

## Test coverage

The existing `ExifParser` network test in `src/utils/metadata/__tests__/exif-parser.test.ts` (gated behind `EXIF_NETWORK_TESTS=1`) tests `ExifParser(url)` against a real civitai-hosted image — identical to what this fix does. Any regression in URL-based EXIF parsing will be caught there.