### PR TITLE
fix(article rating review): resolve covers, show queue counts, block no-op disputes

### DIFF
--- a/src/components/Article/ArticleRatingReviewCard.tsx
+++ b/src/components/Article/ArticleRatingReviewCard.tsx
@@ -289,17 +289,55 @@ export function ArticleRatingReviewCard({
             </Group>
           </Stack>
         ) : (
-          <Stack gap={4}>
-            <Text size="xs" c="dimmed" fw={500}>
-              Moderator note
-            </Text>
-            <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-              {review.modComment?.trim() || (
-                <Text component="span" size="sm" c="dimmed" fs="italic">
-                  No note
+          <Stack gap="xs">
+            {/* Audit trail: who actioned this review and when. `resolver` is
+                null for auto-approved rows (a rescan agreed with the owner). */}
+            <Group gap={6} wrap="nowrap">
+              <Text size="xs" c="dimmed" fw={500}>
+                {review.resolver ? 'Resolved by' : 'Resolved'}
+              </Text>
+              {review.resolver ? (
+                <Group gap={4} wrap="nowrap">
+                  <Avatar src={review.resolver.image ?? undefined} size={18} radius="xl" />
+                  {review.resolver.username ? (
+                    <Text
+                      component={Link}
+                      href={`/user/${review.resolver.username}`}
+                      target="_blank"
+                      size="xs"
+                      c="dimmed"
+                    >
+                      {review.resolver.username}
+                    </Text>
+                  ) : (
+                    <Text size="xs" c="dimmed">
+                      User #{review.resolver.id}
+                    </Text>
+                  )}
+                </Group>
+              ) : (
+                <Text size="xs" c="dimmed" fs="italic">
+                  auto-approved
                 </Text>
               )}
-            </Text>
+              {review.resolvedAt ? (
+                <Text size="xs" c="dimmed">
+                  · {new Date(review.resolvedAt).toLocaleString()}
+                </Text>
+              ) : null}
+            </Group>
+            <Stack gap={4}>
+              <Text size="xs" c="dimmed" fw={500}>
+                Moderator note
+              </Text>
+              <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                {review.modComment?.trim() || (
+                  <Text component="span" size="sm" c="dimmed" fs="italic">
+                    No note
+                  </Text>
+                )}
+              </Text>
+            </Stack>
           </Stack>
         )}
       </Stack>

--- a/src/components/Article/ArticleRatingReviewCard.tsx
+++ b/src/components/Article/ArticleRatingReviewCard.tsx
@@ -100,6 +100,9 @@ export function ArticleRatingReviewCard({
           })),
         };
       });
