### PR TITLE
fix(app-blocks): host postMessage supports opaque-origin (unverified/sandboxed) blocks

### DIFF
--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -12,7 +12,7 @@ import { resolveRequestSignIn } from './requestSignInGate';
 import { resolveRequestConsent } from './requestConsentGate';
 import { hideBlock } from './hiddenBlocks';
 import { sanitizeAppChromeName } from './appChromeName';
-import { intersectSandbox } from './sandbox';
+import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
 import { projectBlockInitContext, projectBlockInitViewer } from './projectBlockInit';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { usePostMessage } from './usePostMessage';
@@ -254,7 +254,20 @@ export function IframeHost({
     }
   }, [iframeSrc]);
 
-  const { send, onMessage } = usePostMessage({ iframeRef, expectedOrigin });
+  // The EFFECTIVE sandbox handed to the iframe attribute below. Derive the
+  // transport's opaque-origin mode from the SAME string so they can never
+  // drift: unverified (no allow-same-origin) → opaque frame → opaque transport;
+  // internal/verified (has allow-same-origin) → real origin → pinned transport.
+  const effectiveSandbox = useMemo(
+    () => intersectSandbox(install.manifest.iframe?.sandbox, install.trustTier),
+    [install.manifest.iframe?.sandbox, install.trustTier]
+  );
+  const opaqueOrigin = useMemo(
+    () => effectiveSandboxIsOpaque(effectiveSandbox),
+    [effectiveSandbox]
+  );
+
+  const { send, onMessage } = usePostMessage({ iframeRef, expectedOrigin, opaqueOrigin });
 
   // applyHeight is wrapped so the postMessage subscribers keep a stable
   // reference even though install.manifest is stable across renders.
@@ -1166,7 +1179,7 @@ export function IframeHost({
         // H-6: client-side sandbox allowlist intersection — defense in depth
         // against a future server-side bypass that lets a dangerous token
         // reach the iframe attribute.
-        sandbox={intersectSandbox(install.manifest.iframe?.sandbox, install.trustTier)}
+        sandbox={effectiveSandbox}
         // H-6: no-referrer keeps the model page URL out of the publisher's
         // server logs.
         referrerPolicy="no-referrer"

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -5,7 +5,7 @@ import { BlockFallback } from './BlockFallback';
 import { AppBlockChrome } from './IframeHost';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { grantedPageScopes, pageFallbackReason } from './pageBlockHostLogic';
-import { intersectSandbox } from './sandbox';
+import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, PageContext } from './types';
 
@@ -108,7 +108,20 @@ export function PageBlockHost({
     }
   }, [iframeSrc]);
 
-  const { send, onMessage } = usePostMessage({ iframeRef, expectedOrigin });
+  // The EFFECTIVE sandbox handed to the iframe attribute below. Derive the
+  // transport's opaque-origin mode from the SAME string so the two can never
+  // drift: unverified (no allow-same-origin) → opaque frame → opaque transport;
+  // internal/verified (has allow-same-origin) → real origin → pinned transport.
+  const effectiveSandbox = useMemo(
+    () => intersectSandbox(sandbox, trustTier),
+    [sandbox, trustTier]
+  );
+  const opaqueOrigin = useMemo(
+    () => effectiveSandboxIsOpaque(effectiveSandbox),
+    [effectiveSandbox]
+  );
+
+  const { send, onMessage } = usePostMessage({ iframeRef, expectedOrigin, opaqueOrigin });
 
   // #3/#6: the scopes the minted JWT ACTUALLY carries (declared − missing).
   // See pageBlockHostLogic.grantedPageScopes. Posting `[]` (the old hardcode)
