### PR TITLE
test(blocks): fix flaky unit:fail — define REDIS_KEYS.GENERATION in blocks.router mocks

### DIFF
--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -58,7 +58,10 @@ vi.mock('~/server/db/client', () => ({
 // stays cheap and we don't accidentally hit live deps.
 vi.mock('~/server/redis/client', () => ({
   redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
-  REDIS_KEYS: { BLOCKS: {} },
+  // GENERATION.RESOURCE_DATA is read at import time by resource-data.redis (pulled
+  // in transitively); without it this suite flakily throws "Cannot read properties
+  // of undefined (reading 'RESOURCE_DATA')" depending on test-file load order.
+  REDIS_KEYS: { BLOCKS: {}, GENERATION: { RESOURCE_DATA: 'packed:generation:resource-data-3' } },
 }));
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: vi.fn(),

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -105,7 +105,13 @@ vi.mock('~/server/db/client', () => ({
 vi.mock('~/server/redis/client', () => ({
   redis: mockRedis,
   sysRedis: mockSysRedis,
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  // GENERATION.RESOURCE_DATA is read at import time by resource-data.redis (pulled
+  // in transitively); without it this suite flakily throws "Cannot read properties
+  // of undefined (reading 'RESOURCE_DATA')" depending on test-file load order.
+  REDIS_KEYS: {
+    BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' },
+    GENERATION: { RESOURCE_DATA: 'packed:generation:resource-data-3' },
+  },
   REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({


### PR DESCRIPTION
Fixes the intermittent **unit:fail** seen across recent PRs' preview pipelines (#2554/#2558/#2559 failed, #2556 passed — **not** caused by any of them).

## Root cause

`blocks.router.subscriptions.test.ts` and `blocks.router.workflow.test.ts` mock `~/server/redis/client` with a trimmed `REDIS_KEYS` that omits `GENERATION`. But `blocks.router`'s import chain transitively pulls in `resource-data.redis`, which reads `REDIS_KEYS.GENERATION.RESOURCE_DATA` **at import time**. Depending on test-file load order (vitest parallelism), that module loads while the trimmed mock is active → `TypeError: Cannot read properties of undefined (reading 'RESOURCE_DATA')` → the **file** fails to load (suite-level). The suite passes **1752/1752 individual tests**; only 2 files intermittently fail to import.

## Fix

Add `GENERATION: { RESOURCE_DATA: ... }` to the mocked `REDIS_KEYS` in both files. `resource-data.redis` reads only that one `GENERATION` key at import, so this makes the import-time read safe **regardless of load order** — removing the flake by construction.

## Verification

Deterministic by construction (the throw is the missing key; defining it removes it). The order-dependent flake can't be reproduced in isolation, and the full unit suite needs Prisma (unrunnable on the NixOS dev box), so the proof is the preview `unit-tests` going + staying green across PRs. Touches test mocks only — no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)