### PR TITLE
feat(app-blocks): viewer_global attribution scope — track page Buzz purchases (W3 flow B)

### DIFF
--- a/prisma/migrations/20260618120000_block_attribution_viewer_global_scope/migration.sql
+++ b/prisma/migrations/20260618120000_block_attribution_viewer_global_scope/migration.sql
@@ -1,0 +1,32 @@
+-- W3 Slice 1 — App Blocks attribution flow B (page Buzz PURCHASE).
+--
+-- Extend the block_buzz_attribution scope CHECK constraint to accept the new
+-- `viewer_global` scope (W10 full-page apps, entity=none). A Buzz purchase made
+-- inside a page surface mints with a synthetic `page_<appBlockId>` instanceId,
+-- which the FIN-1 server re-derivation now resolves to `viewer_global`
+-- (placeholder 0% publisher share — see rate-card.ts RATE_CARD_V3). Without
+-- this constraint change the webhook INSERT of a page-purchase row would be
+-- rejected by the existing IN (...) list.
+--
+-- ⚠️ MANUAL-APPLY (civitai DB rule): this file is committed for history but is
+--    NOT auto-applied. A human must run it via psql/retool on:
+--      1. prod nvme0  (role=postgres CNPG cluster — the main civitai DB)
+--      2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev)
+--    BEFORE the code that writes `viewer_global` deploys — otherwise the
+--    CHECK rejects the INSERT and the page purchase's attribution is lost.
+--
+-- Behavior-preserving for existing rows: it only WIDENS the allowed set; no
+-- existing row uses `viewer_global` (the scope is net-new in this PR).
+
+ALTER TABLE "block_buzz_attribution"
+  DROP CONSTRAINT IF EXISTS "block_buzz_attribution_scope_check";
+
+ALTER TABLE "block_buzz_attribution"
+  ADD CONSTRAINT "block_buzz_attribution_scope_check"
+  CHECK ("scope" IN (
+    'per_model_install',
+    'publisher_all_my_models',
+    'viewer_personal',
+    'platform_default',
+    'viewer_global'
+  ));

