### PR TITLE
test(blocks): substrate unit coverage (trust-tier C1, workflow-completed idempotency, buildApplyScript)

### DIFF
--- a/src/pages/api/internal/blocks/workflow-completed.ts
+++ b/src/pages/api/internal/blocks/workflow-completed.ts
@@ -31,10 +31,14 @@ async function markWorkflowProcessed(workflowId: string): Promise<boolean> {
     }
     return false; // already processed
   } catch {
-    // Fail closed: a Redis incident shouldn't let a retry double-bill.
-    // Returning false here makes the endpoint return 409 (or whatever the
-    // caller maps "already processed" to), which the orchestrator should
-    // retry once Redis recovers.
+    // Fail closed: a Redis incident must not let a retry double-bill, so we
+    // treat the workflow as already-processed (return false). The handler then
+    // responds 200 {ok:true, idempotent:true} and does NOT process/bill it.
+    // Trade-off: a 200 means the orchestrator won't redeliver, so the
+    // completion is effectively dropped for the duration of the outage. That's
+    // acceptable while this is a no-op scaffold (no billing yet); revisit when
+    // Phase-3 billing lands — at that point a Redis outage dropping a billable
+    // completion may warrant a 5xx-to-force-retry instead.
     return false;
   }
 }

--- a/src/server/services/blocks/__tests__/apps-pipeline.buildApplyScript.test.ts
+++ b/src/server/services/blocks/__tests__/apps-pipeline.buildApplyScript.test.ts
@@ -33,14 +33,28 @@ describe('buildApplyScript', () => {
     expect(script).toContain('set -euo pipefail');
   });
 
