### PR TITLE
fix(preview): exempt preview env from tRPC rate limits (fixes #2592)

### DIFF
--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from '@trpc/server';
-import { isDev, isProd, isTest } from '~/env/other';
+import { isDev, isPreview, isProd, isTest } from '~/env/other';
 import { purgeCache } from '~/server/cloudflare/client';
 import { CacheTTL } from '~/server/common/constants';
 import { logToAxiom } from '~/server/logging/client';
@@ -128,8 +128,11 @@ export function rateLimit<TInput = any>(
   if (!Array.isArray(rateLimits)) rateLimits = [rateLimits];
 
   return middleware(async ({ ctx, input, next, path }) => {
-    // Skip if user is a moderator
-    if (ctx.user?.isModerator || isDev || isTest) return await next();
+    // Skip if user is a moderator, or in a non-prod env (dev/test/preview).
+    // Preview runs on the shared dev DB with a small set of CI smoke accounts, so
+    // per-account daily quotas (e.g. the new-post limit) get exhausted across many
+    // PR runs and the smoke suite fails deterministically — see civitai#2592.
+    if (ctx.user?.isModerator || isDev || isTest || isPreview) return await next();
 
     // Skip rate limiting if condition is provided and not met
     if (condition && !condition(input as TInput)) {


### PR DESCRIPTION
## Problem

Five `preview-smoke` mutation-flow specs fail **deterministically** with HTTP 429 because the shared CI smoke `tester` account exhausts the **daily new-post rate limit** across the many PR preview runs per day:

```
HTTP 429 TOO_MANY_REQUESTS: "You've reached your daily limit for new posts. Please try again tomorrow."
```

Affected: `preview-collections`, `preview-engagement`, `preview-post-images`, `preview-post-upload`, `preview-report` (each self-seeds a post via `post.create` / `post.createWithImages`). `smoke-test` is report-only/non-blocking, so this doesn't block merges — but it makes that smoke coverage effectively dark and the `pr-smoke-bot` posts a red comment on every PR, training reviewers to ignore it.

See #2592 for full evidence (same 5 specs fail on two independent preview runs → deterministic, not flaky).

## Fix

Add `isPreview` to the existing non-prod rate-limit exemption in `rateLimit()` (`src/server/middleware.trpc.ts`), mirroring the current `isDev`/`isTest` bypass:

```ts
if (ctx.user?.isModerator || isDev || isTest || isPreview) return await next();
```

This is issue option 3. Chosen over making the tester a moderator (option 1) because it:
- mirrors the existing dev/test exemption pattern exactly (one line + import),
- removes shared-quota coupling for **every** preview mutation flow, not just posts,
- requires no per-account allowlist to maintain.

## Safety

`isPreview` is `process.env.IS_PREVIEW === 'true'` — only true in the ephemeral PR-preview deployments, which run on the shared dev DB and are gated behind the Flipt `preview-site-access` flag. It is never set in production, so prod rate limiting is unchanged.

Fixes #2592

🤖 Generated with [Claude Code](https://claude.com/claude-code)