### PR TITLE
perf(redis): in-process LRU for decoded tensor-metadata — fix api-primary 504 waves from #2649

### DIFF
--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -6,6 +6,7 @@ import { dbRead } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import { getFileForModelVersion } from '~/server/services/file.service';
+import { getFullTensorAnalysisCached } from '~/server/services/tensor-metadata.service';
 import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
 import {
@@ -80,17 +81,28 @@ export default MixedAuthEndpoint(async function handler(
     //  - SUMMARY: the tiny summary fields (~256 B) with `tensors` dropped. Fired on EVERY
     //    model-version view (the badge). A summary cache HIT must never read/decompress the
     //    big blob — it only falls through to the full fetch on a summary MISS.
+    //
+    // HOT-PATH DECODE GUARD: even with the summary/full split, a panel-open viewer hits
+    // the FULL path on every model-page view, and the redis blob is brotli-compressed
+    // (#2649) so each full read pays an async brotli-decompress + a SYNCHRONOUS ~335 KB
+    // msgpack `unpack()` on the shared event loop. For a popular file that repeats per
+    // request and concentrates into the api-primary 504 waves. `getFullTensorAnalysisCached`
+    // wraps the redis-backed fetch in a bounded in-process LRU of the DECODED object, so a
+    // hot model is decoded at most once per pod (the redis memory win is preserved — the
+    // blob stays compressed+split in redis; we only remove the repeated hot-path decode).
     const fetchFull = () =>
-      fetchThroughCache(
-        `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${id}`,
-        () =>
-          parseModelTensorMetadata({
-            url: fileResult.url,
-            format,
-            fileSizeBytes: file.sizeKB * 1024,
-            estimateVram,
-          }),
-        { ttl: CacheTTL.month, compress: true }
+      getFullTensorAnalysisCached(id, () =>
+        fetchThroughCache(
+          `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${id}`,
+          () =>
+            parseModelTensorMetadata({
+              url: fileResult.url,
+              format,
+              fileSizeBytes: file.sizeKB * 1024,
+              estimateVram,
+            }),
+          { ttl: CacheTTL.month, compress: true }
+        )
       );
 
     res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);

--- a/src/server/services/__tests__/tensor-metadata-service.test.ts
+++ b/src/server/services/__tests__/tensor-metadata-service.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ModelTensorAnalysis } from '~/utils/model-tensor-metadata';
+
+/**
+ * Coverage for the in-process decoded-tensor-analysis LRU
+ * (src/server/services/tensor-metadata.service.ts), the relief-bearing fix for the
+ * api-primary 504 waves: a popular file must be DECODED (brotli + msgpack unpack) at
+ * most once per pod, not on every panel-open model-page view.
+ *
+ * Pinned here:
+ *  1. MISS → invokes the (redis-backed) fetcher and returns its result.
+ *  2. HIT  → returns the cached DECODED object WITHOUT re-invoking the fetcher
+ *            (the regression guard: a hot path does NOT re-trigger the decode).
+ *  3. Distinct file ids are cached independently.
+ *  4. The cache is BOUNDED — exceeding the item cap evicts the least-recently-used
+ *     entry, so a re-read of an evicted id re-invokes the fetcher.
+ */
+
+const cacheHitInc = vi.fn();
+const cacheMissInc = vi.fn();
+
+function makeAnalysis(tensorCount: number, marker: string): ModelTensorAnalysis {
+  return {
+    format: 'SafeTensor',
+    tensorCount,
+    totalTensorBytes: tensorCount * 1000,
+    dtypeCounts: [],
+    largestTensor: null,
+    vramEstimate: null,
+    tensors: Array.from({ length: tensorCount }, (_, i) => ({
+      name: `${marker}.tensor.${i}`,
+      shape: [1, 2, 3],
+      dtype: 'F16',
+      sizeBytes: 1000,
+    })),
+  };
+}
+
+describe('tensor-metadata.service decoded-analysis LRU', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    // Small item cap so the eviction test is cheap and deterministic.
+    process.env.TENSOR_METADATA_LRU_MAX_ITEMS = '2';
+    process.env.TENSOR_METADATA_LRU_MAX_SIZE_BYTES = '0'; // disable byte cap for this suite
+    process.env.TENSOR_METADATA_LRU_TTL_MS = '0';
+  });
+
+  afterEach(() => {
+    delete process.env.TENSOR_METADATA_LRU_MAX_ITEMS;
+    delete process.env.TENSOR_METADATA_LRU_MAX_SIZE_BYTES;
+    delete process.env.TENSOR_METADATA_LRU_TTL_MS;
+    vi.clearAllMocks();
+  });
+
+  async function load() {
+    vi.resetModules();
+    vi.doMock('~/server/prom/client', () => ({
+      cacheHitCounter: { inc: cacheHitInc },
+      cacheMissCounter: { inc: cacheMissInc },
+    }));
+    return import('../tensor-metadata.service');
+  }
+
+  it('MISS invokes the fetcher and returns its result', async () => {
+    const { getFullTensorAnalysisCached, __tensorMetadataLruInternals } = await load();
+    __tensorMetadataLruInternals.clear();
+
+    const analysis = makeAnalysis(3, 'a');
+    const fetcher = vi.fn(async () => analysis);
+
+    const result = await getFullTensorAnalysisCached(1, fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result).toBe(analysis);
+    expect(result.tensors).toHaveLength(3);
+    expect(__tensorMetadataLruInternals.has(1)).toBe(true);
+  });
+
+  it('HIT returns the cached object WITHOUT re-invoking the fetcher (decode-once guard)', async () => {
+    const { getFullTensorAnalysisCached, __tensorMetadataLruInternals } = await load();
+    __tensorMetadataLruInternals.clear();
+
+    const analysis = makeAnalysis(5, 'hot');
+    const fetcher = vi.fn(async () => analysis);
+
+    const first = await getFullTensorAnalysisCached(42, fetcher);
+    const second = await getFullTensorAnalysisCached(42, fetcher);
+    const third = await getFullTensorAnalysisCached(42, fetcher);
+
+    // The decode (fetcher) ran exactly ONCE despite three reads — this is the relief.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(first).toBe(analysis);
+    expect(second).toBe(analysis);
+    expect(third).toBe(analysis);
+  });
+
+  it('caches distinct file ids independently', async () => {
+    const { getFullTensorAnalysisCached } = await load();
+
+    const a = makeAnalysis(2, 'idA');
+    const b = makeAnalysis(7, 'idB');
+    const fetcherA = vi.fn(async () => a);
+    const fetcherB = vi.fn(async () => b);
+
+    const ra1 = await getFullTensorAnalysisCached(100, fetcherA);
+    const rb1 = await getFullTensorAnalysisCached(200, fetcherB);
+    const ra2 = await getFullTensorAnalysisCached(100, fetcherA);
+    const rb2 = await getFullTensorAnalysisCached(200, fetcherB);
+
+    expect(ra1).toBe(a);
+    expect(ra2).toBe(a);
+    expect(rb1).toBe(b);
+    expect(rb2).toBe(b);
+    expect(fetcherA).toHaveBeenCalledTimes(1);
+    expect(fetcherB).toHaveBeenCalledTimes(1);
+  });
+
+  it('is BOUNDED — exceeding the item cap evicts LRU, forcing a re-decode of the evicted id', async () => {
+    // MAX_ITEMS=2 (set in beforeEach). Insert 1, 2, then 3 -> id 1 evicted.
+    const { getFullTensorAnalysisCached, __tensorMetadataLruInternals } = await load();
+    __tensorMetadataLruInternals.clear();
+
+    const f1 = vi.fn(async () => makeAnalysis(1, '1'));
+    const f2 = vi.fn(async () => makeAnalysis(1, '2'));
+    const f3 = vi.fn(async () => makeAnalysis(1, '3'));
+
+    await getFullTensorAnalysisCached(1, f1); // [1]
+    await getFullTensorAnalysisCached(2, f2); // [1,2]
+    await getFullTensorAnalysisCached(3, f3); // [2,3]  (1 evicted)
+
+    expect(__tensorMetadataLruInternals.size).toBe(2);
+    expect(__tensorMetadataLruInternals.has(1)).toBe(false);
+    expect(__tensorMetadataLruInternals.has(2)).toBe(true);
+    expect(__tensorMetadataLruInternals.has(3)).toBe(true);
+
+    // Re-reading the evicted id re-invokes the fetcher (no longer a hit).
+    await getFullTensorAnalysisCached(1, f1);
+    expect(f1).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects the byte cap (maxSize) when item cap is generous', async () => {
+    process.env.TENSOR_METADATA_LRU_MAX_ITEMS = '1000';
+    // Base 4096 + 256/tensor. A 10-tensor analysis ~= 4096 + 2560 = 6656 bytes.
+    // Cap at ~9000 bytes => only one such entry fits at a time.
+    process.env.TENSOR_METADATA_LRU_MAX_SIZE_BYTES = '9000';
+    const { getFullTensorAnalysisCached, __tensorMetadataLruInternals } = await load();
+    __tensorMetadataLruInternals.clear();
+
+    const fA = vi.fn(async () => makeAnalysis(10, 'A'));
+    const fB = vi.fn(async () => makeAnalysis(10, 'B'));
+
+    await getFullTensorAnalysisCached(1, fA);
+    await getFullTensorAnalysisCached(2, fB); // pushes total over the byte cap -> evicts id 1
+
+    expect(__tensorMetadataLruInternals.has(2)).toBe(true);
+    expect(__tensorMetadataLruInternals.has(1)).toBe(false);
+  });
+});

