### PR TITLE
feat(blocks): accept scoped OAuth tokens at app-blocks submit + register civitai-cli client

### DIFF
--- a/prisma/migrations/20260619120000_register_civitai_cli_oauth_client/migration.sql
+++ b/prisma/migrations/20260619120000_register_civitai_cli_oauth_client/migration.sql
@@ -1,0 +1,56 @@
+-- Register the first-party `civitai-cli` OAuth client.
+--
+-- This is a PUBLIC (no-secret) client used by the official `civitai` CLI to log
+-- in via the OAuth device-authorization grant (RFC 8628) and obtain a token that
+-- the App Blocks submit endpoint (api/v1/blocks/submit-version) accepts. The CLI
+-- hardcodes the stable client id `civitai-cli`.
+--
+-- allowedScopes = TokenScope.UserRead | TokenScope.AppBlocksSubmit
+--               = 1 | 33554432
+--               = 33554433
+-- (AppBlocksSubmit, bit 25 = 1<<25 = 33554432, is opt-in and INTENTIONALLY
+--  excluded from TokenScope.Full = 33554431. This client is the only first-party
+--  consumer that requests it.)
+--
+-- Owner: the civitai system account (User id -1) — the first-party convention.
+--
+-- IDEMPOTENT: ON CONFLICT DO NOTHING on the PK so re-applying is a no-op. The
+-- WHERE EXISTS guard avoids an FK violation if the civitai system User row is
+-- absent in a given environment (in that case this inserts nothing and the row
+-- must be created manually with a valid owner userId).
+--
+-- ⚠️ MANUAL-APPLY: per the cluster ops rule, civitai DB migrations are NOT
+-- auto-applied. A human applies this to prod (CNPG nvme0) and the dev clone.
+INSERT INTO "OauthClient" (
+  "id",
+  "secret",
+  "name",
+  "description",
+  "logoUrl",
+  "redirectUris",
+  "allowedOrigins",
+  "grants",
+  "allowedScopes",
+  "isConfidential",
+  "userId",
+  "isVerified",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  'civitai-cli',
+  NULL,
+  'Civitai CLI',
+  'Official Civitai command-line tool. Used to submit App Blocks for review and manage your apps from the terminal.',
+  NULL,
+  ARRAY['http://127.0.0.1/callback', 'http://localhost/callback']::TEXT[],
+  ARRAY[]::TEXT[],
+  ARRAY['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:device_code']::TEXT[],
+  33554433,
+  false,
+  -1,
+  true,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+WHERE EXISTS (SELECT 1 FROM "User" WHERE "id" = -1)
+ON CONFLICT ("id") DO NOTHING;

--- a/src/pages/api/auth/oauth/authorize.ts
+++ b/src/pages/api/auth/oauth/authorize.ts
@@ -9,7 +9,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
-import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { TokenScope, ALL_SCOPES } from '~/shared/constants/token-scope.constants';
 import { buzzLimitSchema } from '~/server/schema/api-key.schema';
 import { redirectUriMatches } from '~/server/schema/oauth-client.schema';
 import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
@@ -110,7 +110,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // Validate and clamp scope
     const rawScope = parseInt(params.scope as string, 10);
-    if (isNaN(rawScope) || rawScope < 0 || rawScope > TokenScope.Full) {
+    // Bound against ALL_SCOPES (incl. opt-in AppBlocksSubmit), NOT `Full`, so a
+    // client may request an opt-in bit outside `Full`. The per-client
+    // allowedScopes intersection (downstream) is the real authorization gate.
+    if (isNaN(rawScope) || rawScope < 0 || rawScope > ALL_SCOPES) {
       return res
         .status(400)
         .json({ error: 'invalid_scope', error_description: 'Invalid scope value' });

--- a/src/pages/api/auth/oauth/device-token.ts
+++ b/src/pages/api/auth/oauth/device-token.ts
@@ -7,7 +7,7 @@ import { logOAuthEvent } from '~/server/oauth/audit-log';
 import { createOAuthTokenPair } from '~/server/oauth/token-helpers';
 import { ACCESS_TOKEN_TTL } from '~/server/oauth/constants';
 import { Flags } from '~/shared/utils/flags';
-import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { TokenScope, ALL_SCOPES } from '~/shared/constants/token-scope.constants';
 import { dbRead } from '~/server/db/client';
 import requestIp from 'request-ip';
 
@@ -78,7 +78,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const rawScope = parseInt(data.scope, 10);
-  if (isNaN(rawScope) || rawScope < 0 || rawScope > TokenScope.Full) {
+  // Bound against ALL_SCOPES (incl. opt-in AppBlocksSubmit), NOT `Full` — the
+  // approved device code may legitimately carry AppBlocksSubmit (bit 25), which
+  // is outside `Full`. The per-client allowedScopes intersection below is the
+  // real authorization gate.
+  if (isNaN(rawScope) || rawScope < 0 || rawScope > ALL_SCOPES) {
     return res.status(400).json({ error: 'invalid_scope' });
   }
   const scope = rawScope;

--- a/src/pages/api/auth/oauth/device-token.ts
+++ b/src/pages/api/auth/oauth/device-token.ts
@@ -92,7 +92,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     where: { id: client_id },
     select: { allowedScopes: true },
   });
-  if (client && !Flags.hasFlag(client.allowedScopes, scope)) {
+  // Fail closed: if the client row is absent (e.g. deleted between device-code
+  // creation and token exchange) the scope intersection cannot be evaluated, so
+  // reject rather than skip the gate.
+  if (!client) {
+    return res.status(400).json({ error: 'invalid_client' });
+  }
+  if (!Flags.hasFlag(client.allowedScopes, scope)) {
     return res
       .status(400)
       .json({

--- a/src/pages/api/auth/oauth/device.ts
+++ b/src/pages/api/auth/oauth/device.ts
@@ -7,7 +7,7 @@ import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
 import { DEVICE_CODE_TTL, DEVICE_POLL_INTERVAL } from '~/server/oauth/constants';
 import { Flags } from '~/shared/utils/flags';
-import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { TokenScope, ALL_SCOPES } from '~/shared/constants/token-scope.constants';
 import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
 import { env } from '~/env/server';
 
@@ -79,7 +79,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // Validate scope early (also validated at token exchange, but fail fast for UX)
   const rawScope = parseInt(scope as string, 10) || 0;
-  if (rawScope < 0 || rawScope > TokenScope.Full) {
+  // Bound against ALL_SCOPES (every defined bit, incl. opt-in AppBlocksSubmit),
+  // NOT `Full` — `Full` excludes opt-in bits, so a client legitimately
+  // requesting AppBlocksSubmit (e.g. civitai-cli) would be rejected here.
+  if (rawScope < 0 || rawScope > ALL_SCOPES) {
     return res.status(400).json({ error: 'invalid_scope' });
   }
   // UserRead is a mandatory baseline on every grant — force it on and treat it

--- a/src/pages/api/v1/blocks/submit-version.ts
+++ b/src/pages/api/v1/blocks/submit-version.ts
@@ -6,6 +6,8 @@ import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
 import { submitVersionSchema } from '~/server/schema/blocks/publish-request.schema';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
 
 type AxiomAPIRequest = NextApiRequest & { log: Logger };
 
@@ -22,16 +24,25 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  * applies the SAME gates the session route applies and calls the SAME
  * `submitVersion` service UNCHANGED. The publish logic is not forked.
  *
- * ## Gate posture (intentionally identical to the session route — launch-dark)
- *   - Auth: a valid civitai API key (resolved by `getSessionFromBearerToken`,
- *     which hashes the key with the same `generateSecretHash` the public REST API
- *     uses and looks it up in the `ApiKey` table — NO new key system).
+ * ## Gate posture
+ *   - Auth: a valid civitai API key OR OAuth-issued token (both resolved by
+ *     `getSessionFromBearerToken`, which hashes the credential with the same
+ *     `generateSecretHash` the public REST API uses and looks it up in the
+ *     `ApiKey` table — NO new key system).
+ *   - Token type: a PERSONAL key always passes the type gate (unchanged). An
+ *     OAuth-client-issued token passes ONLY if it carries the dedicated
+ *     `TokenScope.AppBlocksSubmit` bit. That scope is opt-in, off-by-default, and
+ *     EXCLUDED from `TokenScope.Full`, so only a client that explicitly lists it
+ *     in `allowedScopes` and a user who explicitly consented can mint such a
+ *     token (the first-party `civitai-cli` client is provisioned with it). An
+ *     un-scoped OAuth token is rejected 403.
  *   - Feature flag: `isAppBlocksEnabled({ user })` evaluated WITH the resolved
  *     user's context (mirrors the session route + `enforceAppBlocksFlag`).
- *   - Moderator: the resolved user must be `isModerator` and not banned. App
- *     Blocks is mod-only pre-GA; this route keeps that posture (same as the
- *     session route's `ModEndpoint`). When App Blocks goes GA, RELAX this gate in
- *     lockstep with the session route — not unilaterally.
+ *   - Moderator: the resolved user must be `isModerator` and not banned, on BOTH
+ *     the personal-key and OAuth-token paths. App Blocks is mod-only pre-GA; this
+ *     route keeps that posture (same as the session route's `ModEndpoint`). When
+ *     App Blocks goes GA, RELAX this gate in lockstep with the session route —
+ *     not unilaterally.
  *
  * ## Why no CSRF / Origin check here (unlike the session route)
  * The session route guards Origin because it is COOKIE-authed: a logged-in mod's
@@ -94,25 +105,40 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   }
   const user = session.user as SessionUser;
 
-  // 1b. Personal-API-key gate — reject OAuth-client-issued tokens.
-  // `getSessionFromBearerToken` (src/server/auth/bearer-token.ts:42-58) sets
-  // `subject = { type: 'oauth', id: clientId }` IFF the resolved `ApiKey` row has
-  // a non-null `clientId` (i.e. it was minted for an OAuth client a user
+  // 1b. Token-type gate — accept EITHER a personal API key OR a scoped OAuth
+  // token. `getSessionFromBearerToken` (src/server/auth/bearer-token.ts:42-58)
+  // sets `subject = { type: 'oauth', id: clientId }` IFF the resolved `ApiKey`
+  // row has a non-null `clientId` (minted for an OAuth client a user
   // authorized), and `{ type: 'apiKey', id }` for a user-type personal-access
-  // key. `oauthClient.create` is an open `protectedProcedure` — any logged-in
-  // user can register a client — so without this gate a third-party app a mod
-  // authorizes for ANY scope would receive a key that can publish App Blocks
-  // attributed to that mod (an escalation of the consent the mod granted). App
-  // Blocks has no dedicated write-scope flag yet, so a personal-key requirement
-  // (`subject.type !== 'oauth'`, equivalently `clientId == null`) is the minimal
-  // correct gate. This mirrors the OAuth/scoped-token treatment in
-  // src/pages/api/v1/me.ts:24-40 (`subject !== null`). Ordered after auth (401)
-  // and before the mod gate so an OAuth key gets 403, never a leak.
+  // key.
+  //
+  //  - PERSONAL key (`subject.type !== 'oauth'`, i.e. clientId == null): pass.
+  //    This path is UNCHANGED from the launch-dark version — a logged-in mod's
+  //    own key publishes as before. The downstream mod + flag gates still apply.
+  //
+  //  - OAUTH token (`subject.type === 'oauth'`): pass ONLY if the token carries
+  //    the dedicated `TokenScope.AppBlocksSubmit` bit. `oauthClient.create` is an
+  //    open `protectedProcedure` (any logged-in user can register a client), so
+  //    we must NOT accept arbitrary OAuth tokens: a third-party app a mod
+  //    authorizes for some unrelated scope would otherwise be able to publish App
+  //    Blocks attributed to that mod (a consent escalation). `AppBlocksSubmit` is
+  //    opt-in, off-by-default, and EXCLUDED from `TokenScope.Full` (see
+  //    token-scope.constants.ts), so only a client that explicitly lists it in
+  //    `allowedScopes` AND a user who explicitly consented to it can mint a token
+  //    that reaches here. The first-party `civitai-cli` client is provisioned
+  //    with exactly `UserRead | AppBlocksSubmit`.
+  //
+  // The moderator + not-banned gate (step 2) applies to BOTH paths — a scoped
+  // OAuth token from a NON-moderator is still rejected there. Ordered after auth
+  // (401) and before the mod gate so an un-scoped OAuth key gets 403, never a leak.
   if (session.subject?.type === 'oauth') {
-    res.status(403).json({
-      message: 'App Blocks submit requires a personal API key, not an OAuth client token',
-    });
-    return;
+    if (!Flags.hasFlag(session.tokenScope, TokenScope.AppBlocksSubmit)) {
+      res.status(403).json({
+        message:
+          'App Blocks submit requires a personal API key or an OAuth token with the App Blocks submit scope',
+      });
+      return;
+    }
   }
 
   // 2. Moderator gate — App Blocks is mod-only pre-GA (parity with the session

--- a/src/server/oauth/__tests__/device-token-scope.test.ts
+++ b/src/server/oauth/__tests__/device-token-scope.test.ts
@@ -130,4 +130,32 @@ describe('device-token endpoint — AppBlocksSubmit scope survives into the mint
     expect((res._getJSONData() as { error: string }).error).toBe('invalid_scope');
     expect(mockCreatePair).not.toHaveBeenCalled();
   });
+
+  it('fails closed with invalid_client when the client row is absent (audit LOW-1)', async () => {
+    // Client was deleted between device-code creation and token exchange. The
+    // allowedScopes intersection cannot be evaluated, so the endpoint must
+    // reject rather than skip the gate and mint a token.
+    mockHGet.mockResolvedValueOnce({
+      clientId: 'civitai-cli',
+      userCode: 'ABCD-EFGH',
+      scope: CLI_SCOPE.toString(),
+      status: 'approved',
+      userId: 7,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    });
+    mockClientFindUnique.mockResolvedValueOnce(null);
+
+    const { req, res } = createMocks({
+      body: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'devcode',
+        client_id: 'civitai-cli',
+      },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect((res._getJSONData() as { error: string }).error).toBe('invalid_client');
+    expect(mockCreatePair).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/oauth/__tests__/device-token-scope.test.ts
+++ b/src/server/oauth/__tests__/device-token-scope.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+// Verifies the device-flow plumbing change: a device code approved with the
+// opt-in AppBlocksSubmit bit (which exceeds TokenScope.Full) survives the
+// device-token endpoint's scope bound + per-client allowedScopes intersection
+// and reaches createOAuthTokenPair INTACT (so the minted token carries the bit).
+// Before the ALL_SCOPES fix, the `rawScope > TokenScope.Full` bound rejected it
+// with invalid_scope.
+
+function createMocks({ body = {} }: { body?: unknown }) {
+  const req = { method: 'POST', headers: {}, body } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown = undefined;
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {},
+    end() {
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+  };
+  return { req, res };
+}
+
+const { mockHGet, mockHDel, mockCreatePair, mockClientFindUnique } = vi.hoisted(() => ({
+  mockHGet: vi.fn(),
+  mockHDel: vi.fn().mockResolvedValue(undefined),
+  mockCreatePair: vi.fn(),
+  mockClientFindUnique: vi.fn(),
+}));
+
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/utils/endpoint-helpers', () => ({ addCorsHeaders: () => false }));
+vi.mock('~/server/oauth/rate-limit', () => ({
+  checkOAuthRateLimit: vi.fn().mockResolvedValue(true),
+  sendRateLimitResponse: vi.fn(),
+}));
+vi.mock('~/server/oauth/audit-log', () => ({ logOAuthEvent: vi.fn() }));
+vi.mock('~/server/redis/client', () => ({
+  redis: { packed: { hGet: mockHGet }, hDel: mockHDel },
+  REDIS_KEYS: { OAUTH: { DEVICE_CODES: 'oauth:device-codes' } },
+}));
+vi.mock('~/server/oauth/token-helpers', () => ({ createOAuthTokenPair: mockCreatePair }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { oauthClient: { findUnique: mockClientFindUnique } },
+}));
+vi.mock('request-ip', () => ({ default: { getClientIp: () => '203.0.113.7' } }));
+
+import handler from '~/pages/api/auth/oauth/device-token';
+
+const CLI_SCOPE = TokenScope.UserRead | TokenScope.AppBlocksSubmit; // 33554433
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreatePair.mockResolvedValue({
+    accessToken: 'civitai_access',
+    accessTokenExpiresAt: new Date(Date.now() + 3600_000),
+    refreshToken: 'civitai_refresh',
+    refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600_000),
+  });
+});
+
+describe('device-token endpoint — AppBlocksSubmit scope survives into the minted token', () => {
+  it('mints a token carrying AppBlocksSubmit when the approved device code requested it', async () => {
+    mockHGet.mockResolvedValueOnce({
+      clientId: 'civitai-cli',
+      userCode: 'ABCD-EFGH',
+      scope: CLI_SCOPE.toString(),
+      status: 'approved',
+      userId: 7,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    });
+    // Client allows exactly UserRead|AppBlocksSubmit.
+    mockClientFindUnique.mockResolvedValueOnce({ allowedScopes: CLI_SCOPE });
+
+    const { req, res } = createMocks({
+      body: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'devcode',
+        client_id: 'civitai-cli',
+      },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    // The scope bound (now ALL_SCOPES) did NOT reject the bit-25 value.
+    expect(res._getJSONData()).toMatchObject({
+      token_type: 'Bearer',
+      scope: CLI_SCOPE.toString(),
+    });
+    const json = res._getJSONData() as { refresh_token: string; expires_in: number };
+    expect(json.refresh_token).toBe('civitai_refresh');
+    expect(json.expires_in).toBe(3600);
+    // createOAuthTokenPair received the scope INTACT (bit 25 preserved).
+    expect(mockCreatePair).toHaveBeenCalledTimes(1);
+    expect(mockCreatePair).toHaveBeenCalledWith(7, 'civitai-cli', CLI_SCOPE);
+  });
+
+  it('rejects when the client allowedScopes does NOT include AppBlocksSubmit', async () => {
+    mockHGet.mockResolvedValueOnce({
+      clientId: 'civitai-cli',
+      userCode: 'ABCD-EFGH',
+      scope: CLI_SCOPE.toString(),
+      status: 'approved',
+      userId: 7,
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    });
+    // Client only allows UserRead — intersection must reject the submit bit.
+    mockClientFindUnique.mockResolvedValueOnce({ allowedScopes: TokenScope.UserRead });
+
+    const { req, res } = createMocks({
+      body: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'devcode',
+        client_id: 'civitai-cli',
+      },
+    });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect((res._getJSONData() as { error: string }).error).toBe('invalid_scope');
+    expect(mockCreatePair).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/oauth/__tests__/validate-scope.test.ts
+++ b/src/server/oauth/__tests__/validate-scope.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+// Authorization_code path's scope gate (oauthModel.validateScope). Uses the
+// REAL Flags + TokenScope so the bit-math is genuinely exercised: a client
+// whose allowedScopes is TokenScope.Full (bits 0..24, EXCLUDES AppBlocksSubmit)
+// cannot escalate to a token carrying AppBlocksSubmit (bit 25) — mirrors the
+// device-flow intersection, but on the authorize grant. (audit LOW-2)
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { oauthClient: { findUnique: vi.fn() } },
+  dbWrite: { apiKey: {} },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { packed: {}, hExpire: vi.fn(), hDel: vi.fn() },
+  REDIS_KEYS: { OAUTH: {} },
+}));
+vi.mock('~/server/redis/atomic', () => ({ hSetWithTTL: vi.fn() }));
+vi.mock('~/server/utils/key-generator', () => ({
+  generateSecretHash: (s: string) => `hash:${s}`,
+}));
+vi.mock('~/server/oauth/token-helpers', () => ({ createOAuthTokenPair: vi.fn() }));
+
+import { oauthModel } from '../model';
+
+const user = { id: 7 } as any;
+const baseClient = { id: 'civitai-cli', grants: ['authorization_code'] } as any;
+
+describe('oauthModel.validateScope — authorize-flow scope intersection', () => {
+  it('rejects a client requesting AppBlocksSubmit when allowedScopes is Full (no bit 25)', async () => {
+    // allowedScopes = Full (33554431) deliberately EXCLUDES AppBlocksSubmit.
+    const client = { ...baseClient, allowedScopes: TokenScope.Full };
+    const requested = (TokenScope.UserRead | TokenScope.AppBlocksSubmit).toString(); // 33554433
+
+    const result = await oauthModel.validateScope(user, client, [requested]);
+
+    expect(result).toBe(false);
+  });
+
+  it('grants when allowedScopes includes AppBlocksSubmit', async () => {
+    const client = {
+      ...baseClient,
+      allowedScopes: TokenScope.UserRead | TokenScope.AppBlocksSubmit,
+    };
+    const requested = (TokenScope.UserRead | TokenScope.AppBlocksSubmit).toString();
+
+    const result = await oauthModel.validateScope(user, client, [requested]);
+
+    // Returns the granted scope string array (UserRead is always folded in).
+    expect(result).toEqual([(TokenScope.UserRead | TokenScope.AppBlocksSubmit).toString()]);
+  });
+});

--- a/src/server/oauth/model.ts
+++ b/src/server/oauth/model.ts
@@ -13,7 +13,7 @@ import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { hSetWithTTL } from '~/server/redis/atomic';
 import { generateSecretHash } from '~/server/utils/key-generator';
 import { Flags } from '~/shared/utils/flags';
-import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { TokenScope, ALL_SCOPES } from '~/shared/constants/token-scope.constants';
 import { ACCESS_TOKEN_TTL, AUTH_CODE_TTL, REFRESH_TOKEN_TTL } from './constants';
 import { createOAuthTokenPair } from './token-helpers';
 import { OriginNotAllowedError } from './errors';
@@ -33,7 +33,10 @@ function stringToScope(scope: string | string[] | undefined): number {
   if (!scope) return 0;
   const str = Array.isArray(scope) ? scope[0] : scope;
   const parsed = parseInt(str, 10);
-  if (isNaN(parsed) || parsed < 0 || parsed > TokenScope.Full) return 0;
+  // Bound against ALL_SCOPES (incl. opt-in bits like AppBlocksSubmit), NOT
+  // `Full` — clamping to `Full` would silently drop an opt-in bit a client
+  // legitimately requested. Out-of-range → 0 (deny), preserving prior posture.
+  if (isNaN(parsed) || parsed < 0 || parsed > ALL_SCOPES) return 0;
   return parsed;
 }
 

--- a/src/shared/constants/__tests__/token-scope.constants.test.ts
+++ b/src/shared/constants/__tests__/token-scope.constants.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TokenScope,
+  ALL_SCOPES,
+  tokenScopeLabels,
+} from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
+
+describe('TokenScope constants', () => {
+  it('AppBlocksSubmit is bit 25 (1 << 25 = 33554432)', () => {
+    expect(TokenScope.AppBlocksSubmit).toBe(1 << 25);
+    expect(TokenScope.AppBlocksSubmit).toBe(33554432);
+  });
+
+  it('Full is UNCHANGED at 33554431 and EXCLUDES AppBlocksSubmit', () => {
+    // Critical backward-compat invariant: existing personal keys persist
+    // tokenScope = 33554431. Changing Full would silently re-interpret them.
+    expect(TokenScope.Full).toBe(33554431);
+    expect(TokenScope.Full).toBe((1 << 25) - 1);
+    // AppBlocksSubmit is opt-in and NOT folded into Full.
+    expect(Flags.hasFlag(TokenScope.Full, TokenScope.AppBlocksSubmit)).toBe(false);
+  });
+
+  it('ALL_SCOPES includes every defined bit, including AppBlocksSubmit', () => {
+    expect(Flags.hasFlag(ALL_SCOPES, TokenScope.AppBlocksSubmit)).toBe(true);
+    expect(Flags.hasFlag(ALL_SCOPES, TokenScope.UserRead)).toBe(true);
+    expect(Flags.hasFlag(ALL_SCOPES, TokenScope.VaultWrite)).toBe(true);
+    // ALL_SCOPES = Full | AppBlocksSubmit (the only opt-in bit today).
+    expect(ALL_SCOPES).toBe(TokenScope.Full | TokenScope.AppBlocksSubmit);
+    expect(ALL_SCOPES).toBe(67108863); // (1 << 26) - 1
+  });
+
+  it('a UserRead|AppBlocksSubmit token (the civitai-cli scope) is within ALL_SCOPES but exceeds Full', () => {
+    const cliScope = TokenScope.UserRead | TokenScope.AppBlocksSubmit;
+    expect(cliScope).toBe(33554433);
+    // Exceeds Full — this is why the OAuth bound checks use ALL_SCOPES, not Full.
+    expect(cliScope > TokenScope.Full).toBe(true);
+    expect(cliScope <= ALL_SCOPES).toBe(true);
+  });
+
+  it('hasFlag detects the AppBlocksSubmit bit precisely', () => {
+    const scoped = TokenScope.UserRead | TokenScope.AppBlocksSubmit;
+    expect(Flags.hasFlag(scoped, TokenScope.AppBlocksSubmit)).toBe(true);
+    // A Full token (no AppBlocksSubmit) must NOT report the bit.
+    expect(Flags.hasFlag(TokenScope.Full, TokenScope.AppBlocksSubmit)).toBe(false);
+    // A bare UserRead token must NOT report the bit.
+    expect(Flags.hasFlag(TokenScope.UserRead, TokenScope.AppBlocksSubmit)).toBe(false);
+  });
+
+  it('AppBlocksSubmit has a human-readable consent label', () => {
+    expect(tokenScopeLabels[TokenScope.AppBlocksSubmit]).toBe('Submit App Blocks for review');
+  });
+});

--- a/src/shared/constants/token-scope.constants.ts
+++ b/src/shared/constants/token-scope.constants.ts
@@ -58,11 +58,38 @@ export const TokenScope = {
   VaultRead: 1 << 23, // 8388608
   VaultWrite: 1 << 24, // 16777216
 
+  // App Blocks — submit an App Block bundle/version for moderator review.
+  // Opt-in, off-by-default (NOT part of `Full`): granted only to OAuth clients
+  // that explicitly list it in `allowedScopes` and request it (e.g. the
+  // first-party `civitai-cli` client). The submit endpoint
+  // (api/v1/blocks/submit-version) accepts an OAuth-issued token ONLY if it
+  // carries this bit AND the user is a moderator. See AppBlocksSubmit gate.
+  AppBlocksSubmit: 1 << 25, // 33554432
+
   // All scopes
+  //
+  // NOTE: `Full` is INTENTIONALLY frozen at (1 << 25) - 1 = 33554431 — it is the
+  // OR of bits 0..24 ONLY and deliberately EXCLUDES `AppBlocksSubmit` (bit 25).
+  // Existing personal API keys persist `tokenScope = 33554431` in the DB; changing
+  // this constant would silently re-interpret every stored key. `AppBlocksSubmit`
+  // is an opt-in capability, never folded into "Full Access". To bound a value
+  // against every DEFINED bit (incl. AppBlocksSubmit), use `ALL_SCOPES` below, not
+  // `Full`.
   Full: (1 << 25) - 1, // 33554431
 } as const;
 
 export type TokenScopeValue = (typeof TokenScope)[keyof typeof TokenScope];
+
+/**
+ * Mask of EVERY defined scope bit, including opt-in scopes that are NOT part of
+ * `Full` (currently `AppBlocksSubmit`). Use this as the upper bound when
+ * validating a requested/stored scope value in the OAuth flow — bounding against
+ * `Full` would reject any value carrying an opt-in bit. Computed from the enum so
+ * it can never drift behind a newly-added bit.
+ */
+export const ALL_SCOPES: number = Object.entries(TokenScope)
+  .filter(([key]) => key !== 'None' && key !== 'Full')
+  .reduce((acc, [, value]) => acc | value, 0);
 
 /** Human-readable labels for each scope, used in UI */
 export const tokenScopeLabels: Record<number, string> = {
@@ -91,6 +118,7 @@ export const tokenScopeLabels: Record<number, string> = {
   [TokenScope.NotificationsWrite]: 'Manage notification preferences',
   [TokenScope.VaultRead]: 'View vault',
   [TokenScope.VaultWrite]: 'Manage vault',
+  [TokenScope.AppBlocksSubmit]: 'Submit App Blocks for review',
 };
 
 /** Convenience presets for the API key creation UI */

--- a/src/tests/api/v1/blocks/submit-version.test.ts
+++ b/src/tests/api/v1/blocks/submit-version.test.ts
@@ -93,25 +93,48 @@ vi.mock('~/server/services/blocks/publish-request.service', () => ({
 // zod — safe to load.
 
 import handler from '~/pages/api/v1/blocks/submit-version';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 // Personal-access (user-type) key: `getSessionFromBearerToken` sets
 // subject = { type: 'apiKey' } when the ApiKey row has clientId == null.
+// tokenScope = Full is what real personal keys persist; the value is irrelevant
+// to the type gate for personal keys (they pass regardless of scope).
 const MOD_SESSION = {
   user: { id: 7, isModerator: true },
   apiKeyId: 42,
   subject: { type: 'apiKey', id: 42 },
+  tokenScope: TokenScope.Full,
 };
 const NONMOD_SESSION = {
   user: { id: 8, isModerator: false },
   apiKeyId: 43,
   subject: { type: 'apiKey', id: 43 },
+  tokenScope: TokenScope.Full,
 };
-// OAuth-client-issued key: subject = { type: 'oauth', id: clientId }. The user
-// is a moderator, so ONLY the personal-key gate should reject this.
-const OAUTH_MOD_SESSION = {
+// OAuth-client-issued key WITHOUT the AppBlocksSubmit scope: subject =
+// { type: 'oauth', id: clientId }. Even though the user is a moderator, the
+// missing scope must reject this at the token-type gate.
+const OAUTH_MOD_NO_SCOPE_SESSION = {
   user: { id: 7, isModerator: true },
   apiKeyId: 99,
   subject: { type: 'oauth', id: 'client_abc' },
+  tokenScope: TokenScope.UserRead | TokenScope.ModelsRead, // no AppBlocksSubmit
+};
+// OAuth-client-issued key WITH the AppBlocksSubmit scope + a moderator user:
+// this is the new accepted path (the civitai-cli case).
+const OAUTH_MOD_SCOPED_SESSION = {
+  user: { id: 7, isModerator: true },
+  apiKeyId: 99,
+  subject: { type: 'oauth', id: 'civitai-cli' },
+  tokenScope: TokenScope.UserRead | TokenScope.AppBlocksSubmit,
+};
+// OAuth-client-issued key WITH the scope but a NON-moderator user: the mod gate
+// must still reject (scope alone does not bypass the mod requirement).
+const OAUTH_NONMOD_SCOPED_SESSION = {
+  user: { id: 8, isModerator: false },
+  apiKeyId: 100,
+  subject: { type: 'oauth', id: 'civitai-cli' },
+  tokenScope: TokenScope.UserRead | TokenScope.AppBlocksSubmit,
 };
 const goodBody = { bundleBase64: Buffer.from('zipbytes').toString('base64') };
 
@@ -181,20 +204,46 @@ describe('POST /api/v1/blocks/submit-version (token auth)', () => {
     expect(mockSubmitVersion).not.toHaveBeenCalled();
   });
 
-  it('403 when the key is OAuth-client-issued (subject.type === "oauth") even if the user is a mod', async () => {
-    mockGetSession.mockResolvedValueOnce(OAUTH_MOD_SESSION);
+  it('403 when the key is OAuth-client-issued WITHOUT the AppBlocksSubmit scope, even if the user is a mod', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_MOD_NO_SCOPE_SESSION);
     const { req, res } = createMocks({
       headers: { authorization: 'Bearer oauth-client-key' },
       body: goodBody,
     });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(403);
-    expect((res._getJSONData() as { message: string }).message).toContain('personal API key');
+    expect((res._getJSONData() as { message: string }).message).toContain('App Blocks submit scope');
     // Must reject BEFORE the heavy publish path runs.
     expect(mockSubmitVersion).not.toHaveBeenCalled();
     // Must reject BEFORE the flag check / rate-limit round-trip (no leak).
     expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
     expect(mockRedis.multi).not.toHaveBeenCalled();
+  });
+
+  it('accepts an OAuth-client-issued key WITH the AppBlocksSubmit scope + mod (the civitai-cli path)', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_MOD_SCOPED_SESSION);
+    const { req, res } = createMocks({
+      headers: { authorization: 'Bearer oauth-cli-token' },
+      body: goodBody,
+    });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSubmitVersion).toHaveBeenCalledTimes(1);
+    // Attribution is the resolved user, not the client.
+    expect(mockSubmitVersion.mock.calls[0][0].submittedByUserId).toBe(7);
+  });
+
+  it('403 for an OAuth key WITH the AppBlocksSubmit scope but a NON-moderator user (mod gate still holds)', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_NONMOD_SCOPED_SESSION);
+    const { req, res } = createMocks({
+      headers: { authorization: 'Bearer oauth-cli-token' },
+      body: goodBody,
+    });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    // Rejected by the mod gate (not the scope gate) — scope alone is insufficient.
+    expect((res._getJSONData() as { message: string }).message).toContain('civitai team');
+    expect(mockSubmitVersion).not.toHaveBeenCalled();
   });
 
   it('passes the personal-key gate when subject.type is "apiKey" (user-type key) + mod', async () => {


### PR DESCRIPTION
## Summary

Lets the first-party `civitai` CLI obtain an OAuth token via the **existing** device-authorization grant and submit App Blocks for review — by adding a dedicated submit scope, relaxing the submit gate to accept OAuth tokens carrying that scope (personal-API-key path + moderator requirement kept exactly intact), and registering a first-party `civitai-cli` OAuth client.

This is the **server side**. Nothing user-visible changes for existing flows; the new scope is opt-in and excluded from `Full`.

## The 4 pieces

### 1. New scope `TokenScope.AppBlocksSubmit`
- Bit 25 = `1 << 25` = **33554432** (next free bit; 0–24 were used).
- `Full` is **unchanged** at `(1<<25)-1` = **33554431** and intentionally **excludes** the new bit, so existing personal keys (`tokenScope=33554431`) are byte-identical.
- Added consent label `"Submit App Blocks for review"` → renders on both the authorize and device consent screens (both build their scope list from `tokenScopeLabels`).
- Added `ALL_SCOPES` (OR of every defined bit incl. opt-in) so the OAuth bound checks can admit bit 25 without re-folding it into `Full`.

### 2. Submit gate (security-critical) — `src/pages/api/v1/blocks/submit-version.ts`
- **Personal key** (`subject.type !== 'oauth'`): UNCHANGED — passes the type gate exactly as before.
- **OAuth token** (`subject.type === 'oauth'`): passes **only if** `Flags.hasFlag(tokenScope, AppBlocksSubmit)`. Otherwise 403, rejected before the flag/rate-limit/publish path (no leak).
- The **moderator + not-banned** gate is unchanged and applies to **both** paths — a scoped token from a non-mod is still rejected.

### 3. OAuth scope plumbing
Changed the `> TokenScope.Full` upper-bound checks in `device.ts`, `device-token.ts`, `authorize.ts`, and `oauth/model.ts` to `> ALL_SCOPES` so a client may *request* the opt-in bit. The per-client `allowedScopes` intersection remains the real authorization gate.

**Deliberately NOT changed:** the tRPC `oauth-client.schema.ts` `allowedScopes` cap stays at `max(Full)`. Users self-registering OAuth clients must **not** be able to request `AppBlocksSubmit` (that's the consent-escalation surface the gate guards). The first-party client is provisioned by **manual SQL only**.

### 4. First-party `civitai-cli` client
Registered via an idempotent **manual-apply** migration (`prisma/migrations/20260619120000_register_civitai_cli_oauth_client/migration.sql`) — the civitai DB is manual-apply (cluster ops rule #8). `ON CONFLICT DO NOTHING` + a `WHERE EXISTS` FK guard on the owner.

| field | value |
|---|---|
| `id` | `civitai-cli` |
| `name` | `Civitai CLI` |
| `isConfidential` | `false` (public; PKCE / device flow) |
| `grants` | `authorization_code`, `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code` |
| `redirectUris` | `http://127.0.0.1/callback`, `http://localhost/callback` (loopback, port-flexible per RFC 8252) |
| `allowedScopes` | `UserRead \| AppBlocksSubmit` = **33554433** |
| `isVerified` | `true` |
| `userId` | `-1` (civitai system account — first-party owner convention) |

### Manual-apply SQL (prod nvme0 + dev clone)
```sql
INSERT INTO "OauthClient" (
  "id","secret","name","description","logoUrl","redirectUris","allowedOrigins",
  "grants","allowedScopes","isConfidential","userId","isVerified","createdAt","updatedAt"
)
SELECT
  'civitai-cli', NULL, 'Civitai CLI',
  'Official Civitai command-line tool. Used to submit App Blocks for review and manage your apps from the terminal.',
  NULL,
  ARRAY['http://127.0.0.1/callback', 'http://localhost/callback']::TEXT[],
  ARRAY[]::TEXT[],
  ARRAY['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:device_code']::TEXT[],
  33554433, false, -1, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
WHERE EXISTS (SELECT 1 FROM "User" WHERE "id" = -1)
ON CONFLICT ("id") DO NOTHING;
```
> If the system `User` row id `-1` is absent in an env, this inserts nothing — create the row manually with a valid owner userId, or change `-1` to a real civitai-team account id.

## Tests
- Submit gate matrix: personal-key pass (regression guard); scoped-OAuth + mod pass (NEW); un-scoped OAuth 403; scoped-OAuth + non-mod 403 (mod gate holds); banned 403.
- Scope constants: `AppBlocksSubmit` bit value, `Full` unchanged (33554431), `ALL_SCOPES`, `hasFlag`.
- Device plumbing: `AppBlocksSubmit` survives device-token → `createOAuthTokenPair`; client `allowedScopes` still gates.
- 24 new/updated + 55 existing OAuth tests green locally (NixOS node-only runner); changed files typecheck clean.

## CLI device-flow contract (for the client implementation)
- **Init:** `POST /api/auth/oauth/device` body `{ client_id: "civitai-cli", scope: "33554433" }` → `{ device_code, user_code, verification_uri, verification_uri_complete, expires_in, interval }`.
- **Poll:** `POST /api/auth/oauth/device-token` body `{ grant_type: "urn:ietf:params:oauth:grant-type:device_code", device_code, client_id: "civitai-cli" }` → `authorization_pending` until approved, then `{ access_token, token_type: "Bearer", expires_in: 3600, refresh_token, scope }`.
- **Submit:** `Authorization: Bearer <access_token>` to `POST /api/v1/blocks/submit-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)