### PR TITLE
feat(blocks): marketplace E2 — per-app detail page + getAppDetail (dark, mod-gated)

### DIFF
--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -1,5 +1,6 @@
-import { Badge, Button, Card, Group, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Badge, Button, Card, Group, Stack, Text, Title } from '@mantine/core';
 import { IconBolt, IconPlugConnected, IconSettings } from '@tabler/icons-react';
+import Link from 'next/link';
 import { useState } from 'react';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
@@ -55,9 +56,20 @@ export function AppBlockCard({
       <Stack gap="sm" h="100%">
         <Group justify="space-between" align="flex-start" wrap="nowrap">
           <Stack gap={2}>
-            <Title order={4} className="line-clamp-2">
-              {manifest.name ?? block.blockId}
-            </Title>
+            {/*
+              F-E E2: the card title links to the per-app detail page
+              (/apps/<appBlockId>). Install stays the secondary action below.
+            */}
+            <Anchor
+              component={Link}
+              href={`/apps/${block.id}`}
+              underline="never"
+              c="inherit"
+            >
+              <Title order={4} className="line-clamp-2">
+                {manifest.name ?? block.blockId}
+              </Title>
+            </Anchor>
             <Text size="xs" c="dimmed">
               by {block.appName ?? block.appId}
             </Text>
@@ -74,9 +86,11 @@ export function AppBlockCard({
           </Stack>
         </Group>
         {manifest.description && (
-          <Text size="sm" c="dimmed" className="line-clamp-3">
-            {manifest.description}
-          </Text>
+          <Anchor component={Link} href={`/apps/${block.id}`} underline="never" c="inherit">
+            <Text size="sm" c="dimmed" className="line-clamp-3">
+              {manifest.description}
+            </Text>
+          </Anchor>
         )}
         <Group justify="space-between" mt="auto" pt="xs">
           <Group gap={4}>

--- a/src/components/Apps/__tests__/resolveAppsPageAccess.test.ts
+++ b/src/components/Apps/__tests__/resolveAppsPageAccess.test.ts
@@ -37,3 +37,25 @@ describe('resolveAppsPageAccess — gating invariant', () => {
     expect(resolveAppsPageAccess({ features: { appBlocks: true } })).toEqual({ props: {} });
   });
 });
+
+/**
+ * F-E E2 — the per-app detail page (`/apps/<appBlockId>`) reuses the SAME
+ * `resolveAppsPageAccess` gate as the marketplace index. These cases pin that
+ * the detail page is flag-gated FIRST (no session→login redirect, no
+ * isModerator belt), so a real anon/non-mod gets `notFound` today and the page
+ * is anon-capable-but-dark — identical to the index. (Belt-and-suspenders: if
+ * the detail page ever swaps to a different/looser resolver, this fails.)
+ */
+describe('resolveAppsPageAccess — detail page (/apps/[appBlockId]) reuses the index gate', () => {
+  it('no flag + no session → notFound (the detail page stays dark for real anon)', () => {
+    expect(resolveAppsPageAccess({ features: { appBlocks: false } })).toEqual({ notFound: true });
+    expect(resolveAppsPageAccess({ features: undefined })).toEqual({ notFound: true });
+  });
+
+  it('flag granted + no session → renders (dark anon read path, never a redirect)', () => {
+    const result = resolveAppsPageAccess({ features: { appBlocks: true } });
+    expect(result).toEqual({ props: {} });
+    expect(result).not.toHaveProperty('redirect');
+    expect(result).not.toHaveProperty('notFound');
+  });
+});

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -1,0 +1,341 @@
+import {
+  Anchor,
+  Badge,
+  Button,
+  Card,
+  Center,
+  Container,
+  Divider,
+  Group,
+  List,
+  Loader,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
+import {
+  IconArrowLeft,
+  IconExternalLink,
+  IconLock,
+  IconPlugConnected,
+  IconSettings,
+  IconShieldCheck,
+} from '@tabler/icons-react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
+import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
+import { Meta } from '~/components/Meta/Meta';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type {
+  AvailableBlock,
+  PublicAppDetail,
+  SubscriptionRecord,
+  SubscriptionScope,
+} from '~/server/schema/blocks/subscription.schema';
+import {
+  SCOPE_DESCRIPTIONS,
+  SLOT_DESCRIPTIONS,
+} from '~/server/services/blocks/scope-descriptions.constants';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * F-E E2 — per-app marketplace detail page (`/apps/<appBlockId>`).
+ *
+ * 🔒 GATING INVARIANT (E2 — same as E1, do not violate):
+ *   - The SSR resolver runs `resolveAppsPageAccess` FIRST: the `features.appBlocks`
+ *     flag gate is the ONLY access control. A real anon / non-mod viewer does not
+ *     satisfy the mod-segmented Flipt `app-blocks-enabled` flag, so they get
+ *     `notFound`. The page is anon-CAPABLE in code (no session→login redirect)
+ *     but DARK until the segment is widened at launch — there is intentionally
+ *     NO hardcoded isModerator belt (that would break the eventual public flip).
+ *   - `deIndex` stays ON in the page <Meta> (per-app OG/title/description are
+ *     added now, but the page is not crawlable pre-launch — drop `deIndex` only
+ *     at launch).
+ *   - The `getAppDetail` query is the anon-capable public read path; it is gated
+ *     by the SAME mod-segmented flag server-side (dark today) and returns ONLY
+ *     the PublicAppDetail allowlist.
+ */
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  // Flag gate FIRST and ONLY (no session→login redirect): the detail page renders
+  // for a session-less request BEHIND the flag (dark today; lit at segment-widen).
+  resolver: async ({ features }) => resolveAppsPageAccess({ features }),
+});
+
+function slotLabel(slotId?: string): string {
+  switch (slotId) {
+    case 'model.sidebar_top':
+      return 'Model sidebar (top)';
+    case 'model.below_images':
+      return 'Below model images';
+    case 'model.actions_extra':
+      return 'Model action buttons';
+    default:
+      return slotId ?? 'Unknown slot';
+  }
+}
+
+export default function AppDetailPage() {
+  const features = useFeatureFlags();
+  const currentUser = useCurrentUser();
+  const router = useRouter();
+  const appBlockId = typeof router.query.appBlockId === 'string' ? router.query.appBlockId : '';
+
+  // Anon-CAPABLE public read path. Fires for any viewer the appBlocks flag
+  // grants (mods-only today). Returns ONLY the PublicAppDetail allowlist; a
+  // missing / non-approved id 404s server-side.
+  const { data, isLoading, error } = trpc.blocks.getAppDetail.useQuery(
+    { appBlockId },
+    { enabled: !!features.appBlocks && !!appBlockId, retry: false }
+  );
+
+  // Per-user subscription lookup so the CTA shows Manage vs Install. Guarded on
+  // a logged-in user — the dark anon read path must not fire this protected
+  // procedure (it 401s for anon). `features.appBlocks` alone isn't enough behind
+  // a widened segment.
+  const { data: mySubs } = trpc.blocks.listMySubscriptions.useQuery(undefined, {
+    enabled: !!features.appBlocks && !!currentUser,
+  });
+  const existingByScope = useMemo(() => {
+    const map: Partial<Record<SubscriptionScope, SubscriptionRecord>> = {};
+    for (const sub of mySubs ?? []) {
+      if (sub.appBlockId === appBlockId) map[sub.scope] = sub;
+    }
+    return map;
+  }, [mySubs, appBlockId]);
+  const alreadySubscribed = Object.keys(existingByScope).length > 0;
+
+  if (!features.appBlocks) return <NotFound />;
+
+  const detail = data as PublicAppDetail | undefined;
+  const name = detail?.manifest.name ?? detail?.blockId ?? appBlockId;
+  const description = detail?.manifest.description ?? '';
+  const slots = detail?.manifest.targets?.map((t) => t.slotId).filter(Boolean) ?? [];
+  const scopes = detail?.scopes ?? [];
+
+  function handleInstall() {
+    if (!detail) return;
+    // Reuse the E1 install path. PublicAppDetail is a superset of the listing
+    // shape, so build the AvailableBlock the settings modal expects. The modal
+    // sources settings/scopes from the authenticated getInstallConfig itself.
+    const block: AvailableBlock = {
+      id: detail.id,
+      blockId: detail.blockId,
+      appId: detail.appId,
+      appName: detail.appName,
+      manifest: detail.manifest,
+      installCount: detail.installCount,
+    };
+    openAppSettingsModal({ block, existingByScope });
+  }
+
+  // The query 404s (NOT_FOUND) for a missing / non-approved app. retry:false so
+  // the page settles into a NotFound rather than spinning on a hard 404.
+  if (error) return <NotFound />;
+
+  return (
+    <>
+      {/*
+        Per-app OG/meta (title + description from the public manifest). deIndex
+        STAYS ON until launch (the page is mod-only today; don't let crawlers
+        index it). Dropping deIndex is a deliberate launch-time step.
+      */}
+      <Meta
+        title={`${name} — Civitai Apps`}
+        description={description || `${name} on the Civitai App Blocks marketplace.`}
+        deIndex
+      />
+      <Container size="md" py="md">
+        <Stack gap="lg">
+          <Anchor component={Link} href="/apps" size="sm">
+            <Group gap={4}>
+              <IconArrowLeft size={14} />
+              Back to marketplace
+            </Group>
+          </Anchor>
+
+          {isLoading ? (
+            <Center py="xl">
+              <Loader />
+            </Center>
+          ) : !detail ? (
+            <NotFound />
+          ) : (
+            <Stack gap="lg">
+              {/* Header */}
+              <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <Stack gap={4}>
+                  <Title order={2}>{name}</Title>
+                  <Text c="dimmed" size="sm">
+                    by {detail.appName ?? detail.appId}
+                  </Text>
+                  <Group gap="xs" mt={4}>
+                    <Badge variant="light" color="gray" size="sm">
+                      {detail.installCount.toLocaleString()} install
+                      {detail.installCount === 1 ? '' : 's'}
+                    </Badge>
+                    {detail.version && (
+                      <Badge variant="light" color="gray" size="sm">
+                        v{detail.version}
+                      </Badge>
+                    )}
+                    {detail.contentRating && (
+                      <Badge variant="light" color="gray" size="sm">
+                        {detail.contentRating}
+                      </Badge>
+                    )}
+                  </Group>
+                </Stack>
+                <Group gap="xs" wrap="nowrap">
+                  <Button
+                    component="a"
+                    href={detail.liveUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="default"
+                    leftSection={<IconExternalLink size={16} />}
+                  >
+                    Open live
+                  </Button>
+                  {/*
+                    Install CTA — reuses the E1 sign-in-gated path: anon → the
+                    LoginModal (via LoginRedirect); logged-in → the install/
+                    settings modal. Dark today (page is mod-gated).
+                  */}
+                  <LoginRedirect reason="perform-action">
+                    <Button
+                      leftSection={
+                        alreadySubscribed ? (
+                          <IconSettings size={16} />
+                        ) : (
+                          <IconPlugConnected size={16} />
+                        )
+                      }
+                      variant={alreadySubscribed ? 'default' : 'filled'}
+                      onClick={handleInstall}
+                    >
+                      {alreadySubscribed ? 'Manage' : 'Install'}
+                    </Button>
+                  </LoginRedirect>
+                </Group>
+              </Group>
+
+              {description && (
+                <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                  {description}
+                </Text>
+              )}
+
+              <Divider />
+
+              {/* Live preview — a sandboxed iframe of the already-public
+                  standalone block origin (detail.liveUrl). See the tradeoff
+                  note in the page docstring / PR: this avoids introducing any
+                  new anon-token or scope-exposure path that an in-page block
+                  host (model-context + minted block JWT) would require. */}
+              <Stack gap="xs">
+                <Title order={4}>Live preview</Title>
+                <Card withBorder padding={0} radius="md" style={{ overflow: 'hidden' }}>
+                  <iframe
+                    src={detail.liveUrl}
+                    title={`${name} live preview`}
+                    // Minimal sandbox: allow the block's own scripts + same-origin
+                    // (it's served from its own subdomain), nothing else. No
+                    // top-navigation, no popups, no form submission.
+                    sandbox="allow-scripts allow-same-origin"
+                    referrerPolicy="no-referrer"
+                    loading="lazy"
+                    style={{
+                      width: '100%',
+                      height: 420,
+                      border: 0,
+                      display: 'block',
+                    }}
+                  />
+                </Card>
+                <Text size="xs" c="dimmed">
+                  Preview of the standalone block at{' '}
+                  <Anchor href={detail.liveUrl} target="_blank" rel="noopener noreferrer">
+                    {detail.liveUrl.replace(/^https?:\/\//, '')}
+                  </Anchor>
+                  . The live block on a model page runs with your granted permissions; this
+                  standalone preview does not.
+                </Text>
+              </Stack>
+
+              <Divider />
+
+              {/* Permissions disclosure — the approved scopes, rendered via
+                  SCOPE_DESCRIPTIONS (closes the H3 "no permission disclosure at
+                  decision time" gap at the marketplace level). */}
+              <Stack gap="xs">
+                <Group gap="xs">
+                  <ThemeIcon variant="light" color="blue" size="sm" radius="xl">
+                    <IconShieldCheck size={14} />
+                  </ThemeIcon>
+                  <Title order={4}>This app can…</Title>
+                </Group>
+                {scopes.length === 0 ? (
+                  <Text size="sm" c="dimmed">
+                    This app does not request any permissions.
+                  </Text>
+                ) : (
+                  <List
+                    spacing="xs"
+                    size="sm"
+                    icon={
+                      <ThemeIcon variant="light" color="gray" size="sm" radius="xl">
+                        <IconLock size={12} />
+                      </ThemeIcon>
+                    }
+                  >
+                    {scopes.map((scope) => (
+                      <List.Item key={scope}>
+                        {SCOPE_DESCRIPTIONS[scope] ?? scope}
+                      </List.Item>
+                    ))}
+                  </List>
+                )}
+              </Stack>
+
+              <Divider />
+
+              {/* Target slots — where the block mounts, via SLOT_DESCRIPTIONS. */}
+              <Stack gap="xs">
+                <Title order={4}>Appears in</Title>
+                {slots.length === 0 ? (
+                  <Text size="sm" c="dimmed">
+                    This app declares no target slots.
+                  </Text>
+                ) : (
+                  <List spacing="xs" size="sm">
+                    {slots.map((slotId) => (
+                      <List.Item key={slotId}>
+                        <Text component="span" fw={500}>
+                          {slotLabel(slotId)}
+                        </Text>
+                        {SLOT_DESCRIPTIONS[slotId as string] && (
+                          <Text component="span" c="dimmed">
+                            {' '}
+                            — {SLOT_DESCRIPTIONS[slotId as string]}
+                          </Text>
+                        )}
+                      </List.Item>
+                    ))}
+                  </List>
+                )}
+              </Stack>
+            </Stack>
+          )}
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * F-E E2 — `blocks.getAppDetail` router coverage: the anon-capable per-app
+ * detail read path that backs `/apps/<appBlockId>`.
+ *
+ * `isAppBlocksEnabled` is mocked with a FAITHFUL per-user implementation
+ * (mirrors the live `moderators`-segmented flag: ON only when the supplied user
+ * is a moderator). The test drives the REAL blocks router so the middleware's
+ * `{ user: ctx.user }` wiring is what decides the outcome. `BlockRegistry` is
+ * mocked at the module boundary so this suite exercises the router's gate +
+ * NOT_FOUND mapping (the projection/security is covered by the service test
+ * `block-registry.get-app-detail.test.ts`).
+ *
+ * GATING INVARIANT pinned here (FAILS if regressed):
+ *   - anon WITHOUT the flag → NOT_FOUND, registry NEVER consulted (DARK today).
+ *   - non-mod WITHOUT the flag → NOT_FOUND, registry NEVER consulted.
+ *   - anon WITH the flag granted (the lit path post-segment-widen) → served;
+ *     proves it is anon-CAPABLE, NOT mod-only — there is NO isModerator belt.
+ *   - moderator (the live state) → served.
+ *   - a non-approved / missing app → NOT_FOUND (service returns null).
+ */
+
+const { mockIsAppBlocksEnabled, mockGetAppDetail } = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockGetAppDetail: vi.fn(),
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    getAppDetail: (...a: unknown[]) => mockGetAppDetail(...a),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/textToImage/textToImage', () => ({
+  createTextToImageStep: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn() },
+  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+// rateLimit pulls in heavy deps (redis + caches → stale Prisma client in a
+// fresh worktree). Stub it to a pass-through middleware built from the real
+// lightweight factory; the gate under test is the flag middleware.
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: !!(user as { isModerator?: boolean })?.isModerator } as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+
+const PUBLIC_DETAIL = {
+  id: 'ab_1',
+  blockId: 'cool-block',
+  appId: 'app_1',
+  appName: 'Cool App',
+  manifest: { name: 'Cool Block', description: 'd', targets: [{ slotId: 'model.sidebar_top' }] },
+  scopes: ['ai:write:budgeted'],
+  contentRating: 'PG',
+  version: '1.0.0',
+  installCount: 3,
+  liveUrl: 'https://cool-block.civit.ai',
+};
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockGetAppDetail.mockReset();
+  mockGetAppDetail.mockResolvedValue(PUBLIC_DETAIL);
+});
+
+const input = { appBlockId: 'ab_1' };
+
+describe('blocks.getAppDetail — anon-capable, dark behind the flag (F-E E2)', () => {
+  it('anon WITHOUT the flag: gate disables → NOT_FOUND, registry NOT consulted (dark today)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getAppDetail(input)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockGetAppDetail).not.toHaveBeenCalled();
+    expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: undefined });
+  });
+
+  it('non-mod WITHOUT the flag: gate disables → NOT_FOUND, registry NOT consulted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.getAppDetail(input)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockGetAppDetail).not.toHaveBeenCalled();
+  });
+
+  it('anon WITH the flag granted (lit path): served — proves anon-CAPABLE, no isModerator belt', async () => {
+    // Simulate the post-launch segment widen: the flag resolves ON even with no
+    // user. getAppDetail is publicProcedure; there is NO secondary isModerator
+    // gate left to block this. (This test FAILS if an isModerator belt is added.)
+    mockIsAppBlocksEnabled.mockResolvedValue(true);
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.getAppDetail(input);
+    expect(result).toEqual(PUBLIC_DETAIL);
+    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1');
+  });
+
+  it('moderator (the live state today): served', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getAppDetail(input);
+    expect(result).toEqual(PUBLIC_DETAIL);
+    expect(mockGetAppDetail).toHaveBeenCalledTimes(1);
+  });
+
+  it('NOT_FOUND when the service returns null (missing / non-approved app)', async () => {
+    mockGetAppDetail.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.getAppDetail(input)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -10,6 +10,7 @@ import { getUserBuzzAccounts } from '~/server/services/buzz.service';
 import { manifestSettingsSchema } from '~/server/schema/blocks/manifest-settings.meta.schema';
 import { validateBlockSettings } from '~/server/services/blocks/settings-validator.service';
 import {
+  getAppDetailSchema,
   listAvailableSchema,
   subscriptionScopeSchema,
 } from '~/server/schema/blocks/subscription.schema';
@@ -932,6 +933,60 @@ export const blocksRouter = router({
         return { items: [], nextCursor: undefined };
       }
       return BlockRegistry.listAvailable(input);
+    }),
+
+  /**
+   * Per-app marketplace DETAIL — one approved app block, keyed on appBlockId.
+   * Public, ANON-CAPABLE (F-E E2): backs the `/apps/<appBlockId>` detail page so
+   * a viewer can evaluate an app (description, requested scopes, slots, content
+   * rating, install count, version, live preview) before installing.
+   *
+   * GATING INVARIANT (E2) — anon-capable but DARK until launch (same as E1):
+   *   - `enforceAppBlocksFlag` runs FIRST. For a real anon / non-mod viewer the
+   *     mod-segmented `app-blocks-enabled` flag never matches → the middleware
+   *     marks `_appBlocksDisabled` → this query returns NOT_FOUND (so a dark
+   *     viewer sees the same 404 the page's SSR gate produces; no detail leaks).
+   *     The procedure only serves real anon callers once the SEGMENT is widened
+   *     at launch (a deliberate, separate Flipt change). There is intentionally
+   *     NO hardcoded isModerator belt — the flag is the gate by design, so the
+   *     eventual public launch is a pure segment-widen.
+   *
+   * EXPOSURE / SECURITY (what an anon caller can fetch once the segment widens):
+   *   - ONLY a `status='approved'` app — a missing OR non-approved (pending/
+   *     rejected/withdrawn) id returns NOT_FOUND, never its data. This blocks
+   *     id-enumeration of unapproved apps.
+   *   - ONLY the PublicAppDetail allowlist (see the type): the manifest is the
+   *     same `toPublicBlockManifest` subset as the listing (name/description/
+   *     targets[].slotId) — the raw manifest's internal fields (trustTier,
+   *     internal iframe.src, renderMode, settings internals, raw scopes) are
+   *     NEVER shipped. `scopes` are the approved scope ids (the permission
+   *     disclosure); `liveUrl` is the already-public standalone block origin
+   *     (no token / scope attached).
+   *   - No per-user data.
+   *
+   * Anon rate-limiting: same posture as `listAvailable` (keyed on IP for anon;
+   * mods/dev/test exempt by the middleware).
+   */
+  getAppDetail: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .use(
+      rateLimit({
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many marketplace requests — slow down.',
+      })
+    )
+    .input(getAppDetailSchema)
+    .query(async ({ ctx, input }) => {
+      // Dark-flag fail-closed: while the appBlocks flag is off the middleware
+      // marks the ctx and we surface NOT_FOUND (matching the page SSR gate),
+      // never the app's data.
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        throw throwNotFoundError('App block not found');
+      }
+      const detail = await BlockRegistry.getAppDetail(input.appBlockId);
+      if (!detail) throw throwNotFoundError('App block not found');
+      return detail;
     }),
 
   /**

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -182,3 +182,52 @@ export const listAvailableSchema = z.object({
   limit: z.number().int().min(1).max(50).default(20),
 });
 export type ListAvailableInput = z.infer<typeof listAvailableSchema>;
+
+/** Input for the anon-capable `blocks.getAppDetail` (F-E E2). */
+export const getAppDetailSchema = z.object({
+  appBlockId: z.string().min(1).max(64),
+});
+export type GetAppDetailInput = z.infer<typeof getAppDetailSchema>;
+
+/**
+ * PUBLIC per-app detail shape returned by the anon-capable
+ * `blocks.getAppDetail` (F-E E2 marketplace detail page).
+ *
+ * 🔒 ANON-EXPOSURE ALLOWLIST. This is shipped to a session-less caller (behind
+ * the mod-segmented flag — dark today), so it must carry ONLY public,
+ * display-safe data. It is a deliberately NARROW superset of the listing shape
+ * (`AvailableBlock`) — every added field below is publisher-display-safe:
+ *   - `manifest`     — the SAME `PublicBlockManifest` allowlist as the listing
+ *                      (via `toPublicBlockManifest`); the raw stored manifest
+ *                      (with `trustTier`, internal `iframe.src`, `renderMode`,
+ *                      settings internals, raw `scopes`) is NEVER shipped.
+ *   - `scopes`       — the app's APPROVED scope ids (`approved_scopes` column),
+ *                      surfaced so the detail page can render the permission
+ *                      disclosure via SCOPE_DESCRIPTIONS. These are plain scope
+ *                      identifier strings (e.g. `ai:write:budgeted`), not the
+ *                      manifest's internal declaration — safe to disclose since
+ *                      they describe what the app can do, which is the whole
+ *                      point of the disclosure.
+ *   - `contentRating`— the platform content-rating string (already gates which
+ *                      slots a block may mount; display-safe).
+ *   - `version`      — the approved version string.
+ *   - `installCount` — distinct-user install count (same as the listing).
+ *   - `liveUrl`      — the PUBLIC standalone block URL (`https://<slug>.<APPS_
+ *                      DOMAIN>`), the same already-public origin the host
+ *                      iframes. Built server-side from the blockId + APPS_DOMAIN
+ *                      so the client never needs the domain. No token, no scope.
+ *
+ * Add a field here ONLY after confirming it is publisher-display-safe for anon.
+ */
+export type PublicAppDetail = {
+  id: string;
+  blockId: string;
+  appId: string;
+  appName: string | null;
+  manifest: PublicBlockManifest;
+  scopes: string[];
+  contentRating: string | null;
+  version: string | null;
+  installCount: number;
+  liveUrl: string;
+};

