### PR TITLE
fix(app-blocks): allow opaque-origin (null) CORS on block catalog endpoints

### DIFF
--- a/src/pages/api/v1/blocks/images.ts
+++ b/src/pages/api/v1/blocks/images.ts
@@ -239,5 +239,8 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
 // No requiredScope: any valid block token is accepted (see doc above). The
 // maturity clamp (resolveCatalogBrowsingLevel) remains the whole authority
-// surface.
-export default withBlockScope(baseHandler, {});
+// surface. allowOpaqueOrigin: an UNVERIFIED block runs at an opaque origin
+// (`Origin: null`) so its direct catalog fetch needs `ACAO: null` to clear the
+// CORS preflight; safe here (public maturity-clamped data, no credentials,
+// still token-gated) — see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, { allowOpaqueOrigin: true });

--- a/src/pages/api/v1/blocks/models.ts
+++ b/src/pages/api/v1/blocks/models.ts
@@ -179,5 +179,8 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
 // No requiredScope: any valid block token is accepted (see doc above). The
 // maturity clamp (resolveCatalogBrowsingLevel) remains the whole authority
-// surface.
-export default withBlockScope(baseHandler, {});
+// surface. allowOpaqueOrigin: an UNVERIFIED block runs at an opaque origin
+// (`Origin: null`) so its direct catalog fetch needs `ACAO: null` to clear the
+// CORS preflight; safe here (public maturity-clamped data, no credentials,
+// still token-gated) — see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, { allowOpaqueOrigin: true });

--- a/src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts
+++ b/src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts
@@ -119,6 +119,23 @@ function makeReq(authHeader?: string): NextApiRequest {
   } as unknown as NextApiRequest;
 }
 
