### PR TITLE
perf(tensor-metadata): single-flight concurrent decodes + LRU follow-ups (#2677 audit)

### DIFF
--- a/src/server/services/__tests__/tensor-metadata-service.test.ts
+++ b/src/server/services/__tests__/tensor-metadata-service.test.ts
@@ -140,9 +140,9 @@ describe('tensor-metadata.service decoded-analysis LRU', () => {
 
   it('respects the byte cap (maxSize) when item cap is generous', async () => {
     process.env.TENSOR_METADATA_LRU_MAX_ITEMS = '1000';
-    // Base 4096 + 256/tensor. A 10-tensor analysis ~= 4096 + 2560 = 6656 bytes.
-    // Cap at ~9000 bytes => only one such entry fits at a time.
-    process.env.TENSOR_METADATA_LRU_MAX_SIZE_BYTES = '9000';
+    // Base 4096 + 640/tensor. A 10-tensor analysis ~= 4096 + 6400 = 10496 bytes.
+    // Cap at 16000 bytes => one such entry fits, a second pushes over and evicts the first.
+    process.env.TENSOR_METADATA_LRU_MAX_SIZE_BYTES = '16000';
     const { getFullTensorAnalysisCached, __tensorMetadataLruInternals } = await load();
     __tensorMetadataLruInternals.clear();
 
@@ -154,5 +154,70 @@ describe('tensor-metadata.service decoded-analysis LRU', () => {
 
     expect(__tensorMetadataLruInternals.has(2)).toBe(true);
     expect(__tensorMetadataLruInternals.has(1)).toBe(false);
+  });
+
+  it('SINGLE-FLIGHTS concurrent cold misses for the same id (decode runs once)', async () => {
+    const { getFullTensorAnalysisCached, __tensorMetadataLruInternals } = await load();
+    __tensorMetadataLruInternals.clear();
+
+    const analysis = makeAnalysis(4, 'concurrent');
+    // A fetcher that resolves on the next microtask tick so all callers overlap before
+    // the first `.set` lands — the cold-burst window the in-flight map must collapse.
+    let resolve!: (v: ModelTensorAnalysis) => void;
+    const gate = new Promise<ModelTensorAnalysis>((r) => (resolve = r));
+    const fetcher = vi.fn(() => gate);
+
+    const p1 = getFullTensorAnalysisCached(7, fetcher);
+    const p2 = getFullTensorAnalysisCached(7, fetcher);
+    const p3 = getFullTensorAnalysisCached(7, fetcher);
+    expect(__tensorMetadataLruInternals.inFlightSize).toBe(1);
+    resolve(analysis);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    // Three concurrent misses → exactly ONE decode (the herd is collapsed).
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(analysis);
+    expect(r2).toBe(analysis);
+    expect(r3).toBe(analysis);
+    // In-flight entry cleared after settle; result is now a warm hit.
+    expect(__tensorMetadataLruInternals.inFlightSize).toBe(0);
+    expect(__tensorMetadataLruInternals.has(7)).toBe(true);
+  });
+
+  it('does NOT cache a rejected decode, and clears the in-flight entry (next read retries)', async () => {
+    const { getFullTensorAnalysisCached, __tensorMetadataLruInternals } = await load();
+    __tensorMetadataLruInternals.clear();
+
+    const boom = new Error('decode failed');
+    const failing = vi.fn(async () => {
+      throw boom;
+    });
+    await expect(getFullTensorAnalysisCached(9, failing)).rejects.toThrow('decode failed');
+    // Nothing cached, no wedged in-flight entry.
+    expect(__tensorMetadataLruInternals.has(9)).toBe(false);
+    expect(__tensorMetadataLruInternals.inFlightSize).toBe(0);
+
+    // A subsequent read RETRIES the fetcher (the failure was not memoized).
+    const ok = makeAnalysis(2, 'recovered');
+    const succeeding = vi.fn(async () => ok);
+    const result = await getFullTensorAnalysisCached(9, succeeding);
+    expect(result).toBe(ok);
+    expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+
+  it('bustFullTensorAnalysis evicts a warm entry, forcing a re-decode', async () => {
+    const { getFullTensorAnalysisCached, bustFullTensorAnalysis, __tensorMetadataLruInternals } =
+      await load();
+    __tensorMetadataLruInternals.clear();
+
+    const fetcher = vi.fn(async () => makeAnalysis(3, 'bustable'));
+    await getFullTensorAnalysisCached(11, fetcher);
+    expect(__tensorMetadataLruInternals.has(11)).toBe(true);
+
+    bustFullTensorAnalysis(11);
+    expect(__tensorMetadataLruInternals.has(11)).toBe(false);
+
+    await getFullTensorAnalysisCached(11, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(2); // re-decoded after bust
   });
 });

--- a/src/server/services/tensor-metadata.service.ts
+++ b/src/server/services/tensor-metadata.service.ts
@@ -57,13 +57,16 @@ const TTL_MS = Number(process.env.TENSOR_METADATA_LRU_TTL_MS ?? 0);
  * Approximate the in-memory footprint of a decoded analysis. We deliberately avoid
  * JSON.stringify (that would itself walk + materialize the whole 335 KB+ object on the
  * hot path, defeating the purpose). Instead estimate from the tensor count: each
- * `ModelTensorInfo` is a small object with a name string + a short shape array — call it
- * ~256 bytes of retained JS heap per tensor, plus a small fixed base. This is only an
- * eviction heuristic; it does not need to be exact, only monotonic in object size.
+ * `ModelTensorInfo` is a small object with a name string + a short shape array. We use a
+ * deliberately CONSERVATIVE ~640 B/tensor (V8 object overhead + a long dotted tensor-name
+ * string + the shape array can run well past a naive 256 B), so the byte cap errs toward
+ * evicting SOONER rather than under-counting and overshooting the cap. This is only a
+ * heuristic, not exact — the authoritative hard bound on resident set is the ITEM-COUNT
+ * cap (`MAX_ITEMS`); the byte cap is a secondary guard against a burst of huge models.
  */
 function estimateAnalysisBytes(analysis: ModelTensorAnalysis): number {
   const tensorCount = analysis.tensors?.length ?? 0;
-  const APPROX_BYTES_PER_TENSOR = 256;
+  const APPROX_BYTES_PER_TENSOR = 640;
   const BASE_BYTES = 4096;
   // never report 0 — lru-cache requires sizeCalculation > 0.
   return BASE_BYTES + tensorCount * APPROX_BYTES_PER_TENSOR;
@@ -81,10 +84,20 @@ const decodedAnalysisLru = new LRUCache<number, ModelTensorAnalysis>({
   ...(TTL_MS > 0 ? { ttl: TTL_MS, ttlAutopurge: false } : {}),
 });
 
+// Per-id in-flight decode promises. The LRU only caches RESOLVED objects, so without
+// this a burst of concurrent misses for the SAME cold id (e.g. a popular model right
+// after a deploy or an eviction, before the first `.set` lands) would each run the full
+// decompress+decode — the exact cost we're removing, just confined to the warm-up window.
+// Coalescing concurrent misses onto ONE shared promise closes that residual cold-burst.
+// (The redis `fetchThroughCache` single-flight only dedups the ORIGIN PARSE on a redis
+// MISS — it does NOT dedup the decompress+decode of a redis HIT, which is the wave cost.)
+const inFlightDecodes = new Map<number, Promise<ModelTensorAnalysis>>();
+
 /**
  * Return the full decoded tensor analysis for a file id, served from the in-process
  * LRU when warm. On a miss, `fetchDecoded` is invoked (the redis-backed compressed
- * `fetchThroughCache` path), the result is stored, and returned.
+ * `fetchThroughCache` path), the result is stored, and returned. Concurrent misses for
+ * the same id share a single in-flight decode (no thundering herd while cold).
  *
  * @param fileId        model file id (the cache key)
  * @param fetchDecoded  miss handler that produces the decoded analysis (redis-backed)
@@ -99,17 +112,51 @@ export async function getFullTensorAnalysisCached(
     return cached;
   }
 
+  // Join an in-flight decode for this id if one exists (counts as a hit — it avoids a
+  // second decode). Only the request that STARTS the decode is counted as a miss.
+  const pending = inFlightDecodes.get(fileId);
+  if (pending) {
+    cacheHitCounter.inc({ cache_name: CACHE_NAME, cache_type: 'lruCache' });
+    return pending;
+  }
+
   cacheMissCounter.inc({ cache_name: CACHE_NAME, cache_type: 'lruCache' });
-  const analysis = await fetchDecoded();
-  decodedAnalysisLru.set(fileId, analysis);
-  return analysis;
+  const decodePromise = (async () => {
+    // `.set` only on SUCCESS; on throw nothing is cached. `finally` always clears the
+    // in-flight entry so a rejected decode does not wedge future reads.
+    const analysis = await fetchDecoded();
+    decodedAnalysisLru.set(fileId, analysis);
+    return analysis;
+  })().finally(() => {
+    inFlightDecodes.delete(fileId);
+  });
+  inFlightDecodes.set(fileId, decodePromise);
+  return decodePromise;
+}
+
+/**
+ * Invalidate the in-process cache for a file id. No production caller today (tensor
+ * metadata is immutable per file-content and has no redis bust path), but this is the
+ * hook a future re-scan / parser-version change would call to force a re-decode without
+ * waiting for LRU eviction or a pod restart. Clears both the cached object and any
+ * in-flight decode.
+ */
+export function bustFullTensorAnalysis(fileId: number): void {
+  decodedAnalysisLru.delete(fileId);
+  inFlightDecodes.delete(fileId);
 }
 
 /** Test/maintenance helpers — not used on the request path. */
 export const __tensorMetadataLruInternals = {
-  clear: () => decodedAnalysisLru.clear(),
+  clear: () => {
+    decodedAnalysisLru.clear();
+    inFlightDecodes.clear();
+  },
   get size() {
     return decodedAnalysisLru.size;
+  },
+  get inFlightSize() {
+    return inFlightDecodes.size;
   },
   has: (fileId: number) => decodedAnalysisLru.has(fileId),
   peek: (fileId: number) => decodedAnalysisLru.peek(fileId),


### PR DESCRIPTION
Audit follow-ups to **#2677** (the in-process decoded-tensor-metadata LRU that fixed the api-primary 504 waves). #2677 is merged + deployed and verified live (the `cache_type="lruCache"` metric is emitting; 504-wave rate flat so far). These close the audit's 🟡 items.

## 1. Single-flight concurrent cold decodes (the main one)
#2677 caches only **resolved** objects, so a burst of concurrent misses for the same **cold** id (a popular model right after a deploy/eviction, before the first `.set` lands) would each run the full brotli-decompress + ~335 KB msgpack-decode — the wave cost, confined to the warm-up window. (The redis `fetchThroughCache` single-flight only dedups the *origin parse* on a redis miss, **not** the decompress+decode of a redis *hit*.)

Now concurrent misses for the same id coalesce onto **one** in-flight decode promise; only the starter counts as a miss, joiners as hits. **Rejected decodes are not cached** and the in-flight entry is always cleared (no wedge on failure).

## 2. `bustFullTensorAnalysis(fileId)` invalidation hook
No caller today (tensor metadata is immutable per file-content and has no redis bust path), but this is the hook a future re-scan / parser-version change calls to force a re-decode without waiting for LRU eviction or a pod restart.

## 3. Byte-cap estimate 256 → 640 B/tensor
The naive 256 B under-counted real retained heap (V8 overhead + long dotted tensor names + shape arrays). Bumped to a conservative 640 so the byte cap errs toward evicting **sooner**; the authoritative resident-set bound remains the **item-count cap** (`MAX_ITEMS`, default 64) — verified bounded vs the 5 Gi pod limit (~4 Gi headroom).

## Tests
+3 (single-flight decode-once under concurrency; rejected decode not cached + retried; bust forces re-decode). **8/8 pass, type-clean.** Server-only module; no client-bundle reachability change.

Based directly on `main` (not stacked on #2677, which is already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)