### PR TITLE
perf(redis): trim image-meta SWR tail to bound next-redis-cluster memory

### DIFF
--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1127,10 +1127,21 @@ export const imageMetaCache = createCachedObject<ImageWithMeta>({
     `;
     return Object.fromEntries(images.map((x) => [x.id, x]));
   },
-  // 4h TTL to bound Redis memory — image-meta is ~2.8KB/key (~2.3 GiB / ~1% of
-  // the cluster per the 2026-06-09 keyspace audit; the tag caches are the heavy
-  // consumers, not this one). With stale-while-revalidate, effective Redis EX = 8h.
+  // 4h logical TTL. image-meta is ~2.8KB/key; on next-redis-cluster the cache
+  // sits behind tag-ids-for-images (~16.85 GiB/shard) and post-stats (~8.2 GiB)
+  // as a top-3 consumer of an at-cap LRU cluster (3×32 GiB maxmemory, evicting
+  // ~250 keys/s/shard, ~100% used for hours — verified live 2026-06-17). The
+  // default SWR tail keeps every key resident for a full extra `ttl` past
+  // staleness (physical EX 8h). Trim it to 1h (physical EX 5h) to cut the
+  // resident set the cache wants to hold, matching tagIdsForImagesCache /
+  // postStatCache. Trade-off: a key re-read only in the 4h–5h-old band (vs
+  // 4h–8h before) is now a blocking cold-miss (the lock-winner re-queries
+  // Prisma inline on dbRead) instead of a stale-serve — but at cap those tail
+  // keys are exactly what LRU evicts first anyway, so steadily-read images are
+  // unaffected. Do NOT shorten the logical 4h ttl: that would convert the hot
+  // working set into misses and stampede dbRead.
   ttl: CacheTTL.hour * 4,
+  staleWhileRevalidateTtl: CacheTTL.hour,
 });
 
 type ImageWithMetadata = {
@@ -1152,8 +1163,11 @@ export const imageMetadataCache = createCachedObject<ImageWithMetadata>({
     `;
     return Object.fromEntries(images.map((x) => [x.id, x]));
   },
-  // 4h TTL — same rationale as imageMetaCache.
+  // 4h logical TTL + 1h SWR tail (physical EX 5h) — same rationale as
+  // imageMetaCache: bound the resident set on the at-cap next-redis-cluster
+  // without shortening the freshness window.
   ttl: CacheTTL.hour * 4,
+  staleWhileRevalidateTtl: CacheTTL.hour,
 });
 
 export const thumbnailCache = createCachedObject<{


### PR DESCRIPTION
## Problem

`next-redis-cluster` (3-leader/3-follower sharded, **32 GiB maxmemory/shard**, 48Gi container limit) has been **pinned at ~100% used on every shard for hours, evicting ~250 keys/s/shard** (cluster-wide ~600/s) — verified live 2026-06-17 (each shard ~26M keys, RSS ~33.7 GiB). A chronically-full cluster causes intermittent command stalls → 500s + latency on `civitai-dp-prod`.

The growth driver is the **unbounded resident lifetime of the image-meta caches**. `createCachedObject`'s default stale-while-revalidate behavior keeps every key resident for a *full extra `ttl`* past logical staleness — i.e. **physical Redis `EX = 2 × ttl`**. For `imageMetaCache` (4h logical TTL) that's an **8h physical EX**. The extra 4h "stale tail" is pure resident-memory cost: a background revalidate completes sub-second, so a 4h stale window isn't needed.

## The cache (file:line) + change

- `imageMetaCache` — `src/server/redis/caches.ts:1116` (key `packed:caches:image-meta`)
- `imageMetadataCache` — `src/server/redis/caches.ts:1141` (key `packed:caches:image-metadata`)

Read by `getMetaForImages` / `getMetadataForImages` (`src/server/services/image.service.ts:2041`), `api/v1/images` (`src/pages/api/v1/images/index.ts:275`); written/refreshed on image + post mutations.

**Change:** add `staleWhileRevalidateTtl: CacheTTL.hour` to both.

| | logical TTL (freshness) | physical Redis EX (resident) |
|---|---|---|
| before | 4h | **8h** (`ttl × 2`) |
| after | 4h (unchanged) | **5h** (`ttl + 1h`) |

The **logical 4h freshness window is unchanged** — the data cached, key shape, and revalidation cadence are identical. Only the resident lifetime of stale-but-not-yet-revalidated keys shrinks. This mirrors the **already-merged** trims on the two larger consumers in the same file: `tagIdsForImagesCache` (`:51`, ~16.85 GiB/shard) and `postStatCache` (`:1269`, ~8.2 GiB) both use `staleWhileRevalidateTtl: CacheTTL.hour`.

### Why this value (not a shorter logical TTL)

Bounding growth must not trigger a cache-miss → DB-load stampede. The safe lever here is the **stale tail**, not the freshness window:
- Shortening the **logical 4h `ttl`** would convert the *hot working set* into misses and stampede `dbRead` — explicitly avoided.
- Shortening the **physical tail** only affects keys re-read in the narrow **4h–5h-old band** (vs 4h–8h before). On an at-cap `allkeys-lru` cluster those tail keys are exactly the ones LRU evicts first anyway, so steadily-read images already revalidate at the 4h logical boundary and are unaffected.

## DB-load trade-off

A trimmed tail means a key re-read in the 4h–5h-old band is now a **blocking cold-miss** (the `setNxKeepTtl` lock-winner re-queries Prisma inline on `dbRead`, others stale-serve until it lands) instead of a stale-serve. Impact is **bounded to the sparsely-accessed tail**: the lookup is a simple PK `WHERE id IN (...)` on `Image`, single-flighted by the per-id cache lock, and keys with any steady read traffic never reach the tail. Net new DB reads ≈ the count of images first re-touched in that 1-hour-wide band — a small fraction of total reads (cluster keyspace hit ratio is ~87%, and the cluster is already evicting these tail keys, so many of these "new misses" exist today as evictions). No stampede risk: the freshness window and lock-based single-flight are preserved.

## Right-size assessment (recommendation only — not implemented here)

Infra: `clusters/production/apps/next-redis-cluster/redis-cluster.yaml` (datapacket-talos).

**Recommendation: do NOT raise `maxmemory` or the container limit. Keep the TTL/SWR bound (this PR) as the safe lever; right-sizing is gated by node memory, not by the dedicated redis node.**

Numbers:
- **maxmemory 32G is already a deliberate floor on COW headroom.** It was lowered 36G→32G on 2026-06-09 precisely because 36G left only ~12Gi fork/copy-on-write headroom under the 48Gi limit and caused OOMKills during replica resync. 32G (~67% of 48Gi) restores ~16Gi headroom. Raising maxmemory toward the 48Gi limit without raising the limit re-opens that OOM-during-resync failure mode. Live RSS is ~33.7 GiB/master at 32G — the ~14Gi gap to 48Gi is the COW reservation, not free space.
- **Raising the per-pod limit is gated by the 125 GiB nodes, not the 256 GiB one.** The premise that `talos-fug-1v0` has 256GiB only helps the 2 pods on it. The 6 hostpath-pinned pods actually spread across 4 nodes: `talos-fug-1v0` (256GiB, 2 pods) but also `talos-2t6-lkz` (**125GiB, 2 pods** = follower-2 master + leader-0 replica), `talos-48r-b3a` (125GiB), `talos-wjh-tgy` (125GiB). On `talos-2t6-lkz`, 2 redis pods at the current 48Gi limit = 96Gi on a 125GiB node already shared with other workloads (185Gi committed limits). Bumping the limit to e.g. 56Gi → 112Gi of redis alone there — unsafe. A limit raise would require first relocating the second pod off the 125GiB node (hostpath PVC pinning makes that a migration, not a reschedule).
- **Therefore the only safe capacity lever short of new nodes is horizontal:** add a 4th shard (re-shard) so each shard holds less, OR re-home all masters onto larger-RAM nodes and then raise limit+maxmemory together (limit ~64Gi / maxmemory ~44Gi keeps the ~⅔ ratio and ~20Gi COW). Both are prod-infra decisions out of scope for this PR.

Verified live (2026-06-17): all 3 shards ~100% of 32G maxmemory, ~26M keys/shard, evicting ~250/s/shard, masters RSS ~33.7 GiB, `activedefrag` already on (frag overhead now ~1.7Gi vs the prior ~9Gi).

## Post-deploy verification

After this rolls out to `civitai-dp-prod`, on `next-redis-cluster`:
- `redis_memory_used_bytes` / `redis_db_keys` per shard should **plateau and drift below the 32G cap** (the image-meta resident set shrinks by up to its tail fraction as 5h-EX keys expire vs 8h before).
- `rate(redis_evicted_keys_total[5m])` per shard should **drop** as LRU pressure eases.
- Cache-miss counters for `image-meta` / `image-metadata` (`cacheMissCounter{cache_name=...}`) should rise only modestly (the 4h–5h tail band); `dbRead` load should show no stampede.
- No change to image-meta correctness (same data, same 4h freshness).

## Test / typecheck status

Worktree has no `node_modules` (sibling worktree off `origin/main`) — not typechecked locally. The change adds only `staleWhileRevalidateTtl: CacheTTL.hour` to two `createCachedObject({...})` calls, identical in field/value/shape to two already-merged usages in the same file (`tagIdsForImagesCache:51`, `postStatCache:1269`), so types and behavior are consistent. No logic, key shape, or cached-data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
