### PR TITLE
fix(redis/atomic): stringify numeric values before EVAL (regression from #2332)

### DIFF
--- a/src/server/redis/__tests__/atomic.test.ts
+++ b/src/server/redis/__tests__/atomic.test.ts
@@ -35,10 +35,18 @@ describe('hSetWithTTL', () => {
     expect(options.arguments).toEqual(['field-1', 'value-1', '5000']);
   });
 
-  it('stringifies numeric values', async () => {
+  // REGRESSION GUARD (#2332-hotfix): the original cut shipped with
+  // `value as unknown as string`, leaving numeric values as runtime numbers
+  // when they reached node-redis's encodeCommand — which then crashed on
+  // every `setToken(userId, Date.now(), ...)` call in prod. The fail-open
+  // wrappers absorbed the throws (no user-visible 500s) but every
+  // session/token write SILENTLY DROPPED, leaving sysRedis out-of-sync
+  // until rollback. This test must keep the asserted `'42'` (string) shape;
+  // if it ever flips back to `42` (number), the regression is back.
+  it('stringifies numeric values before reaching node-redis encodeCommand', async () => {
     const client = mockClient();
     await hSetWithTTL(client, 'k', 'f', 42, 1000);
-    expect(client.eval.mock.calls[0][1].arguments).toEqual(['f', 42, '1000']);
+    expect(client.eval.mock.calls[0][1].arguments).toEqual(['f', '42', '1000']);
   });
 
   it('forwards Buffer values without coercion (msgpack-packed write path)', async () => {
@@ -96,6 +104,27 @@ describe('hSetMultiWithTTL', () => {
     const client = mockClient();
     await hSetMultiWithTTL(client, 'k', {}, 1000);
     expect(client.eval).not.toHaveBeenCalled();
+  });
+
+  // REGRESSION GUARD (#2332-hotfix): same numeric-value bug as the
+  // single-field hSetWithTTL had. Each value in the entries map was cast
+  // `as unknown as string` without runtime coercion, crashing on any
+  // numeric value (e.g. token timestamps in session-invalidation).
+  it('stringifies numeric values + forwards Buffer values unchanged', async () => {
+    const client = mockClient();
+    const packed = Buffer.from([0x80]);
+    await hSetMultiWithTTL(
+      client,
+      'k',
+      { 'token-num': 123, 'token-str': 'str', 'token-buf': packed },
+      10_000
+    );
+    const args = client.eval.mock.calls[0][1].arguments;
+    // ARGV: [ttl, count, ...fieldNames, ...values]
+    expect(args.slice(0, 5)).toEqual(['10000', '3', 'token-num', 'token-str', 'token-buf']);
+    expect(args[5]).toEqual('123'); // number → string
+    expect(args[6]).toEqual('str'); // string → string
+    expect(args[7]).toBe(packed); // Buffer → Buffer (reference identity)
   });
 
   // PR #2332 round-3 guard — see hSetWithTTL twin test above.

--- a/src/server/redis/atomic.ts
+++ b/src/server/redis/atomic.ts
@@ -78,6 +78,24 @@ type EvalCapableClient = {
 };
 
 /**
+ * Coerce a `string | number | Buffer` argument to something node-redis v5's
+ * `encodeCommand` will accept (a string or a Buffer). Numbers MUST be
+ * stringified here; passing one through reaches encodeCommand at
+ * `node_modules/@redis/client/dist/lib/RESP/encoder.js` which then throws
+ * `RangeError: "Cannot read properties of undefined"` (the encoder dispatches
+ * on the argument's `.length` after assuming string|Buffer). This was the
+ * regression in #2332's first cut: `value as unknown as string` is a TS-only
+ * lie, leaving the runtime number value to crash on every `setToken`-style
+ * call where the caller passes `Date.now()`.
+ *
+ * Buffers pass through unchanged — `.toString()` would default to UTF-8 and
+ * mangle binary content from msgpack-packed call sites.
+ */
+function toRedisArg(v: string | number | Buffer): string | Buffer {
+  return typeof v === 'number' ? String(v) : v;
+}
+
+/**
  * Atomically set a single hash field's value AND its TTL.
  *
  * Atomicity caveat: the script's HSET and HPEXPIRE are independent
@@ -115,12 +133,12 @@ export async function hSetWithTTL(
     return 1
   `;
   // node-redis v5 EVAL options take RedisArgument[] (string | Buffer). We
-  // coerce numbers via String(); Buffer is passed through. We cast to
+  // coerce numbers via toRedisArg(); Buffer is passed through. We cast to
   // string[] because the EvalCapableClient shape declares string[] for
   // simplicity — at runtime node-redis accepts Buffer here too.
   await client.eval(script, {
     keys: [key],
-    arguments: [field, value as unknown as string, String(ttlMs)],
+    arguments: [field, toRedisArg(value) as unknown as string, String(ttlMs)],
   });
 }
 
@@ -175,7 +193,7 @@ export async function hSetMultiWithTTL(
     String(ttlMs),
     String(entries.length),
     ...fieldNames,
-    ...entries.map(([, v]) => v as unknown as string),
+    ...entries.map(([, v]) => toRedisArg(v) as unknown as string),
   ];
 
   const script = `


### PR DESCRIPTION
## Summary

Production hotfix for the regression introduced by #2332. Every authenticated request's `setToken` / `trackToken` / `invalidateToken` write was silently dropping — fail-open wrappers added in round-3/4 absorbed the throws so no 5xx surfaced, but sysRedis session state stopped converging.

## Root cause

`atomic.ts:123` (and `:178` for the multi-field variant) cast `value as unknown as string` — a TypeScript-only assertion. At runtime, when callers like `auth/token-refresh.ts:setToken` pass `Date.now()` (a number), node-redis v5's `encodeCommand` receives the actual JS number and throws because it expects `string | Buffer`. `ttlMs` was stringified via `String(ttlMs)`; `value` was not.

## Detection

- legacy sysRedis `cmdstat_eval`: ~7/sec dispatches but 0 successful HSETs from inside Lua
- `write-degraded` fail-open subtype in Loki: 527/2h (vs 0 before deploy)
- 0 user-visible 5xx because the round-3/4 wrappers caught every throw

## Fix

A 3-line `toRedisArg(v: string | number | Buffer): string | Buffer` helper that stringifies numbers and passes strings + Buffers through unchanged. Applied at both `hSetWithTTL` and `hSetMultiWithTTL` value sites.

## Tests

- Regression guard: the existing `'stringifies numeric values'` test asserted the BROKEN shape (`['f', 42, '1000']`). Corrected to `['f', '42', '1000']` with a load-bearing comment so the assertion can't silently flip back.
- New test for `hSetMultiWithTTL` covering number + string + Buffer in one call.
- 11/11 atomic tests pass. 14/14 broader auth/middleware tests pass.

## Rollback target

`civitai-prod:96ea184` is the version-bump immediately before #2332. Clean rollback if redeploy can't ship in time.