### PR TITLE
feat(app-blocks): enforce color-domain maturity (blue+green SFW) — authoritative generation clamp + BLOCK_INIT signal

### DIFF
--- a/src/components/AppBlocks/BlockHost.tsx
+++ b/src/components/AppBlocks/BlockHost.tsx
@@ -16,10 +16,8 @@ interface BlockHostProps {
  * so v2 can light it up without a structural refactor.
  */
 export function BlockHost({ blockInstall, slotContext }: BlockHostProps) {
-  const { token, expiresAt, error, pending, missingScopes, refresh } = useBlockToken(
-    blockInstall,
-    slotContext
-  );
+  const { token, expiresAt, error, pending, missingScopes, domain, maxBrowsingLevel, refresh } =
+    useBlockToken(blockInstall, slotContext);
 
   // Terminal token-mint failure → collapse (render null, take no space)
   // rather than show a visible "authorization error" card. Matches the
@@ -63,6 +61,8 @@ export function BlockHost({ blockInstall, slotContext }: BlockHostProps) {
       token={token}
       expiresAt={expiresAt}
       missingScopes={missingScopes}
+      domain={domain}
+      maxBrowsingLevel={maxBrowsingLevel}
       onConsentGranted={() => {
         void refresh();
       }}

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -13,7 +13,11 @@ import { resolveRequestConsent } from './requestConsentGate';
 import { hideBlock } from './hiddenBlocks';
 import { sanitizeAppChromeName } from './appChromeName';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
-import { projectBlockInitContext, projectBlockInitViewer } from './projectBlockInit';
+import {
+  projectBlockInitContext,
+  projectBlockInitMaturity,
+  projectBlockInitViewer,
+} from './projectBlockInit';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, BlockInstall, ModelSlotContext, SlotContext } from './types';
@@ -50,6 +54,10 @@ interface IframeHostProps {
    *  we also trim them from the wrapped `token.scopes` we send the iframe so
    *  the block's "do I have this capability?" check is accurate. */
   missingScopes?: string[];
+  /** Advisory color-domain maturity signal (BLOCK_INIT). Server-authoritative
+   *  values mirrored from the token mint — the host forwards, never derives. */
+  domain?: 'green' | 'blue' | 'red' | null;
+  maxBrowsingLevel?: number;
   /** Re-mint the block token after a consent grant so it carries the newly
    *  granted scopes (pushed to the iframe via TOKEN_REFRESH). */
   onConsentGranted?: () => void;
@@ -217,6 +225,8 @@ export function IframeHost({
   token,
   expiresAt,
   missingScopes,
+  domain,
+  maxBrowsingLevel,
   onConsentGranted,
 }: IframeHostProps) {
   // Treat the slot context as ModelSlotContext when the optional viewer/theme
@@ -408,6 +418,8 @@ export function IframeHost({
     viewer: projectBlockInitViewer(context),
     theme: modelCtx.theme ?? 'light',
     renderMode: install.renderMode,
+    // Advisory maturity signal — server-authoritative values from the mint.
+    ...projectBlockInitMaturity({ domain, maxBrowsingLevel }),
   });
 
   // Keep the controller's interval posting the freshest payload. buildInitPayload

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -810,6 +810,14 @@ export function IframeHost({
         typeof raw.baseModelGroup === 'string' ? getBaseModelGroup(raw.baseModelGroup) : null;
       const baseModels = groupKey ? getBaseModelsByGroup(groupKey) : [];
       let answered = false;
+      // MEDIUM-2 (deferred — see PageBlockHost OPEN_RESOURCE_PICKER for the full
+      // rationale): the modal's NSFW filtering inherits the SITE-WIDE browsing
+      // level (blue = mature), so on a SFW (blue/green) block the picker UI can
+      // still surface mature checkpoints even though generation is SFW-clamped.
+      // Not an iframe leak (CHECKPOINT_PICKER_RESULT is name/id-only and every
+      // pick is re-gated SFW server-side at submit). `ResourceSelectOptions`
+      // exposes no browsing-level/sfwOnly constraint; wiring one would mean
+      // modifying the shared ResourceSelectModal internals — deferred follow-up.
       openResourceSelectModal({
         title: 'Choose a checkpoint',
         options: {

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -897,8 +897,33 @@ export function PageBlockHost({
   //  - resourceType allowlist enforced in resolveResourcePickerRequest (pure,
   //    unit-tested): an unsupported type is DROPPED and the modal never opens.
   // NSFW-by-domain is inherited from the native modal's existing parent-context
-  // browsing-level handling (the Meili search client is domain/SFW-scoped at the
-  // app level), exactly as the model checkpoint picker already relies on.
+  // browsing-level handling, exactly as the model checkpoint picker already
+  // relies on.
+  //
+  // MEDIUM-2 (deferred — documented, NOT wired): that inherited handling is the
+  // SITE-WIDE browsing level, where `blue` is mature. So on a blue (or green)
+  // block — which generation clamps to SFW via `domainBrowsingCeiling` — the
+  // picker UI can still SURFACE mature resources, an inconsistent SFW
+  // experience. This is NOT an iframe leak: the RESOURCE_PICKER_RESULT below is
+  // name/id-only (no thumbnails/meta), and every picked id is re-gated SFW
+  // server-side at estimate/submit (assertViewerCanGeneratePageResources +
+  // domainBrowsingCeiling off the RAW request color) before any spend.
+  //
+  // Why not wired here: `openResourceSelectModal`'s `ResourceSelectOptions`
+  // (resource-select.types.ts) exposes NO browsing-level / sfwOnly / nsfw
+  // constraint — only `canGenerate`, `resources`, `excludeIds`. NSFW filtering
+  // is done purely client-side in the SHARED `ResourceHitList` via
+  // `useApplyHiddenPreferences`, which defaults to the site-wide
+  // `useBrowsingLevelDebounced()` context (the Meili query in
+  // useResourceSelectFilters doesn't filter by browsing level at all). Passing a
+  // block-SFW ceiling in would require adding a new option to
+  // `ResourceSelectOptions`, threading it through `ResourceSelectProvider` /
+  // `useResourceSelectContext`, and feeding it to that `useApplyHiddenPreferences`
+  // call — i.e. modifying the shared modal's filtering internals (higher blast
+  // radius, affects every generation-form picker), and even then the hook's
+  // `isModerator && nsfwLevel===0` carve-out leaves gaps for the currently
+  // mod-gated audience. Deferred as a follow-up in the same bucket as the
+  // Phase-3 REST clamp; tracked in the PR body.
   //
   // requestId threads each pick so concurrent requests (e.g. a checkpoint pick
   // and a LoRA pick open back-to-back) never cross — the SDK hook resolves only

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -12,6 +12,7 @@ import {
   pageFallbackReason,
   resolveResourcePickerRequest,
 } from './pageBlockHostLogic';
+import { projectBlockInitMaturity } from './projectBlockInit';
 import { resolveRequestConsent } from './requestConsentGate';
 import { resolveRequestSignIn } from './requestSignInGate';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
@@ -120,6 +121,10 @@ export interface PageBlockHostProps {
   /** #3/#6: the token mint errored. Surface an error state instead of hanging at
    *  `no_token`. */
   tokenError?: boolean;
+  /** Advisory color-domain maturity signal (BLOCK_INIT). Server-authoritative
+   *  values from the token mint — forwarded, never derived client-side. */
+  domain?: 'green' | 'blue' | 'red' | null;
+  maxBrowsingLevel?: number;
   viewer: { id: number; username: string | null } | null;
   theme: 'light' | 'dark';
   /** Re-mint the page token after a consent grant so it carries the newly
@@ -144,6 +149,8 @@ export function PageBlockHost({
   missingScopes,
   needsConsent,
   tokenError,
+  domain,
+  maxBrowsingLevel,
   viewer,
   theme,
   onConsentGranted,
@@ -228,8 +235,22 @@ export function PageBlockHost({
       viewer,
       theme,
       renderMode: 'iframe',
+      // Advisory maturity signal — server-authoritative values from the mint.
+      ...projectBlockInitMaturity({ domain, maxBrowsingLevel }),
     }),
-    [appId, blockId, blockInstanceId, buildContext, expiresAt, grantedScopes, token, viewer, theme]
+    [
+      appId,
+      blockId,
+      blockInstanceId,
+      buildContext,
+      expiresAt,
+      grantedScopes,
+      token,
+      viewer,
+      theme,
+      domain,
+      maxBrowsingLevel,
+    ]
   );
   buildInitPayloadRef.current = buildInitPayload;
 

--- a/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
+++ b/src/components/AppBlocks/__tests__/projectBlockInit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { projectBlockInitContext, projectBlockInitViewer } from '../projectBlockInit';
+import {
+  projectBlockInitContext,
+  projectBlockInitMaturity,
+  projectBlockInitViewer,
+} from '../projectBlockInit';
 import type { BlockCheckpointInfo, ModelSlotContext, ShowcaseImage } from '../types';
 
 /**
@@ -164,5 +168,49 @@ describe('projectBlockInitViewer (BLOCK_INIT viewer allowlist)', () => {
       projectBlockInitViewer({ slotId: 'model.sidebar_top', viewerUserId: null } as ModelSlotContext)
     ).toBeNull();
     expect(projectBlockInitViewer({ slotId: 'model.sidebar_top' })).toBeNull();
+  });
+});
+
+/**
+ * BLOCK_INIT maturity signal projection (advisory — block self-filtering/blur).
+ * The values are the server-authoritative ones from the token mint; the host
+ * forwards them. The projection sanitizes / fails closed so junk never reaches
+ * the iframe.
+ */
+describe('projectBlockInitMaturity', () => {
+  it('forwards a green SFW signal', () => {
+    expect(projectBlockInitMaturity({ domain: 'green', maxBrowsingLevel: 3 })).toEqual({
+      domain: 'green',
+      maxBrowsingLevel: 3,
+    });
+  });
+
+  it('forwards a red mature signal', () => {
+    expect(projectBlockInitMaturity({ domain: 'red', maxBrowsingLevel: 31 })).toEqual({
+      domain: 'red',
+      maxBrowsingLevel: 31,
+    });
+  });
+
+  it('coerces an unrecognized domain to null', () => {
+    expect(projectBlockInitMaturity({ domain: 'purple', maxBrowsingLevel: 3 }).domain).toBeNull();
+  });
+
+  it('maps a missing/null domain to null', () => {
+    expect(projectBlockInitMaturity({ domain: null }).domain).toBeNull();
+    expect(projectBlockInitMaturity({}).domain).toBeNull();
+  });
+
+  it('drops a non-numeric / absent ceiling (undefined → SDK fails closed)', () => {
+    expect(projectBlockInitMaturity({ domain: 'green' }).maxBrowsingLevel).toBeUndefined();
+    expect(
+      projectBlockInitMaturity({ domain: 'green', maxBrowsingLevel: NaN }).maxBrowsingLevel
+    ).toBeUndefined();
+    expect(
+      projectBlockInitMaturity({
+        domain: 'green',
+        maxBrowsingLevel: 'x' as unknown as number,
+      }).maxBrowsingLevel
+    ).toBeUndefined();
   });
 });

--- a/src/components/AppBlocks/projectBlockInit.ts
+++ b/src/components/AppBlocks/projectBlockInit.ts
@@ -104,6 +104,35 @@ export function projectBlockInitContext(
  *
  * Returns `null` for anonymous viewers (no numeric viewer id).
  */
+/**
+ * Project the color-domain maturity signal into the BLOCK_INIT contract fields.
+ *
+ * These are ADVISORY (block self-filtering / blur). The values are the
+ * server-authoritative ones the token mint computed from the request host
+ * (`getRequestDomainColor` → `domainBrowsingCeiling`) and returned alongside
+ * the token — the host never derives them client-side, it forwards them. The
+ * AUTHORITATIVE maturity enforcement is the server generation clamp keyed on
+ * the same value baked into the token claim.
+ *
+ * Defaults are FAIL-CLOSED: an absent ceiling projects `undefined` (the SDK
+ * `useDomainMaturity()` hook treats absent as the most restrictive), and an
+ * unrecognized domain projects `null` rather than leaking a raw value.
+ */
+export function projectBlockInitMaturity(input: {
+  domain?: string | null;
+  maxBrowsingLevel?: number | null;
+}): Pick<BlockInitPayload, 'domain' | 'maxBrowsingLevel'> {
+  const domain =
+    input.domain === 'green' || input.domain === 'blue' || input.domain === 'red'
+      ? input.domain
+      : null;
+  const maxBrowsingLevel =
+    typeof input.maxBrowsingLevel === 'number' && Number.isFinite(input.maxBrowsingLevel)
+      ? input.maxBrowsingLevel
+      : undefined;
+  return { domain, maxBrowsingLevel };
+}
+
 export function projectBlockInitViewer(
   context: SlotContext
 ): BlockInitPayload['viewer'] {

--- a/src/components/AppBlocks/types.ts
+++ b/src/components/AppBlocks/types.ts
@@ -167,6 +167,21 @@ export interface BlockInitPayload {
   } | null;
   theme: 'light' | 'dark';
   renderMode: 'iframe' | 'inline';
+  /**
+   * Color-domain maturity signal (ADVISORY — for block self-filtering / blur).
+   * The AUTHORITATIVE enforcement is the server-side generation clamp keyed on
+   * the same value baked into the block token's `maxBrowsingLevel` claim; this
+   * field lets a block proactively filter its own catalog reads and blur mature
+   * thumbnails without a round-trip.
+   *
+   * - `domain`: the color domain the token was minted on (`green`|`blue`|`red`),
+   *   or null when the host didn't resolve to a known color.
+   * - `maxBrowsingLevel`: the bitwise browsing-level ceiling for this domain
+   *   (green/blue → SFW, red → all). Consumed by the SDK `useDomainMaturity()`
+   *   hook (separate follow-up PR in the SDK repo).
+   */
+  domain?: 'green' | 'blue' | 'red' | null;
+  maxBrowsingLevel?: number;
 }
 
 export interface BlockManifest {

--- a/src/components/AppBlocks/useBlockToken.ts
+++ b/src/components/AppBlocks/useBlockToken.ts
@@ -14,6 +14,12 @@ interface UseBlockTokenResult {
   needsConsent: boolean;
   /** A6: the consent-gated scopes withheld from the current token. */
   missingScopes: string[];
+  /** Advisory maturity signal mirrored from the mint (BLOCK_INIT). The color
+   *  domain the token was minted on, or null when unresolved. */
+  domain: 'green' | 'blue' | 'red' | null;
+  /** Advisory: the bitwise browsing-level ceiling for the domain (SFW on
+   *  green/blue, all on red). undefined on legacy responses → fail closed. */
+  maxBrowsingLevel: number | undefined;
   refresh: () => Promise<void>;
 }
 
@@ -24,6 +30,9 @@ interface TokenResponse {
    *  app's approved manifest. Older responses omit these → treat as no-op. */
   needsConsent?: boolean;
   missingScopes?: string[];
+  /** Advisory maturity signal. Omitted by pre-feature responses → fail closed. */
+  domain?: 'green' | 'blue' | 'red' | null;
+  maxBrowsingLevel?: number;
 }
 
 const REFRESH_LEAD_MS = 2 * 60 * 1000; // refresh 2 minutes before expiry
@@ -59,6 +68,8 @@ export function useBlockToken(
   const [pending, setPending] = useState<boolean>(true);
   const [needsConsent, setNeedsConsent] = useState<boolean>(false);
   const [missingScopes, setMissingScopes] = useState<string[]>([]);
+  const [domain, setDomain] = useState<'green' | 'blue' | 'red' | null>(null);
+  const [maxBrowsingLevel, setMaxBrowsingLevel] = useState<number | undefined>(undefined);
   // M4 (audit-10): peek the current token via a ref instead of running a
   // side-effect inside a state-updater. React 18 strict-mode calls updaters
   // twice in dev; a counter/increment side-effect there would silently
@@ -130,6 +141,16 @@ export function useBlockToken(
       setExpiresAt(data.expiresAt);
       setNeedsConsent(data.needsConsent === true);
       setMissingScopes(Array.isArray(data.missingScopes) ? data.missingScopes : []);
+      setDomain(
+        data.domain === 'green' || data.domain === 'blue' || data.domain === 'red'
+          ? data.domain
+          : null
+      );
+      setMaxBrowsingLevel(
+        typeof data.maxBrowsingLevel === 'number' && Number.isFinite(data.maxBrowsingLevel)
+          ? data.maxBrowsingLevel
+          : undefined
+      );
       setPending(false);
 
       const expiresAtMs = new Date(data.expiresAt).getTime();
@@ -197,5 +218,15 @@ export function useBlockToken(
     await requestToken();
   }, [requestToken]);
 
-  return { token, expiresAt, error, pending, needsConsent, missingScopes, refresh };
+  return {
+    token,
+    expiresAt,
+    error,
+    pending,
+    needsConsent,
+    missingScopes,
+    domain,
+    maxBrowsingLevel,
+    refresh,
+  };
 }

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -19,7 +19,8 @@ import { BlockRegistry } from '~/server/services/block-registry.service';
 import { BlockTokenService } from '~/server/services/block-token.service';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { getFeatureFlags } from '~/server/services/feature-flags.service';
-import { getAllServerHosts } from '~/server/utils/server-domain';
+import { getAllServerHosts, getRequestDomainColor } from '~/server/utils/server-domain';
+import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
 import {
   isKnownBlockScope,
   validateBlockScopesAgainstOauthClient,
@@ -680,6 +681,22 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
           slotId: install.slotId,
         };
 
+  // MATURITY ENFORCEMENT (GA gate). Stamp the AUTHORITATIVE color-domain
+  // maturity ceiling into the token AT MINT, derived from the request host
+  // (the same host the CORS allowlist above already trusts). This claim is the
+  // generation/catalog maturity boundary for the token's whole 15-min lifetime:
+  // a token minted on green/blue carries the SFW ceiling, red carries the
+  // mature ceiling. The block submit/estimate path derives `allowMatureContent`
+  // from THIS claim (never a client body field), so a SFW-domain block cannot
+  // generate mature output even if its own code is wrong or malicious.
+  //
+  // Fail-closed: an unknown/missing domain → domainBrowsingCeiling() returns the
+  // SFW ceiling. We always emit the claim so consumers can distinguish a
+  // legacy (pre-feature) token — which has NO claim and is treated as SFW by
+  // the consumer — from an explicit red mint.
+  const domainColor = getRequestDomainColor(req);
+  const maxBrowsingLevel = domainBrowsingCeiling(domainColor);
+
   const result = await BlockTokenService.sign({
     userId,
     blockId: block.blockId,
@@ -689,6 +706,8 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     scopes: manifestScopes,
     ctx,
     buzzBudget,
+    domain: domainColor ?? null,
+    maxBrowsingLevel,
   });
 
   // A6: surface the consent signal alongside the token. The token carries only
@@ -702,5 +721,11 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     expiresAt: result.expiresAt,
     needsConsent,
     missingScopes,
+    // Advisory maturity signal for the host → BLOCK_INIT. The AUTHORITATIVE
+    // enforcement is the same claim baked into the token above; this is the
+    // plaintext mirror so the host doesn't JWT-decode and blocks can
+    // self-filter their catalog reads / blur. See projectBlockInit.ts.
+    domain: domainColor ?? null,
+    maxBrowsingLevel,
   });
 });

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -132,10 +132,8 @@ export default function AppPage(props: PageProps) {
   // flow to the block via TOKEN_REFRESH (wired to PageBlockHost.onConsentGranted,
   // mirroring how IframeHost re-mints on REQUEST_CONSENT). The rotated token's
   // TOKEN_REFRESH push delivers the granted scopes and the block retries.
-  const { token, expiresAt, needsConsent, missingScopes, error, refresh } = useBlockToken(
-    install,
-    context
-  );
+  const { token, expiresAt, needsConsent, missingScopes, domain, maxBrowsingLevel, error, refresh } =
+    useBlockToken(install, context);
 
   const viewer = currentUser
     ? { id: currentUser.id, username: currentUser.username ?? null }
@@ -160,6 +158,8 @@ export default function AppPage(props: PageProps) {
           declaredScopes={scopes}
           missingScopes={missingScopes}
           needsConsent={needsConsent}
+          domain={domain}
+          maxBrowsingLevel={maxBrowsingLevel}
           tokenError={error != null}
           viewer={viewer}
           theme={theme}

--- a/src/server/middleware/__tests__/block-scope.middleware.test.ts
+++ b/src/server/middleware/__tests__/block-scope.middleware.test.ts
@@ -213,4 +213,75 @@ describe('verifyBlockToken fail-closed shapes (L-VERIFY / L-M6)', () => {
       .sign(key);
     expect(await verifyBlockToken(token)).toBeNull();
   });
+
+  // ---- Maturity claim shape guard ----------------------------------------
+  // The maxBrowsingLevel claim is optional (absent on legacy tokens), but if
+  // PRESENT it must be a finite number — a forged non-numeric value is rejected
+  // outright so the generation clamp never coerces a junk ceiling.
+  async function kidForCurrentKey(): Promise<string> {
+    const { BlockTokenService } = await import('~/server/services/block-token.service');
+    return BlockTokenService.getJwks().keys[0].kid;
+  }
+
+  it('passes through a valid numeric maxBrowsingLevel + domain claim', async () => {
+    const { BlockTokenService } = await import('~/server/services/block-token.service');
+    const r = await BlockTokenService.sign({
+      userId: 1,
+      ...baseClaims,
+      domain: 'green',
+      maxBrowsingLevel: 3,
+    });
+    const claims = await verifyBlockToken(r.token);
+    expect(claims).not.toBeNull();
+    expect(claims?.maxBrowsingLevel).toBe(3);
+    expect(claims?.domain).toBe('green');
+  });
+
+  it('rejects a token whose maxBrowsingLevel claim is non-numeric (forged)', async () => {
+    const key = await importPrivateKey();
+    const kid = await kidForCurrentKey();
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ ...baseClaims, sub: 'user:1', maxBrowsingLevel: 'all' })
+      .setProtectedHeader({ alg: 'RS256', typ: 'JWT', kid })
+      .setIssuer('civitai')
+      .setAudience('civitai-app-block')
+      .setSubject('user:1')
+      .setIssuedAt(now)
+      .setNotBefore(now)
+      .setExpirationTime(now + 600)
+      .sign(key);
+    expect(await verifyBlockToken(token)).toBeNull();
+  });
+
+  it('rejects a token whose maxBrowsingLevel claim is NaN/Infinity', async () => {
+    const key = await importPrivateKey();
+    const kid = await kidForCurrentKey();
+    const now = Math.floor(Date.now() / 1000);
+    // JSON has no NaN literal; jose serializes it, but a forger could emit one
+    // via a raw payload. Simulate the post-parse shape with a non-finite number
+    // surrogate (a stringy huge value is the realistic forge vector handled
+    // above; here we assert the Number.isFinite guard via an object).
+    const token = await new SignJWT({
+      ...baseClaims,
+      sub: 'user:1',
+      maxBrowsingLevel: [3] as unknown as number,
+    })
+      .setProtectedHeader({ alg: 'RS256', typ: 'JWT', kid })
+      .setIssuer('civitai')
+      .setAudience('civitai-app-block')
+      .setSubject('user:1')
+      .setIssuedAt(now)
+      .setNotBefore(now)
+      .setExpirationTime(now + 600)
+      .sign(key);
+    expect(await verifyBlockToken(token)).toBeNull();
+  });
+
+  it('accepts a token that OMITS the maturity claim (legacy) — consumer fails closed', async () => {
+    const { BlockTokenService } = await import('~/server/services/block-token.service');
+    const r = await BlockTokenService.sign({ userId: 1, ...baseClaims });
+    const claims = await verifyBlockToken(r.token);
+    expect(claims).not.toBeNull();
+    expect(claims?.maxBrowsingLevel).toBeUndefined();
+  });
 });

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -41,6 +41,16 @@ export interface BlockTokenClaims {
   ctx: Record<string, unknown>;
   scopes: string[];
   buzzBudget?: number;
+  /**
+   * AUTHORITATIVE color-domain maturity ceiling (bitwise browsing-level flag,
+   * from `domainBrowsingCeiling`) stamped at mint. The block generation path
+   * derives `allowMatureContent` from this — never from a client body field.
+   * ABSENT on legacy tokens minted before the maturity feature → consumers
+   * MUST fail closed (treat as SFW).
+   */
+  maxBrowsingLevel?: number;
+  /** Advisory: the color domain the token was minted on (`green`|`blue`|`red`). */
+  domain?: string;
 }
 
 export type BlockScopedNextApiRequest = NextApiRequest & {
@@ -326,6 +336,22 @@ export async function verifyBlockToken(token: string): Promise<BlockTokenClaims 
       // a future handler that does claims.sub.startsWith('user:') and
       // parseInts without going through parseSubjectUserId.
       if (!isValidSubject(claims.sub)) return null;
+      // Maturity claim shape guard. The claim is optional (absent on legacy
+      // tokens), but if present it MUST be a finite number — a forged token
+      // carrying a non-numeric / NaN / Infinity maxBrowsingLevel is rejected
+      // outright so the generation clamp never coerces a junk ceiling into an
+      // unintended (wider) maturity. (Consumers ALSO fail closed on absence;
+      // this is the upstream belt that keeps a malformed claim from ever
+      // reaching them.) Same for the advisory `domain` string.
+      if (
+        claims.maxBrowsingLevel !== undefined &&
+        (typeof claims.maxBrowsingLevel !== 'number' || !Number.isFinite(claims.maxBrowsingLevel))
+      ) {
+        return null;
+      }
+      if (claims.domain !== undefined && typeof claims.domain !== 'string') {
+        return null;
+      }
       return claims;
     } catch {
       // try the next key

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -2485,3 +2485,182 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
     });
   });
 });
+
+/**
+ * MATURITY ENFORCEMENT (GA gate) — the authoritative server-side belt.
+ *
+ * The maturity ceiling is derived from the TOKEN's `maxBrowsingLevel` claim
+ * (server-minted from the request host), NEVER from a client body field. A
+ * SFW-domain token (green/blue → claim = sfwBrowsingLevelsFlag) must force
+ * `allowMatureContent: false` into the orchestrator workflow body; a red token
+ * (claim = allBrowsingLevelsFlag) must leave it unset (no clamp). A token with
+ * NO claim (legacy / pre-feature) fails CLOSED to SFW.
+ *
+ * Browsing-level flag values (NsfwLevel bits): PG=1, PG13=2 → SFW=3;
+ * R|X|XXX add 4|8|16 → all = 31.
+ */
+const SFW_CEILING = 3; // sfwBrowsingLevelsFlag (PG | PG13)
+const ALL_CEILING = 31; // allBrowsingLevelsFlag (PG | PG13 | R | X | XXX)
+
+describe('blocks workflow — color-domain maturity enforcement', () => {
+  function lastSubmitBody() {
+    const calls = mockSubmitWorkflow.mock.calls;
+    return (calls[calls.length - 1][0] as { body: Record<string, unknown> }).body;
+  }
+  function firstSubmitBody() {
+    return (mockSubmitWorkflow.mock.calls[0][0] as { body: Record<string, unknown> }).body;
+  }
+
+  describe('estimateWorkflow', () => {
+    it('green-domain token (SFW ceiling) forces allowMatureContent=false into the whatif body', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ domain: 'green', maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(firstSubmitBody().allowMatureContent).toBe(false);
+    });
+
+    it('blue-domain token (SFW ceiling, product decision) ALSO forces allowMatureContent=false', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ domain: 'blue', maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(firstSubmitBody().allowMatureContent).toBe(false);
+    });
+
+    it('red-domain token (mature ceiling) does NOT clamp — allowMatureContent omitted', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ domain: 'red', maxBrowsingLevel: ALL_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(firstSubmitBody()).not.toHaveProperty('allowMatureContent');
+    });
+
+    it('legacy token (no maxBrowsingLevel claim) FAILS CLOSED to SFW', async () => {
+      // validClaims() carries NO maxBrowsingLevel — the pre-feature shape.
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(firstSubmitBody().allowMatureContent).toBe(false);
+    });
+  });
+
+  describe('submitWorkflow', () => {
+    function happySubmit(cost = 10) {
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: cost }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: cost }, steps: [] });
+    }
+
+    it('green-domain token forces allowMatureContent=false on BOTH whatif and real submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, domain: 'green', maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(2);
+      expect(firstSubmitBody().allowMatureContent).toBe(false); // whatif
+      expect(lastSubmitBody().allowMatureContent).toBe(false); // real submit
+    });
+
+    it('blue-domain token (SFW per product decision) forces allowMatureContent=false on the real submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, domain: 'blue', maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(lastSubmitBody().allowMatureContent).toBe(false);
+    });
+
+    it('red-domain token leaves allowMatureContent UNSET (mature allowed)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, domain: 'red', maxBrowsingLevel: ALL_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(firstSubmitBody()).not.toHaveProperty('allowMatureContent');
+      expect(lastSubmitBody()).not.toHaveProperty('allowMatureContent');
+    });
+
+    it('legacy token (no claim) FAILS CLOSED to SFW on the real submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(lastSubmitBody().allowMatureContent).toBe(false);
+    });
+
+    it('clamp is TOKEN-derived: a malicious body cannot widen a SFW token to mature', async () => {
+      // The token is SFW (green). The attacker stuffs allowMatureContent:true
+      // (and an nsfwLevel) onto the BODY. The schema strips unknowns, and even
+      // if it didn't, the clamp reads the TOKEN claim — the submitted body MUST
+      // still carry allowMatureContent:false.
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, domain: 'green', maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: { ...validBody(), allowMatureContent: true, nsfwLevel: 'xxx' } as never,
+      });
+      expect(lastSubmitBody().allowMatureContent).toBe(false);
+    });
+
+    it('prompt audit isGreen is DOMAIN-derived: SFW token → isGreen=true', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, domain: 'blue', maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(mockAuditPromptServer).toHaveBeenCalledWith(
+        expect.objectContaining({ isGreen: true })
+      );
+    });
+
+    it('prompt audit isGreen is DOMAIN-derived: red token → isGreen=false', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, domain: 'red', maxBrowsingLevel: ALL_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(mockAuditPromptServer).toHaveBeenCalledWith(
+        expect.objectContaining({ isGreen: false })
+      );
+    });
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1623,12 +1623,14 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       );
     });
 
