### PR TITLE
feat(app-blocks): buzz-SPEND attribution — author bounty per block generation (W3 flow A)

### DIFF
--- a/prisma/migrations/20260618130000_block_spend_attribution/migration.sql
+++ b/prisma/migrations/20260618130000_block_spend_attribution/migration.sql
@@ -1,0 +1,152 @@
+-- ============================================================
+-- App Blocks — buzz SPEND attribution + author bounty (W3 flow A)
+-- ============================================================
+-- One row per block-initiated generation that SPENDS the viewer's own
+-- Buzz balance. Drives the publisher (app author) revenue-share payout
+-- pipeline for the *spend* flow. See claudedocs/
+-- app-blocks-attribution-backhalf-scope-2026-06-18.md (section A) for the
+-- end-to-end design.
+--
+-- WHY A NEW TABLE (not block_buzz_attribution):
+-- A spend is NOT a card purchase. It is the viewer burning their OWN
+-- existing Buzz balance on a generation — there is no payment provider,
+-- no provider fee, no Stripe/Paddle transaction, and no refund/chargeback
+-- /clawback lifecycle. block_buzz_attribution is purchase-shaped: its
+-- conservation CHECK (provider_fee + platform_share + app_owner_share =
+-- usd_amount) assumes a card transaction whose gross is divided three
+-- ways. Spend attribution has a DIFFERENT accounting model (see below),
+-- so hosting it in the purchase table would mean relaxing that CHECK and
+-- polluting the purchase aggregates (getRevenueForOwner). A dedicated
+-- table keeps each flow's lifecycle and invariants clean.
+--
+-- ACCOUNTING MODEL — PLATFORM-FUNDED BOUNTY (not a cut of the spend):
+-- The viewer's Buzz spend on the generation is final and untouched — the
+-- orchestrator already debited the viewer's balance and 100% of that
+-- spend is the platform's revenue (the viewer paid civitai for compute).
+-- The author's share is a SEPARATE, PLATFORM-FUNDED bounty paid ON TOP
+-- of the spend, sized as a percentage of the spend's USD value. It is a
+-- platform marketing/ecosystem expense, NOT a slice carved out of the
+-- viewer's money. Implication: there is NO three-way conservation
+-- invariant here (unlike purchase). The only invariants are:
+--   - author_share_cents >= 0
+--   - author_share_cents = floor(gross_value_cents * spend_share_pct/100)
+--   - author_share_cents = 0 on self-spend or internal-owner.
+-- gross_value_cents is recorded for audit/reporting (the USD value of the
+-- Buzz burned, at buzzDollarRatio 1000 Buzz = $1 = 100 cents) but it is
+-- the platform's revenue, not a pool being split.
+--
+-- ⚠️ MANUAL-APPLY (civitai DB rule #8): committed for history, NOT
+--    auto-applied. A human must run this via psql/retool BEFORE the code
+--    that writes spend rows deploys, on:
+--      1. prod nvme0  (role=postgres CNPG cluster — the main civitai DB)
+--      2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev)
+--
+-- app_owner_user_id is denormalized at attribution time so payouts are
+-- stable even if OauthClient.userId is later reassigned (mirrors
+-- block_buzz_attribution).
+
+CREATE TABLE "block_spend_attribution" (
+  -- Application-generated ULID: 'bsa_<ulid>' (30 chars).
+  "id"                      TEXT PRIMARY KEY,
+
+  -- Spend facts: the viewer burned `buzz_amount` Buzz on this generation.
+  -- gross_value_cents is its USD value (buzzDollarRatio 1000:1 -> cents),
+  -- recorded for reporting. This is platform revenue, NOT a split pool.
+  "user_id"                 INTEGER NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT,
+  "buzz_amount"             INTEGER NOT NULL,
+  "buzz_type"               TEXT NOT NULL DEFAULT 'yellow',
+  "gross_value_cents"       INTEGER NOT NULL,
+
+  -- Generation link. workflow_id is the orchestrator's id for the
+  -- submitted generation; it is the idempotency anchor (a re-poll / retry
+  -- / re-submit of the SAME workflow must not double-attribute).
+  "workflow_id"             TEXT NOT NULL,
+
+  -- Attribution context (all derived server-side from the verified block
+  -- token claims — never client-supplied, so inherently forge-safe).
+  "app_id"                  TEXT NOT NULL REFERENCES "OauthClient"("id") ON DELETE RESTRICT,
+  "app_block_id"            TEXT NOT NULL REFERENCES "app_blocks"("id") ON DELETE RESTRICT,
+  "block_instance_id"       TEXT NOT NULL,
+  -- Optional: model the generation ran against. Pure analytics.
+  "model_id"                INTEGER,
+
+  -- Author bounty (computed at attribution time against the active spend
+  -- rate card). Denormalized rate_card_version so the row pays out under
+  -- its stamped snapshot forever (mirrors block_buzz_attribution).
+  "rate_card_version"       TEXT NOT NULL,
+  "spend_share_pct"         INTEGER NOT NULL,
+  "app_owner_share_cents"   INTEGER NOT NULL,
+  -- Denormalized publisher user — snapshot at attribution time.
+  "app_owner_user_id"       INTEGER NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT,
+
+  -- Lifecycle. Mirrors block_buzz_attribution's status machine so the
+  -- payout aggregator can treat both flows uniformly. Spend has no refund
+  -- path, so 'voided' here is only ever self-spend/internal-owner (a
+  -- zero-share audit row), never a refund/chargeback.
+  "status"                  TEXT NOT NULL DEFAULT 'pending',
+  "voided_reason"           TEXT,
+  "attributed_at"           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "confirmed_at"            TIMESTAMPTZ,
+  "voided_at"               TIMESTAMPTZ,
+  "paid_out_at"             TIMESTAMPTZ,
+  "payout_id"               TEXT,
+
+  -- IDEMPOTENCY: one spend attribution per (workflow, app block). A
+  -- re-poll / retry / re-submit of the same workflow hits this UNIQUE and
+  -- is a no-op (P2002 caught + treated as already-written). app_block_id
+  -- is part of the key (rather than workflow_id alone) to mirror the
+  -- purchase table and leave room for a future multi-block split without
+  -- a schema change.
+  CONSTRAINT "block_spend_attribution_workflow_app_uniq"
+    UNIQUE ("workflow_id", "app_block_id"),
+
+  CONSTRAINT "block_spend_attribution_status_check"
+    CHECK ("status" IN ('pending', 'confirmed', 'voided', 'paid_out', 'held')),
+  CONSTRAINT "block_spend_attribution_voided_reason_check"
+    CHECK (
+      "voided_reason" IS NULL OR "voided_reason" IN (
+        'self_spend', 'internal_owner', 'manual_review'
+      )
+    ),
+  -- Non-negativity. There is NO three-way conservation CHECK here: the
+  -- author share is a platform-funded bounty, NOT a slice of
+  -- gross_value_cents (see the accounting-model note above). The author
+  -- share is independently bounded to its rate-card percentage by the
+  -- service (computeSpendShare) and re-derivable from
+  -- gross_value_cents * spend_share_pct / 100.
+  CONSTRAINT "block_spend_attribution_amounts_nonneg_check"
+    CHECK (
+      "buzz_amount" >= 0 AND
+      "gross_value_cents" >= 0 AND
+      "spend_share_pct" >= 0 AND
+      "app_owner_share_cents" >= 0
+    ),
+  -- The author bounty can never exceed the spend's gross USD value — a
+  -- defensive ceiling that catches a runaway rate / arithmetic bug at
+  -- write time (a bounty larger than the revenue it rewards is always a
+  -- bug, even though the bounty is platform-funded).
+  CONSTRAINT "block_spend_attribution_share_le_gross_check"
+    CHECK ("app_owner_share_cents" <= "gross_value_cents"),
+  -- Bound the TEXT primary key length. 'bsa_' (4) + 26 Crockford base32
+  -- chars = 30 total.
+  CONSTRAINT "block_spend_attribution_id_length_check"
+    CHECK (char_length("id") BETWEEN 28 AND 40)
+);
+
+-- Publisher dashboard: "show me my spend-bounty revenue across all apps".
+CREATE INDEX "bsa_publisher_dashboard_idx"
+  ON "block_spend_attribution" ("app_owner_user_id", "attributed_at" DESC);
+
+-- Per-app drilldown.
+CREATE INDEX "bsa_app_block_dashboard_idx"
+  ON "block_spend_attribution" ("app_block_id", "attributed_at" DESC);
+
+-- Payout job: scan only confirmed-unpaid rows ordered by confirm time.
+CREATE INDEX "bsa_payout_idx"
+  ON "block_spend_attribution" ("status", "confirmed_at")
+  WHERE "status" = 'confirmed';
+
+-- Confirm-pending cron: scan only pending rows ordered by attribution time.
+CREATE INDEX "bsa_pending_aging_idx"
+  ON "block_spend_attribution" ("status", "attributed_at")
+  WHERE "status" = 'pending';

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -550,6 +550,8 @@ model User {
   blockBuzzAttributionsAsPurchaser BlockBuzzAttribution[]    @relation("BlockBuzzAttributionPurchaser")
   blockBuzzAttributionsAsAppOwner  BlockBuzzAttribution[]    @relation("BlockBuzzAttributionAppOwner")
   blockAttributionPayouts          BlockAttributionPayout[]  @relation("BlockAttributionPayoutOwner")
+  blockSpendAttributionsAsSpender  BlockSpendAttribution[]   @relation("BlockSpendAttributionSpender")
+  blockSpendAttributionsAsAppOwner BlockSpendAttribution[]   @relation("BlockSpendAttributionAppOwner")
   publishRequestsSubmitted   AppBlockPublishRequest[]        @relation("PublishRequestSubmitter")
   publishRequestsReviewed    AppBlockPublishRequest[]        @relation("PublishRequestReviewer")
   blockScopeInvocations      BlockScopeInvocation[]
@@ -2216,6 +2218,7 @@ model OauthClient {
   consents       OauthConsent[]
   appBlocks      AppBlock[]
   buzzAttributions BlockBuzzAttribution[]
+  spendAttributions BlockSpendAttribution[] @relation("BlockSpendAttributionApp")
 
   @@index([userId])
 }
@@ -2282,6 +2285,7 @@ model AppBlock {
   platformDefault    PlatformDefaultBlock?
   userSubscriptions  BlockUserSubscription[]
   buzzAttributions   BlockBuzzAttribution[]
+  spendAttributions  BlockSpendAttribution[] @relation("BlockSpendAttributionAppBlock")
   publishRequests    AppBlockPublishRequest[]
   scopeInvocations   BlockScopeInvocation[]
   userScopeGrants    AppUserScopeGrant[]
@@ -2553,6 +2557,67 @@ model BlockAttributionPayout {
   @@unique([appOwnerUserId, periodKey], map: "block_attribution_payout_owner_period_uniq")
   @@index([appOwnerUserId, createdAt(sort: Desc)], map: "bap_owner_created_idx")
   @@map("block_attribution_payout")
+}
+
+/// W3 flow A — App Blocks buzz SPEND attribution (author bounty).
+///
+/// One row per block-initiated generation that spends the VIEWER's own
+/// Buzz balance. Distinct from BlockBuzzAttribution (which covers card
+/// PURCHASES from inside a block): a spend has no payment provider, no
+/// provider fee, no refund/clawback lifecycle.
+///
+/// ACCOUNTING: the author share is a PLATFORM-FUNDED BOUNTY paid on top
+/// of the spend, NOT a slice carved out of the viewer's Buzz. The viewer
+/// burned 100% of their Buzz on the generation (platform revenue); the
+/// author bounty is a separate platform expense sized as a percentage of
+/// the spend's USD value. There is therefore NO three-way conservation
+/// invariant (unlike the purchase table) — see the migration for detail.
+///
+/// Idempotent on (workflow_id, app_block_id): a re-poll / retry /
+/// re-submit of the same workflow is a no-op.
+///
+/// Application-generated id (`bsa_<ulid>`).
+model BlockSpendAttribution {
+  id                 String   @id
+  userId             Int      @map("user_id")
+  user               User     @relation("BlockSpendAttributionSpender", fields: [userId], references: [id], onDelete: Restrict)
+  buzzAmount         Int      @map("buzz_amount")
+  buzzType           String   @default("yellow") @map("buzz_type")
+  /// USD value of the Buzz burned (buzzDollarRatio 1000:1 -> cents).
+  /// Recorded for reporting — it is platform revenue, NOT a split pool.
+  grossValueCents    Int      @map("gross_value_cents")
+
+  /// Orchestrator workflow id — the idempotency anchor.
+  workflowId         String   @map("workflow_id")
+
+  appId              String   @map("app_id")
+  app                OauthClient @relation("BlockSpendAttributionApp", fields: [appId], references: [id], onDelete: Restrict)
+  appBlockId         String   @map("app_block_id")
+  appBlock           AppBlock @relation("BlockSpendAttributionAppBlock", fields: [appBlockId], references: [id], onDelete: Restrict)
+  blockInstanceId    String   @map("block_instance_id")
+  modelId            Int?     @map("model_id")
+
+  rateCardVersion    String   @map("rate_card_version")
+  /// The spend rev-share percentage stamped at write time.
+  spendSharePct      Int      @map("spend_share_pct")
+  appOwnerShareCents Int      @map("app_owner_share_cents")
+  appOwnerUserId     Int      @map("app_owner_user_id")
+  appOwner           User     @relation("BlockSpendAttributionAppOwner", fields: [appOwnerUserId], references: [id], onDelete: Restrict)
+
+  status             String   @default("pending")
+  /// 'self_spend' / 'internal_owner' / 'manual_review'. Spend has no
+  /// refund path, so this is never 'refund'/'chargeback'.
+  voidedReason       String?  @map("voided_reason")
+  attributedAt       DateTime @default(now()) @map("attributed_at") @db.Timestamptz(6)
+  confirmedAt        DateTime? @map("confirmed_at") @db.Timestamptz(6)
+  voidedAt           DateTime? @map("voided_at") @db.Timestamptz(6)
+  paidOutAt          DateTime? @map("paid_out_at") @db.Timestamptz(6)
+  payoutId           String?  @map("payout_id")
+
+  @@unique([workflowId, appBlockId], map: "block_spend_attribution_workflow_app_uniq")
+  @@index([appOwnerUserId, attributedAt(sort: Desc)], map: "bsa_publisher_dashboard_idx")
+  @@index([appBlockId, attributedAt(sort: Desc)], map: "bsa_app_block_dashboard_idx")
+  @@map("block_spend_attribution")
 }
 
 /// W5 v0.5 audit log — one row per successful scope-gated API call from

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -340,6 +340,18 @@ export const blockBuzzAttributionWriteCounter = registerCounterWithLabels({
   labelNames: ['provider', 'scope', 'status'] as const,
 });
 
+// App Blocks buzz SPEND attribution (W3 flow A)
+// One row written per block-initiated generation that spends the viewer's
+// own Buzz balance and accrues an author bounty. `status` ∈
+// 'pending'|'voided' at write time (voided = self-spend/internal-owner
+// zero-share row); 'duplicate' marks an idempotent no-op (same workflow
+// re-submitted). No provider/scope labels — spend has neither.
+export const blockSpendAttributionWriteCounter = registerCounterWithLabels({
+  name: 'block_spend_attribution_total',
+  help: 'Block buzz spend attribution rows written',
+  labelNames: ['status'] as const,
+});
+
 // App Blocks KV datastore (W4-v0)
 // `op` ∈ get|set|delete|list|getQuota; `outcome` ∈ ok|unauthorized|
 // not_found|payload_too_large|quota_exceeded|error. Read-only counters

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -31,6 +31,7 @@ const {
   mockLogToAxiom,
   mockSysRedis,
   mockResolveCanGenerateForVersions,
+  mockRecordSpendAttribution,
 } = vi.hoisted(() => ({
   mockVerifyBlockToken: vi.fn(),
   mockParseSubjectUserId: vi.fn(),
@@ -80,6 +81,11 @@ const {
   // out of the test and we can drive canGenerate per-test. Default = a Map
   // saying the version IS generatable; FORBIDDEN tests override to false / miss.
   mockResolveCanGenerateForVersions: vi.fn(),
+  // W3 flow A — the spend-attribution write the submit path fires
+  // best-effort after a resolved submit. Mocked at the module boundary so
+  // the test asserts exact (server-derived) args + that a throw here never
+  // breaks submit.
+  mockRecordSpendAttribution: vi.fn(),
 }));
 
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
@@ -152,6 +158,12 @@ vi.mock('~/server/services/generation/generation.service', () => ({
 }));
 vi.mock('~/server/logging/client', () => ({
   logToAxiom: (...args: unknown[]) => mockLogToAxiom(...args),
+}));
+// W3 flow A — the submit path dynamic-imports recordSpendAttribution from
+// here. Mock the whole module so we drive the spend-write behavior; the
+// real service is unit-tested separately in spend-attribution.service.test.
+vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
+  recordSpendAttribution: (...args: unknown[]) => mockRecordSpendAttribution(...args),
 }));
 vi.mock('~/server/services/block-registry.service', () => ({
   BlockRegistry: {
@@ -286,9 +298,24 @@ beforeEach(() => {
     mockSysRedis.expire,
     mockSysRedis.ttl,
     mockResolveCanGenerateForVersions,
+    mockRecordSpendAttribution,
   ]) {
     fn.mockReset();
   }
+  // W3 flow A default: the spend-attribution write resolves successfully.
+  // Tests that exercise best-effort override it to reject.
+  mockRecordSpendAttribution.mockResolvedValue({
+    written: true,
+    row: {
+      id: 'bsa_x',
+      status: 'pending',
+      appOwnerShareCents: 0,
+      spendSharePct: 0,
+      grossValueCents: 0,
+      rateCardVersion: 'v4',
+      voidedReason: null,
+    },
+  });
   // Buzz-cap (audit A7): default to an empty window so the cap is non-binding
   // unless a test seeds prior spend. The cap is now an atomic reserve (INCRBY
   // returns the new running total) + refund (DECRBY); default incrBy → cost so
@@ -822,6 +849,138 @@ describe('blocks.submitWorkflow', () => {
         body: { kind: 'unknown', modelId: 7 } as never,
       })
     ).rejects.toThrow();
+  });
+
+  // ---- W3 flow A — buzz SPEND attribution wire-in ------------------------
+  // The submit path fires a best-effort, fire-and-forget spend-attribution
+  // write after a RESOLVED submit with a real workflow id. Everything it
+  // passes is SERVER-DERIVED from the verified token claims (forge-safe);
+  // a throw inside it must NEVER break the generation. The fire is a
+  // detached promise, so we let microtasks flush before asserting.
+  const flushMicrotasks = () => new Promise((r) => setImmediate(r));
+
+  function happySubmitWithWorkflow(cost = 25, workflowId = 'wf_real') {
+    mockSubmitWorkflow
+      .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: cost }, steps: [] })
+      .mockResolvedValueOnce({
+        id: workflowId,
+        status: 'unassigned',
+        cost: { total: cost },
+        steps: [],
+      });
+  }
+
+  it('A-flow: fires a spend attribution with SERVER-DERIVED args on a resolved submit', async () => {
+    // Token carries the attribution-bearing claims; the BODY carries
+    // attacker-controllable fields. The write must read from CLAIMS only.
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({
+        buzzBudget: 1000,
+        appId: 'app_from_token',
+        appBlockId: 'apb_from_token',
+        blockInstanceId: 'bki_from_token',
+        sub: 'user:42',
+      })
+    );
+    happyVersionLookup();
+    happyUser();
+    happySubmitWithWorkflow(25, 'wf_real');
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+
+    expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1);
+    const arg = mockRecordSpendAttribution.mock.calls[0][0];
+    // Server-derived from the VERIFIED token, not the client body.
+    expect(arg.appId).toBe('app_from_token');
+    expect(arg.appBlockId).toBe('apb_from_token');
+    expect(arg.blockInstanceId).toBe('bki_from_token');
+    expect(arg.userId).toBe(42); // from claims.sub, via parseSubjectUserId
+    expect(arg.workflowId).toBe('wf_real'); // the orchestrator's id
+    // Amount is the orchestrator-computed cost (ceil), not a client value.
+    expect(arg.buzzAmount).toBe(25);
+  });
+
+  it('A-flow: forge-safe — a forged appId/appBlockId in the BODY is ignored', async () => {
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({ buzzBudget: 1000, appId: 'app_real', appBlockId: 'apb_real' })
+    );
+    happyVersionLookup();
+    happyUser();
+    happySubmitWithWorkflow(25, 'wf_real');
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    // Inject forged attribution fields onto the body — the schema strips
+    // unknowns, but even if it didn't, the write reads only from claims.
+    await caller.submitWorkflow({
+      blockToken: 'tok',
+      body: {
+        ...validBody(),
+        appId: 'app_ATTACKER',
+        appBlockId: 'apb_ATTACKER',
+        appOwnerUserId: 9999,
+      } as never,
+    });
+    await flushMicrotasks();
+
+    const arg = mockRecordSpendAttribution.mock.calls[0][0];
+    expect(arg.appId).toBe('app_real');
+    expect(arg.appBlockId).toBe('apb_real');
+    // No client-supplied owner/share is forwarded — the service derives it.
+    expect(arg).not.toHaveProperty('appOwnerUserId');
+  });
+
+  it('A-flow: best-effort — a thrown attribution write does NOT break submit', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    happySubmitWithWorkflow(25, 'wf_real');
+    mockRecordSpendAttribution.mockRejectedValue(new Error('attribution DB down'));
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    // The generation must still succeed despite the attribution failure.
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+    expect(result.snapshot.workflowId).toBe('wf_real');
+    expect(result.snapshot.status).toBe('pending');
+    expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1);
+  });
+
+  it('A-flow: does NOT attribute a RESOLVED failed snapshot (no generation to credit)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    // whatif resolves; real submit RESOLVES with a failed status + a
+    // (non-sentinel) id. The reservation is kept, but no generation ran, so
+    // no author bounty accrues.
+    mockSubmitWorkflow
+      .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+      .mockResolvedValueOnce({ id: 'wf_real', status: 'failed', cost: { total: 25 }, steps: [] });
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+    expect(result.snapshot.status).toBe('failed');
+    expect(mockRecordSpendAttribution).not.toHaveBeenCalled();
+  });
+
+  it('A-flow: does NOT attribute the over-budget rejection (no submit happened)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 5 }));
+    happyVersionLookup();
+    happyUser();
+    // Only the whatif fires; cost (25) > budget (5) → early failed return.
+    mockSubmitWorkflow.mockResolvedValueOnce({
+      id: '',
+      status: 'succeeded',
+      cost: { total: 25 },
+      steps: [],
+    });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+    expect(result.snapshot.status).toBe('failed');
+    expect(mockRecordSpendAttribution).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -196,6 +196,21 @@ vi.mock('~/server/services/block-registry.service', () => ({
   },
 }));
 
