### PR TITLE
feat(app-blocks): full-page apps (W10) on a slot-registry foundation — DARK

### DIFF
--- a/src/components/AppBlocks/BlockSlot.tsx
+++ b/src/components/AppBlocks/BlockSlot.tsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { ModelSlotContext } from './types';
+import { slotRemountKey } from './types';
 
 interface BlockSlotProps {
   slotId: ModelSlotContext['slotId'];
@@ -37,14 +38,17 @@ export function BlockSlot({ slotId, context }: BlockSlotProps) {
   // installs to show; otherwise BlockSlot returns null entirely (no empty
   // gap row in the sidebar Stack).
   //
-  // H-4: key on (slotId, modelId) so navigation between model pages
-  // force-unmounts the client. Previously the same mount would persist
+  // H-4: key on (slotId, entityType, entityId) so navigation between model
+  // pages force-unmounts the client. Previously the same mount would persist
   // across model changes; the iframe could receive a single frame of
   // BLOCK_INIT with the new slotContext for the old install before the
-  // tRPC query refreshed and BlockHost-keyed remount caught up.
+  // tRPC query refreshed and BlockHost-keyed remount caught up. The
+  // entity-agnostic helper PRESERVES the model behavior exactly: for a model
+  // context the entity id is the modelId, so this remains
+  // `${slotId}:model:${modelId}` and force-unmounts on model navigation.
   return (
     <BlockSlotClient
-      key={`${slotId}:${context.modelId}`}
+      key={slotRemountKey({ slotId, entityType: 'model', entityId: context.modelId })}
       slotId={slotId}
       context={context}
     />

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1,8 +1,10 @@
 import { Box } from '@mantine/core';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BlockFallback } from './BlockFallback';
 import { AppBlockChrome } from './IframeHost';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
+import { grantedPageScopes, pageFallbackReason } from './pageBlockHostLogic';
 import { intersectSandbox } from './sandbox';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, PageContext } from './types';
@@ -34,7 +36,7 @@ import type { BlockInitPayload, PageContext } from './types';
 const BLOCK_READY_TIMEOUT_MS = 10_000;
 const TOKEN_WAIT_TIMEOUT_MS = 15_000;
 
-type Status = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token';
+type Status = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token' | 'error';
 
 export interface PageBlockHostProps {
   /** AppBlock id (`apb_*`) — used to build the BLOCK_INIT ids + trust chrome. */
@@ -54,6 +56,20 @@ export interface PageBlockHostProps {
   /** The minted, viewer-scoped page token (no money scopes). */
   token: string | null;
   expiresAt: string | null;
+  /** #3/#6: the page manifest's declared scopes. The host posts the ACTUAL
+   *  granted set (declared − missingScopes) in BLOCK_INIT so the block sees the
+   *  scopes the JWT actually carries (e.g. `apps:storage:*`), not `[]`. */
+  declaredScopes: string[];
+  /** #3/#6: consent-gated scopes withheld from the token (reported by the mint).
+   *  Trimmed from the wrapped `token.scopes` so the block's capability check is
+   *  accurate, and used to surface a consent-needed terminal state. */
+  missingScopes?: string[];
+  /** #3/#6: true when the app's approved manifest declares scopes the viewer has
+   *  not granted (the token still mints with the granted subset). */
+  needsConsent?: boolean;
+  /** #3/#6: the token mint errored. Surface an error state instead of hanging at
+   *  `no_token`. */
+  tokenError?: boolean;
   viewer: { id: number; username: string | null } | null;
   theme: 'light' | 'dark';
 }
@@ -70,6 +86,10 @@ export function PageBlockHost({
   slug,
   token,
   expiresAt,
+  declaredScopes,
+  missingScopes,
+  needsConsent,
+  tokenError,
   viewer,
   theme,
 }: PageBlockHostProps) {
@@ -89,6 +109,14 @@ export function PageBlockHost({
   }, [iframeSrc]);
 
   const { send, onMessage } = usePostMessage({ iframeRef, expectedOrigin });
+
+  // #3/#6: the scopes the minted JWT ACTUALLY carries (declared − missing).
+  // See pageBlockHostLogic.grantedPageScopes. Posting `[]` (the old hardcode)
+  // lied to the block about its capabilities.
+  const grantedScopes = useMemo<string[]>(
+    () => grantedPageScopes(declaredScopes, missingScopes),
+    [declaredScopes, missingScopes]
+  );
 
   // Current sub-path under /apps/run/<slug>/<...path> (no leading slash). Read
   // from the router so a popstate / back-forward reflects into the block.
@@ -121,9 +149,10 @@ export function PageBlockHost({
         // initSent only fires after token is present (gated below); the
         // controller posts the freshest payload via the ref.
         raw: token ?? '',
-        // A page token carries only viewer-scoped ambient scopes (apps:storage:*)
-        // — never money scopes. The block reads scopes off the wrapped token.
-        scopes: [],
+        // #3/#6: the REAL granted scopes the JWT carries (page = viewer-scoped
+        // ambient `apps:storage:*`; never money). Posting `[]` lied to the block
+        // about the capabilities it holds.
+        scopes: grantedScopes,
         expiresAt: expiresAt ?? '',
       },
       context: buildContext(),
@@ -132,7 +161,7 @@ export function PageBlockHost({
       theme,
       renderMode: 'iframe',
     }),
-    [appId, blockId, blockInstanceId, buildContext, expiresAt, token, viewer, theme]
+    [appId, blockId, blockInstanceId, buildContext, expiresAt, grantedScopes, token, viewer, theme]
   );
   buildInitPayloadRef.current = buildInitPayload;
 
@@ -161,6 +190,16 @@ export function PageBlockHost({
     };
   }, [token, status, sendInitOnce]);
 
+  // #3/#6: the mint errored (no token will arrive). Surface an `error` state
+  // immediately rather than waiting out the no_token timeout — a hard mint
+  // failure is terminal. (`needsConsent` is NOT terminal: the token still mints
+  // with the granted subset, so the block loads; we only thread the consent
+  // signal into the wrapped scopes above.)
+  useEffect(() => {
+    if (!tokenError || token) return;
+    setStatus((current) => (current === 'loading' ? 'error' : current));
+  }, [tokenError, token]);
+
   // Token never resolves → surface a no_token state instead of an endless
   // skeleton.
   useEffect(() => {
@@ -174,8 +213,10 @@ export function PageBlockHost({
   // Push a TOKEN_REFRESH when the token rotates after init.
   useEffect(() => {
     if (!initSentRef.current || !token) return;
-    send('TOKEN_REFRESH', { token: { raw: token, scopes: [], expiresAt: expiresAt ?? '' } });
-  }, [token, expiresAt, send]);
+    send('TOKEN_REFRESH', {
+      token: { raw: token, scopes: grantedScopes, expiresAt: expiresAt ?? '' },
+    });
+  }, [token, expiresAt, grantedScopes, send]);
 
   // Answer a block-initiated REQUEST_TOKEN.
   useEffect(() => {
@@ -187,11 +228,11 @@ export function PageBlockHost({
           : undefined;
       send('TOKEN_REFRESH_RESPONSE', {
         ...(requestId ? { requestId } : {}),
-        token: { raw: token, scopes: [], expiresAt: expiresAt ?? '' },
+        token: { raw: token, scopes: grantedScopes, expiresAt: expiresAt ?? '' },
       });
     });
     return off;
-  }, [token, expiresAt, send, onMessage]);
+  }, [token, expiresAt, grantedScopes, send, onMessage]);
 
   // BLOCK_READY → ready.
   useEffect(() => {
@@ -250,6 +291,20 @@ export function PageBlockHost({
     send('ROUTE_CHANGED', { subPath });
   }, [subPath, status, send]);
 
+  // #5: page-visibility SUSPEND / RESUME — tell the block to pause work when its
+  // tab is hidden and resume when shown (mirrors IframeHost). Only wired once the
+  // block is ready so a pre-handshake block isn't told to suspend/resume before
+  // it can listen.
+  useEffect(() => {
+    if (status !== 'ready') return;
+    const handler = () => {
+      if (document.visibilityState === 'visible') send('RESUME');
+      else send('SUSPEND');
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [status, send]);
+
   // SUSPEND on unmount.
   useEffect(() => {
     return () => {
@@ -258,10 +313,13 @@ export function PageBlockHost({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Terminal-failure collapse — same anti-spoof posture as IframeHost: a failed
-  // page block shows the trust chrome + nothing (never a fake page).
   const showIframe = status === 'loading' || status === 'ready';
   const isReady = status === 'ready';
+
+  // #4: terminal-state fallback — render a BlockFallback message INSIDE the page
+  // frame instead of a blank viewport. See pageBlockHostLogic.pageFallbackReason
+  // for the status→reason mapping + the anti-spoof rationale.
+  const fallbackReason = pageFallbackReason(status);
 
   return (
     <Box
@@ -276,6 +334,13 @@ export function PageBlockHost({
       }}
       data-testid="app-page-frame"
       data-block-instance-id={blockInstanceId}
+      // #3/#6: surface the consent signal as an observable attribute. The page
+      // token still mints with the granted subset (so the block loads — consent
+      // is NOT terminal here), but a block requesting an ungranted consent-gated
+      // scope drives its own REQUEST_CONSENT against the missing set. This makes
+      // the host-known signal visible to the block frame / debugging rather than
+      // silently swallowed.
+      data-needs-consent={needsConsent ? 'true' : 'false'}
     >
       <AppBlockChrome blockInstanceId={blockInstanceId} appName={appName} />
       {showIframe ? (
@@ -296,6 +361,10 @@ export function PageBlockHost({
             pointerEvents: isReady ? 'auto' : 'none',
           }}
         />
+      ) : fallbackReason ? (
+        <Box style={{ flex: 1, padding: 'var(--mantine-spacing-md)' }} data-testid="app-page-fallback">
+          <BlockFallback reason={fallbackReason} blockName={appName} />
+        </Box>
       ) : null}
     </Box>
   );

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1,0 +1,302 @@
+import { Box } from '@mantine/core';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AppBlockChrome } from './IframeHost';
+import { IframeInitController, shouldStartInit } from './iframeInitController';
+import { intersectSandbox } from './sandbox';
+import { usePostMessage } from './usePostMessage';
+import type { BlockInitPayload, PageContext } from './types';
+
+/**
+ * W10 — full-page App Block host. Renders a block as a FULL-VIEWPORT surface
+ * (not a model-column panel) under the same W7 trust chrome, driving the same
+ * BLOCK_INIT / postMessage handshake the model IframeHost uses — but with a
+ * PAGE context (entity=none, viewer-scoped, NO money scopes) and a deep-link
+ * bridge (subPath forwarding + block-requested navigation).
+ *
+ * Deliberately a SEPARATE component from IframeHost (which is model-coupled:
+ * checkpoint / showcase queries gated on modelId, model-only chrome) so the
+ * behavior-preserving gate on the model path is not at risk. It reuses the
+ * shared primitives: usePostMessage (origin-pinned transport),
+ * IframeInitController (retry-until-BLOCK_READY), AppBlockChrome (spoof-proof
+ * trust frame), intersectSandbox (client-side sandbox allowlist).
+ *
+ * Security posture (mirrors IframeHost):
+ *   - BLOCK_INIT is posted to `new URL(iframeSrc).origin` (explicit target,
+ *     never "*"); incoming messages from other origins are dropped.
+ *   - Sandbox is the manifest ∩ trust-tier allowlist (client-side belt).
+ *   - referrerPolicy=no-referrer; the page never carries a model/money scope.
+ *   - Block-requested navigation (NAVIGATE) is constrained to the page's own
+ *     sub-path space and uses shallow routing — a block can deep-link WITHIN
+ *     its page but can't push the host off to an arbitrary route.
+ */
+
+const BLOCK_READY_TIMEOUT_MS = 10_000;
+const TOKEN_WAIT_TIMEOUT_MS = 15_000;
+
+type Status = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token';
+
+export interface PageBlockHostProps {
+  /** AppBlock id (`apb_*`) — used to build the BLOCK_INIT ids + trust chrome. */
+  appBlockId: string;
+  blockId: string;
+  appId: string;
+  /** The synthetic `page_<appBlockId>` instance id the token was minted for. */
+  blockInstanceId: string;
+  appName: string;
+  /** The `<slug>.civit.ai` bundle URL (manifest.iframe.src), server-resolved. */
+  iframeSrc: string;
+  /** manifest.iframe.sandbox, server-resolved. */
+  sandbox: string;
+  trustTier: 'unverified' | 'verified' | 'internal';
+  /** The page slug (== blockId). Forwarded in context for the block. */
+  slug: string;
+  /** The minted, viewer-scoped page token (no money scopes). */
+  token: string | null;
+  expiresAt: string | null;
+  viewer: { id: number; username: string | null } | null;
+  theme: 'light' | 'dark';
+}
+
+export function PageBlockHost({
+  appBlockId,
+  blockId,
+  appId,
+  blockInstanceId,
+  appName,
+  iframeSrc,
+  sandbox,
+  trustTier,
+  slug,
+  token,
+  expiresAt,
+  viewer,
+  theme,
+}: PageBlockHostProps) {
+  const router = useRouter();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const initSentRef = useRef<boolean>(false);
+  const controllerRef = useRef<IframeInitController | null>(null);
+  const buildInitPayloadRef = useRef<() => BlockInitPayload>();
+
+  const expectedOrigin = useMemo(() => {
+    try {
+      return new URL(iframeSrc).origin;
+    } catch {
+      return '';
+    }
+  }, [iframeSrc]);
+
+  const { send, onMessage } = usePostMessage({ iframeRef, expectedOrigin });
+
+  // Current sub-path under /apps/run/<slug>/<...path> (no leading slash). Read
+  // from the router so a popstate / back-forward reflects into the block.
+  const subPath = useMemo(() => {
+    const raw = router.query.path;
+    if (Array.isArray(raw)) return raw.join('/');
+    if (typeof raw === 'string') return raw;
+    return '';
+  }, [router.query.path]);
+
+  const buildContext = useCallback(
+    (): PageContext => ({
+      slotId: 'app.page',
+      entityType: 'none',
+      slug,
+      subPath,
+      viewerUserId: viewer?.id ?? null,
+      viewerUsername: viewer?.username ?? null,
+      theme,
+    }),
+    [slug, subPath, viewer, theme]
+  );
+
+  const buildInitPayload = useCallback(
+    (): BlockInitPayload => ({
+      blockInstanceId,
+      blockId,
+      appId,
+      token: {
+        // initSent only fires after token is present (gated below); the
+        // controller posts the freshest payload via the ref.
+        raw: token ?? '',
+        // A page token carries only viewer-scoped ambient scopes (apps:storage:*)
+        // — never money scopes. The block reads scopes off the wrapped token.
+        scopes: [],
+        expiresAt: expiresAt ?? '',
+      },
+      context: buildContext(),
+      settings: { publisherSettings: {}, userSettings: {} },
+      viewer,
+      theme,
+      renderMode: 'iframe',
+    }),
+    [appId, blockId, blockInstanceId, buildContext, expiresAt, token, viewer, theme]
+  );
+  buildInitPayloadRef.current = buildInitPayload;
+
+  const sendInitOnce = useCallback(() => {
+    initSentRef.current = true;
+    send('BLOCK_INIT', (buildInitPayloadRef.current ?? (() => undefined as never))());
+  }, [send]);
+
+  // Init handshake — start once token is present (no checkpoint dependency for
+  // a page). Retry-until-BLOCK_READY via the shared controller.
+  useEffect(() => {
+    if (!shouldStartInit({ status, hasToken: !!token, checkpointLoading: false })) return;
+    if (controllerRef.current) return;
+    const controller = new IframeInitController({
+      sendInit: sendInitOnce,
+      readyTimeoutMs: BLOCK_READY_TIMEOUT_MS,
+      onReadyTimeout: () => {
+        setStatus((current) => (current === 'loading' ? 'timeout' : current));
+      },
+    });
+    controllerRef.current = controller;
+    controller.start();
+    return () => {
+      controller.dispose();
+      controllerRef.current = null;
+    };
+  }, [token, status, sendInitOnce]);
+
+  // Token never resolves → surface a no_token state instead of an endless
+  // skeleton.
+  useEffect(() => {
+    if (status !== 'loading' || token) return;
+    const t = setTimeout(() => {
+      setStatus((current) => (current === 'loading' && !token ? 'no_token' : current));
+    }, TOKEN_WAIT_TIMEOUT_MS);
+    return () => clearTimeout(t);
+  }, [status, token]);
+
+  // Push a TOKEN_REFRESH when the token rotates after init.
+  useEffect(() => {
+    if (!initSentRef.current || !token) return;
+    send('TOKEN_REFRESH', { token: { raw: token, scopes: [], expiresAt: expiresAt ?? '' } });
+  }, [token, expiresAt, send]);
+
+  // Answer a block-initiated REQUEST_TOKEN.
+  useEffect(() => {
+    const off = onMessage<{ requestId?: string } | undefined>('REQUEST_TOKEN', (raw) => {
+      if (!token || !initSentRef.current) return;
+      const requestId =
+        raw && typeof raw === 'object' && typeof raw.requestId === 'string'
+          ? raw.requestId
+          : undefined;
+      send('TOKEN_REFRESH_RESPONSE', {
+        ...(requestId ? { requestId } : {}),
+        token: { raw: token, scopes: [], expiresAt: expiresAt ?? '' },
+      });
+    });
+    return off;
+  }, [token, expiresAt, send, onMessage]);
+
+  // BLOCK_READY → ready.
+  useEffect(() => {
+    const off = onMessage<unknown>('BLOCK_READY', () => {
+      let acked = false;
+      setStatus((current) => {
+        if (current === 'loading') {
+          acked = true;
+          return 'ready';
+        }
+        return current;
+      });
+      if (acked) controllerRef.current?.notifyReady();
+    });
+    return off;
+  }, [onMessage]);
+
+  // BLOCK_ERROR{fatal:true} → fatal.
+  useEffect(() => {
+    const off = onMessage<unknown>('BLOCK_ERROR', (raw) => {
+      if (raw && typeof raw === 'object' && (raw as { fatal?: unknown }).fatal === true) {
+        setStatus((current) => (current === 'loading' || current === 'ready' ? 'fatal' : current));
+      }
+    });
+    return off;
+  }, [onMessage]);
+
+  // Deep-link bridge — block requests in-page navigation. The block may push a
+  // new sub-path WITHIN its own page space; we constrain it to the page route so
+  // a block can't navigate the host off to an arbitrary path. `path` is an
+  // untrusted same-origin sub-path: reject absolute URLs, protocol-relative
+  // (`//`), and `..` traversal. Shallow routing keeps the page mounted (no SSR
+  // round-trip) and the subPath change reflects back into the block via the
+  // popstate handler below.
+  useEffect(() => {
+    const off = onMessage<{ path?: unknown } | undefined>('NAVIGATE', (raw) => {
+      if (status !== 'ready') return; // pre-handshake blocks can't drive nav
+      const rawPath = raw && typeof raw === 'object' ? (raw as { path?: unknown }).path : undefined;
+      if (typeof rawPath !== 'string') return;
+      // Normalize: strip a single leading slash; reject anything unsafe.
+      const cleaned = rawPath.replace(/^\/+/, '');
+      if (cleaned.startsWith('/') || cleaned.includes('//') || cleaned.split('/').includes('..')) {
+        return;
+      }
+      const target = cleaned ? `/apps/run/${encodeURIComponent(slug)}/${cleaned}` : `/apps/run/${encodeURIComponent(slug)}`;
+      void router.push(target, undefined, { shallow: true });
+    });
+    return off;
+  }, [onMessage, status, router, slug]);
+
+  // Forward host-side navigation (back/forward, or our own shallow push) into
+  // the block so it can re-render the right view. Fires whenever the resolved
+  // subPath changes AFTER init.
+  useEffect(() => {
+    if (!initSentRef.current || status !== 'ready') return;
+    send('ROUTE_CHANGED', { subPath });
+  }, [subPath, status, send]);
+
+  // SUSPEND on unmount.
+  useEffect(() => {
+    return () => {
+      if (initSentRef.current) send('SUSPEND');
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Terminal-failure collapse — same anti-spoof posture as IframeHost: a failed
+  // page block shows the trust chrome + nothing (never a fake page).
+  const showIframe = status === 'loading' || status === 'ready';
+  const isReady = status === 'ready';
+
+  return (
+    <Box
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        // Full viewport under the global header. The host chrome sits on top;
+        // the iframe fills the rest.
+        height: '100%',
+        minHeight: 'calc(100dvh - 60px)',
+        width: '100%',
+      }}
+      data-testid="app-page-frame"
+      data-block-instance-id={blockInstanceId}
+    >
+      <AppBlockChrome blockInstanceId={blockInstanceId} appName={appName} />
+      {showIframe ? (
+        <iframe
+          ref={iframeRef}
+          src={iframeSrc}
+          sandbox={intersectSandbox(sandbox, trustTier)}
+          referrerPolicy="no-referrer"
+          title={appName || blockId}
+          data-testid="app-page-iframe"
+          data-block-instance-id={blockInstanceId}
+          data-block-ready={isReady ? 'true' : 'false'}
+          style={{
+            flex: 1,
+            display: 'block',
+            width: '100%',
+            border: 0,
+            pointerEvents: isReady ? 'auto' : 'none',
+          }}
+        />
+      ) : null}
+    </Box>
+  );
+}

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  grantedPageScopes,
+  pageFallbackReason,
+  type PageHostStatus,
+} from '../pageBlockHostLogic';
+
+/**
+ * W10 PageBlockHost pure logic.
+ *
+ * #3/#6 — grantedPageScopes: the scopes the host advertises in BLOCK_INIT /
+ * TOKEN_REFRESH must be the REAL granted set the JWT carries (declared −
+ * missing), NOT the old hardcoded `[]`. A page token carries the viewer-scoped
+ * ambient `apps:storage:*` scopes; posting `[]` lied to the block.
+ *
+ * #4 — pageFallbackReason: a full-page surface in a terminal state must render
+ * a BlockFallback message (mapped reason), not a blank viewport.
+ */
+
+describe('grantedPageScopes (#3/#6 — BLOCK_INIT carries the JWT scopes, not [])', () => {
+  it('returns the declared scopes when nothing is withheld (the real JWT scopes — NOT [])', () => {
+    const declared = ['apps:storage:read', 'apps:storage:write'];
+    expect(grantedPageScopes(declared, [])).toEqual(declared);
+    expect(grantedPageScopes(declared, undefined)).toEqual(declared);
+    // The regression we're fixing: this must NOT collapse to the old `[]`.
+    expect(grantedPageScopes(declared, [])).not.toEqual([]);
+  });
+
+  it('strips the consent-withheld scopes from the granted set', () => {
+    const declared = ['apps:storage:read', 'apps:storage:write', 'social:read'];
+    expect(grantedPageScopes(declared, ['social:read'])).toEqual([
+      'apps:storage:read',
+      'apps:storage:write',
+    ]);
+  });
+
+  it('returns [] only when every declared scope is withheld', () => {
+    expect(grantedPageScopes(['social:read'], ['social:read'])).toEqual([]);
+  });
+
+  it('is a no-op for a missingScopes entry that was never declared', () => {
+    const declared = ['apps:storage:read'];
+    expect(grantedPageScopes(declared, ['ai:write:budgeted'])).toEqual(declared);
+  });
+});
+
+describe('pageFallbackReason (#4 — terminal state renders a fallback, not a blank page)', () => {
+  it('returns null for the non-terminal states (iframe is rendered, not a fallback)', () => {
+    expect(pageFallbackReason('loading')).toBeNull();
+    expect(pageFallbackReason('ready')).toBeNull();
+  });
+
+  it('maps each terminal state to a BlockFallback reason (so a failed page shows a message)', () => {
+    const cases: Array<[PageHostStatus, string]> = [
+      ['timeout', 'timeout'],
+      ['fatal', 'fatal_block_error'],
+      ['no_token', 'token_error'],
+      ['error', 'token_error'],
+    ];
+    for (const [status, reason] of cases) {
+      expect(pageFallbackReason(status)).toBe(reason);
+    }
+  });
+
+  it('never returns null for a terminal failure state (no blank-viewport regression)', () => {
+    for (const status of ['timeout', 'fatal', 'no_token', 'error'] as PageHostStatus[]) {
+      expect(pageFallbackReason(status)).not.toBeNull();
+    }
+  });
+});

--- a/src/components/AppBlocks/__tests__/slotRemountKey.test.ts
+++ b/src/components/AppBlocks/__tests__/slotRemountKey.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { slotRemountKey } from '../types';
+
+/**
+ * W10 — the entity-agnostic BlockSlot remount key. The model behavior (H-4:
+ * force-unmount on model navigation) MUST be preserved when the key is widened
+ * from the old `${slotId}:${modelId}` form.
+ */
+describe('slotRemountKey', () => {
+  it('preserves model remount-on-nav behavior: changes when the modelId changes', () => {
+    const a = slotRemountKey({ slotId: 'model.sidebar_top', entityType: 'model', entityId: 111 });
+    const b = slotRemountKey({ slotId: 'model.sidebar_top', entityType: 'model', entityId: 222 });
+    expect(a).not.toBe(b);
+    // Same model + slot → stable key (no spurious remount).
+    expect(a).toBe(
+      slotRemountKey({ slotId: 'model.sidebar_top', entityType: 'model', entityId: 111 })
+    );
+    // The model key encodes the entity so it's distinguishable from a page key.
+    expect(a).toBe('model.sidebar_top:model:111');
+  });
+
+  it('different slots on the same model produce different keys', () => {
+    const top = slotRemountKey({ slotId: 'model.sidebar_top', entityType: 'model', entityId: 5 });
+    const below = slotRemountKey({ slotId: 'model.below_images', entityType: 'model', entityId: 5 });
+    expect(top).not.toBe(below);
+  });
+
+  it('keys a page on its slug (entity=none)', () => {
+    expect(slotRemountKey({ slotId: 'app.page', entityType: 'none', entityId: 'hello' })).toBe(
+      'app.page:none:hello'
+    );
+  });
+
+  it('a null/undefined entityId falls back to "none"', () => {
+    expect(slotRemountKey({ slotId: 'app.page', entityType: 'none' })).toBe('app.page:none:none');
+    expect(
+      slotRemountKey({ slotId: 'app.page', entityType: 'none', entityId: null })
+    ).toBe('app.page:none:none');
+  });
+
+  it('a model key and a page key never collide', () => {
+    const model = slotRemountKey({ slotId: 'model.sidebar_top', entityType: 'model', entityId: 1 });
+    const page = slotRemountKey({ slotId: 'app.page', entityType: 'none', entityId: '1' });
+    expect(model).not.toBe(page);
+  });
+});

--- a/src/components/AppBlocks/iframeInitController.ts
+++ b/src/components/AppBlocks/iframeInitController.ts
@@ -67,7 +67,11 @@ export const INIT_RETRY_INTERVAL_MS = 400;
  * the node vitest env (mirrors hostRenderDecision / resolveRequestSignIn).
  */
 export function shouldStartInit(args: {
-  status: 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token';
+  // Accepts the model IframeHost statuses plus the W10 page host's `error`
+  // terminal state. The gate only fires for `loading`, so any non-loading
+  // status (terminal or otherwise) is a no-op — widening the union is
+  // backward-compatible.
+  status: 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token' | 'error';
   hasToken: boolean;
   checkpointLoading: boolean;
 }): boolean {

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -1,0 +1,57 @@
+// Pure logic for PageBlockHost (W10 full-page apps). Extracted so the two
+// security/UX-load-bearing decisions are unit-testable in the node vitest env
+// (no RTL — civitai-web's unit project runs `environment: 'node'` and only
+// collects `*.test.ts`). Mirrors the IframeHost `hostRenderDecision` pattern.
+
+export type PageHostStatus =
+  | 'loading'
+  | 'ready'
+  | 'timeout'
+  | 'fatal'
+  | 'no_token'
+  | 'error';
+
+/**
+ * #3/#6: the scopes the minted page JWT ACTUALLY carries — the page manifest's
+ * declared scopes minus the consent-gated ones the viewer hasn't granted
+ * (`missingScopes`, reported by the mint). The server signs exactly this set,
+ * so this is what BLOCK_INIT / TOKEN_REFRESH must advertise to the block.
+ * Posting `[]` (the old hardcode) lied to the block about its capabilities
+ * (a page token carries `apps:storage:*`). Mirrors IframeHost.grantedScopes.
+ */
+export function grantedPageScopes(
+  declaredScopes: string[],
+  missingScopes: string[] | undefined
+): string[] {
+  if (!missingScopes || missingScopes.length === 0) return declaredScopes;
+  const withheld = new Set(missingScopes);
+  return declaredScopes.filter((s) => !withheld.has(s));
+}
+
+export type PageFallbackReason = 'timeout' | 'token_error' | 'fatal_block_error';
+
+/**
+ * #4: map a PageBlockHost terminal status to a BlockFallback reason. Unlike the
+ * model IframeHost (which collapses to null on failure because a model column
+ * can disappear cleanly), a FULL-PAGE surface that collapses is just a blank
+ * viewport. So a failed page renders a message INSIDE the trust frame instead.
+ * Returns null for the non-terminal (loading / ready) states — those render the
+ * iframe, not a fallback.
+ *
+ * Anti-spoof note: the message is HOST chrome (not the block), so a failed
+ * block still can't masquerade as a working page.
+ */
+export function pageFallbackReason(status: PageHostStatus): PageFallbackReason | null {
+  switch (status) {
+    case 'loading':
+    case 'ready':
+      return null;
+    case 'fatal':
+      return 'fatal_block_error';
+    case 'error':
+    case 'no_token':
+      return 'token_error';
+    case 'timeout':
+      return 'timeout';
+  }
+}

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -51,8 +51,18 @@ export interface ShowcaseImage {
   clipSkip: number | null;
 }
 
+/**
+ * The entity a slot's context binds to. Drives the entity-aware token mint +
+ * binding. Only `model` (the three model slots) and `none` (the W10 page) are
+ * used today; `user`/`image` are reserved (Phase 1/2) and intentionally not
+ * given a context type yet.
+ */
+export type SlotEntityType = 'model' | 'none';
+
 export interface ModelSlotContext extends SlotContext {
   slotId: 'model.sidebar_top' | 'model.below_images' | 'model.actions_extra';
+  /** Discriminator — present for the entity-aware mint/binding. */
+  entityType?: 'model';
   modelId: number;
   modelVersionId: number;
   modelName: string;
@@ -82,6 +92,50 @@ export interface ModelSlotContext extends SlotContext {
    * has no preview images yet.
    */
   showcaseImages?: ShowcaseImage[];
+}
+
+/**
+ * W10 full-page app context (entity=none). A page is PURE viewer-scoped: no
+ * model/user/image entity, no money scopes. It carries only the viewer +
+ * routing info the block needs to render a full page and deep-link. The host
+ * mints the token from a synthetic `page_<appBlockId>` resolved directly from
+ * the approved AppBlock — there is no install row (stateless, Decision 2).
+ */
+export interface PageContext extends SlotContext {
+  slotId: 'app.page';
+  entityType: 'none';
+  /** The block_id slug the page route resolved (`<slug>.civit.ai`). */
+  slug: string;
+  /** Sub-path under the page route (`/apps/run/<slug>/<...path>`), no leading
+   *  slash. Empty string for the page root. Forwarded so the block can deep-link. */
+  subPath: string;
+  viewerUserId: number | null;
+  viewerUsername?: string | null;
+  /** Host-page color scheme — lets the iframe match without a flicker. */
+  theme?: 'light' | 'dark';
+}
+
+/**
+ * The union of slot contexts the host can produce. Discriminated by
+ * `entityType` (with the model case allowed to omit it for back-compat — model
+ * producers predate the discriminator). `none` is the page.
+ */
+export type BlockSlotContext = ModelSlotContext | PageContext;
+
+/**
+ * Entity-agnostic remount key for a BlockSlot mount. Replaces the model-only
+ * `${slotId}:${context.modelId}` key. PRESERVES the exact model remount-on-nav
+ * behavior (H-4): for a model context the entity id is the modelId, so the key
+ * is `${slotId}:model:${modelId}` and still force-unmounts on model navigation.
+ * For a page it keys on the slug (`${slotId}:none:<slug>`).
+ */
+export function slotRemountKey(args: {
+  slotId: string;
+  entityType: SlotEntityType;
+  entityId?: string | number | null;
+}): string {
+  const { slotId, entityType, entityId } = args;
+  return `${slotId}:${entityType}:${entityId ?? 'none'}`;
 }
 
 /**

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -28,6 +28,12 @@ export interface AppBlockCardProps {
    * not owned by the viewer; 0 = owned but no earnings yet (no chip).
    */
   ownedEarningCents?: number;
+  /**
+   * W10 — whether the viewer can open a full-page app (the `appBlocksPages`
+   * flag). When true AND the app declares a page (`manifest.hasPage`), an
+   * "Open app" link to `/apps/run/<slug>` is shown. Dark today (flag mod-only).
+   */
+  canOpenPage?: boolean;
 }
 
 function slotLabel(slotId?: string): string {
@@ -63,11 +69,13 @@ export function AppBlockCard({
   alreadySubscribed,
   onOpen,
   ownedEarningCents,
+  canOpenPage,
 }: AppBlockCardProps) {
   const manifest = block.manifest as {
     name?: string;
     description?: string;
     targets?: Array<{ slotId?: string }>;
+    hasPage?: boolean;
   };
   const [busy] = useState(false);
   const slot = manifest.targets?.[0]?.slotId;
@@ -151,19 +159,35 @@ export function AppBlockCard({
             normally. This is dark today (the page is mod-gated); it only
             matters once the segment is widened to anon.
           */}
-          <LoginRedirect reason="perform-action">
-            <Button
-              size="xs"
-              variant={alreadySubscribed ? 'default' : 'filled'}
-              leftSection={
-                alreadySubscribed ? <IconSettings size={14} /> : <IconPlugConnected size={14} />
-              }
-              loading={busy}
-              onClick={() => onOpen(block)}
-            >
-              {alreadySubscribed ? 'Manage' : 'Install'}
-            </Button>
-          </LoginRedirect>
+          <Group gap={6} wrap="nowrap">
+            {/* W10 — "Open app" link to the full-page route, shown only when the
+                app declares a page AND the viewer has the appBlocksPages flag
+                (dark today). The route itself 404s without the flag, so this is
+                belt-and-suspenders against showing a dead link. */}
+            {manifest.hasPage && canOpenPage && (
+              <Button
+                component={Link}
+                href={`/apps/run/${encodeURIComponent(block.blockId)}`}
+                size="xs"
+                variant="light"
+              >
+                Open app
+              </Button>
+            )}
+            <LoginRedirect reason="perform-action">
+              <Button
+                size="xs"
+                variant={alreadySubscribed ? 'default' : 'filled'}
+                leftSection={
+                  alreadySubscribed ? <IconSettings size={14} /> : <IconPlugConnected size={14} />
+                }
+                loading={busy}
+                onClick={() => onOpen(block)}
+              >
+                {alreadySubscribed ? 'Manage' : 'Install'}
+              </Button>
+            </LoginRedirect>
+          </Group>
         </Group>
       </Stack>
     </Card>

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -24,6 +24,7 @@ import {
   isKnownBlockScope,
   validateBlockScopesAgainstOauthClient,
 } from '~/shared/constants/block-scope.constants';
+import { isPageSlot, PAGE_FORBIDDEN_SCOPES } from '~/shared/constants/slot-registry';
 import {
   getGrantedScopes,
   partitionByConsent,
@@ -54,23 +55,45 @@ import {
  */
 
 // slotContext is sent by the iframe host (useBlockToken.ts) and carries the
-// browsing context. We require modelId + slotId here because resolveBlockInstance
-// uses them as the auth pin for synthetic blockInstanceIds (`pdb_*`, `bus_*`)
-// — those rows don't carry modelId themselves and the resolver re-validates
-// the claim against the source predicates before mint. The resolver returns
-// the *validated* modelId/slotId from the source row (not the client's), and
-// only those validated values reach the JWT ctx.
-const slotContextSchema = z
+// browsing context. It is now ENTITY-AWARE (W10): an optional `entityType`
+// discriminator selects the binding shape. The default (omitted entityType) is
+// the historical MODEL contract — modelId required — so existing model
+// producers (ModelVersionDetails) are byte-identical. A `none` (page) request
+// carries no modelId.
+//
+// MODEL: requires modelId + slotId. resolveBlockInstance uses them as the auth
+// pin for synthetic blockInstanceIds (`pdb_*`, `bus_*`) — those rows don't
+// carry modelId themselves and the resolver re-validates the claim against the
+// source predicates before mint. The resolver returns the *validated*
+// modelId/slotId from the source row (not the client's), and only those
+// validated values reach the JWT ctx.
+//
+// NONE (page): viewer-scoped, no entity. slotId is the page slot; no modelId.
+const modelSlotContextSchema = z
   .object({
+    entityType: z.literal('model').optional(),
     modelId: z.coerce.number().int().positive(),
     slotId: z.string().min(1).max(64),
   })
   .passthrough();
 
+const pageSlotContextSchema = z
+  .object({
+    entityType: z.literal('none'),
+    slotId: z.string().min(1).max(64),
+  })
+  .passthrough();
+
+const slotContextSchema = z.union([pageSlotContextSchema, modelSlotContextSchema]);
+
 const requestSchema = z.object({
   blockInstanceId: z.string().min(1).max(64),
   slotContext: slotContextSchema,
 });
+
+// W10 — synthetic block-instance id prefix for a stateless full-page app. The
+// id is `page_<appBlockId>`; there is no install row (Decision 2).
+const PAGE_INSTANCE_PREFIX = 'page_';
 
 const BUZZ_BUDGET_DEFAULT = 10;
 const BUZZ_BUDGET_CAP = 1000;
@@ -336,25 +359,93 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  // Use dbWrite (primary) so a freshly-suspended block can't be installed
-  // through a replication-lag window. resolveBlockInstance handles all four
-  // blockInstanceId namespaces (real install `bki_*`, platform default `pdb_*`,
-  // publisher subscription `bus_pub_*`, viewer subscription `bus_view_*`) and
-  // re-validates the caller's (modelId, slotId) claim against the source row
-  // — for synthetic ids that's the only cross-check, since the row itself
-  // isn't per-model.
-  const install = await BlockRegistry.resolveBlockInstance({
-    blockInstanceId,
-    modelId: slotContext.modelId,
-    slotId: slotContext.slotId,
-    viewerUserId: userId,
-    db: 'write',
-  });
+  // Entity dispatch (W10). `entityType` is the discriminator: a `none` request
+  // is a STATELESS full-page app (entity=none), everything else is the
+  // historical MODEL path. The two paths resolve the approved AppBlock
+  // differently but converge on the same scope-intersection + sign logic below.
+  const entityType: 'model' | 'none' = slotContext.entityType === 'none' ? 'none' : 'model';
 
-  if (!install) {
-    res.status(404).json({ error: 'Block install not found' });
-    return;
+  // The resolved install shape both paths feed into the scope/sign logic.
+  // For a page there is no install row, so modelId is null and installedBy is
+  // null (no per-content owner); settings are empty.
+  type ResolvedForMint = {
+    appBlock: NonNullable<Awaited<ReturnType<typeof BlockRegistry.resolveBlockInstance>>>['appBlock'];
+    modelId: number | null;
+    slotId: string;
+    installedByUserId: number | null;
+    settings: Record<string, unknown>;
+  };
+  let resolved: ResolvedForMint | null = null;
+
+  // Discriminate on slotContext.entityType (the zod union discriminator) so TS
+  // narrows `slotContext` to the model variant (with `modelId`) in the else.
+  if (slotContext.entityType === 'none') {
+    // PAGE PATH (W10) — stateless, viewer-scoped, NO money scopes.
+    //
+    // Gate 1: the dedicated `appBlocksPages` flag must be available to this
+    // caller (in addition to the master `appBlocks` gate above). So the page
+    // surface enables independently and stays dark until its own flag is lit.
+    const pagesAvailable = getFeatureFlags({ user: session?.user, req }).appBlocksPages;
+    if (!pagesAvailable) {
+      res.status(403).json({ error: 'App Blocks pages are not available to this account' });
+      return;
+    }
+    // Gate 2: the slot must be a registered PAGE slot (defense in depth — a
+    // page request carrying a model slotId is rejected, not silently coerced).
+    if (!isPageSlot(slotContext.slotId)) {
+      res.status(400).json({ error: 'entityType=none requires a page slot' });
+      return;
+    }
+    // Gate 3: the instance id MUST be the synthetic `page_<appBlockId>` form.
+    // The page surface has no other id namespace; reject anything else so a
+    // model/synthetic id can't be smuggled into the page path.
+    if (!blockInstanceId.startsWith(PAGE_INSTANCE_PREFIX)) {
+      res.status(400).json({ error: 'page tokens require a page_<appBlockId> instance id' });
+      return;
+    }
+    const appBlockId = blockInstanceId.slice(PAGE_INSTANCE_PREFIX.length);
+    const page = await BlockRegistry.resolvePageBlock(appBlockId, { db: 'write' });
+    if (!page) {
+      // Missing / not-approved / not-a-page app → 404 (never leaks which).
+      res.status(404).json({ error: 'Page app not found' });
+      return;
+    }
+    resolved = {
+      appBlock: page.appBlock,
+      modelId: null,
+      slotId: slotContext.slotId,
+      installedByUserId: null,
+      settings: {},
+    };
+  } else {
+    // MODEL PATH (unchanged). Use dbWrite (primary) so a freshly-suspended
+    // block can't be installed through a replication-lag window.
+    // resolveBlockInstance handles all four blockInstanceId namespaces (real
+    // install `bki_*`, platform default `pdb_*`, publisher subscription
+    // `bus_pub_*`, viewer subscription `bus_view_*`) and re-validates the
+    // caller's (modelId, slotId) claim against the source row — for synthetic
+    // ids that's the only cross-check, since the row itself isn't per-model.
+    const install = await BlockRegistry.resolveBlockInstance({
+      blockInstanceId,
+      modelId: slotContext.modelId,
+      slotId: slotContext.slotId,
+      viewerUserId: userId,
+      db: 'write',
+    });
+    if (!install) {
+      res.status(404).json({ error: 'Block install not found' });
+      return;
+    }
+    resolved = {
+      appBlock: install.appBlock,
+      modelId: install.modelId,
+      slotId: install.slotId,
+      installedByUserId: install.installedByUserId,
+      settings: install.settings,
+    };
   }
+
+  const install = resolved;
   const block = install.appBlock;
   if (!block || block.status !== 'approved') {
     res.status(403).json({ error: 'Block is not approved' });
@@ -410,6 +501,25 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
   const requestedScopes = rawManifestScopes.filter(isKnownBlockScope);
+
+  // W10 PAGE HARD RULE (belt over the manifest + approved-scope intersection):
+  // a page (kind==='page', entity=none) is viewer-scoped with no model entity
+  // and no per-content install — money/spend scopes have nothing to bind or
+  // attribute against, so they are UNCONDITIONALLY rejected here. Even if an
+  // app's approved manifest declared `ai:write:budgeted` / `buzz:read:self` /
+  // `social:tip:self`, a page mint refuses to issue. This is the deterministic
+  // server-side gate, independent of the SDK/manifest declaration.
+  if (entityType === 'none' && isPageSlot(install.slotId)) {
+    const forbidden = new Set<string>(PAGE_FORBIDDEN_SCOPES);
+    const offending = requestedScopes.filter((s) => forbidden.has(s));
+    if (offending.length > 0) {
+      res.status(403).json({
+        error: 'page apps cannot carry money/spend scopes',
+        rejected: offending,
+      });
+      return;
+    }
+  }
 
   // A6 (audit HIGH / design-gaps C2): intersect the scopes about to be signed
   // with the viewer's per-user grant for this (user, app_block). Any scope the
@@ -501,13 +611,31 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     : undefined;
 
   // M3 + M4: ctx is fully server-stamped except for the projected scalars
-  // from slotContext. modelId and slotId come from the install row. The
-  // client's slotId, if any, is dropped.
-  const ctx: Record<string, unknown> = {
-    ...projectClientCtx(slotContext),
-    modelId: install.modelId,
-    slotId: install.slotId,
-  };
+  // from slotContext. The client's slotId, if any, is dropped.
+  //
+  // ENTITY-AWARE ctx (W10):
+  //  - MODEL path: ctx is `{ modelId, slotId }` — BYTE-IDENTICAL to pre-W10.
+  //    No `entityType` field is added, so `enforceContextBinding` (reads
+  //    ctx.modelId), `getEffectiveCheckpoint`, and `updateUserSettings` see
+  //    exactly the claims they saw before. The model entity is implicit in the
+  //    presence of `modelId`. (Regression-locked: the model token's claims for
+  //    `generate-from-model` must be byte-identical.)
+  //  - PAGE path (entity=none): ctx is `{ slotId, entityType: 'none' }` — NO
+  //    modelId. A page token therefore can NEVER satisfy a model-bound check
+  //    (`models:read:self` needs ctx.modelId, which is absent → 403) and the
+  //    page-forbidden money scopes were already rejected at mint.
+  const ctx: Record<string, unknown> =
+    entityType === 'none'
+      ? {
+          ...projectClientCtx(slotContext),
+          slotId: install.slotId,
+          entityType: 'none',
+        }
+      : {
+          ...projectClientCtx(slotContext),
+          modelId: install.modelId,
+          slotId: install.slotId,
+        };
 
   const result = await BlockTokenService.sign({
     userId,

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -203,6 +203,22 @@ export default function AppDetailPage() {
                   </Group>
                 </Stack>
                 <Group gap="xs" wrap="nowrap">
+                  {/* W10 — "Open app" affordance: shown only when the app
+                      declares a full-page surface AND the viewer has the
+                      appBlocksPages flag (dark today). Links to the in-host
+                      full-page route (`/apps/run/<slug>`), where the block runs
+                      with a minted viewer-scoped page token under the trust
+                      chrome — distinct from "Open live" (the raw standalone
+                      origin, no token). */}
+                  {detail.manifest.hasPage && features.appBlocksPages && (
+                    <Button
+                      component={Link}
+                      href={`/apps/run/${encodeURIComponent(detail.blockId)}`}
+                      leftSection={<IconExternalLink size={16} />}
+                    >
+                      Open app
+                    </Button>
+                  )}
                   <Button
                     component="a"
                     href={detail.liveUrl}

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -37,8 +37,19 @@ import type {
 } from '~/server/schema/blocks/subscription.schema';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { trpc } from '~/utils/trpc';
+import { MODEL_SLOT_IDS, type ModelSlotId } from '~/shared/constants/slot-registry';
 
-type SlotFilter = 'model.sidebar_top' | 'model.below_images' | 'model.actions_extra';
+// Marketplace slot filter — model-entity region slots ONLY. Derived from the
+// registry's MODEL_SLOT_IDS so the new `page` slot (entity=none) never pollutes
+// the model-page slot filter. Adding a model slot to the registry adds it here
+// automatically; adding a page slot does not.
+type SlotFilter = ModelSlotId;
+
+const MODEL_SLOT_FILTER_LABELS: Record<ModelSlotId, string> = {
+  'model.sidebar_top': 'Model sidebar',
+  'model.below_images': 'Below images',
+  'model.actions_extra': 'Model actions',
+};
 
 const SORT_OPTIONS: { value: MarketplaceSort; label: string }[] = [
   { value: 'popular', label: 'Most popular' },
@@ -269,9 +280,11 @@ export default function AppsPage() {
           >
             <Group gap={6}>
               <Chip value="">All slots</Chip>
-              <Chip value="model.sidebar_top">Model sidebar</Chip>
-              <Chip value="model.below_images">Below images</Chip>
-              <Chip value="model.actions_extra">Model actions</Chip>
+              {MODEL_SLOT_IDS.map((slot) => (
+                <Chip key={slot} value={slot}>
+                  {MODEL_SLOT_FILTER_LABELS[slot]}
+                </Chip>
+              ))}
             </Group>
           </Chip.Group>
 
@@ -286,6 +299,7 @@ export default function AppsPage() {
               subsByBlock={subsByBlock}
               onOpen={handleOpen}
               earningsByAppBlockId={earningsByAppBlockId}
+              canOpenPage={!!features.appBlocksPages}
             />
           )}
           {showRails && newItems.length > 0 && (
@@ -295,6 +309,7 @@ export default function AppsPage() {
               subsByBlock={subsByBlock}
               onOpen={handleOpen}
               earningsByAppBlockId={earningsByAppBlockId}
+              canOpenPage={!!features.appBlocksPages}
             />
           )}
 
@@ -328,6 +343,7 @@ export default function AppsPage() {
                       alreadySubscribed={subsByBlock.has(block.id)}
                       onOpen={handleOpen}
                       ownedEarningCents={earningsByAppBlockId.get(block.id)}
+                      canOpenPage={!!features.appBlocksPages}
                     />
                   </Grid.Col>
                 ))}
@@ -440,12 +456,14 @@ function MarketplaceRail({
   subsByBlock,
   onOpen,
   earningsByAppBlockId,
+  canOpenPage,
 }: {
   title: string;
   blocks: AvailableBlock[];
   subsByBlock: Map<string, Partial<Record<SubscriptionScope, SubscriptionRecord>>>;
   onOpen: (block: AvailableBlock) => void;
   earningsByAppBlockId: Map<string, number>;
+  canOpenPage: boolean;
 }) {
   return (
     <Stack gap="xs">
@@ -458,6 +476,7 @@ function MarketplaceRail({
               alreadySubscribed={subsByBlock.has(block.id)}
               onOpen={onOpen}
               ownedEarningCents={earningsByAppBlockId.get(block.id)}
+              canOpenPage={canOpenPage}
             />
           </Grid.Col>
         ))}

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -1,0 +1,146 @@
+import { Box, useComputedColorScheme } from '@mantine/core';
+import { useMemo } from 'react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { Meta } from '~/components/Meta/Meta';
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import { useBlockToken } from '~/components/AppBlocks/useBlockToken';
+import type { BlockInstall, PageContext } from '~/components/AppBlocks/types';
+import { BlockRegistry } from '~/server/services/block-registry.service';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+
+/**
+ * W10 — full-page App Block route: `/apps/run/<slug>` (+ optional sub-path).
+ *
+ * Route is `[slug]/[[...path]]` (NOT `[appBlockId]`) to avoid colliding with
+ * the sibling `/apps/[appBlockId]` detail route under `/apps`. `<slug>` is the
+ * app's `block_id` (the same value that builds `<slug>.civit.ai`).
+ *
+ * DARK / FLAG-GATED: the page requires BOTH `features.appBlocks` AND
+ * `features.appBlocksPages` (the W10 flag). When either is off for the viewer,
+ * SSR returns a Next 404 (fail-closed) — merging this changes nothing
+ * user-visible. The token mint enforces the same two-flag gate independently.
+ *
+ * STATELESS (Decision 2): no `block_user_subscriptions` row, no migration. The
+ * page resolves the approved AppBlock by slug; the token is minted from a
+ * synthetic `page_<appBlockId>` id. The page is pure viewer-scoped (entity=none)
+ * and carries NO money scopes.
+ */
+
+interface PageProps {
+  appBlockId: string;
+  blockId: string;
+  appId: string;
+  appName: string;
+  pageTitle: string;
+  iframeSrc: string;
+  sandbox: string;
+  trustTier: 'unverified' | 'verified' | 'internal';
+  slug: string;
+}
+
+export const getServerSideProps = createServerSideProps<PageProps>({
+  useSession: true,
+  resolver: async ({ features, ctx }) => {
+    // GATE FIRST, fail-closed. Both flags required. A viewer without them gets
+    // a 404 — the page is invisible/un-enumerable until W10 launch widens the
+    // `app-blocks-pages-enabled` segment.
+    if (!features?.appBlocks || !features?.appBlocksPages) {
+      return { notFound: true };
+    }
+    const rawSlug = ctx.params?.slug;
+    const slug = typeof rawSlug === 'string' ? rawSlug : Array.isArray(rawSlug) ? rawSlug[0] : '';
+    if (!slug) return { notFound: true };
+
+    // Resolve the approved page app by slug (== block_id). Returns null for a
+    // missing / non-approved / non-page app → 404 (never leaks which).
+    const page = await BlockRegistry.resolvePageBlockBySlug(slug, { db: 'read' });
+    if (!page || !page.iframeSrc) return { notFound: true };
+
+    return {
+      props: {
+        appBlockId: page.appBlockId,
+        blockId: page.blockId,
+        appId: page.appId,
+        appName: page.name,
+        pageTitle: page.pageTitle,
+        iframeSrc: page.iframeSrc,
+        sandbox: page.sandbox,
+        trustTier: page.trustTier,
+        slug: page.blockId,
+      },
+    };
+  },
+});
+
+export default function AppPage(props: PageProps) {
+  const { appBlockId, blockId, appId, appName, iframeSrc, sandbox, trustTier, slug } = props;
+  const currentUser = useCurrentUser();
+  const colorScheme = useComputedColorScheme('dark');
+  const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
+
+  // Synthetic page instance id — the mint resolves `page_<appBlockId>` directly
+  // from the approved AppBlock (no install row).
+  const blockInstanceId = `page_${appBlockId}`;
+
+  // A synthetic BlockInstall so we can reuse useBlockToken (it only reads
+  // `install.blockInstanceId` and posts the context through). The manifest /
+  // settings fields are unused on the page mint path.
+  const install = useMemo<BlockInstall>(
+    () => ({
+      blockInstanceId,
+      blockId,
+      appId,
+      appBlockId,
+      manifest: { name: appName, iframe: { src: iframeSrc, minHeight: 200, maxHeight: null, resizable: true, sandbox } },
+      publisherSettings: {},
+      enabled: true,
+      renderMode: 'iframe',
+      trustTier,
+    }),
+    [appBlockId, appId, appName, blockId, blockInstanceId, iframeSrc, sandbox, trustTier]
+  );
+
+  // The slotContext POSTed to /api/v1/block-tokens. entityType:'none' selects
+  // the page mint path server-side.
+  const context = useMemo<PageContext>(
+    () => ({
+      slotId: 'app.page',
+      entityType: 'none',
+      slug,
+      subPath: '',
+      viewerUserId: currentUser?.id ?? null,
+      viewerUsername: currentUser?.username ?? null,
+      theme,
+    }),
+    [slug, currentUser, theme]
+  );
+
+  const { token, expiresAt } = useBlockToken(install, context);
+
+  const viewer = currentUser
+    ? { id: currentUser.id, username: currentUser.username ?? null }
+    : null;
+
+  return (
+    <>
+      <Meta title={`${appName} — Civitai Apps`} deIndex />
+      <Box style={{ width: '100%' }}>
+        <PageBlockHost
+          appBlockId={appBlockId}
+          blockId={blockId}
+          appId={appId}
+          blockInstanceId={blockInstanceId}
+          appName={appName}
+          iframeSrc={iframeSrc}
+          sandbox={sandbox}
+          trustTier={trustTier}
+          slug={slug}
+          token={token}
+          expiresAt={expiresAt}
+          viewer={viewer}
+          theme={theme}
+        />
+      </Box>
+    </>
+  );
+}

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -36,6 +36,9 @@ interface PageProps {
   sandbox: string;
   trustTier: 'unverified' | 'verified' | 'internal';
   slug: string;
+  /** #3/#6: the page manifest's declared scopes, used to compute the actual
+   *  granted set (declared − missingScopes) for BLOCK_INIT. */
+  scopes: string[];
 }
 
 export const getServerSideProps = createServerSideProps<PageProps>({
@@ -67,13 +70,15 @@ export const getServerSideProps = createServerSideProps<PageProps>({
         sandbox: page.sandbox,
         trustTier: page.trustTier,
         slug: page.blockId,
+        scopes: page.scopes,
       },
     };
   },
 });
 
 export default function AppPage(props: PageProps) {
-  const { appBlockId, blockId, appId, appName, iframeSrc, sandbox, trustTier, slug } = props;
+  const { appBlockId, blockId, appId, appName, iframeSrc, sandbox, trustTier, slug, scopes } =
+    props;
   const currentUser = useCurrentUser();
   const colorScheme = useComputedColorScheme('dark');
   const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
@@ -91,13 +96,17 @@ export default function AppPage(props: PageProps) {
       blockId,
       appId,
       appBlockId,
-      manifest: { name: appName, iframe: { src: iframeSrc, minHeight: 200, maxHeight: null, resizable: true, sandbox } },
+      manifest: {
+        name: appName,
+        scopes,
+        iframe: { src: iframeSrc, minHeight: 200, maxHeight: null, resizable: true, sandbox },
+      },
       publisherSettings: {},
       enabled: true,
       renderMode: 'iframe',
       trustTier,
     }),
-    [appBlockId, appId, appName, blockId, blockInstanceId, iframeSrc, sandbox, trustTier]
+    [appBlockId, appId, appName, blockId, blockInstanceId, iframeSrc, sandbox, scopes, trustTier]
   );
 
   // The slotContext POSTed to /api/v1/block-tokens. entityType:'none' selects
@@ -115,7 +124,14 @@ export default function AppPage(props: PageProps) {
     [slug, currentUser, theme]
   );
 
-  const { token, expiresAt } = useBlockToken(install, context);
+  // #3/#6: take the consent signal + error from the mint, not just token/expiry.
+  // `missingScopes` lets PageBlockHost compute the REAL granted set (declared −
+  // missing) for BLOCK_INIT; `needsConsent`/`error` let it surface a terminal
+  // state instead of hanging at `no_token`.
+  const { token, expiresAt, needsConsent, missingScopes, error } = useBlockToken(
+    install,
+    context
+  );
 
   const viewer = currentUser
     ? { id: currentUser.id, username: currentUser.username ?? null }
@@ -137,6 +153,10 @@ export default function AppPage(props: PageProps) {
           slug={slug}
           token={token}
           expiresAt={expiresAt}
+          declaredScopes={scopes}
+          missingScopes={missingScopes}
+          needsConsent={needsConsent}
+          tokenError={error != null}
           viewer={viewer}
           theme={theme}
         />

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
+import { KNOWN_SLOT_IDS as SLOT_KNOWN_SLOT_IDS } from '~/shared/constants/slot-registry';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { FORGEJO_ORG } from '~/server/services/blocks/forgejo.service';
@@ -214,9 +215,14 @@ async function refundBlockBuzzSpend(
   });
 }
 
-// Free-form slot strings are a cache-busting surface for anon callers.
-// Bound to the explicit set we ship today; new slots ship by extending this.
-const KNOWN_SLOT_IDS = z.enum(['model.sidebar_top', 'model.below_images', 'model.actions_extra']);
+// Free-form slot strings are a cache-busting surface for anon callers. Bound
+// to the explicit model-slot set; the canonical source is now the slot registry
+// (src/shared/constants/slot-registry.ts) — re-exported under the SAME name so
+// the reuse sites below (listForModel/installOnModel/getEffectiveCheckpoint
+// inputs) are untouched and the model contract stays byte-identical. The page
+// slot is intentionally NOT in this enum: page tokens never flow through the
+// model slotContext / install procs.
+const KNOWN_SLOT_IDS = SLOT_KNOWN_SLOT_IDS;
 
 // JSON settings get echoed back to every BlockSlot consumer and stamped on the
 // JWT issuance side. Cap size to keep both budgets bounded.

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -129,10 +129,16 @@ export type PublicBlockManifest = {
   name?: string;
   description?: string;
   targets?: Array<{ slotId?: string }>;
+  /**
+   * W10 — whether the app declares a full-page surface (opens at
+   * `/apps/run/<slug>`). A boolean ONLY (never the page path/internals) so the
+   * marketplace can show an "Open app" affordance without leaking config.
+   */
+  hasPage?: boolean;
 };
 
 /** Field names projected from the raw manifest into PublicBlockManifest. */
-export const PUBLIC_MANIFEST_FIELDS = ['name', 'description', 'targets'] as const;
+export const PUBLIC_MANIFEST_FIELDS = ['name', 'description', 'targets', 'hasPage'] as const;
 
 /**
  * Marketplace listing shape. install_count includes per-model installs and
@@ -183,6 +189,12 @@ export function toPublicBlockManifest(raw: unknown): PublicBlockManifest {
         return typeof slotId === 'string' ? { slotId } : null;
       })
       .filter((t): t is { slotId: string } => t !== null);
+  }
+  // W10 — surface ONLY a boolean: does the manifest declare a usable page
+  // (a `page` object with a non-empty string `path`)? Never the path itself.
+  const page = (m.page ?? null) as { path?: unknown } | null;
+  if (page && typeof page === 'object' && typeof page.path === 'string' && page.path.length > 0) {
+    out.hasPage = true;
   }
   return out;
 }

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -304,4 +304,86 @@ describe('BlockManifestValidator', () => {
     };
     expect(BlockManifestValidator.validate(manifest, TokenScope.ModelsRead).valid).toBe(false);
   });
+
+  // W10 — targets[].slotId validation (closes the pre-existing gap) + page field.
+  describe('W10 targets[].slotId + page', () => {
+    it('accepts a manifest with valid model-slot targets', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        targets: [{ slotId: 'model.sidebar_top' }, { slotId: 'model.below_images' }],
+      };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('rejects a target with an unknown slotId', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        targets: [{ slotId: 'model.does_not_exist' }],
+      };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('not a known slot'))).toBe(true);
+      }
+    });
+
+    it('rejects the page slot used as a target (page is declared via the page field)', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        targets: [{ slotId: 'app.page' }],
+      };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('page slot'))).toBe(true);
+      }
+    });
+
+    it('rejects a target missing slotId', () => {
+      const manifest = { ...VALID_MANIFEST, targets: [{}] };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX).valid).toBe(false);
+    });
+
+    it('accepts a valid page descriptor', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        page: { path: '/', title: 'My App', icon: 'apps' },
+      };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('rejects page.path that does not start with /', () => {
+      const manifest = { ...VALID_MANIFEST, page: { path: 'home', title: 'X' } };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('page.path must start with'))).toBe(true);
+      }
+    });
+
+    it('rejects a page with no path', () => {
+      const manifest = { ...VALID_MANIFEST, page: { title: 'X' } };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX).valid).toBe(false);
+    });
+
+    it('rejects a page with no title', () => {
+      const manifest = { ...VALID_MANIFEST, page: { path: '/' } };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX).valid).toBe(false);
+    });
+
+    it('rejects a page declaration with no iframe block', () => {
+      const { iframe: _iframe, ...noIframe } = VALID_MANIFEST;
+      const manifest = {
+        ...noIframe,
+        renderMode: 'inline',
+        trustTier: 'verified',
+        page: { path: '/', title: 'X' },
+      };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('must also declare an iframe'))).toBe(true);
+      }
+    });
+  });
 });

--- a/src/server/services/__tests__/block-registry.resolve-page.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-page.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * W10 — BlockRegistry.resolvePageBlockBySlug (the SSR page resolver).
+ *
+ * Pins the security-critical sourcing of the iframe sandbox's TRUST TIER:
+ * it MUST come from the authoritative, mod-controlled `AppBlock.trustTier`
+ * COLUMN — NOT `manifest.trustTier`, which is a publisher-self-declared field.
+ * Sourcing the tier from the manifest reintroduces the C1 trust-tier
+ * self-escalation class for the page sandbox (a publisher could declare
+ * `internal` to widen its own sandbox). Mirrors the model render path, which
+ * treats the column as authoritative (resolveRenderMode reads the column).
+ *
+ * Also covers the #7 nit (sandbox extracted independently of `iframe.src`'s
+ * type) and the #3/#6 scope surfacing (declared scopes returned for the host's
+ * granted-scope computation).
+ */
+
+const { mockDbRead, mockDbWrite, mockRedis, mockSysRedis } = vi.hoisted(() => {
+  const dbRead = {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    appBlock: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  };
+  const dbWrite = {
+    appBlock: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  };
+  const redis = {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  };
+  const sysRedis = { sMembers: vi.fn(async () => []) };
+  return { mockDbRead: dbRead, mockDbWrite: dbWrite, mockRedis: redis, mockSysRedis: sysRedis };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'r', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+
+import { BlockRegistry } from '~/server/services/block-registry.service';
+
+/** A valid approved page AppBlock row as Prisma would return it from the
+ *  resolvePageBlockBySlug select (id/blockId/appId/manifest/trustTier). */
+function pageRow(opts: {
+  manifest: Record<string, unknown>;
+  trustTier: string;
+}) {
+  return {
+    id: 'apb_page',
+    blockId: 'hello-page',
+    appId: 'appblk-hello-page',
+    manifest: opts.manifest,
+    trustTier: opts.trustTier,
+  };
+}
+
+const PAGE_MANIFEST = (overrides: Record<string, unknown> = {}) => ({
+  name: 'Hello Page',
+  page: { path: '/', title: 'Hello' },
+  iframe: { src: 'https://hello-page.civit.ai', sandbox: 'allow-scripts allow-forms' },
+  ...overrides,
+});
+
+describe('BlockRegistry.resolvePageBlockBySlug — trust tier sourcing (#2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the authoritative trustTier COLUMN, not manifest.trustTier (column=unverified wins over manifest=internal → restrictive sandbox)', async () => {
+    // The publisher SELF-DECLARES `internal` in the manifest (the widest tier),
+    // but the mod-controlled COLUMN says `unverified`. The column MUST win.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({
+        manifest: PAGE_MANIFEST({ trustTier: 'internal' }),
+        trustTier: 'unverified',
+      })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res).not.toBeNull();
+    // The COLUMN value wins — a self-declared `internal` manifest does NOT
+    // escalate the page sandbox's trust tier.
+    expect(res?.trustTier).toBe('unverified');
+  });
+
+  it('honours a column value of internal even when manifest declares unverified', async () => {
+    // The inverse: a mod has GRANTED `internal` in the column; a stale/cautious
+    // manifest says `unverified`. The column is still authoritative.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({
+        manifest: PAGE_MANIFEST({ trustTier: 'unverified' }),
+        trustTier: 'internal',
+      })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.trustTier).toBe('internal');
+  });
+
+  it('maps an unknown/garbage column value to unverified (fail-closed)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'totally-bogus' })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.trustTier).toBe('unverified');
+  });
+
+  it('the select requests the trustTier column (so the column is actually read)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' })
+    );
+    await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    const call = mockDbRead.appBlock.findFirst.mock.calls.at(-1)?.[0] as {
+      select?: Record<string, unknown>;
+    };
+    expect(call?.select?.trustTier).toBe(true);
+  });
+});
+
+describe('BlockRegistry.resolvePageBlockBySlug — sandbox + scopes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('#7: extracts the sandbox independently of iframe.src being a string', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.sandbox).toBe('allow-scripts allow-forms');
+    expect(res?.iframeSrc).toBe('https://hello-page.civit.ai');
+  });
+
+  it('#3/#6: surfaces the page manifest declared scopes for the host', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({
+        manifest: PAGE_MANIFEST({ scopes: ['apps:storage:read', 'apps:storage:write', 42] }),
+        trustTier: 'verified',
+      })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    // Non-string entries are filtered out.
+    expect(res?.scopes).toEqual(['apps:storage:read', 'apps:storage:write']);
+  });
+
+  it('returns scopes:[] when the manifest declares none', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.scopes).toEqual([]);
+  });
+
+  it('returns null for a non-page manifest (no page descriptor)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(
+      pageRow({ manifest: { name: 'x', iframe: { src: 'https://x.civit.ai' } }, trustTier: 'verified' })
+    );
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res).toBeNull();
+  });
+
+  it('returns null when no approved row owns the slug', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    const res = await BlockRegistry.resolvePageBlockBySlug('missing', { db: 'read' });
+    expect(res).toBeNull();
+  });
+});

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -1,4 +1,5 @@
 import { validateBlockScopesAgainstOauthClient } from '~/shared/constants/block-scope.constants';
