### PR TITLE
fix(redis): stringify numeric values in atomic hSet helpers (sysRedis token-write incident)

### DIFF
--- a/src/server/redis/__tests__/atomic.test.ts
+++ b/src/server/redis/__tests__/atomic.test.ts
@@ -38,7 +38,12 @@ describe('hSetWithTTL', () => {
   it('stringifies numeric values', async () => {
     const client = mockClient();
     await hSetWithTTL(client, 'k', 'f', 42, 1000);
-    expect(client.eval.mock.calls[0][1].arguments).toEqual(['f', 42, '1000']);
+    // node-redis v5 EVAL rejects raw numbers ("arguments[N] must be of type
+    // string | Buffer, got number") — numeric values MUST be stringified.
+    expect(client.eval.mock.calls[0][1].arguments).toEqual(['f', '42', '1000']);
+    for (const arg of client.eval.mock.calls[0][1].arguments) {
+      expect(typeof arg === 'string' || Buffer.isBuffer(arg)).toBe(true);
+    }
   });
 
   it('forwards Buffer values without coercion (msgpack-packed write path)', async () => {
@@ -90,6 +95,16 @@ describe('hSetMultiWithTTL', () => {
       'invalid',
       'refresh',
     ]);
+  });
+
+  it('stringifies numeric values (node-redis v5 EVAL rejects raw numbers)', async () => {
+    const client = mockClient();
+    await hSetMultiWithTTL(client, 'k', { 'f-1': 42, 'f-2': 'v' }, 1000);
+    // ARGV: [ttl, count, ...fields, ...values] — numeric value must be '42'
+    expect(client.eval.mock.calls[0][1].arguments).toEqual(['1000', '2', 'f-1', 'f-2', '42', 'v']);
+    for (const arg of client.eval.mock.calls[0][1].arguments) {
+      expect(typeof arg === 'string' || Buffer.isBuffer(arg)).toBe(true);
+    }
   });
 
   it('no-ops on empty input (avoids EVAL with zero fields)', async () => {

--- a/src/server/redis/atomic.ts
+++ b/src/server/redis/atomic.ts
@@ -120,7 +120,7 @@ export async function hSetWithTTL(
   // simplicity — at runtime node-redis accepts Buffer here too.
   await client.eval(script, {
     keys: [key],
-    arguments: [field, value as unknown as string, String(ttlMs)],
+    arguments: [field, (typeof value === 'number' ? String(value) : value) as unknown as string, String(ttlMs)],
   });
 }
 
@@ -175,7 +175,7 @@ export async function hSetMultiWithTTL(
     String(ttlMs),
     String(entries.length),
     ...fieldNames,
-    ...entries.map(([, v]) => v as unknown as string),
+    ...entries.map(([, v]) => (typeof v === 'number' ? String(v) : v) as unknown as string),
   ];
 
   const script = `


### PR DESCRIPTION
## Production incident (2026-06-16, dp-prod)

**Symptom:** ~1hr of elevated 499s on civitai-dp-prod (~2400/10min, up ~10× from baseline), client requests hanging a flat **~125s** across many tRPC endpoints, then the client gives up (499). No 504s, no pod restarts, server dep-health all green.

**Root cause:** `hSetWithTTL` / `hSetMultiWithTTL` (`src/server/redis/atomic.ts`) passed numeric `value`s straight to node-redis v5's EVAL (`value as unknown as string` — a *type cast*, not a runtime coercion), despite the doc comment claiming "We coerce numbers via String()". node-redis v5 rejects raw numbers:
```
TypeError: "arguments[5]" must be of type "string | Buffer", got number
  at encodeCommand (@redis/client/.../encoder.js)
```
`setToken` (auth token-refresh, runs on ~every authenticated request) calls `hSetWithTTL` with a numeric value → this threw **~100k/10min fleet-wide** (logged `sysredis-fail-open` / `tracking-write-cliff`). Fail-open keeps most requests alive, but the repeated encoder throw **corrupted one pod's shared redis command queue**, wedging it — every redis-touching request on that pod hung ~125s → the 499 storm (96% concentrated on the single wedged pod). Introduced by #2332 (`atomic hSet+TTL helper`), which is in the `ece0035` deploy but not the prior `96ea184`.

**Acute mitigation (already applied):** deleted the wedged pod → 499s dropped 230→38/min immediately.

## Fix

Coerce numeric values to strings at both EVAL call sites. Buffer + string pass through unchanged (msgpack-packed write path preserved). `zAddWithTTL` already stringified its score → unaffected.

## Test

The existing unit test **enshrined the bug** — it asserted `arguments == ['f', 42, '1000']` (value left a number) against a bare `vi.fn()` mock that never enforced node-redis's string requirement. Corrected to assert stringification + that every ARGV element is `string | Buffer`, for both helpers (couldn't run vitest in the worktree — no node_modules; assertions are straightforward).

## Deploy note

This is the root-cause forward-fix. The acute incident is already mitigated by the pod delete. If pods re-wedge before this builds/deploys, deleting the wedged pod is the documented relief, or pin Flux to `96ea184` (clean — predates #2332) for immediate fleet-wide relief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)