### PR TITLE
fix(orchestrator): map transient upstream 5xx/network failures to 503 instead of raw 500

### DIFF
--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -72,10 +72,24 @@ const trpcHandler = createNextApiHandler({
       // stringify + Axiom ingest would add event-loop pressure during the exact
       // storm the bulkhead exists to relieve. The `civitai_app_heavy_bulkhead_rejects`
       // gauge already carries the signal, so skip the ingest here too.
+      //
+      // SERVICE_UNAVAILABLE is the transient-upstream mapping (orchestrator 5xx /
+      // network blip → 503; see workflows.ts). It is retry-able + self-describing,
+      // and the continuously-polled `orchestrator.statusUpdate` turns one upstream
+      // blip into a sustained wave of 503 rejects — paying full stack-capture +
+      // JSON.stringify(input) + Axiom ingest per reject would add event-loop
+      // pressure during the exact outage (the same failure mode TOO_MANY_REQUESTS
+      // skips for). The 503 status itself, the preserved `cause`, and the
+      // `redis_commands_inflight` cluster gauge already carry the diagnostic
+      // signal, so the per-reject ingest is pure event-loop cost — skip it. (This
+      // skips ONLY the Axiom ingest: recordTrpcError above still counts the 503 in
+      // civitai_app_http_errors_total{status="503"}, and the client still gets a
+      // real 503.)
       if (
         error.code === 'FORBIDDEN' ||
         error.code === 'UNAUTHORIZED' ||
-        error.code === 'TOO_MANY_REQUESTS'
+        error.code === 'TOO_MANY_REQUESTS' ||
+        error.code === 'SERVICE_UNAVAILABLE'
       ) {
         return error;
       }

--- a/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// Mock ONLY the generated client + the orchestrator client factory + env so we can
+// drive `getWorkflow` / `queryWorkflows` through their error branches. The real
+// `~/server/utils/errorHandling` loads so the actual TRPCError mapping is exercised.
+const { mockGetWorkflow, mockQueryWorkflows } = vi.hoisted(() => ({
+  mockGetWorkflow: vi.fn(),
+  mockQueryWorkflows: vi.fn(),
+}));
+
+vi.mock('@civitai/client', () => ({
+  getWorkflow: mockGetWorkflow,
+  queryWorkflows: mockQueryWorkflows,
+  // unused-by-these-tests named exports referenced at module load
+  addWorkflowTag: vi.fn(),
+  deleteWorkflow: vi.fn(),
+  patchWorkflow: vi.fn(),
+  removeWorkflowTag: vi.fn(),
+  submitWorkflow: vi.fn(),
+  updateWorkflow: vi.fn(),
+  handleError: vi.fn(),
+}));
+
+vi.mock('~/server/services/orchestrator/client', () => ({
+  createOrchestratorClient: vi.fn(() => ({})),
+  internalOrchestratorClient: {},
+}));
+
+vi.mock('~/env/other', () => ({ isDev: false, isProd: true }));
+
+import { getWorkflow, queryWorkflows } from '~/server/services/orchestrator/workflows';
+
+const baseQueryArgs = {
+  token: 'tok',
+  hideMatureContent: false,
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getWorkflow error mapping', () => {
+  it('maps an upstream 5xx (status>=500) to SERVICE_UNAVAILABLE (503), preserving cause', async () => {
+    // Repro of the real prod signature: empty-message raw error + upstream status 500.
+    const upstreamError = { status: 500, detail: 'Internal Server Error' };
+    mockGetWorkflow.mockResolvedValue({ data: undefined, error: upstreamError });
+
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).message).toMatch(/temporarily unavailable/i);
+    // tRPC v11 wraps a non-Error cause in UnknownCauseError, copying its props —
+    // the original upstream error stays diagnosable (status/detail preserved).
+    expect((err as TRPCError).cause).toMatchObject(upstreamError);
+  });
+
+  it('maps a status-less network rejection (fetch failed) to 503', async () => {
+    mockGetWorkflow.mockRejectedValue(new TypeError('fetch failed'));
+
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).cause).toBeInstanceOf(TypeError);
+  });
+
+  it('keeps a 404 mapped as NOT_FOUND (not 503)', async () => {
+    mockGetWorkflow.mockResolvedValue({
+      data: undefined,
+      error: { status: 404, detail: 'gone' },
+    });
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect((err as TRPCError).code).toBe('NOT_FOUND');
+  });
+
+  it('keeps a 400 mapped as BAD_REQUEST (not 503)', async () => {
+    mockGetWorkflow.mockResolvedValue({
+      data: undefined,
+      error: { status: 400, detail: 'bad' },
+    });
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect((err as TRPCError).code).toBe('BAD_REQUEST');
+  });
+
+  it('keeps an unhandled 4xx (422) as BAD_REQUEST, not 503', async () => {
+    mockGetWorkflow.mockResolvedValue({
+      data: undefined,
+      error: { status: 422, detail: 'unprocessable' },
+    });
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect((err as TRPCError).code).toBe('BAD_REQUEST');
+  });
+
+  it('does NOT 503 a genuine code-bug throw — it surfaces as-is (→ 500)', async () => {
+    const bug = new TypeError("Cannot read properties of undefined (reading 'x')");
+    mockGetWorkflow.mockRejectedValue(bug);
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect(err).toBe(bug); // re-thrown raw; tRPC will map to INTERNAL_SERVER_ERROR
+    expect(err).not.toBeInstanceOf(TRPCError);
+  });
+
+  it('returns data on the success path untouched', async () => {
+    mockGetWorkflow.mockResolvedValue({ data: { id: 'wf-1', status: 'succeeded' } });
+    const data = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } });
+    expect(data).toEqual({ id: 'wf-1', status: 'succeeded' });
+  });
+});
+
+describe('queryWorkflows error mapping (queryGeneratedImages path)', () => {
+  it('maps an upstream 5xx to SERVICE_UNAVAILABLE (503)', async () => {
+    const upstreamError = { status: 503, detail: '' };
+    mockQueryWorkflows.mockResolvedValue({ data: undefined, error: upstreamError });
+    const err = await queryWorkflows(baseQueryArgs).catch((e) => e);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).cause).toMatchObject(upstreamError);
+  });
+
+  it('maps a network rejection to 503', async () => {
+    mockQueryWorkflows.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+      })
+    );
+    const err = await queryWorkflows(baseQueryArgs).catch((e) => e);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('keeps a 404 as NOT_FOUND, not 503', async () => {
+    mockQueryWorkflows.mockResolvedValue({
+      data: undefined,
+      error: { status: 404, detail: 'gone' },
+    });
+    const err = await queryWorkflows(baseQueryArgs).catch((e) => e);
+    expect((err as TRPCError).code).toBe('NOT_FOUND');
+  });
+
+  it('does NOT 503 a genuine code-bug throw', async () => {
+    const bug = new TypeError('boom is not a function');
+    mockQueryWorkflows.mockRejectedValue(bug);
+    const err = await queryWorkflows(baseQueryArgs).catch((e) => e);
+    expect(err).toBe(bug);
+  });
+});

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -26,13 +26,23 @@ import type {
 } from '~/server/schema/orchestrator/workflows.schema';
 import { createOrchestratorClient } from '~/server/services/orchestrator/client';
 import {
+  isUpstreamNetworkError,
+  isUpstreamServerOrNetworkError,
   throwAuthorizationError,
   throwBadRequestError,
   throwInsufficientFundsError,
   throwInternalServerError,
   throwNotFoundError,
   throwRateLimitError,
+  throwServiceUnavailableError,
 } from '~/server/utils/errorHandling';
