### PR TITLE
fix(orchestrator): stop logging expected whatIfFromGraph validation as errors + unmask the real 500s

### DIFF
--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -1,4 +1,6 @@
 import { Client } from '@axiomhq/axiom-node';
+import { TRPCError } from '@trpc/server';
+import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
 import { isProd } from '~/env/other';
 import { env } from '~/env/server';
 
@@ -33,6 +35,61 @@ export function safeError(e: unknown): MixedObject | undefined {
     };
   }
   return { message: String(e) };
+}
+
+/**
+ * TRPCError codes that represent a CLIENT fault — i.e. normal user-feedback that
+ * a request was rejected (bad input, not allowed, not found, rate-limited, etc.).
+ * These are NOT incidents and must never be logged at error severity, or they
+ * drown out the real server-side failures on the error board.
+ *
+ * Everything NOT in this set (notably INTERNAL_SERVER_ERROR, TIMEOUT) — and any
+ * non-TRPCError thrown value — is treated as a SERVER fault worth an error log.
+ */
+const CLIENT_FAULT_TRPC_CODES: ReadonlySet<TRPC_ERROR_CODE_KEY> = new Set([
+  'BAD_REQUEST',
+  'FORBIDDEN',
+  'UNAUTHORIZED',
+  'NOT_FOUND',
+  'TOO_MANY_REQUESTS',
+  'CONFLICT',
+  'PRECONDITION_FAILED',
+]);
+
+/**
+ * Classify a thrown value as a client fault (expected user feedback) or a server
+ * fault (a real failure worth an error log). A non-TRPCError is always a server
+ * fault — there was no deliberate validation rejection, so the cause is unknown.
+ */
+export function classifyErrorFault(e: unknown): 'client' | 'server' {
+  if (e instanceof TRPCError && CLIENT_FAULT_TRPC_CODES.has(e.code)) return 'client';
+  return 'server';
+}
+
+/**
+ * Build the `error` field for a server-fault log entry, UN-MASKING the underlying
+ * cause.
+ *
+ * `errorHandling.ts` rewrites the user-facing message to a generic
+ * "An unexpected error ocurred..." but preserves the original error on `.cause`
+ * (see `throwDbError` / `throwInternalServerError` / `handleTRPCError`). Logging
+ * only the masked TRPCError therefore hides the actual failure. This walks to the
+ * cause so the diagnosable signal (the original message + stack + Prisma code)
+ * lands in the log alongside the surfaced TRPCError.
+ */
+export function buildServerFaultErrorLog(e: unknown): MixedObject {
+  if (e instanceof TRPCError) {
+    return {
+      code: e.code,
+      name: e.name,
+      message: e.message,
+      stack: e.stack,
+      // The pre-mask original — carries the real message/stack/Prisma code.
+      cause: safeError(e.cause),
+    };
+  }
+  // Non-TRPCError: log the full error directly (already the real failure).
+  return safeError(e) ?? { message: String(e) };
 }
 
 export async function logToAxiom(data: MixedObject, datastream?: string) {

--- a/src/server/logging/whatif-error-logging.test.ts
+++ b/src/server/logging/whatif-error-logging.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Tests for the whatIfFromGraph logging-hygiene fix.
+ *
+ * `orchestrator.router.ts:whatIfFromGraph` previously logged EVERY failure at
+ * `type:'error'`, making it the largest error-by-name entry in prod even though
+ * ~94% are expected client-fault validation (BAD_REQUEST). The fix branches on
+ * the error's fault class via two pure helpers in `logging/client.ts`:
+ *   - `classifyErrorFault`      → 'client' | 'server'
+ *   - `buildServerFaultErrorLog`→ un-masks the underlying cause for server faults
+ *
+ * The global setup mocks `~/server/logging/client` wholesale, so we pull the
+ * REAL implementations via `importActual` (env/prom remain mocked, which is fine —
+ * these helpers only touch TRPCError shape, not env).
+ */
+
+const { classifyErrorFault, buildServerFaultErrorLog } = await vi.importActual<
+  typeof import('./client')
+>('./client');
+
+// Mirror of errorHandling.ts `throwInternalServerError`: it rewrites the
+// user-facing message to a generic string but PRESERVES the original error on
+// `.cause`. Reproduced here (not imported) so the test asserts on the exact
+// masking shape the router's catch block sees in prod.
+function maskAsInternalServerError(original: Error): TRPCError {
+  return new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'An unexpected error ocurred, please try again later',
+    cause: original,
+  });
+}
+
+describe('classifyErrorFault', () => {
+  const clientFaultCodes = [
+    'BAD_REQUEST',
+    'FORBIDDEN',
+    'UNAUTHORIZED',
+    'NOT_FOUND',
+    'TOO_MANY_REQUESTS',
+    'CONFLICT',
+    'PRECONDITION_FAILED',
+  ] as const;
+
+  it.each(clientFaultCodes)('classifies TRPCError code %s as a client fault', (code) => {
+    expect(classifyErrorFault(new TRPCError({ code, message: 'x' }))).toBe('client');
+  });
+
+  it('classifies INTERNAL_SERVER_ERROR as a server fault', () => {
+    expect(classifyErrorFault(new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'x' }))).toBe(
+      'server'
+    );
+  });
+
+  it('classifies TIMEOUT (not in the client set) as a server fault', () => {
+    expect(classifyErrorFault(new TRPCError({ code: 'TIMEOUT', message: 'x' }))).toBe('server');
+  });
+
+  it('classifies a plain (non-TRPCError) thrown value as a server fault', () => {
+    expect(classifyErrorFault(new Error('boom'))).toBe('server');
+    expect(classifyErrorFault('a string')).toBe('server');
+    expect(classifyErrorFault(undefined)).toBe('server');
+  });
+});
+
+describe('buildServerFaultErrorLog — un-masks the underlying cause', () => {
+  it('surfaces the original cause message/stack/code behind a masked INTERNAL_SERVER_ERROR', () => {
+    const original = new Error('connect ECONNREFUSED 10.0.0.5:6379');
+    (original as Error & { code?: string }).code = 'ECONNREFUSED';
+    const masked = maskAsInternalServerError(original);
+
+    const log = buildServerFaultErrorLog(masked);
+
+    // The surfaced TRPCError fields are still present...
+    expect(log.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(log.message).toBe('An unexpected error ocurred, please try again later');
+    // ...AND the real failure is recovered from `.cause` (was hidden before the fix).
+    expect(log.cause).toBeDefined();
+    expect((log.cause as { message?: string }).message).toBe(
+      'connect ECONNREFUSED 10.0.0.5:6379'
+    );
+    expect((log.cause as { code?: string }).code).toBe('ECONNREFUSED');
+    expect((log.cause as { stack?: string }).stack).toBeTruthy();
+  });
+
+  it('logs a non-TRPCError directly with its real message + stack', () => {
+    const log = buildServerFaultErrorLog(new Error('raw failure'));
+    expect(log.message).toBe('raw failure');
+    expect(log.stack).toBeTruthy();
+  });
+});
+
+/**
+ * End-to-end replication of the router's catch block. We reproduce the EXACT
+ * wiring (classify → branch → log → re-throw) without importing the heavy
+ * orchestrator router, and assert the observable logging + control flow.
+ */
+function whatIfCatchBlock(
+  e: unknown,
+  input: unknown,
+  logToAxiom: (data: Record<string, unknown>) => Promise<void>
+): never {
+  if (classifyErrorFault(e) === 'client') {
+    logToAxiom({
+      name: 'what-if-from-graph',
+      type: 'info',
+      payload: input,
+      error: e instanceof TRPCError ? { code: e.code, name: e.name, message: e.message } : e,
+    }).catch(() => undefined);
+  } else {
+    logToAxiom({
+      name: 'what-if-from-graph',
+      type: 'error',
+      payload: input,
+      error: buildServerFaultErrorLog(e),
+    }).catch(() => undefined);
+  }
+  throw e;
+}
+
+describe('whatIfFromGraph catch block — logging severity + re-throw', () => {
+  it('BAD_REQUEST: NOT logged at error severity, logged at info, and still thrown', () => {
+    const logToAxiom = vi.fn().mockResolvedValue(undefined);
+    const err = new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Some of your resources are not available for generation: Foo',
+    });
+
+    expect(() => whatIfCatchBlock(err, { workflow: 'txt2img' }, logToAxiom)).toThrow(err);
+
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    const logged = logToAxiom.mock.calls[0][0];
+    expect(logged.type).toBe('info');
+    expect(logged.type).not.toBe('error');
+    expect(logged.name).toBe('what-if-from-graph');
+    expect((logged.error as { code?: string }).code).toBe('BAD_REQUEST');
+  });
+
+  it('INTERNAL_SERVER_ERROR: logged at error severity WITH the un-masked cause, and still thrown', () => {
+    const logToAxiom = vi.fn().mockResolvedValue(undefined);
+    const original = new Error('Prisma P2024 connection pool timeout');
+    const err = maskAsInternalServerError(original);
+
+    expect(() => whatIfCatchBlock(err, { workflow: 'txt2img' }, logToAxiom)).toThrow(err);
+
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    const logged = logToAxiom.mock.calls[0][0];
+    expect(logged.type).toBe('error');
+    expect((logged.error as { code?: string }).code).toBe('INTERNAL_SERVER_ERROR');
+    // The masked message is generic, but the diagnosable cause is now present.
+    expect((logged.error as { cause?: { message?: string } }).cause?.message).toBe(
+      'Prisma P2024 connection pool timeout'
+    );
+  });
+
+  it('non-TRPCError: logged at error severity with full stack, and still thrown', () => {
+    const logToAxiom = vi.fn().mockResolvedValue(undefined);
+    const err = new Error('unexpected throw');
+
+    expect(() => whatIfCatchBlock(err, {}, logToAxiom)).toThrow(err);
+
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    const logged = logToAxiom.mock.calls[0][0];
+    expect(logged.type).toBe('error');
+    expect((logged.error as { message?: string }).message).toBe('unexpected throw');
+    expect((logged.error as { stack?: string }).stack).toBeTruthy();
+  });
+});

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -11,7 +11,11 @@ import {
 } from '~/server/services/orchestrator/orchestration-new.service';
 import { getWorkflow as clientGetWorkflow } from '@civitai/client';
 import { internalOrchestratorClient } from '~/server/services/orchestrator/client';
