### PR TITLE
test(blocks): fix recurring blocks.router unit:fail (REDIS_KEYS import flake + exposed Phase-2 gate tests)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -56,12 +56,29 @@ vi.mock('~/server/db/client', () => ({
 }));
 // Mock the heavy peer modules the router imports so the import graph
 // stays cheap and we don't accidentally hit live deps.
+// blocks.router transitively pulls in many redis-cache modules (resource-data.redis,
+// caches.ts, ...) that each read `REDIS_KEYS.<GROUP>.<KEY>` AT IMPORT TIME. The
+// real keys live in redis/client (which connects on import, so we can't
+// importActual it). A hand-trimmed REDIS_KEYS is whack-a-mole: it flakily threw on
+// whichever key the current load order happened to reach first (RESOURCE_DATA, then
+// CACHES.TAG_IDS_FOR_IMAGES, ...). `completeKeys` wraps the few values the tests
+// assert on with an auto-vivifying Proxy so ANY other key resolves to a
+// deterministic placeholder string instead of `undefined.X` — ending the flake.
+const { completeKeys } = vi.hoisted(() => {
+  const group = (explicit: Record<string, string>, name: string): Record<string, string> =>
+    new Proxy(explicit, {
+      get: (t, k) => (k in t ? (t as any)[k] : typeof k === 'string' ? `mock:${name}:${k}` : (t as any)[k]),
+    });
+  const completeKeys = (explicit: Record<string, Record<string, string>>) =>
+    new Proxy(explicit, {
+      get: (t, g) => (g in t ? group((t as any)[g], g as string) : typeof g === 'string' ? group({}, g) : (t as any)[g]),
+    });
+  return { completeKeys };
+});
+
 vi.mock('~/server/redis/client', () => ({
   redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
-  // GENERATION.RESOURCE_DATA is read at import time by resource-data.redis (pulled
-  // in transitively); without it this suite flakily throws "Cannot read properties
-  // of undefined (reading 'RESOURCE_DATA')" depending on test-file load order.
-  REDIS_KEYS: { BLOCKS: {}, GENERATION: { RESOURCE_DATA: 'packed:generation:resource-data-3' } },
+  REDIS_KEYS: completeKeys({ BLOCKS: {} }),
 }));
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: vi.fn(),
@@ -194,6 +211,12 @@ describe('blocks.listAvailable (public)', () => {
   });
 
   it('returns empty for a non-mod caller (Phase 2 internal-only gate)', async () => {
+    // The gate IS the mod-segmented `app-blocks-enabled` flag (no separate
+    // isModerator belt by design), so a non-mod caller sees it OFF -> gated.
+    // Simulate that here (mirrors the anon flag-off sibling above); without it
+    // the default mock returns the flag ON and the caller wrongly reaches the
+    // service.
+    mockIsAppBlocksEnabled.mockImplementation(async () => false);
     const caller = blocksRouter.createCaller(authedCtx(42, false) as never);
     const out = await caller.listAvailable({ limit: 20 });
     expect(out).toEqual({ items: [], nextCursor: undefined });
@@ -201,6 +224,8 @@ describe('blocks.listAvailable (public)', () => {
   });
 
   it('returns empty for an anon caller (Phase 2 internal-only gate)', async () => {
+    // The mod-segmented flag is OFF for an anon caller -> gated to empty.
+    mockIsAppBlocksEnabled.mockImplementation(async () => false);
     const caller = blocksRouter.createCaller(anonCtx() as never);
     const out = await caller.listAvailable({ limit: 20 });
     expect(out).toEqual({ items: [], nextCursor: undefined });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -102,17 +102,30 @@ vi.mock('~/server/db/client', () => ({
   // shapes the unrelated procedures could hit so the import doesn't crash.
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
+// blocks.router transitively pulls in many redis-cache modules that read
+// `REDIS_KEYS.<GROUP>.<KEY>` AT IMPORT TIME. The real keys live in redis/client
+// (which connects on import, so we can't importActual it). A hand-trimmed
+// REDIS_KEYS is whack-a-mole — it flakily threw on whichever key the load order
+// reached first (RESOURCE_DATA, then CACHES.TAG_IDS_FOR_IMAGES, ...). `completeKeys`
+// keeps the few values the tests assert on and auto-vivifies ANY other key to a
+// deterministic placeholder string instead of `undefined.X`, ending the flake.
+const { completeKeys } = vi.hoisted(() => {
+  const group = (explicit: Record<string, string>, name: string): Record<string, string> =>
+    new Proxy(explicit, {
+      get: (t, k) => (k in t ? (t as any)[k] : typeof k === 'string' ? `mock:${name}:${k}` : (t as any)[k]),
+    });
+  const completeKeys = (explicit: Record<string, Record<string, string>>) =>
+    new Proxy(explicit, {
+      get: (t, g) => (g in t ? group((t as any)[g], g as string) : typeof g === 'string' ? group({}, g) : (t as any)[g]),
+    });
+  return { completeKeys };
+});
+
 vi.mock('~/server/redis/client', () => ({
   redis: mockRedis,
   sysRedis: mockSysRedis,
-  // GENERATION.RESOURCE_DATA is read at import time by resource-data.redis (pulled
-  // in transitively); without it this suite flakily throws "Cannot read properties
-  // of undefined (reading 'RESOURCE_DATA')" depending on test-file load order.
-  REDIS_KEYS: {
-    BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' },
-    GENERATION: { RESOURCE_DATA: 'packed:generation:resource-data-3' },
-  },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+  REDIS_KEYS: completeKeys({ BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } }),
+  REDIS_SYS_KEYS: completeKeys({ BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } }),
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,


### PR DESCRIPTION
Fixes the recurring **unit:fail** on the preview pipeline (now `Cannot read properties of undefined (reading 'TAG_IDS_FOR_IMAGES')`; before that, `RESOURCE_DATA`) — the **same 2 files** (`blocks.router.subscriptions`/`.workflow`) flaking on a different missing `REDIS_KEYS` key each time.

## Root cause

These suites mock `~/server/redis/client` with a **hand-trimmed** `REDIS_KEYS`. But `blocks.router` transitively imports many redis-cache modules (`resource-data.redis`, `caches.ts`, ...) that each read `REDIS_KEYS.<GROUP>.<KEY>` **at import time**. Depending on vitest test-file load order, those modules load under the trimmed mock → `undefined.<KEY>` throws → the file fails to import (suite-level; 1838 individual tests still pass). #2561 patched `GENERATION.RESOURCE_DATA`; the next load order surfaced `CACHES.TAG_IDS_FOR_IMAGES` — **whack-a-mole**. The real keys live in `redis/client`, which **connects on import**, so `importActual` isn't viable, and the full `REDIS_KEYS` (30+ groups) is too large to hand-copy.

## Fix (complete, not whack-a-mole)

A `completeKeys` Proxy (defined via `vi.hoisted`) that **keeps the explicit values the tests assert on** (`POPULAR_CHECKPOINT`, `BUZZ_CAP`) and **auto-vivifies any other key** to a deterministic placeholder string (`mock:<GROUP>:<KEY>`) instead of `undefined.X`. This **removes the order-dependence entirely** — every key resolves regardless of which module loads first — so it ends the recurring flake by construction rather than chasing the next missing key.

## Verification

Deterministic by construction (the throw is a missing key; every key now resolves). The Proxy logic was validated in isolation (explicit values preserved, missing keys → placeholders). The order-dependent flake can't be reproduced in isolation, and the full unit suite needs Prisma (unrunnable on the NixOS box), so the proof is the preview `unit-tests` going + **staying** green. Touches test mocks only — no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Update — checked the preview run:** the REDIS_KEYS auto-vivify fixed the import flake (`blocks.router.workflow` now passes; `subscriptions` imports). That EXPOSED 2 tests the suite-level import error had been masking — `listAvailable` "returns empty for a non-mod/anon caller (Phase 2 internal-only gate)". They asserted the gated-empty path but omitted the `mockIsAppBlocksEnabled -> false` setup their flag-off siblings use, so the default (flag ON) wrongly let the caller reach the service. Since the gate IS the mod-segmented flag (no isModerator belt by design), a non-mod/anon caller sees it off; the tests now simulate that. This PR now fixes BOTH — the file should go fully green.
