### PR TITLE
fix(cache): fail-open createCachedArray/Object.fetch on cluster-read reject

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -131,24 +131,25 @@ export const serverSchema = z.object({
   // has rejected stuck commands down these paths since #2556): BOTH fetchThroughCache AND
   // createCachedObject/Array.fetch now catch it and fail-open (degraded origin fetch → slow
   // 200, bounded against a DB stampede by per-id single-flight — see cache-helpers.ts
-  // degradedIdInFlight). createCachedArray.fetch was made fail-open in the SAME change that
-  // lowered this default — that fail-open is THIS deadline's safety net: before it, a
-  // deadline-reject down a cachedObject read propagated as a 500 (a 68-min two-pod 500 spike
-  // on 2026-06-17). Correct regardless of the exact node-redis internal cause.
+  // degradedIdInFlight). createCachedArray.fetch was made fail-open so this reject degrades
+  // rather than 500ing: before it, a deadline-reject down a cachedObject read propagated as a
+  // 500 (a 68-min two-pod 500 spike on 2026-06-17). Correct regardless of the exact node-redis
+  // internal cause.
   //
-  // Default 3000 (3s): the cachedArray `mGet` is a Promise.all of individual per-key GETs
-  // (client.ts packed.mGet), each independently wrapped by instrumentCommands — so no single
-  // wrapped command is a large multi-key op, and 3s is ~22× the ~137ms healthy-completion p99
-  // (SLOWLOG max; p50 sub-ms): it will not clip a legitimate command. BELOW
-  // REDIS_SOCKET_TIMEOUT_MS (10s) so the deadline (not socketTimeout) is now the EFFECTIVE cap
-  // — it unparks a stuck handler in 3s instead of 10s/125s. SAFE to be this aggressive ONLY
-  // because the fail-open above turns a deadline-reject into a slow 200 rather than a 500.
-  // Env-tunable, so it can be raised at runtime without a deploy if it ever clips. 0 disables
-  // it. Cluster-scoped: the SYSTEM client is untouched (it uses REDIS_SYS_READ_TIMEOUT_MS —
-  // see the #2556/#2586 sys-client regression). See redis/command-deadline.ts
-  // withCommandDeadline() + instrumentCommands() and utils/cache-helpers.ts
-  // (fetchThroughCache + createCachedArray fail-open).
-  REDIS_CLUSTER_COMMAND_TIMEOUT_MS: z.coerce.number().default(3000),
+  // Default 15000 (15s): ~650× over the ~23ms healthy-completion p99 (zero risk of clipping a
+  // legitimate slow command) and well below the ~125s client ceiling. Sits ABOVE
+  // REDIS_SOCKET_TIMEOUT_MS (10s) so it is a true BACKSTOP — socketTimeout still does the
+  // primary teardown when it works; this only catches the commands it doesn't. NOTE: this is a
+  // GLOBAL cap on EVERY cluster command, but only the cache-read paths (fetchThroughCache +
+  // createCachedArray) fail open — a non-fail-open command that rejects on the deadline still
+  // surfaces as an error. Lowering this (toward ~3s, which is safe for the now-fail-open cache
+  // reads) is DEFERRED to a separate change so the createCachedArray fail-open above can be
+  // soaked + attributed first without bundling a global timeout change. 0 disables it.
+  // Cluster-scoped: the SYSTEM client is untouched (it uses REDIS_SYS_READ_TIMEOUT_MS — see the
+  // #2556/#2586 sys-client regression). See redis/command-deadline.ts withCommandDeadline() +
+  // instrumentCommands() and utils/cache-helpers.ts (fetchThroughCache + createCachedArray
+  // fail-open).
+  REDIS_CLUSTER_COMMAND_TIMEOUT_MS: z.coerce.number().default(15000),
   NODE_ENV: z.enum(['development', 'test', 'production']),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.preprocess(

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -128,19 +128,27 @@ export const serverSchema = z.object({
   // time REJECTS — which makes the wrapped promise settle → `.finally(done)` fires → the
   // inflight gauge dec's AND the handler unparks with an error instead of a 125s hang.
   // The reject flows the SAME way an existing cluster read error already does (socketTimeout
-  // has rejected stuck commands down these paths since #2556): fetchThroughCache catches and
-  // fail-opens (degraded miss → slow 200); createCachedObject/Array.fetch does NOT catch, so
-  // it propagates (→ error/500) — same as any cluster error today, and strictly better than a
-  // 125s hang. Correct regardless of the exact node-redis internal cause.
+  // has rejected stuck commands down these paths since #2556): BOTH fetchThroughCache AND
+  // createCachedObject/Array.fetch now catch it and fail-open (degraded origin fetch → slow
+  // 200, bounded against a DB stampede by per-id single-flight — see cache-helpers.ts
+  // degradedIdInFlight). createCachedArray.fetch was made fail-open in the SAME change that
+  // lowered this default — that fail-open is THIS deadline's safety net: before it, a
+  // deadline-reject down a cachedObject read propagated as a 500 (a 68-min two-pod 500 spike
+  // on 2026-06-17). Correct regardless of the exact node-redis internal cause.
   //
-  // Default 15000 (15s): ~650× over the ~23ms healthy-completion p99 (zero risk of
-  // clipping a legitimate slow command) and well below the ~125s client ceiling. Sits
-  // ABOVE REDIS_SOCKET_TIMEOUT_MS (10s) so it is a true BACKSTOP — socketTimeout still
-  // does the primary teardown when it works; this only catches the commands it doesn't.
-  // 0 disables it. Cluster-scoped: the SYSTEM client is untouched (it uses
-  // REDIS_SYS_READ_TIMEOUT_MS — see the #2556/#2586 sys-client regression). See
-  // redis/command-deadline.ts withCommandDeadline() + instrumentCommands().
-  REDIS_CLUSTER_COMMAND_TIMEOUT_MS: z.coerce.number().default(15000),
+  // Default 3000 (3s): the cachedArray `mGet` is a Promise.all of individual per-key GETs
+  // (client.ts packed.mGet), each independently wrapped by instrumentCommands — so no single
+  // wrapped command is a large multi-key op, and 3s is ~22× the ~137ms healthy-completion p99
+  // (SLOWLOG max; p50 sub-ms): it will not clip a legitimate command. BELOW
+  // REDIS_SOCKET_TIMEOUT_MS (10s) so the deadline (not socketTimeout) is now the EFFECTIVE cap
+  // — it unparks a stuck handler in 3s instead of 10s/125s. SAFE to be this aggressive ONLY
+  // because the fail-open above turns a deadline-reject into a slow 200 rather than a 500.
+  // Env-tunable, so it can be raised at runtime without a deploy if it ever clips. 0 disables
+  // it. Cluster-scoped: the SYSTEM client is untouched (it uses REDIS_SYS_READ_TIMEOUT_MS —
+  // see the #2556/#2586 sys-client regression). See redis/command-deadline.ts
+  // withCommandDeadline() + instrumentCommands() and utils/cache-helpers.ts
+  // (fetchThroughCache + createCachedArray fail-open).
+  REDIS_CLUSTER_COMMAND_TIMEOUT_MS: z.coerce.number().default(3000),
   NODE_ENV: z.enum(['development', 'test', 'production']),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.preprocess(

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -207,6 +207,27 @@ export const cacheRevalidateCounter = registerCounterWithLabels({
   labelNames: ['cache_name', 'cache_type'] as const,
 });
 
+// createCachedArray cluster-read FAIL-OPEN metrics (PR #2619). The fail-open degrades a
+// rejected cluster Redis read to a direct origin (DB) fetch instead of a 500 — trading 500s
+// for DB load. These make that trade observable:
+//   - degraded_total      = times we entered the degraded path (the fail-open FIRE RATE; a
+//                           proxy for a wedged cluster client, per cache).
+//   - origin_fetch_total  = ids actually sent to lookupFn (the DEDUPED DB load, after per-id
+//                           single-flight). Its rate is the real DB-row load a wedge induces;
+//                           origin_fetch / (ids requested) shows the coalescing effectiveness.
+// Healthy traffic never touches these (the path is reached only on a cluster-read reject).
+export const cacheFailOpenDegradedCounter = registerCounterWithLabels({
+  name: 'cache_failopen_degraded_total',
+  help: 'createCachedArray cluster-read fail-open: degraded-fetch calls by cache name',
+  labelNames: ['cache_name'] as const,
+});
+
+export const cacheFailOpenOriginFetchCounter = registerCounterWithLabels({
+  name: 'cache_failopen_origin_fetch_total',
+  help: 'createCachedArray fail-open: ids sent to origin (lookupFn) by cache name — deduped DB load',
+  labelNames: ['cache_name'] as const,
+});
+
 // tRPC per-procedure latency — wall-clock duration of the full middleware chain +
 // resolver, labeled by procedure path. Used to rank heavy-pool isolation
 // candidates by P99 x rate (the criterion behind the image-feed cutover). Bucket

--- a/src/server/redis/command-deadline.ts
+++ b/src/server/redis/command-deadline.ts
@@ -26,8 +26,8 @@ import { env } from '~/env/server';
  *
  * CONSUMER IMPACT: the reject is caught by the SAME fail-open paths that catch a cluster
  * read error — cache-helpers `fetchThroughCache` AND `createCachedArray`/`createCachedObject`
- * `.fetch` (the latter was made fail-open alongside lowering the deadline default; before
- * that its mGet/set/del had NO try/catch and a reject surfaced as a 500). Both now degrade
+ * `.fetch` (the latter was made fail-open in the same change that added this consumer note;
+ * before that its mGet/set/del had NO try/catch and a reject surfaced as a 500). Both now degrade
  * to an origin fetch → slow 200, NOT a hard 500. The cachedArray origin fetch is bounded
  * against a DB stampede by per-id single-flight (overlapping feed pages share per-id DB
  * results) — see cache-helpers.ts degradedIdInFlight. Strictly better than the 125s-then-499

--- a/src/server/redis/command-deadline.ts
+++ b/src/server/redis/command-deadline.ts
@@ -24,10 +24,14 @@ import { env } from '~/env/server';
  * here — it is bounded separately by withSysReadDeadline / commandsQueueMaxLength, and a
  * blanket timeout on it caused the #2556/#2586 sys-client wedge. See client.ts.
  *
- * CONSUMER IMPACT: the reject is caught by the SAME fail-open paths that already catch a
- * cluster read error (cache-helpers fetchThroughCache + createCachedObject try/catch) →
- * a degraded cache miss → slow 200 (origin fetch), NOT a hard 500. Strictly better than
- * the 125s-then-499 it replaces.
+ * CONSUMER IMPACT: the reject is caught by the SAME fail-open paths that catch a cluster
+ * read error — cache-helpers `fetchThroughCache` AND `createCachedArray`/`createCachedObject`
+ * `.fetch` (the latter was made fail-open alongside lowering the deadline default; before
+ * that its mGet/set/del had NO try/catch and a reject surfaced as a 500). Both now degrade
+ * to an origin fetch → slow 200, NOT a hard 500. The cachedArray origin fetch is bounded
+ * against a DB stampede by per-id single-flight (overlapping feed pages share per-id DB
+ * results) — see cache-helpers.ts degradedIdInFlight. Strictly better than the 125s-then-499
+ * it replaces.
  *
  * `ms` defaults to REDIS_CLUSTER_COMMAND_TIMEOUT_MS; pass an explicit value in tests.
  * `<= 0` disables the guard (returns the input unchanged — no wrapper, no timer).

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -182,6 +182,55 @@ describe('createCachedArray.fetch — per-id single-flight (DB stampede bound)',
   });
 });
 
+describe('createCachedArray.fetch — HEALTHY path (regression guard)', () => {
+  it('serves cache hits without an origin fetch, fetches+caches only the misses', async () => {
+    // id 1 is a fresh cache hit; id 2 is a miss. mGet returns one slot per key.
+    mGetMock.mockResolvedValue([{ id: 1, name: 'cached-1', cachedAt: new Date() }, null]);
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
+    );
+    const cache = createCachedArray<Row>({ key: 'test:healthy' as never, idKey: 'id', lookupFn });
+
+    const result = await cache.fetch([1, 2]);
+
+    // Origin fetched ONLY the miss (id 2), never the hit (id 1) → no degraded path.
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledWith([2]);
+    expect(result.find((r) => r.id === 1)?.name).toBe('cached-1'); // from cache
+    expect(result.find((r) => r.id === 2)?.name).toBe('db-2'); // from origin
+    expect(setMock).toHaveBeenCalled(); // the miss was written back
+  });
+});
+
+describe('createCachedArray.fetch — degraded shared-object isolation (H2)', () => {
+  it('clones per caller so two overlapping degraded fetches with mutating appendFns do not corrupt each other', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const lookupFn = vi.fn(async (ids: number[]) => {
+      await gate;
+      return Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>;
+    });
+    // appendFn mutates the record in place (mirrors cosmeticCache/modelTagCache).
+    const appendFn = async (rows: Set<Row>) => {
+      for (const r of rows) r.name = `${r.name}-appended`;
+    };
+    const cache = createCachedArray<Row>({ key: 'test:share' as never, idKey: 'id', lookupFn, appendFn });
+
+    const p1 = cache.fetch([1, 2]);
+    await flush();
+    const p2 = cache.fetch([2, 3]); // overlaps on id 2 → shares the in-flight promise
+    await flush();
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // Without the clone, id 2's shared object would be appended TWICE ("db-2-appended-appended").
+    expect(r1.find((r) => r.id === 2)?.name).toBe('db-2-appended');
+    expect(r2.find((r) => r.id === 2)?.name).toBe('db-2-appended');
+  });
+});
+
 describe('createCachedObject.fetch — fail-open + best-effort writes', () => {
   it('fails open to a keyed Record from the origin when the read rejects', async () => {
     mGetMock.mockRejectedValue(REDIS_TIMEOUT());

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -42,6 +42,21 @@ vi.mock('~/server/redis/fail-open-log', () => ({
   logSysRedisFailOpen: vi.fn(),
 }));
 
+// Mock prom/client to assert the fail-open counters (degraded fire-rate + deduped origin
+// fetches) and satisfy the other cache counters cache-helpers imports. vi.hoisted so the
+// inc spies exist before the (hoisted) vi.mock factory references them.
+const { degradedInc, originFetchInc } = vi.hoisted(() => ({
+  degradedInc: vi.fn(),
+  originFetchInc: vi.fn(),
+}));
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: degradedInc },
+  cacheFailOpenOriginFetchCounter: { inc: originFetchInc },
+}));
+
 import { createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
 
 type Row = { id: number; name: string };
@@ -59,6 +74,8 @@ beforeEach(() => {
   setMock.mockClear().mockResolvedValue(undefined);
   setNxMock.mockClear().mockResolvedValue(true);
   delMock.mockClear().mockResolvedValue(undefined);
+  degradedInc.mockClear();
+  originFetchInc.mockClear();
 });
 
 afterEach(() => {
@@ -83,6 +100,10 @@ describe('createCachedArray.fetch — CLUSTER read fail-open', () => {
     expect(result.find((r) => r.id === 2)?.name).toBe('db-2');
     // Degraded path must not attempt cache writes (redis is down).
     expect(setMock).not.toHaveBeenCalled();
+    // Observability: one degraded call, and 3 ids sent to origin (the deduped DB load).
+    expect(degradedInc).toHaveBeenCalledTimes(1);
+    expect(degradedInc).toHaveBeenCalledWith({ cache_name: 'test:read' });
+    expect(originFetchInc).toHaveBeenCalledWith({ cache_name: 'test:read' }, 3);
   });
 
   it('omits ids the origin has no row for (notFound semantics preserved, no throw)', async () => {
@@ -153,6 +174,12 @@ describe('createCachedArray.fetch — per-id single-flight (DB stampede bound)',
     // Both callers still get their full, correct id-set back.
     expect(r1.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 2]);
     expect(r2.map((r) => r.id).sort((a, b) => a - b)).toEqual([2, 3]);
+    // The origin-fetch counter measures the DEDUPED DB load: 2 calls (degraded) but only
+    // 3 ids sent to origin total (2 for [1,2] + 1 for [3]) — NOT 4 — proving the metric
+    // reflects the per-id coalescing, not the raw id-set count.
+    expect(degradedInc).toHaveBeenCalledTimes(2);
+    const totalOriginIds = originFetchInc.mock.calls.reduce((s, c) => s + (c[1] as number), 0);
+    expect(totalOriginIds).toBe(3);
   });
 
   it('does NOT leak in-flight entries: a fetch after settle re-issues the origin lookup', async () => {

--- a/src/server/utils/__tests__/cache-helpers-failopen.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-failopen.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Fail-open coverage for createCachedArray / createCachedObject `.fetch`.
+ *
+ * Background (PR #2611 + this PR): a node-redis CLUSTER (cache) command can wedge — the
+ * #2556 socketTimeout / #2611 command-deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS, lowered to
+ * 3s here) now make a stuck read REJECT instead of hanging ~125s. But the cachedArray read
+ * path had NO try/catch around its `redis.packed.mGet`, so that reject propagated → TRPCError
+ * → 500 (a 68-min 500 spike on two wedged API pods on 2026-06-17, concentrated on the
+ * createCachedObject routes tag.getAll / user.getCreator / image.getGenerationData). These
+ * tests pin the contract that the read now fails OPEN to a per-id single-flighted origin
+ * (lookupFn) fetch — mirroring fetchThroughCache — and that the best-effort writes/locks never
+ * turn a successful origin fetch into a 500.
+ *
+ * The redis client is mocked so we can force a read/write rejection deterministically. The
+ * fail-open logger is stubbed to a no-op (fire-and-forget Axiom/Loki I/O, not under test).
+ */
+
+// Controllable fake CLUSTER redis client. Each method can be flipped to reject to simulate a
+// wedged cluster command (socketTimeout / command-deadline reject).
+const mGetMock = vi.fn();
+const setMock = vi.fn().mockResolvedValue(undefined);
+const setNxMock = vi.fn().mockResolvedValue(true);
+const delMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: {
+      mGet: (...args: unknown[]) => mGetMock(...args),
+      set: (...args: unknown[]) => setMock(...args),
+    },
+    setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
+    del: (...args: unknown[]) => delMock(...args),
+  },
+  sysRedis: {},
+  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock', TAG: 'caches:tag' },
+}));
+
+// Keep the fail-open logger inert (fire-and-forget Axiom/Loki, not under test).
+vi.mock('~/server/redis/fail-open-log', () => ({
+  logSysRedisFailOpen: vi.fn(),
+}));
+
+import { createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
+
+type Row = { id: number; name: string };
+
+const REDIS_TIMEOUT = () => new Error('redis cluster command timed out after 3000ms');
+
+// Flush queued microtasks so all concurrent fetches reach the fail-open path before a gated
+// lookupFn resolves.
+const flush = async () => {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+};
+
+beforeEach(() => {
+  mGetMock.mockReset();
+  setMock.mockClear().mockResolvedValue(undefined);
+  setNxMock.mockClear().mockResolvedValue(true);
+  delMock.mockClear().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createCachedArray.fetch — CLUSTER read fail-open', () => {
+  it('returns the ORIGIN (lookupFn) result instead of throwing when the redis read rejects', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
+    );
+
+    const cache = createCachedArray<Row>({ key: 'test:read' as never, idKey: 'id', lookupFn });
+
+    // BEFORE this fix this rejected (→ TRPCError → 500). It must now resolve to the origin
+    // result (degraded slow-200).
+    const result = await cache.fetch([1, 2, 3]);
+
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    expect(result.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    expect(result.find((r) => r.id === 2)?.name).toBe('db-2');
+    // Degraded path must not attempt cache writes (redis is down).
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it('omits ids the origin has no row for (notFound semantics preserved, no throw)', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+    // id 2 missing from the DB result.
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(ids.filter((id) => id !== 2).map((id) => [id, { id, name: `db-${id}` }]))
+    );
+    const cache = createCachedArray<Row>({ key: 'test:nf' as never, idKey: 'id', lookupFn });
+
+    const result = await cache.fetch([1, 2, 3]);
+    expect(result.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 3]);
+  });
+
+  it('runs appendFn on the degraded results (decorator contract preserved)', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+    const lookupFn = async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>;
+    const appendFn = vi.fn(async (rows: Set<Row>) => {
+      for (const r of rows) r.name = `decorated-${r.id}`;
+    });
+    const cache = createCachedArray<Row>({ key: 'test:append' as never, idKey: 'id', lookupFn, appendFn });
+
+    const result = await cache.fetch([7, 8]);
+    expect(appendFn).toHaveBeenCalledTimes(1);
+    expect(result.find((r) => r.id === 7)?.name).toBe('decorated-7');
+  });
+
+  it('PROPAGATES a genuine lookupFn (origin/DB) error — fail-open does NOT swallow it', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+    const lookupFn = vi.fn(async () => {
+      throw new Error('db exploded');
+    });
+    const cache = createCachedArray<Row>({ key: 'test:dberr' as never, idKey: 'id', lookupFn });
+
+    await expect(cache.fetch([1, 2])).rejects.toThrow('db exploded');
+  });
+});
+
+describe('createCachedArray.fetch — per-id single-flight (DB stampede bound)', () => {
+  it('coalesces OVERLAPPING id-sets so each id is looked up at most once concurrently', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+
+    // Gated lookupFn: stays pending until released, forcing the two fetches to overlap.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const lookupCalls: number[][] = [];
+    const lookupFn = vi.fn(async (ids: number[]) => {
+      lookupCalls.push([...ids]);
+      await gate;
+      return Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>;
+    });
+
+    const cache = createCachedArray<Row>({ key: 'test:sf' as never, idKey: 'id', lookupFn });
+
+    const p1 = cache.fetch([1, 2]);
+    await flush(); // let fetch#1 register ids 1,2 in the in-flight map
+    const p2 = cache.fetch([2, 3]); // id 2 overlaps → must reuse, only 3 is newly fetched
+    await flush();
+
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // id 2 must appear in EXACTLY one lookupFn call (coalesced), never duplicated.
+    const allLookedUp = lookupCalls.flat();
+    expect(allLookedUp.filter((id) => id === 2)).toHaveLength(1);
+    expect([...new Set(allLookedUp)].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    // Both callers still get their full, correct id-set back.
+    expect(r1.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(r2.map((r) => r.id).sort((a, b) => a - b)).toEqual([2, 3]);
+  });
+
+  it('does NOT leak in-flight entries: a fetch after settle re-issues the origin lookup', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
+    );
+    const cache = createCachedArray<Row>({ key: 'test:leak' as never, idKey: 'id', lookupFn });
+
+    await cache.fetch([5]); // settles → entry for id 5 must be deleted
+    await cache.fetch([5]); // would reuse a stale promise if the map leaked
+    expect(lookupFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects every joined caller when the shared origin fetch fails, then clears the entry', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+    let calls = 0;
+    const lookupFn = vi.fn(async () => {
+      calls++;
+      throw new Error(`db fail #${calls}`);
+    });
+    const cache = createCachedArray<Row>({ key: 'test:joinerr' as never, idKey: 'id', lookupFn });
+
+    await expect(cache.fetch([9])).rejects.toThrow('db fail #1');
+    // Entry cleared on rejection → next fetch issues a NEW lookup (not a stuck rejected promise).
+    await expect(cache.fetch([9])).rejects.toThrow('db fail #2');
+  });
+});
+
+describe('createCachedObject.fetch — fail-open + best-effort writes', () => {
+  it('fails open to a keyed Record from the origin when the read rejects', async () => {
+    mGetMock.mockRejectedValue(REDIS_TIMEOUT());
+    const lookupFn = async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>;
+    const cache = createCachedObject<Row>({ key: 'test:obj' as never, idKey: 'id', lookupFn });
+
+    const result = await cache.fetch([1, 2]);
+    expect(Object.keys(result).sort()).toEqual(['1', '2']);
+    expect(result['2'].name).toBe('db-2');
+  });
+
+  it('does NOT 500 when the cache WRITE-back rejects after a successful origin miss-fetch', async () => {
+    // Healthy read (empty → all misses), but the write-back to redis rejects (partial wedge).
+    mGetMock.mockResolvedValue([]); // no cached entries → every id is a miss
+    setMock.mockRejectedValue(REDIS_TIMEOUT());
+    const lookupFn = async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>;
+    // cacheNotFound default true → notFound writes also attempted; both must be swallowed.
+    const cache = createCachedObject<Row>({ key: 'test:wb' as never, idKey: 'id', lookupFn });
+
+    const result = await cache.fetch([1, 2]);
+    expect(setMock).toHaveBeenCalled(); // it tried to write
+    expect(Object.keys(result).sort()).toEqual(['1', '2']); // and still returned the data
+  });
+});

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -2,7 +2,13 @@ import type { Prisma, PrismaClient } from '@prisma/client';
 import { chunk } from 'lodash-es';
 import { CacheTTL } from '~/server/common/constants';
 import { logToAxiom } from '~/server/logging/client';
