### PR TITLE
fix(cache): fail-open createCachedObject/Array.fetch + lower cluster command deadline to 3s

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -128,19 +128,26 @@ export const serverSchema = z.object({
   // time REJECTS — which makes the wrapped promise settle → `.finally(done)` fires → the
   // inflight gauge dec's AND the handler unparks with an error instead of a 125s hang.
   // The reject flows the SAME way an existing cluster read error already does (socketTimeout
-  // has rejected stuck commands down these paths since #2556): fetchThroughCache catches and
-  // fail-opens (degraded miss → slow 200); createCachedObject/Array.fetch does NOT catch, so
-  // it propagates (→ error/500) — same as any cluster error today, and strictly better than a
-  // 125s hang. Correct regardless of the exact node-redis internal cause.
+  // has rejected stuck commands down these paths since #2556): BOTH fetchThroughCache AND
+  // createCachedObject/Array.fetch now catch it and fail-open (degraded origin fetch → slow
+  // 200, single-flighted per pod to bound DB load). createCachedObject/Array.fetch was made
+  // fail-open in the same change that lowered this default — that is THIS deadline's safety
+  // net: before it, a deadline-reject down a cachedObject read propagated as a 500.
+  // Correct regardless of the exact node-redis internal cause.
   //
-  // Default 15000 (15s): ~650× over the ~23ms healthy-completion p99 (zero risk of
-  // clipping a legitimate slow command) and well below the ~125s client ceiling. Sits
-  // ABOVE REDIS_SOCKET_TIMEOUT_MS (10s) so it is a true BACKSTOP — socketTimeout still
-  // does the primary teardown when it works; this only catches the commands it doesn't.
+  // Default 3000 (3s): ~22× over the ~137ms healthy p99 (SLOWLOG max; p50 is sub-ms) so it
+  // will not clip a legitimate command — the cachedArray `mGet` is a Promise.all of
+  // individual per-key GETs, each independently wrapped by instrumentCommands, so no single
+  // wrapped command is a large multi-key op. BELOW REDIS_SOCKET_TIMEOUT_MS (10s) so the
+  // deadline (not socketTimeout) is now the EFFECTIVE cap: it unparks a stuck handler in 3s
+  // instead of 10s/125s. SAFE to be this aggressive only because the fail-open above turns a
+  // deadline-reject into a slow 200 rather than a 500. (Was 15000 — a 15s park per stuck
+  // command + a 500 because the cachedObject path didn't yet fail-open; both fixed here.)
   // 0 disables it. Cluster-scoped: the SYSTEM client is untouched (it uses
   // REDIS_SYS_READ_TIMEOUT_MS — see the #2556/#2586 sys-client regression). See
-  // redis/command-deadline.ts withCommandDeadline() + instrumentCommands().
-  REDIS_CLUSTER_COMMAND_TIMEOUT_MS: z.coerce.number().default(15000),
+  // redis/command-deadline.ts withCommandDeadline() + instrumentCommands() and
+  // utils/cache-helpers.ts (fetchThroughCache + createCachedArray fail-open).
+  REDIS_CLUSTER_COMMAND_TIMEOUT_MS: z.coerce.number().default(3000),
   NODE_ENV: z.enum(['development', 'test', 'production']),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.preprocess(

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -130,7 +130,8 @@ export const serverSchema = z.object({
   // The reject flows the SAME way an existing cluster read error already does (socketTimeout
   // has rejected stuck commands down these paths since #2556): BOTH fetchThroughCache AND
   // createCachedObject/Array.fetch now catch it and fail-open (degraded origin fetch → slow
-  // 200, single-flighted per pod to bound DB load). createCachedObject/Array.fetch was made
+  // 200, bounded per pod against a DB stampede by per-id-set single-flight + per-ID
+  // coalescing — see cache-helpers.ts degradedIdInFlight). createCachedObject/Array.fetch was made
   // fail-open in the same change that lowered this default — that is THIS deadline's safety
   // net: before it, a deadline-reject down a cachedObject read propagated as a 500.
   // Correct regardless of the exact node-redis internal cause.

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -43,16 +43,6 @@ interface ClientCommandOptions extends QueueCommandOptions {
 // type CommandType = CommandOptions<ClientCommandOptions>;
 type CommandType = ClientCommandOptions;
 
-// Opaque per-node handle for the cursor-exposing scan primitive (scanNodes /
-// scanNodeStep). One per cluster master, or a single handle for sentinel/single.
-export type ScanNodeHandle = {
-  id: string;
-  scan: (
-    cursor: string,
-    options?: { TYPE?: string; MATCH?: string; COUNT?: number }
-  ) => Promise<{ keys: string[]; cursor: string | number }>;
-};
-
 interface CustomRedisClient<K extends RedisKeyTemplates>
   extends Omit<
     RedisClientType,
@@ -96,14 +86,6 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
     COUNT?: number;
     cursor?: string;
   }): AsyncGenerator<string[], void, unknown>;
-  // Cursor-exposing scan primitive (see impl) — only used by clearCacheByPattern's
-  // resilient drain so a deadline-clipped SCAN step can be retried/resumed.
-  scanNodes(): Promise<ScanNodeHandle[]>;
-  scanNodeStep(
-    handle: ScanNodeHandle,
-    cursor: string,
-    options?: { TYPE?: string; MATCH?: string; COUNT?: number }
-  ): Promise<{ keys: string[]; cursor: string }>;
   packed: {
     get<T>(key: K): Promise<T | null>;
     // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all
@@ -941,50 +923,6 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
       // Single node mode: use original native scanIterator
       yield* originalScanIterator(options);
     }
-  };
-
-  // Cursor-EXPOSING scan primitive for clearCacheByPattern's resilient drain.
-  //
-  // `scanIterator` (above) hides the SCAN cursor inside its generator, so a
-  // single deadline-clipped SCAN step (the `withCommandDeadline(_execute)` wrap
-  // rejects when a shard is memory-pressured) throws out of the `for await` and
-  // KILLS the iterator — the cursor is lost and the rest of the keyspace is never
-  // scanned, leaving matching keys un-deleted (stale cache until natural TTL).
-  //
-  // These two methods let a caller drive SCAN node-by-node with an EXPLICIT
-  // cursor, so a clipped step can be retried from the SAME cursor (bounded) and
-  // a node can be resumed mid-drain instead of restarting from scratch. This is
-  // the ONLY consumer; the happy-path iterator is unchanged.
-  //
-  // `scanNodes()` returns one opaque handle per master (cluster), or a single
-  // handle for sentinel/single — each handle owns the node-scoped `scan(...)`.
-  // `scanNodeStep(handle, cursor, options)` issues ONE SCAN and returns the
-  // keys + the NEXT cursor ('0' = node exhausted).
-  client.scanNodes = async function () {
-    if (baseClient.masters) {
-      const masters = await baseClient.masters;
-      const handles = [] as ScanNodeHandle[];
-      for (const master of masters) {
-        const nodeClient = await baseClient.nodeClient(master);
-        // Identify the node for log/resume context; address shape varies by
-        // node-redis version, so fall back through the common fields.
-        const id =
-          master?.address ??
-          (master?.host != null ? `${master.host}:${master.port ?? ''}` : undefined) ??
-          master?.id ??
-          'master';
-        handles.push({ id, scan: (cursor, opts) => nodeClient.scan(cursor, opts) });
-      }
-      return handles;
-    }
-    // Sentinel + single both expose `scan` on the base client and present as one
-    // logical keyspace.
-    return [{ id: isSentinelClient ? 'sentinel' : 'single', scan: (cursor, opts) => baseClient.scan(cursor, opts) }];
-  };
-
-  client.scanNodeStep = async function (handle: ScanNodeHandle, cursor, options) {
-    const reply = await handle.scan(cursor, options);
-    return { keys: reply.keys as string[], cursor: String(reply.cursor) };
   };
 
   // Wrap mGet to avoid CROSSSLOT errors - fetch keys individually

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -43,6 +43,16 @@ interface ClientCommandOptions extends QueueCommandOptions {
 // type CommandType = CommandOptions<ClientCommandOptions>;
 type CommandType = ClientCommandOptions;
 
+// Opaque per-node handle for the cursor-exposing scan primitive (scanNodes /
+// scanNodeStep). One per cluster master, or a single handle for sentinel/single.
+export type ScanNodeHandle = {
+  id: string;
+  scan: (
+    cursor: string,
+    options?: { TYPE?: string; MATCH?: string; COUNT?: number }
+  ) => Promise<{ keys: string[]; cursor: string | number }>;
+};
+
 interface CustomRedisClient<K extends RedisKeyTemplates>
   extends Omit<
     RedisClientType,
@@ -86,6 +96,14 @@ interface CustomRedisClient<K extends RedisKeyTemplates>
     COUNT?: number;
     cursor?: string;
   }): AsyncGenerator<string[], void, unknown>;
+  // Cursor-exposing scan primitive (see impl) — only used by clearCacheByPattern's
+  // resilient drain so a deadline-clipped SCAN step can be retried/resumed.
+  scanNodes(): Promise<ScanNodeHandle[]>;
+  scanNodeStep(
+    handle: ScanNodeHandle,
+    cursor: string,
+    options?: { TYPE?: string; MATCH?: string; COUNT?: number }
+  ): Promise<{ keys: string[]; cursor: string }>;
   packed: {
     get<T>(key: K): Promise<T | null>;
     // Wrapped to avoid CROSSSLOT errors - fetches keys individually with Promise.all
@@ -923,6 +941,50 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
       // Single node mode: use original native scanIterator
       yield* originalScanIterator(options);
     }
+  };
+
+  // Cursor-EXPOSING scan primitive for clearCacheByPattern's resilient drain.
+  //
+  // `scanIterator` (above) hides the SCAN cursor inside its generator, so a
+  // single deadline-clipped SCAN step (the `withCommandDeadline(_execute)` wrap
+  // rejects when a shard is memory-pressured) throws out of the `for await` and
+  // KILLS the iterator — the cursor is lost and the rest of the keyspace is never
+  // scanned, leaving matching keys un-deleted (stale cache until natural TTL).
+  //
+  // These two methods let a caller drive SCAN node-by-node with an EXPLICIT
+  // cursor, so a clipped step can be retried from the SAME cursor (bounded) and
+  // a node can be resumed mid-drain instead of restarting from scratch. This is
+  // the ONLY consumer; the happy-path iterator is unchanged.
+  //
+  // `scanNodes()` returns one opaque handle per master (cluster), or a single
+  // handle for sentinel/single — each handle owns the node-scoped `scan(...)`.
+  // `scanNodeStep(handle, cursor, options)` issues ONE SCAN and returns the
+  // keys + the NEXT cursor ('0' = node exhausted).
+  client.scanNodes = async function () {
+    if (baseClient.masters) {
+      const masters = await baseClient.masters;
+      const handles = [] as ScanNodeHandle[];
+      for (const master of masters) {
+        const nodeClient = await baseClient.nodeClient(master);
+        // Identify the node for log/resume context; address shape varies by
+        // node-redis version, so fall back through the common fields.
+        const id =
+          master?.address ??
+          (master?.host != null ? `${master.host}:${master.port ?? ''}` : undefined) ??
+          master?.id ??
+          'master';
+        handles.push({ id, scan: (cursor, opts) => nodeClient.scan(cursor, opts) });
+      }
+      return handles;
+    }
+    // Sentinel + single both expose `scan` on the base client and present as one
+    // logical keyspace.
+    return [{ id: isSentinelClient ? 'sentinel' : 'single', scan: (cursor, opts) => baseClient.scan(cursor, opts) }];
+  };
+
+  client.scanNodeStep = async function (handle: ScanNodeHandle, cursor, options) {
+    const reply = await handle.scan(cursor, options);
+    return { keys: reply.keys as string[], cursor: String(reply.cursor) };
   };
 
   // Wrap mGet to avoid CROSSSLOT errors - fetch keys individually

--- a/src/server/redis/command-deadline.ts
+++ b/src/server/redis/command-deadline.ts
@@ -24,10 +24,12 @@ import { env } from '~/env/server';
  * here — it is bounded separately by withSysReadDeadline / commandsQueueMaxLength, and a
  * blanket timeout on it caused the #2556/#2586 sys-client wedge. See client.ts.
  *
- * CONSUMER IMPACT: the reject is caught by the SAME fail-open paths that already catch a
- * cluster read error (cache-helpers fetchThroughCache + createCachedObject try/catch) →
- * a degraded cache miss → slow 200 (origin fetch), NOT a hard 500. Strictly better than
- * the 125s-then-499 it replaces.
+ * CONSUMER IMPACT: the reject is caught by the SAME fail-open paths that catch a cluster
+ * read error — cache-helpers `fetchThroughCache` AND `createCachedArray`/`createCachedObject`
+ * `.fetch` (the latter was made fail-open alongside lowering the deadline default; before
+ * that its mGet/set/del had NO try/catch and a reject surfaced as a 500). Both now degrade
+ * to a single-flighted origin fetch → slow 200, NOT a hard 500. Strictly better than the
+ * 125s-then-499 it replaces.
  *
  * `ms` defaults to REDIS_CLUSTER_COMMAND_TIMEOUT_MS; pass an explicit value in tests.
  * `<= 0` disables the guard (returns the input unchanged — no wrapper, no timer).

--- a/src/server/redis/command-deadline.ts
+++ b/src/server/redis/command-deadline.ts
@@ -28,8 +28,10 @@ import { env } from '~/env/server';
  * read error — cache-helpers `fetchThroughCache` AND `createCachedArray`/`createCachedObject`
  * `.fetch` (the latter was made fail-open alongside lowering the deadline default; before
  * that its mGet/set/del had NO try/catch and a reject surfaced as a 500). Both now degrade
- * to a single-flighted origin fetch → slow 200, NOT a hard 500. Strictly better than the
- * 125s-then-499 it replaces.
+ * to an origin fetch → slow 200, NOT a hard 500. The cachedArray origin fetch is bounded
+ * against a DB stampede by per-id-set single-flight PLUS per-ID coalescing (so distinct
+ * overlapping feed pages share per-id DB results) — see cache-helpers.ts degradedIdInFlight.
+ * Strictly better than the 125s-then-499 it replaces.
  *
  * `ms` defaults to REDIS_CLUSTER_COMMAND_TIMEOUT_MS; pass an explicit value in tests.
  * `<= 0` disables the guard (returns the input unchanged — no wrapper, no timer).

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -102,6 +102,56 @@ describe('createCachedArray.fetch — Redis read fail-open', () => {
     }
   });
 
