### PR TITLE
feat(app-blocks): author analytics dashboard (Phase 0, from existing data)

### DIFF
--- a/prisma/migrations/20260621120000_bus_app_block_created_analytics_idx/migration.sql
+++ b/prisma/migrations/20260621120000_bus_app_block_created_analytics_idx/migration.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- App Blocks — author analytics (Phase 0) supporting index
+-- ============================================================
+-- The author analytics dashboard's installs time-series groups
+-- block_user_subscriptions by (app_block_id, created_at) for the apps the
+-- caller owns. The existing indexes on this table are either partial
+-- (scope='publisher_all_my_models' / 'viewer_personal') or keyed on
+-- (user_id, ...) — none serve an "installs over time for THIS app" scan.
+--
+-- This composite index makes that bounded: the dashboard always filters by
+-- a small set of owned app_block ids + a clamped date range. Cheap to add
+-- (the analytics read path is dark behind the appBlocks flag).
+--
+-- ⚠️ MANUAL APPLY: CNPG nvme0 (main civitai DB) does NOT auto-apply Prisma
+-- migrations. Apply this by hand per environment. On prod prefer:
+--   CREATE INDEX CONCURRENTLY "bus_app_block_created_idx"
+--     ON "block_user_subscriptions" ("app_block_id", "created_at" DESC);
+-- (CONCURRENTLY can't run inside Prisma's migration transaction, hence the
+-- plain form below for the migration history; run the CONCURRENTLY variant
+-- against prod to avoid a write lock.)
+
+CREATE INDEX IF NOT EXISTS "bus_app_block_created_idx"
+  ON "block_user_subscriptions" ("app_block_id", "created_at" DESC);

--- a/prisma/schema.full.prisma
+++ b/prisma/schema.full.prisma
@@ -2483,6 +2483,11 @@ model BlockUserSubscription {
   // express partial unique indexes with array expressions inline). One
   // blanket sub per (user, app, scope); one pinned sub per
   // (user, app, scope, slot, target_model_ids[1]).
+
+  // Phase 0 author analytics: installs-over-time for an owned app block
+  // (app_block_id equality + created_at range). See migration
+  // 20260621120000_bus_app_block_created_analytics_idx.
+  @@index([appBlockId, createdAt(sort: Desc)], map: "bus_app_block_created_idx")
   @@map("block_user_subscriptions")
 }
 

