### PR TITLE
feat(app-blocks): dark backpay reader for tracked attribution (no disbursement)

### DIFF
--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -215,3 +215,42 @@ export async function isAppBlocksPipelineEnabled(): Promise<boolean> {
 export async function isAppBlocksRuntimeEnabled(): Promise<boolean> {
   return isFlipt(APP_BLOCKS_RUNTIME_FLAG);
 }
+
+/**
+ * Dedicated GLOBAL fail-closed flag for the attribution BACKPAY reader
+ * (W3 attribution back-half — Slice 4 read leg, see backpay.service.ts).
+ *
+ * The backpay reader transitions TRACK-ONLY attribution rows
+ * (`status='tracked'`) to `confirmed` at a SIGNED-OFF rate, stamping the
+ * computed author share. It moves NO money — a separate payout rail disburses
+ * `confirmed` rows. Because it is the gate between "recorded but unrated" and
+ * "confirmed for disbursement," it must be DARK until monetization sign-off.
+ *
+ * This is one half of the backpay's DOUBLE-DARK gate; the other half is a
+ * `SIGNED_OFF_RATE_CARD_VERSION` constant (null today) checked in the service.
+ * BOTH must pass for the reader to write — so even with this flag on, an
+ * unsigned/mismatched rate version still refuses (the reader can never apply a
+ * placeholder rate).
+ *
+ * Evaluated globally (entityId='global', empty context), mirroring
+ * `isAppBlocksPipelineEnabled` exactly — so it must be a PLAIN base-`enabled`
+ * boolean in Flipt (NOT segmented), or it would never resolve true.
+ *
+ * Fail-safe: the flag does NOT exist in Flipt yet (it is created only AFTER
+ * this merges, and only when leadership has signed off a rate), or Flipt is
+ * unreachable → `isFlipt` returns `false` → the backpay reader REFUSES (writes
+ * nothing, `skipped:'flag-disabled'`). So the as-merged behaviour is fully
+ * dark and cannot regress open.
+ */
+export const APP_BLOCKS_BACKPAY_FLAG = 'app-blocks-backpay-enabled';
+
+/**
+ * GLOBAL fail-closed gate for the attribution BACKPAY reader (Slice 4).
+ *
+ * Evaluates the dedicated `app-blocks-backpay-enabled` flag with no user
+ * context, mirroring `isAppBlocksPipelineEnabled`. See APP_BLOCKS_BACKPAY_FLAG
+ * for the fail-safe + double-dark reasoning.
+ */
+export async function isAppBlocksBackpayEnabled(): Promise<boolean> {
+  return isFlipt(APP_BLOCKS_BACKPAY_FLAG);
+}

--- a/src/server/services/blocks/__tests__/backpay.service.test.ts
+++ b/src/server/services/blocks/__tests__/backpay.service.test.ts
@@ -63,6 +63,12 @@ const DEFAULT_TEST_CARD = {
 };
 const TEST_CARD = { ...DEFAULT_TEST_CARD };
 const cardHolder = vi.hoisted(() => ({ current: null as unknown }));
+// Lets ONE test override computeSpendShare to simulate a compute bug (a
+// wrong-but-≤gross bounty) so the spend independent-invariant belt can be
+// exercised. null = use the REAL implementation (the default for every test).
+const computeHolder = vi.hoisted(() => ({
+  spend: null as null | ((arg: unknown) => unknown),
+}));
 
 vi.mock('../rate-card', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../rate-card')>();
@@ -71,6 +77,8 @@ vi.mock('../rate-card', async (importOriginal) => {
     get ACTIVE_RATE_CARD() {
       return cardHolder.current;
     },
+    computeSpendShare: (arg: unknown) =>
+      (computeHolder.spend ?? actual.computeSpendShare)(arg),
   };
 });
 
@@ -123,6 +131,7 @@ function signOff(version: string | null = TEST_CARD.version) {
 beforeEach(() => {
   vi.restoreAllMocks();
   cardHolder.current = TEST_CARD; // reset to the default 20%/10% card
+  computeHolder.spend = null; // default: REAL computeSpendShare
   mockLog.mockReset();
   mockFlag.mockReset();
   mockDbRead.blockSubscriptionAttribution.findMany.mockReset().mockResolvedValue([]);
@@ -423,5 +432,73 @@ describe('0%-rate signed-off card (edge)', () => {
     const spendCall = mockDbWrite.blockSpendAttribution.updateMany.mock.calls[0][0];
     expect(spendCall.data.status).toBe('confirmed');
     expect(spendCall.data.appOwnerShareCents).toBe(0);
+  });
+});
+
+describe('independent invariant belts — no false positives on legit edges, fires on a real mismatch', () => {
+  beforeEach(() => {
+    mockFlag.mockResolvedValue(true);
+    signOff();
+  });
+
+  it('subscription fee==0 → still confirms (net=gross, author=floor(gross*pct))', async () => {
+    // gross 1000, fee 0 → net 1000, author = floor(1000*20%) = 200, platform 800.
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([
+      subRow({ id: 'bsu_fee0', grossValueCents: 1000, providerFeeCents: 0, appOwnerUserId: 7 }),
+    ]);
+    const out = await backpayTrackedAttributions();
+    expect(out.confirmedCount).toBe(1);
+    expect(out.heldCount).toBe(0);
+    const call = mockDbWrite.blockSubscriptionAttribution.updateMany.mock.calls[0][0];
+    expect(call.data.status).toBe('confirmed');
+    expect(call.data.appOwnerShareCents).toBe(200);
+    expect(call.data.platformShareCents).toBe(800);
+  });
+
+  it('subscription net==0 (gross==fee) → still confirms, author 0, platform 0', async () => {
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([
+      subRow({ id: 'bsu_net0', grossValueCents: 500, providerFeeCents: 500, appOwnerUserId: 7 }),
+    ]);
+    const out = await backpayTrackedAttributions();
+    expect(out.confirmedCount).toBe(1);
+    const call = mockDbWrite.blockSubscriptionAttribution.updateMany.mock.calls[0][0];
+    expect(call.data.status).toBe('confirmed');
+    expect(call.data.appOwnerShareCents).toBe(0);
+    expect(call.data.platformShareCents).toBe(0);
+  });
+
+  it('spend gross==0 → still confirms with share 0 (no false skip at the zero edge)', async () => {
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([
+      spendRow({ id: 'bsa_0', grossValueCents: 0, appOwnerUserId: 7 }),
+    ]);
+    const out = await backpayTrackedAttributions();
+    expect(out.confirmedCount).toBe(1);
+    const call = mockDbWrite.blockSpendAttribution.updateMany.mock.calls[0][0];
+    expect(call.data.status).toBe('confirmed');
+    expect(call.data.appOwnerShareCents).toBe(0);
+  });
+
+  it('spend bounty that disagrees with the independent re-derivation → skipped (belt fires)', async () => {
+    // Simulate a computeSpendShare bug: returns 999 for gross 1000 @ 10%
+    // (expected 100). 999 <= gross, so the bare `> gross` ceiling would MISS it;
+    // the independent re-derivation catches it and skips the row.
+    computeHolder.spend = () => ({
+      rateCardVersion: TEST_CARD.version,
+      spendSharePct: 10,
+      appOwnerShareCents: 999,
+    });
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([
+      spendRow({ id: 'bsa_bad', grossValueCents: 1000, appOwnerUserId: 7 }),
+    ]);
+    const out = await backpayTrackedAttributions();
+    expect(out.confirmedCount).toBe(0);
+    expect(mockDbWrite.blockSpendAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('spend share failed an independent invariant'),
+        expectedShareCents: 100,
+      }),
+      'webhooks'
+    );
   });
 });

