### PR TITLE
fix(model): coerce virtualizer bigint key to string in ModelTensorMetadata

### DIFF
--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -301,7 +301,7 @@ function TensorTable({ data }: { data: ModelTensorAnalysis }) {
               const row = visibleRows[item.index];
               return (
                 <div
-                  key={item.key}
+                  key={String(item.key)}
                   style={{
                     position: 'absolute',
                     top: 0,


### PR DESCRIPTION
## What

`ModelTensorMetadata.tsx:304` passed the `@tanstack/react-virtual` virtual-item `key` (which can be a `bigint`) directly to React's `key` prop. React's `Key` type is `string | number`, so `next build`'s TypeScript check fails:

\`\`\`
./src/components/Model/ModelVersions/ModelTensorMetadata.tsx:304:19
Type error: Type 'bigint' is not assignable to type 'Key | null | undefined'.
> 304 |   key={item.key}
\`\`\`

This broke the dp-prod Tekton build off `release` (`civitai-web-build-4v57t-build-image`, exit 1 at the type-check stage).

## Fix

`key={item.key}` → `key={String(item.key)}`.

`main` already carries this exact fix (bundled into commit `1314834836`); `release` was 3 commits behind and missing it. This lands the one-line fix on `release` directly to unblock the dp-prod build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)