-    it('derives sfwOnly:true from a green-domain ctx and forwards it into the canGenerate gate', async () => {
-      // The page branch mirrors model-version.controller: the gate context's
-      // sfwOnly is `ctx.domain === 'green'`. fakeCtx() omits domain (→ false),
-      // so a green ctx is the only way to exercise the SFW-gating branch — it
-      // must flow into resolveCanGenerateForVersions' context arg as true.
-      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+    it('derives sfwOnly:true from a SFW token maturity claim (not the request domain)', async () => {
+      // FIX 2: the resource-selection gate's `sfwOnly` is now derived from the
+      // AUTHORITATIVE token maturity (`resolveBlockMaturity` → allowMatureContent
+      // === false on a SFW ceiling), NOT request-time `ctx.domain`. A SFW
+      // maturity claim (green/blue ceiling = 3) must flow into
+      // resolveCanGenerateForVersions' context arg as sfwOnly:true even when the
+      // request `ctx.domain` is the default (blue, which used to map to false).
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ maxBrowsingLevel: 3 }));
       happyVersionLookup();
       happyUser();
       mockSubmitWorkflow.mockResolvedValue({
@@ -1637,7 +1639,8 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
         cost: { total: 12 },
         steps: [],
       });
-      const caller = blocksRouter.createCaller({ ...fakeCtx(), domain: 'green' } as never);
+      // fakeCtx() omits domain → defaults are irrelevant now; the claim drives it.
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
       await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
       expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
       const [, gateCtx] = mockResolveCanGenerateForVersions.mock.calls[0];
@@ -1646,12 +1649,55 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       expect(gateCtx.wildcardsEnabled).toBe(false);
     });
 
