### PR TITLE
feat(app-blocks): block catalog endpoints accept any valid block token (retire catalog:read)

### DIFF
--- a/src/pages/api/v1/blocks/images.ts
+++ b/src/pages/api/v1/blocks/images.ts
@@ -65,10 +65,15 @@ export const config = {
  * no-store` + exact-origin CORS on this route, so there is no cache-key /
  * cross-domain leak here.
  *
- * Scope: `catalog:read` — the SAME browse scope blocks/models uses (a no-op
- * context binding; maps to the ModelsRead OAuth ceiling bit but grants NO new
- * data exposure: the catalog is public + this endpoint is strictly MORE
- * restricted than the public one). No new scope is introduced.
+ * Auth: ANY valid block token (no required scope) — the SAME mode
+ * blocks/models uses. The catalog is PUBLIC, maturity-clamped data, so a
+ * declarable+grantable scope adds CLI-validator + per-app-allowedScopes
+ * friction with NO security value (this endpoint is strictly MORE restricted
+ * than the public /api/v1/images). The token is required ONLY for its signed
+ * `maxBrowsingLevel` claim (the maturity ceiling), NOT for authorization.
+ * withBlockScope still runs FULL token validation + revocation + `private,
+ * no-store` + exact-origin CORS; it just skips the per-scope check. Anon → 401.
+ * (Previously gated on `catalog:read`, retired as no-value friction.)
  *
  * NOTE (advisory until #2670 merges): the authoritative `maxBrowsingLevel`
  * claim is MINTED by PR #2670. Until then every token resolves to SFW here (the
@@ -228,4 +233,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'catalog:read' });
+// No requiredScope: any valid block token is accepted (see doc above). The
+// maturity clamp (resolveCatalogBrowsingLevel) remains the whole authority
+// surface.
+export default withBlockScope(baseHandler, {});

--- a/src/pages/api/v1/blocks/models.ts
+++ b/src/pages/api/v1/blocks/models.ts
@@ -40,11 +40,16 @@ import { constants } from '~/server/common/constants';
  * + exact-origin CORS on this route, so there is no cache-key / cross-domain
  * leak here.
  *
- * Scope: `catalog:read` (a BROWSE scope with a no-op context binding — see
- * block-scope.constants.ts + enforceContextBinding). It maps to the ModelsRead
- * OAuth ceiling bit but grants NO new data exposure: the catalog is public and
- * this endpoint is strictly MORE restricted than the public one. A block that
- * wants the selector declares `catalog:read` in its manifest.
+ * Auth: ANY valid block token (no required scope). The catalog is PUBLIC,
+ * maturity-clamped data, so a specific declarable+grantable scope adds friction
+ * (the Go CLI manifest validator must allow it + each app's
+ * OauthClient.allowedScopes would need the bit) with ZERO security value — this
+ * endpoint is strictly MORE restricted than the public /api/v1/models. The
+ * token is required ONLY for its signed `maxBrowsingLevel` claim (the
+ * authoritative maturity ceiling), NOT for authorization. withBlockScope still
+ * runs the FULL token validation + revocation + `private, no-store` +
+ * exact-origin CORS; it just skips the per-scope check. Anon (no token) → 401.
+ * (Previously gated on `catalog:read`, retired as no-value friction.)
  *
  * NOTE (advisory until #2670 merges): the authoritative `maxBrowsingLevel`
  * claim is MINTED by PR #2670 (color-domain maturity). Until #2670 lands,
@@ -168,4 +173,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'catalog:read' });
+// No requiredScope: any valid block token is accepted (see doc above). The
+// maturity clamp (resolveCatalogBrowsingLevel) remains the whole authority
+// surface.
+export default withBlockScope(baseHandler, {});

--- a/src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts
+++ b/src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+// Setup-order import: installs the ~/env/server mock with the real test RSA
+// keypair BEFORE block-token.service / the middleware evaluate env at module
+// load (same posture as block-scope.runtime-flag.test.ts).
+import '~/__tests__/setup';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * "Any valid block token" mode — `withBlockScope(handler, {})` (no requiredScope).
+ *
+ * The block CATALOG endpoints (/api/v1/blocks/models, /api/v1/blocks/images)
+ * serve PUBLIC, maturity-clamped data, so they require ANY valid block token
+ * rather than a specific declarable scope (`catalog:read` was retired — it added
+ * CLI-validator + per-app-allowedScopes friction with no security value). The
+ * token is needed ONLY for its signed `maxBrowsingLevel` claim, not for authz.
+ *
+ * Asserted contract for the no-requiredScope mode:
+ *   - a valid token that carries ZERO scopes (would 403 in scoped mode) is
+ *     ACCEPTED — the per-scope check + enforceContextBinding are skipped.
+ *   - FULL token validation is still enforced: an invalid token → 401.
+ *   - a REVOKED instance is still rejected → 403 (revocation is independent of
+ *     the scope gate).
+ *   - the `private, no-store` cache header is still forced for the block JWT.
+ *   - anon (no bearer) is NOT silently allowed: the wrapper falls through to the
+ *     wrapped handler (whose own `if (!claims) 401` guard then rejects). There
+ *     is no token to derive the maturity claim from.
+ *
+ * We mock ONLY the runtime flag (ON) + BlockRevocation (per-test), mirroring
+ * block-scope.runtime-flag.test.ts. The token is minted by the REAL
+ * BlockTokenService and run through the REAL middleware.
+ */
+
+const { isFliptMock } = vi.hoisted(() => ({
+  // Runtime flag ON so the middleware verifies (not the dark fall-through path).
+  isFliptMock: vi.fn(async (flag: string) =>
+    flag === 'app-blocks-runtime-enabled' ? true : false
+  ),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: isFliptMock }));
+
+const { isRevokedMock } = vi.hoisted(() => ({ isRevokedMock: vi.fn(async () => false) }));
+vi.mock('~/server/services/block-revocation.service', () => ({
+  BlockRevocation: { isRevoked: isRevokedMock },
+}));
+
+import { withBlockScope } from '../block-scope.middleware';
+import { BlockTokenService } from '~/server/services/block-token.service';
+
+async function mintToken(scopes: string[]): Promise<string> {
+  const r = await BlockTokenService.sign({
+    userId: 42,
+    blockId: 'blk_test',
+    appId: 'app_test',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    scopes,
+    ctx: { modelId: 1 },
+    // The catalog endpoints read this claim; include it so the round-trip is
+    // realistic (the middleware verifies its shape).
+    maxBrowsingLevel: 3,
+    domain: 'green',
+  });
+  return r.token;
+}
+
+function makeRes() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, unknown>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send() {
+      return this;
+    },
+    end() {
+      return this;
+    },
+    setHeader(k: string, v: unknown) {
+      this.headers[k.toLowerCase()] = v;
+      return this;
+    },
+    removeHeader() {
+      return this;
+    },
+    writeHead() {
+      return this;
+    },
+    getHeader(k: string) {
+      return this.headers[k.toLowerCase()];
+    },
+    // Success path registers a fire-and-forget res.on('finish', …) logger; a
+    // no-op registrar is enough (we don't invoke the DB-backed callback).
+    on() {
+      return this;
+    },
+  };
+  return res as unknown as NextApiResponse & {
+    statusCode: number;
+    body: unknown;
+    headers: Record<string, unknown>;
+  };
+}
+
+function makeReq(authHeader?: string): NextApiRequest {
+  // No `origin` header → setBlockCors falls through to the flag/JWT logic.
+  return {
+    method: 'GET',
+    headers: authHeader ? { authorization: authHeader } : {},
+    query: {},
+    url: '/api/v1/blocks/models',
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+}
+
+beforeEach(() => {
+  isFliptMock.mockClear();
+  isRevokedMock.mockClear();
+  isRevokedMock.mockResolvedValue(false);
+});
+
+describe('withBlockScope — "any valid block token" mode (no requiredScope)', () => {
+  it('accepts a valid token carrying ZERO scopes (per-scope gate + binding skipped)', async () => {
+    const token = await mintToken([]); // would 403 in scoped mode
+    const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+      res.status(200).json({ via: 'block' });
+    });
+    const route = withBlockScope(wrapped as never, {}); // NO requiredScope
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`) as never, res as never);
+
+    expect(wrapped).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ via: 'block' });
+    // The verified claims were attached (the middleware really validated it).
+    // And the uncacheable header is still forced for a block JWT.
+    expect(String(res.headers['cache-control'])).toContain('no-store');
+  });
+
+  it('still rejects an INVALID token → 401 (full validation preserved)', async () => {
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, {});
+
+    // 3-segment JWS with a RS256/typ:JWT/kid header (passes isBlockJwt shape)
+    // but a bogus signature → verifyBlockToken returns null → 401.
+    const header = Buffer.from(
+      JSON.stringify({ alg: 'RS256', typ: 'JWT', kid: 'x' })
+    ).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({ sub: 'user:1' })).toString('base64url');
+    const bogus = `${header}.${payload}.bad`;
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${bogus}`) as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+
+  it('still rejects a REVOKED instance → 403 (revocation independent of scope gate)', async () => {
+    isRevokedMock.mockResolvedValue(true);
+    const token = await mintToken([]);
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, {});
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`) as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+
+  it('anon (no bearer) falls through to the wrapped handler — never silently allowed', async () => {
+    // The catalog endpoint's own `if (!claims) 401` guard then rejects. The
+    // point: any-token mode does NOT allow anon (no token = no maturity claim).
+    const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+      res.status(401).json({ error: 'Block token required' });
+    });
+    const route = withBlockScope(wrapped as never, {});
+
+    const res = makeRes();
+    await route(makeReq() as never, res as never);
+
+    expect(wrapped).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/src/server/middleware/__tests__/block-scope.middleware.test.ts
+++ b/src/server/middleware/__tests__/block-scope.middleware.test.ts
@@ -117,17 +117,13 @@ describe('enforceContextBinding', () => {
     ).toThrow();
   });
 
