### PR TITLE
fix(redis): fire cluster self-heal on deadline-hit RATE so a half-open park self-clears (#2665 follow-up)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -215,6 +215,24 @@ export const serverSchema = z.object({
   // trigger (falls back to the inflight-continuity path only).
   REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD: z.coerce.number().default(10),
   REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS: z.coerce.number().default(20000),
+  // ── PER-POD RECONNECT JITTER (fleet-stampede brake) ──────────────────────────────
+  //
+  // The deadline-hit trigger fires within seconds of a half-open park. That's the point
+  // for a pod-LOCAL wedge, but it has a correlated-failure edge: if next-redis-cluster
+  // ITSELF has a genuine >=15s event (master failover, network blip), EVERY pod's cluster
+  // commands deadline-reject at once → the whole fleet (~80-100 pods) trips the deadline-hit
+  // trigger inside the same ~1s watchdog tick and fires forceClusterReconnect (destroy() +
+  // connect()) simultaneously → a connection thundering-herd against an already-unhealthy
+  // cluster, right when it can least absorb it.
+  //
+  // This spreads each pod's reconnect over a random [0, jitter) delay AFTER the trigger
+  // decision (the cooldown/single-flight guards are taken up front, so the jitter cannot
+  // queue a second reconnect or restart the cooldown). A synchronized fleet event then
+  // smears its reconnects across the jitter window instead of all landing on one tick.
+  // 0 disables jitter (reconnect fires immediately — the prior behavior). 1000ms (1s) is
+  // ~the watchdog tick, enough to de-correlate the fleet without materially delaying a
+  // single-pod self-heal (1s on top of the multi-second deadline-hit accumulation).
+  REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS: z.coerce.number().default(1000),
 
   // ── METRIC WRITE/LOCK FAIL-SOFT DEADLINE (FIX #3) ───────────────────────────────
   //

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -193,6 +193,28 @@ export const serverSchema = z.object({
   // How often the watchdog samples inflight. Cheap (one gauge read), so a tight 1s
   // sample keeps the sustained-window measurement accurate without overhead.
   REDIS_CLUSTER_SELFHEAL_CHECK_INTERVAL_MS: z.coerce.number().default(1000),
+  // ── DEADLINE-HIT TRIGGER (the sawtooth-immune self-heal signal) ──────────────────
+  //
+  // The inflight-continuity trigger above CANNOT fire during a real half-open park: the
+  // per-command deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS = 15s) mass-rejects the parked
+  // commands every ~15s, so inflight SAWTOOTHS to ~0 and the sustained-breach timer
+  // (REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS = 20s > 15s) resets before it ever accumulates.
+  // Confirmed live: 21 pods wedged to inflight≈200 for 6–12 min with
+  // civitai_app_redis_selfheal_reconnect_total = 0 across the whole fleet.
+  //
+  // The fix triggers self-heal on a signal the deadline-drain can't erase: the RATE of
+  // deadline TIMEOUTS. A healthy cluster client hits the 15s deadline ZERO times in any
+  // window (healthy p99 ≈ 23ms); a half-open client hits it on ~every command (the drains
+  // ARE the hits). So "N deadline timeouts within W ms" is a monotonic, sawtooth-immune
+  // "this client is wedged" signal that fires within seconds of a park — well inside the
+  // ~60s kubelet readiness-shed threshold, instead of never.
+  //
+  // Default 10 hits within 20000ms (20s): a half-open pool serving even modest traffic
+  // produces dozens–hundreds of 15s deadline rejects in a 20s window, so 10 trips fast;
+  // a one-off transient slow command (a single hit) never reaches 10. 0 disables this
+  // trigger (falls back to the inflight-continuity path only).
+  REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD: z.coerce.number().default(10),
+  REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS: z.coerce.number().default(20000),
 
   // ── METRIC WRITE/LOCK FAIL-SOFT DEADLINE (FIX #3) ───────────────────────────────
   //

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -235,9 +235,14 @@ export const cacheFailOpenOriginFetchCounter = registerCounterWithLabels({
 // human rolling-restart). Pair with redis_commands_inflight on a dashboard to see the
 // pin → reconnect → drain. No labels (per-pod attribution comes from the Prometheus `pod`
 // label); cardinality is 1 series.
-export const redisSelfHealReconnectCounter = registerCounter({
+// `trigger` distinguishes the two watchdog paths: 'deadline' = the sawtooth-immune
+// deadline-hit-rate trigger (the one that actually fires during a real fleet half-open wave —
+// see cluster-selfheal.ts), 'inflight' = the legacy sustained-inflight breach. At the next prod
+// wave, a rising deadline-labeled series is the confirmation that the fix worked. 2 series.
+export const redisSelfHealReconnectCounter = registerCounterWithLabels({
   name: 'redis_selfheal_reconnect_total',
   help: 'Forced cluster-client reconnects by the inflight-leak self-heal watchdog',
+  labelNames: ['trigger'] as const,
 });
 
 // Non-critical metric WRITE/LOCK fail-soft counter (FIX #3). Incremented when a

--- a/src/server/redis/__tests__/cluster-deadline-hits.test.ts
+++ b/src/server/redis/__tests__/cluster-deadline-hits.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  countClusterDeadlineHits,
+  recordClusterDeadlineHit,
+  resetClusterDeadlineHits,
+} from '../cluster-deadline-hits';
+
+// cluster-deadline-hits is the sliding-window recorder of CLUSTER command-deadline TIMEOUTS —
+// the sawtooth-immune self-heal trigger signal. A healthy client records ZERO hits; a half-open
+// client records one per deadline-rejected command. The watchdog samples a windowed count.
+// Module-scoped state → reset before each test.
+
+describe('cluster-deadline-hits', () => {
+  beforeEach(() => resetClusterDeadlineHits());
+
+  it('counts hits recorded inside the window', () => {
+    recordClusterDeadlineHit(1000);
+    recordClusterDeadlineHit(1500);
+    recordClusterDeadlineHit(2000);
+    // window covering [1000..2000] from now=2000, windowMs=2000 → cutoff=0, all 3 counted
+    expect(countClusterDeadlineHits(2000, 2000)).toBe(3);
+  });
+
+  it('excludes hits older than the window (strictly greater than cutoff)', () => {
+    recordClusterDeadlineHit(0);
+    recordClusterDeadlineHit(5000);
+    recordClusterDeadlineHit(9000);
+    // now=10000, windowMs=2000 → cutoff=8000 → only the 9000 hit counts
+    expect(countClusterDeadlineHits(2000, 10000)).toBe(1);
+  });
+
+  it('returns 0 for a healthy client (no hits recorded)', () => {
+    expect(countClusterDeadlineHits(20000, 50000)).toBe(0);
+  });
+
+  it('reset clears the window', () => {
+    recordClusterDeadlineHit(1000);
+    recordClusterDeadlineHit(1100);
+    expect(countClusterDeadlineHits(10000, 2000)).toBe(2);
+    resetClusterDeadlineHits();
+    expect(countClusterDeadlineHits(10000, 2000)).toBe(0);
+  });
+
+  it('bounds memory: keeps counting recent hits even past the ring capacity', () => {
+    // Record far more than RING_CAPACITY (512) hits, all within the window. The ring overwrites
+    // the oldest, but the count is capped at capacity — which is far above any trigger threshold,
+    // so the wedge is still detected. This proves a sustained wedge can't grow memory unbounded.
+    const now = 1_000_000;
+    for (let i = 0; i < 2000; i++) recordClusterDeadlineHit(now);
+    const count = countClusterDeadlineHits(20000, now + 1);
+    expect(count).toBeGreaterThanOrEqual(512); // saturated at capacity
+    expect(count).toBeLessThanOrEqual(512); // never exceeds capacity (bounded)
+  });
+
+  it('a sustained wedge keeps the windowed count high even as old hits age out', () => {
+    // Hits arriving steadily: at t=20000 with windowMs=10000, only hits in (10000,20000] count.
+    for (let t = 0; t <= 20000; t += 1000) recordClusterDeadlineHit(t);
+    // hits at 11000..20000 = 10 of them
+    expect(countClusterDeadlineHits(10000, 20000)).toBe(10);
+  });
+});

--- a/src/server/redis/__tests__/cluster-selfheal.test.ts
+++ b/src/server/redis/__tests__/cluster-selfheal.test.ts
@@ -21,12 +21,25 @@ const DEFAULTS: ClusterSelfHealConfig = {
   // below are unaffected; the deadline-trigger tests opt in explicitly.
   deadlineHitThreshold: 0,
   deadlineHitWindowMs: 20000,
+  // Default jitter OFF so every existing test fires the reconnect immediately (back-compat);
+  // the jitter tests opt in explicitly and inject a deterministic clock + delay.
+  reconnectJitterMs: 0,
 };
 
 /** Test harness: a controllable clock + inflight value + spy reconnect/onReconnect. */
 function makeHarness(
   cfg: Partial<ClusterSelfHealConfig> = {},
-  opts: { reconnect?: () => Promise<void> } = {}
+  opts: {
+    reconnect?: () => Promise<void>;
+    /** Fixed value [0,1) the watchdog's `random()` returns (for deterministic jitter). */
+    random?: number;
+    /**
+     * When true, the injected `delay` does NOT auto-resolve — each call is parked and only
+     * settles when the test calls `releaseDelays()`. Lets us prove the reconnect is held during
+     * the jitter window and that a mid-delay tick single-flights out.
+     */
+    manualDelay?: boolean;
+  } = {}
 ) {
   let nowMs = 0;
   let inflight = 0;
@@ -37,6 +50,14 @@ function makeHarness(
     deadlineHits = 0;
   });
   const log = vi.fn();
+  // Records every requested jitter delay; in manualDelay mode each is held until released.
+  const delayCalls: number[] = [];
+  const pendingResolvers: Array<() => void> = [];
+  const delay = vi.fn((ms: number) => {
+    delayCalls.push(ms);
+    if (!opts.manualDelay) return Promise.resolve();
+    return new Promise<void>((r) => pendingResolvers.push(r));
+  });
   const deps: ClusterSelfHealDeps = {
     getInflight: () => inflight,
     getDeadlineHits: () => deadlineHits,
@@ -45,6 +66,8 @@ function makeHarness(
     now: () => nowMs,
     log,
     onReconnect,
+    delay,
+    random: () => opts.random ?? 0,
   };
   const watchdog = new ClusterSelfHealWatchdog({ ...DEFAULTS, ...cfg }, deps);
   return {
@@ -53,6 +76,13 @@ function makeHarness(
     onReconnect,
     resetDeadlineHits,
     log,
+    delay,
+    delayCalls,
+    /** Resolve all parked manual-delay promises (the jitter windows elapse). */
+    releaseDelays: () => {
+      const rs = pendingResolvers.splice(0);
+      rs.forEach((r) => r());
+    },
     setInflight: (v: number) => (inflight = v),
     setDeadlineHits: (v: number) => (deadlineHits = v),
     advance: (ms: number) => (nowMs += ms),
@@ -325,6 +355,81 @@ describe('ClusterSelfHealWatchdog', () => {
     // Reported as the legacy 'inflight' trigger (no deadline hits) → metric label distinguishes it.
     expect(h.onReconnect).toHaveBeenCalledWith(expect.any(Number), 'inflight');
     await flush();
+  });
+
+  // ── PER-POD RECONNECT JITTER (fleet-stampede brake) ────────────────────────────────
+
+  it('JITTER: delays the actual reconnect by a random [0, jitterMs) before calling reconnect()', async () => {
+    // random()=0.5, jitterMs=1000 → floor(0.5 * 1000) = 500ms delay. With manualDelay the
+    // reconnect stays UN-called until the jitter window is released, proving the delay precedes
+    // the destroy()+connect() (the fleet-stampede smear).
+    const h = makeHarness(
+      { deadlineHitThreshold: 10, deadlineHitWindowMs: 20000, reconnectJitterMs: 1000 },
+      { random: 0.5, manualDelay: true }
+    );
+    h.setDeadlineHits(25); // trip the deadline trigger
+
+    expect(h.watchdog.tick()).toBe(true);
+    // The trigger DECISION happened (guards taken, onReconnect emitted) but the reconnect is
+    // still parked behind the jitter delay.
+    expect(h.onReconnect).toHaveBeenCalledTimes(1);
+    expect(h.delay).toHaveBeenCalledTimes(1);
+    expect(h.delayCalls[0]).toBe(500); // floor(0.5 * 1000)
+    expect(h.delayCalls[0]).toBeLessThan(1000); // strictly within [0, jitterMs)
+    expect(h.reconnect).not.toHaveBeenCalled(); // NOT yet — held by the jitter window
+    // Single-flight + cooldown guards are already in place during the delay.
+    expect(h.watchdog.getState().reconnecting).toBe(true);
+    expect(h.watchdog.getState().lastReconnectAt).toBe(0); // cooldown clock starts at decision time
+
+    // Jitter window elapses → the reconnect finally fires, then reconnecting clears.
+    h.releaseDelays();
+    await flush();
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    expect(h.watchdog.getState().reconnecting).toBe(false);
+  });
+
+  it('JITTER=0: fires the reconnect immediately (back-compat — no delay path at all)', async () => {
+    // jitterMs=0 → delay() is never called; reconnect() is invoked SYNCHRONOUSLY within tick(),
+    // exactly the prior behavior (the existing suite relies on this synchronous call).
+    const h = makeHarness({ deadlineHitThreshold: 10, deadlineHitWindowMs: 20000, reconnectJitterMs: 0 });
+    h.setDeadlineHits(25);
+
+    expect(h.watchdog.tick()).toBe(true);
+    expect(h.delay).not.toHaveBeenCalled(); // no jitter → no delay step
+    expect(h.reconnect).toHaveBeenCalledTimes(1); // called synchronously, not deferred
+    await flush();
+    expect(h.watchdog.getState().reconnecting).toBe(false);
+  });
+
+  it('JITTER single-flight: a second tick DURING the jitter delay does NOT schedule a second reconnect', async () => {
+    // The single-flight guard (reconnecting=true) is taken at DECISION time, before the jitter
+    // delay — so a watchdog tick that fires while the first reconnect is still parked behind its
+    // jitter window must be a no-op. This is the correlated-fleet correctness property: the delay
+    // must NOT open a window where the wedge re-counts and double-fires.
+    const h = makeHarness(
+      { deadlineHitThreshold: 10, deadlineHitWindowMs: 20000, reconnectJitterMs: 1000 },
+      { random: 0.9, manualDelay: true } // floor(0.9*1000)=900ms, held open
+    );
+    h.setDeadlineHits(100); // stays wedged across both ticks
+
+    expect(h.watchdog.tick()).toBe(true); // first trigger → parked behind jitter
+    expect(h.delay).toHaveBeenCalledTimes(1);
+    expect(h.reconnect).not.toHaveBeenCalled();
+
+    // Tick again mid-jitter (still wedged). Must single-flight out: no second delay, no second
+    // reconnect, no second onReconnect/resetDeadlineHits.
+    h.advance(500); // partway through the 900ms jitter window
+    expect(h.watchdog.tick()).toBe(false);
+    expect(h.delay).toHaveBeenCalledTimes(1);
+    expect(h.onReconnect).toHaveBeenCalledTimes(1);
+    expect(h.resetDeadlineHits).toHaveBeenCalledTimes(1);
+    expect(h.reconnect).not.toHaveBeenCalled();
+
+    // Release the (single) jitter window → exactly ONE reconnect total.
+    h.releaseDelays();
+    await flush();
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    expect(h.watchdog.getState().reconnecting).toBe(false);
   });
 
   it('tick() never throws even if the onReconnect hook throws, and still reconnects', async () => {

--- a/src/server/redis/__tests__/cluster-selfheal.test.ts
+++ b/src/server/redis/__tests__/cluster-selfheal.test.ts
@@ -17,6 +17,10 @@ const DEFAULTS: ClusterSelfHealConfig = {
   inflightThreshold: 50,
   sustainedMs: 20000,
   cooldownMs: 60000,
+  // Default the deadline-hit trigger OFF in this harness so the legacy inflight-path tests
+  // below are unaffected; the deadline-trigger tests opt in explicitly.
+  deadlineHitThreshold: 0,
+  deadlineHitWindowMs: 20000,
 };
 
 /** Test harness: a controllable clock + inflight value + spy reconnect/onReconnect. */
@@ -26,11 +30,17 @@ function makeHarness(
 ) {
   let nowMs = 0;
   let inflight = 0;
+  let deadlineHits = 0;
   const reconnect = vi.fn(opts.reconnect ?? (() => Promise.resolve()));
   const onReconnect = vi.fn();
+  const resetDeadlineHits = vi.fn(() => {
+    deadlineHits = 0;
+  });
   const log = vi.fn();
   const deps: ClusterSelfHealDeps = {
     getInflight: () => inflight,
+    getDeadlineHits: () => deadlineHits,
+    resetDeadlineHits,
     reconnect,
     now: () => nowMs,
     log,
@@ -41,8 +51,10 @@ function makeHarness(
     watchdog,
     reconnect,
     onReconnect,
+    resetDeadlineHits,
     log,
     setInflight: (v: number) => (inflight = v),
+    setDeadlineHits: (v: number) => (deadlineHits = v),
     advance: (ms: number) => (nowMs += ms),
     setNow: (ms: number) => (nowMs = ms),
     now: () => nowMs,
@@ -78,8 +90,9 @@ describe('ClusterSelfHealWatchdog', () => {
     expect(h.watchdog.tick()).toBe(true);
     expect(h.reconnect).toHaveBeenCalledTimes(1);
     expect(h.onReconnect).toHaveBeenCalledTimes(1);
-    // onReconnect carries the inflight value at trigger time (for the Prom counter/Loki line).
-    expect(h.onReconnect).toHaveBeenCalledWith(500);
+    // onReconnect carries the inflight value at trigger time + which trigger fired (for the
+    // Prom counter label / Loki line). This is the legacy sustained-inflight path → 'inflight'.
+    expect(h.onReconnect).toHaveBeenCalledWith(500, 'inflight');
 
     await flush(); // let the fire-and-forget reconnect settle
   });
@@ -187,6 +200,130 @@ describe('ClusterSelfHealWatchdog', () => {
     const firesAgain = runFor(h, DEFAULTS.sustainedMs + 2000, 1000);
     expect(firesAgain).toBe(1);
     expect(h.reconnect).toHaveBeenCalledTimes(2);
+    await flush();
+  });
+
+  // ── DEADLINE-HIT TRIGGER (the fix for the real-wave non-firing bug) ────────────────
+
+  it('REGRESSION: a sawtoothing inflight (deadline drains it every ~15s) never fires the inflight trigger', () => {
+    // Reproduces the live bug: the 15s command deadline mass-rejects parked commands, so
+    // inflight crashes below the threshold within each 20s sustained window → breachStartedAt
+    // keeps resetting → the inflight trigger can NEVER accumulate. Deadline trigger OFF here to
+    // isolate the inflight path. Simulate the sawtooth: ~14s pinned high, then a 1s crash to 0.
+    const h = makeHarness({ deadlineHitThreshold: 0 });
+    let fires = 0;
+    for (let cycle = 0; cycle < 10; cycle++) {
+      h.setInflight(200);
+      for (let t = 0; t < 14000; t += 1000) {
+        if (h.watchdog.tick()) fires++;
+        h.advance(1000);
+      }
+      // Deadline batch rejects → inflight crashes below threshold for one sample.
+      h.setInflight(0);
+      if (h.watchdog.tick()) fires++;
+      h.advance(1000);
+    }
+    // ~150s of a real half-open wedge, zero reconnects — exactly the observed prod behavior.
+    expect(fires).toBe(0);
+    expect(h.reconnect).not.toHaveBeenCalled();
+  });
+
+  it('FIX: the deadline-hit trigger fires on the SAME sawtoothing wedge, regardless of inflight dips', async () => {
+    // Same sawtooth, but now the deadline-hit trigger is armed (the drains ARE the hits, so the
+    // hit count stays high even while inflight dips). It must fire on the very first tick once
+    // the hit count is at/above threshold, without needing any inflight continuity.
+    const h = makeHarness({ deadlineHitThreshold: 10, deadlineHitWindowMs: 20000 });
+    h.setInflight(0); // inflight can be ANYTHING — deadline trigger is independent of it
+    h.setDeadlineHits(25); // 25 deadline timeouts in the last 20s window >= 10
+
+    expect(h.watchdog.tick()).toBe(true);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    expect(h.onReconnect).toHaveBeenCalledTimes(1);
+    // onReconnect is told WHICH trigger fired so client.ts emits the `trigger="deadline"`
+    // metric label — the series we watch at the next prod wave to confirm THIS path fired.
+    expect(h.onReconnect).toHaveBeenCalledWith(expect.any(Number), 'deadline');
+    // The window is cleared on trigger so the same pre-heal hits can't immediately re-fire.
+    expect(h.resetDeadlineHits).toHaveBeenCalledTimes(1);
+    await flush();
+  });
+
+  it('does NOT fire the deadline trigger below the hit threshold (a one-off transient slow command)', () => {
+    const h = makeHarness({ deadlineHitThreshold: 10, deadlineHitWindowMs: 20000 });
+    h.setInflight(0);
+    h.setDeadlineHits(9); // one short of the threshold
+    const fires = runFor(h, DEFAULTS.sustainedMs * 3, 1000);
+    expect(fires).toBe(0);
+    expect(h.reconnect).not.toHaveBeenCalled();
+  });
+
+  it('deadline trigger respects the cooldown (one reconnect per cooldown even while hits stay high)', async () => {
+    const h = makeHarness({ deadlineHitThreshold: 10, deadlineHitWindowMs: 20000 });
+    h.setInflight(0);
+    h.setDeadlineHits(100); // stays wedged
+
+    expect(h.watchdog.tick()).toBe(true);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    await flush();
+
+    // resetDeadlineHits zeroed the window; the wedge keeps producing hits, re-arming it.
+    h.setDeadlineHits(100);
+    // Within the cooldown: no second reconnect.
+    const firesDuringCooldown = runFor(h, DEFAULTS.cooldownMs, 1000);
+    expect(firesDuringCooldown).toBe(0);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+
+    // Past the cooldown, still wedged → exactly one more.
+    h.setDeadlineHits(100);
+    const firesAfter = runFor(h, 3000, 1000);
+    expect(firesAfter).toBe(1);
+    expect(h.reconnect).toHaveBeenCalledTimes(2);
+    await flush();
+  });
+
+  it('deadline trigger is inert when its threshold is 0 (falls back to the inflight path only)', () => {
+    const h = makeHarness({ deadlineHitThreshold: 0 });
+    h.setInflight(0);
+    h.setDeadlineHits(100000); // enormous, but the trigger is disabled
+    const fires = runFor(h, DEFAULTS.sustainedMs * 3, 1000);
+    expect(fires).toBe(0);
+    expect(h.reconnect).not.toHaveBeenCalled();
+  });
+
+  it('deadline trigger is inert when getDeadlineHits dep is omitted (back-compat)', () => {
+    // A caller (or older test) that doesn't supply getDeadlineHits must behave as before.
+    let nowMs = 0;
+    let inflight = 0;
+    const reconnect = vi.fn(() => Promise.resolve());
+    const deps: ClusterSelfHealDeps = {
+      getInflight: () => inflight,
+      reconnect,
+      now: () => nowMs,
+      log: vi.fn(),
+      onReconnect: vi.fn(),
+    };
+    const watchdog = new ClusterSelfHealWatchdog(
+      { ...DEFAULTS, deadlineHitThreshold: 10 },
+      deps
+    );
+    inflight = 0; // inflight path never trips
+    for (let t = 0; t < DEFAULTS.sustainedMs * 3; t += 1000) {
+      watchdog.tick();
+      nowMs += 1000;
+    }
+    expect(reconnect).not.toHaveBeenCalled();
+  });
+
+  it('still fires the inflight trigger when inflight genuinely stays pinned (no deadline drain)', async () => {
+    // Belt-and-suspenders: a wedge that leaks inflight WITHOUT deadline-rejecting (e.g. deadline
+    // disabled) must still be caught by the legacy continuous-breach path.
+    const h = makeHarness({ deadlineHitThreshold: 10 });
+    h.setInflight(200); // pinned, never dips
+    h.setDeadlineHits(0); // no deadline hits at all
+    runFor(h, DEFAULTS.sustainedMs, 1000);
+    expect(h.watchdog.tick()).toBe(true);
+    expect(h.reconnect).toHaveBeenCalledTimes(1);
+    // Reported as the legacy 'inflight' trigger (no deadline hits) → metric label distinguishes it.
+    expect(h.onReconnect).toHaveBeenCalledWith(expect.any(Number), 'inflight');
     await flush();
   });
 

--- a/src/server/redis/__tests__/command-deadline.test.ts
+++ b/src/server/redis/__tests__/command-deadline.test.ts
@@ -57,6 +57,36 @@ describe('withCommandDeadline', () => {
     await expect(withCommandDeadline(resolveAfter(30, 'late'), 0)).resolves.toBe('late');
   });
 
+  it('invokes onTimeout exactly once when the deadline fires (the self-heal trigger signal)', async () => {
+    const onTimeout = vi.fn();
+    await expect(withCommandDeadline(never(), 20, onTimeout)).rejects.toThrow(/timed out/);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT invoke onTimeout when the command settles before the deadline (healthy)', async () => {
+    const onTimeout = vi.fn();
+    await expect(withCommandDeadline(resolveAfter(5, 'ok'), 100, onTimeout)).resolves.toBe('ok');
+    await new Promise((r) => setTimeout(r, 120)); // outlive the deadline window
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invoke onTimeout when a real rejection arrives before the deadline', async () => {
+    const onTimeout = vi.fn();
+    await expect(
+      withCommandDeadline(rejectAfter(5, new Error('ClientClosedError')), 100, onTimeout)
+    ).rejects.toThrow('ClientClosedError');
+    await new Promise((r) => setTimeout(r, 120));
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('a throwing onTimeout hook does not break the deadline guard (still rejects with timeout)', async () => {
+    const onTimeout = vi.fn(() => {
+      throw new Error('recorder boom');
+    });
+    await expect(withCommandDeadline(never(), 20, onTimeout)).rejects.toThrow(/timed out/);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
   it('does not emit an unhandledRejection when the orphaned command rejects after the deadline fired', async () => {
     const onUnhandled = vi.fn();
     process.on('unhandledRejection', onUnhandled);

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -10,12 +10,18 @@ import { slugit } from '~/utils/string-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { withCommandDeadline } from '~/server/redis/command-deadline';
 import { ClusterSelfHealWatchdog } from '~/server/redis/cluster-selfheal';
+import type { ClusterSelfHealTrigger } from '~/server/redis/cluster-selfheal';
 import {
   decClusterInflight,
   getClusterInflight,
   incClusterInflight,
   resetClusterInflight,
 } from '~/server/redis/cluster-inflight';
+import {
+  countClusterDeadlineHits,
+  recordClusterDeadlineHit,
+  resetClusterDeadlineHits,
+} from '~/server/redis/cluster-deadline-hits';
 import { compressPacked, decompressPacked } from '~/server/redis/packed-compression';
 // NOTE: do NOT statically import the redis prom metrics from '~/server/prom/client'.
 // This module is client-bundle-reachable (`_app.tsx` → `system-cache.ts` → here),
@@ -413,15 +419,22 @@ function startClusterSelfHeal(
       inflightThreshold: env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD,
       sustainedMs: env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS,
       cooldownMs: env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS,
+      deadlineHitThreshold: env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD,
+      deadlineHitWindowMs: env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS,
     },
     {
       getInflight: () => getClusterInflight(),
+      getDeadlineHits: (windowMs: number) => countClusterDeadlineHits(windowMs),
+      resetDeadlineHits: () => resetClusterDeadlineHits(),
       reconnect: () => forceClusterReconnect(clusterClient, reSetupFailover),
       log,
-      onReconnect: (inflightAtTrigger: number) => {
-        getRedisMetrics()?.redisSelfHealReconnectCounter?.inc();
+      onReconnect: (inflightAtTrigger: number, trigger: ClusterSelfHealTrigger) => {
+        // Labeled by trigger so a rising `trigger="deadline"` series at the next prod wave is the
+        // direct confirmation that the fix's new path fired (the one the inflight path could
+        // never reach). See cluster-selfheal.ts and prom/client.ts.
+        getRedisMetrics()?.redisSelfHealReconnectCounter?.inc({ trigger });
         log(
-          `Cluster self-heal RECONNECT fired [inflight=${inflightAtTrigger}, threshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}]`
+          `Cluster self-heal RECONNECT fired [trigger=${trigger}, inflight=${inflightAtTrigger}, inflightThreshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}, deadlineHitThreshold=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD}, deadlineHitWindowMs=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS}]`
         );
       },
     }
@@ -443,7 +456,7 @@ function startClusterSelfHeal(
   // Don't keep the event loop alive for the watchdog on a graceful process exit.
   clusterSelfHealInterval.unref?.();
   log(
-    `Cluster self-heal watchdog ENABLED [threshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}, cooldownMs=${env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS}, checkMs=${interval}]`
+    `Cluster self-heal watchdog ENABLED [inflightThreshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}, deadlineHitThreshold=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD}, deadlineHitWindowMs=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS}, cooldownMs=${env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS}, checkMs=${interval}]`
   );
   return watchdog;
 }
@@ -930,11 +943,11 @@ type RedisMetricsBridge = {
   // reachable module. attachSysSentinelListeners reads them at attach time.
   sysredisSentinelTopologyChangesCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
   sysredisSentinelClientErrorsCounter: { labels: (labels: Record<string, string>) => { inc: () => void } };
-  // FIX #1 self-heal reconnect counter (no labels) + FIX #3 metric-write fail-soft counter.
-  // Read via the globalThis bridge so this client-bundle-reachable module avoids a static
-  // prom-client import (which drags in fs/cluster). Both may be undefined until prom/client
-  // loads server-side; callers null-check.
-  redisSelfHealReconnectCounter?: { inc: () => void };
+  // FIX #1 self-heal reconnect counter (labeled by `trigger`: 'deadline' | 'inflight') + FIX #3
+  // metric-write fail-soft counter. Read via the globalThis bridge so this client-bundle-
+  // reachable module avoids a static prom-client import (which drags in fs/cluster). Both may be
+  // undefined until prom/client loads server-side; callers null-check.
+  redisSelfHealReconnectCounter?: { inc: (labels: { trigger: string }) => void };
   redisMetricWriteFailSoftCounter?: { labels: (labels: { op: string }) => { inc: () => void } };
 };
 
@@ -1008,7 +1021,7 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     // the sys client (wrapWithDeadline=false). withCommandDeadline reaps the late
     // rejection of the orphaned command so it can't surface as an unhandledRejection.
     const settled = wrapWithDeadline
-      ? withCommandDeadline(Promise.resolve(result))
+      ? withCommandDeadline(Promise.resolve(result), undefined, recordClusterDeadlineHit)
       : Promise.resolve(result);
     return settled.finally(done);
   };

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -421,6 +421,7 @@ function startClusterSelfHeal(
       cooldownMs: env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS,
       deadlineHitThreshold: env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD,
       deadlineHitWindowMs: env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS,
+      reconnectJitterMs: env.REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS,
     },
     {
       getInflight: () => getClusterInflight(),
@@ -456,7 +457,7 @@ function startClusterSelfHeal(
   // Don't keep the event loop alive for the watchdog on a graceful process exit.
   clusterSelfHealInterval.unref?.();
   log(
-    `Cluster self-heal watchdog ENABLED [inflightThreshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}, deadlineHitThreshold=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD}, deadlineHitWindowMs=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS}, cooldownMs=${env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS}, checkMs=${interval}]`
+    `Cluster self-heal watchdog ENABLED [inflightThreshold=${env.REDIS_CLUSTER_SELFHEAL_INFLIGHT_THRESHOLD}, sustainedMs=${env.REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS}, deadlineHitThreshold=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD}, deadlineHitWindowMs=${env.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS}, reconnectJitterMs=${env.REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS}, cooldownMs=${env.REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS}, checkMs=${interval}]`
   );
   return watchdog;
 }

--- a/src/server/redis/cluster-deadline-hits.ts
+++ b/src/server/redis/cluster-deadline-hits.ts
@@ -1,0 +1,68 @@
+/**
+ * In-process sliding-window count of CLUSTER (cache) command-deadline TIMEOUTS
+ * (the second self-heal trigger signal — see cluster-selfheal.ts).
+ *
+ * WHY THIS EXISTS (the bug it fixes): the original self-heal watchdog (FIX #1) triggered
+ * ONLY on `redis_commands_inflight{client="cluster"}` staying CONTINUOUSLY above a
+ * threshold for `REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS` (20s). But the per-command deadline
+ * (`withCommandDeadline`, REDIS_CLUSTER_COMMAND_TIMEOUT_MS = 15s) REJECTS every parked
+ * command at ~15s and dec's the inflight counter. During a real half-open park the parked
+ * commands share roughly the same age, so they reject in a batch every ~15s → inflight
+ * SAWTOOTHS between ~200 and ~0. Each crash below the threshold resets the watchdog's
+ * sustained-breach timer (cluster-selfheal.ts line "inflight <= threshold → breachStartedAt
+ * = null"). Because the deadline (15s) is SHORTER than the sustained window (20s), the
+ * breach timer can never accumulate 20 continuous seconds → self-heal NEVER fires. This was
+ * confirmed live: 21 pods wedged to inflight≈200 for 6–12 min while
+ * `civitai_app_redis_selfheal_reconnect_total` stayed 0 across the whole fleet.
+ *
+ * THE FIX: trigger self-heal on a signal the deadline-drain CANNOT erase — the RATE of
+ * deadline timeouts itself. A healthy cluster client NEVER hits the 15s deadline (healthy
+ * p99 ≈ 23ms); a half-open client hits it constantly (the drains ARE the hits). So "N
+ * deadline timeouts within the last W ms" is a monotonic, sawtooth-immune "this client is
+ * wedged" signal. This module is the in-process recorder for that signal: a tiny bounded
+ * ring of timeout timestamps with a windowed-count read.
+ *
+ * Pure (no redis/prom imports) so it is unit-testable in isolation and so the watchdog can
+ * sample it without a prom dependency — mirroring cluster-inflight.ts. One cluster client per
+ * process → a module-scoped recorder is correct.
+ */
+
+// Bounded ring of recent deadline-timeout timestamps (ms). Bounded so a sustained wedge
+// can't grow this unbounded: once full we overwrite the oldest entry. The window read only
+// ever cares about the last RING_CAPACITY hits inside the window, and the trigger threshold
+// is far below the capacity, so overwriting older-than-window entries loses nothing useful.
+const RING_CAPACITY = 512;
+const ring: number[] = [];
+let writeIdx = 0;
+
+/**
+ * Record one cluster command-deadline timeout. Called by withCommandDeadline's onTimeout
+ * hook (cluster client only). `now` is injectable for tests; defaults to Date.now.
+ */
+export function recordClusterDeadlineHit(now: number = Date.now()): void {
+  if (ring.length < RING_CAPACITY) {
+    ring.push(now);
+  } else {
+    ring[writeIdx] = now;
+    writeIdx = (writeIdx + 1) % RING_CAPACITY;
+  }
+}
+
+/**
+ * Count deadline timeouts recorded within the last `windowMs` (i.e. timestamp > now-windowMs).
+ * O(RING_CAPACITY) — trivial at a 1s watchdog sample. `now` injectable for tests.
+ */
+export function countClusterDeadlineHits(windowMs: number, now: number = Date.now()): number {
+  const cutoff = now - windowMs;
+  let count = 0;
+  for (let i = 0; i < ring.length; i++) {
+    if (ring[i] > cutoff) count++;
+  }
+  return count;
+}
+
+/** Reset the ring (used after a self-heal reconnect so the post-heal window starts clean, and in tests). */
+export function resetClusterDeadlineHits(): void {
+  ring.length = 0;
+  writeIdx = 0;
+}

--- a/src/server/redis/cluster-selfheal.ts
+++ b/src/server/redis/cluster-selfheal.ts
@@ -80,6 +80,17 @@ export interface ClusterSelfHealConfig {
    * command (a single deadline hit) does not.
    */
   deadlineHitWindowMs: number;
+  /**
+   * PER-POD RECONNECT JITTER (fleet-stampede brake). Once a tick DECIDES to reconnect, wait a
+   * random [0, reconnectJitterMs) before actually calling `reconnect()`. This de-correlates a
+   * SYNCHRONIZED fleet event: if next-redis-cluster itself has a genuine >=15s blip, every pod's
+   * deadline-hit trigger trips on the same tick — without jitter all ~80-100 pods would
+   * destroy()+connect() at once, a connection thundering-herd against an already-unhealthy
+   * cluster. The cooldown + single-flight guards are taken at DECISION time (before the delay),
+   * so the jitter never queues a second reconnect or shifts the cooldown clock. <= 0 disables
+   * jitter (reconnect fires immediately — the original behavior).
+   */
+  reconnectJitterMs: number;
 }
 
 export interface ClusterSelfHealDeps {
@@ -107,6 +118,16 @@ export interface ClusterSelfHealDeps {
   reconnect: () => Promise<void>;
   /** Monotonic-ish clock in ms (injected so tests are deterministic). Defaults to Date.now. */
   now?: () => number;
+  /**
+   * Resolves after `ms` (injected so the jitter delay is deterministic in tests). Defaults to a
+   * setTimeout-based sleep. Only ever called with the per-pod jitter delay; never blocks tick().
+   */
+  delay?: (ms: number) => Promise<void>;
+  /**
+   * Returns a float in [0, 1) for the per-pod jitter (injected so tests are deterministic).
+   * Defaults to Math.random — app runtime, NOT a workflow script, so Math.random is fine here.
+   */
+  random?: () => number;
   /** Structured logger. */
   log: (msg: string, ...rest: unknown[]) => void;
   /**
@@ -125,7 +146,8 @@ export type ClusterSelfHealTrigger = 'deadline' | 'inflight';
 
 export class ClusterSelfHealWatchdog {
   private readonly cfg: ClusterSelfHealConfig;
-  private readonly deps: Required<Pick<ClusterSelfHealDeps, 'now'>> & ClusterSelfHealDeps;
+  private readonly deps: Required<Pick<ClusterSelfHealDeps, 'now' | 'delay' | 'random'>> &
+    ClusterSelfHealDeps;
 
   /**
    * Timestamp (ms) at which inflight FIRST crossed above the threshold in the current
@@ -140,7 +162,12 @@ export class ClusterSelfHealWatchdog {
 
   constructor(cfg: ClusterSelfHealConfig, deps: ClusterSelfHealDeps) {
     this.cfg = cfg;
-    this.deps = { ...deps, now: deps.now ?? Date.now };
+    this.deps = {
+      ...deps,
+      now: deps.now ?? Date.now,
+      delay: deps.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms))),
+      random: deps.random ?? Math.random,
+    };
   }
 
   /** Expose internal state for assertions/observability (read-only snapshot). */
@@ -229,10 +256,38 @@ export class ClusterSelfHealWatchdog {
       );
     }
 
-    // Fire-and-forget the actual reconnect; the watchdog stays responsive (single-flight
-    // guard prevents overlap). Any rejection is logged, not thrown.
-    void this.deps
-      .reconnect()
+    // PER-POD JITTER: wait a random [0, reconnectJitterMs) BEFORE the actual reconnect so a
+    // synchronized fleet event (next-redis-cluster itself blips >=15s → every pod's deadline-hit
+    // trigger trips on the same tick) smears its destroy()+connect() across the jitter window
+    // instead of stampeding the cluster on a single tick. The guards above (lastReconnectAt,
+    // breachStartedAt cleared, reconnecting=true) are ALREADY taken at decision time, so during
+    // the delay: concurrent ticks single-flight out (reconnecting=true) and the cooldown clock
+    // is measured from the decision — the delay can't queue a second reconnect or let the window
+    // re-accumulate into a double-fire. reconnecting stays true until the reconnect itself
+    // settles, covering the delay + the reconnect. <= 0 jitter skips the delay entirely and
+    // invokes reconnect() synchronously (the original behavior).
+    const jitterMs =
+      this.cfg.reconnectJitterMs > 0
+        ? Math.floor(this.deps.random() * this.cfg.reconnectJitterMs)
+        : 0;
+
+    // The pre-reconnect step: when jitter > 0, park behind the jitter delay; when jitter is
+    // disabled (0), invoke reconnect() SYNCHRONOUSLY (no delay, no extra microtask) — identical
+    // to the original behavior. reconnecting stays true across the delay AND the reconnect, so a
+    // mid-jitter tick single-flights out and the wedge can't double-fire.
+    const reconnectChain: Promise<void> =
+      jitterMs > 0
+        ? this.deps
+            .delay(jitterMs)
+            .then(() => {
+              this.deps.log(`Cluster self-heal: reconnecting after ${jitterMs}ms jitter`);
+              return this.deps.reconnect();
+            })
+        : this.deps.reconnect();
+
+    // Fire-and-forget; the watchdog stays responsive (single-flight guard prevents overlap).
+    // Any rejection is logged, not thrown.
+    void reconnectChain
       .then(() => {
         this.deps.log('Cluster self-heal: reconnect completed');
       })

--- a/src/server/redis/cluster-selfheal.ts
+++ b/src/server/redis/cluster-selfheal.ts
@@ -10,11 +10,23 @@
  * pod 500s / slow-degrades indefinitely. ONLY a full client reconnect (rebuilds the
  * connections + `_slots`) or a process restart clears the orphaned `_execute` promises.
  *
- * SIGNATURE of a wedged pod: `redis_commands_inflight{client="cluster"}` jumps PAST the
- * threshold and stays PINNED (hundreds–thousands of leaked inflight); a healthy pod sits
- * near 0 and a busy pod only SPIKES transiently. This watchdog samples the same in-process
- * inflight counter that feeds the gauge and forces ONE reconnect when it stays above the
- * threshold CONTINUOUSLY for the sustained window, then waits out a cooldown.
+ * TWO TRIGGERS (either forces a reconnect, subject to the shared cooldown + single-flight):
+ *
+ *   TRIGGER 1 — DEADLINE-HIT RATE (the real-wave signal, sawtooth-immune): N cluster
+ *   command-deadline TIMEOUTS within a sliding window. A healthy client hits the 15s deadline
+ *   ZERO times; a half-open client hits it on ~every command. This is the trigger that
+ *   actually fires during a real fleet wave (see the bug below).
+ *
+ *   TRIGGER 2 — SUSTAINED INFLIGHT (legacy continuous-breach): `redis_commands_inflight`
+ *   pinned above a threshold CONTINUOUSLY for the sustained window. Kept as a backstop for
+ *   wedge shapes that leak inflight without deadline-rejecting.
+ *
+ * THE BUG TRIGGER 1 FIXES: TRIGGER 2 alone NEVER fired during real waves. The per-command
+ * deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS = 15s) mass-rejects the parked commands every
+ * ~15s, so inflight SAWTOOTHS to ~0 and the sustained-breach timer (sustainedMs = 20s > 15s)
+ * resets before it can accumulate 20 continuous seconds. Confirmed live: 21 pods wedged to
+ * inflight≈200 for 6–12 min with selfheal_reconnect_total = 0 across the fleet. The
+ * deadline-TIMEOUT rate is immune to that drain (the drains ARE the timeouts).
  *
  * RECONNECT-STORM SAFETY — three independent brakes:
  *   1. SUSTAINED window: a transient spike drops back under the threshold within the window
@@ -46,11 +58,46 @@ export interface ClusterSelfHealConfig {
   sustainedMs: number;
   /** Minimum wall-clock time between two reconnects. */
   cooldownMs: number;
+  /**
+   * DEADLINE-HIT TRIGGER (the sawtooth-immune signal — see deadlineHitWindowMs note below).
+   * If this many cluster command-deadline TIMEOUTS occur within `deadlineHitWindowMs`, force a
+   * reconnect IMMEDIATELY (subject to the cooldown), WITHOUT requiring inflight to stay
+   * continuously above the threshold. <= 0 disables this trigger (inflight path only).
+   *
+   * WHY this exists: the inflight-continuity trigger above can NEVER fire during a real
+   * half-open park, because the per-command deadline (REDIS_CLUSTER_COMMAND_TIMEOUT_MS = 15s)
+   * mass-rejects the parked commands every ~15s → inflight sawtooths to ~0 → the sustained
+   * timer (sustainedMs = 20s > 15s) resets before it can accumulate. Confirmed live: 21 pods
+   * wedged to inflight≈200 for minutes with selfheal_reconnect_total = 0. The deadline-TIMEOUT
+   * rate is immune to that drain (the drains ARE the timeouts), so a half-open trips this fast.
+   */
+  deadlineHitThreshold: number;
+  /**
+   * Sliding window (ms) over which deadlineHitThreshold deadline timeouts are counted. A
+   * healthy client hits the 15s deadline ZERO times in any window; a half-open client hits it
+   * continuously. Default sized so a genuine wedge (every cluster read deadline-rejecting)
+   * trips well inside the kubelet readiness-shed threshold, while a one-off transient slow
+   * command (a single deadline hit) does not.
+   */
+  deadlineHitWindowMs: number;
 }
 
 export interface ClusterSelfHealDeps {
   /** Reads the current in-process cluster inflight count (same source as the gauge). */
   getInflight: () => number;
+  /**
+   * Reads the number of cluster command-deadline timeouts within the last `deadlineHitWindowMs`
+   * (the sawtooth-immune wedge signal). Receives the window so the recorder owns the windowing.
+   * Optional so existing callers/tests that only drive the inflight path can omit it (treated
+   * as 0 → deadline trigger inert).
+   */
+  getDeadlineHits?: (windowMs: number) => number;
+  /**
+   * Clears the deadline-hit window. Called right after a reconnect is triggered so the
+   * post-heal window starts clean and the same wedge can't immediately re-trigger inside the
+   * cooldown. Optional (no-op if omitted).
+   */
+  resetDeadlineHits?: () => void;
   /**
    * Forces a full client reconnect (destroy → connect, rebuilding `_slots`). The teardown must
    * REJECT in-flight commands immediately (client.ts uses the v5 cluster `destroy()`, NOT the
@@ -64,10 +111,17 @@ export interface ClusterSelfHealDeps {
   log: (msg: string, ...rest: unknown[]) => void;
   /**
    * Called once per successful (or attempted) self-heal reconnect with the inflight value at
-   * trigger time, so client.ts can increment the Prometheus counter + emit a Loki line.
+   * trigger time AND which trigger fired ('deadline' = the sawtooth-immune deadline-hit rate;
+   * 'inflight' = the legacy sustained-inflight breach), so client.ts can increment the
+   * Prometheus counter (labeled by trigger) + emit a Loki line. Distinguishing the trigger is
+   * how the next prod wave is confirmed to have fired the DEADLINE path (the one the inflight
+   * path could never reach) rather than a stray inflight breach.
    */
-  onReconnect: (inflightAtTrigger: number) => void;
+  onReconnect: (inflightAtTrigger: number, trigger: ClusterSelfHealTrigger) => void;
 }
+
+/** Which watchdog trigger forced a given reconnect (for the labeled metric + log line). */
+export type ClusterSelfHealTrigger = 'deadline' | 'inflight';
 
 export class ClusterSelfHealWatchdog {
   private readonly cfg: ClusterSelfHealConfig;
@@ -113,41 +167,60 @@ export class ClusterSelfHealWatchdog {
     const now = this.deps.now();
     const inflight = this.deps.getInflight();
 
+    // ── TRIGGER 1: DEADLINE-HIT RATE (sawtooth-immune — the real-wave signal) ──────────
+    // A half-open park makes ~every cluster command deadline-reject; the per-command deadline
+    // then drains inflight, which is exactly why the inflight-continuity trigger below never
+    // fired during real waves. The deadline-TIMEOUT count is immune to that drain. Evaluate it
+    // FIRST and independently of the inflight breach timer.
+    const deadlineHits =
+      this.cfg.deadlineHitThreshold > 0 && this.deps.getDeadlineHits
+        ? this.deps.getDeadlineHits(this.cfg.deadlineHitWindowMs)
+        : 0;
+    const deadlineTriggered =
+      this.cfg.deadlineHitThreshold > 0 && deadlineHits >= this.cfg.deadlineHitThreshold;
+
+    // ── TRIGGER 2: SUSTAINED INFLIGHT (legacy continuous-breach path) ──────────────────
+    let inflightTriggered = false;
     if (inflight <= this.cfg.inflightThreshold) {
       // Healthy / recovered / transient-spike-ended: reset the sustained timer.
       this.breachStartedAt = null;
-      return false;
-    }
-
-    // Inflight is above the threshold. Start (or continue) the sustained-breach timer.
-    if (this.breachStartedAt == null) {
+    } else if (this.breachStartedAt == null) {
+      // Inflight just crossed above the threshold. Start the sustained-breach timer.
       this.breachStartedAt = now;
-      return false;
+    } else if (now - this.breachStartedAt >= this.cfg.sustainedMs) {
+      inflightTriggered = true;
     }
 
-    // Require the breach to have lasted at least sustainedMs.
-    if (now - this.breachStartedAt < this.cfg.sustainedMs) return false;
+    if (!deadlineTriggered && !inflightTriggered) return false;
 
-    // Respect the cooldown — at most one reconnect per cooldown window.
+    // Respect the cooldown — at most one reconnect per cooldown window (either trigger).
     if (this.lastReconnectAt != null && now - this.lastReconnectAt < this.cfg.cooldownMs) {
       return false;
     }
 
     // ── TRIGGER ──────────────────────────────────────────────────────────────────────
     // Mark the reconnect time + clear the breach timer up front so a long-running reconnect
-    // can't re-trigger and so the cooldown is measured from the trigger, not completion.
+    // can't re-trigger and so the cooldown is measured from the trigger, not completion. Also
+    // clear the deadline-hit window so the post-heal window starts clean (the same wedge can't
+    // instantly re-count the pre-heal hits).
     this.lastReconnectAt = now;
     this.breachStartedAt = null;
     this.reconnecting = true;
+    this.deps.resetDeadlineHits?.();
 
     this.deps.log(
-      `Cluster self-heal: inflight pinned at ${inflight} > ${this.cfg.inflightThreshold} for >=${this.cfg.sustainedMs}ms — forcing reconnect`
+      deadlineTriggered
+        ? `Cluster self-heal: ${deadlineHits} command-deadline timeouts in ${this.cfg.deadlineHitWindowMs}ms (>= ${this.cfg.deadlineHitThreshold}), inflight=${inflight} — forcing reconnect`
+        : `Cluster self-heal: inflight pinned at ${inflight} > ${this.cfg.inflightThreshold} for >=${this.cfg.sustainedMs}ms — forcing reconnect`
     );
     // onReconnect is a fire-and-forget observability hook (Prom counter + Loki line). A throw
     // from it must NOT abort the reconnect or wedge the watchdog (it would leave reconnecting
     // pinned true), so it's isolated.
     try {
-      this.deps.onReconnect(inflight);
+      // 'deadline' takes precedence: it's the trigger we expect during a real fleet wave and
+      // the one we need confirmed at the next wave. (If both conditions are somehow true, the
+      // deadline-hit rate is the more specific wedge signal.)
+      this.deps.onReconnect(inflight, deadlineTriggered ? 'deadline' : 'inflight');
     } catch (err) {
       this.deps.log(
         `Cluster self-heal: onReconnect hook threw (ignored): ${

--- a/src/server/redis/command-deadline.ts
+++ b/src/server/redis/command-deadline.ts
@@ -36,21 +36,35 @@ import { env } from '~/env/server';
  * `ms` defaults to REDIS_CLUSTER_COMMAND_TIMEOUT_MS; pass an explicit value in tests.
  * `<= 0` disables the guard (returns the input unchanged — no wrapper, no timer).
  *
+ * `onTimeout` (optional) is invoked exactly once iff the deadline fires (the command did NOT
+ * settle in time). This is the SELF-HEAL TRIGGER SIGNAL: a healthy cluster client never hits
+ * the deadline, a half-open one hits it constantly, and — unlike the inflight gauge — the
+ * deadline-drain cannot erase this count (the drains ARE the hits). instrumentCommands wires
+ * it to recordClusterDeadlineHit; tests inject a spy. It must never throw into the hot path,
+ * so it is isolated in a try/catch.
+ *
  * Mirrors withSysReadDeadline (sys-read-deadline.ts): the timer is always cleared in
  * finally() (within `ms`), and Promise.race reaps any late rejection from the orphaned
  * command so it never surfaces as an unhandledRejection.
  */
 export function withCommandDeadline<T>(
   p: Promise<T>,
-  ms: number = env.REDIS_CLUSTER_COMMAND_TIMEOUT_MS
+  ms: number = env.REDIS_CLUSTER_COMMAND_TIMEOUT_MS,
+  onTimeout?: () => void
 ): Promise<T> {
   if (!ms || ms <= 0) return p;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error(`redis cluster command timed out after ${ms}ms`)),
-      ms
-    );
+    timer = setTimeout(() => {
+      if (onTimeout) {
+        try {
+          onTimeout();
+        } catch {
+          // A broken hook (e.g. a throwing recorder) must never break the deadline guard.
+        }
+      }
+      reject(new Error(`redis cluster command timed out after ${ms}ms`));
+    }, ms);
   });
   // Timer is always cleared in finally() (within `ms`), so no unref() is needed.
   return Promise.race([p, deadline]).finally(() => {


### PR DESCRIPTION
## The bug: #2665 self-heal never fires during a real wave

The api-primary 504 waves are the node-redis cluster-client **half-open park at fleet scale**: a fraction of pods pile `redis_commands_inflight{client="cluster"}` to its 200 ceiling on never-resolving cluster commands, fail readiness (~60s), and shed from the LB → capacity collapse → 504 wave.

#2665 added a self-heal watchdog that force-reconnects a wedged pod. **It has not been firing**: `civitai_app_redis_selfheal_reconnect_total = 0` across the whole fleet over real waves, despite 21 pods wedging to inflight=200 for 6–12 min.

### Root cause (code-confirmed)
The watchdog's only trigger required `inflight` to stay **continuously** above the threshold for `REDIS_CLUSTER_SELFHEAL_SUSTAINED_MS` (20s). But the #2611 per-command deadline (`REDIS_CLUSTER_COMMAND_TIMEOUT_MS` = **15s**) mass-rejects the parked commands every ~15s, so `inflight` **sawtooths to ~0** and the sustained-breach timer resets before it can accumulate 20 continuous seconds (15 < 20). See `cluster-selfheal.ts` `tick()` (`inflight <= threshold → breachStartedAt = null`).

The reconnect path itself was already correct: `forceClusterReconnect()` uses the v5 cluster `destroy()` (`flushAll(DisconnectsClientError)`) which **immediately rejects every in-flight command**, so parked handlers genuinely unpark (fail-open cache → origin). The watchdog just never reached it.

## The fix: trigger on the deadline-hit RATE (sawtooth-immune)
A healthy cluster client hits the 15s deadline **zero** times; a half-open one hits it on ~every command (the drains ARE the hits). "N timeouts within W ms" is monotonic and immune to the inflight drain, so a park trips it within seconds — well inside the readiness-shed threshold.

- **`cluster-deadline-hits.ts`** (new, pure, bounded ring): records cluster command-deadline timeouts; build-bundle-safe (no imports).
- **`command-deadline.ts`**: optional `onTimeout` hook (the signal), isolated so a throwing recorder can't break the guard.
- **`cluster-selfheal.ts`**: TRIGGER 1 = deadline-hit rate (new), TRIGGER 2 = sustained inflight (legacy backstop); resets the hit window on reconnect; reports which trigger fired.
- **`client.ts`**: wire recorder into `instrumentCommands`; pass trigger to `onReconnect`. Only new import is **type-only** (build trap respected).
- **`prom/client.ts`**: label `redis_selfheal_reconnect_total` by `trigger` (`deadline`|`inflight`) so the next wave confirms the deadline path fired.
- **env**: `REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD=10` / `_WINDOW_MS=20000` (0 disables → inflight-only).

## Tests
31 pass, incl. a **REGRESSION** test reproducing the live non-firing bug (sawtooth inflight → 0 reconnects) and a **FIX** test proving the deadline trigger fires on the same wedge regardless of inflight dips; cooldown / single-flight / back-compat covered.

## Verification limits
Cannot reproduce a real half-open park locally. At the next prod wave, confirm: `redis_commands_inflight{client="cluster"}` drops within seconds, `redis_selfheal_reconnect_total{trigger="deadline"}` increments, and no readiness shed / 504 wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)