### PR TITLE
fix(model): guard getCollectionShowcase against empty-collection 500

### DIFF
--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -1878,7 +1878,9 @@ export async function getModelCollectionShowcaseHandler({ input }: { input: GetB
 
     return {
       ...collection,
-      itemCount: itemCount.count,
+      // getCollectionItemCount uses GROUP BY, so an empty showcase collection
+      // (no accepted items) returns no row and itemCount is undefined — default to 0.
+      itemCount: Number(itemCount?.count ?? 0),
     };
   } catch (error) {
     throw throwDbError(error);


### PR DESCRIPTION
## Root cause

`getModelCollectionShowcaseHandler` (`src/server/controllers/model.controller.ts:1874-1882`) does:

```ts
const [itemCount] = await getCollectionItemCount({
  collectionIds: [collection.id],
  status: CollectionItemStatus.ACCEPTED,
});
return { ...collection, itemCount: itemCount.count };
```

`getCollectionItemCount` (`src/server/services/collection.service.ts:1857`) is a `$queryRaw` with `GROUP BY "collectionId"`. When the model's showcase collection has **zero accepted items** (a freshly-created showcase, all items removed/rejected/deleted, or items whose entity FKs are all null), the `GROUP BY` returns **no rows** → the result array is `[]` → `itemCount` is **`undefined`** → `itemCount.count` throws:

```
TRPCError: Cannot read properties of undefined (reading 'count')
```

The `throwDbError` wrapper turns that into `INTERNAL_SERVER_ERROR` (HTTP 500). On dp-prod this fires ~16 times / 30 min on `model.getCollectionShowcase` (also via `GET /api/trpc/model.getCollectionShowcase`).

- **undefined operand:** `itemCount` — the first element of the (empty) array returned by `getCollectionItemCount`.
- **triggering condition:** a model with a `meta.showcaseCollectionId` pointing at a collection that currently has no ACCEPTED items.

## Fix

```ts
itemCount: Number(itemCount?.count ?? 0),
```

Defaults the missing-row case to `0`, so an empty showcase degrades to a valid **200** with `itemCount: 0` instead of a 500. The `Number(...)` coercion + `?? 0` default mirror the **existing** caller of `getCollectionItemCount` in `collection.controller.ts:122` (`.map((c) => [c.id, Number(c.count)])` with `?? 0` fallback at line 137), so this matches the established codebase convention for the same `COUNT(*)` bigint.

## Client shape (verified safe)

The only consumer of `itemCount` is `ModelVersionDetails.tsx:1033`:
```tsx
{collection.itemCount > 0 ? ` - ${collection.itemCount.toLocaleString()} items` : ''}
```
`itemCount: 0` is the semantically correct value — it renders just "Collection" with no count, which is exactly right for an empty showcase. `useModelShowcaseCollection` already optional-chains `showcase?.id`, so the whole-`null` path (no showcaseCollectionId) was already handled; this only fixes the present-but-empty collection path.

## Risk

Low. One-line change in a single read handler; no schema/query change; no new imports. Behavior only changes for the previously-500ing empty-collection case (now returns `itemCount: 0`); the non-empty case is unchanged (`Number(count)` == prior numeric `count`).

## Verification

- **Typecheck:** the worktree has no `node_modules` (git worktrees don't share it) and a full `pnpm install` + `prisma generate` is constrained on this clone, so `tsc` was not run locally. The change is type-trivial: `itemCount` is already typed `{ id: number; count: number } | undefined` from the array destructure, `?.` is valid on it, and `Number(x ?? 0)` is `number` (narrower than the prior `number`). No new symbols introduced.
- **Post-deploy (dp-prod):** in Loki, the rate of `getCollectionShowcase` `INTERNAL_SERVER_ERROR` / `reading 'count'` log lines on `{app="civitai-dp-prod-api-primary"}` should drop to ~0 (was ~16/30min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)