+  it('coalesces OVERLAPPING id-sets at the id level — the shared ids are NOT double-fetched', async () => {
+    // The audit gap this guards: hot callers (imageMetaCache / tagIdsForImagesCache) pass
+    // per-feed-page id lists. Under a full wedge (EVERY mGet rejects) the per-id-SET single-
+    // flight does NOT collapse [1,2,3] vs [2,3,4] (distinct sets) — so without per-ID
+    // coalescing each page = a full independent DB fetch, flooding the DB ∝ pages. With it,
+    // the overlap {2,3} is fetched ONCE; total distinct ids fetched = {1,2,3,4}, not 3+3=6.
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+
+    // Gate the first batched DB call so the second request enters fail-open while the first's
+    // per-id promises (for 1,2,3) are still in flight — that's what lets it reuse 2 and 3.
+    let releaseFirst: () => void;
+    const firstGate = new Promise<void>((r) => (releaseFirst = r));
+    const fetchedIdBatches: number[][] = [];
+    let callCount = 0;
+    const lookupFn = vi.fn(async (ids: number[]) => {
+      fetchedIdBatches.push([...ids]);
+      callCount++;
+      if (callCount === 1) await firstGate; // hold the first DB call open
+      return Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<
+        string,
+        Row
+      >;
+    });
+
+    const cache = createCachedArray<Row>({ key: 'test:overlap' as never, idKey: 'id', lookupFn });
+
+    const first = cache.fetch([1, 2, 3]); // registers per-id in-flight for 1,2,3, awaits firstGate
+    // Let the first request register its per-id in-flight entries before the second starts.
+    await Promise.resolve();
+    await Promise.resolve();
+    const second = cache.fetch([2, 3, 4]); // should reuse 2,3 in-flight, only originate 4
+    // Let the second request reach its (only) DB call for the missing id (4).
+    await Promise.resolve();
+    await Promise.resolve();
+
+    releaseFirst!();
+    const [r1, r2] = await Promise.all([first, second]);
+
+    // Every distinct id fetched across ALL lookupFn calls — must be exactly {1,2,3,4} (the
+    // overlap counted once), proving per-id dedup. Not 6 (3+3), which is the unbounded flood.
+    const allFetched = new Set(fetchedIdBatches.flat());
+    expect([...allFetched].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    expect(fetchedIdBatches.flat()).toHaveLength(4); // no id fetched twice
+
+    // Correctness: each request still gets ALL of its requested ids back.
+    expect(r1.map((x) => x.id).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    expect(r2.map((x) => x.id).sort((a, b) => a - b)).toEqual([2, 3, 4]);
+    expect(r2.find((x) => x.id === 2)?.name).toBe('db-2'); // the reused-from-first value
+  });
+
   it('does NOT swallow a genuine lookupFn (origin/DB) error — it must still propagate', async () => {
     mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
     const lookupFn = vi.fn(async () => {

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -20,10 +20,6 @@ const mGetMock = vi.fn();
 const setMock = vi.fn().mockResolvedValue(undefined);
 const setNxMock = vi.fn().mockResolvedValue(true);
 const delMock = vi.fn().mockResolvedValue(undefined);
-// clearCacheByPattern drives SCAN via scanNodes()/scanNodeStep(); mocks let us
-// simulate a clipped (deadline-rejected) SCAN/del step deterministically.
-const scanNodesMock = vi.fn();
-const scanNodeStepMock = vi.fn();
 
 vi.mock('~/server/redis/client', () => ({
   redis: {
@@ -33,8 +29,6 @@ vi.mock('~/server/redis/client', () => ({
     },
     setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
     del: (...args: unknown[]) => delMock(...args),
-    scanNodes: (...args: unknown[]) => scanNodesMock(...args),
-    scanNodeStep: (...args: unknown[]) => scanNodeStepMock(...args),
   },
   sysRedis: {},
   REDIS_KEYS: { CACHE_LOCKS: 'caches:lock' },
@@ -45,12 +39,7 @@ vi.mock('~/server/redis/fail-open-log', () => ({
   logSysRedisFailOpen: vi.fn(),
 }));
 
-import {
-  clearCacheByPattern,
-  createCachedArray,
-  createCachedObject,
-} from '~/server/utils/cache-helpers';
-import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
+import { createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
 
 type Row = { id: number; name: string };
 
@@ -58,10 +47,7 @@ beforeEach(() => {
   mGetMock.mockReset();
   setMock.mockClear();
   setNxMock.mockClear();
-  delMock.mockClear().mockResolvedValue(undefined);
-  scanNodesMock.mockReset();
-  scanNodeStepMock.mockReset();
-  vi.mocked(logSysRedisFailOpen).mockClear();
+  delMock.mockClear();
 });
 
 afterEach(() => {
@@ -166,95 +152,6 @@ describe('createCachedArray.fetch — Redis read fail-open', () => {
     expect(r2.find((x) => x.id === 2)?.name).toBe('db-2'); // the reused-from-first value
   });
 
-  it('propagates a lookupFn error to a JOINER too — the overlapping joiner does not hang or get a partial result', async () => {
-    // Owner [1,2,3] originates its per-id promises then its DB call rejects. A concurrent
-    // joiner [2,3,4] reuses the owner's in-flight 2,3 (which will reject) and originates 4.
-    // The joiner MUST reject (inherit the shared-id failure) — not hang, not return [4].
-    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
-
-    let releaseOwner: () => void;
-    const ownerGate = new Promise<void>((r) => (releaseOwner = r));
-    let call = 0;
-    const lookupFn = vi.fn(async (ids: number[]) => {
-      call++;
-      if (call === 1) {
-        // The owner's batched DB call — hold it open, then fail it.
-        await ownerGate;
-        throw new Error('owner DB failure');
-      }
-      // The joiner's own DB call for its non-shared id (4) succeeds.
-      return Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<
-        string,
-        Row
-      >;
-    });
-
-    const cache = createCachedArray<Row>({ key: 'test:joinerr' as never, idKey: 'id', lookupFn });
-
-    const owner = cache.fetch([1, 2, 3]); // registers per-id in-flight for 1,2,3, awaits ownerGate
-    await Promise.resolve();
-    await Promise.resolve();
-    const joiner = cache.fetch([2, 3, 4]); // reuses 2,3 in-flight; originates 4
-    await Promise.resolve();
-    await Promise.resolve();
-
-    releaseOwner!(); // owner's DB call now throws → rejects 1,2,3 (incl. the joiner's reused 2,3)
-
-    await expect(owner).rejects.toThrow(/owner DB failure/);
-    await expect(joiner).rejects.toThrow(/owner DB failure/);
-  });
-
-  it('does NOT leak settled per-id promises — a later degraded fetch RE-originates (after resolve AND after reject)', async () => {
-    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
-
-    // Round 1: resolves. The per-id in-flight entries for 1,2,3 must be cleaned up on settle.
-    const lookupOk = vi.fn(async (ids: number[]) =>
-      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
-    );
-    const cacheOk = createCachedArray<Row>({ key: 'test:noleak-ok' as never, idKey: 'id', lookupFn: lookupOk });
-    await cacheOk.fetch([1, 2, 3]);
-    expect(lookupOk).toHaveBeenCalledTimes(1);
-    // A subsequent degraded fetch of the SAME ids must call the origin AGAIN (not be served
-    // from a stale settled promise) — proving the in-flight entry was deleted on resolve.
-    await cacheOk.fetch([1, 2, 3]);
-    expect(lookupOk).toHaveBeenCalledTimes(2);
-
-    // Round 2: a fetch that REJECTS must also clean up, so the next fetch re-originates.
-    let shouldThrow = true;
-    const lookupErr = vi.fn(async (ids: number[]) => {
-      if (shouldThrow) throw new Error('transient DB failure');
-      return Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<
-        string,
-        Row
-      >;
-    });
-    const cacheErr = createCachedArray<Row>({ key: 'test:noleak-err' as never, idKey: 'id', lookupFn: lookupErr });
-    await expect(cacheErr.fetch([1, 2, 3])).rejects.toThrow(/transient DB failure/);
-    expect(lookupErr).toHaveBeenCalledTimes(1);
-    // The rejected in-flight entries must be gone — the retry re-originates and now succeeds.
-    shouldThrow = false;
-    const recovered = await cacheErr.fetch([1, 2, 3]);
-    expect(lookupErr).toHaveBeenCalledTimes(2);
-    expect(recovered.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 2, 3]);
-  });
-
-  it('filters an ABSENT id from the degraded result — no null/undefined, shape matches the normal path', async () => {
-    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
-    // DB has no row for id 2 (returns only 1 and 3).
-    const lookupFn = vi.fn(async (ids: number[]) =>
-      Object.fromEntries(
-        ids.filter((id) => id !== 2).map((id) => [id, { id, name: `db-${id}` }])
-      ) as Record<string, Row>
-    );
-
-    const cache = createCachedArray<Row>({ key: 'test:absent' as never, idKey: 'id', lookupFn });
-    const result = await cache.fetch([1, 2, 3]);
-
-    // The absent id is filtered out — exactly [1,3], with no null/undefined entries.
-    expect(result.every((r) => r != null)).toBe(true);
-    expect(result.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 3]);
-  });
-
   it('does NOT swallow a genuine lookupFn (origin/DB) error — it must still propagate', async () => {
     mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
     const lookupFn = vi.fn(async () => {
@@ -279,96 +176,6 @@ describe('createCachedArray.fetch — Redis read fail-open', () => {
 
     expect(lookupFn).not.toHaveBeenCalled();
     expect(result).toEqual([{ id: 5, name: 'cached' }]);
-  });
-});
-
-describe('clearCacheByPattern — clipped SCAN/del resilience', () => {
-  // Build a single-node scan that yields keys across cursor steps. `failures` maps a
-  // cursor value to the number of times its SCAN should reject before succeeding (to
-  // simulate a deadline-clipped step that recovers on retry).
-  function setupNode(
-    steps: { cursor: string; keys: string[]; nextCursor: string }[],
-    failures: Record<string, number> = {}
-  ) {
-    const node = { id: 'single', scan: vi.fn() };
-    scanNodesMock.mockResolvedValue([node]);
-    const remaining = { ...failures };
-    scanNodeStepMock.mockImplementation(async (_node: unknown, cursor: string) => {
-      if (remaining[cursor] && remaining[cursor] > 0) {
-        remaining[cursor]--;
-        throw new Error(`SCAN clipped at cursor ${cursor} (deadline 3000ms)`);
-      }
-      const step = steps.find((s) => s.cursor === cursor);
-      if (!step) throw new Error(`unexpected cursor ${cursor}`);
-      return { keys: step.keys, cursor: step.nextCursor };
-    });
-    return node;
-  }
-
-  it('retries a clipped SCAN step from the SAME cursor and completes the full drain', async () => {
-    // Two cursor steps; the first SCAN is clipped twice then succeeds (bounded retry).
-    setupNode(
-      [
-        { cursor: '0', keys: ['k:1', 'k:2'], nextCursor: '12' },
-        { cursor: '12', keys: ['k:3'], nextCursor: '0' },
-      ],
-      { '0': 2 } // clip cursor '0' twice, then it succeeds
-    );
-
-    const cleared = await clearCacheByPattern('k:*' as never);
-
-    // All keys across both steps deleted despite the transient clips.
-    expect(cleared.sort()).toEqual(['k:1', 'k:2', 'k:3']);
-    expect(delMock).toHaveBeenCalledTimes(3);
-    // The clip recovered on retry — no fail-open log fired.
-    expect(logSysRedisFailOpen).not.toHaveBeenCalled();
-  });
-
-  it('does NOT silently abort when a SCAN step exhausts retries — logs loudly and continues best-effort', async () => {
-    // First step yields keys and advances; the SECOND step's cursor is clipped forever.
-    setupNode(
-      [
-        { cursor: '0', keys: ['k:1'], nextCursor: '99' },
-        { cursor: '99', keys: ['k:2'], nextCursor: '0' },
-      ],
-      { '99': 99 } // never recovers
-    );
-
-    const cleared = await clearCacheByPattern('k:*' as never);
-
-    // Best-effort: the first step's key was cleared; the unscanned tail surfaced as a log.
-    expect(cleared).toEqual(['k:1']);
-    expect(logSysRedisFailOpen).toHaveBeenCalledWith(
-      'write-degraded',
-      expect.stringContaining('SCAN'),
-      expect.any(Error),
-      expect.objectContaining({ partial: true, cursor: '99' })
-    );
-  });
-
-  it('retries a clipped del and surfaces a del that exhausts retries (does not drop it silently)', async () => {
-    setupNode([{ cursor: '0', keys: ['k:1', 'k:2'], nextCursor: '0' }]);
-    // k:1 del clipped once then succeeds; k:2 del always fails.
-    let k1Fails = 1;
-    delMock.mockImplementation(async (key: string) => {
-      if (key === 'k:1' && k1Fails > 0) {
-        k1Fails--;
-        throw new Error('del clipped (deadline 3000ms)');
-      }
-      if (key === 'k:2') throw new Error('del clipped forever');
-      return undefined;
-    });
-
-    const cleared = await clearCacheByPattern('k:*' as never);
-
-    // k:1 recovered on retry → cleared; k:2 exhausted → logged, not in cleared.
-    expect(cleared).toEqual(['k:1']);
-    expect(logSysRedisFailOpen).toHaveBeenCalledWith(
-      'write-degraded',
-      expect.stringContaining('del'),
-      expect.any(Error),
-      expect.objectContaining({ key: 'k:2', partial: true })
-    );
   });
 });
 

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -20,6 +20,10 @@ const mGetMock = vi.fn();
 const setMock = vi.fn().mockResolvedValue(undefined);
 const setNxMock = vi.fn().mockResolvedValue(true);
 const delMock = vi.fn().mockResolvedValue(undefined);
+// clearCacheByPattern drives SCAN via scanNodes()/scanNodeStep(); mocks let us
+// simulate a clipped (deadline-rejected) SCAN/del step deterministically.
+const scanNodesMock = vi.fn();
+const scanNodeStepMock = vi.fn();
 
 vi.mock('~/server/redis/client', () => ({
   redis: {
@@ -29,6 +33,8 @@ vi.mock('~/server/redis/client', () => ({
     },
     setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
     del: (...args: unknown[]) => delMock(...args),
+    scanNodes: (...args: unknown[]) => scanNodesMock(...args),
+    scanNodeStep: (...args: unknown[]) => scanNodeStepMock(...args),
   },
   sysRedis: {},
   REDIS_KEYS: { CACHE_LOCKS: 'caches:lock' },
@@ -39,7 +45,12 @@ vi.mock('~/server/redis/fail-open-log', () => ({
   logSysRedisFailOpen: vi.fn(),
 }));
 
-import { createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
+import {
+  clearCacheByPattern,
+  createCachedArray,
+  createCachedObject,
+} from '~/server/utils/cache-helpers';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 
 type Row = { id: number; name: string };
 
@@ -47,7 +58,10 @@ beforeEach(() => {
   mGetMock.mockReset();
   setMock.mockClear();
   setNxMock.mockClear();
-  delMock.mockClear();
+  delMock.mockClear().mockResolvedValue(undefined);
+  scanNodesMock.mockReset();
+  scanNodeStepMock.mockReset();
+  vi.mocked(logSysRedisFailOpen).mockClear();
 });
 
 afterEach(() => {
@@ -152,6 +166,95 @@ describe('createCachedArray.fetch — Redis read fail-open', () => {
     expect(r2.find((x) => x.id === 2)?.name).toBe('db-2'); // the reused-from-first value
   });
 
+  it('propagates a lookupFn error to a JOINER too — the overlapping joiner does not hang or get a partial result', async () => {
+    // Owner [1,2,3] originates its per-id promises then its DB call rejects. A concurrent
+    // joiner [2,3,4] reuses the owner's in-flight 2,3 (which will reject) and originates 4.
+    // The joiner MUST reject (inherit the shared-id failure) — not hang, not return [4].
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+
+    let releaseOwner: () => void;
+    const ownerGate = new Promise<void>((r) => (releaseOwner = r));
+    let call = 0;
+    const lookupFn = vi.fn(async (ids: number[]) => {
+      call++;
+      if (call === 1) {
+        // The owner's batched DB call — hold it open, then fail it.
+        await ownerGate;
+        throw new Error('owner DB failure');
+      }
+      // The joiner's own DB call for its non-shared id (4) succeeds.
+      return Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<
+        string,
+        Row
+      >;
+    });
+
+    const cache = createCachedArray<Row>({ key: 'test:joinerr' as never, idKey: 'id', lookupFn });
+
+    const owner = cache.fetch([1, 2, 3]); // registers per-id in-flight for 1,2,3, awaits ownerGate
+    await Promise.resolve();
+    await Promise.resolve();
+    const joiner = cache.fetch([2, 3, 4]); // reuses 2,3 in-flight; originates 4
+    await Promise.resolve();
+    await Promise.resolve();
+
+    releaseOwner!(); // owner's DB call now throws → rejects 1,2,3 (incl. the joiner's reused 2,3)
+
+    await expect(owner).rejects.toThrow(/owner DB failure/);
+    await expect(joiner).rejects.toThrow(/owner DB failure/);
+  });
+
+  it('does NOT leak settled per-id promises — a later degraded fetch RE-originates (after resolve AND after reject)', async () => {
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+
+    // Round 1: resolves. The per-id in-flight entries for 1,2,3 must be cleaned up on settle.
+    const lookupOk = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
+    );
+    const cacheOk = createCachedArray<Row>({ key: 'test:noleak-ok' as never, idKey: 'id', lookupFn: lookupOk });
+    await cacheOk.fetch([1, 2, 3]);
+    expect(lookupOk).toHaveBeenCalledTimes(1);
+    // A subsequent degraded fetch of the SAME ids must call the origin AGAIN (not be served
+    // from a stale settled promise) — proving the in-flight entry was deleted on resolve.
+    await cacheOk.fetch([1, 2, 3]);
+    expect(lookupOk).toHaveBeenCalledTimes(2);
+
+    // Round 2: a fetch that REJECTS must also clean up, so the next fetch re-originates.
+    let shouldThrow = true;
+    const lookupErr = vi.fn(async (ids: number[]) => {
+      if (shouldThrow) throw new Error('transient DB failure');
+      return Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<
+        string,
+        Row
+      >;
+    });
+    const cacheErr = createCachedArray<Row>({ key: 'test:noleak-err' as never, idKey: 'id', lookupFn: lookupErr });
+    await expect(cacheErr.fetch([1, 2, 3])).rejects.toThrow(/transient DB failure/);
+    expect(lookupErr).toHaveBeenCalledTimes(1);
+    // The rejected in-flight entries must be gone — the retry re-originates and now succeeds.
+    shouldThrow = false;
+    const recovered = await cacheErr.fetch([1, 2, 3]);
+    expect(lookupErr).toHaveBeenCalledTimes(2);
+    expect(recovered.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it('filters an ABSENT id from the degraded result — no null/undefined, shape matches the normal path', async () => {
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+    // DB has no row for id 2 (returns only 1 and 3).
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(
+        ids.filter((id) => id !== 2).map((id) => [id, { id, name: `db-${id}` }])
+      ) as Record<string, Row>
+    );
+
+    const cache = createCachedArray<Row>({ key: 'test:absent' as never, idKey: 'id', lookupFn });
+    const result = await cache.fetch([1, 2, 3]);
+
+    // The absent id is filtered out — exactly [1,3], with no null/undefined entries.
+    expect(result.every((r) => r != null)).toBe(true);
+    expect(result.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 3]);
+  });
+
   it('does NOT swallow a genuine lookupFn (origin/DB) error — it must still propagate', async () => {
     mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
     const lookupFn = vi.fn(async () => {
@@ -176,6 +279,96 @@ describe('createCachedArray.fetch — Redis read fail-open', () => {
 
     expect(lookupFn).not.toHaveBeenCalled();
     expect(result).toEqual([{ id: 5, name: 'cached' }]);
+  });
+});
+
+describe('clearCacheByPattern — clipped SCAN/del resilience', () => {
+  // Build a single-node scan that yields keys across cursor steps. `failures` maps a
+  // cursor value to the number of times its SCAN should reject before succeeding (to
+  // simulate a deadline-clipped step that recovers on retry).
+  function setupNode(
+    steps: { cursor: string; keys: string[]; nextCursor: string }[],
+    failures: Record<string, number> = {}
+  ) {
+    const node = { id: 'single', scan: vi.fn() };
+    scanNodesMock.mockResolvedValue([node]);
+    const remaining = { ...failures };
+    scanNodeStepMock.mockImplementation(async (_node: unknown, cursor: string) => {
+      if (remaining[cursor] && remaining[cursor] > 0) {
+        remaining[cursor]--;
+        throw new Error(`SCAN clipped at cursor ${cursor} (deadline 3000ms)`);
+      }
+      const step = steps.find((s) => s.cursor === cursor);
+      if (!step) throw new Error(`unexpected cursor ${cursor}`);
+      return { keys: step.keys, cursor: step.nextCursor };
+    });
+    return node;
+  }
+
+  it('retries a clipped SCAN step from the SAME cursor and completes the full drain', async () => {
+    // Two cursor steps; the first SCAN is clipped twice then succeeds (bounded retry).
+    setupNode(
+      [
+        { cursor: '0', keys: ['k:1', 'k:2'], nextCursor: '12' },
+        { cursor: '12', keys: ['k:3'], nextCursor: '0' },
+      ],
+      { '0': 2 } // clip cursor '0' twice, then it succeeds
+    );
+
+    const cleared = await clearCacheByPattern('k:*' as never);
+
+    // All keys across both steps deleted despite the transient clips.
+    expect(cleared.sort()).toEqual(['k:1', 'k:2', 'k:3']);
+    expect(delMock).toHaveBeenCalledTimes(3);
+    // The clip recovered on retry — no fail-open log fired.
+    expect(logSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('does NOT silently abort when a SCAN step exhausts retries — logs loudly and continues best-effort', async () => {
+    // First step yields keys and advances; the SECOND step's cursor is clipped forever.
+    setupNode(
+      [
+        { cursor: '0', keys: ['k:1'], nextCursor: '99' },
+        { cursor: '99', keys: ['k:2'], nextCursor: '0' },
+      ],
+      { '99': 99 } // never recovers
+    );
+
+    const cleared = await clearCacheByPattern('k:*' as never);
+
+    // Best-effort: the first step's key was cleared; the unscanned tail surfaced as a log.
+    expect(cleared).toEqual(['k:1']);
+    expect(logSysRedisFailOpen).toHaveBeenCalledWith(
+      'write-degraded',
+      expect.stringContaining('SCAN'),
+      expect.any(Error),
+      expect.objectContaining({ partial: true, cursor: '99' })
+    );
+  });
+
+  it('retries a clipped del and surfaces a del that exhausts retries (does not drop it silently)', async () => {
+    setupNode([{ cursor: '0', keys: ['k:1', 'k:2'], nextCursor: '0' }]);
+    // k:1 del clipped once then succeeds; k:2 del always fails.
+    let k1Fails = 1;
+    delMock.mockImplementation(async (key: string) => {
+      if (key === 'k:1' && k1Fails > 0) {
+        k1Fails--;
+        throw new Error('del clipped (deadline 3000ms)');
+      }
+      if (key === 'k:2') throw new Error('del clipped forever');
+      return undefined;
+    });
+
+    const cleared = await clearCacheByPattern('k:*' as never);
+
+    // k:1 recovered on retry → cleared; k:2 exhausted → logged, not in cleared.
+    expect(cleared).toEqual(['k:1']);
+    expect(logSysRedisFailOpen).toHaveBeenCalledWith(
+      'write-degraded',
+      expect.stringContaining('del'),
+      expect.any(Error),
+      expect.objectContaining({ key: 'k:2', partial: true })
+    );
   });
 });
 

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Fail-open coverage for createCachedArray / createCachedObject `.fetch`.
+ *
+ * Background (PR #2611 + this PR): a node-redis CLUSTER (cache) command can wedge — the
+ * #2556 socketTimeout (~10s) / #2611 command-deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS)
+ * now make a stuck read REJECT instead of hanging 125s. But the cachedArray read path had
+ * NO try/catch around its `redis.packed.mGet`, so that reject propagated → TRPCError → 500
+ * (a 68-min 500 spike on two wedged pods). These tests pin the contract that the read now
+ * fails OPEN to a single-flighted origin (lookupFn) fetch — mirroring fetchThroughCache.
+ *
+ * The redis client is mocked so we can force a read rejection deterministically. The fail-
+ * open logger is stubbed to a no-op (it's fire-and-forget Axiom/Loki I/O, not under test).
+ */
+
+// Controllable fake CLUSTER redis client. mGet can be flipped to reject to simulate a
+// wedged cluster command (socketTimeout / command-deadline reject).
+const mGetMock = vi.fn();
+const setMock = vi.fn().mockResolvedValue(undefined);
+const setNxMock = vi.fn().mockResolvedValue(true);
+const delMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: {
+      mGet: (...args: unknown[]) => mGetMock(...args),
+      set: (...args: unknown[]) => setMock(...args),
+    },
+    setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
+    del: (...args: unknown[]) => delMock(...args),
+  },
+  sysRedis: {},
+  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock' },
+}));
+
+// Keep the fail-open logger inert (it's fire-and-forget Axiom/Loki, not under test).
+vi.mock('~/server/redis/fail-open-log', () => ({
+  logSysRedisFailOpen: vi.fn(),
+}));
+
+import { createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
+
+type Row = { id: number; name: string };
+
+beforeEach(() => {
+  mGetMock.mockReset();
+  setMock.mockClear();
+  setNxMock.mockClear();
+  delMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createCachedArray.fetch — Redis read fail-open', () => {
+  it('returns the ORIGIN (lookupFn) result instead of throwing when the redis read rejects', async () => {
+    // Simulate a wedged cluster command: the read rejects (what the #2611 deadline does).
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
+    );
+
+    const cache = createCachedArray<Row>({ key: 'test:arr' as never, idKey: 'id', lookupFn });
+
+    // BEFORE this fix this would reject (→ TRPCError → 500). It must now resolve to the
+    // origin result (degraded slow-200) instead.
+    const result = await cache.fetch([1, 2, 3]);
+
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    expect(result.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    expect(result.find((r) => r.id === 2)?.name).toBe('db-2');
+  });
+
+  it('single-flights the fail-open origin fetch across concurrent requests for the same id-set', async () => {
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+
+    // A slow lookupFn so the concurrent calls overlap in time and MUST share one promise.
+    let resolveLookup: (v: Record<string, Row>) => void;
+    const lookupGate = new Promise<Record<string, Row>>((r) => (resolveLookup = r));
+    const lookupFn = vi.fn(() => lookupGate);
+
+    const cache = createCachedArray<Row>({ key: 'test:sf' as never, idKey: 'id', lookupFn });
+
+    // Fire 5 concurrent fetches for the same id-set while redis is wedged.
+    const inFlight = [cache.fetch([10, 11]), cache.fetch([10, 11]), cache.fetch([11, 10]), cache.fetch([10, 11]), cache.fetch([10, 11])];
+
+    // Let microtasks flush so all 5 reach the fail-open single-flight before it resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveLookup!({ 10: { id: 10, name: 'a' }, 11: { id: 11, name: 'b' } });
+    const results = await Promise.all(inFlight);
+
+    // The stampede guard: ONE origin call serves all 5 concurrent requests (incl. the
+    // reversed [11,10] id order, which the sorted single-flight key collapses to the same).
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    for (const r of results) {
+      expect(r.map((x) => x.id).sort((a, b) => a - b)).toEqual([10, 11]);
+    }
+  });
+
+  it('does NOT swallow a genuine lookupFn (origin/DB) error — it must still propagate', async () => {
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+    const lookupFn = vi.fn(async () => {
+      throw new Error('real DB failure');
+    });
+
+    const cache = createCachedArray<Row>({ key: 'test:dberr' as never, idKey: 'id', lookupFn });
+
+    // A real origin error is NOT a redis error — it must surface, not be turned into a 200.
+    await expect(cache.fetch([1])).rejects.toThrow(/real DB failure/);
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves results normally (no origin fetch for hits) when the redis read succeeds', async () => {
+    // Healthy read returns a cached, fresh value → no lookupFn call for that id.
+    const cachedAt = new Date(); // fresh
+    mGetMock.mockResolvedValue([{ id: 5, name: 'cached', cachedAt }]);
+    const lookupFn = vi.fn(async () => ({}) as Record<string, Row>);
+
+    const cache = createCachedArray<Row>({ key: 'test:hit' as never, idKey: 'id', lookupFn });
+    const result = await cache.fetch([5]);
+
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(result).toEqual([{ id: 5, name: 'cached' }]);
+  });
+});
+
+describe('createCachedObject.fetch — Redis read fail-open', () => {
+  it('returns the origin result keyed by id (not throws) when the redis read rejects', async () => {
+    mGetMock.mockRejectedValue(new Error('redis cluster command timed out after 3000ms'));
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
+    );
+
+    const cache = createCachedObject<Row>({ key: 'test:obj' as never, idKey: 'id', lookupFn });
+    const result = await cache.fetch([7, 8]);
+
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    expect(result['7']?.name).toBe('db-7');
+    expect(result['8']?.name).toBe('db-8');
+  });
+});

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -155,24 +155,81 @@ export function createCachedArray<T extends object>({
   // When a CLUSTER (cache) Redis read stalls/rejects — the #2556 socketTimeout (~10s) or
   // the #2611 command-deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS) — the cachedArray read
   // would otherwise throw uncaught → TRPCError → 500 (its mGet/set/del had NO try/catch,
-  // unlike fetchThroughCache). Instead degrade to a slow-but-working origin (DB) fetch of
-  // ALL requested ids and return it UNCACHED (we can't write while Redis is down). Single-
-  // flighted per (pod, key, id-set) via the shared failOpenInFlight map so a wedged client
-  // — which cold-misses MANY concurrent requests at once — can't stampede the DB. This is
-  // strictly no worse than today on these paths (a Redis stall already failed the request);
-  // it turns 500 into a slow 200. Mirrors fetchThroughCache's fail-open (cache-helpers.ts
-  // fetchThroughCacheFailOpen + the try/catch around redis.packed.get).
+  // unlike fetchThroughCache). Instead degrade to a slow-but-working origin (DB) fetch and
+  // return it UNCACHED (we can't write while Redis is down). It turns 500 into a slow 200.
+  // Mirrors fetchThroughCache's fail-open (cache-helpers.ts fetchThroughCacheFailOpen + the
+  // try/catch around redis.packed.get).
+  //
+  // STAMPEDE BOUND (PER-ID coalescing): the per-id-set single-flight (failOpenInFlight) only
+  // collapses IDENTICAL id-sets — but the hot callers pass per-feed-page id lists, so under a
+  // full wedge each distinct page would otherwise be a separate DB call → a read flood. To
+  // bound it independent of id-set, this fetch only DB-looks-up the ids for this `key` that
+  // are NOT already in flight on this pod (degradedIdInFlight) and AWAITS the in-flight
+  // promise for the rest. Overlapping pages thus share per-id results → per-(key, pod) DB
+  // load is bounded by distinct concurrent ids, not by distinct id-sets. No fixed cap → no
+  // queue, no caller blocked behind a saturated semaphore. A genuine lookupFn error rejects
+  // the per-id promises (so it still propagates) and every entry is deleted on settle.
   async function fetchFromOriginDegraded(distinctIds: number[]): Promise<T[]> {
-    const degradedResults = new Set<T>();
-    const dbResults: Record<string, T> = {};
-    // Same batching the cache-miss path uses (lookupFn capped at 10000 ids/call).
-    for (const batch of chunk(distinctIds, 10000)) {
-      const batchResults = await lookupFn([...batch] as number[]);
-      Object.assign(dbResults, batchResults);
-    }
+    // Partition the requested ids into ones already being fetched (degraded) on this pod and
+    // ones we must originate ourselves. Reuse the in-flight promise for the former.
+    const reused: Promise<T | undefined>[] = [];
+    const toFetch: number[] = [];
     for (const id of distinctIds) {
-      const result = dbResults[id];
-      if (result) degradedResults.add(result as T);
+      const existing = degradedIdInFlight.get(`${key}:id:${id}`) as
+        | Promise<T | undefined>
+        | undefined;
+      if (existing) reused.push(existing);
+      else toFetch.push(id);
+    }
+
+    // For the ids we must originate: register ONE shared per-id promise each, all backed by a
+    // SINGLE batched lookupFn call. A concurrent overlapping request will reuse these via the
+    // map above instead of issuing its own DB call. resolve/reject deferreds let us settle
+    // each per-id promise once the shared batch returns (or fails).
+    const resolvers = new Map<number, (v: T | undefined) => void>();
+    const rejecters = new Map<number, (e: unknown) => void>();
+    const owned: Promise<T | undefined>[] = [];
+    for (const id of toFetch) {
+      const mapKey = `${key}:id:${id}`;
+      const p = new Promise<T | undefined>((resolve, reject) => {
+        resolvers.set(id, resolve);
+        rejecters.set(id, reject);
+      });
+      // Delete the in-flight entry as soon as THIS id settles (success or error) — matches the
+      // failOpenInFlight .finally(delete) pattern so nothing leaks under a sustained wedge.
+      p.finally(() => {
+        // Only delete if we still own this entry (defensive against a later same-id round).
+        if (degradedIdInFlight.get(mapKey) === p) degradedIdInFlight.delete(mapKey);
+      }).catch(() => undefined);
+      degradedIdInFlight.set(mapKey, p);
+      owned.push(p);
+    }
+
+    if (toFetch.length > 0) {
+      // Same batching the cache-miss path uses (lookupFn capped at 10000 ids/call).
+      const dbResults: Record<string, T> = {};
+      try {
+        for (const batch of chunk(toFetch, 10000)) {
+          const batchResults = await lookupFn([...batch] as number[]);
+          Object.assign(dbResults, batchResults);
+        }
+      } catch (err) {
+        // Genuine origin/DB error: reject EVERY per-id promise we own so the error propagates
+        // to this caller AND any concurrent request that joined via the in-flight map (it is
+        // NOT swallowed). The .finally above removes each map entry.
+        for (const id of toFetch) rejecters.get(id)?.(err);
+        throw err;
+      }
+      // Settle each owned per-id promise with its value (or undefined when not found).
+      for (const id of toFetch) resolvers.get(id)?.(dbResults[id]);
+    }
+
+    // Await both the ids we fetched and the ids we reused from a concurrent in-flight fetch.
+    const settled = await Promise.all([...reused, ...owned]);
+
+    const degradedResults = new Set<T>();
+    for (const result of settled) {
+      if (result) degradedResults.add(result);
     }
     if (appendFn) await appendFn(degradedResults);
     return [...degradedResults].map((x) => {
@@ -199,7 +256,11 @@ export function createCachedArray<T extends object>({
       // Redis READ failed (cluster stall / socketTimeout / command-deadline). The
       // lookupFn itself is OUTSIDE this catch — a genuine DB/logic error from the origin
       // still propagates (matches fetchThroughCache, which never wraps fetchFn). Degrade
-      // to a single-flighted origin fetch instead of a 500.
+      // to an origin fetch instead of a 500, bounded against a DB stampede by TWO layers:
+      //   (1) outer per-id-set single-flight (failOpenInFlight) collapses IDENTICAL id-sets;
+      //   (2) inner per-ID coalescing inside fetchFromOriginDegraded (degradedIdInFlight)
+      //       collapses OVERLAPPING id-sets (the feed-page case) so per-(key, pod) DB load is
+      //       bounded by distinct concurrent ids, not by the number of distinct pages.
       logSysRedisFailOpen('read-degraded', `createCachedArray mGet (cache cluster) [${key}]`, err, {
         key,
         ids: distinctIds.length,
@@ -553,14 +614,49 @@ type FetchThroughCacheEntity<T> = { data: T; cachedAt: number };
  * thundering-herd — a worse cascade.
  *
  * This map degrades that gracefully: during a Redis stall, concurrent requests for the
- * SAME key on the SAME pod share ONE in-flight origin promise. That bounds origin load to
- * ≤ (distinct keys × pods) concurrent origin calls instead of unbounded (× per-request
- * concurrency). It is NOT cross-pod (that's what the Redis lock was for and Redis is down),
- * but it removes the per-pod multiplier, which is the dominant term under a request flood.
- * Entries are deleted as soon as the shared promise settles, so the map only ever holds
- * currently-degraded keys.
+ * SAME single-flight key on the SAME pod share ONE in-flight origin promise. For
+ * fetchThroughCache the key is the cache key, so this bounds origin load to ≤ (distinct
+ * keys × pods). For createCachedArray the key is per-(cache-key, id-SET), so on its own this
+ * collapses only IDENTICAL id-sets — NOT distinct-but-overlapping feed pages; that residual
+ * stampede is bounded by a SECOND, per-ID layer (degradedIdInFlight, above
+ * createCachedArray), which collapses overlapping id-sets so per-(key, pod) DB load is
+ * bounded by distinct concurrent ids. Together they remove the per-pod multiplier, which is
+ * the dominant term under a request flood. Neither is cross-pod (that's what the Redis lock
+ * was for and Redis is down). Entries are deleted as soon as the shared promise settles, so
+ * the map only ever holds currently-degraded keys.
  */
 const failOpenInFlight = new Map<string, Promise<unknown>>();
+
+/**
+ * Per-(pod, cache-key, id) single-flight map for the createCachedArray degraded
+ * (Redis-read-failed) origin fetch.
+ *
+ * WHY (the #2616 audit gap): the per-id-set single-flight above (failOpenInFlight, keyed
+ * `cachedArray-failopen:<key>:<sorted-id-set>`) only collapses requests for an IDENTICAL
+ * id-set. The hot consumers — imageMetaCache.fetch(imageIds) / tagIdsForImagesCache.fetch
+ * (image.service.ts) — pass PER-FEED-PAGE id lists, so under a full cluster wedge (when
+ * EVERY mGet fails) each distinct page is a distinct key → a separate origin DB call. That
+ * turns a 500-storm into a DB read flood ∝ (active feed pages × concurrency × ~80 pods).
+ *
+ * This map dedups at the INDIVIDUAL-ID granularity instead: during a wedge a degraded fetch
+ * only DB-fetches the ids for a given cache `key` that aren't ALREADY in flight on this pod,
+ * and awaits the existing in-flight promise for the rest. Because adjacent feed pages overlap
+ * heavily, this collapses OVERLAPPING id-sets — not just identical ones — so per-(key, pod)
+ * DB origin load is bounded by the count of DISTINCT ids currently being fetched, NOT by the
+ * number of distinct id-sets/pages that arrive. No fixed concurrency cap, so there is no
+ * queue to grow and no caller that waits behind a saturated semaphore: a caller either shares
+ * an in-flight promise or contributes its genuinely-missing ids to a single batched DB call.
+ *
+ * Entries are deleted as soon as their promise settles (success OR error), so the map only
+ * ever holds ids currently being fetched — no leak under a sustained wedge. A genuine
+ * lookupFn/DB error rejects the shared per-id promise (and is deleted), so it still
+ * propagates to every awaiting caller rather than being swallowed.
+ *
+ * REACHED ONLY on the redis-read-FAILED path (fetchFromOriginDegraded). On the healthy path
+ * `mGet` succeeds and this map is never touched — so it cannot affect normal traffic or
+ * healthy-path latency; it only shapes DB load during a wedge.
+ */
+const degradedIdInFlight = new Map<string, Promise<unknown>>();
 
 function fetchThroughCacheFailOpen<T>(key: string, fetchFn: () => Promise<T>): Promise<T> {
   const existing = failOpenInFlight.get(key) as Promise<T> | undefined;

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -10,8 +10,8 @@ import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 export type CacheTarget = 'main' | 'sys';
 
 // The clearCacheByPattern* helpers use only the cross-client methods
-// (scanIterator, del); typed as `any` here to bridge the cache vs sys key-template
-// generics without forcing every caller to know which client they're hitting.
+// (scanNodes/scanNodeStep, del); typed as `any` here to bridge the cache vs sys
+// key-template generics without forcing every caller to know which client they're hitting.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getCacheClient(target: CacheTarget = 'main'): any {
   return target === 'sys' ? sysRedis : redis;
@@ -762,6 +762,27 @@ export async function bustFetchThroughCache(key: RedisKeyTemplateCache) {
   await redis.packed.set(key, toCache, { KEEPTTL: true });
 }
 
+// Bounded retry-with-tiny-backoff for a single clipped (deadline-rejected) Redis
+// step inside the clearCacheByPattern* drain. A transient clip (a SCAN/del step
+// that exceeded REDIS_CLUSTER_COMMAND_TIMEOUT_MS on a memory-pressured shard) must
+// NOT abort the whole invalidation — we retry the SAME step a few times so a single
+// clip doesn't lose the iteration. On exhaustion the LAST error is thrown so the
+// caller can log + decide (best-effort continue), never an infinite loop.
+const SCAN_STEP_MAX_ATTEMPTS = 4; // initial try + 3 retries
+const SCAN_STEP_BACKOFF_MS = 50;
+async function withScanStepRetry<T>(step: () => Promise<T>): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < SCAN_STEP_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await step();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < SCAN_STEP_MAX_ATTEMPTS - 1) await sleep(SCAN_STEP_BACKOFF_MS * (attempt + 1));
+    }
+  }
+  throw lastErr;
+}
+
 /**
  * ⚠️ DANGER — DO NOT call on a hot path (per-request / per-mutation cache busts).
  *
@@ -793,30 +814,93 @@ export async function clearCacheByPattern(
   const cleared: string[] = [];
 
   if (!pattern.includes('*')) {
-    await client.del(pattern);
-    cleared.push(pattern);
+    // Exact key — retry a clipped del so a single transient clip doesn't leave it stale.
+    try {
+      await withScanStepRetry(() => client.del(pattern));
+      cleared.push(pattern);
+    } catch (err) {
+      // Surface (don't pretend success): an exact-key bust that fully failed is a
+      // stale-key gap. Best-effort: log + return what we cleared (nothing here).
+      logSysRedisFailOpen('write-degraded', `clearCacheByPattern del (exact) [${pattern}]`, err, {
+        pattern,
+        partial: true,
+        target,
+      });
+    }
     onProgress?.(cleared.length);
     return cleared;
   }
 
-  // Use cluster's scanIterator which handles scanning all nodes
+  // Drive SCAN node-by-node with an EXPLICIT cursor (scanNodes/scanNodeStep) so a
+  // deadline-clipped SCAN step can be retried from the SAME cursor (bounded) instead
+  // of killing the iterator mid-keyspace and leaving matching keys un-deleted (the
+  // residual stale-cache risk this guards against). On exhausted retries we log
+  // loudly with the node+cursor and continue best-effort (clear as much as possible),
+  // rather than silently aborting the whole invalidation.
   log('Scanning cache with pattern:', pattern, 'target:', target);
-  const stream = client.scanIterator({ MATCH: pattern, COUNT: 10000 });
+  const clearedSet = new Set<string>();
+  const nodes = await client.scanNodes();
 
-  for await (const keys of stream) {
-    const newKeys = (keys as RedisKeyTemplates[]).filter((key) => !cleared.includes(key));
-    log('Total keys:', cleared.length, 'Adding:', newKeys.length);
-    if (newKeys.length === 0) continue;
+  for (const node of nodes) {
+    let cursor = '0';
+    do {
+      let step: { keys: string[]; cursor: string };
+      try {
+        const startCursor = cursor;
+        step = await withScanStepRetry(() =>
+          client.scanNodeStep(node, startCursor, { MATCH: pattern, COUNT: 10000 })
+        );
+      } catch (err) {
+        // SCAN step still clipped after bounded retries — we cannot safely advance
+        // this node's cursor (we'd skip the unscanned tail). Surface the gap and
+        // move on to the next node best-effort. The unscanned keys survive to TTL.
+        logSysRedisFailOpen('write-degraded', `clearCacheByPattern SCAN [${pattern}]`, err, {
+          pattern,
+          node: node.id,
+          cursor,
+          partial: true,
+          target,
+        });
+        break;
+      }
+      cursor = step.cursor;
 
-    const batches = chunk(newKeys, 10000);
-    for (let i = 0; i < batches.length; i++) {
-      log('Clearing batch:', i + 1, 'of', batches.length);
-      // Delete keys one at a time to avoid CROSSSLOT errors on the main cluster.
-      await Promise.all(batches[i].map((key) => client.del(key)));
-      cleared.push(...batches[i]);
-      log('Cleared batch:', i + 1, 'of', batches.length);
-      onProgress?.(cleared.length);
-    }
+      const newKeys = (step.keys as RedisKeyTemplates[]).filter((key) => !clearedSet.has(key));
+      log('Total keys:', clearedSet.size, 'Adding:', newKeys.length);
+      if (newKeys.length === 0) continue;
+
+      const batches = chunk(newKeys, 10000);
+      for (let i = 0; i < batches.length; i++) {
+        log('Clearing batch:', i + 1, 'of', batches.length);
+        // Delete keys one at a time to avoid CROSSSLOT errors on the main cluster.
+        // Retry a clipped del per-key so a transient clip doesn't drop the key.
+        const results = await Promise.allSettled(
+          batches[i].map((key) =>
+            withScanStepRetry(() => client.del(key)).then(() => key)
+          )
+        );
+        for (let j = 0; j < results.length; j++) {
+          const r = results[j];
+          if (r.status === 'fulfilled') {
+            if (!clearedSet.has(r.value)) {
+              clearedSet.add(r.value);
+              cleared.push(r.value);
+            }
+          } else {
+            // A key whose del exhausted retries — log it (stale) and keep going.
+            logSysRedisFailOpen('write-degraded', `clearCacheByPattern del [${pattern}]`, r.reason, {
+              pattern,
+              key: batches[i][j],
+              node: node.id,
+              partial: true,
+              target,
+            });
+          }
+        }
+        log('Cleared batch:', i + 1, 'of', batches.length);
+        onProgress?.(cleared.length);
+      }
+    } while (cursor !== '0');
   }
 
   log('Done clearing cache. Total cleared:', cleared.length);
@@ -855,38 +939,89 @@ export async function clearCacheByPatterns(
   const exact = perPattern.filter((p) => !p.pattern.includes('*'));
   const globbed = perPattern.filter((p) => p.pattern.includes('*'));
 
-  // Fast path for exact keys — no scan needed.
+  // Fast path for exact keys — no scan needed. Retry a clipped del; log + continue
+  // (don't abort the whole multi-pattern bust) if it fully fails.
   for (const p of exact) {
-    await client.del(p.pattern as RedisKeyTemplates);
-    p.cleared.push(p.pattern);
+    try {
+      await withScanStepRetry(() => client.del(p.pattern as RedisKeyTemplates));
+      p.cleared.push(p.pattern);
+    } catch (err) {
+      logSysRedisFailOpen(
+        'write-degraded',
+        `clearCacheByPatterns del (exact) [${p.pattern}]`,
+        err,
+        { pattern: p.pattern, partial: true, target }
+      );
+    }
   }
 
   if (globbed.length > 0) {
+    // Single-pass drain across all nodes with an EXPLICIT cursor (see
+    // clearCacheByPattern) so a deadline-clipped SCAN step is retried/resumed
+    // rather than killing the whole pass and leaving matching keys stale.
     log('Scanning cache for', globbed.length, 'patterns in a single pass, target:', target);
-    const stream = client.scanIterator({ MATCH: '*', COUNT: 10000 });
+    const nodes = await client.scanNodes();
 
-    for await (const keys of stream) {
-      const toDelete: RedisKeyTemplates[] = [];
-      for (const key of keys as RedisKeyTemplates[]) {
-        for (const p of globbed) {
-          if (p.regex.test(key)) {
-            p.cleared.push(key);
-            toDelete.push(key);
-            break;
+    for (const node of nodes) {
+      let cursor = '0';
+      do {
+        let step: { keys: string[]; cursor: string };
+        try {
+          const startCursor = cursor;
+          step = await withScanStepRetry(() =>
+            client.scanNodeStep(node, startCursor, { MATCH: '*', COUNT: 10000 })
+          );
+        } catch (err) {
+          // SCAN step clipped past retries — surface the gap (every globbed pattern
+          // may be under-cleared on this node's unscanned tail) and continue.
+          logSysRedisFailOpen('write-degraded', 'clearCacheByPatterns SCAN', err, {
+            patterns: globbed.map((p) => p.pattern),
+            node: node.id,
+            cursor,
+            partial: true,
+            target,
+          });
+          break;
+        }
+        cursor = step.cursor;
+
+        const toDelete: { key: RedisKeyTemplates; bucket: (typeof globbed)[number] }[] = [];
+        for (const key of step.keys as RedisKeyTemplates[]) {
+          for (const p of globbed) {
+            if (p.regex.test(key)) {
+              toDelete.push({ key, bucket: p });
+              break;
+            }
           }
         }
-      }
-      if (toDelete.length === 0) continue;
+        if (toDelete.length === 0) continue;
 
-      const batches = chunk(toDelete, 10000);
-      for (const batch of batches) {
-        await Promise.all(batch.map((key) => client.del(key)));
-      }
-      const total = perPattern.reduce((s, p) => s + p.cleared.length, 0);
-      onProgress?.({
-        total,
-        perPattern: perPattern.map((p) => ({ pattern: p.pattern, cleared: p.cleared.length })),
-      });
+        const batches = chunk(toDelete, 10000);
+        for (const batch of batches) {
+          const results = await Promise.allSettled(
+            batch.map((entry) => withScanStepRetry(() => client.del(entry.key)).then(() => entry))
+          );
+          for (let j = 0; j < results.length; j++) {
+            const r = results[j];
+            if (r.status === 'fulfilled') {
+              r.value.bucket.cleared.push(r.value.key);
+            } else {
+              logSysRedisFailOpen('write-degraded', 'clearCacheByPatterns del', r.reason, {
+                key: batch[j].key,
+                pattern: batch[j].bucket.pattern,
+                node: node.id,
+                partial: true,
+                target,
+              });
+            }
+          }
+        }
+        const total = perPattern.reduce((s, p) => s + p.cleared.length, 0);
+        onProgress?.({
+          total,
+          perPattern: perPattern.map((p) => ({ pattern: p.pattern, cleared: p.cleared.length })),
+        });
+      } while (cursor !== '0');
     }
   } else {
     const total = perPattern.reduce((s, p) => s + p.cleared.length, 0);

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -10,8 +10,8 @@ import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 export type CacheTarget = 'main' | 'sys';
 
 // The clearCacheByPattern* helpers use only the cross-client methods
-// (scanNodes/scanNodeStep, del); typed as `any` here to bridge the cache vs sys
-// key-template generics without forcing every caller to know which client they're hitting.
+// (scanIterator, del); typed as `any` here to bridge the cache vs sys key-template
+// generics without forcing every caller to know which client they're hitting.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getCacheClient(target: CacheTarget = 'main'): any {
   return target === 'sys' ? sysRedis : redis;
@@ -762,27 +762,6 @@ export async function bustFetchThroughCache(key: RedisKeyTemplateCache) {
   await redis.packed.set(key, toCache, { KEEPTTL: true });
 }
 
-// Bounded retry-with-tiny-backoff for a single clipped (deadline-rejected) Redis
-// step inside the clearCacheByPattern* drain. A transient clip (a SCAN/del step
-// that exceeded REDIS_CLUSTER_COMMAND_TIMEOUT_MS on a memory-pressured shard) must
-// NOT abort the whole invalidation — we retry the SAME step a few times so a single
-// clip doesn't lose the iteration. On exhaustion the LAST error is thrown so the
-// caller can log + decide (best-effort continue), never an infinite loop.
-const SCAN_STEP_MAX_ATTEMPTS = 4; // initial try + 3 retries
-const SCAN_STEP_BACKOFF_MS = 50;
-async function withScanStepRetry<T>(step: () => Promise<T>): Promise<T> {
-  let lastErr: unknown;
-  for (let attempt = 0; attempt < SCAN_STEP_MAX_ATTEMPTS; attempt++) {
-    try {
-      return await step();
-    } catch (err) {
-      lastErr = err;
-      if (attempt < SCAN_STEP_MAX_ATTEMPTS - 1) await sleep(SCAN_STEP_BACKOFF_MS * (attempt + 1));
-    }
-  }
-  throw lastErr;
-}
-
 /**
  * ⚠️ DANGER — DO NOT call on a hot path (per-request / per-mutation cache busts).
  *
@@ -814,93 +793,30 @@ export async function clearCacheByPattern(
   const cleared: string[] = [];
 
   if (!pattern.includes('*')) {
-    // Exact key — retry a clipped del so a single transient clip doesn't leave it stale.
-    try {
-      await withScanStepRetry(() => client.del(pattern));
-      cleared.push(pattern);
-    } catch (err) {
-      // Surface (don't pretend success): an exact-key bust that fully failed is a
-      // stale-key gap. Best-effort: log + return what we cleared (nothing here).
-      logSysRedisFailOpen('write-degraded', `clearCacheByPattern del (exact) [${pattern}]`, err, {
-        pattern,
-        partial: true,
-        target,
-      });
-    }
+    await client.del(pattern);
+    cleared.push(pattern);
     onProgress?.(cleared.length);
     return cleared;
   }
 
-  // Drive SCAN node-by-node with an EXPLICIT cursor (scanNodes/scanNodeStep) so a
-  // deadline-clipped SCAN step can be retried from the SAME cursor (bounded) instead
-  // of killing the iterator mid-keyspace and leaving matching keys un-deleted (the
-  // residual stale-cache risk this guards against). On exhausted retries we log
-  // loudly with the node+cursor and continue best-effort (clear as much as possible),
-  // rather than silently aborting the whole invalidation.
+  // Use cluster's scanIterator which handles scanning all nodes
   log('Scanning cache with pattern:', pattern, 'target:', target);
-  const clearedSet = new Set<string>();
-  const nodes = await client.scanNodes();
+  const stream = client.scanIterator({ MATCH: pattern, COUNT: 10000 });
 
-  for (const node of nodes) {
-    let cursor = '0';
-    do {
-      let step: { keys: string[]; cursor: string };
-      try {
-        const startCursor = cursor;
-        step = await withScanStepRetry(() =>
-          client.scanNodeStep(node, startCursor, { MATCH: pattern, COUNT: 10000 })
-        );
-      } catch (err) {
-        // SCAN step still clipped after bounded retries — we cannot safely advance
-        // this node's cursor (we'd skip the unscanned tail). Surface the gap and
-        // move on to the next node best-effort. The unscanned keys survive to TTL.
-        logSysRedisFailOpen('write-degraded', `clearCacheByPattern SCAN [${pattern}]`, err, {
-          pattern,
-          node: node.id,
-          cursor,
-          partial: true,
-          target,
-        });
-        break;
-      }
-      cursor = step.cursor;
+  for await (const keys of stream) {
+    const newKeys = (keys as RedisKeyTemplates[]).filter((key) => !cleared.includes(key));
+    log('Total keys:', cleared.length, 'Adding:', newKeys.length);
+    if (newKeys.length === 0) continue;
 
-      const newKeys = (step.keys as RedisKeyTemplates[]).filter((key) => !clearedSet.has(key));
-      log('Total keys:', clearedSet.size, 'Adding:', newKeys.length);
-      if (newKeys.length === 0) continue;
-
-      const batches = chunk(newKeys, 10000);
-      for (let i = 0; i < batches.length; i++) {
-        log('Clearing batch:', i + 1, 'of', batches.length);
-        // Delete keys one at a time to avoid CROSSSLOT errors on the main cluster.
-        // Retry a clipped del per-key so a transient clip doesn't drop the key.
-        const results = await Promise.allSettled(
-          batches[i].map((key) =>
-            withScanStepRetry(() => client.del(key)).then(() => key)
-          )
-        );
-        for (let j = 0; j < results.length; j++) {
-          const r = results[j];
-          if (r.status === 'fulfilled') {
-            if (!clearedSet.has(r.value)) {
-              clearedSet.add(r.value);
-              cleared.push(r.value);
-            }
-          } else {
-            // A key whose del exhausted retries — log it (stale) and keep going.
-            logSysRedisFailOpen('write-degraded', `clearCacheByPattern del [${pattern}]`, r.reason, {
-              pattern,
-              key: batches[i][j],
-              node: node.id,
-              partial: true,
-              target,
-            });
-          }
-        }
-        log('Cleared batch:', i + 1, 'of', batches.length);
-        onProgress?.(cleared.length);
-      }
-    } while (cursor !== '0');
+    const batches = chunk(newKeys, 10000);
+    for (let i = 0; i < batches.length; i++) {
+      log('Clearing batch:', i + 1, 'of', batches.length);
+      // Delete keys one at a time to avoid CROSSSLOT errors on the main cluster.
+      await Promise.all(batches[i].map((key) => client.del(key)));
+      cleared.push(...batches[i]);
+      log('Cleared batch:', i + 1, 'of', batches.length);
+      onProgress?.(cleared.length);
+    }
   }
 
   log('Done clearing cache. Total cleared:', cleared.length);
@@ -939,89 +855,38 @@ export async function clearCacheByPatterns(
   const exact = perPattern.filter((p) => !p.pattern.includes('*'));
   const globbed = perPattern.filter((p) => p.pattern.includes('*'));
 
-  // Fast path for exact keys — no scan needed. Retry a clipped del; log + continue
-  // (don't abort the whole multi-pattern bust) if it fully fails.
+  // Fast path for exact keys — no scan needed.
   for (const p of exact) {
-    try {
-      await withScanStepRetry(() => client.del(p.pattern as RedisKeyTemplates));
-      p.cleared.push(p.pattern);
-    } catch (err) {
-      logSysRedisFailOpen(
-        'write-degraded',
-        `clearCacheByPatterns del (exact) [${p.pattern}]`,
-        err,
-        { pattern: p.pattern, partial: true, target }
-      );
-    }
+    await client.del(p.pattern as RedisKeyTemplates);
+    p.cleared.push(p.pattern);
   }
 
   if (globbed.length > 0) {
-    // Single-pass drain across all nodes with an EXPLICIT cursor (see
-    // clearCacheByPattern) so a deadline-clipped SCAN step is retried/resumed
-    // rather than killing the whole pass and leaving matching keys stale.
     log('Scanning cache for', globbed.length, 'patterns in a single pass, target:', target);
-    const nodes = await client.scanNodes();
+    const stream = client.scanIterator({ MATCH: '*', COUNT: 10000 });
 
-    for (const node of nodes) {
-      let cursor = '0';
-      do {
-        let step: { keys: string[]; cursor: string };
-        try {
-          const startCursor = cursor;
-          step = await withScanStepRetry(() =>
-            client.scanNodeStep(node, startCursor, { MATCH: '*', COUNT: 10000 })
-          );
-        } catch (err) {
-          // SCAN step clipped past retries — surface the gap (every globbed pattern
-          // may be under-cleared on this node's unscanned tail) and continue.
-          logSysRedisFailOpen('write-degraded', 'clearCacheByPatterns SCAN', err, {
-            patterns: globbed.map((p) => p.pattern),
-            node: node.id,
-            cursor,
-            partial: true,
-            target,
-          });
-          break;
-        }
-        cursor = step.cursor;
-
-        const toDelete: { key: RedisKeyTemplates; bucket: (typeof globbed)[number] }[] = [];
-        for (const key of step.keys as RedisKeyTemplates[]) {
-          for (const p of globbed) {
-            if (p.regex.test(key)) {
-              toDelete.push({ key, bucket: p });
-              break;
-            }
+    for await (const keys of stream) {
+      const toDelete: RedisKeyTemplates[] = [];
+      for (const key of keys as RedisKeyTemplates[]) {
+        for (const p of globbed) {
+          if (p.regex.test(key)) {
+            p.cleared.push(key);
+            toDelete.push(key);
+            break;
           }
         }
-        if (toDelete.length === 0) continue;
+      }
+      if (toDelete.length === 0) continue;
 
-        const batches = chunk(toDelete, 10000);
-        for (const batch of batches) {
-          const results = await Promise.allSettled(
-            batch.map((entry) => withScanStepRetry(() => client.del(entry.key)).then(() => entry))
-          );
-          for (let j = 0; j < results.length; j++) {
-            const r = results[j];
-            if (r.status === 'fulfilled') {
-              r.value.bucket.cleared.push(r.value.key);
-            } else {
-              logSysRedisFailOpen('write-degraded', 'clearCacheByPatterns del', r.reason, {
-                key: batch[j].key,
-                pattern: batch[j].bucket.pattern,
-                node: node.id,
-                partial: true,
-                target,
-              });
-            }
-          }
-        }
-        const total = perPattern.reduce((s, p) => s + p.cleared.length, 0);
-        onProgress?.({
-          total,
-          perPattern: perPattern.map((p) => ({ pattern: p.pattern, cleared: p.cleared.length })),
-        });
-      } while (cursor !== '0');
+      const batches = chunk(toDelete, 10000);
+      for (const batch of batches) {
+        await Promise.all(batch.map((key) => client.del(key)));
+      }
+      const total = perPattern.reduce((s, p) => s + p.cleared.length, 0);
+      onProgress?.({
+        total,
+        perPattern: perPattern.map((p) => ({ pattern: p.pattern, cleared: p.cleared.length })),
+      });
     }
   } else {
     const total = perPattern.reduce((s, p) => s + p.cleared.length, 0);

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -151,15 +151,66 @@ export function createCachedArray<T extends object>({
   staleWhileRevalidate = true,
   staleWhileRevalidateTtl,
 }: CachedLookupOptions<T>) {
+  // --- Fail-open origin path (Redis-stall degradation) -------------------------------
+  // When a CLUSTER (cache) Redis read stalls/rejects — the #2556 socketTimeout (~10s) or
+  // the #2611 command-deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS) — the cachedArray read
+  // would otherwise throw uncaught → TRPCError → 500 (its mGet/set/del had NO try/catch,
+  // unlike fetchThroughCache). Instead degrade to a slow-but-working origin (DB) fetch of
+  // ALL requested ids and return it UNCACHED (we can't write while Redis is down). Single-
+  // flighted per (pod, key, id-set) via the shared failOpenInFlight map so a wedged client
+  // — which cold-misses MANY concurrent requests at once — can't stampede the DB. This is
+  // strictly no worse than today on these paths (a Redis stall already failed the request);
+  // it turns 500 into a slow 200. Mirrors fetchThroughCache's fail-open (cache-helpers.ts
+  // fetchThroughCacheFailOpen + the try/catch around redis.packed.get).
+  async function fetchFromOriginDegraded(distinctIds: number[]): Promise<T[]> {
+    const degradedResults = new Set<T>();
+    const dbResults: Record<string, T> = {};
+    // Same batching the cache-miss path uses (lookupFn capped at 10000 ids/call).
+    for (const batch of chunk(distinctIds, 10000)) {
+      const batchResults = await lookupFn([...batch] as number[]);
+      Object.assign(dbResults, batchResults);
+    }
+    for (const id of distinctIds) {
+      const result = dbResults[id];
+      if (result) degradedResults.add(result as T);
+    }
+    if (appendFn) await appendFn(degradedResults);
+    return [...degradedResults].map((x) => {
+      // Strip the internal cachedAt the same way the normal return does (degraded
+      // results from lookupFn won't have it, but a future appendFn might attach one).
+      if ('cachedAt' in x) delete x.cachedAt;
+      return x;
+    });
+  }
+
   async function fetch(ids: number[]) {
     if (!ids.length) return [] as T[];
+    const distinctIds = [...new Set(ids)];
     const results = new Set<T>();
     const cacheResults: T[] = [];
-    for (const batch of chunk([...new Set(ids)], 200)) {
-      const batchResults = await redis.packed.mGet<T>(
-        batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache)
+    try {
+      for (const batch of chunk(distinctIds, 200)) {
+        const batchResults = await redis.packed.mGet<T>(
+          batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache)
+        );
+        cacheResults.push(...batchResults.filter(isDefined));
+      }
+    } catch (err) {
+      // Redis READ failed (cluster stall / socketTimeout / command-deadline). The
+      // lookupFn itself is OUTSIDE this catch — a genuine DB/logic error from the origin
+      // still propagates (matches fetchThroughCache, which never wraps fetchFn). Degrade
+      // to a single-flighted origin fetch instead of a 500.
+      logSysRedisFailOpen('read-degraded', `createCachedArray mGet (cache cluster) [${key}]`, err, {
+        key,
+        ids: distinctIds.length,
+      });
+      return fetchThroughCacheFailOpen(
+        // Stable per-(pod, key, id-set) single-flight key. Sorted so id order doesn't
+        // fragment the in-flight share; the id-set scopes it so distinct fetches don't
+        // collide on the same `key`.
+        `cachedArray-failopen:${key}:${[...distinctIds].sort((a, b) => a - b).join(',')}`,
+        () => fetchFromOriginDegraded(distinctIds)
       );
-      cacheResults.push(...batchResults.filter(isDefined));
     }
     const cacheArray = cacheResults.filter((x) => x !== null) as T[];
     const cache = Object.fromEntries(cacheArray.map((x) => [x[idKey], x]));
@@ -171,7 +222,7 @@ export function createCachedArray<T extends object>({
     const ttlExpiry = new Date(Date.now() - ttl * 1000);
     const locks = new Set<RedisKeyTemplateCache>();
     let cacheHits = 0;
-    for (const id of [...new Set(ids)]) {
+    for (const id of distinctIds) {
       const cached = cache[id];
       if (cached) {
         if (cached.notFound) continue;
@@ -202,11 +253,26 @@ export function createCachedArray<T extends object>({
         toRevalidateIds.length
       );
 
-      const gotLocks = await Promise.all(
-        toRevalidateIds.map((id) =>
-          redis.setNxKeepTtlWithEx(`${REDIS_KEYS.CACHE_LOCKS}:${key}:${id}`, '1', 10)
-        )
-      );
+      let gotLocks: boolean[];
+      try {
+        gotLocks = await Promise.all(
+          toRevalidateIds.map((id) =>
+            redis.setNxKeepTtlWithEx(`${REDIS_KEYS.CACHE_LOCKS}:${key}:${id}`, '1', 10)
+          )
+        );
+      } catch (err) {
+        // Lock acquisition (a Redis WRITE) hit a cluster error. We already have a
+        // fresh-enough stale value for every toRevalidate id; serve it rather than
+        // 500. Mirrors fetchThroughCache's lock-error path (serve stale if we have
+        // it). The revalidation just doesn't happen this pass — cheap + correct.
+        logSysRedisFailOpen(
+          'write-degraded',
+          `createCachedArray revalidate-lock (cache cluster) [${key}]`,
+          err,
+          { key, ids: toRevalidateIds.length }
+        );
+        gotLocks = toRevalidateIds.map(() => false);
+      }
       for (let i = 0; i < toRevalidateIds.length; i++) {
         const id = toRevalidateIds[i];
         if (!gotLocks[i]) {
@@ -257,31 +323,49 @@ export function createCachedArray<T extends object>({
         cacheMissCounter.inc({ cache_name: key, cache_type: 'cachedArray' }, actualMisses);
       }
 
-      // then cache the results
+      // then cache the results. The DB lookup above already SUCCEEDED — a Redis WRITE
+      // failure here (cluster stall) must NOT turn a good origin fetch into a 500. Swallow
+      // it best-effort (the entry just isn't cached this pass); mirrors fetchThroughCache's
+      // best-effort set (cache-helpers.ts: the try/catch around redis.packed.set).
       const EX = resolveCacheExpiry(ttl, staleWhileRevalidate, staleWhileRevalidateTtl);
-      if (Object.keys(toCache).length > 0)
-        await Promise.all(
-          Object.entries(toCache).map(([id, cache]) =>
-            redis.packed.set(`${key}:${id}`, cache, { EX })
-          )
-        );
+      try {
+        if (Object.keys(toCache).length > 0)
+          await Promise.all(
+            Object.entries(toCache).map(([id, cache]) =>
+              redis.packed.set(`${key}:${id}`, cache, { EX })
+            )
+          );
 
-      // Use NX to avoid overwriting a value with a not found...
-      // notFoundTtl lets a caller cap negative-cache lifetime separately from
-      // positive results — useful when an empty lookupFn result is likely to
-      // be transient (async ingestion, replication lag) rather than truly empty.
-      if (Object.keys(toCacheNotFound).length > 0) {
-        const notFoundEX = notFoundTtl ?? EX;
-        await Promise.all(
-          Object.entries(toCacheNotFound).map(([id, cache]) =>
-            redis.packed.set(`${key}:${id}`, cache, { EX: notFoundEX, NX: true })
-          )
-        );
+        // Use NX to avoid overwriting a value with a not found...
+        // notFoundTtl lets a caller cap negative-cache lifetime separately from
+        // positive results — useful when an empty lookupFn result is likely to
+        // be transient (async ingestion, replication lag) rather than truly empty.
+        if (Object.keys(toCacheNotFound).length > 0) {
+          const notFoundEX = notFoundTtl ?? EX;
+          await Promise.all(
+            Object.entries(toCacheNotFound).map(([id, cache]) =>
+              redis.packed.set(`${key}:${id}`, cache, { EX: notFoundEX, NX: true })
+            )
+          );
+        }
+      } catch (err) {
+        logSysRedisFailOpen('write-degraded', `createCachedArray set (cache cluster) [${key}]`, err, {
+          key,
+        });
       }
     }
 
-    // Remove locks
-    if (locks.size > 0) await redis.del([...locks]);
+    // Remove locks (best-effort: a failed del just leaves the lock to expire via its
+    // 10s TTL — never let it mask the successful fetch result).
+    if (locks.size > 0)
+      await redis.del([...locks]).catch((err) =>
+        logSysRedisFailOpen(
+          'write-degraded',
+          `createCachedArray del-locks (cache cluster) [${key}]`,
+          err,
+          { key }
+        )
+      );
 
     if (appendFn) await appendFn(results);
 
@@ -453,25 +537,28 @@ type FetchThroughCacheOptions = {
 type FetchThroughCacheEntity<T> = { data: T; cachedAt: number };
 
 /**
- * Per-pod (per-process) single-flight map for the fail-open path ONLY.
+ * Per-pod (per-process) single-flight map for the cache fail-open paths.
  *
- * fetchThroughCache normally prevents an origin (DB/ClickHouse) stampede with a
- * REDIS-backed distributed lock: only the lock-winner runs `fetchFn`, everyone else
- * serves stale or waits. But that lock lives IN Redis — so when Redis itself stalls
- * (the PR #2556 socketTimeout now turns a stalled read into a ~10s throw instead of a
- * 30s-504), the lock is unreachable and the cross-pod single-flight is GONE. Several
- * fetchThroughCache `fetchFn`s are expensive DB/ClickHouse aggregations (buzz pool
- * SUM scans, featured-models, mod-rules, creator-program pool math). Naively
- * catch-and-call-fetchFn on every request across ~80 pods would convert a Redis
- * problem into a DB thundering-herd — a worse cascade.
+ * Both fetchThroughCache AND createCachedObject/Array.fetch normally prevent an origin
+ * (DB/ClickHouse) stampede with a REDIS-backed mechanism: fetchThroughCache uses a
+ * distributed lock (only the lock-winner runs `fetchFn`); the cachedArray path relies on
+ * the Redis cache itself absorbing the read. But those mechanisms live IN Redis — so when
+ * Redis itself stalls (the PR #2556 socketTimeout / #2611 command-deadline now turn a
+ * stalled read into a ~10s/15s throw instead of a 30s-504 or a 125s hang), the lock is
+ * unreachable and the cache returns nothing: the cross-request single-flight is GONE.
+ * Several origin fetches here are expensive (fetchThroughCache: buzz pool SUM scans,
+ * featured-models, mod-rules; cachedObject lookupFns: tag.getAll, user.getCreator,
+ * comment.getAll, image-meta, tag-ids-for-images DB queries). Naively catch-and-call the
+ * origin on every request across ~80 pods would convert a Redis problem into a DB
+ * thundering-herd — a worse cascade.
  *
- * This map degrades that gracefully: during a Redis outage, concurrent requests for
- * the SAME key on the SAME pod share ONE in-flight `fetchFn()` promise. That bounds
- * origin load to ≤ (distinct keys × pods) concurrent origin calls instead of
- * unbounded (× per-request concurrency). It is NOT cross-pod (that's what the Redis
- * lock was for and Redis is down), but it removes the per-pod multiplier, which is the
- * dominant term under a request flood. Entries are deleted as soon as the shared
- * promise settles, so the map only ever holds currently-degraded keys.
+ * This map degrades that gracefully: during a Redis stall, concurrent requests for the
+ * SAME key on the SAME pod share ONE in-flight origin promise. That bounds origin load to
+ * ≤ (distinct keys × pods) concurrent origin calls instead of unbounded (× per-request
+ * concurrency). It is NOT cross-pod (that's what the Redis lock was for and Redis is down),
+ * but it removes the per-pod multiplier, which is the dominant term under a request flood.
+ * Entries are deleted as soon as the shared promise settles, so the map only ever holds
+ * currently-degraded keys.
  */
 const failOpenInFlight = new Map<string, Promise<unknown>>();
 


### PR DESCRIPTION
## What this does
Two cache-resilience fixes for the next-redis-cluster client wedge class:

1. **Fail-open `createCachedObject`/`createCachedArray.fetch`** — on a cluster read stall/reject (incl. the #2611 command-deadline), degrade to the origin (`lookupFn`/DB) → **slow-200 instead of 500**. Closes the gap where a wedged pod's cache reads 500'd (the createCachedObject path was not fail-open, unlike `fetchThroughCache`).
2. **Per-ID coalescing on the degraded path** — a module-level `degradedIdInFlight` map dedups by individual ID across concurrent overlapping id-sets, so a wedge can't flood the DB with per-feed-page point lookups (bounds per-(key,pod) origin load to distinct concurrent IDs). Reached ONLY from the redis-read-failure catch → zero healthy-path impact.
3. **Lower `REDIS_CLUSTER_COMMAND_TIMEOUT_MS` 15s→3s** — a stuck command parks ~3s instead of 15s; safe because Fix #1 turns a deadline-reject into a slow-200 (22× headroom over the ~137ms SLOWLOG max).

## Audited
Two adversarial passes (read-only). The per-ID coalescing was empirically verified (18/18 incl. joiner-error-propagation, no-leak, absent-id, TOCTOU-free check-and-register, complete/correct assembly). Verdict: **safe to merge, no deploy-blockers.**

## Known residual (consciously accepted — NOT hardened here)
The 3s deadline also clips `clearCacheByPattern`'s SCAN/del (no fail-open) → a clipped step could leave a partial invalidation (stale-to-TTL). Low probability (SCAN normally sub-100ms). A hardening was prototyped but **reverted** — it introduced new mock-only cluster-scan code (a worse risk than the rare clip). Separate follow-up; watch `write-degraded` logs post-deploy.

## Post-deploy verification
- Cluster-timeout 500s → ~0 (wedge degrades to slow-200).
- DB read-QPS stays bounded under the next wedge (coalescing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)