### PR TITLE
feat(app-blocks): build/deploy status visibility on /apps/my-submissions (Phase 2)

### DIFF
--- a/prisma/migrations/20260615130000_app_blocks_deploy_state/migration.sql
+++ b/prisma/migrations/20260615130000_app_blocks_deploy_state/migration.sql
@@ -1,0 +1,8 @@
+-- App Blocks Phase 2: per-request build/deploy lifecycle for /apps/my-submissions.
+-- Additive + nullable → backward-compatible, safe to apply ahead of the rollout.
+-- civitai applies migrations MANUALLY (no `prisma migrate deploy`) — apply to
+-- prod cnpg-nvme0 AND the cnpg-cluster-dev clone.
+ALTER TABLE "app_block_publish_requests"
+  ADD COLUMN IF NOT EXISTS "deploy_state" TEXT,
+  ADD COLUMN IF NOT EXISTS "deploy_detail" TEXT,
+  ADD COLUMN IF NOT EXISTS "deploy_updated_at" TIMESTAMPTZ(6);

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2308,6 +2308,9 @@ model AppBlockPublishRequest {
   rejectionReason       String?   @map("rejection_reason")
   approvalNotes         String?   @map("approval_notes")
   forgejoCommitSha      String?   @map("forgejo_commit_sha")                                // populated on approve after Forgejo commit succeeds
+  deployState           String?   @map("deploy_state")                                      // Phase 2 build/deploy lifecycle (approved requests): building|deploying|live|failed
+  deployDetail          String?   @map("deploy_detail")                                      // human-readable detail, primarily the failure reason
+  deployUpdatedAt       DateTime? @map("deploy_updated_at") @db.Timestamptz(6)              // last deploy_state transition
   createdAt             DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt             DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 

--- a/src/components/Apps/__tests__/deploy-status.test.ts
+++ b/src/components/Apps/__tests__/deploy-status.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEPLOY_STALE_AFTER_MS,
+  deployRefetchInterval,
+  isInFlightDeploy,
+  isStaleDeploy,
+  type DeployLifecycleRow,
+} from '../deploy-status';
+
+const NOW = 1_700_000_000_000;
+const fresh = new Date(NOW - 60_000); // 1 min ago
+const stale = new Date(NOW - DEPLOY_STALE_AFTER_MS - 60_000); // > 45 min ago
+
+const row = (over: Partial<DeployLifecycleRow> = {}): DeployLifecycleRow => ({
+  status: 'approved',
+  deployState: 'building',
+  deployUpdatedAt: fresh,
+  ...over,
+});
+
+describe('isInFlightDeploy', () => {
+  it('true only for approved + building/deploying', () => {
+    expect(isInFlightDeploy(row({ deployState: 'building' }))).toBe(true);
+    expect(isInFlightDeploy(row({ deployState: 'deploying' }))).toBe(true);
+    expect(isInFlightDeploy(row({ deployState: 'live' }))).toBe(false);
+    expect(isInFlightDeploy(row({ deployState: 'failed' }))).toBe(false);
+    expect(isInFlightDeploy(row({ deployState: null }))).toBe(false);
+  });
+  it('false for non-approved rows regardless of deployState', () => {
+    expect(isInFlightDeploy(row({ status: 'pending', deployState: 'building' }))).toBe(false);
+    expect(isInFlightDeploy(row({ status: 'rejected', deployState: 'building' }))).toBe(false);
+    expect(isInFlightDeploy(row({ status: 'withdrawn', deployState: 'building' }))).toBe(false);
+  });
+});
+
+describe('isStaleDeploy', () => {
+  it('true for an in-flight row not updated within the threshold', () => {
+    expect(isStaleDeploy(row({ deployUpdatedAt: stale }), NOW)).toBe(true);
+  });
+  it('false for a recently-updated in-flight row', () => {
+    expect(isStaleDeploy(row({ deployUpdatedAt: fresh }), NOW)).toBe(false);
+  });
+  it('false when deployUpdatedAt is null (no transition recorded yet)', () => {
+    expect(isStaleDeploy(row({ deployUpdatedAt: null }), NOW)).toBe(false);
+  });
+  it('false for a terminal row even if the timestamp is old', () => {
+    expect(isStaleDeploy(row({ deployState: 'live', deployUpdatedAt: stale }), NOW)).toBe(false);
+    expect(isStaleDeploy(row({ deployState: 'failed', deployUpdatedAt: stale }), NOW)).toBe(false);
+  });
+  it('parses an ISO string deployUpdatedAt (defensive non-superjson path)', () => {
+    expect(isStaleDeploy(row({ deployUpdatedAt: new Date(stale).toISOString() }), NOW)).toBe(true);
+    expect(isStaleDeploy(row({ deployUpdatedAt: new Date(fresh).toISOString() }), NOW)).toBe(false);
+  });
+});
+
+describe('deployRefetchInterval', () => {
+  it('stops (false) when nothing is in flight', () => {
+    expect(deployRefetchInterval([], NOW)).toBe(false);
+    expect(
+      deployRefetchInterval([row({ deployState: 'live' }), row({ deployState: 'failed' })], NOW)
+    ).toBe(false);
+  });
+  it('polls fast (5s) while any in-flight row is fresh', () => {
+    expect(deployRefetchInterval([row({ deployUpdatedAt: fresh })], NOW)).toBe(5000);
+  });
+  it('backs off (30s) once every in-flight row is stalled — but never stops', () => {
+    expect(deployRefetchInterval([row({ deployUpdatedAt: stale })], NOW)).toBe(30000);
+  });
+  it('a single fresh in-flight row keeps the fast cadence even alongside a stalled one', () => {
+    expect(
+      deployRefetchInterval(
+        [row({ deployUpdatedAt: stale }), row({ deployUpdatedAt: fresh })],
+        NOW
+      )
+    ).toBe(5000);
+  });
+  it('ignores terminal rows when choosing cadence', () => {
+    expect(
+      deployRefetchInterval(
+        [row({ deployState: 'live' }), row({ deployState: 'building', deployUpdatedAt: stale })],
+        NOW
+      )
+    ).toBe(30000);
+  });
+});

