### PR TITLE
feat(blocks): name the app in the host trust-chrome (F-D H2, dark/mod-gated)

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { AppBlockChrome } from '~/components/AppBlocks/IframeHost';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+// H2: the host-rendered "trust frame" around an in-model app block must NAME the
+// app (host-side, spoof-proof) — not just carry it in the invisible iframe
+// `title`. `AppBlockChrome` is exported from IframeHost solely so this renders in
+// isolation (the full IframeHost needs a token + postMessage wiring). Props are
+// identical to the render site. Queries go through the global `page`;
+// `cleanup()` after each test (component-setup.tsx) keeps the document clean.
+//
+// NOTE: this env does not load `@mantine/core/styles.css`, so we assert
+// behaviour/attributes — never computed styles (the visual ellipsis is verified
+// via Playwright on a preview, not here).
+describe('AppBlockChrome (H2 host-rendered app name)', () => {
+  test('renders the app name in the chrome', async () => {
+    renderWithProviders(<AppBlockChrome blockInstanceId="inst-1" appName="Background Remover" />);
+    await expect.element(page.getByText('Background Remover')).toBeInTheDocument();
+  });
+
+  test('a long app name renders in full and the name node stays a single truncating row', async () => {
+    const longName = 'Super Mega Ultra Background Removal And Upscaling Studio Pro Plus Max';
+    renderWithProviders(<AppBlockChrome blockInstanceId="inst-2" appName={longName} />);
+
+    // Full text is present — truncation is purely visual, the accessible name is
+    // not clipped — and a very long name doesn't crash/overflow the render.
+    await expect.element(page.getByText(longName)).toBeInTheDocument();
+
+    // Truncation is locked via Mantine's `data-truncate` attribute (CSS-independent;
+    // the ellipsis rule itself ships in @mantine/core/styles.css, not loaded here).
+    // This catches a regression that drops the `truncate` prop from the name node.
+    const nameEl = page.getByTestId('app-block-name').element();
+    expect(nameEl.getAttribute('data-truncate')).toBe('end');
+  });
+
+  test('falls back to "App block" when appName is undefined (never blank)', async () => {
+    renderWithProviders(<AppBlockChrome blockInstanceId="inst-3" />);
+    await expect.element(page.getByText('App block')).toBeInTheDocument();
+    // Guard against a blank/whitespace-only label.
+    const nameEl = page.getByTestId('app-block-name').element();
+    expect((nameEl.textContent ?? '').trim().length).toBeGreaterThan(0);
+  });
+
+  test('the ⋯ menu trigger is still present', async () => {
+    renderWithProviders(<AppBlockChrome blockInstanceId="inst-4" appName="Background Remover" />);
+    await expect.element(page.getByRole('button', { name: 'App block menu' })).toBeInTheDocument();
+  });
+});

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -157,11 +157,14 @@ export function AppBlockChrome({
       {/* minWidth:0 lets the truncating name shrink instead of pushing the
           ⋯ menu out of the narrow sidebar layout. */}
       <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
-        {/* aria-label keeps the provenance signal for screen readers; the
-            visible name (below) tells the user WHICH app is running. */}
+        {/* Provenance signal for screen readers. role="img" is required for the
+            aria-label to be reliably announced — a bare tabler <svg> has no role,
+            so without it the label is dropped. On the fallback the visible "App
+            block" Text carries provenance, so the icon is marked decorative. */}
         <IconApps
           size={14}
           stroke={1.5}
+          role={hasName ? 'img' : undefined}
           aria-label={hasName ? 'App block' : undefined}
           aria-hidden={hasName ? undefined : true}
           style={{ flexShrink: 0 }}

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -11,6 +11,7 @@ import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import { resolveRequestSignIn } from './requestSignInGate';
 import { resolveRequestConsent } from './requestConsentGate';
 import { hideBlock } from './hiddenBlocks';
+import { sanitizeAppChromeName } from './appChromeName';
 import { intersectSandbox } from './sandbox';
 import { projectBlockInitContext, projectBlockInitViewer } from './projectBlockInit';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
@@ -127,17 +128,19 @@ export function AppBlockChrome({
   modelId?: number;
   modelName?: string;
 }) {
-  // The host-rendered name of the running app. Falls back to the literal
-  // "App block" so the trust label is never blank. (H2) Naming the app in the
-  // host chrome — not just the iframe `title` — lets the user tell WHICH
-  // sandboxed app is running and trust its provenance; the iframe can't fake it.
-  const label = appName?.trim() ? appName.trim() : 'App block';
-  // When we fall back to "App block", the icon's aria-label already says
-  // "App block" — drop the icon's label in that case so a screen reader doesn't
-  // read a redundant "App block App block". When we have a real app name, keep
-  // the icon's "App block" provenance aria-label so the icon + name read as
-  // "App block, <name>".
-  const iconAriaLabel = appName?.trim() ? 'App block' : undefined;
+  // The host-rendered name of the running app. (H2) Naming the app in the host
+  // chrome — not just the iframe `title` — lets the user tell WHICH sandboxed
+  // app is running and trust its provenance; the iframe can't fake it. The name
+  // is publisher-controlled, so sanitize it (strip bidi/control/zero-width chars,
+  // collapse whitespace, bound length) before rendering it in the trust label.
+  const sanitizedName = sanitizeAppChromeName(appName);
+  const hasName = sanitizedName !== null;
+  // Falls back to the literal "App block" so the trust label is never blank.
+  const label = sanitizedName ?? 'App block';
+  // When a real name shows, keep the icon's "App block" provenance aria-label so
+  // the icon + name read as "App block, <name>". On the fallback the visible
+  // Text already says "App block", so mark the icon decorative (aria-hidden)
+  // rather than leaving it an unlabeled SVG / double-reading "App block".
   return (
     <Group
       justify="space-between"
@@ -156,7 +159,13 @@ export function AppBlockChrome({
       <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
         {/* aria-label keeps the provenance signal for screen readers; the
             visible name (below) tells the user WHICH app is running. */}
-        <IconApps size={14} stroke={1.5} aria-label={iconAriaLabel} style={{ flexShrink: 0 }} />
+        <IconApps
+          size={14}
+          stroke={1.5}
+          aria-label={hasName ? 'App block' : undefined}
+          aria-hidden={hasName ? undefined : true}
+          style={{ flexShrink: 0 }}
+        />
         {/* Host-rendered (spoof-proof) app-name label. Truncates with an
             ellipsis at a bounded width so a long name never wraps or shoves
             the menu off the row in the narrow model.sidebar_top slot. */}

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { ActionIcon, Box, Group, Menu } from '@mantine/core';
+import { ActionIcon, Box, Group, Menu, Text } from '@mantine/core';
 import { IconApps, IconDots, IconEyeOff } from '@tabler/icons-react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { BlockFallback } from './BlockFallback';
@@ -116,7 +116,7 @@ function storageErrorMessage(err: unknown): string {
  * publisher or anyone else). Rendering it here (vs in the sandboxed iframe) is
  * the whole point — the trust boundary belongs to the host. (Roadmap W7.)
  */
-function AppBlockChrome({
+export function AppBlockChrome({
   blockInstanceId,
   appName,
   modelId,
@@ -127,6 +127,17 @@ function AppBlockChrome({
   modelId?: number;
   modelName?: string;
 }) {
+  // The host-rendered name of the running app. Falls back to the literal
+  // "App block" so the trust label is never blank. (H2) Naming the app in the
+  // host chrome — not just the iframe `title` — lets the user tell WHICH
+  // sandboxed app is running and trust its provenance; the iframe can't fake it.
+  const label = appName?.trim() ? appName.trim() : 'App block';
+  // When we fall back to "App block", the icon's aria-label already says
+  // "App block" — drop the icon's label in that case so a screen reader doesn't
+  // read a redundant "App block App block". When we have a real app name, keep
+  // the icon's "App block" provenance aria-label so the icon + name read as
+  // "App block, <name>".
+  const iconAriaLabel = appName?.trim() ? 'App block' : undefined;
   return (
     <Group
       justify="space-between"
@@ -140,11 +151,18 @@ function AppBlockChrome({
         background: 'var(--mantine-color-default-hover)',
       }}
     >
-      <Group gap={6} wrap="nowrap">
-        {/* Icon only — the "App block" wordmark was dropped as redundant
-            (the icon + the frame itself already signal it). aria-label keeps
-            the provenance signal for screen readers. */}
-        <IconApps size={14} stroke={1.5} aria-label="App block" />
+      {/* minWidth:0 lets the truncating name shrink instead of pushing the
+          ⋯ menu out of the narrow sidebar layout. */}
+      <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+        {/* aria-label keeps the provenance signal for screen readers; the
+            visible name (below) tells the user WHICH app is running. */}
+        <IconApps size={14} stroke={1.5} aria-label={iconAriaLabel} style={{ flexShrink: 0 }} />
+        {/* Host-rendered (spoof-proof) app-name label. Truncates with an
+            ellipsis at a bounded width so a long name never wraps or shoves
+            the menu off the row in the narrow model.sidebar_top slot. */}
+        <Text size="xs" c="dimmed" truncate maw={160} data-testid="app-block-name">
+          {label}
+        </Text>
       </Group>
       <Menu position="bottom-end" shadow="md" width={180}>
         <Menu.Target>

--- a/src/components/AppBlocks/__tests__/appChromeName.test.ts
+++ b/src/components/AppBlocks/__tests__/appChromeName.test.ts
@@ -49,6 +49,40 @@ describe('sanitizeAppChromeName', () => {
     expect(sanitizeAppChromeName(exact)).toBe(exact);
   });
 
+  it('bounds length by code point and never leaves a lone surrogate at the cut', () => {
+    // Emoji straddles the UTF-16 code-unit cut point — a naive `.slice(unit)` would
+    // split the surrogate pair and leave a lone high surrogate (renders as �).
+    const name = 'x'.repeat(APP_CHROME_NAME_MAX - 2) + '😀' + 'y'.repeat(5);
+    const out = sanitizeAppChromeName(name)!;
+    expect(out.endsWith('…')).toBe(true);
+    // No lone surrogate: spreading by code point, a split pair would surface a
+    // single unit in the surrogate range (U+D800–U+DFFF); a valid pair surfaces as
+    // one >U+FFFF code point.
+    const hasLoneSurrogate = [...out].some((ch) => {
+      const cp = ch.codePointAt(0)!;
+      return cp >= 0xd800 && cp <= 0xdfff;
+    });
+    expect(hasLoneSurrogate).toBe(false);
+  });
+
+  it('caps stacked combining marks (Zalgo) so the label can’t overflow the bar', () => {
+    // 70 combining acute accents on one base — the chrome-overflow spoof vector.
+    // NFC composes the base + first mark into a precomposed letter (A + ́ → Á), then
+    // the remaining run is capped: the result is a short, bounded string, not 70
+    // stacked diacritics.
+    const zalgo = 'A' + '́'.repeat(70);
+    const out = sanitizeAppChromeName(zalgo)!;
+    const markCount = [...out].filter((ch) => /\p{M}/u.test(ch)).length;
+    expect(markCount).toBeLessThanOrEqual(2);
+    // Bounded total length (vs the 71-codepoint input) — no overflow.
+    expect([...out].length).toBeLessThanOrEqual(3);
+  });
+
+  it('preserves legitimate diacritics (does not over-strip a real accented name)', () => {
+    // Vietnamese: NFC keeps these as precomposed letters, no marks dropped.
+    expect(sanitizeAppChromeName('Tiếng Việt')).toBe('Tiếng Việt');
+  });
+
   it('keeps legitimate unicode letters (non-format) intact', () => {
     expect(sanitizeAppChromeName('Café Studio')).toBe('Café Studio');
     expect(sanitizeAppChromeName('日本語アプリ')).toBe('日本語アプリ');

--- a/src/components/AppBlocks/__tests__/appChromeName.test.ts
+++ b/src/components/AppBlocks/__tests__/appChromeName.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { APP_CHROME_NAME_MAX, sanitizeAppChromeName } from '../appChromeName';
+
+describe('sanitizeAppChromeName', () => {
+  it('passes a normal name through unchanged', () => {
+    expect(sanitizeAppChromeName('Background Remover')).toBe('Background Remover');
+  });
+
+  it('returns null for empty / undefined / null', () => {
+    expect(sanitizeAppChromeName(undefined)).toBeNull();
+    expect(sanitizeAppChromeName(null)).toBeNull();
+    expect(sanitizeAppChromeName('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only (so the caller falls back to "App block")', () => {
+    expect(sanitizeAppChromeName('   ')).toBeNull();
+    expect(sanitizeAppChromeName('\t\n')).toBeNull();
+  });
+
+  it('trims and collapses internal whitespace / newlines to single spaces', () => {
+    expect(sanitizeAppChromeName('  Cool   App  ')).toBe('Cool App');
+    expect(sanitizeAppChromeName('Line1\nLine2')).toBe('Line1 Line2');
+    expect(sanitizeAppChromeName('a\t\t b')).toBe('a b');
+  });
+
+  it('strips bidi / RTL-override control chars (display-reordering spoof vector)', () => {
+    // U+202E RIGHT-TO-LEFT OVERRIDE — used to visually reverse following text.
+    expect(sanitizeAppChromeName('Safe‮App')).toBe('SafeApp');
+    // A name made entirely of bidi controls collapses to nothing -> null -> fallback.
+    expect(sanitizeAppChromeName('‭‮‬')).toBeNull();
+  });
+
+  it('strips zero-width and other format/control chars', () => {
+    // zero-width space (200B), zero-width joiner (200D), soft hyphen (00AD)
+    expect(sanitizeAppChromeName('Ev​il‍­App')).toBe('EvilApp');
+    // raw control chars: tab (0009) collapses as whitespace, bell (0007) is removed.
+    expect(sanitizeAppChromeName('Tab	Bell')).toBe('Tab Bell');
+  });
+
+  it('bounds the accessible name length (a screen reader reads the full string, not the clipped box)', () => {
+    const long = 'A'.repeat(200);
+    const out = sanitizeAppChromeName(long)!;
+    expect(out.length).toBeLessThanOrEqual(APP_CHROME_NAME_MAX);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('does not truncate a name exactly at the cap', () => {
+    const exact = 'B'.repeat(APP_CHROME_NAME_MAX);
+    expect(sanitizeAppChromeName(exact)).toBe(exact);
+  });
+
+  it('keeps legitimate unicode letters (non-format) intact', () => {
+    expect(sanitizeAppChromeName('Café Studio')).toBe('Café Studio');
+    expect(sanitizeAppChromeName('日本語アプリ')).toBe('日本語アプリ');
+  });
+});

--- a/src/components/AppBlocks/appChromeName.ts
+++ b/src/components/AppBlocks/appChromeName.ts
@@ -31,15 +31,34 @@ export const APP_CHROME_NAME_MAX = 64;
 export function sanitizeAppChromeName(raw: string | undefined | null): string | null {
   if (!raw) return null;
   const cleaned = raw
+    // NFC first so legit base+mark sequences (Vietnamese, etc.) collapse to
+    // precomposed code points — minimises the combining-mark count we then bound.
+    .normalize('NFC')
     // Remove format chars (\p{Cf}: bidi RLO/LRO overrides, zero-width space/joiner,
-    // soft hyphen, …) outright — they have no width and only reorder/hide text.
+    // soft hyphen, BOM, tag chars, …) outright — they have no width and only
+    // reorder/hide text.
     .replace(/\p{Cf}/gu, '')
     // Turn control chars (\p{Cc}: incl. newlines/tabs AND e.g. bell) into spaces so
     // words don't fuse, then collapse whitespace runs to a single space.
     .replace(/\p{Cc}/gu, ' ')
+    // Cap runs of combining marks (\p{M}) at 2 — kills the "Zalgo" overflow vector
+    // (dozens of stacked diacritics bleeding over adjacent host UI) while keeping
+    // legitimate scripts that need 1–2 marks per base. We bound, not strip, so we
+    // don't mangle real non-Latin names.
+    .replace(/\p{M}+/gu, (run) => [...run].slice(0, 2).join(''))
     .replace(/\s+/gu, ' ')
     .trim();
   if (!cleaned) return null;
-  if (cleaned.length <= APP_CHROME_NAME_MAX) return cleaned;
-  return cleaned.slice(0, APP_CHROME_NAME_MAX - 1).trimEnd() + '…';
+  // Bound by CODE POINT (spread), never by UTF-16 code unit — a code-unit slice can
+  // cut a surrogate pair in half, leaving a lone surrogate that renders as �. Strip
+  // any combining mark left dangling at the cut so the ellipsis isn't decorated.
+  const codepoints = [...cleaned];
+  if (codepoints.length <= APP_CHROME_NAME_MAX) return cleaned;
+  return (
+    codepoints
+      .slice(0, APP_CHROME_NAME_MAX - 1)
+      .join('')
+      .replace(/\p{M}+$/u, '')
+      .trimEnd() + '…'
+  );
 }

--- a/src/components/AppBlocks/appChromeName.ts
+++ b/src/components/AppBlocks/appChromeName.ts
@@ -1,0 +1,45 @@
+/**
+ * Sanitize a publisher-declared app name for display in the host-rendered trust
+ * chrome (`AppBlockChrome`).
+ *
+ * The name comes from `manifest.name` — a PUBLISHER-controlled string. H2
+ * promotes it from the invisible iframe `title` into the visible trust label
+ * ("which sandboxed app is this"). The manifest validator only requires a
+ * non-empty string, so without this the chrome would render unbounded,
+ * unsanitized text in the exact surface meant to be a trust signal. This is
+ * defense-in-depth at the render point: it also covers already-approved installs
+ * in the DB, which bypass any future publish-time validator rule.
+ *
+ * It strips the mechanical UI-spoofing vectors:
+ *  - control chars (\p{Cc}) and format chars (\p{Cf} — bidi RLO/LRO overrides,
+ *    zero-width space/joiner, soft hyphen, …) that can reorder or hide displayed
+ *    text or pad the accessible name a screen reader announces,
+ *  - newlines / runs of whitespace (collapsed to single spaces),
+ * and bounds the length (the visual ellipsis only clips the rendered box — the
+ * accessible name a screen reader reads is the full string, so it must be capped
+ * here too).
+ *
+ * It does NOT defend against name-based impersonation ("Civitai", "Official",
+ * homoglyphs) — that needs a host-side verified-publisher / trustTier
+ * differentiator, tracked separately.
+ *
+ * Returns the cleaned name, or `null` when nothing legible remains (the caller
+ * falls back to the literal "App block").
+ */
+export const APP_CHROME_NAME_MAX = 64;
+
+export function sanitizeAppChromeName(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  const cleaned = raw
+    // Remove format chars (\p{Cf}: bidi RLO/LRO overrides, zero-width space/joiner,
+    // soft hyphen, …) outright — they have no width and only reorder/hide text.
+    .replace(/\p{Cf}/gu, '')
+    // Turn control chars (\p{Cc}: incl. newlines/tabs AND e.g. bell) into spaces so
+    // words don't fuse, then collapse whitespace runs to a single space.
+    .replace(/\p{Cc}/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+  if (!cleaned) return null;
+  if (cleaned.length <= APP_CHROME_NAME_MAX) return cleaned;
+  return cleaned.slice(0, APP_CHROME_NAME_MAX - 1).trimEnd() + '…';
+}


### PR DESCRIPTION
## F-D H2 — name the app in the host trust-chrome

App-platform UX audit finding **H2**: the host-rendered "trust frame" (`AppBlockChrome` in `IframeHost.tsx`) around every in-model app block showed only a generic `IconApps` + ⋯ menu and **never named the app**. Its stated purpose is a spoof-proof, host-side "this is a sandboxed third-party app, not native Civitai UI" signal — but without the app's **name**, a user (or logged-out viewer) can't tell *which* app is running or trust its provenance. The name lived only in the invisible iframe `title`.

### Change
- Render `appName` (already passed in as `install.manifest.name`) **host-side** next to the icon — the iframe can't fake it. Truncated (Mantine `truncate`, `maw=160`, parent `minWidth:0` + icon `flexShrink:0`) so a long name ellipsizes instead of pushing the ⋯ menu off the narrow `model.sidebar_top` row.
- Fallback to literal **"App block"** when the name is empty/whitespace (never blank).
- **a11y**: the icon's `aria-label` is conditional — kept as "App block" when a real name shows (SR reads "App block, &lt;name&gt;"), dropped on fallback so it isn't read twice.
- Export `AppBlockChrome` solely for isolated component testing.

### Test coverage
New `AppBlockChrome.browser.test.tsx` (the `component` vitest project, runs in CI `component-tests`): name renders; long name renders in full and the node stays single-row-truncating (asserted via the CSS-independent `data-truncate` attribute, since `@mantine/core/styles.css` isn't loaded in the test env); `undefined` → "App block" fallback (never blank); ⋯ menu trigger still present.

### Gating / safety
- **No Flipt/gating change.** In-model block rendering is already mod-gated via `features.appBlocks`; nothing user-visible.
- Publisher/author **out of scope** — not available on the `install` object host-side (no manifest publisher field); would need owner-join wiring. Noted as a follow-up.
- `needs-live-confirm`: the truncated label's visual ellipsis in the real narrow sidebar slot — to confirm via Playwright on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)