### PR TITLE
feat(perf): serve per-route First Load JS as JSON (main bundle baseline)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,12 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # (no warm .next/cache) peaks higher than an incremental one and OOMs at 6 GB on
 # newer commits. Build-arg so a builder with more memory can raise it further.
 ARG NODE_BUILD_MEM=8192
+# Commit SHA of the source being built. Passed by the Tekton build (the shared
+# buildkit script forwards COMMIT_SHA → this build-arg); read by
+# scripts/bundle-budget.mjs --json so the served snapshot is commit-attributable.
+# Defaults empty (commit:null) when built outside CI.
+ARG SOURCE_COMMIT=""
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
 RUN --mount=type=cache,target=/app/.next/cache \
     SKIP_ENV_VALIDATION=1 IS_BUILD=true NODE_OPTIONS="--max_old_space_size=${NODE_BUILD_MEM}" pnpm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,12 @@ RUN --mount=type=cache,target=/app/.next/cache \
 # The report is also written to /app/bundle-budget.txt and COPYied into the
 # runner image so the Tekton bundle-comment task can surface it on the PR
 # (kubectl exec ... cat) without a duplicate build.
+# `--json` additionally writes /app/bundle-budget.json (machine-readable per-route
+# First Load JS) — served at /api/internal/bundle-budget for the perf-trend
+# baseline job + the future PR bundle-regression gate.
 # Invoke node directly (not `pnpm run size`) so pnpm's lifecycle preamble
 # (`> model-share@… size /app`) stays out of the report/comment.
-RUN node scripts/bundle-budget.mjs > /app/bundle-budget.txt 2>&1 || true; cat /app/bundle-budget.txt
+RUN node scripts/bundle-budget.mjs --json > /app/bundle-budget.txt 2>&1 || true; cat /app/bundle-budget.txt
 
 # Server source maps (.next/server/**/*.js.map) are emitted by the build
 # (productionBrowserSourceMaps -> turbopackSourceMaps) but @vercel/nft does NOT
@@ -112,6 +115,9 @@ COPY --from=builder /app/package.json ./package.json
 # Bundle-budget report (report-only) — surfaced on the PR by the Tekton
 # bundle-comment task via `kubectl exec ... cat /app/bundle-budget.txt`.
 COPY --from=builder /app/bundle-budget.txt ./bundle-budget.txt
+# Machine-readable per-route First Load JS — served at /api/internal/bundle-budget
+# (main is read by the perf-trend baseline job + the future PR regression gate).
+COPY --from=builder /app/bundle-budget.json ./bundle-budget.json
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -19,7 +19,7 @@
  * Budgets live in `.bundle-budget.json`:
  *   { "shared": "350 kB", "routeMax": "1.5 MB", "routes": { "/x": "2 MB" } }
  */
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { brotliCompressSync, constants as zc } from 'node:zlib';
 import { join } from 'node:path';
 
@@ -27,6 +27,11 @@ const NEXT_DIR = process.env.NEXT_DIR || '.next';
 const MANIFEST = join(NEXT_DIR, 'build-manifest.json');
 const BUDGET_FILE = process.env.BUNDLE_BUDGET_FILE || '.bundle-budget.json';
 const GATE = process.argv.includes('--gate');
+// `--json` also writes a machine-readable per-route snapshot (bytes, brotli),
+// consumed by the perf-trend baseline job + the future PR bundle-regression
+// gate. Report-only; independent of --gate.
+const JSON_OUT = process.argv.includes('--json');
+const JSON_FILE = process.env.BUNDLE_JSON_FILE || 'bundle-budget.json';
 const TOP = Number(process.env.BUNDLE_TOP || 20);
 
 const isJs = (f) => typeof f === 'string' && f.endsWith('.js');
