### PR TITLE
fix(prisma): tolerate orphaned required relations (Inconsistent query result 500s)

### DIFF
--- a/src/server/selectors/article.selector.ts
+++ b/src/server/selectors/article.selector.ts
@@ -24,7 +24,14 @@ export const articleDetailSelect = Prisma.validator<Prisma.ArticleSelect>()({
   title: true,
   publishedAt: true,
   status: true,
-  tags: { select: { tag: { select: simpleTagSelect } } },
+  // `tag` is a required relation on TagsOnArticle, but orphaned join rows
+  // exist in prod (tagId pointing at a hard-deleted Tag). Selecting the
+  // required relation on such a row makes Prisma throw "Inconsistent query
+  // result: Field tag is required ... got null" → HTTP 500 for every consumer
+  // of this select (getArticleById, getModeratorArticles, the search indexer,
+  // the outbound webhook). Filtering on tag existence drops the orphan join
+  // rows so these queries degrade gracefully instead of erroring.
+  tags: { select: { tag: { select: simpleTagSelect } }, where: { tag: { is: {} } } },
   user: {
     select: { ...userWithCosmeticsSelect, isModerator: true },
   },

--- a/src/server/selectors/bounty.selector.ts
+++ b/src/server/selectors/bounty.selector.ts
@@ -21,7 +21,10 @@ export const getBountyDetailsSelect = Prisma.validator<Prisma.BountySelect>()({
   availability: true,
   lockedProperties: true,
   user: { select: userWithCosmeticsSelect },
-  tags: { select: { tag: { select: { id: true, name: true } } } },
+  // where: { tag: { is: {} } } drops orphaned TagsOnBounty join rows (tagId → hard-deleted
+  // Tag); the required `tag` relation would otherwise throw "Inconsistent query result" →
+  // 500. Same class/fix as articleDetailSelect.
+  tags: { select: { tag: { select: { id: true, name: true } } }, where: { tag: { is: {} } } },
   _count: {
     select: {
       entries: true,

--- a/src/server/selectors/post.selector.ts
+++ b/src/server/selectors/post.selector.ts
@@ -66,6 +66,9 @@ export const postSelect = Prisma.validator<Prisma.PostSelect>()({
   user: { select: userWithCosmeticsSelect },
   publishedAt: true,
   availability: true,
-  tags: { select: { tag: { select: simpleTagSelect } } },
+  // where: { tag: { is: {} } } drops orphaned TagsOnPost join rows (tagId → hard-deleted
+  // Tag); the required `tag` relation would otherwise throw "Inconsistent query result" →
+  // 500. Same class/fix as articleDetailSelect.
+  tags: { select: { tag: { select: simpleTagSelect } }, where: { tag: { is: {} } } },
   collectionId: true,
 });

--- a/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
+++ b/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
@@ -1,5 +1,71 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// The modules under test (model.service, article.selector → tag.selector, etc.)
+// call `Prisma.validator<...>()(...)` and the `Prisma.sql`/`raw`/`join` tagged-
+// template helpers at MODULE-LOAD (top-level consts). Under the unit vitest env
+// the real `@prisma/client` is externalised and those runtime members aren't
+// available at SSR import time → `Prisma.validator is not a function`. Mirror the
+// house pattern (see block-registry.page-only-launch / showcase.service tests):
+// stub `@prisma/client` with passthrough runtime helpers. A Proxy backs `Prisma`
+// so any enum the wide import graph references at load resolves to a stub member
+// instead of `undefined`, while the helpers we know the graph calls are real fns.
+vi.mock('@prisma/client', () => {
+  // `Prisma.validator<T>()(x)` → returns a function that returns its argument
+  // unchanged, so the validated select/where object is preserved verbatim (the
+  // tests assert against that exact shape).
+  const validator = () => (x: unknown) => x;
+  // Tagged-template SQL helpers used at module load by caches.ts / selectors.
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+    sql: strings.join('?'),
+  });
+  const raw = (s: string) => ({ sql: s, values: [] });
+  const join = (values: unknown[], separator = ',') => ({ values, separator });
+  const empty = { sql: '', values: [] };
+  class Sql {}
+
+  const known: Record<string, unknown> = {
+    validator,
+    sql,
+    raw,
+    join,
+    empty,
+    Sql,
+    // Common Prisma sort/null constants referenced in selectors at load.
+    SortOrder: { asc: 'asc', desc: 'desc' },
+    QueryMode: { default: 'default', insensitive: 'insensitive' },
+    JsonNull: 'JsonNull',
+    DbNull: 'DbNull',
+    AnyNull: 'AnyNull',
+  };
+
+  // Any other `Prisma.<member>` access (Prisma-generated enums referenced at
+  // load time across the wide import graph) resolves to an empty object stub,
+  // so module evaluation never trips over an undefined member.
+  const Prisma = new Proxy(known, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop];
+      return {};
+    },
+  });
+
+  // Prisma-generated *enums* are exported as top-level named exports too
+  // (e.g. `import { MediaType } from '@prisma/client'`). Back the whole module
+  // with a Proxy: `Prisma` resolves above; any other named import (an enum)
+  // resolves to an empty object stub.
+  return new Proxy(
+    { Prisma, PrismaClient: class PrismaClient {} },
+    {
+      get(target, prop: string) {
+        if (prop in target) return (target as Record<string, unknown>)[prop];
+        if (prop === '__esModule') return true;
+        return {};
+      },
+    }
+  );
+});
+
 /**
  * Regression tests for the "Inconsistent query result" 500s on
  * `model.getRecentlyManuallyAdded` and `article.getById`.

--- a/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
+++ b/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression tests for the "Inconsistent query result" 500s on
+ * `model.getRecentlyManuallyAdded` and `article.getById`.
+ *
+ * Root cause (both): a Prisma `select` materialised a *required* to-one
+ * relation on a row whose related record had been hard-deleted (orphaned FK).
+ * Prisma cannot return `null` for a required relation, so it throws
+ * "Inconsistent query result: Field <X> is required to return data, got null"
+ * at query-execution time → HTTP 500. Measured in prod: ~1.2M orphaned
+ * `ImageResourceNew.modelVersion` rows and 40 orphaned `TagsOnArticle.tag`
+ * rows.
+ *
+ * Fix (both): add a relation-existence filter (`{ is: {} }`) so the DB drops
+ * the orphan rows server-side and the query degrades gracefully (returns the
+ * resolvable rows / empty) instead of erroring.
+ */
+
+// --- model.getRecentlyManuallyAdded ----------------------------------------
+// The handler is a thin wrapper over a single dbRead.imageResourceNew.findMany,
+// so we mock the db client and the env, and stub the (heavy) transitive imports
+// of model.service that aren't exercised by this code path.
+
+const findManyMock = vi.fn();
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { imageResourceNew: { findMany: findManyMock } },
+  dbWrite: {},
+}));
+
+describe('getRecentlyManuallyAdded — orphaned ImageResourceNew.modelVersion', () => {
+  beforeEach(() => {
+    findManyMock.mockReset();
+  });
+
+  it('passes a relation-existence filter so orphaned modelVersion rows are excluded at the DB', async () => {
+    findManyMock.mockResolvedValue([{ modelVersion: { modelId: 11 } }]);
+    const { getRecentlyManuallyAdded } = await import('../model.service');
+
+    await getRecentlyManuallyAdded({ take: 10, userId: 42 });
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const args = findManyMock.mock.calls[0][0];
+    // The load-bearing fix: a required-relation existence filter. Without it,
+    // a row whose modelVersionId points at a deleted ModelVersion makes Prisma
+    // throw and the whole query 500s.
+    expect(args.where.modelVersion).toEqual({ is: {} });
+  });
+
+  it('returns the surviving modelIds (no throw) when the DB filters out the orphan rows', async () => {
+    // Simulate the post-fix DB behaviour: the orphaned row (whose modelVersion
+    // would be null) is excluded by the `{ is: {} }` filter, so findMany only
+    // ever yields rows with a real modelVersion. The handler returns those.
+    findManyMock.mockResolvedValue([
+      { modelVersion: { modelId: 7 } },
+      { modelVersion: { modelId: 7 } }, // dup → uniq
+      { modelVersion: { modelId: 9 } },
+    ]);
+    const { getRecentlyManuallyAdded } = await import('../model.service');
+
+    const result = await getRecentlyManuallyAdded({ take: 10, userId: 42 });
+    expect(result).toEqual([7, 9]);
+  });
+
+  it('returns [] when the user has only orphaned resources (all filtered out)', async () => {
+    // With the fix, an all-orphan result set comes back empty from the DB
+    // instead of throwing "Inconsistent query result".
+    findManyMock.mockResolvedValue([]);
+    const { getRecentlyManuallyAdded } = await import('../model.service');
+
+    const result = await getRecentlyManuallyAdded({ take: 10, userId: 42 });
+    expect(result).toEqual([]);
+  });
+});
+
+// --- article.getById (shared articleDetailSelect) --------------------------
+// The article 500 comes from the `tags.tag` required relation in the shared
+// `articleDetailSelect`, reused by getArticleById, getModeratorArticles, the
+// search indexer, and the outbound webhook. The fix lives in the selector, so
+// we assert the selector shape directly (a pure data object — no heavy imports).
+
+describe('articleDetailSelect — orphaned TagsOnArticle.tag', () => {
+  it('filters the tags relation on tag existence so orphaned join rows are excluded', async () => {
+    const { articleDetailSelect } = await import('~/server/selectors/article.selector');
+
+    // tags must carry a where-clause requiring the related Tag to exist; a
+    // bare `{ select: { tag: ... } }` (no where) re-introduces the 500 because
+    // TagsOnArticle.tag is a required relation with orphaned rows in prod.
+    expect(articleDetailSelect.tags).toMatchObject({
+      where: { tag: { is: {} } },
+      select: { tag: { select: expect.anything() } },
+    });
+  });
+});

