### PR TITLE
feat(app-blocks): Page-LoRA Increment 1 — multi-resource page generation (server-only)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1797,7 +1797,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
     //
     // The pre-spend gate (`resolveCanGenerateForVersions`) deliberately does NOT
     // check early-access `hasAccess` or the `availability:Private` subscription
-    // requirement (see the SCOPE comment on assertViewerCanGeneratePageModel).
+    // requirement (see the SCOPE comment on assertViewerCanGeneratePageResources).
     // Those are enforced DOWNSTREAM by the orchestrator resource belt
     // (`getGenerationResourceData` → `getResourceData`, which folds
     // `canGenerate = hasAccess && canGenerate` and throws on a Private resource
@@ -1861,6 +1861,278 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
         caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+  });
+
+  // ───────────────────── Page-LoRA (Increment 1) ───────────────────────────
+  //
+  // A page token can carry `body.additionalResources: [{ modelVersionId,
+  // strength }]` (LoRA stack). The server resolves each statelessly, enforces
+  // LoRA-only + base-model family-match, then gates the checkpoint AND every
+  // LoRA through resolveCanGenerateForVersions in ONE call — fail-closed if any
+  // resource is non-LoRA / family-mismatched / not entitled. This runs BEFORE
+  // resolveBlockCheckpoint / any cost / any reservation.
+  describe('Page-LoRA — additionalResources', () => {
+    // Multi-version lookup keyed by where.id. Checkpoint 99 = SDXL Checkpoint;
+    // additional rows are LoRAs (override per-test for family/type cases).
+    function versionRows(rows: Record<number, Record<string, unknown>>) {
+      const defaults: Record<number, Record<string, unknown>> = {
+        99: {
+          id: 99,
+          baseModel: 'SDXL 1.0',
+          modelId: 7,
+          status: 'Published',
+          availability: 'Public',
+          usageControl: 'Download',
+          meta: null,
+          generationCoverage: { covered: true },
+          model: { id: 7, type: 'Checkpoint', userId: 1 },
+        },
+        ...rows,
+      };
+      mockDbRead.modelVersion.findUnique.mockImplementation(async (args: any) => {
+        return defaults[args?.where?.id] ?? null;
+      });
+    }
+
+    const sdxlLora = (id: number, over: Record<string, unknown> = {}) => ({
+      id,
+      baseModel: 'SDXL 1.0',
+      modelId: 100 + id,
+      status: 'Published',
+      availability: 'Public',
+      usageControl: 'Download',
+      meta: null,
+      generationCoverage: { covered: true },
+      model: { id: 100 + id, type: 'LORA', userId: 2 },
+      ...over,
+    });
+
+    const bodyWithLoras = (resources: Array<{ modelVersionId: number; strength?: number }>) =>
+      validBody({ additionalResources: resources });
+
+    function pageClaimsLocal(over: Record<string, unknown> = {}) {
+      return validClaims({
+        blockInstanceId: 'page_apb_page',
+        ctx: { slotId: 'app.page', entityType: 'none' },
+        ...over,
+      });
+    }
+
+    it('a page submit gates the checkpoint AND every LoRA in ONE call', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      versionRows({ 201: sdxlLora(201), 202: sdxlLora(202) });
+      happyUser();
+      mockSysRedis.incrBy.mockResolvedValue(25);
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: bodyWithLoras([{ modelVersionId: 201, strength: 0.8 }, { modelVersionId: 202 }]),
+      });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      // The gate ran ONCE with checkpoint + both LoRAs in a single array.
+      expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
+      const [versions] = mockResolveCanGenerateForVersions.mock.calls[0];
+      expect(versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)).toEqual([
+        99, 201, 202,
+      ]);
+    });
+
+    it('SECURITY: an un-entitled LoRA (canGenerate:false) → FORBIDDEN, no spend, no reservation', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      versionRows({ 201: sdxlLora(201) });
+      happyUser();
+      // Checkpoint is generatable, the LoRA is NOT.
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map<number, { canGenerate: boolean }>([
+          [99, { canGenerate: true }],
+          [201, { canGenerate: false }],
+        ])
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled(); // no reservation
+      expect(mockAuditPromptServer).not.toHaveBeenCalled();
+    });
+
+    it('SECURITY fail-closed: a LoRA MISSING from the result Map → FORBIDDEN', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      versionRows({ 201: sdxlLora(201) });
+      happyUser();
+      // The LoRA (201) is simply absent from the Map → must be treated as deny.
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map<number, { canGenerate: boolean }>([[99, { canGenerate: true }]])
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a NON-LoRA additional resource (BAD_REQUEST), before the entitlement gate', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      // 201 is a Checkpoint, not a LoRA.
+      versionRows({ 201: sdxlLora(201, { model: { id: 301, type: 'Checkpoint', userId: 2 } }) });
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      // Type rejection happens before the entitlement gate / any spend.
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a base-model FAMILY-MISMATCHED LoRA (BAD_REQUEST), before the entitlement gate', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      // Checkpoint is SDXL; the LoRA is SD 1.5 → different generation family.
+      versionRows({ 201: sdxlLora(201, { baseModel: 'SD 1.5' }) });
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unpublished LoRA (NOT_FOUND), no info leak', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      versionRows({ 201: sdxlLora(201, { status: 'Draft' }) });
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('estimate: an un-entitled LoRA → FORBIDDEN, no orchestrator whatif', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal());
+      versionRows({ 201: sdxlLora(201) });
+      happyUser();
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map<number, { canGenerate: boolean }>([
+          [99, { canGenerate: true }],
+          [201, { canGenerate: false }],
+        ])
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.estimateWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('BELT: a LoRA that passes the pre-spend gate but is rejected by the orchestrator belt (early-access/Private) → no spend', async () => {
+      // The pre-spend gate deliberately does NOT see early-access / Private
+      // entitlement (default canGenerate:true here). The orchestrator belt (run
+      // inside createTextToImageStep for the FULL resource array at whatIf,
+      // BEFORE any reservation) is the second fail-closed layer.
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      versionRows({ 201: sdxlLora(201) });
+      happyUser();
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map<number, { canGenerate: boolean }>([
+          [99, { canGenerate: true }],
+          [201, { canGenerate: true }],
+        ])
+      );
+      mockCreateTextToImageStep.mockRejectedValueOnce(
+        new TRPCError({ code: 'BAD_REQUEST', message: 'Using Private resources require an active subscription.' })
+      );
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled(); // belt threw before reserve
+      expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+    });
+
+    // ── Money (Piece 4): the multi-resource cost is bounded by BOTH ceilings ──
+    it('MONEY: a 2-LoRA gen whose cost exceeds the per-gen budget returns the failed snapshot', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 30 }));
+      versionRows({ 201: sdxlLora(201), 202: sdxlLora(202) });
+      happyUser();
+      // whatif cost (with the LoRAs) is 75 > the 30 per-gen budget.
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 75 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: bodyWithLoras([{ modelVersionId: 201 }, { modelVersionId: 202 }]),
+      });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.cost).toEqual({ total: 75 });
+      expect(result.snapshot.error).toMatch(/insufficient buzz/i);
+      // Only the whatif ran; no real submit, no reservation taken.
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    it('MONEY: a multi-LoRA gen accumulates against the per-user daily cap (reservation over cap → failed + refund)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      versionRows({ 201: sdxlLora(201), 202: sdxlLora(202) });
+      happyUser();
+      // whatif clears the per-call budget, but the reservation (with the LoRA
+      // cost folded in) tops the 50,000 daily cap → reject + refund.
+      mockSysRedis.incrBy.mockResolvedValue(50040);
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 60 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: bodyWithLoras([{ modelVersionId: 201 }, { modelVersionId: 202 }]),
+      });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(/daily Buzz cap/i);
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1); // whatif only
+      expect(mockSysRedis.decrBy).toHaveBeenCalledTimes(1); // reservation refunded
+      // The reservation amount is the multi-resource cost (ceil 60).
+      expect(mockSysRedis.incrBy.mock.calls[0][1]).toBe(60);
+    });
+
+    // ── Model-path guard: additionalResources is page-only ─────────────────
+    it('MODEL token with additionalResources → FORBIDDEN (page-only feature, no un-gated fan-out)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      // Rejected before the entitlement gate / any orchestrator interaction.
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('MODEL token estimate with additionalResources → FORBIDDEN', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      happyVersionLookup();
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.estimateWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -50,16 +50,19 @@ import {
 } from '~/server/services/blocks/checkpoint.service';
 import { getModelShowcaseImages } from '~/server/services/blocks/showcase.service';
 // Type-only: the runtime `resolveCanGenerateForVersions` is loaded via a
-// dynamic import() inside assertViewerCanGeneratePageModel so the heavy
+// dynamic import() inside assertViewerCanGeneratePageResources so the heavy
 // generation-service import graph (image.service → event-engine-common, etc.)
 // stays OUT of this router's static import graph — mirroring the existing
 // lazy import of recordScopeInvocation below.
 import type { ResolveCanGenerateVersion } from '~/server/services/generation/generation.service';
 import {
   buildTextToImageInput,
+  isPageLoraResource,
   resolveBlockVersionContext,
+  resolvePageResourceContext,
   snapshotFromWorkflow,
 } from '~/server/services/blocks/workflow.service';
+import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { BuzzTypes } from '~/shared/constants/buzz.constants';
 import { WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
@@ -163,27 +166,35 @@ function isPageToken(claims: { ctx?: unknown }): boolean {
 // always a mod (assertViewerIsModerator), so they see mod-level access, which
 // is correct platform behaviour; when GA opens to non-mods the same gate bounds
 // them properly. Fail-closed: a version missing from the result Map → FORBIDDEN.
-async function assertViewerCanGeneratePageModel(opts: {
-  gate: ReturnType<typeof buildGateVersion>;
+//
+// Page-LoRA (Increment 1): generalized from 1→N versions. The checkpoint AND
+// every picked LoRA are gated in ONE `resolveCanGenerateForVersions` call (it
+// already takes an array and returns a Map keyed by version id). FAIL CLOSED if
+// ANY gate's canGenerate is false OR the version is missing from the result Map
+// — a missed entry must deny, never default-allow.
+async function assertViewerCanGeneratePageResources(opts: {
+  gates: ReturnType<typeof buildGateVersion>[];
   viewer: { id: number; isModerator: boolean };
   sfwOnly: boolean;
   wildcardsEnabled: boolean;
 }): Promise<void> {
-  const { gate, viewer, sfwOnly, wildcardsEnabled } = opts;
+  const { gates, viewer, sfwOnly, wildcardsEnabled } = opts;
   const { resolveCanGenerateForVersions } = await import(
     '~/server/services/generation/generation.service'
   );
-  const states = await resolveCanGenerateForVersions([gate], {
+  const states = await resolveCanGenerateForVersions(gates, {
     user: { id: viewer.id, isModerator: viewer.isModerator },
     sfwOnly,
     wildcardsEnabled,
   });
-  const canGenerate = states.get(gate.id)?.canGenerate ?? false;
-  if (!canGenerate) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'model is not available for generation',
-    });
+  for (const gate of gates) {
+    const canGenerate = states.get(gate.id)?.canGenerate ?? false;
+    if (!canGenerate) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'a selected resource is not available for generation',
+      });
+    }
   }
 }
 
@@ -202,6 +213,52 @@ function buildGateVersion(gate: {
   modelVersionAlias: unknown;
 }): ResolveCanGenerateVersion {
   return gate as unknown as ResolveCanGenerateVersion;
+}
+
+// Page-LoRA (Increment 1): resolve + validate the page's additional-resource
+// (LoRA) stack from `body.additionalResources`. For each entry it:
+//   1. resolves the version statelessly (NO modelId binding — pages have none),
+//   2. enforces LoRA-only v1 (rejects any non-LoRA additional resource), and
+//   3. enforces an EXPLICIT base-model FAMILY match against the checkpoint.
+// The family check is the UX layer: without it the orchestrator belt silently
+// DROPS a family-mismatched LoRA (common.ts filters by supported resource
+// types) and the viewer pays for a gen that ignored their LoRA. We collapse
+// both families with getBaseModelSetType (e.g. all SDXL variants → 'SDXL') so a
+// compatible variant isn't falsely rejected.
+//
+// Returns the per-LoRA gate bags so the caller can pass checkpoint + every LoRA
+// through the entitlement gate in ONE call. Throws BAD_REQUEST (non-LoRA /
+// family-mismatch), NOT_FOUND (missing/unpublished version) — all BEFORE any
+// cost/spend.
+async function resolvePageLoraGates(opts: {
+  additionalResources: { modelVersionId: number; strength: number }[] | undefined;
+  checkpointBaseModel: string;
+}): Promise<ReturnType<typeof buildGateVersion>[]> {
+  const { additionalResources, checkpointBaseModel } = opts;
+  if (!additionalResources?.length) return [];
+  const checkpointFamily = getBaseModelSetType(checkpointBaseModel);
+  const gates: ReturnType<typeof buildGateVersion>[] = [];
+  for (const r of additionalResources) {
+    const lora = await resolvePageResourceContext(r.modelVersionId);
+    // LoRA-only v1. A non-LoRA additional resource (Checkpoint, VAE, embedding,
+    // etc.) is rejected at the boundary rather than silently passed downstream.
+    if (!isPageLoraResource(lora.modelType)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'additional resources must be LoRA models',
+      });
+    }
+    // Explicit base-model family match (UX layer; the belt would otherwise
+    // silently drop a mismatch).
+    if (getBaseModelSetType(lora.baseModel) !== checkpointFamily) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'a selected LoRA is not compatible with the checkpoint base model',
+      });
+    }
+    gates.push(buildGateVersion(lora.gate));
+  }
+  return gates;
 }
 
 // ---- Cumulative Buzz-spend cap (audit A7 / design-gaps H1) -----------------
