### PR TITLE
feat(training): "Save every" length knob + Steps/Save every info bubbles

### DIFF
--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -530,12 +530,14 @@ export default function TrainingSelectFile({
       await continueFileMutation.mutateAsync(fileData);
 
       // Seed the submit form: steps-pricing defaults + continueFrom, reusing the source
-      // run's base model and prompts.
+      // run's base model and prompts. "Save every" seeds to ~10 checkpoints; maxTrainEpochs
+      // (sent as `epochs`) is derived from it in the submit form.
       const params = getDefaultTrainingParams(base, 'ai-toolkit');
       params.engine = 'ai-toolkit';
-      params.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
       params.trainBatchSize = 1;
       params.targetSteps = aiToolkitStepDefault(baseType);
+      params.saveEvery = Math.max(1, Math.round(params.targetSteps / AI_TOOLKIT_EPOCHS.default));
+      params.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
       params.continueFrom = continueFromAir;
 
       trainingStore.resetRuns(model.id, mediaType);

--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -56,6 +56,7 @@ import { basePath as trainWizardBasePath } from '~/components/Training/Form/Trai
 import {
   AI_TOOLKIT_EPOCHS,
   aiToolkitStepDefault,
+  aiToolkitSaveEveryDefault,
   type TrainingBaseModelType,
 } from '~/utils/training';
 import type { ModelVersionById } from '~/types/router';
@@ -536,7 +537,7 @@ export default function TrainingSelectFile({
       params.engine = 'ai-toolkit';
       params.trainBatchSize = 1;
       params.targetSteps = aiToolkitStepDefault(baseType);
-      params.saveEvery = Math.max(1, Math.round(params.targetSteps / AI_TOOLKIT_EPOCHS.default));
+      params.saveEvery = aiToolkitSaveEveryDefault(params.targetSteps);
       params.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
       params.continueFrom = continueFromAir;
 

--- a/src/components/Training/Form/TrainingParams.tsx
+++ b/src/components/Training/Form/TrainingParams.tsx
@@ -4,6 +4,7 @@ import type {
   TrainingDetailsParams,
 } from '~/server/schema/model-version.schema';
 import {
+  AI_TOOLKIT_SAVE_EVERY,
   engineTypes,
   type EngineTypes,
   loraTypes,
@@ -321,10 +322,11 @@ export const trainingSettings: TrainingSettingsType[] = [
     ),
     type: 'int',
     // Default mirrors targetSteps / 10 checkpoints; the seeding effects recompute it per run.
-    default: 200,
-    min: 50,
-    max: 5000,
-    step: 50,
+    // Bounds come from AI_TOOLKIT_SAVE_EVERY so the input and the seeds share one source.
+    default: AI_TOOLKIT_SAVE_EVERY.default,
+    min: AI_TOOLKIT_SAVE_EVERY.min,
+    max: AI_TOOLKIT_SAVE_EVERY.max,
+    step: AI_TOOLKIT_SAVE_EVERY.step,
     overrides: {
       ltx2: { all: { default: 300 } },
       ltx23: { all: { default: 300 } },

--- a/src/components/Training/Form/TrainingParams.tsx
+++ b/src/components/Training/Form/TrainingParams.tsx
@@ -308,6 +308,30 @@ export const trainingSettings: TrainingSettingsType[] = [
     },
   },
   {
+    name: 'saveEvery',
+    label: 'Save every',
+    hint: (
+      <>
+        How often (in steps) a checkpoint is saved. Each saved checkpoint is a downloadable epoch
+        you can pick from afterwards.
+        <br />
+        Lower values save more checkpoints (e.g. 3,000 steps saving every 250 produces 12). Has a
+        smaller effect on cost than Steps.
+      </>
+    ),
+    type: 'int',
+    // Default mirrors targetSteps / 10 checkpoints; the seeding effects recompute it per run.
+    default: 200,
+    min: 50,
+    max: 5000,
+    step: 50,
+    overrides: {
+      ltx2: { all: { default: 300 } },
+      ltx23: { all: { default: 300 } },
+      anima: { all: { default: 150 } },
+    },
+  },
+  {
     name: 'resolution',
     label: 'Resolution',
     hint: 'Specify the maximum resolution of training images. If the training images exceed the resolution specified here, they will be scaled down to this resolution.',

--- a/src/components/Training/Form/TrainingSubmit.tsx
+++ b/src/components/Training/Form/TrainingSubmit.tsx
@@ -655,6 +655,7 @@ export const TrainingFormSubmit = ({ model }: { model: NonNullable<TrainingModel
         continueFrom: _continueFrom,
         sampleCfgScale: _sampleCfgScale,
         sampleStrength: _sampleStrength,
+        saveEvery: _saveEvery,
         ...legacyEngineParams
       } = paramData;
       let finalParams: any = legacyEngineParams;

--- a/src/components/Training/Form/TrainingSubmitAdvancedSettings.tsx
+++ b/src/components/Training/Form/TrainingSubmitAdvancedSettings.tsx
@@ -55,6 +55,7 @@ import {
   trainingBaseModelTypesVideo,
   AI_TOOLKIT_EPOCHS,
   aiToolkitStepDefault,
+  aiToolkitSaveEveryDefault,
   aiToolkitBatchMax,
 } from '~/utils/training';
 import type { AudioSampleOverride } from '~/utils/training';
@@ -112,10 +113,7 @@ export const AdvancedSettings = ({
       // checkpoint count (maxTrainEpochs, sent as `epochs`) is derived from it.
       defaultParams.trainBatchSize = 1;
       defaultParams.targetSteps = aiToolkitStepDefault(selectedRun.baseType);
-      defaultParams.saveEvery = Math.max(
-        1,
-        Math.round(defaultParams.targetSteps / AI_TOOLKIT_EPOCHS.default)
-      );
+      defaultParams.saveEvery = aiToolkitSaveEveryDefault(defaultParams.targetSteps);
       defaultParams.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
     } else {
       const repeatsTarget = selectedRun.baseType === 'sd15' ? 400 : 200;

--- a/src/components/Training/Form/TrainingSubmitAdvancedSettings.tsx
+++ b/src/components/Training/Form/TrainingSubmitAdvancedSettings.tsx
@@ -107,11 +107,16 @@ export const AdvancedSettings = ({
     defaultParams.engine = selectedRun.params.engine;
 
     if (features.trainingStepsPricing && selectedRun.params.engine === 'ai-toolkit') {
-      // Steps-based pricing: steps is set directly (not derived from repeats), epochs is
-      // the saved-checkpoint count (default 10), and batchSize defaults to 1.
-      defaultParams.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
+      // Steps-based pricing: steps is set directly (not derived from repeats), batchSize
+      // defaults to 1. "Save every" is the secondary knob (step interval); the saved-
+      // checkpoint count (maxTrainEpochs, sent as `epochs`) is derived from it.
       defaultParams.trainBatchSize = 1;
       defaultParams.targetSteps = aiToolkitStepDefault(selectedRun.baseType);
+      defaultParams.saveEvery = Math.max(
+        1,
+        Math.round(defaultParams.targetSteps / AI_TOOLKIT_EPOCHS.default)
+      );
+      defaultParams.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
     } else {
       const repeatsTarget = selectedRun.baseType === 'sd15' ? 400 : 200;
       defaultParams.numRepeats = Math.max(
@@ -172,6 +177,29 @@ export const AdvancedSettings = ({
     selectedRun.params.numRepeats,
     selectedRun.params.trainBatchSize,
     numImages,
+  ]);
+
+  // Steps-based pricing (AI Toolkit): "Save every" (step interval) is the user-set knob;
+  // derive maxTrainEpochs (the saved-checkpoint count we send as `epochs`) from it as
+  // round(steps / saveEvery), clamped to the allowed checkpoint range. Recomputes when
+  // either steps or saveEvery changes so the sticky interval holds as steps grow.
+  useEffect(() => {
+    if (!features.trainingStepsPricing || selectedRun.params.engine !== 'ai-toolkit') return;
+    const { targetSteps, saveEvery } = selectedRun.params;
+    if (!saveEvery || saveEvery < 1) return;
+    const checkpoints = Math.min(
+      AI_TOOLKIT_EPOCHS.max,
+      Math.max(AI_TOOLKIT_EPOCHS.min, Math.round(targetSteps / saveEvery))
+    );
+    if (selectedRun.params.maxTrainEpochs !== checkpoints) {
+      doUpdate({ params: { maxTrainEpochs: checkpoints } });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    selectedRun.params.engine,
+    selectedRun.params.targetSteps,
+    selectedRun.params.saveEvery,
+    features.trainingStepsPricing,
   ]);
 
   // Adjust optimizer and related settings
@@ -372,6 +400,18 @@ export const AdvancedSettings = ({
       : selectedRun.params.engine === 'kohya'
       ? 'Kohya'
       : selectedRun.params.engine;
+
+  // Steps-based pricing UI only applies to AI Toolkit when the flag is on.
+  const isAiToolkit = features.trainingStepsPricing && selectedRun.params.engine === 'ai-toolkit';
+
+  // For AI Toolkit, lead with the two length knobs in priority order — Steps (primary)
+  // then Save every (secondary) — instead of their default array position.
+  const orderedTrainingSettings = isAiToolkit
+    ? [...trainingSettings].sort((a, b) => {
+        const rank = (name: string) => (name === 'targetSteps' ? 0 : name === 'saveEvery' ? 1 : 2);
+        return rank(a.name) - rank(b.name);
+      })
+    : trainingSettings;
 
   return (
     <>
@@ -831,14 +871,11 @@ export const AdvancedSettings = ({
             <Accordion.Panel>
               <DescriptionTable
                 labelWidth="200px"
-                items={trainingSettings.map((ts) => {
+                items={orderedTrainingSettings.map((ts) => {
                   let inp: React.ReactNode;
 
                   const baseOverride = ts.overrides?.[runBase];
                   const override = baseOverride?.all ?? baseOverride?.[selectedRun.params.engine];
-                  // Steps-based pricing UI only applies to AI Toolkit when the flag is on.
-                  const isAiToolkit =
-                    features.trainingStepsPricing && selectedRun.params.engine === 'ai-toolkit';
 
                   const disabledOverride = override?.disabled;
                   const hint = override?.hint ?? ts.hint;
@@ -952,61 +989,130 @@ export const AdvancedSettings = ({
                     );
                   }
 
+                  // Rows with their own info bubble skip the label hover tooltip to avoid a
+                  // double popup (the bubble carries the full explanation).
+                  const hasInfoBubble =
+                    isAiToolkit && (ts.name === 'targetSteps' || ts.name === 'saveEvery');
+                  const labelInner = (
+                    <Group>
+                      <Group gap={6}>
+                        <Text
+                          inline
+                          style={hint && !hasInfoBubble ? { cursor: 'help' } : undefined}
+                        >
+                          {ts.label}
+                        </Text>
+                        {isAiToolkit && ts.name === 'targetSteps' && (
+                          <InfoPopover type="hover" size="xs" iconProps={{ size: 16 }}>
+                            <Stack gap={4}>
+                              <Text size="sm" fw={600}>
+                                Steps
+                              </Text>
+                              <Text size="sm">
+                                The total number of training steps — the main thing that drives how
+                                long training takes and what it costs. More steps means the LoRA
+                                learns your dataset more strongly; too many can{' '}
+                                <Text span fw={600}>
+                                  overtrain
+                                </Text>{' '}
+                                it and introduce artifacts.
+                              </Text>
+                              <Text size="sm" c="dimmed">
+                                This is the primary dial — start here, then use{' '}
+                                <Text span fw={600}>
+                                  Save every
+                                </Text>{' '}
+                                to choose how many checkpoints you get along the way.
+                              </Text>
+                            </Stack>
+                          </InfoPopover>
+                        )}
+                        {ts.name === 'targetSteps' && selectedRun.params.targetSteps > maxSteps && (
+                          <Tooltip
+                            label={`Max steps too high. Limit: ${numberWithCommas(maxSteps)}`}
+                            position="bottom"
+                          >
+                            <IconAlertTriangle color="orange" size={16} />
+                          </Tooltip>
+                        )}
+                        {ts.name === 'trainBatchSize' &&
+                          ['flux', 'sd35'].includes(selectedRun.baseType) &&
+                          selectedRun.params.engine === 'kohya' &&
+                          selectedRun.params.trainBatchSize > 2 &&
+                          selectedRun.params.resolution > 512 && (
+                            <Tooltip
+                              label={`Batch size too high for resolution (max of 2 for >512)`}
+                              position="bottom"
+                            >
+                              <IconAlertTriangle color="orange" size={16} />
+                            </Tooltip>
+                          )}
+                        {isAiToolkit && ts.name === 'saveEvery' && (
+                          <InfoPopover type="hover" size="xs" iconProps={{ size: 16 }}>
+                            <Stack gap={4}>
+                              <Text size="sm" fw={600}>
+                                Save every
+                              </Text>
+                              <Text size="sm">
+                                How often (in steps) a checkpoint is saved. Each saved checkpoint is
+                                a downloadable{' '}
+                                <Text span fw={600}>
+                                  epoch
+                                </Text>{' '}
+                                — a candidate you can preview and pick from after training.
+                              </Text>
+                              <Text size="sm">
+                                e.g. 3,000 steps saving every 250 produces 3,000 / 250 ={' '}
+                                <Text span fw={600}>
+                                  12 checkpoints
+                                </Text>
+                                . Saving more often gives you more candidates, with a much smaller
+                                effect on cost than Steps.
+                              </Text>
+                            </Stack>
+                          </InfoPopover>
+                        )}
+                        {isAiToolkit && ts.name === 'saveEvery' && (
+                          <Text size="xs" c="dimmed">
+                            ≈ {selectedRun.params.maxTrainEpochs} checkpoint
+                            {selectedRun.params.maxTrainEpochs === 1 ? '' : 's'}
+                          </Text>
+                        )}
+                      </Group>
+                      {/* use this for new parameters */}
+                      {/*{ts.name === 'engine' && selectedRun.baseType === 'flux' && (*/}
+                      {/*  <Badge color="green">NEW</Badge>*/}
+                      {/*)}*/}
+                    </Group>
+                  );
+
                   return {
-                    label: hint ? (
-                      <CivitaiTooltip
-                        position="top"
-                        variant="roundedOpaque"
-                        withArrow
-                        multiline
-                        label={hint}
-                      >
-                        <Group>
-                          <Group gap={6}>
-                            <Text inline style={{ cursor: 'help' }}>
-                              {ts.label}
-                            </Text>
-                            {ts.name === 'targetSteps' &&
-                              selectedRun.params.targetSteps > maxSteps && (
-                                <Tooltip
-                                  label={`Max steps too high. Limit: ${numberWithCommas(maxSteps)}`}
-                                  position="bottom"
-                                >
-                                  <IconAlertTriangle color="orange" size={16} />
-                                </Tooltip>
-                              )}
-                            {ts.name === 'trainBatchSize' &&
-                              ['flux', 'sd35'].includes(selectedRun.baseType) &&
-                              selectedRun.params.engine === 'kohya' &&
-                              selectedRun.params.trainBatchSize > 2 &&
-                              selectedRun.params.resolution > 512 && (
-                                <Tooltip
-                                  label={`Batch size too high for resolution (max of 2 for >512)`}
-                                  position="bottom"
-                                >
-                                  <IconAlertTriangle color="orange" size={16} />
-                                </Tooltip>
-                              )}
-                          </Group>
-                          {/* use this for new parameters */}
-                          {/*{ts.name === 'engine' && selectedRun.baseType === 'flux' && (*/}
-                          {/*  <Badge color="green">NEW</Badge>*/}
-                          {/*)}*/}
-                        </Group>
-                      </CivitaiTooltip>
-                    ) : (
-                      ts.label
-                    ),
+                    label:
+                      hint && !hasInfoBubble ? (
+                        <CivitaiTooltip
+                          position="top"
+                          variant="roundedOpaque"
+                          withArrow
+                          multiline
+                          label={hint}
+                        >
+                          {labelInner}
+                        </CivitaiTooltip>
+                      ) : (
+                        labelInner
+                      ),
                     value: inp,
                     visible: !(
                       ts.name === 'engine' ||
                       (ts.name === 'optimizerArgs' && selectedRun.params.engine === 'ai-toolkit') ||
-                      // Steps pricing (AI Toolkit): batchSize becomes a configurable input and
-                      // numRepeats is hidden. Legacy AI Toolkit keeps the old layout (batchSize
-                      // hidden, numRepeats shown).
+                      // "Save every" is the AI-Toolkit + steps-pricing knob only.
+                      (ts.name === 'saveEvery' && !isAiToolkit) ||
+                      // Steps pricing (AI Toolkit): epochs is derived from Save every (so hide the
+                      // raw Epochs row), numRepeats is deprecated, batchSize is configurable.
+                      // Legacy AI Toolkit keeps the old layout (batchSize hidden, numRepeats shown).
                       (selectedRun.params.engine === 'ai-toolkit' &&
                         (features.trainingStepsPricing
-                          ? ts.name === 'numRepeats'
+                          ? ts.name === 'numRepeats' || ts.name === 'maxTrainEpochs'
                           : ts.name === 'trainBatchSize'))
                     ),
                   };

--- a/src/components/Training/Form/TrainingSubmitModelSelect.tsx
+++ b/src/components/Training/Form/TrainingSubmitModelSelect.tsx
@@ -60,6 +60,7 @@ import {
   type AudioSampleOverride,
   AI_TOOLKIT_EPOCHS,
   aiToolkitStepDefault,
+  aiToolkitSaveEveryDefault,
   getDefaultEngine,
   isSamplePromptsRequired,
   parseAudioCaption,
@@ -275,10 +276,7 @@ export const ModelSelect = ({
       defaultParams.targetSteps = aiToolkitStepDefault(
         (data.baseType ?? selectedRun.baseType) as TrainingBaseModelType
       );
-      defaultParams.saveEvery = Math.max(
-        1,
-        Math.round(defaultParams.targetSteps / AI_TOOLKIT_EPOCHS.default)
-      );
+      defaultParams.saveEvery = aiToolkitSaveEveryDefault(defaultParams.targetSteps);
       defaultParams.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
     } else {
       defaultParams.numRepeats = Math.max(1, Math.min(5000, Math.ceil(200 / (numImages || 1))));

--- a/src/components/Training/Form/TrainingSubmitModelSelect.tsx
+++ b/src/components/Training/Form/TrainingSubmitModelSelect.tsx
@@ -269,12 +269,17 @@ export const ModelSelect = ({
 
     if (features.trainingStepsPricing && engineToUse === 'ai-toolkit') {
       // Steps-based pricing: steps is the primary length knob (prefilled per ecosystem),
-      // epochs = saved checkpoints (default 10), batchSize defaults to 1.
-      defaultParams.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
+      // batchSize defaults to 1. "Save every" (step interval) seeds to ~10 checkpoints;
+      // maxTrainEpochs (sent as `epochs`) is derived from it in AdvancedSettings.
       defaultParams.trainBatchSize = 1;
       defaultParams.targetSteps = aiToolkitStepDefault(
         (data.baseType ?? selectedRun.baseType) as TrainingBaseModelType
       );
+      defaultParams.saveEvery = Math.max(
+        1,
+        Math.round(defaultParams.targetSteps / AI_TOOLKIT_EPOCHS.default)
+      );
+      defaultParams.maxTrainEpochs = AI_TOOLKIT_EPOCHS.default;
     } else {
       defaultParams.numRepeats = Math.max(1, Math.min(5000, Math.ceil(200 / (numImages || 1))));
 

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -162,6 +162,9 @@ export const trainingDetailsParams = z.object({
   sampleStrength: z.number().optional(),
   /** AIR of a previously-trained LoRA to continue training from ("train further"). */
   continueFrom: z.string().optional(),
+  // "Save every N steps" — the UI knob that derives `maxTrainEpochs` (saved checkpoints)
+  // as round(targetSteps / saveEvery). UI-only; we send the derived `epochs`, never this.
+  saveEvery: z.number().int().min(1).optional(),
 });
 export type TrainingDetailsParams = z.infer<typeof trainingDetailsParams>;
 

--- a/src/server/services/orchestrator/training/training.orch.ts
+++ b/src/server/services/orchestrator/training/training.orch.ts
@@ -366,10 +366,11 @@ export const createTrainingWorkflow = async ({
       params = legacyParams;
     }
   } else {
-    // continueFrom / sample params are AI Toolkit-only. The kohya-shaped params schema
-    // tolerates them (it doubles as the UI run state), but they must never reach the
+    // continueFrom / sample params / saveEvery are AI Toolkit-only. The kohya-shaped params
+    // schema tolerates them (it doubles as the UI run state), but they must never reach the
     // kohya/rapid/musubi dispatch, which spreads params straight into the payload.
-    const { continueFrom, sampleCfgScale, sampleStrength, ...engineParams } = trainingParams;
+    const { continueFrom, sampleCfgScale, sampleStrength, saveEvery, ...engineParams } =
+      trainingParams;
     params = engineParams;
   }
 

--- a/src/utils/training.ts
+++ b/src/utils/training.ts
@@ -38,6 +38,15 @@ export type TrainingBaseModelType = (typeof trainingBaseModelType)[number];
 // clamps these server-side, so these are UX guard rails rather than the source of truth.
 export const AI_TOOLKIT_EPOCHS = { default: 10, min: 1, max: 20 } as const;
 
+// "Save every N steps" bounds — the secondary length knob. Kept here so the input config
+// and the per-run seeds stay in sync (seeds must clamp to >= min, not 1).
+export const AI_TOOLKIT_SAVE_EVERY = { default: 200, min: 50, max: 5000, step: 50 } as const;
+
+/** Seed "Save every" so the run starts at ~AI_TOOLKIT_EPOCHS.default checkpoints, never
+ *  below the input minimum even if the step default is small. */
+export const aiToolkitSaveEveryDefault = (steps: number): number =>
+  Math.max(AI_TOOLKIT_SAVE_EVERY.min, Math.round(steps / AI_TOOLKIT_EPOCHS.default));
+
 export const aiToolkitStepDefault = (baseType: TrainingBaseModelType): number =>
   baseType === 'ltx2' || baseType === 'ltx23' ? 3000 : baseType === 'anima' ? 1500 : 2000;
 


### PR DESCRIPTION
Reframe the AI-Toolkit secondary length control from raw "Epochs" to "Save every" (a step interval), placed directly under Steps:

- "Save every N steps" is the user-set knob; the saved-checkpoint count (maxTrainEpochs, sent as `epochs`) is derived as round(steps / saveEvery), clamped to 1-20, with a live "≈ N checkpoints" readout
- Steps renders first (primary), Save every second; raw Epochs row hidden
- saveEvery is UI-only — stripped from every non-AI-Toolkit payload on both the client submit path and the server dispatch
- add ⓘ info bubbles explaining Steps (primary length/cost dial, overtraining) and Save every (checkpoint cadence; 3000 steps / 250 = 12 checkpoints), and drop the now-redundant label hover tooltip on those rows (no double popup)

All gated to AI Toolkit + the trainingStepsPricing flag.