### PR TITLE
feat(metrics): per-user % rollout for watcher metrics cutover + lock-heartbeat (ee#9)

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1910,7 +1910,7 @@ export const getAllImages = async (
       include?.includes('profilePictures') ? getProfilePicturesForUsers(userIds) : undefined,
       includeCosmetics ? getCosmeticsForEntity({ ids: imageIds, entity: 'Image' }) : undefined,
       getThumbnailsForImages(videoIds),
-      getImageMetricsObject(rawImages),
+      getImageMetricsObject(rawImages, userId),
       include?.includes('metaSelect') ? getMetaForImages(imageIds) : undefined,
       includeBaseModel ? imageResourcesCache.fetch(imageIds) : undefined,
     ])
@@ -2222,7 +2222,7 @@ export const getAllImagesIndex = async (
       include?.includes('metaSelect') ? getMetaForImages(imageIds) : undefined,
       getMetadataForImages(videoIds), // Only need this for videos
       getThumbnailsForImages(videoIds), // Only need this for videos
-      getImageMetricsObject(searchResults),
+      getImageMetricsObject(searchResults, currentUserId),
       // Fetch tagIds from cache so client-side hidden-tag filtering works.
       // Search results from BitDex don't include tagIds (too expensive to store),
       // and Meilisearch tagIds may be stale, so always fetch from the authoritative cache.
@@ -3275,7 +3275,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
       const droppedCount = results.length - filtered.length;
       droppedIdsTotal.inc({ route, hit_type: 'miss' }, droppedCount);
 
-      const imageMetrics = await getImageMetricsObject(filtered);
+      const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
       const fullData = filtered.map((h) => {
         const match = imageMetrics[h.id];
         return {
@@ -3395,7 +3395,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     // Apply the (flagged) existence check
     const filtered = await checkImageExistence(filteredHitIds);
 
-    const imageMetrics = await getImageMetricsObject(filtered);
+    const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
 
     const fullData = filtered.map((h) => {
       const match = imageMetrics[h.id];
@@ -4315,7 +4315,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       const droppedCount = limitedHits.length - filtered.length;
       droppedIdsTotal.inc({ route, hit_type: 'miss' }, droppedCount);
 
-      const imageMetrics = await getImageMetricsObject(filtered);
+      const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
       const fullData = filtered.map((h) => {
         const match = imageMetrics[h.id];
         return {
@@ -4439,7 +4439,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       nextCursor = undefined;
     }
 
-    const imageMetrics = await getImageMetricsObject(filtered);
+    const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
 
     const fullData = filtered.map((h) => {
       const match = imageMetrics[h.id];
@@ -4492,7 +4492,12 @@ const getImageMetricService = () =>
 
 type ImageMetricsObject = Awaited<ReturnType<typeof imageMetricsCache.fetch>>;
 
-const getImageMetricsObject = async (data: { id: number }[]): Promise<ImageMetricsObject> => {
+const getImageMetricsObject = async (
+  data: { id: number }[],
+  // The current viewer's userId, used solely to bucket the watcher-cutover
+  // rollout (below). Undefined for anon/unauthenticated reads.
+  userId?: number
+): Promise<ImageMetricsObject> => {
   try {
     const ids = data.map((d) => d.id);
 
@@ -4501,7 +4506,19 @@ const getImageMetricsObject = async (data: { id: number }[]): Promise<ImageMetri
     // `entitymetric:*` path, so merging this is a no-op; flip the flag to roll
     // over, and flip back (then bust `metrics:*`) to revert instantly. The
     // legacy write path is intentionally left intact so flip-back stays warm.
-    const fromWatcher = await getFliptBoolean(FLIPT_FEATURE_FLAGS.IMAGE_METRICS_FROM_WATCHER);
+    //
+    // Bucketed per-user (entityId = userId) so Flipt's percentage rollout ramps
+    // gradually (1% -> 10% -> 100%): a given user gets a consistent source
+    // across their whole feed, and the metrics:* cache warms in proportion to
+    // the rolled-out fraction rather than all at once (the cold-stampede that
+    // sank the first cutover, now also capped per-pod in MetricService). Anon
+    // traffic shares the 'anon' bucket and crosses the threshold atomically as
+    // the percentage ramps. The agg-source table (v2 vs legacy) is a SEPARATE
+    // global flag so every metrics:* populate uses one consistent CH source.
+    const fromWatcher = await getFliptBoolean(
+      FLIPT_FEATURE_FLAGS.IMAGE_METRICS_FROM_WATCHER,
+      userId?.toString() || 'anon'
+    );
     if (fromWatcher) {
       const metrics = await getImageMetricService().fetch('Image', ids);
       const result: ImageMetricsObject = {};
@@ -4686,7 +4703,7 @@ export const getImage = async ({
   const userCosmetics = await getCosmeticsForUsers([creatorId]);
   const profilePictures = await getProfilePicturesForUsers([creatorId]);
 
-  const imageMetrics = await getImageMetricsObject([firstRawImage]);
+  const imageMetrics = await getImageMetricsObject([firstRawImage], userId);
   const match = imageMetrics[firstRawImage.id];
   const imageCosmetics = await getCosmeticsForEntity({
     ids: [firstRawImage.id],


### PR DESCRIPTION
Bundles the app-side change for the entity-metric v2 cutover with the merged `event-engine-common` lock fix.

## Changes

**1. Submodule bump → event-engine-common#9** (`7a0c4b0`)
Heartbeats the per-id Redis stampede lock so a slow populate can't expire it mid-query and trigger cross-pod re-fire (the 2026-06 incident amplifier — `query_log` showed populate p99 going 800ms → 670s with a 27× read-row blowup as agg_new's merges starved). Plus release-on-error in `finally`, and a fix for a pre-existing waiter-harvest bug that made waiters return zeros instead of coalescing onto the holder.

**2. Per-user bucketing of `IMAGE_METRICS_FROM_WATCHER`** (`image.service.ts`)
`getImageMetricsObject(data, userId?)` threads the viewer's userId into the flag eval (`entityId = userId`, `'anon'` fallback) so Flipt's percentage rollout can ramp the watcher-cache cutover **1% → 10% → 100%** instead of all-or-nothing. One eval per request (per-user, not per-image — stays off the hot-path wasm cost). All 7 call sites pass the in-scope user var. The agg-source **table** (v2 vs legacy CH) remains a **separate global flag** so every `metrics:*` populate uses one consistent source regardless of who's bucketed.

## Why bundled

The lock fix and the ramp gate must deploy together: the ramp warms the cold cache gradually, and the heartbeated lock keeps a warming flood from re-firing across the 142 populate-path pods.

## Rollout (post-merge, no cache purge)
1. Flip `METRICS_AGG_V2_READ` ON **globally** (populates read the v2 view — no merge-starve).
2. Ramp `IMAGE_METRICS_FROM_WATCHER` per-user 1% → 10% → 100% via Flipt rollout rule. Watch `system.processes` + the drift canary (now v2-truthed via watcher#5) at each step.
3. Kill switch: flip either flag OFF; revert is instant (legacy `entitymetric:*` write path left intact).

## Reviews
- ee#9: reviewed 2× (heartbeat stop-race + waiter bug caught and fixed), APPROVE.
- This bucketing change: GPT-5.4 APPROVE-WITH-NITS (per-user consistency, no shared-key inconsistency, correct tradeoff).
- CH efficiency pass: no `FINAL`/`OPTIMIZE` added on any read path.

Typecheck: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)