### PR TITLE
refactor(metrics): read image metrics from new ClickHouse pipeline

### DIFF
--- a/src/server/metrics/post.metrics-old.ts
+++ b/src/server/metrics/post.metrics-old.ts
@@ -146,7 +146,7 @@ async function getReactionTasks(ctx: MetricContext) {
   log('getReactionTasks', ctx.lastUpdate);
   const affectedImages = await ctx.ch.$query<{ imageId: number }>`
       SELECT DISTINCT entityId as imageId
-      FROM entityMetricEvents
+      FROM entityMetricEvents_month
       WHERE entityType = 'Image'
         AND entityId IS NOT NULL
         AND createdAt > ${ctx.lastUpdate}

--- a/src/server/metrics/post.metrics.ts
+++ b/src/server/metrics/post.metrics.ts
@@ -92,9 +92,9 @@ async function getReactionTasks(ctx: MetricContext) {
   const affectedImages = await ctx.ch.$query<{ imageId: number }>`
     -- get recent images with reactions
     SELECT DISTINCT entityId as imageId
-    FROM entityMetricEvents
+    FROM entityMetricEvents_month
     WHERE entityType = 'Image'
-    AND metricType LIKE 'Reaction%'
+    AND metricType IN ('Like', 'Heart', 'Laugh', 'Cry')
     AND createdAt > ${ctx.lastUpdate};
   `;
 

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -409,16 +409,20 @@ export const imagesSearchIndex = createSearchIndexUpdateProcessor({
         const metrics = await clickhouse?.$query<Metrics>(`
             SELECT entityId as "id",
                    sumIf(total, metricType = 'Collection') as "collectedCount",
-                   sumIf(total, metricType in ('ReactionLike', 'ReactionHeart', 'ReactionLaugh', 'ReactionCry')) as "reactionCount",
-                   sumIf(total, metricType = 'Comment') as "commentCount",
-                   sumIf(total, metricType = 'ReactionLike') as "likeCount",
-                   sumIf(total, metricType = 'ReactionCry') as "cryCount",
-                   sumIf(total, metricType = 'Buzz') as "tippedAmountCount",
-                   sumIf(total, metricType = 'ReactionHeart') as "heartCount",
-                   sumIf(total, metricType = 'ReactionLaugh') as "laughCount"
-            FROM entityMetricDailyAgg
-            WHERE entityType = 'Image'
-              AND entityId IN (${batch.join(',')})
+                   sumIf(total, metricType in ('Like', 'Heart', 'Laugh', 'Cry')) as "reactionCount",
+                   sumIf(total, metricType = 'commentCount') as "commentCount",
+                   sumIf(total, metricType = 'Like') as "likeCount",
+                   sumIf(total, metricType = 'Cry') as "cryCount",
+                   sumIf(total, metricType = 'tippedAmount') as "tippedAmountCount",
+                   sumIf(total, metricType = 'Heart') as "heartCount",
+                   sumIf(total, metricType = 'Laugh') as "laughCount"
+            FROM (
+              SELECT entityId, metricType, day, argMax(total, refreshedAt) as total
+              FROM entityMetricDailyAgg_new
+              WHERE entityType = 'Image'
+                AND entityId IN (${batch.join(',')})
+              GROUP BY entityId, metricType, day
+            )
             GROUP BY id
           `);
 

--- a/src/server/search-index/metrics-images--update-metrics.search-index.ts
+++ b/src/server/search-index/metrics-images--update-metrics.search-index.ts
@@ -41,12 +41,16 @@ export const imagesMetricsDetailsSearchIndexUpdateMetrics = createSearchIndexUpd
     // TODO somehow check for postId existence, otherwise there are lots of unused rows
 
     lastUpdatedAt ??= new Date(1723528353000);
+    // Subtract a 2-minute buffer so events that landed slightly late (or after
+    // the ReplacingMergeTree dedup settled) near the previous boundary aren't
+    // missed. Overlap is harmless here — entityIds are deduped downstream.
+    const lastUpdatedAtBuffered = new Date(lastUpdatedAt.getTime() - 2 * 60 * 1000);
     const ids = await ch.$query<{ id: number }>`
       SELECT
         distinct entityId as "id"
       FROM entityMetricEvents_month
       WHERE entityType = 'Image'
-      AND createdAt > ${lastUpdatedAt}
+      AND createdAt > ${lastUpdatedAtBuffered}
     `;
     const updateIds = ids?.map((x) => x.id) ?? [];
 

--- a/src/server/search-index/metrics-images--update-metrics.search-index.ts
+++ b/src/server/search-index/metrics-images--update-metrics.search-index.ts
@@ -44,7 +44,7 @@ export const imagesMetricsDetailsSearchIndexUpdateMetrics = createSearchIndexUpd
     const ids = await ch.$query<{ id: number }>`
       SELECT
         distinct entityId as "id"
-      FROM entityMetricEvents
+      FROM entityMetricEvents_month
       WHERE entityType = 'Image'
       AND createdAt > ${lastUpdatedAt}
     `;
@@ -67,12 +67,16 @@ export const imagesMetricsDetailsSearchIndexUpdateMetrics = createSearchIndexUpd
     const tasks = chunk(ids, 5000).map((batch) => async () => {
       const results = await ch?.$query<Metrics>(`
         SELECT entityId as "id",
-          sumIf(total, metricType in ('ReactionLike', 'ReactionHeart', 'ReactionLaugh', 'ReactionCry')) as "reactionCount",
-          sumIf(total, metricType = 'Comment') as "commentCount",
+          sumIf(total, metricType in ('Like', 'Heart', 'Laugh', 'Cry')) as "reactionCount",
+          sumIf(total, metricType = 'commentCount') as "commentCount",
           sumIf(total, metricType = 'Collection') as "collectedCount"
-        FROM entityMetricDailyAgg
-        WHERE entityType = 'Image'
-          AND entityId IN (${batch.join(',')})
+        FROM (
+          SELECT entityId, metricType, day, argMax(total, refreshedAt) as total
+          FROM entityMetricDailyAgg_new
+          WHERE entityType = 'Image'
+            AND entityId IN (${batch.join(',')})
+          GROUP BY entityId, metricType, day
+        )
         GROUP BY id
       `);
       if (results?.length) metrics.push(...results);

--- a/src/server/search-index/metrics-images.search-index.ts
+++ b/src/server/search-index/metrics-images.search-index.ts
@@ -386,12 +386,16 @@ export const imagesMetricsDetailsSearchIndex = createSearchIndexUpdateProcessor(
         logger(`Pulling metrics :: ${indexName} ::`, batchLogKey, subBatchLogKey);
         const metrics = await clickhouse?.$query<Metrics>(`
             SELECT entityId as "id",
-                   sumIf(total, metricType in ('ReactionLike', 'ReactionHeart', 'ReactionLaugh', 'ReactionCry')) as "reactionCount",
-                   sumIf(total, metricType = 'Comment') as "commentCount",
+                   sumIf(total, metricType in ('Like', 'Heart', 'Laugh', 'Cry')) as "reactionCount",
+                   sumIf(total, metricType = 'commentCount') as "commentCount",
                    sumIf(total, metricType = 'Collection') as "collectedCount"
-            FROM entityMetricDailyAgg
-            WHERE entityType = 'Image'
-              AND entityId IN (${batch.join(',')})
+            FROM (
+              SELECT entityId, metricType, day, argMax(total, refreshedAt) as total
+              FROM entityMetricDailyAgg_new
+              WHERE entityType = 'Image'
+                AND entityId IN (${batch.join(',')})
+              GROUP BY entityId, metricType, day
+            )
             GROUP BY id
           `);
 


### PR DESCRIPTION
Migrate image entity-metric reads off the legacy
entityMetricEvents/entityMetricDailyAgg tables onto the deduped entityMetricEvents_month and entityMetricDailyAgg_new tables.

The new tables use standardized metricType names (Like/Heart/Laugh/Cry, commentCount, tippedAmount) instead of the old ones (ReactionLike/..., Comment, Buzz), and entityMetricDailyAgg_new retains multiple refresh snapshots per (entityId, metricType, day), so reads now argMax-dedup by refreshedAt before summing.

- images.search-index.ts, metrics-images*.search-index.ts: read agg_new with renamed metricTypes + argMax dedup subquery
- post.metrics(.ts/-old.ts), update-metrics search index: read entityMetricEvents_month; translate the LIKE 'Reaction%' filter to the new reaction names

Write paths (clickhouse.entityMetric track, admin backfill) stay on the base tables.