### PR TITLE
perf(rate-limiting): reduce sysRedis fan-out + fail-open on the download path

### DIFF
--- a/src/server/utils/__tests__/rate-limiting.test.ts
+++ b/src/server/utils/__tests__/rate-limiting.test.ts
@@ -193,3 +193,87 @@ describe('createLimiter — fail-open on sysRedis error', () => {
     expect(failOpenSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('createLimiter — malformed MULTI reply fails OPEN WITH A LOG (M2: not a silent NaN-serve)', () => {
+  // A MULTI exec() that returns an unexpected shape (future node-redis change, or
+  // a typeMapping attached to the sys client) used to parse via Number(bad ?? 0) →
+  // NaN/0 → `count > limit` always false → serve unlimited forever with NO
+  // `rate-limit-write-degraded` log (limiter silently+permanently disabled). The
+  // arity assertion must THROW so it routes into the logged fail-open instead.
+
+  it.each<[string, unknown[] | null | undefined | Record<string, unknown>]>([
+    ['short array (arity 1)', ['5']],
+    ['long array (arity 3)', ['5', 3600, 'extra']],
+    ['null exec', null],
+    ['non-array object', { 0: '5', 1: 3600 }],
+  ])(
+    'hasExceededLimit: getCount MULTI returns %s → logged fail-open (serve), not silent NaN',
+    async (_label, badShape) => {
+      sysRedis.multi.mockReturnValueOnce(makeMulti(badShape as any));
+
+      const { limiter } = buildLimiter();
+      // Serves (false = not exceeded)…
+      await expect(limiter.hasExceededLimit('42', 'authed')).resolves.toBe(false);
+      // …but ONLY because the fail-open fired — NOT a silent NaN-serve.
+      expect(failOpenSpy).toHaveBeenCalledTimes(1);
+      expect(failOpenSpy).toHaveBeenCalledWith(
+        'rate-limit-write-degraded',
+        'createLimiter.hasExceededLimit',
+        expect.any(Error),
+        expect.objectContaining({ userKey: '42' })
+      );
+      // The limit HMGET must NOT have run — we never reached the NaN-compare.
+      expect(sysRedis.hmGet).not.toHaveBeenCalled();
+    }
+  );
+
+  it('increment: pipeline MULTI returns a malformed shape → logged fail-open (returns the increment)', async () => {
+    sysRedis.exists.mockResolvedValueOnce(1);
+    // arity-1 reply where 2 entries (INCRBY + HMGET) are expected
+    sysRedis.multi.mockReturnValueOnce(makeMulti([11] as any));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.increment('42', 1)).resolves.toBe(1);
+    expect(failOpenSpy).toHaveBeenCalledWith(
+      'rate-limit-write-degraded',
+      'createLimiter.increment',
+      expect.any(Error),
+      expect.objectContaining({ userKey: '42' })
+    );
+    // setLimitHitTime must NOT have run off a NaN newCount.
+    expect(sysRedis.set).not.toHaveBeenCalledWith(
+      'download:limits:42',
+      expect.any(Number),
+      expect.anything()
+    );
+  });
+});
+
+describe('createLimiter — public getCount fail-open (M1)', () => {
+  it('getCount returns undefined + logs when the MULTI read rejects (does not throw)', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti(new Error('sysRedis read timed out')));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.getCount('42')).resolves.toBeUndefined();
+    expect(failOpenSpy).toHaveBeenCalledWith(
+      'rate-limit-write-degraded',
+      'createLimiter.getCount',
+      expect.any(Error),
+      expect.objectContaining({ userKey: '42' })
+    );
+  });
+
+  it('getCount returns undefined + logs on a malformed MULTI reply (not a silent NaN)', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti(['5'] as any)); // arity 1, expected 2
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.getCount('42')).resolves.toBeUndefined();
+    expect(failOpenSpy).toHaveBeenCalledTimes(1);
+    expect(failOpenSpy).toHaveBeenCalledWith(
+      'rate-limit-write-degraded',
+      'createLimiter.getCount',
+      expect.any(Error),
+      expect.objectContaining({ userKey: '42' })
+    );
+  });
+});

