### PR TITLE
feat(metrics): flag-gated v2 read source for entity metrics (default OFF)

### DIFF
--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -13,6 +13,12 @@ export enum FLIPT_FEATURE_FLAGS {
   // cache (MetricService) instead of the legacy in-app `entitymetric:*` cache.
   // Default OFF — reversible kill switch for the metrics-source cutover.
   IMAGE_METRICS_FROM_WATCHER = 'image-metrics-from-watcher',
+  // When ON, the entity-metric read path pulls per-day totals from the
+  // already-FINAL read VIEW `entityMetricDailyAgg_v2` (no argMax dedup) instead
+  // of the ReplacingMergeTree `entityMetricDailyAgg_new` (which needs argMax).
+  // Default OFF — reversible kill switch; merging/deploying is a no-op until the
+  // flag flips, and flipping back instantly restores the legacy source.
+  METRICS_AGG_V2_READ = 'metrics-agg-v2-read',
   FEED_POST_FILTER = 'feed-fetch-filter-in-post',
   REDIS_CLUSTER_ENHANCED_FAILOVER = 'redis-cluster-enhanced-failover',
 
@@ -385,6 +391,53 @@ export function isFliptSync(
 
 export async function ensureFliptInitialized(): Promise<void> {
   await FliptSingleton.getInstance();
+}
+
+// Entity-metric read source, gated by METRICS_AGG_V2_READ. OFF (default) reads
+// the ReplacingMergeTree `entityMetricDailyAgg_new` which needs per-day argMax
+// dedup; ON reads the already-FINAL view `entityMetricDailyAgg_v2` directly.
+// Single source of truth shared by every read site (MetricService provider +
+// the search-index / populate / metric-helper queries) so the cutover is one
+// flag flip everywhere.
+export type EntityMetricAggSource = { table: string; needsArgMaxDedup: boolean };
+
+const ENTITY_METRIC_AGG_LEGACY: EntityMetricAggSource = {
+  table: 'entityMetricDailyAgg_new',
+  needsArgMaxDedup: true,
+};
+const ENTITY_METRIC_AGG_V2: EntityMetricAggSource = {
+  table: 'entityMetricDailyAgg_v2',
+  needsArgMaxDedup: false,
+};
+
+export async function getEntityMetricAggSource(): Promise<EntityMetricAggSource> {
+  const useV2 = await getFliptBoolean(FLIPT_FEATURE_FLAGS.METRICS_AGG_V2_READ);
+  return useV2 ? ENTITY_METRIC_AGG_V2 : ENTITY_METRIC_AGG_LEGACY;
+}
+
+// Build the inner `(entityId, metricType, day, total)` subquery the direct CH
+// read sites (search-index / comic populate / metric-helpers) sum over. `where`
+// is the caller's full WHERE clause (e.g. "WHERE entityType = 'Image' AND ...").
+// Legacy source argMax-dedups per (entity, metric, day); the v2 view is already
+// FINAL so we select total directly. Selecting metricType is harmless even for
+// callers that only group by day (it's just carried through the subquery).
+export function buildEntityMetricPerDaySource(
+  source: EntityMetricAggSource,
+  where: string
+): string {
+  if (source.needsArgMaxDedup) {
+    return `(
+      SELECT entityId, metricType, day, argMax(total, refreshedAt) AS total
+      FROM ${source.table}
+      ${where}
+      GROUP BY entityId, metricType, day
+    )`;
+  }
+  return `(
+      SELECT entityId, metricType, day, total
+      FROM ${source.table}
+      ${where}
+    )`;
 }
 
 export default FliptSingleton;

--- a/src/server/metrics/metric-helpers.ts
+++ b/src/server/metrics/metric-helpers.ts
@@ -5,6 +5,7 @@ import type { AugmentedPool } from '~/server/db/db-helpers';
 import { parameterizedTemplateHandler, templateHandler } from '~/server/db/db-helpers';
 import type { JobContext } from '~/server/jobs/job';
 import { createLogger } from '~/utils/logging';
+import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
 
 const log = createLogger('metric-helpers');
 
@@ -215,23 +216,20 @@ export function getEntityMetricTasks(ctx: EntityMetricContext) {
       ctx.jobContext.checkIfCanceled();
       log(`getEntityMetricTasks(${entityType}, ${metricType})`, i + 1, 'of', tasks.length);
 
-      const metrics = await ctx.ch.$query<{ entityId: number; value: number }>`
+      const aggSource = await getEntityMetricAggSource();
+      const perDaySource = buildEntityMetricPerDaySource(
+        aggSource,
+        `WHERE entityType = '${entityType}'
+            AND metricType = '${metricType}'
+            AND entityId IN (${ids.join(',')})`
+      );
+      const metrics = await ctx.ch.$query<{ entityId: number; value: number }>(`
         SELECT
           entityId,
           sum(total) AS value
-        FROM (
-          SELECT
-            entityId,
-            day,
-            argMax(total, refreshedAt) AS total
-          FROM entityMetricDailyAgg_new
-          WHERE entityType = '${entityType}'
-            AND metricType = '${metricType}'
-            AND entityId IN (${ids})
-          GROUP BY entityId, day
-        )
+        FROM ${perDaySource}
         GROUP BY entityId
-      `;
+      `);
 
       ctx.jobContext.checkIfCanceled();
 

--- a/src/server/redis/entity-metric-populate.ts
+++ b/src/server/redis/entity-metric-populate.ts
@@ -3,6 +3,7 @@ import { clickhouse } from '~/server/clickhouse/client';
 import { entityMetricRedis } from '~/server/redis/entity-metric.redis';
 import { redis, REDIS_KEYS, type RedisKeyTemplateCache } from '~/server/redis/client';
 import { createLogger } from '~/utils/logging';
+import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
 import type {
   EntityMetric_EntityType_Type,
   EntityMetric_MetricType_Type,
@@ -309,22 +310,18 @@ export async function populateComicMetrics(
       // counters) buckets are merged into a single per-id totals row so
       // the Redis layer only knows about a unified 'Comic' key.
       const entityTypeList = COMIC_ENTITY_TYPES.map((t) => `'${t}'`).join(',');
+      const aggSource = await getEntityMetricAggSource();
+      const perDaySource = buildEntityMetricPerDaySource(
+        aggSource,
+        `WHERE entityType IN (${entityTypeList})
+            AND entityId IN (${batchIds.join(',')})`
+      );
       const metrics = await clickhouse.$query<MetricData>(`
         SELECT
           entityId,
           metricType,
           sum(total) AS total
-        FROM (
-          SELECT
-            entityId,
-            metricType,
-            day,
-            argMax(total, refreshedAt) AS total
-          FROM entityMetricDailyAgg_new
-          WHERE entityType IN (${entityTypeList})
-            AND entityId IN (${batchIds.join(',')})
-          GROUP BY entityId, metricType, day
-        )
+        FROM ${perDaySource}
         GROUP BY entityId, metricType
         HAVING total > 0
       `);

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -8,6 +8,7 @@ import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead } from '~/server/db/client';
 import { searchClient as client, updateDocs } from '~/server/meilisearch/client';
 import { getOrCreateIndex } from '~/server/meilisearch/util';
+import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
 import {
   tagCache,
   tagIdsForImagesCache,
@@ -406,6 +407,12 @@ export const imagesSearchIndex = createSearchIndexUpdateProcessor({
       // Metrics:
       if (step === 1) {
         logger(`Pulling metrics :: ${indexName} ::`, batchLogKey, subBatchLogKey);
+        const aggSource = await getEntityMetricAggSource();
+        const perDaySource = buildEntityMetricPerDaySource(
+          aggSource,
+          `WHERE entityType = 'Image'
+                AND entityId IN (${batch.join(',')})`
+        );
         const metrics = await clickhouse?.$query<Metrics>(`
             SELECT entityId as "id",
                    sumIf(total, metricType = 'Collection') as "collectedCount",
@@ -416,13 +423,7 @@ export const imagesSearchIndex = createSearchIndexUpdateProcessor({
                    sumIf(total, metricType = 'tippedAmount') as "tippedAmountCount",
                    sumIf(total, metricType = 'Heart') as "heartCount",
                    sumIf(total, metricType = 'Laugh') as "laughCount"
-            FROM (
-              SELECT entityId, metricType, day, argMax(total, refreshedAt) as total
-              FROM entityMetricDailyAgg_new
-              WHERE entityType = 'Image'
-                AND entityId IN (${batch.join(',')})
-              GROUP BY entityId, metricType, day
-            )
+            FROM ${perDaySource}
             GROUP BY id
           `);
 

--- a/src/server/search-index/metrics-images--update-metrics.search-index.ts
+++ b/src/server/search-index/metrics-images--update-metrics.search-index.ts
@@ -4,6 +4,7 @@ import { metricsSearchClient as client, updateDocs } from '~/server/meilisearch/
 import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
 
 const READ_BATCH_SIZE = 100000;
 const MEILISEARCH_DOCUMENT_BATCH_SIZE = READ_BATCH_SIZE;
@@ -68,19 +69,19 @@ export const imagesMetricsDetailsSearchIndexUpdateMetrics = createSearchIndexUpd
         : Array.from({ length: batch.endId - batch.startId + 1 }, (_, i) => batch.startId + i);
 
     const metrics: Metrics[] = [];
+    const aggSource = await getEntityMetricAggSource();
     const tasks = chunk(ids, 5000).map((batch) => async () => {
+      const perDaySource = buildEntityMetricPerDaySource(
+        aggSource,
+        `WHERE entityType = 'Image'
+            AND entityId IN (${batch.join(',')})`
+      );
       const results = await ch?.$query<Metrics>(`
         SELECT entityId as "id",
           sumIf(total, metricType in ('Like', 'Heart', 'Laugh', 'Cry')) as "reactionCount",
           sumIf(total, metricType = 'commentCount') as "commentCount",
           sumIf(total, metricType = 'Collection') as "collectedCount"
-        FROM (
-          SELECT entityId, metricType, day, argMax(total, refreshedAt) as total
-          FROM entityMetricDailyAgg_new
-          WHERE entityType = 'Image'
-            AND entityId IN (${batch.join(',')})
-          GROUP BY entityId, metricType, day
-        )
+        FROM ${perDaySource}
         GROUP BY id
       `);
       if (results?.length) metrics.push(...results);

--- a/src/server/search-index/metrics-images.search-index.ts
+++ b/src/server/search-index/metrics-images.search-index.ts
@@ -11,6 +11,7 @@ import type { Availability } from '~/shared/utils/prisma/enums';
 import { removeEmpty } from '~/utils/object-helpers';
 import { isDefined } from '~/utils/type-guards';
 import { imageOnSiteSql } from '~/server/utils/image-onsite';
+import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
 
 const READ_BATCH_SIZE = 100000;
 const MEILISEARCH_DOCUMENT_BATCH_SIZE = READ_BATCH_SIZE;
@@ -384,18 +385,18 @@ export const imagesMetricsDetailsSearchIndex = createSearchIndexUpdateProcessor(
 
       if (step === 1) {
         logger(`Pulling metrics :: ${indexName} ::`, batchLogKey, subBatchLogKey);
+        const aggSource = await getEntityMetricAggSource();
+        const perDaySource = buildEntityMetricPerDaySource(
+          aggSource,
+          `WHERE entityType = 'Image'
+                AND entityId IN (${batch.join(',')})`
+        );
         const metrics = await clickhouse?.$query<Metrics>(`
             SELECT entityId as "id",
                    sumIf(total, metricType in ('Like', 'Heart', 'Laugh', 'Cry')) as "reactionCount",
                    sumIf(total, metricType = 'commentCount') as "commentCount",
                    sumIf(total, metricType = 'Collection') as "collectedCount"
-            FROM (
-              SELECT entityId, metricType, day, argMax(total, refreshedAt) as total
-              FROM entityMetricDailyAgg_new
-              WHERE entityType = 'Image'
-                AND entityId IN (${batch.join(',')})
-              GROUP BY entityId, metricType, day
-            )
+            FROM ${perDaySource}
             GROUP BY id
           `);
 

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -194,7 +194,13 @@ import { getImageS3Client } from '~/utils/s3-client';
 import { serverUploadImage, getB2ImageS3Client } from '~/utils/s3-utils';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
-import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
+import {
+  FLIPT_FEATURE_FLAGS,
+  getEntityMetricAggSource,
+  getFliptBoolean,
+  getFliptVariant,
+  isFlipt,
+} from '../flipt/client';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import { queryBitdex } from '~/server/bitdex/client';
 import type { FilterClause, SortClause, Value } from '~/server/bitdex/client';
@@ -2718,7 +2724,11 @@ export async function getImagesFromFeedSearch(
       },
       clickhouse as IClickhouseClient,
       pgDbWrite as IDbClient,
-      new MetricService(clickhouse as IClickhouseClient, redis as unknown as IRedisClient),
+      new MetricService(
+        clickhouse as IClickhouseClient,
+        redis as unknown as IRedisClient,
+        getEntityMetricAggSource
+      ),
       new CacheService(
         redis as unknown as IRedisClient,
         pgDbWrite as IDbClient,
@@ -2729,7 +2739,9 @@ export async function getImagesFromFeedSearch(
         // `image:tagIds` Redis hash. Same {imageId, tags[]} shape + same WD14/Rekognition +
         // styleTags/subjectTags filter, so it's a drop-in. Relieves next-redis-cluster memory.
         (ids: number[]) =>
-          tagIdsForImagesCache.fetch(ids) as Promise<Record<number, { imageId: number; tags: number[] }>>
+          tagIdsForImagesCache.fetch(ids) as Promise<
+            Record<number, { imageId: number; tags: number[] }>
+          >
       )
     );
 
@@ -4474,7 +4486,8 @@ let _imageMetricService: MetricService | null = null;
 const getImageMetricService = () =>
   (_imageMetricService ??= new MetricService(
     clickhouse as IClickhouseClient,
-    redis as unknown as IRedisClient
+    redis as unknown as IRedisClient,
+    getEntityMetricAggSource
   ));
 
 type ImageMetricsObject = Awaited<ReturnType<typeof imageMetricsCache.fetch>>;


### PR DESCRIPTION
## What
Repoint the entity-metric read path from the live ReplacingMergeTree `entityMetricDailyAgg_new` (which needs a per-day `argMax(total, refreshedAt)` dedup wrapper) to the proven read VIEW `entityMetricDailyAgg_v2` (already FINAL per-(entityType,entityId,metricType,day) totals, no dedup), behind a reversible Flipt flag.

**Flag: `metrics-agg-v2-read`, default OFF.** Merging + deploying changes nothing; the cutover is a single flag flip, and flipping back instantly restores the legacy source.

## The 7 read sites changed
- **event-engine-common** (submodule, separate PR civitai/event-engine-common#8): `services/metrics.ts` — `fetchFromClickhouse` + `fetchTimeframes` (the `metrics:*` Redis cache, the critical feed path).
- **model-share**:
  - `src/server/metrics/metric-helpers.ts` — `getEntityMetricTasks`
  - `src/server/redis/entity-metric-populate.ts` — comic populate
  - `src/server/search-index/metrics-images.search-index.ts`
  - `src/server/search-index/metrics-images--update-metrics.search-index.ts`
  - `src/server/search-index/images.search-index.ts`

## Mechanism
- `flipt/client.ts`: new `METRICS_AGG_V2_READ` flag; `getEntityMetricAggSource()` (single source of truth resolving `{ table, needsArgMaxDedup }` off the flag); `buildEntityMetricPerDaySource(source, where)` SQL-fragment helper.
- event-engine-common is framework-free, so model-share owns the flag: `MetricService` gets an optional `aggSourceProvider` callback (3rd constructor arg). model-share passes `getEntityMetricAggSource`; the provider is resolved **fresh per CH query** so the flag stays live despite `MetricService` being a reused singleton.
- The 5 model-share-direct sites gate the table name + dedup inline via the shared helper.
- When OFF: byte-identical to today (`agg_new` + argMax). When ON: `agg_v2`, argMax dropped (v2 is already final — double-applying would be numerically fine but we drop it for clarity/cost).

## Guardrails / merge order
- [ ] Re-point the submodule to the **squash-merged** event-engine-common#8 SHA before merging this PR (currently points at the pre-merge branch commit).
- Do NOT flip the flag or touch ClickHouse as part of merge — deploy is a no-op.

## Typecheck
`pnpm run typecheck` clean (the one `submit-version.test.ts` error is pre-existing and unrelated — broken relative import in a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)