### PR TITLE
feat(app-blocks): enable Buzz generation spend on full-page apps (W10) — dark, mod-gated

### DIFF
--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -312,10 +312,16 @@ export function IframeHost({
   // can display the budget without a JWT decode. Only present when the token
   // actually carries ai:write:budgeted (i.e. after consent); absent otherwise —
   // a budget cap is meaningless without the spend scope it bounds.
+  //
+  // Must stay in lockstep with the server's `resolveBuzzBudget`
+  // (src/pages/api/v1/block-tokens/index.ts): require an INTEGER (not merely a
+  // finite number) so a fractional / Infinity / NaN value falls back to the
+  // default here exactly as the server mints it — otherwise the UI would show a
+  // per-gen budget the server never signed.
   const buzzBudget = useMemo<number | undefined>(() => {
     if (!grantedScopes.includes('ai:write:budgeted')) return undefined;
     const raw = install.publisherSettings?.buzz_budget_per_gen;
-    const candidate = typeof raw === 'number' && Number.isFinite(raw) ? raw : 10;
+    const candidate = typeof raw === 'number' && Number.isInteger(raw) ? raw : 10;
     if (candidate <= 0) return undefined;
     return Math.min(candidate, 1000);
   }, [grantedScopes, install.publisherSettings]);

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -410,12 +410,33 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       res.status(404).json({ error: 'Page app not found' });
       return;
     }
+    // W10 generation spend: a page is stateless (no install settings row), so
+    // its per-gen Buzz budget is sourced from the APPROVED manifest's
+    // `page.buzzBudgetPerGen` field rather than from install settings. We map it
+    // onto the same `buzz_budget_per_gen` settings key the model path uses, so
+    // the existing resolveBuzzBudget(install.settings) calls below treat pages
+    // and model slots IDENTICALLY — the same arbiter, the same clamp, the same
+    // 422 on a non-positive value:
+    //   - manifest declares a finite number   → pass it through verbatim;
+    //     resolveBuzzBudget clamps >CAP to CAP and turns <=0 into the 0 sentinel
+    //     → 422 INVALID_BUZZ_BUDGET (fail-closed, never a silent 0-budget token).
+    //   - manifest omits it / non-number      → settings stay EMPTY so
+    //     resolveBuzzBudget falls back to BUZZ_BUDGET_DEFAULT.
+    // Passing a number through unconditionally (not pre-filtering to >0) keeps
+    // a non-positive manifest budget a HARD ERROR rather than a silent default,
+    // matching the model-slot contract.
+    const pageManifest = (page.appBlock.manifest ?? {}) as { page?: { buzzBudgetPerGen?: unknown } };
+    const manifestBudget = pageManifest.page?.buzzBudgetPerGen;
+    const pageSettings: Record<string, unknown> =
+      typeof manifestBudget === 'number' && Number.isFinite(manifestBudget)
+        ? { buzz_budget_per_gen: manifestBudget }
+        : {};
     resolved = {
       appBlock: page.appBlock,
       modelId: null,
       slotId: slotContext.slotId,
       installedByUserId: null,
-      settings: {},
+      settings: pageSettings,
     };
   } else {
     // MODEL PATH (unchanged). Use dbWrite (primary) so a freshly-suspended

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -267,7 +267,14 @@ function resolveBuzzBudget(
 ): number | null {
   if (!scopes.includes('ai:write:budgeted')) return null;
   const raw = publisherSettings?.buzz_budget_per_gen;
-  const candidate = typeof raw === 'number' && Number.isFinite(raw) ? raw : BUZZ_BUDGET_DEFAULT;
+  // Defense-in-depth (audit should-fix): require an INTEGER, not merely a
+  // finite number. A fractional / Infinity / NaN / non-number value falls back
+  // to the platform default rather than flowing through to a fractional Buzz
+  // budget. This treats model slots and pages identically — both arrive here as
+  // `buzz_budget_per_gen` (the model path from install settings, the page path
+  // mapped from manifest `page.buzzBudgetPerGen`) and both clamp+gate the same
+  // way. A valid positive integer (the model-slot common case) is unchanged.
+  const candidate = typeof raw === 'number' && Number.isInteger(raw) ? raw : BUZZ_BUDGET_DEFAULT;
   if (candidate <= 0) return 0; // sentinel — caller rejects with 422
   return Math.min(candidate, BUZZ_BUDGET_CAP);
 }

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1543,6 +1543,78 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       const incrKey = String(mockSysRedis.incrBy.mock.calls[0][0]);
       expect(incrKey).toMatch(/^system:blocks:buzz-cap:42:\d{4}-\d{2}-\d{2}$/);
     });