+import { isKnownSlotId, isPageSlot } from '~/shared/constants/slot-registry';
 
 type ValidationResult = { valid: true } | { valid: false; errors: string[] };
 
@@ -26,6 +27,18 @@ interface RawManifest {
    * exposed.
    */
   publicSettingsKeys?: unknown;
+  /**
+   * Slot targets the app installs into (model-page slots). Each entry's
+   * `slotId` MUST be a known registered slot id — previously UN-validated
+   * (pre-existing gap, closed in W10).
+   */
+  targets?: unknown;
+  /**
+   * W10 — optional full-page surface descriptor. When present, the app can be
+   * opened as a standalone full page at `/apps/run/<slug>`. `path` is the
+   * sub-path the page mounts at (must start with `/`).
+   */
+  page?: unknown;
   [key: string]: unknown;
 }
 
@@ -403,6 +416,74 @@ export class BlockManifestValidator {
         errors.push('iframe.sandbox must be a non-empty string');
       } else {
         validateSandbox(iframe.sandbox, tierForSandbox, errors);
+      }
+    }
+
+    // W10 (+ pre-existing gap closure): validate `targets[].slotId`. Each target
+    // must be an object whose `slotId` is a KNOWN registered slot id. This was
+    // previously UN-validated — a manifest could declare an arbitrary slot
+    // string that listForModel / the registry would never match (silent
+    // mis-install). Optional (a page-only app may have no model targets).
+    if (m.targets !== undefined) {
+      if (!Array.isArray(m.targets)) {
+        errors.push('targets must be an array');
+      } else {
+        if (m.targets.length > 16) {
+          errors.push('targets must contain at most 16 entries');
+        }
+        for (const t of m.targets) {
+          if (!t || typeof t !== 'object') {
+            errors.push('each target must be an object');
+            continue;
+          }
+          const slotId = (t as { slotId?: unknown }).slotId;
+          if (typeof slotId !== 'string' || slotId.length === 0) {
+            errors.push('each target must carry a non-empty slotId string');
+            continue;
+          }
+          if (!isKnownSlotId(slotId)) {
+            errors.push(`target slotId "${slotId}" is not a known slot`);
+            continue;
+          }
+          // A model-page target must be a model (region) slot, not the page
+          // slot — the page surface is declared via the `page` field, not a
+          // `targets` entry.
+          if (isPageSlot(slotId)) {
+            errors.push(`target slotId "${slotId}" is the page slot — declare a full page via the "page" field, not targets`);
+          }
+        }
+      }
+    }
+
+    // W10 — validate the optional `page` descriptor. When present it must be an
+    // object with a string `path` that starts with '/'; `title` is required
+    // (shown in the host chrome) and `icon` is an optional string. A page app
+    // also needs an iframe.src (validated above) — that is the bundle the page
+    // route iframes.
+    if (m.page !== undefined) {
+      if (!m.page || typeof m.page !== 'object' || Array.isArray(m.page)) {
+        errors.push('page must be an object');
+      } else {
+        const page = m.page as { path?: unknown; title?: unknown; icon?: unknown };
+        if (typeof page.path !== 'string' || page.path.length === 0) {
+          errors.push('page.path must be a non-empty string');
+        } else if (!page.path.startsWith('/')) {
+          errors.push('page.path must start with "/"');
+        } else if (page.path.length > 256) {
+          errors.push('page.path must be ≤256 chars');
+        }
+        if (typeof page.title !== 'string' || page.title.length === 0) {
+          errors.push('page.title must be a non-empty string');
+        } else if (page.title.length > 128) {
+          errors.push('page.title must be ≤128 chars');
+        }
+        if (page.icon !== undefined && (typeof page.icon !== 'string' || page.icon.length > 128)) {
+          errors.push('page.icon must be a string ≤128 chars');
+        }
+        // A page app must ship an iframe block (the bundle the full page mounts).
+        if (!m.iframe || typeof m.iframe !== 'object') {
+          errors.push('a manifest declaring "page" must also declare an iframe block');
+        }
       }
     }
 

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -270,6 +270,10 @@ export interface PageBlockSsr {
   trustTier: 'unverified' | 'verified' | 'internal';
   name: string;
   pageTitle: string;
+  /** #3/#6: the page manifest's declared scopes. The host computes the ACTUAL
+   *  granted set (declared − missingScopes from the mint) for BLOCK_INIT, so the
+   *  block sees the real scopes it has rather than a hardcoded empty array. */
+  scopes: string[];
 }
 
 interface UninstallOpts {
@@ -1481,6 +1485,13 @@ export class BlockRegistry {
         blockId: true,
         appId: true,
         manifest: true,
+        // #2: the AppBlock.trustTier COLUMN is the authoritative, mod-controlled
+        // trust tier. It must drive the iframe sandbox — NOT `manifest.trustTier`,
+        // which is a publisher-self-declared field (using it reintroduces the C1
+        // trust-tier self-escalation class for the page sandbox). Mirrors the
+        // model render path, which reads the `trust_tier` column (see
+        // resolveRenderMode + the `r.trust_tier` raw select used by listForModel).
+        trustTier: true,
       },
     });
     if (!ab) return null;
