### PR TITLE
test(component): --no-sandbox for CI Chromium (makes the Tekton component task runnable)

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -45,18 +45,22 @@ export default defineConfig({
           setupFiles: ['test/browser-process-shim.ts', 'test/component-setup.tsx'],
           browser: {
             enabled: true,
+            // `--no-sandbox` + `--disable-dev-shm-usage`: required to launch
+            // Chromium as root inside the Tekton CI container (node:20 pod runs
+            // as UID 0; without --no-sandbox Chromium refuses to start, and the
+            // container's small /dev/shm crashes it without --disable-dev-shm-usage).
+            // Harmless locally.
             // CI uses Playwright's bundled Chromium (env unset). NixOS can't run
             // that generic binary; point this at a system Chromium, e.g.
             // `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium)`.
-            provider: playwright(
-              process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
-                ? {
-                    launchOptions: {
-                      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
-                    },
-                  }
-                : undefined
-            ),
+            provider: playwright({
+              launchOptions: {
+                args: ['--no-sandbox', '--disable-dev-shm-usage'],
+                ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+                  ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+                  : {}),
+              },
+            }),
             headless: true,
             instances: [{ browser: 'chromium' }],
           },


### PR DESCRIPTION
Makes the new Tekton `component-tests` task (talos-infra #136) actually runnable: vitest browser mode launches Chromium **as root** in the node:20 CI container, which requires `--no-sandbox` (Chromium refuses to start as root otherwise) and `--disable-dev-shm-usage` (small container `/dev/shm` crashes it). Passed via the playwright provider `launchOptions` — always, harmless locally.

This PR also serves as the **verification** that the Tekton component task works end-to-end: its preview run should show `component:pass` + a `preview / component-tests` status.

Verified 6/6 still green locally with the flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)