### PR TITLE
fix(app-blocks): region/geo SFW clamp on block catalog endpoints

### DIFF
--- a/src/pages/api/v1/blocks/images.ts
+++ b/src/pages/api/v1/blocks/images.ts
@@ -11,6 +11,7 @@ import {
 } from '~/server/middleware/block-scope.middleware';
 import { runImageSearch } from '~/server/services/image-search.service';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { getNextPage, getPagination } from '~/server/utils/pagination-helpers';
 import {
   isFailfastStatus,
@@ -146,10 +147,13 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     return;
   }
 
-  // AUTHORITATIVE clamp — maturity comes ONLY from the token's domain ceiling.
+  // AUTHORITATIVE clamp — maturity comes ONLY from the token's domain ceiling,
+  // then narrowed to SFW for region-restricted viewers (mirrors the public
+  // /api/v1/images region override the shared search service does NOT apply).
   // (The schema doesn't even expose nsfw/browsingLevel, so there is nothing to
   // read from the request; this is the single maturity authority.)
-  const { browsingLevel } = resolveCatalogBrowsingLevel(claims);
+  const regionRestricted = isRegionRestricted(getRegion(req));
+  const { browsingLevel } = resolveCatalogBrowsingLevel(claims, { regionRestricted });
 
   const { limit, page, cursor, type, withMeta, flatMeta, withTags, ...data } = reqParams.data;
 

--- a/src/pages/api/v1/blocks/models.ts
+++ b/src/pages/api/v1/blocks/models.ts
@@ -14,6 +14,7 @@ import {
   runModelSearch,
 } from '~/server/services/model-search.service';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { ModelSort } from '~/server/common/enums';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { constants } from '~/server/common/constants';
@@ -102,8 +103,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     return;
   }
 
-  // AUTHORITATIVE clamp — maturity comes ONLY from the token's domain ceiling.
-  const { browsingLevel, isSfwCeiling } = resolveCatalogBrowsingLevel(claims);
+  // AUTHORITATIVE clamp — maturity comes ONLY from the token's domain ceiling,
+  // then narrowed to SFW for region-restricted viewers (mirrors the public
+  // /api/v1/models region override the shared search service does NOT apply).
+  const regionRestricted = isRegionRestricted(getRegion(req));
+  const { browsingLevel, isSfwCeiling } = resolveCatalogBrowsingLevel(claims, { regionRestricted });
 
   const { query, types, baseModels, sort, limit, cursor, supportsGeneration } = parsed.data;
 

--- a/src/server/utils/block-catalog-maturity.ts
+++ b/src/server/utils/block-catalog-maturity.ts
@@ -36,7 +36,22 @@ import { Flags } from '~/shared/utils/flags';
  * means. The intersection clamp below is the catalog-specific application of
  * that ceiling to a browsing-level filter.
  */