+
+    // ──────────────────── GA-gap: orchestrator resource belt ─────────────────
+    //
+    // The pre-spend gate (`resolveCanGenerateForVersions`) deliberately does NOT
+    // check early-access `hasAccess` or the `availability:Private` subscription
+    // requirement (see the SCOPE comment on assertViewerCanGeneratePageModel).
+    // Those are enforced DOWNSTREAM by the orchestrator resource belt
+    // (`getGenerationResourceData` → `getResourceData`, which folds
+    // `canGenerate = hasAccess && canGenerate` and throws on a Private resource
+    // without an active subscription). That belt runs INSIDE
+    // `createTextToImageStep`, and the whatIf step is built BEFORE any Buzz
+    // reservation.
+    //
+    // WHAT THIS PROVES: a page viewer who is NOT entitled to an early-access /
+    // Private model — but whose model PASSES the pre-spend gate (canGenerate is
+    // the DEFAULT true here, modelling the gate's deliberate blind spot) — is
+    // rejected by the belt at the whatIf step, BEFORE any reservation. The
+    // reservation path (`reserveBlockBuzzSpend`/incrBy) is never reached, so the
+    // viewer spends nothing.
+    //
+    // WHAT THIS DOES NOT PROVE: that getResourceData's REAL hasAccess/Private
+    // logic actually rejects those models — that logic is mocked away here (it
+    // lives in orchestrator/common.ts and is exercised by its own suite). This
+    // test pins the ORDERING + fail-shape contract (belt before spend, throw →
+    // no reservation), not the belt's internal entitlement maths. A DEPLOYED
+    // browser run against a real early-access / Private model is still required
+    // to prove end-to-end entitlement enforcement on the live page surface.
+    it('GA-gap: a page model that passes the pre-spend gate but is rejected by the orchestrator belt (early-access/Private) → no spend, no reservation', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      // Pre-spend gate PASSES (default canGenerate:true) — modelling that the
+      // gate does NOT see early-access / Private entitlement.
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map([[99, { canGenerate: true }]])
+      );
+      // The orchestrator resource belt (inside createTextToImageStep) rejects an
+      // un-entitled early-access / Private resource. The whatIf step is the FIRST
+      // belt call in submit, and it is BEFORE the reservation.
+      mockCreateTextToImageStep.mockRejectedValueOnce(
+        new TRPCError({ code: 'FORBIDDEN', message: 'early access pass required' })
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      // The belt threw at the whatIf step — BEFORE any orchestrator submit and
+      // BEFORE any Buzz reservation. Nothing was spent.
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled(); // no reservation
+      expect(mockSysRedis.decrBy).not.toHaveBeenCalled(); // nothing to refund
+    });
+
+    // Companion: the same belt rejection on the ESTIMATE (whatIf) path — the
+    // pre-flight cost estimate also runs through createTextToImageStep, so an
+    // un-entitled model is rejected before a cost is ever returned to the page.
+    it('GA-gap: estimate of a belt-rejected (early-access/Private) page model → throws, no orchestrator submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+      happyVersionLookup();
+      happyUser();
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map([[99, { canGenerate: true }]])
+      );
+      mockCreateTextToImageStep.mockRejectedValueOnce(
+        new TRPCError({ code: 'FORBIDDEN', message: 'this model requires a subscription' })
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
   });
 
   describe('REGRESSION — model token still enforces model binding', () => {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -30,6 +30,7 @@ const {
   mockGetUserBuzzAccounts,
   mockLogToAxiom,
   mockSysRedis,
+  mockResolveCanGenerateForVersions,
 } = vi.hoisted(() => ({
   mockVerifyBlockToken: vi.fn(),
   mockParseSubjectUserId: vi.fn(),
@@ -73,6 +74,12 @@ const {
   })),
   mockGetUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
   mockLogToAxiom: vi.fn(async () => undefined),
+  // W10 page branch: the canonical generation-entitlement gate. The router
+  // dynamic-imports it from generation.service; we mock the module so the
+  // heavy generation import graph (image.service → event-engine-common) stays
+  // out of the test and we can drive canGenerate per-test. Default = a Map
+  // saying the version IS generatable; FORBIDDEN tests override to false / miss.
+  mockResolveCanGenerateForVersions: vi.fn(),
 }));
 
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
@@ -138,6 +145,10 @@ vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
 }));
 vi.mock('~/server/services/buzz.service', () => ({
   getUserBuzzAccounts: (...args: unknown[]) => mockGetUserBuzzAccounts(...args),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  resolveCanGenerateForVersions: (...args: unknown[]) =>
+    mockResolveCanGenerateForVersions(...args),
 }));
 vi.mock('~/server/logging/client', () => ({
   logToAxiom: (...args: unknown[]) => mockLogToAxiom(...args),
@@ -274,6 +285,7 @@ beforeEach(() => {
     mockSysRedis.decrBy,
     mockSysRedis.expire,
     mockSysRedis.ttl,
+    mockResolveCanGenerateForVersions,
   ]) {
     fn.mockReset();
   }
@@ -321,6 +333,13 @@ beforeEach(() => {
   });
   mockGetUserBuzzAccounts.mockResolvedValue({ yellow: 10000, blue: 0, green: 0 });
   mockLogToAxiom.mockResolvedValue(undefined);
+  // Default: the picked version IS generatable (page branch happy path). Tests
+  // that exercise the entitlement gate override to canGenerate:false or an
+  // empty Map (version missing → fail-closed).
+  mockResolveCanGenerateForVersions.mockImplementation(
+    async (versions: Array<{ id: number }>) =>
+      new Map(versions.map((v) => [v.id, { canGenerate: true }]))
+  );
 });
 
 describe('blocks.pollWorkflow', () => {
@@ -1304,5 +1323,220 @@ describe('Phase 2 — block-token runtime procedures reject non-mod viewers', ()
     await expect(
       caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});
+
+/**
+ * W10 — full-page apps spend Buzz on generation. A PAGE token's ctx is
+ * `{ slotId, entityType: 'none' }` with NO modelId: a page lets the viewer pick
+ * ANY model they're entitled to generate against. The runtime branch therefore
+ * (a) SKIPS the model-binding `ctxModelId === body.modelId` check, and
+ * (b) REPLACES it with the canonical generation-entitlement gate
+ *     (resolveCanGenerateForVersions) against the REAL viewer.
+ * Everything else (budget ceiling, daily cap reservation) is shared with the
+ * model path and unchanged.
+ */
+describe('blocks workflow — W10 page token (entityType:none)', () => {
+  // Page claim: ctx carries entityType:'none' + slotId, NO modelId. The
+  // blockInstanceId is the synthetic page id (page_<appBlockId>).
+  function pageClaims(over: Record<string, unknown> = {}) {
+    return validClaims({
+      blockInstanceId: 'page_apb_page',
+      ctx: { slotId: 'app.page', entityType: 'none' },
+      ...over,
+    });
+  }
+
+  describe('estimateWorkflow', () => {
+    it('a page token skips model-binding and passes the canGenerate gate → reaches whatif', async () => {
+      // ctx has NO modelId, body.modelId=7 — a MODEL token would 403 here; a
+      // page token must NOT.
+      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 12 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.cost).toEqual({ total: 12 });
+      // The entitlement gate ran against the picked version (99) with the REAL
+      // viewer (id 42, mod true) — NOT an elevated/hardcoded context.
+      expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
+      const [versions, gateCtx] = mockResolveCanGenerateForVersions.mock.calls[0];
+      expect(versions[0]).toMatchObject({ id: 99 });
+      expect(gateCtx.user).toEqual({ id: 42, isModerator: true });
+      expect(mockSubmitWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ query: { whatif: true } })
+      );
+    });
+
+    it('a page token whose picked model is NOT generatable → FORBIDDEN, no orchestrator call', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+      happyVersionLookup();
+      happyUser();
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map([[99, { canGenerate: false }]])
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('fail-closed: page token where the picked version is MISSING from the result Map → FORBIDDEN', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+      happyVersionLookup();
+      happyUser();
+      mockResolveCanGenerateForVersions.mockResolvedValue(new Map()); // empty → miss
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submitWorkflow', () => {
+    it('a page token submits when generatable + within budget (no spend bound bypassed)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockSysRedis.incrBy.mockResolvedValue(25); // reservation under the cap
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      // Entitlement gate ran (security replacement for model-binding).
+      expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
+      // The daily-cap reservation path runs for pages exactly as for models.
+      expect(mockSysRedis.incrBy).toHaveBeenCalledTimes(1);
+      expect(mockSysRedis.incrBy.mock.calls[0][1]).toBe(25);
+      // Prompt was audited before any orchestrator interaction.
+      expect(mockAuditPromptServer).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt: 'a cat', userId: 42 })
+      );
+    });
+
+    it('a page token whose picked model is NOT generatable → FORBIDDEN, no spend, no reservation', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map([[99, { canGenerate: false }]])
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      // No orchestrator interaction, no prompt audit, and CRUCIALLY no Buzz
+      // reservation (the gate is BEFORE reserveBlockBuzzSpend).
+      expect(mockAuditPromptServer).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('a page submit over budget → failed-shape snapshot (no throw), reservation refunded', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ buzzBudget: 5 }));
+      happyVersionLookup();
+      happyUser();
+      // whatif cost 25 > budget 5. The over-budget check is BEFORE the
+      // reservation, so no reserve/refund here — matches the model path.
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 25 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.cost).toEqual({ total: 25 });
+      expect(result.snapshot.error).toMatch(/insufficient buzz/i);
+      // Only the whatif ran; the real submit did not.
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      // No reservation was taken (over-budget rejected before reserve).
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('a page submit respects the per-USER daily cap (reservation over cap → failed + refund)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      // whatif clears the per-call budget, but the reservation tops the daily
+      // cap → reject + refund, exactly as for a model token.
+      mockSysRedis.incrBy.mockResolvedValue(50015);
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 25 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(/daily Buzz cap/i);
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1); // whatif only
+      expect(mockSysRedis.decrBy).toHaveBeenCalledTimes(1); // reservation refunded
+      // Per-USER key (no appBlockId) — page spend shares the same daily ceiling.
+      const incrKey = String(mockSysRedis.incrBy.mock.calls[0][0]);
+      expect(incrKey).toMatch(/^system:blocks:buzz-cap:42:\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('REGRESSION — model token still enforces model binding', () => {
+    it('estimate: a MODEL token (no entityType) with a mismatched body.modelId → FORBIDDEN', async () => {
+      // ctx.modelId 999 ≠ body.modelId 7, and NO entityType → model path → the
+      // model-binding check must still fire. The entitlement gate must NOT run
+      // (model tokens never reach the page branch).
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ ctx: { modelId: 999 } }));
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+    });
+
+    it('submit: a MODEL token with a mismatched body.modelId → FORBIDDEN (binding unchanged)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, ctx: { modelId: 999 } }));
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('submit: a matching MODEL token does NOT run the page entitlement gate', async () => {
+      // The standard happy model path (ctx.modelId 7 === body 7) must keep its
+      // exact behaviour — no canGenerate call (model binding IS the gate).
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockSysRedis.incrBy.mockResolvedValue(25);
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1374,6 +1374,56 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       );
     });
 