@@ -347,7 +360,7 @@ export function PageBlockHost({
         <iframe
           ref={iframeRef}
           src={iframeSrc}
-          sandbox={intersectSandbox(sandbox, trustTier)}
+          sandbox={effectiveSandbox}
           referrerPolicy="no-referrer"
           title={appName || blockId}
           data-testid="app-page-iframe"

--- a/src/components/AppBlocks/__tests__/sandbox.test.ts
+++ b/src/components/AppBlocks/__tests__/sandbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { intersectSandbox } from '../sandbox';
+import { effectiveSandboxIsOpaque, intersectSandbox } from '../sandbox';
 
 /**
  * L-SANDBOX coverage. intersectSandbox derives the iframe `sandbox`
@@ -57,5 +57,39 @@ describe('intersectSandbox', () => {
       'allow-same-origin',
     ]);
     for (const t of out) expect(allowed.has(t)).toBe(true);
+  });
+});
+
+/**
+ * L-OPAQUE caller derivation. The host's postMessage transport must run in
+ * opaque mode iff the EFFECTIVE iframe sandbox lacks `allow-same-origin` (i.e.
+ * the frame runs at an opaque 'null' origin). Both callers (PageBlockHost +
+ * IframeHost) derive `opaqueOrigin = effectiveSandboxIsOpaque(effectiveSandbox)`
+ * from the SAME `intersectSandbox(...)` value they hand to the iframe
+ * `sandbox` attribute, so transport mode can never drift from the actual frame
+ * origin.
+ */
+describe('effectiveSandboxIsOpaque (transport-mode derivation)', () => {
+  it('unverified tier → no allow-same-origin → opaque (true)', () => {
+    const eff = intersectSandbox('allow-forms', 'unverified');
+    expect(eff.split(/\s+/)).not.toContain('allow-same-origin');
+    expect(effectiveSandboxIsOpaque(eff)).toBe(true);
+  });
+
+  it('internal tier → has allow-same-origin → NOT opaque (false, pinned path preserved)', () => {
+    const eff = intersectSandbox('allow-forms', 'internal');
+    expect(eff.split(/\s+/)).toContain('allow-same-origin');
+    expect(effectiveSandboxIsOpaque(eff)).toBe(false);
+  });
+
+  it('verified tier → has allow-same-origin → NOT opaque (false)', () => {
+    expect(effectiveSandboxIsOpaque(intersectSandbox(undefined, 'verified'))).toBe(false);
+  });
+
+  it('direct token checks', () => {
+    expect(effectiveSandboxIsOpaque('allow-scripts')).toBe(true);
+    expect(effectiveSandboxIsOpaque('allow-scripts allow-same-origin')).toBe(false);
+    // word-boundary safe: a token that merely contains the substring is not a match
+    expect(effectiveSandboxIsOpaque('allow-same-origin-ish')).toBe(true);
   });
 });

--- a/src/components/AppBlocks/__tests__/usePostMessage.test.ts
+++ b/src/components/AppBlocks/__tests__/usePostMessage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { extractRequestId } from '../usePostMessage';
+import {
+  extractRequestId,
+  isInboundOriginAccepted,
+  resolveOutboundTargetOrigin,
+} from '../usePostMessage';
 
 /**
  * L-DEDUP coverage. The replay-dedup key (`requestId`) is carried inside the
@@ -31,5 +35,117 @@ describe('extractRequestId', () => {
     expect(extractRequestId({ payload: { requestId: 42 } })).toBeUndefined();
     expect(extractRequestId({ requestId: 42 })).toBeUndefined();
     expect(extractRequestId({ payload: { requestId: null } })).toBeUndefined();
+  });
+});
+
+const REAL_ORIGIN = 'https://notepad.civit.ai';
+
+/**
+ * L-OPAQUE inbound coverage. A sandboxed block WITHOUT `allow-same-origin`
+ * (unverified/external tier) runs at an opaque origin → `event.origin` is the
+ * literal string `'null'`. The original guard required
+ * `event.origin === expectedOrigin`, so every message from such a frame
+ * (including BLOCK_READY) was dropped and the block could never boot.
+ *
+ * `isInboundOriginAccepted` is the extracted, pure origin-acceptance branch of
+ * the hook's inbound guard. The hook ALSO pins `event.source === contentWindow`
+ * (the authenticating guard, origin-independent) — that pin is what
+ * authenticates the sender in opaque mode and is asserted to still hold by the
+ * source-pin composition test below.
+ */
+describe('isInboundOriginAccepted', () => {
+  describe('opaqueOrigin=false (default, behavior-preserving)', () => {
+    it('accepts ONLY a matching expectedOrigin', () => {
+      expect(isInboundOriginAccepted(REAL_ORIGIN, REAL_ORIGIN, false)).toBe(true);
+    });
+
+    it("rejects the opaque 'null' origin (the original behavior — unverified blocks were dropped)", () => {
+      expect(isInboundOriginAccepted('null', REAL_ORIGIN, false)).toBe(false);
+    });
+
+    it('rejects a non-matching origin', () => {
+      expect(isInboundOriginAccepted('https://evil.example', REAL_ORIGIN, false)).toBe(false);
+    });
+
+    it('rejects everything when expectedOrigin is empty (misconfigured iframe.src)', () => {
+      expect(isInboundOriginAccepted('null', '', false)).toBe(false);
+      expect(isInboundOriginAccepted(REAL_ORIGIN, '', false)).toBe(false);
+      expect(isInboundOriginAccepted('', '', false)).toBe(false);
+    });
+  });
+
+  describe('opaqueOrigin=true (sandboxed/unverified frame)', () => {
+    it("accepts the opaque 'null' origin", () => {
+      expect(isInboundOriginAccepted('null', REAL_ORIGIN, true)).toBe(true);
+    });
+
+    it('still accepts a matching expectedOrigin (belt)', () => {
+      expect(isInboundOriginAccepted(REAL_ORIGIN, REAL_ORIGIN, true)).toBe(true);
+    });
+
+    it('does NOT accept arbitrary non-null origins', () => {
+      expect(isInboundOriginAccepted('https://evil.example', REAL_ORIGIN, true)).toBe(false);
+      // 'null' is special; the string 'nullish' or anything else is rejected.
+      expect(isInboundOriginAccepted('nullish', REAL_ORIGIN, true)).toBe(false);
+    });
+
+    it("accepts 'null' even when expectedOrigin is empty (opaque frames have no pinnable origin)", () => {
+      expect(isInboundOriginAccepted('null', '', true)).toBe(true);
+      // but a non-null, non-matching origin is still rejected.
+      expect(isInboundOriginAccepted('https://evil.example', '', true)).toBe(false);
+    });
+  });
+});
+
+/**
+ * L-OPAQUE source-pin composition. The hook's inbound guard is
+ *   isInboundOriginAccepted(origin) && event.source === contentWindow.
+ * In opaque mode the origin can't authenticate the sender (it's 'null' for
+ * every sandboxed frame), so the source-window pin is the security guard. This
+ * mirrors that exact composition to prove a 'null'-origin message from the
+ * WRONG source window is still rejected even in opaque mode.
+ */
+describe('inbound guard composition (origin AND source-window pin)', () => {
+  const ourWindow = { id: 'our-iframe-contentWindow' };
+  const otherWindow = { id: 'some-other-window' };
+
+  const accepted = (origin: string, source: unknown, opaque: boolean) =>
+    isInboundOriginAccepted(origin, REAL_ORIGIN, opaque) && source === ourWindow;
+
+  it("opaque mode: 'null' origin + correct source → ACCEPTED", () => {
+    expect(accepted('null', ourWindow, true)).toBe(true);
+  });
+
+  it("opaque mode: 'null' origin + WRONG source → REJECTED (source pin holds)", () => {
+    expect(accepted('null', otherWindow, true)).toBe(false);
+  });
+
+  it('pinned mode: matching origin + correct source → ACCEPTED', () => {
+    expect(accepted(REAL_ORIGIN, ourWindow, false)).toBe(true);
+  });
+
+  it('pinned mode: matching origin + WRONG source → REJECTED', () => {
+    expect(accepted(REAL_ORIGIN, otherWindow, false)).toBe(false);
+  });
+});
+
+/**
+ * L-OPAQUE outbound coverage. `resolveOutboundTargetOrigin` is the extracted
+ * pure target-origin selection used by `send`. A null-origin recipient only
+ * accepts a `'*'` targetOrigin (a real origin throws). Pinned mode is unchanged.
+ */
+describe('resolveOutboundTargetOrigin', () => {
+  it("opaqueOrigin=true → posts with '*' (the only value that reaches a null-origin frame)", () => {
+    expect(resolveOutboundTargetOrigin(REAL_ORIGIN, true)).toBe('*');
+    // even with no expectedOrigin, opaque mode must still post to '*'.
+    expect(resolveOutboundTargetOrigin('', true)).toBe('*');
+  });
+
+  it('opaqueOrigin=false → posts with expectedOrigin (never *)', () => {
+    expect(resolveOutboundTargetOrigin(REAL_ORIGIN, false)).toBe(REAL_ORIGIN);
+  });
+
+  it('opaqueOrigin=false with no expectedOrigin → refuses to post (null), never *', () => {
+    expect(resolveOutboundTargetOrigin('', false)).toBeNull();
   });
 });

--- a/src/components/AppBlocks/sandbox.ts
+++ b/src/components/AppBlocks/sandbox.ts
@@ -44,3 +44,26 @@ export function intersectSandbox(raw: string | undefined, trustTier: string): st
   if (TRUSTED_TIERS.has(trustTier)) tokens.add('allow-same-origin');
   return Array.from(tokens).join(' ');
 }
+
+/**
+ * L-OPAQUE: does the EFFECTIVE iframe sandbox (the same string handed to the
+ * `<iframe sandbox=…>` attribute) lack `allow-same-origin`?
+ *
+ * A sandboxed iframe WITHOUT `allow-same-origin` runs at an opaque origin —
+ * `event.origin` is the literal string `'null'` on every message it sends,
+ * and a `postMessage` to it only reaches the frame when `targetOrigin` is
+ * `'*'` (a real origin throws "target origin … does not match recipient
+ * origin 'null'"). The host's postMessage transport must run in opaque mode
+ * for such a frame, otherwise BLOCK_READY (inbound) is dropped and BLOCK_INIT
+ * (outbound) never arrives — exactly the boot failure for unverified/external
+ * blocks.
+ *
+ * Pass the SAME value used for the iframe attribute (i.e. the
+ * `intersectSandbox(sandbox, trustTier)` result) so the transport mode can
+ * never drift from the actual frame origin. Internal/verified tiers keep
+ * `allow-same-origin` → real origin → returns false → pinned behavior is
+ * preserved byte-for-byte.
+ */
+export function effectiveSandboxIsOpaque(effectiveSandbox: string): boolean {
+  return !effectiveSandbox.split(/\s+/).includes('allow-same-origin');
+}

--- a/src/components/AppBlocks/usePostMessage.ts
+++ b/src/components/AppBlocks/usePostMessage.ts
@@ -4,6 +4,29 @@ import type { RefObject } from 'react';
 interface UsePostMessageOptions {
   iframeRef: RefObject<HTMLIFrameElement | null>;
   expectedOrigin: string;
+  /**
+   * Opt-in opaque-origin transport for sandboxed frames WITHOUT
+   * `allow-same-origin` (unverified/external blocks). Such a frame runs at an
+   * opaque origin: `event.origin === 'null'` on everything it sends, and a
+   * `postMessage` to it only reaches the frame with `targetOrigin = '*'`.
+   *
+   * Default `false` → behavior is byte-identical to before this option
+   * existed: inbound is pinned to `expectedOrigin`, outbound posts to
+   * `expectedOrigin`, and a missing `expectedOrigin` refuses to post.
+   *
+   * When `true`:
+   *   - Inbound accepts `event.origin === 'null'` (the opaque origin) in
+   *     addition to a matching `expectedOrigin`. It does NOT accept arbitrary
+   *     non-null origins. The `event.source === iframe.contentWindow`
+   *     source-window pin (origin-independent) remains the authenticating
+   *     guard — origin cannot be pinned for an opaque frame.
+   *   - Outbound posts with `targetOrigin = '*'` (the only value a null-origin
+   *     recipient accepts). This is safe here: the message is delivered solely
+   *     to THIS one host-controlled, sandboxed iframe's `contentWindow`, whose
+   *     `src` the host sets — `'*'` is the standard pattern for messaging your
+   *     own sandboxed frame, and the only listener is that frame.
+   */
+  opaqueOrigin?: boolean;
 }
 
 interface IncomingMessage {
@@ -46,21 +69,73 @@ export function extractRequestId(data: {
 }
 
 /**
+ * Pure origin acceptance check for an inbound message, factored out so the
+ * pinned-vs-opaque branch is unit-testable without the postMessage harness.
+ *
+ *   - Non-opaque (default): accept ONLY when `eventOrigin === expectedOrigin`
+ *     and `expectedOrigin` is truthy. Byte-identical to the original guard.
+ *   - Opaque mode: ALSO accept the literal opaque origin `'null'` (a sandboxed
+ *     frame with no `allow-same-origin`). A matching `expectedOrigin` is still
+ *     accepted as a belt; arbitrary non-null origins are still rejected. The
+ *     real sender authentication in opaque mode is the `event.source` window
+ *     pin enforced by the caller — NOT this origin check.
+ */
+export function isInboundOriginAccepted(
+  eventOrigin: string,
+  expectedOrigin: string,
+  opaqueOrigin: boolean
+): boolean {
+  if (opaqueOrigin && eventOrigin === 'null') return true;
+  if (!expectedOrigin) return false;
+  return eventOrigin === expectedOrigin;
+}
+
+/**
+ * Pure outbound `targetOrigin` resolution for `send`, factored out so the
+ * pinned-vs-opaque branch is unit-testable.
+ *
+ *   - Opaque mode → `'*'`: the recipient runs at an opaque origin ('null') and
+ *     `'*'` is the ONLY targetOrigin that reaches it (a real origin throws
+ *     "target origin … does not match recipient origin 'null'"). Safe because
+ *     the message is delivered solely to the one host-controlled sandboxed
+ *     iframe's contentWindow (the caller still pins the recipient window).
+ *   - Pinned mode with a truthy `expectedOrigin` → that origin (byte-identical
+ *     to the original behavior).
+ *   - Pinned mode with no `expectedOrigin` → `null` ("refuse to post"): the
+ *     original code returned early rather than fall back to `'*'`.
+ */
+export function resolveOutboundTargetOrigin(
+  expectedOrigin: string,
+  opaqueOrigin: boolean
+): string | null {
+  if (opaqueOrigin) return '*';
+  if (!expectedOrigin) return null;
+  return expectedOrigin;
+}
+
+/**
  * Typed postMessage send/receive with security rails:
- *   - Drops messages from origins other than `expectedOrigin`
+ *   - Drops messages from origins other than `expectedOrigin` (or the opaque
+ *     `'null'` origin when `opaqueOrigin` is set — see UsePostMessageOptions)
+ *   - Pins the sender to OUR iframe's `contentWindow` (the authenticating
+ *     guard, origin-independent — the only sender check in opaque mode)
  *   - Deduplicates by `requestId` inside a 5-second window
  *   - Rate-limits incoming messages to 30/sec (excess is dropped)
  */
 export function usePostMessage(opts: UsePostMessageOptions): UsePostMessageResult {
-  const { iframeRef, expectedOrigin } = opts;
+  const { iframeRef, expectedOrigin, opaqueOrigin = false } = opts;
   const handlersRef = useRef<Map<string, Set<(payload: unknown) => void>>>(new Map());
   const recentTimestampsRef = useRef<number[]>([]);
   const seenRequestIdsRef = useRef<Map<string, number>>(new Map());
 
   const handleMessage = useCallback(
     (event: MessageEvent) => {
-      if (!expectedOrigin) return; // misconfigured iframe.src — drop everything
-      if (event.origin !== expectedOrigin) return;
+      // Origin acceptance: pinned to `expectedOrigin` by default; in
+      // opaqueOrigin mode the sandboxed (no allow-same-origin) frame's
+      // `'null'` origin is accepted too. A missing expectedOrigin in non-opaque
+      // mode still drops everything (misconfigured iframe.src). The
+      // event.source window pin below is the authenticating guard either way.
+      if (!isInboundOriginAccepted(event.origin, expectedOrigin, opaqueOrigin)) return;
       // event.source check: origin alone is spoofable across same-origin iframes
       // (two installs from the same publisher on one page can postMessage at
       // each other and forge a BLOCK_ERROR/BLOCK_READY for a sibling). The
@@ -113,7 +188,7 @@ export function usePostMessage(opts: UsePostMessageOptions): UsePostMessageResul
 
       for (const handler of subscribers) handler(data.payload);
     },
-    [expectedOrigin, iframeRef]
+    [expectedOrigin, iframeRef, opaqueOrigin]
   );
 
   useEffect(() => {
@@ -123,12 +198,13 @@ export function usePostMessage(opts: UsePostMessageOptions): UsePostMessageResul
 
   const send = useCallback(
     (type: string, payload?: unknown) => {
-      if (!expectedOrigin) return; // refuse to post to "*"
       const iframe = iframeRef.current;
       if (!iframe || !iframe.contentWindow) return;
-      iframe.contentWindow.postMessage({ type, payload }, expectedOrigin);
+      const targetOrigin = resolveOutboundTargetOrigin(expectedOrigin, opaqueOrigin);
+      if (targetOrigin === null) return; // pinned mode, no origin: refuse to post
+      iframe.contentWindow.postMessage({ type, payload }, targetOrigin);
     },
-    [iframeRef, expectedOrigin]
+    [iframeRef, expectedOrigin, opaqueOrigin]
   );
 
   const onMessage = useCallback(


### PR DESCRIPTION
## The bug

The App Blocks host transport (`src/components/AppBlocks/usePostMessage.ts`) cannot exchange messages with a **sandboxed, unverified-tier block**, so no external/unverified block can boot. Today only `internal`-tier blocks — which get `allow-same-origin` → a real origin matching `expectedOrigin` — work.

A sandboxed block **without** `allow-same-origin` runs at an **opaque origin**:
- every message it sends has `event.origin === 'null'`, so the inbound guard `if (event.origin !== expectedOrigin) return;` dropped its `BLOCK_READY` (and everything else);
- a `postMessage` to it with `targetOrigin = 'https://<slug>.civit.ai'` **throws** `target origin … does not match recipient origin 'null'`, so `BLOCK_INIT` never arrived.

Net effect: the entire external-developer path was blocked.

## The fix (host-side only)

The SDK / block side is unchanged — the host has a real origin, so the block's own inbound validation and its outbound `targetOrigin` to the parent are fine. This is purely the host transport.

- **`usePostMessage` gains an opt-in `opaqueOrigin?: boolean`** (default `false` → behavior **byte-identical** to before: pin origin in + out, refuse `'*'`). When `true`:
  - **Inbound** also accepts `event.origin === 'null'` (and a matching `expectedOrigin` as a belt); it does **not** accept arbitrary non-null origins.
  - **Outbound** posts with `targetOrigin = '*'` — the only value that reaches a null-origin recipient. Gated so `'*'` is used **only** in opaque mode.
  - The origin/target decisions are extracted to **pure, unit-tested helpers** (`isInboundOriginAccepted`, `resolveOutboundTargetOrigin`).
- **The `event.source === iframe.contentWindow` source-window pin is unchanged and is the security guard.** In opaque mode the origin can't authenticate the sender (`'null'` for every sandboxed frame), so the source-window pin is what actually pins us to OUR one iframe.
- **Both callers derive `opaqueOrigin` from the EFFECTIVE sandbox** — the same `intersectSandbox(sandbox, trustTier)` string handed to `<iframe sandbox=…>` — via the new `effectiveSandboxIsOpaque` helper, so transport mode can never drift from the actual frame origin:
  - `src/components/AppBlocks/PageBlockHost.tsx` (W10 page surface)
  - `src/components/AppBlocks/IframeHost.tsx` (model slots)
  - unverified → no `allow-same-origin` → opaque → `true`; internal/verified → has it → `false` → pinned path preserved exactly.

## Why it's safe

- Default (`opaqueOrigin: false`) is unchanged — internal/verified blocks keep the pinned origin in + out, byte-for-byte.
- In opaque mode the loosened origin check is backed by the **source-window pin**, which authenticates the sender independent of origin. Only the literal `'null'` opaque origin is added; arbitrary origins are still rejected.
- Outbound `'*'` only reaches the **one host-controlled, sandboxed iframe** whose `src` the host sets, and it is the only recipient — the standard, accepted pattern for messaging your own sandboxed frame.

## Impact

Unblocks **all** unverified/external blocks in **both** the page surface and the model slots (including the W10 page dog-food `notepad`). Touches the model `IframeHost` hot path but is **behavior-preserving for internal-tier** installs.

## Tests

Node-only (repo `unit` project pattern). Extends:
- `usePostMessage.test.ts` — 20 cases (was 5): opaque-on inbound accepts `'null'` + correct source / rejects `'null'` + wrong source (source pin holds); opaque-on outbound `'*'`; behavior-preserving default (rejects `'null'`, rejects non-matching origin, posts to `expectedOrigin`, refuses to post with no origin).
- `sandbox.test.ts` — 10 cases (was 6): `effectiveSandboxIsOpaque` derivation from a sandbox with/without `allow-same-origin`.

Full AppBlocks node corpus: **146 passing**. The four changed source/test files are TS-clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)