### PR TITLE
fix(rewards): fail-soft the inline buzz-event reward write (CH brownout must not 500 user mutations)

### DIFF
--- a/src/server/rewards/__tests__/base.reward.failsoft.test.ts
+++ b/src/server/rewards/__tests__/base.reward.failsoft.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// WHY THIS TEST EXISTS
+//
+// Production incident 2026-06-18: a ClickHouse Cloud brownout ("Too many
+// simultaneous queries for all users") made the buzz-event REWARD write
+// (addBuzzEvent → clickhouse.insert) fail. Because the inline `apply` path runs
+// synchronously inside user mutations (user.toggleFollow, post.update,
+// collection.saveItem, buzz.claimDailyBoostReward, ...) and previously RETHREW on
+// failure, the CH brownout 500'd those user actions.
+//
+// A non-critical analytics/reward tracking write must NEVER take down a user
+// action. This suite pins the fail-soft contract on the INLINE `apply` path:
+//   (a) a thrown CH error from addBuzzEvent inside `apply` does NOT propagate
+//       (the surrounding user mutation would succeed)
+//   (b) the rewardFailedCounter increments on that failure
+//   (c) no double-award: when the audit insert fails, sendAward is NOT called
+//       (the actual Buzz grant is skipped, not duplicated)
+//   (d) a sendAward failure inside `apply` ALSO does not propagate (and no rethrow)
+//   (e) the batch `process` path STILL rethrows (background cron — unchanged)
+//
+// MONEY-CORRECTNESS (verified from code, documented in PR body): the ClickHouse
+// `buzzEvents` insert from addBuzzEvent is an AUDIT row and does not move money.
+// The grant is `sendAward` (createBuzzTransactionMany → POST /transactions), which
+// runs AFTER addBuzzEvent and is idempotent on externalTransactionId. Dedup is the
+// Redis Lua script in processOnDemand, which commits the dedup entry BEFORE
+// addBuzzEvent — so skipping the award on failure loses one credit but never
+// double-awards.
+// ---------------------------------------------------------------------------
+
+// --- Hoisted mock handles (constructed before the vi.mock factories run) -----
+const h = vi.hoisted(() => {
+  return {
+    insertImpl: vi.fn(async () => {}),
+    evalImpl: vi.fn(async () => 0 as number),
+    hGetImpl: vi.fn(async () => '{}'),
+    createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+    getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+    rewardFailedInc: vi.fn(),
+    rewardGivenInc: vi.fn(),
+    logToAxiom: vi.fn(async () => {}),
+  };
+});
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {
+    insert: (...args: any[]) => h.insertImpl(...args),
+    // `process` path uses ch.$query / ch.query for caps; not exercised here.
+    $query: vi.fn(async () => []),
+    query: vi.fn(async () => ({ json: async () => [] })),
+  },
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    eval: (...args: any[]) => h.evalImpl(...args),
+    hGet: (...args: any[]) => h.hGetImpl(...args),
+  },
+  REDIS_KEYS: { BUZZ_EVENTS: 'buzz-events' },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbWrite: {},
+  dbRead: {},
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: any[]) => h.logToAxiom(...args),
+}));
+
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: (...a: any[]) => h.rewardFailedInc(...a) },
+  rewardGivenCounter: { inc: (...a: any[]) => h.rewardGivenInc(...a) },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),
+  getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
+}));
+
+vi.mock('~/shared/constants/buzz.constants', () => ({
+  TransactionType: { Reward: 'Reward' },
+}));
+
+vi.mock('~/utils/string-helpers', () => ({
+  hashifyObject: (o: any) => `hash:${JSON.stringify(o)}`,
+}));
+
+// Import AFTER mocks are registered.
+import { createBuzzEvent } from '~/server/rewards/base.reward';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // default: insert succeeds, eval awards full amount, multiplier 1
+  h.insertImpl.mockResolvedValue(undefined as any);
+  h.evalImpl.mockResolvedValue(100 as any);
+  h.hGetImpl.mockResolvedValue('{}');
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+});
+
+function makeOnDemandReward() {
+  return createBuzzEvent<{ userId: number; entityId: number }>({
+    type: 'testReward',
+    description: 'Test reward',
+    awardAmount: 100,
+    cap: 1000,
+    onDemand: true,
+    getKey: async (input) => ({
+      toUserId: input.userId,
+      forId: input.entityId,
+      byUserId: input.userId,
+    }),
+  });
+}
+
+describe('base.reward inline apply() fail-soft (CH brownout)', () => {
+  it('(a) does NOT propagate a ClickHouse insert error out of apply()', async () => {
+    h.insertImpl.mockRejectedValue(new Error('Too many simultaneous queries for all users'));
+    const reward = makeOnDemandReward();
+
+    // Must resolve (not reject) — the surrounding user mutation would succeed.
+    await expect(reward.apply({ userId: 1, entityId: 42 })).resolves.toBeUndefined();
+  });
+
+  it('(b) increments rewardFailedCounter when the insert fails', async () => {
+    h.insertImpl.mockRejectedValue(new Error('CH down'));
+    const reward = makeOnDemandReward();
+
+    await reward.apply({ userId: 1, entityId: 42 });
+
+    expect(h.rewardFailedInc).toHaveBeenCalledTimes(1);
+  });
+
+  it('(c) does NOT send the award (no double-award) when the audit insert fails', async () => {
+    h.evalImpl.mockResolvedValue(100); // would be an "awarded" event
+    h.insertImpl.mockRejectedValue(new Error('CH down'));
+    const reward = makeOnDemandReward();
+
+    await reward.apply({ userId: 1, entityId: 42 });
+
+    // The grant (createBuzzTransactionMany) must not run when we couldn't record
+    // the audit row — skip, don't grant, don't 500.
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+    expect(h.rewardGivenInc).not.toHaveBeenCalled();
+  });
+
+  it('(c2) limits inline insert retries (does not block ~2.5s with 5 retries)', async () => {
+    h.insertImpl.mockRejectedValue(new Error('CH down'));
+    const reward = makeOnDemandReward();
+
+    await reward.apply({ userId: 1, entityId: 42 });
+
+    // INLINE_RETRY_COUNT = 1 → 2 total attempts. (Batch path uses 5 → 6 attempts.)
+    expect(h.insertImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('happy path: records the event and sends the award', async () => {
+    h.evalImpl.mockResolvedValue(100);
+    const reward = makeOnDemandReward();
+
+    await reward.apply({ userId: 1, entityId: 42 });
+
+    expect(h.insertImpl).toHaveBeenCalledTimes(1);
+    expect(h.createBuzzTransactionMany).toHaveBeenCalledTimes(1);
+    expect(h.rewardGivenInc).toHaveBeenCalledTimes(1);
+    expect(h.rewardFailedInc).not.toHaveBeenCalled();
+  });
+
+  it('(d) does NOT propagate a sendAward failure out of apply()', async () => {
+    h.evalImpl.mockResolvedValue(100); // awarded
+    h.insertImpl.mockResolvedValue(undefined as any); // audit row written
+    h.createBuzzTransactionMany.mockRejectedValue(new Error('buzz API 500'));
+    const reward = makeOnDemandReward();
+
+    await expect(reward.apply({ userId: 1, entityId: 42 })).resolves.toBeUndefined();
+    expect(h.rewardFailedInc).toHaveBeenCalledTimes(1);
+    expect(h.rewardGivenInc).not.toHaveBeenCalled();
+  });
+
+  it('capped event does not call sendAward (unchanged)', async () => {
+    h.evalImpl.mockResolvedValue(0); // 0 = capped
+    const reward = makeOnDemandReward();
+
+    await reward.apply({ userId: 1, entityId: 42 });
+
+    expect(h.insertImpl).toHaveBeenCalledTimes(1);
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('base.reward batch process() still rethrows (cron path unchanged)', () => {
+  function makeProcessableReward() {
+    return createBuzzEvent<{ userId: number; entityId: number }>({
+      type: 'testProcessable',
+      description: 'Test processable reward',
+      awardAmount: 100,
+      getKey: async (input) => ({
+        toUserId: input.userId,
+        forId: input.entityId,
+        byUserId: input.userId,
+      }),
+    });
+  }
+
+  it('(e) rethrows on update failure in the batch process path', async () => {
+    h.insertImpl.mockRejectedValue(new Error('CH down'));
+    const reward = makeProcessableReward();
+
+    const ctx = {
+      toProcess: [
+        {
+          type: 'testProcessable',
+          toUserId: 1,
+          forId: 42,
+          byUserId: 1,
+          awardAmount: 100,
+          status: 'pending' as const,
+        },
+      ],
+      lastUpdate: new Date(),
+      ch: {} as any,
+      db: {} as any,
+    };
+
+    await expect(reward.process(ctx)).rejects.toThrow(/Buzz Event Processing Failure/);
+  });
+});

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -12,6 +12,15 @@ import { createBuzzTransactionMany, getMultipliersForUser } from '~/server/servi
 import { hashifyObject } from '~/utils/string-helpers';
 import { withRetries } from '../utils/errorHandling';
 
+// Retry budget for the batch `process` (cron) path — can afford to block.
+const BATCH_RETRY_COUNT = 5;
+const BATCH_RETRY_DELAY = 500;
+// Retry budget for the inline `apply` path, which runs synchronously inside user
+// mutations. Keep it tight so a ClickHouse brownout can't block a user action for
+// ~2.5s of retries: 1 retry (= 2 attempts) with a short backoff.
+const INLINE_RETRY_COUNT = 1;
+const INLINE_RETRY_DELAY = 200;
+
 const log = (event: BuzzEventLog, data: MixedObject) => {
   logToAxiom({
     name: 'buzz-rewards',
@@ -231,12 +240,26 @@ export function createBuzzEvent<T>({
       if (event.status === 'capped') event.awardAmount = 0;
     }
 
+    // Fail-soft: the inline `apply` path runs synchronously inside user mutations
+    // (toggleFollow, post.update, collection.saveItem, claimDailyBoostReward, ...).
+    // The ClickHouse `buzzEvents` insert is an AUDIT/analytics row — it does NOT
+    // move money. The actual Buzz grant is `sendAward` below, and dedup is enforced
+    // by the Redis Lua script in `processOnDemand` (which already committed the dedup
+    // entry above). So a failed insert must NEVER 500 the user action: we log + count
+    // and skip the award for this event. The user simply doesn't receive one reward
+    // credit during a ClickHouse brownout — no 500, no double-award (the Redis dedup
+    // entry is already set, so a retry of the same event returns early and never
+    // re-awards). Use a SHORT retry budget so we don't block the mutation for ~2.5s
+    // during a brownout. The batch `process` path is unchanged (background cron).
     try {
-      await addBuzzEvent(event);
+      await addBuzzEvent(event, INLINE_RETRY_COUNT, INLINE_RETRY_DELAY);
     } catch (error) {
       log(event, { message: 'Failed to record Buzz event', error });
       rewardFailedCounter?.inc?.();
-      throw new Error(`Failed to record Buzz event: ${error}`);
+      // Fail-soft: do not rethrow. Skip sendAward for this event too — the audit row
+      // that records the grant could not be written, so we treat the reward as not
+      // granted this time rather than granting Buzz with no corresponding event row.
+      return;
     }
 
     if (event.status === 'awarded') {
@@ -249,9 +272,11 @@ export function createBuzzEvent<T>({
           error,
         });
         rewardFailedCounter?.inc?.();
-        throw new Error(
-          `Failed to send award for Buzz event: ${error}.\n\nTransaction: ${JSON.stringify(event)}`
-        );
+        // Fail-soft: do not rethrow. No double-spend risk — `sendAward` is idempotent
+        // on `externalTransactionId`, and the Redis dedup entry is already set so the
+        // same event will never reach `sendAward` again. The user loses one reward
+        // credit during the outage; the user's mutation still succeeds.
+        return;
       }
     }
   };
@@ -373,7 +398,11 @@ export function createBuzzEvent<T>({
 // TODO: sometimes this can cause duplicate entries.
 //  hypothesis is that this occurs due to a combination of
 //  async inserts + ch's merge strategy
-async function addBuzzEvent(event: BuzzEventLog) {
+async function addBuzzEvent(
+  event: BuzzEventLog,
+  retries: number = BATCH_RETRY_COUNT,
+  retryTimeout: number = BATCH_RETRY_DELAY
+) {
   await withRetries(
     async () =>
       await clickhouse?.insert({
@@ -381,8 +410,8 @@ async function addBuzzEvent(event: BuzzEventLog) {
         values: [event],
         format: 'JSONEachRow',
       }),
-    5,
-    500
+    retries,
+    retryTimeout
   );
 }
 


### PR DESCRIPTION
## Problem (verified production incident 2026-06-18)

A ClickHouse Cloud brownout (\`Too many simultaneous queries for all users\`; CH is a tiny 4vCPU/16GiB box) caused user-facing 500s. Root cause of the *user* 500s: the buzz-event REWARD write in \`base.reward.ts\` is fail-HARD and is \`await\`ed inline inside user mutations (\`user.toggleFollow\`, \`post.update\`, \`collection.saveItem\`, \`buzz.claimDailyBoostReward\`, ...). When the CH insert failed, it rethrew and 500'd those user actions.

A non-critical analytics/reward tracking write must never take down a user action — this matches the house fail-soft pattern (#2619, #2636).

## Changes (\`src/server/rewards/base.reward.ts\`)

The inline \`apply\` path:
- **\`addBuzzEvent\` failure** → keep \`log(...)\` + \`rewardFailedCounter.inc()\`, then **\`return\` (no rethrow)**. The award is skipped for that event.
- **\`sendAward\` failure** → \`log(...)\` + \`rewardFailedCounter.inc()\`, then **\`return\` (no rethrow)**.
- **Bounded inline retries**: \`addBuzzEvent(event, retries, retryTimeout)\` now takes a retry budget. The inline path uses **1 retry / 200ms (= 2 attempts, ≤~0.4s)** instead of the old 5×500ms (~2.5s of blocking retries). The batch \`process\` path keeps 5×500ms (defaults preserved on the function).

\`process\` / \`updateBuzzEvents\` (the background cron path) error semantics are **untouched** — they still rethrow.

## Money-correctness conclusion (with code evidence)

**The ClickHouse \`buzzEvents\` insert is an AUDIT/analytics row — it does NOT move money.** Verified by tracing the on-demand \`apply\` flow:

1. \`processOnDemand(key, multiplier)\` runs the \`ON_DEMAND_REWARD_SCRIPT\` Lua atomically. It **commits the dedup entry to Redis** (\`HSET\`) and returns \`toAward\`. If the event was already awarded it returns \`-1\` → \`apply\` returns early. **The dedup gate is committed BEFORE \`addBuzzEvent\` runs.**
2. \`await addBuzzEvent(event)\` — the CH insert (the failing call). Audit row only.
3. \`if (event.status === 'awarded') await sendAward([event])\` — **this is the actual Buzz grant** (\`createBuzzTransactionMany\` → \`POST /transactions\`), and it runs **after** \`addBuzzEvent\`.

\`createBuzzTransactionMany\` (buzz.service.ts:474) posts with a deterministic \`externalTransactionId\` (\`\${type}:\${forId}-\${toUserId}-\${byUserId}\` etc.), so the grant is **idempotent** on the Buzz API side.

Therefore:
- On \`addBuzzEvent\` failure, **\`sendAward\` has not run yet → no money moved**. We \`return\` and skip the award. The Redis dedup entry is already set, so a later retry of the same event returns early and never re-awards. ⇒ **no double-award, no 500**; the user loses at most one reward credit during the brownout (acceptable).
- On \`sendAward\` failure, returning is also safe — \`externalTransactionId\` idempotency + the already-set Redis dedup entry both prevent a double-spend on any retry.

A user not receiving one reward credit during a CH brownout is acceptable; a 500 or a double-spend is not. This change guarantees the latter two never happen on the inline path.

## Tests

\`src/server/rewards/__tests__/base.reward.failsoft.test.ts\` (8 cases, all passing):
- (a) a thrown CH error from \`addBuzzEvent\` inside \`apply\` does **not** propagate (the mutation would succeed)
- (b) \`rewardFailedCounter\` increments on the failure
- (c) **no double-award**: \`sendAward\`/\`createBuzzTransactionMany\` is **not** called when the audit insert fails
- (c2) inline retries are bounded to 2 attempts (vs 6 on the batch path)
- happy path: insert once + award once + given-counter
- (d) a \`sendAward\` failure inside \`apply\` does **not** propagate
- capped event does not call \`sendAward\` (unchanged)
- (e) the **batch \`process\` path still rethrows** (cron semantics unchanged)

\`\`\`
✓ unit  src/server/rewards/__tests__/base.reward.failsoft.test.ts (8 tests) 3310ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
\`\`\`

(The batch test taking ~2.5s confirms the batch path still uses 5×500ms while the inline path is bounded — the two budgets are genuinely distinct.)

## Typecheck

\`tsc --noEmit\` run locally (NixOS) against \`main\` baseline vs this branch: **identical error count (5383) and zero new errors introduced** by this change (verified by diffing the tsc output). The 5383 pre-existing errors are a local stale-node_modules artifact present on unmodified \`main\` — none touch \`base.reward.ts\`. CI typecheck is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)