### PR TITLE
feat(blocks): marketplace E1 — anon-capable read path (dark, mod-gated)

### DIFF
--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -1,6 +1,7 @@
 import { Badge, Button, Card, Group, Stack, Text, Title } from '@mantine/core';
 import { IconBolt, IconPlugConnected, IconSettings } from '@tabler/icons-react';
 import { useState } from 'react';
+import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
 
 /**
@@ -84,17 +85,28 @@ export function AppBlockCard({
               {block.installCount.toLocaleString()} installs
             </Text>
           </Group>
-          <Button
-            size="xs"
-            variant={alreadySubscribed ? 'default' : 'filled'}
-            leftSection={
-              alreadySubscribed ? <IconSettings size={14} /> : <IconPlugConnected size={14} />
-            }
-            loading={busy}
-            onClick={() => onOpen(block)}
-          >
-            {alreadySubscribed ? 'Manage' : 'Install'}
-          </Button>
+          {/*
+            Anon-conversion CTA (F-E E1): for a session-less viewer, clicking
+            Install opens the LoginModal (via LoginRedirect → requireLogin →
+            dialogStore.trigger(LoginModal, { returnUrl })) instead of the
+            install/settings modal — installing requires auth. For a logged-in
+            viewer LoginRedirect is a pass-through and the onClick runs
+            normally. This is dark today (the page is mod-gated); it only
+            matters once the segment is widened to anon.
+          */}
+          <LoginRedirect reason="perform-action">
+            <Button
+              size="xs"
+              variant={alreadySubscribed ? 'default' : 'filled'}
+              leftSection={
+                alreadySubscribed ? <IconSettings size={14} /> : <IconPlugConnected size={14} />
+              }
+              loading={busy}
+              onClick={() => onOpen(block)}
+            >
+              {alreadySubscribed ? 'Manage' : 'Install'}
+            </Button>
+          </LoginRedirect>
         </Group>
       </Stack>
     </Card>

--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -16,7 +16,7 @@ import {
   Title,
 } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import { baseModels as ALL_BASE_MODELS } from '~/shared/constants/base-model.constants';
 import type {
@@ -100,15 +100,36 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
     scopes?: string[];
   };
 
+  // `block.manifest` may be the PUBLIC marketplace allowlist (F-E E1) —
+  // name/description/targets only, with `settings`/`scopes` deliberately
+  // stripped so anon callers never see manifest internals. When this modal is
+  // opened from a marketplace card (install path), reading the settings form
+  // from `block.manifest.settings` would therefore render NO fields. Fetch the
+  // install-needed bits (settings meta + declared scopes) from the
+  // authenticated `getInstallConfig` procedure instead, keyed on appBlockId.
+  // The "Manage" path (/apps/installed) passes the FULL manifest, so its
+  // `manifest.settings` is already populated; the fetched value matches it.
+  const { data: installConfig } = trpc.blocks.getInstallConfig.useQuery(
+    { appBlockId: block.id },
+    { staleTime: 60_000 }
+  );
+
   // Manifest-driven settings (W3 Phase 4). Fields without an explicit
   // `scope:` declaration are treated as 'publisher' for back-compat with
   // pre-W3 manifests (the gate that produced them only required type +
   // label + description). New manifests should declare scope explicitly.
+  //
+  // Source precedence: the authenticated install config (always carries
+  // settings/scopes, regardless of whether `block.manifest` was the public
+  // subset) wins; fall back to `block.manifest.settings` while it loads (the
+  // Manage path already has the full manifest, so the form is correct
+  // immediately there).
+  const settingsSource = installConfig?.settings ?? manifest.settings;
   const manifestSettings = useMemo<ManifestSettings>(
-    () => normalizeManifestSettings(manifest.settings),
-    [manifest.settings]
+    () => normalizeManifestSettings(settingsSource),
+    [settingsSource]
   );
-  const declaredScopes = manifest.scopes ?? [];
+  const declaredScopes = installConfig?.scopes ?? manifest.scopes ?? [];
 
   // Initialise the form from existing subscriptions when present. Settings
   // are read from whichever scope has them set — they're meant to be
@@ -141,6 +162,27 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
   const [settingsValues, setSettingsValues] = useState<Record<string, unknown>>(() =>
     seedSettingsValues(manifestSettings, initialSettings)
   );
