### PR TITLE
feat(app-blocks): widen install procs moderatorProcedure→protectedProcedure (Layer 1, inert until Flipt flip)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { TRPCError } from '@trpc/server';
 
 /**
  * Coverage for `blocks.getInstallConfig` — the authenticated source the install
@@ -238,22 +237,54 @@ describe('blocks.getInstallConfig', () => {
     });
   });
 
-  // SECURITY: the gate. These FAIL if moderatorProcedure is relaxed to
-  // public/protected — the install-config (manifest internals) must stay
-  // restricted to the same audience that can install, ahead of the public
-  // launch (segment widen).
-  it('DENIES a non-mod authed caller (FORBIDDEN) — manifest lookup never runs', async () => {
+  // SECURITY: the gate. Layer 1 widened getInstallConfig moderatorProcedure →
+  // protectedProcedure (keeping enforceAppBlocksFlag), so the live control is the
+  // mod-segmented appBlocks flag, NOT a hardcoded isModerator belt. For a non-mod
+  // / anon caller the flag is OFF today → enforceAppBlocksFlag marks the query
+  // disabled → the proc fail-soft returns empty config and the manifest lookup
+  // never runs (nothing leaks pre-launch). These tests model the live (dark) flag
+  // by resolving it from the caller's mod status, mirroring the production rule.
+  function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+    return Promise.resolve(!!opts?.user?.isModerator);
+  }
+
+  it('non-mod authed caller, flag dark (live): empty config — manifest lookup never runs', async () => {
+    mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
     const caller = blocksRouter.createCaller(authedCtx(7, false) as never);
+    const out = await caller.getInstallConfig({ appBlockId: 'ab_x' });
+    expect(out).toEqual({ settings: {}, scopes: [] });
+    expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('anon caller → UNAUTHORIZED (protectedProcedure auth gate) — manifest lookup never runs', async () => {
+    // getInstallConfig is now protectedProcedure, so the auth middleware rejects
+    // an anon caller (UNAUTHORIZED) BEFORE enforceAppBlocksFlag even runs — there
+    // is no logged-in owner/installer to serve. The manifest never loads.
+    mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+    const caller = blocksRouter.createCaller(anonCtx() as never);
     await expect(caller.getInstallConfig({ appBlockId: 'ab_x' })).rejects.toMatchObject({
-      code: 'FORBIDDEN',
+      code: 'UNAUTHORIZED',
     });
     expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
   });
 
-  it('DENIES an anon caller — manifest lookup never runs', async () => {
-    const caller = blocksRouter.createCaller(anonCtx() as never);
-    await expect(caller.getInstallConfig({ appBlockId: 'ab_x' })).rejects.toBeInstanceOf(TRPCError);
-    expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
+  // Layer 1 launch behavior (post Flipt segment widen): once the flag is ON for a
+  // non-mod, getInstallConfig serves them the SAME approved-only install config a
+  // mod gets — proving it is owner-/installer-capable, not mod-gated. The
+  // approved + manifest∩approvedScopes projection is unchanged (still no leak).
+  it('non-mod authed caller WITH the flag lit: returns the approved install config', async () => {
+    mockIsAppBlocksEnabled.mockImplementation(async () => true);
+    mockDbReadAppBlockFindUnique.mockResolvedValue({
+      status: 'approved',
+      manifest: APPROVED_MANIFEST,
+      approvedScopes: ['ai:write:budgeted', 'models:read:self'],
+    });
+    const caller = blocksRouter.createCaller(authedCtx(7, false) as never);
+    const out = await caller.getInstallConfig({ appBlockId: 'ab_x' });
+    expect(out.scopes).toEqual(['ai:write:budgeted', 'models:read:self']);
+    expect(Object.keys(out.settings)).toEqual(['buzz_budget_per_gen']);
+    expect(out).not.toHaveProperty('trustTier');
+    expect(out).not.toHaveProperty('iframe');
   });
 
   it('fail-soft returns empty (no manifest lookup) when the appBlocks flag is dark', async () => {

--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -19,25 +19,35 @@ const {
   mockListAvailable,
   mockUpsertSubscription,
   mockDeleteSubscription,
+  mockInstallOnModel,
+  mockUpdateSettings,
+  mockToggleEnabled,
   mockIsAppBlocksEnabled,
   mockDbReadAppBlockFindUnique,
+  mockDbWriteModelFindUnique,
+  mockDbWriteSubscriptionFindUnique,
   mockGetUserBuzzAccounts,
 } = vi.hoisted(() => ({
   mockListUserSubscriptions: vi.fn(),
   mockListAvailable: vi.fn(),
   mockUpsertSubscription: vi.fn(),
   mockDeleteSubscription: vi.fn(async () => undefined),
+  mockInstallOnModel: vi.fn(),
+  mockUpdateSettings: vi.fn(async () => undefined),
+  mockToggleEnabled: vi.fn(async () => undefined),
   mockIsAppBlocksEnabled: vi.fn(async () => true),
   mockDbReadAppBlockFindUnique: vi.fn(),
+  mockDbWriteModelFindUnique: vi.fn(),
+  mockDbWriteSubscriptionFindUnique: vi.fn(),
   mockGetUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
 }));
 
 vi.mock('~/server/services/block-registry.service', () => ({
   BlockRegistry: {
     listForModel: vi.fn(),
-    installOnModel: vi.fn(),
-    updateSettings: vi.fn(),
-    toggleEnabled: vi.fn(),
+    installOnModel: mockInstallOnModel,
+    updateSettings: mockUpdateSettings,
+    toggleEnabled: mockToggleEnabled,
     uninstallFromModel: vi.fn(),
     listUserSubscriptions: mockListUserSubscriptions,
     listAvailable: mockListAvailable,
@@ -52,7 +62,11 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
 }));
 vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: mockDbReadAppBlockFindUnique } },
-  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+  dbWrite: {
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: mockDbWriteModelFindUnique },
+    blockUserSubscription: { findUnique: mockDbWriteSubscriptionFindUnique },
+  },
 }));
 // Mock the heavy peer modules the router imports so the import graph
 // stays cheap and we don't accidentally hit live deps.
@@ -107,6 +121,20 @@ vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
 vi.mock('~/server/services/buzz.service', () => ({
   getUserBuzzAccounts: mockGetUserBuzzAccounts,
 }));
+// blocks.router imports `rateLimit` from middleware.trpc, which transitively
+// pulls in user-preferences.service → caches.ts → tag.selector (a top-level
+// `Prisma.validator(...)` call). In a fresh worktree the generated Prisma client
+// can't be produced (NixOS engine fetch), so evaluating that chain throws at
+// import time. Mock middleware.trpc with a pass-through `rateLimit` middleware
+// (built from the real, lightweight `middleware` factory) to cut the chain —
+// rate-limiting isn't under test here. (Same shim the sibling
+// blocks.router.getInstallConfig.test.ts / flag-gate.test.ts use.)
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return {
+    rateLimit: () => middleware(({ next }) => next()),
+  };
+});
 
 import { blocksRouter } from '../blocks.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -147,7 +175,12 @@ beforeEach(() => {
   mockListAvailable.mockReset();
   mockUpsertSubscription.mockReset();
   mockDeleteSubscription.mockReset();
+  mockInstallOnModel.mockReset();
+  mockUpdateSettings.mockReset();
+  mockToggleEnabled.mockReset();
   mockDbReadAppBlockFindUnique.mockReset();
+  mockDbWriteModelFindUnique.mockReset();
+  mockDbWriteSubscriptionFindUnique.mockReset();
   mockIsAppBlocksEnabled.mockReset();
   mockIsAppBlocksEnabled.mockImplementation(async () => true);
 });
@@ -377,60 +410,28 @@ describe('blocks.deleteSubscription (guarded)', () => {
 });
 
 /**
- * Phase 2 — App Blocks is moderator-only until GA. The ~23 management
- * procedures were converted from `guardedProcedure` (= any verified, not-muted
- * user) to `moderatorProcedure` (= protectedProcedure.use(isMod)). A NON-mod
- * but otherwise-valid verified user must now get FORBIDDEN from every one of
- * them. We sample a representative spread (install management, publish-request
- * review, subscription writes, revenue reads) — they all share the same
- * procedure builder, so one regression in `moderatorProcedure` would flip the
- * whole set.
+ * Layer 1 (App Blocks launch gate-lift) — the six own-data INSTALL procedures
+ * (installOnModel, updateSettings, toggleEnabled, getInstallConfig,
+ * upsertSubscription, deleteSubscription) were widened
+ * `moderatorProcedure → protectedProcedure`, keeping `.use(enforceAppBlocksFlag)`.
+ *
+ * The change is INERT until the Flipt segment widen because the flag stays
+ * mod-segmented: a non-mod sees the flag OFF → `enforceAppBlocksFlag` throws
+ * UNAUTHORIZED before the body. Once the segment widens (flag ON for a non-mod),
+ * the procedure is OWNER-SCOPED — a non-mod OWNER can act; a non-mod NON-owner
+ * is rejected; per-user writes stamp `ctx.user.id` (never input).
+ *
+ * upsertSubscription/deleteSubscription/installOnModel were previously asserted
+ * as FORBIDDEN-for-non-mod here (the old Phase-2 mod gate). That belt is gone by
+ * design for these own-data procs; the coverage now lives in the
+ * 'Layer 1 — install procs widened to protectedProcedure' describe below. The
+ * procedures kept in THIS block (mod-review queue + revenue/apps developer reads)
+ * remain mod-gated.
  */
