### PR TITLE
fix(blocks): declare SUBMIT_RATE_LIMIT on REDIS_SYS_KEYS — unbreak main typecheck

### DIFF
--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1244,6 +1244,16 @@ export const REDIS_SYS_KEYS = {
      * on first write so the per-window key self-expires.
      */
     BUZZ_CAP: 'system:blocks:buzz-cap',
+    /**
+     * Per-API-key (fallback per-IP) rate-limit counter for the token-authed
+     * bundle-submit endpoint (`/api/v1/blocks/submit-version`). `SET NX EX` +
+     * `INCR` in one MULTI (same atomic pattern as the retool endpoint) so the
+     * counter is always created with its TTL. Bundle submit is heavy (decode +
+     * ZIP extract + manifest validate up to ~72 MiB), so the limit is tight.
+     * Lives on `sysRedis` (like the retool limiter + `BUZZ_CAP`), so the key is
+     * declared here rather than in `REDIS_KEYS.BLOCKS`.
+     */
+    SUBMIT_RATE_LIMIT: 'system:blocks:submit-rate-limit',
   },
 } as const;
 
@@ -1427,14 +1437,6 @@ export const REDIS_KEYS = {
   BLOCKS: {
     REGISTRY: 'packed:caches:block-registry',
     TOKEN_RATE_LIMIT: 'blocks:token-rate-limit',
-    /**
-     * Per-API-key (fallback per-IP) rate-limit counter for the token-authed
-     * bundle-submit endpoint (`/api/v1/blocks/submit-version`). `SET NX EX` +
-     * `INCR` in one MULTI (same atomic pattern as the retool endpoint) so the
-     * counter is always created with its TTL. Bundle submit is heavy (decode +
-     * ZIP extract + manifest validate up to ~72 MiB), so the limit is tight.
-     */
-    SUBMIT_RATE_LIMIT: 'blocks:submit-rate-limit',
     /**
      * Per-blockInstanceId revocation marker. Writers (uninstall,
      * toggleEnabled(false), publisher ban) set this key with a 15-minute


### PR DESCRIPTION
## Problem

Every PipelineRun has failed since #2623 merged (`feat(blocks): token-authed app-submit endpoint`, `34aec94c9c`) — main builds, tag builds, and **all** PR checks/previews. Root cause is a `tsc --noEmit` break on `main`:

```
src/pages/api/v1/blocks/submit-version.ts(154,44): error TS2339:
  Property 'SUBMIT_RATE_LIMIT' does not exist on type
  '{ EMERGENCY_KILL_LIST; BUZZ_CAP }'.
src/pages/api/v1/blocks/submit-version.ts(175,43): error TS2345:
  key not assignable to the sysRedis key union.
```

#2623 was merged despite its own `pr-check-2623` failing this exact typecheck.

## Cause

Internal inconsistency within #2623: the endpoint **reads** the counter as `REDIS_SYS_KEYS.BLOCKS.SUBMIT_RATE_LIMIT` against `sysRedis`, but the key was **declared** in `REDIS_KEYS.BLOCKS` (a different registry, regular `redis` client). So the key the endpoint imports never existed, and its `as const` template literal wasn't in the `sysRedis` key union.

## Fix

Move the declaration into `REDIS_SYS_KEYS.BLOCKS` (with the `system:` prefix its siblings use), matching the client the endpoint actually uses — the retool rate-limiter and `BUZZ_CAP` are sysRedis counters too. Drop the orphaned, unconsumed copy from `REDIS_KEYS.BLOCKS`. **Endpoint logic unchanged**; `SUBMIT_RATE_LIMIT` had no other consumer.

## Verification

- `tsc --noEmit` against the touched files (`submit-version.ts`, `redis/client.ts`) is now clean; both original errors resolved.
- The fix is a two-constant registry move — no runtime behavior change beyond the key string (`blocks:submit-rate-limit` → `system:blocks:submit-rate-limit`), which is a fresh key with no existing data to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)