+      // Refresh the queue badges. Single cheap groupBy — safe to invalidate
+      // even while the paginated list uses optimistic removal above.
+      utils.article.getRatingReviewCounts.invalidate();
     },
     onError: (error) => {
       showErrorNotification({ error: new Error(error.message), title: 'Failed to resolve review' });
@@ -128,6 +131,9 @@ export function ArticleRatingReviewCard({
 
   const articleHref = `/articles/${article.id}`;
   const userHref = user.username ? `/user/${user.username}` : undefined;
+  // Live cover is resolved from `coverId` server-side; `article.cover` is the
+  // legacy URL column kept only as a fallback for very old articles.
+  const coverSrc = article.coverImage?.url ?? article.cover;
 
   return (
     <div
@@ -138,9 +144,9 @@ export function ArticleRatingReviewCard({
       {/* Cover */}
       <div className="shrink-0">
         <Link href={articleHref} target="_blank">
-          {article.cover ? (
+          {coverSrc ? (
             <EdgeMedia2
-              src={article.cover}
+              src={coverSrc}
               type="image"
               width={240}
               style={{

--- a/src/components/Article/ArticleRatingReviewModal.tsx
+++ b/src/components/Article/ArticleRatingReviewModal.tsx
@@ -34,10 +34,16 @@ export default function ArticleRatingReviewModal({
         // by falling back to the highest set bit; direct map access on
         // `browsingLevelLabels` returns undefined for those and produces an
         // empty Select label.
-        label: getBrowsingLevelLabel(level),
+        label:
+          level === currentLevel
+            ? `${getBrowsingLevelLabel(level)} (current)`
+            : getBrowsingLevelLabel(level),
         value: String(level),
+        // A review that suggests the rating the article already has is a no-op,
+        // so the current level is unpickable. Server enforces the same rule.
+        disabled: level === currentLevel,
       })),
-    []
+    [currentLevel]
   );
 
   // Default to one severity step below the current rating (the most-likely-correct
@@ -45,14 +51,21 @@ export default function ArticleRatingReviewModal({
   // When the caller knows the article was rescanned to a lower derived level
   // (stale-override banner path), honor that as the default instead.
   const defaultLevel = useMemo(() => {
-    if (initialSuggestedLevel && browsingLevels.includes(initialSuggestedLevel as never)) {
+    if (
+      initialSuggestedLevel &&
+      browsingLevels.includes(initialSuggestedLevel as never) &&
+      initialSuggestedLevel !== currentLevel
+    ) {
       return String(initialSuggestedLevel);
     }
     const currentIndex = browsingLevels.findIndex((l) => l === currentLevel);
     if (currentIndex > 0) return String(browsingLevels[currentIndex - 1]);
-    // currentLevel may be a composite (multi-bit) or unknown — fall back to
-    // PG (lowest selectable) so the owner picks an explicit target.
-    return String(browsingLevels[0]);
+    // Current is the lowest selectable level (or a composite/unknown value) —
+    // there's nothing lower to suggest, so default to the first level that
+    // isn't the current one. Never default to the current level: it's disabled
+    // in the Select and rejected server-side.
+    const firstDifferent = browsingLevels.find((l) => l !== currentLevel);
+    return String(firstDifferent ?? browsingLevels[0]);
   }, [currentLevel, initialSuggestedLevel]);
 
   const [suggestedLevel, setSuggestedLevel] = useState<string | null>(defaultLevel);
@@ -79,8 +92,10 @@ export default function ArticleRatingReviewModal({
     },
   });
 
+  const sameAsCurrent = suggestedLevel != null && Number(suggestedLevel) === currentLevel;
+
   const handleSubmit = () => {
-    if (!suggestedLevel) return;
+    if (!suggestedLevel || sameAsCurrent) return;
     mutation.mutate({
       articleId,
       suggestedLevel: Number(suggestedLevel),
@@ -138,7 +153,11 @@ export default function ArticleRatingReviewModal({
           <Button variant="default" onClick={dialog.onClose} disabled={mutation.isPending}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} loading={mutation.isPending} disabled={!suggestedLevel}>
+          <Button
+            onClick={handleSubmit}
+            loading={mutation.isPending}
+            disabled={!suggestedLevel || sameAsCurrent}
+          >
             Submit review
           </Button>
         </Group>

--- a/src/pages/moderator/article-rating-review.tsx
+++ b/src/pages/moderator/article-rating-review.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Group, Loader, Select, Stack, Title } from '@mantine/core';
+import { Badge, Button, Center, Group, Loader, Select, Stack, Title } from '@mantine/core';
 import { useEffect, useMemo, useState } from 'react';
 
 import { ArticleRatingReviewCard } from '~/components/Article/ArticleRatingReviewCard';
@@ -38,12 +38,30 @@ export default function ArticleRatingReview() {
       getNextPageParam: (last) => last?.nextCursor,
     });
 
+  // Queue depth across all buckets so mods can see how much work is waiting.
+  const { data: counts } = trpc.article.getRatingReviewCounts.useQuery();
+
   const flatData = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);
 
   return (
     <div className="flex flex-col gap-4 p-4">
       <div className="flex items-center justify-between gap-4">
-        <Title>Article Rating Review</Title>
+        <Stack gap={6}>
+          <Title>Article Rating Review</Title>
+          {counts ? (
+            <Group gap={6}>
+              <Badge color="yellow" variant="light" size="lg">
+                {counts.Pending} pending
+              </Badge>
+              <Badge color="teal" variant="light">
+                {counts.Actioned} approved
+              </Badge>
+              <Badge color="red" variant="light">
+                {counts.Unactioned} rejected
+              </Badge>
+            </Group>
+          ) : null}
+        </Stack>
         <Group gap={8}>
           <Select
             placeholder="Status"

--- a/src/server/routers/article.router.ts
+++ b/src/server/routers/article.router.ts
@@ -32,6 +32,7 @@ import {
   createArticleRatingReview,
   getArticleRatingReviewForOwner,
   getArticleRatingReviews,
+  getArticleRatingReviewCounts,
   resolveArticleRatingReview,
 } from '~/server/services/article.service';
 import {
@@ -173,6 +174,9 @@ export const articleRouter = router({
     .use(isFlagProtected('articleRatingDispute'))
     .input(getArticleRatingReviewsSchema)
     .query(({ input }) => getArticleRatingReviews(input)),
+  getRatingReviewCounts: moderatorProcedure
+    .use(isFlagProtected('articleRatingDispute'))
+    .query(() => getArticleRatingReviewCounts()),
   resolveRatingReview: moderatorProcedure
     .use(isFlagProtected('articleRatingDispute'))
     .input(resolveArticleRatingReviewSchema)

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -2702,16 +2702,20 @@ export async function getArticleRatingReviews({
   // Resolve cover images from `coverId` (mirrors the main article feed). The
   // legacy `Article.cover` string is null for every current article, so the
   // review cards rendered blank covers until this lookup was added.
-  const coverIds = rows.map((x) => x.article.coverId).filter(isDefined);
+  // Dedupe ids (resolved tabs can hold multiple reviews for the same article)
+  // and index the result by id so the per-row attach below stays linear.
+  const coverIds = [...new Set(rows.map((x) => x.article.coverId).filter(isDefined))];
   const coverImages = coverIds.length
     ? await dbRead.image.findMany({
         where: { id: { in: coverIds } },
         select: { id: true, url: true, type: true, nsfwLevel: true },
       })
     : [];
+  const coverImageById = new Map(coverImages.map((img) => [img.id, img]));
 
   const items = rows.map((row) => {
-    const coverImage = coverImages.find((x) => x.id === row.article.coverId) ?? null;
+    const coverImage =
+      row.article.coverId != null ? coverImageById.get(row.article.coverId) ?? null : null;
     return { ...row, article: { ...row.article, coverImage } };
   });
 
@@ -2724,8 +2728,10 @@ export async function getArticleRatingReviewCounts() {
     _count: { _all: true },
   });
 
-  // Seed every status the moderator dashboard filters on so the UI can render
-  // a stable set of badges even when a bucket is empty.
+  // Initialize every ReportStatus so the result is a complete
+  // Record<ReportStatus, number> (empty buckets read as 0). The dashboard only
+  // surfaces Pending/Actioned/Unactioned; Processing is here to satisfy the
+  // type, not because it's a filterable bucket.
   const counts: Record<ReportStatus, number> = {
     [ReportStatus.Pending]: 0,
     [ReportStatus.Processing]: 0,

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -2659,6 +2659,16 @@ export async function getArticleRatingReviews({
       appliedLevel: true,
       userComment: true,
       modComment: true,
+      resolvedBy: true,
+      // The moderator who actioned the review (null for auto-approved /
+      // system-resolved rows) — surfaced on the card for audit.
+      resolver: {
+        select: {
+          id: true,
+          username: true,
+          image: true,
+        },
+      },
       user: {
         select: {
           id: true,

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -2398,6 +2398,17 @@ export async function createArticleRatingReview({
     });
   }
 
+  // --- No-op guard ---
+  // A review that suggests the rating the article already carries can never
+  // change anything, so reject it up front (before the rate-limit gate burns
+  // a slot). The modal also disables the current level, but a stale client or
+  // the mod API could still send it.
+  if (suggestedLevel === article.nsfwLevel) {
+    throw throwBadRequestError(
+      'The suggested rating matches the article’s current rating. Choose a different level.'
+    );
+  }
+
   // --- One Pending per article ---
   if (existingPending) {
     throw throwBadRequestError('A review is already pending for this article');
@@ -2659,7 +2670,10 @@ export async function getArticleRatingReviews({
         select: {
           id: true,
           title: true,
+          // Legacy URL column — null for all current articles. Kept only as a
+          // fallback; the live cover is resolved from `coverId` below.
           cover: true,
+          coverId: true,
           nsfwLevel: true,
           userNsfwLevel: true,
           moderatorNsfwLevel: true,
@@ -2675,7 +2689,44 @@ export async function getArticleRatingReviews({
     nextCursor = last?.id;
   }
 
-  return { items: rows, nextCursor };
+  // Resolve cover images from `coverId` (mirrors the main article feed). The
+  // legacy `Article.cover` string is null for every current article, so the
+  // review cards rendered blank covers until this lookup was added.
+  const coverIds = rows.map((x) => x.article.coverId).filter(isDefined);
+  const coverImages = coverIds.length
+    ? await dbRead.image.findMany({
+        where: { id: { in: coverIds } },
+        select: { id: true, url: true, type: true, nsfwLevel: true },
+      })
+    : [];
+
+  const items = rows.map((row) => {
+    const coverImage = coverImages.find((x) => x.id === row.article.coverId) ?? null;
+    return { ...row, article: { ...row.article, coverImage } };
+  });
+
+  return { items, nextCursor };
+}
+
+export async function getArticleRatingReviewCounts() {
+  const grouped = await dbRead.articleRatingReview.groupBy({
+    by: ['status'],
+    _count: { _all: true },
+  });
+
+  // Seed every status the moderator dashboard filters on so the UI can render
+  // a stable set of badges even when a bucket is empty.
+  const counts: Record<ReportStatus, number> = {
+    [ReportStatus.Pending]: 0,
+    [ReportStatus.Processing]: 0,
+    [ReportStatus.Actioned]: 0,
+    [ReportStatus.Unactioned]: 0,
+  };
+  for (const row of grouped) {
+    counts[row.status] = row._count._all;
+  }
+
+  return counts;
 }
 
 /**


### PR DESCRIPTION
## What & why

Three related fixes around the article rating-review feature.

### Moderator dashboard (`/moderator/article-rating-review`)
- **Covers now render.** The card read the legacy `Article.cover` string column, which is `NULL` for every current article (verified against prod replica: all 28 pending reviews had `cover IS NULL` + `coverId IS NOT NULL`). `getArticleRatingReviews` now resolves the cover via `coverId → Image.url`, mirroring the main article feed. Legacy `cover` kept as a fallback.
- **Queue depth is visible.** New `article.getRatingReviewCounts` (single `groupBy(status)`) drives Pending / Approved / Rejected badges in the page header, so mods can see how much work is waiting. Counts invalidate after each resolve.

### Owner dispute modal
- **No more no-op disputes.** The current rating is disabled in the Suggested-rating dropdown (labeled `(current)`), so an owner can't request a review that suggests the level the article already has.
- **Default fix.** The modal default could land on the current rating for PG articles (lowest level clamps to `browsingLevels[0]`). It now never defaults to the current level.

### Server (defense-in-depth)
- `createArticleRatingReview` rejects `suggestedLevel === article.nsfwLevel` with a 400, before the rate-limit gate. Guards against stale clients / the mod API.

## Scope notes
- Same-level block is **exact-match**. Composite (multi-bit) `nsfwLevel` articles aren't blocked — there's no single "current" level to match. Covers the reported case (PG-13 = PG-13) without false blocks.
- No migration. New tRPC query is feature-flag gated (`articleRatingDispute`) like its siblings.

## Testing
- Cover rendering + count badges confirmed manually on the mod dashboard.
- Type-safe by construction; `event-engine-common` submodule pointer left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)