### PR TITLE
test(blocks): preview-e2e coverage for App Blocks marketplace + install/consent (F-C)

### DIFF
--- a/tests/preview-apps-install.spec.ts
+++ b/tests/preview-apps-install.spec.ts
@@ -1,0 +1,257 @@
+import { expect, test } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+import { trpcMutation, trpcQuery } from './preview-trpc';
+
+/**
+ * Preview-e2e (F-C): App Blocks INSTALL + CONSENT round-trip — the authenticated
+ * write path that turns a marketplace browse into an installed app:
+ * `getInstallConfig` → `upsertSubscription` (install) → `listMySubscriptions`
+ * (read-back) → `deleteSubscription` (self-clean), then `grantScopes` (consent)
+ * → `listMyScopeGrants` (read-back). Otherwise untested by the preview suite.
+ *
+ * Runs as the `mod` fixture (id 2000000001) — REQUIRED: getInstallConfig,
+ * upsertSubscription and deleteSubscription are all `moderatorProcedure`, and
+ * `features.appBlocks` (the Flipt mod segment) gates every blocks proc. mod is
+ * also the only role exempt from per-user rate limits. A non-mod tester would be
+ * UNAUTHORIZED on every call here.
+ *
+ * SELF-SEED / SELF-CLEAN (the dev DB + fixtures are shared across concurrent
+ * previews): we DISCOVER an appBlockId at runtime from `listAvailable` (never
+ * hardcode one — the weekly prod clone's approved set varies, and could be
+ * empty → `test.skip()` annotated), CREATE our own `viewer_personal`
+ * subscription, then DELETE it in `finally` so a mid-test failure still cleans
+ * up and re-runs never accumulate/collide on the shared clone.
+ *
+ * NB: DB-backed procs (not meili-backed search) → no `retryFlaky`.
+ *
+ * --- GENERATE / BUZZ-SPEND IS INTENTIONALLY NOT E2E'd HERE -------------------
+ * The generate leg (`blocks.submitWorkflow`) is deliberately NOT covered, for
+ * the SAME reason `generation-submit` is deferred: (1) submitWorkflow re-asserts
+ * `assertViewerIsModerator` AND requires a valid block JWT carrying a positive
+ * `buzzBudget` + `ai:write:budgeted` scope context (it's a GA-gated, token-
+ * minted path, not a plain tRPC input), and (2) Buzz lives in an EXTERNAL
+ * service (`BUZZ_ENDPOINT`), so a spendable balance can't be seeded in the
+ * preview's dev DB. The consent GRANT below is the furthest deterministically-
+ * coverable pre-spend step (it records the user's consent that a later mint
+ * would intersect against); actual spend is out of scope for preview-e2e.
+ * ----------------------------------------------------------------------------
+ *
+ * Verified tRPC shapes (against origin/main, paths relative to civitai/src):
+ *  - blocks.listAvailable → `{ items: AvailableBlock[]; nextCursor? }` (NOT a
+ *    bare array; block-registry.service.ts:2226). Each item's `id` is the
+ *    appBlockId. Used to discover an id (skip-if-empty).
+ *  - blocks.getInstallConfig (blocks.router.ts:1133 moderatorProcedure + flag;
+ *    input { appBlockId }) → `{ settings: Record<string,unknown>; scopes:
+ *    string[] }` where `scopes` = manifest.scopes ∩ approvedScopes (the
+ *    consentable CEILING). Can be empty → consent leg skips (annotated).
+ *  - blocks.upsertSubscription (blocks.router.ts:1186 moderatorProcedure; input
+ *    { appBlockId, scope, targetModelTypes, targetBaseModels, settings?,
+ *    enabled? }) → `SubscriptionRecord` (subscription.schema.ts:86). NOTE the
+ *    `id` is a STRING (ULID-shaped PK), NOT a number. `scope` is
+ *    `subscriptionScopeSchema` = z.enum(['publisher_all_my_models',
+ *    'viewer_personal']) (subscription.schema.ts:13) — we use 'viewer_personal'
+ *    (the "subscribe on every model page I visit" scope). The blanket shape this
+ *    writes has `slotId: null` and `targetModelIds: []`.
+ *  - blocks.listMySubscriptions (blocks.router.ts:909 protectedProcedure) →
+ *    `SubscriptionRecord[]` (BlockRegistry.listUserSubscriptions, returns the
+ *    caller's own rows). We match our row by (appBlockId, scope==='viewer
+ *    _personal', id).
+ *  - blocks.deleteSubscription (blocks.router.ts:1244 moderatorProcedure; input
+ *    { subscriptionId: string }) → `{ ok: true }`. Idempotent (missing row is a
+ *    no-op success) + ownership-checked at the service layer.
+ *  - blocks.grantScopes (blocks.router.ts:820 protectedProcedure; input
+ *    { appBlockId, scopes: string[] (1..32) }) → `{ ok: true; granted: string[]
+ *    }`. Server intersects `scopes` with the manifest∩approvedScopes CEILING and
+ *    returns the actually-granted subset in `granted` — so `granted` is itself
+ *    the deterministic write-confirmation. Throws BAD_REQUEST if NONE of the
+ *    requested scopes are in the ceiling, which is why we source the scope from
+ *    getInstallConfig().scopes (a known-in-ceiling value).
+ *  - blocks.listMyScopeGrants (blocks.router.ts:723 protectedProcedure) →
+ *    `ScopeGrantSurface[]` (user-app-surface.service.ts:42). RETURN-SHAPE
+ *    SURPRISE: this is NOT the raw `app_user_scope_grants` consent ledger — it
+ *    AGGREGATES one row per app the user has INSTALLED/SUBSCRIBED to, and its
+ *    `scopes` field is the app's MANIFEST-declared scopes (the dev's stated
+ *    intent), with the per-app subscription scopes under
+ *    `surfaces.subscriptionScopes`. So a granted scope shows up here ONLY because
+ *    (a) the app is present (the user has a sub for it) and (b) granted ⊆
+ *    manifest scopes. We therefore re-INSTALL before the consent leg so the app
+ *    is present in this surface, and assert the app row exists with the granted
+ *    scope inside its (manifest) `scopes` set. The strong consent confirmation is
+ *    `granted` from grantScopes itself; this read-back is the corroborating
+ *    surface check. (No `revokeScopes` proc exists — see scope-grant.service.ts;
+ *    grantScopes is additive + idempotent, fine on the weekly-refreshed clone.)
+ */
+
+const ROLE = 'mod' as const;
+const SCOPE = 'viewer_personal' as const;
+
+type AvailableBlock = { id: string };
+type ListAvailableResult = { items: AvailableBlock[]; nextCursor?: string };
+
+type InstallConfig = { settings: Record<string, unknown>; scopes: string[] };
+
+// SubscriptionRecord subset this spec reads. `id` is a STRING, not a number.
+type SubscriptionRecord = {
+  id: string;
+  scope: string;
+  appBlockId: string;
+  enabled: boolean;
+};
+
+type GrantScopesResult = { ok: boolean; granted: string[] };
+
+// ScopeGrantSurface subset — `scopes` is the app's MANIFEST scopes (see header).
+type ScopeGrantSurface = {
+  appBlockId: string;
+  scopes: string[];
+  surfaces: { modelInstallCount: number; subscriptionScopes: string[] };
+};
+
+test.describe('App Blocks install + consent round-trip (mod, self-cleaning)', () => {
+  test.use({ storageState: storageStatePath(ROLE) });
+
+  test('upsertSubscription + grantScopes round-trip, verified by read-back', async ({ page }) => {
+    // Warm the request context against the preview origin so page.request shares
+    // the mod auth cookie + a navigated origin (the helper stamps Origin/Referer
+    // for the CSRF gate; navigating once is the safe baseline). domcontentloaded
+    // ONLY — never networkidle.
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    // DISCOVER an appBlockId at runtime (never hardcode). `{}` input is valid.
+    const listing = await trpcQuery<ListAvailableResult>(page.request, 'blocks.listAvailable', {});
+    const blocks = listing?.items ?? [];
+    test.skip(
+      blocks.length === 0,
+      'No approved app blocks in this dev-DB clone — nothing to install (the weekly prod clone can have zero). Skipping rather than hard-failing.'
+    );
+    const appBlockId = blocks[0].id;
+    expect(typeof appBlockId, 'discovered appBlockId should be a string').toBe('string');
+
+    // Track the created subscription id so `finally` can always clean it up.
+    let subscriptionId: string | null = null;
+
+    try {
+      // INSTALL CONFIG: the authenticated source for the install modal's settings
+      // + the consentable scope CEILING. We read it both to exercise the proc and
+      // to source a known-in-ceiling scope for the consent leg below.
+      const installConfig = await trpcQuery<InstallConfig>(
+        page.request,
+        'blocks.getInstallConfig',
+        { appBlockId }
+      );
+      expect(
+        Array.isArray(installConfig?.scopes),
+        'getInstallConfig should return a { scopes: string[] } ceiling'
+      ).toBe(true);
+
+      // INSTALL: create a blanket `viewer_personal` subscription. enabled:true,
+      // no target filters (null → applies everywhere). Returns the created
+      // SubscriptionRecord whose `id` is a STRING.
+      const sub = await trpcMutation<SubscriptionRecord | null>(
+        page.request,
+        'blocks.upsertSubscription',
+        {
+          appBlockId,
+          scope: SCOPE,
+          targetModelTypes: null,
+          targetBaseModels: null,
+          enabled: true,
+        }
+      );
+      expect(typeof sub?.id, 'upsertSubscription should return a string subscription id').toBe(
+        'string'
+      );
+      expect(sub?.scope, 'the created subscription should carry the viewer_personal scope').toBe(
+        SCOPE
+      );
+      subscriptionId = sub!.id;
+
+      // READ-BACK: the new (appBlockId, viewer_personal) subscription must appear
+      // in the caller's own subscriptions — proves the write persisted (not just
+      // 200-OK'd), matched deterministically by the returned id.
+      const mySubs = await trpcQuery<SubscriptionRecord[]>(
+        page.request,
+        'blocks.listMySubscriptions'
+      );
+      const found = (mySubs ?? []).find(
+        (s) => s.id === subscriptionId && s.appBlockId === appBlockId && s.scope === SCOPE
+      );
+      expect(
+        found,
+        `the installed (appBlockId=${appBlockId}, viewer_personal) subscription should be in listMySubscriptions`
+      ).toBeTruthy();
+
+      // CONSENT: grant a scope from the install ceiling so a future block-token
+      // mint can carry it. Source the scope FROM the ceiling (getInstallConfig)
+      // so it's known-grantable — grantScopes BAD_REQUESTs if none are in-ceiling.
+      const ceiling = installConfig?.scopes ?? [];
+      if (ceiling.length > 0) {
+        const scopeToGrant = ceiling[0];
+        const grant = await trpcMutation<GrantScopesResult>(page.request, 'blocks.grantScopes', {
+          appBlockId,
+          scopes: [scopeToGrant],
+        });
+        // `granted` is the server-intersected actually-recorded set — the
+        // deterministic write-confirmation. The requested scope came from the
+        // ceiling, so it must survive the intersection.
+        expect(
+          grant?.granted ?? [],
+          `grantScopes should record the in-ceiling scope "${scopeToGrant}"`
+        ).toContain(scopeToGrant);
+
+        // CORROBORATING READ-BACK on the per-app surface — SOFT. `granted` above
+        // is the authoritative, race-immune consent confirmation (grantScopes
+        // reads the appBlock, not our subscription). listMyScopeGrants, by
+        // contrast, derives the app surface PURELY from the existence of our
+        // `viewer_personal` subscription row — and the `mod` fixture is SHARED
+        // across concurrently-deployed previews, all writing the SAME
+        // (user, appBlockId, viewer_personal) row. A sibling preview's `finally`
+        // cleanup could delete that row between our grant and this read. So:
+        // assert-if-present, annotate-if-absent — never spuriously fail on a
+        // cross-preview teardown race.
+        const grants = await trpcQuery<ScopeGrantSurface[]>(
+          page.request,
+          'blocks.listMyScopeGrants'
+        );
+        const appSurface = (grants ?? []).find((g) => g.appBlockId === appBlockId);
+        if (appSurface) {
+          expect(
+            appSurface.scopes,
+            `the granted scope "${scopeToGrant}" should be within the app's surfaced scope set`
+          ).toContain(scopeToGrant);
+        } else {
+          test.info().annotations.push({
+            type: 'note',
+            description: `listMyScopeGrants surface for ${appBlockId} was absent at read-back — most likely a concurrent preview's cleanup deleted the shared mod subscription. grantScopes().granted already confirmed the consent deterministically.`,
+          });
+        }
+      } else {
+        test.info().annotations.push({
+          type: 'note',
+          description: `getInstallConfig().scopes is empty for ${appBlockId} (no consentable scopes in the manifest∩approved ceiling) — skipping the consent leg. Install round-trip still asserted.`,
+        });
+      }
+    } finally {
+      // CLEANUP: delete our own subscription so re-runs don't accumulate on the
+      // shared dev clone. Idempotent + ownership-checked server-side. Best-effort
+      // — a cleanup failure must not mask the assertions above.
+      if (subscriptionId) {
+        try {
+          await trpcMutation(page.request, 'blocks.deleteSubscription', { subscriptionId });
+          // Verify it's gone (deterministic): re-query and assert absence. Inside
+          // try/catch so a read-back hiccup during teardown can't fail the spec.
+          const after = await trpcQuery<SubscriptionRecord[]>(
+            page.request,
+            'blocks.listMySubscriptions'
+          );
+          expect(
+            (after ?? []).some((s) => s.id === subscriptionId),
+            'the deleted subscription should no longer be in listMySubscriptions'
+          ).toBe(false);
+        } catch {
+          // Teardown is best-effort; the install/consent assertions are the point.
+        }
+      }
+    }
+  });
+});