@@ -1527,9 +1584,9 @@ export const blocksRouter = router({
       // lets the viewer pick any model they're entitled to generate against, so
       // the modelId match is SKIPPED and replaced (below, after the version
       // read) by the pre-spend availability/coverage gate
-      // (assertViewerCanGeneratePageModel). Early-access + Private-subscription
-      // entitlement is enforced separately by the orchestrator resource belt.
-      // See isPageToken / assertViewerCanGeneratePageModel.
+      // (assertViewerCanGeneratePageResources). Early-access + Private-
+      // subscription entitlement is enforced separately by the orchestrator
+      // resource belt. See isPageToken / assertViewerCanGeneratePageResources.
       const isPage = isPageToken(claims);
       if (!isPage) {
         const ctxModelId = Number(
@@ -1537,6 +1594,17 @@ export const blocksRouter = router({
         );
         if (!Number.isInteger(ctxModelId) || ctxModelId !== input.body.modelId) {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'modelId mismatch with token' });
+        }
+        // Page-LoRA (Increment 1): additionalResources is a PAGE-ONLY feature.
+        // A MODEL token's checkpoint comes from resolveBlockCheckpoint (install
+        // rows), and the model branch never runs the per-resource entitlement
+        // gate — so accepting additionalResources here would fan un-gated LoRAs
+        // into the resources array. Reject them fail-closed on the model path.
+        if (input.body.additionalResources?.length) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'additionalResources are not supported for model-bound blocks',
+          });
         }
       }
       const userId = parseSubjectUserId(claims.sub);