--- a/src/server/services/tensor-metadata.service.ts
+++ b/src/server/services/tensor-metadata.service.ts
@@ -1,0 +1,116 @@
+/**
+ * Tensor-metadata full-analysis read path with an in-process decoded-object LRU.
+ *
+ * BACKGROUND (the regression this guards against)
+ * -----------------------------------------------
+ * civitai #2500 caches the FULL parsed tensor analysis (`ModelTensorAnalysis`, incl.
+ * the ~335 KB `tensors[]` array) in `redis.packed` so the `/api/v1/model-files/[id]/
+ * tensor-metadata` accordion panel can render the tensor list. #2649 then made that
+ * full-blob cache brotli-COMPRESSED at rest to reclaim ~80 GiB on next-redis-cluster.
+ *
+ * The compress win is real, but it moved cost onto the HOT read path on the shared
+ * single-threaded `api-primary` event loop: every full read now does an async
+ * brotli-DECOMPRESS (libuv threadpool) PLUS a SYNCHRONOUS msgpack `unpack()` of the
+ * decompressed ~335 KB buffer into a big JS object — and that synchronous decode runs
+ * ON the main event loop, on every accordion-open model-page view. For a popular model
+ * many viewers hit the same file id, so the SAME decode is repeated per request and
+ * concentrates into the api-primary 504 "waves" (see the cluster handoff
+ * `dp_prod_api_primary_504_waves_readiness_cascade_2026_06_21`).
+ *
+ * THE FIX (this module)
+ * ---------------------
+ * A bounded in-process LRU of the already-DECODED `ModelTensorAnalysis`, keyed by file
+ * id. An LRU HIT returns the parsed object with ZERO redis read, ZERO brotli decompress
+ * and ZERO msgpack decode — so a popular model is decoded at most once per pod (until
+ * eviction) instead of once per request. This keeps #2649's redis memory win intact
+ * (the blob stays compressed+split in redis; this LRU only removes the REPEATED
+ * hot-path decode) and is the relief-bearing change for the 504 waves.
+ *
+ * The LRU is bounded BOTH by item count AND by an approximate byte size so a burst of
+ * distinct popular checkpoints can never grow the resident set without limit. On a
+ * cache miss the underlying redis `fetchThroughCache` is still single-flighted (its own
+ * per-pod in-flight map + distributed lock), so concurrent misses do not stampede the
+ * origin parse.
+ */
+
+import { LRUCache } from 'lru-cache';
+import { cacheHitCounter, cacheMissCounter } from '~/server/prom/client';
+import type { ModelTensorAnalysis } from '~/utils/model-tensor-metadata';
+
+const CACHE_NAME = 'tensor-metadata-full';
+
+// Item-count cap: a small set of "hot" checkpoints is what drives the repeated decode,
+// so a modest count is plenty. Tunable via env without a redeploy of intent.
+const MAX_ITEMS = Number(process.env.TENSOR_METADATA_LRU_MAX_ITEMS ?? 64);
+
+// Byte cap (approximate, on the decoded object) so a burst of large distinct models
+// cannot grow the resident set unbounded. Default ~256 MiB of decoded analyses.
+const MAX_SIZE_BYTES = Number(
+  process.env.TENSOR_METADATA_LRU_MAX_SIZE_BYTES ?? 256 * 1024 * 1024
+);
+
+// Optional TTL (ms). 0 = no time-based eviction (the data is immutable by file content,
+// so we rely on LRU + byte/count caps rather than time). Tunable via env.
+const TTL_MS = Number(process.env.TENSOR_METADATA_LRU_TTL_MS ?? 0);
+
+/**
+ * Approximate the in-memory footprint of a decoded analysis. We deliberately avoid
+ * JSON.stringify (that would itself walk + materialize the whole 335 KB+ object on the
+ * hot path, defeating the purpose). Instead estimate from the tensor count: each
+ * `ModelTensorInfo` is a small object with a name string + a short shape array — call it
+ * ~256 bytes of retained JS heap per tensor, plus a small fixed base. This is only an
+ * eviction heuristic; it does not need to be exact, only monotonic in object size.
+ */
+function estimateAnalysisBytes(analysis: ModelTensorAnalysis): number {
+  const tensorCount = analysis.tensors?.length ?? 0;
+  const APPROX_BYTES_PER_TENSOR = 256;
+  const BASE_BYTES = 4096;
+  // never report 0 — lru-cache requires sizeCalculation > 0.
+  return BASE_BYTES + tensorCount * APPROX_BYTES_PER_TENSOR;
+}
+
+// Always keep a definite count cap so the count-limit constructor overload is used
+// (the ttl-limit overload would require `ttlAutopurge`). The byte cap and the optional
+// TTL are spread in only when enabled, so `maxSize`+`sizeCalculation` always travel
+// together and `ttl`+`ttlAutopurge` always travel together (lru-cache v11 invariants).
+const decodedAnalysisLru = new LRUCache<number, ModelTensorAnalysis>({
+  max: MAX_ITEMS > 0 ? MAX_ITEMS : 64,
+  ...(MAX_SIZE_BYTES > 0
+    ? { maxSize: MAX_SIZE_BYTES, sizeCalculation: estimateAnalysisBytes }
+    : {}),
+  ...(TTL_MS > 0 ? { ttl: TTL_MS, ttlAutopurge: false } : {}),
+});
+
+/**
+ * Return the full decoded tensor analysis for a file id, served from the in-process
+ * LRU when warm. On a miss, `fetchDecoded` is invoked (the redis-backed compressed
+ * `fetchThroughCache` path), the result is stored, and returned.
+ *
+ * @param fileId        model file id (the cache key)
+ * @param fetchDecoded  miss handler that produces the decoded analysis (redis-backed)
+ */
+export async function getFullTensorAnalysisCached(
+  fileId: number,
+  fetchDecoded: () => Promise<ModelTensorAnalysis>
+): Promise<ModelTensorAnalysis> {
+  const cached = decodedAnalysisLru.get(fileId);
+  if (cached !== undefined) {
+    cacheHitCounter.inc({ cache_name: CACHE_NAME, cache_type: 'lruCache' });
+    return cached;
+  }
+
+  cacheMissCounter.inc({ cache_name: CACHE_NAME, cache_type: 'lruCache' });
+  const analysis = await fetchDecoded();
+  decodedAnalysisLru.set(fileId, analysis);
+  return analysis;
+}
+
+/** Test/maintenance helpers — not used on the request path. */
+export const __tensorMetadataLruInternals = {
+  clear: () => decodedAnalysisLru.clear(),
+  get size() {
+    return decodedAnalysisLru.size;
+  },
+  has: (fileId: number) => decodedAnalysisLru.has(fileId),
+  peek: (fileId: number) => decodedAnalysisLru.peek(fileId),
+};