-describe('Phase 2 — management procedures reject non-mod verified users (FORBIDDEN)', () => {
+describe('Phase 2 — mod-only procedures reject non-mod verified users (FORBIDDEN)', () => {
   function nonMod() {
     return blocksRouter.createCaller(authedCtx(42, false) as never);
   }
-
-  it('upsertSubscription → FORBIDDEN', async () => {
-    await expect(
-      nonMod().upsertSubscription({
-        appBlockId: 'ab_x',
-        scope: 'viewer_personal',
-        targetModelTypes: null,
-        targetBaseModels: null,
-        settings: {},
-      })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    expect(mockUpsertSubscription).not.toHaveBeenCalled();
-    // The app-block lookup must not even run — isMod gates before the body.
-    expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
-  });
-
-  it('deleteSubscription → FORBIDDEN', async () => {
-    await expect(
-      nonMod().deleteSubscription({ subscriptionId: 'bus_x' })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-    expect(mockDeleteSubscription).not.toHaveBeenCalled();
-  });
-
-  // NOTE: listMySubscriptions / listMyScopeGrants / listMyAppActivity /
-  // listMyScopeInvocations + the own-data management actions (uninstallFromModel,
-  // setSubscriptionPinnedVersion) were GA-relaxed moderator→protected (gotcha
-  // #66) — they're own-data and self-scoped, so a non-mod is NO LONGER FORBIDDEN.
-  // The non-mod happy path for listMySubscriptions is asserted in the
-  // 'blocks.listMySubscriptions (guarded)' describe above. The procedures kept
-  // in this block (install/upsert/delete + the mod-review queue + revenue/apps)
-  // remain mod-gated.
-
-  it('installOnModel → FORBIDDEN', async () => {
-    await expect(
-      nonMod().installOnModel({
-        modelId: 7,
-        appBlockId: 'ab_x',
-        slotId: 'model.sidebar_top',
-      })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
-  });
 
   it('listPendingRequests (mod queue) → FORBIDDEN', async () => {
     await expect(nonMod().listPendingRequests({ limit: 20 })).rejects.toMatchObject({
@@ -450,5 +451,209 @@ describe('Phase 2 — management procedures reject non-mod verified users (FORBI
 
   it('getMyApps → FORBIDDEN', async () => {
     await expect(nonMod().getMyApps()).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});
+
+/**
+ * Layer 1 (App Blocks launch gate-lift) — the six own-data INSTALL procedures
+ * were widened `moderatorProcedure → protectedProcedure` while KEEPING
+ * `.use(enforceAppBlocksFlag)`. For each we assert the three invariants that make
+ * the swap safe + provably inert:
+ *
+ *   (a) non-mod OWNER + flag ON  → succeeds (owner-scoped, not mod-scoped);
+ *   (b) non-mod NON-owner + flag ON → authorization error (owner check holds);
+ *   (c) flag OFF → blocked (UNAUTHORIZED on mutations / empty-soft on the query),
+ *       which is the LIVE state for every non-mod today (mod-segmented flag) —
+ *       hence the change is inert until the Flipt segment widen.
+ *
+ * `fakePerUserFlag` mirrors the live mod-segmented `app-blocks-enabled` rule
+ * (ON iff the caller is a moderator) for the (c) cases; the (a)/(b) cases force
+ * the flag ON to model the post-widen world.
+ */
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped, inert until flip)', () => {
+  const OWNER_ID = 100;
+  const OTHER_ID = 200;
+
+  describe('installOnModel', () => {
+    const input = { modelId: 7, appBlockId: 'ab_x', slotId: 'model.sidebar_top' as const };
+
+    it('(a) non-mod OWNER + flag ON → installs (assertCanManageBlocks owner path)', async () => {
+      mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
+      mockInstallOnModel.mockResolvedValue({ id: 'install_1' });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await caller.installOnModel(input);
+      expect(mockInstallOnModel).toHaveBeenCalledWith(
+        expect.objectContaining({ modelId: 7, appBlockId: 'ab_x', installedByUserId: OWNER_ID })
+      );
+    });
+
+    it('(b) non-mod NON-owner + flag ON → UNAUTHORIZED, never installs', async () => {
+      mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
+      const caller = blocksRouter.createCaller(authedCtx(OTHER_ID, false) as never);
+      await expect(caller.installOnModel(input)).rejects.toBeInstanceOf(TRPCError);
+      expect(mockInstallOnModel).not.toHaveBeenCalled();
+    });
+
+    it('(c) flag OFF (live for a non-mod) → UNAUTHORIZED before the body, never installs', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.installOnModel(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      expect(mockDbWriteModelFindUnique).not.toHaveBeenCalled();
+      expect(mockInstallOnModel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateSettings', () => {
+    const input = { blockInstanceId: 'bus_pinned', settings: { foo: 'bar' } };
+
+    it('(a) non-mod OWNER + flag ON → updates (resolves model → owner check passes)', async () => {
+      mockDbWriteSubscriptionFindUnique.mockResolvedValue({ targetModelIds: [7] });
+      mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      const out = await caller.updateSettings(input);
+      expect(out).toEqual({ ok: true });
+      expect(mockUpdateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ blockInstanceId: 'bus_pinned', modelId: 7 })
+      );
+    });
+
+    it('(b) non-mod NON-owner + flag ON → UNAUTHORIZED, never updates', async () => {
+      mockDbWriteSubscriptionFindUnique.mockResolvedValue({ targetModelIds: [7] });
+      mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
+      const caller = blocksRouter.createCaller(authedCtx(OTHER_ID, false) as never);
+      await expect(caller.updateSettings(input)).rejects.toBeInstanceOf(TRPCError);
+      expect(mockUpdateSettings).not.toHaveBeenCalled();
+    });
+
+    it('(c) flag OFF (live for a non-mod) → UNAUTHORIZED before the body', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.updateSettings(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      expect(mockDbWriteSubscriptionFindUnique).not.toHaveBeenCalled();
+      expect(mockUpdateSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleEnabled', () => {
+    const input = { blockInstanceId: 'bus_pinned', enabled: false };
+
+    it('(a) non-mod OWNER + flag ON → toggles (owner check on resolved model)', async () => {
+      mockDbWriteSubscriptionFindUnique.mockResolvedValue({
+        appBlockId: 'ab_x',
+        slotId: 'model.sidebar_top',
+        targetModelIds: [7],
+      });
+      mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      const out = await caller.toggleEnabled(input);
+      expect(out).toEqual({ ok: true });
+      expect(mockToggleEnabled).toHaveBeenCalledWith(
+        expect.objectContaining({ modelId: 7, appBlockId: 'ab_x', enabled: false })
+      );
+    });
+
+    it('(b) non-mod NON-owner + flag ON → UNAUTHORIZED before mutating', async () => {
+      mockDbWriteSubscriptionFindUnique.mockResolvedValue({
+        appBlockId: 'ab_x',
+        slotId: 'model.sidebar_top',
+        targetModelIds: [7],
+      });
+      mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
+      const caller = blocksRouter.createCaller(authedCtx(OTHER_ID, false) as never);
+      await expect(caller.toggleEnabled(input)).rejects.toBeInstanceOf(TRPCError);
+      expect(mockToggleEnabled).not.toHaveBeenCalled();
+    });
+
+    it('(c) flag OFF (live for a non-mod) → UNAUTHORIZED before the body', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.toggleEnabled(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      expect(mockDbWriteSubscriptionFindUnique).not.toHaveBeenCalled();
+      expect(mockToggleEnabled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('upsertSubscription', () => {
+    const input = {
+      appBlockId: 'ab_x',
+      scope: 'viewer_personal' as const,
+      targetModelTypes: null,
+      targetBaseModels: null,
+      settings: {},
+    };
+
+    it('(a) non-mod OWNER (the caller) + flag ON → upserts, stamping ctx.user.id (NOT input)', async () => {
+      mockDbReadAppBlockFindUnique.mockResolvedValue({
+        blockId: 'g',
+        status: 'approved',
+        approvedScopes: [],
+        manifest: {},
+      });
+      mockUpsertSubscription.mockResolvedValue({ id: 'bus_new' });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await caller.upsertSubscription(input);
+      // userId is stamped server-side from the session, never from input.
+      expect(mockUpsertSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: OWNER_ID, appBlockId: 'ab_x' })
+      );
+    });
+
+    it('(b) non-mod + flag ON + app NOT approved → BAD_REQUEST, never upserts', async () => {
+      // The "owner" boundary for a per-user subscription is the approved-app gate
+      // + the session-stamped userId; a non-approved app is rejected outright.
+      mockDbReadAppBlockFindUnique.mockResolvedValue({ blockId: 'g', status: 'pending' });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.upsertSubscription(input)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    });
+
+    it('(c) flag OFF (live for a non-mod) → UNAUTHORIZED before the body', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.upsertSubscription(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
+      expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteSubscription', () => {
+    const input = { subscriptionId: 'bus_x' };
+
+    it('(a) non-mod OWNER + flag ON → forwards subscriptionId + session userId to the owner-checking service', async () => {
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      const out = await caller.deleteSubscription(input);
+      expect(out).toEqual({ ok: true });
+      // The service rejects when existing.userId !== opts.userId; the router
+      // always passes ctx.user.id (never an input userId), so a non-mod can only
+      // delete their OWN subscription.
+      expect(mockDeleteSubscription).toHaveBeenCalledWith({
+        subscriptionId: 'bus_x',
+        userId: OWNER_ID,
+      });
+    });
+
+    it('(b) non-mod NON-owner + flag ON → service throws authorization, surfaced by the router', async () => {
+      // Model the service-layer owner check (existing.userId !== opts.userId).
+      mockDeleteSubscription.mockRejectedValue(
+        new TRPCError({ code: 'UNAUTHORIZED', message: 'Not the subscription owner' })
+      );
+      const caller = blocksRouter.createCaller(authedCtx(OTHER_ID, false) as never);
+      await expect(caller.deleteSubscription(input)).rejects.toBeInstanceOf(TRPCError);
+      expect(mockDeleteSubscription).toHaveBeenCalledWith({
+        subscriptionId: 'bus_x',
+        userId: OTHER_ID,
+      });
+    });
+
+    it('(c) flag OFF (live for a non-mod) → UNAUTHORIZED before the body', async () => {
+      mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.deleteSubscription(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      expect(mockDeleteSubscription).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -308,7 +308,7 @@ export const blocksRouter = router({
       });
     }),
 
-  installOnModel: moderatorProcedure
+  installOnModel: protectedProcedure
     .use(enforceAppBlocksFlag)
     .input(
       z.object({
@@ -326,7 +326,7 @@ export const blocksRouter = router({
       });
     }),
 
-  updateSettings: moderatorProcedure
+  updateSettings: protectedProcedure
     .use(enforceAppBlocksFlag)
     .input(
       z.object({
@@ -347,7 +347,7 @@ export const blocksRouter = router({
    * so the NOT EXISTS subquery in listForModel suppresses platform defaults
    * for the same app_block_id. See plan §4 invariant.
    */
-  toggleEnabled: moderatorProcedure
+  toggleEnabled: protectedProcedure
     .use(enforceAppBlocksFlag)
     .input(
       z.object({
@@ -1136,7 +1136,7 @@ export const blocksRouter = router({
    * `validateBlockSettings`). The client never becomes the source of truth for
    * what gets persisted.
    */
-  getInstallConfig: moderatorProcedure
+  getInstallConfig: protectedProcedure
     .use(enforceAppBlocksFlag)
     .input(z.object({ appBlockId: z.string().min(1).max(64) }))
     .query(async ({ ctx, input }) => {
@@ -1189,7 +1189,7 @@ export const blocksRouter = router({
    * (mirrors per-model install row shape); `viewer_personal` is a viewer
    * write (mirrors per-viewer override row shape).
    */
-  upsertSubscription: moderatorProcedure
+  upsertSubscription: protectedProcedure
     .use(enforceAppBlocksFlag)
     .input(
       z.object({
@@ -1247,7 +1247,7 @@ export const blocksRouter = router({
    * (already deleted is a success); rows owned by another user raise
    * authorization at the service layer.
    */
-  deleteSubscription: moderatorProcedure
+  deleteSubscription: protectedProcedure
     .use(enforceAppBlocksFlag)
     .input(z.object({ subscriptionId: z.string().min(1).max(64) }))
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## What

Widen the **six own-data App Blocks INSTALL procedures** in `src/server/routers/blocks.router.ts` from `moderatorProcedure` → `protectedProcedure`, keeping `.use(enforceAppBlocksFlag)` byte-for-byte on each and the rest of every procedure unchanged:

1. `installOnModel`
2. `updateSettings`
3. `toggleEnabled`
4. `getInstallConfig`
5. `upsertSubscription`
6. `deleteSubscription`

Minimal diff: just the base-procedure swap on those six (no shared procedure, no refactor). `moderatorProcedure` stays imported and is still used by the out-of-scope mod procs.

## 1. Inert until the Flipt flip

This is a **provably zero-behavior-change merge** today. `enforceAppBlocksFlag` stays on all six. The Flipt `app-blocks-enabled` flag is **base-off + mod-segment**, so a non-mod sees the flag OFF → `enforceAppBlocksFlag` throws `UNAUTHORIZED` (mutations) / fail-soft empty (the `getInstallConfig` query) **before the body runs**. Anon callers on the now-`protectedProcedure` procs are rejected by the auth middleware first. Nothing widens until a **separate, deliberate Flipt segment widen** at launch.

It closes a real client/server skew (the `/apps/installed` + install surfaces already gate per-user on `features.appBlocks`, but these procs were still mod-only) and shrinks the eventual launch diff.

## 2. Owner-scoping verified per-proc (independent of the mod belt)

Confirmed by reading each body + helper, so a non-mod **owner** is the only non-mod who can act and a non-mod **non-owner** is rejected:

- **installOnModel** + **updateSettings** → `assertCanManageBlocks(ctx, modelId)` (mod → allow; else `dbWrite.model.findUnique` and require `row.userId === ctx.user.id`). `updateSettings` resolves the modelId from the pinned subscription first.
- **toggleEnabled** → resolves the model from the subscription, then calls `assertCanManageBlocks` **before** `BlockRegistry.toggleEnabled` mutates.
- **upsertSubscription** → stamps `userId: ctx.user!.id` (server-side, **not** from input) and requires the app `status === 'approved'` (else `BAD_REQUEST`).
- **deleteSubscription** → forwards `userId: ctx.user!.id`; `BlockRegistry.deleteSubscription` rejects when `existing.userId !== opts.userId`.
- **getInstallConfig** → returns only `status === 'approved'` data (404 otherwise) and the **`manifest ∩ approvedScopes`** public subset — no mod-only/internal fields (`trustTier`, internal `iframe.src`, raw manifest) leak.

No owner-scoping was weakened; no rate-limit / muted-user checks added (deliberately deferred).

## 3. Explicitly NOT the launch

Still required before flipping the Flipt segment:
- **Layer 2** — runtime workflow procs (`submitWorkflow`/`estimateWorkflow`/`pollWorkflow`/`cancelWorkflow`/`updateUserSettings`) keep their `assertViewerIsModerator` belt (gated on the separate **Buzz-GA** product decision).
- **Layer 3** — `apps.router` storage mod belt.
- Pre-flip hardening — **rate-limiting** + **muted-user** checks on the widened install procs.

## Tests

Extended the router unit suites (`blocks.router.subscriptions.test.ts`, `blocks.router.getInstallConfig.test.ts`) with Layer-1 coverage for all six: (a) non-mod **owner** + flag-on → succeeds; (b) non-mod **non-owner** + flag-on → authorization error; (c) flag-off → blocked (`UNAUTHORIZED` / fail-soft / anon `UNAUTHORIZED`). Reused the existing mock patterns. Added the `middleware.trpc` `rateLimit` pass-through shim to the subscriptions suite (mirrors the sibling `getInstallConfig`/`flag-gate` suites) so it loads without a generated Prisma client.

Local unit run (node-only vitest, the 3 touched suites): **55 passed / 0 failed**. The authoritative type gate is Tekton's `typecheck` (local tsc is broken on NixOS). The sibling `blocks.router.workflow.test.ts` fails locally with a pre-existing `Prisma.validator` import-chain error on the unmodified base too — out of scope (Layer 2) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)