### PR TITLE
obs(auth/upload): instrument counter-blind auth/oauth + upload 5xx

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import NextAuth from 'next-auth';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { callbackCookieName, civitaiTokenCookieName } from '~/libs/auth';
 import { Tracker } from '~/server/clickhouse/client';
 import { NotificationCategory } from '~/server/common/enums';
@@ -27,6 +28,9 @@ function isValidCallbackUrl(value: string | undefined): boolean {
 }
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: this login handler bypasses the endpoint wrappers, so its
+  // 500s were counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   // console.log(new Date().toISOString() + ' ::', 'nextauth', req.url);
   const customAuthOptions = createAuthOptions(req);
 

--- a/src/pages/api/auth/oauth/authorize.ts
+++ b/src/pages/api/auth/oauth/authorize.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { Prisma } from '@prisma/client';
 import { Request, Response } from '@node-oauth/oauth2-server';
 import requestIp from 'request-ip';
@@ -13,6 +14,9 @@ import { buzzLimitSchema } from '~/server/schema/api-key.schema';
 import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   if (req.method === 'OPTIONS') {
     addCorsHeaders(req, res, ['GET', 'POST'], { allowCredentials: true });
     return;

--- a/src/pages/api/auth/oauth/device-approve.ts
+++ b/src/pages/api/auth/oauth/device-approve.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
@@ -7,6 +8,9 @@ import requestIp from 'request-ip';
 const DEVICE_CODE_KEY = REDIS_KEYS.OAUTH.DEVICE_CODES;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }

--- a/src/pages/api/auth/oauth/device-info.ts
+++ b/src/pages/api/auth/oauth/device-info.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { dbRead } from '~/server/db/client';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
@@ -10,6 +11,9 @@ import { Flags } from '~/shared/utils/flags';
  * Used by the device verification page to show what the user is authorizing.
  */
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }

--- a/src/pages/api/auth/oauth/device-token.ts
+++ b/src/pages/api/auth/oauth/device-token.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
@@ -13,6 +14,9 @@ import requestIp from 'request-ip';
 const DEVICE_CODE_KEY = REDIS_KEYS.OAUTH.DEVICE_CODES;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const shouldStop = addCorsHeaders(req, res, ['POST']);
   if (shouldStop) return;
 

