### PR TITLE
chore(metrics): make entity-metric v2 + watcher cutover permanent

### DIFF
--- a/src/pages/api/internal/bitdex-stats.ts
+++ b/src/pages/api/internal/bitdex-stats.ts
@@ -1,7 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { dbRead } from '~/server/db/client';
-import { imageMetricsCache } from '~/server/redis/entity-metric-populate';
+import { clickhouse } from '~/server/clickhouse/client';
+import { redis } from '~/server/redis/client';
+import { MetricService } from '../../../../event-engine-common/services/metrics';
+import type {
+  IClickhouseClient,
+  IRedisClient,
+} from '../../../../event-engine-common/types/package-stubs';
 
 /**
  * BitDex comparison stats endpoint — lightweight ground-truth lookups.
@@ -19,10 +25,7 @@ import { imageMetricsCache } from '~/server/redis/entity-metric-populate';
  *   and metrics from Redis/ClickHouse (reactionLike, comment, collection, etc.)
  *   Max 50 IDs per request.
  */
-export default WebhookEndpoint(async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default WebhookEndpoint(async function handler(req: NextApiRequest, res: NextApiResponse) {
   // Set a 5-second statement timeout for all PG queries in this request
   await dbRead.$executeRawUnsafe(`SET LOCAL statement_timeout = '5000'`);
 
@@ -60,22 +63,29 @@ export default WebhookEndpoint(async function handler(
         },
       });
 
-      // Metrics from Redis/ClickHouse (per-ID, already optimized with caching)
-      const metrics = await imageMetricsCache.fetch(ids);
+      // Metrics from the watcher-fed `metrics:*` cache (MetricService, backed by
+      // the FINAL entityMetricDailyAgg_v2 view), per-ID with stampede caching.
+      const metricService = new MetricService(
+        clickhouse as IClickhouseClient,
+        redis as unknown as IRedisClient
+      );
+      const metrics = await metricService.fetch('Image', ids);
 
       result.images = images.map((img) => {
         const m = metrics[img.id];
         return {
           ...img,
-          metrics: m ? {
-            reactionLike: m.reactionLike ?? 0,
-            reactionHeart: m.reactionHeart ?? 0,
-            reactionLaugh: m.reactionLaugh ?? 0,
-            reactionCry: m.reactionCry ?? 0,
-            comment: m.comment ?? 0,
-            collection: m.collection ?? 0,
-            buzz: m.buzz ?? 0,
-          } : null,
+          metrics: m
+            ? {
+                reactionLike: m.Like ?? 0,
+                reactionHeart: m.Heart ?? 0,
+                reactionLaugh: m.Laugh ?? 0,
+                reactionCry: m.Cry ?? 0,
+                comment: m.commentCount ?? 0,
+                collection: m.Collection ?? 0,
+                buzz: m.tippedAmount ?? 0,
+              }
+            : null,
         };
       });
     }

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -9,16 +9,6 @@ export enum FLIPT_FEATURE_FLAGS {
   ARTICLE_RATING_DISPUTE = 'article-rating-dispute',
   FEED_IMAGE_EXISTENCE = 'feed-image-existence',
   ENTITY_METRIC_NO_CACHE_BUST = 'entity-metric-no-cache-bust',
-  // When ON, image metric counts are read from the watcher-fed `metrics:*`
-  // cache (MetricService) instead of the legacy in-app `entitymetric:*` cache.
-  // Default OFF — reversible kill switch for the metrics-source cutover.
-  IMAGE_METRICS_FROM_WATCHER = 'image-metrics-from-watcher',
-  // When ON, the entity-metric read path pulls per-day totals from the
-  // already-FINAL read VIEW `entityMetricDailyAgg_v2` (no argMax dedup) instead
-  // of the ReplacingMergeTree `entityMetricDailyAgg_new` (which needs argMax).
-  // Default OFF — reversible kill switch; merging/deploying is a no-op until the
-  // flag flips, and flipping back instantly restores the legacy source.
-  METRICS_AGG_V2_READ = 'metrics-agg-v2-read',
   FEED_POST_FILTER = 'feed-fetch-filter-in-post',
   REDIS_CLUSTER_ENHANCED_FAILOVER = 'redis-cluster-enhanced-failover',
 
@@ -393,49 +383,20 @@ export async function ensureFliptInitialized(): Promise<void> {
   await FliptSingleton.getInstance();
 }
 
-// Entity-metric read source, gated by METRICS_AGG_V2_READ. OFF (default) reads
-// the ReplacingMergeTree `entityMetricDailyAgg_new` which needs per-day argMax
-// dedup; ON reads the already-FINAL view `entityMetricDailyAgg_v2` directly.
-// Single source of truth shared by every read site (MetricService provider +
-// the search-index / populate / metric-helper queries) so the cutover is one
-// flag flip everywhere.
-export type EntityMetricAggSource = { table: string; needsArgMaxDedup: boolean };
-
-const ENTITY_METRIC_AGG_LEGACY: EntityMetricAggSource = {
-  table: 'entityMetricDailyAgg_new',
-  needsArgMaxDedup: true,
-};
-const ENTITY_METRIC_AGG_V2: EntityMetricAggSource = {
-  table: 'entityMetricDailyAgg_v2',
-  needsArgMaxDedup: false,
-};
-
-export async function getEntityMetricAggSource(): Promise<EntityMetricAggSource> {
-  const useV2 = await getFliptBoolean(FLIPT_FEATURE_FLAGS.METRICS_AGG_V2_READ);
-  return useV2 ? ENTITY_METRIC_AGG_V2 : ENTITY_METRIC_AGG_LEGACY;
-}
-
 // Build the inner `(entityId, metricType, day, total)` subquery the direct CH
 // read sites (search-index / comic populate / metric-helpers) sum over. `where`
 // is the caller's full WHERE clause (e.g. "WHERE entityType = 'Image' AND ...").
-// Legacy source argMax-dedups per (entity, metric, day); the v2 view is already
-// FINAL so we select total directly. Selecting metricType is harmless even for
-// callers that only group by day (it's just carried through the subquery).
-export function buildEntityMetricPerDaySource(
-  source: EntityMetricAggSource,
-  where: string
-): string {
-  if (source.needsArgMaxDedup) {
-    return `(
-      SELECT entityId, metricType, day, argMax(total, refreshedAt) AS total
-      FROM ${source.table}
-      ${where}
-      GROUP BY entityId, metricType, day
-    )`;
-  }
+// Reads the already-FINAL view `entityMetricDailyAgg_v2`, so we select total
+// directly (no argMax dedup). Selecting metricType is harmless even for callers
+// that only group by day (it's just carried through the subquery).
+//
+// (Historically this was flag-switchable via METRICS_AGG_V2_READ between the
+// ReplacingMergeTree `entityMetricDailyAgg_new` — which needed argMax — and the
+// v2 view; the v2 cutover is now permanent so the source is hardcoded.)
+export function buildEntityMetricPerDaySource(where: string): string {
   return `(
       SELECT entityId, metricType, day, total
-      FROM ${source.table}
+      FROM entityMetricDailyAgg_v2
       ${where}
     )`;
 }

--- a/src/server/metrics/metric-helpers.ts
+++ b/src/server/metrics/metric-helpers.ts
@@ -5,7 +5,7 @@ import type { AugmentedPool } from '~/server/db/db-helpers';
 import { parameterizedTemplateHandler, templateHandler } from '~/server/db/db-helpers';
 import type { JobContext } from '~/server/jobs/job';
 import { createLogger } from '~/utils/logging';
-import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
+import { buildEntityMetricPerDaySource } from '~/server/flipt/client';
 
 const log = createLogger('metric-helpers');
 
@@ -216,9 +216,7 @@ export function getEntityMetricTasks(ctx: EntityMetricContext) {
       ctx.jobContext.checkIfCanceled();
       log(`getEntityMetricTasks(${entityType}, ${metricType})`, i + 1, 'of', tasks.length);
 
-      const aggSource = await getEntityMetricAggSource();
       const perDaySource = buildEntityMetricPerDaySource(
-        aggSource,
         `WHERE entityType = '${entityType}'
             AND metricType = '${metricType}'
             AND entityId IN (${ids.join(',')})`

--- a/src/server/redis/entity-metric-populate.ts
+++ b/src/server/redis/entity-metric-populate.ts
@@ -3,7 +3,7 @@ import { clickhouse } from '~/server/clickhouse/client';
 import { entityMetricRedis } from '~/server/redis/entity-metric.redis';
 import { redis, REDIS_KEYS, type RedisKeyTemplateCache } from '~/server/redis/client';
 import { createLogger } from '~/utils/logging';
-import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
+import { buildEntityMetricPerDaySource } from '~/server/flipt/client';
 import type {
   EntityMetric_EntityType_Type,
   EntityMetric_MetricType_Type,
@@ -18,157 +18,12 @@ interface MetricData {
   total: number;
 }
 
-/**
- * Bulk populate Redis with entity metrics from ClickHouse
- * Uses per-ID locks to prevent thundering herd without blocking unrelated requests
- * @param forceRefresh - If true, skip exists check and overwrite existing values
- */
-export async function populateEntityMetrics(
-  entityType: EntityMetric_EntityType_Type,
-  entityIds: number[],
-  forceRefresh = false
-): Promise<void> {
-  if (!clickhouse || entityIds.length === 0) return;
-
-  let idsToProcess = entityIds;
-
-  // Only check existence if not force refreshing
-  if (!forceRefresh) {
-    const existsChecks = await Promise.all(
-      entityIds.map((id) => entityMetricRedis.exists(entityType, id))
-    );
-
-    idsToProcess = entityIds.filter((_, index) => !existsChecks[index]);
-
-    if (idsToProcess.length === 0) {
-      return; // All entities already populated
-    }
-  }
-
-  // Try to acquire per-ID locks for entities to process
-  const lockPrefix = `${REDIS_KEYS.ENTITY_METRICS.BASE}:lock:${entityType}`;
-  const lockResults = await Promise.all(
-    idsToProcess.map((id) => redis.setNX(`${lockPrefix}:${id}` as RedisKeyTemplateCache, '1'))
-  );
-
-  // Only load entities where we got the lock
-  const idsToLoad = idsToProcess.filter((_, index) => lockResults[index]);
-  const lockedKeys: RedisKeyTemplateCache[] = idsToLoad.map(
-    (id) => `${lockPrefix}:${id}` as RedisKeyTemplateCache
-  );
-
-  // Set TTL on acquired locks
-  if (lockedKeys.length > 0) {
-    await Promise.all(
-      lockedKeys.map((key) => redis.expire(key, 10)) // 10 seconds per ID
-    );
-  }
-
-  if (idsToLoad.length === 0) {
-    // No locks acquired, another process is handling all these IDs
-    log(`All ${idsToProcess.length} entities are being loaded by other processes`);
-    return;
-  }
-
-  try {
-    log(
-      `${forceRefresh ? 'Refreshing' : 'Loading'} ${idsToLoad.length} entities from ClickHouse (${
-        idsToProcess.length - idsToLoad.length
-      } handled by other processes)`
-    );
-
-    // Process in batches to avoid overwhelming ClickHouse
-    const batches = chunk(idsToLoad, 1000);
-
-    for (const batchIds of batches) {
-      const metrics = await clickhouse.$query<MetricData>(`
-        SELECT
-          entityId,
-          metricType,
-          sum(total) as total
-        FROM entityMetricDailyAgg
-        WHERE entityType = '${entityType}'
-          AND entityId IN (${batchIds.join(',')})
-        GROUP BY entityId, metricType
-        HAVING total > 0
-      `);
-
-      // Group metrics by entityId
-      const groupedMetrics = new Map<number, Record<EntityMetric_MetricType_Type, number>>();
-
-      for (const metric of metrics) {
-        if (!groupedMetrics.has(metric.entityId)) {
-          groupedMetrics.set(metric.entityId, {} as Record<EntityMetric_MetricType_Type, number>);
-        }
-        const entityMetrics = groupedMetrics.get(metric.entityId)!;
-        entityMetrics[metric.metricType] = metric.total;
-      }
-
-      // Bulk set in Redis
-      const promises: Promise<void>[] = [];
-      for (const [entityId, metrics] of groupedMetrics.entries()) {
-        promises.push(entityMetricRedis.setMultipleMetrics(entityType, entityId, metrics));
-      }
-
-      await Promise.all(promises);
-    }
-
-    log(`Completed bulk load for ${idsToLoad.length} entities`);
-  } catch (error) {
-    log('Error during bulk population:', error);
-    // Don't throw - other processes might succeed
-  } finally {
-    // Always release the locks we acquired
-    if (lockedKeys.length > 0) {
-      await redis.del(lockedKeys);
-    }
-  }
-}
-
-/**
- * Pre-warm cache for popular/recent images
- * This could be called periodically or during low-traffic times
- */
-export async function preWarmEntityMetrics(
-  entityType: EntityMetric_EntityType_Type = 'Image',
-  limit = 10000
-): Promise<void> {
-  if (!clickhouse) return;
-
-  log(`Pre-warming cache for top ${limit} entities`);
-
-  try {
-    // Get the most accessed entities from the last 24 hours
-    const recentEntities = await clickhouse.$query<{ entityId: number }>(`
-      SELECT DISTINCT entityId
-      FROM entityMetricDailyAgg
-      WHERE entityType = '${entityType}'
-        AND day >= today() - 1
-      ORDER BY entityId DESC
-      LIMIT ${limit}
-    `);
-
-    const entityIds = recentEntities.map((e) => e.entityId);
-
-    if (entityIds.length > 0) {
-      await populateEntityMetrics(entityType, entityIds);
-      log(`Pre-warmed cache for ${entityIds.length} entities`);
-    }
-  } catch (error) {
-    log('Error during pre-warming:', error);
-  }
-}
-
-type ImageMetricLookup = {
-  imageId: number;
-  reactionLike: number | null;
-  reactionHeart: number | null;
-  reactionLaugh: number | null;
-  reactionCry: number | null;
-  comment: number | null;
-  collection: number | null;
-  buzz: number | null;
-};
+// NOTE: the image-legacy read path was removed after the watcher/v2 cutover.
+// `populateEntityMetrics`, `preWarmEntityMetrics`, and `imageMetricsCache` (which
+// read the in-app `entitymetric:*` Redis cache, populated from ClickHouse's
+// legacy `entityMetricDailyAgg` table) are gone. Image metric reads now go
+// through the watcher-fed `metrics:*` cache via MetricService. The comic path
+// below is unrelated and still uses this file's helpers + entityMetricRedis.
 
 // Comic metrics come from two watcher handlers and land under two
 // `entityType` labels in ClickHouse:
@@ -177,7 +32,7 @@ type ImageMetricLookup = {
 // We unify them under a single 'Comic' Redis key so consumers don't have
 // to know which handler emitted which counter. Names are kept verbatim
 // from the watcher output so the populator can read straight from
-// entityMetricDailyAgg_new without a translation map.
+// entityMetricDailyAgg_v2 without a translation map.
 const COMIC_ENTITY_TYPES = ['Comic', 'ComicProject'] as const;
 const COMIC_REDIS_TYPE = 'Comic' as EntityMetric_EntityType_Type;
 
@@ -198,66 +53,11 @@ type ComicMetricLookup = {
   tippedAmount: number | null;
   tippedCount: number | null;
 };
-// Direct Redis entity metrics fetch with ClickHouse population
-// Implements the same interface as CachedObject for compatibility
-export const imageMetricsCache: Pick<
-  CachedObject<ImageMetricLookup>,
-  'fetch' | 'bust' | 'refresh' | 'flush'
-> = {
-  fetch: async (ids: number | number[]): Promise<Record<string, ImageMetricLookup>> => {
-    if (!Array.isArray(ids)) ids = [ids];
-    if (ids.length === 0) return {};
-
-    // Populate missing metrics from ClickHouse (uses per-ID locks internally)
-    await populateEntityMetrics('Image', ids);
-
-    // Fetch from Redis
-    const metricsMap = await entityMetricRedis.getBulkMetrics('Image', ids);
-
-    const results: Record<string, ImageMetricLookup> = {};
-    for (const id of ids) {
-      const metrics = metricsMap.get(id);
-      results[id] = {
-        imageId: id,
-        reactionLike: metrics?.ReactionLike || null,
-        reactionHeart: metrics?.ReactionHeart || null,
-        reactionLaugh: metrics?.ReactionLaugh || null,
-        reactionCry: metrics?.ReactionCry || null,
-        comment: metrics?.Comment || null,
-        collection: metrics?.Collection || null,
-        buzz: metrics?.Buzz || null,
-      };
-    }
-    return results;
-  },
-
-  bust: async (ids: number | number[]) => {
-    if (!Array.isArray(ids)) ids = [ids];
-    if (ids.length === 0) return;
-
-    // Delete from Redis to force re-fetch from ClickHouse
-    await Promise.all(ids.map((id) => entityMetricRedis.delete('Image', id)));
-  },
-
-  refresh: async (ids: number | number[], skipCache?: boolean) => {
-    if (!Array.isArray(ids)) ids = [ids];
-    if (ids.length === 0) return;
-
-    // Force refresh from ClickHouse with forceRefresh=true to overwrite existing values
-    await populateEntityMetrics('Image', ids, true);
-  },
-
-  flush: async () => {
-    // Clear all image metrics from Redis - Not Supported
-  },
-};
-
 /**
- * Mirror of `populateEntityMetrics` for comics: queries the `_new` aggregate
- * (which is the only one carrying non-Image data) for BOTH `Comic` and
- * `ComicProject` entityType rows, then stores everything under the
- * unified `Comic` Redis key. Uses per-id locks like the image path so a
- * burst of requests for the same comic doesn't fan out to ClickHouse.
+ * Comic metrics populator: queries the entity-metric aggregate for BOTH `Comic`
+ * and `ComicProject` entityType rows, then stores everything under the unified
+ * `Comic` Redis key. Uses per-id locks so a burst of requests for the same comic
+ * doesn't fan out to ClickHouse.
  */
 export async function populateComicMetrics(
   comicIds: number[],
@@ -300,19 +100,14 @@ export async function populateComicMetrics(
 
     const batches = chunk(idsToLoad, 1000);
     for (const batchIds of batches) {
-      // `entityMetricDailyAgg_new` is a materialized view that retains
-      // multiple `refreshedAt` snapshots per `(entityId, metricType, day)`.
-      // We have to argMax-dedup per day before summing across days, or a
-      // refresh that lands while we read will double-count. Same pattern
-      // as `getEntityMetricTasks` in src/server/metrics/metric-helpers.ts.
+      // Reads `entityMetricDailyAgg_v2` (the already-FINAL read view) via the
+      // shared `buildEntityMetricPerDaySource` helper — no argMax dedup needed.
       //
       // Both 'Comic' (engagement counters) and 'ComicProject' (tip
       // counters) buckets are merged into a single per-id totals row so
       // the Redis layer only knows about a unified 'Comic' key.
       const entityTypeList = COMIC_ENTITY_TYPES.map((t) => `'${t}'`).join(',');
-      const aggSource = await getEntityMetricAggSource();
       const perDaySource = buildEntityMetricPerDaySource(
-        aggSource,
         `WHERE entityType IN (${entityTypeList})
             AND entityId IN (${batchIds.join(',')})`
       );
@@ -352,11 +147,11 @@ export async function populateComicMetrics(
 }
 
 /**
- * Comic equivalent of `imageMetricsCache`. Same shape (`fetch`/`bust`/
- * `refresh`/`flush`) so consumers can swap entity types without learning
- * a new API. Returns one row per requested comic id with each tracked
- * counter normalized to `number | null` (`null` when the row exists in
- * Redis but the counter has no entry).
+ * Comic entity-metric read cache backed by `entityMetricRedis` + ClickHouse
+ * population (via `populateComicMetrics`). Exposes a CachedObject-shaped
+ * (`fetch`/`bust`/`refresh`/`flush`) API. Returns one row per requested comic id
+ * with each tracked counter normalized to `number | null` (`null` when the row
+ * exists in Redis but the counter has no entry).
  */
 export const comicMetricsCache: Pick<
   CachedObject<ComicMetricLookup>,

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -1708,7 +1708,7 @@ export const comicsRouter = router({
       }
 
       // Hydrate ClickHouse-backed counters (reads / followers / tips / hides)
-      // from Redis. The cache lazily populates from `entityMetricDailyAgg_new`
+      // from Redis. The cache lazily populates from `entityMetricDailyAgg_v2`
       // on miss, so first-page-of-a-cold-comic costs one CH query and
       // subsequent pages are pure Redis. Fall back to the PG engagement
       // count for `followerCount` until the watcher has fully backfilled.
@@ -2032,7 +2032,7 @@ export const comicsRouter = router({
       // Pull all watcher-fed counters (tips / reads / followers / hides)
       // through the cache. Replaces the previous inline aggregate against
       // BuzzTip — the watcher already rolls those tips up into
-      // `entityMetricDailyAgg_new` under `entityType = 'ComicProject'`,
+      // `entityMetricDailyAgg_v2` under `entityType = 'ComicProject'`,
       // and the cache merges them in with the engagement counters.
       const metrics = (await comicMetricsCache.fetch(project.id))[project.id] ?? null;
 

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -8,7 +8,7 @@ import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { dbRead } from '~/server/db/client';
 import { searchClient as client, updateDocs } from '~/server/meilisearch/client';
 import { getOrCreateIndex } from '~/server/meilisearch/util';
-import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
+import { buildEntityMetricPerDaySource } from '~/server/flipt/client';
 import {
   tagCache,
   tagIdsForImagesCache,
@@ -407,9 +407,7 @@ export const imagesSearchIndex = createSearchIndexUpdateProcessor({
       // Metrics:
       if (step === 1) {
         logger(`Pulling metrics :: ${indexName} ::`, batchLogKey, subBatchLogKey);
-        const aggSource = await getEntityMetricAggSource();
         const perDaySource = buildEntityMetricPerDaySource(
-          aggSource,
           `WHERE entityType = 'Image'
                 AND entityId IN (${batch.join(',')})`
         );

--- a/src/server/search-index/metrics-images--update-metrics.search-index.ts
+++ b/src/server/search-index/metrics-images--update-metrics.search-index.ts
@@ -4,7 +4,7 @@ import { metricsSearchClient as client, updateDocs } from '~/server/meilisearch/
 import { getOrCreateIndex } from '~/server/meilisearch/util';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
-import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
+import { buildEntityMetricPerDaySource } from '~/server/flipt/client';
 
 const READ_BATCH_SIZE = 100000;
 const MEILISEARCH_DOCUMENT_BATCH_SIZE = READ_BATCH_SIZE;
@@ -69,10 +69,8 @@ export const imagesMetricsDetailsSearchIndexUpdateMetrics = createSearchIndexUpd
         : Array.from({ length: batch.endId - batch.startId + 1 }, (_, i) => batch.startId + i);
 
     const metrics: Metrics[] = [];
-    const aggSource = await getEntityMetricAggSource();
     const tasks = chunk(ids, 5000).map((batch) => async () => {
       const perDaySource = buildEntityMetricPerDaySource(
-        aggSource,
         `WHERE entityType = 'Image'
             AND entityId IN (${batch.join(',')})`
       );

--- a/src/server/search-index/metrics-images.search-index.ts
+++ b/src/server/search-index/metrics-images.search-index.ts
@@ -11,7 +11,7 @@ import type { Availability } from '~/shared/utils/prisma/enums';
 import { removeEmpty } from '~/utils/object-helpers';
 import { isDefined } from '~/utils/type-guards';
 import { imageOnSiteSql } from '~/server/utils/image-onsite';
-import { buildEntityMetricPerDaySource, getEntityMetricAggSource } from '~/server/flipt/client';
+import { buildEntityMetricPerDaySource } from '~/server/flipt/client';
 
 const READ_BATCH_SIZE = 100000;
 const MEILISEARCH_DOCUMENT_BATCH_SIZE = READ_BATCH_SIZE;
@@ -391,9 +391,7 @@ export const imagesMetricsDetailsSearchIndex = createSearchIndexUpdateProcessor(
 
       if (step === 1) {
         logger(`Pulling metrics :: ${indexName} ::`, batchLogKey, subBatchLogKey);
-        const aggSource = await getEntityMetricAggSource();
         const perDaySource = buildEntityMetricPerDaySource(
-          aggSource,
           `WHERE entityType = 'Image'
                 AND entityId IN (${batch.join(',')})`
         );

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -75,7 +75,6 @@ import {
 import type { RedisKeyTemplateSys } from '~/server/redis/client';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
-import { imageMetricsCache } from '~/server/redis/entity-metric-populate';
 import { createCachedObject, queryCacheRaw } from '~/server/utils/cache-helpers';
 import { createLruCache } from '~/server/utils/lru-cache';
 import type { GetByIdInput } from '~/server/schema/base.schema';
@@ -197,13 +196,7 @@ import { getImageS3Client } from '~/utils/s3-client';
 import { serverUploadImage, getB2ImageS3Client } from '~/utils/s3-utils';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
-import {
-  FLIPT_FEATURE_FLAGS,
-  getEntityMetricAggSource,
-  getFliptBoolean,
-  getFliptVariant,
-  isFlipt,
-} from '../flipt/client';
+import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import { queryBitdex } from '~/server/bitdex/client';
 import type { FilterClause, SortClause, Value } from '~/server/bitdex/client';
@@ -1925,7 +1918,7 @@ export const getAllImages = async (
       include?.includes('profilePictures') ? getProfilePicturesForUsers(userIds) : undefined,
       includeCosmetics ? getCosmeticsForEntity({ ids: imageIds, entity: 'Image' }) : undefined,
       getThumbnailsForImages(videoIds),
-      getImageMetricsObject(rawImages, userId),
+      getImageMetricsObject(rawImages),
       include?.includes('metaSelect') ? getMetaForImages(imageIds) : undefined,
       includeBaseModel ? imageResourcesCache.fetch(imageIds) : undefined,
     ])
@@ -2237,7 +2230,7 @@ export const getAllImagesIndex = async (
       include?.includes('metaSelect') ? getMetaForImages(imageIds) : undefined,
       getMetadataForImages(videoIds), // Only need this for videos
       getThumbnailsForImages(videoIds), // Only need this for videos
-      getImageMetricsObject(searchResults, currentUserId),
+      getImageMetricsObject(searchResults),
       // Fetch tagIds from cache so client-side hidden-tag filtering works.
       // Search results from BitDex don't include tagIds (too expensive to store),
       // and Meilisearch tagIds may be stale, so always fetch from the authoritative cache.
@@ -2739,11 +2732,7 @@ export async function getImagesFromFeedSearch(
       },
       clickhouse as IClickhouseClient,
       pgDbWrite as IDbClient,
-      new MetricService(
-        clickhouse as IClickhouseClient,
-        redis as unknown as IRedisClient,
-        getEntityMetricAggSource
-      ),
+      new MetricService(clickhouse as IClickhouseClient, redis as unknown as IRedisClient),
       new CacheService(
         redis as unknown as IRedisClient,
         pgDbWrite as IDbClient,
@@ -3299,7 +3288,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
       const droppedCount = results.length - filtered.length;
       droppedIdsTotal.inc({ route, hit_type: 'miss' }, droppedCount);
 
-      const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
+      const imageMetrics = await getImageMetricsObject(filtered);
       const fullData = filtered.map((h) => {
         const match = imageMetrics[h.id];
         return {
@@ -3419,7 +3408,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     // Apply the (flagged) existence check
     const filtered = await checkImageExistence(filteredHitIds);
 
-    const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
+    const imageMetrics = await getImageMetricsObject(filtered);
 
     const fullData = filtered.map((h) => {
       const match = imageMetrics[h.id];
@@ -4348,7 +4337,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       const droppedCount = limitedHits.length - filtered.length;
       droppedIdsTotal.inc({ route, hit_type: 'miss' }, droppedCount);
 
-      const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
+      const imageMetrics = await getImageMetricsObject(filtered);
       const fullData = filtered.map((h) => {
         const match = imageMetrics[h.id];
         return {
@@ -4472,7 +4461,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       nextCursor = undefined;
     }
 
-    const imageMetrics = await getImageMetricsObject(filtered, currentUserId);
+    const imageMetrics = await getImageMetricsObject(filtered);
 
     const fullData = filtered.map((h) => {
       const match = imageMetrics[h.id];
@@ -4519,59 +4508,47 @@ let _imageMetricService: MetricService | null = null;
 const getImageMetricService = () =>
   (_imageMetricService ??= new MetricService(
     clickhouse as IClickhouseClient,
-    redis as unknown as IRedisClient,
-    getEntityMetricAggSource
+    redis as unknown as IRedisClient
   ));
 
-type ImageMetricsObject = Awaited<ReturnType<typeof imageMetricsCache.fetch>>;
+type ImageMetricsObject = Record<
+  number,
+  {
+    imageId: number;
+    reactionLike: number | null;
+    reactionHeart: number | null;
+    reactionLaugh: number | null;
+    reactionCry: number | null;
+    comment: number | null;
+    collection: number | null;
+    buzz: number | null;
+  }
+>;
 
-const getImageMetricsObject = async (
-  data: { id: number }[],
-  // The current viewer's userId, used solely to bucket the watcher-cutover
-  // rollout (below). Undefined for anon/unauthenticated reads.
-  userId?: number
-): Promise<ImageMetricsObject> => {
+// Image metric counts are read from the watcher-fed `metrics:*` cache via
+// MetricService (which now pulls from the FINAL `entityMetricDailyAgg_v2` view).
+// The legacy in-app `entitymetric:*` read path (imageMetricsCache) was retired
+// after the v2 + watcher cutover went 100% stable.
+const getImageMetricsObject = async (data: { id: number }[]): Promise<ImageMetricsObject> => {
   try {
     const ids = data.map((d) => d.id);
 
-    // Cutover kill switch. When ON, read image metrics from the watcher-fed
-    // `metrics:*` cache (MetricService). Default OFF keeps the legacy in-app
-    // `entitymetric:*` path, so merging this is a no-op; flip the flag to roll
-    // over, and flip back (then bust `metrics:*`) to revert instantly. The
-    // legacy write path is intentionally left intact so flip-back stays warm.
-    //
-    // Bucketed per-user (entityId = userId) so Flipt's percentage rollout ramps
-    // gradually (1% -> 10% -> 100%): a given user gets a consistent source
-    // across their whole feed, and the metrics:* cache warms in proportion to
-    // the rolled-out fraction rather than all at once (the cold-stampede that
-    // sank the first cutover, now also capped per-pod in MetricService). Anon
-    // traffic shares the 'anon' bucket and crosses the threshold atomically as
-    // the percentage ramps. The agg-source table (v2 vs legacy) is a SEPARATE
-    // global flag so every metrics:* populate uses one consistent CH source.
-    const fromWatcher = await getFliptBoolean(
-      FLIPT_FEATURE_FLAGS.IMAGE_METRICS_FROM_WATCHER,
-      userId?.toString() || 'anon'
-    );
-    if (fromWatcher) {
-      const metrics = await getImageMetricService().fetch('Image', ids);
-      const result: ImageMetricsObject = {};
-      for (const id of ids) {
-        const m = metrics[id];
-        result[id] = {
-          imageId: id,
-          reactionLike: m?.Like || null,
-          reactionHeart: m?.Heart || null,
-          reactionLaugh: m?.Laugh || null,
-          reactionCry: m?.Cry || null,
-          comment: m?.commentCount || null,
-          collection: m?.Collection || null,
-          buzz: m?.tippedAmount || null,
-        };
-      }
-      return result;
+    const metrics = await getImageMetricService().fetch('Image', ids);
+    const result: ImageMetricsObject = {};
+    for (const id of ids) {
+      const m = metrics[id];
+      result[id] = {
+        imageId: id,
+        reactionLike: m?.Like || null,
+        reactionHeart: m?.Heart || null,
+        reactionLaugh: m?.Laugh || null,
+        reactionCry: m?.Cry || null,
+        comment: m?.commentCount || null,
+        collection: m?.Collection || null,
+        buzz: m?.tippedAmount || null,
+      };
     }
-
-    return await imageMetricsCache.fetch(ids);
+    return result;
   } catch (e) {
     const error = e as Error;
     logToAxiom(
@@ -4736,7 +4713,7 @@ export const getImage = async ({
   const userCosmetics = await getCosmeticsForUsers([creatorId]);
   const profilePictures = await getProfilePicturesForUsers([creatorId]);
 
-  const imageMetrics = await getImageMetricsObject([firstRawImage], userId);
+  const imageMetrics = await getImageMetricsObject([firstRawImage]);
   const match = imageMetrics[firstRawImage.id];
   const imageCosmetics = await getCosmeticsForEntity({
     ids: [firstRawImage.id],

--- a/src/server/utils/metric-helpers.ts
+++ b/src/server/utils/metric-helpers.ts
@@ -5,8 +5,7 @@ import type { ProtectedContext } from '~/server/createContext';
 import { logToAxiom } from '~/server/logging/client';
 import { redis, REDIS_KEYS, type RedisKeyTemplateCache } from '~/server/redis/client';
 import { entityMetricRedis } from '~/server/redis/entity-metric.redis';
-import FliptSingleton, { FLIPT_FEATURE_FLAGS, isFlipt } from '../flipt/client';
-import { imageMetricsCache } from '~/server/redis/entity-metric-populate';
+import { isFlipt } from '../flipt/client';
 
 const logError = (name: string, details: Record<string, unknown>) => {
   logToAxiom({ type: 'error', name, details }, 'clickhouse').catch(() => {
@@ -24,7 +23,7 @@ const getAllMetricsFromClickHouse = async (
 
   const cData = await clickhouse.$query<{ metricType: string; total: number }>`
     SELECT metricType, sum(total) as total
-    FROM entityMetricDailyAgg
+    FROM entityMetricDailyAgg_v2
     WHERE entityType = '${entityType}' AND entityId = ${entityId}
     GROUP BY metricType
   `;
@@ -117,22 +116,12 @@ export const updateEntityMetric = async ({
       await entityMetricRedis.setMetric(entityType, entityId, metricType, 0);
     }
 
-    if (entityType === 'Image') {
-      let shouldBustCache = true;
-      const fliptClient = await FliptSingleton.getInstance();
-      if (fliptClient) {
-        const flag = fliptClient.evaluateBoolean({
-          flagKey: FLIPT_FEATURE_FLAGS.ENTITY_METRIC_NO_CACHE_BUST,
-          entityId: ctx.user?.id.toString() || 'anonymous',
-          context: {},
-        });
-        shouldBustCache = !flag.enabled;
-      }
-
-      if (shouldBustCache) {
-        await imageMetricsCache.bust(entityId);
-      }
-    }
+    // NOTE: the legacy `imageMetricsCache.bust(entityId)` call was removed here
+    // after the watcher/v2 cutover — nothing reads that in-app `entitymetric:*`
+    // image read cache anymore (image reads now go through the watcher-fed
+    // `metrics:*` MetricService cache). The `entityMetricRedis` increment above
+    // and the `ctx.track.entityMetric(...)` emission below are intentionally
+    // kept: the latter is what feeds the watcher (reactions -> metrics).
   } catch (e) {
     const error = e as Error;
     logError('Failed to increment metric', {


### PR DESCRIPTION
## What

The entity-metric **v2 read cutover** (read per-day totals from the already-FINAL `entityMetricDailyAgg_v2` view, served through the watcher-fed `metrics:*` cache via `MetricService`) is **live at 100% and stable**. This PR removes the two feature flags' gating, hardcodes v2 + watcher as the **only** read path, and migrates the last ungated legacy readers off the oldest CH table.

### `src/server/flipt/client.ts`
- Remove `IMAGE_METRICS_FROM_WATCHER` and `METRICS_AGG_V2_READ` from `FLIPT_FEATURE_FLAGS`
- Delete `getEntityMetricAggSource()`, the `ENTITY_METRIC_AGG_LEGACY`/`ENTITY_METRIC_AGG_V2` constants, and the `EntityMetricAggSource` type
- Simplify `buildEntityMetricPerDaySource(where)` to always emit the v2 form — `SELECT entityId, metricType, day, total FROM entityMetricDailyAgg_v2 WHERE ...` — with no argMax dedup (v2 is FINAL). Still used by the direct-read sites (search-index / comic populate / metric-helpers).

### `src/server/services/image.service.ts`
- `getImageMetricsObject()` always reads via the watcher `MetricService`; drops the `IMAGE_METRICS_FROM_WATCHER` flag eval and the legacy `imageMetricsCache.fetch` OFF-branch
- The `userId` param (only used to bucket the rollout) is removed, along with its ~7 call sites
- `ImageMetricsObject` is now an inline type (it previously derived from the deleted `imageMetricsCache.fetch`)
- Both `MetricService(...)` constructions drop the removed 3rd `aggSourceProvider` arg

### Ungated legacy readers repointed to `entityMetricDailyAgg_v2` (FINAL, no argMax)
- `src/server/utils/metric-helpers.ts` `getAllMetricsFromClickHouse()` — was reading `entityMetricDailyAgg` (the **oldest** table); now reads `_v2`. This is the sync-on-miss helper inside `updateEntityMetric`.
- `src/server/redis/entity-metric-populate.ts` comic populate — already went through the shared helper; comment + query now reflect v2.

### Dead legacy READ infra removed (verified no remaining callers)
- `entity-metric-populate.ts`: deleted `populateEntityMetrics`, `preWarmEntityMetrics`, and `imageMetricsCache` (they read the in-app `entitymetric:*` Redis cache populated from the old CH table). The **comic** path (`populateComicMetrics` / `comicMetricsCache`) and `entityMetricRedis` are untouched — still in active use.
- `src/pages/api/internal/bitdex-stats.ts`: migrated `imageMetricsCache.fetch` → `MetricService.fetch('Image', ids)` (with the `Like/Heart/.../tippedAmount` → `reactionLike/.../buzz` field remap).
- Search-index sites + `metrics/metric-helpers.ts`: dropped `getEntityMetricAggSource()`, call `buildEntityMetricPerDaySource(where)` directly.

## ⚠️ Event-emission path preserved
`updateEntityMetric()` in `utils/metric-helpers.ts` still does (1) the `entityMetricRedis` increment and (2) the `ctx.track.entityMetric(...)` emission that **feeds the watcher** (reactions → metrics). **Only** the now-dead legacy `imageMetricsCache.bust(entityId)` call was removed. The `entityMetricRedis` increment/sync block is deliberately left intact (removing it cleanly is riskier and not required) — see follow-ups.

## Submodule
Bumps `event-engine-common` to the PR branch head [civitai/event-engine-common#11](https://github.com/civitai/event-engine-common/pull/11), which drops the agg-source flag plumbing there.

**The submodule pointer MUST be re-pointed to the MERGED ee commit before this lands** (it currently points at the unmerged PR-A branch head).

## Bake-then-merge ordering (do NOT merge yet)
The cutover is live + stable; both PRs are held for a **~3-5 day bake** before merge.

1. **event-engine-common PR #11 merges first.**
2. Then **this PR** re-points the submodule to the merged ee commit and merges.
3. Then **F5** (separate, gated) drops the now-unread legacy CH tables (`entityMetricDailyAgg`, `entityMetricDailyAgg_new`).

No CH table is dropped here.

## Typecheck
`pnpm run typecheck` — all files touched by this PR are clean. The repo currently has ~175 **pre-existing** type errors unrelated to this change (stale generated Prisma client missing the `Model3D` models — `CollectionCard.tsx`, `3d-models/*`, `model3d.service.ts`, etc.); none are in metrics code.

## Deliberately left for follow-up
- The `entityMetricRedis` increment + ClickHouse sync-on-miss block inside `updateEntityMetric()` is now functionally dead for `Image` (nothing reads those `entitymetric:Image:*` keys after `imageMetricsCache` removal) but was left intact to avoid any risk to the write/event path. Safe to remove in a focused follow-up once confirmed.
- `ENTITY_METRIC_NO_CACHE_BUST` (`entity-metric-no-cache-bust`) is now unreferenced in code (it only gated the removed bust). Left in the enum to keep this PR scoped; candidate for enum cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)