### PR TITLE
feat(blocks): marketplace E4 — featured rail + mod curation tooling (dark, mod-gated)

### DIFF
--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -126,6 +126,14 @@ export default function AppsPage() {
   );
   const newItems = (newData?.items ?? []) as AvailableBlock[];
 
+  // E4 Low-1: when the rails are shown, exclude the apps they already surface
+  // from the "All apps" grid so a featured/new app doesn't render twice.
+  const railIds = useMemo(
+    () => new Set(showRails ? [...featuredItems, ...newItems].map((b) => b.id) : []),
+    [showRails, featuredItems, newItems]
+  );
+  const gridItems = useMemo(() => items.filter((b) => !railIds.has(b.id)), [items, railIds]);
+
   // M1 empty-state: distinguish "no apps exist at all" (total===0) from
   // "your filters matched nothing" (filtered===0). A tiny unfiltered probe
   // (limit:1, no filters/search) tells us whether ANY approved app exists,
@@ -286,11 +294,13 @@ export default function AppsPage() {
             />
           )}
 
-          {(showRails && (featuredItems.length > 0 || newItems.length > 0)) && (
-            <Title order={3} mt="xs">
-              All apps
-            </Title>
-          )}
+          {showRails &&
+            (featuredItems.length > 0 || newItems.length > 0) &&
+            gridItems.length > 0 && (
+              <Title order={3} mt="xs">
+                All apps
+              </Title>
+            )}
 
           {isLoading ? (
             <Center py="xl">
@@ -307,7 +317,7 @@ export default function AppsPage() {
           ) : (
             <>
               <Grid gutter="md">
-                {items.map((block: AvailableBlock) => (
+                {gridItems.map((block: AvailableBlock) => (
                   <Grid.Col key={block.id} span={{ base: 12, sm: 6, md: 4, lg: 3 }}>
                     <AppBlockCard
                       block={block}

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -105,6 +105,27 @@ export default function AppsPage() {
     slotFilter || category || (debouncedSearch && debouncedSearch.length > 0)
   );
 
+  // F-E E4 discovery rails — shown ABOVE the grid only on the unfiltered default
+  // view (a "Featured" staff-pick rail + a "New" recently-deployed rail). When
+  // the viewer is actively searching/filtering they want the full grid, so the
+  // rails collapse to avoid duplicating cards. Both reuse the SAME anon-capable,
+  // approved-only public projection as the grid (no extra exposure).
+  const showRails = !hasActiveFilters;
+
+  const { data: featuredData } = trpc.blocks.getFeaturedBlocks.useQuery(
+    { limit: 12 },
+    { enabled: !!features.appBlocks && showRails }
+  );
+  const featuredItems = (featuredData?.items ?? []) as AvailableBlock[];
+
+  // "New" rail: newest-deployed apps, small fixed page (the first page of the
+  // newest sort). Reuses listAvailable, so it's the same projection + gate.
+  const { data: newData } = trpc.blocks.listAvailable.useQuery(
+    { sort: 'newest', limit: 8 },
+    { enabled: !!features.appBlocks && showRails }
+  );
+  const newItems = (newData?.items ?? []) as AvailableBlock[];
+
   // M1 empty-state: distinguish "no apps exist at all" (total===0) from
   // "your filters matched nothing" (filtered===0). A tiny unfiltered probe
   // (limit:1, no filters/search) tells us whether ANY approved app exists,
@@ -242,6 +263,35 @@ export default function AppsPage() {
             </Group>
           </Chip.Group>
 
+          {/* F-E E4 discovery rails — unfiltered default view only. Featured =
+              curated staff picks (sorted by mod-assigned featured_order); New =
+              recently deployed. Each card links to the detail page + installs
+              via the same handler as the grid. */}
+          {showRails && featuredItems.length > 0 && (
+            <MarketplaceRail
+              title="Featured"
+              blocks={featuredItems}
+              subsByBlock={subsByBlock}
+              onOpen={handleOpen}
+              earningsByAppBlockId={earningsByAppBlockId}
+            />
+          )}
+          {showRails && newItems.length > 0 && (
+            <MarketplaceRail
+              title="New"
+              blocks={newItems}
+              subsByBlock={subsByBlock}
+              onOpen={handleOpen}
+              earningsByAppBlockId={earningsByAppBlockId}
+            />
+          )}
+
+          {(showRails && (featuredItems.length > 0 || newItems.length > 0)) && (
+            <Title order={3} mt="xs">
+              All apps
+            </Title>
+          )}
+
           {isLoading ? (
             <Center py="xl">
               <Loader />
@@ -361,6 +411,44 @@ function MarketplaceEmptyState({
         )}
       </Stack>
     </Center>
+  );
+}
+
+/**
+ * F-E E4 discovery rail — a titled horizontal strip of marketplace cards
+ * (Featured / New) shown above the grid on the unfiltered view. Reuses
+ * AppBlockCard so each card behaves identically to the grid (detail link +
+ * install handler + owner-earnings chip).
+ */
+function MarketplaceRail({
+  title,
+  blocks,
+  subsByBlock,
+  onOpen,
+  earningsByAppBlockId,
+}: {
+  title: string;
+  blocks: AvailableBlock[];
+  subsByBlock: Map<string, Partial<Record<SubscriptionScope, SubscriptionRecord>>>;
+  onOpen: (block: AvailableBlock) => void;
+  earningsByAppBlockId: Map<string, number>;
+}) {
+  return (
+    <Stack gap="xs">
+      <Title order={3}>{title}</Title>
+      <Grid gutter="md">
+        {blocks.map((block) => (
+          <Grid.Col key={block.id} span={{ base: 12, sm: 6, md: 4, lg: 3 }}>
+            <AppBlockCard
+              block={block}
+              alreadySubscribed={subsByBlock.has(block.id)}
+              onOpen={onOpen}
+              ownedEarningCents={earningsByAppBlockId.get(block.id)}
+            />
+          </Grid.Col>
+        ))}
+      </Grid>
+    </Stack>
   );
 }
 

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -8,8 +8,11 @@ import {
   Container,
   Group,
   Modal,
+  NumberInput,
   ScrollArea,
+  Select,
   Stack,
+  Switch,
   Table,
   Tabs,
   Text,
@@ -40,6 +43,11 @@ import {
   SCOPE_DESCRIPTIONS,
   SLOT_DESCRIPTIONS,
 } from '~/server/services/blocks/scope-descriptions.constants';
+import {
+  MARKETPLACE_CATEGORIES,
+  MARKETPLACE_CATEGORY_LABELS,
+  type MarketplaceCategory,
+} from '~/server/services/blocks/marketplace-categories.constants';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -756,6 +764,13 @@ function ReviewModal({
           View code in Forgejo
         </Button>
 
+        {/* F-E E4 curation — marketplace metadata (category / featured / order).
+            Only for an APPROVED request that has a linked app_block: featuring
+            is approved-only, and the meta lives on the app_block row. */}
+        {mode === 'approved' && request.appBlockId && (
+          <CurationPanel key={request.appBlockId} appBlockId={request.appBlockId} />
+        )}
+
         <Stack gap={4}>
           <Text size="sm" fw={600}>
             Files
@@ -878,6 +893,150 @@ function ReviewModal({
         )}
       </Stack>
     </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// F-E E4 curation panel — mod controls to set the marketplace category +
+// featured/order on an approved app_block (calls blocks.setMarketplaceMeta).
+// Mod-only (the trPC procedures are moderatorProcedure-gated; the whole review
+// page already requires isModerator).
+// ---------------------------------------------------------------------------
+
+const CATEGORY_SELECT_DATA = MARKETPLACE_CATEGORIES.map((c) => ({
+  value: c,
+  label: MARKETPLACE_CATEGORY_LABELS[c],
+}));
+
+function CurationPanel({ appBlockId }: { appBlockId: string }) {
+  const features = useFeatureFlags();
+  const utils = trpc.useUtils();
+  const metaQuery = trpc.blocks.getMarketplaceMeta.useQuery(
+    { appBlockId },
+    { enabled: !!features?.appBlocks }
+  );
+
+  // Local form state, seeded from the fetched meta. `dirty` becomes true once
+  // the mod edits a field so Save is only enabled when there's a change.
+  const [category, setCategory] = useState<MarketplaceCategory | null>(null);
+  const [featured, setFeatured] = useState(false);
+  const [featuredOrder, setFeaturedOrder] = useState<number | null>(null);
+  const [seeded, setSeeded] = useState(false);
+
+  const meta = metaQuery.data;
+  // Seed once when the query first resolves (and re-seed if a different app's
+  // meta arrives — keyed on appBlockId via the parent remount, but guard here
+  // too in case the panel is reused).
+  if (meta && !seeded) {
+    setCategory(
+      meta.category && (MARKETPLACE_CATEGORIES as readonly string[]).includes(meta.category)
+        ? (meta.category as MarketplaceCategory)
+        : null
+    );
+    setFeatured(meta.featured);
+    setFeaturedOrder(meta.featuredOrder);
+    setSeeded(true);
+  }
+
+  const saveMut = trpc.blocks.setMarketplaceMeta.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'Marketplace metadata saved.' });
+      await utils.blocks.getMarketplaceMeta.invalidate({ appBlockId });
+      await utils.blocks.getFeaturedBlocks.invalidate();
+      await utils.blocks.listAvailable.invalidate();
+    },
+    onError: (e) => {
+      showErrorNotification({ title: 'Save failed', error: new Error(e.message) });
+    },
+  });
+
+  const isApproved = meta?.status === 'approved';
+  const busy = saveMut.isPending;
+
+  const dirty =
+    !!meta &&
+    ((category ?? null) !== (meta.category ?? null) ||
+      featured !== meta.featured ||
+      (featuredOrder ?? null) !== (meta.featuredOrder ?? null));
+
+  return (
+    <Card withBorder p="sm">
+      <Stack gap="sm">
+        <Group gap={6}>
+          <IconLayoutGrid size={14} />
+          <Text size="sm" fw={600}>
+            Marketplace curation
+          </Text>
+        </Group>
+
+        {metaQuery.isLoading ? (
+          <Text size="xs" c="dimmed">
+            Loading…
+          </Text>
+        ) : metaQuery.isError ? (
+          <Alert color="red" icon={<IconAlertTriangle size={16} />}>
+            {metaQuery.error.message}
+          </Alert>
+        ) : (
+          <>
+            {!isApproved && (
+              <Alert color="yellow" variant="light" icon={<IconAlertTriangle size={16} />}>
+                This app is{' '}
+                <Code>{meta?.status ?? 'unknown'}</Code> — only an approved app can be
+                featured. Category/order can still be set.
+              </Alert>
+            )}
+            <Select
+              label="Category"
+              data={CATEGORY_SELECT_DATA}
+              value={category}
+              onChange={(v) => setCategory((v as MarketplaceCategory) || null)}
+              placeholder="No category"
+              clearable
+              disabled={busy}
+              w={240}
+            />
+            <Switch
+              label="Featured (staff pick rail)"
+              checked={featured}
+              onChange={(e) => setFeatured(e.currentTarget.checked)}
+              disabled={busy || !isApproved}
+            />
+            <NumberInput
+              label="Featured order (lower = earlier)"
+              value={featuredOrder ?? ''}
+              onChange={(v) =>
+                setFeaturedOrder(typeof v === 'number' ? v : v === '' ? null : Number(v))
+              }
+              min={0}
+              max={100000}
+              allowDecimal={false}
+              placeholder="unset"
+              disabled={busy}
+              w={240}
+            />
+            <Group justify="flex-end">
+              <Button
+                size="xs"
+                leftSection={<IconCheck size={14} />}
+                disabled={!dirty || busy}
+                loading={busy}
+                onClick={() =>
+                  saveMut.mutate({
+                    appBlockId,
+                    category: category ?? null,
+                    featured,
+                    featuredOrder: featuredOrder ?? null,
+                  })
+                }
+              >
+                Save curation
+              </Button>
+            </Group>
+          </>
+        )}
+      </Stack>
+    </Card>
   );
 }
 

--- a/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
+++ b/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * F-E E4 — `blocks.setMarketplaceMeta` + `blocks.getFeaturedBlocks` router
+ * coverage. Drives the REAL blocks router so the procedure middleware chain
+ * (`moderatorProcedure` = publicProcedure → isAuthed → isMod) is what decides
+ * the outcome; `BlockRegistry` is mocked at the module boundary so this suite
+ * exercises the GATE (not the service logic, which has its own test).
+ *
+ * GATING INVARIANT pinned here (each FAILS if the gate is dropped):
+ *   - setMarketplaceMeta is MOD-ONLY:
+ *       · anon (no session)  → UNAUTHORIZED, service NEVER called.
+ *       · non-mod (logged in) → FORBIDDEN,    service NEVER called.
+ *       · moderator           → served, service called with the input.
+ *   - getFeaturedBlocks is anon-CAPABLE but DARK behind the flag:
+ *       · anon WITHOUT the flag → EMPTY rail, service NOT consulted.
+ *       · anon WITH the flag (lit path) → served — proves anon-capable, no
+ *         isModerator belt.
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockSetMarketplaceMeta,
+  mockGetFeaturedBlocks,
+  mockGetMarketplaceMeta,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockSetMarketplaceMeta: vi.fn(),
+  mockGetFeaturedBlocks: vi.fn(),
+  mockGetMarketplaceMeta: vi.fn(),
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    getAppDetail: vi.fn(),
+    getFeaturedBlocks: (...a: unknown[]) => mockGetFeaturedBlocks(...a),
+    getMarketplaceMeta: (...a: unknown[]) => mockGetMarketplaceMeta(...a),
+    setMarketplaceMeta: (...a: unknown[]) => mockSetMarketplaceMeta(...a),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/textToImage/textToImage', () => ({
+  createTextToImageStep: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn() },
+  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: !!(user as { isModerator?: boolean })?.isModerator } as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+
+const META_RESULT = {
+  appBlockId: 'ab_1',
+  status: 'approved',
+  category: 'games',
+  featured: true,
+  featuredOrder: 3,
+};
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockSetMarketplaceMeta.mockReset();
+  mockSetMarketplaceMeta.mockResolvedValue(META_RESULT);
+  mockGetFeaturedBlocks.mockReset();
+  mockGetFeaturedBlocks.mockResolvedValue([]);
+  mockGetMarketplaceMeta.mockReset();
+  mockGetMarketplaceMeta.mockResolvedValue(META_RESULT);
+});
+
+const SET_INPUT = { appBlockId: 'ab_1', category: 'games', featured: true, featuredOrder: 3 } as const;
+
+describe('blocks.setMarketplaceMeta — MOD-ONLY curation write (F-E E4)', () => {
+  it('anon (no session): UNAUTHORIZED, the write is NEVER attempted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.setMarketplaceMeta(SET_INPUT)).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockSetMarketplaceMeta).not.toHaveBeenCalled();
+  });
+
+  it('non-mod (logged in): FORBIDDEN, the write is NEVER attempted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.setMarketplaceMeta(SET_INPUT)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockSetMarketplaceMeta).not.toHaveBeenCalled();
+  });
+
+  it('moderator: served — the write runs with the validated input', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.setMarketplaceMeta(SET_INPUT);
+    expect(result).toEqual(META_RESULT);
+    expect(mockSetMarketplaceMeta).toHaveBeenCalledTimes(1);
+    // The service receives the parsed input (the tRPC input pipeline may add a
+    // shared `browsingLevel` default), so assert the curation fields explicitly
+    // rather than an exact-equal on the whole object.
+    const arg = mockSetMarketplaceMeta.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg).toMatchObject({
+      appBlockId: 'ab_1',
+      category: 'games',
+      featured: true,
+      featuredOrder: 3,
+    });
+  });
+
+  it('rejects an off-taxonomy category at the schema layer (write NEVER attempted)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(
+      // @ts-expect-error — deliberately an invalid category to prove the enum
+      // validation rejects it before the service runs.
+      caller.setMarketplaceMeta({ appBlockId: 'ab_1', category: 'totally-made-up' })
+    ).rejects.toBeTruthy();
+    expect(mockSetMarketplaceMeta).not.toHaveBeenCalled();
+  });
+
+  it('allows clearing the category (null) for a mod', async () => {
+    mockSetMarketplaceMeta.mockResolvedValue({ ...META_RESULT, category: null });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.setMarketplaceMeta({ appBlockId: 'ab_1', category: null });
+    expect(result.category).toBeNull();
+    const arg = mockSetMarketplaceMeta.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg).toMatchObject({ appBlockId: 'ab_1', category: null });
+  });
+});
+
+describe('blocks.getMarketplaceMeta — MOD-ONLY read (F-E E4)', () => {
+  it('anon: UNAUTHORIZED, the read is NEVER attempted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getMarketplaceMeta({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockGetMarketplaceMeta).not.toHaveBeenCalled();
+  });
+
+  it('non-mod: FORBIDDEN, the read is NEVER attempted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.getMarketplaceMeta({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockGetMarketplaceMeta).not.toHaveBeenCalled();
+  });
+
+  it('moderator: served; NOT_FOUND when the app is missing', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    expect(await caller.getMarketplaceMeta({ appBlockId: 'ab_1' })).toEqual(META_RESULT);
+
+    mockGetMarketplaceMeta.mockResolvedValue(null);
+    await expect(caller.getMarketplaceMeta({ appBlockId: 'missing' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+});
+
+describe('blocks.getFeaturedBlocks — anon-capable, dark behind the flag (F-E E4)', () => {
+  it('anon WITHOUT the flag: gate disables → EMPTY rail, service NOT consulted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.getFeaturedBlocks({ limit: 12 });
+    expect(result).toEqual({ items: [] });
+    expect(mockGetFeaturedBlocks).not.toHaveBeenCalled();
+  });
+
+  it('non-mod WITHOUT the flag: EMPTY rail, service NOT consulted', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    const result = await caller.getFeaturedBlocks({ limit: 12 });
+    expect(result).toEqual({ items: [] });
+    expect(mockGetFeaturedBlocks).not.toHaveBeenCalled();
+  });
+
+  it('anon WITH the flag granted (lit path): served — proves anon-CAPABLE, no isModerator belt', async () => {
+    mockIsAppBlocksEnabled.mockResolvedValue(true);
+    const featured = [
+      {
+        id: 'ab_1',
+        blockId: 'cool-block',
+        appId: 'app_1',
+        appName: 'Cool App',
+        manifest: { name: 'Cool Block' },
+        installCount: 3,
+        category: 'games',
+        scopesSummary: ['ai:write:budgeted'],
+      },
+    ];
+    mockGetFeaturedBlocks.mockResolvedValue(featured);
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.getFeaturedBlocks({ limit: 12 });
+    expect(result).toEqual({ items: featured });
+    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12);
+  });
+
+  it('moderator (the live state today): served', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await caller.getFeaturedBlocks({ limit: 12 });
+    expect(mockGetFeaturedBlocks).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -11,7 +11,10 @@ import { manifestSettingsSchema } from '~/server/schema/blocks/manifest-settings
 import { validateBlockSettings } from '~/server/services/blocks/settings-validator.service';
 import {
   getAppDetailSchema,
+  getFeaturedBlocksSchema,
+  getMarketplaceMetaSchema,
   listAvailableSchema,
+  setMarketplaceMetaSchema,
   subscriptionScopeSchema,
 } from '~/server/schema/blocks/subscription.schema';
 import {
@@ -987,6 +990,89 @@ export const blocksRouter = router({
       const detail = await BlockRegistry.getAppDetail(input.appBlockId);
       if (!detail) throw throwNotFoundError('App block not found');
       return detail;
+    }),
+
+  /**
+   * Featured rail — the curated, approved staff-picks (F-E E4). Public,
+   * ANON-CAPABLE; backs the "Featured" rail above the marketplace grid.
+   *
+   * GATING INVARIANT (E4) — anon-capable but DARK until launch (same as E1/E2):
+   *   - `enforceAppBlocksFlag` runs FIRST. For a real anon / non-mod viewer the
+   *     mod-segmented `app-blocks-enabled` flag never matches → the middleware
+   *     marks `_appBlocksDisabled` → this query returns an EMPTY rail (the same
+   *     posture as `listAvailable` for a disabled flag; no data leaks). The rail
+   *     only serves real anon callers once the SEGMENT is widened at launch.
+   *
+   * EXPOSURE / SECURITY — returns the SAME public `AvailableBlock` allowlist the
+   * marketplace LISTING uses (no widening): the service hard-filters
+   * `status='approved' AND featured=true`, so ONLY curated approved apps reach
+   * the caller, and each row is the `toPublicBlockManifest` subset +
+   * installCount + category + scopesSummary. No private/internal fields, no
+   * per-user data.
+   *
+   * Anon rate-limiting: same posture as `listAvailable`.
+   */
+  getFeaturedBlocks: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .use(
+      rateLimit({
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many marketplace requests — slow down.',
+      })
+    )
+    .input(getFeaturedBlocksSchema)
+    .query(async ({ ctx, input }) => {
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return { items: [] };
+      }
+      const items = await BlockRegistry.getFeaturedBlocks(input.limit);
+      return { items };
+    }),
+
+  /**
+   * MOD-ONLY: read the current marketplace metadata (category/featured/order)
+   * for one app_block — seeds the review-page curation form (F-E E4).
+   *
+   * `moderatorProcedure` + the `isModerator` belt: a non-mod / anon caller is
+   * rejected before any data is read. This is a moderator surface (carries the
+   * internal `status`), NOT the anon `getAppDetail` allowlist.
+   */
+  getMarketplaceMeta: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(getMarketplaceMetaSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('App Blocks curation is restricted to civitai team');
+      }
+      const meta = await BlockRegistry.getMarketplaceMeta(input.appBlockId);
+      if (!meta) throw throwNotFoundError('App block not found');
+      return meta;
+    }),
+
+  /**
+   * MOD-ONLY curation write — set category / featured / featured_order on one
+   * app_block (F-E E4). This is the curation surface backing /apps/review.
+   *
+   * GATING / SECURITY:
+   *   - `moderatorProcedure` checks the tRPC session user is a moderator, AND we
+   *     re-assert `ctx.user?.isModerator` (defense-in-depth, mirroring the other
+   *     mod mutations) — a non-mod / anon caller is DENIED (UNAUTHORIZED /
+   *     FORBIDDEN) before any write. There is intentionally NO public path here.
+   *   - `enforceAppBlocksFlag` keeps it behind the dark mod segment.
+   *   - Validation lives in the service (`setMarketplaceMeta`): the category must
+   *     be in the taxonomy const, and featuring is refused for a non-approved
+   *     app — so an unapproved app can never be surfaced in the anon featured
+   *     rail via this write.
+   */
+  setMarketplaceMeta: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(setMarketplaceMetaSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('App Blocks curation is restricted to civitai team');
+      }
+      return BlockRegistry.setMarketplaceMeta(input);
     }),
 
   /**

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -220,6 +220,68 @@ export const getAppDetailSchema = z.object({
 });
 export type GetAppDetailInput = z.infer<typeof getAppDetailSchema>;
 
+// ---------------------------------------------------------------------------
+// F-E E4 — curation (featured rail + mod-set marketplace metadata).
+// ---------------------------------------------------------------------------
+
+/**
+ * Input for the public, anon-capable `blocks.getFeaturedBlocks` (F-E E4
+ * featured rail). Only a `limit` — the featured set is the curated staff-pick
+ * list, so there's no client-controlled filter/sort (the order is the
+ * mod-assigned `featured_order`). Same exposure posture as `listAvailable`:
+ * approved-only, the `AvailableBlock` public allowlist, mod-gated until launch.
+ */
+export const getFeaturedBlocksSchema = z.object({
+  limit: z.number().int().min(1).max(24).default(12),
+});
+export type GetFeaturedBlocksInput = z.infer<typeof getFeaturedBlocksSchema>;
+
+/**
+ * Input for the MOD-ONLY `blocks.setMarketplaceMeta` (F-E E4 curation write).
+ * Sets the platform-controlled marketplace metadata on ONE app_block. All three
+ * fields are optional so a mod can patch any subset (e.g. just toggle
+ * `featured`); an omitted field is left unchanged at the service layer.
+ *
+ *   - `category`      — a value from the single-source taxonomy const
+ *                       (`MARKETPLACE_CATEGORIES`) OR `null` to clear it. The
+ *                       enum validation refuses any value outside the taxonomy.
+ *   - `featured`      — the staff-pick toggle (the featured rail filter).
+ *   - `featuredOrder` — the rail sort position (lower = earlier), or `null` to
+ *                       clear. Int only.
+ *
+ * NOTE: `category` uses `.nullable()` (not `.optional()` alone) so the client
+ * can explicitly CLEAR it (send `null`). We distinguish "omitted" (undefined →
+ * leave unchanged) from "clear" (null → set to NULL) at the service layer.
+ */
+export const setMarketplaceMetaSchema = z.object({
+  appBlockId: z.string().min(1).max(64),
+  category: z.enum(MARKETPLACE_CATEGORIES).nullable().optional(),
+  featured: z.boolean().optional(),
+  featuredOrder: z.number().int().min(0).max(100000).nullable().optional(),
+});
+export type SetMarketplaceMetaInput = z.infer<typeof setMarketplaceMetaSchema>;
+
+/** Input for the MOD-ONLY `blocks.getMarketplaceMeta` (seeds the curation UI). */
+export const getMarketplaceMetaSchema = z.object({
+  appBlockId: z.string().min(1).max(64),
+});
+export type GetMarketplaceMetaInput = z.infer<typeof getMarketplaceMetaSchema>;
+
+/**
+ * MOD-ONLY current marketplace metadata for one app_block — returned by
+ * `blocks.getMarketplaceMeta` so the review-page curation form can render the
+ * current category/featured/order. Carries `status` (mod-relevant: featuring is
+ * only allowed for `approved`) — this is a moderator surface, NOT the anon
+ * `AvailableBlock`/`PublicAppDetail` allowlist, so a mod-only field is fine.
+ */
+export type MarketplaceMeta = {
+  appBlockId: string;
+  status: string;
+  category: string | null;
+  featured: boolean;
+  featuredOrder: number | null;
+};
+
 /**
  * PUBLIC per-app detail shape returned by the anon-capable
  * `blocks.getAppDetail` (F-E E2 marketplace detail page).

--- a/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
+++ b/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
@@ -251,6 +251,27 @@ describe('BlockRegistry.setMarketplaceMeta — data-integrity rules (F-E E4)', (
     const call = mockDb.appBlock.update.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(call.data).toEqual({ category: null, featuredOrder: null, featured: false });
   });
+
+  it('E4 Low-2: the service writes ONLY its allowlisted fields even if extra keys reach it (mass-assignment guard, independent of the router zod strip)', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValueOnce({ id: 'ab_1', status: 'approved' });
+    const { BlockRegistry } = await import('../block-registry.service');
+    // Call the service DIRECTLY (bypassing the router's zod object that would
+    // strip unknown keys) with attacker-controlled protected columns. The
+    // service's own `data` allowlist must drop them — only `featured` is written.
+    await BlockRegistry.setMarketplaceMeta({
+      appBlockId: 'ab_1',
+      featured: true,
+      status: 'rejected',
+      trustTier: 'internal',
+      manifest: { evil: true },
+      approvedScopes: ['*'],
+    } as never);
+    const call = mockDb.appBlock.update.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(call.data).toEqual({ featured: true });
+    for (const k of ['status', 'trustTier', 'manifest', 'approvedScopes', 'appBlockId']) {
+      expect(call.data).not.toHaveProperty(k);
+    }
+  });
 });
 
 describe('BlockRegistry.getMarketplaceMeta — mod seed read (F-E E4)', () => {

--- a/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
+++ b/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * F-E E4 — service tests for curation:
+ *   - `BlockRegistry.getFeaturedBlocks` (anon-capable featured rail).
+ *   - `BlockRegistry.setMarketplaceMeta` (MOD-ONLY curation write).
+ *   - `BlockRegistry.getMarketplaceMeta` (MOD-ONLY seed read).
+ *
+ * The featured rail is anon-CAPABLE (dark today behind the mod-segmented flag),
+ * so its exposure protections are pinned the same way E1/E2/E3 pin theirs — the
+ * tests FAIL if the projection widens or the approved+featured filter regresses.
+ *
+ * setMarketplaceMeta is mod-only at the ROUTER (covered by the router test); the
+ * SERVICE tests pin the data-integrity rules it enforces regardless of caller:
+ * off-taxonomy categories are rejected, featuring is approved-only, and only the
+ * provided fields are written (a patch, not a full overwrite).
+ *
+ * No DB in unit tests: dbRead/dbWrite are mocked. We capture the featured SQL +
+ * the write `data` to assert the SHAPE.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    appBlock: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+    },
+    blockUserSubscription: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    modelVersion: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  },
+  sysRedis: { sMembers: vi.fn(async () => []) },
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'packed:caches:block-registry', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+
+function capturedSql(): string {
+  expect(mockDb.$queryRaw).toHaveBeenCalled();
+  const lastCall = mockDb.$queryRaw.mock.calls.at(-1);
+  if (!lastCall) return '';
+  const first = lastCall[0] as unknown;
+  if (first && typeof first === 'object' && typeof (first as { sql?: unknown }).sql === 'string') {
+    return (first as { sql: string }).sql;
+  }
+  const strings = first as unknown as TemplateStringsArray;
+  const values = lastCall.slice(1);
+  let sql = '';
+  for (let i = 0; i < strings.length; i++) {
+    sql += strings[i];
+    if (i < values.length) sql += `$${i + 1}`;
+  }
+  return sql;
+}
+
+/** One raw featured-rail row (snake_case), carrying private manifest fields the
+ * projection must strip. */
+function featuredRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_1',
+    block_id: 'cool-block',
+    app_id: 'app_1',
+    app_name: 'Cool App',
+    install_count: 9n,
+    category: 'games',
+    approved_scopes: ['ai:write:budgeted', 'models:read:self', 'buzz:read:self', 'social:tip:self'],
+    manifest: {
+      name: 'Cool Block',
+      description: 'Does cool things',
+      targets: [{ slotId: 'model.sidebar_top', secretCfg: 'leak-me' }],
+      trustTier: 'internal',
+      iframe: { src: 'https://cool-block.internal.example/' },
+      renderMode: 'iframe',
+      scopes: ['INTERNAL_secret_scope'],
+      settings: { apiKey: 'super-secret' },
+    },
+    ...over,
+  };
+}
+
+describe('BlockRegistry.getFeaturedBlocks — featured rail exposure (F-E E4)', () => {
+  beforeEach(() => {
+    mockDb.$queryRaw.mockClear();
+    mockDb.$queryRaw.mockResolvedValue([featuredRow()]);
+  });
+
+  it('SQL hard-filters status=approved AND featured=true (only curated approved apps)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.getFeaturedBlocks(12);
+    const sql = capturedSql();
+    expect(sql).toMatch(/ab\.status\s*=\s*'approved'/);
+    expect(sql).toMatch(/ab\.featured\s*=\s*true/);
+  });
+
+  it('orders by featured_order ASC NULLS LAST then a deterministic tiebreak', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.getFeaturedBlocks(12);
+    const sql = capturedSql();
+    expect(sql).toMatch(/ORDER BY\s+ab\.featured_order\s+ASC\s+NULLS\s+LAST/i);
+    // install_count is the tiebreak, ab.id the final total order.
+    expect(sql).toMatch(/install_count\s+DESC/i);
+    expect(sql).toMatch(/ab\.id\s+ASC/i);
+  });
+
+  it('projects ONLY the public AvailableBlock allowlist — no private/internal leak', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const items = await BlockRegistry.getFeaturedBlocks(12);
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(Object.keys(item).sort()).toEqual(
+      ['appId', 'appName', 'blockId', 'category', 'id', 'installCount', 'manifest', 'scopesSummary'].sort()
+    );
+    const manifest = item.manifest as Record<string, unknown>;
+    expect(manifest.name).toBe('Cool Block');
+    expect(manifest.description).toBe('Does cool things');
+    expect(manifest.targets).toEqual([{ slotId: 'model.sidebar_top' }]);
+    for (const forbidden of ['trustTier', 'iframe', 'renderMode', 'scopes', 'settings']) {
+      expect(manifest, `manifest leaked "${forbidden}"`).not.toHaveProperty(forbidden);
+    }
+    // The whole serialized rail carries no secret value (mutation-test).
+    const serialized = JSON.stringify(items);
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('internal.example');
+    expect(serialized).not.toContain('leak-me');
+    expect(serialized).not.toContain('INTERNAL_secret_scope');
+  });
+
+  it('scopesSummary comes from approved_scopes (capped), category passes through', async () => {
+    const { BlockRegistry, MARKETPLACE_SCOPES_SUMMARY_LIMIT } = await import(
+      '../block-registry.service'
+    );
+    const items = await BlockRegistry.getFeaturedBlocks(12);
+    expect(items[0].scopesSummary).toEqual(
+      ['ai:write:budgeted', 'models:read:self', 'buzz:read:self', 'social:tip:self'].slice(
+        0,
+        MARKETPLACE_SCOPES_SUMMARY_LIMIT
+      )
+    );
+    expect(items[0].category).toBe('games');
+  });
+
+  it('a NULL approved_scopes / malformed manifest do not crash or leak', async () => {
+    mockDb.$queryRaw.mockResolvedValueOnce([
+      featuredRow({ approved_scopes: null, manifest: null }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const items = await BlockRegistry.getFeaturedBlocks(12);
+    expect(items[0].scopesSummary).toEqual([]);
+    expect(items[0].manifest).toEqual({});
+  });
+});
+
+describe('BlockRegistry.setMarketplaceMeta — data-integrity rules (F-E E4)', () => {
+  beforeEach(() => {
+    mockDb.appBlock.findUnique.mockReset();
+    mockDb.appBlock.update.mockReset();
+    mockDb.appBlock.update.mockResolvedValue({
+      id: 'ab_1',
+      status: 'approved',
+      category: 'games',
+      featured: true,
+      featuredOrder: 3,
+    });
+  });
+
+  it('rejects an off-taxonomy category before any write (defense-in-depth)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await expect(
+      BlockRegistry.setMarketplaceMeta({
+        appBlockId: 'ab_1',
+        // @ts-expect-error — deliberately invalid; the service belt must reject.
+        category: 'totally-made-up',
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockDb.appBlock.update).not.toHaveBeenCalled();
+  });
+
+  it('throws NOT_FOUND for a missing app (no write)', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValueOnce(null);
+    const { BlockRegistry } = await import('../block-registry.service');
+    await expect(
+      BlockRegistry.setMarketplaceMeta({ appBlockId: 'missing', featured: false })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockDb.appBlock.update).not.toHaveBeenCalled();
+  });
+
+  it('REFUSES to feature a non-approved app (no write)', async () => {
+    for (const status of ['pending', 'rejected', 'withdrawn', 'disabled']) {
+      mockDb.appBlock.findUnique.mockResolvedValueOnce({ id: 'ab_1', status });
+      const { BlockRegistry } = await import('../block-registry.service');
+      await expect(
+        BlockRegistry.setMarketplaceMeta({ appBlockId: 'ab_1', featured: true }),
+        `status="${status}" must not be featurable`
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    }
+    expect(mockDb.appBlock.update).not.toHaveBeenCalled();
+  });
+
+  it('ALLOWS featuring an approved app, writing the expected fields', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValueOnce({ id: 'ab_1', status: 'approved' });
+    const { BlockRegistry } = await import('../block-registry.service');
+    const result = await BlockRegistry.setMarketplaceMeta({
+      appBlockId: 'ab_1',
+      category: 'games',
+      featured: true,
+      featuredOrder: 3,
+    });
+    expect(mockDb.appBlock.update).toHaveBeenCalledTimes(1);
+    const call = mockDb.appBlock.update.mock.calls[0][0] as {
+      where: { id: string };
+      data: Record<string, unknown>;
+    };
+    expect(call.where).toEqual({ id: 'ab_1' });
+    expect(call.data).toEqual({ category: 'games', featured: true, featuredOrder: 3 });
+    expect(result).toMatchObject({ appBlockId: 'ab_1', featured: true, category: 'games' });
+  });
+
+  it('is a PATCH — only the provided fields are written (omitted = unchanged)', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValueOnce({ id: 'ab_1', status: 'approved' });
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.setMarketplaceMeta({ appBlockId: 'ab_1', featured: false });
+    const call = mockDb.appBlock.update.mock.calls[0][0] as { data: Record<string, unknown> };
+    // category + featuredOrder were NOT provided → not in the write data.
+    expect(call.data).toEqual({ featured: false });
+    expect(call.data).not.toHaveProperty('category');
+    expect(call.data).not.toHaveProperty('featuredOrder');
+  });
+
+  it('allows explicitly CLEARING category/order with null (a non-approved app can be un-featured/edited)', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValueOnce({ id: 'ab_1', status: 'pending' });
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.setMarketplaceMeta({
+      appBlockId: 'ab_1',
+      category: null,
+      featuredOrder: null,
+      featured: false, // un-feature is allowed on a non-approved app
+    });
+    const call = mockDb.appBlock.update.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(call.data).toEqual({ category: null, featuredOrder: null, featured: false });
+  });
+});
+
+describe('BlockRegistry.getMarketplaceMeta — mod seed read (F-E E4)', () => {
+  beforeEach(() => {
+    mockDb.appBlock.findUnique.mockReset();
+  });
+
+  it('returns the current meta for an existing app', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValueOnce({
+      id: 'ab_1',
+      status: 'approved',
+      category: 'utility',
+      featured: true,
+      featuredOrder: 2,
+    });
+    const { BlockRegistry } = await import('../block-registry.service');
+    expect(await BlockRegistry.getMarketplaceMeta('ab_1')).toEqual({
+      appBlockId: 'ab_1',
+      status: 'approved',
+      category: 'utility',
+      featured: true,
+      featuredOrder: 2,
+    });
+  });
+
+  it('returns null for a missing app', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValueOnce(null);
+    const { BlockRegistry } = await import('../block-registry.service');
+    expect(await BlockRegistry.getMarketplaceMeta('missing')).toBeNull();
+  });
+});

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -22,10 +22,13 @@ import {
 import type {
   AvailableBlock,
   ListAvailableInput,
+  MarketplaceMeta,
   PublicAppDetail,
+  SetMarketplaceMetaInput,
   SubscriptionRecord,
   SubscriptionScope,
 } from '~/server/schema/blocks/subscription.schema';
+import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schema';
 
 const CACHE_TTL_SECONDS = 60;
@@ -2422,6 +2425,182 @@ export class BlockRegistry {
       // Already-public standalone origin (no token/scope). Same host the webhook
       // validates the submitted bundle's iframe.src against.
       liveUrl: `https://${row.block_id}.${env.APPS_DOMAIN}`,
+    };
+  }
+
+  /**
+   * F-E E4 featured rail. Anon-CAPABLE (same exposure posture as listAvailable),
+   * gated behind the mod-segmented appBlocks flag in the router (dark today).
+   *
+   * 🔒 ANON-EXPOSURE — returns the SAME public `AvailableBlock` allowlist the
+   * marketplace listing uses (id/blockId/appId/appName + the `toPublicBlock
+   * manifest` subset + installCount + category + scopesSummary). It is NOT a
+   * wider projection — it reuses the exact listing shape so the two can't drift.
+   * The WHERE clause additionally hard-filters `featured = true` (on top of
+   * `status='approved'`), so ONLY curated, approved apps are returned — a
+   * pending/rejected/unfeatured app can never reach an anon caller here.
+   *
+   * Ordering: `featured_order` ASC with NULLS LAST (a curated, mod-assigned
+   * position; unset rows sink to the end), then install_count DESC as a stable
+   * tiebreak, then `ab.id` ASC so the order is fully deterministic.
+   *
+   * No cursor: the featured set is a small curated list (rail above the grid),
+   * capped by `limit` (≤24); paginating a staff-pick rail isn't a requirement.
+   */
+  static async getFeaturedBlocks(limit: number): Promise<AvailableBlock[]> {
+    type Row = {
+      id: string;
+      block_id: string;
+      app_id: string;
+      app_name: string | null;
+      manifest: unknown;
+      install_count: bigint;
+      category: string | null;
+      approved_scopes: string[] | null;
+    };
+    const rows = (await dbRead.$queryRaw<Row[]>`
+      SELECT
+        ab.id,
+        ab.block_id,
+        ab.app_id,
+        oc.name AS app_name,
+        ab.manifest,
+        ab.category,
+        ab.approved_scopes,
+        (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
+         WHERE bus.app_block_id = ab.id) AS install_count
+      FROM app_blocks ab
+      LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
+      WHERE ab.status = 'approved'
+        AND ab.featured = true
+      ORDER BY ab.featured_order ASC NULLS LAST,
+               install_count DESC,
+               ab.id ASC
+      LIMIT ${limit}
+    ` ) as Row[];
+    // Project to the SAME public allowlist as listAvailable (no widening).
+    return rows.map((r) => ({
+      id: r.id,
+      blockId: r.block_id,
+      appId: r.app_id,
+      appName: r.app_name ?? null,
+      manifest: toPublicBlockManifest(r.manifest),
+      installCount: Number(r.install_count),
+      category: r.category ?? null,
+      scopesSummary: Array.isArray(r.approved_scopes)
+        ? r.approved_scopes
+            .filter((s): s is string => typeof s === 'string')
+            .slice(0, MARKETPLACE_SCOPES_SUMMARY_LIMIT)
+        : [],
+    }));
+  }
+
+  /**
+   * F-E E4 — MOD-ONLY: read the current marketplace metadata for one app_block,
+   * to seed the review-page curation form. The router gates this with
+   * `moderatorProcedure`; this method does NO auth itself.
+   *
+   * Returns `null` for a missing app (router → NOT_FOUND). Carries `status`
+   * (mod-relevant: featuring is approved-only) — this is a moderator surface,
+   * not the anon allowlist, so a status field is intentional here.
+   */
+  static async getMarketplaceMeta(appBlockId: string): Promise<MarketplaceMeta | null> {
+    const row = await dbRead.appBlock.findUnique({
+      where: { id: appBlockId },
+      select: {
+        id: true,
+        status: true,
+        category: true,
+        featured: true,
+        featuredOrder: true,
+      },
+    });
+    if (!row) return null;
+    return {
+      appBlockId: row.id,
+      status: row.status,
+      category: row.category ?? null,
+      featured: row.featured,
+      featuredOrder: row.featuredOrder ?? null,
+    };
+  }
+
+  /**
+   * F-E E4 — MOD-ONLY: set the platform-controlled marketplace metadata
+   * (category / featured / featured_order) on ONE app_block. The router gates
+   * this with `moderatorProcedure` + the isModerator belt; this method does NO
+   * auth itself (caller must be a moderator).
+   *
+   * Validation:
+   *   - `category` (when provided & non-null) MUST be in the taxonomy const
+   *     (`MARKETPLACE_CATEGORIES`). Defense-in-depth: the router schema already
+   *     enums it, but a future internal caller can't slip an off-taxonomy value
+   *     past this layer. `null` clears it; `undefined` leaves it unchanged.
+   *   - Featuring (`featured === true`) is allowed ONLY for a `status='approved'`
+   *     app — a pending/rejected/withdrawn/disabled app can never be featured
+   *     (it would otherwise surface in the anon featured rail). Un-featuring or
+   *     editing category/order on a non-approved app is allowed.
+   *   - `featuredOrder` is an int (router-bounded) or null (clear).
+   *
+   * Returns the updated MarketplaceMeta. Throws NOT_FOUND for a missing app and
+   * BAD_REQUEST for an off-taxonomy category or featuring a non-approved app.
+   */
+  static async setMarketplaceMeta(
+    input: SetMarketplaceMetaInput
+  ): Promise<MarketplaceMeta> {
+    const { appBlockId, category, featured, featuredOrder } = input;
+
+    // Taxonomy belt (router already enums it; re-assert so no off-taxonomy value
+    // can ever be written by any caller).
+    if (
+      category != null &&
+      !(MARKETPLACE_CATEGORIES as readonly string[]).includes(category)
+    ) {
+      throwBadRequestError(`Unknown marketplace category: ${category}`);
+    }
+
+    const existing = await dbWrite.appBlock.findUnique({
+      where: { id: appBlockId },
+      select: { id: true, status: true },
+    });
+    if (!existing) throwNotFoundError('App block not found');
+
+    // Approved-only featuring: refuse to feature anything not approved (it would
+    // otherwise appear in the anon-capable featured rail).
+    if (featured === true && existing!.status !== 'approved') {
+      throwBadRequestError(
+        `Only an approved app can be featured (status="${existing!.status}").`
+      );
+    }
+
+    // Build the patch from ONLY the provided fields — an omitted (undefined)
+    // field is left unchanged; an explicit null clears the column.
+    const data: {
+      category?: string | null;
+      featured?: boolean;
+      featuredOrder?: number | null;
+    } = {};
+    if (category !== undefined) data.category = category;
+    if (featured !== undefined) data.featured = featured;
+    if (featuredOrder !== undefined) data.featuredOrder = featuredOrder;
+
+    const updated = await dbWrite.appBlock.update({
+      where: { id: appBlockId },
+      data,
+      select: {
+        id: true,
+        status: true,
+        category: true,
+        featured: true,
+        featuredOrder: true,
+      },
+    });
+    return {
+      appBlockId: updated.id,
+      status: updated.status,
+      category: updated.category ?? null,
+      featured: updated.featured,
+      featuredOrder: updated.featuredOrder ?? null,
     };
   }
 }


