### PR TITLE
feat(blocks): disclose app permissions in the install modal (F-D H3, dark/mod-gated)

### DIFF
--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -4,6 +4,7 @@ import {
   Chip,
   Divider,
   Group,
+  Loader,
   Modal,
   NumberInput,
   ScrollArea,
@@ -29,6 +30,7 @@ import type {
   ManifestSettingField,
 } from '~/server/schema/blocks/manifest-settings.meta.schema';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
+import { BlockScopeList } from '~/components/Apps/BlockScopeList';
 import { trpc } from '~/utils/trpc';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { dialogStore } from '~/components/Dialog/dialogStore';
@@ -109,10 +111,8 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
   // authenticated `getInstallConfig` procedure instead, keyed on appBlockId.
   // The "Manage" path (/apps/installed) passes the FULL manifest, so its
   // `manifest.settings` is already populated; the fetched value matches it.
-  const { data: installConfig } = trpc.blocks.getInstallConfig.useQuery(
-    { appBlockId: block.id },
-    { staleTime: 60_000 }
-  );
+  const { data: installConfig, isLoading: installConfigLoading } =
+    trpc.blocks.getInstallConfig.useQuery({ appBlockId: block.id }, { staleTime: 60_000 });
 
   // Manifest-driven settings (W3 Phase 4). Fields without an explicit
   // `scope:` declaration are treated as 'publisher' for back-compat with
@@ -130,6 +130,12 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
     [settingsSource]
   );
   const declaredScopes = installConfig?.scopes ?? manifest.scopes ?? [];
+  // On the install path `block.manifest` is the public allowlist (scopes
+  // stripped), so the scope disclosure depends on getInstallConfig. Suppress
+  // the "doesn't request any permissions" copy until it resolves so we never
+  // flash a false all-clear. The Manage path carries the full manifest, so
+  // `manifest.scopes` is defined and this is never pending there.
+  const scopesPending = manifest.scopes === undefined && installConfigLoading;
 
   // Initialise the form from existing subscriptions when present. Settings
   // are read from whichever scope has them set — they're meant to be
@@ -283,6 +289,21 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
           <Text size="sm" c="dimmed">
             {manifest.description}
           </Text>
+        )}
+
+        <Divider label="This app can" labelPosition="left" />
+        {scopesPending ? (
+          <Group gap="xs">
+            <Loader size="xs" />
+            <Text size="xs" c="dimmed">
+              Loading permissions…
+            </Text>
+          </Group>
+        ) : (
+          <BlockScopeList
+            scopes={declaredScopes}
+            emptyLabel="This app doesn't request any permissions on your account."
+          />
         )}
 
         <Divider label="Where to show this" labelPosition="left" />

--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -111,8 +111,11 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
   // authenticated `getInstallConfig` procedure instead, keyed on appBlockId.
   // The "Manage" path (/apps/installed) passes the FULL manifest, so its
   // `manifest.settings` is already populated; the fetched value matches it.
-  const { data: installConfig, isLoading: installConfigLoading } =
-    trpc.blocks.getInstallConfig.useQuery({ appBlockId: block.id }, { staleTime: 60_000 });
+  const {
+    data: installConfig,
+    isLoading: installConfigLoading,
+    isError: installConfigError,
+  } = trpc.blocks.getInstallConfig.useQuery({ appBlockId: block.id }, { staleTime: 60_000 });
 
   // Manifest-driven settings (W3 Phase 4). Fields without an explicit
   // `scope:` declaration are treated as 'publisher' for back-compat with
@@ -131,11 +134,18 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
   );
   const declaredScopes = installConfig?.scopes ?? manifest.scopes ?? [];
   // On the install path `block.manifest` is the public allowlist (scopes
