### PR TITLE
test(component): SelectInput + OutputFormatInput tests (+ name the format trigger)

### DIFF
--- a/src/components/generation_v2/inputs/OutputFormatInput.browser.test.tsx
+++ b/src/components/generation_v2/inputs/OutputFormatInput.browser.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { OutputFormatInput } from '~/components/generation_v2/inputs/OutputFormatInput';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+
+// OutputFormatInput is a pure value/onChange leaf (no tRPC/router): a Mantine
+// Menu whose trigger (an UnstyledButton) shows the *selected* option's label,
+// and whose Menu.Items emit onChange(value) on click. Lockable behavior pinned
+// here: the trigger label reflects `value` (defaulting to 'JPEG' when unset),
+// clicking a Menu.Item emits the right value, the `+offset Buzz` glyph renders
+// only for offset>0, and the "Free for Members" line shows for png when
+// isMember. Mantine v7 renders the dropdown in a PORTAL on document.body, so
+// the options only exist after the trigger is clicked — but `page` queries the
+// whole document so they're still findable post-open.
+//
+// `cleanup()` after each test (component-setup.tsx) keeps the document free of
+// prior renders.
+const options = [
+  { label: 'JPEG', value: 'jpeg' },
+  { label: 'PNG', value: 'png', offset: 5 },
+];
+
+describe('OutputFormatInput', () => {
+  // The trigger is an aria-labelled button ("Output Format: <value>"); query by
+  // the stable prefix so these never coincidentally match a future second button
+  // (and don't break as the selected value changes the full name).
+  const trigger = () => page.getByRole('button', { name: /Output Format/ });
+
+  test('trigger shows the selected option\'s label', async () => {
+    renderWithProviders(<OutputFormatInput value="png" options={options} onChange={vi.fn()} />);
+
+    // Scope to the trigger (the menu is closed, but be explicit about intent).
+    await expect.element(trigger().getByText('PNG')).toBeInTheDocument();
+  });
+
+  test('trigger falls back to JPEG when value is unset', async () => {
+    // selected is undefined -> `selected?.label ?? 'JPEG'`. This must hold even
+    // though no option is currently active.
+    renderWithProviders(<OutputFormatInput value={undefined} options={options} onChange={vi.fn()} />);
+
+    await expect.element(trigger().getByText('JPEG')).toBeInTheDocument();
+  });
+
+  test('trigger renders the selected option\'s own +Buzz offset glyph', async () => {
+    // Distinct from FormatLabel inside the menu: the trigger has its OWN offset
+    // span (`selected && offset>0`). value=png (offset 5) -> trigger shows +5,
+    // without opening the dropdown.
+    renderWithProviders(<OutputFormatInput value="png" options={options} onChange={vi.fn()} />);
+
+    await expect.element(trigger().getByText('5')).toBeInTheDocument();
+  });
+
+  test('clicking a Menu.Item emits its value', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<OutputFormatInput value="jpeg" options={options} onChange={onChange} />);
+
+    // Open the portal dropdown, then pick PNG (a Menu.Item -> menuitem role).
+    await userEvent.click(trigger());
+    await userEvent.click(page.getByRole('menuitem', { name: /PNG/ }));
+
+    expect(onChange).toHaveBeenCalledWith('png'); // emits value, not label
+  });
+
+  test('an option with a positive offset renders the +Buzz glyph in its item', async () => {
+    // PNG has offset:5 -> FormatLabel renders a `+` and the offset number.
+    // jpeg (offset undefined/0) must NOT. We assert the offset number shows in
+    // the opened menu.
+    renderWithProviders(<OutputFormatInput value="jpeg" options={options} onChange={vi.fn()} />);
+
+    await userEvent.click(trigger());
+    const png = page.getByRole('menuitem', { name: /PNG/ });
+    await expect.element(png).toBeInTheDocument();
+    await expect.element(png.getByText('5')).toBeInTheDocument();
+  });
+
+  test('isMember shows "Free for Members" on the png item only', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <OutputFormatInput value="jpeg" options={options} isMember onChange={onChange} />
+    );
+
+    await userEvent.click(trigger());
+
+    // isFreeForMember = isMember && option.value === 'png' -> the line shows on
+    // the png item and NOT on jpeg. Scope BOTH assertions to their menuitem so
+    // each fails on its own intent (not a strict-mode multi-match).
+    const png = page.getByRole('menuitem', { name: /PNG/ });
+    const jpeg = page.getByRole('menuitem', { name: /JPEG/ });
+    await expect.element(png.getByText('Free for Members')).toBeInTheDocument();
+    await expect.element(jpeg.getByText('Free for Members')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/generation_v2/inputs/OutputFormatInput.tsx
+++ b/src/components/generation_v2/inputs/OutputFormatInput.tsx
@@ -75,6 +75,11 @@ export function OutputFormatInput({
       <Tooltip label="Output Format" position="top" withArrow>
         <Menu.Target>
           <UnstyledButton
+            // Name the control AND keep the selected value in the accessible
+            // name (WCAG 2.5.3 — the visible label must be contained in it).
+            // Without an aria-label the SR name is just the value ("PNG"); a
+            // bare "Output Format" would drop the value. Include both.
+            aria-label={`Output Format: ${selected?.label ?? 'JPEG'}`}
             className={clsx(
               'flex items-center gap-1.5 rounded-md px-2 py-1 text-sm',
               'bg-gray-1 hover:bg-gray-2',

--- a/src/components/generation_v2/inputs/SelectInput.browser.test.tsx
+++ b/src/components/generation_v2/inputs/SelectInput.browser.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { SelectInput } from '~/components/generation_v2/inputs/SelectInput';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+
+// SelectInput is a pure value/onChange leaf (no tRPC/router) wrapping a Mantine
+// Select, plus an optional row of `presets` buttons rendered in the label.
+// The lockable behavior worth pinning: the `data`/`options` aliasing, the
+// `onChange` truthy-guard (`if (newValue) onChange?.(newValue)`), the preset
+// buttons emitting onChange, and `allowDeselect={false}` (re-picking the
+// current value must NOT clear it). Mantine v7's Select is a text input that
+// reveals its option list (in a portal) on open — queries below confirmed
+// against the real rendered DOM.
+//
+// Queries go through the global `page` (whole-document); `cleanup()` after each
+// test (component-setup.tsx) keeps the document free of prior renders.
+const data = [
+  { label: 'First', value: 'a' },
+  { label: 'Second', value: 'b' },
+  { label: 'Third', value: 'c' },
+];
+
+describe('SelectInput', () => {
+  test('renders the selected value\'s label in the input', async () => {
+    renderWithProviders(<SelectInput value="b" data={data} onChange={vi.fn()} />);
+
+    // Mantine v7 Select is a (readonly) text input; the displayed value is the
+    // matching option's *label*, not its `value`.
+    await expect.element(page.getByRole('textbox')).toHaveValue('Second');
+  });
+
+  test('picking an option from the dropdown emits its value', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<SelectInput value="a" data={data} onChange={onChange} />);
+
+    await userEvent.click(page.getByRole('textbox'));
+    // Options live in a portal-rendered listbox; getByRole('option') finds them.
+    await userEvent.click(page.getByRole('option', { name: 'Third' }));
+
+    expect(onChange).toHaveBeenCalledWith('c'); // emits value, not label
+  });
+
+  test('`options` is aliased to `data` when `data` is absent', async () => {
+    // If the alias breaks, no options render and the click below can't find one.
+    const onChange = vi.fn();
+    renderWithProviders(<SelectInput value="a" options={data} onChange={onChange} />);
+
+    await userEvent.click(page.getByRole('textbox'));
+    await userEvent.click(page.getByRole('option', { name: 'Second' }));
+
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  test('clicking a preset button emits that preset value', async () => {
+    const presets = [
+      { label: 'Square', value: 'a' },
+      { label: 'Portrait', value: 'b' },
+    ];
+    const onChange = vi.fn();
+    renderWithProviders(
+      <SelectInput value="a" data={data} presets={presets} onChange={onChange} label="Size" />
+    );
+
+    await userEvent.click(page.getByRole('button', { name: 'Portrait' }));
+
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  test('re-selecting the current value never emits onChange', async () => {
+    // User-facing invariant: re-picking the already-selected option must not
+    // fire onChange (no spurious change / no clear). TWO mechanisms enforce this
+    // and mask each other, so neither is independently isolable through the
+    // controlled public API: `allowDeselect={false}` suppresses the deselect,
+    // and the `if (newValue) onChange?.(newValue)` truthy-guard swallows the
+    // null Mantine would otherwise emit. This test pins the COMBINED invariant
+    // (defense-in-depth) — removing either one alone still keeps it green; only
+    // removing both surfaces a null emission. Accept that as the coverage limit.
+    const onChange = vi.fn();
+    renderWithProviders(<SelectInput value="b" data={data} onChange={onChange} />);
+
+    await userEvent.click(page.getByRole('textbox'));
+    await userEvent.click(page.getByRole('option', { name: 'Second' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Climbs the component-testing scaffold (from `SeedInput`) to two more `generation_v2` form leaves — **11 new Vitest browser-mode tests** — and gives one trigger a proper accessible name.

- **`SelectInput.browser.test.tsx`** (5) — label-vs-value display, `data`/`options` aliasing, preset-button emit, pick-from-dropdown emit, no-emit-on-reselect.
- **`OutputFormatInput.browser.test.tsx`** (6) — selected/`JPEG`-fallback trigger label, the trigger's own +Buzz offset glyph, Menu.Item emit, in-menu offset glyph, png-only "Free for Members".
- **`OutputFormatInput.tsx`** — `aria-label={`Output Format: ${selected?.label ?? 'JPEG'}`}` on the trigger. The icon button's screen-reader name was previously **just the selected value** ("PNG"); this names the control **and keeps the value** (WCAG 2.5.3 label-in-name), and lets the tests query by a stable name prefix instead of a brittle bare `getByRole('button')`.

Pure `value`/`onChange` leaves — no tRPC/router mocking yet (next climb).

## Quality — audited twice, fixes applied

1. **Test-teeth audit** → fixed a misleading test (removing `allowDeselect={false}` left the suite green); reframed it to honestly pin the combined defense-in-depth invariant (`allowDeselect` + the truthy-guard mask each other, so neither is isolable). Added the trigger-offset gap test. Added the aria-label so queries aren't a brittle bare button match.
2. **Full risk/regression audit** → caught that a *bare* `aria-label="Output Format"` would have **overridden** the button's existing value-derived SR name (stripping "PNG"/"JPEG"). Fixed to the **value-inclusive** label above. Verified: no existing a11y/snapshot/axe tests reference it; `OutputFormatInput` is rendered in exactly one place (single instance, no duplicate-name ambiguity); failure `__screenshots__` are gitignored; `SelectInput.tsx` left pristine.

Verified locally: **17/17 green**, every new test **mutation-checked** for teeth. Runs in Tekton (`component-tests` task), report-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