-import { cacheHitCounter, cacheMissCounter, cacheRevalidateCounter } from '~/server/prom/client';
+import {
+  cacheFailOpenDegradedCounter,
+  cacheFailOpenOriginFetchCounter,
+  cacheHitCounter,
+  cacheMissCounter,
+  cacheRevalidateCounter,
+} from '~/server/prom/client';
 import type { RedisKeyTemplateCache, RedisKeyTemplates } from '~/server/redis/client';
 import { redis, REDIS_KEYS, sysRedis } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -186,6 +192,8 @@ export function createCachedArray<T extends object>({
   // genuine lookupFn error still propagates (the fetch itself is never wrapped — mirrors
   // fetchThroughCache, which never wraps fetchFn).
   async function fetchFromOriginDegraded(distinctIds: number[]): Promise<T[]> {
+    // Fire rate of the fail-open path (a proxy for a wedged cluster client on this pod).
+    cacheFailOpenDegradedCounter.inc({ cache_name: key });
     // Partition into ids already in flight on this pod (reuse, capturing the promise
     // reference NOW so a concurrent settle+delete can't make us miss it) vs. ids we must
     // originate. byId holds the promise to await for EVERY requested id.
@@ -198,6 +206,10 @@ export function createCachedArray<T extends object>({
     }
 
     if (toFetch.length > 0) {
+      // The DEDUPED DB load: only the ids not already in flight reach lookupFn. The reused
+      // ids share a concurrent call's promise (counted by that call), so this never
+      // double-counts — rate(origin_fetch)/rate(degraded) is the per-call dedup factor.
+      cacheFailOpenOriginFetchCounter.inc({ cache_name: key }, toFetch.length);
       // ONE shared batched lookupFn for all newly-needed ids (same 10000-id cap as the
       // cache-miss path); each id's promise extracts its own record from the shared result.
       const batched = (async () => {

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -138,6 +138,35 @@ export function resolveCacheExpiry(
   return ttl + (staleWhileRevalidateTtl ?? ttl);
 }
 
+/**
+ * Per-(pod, cache-key, id) single-flight map for the createCachedArray DEGRADED
+ * (cluster-read-failed) origin fetch.
+ *
+ * WHY: when a CLUSTER (cache) Redis read rejects — the #2556 socketTimeout (~10s) or the
+ * #2611 command-deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS, now 3s) — createCachedArray.fetch
+ * fails open to a direct origin (DB) fetch instead of 500ing (its `mGet` had NO try/catch,
+ * unlike fetchThroughCache; that surfaced as a 68-min two-pod 500 spike on the hot read paths
+ * tag.getAll / user.getCreator / image.getGenerationData on 2026-06-17). But the hot consumers
+ * (imageMetaCache / tagIdsForImagesCache, etc.) pass PER-FEED-PAGE id lists, so under a full
+ * wedge each distinct page would be a separate origin DB call → a read flood ∝ (pages ×
+ * concurrency × ~80 pods): a Redis problem turned into a DB thundering-herd (a worse cascade).
+ *
+ * This map dedups at INDIVIDUAL-ID granularity: a degraded fetch only DB-looks-up the ids for
+ * a given `key` that are NOT already in flight on this pod, and awaits the existing promise
+ * for the rest. Because adjacent pages overlap heavily, this collapses OVERLAPPING id-sets
+ * (not just identical ones) → per-(key, pod) DB load is bounded by the count of DISTINCT
+ * concurrent ids, not by the number of distinct id-sets/pages. No fixed cap → no queue to grow
+ * and no caller blocked behind a saturated semaphore. Entries are deleted as soon as their
+ * promise settles (success OR error), so the map only ever holds ids currently being fetched
+ * — no leak under a sustained wedge. A genuine lookupFn error rejects the shared promise (and
+ * is deleted) so it still propagates to every awaiting caller rather than being swallowed.
+ *
+ * REACHED ONLY on the redis-read-FAILED path (fetchFromOriginDegraded). On the healthy path
+ * `mGet` succeeds and this map is never touched — it cannot affect normal traffic or
+ * healthy-path latency; it only shapes DB load during a wedge.
+ */
+const degradedIdInFlight = new Map<string, Promise<unknown>>();
+
 export function createCachedArray<T extends object>({
   key,
   idKey,
@@ -151,15 +180,82 @@ export function createCachedArray<T extends object>({
   staleWhileRevalidate = true,
   staleWhileRevalidateTtl,
 }: CachedLookupOptions<T>) {
+  // Degraded origin (DB) fetch used when a CLUSTER Redis read rejects. Returns the SAME shape
+  // as the healthy `fetch` (decorated by appendFn, cachedAt stripped) but reads nothing from
+  // and writes nothing to Redis. DB load is bounded by the per-id single-flight above; a
+  // genuine lookupFn error still propagates (the fetch itself is never wrapped — mirrors
+  // fetchThroughCache, which never wraps fetchFn).
+  async function fetchFromOriginDegraded(distinctIds: number[]): Promise<T[]> {
+    // Partition into ids already in flight on this pod (reuse, capturing the promise
+    // reference NOW so a concurrent settle+delete can't make us miss it) vs. ids we must
+    // originate. byId holds the promise to await for EVERY requested id.
+    const byId = new Map<number, Promise<T | undefined>>();
+    const toFetch: number[] = [];
+    for (const id of distinctIds) {
+      const existing = degradedIdInFlight.get(`${key}:${id}`) as Promise<T | undefined> | undefined;
+      if (existing) byId.set(id, existing);
+      else toFetch.push(id);
+    }
+
+    if (toFetch.length > 0) {
+      // ONE shared batched lookupFn for all newly-needed ids (same 10000-id cap as the
+      // cache-miss path); each id's promise extracts its own record from the shared result.
+      const batched = (async () => {
+        const dbResults: Record<string, T> = {};
+        for (const batch of chunk(toFetch, 10000)) {
+          Object.assign(dbResults, await lookupFn([...batch] as number[]));
+        }
+        return dbResults;
+      })();
+      for (const id of toFetch) {
+        const mapKey = `${key}:${id}`;
+        const p = batched.then((r) => r[id]);
+        byId.set(id, p);
+        degradedIdInFlight.set(mapKey, p);
+        // Remove the entry once THIS id settles; guard against clobbering a newer same-id
+        // round. .catch keeps the cleanup chain from ever surfacing an unhandledRejection
+        // (the rejection is still observed by the Promise.all await below).
+        void p
+          .finally(() => {
+            if (degradedIdInFlight.get(mapKey) === p) degradedIdInFlight.delete(mapKey);
+          })
+          .catch(() => undefined);
+      }
+    }
+
+    const settled = await Promise.all(distinctIds.map((id) => byId.get(id) as Promise<T | undefined>));
+    const degraded = new Set<T>();
+    for (const r of settled) if (r) degraded.add(r);
+    if (appendFn) await appendFn(degraded);
+    return [...degraded].map((x) => {
+      if ('cachedAt' in x) delete x.cachedAt;
+      return x;
+    });
+  }
+
   async function fetch(ids: number[]) {
     if (!ids.length) return [] as T[];
+    const distinctIds = [...new Set(ids)];
     const results = new Set<T>();
     const cacheResults: T[] = [];
-    for (const batch of chunk([...new Set(ids)], 200)) {
-      const batchResults = await redis.packed.mGet<T>(
-        batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache)
-      );
-      cacheResults.push(...batchResults.filter(isDefined));
+    try {
+      for (const batch of chunk(distinctIds, 200)) {
+        const batchResults = await redis.packed.mGet<T>(
+          batch.map((id) => `${key}:${id}` as RedisKeyTemplateCache)
+        );
+        cacheResults.push(...batchResults.filter(isDefined));
+      }
+    } catch (err) {
+      // CLUSTER Redis READ rejected (cluster stall / socketTimeout / command-deadline). Fail
+      // OPEN to a per-id single-flighted origin fetch instead of propagating a 500 on these
+      // hot read paths. The lookupFn itself is OUTSIDE this catch (inside
+      // fetchFromOriginDegraded), so a genuine DB/logic error still propagates — matches
+      // fetchThroughCache, which never wraps fetchFn.
+      logSysRedisFailOpen('read-degraded', `createCachedArray mGet (cache cluster) [${key}]`, err, {
+        key,
+        ids: distinctIds.length,
+      });
+      return fetchFromOriginDegraded(distinctIds);
     }
     const cacheArray = cacheResults.filter((x) => x !== null) as T[];
     const cache = Object.fromEntries(cacheArray.map((x) => [x[idKey], x]));
@@ -171,7 +267,7 @@ export function createCachedArray<T extends object>({
     const ttlExpiry = new Date(Date.now() - ttl * 1000);
     const locks = new Set<RedisKeyTemplateCache>();
     let cacheHits = 0;
-    for (const id of [...new Set(ids)]) {
+    for (const id of distinctIds) {
       const cached = cache[id];
       if (cached) {
         if (cached.notFound) continue;
@@ -202,11 +298,26 @@ export function createCachedArray<T extends object>({
         toRevalidateIds.length
       );
 
-      const gotLocks = await Promise.all(
-        toRevalidateIds.map((id) =>
-          redis.setNxKeepTtlWithEx(`${REDIS_KEYS.CACHE_LOCKS}:${key}:${id}`, '1', 10)
-        )
-      );
+      let gotLocks: boolean[];
+      try {
+        gotLocks = await Promise.all(
+          toRevalidateIds.map((id) =>
+            redis.setNxKeepTtlWithEx(`${REDIS_KEYS.CACHE_LOCKS}:${key}:${id}`, '1', 10)
+          )
+        );
+      } catch (err) {
+        // The revalidate lock is a CLUSTER Redis WRITE; on a cluster error we already hold a
+        // fresh-enough stale value for every toRevalidate id, so serve it rather than 500.
+        // (Mirrors fetchThroughCache's lock-error path: serve stale if we have it.) Treating
+        // every lock as not-acquired skips revalidation this pass — cheap and correct.
+        logSysRedisFailOpen(
+          'write-degraded',
+          `createCachedArray revalidate-lock (cache cluster) [${key}]`,
+          err,
+          { key, ids: toRevalidateIds.length }
+        );
+        gotLocks = toRevalidateIds.map(() => false);
+      }
       for (let i = 0; i < toRevalidateIds.length; i++) {
         const id = toRevalidateIds[i];
         if (!gotLocks[i]) {
@@ -257,31 +368,45 @@ export function createCachedArray<T extends object>({
         cacheMissCounter.inc({ cache_name: key, cache_type: 'cachedArray' }, actualMisses);
       }
 
-      // then cache the results
+      // then cache the results. The DB lookup above already SUCCEEDED — a CLUSTER Redis WRITE
+      // failure here must NOT turn a good origin fetch into a 500. Swallow it best-effort (the
+      // entry just isn't cached this pass); mirrors fetchThroughCache's best-effort set.
       const EX = resolveCacheExpiry(ttl, staleWhileRevalidate, staleWhileRevalidateTtl);
-      if (Object.keys(toCache).length > 0)
-        await Promise.all(
-          Object.entries(toCache).map(([id, cache]) =>
-            redis.packed.set(`${key}:${id}`, cache, { EX })
-          )
-        );
+      try {
+        if (Object.keys(toCache).length > 0)
+          await Promise.all(
+            Object.entries(toCache).map(([id, cache]) =>
+              redis.packed.set(`${key}:${id}`, cache, { EX })
+            )
+          );
 
-      // Use NX to avoid overwriting a value with a not found...
-      // notFoundTtl lets a caller cap negative-cache lifetime separately from
-      // positive results — useful when an empty lookupFn result is likely to
-      // be transient (async ingestion, replication lag) rather than truly empty.
-      if (Object.keys(toCacheNotFound).length > 0) {
-        const notFoundEX = notFoundTtl ?? EX;
-        await Promise.all(
-          Object.entries(toCacheNotFound).map(([id, cache]) =>
-            redis.packed.set(`${key}:${id}`, cache, { EX: notFoundEX, NX: true })
-          )
-        );
+        // Use NX to avoid overwriting a value with a not found...
+        // notFoundTtl lets a caller cap negative-cache lifetime separately from
+        // positive results — useful when an empty lookupFn result is likely to
+        // be transient (async ingestion, replication lag) rather than truly empty.
+        if (Object.keys(toCacheNotFound).length > 0) {
+          const notFoundEX = notFoundTtl ?? EX;
+          await Promise.all(
+            Object.entries(toCacheNotFound).map(([id, cache]) =>
+              redis.packed.set(`${key}:${id}`, cache, { EX: notFoundEX, NX: true })
+            )
+          );
+        }
+      } catch (err) {
+        logSysRedisFailOpen('write-degraded', `createCachedArray set (cache cluster) [${key}]`, err, {
+          key,
+        });
       }
     }
 
-    // Remove locks
-    if (locks.size > 0) await redis.del([...locks]);
+    // Remove locks (best-effort: a failed del just leaves the lock to expire via its 10s TTL
+    // — never let it mask the successful fetch result or 500 the request).
+    if (locks.size > 0)
+      await redis.del([...locks]).catch((err) =>
+        logSysRedisFailOpen('write-degraded', `createCachedArray del-locks (cache cluster) [${key}]`, err, {
+          key,
+        })
+      );
 
     if (appendFn) await appendFn(results);
 

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -224,8 +224,15 @@ export function createCachedArray<T extends object>({
     }
 
     const settled = await Promise.all(distinctIds.map((id) => byId.get(id) as Promise<T | undefined>));
+    // Clone each record before returning it. The per-id single-flight shares ONE object
+    // reference across every concurrent caller for that id — but appendFn mutates records IN
+    // PLACE (e.g. caches.ts cosmeticCache: `record.id = record.cosmeticId; delete
+    // record.cosmeticId`) and we strip cachedAt below. Without a clone, two overlapping
+    // degraded fetches would corrupt each other's results. The healthy path is immune (each
+    // request decodes its own objects from msgpack); this restores that isolation. Shallow is
+    // enough — the appendFns reassign/delete TOP-LEVEL fields.
     const degraded = new Set<T>();
-    for (const r of settled) if (r) degraded.add(r);
+    for (const r of settled) if (r) degraded.add({ ...r } as T);
     if (appendFn) await appendFn(degraded);
     return [...degraded].map((x) => {
       if ('cachedAt' in x) delete x.cachedAt;


### PR DESCRIPTION
## Problem

`createCachedArray.fetch` (used by `createCachedObject`) read `redis.packed.mGet` had **no try/catch**, unlike `fetchThroughCache`. So when a CLUSTER (cache) redis command rejects — the **#2611** 15s `withCommandDeadline`, or the **#2556** socketTimeout — that reject propagates straight out as a `TRPCError` → **500**.

**Observed in prod 2026-06-17:** two API-pool pods half-open-wedged (cluster client commands all timing out at the 15s deadline). #2611 correctly bounded the inflight-gauge leak (no 125s park, no storm), but the createCachedObject reads on the wedged pods **still 500'd** — ~3/s each, one for ~70 min, unnoticed — concentrated on hot every-page-load routes: `tag.getAll`, `user.getCreator`, `hiddenPreferences.getHidden`, `buzz.getUserMultipliers`, `image.getGenerationData`. #2611 made the wedge survivable; this closes the user-facing-500 gap it left.

## Fix

- **Read fails open.** On a cluster-read reject, `createCachedArray.fetch` degrades to a direct origin (`lookupFn`) fetch → slow-200 instead of 500. Mirrors `fetchThroughCache`.
- **DB-stampede bound (per-id single-flight).** The hot consumers (`imageMetaCache` / `tagIdsForImagesCache`) pass per-feed-page id lists; under a full wedge a naive fail-open would fan every page out to its own DB call ∝ (pages × concurrency × ~80 pods). A per-`(pod, key, id)` map (`degradedIdInFlight`) only DB-looks-up ids not already in flight on the pod and shares per-id results across overlapping pages — so per-`(key,pod)` DB load is bounded by **distinct concurrent ids**, not page count. A genuine `lookupFn` error still **propagates** (the fetch is never wrapped).
- **Per-caller clone in degraded mode.** The single-flight shares one object reference across concurrent callers; `appendFn` mutates records in place. Each caller gets a shallow clone so two overlapping degraded fetches can't corrupt each other (the healthy path is already immune — fresh msgpack objects).
- **Best-effort writes/locks.** The revalidate-lock, cache write-back, and lock-del now swallow a cluster error (serve stale / skip the write this pass) so a successful origin fetch is never turned into a 500. Mirrors `fetchThroughCache`.

## NOT in this PR (deliberately unbundled)

The original #2616 also lowered `REDIS_CLUSTER_COMMAND_TIMEOUT_MS` 15s→3s. An adversarial audit flagged that as a **global** cap on every cluster command — but only the cache-read paths fail open, so ~57+ direct `redis.get/set` call sites would newly reject at 3s where 15s let them complete (and 3s tails run long exactly during the eviction-storm wedge this targets). To keep the soak attributable, the deadline stays **15s** here; the 3s drop (which is safe *because* the cache reads now fail open) is deferred to a separate follow-up to land after this soaks.

## Tests

`src/server/utils/__tests__/cache-helpers-failopen.test.ts` (11, passing): read fail-open, per-id coalescing of overlapping id-sets, origin-error propagation (not swallowed), no-leak cleanup, the `createCachedObject` Record wrapper, best-effort write-back, a **healthy-path regression guard** (hit served without origin fetch; only miss fetched+cached), and **shared-object isolation** under concurrent overlapping degraded fetches with a mutating appendFn. Changed files typecheck clean (`tsc-files`).

## Relationship to #2616

Reimplements the abandoned **#2616** (`zach/cachedobject-failopen`) from scratch on fresh `main`, with a **single** per-id single-flight map instead of two stacked single-flight layers + a hand-rolled resolver/rejecter deferred map. Fixes a reference-capture race the simpler "re-read the map at await time" approach would have had. Smaller diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)