--- a/src/components/Apps/deploy-status.ts
+++ b/src/components/Apps/deploy-status.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for the App Blocks build/deploy lifecycle shown on
+ * `/apps/my-submissions` (Phase 2). Extracted from the page so the
+ * staleness + poll-cadence logic — the part that churned across two
+ * audit-fix passes — is unit-testable without React.
+ */
+
+export type DeployLifecycleState = 'building' | 'deploying' | 'live' | 'failed' | null;
+
+export type DeployLifecycleRow = {
+  status: string;
+  deployState: DeployLifecycleState;
+  deployUpdatedAt?: string | Date | null;
+};
+
+// A build/deploy that hasn't advanced in this long is treated as STALLED: the
+// fire-and-forget apply watcher was likely lost to a civitai-web pod restart
+// (build-callback.ts documents this self-heal-on-next-build window). Sits
+// COMFORTABLY above the build pipeline's own ceiling — the Tekton pipeline
+// timeout is 20m EXECUTION plus queue time on the single slow build node — so a
+// legitimately slow/queued build is never mislabeled. A stalled row only BACKS
+// OFF polling (never stops), so a slow build that finishes past the threshold
+// still self-heals to live/failed without a page reload.
+export const DEPLOY_STALE_AFTER_MS = 45 * 60 * 1000;
+
+/** An approved request whose code is still being built or deployed. */
+export function isInFlightDeploy(s: Pick<DeployLifecycleRow, 'status' | 'deployState'>): boolean {
+  return (
+    s.status === 'approved' && (s.deployState === 'building' || s.deployState === 'deploying')
+  );
+}
+
+/**
+ * An in-flight row that hasn't transitioned in `DEPLOY_STALE_AFTER_MS` — likely
+ * stuck (watcher lost to a pod restart). `now` is injectable for tests.
+ */
+export function isStaleDeploy(s: DeployLifecycleRow, now: number = Date.now()): boolean {
+  if (!isInFlightDeploy(s) || !s.deployUpdatedAt) return false;
+  const updated =
+    typeof s.deployUpdatedAt === 'string' ? new Date(s.deployUpdatedAt) : s.deployUpdatedAt;
+  return now - updated.getTime() > DEPLOY_STALE_AFTER_MS;
+}
+
+/**
+ * Poll cadence for the submissions query: 5s while an in-flight row is fresh,
+ * 30s once every in-flight row looks stalled (back off but DON'T stop, so a
+ * slow build still self-heals — the global query config is staleTime:Infinity
+ * + refetchOnWindowFocus:false), and stop (`false`) when nothing is in flight.
+ */
+export function deployRefetchInterval(
+  rows: DeployLifecycleRow[],
+  now: number = Date.now()
+): number | false {
+  const inFlight = rows.filter(isInFlightDeploy);
+  if (inFlight.length === 0) return false;
+  return inFlight.some((s) => !isStaleDeploy(s, now)) ? 5000 : 30000;
+}

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -8,6 +8,7 @@ import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
 import { setCommitStatus } from '~/server/services/blocks/forgejo.service';
 import { triggerApply, waitForApplyJob } from '~/server/services/blocks/apps-pipeline.service';
