### PR TITLE
feat(app-blocks): git-push authoring on-ramp + self-service Forgejo credentials (Phase 3)

### DIFF
--- a/prisma/migrations/20260616120000_app_dev_forgejo_identity/migration.sql
+++ b/prisma/migrations/20260616120000_app_dev_forgejo_identity/migration.sql
@@ -1,0 +1,30 @@
+-- App Blocks Phase 3 (git-push self-service): per-civitai-user Forgejo identity.
+--
+-- Lazily provisioned the first time a developer requests git access to one of
+-- their apps. The Forgejo user is `restricted:true` and granted `write` ONLY on
+-- its own civitai-apps/<slug> repo(s) — a push parks a pending review request
+-- but can NEVER deploy without mod approval (no-trust-on-push gate unchanged).
+--
+-- 1:1 with User (the PK IS the civitai userId). `forgejo_token_encrypted` holds
+-- the user's own Forgejo PAT (sha1, scope `write:repository`), AES-256-GCM
+-- encrypted at rest. It is the SOURCE OF TRUTH for the token because Forgejo
+-- cannot recover a user's password to re-mint: the token is minted once at
+-- provision and re-read thereafter.
+--
+-- Additive → backward-compatible, safe to apply ahead of the rollout. civitai
+-- applies migrations MANUALLY (no `prisma migrate deploy`) — apply to prod
+-- cnpg-nvme0 AND the cnpg-cluster-dev clone.
+
+CREATE TABLE IF NOT EXISTS "app_dev_forgejo_identity" (
+    "user_id" INTEGER NOT NULL,
+    "forgejo_username" TEXT NOT NULL,
+    "forgejo_token_encrypted" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "app_dev_forgejo_identity_pkey" PRIMARY KEY ("user_id")
+);
+
+-- FK to User: a GDPR delete cascades the developer's Forgejo identity away.
+ALTER TABLE "app_dev_forgejo_identity"
+  ADD CONSTRAINT "app_dev_forgejo_identity_user_id_fkey"
+  FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -552,6 +552,7 @@ model User {
   publishRequestsReviewed    AppBlockPublishRequest[]        @relation("PublishRequestReviewer")
   blockScopeInvocations      BlockScopeInvocation[]
   appUserScopeGrants         AppUserScopeGrant[]
+  appDevForgejoIdentity      AppDevForgejoIdentity?
 
   @@index([deletedAt])
 }
@@ -2586,6 +2587,29 @@ model AppUserScopeGrant {
 
   @@unique([userId, appBlockId], map: "app_user_scope_grants_user_app_uniq")
   @@map("app_user_scope_grants")
+}
+
+/// App Blocks Phase 3 (git-push self-service) — per-civitai-user Forgejo
+/// identity. 1:1 with User (PK is the civitai userId), provisioned LAZILY the
+/// first time a developer requests git access to one of their apps.
+///
+/// The Forgejo user is `restricted:true` and granted `write` ONLY on its own
+/// civitai-apps/<slug> repo(s), so a push parks a pending review request but can
+/// NEVER deploy without mod approval (the no-trust-on-push gate is unchanged).
+///
+/// `forgejo_token_encrypted` holds the user's own Forgejo PAT (sha1, scope
+/// `write:repository`), AES-256-GCM-encrypted at rest keyed on NEXTAUTH_SECRET.
+/// It is the SOURCE OF TRUTH for the token: Forgejo can't recover a user's
+/// password, so the token is minted once at provision and re-read thereafter,
+/// never re-minted. A GDPR delete of the User cascades this row away.
+model AppDevForgejoIdentity {
+  userId                Int      @id @map("user_id")
+  user                  User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  forgejoUsername       String   @map("forgejo_username")
+  forgejoTokenEncrypted String   @map("forgejo_token_encrypted")
+  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@map("app_dev_forgejo_identity")
 }
 
 model OauthConsent {

--- a/src/components/Apps/AuthorViaGit.tsx
+++ b/src/components/Apps/AuthorViaGit.tsx
@@ -1,0 +1,206 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Code,
+  CopyButton,
+  Group,
+  Loader,
+  Stack,
+  Text,
+} from '@mantine/core';
+import {
+  IconAlertTriangle,
+  IconBrandGit,
+  IconCheck,
+  IconClipboard,
+  IconEye,
+  IconEyeOff,
+} from '@tabler/icons-react';
+import { useState } from 'react';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
+import { maskCloneUrlCredential } from '~/components/Apps/git-access';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * Phase 3 (git-push self-service) — developer-facing "Author via git" panel for
+ * an APPROVED app the viewer owns, rendered inline on /apps/my-submissions.
+ *
+ * Lazy by design: the panel does NOT fetch on page load. `blocks.getMyAppRepo`
+ * lazily provisions a scoped Forgejo identity + grants the caller write on their
+ * repo as a SIDE EFFECT (see the router), so it must be user-initiated — the
+ * query is `enabled` only once the user clicks "Show git access" (revealed=true).
+ *
+ * Credential handling: the clone URL embeds a live push token. We render it
+ * MASKED by default (the token replaced with •••) and only reveal the real URL
+ * when the user clicks "Reveal" — the token is never in the DOM on first paint of
+ * the panel. Copy buttons copy the REAL (unmasked) value regardless of the
+ * reveal toggle, so the user can copy without exposing it on screen.
+ */
+
+// Local mirror of the getMyAppRepo return shape (blocks.router.ts getMyAppRepo)
+// so this component doesn't pull the full RouterOutput type into the page.
+type RepoAvailable = {
+  notYetAvailable: false;
+  slug: string;
+  httpUrl: string;
+  cloneUrl: string;
+  forgejoUsername: string;
+  instructions: string;
+  firstVersionIsZip: false;
+};
+type RepoNotYet = {
+  notYetAvailable: true;
+  slug: string;
+  firstVersionIsZip: true;
+  message: string;
+};
+type GetMyAppRepoResult = RepoAvailable | RepoNotYet;
+
+function CopyableCode({ value, display }: { value: string; display?: string }) {
+  return (
+    <CopyButton value={value}>
+      {({ copied, copy }) => (
+        <Box pos="relative" onClick={copy} style={{ cursor: 'pointer' }}>
+          <Code
+            block
+            color={copied ? 'green' : undefined}
+            style={{ wordBreak: 'break-all', paddingRight: 36 }}
+          >
+            {copied ? 'Copied' : display ?? value}
+          </Code>
+          <LegacyActionIcon
+            className="absolute right-2 top-1/2 -translate-y-1/2"
+            right={8}
+            variant="transparent"
+            color="gray"
+            aria-label="Copy"
+          >
+            {copied ? <IconCheck size={16} /> : <IconClipboard size={16} />}
+          </LegacyActionIcon>
+        </Box>
+      )}
+    </CopyButton>
+  );
+}
+
+function GitAccessPanel({ appBlockId }: { appBlockId: string }) {
+  const [showToken, setShowToken] = useState(false);
+
+  // Lazy: only fires because this panel is mounted (parent gates mount on the
+  // user clicking "Show git access"). enabled is still scoped to a valid id.
+  const repoQuery = trpc.blocks.getMyAppRepo.useQuery(
+    { appBlockId },
+    {
+      enabled: !!appBlockId,
+      // The token-bearing clone URL is sensitive — don't keep it warm.
+      staleTime: 0,
+      gcTime: 0,
+      retry: false,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  if (repoQuery.isLoading) {
+    return (
+      <Group gap="xs" py="xs">
+        <Loader size="xs" />
+        <Text size="sm" c="dimmed">
+          Provisioning your git access…
+        </Text>
+      </Group>
+    );
+  }
+
+  if (repoQuery.isError) {
+    // Non-owner → FORBIDDEN; not-found → NOT_FOUND. Show a muted message, never
+    // crash. (The page only renders this panel for owned approved rows, so this
+    // is the defensive path.)
+    return (
+      <Alert color="gray" variant="light" icon={<IconAlertTriangle size={16} />} py="xs">
+        <Text size="sm">{repoQuery.error.message}</Text>
+      </Alert>
+    );
+  }
+
+  const data = repoQuery.data as GetMyAppRepoResult | undefined;
+  if (!data) return null;
+
+  if (data.notYetAvailable) {
+    return (
+      <Text size="sm" c="dimmed">
+        {data.message}
+      </Text>
+    );
+  }
+
+  const maskedCloneUrl = maskCloneUrlCredential(data.cloneUrl);
+
+  return (
+    <Stack gap="sm" py="xs">
+      <Text size="sm" fw={500}>
+        Clone URL
+      </Text>
+      <Stack gap={4}>
+        <CopyableCode
+          value={data.cloneUrl}
+          display={showToken ? data.cloneUrl : maskedCloneUrl}
+        />
+        <Group justify="space-between">
+          <Button
+            size="compact-xs"
+            variant="subtle"
+            leftSection={
+              showToken ? <IconEyeOff size={14} /> : <IconEye size={14} />
+            }
+            onClick={() => setShowToken((v) => !v)}
+          >
+            {showToken ? 'Hide token' : 'Reveal token'}
+          </Button>
+          <Text size="xs" c="dimmed">
+            This URL contains a push token — treat it like a password.
+          </Text>
+        </Group>
+      </Stack>
+
+      <Text size="sm" fw={500}>
+        Steps
+      </Text>
+      <CopyableCode value={data.instructions} />
+
+      <Alert color="blue" variant="light" py="xs">
+        <Text size="xs">
+          Your first version is uploaded as a ZIP; new versions can be pushed with
+          git. Pushes go to moderator review — they never deploy automatically.
+        </Text>
+      </Alert>
+    </Stack>
+  );
+}
+
+/**
+ * Collapsible "Author via git" affordance. The parent (my-submissions row)
+ * renders this only for APPROVED rows the user owns (the server still owner-gates
+ * the underlying query). The query does not fire until the panel is expanded.
+ */
+export function AuthorViaGit({ appBlockId }: { appBlockId: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Stack gap="xs">
+      <Group>
+        <Button
+          size="xs"
+          variant="light"
+          leftSection={<IconBrandGit size={14} />}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? 'Hide git access' : 'Author via git'}
+        </Button>
+      </Group>
+      {/* Mount-on-expand so the side-effecting getMyAppRepo only runs when the
+          user opts in (it provisions a Forgejo identity). */}
+      {expanded && <GitAccessPanel appBlockId={appBlockId} />}
+    </Stack>
+  );
+}

--- a/src/components/Apps/AuthorViaGit.tsx
+++ b/src/components/Apps/AuthorViaGit.tsx
@@ -166,7 +166,13 @@ function GitAccessPanel({ appBlockId }: { appBlockId: string }) {
       <Text size="sm" fw={500}>
         Steps
       </Text>
-      <CopyableCode value={data.instructions} />
+      {/* instructions embed the same token-bearing clone URL — mask it under the
+          same reveal toggle so the token isn't shown in cleartext on first paint
+          (copy still copies the real value). */}
+      <CopyableCode
+        value={data.instructions}
+        display={showToken ? data.instructions : maskCloneUrlCredential(data.instructions)}
+      />
 
       <Alert color="blue" variant="light" py="xs">
         <Text size="xs">

--- a/src/components/Apps/__tests__/git-access.test.ts
+++ b/src/components/Apps/__tests__/git-access.test.ts
@@ -29,4 +29,20 @@ describe('maskCloneUrlCredential', () => {
     const url = 'https://dev-7:a:b:c@host.tld/org/slug.git';
     expect(maskCloneUrlCredential(url)).toBe('https://dev-7:••••••••@host.tld/org/slug.git');
   });
+
+  it('masks an embedded credential inside a multi-line instructions string', () => {
+    const instructions = [
+      '# Clone your app repo (credential is embedded in the URL):',
+      'git clone https://dev-42:supersecrettoken@forgejo.example.com/civitai-apps/my-slug.git',
+      'cd my-slug && git add -A && git commit -m "update" && git push',
+    ].join('\n');
+    const masked = maskCloneUrlCredential(instructions);
+    // The live token must not survive into the masked display string...
+    expect(masked).not.toContain('supersecrettoken');
+    expect(masked).toContain(
+      'git clone https://dev-42:••••••••@forgejo.example.com/civitai-apps/my-slug.git'
+    );
+    // ...and the surrounding instruction text is preserved.
+    expect(masked).toContain('cd my-slug && git add -A');
+  });
 });

--- a/src/components/Apps/__tests__/git-access.test.ts
+++ b/src/components/Apps/__tests__/git-access.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { maskCloneUrlCredential } from '../git-access';
+
+describe('maskCloneUrlCredential', () => {
+  it('masks the token (password) but keeps the username + host + path', () => {
+    const url = 'https://dev-42:abc123secrettoken@forgejo.example.com/civitai-apps/my-slug.git';
+    const masked = maskCloneUrlCredential(url);
+    expect(masked).toBe('https://dev-42:••••••••@forgejo.example.com/civitai-apps/my-slug.git');
+    // The real token must NOT survive into the masked display string.
+    expect(masked).not.toContain('abc123secrettoken');
+  });
+
+  it('preserves a url-encoded username', () => {
+    const url = 'https://dev%2Buser:tok@host.tld/org/slug.git';
+    expect(maskCloneUrlCredential(url)).toBe('https://dev%2Buser:••••••••@host.tld/org/slug.git');
+  });
+
+  it('returns the url unchanged when there is no embedded credential', () => {
+    const url = 'https://forgejo.example.com/civitai-apps/my-slug.git';
+    expect(maskCloneUrlCredential(url)).toBe(url);
+  });
+
+  it('does not mistake a host:port for a credential (no @)', () => {
+    const url = 'https://host.tld:8443/org/slug.git';
+    expect(maskCloneUrlCredential(url)).toBe(url);
+  });
+
+  it('handles a token that itself contains colons', () => {
+    const url = 'https://dev-7:a:b:c@host.tld/org/slug.git';
+    expect(maskCloneUrlCredential(url)).toBe('https://dev-7:••••••••@host.tld/org/slug.git');
+  });
+});