+    it('a BLUE token (SFW per App-Blocks product decision) also derives sfwOnly:true', async () => {
+      // FIX 2 regression guard: under the OLD `ctx.domain === 'green'` rule a
+      // blue block had sfwOnly:false → could pick a mature resource. Now a blue
+      // token mints a SFW ceiling (maxBrowsingLevel = 3) so the resource gate is
+      // SFW too, unified with the generation-output clamp.
+      mockVerifyBlockToken.mockResolvedValue(
+        pageClaims({ domain: 'blue', maxBrowsingLevel: 3 })
+      );
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 12 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller({ ...fakeCtx(), domain: 'blue' } as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      const [, gateCtx] = mockResolveCanGenerateForVersions.mock.calls[0];
+      expect(gateCtx.sfwOnly).toBe(true);
+    });
+
+    it('a RED token (mature ceiling) derives sfwOnly:false (mature resource selection allowed)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        pageClaims({ domain: 'red', maxBrowsingLevel: 31 })
+      );
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 12 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller({ ...fakeCtx(), domain: 'red' } as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      const [, gateCtx] = mockResolveCanGenerateForVersions.mock.calls[0];
+      expect(gateCtx.sfwOnly).toBe(false);
+    });
+
     it('derives wildcardsEnabled:true from ctx.features.wildcards and forwards it into the canGenerate gate', async () => {
       // The page branch mirrors model-version.controller: the gate context's
       // wildcardsEnabled is `!!ctx.features.wildcards`. fakeCtx() omits the flag
       // (→ false), so an enabled-wildcards ctx is the only way to exercise this
       // branch — it must flow into the gate context arg as true.
-      mockVerifyBlockToken.mockResolvedValue(pageClaims());
+      // Red ceiling (maxBrowsingLevel = 31) so sfwOnly stays false — this test
+      // is about wildcards independence, not the maturity clamp. A token with no
+      // claim would now FAIL CLOSED to sfwOnly:true (FIX 2), masking the point.
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ maxBrowsingLevel: 31 }));
       happyVersionLookup();
       happyUser();
       mockSubmitWorkflow.mockResolvedValue({
@@ -1669,7 +1715,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
       const [, gateCtx] = mockResolveCanGenerateForVersions.mock.calls[0];
       expect(gateCtx.wildcardsEnabled).toBe(true);
-      // green-domain is independent and untouched here → sfwOnly still false.
+      // maturity is independent here → with a red ceiling sfwOnly is false.
       expect(gateCtx.sfwOnly).toBe(false);
     });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -54,6 +54,7 @@ import {
   validateBlockCheckpoint,
 } from '~/server/services/blocks/checkpoint.service';
 import { getModelShowcaseImages } from '~/server/services/blocks/showcase.service';