-  it('catalog:read is a no-op browse binding (no modelId, anon allowed)', () => {
-    // The Phase 3 catalog scope searches PUBLIC data, so it has no modelId
-    // binding and no :self subject requirement. The maturity ceiling is
-    // enforced by the endpoint (claims.maxBrowsingLevel), NOT here.
+  it('rejects the retired catalog:read scope (no longer a known scope)', () => {
+    // catalog:read was added in #2671 and retired the next day: the block
+    // catalog endpoints now accept ANY valid token (no requiredScope) — see
+    // block-scope.anytoken-mode.test.ts. A token still carrying the dead scope
+    // is now an UNKNOWN scope → deny-by-default at runtime.
     const authed = fakeClaims({ scopes: ['catalog:read'] });
-    expect(() => enforceContextBinding(authed, fakeReq({}))).not.toThrow();
-    // No modelId binding: an unrelated id query param does not constrain it.
-    expect(() => enforceContextBinding(authed, fakeReq({ id: '999' }))).not.toThrow();
-    // Anon may browse the catalog.
-    const anon = fakeClaims({ sub: 'anon', scopes: ['catalog:read'] });
-    expect(() => enforceContextBinding(anon, fakeReq({}))).not.toThrow();
+    expect(() => enforceContextBinding(authed, fakeReq({}))).toThrow();
   });
 });
 

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -61,7 +61,30 @@ export type BlockScopedNextApiRequest = NextApiRequest & {
 };
 
 export interface WithBlockScopeOpts {
-  requiredScope: string;
+  /**
+   * The block scope this endpoint requires. When PRESENT, the middleware
+   * enforces `claims.scopes.includes(requiredScope)` (403 on miss) AND runs
+   * `enforceContextBinding` for the token's scopes — the standard per-scope
+   * authorization path (me.ts, submit-version, settings, etc.).
+   *
+   * When OMITTED ("any valid block token" mode), the middleware STILL performs
+   * the FULL token validation (RS256 signature + kid, iss/aud/exp, max-age,
+   * the claim shape guards incl. `maxBrowsingLevel`), the per-instance
+   * revocation check, the `private, no-store` cache header, and exact-origin
+   * CORS — it ONLY skips the per-scope authorization check and
+   * `enforceContextBinding`. Anonymous callers (no token / non-JWT bearer) are
+   * still rejected (the wrapped handler's own 401 guard fires).
+   *
+   * This mode exists for the block CATALOG endpoints (/api/v1/blocks/models,
+   * /api/v1/blocks/images): they serve PUBLIC, maturity-clamped data, so a
+   * specific declarable+grantable scope adds friction (CLI manifest validator +
+   * per-app OauthClient.allowedScopes bit) with no security value. They need a
+   * token ONLY for its signed `maxBrowsingLevel` claim — the authoritative
+   * maturity ceiling source — NOT for authorization. Token validity + the
+   * clamp (resolveCatalogBrowsingLevel, fail-closed SFW) is the whole authority
+   * surface; the scope gate would add nothing.
+   */
+  requiredScope?: string;
 }
 
 // L7 (audit-10): issuer/audience imported from block-token.service so a