+    it('derives sfwOnly:true from a green-domain ctx and forwards it into the canGenerate gate', async () => {
+      // The page branch mirrors model-version.controller: the gate context's
+      // sfwOnly is `ctx.domain === 'green'`. fakeCtx() omits domain (→ false),
+      // so a green ctx is the only way to exercise the SFW-gating branch — it
+      // must flow into resolveCanGenerateForVersions' context arg as true.
+      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 12 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller({ ...fakeCtx(), domain: 'green' } as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
+      const [, gateCtx] = mockResolveCanGenerateForVersions.mock.calls[0];
+      expect(gateCtx.sfwOnly).toBe(true);
+      // wildcards is independent and untouched here → still false.
+      expect(gateCtx.wildcardsEnabled).toBe(false);
+    });
+
+    it('derives wildcardsEnabled:true from ctx.features.wildcards and forwards it into the canGenerate gate', async () => {
+      // The page branch mirrors model-version.controller: the gate context's
+      // wildcardsEnabled is `!!ctx.features.wildcards`. fakeCtx() omits the flag
+      // (→ false), so an enabled-wildcards ctx is the only way to exercise this
+      // branch — it must flow into the gate context arg as true.
+      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 12 },
+        steps: [],
+      });
+      const ctx = fakeCtx();
+      const caller = blocksRouter.createCaller({
+        ...ctx,
+        features: { ...(ctx.features as object), wildcards: true },
+      } as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
+      const [, gateCtx] = mockResolveCanGenerateForVersions.mock.calls[0];
+      expect(gateCtx.wildcardsEnabled).toBe(true);
+      // green-domain is independent and untouched here → sfwOnly still false.
+      expect(gateCtx.sfwOnly).toBe(false);
+    });
+
     it('a page token whose picked model is NOT generatable → FORBIDDEN, no orchestrator call', async () => {
       mockVerifyBlockToken.mockResolvedValue(pageClaims());
       happyVersionLookup();

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -45,6 +45,12 @@ import {
   validateBlockCheckpoint,
 } from '~/server/services/blocks/checkpoint.service';
 import { getModelShowcaseImages } from '~/server/services/blocks/showcase.service';
+// Type-only: the runtime `resolveCanGenerateForVersions` is loaded via a
+// dynamic import() inside assertViewerCanGeneratePageModel so the heavy
+// generation-service import graph (image.service → event-engine-common, etc.)
+// stays OUT of this router's static import graph — mirroring the existing
+// lazy import of recordScopeInvocation below.
+import type { ResolveCanGenerateVersion } from '~/server/services/generation/generation.service';
 import {
   buildTextToImageInput,
   resolveBlockVersionContext,
@@ -114,6 +120,73 @@ async function assertViewerIsModerator(userId: number): Promise<void> {
       message: 'App Blocks is restricted to the civitai team',
     });
   }
+}
+
+// ---- W10 page generation spend --------------------------------------------
+//
+// A model-slot token's ctx is `{ modelId, slotId }` (the install binds the
+// generator to ONE model). A page-slot token's ctx is `{ slotId, entityType:
+// 'none' }` — a page is stateless, has NO model binding, and lets the viewer
+// pick ANY model they're entitled to generate against. `entityType === 'none'`
+// is the discriminator the mint stamps (see the page path in
+// block-tokens/index.ts); model tokens never carry `entityType`.
+function isPageToken(claims: { ctx?: unknown }): boolean {
+  return (claims.ctx as { entityType?: unknown } | undefined)?.entityType === 'none';
+}
+
+// SECURITY-CRITICAL (W10). A page token has no model binding, so the model-
+// binding check (`ctxModelId === body.modelId`) that bounds a model slot does
+// NOT apply. The replacement bound is the platform's canonical generation-
+// entitlement gate: the REAL viewer must actually be allowed to generate
+// against the model they picked, exactly as the standard generation read paths
+// enforce (early-access locks, availability=Private, members-only usageControl,
+// generationCoverage). Without this, "any public model" would silently bypass
+// every per-model access gate.
+//
+// Pass the REAL viewer context (their id + real isModerator + the request's
+// sfwOnly/wildcards flags) — never an elevated context. Today the viewer is
+// always a mod (assertViewerIsModerator), so they see mod-level access, which
+// is correct platform behaviour; when GA opens to non-mods the same gate bounds
+// them properly. Fail-closed: a version missing from the result Map → FORBIDDEN.
+async function assertViewerCanGeneratePageModel(opts: {
+  gate: ReturnType<typeof buildGateVersion>;
+  viewer: { id: number; isModerator: boolean };
+  sfwOnly: boolean;
+  wildcardsEnabled: boolean;
+}): Promise<void> {
+  const { gate, viewer, sfwOnly, wildcardsEnabled } = opts;
+  const { resolveCanGenerateForVersions } = await import(
+    '~/server/services/generation/generation.service'
+  );
+  const states = await resolveCanGenerateForVersions([gate], {
+    user: { id: viewer.id, isModerator: viewer.isModerator },
+    sfwOnly,
+    wildcardsEnabled,
+  });
+  const canGenerate = states.get(gate.id)?.canGenerate ?? false;
+  if (!canGenerate) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'model is not available for generation',
+    });
+  }
+}
+
+// Narrow the `gate` bag `resolveBlockVersionContext` returns into the exact
+// `ResolveCanGenerateVersion` shape (the DB column types are wider than the
+// gate's string enums). Centralised so estimate + submit can't drift.
+function buildGateVersion(gate: {
+  id: number;
+  status: string;
+  availability: string;
+  usageControl: string;
+  baseModel: string;
+  covered: boolean | null | undefined;
+  modelUserId: number;
+  modelType: string;
+  modelVersionAlias: unknown;
+}): ResolveCanGenerateVersion {
+  return gate as unknown as ResolveCanGenerateVersion;
 }
 
 // ---- Cumulative Buzz-spend cap (audit A7 / design-gaps H1) -----------------
