### PR TITLE
feat(app-blocks): marketplace reviews (5★) + blue-buzz reward + Bayesian rating sort

### DIFF
--- a/prisma/migrations/20260621120000_app_block_reviews/migration.sql
+++ b/prisma/migrations/20260621120000_app_block_reviews/migration.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- App Blocks — MARKETPLACE REVIEWS (5-star)
+-- ============================================================
+-- A parallel table to "ResourceReview" (which is hard-bound to model/version
+-- FKs) so app blocks can carry star ratings without bending the model-review
+-- shape. Backs:
+--   - blocks.upsertReview / blocks.listReviews (gated dark behind the
+--     mod-segmented appBlocks Flipt flag)
+--   - getAppRatingTotals (AVG/COUNT, excludes `exclude` rows AND self-reviews)
+--   - the marketplace `rating` sort (Bayesian shrinkage) + avg/count on cards
+--   - the blue-buzz "leave a review" reward (fires ONCE per (user, app) on the
+--     first create; per-(user,app) dedup anchored on the unique constraint)
+--
+-- ⚠️ MANUAL-APPLY. The main civitai DB (CNPG nvme0, role=postgres) does NOT run
+-- `prisma migrate deploy` — this file is committed for HISTORY only and applied
+-- BY HAND (psql) per environment. Apply to:
+--   1. prod nvme0  (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev)
+-- The table is ADDITIVE + read only by the dark, mod-gated marketplace +
+-- review procedures, so applying it ahead of the code deploy is inert.
+--
+-- IF-NOT-EXISTS guards are used so a manual re-run is a no-op (Prisma's own
+-- DDL is not idempotent; this is hand-applied, so we make it safe to re-run).
+
+CREATE TABLE IF NOT EXISTS "app_block_reviews" (
+  "id"            SERIAL PRIMARY KEY,
+  -- The app block being reviewed. CASCADE so deleting an app reaps its reviews.
+  "app_block_id"  TEXT NOT NULL REFERENCES "app_blocks"("id") ON DELETE CASCADE,
+  -- The reviewer. CASCADE on GDPR user-delete.
+  "user_id"       INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  -- 1..5 stars. Range is validated in the service (kept off the DB so a future
+  -- product change doesn't require a manual ALTER on a hand-applied table), but
+  -- a CHECK is cheap insurance against a bad direct write.
+  "rating"        INTEGER NOT NULL,
+  "recommended"   BOOLEAN NOT NULL DEFAULT true,
+  "details"       TEXT,
+  -- Moderator controls. exclude / tos_violation keep abusive reviews out of the
+  -- rating aggregate + the Bayesian marketplace sort.
+  "exclude"       BOOLEAN NOT NULL DEFAULT false,
+  "tos_violation" BOOLEAN NOT NULL DEFAULT false,
+  "created_at"    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT "app_block_reviews_rating_range" CHECK ("rating" >= 1 AND "rating" <= 5)
+);
+
+-- One review per (user, app). Also the per-(user,app) idempotency anchor for the
+-- blue-buzz reward (the create branch only fires when this insert succeeds).
+CREATE UNIQUE INDEX IF NOT EXISTS "app_block_reviews_app_user_uniq"
+  ON "app_block_reviews" ("app_block_id", "user_id");
+
+-- Aggregate read path: AVG(rating) / COUNT(*) WHERE NOT exclude, per app.
+CREATE INDEX IF NOT EXISTS "app_block_reviews_app_agg_idx"
+  ON "app_block_reviews" ("app_block_id", "exclude");

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -564,6 +564,7 @@ model User {
   publishRequestsReviewed    AppBlockPublishRequest[]        @relation("PublishRequestReviewer")
   blockScopeInvocations      BlockScopeInvocation[]
   appUserScopeGrants         AppUserScopeGrant[]
+  appBlockReviews            AppBlockReview[]
   appDevForgejoIdentity      AppDevForgejoIdentity?
 
   @@index([deletedAt])
@@ -2310,6 +2311,7 @@ model AppBlock {
   publishRequests    AppBlockPublishRequest[]
   scopeInvocations   BlockScopeInvocation[]
   userScopeGrants    AppUserScopeGrant[]
+  reviews            AppBlockReview[]
 
   @@unique([appId, blockId], map: "app_blocks_app_block_uniq")
   // W1 audit C-3 fix: enforce one app per slug at the DB layer. The
@@ -2321,6 +2323,40 @@ model AppBlock {
   @@index([status, category], map: "app_blocks_status_category_idx")
   @@index([featured, featuredOrder], map: "app_blocks_featured_order_idx")
   @@map("app_blocks")
+}
+
+/// App Blocks marketplace review (F-E "marketplace" cluster). A parallel table
+/// to ResourceReview (which is hard-bound to model/version FKs) so we can carry
+/// star ratings for app blocks without bending the model-review shape.
+///
+/// 5-star rating (1..5, validated in the service). A blue-buzz reward fires
+/// ONCE per (user, app) on the first create. Self-reviews (app owner reviewing
+/// their own app) are rejected at the service layer AND excluded from the
+/// aggregate. `exclude`/`tosViolation` are moderator controls that keep abusive
+/// reviews out of the rating aggregate + the Bayesian marketplace sort.
+///
+/// ADDITIVE + MANUALLY APPLIED (CNPG nvme0 does not auto-apply; see the
+/// migration). NULL/empty until applied — read only by the dark, mod-gated
+/// marketplace + the gated review procedures.
+model AppBlockReview {
+  id           Int      @id @default(autoincrement())
+  appBlockId   String   @map("app_block_id")
+  appBlock     AppBlock @relation(fields: [appBlockId], references: [id], onDelete: Cascade)
+  userId       Int      @map("user_id")
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  rating       Int // 1..5 (STARS — validated in the service)
+  recommended  Boolean  @default(true)
+  details      String?
+  exclude      Boolean  @default(false)
+  tosViolation Boolean  @default(false) @map("tos_violation")
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  // One review per (user, app).
+  @@unique([appBlockId, userId], map: "app_block_reviews_app_user_uniq")
+  // Aggregate read path (AVG/COUNT WHERE NOT exclude).
+  @@index([appBlockId, exclude], map: "app_block_reviews_app_agg_idx")
+  @@map("app_block_reviews")
 }
 
 /// W1 v0 publish request — every version of every app goes through the

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -1,5 +1,11 @@
 import { Anchor, Badge, Button, Card, Group, Stack, Text, Title, Tooltip } from '@mantine/core';
-import { IconBolt, IconPlugConnected, IconSettings, IconShieldLock } from '@tabler/icons-react';
+import {
+  IconBolt,
+  IconPlugConnected,
+  IconSettings,
+  IconShieldLock,
+  IconStarFilled,
+} from '@tabler/icons-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
@@ -144,11 +150,27 @@ export function AppBlockCard({
           </Group>
         )}
         <Group justify="space-between" mt="auto" pt="xs">
-          <Group gap={4}>
-            <IconBolt size={14} />
-            <Text size="xs" c="dimmed">
-              {block.installCount.toLocaleString()} installs
-            </Text>
+          <Group gap={10}>
+            <Group gap={4}>
+              <IconBolt size={14} />
+              <Text size="xs" c="dimmed">
+                {block.installCount.toLocaleString()} installs
+              </Text>
+            </Group>
+            {/* F-E marketplace reviews: avg rating + review count. avgRating is
+                null for a 0-review app → show "No reviews". */}
+            <Group gap={4}>
+              <IconStarFilled size={13} className="text-yellow-500" />
+              {block.avgRating != null ? (
+                <Text size="xs" c="dimmed">
+                  {block.avgRating.toFixed(1)} ({block.reviewCount.toLocaleString()})
+                </Text>
+              ) : (
+                <Text size="xs" c="dimmed">
+                  No reviews
+                </Text>
+              )}
+            </Group>
           </Group>
           {/*
             Anon-conversion CTA (F-E E1): for a session-less viewer, clicking

--- a/src/components/Apps/AppBlockReviews.browser.test.tsx
+++ b/src/components/Apps/AppBlockReviews.browser.test.tsx
@@ -1,0 +1,196 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * F-E marketplace REVIEWS — component tests for the user-facing review UI.
+ *
+ * Two load-bearing behaviours, both network-free (tRPC mocked via the scaffold's
+ * documented `vi.mock('~/utils/trpc')` pattern):
+ *
+ *   1. The write form calls `blocks.upsertReview` with the rating + details the
+ *      user entered (the form↔backend wiring).
+ *   2. The list renders `details` as ESCAPED PLAIN TEXT — an HTML/script string
+ *      in `details` appears verbatim as text and is NOT parsed into DOM (no
+ *      injected element, no script execution). This guards the audit MEDIUM
+ *      (details is unsanitized server-side; React escaping is the control).
+ */
+
+// Hoisted, per-test-controllable mock impls (vi.mock is hoisted above imports).
+const mocks = vi.hoisted(() => ({
+  upsert: vi.fn(),
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  listItems: [] as Array<{
+    id: number;
+    userId: number;
+    rating: number;
+    recommended: boolean;
+    details: string | null;
+    createdAt: Date;
+  }>,
+  myReview: null as null | {
+    id: number;
+    userId: number;
+    rating: number;
+    recommended: boolean;
+    details: string | null;
+    createdAt: Date;
+  },
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getMyReview: {
+        useQuery: () => ({ data: mocks.myReview, isLoading: false }),
+      },
+      upsertReview: {
+        useMutation: ({ onSuccess }: { onSuccess?: (r: unknown) => void } = {}) => ({
+          mutate: (input: unknown) => {
+            mocks.upsert(input);
+            onSuccess?.({ review: { id: 1 }, isFirstReview: true });
+          },
+          isPending: false,
+        }),
+      },
+      listReviews: {
+        useInfiniteQuery: () => ({
+          data: { pages: [{ items: mocks.listItems, nextCursor: undefined }] },
+          isLoading: false,
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+          isFetchingNextPage: false,
+        }),
+      },
+    },
+    useUtils: () => ({
+      blocks: {
+        getMyReview: { invalidate: mocks.invalidate },
+        listReviews: { invalidate: mocks.invalidate },
+        getAppDetail: { invalidate: mocks.invalidate },
+      },
+    }),
+  },
+}));
+
+// Feature flag + current user: the form gate is supplied by the CALLER
+// (subscriptions prop) here, so just make the flag on and a signed-in user.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 42, username: 'viewer' }),
+}));
+
+// UserAvatar pulls in edge-url/cosmetics machinery we don't need here — stub it
+// to a plain element so the list rows render network-free.
+vi.mock('~/components/UserAvatar/UserAvatar', () => ({
+  UserAvatar: ({ userId }: { userId: number }) => <span>user-{userId}</span>,
+}));
+
+// Notifications are side-effects; stub them out.
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+// DaysFromNow needs the IsClientProvider context (not under test) — stub it.
+vi.mock('~/components/Dates/DaysFromNow', () => ({
+  DaysFromNow: ({ date }: { date: Date }) => <span>{date.toISOString()}</span>,
+}));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { AppBlockReviews } = await import('./AppBlockReviews');
+
+const ENABLED_SUB = {
+  id: 'sub-1',
+  appBlockId: 'app-1',
+  enabled: true,
+} as never;
+
+beforeEach(() => {
+  mocks.upsert.mockClear();
+  mocks.invalidate.mockClear();
+  mocks.listItems = [];
+  mocks.myReview = null;
+});
+
+describe('AppBlockReviews', () => {
+  test('write form submits upsertReview with the entered rating and details', async () => {
+    renderWithProviders(
+      <AppBlockReviews
+        appBlockId="app-1"
+        avgRating={null}
+        reviewCount={0}
+        subscriptions={[ENABLED_SUB]}
+      />
+    );
+
+    // Wait for the form to mount, then pick 4 stars. Mantine Rating renders a
+    // (visually-hidden, 0-size) radio input per star value with the change
+    // handler on its OVERLAID <label> (the visible star). The hidden input
+    // fails Playwright's visibility gate and a raw click on it doesn't reach
+    // React's controlled onChange, so click the associated <label> (carries
+    // `onClick={() => onChange(4)}`) directly.
+    const fourStarsLocator = page.getByRole('radio', { name: '4' });
+    await expect.element(fourStarsLocator).toBeInTheDocument();
+    const fourStars = fourStarsLocator.element() as HTMLInputElement;
+    const label = document.querySelector<HTMLLabelElement>(`label[for="${fourStars.id}"]`);
+    expect(label).not.toBeNull();
+    label!.click();
+
+    // Type details.
+    const textarea = page.getByRole('textbox');
+    await textarea.fill('Great app, very useful');
+
+    await page.getByRole('button', { name: /post review/i }).click();
+
+    expect(mocks.upsert).toHaveBeenCalledTimes(1);
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appBlockId: 'app-1',
+        rating: 4,
+        details: 'Great app, very useful',
+      })
+    );
+    // Success path invalidates the list + summary + my-review queries.
+    expect(mocks.invalidate).toHaveBeenCalled();
+  });
+
+  test('renders review rows and escapes HTML in details (no injected element / script)', async () => {
+    const hostile = '<img src=x onerror="window.__pwned=1"><script>window.__pwned=2</script>hello';
+    mocks.listItems = [
+      {
+        id: 7,
+        userId: 99,
+        rating: 5,
+        recommended: true,
+        details: hostile,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+
+    renderWithProviders(
+      <AppBlockReviews
+        appBlockId="app-1"
+        avgRating={5}
+        reviewCount={1}
+        subscriptions={[]}
+      />
+    );
+
+    // The hostile string is present verbatim as TEXT.
+    await expect.element(page.getByText(hostile, { exact: false })).toBeInTheDocument();
+
+    // It was NOT parsed into DOM: the <img src=x>/<script> from `details` never
+    // became real elements, and their side-effects never ran.
+    expect(document.querySelector('img[src="x"]')).toBeNull();
+    const scriptWithPayload = Array.from(document.querySelectorAll('script')).some((s) =>
+      s.textContent?.includes('__pwned')
+    );
+    expect(scriptWithPayload).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((window as any).__pwned).toBeUndefined();
+  });
+});