### PR DESCRIPTION
## F-E Phase E4 — Curation: featured rail + moderator tooling

Levels up `/apps` with a curated **Featured** rail + the mod tooling to set category/featured. Reuses E1/E2/E3 pieces (`listAvailable`/`block-registry.service.ts`, `MARKETPLACE_CATEGORIES`, `toPublicBlockManifest`, `AvailableBlock`, `SCOPE_DESCRIPTIONS`, `resolveAppsPageAccess`). **The `category`/`featured`/`featured_order` columns are already live (E3 migration applied to prod nvme0 + dev clone) — no new migration.**

### 🔒 GATING INVARIANT (unchanged, not violated)
Stays MODS-ONLY/dark: every marketplace surface is `features.appBlocks`/`enforceAppBlocksFlag`-gated FIRST, `deIndex` stays ON, **no Flipt/segment change**, and there is **no hardcoded `isModerator` belt on the public read paths** (the flag is the gate — dark for non-mods/anon until the segment widens at launch). The public projection is NOT widened beyond display-safe fields.

### Changes
- **`blocks.setMarketplaceMeta`** (NEW `moderatorProcedure`) — MOD-ONLY write of `{ category?, featured?, featuredOrder? }` on one app_block.
  - **Mod-gate**: `moderatorProcedure` (= publicProcedure → isAuthed → isMod) + a defense-in-depth `ctx.user?.isModerator` belt. Anon → `UNAUTHORIZED`, non-mod → `FORBIDDEN`, **before any write**.
  - **Validation** (in the service, so no caller can bypass): `category` must be in `MARKETPLACE_CATEGORIES` (taxonomy) or `null` to clear; **featuring is refused unless `status='approved'`** (so an unapproved app can never reach the anon featured rail); `featuredOrder` is a bounded int or null. Patch semantics — an omitted field is left unchanged, an explicit `null` clears the column. Writes via `dbWrite.appBlock.update`.
