### PR TITLE
fix(redis): cluster-client self-heal on inflight-leak wedge + fail-soft metric write path + disable-able topology rediscover

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -150,6 +150,63 @@ export const serverSchema = z.object({
   // instrumentCommands() and utils/cache-helpers.ts (fetchThroughCache + createCachedArray
   // fail-open).
   REDIS_CLUSTER_COMMAND_TIMEOUT_MS: z.coerce.number().default(15000),
+
+  // ── CLUSTER CLIENT SELF-HEAL WATCHDOG (FIX #1, the inflight-leak wedge) ──────────
+  //
+  // The per-command deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS) reaps each individual
+  // orphaned `_execute` promise (turns a 125s hang into an error so the gauge dec's and
+  // the handler unparks), but it NEVER resets the wedged client/socket: once a pod's
+  // cluster client starts orphaning commands across a retry / `_slots.rediscover()`
+  // topology refresh, the NEXT command orphans identically → the pod produces 500s/slow-
+  // degrades indefinitely. Only a full client reconnect (or a process restart) rebuilds
+  // the connections/`_slots` and clears the orphaned promises.
+  //
+  // Signature of a wedged pod: `redis_commands_inflight{client="cluster"}` jumps PAST the
+  // threshold and stays PINNED (hundreds–thousands of leaked inflight) — a healthy pod
+  // sits near 0 and a busy pod only spikes transiently. The watchdog samples the same
+  // in-process inflight counter that feeds the gauge; when it stays ABOVE the threshold
+  // CONTINUOUSLY for the sustained window it forces ONE reconnect, then waits out a
+  // cooldown before it can fire again (so it can never become a reconnect storm).
+  //
+  // ON by default (this is the only thing that clears the wedge short of a pod restart),
+  // but fully kill-switchable via REDIS_CLUSTER_SELFHEAL_ENABLED=false. Cluster client
+  // ONLY — the single-node sysRedis client is never reconnected by this watchdog.
+  REDIS_CLUSTER_SELFHEAL_ENABLED: z.preprocess(
+    // default true; only the literal string 'false' disables it
+    (x) => x !== 'false',
+    z.boolean().default(true)
+  ),
+  // Inflight count above which a pod is considered POTENTIALLY wedged. Must be > the
+  // command-deadline guard's effective concurrency floor so a merely-busy pod doesn't
+  // trip it. 50 matches the binary-wedge observation (healthy ~0, wedged jumps past 50).
+  REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD: z.coerce.number().default(50),
+  // The inflight count must stay ABOVE the threshold continuously for THIS long before a
+  // reconnect fires. A transient spike (a slow batch, a brief failover) drops back under
+  // the threshold within the window and resets the timer → no reconnect. A genuine wedge
+  // stays pinned. 20s is long enough to exclude every transient we've seen and short
+  // enough to clear a wedge well inside a human's reaction time.
+  REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS: z.coerce.number().default(20000),
+  // Minimum time between two self-heal reconnects. At most one reconnect per cooldown,
+  // so even a flapping wedge can't drive a reconnect storm (each reconnect rejects the
+  // pod's in-flight cluster commands, which the fail-open/fail-soft paths absorb). 60s.
+  REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS: z.coerce.number().default(60000),
+  // How often the watchdog samples inflight. Cheap (one gauge read), so a tight 1s
+  // sample keeps the sustained-window measurement accurate without overhead.
+  REDIS_CLUSTER_SELFHEAL_CHECK_INTERVAL_MS: z.coerce.number().default(1000),
+
+  // ── METRIC WRITE/LOCK FAIL-SOFT DEADLINE (FIX #3) ───────────────────────────────
+  //
+  // The metric WRITE/LOCK commands (`metrics:lock:Image` setNX/expire in
+  // entity-metric-populate.ts, the increment hIncrBy in entity-metric.redis.ts) are
+  // pure analytics/engagement counters — never money or entitlement (see the fail-soft
+  // note in those files). They currently inherit the 15s cluster command deadline and,
+  // when the cluster client is wedged, PARK up to 15s and then throw — which can 500 a
+  // user mutation. This shorter per-command timeout fails those non-critical writes FAST
+  // and the call sites then fail-SOFT (log + count, skip the metric/lock, let the user
+  // action succeed). Unset/<=0 falls back to REDIS_CLUSTER_COMMAND_TIMEOUT_MS (no change
+  // in behavior beyond the existing 15s deadline). Default 1500ms (1.5s) — ~65× the
+  // ~23ms healthy p99, so it never clips a healthy write, but bounds a wedged one.
+  REDIS_METRIC_WRITE_TIMEOUT_MS: z.coerce.number().default(1500),
   NODE_ENV: z.enum(['development', 'test', 'production']),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.preprocess(

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -228,6 +228,30 @@ export const cacheFailOpenOriginFetchCounter = registerCounterWithLabels({
   labelNames: ['cache_name'] as const,
 });
 
+// Cluster-client SELF-HEAL reconnect counter (FIX #1). Incremented once each time the
+// inflight-leak watchdog forces a full cluster reconnect because inflight stayed pinned
+// above the threshold for the sustained window. Healthy pods never touch this; a nonzero
+// rate flags a pod that hit the binary-wedge state and was auto-recovered (vs needing a
+// human rolling-restart). Pair with redis_commands_inflight on a dashboard to see the
+// pin → reconnect → drain. No labels (per-pod attribution comes from the Prometheus `pod`
+// label); cardinality is 1 series.
+export const redisSelfHealReconnectCounter = registerCounter({
+  name: 'redis_selfheal_reconnect_total',
+  help: 'Forced cluster-client reconnects by the inflight-leak self-heal watchdog',
+});
+
+// Non-critical metric WRITE/LOCK fail-soft counter (FIX #3). Incremented when a
+// metrics:lock setNX/expire or an increment hIncrBy hit the short fail-fast timeout (or a
+// redis error) and the call site skipped the metric/lock so the user mutation could still
+// succeed. `op` is a tiny fixed enum (populate-lock:*, increment:*). A sustained rate means
+// engagement metrics are momentarily under-counting on a wedged pod — never a money/
+// entitlement impact (these are analytics counters).
+export const redisMetricWriteFailSoftCounter = registerCounterWithLabels({
+  name: 'redis_metric_write_failsoft_total',
+  help: 'Non-critical metric write/lock cluster commands that failed soft (timed out/errored, skipped)',
+  labelNames: ['op'] as const,
+});
+
 // tRPC per-procedure latency — wall-clock duration of the full middleware chain +
 // resolver, labeled by procedure path. Used to rank heavy-pool isolation
 // candidates by P99 x rate (the criterion behind the image-feed cutover). Bucket
@@ -471,6 +495,8 @@ export const sysredisSentinelClientErrorsCounter = registerSysredisCounter({
   redisCommandDuration,
   sysredisSentinelTopologyChangesCounter,
   sysredisSentinelClientErrorsCounter,
+  redisSelfHealReconnectCounter,
+  redisMetricWriteFailSoftCounter,
 };
 
 // pgPoolAcquireHistogram is registered in src/server/db/db-helpers.ts, not here.

--- a/src/server/redis/__tests__/cluster-inflight.test.ts
+++ b/src/server/redis/__tests__/cluster-inflight.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  decClusterInflight,
+  getClusterInflight,
+  incClusterInflight,
+  resetClusterInflight,
+} from '../cluster-inflight';
+import { ClusterSelfHealWatchdog } from '../cluster-selfheal';
+import type { ClusterSelfHealConfig, ClusterSelfHealDeps } from '../cluster-selfheal';
+
+// FIX #2 coverage: the cluster inflight counter that the self-heal watchdog samples must
+// NEVER go negative — specifically after a heal. forceClusterReconnect calls the cluster
+// client's destroy() (flushAll(DisconnectsClientError)), which IMMEDIATELY rejects every
+// in-flight command; each rejected command then runs done() → decClusterInflight(). Before
+// FIX #2 those N decrements (a per-closure guard, no global floor) drove the counter to ≈ −N
+// permanently, so the watchdog needed inflight > threshold + N to ever re-trigger → a SECOND
+// wedge went unhealed. These tests exercise the REAL counter (the same module client.ts uses,
+// not a stubbed constant) through the reset→decrement interaction and assert the floor holds
+// and the watchdog can re-arm afterwards.
+
+describe('cluster-inflight counter (FIX #2 floor)', () => {
+  beforeEach(() => resetClusterInflight());
+
+  it('increments and decrements in lockstep on the happy path', () => {
+    expect(getClusterInflight()).toBe(0);
+    incClusterInflight();
+    incClusterInflight();
+    expect(getClusterInflight()).toBe(2);
+    expect(decClusterInflight()).toBe(1);
+    expect(decClusterInflight()).toBe(0);
+    expect(getClusterInflight()).toBe(0);
+  });
+
+  it('FLOORS at 0 — a decrement when already at 0 never goes negative', () => {
+    expect(getClusterInflight()).toBe(0);
+    expect(decClusterInflight()).toBe(0);
+    expect(decClusterInflight()).toBe(0);
+    expect(getClusterInflight()).toBe(0);
+  });
+
+  it('post-heal: reset()→0 then N late rejected decrements settle at 0, NOT -N', () => {
+    // N commands in flight when the wedge fires.
+    const N = 7;
+    for (let i = 0; i < N; i++) incClusterInflight();
+    expect(getClusterInflight()).toBe(N);
+
+    // forceClusterReconnect resets up front (the watchdog's sampled value snaps clean)...
+    resetClusterInflight();
+    expect(getClusterInflight()).toBe(0);
+
+    // ...then each of the N destroy()-rejected commands runs its done() → floored decrement.
+    // Pre-FIX-#2 this would have left the counter at -N; the floor keeps it at 0.
+    for (let i = 0; i < N; i++) decClusterInflight();
+    expect(getClusterInflight()).toBe(0);
+  });
+});
+
+// Integration: drive the REAL watchdog with the REAL counter as getInflight (not a constant),
+// simulate a wedge → heal → post-heal rejected decrements, and prove a SECOND wedge still
+// triggers a reconnect (the counter re-armed because it floored at 0 instead of going negative).
+describe('ClusterSelfHealWatchdog re-arms after a heal (FIX #2, real counter)', () => {
+  const CFG: ClusterSelfHealConfig = {
+    enabled: true,
+    inflightThreshold: 50,
+    sustainedMs: 20000,
+    cooldownMs: 60000,
+  };
+
+  beforeEach(() => resetClusterInflight());
+
+  it('a second wedge after a heal still triggers a reconnect (counter floored, not negative)', async () => {
+    let nowMs = 0;
+    let reconnectCount = 0;
+    // The reconnect models forceClusterReconnect's counter handling against the REAL counter:
+    // reset up front, then the N previously-in-flight commands reject and floored-decrement.
+    const nInFlightAtHeal = () => getClusterInflight();
+    const reconnect = (): Promise<void> => {
+      reconnectCount++;
+      const n = nInFlightAtHeal();
+      resetClusterInflight(); // up-front reset
+      for (let i = 0; i < n; i++) decClusterInflight(); // late rejected done()s, floored
+      return Promise.resolve();
+    };
+    const deps: ClusterSelfHealDeps = {
+      getInflight: () => getClusterInflight(),
+      reconnect,
+      now: () => nowMs,
+      log: () => {},
+      onReconnect: () => {},
+    };
+    const watchdog = new ClusterSelfHealWatchdog(CFG, deps);
+
+    // ── First wedge: 500 commands pinned in flight ──
+    for (let i = 0; i < 500; i++) incClusterInflight();
+    // Drive ticks across the sustained window.
+    for (let t = 0; t < CFG.sustainedMs; t += 1000) {
+      watchdog.tick();
+      nowMs += 1000;
+    }
+    expect(watchdog.tick()).toBe(true); // first heal fires
+    await new Promise((r) => setTimeout(r, 0)); // let the reconnect settle
+    expect(reconnectCount).toBe(1);
+    // After the heal the counter floored at 0 (NOT -500).
+    expect(getClusterInflight()).toBe(0);
+
+    // Advance past the cooldown so the watchdog can re-arm.
+    nowMs += CFG.cooldownMs + 1000;
+
+    // ── Second wedge: another genuine pin. With a negative counter this could never reach
+    // threshold again; floored at 0 it can. ──
+    for (let i = 0; i < 500; i++) incClusterInflight();
+    expect(getClusterInflight()).toBe(500);
+    let secondFired = false;
+    for (let t = 0; t < CFG.sustainedMs + 2000; t += 1000) {
+      if (watchdog.tick()) secondFired = true;
+      nowMs += 1000;
+    }
+    expect(secondFired).toBe(true);
+    expect(reconnectCount).toBe(2);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(getClusterInflight()).toBe(0);
+  });
+});

--- a/src/server/redis/__tests__/cluster-selfheal.test.ts
+++ b/src/server/redis/__tests__/cluster-selfheal.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClusterSelfHealWatchdog } from '../cluster-selfheal';
+import type { ClusterSelfHealConfig, ClusterSelfHealDeps } from '../cluster-selfheal';
+
+// ClusterSelfHealWatchdog is the FIX #1 self-heal for the node-redis cluster inflight-leak
+// wedge: when a pod's tracked cluster inflight stays PINNED above the threshold for a
+// sustained window, force exactly ONE reconnect (subject to a cooldown), the only thing that
+// clears the orphaned `_execute` promises short of a process restart. The watchdog is pure
+// (no redis/prom imports) and driven by tick() against a fake clock + injected counter, so we
+// can prove: a sustained breach fires exactly one reconnect; a transient spike does NOT; the
+// cooldown bounds reconnect frequency; disabled is a no-op; the reconnect counter fires with
+// the inflight-at-trigger value; a reconnect rejection doesn't wedge the watchdog. Mirrors
+// command-deadline.test.ts / client.test.ts (each fix in this area regressed once — lock it).
+
+const DEFAULTS: ClusterSelfHealConfig = {
+  enabled: true,
+  inflightThreshold: 50,
+  sustainedMs: 20000,
+  cooldownMs: 60000,
+};
+
+/** Test harness: a controllable clock + inflight value + spy reconnect/onReconnect. */
+function makeHarness(
+  cfg: Partial<ClusterSelfHealConfig> = {},
+  opts: { reconnect?: () => Promise<void> } = {}
+) {
+  let nowMs = 0;
+  let inflight = 0;
+  const reconnect = vi.fn(opts.reconnect ?? (() => Promise.resolve()));
+  const onReconnect = vi.fn();
+  const log = vi.fn();
+  const deps: ClusterSelfHealDeps = {
+    getInflight: () => inflight,
+    reconnect,
+    now: () => nowMs,
+    log,
+    onReconnect,
+  };
+  const watchdog = new ClusterSelfHealWatchdog({ ...DEFAULTS, ...cfg }, deps);
+  return {
+    watchdog,
+    reconnect,
+    onReconnect,
+    log,
+    setInflight: (v: number) => (inflight = v),
+    advance: (ms: number) => (nowMs += ms),
+    setNow: (ms: number) => (nowMs = ms),
+    now: () => nowMs,
+  };
+}
+
+/** Flush all pending microtasks (the reconnect's then→catch→finally chain settles). */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+/** Drive ticks across `ms` at `step` granularity (simulates the watchdog interval). */
+function runFor(h: ReturnType<typeof makeHarness>, ms: number, step = 1000): number {
+  let fires = 0;
+  for (let t = 0; t < ms; t += step) {
+    if (h.watchdog.tick()) fires++;
+    h.advance(step);
+  }
+  return fires;
+}
+
+describe('ClusterSelfHealWatchdog', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fires exactly one reconnect when inflight stays pinned above the threshold for the sustained window', async () => {
+    const h = makeHarness();
+    h.setInflight(500); // wedged: pinned well above 50
+
+    // Below the sustained window: no reconnect yet.
+    const firesEarly = runFor(h, DEFAULTS.sustainedMs, 1000); // ticks across exactly the window
+    expect(firesEarly).toBe(0);
+    expect(h.reconnect).not.toHaveBeenCalled();
+
+    // One more tick now that now-breachStart >= sustainedMs → trigger.
+    expect(h.watchdog.tick()).toBe(true);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    expect(h.onReconnect).toHaveBeenCalledTimes(1);
+    // onReconnect carries the inflight value at trigger time (for the Prom counter/Loki line).
+    expect(h.onReconnect).toHaveBeenCalledWith(500);
+
+    await flush(); // let the fire-and-forget reconnect settle
+  });
+
+  it('does NOT fire on a transient spike that drops back under the threshold before the window elapses', () => {
+    const h = makeHarness();
+    h.setInflight(500); // spike up
+    // Spike lasts only ~half the window.
+    runFor(h, DEFAULTS.sustainedMs / 2, 1000);
+    expect(h.reconnect).not.toHaveBeenCalled();
+
+    // Drops back to healthy — the sustained timer must RESET.
+    h.setInflight(0);
+    h.watchdog.tick();
+    expect(h.watchdog.getState().breachStartedAt).toBeNull();
+
+    // Spike again, but again only briefly: still no reconnect (timer restarted from here).
+    h.setInflight(500);
+    runFor(h, DEFAULTS.sustainedMs / 2, 1000);
+    expect(h.reconnect).not.toHaveBeenCalled();
+  });
+
+  it('respects the cooldown — at most one reconnect per cooldown window even while inflight stays pinned', async () => {
+    const h = makeHarness();
+    h.setInflight(500); // stays wedged the whole time
+
+    // First trigger after the sustained window.
+    runFor(h, DEFAULTS.sustainedMs, 1000);
+    expect(h.watchdog.tick()).toBe(true);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    await flush(); // reconnect resolves → reconnecting=false
+
+    // Keep ticking through the cooldown while still pinned: no second reconnect.
+    const firesDuringCooldown = runFor(h, DEFAULTS.cooldownMs, 1000);
+    expect(firesDuringCooldown).toBe(0);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+
+    // Past the cooldown while still wedged, exactly ONE more reconnect fires (the breach
+    // timer kept running through the cooldown, so it's already satisfied). Drive a generous
+    // window and assert the count, since the firing tick is consumed inside runFor.
+    const firesAfterCooldown = runFor(h, DEFAULTS.sustainedMs + 2000, 1000);
+    expect(firesAfterCooldown).toBe(1);
+    expect(h.reconnect).toHaveBeenCalledTimes(2);
+    await flush();
+  });
+
+  it('is a no-op when disabled (kill switch): never reconnects, clears the breach timer', () => {
+    const h = makeHarness({ enabled: false });
+    h.setInflight(100000); // extreme wedge
+    const fires = runFor(h, DEFAULTS.sustainedMs * 5, 1000);
+    expect(fires).toBe(0);
+    expect(h.reconnect).not.toHaveBeenCalled();
+    expect(h.onReconnect).not.toHaveBeenCalled();
+    expect(h.watchdog.getState().breachStartedAt).toBeNull();
+  });
+
+  it('does not fire while inflight equals the threshold exactly (strictly-above only)', () => {
+    const h = makeHarness();
+    h.setInflight(DEFAULTS.inflightThreshold); // == 50, not > 50
+    const fires = runFor(h, DEFAULTS.sustainedMs * 2, 1000);
+    expect(fires).toBe(0);
+    expect(h.reconnect).not.toHaveBeenCalled();
+  });
+
+  it('single-flights: does not start a second reconnect while one is in progress', async () => {
+    // A reconnect that resolves only when we let it, to hold reconnecting=true.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const h = makeHarness({}, { reconnect: () => gate });
+    h.setInflight(500);
+
+    runFor(h, DEFAULTS.sustainedMs, 1000);
+    expect(h.watchdog.tick()).toBe(true); // first trigger, reconnect pending
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+
+    // While the reconnect is pending, further ticks (even past another window) must NOT
+    // start a second reconnect.
+    runFor(h, DEFAULTS.sustainedMs * 3, 1000);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+
+    release();
+    await gate;
+    await flush();
+    expect(h.watchdog.getState().reconnecting).toBe(false);
+  });
+
+  it('survives a rejecting reconnect: logs it, clears reconnecting, and re-arms after cooldown', async () => {
+    const err = new Error('disconnect failed');
+    const h = makeHarness({}, { reconnect: () => Promise.reject(err) });
+    h.setInflight(500);
+
+    runFor(h, DEFAULTS.sustainedMs, 1000);
+    expect(h.watchdog.tick()).toBe(true);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+
+    // Let the rejected reconnect settle.
+    await flush();
+    expect(h.watchdog.getState().reconnecting).toBe(false);
+    // The failure was logged, not thrown.
+    expect(h.log.mock.calls.some(([m]) => String(m).includes('reconnect failed'))).toBe(true);
+
+    // After the cooldown it can try again (still wedged). The firing tick is consumed inside
+    // runFor, so assert on the reconnect count over a generous window.
+    runFor(h, DEFAULTS.cooldownMs, 1000);
+    const firesAgain = runFor(h, DEFAULTS.sustainedMs + 2000, 1000);
+    expect(firesAgain).toBe(1);
+    expect(h.reconnect).toHaveBeenCalledTimes(2);
+    await flush();
+  });
+
+  it('tick() never throws even if the onReconnect hook throws, and still reconnects', async () => {
+    const h = makeHarness();
+    h.onReconnect.mockImplementation(() => {
+      throw new Error('counter boom');
+    });
+    h.setInflight(500);
+    runFor(h, DEFAULTS.sustainedMs, 1000);
+    // A throwing onReconnect (a broken Prom counter) must NOT abort the reconnect or wedge
+    // the watchdog: tick still returns true, the reconnect still fires, and reconnecting
+    // clears once it settles.
+    expect(() => h.watchdog.tick()).not.toThrow();
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    await flush();
+    expect(h.watchdog.getState().reconnecting).toBe(false);
+    expect(h.watchdog.getState().breachStartedAt).toBeNull();
+  });
+});