-  it('interpolates the namespace into every kubectl -n invocation', () => {
-    const nsInvocations = script.match(/kubectl -n \S+/g) ?? [];
-    expect(nsInvocations.length).toBeGreaterThan(0);
-    for (const inv of nsInvocations) {
-      expect(inv).toBe(`kubectl -n ${NS}`);
-    }
-    // And nothing leaked a different namespace literal.
-    expect(script).not.toMatch(/kubectl -n (?!civitai-apps\b)\S/);
+  it('namespaces every kubectl command except the manifest-scoped apply', () => {
+    // Match EVERY kubectl invocation anywhere in the script (incl. ones inside
+    // `if ! kubectl …` and `$(kubectl …)` — a `kubectl -n` regex misses those).
+    const invocations = [...script.matchAll(/kubectl\s+([^\n]*)/g)].map((m) => m[1].trim());
+    expect(invocations.length).toBeGreaterThan(0);
+
+    // The ONLY un-namespaced kubectl is the manifest-scoped `apply` — its target
+    // namespace lives inside /tmp/rendered.yaml (pinned by the app-templates
+    // ConfigMap, enforced out of scope of this unit). EVERYTHING else must be
+    // `-n ${NS}`-scoped. This catches (a) a dropped `-n` on the smoke/wait/get/
+    // describe/logs/rollout commands, (b) a NEW un-namespaced kubectl command,
+    // and (c) a wrong-namespace leak — none of which the old `-n \S+`-only
+    // regex could see (it never inspected the apply, the highest-blast command).
+    const APPLY = 'apply -f /tmp/rendered.yaml';
+    const offenders = invocations.filter(
+      (inv) => !inv.startsWith(`-n ${NS} `) && !inv.startsWith(APPLY)
+    );
+    expect(offenders).toEqual([]);
+    // …and the apply is the SOLE un-namespaced command (exactly one).
+    expect(invocations.filter((inv) => !inv.startsWith(`-n ${NS} `))).toEqual([APPLY]);
+    // Sanity: the namespaced commands really exist (run/wait/get/describe/logs/rollout).
+    expect(invocations.filter((inv) => inv.startsWith(`-n ${NS} `)).length).toBeGreaterThanOrEqual(4);
   });
 
   it('routes a distinct namespace argument through unchanged (no hardcoded ns)', () => {

--- a/src/server/services/blocks/__tests__/apps-pipeline.buildApplyScript.test.ts
+++ b/src/server/services/blocks/__tests__/apps-pipeline.buildApplyScript.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * buildApplyScript() emits the bash the apply Job runs to smoke-test the
+ * candidate image and roll out the per-app manifest. It is a pure function of
+ * the namespace, but the script is security- and correctness-sensitive:
+ *
+ *   - it MUST be strict-mode bash (`set -euo pipefail`) so a failed smoke
+ *     step aborts the apply instead of shipping a broken image;
+ *   - the caller-supplied namespace is interpolated into every `kubectl -n`
+ *     invocation — pin that it lands on all of them so an apply can never be
+ *     misdirected to the wrong namespace;
+ *   - the per-run shell vars (SLUG / SHA / IMAGE / APP_BLOCK_ID / APPS_DOMAIN)
+ *     must stay SHELL expansions (`${SLUG}`), NOT be interpolated by JS — they
+ *     come from the Job env at runtime, not from this builder;
+ *   - the smoke-pod name is capped at an 8-char short sha to stay under the
+ *     63-char DNS label limit (the 2026-05-30 incident class);
+ *   - the three smoke probes (healthz 200, / 200 text/html, no :8080 port-leak
+ *     redirect) and the cleanup trap must all be present — these are the
+ *     gen-from-model mixed-content / ImagePullBackOff guards.
+ *
+ * Pure function → no mocks needed.
+ */
+
+import { buildApplyScript } from '~/server/services/blocks/apps-pipeline.service';
+
+describe('buildApplyScript', () => {
+  const NS = 'civitai-apps';
+  const script = buildApplyScript(NS);
+
+  it('is strict-mode bash so a failed step aborts the apply', () => {
+    expect(script).toContain('#!/usr/bin/env bash');
+    expect(script).toContain('set -euo pipefail');
+  });
+
+  it('interpolates the namespace into every kubectl -n invocation', () => {
+    const nsInvocations = script.match(/kubectl -n \S+/g) ?? [];
+    expect(nsInvocations.length).toBeGreaterThan(0);
+    for (const inv of nsInvocations) {
+      expect(inv).toBe(`kubectl -n ${NS}`);
+    }
+    // And nothing leaked a different namespace literal.
+    expect(script).not.toMatch(/kubectl -n (?!civitai-apps\b)\S/);
+  });
+
+  it('routes a distinct namespace argument through unchanged (no hardcoded ns)', () => {
+    const other = buildApplyScript('some-other-ns');
+    expect(other).toContain('kubectl -n some-other-ns run');
+    expect(other).not.toContain('kubectl -n civitai-apps');
+  });
+
+  it('leaves per-run vars as SHELL expansions, not JS-interpolated values', () => {
+    // If these had been JS template-interpolated they'd be empty/undefined.
+    for (const v of ['${SLUG}', '${SHA}', '${IMAGE}', '${APP_BLOCK_ID}', '${APPS_DOMAIN}']) {
+      expect(script).toContain(v);
+    }
+    expect(script).not.toContain('undefined');
+  });
+
+  it('caps the smoke-pod name at an 8-char short sha (DNS 63-char label guard)', () => {
+    expect(script).toContain(`SMOKE_POD="smoke-\${SLUG}-$(printf '%s' "\${SHA}" | head -c 8)"`);
+  });
+
+  it('pins the smoke pod hardening: private-registry pull + non-root + drop-ALL caps', () => {
+    expect(script).toContain('imagePullSecrets');
+    expect(script).toContain('ghcr-cred');
+    expect(script).toContain('automountServiceAccountToken":false');
+    expect(script).toContain('runAsNonRoot":true');
+    expect(script).toContain('"drop":["ALL"]');
+    expect(script).toContain('RuntimeDefault');
+  });
+
+  it('always cleans up the smoke pod via an EXIT trap', () => {
+    expect(script).toContain('trap cleanup EXIT');
+    expect(script).toContain('delete pod "${SMOKE_POD}"');
+    expect(script).toContain('--ignore-not-found=true');
+  });
+
+  it('runs all three smoke probes (healthz, root html, port-leak redirect)', () => {
+    expect(script).toContain('/healthz');
+    expect(script).toContain('GET /healthz returned');
+    expect(script).toContain('expected text/html');
+    // The mixed-content port-leak guard rejects any :8080 in a redirect Location.
+    expect(script).toContain("grep -q ':8080'");
+    expect(script).toContain('leaks the in-pod port');
+  });
+
+  it('applies the rendered manifest and waits for the rollout last', () => {
+    const applyIdx = script.indexOf('kubectl apply -f /tmp/rendered.yaml');
+    const rolloutIdx = script.indexOf('rollout status deploy/${SLUG}');
+    expect(applyIdx).toBeGreaterThan(-1);
+    expect(rolloutIdx).toBeGreaterThan(applyIdx);
+    // The apply must come AFTER the smoke test passes.
+    const smokePassIdx = script.indexOf('smoke test: PASSED');
+    expect(applyIdx).toBeGreaterThan(smokePassIdx);
+  });
+});

--- a/src/server/services/blocks/__tests__/apps-pipeline.buildApplyScript.test.ts
+++ b/src/server/services/blocks/__tests__/apps-pipeline.buildApplyScript.test.ts
@@ -34,9 +34,16 @@ describe('buildApplyScript', () => {
   });
 
   it('namespaces every kubectl command except the manifest-scoped apply', () => {
-    // Match EVERY kubectl invocation anywhere in the script (incl. ones inside
-    // `if ! kubectl …` and `$(kubectl …)` — a `kubectl -n` regex misses those).
-    const invocations = [...script.matchAll(/kubectl\s+([^\n]*)/g)].map((m) => m[1].trim());
+    // Match EVERY kubectl invocation anywhere in the EXECUTABLE script (incl.
+    // ones inside `if ! kubectl …` and `$(kubectl …)` — a `kubectl -n` regex
+    // misses those). Strip `#` comment lines first so a future comment that
+    // happens to contain `kubectl` can't inflate the namespaced count or fake
+    // an offender.
+    const executable = script
+      .split('\n')
+      .filter((line: string) => !/^\s*#/.test(line))
+      .join('\n');
+    const invocations = [...executable.matchAll(/kubectl\s+([^\n]*)/g)].map((m) => m[1].trim());
     expect(invocations.length).toBeGreaterThan(0);
 
     // The ONLY un-namespaced kubectl is the manifest-scoped `apply` — its target

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -571,10 +571,10 @@ describe('submitVersion', () => {
       submittedByUserId: 42,
     });
 
-    // fire-and-forget; give the microtask a tick
-    await new Promise((r) => setImmediate(r));
-
-    expect(fetchSpy).toHaveBeenCalled();
+    // fire-and-forget notify — poll until it lands instead of hand-timing the
+    // microtask queue (a new `await` before the fetch would silently make a
+    // single-tick wait flaky).
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe('https://discord.example/hook');
     expect((init as RequestInit).method).toBe('POST');

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -562,7 +562,7 @@ describe('submitVersion', () => {
 
   it('Discord notify is invoked with the right shape on submission', async () => {
     const { submitVersion } = await import('../publish-request.service');
-    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 } as Response));
+    const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) => ({ ok: true, status: 200 } as Response));
     vi.stubGlobal('fetch', fetchSpy);
 
     const buf = await makeValidBundle();
@@ -766,7 +766,7 @@ describe('listPendingRequests', () => {
       row({ id: 'pubreq_2', submittedAt: new Date('2026-05-28T12:00:00Z') }),
     ]);
     const result = await listPendingRequests({});
-    expect(result.items.map((r) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
+    expect(result.items.map((r: { id: string }) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
     expect(result.nextCursor).toBeNull();
     // findMany should have been called with orderBy submittedAt asc.
     const arg = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0];
@@ -792,7 +792,7 @@ describe('listPendingRequests', () => {
       row({ id: 'pubreq_3' }), // third row is the "has next" indicator
     ]);
     const result = await listPendingRequests({ limit: 2 });
-    expect(result.items.map((r) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
+    expect(result.items.map((r: { id: string }) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
     expect(result.nextCursor).toBe('pubreq_2');
   });
 
@@ -853,7 +853,7 @@ describe('listApprovedRequests', () => {
       row({ id: 'pubreq_b', reviewedAt: new Date('2026-05-28T10:00:00Z') }),
     ]);
     const result = await listApprovedRequests({});
-    expect(result.items.map((r) => r.id)).toEqual(['pubreq_a', 'pubreq_b']);
+    expect(result.items.map((r: { id: string }) => r.id)).toEqual(['pubreq_a', 'pubreq_b']);
     const arg = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0];
     expect(arg.orderBy).toEqual({ reviewedAt: 'desc' });
     expect(arg.where).toEqual({ status: 'approved' });
@@ -890,7 +890,7 @@ describe('listApprovedRequests', () => {
       row({ id: 'pubreq_3' }), // limit+1 — the trailing "has next" indicator
     ]);
     const result = await listApprovedRequests({ limit: 2 });
-    expect(result.items.map((r) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
+    expect(result.items.map((r: { id: string }) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
     expect(result.nextCursor).toBe('pubreq_2');
   });
 
@@ -942,7 +942,7 @@ describe('listRejectedRequests', () => {
       row({ id: 'pubreq_b', reviewedAt: new Date('2026-05-28T10:00:00Z') }),
     ]);
     const result = await listRejectedRequests({});
-    expect(result.items.map((r) => r.id)).toEqual(['pubreq_a', 'pubreq_b']);
+    expect(result.items.map((r: { id: string }) => r.id)).toEqual(['pubreq_a', 'pubreq_b']);
     const arg = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0];
     expect(arg.orderBy).toEqual({ reviewedAt: 'desc' });
     expect(arg.where).toEqual({ status: 'rejected' });
@@ -981,7 +981,7 @@ describe('listRejectedRequests', () => {
       row({ id: 'pubreq_3' }), // trailing has-next indicator
     ]);
     const result = await listRejectedRequests({ limit: 2 });
-    expect(result.items.map((r) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
+    expect(result.items.map((r: { id: string }) => r.id)).toEqual(['pubreq_1', 'pubreq_2']);
     expect(result.nextCursor).toBe('pubreq_2');
   });
 

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -1186,6 +1186,119 @@ describe('approveRequest', () => {
     expect(ocUpdateArg.data.allowedScopes).toBe(0);
   });
 
+  // ---- C1: trust-tier self-escalation (the most security-critical contract) ----
+  //
+  // The fix at publish-request.service.ts:1050-1062: trust tier is
+  // moderator-controlled, NEVER publisher-declared. `internal`/`verified`
+  // grant `allow-same-origin`, which defeats the iframe sandbox. A manifest
+  // that declares a raised trustTier must be IGNORED:
+  //   - new app  → always persisted as `unverified`
+  //   - existing → keeps whatever tier is on the DB row
+  // and the normalised manifest (which the sandbox-allowlist validator reads)
+  // must carry the resolved tier too, so the validator can't be tricked.
+  describe('C1: trust-tier is resolved from DB, never raised by the manifest', () => {
+    it('NEW app: a manifest declaring trustTier:internal is persisted as unverified', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      const evilManifest = manifest({ trustTier: 'internal' });
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: evilManifest })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ trustTier: 'internal' });
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      const createArg = mockDbWrite.appBlock.create.mock.calls[0][0].data;
+      // The column the live host reads to decide the sandbox allowlist.
+      expect(createArg.trustTier).toBe('unverified');
+      expect(createArg.trustTier).not.toBe('internal');
+      // The normalised manifest persisted on the row must ALSO be downgraded,
+      // so a later reader keying off manifest.trustTier can't be escalated.
+      expect((createArg.manifest as { trustTier?: string }).trustTier).toBe('unverified');
+    });
+
+    it('NEW app: a manifest declaring trustTier:verified is persisted as unverified', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ trustTier: 'verified' }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ trustTier: 'verified' });
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      const createArg = mockDbWrite.appBlock.create.mock.calls[0][0].data;
+      expect(createArg.trustTier).toBe('unverified');
+      expect((createArg.manifest as { trustTier?: string }).trustTier).toBe('unverified');
+    });
+
+    it('NEW app: a manifest with NO trustTier field still resolves to unverified (no default-to-internal regression)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      // The pre-fix bug DEFAULTED a missing manifest.trustTier to `internal`.
+      const noTierManifest = manifest();
+      delete (noTierManifest as Record<string, unknown>).trustTier;
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: noTierManifest })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle();
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      const createArg = mockDbWrite.appBlock.create.mock.calls[0][0].data;
+      expect(createArg.trustTier).toBe('unverified');
+    });
+
+    it('EXISTING app: keeps the DB trust tier even when the new manifest declares internal', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ version: '0.2.0', trustTier: 'internal' }) })
+      );
+      // Existing row is `verified` (a deliberate out-of-band moderator action).
+      // The manifest declaring `internal` must NOT change it (neither up nor down).
+      mockDbRead.appBlock.findFirst.mockResolvedValue({
+        id: 'apb_existing',
+        appId: 'oc_existing',
+        repoUrl: 'https://forgejo.example/civitai-apps/hello',
+        trustTier: 'verified',
+        app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+      });
+      mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0', trustTier: 'internal' });
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // The manifest-refresh update (NOT the currentVersionSha stamp) carries
+      // the trust tier. It must equal the DB tier, not the manifest's claim.
+      const tierUpdate = mockDbWrite.appBlock.update.mock.calls.find(
+        (c: any[]) => c[0]?.data?.trustTier !== undefined
+      );
+      expect(tierUpdate?.[0]?.data?.trustTier).toBe('verified');
+      expect((tierUpdate?.[0]?.data?.manifest as { trustTier?: string }).trustTier).toBe('verified');
+    });
+
+    it('EXISTING unverified app: a manifest declaring internal stays unverified', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ version: '0.2.0', trustTier: 'internal' }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue({
+        id: 'apb_existing',
+        appId: 'oc_existing',
+        repoUrl: 'https://forgejo.example/civitai-apps/hello',
+        trustTier: 'unverified',
+        app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+      });
+      mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0', trustTier: 'internal' });
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      const tierUpdate = mockDbWrite.appBlock.update.mock.calls.find(
+        (c: any[]) => c[0]?.data?.trustTier !== undefined
+      );
+      expect(tierUpdate?.[0]?.data?.trustTier).toBe('unverified');
+    });
+  });
+
   // C-2 regression — failure at step 2 (Forgejo repo create) leaves the
   // OauthClient INSERT in place with no compensation.
   it('REGRESSION (C-2): Forgejo repo create failure leaves orphaned OauthClient', async () => {

--- a/src/tests/api/internal/blocks/workflow-completed.idempotency.test.ts
+++ b/src/tests/api/internal/blocks/workflow-completed.idempotency.test.ts
@@ -219,9 +219,12 @@ describe('workflow-completed — idempotency dedup (M-6, Critical path 8)', () =
     await invoke(makeReq(), res);
     expect(res._status).toBe(200);
     expect(res._body).toEqual({ ok: true });
-    // Marker keyed on workflowId alone (audit-10 M6) and TTL set on first sight.
+    // Marker keyed on workflowId ALONE (audit-10 M6) and TTL set on first sight.
+    // Assert the EXACT key shape, not just .toContain — a composite key (e.g.
+    // accidentally folding in blockInstanceId) would still contain the workflowId
+    // yet silently break cross-call dedup.
     expect(mockIncrBy).toHaveBeenCalledTimes(1);
-    expect(mockIncrBy.mock.calls[0][0]).toContain(WORKFLOW_ID);
+    expect(mockIncrBy.mock.calls[0][0]).toBe(`blocks:token-rate-limit:wf:${WORKFLOW_ID}`);
     expect(mockExpire).toHaveBeenCalledTimes(1);
     expect(mockExpire.mock.calls[0][1]).toBe(DEDUP_TTL_SECONDS);
   });

--- a/src/tests/api/internal/blocks/workflow-completed.idempotency.test.ts
+++ b/src/tests/api/internal/blocks/workflow-completed.idempotency.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Idempotency + JOB_TOKEN auth + install-validation contract for
+ * POST /api/internal/blocks/workflow-completed.
+ *
+ * The sibling workflow-completed.gate.test.ts pins ONLY the Flipt pipeline-flag
+ * kill switch + a single unauth 401. This file covers the rest of the handler's
+ * stable contract (Critical path 8 — idempotency dedup, plus the JOB_TOKEN auth
+ * surface and the install pre-validation that gates the dedup write):
+ *
+ *   - JOB_TOKEN auth: missing-env-secret → 401; wrong header → 401; correct
+ *     header → proceeds (the timing-safe `safeEqualHeader` path);
+ *   - method != POST → 405;
+ *   - install validation runs BEFORE the 7-day dedup marker is written
+ *     (audit-9 #6): not-found / empty targetModelIds → 404 and NO incrBy;
+ *   - idempotency (M-6): the FIRST delivery proceeds (incrBy → 1, sets the TTL,
+ *     returns {ok:true}); a RETRY short-circuits with {ok:true, idempotent:true}
+ *     and does NOT re-run the (eventual) billing path;
+ *   - Redis fail-closed: an incrBy throw makes the handler treat the delivery
+ *     as already-processed (idempotent short-circuit) so a retry can never
+ *     double-bill while Redis is down;
+ *   - zod body validation: bad blockInstanceId / negative buzzSpent / missing
+ *     required fields → 400 (and dedup never runs).
+ *
+ * Mocking mirrors workflow-completed.gate.test.ts exactly so the two files share
+ * the same boundary assumptions.
+ */
+
+const JOB_TOKEN = 'test-job-token';
+const BLOCK_INSTANCE_ID = 'bki_0123456789ABCDEFGHJKMNPQRS';
+const WORKFLOW_ID = 'wf_test_123';
+const DEDUP_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+const { mockEnvStore, mockFindUnique, mockIncrBy, mockExpire } = vi.hoisted(() => ({
+  // Inlined literal: vi.hoisted() runs before the top-level `const JOB_TOKEN`,
+  // so it can't reference that binding (keep this in sync with JOB_TOKEN below).
+  mockEnvStore: { JOB_TOKEN: 'test-job-token' } as Record<string, unknown>,
+  mockFindUnique: vi.fn(),
+  mockIncrBy: vi.fn(),
+  mockExpire: vi.fn(),
+}));
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/env/server', () => ({
+  env: new Proxy(mockEnvStore, {
+    get(t, p: string) {
+      if (p in t) return t[p];
+      if (p === 'LOGGING') return '';
+      return undefined;
+    },
+  }),
+}));
+// Pipeline flag is hard-ON here — this file is about the post-gate contract.
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: vi.fn(async (flag: string) => flag === 'app-blocks-pipeline-enabled'),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { blockUserSubscription: { findUnique: mockFindUnique } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { incrBy: mockIncrBy, expire: mockExpire },
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'blocks:token-rate-limit' } },
+}));
+
+function makeReq(over: Partial<NextApiRequest> = {}): NextApiRequest {
+  return {
+    method: 'POST',
+    headers: { 'x-civitai-internal-token': JOB_TOKEN },
+    body: { workflowId: WORKFLOW_ID, blockInstanceId: BLOCK_INSTANCE_ID, buzzSpent: 0 },
+    ...over,
+  } as unknown as NextApiRequest;
+}
+
+function makeRes(): NextApiResponse & { _status: number; _body: any } {
+  const res = {
+    _status: 0,
+    _body: null as any,
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & { _status: number; _body: any };
+}
+
+async function invoke(req: NextApiRequest, res: NextApiResponse) {
+  const handler = (await import('~/pages/api/internal/blocks/workflow-completed')).default;
+  await handler(req, res);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnvStore.JOB_TOKEN = JOB_TOKEN;
+  // Default: valid install + first-time dedup so the happy path reaches 200.
+  mockFindUnique.mockResolvedValue({ id: 'sub_1', targetModelIds: [7], appBlockId: 'apb_1' });
+  mockIncrBy.mockResolvedValue(1);
+  mockExpire.mockResolvedValue(1);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('workflow-completed — JOB_TOKEN auth', () => {
+  it('401s a wrong internal token and never touches the DB/Redis', async () => {
+    const res = makeRes();
+    await invoke(makeReq({ headers: { 'x-civitai-internal-token': 'wrong' } }), res);
+    expect(res._status).toBe(401);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(mockIncrBy).not.toHaveBeenCalled();
+  });
+
+  it('401s a token of a DIFFERENT length (safeEqualHeader length guard)', async () => {
+    const res = makeRes();
+    await invoke(makeReq({ headers: { 'x-civitai-internal-token': JOB_TOKEN + 'x' } }), res);
+    expect(res._status).toBe(401);
+  });
+
+  it('401s when the token header is missing entirely', async () => {
+    const res = makeRes();
+    await invoke(makeReq({ headers: {} }), res);
+    expect(res._status).toBe(401);
+  });
+
+  it('401s (fail-closed) when JOB_TOKEN is not configured on the server', async () => {
+    // A missing server secret must NOT degrade into accept-anything.
+    mockEnvStore.JOB_TOKEN = undefined;
+    const res = makeRes();
+    await invoke(makeReq({ headers: { 'x-civitai-internal-token': '' } }), res);
+    expect(res._status).toBe(401);
+  });
+
+  it('accepts the correct token and reaches the post-auth path', async () => {
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(200);
+  });
+});
+
+describe('workflow-completed — method + body validation', () => {
+  it('405s a non-POST method before auth', async () => {
+    const res = makeRes();
+    await invoke(makeReq({ method: 'GET' }), res);
+    expect(res._status).toBe(405);
+  });
+
+  it('400s a blockInstanceId that does not match the bki_<crockford26> shape', async () => {
+    const res = makeRes();
+    await invoke(makeReq({ body: { workflowId: WORKFLOW_ID, blockInstanceId: 'nope', buzzSpent: 0 } }), res);
+    expect(res._status).toBe(400);
+    expect(mockIncrBy).not.toHaveBeenCalled();
+  });
+
+  it('400s a negative buzzSpent', async () => {
+    const res = makeRes();
+    await invoke(
+      makeReq({ body: { workflowId: WORKFLOW_ID, blockInstanceId: BLOCK_INSTANCE_ID, buzzSpent: -1 } }),
+      res
+    );
+    expect(res._status).toBe(400);
+  });
+
+  it('400s an empty workflowId (min(1))', async () => {
+    const res = makeRes();
+    await invoke(
+      makeReq({ body: { workflowId: '', blockInstanceId: BLOCK_INSTANCE_ID, buzzSpent: 0 } }),
+      res
+    );
+    expect(res._status).toBe(400);
+  });
+
+  it('400s a missing body without throwing', async () => {
+    const res = makeRes();
+    await invoke(makeReq({ body: undefined }), res);
+    expect(res._status).toBe(400);
+  });
+});
+
+describe('workflow-completed — install validation gates the dedup write (audit-9 #6)', () => {
+  it('404s when the install is not found and NEVER writes a dedup marker', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(404);
+    // Critical: a bogus pair must not burn a 7-day Redis slot.
+    expect(mockIncrBy).not.toHaveBeenCalled();
+  });
+
+  it('404s when the install has empty targetModelIds and never writes a dedup marker', async () => {
+    mockFindUnique.mockResolvedValue({ id: 'sub_1', targetModelIds: [], appBlockId: 'apb_1' });
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(404);
+    expect(mockIncrBy).not.toHaveBeenCalled();
+  });
+
+  it('404s when targetModelIds is null and never writes a dedup marker', async () => {
+    mockFindUnique.mockResolvedValue({ id: 'sub_1', targetModelIds: null, appBlockId: 'apb_1' });
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(404);
+    expect(mockIncrBy).not.toHaveBeenCalled();
+  });
+});
+
+describe('workflow-completed — idempotency dedup (M-6, Critical path 8)', () => {
+  it('FIRST delivery: incrBy returns 1 → processes, sets the 7-day TTL, {ok:true}', async () => {
+    mockIncrBy.mockResolvedValue(1);
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true });
+    // Marker keyed on workflowId alone (audit-10 M6) and TTL set on first sight.
+    expect(mockIncrBy).toHaveBeenCalledTimes(1);
+    expect(mockIncrBy.mock.calls[0][0]).toContain(WORKFLOW_ID);
+    expect(mockExpire).toHaveBeenCalledTimes(1);
+    expect(mockExpire.mock.calls[0][1]).toBe(DEDUP_TTL_SECONDS);
+  });
+
+  it('RETRY: incrBy returns 2 → short-circuits with {ok:true, idempotent:true} and does NOT re-set the TTL', async () => {
+    mockIncrBy.mockResolvedValue(2);
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true, idempotent: true });
+    // A retry must not refresh/extend the dedup window.
+    expect(mockExpire).not.toHaveBeenCalled();
+  });
+
+  it('two sequential deliveries of the same workflowId: first processes, second is idempotent', async () => {
+    // Simulate Redis returning the real monotonic count across two calls.
+    mockIncrBy.mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+    const res1 = makeRes();
+    await invoke(makeReq(), res1);
+    const res2 = makeRes();
+    await invoke(makeReq(), res2);
+    expect(res1._body).toEqual({ ok: true });
+    expect(res2._body).toEqual({ ok: true, idempotent: true });
+  });
+
+  it('Redis fail-closed: an incrBy throw is treated as already-processed (no double-bill)', async () => {
+    mockIncrBy.mockRejectedValue(new Error('redis down'));
+    const res = makeRes();
+    await invoke(makeReq(), res);
+    // markWorkflowProcessed swallows the error and returns false → idempotent
+    // short-circuit. The handler must NOT throw / 500 and must NOT proceed to
+    // the (eventual) billing path.
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true, idempotent: true });
+    expect(mockExpire).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Unit-test coverage for the **stable App Blocks substrate** — every critical path, with priority on the contracts that have previously regressed. Part of the App Blocks "Foundation/Quality" track (F-B). Test-only; no production code changes.