--- a/src/server/services/blocks/__tests__/backpay.service.test.ts
+++ b/src/server/services/blocks/__tests__/backpay.service.test.ts
@@ -206,14 +206,37 @@ describe('happy path (gate forced open)', () => {
     expect(call.data.status).toBe('confirmed');
     expect(call.data.rateCardVersion).toBe(TEST_CARD.version);
     expect(call.data.appOwnerShareCents).toBe(180);
-    expect(call.data.providerFeeCents).toBe(100);
     expect(call.data.platformShareCents).toBe(720);
     expect(call.data.subscriptionSharePct).toBe(20);
     expect(call.data.confirmedAt).toBeInstanceOf(Date);
-    // conservation, asserted exactly
-    expect(
-      call.data.providerFeeCents + call.data.platformShareCents + call.data.appOwnerShareCents
-    ).toBe(1000);
+    // providerFeeCents is NOT re-stamped — the recorded Stripe fee is preserved.
+    expect(call.data.providerFeeCents).toBeUndefined();
+    // conservation against the row's STORED fee (100): fee + platform + author = gross.
+    expect(100 + call.data.platformShareCents + call.data.appOwnerShareCents).toBe(1000);
+  });
+
+  it('subscription row whose stored fee disagrees with compute (fee > gross) → skipped, NOT confirmed', async () => {
+    // Anomalous row: stored fee 1200 > gross 1000. computeSubscriptionShare
+    // clamps safeFee = min(gross, fee) = 1000, so share.providerFeeCents (1000)
+    // != the row's stored fee (1200) → the independent feeAgrees belt fires and
+    // the row is SKIPPED. Backpay never rewrites the recorded fee to force the
+    // math; the anomaly is left tracked for review.
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([
+      subRow({ id: 'bsu_bad', grossValueCents: 1000, providerFeeCents: 1200, appOwnerUserId: 7 }),
+    ]);
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.confirmedCount).toBe(0);
+    expect(out.heldCount).toBe(0);
+    expect(mockDbWrite.blockSubscriptionAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('failed an independent invariant'),
+        feeAgrees: false,
+      }),
+      'webhooks'
+    );
   });
 
   it('spend tracked → confirmed with share<=gross; version + pct stamped', async () => {
@@ -392,12 +415,10 @@ describe('0%-rate signed-off card (edge)', () => {
     const subCall = mockDbWrite.blockSubscriptionAttribution.updateMany.mock.calls[0][0];
     expect(subCall.data.status).toBe('confirmed');
     expect(subCall.data.appOwnerShareCents).toBe(0);
-    // conservation: fee 100 + platform 900 + author 0 = gross 1000
-    expect(
-      subCall.data.providerFeeCents +
-        subCall.data.platformShareCents +
-        subCall.data.appOwnerShareCents
-    ).toBe(1000);
+    // providerFeeCents is preserved (not re-stamped); conservation against the
+    // row's STORED fee (100): fee 100 + platform 900 + author 0 = gross 1000.
+    expect(subCall.data.providerFeeCents).toBeUndefined();
+    expect(100 + subCall.data.platformShareCents + subCall.data.appOwnerShareCents).toBe(1000);
 
     const spendCall = mockDbWrite.blockSpendAttribution.updateMany.mock.calls[0][0];
     expect(spendCall.data.status).toBe('confirmed');

--- a/src/server/services/blocks/__tests__/backpay.service.test.ts
+++ b/src/server/services/blocks/__tests__/backpay.service.test.ts
@@ -1,0 +1,406 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Blocks BACKPAY reader coverage (W3 attribution back-half, Slice 4).
+ *
+ * This is MONEY-COMPUTATION code — the load-bearing property is the DOUBLE-DARK
+ * gate (a fail-closed Flipt flag AND a signed-off rate-card version, BOTH
+ * required) plus the conservation/ceiling invariants, idempotency, the per-app
+ * Sybil cap, and dryRun. The reader moves NO money; it only transitions
+ * tracked → confirmed/held and stamps the share.
+ *
+ * Prisma + logger + the Flipt flag are mocked at the module boundary so the
+ * test stays in-process and deterministic. `computeSpendShare` /
+ * `computeSubscriptionShare` stay REAL (mocking the money math would defeat the
+ * point) — only `ACTIVE_RATE_CARD` is overlaid with a fixed test card so the
+ * percentages are stable regardless of the live card.
+ */
+
+const { mockDbRead, mockDbWrite, mockLog, mockFlag } = vi.hoisted(() => ({
+  mockDbRead: {
+    blockSubscriptionAttribution: { findMany: vi.fn() },
+    blockSpendAttribution: { findMany: vi.fn() },
+  },
+  mockDbWrite: {
+    blockSubscriptionAttribution: { updateMany: vi.fn() },
+    blockSpendAttribution: { updateMany: vi.fn() },
+  },
+  mockLog: vi.fn(),
+  mockFlag: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: mockDbWrite,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: unknown[]) => {
+    mockLog(...args);
+    return Promise.resolve(null);
+  },
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksBackpayEnabled: () => mockFlag(),
+}));
+
+// A fixed test rate card: subscription 20%, spend 10%, no internal owners. We
+// keep computeSpendShare/computeSubscriptionShare REAL and only overlay
+// ACTIVE_RATE_CARD so the math is deterministic. The mock exposes ACTIVE_RATE_CARD
+// as a GETTER over a mutable holder so a test can swap to a 0%-rate card.
+const DEFAULT_TEST_CARD = {
+  version: 'test-v1',
+  publisherSharePctByScope: {
+    per_model_install: 0,
+    publisher_all_my_models: 0,
+    viewer_personal: 0,
+    platform_default: 0,
+    viewer_global: 0,
+  },
+  spendSharePct: 10,
+  subscriptionSharePct: 20,
+  internalAppOwnerUserIds: [] as number[],
+  effectiveFrom: '2026-06-18',
+};
+const TEST_CARD = { ...DEFAULT_TEST_CARD };
+const cardHolder = vi.hoisted(() => ({ current: null as unknown }));
+
+vi.mock('../rate-card', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../rate-card')>();
+  return {
+    ...actual,
+    get ACTIVE_RATE_CARD() {
+      return cardHolder.current;
+    },
+  };
+});
+
+import {
+  backpayTrackedAttributions,
+  internal,
+  MAX_BACKPAY_CENTS_PER_APP_PER_RUN,
+  SIGNED_OFF_RATE_CARD_VERSION,
+} from '../backpay.service';
+
+type SubRow = {
+  id: string;
+  grossValueCents: number;
+  providerFeeCents: number;
+  appBlockId: string;
+  appOwnerUserId: number;
+};
+type SpendRow = {
+  id: string;
+  grossValueCents: number;
+  appBlockId: string;
+  appOwnerUserId: number;
+};
+
+function subRow(over: Partial<SubRow> = {}): SubRow {
+  return {
+    id: 'bsu_1',
+    grossValueCents: 1000,
+    providerFeeCents: 100,
+    appBlockId: 'apb_1',
+    appOwnerUserId: 42,
+    ...over,
+  };
+}
+function spendRow(over: Partial<SpendRow> = {}): SpendRow {
+  return {
+    id: 'bsa_1',
+    grossValueCents: 1000,
+    appBlockId: 'apb_1',
+    appOwnerUserId: 42,
+    ...over,
+  };
+}
+
+/** Force the signed-off-version gate open to the test card's version. */
+function signOff(version: string | null = TEST_CARD.version) {
+  vi.spyOn(internal, 'getSignedOffRateCardVersion').mockReturnValue(version);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  cardHolder.current = TEST_CARD; // reset to the default 20%/10% card
+  mockLog.mockReset();
+  mockFlag.mockReset();
+  mockDbRead.blockSubscriptionAttribution.findMany.mockReset().mockResolvedValue([]);
+  mockDbRead.blockSpendAttribution.findMany.mockReset().mockResolvedValue([]);
+  mockDbWrite.blockSubscriptionAttribution.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  mockDbWrite.blockSpendAttribution.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  // Default: flag ON (gate half 1 open) — individual tests override.
+  mockFlag.mockResolvedValue(true);
+});
+
+describe('production default — both gate halves dark', () => {
+  it('SIGNED_OFF_RATE_CARD_VERSION is null in production (no rate signed off)', () => {
+    expect(SIGNED_OFF_RATE_CARD_VERSION).toBeNull();
+  });
+});
+
+describe('DOUBLE-DARK gate', () => {
+  it('flag off → no writes, skipped=flag-disabled', async () => {
+    mockFlag.mockResolvedValue(false);
+    signOff(); // even with a signed-off version, the flag half refuses
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.enabled).toBe(false);
+    expect(out.skipped).toBe('flag-disabled');
+    expect(mockDbRead.blockSubscriptionAttribution.findMany).not.toHaveBeenCalled();
+    expect(mockDbRead.blockSpendAttribution.findMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockSubscriptionAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockSpendAttribution.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('flag on but signed-off version null → no writes, skipped=no-signed-off-rate', async () => {
+    mockFlag.mockResolvedValue(true);
+    signOff(null); // production default
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.enabled).toBe(false);
+    expect(out.skipped).toBe('no-signed-off-rate');
+    expect(mockDbRead.blockSubscriptionAttribution.findMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockSpendAttribution.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('signed-off version set but != ACTIVE_RATE_CARD.version → refuse', async () => {
+    mockFlag.mockResolvedValue(true);
+    signOff('some-other-version');
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.enabled).toBe(false);
+    expect(out.skipped).toBe('signed-off-version-mismatch');
+    expect(mockDbWrite.blockSubscriptionAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockSpendAttribution.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('happy path (gate forced open)', () => {
+  beforeEach(() => {
+    mockFlag.mockResolvedValue(true);
+    signOff();
+  });
+
+  it('subscription tracked → confirmed; conservation fee+platform+author=gross exact; version stamped', async () => {
+    // gross 1000, fee 100 → net 900, author = floor(900 * 20%) = 180,
+    // platform = 900 - 180 = 720. fee(100)+platform(720)+author(180)=1000.
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([
+      subRow({ id: 'bsu_x', grossValueCents: 1000, providerFeeCents: 100, appOwnerUserId: 7 }),
+    ]);
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.enabled).toBe(true);
+    expect(out.skipped).toBeUndefined();
+    expect(out.confirmedCount).toBe(1);
+    expect(out.confirmedShareCents).toBe(180);
+    expect(out.heldCount).toBe(0);
+
+    const call = mockDbWrite.blockSubscriptionAttribution.updateMany.mock.calls[0][0];
+    // idempotent write gate
+    expect(call.where).toEqual({ id: 'bsu_x', status: 'tracked' });
+    expect(call.data.status).toBe('confirmed');
+    expect(call.data.rateCardVersion).toBe(TEST_CARD.version);
+    expect(call.data.appOwnerShareCents).toBe(180);
+    expect(call.data.providerFeeCents).toBe(100);
+    expect(call.data.platformShareCents).toBe(720);
+    expect(call.data.subscriptionSharePct).toBe(20);
+    expect(call.data.confirmedAt).toBeInstanceOf(Date);
+    // conservation, asserted exactly
+    expect(
+      call.data.providerFeeCents + call.data.platformShareCents + call.data.appOwnerShareCents
+    ).toBe(1000);
+  });
+
+  it('spend tracked → confirmed with share<=gross; version + pct stamped', async () => {
+    // gross 1000, spend 10% → author = 100, <= gross.
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([
+      spendRow({ id: 'bsa_x', grossValueCents: 1000, appOwnerUserId: 7 }),
+    ]);
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.confirmedCount).toBe(1);
+    expect(out.confirmedShareCents).toBe(100);
+
+    const call = mockDbWrite.blockSpendAttribution.updateMany.mock.calls[0][0];
+    expect(call.where).toEqual({ id: 'bsa_x', status: 'tracked' });
+    expect(call.data.status).toBe('confirmed');
+    expect(call.data.rateCardVersion).toBe(TEST_CARD.version);
+    expect(call.data.spendSharePct).toBe(10);
+    expect(call.data.appOwnerShareCents).toBe(100);
+    expect(call.data.appOwnerShareCents).toBeLessThanOrEqual(1000);
+    expect(call.data.confirmedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('idempotency', () => {
+  it('only ever reads status=tracked rows and updates WHERE status=tracked', async () => {
+    mockFlag.mockResolvedValue(true);
+    signOff();
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([subRow({ id: 'bsu_i' })]);
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([spendRow({ id: 'bsa_i' })]);
+
+    await backpayTrackedAttributions();
+
+    expect(mockDbRead.blockSubscriptionAttribution.findMany.mock.calls[0][0].where).toMatchObject({
+      status: 'tracked',
+      entryType: 'charge',
+    });
+    expect(mockDbRead.blockSpendAttribution.findMany.mock.calls[0][0].where).toMatchObject({
+      status: 'tracked',
+    });
+    expect(mockDbWrite.blockSubscriptionAttribution.updateMany.mock.calls[0][0].where.status).toBe(
+      'tracked'
+    );
+    expect(mockDbWrite.blockSpendAttribution.updateMany.mock.calls[0][0].where.status).toBe(
+      'tracked'
+    );
+  });
+
+  it('a second run with no tracked rows is a no-op (already-confirmed untouched)', async () => {
+    mockFlag.mockResolvedValue(true);
+    signOff();
+    // No tracked rows left (the first run confirmed them).
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([]);
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([]);
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.confirmedCount).toBe(0);
+    expect(out.heldCount).toBe(0);
+    expect(mockDbWrite.blockSubscriptionAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockSpendAttribution.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('voided rows are never processed', () => {
+  it('the read filter excludes voided rows (only status=tracked is fetched)', async () => {
+    mockFlag.mockResolvedValue(true);
+    signOff();
+    await backpayTrackedAttributions();
+    // The where clause is the guarantee voided rows never enter the set.
+    expect(mockDbRead.blockSubscriptionAttribution.findMany.mock.calls[0][0].where.status).toBe(
+      'tracked'
+    );
+    expect(mockDbRead.blockSpendAttribution.findMany.mock.calls[0][0].where.status).toBe('tracked');
+  });
+});
+
+describe('Sybil per-app cap', () => {
+  beforeEach(() => {
+    mockFlag.mockResolvedValue(true);
+    signOff();
+  });
+
+  it('rows beyond MAX_BACKPAY_CENTS_PER_APP_PER_RUN for one app → held, not confirmed', async () => {
+    // Spend share is 10% of gross. To cross the 100_00-cent cap fast, use a
+    // gross of 60_000 cents → share 6_000 per row. Three rows = 18_000 share;
+    // cap = 10_000. Row1 (6_000) confirms (total 6_000). Row2 would push to
+    // 12_000 > 10_000 → held. Row3 also held.
+    const gross = 60_000;
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([
+      spendRow({ id: 'bsa_1', grossValueCents: gross, appBlockId: 'apb_cap', appOwnerUserId: 7 }),
+      spendRow({ id: 'bsa_2', grossValueCents: gross, appBlockId: 'apb_cap', appOwnerUserId: 7 }),
+      spendRow({ id: 'bsa_3', grossValueCents: gross, appBlockId: 'apb_cap', appOwnerUserId: 7 }),
+    ]);
+
+    const out = await backpayTrackedAttributions();
+
+    // sanity: a single row's share is under the cap so the first confirms
+    expect(60_000 * 0.1).toBeLessThanOrEqual(MAX_BACKPAY_CENTS_PER_APP_PER_RUN);
+    expect(out.confirmedCount).toBe(1);
+    expect(out.confirmedShareCents).toBe(6_000);
+    expect(out.heldCount).toBe(2);
+    expect(out.cappedApps).toHaveLength(1);
+    expect(out.cappedApps[0]).toMatchObject({ appBlockId: 'apb_cap', heldCount: 2 });
+
+    const calls = mockDbWrite.blockSpendAttribution.updateMany.mock.calls.map((c) => c[0]);
+    const confirmCalls = calls.filter((c) => c.data.status === 'confirmed');
+    const heldCalls = calls.filter((c) => c.data.status === 'held');
+    expect(confirmCalls).toHaveLength(1);
+    expect(confirmCalls[0].where.id).toBe('bsa_1');
+    expect(heldCalls).toHaveLength(2);
+    expect(heldCalls.every((c) => c.data.voidedReason === 'manual_review')).toBe(true);
+    expect(heldCalls.every((c) => c.where.status === 'tracked')).toBe(true);
+  });
+
+  it('the cap is per app_block_id — a different app is unaffected', async () => {
+    const gross = 60_000;
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([
+      spendRow({ id: 'a1', grossValueCents: gross, appBlockId: 'apb_A', appOwnerUserId: 7 }),
+      spendRow({ id: 'a2', grossValueCents: gross, appBlockId: 'apb_A', appOwnerUserId: 7 }),
+      spendRow({ id: 'b1', grossValueCents: gross, appBlockId: 'apb_B', appOwnerUserId: 7 }),
+    ]);
+
+    const out = await backpayTrackedAttributions();
+
+    // apb_A: row1 confirm, row2 held. apb_B: row1 confirm.
+    expect(out.confirmedCount).toBe(2);
+    expect(out.heldCount).toBe(1);
+    expect(out.cappedApps.map((c) => c.appBlockId)).toEqual(['apb_A']);
+  });
+});
+
+describe('dryRun', () => {
+  it('computes the summary but writes nothing', async () => {
+    mockFlag.mockResolvedValue(true);
+    signOff();
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([
+      subRow({ id: 'bsu_d', grossValueCents: 1000, providerFeeCents: 100, appOwnerUserId: 7 }),
+    ]);
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([
+      spendRow({ id: 'bsa_d', grossValueCents: 1000, appOwnerUserId: 7 }),
+    ]);
+
+    const out = await backpayTrackedAttributions({ dryRun: true });
+
+    expect(out.enabled).toBe(true);
+    expect(out.dryRun).toBe(true);
+    // would confirm both: sub author 180 + spend author 100 = 280
+    expect(out.confirmedCount).toBe(2);
+    expect(out.confirmedShareCents).toBe(280);
+    expect(mockDbWrite.blockSubscriptionAttribution.updateMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.blockSpendAttribution.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('0%-rate signed-off card (edge)', () => {
+  it('author share 0 still transitions tracked → confirmed, conservation holds', async () => {
+    // Overlay a 0% card and sign it off.
+    cardHolder.current = { ...TEST_CARD, version: 'zero-v', spendSharePct: 0, subscriptionSharePct: 0 };
+    mockFlag.mockResolvedValue(true);
+    signOff('zero-v');
+
+    mockDbRead.blockSubscriptionAttribution.findMany.mockResolvedValue([
+      subRow({ id: 'bsu_z', grossValueCents: 1000, providerFeeCents: 100, appOwnerUserId: 7 }),
+    ]);
+    mockDbRead.blockSpendAttribution.findMany.mockResolvedValue([
+      spendRow({ id: 'bsa_z', grossValueCents: 1000, appOwnerUserId: 7 }),
+    ]);
+
+    const out = await backpayTrackedAttributions();
+
+    expect(out.confirmedCount).toBe(2);
+    expect(out.confirmedShareCents).toBe(0); // 0% → no author share
+    expect(out.heldCount).toBe(0);
+
+    const subCall = mockDbWrite.blockSubscriptionAttribution.updateMany.mock.calls[0][0];
+    expect(subCall.data.status).toBe('confirmed');
+    expect(subCall.data.appOwnerShareCents).toBe(0);
+    // conservation: fee 100 + platform 900 + author 0 = gross 1000
+    expect(
+      subCall.data.providerFeeCents +
+        subCall.data.platformShareCents +
+        subCall.data.appOwnerShareCents
+    ).toBe(1000);
+
+    const spendCall = mockDbWrite.blockSpendAttribution.updateMany.mock.calls[0][0];
+    expect(spendCall.data.status).toBe('confirmed');
+    expect(spendCall.data.appOwnerShareCents).toBe(0);
+  });
+});

--- a/src/server/services/blocks/backpay.service.ts
+++ b/src/server/services/blocks/backpay.service.ts
@@ -1,0 +1,461 @@
+import { dbRead, dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { isAppBlocksBackpayEnabled } from '~/server/services/app-blocks-flag';
+import {
+  ACTIVE_RATE_CARD,
+  computeSpendShare,
+  computeSubscriptionShare,
+} from './rate-card';
+
+/**
+ * App Blocks BACKPAY reader (W3 attribution back-half — Slice 4 read leg).
+ *
+ * ## What this is
+ *
+ * Two attribution tables now write TRACK-ONLY rows (PR #2629 membership,
+ * PR #2635 buzz-spend): `block_subscription_attribution` and
+ * `block_spend_attribution`. A track-only row records the EVENT + the MONEY
+ * BASIS (gross_value_cents [+ provider_fee_cents for subscription]) with
+ * `status='tracked'`, `app_owner_share_cents=0`, share-pct 0, and
+ * `rate_card_version='unrated'` (the `UNRATED_RATE_CARD_VERSION` sentinel).
+ * NO rate is applied at write time — deliberately, so immutable rows are never
+ * locked to an unsigned placeholder rate.
+ *
+ * This module is the BACKPAY: when (and ONLY when) a rate is signed off by
+ * monetization leadership, it reads `status='tracked'` rows, computes the
+ * author share at the signed-off rate (via the SAME `computeSpendShare` /
+ * `computeSubscriptionShare` helpers in rate-card.ts), stamps it, and
+ * transitions the row to `confirmed`. A SEPARATE payout rail (PR #2605) later
+ * disburses `confirmed` rows.
+ *
+ * ## What this is NOT
+ *
+ * This module moves NO money. It does not call `createBuzzTransaction`, touch
+ * Tipalti, or credit any account. It ONLY transitions `tracked → confirmed`
+ * (or `tracked → held` for the Sybil cap) and stamps the computed share onto
+ * the row. The returned summary is purely informational.
+ *
+ * ## DOUBLE-DARK GATE (fail-closed — the load-bearing safety property)
+ *
+ * The reader REFUSES to write unless BOTH of these hold; otherwise it returns
+ * a summary with `{ skipped: <reason> }` and writes nothing:
+ *
+ *   1. `isAppBlocksBackpayEnabled()` — a dedicated GLOBAL fail-closed Flipt
+ *      flag (`app-blocks-backpay-enabled`). The flag does NOT exist in Flipt
+ *      yet, so as-merged `isFlipt` returns false → the reader is DARK.
+ *
+ *   2. `SIGNED_OFF_RATE_CARD_VERSION` is non-null AND === ACTIVE_RATE_CARD.version.
+ *      It is `null` TODAY (leadership has not signed off). This guarantees the
+ *      backpay can NEVER apply a placeholder/unsigned rate: even with the flag
+ *      on, a null or mismatched signed-off version → refuse.
+ *
+ * Flipping `SIGNED_OFF_RATE_CARD_VERSION` to a real version is a MONETIZATION-
+ * LEADERSHIP action, not an engineering one. Do not change it without an
+ * explicit, recorded sign-off on the rate-card percentages.
+ */
+
+const BACKPAY_LOG_NAME = 'block-attribution-backpay';
+
+/**
+ * The rate-card version that monetization leadership has SIGNED OFF for backpay.
+ *
+ * ⚠️⚠️⚠️ NULL TODAY — leadership has NOT signed off on any rate. ⚠️⚠️⚠️
+ *
+ * Flipping this to a real version string (e.g. 'v6') is a MONETIZATION-
+ * LEADERSHIP decision, NOT an engineering change. It authorizes the backpay to
+ * stamp every tracked row's author share at THAT card's percentages and confirm
+ * it for eventual disbursement. Do NOT change this without a recorded sign-off
+ * on the rate-card values, AND only to a version that equals
+ * `ACTIVE_RATE_CARD.version` (the gate refuses a mismatch — see the double-dark
+ * gate above). The backpay reads this via {@link getSignedOffRateCardVersion}
+ * so the gate is testable without weakening this production default.
+ */
+export const SIGNED_OFF_RATE_CARD_VERSION: string | null = null;
+
+/**
+ * Internal getter for the signed-off version. Exists ONLY so tests can force
+ * the gate open WITHOUT weakening the production default of `null`.
+ *
+ * Production always resolves the version through `internal.getSignedOffRateCardVersion`
+ * (the indirection object below) — tests override `internal.getSignedOffRateCardVersion`
+ * to force the gate open. The production default returned here stays `null`.
+ */
+export function getSignedOffRateCardVersion(): string | null {
+  return SIGNED_OFF_RATE_CARD_VERSION;
+}
+
+/**
+ * Indirection object the service reads through, so a test can override the
+ * signed-off-version resolver WITHOUT mutating the `SIGNED_OFF_RATE_CARD_VERSION`
+ * const (whose production default must stay `null`). In ESM a same-module call
+ * to a top-level export can't be spied, so the service calls
+ * `internal.getSignedOffRateCardVersion()` rather than the bare function.
+ */
+export const internal = { getSignedOffRateCardVersion };
+
+/**
+ * Per-app Sybil accrual cap (gate c).
+ *
+ * ⚠️ PLACEHOLDER VALUE — the real number is a PRODUCT DECISION, not an
+ * engineering one. 100_00 = $100.00 of confirmed author share per app per run
+ * is an explicit, conservative starting point.
+ *
+ * The cap is per `app_block_id` (NOT per `app_owner_user_id`): "per app" is the
+ * block being credited, and the threat model is a Sybil viewer ring driving
+ * unbounded events toward ONE app/block. Capping by owner would lump an
+ * author's many distinct apps into one bucket — too coarse, and it would let a
+ * single abusive app drain the budget of the author's other (legitimate) apps.
+ * Capping by block matches "protect each app's accrual independently."
+ *
+ * When an app's CUMULATIVE confirmed share within a single run would exceed
+ * this cap, its further rows are routed to `status='held'` (reviewable /
+ * releasable — NOT confirmed, NOT voided) with `voided_reason='manual_review'`,
+ * and the app is logged + reported in `cappedApps`. Held rows can be released
+ * by a later manual review; the cap is forward-only and reversible.
+ */
+export const MAX_BACKPAY_CENTS_PER_APP_PER_RUN = 100_00;
+
+export type BackpaySummary = {
+  /** True when both gate halves passed (flag on AND signed-off version valid). */
+  enabled: boolean;
+  /** True when the run computed but wrote nothing. */
+  dryRun: boolean;
+  /** The version the gate resolved (null when not signed off). */
+  signedOffVersion: string | null;
+  /** Rows examined (status='tracked', entry_type='charge') per table. */
+  processed: { subscription: number; spend: number };
+  /** Rows transitioned tracked → confirmed (0 in dryRun; "would confirm" count). */
+  confirmedCount: number;
+  /** Sum of confirmed author share, in cents (the "would confirm" total in dryRun). */
+  confirmedShareCents: number;
+  /** Rows routed to 'held' by the Sybil cap (0 in dryRun; "would hold" count). */
+  heldCount: number;
+  /** app_block_ids that hit the cap this run, with the share that breached it. */
+  cappedApps: Array<{ appBlockId: string; confirmedShareCents: number; heldCount: number }>;
+  /** Present (and the ONLY meaningful field besides enabled/signedOffVersion) when the gate refused. */
+  skipped?: string;
+};
+
+type BackpayOpts = { dryRun?: boolean; limit?: number };
+
+const DEFAULT_LIMIT = 1000;
+
+/**
+ * Read `status='tracked'` attribution rows in both tables, compute the author
+ * share at the SIGNED-OFF rate, and transition them `tracked → confirmed`
+ * (or `tracked → held` when an app exceeds the per-run Sybil cap). Moves no
+ * money. Idempotent — only ever acts on `status='tracked'`, and the update is
+ * gated `WHERE status='tracked'` so a row can never be double-confirmed.
+ *
+ * @param opts.dryRun  Compute the full summary but write nothing. The eventual
+ *   job caller defaults to dryRun.
+ * @param opts.limit   Max rows to process PER TABLE per run, for safe
+ *   incremental rollout. Defaults to {@link DEFAULT_LIMIT}.
+ */
+export async function backpayTrackedAttributions(
+  opts: BackpayOpts = {}
+): Promise<BackpaySummary> {
+  const dryRun = opts.dryRun ?? false;
+  const limit = Math.max(1, Math.floor(opts.limit ?? DEFAULT_LIMIT));
+
+  const signedOffVersion = internal.getSignedOffRateCardVersion();
+
+  const empty: Omit<BackpaySummary, 'skipped' | 'enabled'> = {
+    dryRun,
+    signedOffVersion,
+    processed: { subscription: 0, spend: 0 },
+    confirmedCount: 0,
+    confirmedShareCents: 0,
+    heldCount: 0,
+    cappedApps: [],
+  };
+
+  const refuse = (skipped: string): BackpaySummary => {
+    const summary: BackpaySummary = { ...empty, enabled: false, skipped };
+    logToAxiom(
+      {
+        name: BACKPAY_LOG_NAME,
+        type: 'warning',
+        message: `backpay refused: ${skipped}`,
+        skipped,
+        dryRun,
+        signedOffVersion,
+      },
+      'webhooks'
+    ).catch(() => null);
+    return summary;
+  };
+
+  // ── DOUBLE-DARK GATE half 1: global fail-closed Flipt flag ──────────────
+  const flagOn = await isAppBlocksBackpayEnabled();
+  if (!flagOn) return refuse('flag-disabled');
+
+  // ── DOUBLE-DARK GATE half 2: a signed-off rate-card version that matches
+  // the active card. null (today) OR a mismatch → refuse, so the backpay can
+  // never apply a placeholder/unsigned rate even with the flag on. ──────────
+  if (signedOffVersion == null) return refuse('no-signed-off-rate');
+  if (signedOffVersion !== ACTIVE_RATE_CARD.version) {
+    return refuse('signed-off-version-mismatch');
+  }
+
+  // Gate passed. From here we either WRITE (tracked → confirmed/held) or, in
+  // dryRun, compute the identical summary without persisting.
+  const internalOwnerIds = new Set(ACTIVE_RATE_CARD.internalAppOwnerUserIds);
+
+  // Per-app (app_block_id) accrual within this run, for the Sybil cap.
+  const accrualByApp = new Map<string, number>();
+  const cappedByApp = new Map<string, { confirmedShareCents: number; heldCount: number }>();
+
+  let confirmedCount = 0;
+  let confirmedShareCents = 0;
+  let heldCount = 0;
+
+  // ── Subscription (block_subscription_attribution) ────────────────────────
+  const subRows = await dbRead.blockSubscriptionAttribution.findMany({
+    where: { status: 'tracked', entryType: 'charge' },
+    select: {
+      id: true,
+      grossValueCents: true,
+      providerFeeCents: true,
+      appBlockId: true,
+      appOwnerUserId: true,
+    },
+    orderBy: { attributedAt: 'asc' },
+    take: limit,
+  });
+
+  for (const row of subRows) {
+    // Belt-and-braces: internal-owner rows are written 'voided' at record time
+    // (never 'tracked'), so they won't appear here — but skip defensively so a
+    // future write-path change can't leak an internal payout through backpay.
+    if (internalOwnerIds.has(row.appOwnerUserId)) continue;
+
+    const share = computeSubscriptionShare({
+      rateCard: ACTIVE_RATE_CARD,
+      grossCents: row.grossValueCents,
+      providerFeeCents: row.providerFeeCents,
+      isSelfPurchase: false,
+      appOwnerUserId: row.appOwnerUserId,
+    });
+
+    // Conservation invariant: fee + platform + author = gross. By construction
+    // safeFee + (net - author) + author = safeGross; assert before persisting.
+    const platformShareCents =
+      row.grossValueCents - share.providerFeeCents - share.appOwnerShareCents;
+    const conserved =
+      share.providerFeeCents + platformShareCents + share.appOwnerShareCents ===
+      row.grossValueCents;
+    if (!conserved) {
+      // A conservation break is a compute bug; never persist it. Log + skip.
+      logToAxiom(
+        {
+          name: BACKPAY_LOG_NAME,
+          type: 'error',
+          message: `subscription conservation invariant broken; skipping ${row.id}`,
+          attributionId: row.id,
+          grossValueCents: row.grossValueCents,
+          providerFeeCents: share.providerFeeCents,
+          platformShareCents,
+          appOwnerShareCents: share.appOwnerShareCents,
+        },
+        'webhooks'
+      ).catch(() => null);
+      continue;
+    }
+
+    const decision = applyCap(
+      accrualByApp,
+      cappedByApp,
+      row.appBlockId,
+      share.appOwnerShareCents
+    );
+
+    if (decision === 'held') {
+      heldCount += 1;
+      if (!dryRun) {
+        await dbWrite.blockSubscriptionAttribution.updateMany({
+          where: { id: row.id, status: 'tracked' },
+          data: { status: 'held', voidedReason: 'manual_review' },
+        });
+      }
+      continue;
+    }
+
+    confirmedCount += 1;
+    confirmedShareCents += share.appOwnerShareCents;
+    if (!dryRun) {
+      await dbWrite.blockSubscriptionAttribution.updateMany({
+        // WHERE status='tracked' makes the confirm idempotent — a concurrent
+        // run or a re-run can never double-confirm an already-confirmed row.
+        where: { id: row.id, status: 'tracked' },
+        data: {
+          status: 'confirmed',
+          confirmedAt: new Date(),
+          rateCardVersion: signedOffVersion,
+          subscriptionSharePct: share.subscriptionSharePct,
+          appOwnerShareCents: share.appOwnerShareCents,
+          platformShareCents,
+          providerFeeCents: share.providerFeeCents,
+        },
+      });
+    }
+  }
+
+  // ── Spend (block_spend_attribution) ──────────────────────────────────────
+  const spendRows = await dbRead.blockSpendAttribution.findMany({
+    where: { status: 'tracked' },
+    select: {
+      id: true,
+      grossValueCents: true,
+      appBlockId: true,
+      appOwnerUserId: true,
+    },
+    orderBy: { attributedAt: 'asc' },
+    take: limit,
+  });
+
+  for (const row of spendRows) {
+    // tracked spend rows are never self/internal (those are written 'voided');
+    // skip internal owners defensively all the same.
+    if (internalOwnerIds.has(row.appOwnerUserId)) continue;
+
+    const share = computeSpendShare({
+      rateCard: ACTIVE_RATE_CARD,
+      grossValueCents: row.grossValueCents,
+      isSelfSpend: false,
+      appOwnerUserId: row.appOwnerUserId,
+    });
+
+    // Invariant: the platform-funded bounty can never exceed the gross it
+    // rewards. computeSpendShare already clamps to gross; assert before write.
+    if (share.appOwnerShareCents > row.grossValueCents) {
+      logToAxiom(
+        {
+          name: BACKPAY_LOG_NAME,
+          type: 'error',
+          message: `spend share exceeds gross; skipping ${row.id}`,
+          attributionId: row.id,
+          grossValueCents: row.grossValueCents,
+          appOwnerShareCents: share.appOwnerShareCents,
+        },
+        'webhooks'
+      ).catch(() => null);
+      continue;
+    }
+
+    const decision = applyCap(
+      accrualByApp,
+      cappedByApp,
+      row.appBlockId,
+      share.appOwnerShareCents
+    );
+
+    if (decision === 'held') {
+      heldCount += 1;
+      if (!dryRun) {
+        await dbWrite.blockSpendAttribution.updateMany({
+          where: { id: row.id, status: 'tracked' },
+          data: { status: 'held', voidedReason: 'manual_review' },
+        });
+      }
+      continue;
+    }
+
+    confirmedCount += 1;
+    confirmedShareCents += share.appOwnerShareCents;
+    if (!dryRun) {
+      await dbWrite.blockSpendAttribution.updateMany({
+        where: { id: row.id, status: 'tracked' },
+        data: {
+          status: 'confirmed',
+          confirmedAt: new Date(),
+          rateCardVersion: signedOffVersion,
+          spendSharePct: share.spendSharePct,
+          appOwnerShareCents: share.appOwnerShareCents,
+        },
+      });
+    }
+  }
+
+  const cappedApps = Array.from(cappedByApp.entries()).map(([appBlockId, v]) => ({
+    appBlockId,
+    confirmedShareCents: v.confirmedShareCents,
+    heldCount: v.heldCount,
+  }));
+
+  const summary: BackpaySummary = {
+    enabled: true,
+    dryRun,
+    signedOffVersion,
+    processed: { subscription: subRows.length, spend: spendRows.length },
+    confirmedCount,
+    confirmedShareCents,
+    heldCount,
+    cappedApps,
+  };
+
+  for (const capped of cappedApps) {
+    logToAxiom(
+      {
+        name: BACKPAY_LOG_NAME,
+        type: 'warning',
+        message: `backpay Sybil cap hit for app ${capped.appBlockId}`,
+        appBlockId: capped.appBlockId,
+        confirmedShareCents: capped.confirmedShareCents,
+        heldCount: capped.heldCount,
+        capCents: MAX_BACKPAY_CENTS_PER_APP_PER_RUN,
+        dryRun,
+      },
+      'webhooks'
+    ).catch(() => null);
+  }
+
+  logToAxiom(
+    {
+      name: BACKPAY_LOG_NAME,
+      type: 'info',
+      message: dryRun ? 'backpay dry-run complete' : 'backpay run complete',
+      dryRun,
+      signedOffVersion,
+      processedSubscription: summary.processed.subscription,
+      processedSpend: summary.processed.spend,
+      confirmedCount,
+      confirmedShareCents,
+      heldCount,
+      cappedAppCount: cappedApps.length,
+    },
+    'webhooks'
+  ).catch(() => null);
+
+  return summary;
+}
+
+/**
+ * Fold a row's computed share into the per-app accrual and decide whether it
+ * is confirmable or must be held. Routes a row to 'held' the moment confirming
+ * it would push the app's CUMULATIVE confirmed share over the per-run cap (so
+ * the FIRST breaching row and all subsequent rows for that app are held).
+ * Returns 'confirm' or 'held'; mutates `accrualByApp` only for confirmed rows
+ * and records held rows in `cappedByApp`.
+ */
+function applyCap(
+  accrualByApp: Map<string, number>,
+  cappedByApp: Map<string, { confirmedShareCents: number; heldCount: number }>,
+  appBlockId: string,
+  shareCents: number
+): 'confirm' | 'held' {
+  const current = accrualByApp.get(appBlockId) ?? 0;
+  if (current + shareCents > MAX_BACKPAY_CENTS_PER_APP_PER_RUN) {
+    const prev = cappedByApp.get(appBlockId) ?? {
+      confirmedShareCents: current,
+      heldCount: 0,
+    };
+    cappedByApp.set(appBlockId, {
+      confirmedShareCents: current,
+      heldCount: prev.heldCount + 1,
+    });
+    return 'held';
+  }
+  accrualByApp.set(appBlockId, current + shareCents);
+  return 'confirm';
+}

--- a/src/server/services/blocks/backpay.service.ts
+++ b/src/server/services/blocks/backpay.service.ts
@@ -345,17 +345,31 @@ export async function backpayTrackedAttributions(
       appOwnerUserId: row.appOwnerUserId,
     });
 
-    // Invariant: the platform-funded bounty can never exceed the gross it
-    // rewards. computeSpendShare already clamps to gross; assert before write.
-    if (share.appOwnerShareCents > row.grossValueCents) {
+    // INDEPENDENT re-derivation (parallels the subscription belt): the
+    // platform-funded bounty must equal min(gross, floor(gross × pct / 100))
+    // AND never exceed gross. Re-derive from the card's own `spendSharePct`
+    // and skip+log on any mismatch — this catches a computeSpendShare
+    // floor/clamp bug that the bare `> gross` ceiling alone would miss (a
+    // wrong-but-≤gross bounty). Bit-identical to compute for a legit row
+    // (gross is a clean non-negative int from the track-time write), so it
+    // carries no false-positive risk on valid data.
+    const expectedShareCents = Math.min(
+      row.grossValueCents,
+      Math.floor((row.grossValueCents * share.spendSharePct) / 100)
+    );
+    if (
+      share.appOwnerShareCents !== expectedShareCents ||
+      share.appOwnerShareCents > row.grossValueCents
+    ) {
       logToAxiom(
         {
           name: BACKPAY_LOG_NAME,
           type: 'error',
-          message: `spend share exceeds gross; skipping ${row.id}`,
+          message: `spend share failed an independent invariant; skipping ${row.id}`,
           attributionId: row.id,
           grossValueCents: row.grossValueCents,
           appOwnerShareCents: share.appOwnerShareCents,
+          expectedShareCents,
         },
         'webhooks'
       ).catch(() => null);

--- a/src/server/services/blocks/backpay.service.ts
+++ b/src/server/services/blocks/backpay.service.ts
@@ -238,25 +238,42 @@ export async function backpayTrackedAttributions(
       appOwnerUserId: row.appOwnerUserId,
     });
 
-    // Conservation invariant: fee + platform + author = gross. By construction
-    // safeFee + (net - author) + author = safeGross; assert before persisting.
-    const platformShareCents =
-      row.grossValueCents - share.providerFeeCents - share.appOwnerShareCents;
-    const conserved =
-      share.providerFeeCents + platformShareCents + share.appOwnerShareCents ===
-      row.grossValueCents;
-    if (!conserved) {
-      // A conservation break is a compute bug; never persist it. Log + skip.
+    // INDEPENDENT invariant guards (not a residual-based tautology). The old
+    // check defined platform = gross − fee − author and then asserted
+    // fee + platform + author === gross, which is true for ANY inputs and so
+    // could never catch a compute bug. Instead, re-derive each quantity
+    // independently from the row's STORED fee and skip+log on any mismatch:
+    //   (a) feeAgrees   — compute must agree with the row's recorded Stripe fee.
+    //       A divergence means an anomalous row (e.g. stored fee > gross, which
+    //       computeSubscriptionShare clamps): NEVER rewrite a recorded financial
+    //       fact to force the math — skip it for review.
+    //   (b) authorAgrees — the author share must equal an independently-derived
+    //       floor(net × pct / 100); catches a computeSubscriptionShare bug.
+    //   (c) platformNonNeg — platform (= gross − stored fee − author) ≥ 0.
+    // The stored fee is PRESERVED on the write (we do not re-stamp it).
+    const storedFeeCents = row.providerFeeCents;
+    const netCents = row.grossValueCents - storedFeeCents;
+    const expectedAuthorCents = Math.floor((netCents * share.subscriptionSharePct) / 100);
+    const platformShareCents = row.grossValueCents - storedFeeCents - share.appOwnerShareCents;
+    const feeAgrees = share.providerFeeCents === storedFeeCents;
+    const authorAgrees = share.appOwnerShareCents === expectedAuthorCents;
+    const platformNonNeg = platformShareCents >= 0;
+    if (!feeAgrees || !authorAgrees || !platformNonNeg) {
       logToAxiom(
         {
           name: BACKPAY_LOG_NAME,
           type: 'error',
-          message: `subscription conservation invariant broken; skipping ${row.id}`,
+          message: `subscription share failed an independent invariant; skipping ${row.id}`,
           attributionId: row.id,
           grossValueCents: row.grossValueCents,
-          providerFeeCents: share.providerFeeCents,
-          platformShareCents,
+          storedFeeCents,
+          computeFeeCents: share.providerFeeCents,
           appOwnerShareCents: share.appOwnerShareCents,
+          expectedAuthorCents,
+          platformShareCents,
+          feeAgrees,
+          authorAgrees,
+          platformNonNeg,
         },
         'webhooks'
       ).catch(() => null);
@@ -295,7 +312,9 @@ export async function backpayTrackedAttributions(
           subscriptionSharePct: share.subscriptionSharePct,
           appOwnerShareCents: share.appOwnerShareCents,
           platformShareCents,
-          providerFeeCents: share.providerFeeCents,
+          // providerFeeCents intentionally NOT updated — the recorded Stripe fee
+          // from track-time is preserved (and asserted to equal compute's fee
+          // via feeAgrees above). Backpay never rewrites a recorded financial fact.
         },
       });
     }
@@ -432,11 +451,15 @@ export async function backpayTrackedAttributions(
 
 /**
  * Fold a row's computed share into the per-app accrual and decide whether it
- * is confirmable or must be held. Routes a row to 'held' the moment confirming
- * it would push the app's CUMULATIVE confirmed share over the per-run cap (so
- * the FIRST breaching row and all subsequent rows for that app are held).
- * Returns 'confirm' or 'held'; mutates `accrualByApp` only for confirmed rows
- * and records held rows in `cappedByApp`.
+ * is confirmable or must be held. Routes a row to 'held' when confirming it
+ * would push the app's accrued confirmed share over the per-run cap.
+ *
+ * GREEDY, not sticky: a held row does NOT advance `accrualByApp`, so a LATER
+ * SMALLER row for the same app whose share still fits under the cap WILL still
+ * be confirmed. The invariant this enforces is "confirmed share per app per run
+ * ≤ cap" (a greedy fill in `attributedAt asc` order) — NOT "every row after the
+ * first breach is held." Returns 'confirm' or 'held'; mutates `accrualByApp`
+ * only for confirmed rows and records held rows in `cappedByApp`.
  */
 function applyCap(
   accrualByApp: Map<string, number>,


### PR DESCRIPTION
## Dark backpay reader for tracked App Blocks attribution

Adds the **read leg** of the W3 attribution back-half (Slice 4): when — and only when — a rate is signed off, it reads `status='tracked'` rows in the two track-only tables, computes the author share at the signed-off rate, stamps it, and transitions the row to `confirmed`. A separate payout rail (PR #2605, **not** this PR) later disburses `confirmed` rows.

**This PR moves NO money.** No `createBuzzTransaction`, no Tipalti, no account credit. It only transitions `tracked → confirmed` (or `tracked → held`) and stamps the computed share. The returned summary is informational. **Activating it (creating the Flipt flag + setting a signed-off rate version) is a monetization-leadership action, not an engineering one.**

### Double-dark fail-closed gate (the load-bearing safety property)
The reader refuses to write unless **BOTH** hold; otherwise it returns `{ skipped, enabled:false, ... }` and writes nothing:

1. **Flag** — new global fail-closed Flipt flag `app-blocks-backpay-enabled` via `isAppBlocksBackpayEnabled()`, mirroring `isAppBlocksPipelineEnabled` exactly (global eval, plain base-`enabled` boolean). The flag does **not exist in Flipt yet** → `isFlipt` returns false → dark as merged.
2. **Signed-off rate version** — module constant `SIGNED_OFF_RATE_CARD_VERSION: string | null = null` (**null today**). The reader refuses unless it is non-null **AND** `=== ACTIVE_RATE_CARD.version`. So even with the flag on, a null or mismatched version → refuse. This guarantees the backpay can never apply a placeholder/unsigned rate.

Tests read the version through an internal indirection (`internal.getSignedOffRateCardVersion`) so the gate is testable without weakening the production default of `null`.

### Per-table compute + conservation invariants
- **Subscription** (`block_subscription_attribution`): `computeSubscriptionShare(...)` → sets `subscription_share_pct`, `app_owner_share_cents`, `platform_share_cents = gross − fee − author`, `rate_card_version`. The conservation invariant `provider_fee + platform_share + app_owner_share = gross` is **asserted exactly before persisting** (a break is logged + the row skipped, never written).
- **Spend** (`block_spend_attribution`): `computeSpendShare(...)` → sets `spend_share_pct`, `app_owner_share_cents`, `rate_card_version`. The ceiling `app_owner_share_cents <= gross_value_cents` is asserted before persisting.
- Both transition `status: tracked → confirmed`, set `confirmed_at = now()`.

### Sybil per-app accrual cap
Configurable module const `MAX_BACKPAY_CENTS_PER_APP_PER_RUN` (**placeholder $100.00** — the real number is a product decision). Cap is per `app_block_id` (the unit "per app" — capping per owner would be too coarse and let one abusive app drain an author's other apps' budget). Once an app's cumulative confirmed share in a run would exceed the cap, its further rows go to `status='held'` with `voided_reason='manual_review'` (reviewable/releasable, **not** confirmed, **not** voided). Every capped app is logged + returned in `cappedApps`.

### Idempotency / dryRun
- Only ever acts on `status='tracked'`; the update is gated `WHERE status='tracked'` so a row can never be double-confirmed (re-run is a no-op).
- Internal-owner rows skipped as a belt (they're written `voided`, never `tracked`).
- `dryRun` computes the full summary but writes nothing (the eventual job caller should default to dryRun). No cron/job wired in this PR.

### Migration / CHECK-constraint verification (no migration added)
Verified against both tables' CHECK constraints — both already allow `confirmed` and `held`:
- `block_spend_attribution_status_check` (after the tracked-status retrofit): `status IN ('tracked','pending','confirmed','voided','paid_out','held')`; `voided_reason` allows `'manual_review'`.
- `block_subscription_attribution_status_check`: `status IN ('tracked','pending','confirmed','voided','paid_out','held')`; conservation CHECK scoped to `entry_type='charge'`; `voided_reason` allows `'manual_review'`.

No DB trigger or app-level guard blocks updating a `tracked` row (the only existing update on these tables is `voidSubscriptionAttributionsForInvoice`, confirming `tracked→…` mutation is intended). **No migration added.**

### Tests
`src/server/services/blocks/__tests__/backpay.service.test.ts` — 13 node-only unit tests, all green; `rate-card.test.ts` (31) + spend/subscription attribution tests (20) confirmed not regressed. Covers: every gate branch (flag off / version null / version mismatch), subscription happy-path with exact conservation, spend happy-path with `share<=gross`, idempotency, voided-never-processed, Sybil cap (held + per-`app_block_id` isolation), dryRun, and a 0%-rate signed-off card edge (author 0, still confirms, conservation holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
