### PR TITLE
feat(app-blocks): page-LoRA GA — allow platform-valid cross-ecosystem LoRAs (areResourcesCompatible)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1870,10 +1870,12 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
   //
   // A page token can carry `body.additionalResources: [{ modelVersionId,
   // strength }]` (LoRA stack). The server resolves each statelessly, enforces
-  // LoRA-only + base-model family-match, then gates the checkpoint AND every
-  // LoRA through resolveCanGenerateForVersions in ONE call — fail-closed if any
-  // resource is non-LoRA / family-mismatched / not entitled. This runs BEFORE
-  // resolveBlockCheckpoint / any cost / any reservation.
+  // LoRA-only + platform generation-compatibility (getResourceGenerationSupport,
+  // GA — allows same-ecosystem AND platform-defined cross-ecosystem LoRAs, still
+  // fail-closed on null/unknown), then gates the checkpoint AND every LoRA
+  // through resolveCanGenerateForVersions in ONE call — fail-closed if any
+  // resource is non-LoRA / not platform-compatible / not entitled. This runs
+  // BEFORE resolveBlockCheckpoint / any cost / any reservation.
   describe('Page-LoRA — additionalResources', () => {
     // Multi-version lookup keyed by where.id. Checkpoint 99 = SDXL Checkpoint;
     // additional rows are LoRAs (override per-test for family/type cases).
@@ -2020,9 +2022,13 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
     });
 
