### PR TITLE
fix(download): return 404/fail-soft instead of 500 on recoverable download errors (URI-malformed, orphan-relation, redis-deadline)

### DIFF
--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -101,6 +101,18 @@ export default PublicEndpoint(
       });
 
       if (fileResult.status === 'not-found') return errorResponse(404, 'File not found');
+      if (fileResult.status === 'resolve-failed') {
+        // Same 404 as `not-found`, but this 404 came from a delivery-worker /
+        // storage-resolver resolve FAILURE, which can be TRANSIENT (a storage
+        // outage, not a permanently-missing file). PublicEndpoint set a default
+        // `Cache-Control: public, s-maxage=300, …` before this handler ran;
+        // override it with `no-store` so a transient resolve failure is NOT
+        // edge-cached as "File not found" for ~5 min for a file that exists.
+        // setHeader (last-write-wins, headers not yet flushed) overrides the
+        // PublicEndpoint default. Deterministic by-id `not-found` stays cacheable.
+        res.setHeader('Cache-Control', 'private, no-store');
+        return errorResponse(404, 'File not found');
+      }
       if (fileResult.status === 'archived')
         return errorResponse(410, 'Model archived, not available for download');
       if (fileResult.status === 'early-access') {

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -137,6 +137,7 @@ function getStatusCode(
     case 'archived':
       return 410;
     case 'not-found':
+    case 'resolve-failed':
       return 404;
     default:
       return 500;
@@ -156,6 +157,7 @@ function getErrorMessage(
     case 'archived':
       return 'Model archived, not available';
     case 'not-found':
+    case 'resolve-failed':
       return 'File not found';
     default:
       return 'Error getting file';

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// file.service.ts imports `@prisma/client` (type-only) plus a wide graph that
+// calls Prisma runtime helpers at module load. Mirror the house stub pattern
+// (see prisma-inconsistent-orphan-relations.test) so the externalised
+// @prisma/client doesn't blow up at SSR import time.
+vi.mock('@prisma/client', () => {
+  const validator = () => (x: unknown) => x;
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+    sql: strings.join('?'),
+  });
+  const raw = (s: string) => ({ sql: s, values: [] });
+  const join = (values: unknown[], separator = ',') => ({ values, separator });
+  const empty = { sql: '', values: [] };
+  class Sql {}
+  const known: Record<string, unknown> = {
+    validator,
+    sql,
+    raw,
+    join,
+    empty,
+    Sql,
+    SortOrder: { asc: 'asc', desc: 'desc' },
+    QueryMode: { default: 'default', insensitive: 'insensitive' },
+    JsonNull: 'JsonNull',
+    DbNull: 'DbNull',
+    AnyNull: 'AnyNull',
+  };
+  const Prisma = new Proxy(known, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop];
+      return {};
+    },
+  });
+  return new Proxy(
+    { Prisma, PrismaClient: class PrismaClient {} },
+    {
+      get(target, prop: string) {
+        if (prop in target) return (target as Record<string, unknown>)[prop];
+        if (prop === '__esModule') return true;
+        return {};
+      },
+    }
+  );
+});
+
+const modelVersionFindFirst = vi.fn();
+const modelFileFindMany = vi.fn();
+const modelFileFindFirst = vi.fn();
+const recommendedResourceFindFirst = vi.fn();
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    modelVersion: { findFirst: modelVersionFindFirst },
+    modelFile: { findMany: modelFileFindMany, findFirst: modelFileFindFirst },
+    recommendedResource: { findFirst: recommendedResourceFindFirst },
+  },
+  dbWrite: {},
+}));
+
+// Entity-access check: grant access by default so the happy path reaches the
+// file lookup + URL resolution.
+const hasEntityAccessMock = vi.fn();
+vi.mock('../common.service', () => ({
+  hasEntityAccess: hasEntityAccessMock,
+}));
+
+// file.service imports getBountyEntryFilteredFiles from bountyEntry.service,
+// which transitively pulls image.service → ../../../event-engine-common/feeds
+// (a separate workspace package not resolvable from this import chain). It's
+// only used by getFilesForModelVersion, NOT the getFileForModelVersion lookup
+// under test — stub it so the module graph loads.
+vi.mock('~/server/services/bountyEntry.service', () => ({
+  getBountyEntryFilteredFiles: vi.fn(),
+}));
+
+// Control whether the delivery URL resolves. A throw here is the
+// "genuinely unresolvable URL" case the fix must turn into a 404 (`not-found`),
+// NOT a 500 (`error`).
+const resolveDownloadUrlMock = vi.fn();
+vi.mock('~/utils/delivery-worker', () => ({
+  resolveDownloadUrl: resolveDownloadUrlMock,
+}));
+
+// The global setup mocks logToAxiom but not safeError (used in the resolve
+// catch). Provide both so the unresolvable-URL path logs without throwing.
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+  safeError: (err: unknown) => ({ name: 'Error', message: String(err) }),
+}));
+
+function publishedModelVersion(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    status: 'Published',
+    model: {
+      id: 10,
+      name: 'Test Model',
+      type: 'Checkpoint',
+      publishedAt: new Date(),
+      status: 'Published',
+      userId: 999,
+      mode: null,
+      nsfw: false,
+      availability: 'Public',
+      poi: false,
+    },
+    name: 'v1',
+    trainedWords: [],
+    earlyAccessEndsAt: null,
+    earlyAccessConfig: null,
+    createdAt: new Date(),
+    requireAuth: false,
+    usageControl: 'Download',
+    ...overrides,
+  };
+}
+
+const aFile = {
+  id: 55,
+  url: 'https://abcd1234.r2.cloudflarestorage.com/civitai/files/x.safetensors',
+  name: 'x.safetensors',
+  overrideName: null,
+  type: 'Model',
+  metadata: { format: 'SafeTensor' },
+  hashes: [{ hash: 'abc' }],
+};
+
+// timeout: the first dynamic import cold-transforms a large module graph.
+describe('getFileForModelVersion — orphan model relation + unresolvable URL', { timeout: 30000 }, () => {
+  beforeEach(() => {
+    modelVersionFindFirst.mockReset();
+    modelFileFindMany.mockReset();
+    modelFileFindFirst.mockReset();
+    recommendedResourceFindFirst.mockReset();
+    hasEntityAccessMock.mockReset();
+    resolveDownloadUrlMock.mockReset();
+
+    hasEntityAccessMock.mockResolvedValue([{ hasAccess: true, permissions: 0 }]);
+    modelFileFindMany.mockResolvedValue([aFile]);
+  });
+
+  // --- Fix #4: orphaned ModelVersion.model -------------------------------
+  it('passes a `model: { is: {} }` existence filter so orphaned-model versions are dropped at the DB', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    resolveDownloadUrlMock.mockResolvedValue({ url: 'https://cdn/ok', urlExpiryDate: new Date() });
+
+    const { getFileForModelVersion } = await import('../file.service');
+    await getFileForModelVersion({ modelVersionId: 1, noAuth: true });
+
+    expect(modelVersionFindFirst).toHaveBeenCalledTimes(1);
+    const args = modelVersionFindFirst.mock.calls[0][0];
+    // The load-bearing fix: without `model: { is: {} }`, a version whose `model`
+    // FK points at a deleted Model makes Prisma throw "Inconsistent query result:
+    // Field model is required to return data, got null" → 500.
+    expect(args.where.model).toEqual({ is: {} });
+  });
+
+  it('returns not-found (→404) when the orphan filter drops the row (findFirst → null)', async () => {
+    // Post-fix DB behaviour: an orphan-model version is filtered out, so findFirst
+    // returns null instead of throwing. The handler maps that to `not-found`.
+    modelVersionFindFirst.mockResolvedValue(null);
+
+    const { getFileForModelVersion } = await import('../file.service');
+    const result = await getFileForModelVersion({ modelVersionId: 1, noAuth: true });
+
+    expect(result.status).toBe('not-found');
+  });
+
+  // --- Fix #3: genuinely-unresolvable delivery URL -----------------------
+  it('returns not-found (→404), NOT error (→500), when the delivery URL cannot be resolved', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    // Both storage-resolver and delivery-worker rejected → resolveDownloadUrl throws.
+    resolveDownloadUrlMock.mockRejectedValue(new Error('Delivery worker error: Not Found'));
+
+    const { getFileForModelVersion } = await import('../file.service');
+    // Authenticated owner-or-mod so the request passes the auth gate and reaches
+    // URL resolution (where the unresolvable-URL → not-found routing lives).
+    const result = await getFileForModelVersion({
+      modelVersionId: 1,
+      noAuth: true,
+      user: { id: 1, isModerator: true },
+    });
+
+    // A broken/missing delivery URL is a not-found, not a server fault.
+    expect(result.status).toBe('not-found');
+    expect(result.status).not.toBe('error');
+  });
+
+  it('returns success with the resolved url on the happy path', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    resolveDownloadUrlMock.mockResolvedValue({
+      url: 'https://cdn.example.com/signed',
+      urlExpiryDate: new Date(),
+    });
+
+    const { getFileForModelVersion } = await import('../file.service');
+    const result = await getFileForModelVersion({
+      modelVersionId: 1,
+      noAuth: true,
+      user: { id: 1, isModerator: true },
+    });
+
+    expect(result.status).toBe('success');
+    if (result.status === 'success') expect(result.url).toBe('https://cdn.example.com/signed');
+  });
+});

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -170,23 +170,29 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
   });
 
   // --- Fix #3: genuinely-unresolvable delivery URL -----------------------
