### PR TITLE
security(webhooks): drop debug console.log of req.headers/req.env in stripe-connect

### DIFF
--- a/src/pages/api/webhooks/stripe-connect.ts
+++ b/src/pages/api/webhooks/stripe-connect.ts
@@ -32,7 +32,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const buf = await buffer(req);
     const rawPayload = buf.toString('utf8');
-    console.log(req.headers, req.env);
     const sig = req.headers['stripe-signature'];
     const webhookSecret = env.STRIPE_CONNECT_WEBHOOK_SECRET;
     let event: Stripe.Event;


### PR DESCRIPTION
## Why

`src/pages/api/webhooks/stripe-connect.ts` ran `console.log(req.headers, req.env)` on **every** Stripe-Connect webhook request — dumping all request headers (including the `stripe-signature` HMAC) and `req.env` to stdout → Loki. It's leftover debug logging with no functional purpose, and a secret/PII-in-logs leak on a payment-path handler.

## What
Removed the one line. Verified it's the only `console.log(req.headers…)` / `req.env` across `pages/api` — isolated, not a pattern.

## Risk
None — pure logging removal, no control-flow/behavior change. (The remaining `console.log` lines in the file — `❌ Error message: …`, `transfer created` — are benign status logs, left as-is.)

Found via adversarial audit of the webhook-instrumentation work (#2539); fixed separately to keep that PR's scope clean. Deploys via `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)