### PR TITLE
fix(blocks): correct handler import in v1 submit-version test (unblocks PR-preview typecheck)

### DIFF
--- a/src/tests/api/v1/blocks/submit-version.test.ts
+++ b/src/tests/api/v1/blocks/submit-version.test.ts
@@ -92,7 +92,7 @@ vi.mock('~/server/services/blocks/publish-request.service', () => ({
 // The schema module is real (we want its actual validation), but it pulls only
 // zod — safe to load.
 
-import handler from '../submit-version';
+import handler from '~/pages/api/v1/blocks/submit-version';
 
 // Personal-access (user-type) key: `getSessionFromBearerToken` sets
 // subject = { type: 'apiKey' } when the ApiKey row has clientId == null.


### PR DESCRIPTION
## Problem
The `typecheck` task fails on **every** PR-preview build on `main`:

```
src/tests/api/v1/blocks/submit-version.test.ts(95,21): error TS2307:
Cannot find module '../submit-version' or its corresponding type declarations.
```

#2626 moved this test from `src/pages/api/v1/blocks/` to `src/tests/api/v1/blocks/` but left its handler import as the old relative `../submit-version` — which now resolves to the non-existent `src/tests/api/v1/submit-version`. The handler actually lives at `src/pages/api/v1/blocks/submit-version.ts`.

The PR-preview image build transpiles without full type-checking, so it built fine — but the separate `typecheck` task (`tsc --noEmit`) fails, marking `preview / deploy` red on unrelated PRs (e.g. #2629, #2630).

## Fix
Use the `~/pages/api/...` alias, matching the sibling `src/tests/api/blocks/submit-version.test.ts` and every other `src/tests/api` handler test. One line, no behavior change.

## Verification
`vitest run src/tests/api/v1/blocks/submit-version.test.ts` → **14/14 pass** with the corrected import resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)