### PR TITLE
perf(db): index RedeemableCode(userId, createdAt DESC)

### DIFF
--- a/prisma/migrations/20260615120000_redeemablecode_userid_createdat_idx/migration.sql
+++ b/prisma/migrations/20260615120000_redeemablecode_userid_createdat_idx/migration.sql
@@ -1,0 +1,13 @@
+-- CreateIndex
+--
+-- The "list a user's redeemable codes" query
+--   SELECT ... FROM "RedeemableCode" WHERE "userId" = $1 ORDER BY "createdAt" DESC OFFSET $2
+-- runs ~194k times/week (the table's only index is the pkey on "code"), so each call
+-- does a parallel Seq Scan over the whole table. Verified on the prod-data dev clone:
+--   before: Parallel Seq Scan, ~48.5 ms, ~8266 shared buffers, 2 parallel workers
+--   after : Index Scan,        ~0.32 ms, ~205 shared buffers, no sort
+-- The composite (userId, createdAt DESC) also satisfies the ORDER BY, so the sort node
+-- is eliminated (vs a bare (userId) index which still needs a sort).
+--
+-- Add CONCURRENTLY when running against the production database to avoid locking the table.
+CREATE INDEX "RedeemableCode_userId_createdAt_idx" ON "RedeemableCode"("userId", "createdAt" DESC);

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -4104,6 +4104,8 @@ model RedeemableCode {
   metadata      Json?
   priceId       String?
   price         Price?             @relation(fields: [priceId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt(sort: Desc)])
 }
 
 enum ToolType {


### PR DESCRIPTION
## What
Adds a composite index on `RedeemableCode(userId, createdAt DESC)`.

## Why
The "list a user's redeemable codes" query:
```sql
SELECT code, type, "unitValue", "createdAt", "expiresAt", "redeemedAt", "priceId"
FROM "RedeemableCode" WHERE "userId" = $1 ORDER BY "createdAt" DESC OFFSET $2
```
runs **~194k times/week** but the table's *only* index is the pkey on `code`. Every call does a **parallel Seq Scan over the whole table** (~11,566s total exec time in `pg_stat_statements`). Surfaced by index-advisor issue #106 (datapacket-talos).

## Verification
`EXPLAIN (ANALYZE, BUFFERS)` on the prod-data dev clone (`cnpg-cluster-dev`), worst-case heavy user:

| Plan | Exec | Buffers | Workers |
|---|---|---|---|
| **before** — Parallel Seq Scan | 48.5 ms | 8,266 (~whole table) | 2 |
| `(userId)` — advisor's suggestion | 2.55 ms | 198 | 1 + sort |
| **`(userId, createdAt DESC)` (this PR)** | **0.32 ms** | 205 | Index Scan, no sort |

The composite also serves the `ORDER BY`, so the sort node is eliminated (~150x vs ~19x for the bare `(userId)` index). Index is tiny — table is only ~64MB / 657k rows.

## Applying
Per repo convention the migration is **applied manually** against the civitai DB. **Add `CONCURRENTLY`** when applying to production to avoid locking the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)