### PR TITLE
fix(api): return 404 (not 500) for nonexistent-username lookups

### DIFF
--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -227,7 +227,7 @@ export const getArticles = async ({
         (await dbRead.user.findUnique(userFindArgs)) ??
         (await dbWrite.user.findUnique(userFindArgs));
 
-      if (!targetUser) throw new Error('User not found');
+      if (!targetUser) throw throwNotFoundError('User not found');
 
       AND.push(Prisma.sql`u.id = ${targetUser.id}`);
     }

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1295,7 +1295,7 @@ export const getAllImages = async (
   }
 
   if (username && !targetUserId) {
-    if (!prefetchedTargetUser) throw new Error('User not found');
+    if (!prefetchedTargetUser) throw throwNotFoundError('User not found');
     targetUserId = prefetchedTargetUser.id;
   }
 
@@ -2920,7 +2920,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     const targetUser =
       (await dbRead.user.findUnique({ where: { username }, select: { id: true } })) ??
       (await dbWrite.user.findUnique({ where: { username }, select: { id: true } }));
-    if (!targetUser) throw new Error('User not found');
+    if (!targetUser) throw throwNotFoundError('User not found');
     userId = targetUser.id;
 
     logToAxiom(
@@ -3774,7 +3774,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     const targetUser =
       (await dbRead.user.findUnique({ where: { username }, select: { id: true } })) ??
       (await dbWrite.user.findUnique({ where: { username }, select: { id: true } }));
-    if (!targetUser) throw new Error('User not found');
+    if (!targetUser) throw throwNotFoundError('User not found');
     userId = targetUser.id;
 
     logToAxiom(

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -468,7 +468,7 @@ export const getModelsRaw = async ({
     const targetUser =
       (await dbRead.user.findUnique(userFindArgs)) ?? (await dbWrite.user.findUnique(userFindArgs));
 
-    if (!targetUser) throw new Error('User not found');
+    if (!targetUser) throw throwNotFoundError('User not found');
 
     AND.push(Prisma.sql`mm."userId" = ${targetUser.id}`);
   }

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -127,7 +127,7 @@ export const getResourceReviewsInfinite = async ({
       (await dbRead.user.findUnique(userFindArgs)) ??
       (await dbWrite.user.findUnique(userFindArgs));
 
-    if (!targetUser) throw new Error('User not found');
+    if (!targetUser) throw throwNotFoundError('User not found');
 
     AND.push({
       userId: {

--- a/src/server/services/user-profile.service.ts
+++ b/src/server/services/user-profile.service.ts
@@ -14,6 +14,7 @@ import { isDefined } from '~/utils/type-guards';
 import { enqueueImageIngestion } from '~/server/services/image.service';
 import type { UserMeta } from '~/server/schema/user.schema';
 import { getUserBanDetails } from '~/utils/user-helpers';
+import { throwNotFoundError } from '~/server/utils/errorHandling';
 import {
   getUserContentOverview as getUserContentOverviewFromCache,
   getUserContentOverviewPublic as getUserContentOverviewPublicFromCache,
@@ -45,7 +46,7 @@ export const getUserContentOverview = async ({
     });
 
     if (!user) {
-      throw new Error('User not found');
+      throw throwNotFoundError('User not found');
     }
 
     userId = user.id;


### PR DESCRIPTION
## Problem

Several service functions throw a **plain** `throw new Error('User not found')` when a **client-supplied** `username`/`user` filter matches no user. Plain `Error`s have no TRPCError `code`, so they surface as **HTTP 500** instead of the correct **404 NOT_FOUND**. A nonexistent / deleted / banned / typo'd username is a client error, not a server fault.

## Mechanism

- **REST `/api/v1/*`** via `handleEndpointError` (`src/server/utils/endpoint-helpers.ts`): the `else` (non-TRPCError) branch returns `res.status(500)`. A `TRPCError{code:'NOT_FOUND'}` instead takes the `if (e instanceof TRPCError)` branch → `getHTTPStatusCodeFromError` → **404**.
- **tRPC** (e.g. `userProfile.overview` → `getUserContentOverviewHandler` in `src/server/controllers/user-profile.controller.ts`): catches with `if (error instanceof TRPCError) throw error; throw throwDbError(error)`. A plain `Error` → `throwDbError` → `INTERNAL_SERVER_ERROR` → **500**; a `NOT_FOUND` TRPCError passes the `instanceof` guard straight through → **404**.

Fix: convert the plain throws to `throw throwNotFoundError('User not found')` (TRPCError `NOT_FOUND`, from `~/server/utils/errorHandling`) at the sites reachable from a client-supplied user/username lookup.

## Evidence (dp-prod, 30-min windows ~2026-06-16 19:14Z)

This single bug was **~60% of the entire API 500 floor** (~0.57/s total):

| Path | Service fn | 500s / 30m |
|---|---|---|
| `GET /api/v1/models?username=<X>` | `getModelsRaw` | **417** (all fast, p50 13ms, 100% carry `username=`) |
| `GET /api/v1/images?username=<X>` | `getAllImages` | **150** |
| `userProfile.overview` (tRPC) | `getUserContentOverview` | **40** |
| — | `handleEndpointError "User not found"` log | ~414/30m (≈ all REST error volume) |

## Sites changed

- `src/server/services/model.service.ts` — `getModelsRaw` (`username`/`user` filter) → REST `/api/v1/models`
- `src/server/services/image.service.ts` — `getAllImages`; `getImagesFromSearchPreFilter`; `getImagesFromSearchPostFilter` (all `username` filters; the latter two reached via `getAllImages`'s `searchFn`) → REST `/api/v1/images`
- `src/server/services/user-profile.service.ts` — `getUserContentOverview` (added the `throwNotFoundError` import) → tRPC `userProfile.overview`
- `src/server/services/resourceReview.service.ts` — `getResourceReviewsInfinite` (`username` filter) → tRPC `resourceReview.getInfinite` (public query)
- `src/server/services/article.service.ts` — `getArticles` (`username` filter) → tRPC `article.getInfinite` (public query)

## Sites deliberately left as plain `Error` (→ 500)

- `user-profile.service.ts` — `'Either username or id must be provided'`: a **caller invariant** (programming error), unreachable for the overview path. Correct as 500.
- `subscriptions.service.ts:403` — `syncFreshdeskMembership` `'User not found'`: looks up by `userId`/`customerId` from **internal callers only** (admin endpoint, internal cron, Stripe/Paddle webhooks, redeemableCode) — not a client-supplied username filter; most callers `.catch()` it. Not on the hot REST/tRPC NOT_FOUND path. Left as-is.

## Risk assessment

- `TRPCError` **is** an `Error` subclass, so the `throw throwNotFoundError(...)` keeps the leading `throw` keyword → control-flow narrowing is unchanged vs `throw new Error()`. Mirrors the existing compiling `throwNotFoundError(...)` usages already in `model.service.ts`/`image.service.ts`.
- Verified every caller of the edited functions either reaches `handleEndpointError` (REST → 404 via `getHTTPStatusCodeFromError`) or a tRPC procedure/controller that **passes TRPCError through** unchanged; none pattern-match on `e instanceof Error` or parse `e.message` in a way a TRPCError breaks.
- Clients already handle 404 from these endpoints (deleted-resource lookups already 404 today). This narrows a class of 500s to the already-handled 404, so it's strictly lower-risk for callers.
- Mirrors the merged orchestrator fix in #2590.

## Verification

- **Typecheck**: not run — the worktree has no `node_modules` and a full `pnpm install` + `prisma generate` is heavy. The change is a 1-token swap (`new Error(...)` → `throwNotFoundError(...)`) mirroring existing compiling usages in the same files; `throwNotFoundError` returns by throwing and the leading `throw` is retained, so narrowing/types are unchanged.
- **Unit test**: attempted a `getUserContentOverview` NOT_FOUND test using the repo's existing `vi.hoisted`/`vi.mock('~/server/db/client')` service-test pattern. It could not run locally: importing the service transitively loads `src/server/selectors/*.selector.ts`, which call `Prisma.validator(...)` at module-eval — and `Prisma.validator` is **undefined** without a generated `@prisma/client` (`prisma generate`, the heavy bootstrap). No existing service test imports the selector chain or stubs `@prisma/client`. Rather than ship a fragile global Prisma stub, the test was dropped (honesty over a stub).
- **Post-deploy verification (Loki / Prometheus)**: the `handleEndpointError + "User not found"` log count should drop to ~0, and `GET /api/v1/models?username=…`, `GET /api/v1/images?username=…`, and `userProfile.overview` for a nonexistent username should return **404** (counted out of the 5xx SLO / `civitai_app_http_errors_total`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)