### PR TITLE
feat(app-blocks): retrofit buzz-spend attribution to track-only (defer share to payout backpay)

### DIFF
--- a/prisma/migrations/20260618150000_block_spend_attribution_tracked_status/migration.sql
+++ b/prisma/migrations/20260618150000_block_spend_attribution_tracked_status/migration.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- App Blocks — buzz SPEND attribution: TRACK-ONLY status retrofit
+-- ============================================================
+-- Widen block_spend_attribution.status to include the 'tracked' state and
+-- make it the new default, so the spend flow uses the SAME track-only write
+-- model as block_subscription_attribution (#2629). See
+-- src/server/services/blocks/buzz-attribution.service.ts:recordSpendAttribution.
+--
+-- WHY: recordSpendAttribution no longer applies the spend rate card at write
+-- time. It records the EVENT + the MONEY BASIS (gross_value_cents) only and
+-- writes the row 'tracked' with app_owner_share_cents=0, spend_share_pct=0,
+-- rate_card_version='unrated'. The author bounty is computed LATER, at PAYOUT
+-- time, as a retroactive BACKPAY over status='tracked' rows at the signed-off
+-- spendSharePct (computeSpendShare stays in rate-card.ts for that). This
+-- avoids baking the placeholder 5% into immutable rows before monetization
+-- sign-off, and makes the spend ledger consistent with the membership ledger
+-- (the backpay reader processes status='tracked' rows).
+--
+-- PURELY ADDITIVE: this only WIDENS the status IN-list (adds 'tracked') and
+-- changes the column DEFAULT from 'pending' to 'tracked'. Every previously
+-- valid status remains valid, so existing rows stay valid with no backfill.
+-- Prod currently has 0 spend rows (the spend flow has not shipped); any
+-- pre-existing 'pending' rows would also remain valid under the new CHECK.
+--
+-- ⚠️ MANUAL-APPLY (civitai DB rule #8): committed for history, NOT
+--    auto-applied. A human must run this via psql/retool BEFORE the code that
+--    writes 'tracked' spend rows deploys, on:
+--      1. prod nvme0  (role=postgres CNPG cluster — the main civitai DB)
+--      2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev)
+
+ALTER TABLE "block_spend_attribution"
+  DROP CONSTRAINT "block_spend_attribution_status_check",
+  ADD CONSTRAINT "block_spend_attribution_status_check"
+    CHECK ("status" IN ('tracked', 'pending', 'confirmed', 'voided', 'paid_out', 'held'));
+
+ALTER TABLE "block_spend_attribution"
+  ALTER COLUMN "status" SET DEFAULT 'tracked';

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2601,14 +2601,17 @@ model BlockSpendAttribution {
   blockInstanceId    String   @map("block_instance_id")
   modelId            Int?     @map("model_id")
 
-  rateCardVersion    String   @map("rate_card_version")
-  /// The spend rev-share percentage stamped at write time.
-  spendSharePct      Int      @map("spend_share_pct")
-  appOwnerShareCents Int      @map("app_owner_share_cents")
+  /// TRACK-ONLY: no rate applied at write time. 'unrated' sentinel until the
+  /// payout-time backpay stamps the signed-off version.
+  rateCardVersion    String   @default("unrated") @map("rate_card_version")
+  /// 0 at write time; the payout-time backpay computes the real bounty.
+  spendSharePct      Int      @default(0) @map("spend_share_pct")
+  appOwnerShareCents Int      @default(0) @map("app_owner_share_cents")
   appOwnerUserId     Int      @map("app_owner_user_id")
   appOwner           User     @relation("BlockSpendAttributionAppOwner", fields: [appOwnerUserId], references: [id], onDelete: Restrict)
 
-  status             String   @default("pending")
+  /// 'tracked' (track-only event) | pending | confirmed | voided | paid_out | held.
+  status             String   @default("tracked")
   /// 'self_spend' / 'internal_owner' / 'manual_review'. Spend has no
   /// refund path, so this is never 'refund'/'chargeback'.
   voidedReason       String?  @map("voided_reason")

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -323,11 +323,12 @@ beforeEach(() => {
     written: true,
     row: {
       id: 'bsa_x',
-      status: 'pending',
+      // TRACK-ONLY: the write records the event + gross only — no rate applied.
+      status: 'tracked',
       appOwnerShareCents: 0,
       spendSharePct: 0,
       grossValueCents: 0,
-      rateCardVersion: 'v4',
+      rateCardVersion: 'unrated',
       voidedReason: null,
     },
   });

--- a/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * W3 flow A — buzz SPEND attribution service coverage. The interesting
- * surface is:
- *   - server-derived author bounty (gross USD from Buzz, share via the
- *     active spend rate card)
+ * W3 flow A — buzz SPEND attribution service coverage. TRACK-ONLY (mirrors
+ * #2629's membership rework): the write records the EVENT + the money BASIS
+ * (gross USD value of the Buzz burned) only — NO rate card is applied at write
+ * time. The author bounty is deferred to a payout-time backpay over
+ * status='tracked' rows. The interesting surface is:
+ *   - track-only row shape: status='tracked', author_share=0,
+ *     spend_share_pct=0, rate_card_version='unrated', gross recorded
+ *   - the write NEVER calls computeSpendShare (the share is deferred)
  *   - self-spend wash (spender == app owner → voided + 0 share)
- *   - internal-owner wash (app owner ∈ internalAppOwnerUserIds)
+ *   - internal-owner wash (app owner ∈ internalAppOwnerUserIds → voided)
  *   - idempotency via the (workflow_id, app_block_id) UNIQUE (P2002)
  *   - missing-app guard
  *   - the platform-funded-bounty ledger invariant (0 ≤ share ≤ gross)
@@ -48,10 +52,26 @@ vi.mock('~/server/logging/client', () => ({
   },
 }));
 
+// Spy on computeSpendShare so the track-only contract is testable: the write
+// must NEVER call it (the bounty is deferred to payout). Everything else from
+// rate-card stays real.
+const computeSpendShareSpy = vi.hoisted(() => vi.fn());
+vi.mock('../rate-card', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../rate-card')>();
+  return {
+    ...actual,
+    computeSpendShare: (...args: Parameters<typeof actual.computeSpendShare>) => {
+      computeSpendShareSpy(...args);
+      return actual.computeSpendShare(...args);
+    },
+  };
+});
+
 import {
   AttributionAppMissingError,
   buzzSpendToUsdCents,
   recordSpendAttribution,
+  UNRATED_RATE_CARD_VERSION,
   type RecordSpendAttributionInput,
 } from '../buzz-attribution.service';
 import { ACTIVE_RATE_CARD } from '../rate-card';
@@ -97,6 +117,7 @@ beforeEach(() => {
   mockDbRead.blockSpendAttribution.findUnique.mockReset();
   mockDbWrite.blockSpendAttribution.create.mockReset();
   mockLog.mockReset();
+  computeSpendShareSpy.mockReset();
   // Default: app exists, owned by a different user than the spender.
   mockDbRead.oauthClient.findUnique.mockResolvedValue({
     id: APP_ID,
@@ -117,7 +138,7 @@ describe('buzzSpendToUsdCents', () => {
 });
 
 describe('recordSpendAttribution', () => {
-  it('writes exactly one pending row with author=appBlock owner, gross=USD cost, share=cost×rate (floored)', async () => {
+  it('TRACK-ONLY: writes exactly one tracked row — event + gross, author=0, NO rate stamped', async () => {
     const res = await recordSpendAttribution(fakeInput());
 
     // Exactly one write.
@@ -128,32 +149,51 @@ describe('recordSpendAttribution', () => {
 
     // Author is the appBlock's owning OauthClient user (server-derived).
     expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
-    // Gross = USD value of the Buzz burned: 5000 Buzz -> 500 cents.
+    // MONEY BASIS recorded: gross = USD value of the Buzz burned (5000 -> 500).
     expect(data.grossValueCents).toBe(500);
-    // Share = gross * active spend rate, floored.
-    const expectedShare = Math.floor((500 * ACTIVE_RATE_CARD.spendSharePct) / 100);
-    expect(data.appOwnerShareCents).toBe(expectedShare);
-    expect(data.spendSharePct).toBe(ACTIVE_RATE_CARD.spendSharePct);
-    // Not self-spend → pending, not voided.
-    expect(data.status).toBe('pending');
+    // NO rate applied at write: author share 0, pct 0, version 'unrated'.
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.spendSharePct).toBe(0);
+    expect(data.rateCardVersion).toBe(UNRATED_RATE_CARD_VERSION);
+    expect(data.rateCardVersion).not.toBe(ACTIVE_RATE_CARD.version);
+    // The write must NOT consult the spend rate card — the bounty is deferred.
+    expect(computeSpendShareSpy).not.toHaveBeenCalled();
+    // Not self/internal → tracked (share-pending), not voided.
+    expect(data.status).toBe('tracked');
     expect(data.voidedReason).toBeNull();
     // Server-derived context preserved.
     expect(data.appId).toBe(APP_ID);
     expect(data.appBlockId).toBe(APP_BLOCK_ID);
     expect(data.workflowId).toBe(WORKFLOW_ID);
     expect(data.userId).toBe(SPENDER_ID);
-    expect(data.rateCardVersion).toBe(ACTIVE_RATE_CARD.version);
+    expect(res.row.status).toBe('tracked');
   });
 
-  it('ledger invariant: 0 ≤ author_share ≤ gross (platform-funded bounty)', async () => {
+  it('ledger invariant: 0 ≤ author_share ≤ gross — and author is always 0 at write (track-only)', async () => {
     await recordSpendAttribution(fakeInput({ buzzAmount: 123456 }));
     const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.grossValueCents).toBeGreaterThan(0);
     expect(data.appOwnerShareCents).toBeGreaterThanOrEqual(0);
     expect(data.appOwnerShareCents).toBeLessThanOrEqual(data.grossValueCents);
-    // And re-derivable from the stamped rate.
-    expect(data.appOwnerShareCents).toBe(
-      Math.floor((data.grossValueCents * data.spendSharePct) / 100)
-    );
+    // Track-only: no rate baked in, so the share is identically 0.
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.spendSharePct).toBe(0);
+  });
+
+  it('MUTATION-CHECK: author share + pct are 0 regardless of the active rate card (no rate applied)', async () => {
+    // Active card defines spendSharePct=5 (a non-zero placeholder). A
+    // track-only write must NOT apply it — author stays 0 and version stays
+    // 'unrated' even though the card carries a real rate. If the write
+    // regressed to applying computeSpendShare/the 5% card, these assertions
+    // (and the not-called spy) would fail.
+    expect(ACTIVE_RATE_CARD.spendSharePct).toBe(5);
+    await recordSpendAttribution(fakeInput({ buzzAmount: 100000 })); // $100 gross
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.grossValueCents).toBe(10000);
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(data.spendSharePct).toBe(0);
+    expect(data.rateCardVersion).toBe(UNRATED_RATE_CARD_VERSION);
+    expect(computeSpendShareSpy).not.toHaveBeenCalled();
   });
 
   it('self-spend (spender == app owner) → voided, zero share', async () => {
@@ -168,6 +208,26 @@ describe('recordSpendAttribution', () => {
     expect(data.appOwnerShareCents).toBe(0);
     expect(data.spendSharePct).toBe(0);
     expect(res.row.status).toBe('voided');
+  });
+
+  it('internal-owner (app owner ∈ internalAppOwnerUserIds) → voided, zero share', async () => {
+    // The owner is a different user than the spender (so NOT self-spend), but
+    // sits on the active card's internal-owner list — its rows must still be
+    // voided so they never enter the backpay. Temporarily inject the owner
+    // into the real list (restored after), since V5 ships with an empty list.
+    const internalList = ACTIVE_RATE_CARD.internalAppOwnerUserIds;
+    internalList.push(APP_OWNER_USER_ID);
+    try {
+      const res = await recordSpendAttribution(fakeInput());
+      const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+      expect(data.status).toBe('voided');
+      expect(data.voidedReason).toBe('internal_owner');
+      expect(data.appOwnerShareCents).toBe(0);
+      expect(data.spendSharePct).toBe(0);
+      expect(res.row.status).toBe('voided');
+    } finally {
+      internalList.pop();
+    }
   });
 
   it('idempotency: a second call for the same workflow returns the existing row, no second write', async () => {

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -18,11 +18,12 @@ import {
 } from '~/server/utils/app-block-ids';
 import {
   computeRateCardSplit,
-  computeSpendShare,
-  // NOTE: computeSubscriptionShare is intentionally NOT imported here.
-  // Membership attribution is TRACK-ONLY (#2629) — no rate is applied at
-  // write time. The share is computed at payout time (Slice 4) as a backpay
-  // against the signed-off rate over status='tracked' rows.
+  // NOTE: neither computeSpendShare nor computeSubscriptionShare is imported
+  // here. Both the buzz-SPEND (flow A) and membership (flow C) attributions
+  // are TRACK-ONLY — no rate is applied at write time. The share is computed
+  // at payout time (Slice 4) as a backpay against the signed-off rate over
+  // status='tracked' rows. The compute* helpers stay in rate-card.ts for that
+  // payout-time backpay to call.
   ACTIVE_RATE_CARD,
 } from './rate-card';
 
@@ -249,6 +250,17 @@ export class AttributionAppMissingError extends Error {
   }
 }
 
+/**
+ * Sentinel `rate_card_version` for TRACK-ONLY attribution rows (#2629 for
+ * membership; the spend flow follows the same model). No rate card is applied
+ * at attribution-write time, so no real version is stamped — the row records
+ * the money basis (gross [+ fee]) and the share is computed at payout time
+ * (Slice 4) as a backpay. A row carrying this sentinel + status='tracked' is
+ * "share-pending": the payout rail re-stamps the signed-off version when it
+ * computes the share.
+ */
+export const UNRATED_RATE_CARD_VERSION = 'unrated' as const;
+
 // ---------------------------------------------------------------
 // W3 flow A — buzz SPEND attribution (author bounty)
 // ---------------------------------------------------------------
@@ -320,9 +332,29 @@ export type RecordSpendAttributionResult = {
  * — it writes a derived audit/payout row. A failed write never affects
  * the generation (the caller fires it best-effort / fire-and-forget).
  *
+ * ⚠️ TRACK-ONLY (mirrors #2629's membership rework). This write records the
+ * ATTRIBUTION EVENT + the MONEY BASIS (gross_value_cents = USD value of the
+ * Buzz burned) only. It does NOT apply the spend rate card and does NOT bake
+ * an author bounty. The row is written:
+ *   - status                = 'tracked'  (share-pending, not yet computed)
+ *   - app_owner_share_cents  = 0
+ *   - spend_share_pct        = 0         (no rate applied)
+ *   - rate_card_version      = 'unrated' (no version stamped)
+ * The author bounty is DEFERRED to PAYOUT time: the future payout rail
+ * (Slice 4) reads status='tracked' rows and computes
+ * bounty = gross × <signed-off spendSharePct> as a clean retroactive BACKPAY
+ * (via the retained `computeSpendShare`), then transitions them to a
+ * computed/confirmed state. Because the tracked row carries the gross, that
+ * computation is exact.
+ *
+ * WHY: committing a bounty at the placeholder spend rate before monetization
+ * sign-off would lock these immutable rows to the placeholder (each row pays
+ * out under its STAMPED snapshot forever). Recording the basis now and
+ * applying the signed-off rate later removes the placeholder-rate liability.
+ *
  * Self-spend (spender == app owner) and internal-owner apps write a
- * voided, zero-share row so the audit trail exists but nothing enters the
- * payout pipeline (mirrors recordAttribution's self-purchase wash).
+ * voided, zero-share row so the audit trail exists but nothing is ever
+ * backpaid (mirrors recordAttribution's self-purchase wash).
  */
 export async function recordSpendAttribution(
   input: RecordSpendAttributionInput
@@ -362,20 +394,22 @@ export async function recordSpendAttribution(
 
   const grossValueCents = buzzSpendToUsdCents(buzzAmount);
   const isSelfSpend = userId === app.userId;
-  const share = computeSpendShare({
-    grossValueCents,
-    isSelfSpend,
-    appOwnerUserId: app.userId,
-  });
-
-  // Void zero-share rows that are zero because of WHO spent/owns (not
-  // because the rate is 0%) so they never enter the payout pipeline. A
-  // legitimately rate-0% row stays 'pending' — it carries no money but is
-  // a real attribution we want to confirm/aggregate (so a later non-zero
-  // card change applies going forward).
   const isInternal = ACTIVE_RATE_CARD.internalAppOwnerUserIds.includes(app.userId);
+
+  // TRACK-ONLY money basis: record the gross (USD value of the Buzz burned),
+  // defer the bounty. NO rate card is applied here (no computeSpendShare
+  // call). The backpay (Slice 4) computes bounty = gross × <signed-off
+  // spendSharePct> over status='tracked' rows. Today: share 0, no rate
+  // stamped.
+  const rateCardVersion = UNRATED_RATE_CARD_VERSION;
+  const spendSharePct = 0;
+  const appOwnerShareCents = 0;
+
+  // Void rows that are zero because of WHO spent/owns so they are never
+  // backpaid. Otherwise the row is 'tracked' — share-pending, awaiting the
+  // payout-time backpay at the signed-off rate.
   const voidedReason = isSelfSpend ? 'self_spend' : isInternal ? 'internal_owner' : null;
-  const status = voidedReason ? 'voided' : 'pending';
+  const status = voidedReason ? 'voided' : 'tracked';
   const voidedAt = voidedReason ? new Date() : null;
 
   const id = newBlockSpendAttributionId();
@@ -393,9 +427,9 @@ export async function recordSpendAttribution(
         appBlockId,
         blockInstanceId,
         modelId,
-        rateCardVersion: share.rateCardVersion,
-        spendSharePct: share.spendSharePct,
-        appOwnerShareCents: share.appOwnerShareCents,
+        rateCardVersion,
+        spendSharePct,
+        appOwnerShareCents,
         appOwnerUserId: app.userId,
         status,
         voidedReason,
@@ -423,9 +457,9 @@ export async function recordSpendAttribution(
         workflowId,
         buzzAmount,
         grossValueCents,
-        spendSharePct: share.spendSharePct,
-        appOwnerShareCents: share.appOwnerShareCents,
-        rateCardVersion: share.rateCardVersion,
+        spendSharePct,
+        appOwnerShareCents,
+        rateCardVersion,
         status,
         voidedReason,
         isSelfSpend,
@@ -489,16 +523,6 @@ const SUBSCRIPTION_ATTRIBUTION_LOG_NAME = 'block-subscription-attribution';
  * agree on the literal.
  */
 export const SUBSCRIPTION_ATTRIBUTION_SCOPE = 'subscription' as const;
-
-/**
- * Sentinel `rate_card_version` for TRACK-ONLY membership rows (#2629). No
- * rate card is applied at attribution-write time, so no real version is
- * stamped — the row records the money basis (gross + fee) and the share is
- * computed at payout time (Slice 4) as a backpay. A row carrying this
- * sentinel + status='tracked' is "share-pending": the payout rail re-stamps
- * the signed-off version when it computes the share.
- */
-export const UNRATED_RATE_CARD_VERSION = 'unrated' as const;
 
 export type RecordSubscriptionAttributionInput = {
   /** The subscriber (purchaser). Trusted: derived from the invoice's customer→User. */

--- a/src/server/services/blocks/rate-card.ts
+++ b/src/server/services/blocks/rate-card.ts
@@ -213,9 +213,19 @@ export const RATE_CARD_V3: RateCard = {
  * V4 — adds the W3 flow A buzz-SPEND author bounty (`spendSharePct`).
  *
  * Carries V3's purchase percentages UNCHANGED (15/15/25/0/0) and sets
- * `spendSharePct` to the FIRST non-zero spend rate. This is the first
- * card emitted for the spend flow: a block-initiated generation that
- * burns the viewer's own Buzz now accrues an author bounty.
+ * `spendSharePct` to the FIRST non-zero spend rate.
+ *
+ * ⚠️ NOT APPLIED AT ATTRIBUTION-WRITE TIME. As of the TRACK-ONLY rework
+ *    (mirroring #2629), `recordSpendAttribution` does NOT call
+ *    `computeSpendShare` and does NOT stamp this percentage onto the row.
+ *    Spend rows are written `status='tracked'` with `app_owner_share_cents=0`,
+ *    `spend_share_pct=0`, and `rate_card_version='unrated'` — they record the
+ *    EVENT + the money BASIS (gross) only. The author bounty is deferred to
+ *    PAYOUT TIME: the future payout rail (Slice 4) reads `status='tracked'`
+ *    rows and computes `bounty = gross × <signed-off spendSharePct>` as a
+ *    clean retroactive BACKPAY. WHY: committing a bounty at this placeholder
+ *    5% before monetization sign-off would lock those immutable rows to the
+ *    placeholder rate forever.
  *
  * ⚠️ PLACEHOLDER RATE — `spendSharePct: 5` is a CONSERVATIVE DEFAULT
  *    chosen pending monetization sign-off (Zach's call: ship a documented
@@ -435,6 +445,12 @@ export type SpendShareResult = {
 
 /**
  * Compute the author bounty for a single block-initiated Buzz SPEND.
+ *
+ * ⚠️ PAYOUT-TIME ONLY. This is NOT called by `recordSpendAttribution`
+ * anymore (the TRACK-ONLY rework, mirroring #2629). Spend rows are written
+ * `status='tracked'` with a 0 bounty and no stamped rate. This function is
+ * retained for the future payout rail (Slice 4) to call against the
+ * signed-off card, computing each tracked row's bounty as a backpay.
  *
  * `grossValueCents` is the USD value of the Buzz the generation burned
  * (buzzDollarRatio 1000 Buzz = $1 = 100 cents — the caller converts). The


### PR DESCRIPTION
## Why

Ledger consistency with the membership track-only model shipped in **#2629**. `recordSubscriptionAttribution` records the attribution event + the money basis (gross) and writes rows `status='tracked'` with `app_owner_share_cents=0` / `share_pct=0` / `rate_card_version='unrated'`, deferring the share to a payout-time **backpay** that processes `status='tracked'` rows at the signed-off rate.

The buzz-**SPEND** table (`block_spend_attribution`, #2627) still **baked** the active card's 5% at write time (`computeSpendShare` → `spend_share_pct` / `app_owner_share_cents` / `rate_card_version='v4'`, `status='pending'`). That:
1. locks immutable rows to an **unsigned placeholder rate** (each row pays out under its stamped snapshot forever), and
2. would make the eventual backpay reader **skip** these rows (it scans `status='tracked'`, not `'pending'`).

This PR retrofits spend to track-only, mirroring #2629 exactly.

## Code change (`recordSpendAttribution`, `src/server/services/blocks/buzz-attribution.service.ts`)

- **Removed `computeSpendShare` from the write path.** It is intentionally **kept** in `rate-card.ts` (its docstring now says "PAYOUT-TIME ONLY") for the future payout backpay to call against the signed-off card — same as `computeSubscriptionShare` was kept in #2629.
- Track-only write values:
  - `rateCardVersion: UNRATED_RATE_CARD_VERSION` (the same `'unrated'` sentinel from #2629 — moved its declaration above the spend section so both flows reuse it)
  - `spendSharePct: 0`, `appOwnerShareCents: 0`
  - `status = voidedReason ? 'voided' : 'tracked'` (was `'pending'`)
- **Self-spend / internal-owner VOID preserved**: `userId === app.userId` → `voided` + `'self_spend'`; `ACTIVE_RATE_CARD.internalAppOwnerUserIds.includes(...)` → `voided` + `'internal_owner'`. These never enter the backpay even at the signed-off rate.
- Still records `grossValueCents` (= `buzzSpendToUsdCents(buzzAmount)`) + `buzzAmount`. App-owner resolve/snapshot, `AttributionAppMissingError`, the `(workflow_id, app_block_id)` P2002 idempotency, and all logging are unchanged.
- Doc/comments updated where they now misstated behavior (RATE_CARD_V4 doc, `computeSpendShare` doc, the import note).

## Migration (additive, manual-apply)

`prisma/migrations/20260618150000_block_spend_attribution_tracked_status/migration.sql`:

```sql
ALTER TABLE "block_spend_attribution"
  DROP CONSTRAINT "block_spend_attribution_status_check",
  ADD CONSTRAINT "block_spend_attribution_status_check"
    CHECK ("status" IN ('tracked', 'pending', 'confirmed', 'voided', 'paid_out', 'held'));

ALTER TABLE "block_spend_attribution"
  ALTER COLUMN "status" SET DEFAULT 'tracked';
```

- **Purely additive**: only widens the `status` IN-list (adds `'tracked'`) and changes the column default `'pending'`→`'tracked'`. Every previously valid status stays valid.
- **MANUAL-APPLY** (CLAUDE.md DB rule #8): apply to **prod nvme0** + the **dev clone** (`cnpg-cluster-dev`) **before the code deploys**. **Prod currently has 0 spend rows** (the spend flow has not shipped) so no backfill; any pre-existing `'pending'` rows would also remain valid. NOT auto-applied — a human runs it.
- `schema.full.prisma` updated to match (`status @default("tracked")`, `rateCardVersion @default("unrated")`, `spendSharePct @default(0)`, `appOwnerShareCents @default(0)`).

## Tests

`src/server/services/blocks/__tests__/spend-attribution.service.test.ts`:
- normal spend → `status='tracked'`, `appOwnerShareCents=0`, `spendSharePct=0`, `rateCardVersion='unrated'`, gross recorded, **`computeSpendShare` never called** (spy)
- self-spend → `voided` / `self_spend`; internal-owner → `voided` / `internal_owner`
- missing app → `AttributionAppMissingError`, no row; idempotency retry → no duplicate
- **mutation-check**: author share + pct stay 0 and version stays `'unrated'` even though `ACTIVE_RATE_CARD.spendSharePct===5`

rate-card tests unchanged (the card still HAS `spendSharePct=5` — only the write stops applying it).

Verified locally (NixOS, node-only vitest): **spend + rate-card = 40 passed**; adjacent **subscription + router-workflow = 77 passed**.

## Notes / edge cases

- `computeSpendShare` is deliberately retained in `rate-card.ts` for the backpay.
- The spend table's existing `app_owner_share_cents <= gross_value_cents` CHECK is trivially satisfied by `share=0`; the `voided_reason` CHECK already allows `self_spend`/`internal_owner`.
- No callers depend on the returned `row`'s share fields (router test mock updated for fidelity only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)