--- a/src/server/utils/__tests__/rate-limiting.test.ts
+++ b/src/server/utils/__tests__/rate-limiting.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// rate-limiting.createLimiter wraps a small set of sysRedis ops behind a download/
+// generation/chat rate limiter. Two contracts matter operationally:
+//   (a) it must FAIL OPEN on any sysRedis error/timeout (serve, don't throw / don't
+//       block) — a wedged sys half-open otherwise 429/500s every download for the
+//       pod's lifetime; and
+//   (b) the happy-path counting/limit semantics must be unchanged after the
+//       fan-out reduction (GET+TTL and INCRBY+HMGET batched into MULTI pipelines).
+//
+// We mock the redis client module so no real connection is constructed. The
+// fail-open logger is mocked to assert it fires (and to keep Axiom out of the test).
+
+// vi.mock factories are hoisted above the imports, so any value they reference must
+// be created with vi.hoisted (also hoisted) — not a plain top-level const.
+const { failOpenSpy, sysRedis } = vi.hoisted(() => ({
+  failOpenSpy: vi.fn(),
+  // Mock the sys redis client surface used by the limiter.
+  sysRedis: {
+    get: vi.fn(),
+    set: vi.fn(),
+    ttl: vi.fn(),
+    exists: vi.fn(),
+    incrBy: vi.fn(),
+    hmGet: vi.fn(),
+    del: vi.fn(),
+    multi: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({
+  logSysRedisFailOpen: (...args: unknown[]) => failOpenSpy(...args),
+}));
+
+// withSysReadDeadline is the wall-clock guard; in tests we want it transparent so
+// a rejecting mock propagates immediately (no real timer). Pass-through.
+vi.mock('~/server/redis/sys-read-deadline', () => ({
+  withSysReadDeadline: <T>(p: Promise<T>) => p,
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis,
+  // The limiter imports these key-string types but they're type-only; the runtime
+  // values are supplied by the test directly as plain strings.
+  REDIS_SYS_KEYS: {},
+}));
+
+import { createLimiter } from '../rate-limiting';
+
+// Build a chainable multi() mock whose exec() resolves to `results` (or rejects).
+function makeMulti(execResult: unknown[] | Error) {
+  const pipeline: any = {};
+  for (const m of ['get', 'ttl', 'incrBy', 'hmGet', 'set', 'exists']) {
+    pipeline[m] = vi.fn(() => pipeline);
+  }
+  pipeline.exec = vi.fn(() =>
+    execResult instanceof Error ? Promise.reject(execResult) : Promise.resolve(execResult)
+  );
+  return pipeline;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sysRedis.set.mockResolvedValue(undefined);
+});
+
+function buildLimiter(fetchCount = vi.fn().mockResolvedValue(0)) {
+  return {
+    fetchCount,
+    limiter: createLimiter({
+      counterKey: 'download:count' as any,
+      limitKey: 'download:limits' as any,
+      fetchCount,
+    }),
+  };
+}
+
+describe('createLimiter — happy-path counting (semantics unchanged)', () => {
+  it('hasExceededLimit: count <= limit → false (not exceeded)', async () => {
+    // getCount → MULTI GET+TTL: count=5, ttl=3600 (valid)
+    sysRedis.multi.mockReturnValueOnce(makeMulti(['5', 3600]));
+    // getLimit → HMGET [userKey, default] → user limit 10
+    sysRedis.hmGet.mockResolvedValueOnce(['10', '20']);
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.hasExceededLimit('42', 'authed')).resolves.toBe(false);
+    expect(sysRedis.hmGet).toHaveBeenCalledWith('download:limits', ['42', 'authed']);
+  });
+
+  it('hasExceededLimit: count > limit → true (exceeded)', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti(['25', 3600]));
+    sysRedis.hmGet.mockResolvedValueOnce(['10', '20']);
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.hasExceededLimit('42', 'authed')).resolves.toBe(true);
+  });
+
+  it('hasExceededLimit: limit of 0 (unlimited) → false even with a high count', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti(['9999', 3600]));
+    sysRedis.hmGet.mockResolvedValueOnce([null, null]); // → Number(undefined ?? undefined ?? 0) = 0
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.hasExceededLimit('42', 'authed')).resolves.toBe(false);
+  });
+
+  it('hasExceededLimit: missing count + fetchOnUnknown=false → undefined → false (no limit read)', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti([null, -2]));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.hasExceededLimit('42', 'authed')).resolves.toBe(false);
+    // getCount returned undefined → getLimit must NOT run
+    expect(sysRedis.hmGet).not.toHaveBeenCalled();
+  });
+
+  it('getCount: value present but TTL < 0 → repopulates from fetchCount', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti(['7', -1]));
+    const fetchCount = vi.fn().mockResolvedValue(99);
+
+    const { limiter } = buildLimiter(fetchCount);
+    await expect(limiter.getCount('42')).resolves.toBe(99);
+    expect(fetchCount).toHaveBeenCalledWith('42');
+    expect(sysRedis.set).toHaveBeenCalledWith('download:count:42', 99, { EX: 60 * 60 });
+  });
+
+  it('increment: INCRBY result returned; sets limit-hit time when exceeded', async () => {
+    sysRedis.exists.mockResolvedValueOnce(1); // key exists, no populate
+    // MULTI: [incrBy → 11, hmGet → [10, 20]]  → limit 10, newCount 11 → exceeded
+    sysRedis.multi.mockReturnValueOnce(makeMulti([11, ['10', '20']]));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.increment('42')).resolves.toBe(11);
+    // setLimitHitTime → sysRedis.set on the limit key
+    expect(sysRedis.set).toHaveBeenCalledWith(
+      'download:limits:42',
+      expect.any(Number),
+      { EX: 60 * 60 }
+    );
+  });
+
+  it('increment: does NOT set limit-hit time when under the limit', async () => {
+    sysRedis.exists.mockResolvedValueOnce(1);
+    sysRedis.multi.mockReturnValueOnce(makeMulti([3, ['10', '20']])); // newCount 3 < limit 10
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.increment('42')).resolves.toBe(3);
+    expect(sysRedis.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('createLimiter — fail-open on sysRedis error', () => {
+  it('hasExceededLimit fails OPEN (returns false, logs) when the count read rejects', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti(new Error('redis cluster command timed out')));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.hasExceededLimit('42', 'authed')).resolves.toBe(false);
+    expect(failOpenSpy).toHaveBeenCalledWith(
+      'rate-limit-write-degraded',
+      'createLimiter.hasExceededLimit',
+      expect.any(Error),
+      expect.objectContaining({ userKey: '42' })
+    );
+  });
+
+  it('hasExceededLimit fails OPEN when the limit HMGET rejects', async () => {
+    sysRedis.multi.mockReturnValueOnce(makeMulti(['5', 3600])); // getCount ok
+    sysRedis.hmGet.mockRejectedValueOnce(new Error('sysRedis read timed out'));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.hasExceededLimit('42', 'authed')).resolves.toBe(false);
+    expect(failOpenSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('increment fails OPEN (returns the increment, logs, does not throw) when the pipeline rejects', async () => {
+    sysRedis.exists.mockResolvedValueOnce(1);
+    sysRedis.multi.mockReturnValueOnce(makeMulti(new Error('redis down')));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.increment('42', 1)).resolves.toBe(1);
+    expect(failOpenSpy).toHaveBeenCalledWith(
+      'rate-limit-write-degraded',
+      'createLimiter.increment',
+      expect.any(Error),
+      expect.objectContaining({ userKey: '42' })
+    );
+    // crucially: it must NOT have thrown — a 500 here would break the download path
+  });
+
+  it('increment fails OPEN when the EXISTS read rejects', async () => {
+    sysRedis.exists.mockRejectedValueOnce(new Error('sysRedis read timed out'));
+
+    const { limiter } = buildLimiter();
+    await expect(limiter.increment('42', 5)).resolves.toBe(5);
+    expect(failOpenSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/utils/rate-limiting.ts
+++ b/src/server/utils/rate-limiting.ts
@@ -1,5 +1,7 @@
 import type { RedisKeyStringsSys } from '~/server/redis/client';
 import { sysRedis } from '~/server/redis/client';
+import { withSysReadDeadline } from '~/server/redis/sys-read-deadline';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 
 export function createLimiter({
   counterKey,
@@ -23,11 +25,28 @@ export function createLimiter({
   }
 
   async function getCount(userKey: string) {
-    const countStr = await sysRedis.get(`${counterKey}:${userKey}`);
+    // Fan-out reduction: the count value and its TTL used to be two sequential
+    // sysRedis round-trips (GET then TTL). On a silent sys half-open each parks
+    // up to the OS-keepalive teardown — stacking the wait. Batch them into one
+    // MULTI exec (single round-trip) so a wedge stacks ~1× the read latency, not
+    // 2×. The sys client is single-node / Sentinel (NEVER a cluster — see
+    // client.ts `isCluster = type === 'cache' && env.REDIS_CLUSTER`), so a MULTI
+    // across the counter key carries no CROSSSLOT risk. Bounded by
+    // withSysReadDeadline (the sys client has no socketTimeout; a pipeline exec
+    // is not bounded by any per-command timeout). Semantics are byte-identical to
+    // the prior GET-then-TTL flow.
+    const key = `${counterKey}:${userKey}` as const;
+    const pipeline = sysRedis.multi();
+    pipeline.get(key);
+    pipeline.ttl(key);
+    const results = await withSysReadDeadline(pipeline.exec());
+
+    const countStr = results?.[0] as unknown as string | null;
+    const ttl = Number(results?.[1] ?? -1);
+
     if (!countStr) return fetchOnUnknown ? await populateCount(userKey) : undefined;
 
     // Handle missing TTL
-    const ttl = await sysRedis.ttl(`${counterKey}:${userKey}`);
     if (ttl < 0) return await populateCount(userKey);
 
     return Number(countStr);
@@ -40,34 +59,74 @@ export function createLimiter({
   }
 
   async function getLimit(userKey: string, fallbackKey = 'default') {
-    const cachedLimit = await sysRedis.hmGet(limitKey, [userKey, fallbackKey]);
+    const cachedLimit = await withSysReadDeadline(sysRedis.hmGet(limitKey, [userKey, fallbackKey]));
     return Number(cachedLimit?.[0] ?? cachedLimit?.[1] ?? 0);
   }
 
   async function hasExceededLimit(userKey: string, fallbackKey = 'default') {
-    const count = await getCount(userKey);
-    if (count === undefined) return false;
+    // Fail-open: a sysRedis error/timeout (silent half-open, failover) must NOT
+    // 429/500 every request for the pod's wedged lifetime. A wedge is rare and
+    // transient; letting a few requests through unlimited is strictly better than
+    // blocking all of them. Mirrors middleware.trpc.recordAttempt (PR #2332) and
+    // refreshToken (token-refresh.ts) — log via logSysRedisFailOpen so a SUSTAINED
+    // fail-open (= abuse protection effectively disabled) is dashboardable, then
+    // return false (= not exceeded = serve).
+    try {
+      const count = await getCount(userKey);
+      if (count === undefined) return false;
 
-    const limit = await getLimit(userKey, fallbackKey);
-    return limit !== 0 && count > limit;
+      const limit = await getLimit(userKey, fallbackKey);
+      return limit !== 0 && count > limit;
+    } catch (error) {
+      logSysRedisFailOpen('rate-limit-write-degraded', 'createLimiter.hasExceededLimit', error, {
+        counterKey,
+        userKey,
+      });
+      return false;
+    }
   }
 
   async function increment(userKey: string, by = 1) {
-    // Ensure key exists before incrementing
-    const exists = await sysRedis.exists(`${counterKey}:${userKey}`);
-    if (!exists) await populateCount(userKey);
+    // Fail-open: the limiter increment runs AFTER the protected action (e.g. the
+    // download is already being served), so a sysRedis error here must not surface
+    // as a 500 / stall. On failure we log and return the would-be count (best
+    // effort) — the only consequence is this attempt is under-counted in the
+    // sliding window until the next successful write, identical to the
+    // recordAttempt fail-open trade-off.
+    try {
+      const key = `${counterKey}:${userKey}` as const;
 
-    // Increment and get new count
-    const newCount = await sysRedis.incrBy(`${counterKey}:${userKey}`, by);
+      // Ensure key exists before incrementing
+      const exists = await withSysReadDeadline(sysRedis.exists(key));
+      if (!exists) await populateCount(userKey);
 
-    // Check if limit exceeded and set limit hit time
-    const limit = await getLimit(userKey);
-    if (limit !== 0 && newCount > limit) await setLimitHitTime(userKey);
-    return newCount;
+      // Fan-out reduction: INCRBY and the limit HMGET used to be two sequential
+      // round-trips. Batch them into one MULTI exec. (INCRBY mutates the counter
+      // key; HMGET reads the limit hash — both on the single-node sys client, no
+      // CROSSSLOT.) The result order matches the queue order.
+      const pipeline = sysRedis.multi();
+      pipeline.incrBy(key, by);
+      pipeline.hmGet(limitKey, [userKey, 'default']);
+      const results = await withSysReadDeadline(pipeline.exec());
+
+      const newCount = Number(results?.[0] ?? 0);
+      const cachedLimit = results?.[1] as unknown as (string | null)[] | undefined;
+      const limit = Number(cachedLimit?.[0] ?? cachedLimit?.[1] ?? 0);
+
+      // Check if limit exceeded and set limit hit time
+      if (limit !== 0 && newCount > limit) await setLimitHitTime(userKey);
+      return newCount;
+    } catch (error) {
+      logSysRedisFailOpen('rate-limit-write-degraded', 'createLimiter.increment', error, {
+        counterKey,
+        userKey,
+      });
+      return by;
+    }
   }
 
   async function getLimitHitTime(userKey: string) {
-    const limitHitTime = await sysRedis.get(`${limitKey}:${userKey}`);
+    const limitHitTime = await withSysReadDeadline(sysRedis.get(`${limitKey}:${userKey}`));
     if (!limitHitTime) return undefined;
     return new Date(Number(limitHitTime));
   }

--- a/src/server/utils/rate-limiting.ts
+++ b/src/server/utils/rate-limiting.ts
@@ -24,7 +24,30 @@ export function createLimiter({
     return fetchedCount;
   }
 
-  async function getCount(userKey: string) {
+  // A MULTI reply must arrive as a fixed-length array (one entry per queued
+  // command). If exec() ever returns an unexpected shape — a future node-redis
+  // change, or someone attaching a typeMapping to the sys client — silently
+  // parsing it via `Number(badShape ?? 0)` yields NaN/0 and the limiter degrades
+  // to "serve unlimited, never log" with NO `rate-limit-write-degraded` signal.
+  // Assert the arity BEFORE parsing and THROW on mismatch so it routes into the
+  // caller's existing logged fail-open instead of disabling abuse protection
+  // silently. (Throws on a genuine null exec too — same desired routing.)
+  function assertMultiArity(results: unknown, expected: number): unknown[] {
+    if (!Array.isArray(results) || results.length !== expected) {
+      throw new Error(
+        `sysRedis MULTI exec returned unexpected shape (expected array of ${expected}, got ${
+          Array.isArray(results) ? `array of ${results.length}` : typeof results
+        })`
+      );
+    }
+    return results;
+  }
+
+  // Internal core of getCount: may THROW (on sysRedis error/timeout or a
+  // malformed MULTI reply). Callers that own a fail-open catch (hasExceededLimit)
+  // use this directly so the error is logged under their fn name; the PUBLIC
+  // getCount wraps this in its own fail-open below.
+  async function getCountCore(userKey: string) {
     // Fan-out reduction: the count value and its TTL used to be two sequential
     // sysRedis round-trips (GET then TTL). On a silent sys half-open each parks
     // up to the OS-keepalive teardown — stacking the wait. Batch them into one
@@ -39,10 +62,10 @@ export function createLimiter({
     const pipeline = sysRedis.multi();
     pipeline.get(key);
     pipeline.ttl(key);
-    const results = await withSysReadDeadline(pipeline.exec());
+    const results = assertMultiArity(await withSysReadDeadline(pipeline.exec()), 2);
 
-    const countStr = results?.[0] as unknown as string | null;
-    const ttl = Number(results?.[1] ?? -1);
+    const countStr = results[0] as unknown as string | null;
+    const ttl = Number(results[1] ?? -1);
 
     if (!countStr) return fetchOnUnknown ? await populateCount(userKey) : undefined;
 
@@ -50,6 +73,24 @@ export function createLimiter({
     if (ttl < 0) return await populateCount(userKey);
 
     return Number(countStr);
+  }
+
+  // Public getCount: fail-open like the other public methods (hasExceededLimit /
+  // increment). It has no direct caller today — the `*.getCount` hits elsewhere
+  // are a different `createCounter` abstraction (server/games/new-order/utils.ts),
+  // not this one — but as a public return it must not throw on a sysRedis wedge
+  // and surface a 500. On a redis error it logs and returns `undefined`, matching
+  // the "count unknown" branch the happy path already produces.
+  async function getCount(userKey: string) {
+    try {
+      return await getCountCore(userKey);
+    } catch (error) {
+      logSysRedisFailOpen('rate-limit-write-degraded', 'createLimiter.getCount', error, {
+        counterKey,
+        userKey,
+      });
+      return undefined;
+    }
   }
 
   async function setLimitHitTime(userKey: string) {
@@ -72,7 +113,10 @@ export function createLimiter({
     // fail-open (= abuse protection effectively disabled) is dashboardable, then
     // return false (= not exceeded = serve).
     try {
-      const count = await getCount(userKey);
+      // Use the throwing core (not the fail-open public getCount) so a sysRedis
+      // error/malformed-reply on the count read routes into THIS catch and logs
+      // under fn `createLimiter.hasExceededLimit`.
+      const count = await getCountCore(userKey);
       if (count === undefined) return false;
 
       const limit = await getLimit(userKey, fallbackKey);
@@ -107,10 +151,13 @@ export function createLimiter({
       const pipeline = sysRedis.multi();
       pipeline.incrBy(key, by);
       pipeline.hmGet(limitKey, [userKey, 'default']);
-      const results = await withSysReadDeadline(pipeline.exec());
+      // Assert arity BEFORE parsing — a malformed reply would otherwise make
+      // newCount NaN and silently disable the limit-hit-time write with no
+      // fail-open log. A throw routes into the catch below (logged fail-open).
+      const results = assertMultiArity(await withSysReadDeadline(pipeline.exec()), 2);
 
-      const newCount = Number(results?.[0] ?? 0);
-      const cachedLimit = results?.[1] as unknown as (string | null)[] | undefined;
+      const newCount = Number(results[0] ?? 0);
+      const cachedLimit = results[1] as unknown as (string | null)[] | undefined;
       const limit = Number(cachedLimit?.[0] ?? cachedLimit?.[1] ?? 0);
 
       // Check if limit exceeded and set limit hit time


### PR DESCRIPTION
## Problem

When a civitai-web pod's sysRedis connection wedges (silent half-open), the **rate limiter** (`createLimiter`) was a tail-latency / error amplifier. It fired multiple **sequential** sysRedis round-trips per request, had **no error handling**, and did **not** use the `withSysReadDeadline` guard. The sys client carries no `socketTimeout` (bounded only by OS keepalive + `commandsQueueMaxLength` — see `client.ts`), so each parked read stacks, and any throw 500s the request.

> **Correction to the original premise:** the limiter uses **`sysRedis`** (the single-node / Sentinel *system* client), **not** the cluster `redis` client. The 15s `withCommandDeadline` is scoped to the **cluster** client only (`wrapWithDeadline = isClusterClient && clientLabel === 'cluster'`). So the download path never stacks the *cluster* 15s deadline — but the underlying fan-out + no-fail-open problem on the **sys** client is real (and arguably worse: no per-command timeout at all on the sys path).

## Scope — all 4 `createLimiter` consumers now fail-open (not just download)

The PR title says "download path", but `createLimiter` is shared. **Every** consumer below inherits the new fail-open behaviour on a sysRedis error/timeout:

| consumer | call site | methods used | prior behaviour on sysRedis error | new behaviour |
|---|---|---|---|---|
| **download** | `src/pages/api/download/models/[modelVersionId].ts` | `hasExceededLimit` + `increment` | throw → 500 (or stall) | fail-open: serve the download |
| **generation-history (read)** | `src/pages/api/generation/history/index.ts` | `hasExceededLimit` + `getLimitHitTime` | throw → 500 | fail-open: serve the history page |
| **generation-history (callback)** | `src/pages/api/generation/history/callback.ts` | `increment` | throw → 500 | fail-open: count under-reports the call |
| **chat anti-spam** | `src/server/services/chat.service.ts:298` (`createMessage`) | `increment` | throw → 500 (message rejected) | **fail-open: the message SENDS** |

### ⚠️ Behaviour change called out (chat anti-spam)
The chat message limiter previously **threw → 500** on a sysRedis error, which incidentally *blocked* the message. It now **fails open and sends the message**, and the per-user spam counter **under-counts** that message until the next successful sysRedis write. This is a deliberate availability trade-off (consistent with the other consumers, and with the house `recordAttempt` / `refreshToken` fail-open pattern): a transient sysRedis wedge should not 500 every chat send. The content-block / moderation guards in `createMessage` still run — only the *rate* counter degrades, and a **sustained** degrade is visible via the `rate-limit-write-degraded` dashboard/alert.

## Changes

### 1. Fan-out reduction (semantics byte-identical)
| method | before | after |
|---|---|---|
| `getCount` | `GET` then `TTL` (2 sequential reads) | one `MULTI` exec (1 round-trip) |
| `increment` | `INCRBY` then limit `HMGET` (2 sequential ops) | one `MULTI` exec (1 round-trip) |
| `hasExceededLimit` worst case | `GET` + `TTL` + `HMGET` = 3 sequential reads | 2 batched ops |

A full download request (`hasExceededLimit` early + `increment` late) drops from **up to 7 sequential sysRedis ops** to **batched pipelines**, so a wedge stacks ~1× the read latency per call instead of N×.

**No CROSSSLOT risk:** the sys client is single-node / Sentinel, never a cluster (`isCluster = type === 'cache' && env.REDIS_CLUSTER`), so `MULTI` across the counter key and the limit hash is safe (same precedent as `token-refresh.ts`'s `sysRedis.multi()` pipeline).

### 2. Fail-open on a sysRedis error/timeout
`hasExceededLimit`, `increment`, and the public `getCount` now wrap their sysRedis ops in `try/catch`; on any error/timeout they `logSysRedisFailOpen('rate-limit-write-degraded', ...)` and **serve** (`hasExceededLimit → false`, `increment → returns the increment best-effort`, `getCount → undefined`) instead of 429/500/stalling. All reads also pass through `withSysReadDeadline`.

**Why it's safe:** a wedge is rare and transient; letting a few requests through unlimited beats 429/500ing every request for the pod's wedged lifetime. Fail-open only on a redis error (never silently disabling abuse protection — see the M2 guard below), and the `rate-limit-write-degraded` subtype is already dashboarded/alerted, so a **sustained** fail-open (= abuse protection effectively off) is visible to ops. Mirrors the established house pattern: `middleware.trpc.recordAttempt` (PR #2332), `refreshToken` (`token-refresh.ts`), `cache-helpers` fail-open.

### 3. Audit fixes (GO-WITH-FIXES)
- **M2 — close the silent-fail-open hole.** The fail-open catches only fire on a *thrown* error, but the MULTI-reply parse paths can't throw — `Number(badShape ?? 0)` yields `NaN`/`0`. If `exec()` ever returned an unexpected shape (a future node-redis change, or a `typeMapping` attached to the sys client), `hasExceededLimit` would compute `count > limit` with `NaN` → always `false` → **serve unlimited forever, never logging** (limiter silently + permanently disabled, no `rate-limit-write-degraded` signal). Fix: assert the MULTI reply arity (`Array.isArray && length === 2`) **before** parsing, for **both** the getCount MULTI (`GET`+`TTL`→2) and the increment MULTI (`INCRBY`+`HMGET`→2); a mismatch **throws** so it routes into the existing logged fail-open instead of degrading to a silent NaN-serve. Happy-path behaviour is unchanged.
- **M1 — public `getCount` is now fail-open too.** `getCount` is a public return of `createLimiter` and (via `withSysReadDeadline`) could throw on a wedge while not being fail-open-wrapped. It has **no direct caller today** (the `*.getCount` hits in `new-order` are a different `createCounter` abstraction in `server/games/new-order/utils.ts` — verified), so it was latent, but as a public surface it shouldn't surface a 500. Wrapped it in the same fail-open (logs `createLimiter.getCount`, returns `undefined`) for consistency with the other public methods. Internally, `hasExceededLimit` calls a throwing `getCountCore` so its own catch still owns the count-read error (preserves the existing `fn` in the log).

### 4. Tests
`src/server/utils/__tests__/rate-limiting.test.ts` — **18/18 green** (node-only vitest):
- **Happy-path counting unchanged (M2 happy path preserved):** count ≤ limit → false; count > limit → true; limit `0` (unlimited) → false; missing count + `fetchOnUnknown=false` → undefined → false (and limit read is **skipped**); value present + TTL<0 → repopulate from `fetchCount`; `increment` returns INCRBY result and sets limit-hit time only when exceeded.
- **Fail-open on error:** count read rejects / limit HMGET rejects / increment pipeline rejects / EXISTS rejects → **serve, log, never throw**.
- **M2 — malformed MULTI reply:** short/long array, `null` exec, and non-array shapes for both `getCount` and `increment` pipelines → **logged fail-open** (`logSysRedisFailOpen('rate-limit-write-degraded', …)` fires), **not** a silent NaN-serve (verified the test fails if the arity guard is removed — neutering the guard reproduces the `0`/no-log silent serve).
- **M1 — public `getCount` fail-open:** redis error and malformed reply → `undefined` + log, never throws.

## Not done / deferred
- I did **not** fold the limit `HMGET` into `getCount`'s `GET+TTL` pipeline for `hasExceededLimit` (would cut it to 1 round-trip), because `getCount` conditionally runs `populateCount` (a DB fetch + `SET`) based on the GET/TTL result — folding the limit read in would change the populate branching. Keeping `getCount` and `getLimit` as separate ≤1-round-trip ops preserves semantics exactly while still halving the worst case.

## Verification status
Unit-tested (fan-out semantics + fail-open + M1/M2). **Not** exercised against a live wedged sysRedis on-cluster. Behaviour-preserving + fail-open-only-on-error, so blast radius is low, but the wedge-degradation has not been reproduced end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