@@ -1556,13 +1624,20 @@ export const blocksRouter = router({
         input.body.modelId
       );
       const user = await getBlockSessionUser(userId);
-      // PAGE branch: pre-spend availability/coverage gate on the model the REAL
-      // viewer picked (the security replacement for the skipped model-binding
-      // check) — fail-closed before any spend. Early-access + Private-sub
-      // entitlement is enforced downstream by the orchestrator resource belt.
+      // PAGE branch: pre-spend availability/coverage gate on every resource the
+      // REAL viewer picked — the checkpoint AND each additional LoRA (the
+      // security replacement for the skipped model-binding check) — fail-closed
+      // before any spend. Early-access + Private-sub entitlement is enforced
+      // downstream by the orchestrator resource belt for the FULL array.
       if (isPage) {
-        await assertViewerCanGeneratePageModel({
-          gate: buildGateVersion(resolved.gate),
+        // Resolve + validate the LoRA stack first (LoRA-only + family-match)
+        // so a bad resource fails BEFORE the entitlement gate / any cost.
+        const loraGates = await resolvePageLoraGates({
+          additionalResources: input.body.additionalResources,
+          checkpointBaseModel: resolved.baseModel,
+        });
+        await assertViewerCanGeneratePageResources({
+          gates: [buildGateVersion(resolved.gate), ...loraGates],
           viewer: { id: userId, isModerator: !!user.isModerator },
           sfwOnly: ctx.domain === 'green',
           wildcardsEnabled: !!ctx.features.wildcards,
@@ -1629,6 +1704,16 @@ export const blocksRouter = router({
         if (!Number.isInteger(ctxModelId) || ctxModelId !== input.body.modelId) {
           throw new TRPCError({ code: 'FORBIDDEN', message: 'modelId mismatch with token' });
         }
+        // Page-LoRA (Increment 1): additionalResources is PAGE-ONLY. The model
+        // branch never runs the per-resource entitlement gate, so reject the
+        // field fail-closed rather than fan un-gated LoRAs into the resources
+        // array. (See estimateWorkflow for the same guard.)
+        if (input.body.additionalResources?.length) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'additionalResources are not supported for model-bound blocks',
+          });
+        }
       }
       const userId = parseSubjectUserId(claims.sub);
       // Anon submit is not just forbidden — there's no buzz account to charge.
@@ -1651,13 +1736,18 @@ export const blocksRouter = router({
         input.body.modelId
       );
       const user = await getBlockSessionUser(userId);
-      // PAGE branch: pre-spend availability/coverage gate on the model the REAL
-      // viewer picked (replaces the skipped model-binding check) — fail closed
-      // BEFORE any reservation. Early-access + Private-sub entitlement is
-      // enforced downstream by the orchestrator resource belt (whatIf + real).
+      // PAGE branch: pre-spend availability/coverage gate on every resource the
+      // REAL viewer picked — the checkpoint AND each additional LoRA (replaces
+      // the skipped model-binding check) — fail closed BEFORE any reservation.
+      // Early-access + Private-sub entitlement is enforced downstream by the
+      // orchestrator resource belt for the FULL array (whatIf + real).
       if (isPage) {
-        await assertViewerCanGeneratePageModel({
-          gate: buildGateVersion(resolved.gate),
+        const loraGates = await resolvePageLoraGates({
+          additionalResources: input.body.additionalResources,
+          checkpointBaseModel: resolved.baseModel,
+        });
+        await assertViewerCanGeneratePageResources({
+          gates: [buildGateVersion(resolved.gate), ...loraGates],
           viewer: { id: userId, isModerator: !!user.isModerator },
           sfwOnly: ctx.domain === 'green',
           wildcardsEnabled: !!ctx.features.wildcards,

--- a/src/server/schema/blocks/__tests__/workflow.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/workflow.schema.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  blockWorkflowBodySchema,
+  LORA_STRENGTH_MAX,
+  LORA_STRENGTH_MIN,
+  MAX_ADDITIONAL_RESOURCES,
+} from '../workflow.schema';
+
+/**
+ * Page-LoRA (Increment 1) — body-schema coverage. The block body runs in an
+ * untrusted iframe, so the additionalResources array caps (count, strength,
+ * positive version id) are enforced at the boundary. These tests lock the
+ * cap geometry so a future loosening is caught.
+ */
+
+const baseBody = (over: Record<string, unknown> = {}) => ({
+  kind: 'textToImage' as const,
+  modelId: 7,
+  modelVersionId: 99,
+  params: { prompt: 'a cat', quantity: 1 },
+  ...over,
+});
+
+describe('blockWorkflowBodySchema — additionalResources (Page-LoRA)', () => {
+  it('parses a body with NO additionalResources (field is optional)', () => {
+    const parsed = blockWorkflowBodySchema.parse(baseBody());
+    expect(parsed.kind).toBe('textToImage');
+    // Optional + absent → stays undefined (not coerced to []).
+    expect((parsed as { additionalResources?: unknown }).additionalResources).toBeUndefined();
+  });
+
+  it('parses up to MAX_ADDITIONAL_RESOURCES LoRA entries', () => {
+    const resources = Array.from({ length: MAX_ADDITIONAL_RESOURCES }, (_, i) => ({
+      modelVersionId: 1000 + i,
+      strength: 1,
+    }));
+    const parsed = blockWorkflowBodySchema.parse(baseBody({ additionalResources: resources }));
+    expect((parsed as any).additionalResources).toHaveLength(MAX_ADDITIONAL_RESOURCES);
+  });
+
+  it('REJECTS more than MAX_ADDITIONAL_RESOURCES entries', () => {
+    const resources = Array.from({ length: MAX_ADDITIONAL_RESOURCES + 1 }, (_, i) => ({
+      modelVersionId: 1000 + i,
+      strength: 1,
+    }));
+    expect(() =>
+      blockWorkflowBodySchema.parse(baseBody({ additionalResources: resources }))
+    ).toThrow();
+  });
+
+  it('defaults strength to 1 when omitted', () => {
+    const parsed = blockWorkflowBodySchema.parse(
+      baseBody({ additionalResources: [{ modelVersionId: 1234 }] })
+    );
+    expect((parsed as any).additionalResources[0].strength).toBe(1);
+  });
+
+  it('accepts strength at the inclusive bounds [MIN, MAX]', () => {
+    const parsed = blockWorkflowBodySchema.parse(
+      baseBody({
+        additionalResources: [
+          { modelVersionId: 1, strength: LORA_STRENGTH_MIN },
+          { modelVersionId: 2, strength: LORA_STRENGTH_MAX },
+        ],
+      })
+    );
+    expect((parsed as any).additionalResources[0].strength).toBe(LORA_STRENGTH_MIN);
+    expect((parsed as any).additionalResources[1].strength).toBe(LORA_STRENGTH_MAX);
+  });
+
+  it('REJECTS strength below the minimum', () => {
+    expect(() =>
+      blockWorkflowBodySchema.parse(
+        baseBody({ additionalResources: [{ modelVersionId: 1, strength: LORA_STRENGTH_MIN - 0.1 }] })
+      )
+    ).toThrow();
+  });
+
+  it('REJECTS strength above the maximum', () => {
+    expect(() =>
+      blockWorkflowBodySchema.parse(
+        baseBody({ additionalResources: [{ modelVersionId: 1, strength: LORA_STRENGTH_MAX + 0.1 }] })
+      )
+    ).toThrow();
+  });
+
+  it('REJECTS a non-positive modelVersionId', () => {
+    expect(() =>
+      blockWorkflowBodySchema.parse(
+        baseBody({ additionalResources: [{ modelVersionId: 0, strength: 1 }] })
+      )
+    ).toThrow();
+    expect(() =>
+      blockWorkflowBodySchema.parse(
+        baseBody({ additionalResources: [{ modelVersionId: -5, strength: 1 }] })
+      )
+    ).toThrow();
+  });
+
+  it('REJECTS a non-integer modelVersionId', () => {
+    expect(() =>
+      blockWorkflowBodySchema.parse(
+        baseBody({ additionalResources: [{ modelVersionId: 12.5, strength: 1 }] })
+      )
+    ).toThrow();
+  });
+});

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -18,10 +18,37 @@ const STEPS_MAX = 50;
 const QUANTITY_MAX = 4;
 const CLIP_SKIP_MAX = 12;
 
+// Page-LoRA caps (App Blocks Page-LoRA, Increment 1). Intentionally tighter
+// than the platform per-tier resource cap — these come from an untrusted
+// iframe, so bound the resource fan-out + strength at the boundary rather than
+// relying on the downstream orchestrator belt. A page block sends the
+// additional resources (LoRA version ids) it obtained out-of-band (author-
+// curated or user-pasted); the server re-derives type/baseModel/entitlement
+// from each version id (no per-LoRA modelId binding — pages have no JWT model
+// binding). `epochNumber` is intentionally OMITTED in v1: epochs imply
+// Private/subscription resources and add a subscription dimension we defer.
+export const MAX_ADDITIONAL_RESOURCES = 5;
+export const LORA_STRENGTH_MIN = -1;
+export const LORA_STRENGTH_MAX = 2;
+
+const blockAdditionalResourceSchema = z.object({
+  modelVersionId: z.number().int().positive(),
+  strength: z.coerce
+    .number()
+    .min(LORA_STRENGTH_MIN)
+    .max(LORA_STRENGTH_MAX)
+    .default(1),
+});
+
 const blockTextToImageBodySchema = z.object({
   kind: z.literal('textToImage'),
   modelId: z.number().int().positive(),
   modelVersionId: z.number().int().positive(),
+  // Optional LoRA stack (Increment 1, LoRA-only v1). Each entry resolves to a
+  // LoRA-type model version that the server entitlement-gates per-resource and
+  // base-model-family-matches against the checkpoint before any spend. Capped
+  // at MAX_ADDITIONAL_RESOURCES for the iframe posture above.
+  additionalResources: z.array(blockAdditionalResourceSchema).max(MAX_ADDITIONAL_RESOURCES).optional(),
   params: z.object({
     prompt: z.string().max(PROMPT_MAX).default(''),
     negativePrompt: z.string().max(NEG_PROMPT_MAX).optional(),

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -18,7 +18,9 @@ vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
 
 import {
   buildTextToImageInput,
+  isPageLoraResource,
   resolveBlockVersionContext,
+  resolvePageResourceContext,
   snapshotFromWorkflow,
 } from '../workflow.service';
 
@@ -284,5 +286,189 @@ describe('buildTextToImageInput', () => {
     expect(out.params.sampler).toBe('DPM++ 2M Karras');
     expect(out.params.steps).toBe(30);
     expect(out.params.seed).toBe(12345);
+  });
+
+  // ── Page-LoRA (Increment 1): fan additionalResources into `resources` ──────
+  it('fans N additional LoRAs into the resources array after the checkpoint anchor', () => {
+    const body = {
+      ...baseBody,
+      additionalResources: [
+        { modelVersionId: 201, strength: 0.8 },
+        { modelVersionId: 202, strength: 1.2 },
+        { modelVersionId: 203, strength: -0.5 },
+      ],
+    };
+    const out = buildTextToImageInput(body as never, checkpointResolved);
+    expect(out.resources).toEqual([
+      { id: 99, strength: 1 }, // checkpoint anchor
+      { id: 201, strength: 0.8 },
+      { id: 202, strength: 1.2 },
+      { id: 203, strength: -0.5 },
+    ]);
+  });
+
+  it('does NOT duplicate the checkpoint when an additionalResource repeats it', () => {
+    const body = {
+      ...baseBody,
+      additionalResources: [
+        { modelVersionId: 99, strength: 0.7 }, // same as the checkpoint anchor
+        { modelVersionId: 201, strength: 1 },
+      ],
+    };
+    const out = buildTextToImageInput(body as never, checkpointResolved);
+    // The checkpoint stays as the single anchor at strength 1 (no double-bill /
+    // double-strength), and only the genuinely-new LoRA is appended.
+    expect(out.resources).toEqual([
+      { id: 99, strength: 1 },
+      { id: 201, strength: 1 },
+    ]);
+  });
+
+  it('does NOT duplicate the bound-model anchor when the body model is a LoRA', () => {
+    // fluxLoraResolved: checkpointVersionId=691639 (resolver anchor),
+    // body.modelVersionId=99 is itself a LoRA pushed as the second entry. An
+    // additionalResource repeating either id must be deduped.
+    const body = {
+      ...baseBody,
+      additionalResources: [
+        { modelVersionId: 691639, strength: 0.5 }, // == checkpoint anchor
+        { modelVersionId: 99, strength: 0.5 }, // == bound-model anchor
+        { modelVersionId: 300, strength: 0.9 }, // genuinely new
+      ],
+    };
+    const out = buildTextToImageInput(body as never, fluxLoraResolved);
+    expect(out.resources).toEqual([
+      { id: 691639, strength: 1 },
+      { id: 99, strength: 1 },
+      { id: 300, strength: 0.9 },
+    ]);
+  });
+
+  it('first-wins dedupe for a LoRA that appears twice in additionalResources', () => {
+    const body = {
+      ...baseBody,
+      additionalResources: [
+        { modelVersionId: 201, strength: 0.3 },
+        { modelVersionId: 201, strength: 0.9 }, // duplicate id
+      ],
+    };
+    const out = buildTextToImageInput(body as never, checkpointResolved);
+    expect(out.resources).toEqual([
+      { id: 99, strength: 1 },
+      { id: 201, strength: 0.3 }, // first occurrence kept
+    ]);
+  });
+
+  it('is byte-identical when additionalResources is absent (no behaviour change)', () => {
+    const out = buildTextToImageInput(baseBody as never, checkpointResolved);
+    expect(out.resources).toEqual([{ id: 99, strength: 1 }]);
+  });
+});
+
+describe('isPageLoraResource', () => {
+  it('returns true for the LoRA family (LORA / LoCon / DoRA)', () => {
+    expect(isPageLoraResource('LORA')).toBe(true);
+    expect(isPageLoraResource('LoCon')).toBe(true);
+    expect(isPageLoraResource('DoRA')).toBe(true);
+  });
+
+  it('returns false for non-LoRA types (Checkpoint / VAE / TextualInversion)', () => {
+    expect(isPageLoraResource('Checkpoint')).toBe(false);
+    expect(isPageLoraResource('VAE')).toBe(false);
+    expect(isPageLoraResource('TextualInversion')).toBe(false);
+    expect(isPageLoraResource('Upscaler')).toBe(false);
+  });
+});
+
+describe('resolvePageResourceContext', () => {
+  beforeEach(() => {
+    mockDbRead.modelVersion.findUnique.mockReset();
+  });
+
+  it('returns the gate bag + baseModel + modelType with NO modelId binding check', async () => {
+    // Note: modelId (8) intentionally differs from any "expected" model — the
+    // page resolver has no binding to enforce, so this resolves successfully
+    // where resolveBlockVersionContext(…, 7) would FORBIDDEN.
+    mockDbRead.modelVersion.findUnique.mockResolvedValue({
+      id: 201,
+      baseModel: 'SDXL 1.0',
+      modelId: 8,
+      status: 'Published',
+      availability: 'Public',
+      usageControl: 'Download',
+      meta: null,
+      generationCoverage: { covered: true },
+      model: { id: 8, type: 'LORA', userId: 55 },
+    });
+    const out = await resolvePageResourceContext(201);
+    expect(out).toEqual({
+      modelId: 8,
+      modelVersionId: 201,
+      baseModel: 'SDXL 1.0',
+      modelType: 'LORA',
+      gate: {
+        id: 201,
+        status: 'Published',
+        availability: 'Public',
+        usageControl: 'Download',
+        baseModel: 'SDXL 1.0',
+        covered: true,
+        modelUserId: 55,
+        modelType: 'LORA',
+        modelVersionAlias: null,
+      },
+    });
+  });
+
+  it('defaults covered to false when no generationCoverage row exists', async () => {
+    mockDbRead.modelVersion.findUnique.mockResolvedValue({
+      id: 201,
+      baseModel: 'SDXL 1.0',
+      modelId: 8,
+      status: 'Published',
+      availability: 'Public',
+      usageControl: 'Download',
+      meta: null,
+      generationCoverage: null,
+      model: { id: 8, type: 'LORA', userId: 55 },
+    });
+    const out = await resolvePageResourceContext(201);
+    expect(out.gate.covered).toBe(false);
+  });
+
+  it('reads the generation alias from version.meta.generationAlias', async () => {
+    mockDbRead.modelVersion.findUnique.mockResolvedValue({
+      id: 201,
+      baseModel: 'SDXL 1.0',
+      modelId: 8,
+      status: 'Published',
+      availability: 'Public',
+      usageControl: 'Download',
+      meta: { generationAlias: { versionId: 999 } },
+      generationCoverage: { covered: true },
+      model: { id: 8, type: 'LORA', userId: 55 },
+    });
+    const out = await resolvePageResourceContext(201);
+    expect(out.gate.modelVersionAlias).toEqual({ versionId: 999 });
+  });
+
+  it('throws NOT_FOUND when the version is missing', async () => {
+    mockDbRead.modelVersion.findUnique.mockResolvedValue(null);
+    await expect(resolvePageResourceContext(201)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('throws NOT_FOUND when the version is unpublished (no info leak)', async () => {
+    mockDbRead.modelVersion.findUnique.mockResolvedValue({
+      id: 201,
+      baseModel: 'SDXL 1.0',
+      modelId: 8,
+      status: 'Draft',
+      availability: 'Public',
+      usageControl: 'Download',
+      meta: null,
+      generationCoverage: { covered: true },
+      model: { id: 8, type: 'LORA', userId: 55 },
+    });
+    await expect(resolvePageResourceContext(201)).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 });

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import type { Workflow, WorkflowStatus } from '@civitai/client';
 import { dbRead } from '~/server/db/client';
 import { getBaseModelSetType } from '~/shared/constants/generation.constants';
+import { ModelType } from '~/shared/utils/prisma/enums';
 import type {
   BlockWorkflowBody,
   BlockWorkflowSnapshot,
@@ -127,6 +128,77 @@ export async function resolveBlockVersionContext(modelVersionId: number, expecte
   };
 }
 
+// Page-LoRA (Increment 1): the model types accepted as a page additional
+// resource. v1 is LoRA-only — the generator's LoRA family is LORA + LoCon +
+// DoRA (the same set the generation resource picker groups as "LoRA"; see
+// base-model.constants supportMap). VAE / embeddings / etc. also flow through
+// the same `resources` array + belt but are deferred to a later increment.
+export const PAGE_LORA_MODEL_TYPES: ReadonlySet<string> = new Set([
+  ModelType.LORA,
+  ModelType.LoCon,
+  ModelType.DoRA,
+]);
+
+export function isPageLoraResource(modelType: string): boolean {
+  return PAGE_LORA_MODEL_TYPES.has(modelType);
+}
+
+/**
+ * Page-LoRA (Increment 1, Option A): resolve a bare modelVersionId for a
+ * STATELESS page — identical select to `resolveBlockVersionContext` but WITHOUT
+ * the `version.modelId !== expectedModelId` FORBIDDEN binding check, because a
+ * page token has no JWT model binding (the viewer picks any resource they're
+ * entitled to; the security boundary is the per-resource entitlement gate in
+ * blocks.router, not a binding check).
+ *
+ * Do NOT route page LoRAs through `resolveBlockCheckpoint` — that helper is
+ * checkpoint-shaped (it asserts `modelType === 'Checkpoint'` and reads install
+ * rows a stateless page has none of). This returns the same `gate` bag +
+ * baseModel + modelType the checkpoint path already returns, so the router can
+ * (a) reject non-LoRA additional resources, (b) family-match against the
+ * checkpoint, and (c) entitlement-gate every resource in one call.
+ *
+ * Like the checkpoint resolver it throws NOT_FOUND for a missing/unpublished
+ * version and never reveals which model a hidden version belongs to.
+ */
+export async function resolvePageResourceContext(modelVersionId: number) {
+  const version = await dbRead.modelVersion.findUnique({
+    where: { id: modelVersionId },
+    select: {
+      id: true,
+      baseModel: true,
+      modelId: true,
+      status: true,
+      availability: true,
+      usageControl: true,
+      meta: true,
+      generationCoverage: { select: { covered: true } },
+      model: { select: { id: true, type: true, userId: true } },
+    },
+  });
+  if (!version || version.status !== 'Published') {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'model version not found' });
+  }
+  return {
+    modelId: version.modelId,
+    modelVersionId: version.id,
+    baseModel: version.baseModel,
+    modelType: version.model.type,
+    gate: {
+      id: version.id,
+      status: version.status,
+      availability: version.availability,
+      usageControl: version.usageControl,
+      baseModel: version.baseModel,
+      covered: version.generationCoverage?.covered ?? false,
+      modelUserId: version.model.userId,
+      modelType: version.model.type,
+      modelVersionAlias:
+        (version.meta as { generationAlias?: unknown } | null)?.generationAlias ?? null,
+    },
+  };
+}
+
 /**
  * Default canvas dimensions per base-model family. Aligned with what the
  * generation form picks when a user hits "Generate" with no overrides —
@@ -172,6 +244,23 @@ export function buildTextToImageInput(
   // count strength.
   if (resolved.modelType !== 'Checkpoint') {
     resources.push({ id: body.modelVersionId, strength: 1 });
+  }
+
+  // Page-LoRA (Increment 1): fan each caller-supplied additional resource into
+  // the generic `resources` array as { id, strength }. The orchestrator step
+  // (createTextToImageStep) consumes `resources` generically and builds
+  // additionalNetworks from the non-Checkpoint entries — no further step change
+  // is needed. DEDUPE against every id already present (the checkpoint anchor
+  // AND the bound-model anchor pushed above) so a LoRA that coincides with the
+  // anchor isn't double-billed / double-counted in strength. A LoRA that
+  // duplicates another LoRA keeps its first occurrence (first-wins).
+  if (body.additionalResources?.length) {
+    const seen = new Set(resources.map((r) => r.id));
+    for (const r of body.additionalResources) {
+      if (seen.has(r.modelVersionId)) continue;
+      seen.add(r.modelVersionId);
+      resources.push({ id: r.modelVersionId, strength: r.strength });
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Lets a **W10 full-page App Block** submit a generation with a **checkpoint + N additional LoRAs**, validated and entitlement-gated entirely server-side. This makes the Gen Matrix dogfood's LoRA axis functional.

**Scope = Increment 1 (Option A), server-only.** The block supplies LoRA version IDs in the request `body` (author-curated or user-pasted); the host already forwards `body` verbatim, so there's **no host change**. The host-mediated picker is Increment 2 (out of scope). Everything is behind the existing dark/mod App Blocks gates.

Product decisions applied (pre-agreed, not re-litigated): **LoRA-only v1**, `MAX_ADDITIONAL_RESOURCES=5`, strength `[-1,2]` default `1`, no `epochNumber`, no per-LoRA `modelId`.

## Pieces

**1 — body schema + step threading**
- `workflow.schema.ts`: optional `additionalResources` array (`{ modelVersionId: +int, strength: coerce [-1,2] default 1 }`, `.max(5)`). Caps intentionally tighter than the platform schema (untrusted iframe posture).
- `buildTextToImageInput`: fans each entry into the existing generic `resources` array, **deduping against the checkpoint AND the bound-model anchor** (first-wins). `createTextToImageStep` + the orchestrator consume `resources` generically — no other step change.

**2 — stateless page resource resolution**
- `resolvePageResourceContext(modelVersionId)`: identical select to `resolveBlockVersionContext` but **drops the `modelId` binding FORBIDDEN check** (pages have no JWT model binding). Page LoRAs resolve here, **not** through `resolveBlockCheckpoint`.
- `resolvePageLoraGates`: enforces **LoRA-only** (LORA/LoCon/DoRA) and an **explicit base-model family match** (`getBaseModelSetType`) vs the checkpoint — without it the orchestrator belt silently DROPS a mismatched LoRA and the viewer pays for a gen that ignored it. Runs **before** the entitlement gate / any cost.

**3 — per-resource entitlement gate (security headline, fail-closed)**
- Generalized `assertViewerCanGeneratePageModel` → `assertViewerCanGeneratePageResources`: checkpoint **AND every LoRA** pass through `resolveCanGenerateForVersions` in **one** call; **FORBIDDEN if any version's `canGenerate` is false OR missing from the result Map** (Map-miss = deny). Threads `sfwOnly: domain==='green'`.
- **Both belts kept**: the pre-spend gate is the fast-fail/UX layer; the orchestrator resource belt (`getGenerationResourceData`) independently re-checks the **full array** for early-access/`Private` in whatIf **and** submit, **before** any reservation.
- **Model-bound tokens reject `additionalResources` fail-closed** — it's a page-only feature; the model branch never runs the per-resource gate, so accepting it there would fan un-gated LoRAs into `resources`.

**4 — money (verify-only, no new code)**
- `whatIfResult.cost.total` already includes all resources; bounded by `buzzBudget` (per-gen) and the per-user daily `BLOCK_BUZZ_CAP_PER_DAY`. Added bounding tests.

## Test coverage

New/extended tests (node-only vitest, all green locally; browser/integration tiers deferred to CI):
- **Schema**: rejects >5 LoRAs, out-of-range strength, non-positive / non-integer versionId; strength defaults to 1.
- **Service**: `buildTextToImageInput` fans N LoRAs without duplicating the checkpoint/anchor (incl. LoRA-as-bound-model + first-wins dup); `resolvePageResourceContext` returns the gate bag with no binding check; `isPageLoraResource`.
- **Security (must-pass)**: un-entitled LoRA (`canGenerate:false`) → FORBIDDEN, no spend/reservation; LoRA **missing from the Map** → FORBIDDEN (fail-closed); non-LoRA → BAD_REQUEST; family-mismatch → BAD_REQUEST; unpublished → NOT_FOUND; **belt rejects an early-access/Private LoRA at whatIf before any reservation** even when the pre-spend gate passes; model-token `additionalResources` → FORBIDDEN.
- **Money**: 2-LoRA cost over per-gen budget → failed snapshot; multi-LoRA spend accumulates against the per-user daily cap (over-cap → failed + refund).

## Adversarial self-audit (fail-closed gate)

- Order verified: `resolvePageLoraGates` (type + family + NOT_FOUND) → `assertViewerCanGeneratePageResources` (entitlement, Map-miss = deny) → checkpoint → cost preflight (belt re-checks full array) → reserve. **All gates run before any reservation; family check runs before cost.**
- No path reaches spend with an un-entitled or wrong-family LoRA (two independent fail-closed layers).
- Model-path un-gated fan-out closed by the explicit FORBIDDEN guard.
- Type-clean (no new `any`/`as unknown` in production code; reuses the existing `buildGateVersion` cast). Empty/absent `additionalResources` is byte-identical to pre-change behavior.

## Not verified here

Local NixOS is offline — `tsc` and browser/Playwright tiers can't run; **CI is authoritative** for typecheck + browser/integration. No deployed/preview click-path run yet (the live Gen Matrix LoRA-axis E2E is a follow-up against a preview).

## Follow-up (separate repo PR)

`@civitai/app-sdk` / `@civitai/blocks-react` body + snapshot types need the new `additionalResources` field for block-side type safety. The host forwards `body` verbatim, so this server change works **without** it; it's purely about typed authoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)