### PR TITLE
feat(app-blocks): membership attribution — TRACK-ONLY (defer share to payout-time backpay) (W3 flow C)

### DIFF
--- a/prisma/migrations/20260618140000_block_subscription_attribution/migration.sql
+++ b/prisma/migrations/20260618140000_block_subscription_attribution/migration.sql
@@ -1,0 +1,201 @@
+-- ============================================================
+-- App Blocks — MEMBERSHIP / subscription attribution (W3 flow C)
+-- ============================================================
+-- One row PER PAID INVOICE per app block: a block-initiated membership
+-- (recurring subscription) purchase credits the app author a revenue
+-- share on each paid invoice. See claudedocs/
+-- app-blocks-attribution-backhalf-scope-2026-06-18.md (section C) for the
+-- end-to-end design. This is the recurring-revenue sibling of
+-- block_buzz_attribution (one-shot card purchase) and
+-- block_spend_attribution (internal Buzz burn).
+--
+-- WHY A NEW TABLE (not block_buzz_attribution):
+-- A subscription has a recurring lifecycle the one-shot purchase table
+-- never modelled:
+--   - ONE invoice per billing period (subscription_create on first
+--     purchase, subscription_cycle on every renewal). The natural
+--     idempotency anchor is the per-period `invoice_id`, NOT a single
+--     payment_transaction_id.
+--   - `subscription_id` groups the periods so we can reconcile / report
+--     across a subscription's life.
+--   - cancellation / proration introduce events the buzz table never had
+--     (subscription.deleted / .updated). Conflating recurring + one-shot
+--     in one table would pollute getRevenueForOwner's purchase aggregates
+--     and force the purchase table's CHECKs to flex for a different shape.
+-- A dedicated table keeps each flow's lifecycle and invariants clean
+-- while reusing the same status machine + clawback pattern.
+--
+-- ACCOUNTING MODEL — same three-way split as block_buzz_attribution:
+-- A membership payment IS a real card transaction (gross USD, real
+-- provider fee). The author share is carved out of the NET (gross - fee)
+-- per the active rate card's subscription percentage, the platform keeps
+-- the remainder. So the three-way conservation invariant DOES hold here
+-- (unlike the spend bounty):
+--   provider_fee_cents + platform_share_cents + app_owner_share_cents
+--     = gross_value_cents
+-- Clawback rows (entry_type='clawback') carry NEGATIVE shares and net out
+-- in the payout aggregate, so the CHECK is scoped to entry_type='charge'.
+--
+-- RENEWALS-PAY POLICY (⚠️ FLAGGED — monetization sign-off, scope §C/E#3):
+-- This table writes ONE row per PAID invoice — so by default a renewal
+-- (subscription_cycle) accrues an author share just like the initial
+-- purchase (subscription_create). This is the "renewals pay" policy. If
+-- product decides "first-invoice-only", the SERVICE gates the write to
+-- billing_reason='subscription_create' (no schema change needed) — the
+-- `billing_reason` column below records which it was so the policy is
+-- auditable + reversible after the fact.
+--
+-- ⚠️ MANUAL-APPLY (civitai DB rule #8): committed for history, NOT
+--    auto-applied. A human must run this via psql/retool BEFORE the code
+--    that writes subscription rows deploys, on:
+--      1. prod nvme0  (role=postgres CNPG cluster — the main civitai DB)
+--      2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev)
+--
+-- app_owner_user_id is denormalized at attribution time so payouts are
+-- stable even if OauthClient.userId is later reassigned (mirrors
+-- block_buzz_attribution).
+
+CREATE TABLE "block_subscription_attribution" (
+  -- Application-generated ULID: 'bsu_<ulid>' (30 chars).
+  "id"                      TEXT PRIMARY KEY,
+
+  -- Purchase facts. user_id is the subscriber (purchaser). buzz_amount is
+  -- the membership's monthly Buzz bonus for this invoice (analytics only —
+  -- the share is computed off usd/gross, not Buzz).
+  "user_id"                 INTEGER NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT,
+  "buzz_amount"             INTEGER NOT NULL DEFAULT 0,
+  "buzz_type"               TEXT NOT NULL DEFAULT 'yellow',
+  -- Gross USD value of the invoice, in cents (Stripe invoice amount_paid).
+  "gross_value_cents"       INTEGER NOT NULL,
+
+  -- Subscription / invoice link. invoice_id is the per-period idempotency
+  -- anchor (each renewal = a new invoice_id = at most one row).
+  -- subscription_id groups the periods. billing_reason records WHY this
+  -- invoice fired (subscription_create | subscription_cycle |
+  -- subscription_update) so the renewals-pay vs first-only policy is
+  -- auditable. payment_provider lets a future Paddle leg share the table.
+  "payment_provider"        TEXT NOT NULL,
+  "invoice_id"              TEXT NOT NULL,
+  "subscription_id"         TEXT,
+  "billing_reason"          TEXT,
+  -- Period window for reporting (from the invoice line). Nullable —
+  -- informational, not load-bearing.
+  "period_start"            TIMESTAMPTZ,
+  "period_end"              TIMESTAMPTZ,
+
+  -- Attribution context (re-derived SERVER-SIDE at checkout, never trusted
+  -- from the client — see attribution-validator.service.ts + the FIN-1
+  -- threading in createSubscribeSession). scope is the membership scope
+  -- ('subscription'); a future model/page split can add others.
+  "app_id"                  TEXT NOT NULL REFERENCES "OauthClient"("id") ON DELETE RESTRICT,
+  "app_block_id"            TEXT NOT NULL REFERENCES "app_blocks"("id") ON DELETE RESTRICT,
+  "block_instance_id"       TEXT NOT NULL,
+  "scope"                   TEXT NOT NULL,
+  -- Optional: model the user was browsing when the CTA fired. Analytics.
+  "model_id"                INTEGER,
+  -- Membership tier at write time (analytics / future tier-weighted rate).
+  "tier"                    TEXT,
+
+  -- Revenue share (computed at attribution time against the active rate
+  -- card's SUBSCRIPTION dimension). Denormalized rate_card_version so the
+  -- row pays out under its stamped snapshot forever.
+  "rate_card_version"       TEXT NOT NULL,
+  "subscription_share_pct"  INTEGER NOT NULL,
+  "app_owner_share_cents"   INTEGER NOT NULL,
+  "platform_share_cents"    INTEGER NOT NULL,
+  "provider_fee_cents"      INTEGER NOT NULL,
+  -- Denormalized publisher user — snapshot at attribution time.
+  "app_owner_user_id"       INTEGER NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT,
+
+  -- Lifecycle. Mirrors block_buzz_attribution's status machine so the
+  -- payout aggregator can treat the flows uniformly. entry_type 'charge'
+  -- (normal forward attribution) | 'clawback' (negative carry-forward on
+  -- refund/proration of a previously paid-out period).
+  "status"                  TEXT NOT NULL DEFAULT 'pending',
+  "entry_type"              TEXT NOT NULL DEFAULT 'charge',
+  "voided_reason"           TEXT,
+  "attributed_at"           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "confirmed_at"            TIMESTAMPTZ,
+  "voided_at"               TIMESTAMPTZ,
+  "paid_out_at"             TIMESTAMPTZ,
+  "payout_id"               TEXT,
+
+  -- IDEMPOTENCY: one attribution per (invoice, app block). A webhook retry
+  -- for the same invoice.paid is a no-op (P2002 caught + treated as
+  -- already-written). Each renewal invoice has its OWN invoice_id, so it
+  -- writes its OWN row (renewals-pay). app_block_id is part of the key to
+  -- mirror the purchase table + leave room for a future multi-block split.
+  CONSTRAINT "block_subscription_attribution_invoice_app_uniq"
+    UNIQUE ("invoice_id", "app_block_id"),
+
+  CONSTRAINT "block_subscription_attribution_scope_check"
+    CHECK ("scope" IN ('subscription')),
+  CONSTRAINT "block_subscription_attribution_status_check"
+    CHECK ("status" IN ('pending', 'confirmed', 'voided', 'paid_out', 'held')),
+  CONSTRAINT "block_subscription_attribution_entry_type_check"
+    CHECK ("entry_type" IN ('charge', 'clawback')),
+  CONSTRAINT "block_subscription_attribution_voided_reason_check"
+    CHECK (
+      "voided_reason" IS NULL OR "voided_reason" IN (
+        'refund', 'chargeback', 'proration', 'self_purchase',
+        'internal_owner', 'manual_review'
+      )
+    ),
+  CONSTRAINT "block_subscription_attribution_provider_check"
+    CHECK ("payment_provider" IN ('stripe', 'paddle', 'nowpayments')),
+  -- Non-negativity for the forward 'charge' rows. Clawback rows carry
+  -- NEGATIVE shares/gross, so the non-negativity + conservation CHECKs are
+  -- scoped to entry_type='charge' only.
+  CONSTRAINT "block_subscription_attribution_amounts_nonneg_check"
+    CHECK (
+      "entry_type" <> 'charge' OR (
+        "buzz_amount" >= 0 AND
+        "gross_value_cents" >= 0 AND
+        "subscription_share_pct" >= 0 AND
+        "app_owner_share_cents" >= 0 AND
+        "platform_share_cents" >= 0 AND
+        "provider_fee_cents" >= 0
+      )
+    ),
+  -- Conservation: fee + platform + author = gross (charge rows only).
+  -- A membership payment is a real card transaction split three ways.
+  -- Catches rate-card arithmetic bugs at write time.
+  CONSTRAINT "block_subscription_attribution_share_sum_check"
+    CHECK (
+      "entry_type" <> 'charge' OR (
+        "provider_fee_cents" + "platform_share_cents" + "app_owner_share_cents"
+        = "gross_value_cents"
+      )
+    ),
+  -- Bound the TEXT primary key length. 'bsu_' (4) + 26 Crockford base32
+  -- chars = 30 total.
+  CONSTRAINT "block_subscription_attribution_id_length_check"
+    CHECK (char_length("id") BETWEEN 28 AND 40)
+);
+
+-- Publisher dashboard: "show me my subscription revenue across all apps".
+CREATE INDEX "bsu_publisher_dashboard_idx"
+  ON "block_subscription_attribution" ("app_owner_user_id", "attributed_at" DESC);
+
+-- Per-app drilldown.
+CREATE INDEX "bsu_app_block_dashboard_idx"
+  ON "block_subscription_attribution" ("app_block_id", "attributed_at" DESC);
+
+-- Subscription lifecycle reconcile: find all periods for a subscription
+-- (refund/proration clawback hooks scan by subscription_id).
+CREATE INDEX "bsu_subscription_idx"
+  ON "block_subscription_attribution" ("subscription_id");
+
+-- Refund/clawback webhook lookup: void by (provider, invoice_id).
+CREATE INDEX "bsu_invoice_idx"
+  ON "block_subscription_attribution" ("payment_provider", "invoice_id");
+
+-- Payout job: scan only confirmed-unpaid rows ordered by confirm time.
+CREATE INDEX "bsu_payout_idx"
+  ON "block_subscription_attribution" ("status", "confirmed_at")
+  WHERE "status" = 'confirmed';
+
+-- Confirm-pending cron: scan only pending rows ordered by attribution time.
+CREATE INDEX "bsu_pending_aging_idx"
+  ON "block_subscription_attribution" ("status", "attributed_at")
+  WHERE "status" = 'pending';

--- a/prisma/migrations/20260618140000_block_subscription_attribution/migration.sql
+++ b/prisma/migrations/20260618140000_block_subscription_attribution/migration.sql
@@ -25,16 +25,37 @@
 -- A dedicated table keeps each flow's lifecycle and invariants clean
 -- while reusing the same status machine + clawback pattern.
 --
--- ACCOUNTING MODEL — same three-way split as block_buzz_attribution:
+-- ⚠️ TRACK-ONLY WRITE MODEL (#2629). The webhook write records the
+-- ATTRIBUTION EVENT + the MONEY BASIS (gross_value_cents + provider_fee_cents)
+-- only. It does NOT apply the rate card at write time. Tracked rows are
+-- written:
+--   status               = 'tracked'   (share-pending, not yet computed)
+--   app_owner_share_cents = 0
+--   subscription_share_pct= 0
+--   rate_card_version     = 'unrated'  (no version stamped)
+--   platform_share_cents  = gross - fee (net)
+-- The author share is computed LATER, at PAYOUT time (Slice 4): the payout
+-- rail reads status='tracked' rows and applies the SIGNED-OFF
+-- subscriptionSharePct as a clean retroactive BACKPAY
+-- (author_share = net × rate), then transitions them to a computed state.
+-- This avoids baking a placeholder rate into immutable rows before
+-- monetization sign-off.
+--
+-- ACCOUNTING MODEL — same three-way split as block_buzz_attribution (the
+-- backpay applies it; the tracked row pre-stages it):
 -- A membership payment IS a real card transaction (gross USD, real
 -- provider fee). The author share is carved out of the NET (gross - fee)
--- per the active rate card's subscription percentage, the platform keeps
--- the remainder. So the three-way conservation invariant DOES hold here
--- (unlike the spend bounty):
+-- per the rate card's subscription percentage, the platform keeps the
+-- remainder. The three-way conservation invariant DOES hold even in the
+-- TRACK-ONLY state because author=0 and platform=net:
 --   provider_fee_cents + platform_share_cents + app_owner_share_cents
---     = gross_value_cents
+--     = fee + net + 0 = gross_value_cents
+-- The backpay later re-splits net into platform/author at the signed-off
+-- rate (still conserving the sum).
 -- Clawback rows (entry_type='clawback') carry NEGATIVE shares and net out
 -- in the payout aggregate, so the CHECK is scoped to entry_type='charge'.
+-- (Track-only writes never produce a clawback — a refunded tracked row is
+-- simply voided before any backpay runs, since author=0 means no debt.)
 --
 -- RENEWALS-PAY POLICY (⚠️ FLAGGED — monetization sign-off, scope §C/E#3):
 -- This table writes ONE row per PAID invoice — so by default a renewal
@@ -99,19 +120,24 @@ CREATE TABLE "block_subscription_attribution" (
   -- Revenue share (computed at attribution time against the active rate
   -- card's SUBSCRIPTION dimension). Denormalized rate_card_version so the
   -- row pays out under its stamped snapshot forever.
-  "rate_card_version"       TEXT NOT NULL,
-  "subscription_share_pct"  INTEGER NOT NULL,
-  "app_owner_share_cents"   INTEGER NOT NULL,
+  -- TRACK-ONLY (#2629): no rate is applied at write time. rate_card_version
+  -- is the 'unrated' sentinel and subscription_share_pct / app_owner_share_cents
+  -- default to 0 until the payout-time backpay computes the real share.
+  "rate_card_version"       TEXT NOT NULL DEFAULT 'unrated',
+  "subscription_share_pct"  INTEGER NOT NULL DEFAULT 0,
+  "app_owner_share_cents"   INTEGER NOT NULL DEFAULT 0,
   "platform_share_cents"    INTEGER NOT NULL,
   "provider_fee_cents"      INTEGER NOT NULL,
   -- Denormalized publisher user — snapshot at attribution time.
   "app_owner_user_id"       INTEGER NOT NULL REFERENCES "User"("id") ON DELETE RESTRICT,
 
-  -- Lifecycle. Mirrors block_buzz_attribution's status machine so the
-  -- payout aggregator can treat the flows uniformly. entry_type 'charge'
-  -- (normal forward attribution) | 'clawback' (negative carry-forward on
-  -- refund/proration of a previously paid-out period).
-  "status"                  TEXT NOT NULL DEFAULT 'pending',
+  -- Lifecycle. 'tracked' is the TRACK-ONLY state (#2629): the event + money
+  -- basis are recorded but no share is computed yet — the payout-time backpay
+  -- promotes tracked → a computed state. The other states mirror
+  -- block_buzz_attribution's machine so the eventual payout aggregator can
+  -- treat the flows uniformly. entry_type 'charge' (forward attribution) |
+  -- 'clawback' (negative carry-forward, reserved for the payout slice).
+  "status"                  TEXT NOT NULL DEFAULT 'tracked',
   "entry_type"              TEXT NOT NULL DEFAULT 'charge',
   "voided_reason"           TEXT,
   "attributed_at"           TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -131,7 +157,7 @@ CREATE TABLE "block_subscription_attribution" (
   CONSTRAINT "block_subscription_attribution_scope_check"
     CHECK ("scope" IN ('subscription')),
   CONSTRAINT "block_subscription_attribution_status_check"
-    CHECK ("status" IN ('pending', 'confirmed', 'voided', 'paid_out', 'held')),
+    CHECK ("status" IN ('tracked', 'pending', 'confirmed', 'voided', 'paid_out', 'held')),
   CONSTRAINT "block_subscription_attribution_entry_type_check"
     CHECK ("entry_type" IN ('charge', 'clawback')),
   CONSTRAINT "block_subscription_attribution_voided_reason_check"

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -552,6 +552,8 @@ model User {
   blockAttributionPayouts          BlockAttributionPayout[]  @relation("BlockAttributionPayoutOwner")
   blockSpendAttributionsAsSpender  BlockSpendAttribution[]   @relation("BlockSpendAttributionSpender")
   blockSpendAttributionsAsAppOwner BlockSpendAttribution[]   @relation("BlockSpendAttributionAppOwner")
+  blockSubscriptionAttributionsAsPurchaser BlockSubscriptionAttribution[] @relation("BlockSubscriptionAttributionPurchaser")
+  blockSubscriptionAttributionsAsAppOwner  BlockSubscriptionAttribution[] @relation("BlockSubscriptionAttributionAppOwner")
   publishRequestsSubmitted   AppBlockPublishRequest[]        @relation("PublishRequestSubmitter")
   publishRequestsReviewed    AppBlockPublishRequest[]        @relation("PublishRequestReviewer")
   blockScopeInvocations      BlockScopeInvocation[]
@@ -2219,6 +2221,7 @@ model OauthClient {
   appBlocks      AppBlock[]
   buzzAttributions BlockBuzzAttribution[]
   spendAttributions BlockSpendAttribution[] @relation("BlockSpendAttributionApp")
+  subscriptionAttributions BlockSubscriptionAttribution[] @relation("BlockSubscriptionAttributionApp")
 
   @@index([userId])
 }
@@ -2286,6 +2289,7 @@ model AppBlock {
   userSubscriptions  BlockUserSubscription[]
   buzzAttributions   BlockBuzzAttribution[]
   spendAttributions  BlockSpendAttribution[] @relation("BlockSpendAttributionAppBlock")
+  subscriptionAttributions BlockSubscriptionAttribution[] @relation("BlockSubscriptionAttributionAppBlock")
   publishRequests    AppBlockPublishRequest[]
   scopeInvocations   BlockScopeInvocation[]
   userScopeGrants    AppUserScopeGrant[]
@@ -2618,6 +2622,89 @@ model BlockSpendAttribution {
   @@index([appOwnerUserId, attributedAt(sort: Desc)], map: "bsa_publisher_dashboard_idx")
   @@index([appBlockId, attributedAt(sort: Desc)], map: "bsa_app_block_dashboard_idx")
   @@map("block_spend_attribution")
+}
+
+/// W3 flow C — App Blocks MEMBERSHIP / subscription attribution.
+///
+/// One row PER PAID INVOICE per app block: a block-initiated membership
+/// (recurring subscription) purchase credits the app author a revenue
+/// share on each paid invoice. The recurring-revenue sibling of
+/// BlockBuzzAttribution (one-shot card purchase) and BlockSpendAttribution
+/// (internal Buzz burn).
+///
+/// ACCOUNTING: a membership payment IS a real card transaction (gross USD,
+/// real provider fee), so it uses the SAME three-way split as
+/// BlockBuzzAttribution — author share is carved out of the net per the
+/// active rate card's subscription percentage. The three-way conservation
+/// invariant holds for entry_type='charge' rows (see the migration CHECK).
+///
+/// RENEWALS-PAY: one row per invoice_id means each renewal
+/// (subscription_cycle) accrues a share by default. The service can gate
+/// the write to billing_reason='subscription_create' for a first-only
+/// policy without a schema change. ⚠️ FLAGGED for monetization sign-off.
+///
+/// Clawback (entry_type='clawback') carries negative shares for a refund /
+/// proration of a previously paid-out period; nets out in the payout
+/// aggregate (mirrors BlockBuzzAttribution's clawback carry-forward).
+///
+/// Idempotent on (invoice_id, app_block_id): a webhook retry for the same
+/// invoice is a no-op.
+///
+/// Application-generated id (`bsu_<ulid>`).
+model BlockSubscriptionAttribution {
+  id                   String   @id
+  userId               Int      @map("user_id")
+  user                 User     @relation("BlockSubscriptionAttributionPurchaser", fields: [userId], references: [id], onDelete: Restrict)
+  buzzAmount           Int      @default(0) @map("buzz_amount")
+  buzzType             String   @default("yellow") @map("buzz_type")
+  /// Gross USD value of the invoice, in cents.
+  grossValueCents      Int      @map("gross_value_cents")
+
+  paymentProvider      String   @map("payment_provider")
+  /// Per-period idempotency anchor — each renewal has its own invoice_id.
+  invoiceId            String   @map("invoice_id")
+  /// Groups the periods of one subscription.
+  subscriptionId       String?  @map("subscription_id")
+  /// subscription_create | subscription_cycle | subscription_update.
+  billingReason        String?  @map("billing_reason")
+  periodStart          DateTime? @map("period_start") @db.Timestamptz(6)
+  periodEnd            DateTime? @map("period_end") @db.Timestamptz(6)
+
+  appId                String   @map("app_id")
+  app                  OauthClient @relation("BlockSubscriptionAttributionApp", fields: [appId], references: [id], onDelete: Restrict)
+  appBlockId           String   @map("app_block_id")
+  appBlock             AppBlock @relation("BlockSubscriptionAttributionAppBlock", fields: [appBlockId], references: [id], onDelete: Restrict)
+  blockInstanceId      String   @map("block_instance_id")
+  scope                String
+  modelId              Int?     @map("model_id")
+  tier                 String?
+
+  rateCardVersion      String   @map("rate_card_version")
+  /// The subscription rev-share percentage stamped at write time.
+  subscriptionSharePct Int      @map("subscription_share_pct")
+  appOwnerShareCents   Int      @map("app_owner_share_cents")
+  platformShareCents   Int      @map("platform_share_cents")
+  providerFeeCents     Int      @map("provider_fee_cents")
+  appOwnerUserId       Int      @map("app_owner_user_id")
+  appOwner             User     @relation("BlockSubscriptionAttributionAppOwner", fields: [appOwnerUserId], references: [id], onDelete: Restrict)
+
+  status               String   @default("pending")
+  /// 'charge' (forward) | 'clawback' (negative carry-forward on refund/proration).
+  entryType            String   @default("charge") @map("entry_type")
+  /// 'refund' / 'chargeback' / 'proration' / 'self_purchase' / 'internal_owner' / 'manual_review'.
+  voidedReason         String?  @map("voided_reason")
+  attributedAt         DateTime @default(now()) @map("attributed_at") @db.Timestamptz(6)
+  confirmedAt          DateTime? @map("confirmed_at") @db.Timestamptz(6)
+  voidedAt             DateTime? @map("voided_at") @db.Timestamptz(6)
+  paidOutAt            DateTime? @map("paid_out_at") @db.Timestamptz(6)
+  payoutId             String?  @map("payout_id")
+
+  @@unique([invoiceId, appBlockId], map: "block_subscription_attribution_invoice_app_uniq")
+  @@index([appOwnerUserId, attributedAt(sort: Desc)], map: "bsu_publisher_dashboard_idx")
+  @@index([appBlockId, attributedAt(sort: Desc)], map: "bsu_app_block_dashboard_idx")
+  @@index([subscriptionId], map: "bsu_subscription_idx")
+  @@index([paymentProvider, invoiceId], map: "bsu_invoice_idx")
+  @@map("block_subscription_attribution")
 }
 
 /// W5 v0.5 audit log — one row per successful scope-gated API call from

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2679,16 +2679,19 @@ model BlockSubscriptionAttribution {
   modelId              Int?     @map("model_id")
   tier                 String?
 
-  rateCardVersion      String   @map("rate_card_version")
-  /// The subscription rev-share percentage stamped at write time.
-  subscriptionSharePct Int      @map("subscription_share_pct")
-  appOwnerShareCents   Int      @map("app_owner_share_cents")
+  /// TRACK-ONLY (#2629): no rate applied at write time. 'unrated' sentinel
+  /// until the payout-time backpay stamps the signed-off version.
+  rateCardVersion      String   @default("unrated") @map("rate_card_version")
+  /// 0 at write time; the payout-time backpay computes the real share.
+  subscriptionSharePct Int      @default(0) @map("subscription_share_pct")
+  appOwnerShareCents   Int      @default(0) @map("app_owner_share_cents")
   platformShareCents   Int      @map("platform_share_cents")
   providerFeeCents     Int      @map("provider_fee_cents")
   appOwnerUserId       Int      @map("app_owner_user_id")
   appOwner             User     @relation("BlockSubscriptionAttributionAppOwner", fields: [appOwnerUserId], references: [id], onDelete: Restrict)
 
-  status               String   @default("pending")
+  /// 'tracked' (track-only event) | pending | confirmed | voided | paid_out | held.
+  status               String   @default("tracked")
   /// 'charge' (forward) | 'clawback' (negative carry-forward on refund/proration).
   entryType            String   @default("charge") @map("entry_type")
   /// 'refund' / 'chargeback' / 'proration' / 'self_purchase' / 'internal_owner' / 'manual_review'.

--- a/src/pages/api/webhooks/stripe.ts
+++ b/src/pages/api/webhooks/stripe.ts
@@ -30,6 +30,7 @@ import {
   AttributionAppMissingError,
   recordAttribution,
   voidAttributionsForPayment,
+  voidSubscriptionAttributionsForInvoice,
 } from '~/server/services/blocks/buzz-attribution.service';
 import { extractAttribution } from '~/server/schema/blocks/attribution.schema';
 
@@ -385,6 +386,29 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 log({
                   type: 'error',
                   stage: 'block-attribution-void',
+                  eventType: event.type,
+                  sourceEventId,
+                  error: (err as Error)?.message,
+                });
+                return 0;
+              });
+
+              // W3 flow C — also void/clawback any membership (subscription)
+              // attribution row keyed on this invoice. block_buzz_attribution
+              // is keyed on the PI id, but block_subscription_attribution is
+              // keyed on the invoice_id (the per-period anchor). The loop
+              // already resolves the parent invoiceId from the PI, so this
+              // matches both keys. Like the buzz void: paid_out rows write a
+              // negative clawback that nets out of the publisher's next
+              // payout; pending/confirmed rows just void.
+              await voidSubscriptionAttributionsForInvoice({
+                paymentProvider: 'stripe',
+                invoiceId: sourceEventId,
+                reason: event.type === 'charge.refunded' ? 'refund' : 'chargeback',
+              }).catch((err) => {
+                log({
+                  type: 'error',
+                  stage: 'block-subscription-attribution-void',
                   eventType: event.type,
                   sourceEventId,
                   error: (err as Error)?.message,

--- a/src/server/controllers/stripe.controller.ts
+++ b/src/server/controllers/stripe.controller.ts
@@ -56,7 +56,7 @@ export const createDonateSessionHandler = async ({
 };
 
 export const createSubscriptionSessionHandler = async ({
-  input: { priceId, refCode },
+  input: { priceId, refCode, blockAttribution },
   ctx,
 }: {
   input: Schema.CreateSubscribeSessionInput;
@@ -67,6 +67,9 @@ export const createSubscriptionSessionHandler = async ({
   const result = await createSubscribeSession({
     priceId,
     refCode,
+    // FIN-1 re-derivation happens inside createSubscribeSession, which has
+    // the authenticated buyer id. The client value is untrusted.
+    blockAttribution,
     customerId,
     user: { id, email },
   });

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -352,6 +352,20 @@ export const blockSpendAttributionWriteCounter = registerCounterWithLabels({
   labelNames: ['status'] as const,
 });
 
+// App Blocks MEMBERSHIP / subscription attribution (W3 flow C)
+// One row written per PAID invoice of a block-initiated membership
+// purchase. `status` ∈ 'pending'|'voided' at write time (voided =
+// self-purchase/internal-owner zero-share row); 'duplicate' marks an
+// idempotent no-op (same invoice webhook retried); 'clawback' marks a
+// negative carry-forward row written on refund/proration of a paid-out
+// period. `billing_reason' tells subscription_create (initial) from
+// subscription_cycle (renewal) so renewals-pay is observable.
+export const blockSubscriptionAttributionWriteCounter = registerCounterWithLabels({
+  name: 'block_subscription_attribution_total',
+  help: 'Block membership/subscription attribution rows written',
+  labelNames: ['provider', 'status', 'billing_reason'] as const,
+});
+
 // App Blocks KV datastore (W4-v0)
 // `op` ∈ get|set|delete|list|getQuota; `outcome` ∈ ok|unauthorized|
 // not_found|payload_too_large|quota_exceeded|error. Read-only counters

--- a/src/server/schema/stripe.schema.ts
+++ b/src/server/schema/stripe.schema.ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 import { Currency } from '~/shared/utils/prisma/enums';
 import { constants } from '~/server/common/constants';
 import { buzzConstants } from '~/shared/constants/buzz.constants';
+import { blockAttributionSchema } from '~/server/schema/blocks/attribution.schema';
 
 export type CreateCustomerInput = z.infer<typeof createCustomerSchema>;
 export const createCustomerSchema = z.object({ id: z.number(), email: z.string().email() });
@@ -10,6 +11,15 @@ export type CreateSubscribeSessionInput = z.infer<typeof createSubscribeSessionS
 export const createSubscribeSessionSchema = z.object({
   priceId: z.string(),
   refCode: z.string().optional(),
+  // W3 flow C — App Blocks MEMBERSHIP attribution. Populated only when the
+  // membership purchase was initiated from inside a block (the block's
+  // "Buy membership" CTA). UNTRUSTED client input: the server re-derives
+  // every field server-side (FIN-1) in createSubscribeSession before
+  // stamping it onto the Stripe subscription metadata. A forged appId/scope
+  // is corrected or stripped; an instance that doesn't resolve for the
+  // buyer is dropped (purchase proceeds un-attributed). Never trusted to
+  // mint earnings.
+  blockAttribution: blockAttributionSchema.optional(),
 });
 
 export type CreateDonateSessionInput = z.infer<typeof createDonateSessionSchema>;

--- a/src/server/services/__tests__/stripe.manageInvoicePaid.attribution.test.ts
+++ b/src/server/services/__tests__/stripe.manageInvoicePaid.attribution.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Stripe } from 'stripe';
+
+/**
+ * W3 flow C — manageInvoicePaid attribution-gating coverage (🟡-1 + 🟡-2).
+ *
+ * The NEW subscription-attribution write (recordSubscriptionAttribution) must
+ * fire ONLY for billing_reason IN (subscription_create, subscription_cycle)
+ * and ONLY when the resolved gross (amount_paid ?? total) is > 0:
+ *
+ *   - subscription_update (mid-cycle upgrade PRORATION invoice) → NO row.
+ *     The proration delta and the period's subscription_cycle invoice are
+ *     DISTINCT invoice_ids over overlapping value; attributing both would
+ *     over-accrue. Proration is NOT separately attributed.
+ *   - subscription_cycle (renewal) → row written (renewals-pay).
+ *   - subscription_create (first invoice) → row written.
+ *   - amount_paid == 0 (proration covered by credit) → no row (no new money).
+ *
+ * The buzz grant / recordMembershipPaymentReward / ref_code logic is LEFT
+ * firing for subscription_update — only the attribution write is gated. We
+ * assert createBuzzTransaction still fires on subscription_update to lock that
+ * in (no regression of the existing renewals-pay / upgrade Buzz grant).
+ *
+ * Every module boundary manageInvoicePaid touches is mocked so the test stays
+ * in-process and deterministic; the real code under test is the gate itself.
+ */
+
+const {
+  mockDbRead,
+  mockDbWrite,
+  mockLog,
+  mockCreateBuzzTransaction,
+  mockGetServerStripe,
+  mockRecordSubscriptionAttribution,
+  mockRecordMembershipPaymentReward,
+  mockBindReferralCodeForUser,
+  mockInvalidateSubscriptionCaches,
+} = vi.hoisted(() => ({
+  mockDbRead: {
+    product: { findMany: vi.fn() },
+  },
+  mockDbWrite: {
+    user: { findUniqueOrThrow: vi.fn(), update: vi.fn() },
+    purchase: { createMany: vi.fn() },
+  },
+  mockLog: vi.fn(),
+  mockCreateBuzzTransaction: vi.fn(),
+  mockGetServerStripe: vi.fn(),
+  mockRecordSubscriptionAttribution: vi.fn(),
+  mockRecordMembershipPaymentReward: vi.fn(),
+  mockBindReferralCodeForUser: vi.fn(),
+  mockInvalidateSubscriptionCaches: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: mockDbWrite,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+vi.mock('~/server/utils/errorHandling', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/utils/errorHandling')>();
+  return {
+    ...actual,
+    handleLogError: vi.fn(),
+    // run the fn once, no retry loop in tests
+    withRetries: (fn: () => Promise<unknown>) => fn(),
+  };
+});
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: (...args: unknown[]) => mockCreateBuzzTransaction(...args),
+  completeStripeBuzzTransaction: vi.fn(),
+  getMultipliersForUser: vi.fn(),
+}));
+vi.mock('~/server/utils/get-server-stripe', () => ({
+  getServerStripe: (...args: unknown[]) => mockGetServerStripe(...args),
+}));
+// vault.service is imported by stripe.service (getOrCreateVault) but unused by
+// manageInvoicePaid; mock it to cut the transitive common.service → caches →
+// selectors → Prisma.validator import chain that crashes under the copied
+// .prisma/client in this worktree.
+vi.mock('~/server/services/vault.service', () => ({
+  getOrCreateVault: vi.fn(),
+}));
+vi.mock('~/server/services/referral.service', () => ({
+  bindReferralCodeForUser: (...args: unknown[]) => mockBindReferralCodeForUser(...args),
+  recordMembershipPaymentReward: (...args: unknown[]) =>
+    mockRecordMembershipPaymentReward(...args),
+}));
+vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
+  recordSubscriptionAttribution: (...args: unknown[]) =>
+    mockRecordSubscriptionAttribution(...args),
+}));
+vi.mock('~/server/utils/subscription.utils', () => ({
+  invalidateSubscriptionCaches: (...args: unknown[]) =>
+    mockInvalidateSubscriptionCaches(...args),
+}));
+vi.mock('~/server/prom/client', () => ({
+  userUpdateCounter: { inc: vi.fn() },
+}));
+
+import { manageInvoicePaid } from '../stripe.service';
+import { encodeAttributionMetadata } from '~/server/schema/blocks/attribution.schema';
+
+const USER_ID = 100;
+const CUSTOMER_ID = 'cus_test';
+const PRODUCT_ID = 'prod_tier';
+const PRICE_ID = 'price_tier';
+const APP_ID = 'app_real';
+const APP_BLOCK_ID = 'apb_real';
+
+// A valid server-derived attribution bag (already FIN-1 validated upstream).
+const ATTRIBUTION_BAG = encodeAttributionMetadata({
+  appId: APP_ID,
+  appBlockId: APP_BLOCK_ID,
+  blockInstanceId: 'bus_view_abc',
+  scope: 'viewer_personal',
+  modelId: 555,
+  slotId: 'model.sidebar_top',
+})!;
+
+function fakeInvoice(over: Partial<Stripe.Invoice> = {}): Stripe.Invoice {
+  return {
+    id: 'in_test',
+    customer: CUSTOMER_ID,
+    status: 'paid',
+    subscription: 'sub_xyz',
+    billing_reason: 'subscription_cycle',
+    amount_paid: 1000,
+    total: 1000,
+    payment_intent: 'pi_test',
+    charge: undefined,
+    subscription_details: { metadata: { ...ATTRIBUTION_BAG } },
+    lines: {
+      data: [
+        {
+          price: { id: PRICE_ID, product: PRODUCT_ID },
+          period: { start: 1_700_000_000, end: 1_702_592_000 },
+        },
+      ],
+    },
+    ...over,
+  } as unknown as Stripe.Invoice;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWrite.user.findUniqueOrThrow.mockResolvedValue({ id: USER_ID, customerId: CUSTOMER_ID });
+  mockDbWrite.user.update.mockResolvedValue({});
+  mockDbWrite.purchase.createMany.mockResolvedValue({ count: 1 });
+  mockDbRead.product.findMany.mockResolvedValue([
+    {
+      id: PRODUCT_ID,
+      // env.TIER_METADATA_KEY drives the membership filter. The default key is
+      // 'tier' (see env/server). monthlyBuzz/buzzType/tier feed the grant.
+      metadata: { tier: 'gold', monthlyBuzz: 5000, buzzType: 'yellow' },
+    },
+  ]);
+  mockCreateBuzzTransaction.mockResolvedValue({});
+  mockRecordMembershipPaymentReward.mockResolvedValue({});
+  mockBindReferralCodeForUser.mockResolvedValue({});
+  mockRecordSubscriptionAttribution.mockResolvedValue({});
+  mockInvalidateSubscriptionCaches.mockResolvedValue(undefined);
+  // No charge → fee fetch is skipped (best-effort 0 fee); stripe client unused
+  // on the happy attribution path, but the ref_code fallback may call it.
+  mockGetServerStripe.mockResolvedValue({
+    checkout: { sessions: { list: vi.fn().mockResolvedValue({ data: [] }) } },
+    charges: { retrieve: vi.fn() },
+  });
+});
+
+describe('manageInvoicePaid — subscription attribution gating (🟡-1 proration)', () => {
+  it('subscription_update (proration) invoice → NO attribution row', async () => {
+    await manageInvoicePaid(fakeInvoice({ billing_reason: 'subscription_update' }));
+    expect(mockRecordSubscriptionAttribution).not.toHaveBeenCalled();
+    // …but the existing upgrade Buzz grant + membership reward STILL fire.
+    expect(mockCreateBuzzTransaction).toHaveBeenCalledTimes(1);
+    expect(mockRecordMembershipPaymentReward).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscription_cycle (renewal) invoice → attribution row written (renewals-pay)', async () => {
+    await manageInvoicePaid(fakeInvoice({ billing_reason: 'subscription_cycle' }));
+    expect(mockRecordSubscriptionAttribution).toHaveBeenCalledTimes(1);
+    const arg = mockRecordSubscriptionAttribution.mock.calls[0][0];
+    expect(arg.invoiceId).toBe('in_test');
+    expect(arg.billingReason).toBe('subscription_cycle');
+    expect(arg.usdAmountCents).toBe(1000);
+    expect(arg.attribution.appId).toBe(APP_ID);
+  });
+
+  it('subscription_create (first) invoice → attribution row written', async () => {
+    await manageInvoicePaid(fakeInvoice({ billing_reason: 'subscription_create' }));
+    expect(mockRecordSubscriptionAttribution).toHaveBeenCalledTimes(1);
+    expect(mockRecordSubscriptionAttribution.mock.calls[0][0].billingReason).toBe(
+      'subscription_create'
+    );
+  });
+});
+
+describe('manageInvoicePaid — zero-gross skip (🟡-2)', () => {
+  it('amount_paid == 0 invoice → no attribution row', async () => {
+    await manageInvoicePaid(
+      fakeInvoice({ billing_reason: 'subscription_cycle', amount_paid: 0, total: 0 })
+    );
+    expect(mockRecordSubscriptionAttribution).not.toHaveBeenCalled();
+    // The Buzz grant still fires — only the attribution write is skipped.
+    expect(mockCreateBuzzTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('amount_paid == 0 but total > 0 → still no row (amount_paid is the basis)', async () => {
+    await manageInvoicePaid(
+      fakeInvoice({ billing_reason: 'subscription_cycle', amount_paid: 0, total: 999 })
+    );
+    expect(mockRecordSubscriptionAttribution).not.toHaveBeenCalled();
+  });
+});
+
+describe('manageInvoicePaid — attribution write payload (no regression)', () => {
+  it('passes the resolved gross (amount_paid) as usdAmountCents', async () => {
+    await manageInvoicePaid(
+      fakeInvoice({ billing_reason: 'subscription_cycle', amount_paid: 1499, total: 1499 })
+    );
+    expect(mockRecordSubscriptionAttribution.mock.calls[0][0].usdAmountCents).toBe(1499);
+  });
+
+  it('no block metadata on the invoice → no attribution row (un-attributed membership)', async () => {
+    await manageInvoicePaid(
+      fakeInvoice({
+        billing_reason: 'subscription_cycle',
+        subscription_details: { metadata: {} },
+      } as Partial<Stripe.Invoice>)
+    );
+    expect(mockRecordSubscriptionAttribution).not.toHaveBeenCalled();
+    // Membership still provisioned.
+    expect(mockCreateBuzzTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/blocks/__tests__/rate-card.test.ts
+++ b/src/server/services/blocks/__tests__/rate-card.test.ts
@@ -3,10 +3,12 @@ import {
   ACTIVE_RATE_CARD,
   computeRateCardSplit,
   computeSpendShare,
+  computeSubscriptionShare,
   RATE_CARD_V1,
   RATE_CARD_V2,
   RATE_CARD_V3,
   RATE_CARD_V4,
+  RATE_CARD_V5,
   type RateCard,
 } from '../rate-card';
 
@@ -30,6 +32,7 @@ describe('computeRateCardSplit', () => {
       viewer_global: 0,
     },
     spendSharePct: 10,
+    subscriptionSharePct: 0,
     internalAppOwnerUserIds: [42],
     effectiveFrom: '2026-01-01',
   };
@@ -183,7 +186,7 @@ describe('computeRateCardSplit', () => {
     }
   });
 
-  it('defaults to ACTIVE_RATE_CARD (now V4) when no rateCard is passed', () => {
+  it('defaults to ACTIVE_RATE_CARD (now V5) when no rateCard is passed', () => {
     const split = computeRateCardSplit({
       grossCents: 1000,
       providerFeeCents: 0,
@@ -192,10 +195,10 @@ describe('computeRateCardSplit', () => {
       appOwnerUserId: 1,
     });
     expect(split.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
-    expect(split.rateCardVersion).toBe(RATE_CARD_V4.version);
-    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V4);
-    // V4 carries V3's purchase percentages unchanged (the spend dimension
-    // is the only addition), so per_model_install is still 15%.
+    expect(split.rateCardVersion).toBe(RATE_CARD_V5.version);
+    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V5);
+    // V5 carries V4's purchase percentages unchanged (the subscription
+    // dimension is the only addition), so per_model_install is still 15%.
     expect(split.appOwnerShareCents).toBe(150);
   });
 
@@ -219,7 +222,7 @@ describe('computeRateCardSplit', () => {
     ).toBe(1000);
   });
 
-  it('viewer_global on the ACTIVE card (V4) also pays 0% with conservation', () => {
+  it('viewer_global on the ACTIVE card (V5) also pays 0% with conservation', () => {
     const split = computeRateCardSplit({
       grossCents: 4999,
       providerFeeCents: 217,
@@ -227,7 +230,7 @@ describe('computeRateCardSplit', () => {
       isSelfPurchase: false,
       appOwnerUserId: 7,
     });
-    expect(split.rateCardVersion).toBe('v4');
+    expect(split.rateCardVersion).toBe('v5');
     expect(split.appOwnerShareCents).toBe(0);
     expect(
       split.providerFeeCents + split.platformShareCents + split.appOwnerShareCents
@@ -317,6 +320,7 @@ describe('computeSpendShare', () => {
       viewer_global: 0,
     },
     spendSharePct: 10,
+    subscriptionSharePct: 0,
     internalAppOwnerUserIds: [42],
     effectiveFrom: '2026-01-01',
   };
@@ -385,17 +389,21 @@ describe('computeSpendShare', () => {
     expect(res.appOwnerShareCents).toBe(0);
   });
 
-  it('V4 is the active card and carries the placeholder spend rate', () => {
-    expect(ACTIVE_RATE_CARD.version).toBe('v4');
-    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V4);
-    // The placeholder is non-zero (the spend flow pays something) but
-    // conservative. If this number changes, it's a deliberate sign-off
-    // decision — update the test alongside the new card.
+  it('V5 is the active card; V4/V5 carry the placeholder spend rate', () => {
+    expect(ACTIVE_RATE_CARD.version).toBe('v5');
+    expect(ACTIVE_RATE_CARD).toBe(RATE_CARD_V5);
+    // The spend placeholder (non-zero, conservative) was introduced in V4
+    // and carried into V5 verbatim. If this number changes, it's a
+    // deliberate sign-off decision — update the test alongside the new card.
     expect(RATE_CARD_V4.spendSharePct).toBe(5);
-    expect(RATE_CARD_V4.spendSharePct).toBeGreaterThan(0);
-    // Purchase percentages carried from V3 unchanged.
+    expect(RATE_CARD_V5.spendSharePct).toBe(5);
+    expect(ACTIVE_RATE_CARD.spendSharePct).toBeGreaterThan(0);
+    // Purchase percentages carried from V3 unchanged through V4 and V5.
     expect(RATE_CARD_V4.publisherSharePctByScope).toEqual(
       RATE_CARD_V3.publisherSharePctByScope
+    );
+    expect(RATE_CARD_V5.publisherSharePctByScope).toEqual(
+      RATE_CARD_V4.publisherSharePctByScope
     );
   });
 
@@ -403,5 +411,163 @@ describe('computeSpendShare', () => {
     expect(RATE_CARD_V1.spendSharePct).toBe(0);
     expect(RATE_CARD_V2.spendSharePct).toBe(0);
     expect(RATE_CARD_V3.spendSharePct).toBe(0);
+  });
+});
+
+/**
+ * W3 flow C — MEMBERSHIP / subscription rev-share math. A membership
+ * payment is a real card transaction split THREE ways (NOT the
+ * platform-funded bounty model of spend), so the invariants mirror
+ * computeRateCardSplit's:
+ *   - fee + platform + author = gross (the SQL CHECK, entry_type='charge')
+ *   - self-purchase / internal-owner -> author 0
+ *   - floor so the platform absorbs the sub-cent remainder
+ */
+describe('computeSubscriptionShare', () => {
+  // Fixed 20% card so the test is stable when the live placeholder moves.
+  const fixedCard: RateCard = {
+    version: 'sub-test',
+    publisherSharePctByScope: {
+      per_model_install: 0,
+      publisher_all_my_models: 0,
+      viewer_personal: 0,
+      platform_default: 0,
+      viewer_global: 0,
+    },
+    spendSharePct: 0,
+    subscriptionSharePct: 20,
+    internalAppOwnerUserIds: [42],
+    effectiveFrom: '2026-01-01',
+  };
+
+  it('splits a clean membership invoice three ways, conservation holds', () => {
+    const split = computeSubscriptionShare({
+      rateCard: fixedCard,
+      grossCents: 1000,
+      providerFeeCents: 50,
+      isSelfPurchase: false,
+      appOwnerUserId: 1,
+    });
+    // net = 950, 20% of 950 = 190, platform 760.
+    expect(split.providerFeeCents).toBe(50);
+    expect(split.appOwnerShareCents).toBe(190);
+    expect(split.platformShareCents).toBe(760);
+    expect(split.subscriptionSharePct).toBe(20);
+    expect(
+      split.providerFeeCents + split.platformShareCents + split.appOwnerShareCents
+    ).toBe(1000);
+    expect(split.rateCardVersion).toBe('sub-test');
+  });
+
+  it('zeroes author share on self-purchase (subscriber == owner)', () => {
+    const split = computeSubscriptionShare({
+      rateCard: fixedCard,
+      grossCents: 1000,
+      providerFeeCents: 50,
+      isSelfPurchase: true,
+      appOwnerUserId: 99,
+    });
+    expect(split.appOwnerShareCents).toBe(0);
+    expect(split.subscriptionSharePct).toBe(0);
+    expect(split.platformShareCents).toBe(950);
+  });
+
+  it('zeroes author share for an internal civitai-owned app', () => {
+    const split = computeSubscriptionShare({
+      rateCard: fixedCard,
+      grossCents: 1000,
+      providerFeeCents: 50,
+      isSelfPurchase: false,
+      appOwnerUserId: 42, // ∈ internalAppOwnerUserIds
+    });
+    expect(split.appOwnerShareCents).toBe(0);
+    expect(split.subscriptionSharePct).toBe(0);
+  });
+
+  it('floors fractional cents so the author never overcollects', () => {
+    // gross 999, fee 0, 20% → 199.8 → 199, platform absorbs the .8c.
+    const split = computeSubscriptionShare({
+      rateCard: fixedCard,
+      grossCents: 999,
+      providerFeeCents: 0,
+      isSelfPurchase: false,
+      appOwnerUserId: 1,
+    });
+    expect(split.appOwnerShareCents).toBe(199);
+    expect(split.platformShareCents).toBe(800);
+    expect(split.appOwnerShareCents + split.platformShareCents).toBe(999);
+  });
+
+  it('clamps a provider fee that exceeds gross', () => {
+    const split = computeSubscriptionShare({
+      rateCard: fixedCard,
+      grossCents: 100,
+      providerFeeCents: 500,
+      isSelfPurchase: false,
+      appOwnerUserId: 1,
+    });
+    expect(split.providerFeeCents).toBe(100);
+    expect(split.appOwnerShareCents).toBe(0);
+    expect(split.platformShareCents).toBe(0);
+    expect(
+      split.providerFeeCents + split.platformShareCents + split.appOwnerShareCents
+    ).toBe(100);
+  });
+
+  it('V5 is the active card and carries the placeholder subscription rate', () => {
+    expect(ACTIVE_RATE_CARD.version).toBe('v5');
+    expect(RATE_CARD_V5.subscriptionSharePct).toBe(15);
+    expect(RATE_CARD_V5.subscriptionSharePct).toBeGreaterThan(0);
+    const split = computeSubscriptionShare({
+      grossCents: 1000,
+      providerFeeCents: 0,
+      isSelfPurchase: false,
+      appOwnerUserId: 1,
+    });
+    expect(split.rateCardVersion).toBe('v5');
+    // 15% of 1000 = 150.
+    expect(split.appOwnerShareCents).toBe(150);
+    expect(split.platformShareCents).toBe(850);
+  });
+
+  it('older cards (V1-V4) carry a 0% subscription rate (flow C is net-new in V5)', () => {
+    expect(RATE_CARD_V1.subscriptionSharePct).toBe(0);
+    expect(RATE_CARD_V2.subscriptionSharePct).toBe(0);
+    expect(RATE_CARD_V3.subscriptionSharePct).toBe(0);
+    expect(RATE_CARD_V4.subscriptionSharePct).toBe(0);
+  });
+
+  it('V5 carries V4 verbatim (purchase + spend) and only adds the subscription rate', () => {
+    // Immutability: V5 must not silently drift V4's stamped values.
+    expect(RATE_CARD_V5.publisherSharePctByScope).toEqual(
+      RATE_CARD_V4.publisherSharePctByScope
+    );
+    expect(RATE_CARD_V5.spendSharePct).toBe(RATE_CARD_V4.spendSharePct);
+    // Sanity on the carried V4 numbers (15/15/25/0/0, spend 5) so a future
+    // edit to V4 can't silently change V5's "carried" assertion.
+    expect(RATE_CARD_V4.publisherSharePctByScope).toMatchObject({
+      per_model_install: 15,
+      publisher_all_my_models: 15,
+      viewer_personal: 25,
+      platform_default: 0,
+      viewer_global: 0,
+    });
+    expect(RATE_CARD_V4.spendSharePct).toBe(5);
+    // The subscription rate is the ONLY thing V5 changes.
+    expect(RATE_CARD_V5.subscriptionSharePct).toBe(15);
+    expect(RATE_CARD_V4.subscriptionSharePct).toBe(0);
+  });
+
+  it('a row stamped under V5 pays V5 rates forever (immutability)', () => {
+    const split = computeSubscriptionShare({
+      rateCard: RATE_CARD_V5,
+      grossCents: 2000,
+      providerFeeCents: 0,
+      isSelfPurchase: false,
+      appOwnerUserId: 1,
+    });
+    expect(split.rateCardVersion).toBe('v5');
+    expect(split.subscriptionSharePct).toBe(15);
+    expect(split.appOwnerShareCents).toBe(300);
   });
 });

--- a/src/server/services/blocks/__tests__/subscription-attribution.fin1.test.ts
+++ b/src/server/services/blocks/__tests__/subscription-attribution.fin1.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * W3 flow C FIN-1 coverage — the membership/subscription checkout chokepoint.
+ *
+ * createSubscribeSession re-derives a block's membership attribution
+ * SERVER-SIDE before stamping it onto the Stripe subscription metadata,
+ * using the SAME validator the Buzz-purchase path uses
+ * (validateBuzzPurchaseAttribution). These tests exercise that validator
+ * with the encode→validate→extract→encode round-trip the subscription
+ * helper performs, proving:
+ *   - a forged client scope (claiming a high-rate scope) is corrected to
+ *     the server-resolved scope
+ *   - a forged client appId is overwritten with the resolved app's id
+ *   - an instance that doesn't resolve for the buyer is STRIPPED (the
+ *     membership purchase proceeds un-attributed — never a forged credit)
+ *   - the page surface (page_*) re-derives to viewer_global server-side
+ *
+ * BlockRegistry.resolveBlockInstance + logger are mocked at the module
+ * boundary; everything else is the real FIN-1 code.
+ */
+
+const { mockResolve, mockLog } = vi.hoisted(() => ({
+  mockResolve: vi.fn(),
+  mockLog: vi.fn(),
+}));
+
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: { resolveBlockInstance: mockResolve },
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+
+import { validateBuzzPurchaseAttribution } from '../attribution-validator.service';
+import {
+  encodeAttributionMetadata,
+  extractAttribution,
+  type BlockAttribution,
+} from '~/server/schema/blocks/attribution.schema';
+
+const BUYER = 100;
+const REAL_APP_ID = 'app_real';
+const REAL_APP_BLOCK_ID = 'apb_real';
+const SLOT = 'model.sidebar_top';
+const MODEL_ID = 555;
+
+/**
+ * Mirror the createSubscribeSession FIN-1 helper:
+ * client BlockAttribution → encode → validate (server re-derive) → extract.
+ * Returns the SERVER-DERIVED attribution (or null when stripped).
+ */
+async function deriveServerSide(
+  clientAttribution: BlockAttribution,
+  sessionUserId: number
+): Promise<BlockAttribution | null> {
+  const encoded = encodeAttributionMetadata(clientAttribution)!;
+  const validated = await validateBuzzPurchaseAttribution({
+    metadata: { ...encoded } as Record<string, unknown> & { userId?: unknown },
+    sessionUserId,
+  });
+  return extractAttribution(validated as Record<string, string | number | null | undefined>);
+}
+
+function resolvedInstance(over: Record<string, unknown> = {}) {
+  return {
+    source: 'viewer_subscription',
+    modelId: MODEL_ID,
+    slotId: SLOT,
+    enabled: true,
+    settings: {},
+    installedByUserId: BUYER,
+    appBlock: {
+      id: REAL_APP_BLOCK_ID,
+      blockId: 'blk',
+      appId: REAL_APP_ID,
+      status: 'approved',
+      manifest: {},
+      approvedScopes: [],
+      app: { allowedScopes: 0 },
+    },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mockResolve.mockReset();
+  mockLog.mockReset();
+});
+
+describe('membership FIN-1 (model surface)', () => {
+  it('corrects a forged client scope to the server-resolved scope', async () => {
+    // Buyer forges the highest-rate scope; the instance actually resolves to
+    // viewer_subscription → viewer_personal (the resolver is authoritative).
+    mockResolve.mockResolvedValueOnce(resolvedInstance({ source: 'viewer_subscription' }));
+
+    const forged: BlockAttribution = {
+      appId: REAL_APP_ID,
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'bus_view_abc',
+      scope: 'platform_default', // forged (client lie — doesn't matter, server overrides)
+      modelId: MODEL_ID,
+      slotId: SLOT,
+    };
+    const derived = await deriveServerSide(forged, BUYER);
+    expect(derived).not.toBeNull();
+    // Server re-derived the scope from the resolved source.
+    expect(derived!.scope).toBe('viewer_personal');
+    expect(derived!.appId).toBe(REAL_APP_ID);
+  });
+
+  it('overwrites a forged client appId with the resolved app id', async () => {
+    mockResolve.mockResolvedValueOnce(resolvedInstance({ source: 'viewer_subscription' }));
+    const forged: BlockAttribution = {
+      appId: 'app_attacker', // forged — points at a confederate's app
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'bus_view_abc',
+      scope: 'viewer_personal',
+      modelId: MODEL_ID,
+      slotId: SLOT,
+    };
+    const derived = await deriveServerSide(forged, BUYER);
+    expect(derived).not.toBeNull();
+    // The attacker's app id is replaced with the real resolved app.
+    expect(derived!.appId).toBe(REAL_APP_ID);
+    expect(derived!.appBlockId).toBe(REAL_APP_BLOCK_ID);
+  });
+
+  it('strips attribution entirely when the instance does not resolve for the buyer', async () => {
+    mockResolve.mockResolvedValueOnce(null); // not a legit viewer/owner
+    const forged: BlockAttribution = {
+      appId: REAL_APP_ID,
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'bus_view_nope',
+      scope: 'viewer_personal',
+      modelId: MODEL_ID,
+      slotId: SLOT,
+    };
+    const derived = await deriveServerSide(forged, BUYER);
+    // Stripped → the membership purchase proceeds un-attributed (no credit).
+    expect(derived).toBeNull();
+  });
+
+  it('strips when modelId/slotId are missing (cannot server-revalidate)', async () => {
+    const forged: BlockAttribution = {
+      appId: REAL_APP_ID,
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'bus_view_abc',
+      scope: 'viewer_personal',
+      // no modelId / slotId — the resolver can't revalidate the instance.
+    };
+    const derived = await deriveServerSide(forged, BUYER);
+    expect(derived).toBeNull();
+    // The resolver was never even called (fail-safe before resolve).
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+});
+
+describe('membership FIN-1 (page surface)', () => {
+  it('re-derives a page_* instance to viewer_global server-side', async () => {
+    mockResolve.mockResolvedValueOnce(
+      resolvedInstance({ source: 'page', modelId: 0, slotId: '' })
+    );
+    const pageAttribution: BlockAttribution = {
+      appId: REAL_APP_ID,
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'page_apb_real',
+      scope: 'viewer_personal', // forged — server corrects to viewer_global
+    };
+    const derived = await deriveServerSide(pageAttribution, BUYER);
+    expect(derived).not.toBeNull();
+    expect(derived!.scope).toBe('viewer_global');
+    expect(derived!.appId).toBe(REAL_APP_ID);
+    // A page has no model entity → no modelId stamped.
+    expect(derived!.modelId).toBeUndefined();
+  });
+});

--- a/src/server/services/blocks/__tests__/subscription-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/subscription-attribution.service.test.ts
@@ -1,17 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * W3 flow C — MEMBERSHIP / subscription attribution service coverage. The
+ * W3 flow C — MEMBERSHIP / subscription attribution service coverage.
+ *
+ * ⚠️ TRACK-ONLY (#2629). The write records the EVENT + money basis (gross +
+ * provider_fee) and DEFERS the share to a payout-time backpay. So the
  * interesting surface is:
- *   - server-derived three-way split (fee + platform + author = gross) per
- *     the active subscription rate card
+ *   - track-only row shape: status='tracked', author_share=0,
+ *     subscription_share_pct=0, rate_card_version='unrated', gross+fee
+ *     recorded, platform_share=net so conservation still holds (author=0)
+ *   - NO rate is applied at write — computeSubscriptionShare is never called
+ *     and the author share is 0 regardless of the rate card
  *   - self-purchase wash (subscriber == owner → voided + 0 share)
  *   - internal-owner wash (owner ∈ internalAppOwnerUserIds)
  *   - idempotency via the (invoice_id, app_block_id) UNIQUE (P2002)
- *   - RENEWALS-PAY: a second invoice on the same subscription → a 2nd row
+ *   - RENEWALS-PAY: a second invoice on the same subscription → a 2nd tracked
+ *     row (the backpay later pays each)
  *   - missing-app guard
- *   - clawback on refund of a paid_out period (negative carry-forward) +
- *     no-clawback for pending/confirmed refunds + clawback dedup
+ *   - refund → the tracked row is VOIDED, no clawback (author=0, no debt)
  *
  * Prisma + logger are mocked at the module boundary so the test stays
  * in-process and deterministic.
@@ -54,13 +60,29 @@ vi.mock('~/server/logging/client', () => ({
   },
 }));
 
+// Spy on computeSubscriptionShare so the track-only contract is testable:
+// the write must NEVER call it (the share is deferred to payout). Everything
+// else from rate-card stays real.
+const computeSubscriptionShareSpy = vi.hoisted(() => vi.fn());
+vi.mock('../rate-card', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../rate-card')>();
+  return {
+    ...actual,
+    computeSubscriptionShare: (...args: Parameters<typeof actual.computeSubscriptionShare>) => {
+      computeSubscriptionShareSpy(...args);
+      return actual.computeSubscriptionShare(...args);
+    },
+  };
+});
+
 import {
   AttributionAppMissingError,
   recordSubscriptionAttribution,
   voidSubscriptionAttributionsForInvoice,
+  UNRATED_RATE_CARD_VERSION,
   type RecordSubscriptionAttributionInput,
 } from '../buzz-attribution.service';
-import { ACTIVE_RATE_CARD, computeSubscriptionShare } from '../rate-card';
+import { ACTIVE_RATE_CARD } from '../rate-card';
 
 const APP_ID = 'app_test';
 const APP_BLOCK_ID = 'apb_test';
@@ -115,6 +137,7 @@ beforeEach(() => {
   mockDbWrite.blockSubscriptionAttribution.findMany.mockReset();
   mockDbWrite.blockSubscriptionAttribution.updateMany.mockReset();
   mockLog.mockReset();
+  computeSubscriptionShareSpy.mockReset();
   // Default: app exists, owned by a different user than the purchaser.
   mockDbRead.oauthClient.findUnique.mockResolvedValue({
     id: APP_ID,
@@ -124,7 +147,7 @@ beforeEach(() => {
 });
 
 describe('recordSubscriptionAttribution', () => {
-  it('writes exactly one pending row: author=appBlock owner, three-way split per the active card', async () => {
+  it('TRACK-ONLY: writes exactly one tracked row — event + gross/fee, author=0, NO rate stamped', async () => {
     const res = await recordSubscriptionAttribution(fakeInput());
 
     expect(mockDbWrite.blockSubscriptionAttribution.create).toHaveBeenCalledTimes(1);
@@ -134,52 +157,82 @@ describe('recordSubscriptionAttribution', () => {
 
     // Author is the appBlock's owning OauthClient user (server-derived).
     expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
-    expect(data.grossValueCents).toBe(1000);
 
-    // Shares match the active card's three-way split (gross 1000, fee 50).
-    const expected = computeSubscriptionShare({
-      grossCents: 1000,
-      providerFeeCents: 50,
-      isSelfPurchase: false,
-      appOwnerUserId: APP_OWNER_USER_ID,
-    });
-    expect(data.appOwnerShareCents).toBe(expected.appOwnerShareCents);
-    expect(data.platformShareCents).toBe(expected.platformShareCents);
-    expect(data.providerFeeCents).toBe(expected.providerFeeCents);
-    expect(data.subscriptionSharePct).toBe(ACTIVE_RATE_CARD.subscriptionSharePct);
+    // Money BASIS recorded: gross + provider_fee. (gross 1000, fee 50.)
+    expect(data.grossValueCents).toBe(1000);
+    expect(data.providerFeeCents).toBe(50);
+
+    // NO rate applied at write: author share 0, pct 0, version 'unrated'.
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.subscriptionSharePct).toBe(0);
+    expect(data.rateCardVersion).toBe(UNRATED_RATE_CARD_VERSION);
+    expect(data.rateCardVersion).not.toBe(ACTIVE_RATE_CARD.version);
+
+    // platform = net (gross - fee) so conservation still holds with author=0.
+    expect(data.platformShareCents).toBe(1000 - 50);
 
     // Conservation invariant (the SQL CHECK on entry_type='charge'):
+    // fee + platform + author = gross, with author = 0.
     expect(
       data.providerFeeCents + data.platformShareCents + data.appOwnerShareCents
     ).toBe(data.grossValueCents);
 
-    // Forward charge, not voided.
-    expect(data.status).toBe('pending');
+    // Share-pending track-only state, forward charge, not voided.
+    expect(data.status).toBe('tracked');
     expect(data.entryType).toBe('charge');
     expect(data.voidedReason).toBeNull();
 
-    // Server context preserved.
+    // The rate card is NEVER consulted at write time (deferred to payout).
+    expect(computeSubscriptionShareSpy).not.toHaveBeenCalled();
+
+    // Server context preserved (the backpay needs it).
     expect(data.appId).toBe(APP_ID);
     expect(data.appBlockId).toBe(APP_BLOCK_ID);
     expect(data.invoiceId).toBe(INVOICE_ID);
     expect(data.subscriptionId).toBe(SUBSCRIPTION_ID);
     expect(data.scope).toBe('subscription');
     expect(data.billingReason).toBe('subscription_create');
-    expect(data.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
   });
 
-  it('author share floor: share = floor((gross-fee) * pct/100), within [0, net]', async () => {
+  it('records gross/fee basis with author=0 + platform=net for the backpay (conservation holds)', async () => {
     await recordSubscriptionAttribution(fakeInput({ usdAmountCents: 1999, providerFeeCents: 87 }));
     const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
     const net = 1999 - 87;
-    expect(data.appOwnerShareCents).toBe(
-      Math.floor((net * ACTIVE_RATE_CARD.subscriptionSharePct) / 100)
-    );
-    expect(data.appOwnerShareCents).toBeGreaterThanOrEqual(0);
-    expect(data.appOwnerShareCents).toBeLessThanOrEqual(net);
+    // No share computed at write — author 0, platform absorbs all of net.
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.platformShareCents).toBe(net);
+    expect(data.providerFeeCents).toBe(87);
+    expect(data.grossValueCents).toBe(1999);
     expect(
       data.providerFeeCents + data.platformShareCents + data.appOwnerShareCents
     ).toBe(1999);
+    expect(computeSubscriptionShareSpy).not.toHaveBeenCalled();
+  });
+
+  it('fee clamped to gross when fee > gross (defensive): author=0, platform=0, still conserves', async () => {
+    await recordSubscriptionAttribution(fakeInput({ usdAmountCents: 100, providerFeeCents: 250 }));
+    const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
+    // fee clamped to gross → net 0 → platform 0, author 0.
+    expect(data.grossValueCents).toBe(100);
+    expect(data.providerFeeCents).toBe(100);
+    expect(data.platformShareCents).toBe(0);
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(
+      data.providerFeeCents + data.platformShareCents + data.appOwnerShareCents
+    ).toBe(100);
+  });
+
+  it('MUTATION-CHECK: author share is 0 regardless of the active rate card (no rate applied at write)', async () => {
+    // Active card defines subscriptionSharePct=15. A track-only write must
+    // NOT apply it — author stays 0 even though the rate is non-zero. If the
+    // write regressed to applying the 15%, this assertion (and the
+    // not-called spy) would fail.
+    expect(ACTIVE_RATE_CARD.subscriptionSharePct).toBeGreaterThan(0);
+    await recordSubscriptionAttribution(fakeInput({ usdAmountCents: 10000, providerFeeCents: 0 }));
+    const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.subscriptionSharePct).toBe(0);
+    expect(computeSubscriptionShareSpy).not.toHaveBeenCalled();
   });
 
   it('self-purchase (subscriber == app owner) → voided, zero author share', async () => {
@@ -229,7 +282,7 @@ describe('recordSubscriptionAttribution', () => {
     );
   });
 
-  it('RENEWALS-PAY: a 2nd invoice (subscription_cycle) on the same subscription writes a 2nd row', async () => {
+  it('RENEWALS-PAY: a 2nd invoice (subscription_cycle) on the same subscription writes a 2nd tracked row', async () => {
     // First invoice (initial purchase).
     const first = await recordSubscriptionAttribution(
       fakeInput({ invoiceId: 'in_period1', billingReason: 'subscription_create' })
@@ -251,9 +304,14 @@ describe('recordSubscriptionAttribution', () => {
     expect(secondData.invoiceId).toBe('in_period2');
     expect(firstData.subscriptionId).toBe(SUBSCRIPTION_ID);
     expect(secondData.subscriptionId).toBe(SUBSCRIPTION_ID);
-    // Both accrue the author share — the renewals-pay policy.
-    expect(firstData.appOwnerShareCents).toBeGreaterThan(0);
-    expect(secondData.appOwnerShareCents).toBeGreaterThan(0);
+    // Both are TRACKED (the backpay later pays each period); gross recorded.
+    expect(firstData.status).toBe('tracked');
+    expect(secondData.status).toBe('tracked');
+    expect(firstData.grossValueCents).toBeGreaterThan(0);
+    expect(secondData.grossValueCents).toBeGreaterThan(0);
+    // No share applied at write on either.
+    expect(firstData.appOwnerShareCents).toBe(0);
+    expect(secondData.appOwnerShareCents).toBe(0);
     expect(secondData.billingReason).toBe('subscription_cycle');
   });
 
@@ -277,9 +335,7 @@ describe('recordSubscriptionAttribution', () => {
 });
 
 describe('voidSubscriptionAttributionsForInvoice', () => {
-  it('refund of a PENDING/CONFIRMED period: voids, NO clawback (money never left)', async () => {
-    // No paid_out rows to claw back.
-    mockDbWrite.blockSubscriptionAttribution.findMany.mockResolvedValueOnce([]);
+  it('refund of a TRACKED period: voids the row, NO clawback (author=0 → no debt)', async () => {
     mockDbWrite.blockSubscriptionAttribution.updateMany.mockResolvedValueOnce({ count: 1 });
 
     const count = await voidSubscriptionAttributionsForInvoice({
@@ -289,100 +345,35 @@ describe('voidSubscriptionAttributionsForInvoice', () => {
     });
 
     expect(count).toBe(1);
-    // No clawback row written.
+    // No clawback row is ever written in the track-only model.
     expect(mockDbWrite.blockSubscriptionAttribution.create).not.toHaveBeenCalled();
-    // The void targets charge rows in pending/confirmed/paid_out.
+    // No paid_out snapshot is read — there is nothing to claw back.
+    expect(mockDbWrite.blockSubscriptionAttribution.findMany).not.toHaveBeenCalled();
+    // The void targets forward 'charge' rows including the live 'tracked'
+    // state (pending/confirmed/paid_out included defensively).
     expect(mockDbWrite.blockSubscriptionAttribution.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           paymentProvider: 'stripe',
           invoiceId: INVOICE_ID,
           entryType: 'charge',
-          status: { in: ['pending', 'confirmed', 'paid_out'] },
+          status: { in: ['tracked', 'pending', 'confirmed', 'paid_out'] },
         }),
         data: expect.objectContaining({ status: 'voided', voidedReason: 'refund' }),
       })
     );
   });
 
-  it('refund of a PAID_OUT period: voids the original AND writes a negative clawback that nets out', async () => {
-    mockDbWrite.blockSubscriptionAttribution.findMany.mockResolvedValueOnce([
-      {
-        appOwnerShareCents: 142,
-        appOwnerUserId: APP_OWNER_USER_ID,
-        userId: PURCHASER_ID,
-        buzzType: 'yellow',
-        appId: APP_ID,
-        appBlockId: APP_BLOCK_ID,
-        blockInstanceId: 'bki_test123',
-        scope: 'subscription',
-        modelId: 555,
-        tier: 'gold',
-        subscriptionId: SUBSCRIPTION_ID,
-        billingReason: 'subscription_cycle',
-        rateCardVersion: 'v5',
-        subscriptionSharePct: 15,
-      },
-    ]);
-    mockDbWrite.blockSubscriptionAttribution.updateMany.mockResolvedValueOnce({ count: 1 });
-
-    const count = await voidSubscriptionAttributionsForInvoice({
-      paymentProvider: 'stripe',
-      invoiceId: INVOICE_ID,
-      reason: 'refund',
-    });
-
-    expect(count).toBe(1);
-    expect(mockDbWrite.blockSubscriptionAttribution.create).toHaveBeenCalledTimes(1);
-    const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
-    // Negative carry-forward, confirmed so the aggregator nets it next mint.
-    expect(data.entryType).toBe('clawback');
-    expect(data.status).toBe('confirmed');
-    expect(data.appOwnerShareCents).toBe(-142);
-    expect(data.grossValueCents).toBe(-142);
-    expect(data.platformShareCents).toBe(0);
-    expect(data.providerFeeCents).toBe(0);
-    // Synthetic invoice id so a repeat refund webhook dedups on the UNIQUE.
-    expect(data.invoiceId).toBe(`${INVOICE_ID}:clawback`);
-    // Owner snapshot preserved → debt routes to the right publisher.
-    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
-
-    // Conservation: original (142) + clawback (-142) = 0 net for the owner.
-    expect(142 + data.appOwnerShareCents).toBe(0);
-  });
-
-  it('clawback dedup: a second refund webhook hits the synthetic-key UNIQUE and is skipped', async () => {
-    mockDbWrite.blockSubscriptionAttribution.findMany.mockResolvedValueOnce([
-      {
-        appOwnerShareCents: 142,
-        appOwnerUserId: APP_OWNER_USER_ID,
-        userId: PURCHASER_ID,
-        buzzType: 'yellow',
-        appId: APP_ID,
-        appBlockId: APP_BLOCK_ID,
-        blockInstanceId: 'bki_test123',
-        scope: 'subscription',
-        modelId: null,
-        tier: null,
-        subscriptionId: SUBSCRIPTION_ID,
-        billingReason: 'subscription_cycle',
-        rateCardVersion: 'v5',
-        subscriptionSharePct: 15,
-      },
-    ]);
-    // The clawback create hits P2002 (already written by a prior webhook).
-    mockDbWrite.blockSubscriptionAttribution.create.mockRejectedValueOnce(
-      new FakePrismaKnownError('dup clawback', 'P2002')
-    );
+  it('refund webhook is idempotent: already-voided row → updateMany count 0, still no clawback', async () => {
     mockDbWrite.blockSubscriptionAttribution.updateMany.mockResolvedValueOnce({ count: 0 });
 
-    // Must NOT throw — the duplicate clawback is swallowed.
     const count = await voidSubscriptionAttributionsForInvoice({
       paymentProvider: 'stripe',
       invoiceId: INVOICE_ID,
       reason: 'chargeback',
     });
+
     expect(count).toBe(0);
-    expect(mockDbWrite.blockSubscriptionAttribution.create).toHaveBeenCalledTimes(1);
+    expect(mockDbWrite.blockSubscriptionAttribution.create).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/__tests__/subscription-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/subscription-attribution.service.test.ts
@@ -1,0 +1,388 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * W3 flow C — MEMBERSHIP / subscription attribution service coverage. The
+ * interesting surface is:
+ *   - server-derived three-way split (fee + platform + author = gross) per
+ *     the active subscription rate card
+ *   - self-purchase wash (subscriber == owner → voided + 0 share)
+ *   - internal-owner wash (owner ∈ internalAppOwnerUserIds)
+ *   - idempotency via the (invoice_id, app_block_id) UNIQUE (P2002)
+ *   - RENEWALS-PAY: a second invoice on the same subscription → a 2nd row
+ *   - missing-app guard
+ *   - clawback on refund of a paid_out period (negative carry-forward) +
+ *     no-clawback for pending/confirmed refunds + clawback dedup
+ *
+ * Prisma + logger are mocked at the module boundary so the test stays
+ * in-process and deterministic.
+ */
+
+class FakePrismaKnownError extends Error {
+  code: string;
+  clientVersion: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+    this.clientVersion = 'test';
+  }
+}
+
+const { mockDbRead, mockDbWrite, mockLog } = vi.hoisted(() => ({
+  mockDbRead: {
+    oauthClient: { findUnique: vi.fn() },
+    blockSubscriptionAttribution: { findUnique: vi.fn() },
+  },
+  mockDbWrite: {
+    blockSubscriptionAttribution: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+  mockLog: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: mockDbWrite,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+
+import {
+  AttributionAppMissingError,
+  recordSubscriptionAttribution,
+  voidSubscriptionAttributionsForInvoice,
+  type RecordSubscriptionAttributionInput,
+} from '../buzz-attribution.service';
+import { ACTIVE_RATE_CARD, computeSubscriptionShare } from '../rate-card';
+
+const APP_ID = 'app_test';
+const APP_BLOCK_ID = 'apb_test';
+const APP_OWNER_USER_ID = 999;
+const PURCHASER_ID = 100;
+const INVOICE_ID = 'in_abc123';
+const SUBSCRIPTION_ID = 'sub_xyz';
+
+function fakeInput(
+  over: Partial<RecordSubscriptionAttributionInput> = {}
+): RecordSubscriptionAttributionInput {
+  return {
+    userId: PURCHASER_ID,
+    buzzAmount: 5000,
+    usdAmountCents: 1000, // $10 membership
+    providerFeeCents: 50,
+    paymentProvider: 'stripe',
+    invoiceId: INVOICE_ID,
+    subscriptionId: SUBSCRIPTION_ID,
+    billingReason: 'subscription_create',
+    tier: 'gold',
+    attribution: {
+      appId: APP_ID,
+      appBlockId: APP_BLOCK_ID,
+      blockInstanceId: 'bki_test123',
+      modelId: 555,
+    },
+    ...over,
+  };
+}
+
+function createEchoesData() {
+  mockDbWrite.blockSubscriptionAttribution.create.mockImplementation(
+    async ({ data }: { data: Record<string, unknown> }) => ({
+      id: data.id,
+      status: data.status,
+      appOwnerShareCents: data.appOwnerShareCents,
+      platformShareCents: data.platformShareCents,
+      providerFeeCents: data.providerFeeCents,
+      subscriptionSharePct: data.subscriptionSharePct,
+      grossValueCents: data.grossValueCents,
+      rateCardVersion: data.rateCardVersion,
+      voidedReason: data.voidedReason ?? null,
+    })
+  );
+}
+
+beforeEach(() => {
+  mockDbRead.oauthClient.findUnique.mockReset();
+  mockDbRead.blockSubscriptionAttribution.findUnique.mockReset();
+  mockDbWrite.blockSubscriptionAttribution.create.mockReset();
+  mockDbWrite.blockSubscriptionAttribution.findMany.mockReset();
+  mockDbWrite.blockSubscriptionAttribution.updateMany.mockReset();
+  mockLog.mockReset();
+  // Default: app exists, owned by a different user than the purchaser.
+  mockDbRead.oauthClient.findUnique.mockResolvedValue({
+    id: APP_ID,
+    userId: APP_OWNER_USER_ID,
+  });
+  createEchoesData();
+});
+
+describe('recordSubscriptionAttribution', () => {
+  it('writes exactly one pending row: author=appBlock owner, three-way split per the active card', async () => {
+    const res = await recordSubscriptionAttribution(fakeInput());
+
+    expect(mockDbWrite.blockSubscriptionAttribution.create).toHaveBeenCalledTimes(1);
+    expect(res.written).toBe(true);
+
+    const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
+
+    // Author is the appBlock's owning OauthClient user (server-derived).
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+    expect(data.grossValueCents).toBe(1000);
+
+    // Shares match the active card's three-way split (gross 1000, fee 50).
+    const expected = computeSubscriptionShare({
+      grossCents: 1000,
+      providerFeeCents: 50,
+      isSelfPurchase: false,
+      appOwnerUserId: APP_OWNER_USER_ID,
+    });
+    expect(data.appOwnerShareCents).toBe(expected.appOwnerShareCents);
+    expect(data.platformShareCents).toBe(expected.platformShareCents);
+    expect(data.providerFeeCents).toBe(expected.providerFeeCents);
+    expect(data.subscriptionSharePct).toBe(ACTIVE_RATE_CARD.subscriptionSharePct);
+
+    // Conservation invariant (the SQL CHECK on entry_type='charge'):
+    expect(
+      data.providerFeeCents + data.platformShareCents + data.appOwnerShareCents
+    ).toBe(data.grossValueCents);
+
+    // Forward charge, not voided.
+    expect(data.status).toBe('pending');
+    expect(data.entryType).toBe('charge');
+    expect(data.voidedReason).toBeNull();
+
+    // Server context preserved.
+    expect(data.appId).toBe(APP_ID);
+    expect(data.appBlockId).toBe(APP_BLOCK_ID);
+    expect(data.invoiceId).toBe(INVOICE_ID);
+    expect(data.subscriptionId).toBe(SUBSCRIPTION_ID);
+    expect(data.scope).toBe('subscription');
+    expect(data.billingReason).toBe('subscription_create');
+    expect(data.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
+  });
+
+  it('author share floor: share = floor((gross-fee) * pct/100), within [0, net]', async () => {
+    await recordSubscriptionAttribution(fakeInput({ usdAmountCents: 1999, providerFeeCents: 87 }));
+    const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
+    const net = 1999 - 87;
+    expect(data.appOwnerShareCents).toBe(
+      Math.floor((net * ACTIVE_RATE_CARD.subscriptionSharePct) / 100)
+    );
+    expect(data.appOwnerShareCents).toBeGreaterThanOrEqual(0);
+    expect(data.appOwnerShareCents).toBeLessThanOrEqual(net);
+    expect(
+      data.providerFeeCents + data.platformShareCents + data.appOwnerShareCents
+    ).toBe(1999);
+  });
+
+  it('self-purchase (subscriber == app owner) → voided, zero author share', async () => {
+    mockDbRead.oauthClient.findUnique.mockResolvedValue({
+      id: APP_ID,
+      userId: PURCHASER_ID, // owner == subscriber
+    });
+    const res = await recordSubscriptionAttribution(fakeInput());
+    const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
+    expect(data.status).toBe('voided');
+    expect(data.voidedReason).toBe('self_purchase');
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.subscriptionSharePct).toBe(0);
+    // Conservation still holds: fee + platform + 0 = gross.
+    expect(data.providerFeeCents + data.platformShareCents).toBe(data.grossValueCents);
+    expect(res.row.status).toBe('voided');
+  });
+
+  it('idempotency: a second webhook for the same invoice returns the existing row, no second write', async () => {
+    const first = await recordSubscriptionAttribution(fakeInput());
+    expect(first.written).toBe(true);
+
+    mockDbWrite.blockSubscriptionAttribution.create.mockRejectedValueOnce(
+      new FakePrismaKnownError('dup', 'P2002')
+    );
+    mockDbRead.blockSubscriptionAttribution.findUnique.mockResolvedValueOnce({
+      id: 'bsu_existing',
+      status: 'pending',
+      appOwnerShareCents: 142,
+      platformShareCents: 808,
+      providerFeeCents: 50,
+      subscriptionSharePct: 15,
+      grossValueCents: 1000,
+      rateCardVersion: 'v5',
+      voidedReason: null,
+    });
+
+    const second = await recordSubscriptionAttribution(fakeInput());
+    expect(second.written).toBe(false);
+    expect(second.row.id).toBe('bsu_existing');
+
+    // Looked up by the (invoice, app) idempotency key.
+    expect(mockDbRead.blockSubscriptionAttribution.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { invoiceId_appBlockId: { invoiceId: INVOICE_ID, appBlockId: APP_BLOCK_ID } },
+      })
+    );
+  });
+
+  it('RENEWALS-PAY: a 2nd invoice (subscription_cycle) on the same subscription writes a 2nd row', async () => {
+    // First invoice (initial purchase).
+    const first = await recordSubscriptionAttribution(
+      fakeInput({ invoiceId: 'in_period1', billingReason: 'subscription_create' })
+    );
+    expect(first.written).toBe(true);
+
+    // Second invoice — DIFFERENT invoice_id (a renewal). Same subscription.
+    // Distinct invoice_id → distinct UNIQUE key → a fresh row, NOT a dup.
+    const second = await recordSubscriptionAttribution(
+      fakeInput({ invoiceId: 'in_period2', billingReason: 'subscription_cycle' })
+    );
+    expect(second.written).toBe(true);
+
+    // Two writes, one per period.
+    expect(mockDbWrite.blockSubscriptionAttribution.create).toHaveBeenCalledTimes(2);
+    const firstData = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0].data;
+    const secondData = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[1][0].data;
+    expect(firstData.invoiceId).toBe('in_period1');
+    expect(secondData.invoiceId).toBe('in_period2');
+    expect(firstData.subscriptionId).toBe(SUBSCRIPTION_ID);
+    expect(secondData.subscriptionId).toBe(SUBSCRIPTION_ID);
+    // Both accrue the author share — the renewals-pay policy.
+    expect(firstData.appOwnerShareCents).toBeGreaterThan(0);
+    expect(secondData.appOwnerShareCents).toBeGreaterThan(0);
+    expect(secondData.billingReason).toBe('subscription_cycle');
+  });
+
+  it('aborts (throws AttributionAppMissingError) when the app is gone — no orphan row', async () => {
+    mockDbRead.oauthClient.findUnique.mockResolvedValue(null);
+    await expect(recordSubscriptionAttribution(fakeInput())).rejects.toBeInstanceOf(
+      AttributionAppMissingError
+    );
+    expect(mockDbWrite.blockSubscriptionAttribution.create).not.toHaveBeenCalled();
+  });
+
+  it('re-throws a non-P2002 DB error (real failures are not swallowed as idempotent)', async () => {
+    mockDbWrite.blockSubscriptionAttribution.create.mockRejectedValueOnce(
+      new FakePrismaKnownError('connection lost', 'P1001')
+    );
+    await expect(recordSubscriptionAttribution(fakeInput())).rejects.toMatchObject({
+      code: 'P1001',
+    });
+    expect(mockDbRead.blockSubscriptionAttribution.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('voidSubscriptionAttributionsForInvoice', () => {
+  it('refund of a PENDING/CONFIRMED period: voids, NO clawback (money never left)', async () => {
+    // No paid_out rows to claw back.
+    mockDbWrite.blockSubscriptionAttribution.findMany.mockResolvedValueOnce([]);
+    mockDbWrite.blockSubscriptionAttribution.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    const count = await voidSubscriptionAttributionsForInvoice({
+      paymentProvider: 'stripe',
+      invoiceId: INVOICE_ID,
+      reason: 'refund',
+    });
+
+    expect(count).toBe(1);
+    // No clawback row written.
+    expect(mockDbWrite.blockSubscriptionAttribution.create).not.toHaveBeenCalled();
+    // The void targets charge rows in pending/confirmed/paid_out.
+    expect(mockDbWrite.blockSubscriptionAttribution.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          paymentProvider: 'stripe',
+          invoiceId: INVOICE_ID,
+          entryType: 'charge',
+          status: { in: ['pending', 'confirmed', 'paid_out'] },
+        }),
+        data: expect.objectContaining({ status: 'voided', voidedReason: 'refund' }),
+      })
+    );
+  });
+
+  it('refund of a PAID_OUT period: voids the original AND writes a negative clawback that nets out', async () => {
+    mockDbWrite.blockSubscriptionAttribution.findMany.mockResolvedValueOnce([
+      {
+        appOwnerShareCents: 142,
+        appOwnerUserId: APP_OWNER_USER_ID,
+        userId: PURCHASER_ID,
+        buzzType: 'yellow',
+        appId: APP_ID,
+        appBlockId: APP_BLOCK_ID,
+        blockInstanceId: 'bki_test123',
+        scope: 'subscription',
+        modelId: 555,
+        tier: 'gold',
+        subscriptionId: SUBSCRIPTION_ID,
+        billingReason: 'subscription_cycle',
+        rateCardVersion: 'v5',
+        subscriptionSharePct: 15,
+      },
+    ]);
+    mockDbWrite.blockSubscriptionAttribution.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    const count = await voidSubscriptionAttributionsForInvoice({
+      paymentProvider: 'stripe',
+      invoiceId: INVOICE_ID,
+      reason: 'refund',
+    });
+
+    expect(count).toBe(1);
+    expect(mockDbWrite.blockSubscriptionAttribution.create).toHaveBeenCalledTimes(1);
+    const { data } = mockDbWrite.blockSubscriptionAttribution.create.mock.calls[0][0];
+    // Negative carry-forward, confirmed so the aggregator nets it next mint.
+    expect(data.entryType).toBe('clawback');
+    expect(data.status).toBe('confirmed');
+    expect(data.appOwnerShareCents).toBe(-142);
+    expect(data.grossValueCents).toBe(-142);
+    expect(data.platformShareCents).toBe(0);
+    expect(data.providerFeeCents).toBe(0);
+    // Synthetic invoice id so a repeat refund webhook dedups on the UNIQUE.
+    expect(data.invoiceId).toBe(`${INVOICE_ID}:clawback`);
+    // Owner snapshot preserved → debt routes to the right publisher.
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+
+    // Conservation: original (142) + clawback (-142) = 0 net for the owner.
+    expect(142 + data.appOwnerShareCents).toBe(0);
+  });
+
+  it('clawback dedup: a second refund webhook hits the synthetic-key UNIQUE and is skipped', async () => {
+    mockDbWrite.blockSubscriptionAttribution.findMany.mockResolvedValueOnce([
+      {
+        appOwnerShareCents: 142,
+        appOwnerUserId: APP_OWNER_USER_ID,
+        userId: PURCHASER_ID,
+        buzzType: 'yellow',
+        appId: APP_ID,
+        appBlockId: APP_BLOCK_ID,
+        blockInstanceId: 'bki_test123',
+        scope: 'subscription',
+        modelId: null,
+        tier: null,
+        subscriptionId: SUBSCRIPTION_ID,
+        billingReason: 'subscription_cycle',
+        rateCardVersion: 'v5',
+        subscriptionSharePct: 15,
+      },
+    ]);
+    // The clawback create hits P2002 (already written by a prior webhook).
+    mockDbWrite.blockSubscriptionAttribution.create.mockRejectedValueOnce(
+      new FakePrismaKnownError('dup clawback', 'P2002')
+    );
+    mockDbWrite.blockSubscriptionAttribution.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    // Must NOT throw — the duplicate clawback is swallowed.
+    const count = await voidSubscriptionAttributionsForInvoice({
+      paymentProvider: 'stripe',
+      invoiceId: INVOICE_ID,
+      reason: 'chargeback',
+    });
+    expect(count).toBe(0);
+    expect(mockDbWrite.blockSubscriptionAttribution.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -4,6 +4,7 @@ import { logToAxiom } from '~/server/logging/client';
 import {
   blockBuzzAttributionWriteCounter,
   blockSpendAttributionWriteCounter,
+  blockSubscriptionAttributionWriteCounter,
 } from '~/server/prom/client';
 import {
   type BlockAttribution,
@@ -13,8 +14,14 @@ import {
   newBlockAttributionPayoutId,
   newBlockBuzzAttributionId,
   newBlockSpendAttributionId,
+  newBlockSubscriptionAttributionId,
 } from '~/server/utils/app-block-ids';
-import { computeRateCardSplit, computeSpendShare, ACTIVE_RATE_CARD } from './rate-card';
+import {
+  computeRateCardSplit,
+  computeSpendShare,
+  computeSubscriptionShare,
+  ACTIVE_RATE_CARD,
+} from './rate-card';
 
 export type AttributionPaymentProvider = 'stripe' | 'paddle' | 'nowpayments';
 
@@ -463,6 +470,430 @@ export async function recordSpendAttribution(
     }
     throw err;
   }
+}
+
+// ---------------------------------------------------------------
+// W3 flow C — MEMBERSHIP / subscription attribution
+// ---------------------------------------------------------------
+
+const SUBSCRIPTION_ATTRIBUTION_LOG_NAME = 'block-subscription-attribution';
+
+/**
+ * The single membership-attribution scope. A membership purchase has no
+ * install scope the way a Buzz purchase does (the user bought a recurring
+ * platform subscription, not an app install) — it resolves to one flat
+ * `subscription` category. Kept as a const so the rate card / row writers
+ * agree on the literal.
+ */
+export const SUBSCRIPTION_ATTRIBUTION_SCOPE = 'subscription' as const;
+
+export type RecordSubscriptionAttributionInput = {
+  /** The subscriber (purchaser). Trusted: derived from the invoice's customer→User. */
+  userId: number;
+  /** Membership monthly Buzz bonus for this invoice (analytics only). */
+  buzzAmount?: number;
+  buzzType?: string;
+  /** Gross USD of the invoice, in cents (Stripe invoice amount_paid). */
+  usdAmountCents: number;
+  /** Provider fee in cents — taken off the top before author share. */
+  providerFeeCents: number;
+  paymentProvider: AttributionPaymentProvider;
+  /** Per-period idempotency anchor — the invoice id. */
+  invoiceId: string;
+  /** Subscription id (groups the periods). */
+  subscriptionId?: string | null;
+  /** subscription_create | subscription_cycle | subscription_update. */
+  billingReason?: string | null;
+  periodStart?: Date | null;
+  periodEnd?: Date | null;
+  /** Membership tier at write time (analytics). */
+  tier?: string | null;
+  /**
+   * Server-derived block attribution (already FIN-1 re-derived at checkout
+   * and stamped onto the subscription metadata; the webhook reads it back
+   * and re-confirms the app owner here). appId/appBlockId/blockInstanceId
+   * are authoritative; scope/modelId are analytics.
+   */
+  attribution: Pick<BlockAttribution, 'appId' | 'appBlockId' | 'blockInstanceId' | 'modelId'>;
+};
+
+export type RecordSubscriptionAttributionResult = {
+  /** False when the (invoice, app) UNIQUE blocked a duplicate write. */
+  written: boolean;
+  row: {
+    id: string;
+    status: string;
+    appOwnerShareCents: number;
+    platformShareCents: number;
+    providerFeeCents: number;
+    subscriptionSharePct: number;
+    grossValueCents: number;
+    rateCardVersion: string;
+    voidedReason: string | null;
+  };
+};
+
+/**
+ * Record a revenue share for one PAID INVOICE of a block-initiated
+ * membership (recurring subscription) purchase. Idempotent on
+ * `(invoice_id, app_block_id)` — a webhook retry for the same invoice is a
+ * no-op (P2002 caught + treated as already-written). Each RENEWAL invoice
+ * has its own invoice_id, so it writes its OWN row — this is the
+ * RENEWALS-PAY policy (flagged for sign-off; the caller can gate to
+ * billing_reason='subscription_create' for a first-only policy).
+ *
+ * ACCOUNTING: a membership payment IS a real card transaction, so the
+ * three-way split applies (provider fee off the top, author share % of the
+ * net, platform keeps the rest) — same as recordAttribution, NOT the
+ * platform-funded bounty model of spend. The conservation invariant
+ * (fee + platform + author = gross) holds and is enforced by the migration
+ * CHECK on entry_type='charge'.
+ *
+ * This function moves NO money and touches NO BuzzTransaction — the buzz
+ * grant + reward happen in manageInvoicePaid before this is called. A
+ * failed write here MUST NOT break membership provisioning (the caller
+ * fires it best-effort / fire-and-forget).
+ *
+ * Self-purchase (subscriber == app owner) and internal-owner apps write a
+ * voided, zero-share row so the audit trail exists but nothing enters the
+ * payout pipeline (mirrors recordAttribution's self-purchase wash).
+ */
+export async function recordSubscriptionAttribution(
+  input: RecordSubscriptionAttributionInput
+): Promise<RecordSubscriptionAttributionResult> {
+  const {
+    userId,
+    buzzAmount = 0,
+    buzzType = 'yellow',
+    usdAmountCents,
+    providerFeeCents,
+    paymentProvider,
+    invoiceId,
+    subscriptionId = null,
+    billingReason = null,
+    periodStart = null,
+    periodEnd = null,
+    tier = null,
+    attribution,
+  } = input;
+
+  // Resolve + snapshot the app owner (mirrors recordAttribution). No owner
+  // -> nothing to pay -> abort (don't write an orphan row).
+  const app = await dbRead.oauthClient.findUnique({
+    where: { id: attribution.appId },
+    select: { id: true, userId: true },
+  });
+  if (!app) {
+    logToAxiom(
+      {
+        name: SUBSCRIPTION_ATTRIBUTION_LOG_NAME,
+        type: 'warning',
+        message: `subscription attribution app not found (skipping write): ${attribution.appId}`,
+        appId: attribution.appId,
+        paymentProvider,
+        invoiceId,
+      },
+      'webhooks'
+    ).catch(() => null);
+    throw new AttributionAppMissingError(attribution.appId);
+  }
+
+  const isSelfPurchase = userId === app.userId;
+  const split = computeSubscriptionShare({
+    grossCents: usdAmountCents,
+    providerFeeCents,
+    isSelfPurchase,
+    appOwnerUserId: app.userId,
+  });
+
+  // Void zero-share rows that are zero because of WHO bought/owns (not
+  // because the rate is 0%) so they never enter the payout pipeline. A
+  // legitimately rate-0% row stays 'pending' — a real attribution we want
+  // to confirm/aggregate so a later non-zero card applies going forward.
+  const isInternal = ACTIVE_RATE_CARD.internalAppOwnerUserIds.includes(app.userId);
+  const voidedReason = isSelfPurchase
+    ? 'self_purchase'
+    : isInternal
+    ? 'internal_owner'
+    : null;
+  const status = voidedReason ? 'voided' : 'pending';
+  const voidedAt = voidedReason ? new Date() : null;
+
+  const id = newBlockSubscriptionAttributionId();
+
+  try {
+    const created = await dbWrite.blockSubscriptionAttribution.create({
+      data: {
+        id,
+        userId,
+        buzzAmount: Math.max(0, Math.floor(buzzAmount)),
+        buzzType,
+        grossValueCents: Math.max(0, Math.floor(usdAmountCents)),
+        paymentProvider,
+        invoiceId,
+        subscriptionId,
+        billingReason,
+        periodStart,
+        periodEnd,
+        appId: attribution.appId,
+        appBlockId: attribution.appBlockId,
+        blockInstanceId: attribution.blockInstanceId,
+        scope: SUBSCRIPTION_ATTRIBUTION_SCOPE,
+        modelId: attribution.modelId ?? null,
+        tier,
+        rateCardVersion: split.rateCardVersion,
+        subscriptionSharePct: split.subscriptionSharePct,
+        appOwnerShareCents: split.appOwnerShareCents,
+        platformShareCents: split.platformShareCents,
+        providerFeeCents: split.providerFeeCents,
+        appOwnerUserId: app.userId,
+        status,
+        entryType: 'charge',
+        voidedReason,
+        voidedAt,
+      },
+      select: {
+        id: true,
+        status: true,
+        appOwnerShareCents: true,
+        platformShareCents: true,
+        providerFeeCents: true,
+        subscriptionSharePct: true,
+        grossValueCents: true,
+        rateCardVersion: true,
+        voidedReason: true,
+      },
+    });
+
+    logToAxiom(
+      {
+        name: SUBSCRIPTION_ATTRIBUTION_LOG_NAME,
+        type: 'info',
+        message: `subscription attribution written ${created.id}`,
+        attributionId: created.id,
+        appId: attribution.appId,
+        appBlockId: attribution.appBlockId,
+        paymentProvider,
+        invoiceId,
+        subscriptionId,
+        billingReason,
+        usdAmountCents,
+        appOwnerShareCents: split.appOwnerShareCents,
+        platformShareCents: split.platformShareCents,
+        providerFeeCents: split.providerFeeCents,
+        subscriptionSharePct: split.subscriptionSharePct,
+        rateCardVersion: split.rateCardVersion,
+        status,
+        voidedReason,
+        isSelfPurchase,
+      },
+      'webhooks'
+    ).catch(() => null);
+
+    try {
+      blockSubscriptionAttributionWriteCounter.inc({
+        provider: paymentProvider,
+        status,
+        billing_reason: billingReason ?? 'unknown',
+      });
+    } catch {
+      // swallow — metric write must never back-pressure the webhook path
+    }
+
+    return { written: true, row: created };
+  } catch (err) {
+    // Idempotency: a webhook retry for the same invoice lands on the
+    // (invoice_id, app_block_id) UNIQUE → P2002. Return the pre-existing
+    // row so callers treat first-write + retry uniformly.
+    const code = (err as { code?: unknown })?.code;
+    if (code === 'P2002') {
+      const existing = await dbRead.blockSubscriptionAttribution.findUnique({
+        where: {
+          invoiceId_appBlockId: { invoiceId, appBlockId: attribution.appBlockId },
+        },
+        select: {
+          id: true,
+          status: true,
+          appOwnerShareCents: true,
+          platformShareCents: true,
+          providerFeeCents: true,
+          subscriptionSharePct: true,
+          grossValueCents: true,
+          rateCardVersion: true,
+          voidedReason: true,
+        },
+      });
+      if (existing) {
+        try {
+          blockSubscriptionAttributionWriteCounter.inc({
+            provider: paymentProvider,
+            status: 'duplicate',
+            billing_reason: billingReason ?? 'unknown',
+          });
+        } catch {
+          // swallow
+        }
+        return { written: false, row: existing };
+      }
+    }
+    throw err;
+  }
+}
+
+/** Synthetic invoice_id suffix for subscription clawback rows so they don't
+ * collide with the original charge row's (invoice_id, app_block_id) UNIQUE.
+ * A second refund webhook for the same invoice hits P2002 on this synthetic
+ * key → we skip the duplicate clawback. */
+const SUBSCRIPTION_CLAWBACK_INVOICE_SUFFIX = ':clawback';
+
+/**
+ * Void the subscription-attribution rows for one paid invoice in response
+ * to a refund / chargeback / proration, mirroring
+ * voidAttributionsForPayment. Idempotent — voiding an already-voided row is
+ * a no-op.
+ *
+ * Refund handling depends on whether the money already left:
+ *   - pending / confirmed rows (never paid): just void. No clawback — the
+ *     publisher was never paid, so there's no debt to recover.
+ *   - paid_out rows: void the original AND write a NEGATIVE carry-forward
+ *     entry_type='clawback' row (status='confirmed', negative shares). The
+ *     payout aggregator nets this debt out of the publisher's next mint.
+ *
+ * Cancellation policy: a cancellation mid-period that keeps the
+ * already-paid period (no refund) is NOT a clawback — the author keeps the
+ * period already earned. Only a refund/proration that actually returns
+ * money to the subscriber claws back. The caller (the refund webhook)
+ * decides which: this fn is invoked only when money is being returned.
+ *
+ * Clawback idempotency: each clawback row reuses the original's
+ * (app_block_id) with a synthetic invoice_id '<orig>:clawback', so the
+ * (invoice_id, app_block_id) UNIQUE makes a second refund webhook a no-op.
+ *
+ * Returns the count of original rows voided (clawbacks counted in the log).
+ */
+export async function voidSubscriptionAttributionsForInvoice({
+  paymentProvider,
+  invoiceId,
+  reason,
+}: {
+  paymentProvider: AttributionPaymentProvider;
+  invoiceId: string;
+  reason: 'refund' | 'chargeback' | 'proration' | 'manual_review';
+}): Promise<number> {
+  // Snapshot the already-paid_out rows BEFORE voiding so we can mint their
+  // clawbacks. Only paid_out rows generate debt. Writing clawbacks BEFORE
+  // the void is the crash-safety ordering (same rationale as
+  // voidAttributionsForPayment).
+  const paidOutRows = await dbWrite.blockSubscriptionAttribution.findMany({
+    where: { paymentProvider, invoiceId, status: 'paid_out', entryType: 'charge' },
+    select: {
+      appOwnerShareCents: true,
+      appOwnerUserId: true,
+      userId: true,
+      buzzType: true,
+      appId: true,
+      appBlockId: true,
+      blockInstanceId: true,
+      scope: true,
+      modelId: true,
+      tier: true,
+      subscriptionId: true,
+      billingReason: true,
+      rateCardVersion: true,
+      subscriptionSharePct: true,
+    },
+  });
+
+  let clawbackCount = 0;
+  for (const orig of paidOutRows) {
+    const clawbackId = newBlockSubscriptionAttributionId();
+    try {
+      await dbWrite.blockSubscriptionAttribution.create({
+        data: {
+          id: clawbackId,
+          userId: orig.userId,
+          buzzAmount: 0,
+          buzzType: orig.buzzType,
+          // Negative gross + negative author share. platform/fee 0 on the
+          // clawback (the conservation CHECK is scoped to entry_type=
+          // 'charge', so a clawback's gross need not three-way sum).
+          grossValueCents: -orig.appOwnerShareCents,
+          paymentProvider,
+          // Synthetic invoice id so the (invoice, app_block) UNIQUE both
+          // avoids colliding with the original AND dedupes repeat refunds.
+          invoiceId: `${invoiceId}${SUBSCRIPTION_CLAWBACK_INVOICE_SUFFIX}`,
+          subscriptionId: orig.subscriptionId,
+          billingReason: orig.billingReason,
+          appId: orig.appId,
+          appBlockId: orig.appBlockId,
+          blockInstanceId: orig.blockInstanceId,
+          scope: orig.scope,
+          modelId: orig.modelId,
+          tier: orig.tier,
+          rateCardVersion: orig.rateCardVersion,
+          subscriptionSharePct: orig.subscriptionSharePct,
+          appOwnerShareCents: -orig.appOwnerShareCents,
+          platformShareCents: 0,
+          providerFeeCents: 0,
+          appOwnerUserId: orig.appOwnerUserId,
+          status: 'confirmed',
+          entryType: 'clawback',
+          voidedReason: null,
+          confirmedAt: new Date(),
+        },
+      });
+      clawbackCount += 1;
+    } catch (err) {
+      const code = (err as { code?: unknown })?.code;
+      if (code === 'P2002') continue;
+      throw err;
+    }
+  }
+
+  const result = await dbWrite.blockSubscriptionAttribution.updateMany({
+    where: {
+      paymentProvider,
+      invoiceId,
+      entryType: 'charge',
+      status: { in: ['pending', 'confirmed', 'paid_out'] },
+    },
+    data: {
+      status: 'voided',
+      voidedReason: reason,
+      voidedAt: new Date(),
+    },
+  });
+
+  if (result.count > 0 || clawbackCount > 0) {
+    logToAxiom(
+      {
+        name: SUBSCRIPTION_ATTRIBUTION_LOG_NAME,
+        type: 'info',
+        message:
+          `voided ${result.count} subscription attribution row(s) for ${invoiceId}` +
+          (clawbackCount > 0 ? ` + ${clawbackCount} clawback row(s)` : ''),
+        paymentProvider,
+        invoiceId,
+        reason,
+        count: result.count,
+        clawbackCount,
+      },
+      'webhooks'
+    ).catch(() => null);
+
+    try {
+      if (clawbackCount > 0) {
+        blockSubscriptionAttributionWriteCounter.inc(
+          { provider: paymentProvider, status: 'clawback', billing_reason: 'unknown' },
+          clawbackCount
+        );
+      }
+    } catch {
+      // swallow
+    }
+  }
+
+  return result.count;
 }
 
 /** Synthetic payment_transaction_id suffix for clawback rows so they don't

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -19,7 +19,10 @@ import {
 import {
   computeRateCardSplit,
   computeSpendShare,
-  computeSubscriptionShare,
+  // NOTE: computeSubscriptionShare is intentionally NOT imported here.
+  // Membership attribution is TRACK-ONLY (#2629) — no rate is applied at
+  // write time. The share is computed at payout time (Slice 4) as a backpay
+  // against the signed-off rate over status='tracked' rows.
   ACTIVE_RATE_CARD,
 } from './rate-card';
 
@@ -487,6 +490,16 @@ const SUBSCRIPTION_ATTRIBUTION_LOG_NAME = 'block-subscription-attribution';
  */
 export const SUBSCRIPTION_ATTRIBUTION_SCOPE = 'subscription' as const;
 
+/**
+ * Sentinel `rate_card_version` for TRACK-ONLY membership rows (#2629). No
+ * rate card is applied at attribution-write time, so no real version is
+ * stamped — the row records the money basis (gross + fee) and the share is
+ * computed at payout time (Slice 4) as a backpay. A row carrying this
+ * sentinel + status='tracked' is "share-pending": the payout rail re-stamps
+ * the signed-off version when it computes the share.
+ */
+export const UNRATED_RATE_CARD_VERSION = 'unrated' as const;
+
 export type RecordSubscriptionAttributionInput = {
   /** The subscriber (purchaser). Trusted: derived from the invoice's customer→User. */
   userId: number;
@@ -542,12 +555,26 @@ export type RecordSubscriptionAttributionResult = {
  * RENEWALS-PAY policy (flagged for sign-off; the caller can gate to
  * billing_reason='subscription_create' for a first-only policy).
  *
- * ACCOUNTING: a membership payment IS a real card transaction, so the
- * three-way split applies (provider fee off the top, author share % of the
- * net, platform keeps the rest) — same as recordAttribution, NOT the
- * platform-funded bounty model of spend. The conservation invariant
- * (fee + platform + author = gross) holds and is enforced by the migration
- * CHECK on entry_type='charge'.
+ * ⚠️ TRACK-ONLY (#2629). This write records the ATTRIBUTION EVENT + the
+ * MONEY BASIS (gross + provider_fee) only. It does NOT apply the rate card
+ * and does NOT bake an author share. The row is written:
+ *   - status               = 'tracked'  (share-pending, not yet computed)
+ *   - app_owner_share_cents = 0
+ *   - subscription_share_pct= 0         (no rate applied)
+ *   - rate_card_version     = 'unrated' (no version stamped)
+ *   - platform_share_cents  = net (gross - fee), so the conservation CHECK
+ *                             (fee + platform + author = gross) still holds
+ *                             with author = 0.
+ * The author share is DEFERRED to PAYOUT time: the future payout rail
+ * (Slice 4) reads status='tracked' rows and computes
+ * author_share = net × <signed-off subscriptionSharePct> as a clean
+ * retroactive BACKPAY, then transitions them to a computed/confirmed state.
+ * Because the tracked row carries gross + fee, that computation is exact.
+ *
+ * WHY: committing a share at the placeholder rate before monetization
+ * sign-off would lock these immutable rows to the placeholder (each row
+ * pays out under its STAMPED snapshot forever). Recording the basis now and
+ * applying the signed-off rate later removes the placeholder-rate liability.
  *
  * This function moves NO money and touches NO BuzzTransaction — the buzz
  * grant + reward happen in manageInvoicePaid before this is called. A
@@ -555,8 +582,8 @@ export type RecordSubscriptionAttributionResult = {
  * fires it best-effort / fire-and-forget).
  *
  * Self-purchase (subscriber == app owner) and internal-owner apps write a
- * voided, zero-share row so the audit trail exists but nothing enters the
- * payout pipeline (mirrors recordAttribution's self-purchase wash).
+ * voided, zero-share row so the audit trail exists but nothing is ever
+ * backpaid (mirrors recordAttribution's self-purchase wash).
  */
 export async function recordSubscriptionAttribution(
   input: RecordSubscriptionAttributionInput
@@ -599,24 +626,32 @@ export async function recordSubscriptionAttribution(
   }
 
   const isSelfPurchase = userId === app.userId;
-  const split = computeSubscriptionShare({
-    grossCents: usdAmountCents,
-    providerFeeCents,
-    isSelfPurchase,
-    appOwnerUserId: app.userId,
-  });
-
-  // Void zero-share rows that are zero because of WHO bought/owns (not
-  // because the rate is 0%) so they never enter the payout pipeline. A
-  // legitimately rate-0% row stays 'pending' — a real attribution we want
-  // to confirm/aggregate so a later non-zero card applies going forward.
   const isInternal = ACTIVE_RATE_CARD.internalAppOwnerUserIds.includes(app.userId);
+
+  // TRACK-ONLY money basis: record gross + provider_fee, defer the share.
+  // NO rate card is applied here (no computeSubscriptionShare call). The
+  // backpay (Slice 4) re-splits `net` into platform/author at the signed-off
+  // rate. Today: author = 0, platform = net, so the conservation CHECK
+  // (fee + platform + author = gross) holds.
+  const safeGross = Math.max(0, Math.floor(usdAmountCents));
+  const safeFee = Math.max(0, Math.min(safeGross, Math.floor(providerFeeCents)));
+  const net = safeGross - safeFee;
+  const appOwnerShareCents = 0;
+  const platformShareCents = net;
+  const providerFeeCentsFinal = safeFee;
+  // No rate applied → no version stamped (sentinel) and 0%.
+  const rateCardVersion = UNRATED_RATE_CARD_VERSION;
+  const subscriptionSharePct = 0;
+
+  // Void rows that are zero because of WHO bought/owns so they are never
+  // backpaid. Otherwise the row is 'tracked' — share-pending, awaiting the
+  // payout-time backpay at the signed-off rate.
   const voidedReason = isSelfPurchase
     ? 'self_purchase'
     : isInternal
     ? 'internal_owner'
     : null;
-  const status = voidedReason ? 'voided' : 'pending';
+  const status = voidedReason ? 'voided' : 'tracked';
   const voidedAt = voidedReason ? new Date() : null;
 
   const id = newBlockSubscriptionAttributionId();
@@ -628,7 +663,7 @@ export async function recordSubscriptionAttribution(
         userId,
         buzzAmount: Math.max(0, Math.floor(buzzAmount)),
         buzzType,
-        grossValueCents: Math.max(0, Math.floor(usdAmountCents)),
+        grossValueCents: safeGross,
         paymentProvider,
         invoiceId,
         subscriptionId,
@@ -641,11 +676,11 @@ export async function recordSubscriptionAttribution(
         scope: SUBSCRIPTION_ATTRIBUTION_SCOPE,
         modelId: attribution.modelId ?? null,
         tier,
-        rateCardVersion: split.rateCardVersion,
-        subscriptionSharePct: split.subscriptionSharePct,
-        appOwnerShareCents: split.appOwnerShareCents,
-        platformShareCents: split.platformShareCents,
-        providerFeeCents: split.providerFeeCents,
+        rateCardVersion,
+        subscriptionSharePct,
+        appOwnerShareCents,
+        platformShareCents,
+        providerFeeCents: providerFeeCentsFinal,
         appOwnerUserId: app.userId,
         status,
         entryType: 'charge',
@@ -678,11 +713,11 @@ export async function recordSubscriptionAttribution(
         subscriptionId,
         billingReason,
         usdAmountCents,
-        appOwnerShareCents: split.appOwnerShareCents,
-        platformShareCents: split.platformShareCents,
-        providerFeeCents: split.providerFeeCents,
-        subscriptionSharePct: split.subscriptionSharePct,
-        rateCardVersion: split.rateCardVersion,
+        appOwnerShareCents,
+        platformShareCents,
+        providerFeeCents: providerFeeCentsFinal,
+        subscriptionSharePct,
+        rateCardVersion,
         status,
         voidedReason,
         isSelfPurchase,
@@ -740,36 +775,24 @@ export async function recordSubscriptionAttribution(
   }
 }
 
-/** Synthetic invoice_id suffix for subscription clawback rows so they don't
- * collide with the original charge row's (invoice_id, app_block_id) UNIQUE.
- * A second refund webhook for the same invoice hits P2002 on this synthetic
- * key → we skip the duplicate clawback. */
-const SUBSCRIPTION_CLAWBACK_INVOICE_SUFFIX = ':clawback';
-
 /**
  * Void the subscription-attribution rows for one paid invoice in response
- * to a refund / chargeback / proration, mirroring
- * voidAttributionsForPayment. Idempotent — voiding an already-voided row is
- * a no-op.
+ * to a refund / chargeback / proration. Idempotent — voiding an
+ * already-voided row is a no-op.
  *
- * Refund handling depends on whether the money already left:
- *   - pending / confirmed rows (never paid): just void. No clawback — the
- *     publisher was never paid, so there's no debt to recover.
- *   - paid_out rows: void the original AND write a NEGATIVE carry-forward
- *     entry_type='clawback' row (status='confirmed', negative shares). The
- *     payout aggregator nets this debt out of the publisher's next mint.
+ * ⚠️ TRACK-ONLY (#2629). Membership rows are written status='tracked' with
+ * app_owner_share_cents = 0 and are NEVER paid out (no rate is applied until
+ * the payout-time backpay). A refunded purchase must simply be VOIDED before
+ * any backpay runs so the future payout rail never computes a share for it.
  *
- * Cancellation policy: a cancellation mid-period that keeps the
- * already-paid period (no refund) is NOT a clawback — the author keeps the
- * period already earned. Only a refund/proration that actually returns
- * money to the subscriber claws back. The caller (the refund webhook)
- * decides which: this fn is invoked only when money is being returned.
+ * There is NO negative carry-forward clawback to write: with author = 0 on
+ * every tracked row, a void leaves nothing owed. (Once the payout rail
+ * exists and transitions tracked → paid_out with a real share, a refund of
+ * an already-paid period WILL need a clawback — that belongs to the payout
+ * slice, written against the rate it actually paid. This function only has
+ * to neutralize unpaid tracked rows, which the void below does.)
  *
- * Clawback idempotency: each clawback row reuses the original's
- * (app_block_id) with a synthetic invoice_id '<orig>:clawback', so the
- * (invoice_id, app_block_id) UNIQUE makes a second refund webhook a no-op.
- *
- * Returns the count of original rows voided (clawbacks counted in the log).
+ * Returns the count of rows voided.
  */
 export async function voidSubscriptionAttributionsForInvoice({
   paymentProvider,
@@ -780,82 +803,16 @@ export async function voidSubscriptionAttributionsForInvoice({
   invoiceId: string;
   reason: 'refund' | 'chargeback' | 'proration' | 'manual_review';
 }): Promise<number> {
-  // Snapshot the already-paid_out rows BEFORE voiding so we can mint their
-  // clawbacks. Only paid_out rows generate debt. Writing clawbacks BEFORE
-  // the void is the crash-safety ordering (same rationale as
-  // voidAttributionsForPayment).
-  const paidOutRows = await dbWrite.blockSubscriptionAttribution.findMany({
-    where: { paymentProvider, invoiceId, status: 'paid_out', entryType: 'charge' },
-    select: {
-      appOwnerShareCents: true,
-      appOwnerUserId: true,
-      userId: true,
-      buzzType: true,
-      appId: true,
-      appBlockId: true,
-      blockInstanceId: true,
-      scope: true,
-      modelId: true,
-      tier: true,
-      subscriptionId: true,
-      billingReason: true,
-      rateCardVersion: true,
-      subscriptionSharePct: true,
-    },
-  });
-
-  let clawbackCount = 0;
-  for (const orig of paidOutRows) {
-    const clawbackId = newBlockSubscriptionAttributionId();
-    try {
-      await dbWrite.blockSubscriptionAttribution.create({
-        data: {
-          id: clawbackId,
-          userId: orig.userId,
-          buzzAmount: 0,
-          buzzType: orig.buzzType,
-          // Negative gross + negative author share. platform/fee 0 on the
-          // clawback (the conservation CHECK is scoped to entry_type=
-          // 'charge', so a clawback's gross need not three-way sum).
-          grossValueCents: -orig.appOwnerShareCents,
-          paymentProvider,
-          // Synthetic invoice id so the (invoice, app_block) UNIQUE both
-          // avoids colliding with the original AND dedupes repeat refunds.
-          invoiceId: `${invoiceId}${SUBSCRIPTION_CLAWBACK_INVOICE_SUFFIX}`,
-          subscriptionId: orig.subscriptionId,
-          billingReason: orig.billingReason,
-          appId: orig.appId,
-          appBlockId: orig.appBlockId,
-          blockInstanceId: orig.blockInstanceId,
-          scope: orig.scope,
-          modelId: orig.modelId,
-          tier: orig.tier,
-          rateCardVersion: orig.rateCardVersion,
-          subscriptionSharePct: orig.subscriptionSharePct,
-          appOwnerShareCents: -orig.appOwnerShareCents,
-          platformShareCents: 0,
-          providerFeeCents: 0,
-          appOwnerUserId: orig.appOwnerUserId,
-          status: 'confirmed',
-          entryType: 'clawback',
-          voidedReason: null,
-          confirmedAt: new Date(),
-        },
-      });
-      clawbackCount += 1;
-    } catch (err) {
-      const code = (err as { code?: unknown })?.code;
-      if (code === 'P2002') continue;
-      throw err;
-    }
-  }
-
+  // Void the forward 'charge' rows for this invoice that haven't already
+  // been voided. 'tracked' is the live track-only state; pending/confirmed/
+  // paid_out are included defensively so a future payout-promoted row is
+  // also neutralized here (the paid-out clawback is the payout slice's job).
   const result = await dbWrite.blockSubscriptionAttribution.updateMany({
     where: {
       paymentProvider,
       invoiceId,
       entryType: 'charge',
-      status: { in: ['pending', 'confirmed', 'paid_out'] },
+      status: { in: ['tracked', 'pending', 'confirmed', 'paid_out'] },
     },
     data: {
       status: 'voided',
@@ -864,33 +821,19 @@ export async function voidSubscriptionAttributionsForInvoice({
     },
   });
 
-  if (result.count > 0 || clawbackCount > 0) {
+  if (result.count > 0) {
     logToAxiom(
       {
         name: SUBSCRIPTION_ATTRIBUTION_LOG_NAME,
         type: 'info',
-        message:
-          `voided ${result.count} subscription attribution row(s) for ${invoiceId}` +
-          (clawbackCount > 0 ? ` + ${clawbackCount} clawback row(s)` : ''),
+        message: `voided ${result.count} subscription attribution row(s) for ${invoiceId}`,
         paymentProvider,
         invoiceId,
         reason,
         count: result.count,
-        clawbackCount,
       },
       'webhooks'
     ).catch(() => null);
-
-    try {
-      if (clawbackCount > 0) {
-        blockSubscriptionAttributionWriteCounter.inc(
-          { provider: paymentProvider, status: 'clawback', billing_reason: 'unknown' },
-          clawbackCount
-        );
-      }
-    } catch {
-      // swallow
-    }
   }
 
   return result.count;

--- a/src/server/services/blocks/rate-card.ts
+++ b/src/server/services/blocks/rate-card.ts
@@ -38,9 +38,14 @@ export type RateCard = {
    * provider fee) paid to the app author, applied per PAID INVOICE. Unlike
    * a one-shot Buzz purchase, a subscription bills recurringly: by the
    * renewals-pay policy each paid invoice (subscription_create AND
-   * subscription_cycle) accrues this share. One flat rate for subscription
-   * (no install-scope dimension): a membership purchase resolves to the
-   * single `subscription` scope. PLACEHOLDER pending monetization sign-off.
+   * subscription_cycle) is tracked.
+   *
+   * ⚠️ NOT applied at attribution-write time. As of the TRACK-ONLY rework
+   * (#2629), this percentage is computed at PAYOUT time as a backpay over
+   * `status='tracked'` rows, NOT stamped onto the row when it's written.
+   * One flat rate for subscription (no install-scope dimension): a
+   * membership purchase resolves to the single `subscription` scope.
+   * PLACEHOLDER pending monetization sign-off.
    */
   subscriptionSharePct: number;
   /**
@@ -269,39 +274,55 @@ export const RATE_CARD_V4: RateCard = {
  * (`subscriptionSharePct`).
  *
  * Carries V4's purchase percentages (15/15/25/0/0) AND its spend bounty
- * (5%) UNCHANGED, and sets `subscriptionSharePct` to the FIRST non-zero
- * subscription rate. This is the first card emitted for the subscription
- * flow: a block-initiated membership purchase now accrues an author share
- * on each paid invoice.
+ * (5%) UNCHANGED, and DEFINES `subscriptionSharePct: 15` as the PLACEHOLDER
+ * subscription rate.
+ *
+ * ⚠️ NOT APPLIED AT ATTRIBUTION-WRITE TIME. As of the TRACK-ONLY rework
+ *    (PR #2629), `recordSubscriptionAttribution` does NOT call
+ *    `computeSubscriptionShare` and does NOT stamp this percentage onto the
+ *    row. Membership attribution rows are written `status='tracked'` with
+ *    `app_owner_share_cents = 0`, `subscription_share_pct = 0`, and
+ *    `rate_card_version = 'unrated'` — they record the EVENT + the money
+ *    BASIS (gross + provider_fee) only. The author share is deferred to
+ *    PAYOUT TIME: the future payout rail (Slice 4) reads `status='tracked'`
+ *    rows and computes `author_share = net × <signed-off subscriptionSharePct>`
+ *    as a clean retroactive BACKPAY, then transitions them to a
+ *    computed/confirmed state. Because the rows carry gross+fee, the
+ *    backpay computation is exact.
+ *
+ *    WHY: committing a share at this placeholder 15% before monetization
+ *    sign-off would lock those rows to the placeholder rate (the
+ *    immutability doctrine pays each row out under its STAMPED snapshot
+ *    forever). Recording the gross/fee now and applying the signed-off rate
+ *    later removes that placeholder-rate liability from the ledger while
+ *    preserving the full purchase trail.
  *
  * ⚠️ PLACEHOLDER RATE — `subscriptionSharePct: 15` mirrors the
  *    publisher-purchase floor (15%) as a CONSERVATIVE STARTING DEFAULT
  *    pending monetization sign-off. Recurring revenue is structurally
  *    different (LTV-weighted, renewals compound), so leadership may choose
- *    a DIFFERENT number than one-shot purchase — this is flagged for sign-
- *    off, not a final figure. Raising is politically easier than lowering
- *    after a public announcement, so this starts at (not above) the
- *    purchase floor.
+ *    a DIFFERENT number than one-shot purchase. It is the rate the eventual
+ *    payout/backpay WILL apply, pending sign-off — not a final figure.
  *
- * ACCOUNTING MODEL — same THREE-WAY split as a Buzz purchase (NOT the
- *    platform-funded bounty model of spend): a membership payment is a real
- *    card transaction. provider_fee comes off the top, the author share is
- *    `subscriptionSharePct` % of the NET (gross - fee), the platform keeps
- *    the remainder. The three-way conservation invariant
- *    (fee + platform + author = gross) holds and is enforced by the
- *    migration's CHECK (entry_type='charge').
+ * ACCOUNTING MODEL (at payout, NOT at write) — same THREE-WAY split as a
+ *    Buzz purchase (NOT the platform-funded bounty model of spend): a
+ *    membership payment is a real card transaction. provider_fee comes off
+ *    the top, the author share is `subscriptionSharePct` % of the NET
+ *    (gross - fee), the platform keeps the remainder. At write time the
+ *    tracked row sets `platform_share = net` and `author_share = 0`, so the
+ *    conservation invariant (fee + platform + author = gross) still holds;
+ *    the backpay re-splits net into platform/author at payout.
  *
  * RENEWALS-PAY POLICY (⚠️ FLAGGED for sign-off, scope §C/E#3): one
  *    attribution row per PAID invoice means renewals (subscription_cycle)
- *    accrue a share just like the initial purchase (subscription_create).
- *    This is the default. A "first-invoice-only" policy is a service-level
- *    gate (write only on subscription_create) — no card change. Recurring
- *    share has real LTV / clawback implications (a refund or downgrade
- *    proration of a previously paid-out period claws back via a negative
- *    entry_type='clawback' row).
+ *    are tracked just like the initial purchase (subscription_create), so
+ *    the backpay will pay each renewal. This is the default. A
+ *    "first-invoice-only" policy is a service-level gate (write only on
+ *    subscription_create) — no card change.
  *
  * When the signed-off rate lands, add a V6 with the agreed % and leave V5
- * in place for the rows stamped under it (cards are immutable).
+ * in place (cards are immutable). `computeSubscriptionShare` below remains
+ * for the payout-time backpay to call against the signed-off card.
  */
 export const RATE_CARD_V5: RateCard = {
   version: 'v5',
@@ -479,6 +500,12 @@ export type SubscriptionShareResult = {
 /**
  * Compute the publisher / platform / provider-fee split for a single
  * block-initiated MEMBERSHIP payment (one paid invoice).
+ *
+ * ⚠️ PAYOUT-TIME ONLY. This is NOT called by `recordSubscriptionAttribution`
+ * anymore (the TRACK-ONLY rework, #2629). Membership rows are written
+ * `status='tracked'` with a 0 share and no stamped rate. This function is
+ * retained for the future payout rail (Slice 4) to call against the
+ * signed-off card, computing each tracked row's author share as a backpay.
  *
  * Same order of operations as computeRateCardSplit: provider fee off the
  * top, the author share is `subscriptionSharePct` % of the NET

--- a/src/server/services/blocks/rate-card.ts
+++ b/src/server/services/blocks/rate-card.ts
@@ -32,6 +32,18 @@ export type RateCard = {
    */
   spendSharePct: number;
   /**
+   * W3 flow C — MEMBERSHIP / subscription attribution.
+   *
+   * The percentage of a block-initiated membership payment's NET (gross -
+   * provider fee) paid to the app author, applied per PAID INVOICE. Unlike
+   * a one-shot Buzz purchase, a subscription bills recurringly: by the
+   * renewals-pay policy each paid invoice (subscription_create AND
+   * subscription_cycle) accrues this share. One flat rate for subscription
+   * (no install-scope dimension): a membership purchase resolves to the
+   * single `subscription` scope. PLACEHOLDER pending monetization sign-off.
+   */
+  subscriptionSharePct: number;
+  /**
    * Apps owned by these userIds always pay 0% to publisher — internal
    * civitai apps where the "share" is meaningless because the same
    * legal entity owns both sides of the transaction.
@@ -89,6 +101,10 @@ export const RATE_CARD_V1: RateCard = {
   // no spend row was ever stamped under V1 (the spend flow is net-new),
   // and V1 is not the active card.
   spendSharePct: 0,
+  // Net-new subscription dimension (W3 flow C). 0% — behavior-preserving:
+  // no subscription row was ever stamped under V1 (flow C is net-new), and
+  // V1 is not the active card.
+  subscriptionSharePct: 0,
   internalAppOwnerUserIds: [],
   effectiveFrom: '2026-05-25',
 };
@@ -133,6 +149,9 @@ export const RATE_CARD_V2: RateCard = {
   // Net-new spend dimension (W3 flow A). 0% — behavior-preserving (no V2
   // spend row ever existed; V2 is not the active card).
   spendSharePct: 0,
+  // Net-new subscription dimension (W3 flow C). 0% — behavior-preserving
+  // (no V2 subscription row ever existed; V2 is not the active card).
+  subscriptionSharePct: 0,
   internalAppOwnerUserIds: [
     // Populate with civitai team userIds before going live. Empty for
     // now — none of the load-bearing paths read this list yet, but the
@@ -162,6 +181,7 @@ export const RATE_CARD_V2: RateCard = {
  *
  * `spendSharePct` is carried at 0% on V3 — V3 predates the spend flow and
  * stamped only purchase rows. The spend flow (W3 flow A) ships under V4.
+ * `subscriptionSharePct` is likewise 0% — flow C ships under V5.
  */
 export const RATE_CARD_V3: RateCard = {
   version: 'v3',
@@ -177,6 +197,7 @@ export const RATE_CARD_V3: RateCard = {
     viewer_global: 0,
   },
   spendSharePct: 0,
+  subscriptionSharePct: 0,
   internalAppOwnerUserIds: [
     // Same as V2 — populate with civitai team userIds before going live.
   ],
@@ -233,13 +254,76 @@ export const RATE_CARD_V4: RateCard = {
   },
   // PLACEHOLDER 5% platform-funded bounty — see the doc block above.
   spendSharePct: 5,
+  // Net-new subscription dimension (W3 flow C). 0% on V4 — behavior-
+  // preserving (V4 stamped only spend + purchase rows; flow C ships under
+  // V5). A percentage change is a new card, not an edit to V4.
+  subscriptionSharePct: 0,
   internalAppOwnerUserIds: [
     // Same as V3 — populate with civitai team userIds before going live.
   ],
   effectiveFrom: '2026-06-18',
 };
 
-export const ACTIVE_RATE_CARD: RateCard = RATE_CARD_V4;
+/**
+ * V5 — adds the W3 flow C MEMBERSHIP / subscription rev-share
+ * (`subscriptionSharePct`).
+ *
+ * Carries V4's purchase percentages (15/15/25/0/0) AND its spend bounty
+ * (5%) UNCHANGED, and sets `subscriptionSharePct` to the FIRST non-zero
+ * subscription rate. This is the first card emitted for the subscription
+ * flow: a block-initiated membership purchase now accrues an author share
+ * on each paid invoice.
+ *
+ * ⚠️ PLACEHOLDER RATE — `subscriptionSharePct: 15` mirrors the
+ *    publisher-purchase floor (15%) as a CONSERVATIVE STARTING DEFAULT
+ *    pending monetization sign-off. Recurring revenue is structurally
+ *    different (LTV-weighted, renewals compound), so leadership may choose
+ *    a DIFFERENT number than one-shot purchase — this is flagged for sign-
+ *    off, not a final figure. Raising is politically easier than lowering
+ *    after a public announcement, so this starts at (not above) the
+ *    purchase floor.
+ *
+ * ACCOUNTING MODEL — same THREE-WAY split as a Buzz purchase (NOT the
+ *    platform-funded bounty model of spend): a membership payment is a real
+ *    card transaction. provider_fee comes off the top, the author share is
+ *    `subscriptionSharePct` % of the NET (gross - fee), the platform keeps
+ *    the remainder. The three-way conservation invariant
+ *    (fee + platform + author = gross) holds and is enforced by the
+ *    migration's CHECK (entry_type='charge').
+ *
+ * RENEWALS-PAY POLICY (⚠️ FLAGGED for sign-off, scope §C/E#3): one
+ *    attribution row per PAID invoice means renewals (subscription_cycle)
+ *    accrue a share just like the initial purchase (subscription_create).
+ *    This is the default. A "first-invoice-only" policy is a service-level
+ *    gate (write only on subscription_create) — no card change. Recurring
+ *    share has real LTV / clawback implications (a refund or downgrade
+ *    proration of a previously paid-out period claws back via a negative
+ *    entry_type='clawback' row).
+ *
+ * When the signed-off rate lands, add a V6 with the agreed % and leave V5
+ * in place for the rows stamped under it (cards are immutable).
+ */
+export const RATE_CARD_V5: RateCard = {
+  version: 'v5',
+  publisherSharePctByScope: {
+    // Carried from V4 verbatim — a percentage change is a new card.
+    per_model_install: 15,
+    publisher_all_my_models: 15,
+    viewer_personal: 25,
+    platform_default: 0,
+    viewer_global: 0,
+  },
+  // Carried from V4 verbatim.
+  spendSharePct: 5,
+  // PLACEHOLDER 15% subscription rev-share — see the doc block above.
+  subscriptionSharePct: 15,
+  internalAppOwnerUserIds: [
+    // Same as V4 — populate with civitai team userIds before going live.
+  ],
+  effectiveFrom: '2026-06-18',
+};
+
+export const ACTIVE_RATE_CARD: RateCard = RATE_CARD_V5;
 
 /**
  * Result of running a (gross, fee, scope) tuple through the active rate
@@ -373,5 +457,72 @@ export function computeSpendShare({
     rateCardVersion: rateCard.version,
     spendSharePct: sharePct,
     appOwnerShareCents,
+  };
+}
+
+/**
+ * Result of running a (gross, fee, owner) tuple through the active card's
+ * SUBSCRIPTION dimension (W3 flow C). A membership payment is a real card
+ * transaction split three ways (like a Buzz purchase), so this carries the
+ * same fee / platform / author fields as RateCardSplit. The sum of the
+ * three `*_cents` fields equals the gross — the migration's CHECK enforces
+ * this for entry_type='charge' rows.
+ */
+export type SubscriptionShareResult = {
+  rateCardVersion: string;
+  subscriptionSharePct: number;
+  appOwnerShareCents: number;
+  platformShareCents: number;
+  providerFeeCents: number;
+};
+
+/**
+ * Compute the publisher / platform / provider-fee split for a single
+ * block-initiated MEMBERSHIP payment (one paid invoice).
+ *
+ * Same order of operations as computeRateCardSplit: provider fee off the
+ * top, the author share is `subscriptionSharePct` % of the NET
+ * (gross - fee), the platform gets the remainder. The three-way sum always
+ * equals the gross by construction (the platform absorbs the sub-cent floor
+ * remainder), so the migration's conservation CHECK holds.
+ *
+ * Special cases (mirror computeRateCardSplit):
+ *   - `isSelfPurchase` (subscriber == app owner) → author share 0. Caller
+ *     sets status='voided', voided_reason='self_purchase'.
+ *   - `appOwnerUserId` ∈ `internalAppOwnerUserIds` → author share 0
+ *     (internal civitai app — same legal entity on both sides).
+ *
+ * Defensive: a provider fee greater than gross (refund/dispute edge) is
+ * clamped to gross → author 0, platform 0 — the platform absorbs the loss.
+ */
+export function computeSubscriptionShare({
+  rateCard = ACTIVE_RATE_CARD,
+  grossCents,
+  providerFeeCents,
+  isSelfPurchase,
+  appOwnerUserId,
+}: {
+  rateCard?: RateCard;
+  grossCents: number;
+  providerFeeCents: number;
+  isSelfPurchase: boolean;
+  appOwnerUserId: number;
+}): SubscriptionShareResult {
+  const safeGross = Math.max(0, Math.floor(grossCents));
+  const safeFee = Math.max(0, Math.min(safeGross, Math.floor(providerFeeCents)));
+  const net = safeGross - safeFee;
+
+  const isInternal = rateCard.internalAppOwnerUserIds.includes(appOwnerUserId);
+  const sharePct =
+    isSelfPurchase || isInternal ? 0 : rateCard.subscriptionSharePct ?? 0;
+  const appOwnerShareCents = Math.floor((net * sharePct) / 100);
+  const platformShareCents = net - appOwnerShareCents;
+
+  return {
+    rateCardVersion: rateCard.version,
+    subscriptionSharePct: sharePct,
+    appOwnerShareCents,
+    platformShareCents,
+    providerFeeCents: safeFee,
   };
 }

--- a/src/server/services/stripe.service.ts
+++ b/src/server/services/stripe.service.ts
@@ -957,128 +957,154 @@ export const manageInvoicePaid = async (invoice: Stripe.Invoice) => {
     // attribution was stamped onto the subscription metadata at checkout
     // (createSubscribeSession). Read it back and write ONE attribution row
     // per PAID invoice (RENEWALS-PAY: subscription_create AND
-    // subscription_cycle both accrue a share — flagged for sign-off; gate
-    // to subscription_create here for a first-only policy).
+    // subscription_cycle both accrue a share).
+    //
+    // Proration policy: gate the attribution write to billing_reason IN
+    // (subscription_create, subscription_cycle) — EXCLUDE subscription_update.
+    // A mid-cycle upgrade emits a `subscription_update` PRORATION invoice
+    // (the upgrade delta for the rest of the period) AND, at the period
+    // boundary, a `subscription_cycle` invoice for the full new price. The
+    // UNIQUE(invoice_id, app_block_id) only dedups the SAME invoice; the
+    // proration and the cycle invoice are DISTINCT invoice_ids covering
+    // OVERLAPPING value, so attributing both would over-accrue (proration
+    // delta + full cycle) for that period. We therefore do NOT separately
+    // attribute proration deltas — the period's subscription_cycle invoice
+    // captures its value. (The buzz grant / recordMembershipPaymentReward /
+    // ref_code logic above is intentionally LEFT firing for subscription_update
+    // so an upgrade still grants Buzz / records the membership reward; only
+    // this attribution write is gated.) Revisit if per-period proration
+    // sharing is ever wanted — the alternative is a per-(subscription_id,
+    // period_start) dedup that attributes the delta and reconciles against the
+    // cycle invoice instead of skipping subscription_update.
     //
     // Best-effort: a failed attribution write MUST NOT break membership
     // provisioning (the buzz grant + reward above already happened). The
     // (invoice_id, app_block_id) UNIQUE makes a webhook retry idempotent.
     // -----------------------------------------------------------------
-    try {
-      const blockAttribution = extractAttribution(
-        subscriptionMetadata as Record<string, string | number | null | undefined>
-      );
-      let resolvedAttribution = blockAttribution;
-      let attributionSource: 'metadata' | 'fallback-session' | 'none' = blockAttribution
-        ? 'metadata'
-        : 'none';
+    const ATTRIBUTABLE_BILLING_REASONS = ['subscription_create', 'subscription_cycle'] as const;
+    const isAttributableBillingReason =
+      !!invoice.billing_reason &&
+      (ATTRIBUTABLE_BILLING_REASONS as readonly string[]).includes(invoice.billing_reason);
+    // $0 invoices (proration fully covered by credit balance, etc.) carry no
+    // NEW money to share — skip the write to avoid creating benign-but-noisy
+    // pending zero-everything rows that the confirm-pending cron promotes
+    // forever. amount_paid is the correct basis (you only share new money).
+    const grossUsdCents = invoice.amount_paid ?? invoice.total ?? 0;
+    if (isAttributableBillingReason && grossUsdCents > 0) {
+      try {
+        const blockAttribution = extractAttribution(
+          subscriptionMetadata as Record<string, string | number | null | undefined>
+        );
+        let resolvedAttribution = blockAttribution;
+        let attributionSource: 'metadata' | 'fallback-session' | 'none' = blockAttribution
+          ? 'metadata'
+          : 'none';
 
-      // Webhook-ordering race (same as ref_code): invoice.paid for a
-      // brand-new subscription can land before checkout.session.completed
-      // copied the metadata onto the Subscription. Fall back to the parent
-      // Checkout Session's metadata so the FIRST invoice isn't lost.
-      if (!resolvedAttribution && invoice.subscription) {
-        const subId =
-          typeof invoice.subscription === 'string'
-            ? invoice.subscription
-            : invoice.subscription.id;
-        try {
-          const stripeClient = await getServerStripe();
-          if (stripeClient) {
-            const sessions = await stripeClient.checkout.sessions.list({
-              subscription: subId,
-              limit: 1,
-            });
-            const sessionMeta = sessions.data[0]?.metadata ?? undefined;
-            const fromSession = extractAttribution(
-              sessionMeta as Record<string, string | number | null | undefined> | undefined
-            );
-            if (fromSession) {
-              resolvedAttribution = fromSession;
-              attributionSource = 'fallback-session';
-            }
-          }
-        } catch (err) {
-          handleLogError(err as Error);
-        }
-      }
-
-      if (resolvedAttribution) {
-        // Pull the actual Stripe fee off the charge's balance transaction
-        // (same as the buzz-purchase path). Best-effort: a 0 fee just means
-        // the publisher gets a slightly higher (net===gross) share.
-        let providerFeeCents = 0;
-        if (stripeChargeId) {
+        // Webhook-ordering race (same as ref_code): invoice.paid for a
+        // brand-new subscription can land before checkout.session.completed
+        // copied the metadata onto the Subscription. Fall back to the parent
+        // Checkout Session's metadata so the FIRST invoice isn't lost.
+        if (!resolvedAttribution && invoice.subscription) {
+          const subId =
+            typeof invoice.subscription === 'string'
+              ? invoice.subscription
+              : invoice.subscription.id;
           try {
             const stripeClient = await getServerStripe();
             if (stripeClient) {
-              const charge = await stripeClient.charges.retrieve(stripeChargeId, {
-                expand: ['balance_transaction'],
+              const sessions = await stripeClient.checkout.sessions.list({
+                subscription: subId,
+                limit: 1,
               });
-              const balanceTx = charge.balance_transaction;
-              if (balanceTx && typeof balanceTx !== 'string') {
-                providerFeeCents = balanceTx.fee ?? 0;
+              const sessionMeta = sessions.data[0]?.metadata ?? undefined;
+              const fromSession = extractAttribution(
+                sessionMeta as Record<string, string | number | null | undefined> | undefined
+              );
+              if (fromSession) {
+                resolvedAttribution = fromSession;
+                attributionSource = 'fallback-session';
               }
             }
-          } catch {
-            // best-effort; leave fee at 0
+          } catch (err) {
+            handleLogError(err as Error);
           }
         }
 
-        const line = invoice.lines.data.find((l) => l.price?.product === billedProduct?.id);
-        const periodStart = line?.period?.start
-          ? new Date(line.period.start * 1000)
-          : null;
-        const periodEnd = line?.period?.end ? new Date(line.period.end * 1000) : null;
+        if (resolvedAttribution) {
+          // Pull the actual Stripe fee off the charge's balance transaction
+          // (same as the buzz-purchase path). Best-effort: a 0 fee just means
+          // the publisher gets a slightly higher (net===gross) share.
+          let providerFeeCents = 0;
+          if (stripeChargeId) {
+            try {
+              const stripeClient = await getServerStripe();
+              if (stripeClient) {
+                const charge = await stripeClient.charges.retrieve(stripeChargeId, {
+                  expand: ['balance_transaction'],
+                });
+                const balanceTx = charge.balance_transaction;
+                if (balanceTx && typeof balanceTx !== 'string') {
+                  providerFeeCents = balanceTx.fee ?? 0;
+                }
+              }
+            } catch {
+              // best-effort; leave fee at 0
+            }
+          }
 
-        const { recordSubscriptionAttribution } = await import(
-          '~/server/services/blocks/buzz-attribution.service'
-        );
-        await recordSubscriptionAttribution({
-          userId: user.id,
-          buzzAmount: billedProductMeta.monthlyBuzz ?? 0,
-          buzzType: (billedProductMeta.buzzType as string) ?? 'yellow',
-          usdAmountCents: invoice.amount_paid ?? invoice.total ?? 0,
-          providerFeeCents,
-          paymentProvider: 'stripe',
-          invoiceId: invoice.id,
-          subscriptionId:
-            typeof invoice.subscription === 'string'
-              ? invoice.subscription
-              : invoice.subscription?.id ?? null,
-          billingReason: invoice.billing_reason ?? null,
-          periodStart,
-          periodEnd,
-          tier: billedProductMeta.tier ?? null,
-          attribution: resolvedAttribution,
-        });
+          const line = invoice.lines.data.find((l) => l.price?.product === billedProduct?.id);
+          const periodStart = line?.period?.start ? new Date(line.period.start * 1000) : null;
+          const periodEnd = line?.period?.end ? new Date(line.period.end * 1000) : null;
 
+          const { recordSubscriptionAttribution } = await import(
+            '~/server/services/blocks/buzz-attribution.service'
+          );
+          await recordSubscriptionAttribution({
+            userId: user.id,
+            buzzAmount: billedProductMeta.monthlyBuzz ?? 0,
+            buzzType: (billedProductMeta.buzzType as string) ?? 'yellow',
+            usdAmountCents: grossUsdCents,
+            providerFeeCents,
+            paymentProvider: 'stripe',
+            invoiceId: invoice.id,
+            subscriptionId:
+              typeof invoice.subscription === 'string'
+                ? invoice.subscription
+                : invoice.subscription?.id ?? null,
+            billingReason: invoice.billing_reason ?? null,
+            periodStart,
+            periodEnd,
+            tier: billedProductMeta.tier ?? null,
+            attribution: resolvedAttribution,
+          });
+
+          logToAxiom(
+            {
+              name: 'invoice-paid-block-attribution',
+              refereeId: user.id,
+              invoiceId: invoice.id,
+              appId: resolvedAttribution.appId,
+              appBlockId: resolvedAttribution.appBlockId,
+              billingReason: invoice.billing_reason,
+              source: attributionSource,
+            },
+            'webhooks'
+          ).catch(() => null);
+        }
+      } catch (attrErr) {
+        // Never fail membership provisioning on an attribution write.
         logToAxiom(
           {
             name: 'invoice-paid-block-attribution',
+            type: 'error',
             refereeId: user.id,
             invoiceId: invoice.id,
-            appId: resolvedAttribution.appId,
-            appBlockId: resolvedAttribution.appBlockId,
-            billingReason: invoice.billing_reason,
-            source: attributionSource,
+            message: 'block subscription attribution write failed',
+            error: (attrErr as Error)?.message,
           },
           'webhooks'
         ).catch(() => null);
       }
-    } catch (attrErr) {
-      // Never fail membership provisioning on an attribution write.
-      logToAxiom(
-        {
-          name: 'invoice-paid-block-attribution',
-          type: 'error',
-          refereeId: user.id,
-          invoiceId: invoice.id,
-          message: 'block subscription attribution write failed',
-          error: (attrErr as Error)?.message,
-        },
-        'webhooks'
-      ).catch(() => null);
     }
 
     // Renewals (subscription_cycle) often arrive without a paired

--- a/src/server/services/stripe.service.ts
+++ b/src/server/services/stripe.service.ts
@@ -28,6 +28,11 @@ import {
 } from './buzz.service';
 import { getOrCreateVault } from '~/server/services/vault.service';
 import { validateBuzzPurchaseAttribution } from '~/server/services/blocks/attribution-validator.service';
+import {
+  encodeAttributionMetadata,
+  extractAttribution,
+  type BlockAttribution,
+} from '~/server/schema/blocks/attribution.schema';
 import { sleep } from '~/server/utils/concurrency-helpers';
 import type { SubscriptionProductMetadata } from '~/server/schema/subscriptions.schema';
 import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions.schema';
@@ -58,9 +63,59 @@ export const createCustomer = async ({ id, email }: Schema.CreateCustomerInput) 
   }
 };
 
+/**
+ * W3 flow C FIN-1 — re-derive App Blocks membership attribution
+ * SERVER-SIDE before stamping it onto a Stripe subscription's metadata.
+ *
+ * The browser passes a `blockAttribution` bag (appId / appBlockId /
+ * blockInstanceId / scope / modelId / slotId) from the block's "Buy
+ * membership" CTA. We NEVER trust it: we run it through the SAME chokepoint
+ * the Buzz-purchase path uses (`validateBuzzPurchaseAttribution`, which
+ * resolves the cited instance AS THE BUYER, strips/corrects forged
+ * appId/scope, and drops attribution that doesn't resolve), then re-encode
+ * the SERVER-DERIVED fields for the subscription metadata.
+ *
+ * Returns a flat string-keyed metadata bag (the `block*` keys) ready to
+ * spread onto `subscription_data.metadata` / `subscriptions.update`
+ * metadata, or `null` when there's nothing valid to stamp (no attribution,
+ * or it was forged/stripped) — so the caller stamps it conditionally and a
+ * normal (non-block) membership purchase carries no block keys.
+ *
+ * This reuses the buzz validator verbatim (same resolver, same strip-on-
+ * forge, same page_* path) so model-slot AND page-surface membership CTAs
+ * are both covered with zero duplicated FIN-1 logic.
+ */
+export async function deriveSubscriptionAttributionMetadata({
+  blockAttribution,
+  sessionUserId,
+}: {
+  blockAttribution?: BlockAttribution;
+  sessionUserId: number;
+}): Promise<Record<string, string> | null> {
+  if (!blockAttribution) return null;
+  // Encode → validate (FIN-1) → decode the server-derived bag.
+  const encoded = encodeAttributionMetadata(blockAttribution);
+  if (!encoded) return null;
+  // validateBuzzPurchaseAttribution pins/asserts a `userId` too; we don't
+  // carry a client userId on the subscription bag, so the spender pin is a
+  // no-op here (the buyer is ctx.user.id, captured by the caller).
+  const validated = await validateBuzzPurchaseAttribution({
+    metadata: { ...encoded } as Record<string, unknown> & { userId?: unknown },
+    sessionUserId,
+  });
+  // Pull the SERVER-DERIVED block fields back out. If the validator stripped
+  // them (forged / non-resolving instance), extractAttribution returns null
+  // and we stamp nothing — the membership purchase proceeds un-attributed.
+  const derived = extractAttribution(
+    validated as Record<string, string | number | null | undefined>
+  );
+  return encodeAttributionMetadata(derived);
+}
+
 export const createSubscribeSession = async ({
   priceId,
   refCode,
+  blockAttribution,
   customerId,
   user,
 }: Schema.CreateSubscribeSessionInput & {
@@ -69,6 +124,14 @@ export const createSubscribeSession = async ({
 }) => {
   const stripe = await getServerStripe();
   if (!stripe) throw throwBadRequestError('Stripe is not available');
+
+  // FIN-1: re-derive the membership attribution server-side ONCE, up front,
+  // against the authenticated buyer. Stamped onto whichever Stripe path the
+  // purchase takes below (upgrade subscriptions.update OR new-sub Checkout).
+  const blockAttributionMetadata = await deriveSubscriptionAttributionMetadata({
+    blockAttribution,
+    sessionUserId: user.id,
+  });
 
   if (!customerId) {
     customerId = await createCustomer(user);
@@ -195,6 +258,17 @@ export const createSubscribeSession = async ({
       const cleanRefCode = refCode?.trim().toUpperCase();
       const sanitizedRefCode = cleanRefCode && cleanRefCode.length > 0 ? cleanRefCode : undefined;
 
+      // Upgrades skip Checkout, so the new-sub metadata stamp below doesn't
+      // apply — patch BOTH ref_code AND the FIN-1 block attribution onto the
+      // subscription metadata here, in the same update call (mirrors the
+      // ref_code pattern). The next invoice.paid (billing_reason:
+      // subscription_update / _cycle) reads it back via
+      // subscription_details.metadata → recordSubscriptionAttribution.
+      const upgradeMetadata: Record<string, string> = {
+        ...(sanitizedRefCode ? { ref_code: sanitizedRefCode } : {}),
+        ...(blockAttributionMetadata ?? {}),
+      };
+
       await stripe.subscriptions.update(subscriptionId, {
         items,
         billing_cycle_anchor: isUpgrade ? 'now' : 'unchanged',
@@ -203,7 +277,7 @@ export const createSubscribeSession = async ({
         payment_behavior: isUpgrade ? 'default_incomplete' : undefined,
         // @ts-ignore This is valid as per stripe's documentation
         discounts,
-        ...(sanitizedRefCode ? { metadata: { ref_code: sanitizedRefCode } } : {}),
+        ...(Object.keys(upgradeMetadata).length > 0 ? { metadata: upgradeMetadata } : {}),
       });
 
       if (sanitizedRefCode) {
@@ -233,6 +307,18 @@ export const createSubscribeSession = async ({
     },
   ];
 
+  // Build the metadata bag stamped onto BOTH the subscription
+  // (subscription_data.metadata → read back on every invoice.paid via
+  // subscription_details.metadata) AND the session metadata (the
+  // webhook-ordering-race fallback, mirroring ref_code). FIN-1 block
+  // attribution rides alongside ref_code. Stripe caps metadata at 50 keys /
+  // 500 chars-per-value; ref_code + the 6 block keys are well within.
+  const checkoutMetadata: Record<string, string> = {
+    ...(refCode ? { ref_code: refCode } : {}),
+    ...(blockAttributionMetadata ?? {}),
+  };
+  const hasCheckoutMetadata = Object.keys(checkoutMetadata).length > 0;
+
   const session = await stripe.checkout.sessions.create({
     customer: customerId,
     mode: 'subscription',
@@ -252,8 +338,8 @@ export const createSubscribeSession = async ({
         optional: true,
       },
     ],
-    ...(refCode
-      ? { subscription_data: { metadata: { ref_code: refCode } }, metadata: { ref_code: refCode } }
+    ...(hasCheckoutMetadata
+      ? { subscription_data: { metadata: checkoutMetadata }, metadata: checkoutMetadata }
       : {}),
   });
 
@@ -864,6 +950,136 @@ export const manageInvoicePaid = async (invoice: Stripe.Invoice) => {
         stripeChargeId,
       },
     }).catch(handleLogError);
+
+    // -----------------------------------------------------------------
+    // W3 flow C — App Blocks MEMBERSHIP attribution. If this membership
+    // purchase was initiated from inside a block, the FIN-1-derived block
+    // attribution was stamped onto the subscription metadata at checkout
+    // (createSubscribeSession). Read it back and write ONE attribution row
+    // per PAID invoice (RENEWALS-PAY: subscription_create AND
+    // subscription_cycle both accrue a share — flagged for sign-off; gate
+    // to subscription_create here for a first-only policy).
+    //
+    // Best-effort: a failed attribution write MUST NOT break membership
+    // provisioning (the buzz grant + reward above already happened). The
+    // (invoice_id, app_block_id) UNIQUE makes a webhook retry idempotent.
+    // -----------------------------------------------------------------
+    try {
+      const blockAttribution = extractAttribution(
+        subscriptionMetadata as Record<string, string | number | null | undefined>
+      );
+      let resolvedAttribution = blockAttribution;
+      let attributionSource: 'metadata' | 'fallback-session' | 'none' = blockAttribution
+        ? 'metadata'
+        : 'none';
+
+      // Webhook-ordering race (same as ref_code): invoice.paid for a
+      // brand-new subscription can land before checkout.session.completed
+      // copied the metadata onto the Subscription. Fall back to the parent
+      // Checkout Session's metadata so the FIRST invoice isn't lost.
+      if (!resolvedAttribution && invoice.subscription) {
+        const subId =
+          typeof invoice.subscription === 'string'
+            ? invoice.subscription
+            : invoice.subscription.id;
+        try {
+          const stripeClient = await getServerStripe();
+          if (stripeClient) {
+            const sessions = await stripeClient.checkout.sessions.list({
+              subscription: subId,
+              limit: 1,
+            });
+            const sessionMeta = sessions.data[0]?.metadata ?? undefined;
+            const fromSession = extractAttribution(
+              sessionMeta as Record<string, string | number | null | undefined> | undefined
+            );
+            if (fromSession) {
+              resolvedAttribution = fromSession;
+              attributionSource = 'fallback-session';
+            }
+          }
+        } catch (err) {
+          handleLogError(err as Error);
+        }
+      }
+
+      if (resolvedAttribution) {
+        // Pull the actual Stripe fee off the charge's balance transaction
+        // (same as the buzz-purchase path). Best-effort: a 0 fee just means
+        // the publisher gets a slightly higher (net===gross) share.
+        let providerFeeCents = 0;
+        if (stripeChargeId) {
+          try {
+            const stripeClient = await getServerStripe();
+            if (stripeClient) {
+              const charge = await stripeClient.charges.retrieve(stripeChargeId, {
+                expand: ['balance_transaction'],
+              });
+              const balanceTx = charge.balance_transaction;
+              if (balanceTx && typeof balanceTx !== 'string') {
+                providerFeeCents = balanceTx.fee ?? 0;
+              }
+            }
+          } catch {
+            // best-effort; leave fee at 0
+          }
+        }
+
+        const line = invoice.lines.data.find((l) => l.price?.product === billedProduct?.id);
+        const periodStart = line?.period?.start
+          ? new Date(line.period.start * 1000)
+          : null;
+        const periodEnd = line?.period?.end ? new Date(line.period.end * 1000) : null;
+
+        const { recordSubscriptionAttribution } = await import(
+          '~/server/services/blocks/buzz-attribution.service'
+        );
+        await recordSubscriptionAttribution({
+          userId: user.id,
+          buzzAmount: billedProductMeta.monthlyBuzz ?? 0,
+          buzzType: (billedProductMeta.buzzType as string) ?? 'yellow',
+          usdAmountCents: invoice.amount_paid ?? invoice.total ?? 0,
+          providerFeeCents,
+          paymentProvider: 'stripe',
+          invoiceId: invoice.id,
+          subscriptionId:
+            typeof invoice.subscription === 'string'
+              ? invoice.subscription
+              : invoice.subscription?.id ?? null,
+          billingReason: invoice.billing_reason ?? null,
+          periodStart,
+          periodEnd,
+          tier: billedProductMeta.tier ?? null,
+          attribution: resolvedAttribution,
+        });
+
+        logToAxiom(
+          {
+            name: 'invoice-paid-block-attribution',
+            refereeId: user.id,
+            invoiceId: invoice.id,
+            appId: resolvedAttribution.appId,
+            appBlockId: resolvedAttribution.appBlockId,
+            billingReason: invoice.billing_reason,
+            source: attributionSource,
+          },
+          'webhooks'
+        ).catch(() => null);
+      }
+    } catch (attrErr) {
+      // Never fail membership provisioning on an attribution write.
+      logToAxiom(
+        {
+          name: 'invoice-paid-block-attribution',
+          type: 'error',
+          refereeId: user.id,
+          invoiceId: invoice.id,
+          message: 'block subscription attribution write failed',
+          error: (attrErr as Error)?.message,
+        },
+        'webhooks'
+      ).catch(() => null);
+    }
 
     // Renewals (subscription_cycle) often arrive without a paired
     // subscription.updated event, so the session/multiplier caches won't be

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -99,6 +99,10 @@ export function newBlockSpendAttributionId(): string {
   return `bsa_${newUlid()}`;
 }
 
+export function newBlockSubscriptionAttributionId(): string {
+  return `bsu_${newUlid()}`;
+}
+
 export function newAppUserScopeGrantId(): string {
   return `augr_${newUlid()}`;
 }


### PR DESCRIPTION
## #2629 is now TRACK-ONLY

Records membership attribution **events + gross**, and **defers the author share to a payout-time backpay** at the signed-off rate. **No placeholder rate is baked into the ledger.**

Previously this PR computed + stored an `author_share_cents` at the placeholder `RATE_CARD_V5.subscriptionSharePct` (15%), version-stamped immutable. Committing that before monetization sign-off would lock those rows to the placeholder rate (the immutability doctrine pays each row out under its **stamped** snapshot forever). Nothing reads this table for payout yet, so this rework purely removes a placeholder-rate liability from the ledger.

### The write shape (`recordSubscriptionAttribution` + `manageInvoicePaid`)

A paid `subscription_create` / `subscription_cycle` invoice with block attribution writes **one** row per `(invoice_id, app_block_id)`:

| field | value |
|---|---|
| `status` | `'tracked'` — new "share-pending, not yet computed/payable" state |
| `app_owner_share_cents` | `0` |
| `subscription_share_pct` | `0` (no rate applied) |
| `rate_card_version` | `'unrated'` (sentinel — no version stamped) |
| `gross_value_cents` | `amount_paid` (the money basis) |
| `provider_fee_cents` | real Stripe fee (so the backpay computes `net = gross − fee`) |
| `platform_share_cents` | `net` (= gross − fee) |

`computeSubscriptionShare` is **no longer called at write time**. The author share is computed **later, at payout**.

**Conservation still holds** with `author = 0`: the SQL CHECK is `provider_fee + platform + author = gross` → `fee + net + 0 = gross`. ✓

### Refund → void (simplified)

With `author = 0` there is no debt, so there is **no negative-clawback** to write. `voidSubscriptionAttributionsForInvoice` now simply sets `status='voided'` on the tracked row so a future backpay never computes a share for a refunded/disputed purchase. The synthetic-invoice-id carry-forward clawback machinery is removed from the subscription path. (A paid-out clawback belongs to the future payout slice, written against the rate it actually paid.)

### Unchanged (not regressed)

- **FIN-1** server re-derivation (forge-safe app/author/scope resolution via the same `validateBuzzPurchaseAttribution` chokepoint).
- **Idempotency**: `UNIQUE(invoice_id, app_block_id)` + P2002 → webhook retry is a no-op.
- **billing_reason gate**: `IN ('subscription_create','subscription_cycle')` — proration (`subscription_update`) writes **no** attribution row.
- **$0-gross skip**.
- **Best-effort isolation** in `manageInvoicePaid` — a failed attribution write never breaks membership provisioning.

### Migration (manual-apply — DB rule #8, table not yet on prod)

`block_subscription_attribution` migration `.sql` updated (kept manual-apply): add `'tracked'` to the status CHECK enum; default `status='tracked'`, `rate_card_version='unrated'`, `subscription_share_pct=0`, `app_owner_share_cents=0`. Prisma schema model updated to match.

### Rate card

`RATE_CARD_V5.subscriptionSharePct: 15` **definition is kept** — it is the placeholder the eventual payout/backpay will apply, **pending sign-off** — and is documented as **applied at payout, not at attribution**. `computeSubscriptionShare` is retained for the payout rail to call.

## Backpay contract (documented here — not built in this PR)

The future payout rail (**Slice 4**) will:
1. read `status='tracked'` subscription rows,
2. compute `author_share = net × <signed-off subscriptionSharePct>` (net = gross − fee, both carried on the row, so the computation is exact),
3. transition them to a computed/confirmed state, and
4. disburse.

i.e. a clean retroactive **backpay at the real rate** once monetization signs off.

> Note: the **#2627** (buzz-SPEND) retrofit to the same track-only model is a **separate pending decision**.

## Tests (vitest)

54 green across the 4 touched suites (`subscription-attribution.service`, `subscription-attribution.fin1`, `rate-card`, `stripe.manageInvoicePaid.attribution`):

- paid `subscription_cycle`/`subscription_create` → `status='tracked'` row, `author=0`, gross+fee recorded, **no** rate stamped (`'unrated'`), `platform=net` (conservation holds).
- **No rate applied at write**: `computeSubscriptionShare` is asserted **not called**; author is 0 regardless of the (non-zero) active rate card.
- FIN-1 still resolves app/author server-side (forge-safe).
- Idempotency, billing_reason gate (proration → no row), $0-skip still hold.
- Refund → the tracked row is **voided**, no clawback / no negative row.
- **Mutation-check**: re-applying the 15% at write fails the author=0 / tracked tests (5 fail) — the track-only contract is genuinely enforced.

Typecheck (`tsc-files` on touched files): clean (only a pre-existing `baseUrl` deprecation warning from tsconfig).
