### PR TITLE
feat(blocks): coherent App Blocks developer funnel (F-D H5, dark/mod-gated)

### DIFF
--- a/src/components/AppLayout/AppHeader/hooks.tsx
+++ b/src/components/AppLayout/AppHeader/hooks.tsx
@@ -15,6 +15,7 @@ import {
   IconGavel,
   IconHistory,
   IconLink,
+  IconListDetails,
   IconMoneybag,
   IconPhotoUp,
   IconPlayerPlayFilled,
@@ -37,6 +38,7 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { LoginRedirectReason } from '~/utils/login-helpers';
 import { trpc } from '~/utils/trpc';
 import type { CollectionType } from '~/shared/utils/prisma/enums';
+import { isAppDeveloper, isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { useMemo } from 'react';
 
 export type UserMenuItem = {
@@ -167,10 +169,31 @@ export function useGetMenuItems(): UserMenuItemGroup[] {
         },
         {
           href: '/apps/revenue',
-          visible: features.appBlocks,
+          visible: features.appBlocks && isAppDeveloper(currentUser),
           icon: IconCurrencyDollar,
           color: theme.colors.green[getPrimaryShade(theme, colorScheme ?? 'dark')],
           label: 'App Revenue',
+        },
+        {
+          href: '/apps/submit',
+          visible: features.appBlocks && isAppDeveloper(currentUser),
+          icon: IconUpload,
+          color: theme.colors.blue[getPrimaryShade(theme, colorScheme ?? 'dark')],
+          label: 'Submit App',
+        },
+        {
+          href: '/apps/my-submissions',
+          visible: features.appBlocks && isAppDeveloper(currentUser),
+          icon: IconListDetails,
+          color: theme.colors.blue[getPrimaryShade(theme, colorScheme ?? 'dark')],
+          label: 'My Submissions',
+        },
+        {
+          href: '/apps/review',
+          visible: features.appBlocks && isAppReviewer(currentUser),
+          icon: IconGavel,
+          color: theme.colors.green[getPrimaryShade(theme, colorScheme ?? 'dark')],
+          label: 'Review Apps',
         },
       ],
     },

--- a/src/pages/apps/[appBlockId]/revenue.tsx
+++ b/src/pages/apps/[appBlockId]/revenue.tsx
@@ -18,6 +18,7 @@ import Link from 'next/link';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { trpc } from '~/utils/trpc';
@@ -33,6 +34,9 @@ export const getServerSideProps = createServerSideProps({
           permanent: false,
         },
       };
+    }
+    if (!isAppDeveloper(session.user)) {
+      return { notFound: true };
     }
     return { props: {} };
   },

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -23,6 +23,7 @@ import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import {
   MARKETPLACE_CATEGORIES,
   MARKETPLACE_CATEGORY_LABELS,
@@ -158,7 +159,10 @@ export default function AppsPage() {
   // marketplace cards owned by the viewer. Visible only to the owner;
   // the trPC procedure is guarded so other users get nothing back.
   const { data: myAppsRaw } = trpc.blocks.getMyApps.useQuery(undefined, {
-    enabled: !!features.appBlocks && !!currentUser,
+    // getMyApps is a moderatorProcedure — gate on the same developer predicate as
+    // the rest of the funnel so a non-developer never fires it (today: mod-only;
+    // post-W11-widen: only app developers, not every logged-in marketplace viewer).
+    enabled: !!features.appBlocks && isAppDeveloper(currentUser),
   });
   const earningsByAppBlockId = useMemo(() => {
     type AppRow = { id: string; lifetimeShareCents: number };
@@ -312,7 +316,7 @@ export default function AppsPage() {
               probeLoading={probeLoading && hasActiveFilters}
               hasActiveFilters={hasActiveFilters}
               onClearFilters={clearFilters}
-              canSubmit={!!currentUser?.isModerator}
+              canSubmit={isAppDeveloper(currentUser)}
             />
           ) : (
             <>
@@ -467,7 +471,7 @@ function SubmitAppLink() {
   // to non-mods, so the worst case if the gate slips is a clear server-
   // side rejection rather than a silent leak.
   const user = useCurrentUser();
-  if (!user?.isModerator) return null;
+  if (!isAppDeveloper(user)) return null;
   return (
     <Button
       component={Link}

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -26,6 +26,7 @@ import { Fragment } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -54,7 +55,7 @@ export const getServerSideProps = createServerSideProps({
         },
       };
     }
-    if (!session.user.isModerator) {
+    if (!isAppDeveloper(session.user)) {
       return { notFound: true };
     }
     return { props: {} };

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { trpc } from '~/utils/trpc';
@@ -32,6 +33,9 @@ export const getServerSideProps = createServerSideProps({
           permanent: false,
         },
       };
+    }
+    if (!isAppDeveloper(session.user)) {
+      return { notFound: true };
     }
     return { props: {} };
   },

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -49,6 +49,7 @@ import {
   MARKETPLACE_CATEGORY_LABELS,
   type MarketplaceCategory,
 } from '~/server/services/blocks/marketplace-categories.constants';
+import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -83,7 +84,7 @@ export const getServerSideProps = createServerSideProps({
         },
       };
     }
-    if (!session.user.isModerator) {
+    if (!isAppReviewer(session.user)) {
       return { notFound: true };
     }
     return { props: {} };

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -32,6 +32,7 @@ import {
   SEMVER_REGEX,
   SLUG_REGEX,
 } from '~/server/schema/blocks/publish-request.schema';
+import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
 import { showErrorNotification } from '~/utils/notifications';
@@ -60,7 +61,7 @@ export const getServerSideProps = createServerSideProps({
         },
       };
     }
-    if (!session.user.isModerator) {
+    if (!isAppDeveloper(session.user)) {
       return { notFound: true };
     }
     return { props: {} };

--- a/src/shared/utils/__tests__/app-blocks-access.test.ts
+++ b/src/shared/utils/__tests__/app-blocks-access.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { isAppDeveloper, isAppReviewer } from '~/shared/utils/app-blocks-access';
+
+describe('isAppDeveloper', () => {
+  it('returns true for a moderator', () => {
+    expect(isAppDeveloper({ isModerator: true })).toBe(true);
+  });
+
+  it('returns false for a non-moderator', () => {
+    expect(isAppDeveloper({ isModerator: false })).toBe(false);
+  });
+
+  it('returns false when isModerator is null', () => {
+    expect(isAppDeveloper({ isModerator: null })).toBe(false);
+  });
+
+  it('returns false when isModerator is missing', () => {
+    expect(isAppDeveloper({})).toBe(false);
+  });
+
+  it('returns false for null user', () => {
+    expect(isAppDeveloper(null)).toBe(false);
+  });
+
+  it('returns false for undefined user', () => {
+    expect(isAppDeveloper(undefined)).toBe(false);
+  });
+});
+
+describe('isAppReviewer', () => {
+  it('returns true for a moderator', () => {
+    expect(isAppReviewer({ isModerator: true })).toBe(true);
+  });
+
+  it('returns false for a non-moderator, null, and undefined', () => {
+    expect(isAppReviewer({ isModerator: false })).toBe(false);
+    expect(isAppReviewer({ isModerator: null })).toBe(false);
+    expect(isAppReviewer({})).toBe(false);
+    expect(isAppReviewer(null)).toBe(false);
+    expect(isAppReviewer(undefined)).toBe(false);
+  });
+});

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -14,14 +14,24 @@
  * developer funnel coherent (you can't have revenue from an app you can't
  * submit).
  *
- * When external-developer submission opens (W11), widen THIS predicate — it
- * is the single flip-point for the whole developer funnel. Do NOT re-inline
- * `isModerator` checks in the individual `getServerSideProps` resolvers or
- * the nav hook; route them all through here.
+ * When external-developer submission opens (W11), widen THIS predicate to
+ * govern every CLIENT/SSR developer gate at once — the page `getServerSideProps`
+ * resolvers, the nav hook, and the marketplace "Submit App" CTAs all route
+ * through it (do NOT re-inline `isModerator` checks; that's the incoherence this
+ * file exists to prevent).
+ *
+ * ⚠️ This is NOT the only thing to flip. The data behind these surfaces is served
+ * by `moderatorProcedure`s — `blocks.getMyRevenue`, `getMyApps`,
+ * `listMyPublishRequests`, `withdrawPublishRequest`, and the `submitVersion`
+ * ModEndpoint. Widening this predicate alone lets a non-mod developer PAST the
+ * page gate only to have every query/mutation 403 (a worse UX than today's clean
+ * 404). At W11 those server procs MUST widen in lockstep — ideally by replacing
+ * `moderatorProcedure` on them with a shared `appDeveloperProcedure` so the
+ * server gate has a single flip-point too.
  *
  * NOTE: the moderator-only REVIEW surface (`/apps/review`) is conceptually
  * always-moderator and is NOT part of this developer flip — it gates on
- * `isModerator` directly, not on `isAppDeveloper`.
+ * {@link isAppReviewer} (which stays moderator-only), not `isAppDeveloper`.
  *
  * Pure (no server/client-only imports) so it's usable from both the
  * `getServerSideProps` resolvers and the client-side nav hook.

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -1,0 +1,46 @@
+/**
+ * App Blocks — developer-surface access gate.
+ *
+ * Single source of truth for who can reach the app-DEVELOPER surfaces
+ * (`/apps/submit`, `/apps/my-submissions`, `/apps/revenue`, and the
+ * per-app `/apps/[appBlockId]/revenue`). These are the surfaces for people
+ * who BUILD and earn from apps, as opposed to the consumer surfaces
+ * (`/apps`, `/apps/installed`) which any user with `features.appBlocks`
+ * can use.
+ *
+ * Today = moderators only (pre-GA). This mirrors the existing `/apps/submit`
+ * gate: submission isn't open to external developers yet, so the earnings
+ * dashboard and submission history are equally moderator-only to keep the
+ * developer funnel coherent (you can't have revenue from an app you can't
+ * submit).
+ *
+ * When external-developer submission opens (W11), widen THIS predicate — it
+ * is the single flip-point for the whole developer funnel. Do NOT re-inline
+ * `isModerator` checks in the individual `getServerSideProps` resolvers or
+ * the nav hook; route them all through here.
+ *
+ * NOTE: the moderator-only REVIEW surface (`/apps/review`) is conceptually
+ * always-moderator and is NOT part of this developer flip — it gates on
+ * `isModerator` directly, not on `isAppDeveloper`.
+ *
+ * Pure (no server/client-only imports) so it's usable from both the
+ * `getServerSideProps` resolvers and the client-side nav hook.
+ */
+export function isAppDeveloper(user: { isModerator?: boolean | null } | null | undefined): boolean {
+  return !!user?.isModerator;
+}
+
+/**
+ * App Blocks — moderator REVIEW-surface access gate (`/apps/review`).
+ *
+ * Distinct from {@link isAppDeveloper} on purpose: reviewing OTHER people's
+ * submitted apps is a moderator action and stays moderator-only even after
+ * external-dev submission opens (W11) — at which point `isAppDeveloper` widens
+ * but this MUST NOT. Kept as its own named predicate (rather than a raw
+ * `isModerator` check in `review.tsx`) so the two gates are greppable and a
+ * future "widen the developer gate" change can't accidentally sweep the
+ * reviewer surface along with it.
+ */
+export function isAppReviewer(user: { isModerator?: boolean | null } | null | undefined): boolean {
+  return !!user?.isModerator;
+}


### PR DESCRIPTION
## F-D H5 — coherent developer funnel

UX audit finding **H5**: the App Blocks developer surfaces were gated inconsistently — `/apps/revenue` showed an empty earnings dashboard to **any** logged-in user, while `/apps/submit` + `/apps/my-submissions` were moderator-only, and submit/my-submissions/review had **no nav entry** (URL-only). A non-mod saw a revenue page for a program they can't join; the real dev/reviewer pages were unreachable from nav.

### No access-model change
Everything stays **moderator-only** (opening to external developers is the separate, deferred **W11** track). This only makes the funnel *coherent*.

### Change
- **Centralize the gate** in two named, documented predicates (`src/shared/utils/app-blocks-access.ts`):
  - `isAppDeveloper` — submit / my-submissions / revenue. The **single flip-point** to widen when external-dev submission opens.
  - `isAppReviewer` — the `/apps/review` moderator surface, which deliberately stays mod-only and must **not** widen with the developer gate. (Kept separate + greppable so a future "widen the dev gate" can't sweep the reviewer surface along — closes a widen-and-forget trap an adversarial audit flagged.)
  - Both = `!!isModerator` today.
- **Page gates**: add `isAppDeveloper` to `revenue.tsx` + `[appBlockId]/revenue.tsx`; route `submit.tsx`/`my-submissions.tsx` through `isAppDeveloper` and `review.tsx` through `isAppReviewer` (behaviour-identical today, just centralized).
- **Nav**: `/apps/revenue` now dev-gated; add **Submit App** / **My Submissions** (dev-gated) + **Review Apps** (reviewer-gated). `/apps` + `/apps/installed` stay open to all `features.appBlocks` users (consumer surfaces).

**Net effect:** non-mods stop seeing `/apps/revenue` (page + nav); mods gain nav for submit/my-submissions/review.

### Safety
- **Double-gated / fail-closed**: the underlying data procs (`getMyRevenue`, `getMyApps`, `listMyPublishRequests`, `withdrawPublishRequest`) are already `moderatorProcedure` + owner-scoped, so the page gate matches the API gate — no data leak that the page gate papers over (verified by adversarial audit).
- **8 unit tests** on the predicates. No Flipt/feature-flag change; all behind `features.appBlocks`. Nav↔page gate parity verified (no visible-but-404 / reachable-but-hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)