### PR TITLE
fix: repair 3 deterministic main-branch failures surfaced by preview CI

### DIFF
--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -303,9 +303,15 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
       onPurchaseSuccess: () => void;
     };
     expect(dialogProps.minBuzzAmount).toBe(1000);
-    // (c) Page attribution is OMITTED — deriveScopeFromInstanceId('page_apb_test')
-    // returns null, so the host passes NO attribution scope to the spend modal.
-    expect(dialogProps.attribution).toBeUndefined();
+    // (c) Page attribution is TRACKED — deriveScopeFromInstanceId('page_apb_test')
+    // returns 'viewer_global' (PR #2624), so the host derives the attribution and
+    // passes it to the spend modal (the iframe never supplies it).
+    expect(dialogProps.attribution).toEqual({
+      appId: 'app_test',
+      appBlockId: 'apb_test',
+      blockInstanceId: 'page_apb_test',
+      scope: 'viewer_global',
+    });
 
     // Simulate a successful purchase, then close the modal (BuyBuzzModal's
     // onPurchaseSuccess flips `purchased`; the dialog onClose posts the reply).

--- a/src/server/controllers/report.controller.ts
+++ b/src/server/controllers/report.controller.ts
@@ -264,7 +264,6 @@ export async function getReportsHandler({ input }: { input: GetReportsInput }) {
               select: {
                 id: true,
                 model3dId: true,
-                rating: true,
                 nsfw: true,
                 tosViolation: true,
                 user: { select: simpleUserSelect },

--- a/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
+++ b/src/server/services/__tests__/prisma-inconsistent-orphan-relations.test.ts
@@ -95,7 +95,9 @@ vi.mock('~/server/db/client', () => ({
   dbWrite: {},
 }));
 
-describe('getRecentlyManuallyAdded — orphaned ImageResourceNew.modelVersion', () => {
+// timeout: the first `await import('../model.service')` cold-transforms a large
+// module graph (~10s) which exceeds the 10s default on the loaded CI node.
+describe('getRecentlyManuallyAdded — orphaned ImageResourceNew.modelVersion', { timeout: 30000 }, () => {
   beforeEach(() => {
     findManyMock.mockReset();
   });


### PR DESCRIPTION
Three tests fail on **every** PR preview right now — one each in unit, component, and smoke — all inherited from `main`. This repairs all three.

### 1. Component — `PageBlockHostWorkflow.browser.test.tsx` (test fix)
PR #2624 (`viewer_global` attribution scope) made `deriveScopeFromInstanceId('page_*')` return `'viewer_global'` instead of `null`, so the page host now derives and forwards an `attribution` object to `BuyBuzzModal`. The test still asserted `toBeUndefined()`. Updated to expect the derived object.

### 2. Server — `report.controller.ts` (code fix)
`getReportsHandler` selected `rating` on the `model3dReview` relation, but `Model3DReview.rating` was **dropped** in migration `20260605120000_model3d_drop_legacy_rating` (the feature moved to a `recommended` thumbs boolean). On any client generated from the current `schema.full.prisma`, `prisma.report.findMany()` throws `Unknown field \`rating\` for select statement on model \`Model3DReview\``, **500ing `report.getAll`** (the moderation report queue). No code reads `rating` (the moderator UI uses only `model3dId`), so the select line is dead — removed. _Why it doesn't break prod: the committed slim `prisma/schema.prisma` artifact predates the Model3D models, so prod's client never validates this relation; previews build the current client and do._

### 3. Unit — `prisma-inconsistent-orphan-relations.test.ts` (test fix)
Two cases timed out at the 10s default: the first `await import('../model.service')` cold-transforms a large module graph (~10.7s measured in CI) on the loaded build node. The assertions pass when not time-constrained — bumped the block `timeout` to 30s.

### Verification
All three are verified-by-construction against the live failures (CI logs + the resolver/migration history). They'll be confirmed green by this PR's own preview build (`unit-tests` / `component-tests` tasks + the `preview-moderation` smoke spec). Not run locally (NixOS/Prisma-client friction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)