### PR TITLE
fix(app-blocks): drive BLOCK_INIT by retry-until-ready, not the iframe load event

### DIFF
--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -13,6 +13,7 @@ import { resolveRequestConsent } from './requestConsentGate';
 import { hideBlock } from './hiddenBlocks';
 import { intersectSandbox } from './sandbox';
 import { projectBlockInitContext, projectBlockInitViewer } from './projectBlockInit';
+import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, BlockInstall, ModelSlotContext, SlotContext } from './types';
 import { dialogStore } from '~/components/Dialog/dialogStore';
@@ -82,8 +83,15 @@ function storageErrorMessage(err: unknown): string {
  * lifecycle. Implements the @civitai/app-sdk/blocks v1 contract — see
  * docs/features/app-blocks.md "BLOCK_INIT contract" for the payload shape.
  *
- *   1. iframe `load` event → if token already in state, send BLOCK_INIT.
- *      Otherwise wait. Both conditions must hold before BLOCK_INIT fires.
+ *   1. Once token is present AND the effective-checkpoint query has resolved,
+ *      POST BLOCK_INIT immediately and RE-POST it on a short interval until
+ *      the block acks with BLOCK_READY (or the readiness timeout fires). This
+ *      is NOT gated on the iframe's `load` event — on prod the cached block
+ *      bundle's `load` fires before React attaches `onLoad`, so a load-gated
+ *      single-shot init was being missed and the block sat blank forever
+ *      ("timed out waiting for BLOCK_INIT"). Repeated init is safe: the
+ *      block's IframeTransport origin-checks and dedupes BLOCK_INIT
+ *      (`if (!this.initResolved)`). See iframeInitController.ts.
  *   2. Wait for BLOCK_READY (≤10s). Timeout shows BlockFallback("timeout").
  *   3. BLOCK_ERROR with `fatal: true` shows BlockFallback("fatal_block_error").
  *   4. RESIZE_IFRAME updates the iframe height, clamped to manifest bounds.
@@ -191,13 +199,21 @@ export function IframeHost({
   const [iframeHeight, setIframeHeight] = useState<number>(
     install.manifest.iframe?.minHeight ?? 200
   );
-  // H-1 (audit): tracked as state, not a ref. The BLOCK_READY timeout
-  // effect's deps are [token, status, iframeLoaded] — using a ref meant the
-  // effect didn't re-run when the iframe's onLoad fired *after* the token
-  // had already resolved. That left no 10s timeout armed, so a silent block
-  // would sit on an indefinite skeleton.
-  const [iframeLoaded, setIframeLoaded] = useState<boolean>(false);
+  // The iframe's `load` event is kept as a best-effort EARLY signal (it can
+  // win the race on fresh/slow loads) but is NO LONGER the trigger for init.
+  // The prod bug was that on cached bundles `load` fires before React attaches
+  // `onLoad`, so a load-gated single-shot init was silently missed and the
+  // block sat blank forever. Init is now driven by IframeInitController
+  // (retry-until-BLOCK_READY), keyed only on token + checkpoint readiness.
   const initSentRef = useRef<boolean>(false);
+  // One controller per mount; owns the BLOCK_INIT retry interval + the
+  // readiness timeout. Created lazily in the init effect.
+  const controllerRef = useRef<IframeInitController | null>(null);
+  // Stable holder for the latest init payload so the controller's interval
+  // always posts the freshest BLOCK_INIT (token/checkpoint can resolve after
+  // the controller started — the next tick picks up the new payload) without
+  // re-creating the controller and resetting its timers.
+  const buildInitPayloadRef = useRef<() => BlockInitPayload>();
 
   const iframeSrc = install.manifest.iframe?.src ?? '';
   const expectedOrigin = useMemo(() => {
@@ -345,17 +361,23 @@ export function IframeHost({
     renderMode: install.renderMode,
   });
 
-  const sendInit = () => {
-    if (initSentRef.current) return;
-    if (!iframeLoaded || !token) return;
-    // Wait for the effective checkpoint to resolve before init — otherwise
-    // the block renders without a checkpoint label and re-mounts when the
-    // query lands. `isLoading` is false even on error; the error path
-    // still lets us init with `checkpoint: null` so the block isn't stuck.
-    if (effectiveCheckpointQuery.isLoading) return;
+  // Keep the controller's interval posting the freshest payload. buildInitPayload
+  // closes over query results that can resolve AFTER the controller started; we
+  // re-point this ref every render so the next retry tick uses the latest data
+  // without resetting the controller's timers.
+  buildInitPayloadRef.current = buildInitPayload;
+
+  // Post a single BLOCK_INIT. The IframeInitController calls this immediately
+  // on start() and then on each retry tick until BLOCK_READY. It is safe to
+  // call repeatedly: the block's IframeTransport origin-checks and dedupes
+  // BLOCK_INIT (`if (!this.initResolved)`), so extra posts are ignored
+  // block-side. `initSentRef` is flipped on the first post so the dependent
+  // flows (TOKEN_REFRESH push, REQUEST_TOKEN reply, SUSPEND-on-unmount) that
+  // key off "have we begun initing?" still fire.
+  const sendInitOnce = useCallback(() => {
     initSentRef.current = true;
-    send('BLOCK_INIT', buildInitPayload());
-  };
+    send('BLOCK_INIT', (buildInitPayloadRef.current ?? (() => undefined as never))());
+  }, [send]);
 
   // H-3: when the token rotates after BLOCK_INIT (every ~13min), send a
   // TOKEN_REFRESH message so the iframe can pick up the new credential
@@ -400,19 +422,46 @@ export function IframeHost({
     return off;
   }, [token, expiresAt, buzzBudget, grantedScopes, send, onMessage]);
 
+  // Init handshake. Start the moment we're ALLOWED to init — token present and
+  // the effective-checkpoint query resolved (`isLoading` false; the error path
+  // also resolves to false and inits with checkpoint: null, as before). NOT
+  // gated on the iframe `load` event: the controller posts BLOCK_INIT
+  // immediately and re-posts every INIT_RETRY_INTERVAL_MS until BLOCK_READY,
+  // which survives the cached-bundle race where `load` fires before React
+  // attaches `onLoad`. The readiness timeout is armed by the controller on
+  // start() (NOT inside an `iframeLoaded` gate), so a block that never acks
+  // surfaces a `timeout` fallback instead of a silent indefinite skeleton.
   useEffect(() => {
-    if (status !== 'loading') return;
-    if (!iframeLoaded || !token) return;
-    // Re-run when the effective-checkpoint query resolves so sendInit's
-    // guard releases. Without this dep the effect doesn't fire after the
-    // query lands, leaving the iframe stuck on the loading skeleton.
-    sendInit();
-    const t = setTimeout(() => {
-      setStatus((current) => (current === 'loading' ? 'timeout' : current));
-    }, BLOCK_READY_TIMEOUT_MS);
-    return () => clearTimeout(t);
+    if (
+      !shouldStartInit({
+        status,
+        hasToken: !!token,
+        checkpointLoading: effectiveCheckpointQuery.isLoading,
+      })
+    ) {
+      return;
+    }
+    if (controllerRef.current) return; // already initing — don't restart timers
+
+    const controller = new IframeInitController({
+      sendInit: sendInitOnce,
+      readyTimeoutMs: BLOCK_READY_TIMEOUT_MS,
+      onReadyTimeout: () => {
+        setStatus((current) => (current === 'loading' ? 'timeout' : current));
+      },
+    });
+    controllerRef.current = controller;
+    controller.start();
+
+    return () => {
+      controller.dispose();
+      controllerRef.current = null;
+    };
+    // sendInitOnce is stable (useCallback over `send`); buildInitPayloadRef
+    // carries the freshest payload so we intentionally do NOT re-run on
+    // payload-input changes — restarting would reset the readiness timeout.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, status, iframeLoaded, effectiveCheckpointQuery.isLoading]);
+  }, [token, status, effectiveCheckpointQuery.isLoading, sendInitOnce]);
 
   // Independent token-wait timer: catches the case where the iframe loads but
   // the token never resolves (e.g. /api/v1/block-tokens repeatedly 5xx-ing).
@@ -443,7 +492,13 @@ export function IframeHost({
         }
         return current;
       });
-      if (appliedReady) applyHeight(payload.height);
+      if (appliedReady) {
+        // Block acked — stop re-posting BLOCK_INIT and cancel the readiness
+        // timeout. One extra in-flight retry tick before this lands is fine
+        // (the block dedupes init), but we must not keep spamming.
+        controllerRef.current?.notifyReady();
+        applyHeight(payload.height);
+      }
     });
     return off;
   }, [onMessage, applyHeight]);