-  it('returns not-found (→404), NOT error (→500), when the delivery URL cannot be resolved', async () => {
+  it('returns resolve-failed (→404 no-store), NOT error (→500), when the delivery URL cannot be resolved', async () => {
     modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
     // Both storage-resolver and delivery-worker rejected → resolveDownloadUrl throws.
     resolveDownloadUrlMock.mockRejectedValue(new Error('Delivery worker error: Not Found'));
 
     const { getFileForModelVersion } = await import('../file.service');
     // Authenticated owner-or-mod so the request passes the auth gate and reaches
-    // URL resolution (where the unresolvable-URL → not-found routing lives).
+    // URL resolution (where the unresolvable-URL → resolve-failed routing lives).
     const result = await getFileForModelVersion({
       modelVersionId: 1,
       noAuth: true,
       user: { id: 1, isModerator: true },
     });
 
-    // A broken/missing delivery URL is a not-found, not a server fault.
-    expect(result.status).toBe('not-found');
+    // A broken/missing delivery URL is not a server fault (still 404 at the
+    // endpoint), but it gets a DISTINCT status from the deterministic by-id
+    // not-found so the endpoint can mark it `Cache-Control: no-store` — a
+    // resolve failure can be TRANSIENT (storage outage) and must not be
+    // edge-cached for 5 min.
+    expect(result.status).toBe('resolve-failed');
     expect(result.status).not.toBe('error');
+    // Distinct from the deterministic not-found (which stays CDN-cacheable).
+    expect(result.status).not.toBe('not-found');
   });
 
   it('returns success with the resolved url on the happy path', async () => {

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -349,6 +349,15 @@ export const getFileForModelVersion = async ({
     // 404, not 500. `resolveDownloadUrl` no longer throws `URI malformed` on a
     // malformed/already-encoded URL (delivery-worker now decodes best-effort),
     // so reaching this catch means the file genuinely can't be resolved.
+    //
+    // Use a DISTINCT `resolve-failed` status (not the deterministic `not-found`)
+    // so the endpoint can mark this 404 `Cache-Control: no-store`. This catch
+    // fires on TRANSIENT delivery-worker/storage-resolver non-2xx too (a storage
+    // outage, not just a permanently-broken URL); under `PublicEndpoint`'s default
+    // `s-maxage=300` a transient failure would otherwise let the CDN edge-cache
+    // "File not found" for ~5 min for a file that actually exists, even after the
+    // backend recovers. The deterministic by-id `not-found` stays cacheable.
+    //
     // Still log so the leak is visible in production. safeError includes
     // `name: 'Error'` which must be spread BEFORE our literal `name` or the
     // event name gets overwritten.
@@ -363,7 +372,7 @@ export const getFileForModelVersion = async ({
       fileType: file.type,
       userId: user?.id,
     }).catch(() => undefined);
-    return { status: 'not-found' };
+    return { status: 'resolve-failed' };
   }
 };
 
@@ -417,7 +426,13 @@ export function getDownloadFilename({
 
 type ModelVersionFileResult =
   | {
-      status: 'not-found' | 'unauthorized' | 'archived' | 'downloads-disabled' | 'error';
+      status:
+        | 'not-found'
+        | 'resolve-failed'
+        | 'unauthorized'
+        | 'archived'
+        | 'downloads-disabled'
+        | 'error';
     }
   | {
       status: 'early-access';

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -174,7 +174,16 @@ export const getFileForModelVersion = async ({
   fileId?: number;
 }): Promise<ModelVersionFileResult> => {
   const modelVersion = await dbRead.modelVersion.findFirst({
-    where: { id: modelVersionId },
+    // `model: { is: {} }` requires the (required) `model` relation to exist.
+    // Without it, a ModelVersion whose `model` was hard-deleted (orphaned FK)
+    // makes Prisma throw "Inconsistent query result: Field model is required to
+    // return data, got null" at query execution → caught upstream → 500 on every
+    // download lookup for that version. With the filter the DB drops the orphan
+    // row, findFirst returns null, and we fall through to the `not-found` (404)
+    // branch below — a model-less version is genuinely not downloadable. Same
+    // class/fix as #2637 (relation-existence filter on orphaned required
+    // relations).
+    where: { id: modelVersionId, model: { is: {} } },
     select: {
       id: true,
       status: true,
@@ -334,9 +343,15 @@ export const getFileForModelVersion = async ({
   } catch (err) {
     // Both storage-resolver and delivery-worker fallback rejected this file —
     // usually an un-registered `file_locations` row on a bucket the
-    // delivery-worker doesn't know. Log so the leak is visible in production.
-    // safeError includes `name: 'Error'` which must be spread BEFORE our
-    // literal `name` or the event name gets overwritten.
+    // delivery-worker doesn't know, or a stored `file.url` whose delivery URL no
+    // longer resolves. A broken/missing delivery URL is a *not-found* (the file
+    // is not deliverable), NOT a server fault — so the endpoint should answer
+    // 404, not 500. `resolveDownloadUrl` no longer throws `URI malformed` on a
+    // malformed/already-encoded URL (delivery-worker now decodes best-effort),
+    // so reaching this catch means the file genuinely can't be resolved.
+    // Still log so the leak is visible in production. safeError includes
+    // `name: 'Error'` which must be spread BEFORE our literal `name` or the
+    // event name gets overwritten.
     logToAxiom({
       type: 'error',
       ...safeError(err),
@@ -348,7 +363,7 @@ export const getFileForModelVersion = async ({
       fileType: file.type,
       userId: user?.id,
     }).catch(() => undefined);
-    return { status: 'error' };
+    return { status: 'not-found' };
   }
 };
 

--- a/src/server/services/orchestrator/__tests__/legacy-metadata-mapper-images-guard.test.ts
+++ b/src/server/services/orchestrator/__tests__/legacy-metadata-mapper-images-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { mapDataToGraphInput } from '../legacy-metadata-mapper';
+
+/**
+ * Regression for `generation.getGenerationData` → "e.images.map is not a function".
+ *
+ * `mapDataToGraphInput` shapes historic params into graph input. The `images`
+ * field is *typed* as an array but can be a non-array in malformed/legacy stored
+ * params; a bare `p.images.map(...)` then throws and the whole getGenerationData
+ * call 500s. The fix only maps when `images` is actually an array.
+ */
+describe('mapDataToGraphInput — non-array images guard', () => {
+  it('does not throw when params.images is a non-array object', () => {
+    expect(() =>
+      mapDataToGraphInput({ prompt: 'x', images: { 0: { url: 'u' } } as unknown }, [])
+    ).not.toThrow();
+  });
+
+  it('does not throw when params.images is a string', () => {
+    expect(() =>
+      mapDataToGraphInput({ prompt: 'x', images: 'not-an-array' as unknown }, [])
+    ).not.toThrow();
+  });
+
+  it('still maps a well-formed images array', () => {
+    const out = mapDataToGraphInput(
+      { prompt: 'x', images: [{ url: 'http://a/img.png', width: 64, height: 48 }] },
+      []
+    );
+    expect(out.images).toEqual([{ url: 'http://a/img.png', width: 64, height: 48 }]);
+  });
+
+  it('leaves images undefined for a non-array (no partial/garbage mapping)', () => {
+    const out = mapDataToGraphInput({ prompt: 'x', images: 123 as unknown }, []);
+    expect(out.images).toBeUndefined();
+  });
+});

--- a/src/server/services/orchestrator/legacy-metadata-mapper.ts
+++ b/src/server/services/orchestrator/legacy-metadata-mapper.ts
@@ -542,7 +542,11 @@ export function mapDataToGraphInput(
         height: p.sourceImage.height,
       },
     ];
-  } else if (p?.images) {
+  } else if (Array.isArray(p?.images)) {
+    // Guard against a non-array `images` (malformed/legacy stored params): a bare
+    // `p.images.map(...)` throws "e.images.map is not a function" while shaping
+    // generation data → generation.getGenerationData 500s. Only map when it's
+    // actually an array; otherwise leave images undefined.
     images = p.images.map((img) => ({
       url: img.url,
       width: img.width,

--- a/src/server/utils/__tests__/public-endpoint-cache-override.test.ts
+++ b/src/server/utils/__tests__/public-endpoint-cache-override.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Audit fix for PR #2664: the model-download endpoint uses `PublicEndpoint`,
+ * whose wrapper sets `Cache-Control: public, s-maxage=300, …` on EVERY response
+ * BEFORE the handler runs. PR #2664 turns a delivery-worker / storage-resolver
+ * resolve FAILURE into a 404. Because a resolve failure can be TRANSIENT (a
+ * storage outage, not a permanently-missing file), that 404 must NOT be
+ * CDN-edge-cached for 5 min — the endpoint sets `Cache-Control: no-store` on the
+ * `resolve-failed` path specifically.
+ *
+ * This test pins the load-bearing mechanism: a `res.setHeader('Cache-Control', …)`
+ * INSIDE the handler overrides the `PublicEndpoint` default (last-write-wins;
+ * headers are not flushed until the handler sends). It exercises the REAL
+ * `PublicEndpoint` wrapper, with only the heavy module-load imports stubbed.
+ */
+
+// endpoint-helpers.ts pulls a wide server graph at module load (env, db, auth,
+// axiom, prom). Stub the pieces that touch real infra so the module imports in
+// isolation. withAxiom must invoke the handler; instrumentApiResponse is a
+// no-op here.
+vi.mock('@civitai/next-axiom', () => ({
+  withAxiom:
+    (handler: (...args: unknown[]) => unknown) =>
+    (...args: unknown[]) =>
+      handler(...args),
+}));
+// `allowedOrigins` at module load spreads `env.TRPC_ORIGINS` (must be iterable)
+// and reads `env.NEXTAUTH_URL`; default everything else to undefined.
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ TRPC_ORIGINS: [] as string[], NEXTAUTH_URL: undefined } as Record<
+    string,
+    unknown
+  >, { get: (t, p: string) => (p in t ? t[p] : undefined) }),
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/db-helpers', () => ({ checkNotUpToDate: vi.fn() }));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/auth/get-server-auth-session', () => ({ getServerAuthSession: vi.fn() }));
+vi.mock('~/server/utils/key-generator', () => ({ generateSecretHash: vi.fn() }));
+vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: vi.fn(() => []) }));
+vi.mock('~/server/prom/http-errors', () => ({ instrumentApiResponse: vi.fn() }));
+vi.mock('~/server/utils/errorHandling', () => ({ isClientAbortError: vi.fn(() => false) }));
+
+import { PublicEndpoint } from '../endpoint-helpers';
+
+type HeaderBag = Record<string, string | string[]>;
+
+function makeReqRes(method = 'GET') {
+  const headers: HeaderBag = {};
+  const req = { method, headers: {}, query: {} } as never;
+  const res = {
+    setHeader: vi.fn((k: string, v: string | string[]) => {
+      headers[k] = v;
+    }),
+    getHeader: (k: string) => headers[k],
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+  } as never;
+  return { req, res, headers };
+}
+
+describe('PublicEndpoint Cache-Control override (PR #2664 resolve-failed 404)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sets the public s-maxage cache header by default (the cacheable deterministic 404 path)', async () => {
+    const { req, res, headers } = makeReqRes();
+    const handler = PublicEndpoint(async () => undefined, ['GET']);
+
+    await handler(req, res);
+
+    // This is the default a deterministic by-id `not-found` 404 keeps — stable,
+    // safe to edge-cache.
+    expect(headers['Cache-Control']).toBe(
+      'public, s-maxage=300, stale-while-revalidate=150'
+    );
+  });
+
+  it('lets a handler override the default with no-store (the transient resolve-failed 404 path)', async () => {
+    const { req, res, headers } = makeReqRes();
+    const handler = PublicEndpoint(async (_req, response) => {
+      // Mirrors the endpoint's `resolve-failed` branch: override the
+      // PublicEndpoint default so a transient resolve failure is NOT edge-cached.
+      response.setHeader('Cache-Control', 'private, no-store');
+      response.status(404).send('File not found');
+    }, ['GET']);
+
+    await handler(req, res);
+
+    // The override WINS: setHeader replaces, and the handler runs AFTER
+    // addPublicCacheHeaders, before any flush.
+    expect(headers['Cache-Control']).toBe('private, no-store');
+    expect(headers['Cache-Control']).not.toContain('s-maxage');
+  });
+});

--- a/src/utils/__tests__/delivery-worker.test.ts
+++ b/src/utils/__tests__/delivery-worker.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Concrete endpoints so the module-load constants resolve and the resolver/
+// delivery-worker branches are reachable. Any field we don't set falls back to
+// the global env Proxy in src/__tests__/setup.ts.
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    {
+      DELIVERY_WORKER_ENDPOINT: 'https://delivery.example.com/',
+      DELIVERY_WORKER_TOKEN: 'tok',
+      STORAGE_RESOLVER_ENDPOINT: '', // disabled by default → delivery-worker path
+      STORAGE_RESOLVER_AUTH: '',
+      S3_UPLOAD_ENDPOINT: 'https://abcd1234.r2.cloudflarestorage.com',
+      S3_UPLOAD_B2_ENDPOINT: 'https://s3.us-west-004.backblazeb2.com',
+      // s3-utils → db/client is transitively imported and reads env.LOGGING.filter
+      // (array) at module load; provide an empty array so the prisma-log builder
+      // is a no-op.
+      LOGGING: [],
+    } as Record<string, unknown>,
+    {
+      get(target, prop: string) {
+        if (prop in target) return target[prop];
+        return undefined;
+      },
+    }
+  ),
+}));
+
+// delivery-worker imports parseKey from s3-utils, which imports db/client and
+// instantiates a real PrismaClient at module load. Stub the db client so the
+// import graph doesn't need `prisma generate` (mirrors s3-utils.test).
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: {},
+}));
+
+import { getDownloadUrl, resolveDownloadUrl, safeDecodeURIComponent } from '../delivery-worker';
+
+describe('safeDecodeURIComponent', () => {
+  it('decodes a well-formed encoded value', () => {
+    expect(safeDecodeURIComponent('a%20b')).toBe('a b');
+  });
+
+  it('does NOT throw on a malformed percent-sequence — returns the raw value', () => {
+    // `decodeURIComponent('%E0%A4%A')` and `decodeURIComponent('100%')` both throw
+    // `URIError: URI malformed`. The safe wrapper must fall back to the raw input.
+    expect(() => safeDecodeURIComponent('%E0%A4%A')).not.toThrow();
+    expect(safeDecodeURIComponent('%E0%A4%A')).toBe('%E0%A4%A');
+    expect(safeDecodeURIComponent('files/100%-done.safetensors')).toBe(
+      'files/100%-done.safetensors'
+    );
+  });
+
+  it('leaves an already-decoded value unchanged', () => {
+    expect(safeDecodeURIComponent('plain/name.safetensors')).toBe('plain/name.safetensors');
+  });
+});
+
+describe('getDownloadUrl — malformed file.url / filename no longer 500s', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function okResponse(url: string) {
+    return {
+      ok: true,
+      json: async () => ({ url, urlExpiryDate: new Date().toISOString() }),
+    } as unknown as Response;
+  }
+
+  it('resolves (does not throw URI malformed) when the key has a bad percent-sequence', async () => {
+    fetchMock.mockResolvedValue(okResponse('https://cdn.example.com/signed'));
+
+    // A stored URL whose key contains a lone/truncated `%` — pre-fix this threw
+    // `URIError: URI malformed` at `decodeURIComponent(key)` before any fetch.
+    const result = await getDownloadUrl(
+      'https://abcd1234.r2.cloudflarestorage.com/civitai/files/bad%2.safetensors',
+      'name%E0%A4%A.safetensors'
+    );
+
+    expect(result.url).toBe('https://cdn.example.com/signed');
+    expect(fetchMock).toHaveBeenCalled();
+    // The request body must carry a string (raw fallback), never throw while
+    // building it.
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(typeof body.fileName).toBe('string');
+  });
+
+  it('throws (→ caller treats as not-found) when the delivery worker rejects every key', async () => {
+    fetchMock.mockResolvedValue({ ok: false, statusText: 'Not Found' } as unknown as Response);
+
+    await expect(
+      getDownloadUrl('https://abcd1234.r2.cloudflarestorage.com/civitai/files/x.safetensors')
+    ).rejects.toThrow(/Delivery worker error/);
+  });
+});
+
+describe('resolveDownloadUrl — falls back to delivery worker when resolver disabled', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not throw URI malformed for a malformed filename on the resolver-disabled path', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://cdn.example.com/ok', urlExpiryDate: new Date().toISOString() }),
+    } as unknown as Response);
+
+    const result = await resolveDownloadUrl(
+      123,
+      'https://abcd1234.r2.cloudflarestorage.com/civitai/files/y.safetensors',
+      'weird%name%.safetensors'
+    );
+    expect(result.url).toBe('https://cdn.example.com/ok');
+  });
+});

