### PR TITLE
feat(model-wizard): file-upload & version-form feedback fixes

### DIFF
--- a/src/components/Post/EditV2/PostImageDropzone.tsx
+++ b/src/components/Post/EditV2/PostImageDropzone.tsx
@@ -126,11 +126,9 @@ export function PostImageDropzone({
             queryUtils.post.getEdit.setData({ id: data.id }, () => data);
             // Refresh the version's post list so re-entering the post step (e.g. via
             // the wizard's back/next) reuses this post instead of creating a new one.
-            if (modelVersionId)
-              await queryUtils.modelVersion.getById.invalidate({
-                id: modelVersionId,
-                withFiles: true,
-              });
+            if (modelVersionId) {
+              await queryUtils.modelVersion.getById.invalidate({ id: modelVersionId, withFiles: true });
+            }
             await onCreatePost?.(data);
             upload(fileData, { postId: data.id });
           },

--- a/src/components/Post/EditV2/PostImageDropzone.tsx
+++ b/src/components/Post/EditV2/PostImageDropzone.tsx
@@ -124,6 +124,13 @@ export function PostImageDropzone({
         {
           onSuccess: async (data) => {
             queryUtils.post.getEdit.setData({ id: data.id }, () => data);
+            // Refresh the version's post list so re-entering the post step (e.g. via
+            // the wizard's back/next) reuses this post instead of creating a new one.
+            if (modelVersionId)
+              await queryUtils.modelVersion.getById.invalidate({
+                id: modelVersionId,
+                withFiles: true,
+              });
             await onCreatePost?.(data);
             upload(fileData, { postId: data.id });
           },

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -557,8 +557,12 @@ function LinkedComponentCard({
  */
 function isMissingRequiredInfo(file: FileFromContextProps): boolean {
   if (!file.type) return true;
-  if (file.name.toLowerCase().endsWith('.gguf')) return !file.quantType;
-  if (file.type === 'Model' && file.modelType === 'Checkpoint') return !file.size || !file.fp;
+  const isGguf = file.name.toLowerCase().endsWith('.gguf');
+  const isCheckpointModel = file.type === 'Model' && file.modelType === 'Checkpoint';
+  // GGUF always needs a quant type; Checkpoint weights additionally need a size
+  // regardless of extension (precision is the only field GGUF Checkpoints skip).
+  if (isGguf) return !file.quantType || (isCheckpointModel && !file.size);
+  if (isCheckpointModel) return !file.size || !file.fp;
   return false;
 }
 

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -32,7 +32,7 @@ import {
   IconLayersLinked,
 } from '@tabler/icons-react';
 import { isEqual, startCase } from 'lodash-es';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { UploadNotice } from '~/components/UploadNotice/UploadNotice';
 import type { FileFromContextProps } from '~/components/Resource/FilesProvider';
@@ -458,7 +458,7 @@ export function Files() {
                 <li>Users&apos; preferences will auto-select the best match for their setup</li>
                 <li>Link to existing models when the component already exists on Civitai</li>
                 <li>
-                  Only create a new <strong>version</strong> when you&apos;ve actually
+                  Only create a new <strong>version</strong>{' '}when you&apos;ve actually
                   trained/updated the model
                 </li>
               </ul>
@@ -548,6 +548,20 @@ function LinkedComponentCard({
   );
 }
 
+/**
+ * Whether a file still needs required metadata before it's publishable — mirrors
+ * the server metadata refinements: a type for everything, quant type for GGUF,
+ * and size + precision for Checkpoint model weights. Drives the "Needs info" badge
+ * so auto-uploaded files that couldn't be auto-detected get flagged instead of
+ * silently persisting incomplete.
+ */
+function isMissingRequiredInfo(file: FileFromContextProps): boolean {
+  if (!file.type) return true;
+  if (file.name.toLowerCase().endsWith('.gguf')) return !file.quantType;
+  if (file.type === 'Model' && file.modelType === 'Checkpoint') return !file.size || !file.fp;
+  return false;
+}
+
 // Compact horizontal file card
 function FileCard({
   data: versionFile,
@@ -628,7 +642,7 @@ function FileCard({
             <Text size="sm" fw={500} c={failedUpload ? 'red' : 'white'} truncate>
               {versionFile.name}
             </Text>
-            {!versionFile.type && !versionFile.isUploading && (
+            {isMissingRequiredInfo(versionFile) && (
               <Badge color="yellow" variant="light" size="xs">
                 Needs info
               </Badge>
@@ -649,30 +663,22 @@ function FileCard({
             />
           )}
         </div>
-        {!versionFile.isUploading && (
-          <Group gap="xs" wrap="nowrap" align="flex-end">
-            <FileEditForm file={versionFile} fileTypes={fileTypes} index={index} />
-            {!trackedFile && (
-              <LegacyActionIcon
-                color="red"
-                onClick={() => handleRemoveFile(versionFile.uuid)}
-                loading={deleteFileMutation.isPending}
-                style={{ marginTop: 18 }}
-              >
-                <IconTrash size={16} />
-              </LegacyActionIcon>
-            )}
-          </Group>
-        )}
-        {versionFile.isUploading && !trackedFile && (
-          <LegacyActionIcon
-            color="red"
-            onClick={() => handleRemoveFile(versionFile.uuid)}
-            loading={deleteFileMutation.isPending}
-          >
-            <IconTrash size={16} />
-          </LegacyActionIcon>
-        )}
+        {/* Selects render during upload too, so the user can set type/precision/
+            size/quant while the bytes upload — the save reads the latest via
+            filesRef. */}
+        <Group gap="xs" wrap="nowrap" align="flex-end">
+          <FileEditForm file={versionFile} fileTypes={fileTypes} index={index} />
+          {!trackedFile && (
+            <LegacyActionIcon
+              color="red"
+              onClick={() => handleRemoveFile(versionFile.uuid)}
+              loading={deleteFileMutation.isPending}
+              style={{ marginTop: 18 }}
+            >
+              <IconTrash size={16} />
+            </LegacyActionIcon>
+          )}
+        </Group>
       </Group>
       {trackedFile && (
         <Card.Section>
@@ -782,15 +788,24 @@ function TrackedFileStatus({
     case 'error':
       return (
         <Group justify="space-between" wrap="nowrap" gap="xs" style={{ width: '100%' }}>
-          <Group gap="xs">
-            <IconBan color="red" />
-            <Text size="sm">Failed to upload</Text>
+          <Group gap="xs" wrap="nowrap">
+            <IconAlertTriangle color="red" style={{ flexShrink: 0 }} />
+            <Text size="sm" c="red">
+              Upload failed and couldn&apos;t recover automatically. Retry, or remove the file.
+            </Text>
           </Group>
-          <Tooltip label="Retry upload" position="left">
-            <LegacyActionIcon color="blue" onClick={() => retry(versionFileUuid)}>
-              <IconRefresh />
-            </LegacyActionIcon>
-          </Tooltip>
+          <Group gap={4} wrap="nowrap">
+            <Tooltip label="Retry upload" position="left">
+              <LegacyActionIcon color="blue" onClick={() => retry(versionFileUuid)}>
+                <IconRefresh />
+              </LegacyActionIcon>
+            </Tooltip>
+            <Tooltip label="Remove file" position="left">
+              <LegacyActionIcon color="red" onClick={handleRemoveFile}>
+                <IconTrash />
+              </LegacyActionIcon>
+            </Tooltip>
+          </Group>
         </Group>
       );
     case 'success':
@@ -855,6 +870,14 @@ function FileEditForm({
     },
   });
 
+  // When the file gets persisted (auto-start assigns an id on upload completion),
+  // rebase the dirty-comparison baseline so Save/Reset don't show spuriously for
+  // a file the user never manually edited.
+  useEffect(() => {
+    if (versionFile.id) setInitialFile({ ...versionFile });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [versionFile.id]);
+
   const handleSave = () => {
     const valid = validationCheck();
     if (valid && versionFile.id) {
@@ -917,11 +940,9 @@ function FileEditForm({
           value={versionFile.type ?? null}
           onChange={(value) => {
             const newType = value as ModelFileType | null;
-            updateFile(versionFile.uuid, {
-              type: newType,
-              size: null,
-              fp: null,
-            });
+            // Preserve precision/size when relabeling the file type — re-picking
+            // them every time is tedious and they're usually still correct.
+            updateFile(versionFile.uuid, { type: newType });
           }}
         />
       </div>
@@ -1033,49 +1054,41 @@ function FileEditForm({
 }
 
 export function UploadStepActions({ onBackClick, onNextClick }: ActionProps) {
-  const { startUpload, files, hasPending, usageControl } = useFilesContext();
+  const { files, usageControl } = useFilesContext();
   const isExternalGeneration = usageControl === ModelUsageControl.ExternalGeneration;
+
+  // Files upload automatically on drop, so "Next" just navigates forward. We
+  // intentionally let the user proceed to the post step WITHOUT files so they can
+  // prep the post before (or while) uploading — the version can't actually be
+  // published until files exist, which is enforced at publish time in the post
+  // step. Warn here so it isn't a surprise.
+  const handleNext = () => {
+    const hasUploadingOrUploaded = files.some((file) => file.isUploading || !!file.id);
+
+    if (!isExternalGeneration && !hasUploadingOrUploaded) {
+      return openConfirmModal({
+        title: (
+          <Group gap="xs">
+            <IconAlertTriangle color="gold" />
+            <Text size="lg">No files uploaded</Text>
+          </Group>
+        ),
+        children:
+          "You haven't uploaded any files yet. You can continue and set up your post now, but you won't be able to publish this version until at least one file has uploaded.",
+        labels: { cancel: 'Cancel', confirm: 'Continue' },
+        onConfirm: onNextClick,
+      });
+    }
+
+    onNextClick();
+  };
 
   return (
     <Group mt="xl" justify="flex-end">
       <Button variant="default" onClick={onBackClick}>
         Back
       </Button>
-      <Button
-        onClick={async () => {
-          const allFailed = files.every(
-            (file) => file.status === 'aborted' || file.status === 'error'
-          );
-          const showConfirmModal = !isExternalGeneration && (!files.length || allFailed);
-
-          if (showConfirmModal) {
-            return openConfirmModal({
-              title: (
-                <Group gap="xs">
-                  <IconAlertTriangle color="gold" />
-                  <Text size="lg">Missing files</Text>
-                </Group>
-              ),
-              children:
-                'You have not uploaded any files. You can continue without files, but you will not be able to publish your model. Are you sure you want to continue?',
-              labels: { cancel: 'Cancel', confirm: 'Continue' },
-              onConfirm: onNextClick,
-            });
-          }
-
-          if (hasPending) {
-            try {
-              await startUpload();
-            } catch (error) {
-              // Avoid going to next step when thrown error
-              return;
-            }
-          }
-          return onNextClick();
-        }}
-      >
-        Next
-      </Button>
+      <Button onClick={handleNext}>Next</Button>
     </Group>
   );
 }

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -1,7 +1,7 @@
 import { Anchor, Stack, Text } from '@mantine/core';
 import { randomId } from '@mantine/hooks';
 import { hideNotification, showNotification } from '@mantine/notifications';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import * as z from 'zod';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import type { LinkedComponent } from '~/server/schema/model-file.schema';
@@ -14,7 +14,11 @@ import type { ModelUpsertInput } from '~/server/schema/model.schema';
 import { ModelStatus, ModelType, ModelUsageControl } from '~/shared/utils/prisma/enums';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import { getPrimaryFileTypes, primaryFileTypesByModelType } from '~/utils/file-display-helpers';
-import { getModelFileFormat } from '~/utils/file-helpers';
+import {
+  getModelFileFormat,
+  inferGgufQuantType,
+  inferSafetensorsPrecision,
+} from '~/utils/file-helpers';
 import { showErrorNotification } from '~/utils/notifications';
 import { bytesToKB } from '~/utils/number-helpers';
 import { getFileExtension, getModelUrl } from '~/utils/string-helpers';
@@ -125,11 +129,20 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
     return [...initialFiles, ...uploading].filter(isDefined);
   });
 
+  // Latest files snapshot for async callbacks (upload completion reads the most
+  // recent metadata the user has set, not what was present when upload started).
+  const filesRef = useRef(files);
+  filesRef.current = files;
+  // Tracks files whose byte-upload has already been kicked off so the auto-start
+  // effect doesn't start the same file twice across renders.
+  const startedUploadsRef = useRef<Set<string>>(new Set());
+
   const handleUpdateFile = (uuid: string, file: Partial<FileFromContextProps>) => {
     setFiles((state) => state.map((x) => (x.uuid === uuid ? { ...x, ...file } : x)));
   };
 
   const removeFile = (uuid: string) => {
+    startedUploadsRef.current.delete(uuid);
     setFiles((state) => state.filter((x) => x.uuid !== uuid));
   };
 
@@ -485,9 +498,15 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
   });
 
   const onDrop = (files: File[], defaultType?: ModelFileType, skipInference?: boolean) => {
+    // For Additional Components (skipInference), we can't reliably tell what kind
+    // of component a weight file is, so we pick a safe default from the section's
+    // allow-list so the upload can start immediately — the user refines the type
+    // after it finishes.
+    const additionalTypes =
+      dropzoneOptionsByModelType[model?.type ?? 'Checkpoint'].additional.fileTypes;
     const toUpload = files.map((file) => {
       const inferredType = skipInference
-        ? defaultType
+        ? defaultType ?? inferComponentFileType(file.name, additionalTypes)
         : defaultType ?? inferFileType(file.name, model?.type);
       return {
         name: file.name,
@@ -505,6 +524,28 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
       };
     }) as FileFromContextProps[];
     setFiles((state) => [...state, ...toUpload]);
+
+    // Auto-detect file metadata from the header so the user doesn't have to pick
+    // it manually: precision (fp) for safetensors, quant type for GGUF. Runs in
+    // the background; the upload-completion handler reads the latest value via
+    // filesRef, so it's fine if this resolves after the byte upload has started.
+    for (const item of toUpload) {
+      if (!item.file) continue;
+      const fileName = item.file.name.toLowerCase();
+      if (fileName.endsWith('.safetensors') || fileName.endsWith('.sft')) {
+        inferSafetensorsPrecision(item.file)
+          .then((fp) => {
+            if (fp) handleUpdateFile(item.uuid, { fp });
+          })
+          .catch(() => null);
+      } else if (fileName.endsWith('.gguf')) {
+        inferGgufQuantType(item.file)
+          .then((quantType) => {
+            if (quantType) handleUpdateFile(item.uuid, { quantType });
+          })
+          .catch(() => null);
+      }
+    }
   };
 
   const handleUpload = async ({
@@ -532,31 +573,40 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
           meta: { versionId, type, size, fp, format, quantType, isRequired, uuid },
         },
         async ({ meta, size, backend, ...result }) => {
-          const { versionId, type, uuid, ...metadata } = meta as {
-            versionId: number;
-            type: ModelFileType;
-            uuid: string;
+          const { versionId, uuid } = meta as { versionId: number; uuid: string };
+          if (!versionId) return;
+          // Read the latest metadata the user (or precision auto-detect) has set
+          // during the upload, falling back to what was captured at upload start.
+          // This is what makes auto-starting the upload on drop safe: the bytes go
+          // up immediately while type/precision can still be edited until save.
+          const latest = filesRef.current.find((x) => x.uuid === uuid);
+          const fileType = latest?.type ?? type;
+          if (!fileType) return;
+          const metadata = {
+            size: latest?.size ?? undefined,
+            fp: latest?.fp ?? undefined,
+            format: latest?.format ?? undefined,
+            quantType: latest?.quantType ?? undefined,
+            isRequired: latest?.isRequired ?? undefined,
           };
-          if (versionId) {
-            try {
-              const saved = await createFileMutation.mutateAsync({
-                ...result,
-                sizeKB: bytesToKB(size),
-                modelVersionId: versionId,
-                type,
-                metadata,
-                ...(backend === 'b2' ? { backend, s3Path: result.key } : {}),
-              });
-              setItems((items) => items.filter((x) => x.uuid !== result.uuid));
-              setFiles((state) =>
-                state.map((x) => (x.uuid === uuid ? { ...x, id: saved.id, isUploading: false } : x))
-              );
-            } catch (e: unknown) {
-              showErrorNotification({
-                title: 'Failed to save file',
-                error: e as Error,
-              });
-            }
+          try {
+            const saved = await createFileMutation.mutateAsync({
+              ...result,
+              sizeKB: bytesToKB(size),
+              modelVersionId: versionId,
+              type: fileType,
+              metadata,
+              ...(backend === 'b2' ? { backend, s3Path: result.key } : {}),
+            });
+            setItems((items) => items.filter((x) => x.uuid !== result.uuid));
+            setFiles((state) =>
+              state.map((x) => (x.uuid === uuid ? { ...x, id: saved.id, isUploading: false } : x))
+            );
+          } catch (e: unknown) {
+            showErrorNotification({
+              title: 'Failed to save file',
+              error: e as Error,
+            });
           }
         }
       );
@@ -585,6 +635,29 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
     if (!file) return;
     await handleUpload(file);
   };
+
+  // Auto-start byte uploads as soon as a file has enough info to upload (a type
+  // and a File object). The slow byte transfer overlaps with the user filling in
+  // metadata; the file record is saved on completion with the latest metadata.
+  // Failed uploads are NOT auto-restarted (their uuid stays in the started set) —
+  // the user retries explicitly via the file's retry button.
+  useEffect(() => {
+    if (!version?.id) return;
+    for (const file of files) {
+      if (
+        file.isPending &&
+        file.file &&
+        file.type &&
+        !file.id &&
+        !file.isUploading &&
+        !startedUploadsRef.current.has(file.uuid)
+      ) {
+        startedUploadsRef.current.add(file.uuid);
+        void handleUpload(file);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [files, version?.id]);
 
   const dropzoneConfig = dropzoneOptionsByModelType[model?.type ?? 'Checkpoint'];
 
@@ -691,6 +764,35 @@ function inferFileType(fileName: string, modelType?: ModelType | null): ModelFil
   }
 }
 
+
+/**
+ * Pick a default type for a file dropped into the Additional Components section so
+ * its upload can start immediately. We can't reliably tell a VAE from a Text
+ * Encoder by the file alone, so weight/unknown files default to the generic
+ * "Other" — the user refines it after the upload finishes. The chosen type is
+ * always one the section actually allows.
+ */
+function inferComponentFileType(
+  fileName: string,
+  allowedTypes: ModelFileType[]
+): ModelFileType | undefined {
+  const ext = getFileExtension(fileName);
+  const pick = (...candidates: ModelFileType[]) =>
+    candidates.find((type) => allowedTypes.includes(type));
+  switch (ext) {
+    case 'yaml':
+    case 'yml':
+    case 'json':
+    case 'txt':
+      return pick('Config', 'Other');
+    case 'zip':
+      return pick('Training Data', 'Archive', 'Other');
+    default:
+      // weights (.safetensors/.ckpt/.pt/.sft/.bin/.gguf/.onnx) and anything else
+      return pick('Other') ?? allowedTypes[0];
+  }
+}
+
 export type DropzoneSection = {
   extensions: string[];
   fileTypes: ModelFileType[];
@@ -725,6 +827,8 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
         'Text Encoder',
         'Workflow',
         'Upscaler',
+        'Enhancement LoRA',
+        'Other',
       ],
       maxFiles: 6,
     },
@@ -744,6 +848,8 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
         'UNet',
         'Diffusion Model',
         'CLIPVision',
+        'Enhancement LoRA',
+        'Other',
       ],
       maxFiles: 5,
     },
@@ -763,6 +869,8 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
         'UNet',
         'Diffusion Model',
         'CLIPVision',
+        'Enhancement LoRA',
+        'Other',
       ],
       maxFiles: 5,
     },
@@ -782,6 +890,8 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
         'UNet',
         'Diffusion Model',
         'CLIPVision',
+        'Enhancement LoRA',
+        'Other',
       ],
       maxFiles: 5,
     },
@@ -794,7 +904,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...archiveExts, ...configExts],
-      fileTypes: ['Training Data', 'Config'],
+      fileTypes: ['Training Data', 'Config', 'Other'],
       maxFiles: 2,
     },
   },
@@ -806,7 +916,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...archiveExts, ...configExts, ...modelExts],
-      fileTypes: ['Training Data', 'Config'],
+      fileTypes: ['Training Data', 'Config', 'Other'],
       maxFiles: 2,
     },
   },
@@ -818,7 +928,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...archiveExts, ...configExts, ...modelExts],
-      fileTypes: ['Training Data', 'Config'],
+      fileTypes: ['Training Data', 'Config', 'Other'],
       maxFiles: 2,
     },
   },
@@ -830,7 +940,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Archive', 'Config'],
+      fileTypes: ['Archive', 'Config', 'Other'],
       maxFiles: 2,
     },
   },
@@ -842,7 +952,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Archive', 'Config'],
+      fileTypes: ['Archive', 'Config', 'Other'],
       maxFiles: 1,
     },
   },
@@ -854,7 +964,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -866,7 +976,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -878,7 +988,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -890,7 +1000,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -902,7 +1012,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -914,7 +1024,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -926,7 +1036,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -938,7 +1048,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -950,7 +1060,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },
@@ -962,7 +1072,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
-      fileTypes: ['Config', 'Archive'],
+      fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
     },
   },

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -572,8 +572,19 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
           type: type === 'Model' ? UploadType.Model : UploadType.Default,
           meta: { versionId, type, size, fp, format, quantType, isRequired, uuid },
         },