@@ -1099,14 +1154,13 @@ export function IframeHost({
           // there's no layout shift when it becomes interactive.
           pointerEvents: isReady ? 'auto' : 'none',
         }}
-        onLoad={() => {
-          // H-1: setState (not ref) so the BLOCK_READY timeout effect
-          // re-runs once both token AND iframeLoaded are true. sendInit
-          // still fires synchronously here for the common case where
-          // the token resolved first.
-          setIframeLoaded(true);
-          sendInit();
-        }}
+        // NOTE: no `onLoad`-driven init. The iframe `load` event is
+        // unreliable as the init trigger — on prod the cached block bundle's
+        // `load` fires before React attaches the handler, so a load-gated
+        // single-shot BLOCK_INIT was silently missed and the block sat blank
+        // ("timed out waiting for BLOCK_INIT"). Init is driven entirely by
+        // IframeInitController (retry-until-BLOCK_READY), keyed on token +
+        // checkpoint readiness. See the init effect above.
       />
       {status === 'loading' && (
         <div style={{ position: 'absolute', inset: 0 }}>

--- a/src/components/AppBlocks/__tests__/iframeInitController.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeInitController.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IframeInitController, INIT_RETRY_INTERVAL_MS } from '../iframeInitController';
+
+/**
+ * Regression coverage for the prod App-Blocks "blank iframe" bug.
+ *
+ * THE BUG: the host posted BLOCK_INIT exactly once, gated on the iframe's
+ * React `onLoad` having fired. On prod the block bundle (`<slug>.civit.ai`) is
+ * cached, so the iframe `load` event fires BEFORE React attaches `onLoad` →
+ * the event is missed → init was never posted → the block's transport rejected
+ * with "timed out waiting for BLOCK_INIT after 10000ms" and the iframe stayed
+ * blank forever. Critically, the readiness timeout was ALSO gated on
+ * `iframeLoaded`, so nothing surfaced a fallback — a silent indefinite
+ * skeleton.
+ *
+ * THE FIX (this controller): once init is allowed (token + checkpoint ready)
+ * the host hands control here. We post BLOCK_INIT immediately, re-post on a
+ * short interval until the block acks (BLOCK_READY → notifyReady), and arm the
+ * readiness timeout on start() — NOT on any load event. Repeated posts are
+ * safe: the block's IframeTransport origin-checks and dedupes BLOCK_INIT
+ * (`if (!this.initResolved)`).
+ *
+ * These tests drive the controller with fake timers. They are the unit that
+ * the old load-gated code could not satisfy: the old path required an `onLoad`
+ * event to fire before it would ever post init OR arm a timeout; this
+ * controller does both with no load signal at all.
+ */
+describe('IframeInitController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeController(overrides?: {
+    sendInit?: () => void;
+    onReadyTimeout?: () => void;
+    readyTimeoutMs?: number;
+    retryIntervalMs?: number;
+  }) {
+    const sendInit = overrides?.sendInit ?? vi.fn();
+    const onReadyTimeout = overrides?.onReadyTimeout ?? vi.fn();
+    const controller = new IframeInitController({
+      sendInit,
+      onReadyTimeout,
+      readyTimeoutMs: overrides?.readyTimeoutMs ?? 10_000,
+      retryIntervalMs: overrides?.retryIntervalMs,
+    });
+    return { controller, sendInit, onReadyTimeout };
+  }
+
+  describe('the race: init does not depend on the iframe load event', () => {
+    it('posts BLOCK_INIT immediately on start(), with no load signal', () => {
+      const { controller, sendInit } = makeController();
+      // No `onLoad` is ever simulated — the controller has no concept of it.
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps re-posting BLOCK_INIT on the retry interval until acked', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1); // immediate
+
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS);
+      expect(sendInit).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS);
+      expect(sendInit).toHaveBeenCalledTimes(3);
+
+      // Several more ticks — still re-sending because no BLOCK_READY arrived.
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 3);
+      expect(sendInit).toHaveBeenCalledTimes(6);
+    });
+
+    it('uses the configurable retry interval', () => {
+      const { controller, sendInit } = makeController({ retryIntervalMs: 250 });
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(250);
+      expect(sendInit).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('retry stops once the block acks (BLOCK_READY → notifyReady)', () => {
+    it('stops re-posting after notifyReady()', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS); // -> 2 sends
+      expect(sendInit).toHaveBeenCalledTimes(2);
+
+      controller.notifyReady();
+
+      // No further sends, ever.
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 10);
+      expect(sendInit).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not fire the readiness timeout after acking', () => {
+      const { controller, sendInit, onReadyTimeout } = makeController({
+        readyTimeoutMs: 10_000,
+      });
+      controller.start();
+      controller.notifyReady();
+      vi.advanceTimersByTime(20_000);
+      expect(onReadyTimeout).not.toHaveBeenCalled();
+      // and no retry sends leaked through after ready
+      expect(sendInit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('silent-blank guard: readiness timeout arms on start(), not on load', () => {
+    it('fires onReadyTimeout when the block never acks', () => {
+      const { controller, onReadyTimeout } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      expect(onReadyTimeout).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(9_999);
+      expect(onReadyTimeout).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(onReadyTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops re-posting init once the readiness timeout fires', () => {
+      const { controller, sendInit } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      vi.advanceTimersByTime(10_000); // timeout fires here
+      const callsAtTimeout = sendInit.mock.calls.length;
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 5);
+      expect(sendInit).toHaveBeenCalledTimes(callsAtTimeout);
+    });
+
+    it('fires the readiness timeout exactly once', () => {
+      const { controller, onReadyTimeout } = makeController({ readyTimeoutMs: 5_000 });
+      controller.start();
+      vi.advanceTimersByTime(60_000);
+      expect(onReadyTimeout).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('idempotency / lifecycle', () => {
+    it('start() is idempotent — a second call does not double the timers', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS);
+      // one interval, not two — so exactly one extra send
+      expect(sendInit).toHaveBeenCalledTimes(2);
+    });
+
+    it('dispose() stops the interval and the readiness timeout (unmount)', () => {
+      const { controller, sendInit, onReadyTimeout } = makeController({
+        readyTimeoutMs: 10_000,
+      });
+      controller.start();
+      controller.dispose();
+      vi.advanceTimersByTime(60_000);
+      expect(sendInit).toHaveBeenCalledTimes(1);
+      expect(onReadyTimeout).not.toHaveBeenCalled();
+    });
+
+    it('start() after stop() is a no-op (cannot resurrect a disposed controller)', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      controller.dispose();
+      controller.start();
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 5);
+      expect(sendInit).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifyReady() before start() prevents any send (defensive)', () => {
+      const { controller, sendInit } = makeController();
+      controller.notifyReady();
+      controller.start();
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 5);
+      expect(sendInit).not.toHaveBeenCalled();
+    });
+
+    it('hasStarted() reflects whether init has begun', () => {
+      const { controller } = makeController();
+      expect(controller.hasStarted()).toBe(false);
+      controller.start();
+      expect(controller.hasStarted()).toBe(true);
+    });
+  });
+});

--- a/src/components/AppBlocks/__tests__/oldBehaviorProof.test.ts
+++ b/src/components/AppBlocks/__tests__/oldBehaviorProof.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * PROOF that the race-regression test would FAIL against the pre-fix host
+ * logic. This reconstructs the OLD init gate exactly (init only when the
+ * iframe `load` event had fired → `iframeLoaded === true`) and shows that,
+ * with no load event, the old gate refuses to init — i.e. the silent blank.
+ *
+ * This file is a guard, not production code: it documents the regression the
+ * real `shouldStartInit` now prevents. Delete-safe.
+ */
+function oldShouldStartInit(args: {
+  status: 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token';
+  hasToken: boolean;
+  checkpointLoading: boolean;
+  iframeLoaded: boolean; // the old, load-gated requirement
+}): boolean {
+  const { status, hasToken, checkpointLoading, iframeLoaded } = args;
+  if (status !== 'loading') return false;
+  if (!iframeLoaded || !hasToken) return false; // <- the bug: load-gated
+  if (checkpointLoading) return false;
+  return true;
+}
+
+describe('old (pre-fix) load-gated init — reproduces the prod blank-iframe bug', () => {
+  it('does NOT init when the iframe load event never fired (the bug)', () => {
+    // Cached-bundle race: load fired before React attached onLoad, so
+    // iframeLoaded stayed false forever — even with token + checkpoint ready.
+    expect(
+      oldShouldStartInit({
+        status: 'loading',
+        hasToken: true,
+        checkpointLoading: false,
+        iframeLoaded: false,
+      })
+    ).toBe(false); // <- silent blank
+  });
+
+  it('only init-ed once a load event was observed', () => {
+    expect(
+      oldShouldStartInit({
+        status: 'loading',
+        hasToken: true,
+        checkpointLoading: false,
+        iframeLoaded: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/components/AppBlocks/__tests__/shouldStartInit.test.ts
+++ b/src/components/AppBlocks/__tests__/shouldStartInit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldStartInit } from '../iframeInitController';
+
+/**
+ * Coverage for the init-START gate — the predicate the host effect keys on.
+ *
+ * THIS is the regression unit for the prod blank-iframe bug. The old host
+ * required `iframeLoaded === true` before it would post BLOCK_INIT or arm the
+ * readiness timeout. On prod the cached block bundle's `load` event fired
+ * before React attached `onLoad`, so `iframeLoaded` never flipped and init was
+ * never attempted — a silent indefinite skeleton. The new gate has NO load
+ * input: with a token and a resolved checkpoint we start initing regardless of
+ * whether the iframe `load` event was ever observed.
+ *
+ * It also pins the gating that MUST still hold (so we don't over-correct):
+ * still wait for the token, still wait for the checkpoint query, and never
+ * (re)start once we've left the loading state.
+ */
+describe('shouldStartInit', () => {
+  describe('the race regression: starts WITHOUT any iframe-load signal', () => {
+    it('starts when token present + checkpoint resolved (no load concept at all)', () => {
+      // There is intentionally no `iframeLoaded` parameter — load-independence
+      // is structural. The old code could not have returned true here without
+      // a load event having fired first.
+      expect(shouldStartInit({ status: 'loading', hasToken: true, checkpointLoading: false })).toBe(
+        true
+      );
+    });
+  });
+
+  describe('preserves the gating that SHOULD hold before init', () => {
+    it('does NOT start while the token is missing (token-wait path owns this)', () => {
+      expect(
+        shouldStartInit({ status: 'loading', hasToken: false, checkpointLoading: false })
+      ).toBe(false);
+    });
+
+    it('does NOT start while the effective-checkpoint query is still loading', () => {
+      expect(shouldStartInit({ status: 'loading', hasToken: true, checkpointLoading: true })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('never (re)starts once out of the loading state', () => {
+    it.each(['ready', 'timeout', 'fatal', 'no_token'] as const)(
+      'returns false for terminal/ready status "%s" even with a token + resolved checkpoint',
+      (status) => {
+        expect(shouldStartInit({ status, hasToken: true, checkpointLoading: false })).toBe(false);
+      }
+    );
+  });
+});

--- a/src/components/AppBlocks/iframeInitController.ts
+++ b/src/components/AppBlocks/iframeInitController.ts
@@ -1,0 +1,178 @@
+// Pure init-handshake controller for IframeHost. Extracted so the
+// retry-until-ack + readiness-timeout orchestration is unit-testable in the
+// node vitest env (civitai-web's vitest runs `environment: 'node'`, collects
+// only `*.test.ts`, and has no RTL — so full Mantine/trpc component renders
+// aren't available). Mirrors the existing W7/W8 pure-helper pattern
+// (hostRenderDecision, resolveRequestSignIn, resolveBuzzPurchaseRequest,
+// extractRequestId): the host effect stays thin and the tricky timing logic
+// lives here behind a deterministic, injectable surface.
+//
+// WHY THIS EXISTS (the prod bug it fixes)
+// --------------------------------------
+// The host used to send BLOCK_INIT exactly once, gated on the iframe's React
+// `onLoad` having fired (`iframeLoaded`). On prod the block bundle
+// (`<slug>.civit.ai`) is cached, so the iframe `load` event can fire BEFORE
+// React attaches the `onLoad` handler → the event is missed → `iframeLoaded`
+// never flips → BLOCK_INIT is never posted → the block sits blank and its
+// own transport rejects with "timed out waiting for BLOCK_INIT after 10000ms".
+//
+// THE FIX
+// -------
+// Stop depending on the `load` event. Once we're allowed to init (token
+// present + effective-checkpoint query resolved) we POST BLOCK_INIT
+// immediately and then RE-POST it on a short interval until the block
+// acknowledges with BLOCK_READY (or the readiness timeout fires). This is
+// robust to BOTH the missed-load race AND posting before the block's message
+// listener is attached (an early post is simply dropped by the block and the
+// next tick re-sends).
+//
+// WHY REPEATED SENDS ARE SAFE (verified against the SDK transport)
+// ----------------------------------------------------------------
+// The block's IframeTransport (civitai-blocks-react
+// src/internal/iframeTransport.ts):
+//   - origin-checks every inbound message: `if
+//     (!this.allowedOrigins.has(event.origin)) return;`
+//   - dedupes init: the BLOCK_INIT branch is guarded by `if
+//     (!this.initResolved)` which it sets true on the first valid init;
+//     subsequent BLOCK_INITs are ignored.
+// So re-posting BLOCK_INIT is idempotent on the block side. A cross-origin
+// `iframe.contentDocument.readyState` check is NOT an option (cross-origin
+// access throws) — hence retry-until-ack rather than load-detection.
+//
+// READINESS TIMEOUT (the silent-blank guard)
+// ------------------------------------------
+// The readiness timeout is armed by `start()` — i.e. when we BEGIN trying to
+// init — NOT gated on the iframe having loaded. Previously it was only armed
+// inside the `iframeLoaded && token` effect, so if `iframeLoaded` never
+// flipped (exactly this bug) NO timeout fired and the user saw an indefinite
+// skeleton. Now a genuinely-broken block still surfaces a `timeout` fallback.
+
+/** Re-post BLOCK_INIT this often until the block acks with BLOCK_READY. */
+export const INIT_RETRY_INTERVAL_MS = 400;
+
+/**
+ * Pure gate: are we ALLOWED to begin the BLOCK_INIT handshake?
+ *
+ * This is the predicate the host's init effect keys on. It deliberately does
+ * NOT include any "iframe loaded" signal — that was the prod bug. The old
+ * single-shot path required `iframeLoaded === true`, which never flipped when
+ * the cached bundle's `load` event fired before React attached `onLoad`. The
+ * correct gates are:
+ *   - we're still in the loading state (haven't already initialized/failed),
+ *   - the block token is present, and
+ *   - the effective-checkpoint query has resolved (`!checkpointLoading`; the
+ *     error path also resolves false and inits with checkpoint:null, as today).
+ *
+ * Extracted as a pure function so the load-independence is unit-testable in
+ * the node vitest env (mirrors hostRenderDecision / resolveRequestSignIn).
+ */
+export function shouldStartInit(args: {
+  status: 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token';
+  hasToken: boolean;
+  checkpointLoading: boolean;
+}): boolean {
+  const { status, hasToken, checkpointLoading } = args;
+  if (status !== 'loading') return false;
+  if (!hasToken) return false;
+  if (checkpointLoading) return false;
+  return true;
+}
+
+export interface IframeInitControllerOptions {
+  /** Post one BLOCK_INIT to the iframe (host's `send('BLOCK_INIT', payload)`). */
+  sendInit: () => void;
+  /** Fired once, when the readiness window elapses without a BLOCK_READY. */
+  onReadyTimeout: () => void;
+  /** ms to wait for BLOCK_READY before calling onReadyTimeout. */
+  readyTimeoutMs: number;
+  /** ms between BLOCK_INIT re-sends. Defaults to INIT_RETRY_INTERVAL_MS. */
+  retryIntervalMs?: number;
+}
+
+/**
+ * Drives the BLOCK_INIT handshake: posts init immediately on `start()`, arms
+ * the readiness timeout, and re-posts init every `retryIntervalMs` until the
+ * block acks (`notifyReady()`) or the timeout fires. Idempotent: a second
+ * `start()` is a no-op, and `notifyReady()` / `dispose()` after stop do
+ * nothing. Stateless wrt React — `IframeHost` owns one instance per mount.
+ */
+export class IframeInitController {
+  private readonly opts: Required<IframeInitControllerOptions>;
+  private started = false;
+  private stopped = false;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(options: IframeInitControllerOptions) {
+    this.opts = {
+      ...options,
+      // Resolve the retry interval explicitly so an `undefined` passed in
+      // `options` (e.g. `retryIntervalMs: undefined`) doesn't clobber the
+      // default via spread — `setInterval(fn, undefined)` would fire as fast
+      // as possible.
+      retryIntervalMs: options.retryIntervalMs ?? INIT_RETRY_INTERVAL_MS,
+    };
+  }
+
+  /**
+   * Begin the handshake. Posts BLOCK_INIT once synchronously, arms the
+   * readiness timeout, and schedules periodic re-sends. No-op if already
+   * started or already stopped.
+   */
+  start(): void {
+    if (this.started || this.stopped) return;
+    this.started = true;
+
+    // Immediate first send — covers the common case where the block's
+    // listener is already attached. Subsequent ticks cover the races
+    // (missed load event, listener-not-yet-attached).
+    this.opts.sendInit();
+
+    this.intervalId = setInterval(() => {
+      // Defensive: if we've stopped between ticks, do nothing. (clearInterval
+      // already prevents this; belt-and-suspenders for fake-timer edge cases.)
+      if (this.stopped) return;
+      this.opts.sendInit();
+    }, this.opts.retryIntervalMs);
+
+    // Arm the readiness timeout HERE — on init-start — not gated on the
+    // iframe load event. This is the silent-blank guard.
+    this.timeoutId = setTimeout(() => {
+      if (this.stopped) return;
+      this.stop();
+      this.opts.onReadyTimeout();
+    }, this.opts.readyTimeoutMs);
+  }
+
+  /** Whether start() has run (i.e. at least one BLOCK_INIT was posted). */
+  hasStarted(): boolean {
+    return this.started;
+  }
+
+  /**
+   * The block acknowledged (BLOCK_READY). Stop re-sending and cancel the
+   * readiness timeout. One extra in-flight tick before this lands is
+   * acceptable — the block dedupes init — but no more after.
+   */
+  notifyReady(): void {
+    this.stop();
+  }
+
+  /** Tear down all timers (unmount, or terminal status from another path). */
+  dispose(): void {
+    this.stop();
+  }
+
+  private stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    if (this.timeoutId !== null) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+}


### PR DESCRIPTION
## The bug (confirmed in prod, mod's browser)

App Blocks rendered the host chrome but the block iframe stayed **blank forever** on prod `civitai.com`. The block bundle loaded (all network 200s) and the block token minted, but the iframe's console showed:

```
IframeTransport: timed out waiting for BLOCK_INIT after 10000ms
```

No host error, just a silent blank.

## Root cause — cross-origin iframe `onLoad` race

`IframeHost.tsx` posted `BLOCK_INIT` **exactly once**, gated on the iframe's React `onLoad` having flipped `iframeLoaded=true`. On prod the cached `<slug>.civit.ai` bundle fires its `load` event **before React attaches the `onLoad` handler** → the event is missed → `iframeLoaded` never becomes true → `sendInit()` early-returns → `BLOCK_INIT` is never posted → the block times out.

Worse: the readiness timeout was **also** armed only inside the `iframeLoaded && token` effect, so when `iframeLoaded` never flipped, **no timeout fired** — the user saw an indefinite skeleton with no fallback. Preview builds won the race on fresh/slow loads, so the block had never actually rendered on prod.

NOT the cause (all verified correct upstream): Flipt flags, the block bundle, infra, CSP `frame-ancestors`, the bundle's `ALLOWED_PARENT_ORIGINS`, and the token mint.

## The fix (host-only — block SDK + bundle unchanged)

Drop the hard dependency on the `load` event.

- **`IframeInitController`** (new, pure, unit-tested): on `start()` it posts `BLOCK_INIT` immediately and **re-posts every 400ms until the block acks with `BLOCK_READY`** (`notifyReady()`) or the readiness timeout fires. Robust to both the missed-load race AND posting before the block's message listener is attached (an early post is dropped; the next tick re-sends).
- Init now starts on a pure gate **`shouldStartInit`** keyed on **token present + effective-checkpoint query resolved** — with **no load input**. The `<iframe>`'s `onLoad` init trigger is removed.
- The **readiness timeout** (`BLOCK_READY_TIMEOUT_MS = 10s` → `status='timeout'`) is armed by the controller on `start()` — i.e. when we *begin* initing — so a genuinely-broken block surfaces a `timeout` fallback instead of a silent blank. The **token-wait timeout** (`no_token`, 15s) is unchanged.
- `BLOCK_READY` calls `notifyReady()` (stops the interval synchronously); the init effect's status-change cleanup also disposes the controller on ready/timeout/fatal/unmount.

### Why repeated `BLOCK_INIT` is safe

Verified against the SDK transport (`civitai-blocks-react/src/internal/iframeTransport.ts`):
- **Origin-checked**: `handleMessage` opens with `if (!this.allowedOrigins.has(event.origin)) return;`
- **Init-deduped**: the `BLOCK_INIT` branch is guarded by `if (!this.initResolved)`, which it sets true on the first valid init — subsequent `BLOCK_INIT`s are ignored.

So re-posting is idempotent block-side. (A cross-origin `iframe.contentDocument.readyState` check is impossible — it throws — which is why retry-until-ack is the right approach rather than load-detection.)

### Preserved flows

`initSentRef` is set on the first post, so `TOKEN_REFRESH` (rotation), `REQUEST_TOKEN` reply, consent re-mint, `RESIZE_IFRAME`, `SUSPEND`-on-unmount, and the `framed()` fallbacks are all unchanged. Token/checkpoint gating that *should* hold before init is preserved.

## Tests

vitest, node env, fake timers (matches the existing AppBlocks pure-helper test pattern — that suite has no RTL; vitest runs `environment: 'node'` and collects only `*.test.ts`):

- `iframeInitController.test.ts` (13) — immediate-send-without-load, retry-until-ack, **stop-on-ready**, **readiness-timeout-arms-on-start (silent-blank guard)**, idempotency/dispose.
- `shouldStartInit.test.ts` (7) — **starts with no load signal** (the race regression), still gates on token + checkpoint, never restarts out of `loading`.
- `oldBehaviorProof.test.ts` (2) — reconstructs the OLD load-gated predicate and shows it returns `false` with no load event (the silent blank this PR fixes).

All 103 AppBlocks tests pass locally (22 new). Full `tsc` is unreliable in the worktree (stale Prisma, ~5k pre-existing errors, **0 referencing AppBlocks**) — CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)