**31 new tests** across 3 files, filling the real gaps (existing coverage was not duplicated):

- **Trust-tier C1 self-escalation** (`publish-request.orchestration.test.ts`): a manifest can never *raise* its own trust tier — manifest `internal`/`verified` → persisted `unverified` for a new app; existing tier preserved on resubmit; missing `trustTier` → `unverified` (the pre-fix default-to-`internal` regression); the normalised `manifest.trustTier` is downgraded too.
- **`workflow-completed` idempotency + auth** (`workflow-completed.idempotency.test.ts`, +17): first delivery processes and sets the 7-day TTL; retry short-circuits; a Redis error fails **closed** (never double-bills); install-not-found / empty `targetModelIds` → 404 **before** the dedup write; full JOB_TOKEN surface (wrong / length-mismatch / missing / unconfigured); 405 non-POST; zod body validation.
- **`buildApplyScript`** (`apps-pipeline.buildApplyScript.test.ts`, +9): strict-mode bash; namespace interpolated into every `kubectl -n`; per-run vars stay shell expansions; 8-char smoke-pod sha cap; pod hardening (ghcr-cred / non-root / drop-ALL); cleanup EXIT trap; the 3 smoke probes incl. the `:8080` port-leak guard; apply-after-smoke ordering.

The other critical paths were **already covered** and left as-is: HMAC dual-secret `verifySignature`, `checkCallbackTimestamp` skew, `expectedImageRef` binding, zip-bomb caps, `BLOCK_BUZZ_CAP_PER_DAY` cap, FIN-1 attribution, `failureSnapshot` non-empty-`workflowId` invariant, the host gates/decision modules.