@@ -1355,12 +1428,19 @@ export const blocksRouter = router({
       if (!claims.scopes.includes('ai:write:budgeted')) {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
       }
-      // Context binding mirrors enforceContextBinding's models:read:self path —
-      // re-check here because the middleware version takes a NextApiRequest and
-      // we're in tRPC land.
-      const ctxModelId = Number((claims.ctx as { modelId?: unknown } | undefined)?.modelId ?? NaN);
-      if (!Number.isInteger(ctxModelId) || ctxModelId !== input.body.modelId) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'modelId mismatch with token' });
+      // Context binding. A MODEL token pins `ctx.modelId`; the body must match
+      // it. A PAGE token (ctx.entityType==='none') has NO model binding — it
+      // lets the viewer pick any model they're entitled to generate against, so
+      // the modelId match is SKIPPED and replaced (below, after the version
+      // read) by the canonical generation-entitlement gate. See isPageToken.
+      const isPage = isPageToken(claims);
+      if (!isPage) {
+        const ctxModelId = Number(
+          (claims.ctx as { modelId?: unknown } | undefined)?.modelId ?? NaN
+        );
+        if (!Number.isInteger(ctxModelId) || ctxModelId !== input.body.modelId) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'modelId mismatch with token' });
+        }
       }
       const userId = parseSubjectUserId(claims.sub);
       if (userId == null) {
@@ -1378,6 +1458,18 @@ export const blocksRouter = router({
         input.body.modelVersionId,
         input.body.modelId
       );
+      const user = await getBlockSessionUser(userId);
+      // PAGE branch: enforce that the REAL viewer is entitled to generate
+      // against the model they picked. This is the security replacement for the
+      // model-binding check skipped above — fail-closed before any spend.
+      if (isPage) {
+        await assertViewerCanGeneratePageModel({
+          gate: buildGateVersion(resolved.gate),
+          viewer: { id: userId, isModerator: !!user.isModerator },
+          sfwOnly: ctx.domain === 'green',
+          wildcardsEnabled: !!ctx.features.wildcards,
+        });
+      }
       const checkpoint = await resolveBlockCheckpoint({
         blockInstanceId: claims.blockInstanceId,
         modelId: resolved.modelId,
@@ -1387,7 +1479,6 @@ export const blocksRouter = router({
         userId,
         slotId: ctxSlotId,
       });
-      const user = await getBlockSessionUser(userId);
       const token = await getOrchestratorToken(userId, ctx);
       const generateInput = buildTextToImageInput(input.body, {
         ...resolved,
@@ -1425,9 +1516,19 @@ export const blocksRouter = router({
       if (typeof claims.buzzBudget !== 'number' || claims.buzzBudget <= 0) {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'block token missing budget' });
       }
-      const ctxModelId = Number((claims.ctx as { modelId?: unknown } | undefined)?.modelId ?? NaN);
-      if (!Number.isInteger(ctxModelId) || ctxModelId !== input.body.modelId) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'modelId mismatch with token' });
+      // Context binding. MODEL token → body.modelId must match ctx.modelId.
+      // PAGE token (ctx.entityType==='none') → no model binding; skip the match
+      // and enforce the canonical generation-entitlement gate after the version
+      // read instead (see estimateWorkflow for the same branch). The buzzBudget
+      // claim + per-user daily cap still bound spend identically for pages.
+      const isPage = isPageToken(claims);
+      if (!isPage) {
+        const ctxModelId = Number(
+          (claims.ctx as { modelId?: unknown } | undefined)?.modelId ?? NaN
+        );
+        if (!Number.isInteger(ctxModelId) || ctxModelId !== input.body.modelId) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'modelId mismatch with token' });
+        }
       }
       const userId = parseSubjectUserId(claims.sub);
       // Anon submit is not just forbidden — there's no buzz account to charge.
@@ -1449,6 +1550,18 @@ export const blocksRouter = router({
         input.body.modelVersionId,
         input.body.modelId
       );
+      const user = await getBlockSessionUser(userId);
+      // PAGE branch: the REAL viewer must be entitled to generate against the
+      // model they picked (replaces the skipped model-binding check) — fail
+      // closed BEFORE any reservation or orchestrator interaction.
+      if (isPage) {
+        await assertViewerCanGeneratePageModel({
+          gate: buildGateVersion(resolved.gate),
+          viewer: { id: userId, isModerator: !!user.isModerator },
+          sfwOnly: ctx.domain === 'green',
+          wildcardsEnabled: !!ctx.features.wildcards,
+        });
+      }
       const checkpoint = await resolveBlockCheckpoint({
         blockInstanceId: claims.blockInstanceId,
         modelId: resolved.modelId,
@@ -1458,7 +1571,6 @@ export const blocksRouter = router({
         userId,
         slotId: ctxSlotId,
       });
-      const user = await getBlockSessionUser(userId);
       const token = await getOrchestratorToken(userId, ctx);
 
       // Prompt audit before any orchestrator interaction (mirrors what

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -136,12 +136,23 @@ function isPageToken(claims: { ctx?: unknown }): boolean {
 
 // SECURITY-CRITICAL (W10). A page token has no model binding, so the model-
 // binding check (`ctxModelId === body.modelId`) that bounds a model slot does
-// NOT apply. The replacement bound is the platform's canonical generation-
-// entitlement gate: the REAL viewer must actually be allowed to generate
-// against the model they picked, exactly as the standard generation read paths
-// enforce (early-access locks, availability=Private, members-only usageControl,
-// generationCoverage). Without this, "any public model" would silently bypass
-// every per-model access gate.
+// NOT apply. The replacement bound is a PRE-SPEND slice of the platform's
+// generation-entitlement gate (`resolveCanGenerateForVersions` →
+// `getResourceCanGenerate`): the REAL viewer must clear availability,
+// generationCoverage, status, members-only usageControl, the hidden-gates set,
+// and base-model-supported. Without this, "any public model" would silently
+// bypass those per-model gates before we ever cost/reserve.
+//
+// SCOPE — what this gate does NOT cover: early-access `hasAccess` and the
+// availability=Private subscription requirement are NOT checked here.
+// `resolveCanGenerateForVersions` deliberately omits both. They are enforced
+// downstream by the orchestrator resource belt in `getGenerationResourceData`
+// (server/services/orchestrator/common.ts): `getResourceData` folds
+// `canGenerate = hasAccess && canGenerate` and the Private-resource path
+// throws without an active subscription — and BOTH the whatIf (estimate) and
+// the real (submit) steps run through that belt BEFORE any Buzz reservation.
+// DO NOT remove that belt assuming this pre-spend gate already covers
+// early-access / Private — it does not.
 //
 // Pass the REAL viewer context (their id + real isModerator + the request's
 // sfwOnly/wildcards flags) — never an elevated context. Today the viewer is
@@ -1432,7 +1443,10 @@ export const blocksRouter = router({
       // it. A PAGE token (ctx.entityType==='none') has NO model binding — it
       // lets the viewer pick any model they're entitled to generate against, so
       // the modelId match is SKIPPED and replaced (below, after the version
-      // read) by the canonical generation-entitlement gate. See isPageToken.
+      // read) by the pre-spend availability/coverage gate
+      // (assertViewerCanGeneratePageModel). Early-access + Private-subscription
+      // entitlement is enforced separately by the orchestrator resource belt.
+      // See isPageToken / assertViewerCanGeneratePageModel.
       const isPage = isPageToken(claims);
       if (!isPage) {
         const ctxModelId = Number(
@@ -1459,9 +1473,10 @@ export const blocksRouter = router({
         input.body.modelId
       );
       const user = await getBlockSessionUser(userId);
-      // PAGE branch: enforce that the REAL viewer is entitled to generate
-      // against the model they picked. This is the security replacement for the
-      // model-binding check skipped above — fail-closed before any spend.
+      // PAGE branch: pre-spend availability/coverage gate on the model the REAL
+      // viewer picked (the security replacement for the skipped model-binding
+      // check) — fail-closed before any spend. Early-access + Private-sub
+      // entitlement is enforced downstream by the orchestrator resource belt.
       if (isPage) {
         await assertViewerCanGeneratePageModel({
           gate: buildGateVersion(resolved.gate),
@@ -1518,9 +1533,11 @@ export const blocksRouter = router({
       }
       // Context binding. MODEL token → body.modelId must match ctx.modelId.
       // PAGE token (ctx.entityType==='none') → no model binding; skip the match
-      // and enforce the canonical generation-entitlement gate after the version
-      // read instead (see estimateWorkflow for the same branch). The buzzBudget
-      // claim + per-user daily cap still bound spend identically for pages.
+      // and enforce the pre-spend availability/coverage gate after the version
+      // read instead (see estimateWorkflow for the same branch; early-access +
+      // Private-sub entitlement is left to the orchestrator resource belt). The
+      // buzzBudget claim + per-user daily cap still bound spend identically for
+      // pages.
       const isPage = isPageToken(claims);
       if (!isPage) {
         const ctxModelId = Number(
@@ -1551,9 +1568,10 @@ export const blocksRouter = router({
         input.body.modelId
       );
       const user = await getBlockSessionUser(userId);
-      // PAGE branch: the REAL viewer must be entitled to generate against the
-      // model they picked (replaces the skipped model-binding check) — fail
-      // closed BEFORE any reservation or orchestrator interaction.
+      // PAGE branch: pre-spend availability/coverage gate on the model the REAL
+      // viewer picked (replaces the skipped model-binding check) — fail closed
+      // BEFORE any reservation. Early-access + Private-sub entitlement is
+      // enforced downstream by the orchestrator resource belt (whatIf + real).
       if (isPage) {
         await assertViewerCanGeneratePageModel({
           gate: buildGateVersion(resolved.gate),

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -405,6 +405,8 @@ describe('BlockManifestValidator', () => {
       [-5, 'negative'],
       [12.5, 'non-integer'],
       ['200' as unknown as number, 'string'],
+      [Infinity, 'Infinity'],
+      [Number.NaN, 'NaN'],
     ])('rejects a %s buzzBudgetPerGen (%s)', (value) => {
       const manifest = {
         ...VALID_MANIFEST,

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -385,5 +385,47 @@ describe('BlockManifestValidator', () => {
         expect(result.errors.some((e) => e.includes('must also declare an iframe'))).toBe(true);
       }
     });
+
+    // W10 generation spend — optional page.buzzBudgetPerGen.
+    it('accepts a page declaring a positive integer buzzBudgetPerGen', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        page: { path: '/', title: 'X', buzzBudgetPerGen: 200 },
+      };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('accepts a page that omits buzzBudgetPerGen (optional → platform default)', () => {
+      const manifest = { ...VALID_MANIFEST, page: { path: '/', title: 'X' } };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it.each([
+      [0, 'zero'],
+      [-5, 'negative'],
+      [12.5, 'non-integer'],
+      ['200' as unknown as number, 'string'],
+    ])('rejects a %s buzzBudgetPerGen (%s)', (value) => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        page: { path: '/', title: 'X', buzzBudgetPerGen: value },
+      };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('buzzBudgetPerGen'))).toBe(true);
+      }
+    });
+
+    // A value above the per-gen cap is NOT rejected at validation time — the
+    // mint handler clamps it to BUZZ_BUDGET_CAP. The validator only enforces
+    // shape (positive integer).
+    it('accepts an above-cap buzzBudgetPerGen (clamped at mint, not rejected here)', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        page: { path: '/', title: 'X', buzzBudgetPerGen: 5000 },
+      };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
   });
 });

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -36,7 +36,11 @@ interface RawManifest {
   /**
    * W10 — optional full-page surface descriptor. When present, the app can be
    * opened as a standalone full page at `/apps/run/<slug>`. `path` is the
-   * sub-path the page mounts at (must start with `/`).
+   * sub-path the page mounts at (must start with `/`). `buzzBudgetPerGen` is the
+   * optional per-generation Buzz budget the page's `ai:write:budgeted` tokens are
+   * minted with (a page is stateless, so unlike a model slot the budget cannot
+   * come from an install settings row — it comes from this manifest field,
+   * server-clamped to the per-gen cap; omitted ⇒ the platform default).
    */
   page?: unknown;
   [key: string]: unknown;
@@ -464,7 +468,12 @@ export class BlockManifestValidator {
       if (!m.page || typeof m.page !== 'object' || Array.isArray(m.page)) {
         errors.push('page must be an object');
       } else {
-        const page = m.page as { path?: unknown; title?: unknown; icon?: unknown };
+        const page = m.page as {
+          path?: unknown;
+          title?: unknown;
+          icon?: unknown;
+          buzzBudgetPerGen?: unknown;
+        };
         if (typeof page.path !== 'string' || page.path.length === 0) {
           errors.push('page.path must be a non-empty string');
         } else if (!page.path.startsWith('/')) {
@@ -479,6 +488,17 @@ export class BlockManifestValidator {
         }
         if (page.icon !== undefined && (typeof page.icon !== 'string' || page.icon.length > 128)) {
           errors.push('page.icon must be a string ≤128 chars');
+        }
+        // W10 generation spend — optional per-gen Buzz budget for the page's
+        // `ai:write:budgeted` tokens. Must be a positive, finite integer when
+        // present (the mint handler clamps it to BUZZ_BUDGET_CAP, so an over-cap
+        // value isn't rejected here — it's silently capped at issuance — but a
+        // non-positive / non-integer / non-finite value is a manifest bug).
+        if (page.buzzBudgetPerGen !== undefined) {
+          const b = page.buzzBudgetPerGen;
+          if (typeof b !== 'number' || !Number.isFinite(b) || !Number.isInteger(b) || b <= 0) {
+            errors.push('page.buzzBudgetPerGen must be a positive integer');
+          }
         }
         // A page app must ship an iframe block (the bundle the full page mounts).
         if (!m.iframe || typeof m.iframe !== 'object') {

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -77,7 +77,17 @@ export async function resolveBlockVersionContext(modelVersionId: number, expecte
       baseModel: true,
       modelId: true,
       status: true,
-      model: { select: { id: true, type: true } },
+      // W10 generation spend: the extra fields below feed
+      // `resolveCanGenerateForVersions` so the PAGE branch in blocks.router can
+      // gate a viewer-picked model through the platform's canonical generation-
+      // entitlement check (early-access / availability / coverage / members-
+      // only). They are additive — the MODEL slot path never reads `gate`, so
+      // its behaviour is byte-identical to before this select grew.
+      availability: true,
+      usageControl: true,
+      meta: true,
+      generationCoverage: { select: { covered: true } },
+      model: { select: { id: true, type: true, userId: true } },
     },
   });
   if (!version || version.status !== 'Published') {
@@ -98,6 +108,22 @@ export async function resolveBlockVersionContext(modelVersionId: number, expecte
     modelVersionId: version.id,
     baseModel: version.baseModel,
     modelType: version.model.type,
+    // The fields `resolveCanGenerateForVersions` needs, shaped as
+    // `ResolveCanGenerateVersion` so the page branch can pass it straight
+    // through. `modelVersionAlias` is read from the version meta exactly as the
+    // standard generation read paths (model-version.controller) do.
+    gate: {
+      id: version.id,
+      status: version.status,
+      availability: version.availability,
+      usageControl: version.usageControl,
+      baseModel: version.baseModel,
+      covered: version.generationCoverage?.covered ?? false,
+      modelUserId: version.model.userId,
+      modelType: version.model.type,
+      modelVersionAlias:
+        (version.meta as { generationAlias?: unknown } | null)?.generationAlias ?? null,
+    },
   };
 }
 

--- a/src/shared/constants/__tests__/slot-registry.test.ts
+++ b/src/shared/constants/__tests__/slot-registry.test.ts
@@ -64,10 +64,16 @@ describe('slot-registry (Phase 0 foundation)', () => {
     );
   });
 
-  it('PAGE_FORBIDDEN_SCOPES covers every money/spend scope', () => {
-    expect([...PAGE_FORBIDDEN_SCOPES].sort()).toEqual(
-      ['ai:write:budgeted', 'buzz:read:self', 'social:tip:self'].sort()
-    );
+  // W10 generation spend: `ai:write:budgeted` is NO LONGER page-forbidden —
+  // pages can spend Buzz on generation, bounded by the manifest per-gen budget
+  // (page.buzzBudgetPerGen) + the per-user daily cap. Tipping + balance-read
+  // stay forbidden (see the doc comment on PAGE_FORBIDDEN_SCOPES for why).
+  it('PAGE_FORBIDDEN_SCOPES forbids only tipping + balance-read (NOT budgeted gen)', () => {
+    expect([...PAGE_FORBIDDEN_SCOPES].sort()).toEqual(['buzz:read:self', 'social:tip:self'].sort());
+  });
+
+  it('ai:write:budgeted is NOT forbidden for pages (generation spend allowed)', () => {
+    expect((PAGE_FORBIDDEN_SCOPES as readonly string[]).includes('ai:write:budgeted')).toBe(false);
   });
 
   // Only `none` and `model` entities are wired in this build. user/image are

--- a/src/shared/constants/slot-registry.ts
+++ b/src/shared/constants/slot-registry.ts
@@ -155,16 +155,28 @@ export function isKnownSlotId(id: string): id is SlotId {
 
 /**
  * Money/spend scopes a `page` (viewer-scoped, entity=none) token must NEVER
- * carry. A page has no model entity and no per-content install to attribute
- * spend against, so granting these would be unbounded. This is the belt over
- * the manifest + approved-scope intersection: even if an app's approved
- * manifest declared them, a `kind==='page'` mint rejects them.
+ * carry. This is the belt over the manifest + approved-scope intersection: even
+ * if an app's approved manifest declared one of these, a `kind==='page'` mint
+ * rejects it.
+ *
+ * W10 generation spend: `ai:write:budgeted` is NO LONGER forbidden for pages.
+ * A page is stateless (no install settings row), so its per-generation budget
+ * comes from the approved manifest's `page.buzzBudgetPerGen` field — server-read,
+ * clamped to BUZZ_BUDGET_CAP, defaulted to BUZZ_BUDGET_DEFAULT when the manifest
+ * omits it (see resolveBuzzBudget in the mint handler). Page generation spend is
+ * therefore bounded by exactly the same two limits a model slot is: the per-gen
+ * `buzzBudget` claim AND the per-user daily cap (BLOCK_BUZZ_CAP_PER_DAY in
+ * blocks.router.ts) — neither is bypassed for pages.
+ *
+ * The two scopes below STAY forbidden for pages:
+ *   - `social:tip:self` — tipping is NOT gated by the buzzBudget cost-preflight,
+ *     so the manifest budget cap does not bound it. On a stateless page (no
+ *     per-content owner to attribute against, no per-gen cost ceiling) a tip
+ *     scope would be effectively unbounded spend, so it remains rejected.
+ *   - `buzz:read:self` — balance read isn't needed to spend a bounded budget,
+ *     and a page (entity=none) has no reason to read the viewer's balance.
  */
-export const PAGE_FORBIDDEN_SCOPES = [
-  'ai:write:budgeted',
-  'buzz:read:self',
-  'social:tip:self',
-] as const;
+export const PAGE_FORBIDDEN_SCOPES = ['buzz:read:self', 'social:tip:self'] as const;
 
 /** Does the slot render a full standalone page (W10)? */
 export function isPageSlot(id: string): boolean {

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -430,6 +430,113 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
       const signArg = mockTokenService.sign.mock.calls[0][0];
       expect(signArg.buzzBudget).toBe(10);
     });
+
+    // ── Audit should-fix: integer enforcement in resolveBuzzBudget ──────────
+    // A fractional manifest budget reaches the mint as a finite number (the
+    // pageSettings mapper only filters non-finite/non-number), so the integer
+    // guard in resolveBuzzBudget is what stops a fractional Buzz budget. It
+    // must DEFAULT (10), not pass 12.5 through.
+    it('a fractional manifest budget (12.5) → integer default (10), never a fractional budget', async () => {
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(12.5));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.buzzBudget).toBe(10);
+      expect(Number.isInteger(signArg.buzzBudget)).toBe(true);
+    });
+
+    it('an Infinity manifest budget → default (10), not an unbounded budget', async () => {
+      // Infinity is filtered by the pageSettings mapper (Number.isFinite false)
+      // → empty settings → resolveBuzzBudget default. Belt: even if it reached
+      // resolveBuzzBudget, Number.isInteger(Infinity) is false → default.
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(Infinity));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.buzzBudget).toBe(10);
+    });
+
+    it('a negative INTEGER manifest budget (-50) reaching the mint → 422 (fail-closed, no silent default)', async () => {
+      // A negative integer is a finite number → mapped into settings → reaches
+      // resolveBuzzBudget as an integer → candidate <= 0 → 0 sentinel → 422.
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(-50));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(422);
+      expect(res._body.error).toBe('INVALID_BUZZ_BUDGET');
+      expect(mockTokenService.sign).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Audit: a MIXED manifest with one still-forbidden money scope is a HARD
+  // reject of the WHOLE request — the allowed ai:write:budgeted does not
+  // "rescue" the request when social:tip:self rides alongside it. ───────────
+  it('MIXED manifest [ai:write:budgeted, social:tip:self] → 403, whole request rejected', async () => {
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['ai:write:budgeted', 'social:tip:self'],
+      revokedAt: null,
+    });
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue({
+      appBlock: {
+        id: 'apb_page',
+        blockId: 'hello-page',
+        appId: 'appblk-hello-page',
+        status: 'approved',
+        manifest: {
+          scopes: ['ai:write:budgeted', 'social:tip:self'],
+          page: { path: '/', title: 'Hello' },
+        },
+        approvedScopes: ['ai:write:budgeted', 'social:tip:self'],
+        // Allow both bits so the OAuth/approved gates pass and the PAGE HARD
+        // RULE is what rejects (social:tip:self stays page-forbidden).
+        app: { allowedScopes: MONEY_BITS },
+      },
+    });
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(403);
+    // No partial mint — the whole request is rejected, no token signed.
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  // ── MODEL_INSTALL positive regression: the path the integer-enforcement fix
+  // most needs to leave untouched. A valid integer install budget mints
+  // verbatim (clamped only by the cap). ────────────────────────────────────
+  it('MODEL path regression: settings.buzz_budget_per_gen=200 + ai:write:budgeted → buzzBudget===200', async () => {
+    mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+      ...MODEL_INSTALL,
+      settings: { buzz_budget_per_gen: 200 },
+      appBlock: {
+        ...MODEL_INSTALL.appBlock,
+        manifest: { scopes: ['ai:write:budgeted'] },
+        approvedScopes: ['ai:write:budgeted'],
+        app: { allowedScopes: 1 << 15 /* AIServicesWrite */ },
+      },
+    });
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['ai:write:budgeted'],
+      revokedAt: null,
+    });
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: modelBody() }), res);
+
+    expect(res._status).toBe(200);
+    expect(mockBlockRegistry.resolvePageBlock).not.toHaveBeenCalled();
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    expect(signArg.buzzBudget).toBe(200);
+    // Model ctx stays byte-identical: { modelId, slotId }, no entityType.
+    expect(signArg.ctx).toEqual({ modelId: 12345, slotId: 'model.sidebar_top' });
   });
 
   it('BYTE-IDENTICAL model path: ctx is exactly { modelId, slotId } (no entityType) for generate-from-model', async () => {

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -162,6 +162,32 @@ const PAGE_BLOCK = (
   },
 });
 
+// OAuth bit that allows ai:write:budgeted (AIServicesWrite = 1<<15).
+const AI_WRITE_BIT = 1 << 15;
+
+// An approved page app that declares the W10 generation-spend scope plus an
+// (optional) manifest per-gen budget. The OAuth client allows ai:write:budgeted
+// and the scope is in the approved set, so the budget path — not an allowlist
+// gate — governs the outcome.
+const PAGE_BUDGET_BLOCK = (manifestBudget?: number) => ({
+  appBlock: {
+    id: 'apb_page',
+    blockId: 'hello-page',
+    appId: 'appblk-hello-page',
+    status: 'approved',
+    manifest: {
+      scopes: ['ai:write:budgeted'],
+      page: {
+        path: '/',
+        title: 'Hello',
+        ...(manifestBudget !== undefined ? { buzzBudgetPerGen: manifestBudget } : {}),
+      },
+    },
+    approvedScopes: ['ai:write:budgeted'],
+    app: { allowedScopes: AI_WRITE_BIT },
+  },
+});
+
 const pageBody = (overrides: Record<string, unknown> = {}) => ({
   blockInstanceId: 'page_apb_page',
   slotContext: { entityType: 'none', slotId: 'app.page', ...overrides },
@@ -234,14 +260,15 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(signArg.scopes).toEqual(['apps:storage:read', 'apps:storage:write']);
   });
 
-  it('rejects a page manifest that declares a money scope (page hard rule)', async () => {
+  it('rejects a page manifest that declares a still-forbidden money scope (page hard rule)', async () => {
     // The OAuth client ALLOWS the money scope + it's in the approved set — so
     // the earlier OAuth/approved gates pass and the PAGE HARD RULE is what
     // rejects (proves the page-specific gate, not the generic allowlist).
+    // social:tip:self is NOT un-forbidden by W10 (only ai:write:budgeted is).
     mockBlockRegistry.resolvePageBlock.mockResolvedValue(
       PAGE_BLOCK(
-        ['apps:storage:read', 'ai:write:budgeted'],
-        ['apps:storage:read', 'ai:write:budgeted'],
+        ['apps:storage:read', 'social:tip:self'],
+        ['apps:storage:read', 'social:tip:self'],
         MONEY_BITS
       )
     );
@@ -254,7 +281,10 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
-  it.each([['buzz:read:self'], ['social:tip:self'], ['ai:write:budgeted']])(
+  // W10: ai:write:budgeted is INTENTIONALLY absent here — it is now allowed for
+  // pages (covered by the budget tests below). Only tipping + balance-read stay
+  // page-forbidden.
+  it.each([['buzz:read:self'], ['social:tip:self']])(
     'rejects forbidden page scope %s',
     async (scope) => {
       mockBlockRegistry.resolvePageBlock.mockResolvedValue(
@@ -318,6 +348,88 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     );
     expect(res._status).toBe(400);
     expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  // ───────────────────────── W10 generation spend ──────────────────────────
+  // A page can now mint an `ai:write:budgeted` token. The per-gen budget is
+  // sourced from the approved manifest's `page.buzzBudgetPerGen`, clamped to
+  // BUZZ_BUDGET_CAP (1000), defaulted to BUZZ_BUDGET_DEFAULT (10) when absent.
+  // (The user must have GRANTED ai:write:budgeted — consent — for it to be
+  // signed; we mock that grant in each case.)
+  describe('W10 generation-spend budget (ai:write:budgeted)', () => {
+    beforeEach(() => {
+      mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+        grantedScopes: ['ai:write:budgeted'],
+        revokedAt: null,
+      });
+    });
+
+    it('mints with buzzBudget === manifest page.buzzBudgetPerGen', async () => {
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(200));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.scopes).toEqual(['ai:write:budgeted']);
+      expect(signArg.buzzBudget).toBe(200);
+      // ctx is still the bare page ctx — no modelId.
+      expect(signArg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
+    });
+
+    it('clamps a manifest budget above the cap to BUZZ_BUDGET_CAP (1000)', async () => {
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(5000));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.buzzBudget).toBe(1000);
+    });
+
+    it('falls back to BUZZ_BUDGET_DEFAULT (10) when the manifest omits a budget', async () => {
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(undefined));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.buzzBudget).toBe(10);
+    });
+
+    it('422 INVALID_BUZZ_BUDGET when the manifest declares a <= 0 budget (fail-closed, no silent default)', async () => {
+      // An explicit non-positive manifest budget is a HARD ERROR — the mint
+      // does NOT silently coerce it to the default. (Belt-and-suspenders: the
+      // manifest validator also rejects a <=0 page.buzzBudgetPerGen at publish
+      // time — unit-covered in the validator test — so this should be
+      // unreachable in practice, but the mint stays fail-closed regardless.)
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(0));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(422);
+      expect(res._body.error).toBe('INVALID_BUZZ_BUDGET');
+      expect(mockTokenService.sign).not.toHaveBeenCalled();
+    });
+
+    it('clamps to default when the manifest budget is a non-number (no 422)', async () => {
+      // A non-number page.buzzBudgetPerGen (validator should have rejected it,
+      // but be defensive) → settings stay empty → DEFAULT budget, not 422.
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+        PAGE_BUDGET_BLOCK('200' as unknown as number)
+      );
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.buzzBudget).toBe(10);
+    });
   });
 
   it('BYTE-IDENTICAL model path: ctx is exactly { modelId, slotId } (no entityType) for generate-from-model', async () => {

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -462,6 +462,25 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
       expect(signArg.buzzBudget).toBe(10);
     });
 
+    it('a NaN manifest budget → default (10), not a poisoned budget', async () => {
+      // NaN is a `number` but Number.isFinite(NaN) is false → filtered by the
+      // pageSettings mapper → empty settings → resolveBuzzBudget default. Belt:
+      // even if it reached resolveBuzzBudget, Number.isInteger(NaN) is false →
+      // default. Locks the third leg of the Number.isInteger guard (fractional /
+      // Infinity / NaN) — without it a NaN budget could short-circuit the
+      // downstream `buzzBudget <= 0` comparisons (NaN comparisons are always
+      // false) and slip a non-numeric budget into the signed token.
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(NaN));
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.buzzBudget).toBe(10);
+      expect(Number.isInteger(signArg.buzzBudget)).toBe(true);
+    });
+
     it('a negative INTEGER manifest budget (-50) reaching the mint → 422 (fail-closed, no silent default)', async () => {
       // A negative integer is a finite number → mapped into settings → reaches
       // resolveBuzzBudget as an integer → candidate <= 0 → 0 sentinel → 422.
@@ -537,6 +556,64 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(signArg.buzzBudget).toBe(200);
     // Model ctx stays byte-identical: { modelId, slotId }, no entityType.
     expect(signArg.ctx).toEqual({ modelId: 12345, slotId: 'model.sidebar_top' });
+  });
+
+  // ── Audit 🟡#2 — REGRESSION LOCK: the Number.isInteger guard now also affects
+  // the MODEL-slot path (both paths share resolveBuzzBudget). A FRACTIONAL
+  // install budget that PRE-PR would have flowed through verbatim (12.5) now
+  // falls back to the DEFAULT (10). This is the intended post-PR behavior — a
+  // model slot can never carry a fractional Buzz budget either. Documented here
+  // so a future change can't silently re-loosen the integer guard for models.
+  it('MODEL path regression: a FRACTIONAL install budget (12.5) → DEFAULT 10 (post-PR integer behavior)', async () => {
+    mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+      ...MODEL_INSTALL,
+      settings: { buzz_budget_per_gen: 12.5 },
+      appBlock: {
+        ...MODEL_INSTALL.appBlock,
+        manifest: { scopes: ['ai:write:budgeted'] },
+        approvedScopes: ['ai:write:budgeted'],
+        app: { allowedScopes: 1 << 15 /* AIServicesWrite */ },
+      },
+    });
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['ai:write:budgeted'],
+      revokedAt: null,
+    });
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: modelBody() }), res);
+
+    expect(res._status).toBe(200);
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    expect(signArg.buzzBudget).toBe(10);
+    expect(Number.isInteger(signArg.buzzBudget)).toBe(true);
+  });
+
+  // ── Anon page mint: when the pages flag is widened to the public (anon passes
+  // both gates), the consent-gated `ai:write:budgeted` scope is STRIPPED from
+  // the anon token — an anon viewer can never mint a spend-capable page token.
+  // Mirrors the model-path anon-strip in index.test.ts. (Today the flag is
+  // mod-only so anon is 403'd at the gate — this proves the strip is the belt
+  // that keeps anon safe IF the flag is ever widened.)
+  it('anon page mint (flag public): ai:write:budgeted is STRIPPED, not signed', async () => {
+    (mockFlags.getFeatureFlags as any).mockImplementation(() => ({
+      appBlocks: true,
+      appBlocksPages: true,
+    }));
+    mockSession.value = null; // anonymous — no grant ledger
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_BUDGET_BLOCK(200));
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+    expect(res._status).toBe(200);
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    // SECURITY INVARIANT: no money scope in an anon token. ai:write:budgeted is
+    // consent-gated, so it is withheld for anon → the anon page token carries
+    // NO spend scope and NO buzzBudget.
+    expect(signArg.scopes).not.toContain('ai:write:budgeted');
+    expect(signArg.buzzBudget).toBeUndefined();
+    expect(signArg.userId).toBeNull();
   });
 
   it('BYTE-IDENTICAL model path: ctx is exactly { modelId, slotId } (no entityType) for generate-from-model', async () => {


### PR DESCRIPTION
## What / why

Enable **W10 full-page App Blocks** (the `app.page` slot, `entity='none'`) to spend Buzz on generation **end-to-end** — mint **and** runtime. A page can mint an `ai:write:budgeted` token (un-forbidden at the mint layer) **and** that token now actually reaches the generation spend path.

Stays **dark + mod-gated** — **no** feature-flag / Flipt changes. Pages remain gated behind the `appBlocksPages` flag at mint and `assertViewerIsModerator` at runtime.

A page is **stateless** (no install settings row), so unlike a model slot its per-gen budget comes from the approved **manifest** field `page.buzzBudgetPerGen`: server-read, clamped to `BUZZ_BUDGET_CAP` (1000), defaulted to `BUZZ_BUDGET_DEFAULT` (10) when omitted, `422 INVALID_BUZZ_BUDGET` when non-positive (fail-closed). The mint maps it onto the same `buzz_budget_per_gen` settings key the model path uses, so `resolveBuzzBudget` + the existing budget/422 logic apply to pages unchanged.

Page generation spend stays bounded by the **same two limits a model slot is**: the per-gen `buzzBudget` claim **and** the per-user daily cap `BLOCK_BUZZ_CAP_PER_DAY` (per-user keyed). Neither is bypassed for pages.

## Trust model — "any public generatable model" (locked)

A model slot binds the generator to ONE model via `ctx.modelId === body.modelId`. A page has no model binding: the viewer picks **any model they're normally entitled to generate against**, bounded by the `buzzBudget` per-gen + the per-user daily cap. That model-binding control is **replaced** (not dropped) for pages by the platform's canonical generation-entitlement gate:

- For a page token (`ctx.entityType === 'none'`), `estimateWorkflow` / `submitWorkflow` **skip** the modelId match and instead call **`resolveCanGenerateForVersions`** against the **REAL viewer** (their id + real `isModerator` + the request's `sfwOnly`/`wildcards` flags — never an elevated/hardcoded context). `canGenerate=false` → `FORBIDDEN`; a version missing from the result Map → fail-closed `FORBIDDEN`, **before** any reservation or orchestrator call.
- This is the security replacement for model-binding: without it, "any public model" would bypass early-access / availability=Private / members-only `usageControl` / `generationCoverage` gates. Today the viewer is always a mod (`assertViewerIsModerator`), so they see mod-level access (correct platform behaviour); when GA opens to non-mods the same gate bounds them.

## Locked decisions

- **Only `ai:write:budgeted` is un-forbidden** for pages. `buzz:read:self` and `social:tip:self` **stay page-forbidden** (tipping isn't bounded by the budget cost-preflight; balance-read isn't needed to spend a bounded budget).
- **Attribution deferred.** `block_buzz_attribution` / rate-card / the attribution scope enum are untouched. Spend records only a `recordScopeInvocation` activity row. **No DB migration.**

## Changes

**Mint half (already on the branch):**
- `slot-registry.ts` — drop `ai:write:budgeted` from `PAGE_FORBIDDEN_SCOPES`.
- `block-tokens/index.ts` (page path) — populate `settings.buzz_budget_per_gen` from `manifest.page.buzzBudgetPerGen`.
- `block-manifest-validator.service.ts` — validate optional `page.buzzBudgetPerGen` (positive integer; above-cap clamped at mint).

**Runtime branch (Part A — new):**
- `blocks.router.ts` — `isPageToken` discriminator; for page tokens, skip the model-binding check and run `assertViewerCanGeneratePageModel` (the entitlement gate) against the real viewer; everything else (budget ceiling, daily-cap reserve/refund, prompt audit, activity log) is shared + unchanged. `resolveCanGenerateForVersions` is dynamic-imported so the heavy generation-service graph stays out of the router's static graph (mirrors the existing lazy `recordScopeInvocation` import).
- `blocks/workflow.service.ts` — `resolveBlockVersionContext` now also returns a `gate` bag (availability / usageControl / coverage / modelUserId / modelType / generationAlias) for the entitlement gate. Additive; the model path never reads it, so model-slot behaviour is byte-identical.
- **Checkpoint resolution is page-safe as-is** — Checkpoint-self short-circuits (no install lookup); non-Checkpoint falls through the null `page_` install to the popular-checkpoint fallback (a `page_` instanceId is an unknown prefix → `resolveBlockInstance` returns null, never throws). No page-specific checkpoint branch was needed.

**Audit fix (Part B — new):**
- `block-tokens/index.ts` `resolveBuzzBudget` — require `Number.isInteger`, not merely finite (defense-in-depth: a fractional/Infinity/NaN budget falls back to DEFAULT; a non-positive integer still 422s). Model-slot valid-integer behaviour unchanged.

## Tests (all passing)

- **blocks.router.workflow** (54, +10): page token + generatable model → reaches whatif with the real viewer ctx; page + ungeneratable (`canGenerate=false`) and fail-closed (version missing from Map) → `FORBIDDEN` with no spend/reservation; page over-budget → failed-shape snapshot; page respects the per-USER daily cap; regression — a model token still enforces model binding and never runs the page gate.
- **page-mint** (19, +5): fractional 12.5 → integer DEFAULT; Infinity → DEFAULT; negative integer -50 → 422; MIXED `[ai:write:budgeted, social:tip:self]` → 403 (whole request); MODEL_INSTALL `buzz_budget_per_gen=200` → `buzzBudget===200`.
- **slot-registry** (10) + **manifest-validator** (48) + **block-tokens/index** (26 model-mint regression) + **checkpoint.service** (20) all green. 177/177 across the relevant suites.

**Typecheck:** `tsc` is not cleanly runnable on this NixOS host (Prisma engines unavailable offline → stale/ungenerated client floods `tsc` with pre-existing codebase-wide errors). Confirmed: **zero `tsc` errors reference `workflow.service.ts`, `block-tokens/index.ts`, or either test file**, and **no error in `blocks.router.ts` references any new symbol/logic** (the only `blocks.router.ts` errors are the pre-existing "Property does not exist on PrismaClient" App-Blocks-table flood at untouched lines).

Do **not** merge until product signs off on the launch sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