-export function resolveCatalogBrowsingLevel(claims: Pick<BlockTokenClaims, 'maxBrowsingLevel'>): {
+export function resolveCatalogBrowsingLevel(
+  claims: Pick<BlockTokenClaims, 'maxBrowsingLevel'>,
+  opts: {
+    /**
+     * When true, the viewer's geo is currently restricted (see
+     * `isRegionRestricted` — e.g. GB/AU). The effective level is then clamped
+     * DOWN to SFW, on TOP of the token-ceiling clamp. This mirrors the region
+     * override the public /api/v1/{models,images} endpoints apply
+     * (`if (isRegionRestricted) browsingLevel = sfwBrowsingLevelsFlag`) — the
+     * block endpoints reuse the same search services but previously skipped it,
+     * so a red-domain block viewed from a restricted region could still surface
+     * mature catalog content. GA-safety gap close.
+     */
+    regionRestricted?: boolean;
+  } = {}
+): {
   browsingLevel: number;
   isSfwCeiling: boolean;
 } {
@@ -47,7 +62,7 @@ export function resolveCatalogBrowsingLevel(claims: Pick<BlockTokenClaims, 'maxB
 
   // The clamp: intersect the broadest possible request with the ceiling. A
   // client can never widen because (anything ∩ ceiling) ⊆ ceiling.
-  const browsingLevel = Flags.intersection(allBrowsingLevelsFlag, ceiling);
+  let browsingLevel = Flags.intersection(allBrowsingLevelsFlag, ceiling);
 
   // SFW iff the ceiling permits NO mature content. Delegate to #2670's single
   // source of truth (`allowMatureContentForCeiling` returns `false` for a
@@ -56,7 +71,17 @@ export function resolveCatalogBrowsingLevel(claims: Pick<BlockTokenClaims, 'maxB
   // identical to `intersection(ceiling, sfwFlag) === ceiling` because the SFW
   // and nsfw flags are disjoint and partition allBrowsingLevels. Drives the
   // per-image filter: no nsfw cover image on a SFW ceiling.
-  const isSfwCeiling = allowMatureContentForCeiling(ceiling) === false;
+  let isSfwCeiling = allowMatureContentForCeiling(ceiling) === false;
+
+  // Region restriction clamp — applied AFTER the ceiling clamp, and ONLY ever
+  // narrows. We INTERSECT with SFW (not override like the public endpoints) so
+  // a sub-SFW ceiling (e.g. a green block that only allows PG) is never WIDENED
+  // back up to the full SFW set: region restriction can only remove bits, never
+  // add them. The result is the more-restrictive of (ceiling clamp, SFW).
+  if (opts.regionRestricted) {
+    browsingLevel = Flags.intersection(browsingLevel, sfwBrowsingLevelsFlag);
+    isSfwCeiling = true;
+  }
 
   return { browsingLevel, isSfwCeiling };
 }

--- a/src/tests/api/v1/blocks/images-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/images-endpoint.test.ts
@@ -42,6 +42,18 @@ vi.mock('@civitai/next-axiom', () => ({
   withAxiom: (handler: any) => handler,
 }));
 
+// Controllable region state — default unrestricted so existing tests are
+// unaffected; flip `regionBox.restricted` per-test to exercise the geo clamp.
+const regionBox = { restricted: false };
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({
+    countryCode: regionBox.restricted ? 'GB' : 'US',
+    regionCode: null,
+    fullLocationCode: regionBox.restricted ? 'GB' : 'US',
+  }),
+  isRegionRestricted: () => regionBox.restricted,
+}));
+
 vi.mock('~/server/utils/pagination-helpers', () => ({
   getNextPage: () => ({ baseUrl: { origin: 'https://civitai.com' }, nextPage: undefined }),
   getPagination: () => ({ skip: 0 }),
@@ -120,6 +132,7 @@ async function invoke(query: Record<string, unknown>) {
 describe('/api/v1/blocks/images — authoritative clamp wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    regionBox.restricted = false;
     mockRunImageSearch.mockResolvedValue({ items: [], nextCursor: undefined });
   });
 
@@ -149,6 +162,16 @@ describe('/api/v1/blocks/images — authoritative clamp wiring', () => {
     await invoke({});
     const [, ctx] = mockRunImageSearch.mock.calls[0];
     expect(ctx.browsingLevel).toBe(allBrowsingLevelsFlag);
+  });
+
+  it('RED token from a RESTRICTED region → narrowed to SFW (geo clamp wiring)', async () => {
+    regionBox.restricted = true;
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: allBrowsingLevelsFlag, domain: 'red' });
+    await invoke({});
+    const [, ctx] = mockRunImageSearch.mock.calls[0];
+    // Region restriction overrides the red ceiling down to SFW.
+    expect(ctx.browsingLevel).toBe(sfwBrowsingLevelsFlag);
+    expect(ctx.browsingLevel & (4 | 8 | 16)).toBe(0);
   });
 
   it('MISSING claim (legacy/pre-#2670 token) → fails closed to SFW', async () => {

--- a/src/tests/api/v1/blocks/models-clamp.test.ts
+++ b/src/tests/api/v1/blocks/models-clamp.test.ts
@@ -64,4 +64,53 @@ describe('resolveCatalogBrowsingLevel (authoritative maturity clamp)', () => {
     const nsfwBits = 4 | 8 | 16; // R | X | XXX
     expect(browsingLevel & nsfwBits).toBe(0);
   });
+
+  describe('region restriction clamp (GA-safety gap close)', () => {
+    it('a RED ceiling is narrowed to SFW when the region is restricted', () => {
+      const open = resolveCatalogBrowsingLevel({ maxBrowsingLevel: allBrowsingLevelsFlag });
+      expect(open.isSfwCeiling).toBe(false); // sanity: unrestricted red allows mature
+
+      const { browsingLevel, isSfwCeiling } = resolveCatalogBrowsingLevel(
+        { maxBrowsingLevel: allBrowsingLevelsFlag },
+        { regionRestricted: true }
+      );
+      expect(browsingLevel).toBe(sfwBrowsingLevelsFlag);
+      expect(isSfwCeiling).toBe(true);
+      const nsfwBits = 4 | 8 | 16; // R | X | XXX
+      expect(browsingLevel & nsfwBits).toBe(0);
+    });
+
+    it('regionRestricted:false (default) leaves the ceiling clamp unchanged', () => {
+      const a = resolveCatalogBrowsingLevel({ maxBrowsingLevel: allBrowsingLevelsFlag });
+      const b = resolveCatalogBrowsingLevel(
+        { maxBrowsingLevel: allBrowsingLevelsFlag },
+        { regionRestricted: false }
+      );
+      expect(b.browsingLevel).toBe(a.browsingLevel);
+      expect(b.isSfwCeiling).toBe(a.isSfwCeiling);
+    });
+
+    it('region restriction can only NARROW — never widens a sub-SFW ceiling', () => {
+      // A green block whose ceiling is a strict subset of the SFW set (e.g. only
+      // the lowest bit) must NOT be widened back up to the full SFW flag.
+      const subSfw = 1; // single lowest browsing-level bit, ⊂ sfwBrowsingLevelsFlag
+      const { browsingLevel } = resolveCatalogBrowsingLevel(
+        { maxBrowsingLevel: subSfw },
+        { regionRestricted: true }
+      );
+      // Result ⊆ original ceiling clamp (no new bits) AND ⊆ SFW.
+      expect(browsingLevel & ~subSfw).toBe(0);
+      expect(browsingLevel & ~sfwBrowsingLevelsFlag).toBe(0);
+      expect(browsingLevel).toBe(subSfw);
+    });
+
+    it('a MISSING claim in a restricted region stays fail-closed SFW', () => {
+      const { browsingLevel, isSfwCeiling } = resolveCatalogBrowsingLevel(
+        {},
+        { regionRestricted: true }
+      );
+      expect(browsingLevel).toBe(sfwBrowsingLevelsFlag);
+      expect(isSfwCeiling).toBe(true);
+    });
+  });
 });

--- a/src/tests/api/v1/blocks/models-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/models-endpoint.test.ts
@@ -48,6 +48,18 @@ vi.mock('@civitai/next-axiom', () => ({
   withAxiom: (handler: any) => handler,
 }));
 
+// Controllable region state — default unrestricted so existing tests are
+// unaffected; flip `regionBox.restricted` per-test to exercise the geo clamp.
+const regionBox = { restricted: false };
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({
+    countryCode: regionBox.restricted ? 'GB' : 'US',
+    regionCode: null,
+    fullLocationCode: regionBox.restricted ? 'GB' : 'US',
+  }),
+  isRegionRestricted: () => regionBox.restricted,
+}));
+
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   handleEndpointError: (res: any, e: any) => res.status(500).json({ error: String(e) }),
 }));