-    it('rejects a base-model FAMILY-MISMATCHED LoRA (BAD_REQUEST), before the entitlement gate', async () => {
+    it('rejects a platform-INCOMPATIBLE cross-ecosystem LoRA (BAD_REQUEST), before the entitlement gate', async () => {
       mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
-      // Checkpoint is SDXL; the LoRA is SD 1.5 → different generation family.
+      // GA: the boundary is now getResourceGenerationSupport (platform
+      // compatibility), not exact-family equality. Checkpoint is SDXL; the LoRA
+      // is SD 1.5 — and there is NO cross-ecosystem generation rule for a SD1
+      // LORA into SDXL (the only SD1→SDXL rule covers TextualInversion, not
+      // LORA), so getResourceGenerationSupport returns null → still rejected.
       versionRows({ 201: sdxlLora(201, { baseModel: 'SD 1.5' }) });
       happyUser();
       const caller = blocksRouter.createCaller(fakeCtx() as never);
@@ -2242,17 +2248,19 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
     });
 
-    // ── FIX 2: 'Other' (unknown base-model family) is treated as NON-matching ──
+    // ── FIX 2: an unrecognized base-model FAILS CLOSED under the GA check ──────
     //
-    // getBaseModelSetType returns 'Other' for any unrecognized baseModel, so a
-    // checkpoint + LoRA with two DIFFERENT unknown baseModels both collapse to
-    // 'Other' and previously matched vacuously. Either side resolving to 'Other'
-    // must now DENY the LoRA.
-    it('FIX2: a checkpoint + LoRA with unknown/Other baseModels → BAD_REQUEST (was vacuously passing)', async () => {
+    // GA: the boundary is getResourceGenerationSupport, which does
+    // baseModelByName.get(...) for BOTH sides and returns null when either is
+    // unrecognized. So an unknown checkpoint baseModel OR an unknown LoRA
+    // baseModel → null → reject. This preserves the fail-closed-on-unknown
+    // posture the old 'Other'-sentinel guards provided, without those guards.
+    it('FIX2: a checkpoint + LoRA with unknown baseModels → BAD_REQUEST (fail-closed on unknown)', async () => {
       mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
-      // Checkpoint body baseModel is an unrecognized string → 'Other'. The LoRA
-      // has a DIFFERENT unrecognized string → also 'Other'. Both collapse to
-      // 'Other'; the deny guard must reject rather than match vacuously.
+      // Checkpoint body baseModel is an unrecognized string; the LoRA has a
+      // DIFFERENT unrecognized string. The unknown CHECKPOINT alone makes
+      // getResourceGenerationSupport return null → reject (it never even looks
+      // up the LoRA's ecosystem once the primary is unresolved).
       versionRows({
         99: {
           id: 99,
@@ -2277,11 +2285,66 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
     });
 
-    it('FIX2: a known-family checkpoint + an Other-family LoRA → BAD_REQUEST', async () => {
+    it('FIX2: a known checkpoint + an unknown-baseModel LoRA → BAD_REQUEST', async () => {
       mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
-      // Checkpoint is a recognized SDXL family; the LoRA baseModel is unknown →
-      // 'Other'. An 'Other' LoRA must be denied even against a known checkpoint.
+      // Checkpoint is a recognized SDXL baseModel; the LoRA baseModel is unknown.
+      // getResourceGenerationSupport resolves the primary ecosystem but then
+      // baseModelByName.get(loraBaseModel) is undefined → null → reject. An
+      // unrecognized LoRA must be denied even against a known checkpoint.
       versionRows({ 201: sdxlLora(201, { baseModel: 'UnknownBaseModel-XYZ' }) });
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    // ── GA: platform-VALID cross-ecosystem LoRA is now ACCEPTED ────────────────
+    //
+    // This is the core proof of the GA swap. Before GA, the exact-family
+    // equality (getBaseModelSetType) collapsed Pony into its own family ('Pony')
+    // distinct from SDXL and REJECTED a Pony LoRA on an SDXL checkpoint. The
+    // platform, however, defines an explicit cross-ecosystem generation rule
+    // (crossEcosystemRules: Pony → SDXL for LORA/DoRA/LoCon/etc. = 'partial'), so
+    // getResourceGenerationSupport('SDXL 1.0', 'Pony', LORA) is non-null → the
+    // gate must now PROCEED to the entitlement gate (no family BAD_REQUEST).
+    it('GA: a platform-compatible cross-ecosystem LoRA (Pony on an SDXL checkpoint) is ACCEPTED', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      // Checkpoint 99 is SDXL (versionRows default); the additional LoRA is Pony.
+      versionRows({ 201: sdxlLora(201, { baseModel: 'Pony' }) });
+      happyUser();
+      mockSysRedis.incrBy.mockResolvedValue(25);
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: bodyWithLoras([{ modelVersionId: 201 }]),
+      });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      // It cleared the compatibility boundary and reached the entitlement gate
+      // (checkpoint + the cross-ecosystem LoRA in ONE call) — NOT a family
+      // BAD_REQUEST.
+      expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
+      const [versions] = mockResolveCanGenerateForVersions.mock.calls[0];
+      expect(versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)).toEqual([
+        99, 201,
+      ]);
+    });
+
+    // ── GA: a genuinely-incompatible cross-ecosystem LoRA is STILL rejected ────
+    //
+    // A Flux LoRA on an SDXL checkpoint: different ecosystems with NO
+    // cross-ecosystem generation rule between them, so
+    // getResourceGenerationSupport('SDXL 1.0', 'Flux.1 D', LORA) is null → reject.
+    // This proves the GA widening did NOT collapse into "accept any cross-
+    // ecosystem LoRA" — only the platform-permitted pairs pass.
+    it('GA: a genuinely-incompatible cross-ecosystem LoRA (Flux on an SDXL checkpoint) is STILL BAD_REQUEST', async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      versionRows({ 201: sdxlLora(201, { baseModel: 'Flux.1 D' }) });
       happyUser();
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -2301,6 +2301,66 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
     });
 
+    // ── LOW-1: the literal 'Other' base-model group FAILS CLOSED ──────────────
+    //
+    // Regression guard for the GA swap. The null check alone does NOT catch the
+    // platform's RECOGNIZED baseModel record literally named 'Other' (BM.Other →
+    // ECO.Other): baseModelByName.get('Other') SUCCEEDS, so an ('Other','Other')
+    // pair resolves both sides to the SAME ECO.Other ecosystem and
+    // getGenerationSupport short-circuits to 'full' BEFORE any disabled/coverage
+    // check → non-null → ACCEPT — a fail-OPEN on a billing boundary. The re-added
+    // getBaseModelSetType(...) === 'Other' guard must reject it (the entitlement
+    // gate must NOT be reached and NO spend reserved).
+    it("LOW-1: a checkpoint + LoRA both with the literal 'Other' baseModel → BAD_REQUEST (fail-closed on 'Other' group)", async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      // Checkpoint body 99 is the recognized 'Other' baseModel record; the LoRA
+      // is also 'Other'. Without the explicit guard getResourceGenerationSupport
+      // would return 'full' (same ECO.Other ecosystem) and the pair would be
+      // accepted — the fail-open this test pins shut.
+      versionRows({
+        99: {
+          id: 99,
+          baseModel: 'Other',
+          modelId: 7,
+          status: 'Published',
+          availability: 'Public',
+          usageControl: 'Download',
+          meta: null,
+          generationCoverage: { covered: true },
+          model: { id: 7, type: 'Checkpoint', userId: 1 },
+        },
+        201: sdxlLora(201, { baseModel: 'Other' }),
+      });
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      // The entitlement gate must NOT be reached and NO Buzz reserved.
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
+    // LOW-1 (LoRA side): a recognized non-'Other' checkpoint + a literal-'Other'
+    // LoRA must also fail closed — the LoRA-side guard rejects before the
+    // support call even though the checkpoint is fine.
+    it("LOW-1: a recognized checkpoint + a literal-'Other' LoRA → BAD_REQUEST", async () => {
+      mockVerifyBlockToken.mockResolvedValue(pageClaimsLocal({ buzzBudget: 1000 }));
+      // Checkpoint 99 is SDXL (versionRows default); the LoRA is the literal
+      // 'Other' baseModel record. getResourceGenerationSupport('SDXL 1.0',
+      // 'Other', LORA) is null here (different ecosystems, no rule) so this also
+      // passes via the null check — but the explicit guard rejects it FIRST,
+      // independent of the support call.
+      versionRows({ 201: sdxlLora(201, { baseModel: 'Other' }) });
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockResolveCanGenerateForVersions).not.toHaveBeenCalled();
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    });
+
     // ── GA: platform-VALID cross-ecosystem LoRA is now ACCEPTED ────────────────
     //
     // This is the core proof of the GA swap. Before GA, the exact-family

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -65,7 +65,7 @@ import {
 import { getResourceGenerationSupport } from '~/shared/constants/basemodel.constants';
 import type { ModelType } from '~/shared/utils/prisma/enums';
 import { BuzzTypes } from '~/shared/constants/buzz.constants';
-import { WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
+import { getBaseModelSetType, WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
 import { cancelWorkflow, getWorkflow, submitWorkflow } from '~/server/services/orchestrator/workflows';
 import { createTextToImageStep } from '~/server/services/orchestrator/textToImage/textToImage';
@@ -243,11 +243,23 @@ function buildGateVersion(gate: {
 //
 // FAIL-CLOSED on unknown: `getResourceGenerationSupport` does
 // `baseModelByName.get(...)` for BOTH the checkpoint and the LoRA baseModel and
-// returns `null` when either is unrecognized (and again `null` when no
-// same-ecosystem / cross-ecosystem rule covers the pair). So an unknown
-// checkpoint baseModel OR an unknown LoRA baseModel → null → reject. The old
-// explicit 'Other'-sentinel guards are therefore redundant and removed; the
-// null check below covers every reject case the family collapse used to.
+// returns `null` when either is unrecognized (an UNKNOWN baseModel STRING) — so
+// an unknown checkpoint baseModel OR an unknown LoRA baseModel → null → reject.
+//
+// BUT the null check ALONE does NOT cover one case the old family collapse did:
+// the platform's RECOGNIZED baseModel record literally named 'Other'
+// (basemodel.constants.ts BM.Other → ecosystemId ECO.Other). For that record
+// `baseModelByName.get('Other')` SUCCEEDS, so a ('Other' checkpoint, 'Other'
+// LoRA) pair resolves both sides to the SAME ECO.Other ecosystem and
+// getGenerationSupport returns 'full' at its same-ecosystem short-circuit
+// (BEFORE the disabled/coverage checks) → non-null → ACCEPT. That is a
+// fail-OPEN on a billing boundary against the platform's "unclassified" bucket.
+// The old `getBaseModelSetType(...) === 'Other'` guard caught it because that
+// helper maps BOTH unknown strings AND the literal-'Other' record to the
+// 'Other' ecosystem key. We therefore RE-ADD an explicit 'Other'-group reject
+// (below, before/independent of the support call) so BOTH the literal-'Other'
+// and unrecognized-string cases stay FAIL-CLOSED — fail-closed is mandatory on
+// this gate.
 //
 // `checkpointBaseModel` MUST be the baseModel of the ACTUAL checkpoint
 // resolveBlockCheckpoint resolves (the anchor buildTextToImageInput uses), NOT
@@ -263,6 +275,20 @@ async function resolvePageLoraGates(opts: {
 }): Promise<ReturnType<typeof buildGateVersion>[]> {
   const { additionalResources, checkpointBaseModel } = opts;
   if (!additionalResources?.length) return [];
+  // FAIL-CLOSED on the 'Other' ecosystem group. getResourceGenerationSupport's
+  // null check does NOT catch the platform's recognized 'Other' baseModel
+  // record (it resolves to a real ECO.Other ecosystem and short-circuits to
+  // 'full' same-ecosystem), so a ('Other', 'Other') pair would fail OPEN. If
+  // the resolved CHECKPOINT baseModel is in the 'Other' group we can't
+  // establish compatibility for ANY LoRA — reject up front, before/independent
+  // of the support call. getBaseModelSetType maps BOTH unknown strings and the
+  // literal-'Other' record to 'Other', closing both holes.
+  if (getBaseModelSetType(checkpointBaseModel) === 'Other') {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'a selected LoRA is not compatible with the checkpoint base model',
+    });
+  }
   const gates: ReturnType<typeof buildGateVersion>[] = [];
   for (const r of additionalResources) {
     const lora = await resolvePageResourceContext(r.modelVersionId);
@@ -281,6 +307,16 @@ async function resolvePageLoraGates(opts: {
     // (fail-closed on unknown). A non-null SupportLevel ('full'|'partial') means
     // the platform permits it, which now allows same-ecosystem AND platform-
     // defined cross-ecosystem LoRAs (e.g. a Pony LoRA on an SDXL checkpoint).
+    // FAIL-CLOSED on the 'Other' ecosystem group for the LoRA side too — same
+    // reasoning as the checkpoint guard above: the support call would return
+    // 'full' for a literal-'Other' LoRA against an 'Other' checkpoint, so reject
+    // an 'Other'-group LoRA before/independent of the support call.
+    if (getBaseModelSetType(lora.baseModel) === 'Other') {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'a selected LoRA is not compatible with the checkpoint base model',
+      });
+    }
     const support = getResourceGenerationSupport(
       checkpointBaseModel,
       lora.baseModel,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -62,7 +62,8 @@ import {
   resolvePageResourceContext,
   snapshotFromWorkflow,
 } from '~/server/services/blocks/workflow.service';
-import { getBaseModelSetType } from '~/shared/constants/generation.constants';
+import { getResourceGenerationSupport } from '~/shared/constants/basemodel.constants';
+import type { ModelType } from '~/shared/utils/prisma/enums';
 import { BuzzTypes } from '~/shared/constants/buzz.constants';
 import { WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
@@ -215,19 +216,38 @@ function buildGateVersion(gate: {
   return gate as unknown as ResolveCanGenerateVersion;
 }
 
-// Page-LoRA (Increment 1): resolve + validate the page's additional-resource
-// (LoRA) stack from `body.additionalResources`. For each entry it:
+// Page-LoRA (Increment 1; GA): resolve + validate the page's additional-
+// resource (LoRA) stack from `body.additionalResources`. For each entry it:
 //   1. resolves the version statelessly (NO modelId binding — pages have none),
 //   2. enforces LoRA-only v1 (rejects any non-LoRA additional resource), and
-//   3. enforces an EXPLICIT base-model FAMILY match against the checkpoint.
-// The family check is the correctness boundary: the orchestrator belt filters
-// by resource TYPE (common.ts keeps a LoRA-typed resource), NOT by base-model
-// family — so a family-mismatched LoRA of type LORA is PASSED downstream and
-// billed for, producing a gen the viewer paid for that quietly ignored (or
-// degraded) their LoRA. This explicit check is what prevents such a LoRA from
-// being sent (and charged) at all. We collapse each side with
-// getBaseModelSetType (e.g. all SDXL variants → 'SDXL') so a compatible variant
-// isn't falsely rejected.
+//   3. enforces the platform's REAL generation-compatibility check against the
+//      checkpoint.
+// The compatibility check is the correctness boundary: the orchestrator belt
+// filters by resource TYPE (common.ts keeps a LoRA-typed resource), NOT by
+// generation compatibility — so an incompatible LoRA of type LORA is PASSED
+// downstream and billed for, producing a gen the viewer paid for that quietly
+// ignored (or degraded) their LoRA. This explicit check is what prevents such a
+// LoRA from being sent (and charged) at all.
+//
+// GA change: this previously collapsed both sides to a coarse base-model FAMILY
+// (getBaseModelSetType, e.g. all SDXL variants → 'SDXL') and required exact
+// equality — which rejected platform-VALID cross-ecosystem LoRAs (e.g. a Pony
+// LoRA on an SDXL checkpoint). It now defers to the platform's own
+// generation-compatibility model via `getResourceGenerationSupport`, the SAME
+// function the generation form / orchestrator pipeline uses
+// (getResourceEcosystemCompatibility, areResourcesCompatible). A non-null
+// SupportLevel ('full' | 'partial') = the platform considers this LoRA
+// generatable against this checkpoint (same-ecosystem OR an explicit
+// cross-ecosystem rule); `null` = NOT compatible → reject. This widens what's
+// accepted to exactly the platform's definition while staying FAIL-CLOSED.
+//
+// FAIL-CLOSED on unknown: `getResourceGenerationSupport` does
+// `baseModelByName.get(...)` for BOTH the checkpoint and the LoRA baseModel and
+// returns `null` when either is unrecognized (and again `null` when no
+// same-ecosystem / cross-ecosystem rule covers the pair). So an unknown
+// checkpoint baseModel OR an unknown LoRA baseModel → null → reject. The old
+// explicit 'Other'-sentinel guards are therefore redundant and removed; the
+// null check below covers every reject case the family collapse used to.
 //
 // `checkpointBaseModel` MUST be the baseModel of the ACTUAL checkpoint
 // resolveBlockCheckpoint resolves (the anchor buildTextToImageInput uses), NOT
@@ -235,27 +255,14 @@ function buildGateVersion(gate: {
 //
 // Returns the per-LoRA gate bags so the caller can pass checkpoint + every LoRA
 // through the entitlement gate in ONE call. Throws BAD_REQUEST (non-LoRA /
-// unknown-family / family-mismatch), NOT_FOUND (missing/unpublished version) —
-// all BEFORE any cost/spend.
+// not platform-compatible incl. unknown baseModel), NOT_FOUND
+// (missing/unpublished version) — all BEFORE any cost/spend.
 async function resolvePageLoraGates(opts: {
   additionalResources: { modelVersionId: number; strength: number }[] | undefined;
   checkpointBaseModel: string;
 }): Promise<ReturnType<typeof buildGateVersion>[]> {
   const { additionalResources, checkpointBaseModel } = opts;
   if (!additionalResources?.length) return [];
-  const checkpointFamily = getBaseModelSetType(checkpointBaseModel);
-  // An unrecognized baseModel collapses to the 'Other' sentinel (getBaseModelGroup).
-  // If the checkpoint family itself is 'Other' we can't establish compatibility
-  // for ANY LoRA, so reject up front — mirrors the `g !== 'Other'` guard
-  // getBaseModelFromResources uses (generation.constants.ts). Without this, two
-  // DIFFERENT unknown baseModels both collapse to 'Other' and the family-match
-  // below would pass vacuously.
-  if (checkpointFamily === 'Other') {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'the resolved checkpoint base model is not recognized for LoRA compatibility',
-    });
-  }
   const gates: ReturnType<typeof buildGateVersion>[] = [];
   for (const r of additionalResources) {
     const lora = await resolvePageResourceContext(r.modelVersionId);
@@ -267,14 +274,19 @@ async function resolvePageLoraGates(opts: {
         message: 'additional resources must be LoRA models',
       });
     }
-    // Explicit base-model family match (correctness boundary; the belt filters
-    // by type, not family, so it would PASS a family-mismatched LoRA and bill
-    // for it). An 'Other' (unrecognized) LoRA family is treated as NON-matching
-    // and denied — two different unknown baseModels both map to 'Other' and
-    // would otherwise match vacuously (checkpointFamily is already guaranteed
-    // non-'Other' above).
-    const loraFamily = getBaseModelSetType(lora.baseModel);
-    if (loraFamily === 'Other' || loraFamily !== checkpointFamily) {
+    // Platform generation-compatibility check (correctness boundary; the belt
+    // filters by type, not compatibility, so it would PASS an incompatible LoRA
+    // and bill for it). `null` = NOT generatable against this checkpoint per the
+    // platform's own model — including when EITHER baseModel is unrecognized
+    // (fail-closed on unknown). A non-null SupportLevel ('full'|'partial') means
+    // the platform permits it, which now allows same-ecosystem AND platform-
+    // defined cross-ecosystem LoRAs (e.g. a Pony LoRA on an SDXL checkpoint).
+    const support = getResourceGenerationSupport(
+      checkpointBaseModel,
+      lora.baseModel,
+      lora.modelType as ModelType
+    );
+    if (support === null) {
       throw new TRPCError({
         code: 'BAD_REQUEST',
         message: 'a selected LoRA is not compatible with the checkpoint base model',


### PR DESCRIPTION
## What

GA follow-up to #2640 / #2641. Swaps the page-LoRA additional-resource compatibility boundary in `resolvePageLoraGates` (`src/server/routers/blocks.router.ts`) from an **exact base-model family collapse** (`getBaseModelSetType` equality) to the platform's **real generation-compatibility model** (`getResourceGenerationSupport` — the same function the generation form / orchestrator pipeline use, alongside `getResourceEcosystemCompatibility` / `areResourcesCompatible`).

### Before
Each side was collapsed to a coarse family (`'SDXL'`, `'Pony'`, …) and required exact equality. That **wrongly rejected platform-valid cross-ecosystem LoRAs** — e.g. a Pony LoRA on an SDXL checkpoint, which the generation pipeline accepts via an explicit `crossEcosystemRules` entry (Pony → SDXL for LORA/DoRA/LoCon = `partial`).

### After
- `getResourceGenerationSupport(checkpointBaseModel, lora.baseModel, lora.modelType)` returning a **non-null** `SupportLevel` (`'full'`|`'partial'`) → ALLOW (same-ecosystem **and** platform-defined cross-ecosystem).
- A **null** return → REJECT with the same `BAD_REQUEST` `'a selected LoRA is not compatible with the checkpoint base model'` error.

### Fail-closed on null/unknown (preserved)
`getResourceGenerationSupport` does `baseModelByName.get(...)` for **both** the checkpoint and the LoRA and returns `null` when **either** baseModel is *unrecognized* (and again when no same-/cross-ecosystem rule covers the pair). So an unknown checkpoint baseModel **or** an unknown LoRA baseModel → `null` → reject.

**Correction (audit LOW-1, fixed in `0cc5bac`):** the null check does **not** cover the platform's *recognized* `baseModel` record literally named `'Other'` — both sides resolve to `ECO.Other`, hitting the same-ecosystem `'full'` short-circuit → ACCEPT (a fail-open the old `getBaseModelSetType(...) === 'Other'` guard caught). So the explicit `'Other'`-group rejects are **re-added** (checkpoint + per-LoRA), alongside the new `getResourceGenerationSupport` cross-ecosystem check. Fail-closed on both the unrecognized-string and recognized-`'Other'` cases. (Backstopped anyway by the downstream entitlement `covered` gate, but closed deterministically.)

Untouched: the LoRA-only check, the checkpoint-anchoring contract (caller still resolves the checkpoint first and passes its resolved baseModel), the per-call/daily Buzz caps, the entitlement gate, and the orchestrator belt. This change touches ONLY the compatibility boundary.

## Tests (`blocks.router.workflow.test.ts` — billing-adjacent boundary)

- **Renamed** the SDXL-checkpoint + SD1.5-LoRA case → it **stays rejected**, but for the accurate reason: the only SD1→SDXL cross rule covers `TextualInversion`, not `LORA`, so `getResourceGenerationSupport` returns `null`.
- **Re-framed** the two FIX2 cases as *fail-closed-on-unknown-baseModel* (unknown checkpoint OR unknown LoRA → `null`) — same verdicts, accurate rationale under the new check.
- **Preserved** the FIX1 checkpoint-anchoring cases (verdicts unchanged: SDXL LoRA on the resolved SDXL checkpoint accepted; SD1.5 LoRA on the resolved SDXL checkpoint rejected).
- **NEW positive cross-ecosystem**: Pony LoRA on an SDXL checkpoint → **ACCEPTED**, proceeds to the entitlement gate (no family `BAD_REQUEST`). Core proof of the GA swap.
- **NEW negative cross-ecosystem**: Flux LoRA on an SDXL checkpoint (no cross rule) → still `BAD_REQUEST`. Proves the widening did not become "accept any cross-ecosystem LoRA".
- **NEW `'Other'` fail-closed** (audit LOW-1): checkpoint `'Other'` + `'Other'` LoRA → `BAD_REQUEST`, entitlement gate not reached / no spend (verified load-bearing — removing the guards makes this fail).

Targeted vitest: **86/86 pass** (`pnpm vitest run --project unit src/server/routers/__tests__/blocks.router.workflow.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
