### PR TITLE
feat(images): flag-gated cutover to watcher-fed metric cache (default off)

### DIFF
--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -9,6 +9,10 @@ export enum FLIPT_FEATURE_FLAGS {
   ARTICLE_RATING_DISPUTE = 'article-rating-dispute',
   FEED_IMAGE_EXISTENCE = 'feed-image-existence',
   ENTITY_METRIC_NO_CACHE_BUST = 'entity-metric-no-cache-bust',
+  // When ON, image metric counts are read from the watcher-fed `metrics:*`
+  // cache (MetricService) instead of the legacy in-app `entitymetric:*` cache.
+  // Default OFF — reversible kill switch for the metrics-source cutover.
+  IMAGE_METRICS_FROM_WATCHER = 'image-metrics-from-watcher',
   FEED_POST_FILTER = 'feed-fetch-filter-in-post',
   REDIS_CLUSTER_ENHANCED_FAILOVER = 'redis-cluster-enhanced-failover',
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -4468,9 +4468,47 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
   }
 }
 
-const getImageMetricsObject = async (data: { id: number }[]) => {
+// Lazily-built MetricService over the watcher-fed `metrics:*` cache, reused
+// across calls (this is the hot feed path) rather than reconstructed per call.
+let _imageMetricService: MetricService | null = null;
+const getImageMetricService = () =>
+  (_imageMetricService ??= new MetricService(
+    clickhouse as IClickhouseClient,
+    redis as unknown as IRedisClient
+  ));
+
+type ImageMetricsObject = Awaited<ReturnType<typeof imageMetricsCache.fetch>>;
+
+const getImageMetricsObject = async (data: { id: number }[]): Promise<ImageMetricsObject> => {
   try {
-    return await imageMetricsCache.fetch(data.map((d) => d.id));
+    const ids = data.map((d) => d.id);
+
+    // Cutover kill switch. When ON, read image metrics from the watcher-fed
+    // `metrics:*` cache (MetricService). Default OFF keeps the legacy in-app
+    // `entitymetric:*` path, so merging this is a no-op; flip the flag to roll
+    // over, and flip back (then bust `metrics:*`) to revert instantly. The
+    // legacy write path is intentionally left intact so flip-back stays warm.
+    const fromWatcher = await getFliptBoolean(FLIPT_FEATURE_FLAGS.IMAGE_METRICS_FROM_WATCHER);
+    if (fromWatcher) {
+      const metrics = await getImageMetricService().fetch('Image', ids);
+      const result: ImageMetricsObject = {};
+      for (const id of ids) {
+        const m = metrics[id];
+        result[id] = {
+          imageId: id,
+          reactionLike: m?.Like || null,
+          reactionHeart: m?.Heart || null,
+          reactionLaugh: m?.Laugh || null,
+          reactionCry: m?.Cry || null,
+          comment: m?.commentCount || null,
+          collection: m?.Collection || null,
+          buzz: m?.tippedAmount || null,
+        };
+      }
+      return result;
+    }
+
+    return await imageMetricsCache.fetch(ids);
   } catch (e) {
     const error = e as Error;
     logToAxiom(


### PR DESCRIPTION
## What
Migrates the **hot image-feed metric read** (`getImageMetricsObject`, image.service.ts) from the legacy in-app `entitymetric:*` cache to the watcher-fed `metrics:*` cache (`MetricService`), **gated behind the `image-metrics-from-watcher` Flipt flag**.

**Default OFF → merging is a behavioral no-op.** This is purely the reversible plumbing.

## Why
The watcher-fed `metrics:*` cache is the future single source (the old `entitymetric:*` system double-tracks the same counts). After the doubling fix (metric-event-watcher #3) and the populate fix (event-engine-common #5), `metrics:*` is correct — this lets us cut the site feed over to it.

## Reversibility (the whole point)
- **Flip ON** → image counts come from the watcher cache.
- **Flip OFF** → instant revert to the legacy path. The legacy **write path (`updateEntityMetric`) is intentionally left intact**, so the old cache stays warm and flip-back is immediate. Bust `metrics:*` on flip-back if needed (it also self-heals from CH).
- Removal of the legacy write path + dead code is a **later phase**, once this is baked at 100%.

## Rollout plan
1. Merge (no-op, flag OFF).
2. After metric-event-watcher #3 + event-engine-common #5 are **deployed**, flip the flag for the `testers` segment, watch the **cache-drift dashboard** (`mew_cache_drift_ratio` ≈ 1.0) + spot-check counts.
3. Ramp to 100%. Flip back instantly if anything looks off.

## ⚠️ Before merge
- **Depends on event-engine-common #5.** The submodule is bumped to #5's branch commit (`9e87d87`); **re-point it to the squash-merged #5 commit** before merging this.
- **Needs a feed verify pass** with the flag ON (run the image feed, confirm counts match) — it's the highest-traffic read path.

## Validation
- `pnpm typecheck` clean (0 errors) with the bumped submodule.
- Flag default OFF → no behavior change until deliberately flipped.

Draft until #5 lands + verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)