### PR DESCRIPTION
## Problem
api-primary 504 "waves" regressed starting **06-20**. 504-wave/day history is a clean before/after: **06-17=0, 06-18=0, 06-19=1, 06-20=7, 06-21=17** — restarting exactly when **#2649** (compress+split tensor-metadata cache) deployed (06-19).

#2649's redis memory win is real (~80 GiB off next-redis-cluster), but it moved cost onto the **hot read path**: the #2500 Tensors accordion fetches the **full blob on every model-page view** for any user with the panel open in localStorage. Each full read now pays an async brotli-decompress **plus a synchronous msgpack-decode of the ~335 KB buffer into a large JS object** — and that decode runs on the shared single-threaded api-primary event loop. For a popular file the **same decode repeats per request** → concentrates into the 504 waves (confirmed: a wedged pod's event-loop main thread pegs at ~100%).

## Fix
A bounded **in-process LRU of the already-decoded `ModelTensorAnalysis`**, keyed by file id (`src/server/services/tensor-metadata.service.ts`). An LRU **hit** returns the parsed object with **zero** redis read, brotli-decompress, or msgpack-decode → a hot model is decoded **at most once per pod** instead of once per request. This is the relief-bearing change.

**Does NOT revert #2649** — the blob stays compressed+split in redis (the ~80 GiB win is preserved); we only remove the *repeated* hot-path decode. (Off-thread/worker decode was considered and rejected: you'd still pay structured-clone transferring the large decoded object back to the main thread, so "decode once and keep it" is the better design.)

Bounded by item count (default 64) AND approximate decoded bytes (~256 MiB), both env-tunable (`TENSOR_METADATA_LRU_MAX_ITEMS` / `_MAX_SIZE_BYTES` / `_TTL_MS`). Misses single-flight through the existing redis `fetchThroughCache`, so concurrent misses don't stampede. Server-only module (imported only by the API route).

## Tests
`tensor-metadata-service.test.ts` (5): miss invokes fetcher; **hit returns decoded object WITHOUT re-decoding** (the regression guard); distinct ids cached independently; count-cap + byte-cap eviction force re-decode. Existing tensor split + packed-compression suites stay green (**16/16 total pass**). Type-clean.

## Verify in prod
After deploy, at the next would-be-wave window: 504-wave rate should flatline; `tensor-metadata-full` LRU hit-rate (cacheHit/Miss prom counters, `cache_type="lruCache"`) climbs; per-pod event-loop CPU stays bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)