--- a/src/utils/delivery-worker.ts
+++ b/src/utils/delivery-worker.ts
@@ -10,6 +10,23 @@ export type DownloadInfo = {
   urlExpiryDate: Date;
 };
 
+/**
+ * `decodeURIComponent` throws `URIError: URI malformed` on a value with a
+ * broken/truncated percent-sequence (e.g. a lone `%`, `%E0%A4%A`). Some stored
+ * `file.url` / filename values are already-encoded or contain raw `%` literals,
+ * so a bare `decodeURIComponent` on the download path throws → caught upstream →
+ * 500 on every download of that file. Decode best-effort: when decoding is not
+ * possible, fall back to the raw value (the storage-resolver / delivery-worker
+ * can still resolve it from the raw key) instead of throwing.
+ */
+export function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 export type BucketInfo = {
   name: string;
   createdDate: Date;
@@ -34,7 +51,7 @@ export async function getDownloadUrlByFileId(
 
   const body = JSON.stringify({
     fileId,
-    fileName: fileName ? decodeURIComponent(fileName) : undefined,
+    fileName: fileName ? safeDecodeURIComponent(fileName) : undefined,
   });
 
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -95,8 +112,11 @@ export async function resolveDownloadUrl(
  */
 export async function getDownloadUrl(fileUrl: string, fileName?: string) {
   const { key } = parseKey(fileUrl);
-  // Some of our old file keys should not be decoded.
-  const keys = [decodeURIComponent(key), key];
+  // Some of our old file keys should not be decoded. `safeDecodeURIComponent`
+  // never throws on a malformed/already-encoded key — it falls back to the raw
+  // key, which is already the second candidate, so a bad key still tries the raw
+  // form instead of 500ing the whole download.
+  const keys = [safeDecodeURIComponent(key), key];
 
   let i = 0;
   let response: Response = new Response();
@@ -105,7 +125,7 @@ export async function getDownloadUrl(fileUrl: string, fileName?: string) {
   while (i < keys.length) {
     const body = JSON.stringify({
       key: keys[i],
-      fileName: fileName ? decodeURIComponent(fileName) : undefined,
+      fileName: fileName ? safeDecodeURIComponent(fileName) : undefined,
     });
 
     response = await fetch(deliveryWorkerEndpoint, {


### PR DESCRIPTION
## Goal
Kill the chronic dp-prod **500 floor on the model-download path** (`/api/download/models/[id]`) and one tiny sibling (`generation.getGenerationData`). These are recoverable, data-driven conditions currently returning HTTP 500; they should return 404 or degrade gracefully. Deterministic/structural, minimal blast radius — no download-authorization logic changed.

## Changes

### #3 — `URI malformed` 500s (primary)
- `src/utils/delivery-worker.ts`: `decodeURIComponent(key|fileName)` throws `URIError: URI malformed` on stored URLs with broken/truncated/already-encoded percent-sequences (e.g. lone `%`, `%E0%A4%A`) → caught upstream → `resolveDownloadUrl` throws → endpoint 500s every download of those files. Added `safeDecodeURIComponent` (try/catch, falls back to the **raw** value) and used it at all three decode sites (`getDownloadUrlByFileId` fileName; `getDownloadUrl` key + fileName). The raw key is already the second delivery-worker candidate, so a malformed key still resolves instead of 500ing.
- `src/server/services/file.service.ts` (resolve-failure catch in `getFileForModelVersion`): a genuinely **unresolvable** delivery URL now returns `status: 'not-found'` (→ **404 "File not found"**) instead of `status: 'error'` (→ 500). A broken/missing delivery URL is a not-found, not a server fault. The endpoint already maps `not-found`→404. Axiom logging retained.

### #4 — Prisma orphan-relation on the download lookup
- `src/server/services/file.service.ts`: `getFileForModelVersion`'s `modelVersion.findFirst` selects the **required** `model` relation; a version whose Model was hard-deleted makes Prisma throw `Inconsistent query result: Field model is required to return data, got null` → 500. Added `{ model: { is: {} } }` to the `where` (mirrors **#2637**) so the DB drops the orphan row → `findFirst` returns null → existing `not-found`→404 branch handles it.

### #5 — `generation.getGenerationData` → `e.images.map is not a function`
- `src/server/services/orchestrator/legacy-metadata-mapper.ts:545`: `mapDataToGraphInput` called `p.images.map(...)` on a non-array `images` (malformed/legacy stored params) → throws → 500. Guarded with `Array.isArray(p?.images)`.

### #2 — redis 15s-deadline on the download path — SECURITY DETERMINATION, **NO code change**
Investigated exactly what redis does on this path. Two redis touchpoints, neither is the cluster wedge and neither is a new fail-soft opportunity:
- **`downloadLimiter.hasExceededLimit`** (`src/pages/api/download/models/[modelVersionId].ts:80`) — this is an **abuse / rate-limit GATE**, not a cache read. Per the security gate it must **NOT** be fail-softed open further. It is **already correctly fail-soft** (`createLimiter` in `src/server/utils/rate-limiting.ts`: on a sysRedis error / `withSysReadDeadline` timeout it logs via `logSysRedisFailOpen('rate-limit-write-degraded', …)` and returns `false` = "not exceeded = serve", shipped in PR #2643). It runs on the **single-node `sysRedis`** client, not next-redis-cluster.
- **`bustUserDownloadsCache`** (line 174) — best-effort, already `.catch()`-swallowed.

There is **no next-redis-cluster call on the download path**, so the "15s cluster command deadline" premise doesn't apply here, and the rate-limit gate is intentionally left as-is (failing it further open would weaken abuse protection). The residual 500 risk on this path is the resolve/orphan/decode classes above, which this PR fixes.

## Tests
- `src/utils/__tests__/delivery-worker.test.ts` — `safeDecodeURIComponent` never throws on malformed percent-sequences (returns raw); `getDownloadUrl`/`resolveDownloadUrl` resolve (no `URI malformed`) on a malformed key/filename; delivery-worker rejecting every key still throws (→ caller routes to not-found).
- `src/server/services/__tests__/file-download-lookup.test.ts` — the `{ model: { is: {} } }` filter is present on the lookup; orphan→null→`not-found`; **unresolvable URL → `not-found`, NOT `error`**; happy-path → `success`.
- `src/server/services/orchestrator/__tests__/legacy-metadata-mapper-images-guard.test.ts` — non-array `images` (object/string/number) does not throw; well-formed array still maps.

**Local run (honest):** 14/14 new tests pass. `tsc --noEmit` diff vs `origin/main` shows **zero new errors** on the touched files — the only `tsc` errors on these files are the pre-existing local-environment class (missing `Prisma` namespace exports from the locally-generated client + implicit-any), identical between base and branch. The repo has a large pre-existing `tsc` error backlog (build transpiles without typecheck); CI is authoritative. Not exercised against live prod data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Audit follow-up (🟡#1) — transient resolve-failure 404 is now `no-store` (not CDN-cacheable)

The 500→404 conversion above introduced a cache hazard: the endpoint uses `PublicEndpoint`, which sets `Cache-Control: public, s-maxage=300, stale-while-revalidate=150` on **every** response. The resolve-failure catch (`file.service.ts` `getFileForModelVersion`) fires not only on permanently-broken URLs but also on **transient** delivery-worker / storage-resolver non-2xx (`delivery-worker.ts` throws on any non-ok). So a transient storage outage could make Cloudflare edge-cache "File not found" for ~5 min for a file that **actually exists** — even after the backend recovers. (Pre-fix this was a 500, which CDNs don't cache.)

**Fix (commit on this branch):**
- The resolve-failure catch now returns a **distinct** status `resolve-failed` (instead of reusing the deterministic `not-found`). `getFileForModelVersion` only emits it from the resolve/delivery-failure catch.
- The download endpoint maps `resolve-failed` → 404 **and** sets `Cache-Control: private, no-store`, overriding `PublicEndpoint`'s default. The override **wins**: `addPublicCacheHeaders` runs before the handler, the handler's `setHeader` replaces it, and headers aren't flushed until the handler sends (verified by `src/server/utils/__tests__/public-endpoint-cache-override.test.ts`, which exercises the real `PublicEndpoint`).
- The **deterministic** by-id `not-found` 404 stays CDN-cacheable (it's stable) — no perf regression on the genuine not-found path.
- `tensor-metadata.ts` (the other `getFileForModelVersion` consumer) already sends `private, no-store`; its switches now handle `resolve-failed` → 404 for parity / type-exhaustiveness.

## Audit follow-up (🟡#2) — SLO/paging gap; alert needed (separate infra PR)

Converting resolve-failures from **500 → 404** removes them from the 5xx SLO / paging signal. A genuine **storage-resolver outage** now surfaces only as 404s plus the retained Axiom `type:'error'` `resolve-download-url-failed` log — **it no longer pages via the 5xx path.** A follow-up **Loki/Axiom alert on `resolve-download-url-failed` volume** is needed so a storage outage still pages. That infra-side alert will be handled separately in `datapacket-talos` (not in this PR).
