### PR TITLE
security(app-blocks): server-re-derive Paddle buzz-purchase attribution (FIN-1)

### DIFF
--- a/src/server/services/__tests__/paddle.processCompleteBuzzTransaction.attribution.test.ts
+++ b/src/server/services/__tests__/paddle.processCompleteBuzzTransaction.attribution.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TransactionNotification } from '@paddle/paddle-node-sdk';
+
+/**
+ * FIN-1 coverage for the Paddle Buzz-purchase attribution path.
+ *
+ * `processCompleteBuzzTransaction` credits buzz to the buyer, then writes an
+ * App Blocks revenue-share attribution row off the line-item customData. The
+ * block-attribution fields in that customData are CLIENT-SUPPLIED, so before
+ * recording we re-derive them SERVER-SIDE through the same chokepoint the
+ * Stripe path uses (`validateBuzzPurchaseAttribution`, which resolves the
+ * cited instance AS THE BUYER, overwrites forged appId/scope, and strips
+ * attribution that doesn't resolve). These tests prove:
+ *   - a forged client appId/scope is corrected to the server-resolved values
+ *     before recordAttribution is called (NOT the client's claim);
+ *   - a non-resolving / absent instance → attribution dropped,
+ *     recordAttribution NOT called, the purchase still proceeds (buzz still
+ *     credited);
+ *   - a normal non-block purchase → no attribution write, buzz still credited.
+ *
+ * Every module boundary the handler touches is mocked so the test stays
+ * in-process and deterministic; the real code under test is the wiring of
+ * validate → extract → record (and that the buzz-credit path is never gated
+ * by the attribution outcome). BlockRegistry.resolveBlockInstance + the logger
+ * are mocked at the validator's module boundary so the REAL FIN-1 validator
+ * runs end-to-end (matching subscription-attribution.fin1.test.ts).
+ */
+
+const {
+  mockResolve,
+  mockLog,
+  mockGetMultipliersForUser,
+  mockCreateBuzzTransaction,
+  mockGrantCosmetics,
+  mockRecordAttribution,
+} = vi.hoisted(() => ({
+  mockResolve: vi.fn(),
+  mockLog: vi.fn(),
+  mockGetMultipliersForUser: vi.fn(),
+  mockCreateBuzzTransaction: vi.fn(),
+  mockGrantCosmetics: vi.fn(),
+  mockRecordAttribution: vi.fn(),
+}));
+
+// Real FIN-1 validator runs; only its resolver + logger are mocked.
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: { resolveBlockInstance: mockResolve },
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: (...args: unknown[]) => mockCreateBuzzTransaction(...args),
+  getMultipliersForUser: (...args: unknown[]) => mockGetMultipliersForUser(...args),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({
+  grantCosmetics: (...args: unknown[]) => mockGrantCosmetics(...args),
+}));
+vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
+  recordAttribution: (...args: unknown[]) => mockRecordAttribution(...args),
+  // AttributionAppMissingError is referenced by the catch block; a plain
+  // Error subclass is enough for the `instanceof` branch.
+  AttributionAppMissingError: class AttributionAppMissingError extends Error {},
+}));
+// paddle.service imports these at module load; none are exercised by
+// processCompleteBuzzTransaction's buzz-purchase path, so stub them to cut
+// the transitive Prisma / env / paddle-client import chains.
+vi.mock('~/server/paddle/client', () => ({
+  cancelPaddleSubscription: vi.fn(),
+  createBuzzTransaction: vi.fn(),
+  createOneTimeProductPurchaseTransaction: vi.fn(),
+  getCustomerLatestTransaction: vi.fn(),
+  getOrCreateCustomer: vi.fn(),
+  getPaddleAdjustments: vi.fn(),
+  getPaddleCustomerSubscriptions: vi.fn(),
+  getPaddleSubscription: vi.fn(),
+  subscriptionBuzzOneTimeCharge: vi.fn(),
+  updatePaddleSubscription: vi.fn(),
+  createAnnualSubscriptionDiscount: vi.fn(),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbWrite: {},
+  dbRead: {},
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({
+  getPlans: vi.fn(),
+}));
+vi.mock('~/server/services/vault.service', () => ({
+  getOrCreateVault: vi.fn(),
+}));
+
+import { processCompleteBuzzTransaction } from '../paddle.service';
+import { encodeAttributionMetadata } from '~/server/schema/blocks/attribution.schema';
+
+const BUYER = 100;
+const REAL_APP_ID = 'app_real';
+const REAL_APP_BLOCK_ID = 'apb_real';
+const SLOT = 'model.sidebar_top';
+const MODEL_ID = 555;
+const TX_ID = 'txn_test';
+
+function resolvedInstance(over: Record<string, unknown> = {}) {
+  return {
+    source: 'viewer_subscription',
+    modelId: MODEL_ID,
+    slotId: SLOT,
+    enabled: true,
+    settings: {},
+    installedByUserId: BUYER,
+    appBlock: {
+      id: REAL_APP_BLOCK_ID,
+      blockId: 'blk',
+      appId: REAL_APP_ID,
+      status: 'approved',
+      manifest: {},
+      approvedScopes: [],
+      app: { allowedScopes: 0 },
+    },
+    ...over,
+  };
+}
+
+/**
+ * Build a Paddle TransactionNotification carrying a buzzPurchase line item.
+ * `blockMeta` (if given) is the CLIENT-SUPPLIED block-attribution bag merged
+ * onto the line-item customData — i.e. the forgeable surface.
+ */
+function fakeTransaction(blockMeta: Record<string, unknown> = {}): TransactionNotification {
+  const customData = {
+    type: 'buzzPurchase',
+    user_id: BUYER,
+    buzz_amount: 1000,
+    ...blockMeta,
+  };
+  return {
+    id: TX_ID,
+    details: { totals: { total: '500' } },
+    items: [{ price: { customData } }],
+  } as unknown as TransactionNotification;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetMultipliersForUser.mockResolvedValue({ purchasesMultiplier: 1 });
+  mockCreateBuzzTransaction.mockResolvedValue({});
+  mockGrantCosmetics.mockResolvedValue({});
+  mockRecordAttribution.mockResolvedValue({});
+});
+
+describe('paddle processCompleteBuzzTransaction — FIN-1 attribution re-derivation', () => {
+  it('valid attribution → records SERVER-DERIVED appId/scope (buzz still credited)', async () => {
+    mockResolve.mockResolvedValueOnce(resolvedInstance({ source: 'viewer_subscription' }));
+
+    const clientBag = encodeAttributionMetadata({
+      appId: REAL_APP_ID,
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'bus_view_abc',
+      scope: 'viewer_personal',
+      modelId: MODEL_ID,
+      slotId: SLOT,
+    })!;
+
+    await processCompleteBuzzTransaction(fakeTransaction(clientBag));
+
+    // Buzz credit happened regardless of attribution.
+    expect(mockCreateBuzzTransaction).toHaveBeenCalled();
+    expect(mockRecordAttribution).toHaveBeenCalledTimes(1);
+    const arg = mockRecordAttribution.mock.calls[0][0];
+    expect(arg.attribution.appId).toBe(REAL_APP_ID);
+    expect(arg.attribution.scope).toBe('viewer_personal');
+    expect(arg.paymentProvider).toBe('paddle');
+    expect(arg.paymentTransactionId).toBe(TX_ID);
+    expect(arg.userId).toBe(BUYER);
+    // v1 fee behavior preserved.
+    expect(arg.providerFeeCents).toBe(0);
+    expect(arg.usdAmountCents).toBe(500);
+  });
+
+  it('forged appId/scope → corrected to the resolved values, NOT the client claim', async () => {
+    // The instance actually resolves to viewer_subscription → viewer_personal,
+    // owned by the real app. The buyer forges a confederate app + a high-rate
+    // scope; the server must overwrite both.
+    mockResolve.mockResolvedValueOnce(resolvedInstance({ source: 'viewer_subscription' }));
+
+    const forgedBag = encodeAttributionMetadata({
+      appId: 'app_attacker', // forged
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'bus_view_abc',
+      scope: 'publisher_all_my_models', // forged high-rate scope
+      modelId: MODEL_ID,
+      slotId: SLOT,
+    })!;
+
+    await processCompleteBuzzTransaction(fakeTransaction(forgedBag));
+
+    expect(mockRecordAttribution).toHaveBeenCalledTimes(1);
+    const arg = mockRecordAttribution.mock.calls[0][0];
+    // Server-derived — NOT the forged values.
+    expect(arg.attribution.appId).toBe(REAL_APP_ID);
+    expect(arg.attribution.appId).not.toBe('app_attacker');
+    expect(arg.attribution.scope).toBe('viewer_personal');
+    expect(arg.attribution.scope).not.toBe('publisher_all_my_models');
+  });
+
+  it('non-resolving instance → attribution dropped, recordAttribution NOT called, buzz still credited', async () => {
+    mockResolve.mockResolvedValueOnce(null); // buyer is not a legit viewer/owner
+
+    const forgedBag = encodeAttributionMetadata({
+      appId: REAL_APP_ID,
+      appBlockId: REAL_APP_BLOCK_ID,
+      blockInstanceId: 'bus_view_nope',
+      scope: 'viewer_personal',
+      modelId: MODEL_ID,
+      slotId: SLOT,
+    })!;
+
+    await processCompleteBuzzTransaction(fakeTransaction(forgedBag));
+
+    expect(mockRecordAttribution).not.toHaveBeenCalled();
+    // Purchase still proceeds: buzz credited.
+    expect(mockCreateBuzzTransaction).toHaveBeenCalled();
+  });
+
+  it('normal non-block purchase → no attribution write, buzz still credited', async () => {
+    await processCompleteBuzzTransaction(fakeTransaction());
+
+    expect(mockRecordAttribution).not.toHaveBeenCalled();
+    // The validator short-circuits (no appId) and never touches the resolver.
+    expect(mockResolve).not.toHaveBeenCalled();
+    expect(mockCreateBuzzTransaction).toHaveBeenCalled();
+  });
+});

--- a/src/server/services/paddle.service.ts
+++ b/src/server/services/paddle.service.ts
@@ -46,6 +46,7 @@ import {
   recordAttribution,
 } from '~/server/services/blocks/buzz-attribution.service';
 import { extractAttribution } from '~/server/schema/blocks/attribution.schema';
+import { validateBuzzPurchaseAttribution } from '~/server/services/blocks/attribution-validator.service';
 import { grantCosmetics } from '~/server/services/cosmetic.service';
 import { getPlans } from '~/server/services/subscriptions.service';
 import { getOrCreateVault } from '~/server/services/vault.service';
@@ -252,12 +253,32 @@ export const processCompleteBuzzTransaction = async (
   // App Blocks revenue-share attribution. Skipped silently when the
   // line-item customData doesn't carry block fields (the steady-state
   // for every non-block paddle buzz purchase). Attribution failures
-  // never throw — the buzz credit has already happened and the next
-  // webhook retry will re-attempt the write (idempotent on
+  // never throw — the buzz credit has already happened above and the
+  // next webhook retry will re-attempt the write (idempotent on
   // payment_transaction_id + app_block_id).
-  const attribution = extractAttribution(meta as Record<string, unknown> as Record<string, string | number | null | undefined>);
-  if (attribution) {
-    try {
+  try {
+    // FIN-1: the block-attribution fields in `meta` are client-supplied
+    // (the browser stamps blockAppId/blockInstanceId/blockScope/etc into
+    // the Paddle line-item customData) and the publisher's revenue share
+    // is credited off them. A buyer could otherwise forge an arbitrary
+    // author's app/scope and mint earnings. We re-derive every block field
+    // SERVER-SIDE against the authenticated buyer (`userId`, the buzz
+    // recipient resolved above) using the SAME chokepoint the Stripe path
+    // uses: resolveBlockInstance AS THE BUYER, overwrite forged appId/scope
+    // with the resolved values, and STRIP attribution that doesn't resolve.
+    // A stripped/absent attribution leaves the purchase un-attributed —
+    // exactly the prior behavior for a non-block purchase. See
+    // attribution-validator.service.ts for the full threat model.
+    const validated = await validateBuzzPurchaseAttribution({
+      metadata: meta as Record<string, unknown> as Record<string, unknown> & {
+        userId?: unknown;
+      },
+      sessionUserId: userId,
+    });
+    const attribution = extractAttribution(
+      validated as Record<string, string | number | null | undefined>
+    );
+    if (attribution) {
       // Paddle doesn't surface processor fees on the line item shape
       // the SDK gives us here — we'd need a separate call against
       // transactions.get and inspect totals.fee. For v1 we leave fee
@@ -276,21 +297,21 @@ export const processCompleteBuzzTransaction = async (
         buzzTransactionId: null,
         attribution,
       });
-    } catch (attrErr) {
-      const isExpected = attrErr instanceof AttributionAppMissingError;
-      logToAxiom(
-        {
-          name: 'paddle-webhook',
-          type: isExpected ? 'warning' : 'error',
-          stage: 'block-attribution-write',
-          paddleTransactionId: transaction.id,
-          attribution,
-          error: (attrErr as Error)?.message,
-          stack: (attrErr as Error)?.stack,
-        },
-        'webhooks'
-      ).catch(() => null);
     }
+  } catch (attrErr) {
+    const isExpected = attrErr instanceof AttributionAppMissingError;
+    logToAxiom(
+      {
+        name: 'paddle-webhook',
+        type: isExpected ? 'warning' : 'error',
+        stage: 'block-attribution-write',
+        paddleTransactionId: transaction.id,
+        paddleTransactionMeta: meta,
+        error: (attrErr as Error)?.message,
+        stack: (attrErr as Error)?.stack,
+      },
+      'webhooks'
+    ).catch(() => null);
   }
 };
 


### PR DESCRIPTION
## The gap

The Paddle buzz-purchase handler `processCompleteBuzzTransaction`
(`src/server/services/paddle.service.ts`) decoded **client-supplied** App
Blocks attribution from the line-item `customData` via
`extractAttribution(meta)` and passed it straight to `recordAttribution(...)`
with **no server-side re-derivation**. A malicious buyer could forge
`blockAppId` / `blockScope` / `blockInstanceId` in the Paddle `customData`
and — once any attribution rate goes non-zero — mint a revenue-share credit
for an arbitrary author against a purchase that never touched a block.

Stripe does **not** have this gap: `src/server/services/stripe.service.ts`
routes every block attribution through `validateBuzzPurchaseAttribution`
before it is stamped/recorded. This is the missing Paddle leg of that FIN-1
chokepoint.

## The fix

Mirror Stripe exactly. Before recording, run the flat `customData` (`meta`)
through `validateBuzzPurchaseAttribution({ metadata: meta, sessionUserId: userId })`
where `userId` is the already-authenticated buyer / buzz recipient resolved
earlier in the handler, then `extractAttribution(validated)` to get the
**server-derived** attribution bag, and pass *that* to `recordAttribution`.
The validator:

- resolves the cited block instance **as the buyer** via
  `BlockRegistry.resolveBlockInstance`,
- overwrites forged `appId` / `scope` with the resolved-row values,
- strips attribution that doesn't resolve (returns the bag with the block
  keys removed → `extractAttribution` returns `null`).

`meta` is already a flat string-keyed record (same shape `extractAttribution`
consumed before), so no `encode` step is needed — the shape is
`validate → extract → record`. The single `recordAttribution` call site is
the only Paddle attribution write (confirmed by grep); there is no Paddle
subscription/membership attribution leg, and none was added.

## Why it's safe

- **Gates only the attribution write.** The buzz credit/grant, amounts,
  cosmetic grant, idempotency on `(payment_transaction_id, app_block_id)`,
  and the `providerFeeCents = 0` v1 behavior are all unchanged.
- **The buzz credit can never be broken by attribution.** The
  validate + extract + record now sit inside the existing best-effort
  `try/catch`, so even a validator throw (e.g. a spender-spoof guard) is
  logged and swallowed — the buzz grant already happened above.
- **Behavior-identical for non-block purchases.** When `customData` carries
  no `blockAppId`, the validator short-circuits (never touches the resolver)
  and `extractAttribution` returns `null` → no attribution write, exactly as
  before.
- **Harmless at the current 0% rate, required before any non-zero rate** —
  this closes the forge surface ahead of monetization.

## Tests

New `src/server/services/__tests__/paddle.processCompleteBuzzTransaction.attribution.test.ts`,
mirroring `subscription-attribution.fin1.test.ts` — the **real** FIN-1
validator runs end-to-end (only `BlockRegistry.resolveBlockInstance` + the
logger are mocked); the rest of the handler's module boundaries are stubbed.

- valid attribution that resolves → `recordAttribution` called with the
  **server-derived** `appId`/`scope`; buzz still credited.
- forged `appId`/`scope` (client claims `app_attacker` + a high-rate scope) →
  corrected to the resolved `app_real` / `viewer_personal`, **not** the
  forged values.
- non-resolving instance (`resolveBlockInstance → null`) → attribution
  dropped, `recordAttribution` **not** called, buzz still credited.
- normal non-block purchase (no block `customData`) → no attribution write,
  resolver never called, buzz still credited.

```
 ✓ unit  paddle.processCompleteBuzzTransaction.attribution.test.ts (4 tests) 4ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Run via the node-only vitest config (NixOS, offline — `tsc` can't run without
Prisma). Not browser-verified (payment webhook path; no UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
