### PR TITLE
feat(blocks): marketplace E5 — screenshot gallery (dark, mod-gated)

### DIFF
--- a/prisma/migrations/20260615120000_e5_screenshots/migration.sql
+++ b/prisma/migrations/20260615120000_e5_screenshots/migration.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- F-E E5 — App Blocks marketplace screenshot gallery
+-- ============================================================
+-- See claudedocs/app-platform-fe-marketplace-plan-2026-06-14.md (Phase E5,
+-- design decision #2).
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations. This file is committed for
+-- history; a HUMAN applies the SQL below per environment (psql/retool). CI /
+-- deploy does NOT run it.
+--
+-- ⚠️ MUST BE APPLIED BEFORE THE E5 CODE GOES LIVE: `getAppDetail` (the dark,
+-- mod-gated detail-page read) SELECTs `ab.screenshots` unconditionally. If the
+-- code is live before this column exists, that query 500s (same constraint as
+-- E3's `category`). The CI/preview build does NOT query it (the build doesn't
+-- run getAppDetail; the anon smoke hits the mod-gated detail page → notFound,
+-- so getAppDetail never runs), so the build passes without the column — but
+-- the live detail page would 500. Apply this first.
+--
+-- ADDITIVE + NON-BREAKING + IDEMPOTENT:
+--   - One nullable jsonb column; existing rows and existing INSERTs (which never
+--     mention it) are unaffected. Defaults to NULL → "no screenshots".
+--   - `IF NOT EXISTS` so re-applying is a no-op.
+--   - No index needed: screenshots are only read on the single-row getAppDetail
+--     path (keyed on the PK), never filtered/sorted on.
+
+ALTER TABLE "app_blocks"
+  ADD COLUMN IF NOT EXISTS "screenshots" jsonb;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2241,6 +2241,16 @@ model AppBlock {
   featured           Boolean   @default(false) // E4 curation: staff-pick rail
   featuredOrder      Int?      @map("featured_order") // E4 curation: rail order
 
+  // F-E E5 marketplace screenshot gallery — publisher-supplied screenshots
+  // auto-discovered from the submitted bundle's `screenshots/` dir, validated
+  // (count/size/magic-bytes/name), uploaded to the bundle MinIO at approve, and
+  // recorded here as an array of { key, index, ext, contentType } entries.
+  // PUBLIC display data (served via the gated /api/blocks/screenshot/... route),
+  // but MOD-REVIEWED before approval. ADDITIVE + manually applied (migration
+  // 20260615120000_e5_screenshots; CNPG nvme0 does not auto-apply). NULL until
+  // applied — read ONLY by the dark, mod-gated getAppDetail (NOT listAvailable).
+  screenshots        Json?     // E5: [{ key, index, ext, contentType }]
+
   createdAt          DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt          DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 

--- a/src/pages/api/blocks/screenshot/[appBlockId]/[file].ts
+++ b/src/pages/api/blocks/screenshot/[appBlockId]/[file].ts
@@ -1,0 +1,115 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { dbRead } from '~/server/db/client';
+import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
+
+/**
+ * F-E E5 — public screenshot serving route for the marketplace gallery.
+ *
+ * The bundle MinIO (where screenshots are stored alongside the ZIP) is an
+ * INTERNAL endpoint with no public bucket policy, so screenshots can't be
+ * hot-linked directly. This route is the opaque public URL the detail page's
+ * <img> tags point at (`/api/blocks/screenshot/<appBlockId>/<index>.<ext>`,
+ * built by `toPublicScreenshots`). It streams ONE approved app's ONE stored
+ * screenshot, with the magic-byte-derived content-type that was validated at
+ * approve.
+ *
+ * 🔒 GATING INVARIANT (E5 — same as the rest of F-E, do not violate):
+ *   - `MixedAuthEndpoint` → anon-CAPABLE (no session required) but we evaluate
+ *     `isAppBlocksEnabled({ user })` with the optional session user FIRST. For a
+ *     real anon / non-mod viewer the mod-segmented `app-blocks-enabled` flag is
+ *     OFF → 404 (dark today; same posture as getAppDetail). Lit only when the
+ *     SEGMENT is widened at launch — there is intentionally NO isModerator belt.
+ *   - Serves ONLY a `status='approved'` app's screenshots — a missing /
+ *     non-approved appBlockId → 404, never its data (no id-enumeration of
+ *     unapproved apps, matching getAppDetail).
+ *   - Serves ONLY a screenshot RECORDED in `app_blocks.screenshots` for that id
+ *     (we look up the entry by index, then fetch its stored MinIO key — the
+ *     client cannot request an arbitrary key/path; index is the only knob).
+ *
+ * EXPOSURE: image bytes + a fixed image content-type only. No app metadata, no
+ * key, no per-user data.
+ */
+
+type StoredScreenshot = {
+  key: unknown;
+  index: unknown;
+  ext: unknown;
+  contentType: unknown;
+};
+
+const ALLOWED_CONTENT_TYPES = new Set(['image/png', 'image/webp', 'image/jpeg']);
+
+export default MixedAuthEndpoint(
+  async (req: NextApiRequest, res: NextApiResponse, user) => {
+    // Dark-flag fail-closed: while the appBlocks flag is off for this viewer
+    // (anon / non-mod today) we 404 — identical to the getAppDetail posture, so
+    // a dark viewer can't even confirm a screenshot exists.
+    if (!(await isAppBlocksEnabled({ user }))) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    const appBlockId = typeof req.query.appBlockId === 'string' ? req.query.appBlockId : '';
+    const file = typeof req.query.file === 'string' ? req.query.file : '';
+    // `file` is `<index>.<ext>` — parse the index; the ext in the URL is
+    // cosmetic (the served content-type comes from the stored record).
+    const dot = file.indexOf('.');
+    const indexStr = dot > 0 ? file.slice(0, dot) : '';
+    const requestedIndex = Number(indexStr);
+    if (!appBlockId || !Number.isInteger(requestedIndex) || requestedIndex < 0) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    const block = await dbRead.appBlock.findUnique({
+      where: { id: appBlockId },
+      select: { status: true, screenshots: true },
+    });
+    // Approved-only — never serve a pending/rejected/withdrawn app's images.
+    if (!block || block.status !== 'approved') {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    const screenshots = Array.isArray(block.screenshots)
+      ? (block.screenshots as StoredScreenshot[])
+      : [];
+    const record = screenshots.find(
+      (s) => typeof s?.index === 'number' && s.index === requestedIndex
+    );
+    if (
+      !record ||
+      typeof record.key !== 'string' ||
+      typeof record.contentType !== 'string' ||
+      !ALLOWED_CONTENT_TYPES.has(record.contentType)
+    ) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+
+    // Stream the object from the bundle MinIO. Imported lazily so the route
+    // (and its env coupling) only loads the S3 client when actually serving.
+    try {
+      const { GetObjectCommand } = await import('@aws-sdk/client-s3');
+      const { getBundleBucket, getBundleS3Client } = await import('~/utils/bundle-s3');
+      const obj = await getBundleS3Client().send(
+        new GetObjectCommand({ Bucket: getBundleBucket(), Key: record.key })
+      );
+      if (!obj.Body) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+      }
+      const bytes = await obj.Body.transformToByteArray();
+      res.setHeader('Content-Type', record.contentType);
+      // Screenshots are immutable per (appBlockId, index, ext) — a re-approve
+      // overwrites in place but the gallery URL only changes on a new approve.
+      // Cache moderately; the page is deIndex'd + dark so this is conservative.
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      res.status(200).send(Buffer.from(bytes));
+    } catch {
+      res.status(404).json({ error: 'Not found' });
+    }
+  },
+  ['GET']
+);

--- a/src/pages/api/blocks/screenshot/[appBlockId]/[file].ts
+++ b/src/pages/api/blocks/screenshot/[appBlockId]/[file].ts
@@ -102,6 +102,11 @@ export default MixedAuthEndpoint(
       }
       const bytes = await obj.Body.transformToByteArray();
       res.setHeader('Content-Type', record.contentType);
+      // Defense-in-depth on a public binary-serving endpoint: never let a
+      // browser content-sniff the validated image bytes into something
+      // executable (e.g. a PNG-header+HTML polyglot). The Content-Type is
+      // already the magic-byte-derived image/* type; nosniff pins it.
+      res.setHeader('X-Content-Type-Options', 'nosniff');
       // Screenshots are immutable per (appBlockId, index, ext) — a re-approve
       // overwrites in place but the gallery URL only changes on a new approve.
       // Cache moderately; the page is deIndex'd + dark so this is conservative.

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -9,6 +9,7 @@ import {
   Group,
   List,
   Loader,
+  SimpleGrid,
   Stack,
   Text,
   ThemeIcon,
@@ -119,6 +120,10 @@ export default function AppDetailPage() {
   const description = detail?.manifest.description ?? '';
   const slots = detail?.manifest.targets?.map((t) => t.slotId).filter(Boolean) ?? [];
   const scopes = detail?.scopes ?? [];
+  // F-E E5 publisher screenshot gallery — public display URLs (gated app route),
+  // magic-byte-validated + mod-reviewed at approval. Empty when the app shipped
+  // no `screenshots/` dir.
+  const screenshots = detail?.screenshots ?? [];
 
   function handleInstall() {
     if (!detail) return;
@@ -235,6 +240,43 @@ export default function AppDetailPage() {
                 <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
                   {description}
                 </Text>
+              )}
+
+              {/* F-E E5 — publisher screenshot gallery. Public display URLs
+                  (the gated /api/blocks/screenshot/... route); the images were
+                  auto-discovered from the submitted bundle, magic-byte-validated,
+                  and MOD-REVIEWED before approval. Rendered alongside (above) the
+                  live preview per design decision #2 ("do both"). Hidden entirely
+                  when the app shipped no screenshots. */}
+              {screenshots.length > 0 && (
+                <>
+                  <Divider />
+                  <Stack gap="xs">
+                    <Title order={4}>Screenshots</Title>
+                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+                      {screenshots.map((shot) => (
+                        <Card
+                          key={shot.index}
+                          withBorder
+                          padding={0}
+                          radius="md"
+                          style={{ overflow: 'hidden' }}
+                        >
+                          {/* Plain <img> from the stored URL (decision #2). No
+                              Next/Image optimizer — these are served by our own
+                              gated route, not a configured image domain. */}
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={shot.url}
+                            alt={`${name} screenshot ${shot.index + 1}`}
+                            loading="lazy"
+                            style={{ width: '100%', height: 'auto', display: 'block' }}
+                          />
+                        </Card>
+                      ))}
+                    </SimpleGrid>
+                  </Stack>
+                </>
               )}
 
               <Divider />

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -11,6 +11,7 @@ import {
   NumberInput,
   ScrollArea,
   Select,
+  SimpleGrid,
   Stack,
   Switch,
   Table,
@@ -764,6 +765,12 @@ function ReviewModal({
           View code in Forgejo
         </Button>
 
+        {/* F-E E5 — publisher screenshot gallery review. Publisher-supplied
+            images are an abuse vector → the mod sees them (here, derived from
+            the submitted bundle) before approving. Renders for every mode so an
+            approved app's screenshots can be re-checked too. */}
+        <ScreenshotsReviewPanel publishRequestId={request.id} />
+
         {/* F-E E4 curation — marketplace metadata (category / featured / order).
             Only for an APPROVED request that has a linked app_block: featuring
             is approved-only, and the meta lives on the app_block row. */}
@@ -893,6 +900,71 @@ function ReviewModal({
         )}
       </Stack>
     </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// F-E E5 screenshot review panel — surfaces the publisher-supplied screenshots
+// auto-discovered from the submitted bundle so the mod reviews them before
+// approval (publisher images = abuse vector). Renders <img> from base64 data
+// URLs returned by the mod-only blocks.getPublishRequestScreenshots query (the
+// pending app has no public screenshot URL yet — it isn't approved).
+// ---------------------------------------------------------------------------
+
+function ScreenshotsReviewPanel({ publishRequestId }: { publishRequestId: string }) {
+  const features = useFeatureFlags();
+  const { data, isLoading, error } = trpc.blocks.getPublishRequestScreenshots.useQuery(
+    { publishRequestId },
+    { enabled: !!features?.appBlocks, retry: false }
+  );
+  const items = data?.items ?? [];
+
+  return (
+    <Stack gap={4}>
+      <Group gap={6}>
+        <IconLayoutGrid size={14} />
+        <Text size="sm" fw={600}>
+          Screenshots
+        </Text>
+        {!isLoading && !error && (
+          <Badge size="sm" variant="light" color={items.length > 0 ? 'blue' : 'gray'}>
+            {items.length}
+          </Badge>
+        )}
+      </Group>
+      {isLoading ? (
+        <Text size="xs" c="dimmed">
+          Loading screenshots from the submitted bundle…
+        </Text>
+      ) : error ? (
+        <Text size="xs" c="red">
+          Could not load screenshots: {error.message}
+        </Text>
+      ) : items.length === 0 ? (
+        <Text size="xs" c="dimmed">
+          This bundle includes no `screenshots/` directory.
+        </Text>
+      ) : (
+        <>
+          <Text size="xs" c="dimmed">
+            Publisher-supplied images from the bundle — review before approving.
+          </Text>
+          <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+            {items.map((shot) => (
+              <Card key={shot.index} withBorder padding={0} radius="md" style={{ overflow: 'hidden' }}>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={shot.dataUrl}
+                  alt={`Screenshot ${shot.index + 1}`}
+                  loading="lazy"
+                  style={{ width: '100%', height: 'auto', display: 'block' }}
+                />
+              </Card>
+            ))}
+          </SimpleGrid>
+        </>
+      )}
+    </Stack>
   );
 }
 

--- a/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
+++ b/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
@@ -241,3 +241,19 @@ describe('enforceAppBlocksFlag — mutation (installOnModel)', () => {
     expect(mockInstallOnModel).not.toHaveBeenCalled();
   });
 });
+
+describe('enforceAppBlocksFlag — mod query (getPublishRequestScreenshots, E5 Low-2)', () => {
+  // The new mod-review screenshot query is moderatorProcedure + enforceAppBlocksFlag;
+  // a non-mod / anon caller must be rejected before the query body reaches (mod-only).
+  const input = { publishRequestId: 'pr_1' };
+
+  it('non-moderator: rejected', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.getPublishRequestScreenshots(input)).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it('anonymous: rejected', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getPublishRequestScreenshots(input)).rejects.toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -21,6 +21,7 @@ import {
   approveRequestSchema,
   backfillPublishRequestSchema,
   getMyPendingForSlugSchema,
+  getPublishRequestScreenshotsSchema,
   listApprovedRequestsSchema,
   listPendingRequestsSchema,
   listRejectedRequestsSchema,
@@ -509,6 +510,33 @@ export const blocksRouter = router({
         throw throwAuthorizationError('Mod review history is restricted to civitai team');
       }
       return listRejectedRequests({ limit: input.limit, cursor: input.cursor });
+    }),
+
+  /**
+   * MOD-ONLY (F-E E5): derive the submitted bundle's screenshots for ONE publish
+   * request so the reviewer can SEE the publisher-supplied images before
+   * approving (publisher images = an abuse vector → must be reviewed with the
+   * bundle). Returns base64 data URLs (the pending app has no public screenshot
+   * URL yet — it isn't approved). Re-runs the SAME caps / magic-byte / name
+   * validation as submit, so a malformed screenshot surfaces here too.
+   *
+   * `moderatorProcedure` + the `isModerator` belt + `enforceAppBlocksFlag`: a
+   * non-mod / anon caller is denied before any bundle is read. No public path.
+   */
+  getPublishRequestScreenshots: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(getPublishRequestScreenshotsSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Mod review is restricted to civitai team');
+      }
+      const { getPublishRequestScreenshots } = await import(
+        '~/server/services/blocks/publish-request.service'
+      );
+      const items = await getPublishRequestScreenshots({
+        publishRequestId: input.publishRequestId,
+      });
+      return { items };
     }),
 
   /**

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -24,6 +24,27 @@ export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MiB per file
 // above any legitimate web bundle's decompressed size yet bounds memory.
 export const MAX_TOTAL_DECOMPRESSED_BYTES = 200 * 1024 * 1024; // 200 MiB
 
+// F-E E5 marketplace screenshot gallery caps. Screenshots are PUBLISHER-SUPPLIED
+// images (an abuse vector), so they get their own tighter caps ON TOP OF the
+// generic bundle caps above:
+//   - count: a gallery, not a dumping ground — extra entries are REJECTED (not
+//     silently truncated) so a publisher can't smuggle payload files past the
+//     reviewer's eye by burying them past a truncation point.
+//   - per-file size: 2 MiB is generous for a screenshot but well under the
+//     10 MiB generic per-file cap, bounding the public-image storage + bandwidth.
+// Both are enforced in extractScreenshots (publish-request.service.ts); a test
+// FAILS if either cap is removed.
+export const MAX_SCREENSHOTS = 8;
+export const MAX_SCREENSHOT_SIZE_BYTES = 2 * 1024 * 1024; // 2 MiB per screenshot
+// Only these extensions are accepted under screenshots/ — and each file's BYTES
+// must additionally match the corresponding image magic-bytes signature (the
+// extension alone is NOT trusted). webp validation also confirms the RIFF...WEBP
+// container, jpeg the SOI marker, png the 8-byte signature.
+export const SCREENSHOT_EXTENSIONS = ['png', 'webp', 'jpg', 'jpeg'] as const;
+export type ScreenshotExtension = (typeof SCREENSHOT_EXTENSIONS)[number];
+// The reserved bundle dir screenshots live under. Anything else is ignored.
+export const SCREENSHOT_DIR = 'screenshots/';
+
 export const submitVersionSchema = z.object({
   // Base64-encoded ZIP bytes. Server decodes, validates size, then
   // extracts manifest.blockId / manifest.version / manifest.name as the
@@ -81,6 +102,15 @@ export const rejectRequestSchema = z.object({
 });
 
 export type RejectRequestInput = z.infer<typeof rejectRequestSchema>;
+
+/** Input for the MOD-ONLY `blocks.getPublishRequestScreenshots` (F-E E5 review). */
+export const getPublishRequestScreenshotsSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+});
+
+export type GetPublishRequestScreenshotsInput = z.infer<
+  typeof getPublishRequestScreenshotsSchema
+>;
 
 export const backfillPublishRequestSchema = z.object({
   slug: z.string().min(3).max(40).regex(SLUG_REGEX),

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -309,9 +309,65 @@ export type MarketplaceMeta = {
  *                      DOMAIN>`), the same already-public origin the host
  *                      iframes. Built server-side from the blockId + APPS_DOMAIN
  *                      so the client never needs the domain. No token, no scope.
+ *   - `screenshots`  — F-E E5 publisher-supplied screenshot gallery. ONLY the
+ *                      public DISPLAY URL of each screenshot (served by the gated
+ *                      `/api/blocks/screenshot/<appBlockId>/<index>.<ext>` route)
+ *                      + its index/contentType. These images were auto-discovered
+ *                      from the bundle, magic-byte-validated, and MOD-REVIEWED
+ *                      before approval — display-safe public data. The underlying
+ *                      MinIO key is NOT exposed (the URL is an opaque app route).
+ *                      Empty array when the app shipped no `screenshots/` dir.
  *
  * Add a field here ONLY after confirming it is publisher-display-safe for anon.
  */
+export type PublicScreenshot = {
+  index: number;
+  url: string;
+  contentType: string;
+};
+
+/** The accepted public screenshot content-types — anything else is dropped so a
+ *  stored record can never coerce the client into a non-image rendering. */
+const PUBLIC_SCREENSHOT_CONTENT_TYPES = new Set(['image/png', 'image/webp', 'image/jpeg']);
+const PUBLIC_SCREENSHOT_EXTS = new Set(['png', 'webp', 'jpg', 'jpeg']);
+
+/**
+ * F-E E5 — project the raw stored `app_blocks.screenshots` jsonb (an array of
+ * `{ key, index, ext, contentType }`) into the PUBLIC gallery shape: ONLY a
+ * display URL + index + content-type. The underlying MinIO `key` is NEVER
+ * exposed — the URL is the opaque, gated `/api/blocks/screenshot/<appBlockId>/
+ * <index>.<ext>` app route. Defensive against arbitrary/legacy jsonb:
+ *   - drops any entry whose index isn't a non-negative int,
+ *   - drops any entry whose ext/contentType isn't in the image allowlist (so a
+ *     tampered/legacy row can't smuggle a non-image content-type to the client),
+ *   - builds the URL from appBlockId + index + ext server-side (never trusts a
+ *     stored URL/key), so a malicious key in the column can't redirect the img.
+ * Returns [] for NULL / non-array / all-invalid.
+ */
+export function toPublicScreenshots(appBlockId: string, raw: unknown): PublicScreenshot[] {
+  if (!Array.isArray(raw)) return [];
+  const out: PublicScreenshot[] = [];
+  for (const entry of raw) {
+    const e = (entry ?? {}) as Record<string, unknown>;
+    const index = e.index;
+    const ext = typeof e.ext === 'string' ? e.ext.toLowerCase() : '';
+    const contentType = typeof e.contentType === 'string' ? e.contentType : '';
+    if (typeof index !== 'number' || !Number.isInteger(index) || index < 0) continue;
+    if (!PUBLIC_SCREENSHOT_EXTS.has(ext)) continue;
+    if (!PUBLIC_SCREENSHOT_CONTENT_TYPES.has(contentType)) continue;
+    out.push({
+      index,
+      // Server-built opaque app route — never the stored key/url. encodeURIComponent
+      // the id defensively (it's a ULID-shaped PK, but be safe).
+      url: `/api/blocks/screenshot/${encodeURIComponent(appBlockId)}/${index}.${ext}`,
+      contentType,
+    });
+  }
+  // Stable display order by index.
+  out.sort((a, b) => a.index - b.index);
+  return out;
+}
+
 export type PublicAppDetail = {
   id: string;
   blockId: string;
@@ -323,4 +379,5 @@ export type PublicAppDetail = {
   version: string | null;
   installCount: number;
   liveUrl: string;
+  screenshots: PublicScreenshot[];
 };

--- a/src/server/services/__tests__/block-registry.get-app-detail.test.ts
+++ b/src/server/services/__tests__/block-registry.get-app-detail.test.ts
@@ -86,6 +86,13 @@ function rawRow(over: Partial<Record<string, unknown>> = {}) {
     version: '1.2.3',
     approved_scopes: ['ai:write:budgeted', 'models:read:self'],
     install_count: 7n,
+    // F-E E5 stored screenshot records (jsonb). The projection must expose ONLY
+    // a public DISPLAY URL + index + content-type — NEVER the underlying MinIO
+    // `key`. Index/ext build the opaque gated app route.
+    screenshots: [
+      { key: 'screenshots/ab_1/0.png', index: 0, ext: 'png', contentType: 'image/png' },
+      { key: 'screenshots/ab_1/1.jpg', index: 1, ext: 'jpg', contentType: 'image/jpeg' },
+    ],
     manifest: {
       name: 'Cool Block',
       description: 'Does cool things',
@@ -201,6 +208,7 @@ describe('BlockRegistry.getAppDetail — anon-exposure protections (F-E E2)', ()
         'liveUrl',
         'manifest',
         'scopes',
+        'screenshots',
         'version',
       ].sort()
     );
@@ -215,6 +223,53 @@ describe('BlockRegistry.getAppDetail — anon-exposure protections (F-E E2)', ()
     const detail = await BlockRegistry.getAppDetail('ab_1');
     expect(detail!.liveUrl).toBe('https://cool-block.civit.ai');
     expect(detail!.liveUrl).not.toMatch(/token|jwt|secret|\?/i);
+  });
+
+  it('screenshots are PUBLIC display URLs only — the stored MinIO key never leaks (F-E E5)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.screenshots).toEqual([
+      { index: 0, url: '/api/blocks/screenshot/ab_1/0.png', contentType: 'image/png' },
+      { index: 1, url: '/api/blocks/screenshot/ab_1/1.jpg', contentType: 'image/jpeg' },
+    ]);
+    // The opaque app route only — never the underlying MinIO key.
+    const serialized = JSON.stringify(detail!.screenshots);
+    expect(serialized).not.toContain('screenshots/ab_1/0.png'); // the raw stored key
+    expect(serialized).not.toContain('"key"');
+    for (const shot of detail!.screenshots) {
+      expect(shot.url.startsWith('/api/blocks/screenshot/')).toBe(true);
+      expect(shot.url).not.toMatch(/token|jwt|secret|\?/i);
+    }
+  });
+
+  it('a NULL screenshots column yields an empty gallery (no crash) (F-E E5)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([rawRow({ screenshots: null })]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.screenshots).toEqual([]);
+  });
+
+  it('a non-image content-type in a stored screenshot record is DROPPED (F-E E5)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      rawRow({
+        screenshots: [
+          { key: 'screenshots/ab_1/0.png', index: 0, ext: 'png', contentType: 'image/png' },
+          // tampered/legacy entry — must be dropped, not surfaced to the client.
+          { key: 'screenshots/ab_1/1.html', index: 1, ext: 'html', contentType: 'text/html' },
+        ],
+      }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.screenshots).toHaveLength(1);
+    expect(detail!.screenshots[0].contentType).toBe('image/png');
+  });
+
+  it('SELECTs the screenshots column (so getAppDetail can render the gallery)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.getAppDetail('ab_1');
+    const sql = capturedSql();
+    expect(sql).toMatch(/ab\.screenshots/);
   });
 
   it('a NULL approved_scopes column yields an empty scope list (no crash)', async () => {

--- a/src/server/services/__tests__/block-registry.get-app-detail.test.ts
+++ b/src/server/services/__tests__/block-registry.get-app-detail.test.ts
@@ -265,6 +265,23 @@ describe('BlockRegistry.getAppDetail — anon-exposure protections (F-E E2)', ()
     expect(detail!.screenshots[0].contentType).toBe('image/png');
   });
 
+  it('a VALID image extension paired with a non-image content-type is DROPPED (content-type allowlist is independent of the ext check, F-E E5 Low-3)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      rawRow({
+        screenshots: [
+          // ext is an allowlisted image ext (png) but the recorded content-type
+          // is text/html — the content-type allowlist must drop it on its OWN
+          // (the ext check alone would let this through). Exercises the
+          // content-type belt independently of the ext belt.
+          { key: 'screenshots/ab_1/0.png', index: 0, ext: 'png', contentType: 'text/html' },
+        ],
+      }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail!.screenshots).toHaveLength(0);
+  });
+
   it('SELECTs the screenshots column (so getAppDetail can render the gallery)', async () => {
     const { BlockRegistry } = await import('../block-registry.service');
     await BlockRegistry.getAppDetail('ab_1');

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -29,7 +29,7 @@ import type {
   SubscriptionScope,
 } from '~/server/schema/blocks/subscription.schema';
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
-import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schema';
+import { toPublicBlockManifest, toPublicScreenshots } from '~/server/schema/blocks/subscription.schema';
 
 const CACHE_TTL_SECONDS = 60;
 export const MAX_BLOCKS_PER_SLOT = 3;
@@ -2381,6 +2381,10 @@ export class BlockRegistry {
       version: string | null;
       approved_scopes: string[] | null;
       install_count: bigint;
+      // F-E E5: stored screenshot records ([{ key, index, ext, contentType }]),
+      // jsonb. NULL until the E5 migration is applied + an app is (re)approved
+      // with a `screenshots/` dir — projected to PUBLIC display URLs below.
+      screenshots: unknown;
     };
     const rows = (await dbRead.$queryRaw<Row[]>`
       SELECT
@@ -2393,6 +2397,7 @@ export class BlockRegistry {
         ab.content_rating,
         ab.version,
         ab.approved_scopes,
+        ab.screenshots,
         (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
          WHERE bus.app_block_id = ab.id) AS install_count
       FROM app_blocks ab
@@ -2425,6 +2430,11 @@ export class BlockRegistry {
       // Already-public standalone origin (no token/scope). Same host the webhook
       // validates the submitted bundle's iframe.src against.
       liveUrl: `https://${row.block_id}.${env.APPS_DOMAIN}`,
+      // F-E E5 screenshot gallery — PUBLIC display URLs only (the gated app
+      // route), built server-side from appBlockId + index + ext. The stored
+      // MinIO key is never exposed; a NULL column (pre-migration / no screenshots)
+      // yields []. These images were magic-byte-validated + mod-reviewed.
+      screenshots: toPublicScreenshots(row.id, row.screenshots),
     };
   }
 

--- a/src/server/services/blocks/__tests__/extract-screenshots.test.ts
+++ b/src/server/services/blocks/__tests__/extract-screenshots.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import {
+  detectImageType,
+  extractScreenshots,
+} from '../publish-request.service';
+import {
+  MAX_SCREENSHOTS,
+  MAX_SCREENSHOT_SIZE_BYTES,
+} from '~/server/schema/blocks/publish-request.schema';
+
+/**
+ * F-E E5 — security coverage for the bundle screenshot capture (publisher
+ * images are an abuse vector). These tests pin the caps + validation so they
+ * FAIL if any is removed (mutation-meaningful):
+ *   - discovery of `screenshots/*` images
+ *   - count cap (>N rejected, NOT truncated)
+ *   - per-file size cap
+ *   - real-image magic-byte validation (a `.png` that isn't a PNG → rejected)
+ *   - path-traversal / sub-dir / odd-name rejection
+ *   - "no screenshots dir → []"
+ */
+
+// --- minimal valid image byte sequences (real magic-byte signatures) ---------
+const PNG_SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_SIG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+function pngBytes(extraBytes = 16): Buffer {
+  return Buffer.concat([PNG_SIG, Buffer.alloc(extraBytes, 0x42)]);
+}
+function jpegBytes(extraBytes = 16): Buffer {
+  return Buffer.concat([JPEG_SIG, Buffer.alloc(extraBytes, 0x42)]);
+}
+function webpBytes(payloadBytes = 16): Buffer {
+  // "RIFF" <size:4> "WEBP" <payload>
+  return Buffer.concat([
+    Buffer.from('RIFF', 'ascii'),
+    Buffer.alloc(4, 0x00),
+    Buffer.from('WEBP', 'ascii'),
+    Buffer.alloc(payloadBytes, 0x42),
+  ]);
+}
+
+async function makeBundle(files: Record<string, Buffer | string>): Promise<Buffer> {
+  const zip = new JSZip();
+  // Always include a manifest so the bundle resembles a real one (not required
+  // by extractScreenshots, but keeps the fixtures realistic).
+  zip.file('block.manifest.json', JSON.stringify({ blockId: 'x', version: '0.1.0', name: 'X' }));
+  for (const [path, content] of Object.entries(files)) {
+    zip.file(path, content);
+  }
+  return Buffer.from(await zip.generateAsync({ type: 'nodebuffer' }));
+}
+
+describe('detectImageType (magic-byte validation)', () => {
+  it('accepts real PNG/JPEG/WebP bytes for the matching extension', () => {
+    expect(detectImageType(pngBytes(), 'png')).toBe('png');
+    expect(detectImageType(jpegBytes(), 'jpg')).toBe('jpg');
+    expect(detectImageType(jpegBytes(), 'jpeg')).toBe('jpg'); // jpeg normalises to jpg
+    expect(detectImageType(webpBytes(), 'webp')).toBe('webp');
+  });
+
+  it('REJECTS bytes that do not match the claimed extension (extension is not trusted)', () => {
+    // A real JPEG masquerading as .png → rejected.
+    expect(detectImageType(jpegBytes(), 'png')).toBeNull();
+    // A PNG claimed as .webp → rejected.
+    expect(detectImageType(pngBytes(), 'webp')).toBeNull();
+    // Arbitrary non-image bytes (e.g. an HTML/script payload) → rejected.
+    expect(detectImageType(Buffer.from('<html>not an image</html>'), 'png')).toBeNull();
+  });
+
+  it('RIFF without the WEBP fourCC is not a webp (e.g. a WAV)', () => {
+    const riffWav = Buffer.concat([
+      Buffer.from('RIFF', 'ascii'),
+      Buffer.alloc(4, 0),
+      Buffer.from('WAVE', 'ascii'),
+      Buffer.alloc(16, 0),
+    ]);
+    expect(detectImageType(riffWav, 'webp')).toBeNull();
+  });
+});
+
+describe('extractScreenshots', () => {
+  it('discovers screenshots/* images in deterministic index order', async () => {
+    const buf = await makeBundle({
+      'screenshots/b.png': pngBytes(),
+      'screenshots/a.jpg': jpegBytes(),
+      'screenshots/c.webp': webpBytes(),
+      'index.html': '<!doctype html>',
+    });
+    const shots = await extractScreenshots(buf);
+    expect(shots.map((s) => s.index)).toEqual([0, 1, 2]);
+    // Sorted by path: a.jpg, b.png, c.webp.
+    expect(shots.map((s) => s.ext)).toEqual(['jpg', 'png', 'webp']);
+    expect(shots.map((s) => s.contentType)).toEqual([
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+    ]);
+  });
+
+  it('returns [] when there is no screenshots/ directory', async () => {
+    const buf = await makeBundle({ 'index.html': '<!doctype html>', 'app.js': 'x' });
+    expect(await extractScreenshots(buf)).toEqual([]);
+  });
+
+  it('REJECTS more than MAX_SCREENSHOTS (count cap; not truncated)', async () => {
+    const files: Record<string, Buffer> = {};
+    for (let i = 0; i <= MAX_SCREENSHOTS; i += 1) {
+      // MAX_SCREENSHOTS + 1 entries → must reject.
+      files[`screenshots/shot-${String(i).padStart(2, '0')}.png`] = pngBytes();
+    }
+    const buf = await makeBundle(files);
+    await expect(extractScreenshots(buf)).rejects.toThrow(
+      new RegExp(`max ${MAX_SCREENSHOTS} screenshots`)
+    );
+  });
+
+  it('accepts exactly MAX_SCREENSHOTS (boundary)', async () => {
+    const files: Record<string, Buffer> = {};
+    for (let i = 0; i < MAX_SCREENSHOTS; i += 1) {
+      files[`screenshots/shot-${String(i).padStart(2, '0')}.png`] = pngBytes();
+    }
+    const buf = await makeBundle(files);
+    const shots = await extractScreenshots(buf);
+    expect(shots.length).toBe(MAX_SCREENSHOTS);
+  });
+
+  it('REJECTS a screenshot over the per-file size cap', async () => {
+    // Use a small injected cap so the fixture stays tiny but still exercises the
+    // per-file bound. PNG sig + (cap) bytes = cap+8 > cap → reject.
+    const cap = 1024;
+    const big = Buffer.concat([PNG_SIG, Buffer.alloc(cap, 0x42)]);
+    const buf = await makeBundle({ 'screenshots/big.png': big });
+    await expect(
+      extractScreenshots(buf, { maxScreenshotSizeBytes: cap })
+    ).rejects.toThrow(/over \d+ bytes|max \d+ per screenshot/);
+  });
+
+  it('default per-file cap is enforced (MAX_SCREENSHOT_SIZE_BYTES)', async () => {
+    // One byte over the real default cap → reject (without an injected cap).
+    const big = Buffer.concat([PNG_SIG, Buffer.alloc(MAX_SCREENSHOT_SIZE_BYTES, 0x42)]);
+    const buf = await makeBundle({ 'screenshots/big.png': big });
+    await expect(extractScreenshots(buf)).rejects.toThrow(/over|max/);
+  });
+
+  it('REJECTS a .png whose bytes are NOT a real PNG (magic-byte validation)', async () => {
+    const buf = await makeBundle({
+      // Claims .png, but the bytes are a JPEG.
+      'screenshots/fake.png': jpegBytes(),
+    });
+    await expect(extractScreenshots(buf)).rejects.toThrow(/not a valid PNG image/);
+  });
+
+  it('REJECTS a screenshot that is not an image at all (script payload as .webp)', async () => {
+    const buf = await makeBundle({
+      'screenshots/evil.webp': Buffer.from('<script>alert(1)</script>'),
+    });
+    await expect(extractScreenshots(buf)).rejects.toThrow(/not a valid WEBP image/);
+  });
+
+  it('REJECTS a sub-directory entry under screenshots/ (no nested paths)', async () => {
+    const buf = await makeBundle({ 'screenshots/nested/a.png': pngBytes() });
+    await expect(extractScreenshots(buf)).rejects.toThrow(/invalid screenshot filename/);
+  });
+
+  it('REJECTS a leading-dot / odd filename', async () => {
+    const buf = await makeBundle({ 'screenshots/.hidden.png': pngBytes() });
+    await expect(extractScreenshots(buf)).rejects.toThrow(/invalid screenshot filename/);
+  });
+
+  it('REJECTS a disallowed extension under screenshots/', async () => {
+    const buf = await makeBundle({ 'screenshots/notes.svg': pngBytes() });
+    await expect(extractScreenshots(buf)).rejects.toThrow(/must be one of/);
+  });
+
+  it('ignores a non-image file that is not under screenshots/', async () => {
+    const buf = await makeBundle({
+      'screenshots/ok.png': pngBytes(),
+      'assets/logo.svg': '<svg></svg>',
+      'README.md': '# hi',
+    });
+    const shots = await extractScreenshots(buf);
+    expect(shots.length).toBe(1);
+    expect(shots[0].ext).toBe('png');
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -1055,8 +1055,11 @@ describe('approveRequest', () => {
     // triggered by approveRequest itself (the git-push webhook no longer
     // triggers builds). The committed sha is stamped onto current_version_sha
     // (the webhook's approval marker) and the Tekton build is kicked.
+    // F-E E5: step-6 also persists the validated screenshot set. This bundle
+    // has no `screenshots/` dir, so the gallery is the empty array (a re-approve
+    // that removed screenshots would clear the column the same way).
     expect(mockDbWrite.appBlock.update).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { currentVersionSha: 'commit_sha_abc' } })
+      expect.objectContaining({ data: { currentVersionSha: 'commit_sha_abc', screenshots: [] } })
     );
     expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
     expect(mockTriggerBuild).toHaveBeenCalledWith(

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -5,7 +5,12 @@ import {
   MAX_BUNDLE_SIZE_BYTES,
   MAX_FILES_IN_BUNDLE,
   MAX_FILE_SIZE_BYTES,
+  MAX_SCREENSHOT_SIZE_BYTES,
+  MAX_SCREENSHOTS,
   MAX_TOTAL_DECOMPRESSED_BYTES,
+  SCREENSHOT_DIR,
+  SCREENSHOT_EXTENSIONS,
+  type ScreenshotExtension,
 } from '~/server/schema/blocks/publish-request.schema';
 // Pure shared module (only depends on token-scope.constants) — safe to import
 // statically without coupling to env/Prisma, so the pure-helper tests still run.
@@ -270,6 +275,233 @@ export async function extractBundleMetadata(
   return { files, manifest };
 }
 
+// ---------------------------------------------------------------------------
+// F-E E5 — screenshot capture (convention-based bundle discovery).
+// ---------------------------------------------------------------------------
+
+/** A validated, magic-byte-checked screenshot extracted from a bundle. */
+export type ExtractedScreenshot = {
+  /** 0-based gallery position (display order = ascending bundle-path order). */
+  index: number;
+  /** Normalised extension (jpg, not jpeg) used for the stored object key + content-type. */
+  ext: ScreenshotExtension;
+  /** MIME type derived from the validated magic bytes (NOT the filename). */
+  contentType: string;
+  /** Raw decompressed image bytes. */
+  content: Buffer;
+};
+
+const SCREENSHOT_CONTENT_TYPE: Record<ScreenshotExtension, string> = {
+  png: 'image/png',
+  webp: 'image/webp',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+};
+
+/**
+ * A screenshot filename under `screenshots/` may ONLY be a flat, safe name:
+ * no nested dirs, no path-traversal, no leading dot, just `[A-Za-z0-9._-]`
+ * before the extension. This rejects `screenshots/../evil`, `screenshots/a/b.png`
+ * (sub-dir), `screenshots/.hidden.png`, and odd/encoded names — the entry must
+ * be exactly `screenshots/<name>.<ext>` at the top of the screenshots dir.
+ */
+const SCREENSHOT_NAME_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * Validate that `buf` actually IS an image of the claimed extension by its
+ * magic bytes — the file EXTENSION is never trusted (a `.png` that is really a
+ * script/HTML/SVG payload must be REJECTED). This is the core anti-abuse check
+ * for publisher-supplied images: the public gallery only ever serves bytes that
+ * passed this gate, with the content-type derived from the bytes, not the name.
+ *
+ *   - PNG  : 89 50 4E 47 0D 0A 1A 0A   (8-byte signature)
+ *   - JPEG : FF D8 FF                   (SOI marker)
+ *   - WebP : "RIFF" .... "WEBP"         (RIFF container, WEBP fourCC at byte 8)
+ *
+ * Returns the normalised extension the bytes match, or null if the bytes don't
+ * match the claimed extension's signature (claimed-vs-actual must agree — a real
+ * JPEG uploaded as `.png` is rejected too, so the content-type we serve is
+ * always correct + consistent with the stored key).
+ */
+export function detectImageType(buf: Buffer, claimedExt: ScreenshotExtension): ScreenshotExtension | null {
+  const isPng =
+    buf.length >= 8 &&
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47 &&
+    buf[4] === 0x0d &&
+    buf[5] === 0x0a &&
+    buf[6] === 0x1a &&
+    buf[7] === 0x0a;
+  const isJpeg = buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff;
+  const isWebp =
+    buf.length >= 12 &&
+    buf.toString('ascii', 0, 4) === 'RIFF' &&
+    buf.toString('ascii', 8, 12) === 'WEBP';
+
+  // The bytes must match the claimed extension's family. `.jpg`/`.jpeg` are the
+  // same format → both require the JPEG signature and normalise to `jpg`.
+  if (claimedExt === 'png') return isPng ? 'png' : null;
+  if (claimedExt === 'webp') return isWebp ? 'webp' : null;
+  if (claimedExt === 'jpg' || claimedExt === 'jpeg') return isJpeg ? 'jpg' : null;
+  return null;
+}
+
+/** Parse + lower-case the extension of a `screenshots/<name>.<ext>` entry. */
+function screenshotExt(filename: string): ScreenshotExtension | null {
+  const dot = filename.lastIndexOf('.');
+  if (dot <= 0) return null; // no extension, or a dotfile with no name
+  const ext = filename.slice(dot + 1).toLowerCase();
+  return (SCREENSHOT_EXTENSIONS as readonly string[]).includes(ext)
+    ? (ext as ScreenshotExtension)
+    : null;
+}
+
+/**
+ * F-E E5 — auto-discover + validate publisher screenshots from a bundle ZIP.
+ *
+ * Convention-based (decision #2): no SDK manifest field. Any entry directly
+ * under the reserved `screenshots/` dir whose name parses to an accepted image
+ * extension is a candidate. Each candidate is validated:
+ *   - NAME      — flat safe name only (SCREENSHOT_NAME_REGEX); no sub-dirs, no
+ *                 `..`, no leading dot, no odd/encoded names. Anything that
+ *                 isn't `screenshots/<safe-name>.<ext>` is REJECTED.
+ *   - SIZE      — per-screenshot cap (MAX_SCREENSHOT_SIZE_BYTES), tighter than
+ *                 the generic per-file cap. Read via the streaming capped reader
+ *                 so an oversized entry aborts before fully materialising.
+ *   - MAGIC     — the BYTES must match the claimed extension's image signature
+ *                 (detectImageType); a `.png` that isn't a real PNG is REJECTED.
+ *   - COUNT     — at most MAX_SCREENSHOTS; the (N+1)th is REJECTED (NOT silently
+ *                 truncated) so a publisher can't bury non-image payloads past a
+ *                 truncation boundary.
+ *
+ * No `screenshots/` dir (or only the bare dir entry) → returns `[]` (fine).
+ *
+ * Pure + DB/MinIO-free so it's unit-testable; called at submit (fail-fast
+ * validation) AND at approve (materialise to MinIO + the app_blocks row).
+ * Index = ascending bundle-path order, so the gallery order is deterministic
+ * and stable across re-submits.
+ *
+ * Throws (with a human-readable message the submit route surfaces inline) on
+ * any cap/validation breach — the WHOLE submission is rejected, consistent with
+ * the existing bundle-validation failure semantics (no partial capture).
+ */
+export async function extractScreenshots(
+  bundleBuffer: Buffer,
+  opts: { maxScreenshots?: number; maxScreenshotSizeBytes?: number } = {}
+): Promise<ExtractedScreenshot[]> {
+  const maxScreenshots = opts.maxScreenshots ?? MAX_SCREENSHOTS;
+  const maxScreenshotSizeBytes = opts.maxScreenshotSizeBytes ?? MAX_SCREENSHOT_SIZE_BYTES;
+
+  const zip = await JSZip.loadAsync(bundleBuffer);
+
+  // Candidate entries: non-dir files whose path begins with `screenshots/`.
+  // Sort by path so the gallery index is deterministic regardless of ZIP order.
+  const candidates = Object.entries(zip.files)
+    .filter(([rawPath, entry]) => !entry.dir && rawPath.startsWith(SCREENSHOT_DIR))
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  // COUNT cap — reject (don't truncate) so nothing is silently dropped.
+  if (candidates.length > maxScreenshots) {
+    throw new Error(
+      `bundle has ${candidates.length} files under ${SCREENSHOT_DIR} (max ${maxScreenshots} screenshots)`
+    );
+  }
+
+  const out: ExtractedScreenshot[] = [];
+  for (const [rawPath, entry] of candidates) {
+    const filename = rawPath.slice(SCREENSHOT_DIR.length);
+    // NAME: must be a flat safe filename — no nested path, no traversal, no
+    // leading dot. (jszip already normalises `..`, but reject any residual
+    // slash / odd name explicitly rather than rely on that.)
+    if (filename.includes('/') || filename.includes('\\') || !SCREENSHOT_NAME_REGEX.test(filename)) {
+      throw new Error(
+        `invalid screenshot filename "${rawPath}" — only flat names like ${SCREENSHOT_DIR}shot-1.png are allowed (no sub-directories, no "..", no leading dot)`
+      );
+    }
+    const claimedExt = screenshotExt(filename);
+    if (!claimedExt) {
+      throw new Error(
+        `screenshot "${rawPath}" must be one of: ${SCREENSHOT_EXTENSIONS.join(', ')}`
+      );
+    }
+    // SIZE: stream with the tighter screenshot cap; aborts mid-stream on breach.
+    let content: Buffer;
+    try {
+      content = await readZipEntryCapped(entry, {
+        maxFileSizeBytes: maxScreenshotSizeBytes,
+        // Screenshots also count against the generic aggregate budget, but the
+        // bundle already passed extractBundleMetadata's aggregate cap; here we
+        // only need the per-screenshot bound, so the "remaining" budget is the
+        // per-file cap itself (any single screenshot over its own cap aborts).
+        remainingTotalBytes: maxScreenshotSizeBytes,
+        maxTotalBytes: maxScreenshotSizeBytes,
+        path: rawPath,
+      });
+    } catch (err) {
+      // Re-wrap the generic over-cap message into a screenshot-specific one.
+      throw new Error(
+        `screenshot "${rawPath}" is over ${maxScreenshotSizeBytes} bytes (max ${maxScreenshotSizeBytes} per screenshot)`
+      );
+    }
+    // MAGIC: the bytes must actually be an image of the claimed type.
+    const detected = detectImageType(content, claimedExt);
+    if (!detected) {
+      throw new Error(
+        `screenshot "${rawPath}" is not a valid ${claimedExt.toUpperCase()} image (its bytes do not match the expected image signature)`
+      );
+    }
+    out.push({
+      index: out.length,
+      ext: detected,
+      contentType: SCREENSHOT_CONTENT_TYPE[detected],
+      content,
+    });
+  }
+  return out;
+}
+
+/**
+ * F-E E5 — upload validated screenshots to the bundle MinIO under a path scoped
+ * by appBlockId (the row that will display them): `screenshots/<appBlockId>/<index>.<ext>`.
+ * Content-type is the magic-byte-derived value (never the filename's). Returns
+ * the stored-screenshot records persisted to `app_blocks.screenshots`.
+ *
+ * Called at APPROVE (when appBlockId is known + the bundle has passed review).
+ * Idempotent on the key: re-approving the same app overwrites the same objects.
+ */
+export type StoredScreenshot = {
+  key: string;
+  index: number;
+  ext: ScreenshotExtension;
+  contentType: string;
+};
+
+async function storeScreenshots(
+  appBlockId: string,
+  screenshots: ExtractedScreenshot[]
+): Promise<StoredScreenshot[]> {
+  if (screenshots.length === 0) return [];
+  const { getBundleBucket, getBundleS3Client } = await import('~/utils/bundle-s3');
+  const client = getBundleS3Client();
+  const bucket = getBundleBucket();
+  const stored: StoredScreenshot[] = [];
+  for (const s of screenshots) {
+    const key = `screenshots/${appBlockId}/${s.index}.${s.ext}`;
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: s.content,
+        ContentType: s.contentType,
+      })
+    );
+    stored.push({ key, index: s.index, ext: s.ext, contentType: s.contentType });
+  }
+  return stored;
+}
+
 /**
  * Diff two file lists (by path + sha256). Returns added/removed/changed
  * paths plus the new file list embedded (so the next submission can diff
@@ -511,6 +743,13 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
 
   const slug = manifest.blockId;
   const version = manifest.version;
+
+  // F-E E5 — validate publisher screenshots NOW (fail-fast) so a bundle with a
+  // too-many / oversized / fake-image / odd-named screenshot is rejected inline
+  // in the submit modal rather than silently carried to the mod queue. The
+  // bytes themselves are re-extracted + uploaded at APPROVE (when appBlockId is
+  // known); here we only assert they pass every cap/magic-byte/name gate.
+  await extractScreenshots(bundleBuffer);
 
   // Static iframe.src sanity check — the deep BlockManifestValidator runs
   // at approve time against the OauthClient.allowedOrigins, but it's worth
@@ -777,9 +1016,8 @@ function isPlatformOwnedPath(path: string): boolean {
  * during approve to push files to Forgejo. Returns Buffer per file (we
  * need binary fidelity for non-text files).
  */
-async function fetchAndExtractBundleFiles(
-  bundleKey: string
-): Promise<Array<{ path: string; content: Buffer }>> {
+/** Fetch the raw bundle ZIP bytes from MinIO by key. */
+async function fetchBundleBuffer(bundleKey: string): Promise<Buffer> {
   const { getBundleBucket, getBundleS3Client } = await import('~/utils/bundle-s3');
   const client = getBundleS3Client();
   const obj = await client.send(
@@ -787,8 +1025,14 @@ async function fetchAndExtractBundleFiles(
   );
   if (!obj.Body) throw new Error(`bundle ${bundleKey} not found in S3`);
   const bytes = await obj.Body.transformToByteArray();
-  const bundleBuffer = Buffer.from(bytes);
+  return Buffer.from(bytes);
+}
 
+/** Extract every file's bytes from an in-memory bundle ZIP, re-applying the
+ *  per-file + running-aggregate caps via the streaming reader. */
+async function extractBundleFilesFromBuffer(
+  bundleBuffer: Buffer
+): Promise<Array<{ path: string; content: Buffer }>> {
   const zip = await JSZip.loadAsync(bundleBuffer);
   const out: Array<{ path: string; content: Buffer }> = [];
   // Defense-in-depth: re-apply per-file + running-aggregate caps via the same
@@ -807,6 +1051,13 @@ async function fetchAndExtractBundleFiles(
     out.push({ path, content });
   }
   return out;
+}
+
+async function fetchAndExtractBundleFiles(
+  bundleKey: string
+): Promise<Array<{ path: string; content: Buffer }>> {
+  const bundleBuffer = await fetchBundleBuffer(bundleKey);
+  return extractBundleFilesFromBuffer(bundleBuffer);
 }
 
 export type ListPendingRequestsOptions = {
@@ -1290,9 +1541,19 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // dropped from the commit — the pipeline injects its own recipe + ignores
   // tenant copies, so committing them to the build-source repo is inert +
   // misleading (audit A8/BUILD-1 Phase 2).
-  const files = (await fetchAndExtractBundleFiles(request.bundleKey)).filter(
+  const bundleBuffer = await fetchBundleBuffer(request.bundleKey);
+  const files = (await extractBundleFilesFromBuffer(bundleBuffer)).filter(
     (f) => !isPlatformOwnedPath(f.path)
   );
+
+  // (4b) F-E E5 — re-extract + validate the bundle's screenshots (same caps /
+  // magic-byte / name gates as submit), then upload them to the bundle MinIO
+  // under `screenshots/<appBlockId>/<index>.<ext>`. Persisted to the row in (6).
+  // The submit path already rejected a bad bundle, so this re-validation should
+  // pass; if a screenshot is somehow invalid here we fail the approve rather
+  // than serve unvalidated publisher bytes. Empty bundle dir → [].
+  const extractedScreenshots = await extractScreenshots(bundleBuffer);
+  const storedScreenshots = await storeScreenshots(appBlockId, extractedScreenshots);
 
   // (5) Atomic single-commit replacement of the repo contents on
   // civitai-apps/<slug>. This commit fires the git-push webhook.
@@ -1313,7 +1574,15 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // the review queue instead of deploying.
   await dbWrite.appBlock.update({
     where: { id: appBlockId },
-    data: { currentVersionSha: forgejoCommitSha },
+    data: {
+      currentVersionSha: forgejoCommitSha,
+      // F-E E5 — persist the validated, uploaded screenshot records. Replaces
+      // the prior set on a re-approve (the storeScreenshots keys are stable per
+      // appBlockId+index, so the objects are overwritten in place). An empty
+      // gallery is stored as [] so a re-submit that REMOVES all screenshots
+      // clears the old set rather than leaving stale entries.
+      screenshots: storedScreenshots as object,
+    },
   });
   await dbWrite.appBlockPublishRequest.update({
     where: { id: request.id },
@@ -1561,6 +1830,43 @@ export async function backfillPublishRequest(
     fileCount: files.length,
     forgejoCommitSha: appBlock.currentVersionSha ?? '',
   };
+}
+
+/**
+ * F-E E5 — MOD review: derive the submitted bundle's screenshots for a publish
+ * request so the reviewer can SEE the publisher-supplied images before approval
+ * (publisher images = an abuse vector → must be reviewed). Re-fetches the stored
+ * bundle from MinIO and re-runs `extractScreenshots` (the SAME caps / magic-byte
+ * / name validation as submit), returning each as a base64 data URL so the
+ * review modal can render plain <img> without a separate public route (the
+ * pending app isn't approved → it has no public screenshot URLs yet).
+ *
+ * Mod-only at the router layer. Returns [] for a request whose bundle has no
+ * `screenshots/` dir. The data URLs are bounded by MAX_SCREENSHOT_SIZE_BYTES *
+ * MAX_SCREENSHOTS (≈16 MiB worst case) — acceptable for a single mod request.
+ */
+export type ReviewScreenshot = {
+  index: number;
+  contentType: string;
+  dataUrl: string;
+};
+
+export async function getPublishRequestScreenshots(opts: {
+  publishRequestId: string;
+}): Promise<ReviewScreenshot[]> {
+  const { dbRead } = await import('~/server/db/client');
+  const row = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: opts.publishRequestId },
+    select: { bundleKey: true },
+  });
+  if (!row) throw new Error(`publish request ${opts.publishRequestId} not found`);
+  const bundleBuffer = await fetchBundleBuffer(row.bundleKey);
+  const screenshots = await extractScreenshots(bundleBuffer);
+  return screenshots.map((s) => ({
+    index: s.index,
+    contentType: s.contentType,
+    dataUrl: `data:${s.contentType};base64,${s.content.toString('base64')}`,
+  }));
 }
 
 export type RejectRequestParams = {

--- a/src/tests/api/blocks/screenshot.test.ts
+++ b/src/tests/api/blocks/screenshot.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * F-E E5 — the public screenshot-serving route
+ * (`/api/blocks/screenshot/[appBlockId]/[file]`). This exercises the SHELL: the
+ * dark-flag gate, the approved-only gate, index parsing/bounds, the
+ * recorded-record lookup, the content-type allowlist, and (on the happy path)
+ * the served headers — incl. the E5 Low-1 `X-Content-Type-Options: nosniff`
+ * belt. The S3 fetch + `isAppBlocksEnabled` + `dbRead` are mocked; we never hit
+ * a real MinIO. Mirrors the ModEndpoint reproduction in submit-version.test.ts.
+ */
+
+const { mockIsAppBlocksEnabled, mockFindUnique, mockUser, mockS3Send } = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn<() => Promise<boolean>>(async () => true),
+  mockFindUnique: vi.fn<(...a: unknown[]) => Promise<unknown>>(async () => null),
+  mockUser: { value: { id: 1, isModerator: true } as { id: number; isModerator?: boolean } | undefined },
+  mockS3Send: vi.fn(async () => ({
+    Body: { transformToByteArray: async () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]) },
+  })),
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/server/db/client', () => ({ dbRead: { appBlock: { findUnique: mockFindUnique } } }));
+// Faithful MixedAuthEndpoint reproduction: GET-only, passes the (maybe-undefined)
+// user straight to the handler — the route's own logic does ALL the gating.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint:
+    (
+      handler: (req: NextApiRequest, res: NextApiResponse, user: unknown) => Promise<unknown>,
+      allowedMethods: string[] = ['GET']
+    ) =>
+    async (req: NextApiRequest, res: NextApiResponse) => {
+      if (!req.method || !allowedMethods.includes(req.method)) {
+        res.status(405).json({ error: 'Method not allowed' });
+        return;
+      }
+      await handler(req, res, mockUser.value);
+    },
+}));
+// The 200 path lazily imports these; mock so the happy path doesn't touch MinIO.
+vi.mock('@aws-sdk/client-s3', () => ({ GetObjectCommand: vi.fn((args: unknown) => args) }));
+vi.mock('~/utils/bundle-s3', () => ({
+  getBundleBucket: () => 'bundles',
+  getBundleS3Client: () => ({ send: mockS3Send }),
+}));
+
+function makeReq(appBlockId: string, file: string): NextApiRequest {
+  return { method: 'GET', headers: {}, query: { appBlockId, file } } as unknown as NextApiRequest;
+}
+function makeRes() {
+  const headers: Record<string, string> = {};
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    _sent: null as unknown,
+    headers,
+    setHeader: vi.fn(function (this: any, k: string, v: string) {
+      headers[k.toLowerCase()] = v;
+      return this;
+    }),
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+    send: vi.fn(function (this: any, b: unknown) {
+      this._sent = b;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & {
+    _status: number;
+    _body: unknown;
+    _sent: unknown;
+    headers: Record<string, string>;
+  };
+}
+async function invoke(appBlockId: string, file: string) {
+  const handler = (await import('~/pages/api/blocks/screenshot/[appBlockId]/[file]')).default;
+  const res = makeRes();
+  await handler(makeReq(appBlockId, file), res);
+  return res;
+}
+
+const PNG = { key: 'screenshots/ab_1/0.png', index: 0, ext: 'png', contentType: 'image/png' };
+
+describe('GET /api/blocks/screenshot/[appBlockId]/[file] (F-E E5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser.value = { id: 1, isModerator: true };
+    mockIsAppBlocksEnabled.mockResolvedValue(true);
+    mockFindUnique.mockResolvedValue({ status: 'approved', screenshots: [PNG] });
+    mockS3Send.mockResolvedValue({
+      Body: { transformToByteArray: async () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]) },
+    });
+  });
+
+  it('404s (fail-closed) when the app-blocks flag is dark — without even a DB lookup', async () => {
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const res = await invoke('ab_1', '0.png');
+    expect(res._status).toBe(404);
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('404s for a NON-approved app (never serves its screenshots)', async () => {
+    mockFindUnique.mockResolvedValue({ status: 'pending', screenshots: [PNG] });
+    const res = await invoke('ab_1', '0.png');
+    expect(res._status).toBe(404);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it('404s for a missing app (no id-enumeration)', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    expect((await invoke('ab_missing', '0.png'))._status).toBe(404);
+  });
+
+  it('404s on a non-numeric / negative / traversal-y index (client cannot pick an arbitrary key)', async () => {
+    expect((await invoke('ab_1', 'abc.png'))._status).toBe(404);
+    expect((await invoke('ab_1', '-1.png'))._status).toBe(404);
+    expect((await invoke('ab_1', '../secret.png'))._status).toBe(404);
+    // no recorded record at this index → 404
+    expect((await invoke('ab_1', '99.png'))._status).toBe(404);
+  });
+
+  it('404s when the recorded record has a non-allowlisted content-type', async () => {
+    mockFindUnique.mockResolvedValue({
+      status: 'approved',
+      screenshots: [{ key: 'k', index: 0, ext: 'png', contentType: 'text/html' }],
+    });
+    const res = await invoke('ab_1', '0.png');
+    expect(res._status).toBe(404);
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it('serves an approved app screenshot by index with the validated content-type + nosniff (Low-1)', async () => {
+    const res = await invoke('ab_1', '0.png');
+    expect(res._status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/png');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    // The S3 key fetched is the STORED key, never anything the client supplied.
+    const sentCmd = mockS3Send.mock.calls[0][0] as { Key?: string };
+    expect(sentCmd.Key).toBe('screenshots/ab_1/0.png');
+  });
+});

--- a/src/tests/api/blocks/screenshot.test.ts
+++ b/src/tests/api/blocks/screenshot.test.ts
@@ -15,7 +15,8 @@ const { mockIsAppBlocksEnabled, mockFindUnique, mockUser, mockS3Send } = vi.hois
   mockIsAppBlocksEnabled: vi.fn<() => Promise<boolean>>(async () => true),
   mockFindUnique: vi.fn<(...a: unknown[]) => Promise<unknown>>(async () => null),
   mockUser: { value: { id: 1, isModerator: true } as { id: number; isModerator?: boolean } | undefined },
-  mockS3Send: vi.fn(async () => ({
+  // Typed param so `.mock.calls[0][0]` is a real (non-empty) tuple element.
+  mockS3Send: vi.fn(async (_cmd: { Key?: string }) => ({
     Body: { transformToByteArray: async () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]) },
   })),
 }));


### PR DESCRIPTION
## F-E Phase E5 — screenshot gallery (capture → moderate → display)

Publisher-provided screenshots alongside the E2 live preview. Plan: `claudedocs/app-platform-fe-marketplace-plan-2026-06-14.md` (Phase E5 + design decision #2). **Convention-based bundle capture, NOT an SDK manifest field** — avoids the npm-2FA cross-repo dependency.

### 🔒 GATING INVARIANT (intact — unchanged)
Stays MODS-ONLY/dark: detail page is flag-gated (`resolveAppsPageAccess` first), `deIndex` ON, `getAppDetail` is `publicProcedure + enforceAppBlocksFlag` (anon-capable but dark), the new screenshot-serving route + the review query are flag/mod-gated. **No Flipt/segment change**, no `isModerator` belt on public read paths. Screenshot URLs are public display data (fine). Launch is still a separate, product-signed-off segment-widen + drop-`deIndex`.

### 🗄️ Migration (MANUAL — NOT CI; must precede the code going live)
`prisma/migrations/20260615120000_e5_screenshots/migration.sql`:
```sql
ALTER TABLE "app_blocks" ADD COLUMN IF NOT EXISTS "screenshots" jsonb;
```
Additive / idempotent / non-breaking (one nullable jsonb column; existing rows + INSERTs unaffected). Per CLAUDE.md DB rule the civitai CNPG nvme0 DB does **not** auto-apply — a **human applies this to prod nvme0 + the dev clone**. `schema.full.prisma` gains `screenshots Json?` on `AppBlock`.

⚠️ **`getAppDetail` SELECTs `ab.screenshots` unconditionally** (like E3's `category`), so the migration MUST be applied **before** the E5 code is live or the detail-page query 500s. The CI/preview build passes without it (the build doesn't query; the anon smoke hits the mod-gated detail page → notFound, so `getAppDetail` never runs).

### Capture security model (publisher images = abuse vector)
Reuses the existing `readZipEntryCapped` streaming caps + the bundle MinIO S3 client. **Added** on top:
- **Count cap** `MAX_SCREENSHOTS=8` — the (N+1)th is **rejected, not truncated** (so a publisher can't bury payloads past a truncation point).
- **Per-file size cap** `MAX_SCREENSHOT_SIZE_BYTES=2 MiB` (tighter than the 10 MiB generic per-file cap), enforced via the streaming reader (aborts mid-stream).
- **Magic-byte validation** — the **bytes** must match the claimed extension's image signature (PNG 8-byte sig / JPEG SOI / RIFF…WEBP); a `.png` that isn't a real PNG, or a script/HTML payload, is **rejected**. The served content-type is derived from the bytes, never the filename.
- **Name sanitization** — only `screenshots/<flat-safe-name>.<ext>`; no sub-dirs, no `..`, no leading dot, `[A-Za-z0-9._-]` only.
- **MinIO path** — uploaded at **approve** (when appBlockId is known) to `screenshots/<appBlockId>/<index>.<ext>` on the bundle MinIO, content-type set. Validated **fail-fast at submit** too (a bad bundle is rejected inline).

### getAppDetail exposure
Adds `screenshots: PublicScreenshot[]` to `PublicAppDetail`, exposing **only** `{ index, url, contentType }`. The `url` is the opaque, gated app route `/api/blocks/screenshot/<appBlockId>/<index>.<ext>` built server-side — **the stored MinIO key is never exposed**. NULL column / non-image content-type entries → dropped → `[]`. Read **only in getAppDetail**, not `listAvailable` (mirrors E2, keeps the pre-migration-500 surface minimal).

### Serving route
`/api/blocks/screenshot/[appBlockId]/[file]` (`MixedAuthEndpoint`): evaluates `isAppBlocksEnabled({ user })` FIRST (dark for anon/non-mod today → 404), serves **only** an `approved` app's **recorded** screenshot (lookup by index → stored key), streams from the internal bundle MinIO with the image content-type. No id-enumeration of unapproved apps, no key/metadata leak.

### Moderate (review.tsx)
Mod-only `blocks.getPublishRequestScreenshots` re-derives the submitted bundle's screenshots (re-runs the same validation) as base64 data URLs (the pending app has no public URL yet); a `ScreenshotsReviewPanel` renders them in the review modal so the mod reviews publisher images before approval.

### Tests
- **`extract-screenshots.test.ts`** (15, mutation-meaningful): discovery + deterministic order; count cap (>8 rejected, =8 boundary); per-file size cap (injected + real default); magic-byte (`.png` that's a JPEG → rejected, script-as-`.webp` → rejected, RIFF-WAV-not-WEBP); sub-dir/leading-dot/odd-ext rejection; no-`screenshots/`-dir → `[]`; `detectImageType` unit cases.
- **`block-registry.get-app-detail.test.ts`** (updated): `screenshots` in the allowlist key set; public-URL-only / **no stored-key leak**; NULL column → `[]`; non-image content-type dropped; SELECTs the column.
- **`publish-request.orchestration.test.ts`** (updated): step-6 `appBlock.update` now persists `screenshots: []` for a no-screenshot bundle.

### Affected-suite run
`blocks/__tests__/*`, `schema/blocks/__tests__/*`, `block-registry.get-app-detail`, `block-registry.subscriptions`, plus the new file: **383 passed / 0 failed**. The 16 failures in `block-registry.list-available` / `.subscriptions.write` / `blocks.router.{subscriptions,workflow}` are the pre-existing worktree `Prisma.sql is not a function` env-resolution failures — **verified identical (4 files / 16 fail) on `origin/main`**, untouched by E5.

### Confirmations
- No dynamic `~/env/server` import in any E5 code (static only — avoids E2's Turbopack chunk collision).
- Public projection not widened beyond display-safe screenshot URLs; `screenshots` read only in `getAppDetail`, not `listAvailable`.
- **Unverified** (no live env): in-browser gallery render, real MinIO upload/serve round-trip, full-project `tsc` (worktree tsc floods pre-existing whole-repo `any`/`Prisma.sql` errors — none in E5 files; the `Prisma.sql` errors in `block-registry.service.ts` are E3's `listAvailable` lines, present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)