-        async ({ meta, size, backend, ...result }) => {
-          const { versionId, uuid } = meta as { versionId: number; uuid: string };
+        async ({ meta, size: uploadedSize, backend, ...result }) => {
+          // `uploadedSize` is the byte size of the upload (renamed to avoid
+          // shadowing the `size` model-metadata field, which is 'full' | 'pruned').
+          const start = meta as {
+            versionId: number;
+            uuid: string;
+            size?: FileFromContextProps['size'];
+            fp?: FileFromContextProps['fp'];
+            format?: FileFromContextProps['format'];
+            quantType?: FileFromContextProps['quantType'];
+            isRequired?: FileFromContextProps['isRequired'];
+          };
+          const { versionId, uuid } = start;
           if (!versionId) return;
           // Read the latest metadata the user (or precision auto-detect) has set
           // during the upload, falling back to what was captured at upload start.
@@ -583,16 +594,16 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
           const fileType = latest?.type ?? type;
           if (!fileType) return;
           const metadata = {
-            size: latest?.size ?? undefined,
-            fp: latest?.fp ?? undefined,
-            format: latest?.format ?? undefined,
-            quantType: latest?.quantType ?? undefined,
-            isRequired: latest?.isRequired ?? undefined,
+            size: latest?.size ?? start.size ?? undefined,
+            fp: latest?.fp ?? start.fp ?? undefined,
+            format: latest?.format ?? start.format ?? undefined,
+            quantType: latest?.quantType ?? start.quantType ?? undefined,
+            isRequired: latest?.isRequired ?? start.isRequired ?? undefined,
           };
           try {
             const saved = await createFileMutation.mutateAsync({
               ...result,
-              sizeKB: bytesToKB(size),
+              sizeKB: bytesToKB(uploadedSize),
               modelVersionId: versionId,
               type: fileType,
               metadata,

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -46,7 +46,10 @@ import {
   nsfwRestrictedBaseModels,
 } from '~/server/common/constants';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
-import { getActiveBaseModels } from '~/shared/constants/basemodel.constants';
+import {
+  baseModelSupportsClipSkip,
+  getActiveBaseModels,
+} from '~/shared/constants/basemodel.constants';
 import type { ClubResourceSchema } from '~/server/schema/club.schema';
 import type { GenerationResourceSchema } from '~/server/schema/generation.schema';
 import { generationResourceSchema } from '~/server/schema/generation.schema';
@@ -217,6 +220,11 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
   // licensing-fee and early-access controls for these versions.
   const isNonCommercial = isNonCommercialBaseModel(baseModel);
   const recResources = form.watch('recommendedResources') ?? [];
+  // Clip skip only applies to SD1.x / SDXL-family base models — hide it elsewhere.
+  const showClipSkip = baseModelSupportsClipSkip(baseModel);
+  // Recommended Resources clutter the form; only surface the section when the
+  // version already has recommended resources set.
+  const showRecommendedResources = recResources.length > 0;
   const [minStrength, maxStrength] = form.watch([
     'settings.minStrength',
     'settings.maxStrength',
@@ -314,7 +322,8 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
 
       const result = await upsertVersionMutation.mutateAsync({
         ...data,
-        clipSkip: data.clipSkip ?? null,
+        // Don't persist a stale clip skip for base models that don't use it.
+        clipSkip: showClipSkip ? data.clipSkip ?? null : null,
         epochs: data.epochs ?? null,
         steps: data.steps ?? null,
         modelId: model?.id ?? -1,
@@ -938,59 +947,65 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
               />
             </Group>
           </Stack>
-          <Stack gap={4}>
-            <Divider label="Recommended Settings" />
-            <Group gap="xs" className="*:grow">
-              <InputNumber
-                name="clipSkip"
-                label="Clip Skip"
-                placeholder="Clip Skip"
-                min={1}
-                max={12}
-              />
-              {showStrengthInput && (
-                <Group w="100%" align="start" grow>
+          {(showClipSkip || showStrengthInput || showRecommendedResources) && (
+            <Stack gap={4}>
+              <Divider label="Recommended Settings" />
+              <Group gap="xs" className="*:grow">
+                {showClipSkip && (
                   <InputNumber
-                    name="settings.minStrength"
-                    label="Min Strength"
-                    min={-100}
-                    max={100}
-                    decimalScale={1}
-                    step={0.1}
+                    name="clipSkip"
+                    label="Clip Skip"
+                    placeholder="Clip Skip"
+                    min={1}
+                    max={12}
                   />
-                  <InputNumber
-                    name="settings.maxStrength"
-                    label="Max Strength"
-                    min={-100}
-                    max={100}
-                    decimalScale={1}
-                    step={0.1}
+                )}
+                {showStrengthInput && (
+                  <Group w="100%" align="start" grow>
+                    <InputNumber
+                      name="settings.minStrength"
+                      label="Min Strength"
+                      min={-100}
+                      max={100}
+                      decimalScale={1}
+                      step={0.1}
+                    />
+                    <InputNumber
+                      name="settings.maxStrength"
+                      label="Max Strength"
+                      min={-100}
+                      max={100}
+                      decimalScale={1}
+                      step={0.1}
+                    />
+                    <InputNumber
+                      name="settings.strength"
+                      label="Strength"
+                      min={minStrength ?? -1}
+                      max={maxStrength ?? 2}
+                      decimalScale={1}
+                      step={0.1}
+                    />
+                  </Group>
+                )}
+                {showRecommendedResources && (
+                  <InputResourceSelectMultiple
+                    name="recommendedResources"
+                    label="Resources"
+                    description="Select which resources work best with your model"
+                    selectSource="modelVersion"
+                    buttonLabel="Add resource"
+                    w="100%"
+                    limit={10}
+                    options={{
+                      resources: [{ type: ModelType.Checkpoint, baseModels: [baseModel] }],
+                      excludeIds: recResources.map((r) => r.id),
+                    }}
                   />
-                  <InputNumber
-                    name="settings.strength"
-                    label="Strength"
-                    min={minStrength ?? -1}
-                    max={maxStrength ?? 2}
-                    decimalScale={1}
-                    step={0.1}
-                  />
-                </Group>
-              )}
-              <InputResourceSelectMultiple
-                name="recommendedResources"
-                label="Resources"
-                description="Select which resources work best with your model"
-                selectSource="modelVersion"
-                buttonLabel="Add resource"
-                w="100%"
-                limit={10}
-                options={{
-                  resources: [{ type: ModelType.Checkpoint, baseModels: [baseModel] }],
-                  excludeIds: recResources.map((r) => r.id),
-                }}
-              />
-            </Group>
-          </Stack>
+                )}
+              </Group>
+            </Stack>
+          )}
           {modelDownloadEnabled && (
             <Stack gap={8}>
               <Divider label="Additional options" />

--- a/src/components/Resource/Forms/PostUpsertForm2.tsx
+++ b/src/components/Resource/Forms/PostUpsertForm2.tsx
@@ -23,7 +23,7 @@ export function PostUpsertForm2({
 }) {
   // #region [state]
   const router = useRouter();
-  const [postId, setPostId] = useState(initialPostId);
+  const [createdPostId, setCreatedPostId] = useState(initialPostId);
   const getFileUploadStatus = useS3UploadStore((state) => state.getStatus);
   const { uploading = 0 } = getFileUploadStatus((item) => item.meta?.versionId === modelVersionId);
   // #endregion
@@ -33,6 +33,13 @@ export function PostUpsertForm2({
     id: modelVersionId,
     withFiles: true,
   });
+
+  // Prefer the post that already exists for this version (freshest source) so
+  // navigating back to the upload step and forward again doesn't spin up a
+  // duplicate post. The locally-created id covers the gap within a single mount
+  // before the modelVersion query refetches.
+  const existingPostId = modelVersion?.posts?.[0]?.id ?? 0;
+  const postId = createdPostId || existingPostId;
 
   const { data, isInitialLoading } = trpc.post.getEdit.useQuery(
     { id: postId },
@@ -71,6 +78,8 @@ export function PostUpsertForm2({
   const isExternalGeneration =
     modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
   const hasFiles = !!modelVersion?.files?.length || isExternalGeneration;
+  // Publishing without files is allowed (the model is just not downloadable until
+  // files are added) — warn rather than block.
   const confirmPublish = isUploading || !hasFiles;
   const confirmMessage = isUploading
     ? 'Files are still uploading. Publishing now will make your model visible, but downloads will not work until uploads finish. Continue?'
@@ -125,7 +134,7 @@ export function PostUpsertForm2({
               Our site is mostly used for sharing AI generated content. Make sure the images you are
               sharing for this resource have been generated with it.
             </Text>
-            <PostImageDropzone onCreatePost={(post) => setPostId(post.id)} />
+            <PostImageDropzone onCreatePost={(post) => setCreatedPostId(post.id)} />
           </div>
         ) : (
           <PostEdit />

--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, LoadingOverlay, Popover, Stack, Stepper, Text, Title } from '@mantine/core';
 import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as z from 'zod';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { FeatureIntroductionHelpButton } from '~/components/FeatureIntroduction/FeatureIntroduction';
@@ -62,6 +62,9 @@ const CreateSteps = ({
   );
   const editing = !!model;
   const hasVersions = model && model.modelVersions.length > 0;
+  // Whether each later step's prerequisite data exists yet — used to let the user
+  // click forward to already-reachable steps (not just back via the indicator).
+  const hasFiles = !!model?.modelVersions?.some((version) => version.files.length > 0);
 
   // URL step → stepper-rendered index. When skipFiles=true the Files step (URL step 3)
   // is omitted, so URL step 4 (post) collapses to rendered index 2.
@@ -127,7 +130,7 @@ const CreateSteps = ({
       </Stepper.Step>
 
       {/* Step 2: Version Info */}
-      <Stepper.Step label={hasVersions ? 'Edit version' : 'Add version'}>
+      <Stepper.Step label={hasVersions ? 'Edit version' : 'Add version'} allowStepSelect={!!model}>
         <div className="container flex max-w-sm flex-col gap-3">
           <Title order={3}>{hasVersions ? 'Edit version' : 'Add version'}</Title>
           <ModelVersionUpsertForm
@@ -168,6 +171,7 @@ const CreateSteps = ({
           label="Upload files"
           loading={uploading > 0}
           color={error + aborted > 0 ? 'red' : undefined}
+          allowStepSelect={!!hasVersions}
         >
           <div className="container flex max-w-sm flex-col gap-3">
             <Title order={3}>Upload files</Title>
@@ -177,7 +181,10 @@ const CreateSteps = ({
         </Stepper.Step>
       )}
 
-      <Stepper.Step label={postId ? 'Edit post' : 'Create a post'}>
+      <Stepper.Step
+        label={postId ? 'Edit post' : 'Create a post'}
+        allowStepSelect={!!hasVersions && (hasFiles || skipFiles)}
+      >
         {model && modelVersion && (
           <PostUpsertForm2 postId={postId} modelVersionId={modelVersion.id} modelId={model.id} />
         )}
@@ -380,11 +387,21 @@ export function ModelWizard() {
   // CreateSteps stepper and the auto-redirect effect agree on the same step layout.
   const skipFiles = modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
 
+  // Only auto-resume to the furthest valid step ONCE, when the model first loads.
+  // Without this guard the effect re-runs on every `model` refetch — e.g. when a
+  // file upload completes and invalidates the model query — yanking the user
+  // forward to the next step. Forward navigation is now user-driven (Next button
+  // or clicking a reachable step indicator).
+  const autoResumedRef = useRef(false);
+
   useEffect(() => {
     // redirect to correct step if missing values
     if (!isNew) {
       // don't redirect for trained type or if model is not loaded
       if (isTraining || !model) return;
+      // resume only once per mount — never push the user forward mid-session
+      if (autoResumedRef.current) return;
+      autoResumedRef.current = true;
 
       const hasVersions = model.modelVersions.length > 0;
       const hasFiles = model.modelVersions.some((version) => version.files.length > 0);

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -65,6 +65,8 @@ export const constants = {
     'ControlNet',
     'Workflow',
     'Upscaler',
+    'Enhancement LoRA',
+    'Other',
   ],
   trainingMediaTypes: ['image', 'video', 'audio'],
   trainingModelTypes: ['Character', 'Style', 'Concept', 'Effect'],
@@ -134,6 +136,8 @@ export const constants = {
     ControlNet: 11,
     Workflow: 12,
     Upscaler: 13,
+    'Enhancement LoRA': 14,
+    Other: 15,
   },
   cardSizes: {
     model: 320,
@@ -467,6 +471,7 @@ export const componentFileTypes = [
   'CLIPVision',
   'ControlNet',
   'Upscaler',
+  'Enhancement LoRA',
 ] as const;
 export type ComponentFileType = (typeof componentFileTypes)[number];
 

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -3258,6 +3258,23 @@ export function getRootEcosystem(ecosystemIdOrBaseModel: number | string): Ecosy
   return ecosystem;
 }
 
+
+/**
+ * Clip skip is a CLIP text-encoder concept that only applies to the Stable
+ * Diffusion 1.x and SDXL families (SDXL children like Pony, Illustrious and
+ * NoobAI resolve to the SDXL root). Returns false for everything else
+ * (Flux, SD3, video ecosystems, etc.) and for unknown base models.
+ */
+export function baseModelSupportsClipSkip(baseModel?: string | null): boolean {
+  if (!baseModel) return false;
+  try {
+    const root = getRootEcosystem(baseModel);
+    return root.id === ECO.SD1 || root.id === ECO.SDXL;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Get ecosystem support, with inheritance from parent
  */

--- a/src/utils/file-display-helpers.ts
+++ b/src/utils/file-display-helpers.ts
@@ -63,6 +63,7 @@ export const comfyFileTypeLabels: Record<string, string> = {
   CLIPVision: 'CLIP Vision',
   Workflow: 'Workflow',
   Upscaler: 'Upscale Model',
+  'Enhancement LoRA': 'Enhancement LoRA',
 };
 
 /**
@@ -121,6 +122,7 @@ export function filterFileTypeByExtension(value: ModelFileType, fileName: string
   switch (extension) {
     case 'ckpt':
     case 'safetensors':
+    case 'sft':
     case 'pt':
     case 'gguf':
     case 'onnx':
@@ -135,14 +137,16 @@ export function filterFileTypeByExtension(value: ModelFileType, fileName: string
         'ControlNet',
         'Upscaler',
         'Text Encoder',
+        'Enhancement LoRA',
+        'Other',
       ].includes(value);
     case 'zip':
-      return ['Training Data', 'Archive', 'Model', 'Workflow'].includes(value);
+      return ['Training Data', 'Archive', 'Model', 'Workflow', 'Other'].includes(value);
     case 'yml':
     case 'yaml':
     case 'json':
     case 'txt':
-      return ['Config', 'Text Encoder', 'Workflow'].includes(value);
+      return ['Config', 'Text Encoder', 'Workflow', 'Other'].includes(value);
     default:
       return true;
   }

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -10,6 +10,227 @@ export function getModelFileFormat(filename: string): ModelFileFormat {
   return 'Other';
 }
 
+/** Map a safetensors dtype string to a ModelFileFp precision value. */
+function safetensorsDtypeToFp(dtype: string): ModelFileFp | null {
+  const d = dtype.toUpperCase();
+  if (d === 'F16') return 'fp16';
+  if (d === 'BF16') return 'bf16';
+  if (d === 'F32' || d === 'F64') return 'fp32';
+  if (d.startsWith('F8')) return 'fp8';
+  return null;
+}
+
+/**
+ * Read a .safetensors file's header (client-side) and infer the dominant weight
+ * precision (fp16/bf16/fp32/fp8). Returns null when it can't be determined.
+ * Only the JSON header is read — never the tensor data — so this is cheap.
+ */
+export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp | null> {
+  try {
+    const name = file.name.toLowerCase();
+    if (!name.endsWith('.safetensors') && !name.endsWith('.sft')) return null;
+
+    // First 8 bytes: little-endian uint64 header length.
+    const lenBuf = await file.slice(0, 8).arrayBuffer();
+    if (lenBuf.byteLength < 8) return null;
+    const headerLen = Number(new DataView(lenBuf).getBigUint64(0, true));
+    // Guard against corrupt/absurd header sizes (cap at 64MB).
+    if (!Number.isFinite(headerLen) || headerLen <= 0 || headerLen > 64 * 1024 * 1024) return null;
+
+    const headerBuf = await file.slice(8, 8 + headerLen).arrayBuffer();
+    const header = JSON.parse(new TextDecoder().decode(headerBuf)) as Record<
+      string,
+      { dtype?: string; data_offsets?: [number, number] }
+    >;
+
+    // Pick the dtype that accounts for the most bytes of tensor data.
+    const bytesByFp = new Map<ModelFileFp, number>();
+    for (const [key, value] of Object.entries(header)) {
+      if (key === '__metadata__' || !value?.dtype) continue;
+      const fp = safetensorsDtypeToFp(value.dtype);
+      if (!fp) continue;
+      const offsets = value.data_offsets;
+      const size = Array.isArray(offsets) && offsets.length === 2 ? offsets[1] - offsets[0] : 1;
+      bytesByFp.set(fp, (bytesByFp.get(fp) ?? 0) + Math.max(size, 0));
+    }
+
+    let best: ModelFileFp | null = null;
+    let bestBytes = -1;
+    for (const [fp, bytes] of bytesByFp) {
+      if (bytes > bestBytes) {
+        best = fp;
+        bestBytes = bytes;
+      }
+    }
+    return best;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Maps llama.cpp's LLAMA_FTYPE enum (stored in GGUF `general.file_type`) to the
+ * quant-type strings the upload form offers. Unquantized ftypes (F32/F16/BF16)
+ * and quant schemes not in the form are intentionally omitted -> no auto-fill.
+ * Source: llama.cpp include/llama.h.
+ */
+const GGUF_FTYPE_TO_QUANT: Record<number, ModelFileQuantType> = {
+  2: 'Q4_0',
+  3: 'Q4_1',
+  7: 'Q8_0',
+  8: 'Q5_0',
+  9: 'Q5_1',
+  10: 'Q2_K',
+  11: 'Q3_K_S',
+  12: 'Q3_K_M',
+  13: 'Q3_K_L',
+  14: 'Q4_K_S',
+  15: 'Q4_K_M',
+  16: 'Q5_K_S',
+  17: 'Q5_K_M',
+  18: 'Q6_K',
+  19: 'IQ2_XXS',
+  20: 'IQ2_XS',
+  21: 'Q2_K_S',
+  22: 'IQ3_XS',
+  23: 'IQ3_XXS',
+  24: 'IQ1_S',
+  25: 'IQ4_NL',
+  28: 'IQ2_S',
+  29: 'IQ2_M',
+  30: 'IQ4_XS',
+  31: 'IQ1_M',
+};
+
+// Thrown when the parser runs past the chunk we've read so far, signalling the
+// caller to read a larger chunk and retry.
+class GgufNeedMoreBytes extends Error {}
+
+/** Read `general.file_type` from the GGUF metadata header of a byte chunk. */
+function readGgufFileType(bytes: Uint8Array): number | null {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const decoder = new TextDecoder();
+  let off = 0;
+  const need = (n: number) => {
+    if (off + n > bytes.length) throw new GgufNeedMoreBytes();
+  };
+  const u32 = () => {
+    need(4);
+    const v = view.getUint32(off, true);
+    off += 4;
+    return v;
+  };
+  const u64 = () => {
+    need(8);
+    const lo = view.getUint32(off, true);
+    const hi = view.getUint32(off + 4, true);
+    off += 8;
+    return hi * 2 ** 32 + lo;
+  };
+  const readStr = () => {
+    const len = u64();
+    need(len);
+    const s = decoder.decode(bytes.subarray(off, off + len));
+    off += len;
+    return s;
+  };
+  const skipValue = (valueType: number) => {
+    switch (valueType) {
+      case 0: // uint8
+      case 1: // int8
+      case 7: // bool
+        need(1);
+        off += 1;
+        return;
+      case 2: // uint16
+      case 3: // int16
+        need(2);
+        off += 2;
+        return;
+      case 4: // uint32
+      case 5: // int32
+      case 6: // float32
+        need(4);
+        off += 4;
+        return;
+      case 8: {
+        // string
+        const len = u64();
+        need(len);
+        off += len;
+        return;
+      }
+      case 9: {
+        // array
+        const itemType = u32();
+        const count = u64();
+        if (count > 50_000_000) throw new Error('GGUF metadata array is too large');
+        for (let i = 0; i < count; i++) skipValue(itemType);
+        return;
+      }
+      case 10: // uint64
+      case 11: // int64
+      case 12: // float64
+        need(8);
+        off += 8;
+        return;
+      default:
+        throw new Error(`Unsupported GGUF metadata value type ${valueType}`);
+    }
+  };
+
+  need(4);
+  if (String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]) !== 'GGUF') return null;
+  off = 4;
+  u32(); // version
+  u64(); // tensor count
+  const metadataCount = u64();
+  if (metadataCount > 1_000_000) return null;
+
+  for (let i = 0; i < metadataCount; i++) {
+    const key = readStr();
+    const valueType = u32();
+    if (key === 'general.file_type') {
+      // file_type is written as UINT32 (4); accept INT32 (5) defensively.
+      if (valueType === 4 || valueType === 5) return u32();
+      skipValue(valueType);
+      return null;
+    }
+    skipValue(valueType);
+  }
+  return null;
+}
+
+/**
+ * Read a .gguf file's header (client-side) and infer the quantization type from
+ * `general.file_type`. Returns null when it can't be determined. Only the header
+ * is read (growing the chunk if needed), never the tensor data.
+ */
+export async function inferGgufQuantType(file: File): Promise<ModelFileQuantType | null> {
+  if (!file.name.toLowerCase().endsWith('.gguf')) return null;
+  // `general.*` keys come first by convention, so file_type is usually within the
+  // first few KB — but grow the read if it sits past large tokenizer arrays.
+  const chunkSizes = [256 * 1024, 4 * 1024 * 1024, 32 * 1024 * 1024];
+  for (const chunkSize of chunkSizes) {
+    const readSize = Math.min(chunkSize, file.size);
+    let bytes: Uint8Array;
+    try {
+      bytes = new Uint8Array(await file.slice(0, readSize).arrayBuffer());
+    } catch {
+      return null;
+    }
+    try {
+      const ftype = readGgufFileType(bytes);
+      return ftype != null ? GGUF_FTYPE_TO_QUANT[ftype] ?? null : null;
+    } catch (e) {
+      // Only retry with a bigger chunk if there are more bytes to read.
+      if (e instanceof GgufNeedMoreBytes && readSize < file.size) continue;
+      return null;
+    }
+  }
+  return null;
+}
+
 const unscannedFile = {
   scannedAt: null,
   scanRequestedAt: null,


### PR DESCRIPTION
Addresses model create wizard / version form / file upload feedback from [868k336b9](https://app.clickup.com/t/868k336b9).

Highlights:
- Clip skip shown only for SD1.5/SDXL-family base models; recommended-resources hidden unless populated
- New "Enhancement LoRA" + "Other" model file types
- Auto-detect precision (safetensors) / quant type (GGUF) on drop; auto-start uploads on drop with metadata editable mid-upload (incomplete files flagged "Needs info")
- Forward stepper navigation; no longer auto-advances the step when an upload completes
- Fix duplicate post creation on wizard back/forward
- Publishing without files still allowed (soft warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)