### PR TITLE
fix(app-blocks): hide appBlockReview reward from Buzz dashboard until GA

### DIFF
--- a/src/server/rewards/active/appBlockReview.reward.ts
+++ b/src/server/rewards/active/appBlockReview.reward.ts
@@ -44,6 +44,12 @@ export const appBlockReviewReward = createBuzzEvent({
   toAccountType: 'blue',
   description: 'You left a review on an app',
   triggerDescription: 'For each app you review for the first time',
+  // HIDDEN from the Buzz-dashboard reward list until App Blocks GA. App Blocks
+  // are still dark/mod-gated, so advertising this reward to everyone leaks the
+  // unreleased feature. The reward still FIRES for the few mod testers who can
+  // review — it's just not listed (user.controller.ts filters the dashboard by
+  // `.visible`). Flip to true (or remove) at App Blocks launch.
+  visible: false,
   awardAmount: REVIEW_AWARD,
   // Daily ceiling, NOT a per-app cap. The per-(user, app) once-ever guarantee is
   // the DB-unique + isFirstReview belt; same-app same-day is the Redis forId


### PR DESCRIPTION
## Problem
The `appBlockReview` blue-buzz reward (added in #2668, now merged + deployed) does not set `visible`, so it defaults to `visible: true`. The Buzz dashboard builds its reward list as `.filter((x) => x.visible)` (`src/server/controllers/user.controller.ts:1277`), so **"You left a review on an app" is shown to every user** — leaking the unreleased **App Blocks** feature, which is still dark/mod-gated behind the `appBlocks` Flipt flag.

## Fix
Set `visible: false` on the reward — the same hide-from-dashboard pattern the referral rewards (`refereeCreated`, `userReferred`) already use. The reward still **fires** for the mod testers who can currently leave reviews; it's just no longer **advertised** in the dashboard. Flip to `true` (or remove the flag) at App Blocks launch.

One-line change, type-safe (`visible?: boolean` on `createBuzzEvent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)