### PR TITLE
App Blocks launch click-path verification (throwaway preview)

### DIFF
--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -145,6 +145,13 @@ export const APP_BLOCKS_RUNTIME_FLAG = 'app-blocks-runtime-enabled';
  * need to flip the flag without standing up Flipt.
  */
 export async function isAppBlocksEnabled(opts?: { user?: SessionUser }): Promise<boolean> {
+  // THROWAWAY launch-verify branch ONLY — env-gated simulation of the post-flip
+  // state (Flipt app-blocks-enabled widened mod→public) so the anon/non-mod
+  // public marketplace surfaces (listAvailable/getAppDetail/getFeaturedBlocks)
+  // light up for the click-path verification. Flipt is shared prod↔preview so it
+  // can't be flipped preview-only. Set APP_BLOCKS_FORCE_ON=true on the preview
+  // pod. DO NOT MERGE.
+  if (process.env.APP_BLOCKS_FORCE_ON === 'true') return true;
   // No user supplied → preserve the original global eval for the machine /
   // anonymous gates (webhooks, JWKS). Their callers are unchanged.
   if (!opts?.user) {

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -222,7 +222,7 @@ const featureFlags = createFeatureFlags({
   // App Blocks (Phase 1) — gates the BlockSlot mount on model pages. Off by
   // default until we ship publisher install UX + moderator approval workflow.
   // When off, BlockSlot renders nothing and no token-issuance traffic fires.
-  appBlocks: { availability: ['mod'], fliptKey: 'app-blocks-enabled' },
+  appBlocks: { availability: ['public'] }, // THROWAWAY launch-verify branch ONLY — public + Flipt-override dropped to exercise the post-flip public marketplace UX. DO NOT MERGE.
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];


### PR DESCRIPTION
Throwaway preview to Playwright the **public** marketplace click-paths before the launch flip. Relaxes the `appBlocks` gate to public on this branch only (Flipt is shared prod↔preview, so it can't be flipped preview-only). Dev DB. **DO NOT MERGE — tear down after verification.** 🤖