--- a/src/server/redis/__tests__/entity-metric-failsoft.test.ts
+++ b/src/server/redis/__tests__/entity-metric-failsoft.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// FIX #3 at the real WRITE call site: EntityMetricRedisClient.increment is the hot engagement
+// counter (hIncrBy + expire). When the cluster client is wedged these commands must FAIL SOFT
+// — the increment returns 0 (the only consumer is a < 0 negative-correction, which 0 skips)
+// and the expire no-ops — so a wedged pod can NEVER 500/park the user mutation that triggered
+// the count. We mock the redis client + env so a hung hIncrBy is deterministic.
+
+// Short fail-fast timeout so the hung-command test is fast; cluster fallback large.
+vi.mock('~/env/server', () => ({
+  env: {
+    REDIS_METRIC_WRITE_TIMEOUT_MS: 20,
+    REDIS_CLUSTER_COMMAND_TIMEOUT_MS: 15000,
+    LOGGING: [] as string[], // createLogger reads env.LOGGING.includes(name)
+  },
+}));
+
+// Fake redis client injected into EntityMetricRedisClient via the constructor.
+// vi.hoisted so the spies exist before the hoisted vi.mock factory runs.
+const { hIncrBy, expire } = vi.hoisted(() => ({ hIncrBy: vi.fn(), expire: vi.fn() }));
+vi.mock('~/server/redis/client', () => ({
+  redis: { hIncrBy, expire },
+  REDIS_KEYS: { ENTITY_METRICS: { BASE: 'packed:entitymetric' } },
+}));
+
+import { EntityMetricRedisClient } from '../entity-metric.redis';
+import { redis } from '~/server/redis/client';
+
+const never = () => new Promise<never>(() => {});
+
+describe('EntityMetricRedisClient.increment fail-soft (FIX #3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('happy path: returns the real hIncrBy total and sets the TTL (unchanged)', async () => {
+    hIncrBy.mockResolvedValue(7);
+    expire.mockResolvedValue(true);
+    const client = new EntityMetricRedisClient(redis as any);
+
+    const result = await client.increment('Image', 123, 'ReactionLike', 1);
+
+    expect(result).toBe(7);
+    expect(hIncrBy).toHaveBeenCalledTimes(1);
+    expect(expire).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails soft when hIncrBy HANGS: resolves to 0 (no throw, the user mutation survives)', async () => {
+    hIncrBy.mockImplementation(never); // wedged cluster client
+    expire.mockResolvedValue(true);
+    const client = new EntityMetricRedisClient(redis as any);
+
+    // The contract: this resolves (to 0), it does NOT reject — so the caller's mutation
+    // completes instead of 500ing.
+    await expect(client.increment('Image', 123, 'ReactionLike', 1)).resolves.toBe(0);
+  });
+
+  it('fails soft when hIncrBy ERRORS (e.g. CROSSSLOT): resolves to 0, does not throw', async () => {
+    hIncrBy.mockRejectedValue(new Error('CROSSSLOT'));
+    expire.mockResolvedValue(true);
+    const client = new EntityMetricRedisClient(redis as any);
+
+    await expect(client.increment('Image', 123, 'ReactionLike', 1)).resolves.toBe(0);
+  });
+
+  it('a hung expire does not throw out of increment either', async () => {
+    hIncrBy.mockResolvedValue(3);
+    expire.mockImplementation(never);
+    const client = new EntityMetricRedisClient(redis as any);
+
+    // Even if expire wedges, increment still resolves with the real total — the sliding TTL
+    // is best-effort.
+    await expect(client.increment('Image', 123, 'ReactionLike', 1)).resolves.toBe(3);
+  });
+});

