### PR TITLE
feat(readiness): let /api/ready treat shared-dependency checks as non-critical (park decouple)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -411,6 +411,23 @@ export const serverSchema = z.object({
   // Comma-delimited check names to skip in /api/health (e.g. "searchMetrics").
   // Static counterpart to the runtime sysRedis DISABLED_HEALTHCHECKS list.
   HEALTHCHECK_DISABLED: commaDelimitedStringArray().optional(),
+  // ── READINESS-ONLY non-critical checks (shared-dependency park decouple) ──────────
+  //
+  // Comma-delimited check names that the READINESS probe (/api/ready) treats as
+  // NON-CRITICAL — i.e. a failure of these checks does NOT make a pod NotReady — while the
+  // diagnostic /api/health view still reports them as fatal (unchanged). This is the source
+  // half of the backstop for the cluster-redis half-open park: a SHARED dependency blip
+  // (every pod's cluster-redis client wedging on the same next-redis-cluster node) must NOT
+  // shed the WHOLE api-primary fleet from the LB at once — that capacity collapse is the 504
+  // wave itself. With "redis" here, a parked pod keeps serving (degrading through the existing
+  // cache fail-open paths) instead of being pulled, while the redis self-heal clears the park
+  // within seconds. Pod-local readiness (warmup gate) is unaffected.
+  //
+  // SAFETY: applies to /api/ready ONLY (never /api/health). A check listed here is still run
+  // and still reported in the readiness body + healthcheck_* metrics — only its contribution
+  // to the binary Ready/NotReady verdict is suppressed. Default empty → today's behavior
+  // exactly (fully reversible). Recommended prod value once the self-heal fix is proven: "redis".
+  READINESS_NONCRITICAL_CHECKS: commaDelimitedStringArray().optional(),
   FRESHDESK_JWT_SECRET: z.string().optional(),
   FRESHDESK_JWT_URL: z.string().optional(),
   FRESHDESK_DOMAIN: z.string().optional(),

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -254,7 +254,14 @@ function getOverallDeadlineMs() {
  * map plus the computed `healthy` flag and whether the overall deadline fired.
  */
 export async function runHealthChecks(
-  signal: AbortSignal
+  signal: AbortSignal,
+  // Extra check names to treat as NON-CRITICAL for THIS run's `healthy` verdict, on top of the
+  // runtime sysRedis NON_CRITICAL_HEALTHCHECKS list. /api/ready passes
+  // env.READINESS_NONCRITICAL_CHECKS so a SHARED-dependency blip (e.g. the cluster-redis
+  // half-open park) can't shed the whole fleet from the LB; /api/health passes nothing so its
+  // diagnostic verdict is unchanged. The checks still RUN and are still reported in `results` +
+  // the healthcheck_* metrics — only their contribution to `healthy` is suppressed.
+  extraNonCritical: readonly CheckKey[] = []
 ): Promise<{ healthy: boolean; results: Record<CheckKey, boolean>; deadlineTimedOut: boolean }> {
   // Start the overall deadline at the TOP — before the config-fetch leg — so
   // the timer bounds the WHOLE run (config fetch + checks), not just the check
@@ -362,8 +369,15 @@ export async function runHealthChecks(
       });
     }
 
+    // A check is non-fatal for THIS run's verdict if it's in the runtime sysRedis
+    // NON_CRITICAL_HEALTHCHECKS list OR in the caller-supplied extraNonCritical set (the
+    // readiness probe passes env.READINESS_NONCRITICAL_CHECKS so a shared-dep park can't shed
+    // the fleet; /api/health passes nothing → unchanged).
     const healthy = activeChecks.every(
-      ([name]) => nonCriticalChecks.includes(name as CheckKey) || results[name as CheckKey]
+      ([name]) =>
+        nonCriticalChecks.includes(name as CheckKey) ||
+        extraNonCritical.includes(name as CheckKey) ||
+        results[name as CheckKey]
     );
     if (!healthy) counters.overall?.inc();
 

--- a/src/pages/api/ready.ts
+++ b/src/pages/api/ready.ts
@@ -1,9 +1,33 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { isProd } from '~/env/other';
+import { env } from '~/env/server';
 import { isWarm, getWarmState, getWarmDurationMs, didFailOpenTimeout } from '~/server/warmup';
 import { runHealthChecks } from '~/pages/api/health';
+import type { CheckKey } from '~/pages/api/health';
+import { parseReadinessNonCritical } from '~/server/readiness/non-critical';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { getRandomInt } from '~/utils/number-helpers';
+
+// Check names the READINESS probe treats as NON-CRITICAL (a failure does NOT make this pod
+// NotReady). Parsed once at module load and filtered to real check names so a typo can't
+// silently suppress the wrong check. Default empty → readiness uses the same fatal-set as
+// /api/health (today's behavior). Set READINESS_NONCRITICAL_CHECKS="redis" once the redis
+// self-heal fix is proven, so a cluster-redis half-open park degrades-in-place instead of
+// shedding the whole api-primary fleet from the LB.
+const VALID_CHECK_KEYS: readonly CheckKey[] = [
+  'write',
+  'read',
+  'pgWrite',
+  'pgRead',
+  'searchMetrics',
+  'redis',
+  'sysRedis',
+  'clickhouse',
+];
+const readinessNonCritical: CheckKey[] = parseReadinessNonCritical(
+  env.READINESS_NONCRITICAL_CHECKS,
+  VALID_CHECK_KEYS
+);
 
 // Warmup-gated readiness probe.
 //
@@ -68,7 +92,7 @@ export default WebhookEndpoint(async (_req: NextApiRequest, res: NextApiResponse
     return;
   }
 
-  const { healthy, results } = await runHealthChecks(signal);
+  const { healthy, results } = await runHealthChecks(signal, readinessNonCritical);
 
   res.off('close', onClose);
 

--- a/src/server/readiness/__tests__/non-critical.test.ts
+++ b/src/server/readiness/__tests__/non-critical.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { parseReadinessNonCritical } from '../non-critical';
+
+// parseReadinessNonCritical validates the READINESS_NONCRITICAL_CHECKS env list down to real
+// check names. The whole point is a typo must suppress NOTHING (never accidentally mark a
+// real check non-critical), and the default (empty/undefined) must preserve today's behavior.
+const VALID = ['write', 'read', 'pgWrite', 'pgRead', 'searchMetrics', 'redis', 'sysRedis', 'clickhouse'] as const;
+
+describe('parseReadinessNonCritical', () => {
+  it('returns [] for undefined (default → readiness uses the same fatal-set as /api/health)', () => {
+    expect(parseReadinessNonCritical(undefined, VALID)).toEqual([]);
+  });
+
+  it('returns [] for an empty list', () => {
+    expect(parseReadinessNonCritical([], VALID)).toEqual([]);
+  });
+
+  it('keeps a valid check name (the intended prod value)', () => {
+    expect(parseReadinessNonCritical(['redis'], VALID)).toEqual(['redis']);
+  });
+
+  it('keeps multiple valid names in input order', () => {
+    expect(parseReadinessNonCritical(['redis', 'searchMetrics'], VALID)).toEqual([
+      'redis',
+      'searchMetrics',
+    ]);
+  });
+
+  it('DROPS unknown names — a typo suppresses nothing rather than the wrong check', () => {
+    // 'rediss' (typo) and 'database' (not a check) must be ignored; only the real 'redis' stays.
+    expect(parseReadinessNonCritical(['rediss', 'database', 'redis'], VALID)).toEqual(['redis']);
+  });
+
+  it('drops ALL names when none are valid (never falls back to suppressing everything)', () => {
+    expect(parseReadinessNonCritical(['nope', 'bogus'], VALID)).toEqual([]);
+  });
+
+  it('trims surrounding whitespace from env-split values', () => {
+    expect(parseReadinessNonCritical([' redis ', '\tsysRedis'], VALID)).toEqual([
+      'redis',
+      'sysRedis',
+    ]);
+  });
+
+  it('dedupes repeated names', () => {
+    expect(parseReadinessNonCritical(['redis', 'redis', 'redis'], VALID)).toEqual(['redis']);
+  });
+});

--- a/src/server/readiness/non-critical.ts
+++ b/src/server/readiness/non-critical.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure parser for the READINESS-only non-critical check list (shared-dependency park decouple).
+ *
+ * The readiness probe (/api/ready) can treat a SHARED dependency check (e.g. the cluster-redis
+ * `redis` check) as non-fatal so a half-open park that wedges every pod's cluster client at once
+ * cannot shed the WHOLE api-primary fleet from the LB (that capacity collapse IS the 504 wave).
+ * This module turns the raw env list into a validated, deduped set of real check names so a typo
+ * can't silently suppress the wrong check (or nothing at all).
+ *
+ * Leaf module with NO heavy imports (no db/redis/prom) so it is unit-testable in isolation and
+ * importing it into ready.ts doesn't drag extra weight onto the probe path. Mirrors the
+ * cluster-deadline-hits / command-deadline leaf-module pattern.
+ */
+
+/**
+ * Filter a raw env list of check names down to the ones that actually exist, returning a deduped
+ * array. Unknown names are dropped (a typo suppresses NOTHING rather than everything). Order of
+ * `validKeys` is irrelevant — membership only.
+ *
+ * Generic over the check-key string-literal union so the caller keeps full type safety without
+ * this module importing the (heavy) health.ts where CheckKey is declared.
+ */
+export function parseReadinessNonCritical<K extends string>(
+  raw: readonly string[] | undefined,
+  validKeys: readonly K[]
+): K[] {
+  if (!raw || raw.length === 0) return [];
+  const valid = new Set<string>(validKeys);
+  const seen = new Set<K>();
+  const out: K[] = [];
+  for (const name of raw) {
+    const trimmed = name.trim();
+    if (valid.has(trimmed) && !seen.has(trimmed as K)) {
+      seen.add(trimmed as K);
+      out.push(trimmed as K);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Why (backstop for the cluster-redis park)

Companion to #2672. When the cluster-redis half-open park hits (every pod's cluster client wedging on the same next-redis-cluster node), the kubelet readiness probe can pull the **whole** api-primary fleet from the LB at once — and that capacity collapse **is** the 504 wave. A SHARED-dependency blip should never shed the whole fleet; this is the resilience backstop even if a park recurs.

## What

Add `READINESS_NONCRITICAL_CHECKS` (comma-delimited check names). The **readiness** probe (`/api/ready`) treats those checks as **non-fatal** for the Ready/NotReady verdict, while the diagnostic `/api/health` view still reports them as fatal (unchanged). The checks still **run** and are still reported in the readiness body + `healthcheck_*` metrics — only their contribution to the binary verdict is suppressed. The warmup (pod-local) gate is unaffected.

- `runHealthChecks` gains an optional `extraNonCritical` param; `/api/ready` passes `env.READINESS_NONCRITICAL_CHECKS`, `/api/health` passes nothing.
- `parseReadinessNonCritical`: pure leaf module that validates the env list to real check names — a typo suppresses **nothing** rather than the wrong check or everything. 8 unit tests.

Default empty → **today's behavior exactly** (fully reversible). Intended prod value once #2672 is proven: `redis`.

## Paired manifest change (datapacket-talos, NOT in this repo)
Set `READINESS_NONCRITICAL_CHECKS=redis` on the `civitai-dp-prod-api` deployment env (`clusters/production/apps/civitai-dp-prod/deployment-api.yaml`) **after** this image ships. No probe-path change needed — readiness already points at `/api/ready`.

## Note on the readiness check itself
The cluster-redis `redis` check is already passive/lenient (`(redis as any)?.isReady !== false`), so it does not itself fail on a half-open. This change makes the decouple **explicit and operator-controllable** for the redis (and, if ever needed, DB) checks, so a shared-dep park can't shed the fleet regardless of how the failure surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)