- **`blocks.getMarketplaceMeta`** (NEW `moderatorProcedure`) — MOD-ONLY read to seed the curation form (carries the mod-relevant `status`; not the anon allowlist).
- **`blocks.getFeaturedBlocks`** (NEW `publicProcedure` + `enforceAppBlocksFlag` + rate-limit) — the featured rail. Lower blast radius than extending `listAvailable` (E3 tests untouched).
- **`/apps` index** — a **Featured** rail (`getFeaturedBlocks`, sorted by `featured_order`) + a **New** rail (`listAvailable` sort=newest, limit 8) above the grid, on the unfiltered view only. Grid/sort/category/pagination unchanged.
- **`/apps/review`** — a mod curation panel on **approved** requests with a linked app_block: category dropdown (from `MARKETPLACE_CATEGORIES`) + featured toggle (disabled unless approved) + optional order, calling `setMarketplaceMeta`.

### Featured-query exposure analysis
`getFeaturedBlocks` returns the **exact same `AvailableBlock` public allowlist** as the marketplace listing (`id`/`blockId`/`appId`/`appName` + the `toPublicBlockManifest` subset name/description/targets[].slotId + `installCount` + `category` + `scopesSummary`) — **no widening**. The SQL hard-filters `status='approved' AND featured=true`, so only curated approved apps are returned; a pending/rejected/unfeatured app can never reach an anon caller. Order: `featured_order ASC NULLS LAST`, then `install_count DESC`, then `ab.id ASC` (deterministic). Same flag-first/dark posture + rate-limit as `listAvailable`; **no `isModerator` belt** (so the eventual launch is a pure segment-widen).

