### PR TITLE
fix(comment): cap+dedup excludedUserIds to avoid Prisma P2029 on comment.getAll

### DIFF
--- a/src/server/controllers/bounty.controller.ts
+++ b/src/server/controllers/bounty.controller.ts
@@ -40,6 +40,7 @@ import type { BountyEntryFileMeta } from '~/server/schema/bounty-entry.schema';
 import { Currency } from '~/shared/utils/prisma/enums';
 import { getReactionsSelectV2 } from '~/server/selectors/reaction.selector';
 import { handleLogError } from '~/server/utils/errorHandling';
+import { boundExcludedUserIds } from '~/server/utils/excluded-user-ids';
 import { filterSensitiveProfanityData } from '~/libs/profanity-simple/helpers';
 import { NsfwLevel } from '~/server/common/enums';
 import { BlockedByUsers } from '~/server/services/user-preferences.service';
@@ -204,11 +205,14 @@ export const getBountyEntriesHandler = async ({
     const blockedByUsers = (await BlockedByUsers.getCached({ userId: ctx.user?.id })).map(
       (u) => u.id
     );
+    // Bound the (involuntary, unbounded) blocked-by list before it feeds the downstream
+    // Prisma `notIn` in getAllEntriesByBountyId — same P2029 class as comment.getAll.
+    const excludedUserIds = boundExcludedUserIds([], blockedByUsers, []);
     const entries = await getAllEntriesByBountyId({
       input: {
         bountyId: input.id,
         userId: input.owned ? ctx.user?.id : undefined,
-        excludedUserIds: blockedByUsers,
+        excludedUserIds,
         cursor: input.cursor,
         limit,
       },

--- a/src/server/controllers/commentv2.controller.ts
+++ b/src/server/controllers/commentv2.controller.ts
@@ -16,6 +16,7 @@ import {
   throwDbError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
+import { boundExcludedUserIds } from '~/server/utils/excluded-user-ids';
 import { updateEntityMetric } from '~/server/utils/metric-helpers';
 import { dbRead } from '../db/client';
 import { hasEntityAccess } from '../services/common.service';
@@ -193,7 +194,10 @@ export const getCommentsThreadDetailsHandler = async ({
       (x) => x.id
     );
     const blockedUsers = (await BlockedUsers.getCached({ userId: ctx.user?.id })).map((x) => x.id);
-    const excludedUserIds = [...hiddenUsers, ...blockedByUsers, ...blockedUsers];
+    // De-dupe + cap so the downstream `notIn` / raw `NOT IN` stays under the Postgres
+    // bind-param limit (heavily-blocked viewer otherwise → P2029 → 500). Ordering is a
+    // load-bearing safety priority — see boundExcludedUserIds.
+    const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
 
     return await getCommentsThreadDetails2({ ...input, excludedUserIds });
   } catch (error) {
@@ -278,7 +282,10 @@ export const getCommentsInfiniteHandler = async ({
       (x) => x.id
     );
     const blockedUsers = (await BlockedUsers.getCached({ userId: ctx.user?.id })).map((x) => x.id);
-    const excludedUserIds = [...hiddenUsers, ...blockedByUsers, ...blockedUsers];
+    // De-dupe + cap so the downstream `notIn` / raw `NOT IN` stays under the Postgres
+    // bind-param limit (heavily-blocked viewer otherwise → P2029 → 500). Ordering is a
+    // load-bearing safety priority — see boundExcludedUserIds.
+    const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
 
     return await getCommentsInfinite({ ...input, excludedUserIds });
   } catch (error) {

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -118,6 +118,7 @@ import {
   throwNotFoundError,
   withRetries,
 } from '~/server/utils/errorHandling';
+import { boundExcludedUserIds } from '~/server/utils/excluded-user-ids';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import { invalidateSession, refreshSession } from '~/server/auth/session-invalidation';
 import { Flags } from '~/shared/utils/flags';
@@ -144,15 +145,22 @@ export const getAllUsersHandler = async ({
   ctx: Context;
 }) => {
   try {
-    const blockedUsersLists = await Promise.all([
+    const [blockedUsers, blockedByUsers] = await Promise.all([
       BlockedUsers.getCached({ userId: ctx.user?.id }),
       BlockedByUsers.getCached({ userId: ctx.user?.id }),
     ]);
 
-    const blockedUsers = [...new Set([...blockedUsersLists.flatMap((x) => x)].map((u) => u.id))];
-
-    if (blockedUsers.length)
-      input.excludedUserIds = [...(input.excludedUserIds ?? []), ...blockedUsers];
+    // Dedupe + cap the merged exclusion list before it feeds getUsers' raw `NOT IN`
+    // (Prisma) / getUsersWithSearch — a heavily-blocked viewer otherwise overflows the
+    // Postgres bind-param limit → P2029 → 500 (same class as comment.getAll). Ordering is a
+    // load-bearing safety priority: pre-existing excluded ids (hidden-user prefs) first,
+    // then the INVOLUNTARY blocked-by list, then the viewer's own block list (sacrificed
+    // first on overflow). See boundExcludedUserIds.
+    input.excludedUserIds = boundExcludedUserIds(
+      input.excludedUserIds ?? [],
+      blockedByUsers.map((u) => u.id),
+      blockedUsers.map((u) => u.id)
+    );
 
     const searchMethod =
       ctx.user?.isModerator && input.contestBanned ? getUsers : getUsersWithSearch;

--- a/src/server/services/comment.service.ts
+++ b/src/server/services/comment.service.ts
@@ -25,13 +25,9 @@ import {
   HiddenUsers,
 } from '~/server/services/user-preferences.service';
 import { throwNotFoundError } from '~/server/utils/errorHandling';
+import { boundExcludedUserIds } from '~/server/utils/excluded-user-ids';
 import { DEFAULT_PAGE_SIZE } from '~/server/utils/pagination-helpers';
 import type { ReportReason, ReportStatus, ReviewReactions } from '~/shared/utils/prisma/enums';
-
-// Postgres caps bind parameters at 32767. A `notIn` negation cannot be auto-split by Prisma
-// (unlike a positive `in`), so a larger exclusion list throws P2029. Bound it conservatively
-// below the limit to leave headroom for the query's other parameters.
-const MAX_EXCLUDED_USER_IDS = 30000;
 
 export const getComments = async <TSelect extends Prisma.CommentSelect>({
   input: {
@@ -57,20 +53,11 @@ export const getComments = async <TSelect extends Prisma.CommentSelect>({
   const hiddenUsers = (await HiddenUsers.getCached({ userId: user?.id })).map((x) => x.id);
   const blockedByUsers = (await BlockedByUsers.getCached({ userId: user?.id })).map((x) => x.id);
   const blockedUsers = (await BlockedUsers.getCached({ userId: user?.id })).map((x) => x.id);
-  // De-duplicate (the three lists overlap heavily — mutual blocks appear in both
-  // blockedUsers and blockedByUsers) and cap the list. `userId: { notIn: [...] }` is a
-  // negation filter: Prisma cannot split it into multiple queries the way it splits a
-  // positive `in`, so once the bind-parameter count crosses the Postgres limit (~32767,
-  // shared with the query's other params) the engine throws P2029 ("Query parameter limit
-  // exceeded ... the negation filters used prevent the query from being split") and the
-  // whole comment list 500s. `blockedByUsers` is unbounded (anyone who blocked the viewer),
-  // so a heavily-blocked account can exceed the limit. Bounding the exclusion well below
-  // the limit keeps the query valid; in the pathological case a few of the lowest-priority
-  // excluded users' comments may show through, which is far preferable to a hard 500.
-  const excludedUserIds = [...new Set([...hiddenUsers, ...blockedByUsers, ...blockedUsers])].slice(
-    0,
-    MAX_EXCLUDED_USER_IDS
-  );
+  // De-dupe + cap the exclusion list so the `userId: { notIn: [...] }` negation below stays
+  // under the Postgres bind-parameter limit (a heavily-blocked viewer's combined list can
+  // otherwise overflow → Prisma P2029 → 500). Ordering is a load-bearing safety priority —
+  // see boundExcludedUserIds.
+  const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
 
   if (filterBy?.includes(ReviewFilter.IncludesImages)) return [];
 

--- a/src/server/services/comment.service.ts
+++ b/src/server/services/comment.service.ts
@@ -28,6 +28,11 @@ import { throwNotFoundError } from '~/server/utils/errorHandling';
 import { DEFAULT_PAGE_SIZE } from '~/server/utils/pagination-helpers';
 import type { ReportReason, ReportStatus, ReviewReactions } from '~/shared/utils/prisma/enums';
 
+// Postgres caps bind parameters at 32767. A `notIn` negation cannot be auto-split by Prisma
+// (unlike a positive `in`), so a larger exclusion list throws P2029. Bound it conservatively
+// below the limit to leave headroom for the query's other parameters.
+const MAX_EXCLUDED_USER_IDS = 30000;
+
 export const getComments = async <TSelect extends Prisma.CommentSelect>({
   input: {
     limit = DEFAULT_PAGE_SIZE,
@@ -52,7 +57,20 @@ export const getComments = async <TSelect extends Prisma.CommentSelect>({
   const hiddenUsers = (await HiddenUsers.getCached({ userId: user?.id })).map((x) => x.id);
   const blockedByUsers = (await BlockedByUsers.getCached({ userId: user?.id })).map((x) => x.id);
   const blockedUsers = (await BlockedUsers.getCached({ userId: user?.id })).map((x) => x.id);
-  const excludedUserIds = [...hiddenUsers, ...blockedByUsers, ...blockedUsers];
+  // De-duplicate (the three lists overlap heavily — mutual blocks appear in both
+  // blockedUsers and blockedByUsers) and cap the list. `userId: { notIn: [...] }` is a
+  // negation filter: Prisma cannot split it into multiple queries the way it splits a
+  // positive `in`, so once the bind-parameter count crosses the Postgres limit (~32767,
+  // shared with the query's other params) the engine throws P2029 ("Query parameter limit
+  // exceeded ... the negation filters used prevent the query from being split") and the
+  // whole comment list 500s. `blockedByUsers` is unbounded (anyone who blocked the viewer),
+  // so a heavily-blocked account can exceed the limit. Bounding the exclusion well below
+  // the limit keeps the query valid; in the pathological case a few of the lowest-priority
+  // excluded users' comments may show through, which is far preferable to a hard 500.
+  const excludedUserIds = [...new Set([...hiddenUsers, ...blockedByUsers, ...blockedUsers])].slice(
+    0,
+    MAX_EXCLUDED_USER_IDS
+  );
 
   if (filterBy?.includes(ReviewFilter.IncludesImages)) return [];
 

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -19,6 +19,7 @@ import {
   BlockedUsers,
   HiddenUsers,
 } from '~/server/services/user-preferences.service';
+import { boundExcludedUserIds } from '~/server/utils/excluded-user-ids';
 import {
   amIBlockedByUser,
   getBasicDataForUsers,
@@ -462,7 +463,16 @@ export const getPagedResourceReviews = async ({
     BlockedByUsers.getCached({ userId }),
     BlockedUsers.getCached({ userId }),
   ]);
-  const excludedUserIds = [...new Set(excludedUsers.flat().map((user) => user.id))];
+  // [hidden, blockedBy, blocked] — bound + dedup so a heavily-blocked viewer's
+  // (unbounded) blockedBy list can't blow past Postgres's 32767 bind-param cap on
+  // the raw NOT IN below (P2029). Same fix + safety-priority order as the comment
+  // surfaces; see boundExcludedUserIds.
+  const [hiddenUsers, blockedByUsers, blockedUsers] = excludedUsers;
+  const excludedUserIds = boundExcludedUserIds(
+    hiddenUsers.map((u) => u.id),
+    blockedByUsers.map((u) => u.id),
+    blockedUsers.map((u) => u.id)
+  );
   if (excludedUserIds.length) {
     AND.push(Prisma.sql`rr."userId" NOT IN (${Prisma.join(excludedUserIds)})`);
   }

--- a/src/server/utils/__tests__/excluded-user-ids.test.ts
+++ b/src/server/utils/__tests__/excluded-user-ids.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { boundExcludedUserIds, MAX_EXCLUDED_USER_IDS } from '../excluded-user-ids';
+
+describe('boundExcludedUserIds', () => {
+  it('returns the union of all three lists when under the cap', () => {
+    const result = boundExcludedUserIds([1, 2], [3, 4], [5, 6]);
+    expect(result).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(result.length).toBeLessThanOrEqual(MAX_EXCLUDED_USER_IDS);
+  });
+
+  it('de-duplicates ids that appear across lists (e.g. mutual blocks)', () => {
+    // 10 is in both blockedByUsers and blockedUsers (a mutual block); 1 repeats within hidden.
+    const result = boundExcludedUserIds([1, 1, 2], [10, 20], [10, 30]);
+    expect(result).toEqual([1, 2, 10, 20, 30]);
+    // Set semantics: every id appears exactly once.
+    expect(new Set(result).size).toBe(result.length);
+  });
+
+  it('never exceeds MAX_EXCLUDED_USER_IDS', () => {
+    const big = Array.from({ length: MAX_EXCLUDED_USER_IDS + 5000 }, (_, i) => i);
+    const result = boundExcludedUserIds([], big, []);
+    expect(result.length).toBe(MAX_EXCLUDED_USER_IDS);
+  });
+
+  it('drops the TAIL (viewer-own blockedUsers) first on overflow, never the involuntary lists', () => {
+    // hiddenUsers + blockedByUsers together exactly fill the cap; blockedUsers is the overflow.
+    const half = MAX_EXCLUDED_USER_IDS / 2;
+    const hiddenUsers = Array.from({ length: half }, (_, i) => i); // ids [0 .. half-1]
+    const blockedByUsers = Array.from({ length: half }, (_, i) => half + i); // ids [half .. MAX-1]
+    const blockedUsers = [900000, 900001, 900002]; // the viewer's OWN mute list — distinct ids
+
+    const result = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
+    const resultSet = new Set(result);
+
+    expect(result.length).toBe(MAX_EXCLUDED_USER_IDS);
+    // Every hidden + involuntary blocked-by id is retained.
+    for (const id of hiddenUsers) expect(resultSet.has(id)).toBe(true);
+    for (const id of blockedByUsers) expect(resultSet.has(id)).toBe(true);
+    // The viewer's own block list is the part sacrificed on overflow.
+    for (const id of blockedUsers) expect(resultSet.has(id)).toBe(false);
+  });
+
+  it('partially keeps blockedUsers only after hidden+blockedBy fit, still preferring involuntary lists', () => {
+    // hidden+blockedBy = MAX-1, leaving exactly one slot for the first blockedUsers id.
+    const hiddenUsers = Array.from({ length: MAX_EXCLUDED_USER_IDS - 1 }, (_, i) => i);
+    const blockedByUsers: number[] = [];
+    const blockedUsers = [800000, 800001, 800002];
+
+    const result = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
+    const resultSet = new Set(result);
+
+    expect(result.length).toBe(MAX_EXCLUDED_USER_IDS);
+    for (const id of hiddenUsers) expect(resultSet.has(id)).toBe(true);
+    // Exactly the first own-block id survives into the final slot; the rest are dropped.
+    expect(resultSet.has(800000)).toBe(true);
+    expect(resultSet.has(800001)).toBe(false);
+    expect(resultSet.has(800002)).toBe(false);
+  });
+
+  it('handles empty inputs', () => {
+    expect(boundExcludedUserIds([], [], [])).toEqual([]);
+  });
+});

--- a/src/server/utils/excluded-user-ids.ts
+++ b/src/server/utils/excluded-user-ids.ts
@@ -1,0 +1,44 @@
+// Postgres caps bind parameters at 32767. A `userId: { notIn: [...] }` (Prisma) or a
+// raw `... NOT IN (...)` is a NEGATION filter: Prisma auto-splits a positive `in` across
+// multiple queries when it exceeds the bind-parameter limit, but it CANNOT split a `notIn`,
+// so once the list crosses the limit the engine throws P2029 ("Query parameter limit
+// exceeded ... the negation filters used prevent the query from being split") and the whole
+// query 500s. `blockedByUsers` (everyone who has blocked the viewer) is unbounded, so a
+// heavily-blocked account's combined exclusion list can exceed the limit.
+//
+// 30000 leaves ~2767 bind-params of headroom below 32767 for the rest of each query (the
+// other params on these comment/bounty/user queries are each <10), so the cap is safe.
+export const MAX_EXCLUDED_USER_IDS = 30000;
+
+/**
+ * Build the bounded, de-duplicated list of user ids to exclude (via a Prisma `notIn` /
+ * raw `NOT IN`) from a query, given the viewer's three block/hidden lists.
+ *
+ * The three lists overlap heavily (a mutual block appears in BOTH `blockedUsers` and
+ * `blockedByUsers`), so we de-dupe with a Set, then cap to `MAX_EXCLUDED_USER_IDS` to keep
+ * the query under the Postgres bind-parameter limit (see the constant comment for why a
+ * `notIn` cannot be auto-split and 500s with P2029 otherwise).
+ *
+ * ORDERING IS LOAD-BEARING — DO NOT REORDER. `.slice` drops the TAIL on overflow, so the
+ * spread order is an intentional safety priority:
+ *   1. `hiddenUsers`     — the viewer's curated hide list (kept; small + viewer's intent)
+ *   2. `blockedByUsers`  — INVOLUNTARY: everyone who has blocked the viewer (harassment-
+ *                          relevant — must stay excluded so a harasser who blocked the
+ *                          viewer cannot then surface to them)
+ *   3. `blockedUsers`    — the viewer's OWN mute list (LAST, so it is sacrificed FIRST on
+ *                          overflow)
+ * On the pathological >30k-id case the viewer's own mute list is the part that may leak a
+ * few comments through — far preferable to a hard 500 that breaks the surface entirely, and
+ * deliberately preferred over leaking the involuntary blocked-by list. A future refactor
+ * MUST NOT silently reorder these spreads.
+ */
+export function boundExcludedUserIds(
+  hiddenUsers: number[],
+  blockedByUsers: number[],
+  blockedUsers: number[]
+): number[] {
+  return [...new Set([...hiddenUsers, ...blockedByUsers, ...blockedUsers])].slice(
+    0,
+    MAX_EXCLUDED_USER_IDS
+  );
+}


### PR DESCRIPTION
## Root cause

`comment.getAll` throws ~14 `INTERNAL_SERVER_ERROR` (HTTP 500) per 30 min on dp-prod. Full Prisma error pulled from Loki (`{app="civitai-dp-prod-api-primary"} |= "prisma.comment.findMany"`):

```
Invalid `prisma.comment.findMany()` invocation:

Query parameter limit exceeded error: Parameter limits for this database provider
require this query to be split into multiple queries, but the negation filters used
prevent the query from being split. Please reduce the used values in the query.
```

This is Prisma error **P2029**. Postgres caps bind parameters at 32767. Prisma auto-chunks a positive `in: [...]` list across multiple queries when it exceeds that limit, but it **cannot split a `notIn` negation** (or a raw `... NOT IN (...)`) — so it throws hard.

**What grows the list:** `excludedUserIds = [...hiddenUsers, ...blockedByUsers, ...blockedUsers]`. `BlockedByUsers` (`user-preferences.service.ts`) is **everyone who has blocked the viewer** — unbounded and not under the viewer's control. A heavily-blocked / controversial account accumulates a combined list large enough to cross the parameter limit, so the query 500s for that viewer.

**Trigger:** server-side scale (a viewer with a very large combined hidden+blocked+blocked-by set), **not** bad client input — so the fix belongs in query construction, not input validation.

## Scope (expanded)

The first commit fixed `comment.getAll` (**v1**, legacy model-discussion). An adversarial audit then found the **identical unbounded pattern on the PRIMARY commentV2 surface** — images / posts / articles / bounties comments — which had **no cap and no dedup** and 500s the same way for the same heavily-blocked viewers. That is the actual high-traffic comment path, so this PR now covers both, plus two more audit-flagged co-vulnerable sites, behind one shared helper.

## Fix

**Shared helper (one source of truth)** — `src/server/utils/excluded-user-ids.ts`:
- `boundExcludedUserIds(hidden, blockedBy, blocked)` = `[...new Set([...hidden, ...blockedBy, ...blocked])].slice(0, MAX_EXCLUDED_USER_IDS)`.
- `MAX_EXCLUDED_USER_IDS = 30000` — headroom below the 32767 cap (the other params on these queries are each <10).
- **De-dups** (mutual blocks appear in both `blockedUsers` and `blockedByUsers`) and **caps** the list so the `notIn` / raw `NOT IN` stays valid.

**Truncation order is LOAD-BEARING (documented in the helper).** The spread order — `hiddenUsers`, then `blockedByUsers` (INVOLUNTARY / harassment-relevant), then `blockedUsers` (the viewer's OWN mute list) **last** — is an intentional safety priority: `.slice` drops the **tail**, so on the pathological >30k overflow the viewer's own mute list is sacrificed **before** the involuntary blocked-by list (a harasser who blocked the viewer must stay excluded). A future refactor must not silently reorder it.

**Build sites changed:**
- `comment.service.ts` (v1 `getAll`) — refactored to call the helper (behavior identical).
- `commentv2.controller.ts` — `getCommentsThreadDetails` + `getCommentsInfinite`, so all four `commentsv2.service.ts` consumers (`notIn` ×3 + the raw `NOT IN (${Prisma.join(...)})`) get the bounded+deduped list.
- `bounty.controller.ts` `getBountyEntries` → `getAllEntriesByBountyId` (`notIn` on the unbounded blocked-by list).
- `user.controller.ts` `getAllUsers` → `getUsers` (raw `NOT IN`).

**Skipped (noted):** `model.controller.ts:1567` uses an in-memory `.includes()`, not a SQL negation — not the P2029 class. `middleware.trpc.ts` injects only the viewer's own curated `hiddenUsers` (not the unbounded involuntary blocked-by list) into many feed endpoints; capping there would change dozens of routes — out of scope.

## Test

`src/server/utils/__tests__/excluded-user-ids.test.ts` — pure-function unit test (6 cases): asserts dedup, the length cap, and that on overflow the viewer's-own `blockedUsers` entries are the ones dropped while `hiddenUsers` / `blockedByUsers` are retained (truncation-order priority pinned). **Ran locally: 6/6 passing** (vitest `unit` project, node env).

## Risk

Low. In the pathological case (combined exclusion > 30k after dedup) a few of the viewer's-own-muted users' comments may show through to that one viewer — strictly preferable to a hard 500 that breaks the surface entirely, and the order priority guarantees the involuntary blocked-by list is never the part dropped. Normal viewers (lists far below 30k) are unaffected; dedup is the only behavior change in the non-overflow case (safe/beneficial). The larger `NOT EXISTS` / anti-join rewrite is a tracked follow-up, out of scope — the cap is the agreed hotfix.

## Verification

- **Unit test ran** (6/6 pass) — the pure helper is the only part with no Prisma dependency.
- **Typecheck:** the worktree has no generated Prisma client (`prisma generate` constraint), so a full `tsc --noEmit` reports ~5249 pre-existing baseline errors with or without this change. The change adds **net +2** errors, both being the implicit-any-on-`.map((u) => u.id)` artifact of the missing Prisma types (identical to many pre-existing ones in these same files), and **zero** in the new helper file. The change is type-trivial (`number[]` in, `number[]` out).
- **Post-deploy:** in Loki, P2029 / `"the negation filters used prevent the query from being split"` errors on `civitai-dp-prod-api-primary` for `comment.findMany` **and** `commentV2.findMany` should drop to ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)