### PR TITLE
feat(app-blocks): page-only launch gate — page apps only for the public, grandfather mods

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -24,7 +24,7 @@ import {
   isKnownBlockScope,
   validateBlockScopesAgainstOauthClient,
 } from '~/shared/constants/block-scope.constants';
-import { isPageSlot, PAGE_FORBIDDEN_SCOPES } from '~/shared/constants/slot-registry';
+import { isLaunchSlot, isPageSlot, PAGE_FORBIDDEN_SCOPES } from '~/shared/constants/slot-registry';
 import {
   getGrantedScopes,
   partitionByConsent,
@@ -477,6 +477,21 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   const block = install.appBlock;
   if (!block || block.status !== 'approved') {
     res.status(403).json({ error: 'Block is not approved' });
+    return;
+  }
+
+  // PAGE-ONLY LAUNCH GATE (belt at the mint — defense-in-depth over the install
+  // path). The public (non-moderator) audience may only mint a token for a
+  // LAUNCH slot (page apps). A non-mod model-slot install shouldn't exist after
+  // the install-path gate, but the mint refuses one anyway. Moderators are
+  // grandfathered so the live mod-only generate-from-model model-slot token
+  // keeps minting. Mod status is the server-stamped session flag (same source
+  // the per-call assertViewerIsModerator belts use), so it can't be spoofed.
+  // `isLaunchSlot` is the single source of truth; the page path naturally
+  // passes (app.page IS a launch slot) and is unchanged.
+  const isModerator = session?.user?.isModerator === true;
+  if (!isModerator && !isLaunchSlot(install.slotId)) {
+    res.status(403).json({ error: 'This app type isn’t available yet.' });
     return;
   }
 

--- a/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
@@ -154,14 +154,20 @@ describe('blocks.getAppDetail — anon-capable, dark behind the flag (F-E E2)', 
     const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
     const result = await caller.getAppDetail(input);
     expect(result).toEqual(PUBLIC_DETAIL);
-    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1');
+    // PAGE-ONLY LAUNCH GATE: an anon caller is non-mod → launchOnly=true is
+    // passed to the service (which restricts to page apps; that filtering is
+    // covered in block-registry.page-only-launch.test.ts — here the service is
+    // mocked, so we only assert the forwarded arg).
+    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1', true);
   });
 
-  it('moderator (the live state today): served', async () => {
+  it('moderator (the live state today): served, launchOnly=false (grandfather)', async () => {
     const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
     const result = await caller.getAppDetail(input);
     expect(result).toEqual(PUBLIC_DETAIL);
     expect(mockGetAppDetail).toHaveBeenCalledTimes(1);
+    // A moderator sees everything → launchOnly=false.
+    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1', false);
   });
 
   it('NOT_FOUND when the service returns null (missing / non-approved app)', async () => {

--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -238,8 +238,25 @@ describe('blocks.listAvailable (public)', () => {
       slotId: 'model.sidebar_top',
       limit: 5,
     });
+    // PAGE-ONLY LAUNCH GATE: the router passes a second `launchOnly` arg =
+    // `!isModerator`. For this MODERATOR caller it's `false` (grandfather — sees
+    // everything).
     expect(mockListAvailable).toHaveBeenCalledWith(
-      expect.objectContaining({ query: 'generate', slotId: 'model.sidebar_top', limit: 5 })
+      expect.objectContaining({ query: 'generate', slotId: 'model.sidebar_top', limit: 5 }),
+      false
+    );
+  });
+
+  it('passes launchOnly=true to the service for a NON-MOD caller (public sees page apps only)', async () => {
+    mockListAvailable.mockResolvedValue({ items: [], nextCursor: undefined });
+    // Force the flag ON for a non-mod (models the post-launch segment-widen) so
+    // the call reaches the service and we can assert the launchOnly arg.
+    mockIsAppBlocksEnabled.mockImplementation(async () => true);
+    const caller = blocksRouter.createCaller(authedCtx(42, false) as never);
+    await caller.listAvailable({ limit: 20 });
+    expect(mockListAvailable).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 20 }),
+      true
     );
   });
 