## Verification

- **Vitest:** block suite green — 633 pass (31 new), 0 skipped.
  ```
  npx vitest run \
    src/tests/api/internal/blocks/workflow-completed.idempotency.test.ts \
    src/server/services/blocks/__tests__/apps-pipeline.buildApplyScript.test.ts \
    src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
  ```
- **Types:** the 3 new files have 0 `tsc` errors. (A local full-repo `tsc` in a fresh worktree is noisy because `next-env.d.ts`/`.next/types` aren't generated there — CI's typecheck, with codegen, is the authoritative gate.)
- Tests assert against the **real implementations**; only DB / Redis / k8s / fetch / forgejo are mocked at the boundary, matching existing conventions. No skipped/disabled tests.

## Not covered (intentional)

- `triggerApply` / `waitForApplyJob` — thin `@kubernetes/client-node` wrappers; a test would mostly assert the mock. Their consumer contract (the apply script + build-callback handling) is covered.
- The SDK-side validator (`@civitai/blocks-react`) lives in a separate repo; `failureSnapshot` pins our side of that contract.
- `src/pages/apps/*` page components — deferred until after the upcoming app-pages/marketplace rework (testing soon-to-change UI = throwaway).
- **Buzz-spend cap** (`BLOCK_BUZZ_CAP_PER_DAY`, per-(user, UTC-day)) is **not** in this PR — it's owned by the pre-existing `src/tests/api/internal/blocks/blocks.router.workflow.test.ts` (test A7: per-USER keying + midnight-UTC refund). The one remaining gap there is the **concurrent reserve-and-refund race** (two `reserveBlockBuzzSpend` interleaving the `> CAP` check), untested anywhere yet — tracked as a follow-up.

## Audit

Adversarially reviewed (incl. mutation testing): reintroducing the trust-tier self-escalation vuln fails 4/5 C1 tests, and flipping the idempotency Redis catch to fail-open fails the fail-closed test — confirming those contracts are genuinely pinned, not tautological. Audit nits addressed in `9acad4d68`: H1 (namespace test now covers the un-namespaced `kubectl apply`, not just `-n` commands), M1 (de-flake the fire-and-forget notify via `vi.waitFor`), L3 (use the `NS` const), L4 (assert the exact dedup-key shape).

_Note: now includes a one-line **comment-only** fix to `src/pages/api/internal/blocks/workflow-completed.ts` (corrects a stale `409`→`200` dedup doc comment surfaced by the re-audit). No behavior change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