-import { logToAxiom } from '~/server/logging/client';
+import {
+  logToAxiom,
+  classifyErrorFault,
+  buildServerFaultErrorLog,
+} from '~/server/logging/client';
 import { edgeCacheIt } from '~/server/middleware.trpc';
 import { generatorFeedbackReward } from '~/server/rewards';
 import { generationStatusDefaultMessage } from '~/server/schema/generation.schema';
@@ -518,19 +522,33 @@ export const orchestratorRouter = router({
           currencies: getAllowedAccountTypes(ctx.features, ['blue']),
         });
       } catch (e) {
-        logToAxiom({
-          name: 'what-if-from-graph',
-          type: 'error',
-          payload: input,
-          error:
-            e instanceof TRPCError
-              ? {
-                  code: e.code,
-                  name: e.name,
-                  message: e.message,
-                }
-              : e,
-        }).catch();
+        // ~94% of failures here are EXPECTED client-fault validation (BAD_REQUEST
+        // et al. — "resources not available for generation", "request is invalid")
+        // for a non-critical cost PREVIEW. Logging those at error severity made
+        // this the single largest error-by-name entry in prod and buried the real
+        // ~6% server faults. Branch on the TRPCError code:
+        //  - client fault → log at 'info' (normal user feedback, not an incident);
+        //  - server fault → log at 'error' WITH the un-masked underlying cause
+        //    (errorHandling.ts replaces the message with a generic string but keeps
+        //    the original on `.cause`), so the real 500s stay diagnosable.
+        // Behavior is otherwise unchanged: the client still receives the original
+        // 400/500 because we always re-throw `e`.
+        if (classifyErrorFault(e) === 'client') {
+          logToAxiom({
+            name: 'what-if-from-graph',
+            type: 'info',
+            payload: input,
+            error:
+              e instanceof TRPCError ? { code: e.code, name: e.name, message: e.message } : e,
+          }).catch();
+        } else {
+          logToAxiom({
+            name: 'what-if-from-graph',
+            type: 'error',
+            payload: input,
+            error: buildServerFaultErrorLog(e),
+          }).catch();
+        }
         throw e;
       }
     }),


