### PR TITLE
fix(orchestrator): log invalidateCivitaiUser failures to Axiom

### DIFF
--- a/src/server/services/orchestrator/civitai.ts
+++ b/src/server/services/orchestrator/civitai.ts
@@ -1,5 +1,6 @@
 import { env } from '~/env/server';
 import { createOrchestratorClient } from '~/server/services/orchestrator/client';
+import { logToAxiom, safeError } from '~/server/logging/client';
 
 export async function invalidateCivitaiUser({ userId }: { userId: number | string }) {
   if (!env.ORCHESTRATOR_ACCESS_TOKEN) {
@@ -12,7 +13,15 @@ export async function invalidateCivitaiUser({ userId }: { userId: number | strin
       url: `/v2/consumer/civitai/${userId}`,
     });
   } catch (error) {
-    // Do nothing, not much harm.
-    console.error(`Error invalidating Civitai user ${userId}:`, error);
+    // Best-effort: this runs on key/token revocation and session changes, so a
+    // failure means the orchestrator keeps serving a stale auth cache until
+    // TTL — exactly the 24h-lingering bug. Surface to Axiom so we can spot it
+    // in prod instead of failing silently. Never throws (callers `await` this
+    // inside user-facing mutations).
+    logToAxiom({
+      type: 'orchestrator.invalidate-user.failed',
+      message: `invalidateCivitaiUser failed for user ${userId}`,
+      error: safeError(error),
+    }).catch(() => {});
   }
 }


### PR DESCRIPTION
Follow-up to #2658.

`invalidateCivitaiUser` expires the orchestrator's auth cache on key/token revocation and session changes. A silent failure means the orchestrator keeps honoring a revoked key/token until TTL — re-opening the exact ~24h-lingering bug from [868k33rew](https://app.clickup.com/t/868k33rew). It previously only `console.error`'d, so a prod failure would be invisible.

This routes failures to Axiom (matching the `deleteAuthSubject` / `bustBuzzLimitCache` pattern used in the same revocation flows). Still best-effort and non-throwing, so it can't break the user-facing mutations that `await` it.

`pnpm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