@@ -432,16 +455,6 @@ export function enforceContextBinding(
       throw forbidden(`unknown scope: ${scope}`);
     }
     switch (scope) {
-      case 'catalog:read': {
-        // BROWSE scope (Phase 3 block catalog endpoint). No context binding:
-        // it searches the PUBLIC catalog, so there is no single modelId to bind
-        // to and no `:self` subject requirement (anon tokens may browse). The
-        // maturity ceiling is enforced separately + authoritatively by the
-        // endpoint via claims.maxBrowsingLevel (clamped, fail-closed to SFW) —
-        // NOT here. This explicit no-op case is required so the fail-closed
-        // `default` below does not reject a valid catalog:read token.
-        break;
-      }
       case 'models:read:self': {
         const modelIdStr =
           readBoundQueryString(req, 'id') ?? readBoundQueryString(req, 'modelId');
@@ -579,19 +592,27 @@ export function withBlockScope(
       return;
     }
 
-    if (!claims.scopes.includes(opts.requiredScope)) {
-      res.status(403).json({ error: `missing required scope: ${opts.requiredScope}` });
-      return;
-    }
-
-    try {
-      enforceContextBinding(claims, req);
-    } catch (err) {
-      if (err instanceof ForbiddenError) {
-        res.status(403).json({ error: err.message });
+    // "Any valid block token" mode (opts.requiredScope omitted): the token has
+    // already passed full validation + the revocation check above. Skip the
+    // per-scope authorization check AND enforceContextBinding — these endpoints
+    // (the public catalog) authorize on token-validity alone and derive their
+    // only authority (the maturity ceiling) from claims.maxBrowsingLevel, not a
+    // scope. See WithBlockScopeOpts.requiredScope.
+    if (opts.requiredScope !== undefined) {
+      if (!claims.scopes.includes(opts.requiredScope)) {
+        res.status(403).json({ error: `missing required scope: ${opts.requiredScope}` });
         return;
       }
-      throw err;
+
+      try {
+        enforceContextBinding(claims, req);
+      } catch (err) {
+        if (err instanceof ForbiddenError) {
+          res.status(403).json({ error: err.message });
+          return;
+        }
+        throw err;
+      }
     }
 
     (req as BlockScopedNextApiRequest).blockClaims = claims;
@@ -682,7 +703,10 @@ export function withBlockScope(
               userId: userIdForLog,
               appBlockId: claims.appBlockId,
               blockInstanceId: claims.blockInstanceId,
-              scope: opts.requiredScope,
+              // In "any valid block token" mode there is no required scope; the
+            // audit column is NOT NULL, so record a stable sentinel that
+            // distinguishes these rows from real per-scope invocations.
+            scope: opts.requiredScope ?? '(any-token)',
               endpoint: endpointForLog,
               statusCode: res.statusCode,
             })

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -36,19 +36,15 @@ export type ScopeBitmaskRequirement = number | typeof SKIP_OAUTH_CHECK;
 
 export const BLOCK_SCOPE_TO_OAUTH_BIT: Record<string, ScopeBitmaskRequirement> = {
   'models:read:self': TokenScope.ModelsRead,
-  // catalog:read — the Phase 3 block catalog-search endpoint
-  // (/api/v1/blocks/models). Distinct from `models:read:self`:
-  //   - models:read:self is single-model + modelId-bound (query.id ≡
-  //     ctx.modelId) — for a block that reads its OWN host model.
-  //   - catalog:read is a BROWSE (search the public catalog) — there is no
-  //     single model to bind to, so its enforceContextBinding case is a NO-OP.
-  // It maps to the same OAuth ceiling bit (ModelsRead) because both read model
-  // data, but it grants NO new data exposure: the catalog is public and the
-  // block endpoint is strictly MORE restricted than the public /api/v1/models
-  // (it authoritatively clamps maturity to the token's domain ceiling — a
-  // SFW-domain block cannot fetch mature catalog content). A block that wants
-  // the in-block model selector declares `catalog:read` in its manifest.
-  'catalog:read': TokenScope.ModelsRead,
+  // NOTE: there is intentionally NO `catalog:read` scope. The block catalog
+  // endpoints (/api/v1/blocks/models, /api/v1/blocks/images) serve PUBLIC,
+  // maturity-clamped data and accept ANY valid block token (withBlockScope with
+  // no requiredScope) — they need the token only for its signed
+  // `maxBrowsingLevel` claim, not for authorization. A `catalog:read` scope was
+  // briefly added (#2671) and retired the next day: requiring a
+  // declarable+grantable scope added friction (Go CLI manifest validator + each
+  // app's OauthClient.allowedScopes bit) with no security value, since the
+  // catalog is strictly MORE restricted than the public /api/v1/models.
   'media:read:owned': TokenScope.MediaRead,
   'user:read:self': TokenScope.UserRead,
   'ai:write:budgeted': TokenScope.AIServicesWrite,

--- a/src/tests/api/v1/blocks/images-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/images-endpoint.test.ts
@@ -67,7 +67,10 @@ function fakeClaims(over: Partial<BlockTokenClaims>): BlockTokenClaims {
     appBlockId: 'apb_test',
     blockInstanceId: 'bki_test',
     ctx: {},
-    scopes: ['catalog:read'],
+    // No catalog:read (retired): the endpoint accepts ANY valid block token
+    // (withBlockScope with no requiredScope). The handler never reads `scopes` —
+    // its only authority is the maturity clamp on claims.maxBrowsingLevel.
+    scopes: [],
     ...over,
   };
 }
@@ -190,6 +193,15 @@ describe('/api/v1/blocks/images — authoritative clamp wiring', () => {
     claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
     const res = await invoke({ page: '11', limit: '100' });
     expect(res.statusCode).toBe(429);
+    expect(mockRunImageSearch).not.toHaveBeenCalled();
+  });
+
+  it('401s when no block claims were stamped (defense-in-depth; e.g. no token)', async () => {
+    // The middleware (real) rejects anon before reaching here; this guards the
+    // handler-internal `if (!claims) 401` path that fires if claims is absent.
+    claimsBox.claims = undefined;
+    const res = await invoke({});
+    expect(res.statusCode).toBe(401);
     expect(mockRunImageSearch).not.toHaveBeenCalled();
   });
 

--- a/src/tests/api/v1/blocks/models-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/models-endpoint.test.ts
@@ -69,7 +69,10 @@ function fakeClaims(over: Partial<BlockTokenClaims>): BlockTokenClaims {
     appBlockId: 'apb_test',
     blockInstanceId: 'bki_test',
     ctx: {},
-    scopes: ['catalog:read'],
+    // No catalog:read (retired): the endpoint accepts ANY valid block token
+    // (withBlockScope with no requiredScope). The handler never reads `scopes` —
+    // its only authority is the maturity clamp on claims.maxBrowsingLevel.
+    scopes: [],
     ...over,
   };
 }
@@ -187,6 +190,15 @@ describe('/api/v1/blocks/models — authoritative clamp wiring', () => {
     // The Meili pre-step must be called with the CLAMPED level too.
     expect(mockResolveModelSearchIds).toHaveBeenCalledTimes(1);
     expect(mockResolveModelSearchIds.mock.calls[0][0].browsingLevel).toBe(sfwBrowsingLevelsFlag);
+  });
+
+  it('401s when no block claims were stamped (defense-in-depth; e.g. no token)', async () => {
+    // The middleware (real) rejects anon before reaching here; this guards the
+    // handler-internal `if (!claims) 401` path that fires if claims is absent.
+    claimsBox.claims = undefined;
+    const res = await invoke({});
+    expect(res.statusCode).toBe(401);
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
   });
 
   it('rejects non-GET', async () => {


### PR DESCRIPTION
## What

Make the block catalog endpoints `/api/v1/blocks/models` + `/api/v1/blocks/images` require **any valid block token** instead of the `catalog:read` scope, and retire `catalog:read`.

Follow-up to the merged #2671 (which introduced `catalog:read` ~1 day ago).

## Why

The catalog is **public, maturity-clamped data** — the #2671 audit confirmed `catalog:read` "adds no exposure". Requiring a declarable+grantable scope added friction with ~zero security value:

- the Go CLI manifest validator rejects an undeclared scope, and
- each app's `OauthClient.allowedScopes` would need the bit set.

The token is needed **only for its signed `maxBrowsingLevel` claim** (the authoritative maturity ceiling), not for authorization — these endpoints are strictly *more* restricted than the public `/api/v1/models`. A specific scope is not needed; token validity + the clamp is the whole authority surface.

This unblocks gen-matrix's in-block selector without a declarable scope.

## How (Option B)

- **`withBlockScope`**: `requiredScope` is now **optional**. When omitted ("any valid block token" mode), the middleware **still** performs FULL token validation (RS256+kid signature, iss/aud/exp, max-age, the claim shape guards incl. `maxBrowsingLevel`), the per-instance revocation check, the `Cache-Control: private, no-store` header, and exact-origin CORS — it **only** skips the per-scope check and `enforceContextBinding`. The `requiredScope`-given path is **byte-identical** for all other callers (`blocks/me.ts`, `models/[id].ts`, `blocks/submit-version`).
- **`models.ts` + `images.ts`** switch to the no-required-scope mode (`withBlockScope(baseHandler, {})`). The maturity clamp (`resolveCatalogBrowsingLevel`, fail-closed SFW) is **unchanged**.
- **Retire `catalog:read`**: removed from `BLOCK_SCOPE_TO_OAUTH_BIT` and its `enforceContextBinding` case. A token still carrying it is now an unknown scope → deny-by-default at runtime (only relevant to *scoped* endpoints; the catalog endpoints no longer check scopes).

## Security posture preserved

- Full token validation + revocation + the maturity clamp + `private, no-store` + exact-origin CORS are all retained. Only the **scope gate** is replaced by "any valid token".
- **Anon (no token) is still rejected (401)** — these endpoints need a token for the maturity claim.
- The public `/api/v1/models` + `/api/v1/images` are **not touched** (confirmed zero changes).

## Tests

- New `block-scope.anytoken-mode.test.ts`: valid zero-scope token passes (per-scope gate + binding skipped), invalid token → 401, revoked instance → 403, anon falls through to the handler's own 401, `no-store` still forced.
- `block-scope.middleware.test.ts`: asserts the retired `catalog:read` is now rejected (deny-by-default).
- `models-endpoint` / `images-endpoint`: drop `catalog:read` from fixtures + add a no-claims (no token) 401 guard test. All clamp tests (green/blue→SFW, red→unclamped, missing→fail-closed) kept unchanged.
- `pnpm typecheck` exit 0; 91 block-scope/endpoint tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)