### PR TITLE
test(blocks): expect the additive `gate` field in resolveBlockVersionContext

### DIFF
--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -151,6 +151,21 @@ describe('resolveBlockVersionContext', () => {
       modelVersionId: 99,
       baseModel: 'SDXL 1.0',
       modelType: 'Checkpoint',
+      // `gate` is the additive entitlement context the resolver now returns
+      // (early-access / availability / coverage / members-only). This mock only
+      // stubs id/baseModel/status/model, so the optional gate fields resolve to
+      // undefined and coverage defaults to false.
+      gate: {
+        id: 99,
+        status: 'Published',
+        availability: undefined,
+        usageControl: undefined,
+        baseModel: 'SDXL 1.0',
+        covered: false,
+        modelUserId: undefined,
+        modelType: 'Checkpoint',
+        modelVersionAlias: null,
+      },
     });
   });
 


### PR DESCRIPTION
## Problem
`src/server/services/blocks/__tests__/workflow.service.test.ts > resolveBlockVersionContext > returns resolved fields …` fails **deterministically on every PR** (surfaced by the preview pipeline's `unit-tests` task — `1 failed | ~2174 passed`):

```
AssertionError: expected { … } to deeply equal { … }
+   "gate": { "availability": undefined, "baseModel": "SDXL 1.0", "covered": false,
+             "id": 99, "modelType": "Checkpoint", "modelUserId": undefined,
+             "modelVersionAlias": null, "status": "Published", "usageControl": undefined }
```

`resolveBlockVersionContext` now returns an additive `gate` entitlement context, but the test's exact `toEqual` expectation wasn't updated.

## Fix
Add `gate` to the expected object. Values are derived directly from the resolver's literal return for this test's mock (which stubs only `id`/`baseModel`/`status`/`model`, so `availability`/`usageControl`/`modelUserId` resolve to `undefined`, `covered` defaults to `false`, `modelVersionAlias` to `null`). `gate` is intentional per the resolver's own comment ("additive — the MODEL slot path never reads `gate`").

## Verification
Correct-by-construction: the new expected object matches **both** the resolver's literal return **and** the exact `Received` object from the CI failure. Confirmed green by the preview `unit-tests` task on this PR's build (local vitest run skipped — the unit suite needs the generated Prisma client, unreliable on NixOS per the known gotcha).

## For review
- ✅ that `gate`'s intended shape is as asserted. If you'd prefer **stronger** coverage, the mock could be enriched (provide `availability`/`usageControl`/`generationCoverage`/`model.userId`) and the gate assertion made non-`undefined` — happy to do that instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)