@@ -1488,22 +1499,38 @@ export class BlockRegistry {
     if (!manifestDeclaresPage(manifest)) return null;
     const iframe = (manifest.iframe ?? {}) as { src?: unknown };
     const iframeSrc = typeof iframe.src === 'string' ? iframe.src : '';
-    const sandbox = typeof iframe.src === 'string' ? (iframe as { sandbox?: unknown }).sandbox : '';
+    // #7: extract the sandbox from `iframe.sandbox` independently — the prior
+    // gate on `typeof iframe.src === 'string'` was misleading (sandbox presence
+    // has nothing to do with src being a string). Harmless before (src/sandbox
+    // are written together) but wrong; gate on the field actually being read.
+    const sandbox = typeof iframe === 'object' && iframe !== null
+      ? (iframe as { sandbox?: unknown }).sandbox
+      : '';
     const page = (manifest.page ?? {}) as { title?: unknown; icon?: unknown };
     const name = typeof manifest.name === 'string' ? manifest.name : ab.blockId;
+    // #3/#6: surface the page's declared scopes so the host can compute the
+    // ACTUAL granted scope set (declared − missing) for BLOCK_INIT, mirroring
+    // IframeHost. Money/spend scopes are rejected at mint for a page, so this is
+    // effectively the consent-exempt ambient set (apps:storage:*) once approved.
+    const declaredScopes = Array.isArray((manifest as { scopes?: unknown }).scopes)
+      ? ((manifest as { scopes: unknown[] }).scopes.filter(
+          (s): s is string => typeof s === 'string'
+        ))
+      : [];
     return {
       appBlockId: ab.id,
       blockId: ab.blockId,
       appId: ab.appId,
       iframeSrc,
       sandbox: typeof sandbox === 'string' ? sandbox : '',
+      // #2: use the COLUMN (authoritative), never `manifest.trustTier`.
       trustTier:
-        typeof manifest.trustTier === 'string' &&
-        (manifest.trustTier === 'verified' || manifest.trustTier === 'internal')
-          ? (manifest.trustTier as 'verified' | 'internal')
+        ab.trustTier === 'verified' || ab.trustTier === 'internal'
+          ? (ab.trustTier as 'verified' | 'internal')
           : 'unverified',
       name,
       pageTitle: typeof page.title === 'string' ? page.title : name,
+      scopes: declaredScopes,
     };
   }
 

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -1465,7 +1465,8 @@ export class BlockRegistry {
    * W10 — resolve a page block by its `<slug>` (== AppBlock.block_id), for the
    * SSR page route. Returns the approved app's id + manifest iframe.src + page
    * descriptor, or null when no approved page app owns that slug (→ 404).
-   * `block_id` is unique per app, so the slug → app mapping is 1:1.
+   * `block_id` is GLOBALLY unique (`@@unique([blockId])`, the W1 C-3 constraint),
+   * so the slug → app mapping is guaranteed 1:1.
    */
   static async resolvePageBlockBySlug(
     slug: string,

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -247,6 +247,31 @@ interface InstallOpts {
   settings?: Record<string, unknown>;
 }
 
+/**
+ * W10 — the page block shape the token mint consumes. Mirrors the `appBlock`
+ * sub-shape of {@link ResolvedBlockInstance} but carries NO modelId / install
+ * row (a page is stateless, entity=none).
+ */
+export interface PageBlockResolution {
+  appBlock: ResolvedBlockInstance['appBlock'];
+}
+
+/**
+ * W10 — the page block shape the SSR route consumes: just enough to render the
+ * full-bleed IframeHost (iframe.src + sandbox + trust tier) and mint a token
+ * (appBlockId). Public-display fields only; never the raw stored manifest.
+ */
+export interface PageBlockSsr {
+  appBlockId: string;
+  blockId: string;
+  appId: string;
+  iframeSrc: string;
+  sandbox: string;
+  trustTier: 'unverified' | 'verified' | 'internal';
+  name: string;
+  pageTitle: string;
+}
+
 interface UninstallOpts {
   modelId: number;
   appBlockId: string;
@@ -340,6 +365,19 @@ function manifestTargetsSlot(manifest: unknown, slotId: string): boolean {
     const cand = (t as { slotId?: unknown }).slotId;
     return typeof cand === 'string' && cand === slotId;
   });
+}
+
+/**
+ * W10 — does the manifest declare a full-page surface? A page app carries a
+ * `page: { path, title, icon? }` object (validated at registration time). Used
+ * to gate the page-mint + SSR resolve so a region/model-only app can't be
+ * opened as a full page.
+ */
+function manifestDeclaresPage(manifest: unknown): boolean {
+  const m = (manifest ?? {}) as { page?: unknown };
+  if (!m.page || typeof m.page !== 'object') return false;
+  const page = m.page as { path?: unknown };
+  return typeof page.path === 'string' && page.path.length > 0;
 }
 
 function resolveRenderMode(
@@ -1371,6 +1409,101 @@ export class BlockRegistry {
 
     // Unknown prefix → not a recognised blockInstanceId.
     return null;
+  }
+
+  /**
+   * W10 — resolve the STATELESS page block for an approved AppBlock id. A
+   * full-page app (`app.page` slot, entity=none) has NO install row: it is
+   * resolved directly from the approved `AppBlock` (Decision 2 — no migration).
+   * The synthetic block-instance id is `page_<appBlockId>`; this returns the
+   * page block shape the token mint needs (manifest + approvedScopes + app
+   * ceiling), or null when the id is missing / not approved (fail-closed, never
+   * leaks a non-approved app's data).
+   *
+   * `modelId`/`installedByUserId` are intentionally absent for a page —
+   * `source: 'platform_default'` is reused only as the closest non-install
+   * source label; the page path NEVER stamps a modelId and never grants money
+   * scopes (the mint enforces both).
+   */
+  static async resolvePageBlock(
+    appBlockId: string,
+    opts?: { db?: 'read' | 'write' }
+  ): Promise<PageBlockResolution | null> {
+    if (!appBlockId) return null;
+    const db = opts?.db === 'read' ? dbRead : dbWrite;
+    const ab = await db.appBlock.findUnique({
+      where: { id: appBlockId },
+      select: {
+        id: true,
+        blockId: true,
+        appId: true,
+        status: true,
+        manifest: true,
+        approvedScopes: true,
+        app: { select: { allowedScopes: true } },
+      },
+    });
+    if (!ab || ab.status !== 'approved') return null;
+    const manifest = (ab.manifest ?? {}) as Record<string, unknown>;
+    // A page app MUST declare a `page` block in its manifest. Without it the
+    // app is a region/model block and has no full-page surface to mint for.
+    if (!manifestDeclaresPage(manifest)) return null;
+    return {
+      appBlock: {
+        id: ab.id,
+        blockId: ab.blockId,
+        appId: ab.appId,
+        status: ab.status,
+        manifest,
+        approvedScopes: ab.approvedScopes ?? [],
+        app: ab.app ? { allowedScopes: ab.app.allowedScopes } : null,
+      },
+    };
+  }
+
+  /**
+   * W10 — resolve a page block by its `<slug>` (== AppBlock.block_id), for the
+   * SSR page route. Returns the approved app's id + manifest iframe.src + page
+   * descriptor, or null when no approved page app owns that slug (→ 404).
+   * `block_id` is unique per app, so the slug → app mapping is 1:1.
+   */
+  static async resolvePageBlockBySlug(
+    slug: string,
+    opts?: { db?: 'read' | 'write' }
+  ): Promise<PageBlockSsr | null> {
+    if (!slug) return null;
+    const db = opts?.db === 'read' ? dbRead : dbWrite;
+    const ab = await db.appBlock.findFirst({
+      where: { blockId: slug, status: 'approved' },
+      select: {
+        id: true,
+        blockId: true,
+        appId: true,
+        manifest: true,
+      },
+    });
+    if (!ab) return null;
+    const manifest = (ab.manifest ?? {}) as Record<string, unknown>;
+    if (!manifestDeclaresPage(manifest)) return null;
+    const iframe = (manifest.iframe ?? {}) as { src?: unknown };
+    const iframeSrc = typeof iframe.src === 'string' ? iframe.src : '';
+    const sandbox = typeof iframe.src === 'string' ? (iframe as { sandbox?: unknown }).sandbox : '';
+    const page = (manifest.page ?? {}) as { title?: unknown; icon?: unknown };
+    const name = typeof manifest.name === 'string' ? manifest.name : ab.blockId;
+    return {
+      appBlockId: ab.id,
+      blockId: ab.blockId,
+      appId: ab.appId,
+      iframeSrc,
+      sandbox: typeof sandbox === 'string' ? sandbox : '',
+      trustTier:
+        typeof manifest.trustTier === 'string' &&
+        (manifest.trustTier === 'verified' || manifest.trustTier === 'internal')
+          ? (manifest.trustTier as 'verified' | 'internal')
+          : 'unverified',
+      name,
+      pageTitle: typeof page.title === 'string' ? page.title : name,
+    };
   }
 
   static async installOnModel(opts: InstallOpts): Promise<{ blockInstanceId: string }> {

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -223,6 +223,11 @@ const featureFlags = createFeatureFlags({
   // default until we ship publisher install UX + moderator approval workflow.
   // When off, BlockSlot renders nothing and no token-issuance traffic fires.
   appBlocks: { availability: ['mod'], fliptKey: 'app-blocks-enabled' },
+  // App Blocks W10 — full-page apps (`/apps/run/<slug>`). A SEPARATE dark flag
+  // so the page surface enables independently of the master `app-blocks-enabled`
+  // gate. The page route + page-token mint require BOTH `appBlocks` AND
+  // `appBlocksPages`. Mod-only today; widened (Flipt segment) at W10 launch.
+  appBlocksPages: { availability: ['mod'], fliptKey: 'app-blocks-pages-enabled' },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];

--- a/src/shared/constants/__tests__/slot-registry.test.ts
+++ b/src/shared/constants/__tests__/slot-registry.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALL_SLOT_IDS,
+  isKnownSlotId,
+  isPageSlot,
+  KNOWN_SLOT_IDS,
+  MODEL_SLOT_IDS,
+  PAGE_FORBIDDEN_SCOPES,
+  PAGE_SLOT_ID,
+  SLOT_REGISTRY,
+} from '../slot-registry';
+
+describe('slot-registry (Phase 0 foundation)', () => {
+  // BEHAVIOR-PRESERVING GATE (PR1): KNOWN_SLOT_IDS.options MUST deep-equal the
+  // historical model-slot tuple, in this exact order. blocks.router.ts uses
+  // this enum for listForModel/installOnModel/getEffectiveCheckpoint inputs; a
+  // drift here silently changes the model install/mint/resolve contract.
+  it('KNOWN_SLOT_IDS.options is byte-identical to the historical 3-model-slot tuple', () => {
+    expect(KNOWN_SLOT_IDS.options).toEqual([
+      'model.sidebar_top',
+      'model.below_images',
+      'model.actions_extra',
+    ]);
+  });
+
+  it('MODEL_SLOT_IDS matches the enum options exactly', () => {
+    expect([...MODEL_SLOT_IDS]).toEqual(KNOWN_SLOT_IDS.options);
+  });
+
+  it('the page slot is NOT in the model enum (page tokens never use the model slotContext)', () => {
+    expect(KNOWN_SLOT_IDS.options).not.toContain(PAGE_SLOT_ID);
+    expect((KNOWN_SLOT_IDS.options as readonly string[]).includes('app.page')).toBe(false);
+  });
+
+  it('every model slot is entity=model, kind=region, install=model_subscription', () => {
+    for (const id of MODEL_SLOT_IDS) {
+      const def = SLOT_REGISTRY[id];
+      expect(def.entity).toBe('model');
+      expect(def.kind).toBe('region');
+      expect(def.installModel).toBe('model_subscription');
+    }
+  });
+
+  it('the page slot is entity=none, kind=page, install=none (stateless)', () => {
+    const page = SLOT_REGISTRY[PAGE_SLOT_ID];
+    expect(page.entity).toBe('none');
+    expect(page.kind).toBe('page');
+    expect(page.installModel).toBe('none');
+    expect(page.geometry).toBe('viewport');
+  });
+
+  it('isPageSlot / isKnownSlotId classify correctly', () => {
+    expect(isPageSlot('app.page')).toBe(true);
+    expect(isPageSlot('model.sidebar_top')).toBe(false);
+    expect(isPageSlot('not.a.slot')).toBe(false);
+    expect(isKnownSlotId('app.page')).toBe(true);
+    expect(isKnownSlotId('model.sidebar_top')).toBe(true);
+    expect(isKnownSlotId('nope')).toBe(false);
+  });
+
+  it('ALL_SLOT_IDS is the model slots plus the page slot', () => {
+    expect(new Set(ALL_SLOT_IDS)).toEqual(
+      new Set([...MODEL_SLOT_IDS, PAGE_SLOT_ID])
+    );
+  });
+
+  it('PAGE_FORBIDDEN_SCOPES covers every money/spend scope', () => {
+    expect([...PAGE_FORBIDDEN_SCOPES].sort()).toEqual(
+      ['ai:write:budgeted', 'buzz:read:self', 'social:tip:self'].sort()
+    );
+  });
+
+  // Only `none` and `model` entities are wired in this build. user/image are
+  // reserved (Phase 1/2) and must NOT appear yet, so a future PR3 can't be
+  // accidentally half-shipped.
+  it('only model + none entities are present in the registry today', () => {
+    const entities = new Set(Object.values(SLOT_REGISTRY).map((s) => s.entity));
+    expect(entities).toEqual(new Set(['model', 'none']));
+  });
+});

--- a/src/shared/constants/slot-registry.ts
+++ b/src/shared/constants/slot-registry.ts
@@ -1,0 +1,172 @@
+/**
+ * App Blocks — SLOT REGISTRY (Phase 0 foundation).
+ *
+ * Single source of truth for every place an App Block can render. Today that is
+ * the three model-page slots (unchanged from the historical
+ * `blocks.router.ts` `z.enum`) plus one new full-page slot for W10 full-page
+ * apps. The registry is the durable shape every downstream derives from:
+ *
+ *   - `KNOWN_SLOT_IDS`  — the zod enum re-exported by blocks.router.ts; its
+ *                         `.options` MUST stay byte-for-byte the historical
+ *                         3-model-slot tuple (regression-locked in
+ *                         __tests__/slot-registry.test.ts) so the model
+ *                         install / mint / resolve path is behavior-preserving.
+ *   - client TS unions  — src/components/AppBlocks/types.ts
+ *   - marketplace filters — src/pages/apps/index.tsx (model-entity region slots
+ *                         only; the page slot must not pollute the model filter)
+ *
+ * ENTITY-AWARENESS: each slot declares the entity its context binds to. Today
+ * only `model` (the three model slots) and `none` (the viewer-scoped page) are
+ * used. `user`/`image` are reserved for Phase 1/2 (profile / image / OSD
+ * surfaces) and are intentionally NOT wired into the token mint, context types,
+ * or install resolver yet — the entity dispatch is shaped so they slot in later
+ * without reworking the model or page paths.
+ */
+import * as z from 'zod';
+
+/** The surface an entity-bound slot reads its context from. */
+export type SlotEntity = 'model' | 'user' | 'image' | 'none';
+
+/**
+ * How a slot renders:
+ *   - `region`   — an inline panel inside an existing page's layout column
+ *                  (today's three model slots).
+ *   - `floating` — a floating/overlay surface (reserved; e.g. OSD).
+ *   - `page`     — a full-bleed standalone page (W10 full-page apps). The block
+ *                  owns the whole viewport region under the host trust chrome.
+ */
+export type SlotKind = 'region' | 'floating' | 'page';
+
+/**
+ * How an app is installed/attached to a slot:
+ *   - `model_subscription` — a `block_user_subscriptions` row (today's model
+ *                            installs + platform defaults + viewer subs).
+ *   - `none`               — STATELESS: no install row at all. A `page` app is
+ *                            resolved directly from the approved `AppBlock`
+ *                            (synthetic `page_<appBlockId>` id) — see Decision 2
+ *                            in the W10 plan. No per-content install, no
+ *                            migration.
+ */
+export type SlotInstallModel = 'model_subscription' | 'none';
+
+export interface SlotDef {
+  /** Stable slot id used in manifests, JWT ctx, and routing. */
+  id: string;
+  kind: SlotKind;
+  /** The entity this slot's context binds to (drives the entity dispatch). */
+  entity: SlotEntity;
+  /**
+   * Coarse geometry hint for the host. `region` slots live inside an existing
+   * page column; `page` slots are full-viewport. Purely advisory to the host
+   * renderer — the manifest's iframe min/max height still governs region slots.
+   */
+  geometry: 'column' | 'viewport';
+  installModel: SlotInstallModel;
+  /** Default install ordering priority (lower renders first). */
+  defaultPriority: number;
+  /** Human description for the marketplace / docs. */
+  description: string;
+}
+
+/**
+ * The canonical slot registry. The three model slots are LOAD-BEARING and
+ * behavior-preserving — their ids, order, entity, and install model match the
+ * pre-registry `blocks.router.ts` `z.enum` exactly. The `page` slot is new
+ * (W10) and is the ONLY non-model-entity slot today.
+ */
+export const SLOT_REGISTRY = {
+  'model.sidebar_top': {
+    id: 'model.sidebar_top',
+    kind: 'region',
+    entity: 'model',
+    geometry: 'column',
+    installModel: 'model_subscription',
+    defaultPriority: 0,
+    description: 'Top of the model page sidebar.',
+  },
+  'model.below_images': {
+    id: 'model.below_images',
+    kind: 'region',
+    entity: 'model',
+    geometry: 'column',
+    installModel: 'model_subscription',
+    defaultPriority: 1,
+    description: 'Below the model page image gallery.',
+  },
+  'model.actions_extra': {
+    id: 'model.actions_extra',
+    kind: 'region',
+    entity: 'model',
+    geometry: 'column',
+    installModel: 'model_subscription',
+    defaultPriority: 2,
+    description: 'Extra model page actions area.',
+  },
+  // W10 — full-page app surface. Pure viewer-scoped (entity=none): no model /
+  // user / image entity, no per-content install (stateless). Resolved from the
+  // approved AppBlock directly via a synthetic `page_<appBlockId>` id.
+  'app.page': {
+    id: 'app.page',
+    kind: 'page',
+    entity: 'none',
+    geometry: 'viewport',
+    installModel: 'none',
+    defaultPriority: 0,
+    description: 'Full-page standalone app surface.',
+  },
+} as const satisfies Record<string, SlotDef>;
+
+export type SlotId = keyof typeof SLOT_REGISTRY;
+
+/** The W10 page slot id, named so reuse sites read intent. */
+export const PAGE_SLOT_ID = 'app.page' as const;
+
+/**
+ * The historical model-slot tuple — the EXACT order/values the pre-registry
+ * `KNOWN_SLOT_IDS` z.enum carried. Pinned here as the single source so
+ * blocks.router.ts re-exports it (keeping the `KNOWN_SLOT_IDS` name so reuse
+ * sites at 287/317/1665 are untouched) and the marketplace can filter to the
+ * model slots without re-listing them. Regression-locked in the test.
+ */
+export const MODEL_SLOT_IDS = [
+  'model.sidebar_top',
+  'model.below_images',
+  'model.actions_extra',
+] as const;
+
+export type ModelSlotId = (typeof MODEL_SLOT_IDS)[number];
+
+/**
+ * Derived zod enum over the model slots — re-exported by blocks.router.ts as
+ * `KNOWN_SLOT_IDS`. KEPT model-only (the three model slots) so the model
+ * install/mint/resolve contracts are byte-identical to pre-registry. The page
+ * slot is intentionally NOT in this enum — page tokens never flow through the
+ * model `slotContextSchema` / `listForModel` / install procs.
+ */
+export const KNOWN_SLOT_IDS = z.enum(MODEL_SLOT_IDS);
+
+/** All registered slot ids (model + page). */
+export const ALL_SLOT_IDS = Object.keys(SLOT_REGISTRY) as SlotId[];
+
+/** Type guard: is `id` a registered slot id (any kind)? */
+export function isKnownSlotId(id: string): id is SlotId {
+  return id in SLOT_REGISTRY;
+}
+
+/**
+ * Money/spend scopes a `page` (viewer-scoped, entity=none) token must NEVER
+ * carry. A page has no model entity and no per-content install to attribute
+ * spend against, so granting these would be unbounded. This is the belt over
+ * the manifest + approved-scope intersection: even if an app's approved
+ * manifest declared them, a `kind==='page'` mint rejects them.
+ */
+export const PAGE_FORBIDDEN_SCOPES = [
+  'ai:write:budgeted',
+  'buzz:read:self',
+  'social:tip:self',
+] as const;
+
+/** Does the slot render a full standalone page (W10)? */
+export function isPageSlot(id: string): boolean {
+  return isKnownSlotId(id) && SLOT_REGISTRY[id].kind === 'page';
+}

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * W10 — handler-level coverage for the PAGE token-mint path of
+ * POST /api/v1/block-tokens (entityType: 'none').
+ *
+ * Mirrors the model-path harness in index.test.ts (mocks auth/registry/redis/
+ * token-service/flags) and asserts the W10 invariants:
+ *   - page mint carries NO money scopes (the page hard rule rejects them)
+ *   - page mint is gated on the `appBlocksPages` flag (in ADDITION to appBlocks)
+ *     and on the app being approved (resolvePageBlock → null ⇒ 404, no token)
+ *   - a stateless page resolves with NO subscription row (resolvePageBlock, not
+ *     resolveBlockInstance) and stamps ctx { slotId, entityType:'none' } (no
+ *     modelId — so it can never satisfy a model-bound check)
+ *   - the MODEL path stays byte-identical: ctx is exactly { modelId, slotId }
+ *     (no entityType field) for the canonical generate-from-model manifest.
+ */
+
+const {
+  mockDbWrite,
+  mockRedis,
+  mockSession,
+  mockTokenService,
+  mockBlockRegistry,
+  mockFlags,
+} = vi.hoisted(() => {
+  const dbWrite = {
+    user: { findUnique: vi.fn<(...args: any[]) => Promise<any>>() },
+    appUserScopeGrant: {
+      findUnique: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
+    },
+  };
+  const redis = {
+    incrBy: vi.fn(async () => 1),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => 60),
+  };
+  const session = { value: null as { user: { id: number; bannedAt: Date | null } } | null };
+  const tokenService = {
+    sign: vi.fn<(...args: any[]) => Promise<any>>(async () => ({
+      token: 'jwt.signed.value',
+      expiresAt: '2099-01-01T00:00:00Z',
+      jti: 'j',
+    })),
+    checkRateLimit: vi.fn<(...args: any[]) => Promise<boolean>>(async () => true),
+  };
+  const blockRegistry = {
+    resolveBlockInstance: vi.fn<(...args: any[]) => Promise<any>>(),
+    resolvePageBlock: vi.fn<(...args: any[]) => Promise<any>>(),
+  };
+  // Flag mock that both the master + pages flag default ON for a mod.
+  const flags = {
+    getFeatureFlags: vi.fn(
+      ({ user }: { user?: { isModerator?: boolean } }) => ({
+        appBlocks: !!user?.isModerator,
+        appBlocksPages: !!user?.isModerator,
+      })
+    ),
+  };
+  return {
+    mockDbWrite: dbWrite,
+    mockRedis: redis,
+    mockSession: session,
+    mockTokenService: tokenService,
+    mockBlockRegistry: blockRegistry,
+    mockFlags: flags,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: {
+    NEXTAUTH_URL: 'https://civitai.com',
+    TRPC_ORIGINS: [],
+    BLOCK_TOKEN_PRIVATE_KEY: 'fake-private',
+    BLOCK_TOKEN_PUBLIC_KEY: 'fake-public',
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => mockSession.value),
+}));
+vi.mock('~/server/services/block-token.service', () => ({ BlockTokenService: mockTokenService }));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: mockBlockRegistry,
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
+}));
+vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: () => ['civitai.com'] }));
+vi.mock('~/server/services/feature-flags.service', () => mockFlags);
+
+function makeReq(opts: {
+  method?: string;
+  origin?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): NextApiRequest {
+  return {
+    method: opts.method ?? 'POST',
+    headers: { origin: opts.origin, ...opts.headers },
+    body: opts.body,
+    socket: { remoteAddress: '127.0.0.1' },
+    query: {},
+  } as unknown as NextApiRequest;
+}
+
+function makeRes() {
+  const res = {
+    _status: 0,
+    _body: null as unknown,
+    _headers: {} as Record<string, string>,
+    setHeader: vi.fn(function (this: any, name: string, value: string) {
+      this._headers[name.toLowerCase()] = value;
+      return this;
+    }),
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, body: unknown) {
+      this._body = body;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+    send: vi.fn(function (this: any, body: unknown) {
+      this._body = body;
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & {
+    _status: number;
+    _body: any;
+    _headers: Record<string, string>;
+  };
+}
+
+// OAuth bits for the money scopes (token-scope.constants): AIServicesWrite
+// (1<<15), BuzzRead (1<<16), SocialTip (1<<20). The page hard rule must reject
+// a money scope EVEN WHEN the OAuth client allows it (otherwise the earlier
+// OAuth-allowlist check would be what rejects, not the page rule).
+const MONEY_BITS = (1 << 15) | (1 << 16) | (1 << 20);
+
+// An approved page app (no install row). resolvePageBlock returns this.
+const PAGE_BLOCK = (
+  manifestScopes: string[],
+  approvedScopes = manifestScopes,
+  allowedScopes = 0
+) => ({
+  appBlock: {
+    id: 'apb_page',
+    blockId: 'hello-page',
+    appId: 'appblk-hello-page',
+    status: 'approved',
+    manifest: { scopes: manifestScopes, page: { path: '/', title: 'Hello' } },
+    approvedScopes,
+    app: { allowedScopes },
+  },
+});
+
+const pageBody = (overrides: Record<string, unknown> = {}) => ({
+  blockInstanceId: 'page_apb_page',
+  slotContext: { entityType: 'none', slotId: 'app.page', ...overrides },
+});
+
+// The canonical generate-from-model model install (for the byte-identical test).
+const MODEL_INSTALL = {
+  source: 'install' as const,
+  modelId: 12345,
+  slotId: 'model.sidebar_top',
+  enabled: true,
+  settings: {},
+  installedByUserId: 42,
+  appBlock: {
+    id: 'apb_gen',
+    blockId: 'generate-from-model',
+    appId: 'appblk-generate-from-model',
+    status: 'approved',
+    manifest: { scopes: ['models:read:self'] },
+    approvedScopes: ['models:read:self'],
+    app: { allowedScopes: 4 /* TokenScope.ModelsRead */ },
+  },
+};
+const modelBody = () => ({
+  blockInstanceId: 'bki_x',
+  slotContext: { modelId: 12345, slotId: 'model.sidebar_top' },
+});
+
+const MOD = { user: { id: 42, isModerator: true, bannedAt: null } } as any;
+
+describe('POST /api/v1/block-tokens — W10 page mint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.value = MOD;
+    mockBlockRegistry.resolveBlockInstance.mockReset();
+    mockBlockRegistry.resolvePageBlock.mockReset();
+    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['apps:storage:read', 'apps:storage:write'],
+      revokedAt: null,
+    });
+    mockRedis.incrBy.mockResolvedValue(1);
+    mockTokenService.checkRateLimit.mockResolvedValue(true);
+    (mockFlags.getFeatureFlags as any).mockImplementation(
+      ({ user }: { user?: { isModerator?: boolean } }) => ({
+        appBlocks: !!user?.isModerator,
+        appBlocksPages: !!user?.isModerator,
+      })
+    );
+  });
+
+  it('mints a viewer-scoped page token via resolvePageBlock (no subscription row)', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+      PAGE_BLOCK(['apps:storage:read', 'apps:storage:write'])
+    );
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(200);
+    // Stateless: the page path NEVER touches resolveBlockInstance.
+    expect(mockBlockRegistry.resolveBlockInstance).not.toHaveBeenCalled();
+    expect(mockBlockRegistry.resolvePageBlock).toHaveBeenCalledWith('apb_page', { db: 'write' });
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    // ctx is { slotId, entityType:'none' } with NO modelId — can't satisfy a
+    // model-bound check.
+    expect(signArg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
+    expect(signArg.ctx.modelId).toBeUndefined();
+    expect(signArg.scopes).toEqual(['apps:storage:read', 'apps:storage:write']);
+  });
+
+  it('rejects a page manifest that declares a money scope (page hard rule)', async () => {
+    // The OAuth client ALLOWS the money scope + it's in the approved set — so
+    // the earlier OAuth/approved gates pass and the PAGE HARD RULE is what
+    // rejects (proves the page-specific gate, not the generic allowlist).
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+      PAGE_BLOCK(
+        ['apps:storage:read', 'ai:write:budgeted'],
+        ['apps:storage:read', 'ai:write:budgeted'],
+        MONEY_BITS
+      )
+    );
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(403);
+    expect(res._body.error).toMatch(/money\/spend scopes/);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it.each([['buzz:read:self'], ['social:tip:self'], ['ai:write:budgeted']])(
+    'rejects forbidden page scope %s',
+    async (scope) => {
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+        PAGE_BLOCK([scope], [scope], MONEY_BITS)
+      );
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+      expect(res._status).toBe(403);
+      expect(mockTokenService.sign).not.toHaveBeenCalled();
+    }
+  );
+
+  it('is flag-gated on appBlocksPages (appBlocks alone is not enough → 403, no token)', async () => {
+    (mockFlags.getFeatureFlags as any).mockImplementation(() => ({
+      appBlocks: true,
+      appBlocksPages: false,
+    }));
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BLOCK(['apps:storage:read']));
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+    expect(res._status).toBe(403);
+    expect(mockBlockRegistry.resolvePageBlock).not.toHaveBeenCalled();
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('404s (no token) for an unapproved / unknown page app (resolvePageBlock → null)', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(null);
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('rejects a page request whose instance id is not page_<appBlockId>', async () => {
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { blockInstanceId: 'bki_smuggled', slotContext: { entityType: 'none', slotId: 'app.page' } },
+      }),
+      res
+    );
+    expect(res._status).toBe(400);
+    expect(mockBlockRegistry.resolvePageBlock).not.toHaveBeenCalled();
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('rejects entityType=none with a non-page slot', async () => {
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { blockInstanceId: 'page_apb_page', slotContext: { entityType: 'none', slotId: 'model.sidebar_top' } },
+      }),
+      res
+    );
+    expect(res._status).toBe(400);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('BYTE-IDENTICAL model path: ctx is exactly { modelId, slotId } (no entityType) for generate-from-model', async () => {
+    mockBlockRegistry.resolveBlockInstance.mockResolvedValue(MODEL_INSTALL);
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['models:read:self'],
+      revokedAt: null,
+    });
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: modelBody() }), res);
+
+    expect(res._status).toBe(200);
+    expect(mockBlockRegistry.resolvePageBlock).not.toHaveBeenCalled();
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    // The model ctx MUST be byte-identical to pre-W10: { modelId, slotId } only.
+    expect(signArg.ctx).toEqual({ modelId: 12345, slotId: 'model.sidebar_top' });
+    expect('entityType' in signArg.ctx).toBe(false);
+    expect(signArg.scopes).toEqual(['models:read:self']);
+    expect(signArg.blockInstanceId).toBe('bki_x');
+  });
+});