--- a/src/server/redis/__tests__/metric-write-failsoft.test.ts
+++ b/src/server/redis/__tests__/metric-write-failsoft.test.ts
@@ -19,6 +19,8 @@ import { withMetricWriteFailSoft } from '../metric-write-failsoft';
 
 const never = () => new Promise<never>(() => {}); // never settles (the wedged-client case)
 const resolveAfter = <T>(ms: number, v: T) => new Promise<T>((r) => setTimeout(() => r(v), ms));
+const rejectAfter = (ms: number, e: Error) =>
+  new Promise<never>((_, rej) => setTimeout(() => rej(e), ms));
 
 describe('withMetricWriteFailSoft', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -101,5 +103,27 @@ describe('withMetricWriteFailSoft', () => {
     await withMetricWriteFailSoft(() => Promise.resolve(1), 0, { op: 'x', timeoutMs: 1000 });
     expect(clearSpy).toHaveBeenCalled();
     clearSpy.mockRestore();
+  });
+
+  it('does NOT emit an unhandledRejection when the command rejects AFTER the deadline fired (FIX #4)', async () => {
+    // The real wedge case: our short fail-soft deadline (10ms) wins; the underlying cluster
+    // command (itself bounded by the 15s withCommandDeadline) rejects ~13.5s later. That LATE
+    // rejection must be reaped, not surface as an unhandledRejection. Mirrors
+    // command-deadline.test.ts / sys-read-deadline.test.ts.
+    const onUnhandled = vi.fn();
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const result = await withMetricWriteFailSoft(
+        () => rejectAfter(40, new Error('late socket death')),
+        'fallback',
+        { op: 'populate-lock:setNX', timeoutMs: 10 }
+      );
+      // Fail-soft: the deadline path returned the fallback (never rejected).
+      expect(result).toBe('fallback');
+      await new Promise((r) => setTimeout(r, 60)); // let the loser settle
+      expect(onUnhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
   });
 });