--- a/src/server/services/__tests__/block-registry.get-app-detail.test.ts
+++ b/src/server/services/__tests__/block-registry.get-app-detail.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * F-E E2 — anon-exposure security tests for the per-app detail
+ * (`BlockRegistry.getAppDetail`, served by the anon-capable
+ * `blocks.getAppDetail` publicProcedure that backs `/apps/<appBlockId>`).
+ *
+ * The detail page is anon-CAPABLE (dark today behind the mod-segmented flag,
+ * lit at launch by widening the segment). These tests pin the exposure
+ * protections so they FAIL if any regresses:
+ *
+ *   1. APPROVED-ONLY — a non-approved (pending/rejected/withdrawn) OR missing
+ *      app returns `null` (→ the router maps null to NOT_FOUND). A non-approved
+ *      app's data can never be enumerated by id.
+ *   2. PUBLIC MANIFEST ALLOWLIST — the raw stored `manifest` jsonb is arbitrary
+ *      publisher JSON + server-SET internal fields (`trustTier`, internal
+ *      `iframe.src`, `renderMode`, `settings`, raw `scopes`, …). The detail
+ *      must project ONLY the vetted public subset (name/description/
+ *      targets[].slotId) — never the raw manifest.
+ *   3. SCOPES are the APPROVED scope ids (the permission-disclosure list), NOT
+ *      the manifest's internal declaration.
+ *   4. liveUrl is the already-public standalone origin (`<slug>.<APPS_DOMAIN>`),
+ *      built from blockId + APPS_DOMAIN — no token / secret.
+ *
+ * We don't run the query (no DB in unit tests). We mock dbRead.$queryRaw to
+ * capture the SQL + return seeded rows so we can assert the projected SHAPE.
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    blockUserSubscription: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    modelVersion: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  },
+  sysRedis: { sMembers: vi.fn(async () => []) },
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'packed:caches:block-registry', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+// getAppDetail builds liveUrl from `env.APPS_DOMAIN` via a dynamic import of
+// `~/env/server` — stub it so the test doesn't pull the real env schema.
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+
+/** Reconstructs the SQL string from the tagged-template args Prisma received. */
+function capturedSql(): string {
+  expect(mockDbRead.$queryRaw).toHaveBeenCalled();
+  const lastCall = mockDbRead.$queryRaw.mock.calls.at(-1);
+  if (!lastCall) return '';
+  const strings = lastCall[0] as unknown as TemplateStringsArray;
+  const values = lastCall.slice(1);
+  let sql = '';
+  for (let i = 0; i < strings.length; i++) {
+    sql += strings[i];
+    if (i < values.length) sql += `$${i + 1}`;
+  }
+  return sql;
+}
+
+/**
+ * One raw DB row (snake_case, as returned by $queryRaw). The `manifest`
+ * deliberately carries private/internal fields a malicious/careless publisher
+ * (or the server's own trustTier stamp) could put there — the projection must
+ * strip every one. `approved_scopes` is the SEPARATE approved-scope column.
+ */
+function rawRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_1',
+    block_id: 'cool-block',
+    app_id: 'app_1',
+    app_name: 'Cool App',
+    status: 'approved',
+    content_rating: 'PG',
+    version: '1.2.3',
+    approved_scopes: ['ai:write:budgeted', 'models:read:self'],
+    install_count: 7n,
+    manifest: {
+      name: 'Cool Block',
+      description: 'Does cool things',
+      targets: [{ slotId: 'model.sidebar_top', secretCfg: 'leak-me' }],
+      // --- private / internal fields that MUST NOT leak to anon ---
+      trustTier: 'internal',
+      iframe: { src: 'https://cool-block.internal.example/', sandbox: 'allow-scripts' },
+      renderMode: 'iframe',
+      // The manifest's OWN scopes declaration — distinct from approved_scopes;
+      // it must not leak (we surface approved_scopes instead).
+      scopes: ['ai:write:budgeted', 'social:tip:self', 'INTERNAL_secret_scope'],
+      settings: { apiKey: 'super-secret' },
+      arbitraryPublisherField: { nested: 'secret' },
+    },
+    ...over,
+  };
+}
+
+describe('BlockRegistry.getAppDetail — anon-exposure protections (F-E E2)', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([rawRow()]);
+  });
+
+  it('returns the public projection for an approved app', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail).not.toBeNull();
+    expect(detail).toMatchObject({
+      id: 'ab_1',
+      blockId: 'cool-block',
+      appId: 'app_1',
+      appName: 'Cool App',
+      contentRating: 'PG',
+      version: '1.2.3',
+      installCount: 7,
+      liveUrl: 'https://cool-block.civit.ai',
+    });
+    expect(detail!.manifest.name).toBe('Cool Block');
+    expect(detail!.manifest.description).toBe('Does cool things');
+    expect(detail!.manifest.targets).toEqual([{ slotId: 'model.sidebar_top' }]);
+  });
+
+  it('scopes come from approved_scopes (the disclosure list), not the manifest', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.scopes).toEqual(['ai:write:budgeted', 'models:read:self']);
+    // Manifest-declared scopes (incl. an internal one) are NOT surfaced.
+    expect(detail!.scopes).not.toContain('social:tip:self');
+    expect(detail!.scopes).not.toContain('INTERNAL_secret_scope');
+  });
+
+  it('returns null for a NON-APPROVED app — never its data (no id-enumeration)', async () => {
+    for (const status of ['pending', 'rejected', 'withdrawn', 'disabled']) {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([rawRow({ status })]);
+      const { BlockRegistry } = await import('../block-registry.service');
+      const detail = await BlockRegistry.getAppDetail('ab_1');
+      expect(detail, `status="${status}" must not return data`).toBeNull();
+    }
+  });
+
+  it('returns null for a missing app', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    expect(await BlockRegistry.getAppDetail('ab_missing')).toBeNull();
+  });
+
+  it('projects ONLY the public allowlist — no private/internal manifest field leaks', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    const manifest = detail!.manifest as Record<string, unknown>;
+
+    for (const forbidden of [
+      'trustTier',
+      'iframe',
+      'renderMode',
+      'scopes',
+      'settings',
+      'arbitraryPublisherField',
+    ]) {
+      expect(manifest, `manifest leaked "${forbidden}"`).not.toHaveProperty(forbidden);
+    }
+    // Per-target fields beyond slotId are dropped (no nested config leak).
+    const target0 = (manifest.targets as Array<Record<string, unknown>>)[0];
+    expect(Object.keys(target0)).toEqual(['slotId']);
+  });
+
+  it('the serialized result contains NO secret value (mutation-test the projection)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    const serialized = JSON.stringify(detail);
+    for (const secret of [
+      'super-secret', // manifest.settings.apiKey
+      'internal.example', // manifest.iframe.src host
+      'leak-me', // manifest.targets[0].secretCfg
+      'INTERNAL_secret_scope', // manifest.scopes internal entry
+    ]) {
+      expect(serialized, `serialized output leaked "${secret}"`).not.toContain(secret);
+    }
+  });
+
+  it('top-level shape is the PublicAppDetail allowlist only (no status/raw leak)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(Object.keys(detail!).sort()).toEqual(
+      [
+        'appId',
+        'appName',
+        'blockId',
+        'contentRating',
+        'id',
+        'installCount',
+        'liveUrl',
+        'manifest',
+        'scopes',
+        'version',
+      ].sort()
+    );
+    // `status` is a DB-internal field; it must never appear on the wire shape.
+    expect(detail!).not.toHaveProperty('status');
+    // The raw manifest internals (re-checked at the top level just in case).
+    expect(detail!).not.toHaveProperty('trustTier');
+  });
+
+  it('liveUrl is the already-public standalone origin (no token/secret)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.liveUrl).toBe('https://cool-block.civit.ai');
+    expect(detail!.liveUrl).not.toMatch(/token|jwt|secret|\?/i);
+  });
+
+  it('a NULL approved_scopes column yields an empty scope list (no crash)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([rawRow({ approved_scopes: null })]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.scopes).toEqual([]);
+  });
+
+  it('a malformed/missing manifest yields an empty public manifest (no crash, no leak)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      rawRow({ manifest: null }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.manifest).not.toHaveProperty('trustTier');
+    expect(detail!.manifest).toEqual({});
+  });
+
+  it('looks up by id (single approved row by appBlockId)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.getAppDetail('ab_1');
+    const sql = capturedSql();
+    expect(sql).toMatch(/FROM app_blocks ab/);
+    expect(sql).toMatch(/WHERE ab\.id =/);
+  });
+});

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -1,3 +1,4 @@
+import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { manifestSettingsSchema } from '~/server/schema/blocks/manifest-settings.meta.schema';
@@ -2294,7 +2295,6 @@ export class BlockRegistry {
     // a non-approved row returns null exactly like a missing one — never its
     // data. (The marketplace install mutations apply the same approved gate.)
     if (!row || row.status !== 'approved') return null;
-    const { env } = await import('~/env/server');
     return {
       id: row.id,
       blockId: row.block_id,

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -20,6 +20,7 @@ import {
 import type {
   AvailableBlock,
   ListAvailableInput,
+  PublicAppDetail,
   SubscriptionRecord,
   SubscriptionScope,
 } from '~/server/schema/blocks/subscription.schema';
@@ -2233,6 +2234,86 @@ export class BlockRegistry {
         installCount: Number(r.install_count),
       })),
       nextCursor,
+    };
+  }
+
+  /**
+   * Per-app marketplace detail (F-E E2). Anon-CAPABLE, but the router gates it
+   * behind the mod-segmented appBlocks flag (dark today).
+   *
+   * 🔒 ANON-EXPOSURE — returns ONLY the PublicAppDetail allowlist for a single
+   * `status='approved'` app:
+   *   - `manifest` is projected through `toPublicBlockManifest` (name/description
+   *     /targets[].slotId only) — the raw stored manifest (trustTier, internal
+   *     iframe.src, renderMode, settings internals, raw scopes) is NEVER shipped.
+   *   - `scopes` are the APPROVED scope ids (`approved_scopes` column) — the
+   *     permission disclosure list, safe to show.
+   *   - `liveUrl` is the already-public standalone block origin, built here from
+   *     `blockId` + `env.APPS_DOMAIN` (the SAME host the webhook validates the
+   *     bundle's iframe against), so the client never needs the domain. No
+   *     token / scope is attached.
+   *
+   * Returns `null` for a missing OR non-approved (pending/rejected/withdrawn)
+   * app — the router maps that to NOT_FOUND so a non-approved app's data can
+   * never be enumerated by id.
+   */
+  static async getAppDetail(appBlockId: string): Promise<PublicAppDetail | null> {
+    type Row = {
+      id: string;
+      block_id: string;
+      app_id: string;
+      app_name: string | null;
+      manifest: unknown;
+      status: string;
+      content_rating: string | null;
+      version: string | null;
+      approved_scopes: string[] | null;
+      install_count: bigint;
+    };
+    const rows = (await dbRead.$queryRaw<Row[]>`
+      SELECT
+        ab.id,
+        ab.block_id,
+        ab.app_id,
+        oc.name AS app_name,
+        ab.manifest,
+        ab.status,
+        ab.content_rating,
+        ab.version,
+        ab.approved_scopes,
+        (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
+         WHERE bus.app_block_id = ab.id) AS install_count
+      FROM app_blocks ab
+      LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
+      WHERE ab.id = ${appBlockId}::text
+      LIMIT 1
+    `) as Row[];
+    const row = rows[0];
+    // Status check is in the application layer (not the WHERE clause) ONLY so a
+    // future caller can't accidentally reuse this method for a non-public path;
+    // a non-approved row returns null exactly like a missing one — never its
+    // data. (The marketplace install mutations apply the same approved gate.)
+    if (!row || row.status !== 'approved') return null;
+    const { env } = await import('~/env/server');
+    return {
+      id: row.id,
+      blockId: row.block_id,
+      appId: row.app_id,
+      appName: row.app_name ?? null,
+      // PUBLIC allowlist projection — identical to the listing path so the two
+      // can't drift in what they expose.
+      manifest: toPublicBlockManifest(row.manifest),
+      // Approved scope ids only — the permission disclosure list. Defensive
+      // against a NULL column (pre-approval rows) → empty list.
+      scopes: Array.isArray(row.approved_scopes)
+        ? row.approved_scopes.filter((s): s is string => typeof s === 'string')
+        : [],
+      contentRating: row.content_rating ?? null,
+      version: row.version ?? null,
+      installCount: Number(row.install_count),
+      // Already-public standalone origin (no token/scope). Same host the webhook
+      // validates the submitted bundle's iframe.src against.
+      liveUrl: `https://${row.block_id}.${env.APPS_DOMAIN}`,
     };
   }
 }