@@ -91,6 +96,26 @@ const routes = Object.keys(pages)
 // Coarse total = brotli of every referenced client .js (deduped via cache).
 const allFiles = uniq(Object.values(pages).flat().filter(isJs).concat(sharedFiles));
 const totalSize = sumBr(allFiles);
+
+// ---- machine-readable snapshot (for the perf-trend baseline + future gate) ----
+if (JSON_OUT) {
+  const snapshot = {
+    // Build provenance — best-effort from common CI env vars; null if absent.
+    commit:
+      process.env.BUILD_SHA ||
+      process.env.SOURCE_COMMIT ||
+      process.env.GIT_SHA ||
+      process.env.GITHUB_SHA ||
+      null,
+    builtAt: new Date().toISOString(),
+    unit: 'bytes-brotli',
+    shared: sharedSize,
+    total: totalSize,
+    routes: Object.fromEntries(routes.map((r) => [r.route, r.size])),
+  };
+  writeFileSync(JSON_FILE, JSON.stringify(snapshot, null, 2));
+  console.log(`bundle-budget: wrote ${JSON_FILE} (${routes.length} routes)`);
+}
 
 // ---- report ----
 const breaches = [];

--- a/src/pages/api/internal/bundle-budget.ts
+++ b/src/pages/api/internal/bundle-budget.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+// Serves this build's per-route First Load JS (brotli, bytes), written by
+// `scripts/bundle-budget.mjs --json` during the Docker build and shipped to
+// /app/bundle-budget.json. Consumers:
+//   - the perf-trend baseline job — records main's numbers over time (Grafana),
+//   - the future PR bundle-regression gate — diffs a PR build vs main.
+// On main this is reachable at https://next.civitai.com/api/internal/bundle-budget?token=<WEBHOOK_TOKEN>.
+// Token-gated via WebhookEndpoint (the same WEBHOOK_TOKEN as the other internal endpoints).
+const BUNDLE_BUDGET_PATH = join(process.cwd(), 'bundle-budget.json');
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  if (!existsSync(BUNDLE_BUDGET_PATH)) {
+    // Older images (built before the --json change) won't have the file.
+    return res.status(404).json({ error: 'bundle-budget.json not present in this build' });
+  }
+  try {
+    const snapshot = JSON.parse(readFileSync(BUNDLE_BUDGET_PATH, 'utf8'));
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    return res.status(200).json(snapshot);
+  } catch {
+    return res.status(500).json({ error: 'failed to read bundle-budget.json' });
+  }
+});


### PR DESCRIPTION
## What

Adds a machine-readable bundle-size endpoint so we can build a **bundle-size trend over time** and (later) a **PR bundle-regression gate** — turning the existing report-only `<!-- bundle-budget-bot -->` signal into something actionable.

- `scripts/bundle-budget.mjs` — new `--json` flag writes `bundle-budget.json` (per-route brotli First Load JS in bytes + shared/total + commit/builtAt) alongside the existing human text report. No change to the default/text path or `--gate`.
- `Dockerfile` — builder runs `bundle-budget.mjs --json`; `bundle-budget.json` is COPYed into the runner image next to `bundle-budget.txt`.
- `src/pages/api/internal/bundle-budget.ts` — token-gated (`WebhookEndpoint`) route that serves the file. On main: `https://next.civitai.com/api/internal/bundle-budget?token=<WEBHOOK_TOKEN>`.

## Why

`main`'s bundle numbers are currently only visible per-PR (report-only, absolute, pull-based). This serves them as the canonical baseline that:
- a daily **perf-trend** job will record into Grafana (catch slow creep no single PR trips), and
- a future **PR regression gate** will diff a PR build against (deterministic, ~0 FP).

Report-only; no behavior change. Built once, used twice.

## Test

After deploy to `next.civitai.com`: `curl -s 'https://next.civitai.com/api/internal/bundle-budget?token=<WEBHOOK_TOKEN>' | jq` → per-route bytes + commit. Older images (pre-`--json`) return 404 gracefully.