+
+  // Re-seed when the manifest settings schema becomes available. On the install
+  // path `manifestSettings` is empty on first render (getInstallConfig hasn't
+  // resolved yet) so the initial seed has no field defaults; once the schema
+  // arrives we merge in any declared defaults for keys the user hasn't touched.
+  // Existing-subscription values (initialSettings) and user edits always win,
+  // so this never clobbers what the user already has/typed.
+  const seededKeysRef = useRef<string>('');
+  useEffect(() => {
+    const keysSig = Object.keys(manifestSettings).sort().join(',');
+    if (keysSig === seededKeysRef.current) return;
+    seededKeysRef.current = keysSig;
+    setSettingsValues((prev) => {
+      const reseeded = seedSettingsValues(manifestSettings, initialSettings);
+      // Preserve any value the user already set / that was already present.
+      return { ...reseeded, ...prev };
+    });
+    // initialSettings is derived from props (existing subscriptions) and is
+    // stable for the modal's lifetime; depend only on the schema shape.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [manifestSettings]);
 
   const handleSettingChange = (key: string, value: unknown) => {
     setSettingsValues((prev) => ({ ...prev, [key]: value }));

--- a/src/components/Apps/__tests__/resolveAppsPageAccess.test.ts
+++ b/src/components/Apps/__tests__/resolveAppsPageAccess.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAppsPageAccess } from '../resolveAppsPageAccess';
+
+/**
+ * F-E E1 — SSR gate-ordering invariant for /apps.
+ *
+ * The marketplace is anon-capable but stays DARK behind the mod-segmented flag.
+ * These tests pin the GATING INVARIANT so it FAILS if the gate is reordered,
+ * removed, or a session→login redirect is reintroduced:
+ *   - No flag → notFound, REGARDLESS of session (gate is the only control,
+ *     and it's a hard notFound — never a login redirect).
+ *   - Flag granted + NO session → renders (the dark anon read path).
+ *   - Flag granted + session → renders.
+ */
+
+describe('resolveAppsPageAccess — gating invariant', () => {
+  it('no appBlocks flag → notFound (gate intact, even with no session)', () => {
+    expect(resolveAppsPageAccess({ features: { appBlocks: false } })).toEqual({ notFound: true });
+  });
+
+  it('undefined/null features → notFound (fails closed)', () => {
+    expect(resolveAppsPageAccess({ features: undefined })).toEqual({ notFound: true });
+    expect(resolveAppsPageAccess({ features: null })).toEqual({ notFound: true });
+    expect(resolveAppsPageAccess({ features: {} })).toEqual({ notFound: true });
+  });
+
+  it('flag granted + NO session → renders (the dark anon read path, no login redirect)', () => {
+    const result = resolveAppsPageAccess({ features: { appBlocks: true } });
+    expect(result).toEqual({ props: {} });
+    // Critically: it must NOT be a redirect. The old behavior bounced anon to
+    // /login; E1 removes that so the page renders behind the flag.
+    expect(result).not.toHaveProperty('redirect');
+    expect(result).not.toHaveProperty('notFound');
+  });
+
+  it('flag granted (mod path today) → renders', () => {
+    expect(resolveAppsPageAccess({ features: { appBlocks: true } })).toEqual({ props: {} });
+  });
+});

--- a/src/components/Apps/resolveAppsPageAccess.ts
+++ b/src/components/Apps/resolveAppsPageAccess.ts
@@ -1,0 +1,28 @@
+/**
+ * SSR access decision for the /apps marketplace (F-E E1). Pure, React-free, and
+ * standalone so the GATING INVARIANT is unit-testable in the node-env unit
+ * project without importing the page's React/Mantine module graph.
+ *
+ * 🔒 GATING INVARIANT (F-E E1 — do not violate):
+ *   - The `features.appBlocks` flag gate is FIRST and is the ONLY access
+ *     control. A logged-out / non-mod user does NOT satisfy the Flipt
+ *     `app-blocks-enabled` mod segment, so `features.appBlocks` is false for
+ *     them → notFound. The page stays dark for real anon/non-mod users until
+ *     the segment is widened at launch (a separate, product-signed-off step).
+ *   - There is intentionally NO separate `session→login` redirect: behind the
+ *     flag gate, a session-less request RENDERS the marketplace read-only
+ *     instead of bouncing to /login. This is the "anon-capable but dark" read
+ *     path — reachable by a real anon user ONLY once the flag grants access
+ *     (mods-only today). (`deIndex` is kept ON in the page <Meta> so the page is
+ *     not crawlable pre-launch.)
+ */
+export type AppsPageAccessResult = { notFound: true } | { props: Record<string, never> };
+
+export function resolveAppsPageAccess(args: {
+  features?: { appBlocks?: boolean } | null;
+}): AppsPageAccessResult {
+  // Flag gate FIRST and ONLY. No session check — the dark anon path renders
+  // behind the flag; access is decided entirely by features.appBlocks.
+  if (!args.features?.appBlocks) return { notFound: true };
+  return { props: {} };
+}

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -28,7 +28,6 @@ import type {
   SubscriptionScope,
 } from '~/server/schema/blocks/subscription.schema';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
-import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { trpc } from '~/utils/trpc';
 
 type SlotFilter = 'model.sidebar_top' | 'model.below_images' | 'model.actions_extra';
@@ -176,7 +175,7 @@ export default function AppsPage() {
             </Center>
           ) : (
             <Grid gutter="md">
-              {(availableData?.items ?? []).map((block) => (
+              {(availableData?.items ?? []).map((block: AvailableBlock) => (
                 <Grid.Col key={block.id} span={{ base: 12, sm: 6, md: 4, lg: 3 }}>
                   <AppBlockCard
                     block={block}

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -18,6 +18,7 @@ import { useMemo, useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppBlockCard } from '~/components/Apps/AppBlockCard';
+import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -27,33 +28,31 @@ import type {
   SubscriptionScope,
 } from '~/server/schema/blocks/subscription.schema';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
-import { getLoginLink } from '~/utils/login-helpers';
+import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { trpc } from '~/utils/trpc';
 
 type SlotFilter = 'model.sidebar_top' | 'model.below_images' | 'model.actions_extra';
 
 export const getServerSideProps = createServerSideProps({
   useSession: true,
-  resolver: async ({ features, session, ctx }) => {
-    if (!features?.appBlocks) return { notFound: true };
-    if (!session?.user) {
-      return {
-        redirect: {
-          destination: getLoginLink({ returnUrl: ctx.resolvedUrl }),
-          permanent: false,
-        },
-      };
-    }
-    return { props: {} };
-  },
+  // GATING INVARIANT (F-E E1): the flag gate is the ONLY access control; no
+  // session→login redirect, so the marketplace renders for a session-less
+  // request BEHIND the flag (dark today; lit when the segment widens). See
+  // resolveAppsPageAccess for the full invariant + `deIndex` note.
+  resolver: async ({ features }) => resolveAppsPageAccess({ features }),
 });
 
 export default function AppsPage() {
   const features = useFeatureFlags();
+  const currentUser = useCurrentUser();
   const [slotFilter, setSlotFilter] = useState<SlotFilter | null>(null);
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearch] = useDebouncedValue(searchInput, 300);
 
+  // The marketplace listing is anon-CAPABLE (publicProcedure) — it fires for
+  // any viewer who has the appBlocks flag, including a session-less one once
+  // the segment widens (dark today). It returns only approved apps + a public
+  // field allowlist.
   const { data: availableData, isLoading } = trpc.blocks.listAvailable.useQuery(
     {
       slotId: slotFilter ?? undefined,
@@ -62,14 +61,18 @@ export default function AppsPage() {
     },
     { enabled: !!features.appBlocks }
   );
+  // The per-user queries below are protectedProcedure — they 401 for an anon
+  // viewer. Guard on a logged-in user so the dark anon read path doesn't fire
+  // them. (`features.appBlocks` alone isn't enough: behind a widened segment an
+  // anon viewer would still hit these.)
   const { data: mySubs } = trpc.blocks.listMySubscriptions.useQuery(undefined, {
-    enabled: !!features.appBlocks,
+    enabled: !!features.appBlocks && !!currentUser,
   });
   // Lifetime earnings per owned app — feeds the "Earning $X" chip on
   // marketplace cards owned by the viewer. Visible only to the owner;
   // the trPC procedure is guarded so other users get nothing back.
   const { data: myAppsRaw } = trpc.blocks.getMyApps.useQuery(undefined, {
-    enabled: !!features.appBlocks,
+    enabled: !!features.appBlocks && !!currentUser,
   });
   const earningsByAppBlockId = useMemo(() => {
     type AppRow = { id: string; lifetimeShareCents: number };

--- a/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
+++ b/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
@@ -24,6 +24,7 @@ import { TRPCError } from '@trpc/server';
 const {
   mockIsAppBlocksEnabled,
   mockListForModel,
+  mockListAvailable,
   mockInstallOnModel,
   mockVerifyBlockToken,
   mockParseSubjectUserId,
@@ -36,6 +37,7 @@ const {
 } = vi.hoisted(() => ({
   mockIsAppBlocksEnabled: vi.fn(),
   mockListForModel: vi.fn(),
+  mockListAvailable: vi.fn(),
   mockInstallOnModel: vi.fn(),
   mockVerifyBlockToken: vi.fn(),
   mockParseSubjectUserId: vi.fn(),
@@ -97,6 +99,7 @@ vi.mock('~/server/logging/client', () => ({
 vi.mock('~/server/services/block-registry.service', () => ({
   BlockRegistry: {
     listForModel: (...a: unknown[]) => mockListForModel(...a),
+    listAvailable: (...a: unknown[]) => mockListAvailable(...a),
     installOnModel: (...a: unknown[]) => mockInstallOnModel(...a),
     updateSettings: vi.fn(),
     toggleEnabled: vi.fn(),
@@ -104,6 +107,13 @@ vi.mock('~/server/services/block-registry.service', () => ({
     resolveBlockInstance: vi.fn(),
   },
 }));
+// rateLimit pulls in redis + heavy deps; the gate under test is the flag
+// middleware, so stub rateLimit to a pass-through middleware. (The real
+// rate-limit middleware is exercised end-to-end by the live stack, not here.)
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
 
 import { blocksRouter } from '../blocks.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -139,6 +149,8 @@ beforeEach(() => {
   mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
   mockListForModel.mockReset();
   mockListForModel.mockResolvedValue([{ id: 'blk_1' }]);
+  mockListAvailable.mockReset();
+  mockListAvailable.mockResolvedValue({ items: [{ id: 'ab_1' }], nextCursor: undefined });
   mockInstallOnModel.mockReset();
   mockInstallOnModel.mockResolvedValue({ id: 'install_1' });
 });
@@ -169,6 +181,46 @@ describe('enforceAppBlocksFlag — query (listForModel)', () => {
     expect(result).toEqual([]);
     expect(mockListForModel).not.toHaveBeenCalled();
     expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: undefined });
+  });
+});
+
+describe('listAvailable — anon-capable read path, dark behind the flag gate (F-E E1)', () => {
+  it('anonymous WITHOUT the flag: gate disables → empty (dark today), registry NOT consulted', async () => {
+    // Real anon today: the mod-segmented flag can never match without a mod
+    // context, so the middleware sets _appBlocksDisabled → empty. This is the
+    // "dark" invariant — removing the old hardcoded isModerator gate did NOT
+    // widen access; the flag gate is the real control.
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [], nextCursor: undefined });
+    expect(mockListAvailable).not.toHaveBeenCalled();
+    expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: undefined });
+  });
+
+  it('non-mod WITHOUT the flag: gate disables → empty, registry NOT consulted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [], nextCursor: undefined });
+    expect(mockListAvailable).not.toHaveBeenCalled();
+  });
+
+  it('anonymous WITH the flag granted (the dark path, lit): registry IS consulted', async () => {
+    // Simulate the post-launch segment widen: the flag resolves ON even with no
+    // user. The procedure must then serve the anon caller (no session) — proving
+    // it is anon-CAPABLE, not just mod-only. listAvailable is publicProcedure;
+    // there is NO secondary isModerator gate left to block this.
+    mockIsAppBlocksEnabled.mockResolvedValue(true);
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [{ id: 'ab_1' }], nextCursor: undefined });
+    expect(mockListAvailable).toHaveBeenCalledTimes(1);
+  });
+
+  it('moderator: gate passes, registry IS consulted (mods-only is the live state)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [{ id: 'ab_1' }], nextCursor: undefined });
+    expect(mockListAvailable).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Coverage for `blocks.getInstallConfig` — the authenticated source the install
+ * modal (AppSettingsModal) uses for the publisher-settings form + declared
+ * scopes, keyed on appBlockId.
+ *
+ * It exists because the anon-capable marketplace listing (`listAvailable`)
+ * projects each manifest down to a PUBLIC allowlist (name/description/targets
+ * only) — so `settings`/`scopes` are NOT available from a marketplace card.
+ * This proc returns ONLY those install-needed bits and is gated to the SAME
+ * audience that can install (moderatorProcedure today). These tests assert:
+ *   - it returns the manifest's settings meta + declared scopes for an approved
+ *     app,
+ *   - it 404s for a non-approved (or missing) app — never leaks an unapproved
+ *     manifest,
+ *   - it is mod-gated: a non-mod and an anon caller are both DENIED (would FAIL
+ *     if the moderatorProcedure gate were dropped to public/protected).
+ *
+ * The service layer (BlockRegistry) is mocked at the module boundary; this
+ * suite exercises the router's auth gate, approved gate, and projection.
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockDbReadAppBlockFindUnique,
+  mockGetUserBuzzAccounts,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(async () => true),
+  mockDbReadAppBlockFindUnique: vi.fn(),
+  mockGetUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    listAvailable: vi.fn(),
+    upsertSubscription: vi.fn(),
+    deleteSubscription: vi.fn(),
+    upsertUserSettings: vi.fn(),
+    getEffectiveCheckpoint: vi.fn(),
+  },
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: mockDbReadAppBlockFindUnique } },
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+  REDIS_KEYS: { BLOCKS: {} },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/textToImage/textToImage', () => ({
+  createTextToImageStep: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: mockGetUserBuzzAccounts,
+}));
+// The E1 router imports `rateLimit` from middleware.trpc, which transitively
+// pulls in user-preferences.service → caches.ts → tag.selector (a top-level
+// `Prisma.validator(...)` call). In a fresh worktree the generated Prisma client
+// can't be produced (NixOS engine fetch), so evaluating that chain throws at
+// import time. Mock middleware.trpc with a pass-through `rateLimit` middleware
+// (built from the real, lightweight `middleware` factory) to cut the chain —
+// rate-limiting isn't under test here.
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return {
+    rateLimit: () => middleware(({ next }) => next()),
+  };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function authedCtx(userId: number, isModerator = true) {
+  return {
+    acceptableOrigin: true,
+    user: { id: userId, isModerator, onboarding: 0x1f } as never,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { canViewNsfw: false, isBlue: false, isGreen: false, isGreenSession: false } as never,
+    track: undefined,
+  };
+}
+
+function anonCtx() {
+  return {
+    acceptableOrigin: true,
+    user: undefined,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { canViewNsfw: false, isBlue: false, isGreen: false, isGreenSession: false } as never,
+    track: undefined,
+  };
+}
+
+const APPROVED_MANIFEST = {
+  name: 'Generate from model',
+  description: 'one-click gen',
+  scopes: ['ai:write:budgeted', 'models:read:self'],
+  // Internal/server-set fields that must never reach the install form — proves
+  // the projection drops everything except settings + scopes.
+  trustTier: 'trusted',
+  iframe: { src: 'https://internal-host.example/secret' },
+  settings: {
+    buzz_budget_per_gen: {
+      type: 'number',
+      scope: 'publisher',
+      label: 'Buzz budget per generation',
+      description: 'Max Buzz spent per generation',
+      min: 0,
+      max: 1000,
+    },
+  },
+};
+
+beforeEach(() => {
+  mockDbReadAppBlockFindUnique.mockReset();
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(async () => true);
+});
+
+describe('blocks.getInstallConfig', () => {
+  it('returns settings meta + declared scopes for an approved app (and nothing else)', async () => {
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'approved',
+      manifest: APPROVED_MANIFEST,
+    });
+    const caller = blocksRouter.createCaller(authedCtx(42) as never);
+    const out = await caller.getInstallConfig({ appBlockId: 'ab_x' });
+
+    expect(out.scopes).toEqual(['ai:write:budgeted', 'models:read:self']);
+    expect(Object.keys(out.settings)).toEqual(['buzz_budget_per_gen']);
+    // The settings field round-trips through the meta schema with its range.
+    expect(out.settings.buzz_budget_per_gen).toMatchObject({
+      type: 'number',
+      scope: 'publisher',
+      min: 0,
+      max: 1000,
+    });
+    // Internal/private manifest fields are NOT part of the returned shape.
+    expect(out).not.toHaveProperty('trustTier');
+    expect(out).not.toHaveProperty('iframe');
+    expect(out).not.toHaveProperty('name');
+  });
+
+  it('returns empty settings + empty scopes for an approved app with no declarations', async () => {
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'approved',
+      manifest: { name: 'who-am-i' },
+    });
+    const caller = blocksRouter.createCaller(authedCtx(42) as never);
+    const out = await caller.getInstallConfig({ appBlockId: 'ab_whoami' });
+    expect(out).toEqual({ settings: {}, scopes: [] });
+  });
+
+  it('404s for a non-approved app — never returns its manifest', async () => {
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'pending',
+      manifest: APPROVED_MANIFEST,
+    });
+    const caller = blocksRouter.createCaller(authedCtx(42) as never);
+    await expect(caller.getInstallConfig({ appBlockId: 'ab_pending' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('404s for a missing app', async () => {
+    mockDbReadAppBlockFindUnique.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(authedCtx(42) as never);
+    await expect(caller.getInstallConfig({ appBlockId: 'ab_missing' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  // SECURITY: the gate. These FAIL if moderatorProcedure is relaxed to
+  // public/protected — the install-config (manifest internals) must stay
+  // restricted to the same audience that can install, ahead of the public
+  // launch (segment widen).
+  it('DENIES a non-mod authed caller (FORBIDDEN) — manifest lookup never runs', async () => {
+    const caller = blocksRouter.createCaller(authedCtx(7, false) as never);
+    await expect(caller.getInstallConfig({ appBlockId: 'ab_x' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('DENIES an anon caller — manifest lookup never runs', async () => {
+    const caller = blocksRouter.createCaller(anonCtx() as never);
+    await expect(caller.getInstallConfig({ appBlockId: 'ab_x' })).rejects.toBeInstanceOf(TRPCError);
+    expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('fail-soft returns empty (no manifest lookup) when the appBlocks flag is dark', async () => {
+    // getInstallConfig is a query, so enforceAppBlocksFlag marks _appBlocksDisabled
+    // rather than throwing. The proc honors that and returns an empty config — the
+    // modal renders no settings form rather than erroring, and crucially the
+    // manifest lookup never runs (nothing leaks while dark).
+    mockIsAppBlocksEnabled.mockImplementation(async () => false);
+    const caller = blocksRouter.createCaller(authedCtx(42) as never);
+    const out = await caller.getInstallConfig({ appBlockId: 'ab_x' });
+    expect(out).toEqual({ settings: {}, scopes: [] });
+    expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -25,6 +25,7 @@ import {
 } from '~/server/schema/blocks/publish-request.schema';
 import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { rateLimit } from '~/server/middleware.trpc';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import {
   getRecentAttributionsForOwner,
@@ -882,18 +883,54 @@ export const blocksRouter = router({
 
   /**
    * Marketplace listing — approved app blocks, optionally filtered by slot
-   * and/or a free-text query. Cursor-paginated. Public (any user can
-   * browse the marketplace; install requires auth).
+   * and/or a free-text query. Cursor-paginated. Public, ANON-CAPABLE (F-E E1):
+   * any viewer the appBlocks flag grants can browse the marketplace without a
+   * session; install requires auth (the Install CTA opens LoginModal for anon).
+   *
+   * GATING INVARIANT (E1) — this is anon-capable but stays DARK until launch:
+   *   - `enforceAppBlocksFlag` runs FIRST and evaluates `isAppBlocksEnabled`
+   *     with `ctx.user`. For a real anon / non-mod viewer the flag is the live
+   *     mod-segmented `app-blocks-enabled`, which can never match without a
+   *     moderator context → the middleware sets `_appBlocksDisabled` → we
+   *     return empty below. So removing the prior hardcoded `isModerator` gate
+   *     does NOT widen access today: the flag gate keeps it dark. The procedure
+   *     only starts serving real anon callers once the SEGMENT is widened at
+   *     launch (a deliberate, separate Flipt change). The earlier
+   *     `if (!ctx.user?.isModerator) return []` was a redundant Phase-2 belt on
+   *     top of the flag gate; it has to go for the segment-widen to actually
+   *     expose this to anon, but the flag gate is the real control.
+   *
+   * EXPOSURE / SECURITY (what an anon caller can fetch once the segment widens):
+   *   - ONLY `status='approved'` rows (the service WHERE-clause filters
+   *     pending/rejected/withdrawn apps out — never returned).
+   *   - ONLY an explicit PUBLIC-FIELD ALLOWLIST projection of each row
+   *     (id, blockId, appId, appName, installCount + a vetted manifest subset:
+   *     name/description/targets[].slotId). The full publisher-supplied
+   *     `manifest` jsonb is NOT returned — it can carry arbitrary publisher
+   *     fields plus server-set internal fields (e.g. `trustTier`, the internal
+   *     `iframe.src` host) that must not leak to anon. See
+   *     `BlockRegistry.listAvailable` for the allowlist.
+   *   - No per-user data (subscriptions / earnings / grants stay on their own
+   *     session-gated procedures).
+   *
+   * Anon rate-limiting: keyed on IP for anon (ctx.user?.id ?? ctx.ip in the
+   * rateLimit middleware), consistent with other public procedures. Mods/dev/
+   * test are exempt by the middleware itself.
    */
   listAvailable: publicProcedure
     .use(enforceAppBlocksFlag)
+    .use(
+      rateLimit({
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many marketplace requests — slow down.',
+      })
+    )
     .input(listAvailableSchema)
     .query(async ({ ctx, input }) => {
       if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
         return { items: [], nextCursor: undefined };
       }
-      // Phase 2: marketplace listing is moderator-only until GA.
-      if (!ctx.user?.isModerator) return { items: [], nextCursor: undefined };
       return BlockRegistry.listAvailable(input);
     }),
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -935,6 +935,65 @@ export const blocksRouter = router({
     }),
 
   /**
+   * Install-time config for ONE approved app block, keyed on appBlockId.
+   *
+   * Why this exists (F-E E1 regression fix): the marketplace listing
+   * (`listAvailable`) is anon-capable and so projects each manifest down to a
+   * PUBLIC allowlist (name/description/targets only) via `toPublicBlockManifest`
+   * — it deliberately drops `settings` and `scopes`. But the install modal
+   * (`AppSettingsModal`) builds its publisher-settings form from
+   * `manifest.settings` and reads `manifest.scopes`. Sourcing those from the
+   * stripped public listing meant the settings form silently vanished when a
+   * user installed a settings-declaring app FROM A MARKETPLACE CARD. This proc
+   * is the AUTHENTICATED source for ONLY those two install-needed bits, so the
+   * public listing can stay narrow (no widening of the anon-exposure allowlist).
+   *
+   * Gate: `moderatorProcedure` + appBlocks flag — the SAME audience that can
+   * actually install (`installOnModel` / `upsertSubscription` are both
+   * `moderatorProcedure`). A non-mod / anon caller is denied, so this can't be
+   * used to enumerate manifest internals ahead of the public launch. It returns
+   * ONLY for `status='approved'` apps (404 otherwise), matching the install
+   * mutations' own approved gate.
+   *
+   * This is a DISPLAY fix only: `upsertSubscription` / `installOnModel` still
+   * re-resolve settings + scopes server-side from the stored manifest by id and
+   * validate them (see upsertSubscription's `dbRead.appBlock.findUnique` +
+   * `validateBlockSettings`). The client never becomes the source of truth for
+   * what gets persisted.
+   */
+  getInstallConfig: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(z.object({ appBlockId: z.string().min(1).max(64) }))
+    .query(async ({ ctx, input }) => {
+      // Dark-flag fail-soft, consistent with the other query procs: when the
+      // appBlocks flag is off the middleware marks the ctx and we surface no
+      // manifest data (the modal renders no settings form rather than erroring).
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return { settings: {}, scopes: [] as string[] };
+      }
+      const block = await dbRead.appBlock.findUnique({
+        where: { id: input.appBlockId },
+        select: { status: true, manifest: true },
+      });
+      if (!block || block.status !== 'approved') {
+        throw throwNotFoundError('App block not found');
+      }
+      const manifest = (block.manifest ?? {}) as Record<string, unknown>;
+      // Project ONLY the install-form inputs. `settings` is validated against
+      // manifestSettingsSchema so a malformed/absent declaration yields {} (the
+      // form renders no fields rather than throwing). `scopes` is the declared
+      // scope list the form uses to decide which `requires_scope` fields show.
+      const parsedSettings = manifestSettingsSchema.safeParse(manifest.settings ?? {});
+      const scopes = Array.isArray(manifest.scopes)
+        ? manifest.scopes.filter((s): s is string => typeof s === 'string')
+        : [];
+      return {
+        settings: parsedSettings.success ? parsedSettings.data : {},
+        scopes,
+      };
+    }),
+
+  /**
    * Create or update the user's subscription for a (appBlockId, scope)
    * pair. Toggling a scope on writes a row; toggling off uses
    * deleteSubscription instead. Settings are validated against the app's

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -110,18 +110,68 @@ export type SubscriptionRecord = {
 };
 
 /**
+ * PUBLIC marketplace manifest subset (F-E E1 anon-exposure allowlist).
+ *
+ * The stored `app_blocks.manifest` jsonb is arbitrary publisher-supplied JSON
+ * plus server-SET internal fields (e.g. `trustTier`, the internal `iframe.src`
+ * host, `renderMode`). It must NEVER be shipped wholesale to an anon caller.
+ * The marketplace listing is anon-capable, so we project ONLY this vetted,
+ * display-safe subset:
+ *   - `name`        — the human display name (already shown on the card).
+ *   - `description` — the short marketing blurb (shown on the card).
+ *   - `targets`     — only the `slotId` of each declared target (drives the
+ *                     slot badge + slot filter). Any other per-target field is
+ *                     dropped so config details can't leak.
+ * Add a field here ONLY after confirming it is publisher-display-safe for anon.
+ */
+export type PublicBlockManifest = {
+  name?: string;
+  description?: string;
+  targets?: Array<{ slotId?: string }>;
+};
+
+/** Field names projected from the raw manifest into PublicBlockManifest. */
+export const PUBLIC_MANIFEST_FIELDS = ['name', 'description', 'targets'] as const;
+
+/**
  * Marketplace listing shape. install_count includes per-model installs and
  * (someday) subscription rows — for v1 it's the per-model installs only;
  * subscriptions land later in the same column with a small SQL change.
+ *
+ * `manifest` is the PUBLIC allowlist subset only (see PublicBlockManifest) —
+ * not the raw stored manifest. This shape is returned by the anon-capable
+ * `blocks.listAvailable` (F-E E1), so it must carry no private/internal data.
  */
 export type AvailableBlock = {
   id: string;
   blockId: string;
   appId: string;
   appName: string | null;
-  manifest: Record<string, unknown>;
+  manifest: PublicBlockManifest;
   installCount: number;
 };
+
+/**
+ * Projects a raw stored manifest down to the public allowlist subset. Defensive
+ * against arbitrary publisher JSON: reads only the allowlisted fields, coerces
+ * each to its expected display type, and drops everything else. Centralised so
+ * the listing + (future E2 detail) paths share ONE projection and can't drift.
+ */
+export function toPublicBlockManifest(raw: unknown): PublicBlockManifest {
+  const m = (raw ?? {}) as Record<string, unknown>;
+  const out: PublicBlockManifest = {};
+  if (typeof m.name === 'string') out.name = m.name;
+  if (typeof m.description === 'string') out.description = m.description;
+  if (Array.isArray(m.targets)) {
+    out.targets = m.targets
+      .map((t) => {
+        const slotId = (t as { slotId?: unknown } | null | undefined)?.slotId;
+        return typeof slotId === 'string' ? { slotId } : null;
+      })
+      .filter((t): t is { slotId: string } => t !== null);
+  }
+  return out;
+}
 
 export const listAvailableSchema = z.object({
   slotId: z

--- a/src/server/services/__tests__/block-registry.list-available.test.ts
+++ b/src/server/services/__tests__/block-registry.list-available.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * F-E E1 — anon-exposure security tests for the marketplace listing
+ * (`BlockRegistry.listAvailable`, served by the anon-capable
+ * `blocks.listAvailable` publicProcedure).
+ *
+ * The marketplace is anon-CAPABLE (dark today behind the mod-segmented flag,
+ * lit at launch by widening the segment). These tests pin the two exposure
+ * protections so they FAIL if either regresses:
+ *
+ *   1. APPROVED-ONLY — the SQL hard-filters `ab.status = 'approved'`, so
+ *      pending / rejected / withdrawn apps can never reach an anon caller.
+ *      Belt-and-suspenders, we also seed a pending row into the (mocked) DB
+ *      result and assert the projection carries no status/secret fields.
+ *   2. PUBLIC FIELD ALLOWLIST — the raw stored `manifest` jsonb is arbitrary
+ *      publisher JSON plus server-SET internal fields (`trustTier`, the
+ *      internal `iframe.src` host, `renderMode`, `scopes`, …). The listing
+ *      must project ONLY the vetted public subset
+ *      (name / description / targets[].slotId) — never the raw manifest.
+ *
+ * We don't run the query (no DB in unit tests). We mock dbRead.$queryRaw to:
+ *   - capture the SQL template (assert the status='approved' filter), and
+ *   - return seeded rows so we can assert the SHAPE of the projected output.
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    blockUserSubscription: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    modelVersion: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  },
+  sysRedis: { sMembers: vi.fn(async () => []) },
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'packed:caches:block-registry', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+
+/** Reconstructs the SQL string from the tagged-template args Prisma received. */
+function capturedSql(): string {
+  expect(mockDbRead.$queryRaw).toHaveBeenCalled();
+  const lastCall = mockDbRead.$queryRaw.mock.calls.at(-1);
+  if (!lastCall) return '';
+  const strings = lastCall[0] as unknown as TemplateStringsArray;
+  const values = lastCall.slice(1);
+  let sql = '';
+  for (let i = 0; i < strings.length; i++) {
+    sql += strings[i];
+    if (i < values.length) sql += `$${i + 1}`;
+  }
+  return sql;
+}
+
+/**
+ * One raw DB row shape (snake_case, as returned by the $queryRaw). The
+ * `manifest` deliberately carries private/internal fields a malicious or
+ * careless publisher (or the server's own trustTier stamp) could put there —
+ * the projection must strip them.
+ */
+function rawRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_1',
+    block_id: 'cool-block',
+    app_id: 'app_1',
+    app_name: 'Cool App',
+    install_count: 5n,
+    manifest: {
+      name: 'Cool Block',
+      description: 'Does cool things',
+      targets: [{ slotId: 'model.sidebar_top', secretCfg: 'leak-me' }],
+      // --- private / internal fields that MUST NOT leak to anon ---
+      trustTier: 'internal',
+      iframe: { src: 'https://cool-block.internal.example/', sandbox: 'allow-scripts' },
+      renderMode: 'iframe',
+      scopes: ['ai:write:budgeted', 'models:read:self'],
+      settings: { apiKey: 'super-secret' },
+      json: 'whatever-internal',
+      arbitraryPublisherField: { nested: 'secret' },
+    },
+    ...over,
+  };
+}
+
+describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([rawRow()]);
+  });
+
+  it('SQL hard-filters status = approved (pending/rejected never returned)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.listAvailable({ limit: 20 });
+    expect(capturedSql()).toMatch(/ab\.status\s*=\s*'approved'/);
+  });
+
+  it('projects ONLY the public manifest allowlist — no private/internal field leaks', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const { items } = await BlockRegistry.listAvailable({ limit: 20 });
+    expect(items).toHaveLength(1);
+    const manifest = items[0].manifest as Record<string, unknown>;
+
+    // Allowlisted, display-safe fields survive.
+    expect(manifest.name).toBe('Cool Block');
+    expect(manifest.description).toBe('Does cool things');
+    expect(manifest.targets).toEqual([{ slotId: 'model.sidebar_top' }]);
+
+    // Private / internal fields are absent.
+    for (const forbidden of [
+      'trustTier',
+      'iframe',
+      'renderMode',
+      'scopes',
+      'settings',
+      'json',
+      'arbitraryPublisherField',
+    ]) {
+      expect(manifest, `manifest leaked "${forbidden}"`).not.toHaveProperty(forbidden);
+    }
+
+    // Per-target fields beyond slotId are dropped (no nested config leak).
+    const target0 = (manifest.targets as Array<Record<string, unknown>>)[0];
+    expect(target0).not.toHaveProperty('secretCfg');
+    expect(Object.keys(target0)).toEqual(['slotId']);
+
+    // The whole serialized listing must not contain any secret value.
+    const serialized = JSON.stringify(items);
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('internal.example');
+    expect(serialized).not.toContain('leak-me');
+  });
+
+  it('returned top-level shape is the public allowlist only (no status/raw leak)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const { items } = await BlockRegistry.listAvailable({ limit: 20 });
+    expect(Object.keys(items[0]).sort()).toEqual(
+      ['appId', 'appName', 'blockId', 'id', 'installCount', 'manifest'].sort()
+    );
+    // status is a DB-internal field; it must never appear on the wire shape.
+    expect(items[0]).not.toHaveProperty('status');
+  });
+
+  it('a malformed/missing manifest yields an empty public manifest (no crash, no leak)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      rawRow({ manifest: null }),
+      rawRow({ id: 'ab_2', manifest: 'a string, not an object' }),
+      rawRow({ id: 'ab_3', manifest: { targets: 'not-an-array', trustTier: 'internal' } }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const { items } = await BlockRegistry.listAvailable({ limit: 20 });
+    expect(items).toHaveLength(3);
+    for (const it of items) {
+      expect(it.manifest).not.toHaveProperty('trustTier');
+      // targets, when not a valid array, is simply omitted.
+      if ('targets' in it.manifest) {
+        expect(Array.isArray((it.manifest as { targets?: unknown }).targets)).toBe(true);
+      }
+    }
+  });
+
+  it('query + slot filter + cursor are threaded into the SQL (anon browse still works)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.listAvailable({
+      limit: 20,
+      query: 'cool',
+      slotId: 'model.sidebar_top',
+      cursor: 'ab_0',
+    });
+    const sql = capturedSql();
+    // ILIKE name/blockId filter, slot @> jsonb filter, and id > cursor pagination.
+    expect(sql).toMatch(/LIKE/i);
+    expect(sql).toMatch(/@>/);
+    expect(sql).toMatch(/ab\.id\s*>/);
+  });
+
+  it('emits nextCursor only when a full page+1 is returned (pagination contract)', async () => {
+    // Return limit+1 rows so the service trims to `limit` and sets nextCursor.
+    const rows = Array.from({ length: 3 }, (_v, i) => rawRow({ id: `ab_${i}` }));
+    mockDbRead.$queryRaw.mockResolvedValueOnce(rows);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const { items, nextCursor } = await BlockRegistry.listAvailable({ limit: 2 });
+    expect(items).toHaveLength(2);
+    expect(nextCursor).toBe('ab_1');
+  });
+});

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -23,6 +23,7 @@ import type {
   SubscriptionRecord,
   SubscriptionScope,
 } from '~/server/schema/blocks/subscription.schema';
+import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schema';
 
 const CACHE_TTL_SECONDS = 60;
 export const MAX_BLOCKS_PER_SLOT = 3;
@@ -2216,12 +2217,19 @@ export class BlockRegistry {
     const trimmed = rows.slice(0, limit);
     const nextCursor = rows.length > limit ? trimmed[trimmed.length - 1]?.id : undefined;
     return {
+      // F-E E1 anon-exposure allowlist: project the raw stored manifest down to
+      // the vetted PUBLIC subset (name/description/targets[].slotId) via
+      // toPublicBlockManifest. The raw manifest is arbitrary publisher JSON plus
+      // server-set internal fields (trustTier, internal iframe.src host) — never
+      // ship it wholesale to an anon caller. Combined with the WHERE
+      // status='approved' filter above, an anon caller can only ever see
+      // approved apps + display-safe fields.
       items: trimmed.map((r: Row) => ({
         id: r.id,
         blockId: r.block_id,
         appId: r.app_id,
         appName: r.app_name ?? null,
-        manifest: (r.manifest ?? {}) as Record<string, unknown>,
+        manifest: toPublicBlockManifest(r.manifest),
         installCount: Number(r.install_count),
       })),
       nextCursor,


### PR DESCRIPTION
## F-E Phase E1 — anon-capable marketplace read path (built but DARK, mod-gated)

Implements **Phase E1** of the App Blocks marketplace plan
(`claudedocs/app-platform-fe-marketplace-plan-2026-06-14.md` in datapacket-talos).
The `/apps` marketplace read path becomes **anon-CAPABLE** (it CAN render for a
session-less request and `listAvailable` becomes anon-callable), but stays
**DARK** — unreachable by real anon/non-mod users — until product sign-off.

### 🔒 GATING INVARIANT (unchanged by this PR — nothing widens today)

- **Mods-only stays mods-only.** Every `/apps` surface keeps the
  `features.appBlocks` flag gate FIRST. A logged-out / non-mod user does NOT
  satisfy the Flipt `app-blocks-enabled` mod segment, so `features.appBlocks`
  is `false` for them → `notFound`. The anon-rendering code is **built-but-dark**:
  it only executes once the segment is widened.
- **`deIndex` stays ON** — the page is not made crawlable.
- **No Flipt flag/segment change here.** "Launch" = widen the
  `app-blocks-enabled` segment + drop `deIndex` — a deliberate, separate,
  product-signed-off step, NOT part of this PR.
- The only behavior change: **behind the flag gate**, a session-less request
  renders the marketplace read-only (instead of a hard login redirect), and
  `listAvailable` is anon-callable. Dark until the segment widens.

### Changes

- **`src/pages/apps/index.tsx`** — SSR resolver keeps the `features.appBlocks`
  gate FIRST and as the ONLY access control; removed the separate hard
  `session→login` redirect so the page renders behind the flag for a
  session-less request. `deIndex` unchanged (still ON). Gate logic extracted to
  a pure, React-free `resolveAppsPageAccess` helper so the invariant is
  unit-testable. Per-user queries (`listMySubscriptions`, `getMyApps`) now also
  gate on a logged-in user so the dark anon path doesn't fire protected
  procedures.
- **`src/server/routers/blocks.router.ts`** — `listAvailable`: removed the
  redundant Phase-2 `if (!ctx.user?.isModerator) return []` gate. The real
  control is the `enforceAppBlocksFlag` middleware, which evaluates
  `isAppBlocksEnabled({ user: ctx.user })`; for a real anon caller the
  mod-segmented flag can never match without a mod context, so the middleware
  returns empty — i.e. removing the secondary gate does **not** widen access
  today. Added anon **IP-keyed rate-limiting** (60/min) consistent with other
  public procedures (mods/dev/test exempt by the middleware).
- **`src/server/schema/blocks/subscription.schema.ts`** + **`block-registry.service.ts`**
  — replaced the raw `manifest` jsonb in the `AvailableBlock` wire shape with an
  explicit **PUBLIC field allowlist** projection (`toPublicBlockManifest`:
  `name` / `description` / `targets[].slotId` only).
- **`src/components/Apps/AppBlockCard.tsx`** — Install/Manage CTA wrapped in
  `LoginRedirect` (`reason="perform-action"`): anon click → `LoginModal`
  (via `requireLogin` → `dialogStore.trigger(LoginModal, { returnUrl })`);
  logged-in click → unchanged install/settings flow.

### Anon-exposure security analysis (what an anon caller can fetch post-launch, and why it's safe)

`blocks.listAvailable` is `publicProcedure`. Once the segment widens, an anon
caller can fetch the marketplace listing. The exposure is bounded to:

1. **Approved apps only.** `BlockRegistry.listAvailable` SQL hard-filters
   `WHERE ab.status = 'approved'`. Pending / rejected / withdrawn apps are never
   returned. (Pinned by test.)
2. **A public field allowlist only.** The stored `app_blocks.manifest` jsonb is
   **arbitrary publisher-supplied JSON** (parsed from their bundle) **plus
   server-SET internal fields** — notably `trustTier` (server stamps `internal`,
   the most-privileged tier), the internal `iframe.src` host, `renderMode`,
   `scopes`, and `settings`. Returning it wholesale would leak those to anon.
   Instead the wire shape carries `toPublicBlockManifest(...)` =
   `{ name?, description?, targets?: [{ slotId }] }` only; per-target fields
   beyond `slotId` are dropped; non-allowlisted and internal fields are absent.
   (Pinned by test: asserts `trustTier`/`iframe`/`renderMode`/`scopes`/
   `settings`/`json`/arbitrary fields are absent, and that secret values do not
   appear in the serialized output.)
3. **No per-user data.** Subscriptions / earnings / scope grants / activity stay
   on their own session-gated (`protected`/`moderator`) procedures, unchanged.

How verified: unit tests seed a manifest carrying private/internal fields +
secret values and assert the projection strips them; a test seeds the SQL filter
assertion for `status='approved'`; the flag-gate test proves the procedure
returns empty for anon/non-mod without the flag and is only consulted once the
flag is granted.

### Test coverage (security-meaningful; designed to FAIL if exposure protection regresses)

- `src/server/services/__tests__/block-registry.list-available.test.ts` (6) —
  approved-only SQL filter; public allowlist projection (private fields absent,
  secrets not serialized, per-target fields dropped, top-level shape locked);
  malformed/missing manifest safety; query/slot/cursor filters threaded;
  pagination `nextCursor` contract.
- `src/server/routers/__tests__/blocks.router.flag-gate.test.ts` (+4) —
  `listAvailable` dark for anon/non-mod without the flag (registry NOT
  consulted); anon-CALLABLE once the flag is granted (registry consulted),
  proving anon-capable and that no secondary `isModerator` gate remains.
- `src/components/Apps/__tests__/resolveAppsPageAccess.test.ts` (4) — gate
  ordering: no flag → `notFound` (and NOT a login redirect) even with no
  session; flag granted + no session → renders (the dark path); fails closed on
  undefined/empty features.

Local run (worktree unit project, deps symlinked from the primary clone):
**19/19 passed** across the three files. Authoritative type/lint check is CI's
Type Check (a fresh worktree lacks `next-env.d.ts`/`.next/types`, so a local
`tsc` reports spurious inference errors — the standalone `resolveAppsPageAccess`
helper does pass an isolated `tsc --noEmit`).

### Notes / risks

- `installCount` semantics inherit the existing per-app caveat (distinct
  subscribed users) — unchanged here.
- Two adjacent pre-existing blocks router tests fail at import time in the
  worktree on `Prisma.validator is not a function` (stale generated client in a
  fresh worktree) — unrelated to this change and resolved by CI's client
  generation. The new E1 tests fully mock `@prisma/client`/db and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