+import { markRequestDeployState } from '~/server/services/blocks/publish-request.service';
 
 /**
  * POST /api/internal/blocks/build-callback
@@ -290,6 +291,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       context: 'civitai/build',
       description: `Build ${body.status ?? 'failed'}`,
     });
+    await markRequestDeployState(body.slug, body.sha, 'failed', `Build ${body.status ?? 'failed'}`);
     res.status(200).json({ ok: true, applied: false, reason: 'build failed' });
     return;
   }
@@ -318,6 +320,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     context: 'civitai/deploy',
     description: 'Applying to civitai-apps',
   });
+  await markRequestDeployState(body.slug, body.sha, 'deploying');
 
   let applyJob: { name: string };
   try {
@@ -339,6 +342,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       context: 'civitai/deploy',
       description: `Apply trigger failed: ${String(e).slice(0, 80)}`,
     });
+    await markRequestDeployState(body.slug, body.sha, 'failed', 'Deploy could not start');
     res.status(500).json({ error: 'Apply trigger failed', detail: String(e).slice(0, 240) });
     return;
   }
@@ -386,6 +390,7 @@ async function watchApplyJobAndRecord(args: {
         where: { id: args.appBlockId },
         data: { currentVersionDeployedAt: new Date() },
       });
+      await markRequestDeployState(args.slug, args.sha, 'live');
       await safe(setCommitStatus, {
         slug: args.slug,
         sha: args.sha,
@@ -403,14 +408,16 @@ async function watchApplyJobAndRecord(args: {
       if (outcome === 'failed') {
         await clearApplyMark(args.appBlockId, args.sha);
       }
+      const deployDetail = outcome === 'timeout' ? 'Deploy timed out' : 'Deploy failed';
       // Flip commit status so the dev sees red.
       await safe(setCommitStatus, {
         slug: args.slug,
         sha: args.sha,
         state: 'failure',
         context: 'civitai/deploy',
-        description: outcome === 'timeout' ? 'Deploy timed out' : 'Deploy failed',
+        description: deployDetail,
       });
+      await markRequestDeployState(args.slug, args.sha, 'failed', deployDetail);
       // eslint-disable-next-line no-console
       console.warn(
         `[build-callback] apply Job ${args.jobName} ended ${outcome}; current_version_deployed_at not updated`

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -291,7 +291,12 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       context: 'civitai/build',
       description: `Build ${body.status ?? 'failed'}`,
     });
-    await markRequestDeployState(body.slug, body.sha, 'failed', `Build ${body.status ?? 'failed'}`);
+    await markRequestDeployState(
+      body.slug,
+      body.sha,
+      'failed',
+      `Build ${String(body.status ?? 'failed').slice(0, 60)}`
+    );
     res.status(200).json({ ok: true, applied: false, reason: 'build failed' });
     return;
   }

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -112,11 +112,14 @@ function formatDate(d: string | Date): string {
 }
 
 // A build/deploy that hasn't advanced in this long is treated as STALLED: the
-// fire-and-forget apply watcher was almost certainly lost to a civitai-web pod
-// restart (build-callback.ts documents this self-heal-on-next-build window).
-// Generous vs a normal queue+build+deploy so a slow-but-progressing build never
-// trips it. Used to (a) stop polling forever and (b) hint the dev to resubmit.
-const DEPLOY_STALE_AFTER_MS = 20 * 60 * 1000;
+// fire-and-forget apply watcher was likely lost to a civitai-web pod restart
+// (build-callback.ts documents this self-heal-on-next-build window). Must sit
+// COMFORTABLY above the build pipeline's own ceiling — the Tekton pipeline
+// timeout is 20m EXECUTION plus queue time on the single slow build node — so a
+// legitimately slow/queued build is never mislabeled. When a row does look
+// stalled we only BACK OFF polling (never stop), so a slow build that finishes
+// past the threshold still self-heals to live/failed without a page reload.
+const DEPLOY_STALE_AFTER_MS = 45 * 60 * 1000;
 
 function isInFlightDeploy(s: Pick<Submission, 'status' | 'deployState'>): boolean {
   return (
@@ -211,14 +214,18 @@ export default function MySubmissionsPage() {
   const features = useFeatureFlags();
   const submissionsQuery = trpc.blocks.listMyPublishRequests.useQuery(undefined, {
     enabled: !!features?.appBlocks,
-    // Live-update the badge while an approved submission is ACTIVELY building/
-    // deploying. Stop once everything is terminal (live/failed) — AND treat a
-    // stalled in-flight row (watcher lost to a pod restart) as terminal so a
-    // single stuck row can't spin the poll every 5s forever.
+    // Poll while an approved submission is building/deploying so the badge
+    // live-updates. Once a row looks stalled (watcher likely lost to a pod
+    // restart) we BACK OFF to 30s rather than stop — so a slow build that
+    // finishes past the staleness threshold still self-heals to live/failed
+    // without a reload (the global query config is staleTime:Infinity +
+    // refetchOnWindowFocus:false, so stopping entirely would never recover).
+    // Stop only when nothing is in flight.
     refetchInterval: (query) => {
       const data = (query.state.data ?? []) as Submission[];
-      const active = data.some((s) => isInFlightDeploy(s) && !isStaleDeploy(s));
-      return active ? 5000 : false;
+      const inFlight = data.filter(isInFlightDeploy);
+      if (inFlight.length === 0) return false;
+      return inFlight.some((s) => !isStaleDeploy(s)) ? 5000 : 30000;
     },
   });
 

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -111,11 +111,48 @@ function formatDate(d: string | Date): string {
   return date.toLocaleString();
 }
 
-function statusBadge(submission: Pick<Submission, 'status' | 'deployState'>) {
+// A build/deploy that hasn't advanced in this long is treated as STALLED: the
+// fire-and-forget apply watcher was almost certainly lost to a civitai-web pod
+// restart (build-callback.ts documents this self-heal-on-next-build window).
+// Generous vs a normal queue+build+deploy so a slow-but-progressing build never
+// trips it. Used to (a) stop polling forever and (b) hint the dev to resubmit.
+const DEPLOY_STALE_AFTER_MS = 20 * 60 * 1000;
+
+function isInFlightDeploy(s: Pick<Submission, 'status' | 'deployState'>): boolean {
+  return (
+    s.status === 'approved' && (s.deployState === 'building' || s.deployState === 'deploying')
+  );
+}
+
+function isStaleDeploy(
+  s: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt'>
+): boolean {
+  if (!isInFlightDeploy(s) || !s.deployUpdatedAt) return false;
+  const updated =
+    typeof s.deployUpdatedAt === 'string' ? new Date(s.deployUpdatedAt) : s.deployUpdatedAt;
+  return Date.now() - updated.getTime() > DEPLOY_STALE_AFTER_MS;
+}
+
+function statusBadge(
+  submission: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt'>
+) {
   const { status } = submission;
   // For an approved request, show the real build/deploy lifecycle rather than a
   // flat "approved" — the dev cares whether their code is actually live.
   if (status === 'approved') {
+    // A stuck in-flight row (watcher lost to a pod restart) shows a muted
+    // "stalled" badge instead of spinning on building/deploying forever.
+    if (isStaleDeploy(submission)) {
+      return (
+        <Badge
+          color="orange"
+          leftSection={<IconAlertTriangle size={12} />}
+          title="No progress for a while — the deploy may be stuck. Resubmit a new version if it doesn't go live."
+        >
+          {submission.deployState} (stalled)
+        </Badge>
+      );
+    }
     switch (submission.deployState) {
       case 'building':
         return (
@@ -174,16 +211,14 @@ export default function MySubmissionsPage() {
   const features = useFeatureFlags();
   const submissionsQuery = trpc.blocks.listMyPublishRequests.useQuery(undefined, {
     enabled: !!features?.appBlocks,
-    // Live-update the badge while any approved submission is mid-build/deploy;
-    // stop polling once everything is terminal (live/failed/non-approved).
+    // Live-update the badge while an approved submission is ACTIVELY building/
+    // deploying. Stop once everything is terminal (live/failed) — AND treat a
+    // stalled in-flight row (watcher lost to a pod restart) as terminal so a
+    // single stuck row can't spin the poll every 5s forever.
     refetchInterval: (query) => {
       const data = (query.state.data ?? []) as Submission[];
-      const inFlight = data.some(
-        (s) =>
-          s.status === 'approved' &&
-          (s.deployState === 'building' || s.deployState === 'deploying')
-      );
-      return inFlight ? 5000 : false;
+      const active = data.some((s) => isInFlightDeploy(s) && !isStaleDeploy(s));
+      return active ? 5000 : false;
     },
   });
 
@@ -320,6 +355,7 @@ export default function MySubmissionsPage() {
                           <Table.Td>
                             <SubmissionActions
                               submission={s}
+                              isFirstVersion={isFirst}
                               onWithdraw={() =>
                                 withdrawMutation.mutate({ publishRequestId: s.id })
                               }
@@ -394,10 +430,12 @@ export default function MySubmissionsPage() {
 
 function SubmissionActions({
   submission,
+  isFirstVersion,
   onWithdraw,
   busy,
 }: {
   submission: Submission;
+  isFirstVersion: boolean;
   onWithdraw: () => void;
   busy: boolean;
 }) {
@@ -416,6 +454,20 @@ function SubmissionActions({
     );
   }
   if (submission.status === 'approved') {
+    // "Open live" points at https://<slug>.civit.ai/. Only meaningful once
+    // something is actually serving: hide it for a FIRST version that hasn't
+    // gone live yet (it would 404 / contradict a "building"/"deploy failed"
+    // badge). For a subsequent version still building/failed, the previously
+    // approved version is still live, so keep the link. null deployState =
+    // legacy approved row → assume live.
+    const live = submission.deployState === 'live' || submission.deployState == null;
+    if (!live && isFirstVersion) {
+      return (
+        <Text size="xs" c="dimmed">
+          —
+        </Text>
+      );
+    }
     return (
       <Button
         size="xs"

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -24,6 +24,7 @@ import {
 import Link from 'next/link';
 import { Fragment } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
+import { deployRefetchInterval, isStaleDeploy } from '~/components/Apps/deploy-status';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
@@ -111,31 +112,6 @@ function formatDate(d: string | Date): string {
   return date.toLocaleString();
 }
 
-// A build/deploy that hasn't advanced in this long is treated as STALLED: the
-// fire-and-forget apply watcher was likely lost to a civitai-web pod restart
-// (build-callback.ts documents this self-heal-on-next-build window). Must sit
-// COMFORTABLY above the build pipeline's own ceiling — the Tekton pipeline
-// timeout is 20m EXECUTION plus queue time on the single slow build node — so a
-// legitimately slow/queued build is never mislabeled. When a row does look
-// stalled we only BACK OFF polling (never stop), so a slow build that finishes
-// past the threshold still self-heals to live/failed without a page reload.
-const DEPLOY_STALE_AFTER_MS = 45 * 60 * 1000;
-
-function isInFlightDeploy(s: Pick<Submission, 'status' | 'deployState'>): boolean {
-  return (
-    s.status === 'approved' && (s.deployState === 'building' || s.deployState === 'deploying')
-  );
-}
-
-function isStaleDeploy(
-  s: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt'>
-): boolean {
-  if (!isInFlightDeploy(s) || !s.deployUpdatedAt) return false;
-  const updated =
-    typeof s.deployUpdatedAt === 'string' ? new Date(s.deployUpdatedAt) : s.deployUpdatedAt;
-  return Date.now() - updated.getTime() > DEPLOY_STALE_AFTER_MS;
-}
-
 function statusBadge(
   submission: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt'>
 ) {
@@ -221,12 +197,7 @@ export default function MySubmissionsPage() {
     // without a reload (the global query config is staleTime:Infinity +
     // refetchOnWindowFocus:false, so stopping entirely would never recover).
     // Stop only when nothing is in flight.
-    refetchInterval: (query) => {
-      const data = (query.state.data ?? []) as Submission[];
-      const inFlight = data.filter(isInFlightDeploy);
-      if (inFlight.length === 0) return false;
-      return inFlight.some((s) => !isStaleDeploy(s)) ? 5000 : 30000;
-    },
+    refetchInterval: (query) => deployRefetchInterval((query.state.data ?? []) as Submission[]),
   });
 
   const withdrawMutation = trpc.blocks.withdrawPublishRequest.useMutation({

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -88,6 +88,12 @@ type Submission = {
   reviewedAt: string | Date | null;
   rejectionReason: string | null;
   approvalNotes: string | null;
+  /** Phase 2 build/deploy lifecycle for an approved request:
+   * 'building' → 'deploying' → 'live', or 'failed'. Null on non-approved rows
+   * and on approved rows from before this feature shipped. */
+  deployState: 'building' | 'deploying' | 'live' | 'failed' | null;
+  deployDetail: string | null;
+  deployUpdatedAt: string | Date | null;
   fileSummary: unknown;
   manifestDiffSummary: unknown;
   /** Total pinned subscriptions referencing this app block. (Was the
@@ -105,18 +111,50 @@ function formatDate(d: string | Date): string {
   return date.toLocaleString();
 }
 
-function statusBadge(status: string) {
+function statusBadge(submission: Pick<Submission, 'status' | 'deployState'>) {
+  const { status } = submission;
+  // For an approved request, show the real build/deploy lifecycle rather than a
+  // flat "approved" — the dev cares whether their code is actually live.
+  if (status === 'approved') {
+    switch (submission.deployState) {
+      case 'building':
+        return (
+          <Badge color="blue" leftSection={<IconClock size={12} />}>
+            building
+          </Badge>
+        );
+      case 'deploying':
+        return (
+          <Badge color="indigo" leftSection={<IconClock size={12} />}>
+            deploying
+          </Badge>
+        );
+      case 'failed':
+        return (
+          <Badge color="red" leftSection={<IconX size={12} />}>
+            deploy failed
+          </Badge>
+        );
+      case 'live':
+        return (
+          <Badge color="green" leftSection={<IconCheck size={12} />}>
+            live
+          </Badge>
+        );
+      default:
+        // Legacy/pre-Phase-2 approved rows (no deploy_state captured).
+        return (
+          <Badge color="green" leftSection={<IconCheck size={12} />}>
+            approved
+          </Badge>
+        );
+    }
+  }
   switch (status) {
     case 'pending':
       return (
         <Badge color="blue" leftSection={<IconClock size={12} />}>
           pending
-        </Badge>
-      );
-    case 'approved':
-      return (
-        <Badge color="green" leftSection={<IconCheck size={12} />}>
-          approved
         </Badge>
       );
     case 'rejected':
@@ -136,6 +174,17 @@ export default function MySubmissionsPage() {
   const features = useFeatureFlags();
   const submissionsQuery = trpc.blocks.listMyPublishRequests.useQuery(undefined, {
     enabled: !!features?.appBlocks,
+    // Live-update the badge while any approved submission is mid-build/deploy;
+    // stop polling once everything is terminal (live/failed/non-approved).
+    refetchInterval: (query) => {
+      const data = (query.state.data ?? []) as Submission[];
+      const inFlight = data.some(
+        (s) =>
+          s.status === 'approved' &&
+          (s.deployState === 'building' || s.deployState === 'deploying')
+      );
+      return inFlight ? 5000 : false;
+    },
   });
 
   const withdrawMutation = trpc.blocks.withdrawPublishRequest.useMutation({
@@ -230,7 +279,7 @@ export default function MySubmissionsPage() {
                           <Table.Td>
                             <Code>{s.version}</Code>
                           </Table.Td>
-                          <Table.Td>{statusBadge(s.status)}</Table.Td>
+                          <Table.Td>{statusBadge(s)}</Table.Td>
                           <Table.Td>
                             <Text size="xs">{formatDate(s.submittedAt)}</Text>
                           </Table.Td>
@@ -307,6 +356,24 @@ export default function MySubmissionsPage() {
                               >
                                 <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
                                   {s.approvalNotes}
+                                </Text>
+                              </Alert>
+                            </Table.Td>
+                          </Table.Tr>
+                        )}
+                        {s.status === 'approved' && s.deployState === 'failed' && (
+                          <Table.Tr>
+                            <Table.Td colSpan={8} p={0}>
+                              <Alert
+                                color="red"
+                                variant="light"
+                                radius={0}
+                                icon={<IconAlertTriangle size={16} />}
+                                title="Build / deploy failed"
+                              >
+                                <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                                  {s.deployDetail ??
+                                    'The build or deploy failed. Fix the issue and resubmit a new version.'}
                                 </Text>
                               </Alert>
                             </Table.Td>

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -653,6 +653,10 @@ export const blocksRouter = router({
           reviewedAt: true,
           rejectionReason: true,
           approvalNotes: true,
+          // Phase 2 build/deploy lifecycle, surfaced on /apps/my-submissions.
+          deployState: true,
+          deployDetail: true,
+          deployUpdatedAt: true,
           fileSummary: true,
           manifestDiffSummary: true,
           appBlock: {

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -1046,6 +1046,15 @@ describe('approveRequest', () => {
       })
     );
 
+    // Phase 2: after triggerBuild succeeds, the approved request is marked
+    // 'building' so the developer sees the lifecycle on /apps/my-submissions.
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { slug: 'hello', forgejoCommitSha: 'commit_sha_abc', status: 'approved' },
+        data: expect.objectContaining({ deployState: 'building' }),
+      })
+    );
+
     // OauthClient gets the slug-scoped allowedOrigins + a deterministic id
     // (post C-2 fix). The deterministic id is what makes retries idempotent.
     const ocArg = mockDbWrite.oauthClient.create.mock.calls[0][0].data;

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1656,12 +1656,48 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     );
   }
 
+  // Phase 2 — surface the build/deploy lifecycle to the developer on
+  // /apps/my-submissions. triggerBuild succeeded above (the catch re-throws),
+  // so the build is now queued: mark the request 'building'. build-callback
+  // advances it deploying → live, or flips it to failed.
+  await markRequestDeployState(request.slug, forgejoCommitSha, 'building');
+
   return {
     publishRequestId: request.id,
     appBlockId,
     forgejoCommitSha,
     isFirstVersion,
   };
+}
+
+/** Build/deploy lifecycle states surfaced on /apps/my-submissions (Phase 2). */
+export type DeployState = 'building' | 'deploying' | 'live' | 'failed';
+
+/**
+ * Advisory: stamp the build/deploy lifecycle state onto the APPROVED publish
+ * request for `(slug, sha)`. Keyed on `forgejo_commit_sha` (unique per approved
+ * version; parked unreviewed requests carry an empty sha so they never match)
+ * + `status='approved'`. Best-effort — a status-write failure must never break
+ * the approve flow or the build-callback, so errors are swallowed. The build is
+ * triggered only by approveRequest, so this is the single source of these
+ * transitions: approveRequest sets 'building'; build-callback sets
+ * 'deploying'/'live'/'failed'.
+ */
+export async function markRequestDeployState(
+  slug: string,
+  sha: string,
+  state: DeployState,
+  detail?: string | null
+): Promise<void> {
+  try {
+    const { dbWrite } = await import('~/server/db/client');
+    await dbWrite.appBlockPublishRequest.updateMany({
+      where: { slug, forgejoCommitSha: sha, status: 'approved' },
+      data: { deployState: state, deployDetail: detail ?? null, deployUpdatedAt: new Date() },
+    });
+  } catch {
+    /* deploy_state is advisory display data — never let it break the caller */
+  }
 }
 
 export type BackfillPublishRequestParams = {

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1691,12 +1691,27 @@ export async function markRequestDeployState(
 ): Promise<void> {
   try {
     const { dbWrite } = await import('~/server/db/client');
-    await dbWrite.appBlockPublishRequest.updateMany({
+    const res = await dbWrite.appBlockPublishRequest.updateMany({
       where: { slug, forgejoCommitSha: sha, status: 'approved' },
       data: { deployState: state, deployDetail: detail ?? null, deployUpdatedAt: new Date() },
     });
-  } catch {
-    /* deploy_state is advisory display data — never let it break the caller */
+    if (res.count === 0) {
+      // A systemic mis-key would otherwise be invisible (badges silently never
+      // advance). Log so a regression is greppable; not fatal.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[markRequestDeployState] no approved request matched (slug=${slug}, sha=${sha.slice(0, 12)}, state=${state})`
+      );
+    }
+  } catch (err) {
+    // deploy_state is advisory display data — never let it break the caller,
+    // but don't swallow silently either.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[markRequestDeployState] write failed (slug=${slug}, state=${state}): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
   }
 }
 

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -25,6 +25,7 @@ const {
   mockWaitApply,
   mockSetCommitStatus,
   mockAppBlockUpdate,
+  mockMarkDeploy,
 } = vi.hoisted(() => {
   // nxResult: true = newly set (first time), false = key already present (replay).
   const mockRedis = { nxResult: true, nxThrows: false };
@@ -47,6 +48,7 @@ const {
     mockWaitApply: vi.fn<(...a: any[]) => Promise<string>>(async () => 'succeeded'),
     mockSetCommitStatus: vi.fn(async () => undefined),
     mockAppBlockUpdate: vi.fn(async () => undefined),
+    mockMarkDeploy: vi.fn<(...a: any[]) => Promise<void>>(async () => undefined),
   };
 });
 
@@ -83,6 +85,11 @@ vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   waitForApplyJob: mockWaitApply,
 }));
 vi.mock('~/server/services/blocks/forgejo.service', () => ({ setCommitStatus: mockSetCommitStatus }));