--- a/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
+++ b/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
@@ -159,3 +159,28 @@ describe('articleDetailSelect — orphaned TagsOnArticle.tag', () => {
     });
   });
 });
+
+// --- sibling selectors with the SAME deleted-Tag orphan source --------------
+// TagsOnPost.tag and TagsOnBounty.tag are the same required-relation class:
+// whatever hard-deleted the Tags that orphaned TagsOnArticle also orphaned these,
+// so they need the identical existence filter or they 500 the same way.
+
+describe('postSelect — orphaned TagsOnPost.tag', () => {
+  it('filters the tags relation on tag existence', async () => {
+    const { postSelect } = await import('~/server/selectors/post.selector');
+    expect(postSelect.tags).toMatchObject({
+      where: { tag: { is: {} } },
+      select: { tag: { select: expect.anything() } },
+    });
+  });
+});
+
+describe('getBountyDetailsSelect — orphaned TagsOnBounty.tag', () => {
+  it('filters the tags relation on tag existence', async () => {
+    const { getBountyDetailsSelect } = await import('~/server/selectors/bounty.selector');
+    expect(getBountyDetailsSelect.tags).toMatchObject({
+      where: { tag: { is: {} } },
+      select: { tag: { select: expect.anything() } },
+    });
+  });
+});

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2506,6 +2506,13 @@ export const getRecentlyManuallyAdded = async ({
     where: {
       detected: false,
       image: { userId },
+      // ImageResourceNew.modelVersion is a required relation, but orphaned rows
+      // exist in prod (modelVersionId pointing at a hard-deleted ModelVersion).
+      // Selecting the required relation on such a row makes Prisma throw
+      // "Inconsistent query result: Field modelVersion is required ... got null"
+      // → HTTP 500. Filtering on relation existence excludes the orphans so the
+      // query degrades gracefully (returns the resolvable rows) instead.
+      modelVersion: { is: {} },
     },
     orderBy: { image: { createdAt: 'desc' } },
     take,


### PR DESCRIPTION
## Problem

Two tRPC procedures throw Prisma **\`Inconsistent query result\`** → HTTP 500 in dp-prod (observed today via Loki, `{namespace=\"civitai-dp-prod\"} |= \"Inconsistent query result\"`):

- `model.getRecentlyManuallyAdded` → `Invalid prisma.imageResourceNew.findMany() ... Field modelVersion is required to return data, got null instead.`
- `article.getById` → `Invalid prisma.article.findFirst() ... Field tag is required to return data, got null instead.`

## Root cause (orphan data, NOT replica lag)

Each query `select`s a relation declared **required (non-null)** in the Prisma schema on a row whose underlying related record has been **hard-deleted** (orphaned FK). Prisma cannot return `null` for a required relation, so it throws at query-execution time — before the handler's existing optional-chaining (`d.modelVersion?.modelId`) ever runs.

Measured on the nvme0 replica:

| Relation | Schema | Orphan count in prod |
|---|---|---|
| `ImageResourceNew.modelVersion` | `ModelVersion @relation` (required, `onDelete: Cascade`) | **1,200,666** |
| `TagsOnArticle.tag` | `Tag @relation` (required, `onDelete: Cascade`) | **40** |

Despite the `onDelete: Cascade` in the schema, orphans exist (raw/bulk deletes or `NOT VALID` FK constraints bypass cascade). This is **not replica lag** — `article.getById` already routes through `getDbWithoutLag('article', id)` (primary on a recent write) and still fails, and the orphan rows are persistently present on the replica, not transiently invisible.

The `article` 500 originates from the article's own `tags.tag` relation, which lives in the **shared `articleDetailSelect`** — so the same orphaned-tag 500 also affects `getModeratorArticles`, the article search indexer, and the outbound article webhook. Fixing it once in the selector covers all four consumers.

## Fix

Add a relation-existence filter (`{ is: {} }`, the type-clean idiom for a *required* to-one relation — the generated `*ScalarRelationFilter` has no `null`) so the DB drops orphan rows server-side and each query **degrades gracefully** (returns the resolvable rows / empty) instead of 500ing. No data is mutated; orphan rows are simply skipped, matching the handlers' already-defensive `?.`/`.filter(isDefined)` intent.

- `model.service.ts` — `where.modelVersion: { is: {} }` on `getRecentlyManuallyAdded`.
- `article.selector.ts` — `tags: { ..., where: { tag: { is: {} } } }` in the shared `articleDetailSelect`.

## Test

`src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts`:

- asserts the orphan-exclusion filter is present on both queries (the load-bearing change — these **fail without the fix**, verified by reverting),
- asserts `getRecentlyManuallyAdded` returns the surviving `modelId`s (deduped) / `[]` rather than throwing when the DB has filtered the orphans out,
- asserts the shared `articleDetailSelect.tags` carries the `where` clause so every consumer is protected.

All 4 pass; both filter-assertion tests fail on the pre-fix code.

## Not addressed (follow-up)

The 1.2M orphaned `ImageResourceNew` rows (and 40 `TagsOnArticle`) are real data hygiene debt — a separate cleanup job could prune them and the FK constraints could be re-validated. This PR only stops them from 500ing user requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Behavior note (silent degrade)
The orphan-tag filter means any consumer of these selectors now **silently omits a tag whenever its `Tag` row was hard-deleted**, instead of 500ing. This is the intended graceful degrade (a deleted tag has no name and shouldn't render anyway), but it is a real, silent behavior change for downstream consumers that assumed a complete tag set — notably the `new-bounty` webhook (`bounty.webhooks.ts`) payload and the post/article/bounty detail pages.