+function makeReqWith(opts: {
+  method?: string;
+  origin?: string;
+  authHeader?: string;
+}): NextApiRequest {
+  const headers: Record<string, string> = {};
+  if (opts.origin !== undefined) headers.origin = opts.origin;
+  if (opts.authHeader) headers.authorization = opts.authHeader;
+  return {
+    method: opts.method ?? 'GET',
+    headers,
+    query: {},
+    url: '/api/v1/blocks/models',
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+}
+
 beforeEach(() => {
   isFliptMock.mockClear();
   isRevokedMock.mockClear();
@@ -189,5 +206,93 @@ describe('withBlockScope — "any valid block token" mode (no requiredScope)', (
 
     expect(wrapped).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('withBlockScope — opaque-origin CORS (allowOpaqueOrigin, catalog endpoints)', () => {
+  it('answers the `Origin: null` PREFLIGHT with 204 + ACAO:null when opted in', async () => {
+    // Unverified blocks run sandboxed without allow-same-origin → opaque origin
+    // → the browser preflight carries `Origin: null`. The catalog endpoints opt
+    // in, so the preflight is fully handled here (the wrapped handler — which
+    // would 405 a non-GET — is never reached).
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+
+    const res = makeRes();
+    await route(
+      makeReqWith({ method: 'OPTIONS', origin: 'null' }) as never,
+      res as never
+    );
+
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['access-control-allow-origin']).toBe('null');
+    expect(String(res.headers['access-control-allow-methods'])).toContain('GET');
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+
+  it('the actual GET from `Origin: null` carries ACAO:null + still requires a valid token', async () => {
+    const token = await mintToken([]);
+    const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+      res.status(200).json({ via: 'block' });
+    });
+    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+
+    const res = makeRes();
+    await route(
+      makeReqWith({ method: 'GET', origin: 'null', authHeader: `Bearer ${token}` }) as never,
+      res as never
+    );
+
+    // The GET ran (token validated) AND the response is readable cross-origin.
+    expect(wrapped).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe('null');
+  });
+
+  it('a `Origin: null` GET with NO/invalid token is still 401 — the preflight is policy, the token is the gate', async () => {
+    const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+      res.status(401).json({ error: 'Block token required' });
+    });
+    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+
+    const res = makeRes();
+    // No Authorization header → falls through to the wrapped handler's 401 guard.
+    await route(makeReqWith({ method: 'GET', origin: 'null' }) as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    // ACAO:null is still set so the browser can READ the 401 (not a CORS error).
+    expect(res.headers['access-control-allow-origin']).toBe('null');
+  });
+
+  it('does NOT honor `Origin: null` when the endpoint did NOT opt in (scoped/credentialed routes)', async () => {
+    // A scoped route (or any route without allowOpaqueOrigin) must NEVER echo
+    // ACAO:null — that would let any sandboxed page read a per-user response.
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { requiredScope: 'models:read:self' });
+
+    const res = makeRes();
+    await route(
+      makeReqWith({ method: 'OPTIONS', origin: 'null' }) as never,
+      res as never
+    );
+
+    // setBlockCors returned 'fallthrough' (no ACAO set); the preflight was NOT
+    // answered here. The wrapped handler (real catalog/route) would 405 it.
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('the opt-in does NOT widen to arbitrary real origins — only the literal `null` is special-cased', async () => {
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+
+    const res = makeRes();
+    await route(
+      makeReqWith({ method: 'OPTIONS', origin: 'https://evil.example' }) as never,
+      res as never
+    );
+
+    // A non-allowlisted, non-null origin gets no ACAO — opaque handling is
+    // strictly scoped to `Origin: null`.
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
   });
 });

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -85,6 +85,32 @@ export interface WithBlockScopeOpts {
    * surface; the scope gate would add nothing.
    */
   requiredScope?: string;
+
+  /**
+   * Opt-in: answer CORS for an OPAQUE-origin caller (`Origin: null`) by echoing
+   * `Access-Control-Allow-Origin: null`.
+   *
+   * WHY: UNVERIFIED App Blocks are sandboxed WITHOUT `allow-same-origin` (see
+   * `src/components/AppBlocks/sandbox.ts` — only internal/verified tiers get
+   * it), so the iframe runs at an OPAQUE origin and every `fetch` it makes
+   * sends `Origin: null`. `null` can never be in the OauthClient.allowedOrigins
+   * allowlist, so a direct (non-bridge) catalog fetch's CORS preflight falls
+   * through to the handler and 405s — the in-block resource browser then can't
+   * load. (Generation/money go through the postMessage host bridge, which is
+   * CORS-free; the catalog selector is the one path that direct-fetches.)
+   *
+   * SAFE ONLY for the block CATALOG endpoints (/api/v1/blocks/{models,images}),
+   * which is why this is an explicit per-endpoint opt-in and NOT a blanket
+   * middleware behavior: they return PUBLIC, maturity-clamped data (strictly ⊆
+   * the public, already-`ACAO:*` /api/v1/models), carry NO credentials
+   * (Allow-Credentials is omitted and block iframes have no civitai cookie), and
+   * the real request still requires a valid short-lived block JWT in
+   * `Authorization` (an attacker's own null-origin sandboxed page can't mint
+   * one). The preflight is CORS POLICY only; the token remains the gate. NEVER
+   * set this on a scoped/credentialed endpoint (me.ts, settings, …) — `ACAO:
+   * null` there would let ANY sandboxed page read a per-user response.
+   */
+  allowOpaqueOrigin?: boolean;
 }
 
 // L7 (audit-10): issuer/audience imported from block-token.service so a
@@ -234,7 +260,8 @@ function rememberWarnedOrigin(origin: string) {
  */
 async function setBlockCors(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
+  opts: WithBlockScopeOpts
 ): Promise<'handled' | 'fallthrough'> {
   const origin = req.headers.origin;
   const isAllowed = await originAllowed(origin);
@@ -248,6 +275,25 @@ async function setBlockCors(
     // civitai session cookies (cross-origin), and emitting "false" is a no-op
     // per the CORS spec. Setting "true" would require Allow-Origin to never
     // be "*", and we want that flexibility on the wrapped handler's path.
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    if (req.method === 'OPTIONS') {
+      res.status(204).end();
+      return 'handled';
+    }
+    return 'fallthrough';
+  }
+
+  // Opaque-origin (`Origin: null`) opt-in — CATALOG endpoints only (see
+  // WithBlockScopeOpts.allowOpaqueOrigin). Unverified blocks run sandboxed
+  // without `allow-same-origin` → opaque origin → `Origin: null`, which can
+  // never be in the allowlist above. We echo `ACAO: null` ONLY when the
+  // endpoint opted in. Allow-Credentials stays omitted (no cookies ride a
+  // null-origin request anyway), and the real GET still requires a valid block
+  // JWT — the preflight is policy only, the token is the gate.
+  if (opts.allowOpaqueOrigin && origin === 'null') {
+    res.setHeader('Access-Control-Allow-Origin', 'null');
+    res.setHeader('Vary', 'Origin');
     res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     if (req.method === 'OPTIONS') {
@@ -537,7 +583,7 @@ export function withBlockScope(
   opts: WithBlockScopeOpts
 ): NextApiHandler {
   return async (req, res) => {
-    const cors = await setBlockCors(req, res);
+    const cors = await setBlockCors(req, res, opts);
     if (cors === 'handled') return;
 
     const authHeader = req.headers.authorization ?? '';


### PR DESCRIPTION
## What

Found during the gen-matrix logged-in-mod click-path verify: `OPTIONS /api/v1/blocks/models → 405`.

**Unverified App Blocks are sandboxed without `allow-same-origin`** (`src/components/AppBlocks/sandbox.ts` — only `internal`/`verified` tiers get it), so the iframe runs at an **opaque origin** and every `fetch` it makes sends `Origin: null`. `null` can never be in the `OauthClient.allowedOrigins` allowlist, so the catalog selector's direct fetch to `/api/v1/blocks/{models,images}` fails its CORS preflight with **405** → the in-block resource browser can't load.

(Generation/money go through the postMessage host bridge and are CORS-free; the catalog selector is the one path that direct-fetches, so it's the only one that hits this. gen-matrix is `trust_tier=unverified`; prod has 3 internal / 4 unverified.)

## Fix

A new explicit, **per-endpoint** `allowOpaqueOrigin` opt on `withBlockScope`. When set, `setBlockCors` echoes `Access-Control-Allow-Origin: null` for an `Origin: null` caller (204 preflight; `ACAO: null` on the real response). Set **only** on the two block **catalog** endpoints — never a blanket middleware behavior.

## Why it's safe (Option C, chosen over host-bridge for cost)

- The catalog endpoints return **PUBLIC, maturity-clamped** data — strictly a subset of the already-`ACAO:*` public `/api/v1/models`.
- **No credentials**: `Allow-Credentials` is omitted and block iframes carry no civitai cookie.
- The real GET **still requires a valid short-lived block JWT** — an attacker's own null-origin sandboxed page can't mint one. The preflight is CORS *policy* only; the token is the gate.
- Scoped/credentialed endpoints (`me.ts`, settings, …) do **not** opt in, so `ACAO: null` can never leak a per-user response. The opt-in is also strictly scoped to the literal `null` origin — it does not widen to arbitrary real origins.

The architecturally pure alternative (route the catalog read through the postMessage host bridge so it's CORS-free for all blocks) is a larger multi-repo SDK change; this is the cheap interim that **preserves the authoritative maturity clamp** for unverified blocks.

## No client change needed

The deployed **gen-matrix v0.6.0** bundle already issues the authoritative fetch (`/api/v1/blocks/models` + `Authorization: Bearer`); it just needed the server to clear the null-origin preflight. Once this deploys, the existing bundle's authoritative path works — no gen-matrix redeploy.

## Tests (87/87 green)

`+5` opaque-origin cases in `block-scope.anytoken-mode.test.ts`:
- `Origin: null` preflight → 204 + `ACAO: null` (wrapped handler never reached)
- `Origin: null` GET → carries `ACAO: null` **and** still validates the token
- `Origin: null` GET with no/invalid token → still 401 (token is the gate)
- a scoped route does **not** honor `Origin: null` (no `ACAO`)
- the opt-in does **not** widen to arbitrary real origins (only literal `null`)

`tsc --noEmit`: clean on all changed files (repo baseline has unrelated pre-existing errors). No new files under `src/pages` (gotcha #81 N/A — tests live under `src/server/middleware/__tests__`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)