@@ -481,10 +498,24 @@ describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped,
   describe('installOnModel', () => {
     const input = { modelId: 7, appBlockId: 'ab_x', slotId: 'model.sidebar_top' as const };
 
-    it('(a) non-mod OWNER + flag ON → installs (assertCanManageBlocks owner path)', async () => {
+    // PAGE-ONLY LAUNCH GATE: installOnModel only ever targets a MODEL slot, which
+    // is a non-launch slot — so a non-mod OWNER is now rejected even with the
+    // flag ON + owning the model (the launch gate is layered ON TOP of the owner
+    // check). This supersedes the pre-launch-gate "(a) non-mod OWNER installs".
+    it('(a) non-mod OWNER + flag ON → FORBIDDEN (model slot is non-launch), never installs', async () => {
       mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
       mockInstallOnModel.mockResolvedValue({ id: 'install_1' });
       const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.installOnModel(input)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockInstallOnModel).not.toHaveBeenCalled();
+    });
+
+    // GRANDFATHER: a MODERATOR can still install a model slot (the live mod-only
+    // generate-from-model path is untouched).
+    it('(a-mod) MODERATOR + flag ON → installs (grandfather; model slot allowed for mods)', async () => {
+      mockDbWriteModelFindUnique.mockResolvedValue({ userId: OWNER_ID });
+      mockInstallOnModel.mockResolvedValue({ id: 'install_1' });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, true) as never);
       await caller.installOnModel(input);
       expect(mockInstallOnModel).toHaveBeenCalledWith(
         expect.objectContaining({ modelId: 7, appBlockId: 'ab_x', installedByUserId: OWNER_ID })
@@ -586,7 +617,26 @@ describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped,
       settings: {},
     };
 
-    it('(a) non-mod OWNER (the caller) + flag ON → upserts, stamping ctx.user.id (NOT input)', async () => {
+    // PAGE-ONLY LAUNCH GATE: a subscription only ever attaches a MODEL-slot app
+    // (manifest has no page) — a non-launch app — so a non-mod is now rejected
+    // even with the flag ON. This supersedes the pre-launch-gate "(a) non-mod
+    // OWNER upserts".
+    it('(a) non-mod + flag ON + MODEL-slot app → FORBIDDEN (non-launch app), never upserts', async () => {
+      mockDbReadAppBlockFindUnique.mockResolvedValue({
+        blockId: 'g',
+        status: 'approved',
+        approvedScopes: [],
+        manifest: {}, // model app (no page field)
+      });
+      mockUpsertSubscription.mockResolvedValue({ id: 'bus_new' });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.upsertSubscription(input)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    });
+
+    // GRANDFATHER: a MODERATOR can still subscribe to a model-slot app, stamping
+    // ctx.user.id (NOT input). Keeps the pre-launch-gate owner-scoping invariant.
+    it('(a-mod) MODERATOR + flag ON + model app → upserts, stamping ctx.user.id (NOT input)', async () => {
       mockDbReadAppBlockFindUnique.mockResolvedValue({
         blockId: 'g',
         status: 'approved',
@@ -594,7 +644,7 @@ describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped,
         manifest: {},
       });
       mockUpsertSubscription.mockResolvedValue({ id: 'bus_new' });
-      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, true) as never);
       await caller.upsertSubscription(input);
       // userId is stamped server-side from the session, never from input.
       expect(mockUpsertSubscription).toHaveBeenCalledWith(

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1,6 +1,10 @@
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
-import { KNOWN_SLOT_IDS as SLOT_KNOWN_SLOT_IDS } from '~/shared/constants/slot-registry';
+import {
+  KNOWN_SLOT_IDS as SLOT_KNOWN_SLOT_IDS,
+  isLaunchSlot,
+  PAGE_SLOT_ID,
+} from '~/shared/constants/slot-registry';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { FORGEJO_ORG } from '~/server/services/blocks/forgejo.service';
@@ -342,6 +346,54 @@ async function assertCanManageBlocks(
   if (row.userId !== ctx.user.id) throw throwAuthorizationError('Not the model owner');
 }
 
+/**
+ * PAGE-ONLY LAUNCH GATE (install path). Rejects a non-launch slot for the
+ * public (non-moderator) audience; moderators are grandfathered (the live
+ * mod-only model-slot apps keep installing). Mod status is the server-stamped
+ * session flag (`ctx.user?.isModerator`), the same source every other belt in
+ * this router uses. `isLaunchSlot` is the single source of truth for "in the
+ * launch surface" — no hardcoded slot id here.
+ */
+function assertLaunchSlotForCaller(
+  ctx: { user?: { id: number; isModerator?: boolean } },
+  slotId: string
+) {
+  if (ctx.user?.isModerator) return; // grandfather mods
+  if (isLaunchSlot(slotId)) return; // launch (page) slots are public-OK
+  throw new TRPCError({
+    code: 'FORBIDDEN',
+    message: 'This app type isn’t available yet.',
+  });
+}
+
+/**
+ * Manifest-level variant of {@link assertLaunchSlotForCaller} for the
+ * subscription path, where the slot isn't an input — it's implied by the app's
+ * manifest targets. A model-slot app (the only kind that takes a subscription;
+ * page apps are stateless and never subscribed) is non-launch, so a non-mod is
+ * rejected. A moderator is grandfathered. An app is launch-eligible iff it
+ * declares a page AND `app.page` is a launch slot (mirrors the service's
+ * isAppLaunchEligible / the public-read filter, keeping the allowlist the single
+ * source of truth).
+ */
+function assertLaunchAppForCaller(
+  ctx: { user?: { id: number; isModerator?: boolean } },
+  manifest: unknown
+) {
+  if (ctx.user?.isModerator) return; // grandfather mods
+  const declaresPage =
+    !!manifest &&
+    typeof (manifest as { page?: unknown }).page === 'object' &&
+    (manifest as { page?: unknown }).page !== null &&
+    typeof (manifest as { page?: { path?: unknown } }).page?.path === 'string' &&
+    ((manifest as { page: { path: string } }).page.path?.length ?? 0) > 0;
+  if (isLaunchSlot(PAGE_SLOT_ID) && declaresPage) return; // a launch page app
+  throw new TRPCError({
+    code: 'FORBIDDEN',
+    message: 'This app type isn’t available yet.',
+  });
+}
+
 async function resolveModelIdFromBlockInstance(blockInstanceId: string): Promise<number> {
   // B2 (same posture as above): dbWrite for the ownership-relevant lookup.
   // updateSettings is publisher-only and only ever operates on pinned
@@ -410,6 +462,13 @@ export const blocksRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       await assertCanManageBlocks(ctx, input.modelId);
+      // PAGE-ONLY LAUNCH GATE: installOnModel only ever targets a MODEL slot
+      // (KNOWN_SLOT_IDS is the 3 model slots; the page slot never flows here),
+      // so every model-slot install is a non-launch slot. Reject it for the
+      // public (non-mod) audience; moderators are grandfathered so the live
+      // mod-only generate-from-model install path is untouched. `isLaunchSlot`
+      // is the single source of truth (not a hardcoded check on the slot id).
+      assertLaunchSlotForCaller(ctx, input.slotId);
       return BlockRegistry.installOnModel({
         ...input,
         installedByUserId: ctx.user!.id,
@@ -1059,7 +1118,12 @@ export const blocksRouter = router({
       if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
         return { items: [], nextCursor: undefined };
       }
-      return BlockRegistry.listAvailable(input);
+      // PAGE-ONLY LAUNCH GATE: the public (non-mod) audience sees launch (page)
+      // apps only; moderators are grandfathered (see everything, incl. the
+      // mod-only model-slot apps like generate-from-model). Mod status comes
+      // from the server-stamped session `ctx.user?.isModerator` (cannot be
+      // spoofed client-side — same source as every other belt in this router).
+      return BlockRegistry.listAvailable(input, !ctx.user?.isModerator);
     }),
 
   /**
@@ -1111,7 +1175,15 @@ export const blocksRouter = router({
       if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
         throw throwNotFoundError('App block not found');
       }
-      const detail = await BlockRegistry.getAppDetail(input.appBlockId);
+      // PAGE-ONLY LAUNCH GATE: a non-mod hitting a non-launch (model-slot) app
+      // gets the SAME NOT_FOUND posture as a missing/unapproved app — the
+      // service returns null for it under launchOnly, so no model-app detail
+      // leaks to the public. Mods (grandfathered) see every app. Mod status is
+      // the server-stamped session flag.
+      const detail = await BlockRegistry.getAppDetail(
+        input.appBlockId,
+        !ctx.user?.isModerator
+      );
       if (!detail) throw throwNotFoundError('App block not found');
       return detail;
     }),
@@ -1150,7 +1222,12 @@ export const blocksRouter = router({
       if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
         return { items: [] };
       }
-      const items = await BlockRegistry.getFeaturedBlocks(input.limit);
+      // PAGE-ONLY LAUNCH GATE: same public-vs-mod split as listAvailable — the
+      // non-mod featured rail carries launch (page) apps only; mods see all.
+      const items = await BlockRegistry.getFeaturedBlocks(
+        input.limit,
+        !ctx.user?.isModerator
+      );
       return { items };
     }),
 
@@ -1302,6 +1379,12 @@ export const blocksRouter = router({
       if (block.status !== 'approved') {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'App block is not approved' });
       }
+      // PAGE-ONLY LAUNCH GATE: a subscription only ever attaches a MODEL-slot
+      // app (page apps are stateless — Decision 2 — and never subscribed), so
+      // for the public (non-mod) audience this is always a non-launch app and is
+      // rejected. Moderators are grandfathered. Resolves launch-eligibility from
+      // the app's manifest (declares a page) since the slot isn't an input here.
+      assertLaunchAppForCaller(ctx, block.manifest);
       // Manifest-driven settings validation. The 4KB cap from the router-
       // level settingsSchema has already fired; this pass enforces the
       // per-field shape declared in the manifest. Manifests without a

--- a/src/server/services/__tests__/block-registry.page-only-launch.test.ts
+++ b/src/server/services/__tests__/block-registry.page-only-launch.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * PAGE-ONLY LAUNCH GATE — service-level tests for the public marketplace reads
+ * (`BlockRegistry.listAvailable` / `getFeaturedBlocks` / `getAppDetail`).
+ *
+ * The public (non-moderator) audience sees launch (page) apps ONLY; moderators
+ * are grandfathered (see everything). The router passes `launchOnly =
+ * !ctx.user?.isModerator`. These tests pin:
+ *   - listAvailable / getFeaturedBlocks thread the page-app SQL filter into the
+ *     query iff launchOnly (and omit it for mods);
+ *   - getAppDetail returns null for a non-launch (model) app under launchOnly
+ *     (→ router NOT_FOUND), returns a page app under launchOnly, and returns a
+ *     model app when launchOnly=false (mod / grandfather).
+ *
+ * Mocks @prisma/client so `Prisma.sql` works without a generated client (the
+ * local NixOS Prisma stub has no `sql`), and stubs dbRead.$queryRaw to capture
+ * the assembled SQL + return seeded rows.
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    blockUserSubscription: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    modelVersion: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+  },
+}));
+
+// A minimal Prisma.sql shim that records its template so the assembled SQL is
+// reconstructable. Each Prisma.sql(...) call returns a tagged object carrying a
+// `.sql` string; interpolating one inside another flattens via toString.
+vi.mock('@prisma/client', () => {
+  function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+    let out = '';
+    for (let i = 0; i < strings.length; i++) {
+      out += strings[i];
+      if (i < values.length) {
+        const v = values[i];
+        out +=
+          v && typeof v === 'object' && '__sql' in (v as object)
+            ? (v as { __sql: string }).__sql
+            : '?';
+      }
+    }
+    return { __sql: out, sql: out, toString: () => out } as unknown as { sql: string };
+  }
+  return { Prisma: { sql } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  },
+  sysRedis: { sMembers: vi.fn(async () => []) },
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'packed:caches:block-registry', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+
+/** Reconstruct the assembled SQL string from the captured Prisma.sql object. */
+function capturedSql(): string {
+  expect(mockDbRead.$queryRaw).toHaveBeenCalled();
+  const lastCall = mockDbRead.$queryRaw.mock.calls.at(-1);
+  if (!lastCall) return '';
+  const first = lastCall[0] as unknown;
+  if (first && typeof first === 'object' && typeof (first as { sql?: unknown }).sql === 'string') {
+    return (first as { sql: string }).sql;
+  }
+  // Tagged-template form (getFeaturedBlocks): rebuild from strings + values.
+  const strings = first as unknown as TemplateStringsArray;
+  const values = lastCall.slice(1);
+  let s = '';
+  for (let i = 0; i < strings.length; i++) {
+    s += strings[i];
+    if (i < values.length) {
+      const v = values[i];
+      s += v && typeof v === 'object' && 'sql' in (v as object) ? (v as { sql: string }).sql : '?';
+    }
+  }
+  return s;
+}
+
+const PAGE_FILTER_RE = /ab\.manifest->'page'->>'path'/;
+
+function listRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_1',
+    block_id: 'cool-block',
+    app_id: 'app_1',
+    app_name: 'Cool App',
+    install_count: 5n,
+    category: 'utility',
+    approved_scopes: ['user:read:self'],
+    sort_key: '00000000000000000005',
+    manifest: { name: 'Cool Block', targets: [{ slotId: 'model.sidebar_top' }] },
+    ...over,
+  };
+}
+
+function detailRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_det',
+    block_id: 'detail-block',
+    app_id: 'app_1',
+    app_name: 'Detail App',
+    status: 'approved',
+    content_rating: null,
+    version: '1.0.0',
+    approved_scopes: ['user:read:self'],
+    install_count: 3n,
+    screenshots: null,
+    // model app by default (no page field)
+    manifest: { name: 'Detail Block', targets: [{ slotId: 'model.sidebar_top' }] },
+    ...over,
+  };
+}
+
+describe('BlockRegistry — page-only launch gate (public reads)', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([listRow()]);
+  });
+
+  describe('listAvailable', () => {
+    it('non-mod (launchOnly=true) threads the page-app filter into the SQL', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' }, true);
+      expect(capturedSql()).toMatch(PAGE_FILTER_RE);
+    });
+
+    it('mod (launchOnly=false / default) does NOT add the page-app filter', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' }, false);
+      expect(capturedSql()).not.toMatch(PAGE_FILTER_RE);
+      // default param is also non-launch (mods/internal callers)
+      mockDbRead.$queryRaw.mockClear();
+      await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' });
+      expect(capturedSql()).not.toMatch(PAGE_FILTER_RE);
+    });
+
+    it('the approved-only filter still stands under launchOnly (no regression)', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' }, true);
+      expect(capturedSql()).toMatch(/ab\.status\s*=\s*'approved'/);
+    });
+  });
+
+  describe('getFeaturedBlocks', () => {
+    it('non-mod (launchOnly=true) threads the page-app filter into the SQL', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.getFeaturedBlocks(12, true);
+      expect(capturedSql()).toMatch(PAGE_FILTER_RE);
+    });
+
+    it('mod (launchOnly=false / default) does NOT add the page-app filter', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.getFeaturedBlocks(12, false);
+      expect(capturedSql()).not.toMatch(PAGE_FILTER_RE);
+    });
+  });
+
+  describe('getAppDetail', () => {
+    it('non-mod (launchOnly=true): a MODEL app resolves to null (→ NOT_FOUND, no leak)', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([detailRow()]); // model app
+      const { BlockRegistry } = await import('../block-registry.service');
+      const detail = await BlockRegistry.getAppDetail('ab_det', true);
+      expect(detail).toBeNull();
+    });
+
+    it('non-mod (launchOnly=true): a PAGE app resolves normally', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([
+        detailRow({ manifest: { name: 'Page Block', page: { path: '/run', title: 'Run' } } }),
+      ]);
+      const { BlockRegistry } = await import('../block-registry.service');
+      const detail = await BlockRegistry.getAppDetail('ab_det', true);
+      expect(detail).not.toBeNull();
+      expect(detail?.id).toBe('ab_det');
+    });
+
+    it('mod (launchOnly=false / default): a MODEL app resolves normally (grandfather)', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([detailRow()]); // model app
+      const { BlockRegistry } = await import('../block-registry.service');
+      const detail = await BlockRegistry.getAppDetail('ab_det', false);
+      expect(detail).not.toBeNull();
+      expect(detail?.id).toBe('ab_det');
+      // default param behaves like a mod (back-compat for internal callers)
+      mockDbRead.$queryRaw.mockResolvedValueOnce([detailRow()]);
+      const detail2 = await BlockRegistry.getAppDetail('ab_det');
+      expect(detail2).not.toBeNull();
+    });
+
+    it('a non-approved app is null regardless of launchOnly (approved-gate unchanged)', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([
+        detailRow({ status: 'pending', manifest: { name: 'P', page: { path: '/x', title: 'X' } } }),
+      ]);
+      const { BlockRegistry } = await import('../block-registry.service');
+      expect(await BlockRegistry.getAppDetail('ab_det', true)).toBeNull();
+    });
+  });
+});

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -30,6 +30,7 @@ import type {
 } from '~/server/schema/blocks/subscription.schema';
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 import { toPublicBlockManifest, toPublicScreenshots } from '~/server/schema/blocks/subscription.schema';
+import { isLaunchSlot, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
 
 const CACHE_TTL_SECONDS = 60;
 export const MAX_BLOCKS_PER_SLOT = 3;
@@ -382,6 +383,46 @@ function manifestDeclaresPage(manifest: unknown): boolean {
   if (!m.page || typeof m.page !== 'object') return false;
   const page = m.page as { path?: unknown };
   return typeof page.path === 'string' && page.path.length > 0;
+}
+
+/**
+ * PAGE-ONLY LAUNCH GATE — the app-level predicate behind the slot-level
+ * `isLaunchSlot` allowlist (src/shared/constants/slot-registry.ts).
+ *
+ * The public (non-mod) marketplace exposes launch slots only. The ONLY launch
+ * slot today is `app.page`, and a page app is identified at the app level by
+ * declaring its page surface (the `page` field — never a `targets[]` entry; the
+ * manifest validator forbids `app.page` in targets). So "this app's slot is a
+ * launch slot" ⇔ "this app declares a page". `manifestDeclaresPage` is reused so
+ * the launch check and the page-mint / SSR-resolve path agree on what a page is.
+ *
+ * Gated on `isLaunchSlot(PAGE_SLOT_ID)` so the slot-registry allowlist stays the
+ * single source of truth: if `app.page` were ever removed from
+ * `LAUNCH_SLOT_IDS`, this returns false for every app and the public surface
+ * goes (correctly) empty — no separate edit here.
+ */
+function isAppLaunchEligible(manifest: unknown): boolean {
+  return isLaunchSlot(PAGE_SLOT_ID) && manifestDeclaresPage(manifest);
+}
+
+/**
+ * The SQL embodiment of {@link isAppLaunchEligible}, applied in the public
+ * marketplace queries when the caller is a non-moderator (`launchOnly`).
+ *
+ * Returns a Prisma.sql predicate that keeps ONLY launch-eligible (page) apps:
+ *   - while `app.page` is a launch slot: `manifest->'page'->>'path'` is a
+ *     non-empty string (the same "declares a page" test `manifestDeclaresPage`
+ *     applies in JS — `->>` yields NULL for a missing/non-string path);
+ *   - if `app.page` is no longer a launch slot: `false` (public surface empty),
+ *     mirroring `isAppLaunchEligible`.
+ *
+ * For a moderator caller the router passes `launchOnly=false` → this is omitted
+ * entirely (grandfather: mods see/install/mint everything).
+ */
+function launchOnlySqlFilter(launchOnly: boolean): Prisma.Sql {
+  if (!launchOnly) return Prisma.sql`TRUE`;
+  if (!isLaunchSlot(PAGE_SLOT_ID)) return Prisma.sql`FALSE`;
+  return Prisma.sql`COALESCE(ab.manifest->'page'->>'path', '') <> ''`;
 }
 
 function resolveRenderMode(
@@ -2385,7 +2426,12 @@ export class BlockRegistry {
    * null), which is fine while the surface is dark.
    */
   static async listAvailable(
-    input: ListAvailableInput
+    input: ListAvailableInput,
+    // PAGE-ONLY LAUNCH GATE: when true (a non-moderator caller — the router
+    // passes `!ctx.user?.isModerator`), the marketplace returns ONLY
+    // launch-eligible (page) apps. Defaults false (moderator / internal callers
+    // see everything — grandfather). See launchOnlySqlFilter / isLaunchSlot.
+    launchOnly = false
   ): Promise<{ items: AvailableBlock[]; nextCursor?: string }> {
     const { slotId, query, category, sort, cursor, limit } = input;
     type Row = {
@@ -2456,6 +2502,8 @@ export class BlockRegistry {
       FROM app_blocks ab
       LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
       WHERE ab.status = 'approved'
+        -- PAGE-ONLY LAUNCH GATE: non-mod callers see launch (page) apps only.
+        AND ${launchOnlySqlFilter(launchOnly)}
         AND (
           ${slotFilter}::text IS NULL
           OR ab.manifest @> ${slotFilter}::jsonb
@@ -2530,7 +2578,14 @@ export class BlockRegistry {
    * app — the router maps that to NOT_FOUND so a non-approved app's data can
    * never be enumerated by id.
    */
-  static async getAppDetail(appBlockId: string): Promise<PublicAppDetail | null> {
+  static async getAppDetail(
+    appBlockId: string,
+    // PAGE-ONLY LAUNCH GATE: when true (non-mod caller), a non-launch (model)
+    // app resolves to null — the router maps that to the SAME NOT_FOUND a
+    // missing/unapproved app produces, so a non-mod can't enumerate or read a
+    // model-slot app's detail. Defaults false (mods see everything).
+    launchOnly = false
+  ): Promise<PublicAppDetail | null> {
     type Row = {
       id: string;
       block_id: string;
@@ -2572,6 +2627,11 @@ export class BlockRegistry {
     // a non-approved row returns null exactly like a missing one — never its
     // data. (The marketplace install mutations apply the same approved gate.)
     if (!row || row.status !== 'approved') return null;
+    // PAGE-ONLY LAUNCH GATE (non-mod): a non-launch (model-slot) app is
+    // indistinguishable from a missing one to the public — return null so the
+    // router surfaces NOT_FOUND (no detail leak). isAppLaunchEligible reuses the
+    // same "declares a page" predicate as the listing filter + the page mint.
+    if (launchOnly && !isAppLaunchEligible(row.manifest)) return null;
     return {
       id: row.id,
       blockId: row.block_id,
@@ -2618,7 +2678,12 @@ export class BlockRegistry {
    * No cursor: the featured set is a small curated list (rail above the grid),
    * capped by `limit` (≤24); paginating a staff-pick rail isn't a requirement.
    */
-  static async getFeaturedBlocks(limit: number): Promise<AvailableBlock[]> {
+  static async getFeaturedBlocks(
+    limit: number,
+    // PAGE-ONLY LAUNCH GATE: non-mod callers get launch (page) apps only;
+    // mods see every featured app. Defaults false. See launchOnlySqlFilter.
+    launchOnly = false
+  ): Promise<AvailableBlock[]> {
     type Row = {
       id: string;
       block_id: string;
@@ -2643,6 +2708,8 @@ export class BlockRegistry {
       FROM app_blocks ab
       LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
       WHERE ab.status = 'approved'
+        -- PAGE-ONLY LAUNCH GATE: non-mod callers see launch (page) apps only.
+        AND ${launchOnlySqlFilter(launchOnly)}
         AND ab.featured = true
       ORDER BY ab.featured_order ASC NULLS LAST,
                install_count DESC,

--- a/src/shared/constants/__tests__/slot-registry.test.ts
+++ b/src/shared/constants/__tests__/slot-registry.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   ALL_SLOT_IDS,
   isKnownSlotId,
+  isLaunchSlot,
   isPageSlot,
   KNOWN_SLOT_IDS,
+  LAUNCH_SLOT_IDS,
   MODEL_SLOT_IDS,
   PAGE_FORBIDDEN_SCOPES,
   PAGE_SLOT_ID,
@@ -82,5 +84,44 @@ describe('slot-registry (Phase 0 foundation)', () => {
   it('only model + none entities are present in the registry today', () => {
     const entities = new Set(Object.values(SLOT_REGISTRY).map((s) => s.entity));
     expect(entities).toEqual(new Set(['model', 'none']));
+  });
+
+  // ---------------------------------------------------------------------------
+  // PAGE-ONLY LAUNCH GATE — the public-audience launch allowlist.
+  // ---------------------------------------------------------------------------
+  describe('LAUNCH_SLOT_IDS / isLaunchSlot (page-only launch allowlist)', () => {
+    it('the launch allowlist is exactly the page slot today', () => {
+      expect([...LAUNCH_SLOT_IDS]).toEqual(['app.page']);
+      // The page slot id constant IS the launch slot — they can't drift.
+      expect([...LAUNCH_SLOT_IDS]).toContain(PAGE_SLOT_ID);
+    });
+
+    it('isLaunchSlot is TRUE for the page slot', () => {
+      expect(isLaunchSlot('app.page')).toBe(true);
+      expect(isLaunchSlot(PAGE_SLOT_ID)).toBe(true);
+    });
+
+    it('isLaunchSlot is FALSE for every model slot (model slots are mod-only at launch)', () => {
+      for (const id of MODEL_SLOT_IDS) {
+        expect(isLaunchSlot(id), `model slot "${id}" must NOT be a launch slot`).toBe(false);
+      }
+      expect(isLaunchSlot('model.sidebar_top')).toBe(false);
+      expect(isLaunchSlot('model.below_images')).toBe(false);
+      expect(isLaunchSlot('model.actions_extra')).toBe(false);
+    });
+
+    it('isLaunchSlot is FALSE for an unknown / arbitrary slot id', () => {
+      expect(isLaunchSlot('not.a.slot')).toBe(false);
+      expect(isLaunchSlot('')).toBe(false);
+    });
+
+    // The launch surface must be a SUBSET of the page slots — a model slot must
+    // never sneak in (that would expose model apps to the public). This locks
+    // the invariant a future widen has to consciously break.
+    it('every launch slot is a page slot (no model slot in the launch surface)', () => {
+      for (const id of LAUNCH_SLOT_IDS) {
+        expect(isPageSlot(id), `launch slot "${id}" must be a page slot`).toBe(true);
+      }
+    });
   });
 });

--- a/src/shared/constants/slot-registry.ts
+++ b/src/shared/constants/slot-registry.ts
@@ -182,3 +182,35 @@ export const PAGE_FORBIDDEN_SCOPES = ['buzz:read:self', 'social:tip:self'] as co
 export function isPageSlot(id: string): boolean {
   return isKnownSlotId(id) && SLOT_REGISTRY[id].kind === 'page';
 }
+
+/**
+ * LAUNCH ALLOWLIST — the slot ids exposed to the PUBLIC (non-moderator) audience
+ * at the initial App Blocks public launch.
+ *
+ * WHY: the initial launch ships the full-page app surface (`app.page`) ONLY. The
+ * three model-page slots (`model.sidebar_top` / `model.below_images` /
+ * `model.actions_extra`) are NOT part of the public launch — they remain
+ * MOD-ONLY for testing/dog-fooding (e.g. the live `generate-from-model` block)
+ * until a later product decision widens them. So this is a PUBLIC-audience
+ * restriction layered on top of the existing `features.appBlocks` flag gate:
+ * moderators are unaffected (they see/install/mint every slot, grandfathering
+ * the existing mod-only model-slot usage); non-mods are scoped to launch slots.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for "what's in the public launch". Widening
+ * the launch surface later (e.g. graduating a model slot to public) is ONE edit
+ * here — every enforcement point (public marketplace reads, the model-slot
+ * install path, the token mint belt) calls `isLaunchSlot` rather than hardcoding
+ * `'app.page'`.
+ */
+export const LAUNCH_SLOT_IDS = ['app.page'] as const;
+
+export type LaunchSlotId = (typeof LAUNCH_SLOT_IDS)[number];
+
+/**
+ * Is `id` a slot exposed to the public (non-mod) audience at launch? See
+ * {@link LAUNCH_SLOT_IDS}. A non-mod caller may only browse / install / mint
+ * apps whose slot satisfies this; a moderator is exempt (grandfathered).
+ */
+export function isLaunchSlot(id: string): boolean {
+  return (LAUNCH_SLOT_IDS as readonly string[]).includes(id);
+}

--- a/src/tests/api/v1/block-tokens/index.test.ts
+++ b/src/tests/api/v1/block-tokens/index.test.ts
@@ -575,14 +575,23 @@ describe('POST /api/v1/block-tokens', () => {
   // consent-gated `:self`/owned/money/tip scope STRIPPED), instead of a 403.
   // ==========================================================================
 
-  it('anon mint (flag public): issues a token with money/self scopes STRIPPED, not 403', async () => {
+  // PAGE-ONLY LAUNCH GATE: an anon caller is a non-moderator, and these bodies
+  // mint a MODEL slot (model.sidebar_top) — a NON-launch slot. The launch belt
+  // therefore rejects the mint with 403 BEFORE the anon scope-strip runs. (The
+  // anon scope-strip invariant — money/self scopes withheld for anon — is now
+  // exercised on the PAGE path, where a non-mod CAN mint: see
+  // src/tests/api/v1/block-tokens/page-mint.test.ts.) These two tests previously
+  // asserted the pre-launch-gate "anon mints a model-slot token with scopes
+  // stripped, not 403"; under page-only launch that path is closed for non-mods.
+  it('anon mint (flag public) + MODEL slot: rejected by the page-only launch belt (403), never signs', async () => {
     const flagMod = await import('~/server/services/feature-flags.service');
-    // Flag widened to public: anon now passes the mint gate.
+    // Flag widened to public: anon now passes the master appBlocks flag gate…
     (flagMod.getFeatureFlags as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       appBlocks: true,
     });
-    mockSession.value = null; // anonymous
-    // generate-from-model's real manifest: models:read:self + ai:write:budgeted.
+    mockSession.value = null; // anonymous (non-mod)
+    // generate-from-model's real manifest: models:read:self + ai:write:budgeted,
+    // on a MODEL slot (RESOLVED_INSTALL.slotId = model.sidebar_top).
     mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
       ...RESOLVED_INSTALL,
       appBlock: {
@@ -595,59 +604,34 @@ describe('POST /api/v1/block-tokens', () => {
     const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
     const res = makeRes();
     await handler(makeReq({ origin: 'https://civitai.com', body: validBody() }), res);
-    expect(res._status).toBe(200);
-    expect(mockTokenService.sign).toHaveBeenCalled();
-    const signArgs = mockTokenService.sign.mock.calls.at(-1)?.[0] as {
-      scopes: string[];
-      userId: number | null;
-    };
-    // SECURITY INVARIANT: no money/owned/tip scope in an anon token. The
-    // consent-gated strip is the COMPLEMENT of CONSENT_EXEMPT_SCOPES, so every
-    // gated `:self`/owned/money/tip scope is withheld.
-    expect(signArgs.scopes).not.toContain('ai:write:budgeted');
-    expect(signArgs.scopes).not.toContain('buzz:read:self');
-    expect(signArgs.scopes).not.toContain('user:read:self');
-    expect(signArgs.scopes).not.toContain('social:tip:self');
-    expect(signArgs.scopes).not.toContain('media:read:owned');
-    // models:read:self is consent-exempt (allow-by-default — it's the public
-    // model on the page the block is mounted on), so it SURVIVES for anon. For
-    // generate-from-model (models:read:self + ai:write:budgeted) the anon-safe
-    // subset is therefore exactly [models:read:self].
-    expect(signArgs.scopes).toEqual(['models:read:self']);
-    // sub is anon (userId null on the sign call).
-    expect(signArgs.userId).toBeNull();
-    // No consent prompt for anon — the host converts gated actions to sign-in.
-    const body = res._body as { needsConsent: boolean; missingScopes: string[] };
-    expect(body.needsConsent).toBe(false);
-    expect(body.missingScopes).toEqual([]);
+    // …but the model slot is non-launch → 403 from the launch belt, no token.
+    expect(res._status).toBe(403);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
-  it('anon mint (flag public): consent-exempt apps:storage:* survives the strip', async () => {
-    // Belt-and-suspenders: a manifest mixing a money scope with a consent-exempt
-    // ambient scope keeps only the exempt one for anon. Proves the strip is the
-    // COMPLEMENT of the exempt set, not a hand-maintained money denylist.
+  it('authed NON-MOD mint (flag public) + MODEL slot: rejected by the launch belt (403)', async () => {
+    // The defense-in-depth belt also catches an AUTHENTICATED non-mod (a model
+    // install shouldn't exist for them after the install-path gate, but the mint
+    // refuses anyway). Mods are unaffected (covered by 'authed-mod mint' below).
     const flagMod = await import('~/server/services/feature-flags.service');
     (flagMod.getFeatureFlags as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       appBlocks: true,
     });
-    mockSession.value = null;
+    mockSession.value = { user: { id: 77, bannedAt: null, isModerator: false } } as never;
     mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
       ...RESOLVED_INSTALL,
       appBlock: {
         ...RESOLVED_INSTALL.appBlock,
-        manifest: { scopes: ['apps:storage:read', 'ai:write:budgeted', 'buzz:read:self'] },
-        approvedScopes: ['apps:storage:read', 'ai:write:budgeted', 'buzz:read:self'],
-        app: { allowedScopes: 0xffffffff },
+        manifest: { scopes: ['models:read:self'] },
+        approvedScopes: ['models:read:self'],
+        app: { allowedScopes: 4 },
       },
     });
     const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
     const res = makeRes();
     await handler(makeReq({ origin: 'https://civitai.com', body: validBody() }), res);
-    expect(res._status).toBe(200);
-    const signArgs = mockTokenService.sign.mock.calls.at(-1)?.[0] as { scopes: string[] };
-    expect(signArgs.scopes).toEqual(['apps:storage:read']);
-    expect(signArgs.scopes).not.toContain('ai:write:budgeted');
-    expect(signArgs.scopes).not.toContain('buzz:read:self');
+    expect(res._status).toBe(403);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
   it('authed-mod mint: unchanged — manifest scopes sign when granted', async () => {

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -260,6 +260,30 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(signArg.scopes).toEqual(['apps:storage:read', 'apps:storage:write']);
   });
 
+  it('PAGE-ONLY LAUNCH GATE: a NON-MOD can still mint a page token (launch belt must NOT hide page apps)', async () => {
+    // The page-only launch gate restricts the PUBLIC to launch (page) slots —
+    // it must NOT block the page path itself (that would defeat the purpose).
+    // app.page IS a launch slot, so a non-mod with both page flags on mints a
+    // page token exactly like a mod. (Flag the non-mod ON to model the launch
+    // segment-widen; otherwise the appBlocks/appBlocksPages gates would 403
+    // first, masking the launch-belt behaviour under test.)
+    const NON_MOD = { user: { id: 7, isModerator: false, bannedAt: null } } as any;
+    mockSession.value = NON_MOD;
+    (mockFlags.getFeatureFlags as any).mockImplementation(() => ({
+      appBlocks: true,
+      appBlocksPages: true,
+    }));
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+      PAGE_BLOCK(['apps:storage:read', 'apps:storage:write'])
+    );
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+    // 200 — the launch belt passes for a page slot regardless of mod status.
+    expect(res._status).toBe(200);
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects a page manifest that declares a still-forbidden money scope (page hard rule)', async () => {
     // The OAuth client ALLOWS the money scope + it's in the approved set — so
     // the earlier OAuth/approved gates pass and the PAGE HARD RULE is what


### PR DESCRIPTION
## Decision: page-only public launch

For the **initial public launch**, the App Blocks marketplace + installs expose **page apps (`app.page`) ONLY**. The three model-slot surfaces (`model.sidebar_top` / `model.below_images` / `model.actions_extra`) are **not** part of launch.

**We grandfather moderators** so the live mod-only `generate-from-model` block keeps working for testing, but block **new public exposure** — i.e. the restriction applies to the **public (non-mod) audience**; **mods are unaffected** (see/install/mint every slot).

This is **additive on top of** the existing `features.appBlocks` / `enforceAppBlocksFlag` gating — it does **not** change the flag model or the Flipt flag. It only narrows what the public sees once the segment is widened at launch.

## The allowlist (single source of truth)

`src/shared/constants/slot-registry.ts`:
- `export const LAUNCH_SLOT_IDS = ['app.page'] as const;`
- `export function isLaunchSlot(id: string): boolean`

Every enforcement point calls `isLaunchSlot` (no hardcoded `'app.page'`), so **widening the launch surface later = one edit here**. A page app is identified at the app level by declaring its page surface (`page.path`) — `app.page` is never a `targets[]` entry (the manifest validator forbids it), so "this app's slot is a launch slot" ⇔ "this app declares a page".

## Enforcement points

Each branches on the **server-stamped session moderator flag** (`ctx.user?.isModerator` in the router; `session?.user?.isModerator` in the mint endpoint) — the same source every existing belt uses (can't be spoofed client-side).

1. **Public marketplace reads** (`blocks.router.ts` → `BlockRegistry`): non-mod callers pass `launchOnly = !isModerator` into `listAvailable` / `getFeaturedBlocks` / `getAppDetail`. The service applies a page-app SQL filter (`COALESCE(manifest->'page'->>'path','') <> ''`) so pagination stays correct; `getAppDetail` returns the **same NOT_FOUND posture** for a non-launch app as a missing/unapproved one (no model-app detail leak). Mods → `launchOnly=false` (everything).
2. **Install path** (`installOnModel`, `upsertSubscription`, both `protectedProcedure`): non-mod + model slot → `FORBIDDEN` ("This app type isn't available yet."). `installOnModel` only ever takes model slots; `upsertSubscription` only ever attaches model-slot apps (page apps are stateless, never subscribed). Mods grandfathered.
3. **Belt at the mint** (`POST /api/v1/block-tokens`): defense-in-depth — a non-mod minting a non-launch slot → 403, even though the install gate should prevent one existing. The page path naturally passes (`app.page` IS a launch slot) and is unchanged.

## Tests (vitest)

- `isLaunchSlot` unit: page=true, model slots=false, unknown=false; launch surface ⊆ page slots.
- **Service reads** (`block-registry.page-only-launch.test.ts`, mocks `@prisma/client` so `Prisma.sql` works): non-mod threads the page filter into the SQL; mod omits it; `getAppDetail` → null for a model app under launchOnly, served for a page app, served for a mod.
- **Install/subscribe** (`blocks.router.subscriptions.test.ts`): non-mod + model slot → FORBIDDEN; **mod + model slot → allowed (grandfather)**; non-mod listAvailable forwards `launchOnly=true`.
- **Mint belt** (`block-tokens/index.test.ts` + `page-mint.test.ts`): non-mod model-slot mint → 403; mod model-slot mint → signs (grandfather); **non-mod page mint → 200** (the belt must NOT hide page apps from the public).
- **Mutation-checked** both key branches (install helper + mint belt): inverting the `isModerator` check fails the grandfather + non-mod tests.

All touched suites: **126 passed**. (The pre-existing `block-registry.list-available` / `get-app-detail` SQL suites can't run on this NixOS host — ungenerated Prisma stub lacks `Prisma.sql`; they fail identically before this change and run in CI.)

## Typecheck

The router / mint endpoint / slot-registry / new test typecheck **clean**. The only `tsc` errors in touched files are `Prisma.sql`/`Prisma.Sql` "not exported" — present on the **pre-existing** `Prisma.sql` usage too (offline-Prisma host limitation), using the identical API the file already relies on. Not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)