--- a/src/components/Apps/git-access.ts
+++ b/src/components/Apps/git-access.ts
@@ -13,17 +13,18 @@
 const TOKEN_MASK = '••••••••';
 
 /**
- * Replaces the password (token) segment of a `user:token@host` clone URL with a
- * fixed mask, preserving the username and everything from `@host` onward so the
- * shape is still recognizable. Returns the input unchanged if it doesn't carry
- * an embedded `user:pass@` credential (nothing to mask, fail-safe — never throws).
+ * Replaces the password (token) segment of any `scheme://user:token@host`
+ * credential with a fixed mask, preserving the username + host + path. Works on
+ * a bare clone URL AND on a multi-line string that EMBEDS one (e.g. the
+ * `git clone <url>` instructions snippet) — every occurrence is masked. Only
+ * masks when both a colon (a password) and an `@` are present in the userinfo,
+ * with no `/` or whitespace inside (so it never mangles a `host:port` or a URL
+ * without credentials). Returns the input unchanged when there's nothing to mask
+ * (fail-safe — never throws).
  */
-export function maskCloneUrlCredential(cloneUrl: string): string {
-  // Match scheme + userinfo (user:pass) + the rest. Only mask when BOTH a colon
-  // (a password is present) and an '@' (it's really userinfo, not a host:port)
-  // are in the authority. Non-greedy user/pass; the '@' anchors the credential.
-  const m = cloneUrl.match(/^(\w+:\/\/)([^:/@\s]+):([^@\s]+)@(.+)$/);
-  if (!m) return cloneUrl;
-  const [, scheme, user, , rest] = m;
-  return `${scheme}${user}:${TOKEN_MASK}@${rest}`;
+export function maskCloneUrlCredential(text: string): string {
+  return text.replace(
+    /(\w+:\/\/)([^:/@\s]+):([^@\s]+)@/g,
+    (_full, scheme, user) => `${scheme}${user}:${TOKEN_MASK}@`
+  );
 }

--- a/src/components/Apps/git-access.ts
+++ b/src/components/Apps/git-access.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure helper for the Phase 3 "Author via git" panel (AuthorViaGit.tsx).
+ * Extracted so the credential-masking logic is unit-testable without React.
+ *
+ * `blocks.getMyAppRepo` returns a clone URL with the push token embedded as the
+ * basic-auth password:
+ *   https://<username>:<token>@<host>/<org>/<slug>.git
+ * The panel renders this MASKED by default so the live token isn't in the DOM on
+ * first paint; this helper produces the masked display string. The REAL URL is
+ * still what the copy button copies — masking is display-only.
+ */
+
+const TOKEN_MASK = '••••••••';
+
+/**
+ * Replaces the password (token) segment of a `user:token@host` clone URL with a
+ * fixed mask, preserving the username and everything from `@host` onward so the
+ * shape is still recognizable. Returns the input unchanged if it doesn't carry
+ * an embedded `user:pass@` credential (nothing to mask, fail-safe — never throws).
+ */
+export function maskCloneUrlCredential(cloneUrl: string): string {
+  // Match scheme + userinfo (user:pass) + the rest. Only mask when BOTH a colon
+  // (a password is present) and an '@' (it's really userinfo, not a host:port)
+  // are in the authority. Non-greedy user/pass; the '@' anchors the credential.
+  const m = cloneUrl.match(/^(\w+:\/\/)([^:/@\s]+):([^@\s]+)@(.+)$/);
+  if (!m) return cloneUrl;
+  const [, scheme, user, , rest] = m;
+  return `${scheme}${user}:${TOKEN_MASK}@${rest}`;
+}

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -24,6 +24,7 @@ import {
 import Link from 'next/link';
 import { Fragment } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
+import { AuthorViaGit } from '~/components/Apps/AuthorViaGit';
 import { deployRefetchInterval, isStaleDeploy } from '~/components/Apps/deploy-status';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -390,6 +391,17 @@ export default function MySubmissionsPage() {
                                     'The build or deploy failed. Fix the issue and resubmit a new version.'}
                                 </Text>
                               </Alert>
+                            </Table.Td>
+                          </Table.Tr>
+                        )}
+                        {/* Phase 3: git-push self-service. Approved rows with an
+                            app block (FK set on approve) can author updates via
+                            git. The server still owner-gates getMyAppRepo, and
+                            the panel only fetches the token on user expand. */}
+                        {s.status === 'approved' && s.appBlockId && (
+                          <Table.Tr>
+                            <Table.Td colSpan={8}>
+                              <AuthorViaGit appBlockId={s.appBlockId} />
                             </Table.Td>
                           </Table.Tr>
                         )}

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -177,6 +177,21 @@ describe('blocks.getMyAppRepo — Phase 3 git-push credential', () => {
     expect(mockAddCollaborator).not.toHaveBeenCalled();
   });
 
