### PR TITLE
Fungies first-party gift cards + restore gift-cards page

### DIFF
--- a/src/pages/gift-cards/index.module.scss
+++ b/src/pages/gift-cards/index.module.scss
@@ -97,9 +97,7 @@
     }
 
     // Override text colors for better contrast on gradient
-    & {
-      color: white;
-    }
+    color: white;
 
     // Keep badges and text clean for readability - no glassmorphism
   }

--- a/src/pages/gift-cards/index.tsx
+++ b/src/pages/gift-cards/index.tsx
@@ -1,14 +1,669 @@
-import type { GetServerSideProps } from 'next';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Container,
+  Grid,
+  Group,
+  Image,
+  SegmentedControl,
+  Select,
+  Stack,
+  Text,
+  Title,
+  UnstyledButton,
+} from '@mantine/core';
+import {
+  IconExternalLink,
+  IconCheck,
+  IconBolt,
+  IconAlertTriangle,
+  IconCoinBitcoin,
+} from '@tabler/icons-react';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { Meta } from '~/components/Meta/Meta';
+import { PromoNotification } from '~/components/PromoNotification/PromoNotification';
+import { KinguinCheckout } from '~/components/KinguinCheckout';
+import { useKinguinSDK } from '~/hooks/useKinguinSDK';
+import { useMutateCoinbaseCodeOrder, useCoinbaseStatus } from '~/components/Coinbase/util';
+import type { Vendor } from '~/utils/gift-cards/vendors';
+import { NextLink } from '~/components/NextLink/NextLink';
+import { getVendorDiscount } from '~/utils/gift-cards/discount-utils';
+import { GIFT_CARD_DISCLAIMER } from '~/utils/gift-cards/constants';
+import { trpc } from '~/utils/trpc';
+import { Countdown } from '~/components/Countdown/Countdown';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { getEnabledVendorsServer } from '~/server/services/gift-card-vendors.service';
+import classes from './index.module.scss';
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  return {
-    redirect: {
-      destination: '/purchase/buzz',
-      permanent: false,
-    },
-  };
+// Kinguin utility moved to KinguinCheckout component
+
+// Reusable gift card component
+interface GiftCardItemProps {
+  title: string;
+  image: string;
+  imageAlt: string;
+  primaryUrl: string;
+  discountPercentage?: number;
+  className?: string;
+  actions: React.ReactNode;
+  type?: 'buzz' | 'membership';
+}
+
+const GiftCardItem = ({
+  title,
+  image,
+  imageAlt,
+  primaryUrl,
+  discountPercentage,
+  className,
+  actions,
+  type,
+}: GiftCardItemProps) => {
+  const isMembership = type === 'membership';
+  const hasDiscount = !!discountPercentage;
+
+  return (
+    <Card
+      shadow="lg"
+      padding="lg"
+      radius="md"
+      withBorder
+      className={`${className ?? ''} ${classes.giftCardEnhanced}`}
+      style={{
+        position: 'relative',
+        transition: 'all 0.3s ease',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Subtle top accent */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '3px',
+          background:
+            'linear-gradient(90deg, var(--mantine-color-blue-6), var(--mantine-color-cyan-5), var(--mantine-color-violet-6))',
+        }}
+      />
+
+      <Stack gap="md">
+        <Text
+          fw={600}
+          size="lg"
+          ta="center"
+          style={{
+            color: 'var(--mantine-color-text)',
+          }}
+        >
+          {title}
+        </Text>
+
+        <Card.Section p="sm">
+          {primaryUrl ? (
+            <UnstyledButton
+              component="a"
+              href={primaryUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative block"
+            >
+              {hasDiscount && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: 150,
+                    height: 150,
+                    overflow: 'hidden',
+                    zIndex: 2,
+                    pointerEvents: 'none',
+                  }}
+                >
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: 35,
+                      left: -45,
+                      width: 180,
+                      padding: '10px 0',
+                      background: 'linear-gradient(135deg, #ff6b1a 0%, #8b2fc9 100%)',
+                      transform: 'rotate(-45deg)',
+                      textAlign: 'center',
+                      boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+                    }}
+                  >
+                    <Text
+                      size="sm"
+                      fw={700}
+                      c="white"
+                      style={{
+                        textShadow: '0 1px 2px rgba(0, 0, 0, 0.4)',
+                        letterSpacing: '0.5px',
+                      }}
+                    >
+                      {discountPercentage}% OFF
+                    </Text>
+                  </div>
+                </div>
+              )}
+              <Image
+                src={image}
+                alt={imageAlt}
+                height={200}
+                fit="contain"
+                style={{ cursor: 'pointer' }}
+              />
+            </UnstyledButton>
+          ) : (
+            <div className="relative">
+              <Image src={image} alt={imageAlt} height={200} fit="contain" />
+            </div>
+          )}
+        </Card.Section>
+
+        <Stack gap="sm">{actions}</Stack>
+      </Stack>
+    </Card>
+  );
 };
 
