### PR TITLE
fix(reaction-abuse): move exclusion endpoint off /api/testing (prod-unreachable) → /api/admin

### DIFF
--- a/src/pages/api/admin/reaction-abuse.ts
+++ b/src/pages/api/admin/reaction-abuse.ts
@@ -9,8 +9,14 @@
  * excluded users stop counting toward reaction metrics/ranking (forward-only,
  * within ~5 min on the current day).
  *
+ * NOTE: lives under /api/admin (NOT /api/testing) on purpose — it is called by a
+ * scheduled agent in PRODUCTION, and `route-guards.middleware.ts` hard-blocks
+ * /api/testing/* in prod (`canAccess: () => !isProd` → 307 to /login before the
+ * token check ever runs). /api/admin is the home for WEBHOOK_TOKEN-secured ops
+ * endpoints that must run in prod.
+ *
  * Usage:
- *   POST /api/testing/reaction-abuse?token=$WEBHOOK_TOKEN
+ *   POST /api/admin/reaction-abuse?token=$WEBHOOK_TOKEN
  *   Content-Type: application/json
  *   Body: { "action": "<action>", ...params }
  *


### PR DESCRIPTION
## Problem

The reaction-abuse exclusion endpoint (added in #2580) is called by a **scheduled agent in production**, but it shipped under `src/pages/api/testing/reaction-abuse.ts`. `src/server/middleware/route-guards.middleware.ts` hard-blocks that namespace in prod:

```js
addRouteGuard({ matcher: ['/api/testing/:path*'], canAccess: () => !isProd });
```

So in production (`isProd === true`) **every** request to `/api/testing/reaction-abuse` gets a **307 → `/login`** *before* the `WebhookEndpoint` token check runs — no token or session passes (not even a moderator's; the sibling `/testing/*` UI guard has a mod exception, this one doesn't). Verified both through Cloudflare and against the in-cluster origin (`NODE_ENV=production`). The endpoint deployed but is unreachable exactly where it's meant to be called.

## Fix

Pure relocation: `git mv` to `src/pages/api/admin/reaction-abuse.ts`. Same `WebhookEndpoint` auth, **no logic change**.

`/api/admin/*` is the canonical home for `WEBHOOK_TOKEN`-secured ops endpoints that run in prod — 30+ existing admin endpoints (cache purge, backfills, payouts) use the identical `WebhookEndpoint(...)` wrapper, and no middleware gates `/api/admin` (checked the full stack: previewAuth / regionBlock / apiRegionBlock / routeGuards / apiCache / botDetection — none match `/api/admin`). Added a header note so it isn't moved back under `/api/testing`.

(If you'd prefer `/api/mod/` since this is anti-abuse, or a guard exception instead of a move, easy to switch — but a move keeps a prod endpoint out of the dev-only namespace, which is the cleaner invariant.)

## Caller updated in lockstep

The out-of-cluster caller (`datapacket-talos` `reaction-abuse-svc` poller) is updated to `POST /api/admin/reaction-abuse` in the same change set (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)