### PR TITLE
fix(oauth device): move DeviceCodeEntry out of src/pages (unbreak Next build) + autofocus input

### DIFF
--- a/src/components/Login/DeviceCodeEntry.browser.test.tsx
+++ b/src/components/Login/DeviceCodeEntry.browser.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-import { DeviceCodeEntry } from '~/pages/login/oauth/DeviceCodeEntry';
+import { DeviceCodeEntry } from '~/components/Login/DeviceCodeEntry';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
-import { renderWithProviders } from '../../../../test/component-setup';
+import { renderWithProviders } from '../../../test/component-setup';
 
 // DeviceCodeEntry is the code-entry step of the OAuth device flow. It owns the
 // "when to submit" UX (Enter-to-submit + auto-submit on a complete code) and the
@@ -110,27 +110,27 @@ describe('DeviceCodeEntry', () => {
 
   test('a complete initialCode (verification_uri_complete) auto-submits once on mount, not per render', async () => {
     const onSubmit = vi.fn();
-    const { rerender } = renderWithProviders(
+    const { rerender } = await renderWithProviders(
       <DeviceCodeEntry initialCode={FULL_CODE} onSubmit={onSubmit} />
     );
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
 
     // A re-render with the same complete value must NOT re-fire (the ref guard).
-    rerender(<DeviceCodeEntry initialCode={FULL_CODE} onSubmit={onSubmit} username="alice" />);
+    await rerender(<DeviceCodeEntry initialCode={FULL_CODE} onSubmit={onSubmit} username="alice" />);
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   test('does not re-fire while a submit is in flight (loading)', async () => {
     const onSubmit = vi.fn();
-    const { rerender } = renderWithProviders(<DeviceCodeEntry onSubmit={onSubmit} />);
+    const { rerender } = await renderWithProviders(<DeviceCodeEntry onSubmit={onSubmit} />);
 
     await userEvent.fill(input(), FULL_CODE);
     expect(onSubmit).toHaveBeenCalledTimes(1);
 
     // Parent flips to loading after the first submit. The button shows a spinner
     // and is non-interactive; pressing Enter must not stack a second lookup.
-    rerender(<DeviceCodeEntry loading onSubmit={onSubmit} />);
+    await rerender(<DeviceCodeEntry loading onSubmit={onSubmit} />);
     await userEvent.click(input());
     await userEvent.keyboard('{Enter}');
     expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -166,5 +166,15 @@ describe('DeviceCodeEntry', () => {
     await userEvent.clear(input());
     await userEvent.fill(input(), FULL_CODE);
     expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  test('focuses the code input on mount so the user can paste/type immediately', async () => {
+    const onSubmit = vi.fn();
+    renderWithProviders(<DeviceCodeEntry onSubmit={onSubmit} />);
+
+    // The mount-time focus effect should put the caret in the field with no
+    // click, and it must not have triggered a submit on an empty value.
+    await expect.element(input()).toHaveFocus();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Login/DeviceCodeEntry.tsx
+++ b/src/components/Login/DeviceCodeEntry.tsx
@@ -40,6 +40,16 @@ export function DeviceCodeEntry({
 }: DeviceCodeEntryProps) {
   const [code, setCode] = useState(initialCode);
 
+  // Focus the input on mount so the user can paste/type the code immediately
+  // without clicking. A ref + one-shot effect (rather than the `autoFocus`
+  // prop) keeps focus deterministic and assertable, and runs once — it does not
+  // re-run on the auto-submit / loading re-renders, so it can't fight the
+  // auto-submit-on-completeness or Enter logic.
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
   // The exact value we last fired `onSubmit` for. We only auto-submit / accept
   // Enter once per distinct complete value; editing to a different value
   // (including correcting a bad code) clears this and re-arms submission. A
@@ -95,6 +105,7 @@ export function DeviceCodeEntry({
         Enter the code shown on your device to authorize it with your Civitai account.
       </Text>
       <TextInput
+        ref={inputRef}
         aria-label="Device code"
         value={code}
         onChange={(e) => handleChange(e.currentTarget.value)}

--- a/src/pages/login/oauth/device.tsx
+++ b/src/pages/login/oauth/device.tsx
@@ -14,7 +14,7 @@ import { IconCheck, IconDeviceMobile, IconShieldCheck, IconX } from '@tabler/ico
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { DeviceCodeEntry } from '~/pages/login/oauth/DeviceCodeEntry';
+import { DeviceCodeEntry } from '~/components/Login/DeviceCodeEntry';
 import { formatUserCode } from '~/server/oauth/user-code';
 
 interface DeviceAppInfo {


### PR DESCRIPTION
## Summary

PR #2647 added `DeviceCodeEntry.tsx` and `DeviceCodeEntry.browser.test.tsx` **under `src/pages/login/oauth/`**. Next.js treats everything under `src/pages/**` as a route and collects it during the build, so a component — and especially a test file — placed there breaks the build. This PR relocates them out of `src/pages/` and fixes the inherited typecheck error, plus autofocuses the code input.

**This unblocks `main`'s Next build (RED since #2647 merged) AND PR #2648's inherited preview failure.** #2648 goes green once this lands on `main` and #2648 is updated (merge `main` into it / rebase). #2648's own e2e test lives under `src/tests/` (which Next ignores) and was never the problem.

## The two failures (from #2648's failed preview pipeline)

1. **build-image (Next build) failed** — Next collected the `.browser.test.tsx` as a page:
   `Type 'typeof import(".../DeviceCodeEntry.browser.test")' does not satisfy the constraint 'PagesPageConfig'`.
2. **typecheck failed** — the browser test called `.rerender` on the render helper's result (a `Promise<RenderResult>`) without awaiting:
   `error TS2339: Property 'rerender' does not exist on type 'Promise<RenderResult>'` (lines 113/126).

## Changes

**A — Relocation (the build fix).** Moved the component + its co-located browser test out of `src/pages/` into `src/components/Login/`, matching the established "browser tests live beside the component under `src/components`" convention (e.g. `src/components/generation_v2/inputs/*.browser.test.tsx`, `src/components/AppBlocks/*.browser.test.tsx`). The repo has **no `pageExtensions`** filter, so relocation IS the fix — Next no longer collects the component/test as pages.

| Old path (`src/pages/`) | New path (`src/components/`) |
|---|---|
| `src/pages/login/oauth/DeviceCodeEntry.tsx` | `src/components/Login/DeviceCodeEntry.tsx` |
| `src/pages/login/oauth/DeviceCodeEntry.browser.test.tsx` | `src/components/Login/DeviceCodeEntry.browser.test.tsx` |

Repointed `device.tsx`'s import to `~/components/Login/DeviceCodeEntry` and fixed the test's relative import depth to `../../../test/component-setup`. `src/server/oauth/user-code.ts` left in place (server, fine). Only the real page route `device.tsx` (+ pre-existing `authorize.tsx`) remains under `src/pages/login/oauth/`.

**B — `.rerender` type fix.** `await` the render helper before `.rerender` (`const { rerender } = await renderWithProviders(...)` + `await rerender(...)`) so the awaited value is a `RenderResult`. No `any` / `@ts-ignore`.

**C — Autofocus.** The code input now focuses on mount (a `ref` + one-shot `useEffect(() => inputRef.current?.focus(), [])`) so the user can paste/type the device code immediately without clicking. The effect runs once and does not re-run on the auto-submit / loading re-renders, so it doesn't fight the existing auto-submit-on-completeness or Enter-to-submit logic. Added a test asserting the input is focused on mount.

## Verification

- **Typecheck**: ran the repo's `tsc --noEmit` against the changed files. The component (`DeviceCodeEntry.tsx`) and the page route (`device.tsx`) typecheck **clean (zero errors)**, and both originally-reported errors are gone (the `.rerender` TS2339 and the `PagesPageConfig` page-collection error). The browser test's remaining `page` / `userEvent` / `expect.element` type complaints under bare `tsc` are pre-existing repo-wide noise identical to every sibling `*.browser.test.tsx` (SeedInput, PageBlockHost, WorkflowInput, …) — they resolve under the vitest browser-mode config at test time, not bare `tsc`; nothing new was introduced.
- **Browser test run**: deferred — the Vitest browser-mode suite (Playwright) doesn't run in this offline environment; logic/types are clean and CI runs the suite.
- **Sanity**: `grep -r "DeviceCodeEntry" src/` shows the page importing from the NEW path with no dangling old-path imports; `src/pages/login/oauth/` contains only `device.tsx` + the pre-existing `authorize.tsx` (no component/test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)