### PR TITLE
fix(a11y): name icon-only model-page controls + image alt / progressbar / creator social-link names

### DIFF
--- a/src/components/CardTemplates/AspectRatioImageCard.tsx
+++ b/src/components/CardTemplates/AspectRatioImageCard.tsx
@@ -59,6 +59,8 @@ export type AspectRatioImageCardProps<T extends DialogKey> = {
   target?: string;
   isRemix?: boolean;
   explain?: boolean;
+  /** Accessible fallback alt text when the image itself has no name (e.g. the card's title). */
+  alt?: string;
 } & ContentTypeProps;
 
 const IMAGE_CARD_WIDTH = 450;
@@ -80,6 +82,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
   target,
   isRemix,
   explain,
+  alt,
 }: AspectRatioImageCardProps<T>) {
   const originalAspectRatio = image && image.width && image.height ? image.width / image.height : 1;
 
@@ -147,7 +150,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
                         metadata={image.metadata as MixedObject}
                         src={image.url}
                         name={image.name ?? image.id.toString()}
-                        alt={image.name ?? undefined}
+                        alt={image.name ?? alt ?? undefined}
                         type={image.type}
                         imageId={image.id}
                         thumbnailUrl={image.thumbnailUrl}

--- a/src/components/CardTemplates/AspectRatioImageCard.tsx
+++ b/src/components/CardTemplates/AspectRatioImageCard.tsx
@@ -168,7 +168,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
                       metadata={image.metadata as MixedObject}
                       src={image.url}
                       name={image.name ?? image.id.toString()}
-                      alt={image.name ?? undefined}
+                      alt={image.name ?? alt ?? undefined}
                       type={image.type}
                       imageId={image.id}
                       thumbnailUrl={image.thumbnailUrl}

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -112,6 +112,7 @@ function ModelCardContent({ data }: Props) {
       contentType="model"
       contentId={data.id}
       image={data.images[0]}
+      alt={data.name}
       onSite={!!data.version.trainingStatus}
       isRemix={!!data.images[0]?.remixOfId}
       header={

--- a/src/components/CreatorCard/CreatorCard.tsx
+++ b/src/components/CreatorCard/CreatorCard.tsx
@@ -8,7 +8,7 @@ import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { constants } from '~/server/common/constants';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
 import { formatDate } from '~/utils/date-helpers';
-import { sortDomainLinks } from '~/utils/domain-link';
+import { getDomainLinkLabel, sortDomainLinks } from '~/utils/domain-link';
 import { trpc } from '~/utils/trpc';
 import { TipBuzzButton } from '../Buzz/TipBuzzButton';
 import { UserStatBadges } from '../UserStatBadges/UserStatBadges';
@@ -114,6 +114,7 @@ export function CreatorCard({
                 target="_blank"
                 rel="nofollow noreferrer"
                 size={32}
+                aria-label={getDomainLinkLabel(link)}
               >
                 <DomainIcon domain={link.domain} size={20} />
               </LegacyActionIcon>

--- a/src/components/CreatorCard/CreatorCardSimple.tsx
+++ b/src/components/CreatorCard/CreatorCardSimple.tsx
@@ -17,7 +17,7 @@ import { UserAvatar, UserProfileLink } from '~/components/UserAvatar/UserAvatar'
 import { constants, creatorCardStatsDefaults } from '~/server/common/constants';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
 import { formatDate } from '~/utils/date-helpers';
-import { sortDomainLinks } from '~/utils/domain-link';
+import { getDomainLinkLabel, sortDomainLinks } from '~/utils/domain-link';
 import { trpc } from '~/utils/trpc';
 import type { UserStats } from '../UserStatBadges/UserStatBadges';
 import { UserStatBadgesV2 } from '../UserStatBadges/UserStatBadges';
@@ -237,6 +237,7 @@ const CreatorCardSimpleContent = ({
                 target="_blank"
                 rel="nofollow noreferrer"
                 size={32}
+                aria-label={getDomainLinkLabel(link)}
               >
                 <DomainIcon domain={link.domain} size={20} />
               </LegacyActionIcon>

--- a/src/components/EmblaCarousel/EmblaCarousel.tsx
+++ b/src/components/EmblaCarousel/EmblaCarousel.tsx
@@ -185,6 +185,7 @@ function EmblaButton({
         className
       )}
       type="button"
+      aria-label={props['aria-label'] ?? (type === 'next' ? 'Next image' : 'Previous image')}
       tabIndex={(type === 'next' ? canScrollNext : canScrollPrevious) ? 0 : -1}
       onClick={type === 'next' ? nextClick : previousClick}
       data-disabled={disabled}

--- a/src/components/HelpButton/HelpButton.tsx
+++ b/src/components/HelpButton/HelpButton.tsx
@@ -8,7 +8,7 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 export const HelpButton = forwardRef<HTMLButtonElement, Props>(
   ({ iconProps, tooltip, ...actionIconProps }, ref) => {
     const button = (
-      <LegacyActionIcon ref={ref} {...actionIconProps}>
+      <LegacyActionIcon ref={ref} aria-label={tooltip ?? 'Help'} {...actionIconProps}>
         <Text c="dimmed" inline>
           <IconHelpCircle {...iconProps} />
         </Text>

--- a/src/components/Model/HowToUseModel/HowToUseModel.tsx
+++ b/src/components/Model/HowToUseModel/HowToUseModel.tsx
@@ -47,6 +47,7 @@ export const HowToButton = ({
         size="xs"
         c="dimmed"
         style={{ lineHeight: 1 }}
+        aria-label={tooltip}
       >
         <IconInfoSquareRounded size={size} {...iconProps} />
       </Text>

--- a/src/components/Model/ModelVersionList/ModelVersionList.tsx
+++ b/src/components/Model/ModelVersionList/ModelVersionList.tsx
@@ -93,6 +93,7 @@ export function ModelVersionList({
           variant="transparent"
           radius="xl"
           onClick={scrollLeft}
+          aria-label="Scroll versions left"
         >
           <IconChevronLeft />
         </LegacyActionIcon>
@@ -242,6 +243,7 @@ export function ModelVersionList({
           variant="transparent"
           radius="xl"
           onClick={scrollRight}
+          aria-label="Scroll versions right"
         >
           <IconChevronRight />
         </LegacyActionIcon>

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -649,6 +649,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                             color="gray"
                             fullWidth
                             style={{ paddingLeft: 0, paddingRight: 0 }}
+                            aria-label="Share"
                           >
                             <IconShare3 size={18} />
                           </Button>
@@ -669,6 +670,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                               color={isFavorite ? 'green' : 'gray'}
                               fullWidth
                               style={{ paddingLeft: 0, paddingRight: 0 }}
+                              aria-label={isFavorite ? 'Unlike' : 'Like'}
                             >
                               <ThumbsUpIcon color="#fff" filled={isFavorite} size={18} />
                             </Button>
@@ -691,6 +693,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                               variant={isInVault ? 'light' : undefined}
                               fullWidth
                               style={{ paddingLeft: 0, paddingRight: 0 }}
+                              aria-label={isInVault ? 'Remove from Vault' : 'Add to Vault'}
                             >
                               {isLoading ? (
                                 <Loader size="xs" />
@@ -723,6 +726,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                               variant="light"
                               fullWidth
                               style={{ paddingLeft: 0, paddingRight: 0 }}
+                              aria-label={label}
                             >
                               {icon}
                             </Button>
@@ -752,6 +756,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                             loading={toggleNotifyModelMutation.isPending}
                             fullWidth
                             style={{ paddingLeft: 0, paddingRight: 0 }}
+                            aria-label={
+                              isNotificationOn
+                                ? 'Stop getting notifications for this model'
+                                : 'Get notifications for this model'
+                            }
                           >
                             {isNotificationOn ? (
                               <IconBellCheck size={18} />
@@ -777,6 +786,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                             }
                             fullWidth
                             style={{ paddingLeft: 0, paddingRight: 0 }}
+                            aria-label="Add to collection"
                           >
                             <IconBookmark size={18} />
                           </Button>
@@ -814,6 +824,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                               }
                               fullWidth
                               style={{ paddingLeft: 0, paddingRight: 0 }}
+                              aria-label="Report"
                             >
                               <IconFlag size={18} />
                             </Button>
@@ -1169,6 +1180,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                                     size="md"
                                     radius="md"
                                     disabled={archived || isLoadingAccess}
+                                    aria-label={
+                                      canDownload
+                                        ? 'Download from source model'
+                                        : 'Purchase to download'
+                                    }
                                   >
                                     <IconDownload size={16} />
                                   </ActionIcon>

--- a/src/components/Model/ModelVersions/ModelVersionDonationGoals.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDonationGoals.tsx
@@ -119,6 +119,7 @@ const DonationGoalItem = ({
             color={progress < 100 ? 'yellow.7' : 'green'}
             striped={donationGoal.active}
             animated={donationGoal.active}
+            aria-label={`Donation goal progress: ${donationGoal.title}`}
           >
             <Progress.Label>{Math.floor(progress)}%</Progress.Label>
           </Progress.Section>

--- a/src/components/Reaction/Reactions.tsx
+++ b/src/components/Reaction/Reactions.tsx
@@ -160,6 +160,7 @@ export function Reactions({
             size="compact-xs"
             onClick={() => setShowAll((s) => !s)}
             classNames={{ inner: 'flex gap-0.5' }}
+            aria-label="Add reaction"
             {...(buttonStyling ? buttonStyling('AddReaction') : {})}
           >
             <IconPlus size={16} stroke={2.5} />
@@ -289,6 +290,7 @@ function ReactionBadge({
       color={color}
       size="compact-xs"
       classNames={{ label: 'flex gap-1' }}
+      aria-label={`${reaction} reaction`}
       {...buttonStyling?.(reaction, hasReacted)}
       {...buttonProps}
     >

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -185,6 +185,7 @@ export function UserAvatar({
                 src={decoration.data.url}
                 type="image"
                 name="user avatar decoration"
+                alt=""
                 style={{
                   position: 'absolute',
                   top: '50%',

--- a/src/components/UserAvatar/UserAvatarSimple.tsx
+++ b/src/components/UserAvatar/UserAvatarSimple.tsx
@@ -89,6 +89,7 @@ export function UserAvatarSimple({
               // original={anim === false ? false : undefined}
               type="image"
               name="user avatar decoration"
+              alt=""
               className="absolute left-1/2 top-1/2 z-[2]"
               loading="lazy"
               style={{

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -892,7 +892,11 @@ export default function ModelDetailsV2({
                     withinPortal
                   >
                     <Menu.Target>
-                      <LegacyActionIcon className={classes.headerButton} variant="light">
+                      <LegacyActionIcon
+                        className={classes.headerButton}
+                        variant="light"
+                        aria-label="Model options"
+                      >
                         <IconDotsVertical size={20} />
                       </LegacyActionIcon>
                     </Menu.Target>

--- a/src/utils/domain-link.ts
+++ b/src/utils/domain-link.ts
@@ -35,6 +35,43 @@ export function getDomainLinkType(url: string) {
   return key;
 }
 
+// Human-readable platform names for the known domain keys (for accessible labels).
+const domainDisplayNames: Record<DomainLink, string> = {
+  huggingFace: 'Hugging Face',
+  twitter: 'Twitter',
+  x: 'X',
+  twitch: 'Twitch',
+  reddit: 'Reddit',
+  youtube: 'YouTube',
+  facebook: 'Facebook',
+  instagram: 'Instagram',
+  buyMeACoffee: 'Buy Me a Coffee',
+  patreon: 'Patreon',
+  koFi: 'Ko-fi',
+  coindrop: 'Coindrop',
+  discord: 'Discord',
+  github: 'GitHub',
+  linktree: 'Linktree',
+  deviantArt: 'DeviantArt',
+  tumblr: 'Tumblr',
+  telegram: 'Telegram',
+  vk: 'VK',
+  bilibili: 'Bilibili',
+  civitai: 'Civitai',
+  linkedin: 'LinkedIn',
+};
+
+/** Accessible label for an external creator link icon, e.g. "Discord profile" or "example.com profile". */
+export function getDomainLinkLabel(link: { url: string; domain?: DomainLink }): string {
+  const domain = link.domain ?? getDomainLinkType(link.url);
+  if (domain) return `${domainDisplayNames[domain]} profile`;
+  try {
+    return `${new URL(link.url).hostname.replace(/^www\./, '')} profile`;
+  } catch {
+    return 'External profile link';
+  }
+}
+
 export function sortDomainLinks<T extends { url: string }>(links: T[]) {
   return links
     .map((link) => {


### PR DESCRIPTION
## What

Harvest the accessibility of the **model detail page** (`/models/[id]`) — the highest-traffic entrypoint and the worst-scoring a11y page in the Lighthouse CI route set (`/models/4201` was added to LHCI in #2543). Report-only; no gating.

Axe (wcag2a/aa, measured on prod) flagged on this page: **button-name ×45**, **image-alt ×5**, **link-name ×14**, **aria-progressbar-name ×1**, plus `label`/chrome `link-name` (already resolved on `main` by #2535/#2540). This PR names the icon-only model-page controls, gives content images alt text, names the donation progressbar, and labels the creator social links.

Additive a11y only — **no visual or behavioral change**, SSR-safe, Mantine v7 conventions (`ActionIcon`/`Button` take `aria-label`). Every label names the control's real function (read from its `onClick` / tooltip).

## Fixes by audit / component

**`button-name` / `link-name`** (icon-only controls)
- **EmblaCarousel** prev/next → "Previous image" / "Next image" (default, caller-overridable) — covers the model preview gallery controls.
- **ModelVersionList** scroll arrows → "Scroll versions left/right".
- **Reactions** → "Add reaction" toggle + "`<reaction>` reaction" emoji buttons (shared component → cross-page win).
- **ModelVersionDetails** action row → Share / Like–Unlike / Vault / Civitai Link / Notify / Add to collection / Report / required-component download (each from its tooltip).
- **Model header** options menu → "Model options"; `HelpButton` + `HowToButton` derive `aria-label` from their existing tooltip.
- **CreatorCard** (+Simple) external creator social links → readable platform name via a new `getDomainLinkLabel()` helper (e.g. "Discord profile"; hostname fallback for unknown domains).

**`image-alt`** (critical)
- **AspectRatioImageCard** now accepts an `alt` fallback; **ModelCard** passes the model name, so suggested-resource cover images whose `image.name` is null get meaningful alt (a11y + SEO).
- **User avatar cosmetic decoration** overlay (`UserAvatar` + `UserAvatarSimple`) → `alt=""` (decorative — the avatar + username already convey the user).

**`aria-progressbar-name`**
- Donation-goal `Progress` section → "Donation goal progress: `<title>`".

## Verification

- Re-ran axe-core against prod `/models/4201` to extract the exact offending nodes (not guessed), mapped each flagged selector to its component, and labeled by real function.
- `tsc --noEmit`: the repo baseline is dirty on `main`; normalized error-signature diff confirms **0 new type errors** introduced by this branch (35 identical pre-existing signatures on both `main` and this branch for the touched files).
- Will confirm the `/models/4201` a11y score rise + no CLS / other-route regression from the `lhci-bot` comment on this PR's preview build.

## Open items
- `aria-allowed-attr` ×7 (Mantine `HoverCard.Target` injecting `aria-haspopup="dialog"` onto non-interactive stat badges in the title row) is **not** fixed here — the clean fix needs an interactive-role/focus decision (behavior change). Flagged for a follow-up call rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
