### PR TITLE
fix(api-key): invalidate orchestrator auth cache on key/token revocation

### DIFF
--- a/src/pages/api/auth/oauth/revoke.ts
+++ b/src/pages/api/auth/oauth/revoke.ts
@@ -8,6 +8,7 @@ import { addCorsHeaders } from '~/server/utils/endpoint-helpers';
 import { checkOAuthRateLimit, sendRateLimitResponse } from '~/server/oauth/rate-limit';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
+import { invalidateCivitaiUser } from '~/server/services/orchestrator/civitai';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // 5xx attribution: bypasses the endpoint wrappers, so its 500s were
@@ -146,6 +147,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             },
           });
         }
+
+        // Expire the revoked token in the orchestrator's auth cache so it
+        // stops authenticating immediately instead of lingering until TTL.
+        await invalidateCivitaiUser({ userId: apiKey.userId });
         break;
       }
     }

--- a/src/server/routers/oauth-client.router.ts
+++ b/src/server/routers/oauth-client.router.ts
@@ -4,6 +4,7 @@ import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
+import { invalidateCivitaiUser } from '~/server/services/orchestrator/civitai';
 import {
   createOauthClientSchema,
   deleteOauthClientSchema,
@@ -170,10 +171,28 @@ export const oauthClientRouter = router({
       });
       if (!client) throw new TRPCError({ code: 'NOT_FOUND' });
 
+      // Collect every user who holds a token under this client BEFORE the
+      // cascade wipes the rows — we need their ids to expire the orchestrator's
+      // auth cache below. A client can be authorized by many users, not just
+      // the owner.
+      const tokenHolders = await dbWrite.apiKey.findMany({
+        where: { clientId: input.id },
+        select: { userId: true },
+        distinct: ['userId'],
+      });
+
       // Cascade delete handles tokens and consents
       await dbWrite.oauthClient.delete({ where: { id: input.id } });
 
       logOAuthEvent({ type: 'client.deleted', userId: ctx.user.id, clientId: input.id });
+
+      // The DB cascade revokes the tokens, but the orchestrator caches them
+      // for auth and would keep honoring the deleted tokens until TTL. Expire
+      // each affected user's cache so revocation takes effect immediately.
+      // Best-effort: invalidateCivitaiUser swallows its own errors.
+      await Promise.all(
+        tokenHolders.map(({ userId }) => invalidateCivitaiUser({ userId }))
+      );
 
       return { success: true };
     }),

--- a/src/server/routers/oauth-consent.router.ts
+++ b/src/server/routers/oauth-consent.router.ts
@@ -6,6 +6,7 @@ import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
 import { buzzLimitSchema, type BuzzLimit } from '~/server/schema/api-key.schema';
 import { bustBuzzLimitCache, deleteAuthSubject } from '~/server/http/orchestrator/api-key-spend';
+import { invalidateCivitaiUser } from '~/server/services/orchestrator/civitai';
 import { logToAxiom, safeError } from '~/server/logging/client';
 import * as z from 'zod';
 
@@ -149,6 +150,10 @@ export const oauthConsentRouter = router({
           error: safeError(err),
         }).catch(() => {});
       });
+
+      // Expire the revoked tokens in the orchestrator's auth cache so they
+      // stop authenticating immediately instead of lingering until TTL.
+      await invalidateCivitaiUser({ userId: ctx.user.id });
 
       logOAuthEvent({
         type: 'authorization.denied',

--- a/src/server/services/api-key.service.ts
+++ b/src/server/services/api-key.service.ts
@@ -13,6 +13,7 @@ import { simpleUserSelect } from '~/server/selectors/user.selector';
 import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
 import { generationServiceCookie } from '~/shared/constants/generation.constants';
 import { bustBuzzLimitCache, deleteAuthSubject } from '~/server/http/orchestrator/api-key-spend';
+import { invalidateCivitaiUser } from '~/server/services/orchestrator/civitai';
 import { logToAxiom, safeError } from '~/server/logging/client';
 
 export function getApiKey({ id }: GetAPIKeyInput) {
@@ -147,6 +148,11 @@ export async function deleteApiKey({ id, userId }: DeleteAPIKeyInput & { userId:
         error: safeError(err),
       }).catch(() => {});
     });
+
+    // Expire the deleted key in the orchestrator: it caches the user's API
+    // keys for auth, so without this the key keeps working until the cache
+    // TTL lapses. invalidateCivitaiUser swallows its own errors.
+    await invalidateCivitaiUser({ userId });
   }
 
   return result;


### PR DESCRIPTION
## Problem

Deleted API keys kept authenticating for **~24 hours** after deletion. The orchestrator caches a user's API keys for auth and the cache was never busted on delete — it only expired via natural TTL.

Reported in Freshdesk #67958 (ClickUp [868k33rew](https://app.clickup.com/t/868k33rew), Issue 1): a user deleted a leaked key but it kept spending Buzz for over an hour after deletion, stopped only by their 500-buzz spend cap.

## Fix

Call `invalidateCivitaiUser` (Koen's `DELETE /v2/consumer/civitai/{userId}` → `InvalidateUserCache`) on every key/token removal path, so the orchestrator drops its cached copy immediately instead of after TTL:

- `deleteApiKey` — profile-UI key delete (the exact repro)
- `oauthConsentRouter.revokeApp` — connected-app revoke
- `api/auth/oauth/revoke` — RFC 7009 token revocation

The helper already existed (used on session changes); it was just never wired into the deletion paths. Best-effort: it swallows its own errors so a transient orchestrator hiccup never fails the user-facing mutation. Sits alongside the existing `deleteAuthSubject` spend-record cleanup.

## Scope notes

- **Issue 2** (ComfyUI auth node leaking the key via workflow metadata) is a separate codebase (comfy-nodes repo) and is **not** addressed here.
- Bonus "key revoked" audit log from the ticket: not added. The OAuth paths already emit `logOAuthEvent`; `deleteApiKey` does not yet.
- Skipped `orchestrator-key.ts` (System-key rotation that delete-then-recreates → immediate re-fetch) and internal refresh-token rotation in `oauth/model.ts` — neither is the user-facing leak.

## Test

`pnpm run typecheck` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