--- a/src/server/schema/blocks/__tests__/attribution.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/attribution.schema.test.ts
@@ -26,8 +26,20 @@ describe('deriveScopeFromInstanceId', () => {
     ['bus_pub_01HZK', 'publisher_all_my_models'],
     ['bus_view_01HZK', 'viewer_personal'],
     ['pdb_01HZK', 'platform_default'],
+    // W3 flow B: page surface (W10) → viewer_global. `page_<appBlockId>`.
+    ['page_apb_01HZK', 'viewer_global'],
   ] as const)('maps %s to %s', (id, scope) => {
     expect(deriveScopeFromInstanceId(id)).toBe(scope);
+  });
+
+  it('maps a page_ instance to viewer_global (flow B) and leaves the others unchanged', () => {
+    expect(deriveScopeFromInstanceId('page_apb_xyz')).toBe('viewer_global');
+    // The pre-existing prefixes are unchanged by the new branch.
+    expect(deriveScopeFromInstanceId('mbi_x')).toBe('publisher_all_my_models');
+    expect(deriveScopeFromInstanceId('bki_x')).toBe('publisher_all_my_models');
+    expect(deriveScopeFromInstanceId('bus_pub_x')).toBe('publisher_all_my_models');
+    expect(deriveScopeFromInstanceId('bus_view_x')).toBe('viewer_personal');
+    expect(deriveScopeFromInstanceId('pdb_x')).toBe('platform_default');
   });
 
   it('no longer emits the stale per_model_install bucket for any live prefix (L-M2)', () => {

--- a/src/server/schema/blocks/attribution.schema.ts
+++ b/src/server/schema/blocks/attribution.schema.ts
@@ -15,6 +15,14 @@ export const blockAttributionScopeSchema = z.enum([
   'publisher_all_my_models', // bus_pub_* (blanket) + mbi_*/bki_* (per-model-pinned) — block_user_subscriptions
   'viewer_personal',         // bus_view_* — block_user_subscriptions (viewer scope)
   'platform_default',        // pdb_* — platform_default_blocks
+  // W10 full-page apps (`app.page` slot, entity=none). A page is a stateless,
+  // viewer-chosen full-page surface with NO model entity and NO install row —
+  // its synthetic instanceId is `page_<appBlockId>` (see block-tokens page
+  // mint). A Buzz PURCHASE made inside a page resolves to this scope.
+  // Placeholder publisher share is 0% (page revenue is largely
+  // platform-counterfactual); raise via a future rate card after monetization
+  // sign-off. See deriveScopeFromInstanceId + SOURCE_TO_SCOPE['page'].
+  'viewer_global',           // page_* — pages (resolvePageBlock, entity=none)
 ]);
 export type BlockAttributionScope = z.infer<typeof blockAttributionScopeSchema>;
 
@@ -89,6 +97,11 @@ export function deriveScopeFromInstanceId(
   if (blockInstanceId.startsWith('bus_pub_')) return 'publisher_all_my_models';
   if (blockInstanceId.startsWith('bus_view_')) return 'viewer_personal';
   if (blockInstanceId.startsWith('pdb_')) return 'platform_default';
+  // W10 page surface — `page_<appBlockId>` (the synthetic page mint id). A page
+  // has no model entity; the purchase attributes to the page app's author at
+  // the `viewer_global` scope. Kept in lockstep with the server's
+  // SOURCE_TO_SCOPE['page'] re-derivation (the server is authoritative).
+  if (blockInstanceId.startsWith('page_')) return 'viewer_global';
   return null;
 }
 

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -220,7 +220,14 @@ export type ResolvedBlockSource =
   | 'install'
   | 'platform_default'
   | 'publisher_subscription'
-  | 'viewer_subscription';
+  | 'viewer_subscription'
+  // W10 full-page app (`page_<appBlockId>`, entity=none). A page is stateless:
+  // it has NO install row, NO model entity, and resolves directly from the
+  // approved AppBlock (see resolvePageBlock). Used by the FIN-1
+  // buzz-attribution re-derivation to bucket a page purchase as
+  // `viewer_global` (SOURCE_TO_SCOPE in attribution-validator.service.ts).
+  // `modelId` is the 0 sentinel for this source — a page never pins a model.
+  | 'page';
 
 export interface ResolvedBlockInstance {
   source: ResolvedBlockSource;
@@ -1067,6 +1074,46 @@ export class BlockRegistry {
   }): Promise<ResolvedBlockInstance | null> {
     const { blockInstanceId, modelId, slotId, viewerUserId } = opts;
     const db = opts.db === 'read' ? dbRead : dbWrite;
+
+    // page_<app_block_id> — W10 full-page app, entity=none (FIN-1 re-derive).
+    //
+    // A page is STATELESS: no install row, no model entity, no per-owner /
+    // per-viewer predicate. It is "viewer-global" — any viewer who can load
+    // the page can transact inside it, so the only authoritative check is that
+    // the cited AppBlock is APPROVED and actually declares a page surface
+    // (exactly resolvePageBlock's contract). modelId/slotId/viewerUserId are
+    // intentionally ignored for this source. This branch exists so the
+    // buzz-attribution validator re-derives a page purchase to a single
+    // source (`page` → `viewer_global`) rather than trusting the client
+    // `blockScope`; a forged scope on a `page_*` id is corrected, and a
+    // `page_*` id for a non-approved / non-page app fails to resolve (→ the
+    // validator strips attribution, fail-safe).
+    //
+    // NOTE: this resolver path is read-only re-derivation for attribution. The
+    // TOKEN MINT page path (block-tokens/index.ts) deliberately does NOT route
+    // through here — it builds its own `resolved` from resolvePageBlock with
+    // the page-specific budget/scope gates. Both call resolvePageBlock, so they
+    // agree on which page apps exist.
+    if (blockInstanceId.startsWith('page_')) {
+      const appBlockId = blockInstanceId.slice('page_'.length);
+      if (!appBlockId) return null;
+      const page = await BlockRegistry.resolvePageBlock(appBlockId, {
+        db: opts.db === 'read' ? 'read' : 'write',
+      });
+      if (!page) return null;
+      return {
+        source: 'page',
+        // A page has no model entity. 0 is the documented sentinel; the
+        // attribution validator omits blockModelId for the `page` source so
+        // a 0 never lands on a row.
+        modelId: 0,
+        slotId,
+        enabled: true,
+        settings: {},
+        installedByUserId: null,
+        appBlock: page.appBlock,
+      };
+    }
 
     // mbi_* / bki_* — historical per-model install ids. Since the 2026-05-30
     // kill_per_model_installs migration, these resolve via block_user

--- a/src/server/services/blocks/__tests__/attribution-validator.service.test.ts
+++ b/src/server/services/blocks/__tests__/attribution-validator.service.test.ts
@@ -248,3 +248,181 @@ describe('validateBuzzPurchaseAttribution', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// W3 flow B — page Buzz PURCHASE attribution (`page_<appBlockId>`).
+//
+// A page purchase carries NO modelId/slotId. The validator must re-derive it
+// to `viewer_global` via the resolver's `page` source BEFORE the model-path
+// modelId/slotId gate, and must keep the FIN-1 forge-resistance invariant
+// (a forged scope / app is corrected; an unresolvable page is stripped).
+// ---------------------------------------------------------------------------
+const PAGE_APP_ID = 'app_page';
+const PAGE_APP_BLOCK_ID = 'apb_page';
+const PAGE_INSTANCE = `page_${PAGE_APP_BLOCK_ID}`;
+
+/** Metadata a page surface would carry — NO modelId, NO slotId. */
+function pageMetadata(over: Record<string, unknown> = {}) {
+  return {
+    type: 'buzzPurchase',
+    unitAmount: 100,
+    buzzAmount: 1000,
+    userId: SESSION_USER,
+    buzzType: 'yellow',
+    blockAppId: PAGE_APP_ID,
+    blockAppBlockId: PAGE_APP_BLOCK_ID,
+    blockInstanceId: PAGE_INSTANCE,
+    blockScope: 'viewer_global',
+    // deliberately no blockModelId / blockSlotId — a page has neither.
+    ...over,
+  } as Record<string, unknown> & {
+    userId?: unknown;
+    blockAppId?: string | null;
+    blockInstanceId?: string | null;
+  };
+}
+
+/** What resolveBlockInstance's `page` branch returns (modelId=0 sentinel). */
+function resolvedPage(over: Record<string, unknown> = {}) {
+  return {
+    source: 'page',
+    modelId: 0,
+    slotId: '',
+    enabled: true,
+    settings: {},
+    installedByUserId: null,
+    appBlock: {
+      id: PAGE_APP_BLOCK_ID,
+      blockId: 'blk_page',
+      appId: PAGE_APP_ID,
+      status: 'approved',
+      manifest: {},
+      approvedScopes: [],
+      app: null,
+    },
+    ...over,
+  };
+}
+
+describe('validateBuzzPurchaseAttribution — page surface (flow B)', () => {
+  it('resolves a page purchase to viewer_global (no modelId/slotId needed)', async () => {
+    mockResolve.mockResolvedValueOnce(resolvedPage());
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: pageMetadata(),
+      sessionUserId: SESSION_USER,
+    });
+
+    // The resolver was called with the page instance + session user.
+    expect(mockResolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blockInstanceId: PAGE_INSTANCE,
+        viewerUserId: SESSION_USER,
+        db: 'write',
+      })
+    );
+    expect(out.blockScope).toBe('viewer_global');
+    expect(out.blockAppId).toBe(PAGE_APP_ID);
+    expect(out.blockAppBlockId).toBe(PAGE_APP_BLOCK_ID);
+    expect(out.blockInstanceId).toBe(PAGE_INSTANCE);
+    expect(out.userId).toBe(SESSION_USER);
+    // No modelId is stamped on a page row — the 0 sentinel must NOT leak.
+    expect(out.blockModelId).toBeUndefined();
+  });
+
+  it('FIN-1 — corrects a forged high-rate scope on a page instance to viewer_global', async () => {
+    // Attacker stamps viewer_personal (25%) on a page_* id to mint a wider cut.
+    mockResolve.mockResolvedValueOnce(resolvedPage());
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: pageMetadata({ blockScope: 'viewer_personal' }),
+      sessionUserId: SESSION_USER,
+    });
+    // Server re-derives from source='page' → viewer_global (0% on the card).
+    expect(out.blockScope).toBe('viewer_global');
+  });
+
+  it('FIN-1 — overwrites a forged blockAppId with the resolved page app', async () => {
+    mockResolve.mockResolvedValueOnce(resolvedPage());
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: pageMetadata({ blockAppId: 'app_confederate', blockAppBlockId: 'apb_confederate' }),
+      sessionUserId: SESSION_USER,
+    });
+    expect(out.blockAppId).toBe(PAGE_APP_ID);
+    expect(out.blockAppBlockId).toBe(PAGE_APP_BLOCK_ID);
+  });
+
+  it('FIN-1 — strips attribution when the page does not resolve (non-approved / non-page app)', async () => {
+    mockResolve.mockResolvedValueOnce(null);
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: pageMetadata({ blockInstanceId: 'page_apb_forged' }),
+      sessionUserId: SESSION_USER,
+    });
+    expect(out.blockAppId).toBeUndefined();
+    expect(out.blockInstanceId).toBeUndefined();
+    expect(out.blockScope).toBeUndefined();
+    // purchase preserved (no throw)
+    expect(out.buzzAmount).toBe(1000);
+    expect(out.userId).toBe(SESSION_USER);
+  });
+
+  it('FIN-1 — strips a forged modelId off a page row (page has no model entity)', async () => {
+    // An attacker tacks a blockModelId onto a page instance hoping it rides
+    // along. stripBlockKeys clears it and the page branch never re-stamps one.
+    mockResolve.mockResolvedValueOnce(resolvedPage());
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: pageMetadata({ blockModelId: '999', blockSlotId: 'model.sidebar_top' }),
+      sessionUserId: SESSION_USER,
+    });
+    expect(out.blockModelId).toBeUndefined();
+    expect(out.blockSlotId).toBeUndefined();
+    expect(out.blockScope).toBe('viewer_global');
+  });
+
+  it('strips a page instance whose resolver returns a non-page source (defense in depth)', async () => {
+    // Should never happen (the resolver page branch always sets source='page'),
+    // but if a future bug returned some other source for a page_* id we must
+    // NOT silently bucket it — strip instead.
+    mockResolve.mockResolvedValueOnce(resolvedPage({ source: 'viewer_subscription' }));
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: pageMetadata(),
+      sessionUserId: SESSION_USER,
+    });
+    expect(out.blockAppId).toBeUndefined();
+    expect(out.blockScope).toBeUndefined();
+  });
+
+  it('strips (does not throw) when the resolver throws on a page instance', async () => {
+    mockResolve.mockRejectedValueOnce(new Error('db down'));
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: pageMetadata(),
+      sessionUserId: SESSION_USER,
+    });
+    expect(out.blockAppId).toBeUndefined();
+    expect(out.buzzAmount).toBe(1000);
+  });
+
+  it('VECTOR 1 still applies on the page path — spender spoof is rejected before resolve', async () => {
+    await expect(
+      validateBuzzPurchaseAttribution({
+        metadata: pageMetadata({ userId: 999 }),
+        sessionUserId: SESSION_USER,
+      })
+    ).rejects.toThrow(/error while creating your order/i);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it('REGRESSION — a model-slot purchase still derives its existing scope (page branch does not intercept it)', async () => {
+    // The model path must be unaffected: a bus_view_ instance still goes
+    // through the modelId/slotId gate + resolves to viewer_personal.
+    mockResolve.mockResolvedValueOnce(resolvedInstance());
+    const out = await validateBuzzPurchaseAttribution({
+      metadata: blockMetadata(),
+      sessionUserId: SESSION_USER,
+    });
+    expect(out.blockScope).toBe('viewer_personal');
+    expect(out.blockModelId).toBe(String(MODEL_ID));
+    // model path passes modelId+slotId to the resolver
+    expect(mockResolve).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: MODEL_ID, slotId: SLOT })
+    );
+  });
+});