--- a/src/pages/api/auth/oauth/device.ts
+++ b/src/pages/api/auth/oauth/device.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { randomBytes, randomInt } from 'crypto';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { dbRead } from '~/server/db/client';
@@ -28,6 +29,9 @@ function generateUserCode(): string {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const shouldStop = addCorsHeaders(req, res, ['POST']);
   if (shouldStop) return;
 

--- a/src/pages/api/auth/oauth/revoke.ts
+++ b/src/pages/api/auth/oauth/revoke.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { timingSafeEqual } from 'crypto';
 import requestIp from 'request-ip';
 import { dbRead, dbWrite } from '~/server/db/client';
@@ -9,6 +10,9 @@ import { logOAuthEvent } from '~/server/oauth/audit-log';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const origin = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
 
   // Preflight stays permissive — we can't classify the caller until we see the

--- a/src/pages/api/auth/oauth/token.ts
+++ b/src/pages/api/auth/oauth/token.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { Request, Response } from '@node-oauth/oauth2-server';
 import requestIp from 'request-ip';
 import { oauthServer } from '~/server/oauth/server';
@@ -27,6 +28,9 @@ function setPublicClientCors(res: NextApiResponse, origin: string) {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   // Preflight stays permissive — we can't classify confidential vs public
   // until we see the client_id on the actual POST.
   if (req.method === 'OPTIONS') {

--- a/src/pages/api/auth/oauth/userinfo.ts
+++ b/src/pages/api/auth/oauth/userinfo.ts
@@ -1,10 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { Flags } from '~/shared/utils/flags';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const shouldStop = addCorsHeaders(req, res, ['GET']);
   if (shouldStop) return;
 

--- a/src/pages/api/upload/abort.ts
+++ b/src/pages/api/upload/abort.ts
@@ -1,9 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { abortMultipartUpload, getUploadS3Client, getB2ImageS3Client } from '~/utils/s3-utils';
 import { logToAxiom } from '~/server/logging/client';
 
 const upload = async (req: NextApiRequest, res: NextApiResponse) => {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const session = await getServerAuthSession({ req, res });
   const userId = session?.user?.id;
   if (!userId || session.user?.bannedAt) {

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -1,9 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { completeMultipartUpload, getUploadS3Client, getB2ImageS3Client } from '~/utils/s3-utils';
 import { logToAxiom } from '~/server/logging/client';
 
 const upload = async (req: NextApiRequest, res: NextApiResponse) => {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const session = await getServerAuthSession({ req, res });
   const userId = session?.user?.id;
   if (!userId || session.user?.bannedAt) {

--- a/src/pages/api/upload/index.ts
+++ b/src/pages/api/upload/index.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { UploadType } from '~/server/common/enums';
 import { extname } from 'node:path';
@@ -11,6 +12,9 @@ import { logToAxiom } from '~/server/logging/client';
 import { isFlipt, FLIPT_FEATURE_FLAGS } from '~/server/flipt/client';
 
 const upload = async (req: NextApiRequest, res: NextApiResponse) => {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const session = await getServerAuthSession({ req, res });
   const userId = session?.user?.id;
   if (!userId || session.user?.bannedAt) {

--- a/src/pages/api/v1/image-upload/index.ts
+++ b/src/pages/api/v1/image-upload/index.ts
@@ -1,10 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getCustomPutUrl, getImageUploadBackend } from '~/utils/s3-utils';
 import { randomUUID } from 'crypto';
 import { registerMediaLocation } from '~/server/services/storage-resolver';
 
 export default async function imageUpload(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   const session = await getServerAuthSession({ req, res });
   const userId = session?.user?.id;
   if (!userId || session.user?.bannedAt) {

--- a/src/pages/api/v1/image-upload/multipart/index.ts
+++ b/src/pages/api/v1/image-upload/multipart/index.ts
@@ -1,11 +1,15 @@
 import { randomUUID } from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getMimeTypeFromExt } from '~/shared/constants/mime-types';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getMultipartPutUrl, getImageUploadBackend } from '~/utils/s3-utils';
 import { registerMediaLocation } from '~/server/services/storage-resolver';
 
 export default async function imageUploadMultipart(req: NextApiRequest, res: NextApiResponse) {
+  // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
+  // counter-blind. Listener-only (res.once('finish')); no behavior change.
+  instrumentApiResponse(req, res);
   try {
     const session = await getServerAuthSession({ req, res });
     const userId = session?.user?.id;

--- a/src/server/prom/__tests__/http-errors.test.ts
+++ b/src/server/prom/__tests__/http-errors.test.ts
@@ -102,4 +102,13 @@ describe('instrumentApiResponse', () => {
     instrumentApiResponse(badReq, res);
     expect(() => emitFinish()).not.toThrow(); // telemetry failure can't break the response
   });
+
+  it('no-ops (never throws) on a non-EventEmitter res double without .once', () => {
+    // Handler unit tests often pass a partial res mock (status/json/setHeader)
+    // with no .once. The helper must not throw — else it breaks the handler in
+    // every such test (regression caught in oauth/token-endpoint.test.ts).
+    const fakeRes = { statusCode: 200, status: () => fakeRes, json: () => fakeRes };
+    const req = { method: 'POST', url: '/api/auth/oauth/token', query: {} } as unknown as NextApiRequest;
+    expect(() => instrumentApiResponse(req, fakeRes as unknown as NextApiResponse)).not.toThrow();
+  });
 });

--- a/src/server/prom/__tests__/http-errors.test.ts
+++ b/src/server/prom/__tests__/http-errors.test.ts
@@ -110,5 +110,9 @@ describe('instrumentApiResponse', () => {
     const fakeRes = { statusCode: 200, status: () => fakeRes, json: () => fakeRes };
     const req = { method: 'POST', url: '/api/auth/oauth/token', query: {} } as unknown as NextApiRequest;
     expect(() => instrumentApiResponse(req, fakeRes as unknown as NextApiResponse)).not.toThrow();
+    // and a null/undefined res must not throw either (total "never break" contract)
+    expect(() =>
+      instrumentApiResponse(req, undefined as unknown as NextApiResponse)
+    ).not.toThrow();
   });
 });

--- a/src/server/prom/http-errors.ts
+++ b/src/server/prom/http-errors.ts
@@ -148,9 +148,13 @@ function reconstructApiRoute(req: NextApiRequest): string {
 export function instrumentApiResponse(req: NextApiRequest, res: NextApiResponse): void {
   // Honor the "can never break the response" contract for ALL inputs: a real
   // Node ServerResponse is always an EventEmitter, but a handler unit-test may
-  // pass a partial `res` double without `.once`. No-op rather than throw — the
-  // worst case is a missing metric in a test, never a broken handler.
-  if (typeof res.once !== 'function') return;
+  // pass a partial `res` double without `.once` (and a null res is cheap to
+  // guard too). No-op rather than throw — worst case is a missing metric, never
+  // a broken handler. NOTE: this also silently no-ops on the Edge runtime (a Web
+  // Response has no `.once`); there are no edge API routes today, but a future
+  // edge route would need different instrumentation — a finish-listener can't
+  // see it (same class as the edge-502/504 SCOPE caveat above).
+  if (!res || typeof res.once !== 'function') return;
   res.once('finish', () => {
     const status = res.statusCode;
     if (status < 500) return; // hot-path: 2xx/3xx/4xx do zero normalization work

--- a/src/server/prom/http-errors.ts
+++ b/src/server/prom/http-errors.ts
@@ -146,6 +146,11 @@ function reconstructApiRoute(req: NextApiRequest): string {
  * break the response.
  */
 export function instrumentApiResponse(req: NextApiRequest, res: NextApiResponse): void {
+  // Honor the "can never break the response" contract for ALL inputs: a real
+  // Node ServerResponse is always an EventEmitter, but a handler unit-test may
+  // pass a partial `res` double without `.once`. No-op rather than throw — the
+  // worst case is a missing metric in a test, never a broken handler.
+  if (typeof res.once !== 'function') return;
   res.once('finish', () => {
     const status = res.statusCode;
     if (status < 500) return; // hot-path: 2xx/3xx/4xx do zero normalization work


### PR DESCRIPTION
## Why

Final slice of the API 5xx-observability sweep. `civitai_app_http_errors_total` only covers routes that go through the 6 endpoint-helper wrappers (+ tRPC); a set of bare handlers bypass them, so their 500s show only in the shared Traefik aggregate — unattributable per-route (the COVERAGE note in `http-errors.ts` calls these out explicitly). #2539 closed the payment webhooks; this closes **auth/oauth + upload**.

## What

`instrumentApiResponse(req, res)` at the top of **14 bare handlers**:
- **auth**: `[...nextauth]` (the login handler), `oauth/{authorize, device, device-approve, device-info, device-token, revoke, token, userinfo}`
- **upload**: `upload/{abort, complete, index}`, `v1/image-upload/{index, multipart}`

It's the **same `res.once('finish')` listener** already used by every wrapped route and the payment webhooks: increments the counter only on `status >= 500`, wrapped in try/catch — **pure observability, zero behavior/response change**. It cannot affect the login flow, OAuth token exchange, or upload presigning (it only reads `statusCode` after the response is sent). Its passivity is **runtime-proven** by `src/server/prom/__tests__/http-errors.test.ts` (added in #2539) — never mutates the response, counts only 5xx, once, no leak, no throw.

## Skipped (intentionally)
- Already counted via their wrappers: `auth/{civ-token, impersonate, sync}` (Authed), `freshdesk` (MixedAuth), `user-from-token` (WebhookEndpoint → TokenSecured).
- `.well-known/openid-configuration` — static sync config handler; can't meaningfully 5xx.

## Risk
Listener-only, identical to the prod-proven helper on 27+ routes. Deploys via `release`. After deploy: a previously-invisible login/OAuth/upload 500-storm would now surface as `civitai_app_http_errors_total{route=~"...auth...|...upload...",status="5.."}` — that's the intended new signal, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)