--- a/tests/preview-apps-marketplace.spec.ts
+++ b/tests/preview-apps-marketplace.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+import { trpcQuery } from './preview-trpc';
+
+/**
+ * Preview-e2e (F-C): App Blocks MARKETPLACE discovery + per-app detail — the
+ * anon-capable PUBLIC read path (`blocks.listAvailable` → `blocks.getAppDetail`)
+ * plus the two host pages that render them (`/apps`, `/apps/<appBlockId>`).
+ * Otherwise untested by the preview suite; a PR that broke the marketplace
+ * listing/detail projection or the `features.appBlocks` page gate passes every
+ * other preview spec today.
+ *
+ * Runs as the `mod` fixture (id 2000000001) — the ONLY preview role with
+ * `features.appBlocks` (the Flipt `app-blocks-enabled` flag is moderator-segment
+ * -only) AND exempt from the per-IP marketplace rate limit (listAvailable /
+ * getAppDetail carry a 60/60 rateLimit that the middleware waives for mods).
+ * The non-mod testers do NOT have appBlocks: for them /apps SSR-resolves to a
+ * Next 404 (resolveAppsPageAccess → notFound) and listAvailable returns empty —
+ * so this MUST run as mod to exercise the real read path.
+ *
+ * Data resilience: the dev DB is a weekly prod clone — there are ~3 approved app
+ * blocks today, but a given clone could have zero. So we DISCOVER an appBlockId
+ * at runtime from `listAvailable` (never hardcode one) and `test.skip()` with an
+ * annotation when the clone has no approved blocks, rather than hard-failing.
+ *
+ * NB: these procs are DB-backed (not meili-backed search), so no `retryFlaky`.
+ *
+ * Verified tRPC shapes (against origin/main, paths relative to civitai/src):
+ *  - blocks.listAvailable (blocks.router.ts:952 publicProcedure + enforceApp
+ *    BlocksFlag + 60/60 rateLimit; input listAvailableSchema, all fields
+ *    optional/defaulted so `{}` is valid) RETURNS AN OBJECT, NOT a bare array:
+ *    `{ items: AvailableBlock[]; nextCursor?: string }`
+ *    (BlockRegistry.listAvailable, block-registry.service.ts:2226). Each
+ *    AvailableBlock (subscription.schema.ts:157) = { id, blockId, appId,
+ *    appName, manifest: PublicBlockManifest, installCount, category,
+ *    scopesSummary }. We DISCOVER an id from `items[0].id` (that id is the
+ *    `appBlockId`).
+ *  - blocks.getAppDetail (blocks.router.ts:1001 publicProcedure + flag +
+ *    60/60 rateLimit; input { appBlockId }) returns `PublicAppDetail | null`
+ *    (subscription.schema.ts:371): { id, blockId, appId, appName, manifest:
+ *    { name?, description?, targets? }, scopes: string[], contentRating,
+ *    version, installCount, liveUrl, screenshots }. Returns null for a missing
+ *    / non-approved id (the router then throws NOT_FOUND — our helper would
+ *    surface that as a thrown error). We assert the shape of a discovered,
+ *    known-approved id, so a non-null detail is expected.
+ *  - Detail page (`/apps/[appBlockId]/index.tsx`) renders the block name as
+ *    `<Title order={2}>{name}</Title>` where
+ *    `name = detail.manifest.name ?? detail.blockId ?? appBlockId` — so the
+ *    visible host-rendered name == `manifest.name || blockId`.
+ *  - Marketplace page (`/apps/index.tsx`) renders `<Title order={2}>Civitai App
+ *    Blocks</Title>` for an appBlocks-enabled viewer; a non-appBlocks viewer
+ *    gets the Next 404 (resolveAppsPageAccess.ts → notFound).
+ */
+
+const ROLE = 'mod' as const;
+
+// Public marketplace listing shape (the fields this spec reads). Mirrors
+// AvailableBlock — typed locally so the tRPC result isn't `unknown`/implicit any.
+type AvailableBlock = {
+  id: string;
+  blockId: string;
+  appId: string;
+  appName: string | null;
+  manifest: { name?: string; description?: string; targets?: Array<{ slotId?: string }> };
+  installCount: number;
+  category: string | null;
+  scopesSummary: string[];
+};
+type ListAvailableResult = { items: AvailableBlock[]; nextCursor?: string };
+
+// Public per-app detail shape (the fields this spec reads). Mirrors
+// PublicAppDetail — getAppDetail returns this or null.
+type PublicAppDetail = {
+  id: string;
+  blockId: string;
+  appId: string;
+  appName: string | null;
+  manifest: { name?: string; description?: string; targets?: Array<{ slotId?: string }> };
+  scopes: string[];
+  contentRating: string | null;
+  version: string | null;
+  installCount: number;
+  liveUrl: string;
+  screenshots: Array<{ index: number; url: string; contentType: string }>;
+};
+
+test.describe('App Blocks marketplace discovery + detail render (mod)', () => {
+  test.use({ storageState: storageStatePath(ROLE) });
+
+  test('listAvailable → getAppDetail round-trip + /apps and /apps/[id] render', async ({
+    page,
+  }) => {
+    // The marketplace index renders for an appBlocks-enabled viewer (the mod) and
+    // 404s for everyone else. Asserting it loads (status < 400) + shows its known
+    // heading proves the mod cleared the `features.appBlocks` SSR gate (NOT the
+    // 404 a non-appBlocks user gets). domcontentloaded ONLY — never networkidle.
+    const resp = await page.goto('/apps', { waitUntil: 'domcontentloaded' });
+    expect(resp?.status(), 'GET /apps status for the appBlocks-enabled mod').toBeLessThan(400);
+    await expect(
+      page.getByRole('heading', { name: 'Civitai App Blocks' }),
+      '/apps should render the marketplace heading for an appBlocks-enabled mod (not a 404)'
+    ).toBeVisible();
+
+    // DISCOVER an appBlockId at runtime from the public listing. Never hardcode
+    // one — the weekly dev clone's approved set varies. `{}` input is valid (all
+    // listAvailableSchema fields are optional/defaulted). page.request carries the
+    // mod cookie; the helper stamps Origin/Referer for the CSRF gate.
+    const listing = await trpcQuery<ListAvailableResult>(page.request, 'blocks.listAvailable', {});
+    expect(
+      Array.isArray(listing?.items),
+      'blocks.listAvailable should resolve to { items: AvailableBlock[] }'
+    ).toBe(true);
+
+    const blocks = listing?.items ?? [];
+    test.skip(
+      blocks.length === 0,
+      'No approved app blocks in this dev-DB clone — nothing to discover (the weekly prod clone can have zero). Skipping the detail-render leg rather than hard-failing.'
+    );
+
+    // One representative block — don't crawl the whole list.
+    const first = blocks[0];
+    expect(typeof first.id, 'each listed block should carry a string id (the appBlockId)').toBe(
+      'string'
+    );
+
+    // Per-app DETAIL for that exact block. getAppDetail returns the public
+    // projection for an approved id; a discovered id IS approved (listAvailable
+    // only returns status='approved' rows), so detail must be non-null.
+    const detail = await trpcQuery<PublicAppDetail | null>(page.request, 'blocks.getAppDetail', {
+      appBlockId: first.id,
+    });
+    expect(
+      detail,
+      'getAppDetail should return a non-null detail for a discovered approved id'
+    ).not.toBeNull();
+    expect(detail!.id, 'getAppDetail.id should echo the requested appBlockId').toBe(first.id);
+    // A human display name: manifest.name is the public allowlist field; fall back
+    // to blockId (the page does the same: name = manifest.name ?? blockId ?? id).
+    const detailName = detail!.manifest.name ?? detail!.blockId;
+    expect(
+      typeof detailName,
+      'detail should expose a display name (manifest.name or blockId)'
+    ).toBe('string');
+    expect(detailName.length, 'the display name should be non-empty').toBeGreaterThan(0);
+    // The scopes + slots arrays are shape-correct (anon-display allowlist).
+    expect(Array.isArray(detail!.scopes), 'detail.scopes should be an array').toBe(true);
+    expect(
+      Array.isArray(detail!.manifest.targets ?? []),
+      'detail.manifest.targets should be an array (slot badges)'
+    ).toBe(true);
+
+    // The DETAIL PAGE renders that block's name (host-rendered <Title> text). This
+    // proves the page's getAppDetail query + SSR appBlocks gate work end-to-end,
+    // not just the bare tRPC call. domcontentloaded ONLY.
+    const detailResp = await page.goto(`/apps/${encodeURIComponent(first.id)}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(detailResp?.status(), `GET /apps/${first.id} status`).toBeLessThan(400);
+    await expect(
+      page.getByRole('heading', { name: detailName }),
+      `the detail page should render the block name "${detailName}"`
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## F-C — App Blocks preview-e2e coverage

Adds the first App Blocks journeys to the Playwright **preview-e2e** suite (the report-only `smoke-test` Tekton task that runs against the live `pr-N.civitaic.com` preview). Run as the **`mod`** fixture — the only preview role with `features.appBlocks` (Flipt mod segment) and rate-limit exempt.

### Specs
- **`preview-apps-marketplace.spec.ts`** — GET `/apps` renders the marketplace for an appBlocks-enabled mod (proves the gate, vs the non-mod 404) → `blocks.listAvailable` discovers an `appBlockId` from `.items` → `blocks.getAppDetail` shape (name/scopes/slots) → GET `/apps/[id]` renders the block-name heading. The anon-capable **public read path**, end-to-end.
- **`preview-apps-install.spec.ts`** — `getInstallConfig` → `upsertSubscription(viewer_personal)` → `listMySubscriptions` read-back → `grantScopes` (consent, sourced from the manifest∩approved ceiling) → `listMyScopeGrants` corroboration → cleanup `deleteSubscription` in `finally`. The authenticated **install + consent** write path, self-cleaning on the shared dev clone.

### Design / resilience
- **Discover IDs at runtime** (never hardcode); `test.skip` (annotated) if the weekly dev clone has zero approved blocks (it has ~3 today). ⚠️ *skip ≠ coverage* — if a regression emptied `listAvailable` on a populated DB, both specs skip green; acceptable per the empty-clone resilience, noted here.
- **`grantScopes().granted`** is the authoritative, race-immune consent confirmation; the `listMyScopeGrants` surface read-back is **soft** (assert-if-present / annotate-if-absent) because the shared `mod` subscription it derives from can be deleted by a concurrent preview's `finally` cleanup (the one flake an adversarial audit surfaced — fixed here).
- **Generate/Buzz-spend is intentionally NOT e2e'd** — `submitWorkflow` is GA-gated (`assertViewerIsModerator`) + Buzz is an external service (can't seed spend), same rationale as the deferred `generation-submit`. The consent grant is the furthest deterministically-coverable pre-spend step.

### Verification
- **Read-from-source, not assumed** (the return-shape traps that bite every preview-spec author): `listAvailable` → `{items:[]}` not a bare array; subscription `id` is a string ULID; `listMyScopeGrants` is an aggregated per-app surface (manifest scopes), not the raw grant ledger; no `revokeScopes` proc.
- **Adversarially audited** — verbs (query/mutation), inputs, return shapes, mod gating, headings, CSRF/origin, cleanup robustness, and typecheck all verified against `origin/main`. Verdict: both specs pass against a populated preview.
- Test-only; no production code. Both specs discovered by `playwright --list` + prettier-clean. The PR's own `smoke-test` task is the live gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)