+  it('banned owner: FORBIDDEN, nothing provisioned (no credential issued to a banned account)', async () => {
+    findUnique.mockResolvedValue({
+      blockId: 'my-app',
+      status: 'approved',
+      app: { userId: ownerUser.id },
+    });
+    const bannedOwner = { ...ownerUser, bannedAt: new Date() };
+    const caller = blocksRouter.createCaller(fakeCtx(bannedOwner) as never);
+    await expect(caller.getMyAppRepo({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+    expect(mockAddCollaborator).not.toHaveBeenCalled();
+  });
+
   it('owner, app approved: provisions identity, grants write on the slug repo, returns the clone URL with creds', async () => {
     findUnique.mockResolvedValue({
       blockId: 'my-app',

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Phase 3 (git-push self-service) — `blocks.getMyAppRepo` router coverage.
+ * Drives the REAL blocks router so the middleware chain (`protectedProcedure`
+ * → isAuthed, `enforceAppBlocksFlag`) + the owner gate decide the outcome; the
+ * dev-git-access + forgejo services are mocked at the module boundary so this
+ * suite exercises the GATE + URL assembly, not the provisioning service (which
+ * has its own test).
+ *
+ * GATING INVARIANTS pinned here (each FAILS if the gate is dropped):
+ *   - anon → UNAUTHORIZED, nothing provisioned.
+ *   - non-owner (logged in) → FORBIDDEN, nothing provisioned.
+ *   - owner, app NOT approved → `notYetAvailable` shape, nothing provisioned.
+ *   - owner, app approved → provisions an identity, grants `write` on the
+ *     slug's repo, returns a clone URL carrying the username + token.
+ */
+
+const { mockIsAppBlocksEnabled, mockEnsureForgejoIdentity, mockAddCollaborator } = vi.hoisted(
+  () => ({
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockEnsureForgejoIdentity: vi.fn(),
+    mockAddCollaborator: vi.fn(),
+  })
+);
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/env/server', () => ({
+  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com' },
+}));
+vi.mock('~/server/services/blocks/dev-git-access.service', () => ({
+  ensureForgejoIdentity: mockEnsureForgejoIdentity,
+}));
+// FORGEJO_ORG is imported statically by the router; addCollaborator is reached
+// via the router's dynamic import — both come from this mock.
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  FORGEJO_ORG: 'civitai-apps',
+  addCollaborator: mockAddCollaborator,
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    getAppDetail: vi.fn(),
+    getFeaturedBlocks: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/textToImage/textToImage', () => ({
+  createTextToImageStep: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbWrite: {},
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn() },
+  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { dbRead } from '~/server/db/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: true } as never,
+    track: undefined,
+  };
+}
+
+const ownerUser = { id: 7, isModerator: false, tier: 'free', username: 'owner' };
+const otherUser = { id: 99, isModerator: false, tier: 'free', username: 'intruder' };
+
+const findUnique = dbRead.appBlock.findUnique as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockResolvedValue(true); // flag lit for all these tests
+  mockEnsureForgejoIdentity.mockReset();
+  mockEnsureForgejoIdentity.mockResolvedValue({
+    forgejoUsername: 'dev-7',
+    token: 'minted-token-sha1',
+  });
+  mockAddCollaborator.mockReset();
+  mockAddCollaborator.mockResolvedValue(undefined);
+  findUnique.mockReset();
+});
+
+describe('blocks.getMyAppRepo — Phase 3 git-push credential', () => {
+  it('anon (no session): UNAUTHORIZED, nothing provisioned', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getMyAppRepo({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+    expect(mockAddCollaborator).not.toHaveBeenCalled();
+  });
+
+  it('non-owner: FORBIDDEN, nothing provisioned', async () => {
+    findUnique.mockResolvedValue({
+      blockId: 'my-app',
+      status: 'approved',
+      app: { userId: ownerUser.id },
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(otherUser) as never);
+    await expect(caller.getMyAppRepo({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+    expect(mockAddCollaborator).not.toHaveBeenCalled();
+  });
+
+  it('owner but block missing: NOT_FOUND', async () => {
+    findUnique.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(caller.getMyAppRepo({ appBlockId: 'nope' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('owner, app NOT approved: returns the notYetAvailable shape, nothing provisioned', async () => {
+    findUnique.mockResolvedValue({
+      blockId: 'my-app',
+      status: 'pending',
+      app: { userId: ownerUser.id },
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    const result = await caller.getMyAppRepo({ appBlockId: 'ab_1' });
+    expect(result.notYetAvailable).toBe(true);
+    expect(result.firstVersionIsZip).toBe(true);
+    expect(result.slug).toBe('my-app');
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+    expect(mockAddCollaborator).not.toHaveBeenCalled();
+  });
+
+  it('owner, app approved: provisions identity, grants write on the slug repo, returns the clone URL with creds', async () => {
+    findUnique.mockResolvedValue({
+      blockId: 'my-app',
+      status: 'approved',
+      app: { userId: ownerUser.id },
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    const result = await caller.getMyAppRepo({ appBlockId: 'ab_1' });
+
+    expect(result.notYetAvailable).toBe(false);
+    expect(result.slug).toBe('my-app');
+    expect(result.forgejoUsername).toBe('dev-7');
+
+    // Provisioned the caller's identity (not anyone else's).
+    expect(mockEnsureForgejoIdentity).toHaveBeenCalledWith(7);
+    // Granted WRITE on this slug's repo.
+    expect(mockAddCollaborator).toHaveBeenCalledWith({
+      slug: 'my-app',
+      username: 'dev-7',
+      permission: 'write',
+    });
+
+    // Public (no-cred) URL + credentialed clone URL.
+    expect(result.httpUrl).toBe('https://forgejo.civitai.com/civitai-apps/my-app.git');
+    expect(result.cloneUrl).toBe(
+      'https://dev-7:minted-token-sha1@forgejo.civitai.com/civitai-apps/my-app.git'
+    );
+    // Instructions carry the credentialed clone + the no-trust-on-push notice.
+    expect(result.instructions).toContain(result.cloneUrl);
+    expect(result.instructions).toMatch(/moderator approves/i);
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1947,6 +1947,15 @@ export const blocksRouter = router({
       if (block.app?.userId !== ctx.user!.id) {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
       }
+      // A banned/suspended account must not be issued (or re-issued) a live push
+      // credential. They still can't deploy (the mod gate holds), but we don't
+      // hand out a fresh Forgejo token. Full revoke-on-ban is a follow-up.
+      if (ctx.user!.bannedAt) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Account is not eligible for git access',
+        });
+      }
 
       const slug = block.blockId;
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1,6 +1,8 @@
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
+import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { FORGEJO_ORG } from '~/server/services/blocks/forgejo.service';
 import { logToAxiom } from '~/server/logging/client';
 import { getOrchestratorToken } from '~/server/orchestrator/get-orchestrator-token';
 import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
@@ -1897,6 +1899,109 @@ export const blocksRouter = router({
         lifetimeShareCents: lifetimeMap.get(a.id)?.shareCents ?? 0,
         lifetimeCount: lifetimeMap.get(a.id)?.count ?? 0,
       }));
+    }),
+
+  /**
+   * Phase 3 (git-push self-service) — return the developer's clone URL +
+   * push credential for one of THEIR apps.
+   *
+   * Owner-gated on OauthClient.userId (the same v1 source of truth as
+   * getMyApps). Lazily provisions a scoped, restricted Forgejo identity for
+   * the caller the first time they ask (ensureForgejoIdentity), then grants
+   * that identity `write` on the app's own civitai-apps/<slug> repo
+   * (addCollaborator). A push parks a pending review request and can NEVER
+   * deploy without mod approval — the no-trust-on-push gate is unchanged.
+   *
+   * The repo only exists once the FIRST version has been ZIP-approved (approve
+   * pre-creates civitai-apps/<slug>); until then there's nothing to push to, so
+   * we return a `notYetAvailable` shape rather than provisioning a credential
+   * the dev can't use.
+   *
+   * `protectedProcedure` (not moderator): an app owner authoring their own app
+   * need not be a mod. Access is bounded by the app.userId owner check + the
+   * appBlocks flag, and the credential is write-on-their-own-repo-only.
+   */
+  getMyAppRepo: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(z.object({ appBlockId: z.string().min(1).max(64) }))
+    .query(async ({ ctx, input }) => {
+      if (!ctx.features.appBlocks) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'App Blocks is not available to this account',
+        });
+      }
+      const block = await dbRead.appBlock.findUnique({
+        where: { id: input.appBlockId },
+        select: {
+          blockId: true,
+          status: true,
+          app: { select: { userId: true } },
+        },
+      });
+      if (!block) throw throwNotFoundError('App block not found');
+      // Owner gate — OauthClient.userId is the v1 app-ownership source of truth.
+      // FORBIDDEN (authenticated but not permitted) rather than UNAUTHORIZED, to
+      // distinguish a logged-in non-owner from an anon caller; mirrors the
+      // grantScopes ceiling gate above.
+      if (block.app?.userId !== ctx.user!.id) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
+      }
+
+      const slug = block.blockId;
+
+      // No Forgejo repo exists until the first version is ZIP-approved
+      // (approveRequest pre-creates civitai-apps/<slug>). Signal "not yet"
+      // instead of provisioning a credential against a missing repo.
+      if (block.status !== 'approved') {
+        return {
+          notYetAvailable: true as const,
+          slug,
+          firstVersionIsZip: true as const,
+          message:
+            'Your first version must be submitted as a ZIP and approved before git access is available. After that, git push to this repo to submit updates.',
+        };
+      }
+
+      const { ensureForgejoIdentity } = await import(
+        '~/server/services/blocks/dev-git-access.service'
+      );
+      const { addCollaborator } = await import('~/server/services/blocks/forgejo.service');
+
+      const { forgejoUsername, token } = await ensureForgejoIdentity(ctx.user!.id);
+      // Idempotent: grants write on this slug's repo (no-op if already a
+      // collaborator). The repo lives under civitai-apps/<slug>.
+      await addCollaborator({ slug, username: forgejoUsername, permission: 'write' });
+
+      // Browser-facing host (clone via Cloudflare → oauth2-proxy is bypassed by
+      // the embedded basic-auth credential, which Forgejo accepts for git).
+      const publicHost = env.FORGEJO_PUBLIC_URL.replace(/^https?:\/\//, '').replace(/\/$/, '');
+      const httpUrl = `https://${publicHost}/${FORGEJO_ORG}/${slug}.git`;
+      const cloneUrl = `https://${encodeURIComponent(forgejoUsername)}:${token}@${publicHost}/${FORGEJO_ORG}/${slug}.git`;
+
+      const instructions = [
+        `# Clone your app repo (credential is embedded in the URL):`,
+        `git clone ${cloneUrl}`,
+        `cd ${slug}`,
+        ``,
+        `# Make changes, then:`,
+        `git add -A`,
+        `git commit -m "describe your change"`,
+        `git push origin main`,
+        ``,
+        `# A push parks a pending review request. It is NOT deployed until a`,
+        `# Civitai moderator approves it.`,
+      ].join('\n');
+
+      return {
+        notYetAvailable: false as const,
+        slug,
+        httpUrl,
+        cloneUrl,
+        forgejoUsername,
+        instructions,
+        firstVersionIsZip: false as const,
+      };
     }),
 });
 

--- a/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
@@ -26,6 +26,7 @@ const { mockDbRead, mockDbWrite, mockForgejo } = vi.hoisted(() => ({
       update: vi.fn(),
       updateMany: vi.fn(),
       delete: vi.fn(),
+      deleteMany: vi.fn(),
     },
   },
   mockForgejo: {
@@ -105,7 +106,7 @@ describe('ensureForgejoIdentity — owner (provisioning) path', () => {
       created: true,
     });
     mockForgejo.mintForgejoUserToken.mockResolvedValue('minted-token-sha1');
-    mockDbWrite.appDevForgejoIdentity.update.mockResolvedValue({});
+    mockDbWrite.appDevForgejoIdentity.updateMany.mockResolvedValue({ count: 1 }); // fill wins
 
     const res = await mod.ensureForgejoIdentity(42);
     expect(res).toEqual({ forgejoUsername: 'dev-42', token: 'minted-token-sha1' });
@@ -127,17 +128,19 @@ describe('ensureForgejoIdentity — owner (provisioning) path', () => {
       })
     );
 
-    // FILL: UPDATE the claim row with the ENCRYPTED token (not plaintext).
-    expect(mockDbWrite.appDevForgejoIdentity.update).toHaveBeenCalledTimes(1);
-    const upd = mockDbWrite.appDevForgejoIdentity.update.mock.calls[0][0];
-    expect(upd.where).toEqual({ userId: 42 });
-    expect(upd.data.forgejoTokenEncrypted).not.toContain('minted-token-sha1');
-    expect(mod.__testing.decryptToken(upd.data.forgejoTokenEncrypted, 'unit-test-secret-key')).toBe(
+    // FILL: conditional updateMany guarded on the STILL-empty token (so a
+    // concurrent reclaimer's good token can't be overwritten), storing the
+    // ENCRYPTED token (not plaintext). Only the fill ran (no reclaim here).
+    expect(mockDbWrite.appDevForgejoIdentity.updateMany).toHaveBeenCalledTimes(1);
+    const fill = mockDbWrite.appDevForgejoIdentity.updateMany.mock.calls[0][0];
+    expect(fill.where).toEqual({ userId: 42, forgejoTokenEncrypted: '' });
+    expect(fill.data.forgejoTokenEncrypted).not.toContain('minted-token-sha1');
+    expect(mod.__testing.decryptToken(fill.data.forgejoTokenEncrypted, 'unit-test-secret-key')).toBe(
       'minted-token-sha1'
     );
 
     expect(mockForgejo.deleteForgejoUser).not.toHaveBeenCalled();
-    expect(mockDbWrite.appDevForgejoIdentity.delete).not.toHaveBeenCalled();
+    expect(mockDbWrite.appDevForgejoIdentity.deleteMany).not.toHaveBeenCalled();
   });
 
   it('true-orphan edge (we hold the claim, Forgejo user exists) — deletes + recreates for a known password', async () => {
@@ -152,13 +155,13 @@ describe('ensureForgejoIdentity — owner (provisioning) path', () => {
         created: true,
       });
     mockForgejo.mintForgejoUserToken.mockResolvedValue('recreated-token-sha1');
-    mockDbWrite.appDevForgejoIdentity.update.mockResolvedValue({});
+    mockDbWrite.appDevForgejoIdentity.updateMany.mockResolvedValue({ count: 1 });
 
     const res = await mod.ensureForgejoIdentity(9);
     expect(res.token).toBe('recreated-token-sha1');
     expect(mockForgejo.deleteForgejoUser).toHaveBeenCalledWith('dev-9');
     expect(mockForgejo.createForgejoUser).toHaveBeenCalledTimes(2);
-    expect(mockDbWrite.appDevForgejoIdentity.update).toHaveBeenCalledTimes(1);
+    expect(mockDbWrite.appDevForgejoIdentity.updateMany).toHaveBeenCalledTimes(1);
   });
 
   it('rolls back the claim row if provisioning throws (so a retry can re-provision)', async () => {
@@ -171,11 +174,14 @@ describe('ensureForgejoIdentity — owner (provisioning) path', () => {
       created: true,
     });
     mockForgejo.mintForgejoUserToken.mockRejectedValue(new Error('forgejo down'));
-    mockDbWrite.appDevForgejoIdentity.delete.mockResolvedValue({});
+    mockDbWrite.appDevForgejoIdentity.deleteMany.mockResolvedValue({ count: 1 });
 
     await expect(mod.ensureForgejoIdentity(3)).rejects.toThrow(/forgejo down/);
-    // Placeholder claim rolled back so the next attempt isn't wedged.
-    expect(mockDbWrite.appDevForgejoIdentity.delete).toHaveBeenCalledWith({ where: { userId: 3 } });
+    // Roll back ONLY a still-empty claim (deleteMany guarded on the empty token)
+    // so a concurrent reclaimer's filled row is never nuked.
+    expect(mockDbWrite.appDevForgejoIdentity.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 3, forgejoTokenEncrypted: '' },
+    });
   });
 });
 
@@ -200,18 +206,19 @@ describe('ensureForgejoIdentity — recovers from an abandoned (wedged) claim', 
       created: true,
     });
     mockForgejo.mintForgejoUserToken.mockResolvedValue('reclaimed-token-sha1');
-    mockDbWrite.appDevForgejoIdentity.update.mockResolvedValue({});
 
     const res = await mod.ensureForgejoIdentity(8);
     expect(res).toEqual({ forgejoUsername: 'dev-8', token: 'reclaimed-token-sha1' });
-    // Reclaim is guarded on a RANGE (empty token + createdAt older than the
-    // stale threshold), not exact equality (timestamptz µs vs JS-Date ms).
+    // Two updateMany calls: [0] the RANGE-guarded reclaim (empty token +
+    // createdAt older than the stale threshold — not exact equality, since
+    // timestamptz µs ≠ JS-Date ms), [1] the conditional fill.
+    expect(mockDbWrite.appDevForgejoIdentity.updateMany).toHaveBeenCalledTimes(2);
     const reclaimWhere = mockDbWrite.appDevForgejoIdentity.updateMany.mock.calls[0][0].where;
     expect(reclaimWhere).toMatchObject({ userId: 8, forgejoTokenEncrypted: '' });
     expect(reclaimWhere.createdAt.lt).toBeInstanceOf(Date);
-    // Then it provisioned + filled the token (no permanent wedge).
+    const fillWhere = mockDbWrite.appDevForgejoIdentity.updateMany.mock.calls[1][0].where;
+    expect(fillWhere).toEqual({ userId: 8, forgejoTokenEncrypted: '' });
     expect(mockForgejo.mintForgejoUserToken).toHaveBeenCalled();
-    expect(mockDbWrite.appDevForgejoIdentity.update).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the Phase 3 (git-push self-service) dev-git-access service:
+ *   - ensureForgejoIdentity create-path (provisions Forgejo user, mints token,
+ *     encrypts + inserts the identity row, returns the decrypted token)
+ *   - ensureForgejoIdentity reuse-path (existing row → decrypt + return, with
+ *     ZERO Forgejo calls)
+ *   - the "Forgejo user exists but no DB row" edge (delete + recreate to get a
+ *     known password)
+ *   - the encrypt/decrypt round-trip (AES-256-GCM keyed on NEXTAUTH_SECRET)
+ *
+ * Mocking strategy mirrors the sibling block service tests: vi.hoisted carries
+ * the mock surfaces; ~/server/db/client, ~/env/server, and ./forgejo.service
+ * are mocked at the module boundary so no Prisma/env/Forgejo is booted.
+ */
+
+const { mockDbRead, mockDbWrite, mockForgejo } = vi.hoisted(() => ({
+  mockDbRead: {
+    appDevForgejoIdentity: { findUnique: vi.fn() },
+  },
+  mockDbWrite: {
+    appDevForgejoIdentity: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+  mockForgejo: {
+    createForgejoUser: vi.fn(),
+    mintForgejoUserToken: vi.fn(),
+    deleteForgejoUser: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/env/server', () => ({ env: { NEXTAUTH_SECRET: 'unit-test-secret-key' } }));
+vi.mock('../forgejo.service', () => mockForgejo);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('encrypt/decrypt round-trip', () => {
+  it('round-trips a token through AES-256-GCM', async () => {
+    const { __testing } = await import('../dev-git-access.service');
+    const secret = 'some-server-secret';
+    const token = 'sha1-deadbeefcafebabe1234567890';
+    const packed = __testing.encryptToken(token, secret);
+
+    // Self-describing iv:tag:ciphertext format; not plaintext.
+    expect(packed.split(':')).toHaveLength(3);
+    expect(packed).not.toContain(token);
+
+    expect(__testing.decryptToken(packed, secret)).toBe(token);
+  });
+
+  it('fails decryption with the wrong secret (GCM auth tag)', async () => {
+    const { __testing } = await import('../dev-git-access.service');
+    const packed = __testing.encryptToken('tok', 'right-secret');
+    expect(() => __testing.decryptToken(packed, 'wrong-secret')).toThrow();
+  });
+
+  it('throws on a malformed packed string', async () => {
+    const { __testing } = await import('../dev-git-access.service');
+    expect(() => __testing.decryptToken('not-packed', 'secret')).toThrow(/malformed/);
+  });
+});
+
+describe('ensureForgejoIdentity — reuse-path', () => {
+  it('returns the decrypted stored token without any Forgejo calls', async () => {
+    const mod = await import('../dev-git-access.service');
+    // Pre-encrypt a token the same way the service would, so the stored row is
+    // realistic.
+    const encrypted = mod.__testing.encryptToken('stored-token-sha1', 'unit-test-secret-key');
+    mockDbRead.appDevForgejoIdentity.findUnique.mockResolvedValue({
+      forgejoUsername: 'dev-7',
+      forgejoTokenEncrypted: encrypted,
+    });
+
+    const res = await mod.ensureForgejoIdentity(7);
+    expect(res).toEqual({ forgejoUsername: 'dev-7', token: 'stored-token-sha1' });
+
+    // No provisioning happened.
+    expect(mockForgejo.createForgejoUser).not.toHaveBeenCalled();
+    expect(mockForgejo.mintForgejoUserToken).not.toHaveBeenCalled();
+    expect(mockDbWrite.appDevForgejoIdentity.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureForgejoIdentity — owner (provisioning) path', () => {
+  it('claims a placeholder row, provisions the user, mints a write:repository token, UPDATEs the row with the encrypted token, returns', async () => {
+    const mod = await import('../dev-git-access.service');
+    mockDbRead.appDevForgejoIdentity.findUnique.mockResolvedValue(null); // fast-path miss
+    mockDbWrite.appDevForgejoIdentity.create.mockResolvedValue({}); // claim wins
+    mockForgejo.createForgejoUser.mockResolvedValue({
+      user: { id: 100, username: 'dev-42' },
+      password: 'fresh-password-1234567890abcdef',
+      created: true,
+    });
+    mockForgejo.mintForgejoUserToken.mockResolvedValue('minted-token-sha1');
+    mockDbWrite.appDevForgejoIdentity.update.mockResolvedValue({});
+
+    const res = await mod.ensureForgejoIdentity(42);
+    expect(res).toEqual({ forgejoUsername: 'dev-42', token: 'minted-token-sha1' });
+
+    // CLAIM: placeholder row with an EMPTY token, on the dev-<id> handle.
+    expect(mockDbWrite.appDevForgejoIdentity.create).toHaveBeenCalledTimes(1);
+    const claim = mockDbWrite.appDevForgejoIdentity.create.mock.calls[0][0].data;
+    expect(claim).toMatchObject({ userId: 42, forgejoUsername: 'dev-42', forgejoTokenEncrypted: '' });
+
+    expect(mockForgejo.createForgejoUser).toHaveBeenCalledWith({
+      username: 'dev-42',
+      email: 'dev-42@apps.civitai.invalid',
+    });
+    expect(mockForgejo.mintForgejoUserToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'dev-42',
+        password: 'fresh-password-1234567890abcdef',
+        scopes: ['write:repository'],
+      })
+    );
+
+    // FILL: UPDATE the claim row with the ENCRYPTED token (not plaintext).
+    expect(mockDbWrite.appDevForgejoIdentity.update).toHaveBeenCalledTimes(1);
+    const upd = mockDbWrite.appDevForgejoIdentity.update.mock.calls[0][0];
+    expect(upd.where).toEqual({ userId: 42 });
+    expect(upd.data.forgejoTokenEncrypted).not.toContain('minted-token-sha1');
+    expect(mod.__testing.decryptToken(upd.data.forgejoTokenEncrypted, 'unit-test-secret-key')).toBe(
+      'minted-token-sha1'
+    );
+
+    expect(mockForgejo.deleteForgejoUser).not.toHaveBeenCalled();
+    expect(mockDbWrite.appDevForgejoIdentity.delete).not.toHaveBeenCalled();
+  });
+
+  it('true-orphan edge (we hold the claim, Forgejo user exists) — deletes + recreates for a known password', async () => {
+    const mod = await import('../dev-git-access.service');
+    mockDbRead.appDevForgejoIdentity.findUnique.mockResolvedValue(null);
+    mockDbWrite.appDevForgejoIdentity.create.mockResolvedValue({});
+    mockForgejo.createForgejoUser
+      .mockResolvedValueOnce({ user: { id: 1, username: 'dev-9' }, password: null, created: false })
+      .mockResolvedValueOnce({
+        user: { id: 2, username: 'dev-9' },
+        password: 'recreated-pw-abcdef1234567890',
+        created: true,
+      });
+    mockForgejo.mintForgejoUserToken.mockResolvedValue('recreated-token-sha1');
+    mockDbWrite.appDevForgejoIdentity.update.mockResolvedValue({});
+
+    const res = await mod.ensureForgejoIdentity(9);
+    expect(res.token).toBe('recreated-token-sha1');
+    expect(mockForgejo.deleteForgejoUser).toHaveBeenCalledWith('dev-9');
+    expect(mockForgejo.createForgejoUser).toHaveBeenCalledTimes(2);
+    expect(mockDbWrite.appDevForgejoIdentity.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back the claim row if provisioning throws (so a retry can re-provision)', async () => {
+    const mod = await import('../dev-git-access.service');
+    mockDbRead.appDevForgejoIdentity.findUnique.mockResolvedValue(null);
+    mockDbWrite.appDevForgejoIdentity.create.mockResolvedValue({});
+    mockForgejo.createForgejoUser.mockResolvedValue({
+      user: { id: 3, username: 'dev-3' },
+      password: 'pw-xxxxxxxxxxxxxxxxxxxxxxxx',
+      created: true,
+    });
+    mockForgejo.mintForgejoUserToken.mockRejectedValue(new Error('forgejo down'));
+    mockDbWrite.appDevForgejoIdentity.delete.mockResolvedValue({});
+
+    await expect(mod.ensureForgejoIdentity(3)).rejects.toThrow(/forgejo down/);
+    // Placeholder claim rolled back so the next attempt isn't wedged.
+    expect(mockDbWrite.appDevForgejoIdentity.delete).toHaveBeenCalledWith({ where: { userId: 3 } });
+  });
+});
+
+describe('ensureForgejoIdentity — concurrent non-owner waits for the owner', () => {
+  it('on a P2002 claim race, waits for the owner to land the token and returns it (no Forgejo calls of its own)', async () => {
+    const mod = await import('../dev-git-access.service');
+    const winnerEncrypted = mod.__testing.encryptToken('winner-token', 'unit-test-secret-key');
+    // fast-path miss, then the wait-loop sees the owner's completed row.
+    mockDbRead.appDevForgejoIdentity.findUnique
+      .mockResolvedValueOnce(null) // fast path
+      .mockResolvedValue({ forgejoUsername: 'dev-5', forgejoTokenEncrypted: winnerEncrypted }); // wait loop
+    mockDbWrite.appDevForgejoIdentity.create.mockRejectedValue({ code: 'P2002' }); // lost the claim
+
+    const res = await mod.ensureForgejoIdentity(5);
+    expect(res).toEqual({ forgejoUsername: 'dev-5', token: 'winner-token' });
+    // Non-owner does NO provisioning of its own.
+    expect(mockForgejo.createForgejoUser).not.toHaveBeenCalled();
+    expect(mockForgejo.mintForgejoUserToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
@@ -24,6 +24,7 @@ const { mockDbRead, mockDbWrite, mockForgejo } = vi.hoisted(() => ({
       findUnique: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       delete: vi.fn(),
     },
   },
@@ -175,6 +176,43 @@ describe('ensureForgejoIdentity — owner (provisioning) path', () => {
     await expect(mod.ensureForgejoIdentity(3)).rejects.toThrow(/forgejo down/);
     // Placeholder claim rolled back so the next attempt isn't wedged.
     expect(mockDbWrite.appDevForgejoIdentity.delete).toHaveBeenCalledWith({ where: { userId: 3 } });
+  });
+});
+
+describe('ensureForgejoIdentity — recovers from an abandoned (wedged) claim', () => {
+  it('reclaims a stale empty-token row (owner died mid-provision) and provisions it itself', async () => {
+    const mod = await import('../dev-git-access.service');
+    const staleCreatedAt = new Date(Date.now() - 120_000); // 2 min old → past the 60s stale threshold
+    mockDbRead.appDevForgejoIdentity.findUnique
+      .mockResolvedValueOnce(null) // fast-path miss
+      .mockResolvedValue({
+        forgejoUsername: 'dev-8',
+        forgejoTokenEncrypted: '', // abandoned: claimed but never filled
+        createdAt: staleCreatedAt,
+      });
+    // We lose the fresh claim (the dead owner's row already occupies the PK)...
+    mockDbWrite.appDevForgejoIdentity.create.mockRejectedValue({ code: 'P2002' });
+    // ...but we atomically reclaim the stale row and become the owner.
+    mockDbWrite.appDevForgejoIdentity.updateMany.mockResolvedValue({ count: 1 });
+    mockForgejo.createForgejoUser.mockResolvedValue({
+      user: { id: 8, username: 'dev-8' },
+      password: 'pw-reclaim-1234567890abcdef',
+      created: true,
+    });
+    mockForgejo.mintForgejoUserToken.mockResolvedValue('reclaimed-token-sha1');
+    mockDbWrite.appDevForgejoIdentity.update.mockResolvedValue({});
+
+    const res = await mod.ensureForgejoIdentity(8);
+    expect(res).toEqual({ forgejoUsername: 'dev-8', token: 'reclaimed-token-sha1' });
+    // Reclaim was optimistic-concurrency guarded on the empty token + createdAt.
+    expect(mockDbWrite.appDevForgejoIdentity.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 8, forgejoTokenEncrypted: '', createdAt: staleCreatedAt },
+      })
+    );
+    // Then it provisioned + filled the token (no permanent wedge).
+    expect(mockForgejo.mintForgejoUserToken).toHaveBeenCalled();
+    expect(mockDbWrite.appDevForgejoIdentity.update).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-git-access.service.test.ts
@@ -204,12 +204,11 @@ describe('ensureForgejoIdentity — recovers from an abandoned (wedged) claim', 
 
     const res = await mod.ensureForgejoIdentity(8);
     expect(res).toEqual({ forgejoUsername: 'dev-8', token: 'reclaimed-token-sha1' });
-    // Reclaim was optimistic-concurrency guarded on the empty token + createdAt.
-    expect(mockDbWrite.appDevForgejoIdentity.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { userId: 8, forgejoTokenEncrypted: '', createdAt: staleCreatedAt },
-      })
-    );
+    // Reclaim is guarded on a RANGE (empty token + createdAt older than the
+    // stale threshold), not exact equality (timestamptz µs vs JS-Date ms).
+    const reclaimWhere = mockDbWrite.appDevForgejoIdentity.updateMany.mock.calls[0][0].where;
+    expect(reclaimWhere).toMatchObject({ userId: 8, forgejoTokenEncrypted: '' });
+    expect(reclaimWhere.createdAt.lt).toBeInstanceOf(Date);
     // Then it provisioned + filled the token (no permanent wedge).
     expect(mockForgejo.mintForgejoUserToken).toHaveBeenCalled();
     expect(mockDbWrite.appDevForgejoIdentity.update).toHaveBeenCalledTimes(1);

--- a/src/server/services/blocks/__tests__/forgejo.service.test.ts
+++ b/src/server/services/blocks/__tests__/forgejo.service.test.ts
@@ -277,3 +277,95 @@ describe('commitFiles', () => {
     ).rejects.toThrow(/Forgejo 404/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3 (git-push self-service) — per-user Forgejo identity provisioning.
+// ---------------------------------------------------------------------------
+
+describe('createForgejoUser', () => {
+  it('POSTs a restricted/private user via the admin API and returns the password (fresh create)', async () => {
+    const { createForgejoUser } = await import('../forgejo.service');
+    fm.enqueue({ id: 42, login: 'dev-7', username: 'dev-7' });
+
+    const res = await createForgejoUser({ username: 'dev-7', email: 'dev-7@apps.civitai.invalid' });
+    expect(res.created).toBe(true);
+    expect(res.user.id).toBe(42);
+    expect(typeof res.password).toBe('string');
+    expect((res.password as string).length).toBeGreaterThanOrEqual(24);
+
+    // Admin endpoint + admin token + restricted/private flags.
+    expect(fm.calls[0].url).toBe('https://forgejo.example/api/v1/admin/users');
+    expect((fm.calls[0].init?.headers as Record<string, string>)['Authorization']).toBe(
+      'token tok-test'
+    );
+    const body = JSON.parse(fm.calls[0].init!.body as string);
+    expect(body.username).toBe('dev-7');
+    expect(body.email).toBe('dev-7@apps.civitai.invalid');
+    expect(body.restricted).toBe(true);
+    expect(body.visibility).toBe('private');
+    expect(body.must_change_password).toBe(false);
+    expect(typeof body.password).toBe('string');
+  });
+
+  it('is idempotent on 422 (already exists) — falls back to getForgejoUser, returns null password', async () => {
+    const { createForgejoUser } = await import('../forgejo.service');
+    fm.enqueue({ message: 'user already exists' }, 422); // POST /admin/users
+    fm.enqueue({ id: 9, username: 'dev-7' }); // GET /users/dev-7
+
+    const res = await createForgejoUser({ username: 'dev-7', email: 'dev-7@apps.civitai.invalid' });
+    expect(res.created).toBe(false);
+    expect(res.password).toBeNull();
+    expect(res.user.id).toBe(9);
+
+    // Second call is the GET fallback.
+    expect(fm.calls[1].url).toBe('https://forgejo.example/api/v1/users/dev-7');
+  });
+});
+
+describe('getForgejoUser', () => {
+  it('GETs the user by username with admin auth', async () => {
+    const { getForgejoUser } = await import('../forgejo.service');
+    fm.enqueue({ id: 5, username: 'dev-12' });
+
+    const user = await getForgejoUser('dev-12');
+    expect(user.id).toBe(5);
+    expect(fm.calls[0].url).toBe('https://forgejo.example/api/v1/users/dev-12');
+    expect((fm.calls[0].init?.headers as Record<string, string>)['Authorization']).toBe(
+      'token tok-test'
+    );
+  });
+});
+
+describe('mintForgejoUserToken', () => {
+  it('authenticates as the user via HTTP Basic (NOT the admin token) and returns the sha1', async () => {
+    const { mintForgejoUserToken } = await import('../forgejo.service');
+    fm.enqueue({ id: 1, name: 'civitai-git-push', sha1: 'tok-sha1-abc' });
+
+    const sha1 = await mintForgejoUserToken({
+      username: 'dev-7',
+      password: 'pw-1234567890abcdef',
+      name: 'civitai-git-push',
+      scopes: ['write:repository'],
+    });
+    expect(sha1).toBe('tok-sha1-abc');
+
+    expect(fm.calls[0].url).toBe('https://forgejo.example/api/v1/users/dev-7/tokens');
+    const auth = (fm.calls[0].init?.headers as Record<string, string>)['Authorization'];
+    const expected = `Basic ${Buffer.from('dev-7:pw-1234567890abcdef').toString('base64')}`;
+    expect(auth).toBe(expected);
+    // Crucially NOT the admin token.
+    expect(auth).not.toContain('tok-test');
+
+    const body = JSON.parse(fm.calls[0].init!.body as string);
+    expect(body.name).toBe('civitai-git-push');
+    expect(body.scopes).toEqual(['write:repository']);
+  });
+
+  it('throws when Forgejo returns no sha1', async () => {
+    const { mintForgejoUserToken } = await import('../forgejo.service');
+    fm.enqueue({ id: 1, name: 'x' }); // missing sha1
+    await expect(
+      mintForgejoUserToken({ username: 'dev-7', password: 'pw', name: 'x', scopes: [] })
+    ).rejects.toThrow(/no sha1/);
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -71,6 +71,10 @@ const {
       ensurePushWebhook: vi.fn(),
       commitFiles: vi.fn(),
       listRepoTree: vi.fn(),
+      // listRepoTreeAtRef — used by reconstructBundleFromForgejo (the
+      // push-originated approve path + backfill). Resolves a commit SHA / ref
+      // directly to its blob tree (no branch→commit lookup).
+      listRepoTreeAtRef: vi.fn(),
       getBlobContent: vi.fn(),
       getRepo: vi.fn(),
       ensureReviewRepo: vi.fn(),
@@ -1100,6 +1104,123 @@ describe('approveRequest', () => {
     expect((abArg.manifest as any).iframe.src).toBe('https://hello.civit.ai/');
   });
 
+  // PUSH-ORIGINATED approve (Phase 3 git-push authoring). The git-push webhook
+  // parks an unreviewed direct push as a `pending` request with EMPTY bundle
+  // pointers (bundleKey='', bundleSha256='') + the pushed forgejoCommitSha — the
+  // ZIP was never uploaded, so the Forgejo repo at that sha IS the artifact.
+  // approveRequest must reconstruct the bundle from Forgejo (NOT GET a bundleKey
+  // from S3), then drive the identical downstream: commit, sha stamp, build
+  // trigger, deployState='building'.
+  it('PUSH path: reconstructs the bundle from Forgejo when bundleKey is empty', async () => {
+    const { approveRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+      pendingRequest({
+        bundleKey: '',
+        bundleSha256: '',
+        forgejoCommitSha: 'pushsha123',
+      })
+    );
+    // First version (no existing app block) — exercises the full create path.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    // The repo @ pushsha123 has a manifest + index.html (no Dockerfile this
+    // time, so nothing is filtered as platform-owned).
+    mockForgejo.listRepoTreeAtRef.mockResolvedValue(
+      new Map([
+        ['block.manifest.json', 'blobM'],
+        ['index.html', 'blobH'],
+      ])
+    );
+    mockForgejo.getBlobContent.mockImplementation(async (_slug: string, sha: string) => {
+      if (sha === 'blobM') return Buffer.from(JSON.stringify(manifest()));
+      return Buffer.from('<!doctype html><html><body>pushed</body></html>');
+    });
+    // mockBundleBuffer.current stays null — if the code ever fell back to the S3
+    // GET path the mock S3 GET throws ("mockBundleBuffer.current not set"),
+    // which would fail this test. That's the regression guard.
+
+    const result = await approveRequest({
+      publishRequestId: 'pubreq_1',
+      reviewerUserId: 999,
+      approvalNotes: 'reviewed the pushed code',
+    });
+
+    // Reconstructed from Forgejo at the EXACT pushed sha.
+    expect(mockForgejo.listRepoTreeAtRef).toHaveBeenCalledWith('hello', 'pushsha123');
+    // NO S3 GET on a bundleKey (the push request has none). storeScreenshots /
+    // storeBundle PUTs are fine; assert specifically no GetObjectCommand fired.
+    const gets = mockS3Send.mock.calls.filter(
+      (c) => c[0]?.constructor?.name === 'GetObjectCommand'
+    );
+    expect(gets).toHaveLength(0);
+
+    expect(result.isFirstVersion).toBe(true);
+    expect(result.forgejoCommitSha).toBe('commit_sha_abc');
+
+    // Committed the reconstructed files (manifest gets the canonical iframe.src
+    // rewrite; index.html passes through).
+    const commitArg = mockForgejo.commitFiles.mock.calls[0][0];
+    expect(commitArg.replaceAllFiles).toBe(true);
+    expect(commitArg.files.map((f: { path: string }) => f.path).sort()).toEqual([
+      'block.manifest.json',
+      'index.html',
+    ]);
+
+    // current_version_sha stamped to the new committed sha.
+    expect(mockDbWrite.appBlock.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { currentVersionSha: 'commit_sha_abc', screenshots: [] } })
+    );
+    // Build triggered with the committed sha.
+    expect(mockTriggerBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'hello', sha: 'commit_sha_abc' })
+    );
+    // Phase 2: marked 'building' after the trigger succeeds.
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { slug: 'hello', forgejoCommitSha: 'commit_sha_abc', status: 'approved' },
+        data: expect.objectContaining({ deployState: 'building' }),
+      })
+    );
+    // The publish_request is finalised approved.
+    const reqUpdate = mockDbWrite.appBlockPublishRequest.update.mock.calls.find(
+      (c: any[]) => c[0]?.where?.id === 'pubreq_1'
+    );
+    expect(reqUpdate?.[0]?.data?.status).toBe('approved');
+  });
+
+  // ZIP-path regression: a request WITH a bundleKey still GETs from S3 and never
+  // touches the Forgejo-reconstruct path.
+  it('ZIP path: still GETs the bundle from S3 (no Forgejo reconstruct) when bundleKey is set', async () => {
+    const { approveRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+      pendingRequest({ bundleKey: 'bundles/sha.zip' })
+    );
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockBundleBuffer.current = await makeValidBundle();
+
+    await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+    // S3 GET happened on the bundleKey path.
+    const gets = mockS3Send.mock.calls.filter(
+      (c) => c[0]?.constructor?.name === 'GetObjectCommand'
+    );
+    expect(gets).toHaveLength(1);
+    // Forgejo reconstruct path was NOT taken.
+    expect(mockForgejo.listRepoTreeAtRef).not.toHaveBeenCalled();
+  });
+
+  // Defensive: a malformed request with neither a bundle nor a sha throws clearly.
+  it('throws clearly when a request has neither a bundle nor a forgejo commit', async () => {
+    const { approveRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+      pendingRequest({ bundleKey: '', bundleSha256: '', forgejoCommitSha: '' })
+    );
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+
+    await expect(
+      approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 })
+    ).rejects.toThrow(/neither a bundle nor a forgejo commit/);
+  });
+
   it('A1: caps OauthClient.allowedScopes to the manifest-derived bitmask (not Full)', async () => {
     const { approveRequest } = await import('../publish-request.service');
     // models:read:self (bit 1<<2 = 4) + user:read:self (1<<0 = 1) +
@@ -1729,7 +1850,7 @@ describe('backfillPublishRequest', () => {
       app: { userId: 42 },
     });
     mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null); // not already backfilled
-    mockForgejo.listRepoTree.mockResolvedValue(
+    mockForgejo.listRepoTreeAtRef.mockResolvedValue(
       new Map([
         ['block.manifest.json', 'blob1'],
         ['index.html', 'blob2'],
@@ -1773,7 +1894,7 @@ describe('backfillPublishRequest', () => {
       appBlockId: 'apb_existing',
       bundleSizeBytes: 12345n,
     });
-    mockForgejo.listRepoTree.mockResolvedValue(new Map([['block.manifest.json', 'blob1']]));
+    mockForgejo.listRepoTreeAtRef.mockResolvedValue(new Map([['block.manifest.json', 'blob1']]));
     mockForgejo.getBlobContent.mockResolvedValue(Buffer.from(JSON.stringify(manifest())));
 
     const result = await backfillPublishRequest({
@@ -1807,10 +1928,67 @@ describe('backfillPublishRequest', () => {
       app: { userId: 42 },
     });
     mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
-    mockForgejo.listRepoTree.mockResolvedValue(new Map());
+    mockForgejo.listRepoTreeAtRef.mockResolvedValue(new Map());
 
     await expect(backfillPublishRequest({ slug: 'hello', reviewerUserId: 999 })).rejects.toThrow(
       /empty/
     );
+  });
+});
+
+// ---- reconstructBundleFromForgejo ------------------------------------------
+
+describe('reconstructBundleFromForgejo', () => {
+  it('builds a non-empty ZIP Buffer from the repo tree + blobs at the ref', async () => {
+    const { reconstructBundleFromForgejo } = await import('../publish-request.service');
+    mockForgejo.listRepoTreeAtRef.mockResolvedValue(
+      new Map([
+        ['block.manifest.json', 'blobM'],
+        ['index.html', 'blobH'],
+      ])
+    );
+    mockForgejo.getBlobContent.mockImplementation(async (_slug: string, sha: string) => {
+      if (sha === 'blobM') return Buffer.from(JSON.stringify(manifest()));
+      return Buffer.from('<!doctype html>');
+    });
+
+    const buf = await reconstructBundleFromForgejo('hello', 'pushsha123');
+
+    // Resolved the tree at the exact ref (sha), not a branch.
+    expect(mockForgejo.listRepoTreeAtRef).toHaveBeenCalledWith('hello', 'pushsha123');
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.length).toBeGreaterThan(0);
+
+    // The reconstructed ZIP round-trips to the expected file set.
+    const zip = await JSZip.loadAsync(buf);
+    expect(Object.keys(zip.files).sort()).toEqual(['block.manifest.json', 'index.html']);
+  });
+
+  it('is deterministic — identical repo state yields byte-identical bytes', async () => {
+    const { reconstructBundleFromForgejo } = await import('../publish-request.service');
+    // Tree entry order is reversed between the two runs to prove the helper
+    // sorts entries (so Forgejo ordering can't change the resulting bytes).
+    mockForgejo.getBlobContent.mockImplementation(async (_slug: string, sha: string) => {
+      if (sha === 'blobM') return Buffer.from(JSON.stringify(manifest()));
+      return Buffer.from('<!doctype html>');
+    });
+
+    mockForgejo.listRepoTreeAtRef.mockResolvedValueOnce(
+      new Map([
+        ['block.manifest.json', 'blobM'],
+        ['index.html', 'blobH'],
+      ])
+    );
+    const a = await reconstructBundleFromForgejo('hello', 'pushsha123');
+
+    mockForgejo.listRepoTreeAtRef.mockResolvedValueOnce(
+      new Map([
+        ['index.html', 'blobH'],
+        ['block.manifest.json', 'blobM'],
+      ])
+    );
+    const b = await reconstructBundleFromForgejo('hello', 'pushsha123');
+
+    expect(a.equals(b)).toBe(true);
   });
 });

--- a/src/server/services/blocks/dev-git-access.service.ts
+++ b/src/server/services/blocks/dev-git-access.service.ts
@@ -236,13 +236,33 @@ export async function ensureForgejoIdentity(userId: number): Promise<ForgejoIden
       scopes: FORGEJO_TOKEN_SCOPES,
     });
 
-    await dbWrite.appDevForgejoIdentity.update({
-      where: { userId },
+    // Fill the token ONLY while the row is still our empty claim. If we stalled
+    // >STALE_CLAIM_MS and a waiter reclaimed + filled it (against a possibly
+    // RECREATED Forgejo user), our token is dead — don't overwrite the winner's
+    // good token with it. count 0 → we were superseded: return the winner's
+    // stored token instead of persisting a dead one.
+    const filled = await dbWrite.appDevForgejoIdentity.updateMany({
+      where: { userId, forgejoTokenEncrypted: '' },
       data: { forgejoTokenEncrypted: encryptToken(token, secret) },
     });
-    return { forgejoUsername, token };
+    if (filled.count === 1) {
+      return { forgejoUsername, token };
+    }
+    const winner = await readIdentity(dbRead, userId);
+    if (winner && winner.forgejoTokenEncrypted) {
+      return {
+        forgejoUsername: winner.forgejoUsername,
+        token: decryptToken(winner.forgejoTokenEncrypted, secret),
+      };
+    }
+    throw new Error('Forgejo identity provisioning was superseded — please retry');
   } catch (err) {
-    await dbWrite.appDevForgejoIdentity.delete({ where: { userId } }).catch(() => {});
+    // Roll back ONLY a still-empty claim (ours). If a reclaimer already filled
+    // the row with a valid token, a blind delete would nuke their good row —
+    // deleteMany guarded on the empty token leaves it intact.
+    await dbWrite.appDevForgejoIdentity
+      .deleteMany({ where: { userId, forgejoTokenEncrypted: '' } })
+      .catch(() => {});
     throw err;
   }
 }

--- a/src/server/services/blocks/dev-git-access.service.ts
+++ b/src/server/services/blocks/dev-git-access.service.ts
@@ -1,0 +1,214 @@
+/**
+ * App Blocks Phase 3 (git-push self-service) — per-user Forgejo identity.
+ *
+ * The first time a developer asks for git access to one of their apps we LAZILY
+ * provision them a scoped Forgejo identity + token, persisted in
+ * `app_dev_forgejo_identity` (1:1 with the civitai userId). Subsequent requests
+ * read the stored token; we NEVER re-mint (Forgejo can't recover a user's
+ * password, so the DB row is the source of truth for the token).
+ *
+ * Isolation: the Forgejo user is `restricted:true` (no ambient access) and is
+ * granted `write` ONLY on its own civitai-apps/<slug> repo(s) by the router
+ * (addCollaborator). A push parks a pending review request and can NEVER deploy
+ * without mod approval — the no-trust-on-push gate is unchanged.
+ *
+ * The Forgejo handle is `dev-${userId}` (numeric → always a valid, unique,
+ * stable Forgejo username — the civitai username can carry invalid chars or
+ * collide, and can be changed by the user). The email is non-routable
+ * (`dev-${userId}@apps.civitai.invalid`) — Forgejo requires a unique email but
+ * we never send to it.
+ *
+ * The stored token (the user's Forgejo PAT, scope `write:repository`) is
+ * AES-256-GCM encrypted at rest keyed on NEXTAUTH_SECRET (see encryptToken).
+ *
+ * db/forgejo are dynamically imported inside the functions so this module has no
+ * load-time side effects (mirrors the sibling publish-request / scope-grant
+ * services — keeps the env-coupled Prisma/Forgejo clients out of the import
+ * graph until actually invoked).
+ */
+
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+
+// gitea-1.22 fine-grained token scope for repo write (implies read). The dev
+// only ever pushes to their own repo, so write:repository is the full ceiling.
+const FORGEJO_TOKEN_SCOPES = ['write:repository'];
+const FORGEJO_TOKEN_NAME = 'civitai-git-push';
+
+const GCM_ALGORITHM = 'aes-256-gcm';
+
+/**
+ * Derive a stable 32-byte AES key from NEXTAUTH_SECRET. NEXTAUTH_SECRET is an
+ * existing always-present server secret (also keys key-generator's secret hash
+ * + civ-token). SHA-256 normalises whatever its length is to the 32 bytes
+ * aes-256 needs.
+ */
+function deriveKey(secret: string): Buffer {
+  return createHash('sha256').update(secret).digest();
+}
+
+/**
+ * AES-256-GCM encrypt a token to a single self-describing string:
+ *   <iv-hex>:<authTag-hex>:<ciphertext-hex>
+ * GCM (over the CBC the legacy key-generator helper uses) gives us tamper
+ * detection — a corrupted/forged ciphertext fails decryptToken loudly rather
+ * than yielding a silently-wrong token.
+ */
+function encryptToken(plaintext: string, secret: string): string {
+  const key = deriveKey(secret);
+  const iv = randomBytes(12); // 96-bit nonce — the GCM-recommended size.
+  const cipher = createCipheriv(GCM_ALGORITHM, new Uint8Array(key), new Uint8Array(iv));
+  const enc = Buffer.concat([
+    new Uint8Array(cipher.update(plaintext, 'utf8')),
+    new Uint8Array(cipher.final()),
+  ]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${tag.toString('hex')}:${enc.toString('hex')}`;
+}
+
+function decryptToken(packed: string, secret: string): string {
+  const [ivHex, tagHex, dataHex] = packed.split(':');
+  if (!ivHex || !tagHex || !dataHex) {
+    throw new Error('app_dev_forgejo_identity: malformed encrypted token');
+  }
+  const key = deriveKey(secret);
+  const decipher = createDecipheriv(
+    GCM_ALGORITHM,
+    new Uint8Array(key),
+    new Uint8Array(Buffer.from(ivHex, 'hex'))
+  );
+  decipher.setAuthTag(new Uint8Array(Buffer.from(tagHex, 'hex')));
+  const dec = Buffer.concat([
+    new Uint8Array(decipher.update(new Uint8Array(Buffer.from(dataHex, 'hex')))),
+    new Uint8Array(decipher.final()),
+  ]);
+  return dec.toString('utf8');
+}
+
+/** The deterministic Forgejo handle for a civitai user. */
+export function forgejoUsernameForUser(userId: number): string {
+  return `dev-${userId}`;
+}
+
+export type ForgejoIdentity = { forgejoUsername: string; token: string };
+
+type IdentityRow = { forgejoUsername: string; forgejoTokenEncrypted: string };
+
+async function readIdentity(
+  db: { appDevForgejoIdentity: { findUnique: (a: unknown) => Promise<unknown> } },
+  userId: number
+): Promise<IdentityRow | null> {
+  return (await db.appDevForgejoIdentity.findUnique({
+    where: { userId },
+    select: { forgejoUsername: true, forgejoTokenEncrypted: true },
+  })) as IdentityRow | null;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// How long a non-owner waits for the owner to land the token before giving up.
+// Covers the owner's create-user + mint-token Forgejo round-trips (~1s) with
+// generous headroom; a timeout surfaces as a retryable error, not a wedge.
+const PROVISION_WAIT_TRIES = 25;
+const PROVISION_WAIT_MS = 200;
+
+/**
+ * Read-or-provision the caller's Forgejo identity, returning their decrypted
+ * push token. Concurrency-safe via a DB CLAIM (no advisory locks, so it's
+ * correct under transaction-pooling pgbouncer):
+ *
+ *   - HIT: a COMPLETE row (non-empty token) exists → decrypt + return, no
+ *     Forgejo calls.
+ *   - CLAIM: insert a placeholder row (empty token). The (userId) PK lets
+ *     exactly ONE concurrent caller win the insert and become the provisioning
+ *     owner; the rest get P2002 and WAIT for the owner's token to land.
+ *   - OWNER: create the restricted Forgejo user, mint a `write:repository`
+ *     token (HTTP-Basic-authed as that user), and UPDATE the claim row with the
+ *     encrypted token. On any failure, the claim row is rolled back so the next
+ *     attempt re-provisions cleanly (no wedged empty row).
+ *
+ * Edge — "Forgejo user exists but we hold a fresh claim" (a true orphan: a prior
+ * provision half-failed leaving a Forgejo user but no DB row): createForgejoUser
+ * returns `created:false`/`password:null` (the password is unrecoverable). We
+ * delete + recreate the Forgejo user to control a fresh password, then mint.
+ * This is now SAFE under concurrency because we hold the claim — no other caller
+ * can be minting against the same Forgejo user. The deleted user owns no repos
+ * (it's only ever a collaborator on platform-owned civitai-apps/<slug>), so the
+ * purge never touches app code.
+ */
+export async function ensureForgejoIdentity(userId: number): Promise<ForgejoIdentity> {
+  const { dbRead, dbWrite } = await import('~/server/db/client');
+  const { env } = await import('~/env/server');
+
+  const secret = env.NEXTAUTH_SECRET;
+  if (!secret) throw new Error('NEXTAUTH_SECRET not configured — cannot encrypt Forgejo token');
+
+  const forgejoUsername = forgejoUsernameForUser(userId);
+
+  // Fast path: a COMPLETE identity already exists (non-empty token).
+  const fast = await readIdentity(dbRead, userId);
+  if (fast && fast.forgejoTokenEncrypted) {
+    return { forgejoUsername: fast.forgejoUsername, token: decryptToken(fast.forgejoTokenEncrypted, secret) };
+  }
+
+  // Claim provisioning by inserting a placeholder (empty-token) row.
+  let owner = false;
+  try {
+    await dbWrite.appDevForgejoIdentity.create({
+      data: { userId, forgejoUsername, forgejoTokenEncrypted: '' },
+    });
+    owner = true;
+  } catch (err) {
+    if ((err as { code?: unknown })?.code !== 'P2002') throw err;
+  }
+
+  if (!owner) {
+    // Someone else owns provisioning (or a complete row appeared between the
+    // fast path and the claim). Wait a bounded time for the token to land.
+    for (let i = 0; i < PROVISION_WAIT_TRIES; i++) {
+      const row = await readIdentity(dbRead, userId);
+      if (row && row.forgejoTokenEncrypted) {
+        return { forgejoUsername: row.forgejoUsername, token: decryptToken(row.forgejoTokenEncrypted, secret) };
+      }
+      await sleep(PROVISION_WAIT_MS);
+    }
+    throw new Error('Forgejo identity provisioning is taking too long — please retry');
+  }
+
+  // We own provisioning. Create the user + mint the token + fill in the claim.
+  // Any failure rolls back the claim so a retry can re-provision cleanly.
+  try {
+    const { createForgejoUser, mintForgejoUserToken, deleteForgejoUser } = await import(
+      './forgejo.service'
+    );
+    const email = `dev-${userId}@apps.civitai.invalid`;
+    let { password, created } = await createForgejoUser({ username: forgejoUsername, email });
+    if (!created || !password) {
+      // True orphan — safe to recreate: we hold the claim, no concurrent minter.
+      await deleteForgejoUser(forgejoUsername);
+      const recreated = await createForgejoUser({ username: forgejoUsername, email });
+      if (!recreated.created || !recreated.password) {
+        throw new Error(`Forgejo user ${forgejoUsername} could not be (re)created with a known password`);
+      }
+      password = recreated.password;
+    }
+
+    const token = await mintForgejoUserToken({
+      username: forgejoUsername,
+      password: password!,
+      name: FORGEJO_TOKEN_NAME,
+      scopes: FORGEJO_TOKEN_SCOPES,
+    });
+
+    await dbWrite.appDevForgejoIdentity.update({
+      where: { userId },
+      data: { forgejoTokenEncrypted: encryptToken(token, secret) },
+    });
+    return { forgejoUsername, token };
+  } catch (err) {
+    await dbWrite.appDevForgejoIdentity.delete({ where: { userId } }).catch(() => {});
+    throw err;
+  }
+}
+
+// Exported for unit tests (encrypt/decrypt round-trip without booting Prisma).
+export const __testing = { encryptToken, decryptToken, deriveKey };

--- a/src/server/services/blocks/dev-git-access.service.ts
+++ b/src/server/services/blocks/dev-git-access.service.ts
@@ -91,7 +91,11 @@ export function forgejoUsernameForUser(userId: number): string {
 
 export type ForgejoIdentity = { forgejoUsername: string; token: string };
 
-type IdentityRow = { forgejoUsername: string; forgejoTokenEncrypted: string };
+type IdentityRow = {
+  forgejoUsername: string;
+  forgejoTokenEncrypted: string;
+  createdAt: Date;
+};
 
 async function readIdentity(
   db: { appDevForgejoIdentity: { findUnique: (a: unknown) => Promise<unknown> } },
@@ -99,7 +103,7 @@ async function readIdentity(
 ): Promise<IdentityRow | null> {
   return (await db.appDevForgejoIdentity.findUnique({
     where: { userId },
-    select: { forgejoUsername: true, forgejoTokenEncrypted: true },
+    select: { forgejoUsername: true, forgejoTokenEncrypted: true, createdAt: true },
   })) as IdentityRow | null;
 }
 
@@ -110,6 +114,12 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 // generous headroom; a timeout surfaces as a retryable error, not a wedge.
 const PROVISION_WAIT_TRIES = 25;
 const PROVISION_WAIT_MS = 200;
+
+// A placeholder (empty-token) claim row this old is treated as ABANDONED — the
+// owner died hard (pod kill) between the claim and the token write, so its
+// catch-rollback never ran. Must comfortably exceed PROVISION_WAIT (~5s) +
+// realistic provisioning latency so a slow-but-live owner is never stolen from.
+const STALE_CLAIM_MS = 60_000;
 
 /**
  * Read-or-provision the caller's Forgejo identity, returning their decrypted
@@ -163,15 +173,34 @@ export async function ensureForgejoIdentity(userId: number): Promise<ForgejoIden
 
   if (!owner) {
     // Someone else owns provisioning (or a complete row appeared between the
-    // fast path and the claim). Wait a bounded time for the token to land.
+    // fast path and the claim). Wait a bounded time for the token to land —
+    // OR, if the claim row is ABANDONED (empty token + older than the stale
+    // threshold: an owner that died mid-provision so its rollback never ran),
+    // atomically reclaim it and become the owner ourselves, so the user can
+    // never be permanently wedged behind a dead claim.
     for (let i = 0; i < PROVISION_WAIT_TRIES; i++) {
       const row = await readIdentity(dbRead, userId);
       if (row && row.forgejoTokenEncrypted) {
         return { forgejoUsername: row.forgejoUsername, token: decryptToken(row.forgejoTokenEncrypted, secret) };
       }
+      if (row && !row.forgejoTokenEncrypted && Date.now() - row.createdAt.getTime() > STALE_CLAIM_MS) {
+        // Optimistic-concurrency reclaim: only succeeds if the row is STILL the
+        // same empty, stale claim we just read (createdAt unchanged). Bumping
+        // createdAt makes us the new owner; a competing reclaimer gets count 0.
+        const reclaimed = await dbWrite.appDevForgejoIdentity.updateMany({
+          where: { userId, forgejoTokenEncrypted: '', createdAt: row.createdAt },
+          data: { createdAt: new Date() },
+        });
+        if (reclaimed.count === 1) {
+          owner = true;
+          break;
+        }
+      }
       await sleep(PROVISION_WAIT_MS);
     }
-    throw new Error('Forgejo identity provisioning is taking too long — please retry');
+    if (!owner) {
+      throw new Error('Forgejo identity provisioning is taking too long — please retry');
+    }
   }
 
   // We own provisioning. Create the user + mint the token + fill in the claim.

--- a/src/server/services/blocks/dev-git-access.service.ts
+++ b/src/server/services/blocks/dev-git-access.service.ts
@@ -184,11 +184,19 @@ export async function ensureForgejoIdentity(userId: number): Promise<ForgejoIden
         return { forgejoUsername: row.forgejoUsername, token: decryptToken(row.forgejoTokenEncrypted, secret) };
       }
       if (row && !row.forgejoTokenEncrypted && Date.now() - row.createdAt.getTime() > STALE_CLAIM_MS) {
-        // Optimistic-concurrency reclaim: only succeeds if the row is STILL the
-        // same empty, stale claim we just read (createdAt unchanged). Bumping
-        // createdAt makes us the new owner; a competing reclaimer gets count 0.
+        // Reclaim the abandoned claim. Guard on a RANGE (still empty + still
+        // older than the threshold), NOT exact createdAt equality — Postgres
+        // timestamptz(6) keeps microseconds but Prisma reads a millisecond Date,
+        // so an equality match would spuriously fail. The range + the row lock
+        // serialize concurrent reclaimers: the first updateMany bumps createdAt
+        // to now; a competing one re-evaluates the predicate post-commit (no
+        // longer < threshold) → count 0. Exactly one reclaimer wins.
         const reclaimed = await dbWrite.appDevForgejoIdentity.updateMany({
-          where: { userId, forgejoTokenEncrypted: '', createdAt: row.createdAt },
+          where: {
+            userId,
+            forgejoTokenEncrypted: '',
+            createdAt: { lt: new Date(Date.now() - STALE_CLAIM_MS) },
+          },
           data: { createdAt: new Date() },
         });
         if (reclaimed.count === 1) {

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -17,6 +17,7 @@
  * env that doesn't have direct cluster DNS. FORGEJO_BASE_URL handles both.
  */
 
+import { randomBytes } from 'crypto';
 import { env } from '~/env/server';
 
 export const FORGEJO_ORG = 'civitai-apps';
@@ -392,6 +393,131 @@ export async function commitFiles(opts: {
   });
   const result = await unwrap<{ commit: { sha: string } }>(res);
   return { sha: result.commit.sha };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 (git-push self-service) — per-user Forgejo identity provisioning.
+//
+// These functions mint a SCOPED, restricted Forgejo user + token for a civitai
+// developer so they can `git push` to their own civitai-apps/<slug> repo. The
+// admin token (createForgejoUser / getForgejoUser) creates/looks up the user;
+// the user's OWN HTTP-Basic creds (mintForgejoUserToken) mint their token —
+// Forgejo refuses to mint a user token via the admin PAT.
+//
+// Isolation: the created user is `restricted:true` + `visibility:'private'`, so
+// it has NO ambient access; write on a specific repo comes only from an explicit
+// addCollaborator call (the dev-git-access flow). A push still parks a pending
+// review request and can NEVER deploy without mod approval.
+// ---------------------------------------------------------------------------
+
+export type ForgejoUser = { id: number; username: string };
+
+/**
+ * Random Forgejo password for a provisioned dev user. 32 hex chars (16 bytes
+ * of entropy) clears Forgejo's MIN_PASSWORD_LENGTH and is used exactly once —
+ * to HTTP-Basic-auth the immediate `mintForgejoUserToken` call. It is never
+ * stored (the minted token is the persisted credential).
+ */
+function randomForgejoPassword(): string {
+  return randomBytes(16).toString('hex');
+}
+
+/**
+ * Create a restricted, private Forgejo user via the admin API.
+ *
+ * Idempotent: a 409/422 (username/email already taken) is treated as
+ * "already exists" and we return the existing user via getForgejoUser — but
+ * WITHOUT a password (you can't recover an existing user's password). The
+ * caller (ensureForgejoIdentity) only mints a token on the fresh-create path,
+ * where `password` is returned; the DB identity row is the source of truth for
+ * the token thereafter.
+ *
+ * `restricted:true` is the isolation boundary: the user sees nothing it isn't
+ * explicitly made a collaborator on.
+ */
+export async function createForgejoUser(opts: {
+  username: string;
+  email: string;
+}): Promise<{ user: ForgejoUser; password: string | null; created: boolean }> {
+  const password = randomForgejoPassword();
+  const res = await fjFetch('/api/v1/admin/users', {
+    method: 'POST',
+    body: JSON.stringify({
+      username: opts.username,
+      email: opts.email,
+      password,
+      must_change_password: false,
+      restricted: true,
+      visibility: 'private',
+    }),
+  });
+  if (res.status === 409 || res.status === 422) {
+    // Already exists — recover the row; password is unknown/unrecoverable.
+    const existing = await getForgejoUser(opts.username);
+    return { user: existing, password: null, created: false };
+  }
+  const user = await unwrap<ForgejoUser>(res);
+  return { user, password, created: true };
+}
+
+/** Look up a Forgejo user by username (admin auth). */
+export async function getForgejoUser(username: string): Promise<ForgejoUser> {
+  const res = await fjFetch(`/api/v1/users/${encodeURIComponent(username)}`);
+  return unwrap<ForgejoUser>(res);
+}
+
+/**
+ * Delete a Forgejo user via the admin API. Used only to recover the rare
+ * "Forgejo user exists but we have NO DB identity row" edge: since the password
+ * is unrecoverable we can't mint a token for the orphaned user, so we delete +
+ * recreate it cleanly. `purge:true` removes its repos/data too. 404 (already
+ * gone) is treated as success.
+ */
+export async function deleteForgejoUser(username: string): Promise<void> {
+  const res = await fjFetch(
+    `/api/v1/admin/users/${encodeURIComponent(username)}?purge=true`,
+    { method: 'DELETE' }
+  );
+  if (!res.ok && res.status !== 204 && res.status !== 404) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Forgejo deleteUser ${res.status}: ${body.slice(0, 240)}`);
+  }
+}
+
+/**
+ * Mint a fine-grained access token FOR a Forgejo user, authed as that user via
+ * HTTP Basic (username:password) — NOT the admin token. gitea/Forgejo's
+ * POST /users/{username}/tokens requires the user's own credentials; the admin
+ * PAT is rejected here.
+ *
+ * `scopes` are gitea-1.22 fine-grained scope strings; for repo write the scope
+ * is `write:repository` (which implies read). Returns the token's `sha1` — the
+ * value the developer uses in the clone URL. The token is shown ONCE by Forgejo
+ * (here); we encrypt + persist it immediately.
+ */
+export async function mintForgejoUserToken(opts: {
+  username: string;
+  password: string;
+  name: string;
+  scopes: string[];
+}): Promise<string> {
+  const basic = Buffer.from(`${opts.username}:${opts.password}`).toString('base64');
+  const url = `${getBaseUrl()}/api/v1/users/${encodeURIComponent(opts.username)}/tokens`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ name: opts.name, scopes: opts.scopes }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  const token = await unwrap<{ sha1: string }>(res);
+  if (!token?.sha1) {
+    throw new Error('Forgejo token mint returned no sha1');
+  }
+  return token.sha1;
 }
 
 /**

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -251,8 +251,26 @@ export async function listRepoTree(
     `/api/v1/repos/${org}/${slug}/branches/${encodeURIComponent(branch)}`
   );
   const branchInfo = await unwrap<{ commit: { id: string } }>(branchRes);
+  return listRepoTreeAtRef(slug, branchInfo.commit.id, org);
+}
+
+/**
+ * Recursively list every blob in the repo at an arbitrary git ref —
+ * a commit SHA (NOT just a branch name) — as Map<path, blob-sha>. Same
+ * shape as `listRepoTree`, but skips the branch→commit lookup so the
+ * caller can snapshot a specific historical commit (e.g. the sha a
+ * git-push parked on a pending review request).
+ *
+ * Forgejo's `git/trees/<ref>` resolves a commit ref to its root tree, so
+ * passing a commit SHA returns that commit's full recursive blob list.
+ */
+export async function listRepoTreeAtRef(
+  slug: string,
+  ref: string,
+  org: string = FORGEJO_ORG
+): Promise<Map<string, string>> {
   const treeRes = await fjFetch(
-    `/api/v1/repos/${org}/${slug}/git/trees/${branchInfo.commit.id}?recursive=true&per_page=1000`
+    `/api/v1/repos/${org}/${slug}/git/trees/${encodeURIComponent(ref)}?recursive=true&per_page=1000`
   );
   const tree = await unwrap<{
     tree: Array<{ path: string; type: string; sha: string }>;
@@ -260,7 +278,7 @@ export async function listRepoTree(
   }>(treeRes);
   if (tree.truncated) {
     throw new Error(
-      `Forgejo tree for ${slug}@${branch} is truncated (>1000 entries); pagination not implemented`
+      `Forgejo tree for ${slug}@${ref} is truncated (>1000 entries); pagination not implemented`
     );
   }
   const result = new Map<string, string>();

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1030,6 +1030,56 @@ async function fetchAndExtractBundleFiles(
   return extractBundleFilesFromBuffer(bundleBuffer);
 }
 
+/**
+ * Reconstruct a bundle ZIP Buffer from the live Forgejo repo at a given ref.
+ *
+ * Used by:
+ *   - `approveRequest` for a PUSH-ORIGINATED publish request (one the git-push
+ *     webhook parked with empty bundle pointers + a real forgejoCommitSha — the
+ *     ZIP was never uploaded, so the Forgejo repo at that sha IS the artifact);
+ *   - `backfillPublishRequest` to snapshot an existing live app's current HEAD.
+ *
+ * `ref` is any git ref the Forgejo tree endpoint resolves — a branch name OR a
+ * commit SHA. The push path passes the exact pushed sha so the reconstructed
+ * bytes match the reviewed commit, not a since-moved branch HEAD.
+ *
+ * The ZIP is built deterministically (`date: new Date(0)`, entries added in
+ * sorted path order) so the same repo state always produces the same bytes →
+ * a stable bundleSha256. Blobs are fetched with bounded concurrency (8 in
+ * flight) to avoid hammering Forgejo on large repos.
+ */
+export async function reconstructBundleFromForgejo(slug: string, ref: string): Promise<Buffer> {
+  const { listRepoTreeAtRef, getBlobContent } = await import('./forgejo.service');
+
+  // Snapshot the blob tree at the exact ref (commit sha or branch).
+  const tree = await listRepoTreeAtRef(slug, ref);
+  // Sort by path so the ZIP entry order — and thus the resulting bytes /
+  // bundleSha256 — is deterministic regardless of Forgejo's tree ordering.
+  const entries = Array.from(tree.entries())
+    .map(([path, blobSha]) => ({ path, blobSha }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  const CONCURRENCY = 8;
+  const files: Array<{ path: string; content: Buffer }> = [];
+  for (let i = 0; i < entries.length; i += CONCURRENCY) {
+    const batch = entries.slice(i, i + CONCURRENCY);
+    const fetched = await Promise.all(
+      batch.map(async (e) => ({
+        path: e.path,
+        content: await getBlobContent(slug, e.blobSha),
+      }))
+    );
+    files.push(...fetched);
+  }
+
+  // Build an in-memory ZIP — same shape a developer would have uploaded.
+  // `date: new Date(0)` zeroes per-entry timestamps so re-runs with identical
+  // repo state produce an identical bundleSha256 (mirrors backfill).
+  const zip = new JSZip();
+  for (const f of files) zip.file(f.path, f.content, { date: new Date(0) });
+  return Buffer.from(await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' }));
+}
+
 export type ListPendingRequestsOptions = {
   limit?: number;
   cursor?: string;
@@ -1231,6 +1281,9 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
       version: true,
       manifest: true,
       bundleKey: true,
+      // Push-originated requests (git-push webhook) carry an empty bundleKey
+      // and this real sha — approve reconstructs the bundle from Forgejo at it.
+      forgejoCommitSha: true,
       submittedByUserId: true,
       appBlockId: true,
     },
@@ -1513,12 +1566,31 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     });
   }
 
-  // (4) Fetch + extract bundle. Single MinIO GET; the per-file extract
-  // happens in-memory. Platform-owned build files (Dockerfile/nginx.conf) are
-  // dropped from the commit — the pipeline injects its own recipe + ignores
-  // tenant copies, so committing them to the build-source repo is inert +
-  // misleading (audit A8/BUILD-1 Phase 2).
-  const bundleBuffer = await fetchBundleBuffer(request.bundleKey);
+  // (4) Obtain the bundle bytes. Two origins:
+  //   - ZIP path (submitVersion): the dev uploaded a ZIP → we have a real
+  //     bundleKey → GET it from MinIO (single GET; per-file extract in-memory).
+  //   - PUSH path (git-push webhook): a direct push to civitai-apps/<slug> was
+  //     parked as a `pending` review request with EMPTY bundle pointers
+  //     (bundleKey='') and the pushed forgejoCommitSha — the ZIP was never
+  //     uploaded, so the Forgejo repo at that sha IS the artifact. Reconstruct
+  //     the bundle from the repo at the exact reviewed sha so everything
+  //     downstream (extract / platform-owned filter / manifest rewrite /
+  //     screenshots / commit / sha stamp / build trigger) is byte-identical to
+  //     the ZIP path. (See git-push.ts recordPendingFromPush.)
+  // Platform-owned build files (Dockerfile/nginx.conf) are dropped from the
+  // commit — the pipeline injects its own recipe + ignores tenant copies, so
+  // committing them to the build-source repo is inert + misleading (audit
+  // A8/BUILD-1 Phase 2).
+  let bundleBuffer: Buffer;
+  if (request.bundleKey) {
+    bundleBuffer = await fetchBundleBuffer(request.bundleKey);
+  } else if (request.forgejoCommitSha) {
+    bundleBuffer = await reconstructBundleFromForgejo(request.slug, request.forgejoCommitSha);
+  } else {
+    throw new Error(
+      `publish request ${request.id} has neither a bundle nor a forgejo commit to approve`
+    );
+  }
   const files = (await extractBundleFilesFromBuffer(bundleBuffer)).filter(
     (f) => !isPlatformOwnedPath(f.path)
   );
@@ -1752,7 +1824,7 @@ export async function backfillPublishRequest(
     import('~/server/db/client'),
     import('~/server/utils/app-block-ids'),
   ]);
-  const { getRepo, listRepoTree, getBlobContent } = await import('./forgejo.service');
+  const { getRepo } = await import('./forgejo.service');
 
   // Identify the live app row.
   const appBlock = await dbRead.appBlock.findFirst({
@@ -1770,38 +1842,23 @@ export async function backfillPublishRequest(
     throw new Error(`app_blocks row for slug=${params.slug} not found; nothing to backfill`);
   }
 
-  // Pull repo metadata to know the default branch + the current commit SHA
-  // we're snapshotting.
+  // Pull repo metadata to know the default branch we're snapshotting.
   const repo = await getRepo(params.slug);
   const defaultBranch = repo.default_branch ?? 'main';
 
-  // Recursively list blobs in the default branch, then download each blob's
-  // raw bytes in parallel (capped at 8 in flight to avoid hammering Forgejo).
-  const tree = await listRepoTree(params.slug, defaultBranch);
-  const entries = Array.from(tree.entries()).map(([path, blobSha]) => ({ path, blobSha }));
-
-  const CONCURRENCY = 8;
-  const files: Array<{ path: string; content: Buffer }> = [];
-  for (let i = 0; i < entries.length; i += CONCURRENCY) {
-    const batch = entries.slice(i, i + CONCURRENCY);
-    const fetched = await Promise.all(
-      batch.map(async (e) => ({
-        path: e.path,
-        content: await getBlobContent(params.slug, e.blobSha),
-      }))
-    );
-    files.push(...fetched);
-  }
-
-  // Build an in-memory ZIP — same shape a developer would have uploaded.
-  // Generate deterministic-ish so re-runs with identical repo state produce
-  // identical bundleSha256.
-  const zip = new JSZip();
-  for (const f of files) zip.file(f.path, f.content, { date: new Date(0) });
-  const bundleBuffer = Buffer.from(
-    await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' })
-  );
+  // Reconstruct the bundle from the live repo's default-branch HEAD — same
+  // deterministic ZIP build the push-approve path uses (sorted entries +
+  // date:new Date(0)) so re-runs with identical repo state produce an identical
+  // bundleSha256.
+  const bundleBuffer = await reconstructBundleFromForgejo(params.slug, defaultBranch);
   const bundleSha256 = createHash('sha256').update(bundleBuffer).digest('hex');
+
+  // Extract once up-front for consistent file_summary semantics AND the
+  // fileCount returned on both the idempotent + fresh paths.
+  const { files: fileMetas, manifest } = await extractBundleMetadata(bundleBuffer);
+  if (!manifest || typeof manifest !== 'object') {
+    throw new Error(`backfilled bundle for ${params.slug} has no valid block.manifest.json`);
+  }
 
   // Idempotency: if a publish_request for this exact (slug, sha) already
   // exists, return it instead of inserting a duplicate.
@@ -1815,15 +1872,9 @@ export async function backfillPublishRequest(
       appBlockId: existing.appBlockId ?? appBlock.id,
       bundleSha256,
       bundleSizeBytes: Number(existing.bundleSizeBytes),
-      fileCount: files.length,
+      fileCount: fileMetas.length,
       forgejoCommitSha: appBlock.currentVersionSha ?? '',
     };
-  }
-
-  // Reuse the submit path's extract for consistent file_summary semantics.
-  const { files: fileMetas, manifest } = await extractBundleMetadata(bundleBuffer);
-  if (!manifest || typeof manifest !== 'object') {
-    throw new Error(`backfilled bundle for ${params.slug} has no valid block.manifest.json`);
   }
 
   // Upload to MinIO. Reuses the storeBundle helper via dynamic import.
@@ -1889,7 +1940,7 @@ export async function backfillPublishRequest(
     appBlockId: appBlock.id,
     bundleSha256,
     bundleSizeBytes: bundleBuffer.length,
-    fileCount: files.length,
+    fileCount: fileMetas.length,
     forgejoCommitSha: appBlock.currentVersionSha ?? '',
   };
 }

--- a/tests/preview-apps-git-access.spec.ts
+++ b/tests/preview-apps-git-access.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+import { trpcQuery } from './preview-trpc';
+
+/**
+ * Preview-e2e (F / Phase 3 git-push self-service): App Blocks `getMyAppRepo`
+ * OWNER-GATE + endpoint wiring. Proves the SECURITY-CRITICAL property — a
+ * logged-in NON-OWNER cannot mint a push credential for someone else's app — and
+ * that the proc is reachable, WITHOUT polluting the SHARED Forgejo.
+ *
+ * Runs as the `mod` fixture (id 2000000001, ci-smoke-mod): `getMyAppRepo` is a
+ * `protectedProcedure` gated by `features.appBlocks` (the Flipt mod segment), so
+ * a non-mod tester would be UNAUTHORIZED/FORBIDDEN before the owner check even
+ * runs and the gate under test would be untestable. mod is also rate-limit-exempt
+ * and clears the flag. Crucially, the `mod` fixture is NOT the owner of the apps
+ * `listAvailable` surfaces (those are real prod-clone apps owned by other users),
+ * so calling getMyAppRepo on one exercises the NON-OWNER path → FORBIDDEN.
+ *
+ * --- THE PROVISIONING HAPPY-PATH IS INTENTIONALLY NOT E2E'd HERE -------------
+ * The OWNER happy-path (status='approved' + caller IS the owner) is deliberately
+ * NOT covered, for the same reason the publish spec defers approve→build→render
+ * and the install spec defers generate/buzz: a successful getMyAppRepo call
+ * `ensureForgejoIdentity(userId)` — it CREATES a real `dev-<userId>` user on the
+ * SHARED Forgejo instance and grants it `write` collaborator on the app repo
+ * (blocks.router.ts getMyAppRepo → dev-git-access.service + forgejo.service). That
+ * is durable, side-effecting state on shared infra with NO cheap teardown (needs
+ * Forgejo admin), so an automated preview run must never trigger it. The full
+ * provisioning path (real Forgejo user + scoped token + git push → parked review
+ * request, never auto-deploying) is verified by the UNIT suite (dev-git-access /
+ * forgejo / git-push gate tests) + a MANUAL preview check — exactly the Phase-1
+ * approve→render exclusion and the publish spec's approve exclusion.
+ *
+ * This spec therefore covers what IS safely automatable: the owner-gate (a
+ * non-owner is rejected BEFORE any Forgejo side effect — the owner check throws
+ * first) + the NOT_FOUND wiring for a bogus id. Both reject before
+ * ensureForgejoIdentity is ever reached, so neither touches Forgejo.
+ *
+ * Verified shapes (against the worktree's blocks.router.ts, paths rel. to civitai/src):
+ *  - blocks.listAvailable (publicProcedure + flag + 60/60 rateLimit; input
+ *    listAvailableSchema, `{}` valid) → `{ items: AvailableBlock[]; nextCursor? }`
+ *    (NOT a bare array). Each item's `id` is the appBlockId. Used to discover an
+ *    id the mod does NOT own (skip-if-empty, annotated). The returned apps are
+ *    `status='approved'` (the registry filters), which is also what drives
+ *    getMyAppRepo PAST the not-yet-available short-circuit and INTO the owner gate.
+ *  - blocks.getMyAppRepo (blocks.router.ts getMyAppRepo, protectedProcedure +
+ *    enforceAppBlocksFlag; input { appBlockId: string (1..64) }):
+ *      • caller is NOT the app owner → throws TRPCError FORBIDDEN ('Not the app
+ *        owner'). The owner check (block.app.userId !== ctx.user.id) runs BEFORE
+ *        ensureForgejoIdentity, so NO Forgejo user/collaborator is created.
+ *      • unknown appBlockId → throws NOT_FOUND ('App block not found') via
+ *        throwNotFoundError, before any owner/Forgejo logic.
+ *      • (owner + approved → { notYetAvailable:false, cloneUrl, httpUrl,
+ *        forgejoUsername, instructions, firstVersionIsZip:false } — NOT asserted
+ *        here; see the exclusion note above.)
+ */
+
+const ROLE = 'mod' as const;
+
+type AvailableBlock = { id: string };
+type ListAvailableResult = { items: AvailableBlock[]; nextCursor?: string };
+
+// The tRPC v11 (superjson) error envelope for a batched GET:
+//   [{ error: { json: { message, code (numeric), data: { code: string,
+//      httpStatus } } } }]
+// We read the human-readable `data.code` ('FORBIDDEN' / 'NOT_FOUND').
+type TrpcErrorEnvelope = {
+  error?: { json?: { message?: string; data?: { code?: string; httpStatus?: number } } };
+};
+
+/**
+ * Raw batched-GET call to a tRPC query that we EXPECT to error, returning the
+ * parsed error code + message. The shared `trpcQuery` helper throws on a tRPC
+ * error (good for happy-path), but to assert the ERROR CODE deterministically we
+ * inspect the envelope ourselves. Mirrors preview-trpc's batched wire format +
+ * CSRF (Origin/Referer) stamping.
+ */
+async function trpcQueryExpectError(
+  request: APIRequestContext,
+  proc: string,
+  input: unknown,
+  previewUrl: string
+): Promise<{ code: string | undefined; message: string | undefined; httpStatus: number }> {
+  const enc = encodeURIComponent(JSON.stringify({ '0': { json: input } }));
+  const res = await request.get(`/api/trpc/${proc}?batch=1&input=${enc}`, {
+    headers: { origin: previewUrl, referer: `${previewUrl}/` },
+  });
+  const body = (await res.json().catch(() => ({}))) as unknown;
+  const entry = (Array.isArray(body) ? body[0] : body) as TrpcErrorEnvelope;
+  return {
+    code: entry?.error?.json?.data?.code,
+    message: entry?.error?.json?.message,
+    httpStatus: res.status(),
+  };
+}
+
+test.describe('App Blocks getMyAppRepo owner-gate + wiring (mod, no Forgejo side effects)', () => {
+  test.use({ storageState: storageStatePath(ROLE) });
+
+  test('non-owner → FORBIDDEN; unknown id → NOT_FOUND (no credential minted)', async ({
+    page,
+  }) => {
+    const previewUrl = process.env.PREVIEW_URL ?? '';
+
+    // Warm the request context against the preview origin so page.request shares
+    // the mod auth cookie + a navigated origin (the CSRF gate needs Origin/Referer
+    // host allowlisted; NEXTAUTH_URL == the preview URL). domcontentloaded ONLY —
+    // never networkidle.
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const request = page.request;
+
+    // DISCOVER an approved appBlockId the mod does NOT own (never hardcode — the
+    // weekly prod clone's approved set varies, and could be empty → skip).
+    const listing = await trpcQuery<ListAvailableResult>(request, 'blocks.listAvailable', {});
+    const blocks = listing?.items ?? [];
+    test.skip(
+      blocks.length === 0,
+      'No approved app blocks in this dev-DB clone — nothing to probe the owner-gate against (the weekly prod clone can have zero). Skipping rather than hard-failing.'
+    );
+    const appBlockId = blocks[0].id;
+    expect(typeof appBlockId, 'discovered appBlockId should be a string').toBe('string');
+
+    // OWNER-GATE: the mod fixture is NOT the owner of this prod-clone app, so
+    // getMyAppRepo must reject with FORBIDDEN. This is the security-critical
+    // assertion: a logged-in non-owner is denied a push credential. The owner
+    // check throws BEFORE ensureForgejoIdentity, so this creates NO Forgejo user
+    // and grants NO collaborator — safe to run automated against shared infra.
+    const forbidden = await trpcQueryExpectError(
+      request,
+      'blocks.getMyAppRepo',
+      { appBlockId },
+      previewUrl
+    );
+    expect(
+      forbidden.code,
+      `getMyAppRepo on an app the mod does not own should be FORBIDDEN (was: ${forbidden.code} / "${forbidden.message}")`
+    ).toBe('FORBIDDEN');
+
+    // WIRING: an unknown appBlockId resolves to no AppBlock row → NOT_FOUND,
+    // thrown before any owner/Forgejo logic. A non-existent-but-charset-valid id.
+    const bogusId = `ci-smoke-nope-${Date.now()}`.slice(0, 64);
+    const notFound = await trpcQueryExpectError(
+      request,
+      'blocks.getMyAppRepo',
+      { appBlockId: bogusId },
+      previewUrl
+    );
+    expect(
+      notFound.code,
+      `getMyAppRepo on a non-existent appBlockId should be NOT_FOUND (was: ${notFound.code} / "${notFound.message}")`
+    ).toBe('NOT_FOUND');
+  });
+});


### PR DESCRIPTION
## What

**Phase 3** of the App Blocks DX arc: developers can author new versions of their app by **`git push`** instead of re-uploading a ZIP, and the platform provisions each developer a scoped Forgejo identity self-service. A push lands in the moderator review queue — it **never auto-deploys** (the no-trust-on-push gate is unchanged).

## How (3 commits)

1. **`427b9bb22` — approve push-originated requests from Forgejo (the load-bearing fix).** A git push parks a pending request with *empty* bundle pointers; `approveRequest` used to crash on `fetchBundleBuffer('')`. It's now source-agnostic: `bundleKey` → MinIO ZIP; else reconstruct the bundle from the Forgejo repo at the pushed sha (`reconstructBundleFromForgejo`, reusing the backfill path). Everything downstream unchanged.
2. **`a44e43f70` — per-developer Forgejo identity + `getMyAppRepo`.** New `app_dev_forgejo_identity` table (AES-256-GCM-encrypted PAT, keyed on `NEXTAUTH_SECRET`). New Forgejo APIs (create restricted user, mint a `write:repository` token via HTTP-Basic-as-the-user, idempotent). `ensureForgejoIdentity` is **concurrency-safe via a DB claim** (pooler-safe, non-destructive — fixes a race in the first cut where two concurrent provisions could persist a dead token). `blocks.getMyAppRepo` (owner-gated) provisions on demand + `addCollaborator(write)` + returns the authed clone URL.
3. **`126b22d6f` — "Author via git" UI + e2e.** Mount-on-expand panel on `/apps/my-submissions` (never fetches the token on page load — provisioning is a side effect), credential **masked-by-default** with reveal toggle. Preview e2e asserts the live **owner-gate** (non-owner → FORBIDDEN before any Forgejo state is created).

**Isolation:** the dev's Forgejo user is `restricted` + granted `write` on **only their own** `civitai-apps/<slug>` repo(s). A push parks a pending review request and **cannot deploy** without mod approval.

**Model:** first version is ZIP-only (the repo doesn't exist until first approve); subsequent versions via git push.

## ⚠️ Migration — manual apply required

`prisma/migrations/20260616120000_app_dev_forgejo_identity/` adds the table (additive). Apply to **prod cnpg-nvme0** + the **dev clone** (civitai uses no `prisma migrate deploy`).

## Operational note (verified)

Self-service provisioning needs `FORGEJO_ADMIN_TOKEN` to `POST /api/v1/admin/users` — **preflighted ✅** (`civitai-admin` is_admin=True, `admin/users → HTTP 200`, Forgejo 15.0.3).

## Tests
- Unit: approve-from-Forgejo (push path + ZIP regression + determinism), Forgejo user/token APIs, the claim-first provisioning (owner-wait + rollback + orphan edge), owner gate, the clone-URL masker. **Blocks suite 366/366 green** (node-only project).
- e2e: `preview-apps-git-access.spec.ts` (owner-gate live, no shared-Forgejo side effects), discovered under `preview-smoke`.
- The full push→park→approve→render loop creates shared-Forgejo state with no safe teardown → unit-covered + a **manual** preview check (mirrors Phase 1's approve→render exclusion).

## Follow-ups (noted)
Banned-user token revocation; push-rate debounce; SSH deploy keys; screenshot capture on push-originated approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)