+// blocks.router imports `rateLimit` from middleware.trpc, which transitively
+// pulls in user-preferences.service → caches.ts → tag.selector (a top-level
+// `Prisma.validator(...)` call). In a fresh worktree the generated Prisma client
+// can't be produced (NixOS engine fetch), so evaluating that chain throws at
+// import time. Mock middleware.trpc with a pass-through `rateLimit` middleware
+// (built from the real, lightweight `middleware` factory) to cut the chain —
+// rate-limiting isn't under test here. (Same shim the sibling
+// blocks.router.subscriptions.test.ts / getInstallConfig.test.ts / flag-gate.test.ts use.)
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return {
+    rateLimit: () => middleware(({ next }) => next()),
+  };
+});
+
 import { blocksRouter } from '../blocks.router';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -900,6 +915,80 @@ describe('blocks.submitWorkflow', () => {
     expect(arg.workflowId).toBe('wf_real'); // the orchestrator's id
     // Amount is the orchestrator-computed cost (ceil), not a client value.
     expect(arg.buzzAmount).toBe(25);
+  });
+
+  // 🟡-1: the bounty must accrue off the REALIZED debit on the submit
+  // snapshot, not the whatif preflight ESTIMATE. Drive the whatif and the
+  // real submit to DIFFERENT costs so a regression to `Math.ceil(cost)`
+  // (the estimate) is caught.
+  function submitWithEstimateAndRealized(
+    estimate: number,
+    realized: number | undefined,
+    workflowId = 'wf_real'
+  ) {
+    // First call (whatif) → ESTIMATE; second call (real submit) → REALIZED.
+    mockSubmitWorkflow
+      .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: estimate }, steps: [] })
+      .mockResolvedValueOnce({
+        id: workflowId,
+        status: 'unassigned',
+        // When `realized` is undefined, emit a snapshot with NO cost so the
+        // router exercises its estimate-fallback branch.
+        ...(realized === undefined ? {} : { cost: { total: realized } }),
+        steps: [],
+      });
+  }
+
+  it('🟡-1: accrues the bounty off the REALIZED debit (estimate 100, realized 40 → 40)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    submitWithEstimateAndRealized(100, 40);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+
+    expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1);
+    const arg = mockRecordSpendAttribution.mock.calls[0][0];
+    // Realized (40), NOT the whatif estimate (100). A revert to
+    // `Math.ceil(cost)` makes this 100 and fails the assertion.
+    expect(arg.buzzAmount).toBe(40);
+  });
+
+  it('🟡-1: a cache-hit / 0-realized accrues NOTHING even with a non-zero estimate', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    // Estimate said 100 but the gen cost 0 (cache hit). The author must not
+    // be credited for a generation the platform never charged for.
+    submitWithEstimateAndRealized(100, 0);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+
+    expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1);
+    const arg = mockRecordSpendAttribution.mock.calls[0][0];
+    expect(arg.buzzAmount).toBe(0);
+  });
+
+  it('🟡-1: falls back to the ESTIMATE when the realized value is absent', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    // Submit snapshot carries no cost → realized absent → fall back to the
+    // estimate (100) so attribution isn't silently zeroed when the
+    // orchestrator omits the cost on the snapshot.
+    submitWithEstimateAndRealized(100, undefined);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+
+    expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1);
+    const arg = mockRecordSpendAttribution.mock.calls[0][0];
+    expect(arg.buzzAmount).toBe(100);
   });
 
   it('A-flow: forge-safe — a forged appId/appBlockId in the BODY is ignored', async () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1843,9 +1843,32 @@ export const blocksRouter = router({
           const { recordSpendAttribution } = await import(
             '~/server/services/blocks/buzz-attribution.service'
           );
+          // Accrue the author bounty off the REALIZED debit, not the
+          // whatif preflight ESTIMATE (`cost`). `snapshotFromWorkflow`
+          // surfaces the REAL submit's `workflow.cost.total` onto
+          // `snapshot.cost.total` (see workflow.service.ts:~49,61), read
+          // from the SAME resolved `submitted` snapshot this handler
+          // already holds (no re-fetch). The realized value is what the
+          // platform actually took, so the bounty matches the spend
+          // (the `share_le_gross` intent). This closes: (a) estimate >
+          // realized over-accrual; (b) a cache-hit / 0-realized that
+          // would otherwise still accrue off a non-zero estimate (author
+          // paid for a gen that cost nothing); (c) queue/surge/tier drift
+          // landing on platform bounty liability. Fall back to the
+          // estimate ONLY when the realized value is absent on the
+          // snapshot (e.g. a snapshot that carries no cost).
+          //
+          // SYBIL CAP NOTE (audit 🟡-2): there is NO per-APP aggregate
+          // accrual cap here — only the per-(USER, UTC-day) Buzz SPEND
+          // reservation above. A Sybil ring of many viewers could mint
+          // unbounded platform-funded bounty toward ONE app. This is
+          // accrual-only + mod-gated today, so it is not a merge blocker,
+          // but a per-app earnings cap / velocity check is a HARD
+          // prerequisite before the spend flow opens to non-mods (track
+          // alongside the Slice-4 payout gate + the rate sign-off).
           await recordSpendAttribution({
             userId,
-            buzzAmount: Math.ceil(cost),
+            buzzAmount: Math.ceil(snapshot.cost?.total ?? cost),
             workflowId: spendWorkflowId,
             appId: claims.appId,
             appBlockId: claims.appBlockId,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1821,6 +1821,42 @@ export const blocksRouter = router({
         /* swallowed inside helper */
       });
 
+      // W3 flow A — buzz SPEND attribution (author bounty). The block
+      // burned the viewer's own Buzz on this generation; accrue the app
+      // author's platform-funded bounty share. EVERYTHING is server-derived
+      // from the VERIFIED token claims (appId/appBlockId/blockInstanceId
+      // from the JWT, spender from `sub`, author looked up from the app's
+      // OauthClient) — there is NO client-supplied attribution, so spend is
+      // inherently forge-safe. Idempotent on (workflowId, appBlockId), so a
+      // re-poll / retry can't double-attribute. Fire-and-forget with its
+      // own try/catch (mirrors recordScopeInvocation): a failed attribution
+      // write must NEVER break the generation — the Buzz was already spent
+      // and the snapshot is already the user-facing source of truth.
+      //
+      // Only fire on a REAL workflow id. A returned 'failed' sentinel
+      // snapshot (the over-budget / insufficient-budget path above returns
+      // early before we get here, but the orchestrator can also resolve to
+      // a 'failed' status without queueing) has no generation to attribute.
+      const spendWorkflowId = snapshot.workflowId;
+      if (spendWorkflowId && spendWorkflowId !== 'failed' && snapshot.status !== 'failed') {
+        void (async () => {
+          const { recordSpendAttribution } = await import(
+            '~/server/services/blocks/buzz-attribution.service'
+          );
+          await recordSpendAttribution({
+            userId,
+            buzzAmount: Math.ceil(cost),
+            workflowId: spendWorkflowId,
+            appId: claims.appId,
+            appBlockId: claims.appBlockId,
+            blockInstanceId: claims.blockInstanceId,
+            modelId: resolved.modelId,
+          });
+        })().catch(() => {
+          /* best-effort: a failed attribution write never breaks submit */
+        });
+      }
+
       return { snapshot: autoClaim ? { ...snapshot, autoClaim } : snapshot };
     }),
 

--- a/src/server/services/blocks/__tests__/buzz-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/buzz-attribution.service.test.ts
@@ -68,6 +68,7 @@ import {
   voidAttributionsForPayment,
 } from '../buzz-attribution.service';
 import type { BlockAttribution } from '~/server/schema/blocks/attribution.schema';
+import { ACTIVE_RATE_CARD } from '../rate-card';
 
 const APP_ID = 'app_test';
 const APP_BLOCK_ID = 'apb_test';
@@ -138,13 +139,18 @@ describe('recordAttribution', () => {
     expect(dataArg.status).toBe('pending');
     expect(dataArg.voidedReason).toBeNull();
     expect(dataArg.providerFeeCents).toBe(50);
-    // net 950 * 15% (v2 per_model_install) = 142.5 → floor 142
+    // net 950 * 15% per_model_install = 142.5 → floor 142. The active card
+    // (V2→V3→V4) has carried per_model_install at 15% verbatim, so the math
+    // is version-stable; only the stamped version label tracks ACTIVE.
     expect(dataArg.appOwnerShareCents).toBe(142);
     expect(dataArg.platformShareCents).toBe(808);
     expect(
       dataArg.providerFeeCents + dataArg.platformShareCents + dataArg.appOwnerShareCents
     ).toBe(1000);
-    expect(dataArg.rateCardVersion).toBe('v2');
+    // Pin to the active card's version rather than a literal so this doesn't
+    // go stale every time ACTIVE_RATE_CARD advances (it was stale at 'v2'
+    // through the V3 bump).
+    expect(dataArg.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
     expect(dataArg.id).toMatch(/^bba_/);
   });
 

--- a/src/server/services/blocks/__tests__/rate-card.test.ts
+++ b/src/server/services/blocks/__tests__/rate-card.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   ACTIVE_RATE_CARD,
   computeRateCardSplit,
+  computeSpendShare,
   RATE_CARD_V1,
   RATE_CARD_V2,
   RATE_CARD_V3,
+  RATE_CARD_V4,
   type RateCard,
 } from '../rate-card';
 
@@ -27,6 +29,7 @@ describe('computeRateCardSplit', () => {
       platform_default: 0,
       viewer_global: 0,
     },
+    spendSharePct: 10,
     internalAppOwnerUserIds: [42],
     effectiveFrom: '2026-01-01',
   };
@@ -180,7 +183,7 @@ describe('computeRateCardSplit', () => {
     }
   });
 
-  it('defaults to ACTIVE_RATE_CARD (now V3) when no rateCard is passed', () => {
+  it('defaults to ACTIVE_RATE_CARD (now V4) when no rateCard is passed', () => {
     const split = computeRateCardSplit({
       grossCents: 1000,
       providerFeeCents: 0,
@@ -189,8 +192,11 @@ describe('computeRateCardSplit', () => {
       appOwnerUserId: 1,
     });
     expect(split.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
-    expect(split.rateCardVersion).toBe(RATE_CARD_V3.version);
-    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V3);
+    expect(split.rateCardVersion).toBe(RATE_CARD_V4.version);
+    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V4);
+    // V4 carries V3's purchase percentages unchanged (the spend dimension
+    // is the only addition), so per_model_install is still 15%.
+    expect(split.appOwnerShareCents).toBe(150);
   });
 
   // --- W3 flow B: viewer_global (page purchase) at 0% ---------------------
@@ -213,7 +219,7 @@ describe('computeRateCardSplit', () => {
     ).toBe(1000);
   });
 
-  it('viewer_global on the ACTIVE card (V3) also pays 0% with conservation', () => {
+  it('viewer_global on the ACTIVE card (V4) also pays 0% with conservation', () => {
     const split = computeRateCardSplit({
       grossCents: 4999,
       providerFeeCents: 217,
@@ -221,7 +227,7 @@ describe('computeRateCardSplit', () => {
       isSelfPurchase: false,
       appOwnerUserId: 7,
     });
-    expect(split.rateCardVersion).toBe('v3');
+    expect(split.rateCardVersion).toBe('v4');
     expect(split.appOwnerShareCents).toBe(0);
     expect(
       split.providerFeeCents + split.platformShareCents + split.appOwnerShareCents
@@ -288,5 +294,114 @@ describe('computeRateCardSplit', () => {
     expect(split.rateCardVersion).toBe('v2');
     expect(split.appOwnerShareCents).toBe(250);
     expect(split.platformShareCents).toBe(750);
+  });
+});
+
+/**
+ * W3 flow A — buzz SPEND author-bounty math. The bounty is a
+ * platform-funded percentage of the spend's USD value, NOT a split of a
+ * pool. The invariants asserted here mirror the migration's CHECKs:
+ *   - share >= 0, share <= gross
+ *   - share = floor(gross * pct / 100)
+ *   - self-spend / internal-owner -> 0
+ */
+describe('computeSpendShare', () => {
+  // Fixed 10% card so the test is stable when the live placeholder moves.
+  const fixedCard: RateCard = {
+    version: 'spend-test',
+    publisherSharePctByScope: {
+      per_model_install: 0,
+      publisher_all_my_models: 0,
+      viewer_personal: 0,
+      platform_default: 0,
+      viewer_global: 0,
+    },
+    spendSharePct: 10,
+    internalAppOwnerUserIds: [42],
+    effectiveFrom: '2026-01-01',
+  };
+
+  it('pays the placeholder spend rate of the gross USD value, floored', () => {
+    // 1234 cents gross @ 10% = 123.4 -> 123 (platform absorbs the .4).
+    const res = computeSpendShare({
+      rateCard: fixedCard,
+      grossValueCents: 1234,
+      isSelfSpend: false,
+      appOwnerUserId: 1,
+    });
+    expect(res.rateCardVersion).toBe('spend-test');
+    expect(res.spendSharePct).toBe(10);
+    expect(res.appOwnerShareCents).toBe(123);
+    // Invariant: 0 <= share <= gross.
+    expect(res.appOwnerShareCents).toBeGreaterThanOrEqual(0);
+    expect(res.appOwnerShareCents).toBeLessThanOrEqual(1234);
+    // Invariant: share == floor(gross * pct / 100).
+    expect(res.appOwnerShareCents).toBe(Math.floor((1234 * 10) / 100));
+  });
+
+  it('zeroes the bounty on self-spend (author generating in own app)', () => {
+    const res = computeSpendShare({
+      rateCard: fixedCard,
+      grossValueCents: 1000,
+      isSelfSpend: true,
+      appOwnerUserId: 7,
+    });
+    expect(res.appOwnerShareCents).toBe(0);
+    expect(res.spendSharePct).toBe(0);
+  });
+
+  it('zeroes the bounty for an internal civitai-owned app', () => {
+    const res = computeSpendShare({
+      rateCard: fixedCard,
+      grossValueCents: 1000,
+      isSelfSpend: false,
+      appOwnerUserId: 42, // ∈ internalAppOwnerUserIds
+    });
+    expect(res.appOwnerShareCents).toBe(0);
+    expect(res.spendSharePct).toBe(0);
+  });
+
+  it('clamps a never-exceed-gross ceiling even with a runaway rate', () => {
+    const runaway: RateCard = { ...fixedCard, spendSharePct: 250 };
+    const res = computeSpendShare({
+      rateCard: runaway,
+      grossValueCents: 100,
+      isSelfSpend: false,
+      appOwnerUserId: 1,
+    });
+    // 100 * 250% = 250, clamped to gross (100) — a bounty can never exceed
+    // the revenue it rewards (matches the migration's share_le_gross CHECK).
+    expect(res.appOwnerShareCents).toBe(100);
+    expect(res.appOwnerShareCents).toBeLessThanOrEqual(100);
+  });
+
+  it('floors a negative/garbage gross to 0', () => {
+    const res = computeSpendShare({
+      rateCard: fixedCard,
+      grossValueCents: -500,
+      isSelfSpend: false,
+      appOwnerUserId: 1,
+    });
+    expect(res.appOwnerShareCents).toBe(0);
+  });
+
+  it('V4 is the active card and carries the placeholder spend rate', () => {
+    expect(ACTIVE_RATE_CARD.version).toBe('v4');
+    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V4);
+    // The placeholder is non-zero (the spend flow pays something) but
+    // conservative. If this number changes, it's a deliberate sign-off
+    // decision — update the test alongside the new card.
+    expect(RATE_CARD_V4.spendSharePct).toBe(5);
+    expect(RATE_CARD_V4.spendSharePct).toBeGreaterThan(0);
+    // Purchase percentages carried from V3 unchanged.
+    expect(RATE_CARD_V4.publisherSharePctByScope).toEqual(
+      RATE_CARD_V3.publisherSharePctByScope
+    );
+  });
+
+  it('older cards (V1-V3) carry a 0% spend rate (spend is net-new in V4)', () => {
+    expect(RATE_CARD_V1.spendSharePct).toBe(0);
+    expect(RATE_CARD_V2.spendSharePct).toBe(0);
+    expect(RATE_CARD_V3.spendSharePct).toBe(0);
   });
 });

--- a/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * W3 flow A — buzz SPEND attribution service coverage. The interesting
+ * surface is:
+ *   - server-derived author bounty (gross USD from Buzz, share via the
+ *     active spend rate card)
+ *   - self-spend wash (spender == app owner → voided + 0 share)
+ *   - internal-owner wash (app owner ∈ internalAppOwnerUserIds)
+ *   - idempotency via the (workflow_id, app_block_id) UNIQUE (P2002)
+ *   - missing-app guard
+ *   - the platform-funded-bounty ledger invariant (0 ≤ share ≤ gross)
+ *
+ * Prisma + logger are mocked at the module boundary so the test stays
+ * in-process and deterministic. The Prom counter is real (the service
+ * wraps it in try/catch) — no need to mock it.
+ */
+
+class FakePrismaKnownError extends Error {
+  code: string;
+  clientVersion: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+    this.clientVersion = 'test';
+  }
+}
+
+const { mockDbRead, mockDbWrite, mockLog } = vi.hoisted(() => ({
+  mockDbRead: {
+    oauthClient: { findUnique: vi.fn() },
+    blockSpendAttribution: { findUnique: vi.fn() },
+  },
+  mockDbWrite: {
+    blockSpendAttribution: { create: vi.fn() },
+  },
+  mockLog: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: mockDbWrite,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+
+import {
+  AttributionAppMissingError,
+  buzzSpendToUsdCents,
+  recordSpendAttribution,
+  type RecordSpendAttributionInput,
+} from '../buzz-attribution.service';
+import { ACTIVE_RATE_CARD } from '../rate-card';
+
+const APP_ID = 'app_test';
+const APP_BLOCK_ID = 'apb_test';
+const APP_OWNER_USER_ID = 999;
+const SPENDER_ID = 100;
+const WORKFLOW_ID = 'wf_abc123';
+
+function fakeInput(over: Partial<RecordSpendAttributionInput> = {}): RecordSpendAttributionInput {
+  return {
+    userId: SPENDER_ID,
+    buzzAmount: 5000, // 5000 Buzz = $5 = 500 cents
+    workflowId: WORKFLOW_ID,
+    appId: APP_ID,
+    appBlockId: APP_BLOCK_ID,
+    blockInstanceId: 'bki_test123',
+    modelId: 555,
+    ...over,
+  };
+}
+
+// Echo the data back as the "created" row so assertions can read what the
+// service computed (mirrors the real Prisma create return shape, narrowed
+// to the service's `select`).
+function createEchoesData() {
+  mockDbWrite.blockSpendAttribution.create.mockImplementation(
+    async ({ data }: { data: Record<string, unknown> }) => ({
+      id: data.id,
+      status: data.status,
+      appOwnerShareCents: data.appOwnerShareCents,
+      spendSharePct: data.spendSharePct,
+      grossValueCents: data.grossValueCents,
+      rateCardVersion: data.rateCardVersion,
+      voidedReason: data.voidedReason ?? null,
+    })
+  );
+}
+
+beforeEach(() => {
+  mockDbRead.oauthClient.findUnique.mockReset();
+  mockDbRead.blockSpendAttribution.findUnique.mockReset();
+  mockDbWrite.blockSpendAttribution.create.mockReset();
+  mockLog.mockReset();
+  // Default: app exists, owned by a different user than the spender.
+  mockDbRead.oauthClient.findUnique.mockResolvedValue({
+    id: APP_ID,
+    userId: APP_OWNER_USER_ID,
+  });
+  createEchoesData();
+});
+
+describe('buzzSpendToUsdCents', () => {
+  it('converts Buzz to USD cents at the 1000:1 ratio, floored', () => {
+    expect(buzzSpendToUsdCents(1000)).toBe(100); // $1
+    expect(buzzSpendToUsdCents(5000)).toBe(500); // $5
+    expect(buzzSpendToUsdCents(4999)).toBe(499); // floors, never over-states
+    expect(buzzSpendToUsdCents(10)).toBe(1); // 1 cent
+    expect(buzzSpendToUsdCents(9)).toBe(0); // sub-cent floors to 0
+    expect(buzzSpendToUsdCents(-100)).toBe(0); // garbage clamps to 0
+  });
+});
+
+describe('recordSpendAttribution', () => {
+  it('writes exactly one pending row with author=appBlock owner, gross=USD cost, share=cost×rate (floored)', async () => {
+    const res = await recordSpendAttribution(fakeInput());
+
+    // Exactly one write.
+    expect(mockDbWrite.blockSpendAttribution.create).toHaveBeenCalledTimes(1);
+    expect(res.written).toBe(true);
+
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+
+    // Author is the appBlock's owning OauthClient user (server-derived).
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+    // Gross = USD value of the Buzz burned: 5000 Buzz -> 500 cents.
+    expect(data.grossValueCents).toBe(500);
+    // Share = gross * active spend rate, floored.
+    const expectedShare = Math.floor((500 * ACTIVE_RATE_CARD.spendSharePct) / 100);
+    expect(data.appOwnerShareCents).toBe(expectedShare);
+    expect(data.spendSharePct).toBe(ACTIVE_RATE_CARD.spendSharePct);
+    // Not self-spend → pending, not voided.
+    expect(data.status).toBe('pending');
+    expect(data.voidedReason).toBeNull();
+    // Server-derived context preserved.
+    expect(data.appId).toBe(APP_ID);
+    expect(data.appBlockId).toBe(APP_BLOCK_ID);
+    expect(data.workflowId).toBe(WORKFLOW_ID);
+    expect(data.userId).toBe(SPENDER_ID);
+    expect(data.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
+  });
+
+  it('ledger invariant: 0 ≤ author_share ≤ gross (platform-funded bounty)', async () => {
+    await recordSpendAttribution(fakeInput({ buzzAmount: 123456 }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.appOwnerShareCents).toBeGreaterThanOrEqual(0);
+    expect(data.appOwnerShareCents).toBeLessThanOrEqual(data.grossValueCents);
+    // And re-derivable from the stamped rate.
+    expect(data.appOwnerShareCents).toBe(
+      Math.floor((data.grossValueCents * data.spendSharePct) / 100)
+    );
+  });
+
+  it('self-spend (spender == app owner) → voided, zero share', async () => {
+    mockDbRead.oauthClient.findUnique.mockResolvedValue({
+      id: APP_ID,
+      userId: SPENDER_ID, // owner == spender
+    });
+    const res = await recordSpendAttribution(fakeInput());
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.status).toBe('voided');
+    expect(data.voidedReason).toBe('self_spend');
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.spendSharePct).toBe(0);
+    expect(res.row.status).toBe('voided');
+  });
+
+  it('idempotency: a second call for the same workflow returns the existing row, no second write', async () => {
+    // First write succeeds.
+    const first = await recordSpendAttribution(fakeInput());
+    expect(first.written).toBe(true);
+
+    // Second write hits the (workflow_id, app_block_id) UNIQUE → P2002.
+    mockDbWrite.blockSpendAttribution.create.mockRejectedValueOnce(
+      new FakePrismaKnownError('dup', 'P2002')
+    );
+    mockDbRead.blockSpendAttribution.findUnique.mockResolvedValueOnce({
+      id: 'bsa_existing',
+      status: 'pending',
+      appOwnerShareCents: 25,
+      spendSharePct: 5,
+      grossValueCents: 500,
+      rateCardVersion: 'v4',
+      voidedReason: null,
+    });
+
+    const second = await recordSpendAttribution(fakeInput());
+    expect(second.written).toBe(false);
+    expect(second.row.id).toBe('bsa_existing');
+
+    // Looked up by the workflow+app idempotency key.
+    expect(mockDbRead.blockSpendAttribution.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { workflowId_appBlockId: { workflowId: WORKFLOW_ID, appBlockId: APP_BLOCK_ID } },
+      })
+    );
+  });
+
+  it('aborts (throws AttributionAppMissingError) when the app is gone — no orphan row', async () => {
+    mockDbRead.oauthClient.findUnique.mockResolvedValue(null);
+    await expect(recordSpendAttribution(fakeInput())).rejects.toBeInstanceOf(
+      AttributionAppMissingError
+    );
+    expect(mockDbWrite.blockSpendAttribution.create).not.toHaveBeenCalled();
+  });
+
+  it('re-throws a non-P2002 DB error (real failures are not swallowed as idempotent)', async () => {
+    mockDbWrite.blockSpendAttribution.create.mockRejectedValueOnce(
+      new FakePrismaKnownError('connection lost', 'P1001')
+    );
+    await expect(recordSpendAttribution(fakeInput())).rejects.toMatchObject({
+      code: 'P1001',
+    });
+    // Did NOT fall through to the idempotent lookup.
+    expect(mockDbRead.blockSpendAttribution.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -1,7 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
-import { blockBuzzAttributionWriteCounter } from '~/server/prom/client';
+import {
+  blockBuzzAttributionWriteCounter,
+  blockSpendAttributionWriteCounter,
+} from '~/server/prom/client';
 import {
   type BlockAttribution,
   type BlockAttributionScope,
@@ -9,8 +12,9 @@ import {
 import {
   newBlockAttributionPayoutId,
   newBlockBuzzAttributionId,
+  newBlockSpendAttributionId,
 } from '~/server/utils/app-block-ids';
-import { computeRateCardSplit, ACTIVE_RATE_CARD } from './rate-card';
+import { computeRateCardSplit, computeSpendShare, ACTIVE_RATE_CARD } from './rate-card';
 
 export type AttributionPaymentProvider = 'stripe' | 'paddle' | 'nowpayments';
 
@@ -232,6 +236,232 @@ export class AttributionAppMissingError extends Error {
     super(`OauthClient '${appId}' not found for attribution`);
     this.name = 'AttributionAppMissingError';
     this.appId = appId;
+  }
+}
+
+// ---------------------------------------------------------------
+// W3 flow A — buzz SPEND attribution (author bounty)
+// ---------------------------------------------------------------
+
+const SPEND_ATTRIBUTION_LOG_NAME = 'block-spend-attribution';
+
+/**
+ * buzzDollarRatio (1000 Buzz = $1 USD) -> Buzz to USD cents. Local
+ * constant (rather than importing the whole constants module into the
+ * service) and documented inline. $1 = 100 cents, so 1000 Buzz = 100
+ * cents => 1 cent per 10 Buzz.
+ */
+const BUZZ_PER_USD = 1000;
+export function buzzSpendToUsdCents(buzzAmount: number): number {
+  // Floor so we never over-state the spend's USD value (which would
+  // over-pay the bounty). e.g. 4999 Buzz -> 499 cents (not 500).
+  return Math.floor((Math.max(0, buzzAmount) / BUZZ_PER_USD) * 100);
+}
+
+export type RecordSpendAttributionInput = {
+  /** The viewer (spender). Server-derived from the verified token's `sub`. */
+  userId: number;
+  /** Buzz the generation burned (the orchestrator-computed cost). */
+  buzzAmount: number;
+  /** Yellow / blue / etc — mirrors BuzzTransaction.fromAccountType. */
+  buzzType?: string;
+  /** Orchestrator workflow id — the idempotency anchor. */
+  workflowId: string;
+  /** OauthClient.id — server-derived from the verified token's `appId`. */
+  appId: string;
+  /** AppBlock.id — server-derived from the verified token's `appBlockId`. */
+  appBlockId: string;
+  /** Block instance id — server-derived from the verified token. */
+  blockInstanceId: string;
+  /** Optional: model the generation ran against (analytics only). */
+  modelId?: number | null;
+};
+
+export type RecordSpendAttributionResult = {
+  /** False when the (workflow, app) UNIQUE blocked a duplicate write. */
+  written: boolean;
+  row: {
+    id: string;
+    status: string;
+    appOwnerShareCents: number;
+    spendSharePct: number;
+    grossValueCents: number;
+    rateCardVersion: string;
+    voidedReason: string | null;
+  };
+};
+
+/**
+ * Record an author bounty for a block-initiated generation that SPENT the
+ * viewer's own Buzz. Idempotent on `(workflow_id, app_block_id)` — a
+ * re-poll / retry / re-submit of the same workflow is a no-op.
+ *
+ * EVERYTHING is server-derived from the verified block-token claims by
+ * the caller (submitWorkflow): appId/appBlockId/blockInstanceId come from
+ * the JWT, the spender from `sub`, and the author is looked up here from
+ * the AppBlock's owning OauthClient. There is NO client-supplied
+ * attribution field — spend is server-initiated via the token, so it is
+ * inherently forge-safe (unlike the purchase/Paddle path, which must
+ * re-derive client metadata via validateBuzzPurchaseAttribution).
+ *
+ * ACCOUNTING: the bounty is platform-funded (paid ON TOP of the spend),
+ * not a cut of the viewer's Buzz. See rate-card.ts RATE_CARD_V4 and the
+ * migration. This function moves NO money and touches NO BuzzTransaction
+ * — it writes a derived audit/payout row. A failed write never affects
+ * the generation (the caller fires it best-effort / fire-and-forget).
+ *
+ * Self-spend (spender == app owner) and internal-owner apps write a
+ * voided, zero-share row so the audit trail exists but nothing enters the
+ * payout pipeline (mirrors recordAttribution's self-purchase wash).
+ */
+export async function recordSpendAttribution(
+  input: RecordSpendAttributionInput
+): Promise<RecordSpendAttributionResult> {
+  const {
+    userId,
+    buzzAmount,
+    buzzType = 'yellow',
+    workflowId,
+    appId,
+    appBlockId,
+    blockInstanceId,
+    modelId = null,
+  } = input;
+
+  // Resolve + snapshot the app owner (mirrors recordAttribution). The
+  // OauthClient is the source of truth for "who owns this app"; we
+  // snapshot userId onto the row so a future reassignment doesn't
+  // re-route past payouts. No owner -> nothing to pay -> abort.
+  const app = await dbRead.oauthClient.findUnique({
+    where: { id: appId },
+    select: { id: true, userId: true },
+  });
+  if (!app) {
+    logToAxiom(
+      {
+        name: SPEND_ATTRIBUTION_LOG_NAME,
+        type: 'warning',
+        message: `spend attribution app not found (skipping write): ${appId}`,
+        appId,
+        workflowId,
+      },
+      'webhooks'
+    ).catch(() => null);
+    throw new AttributionAppMissingError(appId);
+  }
+
+  const grossValueCents = buzzSpendToUsdCents(buzzAmount);
+  const isSelfSpend = userId === app.userId;
+  const share = computeSpendShare({
+    grossValueCents,
+    isSelfSpend,
+    appOwnerUserId: app.userId,
+  });
+
+  // Void zero-share rows that are zero because of WHO spent/owns (not
+  // because the rate is 0%) so they never enter the payout pipeline. A
+  // legitimately rate-0% row stays 'pending' — it carries no money but is
+  // a real attribution we want to confirm/aggregate (so a later non-zero
+  // card change applies going forward).
+  const isInternal = ACTIVE_RATE_CARD.internalAppOwnerUserIds.includes(app.userId);
+  const voidedReason = isSelfSpend ? 'self_spend' : isInternal ? 'internal_owner' : null;
+  const status = voidedReason ? 'voided' : 'pending';
+  const voidedAt = voidedReason ? new Date() : null;
+
+  const id = newBlockSpendAttributionId();
+
+  try {
+    const created = await dbWrite.blockSpendAttribution.create({
+      data: {
+        id,
+        userId,
+        buzzAmount: Math.max(0, Math.floor(buzzAmount)),
+        buzzType,
+        grossValueCents,
+        workflowId,
+        appId,
+        appBlockId,
+        blockInstanceId,
+        modelId,
+        rateCardVersion: share.rateCardVersion,
+        spendSharePct: share.spendSharePct,
+        appOwnerShareCents: share.appOwnerShareCents,
+        appOwnerUserId: app.userId,
+        status,
+        voidedReason,
+        voidedAt,
+      },
+      select: {
+        id: true,
+        status: true,
+        appOwnerShareCents: true,
+        spendSharePct: true,
+        grossValueCents: true,
+        rateCardVersion: true,
+        voidedReason: true,
+      },
+    });
+
+    logToAxiom(
+      {
+        name: SPEND_ATTRIBUTION_LOG_NAME,
+        type: 'info',
+        message: `spend attribution written ${created.id}`,
+        attributionId: created.id,
+        appId,
+        appBlockId,
+        workflowId,
+        buzzAmount,
+        grossValueCents,
+        spendSharePct: share.spendSharePct,
+        appOwnerShareCents: share.appOwnerShareCents,
+        rateCardVersion: share.rateCardVersion,
+        status,
+        voidedReason,
+        isSelfSpend,
+      },
+      'webhooks'
+    ).catch(() => null);
+
+    try {
+      blockSpendAttributionWriteCounter.inc({ status });
+    } catch {
+      // swallow — metric write must never back-pressure the caller
+    }
+
+    return { written: true, row: created };
+  } catch (err) {
+    // Idempotency: a re-poll / retry / re-submit that races the original
+    // write lands on the (workflow_id, app_block_id) UNIQUE -> P2002.
+    // Return the pre-existing row so callers treat first-write and retry
+    // uniformly. Duck-type the Prisma error code (the class isn't always
+    // constructible when the generated client is stale in tests).
+    const code = (err as { code?: unknown })?.code;
+    if (code === 'P2002') {
+      const existing = await dbRead.blockSpendAttribution.findUnique({
+        where: {
+          workflowId_appBlockId: { workflowId, appBlockId },
+        },
+        select: {
+          id: true,
+          status: true,
+          appOwnerShareCents: true,
+          spendSharePct: true,
+          grossValueCents: true,
+          rateCardVersion: true,
+          voidedReason: true,
+        },
+      });
+      if (existing) {
+        try {
+          blockSpendAttributionWriteCounter.inc({ status: 'duplicate' });
+        } catch {
+          // swallow
+        }
+        return { written: false, row: existing };
+      }
+    }
+    throw err;
   }
 }
 

--- a/src/server/services/blocks/rate-card.ts
+++ b/src/server/services/blocks/rate-card.ts
@@ -21,6 +21,17 @@ export type RateCard = {
    */
   publisherSharePctByScope: Record<BlockAttributionScope, number>;
   /**
+   * W3 flow A — buzz SPEND attribution (author bounty).
+   *
+   * The percentage of a block-initiated generation's USD value paid to
+   * the app author as a PLATFORM-FUNDED BOUNTY (NOT a cut of the viewer's
+   * spend — see the accounting note below and the migration). One flat
+   * rate for spend (no per-scope dimension): a spend has no install
+   * scope the way a purchase does — it's just "this app caused a
+   * generation". PLACEHOLDER pending monetization sign-off.
+   */
+  spendSharePct: number;
+  /**
    * Apps owned by these userIds always pay 0% to publisher — internal
    * civitai apps where the "share" is meaningless because the same
    * legal entity owns both sides of the transaction.
@@ -74,6 +85,10 @@ export const RATE_CARD_V1: RateCard = {
     // behavior-preserving for this card's stamped rows.
     viewer_global: 0,
   },
+  // Net-new spend dimension (W3 flow A). 0% on V1 is behavior-preserving:
+  // no spend row was ever stamped under V1 (the spend flow is net-new),
+  // and V1 is not the active card.
+  spendSharePct: 0,
   internalAppOwnerUserIds: [],
   effectiveFrom: '2026-05-25',
 };
@@ -115,6 +130,9 @@ export const RATE_CARD_V2: RateCard = {
     // behavior-preserving for this card's stamped rows.
     viewer_global: 0,
   },
+  // Net-new spend dimension (W3 flow A). 0% — behavior-preserving (no V2
+  // spend row ever existed; V2 is not the active card).
+  spendSharePct: 0,
   internalAppOwnerUserIds: [
     // Populate with civitai team userIds before going live. Empty for
     // now — none of the load-bearing paths read this list yet, but the
@@ -141,6 +159,9 @@ export const RATE_CARD_V2: RateCard = {
  * PLACEHOLDER — a real publisher share for pages needs monetization
  * leadership sign-off. When that lands, add a V4 with the agreed % and
  * leave V3 in place for the rows stamped under it (cards are immutable).
+ *
+ * `spendSharePct` is carried at 0% on V3 — V3 predates the spend flow and
+ * stamped only purchase rows. The spend flow (W3 flow A) ships under V4.
  */
 export const RATE_CARD_V3: RateCard = {
   version: 'v3',
@@ -155,13 +176,70 @@ export const RATE_CARD_V3: RateCard = {
     // monetization sign-off.
     viewer_global: 0,
   },
+  spendSharePct: 0,
   internalAppOwnerUserIds: [
     // Same as V2 — populate with civitai team userIds before going live.
   ],
   effectiveFrom: '2026-06-18',
 };
 
-export const ACTIVE_RATE_CARD: RateCard = RATE_CARD_V3;
+/**
+ * V4 — adds the W3 flow A buzz-SPEND author bounty (`spendSharePct`).
+ *
+ * Carries V3's purchase percentages UNCHANGED (15/15/25/0/0) and sets
+ * `spendSharePct` to the FIRST non-zero spend rate. This is the first
+ * card emitted for the spend flow: a block-initiated generation that
+ * burns the viewer's own Buzz now accrues an author bounty.
+ *
+ * ⚠️ PLACEHOLDER RATE — `spendSharePct: 5` is a CONSERVATIVE DEFAULT
+ *    chosen pending monetization sign-off (Zach's call: ship a documented
+ *    conservative number, not a guessed-final one). Raising is politically
+ *    easier than lowering after a public announcement, so this starts low.
+ *
+ * ACCOUNTING MODEL — PLATFORM-FUNDED BOUNTY, not a cut of the spend:
+ *    The viewer burns 100% of their Buzz on the generation (that is
+ *    platform revenue — the viewer paid civitai for compute). The author
+ *    bounty is a SEPARATE platform expense paid ON TOP, sized as
+ *    `spendSharePct` % of the spend's USD value. It is a marketing /
+ *    ecosystem cost, NOT a slice carved out of the viewer's money. There
+ *    is therefore NO three-way conservation invariant for spend rows (the
+ *    block_spend_attribution table omits the purchase table's
+ *    fee+platform+author=gross CHECK). The conservation/ledger invariant
+ *    that DOES hold: author_share = floor(grossValueCents * spendSharePct
+ *    / 100), 0 ≤ author_share ≤ grossValueCents, and author_share = 0 on
+ *    self-spend / internal-owner.
+ *
+ *    LEDGER IMPLICATION FOR SIGN-OFF: every paid spend bounty is net-new
+ *    platform spend (it does not reduce platform revenue on the
+ *    generation). At spendSharePct=N% and a daily block-spend volume of
+ *    $X USD-equivalent, the platform's bounty liability is ~$X·N%/day.
+ *    This is the number monetization must sign off on, NOT a revenue
+ *    split. Cap exposure with the existing BLOCK_BUZZ_CAP_PER_DAY (bounds
+ *    per-user daily spend) and the per-app earnings cap (unimplemented
+ *    placeholder) before widening beyond mods.
+ *
+ * When the signed-off rate lands, add a V5 with the agreed % and leave V4
+ * in place for the rows stamped under it (cards are immutable).
+ */
+export const RATE_CARD_V4: RateCard = {
+  version: 'v4',
+  publisherSharePctByScope: {
+    // Carried from V3 verbatim — a percentage change is a new card.
+    per_model_install: 15,
+    publisher_all_my_models: 15,
+    viewer_personal: 25,
+    platform_default: 0,
+    viewer_global: 0,
+  },
+  // PLACEHOLDER 5% platform-funded bounty — see the doc block above.
+  spendSharePct: 5,
+  internalAppOwnerUserIds: [
+    // Same as V3 — populate with civitai team userIds before going live.
+  ],
+  effectiveFrom: '2026-06-18',
+};
+
+export const ACTIVE_RATE_CARD: RateCard = RATE_CARD_V4;
 
 /**
  * Result of running a (gross, fee, scope) tuple through the active rate
@@ -234,5 +312,66 @@ export function computeRateCardSplit({
     appOwnerShareCents,
     platformShareCents,
     providerFeeCents: safeFee,
+  };
+}
+
+/**
+ * Result of running a (grossValueCents, owner) tuple through the active
+ * card's SPEND dimension (W3 flow A). Unlike RateCardSplit there is no
+ * platform-share / provider-fee field: the author bounty is platform-
+ * funded and paid ON TOP of the spend, not carved out of it, so there is
+ * nothing to "split". See RATE_CARD_V4's accounting note.
+ */
+export type SpendShareResult = {
+  rateCardVersion: string;
+  spendSharePct: number;
+  appOwnerShareCents: number;
+};
+
+/**
+ * Compute the author bounty for a single block-initiated Buzz SPEND.
+ *
+ * `grossValueCents` is the USD value of the Buzz the generation burned
+ * (buzzDollarRatio 1000 Buzz = $1 = 100 cents — the caller converts). The
+ * bounty is `spendSharePct` % of that value, floored so the platform
+ * never over-pays a fractional cent.
+ *
+ * Special cases (mirror computeRateCardSplit):
+ *   - `isSelfSpend` (spender == app owner) → 0 bounty. The author
+ *     generating in their own app earns nothing; the caller sets
+ *     status='voided', voided_reason='self_spend' so the row never enters
+ *     the payout pipeline.
+ *   - `appOwnerUserId` ∈ `internalAppOwnerUserIds` → 0 bounty (internal
+ *     civitai app — same legal entity on both sides).
+ *
+ * Invariants (also enforced by the migration's CHECKs):
+ *   - appOwnerShareCents >= 0
+ *   - appOwnerShareCents <= grossValueCents (a bounty can never exceed
+ *     the revenue it rewards — a runaway rate is a bug)
+ */
+export function computeSpendShare({
+  rateCard = ACTIVE_RATE_CARD,
+  grossValueCents,
+  isSelfSpend,
+  appOwnerUserId,
+}: {
+  rateCard?: RateCard;
+  grossValueCents: number;
+  isSelfSpend: boolean;
+  appOwnerUserId: number;
+}): SpendShareResult {
+  const safeGross = Math.max(0, Math.floor(grossValueCents));
+
+  const isInternal = rateCard.internalAppOwnerUserIds.includes(appOwnerUserId);
+  const sharePct = isSelfSpend || isInternal ? 0 : rateCard.spendSharePct ?? 0;
+  // Floor so the platform never over-pays a sub-cent remainder, then clamp
+  // to the gross as a defensive ceiling (the bounty can never exceed the
+  // spend's USD value — matches the migration's _share_le_gross_check).
+  const appOwnerShareCents = Math.min(safeGross, Math.floor((safeGross * sharePct) / 100));
+
+  return {
+    rateCardVersion: rateCard.version,
+    spendSharePct: sharePct,
+    appOwnerShareCents,
   };
 }

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -95,6 +95,10 @@ export function newBlockAttributionPayoutId(): string {
   return `bba_payout_${newUlid()}`;
 }
 
+export function newBlockSpendAttributionId(): string {
+  return `bsa_${newUlid()}`;
+}
+
 export function newAppUserScopeGrantId(): string {
   return `augr_${newUlid()}`;
 }


### PR DESCRIPTION
## What & why

Block-initiated generations that burn the **viewer's own Buzz** earned the app author **\$0** today — `submitWorkflow` wrote only a `recordScopeInvocation` audit row (the inline comment even said *"block_buzz_attribution only covers Buzz PURCHASES"*). This slice (W3 flow A, the WRITE/accrual half) makes a block-initiated **spend** accrue a version-stamped author share.

Scope: **flow A only**. Flows B (page purchase, merged in #2624), C (membership), D (payout disbursement, #2605) are **out of scope** and untouched. This is **accrual only** — rows accumulate (visible via revenue aggregates later); no money moves.

## Storage shape (+ why)

A **NEW table `block_spend_attribution`** (scope-doc recommendation, option b), NOT an extension of `block_buzz_attribution`:
- A spend is the viewer burning existing Buzz on a generation — **no payment provider, no provider fee, no Stripe/Paddle txn, no refund/chargeback/clawback lifecycle**.
- `block_buzz_attribution` is purchase-shaped: its conservation CHECK (`provider_fee + platform_share + author_share = gross`) assumes a card txn divided three ways. Hosting spend there means relaxing that CHECK and polluting the purchase aggregates (`getRevenueForOwner`).
- Idempotency key: **`UNIQUE (workflow_id, app_block_id)`**.

## Accounting model (flag for sign-off)

**Platform-funded BOUNTY, not a cut of the spend.** The viewer burns 100% of their Buzz on the generation — that is platform revenue (the viewer paid civitai for compute). The author share is a **separate platform expense paid on top**, sized as a % of the spend's USD value (`buzzDollarRatio` 1000 Buzz = \$1 = 100 cents).

**Ledger implication:** there is **no three-way conservation invariant** for spend rows (the table omits the purchase table's `fee+platform+author=gross` CHECK). The invariants that *do* hold (enforced by CHECKs + `computeSpendShare`):
- `0 ≤ app_owner_share_cents ≤ gross_value_cents`
- `app_owner_share_cents = floor(gross_value_cents × spend_share_pct / 100)`
- self-spend / internal-owner → `0` share (voided audit row).

Every paid bounty is **net-new platform spend** (it does not reduce platform revenue on the gen). At `spend_share_pct=N%` and daily block-spend volume \$X, the bounty liability is ~\$X·N%/day — that is the number monetization signs off on, bounded today by `BLOCK_BUZZ_CAP_PER_DAY`.

## Placeholder rate (flag for sign-off)

`RATE_CARD_V4` carries V3's purchase %s **verbatim** and adds **`spendSharePct: 5`** — a **PLACEHOLDER, conservative default** pending monetization sign-off (per Zach's decision: ship a documented conservative number, not a guessed-final one; raising is easier than lowering post-announcement). Cards are immutable; a signed-off rate lands as V5. Header-comment convention matches the existing card.

## Forge-safety (server-derived)

**No client-supplied attribution.** Everything is derived from the **verified block-token claims**: `appId`/`appBlockId`/`blockInstanceId` from the JWT, spender from `sub`, author looked up from the app's `OauthClient`. Spend is server-initiated via the token, so it's inherently forge-safe — unlike the purchase/Paddle path that must re-derive client metadata via `validateBuzzPurchaseAttribution`. A forged `appId`/`appBlockId` in the request body is ignored (tested).

## Idempotency

`recordSpendAttribution` is idempotent on `(workflow_id, app_block_id)` (P2002 → returns the existing row), mirroring the purchase service. A re-poll / retry / re-submit of the same workflow can't double-attribute.

## Wire-in (best-effort, off the REALIZED debit)

Fired fire-and-forget beside `recordScopeInvocation` with its own try/catch — **a failed attribution write never breaks the generation** (the Buzz is already spent, the snapshot is the user-facing source of truth). Only fires on a **real, non-failed** workflow id.

**The bounty gross is accrued off the REALIZED debit, not the whatif estimate** (audit 🟡-1, fixed): `buzzAmount = Math.ceil(snapshot.cost?.total ?? cost)`. `snapshotFromWorkflow` surfaces the real submit's `workflow.cost.total` onto `snapshot.cost.total` (`workflow.service.ts:~49,61`), read from the same resolved `submitted` snapshot the handler already holds (no re-fetch). It falls back to the whatif estimate (`cost`) only when the realized value is absent. This closes (a) estimate>realized over-accrual, (b) a cache-hit / 0-realized still accruing off a non-zero estimate (author paid for a gen that cost nothing), and (c) queue/surge/tier drift landing on platform bounty liability — the bounty now matches what the platform actually took (`share_le_gross` intent).

## Migration — ⚠️ MANUAL-APPLY

`prisma/migrations/20260618130000_block_spend_attribution/migration.sql` is committed for history but is **NOT auto-applied** (CLAUDE.md DB rule #8). A human must run it via psql/retool **BEFORE this deploys**, on:
1. **prod nvme0** (`role=postgres` CNPG cluster — the main civitai DB)
2. the **dev clone** (`cnpg-cluster-dev`, ns `cnpg-database-dev`)

## Tests (vitest)

- **spend-attribution.service**: one row written (author = appBlock owner, gross = USD cost, share = cost×rate floored); ledger invariant `0 ≤ share ≤ gross`; self-spend → voided/0; idempotency (second call → existing row, no second write); missing-app abort; non-P2002 rethrow.
- **rate-card**: spend math (floor, self/internal/runaway-clamp/negative-gross), V4 active + placeholder, V1–V3 carry 0% spend.
- **router wire-in**: server-derived args, forged body ignored, best-effort (thrown write doesn't break submit), no attribution on a resolved-failed snapshot, no attribution on over-budget rejection.
- **realized-debit (🟡-1, new)**: estimate=100 / realized=40 → row gross=40; cache-hit realized=0 → gross=0 (no over-accrual); realized absent → falls back to the estimate (100).

**66/66 `blocks.router.workflow` tests + 7/7 `spend-attribution.service` tests green** (run on a NixOS node-only vitest config reusing the generated Prisma client). Mutation-checked: reverting the wire-in to `Math.ceil(cost)` fails the realized-40 and cache-hit-0 tests as expected (the fallback test still passes, since fallback == estimate).

> Note: `blocks.router.workflow.test.ts` was missing the documented `middleware.trpc` pass-through shim that its sibling blocks router tests (`subscriptions` / `getInstallConfig` / `flag-gate`) all carry — without it the file can't evaluate the transitive `Prisma.validator` import chain on a fresh worktree. Added the same shim so the suite loads; no behavioral change.

**Typecheck:** touched files typecheck clean via `tsc-files` (only an unrelated project-tsconfig `baseUrl`-deprecation warning, exit 0).

## Audit 🟡-2 — per-app Sybil accrual cap (NOTE, not implemented)

There is **no per-APP aggregate accrual cap** — only the per-`(USER, UTC-day)` Buzz **spend** reservation (`BLOCK_BUZZ_CAP_PER_DAY`). A Sybil ring of many viewers could mint unbounded platform-funded bounty toward **one** app. It's **accrual-only + mod-gated** today, so it is **not a merge blocker**, but a **per-app earnings cap / velocity check is a HARD prerequisite before the spend flow opens to non-mods** — track it alongside the Slice-4 payout gate (#2605) and the rate sign-off. Flagged in-code at the wire-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
