### PR TITLE
fix(model+model-version): re-throw caught TRPCError instead of swallowing it (11 handlers)

### DIFF
--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -679,7 +679,7 @@ export const requestReviewHandler = async ({ input }: { input: GetByIdInput }) =
 
     return updatedModel;
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -732,7 +732,7 @@ export const declineReviewHandler = async ({
 
     return updatedModel;
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -750,7 +750,7 @@ export const earlyAccessModelVersionsOnTimeframeHandler = async ({
       userId: ctx.user.id,
     });
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -768,7 +768,7 @@ export const modelVersionGeneratedImagesOnTimeframeHandler = async ({
       userId: ctx.user.id,
     });
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -849,7 +849,7 @@ export const modelVersionEarlyAccessPurchaseHandler = async ({
       buzzType: getAllowedAccountTypes(ctx.features)[0],
     });
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -868,7 +868,7 @@ export const modelVersionDonationGoalsHandler = async ({
       isModerator: ctx.user?.isModerator,
     });
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -1086,7 +1086,7 @@ export const restoreModelHandler = async ({
 
     return model;
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -1250,7 +1250,7 @@ export const toggleModelLockHandler = async ({ input }: { input: ToggleModelLock
   try {
     await toggleLockModel(input);
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -1283,7 +1283,7 @@ export const requestReviewHandler = async ({ input }: { input: GetByIdInput }) =
 
     return updatedModel;
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -1335,7 +1335,7 @@ export const declineReviewHandler = async ({
 
     return updatedModel;
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };
@@ -1387,7 +1387,7 @@ export const changeModelModifierHandler = async ({
 
     return updatedModel;
   } catch (error) {
-    if (error instanceof TRPCError) error;
+    if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);
   }
 };


### PR DESCRIPTION
## Problem

11 handlers across `model.controller.ts` (5) and `model-version.controller.ts` (6) contained `if (error instanceof TRPCError) error;` — a **no-op** expression statement, missing the `throw`. A `TRPCError` (NOT_FOUND / BAD_REQUEST / FORBIDDEN / insufficient-funds …) raised inside the handler was caught, **silently dropped**, and the handler fell through to `return undefined` — the caller saw a "successful" response with no data instead of the real error.

```ts
} catch (error) {
  if (error instanceof TRPCError) error;        // <-- no-op; should `throw error`
  else throw throwDbError(error);
}
```

Surfaced during the adversarial audit of #2595 (auditor spotted one line; grep found 5 in `model.controller.ts`). A second audit of the model-only fix flagged that the **identical bug was still live in the sibling `model-version.controller.ts`** — including the `requestReview`/`declineReview` *version twins* driven by the **same moderator UI** (the buttons pick the version-vs-model mutation by selection). Fixing only the model half would have left the same button erroring for models but silently false-succeeding for versions — an inconsistency worse than the uniform pre-state. So this PR fixes both.

### Affected handlers
- **model.controller.ts**: `restoreModel`, `toggleModelLock`, `requestReview`, `declineReview`, `changeModelModifier`
- **model-version.controller.ts**: `requestReview`, `declineReview`, `earlyAccessModelVersionsOnTimeframe`, `modelVersionGeneratedImagesOnTimeframe`, `modelVersionEarlyAccessPurchase`, `modelVersionDonationGoals`

`modelVersionEarlyAccessPurchaseHandler` is a **purchase** flow, where a swallowed BAD_REQUEST/insufficient-funds error returning undefined-as-success is especially wrong.

## Fix

`throw error` so the TRPCError propagates with its correct HTTP status — the established pattern used by sibling handlers in these files. The `else throw throwDbError(error)` branch is unchanged. After this PR the `instanceof TRPCError) error;` no-op is **gone repo-wide** (verified by grep).

## Risk / behaviour change (corrective, low blast radius)

Per two independent audits: the newly-surfaced errors are **low-frequency, moderator-only, and 4xx** (BAD_REQUEST/NOT_FOUND), handled by the callers' existing `onError` toasts (e.g. `models/[id]` "Unable to change mode" + optimistic-revert; mod queue "Error declining request" keeps the modal open). No happy-path change, no partial-write exposure (every reachable TRPCError is thrown *before* the DB writes), and these are 4xx so they won't trip 5xx SLO alarms (expect a small uptick in logged 400s on `model.changeMode` / `declineReview`). Trivial single-commit revert.

## Verification

Not typechecked locally (worktree has no `node_modules`); the change is a 1-token addition mirroring the correct sibling handlers. Tekton/preview pipeline gates the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)