### PR TITLE
feat(basemodel): lock Ideogram to non-commercial license + wire license notice

### DIFF
--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -119,9 +119,9 @@ import {
   baseModelLicenses,
   CAROUSEL_LIMIT,
   constants,
+  getEffectiveCommercialUse,
   getRestrictedNsfwLevelsForBaseModel,
 } from '~/server/common/constants';
-import { getEffectiveCommercialUse } from '~/shared/constants/basemodel.constants';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
 import { unpublishReasons } from '~/server/common/moderation-helpers';
 import { ReportEntity } from '~/shared/utils/report-helpers';

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -116,6 +116,7 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { baseModelLicenses, CAROUSEL_LIMIT, constants } from '~/server/common/constants';
+import { getEffectiveCommercialUse } from '~/shared/constants/basemodel.constants';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
 import { unpublishReasons } from '~/server/common/moderation-helpers';
 import { ReportEntity } from '~/shared/utils/report-helpers';
@@ -484,9 +485,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
           {/* Owner-only banner: lists publisher_all_my_models subscriptions
               that would render here so the model owner can opt out of any
               specific subscription for this model. Hidden for non-owners. */}
-          {isOwner && (
-            <PublisherSubscriptionBanner modelId={model.id} modelType={model.type} />
-          )}
+          {isOwner && <PublisherSubscriptionBanner modelId={model.id} modelType={model.type} />}
           {model.mode !== ModelModifier.TakenDown && mobile && (
             <ModelCarousel
               modelId={model.id}
@@ -516,11 +515,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
               creatorUserId: model.user.id,
               viewerUserId: user?.id ?? null,
               viewerUsername: user?.username ?? null,
-              viewerStatus: user?.bannedAt
-                ? 'banned'
-                : user?.muted
-                ? 'muted'
-                : 'active',
+              viewerStatus: user?.bannedAt ? 'banned' : user?.muted ? 'muted' : 'active',
               viewerNsfwEnabled: viewerShowNsfw,
               theme: colorScheme === 'dark' ? 'dark' : 'light',
             }}
@@ -1821,7 +1816,18 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                 ))}
               </Stack>
             )}
-            <PermissionIndicator permissions={model} ml="auto" />
+            <PermissionIndicator
+              permissions={{
+                ...model,
+                // Non-commercial base models (e.g. Ideogram) override the stored
+                // commercial-use permission for the displayed version.
+                allowCommercialUse: getEffectiveCommercialUse(
+                  model.allowCommercialUse,
+                  version.baseModel
+                ),
+              }}
+              ml="auto"
+            />
           </Group>
           {license?.notice && (
             <Text size="xs" c="dimmed">

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -115,7 +115,12 @@ import { ToggleVaultButton } from '~/components/Vault/ToggleVaultButton';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
-import { baseModelLicenses, CAROUSEL_LIMIT, constants } from '~/server/common/constants';
+import {
+  baseModelLicenses,
+  CAROUSEL_LIMIT,
+  constants,
+  getRestrictedNsfwLevelsForBaseModel,
+} from '~/server/common/constants';
 import { getEffectiveCommercialUse } from '~/shared/constants/basemodel.constants';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
 import { unpublishReasons } from '~/server/common/moderation-helpers';
@@ -466,6 +471,10 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
       ? unpublishReasons[unpublishedReason]?.notificationMessage
       : `Removal reason: ${version.meta?.customMessage || 'No reason provided.'}`;
   const license = baseModelLicenses[version.baseModel];
+  // Base model can restrict mature content (e.g. Ideogram) and/or commercial use.
+  // Both are derived per displayed version rather than stored on the model.
+  const baseModelRestrictsMature =
+    getRestrictedNsfwLevelsForBaseModel(version.baseModel).length > 0;
   const onSite = !!version.trainingStatus;
   const showAddendumLicense =
     constants.supportedBaseModelAddendums.includes(version.baseModel as 'SD 1.5' | 'SDXL 1.0') &&
@@ -1764,7 +1773,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
           )}
 
           <Group justify="space-between" align="flex-start" wrap="nowrap">
