### PR TITLE
fix(app-blocks): wire lazy-consent REQUEST_CONSENT handler into the W10 page host

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -1,0 +1,168 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * W10 lazy-consent gap regression (page surface).
+ *
+ * A full-page App Block (`/apps/run/<slug>`) that needs a consent-gated scope
+ * (e.g. `ai:write:budgeted` once #2612 enabled the page money scope) fires
+ * REQUEST_CONSENT on the user's first Generate. Before this fix the consent
+ * bridge was only wired into the model-slot host (IframeHost); the page host
+ * (PageBlockHost) never handled REQUEST_CONSENT, so the message fired into the
+ * void and the block hung on "confirm in the Civitai dialog".
+ *
+ * These tests mount the REAL PageBlockHost (mirroring AppBlockChrome.browser.test
+ * / the model path's testing posture) and drive the actual postMessage bridge:
+ *   - iframeSrc is same-origin + trustTier='internal' so the transport runs in
+ *     PINNED mode (allow-same-origin → real origin === expectedOrigin), exactly
+ *     like a verified/internal block. We post FROM the iframe's contentWindow so
+ *     the `event.source === iframe.contentWindow` authenticating pin holds.
+ *   - We assert against the shared dialogStore (the same store IframeHost's
+ *     consent handler triggers) rather than rendering the modal, since
+ *     BlockConsentModal needs a real tRPC mutation. This pins the host→dialog
+ *     wiring: gate result → BlockConsentModal with the server-known missing set,
+ *     appName as blockName, and onGranted → onConsentGranted.
+ *
+ * The pure gate (readiness + non-empty + server-known set) is covered by
+ * requestConsentGate.test.ts; this is the host-integration layer.
+ */
+
+// Simulate a message FROM the host iframe by dispatching a MessageEvent whose
+// `source` is the iframe's contentWindow and whose `origin` matches the host's
+// expectedOrigin (same-origin iframeSrc). This satisfies BOTH authenticating
+// pins usePostMessage enforces on real block messages —
+//   1. event.source === iframe.contentWindow (the spoof guard), and
+//   2. isInboundOriginAccepted(origin, expectedOrigin) (the origin pin) —
+// without depending on a real cross-document load racing the test (a live
+// contentWindow.postMessage to a still-loading same-origin frame is dropped).
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+// Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
+// whose expectedOrigin equals this frame's origin.
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Budgeted Generator',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['apps:storage:read', 'apps:storage:write', 'ai:write:budgeted'],
+  missingScopes: ['ai:write:budgeted'],
+  needsConsent: true,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+// Drive the handshake to BLOCK_READY (status='ready') so the consent gate's
+// `status === 'ready'` precondition is satisfied — same prerequisite a real
+// block hits before its first Generate.
+async function driveToReady() {
+  // Wait until the iframe is mounted + its contentWindow is reachable.
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  // The host posts BLOCK_INIT on a retry interval; we just ack READY.
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
+  beforeEach(() => {
+    // dialogStore is a module-level zustand store shared across tests — reset it.
+    useDialogStore.getState().closeAll();
+  });
+
+  test('after BLOCK_READY, REQUEST_CONSENT opens the consent dialog with the server-known missing set', async () => {
+    const onConsentGranted = vi.fn();
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={onConsentGranted} />);
+
+    await driveToReady();
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+
+    // The block claims a WIDER set than the host withheld — the host must ignore
+    // the claim and grant only its server-known missingScopes.
+    postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted', 'buzz:spend:self'] });
+
+    await vi.waitFor(() => {
+      expect(useDialogStore.getState().dialogs).toHaveLength(1);
+    });
+
+    const dialog = useDialogStore.getState().dialogs[0];
+    const dialogProps = dialog.props as {
+      appBlockId: string;
+      blockName?: string;
+      missingScopes: string[];
+      onGranted: () => void;
+    };
+    // Grant ONLY the server-known missing set, never the block's wider claim.
+    expect(dialogProps.missingScopes).toEqual(['ai:write:budgeted']);
+    expect(dialogProps.appBlockId).toBe('apb_test');
+    // PageBlockHost surfaces the app name as `appName` → BlockConsentModal.blockName.
+    expect(dialogProps.blockName).toBe('Budgeted Generator');
+
+    // onGranted → onConsentGranted (re-mint hook) — the fire-and-forget channel
+    // that re-mints the token; the rotated token's TOKEN_REFRESH delivers scopes.
+    expect(onConsentGranted).not.toHaveBeenCalled();
+    dialogProps.onGranted();
+    expect(onConsentGranted).toHaveBeenCalledTimes(1);
+  });
+
+  test('REQUEST_CONSENT before BLOCK_READY is dropped (no pre-handshake permission modal)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+    // Do NOT drive to ready — fire consent while status is still 'loading'.
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+    postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted'] });
+
+    // Give the message a chance to be (incorrectly) handled, then assert it wasn't.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('REQUEST_CONSENT with nothing missing is a no-op (no dialog)', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        missingScopes={[]}
+        needsConsent={false}
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted'] });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+});

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1,13 +1,21 @@
 import { Box } from '@mantine/core';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BlockFallback } from './BlockFallback';
 import { AppBlockChrome } from './IframeHost';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { grantedPageScopes, pageFallbackReason } from './pageBlockHostLogic';
+import { resolveRequestConsent } from './requestConsentGate';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, PageContext } from './types';
+import { dialogStore } from '~/components/Dialog/dialogStore';
+
+// Lazy-consent UI (REQUEST_CONSENT). Opened on demand when a logged-in viewer
+// clicks an action whose consent-gated scope the page token is missing. Mirrors
+// IframeHost's dynamic import (SSR-disabled).
+const BlockConsentModal = dynamic(() => import('./BlockConsentModal'), { ssr: false });
 
 /**
  * W10 — full-page App Block host. Renders a block as a FULL-VIEWPORT surface
@@ -72,6 +80,10 @@ export interface PageBlockHostProps {
   tokenError?: boolean;
   viewer: { id: number; username: string | null } | null;
   theme: 'light' | 'dark';
+  /** Re-mint the page token after a consent grant so it carries the newly
+   *  granted scopes (pushed to the iframe via TOKEN_REFRESH). Mirrors
+   *  IframeHost.onConsentGranted → useBlockToken.refresh. */
+  onConsentGranted?: () => void;
 }
 
 export function PageBlockHost({
@@ -92,6 +104,7 @@ export function PageBlockHost({
   tokenError,
   viewer,
   theme,
+  onConsentGranted,
 }: PageBlockHostProps) {
   const router = useRouter();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -272,6 +285,51 @@ export function PageBlockHost({
     });
     return off;
   }, [onMessage]);
+
+  // Lazy consent (A6): the block (rendered in full for a logged-in viewer whose
+  // page token is missing a consent-gated scope, e.g. `ai:write:budgeted` once
+  // the page money scope is enabled) asks the host to open the consent UI when
+  // the user clicks an action that needs that capability (e.g. Generate),
+  // instead of a prompt on load. Mirrors IframeHost's REQUEST_CONSENT handler
+  // exactly: we grant ONLY the missing set the MINT computed (`missingScopes` —
+  // server-known truth), NOT any scopes the block claims; the gate also pins
+  // status === 'ready' so a pre-handshake block can't pop a permission modal
+  // before any interaction (same posture as NAVIGATE). On grant we re-mint the
+  // token (onConsentGranted → useBlockToken.refresh); the new scopes flow to the
+  // iframe via the TOKEN_REFRESH push above and the block retries — there is no
+  // host→block reply (fire-and-forget).
+  //
+  // This was the W10 page-consent gap: the page surface (#2606) carried no money
+  // scopes, so no consent handler was needed; #2612 enabled the page money scope
+  // but never ported this handler from IframeHost, so REQUEST_CONSENT fired into
+  // the void and the block hung on "confirm in the Civitai dialog".
+  useEffect(() => {
+    const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', () => {
+      // PageBlockHost's local Status carries an extra terminal `'error'` variant
+      // (a hard mint failure) the shared gate's HostStatus union doesn't model.
+      // The gate only ever grants when status === 'ready', and `'error'` is a
+      // disjoint terminal state (the iframe isn't even rendered), so collapse it
+      // to a non-ready sentinel before delegating — semantics are unchanged (it
+      // would return null either way), this just satisfies the union type.
+      const gateStatus = status === 'error' ? 'no_token' : status;
+      const scopesToGrant = resolveRequestConsent(gateStatus, missingScopes ?? []);
+      if (scopesToGrant == null) return; // not ready, or nothing missing — drop
+      dialogStore.trigger({
+        component: BlockConsentModal,
+        props: {
+          appBlockId,
+          // PageBlockHost surfaces the app name as `appName` (the model host
+          // uses `install.manifest.name`).
+          blockName: appName,
+          missingScopes: scopesToGrant,
+          onGranted: () => {
+            onConsentGranted?.();
+          },
+        },
+      });
+    });
+    return off;
+  }, [onMessage, status, missingScopes, appBlockId, appName, onConsentGranted]);
 
   // Deep-link bridge — block requests in-page navigation. The block may push a
   // new sub-path WITHIN its own page space; we constrain it to the page route so

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -128,7 +128,11 @@ export default function AppPage(props: PageProps) {
   // `missingScopes` lets PageBlockHost compute the REAL granted set (declared −
   // missing) for BLOCK_INIT; `needsConsent`/`error` let it surface a terminal
   // state instead of hanging at `no_token`.
-  const { token, expiresAt, needsConsent, missingScopes, error } = useBlockToken(
+  // `refresh` re-mints the page token after a consent grant so the new scopes
+  // flow to the block via TOKEN_REFRESH (wired to PageBlockHost.onConsentGranted,
+  // mirroring how IframeHost re-mints on REQUEST_CONSENT). The rotated token's
+  // TOKEN_REFRESH push delivers the granted scopes and the block retries.
+  const { token, expiresAt, needsConsent, missingScopes, error, refresh } = useBlockToken(
     install,
     context
   );
@@ -159,6 +163,7 @@ export default function AppPage(props: PageProps) {
           tokenError={error != null}
           viewer={viewer}
           theme={theme}
+          onConsentGranted={refresh}
         />
       </Box>
     </>


### PR DESCRIPTION
## The bug (found by a live dog-food)

A full-page App Block (`/apps/run/<slug>`) that needs a consent-gated scope (e.g. `ai:write:budgeted`) fires `REQUEST_CONSENT` on the user's first **Generate**, but **nothing opens the consent dialog** — the block shows _"Grant access to generate — confirm in the Civitai dialog"_ and hangs; **try again** re-fires into the void.

**Root cause:** the lazy-consent bridge was only wired into the model-slot host (`IframeHost.tsx`), never the page host (`PageBlockHost.tsx`). When the page surface (#2606) shipped, pages carried no money scopes, so no consent handler was needed; #2612 enabled the page money scope but didn't port the handler.

## The fix

Port IframeHost's `onMessage('REQUEST_CONSENT', …)` handler to `PageBlockHost`, mirroring its consent semantics **exactly**:

- **Grant only the server-known `missingScopes`** (via `resolveRequestConsent`), never the scopes the block claims — defense-in-depth on top of the server-side `manifest ∩ approved` bound.
- **Gate on `status === 'ready'`** so a pre-handshake block can't pop a permission modal before any interaction (same posture as `REQUEST_SIGN_IN` / `OPEN_BUZZ_PURCHASE` / page `NAVIGATE`).
- **Fire-and-forget:** on grant, re-mint the token via `onConsentGranted` → `useBlockToken.refresh`; the rotated token's existing `TOKEN_REFRESH` push delivers the new scopes and the block retries. No host→block reply.

The page route (`/apps/run/[slug]/[[...path]].tsx`) now destructures `refresh` from `useBlockToken` and passes it as `onConsentGranted`, exactly how IframeHost's `onConsentGranted` re-mints.

`IframeHost` and the model path are **untouched**. **No feature-flag change** — the page surface stays dark + mod-gated.

### Note on the `'error'` status
PageBlockHost's local `Status` carries an extra terminal `'error'` variant (hard mint failure) that the shared gate's `HostStatus` union doesn't model. Since the gate only grants on `'ready'` and `'error'` is disjoint, the call site collapses `'error'` → a non-ready sentinel before delegating — semantics unchanged, just satisfies the union type. (This is the one place the page host deviates from a byte-for-byte IframeHost mirror.)

## Tests

- New `src/components/AppBlocks/PageBlockHost.browser.test.tsx` (Vitest browser mode, real Chromium — same harness as `AppBlockChrome.browser.test.tsx`): mounts the **real** `PageBlockHost`, drives the postMessage handshake to `BLOCK_READY`, then asserts:
  - `REQUEST_CONSENT` after ready opens the consent dialog with the **server-known** missing set, ignoring a wider block-claimed set; `blockName` = `appName`; `onGranted` → `onConsentGranted`.
  - `REQUEST_CONSENT` **before** ready is dropped (no pre-handshake permission modal).
  - `REQUEST_CONSENT` with nothing missing is a no-op.
- The pure gate stays covered by the existing `requestConsentGate.test.ts` (not duplicated).
- **Mutation-checked:** an inert handler (the original bug) and a wrong-scope-set both fail the new test.

Full AppBlocks suites green: **146 unit + 7 component** tests pass. `tsc` introduces no new errors in the touched files (the project-wide `tsc` is blocked by unrelated offline-Prisma drift on NixOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)