--- a/src/server/services/blocks/__tests__/rate-card.test.ts
+++ b/src/server/services/blocks/__tests__/rate-card.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   ACTIVE_RATE_CARD,
   computeRateCardSplit,
+  RATE_CARD_V1,
   RATE_CARD_V2,
+  RATE_CARD_V3,
   type RateCard,
 } from '../rate-card';
 
@@ -23,6 +25,7 @@ describe('computeRateCardSplit', () => {
       publisher_all_my_models: 20,
       viewer_personal: 25,
       platform_default: 0,
+      viewer_global: 0,
     },
     internalAppOwnerUserIds: [42],
     effectiveFrom: '2026-01-01',
@@ -160,6 +163,7 @@ describe('computeRateCardSplit', () => {
       'publisher_all_my_models',
       'viewer_personal',
       'platform_default',
+      'viewer_global',
     ] as const) {
       const split = computeRateCardSplit({
         grossCents,
@@ -176,7 +180,7 @@ describe('computeRateCardSplit', () => {
     }
   });
 
-  it('defaults to ACTIVE_RATE_CARD when no rateCard is passed', () => {
+  it('defaults to ACTIVE_RATE_CARD (now V3) when no rateCard is passed', () => {
     const split = computeRateCardSplit({
       grossCents: 1000,
       providerFeeCents: 0,
@@ -185,6 +189,104 @@ describe('computeRateCardSplit', () => {
       appOwnerUserId: 1,
     });
     expect(split.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
-    expect(split.rateCardVersion).toBe(RATE_CARD_V2.version);
+    expect(split.rateCardVersion).toBe(RATE_CARD_V3.version);
+    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V3);
+  });
+
+  // --- W3 flow B: viewer_global (page purchase) at 0% ---------------------
+
+  it('viewer_global pays the publisher 0% — platform keeps net, conservation holds', () => {
+    const split = computeRateCardSplit({
+      grossCents: 1000,
+      providerFeeCents: 50,
+      scope: 'viewer_global',
+      isSelfPurchase: false,
+      appOwnerUserId: 1,
+    });
+    // net = 950, viewer_global @ 0% → publisher 0, platform 950.
+    expect(split.appOwnerShareCents).toBe(0);
+    expect(split.platformShareCents).toBe(950);
+    expect(split.providerFeeCents).toBe(50);
+    // Conservation: fee + platform + author == gross (the SQL CHECK).
+    expect(
+      split.providerFeeCents + split.platformShareCents + split.appOwnerShareCents
+    ).toBe(1000);
+  });
+
+  it('viewer_global on the ACTIVE card (V3) also pays 0% with conservation', () => {
+    const split = computeRateCardSplit({
+      grossCents: 4999,
+      providerFeeCents: 217,
+      scope: 'viewer_global',
+      isSelfPurchase: false,
+      appOwnerUserId: 7,
+    });
+    expect(split.rateCardVersion).toBe('v3');
+    expect(split.appOwnerShareCents).toBe(0);
+    expect(
+      split.providerFeeCents + split.platformShareCents + split.appOwnerShareCents
+    ).toBe(4999);
+  });
+
+  // --- Immutability: every card carries its stamped percentages ----------
+
+  it('V3 carries V2 percentages verbatim and adds viewer_global at 0%', () => {
+    expect(RATE_CARD_V3.version).toBe('v3');
+    expect(RATE_CARD_V3.publisherSharePctByScope.per_model_install).toBe(
+      RATE_CARD_V2.publisherSharePctByScope.per_model_install
+    );
+    expect(RATE_CARD_V3.publisherSharePctByScope.publisher_all_my_models).toBe(
+      RATE_CARD_V2.publisherSharePctByScope.publisher_all_my_models
+    );
+    expect(RATE_CARD_V3.publisherSharePctByScope.viewer_personal).toBe(
+      RATE_CARD_V2.publisherSharePctByScope.viewer_personal
+    );
+    expect(RATE_CARD_V3.publisherSharePctByScope.platform_default).toBe(
+      RATE_CARD_V2.publisherSharePctByScope.platform_default
+    );
+    // The new scope is the only addition, at 0%.
+    expect(RATE_CARD_V3.publisherSharePctByScope.viewer_global).toBe(0);
+    // Sanity on the actual V2 numbers (15/15/25/0) so a future edit to V2
+    // can't silently drift V3's "carried" values.
+    expect(RATE_CARD_V2.publisherSharePctByScope.per_model_install).toBe(15);
+    expect(RATE_CARD_V2.publisherSharePctByScope.publisher_all_my_models).toBe(15);
+    expect(RATE_CARD_V2.publisherSharePctByScope.viewer_personal).toBe(25);
+    expect(RATE_CARD_V2.publisherSharePctByScope.platform_default).toBe(0);
+  });
+
+  it('V1/V2 keep their stamped values (immutable) + viewer_global at 0%', () => {
+    expect(RATE_CARD_V1.version).toBe('v1');
+    expect(RATE_CARD_V1.publisherSharePctByScope).toMatchObject({
+      per_model_install: 20,
+      publisher_all_my_models: 20,
+      viewer_personal: 25,
+      platform_default: 0,
+      viewer_global: 0,
+    });
+    expect(RATE_CARD_V2.version).toBe('v2');
+    expect(RATE_CARD_V2.publisherSharePctByScope).toMatchObject({
+      per_model_install: 15,
+      publisher_all_my_models: 15,
+      viewer_personal: 25,
+      platform_default: 0,
+      viewer_global: 0,
+    });
+  });
+
+  it('a row stamped under V2 still pays V2 percentages (past rows pay under their version)', () => {
+    // Backward-compat: an old model-slot purchase computed against V2 must
+    // still pay viewer_personal @ 25%, regardless of ACTIVE_RATE_CARD moving
+    // to V3.
+    const split = computeRateCardSplit({
+      rateCard: RATE_CARD_V2,
+      grossCents: 1000,
+      providerFeeCents: 0,
+      scope: 'viewer_personal',
+      isSelfPurchase: false,
+      appOwnerUserId: 1,
+    });
+    expect(split.rateCardVersion).toBe('v2');
+    expect(split.appOwnerShareCents).toBe(250);
+    expect(split.platformShareCents).toBe(750);
   });
 });

--- a/src/server/services/blocks/attribution-validator.service.ts
+++ b/src/server/services/blocks/attribution-validator.service.ts
@@ -58,6 +58,11 @@ const SOURCE_TO_SCOPE: Record<ResolvedBlockSource, BlockAttributionScope> = {
   publisher_subscription: 'publisher_all_my_models',
   viewer_subscription: 'viewer_personal',
   platform_default: 'platform_default',
+  // W10 page surface (`page_<appBlockId>`, entity=none). A Buzz purchase made
+  // inside a full-page app re-derives to `viewer_global` — the page has no
+  // model entity and is viewer-chosen. Placeholder publisher share is 0% (see
+  // rate-card.ts); raise via a future card after monetization sign-off.
+  page: 'viewer_global',
 };
 
 /**
@@ -169,6 +174,102 @@ export async function validateBuzzPurchaseAttribution<
       'webhooks'
     ).catch(() => null);
     return stripBlockKeys(base);
+  }
+
+  // -----------------------------------------------------------------
+  // W10 page surface (`page_<appBlockId>`) — flow B page-purchase path.
+  //
+  // A page purchase carries NO modelId/slotId (a page is stateless,
+  // entity=none), so it must be re-derived BEFORE the model-path
+  // modelId/slotId gate below — otherwise that gate would strip every page
+  // purchase. We still re-derive SERVER-SIDE (never trust the client): the
+  // resolver's `page` namespace authoritatively confirms the cited AppBlock
+  // is approved + declares a page surface, and returns `source: 'page'` →
+  // SOURCE_TO_SCOPE['page'] = 'viewer_global'. So:
+  //   - a forged high-rate `blockScope` on a `page_*` id is corrected to
+  //     viewer_global (the rate-card pays 0% for it — no minting a wider cut);
+  //   - a forged `blockAppId` is overwritten with the resolved page's app;
+  //   - a `page_*` id for a non-approved / non-page app fails to resolve →
+  //     attribution is STRIPPED (fail-safe), purchase proceeds un-attributed.
+  // No `blockModelId` is stamped (a page has no model entity; the resolver's
+  // sentinel modelId=0 is intentionally NOT written onto the row).
+  // -----------------------------------------------------------------
+  if (String(blockInstanceId).startsWith('page_')) {
+    let pageResolved;
+    try {
+      pageResolved = await BlockRegistry.resolveBlockInstance({
+        blockInstanceId: String(blockInstanceId),
+        // modelId/slotId are ignored by the resolver's page branch but the
+        // signature requires them. 0/'' are inert sentinels.
+        modelId: 0,
+        slotId: '',
+        viewerUserId: sessionUserId,
+        db: 'write',
+      });
+    } catch (err) {
+      logToAxiom(
+        {
+          name: LOG_NAME,
+          type: 'error',
+          message: 'stripped attribution: resolveBlockInstance threw (page)',
+          sessionUserId,
+          blockInstanceId: String(blockInstanceId),
+          error: (err as Error)?.message,
+        },
+        'webhooks'
+      ).catch(() => null);
+      return stripBlockKeys(base);
+    }
+
+    if (!pageResolved || pageResolved.source !== 'page') {
+      logToAxiom(
+        {
+          name: LOG_NAME,
+          type: 'warning',
+          message: 'stripped attribution: page instance did not resolve',
+          sessionUserId,
+          blockInstanceId: String(blockInstanceId),
+          clientAppId: String(appId),
+          clientScope: String(base[ATTRIBUTION_METADATA_KEYS.scope] ?? ''),
+        },
+        'webhooks'
+      ).catch(() => null);
+      return stripBlockKeys(base);
+    }
+
+    const pageScope = SOURCE_TO_SCOPE[pageResolved.source];
+    const pageFields: Record<string, string> = {
+      [ATTRIBUTION_METADATA_KEYS.appId]: pageResolved.appBlock.appId,
+      [ATTRIBUTION_METADATA_KEYS.appBlockId]: pageResolved.appBlock.id,
+      [ATTRIBUTION_METADATA_KEYS.blockInstanceId]: String(blockInstanceId),
+      [ATTRIBUTION_METADATA_KEYS.scope]: pageScope,
+      // intentionally NO modelId — a page has no model entity.
+    };
+    // stripBlockKeys clears any client-supplied blockModelId/blockSlotId too,
+    // so a forged modelId can never ride along on a page row.
+    const pageOut = { ...stripBlockKeys(base), ...pageFields } as T;
+
+    if (
+      String(appId) !== pageResolved.appBlock.appId ||
+      String(base[ATTRIBUTION_METADATA_KEYS.scope] ?? '') !== pageScope
+    ) {
+      logToAxiom(
+        {
+          name: LOG_NAME,
+          type: 'info',
+          message: 'corrected forged/mismatched page attribution fields',
+          sessionUserId,
+          blockInstanceId: String(blockInstanceId),
+          clientAppId: String(appId),
+          derivedAppId: pageResolved.appBlock.appId,
+          clientScope: String(base[ATTRIBUTION_METADATA_KEYS.scope] ?? ''),
+          derivedScope: pageScope,
+        },
+        'webhooks'
+      ).catch(() => null);
+    }
+
+    return pageOut as T;
   }
 
   // -----------------------------------------------------------------

--- a/src/server/services/blocks/rate-card.ts
+++ b/src/server/services/blocks/rate-card.ts
@@ -35,11 +35,19 @@ export type RateCard = {
 // leadership" section of
 // claudedocs/app-blocks-buzz-attribution-handoff-2026-05-25.md.
 //
-// Two cards defined: V1 (the original spec placeholder, 20/20/25/0)
-// and V2 (the recommended starting point, 15/15/25/0). Rate cards
-// are immutable — past attribution rows stamp their version at
-// write time and pay out under it forever. To change percentages,
-// add a V3, leave V1/V2 in place for the rows that referenced them.
+// Three cards defined: V1 (the original spec placeholder, 20/20/25/0),
+// V2 (the recommended starting point, 15/15/25/0) and V3 (V2 + the
+// new W10 page scope `viewer_global` at 0%). Rate cards are immutable
+// — past attribution rows stamp their version at write time and pay
+// out under it forever. To change percentages, add a V4, leave
+// V1/V2/V3 in place for the rows that referenced them.
+//
+// `viewer_global` (W10 page purchase, flow B) is a PLACEHOLDER 0% on
+// every card — no historical row ever used it (the scope is net-new
+// in this PR), so adding it at 0% to V1/V2 is behavior-preserving for
+// their stamped rows. Page revenue is largely platform-counterfactual,
+// so 0% is the v1 launch number; a real publisher share for pages
+// needs monetization-leadership sign-off and lands as a future card.
 //
 // Open items still to confirm:
 //   - Final cuts. V2 starts lower; raising is politically easier
@@ -62,6 +70,9 @@ export const RATE_CARD_V1: RateCard = {
     publisher_all_my_models: 20,
     viewer_personal: 25,
     platform_default: 0,
+    // Net-new scope (W10 page purchase). No V1 row ever used it; 0% is
+    // behavior-preserving for this card's stamped rows.
+    viewer_global: 0,
   },
   internalAppOwnerUserIds: [],
   effectiveFrom: '2026-05-25',
@@ -100,6 +111,9 @@ export const RATE_CARD_V2: RateCard = {
     // Mod-promoted on the platform's behalf — publisher already earns
     // via reach / install funnel, no extra share.
     platform_default: 0,
+    // Net-new scope (W10 page purchase). No V2 row ever used it; 0% is
+    // behavior-preserving for this card's stamped rows.
+    viewer_global: 0,
   },
   internalAppOwnerUserIds: [
     // Populate with civitai team userIds before going live. Empty for
@@ -112,7 +126,42 @@ export const RATE_CARD_V2: RateCard = {
   effectiveFrom: '2026-05-26',
 };
 
-export const ACTIVE_RATE_CARD: RateCard = RATE_CARD_V2;
+/**
+ * V3 — adds the W10 page-purchase scope (`viewer_global`, flow B).
+ *
+ * Carries V2's percentages UNCHANGED (15/15/25/0) and adds
+ * `viewer_global: 0`. This is the first card emitted for page purchases:
+ * a Buzz purchase made inside a full-page app is TRACKED (a
+ * block_buzz_attribution row is written) but pays the author 0% for now —
+ * page revenue is largely platform-counterfactual, and shipping at 0%
+ * (rather than not tracking at all) means the row history exists so a
+ * later, signed-off non-zero card can be applied going forward without
+ * losing the pre-decision purchase trail.
+ *
+ * PLACEHOLDER — a real publisher share for pages needs monetization
+ * leadership sign-off. When that lands, add a V4 with the agreed % and
+ * leave V3 in place for the rows stamped under it (cards are immutable).
+ */
+export const RATE_CARD_V3: RateCard = {
+  version: 'v3',
+  publisherSharePctByScope: {
+    // Carried from V2 verbatim — do NOT change these here; a percentage
+    // change is a new card, not an edit to V3.
+    per_model_install: 15,
+    publisher_all_my_models: 15,
+    viewer_personal: 25,
+    platform_default: 0,
+    // W10 page purchase — placeholder 0%, raise via a future card after
+    // monetization sign-off.
+    viewer_global: 0,
+  },
+  internalAppOwnerUserIds: [
+    // Same as V2 — populate with civitai team userIds before going live.
+  ],
+  effectiveFrom: '2026-06-18',
+};
+
+export const ACTIVE_RATE_CARD: RateCard = RATE_CARD_V3;
 
 /**
  * Result of running a (gross, fee, scope) tuple through the active rate


### PR DESCRIPTION
## What this does (W3 attribution back-half — flow B only)

Today a Buzz **purchase** made inside a W10 full-page app mints with instanceId `page_<appBlockId>`. `deriveScopeFromInstanceId` returns `null` for that prefix → the FIN-1 server re-derivation can't resolve it → **attribution is stripped**: the purchase completes but is never tracked and the app author earns nothing.

This PR adds a new **`viewer_global`** attribution scope (page surface, entity=none) at a **placeholder 0% publisher share**, so page purchases are **TRACKED now (at 0%)** rather than silently dropped. A real publisher share for pages is a monetization-leadership decision and lands later as a new rate card — but the row history exists in the meantime, so the pre-decision purchase trail isn't lost.

This is the only thing the PR does.

### Changes
- **`attribution.schema.ts`** — add `viewer_global` to `blockAttributionScopeSchema`; map the `page_` instanceId prefix → `viewer_global` in `deriveScopeFromInstanceId` (client-side; the server is authoritative).
- **`block-registry.service.ts`** — add a `page` member to `ResolvedBlockSource` and a `page_*` branch in `resolveBlockInstance`. It resolves via `resolvePageBlock` (approved + page-declared), is viewer-global (no per-owner/per-model predicate), has no model entity (`modelId = 0` sentinel), and returns `source: 'page'`.
- **`attribution-validator.service.ts` (FIN-1)** — re-derive a page purchase **server-side** *before* the model-path `modelId`/`slotId` gate (a page carries neither). `SOURCE_TO_SCOPE['page'] = 'viewer_global'`. Forge-resistance preserved: a forged high-rate `blockScope` on a `page_*` id is corrected to `viewer_global`; a forged `blockAppId` is overwritten with the resolved page's app; a `page_*` id for a non-approved / non-page app fails to resolve → attribution is **stripped** (fail-safe, purchase proceeds un-attributed); no `blockModelId` is stamped on a page row.
- **`rate-card.ts`** — add `RATE_CARD_V3` (carries V2's percentages **unchanged** — 15/15/25/0 — plus `viewer_global: 0`); `ACTIVE_RATE_CARD = RATE_CARD_V3`. Adding `viewer_global` to the `BlockAttributionScope` type forces it into V1/V2's maps too — set to `0` there (behavior-preserving; no historical row ever used it). Cards stay immutable/version-stamped: past rows pay under their stamped version.

### `viewer_global` @ 0% placeholder
0% is the v1 launch number (page revenue is largely platform-counterfactual). **Raising it requires monetization sign-off** and ships as a future card (V4) — V3 stays in place for the rows stamped under it.

## Migration — manual-apply, **apply BEFORE deploy**
`prisma/migrations/20260618120000_block_attribution_viewer_global_scope/migration.sql` extends the scope CHECK constraint:

```sql
ALTER TABLE "block_buzz_attribution"
  DROP CONSTRAINT IF EXISTS "block_buzz_attribution_scope_check";

ALTER TABLE "block_buzz_attribution"
  ADD CONSTRAINT "block_buzz_attribution_scope_check"
  CHECK ("scope" IN (
    'per_model_install',
    'publisher_all_my_models',
    'viewer_personal',
    'platform_default',
    'viewer_global'
  ));
```

Per the civitai DB rule, this is **NOT auto-applied** — a human applies it via psql/retool to:
1. **prod nvme0** (the main civitai DB, CNPG `role=postgres`)
2. **the dev clone** (`cnpg-cluster-dev`, ns `cnpg-database-dev`)

**Ordering matters: apply the migration BEFORE the code that writes `viewer_global` deploys**, otherwise the CHECK rejects the page-purchase INSERT and the attribution is lost. It only widens the allowed set, so it's safe to apply ahead of the deploy.

## Tests (vitest — 51 passing across the 3 touched suites)
- `deriveScopeFromInstanceId('page_…') === 'viewer_global'`; all existing prefixes unchanged.
- `computeRateCardSplit` for `viewer_global` → `appOwnerShareCents = 0`, conservation holds (`fee + platform + author = gross`).
- FIN-1 page re-derivation: a page purchase resolves to `viewer_global`; a forged scope/app on a `page_*` instance is corrected; a non-resolving page is stripped; no `blockModelId` rides along; spender-spoof still rejected; model-slot purchase regression (existing scope + % unaffected).
- V3 carries V2's percentages exactly; V1/V2 keep their stamped values (immutability); a row stamped under V2 still pays V2 %s.
- **Mutation-checked**: breaking the page→`viewer_global` mapping (in both the schema derive and `SOURCE_TO_SCOPE`) fails the relevant tests.

Typecheck: the three schema/service/validator files are clean; `block-registry.service.ts`'s only `tsc-files` errors are pre-existing `Prisma.sql` raw-SQL helpers failing under the offline Prisma client (NixOS limitation, unrelated lines, not in this diff).

## Out of scope (next W3 slices)
- **Flow A** — block-initiated Buzz **spend** attribution.
- **Flow C** — membership/subscription purchase attribution.
- **Flow D** — payout finish (PR #2605 rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
