### PR TITLE
test(blocks): fix AppBlockChrome long-name test after sanitizer length cap

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -21,11 +21,14 @@ describe('AppBlockChrome (H2 host-rendered app name)', () => {
   });
 
   test('a long app name renders in full and the name node stays a single truncating row', async () => {
-    const longName = 'Super Mega Ultra Background Removal And Upscaling Studio Pro Plus Max';
+    // Long enough to need VISUAL truncation (maw=160 ellipsizes well before this),
+    // but deliberately under sanitizeAppChromeName's APP_CHROME_NAME_MAX (64) so the
+    // *accessible* name is rendered in full here — the over-cap length-bound is a
+    // separate concern covered by the sanitizer unit test (appChromeName.test.ts).
+    const longName = 'Background Remover Pro Max Ultra Deluxe Edition Plus';
     renderWithProviders(<AppBlockChrome blockInstanceId="inst-2" appName={longName} />);
 
-    // Full text is present — truncation is purely visual, the accessible name is
-    // not clipped — and a very long name doesn't crash/overflow the render.
+    // Full text present (the visual ellipsis clips the box, not the DOM text).
     await expect.element(page.getByText(longName)).toBeInTheDocument();
 
     // Truncation is locked via Mantine's `data-truncate` attribute (CSS-independent;


### PR DESCRIPTION
## Fix a report-only component-test failure on `main` (mine, from H2)

The H2 round-2 hardening (#2572) added `APP_CHROME_NAME_MAX = 64` to `sanitizeAppChromeName`, so `AppBlockChrome` now length-bounds the rendered app name. But the round-1 component test still asserted the **full ~69-char** long name via `getByText(longName)` — which the sanitizer now truncates. So the test fails:

```
VitestBrowserElementError: Cannot find element with locator:
  getByText('Super Mega Ultra Background Removal And Upscaling Studio Pro Plus Max')
```

`component-tests` is **report-only/non-blocking**, so it didn't block H2's merge — but it's been **red on `main`** since, reddening every subsequent PR's component-tests (it nearly masked the signal on PR #2574). Caught because I can't run browser tests locally on NixOS — exactly the "full CI is the gate" lesson.

### Fix
Use a 51-char name — long enough to exercise the chrome's **visual** truncation (`maw=160` + `data-truncate`, which is what this test locks) but **under the cap** so the accessible name renders in full and `getByText` finds it. The over-cap length-bound is already covered by the sanitizer **unit** test (`appChromeName.test.ts`), so no coverage is lost.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)