### PR TITLE
fix(images): tolerate resize-cache purge failures (post.updateImage 500s)

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -253,16 +253,37 @@ const {
 // no user should have to see images on the site that haven't been scanned or are queued for removal
 
 export async function purgeResizeCache({ url }: { url: string }) {
-  // Purge from new cache bucket
-  const { items } = await getImageS3Client().listObjects({
-    bucket: env.S3_IMAGE_CACHE_BUCKET,
-    prefix: url,
-  });
-  const keys = items.map((x) => x.Key).filter(isDefined);
-  if (keys.length) {
-    await getImageS3Client().deleteManyObjects({
+  // Best-effort: purge resized variants from the image-cache bucket. This is a
+  // cache invalidation, NOT a source-of-truth write — a stale resized variant is
+  // self-healing (re-derived on next request) and must never fail the caller's
+  // mutation. The S3 client here talks to an S3-compatible proxy
+  // (S3_IMAGE_UPLOAD_ENDPOINT); when that proxy returns a non-S3 body (e.g. a
+  // plain-text "404 page not found" from the proxy front-end), the AWS SDK's
+  // deserializer throws `char '4' is not expected.:1:1` which previously
+  // surfaced as a 500 on post.updateImage (hideMeta toggle). Swallow + log so a
+  // flaky/non-conforming cache proxy can't break image edits. (The deleteImage
+  // caller already wraps this in try/catch — this makes the contract intrinsic.)
+  try {
+    const { items } = await getImageS3Client().listObjects({
       bucket: env.S3_IMAGE_CACHE_BUCKET,
-      keys,
+      prefix: url,
+    });
+    const keys = items.map((x) => x.Key).filter(isDefined);
+    if (keys.length) {
+      await getImageS3Client().deleteManyObjects({
+        bucket: env.S3_IMAGE_CACHE_BUCKET,
+        keys,
+      });
+    }
+  } catch (err) {
+    logToAxiom({
+      type: 'warning',
+      name: 'purge-resize-cache',
+      message: 'resize-cache purge failed',
+      imageKey: url,
+      error: safeError(err),
+    }).catch(() => {
+      // swallow — best effort logging
     });
   }
 


### PR DESCRIPTION
## Root cause

`post.updateImage` throws **~63 `INTERNAL_SERVER_ERROR` (HTTP 500) per 30 min** on dp-prod. Every error in Loki has input `hideMeta:true` (sampled 30/30). That toggle is the **only** path through `updatePostImage` that calls `purgeResizeCache` (`src/server/services/post.service.ts:1339`, gated on `currentImage.hideMeta !== image.hideMeta`), which is the sole S3-touching code on the `updateImage` path.

**The deserializing call:** `purgeResizeCache` (`src/server/services/image.service.ts:255`) does:
```ts
const { items } = await getImageS3Client().listObjects({ bucket: env.S3_IMAGE_CACHE_BUCKET, prefix: url });
```
`getImageS3Client()` is an `@aws-sdk/client-s3` (smithy) client pointed at `S3_IMAGE_UPLOAD_ENDPOINT = https://s3-image-proxy.civitai.com`, bucket `S3_IMAGE_CACHE_BUCKET = civitai-media-cache` (verified from the live `civitai-cfg-primary` ConfigMap).

**Why the body starts with `'4'`:** that proxy does **not** implement the `ListObjectsV2` route. A path-style `GET /civitai-media-cache?list-type=2&prefix=...` returns a plain-text **`404 page not found`** (Go's default 404, `content-type: text/plain`, `x-content-type-options: nosniff`) — verified directly with curl. The AWS SDK v3 (`@smithy/core` schema deserializer) tries to parse that body as the expected structured/XML error response and throws:
```
char '4' is not expected.:1:1
  Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
```
(`char '4'` = the first byte of `404 page not found`; `:1:1` = parse position; the exact phrasing is `@smithy/core`'s `submodules/schema`.) The throw propagates out of the mutation as a 500 — the tRPC stack reports it via `resolveMiddleware` because the resolver is wrapped.

## Which of the 3 cases

**Case 1 (non-essential call) — tolerate it.** `purgeResizeCache` is a best-effort cache *invalidation*, not a source-of-truth write: a stale resized variant is self-healing (re-derived on next request). Evidence it's meant to be best-effort:
- its sibling image-cacher leg is already explicitly best-effort ("Never block or throw … we accept up to 4d of stale L2 entries");
- the **other caller**, `deleteImageFromS3` (`image.service.ts:323`), already wraps it in `try/catch { /* do nothing */ }`.

Only the `updatePostImage` path let it throw — it runs inside `Promise.all(cacheRefreshPromises)` with no per-call catch, and the controller maps non-`TRPCError`s to `throwDbError` → 500.

There is *also* a genuine integration fault behind it (the proxy not serving `ListObjectsV2`). I deliberately did **not** silently bury that: the catch **logs to Axiom** (`name=purge-resize-cache`) so the failure stays observable, and I call it out as a separate infra follow-up below rather than papering over a server fault.

## The fix

Wrap the S3 `listObjects`/`deleteManyObjects` in `purgeResizeCache` in a `try/catch` that logs and continues, making the best-effort contract intrinsic to the function (fixes both callers). No behavior change on success; on failure the user's image edit succeeds instead of 500-ing.

## Risk

Low. Single-file, ~20 lines, no signature/return-type change (function already returns `void`). Mirrors the existing best-effort pattern in the same function and the existing `try/catch` at the delete-path caller. Downside: while the proxy is broken, resize-cache purges are skipped — i.e. up to a stale resized variant after a hideMeta toggle (self-healing), strictly better than a 500.

## Verification

Worktree lacks `node_modules`; service tests also need `prisma generate`, so full `tsc`/tests were **not** run here. Change is isolated to one file using already-imported symbols (`logToAxiom`, `safeError`, `getImageS3Client`, `env`, `isDefined`), structurally a `try/catch` wrap.

**Post-deploy check:** the `post.updateImage` `INTERNAL_SERVER_ERROR` / "Deserialization" count in Loki —
```
{app="civitai-dp-prod-api-primary"} |= "post.updateImage" |= "Deserialization"
```
— should drop to **~0**, replaced by best-effort `name=purge-resize-cache` warnings until the proxy is fixed.

## Separate infra follow-up (not in this PR)

`s3-image-proxy.civitai.com` returning `404 page not found` for `ListObjectsV2` against `civitai-media-cache` is a real misconfiguration — resize-cache purges aren't actually running today. The proxy/bucket wiring should be fixed (or the call repointed at the real bucket endpoint) so purges work. This PR only stops that fault from breaking user image edits and makes it observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)