### PR TITLE
fix(redis): socketTimeout + in-flight instrumentation to remediate & confirm the api-primary 504 cascade

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -39,6 +39,26 @@ export const serverSchema = z.object({
   REDIS_CLUSTER_REFRESH_INTERVAL: z.coerce.number().default(30000), // Topology refresh interval in ms (default 30s)
   REDIS_SYS_URL: z.url(),
   REDIS_TIMEOUT: z.preprocess((x) => (x ? parseInt(String(x)) : 5000), z.number().optional()),
+  // Socket-level inactivity timeout (ms). Passed to node-redis `socket.socketTimeout`,
+  // which maps to net.Socket.setTimeout — it fires only when NO data is sent or
+  // received on the live socket for this long (reset by any traffic), so under normal
+  // command flow it never trips. Its job is to kill a SILENT half-open connection
+  // (pod reschedule/failover with no RST/FIN) instead of waiting ~30s for OS TCP
+  // keepalive, which is the root cause of the api-primary 504 cascades (commands park
+  // off-CPU in the node-redis queue until the socket is finally torn down). Set well
+  // above the ping interval (4min) is NOT required because pings count as traffic and
+  // keep it reset; 10s is comfortably above normal round-trip latency (<5ms). Tunable
+  // so it can be widened/disabled in prod without a redeploy.
+  REDIS_SOCKET_TIMEOUT_MS: z.coerce.number().default(10000),
+  // Per-command timeout (ms) applied ONLY to verified fail-open hot-path reads
+  // (refreshToken pipeline, needsUpdate/getClientConfigCached). node-redis arms an
+  // AbortSignal.timeout per command that rejects a parked/slow command with a
+  // TimeoutError — at these call sites a TimeoutError is caught and degrades (keep
+  // session / skip update banner), so it converts a 30s park into a fast fail-open,
+  // never a 500. Default is far above normal latency (<5ms) so it only fires on a
+  // genuine stall. Set to 0 to disable the per-command layer (socketTimeout still
+  // applies). Tunable for canary rollout.
+  REDIS_COMMAND_TIMEOUT_MS: z.coerce.number().default(2000),
   NODE_ENV: z.enum(['development', 'test', 'production']),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.preprocess(

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -40,16 +40,35 @@ export const serverSchema = z.object({
   REDIS_SYS_URL: z.url(),
   REDIS_TIMEOUT: z.preprocess((x) => (x ? parseInt(String(x)) : 5000), z.number().optional()),
   // Socket-level inactivity timeout (ms). Passed to node-redis `socket.socketTimeout`,
-  // which maps to net.Socket.setTimeout — it fires only when NO data is sent or
-  // received on the live socket for this long (reset by any traffic), so under normal
-  // command flow it never trips. Its job is to kill a SILENT half-open connection
-  // (pod reschedule/failover with no RST/FIN) instead of waiting ~30s for OS TCP
-  // keepalive, which is the root cause of the api-primary 504 cascades (commands park
-  // off-CPU in the node-redis queue until the socket is finally torn down). Set well
-  // above the ping interval (4min) is NOT required because pings count as traffic and
-  // keep it reset; 10s is comfortably above normal round-trip latency (<5ms). Tunable
-  // so it can be widened/disabled in prod without a redeploy.
+  // which maps to net.Socket.setTimeout — an IDLE timer that fires when NO read OR
+  // write activity happens on the live socket for this long (any command write or
+  // received reply resets it; verified empirically against @redis/client@5.8.3 +
+  // a real redis-server). Its job is to kill a SILENT half-open connection (pod
+  // reschedule/failover with no RST/FIN): during a real stall the in-flight command
+  // is PARKED in the node-redis queue and blocks every subsequent write (including
+  // the keepalive PING), so the idle timer runs to completion and tears the dead
+  // socket down in ~REDIS_SOCKET_TIMEOUT_MS instead of waiting ~30s for OS TCP
+  // keepalive — the root cause of the api-primary 504 cascades. 10s is comfortably
+  // above normal round-trip latency (<5ms). Tunable so it can be widened/disabled in
+  // prod without a redeploy.
+  //
+  // ⚠️ INVARIANT: REDIS_PING_INTERVAL_MS MUST stay well below this value, otherwise a
+  // HEALTHY but idle socket (off-peak, a cold slot range, a quiet pod) goes idle for
+  // > socketTimeout with no traffic and the idle timer fires on a perfectly good node
+  // → spurious reconnect churn. The keepalive PING is what keeps an idle-but-healthy
+  // socket under the timeout. client.ts derives + clamps the ping interval to enforce
+  // this even if the two envs are mis-set; see getBaseClient().
   REDIS_SOCKET_TIMEOUT_MS: z.coerce.number().default(10000),
+  // Keepalive PING interval (ms). node-redis issues a `PING` every interval ONLY when
+  // the socket is otherwise idle (a parked/in-flight command blocks it from being
+  // written). Each PING is a write+reply round-trip that resets the socketTimeout idle
+  // timer, so it keeps a HEALTHY idle socket alive while a genuinely half-open one
+  // (where the parked command blocks the PING) still trips socketTimeout. MUST be
+  // comfortably below REDIS_SOCKET_TIMEOUT_MS — client.ts additionally clamps it to
+  // min(this, socketTimeout/2) so the invariant holds even on a misconfig. Default 5s
+  // (≈ half the 10s default socketTimeout). PING load is trivial: one tiny command per
+  // idle node per interval (cluster: per node; a few nodes × pods × 0.2/s).
+  REDIS_PING_INTERVAL_MS: z.coerce.number().default(5000),
   // Per-command timeout (ms) applied ONLY to verified fail-open hot-path reads
   // (refreshToken pipeline, needsUpdate/getClientConfigCached). node-redis arms an
   // AbortSignal.timeout per command that rejects a parked/slow command with a

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -253,6 +253,20 @@ export const redisCommandDuration = registerHistogram({
   buckets: [0.001, 0.005, 0.025, 0.1, 0.5, 1, 2, 5, 10, 30],
 });
 
+// Bridge the redis metric handles to '~/server/redis/client' via globalThis,
+// WITHOUT that module statically importing this one. redis/client.ts is
+// client-bundle-reachable (`_app.tsx` → `system-cache.ts` → redis/client.ts) and
+// prom-client eagerly requires `fs`/`cluster` at load (defaultMetrics + cluster
+// aggregator), so a static `redis/client → prom/client` import edge breaks the
+// pages-router client webpack build. This module only ever loads server-side
+// (imported by trpc/api routes/instrumentation at startup), so publishing here is
+// safe and is in place before any real redis command runs. instrumentCommands()
+// reads `globalThis.__civitaiRedisMetrics` at command time.
+(globalThis as unknown as { __civitaiRedisMetrics?: unknown }).__civitaiRedisMetrics = {
+  redisCommandsInflight,
+  redisCommandDuration,
+};
+
 // Image feed metrics
 export const imagesFeedWithoutIndexCounter = registerCounter({
   name: 'images_feed_without_index_total',

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -223,6 +223,36 @@ export const trpcProcedureDuration = registerHistogram({
   buckets: [0.05, 0.25, 1, 2, 5, 10, 30],
 });
 
+// Redis client in-flight + duration instrumentation.
+//
+// WHY: api-primary 504 cascades root-cause to node-redis commands parking
+// off-CPU in the command queue against a SILENT half-open connection (no
+// RST/FIN). The event loop stays flat and every dependency server-metric is
+// clean — the stall is entirely client-side and was uninstrumented. These two
+// metrics make it visible: during a cascade `redis_commands_inflight` climbs
+// toward the concurrency ceiling and `redis_command_duration_seconds` piles
+// into the top (~30s) bucket, directly attributing the request hang to Redis
+// (and confirming/refuting the socketTimeout fix on the next event).
+//
+// Cardinality is intentionally tiny: one label `client` ∈ cluster|sys. No
+// per-key / per-command-name labels. Overhead per command is a gauge inc/dec
+// plus one histogram observe of an already-captured timestamp delta — no
+// per-command allocation beyond the closure the wrapper already creates.
+export const redisCommandsInflight = registerGaugeWithLabels({
+  name: 'redis_commands_inflight',
+  help: 'In-flight node-redis commands by client (cluster vs sys); climbs toward the queue ceiling during a half-open stall',
+  labelNames: ['client'] as const,
+});
+
+export const redisCommandDuration = registerHistogram({
+  name: 'redis_command_duration_seconds',
+  help: 'node-redis command wall-clock duration by client; the long tail (~30s bucket) is the half-open command-queue park',
+  labelNames: ['client'] as const,
+  // Up to 30s to capture the parked-command tail that maps onto the Traefik
+  // 30s ceiling → 504. Lean bucket set keeps the series count low.
+  buckets: [0.001, 0.005, 0.025, 0.1, 0.5, 1, 2, 5, 10, 30],
+});
+
 // Image feed metrics
 export const imagesFeedWithoutIndexCounter = registerCounter({
   name: 'images_feed_without_index_total',

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -8,7 +8,14 @@ import { env } from '~/env/server';
 import { createLogger } from '~/utils/logging';
 import { slugit } from '~/utils/string-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
-import { redisCommandDuration, redisCommandsInflight } from '~/server/prom/client';
+// NOTE: do NOT statically import the redis prom metrics from '~/server/prom/client'.
+// This module is client-bundle-reachable (`_app.tsx` → `system-cache.ts` → here),
+// and prom-client eagerly requires `fs`/`cluster` at module load (defaultMetrics +
+// cluster aggregator), which the pages-router client webpack build cannot resolve
+// → "Module not found: Can't resolve 'cluster'/'fs'". The metrics are defined and
+// registered server-side in `~/server/prom/client` and published on `globalThis`
+// (`__civitaiRedisMetrics`); `instrumentCommands` reads that handle at command time
+// (server runtime only). See getRedisMetrics() below.
 
 export type RedisKeyStringsCache = Values<typeof REDIS_KEYS>;
 export type RedisKeyStringsSys = Values<typeof REDIS_SYS_KEYS>;
@@ -514,6 +521,23 @@ function getBaseClient(type: 'cache' | 'system') {
  * Overhead per command: one gauge inc/dec + one Date.now() delta observe. No
  * per-command allocation beyond the closure the call already pays for.
  */
+// Shape of the prom metric handles published by '~/server/prom/client' on
+// globalThis. Only the methods instrumentCommands calls are typed here.
+type RedisMetricsBridge = {
+  redisCommandsInflight: { inc: (labels: { client: string }) => void; dec: (labels: { client: string }) => void };
+  redisCommandDuration: { observe: (labels: { client: string }, value: number) => void };
+};
+
+// Server-runtime lookup of the prom metric handles WITHOUT a static import edge
+// (which would drag prom-client's fs/cluster requires into the client bundle).
+// Returns undefined until '~/server/prom/client' has loaded server-side (always
+// true by the time real redis commands run — trpc/api routes import it at startup);
+// when undefined, instrumentation simply no-ops for that command (leak-free).
+function getRedisMetrics(): RedisMetricsBridge | undefined {
+  return (globalThis as unknown as { __civitaiRedisMetrics?: RedisMetricsBridge })
+    .__civitaiRedisMetrics;
+}
+
 function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
   const self = client?._self ?? client;
   if (!self) return;
@@ -529,11 +553,16 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     return;
   }
   self[methodName] = function (this: any, ...args: any[]) {
-    redisCommandsInflight.inc(labels);
+    // Read the metric handles published by '~/server/prom/client' on globalThis
+    // (no static import — see the note on the prom import above). Capture ONCE per
+    // command so inc/dec stay balanced even if prom/client loads mid-flight (a
+    // dec without its matching inc would drive the gauge negative).
+    const metrics = getRedisMetrics();
+    metrics?.redisCommandsInflight.inc(labels);
     const start = Date.now();
     const done = () => {
-      redisCommandsInflight.dec(labels);
-      redisCommandDuration.observe(labels, (Date.now() - start) / 1000);
+      metrics?.redisCommandsInflight.dec(labels);
+      metrics?.redisCommandDuration.observe(labels, (Date.now() - start) / 1000);
     };
     let result: any;
     try {

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -265,16 +265,19 @@ function getBaseClient(type: 'cache' | 'system') {
     },
     connectTimeout: env.REDIS_TIMEOUT,
     // Socket-level inactivity guard. node-redis maps this to net.Socket.setTimeout,
-    // which fires only when NO data is sent OR received for this long (reset by any
-    // traffic — including the 4-min pingInterval and normal commands), then destroys
-    // the socket with a SocketTimeoutError and triggers the reconnectStrategy above.
+    // an IDLE timer that fires when NO read OR write happens for this long (any
+    // command write or received reply resets it — verified against @redis/client@5.8.3
+    // + a real redis-server), then destroys the socket with a SocketTimeoutError and
+    // triggers the reconnectStrategy above.
     // This is the structural fix for the 504 cascade: on a SILENT half-open
-    // connection (pod reschedule/failover, no RST/FIN) commands previously parked
-    // off-CPU in the command queue until OS TCP keepalive killed the socket ~30s
-    // later (= Traefik ceiling = 504). With socketTimeout, the dead socket is torn
-    // down in ~REDIS_SOCKET_TIMEOUT_MS, parked commands reject promptly, and the
-    // client reconnects. Does NOT fire under healthy load (constant traffic keeps it
-    // reset). Tunable via REDIS_SOCKET_TIMEOUT_MS (0/unset to disable).
+    // connection (pod reschedule/failover, no RST/FIN) the in-flight command is PARKED
+    // in the node-redis queue and blocks every subsequent write (incl. the keepalive
+    // PING), so the idle timer runs to completion and tears the dead socket down in
+    // ~REDIS_SOCKET_TIMEOUT_MS instead of waiting ~30s for OS TCP keepalive (= Traefik
+    // ceiling = 504); parked commands then reject promptly and the client reconnects.
+    // On a HEALTHY idle socket the keepalive PING (pingInterval, derived below) writes
+    // every interval and keeps this timer reset, so it does NOT spuriously fire.
+    // Tunable via REDIS_SOCKET_TIMEOUT_MS (0/unset to disable).
     ...(env.REDIS_SOCKET_TIMEOUT_MS > 0
       ? { socketTimeout: env.REDIS_SOCKET_TIMEOUT_MS }
       : {}),
@@ -285,7 +288,23 @@ function getBaseClient(type: 'cache' | 'system') {
     password: url.password,
   };
 
-  const pingInterval = 4 * 60 * 1000;
+  // Keepalive PING interval. node-redis issues a PING every interval ONLY when the
+  // socket is otherwise idle (a parked/in-flight command blocks it from being written),
+  // and each PING is a write+reply that resets the socketTimeout idle timer — so it
+  // keeps a HEALTHY idle socket alive while a genuinely half-open socket (parked command
+  // blocks the PING) still trips socketTimeout. The INVARIANT pingInterval < socketTimeout
+  // is what prevents a healthy idle socket from spuriously firing socketTimeout. We CLAMP
+  // to min(env, socketTimeout/2) so the invariant holds even if REDIS_PING_INTERVAL_MS is
+  // mis-set >= socketTimeout. When socketTimeout is disabled (0) there is no idle timer
+  // to keep reset, so we just honor the configured ping interval.
+  const socketTimeoutMs = env.REDIS_SOCKET_TIMEOUT_MS;
+  const pingInterval =
+    socketTimeoutMs > 0
+      ? Math.min(env.REDIS_PING_INTERVAL_MS, Math.floor(socketTimeoutMs / 2))
+      : env.REDIS_PING_INTERVAL_MS;
+  log(
+    `Redis ping interval (${type}) = ${pingInterval}ms (env REDIS_PING_INTERVAL_MS=${env.REDIS_PING_INTERVAL_MS}, socketTimeout=${socketTimeoutMs}ms)`
+  );
 
   // System redis is always a single node
   // Cache redis can be either cluster or single node based on env.REDIS_CLUSTER

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -8,6 +8,7 @@ import { env } from '~/env/server';
 import { createLogger } from '~/utils/logging';
 import { slugit } from '~/utils/string-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
+import { redisCommandDuration, redisCommandsInflight } from '~/server/prom/client';
 
 export type RedisKeyStringsCache = Values<typeof REDIS_KEYS>;
 export type RedisKeyStringsSys = Values<typeof REDIS_SYS_KEYS>;
@@ -263,6 +264,20 @@ function getBaseClient(type: 'cache' | 'system') {
       return Math.min(retries * 100, 3000);
     },
     connectTimeout: env.REDIS_TIMEOUT,
+    // Socket-level inactivity guard. node-redis maps this to net.Socket.setTimeout,
+    // which fires only when NO data is sent OR received for this long (reset by any
+    // traffic — including the 4-min pingInterval and normal commands), then destroys
+    // the socket with a SocketTimeoutError and triggers the reconnectStrategy above.
+    // This is the structural fix for the 504 cascade: on a SILENT half-open
+    // connection (pod reschedule/failover, no RST/FIN) commands previously parked
+    // off-CPU in the command queue until OS TCP keepalive killed the socket ~30s
+    // later (= Traefik ceiling = 504). With socketTimeout, the dead socket is torn
+    // down in ~REDIS_SOCKET_TIMEOUT_MS, parked commands reject promptly, and the
+    // client reconnects. Does NOT fire under healthy load (constant traffic keeps it
+    // reset). Tunable via REDIS_SOCKET_TIMEOUT_MS (0/unset to disable).
+    ...(env.REDIS_SOCKET_TIMEOUT_MS > 0
+      ? { socketTimeout: env.REDIS_SOCKET_TIMEOUT_MS }
+      : {}),
   };
 
   const authConfig = {
@@ -455,8 +470,94 @@ function getBaseClient(type: 'cache' | 'system') {
   return baseClient;
 }
 
+/**
+ * Wrap the per-client command chokepoint so EVERY command is counted in the
+ * `redis_commands_inflight` gauge and timed into `redis_command_duration_seconds`.
+ *
+ * The chokepoint differs by client kind (verified against @redis/client@5.8.3):
+ *  - SINGLE client (sysRedis): typed methods (`get`/`hGetAll`/`set`/...) →
+ *    `_executeCommand` → `this.sendCommand`. Wrap `sendCommand` on `_self`.
+ *  - CLUSTER client (cache): typed methods route through `this._self._execute(...)`,
+ *    NOT the cluster's top-level `sendCommand` (that's only for keyless commands).
+ *    `_execute` is the per-command wrapper that picks a node and runs it. Wrap
+ *    `_execute` on `_self` so both keyed and keyless cluster commands are caught.
+ *
+ * `createCluster` returns a proxy (`Object.create(realCluster)`) and `_self` points
+ * at the real instance, so we must patch the method on `client._self` (own property),
+ * which proxies inherit through the prototype chain.
+ *
+ * NOTE: node-redis routes MULTI/pipeline sub-commands through `#queue.addCommand`
+ * directly (NOT `sendCommand`/`_execute`), so a batched `multi().exec()` is counted
+ * as ONE inflight unit, not per sub-command. Acceptable: the gauge is a
+ * stall/concurrency signal and a parked pipeline still shows as one long-lived
+ * inflight entry landing in the top duration bucket.
+ *
+ * Overhead per command: one gauge inc/dec + one Date.now() delta observe. No
+ * per-command allocation beyond the closure the call already pays for.
+ */
+function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
+  const self = client?._self ?? client;
+  if (!self) return;
+  const labels = { client: clientLabel } as const;
+  // Detect the real chokepoint by capability rather than the static label: a
+  // 'cache' client is a CLUSTER (wrap `_execute`) only when REDIS_CLUSTER is on;
+  // otherwise it's a plain single client (wrap `sendCommand`), same as sysRedis.
+  const isClusterClient = typeof self._execute === 'function';
+  const methodName = isClusterClient ? '_execute' : 'sendCommand';
+  const original = self[methodName];
+  if (typeof original !== 'function') {
+    log(`Redis instrumentation: ${methodName} not found on ${clientLabel} client`);
+    return;
+  }
+  self[methodName] = function (this: any, ...args: any[]) {
+    redisCommandsInflight.inc(labels);
+    const start = Date.now();
+    const done = () => {
+      redisCommandsInflight.dec(labels);
+      redisCommandDuration.observe(labels, (Date.now() - start) / 1000);
+    };
+    let result: any;
+    try {
+      result = original.apply(this, args);
+    } catch (err) {
+      // Synchronous throw (e.g. ClientClosedError) — still account for it.
+      done();
+      throw err;
+    }
+    return Promise.resolve(result).finally(done);
+  };
+}
+
+/**
+ * Apply the env-tunable per-command timeout to a fail-open read.
+ *
+ * Returns a node-redis command-options proxy (no new connection) whose commands
+ * carry `{ timeout: REDIS_COMMAND_TIMEOUT_MS }`. node-redis arms an
+ * `AbortSignal.timeout` per command that rejects a parked/slow command with a
+ * `TimeoutError`. ⚠️ ONLY use this on callers that catch the throw and degrade —
+ * at a non-fail-open site it would convert a 30s park into a 500.
+ *
+ * Returns the client unchanged when the timeout is disabled (env = 0).
+ *
+ * Caveat: node-redis does NOT propagate the per-command timeout into MULTI/pipeline
+ * sub-commands, so this has no effect on `client.multi()` batches (those rely on the
+ * socketTimeout structural fix instead).
+ */
+export function withRedisCommandTimeout<C>(client: C): C {
+  const timeout = env.REDIS_COMMAND_TIMEOUT_MS;
+  if (!timeout || timeout <= 0) return client;
+  const withOpts = (client as any).withCommandOptions;
+  if (typeof withOpts !== 'function') return client;
+  return withOpts.call(client, { timeout }) as C;
+}
+
 function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
   const client = getBaseClient(type) as unknown as CustomRedisClient<K>;
+
+  // Wire in-flight + duration instrumentation at the per-command chokepoint.
+  // 'cache' is the cluster client (wrap `_execute`), 'system' is the single
+  // sysRedis client (wrap `sendCommand`).
+  instrumentCommands(client, type === 'cache' ? 'cluster' : 'sys');
 
   // Create a separate client instance with Buffer type mapping for packed operations
   // `withTypeMapping` creates a NEW client instance - it doesn't modify the original client.

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -11,7 +11,7 @@ import {
 } from '~/server/utils/request-bulkhead';
 import { trpcProcedureDuration } from '~/server/prom/client';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withRedisCommandTimeout } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import { getFeatureFlags } from '~/server/services/feature-flags.service';
@@ -77,7 +77,11 @@ let clientConfigCache: { value: Record<string, string>; expiresAt: number } | nu
 async function getClientConfigCached(): Promise<Record<string, string>> {
   const now = Date.now();
   if (clientConfigCache && clientConfigCache.expiresAt > now) return clientConfigCache.value;
-  const client = await sysRedis.hGetAll(REDIS_SYS_KEYS.CLIENT);
+  // Per-command timeout (env REDIS_COMMAND_TIMEOUT_MS) so a stalled/half-open
+  // sysRedis can't park this hGetAll for ~30s. This read runs on EVERY web tRPC
+  // procedure; a TimeoutError here is caught by needsUpdate's try/catch below and
+  // fails open (skips the update banner), never a 500.
+  const client = await withRedisCommandTimeout(sysRedis).hGetAll(REDIS_SYS_KEYS.CLIENT);
   clientConfigCache = { value: client, expiresAt: now + CLIENT_CONFIG_TTL_MS };
   return client;
 }

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -5,6 +5,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { cacheHitCounter, cacheMissCounter, cacheRevalidateCounter } from '~/server/prom/client';
 import type { RedisKeyTemplateCache, RedisKeyTemplates } from '~/server/redis/client';
 import { redis, REDIS_KEYS, sysRedis } from '~/server/redis/client';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 
 export type CacheTarget = 'main' | 'sys';
 
@@ -424,6 +425,43 @@ type FetchThroughCacheOptions = {
   retryCount?: number;
 };
 type FetchThroughCacheEntity<T> = { data: T; cachedAt: number };
+
+/**
+ * Per-pod (per-process) single-flight map for the fail-open path ONLY.
+ *
+ * fetchThroughCache normally prevents an origin (DB/ClickHouse) stampede with a
+ * REDIS-backed distributed lock: only the lock-winner runs `fetchFn`, everyone else
+ * serves stale or waits. But that lock lives IN Redis — so when Redis itself stalls
+ * (the PR #2556 socketTimeout now turns a stalled read into a ~10s throw instead of a
+ * 30s-504), the lock is unreachable and the cross-pod single-flight is GONE. Several
+ * fetchThroughCache `fetchFn`s are expensive DB/ClickHouse aggregations (buzz pool
+ * SUM scans, featured-models, mod-rules, creator-program pool math). Naively
+ * catch-and-call-fetchFn on every request across ~80 pods would convert a Redis
+ * problem into a DB thundering-herd — a worse cascade.
+ *
+ * This map degrades that gracefully: during a Redis outage, concurrent requests for
+ * the SAME key on the SAME pod share ONE in-flight `fetchFn()` promise. That bounds
+ * origin load to ≤ (distinct keys × pods) concurrent origin calls instead of
+ * unbounded (× per-request concurrency). It is NOT cross-pod (that's what the Redis
+ * lock was for and Redis is down), but it removes the per-pod multiplier, which is the
+ * dominant term under a request flood. Entries are deleted as soon as the shared
+ * promise settles, so the map only ever holds currently-degraded keys.
+ */
+const failOpenInFlight = new Map<string, Promise<unknown>>();
+
+function fetchThroughCacheFailOpen<T>(key: string, fetchFn: () => Promise<T>): Promise<T> {
+  const existing = failOpenInFlight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  // Promise.resolve().then(fetchFn) so even a SYNCHRONOUS throw inside fetchFn becomes
+  // a rejected promise — guaranteeing the .finally cleanup runs and the map entry is
+  // always removed (no leaked/stuck in-flight entry).
+  const p = Promise.resolve().then(fetchFn).finally(() => {
+    failOpenInFlight.delete(key);
+  });
+  failOpenInFlight.set(key, p);
+  return p;
+}
+
 export async function fetchThroughCache<T>(
   key: RedisKeyTemplateCache,
   fetchFn: () => Promise<T>,
@@ -434,12 +472,38 @@ export async function fetchThroughCache<T>(
   const retryCount = options.retryCount ?? 3;
   const lockKey = `${REDIS_KEYS.CACHE_LOCKS}:${key}` as const;
 
-  const cachedData = await redis.packed.get<FetchThroughCacheEntity<T>>(key);
+  // --- Redis READ (cache lookup) -------------------------------------------------
+  // With the socketTimeout fix a stalled Redis read now THROWS (~10s) instead of
+  // hanging to the 30s Traefik 504. Fail OPEN: degrade to a slow-but-working origin
+  // fetch (single-flighted per pod to avoid a DB stampede — see failOpenInFlight)
+  // rather than propagating a 500 on these ~18 hot read paths. This is strictly no
+  // worse than today's behavior on the same paths (a Redis stall already meant a
+  // failed request); it just turns the failure mode from 500/504 into a slow 200.
+  let cachedData: FetchThroughCacheEntity<T> | null;
+  try {
+    cachedData = await redis.packed.get<FetchThroughCacheEntity<T>>(key);
+  } catch (err) {
+    logSysRedisFailOpen('read-degraded', 'fetchThroughCache get (cache cluster)', err, { key });
+    return fetchThroughCacheFailOpen(key, fetchFn);
+  }
+
   const cachedExpired =
     !cachedData || (cachedData && Date.now() - ttl * 1000 > cachedData.cachedAt);
   if (cachedExpired) {
+    // --- Redis LOCK (stampede guard) ---------------------------------------------
     // Try to set lock. If already locked, do nothing...
-    const gotLock = await redis.setNxKeepTtlWithEx(lockKey, '1', lockTTL);
+    let gotLock: boolean;
+    try {
+      gotLock = await redis.setNxKeepTtlWithEx(lockKey, '1', lockTTL);
+    } catch (err) {
+      // Lock acquisition itself hit a Redis error. We still have a fresh-enough
+      // intent to refresh, but the distributed lock is unavailable. Serve stale if we
+      // have it (cheapest, fully correct); otherwise fail open to a single-flighted
+      // origin fetch (per-pod bounded) instead of throwing a 500.
+      logSysRedisFailOpen('read-degraded', 'fetchThroughCache lock (cache cluster)', err, { key });
+      if (cachedData) return cachedData.data;
+      return fetchThroughCacheFailOpen(key, fetchFn);
+    }
     if (!gotLock) {
       if (cachedData) return cachedData.data;
       if (retryCount === 0) throw new Error('Failed to fetch data through cache');
@@ -454,13 +518,30 @@ export async function fetchThroughCache<T>(
     }
   } else if (cachedData) return cachedData.data;
 
+  // We hold the lock (or there is no lock contention): run the origin fetch and try
+  // to populate the cache. The fetch itself is NOT wrapped — a genuine fetchFn error
+  // is a real error and must propagate as before. Only the best-effort Redis writes
+  // (set result, release lock) are swallowed so a Redis stall on the WRITE side never
+  // turns a successful origin fetch into a 500.
   try {
     const data = await fetchFn();
     const toCache: FetchThroughCacheEntity<T> = { data, cachedAt: Date.now() };
-    await redis.packed.set(key, toCache, { EX: ttl * 2 });
+    try {
+      await redis.packed.set(key, toCache, { EX: ttl * 2 });
+    } catch (err) {
+      logSysRedisFailOpen('write-degraded', 'fetchThroughCache set (cache cluster)', err, { key });
+    }
     return data;
   } finally {
-    await redis.del(lockKey);
+    // Best-effort lock release; a failure here just leaves the lock to expire via its
+    // TTL (lockTTL). Never let it mask the fetch result or throw.
+    try {
+      await redis.del(lockKey);
+    } catch (err) {
+      logSysRedisFailOpen('write-degraded', 'fetchThroughCache del-lock (cache cluster)', err, {
+        key,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Root cause

api-primary has recurring **504 cascades** (several/day, ~15min, up to 74/s). They root-cause to the node-redis clients in `src/server/redis/client.ts` having **no socket-level and no per-command timeout** — only `connectTimeout` (`env.REDIS_TIMEOUT`), which applies **only during the connect handshake** and is cleared once the socket is ready.

On a **silent half-open** connection to a `next-redis-cluster` node (pod reschedule / failover / transient network blip — **no RST/FIN**), a queued command never rejects: no timeout is armed on the live socket, and node-redis's MOVED/ASK retry loop only fires on *received* error replies. Commands park **off-CPU in the node-redis command queue** (the event loop stays flat, all dependency server-metrics clean — the stall is client-side and was uninstrumented) until OS TCP keepalive finally kills the socket **~30s** later. All parked commands then reject at once. Each affected request had already hung to **Traefik's 30s ceiling → 504**. Because `redis` is a single shared cluster client read on ~every request path, **all routes hang together → broad cascade**.

This PR is **both the fix and the confirmation**: the new `redis_commands_inflight` gauge + duration histogram will, at the next cascade, show inflight climbing toward the queue ceiling and duration piling into the ~30s bucket — directly attributing the 30s park to Redis (and proving/refuting the socketTimeout fix).

## What changed (safety-ordered)

### 1. `socket.socketTimeout` — structural, all commands (`REDIS_SOCKET_TIMEOUT_MS`, default `10000`)
Set on both the cluster `defaults.socket` and the single `sysRedis` socket. node-redis v5 maps `socketTimeout` to **`net.Socket.setTimeout`**, an **idle timer reset by read OR write activity** on the live socket (any command write or any received reply resets it).

**Half-open teardown (the fix):** during a real stall the in-flight command is **PARKED in the node-redis command queue**, which **blocks every subsequent write** — including the keepalive PING. With no write and no reply, the idle timer runs to completion and tears the dead socket down in **~`REDIS_SOCKET_TIMEOUT_MS`** (≈10s) instead of ~30s OS TCP keepalive, so parked commands reject well under the 504 ceiling and the client reconnects. Set `REDIS_SOCKET_TIMEOUT_MS=0` to disable.

### 1b. `pingInterval` < `socketTimeout` — kill the idle spurious-fire (`REDIS_PING_INTERVAL_MS`, default `5000`) — **NEW (audit follow-up)**
**Correction to the original PR's claim.** The earlier comment said the 4-minute `pingInterval` "counts as traffic and keeps `socketTimeout` reset." That is **wrong**: `socketTimeout` is a 10s idle timer, and a **4-minute** ping cannot keep a **10s** timer reset. So a **HEALTHY but idle** per-node cluster connection (or the sys client) — off-peak, a cold slot range, a quiet pod — would go idle for >10s and fire `socketTimeout` on a **perfectly good node** → reconnect churn (self-healing via `reconnectStrategy`, but real and avoidable).

Fix: make the keepalive ping fire **comfortably under** `socketTimeout`. New env `REDIS_PING_INTERVAL_MS` (default 5s ≈ half of the 10s socketTimeout), applied to both the cluster and sysRedis client config. node-redis issues a `PING` every interval **only when the socket is otherwise idle** (a parked/in-flight command blocks it from being written); each PING is a **write+reply round-trip that resets the idle timer**. So:
- On a **healthy idle** socket the 5s PING keeps the 10s timer reset → **no spurious fire**.
- On a **half-open** socket the parked command blocks the PING write → the timer still runs to completion → **teardown preserved**.

**Invariant guard:** `client.ts` derives `pingInterval = min(REDIS_PING_INTERVAL_MS, floor(socketTimeout/2))`, so `pingInterval < socketTimeout` holds even if someone overrides the envs to a bad combination (e.g. ping ≥ socketTimeout would re-introduce the idle fire). The env-schema + `client.ts` comments were corrected accordingly.

**Verified against `@redis/client@5.8.3` + a real `redis-server`:**
- `pingInterval=3s` under `socketTimeout=10s`, idle → `PING`/`PONG` every 3s, **socketTimeout never fires** (ping resets the idle timer).
- 4-min ping under a short socketTimeout, fully idle → socketTimeout **DOES fire** at the timeout (confirms the original bug).
- node-redis half-open repro (server goes silent with a parked `get`, `pingInterval=5s`, `socketTimeout=10s`) → SocketTimeoutError fires at **exactly 10s**, i.e. the ping did NOT reset it because it was queued behind the parked command (confirms half-open teardown is preserved under the shorter ping).

PING load is trivial: one tiny command per *idle* node per interval (a few nodes × pods × ~0.2/s).

### 2. Per-command timeout — verified fail-open read only (`REDIS_COMMAND_TIMEOUT_MS`, default `2000`)
A per-command `timeout` in node-redis arms an `AbortSignal.timeout` that rejects a parked/slow command with a `TimeoutError`. Converting a stall into a throw is only safe where the caller **fails open**, so it is applied via the `withRedisCommandTimeout()` helper to exactly **one** site:

- `getClientConfigCached()` (`src/server/trpc.ts`) — the `sysRedis.hGetAll(CLIENT)` that runs on **every** web tRPC procedure. Its caller `needsUpdate` wraps it in try/catch and returns `false` on error → a `TimeoutError` becomes a skipped update-banner, **never a 500**.

### 3. `fetchThroughCache` fail-open + per-pod single-flight — **NEW (audit follow-up)**
`fetchThroughCache` (`src/server/utils/cache-helpers.ts`, ~18 hot user-facing read paths) previously did `redis.packed.get` / `setNxKeepTtlWithEx` / `redis.del` with **no try/catch**. With the new `socketTimeout`, a stalled Redis read now **throws at ~10s → a 500** (vs the old 30s-504). Both are bad; we now **fail open**: on a Redis read/lock error, degrade to calling the origin `fetchFn()` and return its result (a slow 200).

**Stampede consideration (the second-order risk).** `fetchThroughCache`'s stampede guard is a **Redis-backed distributed lock** (only the lock-winner runs `fetchFn`; everyone else serves stale or waits). That lock **lives in Redis** — so during a Redis stall the cross-pod single-flight is *gone*, and several of these `fetchFn`s are **expensive DB/ClickHouse aggregations** (buzz pool `SUM` scans, featured-models, mod-rules, creator-program pool math). A naive catch-and-call-`fetchFn` on every request across ~80 pods would convert a Redis problem into a **DB thundering-herd** — a worse cascade.

To bound that, the fail-open path runs through a **per-pod (per-process) in-process single-flight** (`failOpenInFlight`): concurrent requests for the **same key on the same pod** share **one** in-flight `fetchFn()` promise. This bounds origin load to ≤ (distinct keys × pods) concurrent origin calls instead of unbounded (× per-request concurrency). It is **not** cross-pod (that's what the now-unreachable Redis lock provided), but it removes the dominant per-pod multiplier. During a *full* Redis outage the origin still sees elevated (but bounded) load — that's the accepted, explicit trade-off for serving slow-200s instead of 500s.

Scope decisions:
- **All call sites fail open** through the single-flight, because the per-pod bound makes even the expensive aggregations safe-enough (≤1 concurrent origin call per key per pod) and a slow-200 is strictly better than a 500 on every one of these read paths.
- **Redis WRITES** (`setNxKeepTtlWithEx` lock release via `del`, and the result `packed.set`) failing are **swallowed best-effort** (the lock just expires via its TTL), never a 500.
- The origin **`fetchFn` error itself still propagates** unchanged — a genuine DB error is a real error, not something to mask.

All fail-open / write-degraded events are logged via the existing `logSysRedisFailOpen` pattern (`read-degraded` / `write-degraded` subtypes, tagged with the cache key).

### 4. Instrumentation — the confirmation (`src/server/prom/client.ts`)
- `redis_commands_inflight` gauge (label `client` ∈ `cluster`|`sys`) — inc before issue, dec in `finally`.
- `redis_command_duration_seconds` histogram (same label, buckets to 30s).

Wired at the per-command chokepoint in `client.ts`: **`_execute`** for the cluster client and **`sendCommand`** for the single `sysRedis` client. Low cardinality (one `client` label). Pipeline (`multi().exec()`) is counted as one inflight unit — acceptable for a stall/concurrency signal.

### 5. `disableOfflineQueue` — intentionally skipped
It would fast-reject (`ClientOfflineError`) into the fail-open paths, but the cache `redis` and `sysRedis` clients are read/written by **many non-fail-open callers** that would then throw to users during **routine brief reconnects**. socketTimeout + the targeted per-command timeout + the fetchThroughCache fail-open cover the stall without that blast radius.

## Env knobs
| Var | Default | Effect |
|---|---|---|
| `REDIS_SOCKET_TIMEOUT_MS` | `10000` | Socket idle/stall guard on both clients; `0` disables |
| `REDIS_PING_INTERVAL_MS` | `5000` | Keepalive ping; kept `< socketTimeout` (clamped to `min(env, socketTimeout/2)`) so a healthy idle socket never spuriously fires |
| `REDIS_COMMAND_TIMEOUT_MS` | `2000` | Per-command timeout on `getClientConfigCached`; `0` disables |

## Typecheck
`pnpm typecheck` does not fully run on the dev box (Prisma engine 404 → thousands of pre-existing errors in untouched files). Ran `tsc --noEmit` against the shared `node_modules`: **zero errors in `server-schema.ts` and `redis/client.ts`**; `cache-helpers.ts` shows only the **pre-existing `Prisma.Sql` 404 errors in `queryCache`** (lines 31/32/45/58/60), **none in the changed `fetchThroughCache` lines**. **Tekton is the real gate.**

## Rollout
All knobs env-tunable (no redeploy to widen/disable) → roll out as a canary; widen the per-command timeout or set it to `0`, or raise `REDIS_PING_INTERVAL_MS` / `REDIS_SOCKET_TIMEOUT_MS`, if anything looks tight. The socketTimeout protection stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
