### PR TITLE
perf(app-blocks): scope membership-attribution race fallback to subscription_create

### DIFF
--- a/src/server/services/__tests__/stripe.manageInvoicePaid.attribution.test.ts
+++ b/src/server/services/__tests__/stripe.manageInvoicePaid.attribution.test.ts
@@ -239,3 +239,55 @@ describe('manageInvoicePaid — attribution write payload (no regression)', () =
     expect(mockCreateBuzzTransaction).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('manageInvoicePaid — Checkout-Session race fallback is scoped to subscription_create', () => {
+  // Returns a stripe-client mock whose checkout.sessions.list is a tracked spy
+  // resolving to `sessionMeta`, so a test can assert whether the fallback ran.
+  function stripeClientWithSession(sessionMeta: Record<string, string> | undefined) {
+    const list = vi.fn().mockResolvedValue({ data: sessionMeta ? [{ metadata: sessionMeta }] : [] });
+    mockGetServerStripe.mockResolvedValue({
+      checkout: { sessions: { list } },
+      charges: { retrieve: vi.fn() },
+    });
+    return list;
+  }
+
+  it('subscription_create with empty subscription metadata → falls back to the Checkout Session (race preserved)', async () => {
+    const list = stripeClientWithSession({ ...ATTRIBUTION_BAG });
+    await manageInvoicePaid(
+      fakeInvoice({
+        billing_reason: 'subscription_create',
+        subscription_details: { metadata: {} },
+      } as Partial<Stripe.Invoice>)
+    );
+    // The attribution race fallback fires for the FIRST invoice and recovers
+    // the block attribution from the parent Checkout Session.
+    expect(mockRecordSubscriptionAttribution).toHaveBeenCalledTimes(1);
+    expect(mockRecordSubscriptionAttribution.mock.calls[0][0].attribution.appId).toBe(APP_ID);
+    // Two list calls here: the unrelated ref_code fallback (no ref_code present)
+    // AND the attribution fallback. The cycle test below shows the attribution
+    // one is gone on renewals — i.e. exactly one fewer call.
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it('subscription_cycle with empty subscription metadata → attribution fallback is skipped (trim)', async () => {
+    const list = stripeClientWithSession({ ...ATTRIBUTION_BAG });
+    await manageInvoicePaid(
+      fakeInvoice({
+        billing_reason: 'subscription_cycle',
+        subscription_details: { metadata: {} },
+      } as Partial<Stripe.Invoice>)
+    );
+    // A real block renewal always carries the block keys (copied onto the
+    // subscription at creation), so an empty-metadata renewal genuinely has no
+    // attribution. The trim skips the Checkout-Session lookup → NO row recovered
+    // even though the session DID have block metadata.
+    expect(mockRecordSubscriptionAttribution).not.toHaveBeenCalled();
+    // Only ONE list call remains: the pre-existing ref_code fallback. The
+    // attribution fallback's extra round-trip is trimmed on renewals (was 2 in
+    // the create case above).
+    expect(list).toHaveBeenCalledTimes(1);
+    // Membership still provisioned.
+    expect(mockCreateBuzzTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/stripe.service.ts
+++ b/src/server/services/stripe.service.ts
@@ -1004,7 +1004,20 @@ export const manageInvoicePaid = async (invoice: Stripe.Invoice) => {
         // brand-new subscription can land before checkout.session.completed
         // copied the metadata onto the Subscription. Fall back to the parent
         // Checkout Session's metadata so the FIRST invoice isn't lost.
-        if (!resolvedAttribution && invoice.subscription) {
+        //
+        // SCOPED to subscription_create: the race only exists for a
+        // subscription's FIRST invoice. By the time a renewal
+        // (subscription_cycle) fires, the metadata was stamped onto the
+        // Subscription at creation and is reliably present in
+        // subscription_details.metadata — so a renewal that resolves no
+        // attribution genuinely has none (a non-block membership), and the
+        // Checkout-Session lookup would be a guaranteed-empty Stripe API call
+        // on every renewal. Gating it here avoids that per-renewal round-trip.
+        if (
+          !resolvedAttribution &&
+          invoice.subscription &&
+          invoice.billing_reason === 'subscription_create'
+        ) {
           const subId =
             typeof invoice.subscription === 'string'
               ? invoice.subscription


### PR DESCRIPTION
## What
Follow-up to #2629. The new subscription-attribution write in `manageInvoicePaid` runs a `checkout.sessions.list` lookup to recover block attribution when `subscription_details.metadata` is empty — guarding the Stripe webhook-ordering race where `invoice.paid` lands before `checkout.session.completed` copies the metadata onto the Subscription.

That race **only exists for a subscription's first invoice**. On renewals (`subscription_cycle`) the metadata was stamped at creation and is reliably present, so an empty-metadata renewal genuinely has no block attribution — the session lookup is a **guaranteed-empty Stripe API call on every renewal**. Gating the fallback to `billing_reason === 'subscription_create'` removes that per-renewal round-trip.

## Why it's safe
- **Track-only / no money path** — this is the W3 attribution write that records a `status='tracked'` row; it never moves money.
- **First invoice still recovers attribution** via the fallback (race preserved).
- A real block renewal always carries the block keys (copied onto the subscription at creation), so skipping the session lookup on renewals loses nothing real.
- Does **not** touch the pre-existing `ref_code` fallback (which has the same shape but is out of scope — changing it would alter referral logic).

## Verification
Stripe docs confirmed (`apiVersion: 2022-11-15`): `subscription_create` is the first-invoice `billing_reason` on this API version, `subscription_data.metadata` propagates to `invoice.subscription_details.metadata`, and event delivery order is not guaranteed (hence the fallback). Added 2 tests (create still falls back / cycle is trimmed); full `manageInvoicePaid` attribution suite **9/9 green** via the node-only vitest project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)