+import { getRequestDomainColor } from '~/server/utils/server-domain';
 // Type-only: the runtime `resolveCanGenerateForVersions` is loaded via a
 // dynamic import() inside assertViewerCanGeneratePageResources so the heavy
 // generation-service import graph (image.service → event-engine-common, etc.)
@@ -2189,16 +2190,30 @@ export const blocksRouter = router({
       // iframe for NSFW-opted-out or logged-out viewers. Anon (no ctx.user)
       // is forced to public (PG) inside the service.
       //
-      // `ctx.domain` carries the color-domain maturity CEILING: on a SFW domain
+      // The color domain carries the maturity CEILING: on a SFW domain
       // (green/blue) the service clamps the effective browsing level to SFW so a
       // logged-in viewer can't request `browsingLevel: 31` and pull mature
       // thumbnails + meta into the iframe. This is the display-surface analogue
       // of the authoritative generation clamp. This is a public read with no
       // block-token claim handy, so the request-time domain is the authority.
+      //
+      // LOW-1 hardening: derive the maturity domain from the RAW
+      // `getRequestDomainColor(req)` — which returns `undefined` for an
+      // UNRESOLVED host — NOT from `ctx.domain`, which is `?? 'blue'`-defaulted
+      // in createContext for the convenience of code that wants a concrete
+      // color. Routing the showcase clamp through that default would make an
+      // unresolved host fail-CLOSED today only because `domainBrowsingCeiling`
+      // happens to map 'blue' → SFW; the moment the platform flips blue→mature
+      // there, the `?? 'blue'` default would silently turn this fail-closed read
+      // into a fail-OPEN one for unresolved hosts. Passing the raw `undefined`
+      // through makes `domainBrowsingCeiling(undefined)` fail closed to SFW
+      // independent of blue's mapping — matching how the authoritative
+      // generation belt clamps off the raw color (never the 'blue' default).
+      const rawDomain = getRequestDomainColor(ctx.req);
       return getModelShowcaseImages(input.modelVersionId, {
         userId: ctx.user?.id ?? null,
         browsingLevel: input.browsingLevel,
-        domain: ctx.domain,
+        domain: rawDomain,
       });
     }),
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -36,6 +36,11 @@ import {
   withdrawRequestSchema,
 } from '~/server/schema/blocks/publish-request.schema';
 import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema';