+// Phase 2: build-callback marks the per-request deploy lifecycle. Mock the
+// helper so we can assert the transitions (the real one writes to the DB).
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  markRequestDeployState: mockMarkDeploy,
+}));
 
 import {
   checkCallbackTimestamp,
@@ -361,6 +368,8 @@ describe('build-callback handler — flag gate + replay guard', () => {
     expect(res._body).toMatchObject({ applied: false });
     expect(mockTriggerApply).not.toHaveBeenCalled();
     expect(mockSetNx).not.toHaveBeenCalled(); // dedup slot untouched by a failure callback
+    // Phase 2: a build failure marks the request 'failed' so the dev sees it.
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'failed', expect.stringMatching(/Build/));
   });
 
   it('clears the replay slot on a DEFINITIVE apply failure so a same-sha retry is not blocked', async () => {
@@ -369,6 +378,9 @@ describe('build-callback handler — flag gate + replay guard', () => {
     await invoke(signedReq(validSuccessBody()), res);
     await flush(); // let the fire-and-forget watcher run
     expect(mockRedisDel).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`));
+    // Phase 2: 'deploying' on apply trigger, then 'failed' from the watcher.
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'deploying');
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'failed', 'Deploy failed');
   });
 
   it('does NOT clear the slot on apply timeout (the Job may still be running)', async () => {
@@ -377,6 +389,8 @@ describe('build-callback handler — flag gate + replay guard', () => {
     await invoke(signedReq(validSuccessBody()), res);
     await flush();
     expect(mockRedisDel).not.toHaveBeenCalled();
+    // Phase 2: a timeout is surfaced as 'failed' with the timeout detail.
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'failed', 'Deploy timed out');
   });
 
   it('records the deploy and keeps the slot on apply success', async () => {
@@ -386,6 +400,9 @@ describe('build-callback handler — flag gate + replay guard', () => {
     await flush();
     expect(mockAppBlockUpdate).toHaveBeenCalledWith(expect.objectContaining({ where: { id: APB } }));
     expect(mockRedisDel).not.toHaveBeenCalled();
+    // Phase 2: the request transitions 'deploying' (apply trigger) → 'live' (watcher).
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'deploying');
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'live');
   });
 
   it('clears the replay slot when triggerApply itself throws — no watcher runs, so the catch must free it', async () => {
@@ -396,6 +413,8 @@ describe('build-callback handler — flag gate + replay guard', () => {
     // mark was set (SET NX) then freed in the catch so a same-sha retry isn't wedged
     expect(mockSetNx).toHaveBeenCalledTimes(1);
     expect(mockRedisDel).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`));
+    // Phase 2: an apply-trigger failure marks the request 'failed'.
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'failed', 'Deploy could not start');
   });
 
   // ---- F5: callback `ts` replay-freshness through the handler ----------------

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -413,7 +413,8 @@ describe('build-callback handler — flag gate + replay guard', () => {
     // mark was set (SET NX) then freed in the catch so a same-sha retry isn't wedged
     expect(mockSetNx).toHaveBeenCalledTimes(1);
     expect(mockRedisDel).toHaveBeenCalledWith(expect.stringContaining(`apply:${APB}:${SHA}`));
-    // Phase 2: an apply-trigger failure marks the request 'failed'.
+    // Phase 2: 'deploying' is written before triggerApply, then 'failed' when it throws.
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'deploying');
     expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'failed', 'Deploy could not start');
   });
 


