### PR TITLE
fix(api): rank v1 models search by relevance, not recency

### DIFF
--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -108,6 +108,17 @@ export default MixedAuthEndpoint(async function handler(
   let meiliNextCursor: string | undefined;
   if (query) {
     const browsingLevelValues = Flags.instanceToArray(browsingLevel);
+    // Offset-based pagination for relevance-ranked text search.
+    //
+    // The query cursor is now an opaque numeric OFFSET, not a model id. We
+    // dropped the previous `sort: ['id:desc']` because the models index puts
+    // 'sort' first in its rankingRules (models.search-index.ts), so forcing an
+    // id sort made Meili rank by recency instead of text relevance — burying
+    // canonical low-id models (e.g. the original "DreamShaper", id 4384) past
+    // the first pages even though they are the exact-name match. Relevance
+    // ranking surfaces the right model first; id-cursor pagination is
+    // incompatible with that order, so we page by offset instead.
+    const queryOffset = cursor && Number.isFinite(Number(cursor)) ? Math.max(0, Number(cursor)) : 0;
     // Fetch IDs from Meilisearch.
     // Wrap the SDK call under withMeili('search', ...) so a backend brownout
     // is bounded by MEILI_CALL_TIMEOUT_MS instead of bleeding the event loop
@@ -124,13 +135,10 @@ export default MixedAuthEndpoint(async function handler(
       meiliResult = client
         ? await withMeili('search', () =>
             client.index(MODELS_SEARCH_INDEX).search<{ id: number }>(query, {
+              offset: queryOffset || undefined,
               limit: limit ? limit + 1 : undefined,
-              filter: [
-                cursor ? `id < ${String(cursor)}` : undefined,
-                `nsfwLevel IN [${browsingLevelValues.join(',')}]`,
-              ].filter(isDefined),
+              filter: [`nsfwLevel IN [${browsingLevelValues.join(',')}]`],
               attributesToRetrieve: ['id'],
-              sort: ['id:desc'],
             })
           )
         : undefined;
@@ -148,8 +156,13 @@ export default MixedAuthEndpoint(async function handler(
       throw e;
     }
 
-    meiliNextCursor = meiliResult?.hits.pop()?.id.toString();
-    searchIds = meiliResult?.hits?.map((hit: { id: number }) => hit.id) ?? [];
+    // We request `limit + 1` hits to detect whether another page exists
+    // without a second count query. The extra hit is sliced off and the next
+    // offset is advanced by `limit`.
+    const hits = meiliResult?.hits ?? [];
+    const hasMore = limit ? hits.length > limit : false;
+    searchIds = (hasMore ? hits.slice(0, limit) : hits).map((hit) => hit.id);
+    meiliNextCursor = hasMore ? String(queryOffset + limit) : undefined;
   }
 
   try {
@@ -168,6 +181,13 @@ export default MixedAuthEndpoint(async function handler(
       user,
     });
 
+    // Meilisearch returns ids in relevance order, but getModelsWithVersions
+    // re-sorts by lastVersionAt/modelId (model.service.ts). For text search,
+    // restore the relevance ranking so the best match stays first.
+    const orderedItems = query
+      ? searchIds.map((id) => items.find((m) => m.id === id)).filter(isDefined)
+      : items;
+
     const preferredFormat = {
       type: user?.filePreferences?.size === 'pruned' ? 'Pruned Model' : undefined,
       metadata: user?.filePreferences,
@@ -185,7 +205,7 @@ export default MixedAuthEndpoint(async function handler(
     }
 
     return res.status(200).json({
-      items: items.map(({ modelVersions, tagsOnModels, user, ...model }) => ({
+      items: orderedItems.map(({ modelVersions, tagsOnModels, user, ...model }) => ({
         ...model,
         mode: model.mode == null ? undefined : model.mode,
         creator: user


### PR DESCRIPTION
## Problem

Reported: searching the `/api/v1/models` endpoint for **"DreamShaper"** never returns the original [DreamShaper](https://civitai.com/models/4384) model (id `4384`) — it's buried under thousands of newer `...DreamShaper...` derivatives/merges, even though it's the exact-name match.

## Root cause

The endpoint forced `sort: ['id:desc']` on the Meilisearch query, and the `models_v9` index lists `sort` **first** in its `rankingRules` (`models.search-index.ts`). That combination makes Meili order matches by **recency** and demote text relevance (`words`/`proximity`/`exactness`) to a weak tiebreak. Broad terms surface the newest matching models; old canonical models sink past the first pages.

Confirmed against the live `models_v9` index — same query, same filter:

| Ranking | Top result for "DreamShaper" |
|---|---|
| `sort:id:desc` (before) | newest merge LoRAs; id 4384 not in top 10 |
| relevance (after) | **id 4384 "DreamShaper"** at rank 0 |

## Fix (scoped to the `query` path only)

- Drop the forced `id:desc` sort → Meili ranks by relevance.
- Switch query pagination from id-keyset (`id < cursor`) to **offset**, since relevance order isn't monotonic in id. The query `cursor` is now an opaque integer offset.
- Restore relevance order on output (`getModelsWithVersions` re-sorts by `lastVersionAt`/`modelId`) by reordering items to match Meili's hit order.

The **non-query browse path is unchanged** (still PG id-keyset, unbounded).

## Tradeoff

Offset paging on search is bounded by the index `maxTotalHits` (currently **100,000**). This only affects deep pagination of a *text query* — never human search; bulk enumeration uses the no-query path. Relevance ranking and id-keyset pagination cannot coexist in Meili (keyset needs id as the primary sort, which is exactly what buries the relevant result).

## Verification

- `pnpm run typecheck` ✅ / `prettier --check` ✅
- Live local endpoint, `query=DreamShaper`: id 4384 is rank 0; "Dreamshaper 8" now appears on page 2.
- Pagination advances `nextCursor` 5 → 10, no dupes.
- Browse path (no query) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)