--- a/src/components/AppBlocks/AppAnalyticsPanel.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.tsx
@@ -1,0 +1,333 @@
+import {
+  Alert,
+  Badge,
+  Card,
+  Group,
+  Loader,
+  Select,
+  SimpleGrid,
+  Stack,
+  Table,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import type { ChartOptions } from 'chart.js';
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Filler,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip as ChartTooltip,
+} from 'chart.js';
+import { IconInfoCircle } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import { useComputedColorScheme, useMantineTheme } from '@mantine/core';
+import dayjs from '~/shared/utils/dayjs';
+import { trpc } from '~/utils/trpc';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, ChartTooltip, Filler);
+
+type TimePoint = { bucket: string; value: number };
+
+type AnalyticsData = {
+  range: { from: string | Date; to: string | Date; granularity: 'day' | 'week' };
+  notOwned: boolean;
+  installs: { total: number; active: number; series: TimePoint[] };
+  runs: { count: number; buzzSpent: number; series: TimePoint[] };
+  buzzPurchased: { count: number; buzzAmount: number; grossCents: number };
+  engagement: {
+    apiCalls: number;
+    activeUsers: number;
+    errorRate: number;
+    topScopes: Array<{ scope: string; count: number }>;
+    topEndpoints: Array<{ endpoint: string; count: number }>;
+  };
+};
+
+type MyApp = {
+  id: string;
+  appName: string | null;
+  blockId: string;
+};
+
+function MetricCard({
+  label,
+  value,
+  sub,
+  tooltip,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  tooltip?: string;
+}) {
+  return (
+    <Card padding="md" radius="md" withBorder>
+      <Group gap="xs">
+        <Text size="xs" c="dimmed" fw={600} tt="uppercase">
+          {label}
+        </Text>
+        {tooltip && (
+          <Tooltip label={tooltip} position="top" multiline maw={280}>
+            <IconInfoCircle size={14} />
+          </Tooltip>
+        )}
+      </Group>
+      <Title order={3} mt={4}>
+        {value}
+      </Title>
+      {sub && (
+        <Text size="xs" c="dimmed">
+          {sub}
+        </Text>
+      )}
+    </Card>
+  );
+}
+
+function MiniLineChart({
+  points,
+  granularity,
+}: {
+  points: TimePoint[];
+  granularity: 'day' | 'week';
+}) {
+  const theme = useMantineTheme();
+  const colorScheme = useComputedColorScheme('dark');
+  const lineColor = theme.colors.blue[colorScheme === 'dark' ? 5 : 6];
+
+  const data = useMemo(
+    () => ({
+      labels: points.map((p) => p.bucket),
+      datasets: [
+        {
+          data: points.map((p) => p.value),
+          borderColor: lineColor,
+          backgroundColor: `${lineColor}1f`,
+          borderWidth: 2,
+          fill: true,
+          tension: 0.3,
+          pointRadius: 0,
+          pointHoverRadius: 4,
+          pointHoverBackgroundColor: lineColor,
+        },
+      ],
+    }),
+    [points, lineColor]
+  );
+
+  const options = useMemo<ChartOptions<'line'>>(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        x: { display: false },
+        y: { display: false, beginAtZero: true },
+      },
+      plugins: {
+        legend: { display: false },
+        title: { display: false },
+        tooltip: {
+          displayColors: false,
+          callbacks: {
+            title: (items) =>
+              dayjs.utc(items[0]?.label).format(granularity === 'week' ? 'MMM D' : 'MMM D'),
+            label: (item) => `${item.parsed.y}`,
+          },
+        },
+      },
+    }),
+    [granularity]
+  );
+
+  if (!points.length) {
+    return (
+      <Text c="dimmed" size="xs" py="sm">
+        No data in this range.
+      </Text>
+    );
+  }
+
+  return (
+    <div className="h-16 w-full">
+      <Line data={data} options={options} />
+    </div>
+  );
+}
+
+export function AppAnalyticsPanel() {
+  const { data: appsRaw, isLoading: appsLoading } = trpc.blocks.getMyApps.useQuery();
+  const apps = (appsRaw as MyApp[] | undefined) ?? [];
+  const [appBlockId, setAppBlockId] = useState<string | null>(null);
+
+  const {
+    data: analyticsRaw,
+    isLoading: analyticsLoading,
+    error,
+  } = trpc.blocks.getMyAppAnalytics.useQuery({
+    appBlockId: appBlockId ?? undefined,
+  });
+  const analytics = analyticsRaw as AnalyticsData | undefined;
+
+  const appOptions = [
+    { value: '', label: 'All my apps' },
+    ...apps.map((a) => ({
+      value: a.id,
+      label: a.appName ?? a.blockId ?? a.id,
+    })),
+  ];
+
+  return (
+    <Stack gap="lg">
+      <Group justify="space-between" align="flex-end">
+        <Select
+          label="App"
+          data={appOptions}
+          value={appBlockId ?? ''}
+          onChange={(v) => setAppBlockId(v ? v : null)}
+          disabled={appsLoading}
+          w={260}
+          comboboxProps={{ withinPortal: true }}
+        />
+        {analytics && (
+          <Text size="xs" c="dimmed">
+            {dayjs(analytics.range.from).format('MMM D, YYYY')} –{' '}
+            {dayjs(analytics.range.to).format('MMM D, YYYY')} (
+            {analytics.range.granularity})
+          </Text>
+        )}
+      </Group>
+
+      {analyticsLoading && (
+        <Group justify="center" py="xl">
+          <Loader />
+        </Group>
+      )}
+      {error && (
+        <Text c="red" size="sm">
+          Failed to load analytics: {error.message}
+        </Text>
+      )}
+
+      {analytics && (
+        <>
+          <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
+            <MetricCard
+              label="Active installs"
+              value={analytics.installs.active.toLocaleString()}
+              sub={`${analytics.installs.total.toLocaleString()} total (all time)`}
+              tooltip="Currently-enabled installs. Total counts every install ever created."
+            />
+            <MetricCard
+              label="Runs (range)"
+              value={analytics.runs.count.toLocaleString()}
+              sub={`${analytics.runs.buzzSpent.toLocaleString()} Buzz spent`}
+              tooltip="Generations run through your app within the selected range, and the viewer Buzz burned doing so."
+            />
+            <MetricCard
+              label="Buzz purchased"
+              value={analytics.buzzPurchased.buzzAmount.toLocaleString()}
+              sub={`${analytics.buzzPurchased.count.toLocaleString()} purchase${
+                analytics.buzzPurchased.count === 1 ? '' : 's'
+              } · $${(analytics.buzzPurchased.grossCents / 100).toFixed(2)}`}
+              tooltip="Buzz bought via card from inside your app within the range (gross value shown)."
+            />
+            <MetricCard
+              label="Active users"
+              value={analytics.engagement.activeUsers.toLocaleString()}
+              sub={`${analytics.engagement.apiCalls.toLocaleString()} API calls`}
+              tooltip="Distinct signed-in users who made a scoped API call within the range. See the coverage note below."
+            />
+          </SimpleGrid>
+
+          <Alert
+            variant="light"
+            color="gray"
+            icon={<IconInfoCircle size={16} />}
+            title="What engagement counts"
+          >
+            <Text size="sm">
+              Active users, API calls, and error rate reflect only{' '}
+              <strong>authenticated, scope-gated API calls</strong> your app makes.
+              A static block (or one with no scoped API surface) will show installs
+              and revenue but flat engagement, and <strong>anonymous viewers are
+              not counted</strong>. Installs, runs, and Buzz figures are unaffected.
+            </Text>
+          </Alert>
+
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+            <Card padding="md" radius="md" withBorder>
+              <Title order={5}>New installs over time</Title>
+              <MiniLineChart
+                points={analytics.installs.series}
+                granularity={analytics.range.granularity}
+              />
+            </Card>
+            <Card padding="md" radius="md" withBorder>
+              <Title order={5}>Runs over time</Title>
+              <MiniLineChart
+                points={analytics.runs.series}
+                granularity={analytics.range.granularity}
+              />
+            </Card>
+          </SimpleGrid>
+
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+            <Card padding="md" radius="md" withBorder>
+              <Group justify="space-between">
+                <Title order={5}>Top scopes</Title>
+                <Badge variant="light" color="gray" size="sm">
+                  {(analytics.engagement.errorRate * 100).toFixed(1)}% errors
+                </Badge>
+              </Group>
+              {analytics.engagement.topScopes.length === 0 ? (
+                <Text c="dimmed" size="sm" mt="sm">
+                  No scoped API calls in this range.
+                </Text>
+              ) : (
+                <Table mt="sm">
+                  <Table.Tbody>
+                    {analytics.engagement.topScopes.map((s) => (
+                      <Table.Tr key={s.scope}>
+                        <Table.Td>{s.scope}</Table.Td>
+                        <Table.Td ta="right">{s.count.toLocaleString()}</Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              )}
+            </Card>
+            <Card padding="md" radius="md" withBorder>
+              <Title order={5}>Top endpoints</Title>
+              {analytics.engagement.topEndpoints.length === 0 ? (
+                <Text c="dimmed" size="sm" mt="sm">
+                  No scoped API calls in this range.
+                </Text>
+              ) : (
+                <Table mt="sm">
+                  <Table.Tbody>
+                    {analytics.engagement.topEndpoints.map((e) => (
+                      <Table.Tr key={e.endpoint}>
+                        <Table.Td>
+                          <Text size="sm" lineClamp={1}>
+                            {e.endpoint}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td ta="right">{e.count.toLocaleString()}</Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              )}
+            </Card>
+          </SimpleGrid>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/AppBlocks/AppAnalyticsPanel.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.tsx
@@ -197,8 +197,7 @@ export function AppAnalyticsPanel() {
         {analytics && (
           <Text size="xs" c="dimmed">
             {dayjs(analytics.range.from).format('MMM D, YYYY')} –{' '}
-            {dayjs(analytics.range.to).format('MMM D, YYYY')} (
-            {analytics.range.granularity})
+            {dayjs(analytics.range.to).format('MMM D, YYYY')} ({analytics.range.granularity})
           </Text>
         )}
       </Group>
@@ -253,10 +252,10 @@ export function AppAnalyticsPanel() {
           >
             <Text size="sm">
               Active users, API calls, and error rate reflect only{' '}
-              <strong>authenticated, scope-gated API calls</strong> your app makes.
-              A static block (or one with no scoped API surface) will show installs
-              and revenue but flat engagement, and <strong>anonymous viewers are
-              not counted</strong>. Installs, runs, and Buzz figures are unaffected.
+              <strong>authenticated, scope-gated API calls</strong> your app makes. A static block
+              (or one with no scoped API surface) will show installs and revenue but flat
+              engagement, and <strong>anonymous viewers are not counted</strong>. Installs, runs,
+              and Buzz figures are unaffected.
             </Text>
           </Alert>
 

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -129,10 +129,7 @@ function SummaryCards({ summary }: { summary: SummaryShape }) {
           <Text size="xs" c="dimmed" fw={600} tt="uppercase">
             Voided
           </Text>
-          <Tooltip
-            label="Refunds, chargebacks, and self-purchases. Not paid out."
-            position="top"
-          >
+          <Tooltip label="Refunds, chargebacks, and self-purchases. Not paid out." position="top">
             <IconInfoCircle size={14} />
           </Tooltip>
         </Group>
@@ -154,116 +151,106 @@ function RevenuePanel() {
   return (
     <Stack gap="lg">
       {isLoading && (
-            <Group justify="center" py="xl">
-              <Loader />
-            </Group>
-          )}
-          {error && (
-            <Text c="red" size="sm">
-              Failed to load revenue: {error.message}
-            </Text>
+        <Group justify="center" py="xl">
+          <Loader />
+        </Group>
+      )}
+      {error && (
+        <Text c="red" size="sm">
+          Failed to load revenue: {error.message}
+        </Text>
+      )}
+
+      {data && (
+        <>
+          <SummaryCards summary={data.summary} />
+
+          {data.topApps.length > 0 && (
+            <Card padding="md" radius="md" withBorder>
+              <Title order={5}>Top earning apps</Title>
+              <Stack gap="xs" mt="sm">
+                {data.topApps.map((app) => (
+                  <Group key={app.appBlockId} justify="space-between">
+                    <Anchor component={Link} href={`/apps/${app.appBlockId}/revenue`} size="sm">
+                      {app.appBlockId}
+                    </Anchor>
+                    <Group gap="xs">
+                      <Text size="sm" fw={600}>
+                        {dollars(app.shareCents)}
+                      </Text>
+                      <Badge variant="light" size="sm">
+                        {app.count}
+                      </Badge>
+                    </Group>
+                  </Group>
+                ))}
+              </Stack>
+            </Card>
           )}
 
-          {data && (
-            <>
-              <SummaryCards summary={data.summary} />
-
-              {data.topApps.length > 0 && (
-                <Card padding="md" radius="md" withBorder>
-                  <Title order={5}>Top earning apps</Title>
-                  <Stack gap="xs" mt="sm">
-                    {data.topApps.map((app) => (
-                      <Group key={app.appBlockId} justify="space-between">
-                        <Anchor
-                          component={Link}
-                          href={`/apps/${app.appBlockId}/revenue`}
+          <Card padding="md" radius="md" withBorder>
+            <Title order={5}>Recent attributions</Title>
+            {data.recentAttributions.length === 0 ? (
+              <Text c="dimmed" size="sm" mt="sm">
+                No buzz purchases yet. Install your blocks on more models to earn share.
+              </Text>
+            ) : (
+              <Table mt="sm" highlightOnHover>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Date</Table.Th>
+                    <Table.Th>App</Table.Th>
+                    <Table.Th>Scope</Table.Th>
+                    <Table.Th>
+                      <Group gap={4}>
+                        <IconBolt size={14} />
+                        Buzz
+                      </Group>
+                    </Table.Th>
+                    <Table.Th>Gross</Table.Th>
+                    <Table.Th>Your share</Table.Th>
+                    <Table.Th>Status</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {data.recentAttributions.map((row: RecentRow) => (
+                    <Table.Tr key={row.id}>
+                      <Table.Td>{new Date(row.attributedAt).toLocaleDateString()}</Table.Td>
+                      <Table.Td>
+                        <Anchor component={Link} href={`/apps/${row.appBlockId}/revenue`} size="sm">
+                          {row.appBlockId}
+                        </Anchor>
+                      </Table.Td>
+                      <Table.Td>{row.scope}</Table.Td>
+                      <Table.Td>{row.buzzAmount.toLocaleString()}</Table.Td>
+                      <Table.Td>{dollars(row.usdAmountCents)}</Table.Td>
+                      <Table.Td>{dollars(row.appOwnerShareCents)}</Table.Td>
+                      <Table.Td>
+                        <Badge
+                          variant="light"
+                          color={
+                            row.status === 'paid_out'
+                              ? 'green'
+                              : row.status === 'confirmed'
+                              ? 'teal'
+                              : row.status === 'voided'
+                              ? 'red'
+                              : 'gray'
+                          }
                           size="sm"
                         >
-                          {app.appBlockId}
-                        </Anchor>
-                        <Group gap="xs">
-                          <Text size="sm" fw={600}>
-                            {dollars(app.shareCents)}
-                          </Text>
-                          <Badge variant="light" size="sm">
-                            {app.count}
-                          </Badge>
-                        </Group>
-                      </Group>
-                    ))}
-                  </Stack>
-                </Card>
-              )}
-
-              <Card padding="md" radius="md" withBorder>
-                <Title order={5}>Recent attributions</Title>
-                {data.recentAttributions.length === 0 ? (
-                  <Text c="dimmed" size="sm" mt="sm">
-                    No buzz purchases yet. Install your blocks on more models to earn share.
-                  </Text>
-                ) : (
-                  <Table mt="sm" highlightOnHover>
-                    <Table.Thead>
-                      <Table.Tr>
-                        <Table.Th>Date</Table.Th>
-                        <Table.Th>App</Table.Th>
-                        <Table.Th>Scope</Table.Th>
-                        <Table.Th>
-                          <Group gap={4}>
-                            <IconBolt size={14} />
-                            Buzz
-                          </Group>
-                        </Table.Th>
-                        <Table.Th>Gross</Table.Th>
-                        <Table.Th>Your share</Table.Th>
-                        <Table.Th>Status</Table.Th>
-                      </Table.Tr>
-                    </Table.Thead>
-                    <Table.Tbody>
-                      {data.recentAttributions.map((row: RecentRow) => (
-                        <Table.Tr key={row.id}>
-                          <Table.Td>
-                            {new Date(row.attributedAt).toLocaleDateString()}
-                          </Table.Td>
-                          <Table.Td>
-                            <Anchor
-                              component={Link}
-                              href={`/apps/${row.appBlockId}/revenue`}
-                              size="sm"
-                            >
-                              {row.appBlockId}
-                            </Anchor>
-                          </Table.Td>
-                          <Table.Td>{row.scope}</Table.Td>
-                          <Table.Td>{row.buzzAmount.toLocaleString()}</Table.Td>
-                          <Table.Td>{dollars(row.usdAmountCents)}</Table.Td>
-                          <Table.Td>{dollars(row.appOwnerShareCents)}</Table.Td>
-                          <Table.Td>
-                            <Badge
-                              variant="light"
-                              color={
-                                row.status === 'paid_out'
-                                  ? 'green'
-                                  : row.status === 'confirmed'
-                                  ? 'teal'
-                                  : row.status === 'voided'
-                                  ? 'red'
-                                  : 'gray'
-                              }
-                              size="sm"
-                            >
-                              {row.status}
-                              {row.voidedReason ? ` (${row.voidedReason})` : ''}
-                            </Badge>
-                          </Table.Td>
-                        </Table.Tr>
-                      ))}
-                    </Table.Tbody>
-                  </Table>
-                )}
-              </Card>
-            </>
-          )}
+                          {row.status}
+                          {row.voidedReason ? ` (${row.voidedReason})` : ''}
+                        </Badge>
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            )}
+          </Card>
+        </>
+      )}
     </Stack>
   );
 }
@@ -280,8 +267,7 @@ export default function AppBlocksDashboardPage() {
           <div>
             <Title order={2}>App Blocks Dashboard</Title>
             <Text c="dimmed" size="sm">
-              Revenue share and analytics for your blocks. Payouts are batched
-              weekly; see{' '}
+              Revenue share and analytics for your blocks. Payouts are batched weekly; see{' '}
               <Anchor component={Link} href="/apps/installed">
                 Apps
               </Anchor>{' '}

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -8,6 +8,7 @@ import {
   SimpleGrid,
   Stack,
   Table,
+  Tabs,
   Text,
   Title,
   Tooltip,
@@ -15,6 +16,7 @@ import {
 import { IconBolt, IconInfoCircle } from '@tabler/icons-react';
 import Link from 'next/link';
 import { NotFound } from '~/components/AppLayout/NotFound';
+import { AppAnalyticsPanel } from '~/components/AppBlocks/AppAnalyticsPanel';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
@@ -145,29 +147,13 @@ function SummaryCards({ summary }: { summary: SummaryShape }) {
   );
 }
 
-export default function RevenueDashboardPage() {
-  const features = useFeatureFlags();
-  if (!features.appBlocks) return <NotFound />;
+function RevenuePanel() {
   const { data: rawData, isLoading, error } = trpc.blocks.getMyRevenue.useQuery({});
   const data = rawData as RevenueData | undefined;
 
   return (
-    <>
-      <Meta title="App Blocks Revenue — Civitai" deIndex />
-      <Container size="lg" py="xl">
-        <Stack gap="lg">
-          <div>
-            <Title order={2}>App Blocks Revenue</Title>
-            <Text c="dimmed" size="sm">
-              Revenue share from buzz purchases originated inside your blocks. Payouts
-              are batched weekly; see <Anchor component={Link} href="/apps/installed">
-                Apps
-              </Anchor>{' '}
-              to manage installations.
-            </Text>
-          </div>
-
-          {isLoading && (
+    <Stack gap="lg">
+      {isLoading && (
             <Group justify="center" py="xl">
               <Loader />
             </Group>
@@ -278,6 +264,43 @@ export default function RevenueDashboardPage() {
               </Card>
             </>
           )}
+    </Stack>
+  );
+}
+
+export default function AppBlocksDashboardPage() {
+  const features = useFeatureFlags();
+  if (!features.appBlocks) return <NotFound />;
+
+  return (
+    <>
+      <Meta title="App Blocks Dashboard — Civitai" deIndex />
+      <Container size="lg" py="xl">
+        <Stack gap="lg">
+          <div>
+            <Title order={2}>App Blocks Dashboard</Title>
+            <Text c="dimmed" size="sm">
+              Revenue share and analytics for your blocks. Payouts are batched
+              weekly; see{' '}
+              <Anchor component={Link} href="/apps/installed">
+                Apps
+              </Anchor>{' '}
+              to manage installations.
+            </Text>
+          </div>
+
+          <Tabs defaultValue="revenue" keepMounted={false}>
+            <Tabs.List mb="md">
+              <Tabs.Tab value="revenue">Revenue</Tabs.Tab>
+              <Tabs.Tab value="analytics">Analytics</Tabs.Tab>
+            </Tabs.List>
+            <Tabs.Panel value="revenue">
+              <RevenuePanel />
+            </Tabs.Panel>
+            <Tabs.Panel value="analytics">
+              <AppAnalyticsPanel />
+            </Tabs.Panel>
+          </Tabs>
         </Stack>
       </Container>
     </>

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -18,6 +18,8 @@ import { TRPCError } from '@trpc/server';
 const {
   mockIsAppBlocksEnabled,
   mockGetMyAppAnalytics,
+  mockGetRevenueForOwner,
+  mockGetRecentAttributionsForOwner,
   mockVerifyBlockToken,
   mockParseSubjectUserId,
   mockGetUserById,
@@ -29,6 +31,8 @@ const {
 } = vi.hoisted(() => ({
   mockIsAppBlocksEnabled: vi.fn(),
   mockGetMyAppAnalytics: vi.fn(),
+  mockGetRevenueForOwner: vi.fn(),
+  mockGetRecentAttributionsForOwner: vi.fn(),
   mockVerifyBlockToken: vi.fn(),
   mockParseSubjectUserId: vi.fn(),
   mockGetUserById: vi.fn(),
@@ -50,10 +54,31 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
 }));
 vi.mock('~/server/services/blocks/app-analytics.service', () => ({
   getMyAppAnalytics: (...a: unknown[]) => mockGetMyAppAnalytics(...a),
+  // emptyAnalytics + resolveRange are pure (no DB) — use the real ones so the
+  // flag-off short-circuit returns the genuine zeroed shape.
+  emptyAnalytics: (range: unknown, notOwned: boolean) => ({
+    range,
+    notOwned,
+    installs: { total: 0, active: 0, series: [] },
+    runs: { count: 0, buzzSpent: 0, series: [] },
+    buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },
+    engagement: { apiCalls: 0, activeUsers: 0, errorRate: 0, topScopes: [], topEndpoints: [] },
+  }),
+  resolveRange: () => ({ from: new Date(0), to: new Date(0), granularity: 'day' as const }),
 }));
 vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
-  getRevenueForOwner: vi.fn(),
-  getRecentAttributionsForOwner: vi.fn(),
+  getRevenueForOwner: (...a: unknown[]) => mockGetRevenueForOwner(...a),
+  getRecentAttributionsForOwner: (...a: unknown[]) => mockGetRecentAttributionsForOwner(...a),
+  emptyRevenue: () => ({
+    summary: {
+      pending: { count: 0, grossCents: 0, shareCents: 0 },
+      confirmed: { count: 0, grossCents: 0, shareCents: 0 },
+      paidOut: { count: 0, grossCents: 0, shareCents: 0 },
+      voided: { count: 0, grossCents: 0 },
+    },
+    topApps: [],
+    recentAttributions: [],
+  }),
 }));
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: mockVerifyBlockToken,
@@ -149,6 +174,10 @@ beforeEach(() => {
   mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
   mockGetMyAppAnalytics.mockReset();
   mockGetMyAppAnalytics.mockResolvedValue(SENTINEL);
+  mockGetRevenueForOwner.mockReset();
+  mockGetRevenueForOwner.mockResolvedValue({ summary: {}, topApps: [] });
+  mockGetRecentAttributionsForOwner.mockReset();
+  mockGetRecentAttributionsForOwner.mockResolvedValue([]);
 });
 
 describe('getMyAppAnalytics — gate', () => {
@@ -171,6 +200,20 @@ describe('getMyAppAnalytics — gate', () => {
   it('anonymous: rejected', async () => {
     const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
     await expect(caller.getMyAppAnalytics({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('flag OFF (even for a moderator): returns zeroed analytics + runs NO aggregate', async () => {
+    // moderatorProcedure passes (mod), but the appBlocks flag is OFF →
+    // enforceAppBlocksFlag marks _appBlocksDisabled on the query ctx → the proc
+    // short-circuits to the empty shape and never touches the aggregate service.
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getMyAppAnalytics({ appBlockId: 'apb_1' });
+    expect(result.notOwned).toBe(false);
+    expect(result.installs).toEqual({ total: 0, active: 0, series: [] });
+    expect(result.runs).toEqual({ count: 0, buzzSpent: 0, series: [] });
+    expect(result.buzzPurchased).toEqual({ count: 0, buzzAmount: 0, grossCents: 0 });
     expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
   });
 });
@@ -202,5 +245,25 @@ describe('getMyAppAnalytics — input validation & delegation', () => {
       caller.getMyAppAnalytics({ from: 'not-a-date' })
     ).rejects.toBeInstanceOf(TRPCError);
     expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+});
+
+describe('getMyRevenue — dark-flag short-circuit', () => {
+  it('flag ON (moderator): runs the revenue aggregate', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getMyRevenue({ appBlockId: 'apb_1' });
+    expect(mockGetRevenueForOwner).toHaveBeenCalledTimes(1);
+    expect(result.recentAttributions).toEqual([]);
+  });
+
+  it('flag OFF (even for a moderator): returns zeroed revenue + runs NO query', async () => {
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getMyRevenue({ appBlockId: 'apb_1' });
+    expect(result.topApps).toEqual([]);
+    expect(result.recentAttributions).toEqual([]);
+    expect(result.summary.confirmed).toEqual({ count: 0, grossCents: 0, shareCents: 0 });
+    expect(mockGetRevenueForOwner).not.toHaveBeenCalled();
+    expect(mockGetRecentAttributionsForOwner).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Phase 0 author-analytics proc — gate + delegation + input validation.
+ *
+ * Same mock skeleton as blocks.router.flag-gate.test.ts (heavy services
+ * stubbed so importing the router doesn't drag in the stale generated
+ * Prisma client). The analytics SERVICE is mocked at the boundary — this
+ * test asserts the ROUTER wiring:
+ *   - moderatorProcedure + enforceAppBlocksFlag gate (non-mod / anon rejected,
+ *     dark behind the appBlocks flag);
+ *   - the caller's session user id is threaded into the service (ownership is
+ *     enforced inside the service, covered by app-analytics.service.test.ts);
+ *   - the zod input is validated (appBlockId length cap, from/to datetime).
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockGetMyAppAnalytics,
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetUserById,
+  mockGetUserBuzzAccounts,
+  mockLogToAxiom,
+  mockRedis,
+  mockSysRedis,
+  mockDbRead,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockGetMyAppAnalytics: vi.fn(),
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockGetUserBuzzAccounts: vi.fn(),
+  mockLogToAxiom: vi.fn(async () => undefined),
+  mockRedis: { get: vi.fn(), set: vi.fn() },
+  mockSysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+    appBlock: { findMany: vi.fn() },
+    blockBuzzAttribution: { groupBy: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/server/services/blocks/app-analytics.service', () => ({
+  getMyAppAnalytics: (...a: unknown[]) => mockGetMyAppAnalytics(...a),
+}));
+vi.mock('~/server/services/blocks/buzz-attribution.service', () => ({
+  getRevenueForOwner: vi.fn(),
+  getRecentAttributionsForOwner: vi.fn(),
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...a: unknown[]) => mockParseSubjectUserId(...a),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/textToImage/textToImage', () => ({
+  createTextToImageStep: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  getUserById: (...a: unknown[]) => mockGetUserById(...a),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: (...a: unknown[]) => mockGetUserBuzzAccounts(...a),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: !!(user as { isModerator?: boolean })?.isModerator } as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+
+const SENTINEL = {
+  range: { from: new Date(), to: new Date(), granularity: 'day' as const },
+  notOwned: false,
+  installs: { total: 0, active: 0, series: [] },
+  runs: { count: 0, buzzSpent: 0, series: [] },
+  buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },
+  engagement: { apiCalls: 0, activeUsers: 0, errorRate: 0, topScopes: [], topEndpoints: [] },
+};
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockGetMyAppAnalytics.mockReset();
+  mockGetMyAppAnalytics.mockResolvedValue(SENTINEL);
+});
+
+describe('getMyAppAnalytics — gate', () => {
+  it('moderator: gate passes, service called with the session user id', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getMyAppAnalytics({ appBlockId: 'apb_1' });
+    expect(result).toBe(SENTINEL);
+    expect(mockGetMyAppAnalytics).toHaveBeenCalledTimes(1);
+    const args = mockGetMyAppAnalytics.mock.calls[0][0];
+    expect(args.userId).toBe(modUser.id);
+    expect(args.appBlockId).toBe('apb_1');
+  });
+
+  it('non-moderator: rejected before the service runs', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.getMyAppAnalytics({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('anonymous: rejected', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getMyAppAnalytics({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+});
+
+describe('getMyAppAnalytics — input validation & delegation', () => {
+  it('threads optional from/to (parsed to Date) into the service', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await caller.getMyAppAnalytics({
+      from: '2026-06-01T00:00:00.000Z',
+      to: '2026-06-21T00:00:00.000Z',
+    });
+    const args = mockGetMyAppAnalytics.mock.calls[0][0];
+    expect(args.from).toBeInstanceOf(Date);
+    expect(args.to).toBeInstanceOf(Date);
+    expect(args.from.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('rejects an over-long appBlockId (zod max 64)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(
+      caller.getMyAppAnalytics({ appBlockId: 'x'.repeat(65) })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-datetime `from`', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(
+      caller.getMyAppAnalytics({ from: 'not-a-date' })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -43,6 +43,7 @@ import {
   getRecentAttributionsForOwner,
   getRevenueForOwner,
 } from '~/server/services/blocks/buzz-attribution.service';
+import { getMyAppAnalytics } from '~/server/services/blocks/app-analytics.service';
 import {
   getRepresentativeBaseModel,
   resolveBlockCheckpoint,
@@ -2301,6 +2302,36 @@ export const blocksRouter = router({
         appBlockId: input.appBlockId,
       });
       return { summary, topApps, recentAttributions };
+    }),
+
+  /**
+   * Phase 0 author analytics — installs, runs+buzz spent, buzz purchased,
+   * and engagement for the caller's OWN app(s), derived entirely from
+   * existing App Blocks tables (no new instrumentation). Read-only.
+   *
+   * Same audience gate as getMyRevenue (moderatorProcedure +
+   * enforceAppBlocksFlag — dark behind the appBlocks flag). Ownership is
+   * enforced inside the service: it resolves the caller's owned app_block
+   * ids via AppBlock.app.userId and returns zeroed/empty analytics for a
+   * non-owned id, so an author can never read another author's metrics.
+   */
+  getMyAppAnalytics: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z.object({
+        appBlockId: z.string().min(1).max(64).optional(),
+        from: z.string().datetime().optional(),
+        to: z.string().datetime().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const user = ctx.user as SessionUser;
+      return getMyAppAnalytics({
+        userId: user.id,
+        appBlockId: input.appBlockId,
+        from: input.from ? new Date(input.from) : undefined,
+        to: input.to ? new Date(input.to) : undefined,
+      });
     }),
 
   /**

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -40,10 +40,15 @@ import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { rateLimit } from '~/server/middleware.trpc';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import {
+  emptyRevenue,
   getRecentAttributionsForOwner,
   getRevenueForOwner,
 } from '~/server/services/blocks/buzz-attribution.service';
-import { getMyAppAnalytics } from '~/server/services/blocks/app-analytics.service';
+import {
+  emptyAnalytics,
+  getMyAppAnalytics,
+  resolveRange,
+} from '~/server/services/blocks/app-analytics.service';
 import {
   getRepresentativeBaseModel,
   resolveBlockCheckpoint,
@@ -2290,6 +2295,12 @@ export const blocksRouter = router({
       })
     )
     .query(async ({ ctx, input }) => {
+      // Dark-flag fail-closed: while the appBlocks flag is off the middleware
+      // marks the ctx → return the zeroed revenue shape WITHOUT running any
+      // aggregate, so a flag-off moderator gets no live revenue data.
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return emptyRevenue();
+      }
       const user = ctx.user as SessionUser;
       const { summary, topApps } = await getRevenueForOwner({
         ownerUserId: user.id,
@@ -2325,12 +2336,20 @@ export const blocksRouter = router({
       })
     )
     .query(async ({ ctx, input }) => {
+      const from = input.from ? new Date(input.from) : undefined;
+      const to = input.to ? new Date(input.to) : undefined;
+      // Dark-flag fail-closed: while the appBlocks flag is off the middleware
+      // marks the ctx → return the zeroed analytics shape (with the resolved
+      // range, so the UI still has a window) WITHOUT running any aggregate.
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return emptyAnalytics(resolveRange({ from, to }), false);
+      }
       const user = ctx.user as SessionUser;
       return getMyAppAnalytics({
         userId: user.id,
         appBlockId: input.appBlockId,
-        from: input.from ? new Date(input.from) : undefined,
-        to: input.to ? new Date(input.to) : undefined,
+        from,
+        to,
       });
     }),
 

--- a/src/server/services/blocks/__tests__/app-analytics.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-analytics.service.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the Phase 0 author-analytics service. The security-critical
+ * surface is ownership: a caller must only ever see analytics for app_block
+ * ids resolved from AppBlock.app.userId === their id. Everything else is
+ * aggregation correctness + range clamping.
+ *
+ * Prisma is mocked at the module boundary; the raw `$queryRaw` calls are
+ * matched by sniffing the SQL text of the tagged template so each of the
+ * three raw queries (installs series / runs series / distinct users) gets
+ * its own canned result.
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    appBlock: { findMany: vi.fn() },
+    blockUserSubscription: { count: vi.fn() },
+    blockSpendAttribution: { aggregate: vi.fn() },
+    blockBuzzAttribution: { aggregate: vi.fn() },
+    blockScopeInvocation: { count: vi.fn(), groupBy: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {},
+}));
+
+// `Prisma.sql` / `Prisma.join` are used by the service to build the raw
+// queries. Provide a minimal shim that records the static SQL strings so
+// the $queryRaw mock can route by content.
+vi.mock('@prisma/client', () => ({
+  Prisma: {
+    sql: (strings: TemplateStringsArray, ..._values: unknown[]) => ({
+      __sql: strings.join('?'),
+    }),
+    join: (values: unknown[]) => ({ __join: values }),
+  },
+}));
+
+import {
+  DEFAULT_RANGE_DAYS,
+  MAX_RANGE_DAYS,
+  getMyAppAnalytics,
+  getOwnedAppBlockIds,
+  resolveRange,
+} from '../app-analytics.service';
+
+const OWNER_ID = 42;
+const OWNED_ID = 'apb_owned';
+const OWNED_ID_2 = 'apb_owned2';
+const FOREIGN_ID = 'apb_someone_else';
+
+function routeQueryRaw() {
+  // The three raw queries are distinguished by a unique table token in
+  // their SQL text.
+  mockDbRead.$queryRaw.mockImplementation((arg: { __sql?: string }) => {
+    const sql = arg?.__sql ?? '';
+    if (sql.includes('block_user_subscriptions')) {
+      return Promise.resolve([
+        { bucket: new Date('2026-06-01T00:00:00Z'), value: 3n },
+        { bucket: new Date('2026-06-02T00:00:00Z'), value: 5n },
+      ]);
+    }
+    if (sql.includes('block_spend_attribution')) {
+      return Promise.resolve([{ bucket: new Date('2026-06-01T00:00:00Z'), value: 7n }]);
+    }
+    if (sql.includes('block_scope_invocations')) {
+      return Promise.resolve([{ value: 4n }]); // distinct users
+    }
+    return Promise.resolve([]);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: caller owns one app.
+  mockDbRead.appBlock.findMany.mockResolvedValue([{ id: OWNED_ID }, { id: OWNED_ID_2 }]);
+  mockDbRead.blockUserSubscription.count
+    .mockResolvedValueOnce(20) // installs total
+    .mockResolvedValueOnce(12); // installs active
+  mockDbRead.blockSpendAttribution.aggregate.mockResolvedValue({
+    _count: 7,
+    _sum: { buzzAmount: 7000 },
+  });
+  mockDbRead.blockBuzzAttribution.aggregate.mockResolvedValue({
+    _count: 2,
+    _sum: { buzzAmount: 5000, usdAmountCents: 999 },
+  });
+  // invocations: total count then error count
+  mockDbRead.blockScopeInvocation.count
+    .mockResolvedValueOnce(100) // apiCalls total
+    .mockResolvedValueOnce(10); // status>=400
+  mockDbRead.blockScopeInvocation.groupBy
+    .mockResolvedValueOnce([
+      { scope: 'ai:write:budgeted', _count: 60 },
+      { scope: 'models:read', _count: 40 },
+    ])
+    .mockResolvedValueOnce([{ endpoint: '/api/v1/foo', _count: 70 }]);
+  routeQueryRaw();
+});
+
+describe('resolveRange', () => {
+  const now = new Date('2026-06-21T00:00:00Z');
+
+  it('defaults to the last DEFAULT_RANGE_DAYS at day granularity', () => {
+    const r = resolveRange({ now });
+    expect(r.to.getTime()).toBe(now.getTime());
+    const spanDays = (r.to.getTime() - r.from.getTime()) / (24 * 3600 * 1000);
+    expect(spanDays).toBeCloseTo(DEFAULT_RANGE_DAYS, 5);
+    expect(r.granularity).toBe('day');
+  });
+
+  it('switches to week granularity for ranges over 60 days', () => {
+    const from = new Date(now.getTime() - 120 * 24 * 3600 * 1000);
+    const r = resolveRange({ from, to: now, now });
+    expect(r.granularity).toBe('week');
+  });
+
+  it('caps the range at MAX_RANGE_DAYS', () => {
+    const from = new Date(now.getTime() - 5 * 365 * 24 * 3600 * 1000);
+    const r = resolveRange({ from, to: now, now });
+    const spanDays = (r.to.getTime() - r.from.getTime()) / (24 * 3600 * 1000);
+    expect(spanDays).toBeLessThanOrEqual(MAX_RANGE_DAYS + 0.001);
+  });
+
+  it('clamps a future `to` down to now', () => {
+    const future = new Date(now.getTime() + 10 * 24 * 3600 * 1000);
+    const r = resolveRange({ to: future, now });
+    expect(r.to.getTime()).toBe(now.getTime());
+  });
+
+  it('falls back to default when from > to', () => {
+    const from = new Date('2026-06-20T00:00:00Z');
+    const to = new Date('2026-06-10T00:00:00Z');
+    const r = resolveRange({ from, to, now });
+    expect(r.from.getTime()).toBeLessThan(r.to.getTime());
+  });
+});
+
+describe('getOwnedAppBlockIds (ownership resolution)', () => {
+  it('returns all owned ids when no specific id is requested', async () => {
+    const ids = await getOwnedAppBlockIds({ ownerUserId: OWNER_ID });
+    expect(ids).toEqual([OWNED_ID, OWNED_ID_2]);
+    expect(mockDbRead.appBlock.findMany).toHaveBeenCalledWith({
+      where: { app: { userId: OWNER_ID } },
+      select: { id: true },
+    });
+  });
+
+  it('returns the single requested id when the caller owns it', async () => {
+    const ids = await getOwnedAppBlockIds({ ownerUserId: OWNER_ID, appBlockId: OWNED_ID });
+    expect(ids).toEqual([OWNED_ID]);
+  });
+
+  it('returns [] when the requested id is NOT owned (no cross-owner leak)', async () => {
+    const ids = await getOwnedAppBlockIds({ ownerUserId: OWNER_ID, appBlockId: FOREIGN_ID });
+    expect(ids).toEqual([]);
+  });
+});
+
+describe('getMyAppAnalytics (aggregation)', () => {
+  it('aggregates installs, runs+buzz, purchased and engagement correctly', async () => {
+    const result = await getMyAppAnalytics({ userId: OWNER_ID });
+
+    expect(result.notOwned).toBe(false);
+    // installs
+    expect(result.installs.total).toBe(20);
+    expect(result.installs.active).toBe(12);
+    expect(result.installs.series).toEqual([
+      { bucket: '2026-06-01T00:00:00.000Z', value: 3 },
+      { bucket: '2026-06-02T00:00:00.000Z', value: 5 },
+    ]);
+    // runs + buzz spent
+    expect(result.runs.count).toBe(7);
+    expect(result.runs.buzzSpent).toBe(7000);
+    expect(result.runs.series).toEqual([
+      { bucket: '2026-06-01T00:00:00.000Z', value: 7 },
+    ]);
+    // buzz purchased
+    expect(result.buzzPurchased.count).toBe(2);
+    expect(result.buzzPurchased.buzzAmount).toBe(5000);
+    expect(result.buzzPurchased.grossCents).toBe(999);
+    // engagement
+    expect(result.engagement.apiCalls).toBe(100);
+    expect(result.engagement.activeUsers).toBe(4);
+    expect(result.engagement.errorRate).toBeCloseTo(0.1, 5);
+    expect(result.engagement.topScopes).toEqual([
+      { scope: 'ai:write:budgeted', count: 60 },
+      { scope: 'models:read', count: 40 },
+    ]);
+    expect(result.engagement.topEndpoints).toEqual([
+      { endpoint: '/api/v1/foo', count: 70 },
+    ]);
+  });
+
+  it('reports a zero error rate when there are no API calls', async () => {
+    // Override invocation counts: 0 total, 0 errors.
+    mockDbRead.blockScopeInvocation.count.mockReset();
+    mockDbRead.blockScopeInvocation.count.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    const result = await getMyAppAnalytics({ userId: OWNER_ID });
+    expect(result.engagement.apiCalls).toBe(0);
+    expect(result.engagement.errorRate).toBe(0);
+  });
+
+  it('passes the owned id set into the aggregate where-clauses', async () => {
+    await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: OWNED_ID });
+    // spend aggregate should be scoped to the single owned id
+    const spendArgs = mockDbRead.blockSpendAttribution.aggregate.mock.calls[0][0];
+    expect(spendArgs.where.appBlockId).toEqual({ in: [OWNED_ID] });
+    expect(spendArgs.where.attributedAt).toHaveProperty('gte');
+    expect(spendArgs.where.attributedAt).toHaveProperty('lte');
+  });
+});
+
+describe('getMyAppAnalytics (ownership enforcement)', () => {
+  it('returns zeroed analytics with notOwned=true for a non-owned id', async () => {
+    const result = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: FOREIGN_ID });
+    expect(result.notOwned).toBe(true);
+    expect(result.installs.total).toBe(0);
+    expect(result.runs.count).toBe(0);
+    expect(result.buzzPurchased.count).toBe(0);
+    expect(result.engagement.apiCalls).toBe(0);
+    // CRITICAL: none of the aggregate queries ran — no foreign data touched.
+    expect(mockDbRead.blockSpendAttribution.aggregate).not.toHaveBeenCalled();
+    expect(mockDbRead.blockBuzzAttribution.aggregate).not.toHaveBeenCalled();
+    expect(mockDbRead.blockScopeInvocation.count).not.toHaveBeenCalled();
+  });
+
+  it('returns empty (notOwned=false) when the caller owns nothing', async () => {
+    mockDbRead.appBlock.findMany.mockResolvedValue([]);
+    const result = await getMyAppAnalytics({ userId: OWNER_ID });
+    expect(result.notOwned).toBe(false);
+    expect(result.installs.total).toBe(0);
+    expect(mockDbRead.blockSpendAttribution.aggregate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -83,10 +83,7 @@ export type AppAnalytics = {
   };
 };
 
-function emptyAnalytics(
-  range: AppAnalytics['range'],
-  notOwned: boolean
-): AppAnalytics {
+function emptyAnalytics(range: AppAnalytics['range'], notOwned: boolean): AppAnalytics {
   return {
     range,
     notOwned,
@@ -109,11 +106,7 @@ function emptyAnalytics(
  * granularity for ranges up to ~60d, week granularity beyond, so the
  * series stays bounded (≤ ~53 points).
  */
-export function resolveRange(input: {
-  from?: Date;
-  to?: Date;
-  now?: Date;
-}): AppAnalytics['range'] {
+export function resolveRange(input: { from?: Date; to?: Date; now?: Date }): AppAnalytics['range'] {
   const now = input.now ?? new Date();
   let to = input.to ?? now;
   if (to.getTime() > now.getTime()) to = now;
@@ -310,12 +303,14 @@ export async function getMyAppAnalytics({
       apiCalls,
       activeUsers,
       errorRate,
-      topScopes: (
-        topScopes as Array<{ scope: string; _count: number }>
-      ).map((r) => ({ scope: r.scope, count: r._count })),
-      topEndpoints: (
-        topEndpoints as Array<{ endpoint: string; _count: number }>
-      ).map((r) => ({ endpoint: r.endpoint, count: r._count })),
+      topScopes: (topScopes as Array<{ scope: string; _count: number }>).map((r) => ({
+        scope: r.scope,
+        count: r._count,
+      })),
+      topEndpoints: (topEndpoints as Array<{ endpoint: string; _count: number }>).map((r) => ({
+        endpoint: r.endpoint,
+        count: r._count,
+      })),
     },
   };
 }

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -83,7 +83,7 @@ export type AppAnalytics = {
   };
 };
 
-function emptyAnalytics(range: AppAnalytics['range'], notOwned: boolean): AppAnalytics {
+export function emptyAnalytics(range: AppAnalytics['range'], notOwned: boolean): AppAnalytics {
   return {
     range,
     notOwned,

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -1,0 +1,321 @@
+import { Prisma } from '@prisma/client';
+import { dbRead } from '~/server/db/client';
+
+/**
+ * App Blocks — author-facing analytics (Phase 0).
+ *
+ * PURE DERIVATION: every metric here is computed from data App Blocks
+ * ALREADY writes. No new events, tables, or instrumentation — that is a
+ * deliberate later phase. Read-only (`dbRead`), no writes, no money
+ * movement.
+ *
+ * SECURITY: an author must NEVER see another author's analytics. Every
+ * query is scoped to app_block ids the caller OWNS. Ownership is the v1
+ * source of truth `AppBlock.app.userId === ownerUserId` (the OauthClient
+ * relation), mirrored exactly from getMyApps / getMyRevenue. We resolve
+ * the caller's owned ids FIRST and intersect the requested `appBlockId`
+ * against them; a non-owner (or an unknown id) gets an empty result, never
+ * another owner's rows.
+ *
+ * BOUNDED SCANS: the date range is clamped (default last 30d, capped at
+ * MAX_RANGE_DAYS) and every aggregate is filtered by both the owned
+ * app_block id set AND the date range so a query can't degrade into an
+ * unbounded table scan. The per-app id equality + attributed_at/invoked_at
+ * range hits the existing dashboard indexes
+ * (bsa_app_block_dashboard_idx / bba_app_block_dashboard_idx /
+ * bsi_app_block_invoked_idx) and the new bus analytics index.
+ */
+
+export const DEFAULT_RANGE_DAYS = 30;
+export const MAX_RANGE_DAYS = 366; // ~1y cap so no unbounded scans
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type AnalyticsTimePoint = { bucket: string; value: number };
+
+export type AppAnalytics = {
+  /** The resolved range actually queried (after clamping). */
+  range: { from: Date; to: Date; granularity: 'day' | 'week' };
+  /** True when the caller does not own `appBlockId` — all metrics are zeroed. */
+  notOwned: boolean;
+  installs: {
+    /** All-time installs for this app (subscription rows ever created). */
+    total: number;
+    /** Currently-active installs (enabled = true), all-time. */
+    active: number;
+    /** New installs per bucket within the range. */
+    series: AnalyticsTimePoint[];
+  };
+  runs: {
+    /** Generations/runs through the app within the range. */
+    count: number;
+    /** Sum of viewer Buzz burned through the app within the range. */
+    buzzSpent: number;
+    /** Runs per bucket within the range. */
+    series: AnalyticsTimePoint[];
+  };
+  /** Buzz purchased (card) through the app within the range. */
+  buzzPurchased: {
+    /** Count of purchase rows. */
+    count: number;
+    /** Sum of buzz_amount purchased. */
+    buzzAmount: number;
+    /** Gross USD value purchased, in cents. */
+    grossCents: number;
+  };
+  /**
+   * Engagement from block_scope_invocations. COVERAGE CAVEAT: this table
+   * is written ONLY on AUTHENTICATED, scope-gated API calls. Anonymous
+   * viewers and static / no-scope blocks emit nothing here — so a block
+   * with no scoped API surface shows installs + revenue but flat
+   * engagement. The UI surfaces this caveat.
+   */
+  engagement: {
+    /** Total scoped API calls within the range. */
+    apiCalls: number;
+    /** Distinct authenticated users who made a scoped call. */
+    activeUsers: number;
+    /** Ratio of calls with status_code >= 400 (0..1). */
+    errorRate: number;
+    /** Top scopes by call volume. */
+    topScopes: Array<{ scope: string; count: number }>;
+    /** Top endpoints by call volume. */
+    topEndpoints: Array<{ endpoint: string; count: number }>;
+  };
+};
+
+function emptyAnalytics(
+  range: AppAnalytics['range'],
+  notOwned: boolean
+): AppAnalytics {
+  return {
+    range,
+    notOwned,
+    installs: { total: 0, active: 0, series: [] },
+    runs: { count: 0, buzzSpent: 0, series: [] },
+    buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },
+    engagement: {
+      apiCalls: 0,
+      activeUsers: 0,
+      errorRate: 0,
+      topScopes: [],
+      topEndpoints: [],
+    },
+  };
+}
+
+/**
+ * Clamp the requested range: default to the last DEFAULT_RANGE_DAYS, never
+ * exceed MAX_RANGE_DAYS, and never let `from` be after `to`. Picks day
+ * granularity for ranges up to ~60d, week granularity beyond, so the
+ * series stays bounded (≤ ~53 points).
+ */
+export function resolveRange(input: {
+  from?: Date;
+  to?: Date;
+  now?: Date;
+}): AppAnalytics['range'] {
+  const now = input.now ?? new Date();
+  let to = input.to ?? now;
+  if (to.getTime() > now.getTime()) to = now;
+  let from = input.from ?? new Date(to.getTime() - DEFAULT_RANGE_DAYS * DAY_MS);
+  if (from.getTime() > to.getTime()) from = new Date(to.getTime() - DEFAULT_RANGE_DAYS * DAY_MS);
+  const maxFrom = new Date(to.getTime() - MAX_RANGE_DAYS * DAY_MS);
+  if (from.getTime() < maxFrom.getTime()) from = maxFrom;
+  const spanDays = (to.getTime() - from.getTime()) / DAY_MS;
+  const granularity: 'day' | 'week' = spanDays > 60 ? 'week' : 'day';
+  return { from, to, granularity };
+}
+
+/**
+ * The app_block ids the caller owns, optionally narrowed to a single
+ * requested id. Returns [] when the requested id isn't theirs (or they
+ * own nothing) — the callers then fail closed to an empty result.
+ */
+export async function getOwnedAppBlockIds({
+  ownerUserId,
+  appBlockId,
+}: {
+  ownerUserId: number;
+  appBlockId?: string;
+}): Promise<string[]> {
+  const owned = await dbRead.appBlock.findMany({
+    where: { app: { userId: ownerUserId } },
+    select: { id: true },
+  });
+  const ownedIds = owned.map((a) => a.id);
+  if (!appBlockId) return ownedIds;
+  return ownedIds.includes(appBlockId) ? [appBlockId] : [];
+}
+
+/**
+ * Author-facing analytics for ONE owned app block (or all the caller's
+ * apps when `appBlockId` is omitted), over a bounded date range.
+ *
+ * SECURITY: resolves owned ids first; returns zeroed analytics with
+ * `notOwned: true` if the requested id isn't the caller's.
+ */
+export async function getMyAppAnalytics({
+  appBlockId,
+  userId,
+  from,
+  to,
+  now,
+}: {
+  appBlockId?: string;
+  userId: number;
+  from?: Date;
+  to?: Date;
+  now?: Date;
+}): Promise<AppAnalytics> {
+  const range = resolveRange({ from, to, now });
+  const ownedIds = await getOwnedAppBlockIds({ ownerUserId: userId, appBlockId });
+
+  // Fail closed: a specifically-requested id that the caller does not own
+  // yields zeroed analytics flagged notOwned (never another owner's data).
+  if (appBlockId && ownedIds.length === 0) {
+    return emptyAnalytics(range, true);
+  }
+  // The caller owns nothing — nothing to report (but not "notOwned", since
+  // they didn't ask for a specific foreign id).
+  if (ownedIds.length === 0) {
+    return emptyAnalytics(range, false);
+  }
+
+  const idIn = { in: ownedIds };
+  const rangeFilter = { gte: range.from, lte: range.to };
+  // date_trunc unit string is a fixed literal chosen from a closed set —
+  // never user input — so it is safe to inline in the raw SQL.
+  const truncUnit = range.granularity;
+
+  const [
+    installsTotal,
+    installsActive,
+    installsSeries,
+    runsAgg,
+    runsSeries,
+    purchasedAgg,
+    invocationsAgg,
+    distinctUsers,
+    errorCount,
+    topScopes,
+    topEndpoints,
+  ] = await Promise.all([
+    // INSTALLS — block_user_subscriptions. Total & active are all-time
+    // (an author cares about their current install base), the series is
+    // new installs within the range.
+    dbRead.blockUserSubscription.count({ where: { appBlockId: idIn } }),
+    dbRead.blockUserSubscription.count({
+      where: { appBlockId: idIn, enabled: true },
+    }),
+    dbRead.$queryRaw<Array<{ bucket: Date; value: bigint }>>(Prisma.sql`
+      SELECT date_trunc(${truncUnit}, "created_at") AS bucket, count(*)::bigint AS value
+      FROM "block_user_subscriptions"
+      WHERE "app_block_id" IN (${Prisma.join(ownedIds)})
+        AND "created_at" >= ${range.from}
+        AND "created_at" <= ${range.to}
+      GROUP BY 1
+      ORDER BY 1 ASC
+    `),
+
+    // RUNS + BUZZ SPENT — block_spend_attribution. Generations through the
+    // app + Buzz burned, within the range. Hits bsa_app_block_dashboard_idx
+    // (app_block_id, attributed_at).
+    dbRead.blockSpendAttribution.aggregate({
+      where: { appBlockId: idIn, attributedAt: rangeFilter },
+      _count: true,
+      _sum: { buzzAmount: true },
+    }),
+    dbRead.$queryRaw<Array<{ bucket: Date; value: bigint }>>(Prisma.sql`
+      SELECT date_trunc(${truncUnit}, "attributed_at") AS bucket, count(*)::bigint AS value
+      FROM "block_spend_attribution"
+      WHERE "app_block_id" IN (${Prisma.join(ownedIds)})
+        AND "attributed_at" >= ${range.from}
+        AND "attributed_at" <= ${range.to}
+      GROUP BY 1
+      ORDER BY 1 ASC
+    `),
+
+    // BUZZ PURCHASED — block_buzz_attribution. Card purchases originated
+    // inside the app. Hits bba_app_block_dashboard_idx.
+    dbRead.blockBuzzAttribution.aggregate({
+      where: { appBlockId: idIn, attributedAt: rangeFilter },
+      _count: true,
+      _sum: { buzzAmount: true, usdAmountCents: true },
+    }),
+
+    // ENGAGEMENT — block_scope_invocations. AUTH + scoped-call only. Hits
+    // bsi_app_block_invoked_idx (app_block_id, invoked_at).
+    dbRead.blockScopeInvocation.count({
+      where: { appBlockId: idIn, invokedAt: rangeFilter },
+    }),
+    dbRead.$queryRaw<Array<{ value: bigint }>>(Prisma.sql`
+      SELECT count(DISTINCT "user_id")::bigint AS value
+      FROM "block_scope_invocations"
+      WHERE "app_block_id" IN (${Prisma.join(ownedIds)})
+        AND "invoked_at" >= ${range.from}
+        AND "invoked_at" <= ${range.to}
+    `),
+    dbRead.blockScopeInvocation.count({
+      where: {
+        appBlockId: idIn,
+        invokedAt: rangeFilter,
+        statusCode: { gte: 400 },
+      },
+    }),
+    dbRead.blockScopeInvocation.groupBy({
+      by: ['scope'],
+      where: { appBlockId: idIn, invokedAt: rangeFilter },
+      _count: true,
+      orderBy: { _count: { scope: 'desc' } },
+      take: 5,
+    }),
+    dbRead.blockScopeInvocation.groupBy({
+      by: ['endpoint'],
+      where: { appBlockId: idIn, invokedAt: rangeFilter },
+      _count: true,
+      orderBy: { _count: { endpoint: 'desc' } },
+      take: 5,
+    }),
+  ]);
+
+  const apiCalls = invocationsAgg;
+  const activeUsers = Number(distinctUsers[0]?.value ?? 0);
+  const errorRate = apiCalls > 0 ? errorCount / apiCalls : 0;
+
+  return {
+    range,
+    notOwned: false,
+    installs: {
+      total: installsTotal,
+      active: installsActive,
+      series: installsSeries.map((r) => ({
+        bucket: r.bucket.toISOString(),
+        value: Number(r.value),
+      })),
+    },
+    runs: {
+      count: runsAgg._count ?? 0,
+      buzzSpent: runsAgg._sum.buzzAmount ?? 0,
+      series: runsSeries.map((r) => ({
+        bucket: r.bucket.toISOString(),
+        value: Number(r.value),
+      })),
+    },
+    buzzPurchased: {
+      count: purchasedAgg._count ?? 0,
+      buzzAmount: purchasedAgg._sum.buzzAmount ?? 0,
+      grossCents: purchasedAgg._sum.usdAmountCents ?? 0,
+    },
+    engagement: {
+      apiCalls,
+      activeUsers,
+      errorRate,
+      topScopes: (
+        topScopes as Array<{ scope: string; _count: number }>
+      ).map((r) => ({ scope: r.scope, count: r._count })),
+      topEndpoints: (
+        topEndpoints as Array<{ endpoint: string; _count: number }>
+      ).map((r) => ({ endpoint: r.endpoint, count: r._count })),
+    },
+  };
+}

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -1250,6 +1250,30 @@ export async function getRevenueForOwner({
 }
 
 /**
+ * Zeroed revenue payload — the dark-behind-the-flag shape for getMyRevenue.
+ * Mirrors getRevenueForOwner's `{ summary, topApps }` (+ empty attributions
+ * feed) with every bucket at zero so a flag-off caller gets no data and we
+ * run NO aggregate queries. Pure constant; no DB access.
+ */
+export function emptyRevenue(): {
+  summary: RevenueSummary;
+  topApps: Array<{ appBlockId: string; shareCents: number; count: number }>;
+  recentAttributions: [];
+} {
+  const zeroBucket = { count: 0, grossCents: 0, shareCents: 0 };
+  return {
+    summary: {
+      pending: { ...zeroBucket },
+      confirmed: { ...zeroBucket },
+      paidOut: { ...zeroBucket },
+      voided: { count: 0, grossCents: 0 },
+    },
+    topApps: [],
+    recentAttributions: [],
+  };
+}
+
+/**
  * Recent attributions for the publisher dashboard's activity feed.
  * Limited to the last 50 so the response stays small; the timeseries
  * chart uses the aggregate above instead of walking individual rows.


### PR DESCRIPTION
## App Blocks — author analytics, Phase 0

An author-facing analytics view derived **entirely from data App Blocks already writes** — no new instrumentation, events, or tables. Read-only, dark behind the `appBlocks` flag (mod-only today), surfaced as a new **Analytics** tab on the existing `/apps/revenue` page. Mirrors the `getMyRevenue` audience gate.

### Metrics + their sources
| Metric | Source table | Index used |
|---|---|---|
| Installs — total / active (`enabled`) / new-per-bucket series | `block_user_subscriptions` | `bus_app_block_created_idx` (new) for the series |
| Runs (generations) + Buzz spent (`buzzAmount` sum) + series | `block_spend_attribution` | `bsa_app_block_dashboard_idx` |
| Buzz purchased (count + `buzzAmount` + gross USD cents) | `block_buzz_attribution` | `bba_app_block_dashboard_idx` |
| Engagement — API calls, distinct active users, error rate (`status_code >= 400`), top scopes/endpoints | `block_scope_invocations` | `bsi_app_block_invoked_idx` |

### Engagement-coverage caveat (surfaced in the UI)
`block_scope_invocations` is written **only on authenticated, scope-gated API calls**. The Analytics tab carries an explicit note that active users / API calls / error rate reflect *only* apps that make scoped API calls — a static / no-scope block shows installs + revenue but flat engagement, and **anonymous viewers are not counted**. Installs / runs / Buzz figures are unaffected.

### Security — ownership
The service resolves the caller's owned `appBlockId`s **first** via `AppBlock.app.userId === ctx.user.id` (the same v1 source of truth as `getMyApps` / `getMyRevenue`) and intersects the requested id against them. A non-owned id returns **zeroed analytics (`notOwned`) and runs NO aggregate queries** — an author can never read another author's metrics. The date range is clamped (default 30d, cap ~1y) so queries can't degrade into unbounded scans. Covered by a test asserting a non-owner gets empty results and that none of the aggregate queries fire.

### Footprint
- New `app-analytics.service.ts` (all the logic) + **one thin** `getMyAppAnalytics` proc in `blocks.router.ts` (kept minimal to avoid conflicts with the open app-reviews PR #2668, which also edits the router — based on `main`, not on #2668).
- New `AppAnalyticsPanel` component reusing the existing `chart.js` / `react-chartjs-2` primitive (no new chart dep).
- `bus_app_block_created_idx` — **manual-apply** migration (CNPG nvme0 does not auto-apply Prisma migrations); prefer the `CREATE INDEX CONCURRENTLY` variant noted in the migration on prod.

### Verification
- `pnpm typecheck` — exit 0.
- 19 new unit tests green (service aggregation / range clamp / ownership; router gate / delegation / input validation); existing blocks tests (`flag-gate`, `buzz-attribution`) unregressed.

### Deliberately deferred (later phases)
The platform digest and a render/impression event are **deliberate later phases** — Phase 0 is pure derivation from existing tables. Read-only; no writes; no money movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)