### PR DESCRIPTION
## What

**Phase 2** of the App Blocks DX arc. Today, after a moderator approves a publish request, the developer is blind to what happens next — the `/apps/my-submissions` row flips to a green "approved" the instant it's approved and stays there even if the build or deploy **fails**. This surfaces the real lifecycle: **Building → Deploying → Live**, or **Failed** (with a reason), live-updating while in flight.

## How

**Persist per-request lifecycle** on `app_block_publish_requests` (3 additive, nullable columns) rather than deriving from `current_version_deployed_at` — derivation can't represent *failure* (a first-version build/deploy failure leaves it NULL → would show "Building" forever).

- New `markRequestDeployState(slug, sha, state, detail?)` helper — advisory/best-effort, keyed on `forgejo_commit_sha` + `status='approved'`.
- **Writers** (build is triggered only by `approveRequest`, so transitions are single-sourced):
  - `approveRequest` → `building` (after `triggerBuild` succeeds)
  - `build-callback`: `deploying` on apply-trigger; `failed` on build failure / apply-trigger failure; the fire-and-forget watcher → `live` on apply success, `failed` (with `Deploy failed` / `Deploy timed out`) on apply failure/timeout.
- **Reader**: `listMyPublishRequests` returns `deployState` / `deployDetail` / `deployUpdatedAt`.
- **UI** (`/apps/my-submissions`): deploy-aware status badge (building/deploying/live/deploy-failed), an inline failure-detail `Alert` row, and a conditional **5s `refetchInterval`** that polls only while something is mid-build/deploy.