--- a/tests/preview-apps-page.spec.ts
+++ b/tests/preview-apps-page.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+import { trpcQuery } from './preview-trpc';
+
+/**
+ * Preview-e2e (W10): App Blocks FULL-PAGE app surface — the `/apps/run/<slug>`
+ * route + the page-token mint. A mod opens a page-declaring app's full-page
+ * surface; we assert the host trust chrome + the block iframe mount, and that
+ * the page received a BLOCK_INIT (the iframe transitions to ready, which only
+ * happens after the host posts BLOCK_INIT with a viewer-scoped page token +
+ * subPath). Otherwise untested by the preview suite.
+ *
+ * Runs as the `mod` fixture (id 2000000001) — the ONLY preview role with BOTH
+ * `features.appBlocks` AND `features.appBlocksPages` (both flags are
+ * moderator-segment-only / mod-only by availability). For a non-mod the page
+ * SSR-resolves to a Next 404 (the two-flag gate), and the token mint 403s. So
+ * this MUST run as mod to exercise the real page path.
+ *
+ * Data resilience: the dev DB is a weekly prod clone. A page-declaring approved
+ * app may not exist in a given clone, so we DISCOVER one at runtime from
+ * `listAvailable` (manifest.hasPage === true) and `test.skip()` with an
+ * annotation when none exists — never hardcode a slug.
+ *
+ * NB: the preview run is the GATE — it needs the `app-blocks-pages-enabled`
+ * Flipt flag relaxed to the mod segment on the preview env (same posture as
+ * `app-blocks-enabled`). The spec is authored here; the green preview run
+ * validates it.
+ *
+ * Verified tRPC / route shapes (against origin/main + this PR):
+ *  - blocks.listAvailable → `{ items: AvailableBlock[]; nextCursor? }`. Each
+ *    AvailableBlock now carries `manifest.hasPage?: boolean` (W10 public
+ *    projection) + `blockId` (the `<slug>` used by the page route).
+ *  - Page route `/apps/run/[slug]/[[...path]]` SSR-gates on
+ *    `features.appBlocks && features.appBlocksPages`, resolves the approved app
+ *    by `block_id`, and renders `<PageBlockHost>` (data-testid="app-page-frame"
+ *    with the `<iframe data-testid="app-page-iframe">` inside, plus the W7
+ *    `data-testid="app-block-chrome"` trust bar).
+ */
+
+const ROLE = 'mod' as const;
+
+type AvailableBlock = {
+  id: string;
+  blockId: string;
+  appId: string;
+  appName: string | null;
+  manifest: { name?: string; description?: string; hasPage?: boolean };
+  installCount: number;
+};
+type ListAvailableResult = { items: AvailableBlock[]; nextCursor?: string };
+
+test.describe('App Blocks full-page app surface (mod)', () => {
+  test.use({ storageState: storageStatePath(ROLE) });
+
+  test('a page-declaring app opens at /apps/run/<slug> and the iframe mounts + inits', async ({
+    page,
+  }) => {
+    // DISCOVER a page-declaring approved app from the public listing. `{}` is a
+    // valid input (all listAvailableSchema fields optional). page.request carries
+    // the mod cookie; the helper stamps Origin/Referer for the CSRF gate.
+    const listing = await trpcQuery<ListAvailableResult>(page.request, 'blocks.listAvailable', {});
+    const blocks = listing?.items ?? [];
+    const pageApp = blocks.find((b) => b.manifest?.hasPage === true);
+
+    test.skip(
+      !pageApp,
+      'No approved app declaring a full-page surface (manifest.page) in this dev-DB clone — nothing to open. Skipping rather than hard-failing.'
+    );
+    if (!pageApp) return;
+
+    // The full-page route. SSR must succeed (status < 400) for the mod who
+    // clears the two-flag gate (NOT the 404 a non-pages viewer gets).
+    const resp = await page.goto(`/apps/run/${encodeURIComponent(pageApp.blockId)}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(
+      resp?.status(),
+      `GET /apps/run/${pageApp.blockId} status for the appBlocksPages-enabled mod`
+    ).toBeLessThan(400);
+
+    // The host trust chrome (rendered in civitai-web, spoof-proof) is present —
+    // proves PageBlockHost mounted (not a 404 / blank).
+    await expect(
+      page.getByTestId('app-block-chrome'),
+      'the full-page host should render the W7 trust chrome'
+    ).toBeVisible();
+
+    // The block iframe mounts (server-resolved manifest.iframe.src).
+    const frame = page.getByTestId('app-page-iframe');
+    await expect(frame, 'the full-page block iframe should mount').toBeVisible();
+
+    // The host posts BLOCK_INIT (viewer page token + subPath) on a retry loop
+    // until the block acks BLOCK_READY → data-block-ready flips to "true". This
+    // is the e2e proof that the page-mint + handshake worked. Allow generous
+    // time for the cross-origin bundle to load + ack on a cold preview.
+    await expect(
+      frame,
+      'the full-page block should receive BLOCK_INIT and ack ready (page token minted)'
+    ).toHaveAttribute('data-block-ready', 'true', { timeout: 20_000 });
+  });
+});


### PR DESCRIPTION
## What

Durable **W10 full-page App Blocks** surface (`/apps/run/<slug>`) on a clean **slot-registry foundation**, **fully DARK behind two flags** — merging changes nothing user-visible. Combines the W10 plan's **PR1 + PR2 + PR4** into one coherent PR (the repo bans stacked PRs and these are sequentially dependent). **PR3 (install/resolver polymorphism + migration) is DEFERRED** — a page is **stateless** (no install row, **no migration**).

Plan: `claudedocs/app-blocks-w10-foundation-impl-plan-2026-06-17.md` (datapacket-talos).

## Dark / flag-gated (both off → inert)

- New dark flag **`appBlocksPages`** (`fliptKey: app-blocks-pages-enabled`, `availability: ['mod']`). The master `app-blocks-enabled` is **untouched**.
- Page **route** SSR-gates on `features.appBlocks && features.appBlocksPages` FIRST (fail-closed `notFound`). The **token mint** enforces the same two-flag gate independently. With either flag off the route 404s and the mint 403s — nothing renders, no traffic fires.

## Stateless page (Decision 2 — no migration)

A page needs **no `block_user_subscriptions` row**. The token is minted from a synthetic **`page_<appBlockId>`** resolved directly from the **approved `AppBlock`** (`BlockRegistry.resolvePageBlock`). No DB change.

## Entity-aware token mint (model path byte-identical)

- Mint generalized to an `entityType` discriminator. **MODEL path is byte-identical**: `ctx = { modelId, slotId }` (no `entityType` field added), so `enforceContextBinding` / `getEffectiveCheckpoint` / `updateUserSettings` see exactly the claims they saw before (regression-locked).
- **PAGE path (entity=none):** pure viewer-scoped, `ctx = { slotId, entityType:'none' }` (no `modelId` → can never satisfy a model-bound check). **Carries NO money scopes** — a hard rule rejects `ai:write:budgeted` / `buzz:read:self` / `social:tip:self` (belt over the manifest + approved-scope intersection). Page-slot-only + `page_<id>`-instance-only.
- `BlockSlot` remount key generalized to `${slotId}:${entityType}:${entityId}` (`slotRemountKey`), **preserving the exact model remount-on-nav behavior (H-4)**.

## Slot registry foundation

`src/shared/constants/slot-registry.ts` — single source: today's 3 model slots + one new `app.page` (kind:`page`, entity:`none`) slot. `KNOWN_SLOT_IDS` re-exported under the same name (model-only enum) so `blocks.router.ts` reuse sites are untouched; marketplace filter + client unions derive from it.

## Route + host

- `src/pages/apps/run/[slug]/[[...path]].tsx` (avoids the `[appBlockId]` sibling collision). Full-bleed `PageBlockHost` under the W7 trust chrome, iframing `manifest.iframe.src`, with subPath deep-linking (`NAVIGATE` shallow-routed + traversal-guarded; `ROUTE_CHANGED` on `popstate`).
- New `PageBlockHost.tsx` — deliberately **separate** from the model `IframeHost` (left untouched) so the model path can't be destabilized; reuses the shared primitives (origin-pinned transport, retry-until-`BLOCK_READY` controller, trust chrome, sandbox intersection).

## Manifest + discovery

- Validator now validates `page:{path,title,icon?}` **and** closes the pre-existing gap by validating `targets[].slotId ∈ KNOWN_SLOT_IDS`.
- Public manifest projection surfaces a `hasPage` boolean (no internals) → "Open app" affordance on `/apps` cards + the detail page, flag-gated.

## Behavior-preserving gate

The full existing AppBlocks corpus stays green. **220 unit tests pass** (oldBehaviorProof, hostRenderDecision, iframeInitController, slotReservation, sortInstallsForSlot, projectBlockInit, hiddenBlocks, failureSnapshot, block-registry / block-token / block-manifest-validator services, block-scope middleware + constants) — plus the new W10 tests.

## Tests added

- **Unit:** slot-registry regression lock (`KNOWN_SLOT_IDS.options` == historical tuple); entity-agnostic remount key preserves model behavior; manifest validator accepts page + rejects unknown slotId; page mint carries no money scopes, is flag-gated + approved-only + stateless (resolves via `resolvePageBlock`, never `resolveBlockInstance`); **model token claims byte-identical** for `generate-from-model`.
- **e2e:** `tests/preview-apps-page.spec.ts` (mod fixture) drives a mod opening `/apps/run/<slug>`, asserts the iframe mounts and acks ready (BLOCK_INIT with a viewer page token). **Runs on the PR preview — needs `app-blocks-pages-enabled` relaxed to the mod segment there** (same posture as `app-blocks-enabled`).

## Deferred

- **PR3** (install/resolver polymorphism + additive migration, `users:/images:read:context` scopes, `UserSlotContext`/`ImageSlotContext`) — the entity dispatch is shaped so these slot in later without rework, but they are NOT built here.

## Verification notes

- Local typecheck is broken repo-wide (Prisma client not generated locally → ~4.6k pre-existing errors incl. the `Prisma.sql`/`$queryRaw` cascade in pre-existing `getAppDetail`). Filtered tsc shows **zero errors in any touched file**; the Tekton `pr-preview-*` typecheck is authoritative.
- The e2e preview run is the gate for the page click-path; not yet run on a live preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)