### PR DESCRIPTION
## Problem

`orchestrator.whatIfFromGraph` (the generation **cost estimator** the gen-form polls continuously) logged **every** failure at `type:'error'` in its catch block (`src/server/routers/orchestrator.router.ts`). On prod this is the single largest error-by-name entry (~1,180/h), but **~94% are expected `BAD_REQUEST` validation** ("Some of your resources are not available for generation", "Your request is invalid", "not enabled for generation", "No images can be upscaled…") — normal user feedback for a non-critical cost **preview**. Only ~6% are real `INTERNAL_SERVER_ERROR`s (~1/min), and their underlying cause was **masked** by `errorHandling.ts` (which replaces the message with the generic "An unexpected error ocurred…" before the catch sees it). Net: expected validation pollutes the error board and hides real incidents.

## Part A — Logging hygiene (implemented)

Branch the catch on the error's **fault class**, via two new pure helpers in `src/server/logging/client.ts`:

- **`classifyErrorFault(e)`** → `'client'` for the client-fault TRPC codes (`BAD_REQUEST`, `FORBIDDEN`, `UNAUTHORIZED`, `NOT_FOUND`, `TOO_MANY_REQUESTS`, `CONFLICT`, `PRECONDITION_FAILED`); `'server'` for everything else (notably `INTERNAL_SERVER_ERROR`, `TIMEOUT`) and **any non-TRPCError** thrown value.
- **`buildServerFaultErrorLog(e)`** → for server faults, **un-masks the cause**: `errorHandling.ts` (`throwDbError`/`throwInternalServerError`/`handleTRPCError`/`throwDbCustomError`) preserves the original error on `.cause`, so this recovers the real message + stack + Prisma code (via the existing `safeError` helper) alongside the surfaced TRPCError.

