### PR TITLE
test(blocks): raise PGlite hook timeout for listForModel.behavior (fixes Tekton unit:fail)

### DIFF
--- a/src/server/services/__tests__/listForModel.behavior.test.ts
+++ b/src/server/services/__tests__/listForModel.behavior.test.ts
@@ -11,6 +11,15 @@ import {
   truncateAll,
 } from './listForModel.harness';
 
+// Spinning up the in-process PGlite (WASM Postgres) + schema in beforeAll, and
+// the second PGlite in the bridge sanity test, can exceed the default 10s
+// hook/test timeout on a slow / heavily-contended CI node (observed: the
+// beforeAll hook timing out on the Tekton preview build pool, where this suite
+// was the lone unit-test failure while it passes on faster GitHub runners).
+// Generous, env-agnostic timeouts for this one PGlite-backed file — relaxing a
+// timeout can only help a slow runner, never mask a real failure.
+vi.setConfig({ hookTimeout: 60_000, testTimeout: 60_000 });
+
 /**
  * Behavioral tests for BlockRegistry.listForModel that run the REAL UNION-ALL
  * query against an in-process Postgres (PGlite). See listForModel.harness.ts


### PR DESCRIPTION
## What

Raises the hook/test timeout for `listForModel.behavior.test.ts` (the only PGlite-backed unit test) via a single `vi.setConfig({ hookTimeout: 60_000, testTimeout: 60_000 })`.

## Why

This suite was the **lone unit-test failure** on the DataPacket Tekton preview build pool (surfacing as `unit:fail (report-only)` on every recent PR's preview comment), while passing on GitHub Actions. Root cause (from the Tekton run log) is **not** a product bug or a flaky assertion:

```
FAIL src/server/services/__tests__/listForModel.behavior.test.ts
Error: Hook timed out in 10000ms.
 ❯ beforeAll(async () => { db = new PGlite(); … await createSchema(db); })
```

The `beforeAll` spins up an in-process PGlite (WASM Postgres) + schema; the bridge sanity test news up a second PGlite. On the slow / heavily-contended Tekton node (that run showed `import 485s` / `transform 230s`) the WASM init exceeds the default **10s** hook timeout → the whole file fails (its tests never run: `1 file failed`, `0 tests failed`). GitHub's faster runners finish under 10s, so it's green there.

## Fix

One line, file-scoped — generous, env-agnostic timeouts. Relaxing a timeout can only help a slow runner; it can't mask a real failure (a genuinely broken test still fails its assertions). No product code changes; no change to what the tests assert.

## Verification

- The suite passes on GitHub Actions today (unchanged by this) — see this PR's `Unit Tests` check.
- The real proof is this PR's **preview `unit:pass`** on the Tekton pool (where it currently fails). Locally I confirmed the change parses and doesn't alter behavior (the `beforeAll` + bridge test run as before).

Found while auditing the preview comment on #2547 (component-testing scaffold); this is a separate, pre-existing issue, fixed in its own PR.