### PR DESCRIPTION
## F-E E2 — per-app detail page + `getAppDetail` + live preview

Builds on the merged E1 (PR #2554). Adds a destination to evaluate an app before installing, a new anon-capable public read procedure, and a live block preview. Closes audit C2 (no detail page) and the marketplace-level part of H3 (permissions at decision time).

Plan: `claudedocs/app-platform-fe-marketplace-plan-2026-06-14.md` → Phase E2.

### 🔒 Gating invariant (UNCHANGED from E1 — nothing user-visible)
Everything stays **mods-only / dark** until a separate, product-signed-off launch flip.
- The detail page SSR resolver runs `resolveAppsPageAccess` (the E1 helper) **FIRST**: `features.appBlocks` is the **only** access control. A real anon / non-mod doesn't satisfy the mod-segmented Flipt `app-blocks-enabled` flag, so they get `notFound` today. The page is anon-*capable* in code (no session→login redirect) but dark until the segment widens.
- **`deIndex` stays ON** on the detail page. Per-app OG/title/description are added now; dropping `deIndex` is a launch-time step.
- **No Flipt / segment change.** **No hardcoded `isModerator` belt** — the flag is the gate by design, so the eventual public launch is a pure segment-widen. (A router test asserts the lit path serves anon, which would fail if a belt were added.)

### `getAppDetail` anon-exposure security analysis
`blocks.getAppDetail(appBlockId)` is a NEW `publicProcedure.use(enforceAppBlocksFlag).use(rateLimit 60/60)`. Exactly what it exposes (the `PublicAppDetail` allowlist), and nothing else:

| Field | Source | Why it's safe to disclose |
|---|---|---|
| `id`, `blockId`, `appId`, `appName` | row / OauthClient | already on the E1 listing |
| `manifest` | `toPublicBlockManifest(raw)` (the **E1 allowlist**, not widened) | only `name` / `description` / `targets[].slotId`; raw manifest internals dropped |
| `scopes` | `approved_scopes` column | the permission-disclosure list (what the app can do) — rendered via `SCOPE_DESCRIPTIONS`. The manifest's own internal `scopes` declaration is **not** surfaced |
| `contentRating` | `content_rating` column | platform rating string (already gates slot eligibility) |
| `version` | `version` column | approved version string |
| `installCount` | `COUNT(DISTINCT user_id)` | same as the listing |
| `liveUrl` | built server-side: `https://<blockId>.<env.APPS_DOMAIN>` | the **already-public** standalone block origin (the same host the publish webhook validates the bundle's iframe.src + allowedOrigins against). No token / scope attached |

Protections, and how they're verified (tests fail if any regresses):
- **Approved-only / no id-enumeration.** A missing OR non-approved (pending/rejected/withdrawn/disabled) app returns `null` → router maps to `NOT_FOUND`. Status is checked in the service, never returned.
- **No private leak.** `trustTier`, internal `iframe.src`, `renderMode`, `settings`, the raw manifest `scopes`, and arbitrary publisher fields are dropped by reusing the E1 `toPublicBlockManifest` projection — **not widened**. A **mutation/serialization test** seeds those secrets into the row and asserts none appear in the result object *or* its JSON-serialized output.
- **Dark behind the flag.** `enforceAppBlocksFlag` runs first; while dark the query returns `NOT_FOUND` and the registry is never consulted (no data fetched). Anon/non-mod can't reach it today.

### Live-preview approach + tradeoff
**A minimal sandboxed `<iframe sandbox="allow-scripts allow-same-origin" referrerPolicy="no-referrer">` of the standalone block origin (`liveUrl`).**

Considered reusing the in-page block host (`BlockSlotClient` / `useBlockToken`), but it is bound to a **model context** (`modelId`/`slotId`) and mints a **block-scoped JWT** via `POST /api/v1/block-tokens`. Driving it from a marketplace detail page would require a synthetic model context + a new token-issuance path — i.e. a **new anon-token / scope-exposure surface**, which the task explicitly forbids. The iframe embeds an origin that is *already public* (the same URL `/apps/my-submissions` links to) and attaches **no token/scope**. Tradeoff: the preview is the standalone block, not the in-context (model-bound, permissioned) render — noted in the UI copy. It only renders behind the flag gate anyway (dark today).

### Other changes
- `/apps/[appBlockId]/index.tsx` (SSR, flag-gated, deIndex, per-app OG). Renders name, publisher, description, **permissions** via `SCOPE_DESCRIPTIONS` ("This app can…"), **slots** via `SLOT_DESCRIPTIONS`, content rating, install count, version, "Open live", the E1 sign-in-gated Install CTA (anon → LoginModal; mod → AppSettingsModal), and the live preview.
- `AppBlockCard`: title + description now link to `/apps/<appBlockId>`; Install stays secondary.

### Test coverage (node `unit` project — green locally)
- `block-registry.get-app-detail.test.ts` (11): public projection; **scopes from `approved_scopes`, not the manifest**; `null` for each non-approved status + missing; allowlist-only (no private field); **serialized-output mutation test** (no secret value); top-level shape allowlist; `liveUrl` has no token; NULL `approved_scopes` → `[]`; malformed manifest → `{}`.
- `blocks.router.getAppDetail.test.ts` (5): anon dark → NOT_FOUND (registry not consulted); non-mod dark → NOT_FOUND; **anon WITH flag granted → served (proves anon-capable, no isModerator belt)**; mod served; service-null → NOT_FOUND.
- `resolveAppsPageAccess.test.ts` (extended): the detail page reuses the index gate — no-flag → notFound even with no session; flag+no-session → renders, never a redirect.

### Not verified (honest)
- **No full `tsc`** — fresh worktree lacks `next-env.d.ts`/`.next/types` (thousands of spurious errors); relying on the **PR preview build** for the authoritative typecheck. New files are type-correct against the imported symbols.
- **No browser render** of the detail page / preview iframe (the page is dark behind the mod-segmented flag; needs a preview deploy with the flag temporarily granted, or Playwright, to exercise the click path). The component logic + the security boundary are covered by the unit tests.
- The pre-existing `blocks.router.subscriptions.test.ts` fails in a fresh worktree (`Prisma.validator is not a function` — generated client not built); unrelated to this PR (file untouched), and the E2 tests mock around that chain like the other E1 router tests do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
