### PR TITLE
feat(generation): wire Boogu generation support (graph + handler)

### DIFF
--- a/docs/plans/boogu-generation-support.md
+++ b/docs/plans/boogu-generation-support.md
@@ -1,0 +1,174 @@
+# Boogu — Generation Support Plan
+
+Status: **PREPPED, not executed.** Ecosystem record already merged (PR #2656: `ECO.Boogu=74`, `BM.Boogu=93`, family 23, Apache-2.0 license id 13). This doc outlines everything needed to wire Boogu into the generator so we can execute fast once the blockers clear.
+
+## What Boogu is
+
+`Boogu-Image-0.1` — unified multimodal image gen + edit. Built on Qwen3-VL-8B-Instruct (understanding) + FLUX.1-dev (generation), ~10B params, Apache-2.0. Three published checkpoints:
+
+| Variant | Task | Steps | CFG | Notes |
+|---|---|---|---|---|
+| **Base** | text-to-image | 25-50 (def ~35) | 2.0-5.0 (def 4) | text rendering + controllability |
+| **Turbo** | text-to-image | 4 | 0.0 | Decoupled-DMD distilled, fast |
+| **Edit** | text-guided image-to-image | 25-50 | 2.0-5.0 (def 5) | object/attribute/style edits |
+
+Default resolution 1024x1024 (2K capable). Bilingual (CN/EN) text rendering.
+
+---
+
+## BLOCKERS (must clear before generation works end-to-end)
+
+1. **No `@civitai/client` types for Boogu.** Checked installed (`0.2.0-beta.71`), `latest` tag (`0.1.1-beta.0`), newest `beta` (`0.2.0-beta.72`) — zero `boogu`. ZImage types exist there; Boogu does not. **The orchestrator team must add a Boogu engine and publish typed inputs** (`BooguBaseCreateImageGenInput` / `BooguTurboCreateImageGenInput` / `BooguEditImageGenInput`, names TBD) before the handler can be strictly typed and before whatIf/generation actually succeeds. Until then we can scaffold the graph + UI and a handler with generic `ImageGenStepTemplate` + `as` casts, but it won't run.
+2. **Civitai model version IDs — RESOLVED.** The 3 CivitaiOfficial draft checkpoints + their v0.1 version IDs (graph discriminator + `ecosystemSettings.defaults.model.id`):
+
+   | Variant | Model ID | Version ID |
+   |---|---|---|
+   | Base  | 2714299 | **3049541** |
+   | Edit  | 2714541 | **3049824** |
+   | Turbo | 2714686 | **3050010** |
+
+   ```ts
+   const booguVersionIds = { base: 3049541, edit: 3049824, turbo: 3050010 } as const;
+   ```
+
+   Base-model flip (Other -> Boogu) script: `C:\Users\Zipp4\AppData\Local\Temp\boogu-flip.mjs` (dry-run default; `--execute` to write). Validated via dry-run; run after the v5.0.1868 deploy is live in prod.
+3. **Engine string + edit operation contract — orchestrator's call.** ZImage uses `engine: 'sdcpp', ecosystem: 'zImage'`. Boogu's engine (comfy? sdcpp? a new one?) and whether edit is `operation: 'editImage'` vs image-presence-inferred is whatever the orchestrator implements. Confirm with orchestrator team.
+
+## Gating mechanism (answer to "Flipt or ecosystem mgmt?")
+
+**Not Flipt.** Recent ecosystems (ZImage, Ideogram, Ernie, Krea2) have **no** Flipt flags. Visibility is gated by flags on the `BaseModelRecord` in `basemodel.constants.ts`:
+- `hidden: true` — not user-facing yet (Imagen4, NanoBanana, OpenAI, SCascade all use this)
+- `disabled: true` — root-level disable of all support
+- `experimental: true` — shown but flagged experimental (Qwen)
+
+Plan: ship the graph/handler with `BM.Boogu` marked `hidden: true`, flip to visible when orchestrator + versions are ready. No Flipt work needed.
+
+---
+
+## Architecture decision: ONE ecosystem, model.id discriminator
+
+You wanted a single "Boogu" ecosystem. That fits the modern pattern and we don't need ZImage's two-ecosystem split.
+
+- **ZImage** modeled Turbo/Base as **two ecosystems** (`ZImageTurbo`, `ZImageBase`) sharing one graph, discriminated on `ctx.ecosystem`.
+- **NanoBanana / Qwen2 / Flux2** model **multiple modes in ONE ecosystem**, discriminated on `model.id`, and handle txt2img-vs-edit in the same ecosystem by appearing in both `TXT2IMG_IDS` and `EDIT_IMG_IDS` with a handler that branches on image presence.
+
+**Recommendation: mirror NanoBanana.** One `Boogu` ecosystem, computed discriminator on selected `model.id` → 3 subgraphs (Base / Turbo / Edit), each declaring its own `cfgScale`/`steps` `sliderNode` defaults+ranges. Edit subgraph enables the `images` node; Base/Turbo don't. Register `ECO.Boogu` in both `TXT2IMG_IDS` (Base/Turbo) and `EDIT_IMG_IDS` (Edit). Handler sets `operation: 'editImage'` when `hasImages`, else `'createImage'`.
+
+This keeps it to the single ecosystem you asked for while supporting all 3 variants.
+
+---
+
+## File-by-file changes
+
+### 1. `src/shared/data-graph/generation/boogu-graph.ts` (NEW)
+
+Mirror `nano-banana-graph.ts` (3-mode, model.id discriminator) + `z-image-graph.ts` (turbo slider ranges). Structure:
+
+```ts
+const booguVersionIds = {
+  base:  <BASE_VERSION_ID>,   // BLOCKER #2
+  turbo: <TURBO_VERSION_ID>,
+  edit:  <EDIT_VERSION_ID>,
+} as const;
+
+// Turbo subgraph: cfgScale {min:1,max:2,step:0.1,default:1} (orchestrator clamps CFG 0)
+//                 steps {min:1,max:12,default:4}; NO sampler/scheduler; NO images node
+// Base subgraph:  cfgScale {min:1,max:8,step:0.5,default:4}
+//                 steps {min:1,max:50,default:35}; NO images node
+// Edit subgraph:  cfgScale {min:1,max:8,step:0.5,default:5}
+//                 steps {min:1,max:50,default:35}
+//                 images node: when !ctx.workflow.startsWith('txt'), imagesNode({ max: 1 })  // confirm max
+//
+// .computed('booguMode', ctx => mode-from-model.id, ['model'])
+// .groupedDiscriminator('booguMode', [{turbo},{base},{edit}])
+```
+
+- Declare slider defaults **on each subgraph** — do NOT use `.effect()` to reset across variants (clobbers stored values + fires server-side; see skill gotcha).
+- Aspect ratios: use `sdxlAspectRatioBuckets` (FLUX-based), default `1:1`, 1024-centric. Add `priorityOptions: ['16:9','4:3','1:1','3:4','9:16']` if >5 ratios.
+- Resources/LoRA: Boogu is FLUX.1-dev-based → **could** support community LoRAs. Default to `createResourcesGraph` merge (like ZImage) but confirm orchestrator accepts them; if not, drop.
+- Export `booguVersionIds` for the handler.
+
+### 2. `src/server/services/orchestrator/ecosystems/boogu.handler.ts` (NEW)
+
+Mirror `nano-banana.handler.ts` / `flux2.handler.ts`:
+
+```ts
+const hasImages = !!data.images?.length;
+const operation = hasImages ? 'editImage' : 'createImage';
+return [{
+  $type: 'imageGen',
+  input: removeEmpty({
+    engine: '<ENGINE>',            // BLOCKER #3
+    // ecosystem: 'boogu',         // only if comfy/sdcpp engine
+    model: <map model.id -> 'base'|'turbo'|'edit'>,
+    operation,                     // if orchestrator requires it
+    prompt: data.prompt,
+    images: hasImages ? data.images?.map(x => x.url) : undefined,
+    aspectRatio: data.aspectRatio?.value,
+    cfgScale: 'cfgScale' in data ? data.cfgScale : undefined,
+    steps: 'steps' in data ? data.steps : undefined,
+    seed: data.seed,
+  }) as <BooguInputType>,           // BLOCKER #1 — generic ImageGenStepTemplate cast until client ships
+}];
+```
+
+### 3. `src/shared/constants/basemodel.constants.ts`
+
+- **`ecosystemSupport`**: add `{ ecosystemId: ECO.Boogu, supportType: 'generation', modelTypes: checkpointAndLora }` (+ training `loraOnly` + auction if we allow LoRA training; else `checkpointOnly`).
+- **`ecosystemSettings`**: `{ ecosystemId: ECO.Boogu, defaults: { model: { id: <BASE_VERSION_ID> } } }`.
+- **`BM.Boogu` record**: add `hidden: true` until launch-ready (BLOCKER gate).
+
+### 4. `src/shared/data-graph/generation/config/workflows.ts`
+
+- Add `ECO.Boogu` to **`TXT2IMG_IDS`** (Base/Turbo).
+- Add `ECO.Boogu` to **`EDIT_IMG_IDS`** (Edit).
+- Add `img2img:edit` + `txt2img` entries to `NEW_FORM_ONLY` (every new ecosystem is new-form-only):
+  ```ts
+  ['txt2img',      (ecoId) => /* ... */ ecoId === ECO.Boogu],
+  ['img2img:edit', (ecoId) => /* ... */ ecoId === ECO.Boogu],
+  ```
+
+### 5. `src/shared/data-graph/generation/ecosystem-graph.ts`
+
+- `import { booguGraph } from './boogu-graph';`
+- Add to `groupedDiscriminator` (image group): `{ values: ['Boogu'] as const, graph: booguGraph },`
+
+### 6. `src/server/services/orchestrator/ecosystems/index.ts`
+
+- `import { createBooguInput } from './boogu.handler';`
+- `export type BooguCtx = EcosystemGraphOutput & { ecosystem: 'Boogu' };`
+- `export { createBooguInput } from './boogu.handler';`
+- switch case: `case 'Boogu': return createBooguInput(normalizedData, handlerCtx);`
+
+### 7. `src/components/generation_v2/GenerationFormProvider.tsx`
+
+- Add `'Boogu'` to `TURBO_VARIANT_ECOSYSTEMS` so `cfgScale`/`steps` scope per `model.id` — Turbo (cfg 0, 4 steps) and Base (cfg 4, ~35 steps) have very different ranges within the one ecosystem and would otherwise trample each other's stored values.
+
+### 8. Typecheck
+
+`pnpm run typecheck` — iterate to clean. Expect type-cast friction from BLOCKER #1 (no client types); use generic `ImageGenStepTemplate` + `as` until the client ships.
+
+---
+
+## UI behavior (free, no extra work)
+
+The image-upload control renders automatically: the Edit subgraph's `images` node (`when: !ctx.workflow.startsWith('txt')`) makes `GenerationForm.tsx`'s `Controller name="images"` render `ImageUploadMultipleInput`. Mask drawing enables when `workflow === 'img2img:edit'`. Driven purely by graph structure + workflow-array membership — no ecosystem flag needed.
+
+---
+
+## Execution order (once blockers clear)
+
+1. Orchestrator ships Boogu engine + publishes `@civitai/client` with Boogu types. → `pnpm add @civitai/client@<ver>`
+2. Get the 3 Civitai model version IDs from Justin.
+3. Confirm engine string + edit contract + LoRA support with orchestrator.
+4. Make edits 1-7 in one pass; typecheck.
+5. Verify in local form (dev-server): select Boogu, switch Base/Turbo/Edit, confirm controls + whatIf.
+6. Flip `BM.Boogu` off `hidden` to launch.
+
+## Open questions for orchestrator team
+
+- Engine string for Boogu? (`comfy` / `sdcpp` / new?)
+- Edit: `operation: 'editImage'` field, or inferred from image presence?
+- Community LoRAs on the FLUX.1-dev base — supported?
+- Edit input: single source image or multiple? (assumed `max: 1`)
+- Turbo CFG truly 0 — does the slider send 0 or does orchestrator hardcode it?

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@axiomhq/axiom-node": "^0.12.0",
     "@civitai/app-sdk": "^0.6.0",
     "@civitai/blocks-react": "^0.4.0",
-    "@civitai/client": "0.2.0-beta.72",
+    "@civitai/client": "0.2.0-beta.73",
     "@civitai/cybertipline-tools": "^0.1.0",
     "@civitai/next-axiom": "^0.17.0",
     "@clavata/sdk": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.2(@civitai/app-sdk@0.6.0)(react@18.3.1)
       '@civitai/client':
-        specifier: 0.2.0-beta.72
-        version: 0.2.0-beta.72
+        specifier: 0.2.0-beta.73
+        version: 0.2.0-beta.73
       '@civitai/cybertipline-tools':
         specifier: ^0.1.0
         version: 0.1.0
@@ -1219,8 +1219,8 @@ packages:
       '@civitai/app-sdk': ^0.6.0
       react: ^18.0.0 || ^19.0.0
 
-  '@civitai/client@0.2.0-beta.72':
-    resolution: {integrity: sha512-zyU8t4kdCSip9iQYyj+P0dQ89Rj9nfAGoMC0TE1SUiKbwS/fPONxgekeLRezsUMRJz3OJaQjyveD+ZQD8kscJQ==}
+  '@civitai/client@0.2.0-beta.73':
+    resolution: {integrity: sha512-cpnAvXXwnfy++LVNYFrxkzzHZ8wG20e8TtEbdyN+jw/54KO2YTi3r63Rhr+IlbyIM22KIjFIfun8JtDd/R0Beg==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
   '@civitai/cybertipline-tools@0.1.0':
@@ -11497,7 +11497,7 @@ snapshots:
       '@civitai/app-sdk': 0.6.0
       react: 18.3.1
 
-  '@civitai/client@0.2.0-beta.72':
+  '@civitai/client@0.2.0-beta.73':
     dependencies:
       '@hey-api/client-fetch': 0.1.14
       rfc6902: 5.2.0

--- a/src/components/generation_v2/GenerationFormProvider.tsx
+++ b/src/components/generation_v2/GenerationFormProvider.tsx
@@ -160,7 +160,13 @@ export function getLastUsedCheckpointIdForEcosystem(ecosystemKey: string): numbe
  *
  * Add new ecosystems here when introducing a turbo/distilled variant.
  */
-const TURBO_VARIANT_ECOSYSTEMS = new Set<string>(['Lens', 'Ernie', 'ZImageTurbo', 'ZImageBase']);
+const TURBO_VARIANT_ECOSYSTEMS = new Set<string>([
+  'Lens',
+  'Ernie',
+  'ZImageTurbo',
+  'ZImageBase',
+  'Boogu',
+]);
 
 const storageAdapter = createLocalStorageAdapter({
   prefix: STORAGE_KEY,

--- a/src/server/services/orchestrator/ecosystems/boogu.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/boogu.handler.ts
@@ -1,0 +1,102 @@
+/**
+ * Boogu Family Handler
+ *
+ * Handles the Boogu ecosystem (comfy engine, ecosystem 'boogu') using the
+ * imageGen step type. One ecosystem, three checkpoints routed by model.id:
+ *  - base  -> ComfyBooguBaseCreateImageGenInput  (operation: createImage)
+ *  - turbo -> ComfyBooguTurboCreateImageGenInput (operation: createImage)
+ *  - edit  -> ComfyBooguEditImageInput           (operation: editImage, + images)
+ *
+ * Supports community LoRAs (mapped AIR -> strength).
+ */
+
+import type {
+  ComfyBooguBaseCreateImageGenInput,
+  ComfyBooguTurboCreateImageGenInput,
+  ComfyBooguEditImageInput,
+  ImageGenStepTemplate,
+} from '@civitai/client';
+import { removeEmpty } from '~/utils/object-helpers';
+import type { GenerationGraphTypes } from '~/shared/data-graph/generation/generation-graph';
+import type { ResourceData } from '~/shared/data-graph/generation/common';
+import { defineHandler } from './handler-factory';
+
+// Types derived from generation graph
+type EcosystemGraphOutput = Extract<GenerationGraphTypes['Ctx'], { ecosystem: string }>;
+type BooguCtx = EcosystemGraphOutput & { ecosystem: 'Boogu' };
+
+/** Map model version ID -> orchestrator model string */
+const versionIdToModel = new Map<number, 'base' | 'turbo' | 'edit'>([
+  [3049541, 'base'],
+  [3050010, 'turbo'],
+  [3049824, 'edit'],
+]);
+
+export const createBooguInput = defineHandler<BooguCtx, [ImageGenStepTemplate]>((data, ctx) => {
+  const quantity = data.quantity ?? 1;
+
+  let model: 'base' | 'turbo' | 'edit' = data.workflow.startsWith('txt') ? 'base' : 'edit';
+  if (data.model) {
+    const match = versionIdToModel.get(data.model.id);
+    if (match) model = match;
+  }
+
+  const loras: Record<string, number> = {};
+  if ('resources' in data && Array.isArray(data.resources)) {
+    for (const resource of data.resources as ResourceData[]) {
+      loras[ctx.airs.getOrThrow(resource.id)] = resource.strength ?? 1;
+    }
+  }
+
+  const baseInput = {
+    engine: 'comfy',
+    ecosystem: 'boogu',
+    prompt: data.prompt,
+    negativePrompt: 'negativePrompt' in data ? data.negativePrompt : undefined,
+    width: data.aspectRatio?.width,
+    height: data.aspectRatio?.height,
+    cfgScale: 'cfgScale' in data ? data.cfgScale : undefined,
+    steps: 'steps' in data ? data.steps : undefined,
+    quantity,
+    seed: data.seed,
+    loras: Object.keys(loras).length > 0 ? loras : undefined,
+  };
+
+  if (model === 'edit') {
+    return [
+      {
+        $type: 'imageGen',
+        input: removeEmpty({
+          ...baseInput,
+          model: 'edit',
+          operation: 'editImage',
+          images: data.images?.map((x) => x.url) ?? [],
+        }) as ComfyBooguEditImageInput,
+      },
+    ];
+  }
+
+  if (model === 'turbo') {
+    return [
+      {
+        $type: 'imageGen',
+        input: removeEmpty({
+          ...baseInput,
+          model: 'turbo',
+          operation: 'createImage',
+        }) as ComfyBooguTurboCreateImageGenInput,
+      },
+    ];
+  }
+
+  return [
+    {
+      $type: 'imageGen',
+      input: removeEmpty({
+        ...baseInput,
+        model: 'base',
+        operation: 'createImage',
+      }) as ComfyBooguBaseCreateImageGenInput,
+    },
+  ];
+});

--- a/src/server/services/orchestrator/ecosystems/index.ts
+++ b/src/server/services/orchestrator/ecosystems/index.ts
@@ -46,6 +46,7 @@ import { createLensInput } from './lens.handler';
 import { createKrea2Input } from './krea2.handler';
 import { createMAIInput } from './mai.handler';
 import { createZImageInput } from './z-image.handler';
+import { createBooguInput } from './boogu.handler';
 import { createHiDreamInput } from './hi-dream.handler';
 import { createHiDreamO1Input } from './hi-dream-o1.handler';
 import { createPonyV7Input } from './pony-v7.handler';
@@ -129,6 +130,9 @@ export type ChromaCtx = EcosystemGraphOutput & { ecosystem: 'Chroma' };
 
 /** ZImage context (ZImageTurbo and ZImageBase) */
 export type ZImageCtx = EcosystemGraphOutput & { ecosystem: 'ZImageTurbo' | 'ZImageBase' };
+
+/** Boogu context */
+export type BooguCtx = EcosystemGraphOutput & { ecosystem: 'Boogu' };
 
 /** HiDream context */
 export type HiDreamCtx = EcosystemGraphOutput & { ecosystem: 'HiDream' };
@@ -220,6 +224,7 @@ export { createNanoBananaInput } from './nano-banana.handler';
 export { createAnimaInput } from './anima.handler';
 export { createChromaInput } from './chroma.handler';
 export { createZImageInput } from './z-image.handler';
+export { createBooguInput } from './boogu.handler';
 export { createHiDreamInput } from './hi-dream.handler';
 export { createHiDreamO1Input } from './hi-dream-o1.handler';
 export { createPonyV7Input } from './pony-v7.handler';
@@ -330,6 +335,10 @@ async function createEcosystemStep(
     case 'ZImageTurbo':
     case 'ZImageBase':
       return createZImageInput(normalizedData, handlerCtx);
+
+    // Boogu
+    case 'Boogu':
+      return createBooguInput(normalizedData, handlerCtx);
 
     // HiDream
     case 'HiDream':

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -1028,6 +1028,9 @@ export const ecosystemSupport: EcosystemSupport[] = [
   { ecosystemId: ECO.ZImageBase, supportType: 'training', modelTypes: loraOnly },
   { ecosystemId: ECO.ZImageBase, supportType: 'auction', modelTypes: checkpointAndLora },
 
+  // Boogu - checkpoint and LORA (training upcoming per orchestrator)
+  { ecosystemId: ECO.Boogu, supportType: 'generation', modelTypes: checkpointAndLora },
+
   // LTXV - checkpoint only (parent ecosystem)
   { ecosystemId: ECO.LTXV, supportType: 'generation', modelTypes: checkpointOnly },
 
@@ -1371,6 +1374,12 @@ export const ecosystemSettings: EcosystemSettings[] = [
     ecosystemId: ECO.ZImageBase,
     defaults: {
       model: { id: 2635223 },
+    },
+  },
+  {
+    ecosystemId: ECO.Boogu,
+    defaults: {
+      model: { id: 3049541 },
     },
   },
   {

--- a/src/shared/data-graph/generation/boogu-graph.ts
+++ b/src/shared/data-graph/generation/boogu-graph.ts
@@ -1,0 +1,172 @@
+/**
+ * Boogu Family Graph
+ *
+ * Controls for the Boogu ecosystem (Boogu-Image-0.1, comfy engine).
+ * One ecosystem, three checkpoints selected per workflow and discriminated on
+ * model.id into base / turbo / edit modes:
+ *  - Base  (txt2img):      full steps/cfg
+ *  - Turbo (txt2img):      distilled — few steps, low cfg
+ *  - Edit  (img2img:edit): takes source image(s)
+ *
+ * Built on Qwen3-VL-8B + FLUX.1-dev. Supports community LoRAs.
+ */
+
+import { DataGraph } from '~/libs/data-graph/data-graph';
+import type { GenerationCtx } from './context';
+import {
+  aspectRatioNode,
+  createCheckpointGraph,
+  createResourcesGraph,
+  imagesNode,
+  negativePromptGraph,
+  promptGraph,
+  seedNode,
+  sliderNode,
+  snippetsGraph,
+  triggerWordsGraph,
+  type ResourceData,
+} from './common';
+import { sdxlAspectRatioBuckets } from '~/shared/constants/generation.constants';
+
+// =============================================================================
+// Boogu Constants
+// =============================================================================
+
+/** Boogu mode type */
+export type BooguMode = 'base' | 'turbo' | 'edit';
+
+/** Boogu model version IDs (CivitaiOfficial Boogu-Image-0.1 checkpoints) */
+const booguVersionIds = {
+  base: 3049541,
+  turbo: 3050010,
+  edit: 3049824,
+} as const;
+
+/** Map from version ID to mode name */
+const versionIdToMode = new Map<number, BooguMode>(
+  Object.entries(booguVersionIds).map(([mode, id]) => [id, mode as BooguMode])
+);
+
+/** Version options for txt2img workflow (Base + Turbo) */
+const booguTxt2ImgVersionOptions = [
+  { label: 'Base', value: booguVersionIds.base },
+  { label: 'Turbo', value: booguVersionIds.turbo },
+];
+
+/** Version options for img2img:edit workflow (Edit only) */
+const booguEditVersionOptions = [{ label: 'Edit', value: booguVersionIds.edit }];
+
+/** Workflow-specific version configuration */
+const booguWorkflowVersions = {
+  txt2img: {
+    versions: { options: booguTxt2ImgVersionOptions },
+    defaultModelId: booguVersionIds.base,
+  },
+  'img2img:edit': {
+    versions: { options: booguEditVersionOptions },
+    defaultModelId: booguVersionIds.edit,
+  },
+};
+
+// =============================================================================
+// Mode Subgraphs
+// =============================================================================
+
+/** Context shape passed to boogu mode subgraphs */
+type BooguModeCtx = {
+  ecosystem: string;
+  workflow: string;
+  model: ResourceData;
+  booguMode: BooguMode;
+};
+
+/**
+ * Base mode subgraph: full controls (cfg 1-8, steps up to 50).
+ * Defaults live on each subgraph's sliderNode — zod clamps across variants,
+ * so no `.effect()` reset is needed (and Boogu is in TURBO_VARIANT_ECOSYSTEMS,
+ * which scopes cfgScale/steps per model.id so Turbo and Base don't trample).
+ */
+const baseModeGraph = new DataGraph<BooguModeCtx, GenerationCtx>()
+  .merge(createResourcesGraph())
+  .merge(negativePromptGraph)
+  .node('aspectRatio', aspectRatioNode({ options: sdxlAspectRatioBuckets, defaultValue: '1:1' }))
+  .node('cfgScale', sliderNode({ min: 1, max: 8, step: 0.5, defaultValue: 4 }))
+  .node('steps', sliderNode({ min: 1, max: 50, defaultValue: 35 }));
+
+/** Turbo mode subgraph: distilled — few steps, low cfg. */
+const turboModeGraph = new DataGraph<BooguModeCtx, GenerationCtx>()
+  .merge(createResourcesGraph())
+  .node('aspectRatio', aspectRatioNode({ options: sdxlAspectRatioBuckets, defaultValue: '1:1' }))
+  .node('cfgScale', sliderNode({ min: 1, max: 2, step: 0.1, defaultValue: 1 }))
+  .node('steps', sliderNode({ min: 1, max: 12, defaultValue: 4 }));
+
+/** Edit mode subgraph: full controls; source image taken via the root images node. */
+const editModeGraph = new DataGraph<BooguModeCtx, GenerationCtx>()
+  .merge(createResourcesGraph())
+  .merge(negativePromptGraph)
+  .node('aspectRatio', aspectRatioNode({ options: sdxlAspectRatioBuckets, defaultValue: '1:1' }))
+  .node('cfgScale', sliderNode({ min: 1, max: 8, step: 0.5, defaultValue: 5 }))
+  .node('steps', sliderNode({ min: 1, max: 50, defaultValue: 35 }));
+
+// =============================================================================
+// Boogu Family Graph
+// =============================================================================
+
+/**
+ * Boogu family controls.
+ *
+ * Checkpoint selector swaps version options per workflow (Base/Turbo on
+ * txt2img, Edit on img2img:edit). `booguMode` is computed from the selected
+ * model.id, then discriminated into the base/turbo/edit subgraphs.
+ */
+export const booguGraph = new DataGraph<
+  { ecosystem: string; workflow: string; model: ResourceData },
+  GenerationCtx
+>()
+  // Images node — shown for img2img:edit, hidden for txt2img
+  .node(
+    'images',
+    (ctx) => ({
+      ...imagesNode({ max: 1 }),
+      when: !ctx.workflow.startsWith('txt'),
+    }),
+    ['workflow']
+  )
+  // Checkpoint graph with per-workflow version options
+  .merge(
+    (ctx) =>
+      createCheckpointGraph({
+        workflowVersions: booguWorkflowVersions,
+        currentWorkflow: ctx.workflow,
+      }),
+    ['workflow']
+  )
+  .node('seed', seedNode())
+  // Computed: derive boogu mode from the selected model.id (fallback by workflow)
+  .computed(
+    'booguMode',
+    (ctx): BooguMode => {
+      const modelId = ctx.model?.id;
+      if (modelId) {
+        const mode = versionIdToMode.get(modelId);
+        if (mode) return mode;
+      }
+      return ctx.workflow.startsWith('txt') ? 'base' : 'edit';
+    },
+    ['model', 'workflow']
+  )
+  // Discriminated union based on booguMode
+  .discriminator('booguMode', {
+    base: baseModeGraph,
+    turbo: turboModeGraph,
+    edit: editModeGraph,
+  })
+  // Prompt + triggerWords are common to all modes. negativePrompt is only in
+  // base/edit branches; its registration effect self-adds to the snippets
+  // target map when that branch is active.
+  .merge(triggerWordsGraph)
+  .merge(snippetsGraph)
+  .merge(promptGraph);
+
+// Export constants for use in components and handlers
+export { booguVersionIds, booguTxt2ImgVersionOptions, booguEditVersionOptions };

--- a/src/shared/data-graph/generation/config/workflows.ts
+++ b/src/shared/data-graph/generation/config/workflows.ts
@@ -64,6 +64,7 @@ const EDIT_IMG_IDS = [
   ECO.WanImage27,
   ECO.HiDreamO1,
   ECO.MAI,
+  ECO.Boogu,
 ];
 
 /** Image ecosystems that support image:create */
@@ -103,6 +104,7 @@ const TXT2IMG_IDS = [
   ECO.Lens,
   ECO.Krea2,
   ECO.MAI,
+  ECO.Boogu,
 ];
 
 /** Video ecosystems that support video:create */
@@ -798,7 +800,8 @@ const NEW_FORM_ONLY = new Map<string, NewFormOnlyRule>([
       ecoId === ECO.HiDreamO1 ||
       ecoId === ECO.Lens ||
       ecoId === ECO.Krea2 ||
-      ecoId === ECO.MAI,
+      ecoId === ECO.MAI ||
+      ecoId === ECO.Boogu,
   ],
   [
     'img2img:edit',
@@ -807,7 +810,8 @@ const NEW_FORM_ONLY = new Map<string, NewFormOnlyRule>([
       ecoId === ECO.Grok ||
       ecoId === ECO.Qwen2 ||
       ecoId === ECO.WanImage27 ||
-      ecoId === ECO.HiDreamO1,
+      ecoId === ECO.HiDreamO1 ||
+      ecoId === ECO.Boogu,
   ],
 
   // Grok/LTXV23 vid2vid:edit - no legacy equivalent

--- a/src/shared/data-graph/generation/ecosystem-graph.ts
+++ b/src/shared/data-graph/generation/ecosystem-graph.ts
@@ -48,6 +48,7 @@ import { flux2Graph } from './flux2-graph';
 import { flux2KleinGraph } from './flux2-klein-graph';
 import { fluxKontextGraph } from './flux-kontext-graph';
 import { zImageGraph } from './z-image-graph';
+import { booguGraph } from './boogu-graph';
 import { chromaGraph } from './chroma-graph';
 import { hiDreamGraph } from './hi-dream-graph';
 import { hiDreamO1Graph } from './hi-dream-o1-graph';
@@ -351,6 +352,7 @@ export const ecosystemGraph = new DataGraph<
     },
     { values: ['Flux1Kontext'] as const, graph: fluxKontextGraph },
     { values: ['ZImageTurbo', 'ZImageBase'] as const, graph: zImageGraph },
+    { values: ['Boogu'] as const, graph: booguGraph },
     { values: ['Chroma'] as const, graph: chromaGraph },
     { values: ['HiDream'] as const, graph: hiDreamGraph },
     { values: ['HiDream-O1'] as const, graph: hiDreamO1Graph },


### PR DESCRIPTION
Wires the **Boogu** ecosystem into the generator. Follow-up to #2656 (which added the ecosystem + base-model record).

## What's here
- **`boogu-graph.ts`** — one ecosystem, per-workflow checkpoint options (Base/Turbo on `txt2img`, Edit on `img2img:edit`), discriminated on `model.id` into base/turbo/edit subgraphs with their own cfg/step ranges. Edit gets the source-image node. Community LoRAs supported.
- **`boogu.handler.ts`** — routes `model.id` → `base`/`turbo`/`edit`, `createImage` vs `editImage`, maps to `ComfyBooguBaseCreateImageGenInput` / `ComfyBooguTurboCreateImageGenInput` / `ComfyBooguEditImageInput`. Comfy engine, ecosystem `boogu`.
- Wiring: ecosystem-graph discriminator, ecosystems router switch + ctx type, `TXT2IMG_IDS` + `EDIT_IMG_IDS` + `NEW_FORM_ONLY`, `ecosystemSupport` + `ecosystemSettings`, `TURBO_VARIANT_ECOSYSTEMS`.
- Bumps `@civitai/client` → `0.2.0-beta.73` (Luis's published build with Boogu inference types).

Model version IDs: Base `3049541`, Turbo `3050010`, Edit `3049824`. (Models flipped to the `Boogu` base model; AIRs resolve to `urn:air:boogu:...`.)

## Status / caveats
- ✅ `pnpm typecheck` clean.
- ⚠️ **Not yet reviewed in the UI** — controls render / whatIf untested.
- ⚠️ End-to-end generation also depends on the orchestrator Boogu engine finishing rollout (training is upcoming per Koen).
- `ecosystemSupport` is generation-only for now (training deferred).

Plan, contract, and AIRs: `docs/plans/boogu-generation-support.md`.

cc @lrojas94 — handing this off for review/finish alongside your Boogu work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)