+import {
+  allowMatureContentForCeiling,
+  domainBrowsingCeiling,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { rateLimit } from '~/server/middleware.trpc';
 import { BlockRegistry } from '~/server/services/block-registry.service';
@@ -140,6 +145,45 @@ async function assertViewerIsModerator(userId: number): Promise<void> {
 // block-tokens/index.ts); model tokens never carry `entityType`.
 function isPageToken(claims: { ctx?: unknown }): boolean {
   return (claims.ctx as { entityType?: unknown } | undefined)?.entityType === 'none';
+}
+
+// ---- Maturity enforcement (GA gate) ---------------------------------------
+//
+// AUTHORITATIVE server-side belt. The maturity ceiling comes from the TOKEN's
+// `maxBrowsingLevel` claim (server-minted from the request host at issuance —
+// see block-tokens/index.ts), NEVER from a client-supplied body field, so a
+// block on a SFW domain (green/blue) cannot generate mature output even if its
+// own code is wrong or malicious.
+//
+// FAIL CLOSED: a token minted before this feature (or any token missing the
+// numeric claim) is treated as the most restrictive SFW ceiling, never as
+// "unrestricted". `verifyBlockToken` already rejects a present-but-non-numeric
+// claim, so by here the value is either a finite number or undefined.
+//
+// Returns:
+//   - maxBrowsingLevel:   the effective ceiling (claim value, or SFW fallback)
+//   - allowMatureContent: the orchestrator flag derived from it
+//                         (`false` on SFW, `undefined`/no-clamp only on red)
+//   - isGreen:            the prompt-audit's "SFW prompt audit" toggle — true
+//                         whenever the ceiling is SFW (i.e. NOT mature-allowed)
+function resolveBlockMaturity(claims: { maxBrowsingLevel?: number }): {
+  maxBrowsingLevel: number;
+  allowMatureContent: boolean | undefined;
+  isGreen: boolean;
+} {
+  const maxBrowsingLevel =
+    typeof claims.maxBrowsingLevel === 'number' && Number.isFinite(claims.maxBrowsingLevel)
+      ? claims.maxBrowsingLevel
+      : sfwBrowsingLevelsFlag; // fail closed
+  const allowMatureContent = allowMatureContentForCeiling(maxBrowsingLevel);
+  return {
+    maxBrowsingLevel,
+    allowMatureContent,
+    // `auditPromptServer`'s `isGreen` flag selects the SFW prompt audit. Tie it
+    // to the maturity ceiling rather than the literal green domain: a blue
+    // (SFW, per the App-Blocks product decision) block gets the SFW audit too.
+    isGreen: allowMatureContent === false,
+  };
 }
 
 // SECURITY-CRITICAL (W10). A page token has no model binding, so the model-
@@ -1748,12 +1792,17 @@ export const blocksRouter = router({
         checkpointVersionId: checkpoint.versionId,
       });
       const step = await createTextToImageStep({ ...generateInput, user, whatIf: true });
+      // Maturity clamp (authoritative). Derive allowMatureContent from the
+      // TOKEN claim, not the body — a SFW-domain token forces it false so the
+      // orchestrator rejects mature output. Mirrors submitWorkflow below.
+      const { allowMatureContent } = resolveBlockMaturity(claims);
       const workflow = await submitWorkflow({
         token,
         body: {
           steps: [step],
           tags: buildWorkflowTags(claims, resolved.baseModel),
           currencies: BLOCK_CURRENCIES,
+          ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
         },
         query: { whatif: true },
       });
@@ -1866,14 +1915,23 @@ export const blocksRouter = router({
       }
       const token = await getOrchestratorToken(userId, ctx);
 
+      // Maturity clamp (authoritative, GA gate). Derived ONCE from the token's
+      // server-minted ceiling claim and applied to: (a) the prompt audit
+      // (`isGreen` → SFW prompt audit on SFW domains), (b) the whatIf cost
+      // step, and (c) the real submit. NEVER from a client body field, so a
+      // SFW-domain (green/blue) block cannot widen to mature output. Fail
+      // closed: a legacy/absent claim resolves to the SFW ceiling.
+      const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
+
       // Prompt audit before any orchestrator interaction (mirrors what
       // generateFromGraph does). A block can't bypass moderation by submitting
-      // through this path.
+      // through this path. `isGreen` (SFW prompt audit) is domain/ceiling-
+      // derived so a SFW-domain block's prompts get the stricter audit.
       await auditPromptServer({
         prompt: input.body.params.prompt,
         negativePrompt: input.body.params.negativePrompt,
         userId,
-        isGreen: false,
+        isGreen,
         isModerator: !!user.isModerator,
       });
 
@@ -1894,7 +1952,12 @@ export const blocksRouter = router({
       const tags = buildWorkflowTags(claims, resolved.baseModel);
       const whatIfResult = await submitWorkflow({
         token,
-        body: { steps: [stepForCostCheck], tags, currencies: BLOCK_CURRENCIES },
+        body: {
+          steps: [stepForCostCheck],
+          tags,
+          currencies: BLOCK_CURRENCIES,
+          ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+        },
         query: { whatif: true },
       });
       const cost = whatIfResult.cost?.total ?? 0;
@@ -1972,7 +2035,14 @@ export const blocksRouter = router({
         const step = await createTextToImageStep({ ...generateInput, user });
         const submitted = await submitWorkflow({
           token,
-          body: { steps: [step], tags, currencies: BLOCK_CURRENCIES },
+          body: {
+            steps: [step],
+            tags,
+            currencies: BLOCK_CURRENCIES,
+            // Authoritative maturity clamp on the REAL submit — the orchestrator
+            // rejects mature output when this is false. Token-claim derived.
+            ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+          },
         });
         snapshot = snapshotFromWorkflow(submitted);
       } catch (e) {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1771,6 +1771,13 @@ export const blocksRouter = router({
       // for the whole array — is enforced downstream by the orchestrator
       // resource belt over the FULL resources array; this gate is not the sole
       // boundary. Keep both belts.
+      // Maturity clamp (authoritative). Derived ONCE from the token's
+      // server-minted ceiling claim, NOT a client body field nor request-time
+      // `ctx.domain`. Drives both the resource-selection gate (`sfwOnly`, so a
+      // SFW-domain block can't even PICK a mature resource — defense in depth)
+      // and the generation-output clamp (`allowMatureContent`). Green AND blue
+      // → sfwOnly true; red → false. Mirrors submitWorkflow below.
+      const { allowMatureContent } = resolveBlockMaturity(claims);
       if (isPage) {
         // Resolve + validate the LoRA stack first (LoRA-only + family-match)
         // so a bad resource fails BEFORE the entitlement gate / any cost.
@@ -1782,7 +1789,10 @@ export const blocksRouter = router({
         await assertViewerCanGeneratePageResources({
           gates: [buildGateVersion(resolved.gate), ...loraGates],
           viewer: { id: userId, isModerator: !!user.isModerator },
-          sfwOnly: ctx.domain === 'green',
+          // SFW-only resource selection unifies with the output clamp: derive
+          // from the authoritative token maturity (green/blue → true), not the
+          // request domain. `allowMatureContent === false` ⇔ SFW ceiling.
+          sfwOnly: allowMatureContent === false,
           wildcardsEnabled: !!ctx.features.wildcards,
         });
       }
@@ -1792,10 +1802,6 @@ export const blocksRouter = router({
         checkpointVersionId: checkpoint.versionId,
       });
       const step = await createTextToImageStep({ ...generateInput, user, whatIf: true });
-      // Maturity clamp (authoritative). Derive allowMatureContent from the
-      // TOKEN claim, not the body — a SFW-domain token forces it false so the
-      // orchestrator rejects mature output. Mirrors submitWorkflow below.
-      const { allowMatureContent } = resolveBlockMaturity(claims);
       const workflow = await submitWorkflow({
         token,
         body: {
@@ -1901,6 +1907,16 @@ export const blocksRouter = router({
       // for the whole array, is enforced downstream by the orchestrator
       // resource belt over the FULL array (whatIf + real) — this gate is not
       // the sole boundary. Keep both belts.
+      // Maturity clamp (authoritative, GA gate). Derived ONCE from the token's
+      // server-minted ceiling claim and applied to: (a) the resource-selection
+      // gate (`sfwOnly`, defense in depth — a SFW block can't even PICK a
+      // mature resource), (b) the prompt audit (`isGreen` → SFW prompt audit on
+      // SFW domains), (c) the whatIf cost step, and (d) the real submit. NEVER
+      // from a client body field nor request-time `ctx.domain`, so a SFW-domain
+      // (green/blue) block cannot widen to mature output. Fail closed: a
+      // legacy/absent claim resolves to the SFW ceiling.
+      const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
+
       if (isPage) {
         const loraGates = await resolvePageLoraGates({
           additionalResources: input.body.additionalResources,
@@ -1909,19 +1925,14 @@ export const blocksRouter = router({
         await assertViewerCanGeneratePageResources({
           gates: [buildGateVersion(resolved.gate), ...loraGates],
           viewer: { id: userId, isModerator: !!user.isModerator },
-          sfwOnly: ctx.domain === 'green',
+          // Unify resource selection with the output clamp: SFW-only iff the
+          // authoritative token maturity is SFW (green/blue), not the request
+          // domain. `allowMatureContent === false` ⇔ SFW ceiling.
+          sfwOnly: allowMatureContent === false,
           wildcardsEnabled: !!ctx.features.wildcards,
         });
       }
       const token = await getOrchestratorToken(userId, ctx);
-
-      // Maturity clamp (authoritative, GA gate). Derived ONCE from the token's
-      // server-minted ceiling claim and applied to: (a) the prompt audit
-      // (`isGreen` → SFW prompt audit on SFW domains), (b) the whatIf cost
-      // step, and (c) the real submit. NEVER from a client body field, so a
-      // SFW-domain (green/blue) block cannot widen to mature output. Fail
-      // closed: a legacy/absent claim resolves to the SFW ceiling.
-      const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
 
       // Prompt audit before any orchestrator interaction (mirrors what
       // generateFromGraph does). A block can't bypass moderation by submitting
@@ -2177,9 +2188,17 @@ export const blocksRouter = router({
       // gen-meta (prompt/seed) aren't leaked into the third-party publisher
       // iframe for NSFW-opted-out or logged-out viewers. Anon (no ctx.user)
       // is forced to public (PG) inside the service.
+      //
+      // `ctx.domain` carries the color-domain maturity CEILING: on a SFW domain
+      // (green/blue) the service clamps the effective browsing level to SFW so a
+      // logged-in viewer can't request `browsingLevel: 31` and pull mature
+      // thumbnails + meta into the iframe. This is the display-surface analogue
+      // of the authoritative generation clamp. This is a public read with no
+      // block-token claim handy, so the request-time domain is the authority.
       return getModelShowcaseImages(input.modelVersionId, {
         userId: ctx.user?.id ?? null,
         browsingLevel: input.browsingLevel,
+        domain: ctx.domain,
       });
     }),
 

--- a/src/server/services/__tests__/block-token.service.test.ts
+++ b/src/server/services/__tests__/block-token.service.test.ts
@@ -72,6 +72,92 @@ describe('BlockTokenService.sign — JWT round-trip', () => {
     expect(payload.buzzBudget).toBe(200);
   });
 
+  it('stamps maxBrowsingLevel + domain claims when supplied (SFW domain)', async () => {
+    const { BlockTokenService } = await import('../block-token.service');
+    const r = await BlockTokenService.sign({
+      userId: 1,
+      blockId: 'b',
+      appId: 'a',
+      appBlockId: 'apb_a',
+      blockInstanceId: 'bki',
+      scopes: ['ai:write:budgeted'],
+      ctx: { modelId: 1 },
+      domain: 'green',
+      maxBrowsingLevel: 3, // sfwBrowsingLevelsFlag (PG | PG13)
+    });
+    const { payload } = await jwtVerify(r.token, publicKey, {
+      issuer: 'civitai',
+      audience: 'civitai-app-block',
+      algorithms: ['RS256'],
+    });
+    expect(payload.maxBrowsingLevel).toBe(3);
+    expect(payload.domain).toBe('green');
+  });
+
+  it('stamps the mature ceiling for a red domain', async () => {
+    const { BlockTokenService } = await import('../block-token.service');
+    const r = await BlockTokenService.sign({
+      userId: 1,
+      blockId: 'b',
+      appId: 'a',
+      appBlockId: 'apb_a',
+      blockInstanceId: 'bki',
+      scopes: ['ai:write:budgeted'],
+      ctx: { modelId: 1 },
+      domain: 'red',
+      maxBrowsingLevel: 31, // allBrowsingLevelsFlag
+    });
+    const { payload } = await jwtVerify(r.token, publicKey, {
+      issuer: 'civitai',
+      audience: 'civitai-app-block',
+      algorithms: ['RS256'],
+    });
+    expect(payload.maxBrowsingLevel).toBe(31);
+    expect(payload.domain).toBe('red');
+  });
+
+  it('omits the maturity claims entirely when not supplied (legacy path)', async () => {
+    const { BlockTokenService } = await import('../block-token.service');
+    const r = await BlockTokenService.sign({
+      userId: 1,
+      blockId: 'b',
+      appId: 'a',
+      appBlockId: 'apb_a',
+      blockInstanceId: 'bki',
+      scopes: ['models:read:self'],
+      ctx: { modelId: 1 },
+    });
+    const { payload } = await jwtVerify(r.token, publicKey, {
+      issuer: 'civitai',
+      audience: 'civitai-app-block',
+      algorithms: ['RS256'],
+    });
+    expect(payload.maxBrowsingLevel).toBeUndefined();
+    expect(payload.domain).toBeUndefined();
+  });
+
+  it('omits the domain claim when null (host did not resolve a color) but keeps the ceiling', async () => {
+    const { BlockTokenService } = await import('../block-token.service');
+    const r = await BlockTokenService.sign({
+      userId: 1,
+      blockId: 'b',
+      appId: 'a',
+      appBlockId: 'apb_a',
+      blockInstanceId: 'bki',
+      scopes: ['models:read:self'],
+      ctx: { modelId: 1 },
+      domain: null,
+      maxBrowsingLevel: 3, // still the fail-closed SFW ceiling
+    });
+    const { payload } = await jwtVerify(r.token, publicKey, {
+      issuer: 'civitai',
+      audience: 'civitai-app-block',
+      algorithms: ['RS256'],
+    });
+    expect(payload.domain).toBeUndefined();
+    expect(payload.maxBrowsingLevel).toBe(3);
+  });
+
   it('signs anon subjects as sub="anon"', async () => {
     const { BlockTokenService } = await import('../block-token.service');
     const r = await BlockTokenService.sign({

--- a/src/server/services/block-token.service.ts
+++ b/src/server/services/block-token.service.ts
@@ -143,6 +143,21 @@ export interface SignBlockTokenInput {
   scopes: string[];
   ctx: Record<string, unknown>;
   buzzBudget?: number;
+  /**
+   * The color domain the token was minted on (`green` | `blue` | `red`), or
+   * null when the request host didn't resolve to a known color. Advisory /
+   * audit field; the AUTHORITATIVE maturity boundary is `maxBrowsingLevel`.
+   */
+  domain?: string | null;
+  /**
+   * AUTHORITATIVE maturity ceiling for this token (a bitwise browsing-level
+   * flag from `domainBrowsingCeiling`). The block submit/estimate path derives
+   * `allowMatureContent` from THIS value, not from any client body field, so a
+   * SFW-domain (green/blue) token can never widen to mature output. A token
+   * minted before this feature carries NO claim — consumers MUST fail closed
+   * (treat absent as SFW), so omit the claim only for that legacy path.
+   */
+  maxBrowsingLevel?: number;
 }
 
 export interface SignBlockTokenResult {
@@ -191,6 +206,17 @@ export class BlockTokenService {
     };
     if (typeof input.buzzBudget === 'number') {
       claims.buzzBudget = input.buzzBudget;
+    }
+    // Maturity enforcement claims. `maxBrowsingLevel` is the authoritative
+    // server-minted ceiling the block submit/estimate path clamps generation
+    // against; `domain` is an advisory audit/UX signal. Both are stamped at
+    // mint from the request host so the block's own (untrusted) code can never
+    // influence them.
+    if (typeof input.maxBrowsingLevel === 'number') {
+      claims.maxBrowsingLevel = input.maxBrowsingLevel;
+    }
+    if (input.domain != null) {
+      claims.domain = input.domain;
     }
 
     const token = await new SignJWT(claims)

--- a/src/server/services/blocks/__tests__/showcase.service.test.ts
+++ b/src/server/services/blocks/__tests__/showcase.service.test.ts
@@ -334,6 +334,64 @@ describe('getModelShowcaseImages', () => {
     });
   });
 
+  // LOW-1: the showcase clamp must fail closed for an UNRESOLVED host
+  // independent of how `domainBrowsingCeiling` happens to map 'blue' today.
+  // The router passes the RAW `getRequestDomainColor(req)` (→ `undefined` for an
+  // unresolved host) rather than `ctx.domain` (which is `?? 'blue'`-defaulted in
+  // createContext). If, instead, the showcase rode on the 'blue'-defaulted
+  // value, the moment the platform flips blue→mature in `domainBrowsingCeiling`
+  // an unresolved host would silently turn this fail-closed read into a
+  // fail-OPEN one. This suite stubs the ceiling so blue→mature and proves an
+  // `undefined` domain still clamps to SFW — i.e. the fix does NOT depend on
+  // blue's value.
+  describe('LOW-1: undefined domain fails closed independent of the blue ceiling', () => {
+    const wideRows = [
+      imageRow(1, 100, {}, { nsfwLevel: PG }),
+      imageRow(2, 90, {}, { nsfwLevel: PG13 }),
+      imageRow(3, 80, {}, { nsfwLevel: R }),
+      imageRow(4, 70, {}, { nsfwLevel: X }),
+      imageRow(5, 60, {}, { nsfwLevel: XXX }),
+    ];
+
+    it('undefined domain stays SFW even when blue would map to all-levels', async () => {
+      // Stub the SINGLE source of truth so blue (and only blue) maps to the
+      // all-levels ceiling — simulating a future site-wide blue→mature flip.
+      // `undefined` must still fail closed to SFW: had the router passed the
+      // 'blue'-defaulted ctx.domain, this viewer would now see R/X/XXX.
+      const constants = await import('~/shared/constants/browsingLevel.constants');
+      const spy = vi
+        .spyOn(constants, 'domainBrowsingCeiling')
+        .mockImplementation((color) => {
+          if (color === 'blue' || color === 'red') return constants.allBrowsingLevelsFlag;
+          if (color == null) return constants.sfwBrowsingLevelsFlag; // fail closed
+          return constants.sfwBrowsingLevelsFlag;
+        });
+      try {
+        mockDbRead.imageResourceNew.findMany.mockResolvedValue([...wideRows]);
+        // Unresolved host → raw color undefined → passed through as undefined.
+        const undefinedResult = await getModelShowcaseImages(99, {
+          userId: 42,
+          browsingLevel: PG | PG13 | R | X | XXX,
+          domain: undefined,
+        });
+        expect(undefinedResult.map((i) => i.id)).toEqual([1, 2]); // SFW only
+
+        // Control: explicit blue, under the SAME stub, WOULD widen to mature —
+        // proving the undefined-fails-closed result above is not an artifact of
+        // the stub being inert (i.e. the blue default would have been a leak).
+        mockDbRead.imageResourceNew.findMany.mockResolvedValue([...wideRows]);
+        const blueResult = await getModelShowcaseImages(99, {
+          userId: 42,
+          browsingLevel: PG | PG13 | R | X | XXX,
+          domain: 'blue',
+        });
+        expect(blueResult.map((i) => i.id)).toEqual([1, 2, 3, 4, 5]);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
   describe('meta extraction', () => {
     async function getFirstMeta(meta: unknown) {
       mockDbRead.imageResourceNew.findMany.mockResolvedValue([imageRow(1, 10, meta)]);

--- a/src/server/services/blocks/__tests__/showcase.service.test.ts
+++ b/src/server/services/blocks/__tests__/showcase.service.test.ts
@@ -179,9 +179,14 @@ describe('getModelShowcaseImages', () => {
         imageRow(3, 80, {}, { nsfwLevel: X }),
         imageRow(4, 70, {}, { nsfwLevel: XXX }),
       ]);
+      // domain:'red' so the color-domain ceiling is all-levels and this test
+      // isolates the VIEWER-level dimension (the domain clamp is covered in the
+      // dedicated suite below); without it the SFW fail-closed default would
+      // mask the requested-level pass-through.
       const result = await getModelShowcaseImages(99, {
         userId: 42,
         browsingLevel: PG | PG13 | R | X | XXX,
+        domain: 'red',
       });
       // All intersect the requested level → all returned (reaction order).
       expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4]);
@@ -193,9 +198,11 @@ describe('getModelShowcaseImages', () => {
         imageRow(2, 90, {}, { nsfwLevel: R }),
         imageRow(3, 80, {}, { nsfwLevel: X }),
       ]);
+      // domain:'red' isolates the viewer-level dimension (see note above).
       const result = await getModelShowcaseImages(99, {
         userId: 42,
         browsingLevel: PG | PG13 | R,
+        domain: 'red',
       });
       expect(result.map((i) => i.id)).toEqual([1, 2]);
     });
@@ -257,6 +264,73 @@ describe('getModelShowcaseImages', () => {
       // BEFORE the 6-image cap, so the lower-reaction PG images aren't starved.
       const result = await getModelShowcaseImages(99);
       expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+  });
+
+  describe('color-domain ceiling (security: mature thumbnail leak on a SFW domain)', () => {
+    const wideRows = [
+      imageRow(1, 100, {}, { nsfwLevel: PG }),
+      imageRow(2, 90, {}, { nsfwLevel: PG13 }),
+      imageRow(3, 80, {}, { nsfwLevel: R }),
+      imageRow(4, 70, {}, { nsfwLevel: X }),
+      imageRow(5, 60, {}, { nsfwLevel: XXX }),
+    ];
+
+    it('green domain clamps a viewer requesting browsingLevel:31 to SFW (no R/X/XXX)', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([...wideRows]);
+      // Logged-in viewer asks for everything (PG|PG13|R|X|XXX = 31) but is on a
+      // green (SFW) domain — the ceiling intersection drops R/X/XXX so no mature
+      // thumbnail URL or its prompt/seed meta reaches the iframe.
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13 | R | X | XXX,
+        domain: 'green',
+      });
+      expect(result.map((i) => i.id)).toEqual([1, 2]);
+    });
+
+    it('blue domain (App-Blocks SFW) also clamps browsingLevel:31 to SFW', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([...wideRows]);
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13 | R | X | XXX,
+        domain: 'blue',
+      });
+      // blue is SFW for App Blocks (mirrors the generation clamp) → mature dropped.
+      expect(result.map((i) => i.id)).toEqual([1, 2]);
+    });
+
+    it('red domain leaves the requested level unclamped (mature thumbnails returned)', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([...wideRows]);
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13 | R | X | XXX,
+        domain: 'red',
+      });
+      expect(result.map((i) => i.id)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('unknown/missing domain fails closed to SFW for a wide-requesting viewer', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([...wideRows]);
+      // No domain passed (or an unrecognized one) → ceiling fails closed to SFW,
+      // so even a logged-in browsingLevel:31 viewer never sees R/X/XXX.
+      const result = await getModelShowcaseImages(99, {
+        userId: 42,
+        browsingLevel: PG | PG13 | R | X | XXX,
+      });
+      expect(result.map((i) => i.id)).toEqual([1, 2]);
+    });
+
+    it('anon on red domain is still capped to public/PG (ceiling never widens anon)', async () => {
+      mockDbRead.imageResourceNew.findMany.mockResolvedValue([...wideRows]);
+      // The ceiling intersection only ever tightens; anon stays at public (PG)
+      // even on red, since public ⊆ red-ceiling.
+      const result = await getModelShowcaseImages(99, {
+        userId: null,
+        browsingLevel: PG | PG13 | R | X | XXX,
+        domain: 'red',
+      });
+      expect(result.map((i) => i.id)).toEqual([1]);
     });
   });
 

--- a/src/server/services/blocks/showcase.service.ts
+++ b/src/server/services/blocks/showcase.service.ts
@@ -3,10 +3,12 @@ import { dbRead } from '~/server/db/client';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { Flags } from '~/shared/utils/flags';
 import {
+  domainBrowsingCeiling,
   onlySelectableLevels,
   publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
+import type { ColorDomain } from '~/shared/constants/domain.constants';
 
 const MAX_SHOWCASE_IMAGES = 6;
 
@@ -34,6 +36,19 @@ export interface ShowcaseViewer {
    * When omitted for a logged-in viewer we fall back to SFW (safe default).
    */
   browsingLevel?: number;
+  /**
+   * The color domain of the block-host request (`green`/`blue`/`red`). Maps to
+   * a maturity CEILING via `domainBrowsingCeiling` that the viewer's resolved
+   * level is intersected against — so a logged-in viewer on a SFW domain
+   * (green/blue) can't request `browsingLevel: 31` and pull mature thumbnails +
+   * gen-meta into the iframe. `undefined`/unknown fails closed to SFW. This is
+   * the display-surface analogue of the authoritative generation maturity
+   * clamp (blocks.router `resolveBlockMaturity`); `getShowcaseImages` is a
+   * public read with no token claim handy, so the request-time `ctx.domain` is
+   * the authority for this read. Anon viewers are already capped to public
+   * regardless, so the ceiling only ever tightens a logged-in view.
+   */
+  domain?: ColorDomain | null;
 }
 
 /**
@@ -47,11 +62,21 @@ export interface ShowcaseViewer {
  *   - logged-in               → the requested level, with unselectable bits
  *     (Blocked) stripped via `onlySelectableLevels`. Missing / zero falls back
  *     to SFW so a viewer with no settings yet never gets NSFW by default.
+ *
+ * The resolved level is then INTERSECTED with the color-domain maturity ceiling
+ * (`domainBrowsingCeiling(viewer.domain)`): on a SFW domain (green/blue, or an
+ * unknown/missing domain which fails closed to SFW) the result can never carry
+ * mature bits even when a logged-in viewer requests `browsingLevel: 31`. On a
+ * red domain the ceiling is all-levels, so it's a no-op there. (Anon is already
+ * forced to public above, so the intersection only ever tightens a logged-in
+ * view — `public ⊆ SFW` makes it a no-op for anon.)
  */
 function resolveAllowedBrowsingLevel(viewer?: ShowcaseViewer): number {
-  if (!viewer?.userId) return publicBrowsingLevelsFlag;
+  const ceiling = domainBrowsingCeiling(viewer?.domain);
+  if (!viewer?.userId) return Flags.intersection(publicBrowsingLevelsFlag, ceiling);
   const requested = onlySelectableLevels(viewer.browsingLevel ?? 0);
-  return requested > 0 ? requested : sfwBrowsingLevelsFlag;
+  const resolved = requested > 0 ? requested : sfwBrowsingLevelsFlag;
+  return Flags.intersection(resolved, ceiling);
 }
 
 /**

--- a/src/shared/constants/__tests__/browsingLevel-maturity.test.ts
+++ b/src/shared/constants/__tests__/browsingLevel-maturity.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  allBrowsingLevelsFlag,
+  allowMatureContentForCeiling,
+  domainBrowsingCeiling,
+  nsfwBrowsingLevelsFlag,
+  publicBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import { Flags } from '~/shared/utils/flags';
+
+/**
+ * App Blocks maturity policy — the single source of truth.
+ *
+ * `domainBrowsingCeiling` maps a color domain to the max browsing-level flag a
+ * block on that domain may render/generate. PRODUCT DECISION: green AND blue
+ * both clamp to SFW; only red permits mature. Unknown/missing domains fail
+ * CLOSED to SFW.
+ */
+describe('domainBrowsingCeiling', () => {
+  it('green → SFW (PG + PG13)', () => {
+    expect(domainBrowsingCeiling('green')).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('blue → SFW (product decision — deliberately NOT mature)', () => {
+    expect(domainBrowsingCeiling('blue')).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('blue maps to the SAME ceiling as green', () => {
+    expect(domainBrowsingCeiling('blue')).toBe(domainBrowsingCeiling('green'));
+  });
+
+  it('red → all browsing levels (no clamp)', () => {
+    expect(domainBrowsingCeiling('red')).toBe(allBrowsingLevelsFlag);
+  });
+
+  it('SFW ceiling contains NO nsfw bits', () => {
+    expect(Flags.intersects(domainBrowsingCeiling('green'), nsfwBrowsingLevelsFlag)).toBe(false);
+    expect(Flags.intersects(domainBrowsingCeiling('blue'), nsfwBrowsingLevelsFlag)).toBe(false);
+  });
+
+  it('red ceiling DOES contain nsfw bits', () => {
+    expect(Flags.intersects(domainBrowsingCeiling('red'), nsfwBrowsingLevelsFlag)).toBe(true);
+  });
+
+  it('fails CLOSED to SFW on undefined domain', () => {
+    expect(domainBrowsingCeiling(undefined)).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('fails CLOSED to SFW on null domain', () => {
+    expect(domainBrowsingCeiling(null)).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('fails CLOSED to SFW on an unknown domain value', () => {
+    // Cast through unknown — defends the runtime default branch even if a
+    // future caller passes a value outside the ColorDomain union.
+    expect(domainBrowsingCeiling('purple' as unknown as 'green')).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('the SFW ceiling is never the empty (0) flag — a clamp must always permit PG', () => {
+    expect(domainBrowsingCeiling(undefined)).not.toBe(0);
+    // PG must always be permitted on a SFW domain.
+    expect(Flags.intersects(domainBrowsingCeiling('green'), publicBrowsingLevelsFlag)).toBe(true);
+  });
+});
+
+describe('allowMatureContentForCeiling', () => {
+  it('SFW ceiling → false (block mature output)', () => {
+    expect(allowMatureContentForCeiling(sfwBrowsingLevelsFlag)).toBe(false);
+  });
+
+  it('PG-only ceiling → false', () => {
+    expect(allowMatureContentForCeiling(publicBrowsingLevelsFlag)).toBe(false);
+  });
+
+  it('all-levels ceiling → undefined (no clamp)', () => {
+    expect(allowMatureContentForCeiling(allBrowsingLevelsFlag)).toBeUndefined();
+  });
+
+  it('a ceiling carrying even a single nsfw bit → undefined (no clamp)', () => {
+    // NsfwLevel.R = 4 → mature allowed.
+    expect(allowMatureContentForCeiling(4)).toBeUndefined();
+  });
+
+  it('an empty (0) ceiling → false (most restrictive)', () => {
+    expect(allowMatureContentForCeiling(0)).toBe(false);
+  });
+
+  it('composes with domainBrowsingCeiling: green/blue → false, red → undefined', () => {
+    expect(allowMatureContentForCeiling(domainBrowsingCeiling('green'))).toBe(false);
+    expect(allowMatureContentForCeiling(domainBrowsingCeiling('blue'))).toBe(false);
+    expect(allowMatureContentForCeiling(domainBrowsingCeiling('red'))).toBeUndefined();
+    expect(allowMatureContentForCeiling(domainBrowsingCeiling(undefined))).toBe(false);
+  });
+});

--- a/src/shared/constants/browsingLevel.constants.ts
+++ b/src/shared/constants/browsingLevel.constants.ts
@@ -1,4 +1,5 @@
 import { NsfwLevel } from '~/server/common/enums';
+import type { ColorDomain } from '~/shared/constants/domain.constants';
 import { Flags } from '~/shared/utils/flags';
 
 export function parseBitwiseBrowsingLevel(level: number): number[] {
@@ -99,6 +100,54 @@ export const nsfwBrowsingLevelsFlag = flagifyBrowsingLevel(nsfwBrowsingLevelsArr
 
 // all browsing levels
 export const allBrowsingLevelsFlag = flagifyBrowsingLevel([...browsingLevels]);
+
+/**
+ * App Blocks maturity policy — the SINGLE SOURCE OF TRUTH mapping a color
+ * domain to the maximum browsing-level flag content rendered/generated inside a
+ * block on that domain may carry.
+ *
+ * PRODUCT DECISION (App-Blocks-scoped): BOTH `green` AND `blue` clamp to SFW
+ * (PG + PG-13); only `red` permits mature output. This DELIBERATELY differs
+ * from the site-wide `canViewNsfw` feature flag, which today is TRUE on `blue`
+ * (the main site treats blue as a mature domain). Blocks lead the platform
+ * here: until the site-wide blue→SFW flip lands as a separate platform change,
+ * the App-Blocks generation/catalog belts enforce blue=SFW on their own. Change
+ * the policy in ONE place — this function — and the token-mint claim, the
+ * generation clamp, the prompt-audit, and the BLOCK_INIT signal all follow.
+ *
+ * Returned value is a bitwise browsing-level flag (see `NsfwLevel`):
+ *   - green → SFW  (PG + PG-13)              `sfwBrowsingLevelsFlag`
+ *   - blue  → SFW  (PG + PG-13) [product]    `sfwBrowsingLevelsFlag`
+ *   - red   → all levels (no clamp)          `allBrowsingLevelsFlag`
+ *
+ * Unknown / undefined domain → FAIL CLOSED to SFW (the most restrictive
+ * non-empty ceiling). Callers must never widen on ambiguity.
+ */
+export function domainBrowsingCeiling(color: ColorDomain | undefined | null): number {
+  switch (color) {
+    case 'red':
+      return allBrowsingLevelsFlag;
+    case 'green':
+    case 'blue':
+      return sfwBrowsingLevelsFlag;
+    default:
+      // Fail closed: an unknown/missing domain gets the most restrictive ceiling.
+      return sfwBrowsingLevelsFlag;
+  }
+}
+
+/**
+ * Derive whether mature (NSFW) generation output is permitted for a given
+ * browsing-level ceiling. Mirrors the orchestrator's `allowMatureContent`
+ * semantics (orchestrator.router.ts): `false` hard-blocks mature output,
+ * `undefined` leaves it to the caller/orchestrator default (red domain).
+ *
+ * A ceiling that contains NO nsfw bits (SFW domains) → `false` (block mature).
+ * A ceiling that contains any nsfw bit (red) → `undefined` (no clamp).
+ */
+export function allowMatureContentForCeiling(maxBrowsingLevel: number): boolean | undefined {
+  return Flags.intersects(maxBrowsingLevel, nsfwBrowsingLevelsFlag) ? undefined : false;
+}
 
 // helpers
 export function onlySelectableLevels(level: number) {


### PR DESCRIPTION
## What & why

App Blocks GA safety gate. Apps must enforce the maturity of the **color domain** they render on: **RED = mature, BLUE + GREEN = SFW** (product decision). This is a SECURITY/SAFETY feature — the substance is the **authoritative server-side belt**: a block on a SFW domain must NOT be able to generate mature output, pick a mature resource, or surface mature showcase thumbnails — even if its client code is wrong or malicious.

Block-scoped: the main site's `canViewNsfw` / `applyDomainFeature` and the non-block generation/showcase paths are unchanged. Notably **blue is mature site-wide today** (`canViewNsfw` is true on blue); this feature makes **blocks** treat blue as SFW ahead of the platform — the site-wide blue→SFW flip is a separate platform change.

**Coverage at a glance (honest):**
- **Generation output** — authoritatively SFW-clamped on green/blue (the money/output belt).
- **Resource picker (server entitlement gate)** — SFW-clamped on green/blue (defense in depth — the page entitlement gate's `sfwOnly` forbids a SFW block from *picking* a mature resource at spend). NOTE: the picker *UI* the viewer browses is **not** SFW-clamped — see the MEDIUM-2 deferral below.
- **Showcase display surface** — NOW also clamped: a SFW-domain viewer can't pull mature thumbnails + prompt/seed meta into the iframe. Hardened (LOW-1) to derive the ceiling off the RAW request color (`getRequestDomainColor(req)` → unresolved host = `undefined` → fail-closed SFW) rather than the `?? 'blue'`-defaulted `ctx.domain`, so it stays fail-closed independent of a future blue→mature flip.
- **`/api/v1/models` REST catalog read** — **NOT covered yet** (Phase-3 follow-up): a SFW-domain block can still fetch mature thumbnails via the public REST endpoint until that lands. Display is therefore tightened, **not** fully covered.
- **Resource-picker UI maturity** — **NOT covered yet** (MEDIUM-2 follow-up, documented below): on a SFW block the native picker modal can still *show* mature resources (site-wide level inheritance), though every pick is re-gated SFW server-side. Not an iframe leak (name/id-only payload).

## The belt (authoritative)

1. **Single source of truth** — `domainBrowsingCeiling(color)` (`src/shared/constants/browsingLevel.constants.ts`): green/blue → `sfwBrowsingLevelsFlag` (PG+PG13), red → `allBrowsingLevelsFlag`. Unknown/undefined/null → **fail closed to SFW**. The whole policy flips from this one function if the platform later changes blue. Sibling `allowMatureContentForCeiling(flag)` derives the orchestrator's `allowMatureContent` (`false` on SFW, `undefined`/no-clamp on red).

2. **Stamped into the token AT MINT** (`src/pages/api/v1/block-tokens/index.ts`): `getRequestDomainColor(req)` → `domainBrowsingCeiling` → `maxBrowsingLevel` claim (plus advisory `domain`). The mint already reads the host for CORS; we reuse it. The claim is the maturity boundary for the token's 15-min lifetime. `verifyBlockToken` rejects a present-but-non-numeric claim (forge guard).

3. **Generation clamp — submit AND estimate** (`src/server/routers/blocks.router.ts`): `resolveBlockMaturity(claims)` derives `allowMatureContent` from the **token claim**, never from a client body field, and passes it into the `submitWorkflow`/whatif body (mirrors `orchestrator.router.ts`). The orchestrator hard-rejects mature output when `allowMatureContent: false`.
   - **Token-derived, not body-derived:** the workflow body schema (`z.object`) has no `allowMatureContent`/`nsfwLevel` field, so a malicious body field is stripped at the zod boundary AND the clamp reads the claim — a forged/replayed body cannot widen a SFW token. (Test asserts this.)
   - **Fail closed:** a token predating this change (no claim) resolves to the SFW ceiling.
   - Hardcoded prompt-audit `isGreen: false` is now domain/ceiling-derived, so a SFW-domain block's prompts get the SFW prompt audit.

4. **Resource-picker clamp** (`blocks.router.ts`, both page workflow call sites): the page resource-entitlement gate's `sfwOnly` now derives from the SAME authoritative maturity as the output clamp — `sfwOnly = (allowMatureContent === false)` from `resolveBlockMaturity(claims)` — instead of the request-time `ctx.domain === 'green'`. **Fixes** (a) blue being ignored (`ctx.domain === 'green'` left a blue block `sfwOnly:false`, so it could pick a mature resource, inconsistent with blue=SFW) and (b) keying off the request domain rather than the token claim. Now green AND blue → `sfwOnly:true`, red → false. A SFW block can't even pick a mature resource — defense in depth in front of the output clamp.

5. **Showcase display-surface clamp** (`src/server/services/blocks/showcase.service.ts`): `resolveAllowedBrowsingLevel` previously honored a logged-in viewer's client-supplied `browsingLevel` (capped only by `onlySelectableLevels`, which keeps R/X/XXX) with **no** color-domain clamp — so a viewer on a green/blue block could request `browsingLevel:31` and get mature image URLs + prompt/seed meta posted into the third-party iframe (`BLOCK_INIT.context.showcaseImages`). The effective level is now **intersected** with `domainBrowsingCeiling(ctx.domain)` (`Flags.intersection`): green/blue/unknown fail closed to SFW, red unclamped. `getShowcaseImages` is a public read with no block-token claim handy, so request-time `ctx.domain` is the authority for this read (threaded through from the router). Anon viewers were already forced to public; the intersection only ever tightens a logged-in view.

## Advisory BLOCK_INIT signal

`projectBlockInitMaturity()` (`projectBlockInit.ts`) projects `domain` + `maxBrowsingLevel` onto `BlockInitPayload` (server-authoritative values from the mint, forwarded by the host through `useBlockToken` → IframeHost/PageBlockHost). Lets blocks self-filter their catalog reads / blur mature thumbnails.

**For the SDK follow-up PR** — the new BLOCK_INIT fields:
```ts
// BlockInitPayload
domain?: 'green' | 'blue' | 'red' | null;
maxBrowsingLevel?: number; // bitwise browsing-level flag; undefined → SDK fails closed
```
The planned `useDomainMaturity()` hook should treat `maxBrowsingLevel === undefined` as the most restrictive (SFW).

## Deferred — Phase 3 `/api/v1/models` REST catalog clamp (design only, NOT in this PR)

The `/api/v1/models` REST endpoint blocks call directly (`src/pages/api/v1/models/index.ts`) skips the tRPC/showcase domain clamp, so on a SFW domain a block could still **fetch** mature thumbnails via the public catalog. Fixing it authoritatively means clamping by request Host (or routing block catalog reads through the color-specific host), which has cache-key impact and is a public-API contract change beyond blocks — higher blast radius, so it stays a documented follow-up. **Design:** add a Host→ceiling clamp at the REST `/api/v1/models` boundary (intersect the request's `browsingLevel`/nsfw filter with `domainBrowsingCeiling(getRequestDomainColor(req))`), with a separate cache-key dimension per color so a SFW response can't be served from a mature cache entry.

## Deferred — MEDIUM-2 native resource-picker UI SFW clamp (documented, NOT in this PR)

The native resource-select modal opened from `PageBlockHost` `OPEN_RESOURCE_PICKER` and `IframeHost` `OPEN_CHECKPOINT_PICKER` (`openResourceSelectModal`) inherits the **site-wide** browsing level (where blue = mature) for its NSFW filtering, so on a SFW (blue/green) block the picker UI can still **surface** mature resources even though generation is SFW-clamped. This is **not an iframe leak**: the `RESOURCE_PICKER_RESULT` / `CHECKPOINT_PICKER_RESULT` payload is name/id-only (no thumbnails or meta), and every picked id is re-gated SFW server-side at estimate/submit (`assertViewerCanGeneratePageResources` + `domainBrowsingCeiling` off the raw request color) before any spend — it's an inconsistent SFW *experience*, not a content escape.

**Why deferred:** `ResourceSelectOptions` (`resource-select.types.ts`) exposes no browsing-level / `sfwOnly` / nsfw constraint — only `canGenerate`, `resources`, `excludeIds`. NSFW filtering is done purely client-side in the shared `ResourceHitList` via `useApplyHiddenPreferences`, which defaults to the site-wide `useBrowsingLevelDebounced()` context (the Meili query in `useResourceSelectFilters` doesn't filter by browsing level at all). Wiring a block-SFW ceiling would require adding a new option to `ResourceSelectOptions`, threading it through `ResourceSelectProvider` / `useResourceSelectContext` to that `useApplyHiddenPreferences` call — modifying the shared modal's filtering internals (affects every generation-form picker, higher blast radius) — and even then the hook's `isModerator && nsfwLevel===0` carve-out leaves gaps for the currently mod-gated audience. Deferred with a precise code comment at both call sites (same bucket as the Phase-3 REST clamp).

Until both deferrals land, **display is tightened (showcase fail-closed off the raw color), not fully covered (REST catalog read + native picker UI).**

## Fail-closed summary

Missing claim → SFW. Unknown domain → SFW. Non-numeric/NaN claim → token rejected. No ambiguity widens maturity — on the generation, resource-picker, and showcase paths.

## Verification (honest)

- `pnpm typecheck` — exit 0 (full project).
- `pnpm vitest run` on the touched + sibling suites — green.
  - `domainBrowsingCeiling`/`allowMatureContentForCeiling`: green/blue→SFW, red→all, fail-closed.
  - Token mint stamps the ceiling (green/blue→SFW, red→mature); omits on legacy; rejects forged non-numeric claim.
  - Submit + estimate: green AND blue tokens force `allowMatureContent=false` into the submitWorkflow body (asserted on the value passed to `submitWorkflow`, derived from the claim); a malicious body can't widen; red allows mature; legacy fails closed.
  - **Resource picker:** a SFW token maturity claim (green/blue) → `sfwOnly:true` into `resolveCanGenerateForVersions` (not request-domain-derived); a red claim → `sfwOnly:false`. Blue regression guard asserts `sfwOnly:true`.
  - **Showcase:** green AND blue viewer with `browsingLevel:31` → result clamped to SFW (no R/X/XXX images/meta); red → unclamped; unknown/missing domain → fail-closed SFW; anon on red → still public-capped. (Two pre-existing viewer-level tests pinned to `domain:'red'` to isolate the viewer dimension from the new domain clamp.) **LOW-1:** a test stubs `domainBrowsingCeiling` so blue→all-levels and proves an `undefined` domain still clamps to SFW (with an explicit-blue control that widens under the same stub) — the showcase fail-closed holds independent of blue's mapping.
  - prompt-audit `isGreen` domain-derived; BLOCK_INIT projection.
  - Full blocks router + services suites (636 tests) green after the changes.
- **Not** browser/e2e verified (CI is report-only; ran tests locally). The orchestrator's actual rejection of `allowMatureContent:false` is exercised by the orchestrator, not re-tested here — this PR proves the flag/ceiling is correctly derived and passed/intersected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

