### PR TITLE
fix(orchestrator): 400 not 500 for generation-graph input validation errors

### DIFF
--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -496,7 +496,7 @@ function validateInput(input: Record<string, unknown>, externalCtx: GenerationCt
     const errorMessages = Object.entries(result.errors)
       .map(([key, error]) => `${key}: ${error.message}`)
       .join(', ');
-    throw new Error(`Validation failed: ${errorMessages}`);
+    throw throwBadRequestError(`Validation failed: ${errorMessages}`);
   }
 
   const computedKeys = new Set<string>();
@@ -518,7 +518,7 @@ function createVideoInterpolationInput(
   data: Extract<GenerationGraphOutput, { workflow: 'vid2vid:interpolate' }>
 ): StepInput {
   if (!data.video?.url) {
-    throw new Error('Video URL is required for video interpolation');
+    throw throwBadRequestError('Video URL is required for video interpolation');
   }
 
   return {
@@ -539,7 +539,7 @@ function createVideoUpscaleInput(
   const { video, scaleFactor } = data;
 
   if (!video?.url) {
-    throw new Error('Video URL is required for video upscaling');
+    throw throwBadRequestError('Video URL is required for video upscaling');
   }
 
   return {
@@ -574,7 +574,7 @@ async function createImageUpscaleSteps(
 
     const image = images[i];
     if (!image?.url) {
-      throw new Error(`Invalid image data at index ${i}`);
+      throw throwBadRequestError(`Invalid image data at index ${i}`);
     }
 
     steps.push(
@@ -595,7 +595,7 @@ async function createImageUpscaleSteps(
   }
 
   if (steps.length === 0) {
-    throw new Error('No images can be upscaled with the selected settings');
+    throw throwBadRequestError('No images can be upscaled with the selected settings');
   }
 
   return Promise.all(steps);
@@ -610,7 +610,7 @@ async function createImageRemoveBackgroundInput(
 ): Promise<StepInput> {
   const sourceImage = data.images?.[0];
   if (!sourceImage?.url) {
-    throw new Error('Image URL is required for background removal');
+    throw throwBadRequestError('Image URL is required for background removal');
   }
 
   const step = await createComfyInput({
@@ -640,7 +640,7 @@ async function createImagePreprocessInput(
 ): Promise<StepInput> {
   const sourceImage = data.images?.[0];
   if (!sourceImage?.url) {
-    throw new Error('Image URL is required for preprocess');
+    throw throwBadRequestError('Image URL is required for preprocess');
   }
 
   const input = removeEmpty({
@@ -725,7 +725,7 @@ async function createStepInputs(
     default: {
       // Ecosystem workflows - ecosystem must be defined
       if (!('ecosystem' in data) || !data.ecosystem) {
-        throw new Error('ecosystem is required for ecosystem workflows');
+        throw throwBadRequestError('ecosystem is required for ecosystem workflows');
       }
       rawResult = await createEcosystemStepInput(data as EcosystemGraphOutput, handlerCtx);
       break;


### PR DESCRIPTION
## Problem

While driving the dp-prod 500 floor toward zero, the single largest app-side 500 producer is **`orchestrator.whatIfFromGraph`** — ~**279 500s / 30m (54% of all API 500s)**, all **fast (~11ms)** and all deterministic. They are not server faults: they are **client input-validation errors** mis-coded as 500.

Root cause: the generation-graph builder (`orchestration-new.service.ts`) threw a plain `Error` for client-input validation failures. tRPC has no code on a plain `Error`, so it defaults to `INTERNAL_SERVER_ERROR` → **HTTP 500**. Meanwhile the *sibling* checks in the same endpoint already throw `throwBadRequestError` and correctly return 400 (487 proper 400s / 30m observed).

Evidence (Traefik logs, dp-prod, 30m window):
- `whatIfFromGraph`: **400=487, 500=279** — the 500s are exclusively the `validateInput` `Error("Validation failed: ...")` path (Zod `.max()` "exceeded the maximum number of allowed resources", etc.). 100% solo (non-batched) requests, so genuine HTTP 500s, not a tRPC-batch attribution artifact.
- `generateFromGraph` shares the same `validateInput` and was equally affected.

## Fix

Switch the 8 **client-input** validation throws to `throwBadRequestError` (already imported and used for the adjacent checks in this file → HTTP 400):

- `validateInput` Zod parse failure (`Validation failed: …`) — feeds both `whatIfFromGraph` and `generateFromGraph`
- video interpolation / upscale: "Video URL is required …"
- img2img upscale: "Invalid image data at index N" / "No images can be upscaled …"
- background-removal / preprocess: "Image URL is required …"
- ecosystem workflows: "ecosystem is required …"

Left `AIR not found for resource ID …` (~line 174) as-is — that's an internal data-integrity error, not client input.

## Risk

Low. `TRPCError` is still an `Error` subclass, so every `catch` still works; control flow is unchanged (a `throw` still terminates the branch). The client already receives + displays 400s from this endpoint's sibling checks today, so there's no new client behavior. Net effect: these expected client errors stop polluting the 500 SLO, and 500 becomes a true server-fault signal.

## Verification

- Diagnosed live on dp-prod via Traefik access logs + api-primary error logs (per-message counts + duration distribution).
- Not typechecked locally (worktree has no `node_modules`); the change mirrors three already-compiling `throw throwBadRequestError(...)` lines in the same file. Tekton/preview pipeline gates the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)