--- a/src/components/Apps/AppBlockReviews.tsx
+++ b/src/components/Apps/AppBlockReviews.tsx
@@ -1,0 +1,375 @@
+import {
+  Badge,
+  Button,
+  Card,
+  Divider,
+  Group,
+  Loader,
+  Rating,
+  Stack,
+  Switch,
+  Text,
+  Textarea,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
+import {
+  IconMoodSmile,
+  IconStarFilled,
+  IconThumbDown,
+  IconThumbUp,
+} from '@tabler/icons-react';
+import { useEffect, useMemo, useState } from 'react';
+import { DaysFromNow } from '~/components/Dates/DaysFromNow';
+import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { SubscriptionRecord } from '~/server/schema/blocks/subscription.schema';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+const DETAILS_MAX = 10000;
+
+type AppBlockReviewsProps = {
+  appBlockId: string;
+  /** Aggregate from getAppDetail. avgRating is null for a 0-review app. */
+  avgRating: number | null;
+  reviewCount: number;
+  /**
+   * The viewer's subscriptions for THIS app (already filtered by the page). The
+   * write form is gated on at least one ENABLED install — this matches the
+   * server gate (an enabled BlockUserSubscription is required). Pass an empty
+   * array when the viewer has none / is anon.
+   */
+  subscriptions: SubscriptionRecord[];
+};
+
+/**
+ * F-E marketplace REVIEWS — user-facing UI for the App Blocks 5-star review
+ * system. Pure UI + query wiring over the (already-tested, audited) backend
+ * procs: `blocks.upsertReview`, `blocks.listReviews`, `blocks.getMyReview`.
+ *
+ * GATING (mirrors the server gates; the server is the source of truth — these
+ * are display-only short-circuits):
+ *   - The whole section is rendered ONLY behind the page's `appBlocks` flag
+ *     (the page already returns <NotFound/> when the flag is off, but we guard
+ *     here too so the component can never render dark).
+ *   - The WRITE FORM shows only when the viewer is (a) signed in AND (b) has at
+ *     least one ENABLED install for this app. The "no self-review" gate has no
+ *     client-visible owner signal in PublicAppDetail, so it is enforced on the
+ *     server — if an owner somehow installs + tries to review, the upsert 403s
+ *     and we surface the friendly "You cannot review your own app" message.
+ *
+ * SECURITY: review `details` is rendered as PLAIN TEXT via React's default
+ * escaping (a `<Text>` child) — NEVER dangerouslySetInnerHTML. `details` is not
+ * sanitized server-side (audit MEDIUM), so the escaping is the control.
+ */
+export function AppBlockReviews({
+  appBlockId,
+  avgRating,
+  reviewCount,
+  subscriptions,
+}: AppBlockReviewsProps) {
+  const features = useFeatureFlags();
+  const currentUser = useCurrentUser();
+
+  const hasEnabledInstall = useMemo(
+    () => subscriptions.some((s) => s.appBlockId === appBlockId && s.enabled),
+    [subscriptions, appBlockId]
+  );
+  const canReview = !!features.appBlocks && !!currentUser && hasEnabledInstall;
+
+  // Don't render the section at all if the page itself is gated off.
+  if (!features.appBlocks) return null;
+
+  return (
+    <Stack gap="lg">
+      <ReviewSummary avgRating={avgRating} reviewCount={reviewCount} />
+      {canReview && <ReviewForm appBlockId={appBlockId} />}
+      <ReviewList appBlockId={appBlockId} viewerUserId={currentUser?.id} />
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary — avg stars + count. Renders even at 0 reviews.
+// ---------------------------------------------------------------------------
+
+function ReviewSummary({
+  avgRating,
+  reviewCount,
+}: {
+  avgRating: number | null;
+  reviewCount: number;
+}) {
+  const hasReviews = reviewCount > 0 && avgRating != null;
+  return (
+    <Stack gap={4}>
+      <Title order={4}>Reviews</Title>
+      {hasReviews ? (
+        <Group gap="xs" align="center">
+          <Text fw={600} size="xl" lh={1}>
+            {avgRating.toFixed(1)}
+          </Text>
+          <Rating value={avgRating} fractions={10} readOnly />
+          <Text c="dimmed" size="sm">
+            ({reviewCount.toLocaleString()} review{reviewCount === 1 ? '' : 's'})
+          </Text>
+        </Group>
+      ) : (
+        <Text c="dimmed" size="sm">
+          No reviews yet
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Write / edit form — gated by the caller. Pre-fills from getMyReview so the
+// SAME form edits an existing review (the backend upserts on (user, app)).
+// ---------------------------------------------------------------------------
+
+function ReviewForm({ appBlockId }: { appBlockId: string }) {
+  const queryUtils = trpc.useUtils();
+  const { data: myReview, isLoading: loadingMine } = trpc.blocks.getMyReview.useQuery({
+    appBlockId,
+  });
+
+  const [rating, setRating] = useState(0);
+  const [recommended, setRecommended] = useState(true);
+  const [details, setDetails] = useState('');
+
+  // Seed the form from the viewer's existing review once it loads. Keyed on the
+  // review id so a fresh load (or switching apps) reseeds, but typing isn't
+  // clobbered on every render.
+  useEffect(() => {
+    if (myReview) {
+      setRating(myReview.rating);
+      setRecommended(myReview.recommended);
+      setDetails(myReview.details ?? '');
+    }
+  }, [myReview?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { mutate, isPending } = trpc.blocks.upsertReview.useMutation({
+    onSuccess: async (res) => {
+      if (res.isFirstReview) {
+        showSuccessNotification({
+          title: 'Review posted',
+          message: 'Thanks for your review! +25 Buzz',
+        });
+      } else {
+        showSuccessNotification({ message: 'Review updated' });
+      }
+      await Promise.all([
+        queryUtils.blocks.getMyReview.invalidate({ appBlockId }),
+        queryUtils.blocks.listReviews.invalidate({ appBlockId }),
+        // The aggregate (avgRating/reviewCount) lives on getAppDetail; refresh it
+        // so the summary reflects the new/changed review.
+        queryUtils.blocks.getAppDetail.invalidate({ appBlockId }),
+      ]);
+    },
+    onError: (error) => {
+      showErrorNotification({
+        title: 'Could not post review',
+        error: new Error(error.message),
+      });
+    },
+  });
+
+  const handleSubmit = () => {
+    if (rating < 1) {
+      showErrorNotification({
+        title: 'Pick a rating',
+        error: new Error('Select a star rating (1–5) before posting.'),
+      });
+      return;
+    }
+    mutate({
+      appBlockId,
+      rating,
+      recommended,
+      details: details.trim() ? details : null,
+    });
+  };
+
+  const isEditing = !!myReview;
+  const overLimit = details.length > DETAILS_MAX;
+
+  return (
+    <Card withBorder radius="md" p="md">
+      <Stack gap="sm">
+        <Group justify="space-between" align="center">
+          <Text fw={600}>{isEditing ? 'Edit your review' : 'Write a review'}</Text>
+          {loadingMine && <Loader size="xs" />}
+        </Group>
+
+        <Group gap="xs" align="center">
+          <Text size="sm">Rating</Text>
+          <Rating value={rating} onChange={setRating} size="lg" />
+        </Group>
+
+        <Switch
+          checked={recommended}
+          onChange={(e) => setRecommended(e.currentTarget.checked)}
+          label="I recommend this app"
+          thumbIcon={
+            recommended ? (
+              <IconThumbUp size={12} stroke={3} />
+            ) : (
+              <IconThumbDown size={12} stroke={3} />
+            )
+          }
+        />
+
+        <Stack gap={2}>
+          <Textarea
+            label="Details (optional)"
+            placeholder="What did you think of this app?"
+            value={details}
+            onChange={(e) => setDetails(e.currentTarget.value)}
+            autosize
+            minRows={3}
+            maxRows={10}
+            maxLength={DETAILS_MAX}
+            error={overLimit ? `Max ${DETAILS_MAX.toLocaleString()} characters` : undefined}
+          />
+          <Text size="xs" c={overLimit ? 'red' : 'dimmed'} ta="right">
+            {details.length.toLocaleString()} / {DETAILS_MAX.toLocaleString()}
+          </Text>
+        </Stack>
+
+        <Group justify="flex-end">
+          <Button
+            onClick={handleSubmit}
+            loading={isPending}
+            disabled={rating < 1 || overLimit}
+            leftSection={<IconStarFilled size={16} />}
+          >
+            {isEditing ? 'Update review' : 'Post review'}
+          </Button>
+        </Group>
+      </Stack>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List — keyset/infinite. Renders details as ESCAPED PLAIN TEXT.
+// ---------------------------------------------------------------------------
+
+function ReviewList({
+  appBlockId,
+  viewerUserId,
+}: {
+  appBlockId: string;
+  viewerUserId?: number;
+}) {
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    trpc.blocks.listReviews.useInfiniteQuery(
+      { appBlockId },
+      { getNextPageParam: (lastPage) => lastPage.nextCursor }
+    );
+
+  const items = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);
+
+  if (isLoading) {
+    return (
+      <Group justify="center" py="md">
+        <Loader size="sm" />
+      </Group>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <Text c="dimmed" size="sm">
+        Be the first to review this app.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      {items.map((review) => (
+        <div key={review.id}>
+          <ReviewRow review={review} isViewer={review.userId === viewerUserId} />
+          <Divider mt="md" />
+        </div>
+      ))}
+      {hasNextPage && (
+        <Group justify="center">
+          <Button
+            variant="default"
+            onClick={() => fetchNextPage()}
+            loading={isFetchingNextPage}
+          >
+            Load more
+          </Button>
+        </Group>
+      )}
+    </Stack>
+  );
+}
+
+function ReviewRow({
+  review,
+  isViewer,
+}: {
+  review: {
+    id: number;
+    userId: number;
+    rating: number;
+    recommended: boolean;
+    details: string | null;
+    createdAt: Date;
+  };
+  isViewer: boolean;
+}) {
+  return (
+    <Group align="flex-start" wrap="nowrap" gap="sm">
+      <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
+        <Group gap="xs" align="center" wrap="wrap">
+          <UserAvatar userId={review.userId} size="sm" withUsername linkToProfile />
+          {isViewer && (
+            <Badge size="xs" variant="light" color="blue">
+              Your review
+            </Badge>
+          )}
+          <Text c="dimmed" size="xs">
+            <DaysFromNow date={review.createdAt} />
+          </Text>
+        </Group>
+        <Group gap="xs" align="center">
+          <Rating value={review.rating} readOnly size="sm" />
+          {review.recommended ? (
+            <Group gap={4} align="center">
+              <ThemeIcon variant="light" color="green" size="sm" radius="xl">
+                <IconMoodSmile size={12} />
+              </ThemeIcon>
+              <Text size="xs" c="green">
+                Recommends
+              </Text>
+            </Group>
+          ) : (
+            <Group gap={4} align="center">
+              <ThemeIcon variant="light" color="red" size="sm" radius="xl">
+                <IconThumbDown size={12} />
+              </ThemeIcon>
+              <Text size="xs" c="red">
+                Doesn&apos;t recommend
+              </Text>
+            </Group>
+          )}
+        </Group>
+        {/* PLAIN TEXT ONLY — React escapes this. NEVER dangerouslySetInnerHTML:
+            `details` is not sanitized server-side. */}
+        {review.details && (
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {review.details}
+          </Text>
+        )}
+      </Stack>
+    </Group>
+  );
+}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -27,6 +27,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
+import { AppBlockReviews } from '~/components/Apps/AppBlockReviews';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
@@ -112,6 +113,12 @@ export default function AppDetailPage() {
     return map;
   }, [mySubs, appBlockId]);
   const alreadySubscribed = Object.keys(existingByScope).length > 0;
+  // Subscriptions for THIS app — feeds the reviews write-form gate (an enabled
+  // install is required to review, mirroring the server gate).
+  const mySubsForApp = useMemo(
+    () => (mySubs ?? []).filter((sub) => sub.appBlockId === appBlockId),
+    [mySubs, appBlockId]
+  );
 
   if (!features.appBlocks) return <NotFound />;
 
@@ -397,6 +404,21 @@ export default function AppDetailPage() {
                   </List>
                 )}
               </Stack>
+
+              <Divider />
+
+              {/* F-E marketplace REVIEWS — summary + (gated) write form + list.
+                  Rendered behind the same appBlocks flag as the rest of the page
+                  (the component also self-guards). The aggregate (avgRating /
+                  reviewCount) comes from getAppDetail; the write form shows only
+                  for a signed-in viewer with an enabled install (server-enforced
+                  gates mirrored client-side). */}
+              <AppBlockReviews
+                appBlockId={appBlockId}
+                avgRating={detail.avgRating}
+                reviewCount={detail.reviewCount}
+                subscriptions={mySubsForApp}
+              />
             </Stack>
           )}
         </Stack>

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -141,6 +141,9 @@ export default function AppDetailPage() {
       // scopes from the authenticated getInstallConfig), so safe placeholders.
       category: null,
       scopesSummary: [],
+      // Marketplace reviews — carry through from the detail (display-safe).
+      avgRating: detail.avgRating,
+      reviewCount: detail.reviewCount,
     };
     openAppSettingsModal({ block, existingByScope });
   }

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -52,6 +52,7 @@ const MODEL_SLOT_FILTER_LABELS: Record<ModelSlotId, string> = {
 };
 
 const SORT_OPTIONS: { value: MarketplaceSort; label: string }[] = [
+  { value: 'rating', label: 'Top rated' },
   { value: 'popular', label: 'Most popular' },
   { value: 'newest', label: 'Newest' },
   { value: 'name', label: 'Name (A–Z)' },
@@ -76,7 +77,7 @@ export default function AppsPage() {
   const currentUser = useCurrentUser();
   const [slotFilter, setSlotFilter] = useState<SlotFilter | null>(null);
   const [category, setCategory] = useState<MarketplaceCategory | null>(null);
-  const [sort, setSort] = useState<MarketplaceSort>('popular');
+  const [sort, setSort] = useState<MarketplaceSort>('rating');
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearch] = useDebouncedValue(searchInput, 300);
 

--- a/src/pages/apps/installed.tsx
+++ b/src/pages/apps/installed.tsx
@@ -749,6 +749,9 @@ export default function InstalledAppsPage() {
       // E3 marketplace-card fields — unused on the Manage path (modal-only).
       category: null,
       scopesSummary: [],
+      // Marketplace reviews — unused on the Manage path (modal-only).
+      avgRating: null,
+      reviewCount: 0,
     };
     const existingByScope: Partial<Record<typeof sub.scope, SubscriptionRecord>> = {};
     for (const candidate of subs ?? []) {

--- a/src/server/rewards/__tests__/appBlockReview.reward.test.ts
+++ b/src/server/rewards/__tests__/appBlockReview.reward.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// appBlockReview reward (F-E "marketplace" cluster) — blue-buzz for leaving a
+// review. Money-touching, so we pin:
+//   - fires ONCE on the create branch (isFirstReview=true): blue account,
+//     forId = appBlockId (per-(user,app) dedup), correct user.
+//   - does NOT fire on an update (isFirstReview=false → getKey returns false →
+//     no Redis dedup write, no audit insert, no award).
+//   - fail-soft: a ClickHouse insert throw inside apply() does NOT propagate
+//     (the surrounding review write must still succeed).
+//   - already-awarded (Redis dedup returns -1) → no award, no throw.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => ({
+  insertImpl: vi.fn(async () => {}),
+  evalImpl: vi.fn(async () => 25 as number),
+  hGetImpl: vi.fn(async () => '{}'),
+  createBuzzTransactionMany: vi.fn(async () => ({ transactions: [] })),
+  getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
+  rewardFailedInc: vi.fn(),
+  rewardGivenInc: vi.fn(),
+  logToAxiom: vi.fn(async () => {}),
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: {
+    insert: (...args: any[]) => h.insertImpl(...args),
+    $query: vi.fn(async () => []),
+    query: vi.fn(async () => ({ json: async () => [] })),
+  },
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    eval: (...args: any[]) => h.evalImpl(...args),
+    hGet: (...args: any[]) => h.hGetImpl(...args),
+  },
+  REDIS_KEYS: { BUZZ_EVENTS: 'buzz-events' },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: {}, dbRead: {} }));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...args: any[]) => h.logToAxiom(...args),
+}));
+vi.mock('~/server/prom/client', () => ({
+  rewardFailedCounter: { inc: (...a: any[]) => h.rewardFailedInc(...a) },
+  rewardGivenCounter: { inc: (...a: any[]) => h.rewardGivenInc(...a) },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),
+  getMultipliersForUser: (...args: any[]) => h.getMultipliersForUser(...args),
+}));
+vi.mock('~/shared/constants/buzz.constants', () => ({
+  TransactionType: { Reward: 'Reward' },
+}));
+vi.mock('~/utils/string-helpers', () => ({
+  hashifyObject: (o: any) => `hash:${JSON.stringify(o)}`,
+}));
+
+// Import AFTER mocks.
+import { appBlockReviewReward } from '~/server/rewards/active/appBlockReview.reward';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.insertImpl.mockResolvedValue(undefined as any);
+  h.evalImpl.mockResolvedValue(25 as any); // award full amount by default
+  h.hGetImpl.mockResolvedValue('{}');
+  h.getMultipliersForUser.mockResolvedValue({ rewardsMultiplier: 1 });
+});
+
+describe('appBlockReviewReward', () => {
+  it('fires once on the create branch: blue account, forId=appBlockId, correct user', async () => {
+    await appBlockReviewReward.apply(
+      { appBlockId: 'ab_42', userId: 7, isFirstReview: true },
+      { ip: '1.2.3.4' }
+    );
+
+    // Audit row recorded with the right key.
+    expect(h.insertImpl).toHaveBeenCalledTimes(1);
+    const inserted = h.insertImpl.mock.calls[0][0] as { values: any[] };
+    expect(inserted.values[0]).toMatchObject({
+      type: 'appBlockReview',
+      toUserId: 7,
+      byUserId: 7,
+      forId: 'ab_42',
+    });
+
+    // Award granted to the BLUE account.
+    expect(h.createBuzzTransactionMany).toHaveBeenCalledTimes(1);
+    const txs = h.createBuzzTransactionMany.mock.calls[0][0] as any[];
+    expect(txs[0]).toMatchObject({ toAccountId: 7, toAccountType: 'blue' });
+    // Dedup anchor in the external transaction id is the appBlockId.
+    expect(txs[0].externalTransactionId).toContain('appBlockReview:ab_42');
+    expect(h.rewardGivenInc).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire on an update (isFirstReview=false → no key, no award, no insert)', async () => {
+    await appBlockReviewReward.apply(
+      { appBlockId: 'ab_42', userId: 7, isFirstReview: false },
+      { ip: '1.2.3.4' }
+    );
+
+    // getKey returned false → apply short-circuits before any side effect.
+    expect(h.evalImpl).not.toHaveBeenCalled();
+    expect(h.insertImpl).not.toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+
+  it('fail-soft: a ClickHouse insert throw does NOT propagate (review write survives)', async () => {
+    h.insertImpl.mockRejectedValue(new Error('Too many simultaneous queries for all users'));
+
+    await expect(
+      appBlockReviewReward.apply({ appBlockId: 'ab_42', userId: 7, isFirstReview: true })
+    ).resolves.toBeUndefined();
+
+    // No grant when the audit insert failed (no double-award), failure counted.
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+    expect(h.rewardFailedInc).toHaveBeenCalledTimes(1);
+  });
+
+  it('already-awarded (Redis dedup returns -1) → no award, no throw', async () => {
+    h.evalImpl.mockResolvedValue(-1); // dedup hit
+    await expect(
+      appBlockReviewReward.apply({ appBlockId: 'ab_42', userId: 7, isFirstReview: true })
+    ).resolves.toBeUndefined();
+
+    expect(h.insertImpl).not.toHaveBeenCalled();
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/rewards/__tests__/appBlockReview.reward.test.ts
+++ b/src/server/rewards/__tests__/appBlockReview.reward.test.ts
@@ -128,4 +128,86 @@ describe('appBlockReviewReward', () => {
     expect(h.insertImpl).not.toHaveBeenCalled();
     expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
   });
+
+  // -------------------------------------------------------------------------
+  // DAILY-CEILING (FIX 1): the cap is a per-UTC-day TOTAL across all apps, NOT a
+  // per-app cap. We prove the two belts that make this safe without
+  // re-implementing the Lua:
+  //   - distinct apps reviewed by the SAME user the SAME day produce DISTINCT
+  //     Redis cacheKeys (ARGV[2]) → they don't dedup against each other, so each
+  //     pays (the prior cap=25-per-day-total bug would have capped the 2nd to 0;
+  //     here the cap passed to Redis is the higher ceiling, ARGV[4]=250).
+  //   - the SAME app same-day produces the SAME cacheKey → the Redis dedup
+  //     (eval returns -1) suppresses the 2nd award, AND an update branch
+  //     (isFirstReview=false) never even reaches eval.
+  // -------------------------------------------------------------------------
+  describe('FIX 1: per-distinct-app reward, daily ceiling (not per-app cap)', () => {
+    const cacheKeyOf = (call: any[]) => call[1].arguments[1] as string; // ARGV[2]
+    const capOf = (call: any[]) => call[1].arguments[3] as string; // ARGV[4]
+
+    it('two DIFFERENT apps, same user, same day → distinct cacheKeys (each can pay) + cap is the higher ceiling (250)', async () => {
+      await appBlockReviewReward.apply(
+        { appBlockId: 'ab_1', userId: 7, isFirstReview: true },
+        { ip: '1.2.3.4' }
+      );
+      await appBlockReviewReward.apply(
+        { appBlockId: 'ab_2', userId: 7, isFirstReview: true },
+        { ip: '1.2.3.4' }
+      );
+
+      expect(h.evalImpl).toHaveBeenCalledTimes(2);
+      const k1 = cacheKeyOf(h.evalImpl.mock.calls[0]);
+      const k2 = cacheKeyOf(h.evalImpl.mock.calls[1]);
+      // Distinct apps → distinct dedup cacheKeys → NOT mutually capped at the
+      // first review. (forId = appBlockId is baked into the key.)
+      expect(k1).not.toEqual(k2);
+      expect(k1).toContain('ab_1');
+      expect(k2).toContain('ab_2');
+
+      // The cap handed to the Lua is the DAILY CEILING (25 * 10 = 250), NOT 25 —
+      // so the 2nd distinct app isn't capped to 0 the way cap=25 would.
+      expect(capOf(h.evalImpl.mock.calls[0])).toBe('250');
+      expect(capOf(h.evalImpl.mock.calls[1])).toBe('250');
+
+      // Both first-reviews granted (eval returns the full award by default).
+      expect(h.createBuzzTransactionMany).toHaveBeenCalledTimes(2);
+      const tx1 = h.createBuzzTransactionMany.mock.calls[0][0] as any[];
+      const tx2 = h.createBuzzTransactionMany.mock.calls[1][0] as any[];
+      expect(tx1[0].externalTransactionId).toContain('appBlockReview:ab_1');
+      expect(tx2[0].externalTransactionId).toContain('appBlockReview:ab_2');
+    });
+
+    it('SAME app reviewed twice the same day → SAME cacheKey → Redis dedup suppresses the 2nd award (no double-pay)', async () => {
+      // 1st create: full award.
+      await appBlockReviewReward.apply(
+        { appBlockId: 'ab_1', userId: 7, isFirstReview: true },
+        { ip: '1.2.3.4' }
+      );
+      // 2nd same-app same-day attempt: the Lua would HGET the existing entry and
+      // return -1 (already awarded). Model that.
+      h.evalImpl.mockResolvedValueOnce(-1 as any);
+      await appBlockReviewReward.apply(
+        { appBlockId: 'ab_1', userId: 7, isFirstReview: true },
+        { ip: '1.2.3.4' }
+      );
+
+      // Same forId → identical cacheKey across both attempts.
+      const k1 = cacheKeyOf(h.evalImpl.mock.calls[0]);
+      const k2 = cacheKeyOf(h.evalImpl.mock.calls[1]);
+      expect(k1).toEqual(k2);
+
+      // Only the FIRST attempt granted Buzz; the dedup (-1) suppressed the 2nd.
+      expect(h.createBuzzTransactionMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('SAME app, an UPDATE (isFirstReview=false) never reaches Redis → no reward', async () => {
+      await appBlockReviewReward.apply(
+        { appBlockId: 'ab_1', userId: 7, isFirstReview: false },
+        { ip: '1.2.3.4' }
+      );
+      // getKey returns false on the update branch → short-circuit before eval.
+      expect(h.evalImpl).not.toHaveBeenCalled();
+      expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/server/rewards/active/appBlockReview.reward.ts
+++ b/src/server/rewards/active/appBlockReview.reward.ts
@@ -1,0 +1,45 @@
+import { createBuzzEvent } from '../base.reward';
+
+/**
+ * Blue-buzz reward for leaving an App Block review (F-E "marketplace" cluster).
+ *
+ * Fires ONCE per (user, app): `forId = appBlockId` is the dedup anchor, and the
+ * caller only `apply`s on the CREATE branch of the review upsert (the DB unique
+ * `(app_block_id, user_id)` guarantees there's exactly one create per pair). The
+ * on-demand Redis dedup (`type:forId:toUserId:byUserId`) is a second belt.
+ *
+ * Blue buzz (non-cashable, generation-only) is the right currency: a review
+ * reward should fund generation, never be withdrawable. cap == awardAmount so a
+ * user can earn it at most once per app per day-window (the per-(user,app)
+ * uniqueness already caps it at once ever — the cap is belt-and-suspenders).
+ *
+ * Fail-soft: the inline `apply` path in createBuzzEvent never rethrows (a
+ * ClickHouse/reward brownout must not 500 the review write). The caller still
+ * wraps it in try/catch for defense-in-depth.
+ */
+export const appBlockReviewReward = createBuzzEvent({
+  type: 'appBlockReview',
+  toAccountType: 'blue',
+  description: 'You left a review on an app',
+  triggerDescription: 'For the first review you leave on each app',
+  awardAmount: 25,
+  cap: 25,
+  onDemand: true,
+  getKey: async (input: AppBlockReviewEvent) => {
+    // Only the first review (the create branch) is rewardable. A no-op update
+    // passes isFirstReview=false → no key → no award.
+    if (!input.isFirstReview) return false;
+    return {
+      toUserId: input.userId,
+      forId: input.appBlockId, // per-(user,app) dedup
+      byUserId: input.userId,
+      type: `appBlockReview`,
+    };
+  },
+});
+
+type AppBlockReviewEvent = {
+  appBlockId: string;
+  userId: number;
+  isFirstReview: boolean;
+};

--- a/src/server/rewards/active/appBlockReview.reward.ts
+++ b/src/server/rewards/active/appBlockReview.reward.ts
@@ -1,17 +1,39 @@
 import { createBuzzEvent } from '../base.reward';
 
+// Per-review award (blue buzz). The feature is "earn buzz for leaving a review",
+// so EACH distinct app the user first-reviews pays this once.
+const REVIEW_AWARD = 25;
+
+// DAILY ANTI-ABUSE CEILING (tunable). The on-demand reward's Lua cap counts ALL
+// entries in the per-(user, type) daily hash, so `cap` is a TOTAL across every
+// distinct app reviewed today — NOT a per-app cap. We set it to N distinct
+// app-reviews/day so each new app pays, while a single user can't farm it
+// unbounded in one UTC day. Blue buzz is non-cashable (generation-only) and
+// reviews are install-gated, so the farm value is low; pick a generous N.
+//   ⚠️ If this were `cap == REVIEW_AWARD`, the user's FIRST paid review on a UTC
+//   day would exhaust the cap and every OTHER distinct-app first-review that day
+//   would be capped to 0 — defeating the per-distinct-app intent.
+const DAILY_REVIEW_REWARD_CEILING = REVIEW_AWARD * 10; // 10 app-reviews/day
+
 /**
  * Blue-buzz reward for leaving an App Block review (F-E "marketplace" cluster).
  *
- * Fires ONCE per (user, app): `forId = appBlockId` is the dedup anchor, and the
- * caller only `apply`s on the CREATE branch of the review upsert (the DB unique
- * `(app_block_id, user_id)` guarantees there's exactly one create per pair). The
- * on-demand Redis dedup (`type:forId:toUserId:byUserId`) is a second belt.
+ * ONCE EVER PER (user, app) — guaranteed by two existing belts (NOT this cap):
+ *   1. DB-side: the `AppBlockReview` unique `(app_block_id, user_id)` + the
+ *      service's `isFirstReview` (true ONLY on the create branch) ⇒ the reward
+ *      is `apply`d at most once per (user, app), ever.
+ *   2. Redis-side: the on-demand dedup keys on `forId = appBlockId`, so the SAME
+ *      app reviewed twice the same UTC day hashes to the SAME cacheKey and is
+ *      deduped (returns -1). DISTINCT apps hash to DISTINCT cacheKeys, so they
+ *      do NOT dedup against each other — each distinct app can pay.
+ *
+ * `cap` is therefore a DAILY ANTI-FARM CEILING across all apps (see
+ * DAILY_REVIEW_REWARD_CEILING), NOT the once-per guard. Raising it lets distinct
+ * apps each pay (up to the ceiling/award per UTC day) WITHOUT letting the same
+ * app pay twice — the two belts above own that.
  *
  * Blue buzz (non-cashable, generation-only) is the right currency: a review
- * reward should fund generation, never be withdrawable. cap == awardAmount so a
- * user can earn it at most once per app per day-window (the per-(user,app)
- * uniqueness already caps it at once ever — the cap is belt-and-suspenders).
+ * reward should fund generation, never be withdrawable.
  *
  * Fail-soft: the inline `apply` path in createBuzzEvent never rethrows (a
  * ClickHouse/reward brownout must not 500 the review write). The caller still
@@ -21,9 +43,12 @@ export const appBlockReviewReward = createBuzzEvent({
   type: 'appBlockReview',
   toAccountType: 'blue',
   description: 'You left a review on an app',
-  triggerDescription: 'For the first review you leave on each app',
-  awardAmount: 25,
-  cap: 25,
+  triggerDescription: 'For each app you review for the first time',
+  awardAmount: REVIEW_AWARD,
+  // Daily ceiling, NOT a per-app cap. The per-(user, app) once-ever guarantee is
+  // the DB-unique + isFirstReview belt; same-app same-day is the Redis forId
+  // dedup. This only bounds total distinct-app review rewards per UTC day.
+  cap: DAILY_REVIEW_REWARD_CEILING,
   onDemand: true,
   getKey: async (input: AppBlockReviewEvent) => {
     // Only the first review (the create branch) is rewardable. A no-op update
@@ -31,7 +56,9 @@ export const appBlockReviewReward = createBuzzEvent({
     if (!input.isFirstReview) return false;
     return {
       toUserId: input.userId,
-      forId: input.appBlockId, // per-(user,app) dedup
+      // DISTINCT per app: this is the Redis dedup anchor, so distinct apps get
+      // distinct cacheKeys (each pays) while the same app same-day is deduped.
+      forId: input.appBlockId,
       byUserId: input.userId,
       type: `appBlockReview`,
     };

--- a/src/server/rewards/index.ts
+++ b/src/server/rewards/index.ts
@@ -1,6 +1,7 @@
 export { imagePostedToModelReward } from './passive/imagePostedToModel.reward';
 export { encouragementReward } from './active/encouragement.reward';
 export { firstDailyPostReward } from './active/firstDailyPost.reward';
+export { appBlockReviewReward } from './active/appBlockReview.reward';
 export { goodContentReward } from './passive/goodContent.reward';
 export { collectedContentReward } from './passive/collectedContent.reward';
 export { refereeCreatedReward } from './active/refereeCreated.reward';

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -28,7 +28,9 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
 }));
 vi.mock('~/env/server', () => ({
-  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com' },
+  // LOGGING is read by cache-helpers' createLogger at module-eval (the router
+  // now statically imports appBlockReview.service, which imports cache-helpers).
+  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', LOGGING: '' },
 }));
 vi.mock('~/server/services/blocks/dev-git-access.service', () => ({
   ensureForgejoIdentity: mockEnsureForgejoIdentity,
@@ -84,6 +86,17 @@ vi.mock('~/server/redis/client', () => ({
 }));
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+// F-E marketplace reviews — the router now statically imports these; stub them
+// so this test stays isolated (it exercises getMyAppRepo, not reviews).
+vi.mock('~/server/rewards/active/appBlockReview.reward', () => ({
+  appBlockReviewReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/appBlockReview.service', () => ({
+  upsertAppBlockReview: vi.fn(),
+  listAppBlockReviews: vi.fn(),
+  getMyAppBlockReview: vi.fn(),
+  setAppReviewExcluded: vi.fn(),
 }));
 vi.mock('~/server/services/buzz.service', () => ({
   getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),

--- a/src/server/routers/__tests__/blocks.router.upsertReview.test.ts
+++ b/src/server/routers/__tests__/blocks.router.upsertReview.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * F-E marketplace REVIEWS — `blocks.upsertReview` router coverage.
+ *
+ * Pins the MONEY-TOUCHING wiring at the boundary (the gates themselves are
+ * covered exhaustively in appBlockReview.service.test.ts; the reward in
+ * appBlockReview.reward.test.ts):
+ *   - DARK: the appBlocks flag is the gate. A non-mod without the flag → the
+ *     mutation throws UNAUTHORIZED, the service is NEVER consulted, the reward
+ *     NEVER fires.
+ *   - REWARD fires ONLY on the create branch (isFirstReview=true).
+ *   - REWARD does NOT fire on an update (isFirstReview=false).
+ *   - FAIL-SOFT: a reward throw does NOT fail the review mutation (the review
+ *     write already committed).
+ */
+
+const { mockIsAppBlocksEnabled, mockUpsert, mockRewardApply } = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockUpsert: vi.fn(),
+  mockRewardApply: vi.fn(),
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/server/services/appBlockReview.service', () => ({
+  upsertAppBlockReview: (...a: unknown[]) => mockUpsert(...a),
+  listAppBlockReviews: vi.fn(),
+  getMyAppBlockReview: vi.fn(),
+  setAppReviewExcluded: vi.fn(),
+}));
+vi.mock('~/server/rewards/active/appBlockReview.reward', () => ({
+  appBlockReviewReward: { apply: (...a: unknown[]) => mockRewardApply(...a) },
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    getAppDetail: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/textToImage/textToImage', () => ({
+  createTextToImageStep: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn() },
+  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+// guardedProcedure = protected + onboarded + not-muted. onboarding=255 sets all
+// steps (incl. Buzz); muted:false; not banned/deleted.
+const modUser = {
+  id: 1,
+  isModerator: true,
+  tier: 'free',
+  username: 'mod',
+  onboarding: 255,
+  muted: false,
+};
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    ip: '1.2.3.4',
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: !!(user as { isModerator?: boolean })?.isModerator } as never,
+    track: undefined,
+  };
+}
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset().mockImplementation(fakePerUserFlag);
+  mockUpsert.mockReset();
+  mockRewardApply.mockReset().mockResolvedValue(undefined);
+});
+
+const input = { appBlockId: 'ab_1', rating: 5 };
+
+describe('blocks.upsertReview — dark behind the flag + reward wiring', () => {
+  it('DARK: a non-mod without the flag → UNAUTHORIZED, service + reward NOT called', async () => {
+    const nonMod = { ...modUser, id: 2, isModerator: false };
+    const caller = blocksRouter.createCaller(fakeCtx(nonMod) as never);
+    await expect(caller.upsertReview(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockRewardApply).not.toHaveBeenCalled();
+  });
+
+  it('CREATE branch fires the blue-buzz reward exactly once (isFirstReview=true)', async () => {
+    mockUpsert.mockResolvedValue({
+      review: { id: 1, appBlockId: 'ab_1', rating: 5, recommended: true },
+      isFirstReview: true,
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.upsertReview(input);
+    expect(res.isFirstReview).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockRewardApply).toHaveBeenCalledTimes(1);
+    expect(mockRewardApply).toHaveBeenCalledWith(
+      { appBlockId: 'ab_1', userId: 1, isFirstReview: true },
+      { ip: '1.2.3.4' }
+    );
+  });
+
+  it('UPDATE branch does NOT fire the reward (isFirstReview=false)', async () => {
+    mockUpsert.mockResolvedValue({
+      review: { id: 1, appBlockId: 'ab_1', rating: 4, recommended: true },
+      isFirstReview: false,
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.upsertReview({ appBlockId: 'ab_1', rating: 4 });
+    expect(res.isFirstReview).toBe(false);
+    expect(mockRewardApply).not.toHaveBeenCalled();
+  });
+
+  it('FAIL-SOFT: a reward throw does NOT fail the review mutation', async () => {
+    mockUpsert.mockResolvedValue({
+      review: { id: 1, appBlockId: 'ab_1', rating: 5, recommended: true },
+      isFirstReview: true,
+    });
+    mockRewardApply.mockRejectedValue(new Error('ClickHouse brownout'));
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    // Resolves (review committed) despite the reward throwing.
+    await expect(caller.upsertReview(input)).resolves.toMatchObject({ isFirstReview: true });
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -20,10 +20,20 @@ import {
   getAppDetailSchema,
   getFeaturedBlocksSchema,
   getMarketplaceMetaSchema,
+  listAppBlockReviewsSchema,
   listAvailableSchema,
+  setAppReviewExcludedSchema,
   setMarketplaceMetaSchema,
   subscriptionScopeSchema,
+  upsertAppBlockReviewSchema,
 } from '~/server/schema/blocks/subscription.schema';
+import {
+  getMyAppBlockReview,
+  listAppBlockReviews,
+  setAppReviewExcluded,
+  upsertAppBlockReview,
+} from '~/server/services/appBlockReview.service';
+import { appBlockReviewReward } from '~/server/rewards/active/appBlockReview.reward';
 import {
   approveRequestSchema,
   backfillPublishRequestSchema,
@@ -71,6 +81,7 @@ import { cancelWorkflow, getWorkflow, submitWorkflow } from '~/server/services/o
 import { createTextToImageStep } from '~/server/services/orchestrator/textToImage/textToImage';
 import { getUserById } from '~/server/services/user.service';
 import {
+  guardedProcedure,
   moderatorProcedure,
   protectedProcedure,
   middleware,
@@ -1358,6 +1369,117 @@ export const blocksRouter = router({
         !ctx.user?.isModerator
       );
       return { items };
+    }),
+
+  // -------------------------------------------------------------------------
+  // F-E marketplace REVIEWS (5-star) — all DARK behind enforceAppBlocksFlag.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Create-or-update the viewer's review for an app block (5-star).
+   *
+   * GATING / ANTI-ABUSE (all enforced, see appBlockReview.service):
+   *   - enforceAppBlocksFlag (dark today: mutation throws UNAUTHORIZED when off).
+   *   - guardedProcedure: authenticated, email-verified, NOT muted.
+   *   - rating ∈ [1,5]; NO self-review (owner rejected); MUST have an enabled
+   *     install; ONE per (user, app) via the DB unique (upsert, not a 2nd row).
+   *
+   * REWARD (money-touching): a blue-buzz reward fires ONCE per (user, app), only
+   * on the CREATE branch (isFirstReview), AFTER the insert succeeds. It is
+   * FAIL-SOFT — a reward/ClickHouse outage must never 500 the review. We wrap
+   * it in try/catch as defense-in-depth on top of createBuzzEvent's own
+   * fail-soft inline path.
+   */
+  upsertReview: guardedProcedure
+    .use(enforceAppBlocksFlag)
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 60,
+        errorMessage: 'Too many review submissions — slow down.',
+      })
+    )
+    .input(upsertAppBlockReviewSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { review, isFirstReview } = await upsertAppBlockReview({
+        userId: ctx.user.id,
+        appBlockId: input.appBlockId,
+        rating: input.rating,
+        recommended: input.recommended,
+        details: input.details ?? null,
+      });
+
+      // Blue-buzz reward — first review only, fail-soft. The reward must never
+      // fail the review write (it's an audit/analytics + non-cashable grant).
+      if (isFirstReview) {
+        try {
+          await appBlockReviewReward.apply(
+            { appBlockId: input.appBlockId, userId: ctx.user.id, isFirstReview: true },
+            { ip: ctx.ip }
+          );
+        } catch (error) {
+          logToAxiom(
+            {
+              name: 'app-block-review-reward',
+              type: 'error',
+              message: 'Failed to apply appBlockReview reward (non-fatal)',
+              appBlockId: input.appBlockId,
+              userId: ctx.user.id,
+              error: (error as Error)?.message,
+            },
+            'app-blocks'
+          ).catch(() => undefined);
+        }
+      }
+
+      return { review, isFirstReview };
+    }),
+
+  /**
+   * Keyset-paginated list of an app's reviews (newest first), excluding
+   * mod-excluded rows. Public/anon-CAPABLE but DARK behind the flag (returns an
+   * empty page when the flag is off, same posture as listAvailable).
+   */
+  listReviews: publicProcedure
+    .use(enforceAppBlocksFlag)
+    .use(
+      rateLimit({
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many review requests — slow down.',
+      })
+    )
+    .input(listAppBlockReviewsSchema)
+    .query(async ({ ctx, input }) => {
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return { items: [], nextCursor: undefined };
+      }
+      return listAppBlockReviews(input);
+    }),
+
+  /**
+   * The viewer's own review for an app block (or null) — backs the
+   * "you rated this N★" state on the detail page. protectedProcedure (per-user
+   * data), DARK behind the flag.
+   */
+  getMyReview: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(getAppDetailSchema)
+    .query(async ({ ctx, input }) => {
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return null;
+      return getMyAppBlockReview(input.appBlockId, ctx.user.id);
+    }),
+
+  /**
+   * MOD-ONLY: flip `exclude` on a review so it drops out of the rating aggregate
+   * + the Bayesian sort. moderatorProcedure + the flag gate. Mirrors
+   * toggleExcludeResourceReview.
+   */
+  setReviewExcluded: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(setAppReviewExcludedSchema)
+    .mutation(async ({ input }) => {
+      return setAppReviewExcluded(input);
     }),
 
   /**

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -169,6 +169,11 @@ export type AvailableBlock = {
   installCount: number;
   category: string | null;
   scopesSummary: string[];
+  // Marketplace reviews (F-E "marketplace" cluster). avgRating is NULL when the
+  // app has no aggregate-eligible reviews (0-review apps); reviewCount excludes
+  // mod-excluded + self-reviews. Both display-safe (aggregate numbers only).
+  avgRating: number | null;
+  reviewCount: number;
 };
 
 /**
@@ -200,13 +205,17 @@ export function toPublicBlockManifest(raw: unknown): PublicBlockManifest {
 }
 
 /**
- * F-E E3 marketplace sort options:
- *   - `popular` (default) — install_count DESC (distinct-user installs).
- *   - `newest`            — current_version_deployed_at DESC, falling back to
- *                           created_at for pre-W2 rows with no deploy timestamp.
- *   - `name`              — manifest name ASC (case-insensitive).
+ * F-E marketplace sort options:
+ *   - `rating` (DEFAULT) — Bayesian-shrinkage avg rating DESC (a few-review 5★
+ *                          app can't outrank a many-review 4.x app; 0-review
+ *                          apps sit mid-pack at the global mean `m`). Ties fall
+ *                          back to install_count then id.
+ *   - `popular`          — install_count DESC (distinct-user installs).
+ *   - `newest`           — current_version_deployed_at DESC, falling back to
+ *                          created_at for pre-W2 rows with no deploy timestamp.
+ *   - `name`             — manifest name ASC (case-insensitive).
  */
-export const marketplaceSortSchema = z.enum(['popular', 'newest', 'name']);
+export const marketplaceSortSchema = z.enum(['rating', 'popular', 'newest', 'name']);
 export type MarketplaceSort = z.infer<typeof marketplaceSortSchema>;
 
 export const listAvailableSchema = z.object({
@@ -218,9 +227,10 @@ export const listAvailableSchema = z.object({
   // taxonomy const (MARKETPLACE_CATEGORIES) so the schema and the UI/DB share
   // ONE list — adding a category is a one-line const edit, no schema migration.
   category: z.enum(MARKETPLACE_CATEGORIES).optional(),
-  // F-E E3: sort order; defaults to popular (install_count desc) — same as the
-  // pre-E3 fixed ordering, so the default behaviour is unchanged.
-  sort: marketplaceSortSchema.default('popular'),
+  // F-E marketplace: sort order; defaults to `rating` (Bayesian-shrinkage avg
+  // rating desc) so the best-reviewed apps surface first; 0-review apps sit
+  // mid-pack at the global mean (not unfairly buried).
+  sort: marketplaceSortSchema.default('rating'),
   cursor: z.string().max(64).optional(),
   limit: z.number().int().min(1).max(50).default(20),
 });
@@ -278,6 +288,34 @@ export const getMarketplaceMetaSchema = z.object({
   appBlockId: z.string().min(1).max(64),
 });
 export type GetMarketplaceMetaInput = z.infer<typeof getMarketplaceMetaSchema>;
+
+// ---------------------------------------------------------------------------
+// F-E marketplace REVIEWS (5-star) — schemas.
+// ---------------------------------------------------------------------------
+
+/** Upsert (create-or-update) the viewer's review for an app block. */
+export const upsertAppBlockReviewSchema = z.object({
+  appBlockId: z.string().min(1).max(64),
+  rating: z.number().int().min(1).max(5), // STARS
+  recommended: z.boolean().optional(),
+  details: z.string().max(10000).nullish(),
+});
+export type UpsertAppBlockReviewInput = z.infer<typeof upsertAppBlockReviewSchema>;
+
+/** Keyset-paginated list of an app's reviews (newest first). */
+export const listAppBlockReviewsSchema = z.object({
+  appBlockId: z.string().min(1).max(64),
+  cursor: z.number().int().positive().optional(),
+  limit: z.number().int().min(1).max(50).default(20),
+});
+export type ListAppBlockReviewsInput = z.infer<typeof listAppBlockReviewsSchema>;
+
+/** MOD-ONLY: flip `exclude` on a review (keeps abuse out of the aggregate). */
+export const setAppReviewExcludedSchema = z.object({
+  id: z.number().int().positive(),
+  exclude: z.boolean(),
+});
+export type SetAppReviewExcludedInput = z.infer<typeof setAppReviewExcludedSchema>;
 
 /**
  * MOD-ONLY current marketplace metadata for one app_block — returned by
@@ -390,6 +428,9 @@ export type PublicAppDetail = {
   contentRating: string | null;
   version: string | null;
   installCount: number;
+  // Marketplace reviews (aggregate-eligible). avgRating NULL = 0-review app.
+  avgRating: number | null;
+  reviewCount: number;
   liveUrl: string;
   screenshots: PublicScreenshot[];
 };

--- a/src/server/services/__tests__/appBlockReview.service.test.ts
+++ b/src/server/services/__tests__/appBlockReview.service.test.ts
@@ -90,6 +90,62 @@ describe('upsertAppBlockReview — create vs update', () => {
   });
 });
 
+describe('upsertAppBlockReview — recommended default/preserve (FIX 2)', () => {
+  it('CREATE defaults recommended to true when omitted', async () => {
+    mockDb.appBlockReview.findUnique.mockResolvedValue(null);
+    await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 });
+    const data = (mockDb.appBlockReview.create.mock.calls[0][0] as { data: any }).data;
+    expect(data.recommended).toBe(true);
+  });
+
+  it('CREATE honors an explicit recommended=false', async () => {
+    mockDb.appBlockReview.findUnique.mockResolvedValue(null);
+    await upsertAppBlockReview({
+      userId: 7,
+      appBlockId: 'ab_1',
+      rating: 5,
+      recommended: false,
+    });
+    const data = (mockDb.appBlockReview.create.mock.calls[0][0] as { data: any }).data;
+    expect(data.recommended).toBe(false);
+  });
+
+  it('UPDATE that OMITS recommended does NOT write it (preserves a stored false)', async () => {
+    mockDb.appBlockReview.findUnique.mockResolvedValue({ id: 1 });
+    await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 4 });
+    const data = (mockDb.appBlockReview.update.mock.calls[0][0] as { data: any }).data;
+    // The bug: a default `recommended = true` would flip an existing false back
+    // to true. The field must be ABSENT from the update payload when omitted.
+    expect('recommended' in data).toBe(false);
+    expect(data).toMatchObject({ rating: 4 });
+  });
+
+  it('UPDATE that PROVIDES recommended writes it explicitly', async () => {
+    mockDb.appBlockReview.findUnique.mockResolvedValue({ id: 1 });
+    await upsertAppBlockReview({
+      userId: 7,
+      appBlockId: 'ab_1',
+      rating: 4,
+      recommended: false,
+    });
+    const data = (mockDb.appBlockReview.update.mock.calls[0][0] as { data: any }).data;
+    expect(data.recommended).toBe(false);
+  });
+
+  it('P2002-fallback UPDATE also preserves recommended when omitted', async () => {
+    mockDb.appBlockReview.findUnique.mockResolvedValue(null);
+    mockDb.appBlockReview.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: 'test',
+      })
+    );
+    await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 });
+    const data = (mockDb.appBlockReview.update.mock.calls[0][0] as { data: any }).data;
+    expect('recommended' in data).toBe(false);
+  });
+});
+
 describe('upsertAppBlockReview — concurrent first-review race (P2002 → update)', () => {
   it('a CREATE that loses the unique race falls back to UPDATE with isFirstReview=false (no 2nd reward, no 500)', async () => {
     // Both racers read null (findUnique) → both reach create. This racer LOSES:

--- a/src/server/services/__tests__/appBlockReview.service.test.ts
+++ b/src/server/services/__tests__/appBlockReview.service.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// App Blocks review SERVICE — upsert gates + aggregate + cache bust.
+//
+// Pins (money + correctness):
+//   - create vs update: isFirstReview ONLY on create (drives the once-per
+//     reward); update returns false.
+//   - GATES: rating range; NO self-review (app owner rejected); NOT-installed
+//     rejected; one-per-user via the unique (we read existing → update branch).
+//   - getAppRatingTotals SQL excludes mod-excluded rows AND self-reviews.
+//   - cache bust fires on upsert (the app tag + the global-mean tag).
+// ---------------------------------------------------------------------------
+
+const { mockDb, mockBust, capturedRatingSql } = vi.hoisted(() => ({
+  mockDb: {
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    blockUserSubscription: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    appBlockReview: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      delete: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  },
+  mockBust: vi.fn(async () => undefined),
+  capturedRatingSql: { value: '' as string },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+
+// queryCache: bypass Redis — execute the query and capture the SQL so we can
+// assert the exclude + self-review filters are present.
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache: () => async (query: { sql?: string }) => {
+    if (query && typeof query === 'object' && typeof query.sql === 'string') {
+      capturedRatingSql.value = query.sql;
+    }
+    // Return a single aggregate row so getAppRatingTotals projects it.
+    return [{ avg_rating: 4.25, review_count: 8 }];
+  },
+  bustCacheTag: (...args: unknown[]) => mockBust(...args),
+}));
+
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+
+import {
+  bustAppRatingCache,
+  getAppRatingTotals,
+  setAppReviewExcluded,
+  upsertAppBlockReview,
+} from '~/server/services/appBlockReview.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedRatingSql.value = '';
+  // Default: app owned by user 99, viewer installed.
+  mockDb.appBlock.findUnique.mockResolvedValue({ app: { userId: 99 } });
+  mockDb.blockUserSubscription.findFirst.mockResolvedValue({ id: 'bus_1' });
+  mockDb.appBlockReview.findUnique.mockResolvedValue(null);
+  mockDb.appBlockReview.create.mockResolvedValue({
+    id: 1,
+    appBlockId: 'ab_1',
+    rating: 5,
+    recommended: true,
+  });
+  mockDb.appBlockReview.update.mockResolvedValue({
+    id: 1,
+    appBlockId: 'ab_1',
+    rating: 4,
+    recommended: true,
+  });
+});
+
+describe('upsertAppBlockReview — create vs update', () => {
+  it('CREATE branch returns isFirstReview=true and inserts', async () => {
+    const res = await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 });
+    expect(res.isFirstReview).toBe(true);
+    expect(mockDb.appBlockReview.create).toHaveBeenCalledTimes(1);
+    expect(mockDb.appBlockReview.update).not.toHaveBeenCalled();
+  });
+
+  it('UPDATE branch returns isFirstReview=false (no second-award) and updates', async () => {
+    mockDb.appBlockReview.findUnique.mockResolvedValue({ id: 1 });
+    const res = await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 4 });
+    expect(res.isFirstReview).toBe(false);
+    expect(mockDb.appBlockReview.update).toHaveBeenCalledTimes(1);
+    expect(mockDb.appBlockReview.create).not.toHaveBeenCalled();
+  });
+
+  it('busts the rating cache (app tag + global-mean tag) on upsert', async () => {
+    await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 });
+    expect(mockBust).toHaveBeenCalledTimes(1);
+    const tags = mockBust.mock.calls[0][0] as string[];
+    expect(tags).toContain('app-rating:ab_1');
+    expect(tags).toContain('app-rating:global-mean');
+  });
+});
+
+describe('upsertAppBlockReview — anti-abuse gates', () => {
+  it('rejects an out-of-range rating (0 / 6 / non-integer)', async () => {
+    for (const bad of [0, 6, 3.5]) {
+      await expect(
+        upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: bad })
+      ).rejects.toThrow();
+    }
+    expect(mockDb.appBlockReview.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a SELF-REVIEW (the app owner reviewing their own app)', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue({ app: { userId: 7 } }); // owner == viewer
+    await expect(
+      upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 })
+    ).rejects.toThrow(/your own app/i);
+    expect(mockDb.appBlockReview.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the viewer has NOT installed (no enabled subscription)', async () => {
+    mockDb.blockUserSubscription.findFirst.mockResolvedValue(null);
+    await expect(
+      upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 })
+    ).rejects.toThrow(/install/i);
+    expect(mockDb.appBlockReview.create).not.toHaveBeenCalled();
+  });
+
+  it('only counts an ENABLED install (findFirst is scoped to enabled=true)', async () => {
+    await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 });
+    const where = (mockDb.blockUserSubscription.findFirst.mock.calls[0][0] as { where: any }).where;
+    expect(where).toMatchObject({ appBlockId: 'ab_1', userId: 7, enabled: true });
+  });
+
+  it('rejects for a missing app block', async () => {
+    mockDb.appBlock.findUnique.mockResolvedValue(null);
+    await expect(
+      upsertAppBlockReview({ userId: 7, appBlockId: 'ab_missing', rating: 5 })
+    ).rejects.toThrow();
+  });
+});
+
+describe('getAppRatingTotals — aggregate excludes mod-excluded + self-reviews', () => {
+  it('SQL excludes `exclude` rows AND the app owner self-review', async () => {
+    const totals = await getAppRatingTotals('ab_1');
+    expect(totals).toEqual({ avgRating: 4.25, reviewCount: 8 });
+    const sql = capturedRatingSql.value;
+    expect(sql).toMatch(/NOT\s+abr\.exclude/i);
+    // Self-review exclusion: owner (OauthClient.userId) vs reviewer, NULL-safe.
+    expect(sql).toMatch(/oc\."userId"\s+IS DISTINCT FROM\s+abr\.user_id/i);
+    expect(sql).toMatch(/AVG\(abr\.rating\)/i);
+  });
+});
+
+describe('setAppReviewExcluded — mod control busts the cache', () => {
+  it('flips exclude + busts the app rating cache', async () => {
+    mockDb.appBlockReview.update.mockResolvedValue({ id: 5, appBlockId: 'ab_9', exclude: true });
+    const res = await setAppReviewExcluded({ id: 5, exclude: true });
+    expect(res).toEqual({ id: 5, appBlockId: 'ab_9', exclude: true });
+    expect(mockBust).toHaveBeenCalledTimes(1);
+    expect(mockBust.mock.calls[0][0]).toContain('app-rating:ab_9');
+  });
+});
+
+describe('bustAppRatingCache', () => {
+  it('busts both the per-app tag and the global-mean tag', async () => {
+    await bustAppRatingCache('ab_x');
+    expect(mockBust).toHaveBeenCalledWith(['app-rating:ab_x', 'app-rating:global-mean']);
+  });
+});

--- a/src/server/services/__tests__/appBlockReview.service.test.ts
+++ b/src/server/services/__tests__/appBlockReview.service.test.ts
@@ -1,18 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
-// App Blocks review SERVICE — upsert gates + aggregate + cache bust.
+// App Blocks review SERVICE — upsert gates + concurrency + cache bust.
 //
 // Pins (money + correctness):
 //   - create vs update: isFirstReview ONLY on create (drives the once-per
 //     reward); update returns false.
+//   - CONCURRENCY: a first-review create that loses the unique race (P2002)
+//     falls back to update with isFirstReview=false → graceful, NO second
+//     reward, NO 500.
 //   - GATES: rating range; NO self-review (app owner rejected); NOT-installed
 //     rejected; one-per-user via the unique (we read existing → update branch).
-//   - getAppRatingTotals SQL excludes mod-excluded rows AND self-reviews.
-//   - cache bust fires on upsert (the app tag + the global-mean tag).
+//   - cache bust fires on upsert / setExcluded (the global-mean tag only — the
+//     visible per-app aggregates are uncached, so there is no per-app tag).
 // ---------------------------------------------------------------------------
 
-const { mockDb, mockBust, capturedRatingSql } = vi.hoisted(() => ({
+import { Prisma } from '@prisma/client';
+
+const { mockDb, mockBust } = vi.hoisted(() => ({
   mockDb: {
     appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     blockUserSubscription: {
@@ -27,36 +32,22 @@ const { mockDb, mockBust, capturedRatingSql } = vi.hoisted(() => ({
     },
   },
   mockBust: vi.fn(async () => undefined),
-  capturedRatingSql: { value: '' as string },
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
 
-// queryCache: bypass Redis — execute the query and capture the SQL so we can
-// assert the exclude + self-review filters are present.
 vi.mock('~/server/utils/cache-helpers', () => ({
-  queryCache: () => async (query: { sql?: string }) => {
-    if (query && typeof query === 'object' && typeof query.sql === 'string') {
-      capturedRatingSql.value = query.sql;
-    }
-    // Return a single aggregate row so getAppRatingTotals projects it.
-    return [{ avg_rating: 4.25, review_count: 8 }];
-  },
   bustCacheTag: (...args: unknown[]) => mockBust(...args),
 }));
 
-vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
-
 import {
   bustAppRatingCache,
-  getAppRatingTotals,
   setAppReviewExcluded,
   upsertAppBlockReview,
 } from '~/server/services/appBlockReview.service';
 
 beforeEach(() => {
   vi.clearAllMocks();
-  capturedRatingSql.value = '';
   // Default: app owned by user 99, viewer installed.
   mockDb.appBlock.findUnique.mockResolvedValue({ app: { userId: 99 } });
   mockDb.blockUserSubscription.findFirst.mockResolvedValue({ id: 'bus_1' });
@@ -91,12 +82,56 @@ describe('upsertAppBlockReview — create vs update', () => {
     expect(mockDb.appBlockReview.create).not.toHaveBeenCalled();
   });
 
-  it('busts the rating cache (app tag + global-mean tag) on upsert', async () => {
+  it('busts the global-mean cache on upsert (no per-app tag — aggregates are uncached)', async () => {
     await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 });
     expect(mockBust).toHaveBeenCalledTimes(1);
     const tags = mockBust.mock.calls[0][0] as string[];
-    expect(tags).toContain('app-rating:ab_1');
-    expect(tags).toContain('app-rating:global-mean');
+    expect(tags).toEqual(['app-rating:global-mean']);
+  });
+});
+
+describe('upsertAppBlockReview — concurrent first-review race (P2002 → update)', () => {
+  it('a CREATE that loses the unique race falls back to UPDATE with isFirstReview=false (no 2nd reward, no 500)', async () => {
+    // Both racers read null (findUnique) → both reach create. This racer LOSES:
+    // the unique index throws P2002. The service must catch it, update instead,
+    // and report isFirstReview=false so the reward fires ONLY for the winner.
+    mockDb.appBlockReview.findUnique.mockResolvedValue(null);
+    mockDb.appBlockReview.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: 'test',
+      })
+    );
+    mockDb.appBlockReview.update.mockResolvedValue({
+      id: 1,
+      appBlockId: 'ab_1',
+      rating: 5,
+      recommended: true,
+    });
+
+    const res = await upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 });
+
+    // Graceful: no throw, falls through to update.
+    expect(res.isFirstReview).toBe(false); // ← NO second reward for the loser.
+    expect(mockDb.appBlockReview.create).toHaveBeenCalledTimes(1); // attempted, lost.
+    expect(mockDb.appBlockReview.update).toHaveBeenCalledTimes(1); // fallback ran.
+    // The fallback update keys on the unique (appBlockId, userId), not a stale id.
+    const updateArg = mockDb.appBlockReview.update.mock.calls[0][0] as { where: unknown };
+    expect(updateArg.where).toEqual({ appBlockId_userId: { appBlockId: 'ab_1', userId: 7 } });
+  });
+
+  it('rethrows a NON-P2002 create error (does not silently swallow real failures)', async () => {
+    mockDb.appBlockReview.findUnique.mockResolvedValue(null);
+    mockDb.appBlockReview.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('connection lost', {
+        code: 'P1001',
+        clientVersion: 'test',
+      })
+    );
+    await expect(
+      upsertAppBlockReview({ userId: 7, appBlockId: 'ab_1', rating: 5 })
+    ).rejects.toThrow();
+    expect(mockDb.appBlockReview.update).not.toHaveBeenCalled();
   });
 });
 
@@ -140,31 +175,19 @@ describe('upsertAppBlockReview — anti-abuse gates', () => {
   });
 });
 
-describe('getAppRatingTotals — aggregate excludes mod-excluded + self-reviews', () => {
-  it('SQL excludes `exclude` rows AND the app owner self-review', async () => {
-    const totals = await getAppRatingTotals('ab_1');
-    expect(totals).toEqual({ avgRating: 4.25, reviewCount: 8 });
-    const sql = capturedRatingSql.value;
-    expect(sql).toMatch(/NOT\s+abr\.exclude/i);
-    // Self-review exclusion: owner (OauthClient.userId) vs reviewer, NULL-safe.
-    expect(sql).toMatch(/oc\."userId"\s+IS DISTINCT FROM\s+abr\.user_id/i);
-    expect(sql).toMatch(/AVG\(abr\.rating\)/i);
-  });
-});
-
 describe('setAppReviewExcluded — mod control busts the cache', () => {
-  it('flips exclude + busts the app rating cache', async () => {
+  it('flips exclude + busts the global-mean cache', async () => {
     mockDb.appBlockReview.update.mockResolvedValue({ id: 5, appBlockId: 'ab_9', exclude: true });
     const res = await setAppReviewExcluded({ id: 5, exclude: true });
     expect(res).toEqual({ id: 5, appBlockId: 'ab_9', exclude: true });
     expect(mockBust).toHaveBeenCalledTimes(1);
-    expect(mockBust.mock.calls[0][0]).toContain('app-rating:ab_9');
+    expect(mockBust.mock.calls[0][0]).toEqual(['app-rating:global-mean']);
   });
 });
 
 describe('bustAppRatingCache', () => {
-  it('busts both the per-app tag and the global-mean tag', async () => {
-    await bustAppRatingCache('ab_x');
-    expect(mockBust).toHaveBeenCalledWith(['app-rating:ab_x', 'app-rating:global-mean']);
+  it('busts the global-mean tag only (per-app aggregates are uncached)', async () => {
+    await bustAppRatingCache();
+    expect(mockBust).toHaveBeenCalledWith(['app-rating:global-mean']);
   });
 });

--- a/src/server/services/__tests__/block-registry.get-app-detail.test.ts
+++ b/src/server/services/__tests__/block-registry.get-app-detail.test.ts
@@ -52,7 +52,10 @@ vi.mock('~/server/redis/client', () => ({
 }));
 // getAppDetail builds liveUrl from `env.APPS_DOMAIN` via a dynamic import of
 // `~/env/server` — stub it so the test doesn't pull the real env schema.
-vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+// LOGGING is read by cache-helpers' createLogger at module-eval (the service
+// now imports cache-helpers for the review-aggregate queryCache); '' = no-op
+// logger.
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai', LOGGING: '' } }));
 
 /** Reconstructs the SQL string from the tagged-template args Prisma received. */
 function capturedSql(): string {
@@ -86,6 +89,8 @@ function rawRow(over: Partial<Record<string, unknown>> = {}) {
     version: '1.2.3',
     approved_scopes: ['ai:write:budgeted', 'models:read:self'],
     install_count: 7n,
+    avg_rating: 4.5,
+    review_count: 12n,
     // F-E E5 stored screenshot records (jsonb). The projection must expose ONLY
     // a public DISPLAY URL + index + content-type — NEVER the underlying MinIO
     // `key`. Index/ext build the opaque gated app route.
@@ -129,6 +134,8 @@ describe('BlockRegistry.getAppDetail — anon-exposure protections (F-E E2)', ()
       contentRating: 'PG',
       version: '1.2.3',
       installCount: 7,
+      avgRating: 4.5,
+      reviewCount: 12,
       liveUrl: 'https://cool-block.civit.ai',
     });
     expect(detail!.manifest.name).toBe('Cool Block');
@@ -201,12 +208,14 @@ describe('BlockRegistry.getAppDetail — anon-exposure protections (F-E E2)', ()
       [
         'appId',
         'appName',
+        'avgRating',
         'blockId',
         'contentRating',
         'id',
         'installCount',
         'liveUrl',
         'manifest',
+        'reviewCount',
         'scopes',
         'screenshots',
         'version',

--- a/src/server/services/__tests__/block-registry.list-available.test.ts
+++ b/src/server/services/__tests__/block-registry.list-available.test.ts
@@ -311,6 +311,46 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
     expect(capturedSql()).not.toMatch(/lpad\(round\(/i);
   });
 
+  // FIX 2 — PIN the Bayesian mean `m` into the rating-sort cursor so a paging
+  // session stays stable when the 1h global-mean cache expires/busts mid-page.
+  it('sort=rating: page 1 PINS the global mean into nextCursor', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    // Call 1 = getGlobalMeanRating (via queryCache → $queryRaw): return m=4.25.
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ mean: 4.25 }]);
+    // Call 2 = the list query: limit+1 rows so nextCursor is emitted.
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      rawRow({ id: 'ab_0', sort_key: '00000004250000' }),
+      rawRow({ id: 'ab_1', sort_key: '00000004240000' }),
+      rawRow({ id: 'ab_2', sort_key: '00000004230000' }),
+    ]);
+    const { nextCursor } = await BlockRegistry.listAvailable({ limit: 2, sort: 'rating' });
+    expect(nextCursor).toBeDefined();
+    const decoded = Buffer.from(nextCursor as string, 'base64url').toString('utf8');
+    const sep = String.fromCharCode(31);
+    // sortKey␟id␟mean — the third field is the pinned mean (4.25).
+    expect(decoded).toBe(`00000004240000${sep}ab_1${sep}4.25`);
+  });
+
+  it('sort=rating: a cursor with a pinned mean REUSES it (no global-mean re-read)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    const sep = String.fromCharCode(31);
+    // A page-2 cursor pinning m=2.5 (a value the live cache would NOT return —
+    // proving the pinned value is what flows into the SQL, not a fresh read).
+    const cursor = Buffer.from(`00000002500000${sep}ab_5${sep}2.5`, 'utf8').toString('base64url');
+    // ONLY ONE $queryRaw is queued (the list query). If the service re-read the
+    // global mean it would consume this and the list query would get []; instead
+    // the pinned mean short-circuits the read so this feeds the list query.
+    mockDbRead.$queryRaw.mockResolvedValueOnce([rawRow({ id: 'ab_9', sort_key: '00000002400000' })]);
+    const { items } = await BlockRegistry.listAvailable({ limit: 20, sort: 'rating', cursor });
+    // The list query ran and projected the row → the pinned mean fed it directly.
+    expect(items).toHaveLength(1);
+    // Exactly ONE $queryRaw call total (the list) — the mean re-read was skipped.
+    expect(mockDbRead.$queryRaw).toHaveBeenCalledTimes(1);
+    // The pinned mean 2.5 is bound into the Bayesian sort key (C*m term = 10*2.5).
+    const sql = capturedSql();
+    expect(sql).toMatch(/lpad\(round\(/i); // rating key present
+  });
+
   it('category filter is threaded into the SQL (only the requested category)', async () => {
     const { BlockRegistry } = await import('../block-registry.service');
     await BlockRegistry.listAvailable({ limit: 20, sort: 'popular', category: 'games' });

--- a/src/server/services/__tests__/block-registry.list-available.test.ts
+++ b/src/server/services/__tests__/block-registry.list-available.test.ts
@@ -40,10 +40,14 @@ vi.mock('~/server/redis/client', () => ({
     get: vi.fn(async () => null),
     set: vi.fn(async () => undefined),
     del: vi.fn(async () => 0),
+    // sAdd: used by cache-helpers tagCacheKey — the `rating` sort caches the
+    // global-mean scalar through queryCache, which tags the key.
+    sAdd: vi.fn(async () => 0),
     scanIterator: async function* () {},
   },
   sysRedis: { sMembers: vi.fn(async () => []) },
   REDIS_KEYS: {
+    TAG: 'cache:tag',
     BLOCKS: { REGISTRY: 'packed:caches:block-registry', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
   },
   REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
@@ -96,6 +100,8 @@ function rawRow(over: Partial<Record<string, unknown>> = {}) {
     // service uses to build the keyset cursor.
     category: 'utility',
     approved_scopes: ['ai:write:budgeted', 'models:read:self', 'buzz:read:self', 'social:tip:self'],
+    avg_rating: 4.2,
+    review_count: 8n,
     sort_key: '00000000000000000005',
     manifest: {
       name: 'Cool Block',
@@ -176,6 +182,9 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
         'installCount',
         'manifest',
         'scopesSummary',
+        // F-E marketplace reviews — display-safe aggregates.
+        'avgRating',
+        'reviewCount',
       ].sort()
     );
     // status is a DB-internal field; it must never appear on the wire shape.
@@ -244,7 +253,7 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
   // F-E E3 — sort, category filter, scopes-summary.
   // ---------------------------------------------------------------------------
 
-  it('sort=popular orders by install count DESC (default)', async () => {
+  it('sort=popular orders by install count DESC', async () => {
     const { BlockRegistry } = await import('../block-registry.service');
     await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' });
     const sql = capturedSql();
@@ -270,6 +279,36 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
     expect(sql).toMatch(/ORDER BY\s+sort_key\s+ASC/i);
     // ASC sort resumes with `>` (not `<`) on the keyset tuple.
     expect(sql).toMatch(/,\s*ab\.id\)\s*>\s*\(/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // F-E marketplace REVIEWS — Bayesian `rating` sort DRIFT GUARD.
+  // The rating sort key text MUST be reused identically in the SELECT (AS
+  // sort_key) and the keyset WHERE — if it drifts, keyset pagination silently
+  // skips rows. The Bayesian-score ordering + keyset-completeness PROPERTIES are
+  // pinned in block-registry.rating-sort.test.ts (pure-JS mirror of the SQL).
+  // ---------------------------------------------------------------------------
+
+  it('sort=rating (the schema DEFAULT) emits the Bayesian key in SELECT + keyset WHERE (no drift)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    // `rating` is the marketplaceSortSchema default; the service takes the parsed
+    // input so we pass it explicitly here (the zod default applies at the router).
+    await BlockRegistry.listAvailable({ limit: 20, sort: 'rating' });
+    const sql = capturedSql();
+    // The Bayesian encoding fragment (round(score*scale) zero-padded, concat the
+    // install-count) is unique to the rating key.
+    const occurrences = sql.match(/lpad\(round\(/gi)?.length ?? 0;
+    // Emitted once in SELECT (AS sort_key) and once in the keyset WHERE tuple.
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+    expect(sql).toMatch(/AS sort_key/i);
+    expect(sql).toMatch(/ORDER BY\s+sort_key\s+DESC/i);
+    expect(sql).toMatch(/,\s*ab\.id\)\s*<\s*\(/); // DESC keyset resumes with `<`
+  });
+
+  it('a NON-rating sort does NOT emit the Bayesian fragment', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' });
+    expect(capturedSql()).not.toMatch(/lpad\(round\(/i);
   });
 
   it('category filter is threaded into the SQL (only the requested category)', async () => {
@@ -331,7 +370,18 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
     const { BlockRegistry } = await import('../block-registry.service');
     const { items } = await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' });
     expect(Object.keys(items[0]).sort()).toEqual(
-      ['appId', 'appName', 'blockId', 'category', 'id', 'installCount', 'manifest', 'scopesSummary'].sort()
+      [
+        'appId',
+        'appName',
+        'avgRating',
+        'blockId',
+        'category',
+        'id',
+        'installCount',
+        'manifest',
+        'reviewCount',
+        'scopesSummary',
+      ].sort()
     );
     expect(items[0]).not.toHaveProperty('status');
     expect(items[0]).not.toHaveProperty('approved_scopes');

--- a/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
+++ b/src/server/services/__tests__/block-registry.marketplace-meta.test.ts
@@ -46,7 +46,7 @@ vi.mock('~/server/redis/client', () => ({
   },
   REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
 }));
-vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai', LOGGING: '' } }));
 
 function capturedSql(): string {
   expect(mockDb.$queryRaw).toHaveBeenCalled();
@@ -77,6 +77,8 @@ function featuredRow(over: Partial<Record<string, unknown>> = {}) {
     install_count: 9n,
     category: 'games',
     approved_scopes: ['ai:write:budgeted', 'models:read:self', 'buzz:read:self', 'social:tip:self'],
+    avg_rating: 4.7,
+    review_count: 21n,
     manifest: {
       name: 'Cool Block',
       description: 'Does cool things',
@@ -121,7 +123,18 @@ describe('BlockRegistry.getFeaturedBlocks — featured rail exposure (F-E E4)', 
     expect(items).toHaveLength(1);
     const item = items[0];
     expect(Object.keys(item).sort()).toEqual(
-      ['appId', 'appName', 'blockId', 'category', 'id', 'installCount', 'manifest', 'scopesSummary'].sort()
+      [
+        'appId',
+        'appName',
+        'avgRating',
+        'blockId',
+        'category',
+        'id',
+        'installCount',
+        'manifest',
+        'reviewCount',
+        'scopesSummary',
+      ].sort()
     );
     const manifest = item.manifest as Record<string, unknown>;
     expect(manifest.name).toBe('Cool Block');

--- a/src/server/services/__tests__/block-registry.page-only-launch.test.ts
+++ b/src/server/services/__tests__/block-registry.page-only-launch.test.ts
@@ -63,7 +63,7 @@ vi.mock('~/server/redis/client', () => ({
   },
   REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
 }));
-vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai', LOGGING: '' } }));
 
 /** Reconstruct the assembled SQL string from the captured Prisma.sql object. */
 function capturedSql(): string {

--- a/src/server/services/__tests__/block-registry.rating-sort.test.ts
+++ b/src/server/services/__tests__/block-registry.rating-sort.test.ts
@@ -153,3 +153,101 @@ describe('rating sort — KEYSET COMPLETENESS over ties (no skips / no dupes)', 
     expect(seen[seen.length - 1]).toBe('ab_bad');
   });
 });
+
+describe('rating sort — PINNED `m` survives a mid-pagination mean change (no skip/dupe)', () => {
+  // FIX 2: the global mean `m` comes from a 1h cache that can expire/bust
+  // mid-pagination. The keyset cursor encodes a row's sort_key computed with the
+  // page-1 mean; if a later page re-derives every row's key with a DIFFERENT
+  // mean, the boundary shifts → one row is silently skipped or duplicated.
+  // listAvailable PINS page-1's `m` into the cursor and reuses it for every page.
+  //
+  // This test models BOTH behaviors over the SAME dataset and a mean that
+  // changes after page 1:
+  //   - PINNED  (the fix): every page uses page-1's m → exactly-once coverage.
+  //   - UNPINNED (the bug): each page re-reads the changed m → skip and/or dupe.
+  type App = { id: string; sum: number; n: number; installs: number };
+
+  // A dataset where rated apps interleave with the 0-review (score=m) apps, so a
+  // shift in m re-orders rows relative to the 0-review band → a boundary skip.
+  const apps: App[] = [
+    ...Array.from({ length: 8 }, (_, i) => ({
+      id: `ab_zero_${String(i).padStart(2, '0')}`,
+      sum: 0,
+      n: 0,
+      installs: i % 2 === 0 ? 0 : i,
+    })),
+    { id: 'ab_a', sum: 18, n: 4, installs: 5 }, // avg 4.5
+    { id: 'ab_b', sum: 14, n: 4, installs: 4 }, // avg 3.5
+    { id: 'ab_c', sum: 21, n: 5, installs: 3 }, // avg 4.2
+    { id: 'ab_d', sum: 10, n: 4, installs: 2 }, // avg 2.5
+  ];
+
+  function key(a: App, m: number): string {
+    return sortKey(a.sum, a.n, a.installs, m);
+  }
+
+  // Page the keyset. `meanForPage(pageIndex)` supplies the mean used to derive
+  // sort keys for that page's evaluation (cursor + ordering), simulating either
+  // a pinned mean (always page-1's) or an unpinned per-page cache read.
+  function pageWithMeanSchedule(
+    pageSize: number,
+    meanForPage: (pageIndex: number) => number
+  ): string[] {
+    const seen: string[] = [];
+    let cursor: { key: string; id: string } | null = null;
+    for (let page = 0; page < 100; page++) {
+      const m = meanForPage(page);
+      // Re-derive ordering + keyset under THIS page's mean (Postgres recomputes
+      // sort_key per query; only the cursor tuple is carried from the prior page).
+      const ordered = [...apps].sort((a, b) => {
+        const ka = key(a, m);
+        const kb = key(b, m);
+        if (ka !== kb) return ka < kb ? 1 : -1;
+        return a.id < b.id ? 1 : -1;
+      });
+      const remaining = ordered.filter((a) => {
+        if (!cursor) return true;
+        const k = key(a, m);
+        if (k !== cursor.key) return k < cursor.key;
+        return a.id < cursor.id;
+      });
+      const slice = remaining.slice(0, pageSize);
+      if (slice.length === 0) break;
+      for (const a of slice) seen.push(a.id);
+      const last = slice[slice.length - 1];
+      cursor = { key: key(last, m), id: last.id };
+      if (slice.length < pageSize) break;
+    }
+    return seen;
+  }
+
+  const M1 = 3.0; // page-1 mean
+  const M2 = 4.5; // mean after the cache expires/busts mid-pagination
+
+  it('PINNED: reusing page-1 mean across pages covers every app exactly once', () => {
+    // Pinned = the cursor carries m=M1, so EVERY page uses M1.
+    const seen = pageWithMeanSchedule(4, () => M1);
+    expect(seen).toHaveLength(apps.length);
+    expect(new Set(seen).size).toBe(apps.length); // no dupes
+    expect(new Set(seen)).toEqual(new Set(apps.map((a) => a.id))); // no skips
+  });
+
+  it('PINNED still holds when the mean WOULD have changed after page 1', () => {
+    // The fix: even though the live cache flipped M1→M2 after page 1, the cursor
+    // pins M1 so pages 2..N keep using M1. Identical to the all-M1 schedule.
+    const pinned = pageWithMeanSchedule(4, () => M1);
+    expect(pinned).toHaveLength(apps.length);
+    expect(new Set(pinned).size).toBe(apps.length);
+    expect(new Set(pinned)).toEqual(new Set(apps.map((a) => a.id)));
+  });
+
+  it('UNPINNED (the bug being fixed): a mid-pagination mean change skips/dupes', () => {
+    // Page 1 uses M1, pages 2..N re-read the busted cache → M2. This is the
+    // pre-fix behavior; it must NOT cleanly cover every app exactly once
+    // (proving the pin is load-bearing, not cosmetic).
+    const unpinned = pageWithMeanSchedule(4, (page) => (page === 0 ? M1 : M2));
+    const exactlyOnce =
+      unpinned.length === apps.length && new Set(unpinned).size === apps.length;
+    expect(exactlyOnce).toBe(false);
+  });
+});

--- a/src/server/services/__tests__/block-registry.rating-sort.test.ts
+++ b/src/server/services/__tests__/block-registry.rating-sort.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// F-E marketplace REVIEWS — the Bayesian `rating` sort (the LOAD-BEARING piece).
+//
+// This file pins the two PURE properties (the SQL-shape DRIFT GUARD lives in
+// block-registry.list-available.test.ts, which already imports the service with
+// the right mock surface):
+//   1. BAYESIAN ORDERING (formula) — a few-review 5★ app does NOT outrank a
+//      many-review 4.x app; a 0-review app sits mid-pack at the global mean `m`.
+//      Verified against a pure-JS mirror of the EXACT SQL formula
+//      (C*m + SUM)/(C+n), encoded the same way (round(score*SCALE) zero-padded
+//      || install_count zero-padded), so the test tracks the SQL encoding.
+//   2. KEYSET COMPLETENESS — paging the keyset over a dataset with MANY ties
+//      (all 0-review apps share score=m) returns every app EXACTLY once: no
+//      skips, no duplicates. Simulated in JS with the SAME (sort_key, id) tuple
+//      ordering + strict-less-than resume Postgres uses.
+// ---------------------------------------------------------------------------
+
+// --- Pure-JS mirror of the EXACT SQL formula + encoding (tracks the SQL). -----
+const C = 10; // BAYES_MIN_REVIEWS
+const SCALE = 1_000_000; // BAYES_SCORE_SCALE
+const SCORE_PAD = 9;
+const INSTALL_PAD = 20;
+
+function bayesScore(sumRating: number, n: number, m: number): number {
+  return (C * m + sumRating) / (C + n);
+}
+function sortKey(sumRating: number, n: number, installCount: number, m: number): string {
+  const score = bayesScore(sumRating, n, m);
+  const scoreInt = Math.round(score * SCALE);
+  return String(scoreInt).padStart(SCORE_PAD, '0') + String(installCount).padStart(INSTALL_PAD, '0');
+}
+
+describe('rating sort — Bayesian ordering (formula correctness)', () => {
+  const m = 4.0;
+
+  it('a few-review 5★ app does NOT outrank a many-review 4.x app', async () => {
+    // App F: 2 reviews, both 5★ → sum=10, n=2.
+    const fewFiveStar = bayesScore(10, 2, m); // (40+10)/12 = 4.166...
+    // App M: 50 reviews averaging 4.6 → sum=230, n=50.
+    const manyHigh = bayesScore(230, 50, m); // (40+230)/60 = 4.5
+    expect(manyHigh).toBeGreaterThan(fewFiveStar);
+  });
+
+  it('a 0-review app sits at the global mean m (mid-pack, not buried)', () => {
+    const zeroReview = bayesScore(0, 0, m); // (40+0)/10 = 4.0 = m
+    expect(zeroReview).toBeCloseTo(m, 6);
+    // It outranks a genuinely-bad app...
+    const bad = bayesScore(10, 5, m); // (40+10)/15 = 3.33
+    expect(zeroReview).toBeGreaterThan(bad);
+    // ...but is outranked by a solidly-good, well-reviewed app.
+    const good = bayesScore(220, 50, m); // (40+220)/60 = 4.33
+    expect(good).toBeGreaterThan(zeroReview);
+  });
+
+  it('the text encoding preserves the numeric DESC ordering', () => {
+    const good = sortKey(220, 50, 5, m);
+    const zero = sortKey(0, 0, 5, m);
+    const bad = sortKey(10, 5, 5, m);
+    // DESC text sort: good > zero > bad.
+    expect(good > zero).toBe(true);
+    expect(zero > bad).toBe(true);
+  });
+
+  it('equal scores fall back to install_count (then id) via the concatenated key', () => {
+    // Two 0-review apps (same score=m) with different install counts.
+    const hiInstall = sortKey(0, 0, 100, m);
+    const loInstall = sortKey(0, 0, 3, m);
+    expect(hiInstall > loInstall).toBe(true); // more installs ranks first on a tie
+  });
+});
+
+describe('rating sort — KEYSET COMPLETENESS over ties (no skips / no dupes)', () => {
+  // Build a dataset with MANY ties at score=m (0-review apps) plus a few rated
+  // apps, then page it exactly as Postgres does:
+  //   ORDER BY sort_key DESC, id DESC
+  //   WHERE (sort_key, id) < (cursorSortKey, cursorId)  -- strict, row-value
+  // and assert every app is returned exactly once.
+  const m = 4.0;
+  type App = { id: string; sum: number; n: number; installs: number };
+
+  function buildKey(a: App): string {
+    return sortKey(a.sum, a.n, a.installs, m);
+  }
+
+  // 12 zero-review apps (all tie at score=m, varied installs incl. exact-tie
+  // installs to force the id tiebreaker) + 3 rated apps.
+  const apps: App[] = [
+    ...Array.from({ length: 12 }, (_, i) => ({
+      id: `ab_zero_${String(i).padStart(2, '0')}`,
+      sum: 0,
+      n: 0,
+      // Several share installs=0 → the id tiebreaker MUST disambiguate them.
+      installs: i % 3 === 0 ? 0 : i,
+    })),
+    { id: 'ab_great', sum: 240, n: 50, installs: 7 },
+    { id: 'ab_ok', sum: 150, n: 40, installs: 2 },
+    { id: 'ab_bad', sum: 12, n: 6, installs: 1 },
+  ];
+
+  // Postgres row-value comparison: (sort_key, id) DESC. A row sorts before
+  // another if its sort_key is greater, or (equal sort_key) its id is greater.
+  function cmpDesc(a: App, b: App): number {
+    const ka = buildKey(a);
+    const kb = buildKey(b);
+    if (ka !== kb) return ka < kb ? 1 : -1; // greater key first (DESC)
+    if (a.id !== b.id) return a.id < b.id ? 1 : -1; // greater id first (DESC)
+    return 0;
+  }
+
+  function pageKeyset(pageSize: number): string[] {
+    const ordered = [...apps].sort(cmpDesc);
+    const seen: string[] = [];
+    let cursor: { key: string; id: string } | null = null;
+    // Loop pages until exhausted.
+    // The WHERE resumes strictly after the cursor tuple in DESC order.
+    for (let guard = 0; guard < 100; guard++) {
+      const remaining = ordered.filter((a) => {
+        if (!cursor) return true;
+        const k = buildKey(a);
+        // (k, id) < (cursor.key, cursor.id) under DESC means: k is strictly
+        // smaller, OR equal-k and id strictly smaller.
+        if (k !== cursor.key) return k < cursor.key;
+        return a.id < cursor.id;
+      });
+      const page = remaining.slice(0, pageSize);
+      if (page.length === 0) break;
+      for (const a of page) seen.push(a.id);
+      const last = page[page.length - 1];
+      cursor = { key: buildKey(last), id: last.id };
+      if (page.length < pageSize) break;
+    }
+    return seen;
+  }
+
+  it('pages of 5 cover every app exactly once (no skips, no dupes)', () => {
+    const seen = pageKeyset(5);
+    expect(seen).toHaveLength(apps.length);
+    expect(new Set(seen).size).toBe(apps.length); // no dupes
+    expect(new Set(seen)).toEqual(new Set(apps.map((a) => a.id))); // no skips
+  });
+
+  it('pages of 1 (degenerate) also cover every app exactly once', () => {
+    const seen = pageKeyset(1);
+    expect(seen).toHaveLength(apps.length);
+    expect(new Set(seen).size).toBe(apps.length);
+  });
+
+  it('the well-reviewed app ranks first and the bad app last in the full keyset scan', () => {
+    const seen = pageKeyset(5);
+    expect(seen[0]).toBe('ab_great');
+    expect(seen[seen.length - 1]).toBe('ab_bad');
+  });
+});

--- a/src/server/services/appBlockReview.service.ts
+++ b/src/server/services/appBlockReview.service.ts
@@ -1,7 +1,6 @@
 import { Prisma } from '@prisma/client';
-import { CacheTTL } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { bustCacheTag, queryCache } from '~/server/utils/cache-helpers';
+import { bustCacheTag } from '~/server/utils/cache-helpers';
 import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
 
 /**
@@ -21,56 +20,24 @@ import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/er
 export const BAYES_MIN_REVIEWS = 10;
 
 // ---------------------------------------------------------------------------
-// Cache: rating totals (avg + count) per app block.
+// Cache invalidation.
 // ---------------------------------------------------------------------------
 
-const ratingTag = (appBlockId: string) => `app-rating:${appBlockId}`;
-// Global-mean tag — busted alongside any single-app bust because adding/removing
-// a review shifts the marketplace-wide Bayesian prior `m` (kept in sync with
-// block-registry.service.ts's getGlobalMeanRating tag).
+// The ONLY rating cache feeding a visible surface is the marketplace-wide
+// Bayesian prior `m` (block-registry.service.ts's getGlobalMeanRating, tag
+// `app-rating:global-mean`, 1h). The per-app card/detail AVG+COUNT numbers are
+// NOT cached — listAvailable / getAppDetail recompute them via correlated
+// subqueries on every request — so there is no per-app tag to bust. Adding or
+// removing a review shifts `m`, so a review change busts the global-mean tag.
 const GLOBAL_MEAN_TAG = 'app-rating:global-mean';
 
 /**
- * Bust the getAppRatingTotals cache for one app AND the global-mean cache (a
- * review change shifts both the app's avg and the marketplace-wide prior `m`).
- * Fire-and-forget.
+ * Bust the marketplace-wide Bayesian-prior (`m`) cache after a review change.
+ * No per-app tag exists: the visible per-app aggregates are recomputed uncached
+ * in the registry, so only the global mean needs invalidating. Fire-and-forget.
  */
-export const bustAppRatingCache = async (appBlockId: string) => {
-  await bustCacheTag([ratingTag(appBlockId), GLOBAL_MEAN_TAG]);
-};
-
-export type AppRatingTotals = { avgRating: number | null; reviewCount: number };
-
-/**
- * AVG(rating) + COUNT(*) for an app block, EXCLUDING:
- *   - moderator-excluded rows (`exclude = true`), and
- *   - the app owner's own review (self-review) — joined via
- *     OauthClient.userId, mirroring resourceReview's `m."userId" != rr."userId"`.
- * Cached 1h, tag `app-rating:<id>` (busted on upsert / delete / setExcluded).
- */
-export const getAppRatingTotals = async (appBlockId: string): Promise<AppRatingTotals> => {
-  const query = Prisma.sql`
-    SELECT
-      AVG(abr.rating)::float AS avg_rating,
-      COUNT(abr.id)::int     AS review_count
-    FROM app_block_reviews abr
-    JOIN app_blocks ab ON ab.id = abr.app_block_id
-    JOIN "OauthClient" oc ON oc.id = ab.app_id
-    WHERE abr.app_block_id = ${appBlockId}
-      AND NOT abr.exclude
-      -- Exclude the app owner's own review from the aggregate (self-review).
-      AND oc."userId" IS DISTINCT FROM abr.user_id
-  `;
-  const cacheable = queryCache(dbRead, 'getAppRatingTotals', 'v1');
-  const rows = await cacheable<{ avg_rating: number | null; review_count: number }[]>(query, {
-    ttl: CacheTTL.hour,
-    tag: [ratingTag(appBlockId)],
-  });
-  const row = rows[0];
-  return {
-    avgRating: row?.avg_rating ?? null,
-    reviewCount: row?.review_count ?? 0,
-  };
+export const bustAppRatingCache = async () => {
+  await bustCacheTag([GLOBAL_MEAN_TAG]);
 };
 
 // ---------------------------------------------------------------------------
@@ -156,24 +123,50 @@ export const upsertAppBlockReview = async ({
     select: { id: true },
   });
 
+  const reviewSelect = {
+    id: true,
+    appBlockId: true,
+    rating: true,
+    recommended: true,
+  } as const;
+
   let review: { id: number; appBlockId: string; rating: number; recommended: boolean };
   let isFirstReview: boolean;
   if (!existing) {
-    review = await dbWrite.appBlockReview.create({
-      data: { appBlockId, userId, rating, recommended, details },
-      select: { id: true, appBlockId: true, rating: true, recommended: true },
-    });
-    isFirstReview = true;
+    // CONCURRENCY: two simultaneous FIRST reviews for the same (user, app) both
+    // read null above → both reach this create. The unique index lets exactly
+    // one win; the loser's create hits Prisma P2002 (unique violation). Catch
+    // it and fall through to the UPDATE branch with isFirstReview=false so the
+    // loser (a) doesn't 500 and (b) does NOT collect a second once-per reward —
+    // the winner's create already set isFirstReview=true and fired it once.
+    try {
+      review = await dbWrite.appBlockReview.create({
+        data: { appBlockId, userId, rating, recommended, details },
+        select: reviewSelect,
+      });
+      isFirstReview = true;
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        review = await dbWrite.appBlockReview.update({
+          where: { appBlockId_userId: { appBlockId, userId } },
+          data: { rating, recommended, details },
+          select: reviewSelect,
+        });
+        isFirstReview = false;
+      } else {
+        throw e;
+      }
+    }
   } else {
     review = await dbWrite.appBlockReview.update({
       where: { id: existing.id },
       data: { rating, recommended, details },
-      select: { id: true, appBlockId: true, rating: true, recommended: true },
+      select: reviewSelect,
     });
     isFirstReview = false;
   }
 
-  await bustAppRatingCache(appBlockId).catch(() => undefined);
+  await bustAppRatingCache().catch(() => undefined);
   return { review, isFirstReview };
 };
 
@@ -267,20 +260,6 @@ export const setAppReviewExcluded = async ({
     data: { exclude },
     select: { id: true, appBlockId: true, exclude: true },
   });
-  await bustAppRatingCache(updated.appBlockId).catch(() => undefined);
+  await bustAppRatingCache().catch(() => undefined);
   return updated;
-};
-
-/** Delete a review (owner self-delete OR mod). Busts the rating cache. */
-export const deleteAppBlockReview = async ({
-  id,
-}: {
-  id: number;
-}): Promise<{ id: number; appBlockId: string }> => {
-  const deleted = await dbWrite.appBlockReview.delete({
-    where: { id },
-    select: { id: true, appBlockId: true },
-  });
-  await bustAppRatingCache(deleted.appBlockId).catch(() => undefined);
-  return deleted;
 };

--- a/src/server/services/appBlockReview.service.ts
+++ b/src/server/services/appBlockReview.service.ts
@@ -89,17 +89,28 @@ export type UpsertAppBlockReviewResult = {
  *
  * Returns `isFirstReview` so the caller fires the blue-buzz reward ONLY on the
  * first create. Busts the rating cache after the write.
+ *
+ * `recommended`: CREATE defaults it to true; UPDATE leaves an existing value
+ * UNCHANGED when the caller omits it (so a partial edit can't silently flip a
+ * stored `false` back to true).
  */
 export const upsertAppBlockReview = async ({
   userId,
   appBlockId,
   rating,
-  recommended = true,
+  recommended,
   details = null,
 }: UpsertAppBlockReviewInput & { userId: number }): Promise<UpsertAppBlockReviewResult> => {
   if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
     throw throwBadRequestError('Rating must be a whole number from 1 to 5');
   }
+
+  // CREATE defaults `recommended` to true; UPDATE leaves it UNCHANGED when the
+  // caller omitted it (input.recommended === undefined) — so a direct-API edit
+  // that doesn't send `recommended` can't silently flip an existing `false` back
+  // to true. Only an EXPLICIT boolean is written on update.
+  const createRecommended = recommended ?? true;
+  const updateRecommended = recommended === undefined ? {} : { recommended };
 
   // Gate 2: no self-review. Reject before any write so the owner can't seed
   // their own (even though it's excluded from the aggregate too).
@@ -141,7 +152,7 @@ export const upsertAppBlockReview = async ({
     // the winner's create already set isFirstReview=true and fired it once.
     try {
       review = await dbWrite.appBlockReview.create({
-        data: { appBlockId, userId, rating, recommended, details },
+        data: { appBlockId, userId, rating, recommended: createRecommended, details },
         select: reviewSelect,
       });
       isFirstReview = true;
@@ -149,7 +160,7 @@ export const upsertAppBlockReview = async ({
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
         review = await dbWrite.appBlockReview.update({
           where: { appBlockId_userId: { appBlockId, userId } },
-          data: { rating, recommended, details },
+          data: { rating, ...updateRecommended, details },
           select: reviewSelect,
         });
         isFirstReview = false;
@@ -160,7 +171,7 @@ export const upsertAppBlockReview = async ({
   } else {
     review = await dbWrite.appBlockReview.update({
       where: { id: existing.id },
-      data: { rating, recommended, details },
+      data: { rating, ...updateRecommended, details },
       select: reviewSelect,
     });
     isFirstReview = false;

--- a/src/server/services/appBlockReview.service.ts
+++ b/src/server/services/appBlockReview.service.ts
@@ -1,0 +1,286 @@
+import { Prisma } from '@prisma/client';
+import { CacheTTL } from '~/server/common/constants';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { bustCacheTag, queryCache } from '~/server/utils/cache-helpers';
+import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
+
+/**
+ * App Blocks marketplace review service (F-E "marketplace" cluster).
+ *
+ * Mirrors the model-review service (resourceReview.service.ts) but against the
+ * parallel `app_block_reviews` table. ALL surfaces are gated dark behind the
+ * mod-segmented appBlocks flag at the tRPC layer — this service does no auth of
+ * its own beyond the anti-abuse gates documented per-method.
+ */
+
+// Bayesian shrinkage prior strength (C) for the marketplace `rating` sort. The
+// score is (C*m + SUM(rating)) / (C + n): a few-review app is pulled toward the
+// global mean `m`, so it can't outrank a many-review app on a single 5★. Taxonomy
+// const (no migration); tune freely. 10 ≈ "trust the app's own average once it
+// has ~10 reviews".
+export const BAYES_MIN_REVIEWS = 10;
+
+// ---------------------------------------------------------------------------
+// Cache: rating totals (avg + count) per app block.
+// ---------------------------------------------------------------------------
+
+const ratingTag = (appBlockId: string) => `app-rating:${appBlockId}`;
+// Global-mean tag — busted alongside any single-app bust because adding/removing
+// a review shifts the marketplace-wide Bayesian prior `m` (kept in sync with
+// block-registry.service.ts's getGlobalMeanRating tag).
+const GLOBAL_MEAN_TAG = 'app-rating:global-mean';
+
+/**
+ * Bust the getAppRatingTotals cache for one app AND the global-mean cache (a
+ * review change shifts both the app's avg and the marketplace-wide prior `m`).
+ * Fire-and-forget.
+ */
+export const bustAppRatingCache = async (appBlockId: string) => {
+  await bustCacheTag([ratingTag(appBlockId), GLOBAL_MEAN_TAG]);
+};
+
+export type AppRatingTotals = { avgRating: number | null; reviewCount: number };
+
+/**
+ * AVG(rating) + COUNT(*) for an app block, EXCLUDING:
+ *   - moderator-excluded rows (`exclude = true`), and
+ *   - the app owner's own review (self-review) — joined via
+ *     OauthClient.userId, mirroring resourceReview's `m."userId" != rr."userId"`.
+ * Cached 1h, tag `app-rating:<id>` (busted on upsert / delete / setExcluded).
+ */
+export const getAppRatingTotals = async (appBlockId: string): Promise<AppRatingTotals> => {
+  const query = Prisma.sql`
+    SELECT
+      AVG(abr.rating)::float AS avg_rating,
+      COUNT(abr.id)::int     AS review_count
+    FROM app_block_reviews abr
+    JOIN app_blocks ab ON ab.id = abr.app_block_id
+    JOIN "OauthClient" oc ON oc.id = ab.app_id
+    WHERE abr.app_block_id = ${appBlockId}
+      AND NOT abr.exclude
+      -- Exclude the app owner's own review from the aggregate (self-review).
+      AND oc."userId" IS DISTINCT FROM abr.user_id
+  `;
+  const cacheable = queryCache(dbRead, 'getAppRatingTotals', 'v1');
+  const rows = await cacheable<{ avg_rating: number | null; review_count: number }[]>(query, {
+    ttl: CacheTTL.hour,
+    tag: [ratingTag(appBlockId)],
+  });
+  const row = rows[0];
+  return {
+    avgRating: row?.avg_rating ?? null,
+    reviewCount: row?.review_count ?? 0,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Anti-abuse gates.
+// ---------------------------------------------------------------------------
+
+/** Returns the app owner's userId (via OauthClient) for the given app block. */
+async function getAppOwnerUserId(appBlockId: string): Promise<number | null> {
+  const row = await dbRead.appBlock.findUnique({
+    where: { id: appBlockId },
+    select: { app: { select: { userId: true } } },
+  });
+  return row?.app.userId ?? null;
+}
+
+/** True when the viewer has an ENABLED subscription (install) for the app. */
+async function hasEnabledInstall(appBlockId: string, userId: number): Promise<boolean> {
+  const row = await dbRead.blockUserSubscription.findFirst({
+    where: { appBlockId, userId, enabled: true },
+    select: { id: true },
+  });
+  return !!row;
+}
+
+// ---------------------------------------------------------------------------
+// Upsert.
+// ---------------------------------------------------------------------------
+
+export type UpsertAppBlockReviewInput = {
+  appBlockId: string;
+  rating: number;
+  recommended?: boolean;
+  details?: string | null;
+};
+
+export type UpsertAppBlockReviewResult = {
+  review: { id: number; appBlockId: string; rating: number; recommended: boolean };
+  /** True only on the CREATE branch — the reward fires once per (user, app). */
+  isFirstReview: boolean;
+};
+
+/**
+ * Create-or-update the viewer's review for an app block, keyed on the unique
+ * (app_block_id, user_id). Anti-abuse gates (all enforced here):
+ *   1. rating ∈ [1, 5] (STARS).
+ *   2. NO SELF-REVIEW — the app owner cannot review their own app.
+ *   3. MUST HAVE INSTALLED — an ENABLED BlockUserSubscription is required.
+ *   4. ONE PER (user, app) — the DB unique constraint (an upsert, not a 2nd row).
+ *
+ * Returns `isFirstReview` so the caller fires the blue-buzz reward ONLY on the
+ * first create. Busts the rating cache after the write.
+ */
+export const upsertAppBlockReview = async ({
+  userId,
+  appBlockId,
+  rating,
+  recommended = true,
+  details = null,
+}: UpsertAppBlockReviewInput & { userId: number }): Promise<UpsertAppBlockReviewResult> => {
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    throw throwBadRequestError('Rating must be a whole number from 1 to 5');
+  }
+
+  // Gate 2: no self-review. Reject before any write so the owner can't seed
+  // their own (even though it's excluded from the aggregate too).
+  const ownerUserId = await getAppOwnerUserId(appBlockId);
+  if (ownerUserId == null) throw throwBadRequestError('App block not found');
+  if (ownerUserId === userId) {
+    throw throwAuthorizationError('You cannot review your own app');
+  }
+
+  // Gate 3: must have installed (enabled subscription).
+  if (!(await hasEnabledInstall(appBlockId, userId))) {
+    throw throwAuthorizationError('Install the app before reviewing it');
+  }
+
+  // Gate 1+4: upsert on the unique (app_block_id, user_id). The unique index
+  // makes the create-vs-update decision atomic — we read first to know which
+  // branch ran (isFirstReview) for the once-per reward, and the unique index
+  // guarantees a concurrent double-create can't slip a second row through.
+  const existing = await dbWrite.appBlockReview.findUnique({
+    where: { appBlockId_userId: { appBlockId, userId } },
+    select: { id: true },
+  });
+
+  let review: { id: number; appBlockId: string; rating: number; recommended: boolean };
+  let isFirstReview: boolean;
+  if (!existing) {
+    review = await dbWrite.appBlockReview.create({
+      data: { appBlockId, userId, rating, recommended, details },
+      select: { id: true, appBlockId: true, rating: true, recommended: true },
+    });
+    isFirstReview = true;
+  } else {
+    review = await dbWrite.appBlockReview.update({
+      where: { id: existing.id },
+      data: { rating, recommended, details },
+      select: { id: true, appBlockId: true, rating: true, recommended: true },
+    });
+    isFirstReview = false;
+  }
+
+  await bustAppRatingCache(appBlockId).catch(() => undefined);
+  return { review, isFirstReview };
+};
+
+// ---------------------------------------------------------------------------
+// List (keyset).
+// ---------------------------------------------------------------------------
+
+export type AppBlockReviewListItem = {
+  id: number;
+  userId: number;
+  rating: number;
+  recommended: boolean;
+  details: string | null;
+  createdAt: Date;
+};
+
+/**
+ * Keyset-paginated list of an app's reviews, newest first. Excludes mod-excluded
+ * rows. Keyset on `id DESC` (id is monotonic; createdAt can tie). Returns the
+ * page + a `nextCursor` (the last row's id) when more rows exist.
+ */
+export const listAppBlockReviews = async ({
+  appBlockId,
+  cursor,
+  limit = 20,
+}: {
+  appBlockId: string;
+  cursor?: number;
+  limit?: number;
+}): Promise<{ items: AppBlockReviewListItem[]; nextCursor?: number }> => {
+  const take = Math.min(Math.max(limit, 1), 50);
+  const rows = await dbRead.appBlockReview.findMany({
+    where: {
+      appBlockId,
+      exclude: false,
+      ...(cursor ? { id: { lt: cursor } } : {}),
+    },
+    orderBy: { id: 'desc' },
+    take: take + 1,
+    select: {
+      id: true,
+      userId: true,
+      rating: true,
+      recommended: true,
+      details: true,
+      createdAt: true,
+    },
+  });
+  const items = rows.slice(0, take);
+  const nextCursor = rows.length > take ? items[items.length - 1]?.id : undefined;
+  return { items, nextCursor };
+};
+
+/** The viewer's own review for an app block (or null). */
+export const getMyAppBlockReview = async (
+  appBlockId: string,
+  userId: number
+): Promise<AppBlockReviewListItem | null> => {
+  const row = await dbRead.appBlockReview.findUnique({
+    where: { appBlockId_userId: { appBlockId, userId } },
+    select: {
+      id: true,
+      userId: true,
+      rating: true,
+      recommended: true,
+      details: true,
+      createdAt: true,
+    },
+  });
+  return row ?? null;
+};
+
+// ---------------------------------------------------------------------------
+// Moderator controls.
+// ---------------------------------------------------------------------------
+
+/**
+ * MOD-ONLY (gated at the router with moderatorProcedure). Flip `exclude` on a
+ * review so it drops out of the aggregate + ranking. Busts the rating cache.
+ * Mirrors toggleExcludeResourceReview.
+ */
+export const setAppReviewExcluded = async ({
+  id,
+  exclude,
+}: {
+  id: number;
+  exclude: boolean;
+}): Promise<{ id: number; appBlockId: string; exclude: boolean }> => {
+  const updated = await dbWrite.appBlockReview.update({
+    where: { id },
+    data: { exclude },
+    select: { id: true, appBlockId: true, exclude: true },
+  });
+  await bustAppRatingCache(updated.appBlockId).catch(() => undefined);
+  return updated;
+};
+
+/** Delete a review (owner self-delete OR mod). Busts the rating cache. */
+export const deleteAppBlockReview = async ({
+  id,
+}: {
+  id: number;
+}): Promise<{ id: number; appBlockId: string }> => {
+  const deleted = await dbWrite.appBlockReview.delete({
+    where: { id },
+    select: { id: true, appBlockId: true },
+  });
+  await bustAppRatingCache(deleted.appBlockId).catch(() => undefined);
+  return deleted;
+};

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -48,35 +48,60 @@ export const MAX_BLOCKS_PER_SLOT = 3;
 export const MARKETPLACE_SCOPES_SUMMARY_LIMIT = 3;
 
 /**
- * F-E E3 marketplace keyset cursor. Encodes the last row's `(sortKey, id)` as a
- * base64url string so the next page resumes strictly after it (the sort key is
- * embedded so a paged scan stays stable even when many rows share a sort value,
- * e.g. install_count=0). Opaque to the client. We use a unit-separator (\x1f) —
- * a char that can't appear in any of our sort keys (zero-padded digits, a
- * fixed-width timestamp, or a lowercased name) nor in an app_block id — so the
- * split is unambiguous.
+ * F-E E3 marketplace keyset cursor. Encodes the last row's `(sortKey, id)` plus
+ * the pinned Bayesian mean `m` as a base64url string so the next page resumes
+ * strictly after it (the sort key is embedded so a paged scan stays stable even
+ * when many rows share a sort value, e.g. install_count=0). Opaque to the
+ * client. We use a unit-separator (\x1f) — a char that can't appear in any of
+ * our sort keys (zero-padded digits, a fixed-width timestamp, or a lowercased
+ * name) nor in an app_block id nor a numeric mean — so the split is unambiguous.
+ *
+ * `m` PINNING (the `rating` sort): the sort key is computed from the global mean
+ * `m`, which is read from a 1h cache that can expire/bust MID-PAGINATION. If
+ * page 2 re-derived every row's key with a different `m` than page 1's cursor
+ * was encoded with, the keyset boundary shifts and one row is silently skipped
+ * or duplicated. So we PIN `m` into the cursor and reuse it for every page of a
+ * paging session. Empty for sorts that don't use `m` (popular/newest/name).
  */
 const CURSOR_SEPARATOR = String.fromCharCode(31); // unit separator (\x1f)
-function encodeMarketplaceCursor(sortKey: string, id: string): string {
-  return Buffer.from(`${sortKey}${CURSOR_SEPARATOR}${id}`, 'utf8').toString('base64url');
+function encodeMarketplaceCursor(sortKey: string, id: string, pinnedMean?: number): string {
+  // Only the `rating` sort pins a mean; other sorts emit the legacy 2-field
+  // `sortKey␟id` cursor (no trailing separator) so their format is unchanged.
+  const body =
+    pinnedMean == null
+      ? `${sortKey}${CURSOR_SEPARATOR}${id}`
+      : `${sortKey}${CURSOR_SEPARATOR}${id}${CURSOR_SEPARATOR}${pinnedMean}`;
+  return Buffer.from(body, 'utf8').toString('base64url');
 }
 function decodeMarketplaceCursor(cursor: string | undefined): {
   cursorSortKey: string | null;
   cursorId: string | null;
+  /** The mean `m` pinned by the FIRST page of this session (null if absent). */
+  cursorMean: number | null;
 } {
-  if (!cursor) return { cursorSortKey: null, cursorId: null };
+  const empty = { cursorSortKey: null, cursorId: null, cursorMean: null };
+  if (!cursor) return empty;
   let decoded: string;
   try {
     decoded = Buffer.from(cursor, 'base64url').toString('utf8');
   } catch {
     // Malformed cursor → treat as first page (fail-open to a safe default).
-    return { cursorSortKey: null, cursorId: null };
+    return empty;
   }
-  const sep = decoded.indexOf(CURSOR_SEPARATOR);
-  if (sep < 0) return { cursorSortKey: null, cursorId: null };
+  // Split on the FIRST two separators: [sortKey, id, mean]. sortKey + id can't
+  // contain \x1f (zero-padded digits / timestamp / lowercased name / app id),
+  // so the first two indexOf hits are the field boundaries.
+  const sep1 = decoded.indexOf(CURSOR_SEPARATOR);
+  if (sep1 < 0) return empty;
+  const sep2 = decoded.indexOf(CURSOR_SEPARATOR, sep1 + 1);
+  // Legacy 2-field cursor (no pinned mean) — fail-open to an unpinned page.
+  const cursorId = sep2 < 0 ? decoded.slice(sep1 + 1) : decoded.slice(sep1 + 1, sep2);
+  const meanField = sep2 < 0 ? '' : decoded.slice(sep2 + 1);
+  const meanNum = meanField === '' ? NaN : Number(meanField);
   return {
-    cursorSortKey: decoded.slice(0, sep),
-    cursorId: decoded.slice(sep + 1),
+    cursorSortKey: decoded.slice(0, sep1),
+    cursorId,
+    cursorMean: Number.isFinite(meanNum) ? meanNum : null,
   };
 }
 
@@ -87,8 +112,8 @@ function decodeMarketplaceCursor(cursor: string | undefined): {
 /**
  * Correlated subquery: AVG(rating) over an app's AGGREGATE-ELIGIBLE reviews —
  * NOT mod-excluded AND NOT the app owner's own (self-review). NULL for a
- * 0-review app. Identical eligibility to getAppRatingTotals so the card number,
- * the detail number, and the sort all agree.
+ * 0-review app. The card number, the detail number, and the global-mean `m`
+ * share this eligibility filter so they all agree (one source of truth).
  */
 const AVG_RATING_SUBQUERY = Prisma.sql`(
   SELECT AVG(abr.rating)::float
@@ -2600,8 +2625,9 @@ export class BlockRegistry {
     const categoryFilter = category ?? null;
 
     // Keyset cursor = `${sortKey} ${id}` of the last row of the prior page.
-    // Split it back into (sortKey, id) so the WHERE clause resumes after it.
-    const { cursorSortKey, cursorId } = decodeMarketplaceCursor(cursor);
+    // Split it back into (sortKey, id, mean) so the WHERE clause resumes after
+    // it and the `rating` sort reuses the SAME pinned mean across all pages.
+    const { cursorSortKey, cursorId, cursorMean } = decodeMarketplaceCursor(cursor);
 
     // The sort key is a TEXT expression chosen so a plain text comparison
     // orders rows correctly for the requested sort. The SAME expression is used
@@ -2618,7 +2644,16 @@ export class BlockRegistry {
     // a correct, total keyset.
     // `rating` (the default) needs the marketplace-wide Bayesian prior `m`
     // (cheap, 1h-cached scalar) injected as a param. The other sorts ignore it.
-    const globalMean = sort === 'rating' ? await getGlobalMeanRating() : 0;
+    // PIN `m` across a paging session: page 1 reads the 1h cache and encodes the
+    // value it used into nextCursor; pages 2..N decode that pinned `m` and reuse
+    // it (NOT a fresh cache read) so the sort key stays identical even if the
+    // cache expires/busts mid-pagination — otherwise the keyset boundary shifts
+    // and one row is silently skipped or duplicated. Cursorless first page only
+    // reads the cache. Other sorts don't use `m` (kept 0).
+    const globalMean =
+      sort === 'rating'
+        ? cursorMean ?? (await getGlobalMeanRating())
+        : 0;
     const sortKeyExpr =
       sort === 'rating'
         ? bayesianRatingSortKey(globalMean)
@@ -2679,8 +2714,13 @@ export class BlockRegistry {
     `)) as Row[];
     const trimmed = rows.slice(0, limit);
     const last = trimmed[trimmed.length - 1];
+    // Pin `m` into the cursor for the `rating` sort so every subsequent page
+    // reuses page 1's mean (see globalMean above). Omitted for other sorts.
+    const pinnedMean = sort === 'rating' ? globalMean : undefined;
     const nextCursor =
-      rows.length > limit && last ? encodeMarketplaceCursor(last.sort_key, last.id) : undefined;
+      rows.length > limit && last
+        ? encodeMarketplaceCursor(last.sort_key, last.id, pinnedMean)
+        : undefined;
     return {
       // F-E E1 anon-exposure allowlist: project the raw stored manifest down to
       // the vetted PUBLIC subset (name/description/targets[].slotId) via

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -31,6 +31,9 @@ import type {
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 import { toPublicBlockManifest, toPublicScreenshots } from '~/server/schema/blocks/subscription.schema';
 import { isLaunchSlot, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+import { CacheTTL } from '~/server/common/constants';
+import { queryCache } from '~/server/utils/cache-helpers';
+import { BAYES_MIN_REVIEWS } from '~/server/services/appBlockReview.service';
 
 const CACHE_TTL_SECONDS = 60;
 export const MAX_BLOCKS_PER_SLOT = 3;
@@ -75,6 +78,100 @@ function decodeMarketplaceCursor(cursor: string | undefined): {
     cursorSortKey: decoded.slice(0, sep),
     cursorId: decoded.slice(sep + 1),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace reviews — aggregate SQL + Bayesian sort (F-E "marketplace").
+// ---------------------------------------------------------------------------
+
+/**
+ * Correlated subquery: AVG(rating) over an app's AGGREGATE-ELIGIBLE reviews —
+ * NOT mod-excluded AND NOT the app owner's own (self-review). NULL for a
+ * 0-review app. Identical eligibility to getAppRatingTotals so the card number,
+ * the detail number, and the sort all agree.
+ */
+const AVG_RATING_SUBQUERY = Prisma.sql`(
+  SELECT AVG(abr.rating)::float
+  FROM app_block_reviews abr
+  WHERE abr.app_block_id = ab.id
+    AND NOT abr.exclude
+    AND abr.user_id IS DISTINCT FROM oc."userId"
+)`;
+
+/** Correlated subquery: COUNT of aggregate-eligible reviews (same filter). */
+const REVIEW_COUNT_SUBQUERY = Prisma.sql`(
+  SELECT COUNT(*)::bigint
+  FROM app_block_reviews abr
+  WHERE abr.app_block_id = ab.id
+    AND NOT abr.exclude
+    AND abr.user_id IS DISTINCT FROM oc."userId"
+)`;
+
+/** Correlated subquery: SUM(rating) of aggregate-eligible reviews (same filter). */
+const SUM_RATING_SUBQUERY = Prisma.sql`(
+  SELECT COALESCE(SUM(abr.rating), 0)::float
+  FROM app_block_reviews abr
+  WHERE abr.app_block_id = ab.id
+    AND NOT abr.exclude
+    AND abr.user_id IS DISTINCT FROM oc."userId"
+)`;
+
+// Scale factor for encoding the [1,5] Bayesian score as a zero-padded sortable
+// integer string. score * 1e6 → 7 digits max (5_000_000), lpad to 9 for headroom.
+const BAYES_SCORE_SCALE = 1_000_000;
+const BAYES_SCORE_PAD = 9;
+const INSTALL_PAD = 20; // matches the `popular` sort's install-count padding
+
+/**
+ * The Bayesian-shrinkage `rating` sort key, as a single zero-padded sortable
+ * TEXT (the same fragment reused IDENTICALLY in SELECT, the keyset WHERE, and
+ * ORDER BY — if it drifts, keyset pagination silently skips rows).
+ *
+ *   score = (C*m + SUM(rating)) / (C + n)
+ *     n = aggregate-eligible review count, m = global mean (param), C = prior.
+ *   0-review apps → score = m (mid-pack, not buried).
+ *
+ * Encoded DESC: lpad(round(score*SCALE)) so a plain TEXT DESC compare orders by
+ * score. Tiebreaker concatenated: equal scores fall back to install_count
+ * (lpad), then `ab.id` (the row-value keyset's final component). The whole key
+ * is one TEXT so the keyset tuple `(sort_key, id)` is a correct total order.
+ */
+function bayesianRatingSortKey(globalMean: number): Prisma.Sql {
+  // score = (C*m + SUM) / (C + n). C and m are server constants/params (safe).
+  const score = Prisma.sql`(
+    (${BAYES_MIN_REVIEWS}::float * ${globalMean}::float + ${SUM_RATING_SUBQUERY})
+    / (${BAYES_MIN_REVIEWS}::float + ${REVIEW_COUNT_SUBQUERY})
+  )`;
+  const installCount = Prisma.sql`(
+    SELECT COUNT(DISTINCT bus.user_id) FROM block_user_subscriptions bus
+    WHERE bus.app_block_id = ab.id
+  )`;
+  return Prisma.sql`(
+    lpad(round(${score} * ${BAYES_SCORE_SCALE})::bigint::text, ${BAYES_SCORE_PAD}, '0')
+    || lpad(${installCount}::text, ${INSTALL_PAD}, '0')
+  )`;
+}
+
+/**
+ * The global mean rating `m` across ALL aggregate-eligible app reviews (NOT
+ * exclude AND not self-review), cached 1h. Falls back to the neutral mid-scale
+ * (3.0) when there are no reviews yet (the marketplace is dark/empty), so a
+ * 0-review world still produces a sane, stable sort.
+ */
+async function getGlobalMeanRating(): Promise<number> {
+  const cacheable = queryCache(dbRead, 'getGlobalMeanRating', 'v1');
+  const rows = await cacheable<{ mean: number | null }[]>(
+    Prisma.sql`
+      SELECT AVG(abr.rating)::float AS mean
+      FROM app_block_reviews abr
+      JOIN app_blocks ab ON ab.id = abr.app_block_id
+      JOIN "OauthClient" oc ON oc.id = ab.app_id
+      WHERE NOT abr.exclude
+        AND abr.user_id IS DISTINCT FROM oc."userId"
+    `,
+    { ttl: CacheTTL.hour, tag: ['app-rating:global-mean'] }
+  );
+  return rows[0]?.mean ?? 3.0;
 }
 
 // Slot-reservation math lives in a client-safe module so the model-page SSR
@@ -2490,6 +2587,8 @@ export class BlockRegistry {
       install_count: bigint;
       category: string | null;
       approved_scopes: string[] | null;
+      avg_rating: number | null;
+      review_count: bigint;
       // The sort key for THIS row, projected so we can encode it into the
       // nextCursor for a stable keyset scan. Text so one column fits all sorts.
       sort_key: string;
@@ -2517,13 +2616,18 @@ export class BlockRegistry {
     // less-than the cursor tuple); name ASC (resume strictly greater-than).
     // ab.id shares the sort_key direction so the row-value tuple comparison is
     // a correct, total keyset.
+    // `rating` (the default) needs the marketplace-wide Bayesian prior `m`
+    // (cheap, 1h-cached scalar) injected as a param. The other sorts ignore it.
+    const globalMean = sort === 'rating' ? await getGlobalMeanRating() : 0;
     const sortKeyExpr =
-      sort === 'popular'
+      sort === 'rating'
+        ? bayesianRatingSortKey(globalMean)
+        : sort === 'popular'
         ? Prisma.sql`lpad((SELECT COUNT(DISTINCT bus.user_id) FROM block_user_subscriptions bus WHERE bus.app_block_id = ab.id)::text, 20, '0')`
         : sort === 'newest'
         ? Prisma.sql`to_char(COALESCE(ab.current_version_deployed_at, ab.created_at) AT TIME ZONE 'UTC', 'YYYYMMDDHH24MISSUS')`
         : Prisma.sql`LOWER(COALESCE(ab.manifest->>'name', ab.block_id))`;
-    const descending = sort === 'popular' || sort === 'newest';
+    const descending = sort === 'rating' || sort === 'popular' || sort === 'newest';
     const dir = descending ? Prisma.sql`DESC` : Prisma.sql`ASC`;
     const keysetCmp = descending ? Prisma.sql`<` : Prisma.sql`>`;
 
@@ -2544,6 +2648,10 @@ export class BlockRegistry {
         -- ranking. COUNT(DISTINCT user_id) makes the number mean "users".
         (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
          WHERE bus.app_block_id = ab.id) AS install_count,
+        -- Marketplace reviews: aggregate-eligible AVG + COUNT (excludes
+        -- mod-excluded + self-reviews). NULL avg = 0-review app.
+        ${AVG_RATING_SUBQUERY} AS avg_rating,
+        ${REVIEW_COUNT_SUBQUERY} AS review_count,
         -- The sort key for this row, as text, so the keyset cursor can carry it.
         ${sortKeyExpr} AS sort_key
       FROM app_blocks ab
@@ -2600,6 +2708,9 @@ export class BlockRegistry {
               .filter((s): s is string => typeof s === 'string')
               .slice(0, MARKETPLACE_SCOPES_SUMMARY_LIMIT)
           : [],
+        // Marketplace reviews (aggregate-eligible). avgRating NULL = 0-review.
+        avgRating: r.avg_rating ?? null,
+        reviewCount: Number(r.review_count),
       })),
       nextCursor,
     };
@@ -2644,6 +2755,8 @@ export class BlockRegistry {
       version: string | null;
       approved_scopes: string[] | null;
       install_count: bigint;
+      avg_rating: number | null;
+      review_count: bigint;
       // F-E E5: stored screenshot records ([{ key, index, ext, contentType }]),
       // jsonb. NULL until the E5 migration is applied + an app is (re)approved
       // with a `screenshots/` dir — projected to PUBLIC display URLs below.
@@ -2662,7 +2775,9 @@ export class BlockRegistry {
         ab.approved_scopes,
         ab.screenshots,
         (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
-         WHERE bus.app_block_id = ab.id) AS install_count
+         WHERE bus.app_block_id = ab.id) AS install_count,
+        ${AVG_RATING_SUBQUERY} AS avg_rating,
+        ${REVIEW_COUNT_SUBQUERY} AS review_count
       FROM app_blocks ab
       LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
       WHERE ab.id = ${appBlockId}::text
@@ -2695,6 +2810,10 @@ export class BlockRegistry {
       contentRating: row.content_rating ?? null,
       version: row.version ?? null,
       installCount: Number(row.install_count),
+      // Marketplace reviews (aggregate-eligible — excludes mod-excluded +
+      // self-reviews). avgRating NULL = 0-review. Display-safe aggregates.
+      avgRating: row.avg_rating ?? null,
+      reviewCount: Number(row.review_count),
       // Already-public standalone origin (no token/scope). Same host the webhook
       // validates the submitted bundle's iframe.src against.
       liveUrl: `https://${row.block_id}.${env.APPS_DOMAIN}`,
@@ -2740,6 +2859,8 @@ export class BlockRegistry {
       install_count: bigint;
       category: string | null;
       approved_scopes: string[] | null;
+      avg_rating: number | null;
+      review_count: bigint;
     };
     const rows = (await dbRead.$queryRaw<Row[]>`
       SELECT
@@ -2751,7 +2872,9 @@ export class BlockRegistry {
         ab.category,
         ab.approved_scopes,
         (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
-         WHERE bus.app_block_id = ab.id) AS install_count
+         WHERE bus.app_block_id = ab.id) AS install_count,
+        ${AVG_RATING_SUBQUERY} AS avg_rating,
+        ${REVIEW_COUNT_SUBQUERY} AS review_count
       FROM app_blocks ab
       LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
       WHERE ab.status = 'approved'
@@ -2777,6 +2900,8 @@ export class BlockRegistry {
             .filter((s): s is string => typeof s === 'string')
             .slice(0, MARKETPLACE_SCOPES_SUMMARY_LIMIT)
         : [],
+      avgRating: r.avg_rating ?? null,
+      reviewCount: Number(r.review_count),
     }));
   }
 

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -2578,9 +2578,10 @@ export class BlockRegistry {
   /**
    * Marketplace listing. Filters by slot (manifest @> {targets:[{slotId}]}),
    * a free-text ILIKE on the manifest name/blockId, and (F-E E3) a mod-assigned
-   * `category`. Sortable (F-E E3) by `popular` (install_count desc — the
-   * default, unchanged from pre-E3), `newest` (current_version_deployed_at
-   * desc, falling back to created_at), or `name` (manifest name asc).
+   * `category`. Sortable by `rating` (Bayesian-shrinkage avg rating desc — the
+   * DEFAULT; 0-review apps sit mid-pack at the global mean), `popular`
+   * (install_count desc), `newest` (current_version_deployed_at desc, falling
+   * back to created_at), or `name` (manifest name asc).
    *
    * Cursor: a deterministic keyset over `(sortKey, id)`. We always append
    * `ab.id ASC` as the final tiebreaker so the cursor is unambiguous; the

--- a/src/shared/utils/prisma/models.ts
+++ b/src/shared/utils/prisma/models.ts
@@ -622,6 +622,7 @@ export interface User {
   publishRequestsReviewed?: AppBlockPublishRequest[];
   blockScopeInvocations?: BlockScopeInvocation[];
   appUserScopeGrants?: AppUserScopeGrant[];
+  appBlockReviews?: AppBlockReview[];
   appDevForgejoIdentity?: AppDevForgejoIdentity | null;
 }
 
@@ -1792,6 +1793,22 @@ export interface AppBlock {
   publishRequests?: AppBlockPublishRequest[];
   scopeInvocations?: BlockScopeInvocation[];
   userScopeGrants?: AppUserScopeGrant[];
+  reviews?: AppBlockReview[];
+}
+
+export interface AppBlockReview {
+  id: number;
+  appBlockId: string;
+  appBlock?: AppBlock;
+  userId: number;
+  user?: User;
+  rating: number;
+  recommended: boolean;
+  details: string | null;
+  exclude: boolean;
+  tosViolation: boolean;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface AppBlockPublishRequest {


### PR DESCRIPTION
App Blocks marketplace **reviews** cluster: 5-star app reviews, a blue-buzz reward for leaving one, and avg-rating + review-count on the marketplace with a **Bayesian default sort**. Everything ships **DARK** behind the existing mod-segmented `appBlocks` flag (consistent with E1–E5).

## New table — `AppBlockReview` (parallel to ResourceReview)
`ResourceReview` is hard-bound to model/version FKs, so this is a parallel table. One review per `(app_block_id, user_id)`; aggregate index `(app_block_id, exclude)`; `rating` 1..5 with a CHECK.

### ⚠️ MANUAL-APPLY migration (CLAUDE.md rule 8 — CNPG nvme0 does NOT auto-apply)
`prisma/migrations/20260621120000_app_block_reviews/migration.sql` is committed for **history only**. Apply BY HAND (psql) to **(1) prod nvme0** and **(2) the dev clone** (`cnpg-cluster-dev`, ns `cnpg-database-dev`). The table is additive + read only by the dark, mod-gated surfaces, so applying ahead of the deploy is inert. Exact SQL:

```sql
CREATE TABLE IF NOT EXISTS "app_block_reviews" (
  "id"            SERIAL PRIMARY KEY,
  "app_block_id"  TEXT NOT NULL REFERENCES "app_blocks"("id") ON DELETE CASCADE,
  "user_id"       INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
  "rating"        INTEGER NOT NULL,
  "recommended"   BOOLEAN NOT NULL DEFAULT true,
  "details"       TEXT,
  "exclude"       BOOLEAN NOT NULL DEFAULT false,
  "tos_violation" BOOLEAN NOT NULL DEFAULT false,
  "created_at"    TIMESTAMPTZ NOT NULL DEFAULT now(),
  "updated_at"    TIMESTAMPTZ NOT NULL DEFAULT now(),
  CONSTRAINT "app_block_reviews_rating_range" CHECK ("rating" >= 1 AND "rating" <= 5)
);
CREATE UNIQUE INDEX IF NOT EXISTS "app_block_reviews_app_user_uniq"
  ON "app_block_reviews" ("app_block_id", "user_id");
CREATE INDEX IF NOT EXISTS "app_block_reviews_app_agg_idx"
  ON "app_block_reviews" ("app_block_id", "exclude");
```

## Service + tRPC (mirrors the model-review service)
- `upsertAppBlockReview` → create-or-update on the unique key; returns `isFirstReview` (the once-per reward anchor).
- `getAppRatingTotals` → `AVG`/`COUNT`, cached 1h (tag `app-rating:<id>`), **excludes mod-excluded rows AND self-reviews** (NULL-safe `oc."userId" IS DISTINCT FROM abr.user_id`).
- `listAppBlockReviews` (keyset on `id DESC`), `getMyAppBlockReview`, `setAppReviewExcluded` (mod), `deleteAppBlockReview`. Cache bust busts the per-app **and** the global-mean tag.
- Router (`blocks.router.ts`): `upsertReview` (guardedProcedure), `listReviews` (public, empty when dark), `getMyReview` (protected), `setReviewExcluded` (moderator). All `.use(enforceAppBlocksFlag)` — DARK.
- `getAppDetail` now returns `avgRating` + `reviewCount`; the viewer's own review is served by the gated `getMyReview`.

## Anti-abuse gates (all enforced + tested)
1. **One per (user, app)** — the `@@unique`.
2. **No self-review** — the app owner (`AppBlock.app.userId`) is rejected at the service AND excluded from the aggregate.
3. **Must have installed** — gated on an **enabled** `BlockUserSubscription` for `(userId, appBlockId)`.
4. `exclude` / `tosViolation` — mod controls keep abusive reviews out of the aggregate + the ranking (`setReviewExcluded`).

## Blue-buzz reward (money-touching — copy the pattern, fail-soft, reward-once)
`src/server/rewards/active/appBlockReview.reward.ts` (`createBuzzEvent`, `toAccountType:'blue'`, award/cap 25, `onDemand`, `forId=appBlockId` per-(user,app) dedup). Applied **only on the create branch**, **after** a successful insert, **fail-soft** (a ClickHouse/reward outage never 500s the review — `try/catch` on top of `createBuzzEvent`'s own inline fail-soft path). Blue buzz is non-cashable (generation-only) — the correct currency for a review reward. `'appBlockReview'` is a plain reward `type` string (no enum to extend); exported from `~/server/rewards` so the batch processor picks it up (a no-op for an `onDemand` reward).

## Marketplace: avg + count, default sort = Bayesian
- `avgRating` + `reviewCount` added to the `AvailableBlock` projection (computed as correlated subqueries in `listAvailable` / `getFeaturedBlocks` / `getAppDetail`) and rendered on `AppBlockCard` (★ + `avg.toFixed(1)` + count, "No reviews" for 0-review).
- New default sort **`rating`** = Bayesian shrinkage: `score = (C*m + SUM(rating)) / (C + n)`, `C=BAYES_MIN_REVIEWS=10`, `m`=cached (1h) global mean. A few-review 5★ app can't outrank a many-review 4.x app; **0-review apps sit mid-pack at `m`**. Added to `marketplaceSortSchema` + made the default; "Top rated" added to the page sort options + initial state.
- **Load-bearing:** the Bayesian score is encoded as a single zero-padded sortable **TEXT**, `lpad(round(score*1e6)) || lpad(install_count) ` (tiebreaker), reused **IDENTICALLY** in SELECT (`AS sort_key`) + the keyset-WHERE tuple + ORDER BY — if it drifts, keyset pagination silently skips rows. Literal expr:
  ```sql
  lpad(round(((10::float * $m::float + SUM_RATING)/(10::float + REVIEW_COUNT)) * 1000000)::bigint::text, 9, '0')
    || lpad(INSTALL_COUNT::text, 20, '0')
  ```

## Tests (typecheck clean; vitest green)
- **Service**: create vs update (`isFirstReview` only on create); gates (no-self-review, not-installed, enabled-only install, missing app, rating range); aggregate SQL excludes `exclude` + self-reviews; cache bust (app + global-mean tags).
- **Reward**: fires once on create (blue, `forId=appBlockId`); not on update; fail-soft (CH throw doesn't propagate); already-awarded dedup → no award.
- **Marketplace**: avg/count projected; Bayesian ordering (few-review 5★ < many-review 4.x; 0-review = m; encoding preserves order; install tiebreaker); **keyset completeness** — pages of 5 and 1 cover every app exactly once over a dataset with many ties at score=m (no skips/dupes); SQL drift-guard (Bayesian key appears in SELECT + keyset-WHERE).
- **Router**: `upsertReview` DARK gate (UNAUTHORIZED, service/reward not called); reward fires once on create, not on update; fail-soft (reward throw doesn't fail the mutation).

`pnpm typecheck` exits 0. `vitest run --project unit` on all new + affected files: **338 passing**. (Per the project memory, CI preview unit suites are report-only + the build transpiles without typecheck, so these were run explicitly.)

## Deviations from the spec
- `getAppDetail` stays anon-capable (no `userId`); the viewer's own review is served by a separate gated `getMyReview` procedure rather than threading `userId` into the anon detail path — cleaner + matches the existing per-user/anon split.
- Self-review aggregate filter uses NULL-safe `IS DISTINCT FROM` (vs `!=`) so an edge-case orphaned OauthClient can't zero out an app's aggregate.

Dark behind the `appBlocks` flag. The migration is **manual-apply** — no deploy/CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)