In the router catch:
- **client fault** → log at `type:'info'` (the codebase already uses `'info'`/`'warn'`/`'error'` as a severity convention — e.g. `user-restriction.router.ts`, `remove-old-drafts.ts`).
- **server fault** → keep `type:'error'`, now with the unmasked cause.
- **Control flow unchanged: always `throw e`** — clients still get the exact same 400/500.

## Part B — Fail-soft the 500 branch: **WITHHELD (not money-safe)**

The money-safety gate fails. I read every whatIf consumer:

- `src/components/generation_v2/hooks/useWhatIfFromGraph.ts` falls back to `defaultWorkflowCost` (`total: 0`) when there's no data.
- `src/components/generation_v2/FormFooter.tsx`: the `SubmitButton` is `disabled={… || isError || !canEstimateCost || insufficientBuzz}` and `useTotalGenerationCost()` returns `data?.cost?.total ?? 0`; `insufficientBuzz` requires `totalCost > 0`.
- The four modals (`UpscaleImageModal`, `UpscaleVideoModal`, `VideoInterpolationModal`, `BackgroundRemovalModal`) all gate submit on `whatIf.isError` and read cost as `whatIf.data?.cost?.total ?? 0`.

So returning a non-error sentinel would flip `isError` to false, collapse the displayed cost to **0**, and **re-enable the Generate button** — letting a user submit a real-Buzz generation at a price of 0 they never saw and never agreed to. (Spend is enforced at submit, so it wouldn't be free — it'd be silently mispriced from the user's view, exactly the case the gate forbids.) The current throw → `isError:true` → submit disabled is the safe state, so the server-fault branch **keeps throwing**. Only Part A is shipped. This is also the reversible choice.

(Confirmed `whatIfFromGraph` is a read-only `.query` — it never moves Buzz; the only risk was a soft-failed estimate enabling a mispriced submit.)

## Tests

`src/server/logging/whatif-error-logging.test.ts` (15 cases, vitest unit project):
- `classifyErrorFault`: every client-fault code → `'client'`; ISE / TIMEOUT / non-TRPCError → `'server'`.
- `buildServerFaultErrorLog`: recovers the original cause message/stack/code from behind a masked ISE; logs a raw `Error` directly.
- A faithful replication of the router catch block asserting: **BAD_REQUEST is NOT logged at error severity (logs at `info`) and is still thrown**; **ISE logs at `error` WITH the unmasked cause and is still thrown**; non-TRPCError logs at `error` with full stack and is still thrown.

All 15 pass locally (vitest).

## Typecheck

`tsc --noEmit` full-repo, branch vs `origin/main`: **identical error-location sets — zero new, zero removed** (verified by diffing `file(line,col): error TSxxxx` keys; the only textual differences were TS union-member display-ordering noise). The large pre-existing baseline count is the stale-Prisma-client NixOS local-run artifact; CI is authoritative.

## Blast radius

Logging-only change to one catch block + two new pure exported helpers + a new test file. No validation logic, no orchestrator submit path, no client behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)