### PR TITLE
feat(app-blocks): publisher revenue payout — separate Tipalti rail, pull model (DARK)

### DIFF
--- a/prisma/migrations/20260616130000_payout2_block_payout_withdrawal/migration.sql
+++ b/prisma/migrations/20260616130000_payout2_block_payout_withdrawal/migration.sql
@@ -1,0 +1,67 @@
+-- ============================================================
+-- PAYOUT-2 — block_payout_withdrawal tracking table
+-- ============================================================
+-- Tracking record for the App Blocks publisher revenue-share DISBURSEMENT
+-- (the "separate rail" pull-model withdrawal added in PR1). One row per
+-- `withdrawAppRevenue` attempt.
+--
+-- This is the App-Blocks analogue of "CashWithdrawal", kept on its OWN table
+-- so app-revenue payouts are NEVER conflated with creator-program cash
+-- withdrawals. The disbursement nets confirmed `block_buzz_attribution` share
+-- and pays it via Tipalti WITHOUT ever touching the externally-owned Buzz cash
+-- accounts (cashSettled/cashPending) or the creator-program pool — that
+-- separation is the whole point of the separate rail (avoids the pool cap +
+-- 30% fee; preserves the Tipalti 1099-NEC path).
+--
+-- MANUAL APPLY ONLY: per the datapacket-talos repo rule, App-Blocks / civitai
+-- migrations are NOT auto-applied by CI/deploy. A human applies this SQL to
+-- each environment (prod nvme0 + the dev clone). `_prisma_migrations` is not
+-- the source of truth here.
+--
+-- DARK: this table is only written by `withdrawAppRevenue`, which refuses
+-- unless the `app-blocks-payout-enabled` Flipt flag is on (defaults closed).
+-- Creating the table moves no money and changes no behaviour on its own.
+
+BEGIN;
+
+CREATE TABLE "block_payout_withdrawal" (
+  -- Application-generated id: 'bpw_<ulid>'. Also the Tipalti refCode source.
+  "id"                 TEXT PRIMARY KEY,
+  "app_owner_user_id"  INTEGER NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT,
+  -- Links to the block_attribution_payout ledger row this disbursement
+  -- realized. ON DELETE SET NULL so a compensating revert (which deletes the
+  -- ledger row) does not also delete the audit record of the failed attempt.
+  "payout_id"          TEXT REFERENCES "block_attribution_payout"("id") ON DELETE SET NULL,
+  -- Net publisher share disbursed, in USD cents (matches the minted ledger
+  -- row's total_cents). Tipalti is paid cents/100.
+  "amount_cents"       INTEGER NOT NULL,
+  -- Tipalti CashWithdrawalMethod snapshot.
+  "method"             TEXT NOT NULL,
+  -- Tipalti refCode (== id truncated to 16 chars by getWithdrawalRefCode).
+  "ref_code"           TEXT NOT NULL,
+  -- 'pending_approval' (Tipalti batch created, awaiting mod approval) or
+  -- 'reverted' (disbursement failed after the mint; mint was compensated and
+  -- the publisher's balance restored — kept for audit).
+  "status"             TEXT NOT NULL DEFAULT 'pending_approval',
+  "payment_batch_id"   TEXT,
+  "note"               TEXT,
+  "created_at"         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT "block_payout_withdrawal_amount_positive_check"
+    CHECK ("amount_cents" > 0),
+  CONSTRAINT "block_payout_withdrawal_status_check"
+    CHECK ("status" IN ('pending_approval', 'reverted')),
+  CONSTRAINT "block_payout_withdrawal_id_length_check"
+    CHECK (char_length("id") BETWEEN 20 AND 48)
+);
+
+-- Publisher withdrawal history lookup (newest first).
+CREATE INDEX "bpw_owner_created_idx"
+  ON "block_payout_withdrawal" ("app_owner_user_id", "created_at" DESC);
+
+-- Find the withdrawal that realized a given payout ledger row.
+CREATE INDEX "bpw_payout_idx"
+  ON "block_payout_withdrawal" ("payout_id");
+
+COMMIT;

--- a/prisma/migrations/20260616130000_payout2_block_payout_withdrawal/migration.sql
+++ b/prisma/migrations/20260616130000_payout2_block_payout_withdrawal/migration.sql
@@ -25,7 +25,8 @@
 BEGIN;
 
 CREATE TABLE "block_payout_withdrawal" (
-  -- Application-generated id: 'bpw_<ulid>'. Also the Tipalti refCode source.
+  -- Application-generated id: 'bpw_<ulid>'. The Tipalti refCode (ref_code) is
+  -- derived from it (prefix 'BPW' + the ULID tail, 16 chars).
   "id"                 TEXT PRIMARY KEY,
   "app_owner_user_id"  INTEGER NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT,
   -- Links to the block_attribution_payout ledger row this disbursement
@@ -37,21 +38,32 @@ CREATE TABLE "block_payout_withdrawal" (
   "amount_cents"       INTEGER NOT NULL,
   -- Tipalti CashWithdrawalMethod snapshot.
   "method"             TEXT NOT NULL,
-  -- Tipalti refCode (== id truncated to 16 chars by getWithdrawalRefCode).
+  -- App-Blocks-rail Tipalti refCode (prefix 'BPW', 16 chars, derived from id).
+  -- The full refCode is stored + indexed so the webhook reconciles by exact
+  -- match (the refCode is NOT round-trippable into the id — Tipalti 16-char cap).
   "ref_code"           TEXT NOT NULL,
-  -- 'pending_approval' (Tipalti batch created, awaiting mod approval) or
-  -- 'reverted' (disbursement failed after the mint; mint was compensated and
-  -- the publisher's balance restored — kept for audit).
-  "status"             TEXT NOT NULL DEFAULT 'pending_approval',
+  -- The refCode Tipalti echoes back on the created payment batch. Persisted so
+  -- reconciliation can match either what we sent or what Tipalti returned.
+  "payment_ref_code"   TEXT,
+  -- State machine (see schema.full.prisma for the full doc):
+  --   'processing'       — row created; mint/Tipalti in progress.
+  --   'pending_approval' — Tipalti batch created, awaiting mod approval.
+  --   'completed'        — payment approved/completed (terminal, money sent).
+  --   'failed'           — disbursement/mint failed OR Tipalti declined; mint
+  --                        reverted + balance restored (terminal).
+  --   'no_balance'       — nothing to disburse at mint time (terminal, no money).
+  "status"             TEXT NOT NULL DEFAULT 'processing',
   "payment_batch_id"   TEXT,
   "note"               TEXT,
   "created_at"         TIMESTAMPTZ NOT NULL DEFAULT now(),
   "updated_at"         TIMESTAMPTZ NOT NULL DEFAULT now(),
 
-  CONSTRAINT "block_payout_withdrawal_amount_positive_check"
-    CHECK ("amount_cents" > 0),
+  -- amount_cents starts at 0 ('processing' before the mint claims rows) and is
+  -- set to the minted total on disburse, so the floor is >= 0 (not > 0).
+  CONSTRAINT "block_payout_withdrawal_amount_nonneg_check"
+    CHECK ("amount_cents" >= 0),
   CONSTRAINT "block_payout_withdrawal_status_check"
-    CHECK ("status" IN ('pending_approval', 'reverted')),
+    CHECK ("status" IN ('processing', 'pending_approval', 'completed', 'failed', 'no_balance')),
   CONSTRAINT "block_payout_withdrawal_id_length_check"
     CHECK (char_length("id") BETWEEN 20 AND 48)
 );
@@ -63,5 +75,9 @@ CREATE INDEX "bpw_owner_created_idx"
 -- Find the withdrawal that realized a given payout ledger row.
 CREATE INDEX "bpw_payout_idx"
   ON "block_payout_withdrawal" ("payout_id");
+
+-- Webhook reconciliation: look up the row by the Tipalti refCode (exact match).
+CREATE INDEX "bpw_ref_code_idx"
+  ON "block_payout_withdrawal" ("ref_code");
 
 COMMIT;

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -548,6 +548,7 @@ model User {
   blockBuzzAttributionsAsPurchaser BlockBuzzAttribution[]    @relation("BlockBuzzAttributionPurchaser")
   blockBuzzAttributionsAsAppOwner  BlockBuzzAttribution[]    @relation("BlockBuzzAttributionAppOwner")
   blockAttributionPayouts          BlockAttributionPayout[]  @relation("BlockAttributionPayoutOwner")
+  blockPayoutWithdrawals           BlockPayoutWithdrawal[]   @relation("BlockPayoutWithdrawalOwner")
   publishRequestsSubmitted   AppBlockPublishRequest[]        @relation("PublishRequestSubmitter")
   publishRequestsReviewed    AppBlockPublishRequest[]        @relation("PublishRequestReviewer")
   blockScopeInvocations      BlockScopeInvocation[]
@@ -2529,6 +2530,52 @@ model BlockAttributionPayout {
   @@unique([appOwnerUserId, periodKey], map: "block_attribution_payout_owner_period_uniq")
   @@index([appOwnerUserId, createdAt(sort: Desc)], map: "bap_owner_created_idx")
   @@map("block_attribution_payout")
+}
+
+/// PR1 (pull model) — tracking record for a publisher revenue-share
+/// DISBURSEMENT via Tipalti. One row per `withdrawAppRevenue` attempt.
+///
+/// This is the App-Blocks analogue of `CashWithdrawal`, but kept on its OWN
+/// table so app-revenue payouts (the "separate rail" that nets confirmed
+/// `block_buzz_attribution` share and pays it out WITHOUT ever touching the
+/// externally-owned Buzz cash accounts / creator-program pool) are never
+/// conflated with creator-program cash withdrawals.
+///
+/// `payoutId` links to the `block_attribution_payout` ledger row this
+/// disbursement realized. `status`:
+///   - 'pending_approval' — Tipalti payment batch created, waiting on the
+///     moderator-approval step (mirrors CashWithdrawal's terminal state here).
+///   - 'reverted'         — Tipalti (or this record's write) failed AFTER the
+///     mint; the mint was compensated (rows un-flipped, ledger row deleted) and
+///     the publisher's balance restored. Kept for audit.
+///
+/// Application-generated id (`bpw_<ulid>`), which is also the Tipalti refCode
+/// source — so the whole flow is retryable/idempotent off one id.
+model BlockPayoutWithdrawal {
+  id             String   @id
+  appOwnerUserId Int      @map("app_owner_user_id")
+  appOwner       User     @relation("BlockPayoutWithdrawalOwner", fields: [appOwnerUserId], references: [id], onDelete: Restrict)
+  /// Links to the block_attribution_payout ledger row minted for this
+  /// disbursement. NULL only transiently before the mint (never persisted NULL
+  /// on a row that reached Tipalti).
+  payoutId       String?  @map("payout_id")
+  /// Net publisher share disbursed, in USD cents (matches the minted ledger
+  /// row's total_cents). Tipalti is paid cents/100.
+  amountCents    Int      @map("amount_cents")
+  /// Tipalti CashWithdrawalMethod used (snapshot of the payable method).
+  method         String
+  /// Tipalti refCode (== id, truncated to 16 chars by getWithdrawalRefCode).
+  refCode        String   @map("ref_code")
+  status         String   @default("pending_approval")
+  /// Tipalti paymentBatchId once the batch is created.
+  paymentBatchId String?  @map("payment_batch_id")
+  note           String?
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@index([appOwnerUserId, createdAt(sort: Desc)], map: "bpw_owner_created_idx")
+  @@index([payoutId], map: "bpw_payout_idx")
+  @@map("block_payout_withdrawal")
 }
 
 /// W5 v0.5 audit log — one row per successful scope-gated API call from

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2542,31 +2542,43 @@ model BlockAttributionPayout {
 /// conflated with creator-program cash withdrawals.
 ///
 /// `payoutId` links to the `block_attribution_payout` ledger row this
-/// disbursement realized. `status`:
+/// disbursement realized. `status` (state machine driven by withdrawAppRevenue
+/// + the Tipalti webhook reconciliation handler):
+///   - 'processing'       — row created up-front (so the webhook can always find
+///     it); mint + Tipalti disbursement in progress. amountCents is 0 here.
 ///   - 'pending_approval' — Tipalti payment batch created, waiting on the
-///     moderator-approval step (mirrors CashWithdrawal's terminal state here).
-///   - 'reverted'         — Tipalti (or this record's write) failed AFTER the
-///     mint; the mint was compensated (rows un-flipped, ledger row deleted) and
-///     the publisher's balance restored. Kept for audit.
+///     moderator-approval step.
+///   - 'completed'        — Tipalti payment approved/completed (terminal; money
+///     sent). Set by the webhook.
+///   - 'failed'           — disbursement/mint failed before money moved, OR the
+///     payment was declined/cancelled by Tipalti; the mint was reverted (rows
+///     un-flipped, ledger row deleted) and the publisher's balance restored.
+///   - 'no_balance'       — nothing to disburse at mint time (net<=0/already
+///     paid); no money moved (terminal).
 ///
-/// Application-generated id (`bpw_<ulid>`), which is also the Tipalti refCode
-/// source — so the whole flow is retryable/idempotent off one id.
+/// Application-generated id (`bpw_<ulid>`). The Tipalti refCode (refCode) is
+/// derived from it (prefix 'BPW' + ULID tail, 16 chars) and stored + indexed so
+/// the webhook reconciles by exact refCode match (the refCode is not
+/// round-trippable into the id — Tipalti caps refCodes at 16 chars).
 model BlockPayoutWithdrawal {
   id             String   @id
   appOwnerUserId Int      @map("app_owner_user_id")
   appOwner       User     @relation("BlockPayoutWithdrawalOwner", fields: [appOwnerUserId], references: [id], onDelete: Restrict)
   /// Links to the block_attribution_payout ledger row minted for this
-  /// disbursement. NULL only transiently before the mint (never persisted NULL
-  /// on a row that reached Tipalti).
+  /// disbursement. NULL before the mint (the 'processing' window) and after a
+  /// revert (failed/declined). Set once the mint claims rows.
   payoutId       String?  @map("payout_id")
   /// Net publisher share disbursed, in USD cents (matches the minted ledger
-  /// row's total_cents). Tipalti is paid cents/100.
+  /// row's total_cents). Tipalti is paid cents/100. 0 while 'processing'.
   amountCents    Int      @map("amount_cents")
   /// Tipalti CashWithdrawalMethod used (snapshot of the payable method).
   method         String
-  /// Tipalti refCode (== id, truncated to 16 chars by getWithdrawalRefCode).
+  /// App-Blocks-rail Tipalti refCode (prefix 'BPW', 16 chars, derived from id).
+  /// The webhook looks this row up by exact ref_code match.
   refCode        String   @map("ref_code")
-  status         String   @default("pending_approval")
+  /// The refCode Tipalti echoes back on the created payment batch.
+  paymentRefCode String?  @map("payment_ref_code")
+  status         String   @default("processing")
   /// Tipalti paymentBatchId once the batch is created.
   paymentBatchId String?  @map("payment_batch_id")
   note           String?
@@ -2575,6 +2587,7 @@ model BlockPayoutWithdrawal {
 
   @@index([appOwnerUserId, createdAt(sort: Desc)], map: "bpw_owner_created_idx")
   @@index([payoutId], map: "bpw_payout_idx")
+  @@index([refCode], map: "bpw_ref_code_idx")
   @@map("block_payout_withdrawal")
 }
 

--- a/src/pages/api/webhooks/tipalti.ts
+++ b/src/pages/api/webhooks/tipalti.ts
@@ -8,8 +8,10 @@ import tipaltiCaller from '~/server/http/tipalti/tipalti.caller';
 import type { Tipalti } from '~/server/http/tipalti/tipalti.schema';
 import { updateBuzzWithdrawalRequest } from '~/server/services/buzz-withdrawal-request.service';
 import { updateCashWithdrawal, userCashCache } from '~/server/services/creator-program.service';
+import { processBlockPayoutEvent } from '~/server/services/blocks/payout-webhook.service';
 import { updateByTipaltiAccount } from '~/server/services/user-payment-configuration.service';
 import { parseRefCodeToWithdrawalId } from '~/server/utils/creator-program.utils';
+import { isBlockPayoutRefCode } from '~/server/utils/app-block-ids';
 import type { CashWithdrawalMethod } from '~/shared/utils/prisma/enums';
 import { BuzzWithdrawalRequestStatus, CashWithdrawalStatus } from '~/shared/utils/prisma/enums';
 
@@ -105,7 +107,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             paymentStatus: string;
           };
 
-          if (payment.refCode.startsWith('CW')) {
+          // App-Blocks payout rail — MUST be checked BEFORE the 'CW' branch so
+          // these don't misroute into the creator-program handler (which would
+          // 400 and leave the disbursement unreconciled forever). The BPW
+          // prefix can't collide with CW.
+          if (isBlockPayoutRefCode(payment.refCode)) {
+            await processBlockPayoutEvent(event);
+          } else if (payment.refCode.startsWith('CW')) {
             // Creator Program V2:
             await processCashWithdrawalEvent(event);
           } else {
@@ -121,7 +129,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         case 'paymentError': {
           const payment = event.eventData as { refCode: string; paymentStatus: string };
 
-          if (payment.refCode.startsWith('CW')) {
+          // App-Blocks payout rail first (see note above).
+          if (isBlockPayoutRefCode(payment.refCode)) {
+            await processBlockPayoutEvent(event);
+          } else if (payment.refCode.startsWith('CW')) {
             // Creator Program V2:
             await processCashWithdrawalEvent(event);
           } else {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1870,6 +1870,7 @@ export const blocksRouter = router({
           },
           topApps: [] as Array<{ appBlockId: string; shareCents: number; count: number }>,
           minWithdrawalCents: MIN_APP_REVENUE_PAYOUT_CENTS,
+          pendingWithdrawalCents: 0,
         };
       }
       const user = ctx.user as SessionUser;
@@ -1879,7 +1880,24 @@ export const blocksRouter = router({
         from: input?.from ? new Date(input.from) : undefined,
         to: input?.to ? new Date(input.to) : undefined,
       });
-      return { summary, topApps, minWithdrawalCents: MIN_APP_REVENUE_PAYOUT_CENTS };
+      // #6: in-flight withdrawal amount (rows already consuming the confirmed
+      // balance) so the UI / a caller can avoid offering a balance a withdrawal
+      // is already claiming. 'processing' rows carry amountCents 0 (set on
+      // disburse), so they contribute 0 here — only post-mint 'pending_approval'
+      // rows have a real claimed amount, which is the value worth surfacing.
+      const inflight = await dbRead.blockPayoutWithdrawal.aggregate({
+        where: {
+          appOwnerUserId: user.id,
+          status: { in: ['processing', 'pending_approval'] },
+        },
+        _sum: { amountCents: true },
+      });
+      return {
+        summary,
+        topApps,
+        minWithdrawalCents: MIN_APP_REVENUE_PAYOUT_CENTS,
+        pendingWithdrawalCents: inflight._sum.amountCents ?? 0,
+      };
     }),
 
   /**
@@ -1896,6 +1914,18 @@ export const blocksRouter = router({
    */
   withdrawMyAppRevenue: protectedProcedure
     .use(enforceAppBlocksFlag)
+    // Cheap extra guard against double-click / retry hammering the payout path
+    // (the per-owner advisory lock in mintPayoutForOwner is the real
+    // correctness guarantee; this just keeps the disbursement path from being
+    // spammed). 3 attempts / 10 min per user. Mods/dev/test exempt by the
+    // middleware itself.
+    .use(
+      rateLimit({
+        limit: 3,
+        period: 600,
+        errorMessage: 'Too many withdrawal attempts — please wait a few minutes.',
+      })
+    )
     .mutation(async ({ ctx }) => {
       const user = ctx.user as SessionUser;
       const { withdrawAppRevenue } = await import('~/server/services/blocks/payout.service');

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -38,6 +38,7 @@ import {
   getRecentAttributionsForOwner,
   getRevenueForOwner,
 } from '~/server/services/blocks/buzz-attribution.service';
+import { MIN_APP_REVENUE_PAYOUT_CENTS } from '~/server/services/blocks/payout.service';
 import {
   getRepresentativeBaseModel,
   resolveBlockCheckpoint,
@@ -1831,6 +1832,74 @@ export const blocksRouter = router({
         appBlockId: input.appBlockId,
       });
       return { summary, topApps, recentAttributions };
+    }),
+
+  /**
+   * PR1 — developer-track revenue read for the publisher's OWN App-Block
+   * revenue (pending / confirmed / paid-out / voided + topApps). Owner-scoped
+   * to `ctx.user.id`; `getRevenueForOwner` filters by `app_owner_user_id`, so a
+   * caller can only ever see their own balances. `protectedProcedure` (NOT
+   * moderator-gated) so it follows the developer track — but
+   * `enforceAppBlocksFlag` still gates it behind the live mod-segmented
+   * `app-blocks-enabled` flag, so it stays dark for non-mods until the
+   * visibility segment is widened at launch.
+   *
+   * Read-only — surfaces the confirmed balance the publisher can withdraw via
+   * `withdrawMyAppRevenue`. (Distinct from the moderator `getMyRevenue` above,
+   * which also returns the recent-attributions feed.)
+   */
+  getMyAppRevenue: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z
+        .object({
+          appBlockId: z.string().min(1).max(64).optional(),
+          from: z.string().datetime().optional(),
+          to: z.string().datetime().optional(),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return {
+          summary: {
+            pending: { count: 0, grossCents: 0, shareCents: 0 },
+            confirmed: { count: 0, grossCents: 0, shareCents: 0 },
+            paidOut: { count: 0, grossCents: 0, shareCents: 0 },
+            voided: { count: 0, grossCents: 0 },
+          },
+          topApps: [] as Array<{ appBlockId: string; shareCents: number; count: number }>,
+          minWithdrawalCents: MIN_APP_REVENUE_PAYOUT_CENTS,
+        };
+      }
+      const user = ctx.user as SessionUser;
+      const { summary, topApps } = await getRevenueForOwner({
+        ownerUserId: user.id,
+        appBlockId: input?.appBlockId,
+        from: input?.from ? new Date(input.from) : undefined,
+        to: input?.to ? new Date(input.to) : undefined,
+      });
+      return { summary, topApps, minWithdrawalCents: MIN_APP_REVENUE_PAYOUT_CENTS };
+    }),
+
+  /**
+   * PR1 — publisher-initiated, full-balance withdrawal of App-Block revenue
+   * share over the separate Tipalti rail (pull model). Owner-scoped: it acts on
+   * `ctx.user.id` ONLY, so a caller can never withdraw another publisher's
+   * revenue. The service refuses unless the dedicated `app-blocks-payout-enabled`
+   * Flipt flag is on (defaults closed) — so this mutation moves NO money until
+   * that flag is explicitly flipped, independent of merging this code.
+   *
+   * `enforceAppBlocksFlag` (the visibility gate) ALSO guards it, so it is doubly
+   * dark pre-launch. See `withdrawAppRevenue` for the mint → disburse → revert
+   * invariant.
+   */
+  withdrawMyAppRevenue: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .mutation(async ({ ctx }) => {
+      const user = ctx.user as SessionUser;
+      const { withdrawAppRevenue } = await import('~/server/services/blocks/payout.service');
+      return withdrawAppRevenue(user.id);
     }),
 
   /**

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -72,6 +72,43 @@ export const APP_BLOCKS_PIPELINE_FLAG = 'app-blocks-pipeline-enabled';
 export const APP_BLOCKS_RUNTIME_FLAG = 'app-blocks-runtime-enabled';
 
 /**
+ * Dedicated GLOBAL flag for the publisher REVENUE-PAYOUT rail (PR1, pull model).
+ *
+ * `withdrawAppRevenue` (the publisher-initiated, full-balance withdrawal that
+ * mints a `block_attribution_payout` ledger row and disburses the net confirmed
+ * App-Block revenue share via Tipalti — the "separate rail" that NEVER touches
+ * the externally-owned Buzz cash accounts) gates on this flag FIRST. With the
+ * flag off, `withdrawAppRevenue` throws before doing anything — no mint, no
+ * Tipalti call, no money moves.
+ *
+ * ## Why a SEPARATE flag (not the user-visibility / pipeline / runtime flags)
+ *
+ * Paying real money is a strictly higher-stakes lever than "users can see
+ * blocks", "the build machine can run", or "deployed blocks' tokens verify".
+ * Those can all be lit for the mod-gated internal launch while disbursement
+ * stays dark. A dedicated flag lets money movement be turned on LAST, by itself,
+ * after the read-only revenue dashboard has been validated against live data.
+ *
+ * Evaluated globally (entityId='global', empty context) — it is a kill-switch
+ * for the disbursement subsystem, not a per-user visibility gate (per-user
+ * authorization is the ownership scoping on the tRPC proc + the Tipalti-payable
+ * preconditions inside `withdrawAppRevenue`). So it MUST be a PLAIN GLOBAL
+ * BOOLEAN in Flipt (base `enabled`, NO segment) — a segment-targeted flag would
+ * never match a global eval and silently leave payouts DARK.
+ *
+ * Fail-safe (DEFAULTS CLOSED): the flag does not exist yet — it is created in
+ * Flipt only AFTER this merges. A missing flag (or an unreachable Flipt) →
+ * `isFlipt` returns `false` → `withdrawAppRevenue` refuses → no money moves on
+ * merge. This is the load-bearing invariant: merging this PR moves zero dollars.
+ *
+ * OPERATOR NOTE — to turn payouts ON: create `app-blocks-payout-enabled` in
+ * Flipt as a plain global boolean and set base `enabled: true`. To pause
+ * disbursement instantly, flip it back to `false` (or delete it) — the next
+ * `withdrawAppRevenue` call refuses without a redeploy.
+ */
+export const APP_BLOCKS_PAYOUT_FLAG = 'app-blocks-payout-enabled';
+
+/**
  * Server-side check for the App Blocks feature flag.
  *
  * ## Three-axis flag model
@@ -214,4 +251,20 @@ export async function isAppBlocksPipelineEnabled(): Promise<boolean> {
  */
 export async function isAppBlocksRuntimeEnabled(): Promise<boolean> {
   return isFlipt(APP_BLOCKS_RUNTIME_FLAG);
+}
+
+/**
+ * GLOBAL gate for the publisher REVENUE-PAYOUT rail (PR1, pull model).
+ *
+ * Evaluates the dedicated `app-blocks-payout-enabled` flag with no user context
+ * (entityId='global', empty context). `withdrawAppRevenue` checks this FIRST and
+ * refuses if it returns `false`, so no mint and no Tipalti disbursement can
+ * happen until this is explicitly turned on.
+ *
+ * DEFAULTS CLOSED: the flag is created in Flipt only AFTER this merges, so a
+ * missing flag (or unreachable Flipt) → `false` → payouts stay dark → no money
+ * moves on merge. See APP_BLOCKS_PAYOUT_FLAG for the operator runbook.
+ */
+export async function isAppBlocksPayoutEnabled(): Promise<boolean> {
+  return isFlipt(APP_BLOCKS_PAYOUT_FLAG);
 }

--- a/src/server/services/blocks/__tests__/buzz-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/buzz-attribution.service.test.ts
@@ -44,6 +44,10 @@ const { mockDbRead, mockDbWrite, mockLog } = vi.hoisted(() => ({
       findUnique: vi.fn(),
       delete: vi.fn(),
     },
+    // Per-owner advisory lock taken at the top of mintPayoutForOwner's txn.
+    // No-op in the unit harness (no real DB / concurrency) — the lock's
+    // serialization behavior needs an integration test (noted in the PR).
+    $executeRaw: vi.fn().mockResolvedValue(0),
     // Interactive transaction: run the callback against the same mock
     // (no real isolation needed in these unit tests).
     $transaction: vi.fn((fn: (tx: unknown) => unknown) => fn(mockDbWrite)),
@@ -97,6 +101,8 @@ beforeEach(() => {
   mockDbWrite.blockAttributionPayout.create.mockReset();
   mockDbWrite.blockAttributionPayout.findUnique.mockReset();
   mockDbWrite.blockAttributionPayout.delete.mockReset();
+  mockDbWrite.$executeRaw.mockClear();
+  mockDbWrite.$executeRaw.mockResolvedValue(0);
   // findMany defaults to "no paid_out rows" so existing void tests that
   // don't set it up exercise the no-clawback path.
   mockDbWrite.blockBuzzAttribution.findMany.mockResolvedValue([]);
@@ -503,6 +509,67 @@ describe('mintPayoutForOwner', () => {
     expect(flip.data.status).toBe('paid_out');
     expect(flip.data.payoutId).toBe(ledger.id);
     expect(flip.data.paidOutAt).toBeInstanceOf(Date);
+  });
+
+  it('takes a per-owner advisory lock at the top of the txn (serializes concurrent mints)', async () => {
+    mockDbWrite.blockBuzzAttribution.aggregate.mockResolvedValueOnce({
+      _sum: { appOwnerShareCents: 1500 },
+      _count: 7,
+    });
+    mockDbWrite.blockAttributionPayout.create.mockResolvedValueOnce({});
+    mockDbWrite.blockBuzzAttribution.updateMany.mockResolvedValueOnce({ count: 7 });
+
+    await mintPayoutForOwner({ appOwnerUserId: APP_OWNER_USER_ID, periodKey: PERIOD });
+
+    // The advisory lock is acquired (the $executeRaw call) BEFORE the aggregate.
+    expect(mockDbWrite.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(mockDbWrite.$executeRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDbWrite.blockBuzzAttribution.aggregate.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('the LOSING concurrent attempt re-aggregates net 0 → minted:false (no double-claim)', async () => {
+    // Models the loser: after the winner committed (rows already paid_out), the
+    // loser acquires the lock, re-aggregates confirmed rows, sees 0 → carries
+    // forward without minting or flipping. This is the property the advisory
+    // lock guarantees in prod; here we assert the net<=0 branch handles it.
+    mockDbWrite.blockBuzzAttribution.aggregate.mockResolvedValueOnce({
+      _sum: { appOwnerShareCents: 0 },
+      _count: 0,
+    });
+
+    const result = await mintPayoutForOwner({
+      appOwnerUserId: APP_OWNER_USER_ID,
+      periodKey: PERIOD,
+    });
+
+    expect(result).toEqual({ minted: false, carriedForwardCents: 0, rowCount: 0 });
+    expect(mockDbWrite.blockAttributionPayout.create).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockBuzzAttribution.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('DEFENSE-IN-DEPTH: a 0-flip after a positive aggregate deletes the ledger row and returns minted:false', async () => {
+    // Aggregate saw a positive net and minted a ledger row, but the flip
+    // somehow touched 0 rows (would be a double-pay if reported payable). The
+    // guard must delete the just-created ledger row and return not-minted.
+    mockDbWrite.blockBuzzAttribution.aggregate.mockResolvedValueOnce({
+      _sum: { appOwnerShareCents: 1500 },
+      _count: 7,
+    });
+    mockDbWrite.blockAttributionPayout.create.mockResolvedValueOnce({});
+    mockDbWrite.blockBuzzAttribution.updateMany.mockResolvedValueOnce({ count: 0 });
+    mockDbWrite.blockAttributionPayout.delete.mockResolvedValueOnce({});
+
+    const result = await mintPayoutForOwner({
+      appOwnerUserId: APP_OWNER_USER_ID,
+      periodKey: PERIOD,
+    });
+
+    expect(result).toEqual({ minted: false, carriedForwardCents: 0, rowCount: 0 });
+    // The ledger row created moments earlier was deleted in the same txn.
+    expect(mockDbWrite.blockAttributionPayout.delete).toHaveBeenCalledWith({
+      where: { id: expect.stringMatching(/^bba_payout_/) },
+    });
   });
 
   it('is idempotent on P2002 — no second flip, no throw', async () => {

--- a/src/server/services/blocks/__tests__/buzz-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/buzz-attribution.service.test.ts
@@ -41,6 +41,8 @@ const { mockDbRead, mockDbWrite, mockLog } = vi.hoisted(() => ({
     },
     blockAttributionPayout: {
       create: vi.fn(),
+      findUnique: vi.fn(),
+      delete: vi.fn(),
     },
     // Interactive transaction: run the callback against the same mock
     // (no real isolation needed in these unit tests).
@@ -65,6 +67,7 @@ import {
   mintPayoutForOwner,
   recordAttribution,
   REFUND_WINDOWS_DAYS,
+  revertPayoutMint,
   voidAttributionsForPayment,
 } from '../buzz-attribution.service';
 import type { BlockAttribution } from '~/server/schema/blocks/attribution.schema';
@@ -92,6 +95,8 @@ beforeEach(() => {
   mockDbWrite.blockBuzzAttribution.findMany.mockReset();
   mockDbWrite.blockBuzzAttribution.aggregate.mockReset();
   mockDbWrite.blockAttributionPayout.create.mockReset();
+  mockDbWrite.blockAttributionPayout.findUnique.mockReset();
+  mockDbWrite.blockAttributionPayout.delete.mockReset();
   // findMany defaults to "no paid_out rows" so existing void tests that
   // don't set it up exercise the no-clawback path.
   mockDbWrite.blockBuzzAttribution.findMany.mockResolvedValue([]);
@@ -570,6 +575,64 @@ describe('mintPayoutForOwner', () => {
     // The aggregate query only ever reads confirmed rows.
     const aggWhere = mockDbWrite.blockBuzzAttribution.aggregate.mock.calls[0][0].where;
     expect(aggWhere).toEqual({ appOwnerUserId: APP_OWNER_USER_ID, status: 'confirmed' });
+  });
+});
+
+describe('revertPayoutMint', () => {
+  const PAYOUT_ID = 'bba_payout_TEST';
+
+  it('un-flips paid_out rows → confirmed and deletes the ledger row', async () => {
+    mockDbWrite.blockAttributionPayout.findUnique.mockResolvedValueOnce({
+      id: PAYOUT_ID,
+      appOwnerUserId: APP_OWNER_USER_ID,
+    });
+    mockDbWrite.blockBuzzAttribution.updateMany.mockResolvedValueOnce({ count: 4 });
+    mockDbWrite.blockAttributionPayout.delete.mockResolvedValueOnce({});
+
+    const result = await revertPayoutMint({
+      payoutId: PAYOUT_ID,
+      appOwnerUserId: APP_OWNER_USER_ID,
+    });
+
+    expect(result).toEqual({ reverted: 4, ledgerDeleted: true });
+
+    // Rows un-flipped: scoped by payoutId, paid_out → confirmed, linkage cleared.
+    const flip = mockDbWrite.blockBuzzAttribution.updateMany.mock.calls[0][0];
+    expect(flip.where).toEqual({ payoutId: PAYOUT_ID, status: 'paid_out' });
+    expect(flip.data).toEqual({ status: 'confirmed', paidOutAt: null, payoutId: null });
+
+    // Ledger row deleted by id.
+    expect(mockDbWrite.blockAttributionPayout.delete).toHaveBeenCalledWith({
+      where: { id: PAYOUT_ID },
+    });
+  });
+
+  it('is idempotent when the ledger row is already gone (un-flips stragglers, no delete)', async () => {
+    mockDbWrite.blockAttributionPayout.findUnique.mockResolvedValueOnce(null);
+    mockDbWrite.blockBuzzAttribution.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    const result = await revertPayoutMint({
+      payoutId: PAYOUT_ID,
+      appOwnerUserId: APP_OWNER_USER_ID,
+    });
+
+    expect(result).toEqual({ reverted: 0, ledgerDeleted: false });
+    expect(mockDbWrite.blockAttributionPayout.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses to revert a payout that belongs to a different owner', async () => {
+    mockDbWrite.blockAttributionPayout.findUnique.mockResolvedValueOnce({
+      id: PAYOUT_ID,
+      appOwnerUserId: 12345, // not APP_OWNER_USER_ID
+    });
+
+    await expect(
+      revertPayoutMint({ payoutId: PAYOUT_ID, appOwnerUserId: APP_OWNER_USER_ID })
+    ).rejects.toThrow(/owner/);
+
+    // Nothing touched on a foreign payout.
+    expect(mockDbWrite.blockBuzzAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockAttributionPayout.delete).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/blocks/__tests__/payout-webhook.service.test.ts
+++ b/src/server/services/blocks/__tests__/payout-webhook.service.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the App-Blocks payout RECONCILIATION webhook handler (audit
+ * blocker #2). The interesting surface:
+ *   - an approved/completed event → row 'completed'
+ *   - a declined/failed/cancelled event → row 'failed' AND revertPayoutMint
+ *     called (balance restored — safe because money did not leave)
+ *   - the handler looks the row up by EXACT refCode (the BPW-prefixed code)
+ *   - intermediate events leave the terminal status alone
+ *   - a re-delivered failure does NOT double-revert (already 'failed')
+ *
+ * db + revert + logger are mocked at the module boundary.
+ */
+
+const { mockDbWrite, mockRevert, mockLog } = vi.hoisted(() => ({
+  mockDbWrite: {
+    blockPayoutWithdrawal: { findFirst: vi.fn(), update: vi.fn() },
+  },
+  mockRevert: vi.fn(),
+  mockLog: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
+  revertPayoutMint: (...a: unknown[]) => mockRevert(...a),
+}));
+
+import { processBlockPayoutEvent } from '../payout-webhook.service';
+
+const REFCODE = 'BPW0123456789A';
+const OWNER = 555;
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: 'bpw_test',
+    appOwnerUserId: OWNER,
+    payoutId: 'bba_payout_X',
+    refCode: REFCODE,
+    status: 'pending_approval',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWrite.blockPayoutWithdrawal.findFirst.mockResolvedValue(row());
+  mockDbWrite.blockPayoutWithdrawal.update.mockResolvedValue({ id: 'bpw_test' });
+  mockRevert.mockResolvedValue({ reverted: 5, ledgerDeleted: true });
+});
+
+describe('processBlockPayoutEvent — refCode resolution', () => {
+  it('looks the row up by exact refCode for a group event (payments[0].refCode)', async () => {
+    await processBlockPayoutEvent({
+      type: 'paymentGroupApproved',
+      eventData: { payments: [{ refCode: REFCODE }] },
+    });
+    expect(mockDbWrite.blockPayoutWithdrawal.findFirst).toHaveBeenCalledWith({
+      where: { refCode: REFCODE },
+    });
+  });
+
+  it('looks the row up by exact refCode for a payment-level event (eventData.refCode)', async () => {
+    await processBlockPayoutEvent({
+      type: 'paymentCompleted',
+      eventData: { refCode: REFCODE },
+    });
+    expect(mockDbWrite.blockPayoutWithdrawal.findFirst).toHaveBeenCalledWith({
+      where: { refCode: REFCODE },
+    });
+  });
+
+  it('throws when the row is not found (so the webhook surfaces the miss)', async () => {
+    mockDbWrite.blockPayoutWithdrawal.findFirst.mockResolvedValueOnce(null);
+    await expect(
+      processBlockPayoutEvent({ type: 'paymentCompleted', eventData: { refCode: REFCODE } })
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
+describe('processBlockPayoutEvent — approved/completed → completed', () => {
+  it('marks the row completed on paymentGroupApproved (no revert)', async () => {
+    await processBlockPayoutEvent({
+      type: 'paymentGroupApproved',
+      eventData: { payments: [{ refCode: REFCODE }] },
+    });
+    const data = mockDbWrite.blockPayoutWithdrawal.update.mock.calls[0][0].data;
+    expect(data.status).toBe('completed');
+    expect(mockRevert).not.toHaveBeenCalled();
+  });
+
+  it('marks the row completed on paymentCompleted (no revert)', async () => {
+    await processBlockPayoutEvent({ type: 'paymentCompleted', eventData: { refCode: REFCODE } });
+    const data = mockDbWrite.blockPayoutWithdrawal.update.mock.calls[0][0].data;
+    expect(data.status).toBe('completed');
+    expect(mockRevert).not.toHaveBeenCalled();
+  });
+});
+
+describe('processBlockPayoutEvent — declined/failed → failed + revert', () => {
+  it('marks failed and reverts the mint on paymentGroupDeclined', async () => {
+    await processBlockPayoutEvent({
+      type: 'paymentGroupDeclined',
+      eventData: { payments: [{ refCode: REFCODE }] },
+    });
+    expect(mockRevert).toHaveBeenCalledWith({ payoutId: 'bba_payout_X', appOwnerUserId: OWNER });
+    const data = mockDbWrite.blockPayoutWithdrawal.update.mock.calls[0][0].data;
+    expect(data.status).toBe('failed');
+    expect(data.payoutId).toBeNull();
+  });
+
+  it('marks failed and reverts on paymentError', async () => {
+    await processBlockPayoutEvent({
+      type: 'paymentError',
+      eventData: { refCode: REFCODE, errorDescription: 'bank rejected' },
+    });
+    expect(mockRevert).toHaveBeenCalledWith({ payoutId: 'bba_payout_X', appOwnerUserId: OWNER });
+    const data = mockDbWrite.blockPayoutWithdrawal.update.mock.calls[0][0].data;
+    expect(data.status).toBe('failed');
+    expect(data.note).toMatch(/bank rejected/);
+  });
+
+  it('does NOT double-revert a re-delivered failure (already failed)', async () => {
+    mockDbWrite.blockPayoutWithdrawal.findFirst.mockResolvedValueOnce(row({ status: 'failed' }));
+    await processBlockPayoutEvent({
+      type: 'paymentGroupDeclined',
+      eventData: { payments: [{ refCode: REFCODE }] },
+    });
+    expect(mockRevert).not.toHaveBeenCalled();
+  });
+
+  it('emits CRITICAL + rethrows if the revert itself fails', async () => {
+    mockRevert.mockRejectedValueOnce(new Error('revert deadlock'));
+    await expect(
+      processBlockPayoutEvent({ type: 'paymentError', eventData: { refCode: REFCODE } })
+    ).rejects.toThrow(/revert deadlock/);
+    const critical = mockLog.mock.calls.find(
+      (c) => c[0]?.name === 'block-revenue-payout-critical-sent-not-recorded'
+    );
+    expect(critical).toBeTruthy();
+  });
+});
+
+describe('processBlockPayoutEvent — intermediate events', () => {
+  it('does not change the terminal status on paymentSubmitted', async () => {
+    await processBlockPayoutEvent({ type: 'paymentSubmitted', eventData: { refCode: REFCODE } });
+    const data = mockDbWrite.blockPayoutWithdrawal.update.mock.calls[0][0].data;
+    expect(data.status).toBeUndefined(); // no status key → unchanged
+    expect(mockRevert).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/payout.service.test.ts
+++ b/src/server/services/blocks/__tests__/payout.service.test.ts
@@ -41,7 +41,7 @@ const {
     userPaymentConfiguration: { findUnique: vi.fn() },
   },
   mockDbWrite: {
-    blockPayoutWithdrawal: { create: vi.fn() },
+    blockPayoutWithdrawal: { create: vi.fn(), update: vi.fn() },
   },
   mockLog: vi.fn(),
 }));
@@ -103,8 +103,9 @@ beforeEach(() => {
     totalCents: 25_000,
     rowCount: 5,
   });
-  mockPayTipalti.mockResolvedValue({ paymentBatchId: 'batch_1', paymentRefCode: 'CW777_x' });
+  mockPayTipalti.mockResolvedValue({ paymentBatchId: 'batch_1', paymentRefCode: 'BPWxxxxxxxxxxxx' });
   mockDbWrite.blockPayoutWithdrawal.create.mockResolvedValue({ id: 'bpw_1' });
+  mockDbWrite.blockPayoutWithdrawal.update.mockResolvedValue({ id: 'bpw_1' });
   mockRevert.mockResolvedValue({ reverted: 5, ledgerDeleted: true });
 });
 
@@ -179,8 +180,23 @@ describe('withdrawAppRevenue — preconditions', () => {
 });
 
 describe('withdrawAppRevenue — happy path', () => {
-  it('mints, flips, and pays Tipalti the DOLLAR amount (cents/100)', async () => {
+  it('creates the tracking row FIRST, mints, then pays Tipalti the DOLLAR amount (cents/100)', async () => {
     const result = await withdrawAppRevenue(OWNER);
+
+    // SAFE ORDERING (#3): the tracking row is created BEFORE the mint, in
+    // 'processing', carrying a BPW refCode the webhook can find.
+    expect(mockDbWrite.blockPayoutWithdrawal.create).toHaveBeenCalledTimes(1);
+    const created = mockDbWrite.blockPayoutWithdrawal.create.mock.calls[0][0].data;
+    expect(created.status).toBe('processing');
+    expect(created.appOwnerUserId).toBe(OWNER);
+    expect(created.payoutId).toBeNull();
+    expect(created.refCode).toMatch(/^BPW/);
+    expect(created.id).toMatch(/^bpw_/);
+
+    // The create happens before any Tipalti call.
+    expect(mockDbWrite.blockPayoutWithdrawal.create.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPayTipalti.mock.invocationCallOrder[0]
+    );
 
     // Minted under a unique, per-attempt period key.
     expect(mockMint).toHaveBeenCalledTimes(1);
@@ -189,20 +205,21 @@ describe('withdrawAppRevenue — happy path', () => {
     expect(typeof mintArg.periodKey).toBe('string');
     expect(mintArg.periodKey).toMatch(/^withdraw:/);
 
-    // Tipalti paid DOLLARS, byUserId -1 (the bank), to the owner.
+    // Tipalti paid DOLLARS, byUserId -1 (the bank), to the owner; refCode is BPW.
     expect(mockPayTipalti).toHaveBeenCalledTimes(1);
     const payArg = mockPayTipalti.mock.calls[0][0];
     expect(payArg.amount).toBe(250); // 25_000 cents / 100
     expect(payArg.toUserId).toBe(OWNER);
     expect(payArg.byUserId).toBe(-1);
+    expect(payArg.requestId).toMatch(/^BPW/);
 
-    // Tracking row written, linked to the payout, pending approval.
-    const rec = mockDbWrite.blockPayoutWithdrawal.create.mock.calls[0][0].data;
-    expect(rec.appOwnerUserId).toBe(OWNER);
-    expect(rec.payoutId).toBe('bba_payout_X');
-    expect(rec.amountCents).toBe(25_000);
-    expect(rec.status).toBe('pending_approval');
-    expect(rec.id).toMatch(/^bpw_/);
+    // On success the row is UPDATED to pending_approval with the batch id.
+    const upd = mockDbWrite.blockPayoutWithdrawal.update.mock.calls.map((c) => c[0].data);
+    const pending = upd.find((d) => d.status === 'pending_approval');
+    expect(pending).toBeTruthy();
+    expect(pending?.payoutId).toBe('bba_payout_X');
+    expect(pending?.amountCents).toBe(25_000);
+    expect(pending?.paymentBatchId).toBe('batch_1');
 
     // No revert on success.
     expect(mockRevert).not.toHaveBeenCalled();
@@ -215,50 +232,68 @@ describe('withdrawAppRevenue — happy path', () => {
   });
 });
 
-describe('withdrawAppRevenue — compensating revert', () => {
+describe('withdrawAppRevenue — compensating revert (pre-money failure)', () => {
   it('reverts the mint when Tipalti FAILS, preserving the balance, re-throwing', async () => {
     const tipaltiErr = new Error('Tipalti unreachable');
     mockPayTipalti.mockRejectedValueOnce(tipaltiErr);
 
     await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/Tipalti unreachable/);
 
-    // The mint was reverted for THIS payout + owner (balance restored).
+    // The mint was reverted for THIS payout + owner (balance restored). Safe:
+    // the failure happened BEFORE money moved.
     expect(mockRevert).toHaveBeenCalledTimes(1);
     expect(mockRevert).toHaveBeenCalledWith({ payoutId: 'bba_payout_X', appOwnerUserId: OWNER });
 
-    // The 'pending_approval' tracking row was NOT written (money never sent);
-    // an audit row marked 'reverted' is written instead.
-    const createdRows = mockDbWrite.blockPayoutWithdrawal.create.mock.calls.map((c) => c[0].data);
-    expect(createdRows.some((r) => r.status === 'pending_approval')).toBe(false);
-    const audit = createdRows.find((r) => r.status === 'reverted');
-    expect(audit).toBeTruthy();
-    // Revert succeeded → ledger row gone → audit row's payoutId is null (FK-safe).
-    expect(audit?.payoutId).toBeNull();
+    // The pre-created row is UPDATED to 'failed' (no 'pending_approval' update).
+    const upd = mockDbWrite.blockPayoutWithdrawal.update.mock.calls.map((c) => c[0].data);
+    expect(upd.some((d) => d.status === 'pending_approval')).toBe(false);
+    const failed = upd.find((d) => d.status === 'failed');
+    expect(failed).toBeTruthy();
+    // Revert succeeded → ledger row gone → payoutId cleared (FK-safe).
+    expect(failed?.payoutId).toBeNull();
   });
 
-  it('reverts when the tracking-record write fails AFTER a successful Tipalti call', async () => {
-    mockDbWrite.blockPayoutWithdrawal.create
-      .mockRejectedValueOnce(new Error('db write failed')) // the pending_approval row
-      .mockResolvedValueOnce({ id: 'bpw_audit' }); // the reverted audit row
-
-    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/db write failed/);
-
-    expect(mockPayTipalti).toHaveBeenCalledTimes(1);
-    expect(mockRevert).toHaveBeenCalledWith({ payoutId: 'bba_payout_X', appOwnerUserId: OWNER });
-  });
-
-  it('keeps the payoutId on the audit row when the REVERT itself fails (manual intervention)', async () => {
+  it('keeps the payoutId + emits CRITICAL when the REVERT itself fails (manual intervention)', async () => {
     mockPayTipalti.mockRejectedValueOnce(new Error('Tipalti boom'));
     mockRevert.mockRejectedValueOnce(new Error('revert tx deadlock'));
 
     await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/Tipalti boom/);
 
-    const audit = mockDbWrite.blockPayoutWithdrawal.create.mock.calls
+    const failed = mockDbWrite.blockPayoutWithdrawal.update.mock.calls
       .map((c) => c[0].data)
-      .find((r) => r.status === 'reverted');
+      .find((d) => d.status === 'failed');
     // Revert failed → ledger row may still exist → keep the linkage + flag it.
-    expect(audit?.payoutId).toBe('bba_payout_X');
-    expect(audit?.note).toMatch(/manual intervention/i);
+    expect(failed?.payoutId).toBe('bba_payout_X');
+    expect(failed?.note).toMatch(/manual intervention/i);
+
+    // A CRITICAL alertable signal was emitted for the failed revert.
+    const critical = mockLog.mock.calls.find(
+      (c) => c[0]?.name === 'block-revenue-payout-critical-sent-not-recorded'
+    );
+    expect(critical).toBeTruthy();
+  });
+});
+
+describe('withdrawAppRevenue — success-path row update failure (money already sent)', () => {
+  it('does NOT revert, emits CRITICAL, and still returns success when the pending_approval update fails', async () => {
+    // create (processing) succeeds; the success-path update throws.
+    mockDbWrite.blockPayoutWithdrawal.update.mockRejectedValueOnce(new Error('db write failed'));
+
+    const result = await withdrawAppRevenue(OWNER);
+
+    // Money already moved → NEVER revert.
+    expect(mockPayTipalti).toHaveBeenCalledTimes(1);
+    expect(mockRevert).not.toHaveBeenCalled();
+
+    // CRITICAL alertable signal emitted.
+    const critical = mockLog.mock.calls.find(
+      (c) => c[0]?.name === 'block-revenue-payout-critical-sent-not-recorded'
+    );
+    expect(critical).toBeTruthy();
+
+    // The disbursement happened, so we surface success (the webhook reconciles
+    // the row off the persisted refCode) rather than tripping a double-pay retry.
+    expect(result).toMatchObject({ payoutId: 'bba_payout_X', amountCents: 25_000 });
   });
 });
 
@@ -271,6 +306,9 @@ describe('withdrawAppRevenue — idempotency / no double-pay', () => {
     expect(mockMint).toHaveBeenCalledTimes(1);
     expect(mockPayTipalti).not.toHaveBeenCalled();
     expect(mockRevert).not.toHaveBeenCalled();
+    // The pre-created row is marked no_balance (terminal, no money).
+    const upd = mockDbWrite.blockPayoutWithdrawal.update.mock.calls.map((c) => c[0].data);
+    expect(upd.some((d) => d.status === 'no_balance')).toBe(true);
   });
 
   it('does NOT call Tipalti when net is non-positive at mint time (clawback landed)', async () => {
@@ -282,5 +320,35 @@ describe('withdrawAppRevenue — idempotency / no double-pay', () => {
 
     expect(mockPayTipalti).not.toHaveBeenCalled();
     expect(mockRevert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call Tipalti when the mint flipped 0 rows (carriedForwardCents:0, rowCount:0)', async () => {
+    // The advisory-lock 0-flip guard returns minted:false with a 0 net — this
+    // is the losing-race shape. Must abort before Tipalti.
+    mockMint.mockResolvedValueOnce({ minted: false, carriedForwardCents: 0, rowCount: 0 });
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/no confirmed app revenue/i);
+
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+    expect(mockRevert).not.toHaveBeenCalled();
+  });
+
+  it('aborts (no Tipalti) and reverts if a minted result somehow carries a 0 amount', async () => {
+    // Belt-and-braces guard: minted:true but totalCents 0 must NOT reach Tipalti.
+    mockMint.mockResolvedValueOnce({
+      minted: true,
+      payoutId: 'bba_payout_zero',
+      totalCents: 0,
+      rowCount: 0,
+    });
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/no confirmed app revenue/i);
+
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+    // Safe pre-money revert of whatever the mint touched.
+    expect(mockRevert).toHaveBeenCalledWith({
+      payoutId: 'bba_payout_zero',
+      appOwnerUserId: OWNER,
+    });
   });
 });

--- a/src/server/services/blocks/__tests__/payout.service.test.ts
+++ b/src/server/services/blocks/__tests__/payout.service.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the publisher revenue-payout "separate rail" (PR1, pull model).
+ *
+ * The financial edge cases are the gate here:
+ *   - FLAG OFF → refuse before ANY mint / Tipalti call.
+ *   - non-owner can only ever act on ctx.user.id (enforced at the proc; the
+ *     service takes a userId and scopes everything to it — see the proc test).
+ *   - below-$100 confirmed net → rejected, no mint, no Tipalti.
+ *   - happy path → mints, then Tipalti is paid the right DOLLAR amount
+ *     (cents/100), tracking row written.
+ *   - Tipalti FAILURE → compensating revert (rows back to confirmed, ledger
+ *     row deleted, balance preserved), original error re-thrown.
+ *   - double / repeat withdraw is idempotent (mint UNIQUE guard / alreadyPaid
+ *     path → no Tipalti, no double-pay).
+ *   - clawback (net ≤ 0) → abort without minting / paying.
+ *
+ * All collaborators (flag, mint/revenue/revert, Tipalti, db) are mocked at the
+ * module boundary so the test is in-process + deterministic — mirrors the
+ * buzz-attribution.service test.
+ */
+
+const {
+  mockIsPayoutEnabled,
+  mockGetRevenue,
+  mockMint,
+  mockRevert,
+  mockPayTipalti,
+  mockDbRead,
+  mockDbWrite,
+  mockLog,
+} = vi.hoisted(() => ({
+  mockIsPayoutEnabled: vi.fn(),
+  mockGetRevenue: vi.fn(),
+  mockMint: vi.fn(),
+  mockRevert: vi.fn(),
+  mockPayTipalti: vi.fn(),
+  mockDbRead: {
+    user: { findFirst: vi.fn() },
+    userPaymentConfiguration: { findUnique: vi.fn() },
+  },
+  mockDbWrite: {
+    blockPayoutWithdrawal: { create: vi.fn() },
+  },
+  mockLog: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksPayoutEnabled: () => mockIsPayoutEnabled(),
+}));
+vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
+  getRevenueForOwner: (...a: unknown[]) => mockGetRevenue(...a),
+  mintPayoutForOwner: (...a: unknown[]) => mockMint(...a),
+  revertPayoutMint: (...a: unknown[]) => mockRevert(...a),
+}));
+vi.mock('~/server/services/user-payment-configuration.service', () => ({
+  payToTipaltiAccount: (...a: unknown[]) => mockPayTipalti(...a),
+}));
+
+import { withdrawAppRevenue, MIN_APP_REVENUE_PAYOUT_CENTS } from '../payout.service';
+
+const OWNER = 777;
+
+function setConfirmedNet(shareCents: number) {
+  mockGetRevenue.mockResolvedValue({
+    summary: {
+      pending: { count: 0, grossCents: 0, shareCents: 0 },
+      confirmed: { count: 5, grossCents: shareCents, shareCents },
+      paidOut: { count: 0, grossCents: 0, shareCents: 0 },
+      voided: { count: 0, grossCents: 0 },
+    },
+    topApps: [],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default: flag ON, payable, healthy user, plenty of confirmed balance.
+  mockIsPayoutEnabled.mockResolvedValue(true);
+  mockDbRead.user.findFirst.mockResolvedValue({
+    id: OWNER,
+    bannedAt: null,
+    onboarding: 0,
+  });
+  mockDbRead.userPaymentConfiguration.findUnique.mockResolvedValue({
+    userId: OWNER,
+    tipaltiPaymentsEnabled: true,
+    tipaltiWithdrawalMethod: 'BankWire',
+  });
+  setConfirmedNet(25_000); // $250
+  mockMint.mockResolvedValue({
+    minted: true,
+    payoutId: 'bba_payout_X',
+    totalCents: 25_000,
+    rowCount: 5,
+  });
+  mockPayTipalti.mockResolvedValue({ paymentBatchId: 'batch_1', paymentRefCode: 'CW777_x' });
+  mockDbWrite.blockPayoutWithdrawal.create.mockResolvedValue({ id: 'bpw_1' });
+  mockRevert.mockResolvedValue({ reverted: 5, ledgerDeleted: true });
+});
+
+describe('withdrawAppRevenue — flag gate', () => {
+  it('refuses when the payout flag is OFF, before any mint or Tipalti call', async () => {
+    mockIsPayoutEnabled.mockResolvedValueOnce(false);
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/not enabled/i);
+
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+    // Flag is the FIRST check — we never even read the user.
+    expect(mockDbRead.user.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('withdrawAppRevenue — preconditions', () => {
+  it('rejects a banned user (no mint, no Tipalti)', async () => {
+    mockDbRead.user.findFirst.mockResolvedValueOnce({
+      id: OWNER,
+      bannedAt: new Date(),
+      onboarding: 0,
+    });
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/banned/i);
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-payable user (tipaltiPaymentsEnabled false)', async () => {
+    mockDbRead.userPaymentConfiguration.findUnique.mockResolvedValueOnce({
+      userId: OWNER,
+      tipaltiPaymentsEnabled: false,
+      tipaltiWithdrawalMethod: 'BankWire',
+    });
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/payable/i);
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+  });
+
+  it('rejects when no real Tipalti withdrawal method (NoPM)', async () => {
+    mockDbRead.userPaymentConfiguration.findUnique.mockResolvedValueOnce({
+      userId: OWNER,
+      tipaltiPaymentsEnabled: true,
+      tipaltiWithdrawalMethod: 'NoPM',
+    });
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/payment method/i);
+    expect(mockMint).not.toHaveBeenCalled();
+  });
+
+  it('rejects a confirmed net below the $100 minimum (no mint, no Tipalti)', async () => {
+    setConfirmedNet(MIN_APP_REVENUE_PAYOUT_CENTS - 1); // $99.99
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/minimum/i);
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+  });
+
+  it('allows exactly the $100 minimum', async () => {
+    setConfirmedNet(MIN_APP_REVENUE_PAYOUT_CENTS); // $100
+    mockMint.mockResolvedValueOnce({
+      minted: true,
+      payoutId: 'bba_payout_min',
+      totalCents: MIN_APP_REVENUE_PAYOUT_CENTS,
+      rowCount: 2,
+    });
+    mockPayTipalti.mockResolvedValueOnce({ paymentBatchId: 'b', paymentRefCode: 'r' });
+
+    await withdrawAppRevenue(OWNER);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    // Tipalti paid $100 (DOLLARS).
+    expect(mockPayTipalti.mock.calls[0][0].amount).toBe(100);
+  });
+});
+
+describe('withdrawAppRevenue — happy path', () => {
+  it('mints, flips, and pays Tipalti the DOLLAR amount (cents/100)', async () => {
+    const result = await withdrawAppRevenue(OWNER);
+
+    // Minted under a unique, per-attempt period key.
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    const mintArg = mockMint.mock.calls[0][0];
+    expect(mintArg.appOwnerUserId).toBe(OWNER);
+    expect(typeof mintArg.periodKey).toBe('string');
+    expect(mintArg.periodKey).toMatch(/^withdraw:/);
+
+    // Tipalti paid DOLLARS, byUserId -1 (the bank), to the owner.
+    expect(mockPayTipalti).toHaveBeenCalledTimes(1);
+    const payArg = mockPayTipalti.mock.calls[0][0];
+    expect(payArg.amount).toBe(250); // 25_000 cents / 100
+    expect(payArg.toUserId).toBe(OWNER);
+    expect(payArg.byUserId).toBe(-1);
+
+    // Tracking row written, linked to the payout, pending approval.
+    const rec = mockDbWrite.blockPayoutWithdrawal.create.mock.calls[0][0].data;
+    expect(rec.appOwnerUserId).toBe(OWNER);
+    expect(rec.payoutId).toBe('bba_payout_X');
+    expect(rec.amountCents).toBe(25_000);
+    expect(rec.status).toBe('pending_approval');
+    expect(rec.id).toMatch(/^bpw_/);
+
+    // No revert on success.
+    expect(mockRevert).not.toHaveBeenCalled();
+
+    expect(result).toMatchObject({
+      payoutId: 'bba_payout_X',
+      amountCents: 25_000,
+      paymentBatchId: 'batch_1',
+    });
+  });
+});
+
+describe('withdrawAppRevenue — compensating revert', () => {
+  it('reverts the mint when Tipalti FAILS, preserving the balance, re-throwing', async () => {
+    const tipaltiErr = new Error('Tipalti unreachable');
+    mockPayTipalti.mockRejectedValueOnce(tipaltiErr);
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/Tipalti unreachable/);
+
+    // The mint was reverted for THIS payout + owner (balance restored).
+    expect(mockRevert).toHaveBeenCalledTimes(1);
+    expect(mockRevert).toHaveBeenCalledWith({ payoutId: 'bba_payout_X', appOwnerUserId: OWNER });
+
+    // The 'pending_approval' tracking row was NOT written (money never sent);
+    // an audit row marked 'reverted' is written instead.
+    const createdRows = mockDbWrite.blockPayoutWithdrawal.create.mock.calls.map((c) => c[0].data);
+    expect(createdRows.some((r) => r.status === 'pending_approval')).toBe(false);
+    const audit = createdRows.find((r) => r.status === 'reverted');
+    expect(audit).toBeTruthy();
+    // Revert succeeded → ledger row gone → audit row's payoutId is null (FK-safe).
+    expect(audit?.payoutId).toBeNull();
+  });
+
+  it('reverts when the tracking-record write fails AFTER a successful Tipalti call', async () => {
+    mockDbWrite.blockPayoutWithdrawal.create
+      .mockRejectedValueOnce(new Error('db write failed')) // the pending_approval row
+      .mockResolvedValueOnce({ id: 'bpw_audit' }); // the reverted audit row
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/db write failed/);
+
+    expect(mockPayTipalti).toHaveBeenCalledTimes(1);
+    expect(mockRevert).toHaveBeenCalledWith({ payoutId: 'bba_payout_X', appOwnerUserId: OWNER });
+  });
+
+  it('keeps the payoutId on the audit row when the REVERT itself fails (manual intervention)', async () => {
+    mockPayTipalti.mockRejectedValueOnce(new Error('Tipalti boom'));
+    mockRevert.mockRejectedValueOnce(new Error('revert tx deadlock'));
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/Tipalti boom/);
+
+    const audit = mockDbWrite.blockPayoutWithdrawal.create.mock.calls
+      .map((c) => c[0].data)
+      .find((r) => r.status === 'reverted');
+    // Revert failed → ledger row may still exist → keep the linkage + flag it.
+    expect(audit?.payoutId).toBe('bba_payout_X');
+    expect(audit?.note).toMatch(/manual intervention/i);
+  });
+});
+
+describe('withdrawAppRevenue — idempotency / no double-pay', () => {
+  it('does NOT call Tipalti when the mint reports alreadyPaid (repeat/concurrent attempt)', async () => {
+    mockMint.mockResolvedValueOnce({ minted: false, alreadyPaid: true });
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/no confirmed app revenue/i);
+
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+    expect(mockRevert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call Tipalti when net is non-positive at mint time (clawback landed)', async () => {
+    // The pre-gate read saw enough balance, but a clawback flips the net at
+    // mint time → mint carries forward, refuses to flip → no disbursement.
+    mockMint.mockResolvedValueOnce({ minted: false, carriedForwardCents: -50, rowCount: 3 });
+
+    await expect(withdrawAppRevenue(OWNER)).rejects.toThrow(/no confirmed app revenue/i);
+
+    expect(mockPayTipalti).not.toHaveBeenCalled();
+    expect(mockRevert).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -393,6 +393,15 @@ export type MintPayoutResult =
   | { minted: false; carriedForwardCents: number; rowCount: number };
 
 /**
+ * Fixed lock domain (key1) for the per-owner payout advisory lock. The 2-arg
+ * `pg_advisory_xact_lock(key1 int, key2 int)` form namespaces the lock by
+ * (domain, ownerId) so it can NEVER collide with an advisory lock taken
+ * elsewhere in the codebase for a different purpose on the same integer. Picked
+ * once; do not reuse this value for any other advisory-lock domain.
+ */
+const PAYOUT_MINT_LOCK_DOMAIN = 0x6270_7761; // 'bpwa' (block-payout-withdrawal-advisory)
+
+/**
  * Idempotently MINT a payout ledger entry for one publisher for one
  * period, and flip the contributing confirmed rows to paid_out — all in
  * a single transaction.
@@ -423,6 +432,20 @@ export async function mintPayoutForOwner({
   periodKey: string;
 }): Promise<MintPayoutResult> {
   return dbWrite.$transaction(async (tx: Prisma.TransactionClient): Promise<MintPayoutResult> => {
+    // 0. PER-OWNER SERIALIZATION (money-correctness blocker #1). Take a
+    // transaction-scoped advisory lock keyed on (domain, ownerId) at the very
+    // top of the txn. Two concurrent withdrawals for the SAME owner (double
+    // click / retry / racing requests) now serialize here: the winner runs the
+    // aggregate→flip→commit; the loser BLOCKS until the winner commits, then
+    // re-runs step 1 against the post-flip state, sees net 0, and returns
+    // `minted:false` — so it can never pay Tipalti for already-paid rows.
+    //
+    // pg_advisory_xact_lock auto-releases on COMMIT/ROLLBACK (no manual unlock,
+    // no leak on error). Without this, READ COMMITTED + no row lock let both
+    // txns read the same confirmed rows and both "succeed" (one flips 0 rows but
+    // returned totalCents from its pre-flip aggregate → double-pay).
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${PAYOUT_MINT_LOCK_DOMAIN}::int, ${appOwnerUserId}::int)`;
+
     // 1. Aggregate this owner's payable rows. status='confirmed'
     // naturally includes negative entry_type='clawback' rows, so the net
     // already accounts for carry-forward debt.
@@ -472,6 +495,33 @@ export async function mintPayoutForOwner({
         payoutId,
       },
     });
+
+    // 5. DEFENSE-IN-DEPTH (money-correctness blocker #1). The aggregate in (1)
+    // and the flip in (4) are now serialized by the advisory lock, so a winner
+    // that aggregated a positive net MUST flip those same rows — `flipped.count`
+    // should equal `rowCount`. But if we ever flip ZERO rows we MUST NOT report
+    // a payable amount: a 0-flip means nothing was actually claimed, yet
+    // `netCents` (the pre-flip aggregate) is still > 0 → the caller would pay
+    // Tipalti for money no row backs (double-pay). So treat a 0-flip as
+    // NOT MINTED: delete the just-created ledger row in THIS txn (so the
+    // idempotency key is freed for a clean retry) and return minted:false. With
+    // the advisory lock this branch is unreachable; it closes the invariant.
+    if (flipped.count === 0) {
+      await tx.blockAttributionPayout.delete({ where: { id: payoutId } });
+      logToAxiom(
+        {
+          name: ATTRIBUTION_LOG_NAME,
+          type: 'warning',
+          message: `mint flipped 0 rows for owner ${appOwnerUserId} (${periodKey}) — treating as not-minted`,
+          appOwnerUserId,
+          periodKey,
+          netCents,
+          rowCount,
+        },
+        'webhooks'
+      ).catch(() => null);
+      return { minted: false, carriedForwardCents: 0, rowCount: 0 };
+    }
 
     logToAxiom(
       {
@@ -523,6 +573,16 @@ export type RevertPayoutResult = {
  * (defense-in-depth: a caller can never delete another owner's payout by passing
  * the wrong id). A mismatch throws — the caller should never reach this with a
  * foreign payoutId.
+ *
+ * INVARIANT (audit #5): the hard-delete of the ledger row below is only ever
+ * reachable BEFORE money has moved. `withdrawAppRevenue` (the only caller) now
+ * orders the flow so this revert runs ONLY on the Tipalti-disbursement FAILURE
+ * path — i.e. before a successful `payToTipaltiAccount`. After a SUCCESSFUL
+ * disbursement the caller never invokes revert (it leaves rows `paid_out` and
+ * reconciles via the webhook instead). So a hard delete here can never erase the
+ * ledger for money that was actually sent. Do NOT add a post-success caller of
+ * this function; if reconciliation ever needs to unwind a SENT-then-failed
+ * payment, that must restore balance via a clawback row, not this hard delete.
  */
 export async function revertPayoutMint({
   payoutId,

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { blockBuzzAttributionWriteCounter } from '~/server/prom/client';
@@ -488,6 +488,92 @@ export async function mintPayoutForOwner({
     ).catch(() => null);
 
     return { minted: true, payoutId, totalCents: netCents, rowCount: flipped.count };
+  });
+}
+
+export type RevertPayoutResult = {
+  /** Rows flipped paid_out → confirmed (payout_id/paid_out_at cleared). */
+  reverted: number;
+  /** Whether the ledger row was deleted (false if it was already gone). */
+  ledgerDeleted: boolean;
+};
+
+/**
+ * COMPENSATING REVERT for a minted-but-undisbursed payout.
+ *
+ * `withdrawAppRevenue` mints the ledger row + flips the contributing rows to
+ * `paid_out` BEFORE it calls Tipalti. If the Tipalti disbursement (or the
+ * tracking-record write that follows it) fails, the publisher would otherwise be
+ * stuck with a zero balance for money they never received. Because the mint
+ * moved NO actual money — it only changed row state and wrote an idempotency
+ * ledger row — the failure is fully reversible: we un-flip the `paid_out` rows
+ * for this `payoutId` back to `confirmed` (clearing `paid_out_at` + `payout_id`)
+ * AND delete the `block_attribution_payout` ledger row, in ONE transaction. The
+ * publisher's confirmed balance is restored exactly and they can retry (the next
+ * attempt generates a fresh ULID period_key, so it is not blocked by the
+ * now-deleted ledger row).
+ *
+ * Scoped strictly by `payoutId` (NOT by owner) so it can only ever touch the
+ * rows THIS mint flipped — it cannot accidentally revert a different period's
+ * payout for the same owner, and it cannot revert a clawback that was minted
+ * under a different payout. Idempotent: if the ledger row is already gone (a
+ * prior revert ran) the delete is a no-op and we still un-flip any stragglers.
+ *
+ * Deliberately verifies the deleted ledger row belonged to the expected owner
+ * (defense-in-depth: a caller can never delete another owner's payout by passing
+ * the wrong id). A mismatch throws — the caller should never reach this with a
+ * foreign payoutId.
+ */
+export async function revertPayoutMint({
+  payoutId,
+  appOwnerUserId,
+}: {
+  payoutId: string;
+  appOwnerUserId: number;
+}): Promise<RevertPayoutResult> {
+  return dbWrite.$transaction(async (tx: Prisma.TransactionClient): Promise<RevertPayoutResult> => {
+    // Defense-in-depth: confirm the ledger row (if present) is this owner's
+    // before we touch anything. A foreign payoutId is a programming error.
+    const ledger = await tx.blockAttributionPayout.findUnique({
+      where: { id: payoutId },
+      select: { id: true, appOwnerUserId: true },
+    });
+    if (ledger && ledger.appOwnerUserId !== appOwnerUserId) {
+      throw new Error(
+        `revertPayoutMint: payout ${payoutId} owner ${ledger.appOwnerUserId} != expected ${appOwnerUserId}`
+      );
+    }
+
+    // 1. Un-flip the rows this payout claimed. Scope by payoutId so only the
+    // exact rows minted here revert. Restore status='confirmed' so the net
+    // is immediately re-claimable on retry.
+    const reverted = await tx.blockBuzzAttribution.updateMany({
+      where: { payoutId, status: 'paid_out' },
+      data: { status: 'confirmed', paidOutAt: null, payoutId: null },
+    });
+
+    // 2. Delete the idempotency ledger row so it no longer counts as a paid
+    // period. The flip in (1) already removed the payout_id linkage.
+    let ledgerDeleted = false;
+    if (ledger) {
+      await tx.blockAttributionPayout.delete({ where: { id: payoutId } });
+      ledgerDeleted = true;
+    }
+
+    logToAxiom(
+      {
+        name: ATTRIBUTION_LOG_NAME,
+        type: 'warning',
+        message: `reverted payout mint ${payoutId} for owner ${appOwnerUserId} (disbursement failed)`,
+        payoutId,
+        appOwnerUserId,
+        reverted: reverted.count,
+        ledgerDeleted,
+      },
+      'webhooks'
+    ).catch(() => null);
+
+    return { reverted: reverted.count, ledgerDeleted };
   });
 }
 

--- a/src/server/services/blocks/payout-webhook.service.ts
+++ b/src/server/services/blocks/payout-webhook.service.ts
@@ -1,0 +1,153 @@
+import { dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { revertPayoutMint } from '~/server/services/blocks/buzz-attribution.service';
+
+/**
+ * App-Blocks publisher-revenue payout RECONCILIATION (audit blocker #2).
+ *
+ * Extracted from the Tipalti webhook route so it is unit-testable without
+ * standing up the whole `/api/webhooks/tipalti` handler (env validation, the
+ * Tipalti signature client, the creator-program services). The route imports
+ * and dispatches to this for any refCode on the App-Blocks rail (BPW prefix).
+ *
+ * Mirrors `processCashWithdrawalEvent` but drives the dedicated
+ * `block_payout_withdrawal` table. The rail's refCode uses the `BPW` prefix and
+ * is persisted on the row, so we look the row up by EXACT `ref_code` match (the
+ * refCode is not parseable back into the id — Tipalti's 16-char cap).
+ *
+ * Terminal-state machine:
+ *   - paymentGroupApproved / paymentCompleted        → 'completed'
+ *   - paymentGroupDeclined / paymentError / Canceled → 'failed' AND restore the
+ *     publisher's balance by reverting the mint (un-flip rows → confirmed)
+ *     keyed on the row's payoutId. Safe: a declined/cancelled/errored payment
+ *     means money did NOT leave.
+ *   - paymentSubmitted / paymentDeferred             → left in 'pending_approval'
+ *     (intermediate; no terminal change, note updated).
+ *
+ * Idempotent: revertPayoutMint no-ops on a re-delivered failure (rows already
+ * confirmed / ledger gone), and the failure restore only fires when
+ * transitioning into 'failed' from a non-terminal state.
+ */
+const BLOCK_PAYOUT_WEBHOOK_LOG = 'block-revenue-payout-webhook';
+const BLOCK_PAYOUT_CRITICAL_LOG = 'block-revenue-payout-critical-sent-not-recorded';
+
+export type BlockPayoutWebhookEvent = {
+  type: string;
+  eventData: {
+    refCode?: string;
+    paymentStatus?: string;
+    errorDescription?: string;
+    payments?: Array<{ refCode: string; paymentStatus?: string }>;
+    [k: string]: unknown;
+  };
+};
+
+export async function processBlockPayoutEvent(event: BlockPayoutWebhookEvent): Promise<void> {
+  const refCode =
+    event.type === 'paymentGroupApproved' || event.type === 'paymentGroupDeclined'
+      ? event.eventData.payments?.[0]?.refCode
+      : event.eventData.refCode;
+
+  if (!refCode) {
+    throw new Error('Block payout webhook missing refCode');
+  }
+
+  const row = await dbWrite.blockPayoutWithdrawal.findFirst({
+    where: { refCode },
+  });
+
+  if (!row) {
+    throw new Error(`Block payout withdrawal not found for refCode: ${refCode}`);
+  }
+
+  let nextStatus: string | null = null;
+  let note: string;
+  let restoreBalance = false;
+
+  switch (event.type) {
+    case 'paymentGroupApproved':
+    case 'paymentCompleted':
+      nextStatus = 'completed';
+      note =
+        event.type === 'paymentCompleted'
+          ? 'Payment completed'
+          : "Payment approved by Moderators. Tipalti's processing should start shortly.";
+      break;
+
+    case 'paymentGroupDeclined':
+    case 'paymentError':
+    case 'paymentCanceled':
+      nextStatus = 'failed';
+      restoreBalance = true;
+      note =
+        event.type === 'paymentError'
+          ? `Payment error: ${event.eventData.errorDescription ?? 'unknown'}`
+          : event.type === 'paymentCanceled'
+          ? 'Payment canceled'
+          : 'Payment declined';
+      break;
+
+    case 'paymentSubmitted':
+      note = 'Payment submitted; awaiting completion';
+      break;
+    case 'paymentDeferred':
+      note = 'Payment deferred';
+      break;
+    default:
+      note = `Unhandled event ${event.type}`;
+      break;
+  }
+
+  // Restore the publisher's balance on a terminal FAILURE (money did not leave).
+  // Only when transitioning into 'failed' from a non-terminal state, and only if
+  // the row still carries a payoutId. Idempotent on re-delivery.
+  if (
+    restoreBalance &&
+    row.payoutId &&
+    row.status !== 'failed' &&
+    row.status !== 'completed'
+  ) {
+    try {
+      await revertPayoutMint({ payoutId: row.payoutId, appOwnerUserId: row.appOwnerUserId });
+    } catch (e) {
+      logToAxiom(
+        {
+          name: BLOCK_PAYOUT_CRITICAL_LOG,
+          type: 'error',
+          message: `CRITICAL: failed to restore balance for declined block payout ${row.id} — manual reconciliation required`,
+          withdrawalId: row.id,
+          payoutId: row.payoutId,
+          appOwnerUserId: row.appOwnerUserId,
+          error: e,
+        },
+        'webhooks'
+      ).catch(() => null);
+      throw e;
+    }
+  }
+
+  await dbWrite.blockPayoutWithdrawal.update({
+    where: { id: row.id },
+    data: {
+      ...(nextStatus ? { status: nextStatus } : {}),
+      // The revert clears the ledger row via ON DELETE SET NULL, but explicitly
+      // null the FK here so it can't dangle on the failed row.
+      ...(restoreBalance ? { payoutId: null } : {}),
+      note,
+    },
+  });
+
+  logToAxiom(
+    {
+      name: BLOCK_PAYOUT_WEBHOOK_LOG,
+      type: nextStatus === 'failed' ? 'warning' : 'info',
+      message: `block payout ${row.id} → ${nextStatus ?? row.status} (${event.type})`,
+      withdrawalId: row.id,
+      appOwnerUserId: row.appOwnerUserId,
+      eventType: event.type,
+      nextStatus,
+      restoredBalance: restoreBalance,
+    },
+    'webhooks'
+  ).catch(() => null);
+}

--- a/src/server/services/blocks/payout.service.ts
+++ b/src/server/services/blocks/payout.service.ts
@@ -1,0 +1,249 @@
+import { dbRead, dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { OnboardingSteps } from '~/server/common/enums';
+import { isAppBlocksPayoutEnabled } from '~/server/services/app-blocks-flag';
+import {
+  getRevenueForOwner,
+  mintPayoutForOwner,
+  revertPayoutMint,
+} from '~/server/services/blocks/buzz-attribution.service';
+import { payToTipaltiAccount } from '~/server/services/user-payment-configuration.service';
+import { getWithdrawalRefCode } from '~/server/utils/creator-program.utils';
+import { newBlockPayoutWithdrawalId, newUlid } from '~/server/utils/app-block-ids';
+import {
+  throwAuthorizationError,
+  throwBadRequestError,
+  throwInsufficientFundsError,
+} from '~/server/utils/errorHandling';
+import { Flags } from '~/shared/utils/flags';
+import { CashWithdrawalMethod } from '~/shared/utils/prisma/enums';
+
+const PAYOUT_LOG_NAME = 'block-revenue-payout';
+
+/**
+ * Minimum disbursable balance, in USD cents. Mirrors the creator-program
+ * `minBuzzWithdrawal` ($100) so the two rails share a withdrawal floor — keeps
+ * Tipalti batch volume sane and matches the publisher-facing "$100 minimum"
+ * copy. 10_000 cents = $100.
+ */
+export const MIN_APP_REVENUE_PAYOUT_CENTS = 10_000;
+
+export type WithdrawAppRevenueResult = {
+  withdrawalId: string;
+  payoutId: string;
+  amountCents: number;
+  paymentBatchId: string;
+  paymentRefCode: string;
+};
+
+/**
+ * PR1 — publisher-initiated, full-balance withdrawal of App-Block revenue
+ * share over the SEPARATE Tipalti rail.
+ *
+ * "Separate rail" = the money is the publisher's confirmed `block_buzz_
+ * attribution` share (USD cents, already net of the rate-card platform split),
+ * NOT Buzz. It is disbursed via Tipalti directly and NEVER credited into the
+ * externally-owned Buzz cash accounts (cashSettled/cashPending) — so it is not
+ * subject to the creator-program pool cap or the 30% fee, and it preserves the
+ * existing Tipalti 1099-NEC reporting path. No `createBuzzTransaction` /
+ * `cashSettled` burn happens here (contrast `withdrawCash`), which is exactly
+ * why the compensating revert below is a pure DB rollback — no Buzz to refund.
+ *
+ * Sequence (idempotent + retryable):
+ *   a. FLAG GATE FIRST — refuse unless `app-blocks-payout-enabled` is on. With
+ *      it off (the default), nothing past here runs: no mint, no Tipalti.
+ *   b. Preconditions: user not banned; Tipalti payable (tipaltiPaymentsEnabled
+ *      + a real withdrawal method ≠ NoPM); confirmed net ≥ $100.
+ *   c. Generate a fresh ULID up front and use it as BOTH the mint period_key
+ *      AND the withdrawal id, so each attempt is globally unique and a retry
+ *      after a revert can't collide with the (deleted) prior period.
+ *   d. mintPayoutForOwner(periodKey) — flips this owner's confirmed net to
+ *      paid_out under a fresh ledger row. If !minted (net≤0 / already paid),
+ *      abort WITHOUT calling Tipalti (nothing to disburse).
+ *   e. payToTipaltiAccount(amount = totalCents/100, byUserId:-1) and record the
+ *      tracking row.
+ *   g. COMPENSATING REVERT on ANY failure after the mint — un-flip the rows +
+ *      delete the ledger row (revertPayoutMint) so the publisher keeps the
+ *      balance and can retry. This is the load-bearing correctness property.
+ */
+export async function withdrawAppRevenue(userId: number): Promise<WithdrawAppRevenueResult> {
+  // a. FLAG GATE — must be first. Nothing moves until this is explicitly on.
+  if (!(await isAppBlocksPayoutEnabled())) {
+    throw throwBadRequestError('App Blocks revenue payouts are not enabled');
+  }
+
+  // b. Preconditions ------------------------------------------------------
+  // Ban check: a globally-banned user, or one banned from the creator program
+  // (same Tipalti payment infrastructure), cannot withdraw.
+  const user = await dbRead.user.findFirst({
+    where: { id: userId },
+    select: { id: true, bannedAt: true, onboarding: true },
+  });
+  if (!user) throw throwAuthorizationError('User not found');
+  if (user.bannedAt) throw throwAuthorizationError('User is banned');
+  if (Flags.hasFlag(user.onboarding, OnboardingSteps.BannedCreatorProgram)) {
+    throw throwAuthorizationError('User is banned from payouts');
+  }
+
+  // Tipalti-payable — the SAME preconditions withdrawCash enforces. We reuse
+  // them so app-revenue payouts ride the identical, already-vetted Tipalti
+  // payable surface (tax forms, 1099-NEC, payee account).
+  const userPaymentConfiguration = await dbRead.userPaymentConfiguration.findUnique({
+    where: { userId },
+  });
+  if (!userPaymentConfiguration?.tipaltiPaymentsEnabled) {
+    throw throwBadRequestError('User is not payable. Please complete payment setup.');
+  }
+  const method = userPaymentConfiguration.tipaltiWithdrawalMethod;
+  if (!method || method === CashWithdrawalMethod.NoPM) {
+    throw throwBadRequestError(
+      'We could not determine your Tipalti payment method. Please update it and check back.'
+    );
+  }
+
+  // Confirmed net balance ≥ $100. getRevenueForOwner's `confirmed` bucket
+  // shareCents already nets clawbacks (negative confirmed rows) — same set
+  // mintPayoutForOwner will aggregate, so this gate and the mint agree.
+  const { summary } = await getRevenueForOwner({ ownerUserId: userId });
+  const confirmedNetCents = summary.confirmed.shareCents;
+  if (confirmedNetCents < MIN_APP_REVENUE_PAYOUT_CENTS) {
+    throw throwInsufficientFundsError(
+      `App revenue balance is below the $${(MIN_APP_REVENUE_PAYOUT_CENTS / 100).toFixed(
+        0
+      )} minimum withdrawal.`
+    );
+  }
+
+  // c. Unique request id (drives mint period_key + withdrawal id + refCode). --
+  const withdrawalId = newBlockPayoutWithdrawalId();
+  const periodKey = `withdraw:${newUlid()}`;
+  const refCode = getWithdrawalRefCode(withdrawalId, userId);
+
+  // d. MINT — flips confirmed → paid_out under a fresh ledger row. After this
+  // line we OWE the publisher a disbursement or a revert. -------------------
+  const mint = await mintPayoutForOwner({ appOwnerUserId: userId, periodKey });
+  if (!mint.minted) {
+    // Net non-positive (e.g. a clawback landed between the gate and the mint)
+    // or the period was somehow already paid. Either way: nothing to disburse,
+    // nothing was flipped to pay out — abort cleanly without touching Tipalti.
+    logToAxiom(
+      {
+        name: PAYOUT_LOG_NAME,
+        type: 'info',
+        message: `withdraw aborted before Tipalti (nothing to pay) for owner ${userId}`,
+        userId,
+        periodKey,
+        mint,
+      },
+      'webhooks'
+    ).catch(() => null);
+    throw throwInsufficientFundsError('No confirmed App revenue available to withdraw.');
+  }
+
+  const { payoutId, totalCents } = mint;
+
+  // e + g. Disburse, recording the tracking row. ANY failure past the mint
+  // triggers the compensating revert so the publisher keeps their balance. ---
+  try {
+    const { paymentBatchId, paymentRefCode } = await payToTipaltiAccount({
+      requestId: refCode,
+      toUserId: userId,
+      // Tipalti takes DOLLARS, not cents (mirrors withdrawCash).
+      amount: totalCents / 100,
+      description: `App Blocks revenue payout ${refCode}`,
+      byUserId: -1, // the bank
+    });
+
+    // Tracking record. Written AFTER the Tipalti batch so a failed disbursement
+    // never leaves a row claiming money was sent; if THIS write fails we still
+    // revert the mint (publisher keeps balance) and surface the error.
+    await dbWrite.blockPayoutWithdrawal.create({
+      data: {
+        id: withdrawalId,
+        appOwnerUserId: userId,
+        payoutId,
+        amountCents: totalCents,
+        method,
+        refCode: paymentRefCode,
+        status: 'pending_approval',
+        paymentBatchId,
+        note: 'Payment waiting for Moderator approval',
+      },
+    });
+
+    logToAxiom(
+      {
+        name: PAYOUT_LOG_NAME,
+        type: 'info',
+        message: `withdrew App revenue ${withdrawalId} for owner ${userId}`,
+        userId,
+        withdrawalId,
+        payoutId,
+        totalCents,
+        paymentBatchId,
+        paymentRefCode,
+      },
+      'webhooks'
+    ).catch(() => null);
+
+    return {
+      withdrawalId,
+      payoutId,
+      amountCents: totalCents,
+      paymentBatchId,
+      paymentRefCode,
+    };
+  } catch (e) {
+    // COMPENSATING REVERT. No Buzz/cash moved, so this is a pure DB rollback:
+    // un-flip the paid_out rows → confirmed and delete the ledger row, in one
+    // transaction. The publisher's confirmed balance is restored exactly and
+    // they can retry (the next attempt mints under a fresh period_key).
+    let revertError: unknown = null;
+    try {
+      await revertPayoutMint({ payoutId, appOwnerUserId: userId });
+    } catch (re) {
+      revertError = re;
+    }
+
+    // Best-effort audit row of the failed-then-reverted attempt. The payoutId
+    // FK is ON DELETE SET NULL so the revert's ledger delete won't drop this.
+    try {
+      await dbWrite.blockPayoutWithdrawal.create({
+        data: {
+          id: withdrawalId,
+          appOwnerUserId: userId,
+          payoutId: revertError ? payoutId : null,
+          amountCents: totalCents,
+          method,
+          refCode,
+          status: 'reverted',
+          note: `Disbursement failed; mint ${
+            revertError ? 'REVERT FAILED — manual intervention required' : 'reverted'
+          }: ${(e as Error)?.message ?? 'unknown error'}`,
+        },
+      });
+    } catch {
+      // swallow — the revert (balance restoration) is what matters; the audit
+      // row is secondary and must never mask the original error.
+    }
+
+    logToAxiom(
+      {
+        name: PAYOUT_LOG_NAME,
+        type: 'error',
+        message: `App revenue withdrawal FAILED for owner ${userId} — mint ${
+          revertError ? 'REVERT FAILED' : 'reverted'
+        }`,
+        userId,
+        withdrawalId,
+        payoutId,
+        totalCents,
+        error: e,
+        revertError,
+      },
+      'webhooks'
+    ).catch(() => null);
+
+    throw e;
+  }
+}

--- a/src/server/services/blocks/payout.service.ts
+++ b/src/server/services/blocks/payout.service.ts
@@ -8,8 +8,11 @@ import {
   revertPayoutMint,
 } from '~/server/services/blocks/buzz-attribution.service';
 import { payToTipaltiAccount } from '~/server/services/user-payment-configuration.service';
-import { getWithdrawalRefCode } from '~/server/utils/creator-program.utils';
-import { newBlockPayoutWithdrawalId, newUlid } from '~/server/utils/app-block-ids';
+import {
+  getBlockPayoutRefCode,
+  newBlockPayoutWithdrawalId,
+  newUlid,
+} from '~/server/utils/app-block-ids';
 import {
   throwAuthorizationError,
   throwBadRequestError,
@@ -19,6 +22,18 @@ import { Flags } from '~/shared/utils/flags';
 import { CashWithdrawalMethod } from '~/shared/utils/prisma/enums';
 
 const PAYOUT_LOG_NAME = 'block-revenue-payout';
+
+/**
+ * Dedicated ALERTABLE log name (audit #4). Emitted ONLY on the one unsafe
+ * branch: Tipalti accepted the payment batch but the subsequent DB row-update
+ * (status → pending_approval) failed, so money has moved but our tracking row
+ * is not in its expected terminal-pending state. We deliberately do NOT revert
+ * in this branch (money is already gone — see #3 ordering), so this needs human
+ * eyes. Wire a Prometheus/Loki alert rule to match this exact `name` so it pages
+ * (no in-process goalert hook exists for money paths; the convention is a
+ * distinct logToAxiom name an alert rule keys on — see manage-alerts skill).
+ */
+const PAYOUT_CRITICAL_LOG_NAME = 'block-revenue-payout-critical-sent-not-recorded';
 
 /**
  * Minimum disbursable balance, in USD cents. Mirrors the creator-program
@@ -49,22 +64,30 @@ export type WithdrawAppRevenueResult = {
  * `cashSettled` burn happens here (contrast `withdrawCash`), which is exactly
  * why the compensating revert below is a pure DB rollback — no Buzz to refund.
  *
- * Sequence (idempotent + retryable):
+ * Sequence (idempotent + retryable; audit #3 SAFE ORDERING — mirrors
+ * withdrawCash's shape so there is NO "revert after money already sent" window):
  *   a. FLAG GATE FIRST — refuse unless `app-blocks-payout-enabled` is on. With
  *      it off (the default), nothing past here runs: no mint, no Tipalti.
  *   b. Preconditions: user not banned; Tipalti payable (tipaltiPaymentsEnabled
  *      + a real withdrawal method ≠ NoPM); confirmed net ≥ $100.
- *   c. Generate a fresh ULID up front and use it as BOTH the mint period_key
- *      AND the withdrawal id, so each attempt is globally unique and a retry
- *      after a revert can't collide with the (deleted) prior period.
- *   d. mintPayoutForOwner(periodKey) — flips this owner's confirmed net to
- *      paid_out under a fresh ledger row. If !minted (net≤0 / already paid),
- *      abort WITHOUT calling Tipalti (nothing to disburse).
- *   e. payToTipaltiAccount(amount = totalCents/100, byUserId:-1) and record the
- *      tracking row.
- *   g. COMPENSATING REVERT on ANY failure after the mint — un-flip the rows +
- *      delete the ledger row (revertPayoutMint) so the publisher keeps the
- *      balance and can retry. This is the load-bearing correctness property.
+ *   c. Create the `block_payout_withdrawal` tracking row in 'processing' FIRST,
+ *      carrying the withdrawalId + refCode, so the Tipalti webhook can ALWAYS
+ *      find a row to reconcile against (no row-after-Tipalti race).
+ *   d. mintPayoutForOwner — serialized per-owner by an advisory lock; flips this
+ *      owner's confirmed net to paid_out under a fresh ledger row. If !minted
+ *      (net≤0 / already paid / 0-flip), mark the row 'no_balance' and abort with
+ *      NO Tipalti call (nothing to disburse).
+ *   e. payToTipaltiAccount(amount = totalCents/100, byUserId:-1).
+ *        - ON FAILURE (no money moved): revertPayoutMint (un-flip rows + delete
+ *          the ledger row) + mark the row 'failed' → balance restored, retryable.
+ *        - ON SUCCESS: update the row → 'pending_approval' with paymentBatchId/
+ *          paymentRefCode. If THAT update fails (money already sent): DO NOT
+ *          revert — emit the CRITICAL alertable signal and leave rows paid_out;
+ *          the row already exists (from step c) so the webhook still reconciles.
+ *
+ * The load-bearing property: a revert (which restores the publisher's balance)
+ * is only ever reachable on the pre-disbursement failure path. We never restore
+ * a balance for money that actually left.
  */
 export async function withdrawAppRevenue(userId: number): Promise<WithdrawAppRevenueResult> {
   // a. FLAG GATE — must be first. Nothing moves until this is explicitly on.
@@ -114,24 +137,47 @@ export async function withdrawAppRevenue(userId: number): Promise<WithdrawAppRev
     );
   }
 
-  // c. Unique request id (drives mint period_key + withdrawal id + refCode). --
+  // c. Unique request id + refCode, and the tracking ROW FIRST (audit #3). -----
+  // The row is created in 'processing' BEFORE the mint/Tipalti so the webhook
+  // can always find a row to reconcile against (keyed on the stored refCode).
+  // refCode uses the dedicated BPW prefix (NOT 'CW') so the Tipalti webhook
+  // routes it to the block-payout handler, not the creator-program one (#2).
   const withdrawalId = newBlockPayoutWithdrawalId();
   const periodKey = `withdraw:${newUlid()}`;
-  const refCode = getWithdrawalRefCode(withdrawalId, userId);
+  const refCode = getBlockPayoutRefCode(withdrawalId);
 
-  // d. MINT — flips confirmed → paid_out under a fresh ledger row. After this
-  // line we OWE the publisher a disbursement or a revert. -------------------
+  await dbWrite.blockPayoutWithdrawal.create({
+    data: {
+      id: withdrawalId,
+      appOwnerUserId: userId,
+      payoutId: null,
+      amountCents: 0, // unknown until the mint claims rows; set on disburse.
+      method,
+      refCode,
+      status: 'processing',
+      note: 'Withdrawal initiated',
+    },
+  });
+
+  // d. MINT — serialized per-owner by an advisory lock inside mintPayoutForOwner.
+  // Flips confirmed → paid_out under a fresh ledger row, OR returns minted:false
+  // (net≤0 / already paid / 0-flip). On !minted: nothing was claimed, so abort
+  // before Tipalti and mark the tracking row 'no_balance'. -----------------------
   const mint = await mintPayoutForOwner({ appOwnerUserId: userId, periodKey });
   if (!mint.minted) {
-    // Net non-positive (e.g. a clawback landed between the gate and the mint)
-    // or the period was somehow already paid. Either way: nothing to disburse,
-    // nothing was flipped to pay out — abort cleanly without touching Tipalti.
+    await dbWrite.blockPayoutWithdrawal
+      .update({
+        where: { id: withdrawalId },
+        data: { status: 'no_balance', note: 'No confirmed App revenue available to withdraw' },
+      })
+      .catch(() => null);
     logToAxiom(
       {
         name: PAYOUT_LOG_NAME,
         type: 'info',
         message: `withdraw aborted before Tipalti (nothing to pay) for owner ${userId}`,
         userId,
+        withdrawalId,
         periodKey,
         mint,
       },
@@ -140,64 +186,41 @@ export async function withdrawAppRevenue(userId: number): Promise<WithdrawAppRev
     throw throwInsufficientFundsError('No confirmed App revenue available to withdraw.');
   }
 
-  const { payoutId, totalCents } = mint;
+  const { payoutId, totalCents, rowCount } = mint;
 
-  // e + g. Disburse, recording the tracking row. ANY failure past the mint
-  // triggers the compensating revert so the publisher keeps their balance. ---
+  // Belt-and-braces against blocker #1: a minted result must carry a positive
+  // amount backed by flipped rows. mintPayoutForOwner already guarantees this
+  // (advisory lock + 0-flip guard), but assert here so a payable amount can
+  // NEVER reach Tipalti without rows behind it.
+  if (totalCents <= 0 || rowCount <= 0) {
+    // This is not a money-moved state (Tipalti hasn't been called), so revert is
+    // safe: un-flip whatever the mint touched + delete the ledger row.
+    await revertPayoutMint({ payoutId, appOwnerUserId: userId }).catch(() => null);
+    await dbWrite.blockPayoutWithdrawal
+      .update({
+        where: { id: withdrawalId },
+        data: { status: 'failed', payoutId: null, note: 'Mint returned no payable rows' },
+      })
+      .catch(() => null);
+    throw throwBadRequestError('No confirmed App revenue available to withdraw.');
+  }
+
+  // e. DISBURSE. ------------------------------------------------------------
+  let paymentBatchId: string;
+  let paymentRefCode: string;
   try {
-    const { paymentBatchId, paymentRefCode } = await payToTipaltiAccount({
+    ({ paymentBatchId, paymentRefCode } = await payToTipaltiAccount({
       requestId: refCode,
       toUserId: userId,
       // Tipalti takes DOLLARS, not cents (mirrors withdrawCash).
       amount: totalCents / 100,
       description: `App Blocks revenue payout ${refCode}`,
       byUserId: -1, // the bank
-    });
-
-    // Tracking record. Written AFTER the Tipalti batch so a failed disbursement
-    // never leaves a row claiming money was sent; if THIS write fails we still
-    // revert the mint (publisher keeps balance) and surface the error.
-    await dbWrite.blockPayoutWithdrawal.create({
-      data: {
-        id: withdrawalId,
-        appOwnerUserId: userId,
-        payoutId,
-        amountCents: totalCents,
-        method,
-        refCode: paymentRefCode,
-        status: 'pending_approval',
-        paymentBatchId,
-        note: 'Payment waiting for Moderator approval',
-      },
-    });
-
-    logToAxiom(
-      {
-        name: PAYOUT_LOG_NAME,
-        type: 'info',
-        message: `withdrew App revenue ${withdrawalId} for owner ${userId}`,
-        userId,
-        withdrawalId,
-        payoutId,
-        totalCents,
-        paymentBatchId,
-        paymentRefCode,
-      },
-      'webhooks'
-    ).catch(() => null);
-
-    return {
-      withdrawalId,
-      payoutId,
-      amountCents: totalCents,
-      paymentBatchId,
-      paymentRefCode,
-    };
+    }));
   } catch (e) {
-    // COMPENSATING REVERT. No Buzz/cash moved, so this is a pure DB rollback:
-    // un-flip the paid_out rows → confirmed and delete the ledger row, in one
-    // transaction. The publisher's confirmed balance is restored exactly and
-    // they can retry (the next attempt mints under a fresh period_key).
+    // FAILURE BEFORE money moved → safe to restore the balance. Compensating
+    // revert (un-flip rows → confirmed + delete the ledger row), then mark the
+    // tracking row 'failed'. The publisher keeps their balance and can retry.
     let revertError: unknown = null;
     try {
       await revertPayoutMint({ payoutId, appOwnerUserId: userId });
@@ -205,31 +228,25 @@ export async function withdrawAppRevenue(userId: number): Promise<WithdrawAppRev
       revertError = re;
     }
 
-    // Best-effort audit row of the failed-then-reverted attempt. The payoutId
-    // FK is ON DELETE SET NULL so the revert's ledger delete won't drop this.
-    try {
-      await dbWrite.blockPayoutWithdrawal.create({
+    await dbWrite.blockPayoutWithdrawal
+      .update({
+        where: { id: withdrawalId },
         data: {
-          id: withdrawalId,
-          appOwnerUserId: userId,
+          // Revert succeeded → ledger row gone → clear the FK. Revert FAILED →
+          // keep the linkage so an operator can find the orphaned ledger row.
           payoutId: revertError ? payoutId : null,
           amountCents: totalCents,
-          method,
-          refCode,
-          status: 'reverted',
+          status: 'failed',
           note: `Disbursement failed; mint ${
             revertError ? 'REVERT FAILED — manual intervention required' : 'reverted'
           }: ${(e as Error)?.message ?? 'unknown error'}`,
         },
-      });
-    } catch {
-      // swallow — the revert (balance restoration) is what matters; the audit
-      // row is secondary and must never mask the original error.
-    }
+      })
+      .catch(() => null);
 
     logToAxiom(
       {
-        name: PAYOUT_LOG_NAME,
+        name: revertError ? PAYOUT_CRITICAL_LOG_NAME : PAYOUT_LOG_NAME,
         type: 'error',
         message: `App revenue withdrawal FAILED for owner ${userId} — mint ${
           revertError ? 'REVERT FAILED' : 'reverted'
@@ -246,4 +263,76 @@ export async function withdrawAppRevenue(userId: number): Promise<WithdrawAppRev
 
     throw e;
   }
+
+  // f. SUCCESS → record the terminal pending-approval state. -----------------
+  // Money has ALREADY moved. If THIS update fails we must NOT revert (we'd
+  // restore a balance that was disbursed). The row already exists (step c) so
+  // the webhook can still reconcile; we emit a CRITICAL alertable signal and
+  // leave the rows paid_out. (#3 hard-case elimination + #4 alert.)
+  try {
+    await dbWrite.blockPayoutWithdrawal.update({
+      where: { id: withdrawalId },
+      data: {
+        payoutId,
+        amountCents: totalCents,
+        status: 'pending_approval',
+        paymentBatchId,
+        // Keep `refCode` as the BPW refCode we SENT (the webhook-lookup key);
+        // store what Tipalti echoed separately. They're equal today
+        // (payToTipaltiAccount slices requestId to 16 chars == our refCode), but
+        // recording both keeps reconciliation robust if Tipalti ever transforms.
+        paymentRefCode,
+        note: 'Payment waiting for Moderator approval',
+      },
+    });
+  } catch (updateErr) {
+    logToAxiom(
+      {
+        name: PAYOUT_CRITICAL_LOG_NAME,
+        type: 'error',
+        message: `CRITICAL: Tipalti payment SENT but block_payout_withdrawal row update FAILED for owner ${userId} — money moved, row not in pending_approval. Manual reconciliation required.`,
+        userId,
+        withdrawalId,
+        payoutId,
+        totalCents,
+        paymentBatchId,
+        paymentRefCode,
+        error: updateErr,
+      },
+      'webhooks'
+    ).catch(() => null);
+    // Money is out the door; surface success to the caller (the disbursement
+    // happened) rather than tripping a retry that would double-pay. The webhook
+    // reconciles the row off the persisted refCode.
+    return {
+      withdrawalId,
+      payoutId,
+      amountCents: totalCents,
+      paymentBatchId,
+      paymentRefCode,
+    };
+  }
+
+  logToAxiom(
+    {
+      name: PAYOUT_LOG_NAME,
+      type: 'info',
+      message: `withdrew App revenue ${withdrawalId} for owner ${userId}`,
+      userId,
+      withdrawalId,
+      payoutId,
+      totalCents,
+      paymentBatchId,
+      paymentRefCode,
+    },
+    'webhooks'
+  ).catch(() => null);
+
+  return {
+    withdrawalId,
+    payoutId,
+    amountCents: totalCents,
+    paymentBatchId,
+    paymentRefCode,
+  };
 }

--- a/src/server/utils/__tests__/app-block-payout-refcode.test.ts
+++ b/src/server/utils/__tests__/app-block-payout-refcode.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BLOCK_PAYOUT_REFCODE_PREFIX,
+  getBlockPayoutRefCode,
+  isBlockPayoutRefCode,
+  newBlockPayoutWithdrawalId,
+} from '../app-block-ids';
+
+describe('App-Blocks payout refCode (audit blocker #2)', () => {
+  it('derives a refCode that does NOT collide with the creator-program CW prefix', () => {
+    const id = newBlockPayoutWithdrawalId();
+    const refCode = getBlockPayoutRefCode(id);
+    expect(refCode.startsWith(BLOCK_PAYOUT_REFCODE_PREFIX)).toBe(true);
+    // CRITICAL: the Tipalti webhook dispatches creator-program payouts on the
+    // 'CW' prefix. Ours must never start with 'CW' or it would misroute → 400.
+    expect(refCode.startsWith('CW')).toBe(false);
+  });
+
+  it('fits within Tipalti’s 16-char refCode cap', () => {
+    const refCode = getBlockPayoutRefCode(newBlockPayoutWithdrawalId());
+    expect(refCode.length).toBeLessThanOrEqual(16);
+    // exactly 16 (BPW + 13-char ULID tail)
+    expect(refCode.length).toBe(16);
+  });
+
+  it('isBlockPayoutRefCode recognizes the rail and rejects CW / buzz refCodes', () => {
+    expect(isBlockPayoutRefCode(getBlockPayoutRefCode(newBlockPayoutWithdrawalId()))).toBe(true);
+    expect(isBlockPayoutRefCode('CW123_abc')).toBe(false);
+    expect(isBlockPayoutRefCode('someBuzzTransferId')).toBe(false);
+  });
+
+  it('two distinct withdrawal ids yield distinct refCodes', () => {
+    const a = getBlockPayoutRefCode(newBlockPayoutWithdrawalId());
+    const b = getBlockPayoutRefCode(newBlockPayoutWithdrawalId());
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -98,3 +98,13 @@ export function newBlockAttributionPayoutId(): string {
 export function newAppUserScopeGrantId(): string {
   return `augr_${newUlid()}`;
 }
+
+/**
+ * Tracking record for a publisher revenue-share DISBURSEMENT (Tipalti). One per
+ * `withdrawAppRevenue` attempt; doubles as the Tipalti refCode source. Kept on
+ * its own `block_payout_withdrawal` table so app-revenue payouts are never
+ * conflated with creator-program `CashWithdrawal` rows (separate rail).
+ */
+export function newBlockPayoutWithdrawalId(): string {
+  return `bpw_${newUlid()}`;
+}

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -101,10 +101,48 @@ export function newAppUserScopeGrantId(): string {
 
 /**
  * Tracking record for a publisher revenue-share DISBURSEMENT (Tipalti). One per
- * `withdrawAppRevenue` attempt; doubles as the Tipalti refCode source. Kept on
- * its own `block_payout_withdrawal` table so app-revenue payouts are never
- * conflated with creator-program `CashWithdrawal` rows (separate rail).
+ * `withdrawAppRevenue` attempt. Kept on its own `block_payout_withdrawal` table
+ * so app-revenue payouts are never conflated with creator-program
+ * `CashWithdrawal` rows (separate rail).
  */
 export function newBlockPayoutWithdrawalId(): string {
   return `bpw_${newUlid()}`;
+}
+
+/**
+ * App-Blocks-rail Tipalti refCode prefix. Deliberately does NOT start with
+ * 'CW' (the creator-program `CashWithdrawal` prefix) so the Tipalti webhook can
+ * dispatch app-rail payments to the dedicated `block_payout_withdrawal`
+ * reconciliation handler BEFORE the `startsWith('CW')` branch — routing them
+ * into the CW handler would 400 (the lookup fails) and leave the row stuck
+ * forever. See `tipalti.ts` and `getBlockPayoutRefCode`.
+ */
+export const BLOCK_PAYOUT_REFCODE_PREFIX = 'BPW';
+
+/**
+ * Derive a Tipalti refCode for an App-Blocks payout from its withdrawal id.
+ *
+ * Tipalti caps refCodes at 16 chars (`payToTipaltiAccount` slices
+ * `requestId.slice(0, 16)`), so we CANNOT round-trip the full `bpw_<ulid>` id
+ * back out of the refCode. Instead the refCode is `BPW` + the last 13 chars of
+ * the ULID suffix (the high-entropy random tail) = exactly 16 chars, and the
+ * FULL refCode is persisted on the `block_payout_withdrawal` row + indexed, so
+ * the webhook looks the row up by exact `ref_code` match rather than parsing the
+ * id back out. Collision risk across the 13-char Crockford tail (65 bits) is
+ * negligible, and the unique `ref_code` lookup is exact regardless.
+ *
+ * @param withdrawalId a `bpw_<ulid>` id from `newBlockPayoutWithdrawalId`
+ */
+export function getBlockPayoutRefCode(withdrawalId: string): string {
+  // Strip the 'bpw_' prefix to get the 26-char ULID, then take its tail so the
+  // refCode carries the random (collision-resistant) portion, not just the
+  // shared millisecond timestamp prefix.
+  const ulid = withdrawalId.startsWith('bpw_') ? withdrawalId.slice(4) : withdrawalId;
+  const tail = ulid.slice(-13);
+  return `${BLOCK_PAYOUT_REFCODE_PREFIX}${tail}`; // 3 + 13 = 16 chars
+}
+
+/** True if a Tipalti refCode belongs to the App-Blocks payout rail. */
+export function isBlockPayoutRefCode(refCode: string): boolean {
+  return refCode.startsWith(BLOCK_PAYOUT_REFCODE_PREFIX);
 }


### PR DESCRIPTION
## What

Adds a **publisher-initiated, full-balance withdrawal** of App-Block revenue share over a **separate Tipalti rail (pull model)**, fully **DARK behind a flag that defaults closed** — **merging this moves NO money.**

Backend only (PR1). The dashboard UI and the auto-push payout option are **deliberate follow-ups**. The bulk-payout cron (`bulk-payout-block-attributions.ts`) stays **observer-only**.

## Why "separate rail"

The rail is the existing attribution ledger. `withdrawAppRevenue` nets the publisher's **confirmed `block_buzz_attribution` share** (USD cents, already net of the rate-card platform split, with negative clawback rows included) and disburses it via `payToTipaltiAccount` **directly**. It **NEVER** credits the externally-owned Buzz cash accounts (`cashSettled`/`cashPending`), so it is **not subject to the creator-program pool cap or the 30% fee**, and it **preserves the existing Tipalti 1099-NEC** reporting path. (Contrast `withdrawCash`, which burns `cashSettled` Buzz — none of that happens here, which is exactly why the revert below is a pure DB rollback.)

V2 placeholder rate-card values are **unchanged** — payout reads the same confirmed share the rate card already computed.

## Dark / flag-gated (no money on merge)

- New dedicated **global** Flipt flag `app-blocks-payout-enabled`, **fail-safe CLOSED**: the flag is created in Flipt only *after* this merges, so a missing flag (or unreachable Flipt) → `isFlipt` → `false` → `withdrawAppRevenue` refuses → **no mint, no Tipalti, no money** on merge.
- `withdrawAppRevenue` checks this flag **first**, before reading the user.
- The tRPC procs are **also** behind `enforceAppBlocksFlag` (the mod-segmented visibility gate), so the surface is doubly dark pre-launch.

**To turn payouts ON:** create `app-blocks-payout-enabled` in Flipt as a plain **global boolean** with base `enabled: true`. To pause instantly, flip it back to `false` (or delete it) — the next call refuses, no redeploy.

## Pull model (publisher-initiated, min $100)

Full-balance withdrawal (no partial amount). Sequence in `withdrawAppRevenue(userId)`:
1. Flag gate (above).
2. Preconditions: user not banned; Tipalti payable (reuses `withdrawCash`'s `tipaltiPaymentsEnabled` + valid `tipaltiWithdrawalMethod` ≠ `NoPM` checks); confirmed net ≥ **$100** (10000 cents) via `getRevenueForOwner`.
3. Fresh ULID up front, used as the `mintPayoutForOwner` `periodKey` (unique per attempt → retryable, no double-pay via the `(owner, period)` UNIQUE).
4. `mintPayoutForOwner` — if `!minted` (net ≤ 0 / already paid), abort **without** calling Tipalti.
5. `payToTipaltiAccount({ amount: totalCents/100 /* DOLLARS */, byUserId: -1, … })` + write the tracking row.

## Revert-on-failure invariant (the load-bearing property)

On **any** failure after the mint (Tipalti error, or the tracking-record write), `revertPayoutMint` runs in **one transaction**: un-flips the `paid_out` rows for this `payoutId` back to `confirmed` (clears `paid_out_at`/`payout_id`) **and deletes** the `block_attribution_payout` ledger row. Since no Buzz/cash ever moved, the publisher's confirmed balance is **restored exactly** and they can retry. An audit `block_payout_withdrawal` row (`status='reverted'`) is written; if the revert *itself* fails, the row keeps the `payoutId` linkage and a "manual intervention required" note. Logged to Axiom (mirrors `withdrawCash`).

## Migration — NOT auto-applied

Adds a dedicated **`block_payout_withdrawal`** tracking table (Prisma model + `prisma/migrations/20260616130000_payout2_block_payout_withdrawal/migration.sql`), kept **separate** from creator-program `CashWithdrawal` so app-revenue payouts are never conflated with cash withdrawals. **The migration is NOT auto-applied** — a human applies it per the repo's manual-migration rule (prod nvme0 + the dev clone). Creating the table changes no behaviour on its own (only `withdrawAppRevenue` writes it, and that's flag-gated closed).

## Files

- `src/server/services/blocks/payout.service.ts` (new) — `withdrawAppRevenue(userId)`, `MIN_APP_REVENUE_PAYOUT_CENTS`.
- `src/server/services/blocks/buzz-attribution.service.ts` — `revertPayoutMint({payoutId, appOwnerUserId})` (new compensating primitive).
- `src/server/services/app-blocks-flag.ts` — `APP_BLOCKS_PAYOUT_FLAG` + `isAppBlocksPayoutEnabled()`.
- `src/server/routers/blocks.router.ts` — `getMyAppRevenue` (read), `withdrawMyAppRevenue` (mutation); both `protectedProcedure` + `enforceAppBlocksFlag`, owner-scoped to `ctx.user.id`.
- `src/server/utils/app-block-ids.ts` — `newBlockPayoutWithdrawalId()`.
- `prisma/schema.full.prisma` — `BlockPayoutWithdrawal` model + User back-relation.
- `prisma/migrations/.../migration.sql` — **not auto-applied**.
- Tests: `payout.service.test.ts` (new, 12) + `buzz-attribution.service.test.ts` (+3 revert tests).

## Tests (real output)

```
✓ buzz-attribution.service.test.ts (24 tests)
✓ payout.service.test.ts (12 tests)
Test Files  2 passed (2)
     Tests  36 passed (36)
```

Covers: flag-off rejected (no Tipalti, never reads user); banned/non-payable/NoPM rejected; below-$100 rejected (no mint); $100 exactly allowed; happy path mints+flips+pays the right **dollar** amount (cents/100), byUserId -1, to the owner; **Tipalti-failure → full revert** (rows back to confirmed, ledger deleted, balance preserved, error re-thrown); tracking-write-failure → revert; revert-itself-fails → audit keeps linkage; idempotent double-withdraw (`alreadyPaid` path → no Tipalti); clawback net ≤ 0 aborts without minting.

## Verification notes

- Tests run via a node-only vitest config (NixOS can't load `@vitest/browser-playwright`); the `unit` project config is otherwise unchanged.
- The 3 new TS files lint clean. A full repo typecheck is dominated by pre-existing stale-Prisma-client noise (the generated client isn't regenerated in this worktree) — **zero** type errors reference any touched file or new symbol. The new Prisma delegate usage mirrors the existing `blockAttributionPayout` delegate exactly and is exercised against mocks in tests.

---

## Audit fixes (commit `ffd014c23`) — money-correctness blockers closed

An adversarial audit of this rail found two 🔴 money blockers plus ordering/alerting/audit gaps. All fixed; the rail stays **DARK** (the `app-blocks-payout-enabled` flag still defaults closed — merging moves zero dollars).

### 🔴 1 — Concurrent double-pay (fixed)
- **Per-owner advisory lock.** `mintPayoutForOwner` now runs `SELECT pg_advisory_xact_lock(<fixed-domain-int>, ownerId)` at the top of its `$transaction` (2-arg form so the lock namespace can't collide with any other advisory-lock domain). Two concurrent withdrawals for one owner serialize: the winner aggregates→flips→commits; the loser blocks, then re-aggregates the post-flip state, sees net 0, and returns `minted:false` — so it can never pay Tipalti for already-paid rows.
- **0-flip defense-in-depth.** If the flip touches 0 rows after a positive aggregate, the just-created ledger row is deleted in-tx and the result is `minted:false`. Unreachable with the lock, but closes the invariant.
- **Caller guard.** `withdrawAppRevenue` only calls `payToTipaltiAccount` when `mint.minted && totalCents>0 && rowCount>0`.
- **Rate limit.** `withdrawMyAppRevenue` proc now carries `rateLimit(3 / 10 min)` as a cheap double-click/retry guard.

### 🔴 2 — Tipalti webhook misroute (fixed — rail now reconciles)
- **Dedicated refCode.** New `getBlockPayoutRefCode` → `BPW`-prefixed, 16-char (Tipalti cap), and the full refCode is persisted + indexed on `block_payout_withdrawal` so the webhook looks the row up by exact `ref_code` match (the refCode isn't round-trippable into the id).
- **Dedicated webhook branch.** `tipalti.ts` detects the `BPW` prefix **before** the `startsWith('CW')` checks and routes to `processBlockPayoutEvent` (extracted to `payout-webhook.service.ts`): payment/group **approved → `completed`**; payment **declined/error/cancelled → `failed`** AND `revertPayoutMint` (un-flip rows → `confirmed`, restoring the publisher's balance — safe because money did NOT leave). The `CW` path is untouched.

### 🟡 3/4/5 — safe ordering + alerting + audit
- **Safe ordering (mirrors `withdrawCash`):** create the tracking row in `processing` **first** → mint → on `!minted` mark `no_balance` (no Tipalti) → on Tipalti failure `revertPayoutMint` + mark `failed` → on success update to `pending_approval`. **If the success-path update fails (money already sent) we do NOT revert** — we emit the critical alert and leave rows `paid_out`; the row already exists so the webhook still reconciles. This removes the "revert restores a balance that was actually disbursed" window.
- **Alerting (#4):** the "Tipalti sent but DB row not updated / revert failed" branches emit a dedicated alertable `logToAxiom` name: **`block-revenue-payout-critical-sent-not-recorded`**. There is no in-process goalert hook for money paths in this repo; the convention (see `manage-alerts`) is a distinct log name an alert rule matches. **Wire a Loki/Prometheus alert on this name before flipping the payout flag on.**
- **Audit (#5):** `revertPayoutMint`'s hard-delete is now documented + structurally reachable only on the pre-disbursement failure path (never after a successful Tipalti call).

### 🟡 6 — `getMyAppRevenue` now returns `pendingWithdrawalCents`
Sum of `processing`/`pending_approval` rows, so the UI can avoid offering a balance a withdrawal is already consuming.

### Migration
The **unapplied** `20260616130000` migration was edited **in place** (no second migration): status set widened to `processing | pending_approval | completed | failed | no_balance`, `amount_cents >= 0` (0 while `processing`), added `payment_ref_code`, and a `ref_code` index for webhook lookup. `schema.full.prisma` kept in sync. **NOT applied** — a human applies it per the repo's manual-migration rule.

### `block_payout_withdrawal` state machine
```
processing ──mint !minted──────────────► no_balance        (terminal, no money)
processing ──Tipalti fail──► revert ────► failed           (terminal, balance restored)
processing ──Tipalti ok─────────────────► pending_approval
pending_approval ──webhook approved/completed──► completed  (terminal, money sent)
pending_approval ──webhook declined/error/cancelled──► revert ──► failed (terminal, balance restored)
```

### Reconciliation runbook
- **Normal:** publisher withdraws → row `processing` → `pending_approval` (Tipalti batch created, awaiting mod approval) → Tipalti webhook → `completed` (approved) or `failed` (declined, balance auto-restored via `revertPayoutMint`).
- **Stuck `processing`:** the service crashed between row-create and the success/failure update. No Tipalti batch was confirmed for it (no `payment_batch_id`). Safe to mark `failed` manually and re-check the publisher's confirmed balance (rows were either never flipped or already reverted).
- **`block-revenue-payout-critical-sent-not-recorded` fires:** money was sent (or a decline-revert failed) but our DB write didn't land. Find the row by `ref_code` / `withdrawalId` in the log, cross-check the Tipalti dashboard for the `payment_batch_id`, and (a) if Tipalti shows the payment, set the row to its true terminal state by hand — do **not** re-run the withdrawal (it would double-pay); (b) if a decline-revert failed, manually re-run `revertPayoutMint({payoutId, appOwnerUserId})` (idempotent) to restore the balance.
- **Webhook says "not found for refCode":** the refCode isn't `BPW`-prefixed (creator-program `CW` → that's the other handler) or the row was never created. Check `block_payout_withdrawal.ref_code`.

### Tests (55 pass, real run)
`mintPayoutForOwner` advisory-lock acquisition + 0-flip guard + losing-race-net-0; `withdrawAppRevenue` safe-ordering happy/Tipalti-failure/critical-update-failure/no-balance/zero-amount paths; `processBlockPayoutEvent` routing/approve/decline/re-deliver/critical; BPW refCode prefix-not-CW + 16-char cap. **Advisory-lock serialization under true DB concurrency needs an integration test** (the unit harness mocks `$transaction`/`$executeRaw`, so it asserts the lock is *acquired before the aggregate* and the net-0 loser branch, not real contention).