--- a/src/server/redis/__tests__/metric-write-failsoft.test.ts
+++ b/src/server/redis/__tests__/metric-write-failsoft.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// withMetricWriteFailSoft is FIX #3: the non-critical metric WRITE/LOCK guard. The
+// metrics:lock setNX/expire and increment hIncrBy are pure analytics counters — never money/
+// entitlement — so a wedged cluster client must FAIL FAST (short timeout, not the 15s cluster
+// deadline) and FAIL SOFT (return the caller's fallback + count, let the user mutation
+// succeed) instead of 500ing or parking. These pin: happy path unchanged; a hung command
+// times out and returns the fallback + fires onFail; a redis error fails soft too; the env
+// timeout is honored; <=0 falls back to the cluster deadline. env is mocked so both branches
+// are deterministic (mirrors meilisearch/client.test.ts).
+vi.mock('~/env/server', () => ({
+  env: {
+    REDIS_METRIC_WRITE_TIMEOUT_MS: 1500,
+    REDIS_CLUSTER_COMMAND_TIMEOUT_MS: 15000,
+  },
+}));
+
+import { withMetricWriteFailSoft } from '../metric-write-failsoft';
+
+const never = () => new Promise<never>(() => {}); // never settles (the wedged-client case)
+const resolveAfter = <T>(ms: number, v: T) => new Promise<T>((r) => setTimeout(() => r(v), ms));
+
+describe('withMetricWriteFailSoft', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('passes the real value through on the happy path (unchanged behavior, no onFail)', async () => {
+    const onFail = vi.fn();
+    const result = await withMetricWriteFailSoft(() => Promise.resolve(true), false, {
+      op: 'populate-lock:setNX',
+      onFail,
+      timeoutMs: 1500,
+    });
+    expect(result).toBe(true);
+    expect(onFail).not.toHaveBeenCalled();
+  });
+
+  it('returns a non-boolean happy value verbatim (e.g. an increment total)', async () => {
+    const result = await withMetricWriteFailSoft(() => Promise.resolve(42), 0, {
+      op: 'increment:hIncrBy',
+      timeoutMs: 1500,
+    });
+    expect(result).toBe(42);
+  });
+
+  it('fails soft on a HUNG command: times out, returns the fallback, fires onFail (the wedge case)', async () => {
+    const onFail = vi.fn();
+    // The calling mutation must still resolve — it gets the fallback, not a throw.
+    const result = await withMetricWriteFailSoft(never, false, {
+      op: 'populate-lock:setNX',
+      onFail,
+      timeoutMs: 20, // short so the test is fast
+    });
+    expect(result).toBe(false); // lock "not acquired" → caller skips this id
+    expect(onFail).toHaveBeenCalledTimes(1);
+    expect(onFail).toHaveBeenCalledWith('populate-lock:setNX', expect.any(Error));
+    expect(onFail.mock.calls[0][1].message).toMatch(/timed out after 20ms/);
+  });
+
+  it('fails soft on a redis ERROR (not just a timeout): returns fallback + fires onFail', async () => {
+    const onFail = vi.fn();
+    const result = await withMetricWriteFailSoft(
+      () => Promise.reject(new Error('CROSSSLOT')),
+      0,
+      { op: 'increment:hIncrBy', onFail, timeoutMs: 1500 }
+    );
+    expect(result).toBe(0);
+    expect(onFail).toHaveBeenCalledWith('increment:hIncrBy', expect.any(Error));
+    expect(onFail.mock.calls[0][1].message).toMatch(/CROSSSLOT/);
+  });
+
+  it('never rejects — even a hung command resolves to the fallback (the calling mutation survives)', async () => {
+    // If this leaked a rejection, the test runner would surface it.
+    await expect(
+      withMetricWriteFailSoft(never, 'fallback', { op: 'x', timeoutMs: 10 })
+    ).resolves.toBe('fallback');
+  });
+
+  it('honors an explicit short timeoutMs (does NOT inherit the 15s cluster deadline)', async () => {
+    const onFail = vi.fn();
+    const start = Date.now();
+    await withMetricWriteFailSoft(never, false, { op: 'populate-lock:expire', onFail, timeoutMs: 30 });
+    const elapsed = Date.now() - start;
+    // Bounded by the explicit 30ms, nowhere near 15s.
+    expect(elapsed).toBeLessThan(2000);
+    expect(onFail).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to REDIS_METRIC_WRITE_TIMEOUT_MS when timeoutMs is omitted', async () => {
+    // The mocked default is 1500ms; a 5ms command resolves well within it (no fallback).
+    const onFail = vi.fn();
+    const result = await withMetricWriteFailSoft(() => resolveAfter(5, 'ok'), 'fb', {
+      op: 'increment:hIncrBy',
+      onFail,
+    });
+    expect(result).toBe('ok');
+    expect(onFail).not.toHaveBeenCalled();
+  });
+
+  it('clears the timer on the happy path (no dangling timer keeps the loop alive)', async () => {
+    const clearSpy = vi.spyOn(global, 'clearTimeout');
+    await withMetricWriteFailSoft(() => Promise.resolve(1), 0, { op: 'x', timeoutMs: 1000 });
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});

--- a/src/server/redis/__tests__/periodic-refresh.test.ts
+++ b/src/server/redis/__tests__/periodic-refresh.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+
+// FIX #2: the 30s periodic `_slots.rediscover()` must be env-tunable AND disable-able via
+// REDIS_CLUSTER_REFRESH_INTERVAL, so the infra side can run the "lengthen / disable the
+// periodic rediscover" experiment (the most plausible SEED of the inflight-leak wedge) as a
+// pure env change. resolvePeriodicRefresh encodes that decision purely so we can pin it:
+// 0 (or negative) = the disable sentinel; a value lengthens; unset = the schema default 30s.
+//
+// client.ts opens TCP sockets at module load via getCacheClient(); stub the redis factories +
+// the Flipt client so importing it is side-effect-free (mirrors client.test.ts).
+import { vi } from 'vitest';
+vi.mock('redis', () => {
+  const noopClient = () => {
+    const client: any = {
+      on: () => client,
+      connect: vi.fn(() => Promise.resolve()),
+      withTypeMapping: vi.fn(() => client),
+      scan: vi.fn(),
+      mGet: vi.fn(),
+      del: vi.fn(),
+      unlink: vi.fn(),
+    };
+    return client;
+  };
+  return {
+    createClient: vi.fn(noopClient),
+    createCluster: vi.fn(noopClient),
+    createSentinel: vi.fn(noopClient),
+    RESP_TYPES: { BLOB_STRING: 'BLOB_STRING' },
+  };
+});
+vi.mock('~/server/flipt/client', () => ({
+  FLIPT_FEATURE_FLAGS: { REDIS_CLUSTER_ENHANCED_FAILOVER: 'redis_cluster_enhanced_failover' },
+  isFlipt: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { resolvePeriodicRefresh } from '~/server/redis/client';
+
+describe('resolvePeriodicRefresh (FIX #2 — env-disable-able topology rediscover)', () => {
+  it('0 is the DISABLE sentinel: no periodic rediscover scheduled', () => {
+    expect(resolvePeriodicRefresh(0)).toEqual({ enabled: false, intervalMs: 0 });
+  });
+
+  it('a negative value also disables (sentinel is <= 0)', () => {
+    expect(resolvePeriodicRefresh(-1)).toEqual({ enabled: false, intervalMs: 0 });
+  });
+
+  it('the default 30000 (unset env) keeps the standing 30s behavior — UNCHANGED', () => {
+    // server-schema defaults REDIS_CLUSTER_REFRESH_INTERVAL to 30000 when unset.
+    expect(resolvePeriodicRefresh(30000)).toEqual({ enabled: true, intervalMs: 30000 });
+  });
+
+  it('a LARGER value lengthens the interval (the experiment lever)', () => {
+    expect(resolvePeriodicRefresh(120000)).toEqual({ enabled: true, intervalMs: 120000 });
+  });
+
+  it('a smaller positive value shortens it (still enabled)', () => {
+    expect(resolvePeriodicRefresh(5000)).toEqual({ enabled: true, intervalMs: 5000 });
+  });
+
+  it('a non-finite value (mis-set env) falls back to the 30s default rather than silently disabling', () => {
+    expect(resolvePeriodicRefresh(NaN)).toEqual({ enabled: true, intervalMs: 30000 });
+    expect(resolvePeriodicRefresh(Infinity)).toEqual({ enabled: true, intervalMs: 30000 });
+  });
+});

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -10,6 +10,12 @@ import { slugit } from '~/utils/string-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { withCommandDeadline } from '~/server/redis/command-deadline';
 import { ClusterSelfHealWatchdog } from '~/server/redis/cluster-selfheal';
+import {
+  decClusterInflight,
+  getClusterInflight,
+  incClusterInflight,
+  resetClusterInflight,
+} from '~/server/redis/cluster-inflight';
 import { compressPacked, decompressPacked } from '~/server/redis/packed-compression';
 // NOTE: do NOT statically import the redis prom metrics from '~/server/prom/client'.
 // This module is client-bundle-reachable (`_app.tsx` → `system-cache.ts` → here),
@@ -211,13 +217,13 @@ const log = createLogger('redis', 'green');
 // Track topology refresh intervals for cleanup
 const clusterRefreshIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
-// In-process count of in-flight CLUSTER commands. instrumentCommands inc/decs this in
-// lockstep with the redis_commands_inflight{client="cluster"} gauge — it is the same
-// signal the gauge exposes, read locally (the prom-client Gauge doesn't cheaply surface its
-// value) so the self-heal watchdog (FIX #1) can sample it without a prom dependency. Module-
-// scoped because there is one cluster client per process. (The sys client uses 'sys' and is
-// NOT tracked here — the watchdog only ever acts on the cluster client.)
-let clusterInflight = 0;
+// In-process count of in-flight CLUSTER commands lives in `./cluster-inflight` so EVERY
+// mutation goes through a single floored helper (the counter can never go negative — see
+// FIX #2 there). instrumentCommands inc/decs it in lockstep with the
+// redis_commands_inflight{client="cluster"} gauge — the same signal the gauge exposes, read
+// locally (the prom-client Gauge doesn't cheaply surface its value) so the self-heal watchdog
+// (FIX #1) can sample it without a prom dependency. (The sys client uses 'sys' and is NOT
+// tracked — the watchdog only ever acts on the cluster client.)
 
 /**
  * Trigger topology rediscovery on a cluster client.
@@ -284,37 +290,109 @@ export function resolvePeriodicRefresh(refreshIntervalMs: number): {
 }
 
 /**
- * Force a FULL reconnect of a node-redis cluster client (FIX #1). Disconnect tears down the
- * existing node connections + rejects in-flight commands, and connect() rebuilds them and
- * re-runs slot discovery — which is the ONLY way (short of a process restart) to clear the
- * orphaned `_execute` promises that the inflight-leak wedge accumulates.
+ * Force a FULL reconnect of a node-redis cluster client (FIX #1). The teardown must REJECT
+ * the in-flight commands IMMEDIATELY (not drain them) and connect() rebuilds the node
+ * connections + re-runs slot discovery — which is the ONLY way (short of a process restart)
+ * to clear the orphaned `_execute` promises that the inflight-leak wedge accumulates.
  *
- * node-redis exposes graceful `close()` (v5) / `disconnect()` (legacy) and `destroy()` for a
- * hard teardown; we prefer a graceful close so the existing `close` wrapper still clears the
- * topology-refresh interval, then re-connect. Any teardown error is non-fatal: connect() is
- * still attempted, and the watchdog re-arms after the cooldown regardless.
+ * WHY `destroy()`, NOT `close()` (FIX #1 — verified against @redis/client@5.8.3):
+ *   - cluster `close()` → `#destroy(c => c.close())` → `Promise.allSettled(perNodeClose)`, and
+ *     per-node `RedisClient.close()` "waits for pending commands": it only resolves once the
+ *     node's reply `#queue.isEmpty()`. The whole reason we're reconnecting is that commands
+ *     are ORPHANED and never get a reply → the queue never empties → `close()` can HANG.
+ *     Because the watchdog single-flights on `reconnecting=true` until reconnect settles, a
+ *     hung `close()` pins `reconnecting=true` forever — the watchdog would be permanently dead
+ *     after its first trigger, failing in exactly the scenario it exists for.
+ *   - cluster `destroy()` → per-node `RedisClient.destroy()` =
+ *     `#queue.flushAll(new DisconnectsClientError())` + `socket.destroy()`: it REJECTS every
+ *     in-flight command immediately and tears the sockets down synchronously. That's what we
+ *     want. (`disconnect()` is the legacy alias and also rejects immediately, but `destroy()`
+ *     is the documented v5 method.)
+ *
+ * Each rejected in-flight command then runs its done() closure → decClusterInflight() (floored
+ * at 0, FIX #2), so the counter drains back to ~0 and the watchdog can re-arm. We also reset
+ * it up front so the watchdog's sampled value snaps clean at the trigger instant.
+ *
+ * Because `destroy()` is SYNCHRONOUS and does NOT go through the wrapped `close()` that clears
+ * the topology-refresh interval, this function explicitly clears that interval before tearing
+ * down (FIX #3) so it isn't leaked, then re-establishes failover after reconnect so the new
+ * connection gets exactly one fresh periodic-rediscover interval.
+ *
+ * Any teardown error is non-fatal: connect() is still attempted, and the watchdog re-arms
+ * after the cooldown regardless.
+ *
+ * @param reSetupFailover re-runs setupEnhancedFailover() after connect() resolves, so the
+ *   periodic `_slots.rediscover()` interval (and node-error/disconnect rediscovery) is
+ *   re-established post-heal exactly once (FIX #3). Injected by getBaseClient (the closure
+ *   lives there); optional so unit tests can drive the function without it.
  */
-async function forceClusterReconnect(clusterClient: any): Promise<void> {
+async function forceClusterReconnect(
+  clusterClient: any,
+  reSetupFailover?: () => Promise<void>
+): Promise<void> {
+  // FIX #3: clear the existing topology-refresh interval BEFORE the destroy(). destroy()
+  // bypasses the wrapped close() that would otherwise clear it, so without this the old
+  // interval leaks and reSetupFailover() below would schedule a SECOND one (net: two
+  // intervals firing rediscover on one client). Clearing here + re-creating in
+  // reSetupFailover keeps it at exactly one.
+  clearClusterRefreshInterval('cache');
+
   try {
-    if (typeof clusterClient.close === 'function') {
-      await clusterClient.close();
-    } else if (typeof clusterClient.disconnect === 'function') {
-      await clusterClient.disconnect();
-    } else if (typeof clusterClient.destroy === 'function') {
-      // destroy is synchronous; wrap so the caller can still await uniformly.
+    if (typeof clusterClient.destroy === 'function') {
+      // destroy() rejects in-flight commands immediately (flushAll(DisconnectsClientError))
+      // and tears sockets down synchronously — does NOT wait for the wedged queue to drain.
       clusterClient.destroy();
+    } else if (typeof clusterClient.disconnect === 'function') {
+      // Legacy alias for destroy() — also rejects in-flight immediately.
+      await clusterClient.disconnect();
+    } else if (typeof clusterClient.close === 'function') {
+      // Last resort only: close() can HANG on the wedged queue (see WHY above). Bound it so
+      // a hang can't pin reconnecting=true forever; fall through to connect() regardless.
+      await Promise.race([
+        clusterClient.close(),
+        new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+      ]);
     }
   } catch (err) {
-    log(`Cluster self-heal: disconnect threw (continuing to reconnect): ${
-      err instanceof Error ? err.message : String(err)
-    }`);
+    log(
+      `Cluster self-heal: teardown threw (continuing to reconnect): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
   }
-  // Reset the local inflight counter — the disconnect rejected every in-flight command, so
-  // their done() callbacks fire as the rejections settle; resetting here avoids a transient
-  // mismatch if any settle late. (Each rejected command's done() guards against a
-  // double-decrement, so this stays >= 0.)
-  if (clusterInflight > 0) clusterInflight = 0;
+  // Reset the local inflight counter up front — destroy() rejected every in-flight command,
+  // so their done() closures fire as the rejections settle and EACH floored-decrements toward
+  // 0 (FIX #2 — the floor is what stops a post-heal burst of rejects driving it negative). The
+  // reset just snaps the watchdog's sampled value clean at the trigger instant rather than
+  // letting it decay over the next few ticks.
+  resetClusterInflight();
+
   await clusterClient.connect();
+
+  // FIX #3: re-establish enhanced failover (incl. the periodic-rediscover interval) on the
+  // freshly-connected client. setupEnhancedFailover clears any prior interval for this client
+  // kind first, so combined with the clear above this yields exactly ONE interval (honoring
+  // the REDIS_CLUSTER_REFRESH_INTERVAL disable sentinel). Non-fatal if it throws.
+  if (reSetupFailover) {
+    try {
+      await reSetupFailover();
+    } catch (err) {
+      log(
+        `Cluster self-heal: re-setup failover after reconnect failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+}
+
+/** Clear (and forget) the topology-refresh interval for a client kind, if scheduled. */
+function clearClusterRefreshInterval(type: 'cache' | 'system'): void {
+  const interval = clusterRefreshIntervals.get(type);
+  if (interval) {
+    clearInterval(interval);
+    clusterRefreshIntervals.delete(type);
+  }
 }
 
 /**
@@ -325,7 +403,10 @@ async function forceClusterReconnect(clusterClient: any): Promise<void> {
  * Cluster client ONLY. Exposed (returns the watchdog) so a unit test can construct one with
  * injected deps without booting the module-level interval here.
  */
-function startClusterSelfHeal(clusterClient: any): ClusterSelfHealWatchdog {
+function startClusterSelfHeal(
+  clusterClient: any,
+  reSetupFailover?: () => Promise<void>
+): ClusterSelfHealWatchdog {
   const watchdog = new ClusterSelfHealWatchdog(
     {
       enabled: env.REDIS_CLUSTER_SELFHEAL_ENABLED,
@@ -334,8 +415,8 @@ function startClusterSelfHeal(clusterClient: any): ClusterSelfHealWatchdog {
       cooldownMs: env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS,
     },
     {
-      getInflight: () => clusterInflight,
-      reconnect: () => forceClusterReconnect(clusterClient),
+      getInflight: () => getClusterInflight(),
+      reconnect: () => forceClusterReconnect(clusterClient, reSetupFailover),
       log,
       onReconnect: (inflightAtTrigger: number) => {
         getRedisMetrics()?.redisSelfHealReconnectCounter?.inc();
@@ -724,14 +805,13 @@ function getBaseClient(type: 'cache' | 'system') {
         const { enabled: refreshEnabled, intervalMs: refreshInterval } = resolvePeriodicRefresh(
           env.REDIS_CLUSTER_REFRESH_INTERVAL
         );
-        // Guard against re-entry: setupEnhancedFailover runs on EVERY connect(), including a
-        // self-heal forced reconnect. Without this, each reconnect would stack another
-        // interval + re-wrap close. Clear any prior interval for this client kind first.
-        const priorInterval = clusterRefreshIntervals.get(type);
-        if (priorInterval) {
-          clearInterval(priorInterval);
-          clusterRefreshIntervals.delete(type);
-        }
+        // Guard against re-entry. setupEnhancedFailover runs on the INITIAL connect() AND is
+        // re-invoked by forceClusterReconnect (FIX #3) after a self-heal forced reconnect (it's
+        // passed in as reSetupFailover). Without clearing first, a re-setup would stack a second
+        // interval + re-wrap close. forceClusterReconnect already clears the interval before its
+        // destroy(); clearing again here is idempotent and also covers any future re-entry path.
+        // Net: after any connect()/reconnect there is exactly ONE refresh interval.
+        clearClusterRefreshInterval(type);
         if (refreshEnabled) {
           const intervalId = setInterval(() => {
             triggerTopologyRediscovery(baseClient, 'periodic refresh');
@@ -783,10 +863,13 @@ function getBaseClient(type: 'cache' | 'system') {
         log(`${type} cluster client connected`);
         await setupEnhancedFailover();
         // FIX #1: start the inflight-leak self-heal watchdog ONCE per process for the cache
-        // cluster client. Guarded so a self-heal forced reconnect (which re-runs this connect
-        // callback) doesn't stack a second interval.
+        // cluster client. Guarded so a self-heal forced reconnect doesn't stack a second
+        // watchdog interval. Pass setupEnhancedFailover so forceClusterReconnect re-establishes
+        // the periodic-rediscover interval after a heal (FIX #3). The forced reconnect does NOT
+        // re-run this connect() .then callback (it calls baseClient.connect() directly), so the
+        // re-setup must be threaded through the watchdog, not relied on here.
         if (type === 'cache' && !clusterSelfHealInterval) {
-          startClusterSelfHeal(baseClient);
+          startClusterSelfHeal(baseClient, setupEnhancedFailover);
         }
       })
       .catch((err) => {
@@ -897,12 +980,16 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     const metrics = getRedisMetrics();
     metrics?.redisCommandsInflight.inc(labels);
     // Mirror the gauge into the local counter for the self-heal watchdog (cluster only).
-    if (clientLabel === 'cluster') clusterInflight++;
+    if (clientLabel === 'cluster') incClusterInflight();
     const start = Date.now();
-    let dec = false; // guard so a double-settle (shouldn't happen) can't drive the counter negative
+    let dec = false; // per-closure guard so a double-settle (shouldn't happen) can't double-dec
     const done = () => {
       if (clientLabel === 'cluster' && !dec) {
-        clusterInflight--;
+        // FLOORED decrement (decClusterInflight clamps at 0). The per-closure `dec` guard above
+        // only stops THIS closure decrementing twice — it does NOT stop N distinct rejected
+        // closures (e.g. the burst destroy() rejects after a heal) decrementing past 0. The
+        // floor is what keeps the counter accurate post-heal so the watchdog can re-arm (FIX #2).
+        decClusterInflight();
         dec = true;
       }
       metrics?.redisCommandsInflight.dec(labels);

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -9,6 +9,7 @@ import { createLogger } from '~/utils/logging';
 import { slugit } from '~/utils/string-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { withCommandDeadline } from '~/server/redis/command-deadline';
+import { ClusterSelfHealWatchdog } from '~/server/redis/cluster-selfheal';
 import { compressPacked, decompressPacked } from '~/server/redis/packed-compression';
 // NOTE: do NOT statically import the redis prom metrics from '~/server/prom/client'.
 // This module is client-bundle-reachable (`_app.tsx` → `system-cache.ts` → here),
@@ -210,6 +211,14 @@ const log = createLogger('redis', 'green');
 // Track topology refresh intervals for cleanup
 const clusterRefreshIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
+// In-process count of in-flight CLUSTER commands. instrumentCommands inc/decs this in
+// lockstep with the redis_commands_inflight{client="cluster"} gauge — it is the same
+// signal the gauge exposes, read locally (the prom-client Gauge doesn't cheaply surface its
+// value) so the self-heal watchdog (FIX #1) can sample it without a prom dependency. Module-
+// scoped because there is one cluster client per process. (The sys client uses 'sys' and is
+// NOT tracked here — the watchdog only ever acts on the cluster client.)
+let clusterInflight = 0;
+
 /**
  * Trigger topology rediscovery on a cluster client.
  * Uses internal _slots.rediscover() method - this is undocumented but stable.
@@ -245,6 +254,117 @@ function triggerTopologyRediscovery(clusterClient: any, reason: string) {
     // Silently ignore if rediscover is not available
     log(`Topology rediscovery error: ${err instanceof Error ? err.message : err}`);
   }
+}
+
+// Hold the watchdog interval so it can be cleared on client close (mirrors
+// clusterRefreshIntervals). Module-scoped: one cluster client per process.
+let clusterSelfHealInterval: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * FIX #2: decide whether the periodic `_slots.rediscover()` should be scheduled, from the
+ * REDIS_CLUSTER_REFRESH_INTERVAL value. Pure (no side effects) so it can be unit-tested
+ * without booting the cluster client.
+ *
+ * Contract:
+ *   - value  > 0 → { enabled: true,  intervalMs: value }  (a LARGER value lengthens it)
+ *   - value <= 0 → { enabled: false, intervalMs: 0 }      (0 is the DISABLE SENTINEL)
+ *   - NaN / non-finite (mis-set env) → treated as the default 30000 so a typo can't silently
+ *     disable the refresh (the schema coerces, but be defensive).
+ *
+ * Default behavior is unchanged when the env is unset: server-schema defaults
+ * REDIS_CLUSTER_REFRESH_INTERVAL to 30000, so this returns { enabled: true, intervalMs: 30000 }.
+ */
+export function resolvePeriodicRefresh(refreshIntervalMs: number): {
+  enabled: boolean;
+  intervalMs: number;
+} {
+  if (!Number.isFinite(refreshIntervalMs)) return { enabled: true, intervalMs: 30000 };
+  if (refreshIntervalMs > 0) return { enabled: true, intervalMs: refreshIntervalMs };
+  return { enabled: false, intervalMs: 0 }; // 0 (or negative) = disable sentinel
+}
+
+/**
+ * Force a FULL reconnect of a node-redis cluster client (FIX #1). Disconnect tears down the
+ * existing node connections + rejects in-flight commands, and connect() rebuilds them and
+ * re-runs slot discovery — which is the ONLY way (short of a process restart) to clear the
+ * orphaned `_execute` promises that the inflight-leak wedge accumulates.
+ *
+ * node-redis exposes graceful `close()` (v5) / `disconnect()` (legacy) and `destroy()` for a
+ * hard teardown; we prefer a graceful close so the existing `close` wrapper still clears the
+ * topology-refresh interval, then re-connect. Any teardown error is non-fatal: connect() is
+ * still attempted, and the watchdog re-arms after the cooldown regardless.
+ */
+async function forceClusterReconnect(clusterClient: any): Promise<void> {
+  try {
+    if (typeof clusterClient.close === 'function') {
+      await clusterClient.close();
+    } else if (typeof clusterClient.disconnect === 'function') {
+      await clusterClient.disconnect();
+    } else if (typeof clusterClient.destroy === 'function') {
+      // destroy is synchronous; wrap so the caller can still await uniformly.
+      clusterClient.destroy();
+    }
+  } catch (err) {
+    log(`Cluster self-heal: disconnect threw (continuing to reconnect): ${
+      err instanceof Error ? err.message : String(err)
+    }`);
+  }
+  // Reset the local inflight counter — the disconnect rejected every in-flight command, so
+  // their done() callbacks fire as the rejections settle; resetting here avoids a transient
+  // mismatch if any settle late. (Each rejected command's done() guards against a
+  // double-decrement, so this stays >= 0.)
+  if (clusterInflight > 0) clusterInflight = 0;
+  await clusterClient.connect();
+}
+
+/**
+ * Start the cluster-client self-heal watchdog (FIX #1). Samples the local cluster inflight
+ * counter on REDIS_CLUSTER_SELFHEAL_CHECK_INTERVAL_MS and forces a full reconnect when it
+ * stays pinned above the threshold for the sustained window (subject to the cooldown). All
+ * thresholds are env-tunable; REDIS_CLUSTER_SELFHEAL_ENABLED=false disables it entirely.
+ * Cluster client ONLY. Exposed (returns the watchdog) so a unit test can construct one with
+ * injected deps without booting the module-level interval here.
+ */
+function startClusterSelfHeal(clusterClient: any): ClusterSelfHealWatchdog {
+  const watchdog = new ClusterSelfHealWatchdog(
+    {
+      enabled: env.REDIS_CLUSTER_SELFHEAL_ENABLED,
+      inflightThreshold: env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD,
+      sustainedMs: env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS,
+      cooldownMs: env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS,
+    },
+    {
+      getInflight: () => clusterInflight,
+      reconnect: () => forceClusterReconnect(clusterClient),
+      log,
+      onReconnect: (inflightAtTrigger: number) => {
+        getRedisMetrics()?.redisSelfHealReconnectCounter?.inc();
+        log(
+          `Cluster self-heal RECONNECT fired [inflight=${inflightAtTrigger}, threshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}]`
+        );
+      },
+    }
+  );
+
+  if (!env.REDIS_CLUSTER_SELFHEAL_ENABLED) {
+    log('Cluster self-heal watchdog DISABLED (REDIS_CLUSTER_SELFHEAL_ENABLED=false)');
+    return watchdog;
+  }
+
+  const interval = Math.max(250, env.REDIS_CLUSTER_SELFHEAL_CHECK_INTERVAL_MS);
+  clusterSelfHealInterval = setInterval(() => {
+    try {
+      watchdog.tick();
+    } catch (err) {
+      log(`Cluster self-heal tick error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, interval);
+  // Don't keep the event loop alive for the watchdog on a graceful process exit.
+  clusterSelfHealInterval.unref?.();
+  log(
+    `Cluster self-heal watchdog ENABLED [threshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}, cooldownMs=${env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS}, checkMs=${interval}]`
+  );
+  return watchdog;
 }
 
 /**
@@ -593,8 +713,26 @@ function getBaseClient(type: 'cache' | 'system') {
 
         log('Enhanced cluster failover handling is ENABLED');
 
-        const refreshInterval = env.REDIS_CLUSTER_REFRESH_INTERVAL;
-        if (refreshInterval > 0) {
+        // FIX #2: the periodic `_slots.rediscover()` is env-tunable AND disable-able via
+        // REDIS_CLUSTER_REFRESH_INTERVAL (the standing 30s default is unchanged when unset):
+        //   * a LARGER value lengthens the interval;
+        //   * 0 (or any value <= 0) is the DISABLE SENTINEL — no periodic rediscover is
+        //     scheduled at all (event-driven rediscovery on node-error/node-disconnect still
+        //     runs). This lets the infra side run the "lengthen / disable the periodic
+        //     rediscover" experiment (it is the most plausible SEED of the inflight-leak wedge:
+        //     a periodic rediscover racing an in-flight write) as a pure env change, no deploy.
+        const { enabled: refreshEnabled, intervalMs: refreshInterval } = resolvePeriodicRefresh(
+          env.REDIS_CLUSTER_REFRESH_INTERVAL
+        );
+        // Guard against re-entry: setupEnhancedFailover runs on EVERY connect(), including a
+        // self-heal forced reconnect. Without this, each reconnect would stack another
+        // interval + re-wrap close. Clear any prior interval for this client kind first.
+        const priorInterval = clusterRefreshIntervals.get(type);
+        if (priorInterval) {
+          clearInterval(priorInterval);
+          clusterRefreshIntervals.delete(type);
+        }
+        if (refreshEnabled) {
           const intervalId = setInterval(() => {
             triggerTopologyRediscovery(baseClient, 'periodic refresh');
           }, refreshInterval);
@@ -602,21 +740,30 @@ function getBaseClient(type: 'cache' | 'system') {
           // Store interval for cleanup
           clusterRefreshIntervals.set(type, intervalId);
 
-          // Wrap close to clean up interval
-          const originalClose = baseClient.close?.bind(baseClient);
-          if (originalClose) {
-            (baseClient as any).close = async () => {
-              const interval = clusterRefreshIntervals.get(type);
-              if (interval) {
-                clearInterval(interval);
-                clusterRefreshIntervals.delete(type);
-                log(`Cleared topology refresh interval for ${type}`);
-              }
-              return originalClose();
-            };
+          // Wrap close to clean up interval (only wrap once — re-wrapping on each reconnect
+          // would nest the wrappers).
+          if (!(baseClient as any).__refreshCloseWrapped) {
+            const originalClose = baseClient.close?.bind(baseClient);
+            if (originalClose) {
+              (baseClient as any).__refreshCloseWrapped = true;
+              (baseClient as any).close = async () => {
+                const interval = clusterRefreshIntervals.get(type);
+                if (interval) {
+                  clearInterval(interval);
+                  clusterRefreshIntervals.delete(type);
+                  log(`Cleared topology refresh interval for ${type}`);
+                }
+                return originalClose();
+              };
+            }
           }
 
           log(`Topology refresh scheduled every ${refreshInterval}ms`);
+        } else {
+          // Disable sentinel hit.
+          log(
+            `Periodic topology refresh DISABLED (REDIS_CLUSTER_REFRESH_INTERVAL=${refreshInterval} <= 0); event-driven rediscovery still active`
+          );
         }
       } catch (err) {
         log(`Enhanced failover setup failed: ${err instanceof Error ? err.message : err}`);
@@ -635,6 +782,12 @@ function getBaseClient(type: 'cache' | 'system') {
       .then(async () => {
         log(`${type} cluster client connected`);
         await setupEnhancedFailover();
+        // FIX #1: start the inflight-leak self-heal watchdog ONCE per process for the cache
+        // cluster client. Guarded so a self-heal forced reconnect (which re-runs this connect
+        // callback) doesn't stack a second interval.
+        if (type === 'cache' && !clusterSelfHealInterval) {
+          startClusterSelfHeal(baseClient);
+        }
       })
       .catch((err) => {
         log(`Redis connection failed (${type})`, err);
@@ -694,6 +847,12 @@ type RedisMetricsBridge = {
   // reachable module. attachSysSentinelListeners reads them at attach time.
   sysredisSentinelTopologyChangesCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
   sysredisSentinelClientErrorsCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
+  // FIX #1 self-heal reconnect counter (no labels) + FIX #3 metric-write fail-soft counter.
+  // Read via the globalThis bridge so this client-bundle-reachable module avoids a static
+  // prom-client import (which drags in fs/cluster). Both may be undefined until prom/client
+  // loads server-side; callers null-check.
+  redisSelfHealReconnectCounter?: { inc: () => void };
+  redisMetricWriteFailSoftCounter?: { labels: (labels: { op: string }) => { inc: () => void } };
 };
 
 // Server-runtime lookup of the prom metric handles WITHOUT a static import edge
@@ -737,8 +896,15 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     // dec without its matching inc would drive the gauge negative).
     const metrics = getRedisMetrics();
     metrics?.redisCommandsInflight.inc(labels);
+    // Mirror the gauge into the local counter for the self-heal watchdog (cluster only).
+    if (clientLabel === 'cluster') clusterInflight++;
     const start = Date.now();
+    let dec = false; // guard so a double-settle (shouldn't happen) can't drive the counter negative
     const done = () => {
+      if (clientLabel === 'cluster' && !dec) {
+        clusterInflight--;
+        dec = true;
+      }
       metrics?.redisCommandsInflight.dec(labels);
       metrics?.redisCommandDuration.observe(labels, (Date.now() - start) / 1000);
     };

--- a/src/server/redis/cluster-inflight.ts
+++ b/src/server/redis/cluster-inflight.ts
@@ -1,0 +1,60 @@
+/**
+ * In-process count of in-flight CLUSTER (cache) redis commands (FIX #1/#2 support).
+ *
+ * instrumentCommands inc/decs this in lockstep with the
+ * `redis_commands_inflight{client="cluster"}` gauge — it is the same signal the gauge
+ * exposes, read locally (the prom-client Gauge doesn't cheaply surface its value) so the
+ * self-heal watchdog can sample it without a prom dependency. There is one cluster client
+ * per process, so a module-scoped counter is correct.
+ *
+ * EVERY mutation goes through these helpers so the counter has ONE invariant:
+ *   it can never go negative.
+ *
+ * WHY the floor matters (FIX #2): a forced self-heal reconnect calls the cluster client's
+ * `destroy()`, which `flushAll(DisconnectsClientError)` — IMMEDIATELY rejecting every
+ * in-flight command. Each of those rejected commands then runs its `done()` closure, which
+ * decrements this counter. The per-closure `dec` guard only prevents a single closure from
+ * decrementing twice; it does NOT stop N distinct closures from decrementing past 0. Without
+ * a global floor, a heal that rejected N commands would leave the counter at ≈ −N, so the
+ * watchdog would then need inflight > threshold + N to ever re-trigger and a SECOND wedge
+ * would go unhealed. Flooring every decrement at 0 keeps the counter an accurate reflection
+ * of reality after a heal, so the watchdog can re-arm. (This is why `reset()` is a
+ * convenience, not a correctness requirement — the floored decrements settle to ~0 on their
+ * own as the rejected commands drain.)
+ *
+ * Pure (no redis/prom imports) so it is unit-testable in isolation, and so the FIX #2
+ * reset→decrement interaction can be exercised against the REAL counter logic client.ts uses
+ * (not a stubbed constant).
+ */
+
+let clusterInflight = 0;
+
+/** Increment on command start. */
+export function incClusterInflight(): void {
+  clusterInflight++;
+}
+
+/**
+ * Decrement on command settle, FLOORED at 0 so a post-heal burst of rejected commands can't
+ * drive the counter negative (FIX #2). Returns the new value.
+ */
+export function decClusterInflight(): number {
+  clusterInflight = Math.max(0, clusterInflight - 1);
+  return clusterInflight;
+}
+
+/** Read the current count (the value the self-heal watchdog samples). */
+export function getClusterInflight(): number {
+  return clusterInflight;
+}
+
+/**
+ * Reset to 0. Called by forceClusterReconnect before it tears the client down. With
+ * `destroy()` immediately rejecting the in-flight commands, this is belt-and-suspenders:
+ * the floored decrements from those rejections settle the counter to ~0 regardless. Kept so
+ * the watchdog's sampled value snaps clean at the trigger instead of decaying over the next
+ * few ticks.
+ */
+export function resetClusterInflight(): void {
+  clusterInflight = 0;
+}

--- a/src/server/redis/cluster-selfheal.ts
+++ b/src/server/redis/cluster-selfheal.ts
@@ -52,8 +52,10 @@ export interface ClusterSelfHealDeps {
   /** Reads the current in-process cluster inflight count (same source as the gauge). */
   getInflight: () => number;
   /**
-   * Forces a full client reconnect (disconnect → connect, rebuilding `_slots`). Rejecting
-   * is fine — the watchdog logs it and re-arms after the cooldown. Must resolve/settle.
+   * Forces a full client reconnect (destroy → connect, rebuilding `_slots`). The teardown must
+   * REJECT in-flight commands immediately (client.ts uses the v5 cluster `destroy()`, NOT the
+   * draining `close()`) so it can't hang and pin `reconnecting` true forever. Rejecting is fine
+   * — the watchdog logs it and re-arms after the cooldown. Must resolve/settle.
    */
   reconnect: () => Promise<void>;
   /** Monotonic-ish clock in ms (injected so tests are deterministic). Defaults to Date.now. */

--- a/src/server/redis/cluster-selfheal.ts
+++ b/src/server/redis/cluster-selfheal.ts
@@ -1,0 +1,175 @@
+/**
+ * Cluster-client self-heal watchdog (FIX #1 for the node-redis cluster inflight-leak wedge).
+ *
+ * WHY (civitai-dp-prod api-primary): a small fraction of cluster command promises get
+ * ORPHANED across a cluster retry / `_slots.rediscover()` topology refresh and never
+ * settle. The per-command deadline (withCommandDeadline / REDIS_CLUSTER_COMMAND_TIMEOUT_MS)
+ * reaps each *individual* orphaned command — it turns the 125s hang into an error so the
+ * inflight gauge dec's and the handler unparks — but it NEVER resets the wedged
+ * client/socket. Once a pod starts orphaning, the NEXT command orphans identically, so the
+ * pod 500s / slow-degrades indefinitely. ONLY a full client reconnect (rebuilds the
+ * connections + `_slots`) or a process restart clears the orphaned `_execute` promises.
+ *
+ * SIGNATURE of a wedged pod: `redis_commands_inflight{client="cluster"}` jumps PAST the
+ * threshold and stays PINNED (hundreds–thousands of leaked inflight); a healthy pod sits
+ * near 0 and a busy pod only SPIKES transiently. This watchdog samples the same in-process
+ * inflight counter that feeds the gauge and forces ONE reconnect when it stays above the
+ * threshold CONTINUOUSLY for the sustained window, then waits out a cooldown.
+ *
+ * RECONNECT-STORM SAFETY — three independent brakes:
+ *   1. SUSTAINED window: a transient spike drops back under the threshold within the window
+ *      and resets the timer → no reconnect. Only a genuine pinned wedge survives the window.
+ *   2. COOLDOWN: at most ONE reconnect per cooldown, regardless of how long inflight stays
+ *      pinned. After a reconnect the watchdog re-arms only after the cooldown elapses.
+ *   3. SINGLE-FLIGHT: while a reconnect is in progress, ticks are skipped.
+ *
+ * MONEY/ENTITLEMENT SAFETY: a reconnect rejects the pod's in-flight cluster commands. That
+ * reject surfaces as a NORMAL command error (a rejected promise) on whatever path issued the
+ * command — it can NEVER silently succeed-or-skip. The cluster client carries cache/metric
+ * traffic; money/entitlement state lives in Postgres and the sysRedis (single-node) client,
+ * which this watchdog NEVER touches. Any caller that does issue a money-adjacent cluster
+ * command sees the same rejection it already gets for any cluster error and must retry/handle
+ * it — identical to a socketTimeout teardown today.
+ *
+ * This module is PURE (no redis/prom imports) so it can be unit-tested by driving `tick()`
+ * with a fake clock + injected counter/reconnect, mirroring the command-deadline / sentinel
+ * test pattern. client.ts constructs one instance per cluster client and drives it on an
+ * interval.
+ */
+
+export interface ClusterSelfHealConfig {
+  /** Master kill-switch. When false, tick() is a no-op and never reconnects. */
+  enabled: boolean;
+  /** Inflight count strictly above which a pod is considered potentially wedged. */
+  inflightThreshold: number;
+  /** Inflight must stay above the threshold continuously for this long before reconnecting. */
+  sustainedMs: number;
+  /** Minimum wall-clock time between two reconnects. */
+  cooldownMs: number;
+}
+
+export interface ClusterSelfHealDeps {
+  /** Reads the current in-process cluster inflight count (same source as the gauge). */
+  getInflight: () => number;
+  /**
+   * Forces a full client reconnect (disconnect → connect, rebuilding `_slots`). Rejecting
+   * is fine — the watchdog logs it and re-arms after the cooldown. Must resolve/settle.
+   */
+  reconnect: () => Promise<void>;
+  /** Monotonic-ish clock in ms (injected so tests are deterministic). Defaults to Date.now. */
+  now?: () => number;
+  /** Structured logger. */
+  log: (msg: string, ...rest: unknown[]) => void;
+  /**
+   * Called once per successful (or attempted) self-heal reconnect with the inflight value at
+   * trigger time, so client.ts can increment the Prometheus counter + emit a Loki line.
+   */
+  onReconnect: (inflightAtTrigger: number) => void;
+}
+
+export class ClusterSelfHealWatchdog {
+  private readonly cfg: ClusterSelfHealConfig;
+  private readonly deps: Required<Pick<ClusterSelfHealDeps, 'now'>> & ClusterSelfHealDeps;
+
+  /**
+   * Timestamp (ms) at which inflight FIRST crossed above the threshold in the current
+   * continuous run, or null when inflight is at/under the threshold. Reset whenever inflight
+   * drops back under the threshold — this is what makes the trigger require a SUSTAINED breach.
+   */
+  private breachStartedAt: number | null = null;
+  /** Timestamp of the last reconnect (for the cooldown). null = never reconnected. */
+  private lastReconnectAt: number | null = null;
+  /** Single-flight guard: true while a reconnect promise is in flight. */
+  private reconnecting = false;
+
+  constructor(cfg: ClusterSelfHealConfig, deps: ClusterSelfHealDeps) {
+    this.cfg = cfg;
+    this.deps = { ...deps, now: deps.now ?? Date.now };
+  }
+
+  /** Expose internal state for assertions/observability (read-only snapshot). */
+  getState() {
+    return {
+      breachStartedAt: this.breachStartedAt,
+      lastReconnectAt: this.lastReconnectAt,
+      reconnecting: this.reconnecting,
+    };
+  }
+
+  /**
+   * One watchdog sample. Returns true iff this tick TRIGGERED a reconnect. Safe to call on a
+   * fixed interval. Never throws — a reconnect rejection is caught and logged.
+   */
+  tick(): boolean {
+    if (!this.cfg.enabled) {
+      // Kill-switch: also clear any in-progress breach timer so flipping it back on starts clean.
+      this.breachStartedAt = null;
+      return false;
+    }
+    if (this.reconnecting) return false; // single-flight
+
+    const now = this.deps.now();
+    const inflight = this.deps.getInflight();
+
+    if (inflight <= this.cfg.inflightThreshold) {
+      // Healthy / recovered / transient-spike-ended: reset the sustained timer.
+      this.breachStartedAt = null;
+      return false;
+    }
+
+    // Inflight is above the threshold. Start (or continue) the sustained-breach timer.
+    if (this.breachStartedAt == null) {
+      this.breachStartedAt = now;
+      return false;
+    }
+
+    // Require the breach to have lasted at least sustainedMs.
+    if (now - this.breachStartedAt < this.cfg.sustainedMs) return false;
+
+    // Respect the cooldown — at most one reconnect per cooldown window.
+    if (this.lastReconnectAt != null && now - this.lastReconnectAt < this.cfg.cooldownMs) {
+      return false;
+    }
+
+    // ── TRIGGER ──────────────────────────────────────────────────────────────────────
+    // Mark the reconnect time + clear the breach timer up front so a long-running reconnect
+    // can't re-trigger and so the cooldown is measured from the trigger, not completion.
+    this.lastReconnectAt = now;
+    this.breachStartedAt = null;
+    this.reconnecting = true;
+
+    this.deps.log(
+      `Cluster self-heal: inflight pinned at ${inflight} > ${this.cfg.inflightThreshold} for >=${this.cfg.sustainedMs}ms — forcing reconnect`
+    );
+    // onReconnect is a fire-and-forget observability hook (Prom counter + Loki line). A throw
+    // from it must NOT abort the reconnect or wedge the watchdog (it would leave reconnecting
+    // pinned true), so it's isolated.
+    try {
+      this.deps.onReconnect(inflight);
+    } catch (err) {
+      this.deps.log(
+        `Cluster self-heal: onReconnect hook threw (ignored): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+
+    // Fire-and-forget the actual reconnect; the watchdog stays responsive (single-flight
+    // guard prevents overlap). Any rejection is logged, not thrown.
+    void this.deps
+      .reconnect()
+      .then(() => {
+        this.deps.log('Cluster self-heal: reconnect completed');
+      })
+      .catch((err: unknown) => {
+        this.deps.log(
+          `Cluster self-heal: reconnect failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      })
+      .finally(() => {
+        this.reconnecting = false;
+      });
+
+    return true;
+  }
+}

--- a/src/server/redis/entity-metric-populate.ts
+++ b/src/server/redis/entity-metric-populate.ts
@@ -9,8 +9,24 @@ import type {
   EntityMetric_MetricType_Type,
 } from '~/shared/utils/prisma/enums';
 import type { CachedObject } from '~/server/utils/cache-helpers';
+import { withMetricWriteFailSoft } from '~/server/redis/metric-write-failsoft';
 
 const log = createLogger('entity-metric-populate', 'magenta');
+
+// FIX #3: fail-soft hook for the metric LOCK/WRITE commands below. These locks/writes are
+// pure thundering-herd guards over an analytics populate — never money/entitlement — so when
+// the cluster client is wedged we'd rather skip the lock (let the populate run / be skipped)
+// than 500 or park 15s. Logs (Loki) + increments the Prometheus fail-soft counter.
+function metricWriteFailHook(op: string, err: unknown) {
+  log(`metric write fail-soft [op=${op}]:`, err instanceof Error ? err.message : err);
+  (
+    globalThis as unknown as {
+      __civitaiRedisMetrics?: {
+        redisMetricWriteFailSoftCounter?: { labels: (l: { op: string }) => { inc: () => void } };
+      };
+    }
+  ).__civitaiRedisMetrics?.redisMetricWriteFailSoftCounter?.labels({ op }).inc();
+}
 
 interface MetricData {
   entityId: number;
@@ -32,10 +48,21 @@ export async function populateEntityMetrics(
 
   let idsToProcess = entityIds;
 
-  // Only check existence if not force refreshing
+  // Only check existence if not force refreshing.
+  // FIX #3: each exists/setNX/expire is a NON-CRITICAL cluster command — fail it FAST
+  // (REDIS_METRIC_WRITE_TIMEOUT_MS, not the 15s deadline) and FAIL-SOFT on a wedge so this
+  // analytics populate never parks/500s a user mutation: exists fail-soft → false (treat as
+  // "not populated"); setNX fail-soft → false ("lock not acquired" → skip this id, another
+  // process / a later call handles it); expire fail-soft → no-op (the lock just TTLs via the
+  // 10s the consumer expects, or sticks slightly longer — harmless).
   if (!forceRefresh) {
     const existsChecks = await Promise.all(
-      entityIds.map((id) => entityMetricRedis.exists(entityType, id))
+      entityIds.map((id) =>
+        withMetricWriteFailSoft(() => entityMetricRedis.exists(entityType, id), false, {
+          op: 'populate-exists',
+          onFail: metricWriteFailHook,
+        })
+      )
     );
 
     idsToProcess = entityIds.filter((_, index) => !existsChecks[index]);
@@ -48,7 +75,13 @@ export async function populateEntityMetrics(
   // Try to acquire per-ID locks for entities to process
   const lockPrefix = `${REDIS_KEYS.ENTITY_METRICS.BASE}:lock:${entityType}`;
   const lockResults = await Promise.all(
-    idsToProcess.map((id) => redis.setNX(`${lockPrefix}:${id}` as RedisKeyTemplateCache, '1'))
+    idsToProcess.map((id) =>
+      withMetricWriteFailSoft(
+        () => redis.setNX(`${lockPrefix}:${id}` as RedisKeyTemplateCache, '1'),
+        false,
+        { op: 'populate-lock:setNX', onFail: metricWriteFailHook }
+      )
+    )
   );
 
   // Only load entities where we got the lock
@@ -60,7 +93,12 @@ export async function populateEntityMetrics(
   // Set TTL on acquired locks
   if (lockedKeys.length > 0) {
     await Promise.all(
-      lockedKeys.map((key) => redis.expire(key, 10)) // 10 seconds per ID
+      lockedKeys.map((key) =>
+        withMetricWriteFailSoft(() => redis.expire(key, 10), false, {
+          op: 'populate-lock:expire',
+          onFail: metricWriteFailHook,
+        })
+      ) // 10 seconds per ID
     );
   }
 
@@ -118,9 +156,13 @@ export async function populateEntityMetrics(
     log('Error during bulk population:', error);
     // Don't throw - other processes might succeed
   } finally {
-    // Always release the locks we acquired
+    // Always release the locks we acquired (fail-soft: a wedged del must not throw out of the
+    // finally — the lock TTLs in 10s regardless).
     if (lockedKeys.length > 0) {
-      await redis.del(lockedKeys);
+      await withMetricWriteFailSoft(() => redis.del(lockedKeys), 0, {
+        op: 'populate-lock:del',
+        onFail: metricWriteFailHook,
+      });
     }
   }
 }
@@ -267,9 +309,15 @@ export async function populateComicMetrics(
 
   let idsToProcess = comicIds;
 
+  // FIX #3: same non-critical fail-fast + fail-soft treatment as the Image path above.
   if (!forceRefresh) {
     const existsChecks = await Promise.all(
-      comicIds.map((id) => entityMetricRedis.exists(COMIC_REDIS_TYPE, id))
+      comicIds.map((id) =>
+        withMetricWriteFailSoft(() => entityMetricRedis.exists(COMIC_REDIS_TYPE, id), false, {
+          op: 'populate-exists',
+          onFail: metricWriteFailHook,
+        })
+      )
     );
     idsToProcess = comicIds.filter((_, index) => !existsChecks[index]);
     if (idsToProcess.length === 0) return;
@@ -277,14 +325,27 @@ export async function populateComicMetrics(
 
   const lockPrefix = `${REDIS_KEYS.ENTITY_METRICS.BASE}:lock:${COMIC_REDIS_TYPE}`;
   const lockResults = await Promise.all(
-    idsToProcess.map((id) => redis.setNX(`${lockPrefix}:${id}` as RedisKeyTemplateCache, '1'))
+    idsToProcess.map((id) =>
+      withMetricWriteFailSoft(
+        () => redis.setNX(`${lockPrefix}:${id}` as RedisKeyTemplateCache, '1'),
+        false,
+        { op: 'populate-lock:setNX', onFail: metricWriteFailHook }
+      )
+    )
   );
   const idsToLoad = idsToProcess.filter((_, index) => lockResults[index]);
   const lockedKeys: RedisKeyTemplateCache[] = idsToLoad.map(
     (id) => `${lockPrefix}:${id}` as RedisKeyTemplateCache
   );
   if (lockedKeys.length > 0) {
-    await Promise.all(lockedKeys.map((key) => redis.expire(key, 10)));
+    await Promise.all(
+      lockedKeys.map((key) =>
+        withMetricWriteFailSoft(() => redis.expire(key, 10), false, {
+          op: 'populate-lock:expire',
+          onFail: metricWriteFailHook,
+        })
+      )
+    );
   }
   if (idsToLoad.length === 0) {
     log(`All ${idsToProcess.length} comics are being loaded by other processes`);
@@ -346,7 +407,10 @@ export async function populateComicMetrics(
     log('Error during comic bulk population:', error);
   } finally {
     if (lockedKeys.length > 0) {
-      await redis.del(lockedKeys);
+      await withMetricWriteFailSoft(() => redis.del(lockedKeys), 0, {
+        op: 'populate-lock:del',
+        onFail: metricWriteFailHook,
+      });
     }
   }
 }

--- a/src/server/redis/entity-metric.redis.ts
+++ b/src/server/redis/entity-metric.redis.ts
@@ -6,8 +6,23 @@ import { chunk } from 'lodash-es';
 import type { RedisKeyTemplateCache } from './client';
 import { redis, REDIS_KEYS } from './client';
 import { createLogger } from '~/utils/logging';
+import { withMetricWriteFailSoft } from '~/server/redis/metric-write-failsoft';
 
 const log = createLogger('entity-metrics-redis', 'blue');
+
+// FIX #3: fail-soft hook for the increment WRITE path. Engagement-count increments are
+// analytics only (never money/entitlement), so a wedged cluster client must not 500/park a
+// user mutation through them — skip the increment, log + count, let the action succeed.
+function metricWriteFailHook(op: string, err: unknown) {
+  log(`metric write fail-soft [op=${op}]:`, err instanceof Error ? err.message : err);
+  (
+    globalThis as unknown as {
+      __civitaiRedisMetrics?: {
+        redisMetricWriteFailSoftCounter?: { labels: (l: { op: string }) => { inc: () => void } };
+      };
+    }
+  ).__civitaiRedisMetrics?.redisMetricWriteFailSoftCounter?.labels({ op }).inc();
+}
 
 /**
  * Static helper methods for entity metrics calculations
@@ -67,14 +82,26 @@ export class EntityMetricRedisClient {
     amount = 1
   ): Promise<number> {
     const key = this.getKey(entityType, entityId);
-    const result = await this.redis.hIncrBy(key, metricType, amount);
+    // FIX #3: fail-fast (short timeout) + fail-soft (skip on wedge → return 0) so a wedged
+    // cluster client can't 500/park the user mutation that triggered this analytics
+    // increment. 0 means "couldn't read the new total" — the only consumer is the < 0
+    // negative-correction in metric-helpers.ts, which 0 safely skips.
+    const result = await withMetricWriteFailSoft(
+      () => this.redis.hIncrBy(key, metricType, amount),
+      0,
+      { op: 'increment:hIncrBy', onFail: metricWriteFailHook }
+    );
     // Bound the key on the hot increment path too. setMetric/setMultipleMetrics
     // set this TTL, but increment() previously left the key permanent — so any
     // entitymetric:* key whose first/only touch was an increment (the hot
     // reaction/comment path) never expired. Refreshing on each increment also
     // gives a sliding TTL: the key lives while active, reaped 1h after the last
     // touch. (2026-06-09 redis usage audit)
-    await this.redis.expire(key, EntityMetricRedisClient.METRIC_TTL_SECONDS);
+    await withMetricWriteFailSoft(
+      () => this.redis.expire(key, EntityMetricRedisClient.METRIC_TTL_SECONDS),
+      false,
+      { op: 'increment:expire', onFail: metricWriteFailHook }
+    );
     return result;
   }
 

--- a/src/server/redis/metric-write-failsoft.ts
+++ b/src/server/redis/metric-write-failsoft.ts
@@ -58,13 +58,23 @@ export async function withMetricWriteFailSoft<T>(
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     if (ms && ms > 0) {
+      // Start the command ONCE and hold the reference so we can reap its LATE rejection on
+      // the timeout path (FIX #4). run() is the cluster command, itself wrapped by the 15s
+      // withCommandDeadline — so when our 1.5s `deadline` wins the race, run() is still in
+      // flight and rejects ~13.5s later. Without an attached handler that surfaces as an
+      // `unhandledRejection`. Reap it explicitly (mirrors command-deadline.ts /
+      // sys-read-deadline.ts, which assert no unhandledRejection in their tests).
+      const running = run();
+      running.catch(() => {
+        /* reaped: the fail-soft fallback was already returned on the deadline path */
+      });
       const deadline = new Promise<never>((_, reject) => {
         timer = setTimeout(
           () => reject(new Error(`metric write '${options.op}' timed out after ${ms}ms`)),
           ms
         );
       });
-      return await Promise.race([run(), deadline]);
+      return await Promise.race([running, deadline]);
     }
     return await run();
   } catch (err) {

--- a/src/server/redis/metric-write-failsoft.ts
+++ b/src/server/redis/metric-write-failsoft.ts
@@ -1,0 +1,76 @@
+import { env } from '~/env/server';
+
+/**
+ * Fail-fast + fail-soft guard for NON-CRITICAL metric WRITE/LOCK cluster commands
+ * (FIX #3 for the inflight-leak wedge).
+ *
+ * WHY: the metric write/lock commands — `metrics:lock:Image:<id>` setNX/expire
+ * (entity-metric-populate.ts), the increment hIncrBy (entity-metric.redis.ts) — are pure
+ * analytics/engagement counters. They are NOT money or entitlement: the values are
+ * reaction/comment/collection/buzz-tip ROLLUP counts repopulated from ClickHouse on a cache
+ * miss, and the locks are thundering-herd guards (a failed lock just means another process
+ * may also populate, or the populate is skipped this call — the read path already fail-opens
+ * to {} and the increment caller already swallows). EVIDENCE: imageMetricsCache.fetch's only
+ * caller (image.service.ts getImageMetrics) catches and returns {}; the increment path
+ * (metric-helpers.ts updateEntityMetric) catches and logs. So skipping any of these can
+ * never move money or grant/deny entitlement — at worst a counter is momentarily stale.
+ *
+ * Under the 15s default cluster command deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS), a
+ * WEDGED cluster client makes each of these PARK up to 15s and then throw — which can 500 a
+ * user mutation (or, where caught, add 15s of latency before the catch). This guard:
+ *   1. FAIL-FAST: bounds the command at REDIS_METRIC_WRITE_TIMEOUT_MS (default 1.5s) instead
+ *      of inheriting the 15s deadline, so a wedge is surfaced in ~1.5s not ~15s.
+ *   2. FAIL-SOFT: on timeout OR any redis error, returns the caller-supplied `fallback`
+ *      (e.g. `false` for a lock that "wasn't acquired", a benign number for an increment) and
+ *      fires the onFail hook (log + Prometheus counter) — the user action proceeds.
+ *
+ * The happy path is UNCHANGED: a command that settles before the timeout returns its real
+ * value with no fallback and no onFail.
+ *
+ * Cluster-scoped: only wrap cluster (cache) metric commands. The sysRedis client has its own
+ * bounding (withSysReadDeadline) and is never wrapped here.
+ */
+export interface MetricWriteFailSoftOptions {
+  /** Wall-clock timeout (ms). Defaults to REDIS_METRIC_WRITE_TIMEOUT_MS; <=0 falls back to
+   *  REDIS_CLUSTER_COMMAND_TIMEOUT_MS (the existing 15s deadline) so disabling is explicit. */
+  timeoutMs?: number;
+  /** Short label for logs/metrics (e.g. 'populate-lock:setNX', 'increment:hIncrBy'). */
+  op: string;
+  /** Fire-and-forget hook on the fail-soft path: (op, error) => log + count. Never throws. */
+  onFail?: (op: string, err: unknown) => void;
+}
+
+/**
+ * Run a non-critical metric write/lock redis command with a short fail-fast timeout and a
+ * fail-soft fallback. Resolves to the command's value on success, or `fallback` on
+ * timeout/error (after invoking onFail). Never rejects.
+ */
+export async function withMetricWriteFailSoft<T>(
+  run: () => Promise<T>,
+  fallback: T,
+  options: MetricWriteFailSoftOptions
+): Promise<T> {
+  const configured = options.timeoutMs ?? env.REDIS_METRIC_WRITE_TIMEOUT_MS;
+  // <=0 means "no dedicated metric-write bound" → fall back to the global cluster deadline
+  // (which still applies via instrumentCommands), preserving prior behavior.
+  const ms = configured > 0 ? configured : env.REDIS_CLUSTER_COMMAND_TIMEOUT_MS;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    if (ms && ms > 0) {
+      const deadline = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`metric write '${options.op}' timed out after ${ms}ms`)),
+          ms
+        );
+      });
+      return await Promise.race([run(), deadline]);
+    }
+    return await run();
+  } catch (err) {
+    options.onFail?.(options.op, err);
+    return fallback;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Context — prod incident root-caused 2026-06-20
civitai-dp-prod api-primary pods wedged against next-redis-cluster (~51/s HTTP 500s for ~45 min until a human rolling-restart cleared it). Root cause: the **node-redis cluster `_execute` inflight-leak** — a small fraction of cluster command promises get orphaned across cluster retry / `_slots.rediscover()` topology refresh and never settle. The existing 15s per-command deadline (`withCommandDeadline`) reaps each *command* (turns the hang into a 500 so the gauge dec's) but **never resets the wedged client** → the pod produces 500s indefinitely until a process restart.

A wedged pod flips to a binary state: `redis_commands_inflight{client="cluster"}` jumps past 50 and stays pinned (hundreds–thousands leaked). The wedge concentrates on the write/lock path (api-primary). The most plausible seed is the standing 30s periodic `_slots.rediscover()` racing an in-flight write.

This is a cohesive "cluster client self-heal + resilience" PR — three fixes.

## FIX #1 (primary) — client-level self-heal via forced reconnect
New pure, unit-tested `ClusterSelfHealWatchdog` (`src/server/redis/cluster-selfheal.ts`). When the in-process cluster inflight counter stays **above a threshold continuously for a sustained window** (the binary-wedge signature), it forces a **full client reconnect** (`close()` → `connect()`, rebuilding connections + `_slots`) — the only thing short of a process restart that clears the orphaned `_execute` promises.

Reconnect-storm safety — three independent brakes:
1. **Sustained window** — a transient spike drops back under the threshold and resets the timer; only a genuine pinned wedge survives.
2. **Cooldown** — at most one reconnect per cooldown.
3. **Single-flight** — ticks are skipped while a reconnect is in progress.

- Env-gated, **on-by-default + kill-switchable** (`REDIS_CLUSTER_SELFHEAL_ENABLED`).
- Logs + increments `civitai_app_redis_selfheal_reconnect_total` with the inflight value at trigger.
- A reconnect rejects in-flight commands → surfaces as a **normal command error** (never silent). **Money/entitlement safety:** the cluster client carries cache/metric traffic; money/entitlement state lives in Postgres + the single-node sysRedis client, which this watchdog **never touches**. A money-adjacent cluster command would see the same rejection it already gets for any cluster error (identical to a socketTimeout teardown).
- `client.ts` maintains a local `clusterInflight` counter in lockstep with the gauge (so the watchdog samples it without a prom dependency), and starts the watchdog **once per process** on the cache cluster connect.

## FIX #3 — fail-fast + fail-soft the non-critical metric write/lock path
New `withMetricWriteFailSoft` (`src/server/redis/metric-write-failsoft.ts`). The `metrics:lock:Image` setNX/expire (`entity-metric-populate.ts`) and the increment `hIncrBy` (`entity-metric.redis.ts`) are **pure analytics/engagement counters — never money/entitlement** (evidence: the read path `getImageMetrics` already fail-opens to `{}`, and the increment caller `updateEntityMetric` already swallows). They now:
- use a **short per-command timeout** (`REDIS_METRIC_WRITE_TIMEOUT_MS`, default 1.5s) instead of the 15s deadline, and
- **fail soft** (log + count via `civitai_app_redis_metric_write_failsoft_total` + skip), so a wedged cluster client can never 500/park a user mutation.

The happy path is unchanged.

## FIX #2 — env-disable-able periodic topology rediscover
`REDIS_CLUSTER_REFRESH_INTERVAL`: **0 (or any value ≤ 0) is the DISABLE SENTINEL** (no periodic rediscover; event-driven rediscovery on node-error/node-disconnect still runs), a larger value lengthens it, **unset = the unchanged 30s default**. Extracted as a pure, tested `resolvePeriodicRefresh()`. Lets infra run the lengthen/disable experiment (the most plausible wedge seed) as a pure env change. Also guards `setupEnhancedFailover` against stacking refresh intervals on each reconnect.

## New env vars (all safe defaults; nothing changes when unset except the on-by-default watchdog)
| var | default | purpose |
|---|---|---|
| `REDIS_CLUSTER_SELFHEAL_ENABLED` | `true` | FIX #1 kill-switch |
| `REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD` | `50` | wedge threshold |
| `REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS` | `20000` | sustained-breach window |
| `REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS` | `60000` | ≤1 reconnect/cooldown |
| `REDIS_CLUSTER_SELFHEAL_CHECK_INTERVAL_MS` | `1000` | sample interval |
| `REDIS_METRIC_WRITE_TIMEOUT_MS` | `1500` | FIX #3 fail-fast bound |
| `REDIS_CLUSTER_REFRESH_INTERVAL` | `30000` | FIX #2 — **0 = disable sentinel** |

## Tests (72 redis unit tests green)
- **#1** (`cluster-selfheal.test.ts`): sustained-high-inflight triggers exactly one reconnect; respects cooldown; no-fire on transient spike; no-op when disabled; strictly-above-threshold; single-flight; survives a rejecting reconnect; tick never throws.
- **#3** (`metric-write-failsoft.test.ts` + `entity-metric-failsoft.test.ts`): a metric-lock/increment timeout/error fails soft (the calling path still resolves) + increments the counter; happy path unchanged; honors the short timeout (not 15s).
- **#2** (`periodic-refresh.test.ts`): `REDIS_CLUSTER_REFRESH_INTERVAL=0` disables, a value lengthens, unset = default.

Typecheck: zero new `tsc` errors in changed files (the repo has a large pre-existing baseline unrelated to this change; CI authoritative). Local vitest run via borrowed primary-clone `node_modules`, then restored to pristine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)