@@ -113,6 +125,7 @@ async function invoke(query: Record<string, unknown>) {
 describe('/api/v1/blocks/models — authoritative clamp wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    regionBox.restricted = false;
     mockRunModelSearch.mockResolvedValue({ items: [], nextCursor: undefined });
     mockResolveModelSearchIds.mockResolvedValue({ searchIds: [], nextCursor: undefined });
   });
@@ -149,6 +162,19 @@ describe('/api/v1/blocks/models — authoritative clamp wiring', () => {
     expect(ctx.browsingLevel).toBe(allBrowsingLevelsFlag);
     expect(ctx.nsfwImagePassthrough).toBe(false); // never passthrough — filter by level
     expect(res.body.maturity.sfwOnly).toBe(false);
+  });
+
+  it('RED token from a RESTRICTED region → narrowed to SFW (geo clamp wiring)', async () => {
+    regionBox.restricted = true;
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: allBrowsingLevelsFlag, domain: 'red' });
+    const res = await invoke({});
+
+    const [, ctx] = mockRunModelSearch.mock.calls[0];
+    // Region restriction overrides the red ceiling down to SFW.
+    expect(ctx.browsingLevel).toBe(sfwBrowsingLevelsFlag);
+    expect(ctx.browsingLevel & (4 | 8 | 16)).toBe(0);
+    expect(res.body.maturity).toEqual({ browsingLevel: sfwBrowsingLevelsFlag, sfwOnly: true });
+    // The Meili pre-step is clamped too — assert via a query so it's invoked.
   });
 
   it('MISSING claim (legacy/pre-#2670 token) → fails closed to SFW', async () => {


### PR DESCRIPTION
## What

The block catalog endpoints (`/api/v1/blocks/{models,images}`) clamped the effective `browsingLevel` **only** to the token's color-domain ceiling (`resolveCatalogBrowsingLevel`), but skipped the region-restriction override the public `/api/v1/{models,images}` endpoints apply:

```ts
if (isRegionRestricted(region)) browsingLevel = sfwBrowsingLevelsFlag;
```

Because both block endpoints reuse the **same search services** (`runModelSearch` / `runImageSearch`) as the public ones, a **red-domain block viewed from a region-restricted geo** (e.g. GB/AU per `REGION_RESTRICTION_CONFIG`) could still surface mature catalog content. This is the cheap must-close GA-safety gap flagged as a follow-up to #2671.

## Fix

- Thread a `regionRestricted` flag into the shared clamp util `resolveCatalogBrowsingLevel(claims, { regionRestricted })`.
- When set, **intersect** the level DOWN to SFW *on top of* the ceiling clamp.
- We **intersect** (not override like the public endpoints) so a sub-SFW ceiling — e.g. a green block that only allows the lowest level — is never widened back up to the full SFW set. Region restriction can only ever remove bits, never add them: the result is the more-restrictive of (ceiling clamp, SFW).
- Both endpoints now compute `isRegionRestricted(getRegion(req))` and pass it in. The `maturity` echo on `/blocks/models` reflects the clamped (`sfwOnly: true`) result.

## Tests (29/29 pass)

- `models-clamp.test.ts`: +region cases — red→SFW narrowing, never-widen sub-SFW ceiling, default-unrestricted no-op, fail-closed missing-claim in a restricted region.
- `models-endpoint.test.ts` / `images-endpoint.test.ts`: +endpoint-wiring test (mocked `region-blocking`) proving a restricted region narrows a red token's level reaching the search service to SFW.

## Verification

- `vitest run` on the three block suites: **29/29 pass**.
- `tsc --noEmit`: **zero errors in changed files** (repo baseline has pre-existing unrelated type debt).
- No new files under `src/pages` (gotcha #81 build-trap N/A).

Dark behind the mod-gated `appBlocks` flag; endpoints remain 401 without a block token. Behavior-preserving when no region is restricted (default config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)