### PR TITLE
test(blocks): fix stale getFeaturedBlocks assertion (page-only launch-gate arg)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
+++ b/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
@@ -250,12 +250,16 @@ describe('blocks.getFeaturedBlocks — anon-capable, dark behind the flag (F-E E
     const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
     const result = await caller.getFeaturedBlocks({ limit: 12 });
     expect(result).toEqual({ items: featured });
-    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12);
+    // PAGE-ONLY LAUNCH GATE (#2622): a non-mod/anon caller passes launchOnly=true
+    // so the featured rail carries launch (page) apps only.
+    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12, true);
   });
 
-  it('moderator (the live state today): served', async () => {
+  it('moderator (the live state today): served — sees ALL featured apps (launchOnly=false)', async () => {
     const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
     await caller.getFeaturedBlocks({ limit: 12 });
     expect(mockGetFeaturedBlocks).toHaveBeenCalledTimes(1);
+    // Mods bypass the page-only launch gate → launchOnly=false (all apps).
+    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12, false);
   });
 });


### PR DESCRIPTION
## Problem
`src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts` has one failing test on `main`:

```
blocks.getFeaturedBlocks … anon WITH the flag granted (lit path)
AssertionError: expected "vi.fn()" to be called with arguments: [ 12 ]
```

The page-only launch gate (#2622) changed the router to call `BlockRegistry.getFeaturedBlocks(limit, launchOnly)` — a second `launchOnly` arg (`!ctx.user?.isModerator`) so the non-mod featured rail carries launch (page) apps only. The test still asserted the old single-arg signature `toHaveBeenCalledWith(12)`.

It surfaced as red on PR previews' `unit-tests` task (which is report-only / non-blocking, so it had been silently failing on `main`). The `dbRead`-mock log line in the output is unrelated fire-and-forget noise — the real failure is this assertion.

## Fix
Assert the real two-arg signature, and make the test actually cover the launch gate:
- anon/non-mod → `getFeaturedBlocks(12, true)` (launch/page apps only)
- mod → `getFeaturedBlocks(12, false)` (all apps)

## Verification
`vitest run src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts` → **12/12 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)