-export default function GiftCardsPage() {
-  return null;
+interface GiftCardsPageProps {
+  enabledVendors: Vendor[];
 }
+
+export const getServerSideProps = createServerSideProps<GiftCardsPageProps>({
+  useSession: true,
+  resolver: async ({ session, features }) => {
+    // The entire gift-card experience is gated by the `giftCards` flag (master
+    // Flipt kill switch + blue/red-only domain gating; green is never included).
+    // When it's off — killed, or on the green domain — redirect to pricing.
+    if (!features?.giftCards) {
+      return { redirect: { destination: '/pricing', permanent: false } };
+    }
+
+    const enabledVendors = await getEnabledVendorsServer(session?.user);
+
+    return {
+      props: {
+        // JSON round-trip to convert Date objects to ISO strings,
+        // which Next.js can serialize in getServerSideProps.
+        enabledVendors: JSON.parse(JSON.stringify(enabledVendors)),
+      },
+    };
+  },
+});
+
+export default function GiftCardsPage({ enabledVendors }: GiftCardsPageProps) {
+  const router = useRouter();
+  const [selectedVendor, setSelectedVendor] = useState<Vendor | undefined>();
+  const { data: kinguinPaymentWarning } = trpc.system.getDbKV.useQuery({
+    key: 'kinguinPaymentWarning',
+  });
+  const showKinguinPaymentWarning = !!kinguinPaymentWarning;
+
+  // Kinguin checkout states
+  const [showKinguinCheckout, setShowKinguinCheckout] = useState(false);
+  const [kinguinProductUrl, setKinguinProductUrl] = useState<string>('');
+  const [kinguinProductName, setKinguinProductName] = useState<string>('');
+
+  // Load Kinguin SDK when vendor is Kinguin
+  const kinguinSDK = useKinguinSDK(selectedVendor?.id === 'kinguin');
+
+  // Crypto purchase hooks
+  const { createCodeOrder, creatingCodeOrder } = useMutateCoinbaseCodeOrder();
+  const { healthy: coinbaseHealthy } = useCoinbaseStatus();
+
+  // Handle vendor selection from URL
+  useEffect(() => {
+    const vendorParam = router.query.vendor as string | undefined;
+    if (vendorParam) {
+      const vendor = enabledVendors.find((v) => v.id === vendorParam);
+      if (vendor) {
+        setSelectedVendor(vendor);
+        return;
+      }
+    }
+    // Set default vendor if no valid vendor in URL
+    setSelectedVendor(enabledVendors[0]);
+  }, [router.query.vendor, enabledVendors]);
+
+  // Update URL when vendor changes
+  const handleVendorChange = (vendorId: string) => {
+    const vendor = enabledVendors.find((v) => v.id === vendorId);
+    if (vendor) {
+      // Close Kinguin checkout if switching vendors
+      if (showKinguinCheckout) {
+        closeKinguinCheckout();
+      }
+
+      setSelectedVendor(vendor);
+      router.push(
+        {
+          pathname: '/gift-cards',
+          query: { ...router.query, vendor: vendorId },
+        },
+        undefined,
+        { shallow: true }
+      );
+    }
+  };
+
+  // Check if we should show sections based on query params
+  const typeFilter = router.query.type as string | undefined;
+  const showBuzzCards = !typeFilter || typeFilter === 'buzz';
+  const showMemberships = !typeFilter || typeFilter === 'memberships';
+
+  // Check for purchase success
+  const purchaseSuccess = router.query.purchase === 'success';
+
+  // Handle type filter changes
+  const handleTypeChange = (value: string) => {
+    const newQuery = { ...router.query };
+    if (value === 'all') {
+      delete newQuery.type;
+    } else {
+      newQuery.type = value;
+    }
+
+    router.push(
+      {
+        pathname: '/gift-cards',
+        query: newQuery,
+      },
+      undefined,
+      { shallow: true }
+    );
+  };
+
+  // Kinguin checkout handlers
+  const handleKinguinPurchase = (productUrl: string, productName: string) => {
+    setKinguinProductUrl(productUrl);
+    setKinguinProductName(productName);
+    setShowKinguinCheckout(true);
+  };
+
+  const closeKinguinCheckout = () => {
+    setShowKinguinCheckout(false);
+    setKinguinProductUrl('');
+    setKinguinProductName('');
+  };
+
+  if (!selectedVendor) {
+    return (
+      <>
+        <Meta
+          title="Gift Cards | Civitai"
+          description="Purchase Civitai Buzz gift cards and membership packages"
+          canonical="/gift-cards"
+        />
+        <Container size="xl" py="xl">
+          <Title order={1} mb="lg">
+            Memberships
+          </Title>
+          <Text>No vendors available at this time.</Text>
+        </Container>
+      </>
+    );
+  }
+
+  const formatBuzzAmount = (amount: number) => {
+    if (amount >= 1000) {
+      return `${amount / 1000}K`;
+    }
+    return amount.toString();
+  };
+
+  return (
+    <>
+      <Meta
+        title="Gift Cards | Civitai"
+        description="Purchase Civitai Buzz gift cards and membership packages"
+        canonical="/gift-cards"
+      />
+
+      <Container size="xl" py="xl">
+        <Stack gap="xl">
+          <div className={classes.headerSection}>
+            <Group justify="space-between" align="flex-start" wrap="wrap">
+              <div>
+                <Title order={1} mb="sm">
+                  Memberships
+                </Title>
+                <Text c="dimmed" size="lg">
+                  Purchase gift card membership packages from our trusted vendors
+                </Text>
+              </div>
+
+              <Stack gap="sm" align="flex-end">
+                {/* Controls Row */}
+                <Group gap="md" wrap="wrap">
+                  {/* Type Selector */}
+                  <Stack gap="xs">
+                    <Text size="xs" c="dimmed" fw={700}>
+                      Show
+                    </Text>
+                    <SegmentedControl
+                      value={typeFilter || 'all'}
+                      onChange={handleTypeChange}
+                      data={[
+                        { label: 'All', value: 'all' },
+                        // { label: 'Buzz Cards', value: 'buzz' },
+                        { label: 'Memberships', value: 'memberships' },
+                      ]}
+                      size="sm"
+                    />
+                  </Stack>
+
+                  {/* Vendor Selector */}
+                  <Stack gap="xs">
+                    <Text size="xs" c="dimmed" fw={700}>
+                      Vendor
+                    </Text>
+                    {enabledVendors.length <= 3 ? (
+                      <SegmentedControl
+                        value={selectedVendor.id}
+                        onChange={handleVendorChange}
+                        data={enabledVendors.map((v) => ({
+                          label: v.badge ? (
+                            <Group gap={6} wrap="nowrap" align="center">
+                              <span>{v.displayName}</span>
+                              <Box className={classes.newVendorDot} />
+                            </Group>
+                          ) : (
+                            v.displayName
+                          ),
+                          value: v.id,
+                        }))}
+                        size="sm"
+                      />
+                    ) : (
+                      <Select
+                        value={selectedVendor.id}
+                        onChange={(value) => value && handleVendorChange(value)}
+                        data={enabledVendors.map((v) => ({
+                          label: v.badge ? `${v.displayName} •` : v.displayName,
+                          value: v.id,
+                        }))}
+                        size="sm"
+                        style={{ width: 180 }}
+                      />
+                    )}
+                  </Stack>
+                </Group>
+              </Stack>
+            </Group>
+
+            {/* Promo Notification - positioned absolutely on desktop, normal flow on mobile */}
+            {selectedVendor.promo && (
+              <div className={classes.promoNotification}>
+                <PromoNotification
+                  vendorId={selectedVendor.id}
+                  vendorName={selectedVendor.displayName}
+                  promo={selectedVendor.promo}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Discount Banner */}
+          {(() => {
+            const discountInfo = getVendorDiscount(selectedVendor);
+            return discountInfo.isActive && discountInfo.title && discountInfo.description ? (
+              <Alert
+                variant="filled"
+                title={discountInfo.title}
+                styles={{
+                  root: {
+                    background: 'linear-gradient(135deg, #ff6b1a 0%, #8b2fc9 100%)',
+                    borderColor: '#ff8c42',
+                  },
+                  title: {
+                    color: 'white',
+                  },
+                }}
+              >
+                <Stack gap="xs">
+                  <Text size="sm" c="white">
+                    {discountInfo.description}
+                  </Text>
+                  {selectedVendor.discount?.endDate && (
+                    <Text size="sm" c="white" fw={600}>
+                      Time remaining:{' '}
+                      <Countdown endTime={selectedVendor.discount.endDate} format="short" />
+                    </Text>
+                  )}
+                </Stack>
+              </Alert>
+            ) : null;
+          })()}
+
+          {/* Purchase Success Notification */}
+          {purchaseSuccess && !showKinguinCheckout && (
+            <Alert
+              icon={<IconCheck size={16} />}
+              title="Purchase Successful!"
+              color="green"
+              mb="xl"
+            >
+              Your gift card purchase has been completed successfully. You should receive your gift
+              card code via email shortly.
+            </Alert>
+          )}
+
+          {/* Payment Method Warning */}
+          {!showKinguinCheckout && selectedVendor.id === 'kinguin' && showKinguinPaymentWarning && (
+            <Alert icon={<IconAlertTriangle size={30} />} color="red" radius="md">
+              <Text>
+                Due to current technical limitations on Kinguin, Credit Cards, and some other
+                payment methods, are temporarily unavailable for Civitai Gift Cards.{' '}
+                <Text component={NextLink} href="/purchase/buzz" c="blue" td="underline" inherit>
+                  Alternative Buzz purchase options
+                </Text>{' '}
+                remain available. We&apos;re working with Kinguin to restore full payment support.
+              </Text>
+            </Alert>
+          )}
+
+          {/* Kinguin Checkout View */}
+          {showKinguinCheckout ? (
+            <KinguinCheckout
+              productUrl={kinguinProductUrl}
+              productName={kinguinProductName}
+              onClose={closeKinguinCheckout}
+              sdkLoaded={kinguinSDK.sdkLoaded}
+              sdkError={kinguinSDK.sdkError}
+              kinguinCheckoutSDK={kinguinSDK.kinguinCheckoutSDK}
+            />
+          ) : (
+            <>
+              {/* Buzz Gift Cards Section */}
+              {showBuzzCards && selectedVendor.products.buzzCards.length > 0 && (
+                <div>
+                  <Title order={2} mb="lg">
+                    Buzz Gift Cards
+                  </Title>
+                  <Grid gutter="lg">
+                    {selectedVendor.products.buzzCards.map((card) => {
+                      const discountInfo = getVendorDiscount(selectedVendor);
+                      return (
+                        <Grid.Col key={card.amount} span={{ base: 12, sm: 6, md: 4 }}>
+                          <GiftCardItem
+                            title={`${formatBuzzAmount(card.amount)} Buzz`}
+                            image={card.image}
+                            imageAlt={`${formatBuzzAmount(card.amount)} Buzz Gift Card`}
+                            primaryUrl={card.url}
+                            discountPercentage={
+                              discountInfo.isActive ? discountInfo.percentage : undefined
+                            }
+                            className={classes.card}
+                            type="buzz"
+                            actions={
+                              selectedVendor.id === 'crypto' ? (
+                                <Button
+                                  onClick={() =>
+                                    createCodeOrder({
+                                      type: 'Buzz',
+                                      buzzAmount: card.amount,
+                                    })
+                                  }
+                                  disabled={creatingCodeOrder || !coinbaseHealthy}
+                                  loading={creatingCodeOrder}
+                                  leftSection={<IconCoinBitcoin size={16} />}
+                                  fullWidth
+                                  size="md"
+                                  className={classes.buzzButton}
+                                >
+                                  Buy with Crypto
+                                </Button>
+                              ) : selectedVendor.id === 'kinguin' ? (
+                                <Button
+                                  onClick={() =>
+                                    handleKinguinPurchase(
+                                      card.url,
+                                      `${formatBuzzAmount(card.amount)} Buzz`
+                                    )
+                                  }
+                                  fullWidth
+                                  size="md"
+                                  className={classes.buzzButton}
+                                >
+                                  Buy Now
+                                </Button>
+                              ) : (
+                                <Button
+                                  component="a"
+                                  href={card.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  rightSection={<IconExternalLink size={16} />}
+                                  fullWidth
+                                  size="md"
+                                  className={classes.buzzButton}
+                                >
+                                  Buy Now
+                                </Button>
+                              )
+                            }
+                          />
+                        </Grid.Col>
+                      );
+                    })}
+                  </Grid>
+                </div>
+              )}
+
+              {/* Memberships Section */}
+              {showMemberships && selectedVendor.products.memberships.length > 0 && (
+                <div>
+                  <Title order={2} mb="lg">
+                    Membership Packages
+                  </Title>
+                  <Grid gutter="lg">
+                    {selectedVendor.products.memberships.map((membership) => {
+                      const discountInfo = getVendorDiscount(selectedVendor);
+
+                      return (
+                        <Grid.Col key={membership.tier} span={{ base: 12, md: 4 }}>
+                          <GiftCardItem
+                            title={`${membership.tier} Membership`}
+                            image={membership.image}
+                            imageAlt={`${membership.tier} Membership`}
+                            primaryUrl={membership.durations[0]?.url}
+                            discountPercentage={
+                              discountInfo.isActive ? discountInfo.percentage : undefined
+                            }
+                            className={classes.membershipCard}
+                            type="membership"
+                            actions={
+                              <Group gap="xs" grow>
+                                {membership.durations.map((duration) => {
+                                  const productName = `${membership.tier} Membership - ${
+                                    duration.months
+                                  } Month${duration.months > 1 ? 's' : ''}`;
+
+                                  return selectedVendor.id === 'crypto' ? (
+                                    <Button
+                                      key={duration.months}
+                                      onClick={() =>
+                                        createCodeOrder({
+                                          type: 'Membership',
+                                          tier: membership.tier.toLowerCase() as
+                                            | 'bronze'
+                                            | 'silver'
+                                            | 'gold',
+                                          months: duration.months,
+                                        })
+                                      }
+                                      disabled={creatingCodeOrder || !coinbaseHealthy}
+                                      loading={creatingCodeOrder}
+                                      size="sm"
+                                      className={classes.membershipButton}
+                                    >
+                                      {duration.months} Mo{duration.months > 1 ? 's' : ''}
+                                    </Button>
+                                  ) : selectedVendor.id === 'kinguin' ? (
+                                    <Button
+                                      key={duration.months}
+                                      onClick={() =>
+                                        handleKinguinPurchase(duration.url, productName)
+                                      }
+                                      size="sm"
+                                      className={classes.membershipButton}
+                                    >
+                                      {duration.months} Month{duration.months > 1 ? 's' : ''}
+                                    </Button>
+                                  ) : (
+                                    <Button
+                                      key={duration.months}
+                                      component="a"
+                                      href={duration.url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      rightSection={<IconExternalLink size={16} />}
+                                      size="sm"
+                                      className={classes.membershipButton}
+                                    >
+                                      {duration.months} Month{duration.months > 1 ? 's' : ''}
+                                    </Button>
+                                  );
+                                })}
+                              </Group>
+                            }
+                          />
+                        </Grid.Col>
+                      );
+                    })}
+                  </Grid>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Disclaimer */}
+          {!showKinguinCheckout && (
+            <Text size="xs" c="dimmed" ta="center" mt="md">
+              {GIFT_CARD_DISCLAIMER.purchase} By purchasing, you agree to our{' '}
+              <Text
+                component={NextLink}
+                href={GIFT_CARD_DISCLAIMER.termsUrl}
+                size="xs"
+                c="blue"
+                td="underline"
+              >
+                {GIFT_CARD_DISCLAIMER.termsLinkText}
+              </Text>
+              .
+            </Text>
+          )}
+        </Stack>
+      </Container>
+    </>
+  );
+}
+

--- a/src/pages/purchase/buzz.tsx
+++ b/src/pages/purchase/buzz.tsx
@@ -1,4 +1,17 @@
-import { Alert, Center, Container, Divider, Stack, Text, Title } from '@mantine/core';
+import {
+  Alert,
+  Button,
+  Card,
+  Center,
+  Container,
+  Divider,
+  Group,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
+import { IconArrowRight, IconGift } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import * as z from 'zod';
@@ -6,6 +19,8 @@ import { BuzzFeatures } from '~/components/Buzz/BuzzFeatures';
 import { BuzzPurchaseLayout } from '~/components/Buzz/BuzzPurchaseLayout';
 import { CurrencyBadge } from '~/components/Currency/CurrencyBadge';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { NextLink } from '~/components/NextLink/NextLink';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { Currency } from '~/shared/utils/prisma/enums';
 import { getLoginLink } from '~/utils/login-helpers';
@@ -34,8 +49,16 @@ const schema = z.object({
 
 export default function PurchaseBuzz() {
   const router = useRouter();
+  const features = useFeatureFlags();
   const { returnUrl, minBuzzAmount, buzzType, success: successParam } = schema.parse(router.query);
   const [success, setSuccess] = useState<boolean>(successParam === 'true');
+
+  // On blue/red domains Buzz can only be bought with crypto (no standard card
+  // payments). Gift cards, however, are credit-card payable — point users there.
+  // `features.giftCards` is the master kill switch (blue/red only, Flipt-gated),
+  // so the banner disappears the moment the gift-card experience is turned off.
+  const cryptoOnly = !(features.isGreen || buzzType === 'green');
+  const showGiftCardBanner = cryptoOnly && features.giftCards;
 
   const handlePurchaseSuccess = () => {
     if (returnUrl) {
@@ -81,6 +104,44 @@ export default function PurchaseBuzz() {
 
   return (
     <Container size="xl" mb="lg" pt="sm">
+      {showGiftCardBanner && (
+        <Card
+          withBorder
+          radius="md"
+          p="md"
+          mb="xl"
+          style={{
+            background:
+              'linear-gradient(135deg, var(--mantine-color-yellow-4), var(--mantine-color-orange-5))',
+            borderColor: 'var(--mantine-color-orange-4)',
+          }}
+        >
+          <Group justify="space-between" gap="md">
+            <Group gap="sm" wrap="nowrap" style={{ flex: 1, minWidth: 220 }}>
+              <ThemeIcon size="xl" radius="xl" variant="white" color="orange">
+                <IconGift size={22} />
+              </ThemeIcon>
+              <div>
+                <Text fw={700} c="dark.8">
+                  Gift cards available &mdash; pay with a credit card
+                </Text>
+                <Text size="sm" c="dark.7">
+                  Buy Buzz or a Membership with any debit/credit card, no crypto required.
+                </Text>
+              </div>
+            </Group>
+            <Button
+              component={NextLink}
+              href="/gift-cards"
+              color="dark"
+              radius="md"
+              rightSection={<IconArrowRight size={16} />}
+            >
+              Browse gift cards
+            </Button>
+          </Group>
+        </Card>
+      )}
       {minBuzzAmount && (
         <Alert radius="sm" color="info" mb="xl">
           <Stack gap={0}>

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -19,6 +19,7 @@ export enum FLIPT_FEATURE_FLAGS {
   GIFT_CARD_VENDOR_WAIFU_WAY = 'gift-card-vendor-waifu-way',
   GIFT_CARD_VENDOR_LEWT_DROP = 'gift-card-vendor-lewt-drop',
   GIFT_CARD_VENDOR_CRYPTO = 'gift-card-vendor-crypto',
+  GIFT_CARD_VENDOR_FUNGIES = 'gift-card-vendor-fungies',
   IMAGE_TRAINING = 'image-training',
   VIDEO_TRAINING = 'video-training',
   AI_TOOLKIT_SD15 = 'ai-toolkit-sd15',

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -190,6 +190,12 @@ const featureFlags = createFeatureFlags({
   annualMemberships: ['dev'],
   disablePayments: ['blue', 'red', 'public'],
   prepaidMemberships: ['public'],
+  // Master kill switch for the entire gift-card experience (the /gift-cards page
+  // AND the buzz-page banner). Blue/red domains only (green is excluded by the
+  // domain availability above). Driven by the `gift-cards` Flipt flag — mod
+  // rollout today, widen the Flipt segment to launch. Flip the Flipt flag off to
+  // instantly kill the page + banner everywhere.
+  giftCards: { availability: ['blue', 'red', 'public'], fliptKey: 'gift-cards' },
   coinbasePayments: [],
   emerchantpayPayments: ['public'],
   nowpaymentPayments: [],

--- a/src/server/services/gift-card-vendors.service.ts
+++ b/src/server/services/gift-card-vendors.service.ts
@@ -8,6 +8,7 @@ import { waifuWayVendor } from '~/utils/gift-cards/vendors/waifu-way';
 import { lewtDropVendor } from '~/utils/gift-cards/vendors/lewt-drop';
 import { royalCdKeysVendor } from '~/utils/gift-cards/vendors/royal-cd-keys';
 import { cryptoVendor } from '~/utils/gift-cards/vendors/crypto';
+import { fungiesVendor } from '~/utils/gift-cards/vendors/fungies';
 
 /**
  * Vendor configuration with optional Flipt flag for dynamic enablement.
@@ -19,6 +20,7 @@ const vendorConfigs: Array<{
   fliptFlag?: FLIPT_FEATURE_FLAGS;
 }> = [
   { vendor: cryptoVendor, fliptFlag: FLIPT_FEATURE_FLAGS.GIFT_CARD_VENDOR_CRYPTO },
+  { vendor: fungiesVendor, fliptFlag: FLIPT_FEATURE_FLAGS.GIFT_CARD_VENDOR_FUNGIES },
   { vendor: kinguinVendor },
   { vendor: buybuzzVendor },
   { vendor: waifuWayVendor, fliptFlag: FLIPT_FEATURE_FLAGS.GIFT_CARD_VENDOR_WAIFU_WAY },

--- a/src/utils/gift-cards/vendors/fungies.ts
+++ b/src/utils/gift-cards/vendors/fungies.ts
@@ -1,0 +1,111 @@
+import type { Vendor } from './types';
+
+// Fungies-hosted checkout. Each product/duration links to a Fungies checkout
+// element at https://fungies.civitai.com/checkout-element/<elementId>.
+// Element ids are created via the Fungies API (one per active offer).
+const checkout = (id: string) => `https://fungies.civitai.com/checkout-element/${id}`;
+
+export const fungiesVendor: Vendor = {
+  id: 'fungies',
+  name: 'Fungies',
+  displayName: 'Fungies',
+  // Enablement is controlled by the GIFT_CARD_VENDOR_FUNGIES Flipt flag in
+  // gift-card-vendors.service.ts; this static value is only a fallback.
+  enabled: false,
+  products: {
+    buzzCards: [
+      {
+        amount: 10000,
+        price: 10,
+        image: '/images/gift-cards/10kbuzz.webp',
+        url: checkout('f34b189b-9804-4629-9393-cb3ad8567f1e'),
+      },
+      {
+        amount: 25000,
+        price: 25,
+        image: '/images/gift-cards/25kbuzz.webp',
+        url: checkout('6a7ba117-96b1-460e-a525-c3170c0359b9'),
+      },
+      {
+        amount: 50000,
+        price: 50,
+        image: '/images/gift-cards/50kbuzz.webp',
+        url: checkout('5bbc1c6e-a104-44ab-b6e9-6c7e1aa40376'),
+      },
+    ],
+    memberships: [
+      {
+        tier: 'Bronze',
+        image: '/images/gift-cards/bronze_final.webp',
+        durations: [
+          {
+            months: 3,
+            price: 30,
+            url: checkout('01d30a1f-623f-496e-a095-8cfbcbafef10'),
+            image: '/images/gift-cards/bronze_final.webp',
+          },
+          {
+            months: 6,
+            price: 54,
+            url: checkout('7df69a3b-3b14-4c7c-bee8-9095cb32b8b1'),
+            image: '/images/gift-cards/Bronze6.webp',
+          },
+          {
+            months: 12,
+            price: 108,
+            url: checkout('c7bf461d-c05e-481d-bd66-9bae1779511f'),
+            image: '/images/gift-cards/Bronze12.webp',
+          },
+        ],
+      },
+      {
+        tier: 'Silver',
+        image: '/images/gift-cards/silver_final.webp',
+        durations: [
+          {
+            months: 3,
+            price: 75,
+            url: checkout('34e07c44-5027-43cc-8a4b-93211d0916a8'),
+            image: '/images/gift-cards/silver_final.webp',
+          },
+          {
+            months: 6,
+            price: 135,
+            url: checkout('f0cc9b15-fb9d-4a63-9eed-8c6ae027811f'),
+            image: '/images/gift-cards/Silver6.webp',
+          },
+          {
+            months: 12,
+            price: 270,
+            url: checkout('85d4fa30-f487-453d-8e57-ddd31ed2a6f4'),
+            image: '/images/gift-cards/Silver12.webp',
+          },
+        ],
+      },
+      {
+        tier: 'Gold',
+        image: '/images/gift-cards/gold_final.webp',
+        durations: [
+          {
+            months: 3,
+            price: 150,
+            url: checkout('90c5260d-98ec-4ef3-90be-e703269008f0'),
+            image: '/images/gift-cards/gold_final.webp',
+          },
+          {
+            months: 6,
+            price: 270,
+            url: checkout('16ad9797-bbd2-4467-99aa-4d79602a5bf6'),
+            image: '/images/gift-cards/Gold6.webp',
+          },
+          {
+            months: 12,
+            price: 540,
+            url: checkout('271067ca-744e-463b-a34d-79840a3c5d23'),
+            image: '/images/gift-cards/Gold12.webp',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/src/utils/gift-cards/vendors/index.ts
+++ b/src/utils/gift-cards/vendors/index.ts
@@ -5,9 +5,11 @@ import { waifuWayVendor } from './waifu-way';
 import { lewtDropVendor } from './lewt-drop';
 import { royalCdKeysVendor } from './royal-cd-keys';
 import { cryptoVendor } from './crypto';
+import { fungiesVendor } from './fungies';
 
 const vendorRegistry: VendorRegistry = {
   crypto: cryptoVendor,
+  fungies: fungiesVendor,
   kinguin: kinguinVendor,
   buybuzz: buybuzzVendor,
   'waifu-way': waifuWayVendor,


### PR DESCRIPTION
## Summary
Brings back the gift-cards experience with **Fungies** as a first-party, credit-card-payable vendor, all behind a master Flipt kill switch. Mod-only for now.

## Changes
- **New Fungies vendor** (`utils/gift-cards/vendors/fungies.ts`): Buzz 10k/25k/50k + Bronze/Silver/Gold 3/6/12mo, each linking to its `fungies.civitai.com` checkout element. Registered in `vendors/index.ts` + `gift-card-vendors.service.ts`, gated by `GIFT_CARD_VENDOR_FUNGIES`.
- **Restored `/gift-cards` page**: it had been a stub redirecting to `/purchase/buzz` since #2128. Restored the full page (+ SCSS) and re-enabled the Buzz gift cards section.
- **Master kill switch**: new `giftCards` feature flag (`availability: ['blue','red','public']`, `fliptKey: 'gift-cards'`) gates **both** the page and the banner. Page redirects to `/pricing` when the flag is off or on the green domain.
- **Buzz-page banner** (`purchase/buzz.tsx`): yellow→orange gradient card shown only in crypto-only mode (blue/red) pointing users to credit-card-payable gift cards for Buzz or Membership.

## Flags (in `flipt-state`, already pushed)
- `gift-cards` — master experience switch (mod rollout). **This is the kill switch.**
- `gift-card-vendor-fungies` — the Fungies vendor (mod rollout).
- `gift-card-vendor-crypto` — disabled.

## Backing data
Fungies products, 15 priced offers, 150k redeem-code keys, and 12 checkout elements were provisioned via the Fungies API.

## Rollout / kill
- **Launch**: widen the `gift-cards` Flipt segment (and `gift-card-vendor-fungies`) — no deploy.
- **Kill** (if Fungies doesn't work out): disable the `gift-cards` Flipt flag — page + banner vanish instantly.

## Testing
`npm run typecheck` clean (only a pre-existing unrelated error in `src/tests/api/v1/blocks/submit-version.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)