### PR TITLE
perf(track): move addView off the tRPC middleware path to a beacon route

### DIFF
--- a/src/components/TrackView/TrackView.tsx
+++ b/src/components/TrackView/TrackView.tsx
@@ -4,7 +4,27 @@ import { useAdsContext } from '~/components/Ads/AdsProvider';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
 import type { AddViewSchema } from '~/server/schema/track.schema';
-import { trpc } from '~/utils/trpc';
+import { removeEmpty } from '~/utils/object-helpers';
+
+// Fire a view event at the lightweight /api/track/view beacon instead of the
+// track.addView tRPC mutation. addView was the #1 request-count source on
+// api-primary (~71 req/s) and paid the full tRPC middleware chain + superjson
+// encode per call for an empty, fire-and-forget response. The beacon route runs
+// the same Tracker.view() (same ClickHouse `views` insert, same payload shape)
+// without any of that fixed per-request cost. `keepalive: true` lets the request
+// survive a page unload/navigation (mirrors /api/page-view), so the event isn't
+// lost if the user clicks through immediately after the 1s debounce fires.
+function sendView(input: AddViewSchema) {
+  void fetch('/api/track/view', {
+    method: 'POST',
+    keepalive: true,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(removeEmpty(input)),
+  }).catch(() => {
+    // Fire-and-forget telemetry: a failed beacon must never surface to the user
+    // or throw an unhandled rejection. The server side already retries/logs.
+  });
+}
 
 export function TrackView({
   type,
@@ -14,7 +34,6 @@ export function TrackView({
   nsfw: nsfwOverride,
   nsfwLevel,
 }: AddViewSchema) {
-  const trackMutation = trpc.track.addView.useMutation();
   const observedEntityId = useRef<number | null>(null);
   const { adsEnabled, adsBlocked, useDirectAds } = useAdsContext();
 
@@ -25,7 +44,7 @@ export function TrackView({
     const timeout = setTimeout(() => {
       if (entityId !== observedEntityId.current) {
         observedEntityId.current = entityId;
-        trackMutation.mutate({
+        sendView({
           type,
           entityType,
           entityId,

--- a/src/pages/api/track/view.ts
+++ b/src/pages/api/track/view.ts
@@ -1,0 +1,58 @@
+import { isDev } from '~/env/other';
+import { Tracker } from '~/server/clickhouse/client';
+import { addViewSchema } from '~/server/schema/track.schema';
+import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+
+// Lightweight beacon endpoint for view tracking. Replaces the `track.addView`
+// tRPC mutation for the browser <TrackView> component (~71 req/s, the #1
+// request-count source on api-primary). The tRPC procedure paid the full
+// non-batched middleware chain (recordProcedureDuration -> isAcceptableOrigin
+// -> enforceClientVersion -> applyDomainFeature[Flipt] -> enforceTokenScope) +
+// superjson encode per call for an empty, fire-and-forget response. This route
+// runs none of that — it resolves session/ip/userAgent via the same Tracker and
+// fires the identical `views` ClickHouse insert, so the analytics payload shape
+// and volume are unchanged.
+//
+// Same-origin only: validated by referer/origin host == request host, matching
+// the sibling /api/page-view beacon. The browser <TrackView> is always
+// cookie-authenticated; bearer/API-key callers keep using the tRPC
+// `track.addView` procedure (which still enforces UserWrite scope).
+export default PublicEndpoint(
+  async (req, res) => {
+    if (isDev) return res.status(200).end();
+
+    // Same-origin guard (mirrors /api/page-view). Origin preferred, referer
+    // fallback for clients that suppress Origin.
+    const source = req.headers.origin ?? req.headers.referer;
+    const sourceHost = source
+      ? (() => {
+          try {
+            return new URL(source).host;
+          } catch {
+            return undefined;
+          }
+        })()
+      : undefined;
+    if (!sourceHost || sourceHost !== req.headers.host)
+      return res.status(400).send('invalid request');
+
+    let parsed;
+    try {
+      parsed = JSON.parse(req.body);
+    } catch {
+      return res.status(400).send('invalid body');
+    }
+
+    const result = addViewSchema.safeParse(parsed);
+    if (!result.success) return res.status(400).send('invalid input');
+
+    const tracker = new Tracker(req, res);
+    // Fire-and-forget: view() resolves the session, builds the actor, and
+    // dispatches the ClickHouse insert without awaiting the network round-trip
+    // (same as the tRPC resolver). We don't await it.
+    void tracker.view(result.data);
+
+    return res.status(200).end();
+  },
+  ['POST']
+);

--- a/src/pages/api/track/view.ts
+++ b/src/pages/api/track/view.ts
@@ -36,9 +36,15 @@ export default PublicEndpoint(
     if (!sourceHost || sourceHost !== req.headers.host)
       return res.status(400).send('invalid request');
 
-    let parsed;
+    // Next's body parser already deserializes an `application/json` request body
+    // into an object (the <TrackView> client sends that Content-Type), but a
+    // client that omits Content-Type (text/plain) leaves it a raw string. Handle
+    // BOTH — JSON.parse(<object>) would throw ("[object Object]") and 400 every
+    // real browser beacon. (The /api/page-view sibling only does JSON.parse
+    // because ITS client sends no Content-Type.)
+    let parsed: unknown;
     try {
-      parsed = JSON.parse(req.body);
+      parsed = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
     } catch {
       return res.status(400).send('invalid body');
     }

--- a/src/server/clickhouse/client.ts
+++ b/src/server/clickhouse/client.ts
@@ -498,7 +498,19 @@ export class Tracker {
     });
   }
 
-  public view(values: { type: ViewType; entityType: EntityType; entityId: number }) {
+  public view(values: {
+    type: ViewType;
+    entityType: EntityType;
+    entityId: number;
+    // Optional client-supplied context, forwarded verbatim into the `views`
+    // ClickHouse row (same shape the track.addView tRPC resolver passed
+    // through). Kept optional so server-side callers can omit them.
+    ads?: 'Member' | 'Blocked' | 'Served' | 'Off';
+    nsfw?: boolean;
+    nsfwLevel?: number;
+    browsingLevel?: number;
+    details?: Record<string, unknown>;
+  }) {
     return this.track('views', values);
   }
 

--- a/src/tests/api/track/view.test.ts
+++ b/src/tests/api/track/view.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Coverage for POST /api/track/view — the lightweight beacon that replaces the
+ * track.addView tRPC mutation for the browser <TrackView> component.
+ *
+ * Verifies the behavior-preserving contract:
+ *  - same-origin guard (origin/referer host must equal request host),
+ *  - body parse + addViewSchema validation (400 on bad input),
+ *  - the ClickHouse `views` insert is dispatched via Tracker.view() with the
+ *    FULL parsed payload (so the analytics shape/volume is unchanged),
+ *  - dev short-circuits to 200 with no insert.
+ */
+
+const { mockView, devStore } = vi.hoisted(() => ({
+  mockView: vi.fn(),
+  devStore: { isDev: false },
+}));
+
+// PublicEndpoint wraps the handler with CORS/metrics we don't exercise here —
+// pass it through so the route's own logic (origin guard, parse, view dispatch)
+// is what's under test. allowedMethods is irrelevant to a passthrough.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => handler,
+}));
+
+vi.mock('~/env/other', () => ({
+  get isDev() {
+    return devStore.isDev;
+  },
+  get isProd() {
+    return !devStore.isDev;
+  },
+}));
+
+// Tracker is the shared ClickHouse client; we assert .view() is called with the
+// exact parsed payload (same method the tRPC resolver used → identical insert).
+vi.mock('~/server/clickhouse/client', () => ({
+  Tracker: class {
+    view = mockView;
+  },
+}));
+
+function makeRes() {
+  const res = {} as NextApiResponse & { _status?: number; _body?: unknown };
+  res.status = vi.fn((code: number) => {
+    res._status = code;
+    return res;
+  }) as any;
+  res.send = vi.fn((body: unknown) => {
+    res._body = body;
+    return res;
+  }) as any;
+  res.end = vi.fn(() => res) as any;
+  return res;
+}
+
+function makeReq(opts: { host?: string; origin?: string; referer?: string; body?: unknown }) {
+  return {
+    method: 'POST',
+    headers: {
+      host: opts.host ?? 'civitai.com',
+      ...(opts.origin ? { origin: opts.origin } : {}),
+      ...(opts.referer ? { referer: opts.referer } : {}),
+    },
+    body: typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body),
+  } as unknown as NextApiRequest;
+}
+
+const validInput = {
+  type: 'ImageView' as const,
+  entityType: 'Image' as const,
+  entityId: 123,
+  ads: 'Served' as const,
+  nsfw: false,
+  browsingLevel: 1,
+  nsfwLevel: 0,
+  details: { foo: 'bar' },
+};
+
+describe('POST /api/track/view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devStore.isDev = false;
+  });
+
+  it('dispatches Tracker.view with the full parsed payload on a same-origin request', async () => {
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({ host: 'civitai.com', origin: 'https://civitai.com', body: validInput });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).toHaveBeenCalledTimes(1);
+    expect(mockView).toHaveBeenCalledWith(validInput);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('preserves false/0-valued fields (nsfw:false, nsfwLevel:0) in the insert', async () => {
+    const handler = (await import('~/pages/api/track/view')).default;
+    const body = { type: 'ModelView', entityType: 'Model', entityId: 7, nsfw: false, nsfwLevel: 0 };
+    const req = makeReq({ origin: 'https://civitai.com', body });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: 7, nsfw: false, nsfwLevel: 0 })
+    );
+  });
+
+  it('accepts the referer host as the origin fallback', async () => {
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: validInput });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('rejects a cross-origin request (host mismatch) with 400 and no insert', async () => {
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({ host: 'civitai.com', origin: 'https://evil.example', body: validInput });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a request with no origin/referer with 400 and no insert', async () => {
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({ host: 'civitai.com', body: validInput });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects an unparseable body with 400 and no insert', async () => {
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({ origin: 'https://civitai.com', body: '{not json' });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects schema-invalid input (bad enum) with 400 and no insert', async () => {
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({
+      origin: 'https://civitai.com',
+      body: { type: 'NotAView', entityType: 'Image', entityId: 1 },
+    });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('short-circuits to 200 in dev without inserting', async () => {
+    devStore.isDev = true;
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({ origin: 'https://civitai.com', body: validInput });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/src/tests/api/track/view.test.ts
+++ b/src/tests/api/track/view.test.ts
@@ -56,7 +56,17 @@ function makeRes() {
   return res;
 }
 
-function makeReq(opts: { host?: string; origin?: string; referer?: string; body?: unknown }) {
+function makeReq(opts: {
+  host?: string;
+  origin?: string;
+  referer?: string;
+  body?: unknown;
+  // When true, pass `body` through as-is (an OBJECT) to simulate how Next's body
+  // parser delivers an `application/json` request — which is the real browser path
+  // (<TrackView> sends Content-Type: application/json). Default stringifies, which
+  // only matches a no-Content-Type (text/plain) client.
+  objectBody?: boolean;
+}) {
   return {
     method: 'POST',
     headers: {
@@ -64,7 +74,11 @@ function makeReq(opts: { host?: string; origin?: string; referer?: string; body?
       ...(opts.origin ? { origin: opts.origin } : {}),
       ...(opts.referer ? { referer: opts.referer } : {}),
     },
-    body: typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body),
+    body: opts.objectBody
+      ? opts.body
+      : typeof opts.body === 'string'
+      ? opts.body
+      : JSON.stringify(opts.body),
   } as unknown as NextApiRequest;
 }
 
@@ -88,6 +102,22 @@ describe('POST /api/track/view', () => {
   it('dispatches Tracker.view with the full parsed payload on a same-origin request', async () => {
     const handler = (await import('~/pages/api/track/view')).default;
     const req = makeReq({ host: 'civitai.com', origin: 'https://civitai.com', body: validInput });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockView).toHaveBeenCalledTimes(1);
+    expect(mockView).toHaveBeenCalledWith(validInput);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('dispatches when Next pre-parsed the body to an OBJECT (application/json — the real browser path)', async () => {
+    // Regression guard: the <TrackView> client sends Content-Type: application/json,
+    // so Next's body parser hands the handler an OBJECT, not a string. A naive
+    // JSON.parse(req.body) would throw on the object → 400 → drop EVERY production
+    // view. This must dispatch the insert exactly like the string path.
+    const handler = (await import('~/pages/api/track/view')).default;
+    const req = makeReq({ origin: 'https://civitai.com', body: validInput, objectBody: true });
     const res = makeRes();
 
     await handler(req as any, res);


### PR DESCRIPTION
## Why

`track.addView` is the **#1 request-count source on api-primary (~71 req/s)** yet its resolver is near-zero — a fire-and-forget ClickHouse `views` insert (`void sendWithRetry`). Each call still pays the full **non-batched** tRPC middleware chain (`isAcceptableOrigin → enforceClientVersion → applyDomainFeature`[Flipt eval]` → enforceTokenScope`), `resolveSession`, and a superjson encode — for an empty response. Per the api-primary tRPC cost analysis (Tier-1 #2), that fixed per-request cost — paid ~71×/s — is the diffuse on-CPU work behind the recurring 504 waves. The lever is cutting that ambient per-request fixed cost.

## What

- New lightweight **`/api/track/view`** beacon route, mirroring the existing `/api/page-view`: same-origin guard (origin/referer host == request host), `addViewSchema` validation, then the **same `Tracker.view()`** call (identical `views` insert) — with **no tRPC middleware and no superjson**.
- `<TrackView>` (the only browser call-site) now `fetch(..., { keepalive: true })`s the beacon instead of `trpc.track.addView.useMutation()`. `keepalive` lets the request survive page unload/navigation right after the 1s debounce.
- Widened `Tracker.view()`'s param type to document the full forwarded payload (no runtime change — the tRPC resolver already passed these through).

## Mechanism choice: beacon over client-batching

`<TrackView>` events are temporally sparse per client (one per navigation, 1s-debounced) — they aren't concurrent within a session, so client-batching into `trackMany` would coalesce ~nothing. The 71/s is **aggregate cross-user** volume; the win is removing the per-request fixed cost, which the beacon does directly.

## Behavior preserved

- **ClickHouse `views` data unchanged** — same `Tracker.view() → track('views', …)` path, same fields (`type/entityType/entityId/ads/nsfw/nsfwLevel/browsingLevel/details`), including `false`/`0` values (`removeEmpty` only drops `null`/`undefined`/empty-arrays).
- **Session/ip/userAgent attribution unchanged** — beacon constructs a `Tracker(req,res)` exactly as the tRPC context did; `resolveSession()` runs the same.
- **tRPC `track.addView` procedure left intact** for bearer/API-key callers (still enforces `UserWrite` scope). Only the cookie-auth browser path moves.

## Tests

New `src/tests/api/track/view.test.ts` (8 cases, all passing): same-origin dispatch with full payload, `false`/`0` field preservation, referer fallback, cross-origin reject, missing-origin reject, unparseable body, schema-invalid input, dev short-circuit.

## Verification

- Unit tests: **8/8 pass** (`vitest run --project unit src/tests/api/track/view.test.ts`).
- `tsc --noEmit` clean on all three touched files.
- Full `next build`: compiles + bundles all chunks including the new route. Two stop points are **pre-existing/environmental, not from this change**: an unrelated `AccountsCard.tsx` implicit-any on `main`, and a Prisma-client runtime quirk during page-data eval in the local hardlinked `node_modules`.

## Caveats

- **Not browser-verified** in a running app — needs a click-path check post-deploy that `views` rows still land for an image/model view (confirm CH `views` volume is unchanged after rollout).
- Minor analytics-timing nuance: the beacon is `keepalive` fire-and-forget like the prior mutation; no per-call ack to the client (there never was a meaningful one — it was an empty response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)