-            {model.type === 'Checkpoint' && (
+            {(model.type === 'Checkpoint' || !!license || model.licenses.length > 0) && (
               <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
                 <Group gap={4} wrap="wrap" align="center">
                   <IconLicense size={16} />
@@ -1819,12 +1828,14 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
             <PermissionIndicator
               permissions={{
                 ...model,
-                // Non-commercial base models (e.g. Ideogram) override the stored
-                // commercial-use permission for the displayed version.
+                // Permissions are derived per displayed version from its base model:
+                // non-commercial base models (e.g. Ideogram) force commercial use off,
+                // and mature-restricted base models force SFW-only generation.
                 allowCommercialUse: getEffectiveCommercialUse(
                   model.allowCommercialUse,
                   version.baseModel
                 ),
+                sfwOnly: model.sfwOnly || baseModelRestrictsMature,
               }}
               ml="auto"
             />

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -215,6 +215,9 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   const skipTrainedWords = !isTextualInversion && (form.watch('skipTrainedWords') ?? false);
   const trainedWords = form.watch('trainedWords') ?? [];
   const baseModel = form.watch('baseModel') ?? 'SD 1.5';
+  // Non-commercial base models (e.g. Ideogram) can't be monetized — hide the
+  // licensing-fee and early-access controls for these versions.
+  const isNonCommercialBaseModel = isNonCommercialLockedBaseModel(baseModel);
   const recResources = form.watch('recommendedResources') ?? [];
   const [minStrength, maxStrength] = form.watch([
     'settings.minStrength',
@@ -227,9 +230,10 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   const existingSettlementCurrency = version?.licensingFeeSettlementCurrency ?? null;
   const hasExistingLicensingFee = (version?.licensingFee ?? 0) > 0;
   const showLicensingFeeBlock =
-    !!features.licensingFee ||
-    hasExistingLicensingFee ||
-    existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash;
+    !isNonCommercialBaseModel &&
+    (!!features.licensingFee ||
+      hasExistingLicensingFee ||
+      existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash);
   const showLicensingFeeSettlementCurrency =
     existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash ||
     !!currentUser?.isModerator;
@@ -379,6 +383,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   const showEarlyAccessInput =
     !model?.poi && // POI models won't allow EA.
     !isPrivateModel &&
+    !isNonCommercialBaseModel && // Non-commercial base models can't be monetized.
     (currentUser?.isModerator ||
       (maxEarlyAccessModels > 0 &&
         features.earlyAccessModel &&
@@ -859,11 +864,11 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
               </Text>
             </Alert>
           )}
-          {isNonCommercialLockedBaseModel(baseModel) && (
+          {isNonCommercialBaseModel && (
             <Alert color="yellow" title="Non-commercial base model">
               <Text>
-                {baseModel} is licensed for non-commercial use only. Commercial use has been
-                disabled for this model and cannot be enabled.
+                {baseModel} is licensed for non-commercial use only. This version cannot be
+                monetized (no licensing fees or paid early access) and commercial use is disabled.
               </Text>
             </Alert>
           )}

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -42,13 +42,11 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import {
   constants,
   EARLY_ACCESS_CONFIG,
+  isNonCommercialBaseModel,
   nsfwRestrictedBaseModels,
 } from '~/server/common/constants';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
-import {
-  getActiveBaseModels,
-  isNonCommercialLockedBaseModel,
-} from '~/shared/constants/basemodel.constants';
+import { getActiveBaseModels } from '~/shared/constants/basemodel.constants';
 import type { ClubResourceSchema } from '~/server/schema/club.schema';
 import type { GenerationResourceSchema } from '~/server/schema/generation.schema';
 import { generationResourceSchema } from '~/server/schema/generation.schema';
@@ -217,7 +215,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   const baseModel = form.watch('baseModel') ?? 'SD 1.5';
   // Non-commercial base models (e.g. Ideogram) can't be monetized — hide the
   // licensing-fee and early-access controls for these versions.
-  const isNonCommercialBaseModel = isNonCommercialLockedBaseModel(baseModel);
+  const isNonCommercial = isNonCommercialBaseModel(baseModel);
   const recResources = form.watch('recommendedResources') ?? [];
   const [minStrength, maxStrength] = form.watch([
     'settings.minStrength',
@@ -230,7 +228,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   const existingSettlementCurrency = version?.licensingFeeSettlementCurrency ?? null;
   const hasExistingLicensingFee = (version?.licensingFee ?? 0) > 0;
   const showLicensingFeeBlock =
-    !isNonCommercialBaseModel &&
+    !isNonCommercial &&
     (!!features.licensingFee ||
       hasExistingLicensingFee ||
       existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash);
@@ -259,12 +257,12 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   // be re-submitted, then rejected server-side with a confusing error). Clear them
   // when switching to such a base model so the form can save.
   useEffect(() => {
-    if (!isNonCommercialBaseModel) return;
+    if (!isNonCommercial) return;
     if ((form.getValues('licensingFee') ?? 0) > 0) form.setValue('licensingFee', 0);
     if (form.getValues('monetization')) form.setValue('monetization', null);
     if (form.getValues('earlyAccessConfig')) form.setValue('earlyAccessConfig', null);
     if (form.getValues('useMonetization')) form.setValue('useMonetization', false);
-  }, [isNonCommercialBaseModel]);
+  }, [isNonCommercial]);
 
   const upsertVersionMutation = trpc.modelVersion.upsert.useMutation({
     onError(error) {
@@ -395,7 +393,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   const showEarlyAccessInput =
     !model?.poi && // POI models won't allow EA.
     !isPrivateModel &&
-    !isNonCommercialBaseModel && // Non-commercial base models can't be monetized.
+    !isNonCommercial && // Non-commercial base models can't be monetized.
     (currentUser?.isModerator ||
       (maxEarlyAccessModels > 0 &&
         features.earlyAccessModel &&
@@ -876,7 +874,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
               </Text>
             </Alert>
           )}
-          {isNonCommercialBaseModel && (
+          {isNonCommercial && (
             <Alert color="yellow" title="Non-commercial base model">
               <Text>
                 {baseModel} is licensed for non-commercial use only. This version cannot be

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -254,6 +254,18 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
     }
   }, [baseModel]);
 
+  // Non-commercial base models can't be monetized. The monetization controls are
+  // hidden (shouldUnregister is false, so their values would otherwise persist and
+  // be re-submitted, then rejected server-side with a confusing error). Clear them
+  // when switching to such a base model so the form can save.
+  useEffect(() => {
+    if (!isNonCommercialBaseModel) return;
+    if ((form.getValues('licensingFee') ?? 0) > 0) form.setValue('licensingFee', 0);
+    if (form.getValues('monetization')) form.setValue('monetization', null);
+    if (form.getValues('earlyAccessConfig')) form.setValue('earlyAccessConfig', null);
+    if (form.getValues('useMonetization')) form.setValue('useMonetization', false);
+  }, [isNonCommercialBaseModel]);
+
   const upsertVersionMutation = trpc.modelVersion.upsert.useMutation({
     onError(error) {
       showErrorNotification({

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -45,7 +45,10 @@ import {
   nsfwRestrictedBaseModels,
 } from '~/server/common/constants';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
-import { getActiveBaseModels } from '~/shared/constants/basemodel.constants';
+import {
+  getActiveBaseModels,
+  isNonCommercialLockedBaseModel,
+} from '~/shared/constants/basemodel.constants';
 import type { ClubResourceSchema } from '~/server/schema/club.schema';
 import type { GenerationResourceSchema } from '~/server/schema/generation.schema';
 import { generationResourceSchema } from '~/server/schema/generation.schema';
@@ -798,8 +801,8 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
                     style={{ flexShrink: 0, marginTop: 2 }}
                   />
                   <Text size="xs" c="yellow">
-                    With a license fee set, this version stops earning creator compensation and
-                    tips — you earn through the license fee instead.
+                    With a license fee set, this version stops earning creator compensation and tips
+                    — you earn through the license fee instead.
                   </Text>
                 </Group>
               )}
@@ -853,6 +856,14 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
                 >
                   Learn more
                 </Text>
+              </Text>
+            </Alert>
+          )}
+          {isNonCommercialLockedBaseModel(baseModel) && (
+            <Alert color="yellow" title="Non-commercial base model">
+              <Text>
+                {baseModel} is licensed for non-commercial use only. Commercial use has been
+                disabled for this model and cannot be enabled.
               </Text>
             </Alert>
           )}

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -4,6 +4,7 @@ import { IMAGE_MIME_TYPE, VIDEO_MIME_TYPE } from '~/shared/constants/mime-types'
 import type { GenerationResource } from '~/shared/types/generation.types';
 import {
   BountyType,
+  CommercialUse,
   Currency,
   MetricTimeframe,
   ModelStatus,
@@ -484,6 +485,10 @@ type LicenseDetails = {
   // When true, mature content is restricted (auto-derives `restrictedNsfwLevels`
   // to MATURE_NSFW_LEVELS). Use this instead of hand-listing levels.
   disableMature?: boolean;
+  // When true, the license forbids commercial use. Drives both the commercial-use
+  // permission override (-> [None]) and the per-version monetization block. The set
+  // of affected base models is derived from this flag (see nonCommercialBaseModels).
+  nonCommercial?: boolean;
 };
 
 // Levels considered "mature" — restricted whenever a license sets disableMature.
@@ -635,6 +640,8 @@ const baseLicenses: Record<string, LicenseDetails> = {
     // License AUP bars pornographic/obscene content. `disableMature` auto-derives
     // the restricted NSFW levels (see getRestrictedNsfwLevelsForBaseModel).
     disableMature: true,
+    // Ideogram Non-Commercial Model Agreement forbids commercial use.
+    nonCommercial: true,
   },
 };
 
@@ -739,6 +746,27 @@ export const nsfwRestrictedBaseModels: BaseModel[] = Object.entries(baseModelLic
 
 export function getRestrictedNsfwLevelsForBaseModel(baseModel: string): NsfwLevel[] {
   return getLicenseRestrictedNsfwLevels(baseModelLicenses[baseModel as BaseModel]);
+}
+
+// Base models whose license forbids commercial use — derived from the `nonCommercial`
+// license flag (single source of truth), mirroring nsfwRestrictedBaseModels.
+export const nonCommercialBaseModels: BaseModel[] = Object.entries(baseModelLicenses)
+  .filter(([, license]) => !!license?.nonCommercial)
+  .map(([baseModel]) => baseModel as BaseModel);
+
+export function isNonCommercialBaseModel(baseModel?: string | null): boolean {
+  return !!baseModel && !!baseModelLicenses[baseModel as BaseModel]?.nonCommercial;
+}
+
+// Effective commercial-use permissions for a resource given its base model.
+// Non-commercial base models override the stored creator permission to [None] — we
+// derive this at read time rather than storing it, so it always reflects the current
+// license config and needs no migration. Use wherever commercial-use is surfaced.
+export function getEffectiveCommercialUse(
+  allowCommercialUse: CommercialUse[],
+  baseModel?: string | null
+): CommercialUse[] {
+  return isNonCommercialBaseModel(baseModel) ? [CommercialUse.None] : allowCommercialUse;
 }
 
 export function isNsfwLevelRestrictedForBaseModel(

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -628,10 +628,10 @@ const baseLicenses: Record<string, LicenseDetails> = {
     // Public blob page — the nf4 `raw` URL is gated and 401s.
     url: 'https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md',
     name: 'Ideogram Non-Commercial Model Agreement',
-    // Section 3(iii) attribution wording. Their cited github URL 404s, so we point
-    // at the working HF blob page instead.
+    // Section 3(iii) attribution wording; the URL lives on the linked license name
+    // shown above the notice, so we omit the bare URL here.
     notice:
-      'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement available at https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md. All rights reserved. Copyright © Ideogram, Inc.',
+      'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement. All rights reserved. Copyright © Ideogram, Inc.',
     // License AUP bars pornographic/obscene content. `disableMature` auto-derives
     // the restricted NSFW levels (see getRestrictedNsfwLevelsForBaseModel).
     disableMature: true,

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -481,7 +481,13 @@ type LicenseDetails = {
   notice?: string;
   poweredBy?: string;
   restrictedNsfwLevels?: NsfwLevel[];
+  // When true, mature content is restricted (auto-derives `restrictedNsfwLevels`
+  // to MATURE_NSFW_LEVELS). Use this instead of hand-listing levels.
+  disableMature?: boolean;
 };
+
+// Levels considered "mature" — restricted whenever a license sets disableMature.
+const MATURE_NSFW_LEVELS: NsfwLevel[] = [NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX];
 const baseLicenses: Record<string, LicenseDetails> = {
   openrail: {
     url: 'https://huggingface.co/spaces/CompVis/stable-diffusion-license',
@@ -618,6 +624,18 @@ const baseLicenses: Record<string, LicenseDetails> = {
     url: 'https://www.vidu.com/terms',
     name: 'Vidu Q1',
   },
+  'ideogram nc': {
+    // Public blob page — the nf4 `raw` URL is gated and 401s.
+    url: 'https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md',
+    name: 'Ideogram Non-Commercial Model Agreement',
+    // Section 3(iii) attribution wording. Their cited github URL 404s, so we point
+    // at the working HF blob page instead.
+    notice:
+      'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement available at https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md. All rights reserved. Copyright © Ideogram, Inc.',
+    // License AUP bars pornographic/obscene content. `disableMature` auto-derives
+    // the restricted NSFW levels (see getRestrictedNsfwLevelsForBaseModel).
+    disableMature: true,
+  },
 };
 
 export const baseModelLicenses: Record<BaseModel, LicenseDetails | undefined> = {
@@ -698,22 +716,29 @@ export const baseModelLicenses: Record<BaseModel, LicenseDetails | undefined> = 
   Kling: baseLicenses['kling'],
   'Vidu Q1': baseLicenses['vidu'],
   Seedance: baseLicenses['seedream'],
+  'Ideogram 4.0': baseLicenses['ideogram nc'],
 };
 
 export type ModelFileType = (typeof constants.modelFileTypes)[number];
 export type Sampler = (typeof constants.samplers)[number];
 
+// Resolve the restricted NSFW levels for a license, deriving from `disableMature`
+// when an explicit `restrictedNsfwLevels` array isn't provided.
+function getLicenseRestrictedNsfwLevels(license: LicenseDetails | undefined): NsfwLevel[] {
+  if (!license) return [];
+  if (license.restrictedNsfwLevels && license.restrictedNsfwLevels.length > 0)
+    return license.restrictedNsfwLevels;
+  if (license.disableMature) return MATURE_NSFW_LEVELS;
+  return [];
+}
+
 // Base models that use licenses with NSFW restrictions
 export const nsfwRestrictedBaseModels: BaseModel[] = Object.entries(baseModelLicenses)
-  .filter(
-    ([, license]) =>
-      license && license.restrictedNsfwLevels && license.restrictedNsfwLevels.length > 0
-  )
+  .filter(([, license]) => getLicenseRestrictedNsfwLevels(license).length > 0)
   .map(([baseModel]) => baseModel as BaseModel);
 
 export function getRestrictedNsfwLevelsForBaseModel(baseModel: string): NsfwLevel[] {
-  const license = baseModelLicenses[baseModel as BaseModel];
-  return license?.restrictedNsfwLevels || [];
+  return getLicenseRestrictedNsfwLevels(baseModelLicenses[baseModel as BaseModel]);
 }
 
 export function isNsfwLevelRestrictedForBaseModel(

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -87,7 +87,10 @@ import { filesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
 import type { BaseModel, BaseModelGroup } from '~/shared/constants/basemodel.constants';
-import { getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
+import {
+  getBaseModelsByGroup,
+  isNonCommercialLockedBaseModel,
+} from '~/shared/constants/basemodel.constants';
 import type { ImageMetadata } from '~/server/schema/media.schema';
 
 export const getModelVersionRunStrategies = async ({
@@ -285,6 +288,21 @@ export const upsertModelVersion = async ({
         ', '
       )}`
     );
+  }
+
+  // Non-commercial base models (e.g. Ideogram) can't be monetized — reject any
+  // monetization on this version. Scoped to the version, so a model's other
+  // versions on commercial base models can still monetize.
+  if (isNonCommercialLockedBaseModel(data.baseModel)) {
+    const attemptsMonetization =
+      (data.licensingFee != null && data.licensingFee > 0) ||
+      !!monetization ||
+      !!updatedEarlyAccessConfig;
+    if (attemptsMonetization) {
+      throw throwBadRequestError(
+        `The base model "${data.baseModel}" is licensed for non-commercial use and cannot be monetized.`
+      );
+    }
   }
 
   // Check if trying to publish a model version when model is marked as cannotPublish

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -4,7 +4,12 @@ import dayjs from '~/shared/utils/dayjs';
 import type { SessionUser } from 'next-auth';
 import { env } from '~/env/server';
 import { clickhouse } from '~/server/clickhouse/client';
-import { CacheTTL, constants, nsfwRestrictedBaseModels } from '~/server/common/constants';
+import {
+  CacheTTL,
+  constants,
+  isNonCommercialBaseModel,
+  nsfwRestrictedBaseModels,
+} from '~/server/common/constants';
 import type { ModelFileType } from '~/server/common/constants';
 import {
   EntityAccessPermission,
@@ -87,10 +92,7 @@ import { filesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
 import type { BaseModel, BaseModelGroup } from '~/shared/constants/basemodel.constants';
-import {
-  getBaseModelsByGroup,
-  isNonCommercialLockedBaseModel,
-} from '~/shared/constants/basemodel.constants';
+import { getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
 import type { ImageMetadata } from '~/server/schema/media.schema';
 
 export const getModelVersionRunStrategies = async ({
@@ -293,7 +295,7 @@ export const upsertModelVersion = async ({
   // Non-commercial base models (e.g. Ideogram) can't be monetized — reject any
   // monetization on this version. Scoped to the version, so a model's other
   // versions on commercial base models can still monetize.
-  if (isNonCommercialLockedBaseModel(data.baseModel)) {
+  if (isNonCommercialBaseModel(data.baseModel)) {
     const attemptsMonetization =
       (data.licensingFee != null && data.licensingFee > 0) ||
       !!monetization?.type ||

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -296,7 +296,7 @@ export const upsertModelVersion = async ({
   if (isNonCommercialLockedBaseModel(data.baseModel)) {
     const attemptsMonetization =
       (data.licensingFee != null && data.licensingFee > 0) ||
-      !!monetization ||
+      !!monetization?.type ||
       !!updatedEarlyAccessConfig;
     if (attemptsMonetization) {
       throw throwBadRequestError(

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -10,7 +10,7 @@
  * @see docs/generation-support-redesign.md for design documentation
  */
 
-import { ModelType, type MediaType } from '~/shared/utils/prisma/enums';
+import { CommercialUse, ModelType, type MediaType } from '~/shared/utils/prisma/enums';
 import { lazy } from '~/shared/utils/lazy';
 import { isDefined } from '~/utils/type-guards';
 
@@ -2131,9 +2131,12 @@ export const licenses: LicenseRecord[] = [
   {
     id: 37,
     name: 'Ideogram Non-Commercial Model Agreement',
-    url: 'https://github.com/ideogram-oss/ideogram-4/model_licenses/LICENSE-IDEOGRAM-4-NON-COMMERCIAL',
+    // Public blob page — the nf4 `raw` URL is gated and 401s.
+    url: 'https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md',
+    // Section 3(iii) attribution wording. Their cited github URL 404s, so we point
+    // at the working HF blob page instead.
     notice:
-      'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement. All rights reserved. Copyright © Ideogram, Inc.',
+      'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement available at https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md. All rights reserved. Copyright © Ideogram, Inc.',
     disableMature: true,
   },
 ];
@@ -3536,6 +3539,33 @@ export function getEcosystemDefaults(
 // =============================================================================
 // Base Model Helpers
 // =============================================================================
+
+/**
+ * Base models whose license forbids commercial use. Selecting one of these as a
+ * resource's base model locks the model's creator permissions to non-commercial
+ * (allowCommercialUse is forced to [None] and the commercial options are disabled
+ * in the upload UI). Keyed by base model `name` (the value stored on
+ * ModelVersion.baseModel). Scoped to Ideogram for now — see license id 37.
+ */
+export const nonCommercialLockedBaseModels: string[] = ['Ideogram 4.0'];
+
+export function isNonCommercialLockedBaseModel(baseModel?: string | null): boolean {
+  return !!baseModel && nonCommercialLockedBaseModels.includes(baseModel);
+}
+
+/**
+ * Resolve the effective commercial-use permissions for a resource given its base
+ * model. Non-commercial base models (e.g. Ideogram) override the stored creator
+ * permission to [None] — we derive this at read time rather than storing it, so it
+ * always reflects the current base model config and needs no migration of existing
+ * records. Use everywhere creator commercial-use permissions are surfaced.
+ */
+export function getEffectiveCommercialUse(
+  allowCommercialUse: CommercialUse[],
+  baseModel?: string | null
+): CommercialUse[] {
+  return isNonCommercialLockedBaseModel(baseModel) ? [CommercialUse.None] : allowCommercialUse;
+}
 
 /**
  * Get active base models for selection UIs (e.g., model version upsert form).

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -10,7 +10,7 @@
  * @see docs/generation-support-redesign.md for design documentation
  */
 
-import { CommercialUse, ModelType, type MediaType } from '~/shared/utils/prisma/enums';
+import { ModelType, type MediaType } from '~/shared/utils/prisma/enums';
 import { lazy } from '~/shared/utils/lazy';
 import { isDefined } from '~/utils/type-guards';
 
@@ -89,6 +89,8 @@ export type LicenseRecord = {
   notice?: string;
   poweredBy?: string;
   disableMature?: boolean;
+  // License forbids commercial use (drives commercial-use override + monetization block).
+  nonCommercial?: boolean;
 };
 
 export type BaseModelFamilyRecord = {
@@ -2139,6 +2141,7 @@ export const licenses: LicenseRecord[] = [
     notice:
       'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement. All rights reserved. Copyright © Ideogram, Inc.',
     disableMature: true,
+    nonCommercial: true,
   },
 ];
 
@@ -3540,33 +3543,6 @@ export function getEcosystemDefaults(
 // =============================================================================
 // Base Model Helpers
 // =============================================================================
-
-/**
- * Base models whose license forbids commercial use. Selecting one of these as a
- * resource's base model locks the model's creator permissions to non-commercial
- * (allowCommercialUse is forced to [None] and the commercial options are disabled
- * in the upload UI). Keyed by base model `name` (the value stored on
- * ModelVersion.baseModel). Scoped to Ideogram for now — see license id 37.
- */
-export const nonCommercialLockedBaseModels: string[] = ['Ideogram 4.0'];
-
-export function isNonCommercialLockedBaseModel(baseModel?: string | null): boolean {
-  return !!baseModel && nonCommercialLockedBaseModels.includes(baseModel);
-}
-
-/**
- * Resolve the effective commercial-use permissions for a resource given its base
- * model. Non-commercial base models (e.g. Ideogram) override the stored creator
- * permission to [None] — we derive this at read time rather than storing it, so it
- * always reflects the current base model config and needs no migration of existing
- * records. Use everywhere creator commercial-use permissions are surfaced.
- */
-export function getEffectiveCommercialUse(
-  allowCommercialUse: CommercialUse[],
-  baseModel?: string | null
-): CommercialUse[] {
-  return isNonCommercialLockedBaseModel(baseModel) ? [CommercialUse.None] : allowCommercialUse;
-}
 
 /**
  * Get active base models for selection UIs (e.g., model version upsert form).

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -2131,12 +2131,13 @@ export const licenses: LicenseRecord[] = [
   {
     id: 37,
     name: 'Ideogram Non-Commercial Model Agreement',
-    // Public blob page — the nf4 `raw` URL is gated and 401s.
+    // Public blob page — the nf4 `raw` URL is gated and 401s, and their license's
+    // own cited github URL 404s. The license name links here in the UI.
     url: 'https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md',
-    // Section 3(iii) attribution wording. Their cited github URL 404s, so we point
-    // at the working HF blob page instead.
+    // Section 3(iii) attribution wording; the URL lives on the linked license name
+    // above the notice, so we omit the bare URL here.
     notice:
-      'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement available at https://huggingface.co/ideogram-ai/ideogram-4-nf4/blob/main/LICENSE.md. All rights reserved. Copyright © Ideogram, Inc.',
+      'Ideogram 4 is provided under and subject to the Ideogram Non-Commercial Model Agreement. All rights reserved. Copyright © Ideogram, Inc.',
     disableMature: true,
   },
 ];


### PR DESCRIPTION
## What

Ideogram 4.0 ships under the **Ideogram Non-Commercial Model Agreement** (forbids commercial use). This wires up the license display and locks commercial use for Ideogram LoRAs.

## Changes

- **License data (id 37)** — notice now uses the §3(iii) attribution wording with the working HF blob URL. Their cited github URL 404s; the `nf4/raw` URL 401s (gated repo). `url` points at the public HF blob page.
- **License notice display** — added `Ideogram 4.0` to the live `baseModelLicenses` map so the license + notice render on LoRA model pages (the V2 `getBaseModelLicense` is unused; the old map is what `ModelVersionDetails` reads).
- **`disableMature` is now automatic** — added it to the live `LicenseDetails`; `getRestrictedNsfwLevelsForBaseModel` / `nsfwRestrictedBaseModels` derive `[R,X,XXX]` from it instead of hand-listed levels. Honors the Ideogram AUP (bars pornographic/obscene content).
- **Commercial-use lock = read-time override** — `getEffectiveCommercialUse(allowCommercialUse, baseModel)` returns `[None]` for non-commercial base models. Applied **per displayed version** on the model-page permission badges. Nothing stored → existing models covered, no migration.
- **Creator alert** when an Ideogram base model is selected on upload.

## Notes

- No DB migration.
- `allowCommercialUse` is a model-level field; the override is applied at the model-page badges (per displayed version). Other readers (search/resource cards, partner/generation APIs, upload-form checkboxes) still read the stored value — the shared helper drops into those for fuller coverage if we want it.
- No competitive-training notice added — that's a §7 use restriction, not a mandated distribution notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)