## ⚠️ Migration — manual apply required

`prisma/migrations/20260615130000_app_blocks_deploy_state/migration.sql` adds 3 nullable columns. **Additive → safe to apply ahead of the image**, but civitai uses **no `prisma migrate deploy`** — apply manually to **prod cnpg-nvme0** and the **dev clone**:

```sql
ALTER TABLE "app_block_publish_requests"
  ADD COLUMN IF NOT EXISTS "deploy_state" TEXT,
  ADD COLUMN IF NOT EXISTS "deploy_detail" TEXT,
  ADD COLUMN IF NOT EXISTS "deploy_updated_at" TIMESTAMPTZ(6);
```

## Tests

- `build-callback.test.ts`: build-fail→`failed`, success→`deploying`→`live`, apply fail/timeout→`failed` (+detail), apply-trigger-throw→`failed`.
- `publish-request.orchestration.test.ts`: `approveRequest` → `building` after `triggerBuild`.
- Full blocks unit suite green locally: **391/391** (node-only `unit` project).
- No deploy-pipeline behavior change — purely additive status capture + display. Behind the existing mod gate.

Deploy-lifecycle states need a real build (heavy/flaky), so — like Phase 1's approve→render — they're unit-covered, not preview-e2e'd. Logs / a "view build" deep-link / richer failure reasons (from `waitForApplyJob` conditions) are noted follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)