+
+// Stable, user-facing copy for a transient orchestrator outage (HTTP 503). Shared
+// by every read path that funnels through this module (getWorkflow → statusUpdate;
+// queryWorkflows → queryGeneratedImages) so a brief upstream blip becomes one
+// retry-able message instead of a wave of raw 500s with an empty body.
+const ORCHESTRATOR_UNAVAILABLE_MESSAGE =
+  'Generation services are temporarily unavailable. Please try again.';
 
 export async function queryWorkflows({
   token,
@@ -50,8 +60,14 @@ export async function queryWorkflows({
       fromDate: fromDate?.toISOString(),
       toDate: toDate?.toISOString(),
     },
-  }).catch((error) => {
-    throw error;
+  }).catch((thrown) => {
+    // A rejected client call has no HTTP status. A recognized NETWORK failure
+    // (fetch failed / ECONNREFUSED / timeout) is a transient upstream outage →
+    // retry-able 503, not an app 500. An unrecognized throw (a real bug in our
+    // code) is left to bubble as a 500.
+    if (isUpstreamNetworkError(thrown))
+      throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, thrown);
+    throw thrown;
   });
   if (!data) {
     switch (error.status) {
@@ -72,9 +88,16 @@ export async function queryWorkflows({
           throw throwInternalServerError('Generation services down');
         // An unhandled 4xx is a client/validation fault (e.g. a 404 on a deleted or
         // not-owned workflow) — surface as 4xx, not a re-thrown raw error that tRPC
-        // maps to 500. Genuine 5xx / status-less failures stay a server error.
+        // maps to 500.
         if (typeof error.status === 'number' && error.status >= 400 && error.status < 500)
           throw throwBadRequestError(error.detail);
+        // A genuine upstream 5xx (or status-less network fault) is a transient
+        // dependency outage — surface as a retry-able 503 so the polling client
+        // backs off, instead of a raw 500 with an empty message that counts
+        // against our 500 SLO. Unexpected/unclassified errors still fall through
+        // to a raw re-throw (→ 500) so real bugs stay visible.
+        if (isUpstreamServerOrNetworkError({ clientError: error, thrown: error }))
+          throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, error);
         throw error;
     }
   }
@@ -89,7 +112,16 @@ export async function getWorkflow({
   query,
 }: Options<GetWorkflowData> & { token: string }) {
   const client = createOrchestratorClient(token);
-  const { data, error } = await clientGetWorkflow({ client, path, query });
+  const { data, error } = await clientGetWorkflow({ client, path, query }).catch((thrown) => {
+    // The generated client REJECTS (no `{ data, error }` result) when the fetch
+    // itself fails — e.g. orchestrator unreachable. The statusUpdate poll fires
+    // continuously, so a brief blip here otherwise becomes a wave of raw 500s
+    // (TypeError: fetch failed). A recognized network failure → retry-able 503;
+    // an unrecognized throw (a real bug) bubbles as a 500.
+    if (isUpstreamNetworkError(thrown))
+      throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, thrown);
+    throw thrown;
+  });
   if (!data) {
     switch (error.status) {
       case 400:
@@ -109,9 +141,18 @@ export async function getWorkflow({
           throw throwInternalServerError('Generation services down');
         // An unhandled 4xx is a client/validation fault (e.g. a 404 on a deleted or
         // not-owned workflow) — surface as 4xx, not a re-thrown raw error that tRPC
-        // maps to 500. Genuine 5xx / status-less failures stay a server error.
+        // maps to 500.
         if (typeof error.status === 'number' && error.status >= 400 && error.status < 500)
           throw throwBadRequestError(error.detail);
+        // A genuine upstream 5xx (or status-less network fault) is a transient
+        // dependency outage — surface as a retry-able 503 (SERVICE_UNAVAILABLE)
+        // with a stable message + the original error preserved as `cause`,
+        // instead of re-throwing the raw client error (empty message → tRPC
+        // INTERNAL_SERVER_ERROR 500 against our 500 SLO). This is the wave-of-500s
+        // root cause for orchestrator.statusUpdate. Unclassified errors still
+        // re-throw raw (→ 500) so genuine code bugs stay visible.
+        if (isUpstreamServerOrNetworkError({ clientError: error, thrown: error }))
+          throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, error);
         throw error;
     }
   }

--- a/src/server/utils/__tests__/errorHandling.upstream-classify.test.ts
+++ b/src/server/utils/__tests__/errorHandling.upstream-classify.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isUpstreamNetworkError,
+  isUpstreamServerOrNetworkError,
+} from '~/server/utils/errorHandling';
+
+// Pure classifier tests — these gate whether an orchestrator-client failure is
+// treated as a transient upstream outage (→ 503) vs. left to surface as a 500.
+// They have no env/Prisma dependencies beyond the module under test.
+
+describe('isUpstreamNetworkError', () => {
+  it('matches the canonical undici "fetch failed" TypeError', () => {
+    const err = new TypeError('fetch failed');
+    expect(isUpstreamNetworkError(err)).toBe(true);
+  });
+
+  it('matches a fetch failed whose syscall is nested under .cause', () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 10.0.0.1:443'), {
+      code: 'ECONNREFUSED',
+    });
+    const err = Object.assign(new TypeError('fetch failed'), { cause });
+    expect(isUpstreamNetworkError(err)).toBe(true);
+  });
+
+  it.each([
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ENOTFOUND',
+    'EAI_AGAIN',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_SOCKET',
+  ])('matches a top-level error carrying network code %s', (code) => {
+    const err = Object.assign(new Error('socket error'), { code });
+    expect(isUpstreamNetworkError(err)).toBe(true);
+  });
+
+  it('matches an AbortError / request-timeout with no HTTP status', () => {
+    const abort = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    expect(isUpstreamNetworkError(abort)).toBe(true);
+    const timeout = Object.assign(new Error('timeout'), { name: 'TimeoutError' });
+    expect(isUpstreamNetworkError(timeout)).toBe(true);
+  });
+
+  it('does NOT match a genuine application bug (plain TypeError from our code)', () => {
+    // e.g. `Cannot read properties of undefined (reading 'status')` thrown by a
+    // real bug in our mapping logic — must stay a 500, never be 503'd.
+    const bug = new TypeError("Cannot read properties of undefined (reading 'foo')");
+    expect(isUpstreamNetworkError(bug)).toBe(false);
+  });
+
+  it('does NOT match an arbitrary Error / a 4xx-ish detail string', () => {
+    expect(isUpstreamNetworkError(new Error('Bad Request'))).toBe(false);
+    expect(isUpstreamNetworkError(new Error('Internal Server Error'))).toBe(false);
+    expect(isUpstreamNetworkError('some string')).toBe(false);
+    expect(isUpstreamNetworkError(undefined)).toBe(false);
+    expect(isUpstreamNetworkError(null)).toBe(false);
+  });
+
+  it('does not infinite-loop on a self-referential cause chain', () => {
+    const err: any = new Error('weird');
+    err.cause = err;
+    expect(isUpstreamNetworkError(err)).toBe(false);
+  });
+});
+
+describe('isUpstreamServerOrNetworkError', () => {
+  it('treats an upstream HTTP status >= 500 as upstream fault', () => {
+    expect(isUpstreamServerOrNetworkError({ clientError: { status: 500 } })).toBe(true);
+    expect(isUpstreamServerOrNetworkError({ clientError: { status: 502 } })).toBe(true);
+    expect(isUpstreamServerOrNetworkError({ clientError: { status: 503 } })).toBe(true);
+  });
+
+  it('does NOT treat a 4xx as an upstream fault (keep mapped client code)', () => {
+    expect(isUpstreamServerOrNetworkError({ clientError: { status: 400 } })).toBe(false);
+    expect(isUpstreamServerOrNetworkError({ clientError: { status: 404 } })).toBe(false);
+    expect(isUpstreamServerOrNetworkError({ clientError: { status: 429 } })).toBe(false);
+  });
+
+  it('treats a status-less thrown network failure as upstream fault', () => {
+    expect(isUpstreamServerOrNetworkError({ thrown: new TypeError('fetch failed') })).toBe(true);
+  });
+
+  it('does NOT treat a status-less unexpected throw (real bug) as upstream fault', () => {
+    expect(
+      isUpstreamServerOrNetworkError({ thrown: new TypeError('x is not a function') })
+    ).toBe(false);
+    expect(isUpstreamServerOrNetworkError({ clientError: null })).toBe(false);
+    expect(isUpstreamServerOrNetworkError({})).toBe(false);
+  });
+});

