### PR TITLE
fix(a11y): resolve remaining home-route Lighthouse a11y failures (follow-up to #2535)

### DIFF
--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -624,6 +624,9 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
               <HoverCard.Target>
                 <Text
                   component="div"
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Quick search keyboard shortcut"
                   fw="bold"
                   style={{
                     border: `1px solid ${

--- a/src/components/CivitaiLink/CivitaiLinkPopover.tsx
+++ b/src/components/CivitaiLink/CivitaiLinkPopover.tsx
@@ -68,11 +68,7 @@ export function CivitaiLinkPopover() {
       zIndex={imageGenerationDrawerZIndex + 1}
       withinPortal
     >
-      <Popover.Target>
-        <span role="button" aria-label="Civitai Link">
-          <LinkButton />
-        </span>
-      </Popover.Target>
+      <LinkButton />
       <Popover.Dropdown p={0}>
         <LinkDropdown />
       </Popover.Dropdown>
@@ -453,9 +449,11 @@ function LinkButton() {
   return (
     <div className="relative">
       <Indicator className="flex items-center" color={color} disabled={!color}>
-        <LegacyActionIcon variant="subtle" color="gray" aria-label="Civitai Link">
-          <IconScreenShare />
-        </LegacyActionIcon>
+        <Popover.Target>
+          <LegacyActionIcon variant="subtle" color="gray" aria-label="Civitai Link">
+            <IconScreenShare />
+          </LegacyActionIcon>
+        </Popover.Target>
       </Indicator>
       {activityProgress && activityProgress > 0 && activityProgress < 100 && (
         <Progress

--- a/src/components/ToSModal/TosModal.tsx
+++ b/src/components/ToSModal/TosModal.tsx
@@ -79,70 +79,72 @@ export default function TosModal({
   };
 
   return (
-    <Modal
-      {...dialog}
-      size="lg"
-      withCloseButton={false}
-      closeOnClickOutside={false}
-      closeOnEscape={false}
-      radius="md"
-    >
-      {isLoading || !data?.content ? (
-        <Center>
-          <Loader />
-        </Center>
-      ) : (
-        <Stack gap="md">
-          {data?.title && (
-            <>
-              <Stack ref={headerRef} gap={0}>
-                <Title order={2}>{data?.title}</Title>
-                {data.lastmod ? (
-                  <Text size="sm" c="dimmed">
-                    Last modified: {formatDate(data.lastmod, undefined, true)}
-                  </Text>
-                ) : null}
-              </Stack>
-              <Divider mx="-lg" />
-            </>
-          )}
-          <ScrollArea.Autosize mah={`calc(90dvh - ${getScrollAreaMaxHeight()}px`}>
-            <Stack>
-              <CustomMarkdown
-                // allowedElements={['p', 'a', 'strong', 'h1', 'h2', 'ul', 'ol', 'li']}
-                rehypePlugins={[rehypeRaw]}
-                remarkPlugins={[remarkBreaks, remarkGfm]}
-                unwrapDisallowed
-                className="markdown-content-spaced"
-              >
-                {data.content}
-              </CustomMarkdown>
-            </Stack>
-          </ScrollArea.Autosize>
-          <Stack ref={footerRef} gap="md">
-            <Checkbox
-              checked={acceptedCoC}
-              onChange={(event) => setAcceptedCoC(event.currentTarget.checked)}
-              label="I have read and agree to the Terms of Service"
-              size="sm"
-            />
-            <Group ml="auto">
-              {showBackButton && (
-                <Button onClick={handleClose} color="gray" disabled={updateUserSettings.isPending}>
-                  Go back
-                </Button>
+    <Modal.Root {...dialog} size="lg" closeOnClickOutside={false} closeOnEscape={false} radius="md">
+      <Modal.Overlay />
+      <Modal.Content radius="md" aria-label="Terms of Service">
+        <Modal.Body>
+          {isLoading || !data?.content ? (
+            <Center>
+              <Loader />
+            </Center>
+          ) : (
+            <Stack gap="md">
+              {data?.title && (
+                <>
+                  <Stack ref={headerRef} gap={0}>
+                    <Title order={2}>{data?.title}</Title>
+                    {data.lastmod ? (
+                      <Text size="sm" c="dimmed">
+                        Last modified: {formatDate(data.lastmod, undefined, true)}
+                      </Text>
+                    ) : null}
+                  </Stack>
+                  <Divider mx="-lg" />
+                </>
               )}
-              <Button
-                onClick={handleConfirm}
-                disabled={!acceptedCoC}
-                loading={updateUserSettings.isPending || loading}
-              >
-                Accept
-              </Button>
-            </Group>
-          </Stack>
-        </Stack>
-      )}
-    </Modal>
+              <ScrollArea.Autosize mah={`calc(90dvh - ${getScrollAreaMaxHeight()}px`}>
+                <Stack>
+                  <CustomMarkdown
+                    // allowedElements={['p', 'a', 'strong', 'h1', 'h2', 'ul', 'ol', 'li']}
+                    rehypePlugins={[rehypeRaw]}
+                    remarkPlugins={[remarkBreaks, remarkGfm]}
+                    unwrapDisallowed
+                    className="markdown-content-spaced"
+                  >
+                    {data.content}
+                  </CustomMarkdown>
+                </Stack>
+              </ScrollArea.Autosize>
+              <Stack ref={footerRef} gap="md">
+                <Checkbox
+                  checked={acceptedCoC}
+                  onChange={(event) => setAcceptedCoC(event.currentTarget.checked)}
+                  label="I have read and agree to the Terms of Service"
+                  size="sm"
+                />
+                <Group ml="auto">
+                  {showBackButton && (
+                    <Button
+                      onClick={handleClose}
+                      color="gray"
+                      disabled={updateUserSettings.isPending}
+                    >
+                      Go back
+                    </Button>
+                  )}
+                  <Button
+                    onClick={handleConfirm}
+                    disabled={!acceptedCoC}
+                    loading={updateUserSettings.isPending || loading}
+                  >
+                    Accept
+                  </Button>
+                </Group>
+              </Stack>
+            </Stack>
+          )}
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
   );
 }

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -125,6 +125,9 @@ export function Home() {
                         <Popover withArrow width={380}>
                           <Popover.Target>
                             <Box
+                              role="button"
+                              tabIndex={0}
+                              aria-label="About this section"
                               display="inline-block"
                               style={{ lineHeight: 0.3, cursor: 'pointer' }}
                               color="white"
@@ -180,6 +183,9 @@ export function Home() {
                         <Popover withArrow width={380}>
                           <Popover.Target>
                             <Box
+                              role="button"
+                              tabIndex={0}
+                              aria-label="About this section"
                               display="inline-block"
                               style={{ lineHeight: 0.3, cursor: 'pointer' }}
                               color="white"


### PR DESCRIPTION
## What

Follow-up to #2535 (a11y 0.66 → 0.87 on `/`). Resolves the **3 remaining
Lighthouse a11y failures** on the home route plus **1 audit-found quality issue**,
and **flags 1** (color-contrast) for a design decision.

Report-only, additive/structural a11y only — **no visual or behavioral change
beyond accessibility**. Pages-router SSR-safe, Mantine v7 conventions. Lighthouse
a11y is authed as `ci-smoke-gold`, so the flagged DOM reflects that user.

Baseline elements extracted from the post-#2535 `/` Lighthouse report
(PR #2535, commit `e7bc0a0`, a11y 87).

## Fixes

### 1. `aria-allowed-attr` (weight 10, 2 elements)
Two non-button elements were receiving `aria-expanded` (invalid on a generic role)
because Mantine clones `aria-haspopup="dialog"` / `aria-expanded` / `aria-controls`
onto its popover/hovercard target child.

- **`src/pages/home/index.tsx`** — the Images/Models section info `Popover.Target`
  was a bare `<Box display="inline-block">` with **no role, no name, no tabIndex**.
  Added `role="button" tabIndex={0} aria-label="About this section"` — this mirrors
  the existing `CollectionHomeBlock` / `FeaturedModelVersionHomeBlock` /
  `SocialHomeBlock` info buttons (same pattern, not a new one). Now `aria-expanded`
  is valid, the control is keyboard-reachable, and it has a name.
  _(Audit node: `div.MasonryContainer-…__queries > … > div#mantine-…-target`.)_
- **`src/components/AutocompleteSearch/AutocompleteSearch.tsx`** — the `/`
  quick-search hint `HoverCard.Target` was a `<Text component="div">` receiving
  `aria-expanded`. Added `role="button" tabIndex={0} aria-label="Quick search
  keyboard shortcut"` so the cloned ARIA is valid and the hint is keyboard-reachable.
  _(Audit node: `div.AutocompleteSearch-…__root > … > div#mantine-…-target`.)_

### 2. `aria-dialog-name` (weight 7, 1 element)
**`src/components/ToSModal/TosModal.tsx`** — the Terms-of-Service modal
(auto-opened for authed users via `useToSUpdateModal` → `dialogStore.trigger`,
which is why it appears in the gold-user audit) rendered `role="dialog"
aria-modal="true"` with **no accessible name**. It uses `withCloseButton={false}`
and renders its title in the body, so no `Modal.Title` mounts.

Mantine's convenience `<Modal>` only wires `aria-labelledby` when a `Modal.Title`
is mounted, and it forwards `aria-label` to `ModalRoot` (a wrapper) — **not** to
the `role="dialog"` content element. So I switched this one modal to the compound
`Modal.Root` / `Modal.Overlay` / `Modal.Content` / `Modal.Body` API (identical
rendering — the convenience component is just this composition minus a header it
never rendered here) and put `aria-label="Terms of Service"` directly on
`Modal.Content`. Preserved `size`, `radius`, `closeOnClickOutside={false}`,
`closeOnEscape={false}`, and the existing in-body title — **no visual change**.
_(Audit node: `section.m_fd1ab0aa.mantine-Modal-content[role=dialog][aria-modal=true]`.)_

### 3. CivitaiLink popover shape (audit-found quality; Lighthouse won't flag)
**`src/components/CivitaiLink/CivitaiLinkPopover.tsx`** — the `Popover.Target` was
a `<span role="button" aria-label="Civitai Link">` (no tabIndex) **wrapping a real
`<button>`** (the `LegacyActionIcon`) that **also** had `aria-label="Civitai Link"`
→ button-nested-in-button + duplicated name. Restructured so the
`LegacyActionIcon` **is** the `Popover.Target` directly: Mantine now clones
`aria-haspopup` / `aria-expanded` / `aria-controls` + ref + onClick onto the real
button (valid role), and the wrapper span + duplicate label are gone. The
`Indicator` (status dot) and progress bar decorations are preserved around the
target; `Popover.Target`/`Popover.Dropdown` pair via React context, not DOM
adjacency, so nesting the target inside the `Indicator` keeps the popover working.

## Flagged — NOT fixed (needs a design call)

### `color-contrast` (weight 7, 1 element)
- **Element:** `span.mantine-Avatar-placeholder` (a user-initials avatar placeholder,
  shown when a creator has no avatar image; rendered on `/`).
- **Colors:** foreground `#dee2e6` (this is `theme.colors.gray[3]`), background
  `#66686b` (Mantine's *computed* dark-mode Avatar placeholder bg — not a literal
  theme token).
- **Measured ratio:** **4.29 : 1** (Lighthouse), short of the 4.5 : 1 AA threshold
  by 0.21.
- **Decision: flag, do not fix.** This is the **default Mantine v7 Avatar
  placeholder rendering** with the neutral **gray** palette — it is *not* a
  deliberate Civitai brand color (no brand hue involved). But the foreground
  `#dee2e6` is the shared `gray[3]` token used app-wide, so darkening it ripples
  broadly, and the background is component-computed rather than a single token to
  tweak. It's a borderline default-theme miss, not an unambiguous bug.
- **Recommendation (Zach's call):** scope a fix to the Avatar placeholder only,
  e.g. set placeholder text to `gray[2]` (`#e9ecef`) **or** darken the placeholder
  bg via an Avatar `styles`/`classNames` override / theme `Avatar` component
  default, rather than changing the global `gray[3]` token. Low priority — small
  gap, default-theme origin.

## Verification
- **Before (post-#2535):** `/` a11y **87** (PR #2535, commit `e7bc0a0`).
- **After (this PR, commit `825521e`):** `/` a11y **93** (per the preview
  `lhci-bot` run) — **+6**. As predicted, fixing the 2 `aria-allowed-attr` (w10)
  + the dialog name (w7) raised the score; it does **not** reach 100 because the
  flagged `color-contrast` (w7) is intentionally left unfixed.
- **No perf/CLS regression on `/`:** Perf **56** (unchanged from #2535's 56),
  LCP **2.2s** (unchanged), CLS **0.585** (vs #2535's 0.590 — within run-to-run
  noise; the a11y changes are attribute/structure-only and add no layout).
- **Functional:** preview smoke tests **43 passed / 0 flaky / 0 failed**,
  including the **gold** user path (the one the a11y audit authenticates as) and
  mod/tester/restricted/anon gates -> confirms the CivitaiLink popover restructure
  and the ToS-modal compound-API change did not break rendering/interaction.
- **Typecheck:** CI `pr-check` typecheck **passed** (authoritative, full type
  generation).
- **Automated review:** `pr-reviewer` round 1 -- **0 findings** at confidence >=0.80.
- Typecheck: no new type errors introduced (verified the only `tsc` errors in the
  touched files are pre-existing implicit-any issues present identically on the
  base commit; full CI typegen resolves them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