### Test coverage
- **`setMarketplaceMeta` mod-gate** (router): anon → `UNAUTHORIZED`, non-mod → `FORBIDDEN`, service never called (FAILS if the gate is dropped); off-taxonomy `category` rejected at the schema layer; mod → served with the validated input. Same for `getMarketplaceMeta`.
- **`setMarketplaceMeta` data-integrity** (service): off-taxonomy reject (no write), `NOT_FOUND` for a missing app, **refuses to feature a non-approved app** (pending/rejected/withdrawn/disabled), writes the expected fields, patch semantics (only provided fields written), explicit null-clear.
- **Featured query** (service): SQL filters `approved AND featured`, ordered by `featured_order` + tiebreak, projects ONLY the `AvailableBlock` allowlist (mutation-test: no private/internal manifest leak), scopesSummary from `approved_scopes`, NULL-safe. Router: anon WITHOUT the flag → empty rail (service not consulted); anon WITH the flag → served (proves anon-capable, no belt).
- Did **not** touch `listAvailable`/`AvailableBlock` (chose the dedicated query) → E3 tests untouched.

**Full block unit suite run** (`block-registry*`, `services/blocks/__tests__`, `routers/__tests__/blocks*`, `components/Apps/__tests__`): **424 passed / 16 failed (440)** + Apps component tests 12/12. All 16 failures are the worktree's environmental `Prisma.sql`/`Prisma.validator is not a function` Vite-resolution quirk in `listAvailable`-touching tests — **proven identical on the stashed base** (the untouched E1 `list-available` test fails the same 14/14 with my edits stashed). My 25 new tests all pass. **Typecheck**: worktree `tsc` is environmentally unreliable (5476 cascade errors from the broken Prisma client types); my four hand-edited source files (`apps/index.tsx`, `apps/review.tsx`, `blocks.router.ts`, `subscription.schema.ts`) report **0** errors, and the only errors near the service are the pre-existing E3 `Prisma.sql` lines I didn't author. **CI typecheck is the authoritative gate.**

### Honest unverified
- **Browser render** of the rails + the review curation panel — not exercised (no live preview run); UI is straightforward Mantine reuse of `AppBlockCard`/existing review modal.
- **Full-project `tsc`** — only runnable cleanly in CI (worktree Prisma client is broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)