--- a/src/server/utils/errorHandling.ts
+++ b/src/server/utils/errorHandling.ts
@@ -208,6 +208,101 @@ export function throwConflictError(message: string | null = null, error?: unknow
   });
 }
 
+/**
+ * Surface a transient dependency outage as TRPCError SERVICE_UNAVAILABLE (HTTP 503,
+ * retry-able) instead of a raw INTERNAL_SERVER_ERROR (500). 503 tells a polling
+ * client "temporarily unavailable, back off and retry" and keeps a dependency's
+ * own 5xx / network blip from counting against this app's 500 SLO.
+ *
+ * Always pass the original error as `cause` so it stays diagnosable in logs.
+ */
+export function throwServiceUnavailableError(message: string | null = null, error?: unknown) {
+  message ??= 'This service is temporarily unavailable. Please try again.';
+  throw new TRPCError({
+    code: 'SERVICE_UNAVAILABLE',
+    message,
+    cause: error,
+  });
+}
+
+/**
+ * True when an error is a status-less NETWORK failure reaching an upstream HTTP
+ * dependency — the TCP/DNS/TLS layer failed before any HTTP response came back, so
+ * there is no HTTP status to key off. The Node/undici fetch surfaces these as a
+ * bare `TypeError: fetch failed` whose `.cause` carries the real syscall
+ * (`ECONNREFUSED`/`ETIMEDOUT`/`ENOTFOUND`/`ECONNRESET`/`EAI_AGAIN`), or as an
+ * `AbortError`/timeout.
+ *
+ * This is intentionally NARROW: it matches ONLY recognized network signatures, so a
+ * genuine `TypeError` thrown by OUR OWN code (a real bug — e.g. reading a property
+ * of undefined) does NOT match and is left to surface as a 500. We never blanket-
+ * convert "any thrown error" to a network failure.
+ */
+export function isUpstreamNetworkError(e: unknown): boolean {
+  const NETWORK_CODES = new Set([
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'ENOTFOUND',
+    'EAI_AGAIN',
+    'EHOSTUNREACH',
+    'ENETUNREACH',
+    'EPIPE',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_SOCKET',
+    'UND_ERR_HEADERS_TIMEOUT',
+    'UND_ERR_BODY_TIMEOUT',
+  ]);
+  // Walk the `.cause` chain (undici nests the syscall error under TypeError.cause).
+  let cur = e as { name?: string; message?: string; code?: string; cause?: unknown } | undefined;
+  for (let depth = 0; depth < 4 && cur && typeof cur === 'object'; depth++) {
+    if (typeof cur.code === 'string' && NETWORK_CODES.has(cur.code)) return true;
+    const msg = typeof cur.message === 'string' ? cur.message : '';
+    // The canonical undici/fetch network-failure signature.
+    if (msg === 'fetch failed' || msg.includes('fetch failed')) return true;
+    if (msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT') || msg.includes('ENOTFOUND'))
+      return true;
+    // A request-timeout / abort with no HTTP status is also a transient reach
+    // failure (e.g. an orchestrator request that timed out before a response).
+    if (
+      cur.name === 'AbortError' ||
+      cur.name === 'TimeoutError' ||
+      msg === 'The operation was aborted' ||
+      msg === 'This operation was aborted'
+    )
+      return true;
+    cur = cur.cause as typeof cur;
+  }
+  return false;
+}
+
+/**
+ * Decides whether an orchestrator-client failure represents a genuine UPSTREAM
+ * server fault or network failure (→ should be surfaced as a retry-able 503) vs.
+ * something we should leave alone.
+ *
+ * Returns true ONLY for:
+ *  - a client error object carrying an HTTP `status >= 500` (upstream 5xx), or
+ *  - a status-less network failure (see {@link isUpstreamNetworkError}).
+ *
+ * Returns false for 4xx (client/validation faults — keep their mapped codes) and
+ * for unrecognized errors (a real bug in our code → keep surfacing as 500).
+ *
+ * `clientError` is the `{ status?, detail? }`-shaped object from the generated
+ * client's `{ data, error }` result; `thrown` is an error caught from a rejected
+ * client call (network failures arrive this way, with no `status`).
+ */
+export function isUpstreamServerOrNetworkError(args: {
+  clientError?: { status?: unknown } | null;
+  thrown?: unknown;
+}): boolean {
+  const { clientError, thrown } = args;
+  const status = clientError?.status;
+  if (typeof status === 'number' && status >= 500) return true;
+  if (thrown !== undefined && isUpstreamNetworkError(thrown)) return true;
+  return false;
+}
+
 export function handleLogError(e: Error, name?: string, details?: MixedObject) {
   const error = new Error(e.message ?? 'Unexpected error occurred', { cause: e });
   if (isProd)


### PR DESCRIPTION
## Problem

On dp-prod, an episodic burst of api-primary HTTP **500s** comes from the generation/orchestrator procedures (`orchestrator.statusUpdate`, `whatIfFromGraph`, `generateFromGraph`, `queryGeneratedImages`) whenever the orchestrator backend has a transient **5xx / network** blip.

Root cause: `getWorkflow()` / `queryWorkflows()` in `src/server/services/orchestrator/workflows.ts` re-threw the **raw generated-client error** (empty `message`) on any non-4xx outcome. tRPC wrapped that as `INTERNAL_SERVER_ERROR` (HTTP 500, empty body). The `statusUpdate` poll fires continuously, so a brief upstream blip becomes a wave of user 500s.

Confirmed in prod: of 400 sampled `statusUpdate` ISEs, **385 had empty message+cause**, **15 were `TypeError: fetch failed`**; the FromGraph cause was the literal `"Internal Server Error"` from upstream.

## Fix

A transient dependency outage is not an application fault. Map it to a retry-able **`SERVICE_UNAVAILABLE` (HTTP 503)** with a stable user-facing message ("Generation services are temporarily unavailable. Please try again.") and the **original error preserved as `cause`**. 503 tells the polling client to back off, and stops these blips from counting against the app 500 SLO. This is the standard "don't surface a dependency's 5xx as your own 500" pattern (already used for Meili in `image.service.ts`).

### How upstream-fault vs. real-bug is distinguished (scoped, NOT a blanket convert)
- client error carrying HTTP **`status >= 500`** → 503
- **status-less network failure** (new `isUpstreamNetworkError`: `fetch failed`, `ECONNREFUSED`/`ETIMEDOUT`/`ENOTFOUND`/`ECONNRESET`/`EAI_AGAIN`/abort/undici codes, walked over the `.cause` chain) → 503
- **4xx branches unchanged** (BAD_REQUEST / UNAUTHORIZED / NOT_FOUND / TOO_MANY_REQUESTS keep their correct client codes)
- an **unrecognized throw** (e.g. a genuine `TypeError` in our own mapping logic) still re-throws raw → tRPC 500, so real bugs stay visible

### Coverage
Every read path funneling through this module:
- `orchestrator.statusUpdate` → `getWorkflowStatusUpdate` → **`getWorkflow`**
- `queryGeneratedImages` → `queryGeneratedImageWorkflows2` → **`queryWorkflows`**

`getWorkflow` also gained a `.catch` so a network rejection (which previously never reached the status switch and escaped raw) is classified. `submitWorkflow` (generate/whatIf) keeps its own existing error handling and is intentionally out of scope.

### New helpers (`src/server/utils/errorHandling.ts`)
`throwServiceUnavailableError`, `isUpstreamNetworkError`, `isUpstreamServerOrNetworkError`.

## Tests
- `errorHandling.upstream-classify.test.ts` — pure classifier (network signatures incl. nested `.cause`; rejects plain code-bug TypeErrors; 5xx-yes / 4xx-no; self-referential cause loop guard).
- `workflows.error-mapping.test.ts` — `getWorkflow`/`queryWorkflows` integration: upstream 5xx **and** `fetch failed` → 503 with cause preserved; 4xx (400/404/422) keeps its mapped code; an unexpected throw surfaces as-is (not 503); success path untouched.

**28 new tests pass**; full orchestrator + utils unit suites pass (227) with no regressions. Typecheck: repo has ~5265 pre-existing `tsc` errors locally (missing generated Prisma types); a base-vs-tip diff shows **zero new errors in any changed file** (the 12-in/12-out churn is all in unrelated files = `tsc` inference shuffle). CI is authoritative.

## Accuracy correction — this does NOT remove 503 from the 5xx floor

The earlier framing ("stops these blips from counting against the app 500 SLO") overstates the effect. A 503 is **still a 5xx**:
- `src/server/prom/http-errors.ts` `recordTrpcError` increments `civitai_app_http_errors_total` for **any** status `>= 500`, so the mapped error now increments `{status="503"}` (it previously incremented `{status="500"}`).
- Traefik `traefik_service_requests_total{code=~"5.."}` also still counts 503.

So nothing is removed from the raw 5xx floor by this PR. The genuine, real benefits are:
1. **Correct, retry-able code** — the polling client backs off on a 503 instead of erroring on a 500.
2. **Diagnosable cause preserved** — no more empty-message/empty-cause 500.
3. **SLO separability** — `status="500"` (app faults) is now distinguishable from `status="503"` (transient upstream) **if/when a dashboard splits the counter by `status`**. No dashboard change is included in this PR, so until that filter exists, these still show up in the undifferentiated 5xx floor.

## Follow-up (audit fix, this branch): skip 503 from the onError Axiom fast-path

Added in `86b0913` — `src/pages/api/trpc/[trpc].ts`. The continuously-polled `orchestrator.statusUpdate` turns one upstream blip into a sustained wave of `SERVICE_UNAVAILABLE` rejects, and 503 was **not** in the onError Axiom-ingest skip set, so each reject paid full stack-capture + `JSON.stringify(input)` + `await logToAxiom` on the event loop during the exact outage — the same event-loop-pressure failure mode `TOO_MANY_REQUESTS` already skips for. `SERVICE_UNAVAILABLE` is now in that skip set (joining `FORBIDDEN`/`UNAUTHORIZED`/`TOO_MANY_REQUESTS`). This skips **only** the Axiom ingest: `recordTrpcError` (called earlier in `onError`) still counts the 503 in the Prom counter above, and the HTTP 503 returned to the client is unchanged. The 503 status + preserved `cause` + the `redis_commands_inflight` cluster gauge carry the diagnostic signal, so the per-reject ingest is pure event-loop cost. (Skip-set change covered by inspection — there is no existing onError unit test in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