-  // stripped), so the scope disclosure depends on getInstallConfig. Suppress
-  // the "doesn't request any permissions" copy until it resolves so we never
-  // flash a false all-clear. The Manage path carries the full manifest, so
-  // `manifest.scopes` is defined and this is never pending there.
+  // stripped), so the scope disclosure depends on getInstallConfig. The Manage
+  // path carries the full manifest, so `manifest.scopes` is defined there and
+  // neither of these is ever set.
+  //
+  // - `scopesPending`: still loading → show a loader, never an all-clear.
+  // - `scopesUnavailable`: getInstallConfig errored → declaredScopes falls back
+  //   to [], which would render the "doesn't request any permissions" copy and
+  //   mislead the user into authorizing UNDISCLOSED scopes. Render an explicit
+  //   error instead and block Save so install never proceeds without a real
+  //   disclosure.
   const scopesPending = manifest.scopes === undefined && installConfigLoading;
+  const scopesUnavailable = manifest.scopes === undefined && installConfigError;
 
   // Initialise the form from existing subscriptions when present. Settings
   // are read from whichever scope has them set — they're meant to be
@@ -299,6 +309,11 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
               Loading permissions…
             </Text>
           </Group>
+        ) : scopesUnavailable ? (
+          <Text size="xs" c="red">
+            Couldn&apos;t load this app&apos;s permissions. Close and try again before installing —
+            don&apos;t install without reviewing what it can access.
+          </Text>
         ) : (
           <BlockScopeList
             scopes={declaredScopes}
@@ -428,6 +443,7 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
             <Button
               leftSection={<IconCheck size={16} />}
               loading={upsertMutation.isPending || deleteMutation.isPending}
+              disabled={scopesUnavailable}
               onClick={handleSave}
             >
               Save

--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -16,7 +16,7 @@ import {
   TextInput,
   Title,
 } from '@mantine/core';
-import { IconCheck } from '@tabler/icons-react';
+import { IconAlertTriangle, IconCheck } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import { baseModels as ALL_BASE_MODELS } from '~/shared/constants/base-model.constants';
@@ -111,11 +111,8 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
   // authenticated `getInstallConfig` procedure instead, keyed on appBlockId.
   // The "Manage" path (/apps/installed) passes the FULL manifest, so its
   // `manifest.settings` is already populated; the fetched value matches it.
-  const {
-    data: installConfig,
-    isLoading: installConfigLoading,
-    isError: installConfigError,
-  } = trpc.blocks.getInstallConfig.useQuery({ appBlockId: block.id }, { staleTime: 60_000 });
+  const { data: installConfig, isLoading: installConfigLoading } =
+    trpc.blocks.getInstallConfig.useQuery({ appBlockId: block.id }, { staleTime: 60_000 });
 
   // Manifest-driven settings (W3 Phase 4). Fields without an explicit
   // `scope:` declaration are treated as 'publisher' for back-compat with
@@ -139,13 +136,16 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
   // neither of these is ever set.
   //
   // - `scopesPending`: still loading → show a loader, never an all-clear.
-  // - `scopesUnavailable`: getInstallConfig errored → declaredScopes falls back
-  //   to [], which would render the "doesn't request any permissions" copy and
-  //   mislead the user into authorizing UNDISCLOSED scopes. Render an explicit
-  //   error instead and block Save so install never proceeds without a real
-  //   disclosure.
+  // - `scopesUnavailable`: getInstallConfig did NOT resolve to data (error, or
+  //   any non-success state) → declaredScopes falls back to [], which would
+  //   render the "doesn't request any permissions" copy and mislead the user
+  //   into authorizing UNDISCLOSED scopes. Render an explicit error instead and
+  //   block Save so install never proceeds without a real disclosure. Keyed on
+  //   "not resolved" (`!installConfig`) rather than `isError` so any non-success
+  //   outcome blocks the all-clear, not just an explicit error.
   const scopesPending = manifest.scopes === undefined && installConfigLoading;
-  const scopesUnavailable = manifest.scopes === undefined && installConfigError;
+  const scopesUnavailable =
+    manifest.scopes === undefined && !installConfigLoading && !installConfig;
 
   // Initialise the form from existing subscriptions when present. Settings
   // are read from whichever scope has them set — they're meant to be
@@ -310,10 +310,17 @@ export function AppSettingsModal(props: AppSettingsModalProps) {
             </Text>
           </Group>
         ) : scopesUnavailable ? (
-          <Text size="xs" c="red">
-            Couldn&apos;t load this app&apos;s permissions. Close and try again before installing —
-            don&apos;t install without reviewing what it can access.
-          </Text>
+          <Group gap="xs" wrap="nowrap" align="flex-start" role="alert">
+            <IconAlertTriangle
+              size={16}
+              color="var(--mantine-color-red-6)"
+              style={{ flexShrink: 0 }}
+            />
+            <Text size="xs" c="red">
+              Couldn&apos;t load this app&apos;s permissions. Close and try again before installing
+              — don&apos;t install without reviewing what it can access.
+            </Text>
+          </Group>
         ) : (
           <BlockScopeList
             scopes={declaredScopes}

--- a/src/components/Apps/BlockScopeList.tsx
+++ b/src/components/Apps/BlockScopeList.tsx
@@ -1,0 +1,49 @@
+import { Badge, Group, Stack, Text } from '@mantine/core';
+import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
+
+/**
+ * Renders a block's declared JWT scopes as a badge + friendly-description
+ * list. Shared by the install/manage modal (pre-Save disclosure — UX audit
+ * H3) and the /apps/installed "Apps & permissions" panel so the two surfaces
+ * never drift. Unknown scopes (not in SCOPE_DESCRIPTIONS) render as a bare
+ * badge with an italic "(no description)" — keeping the description map a soft
+ * contract so new scopes ship without breaking the UI.
+ */
+export function BlockScopeList({
+  scopes,
+  emptyLabel = "This app doesn't claim any JWT scopes — it only consumes data from the host-bridge postMessage protocol.",
+}: {
+  scopes: string[];
+  emptyLabel?: string;
+}) {
+  if (scopes.length === 0) {
+    return (
+      <Text size="xs" c="dimmed" fs="italic">
+        {emptyLabel}
+      </Text>
+    );
+  }
+  return (
+    <Stack gap={4}>
+      {scopes.map((scope) => {
+        const desc = SCOPE_DESCRIPTIONS[scope];
+        return (
+          <Group key={scope} gap="xs" wrap="nowrap" align="flex-start">
+            <Badge size="sm" variant="light">
+              {scope}
+            </Badge>
+            {desc ? (
+              <Text size="xs" c="dimmed">
+                {desc}
+              </Text>
+            ) : (
+              <Text size="xs" c="dimmed" fs="italic">
+                (no description)
+              </Text>
+            )}
+          </Group>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/src/pages/apps/installed.tsx
+++ b/src/pages/apps/installed.tsx
@@ -40,7 +40,7 @@ import type {
   AvailableBlock,
   SubscriptionRecord,
 } from '~/server/schema/blocks/subscription.schema';
-import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
+import { BlockScopeList } from '~/components/Apps/BlockScopeList';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { formatDate } from '~/utils/date-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
@@ -379,34 +379,7 @@ function ScopeGrantsPanel() {
               </Stack>
             </Group>
             <Divider />
-            {grant.scopes.length === 0 ? (
-              <Text size="xs" c="dimmed" fs="italic">
-                This app doesn't claim any JWT scopes — it only consumes data from the host-bridge
-                postMessage protocol.
-              </Text>
-            ) : (
-              <Stack gap={4}>
-                {grant.scopes.map((scope) => {
-                  const desc = SCOPE_DESCRIPTIONS[scope];
-                  return (
-                    <Group key={scope} gap="xs" wrap="nowrap" align="flex-start">
-                      <Badge size="sm" variant="light">
-                        {scope}
-                      </Badge>
-                      {desc ? (
-                        <Text size="xs" c="dimmed">
-                          {desc}
-                        </Text>
-                      ) : (
-                        <Text size="xs" c="dimmed" fs="italic">
-                          (no description)
-                        </Text>
-                      )}
-                    </Group>
-                  );
-                })}
-              </Stack>
-            )}
+            <BlockScopeList scopes={grant.scopes} />
           </Stack>
         </Card>
       ))}

--- a/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
@@ -151,10 +151,11 @@ beforeEach(() => {
 });
 
 describe('blocks.getInstallConfig', () => {
-  it('returns settings meta + declared scopes for an approved app (and nothing else)', async () => {
+  it('returns settings meta + approved scopes for an approved app (and nothing else)', async () => {
     mockDbReadAppBlockFindUnique.mockResolvedValue({
       status: 'approved',
       manifest: APPROVED_MANIFEST,
+      approvedScopes: ['ai:write:budgeted', 'models:read:self'],
     });
     const caller = blocksRouter.createCaller(authedCtx(42) as never);
     const out = await caller.getInstallConfig({ appBlockId: 'ab_x' });
@@ -172,6 +173,40 @@ describe('blocks.getInstallConfig', () => {
     expect(out).not.toHaveProperty('trustTier');
     expect(out).not.toHaveProperty('iframe');
     expect(out).not.toHaveProperty('name');
+  });
+
+  // H3 disclosure correctness: the install modal shows these scopes at the
+  // authorization moment, so they MUST equal the mint ceiling (manifest ∩
+  // approvedScopes), NOT the raw self-declared manifest. A scope the mod did
+  // NOT approve will never be minted — disclosing it would over-state, and an
+  // internal/unapproved scope id the manifest declares must not leak. Mirrors
+  // grantScopes' ceiling + getAppDetail's approved-only projection.
+  it('discloses only manifest ∩ approvedScopes — drops mod-narrowed/unapproved scopes', async () => {
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'approved',
+      manifest: {
+        name: 'overclaiming app',
+        scopes: ['ai:write:budgeted', 'models:read:self', 'social:tip:self', 'INTERNAL_secret'],
+      },
+      // The moderator narrowed approval to a subset; the other two are NOT granted.
+      approvedScopes: ['ai:write:budgeted', 'models:read:self'],
+    });
+    const caller = blocksRouter.createCaller(authedCtx(42) as never);
+    const out = await caller.getInstallConfig({ appBlockId: 'ab_overclaim' });
+    expect(out.scopes).toEqual(['ai:write:budgeted', 'models:read:self']);
+    expect(out.scopes).not.toContain('social:tip:self');
+    expect(out.scopes).not.toContain('INTERNAL_secret');
+  });
+
+  it('returns empty scopes when approvedScopes is empty even if the manifest declares some', async () => {
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'approved',
+      manifest: { name: 'pending-approval', scopes: ['ai:write:budgeted'] },
+      approvedScopes: [],
+    });
+    const caller = blocksRouter.createCaller(authedCtx(42) as never);
+    const out = await caller.getInstallConfig({ appBlockId: 'ab_unapproved_scopes' });
+    expect(out.scopes).toEqual([]);
   });
 
   it('returns empty settings + empty scopes for an approved app with no declarations', async () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1142,7 +1142,7 @@ export const blocksRouter = router({
       }
       const block = await dbRead.appBlock.findUnique({
         where: { id: input.appBlockId },
-        select: { status: true, manifest: true },
+        select: { status: true, manifest: true, approvedScopes: true },
       });
       if (!block || block.status !== 'approved') {
         throw throwNotFoundError('App block not found');
@@ -1150,12 +1150,20 @@ export const blocksRouter = router({
       const manifest = (block.manifest ?? {}) as Record<string, unknown>;
       // Project ONLY the install-form inputs. `settings` is validated against
       // manifestSettingsSchema so a malformed/absent declaration yields {} (the
-      // form renders no fields rather than throwing). `scopes` is the declared
-      // scope list the form uses to decide which `requires_scope` fields show.
+      // form renders no fields rather than throwing).
       const parsedSettings = manifestSettingsSchema.safeParse(manifest.settings ?? {});
-      const scopes = Array.isArray(manifest.scopes)
+      // `scopes` = manifest.scopes ∩ approvedScopes — the SAME mod-narrowed
+      // ceiling grantScopes (above) enforces at mint and getAppDetail/
+      // scopesSummary expose on the public surfaces. The disclosure must match
+      // what the app can actually be granted: surfacing raw `manifest.scopes`
+      // would over-state (list scopes the mod did NOT approve, so the app will
+      // never be minted them) and could leak an unapproved/internal scope id
+      // the manifest declares but approval dropped.
+      const manifestScopes = Array.isArray(manifest.scopes)
         ? manifest.scopes.filter((s): s is string => typeof s === 'string')
         : [];
+      const approved = new Set(block.approvedScopes ?? []);
+      const scopes = manifestScopes.filter((s) => approved.has(s));
       return {
         settings: parsedSettings.success ? parsedSettings.data : {},
         scopes,

--- a/src/server/services/blocks/scope-descriptions.constants.ts
+++ b/src/server/services/blocks/scope-descriptions.constants.ts
@@ -26,6 +26,8 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'social:tip:self': 'Post tips on behalf of the viewer',
   'block:settings:read': "Read this block's per-install settings",
   'block:settings:write': "Update this block's per-install settings",
+  'apps:storage:read': "Read this app's private per-install data store",
+  'apps:storage:write': "Write to this app's private per-install data store",
 };
 
 export const SLOT_DESCRIPTIONS: Record<string, string> = {


### PR DESCRIPTION
## F-D H3 — install modal scope disclosure

App-platform UX audit finding **H3**: the install/manage modal (`AppSettingsModal`) let a user authorize an app onto "every model I own" / "every model page I view" **without ever showing the app's JWT scopes**. Consent-gated/money scopes are caught by lazy-consent (`BlockConsentModal`) at the Generate action, but non-gated scopes (`user:read:self`, `models:read:self`, …) were granted silently at install with no disclosure anywhere until the user dug into `/apps/installed` post-hoc.

### Change
- **`AppSettingsModal`** — new **"This app can"** section listing the app's scopes (badge + friendly description), above the placement controls / before Save. Sourced from `getInstallConfig` (the public marketplace manifest strips scopes; the manage path has the full manifest). Loader while pending; on a non-resolved/errored fetch it shows an explicit **alert** (icon + `role="alert"`) and **disables Save** so install never proceeds without a real disclosure.
- **`BlockScopeList`** (new) — extracts the scope badge+description renderer that was inline in `installed.tsx`, so the install modal and the "Apps & permissions" panel share one renderer and can't drift.
- **`SCOPE_DESCRIPTIONS`** — add `apps:storage:read` / `apps:storage:write` (W4 KV scopes), which previously rendered `(no description)`.
- **`getInstallConfig`** — disclose `manifest.scopes ∩ approvedScopes` (the moderator-narrowed mint ceiling), matching `getAppDetail`/`scopesSummary`. Raw `manifest.scopes` would over-state (list unapproved scopes the app is never minted) or leak an internal/unapproved scope id. +2 tests lock the intersection.

### Gating / safety
- **No Flipt/gating change.** Still behind the `features.appBlocks` mod flag; `deIndex` unchanged. Nothing user-visible.
- Lazy-consent unchanged — this only adds disclosure at the install decision point.
- Pure UI + a server-side scope-source correction (well within the existing mod-gated proc). No authz/gate change.

### Audit trail
Two adversarial subagent audits (quality-engineer + security-engineer). Fixes landed in commits 2–3: false "no permissions" all-clear on fetch error → explicit alert + Save-disable (HIGH); raw-manifest-vs-approved-scope disclosure source → intersect with `approvedScopes` (HIGH); robustness (`!installConfig` gating) + a11y (icon/`role=alert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)