### PR TITLE
perf(api): gate model3d.getByPostId on the model3dFeed flag client-side

### DIFF
--- a/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
+++ b/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+
+/**
+ * "Posted/Posting to 3D Model" chip — guards the ambient-call cut.
+ *
+ * The image viewers render this chip on EVERY image view via `postId`, which
+ * used to fire `model3d.getByPostId` per view. That call is Flipt-gated
+ * (`model3dFeed`, availability ['mod']) and returns null for the vast majority
+ * of posts, so it was ~36 req/s of mostly-wasted full-middleware cycles on
+ * api-primary. The fix gates the client call on the SAME `features.model3dFeed`
+ * flag. These tests pin the load-bearing behaviour:
+ *
+ *   1. Flag OFF (non-mod): the postId lookup is NOT enabled (never fires) and
+ *      the chip renders nothing.
+ *   2. Flag ON + the post HAS a linked Model3D: the lookup fires and the chip
+ *      renders (real 3D posts still show it).
+ *   3. Flag ON + the post has NO linked Model3D (query returns null): chip
+ *      renders nothing.
+ */
+
+const mocks = vi.hoisted(() => ({
+  // Captures the `enabled` flag the component passes to getByPostId so we can
+  // assert the call is suppressed when the feature flag is off.
+  byPostEnabled: undefined as boolean | undefined,
+  byPostData: null as null | { id: number; name: string; thumbnailImage: null },
+  model3dFeed: false,
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    model3d: {
+      getByPostId: {
+        useQuery: (_input: unknown, opts?: { enabled?: boolean }) => {
+          mocks.byPostEnabled = opts?.enabled;
+          // Mirror react-query: a disabled query yields no data.
+          return { data: opts?.enabled ? mocks.byPostData : undefined };
+        },
+      },
+      getById: {
+        useQuery: () => ({ data: undefined }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ model3dFeed: mocks.model3dFeed }),
+}));
+
+// EdgeMedia/NextLink pull in edge-url + routing machinery not under test.
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia: ({ alt }: { alt?: string }) => <span>{alt}</span>,
+}));
+vi.mock('~/components/NextLink/NextLink', () => ({
+  NextLink: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
+    <a href={typeof href === 'string' ? href : '#'}>{children}</a>
+  ),
+}));
+
+const { PostingToModel3DCard } = await import('./PostingToModel3DCard');
+
+beforeEach(() => {
+  mocks.byPostEnabled = undefined;
+  mocks.byPostData = null;
+  mocks.model3dFeed = false;
+});
+
+describe('PostingToModel3DCard', () => {
+  test('flag OFF: does not fire the postId lookup and renders nothing', async () => {
+    mocks.model3dFeed = false;
+    // Even though the server WOULD resolve a Model3D for this post, the call is
+    // suppressed client-side because the viewer can't see the 3D feature.
+    mocks.byPostData = { id: 5, name: 'My 3D Model', thumbnailImage: null };
+
+    renderWithProviders(<PostingToModel3DCard postId={123} label="Posted to 3D Model" />);
+
+    // vitest-browser-react commits asynchronously; wait for the component to
+    // run its hooks, then assert the query was passed `enabled: false`.
+    await vi.waitFor(() => expect(mocks.byPostEnabled).toBe(false));
+    // No chip (the flag-off query yields no data) — nothing in the document.
+    expect(document.body.textContent).not.toContain('My 3D Model');
+    expect(document.querySelector('a[href^="/3d-models/"]')).toBeNull();
+  });
+
+  test('flag ON + post linked to a Model3D: lookup fires and chip renders', async () => {
+    mocks.model3dFeed = true;
+    mocks.byPostData = { id: 5, name: 'My 3D Model', thumbnailImage: null };
+
+    renderWithProviders(<PostingToModel3DCard postId={123} label="Posted to 3D Model" />);
+
+    await vi.waitFor(() => expect(mocks.byPostEnabled).toBe(true));
+    await expect.element(page.getByText('My 3D Model')).toBeInTheDocument();
+    await expect.element(page.getByText('Posted to 3D Model')).toBeInTheDocument();
+    // Links to the resolved 3D model detail page.
+    await expect.element(page.getByRole('link')).toHaveAttribute('href', '/3d-models/5');
+  });
+
+  test('flag ON + post NOT linked (lookup returns null): renders nothing', async () => {
+    mocks.model3dFeed = true;
+    mocks.byPostData = null;
+
+    renderWithProviders(<PostingToModel3DCard postId={123} label="Posted to 3D Model" />);
+
+    await vi.waitFor(() => expect(mocks.byPostEnabled).toBe(true));
+    expect(document.querySelector('a[href^="/3d-models/"]')).toBeNull();
+  });
+});

--- a/src/components/Model3D/Posting/PostingToModel3DCard.tsx
+++ b/src/components/Model3D/Posting/PostingToModel3DCard.tsx
@@ -2,6 +2,7 @@ import { Anchor, Group, Stack, Text, ThemeIcon } from '@mantine/core';
 import { IconArrowRight, IconCube } from '@tabler/icons-react';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { trpc } from '~/utils/trpc';
 
 type Props = {
@@ -28,17 +29,31 @@ export function PostingToModel3DCard({
   label = 'Posting to 3D Model',
   className,
 }: Props) {
+  // The whole 3D-model surface is gated behind the `model3dFeed` Flipt flag
+  // (availability: ['mod']). The image viewers render this chip on EVERY image
+  // view via `postId`, but for the vast majority of viewers (non-mods) the
+  // server-side `isFlagProtected('model3dFeed')` rejects the lookup — so the
+  // postId→Model3D query was firing ~per-image-view through full tRPC
+  // middleware + Flipt eval + a DB read only to return null. Gate the calls on
+  // the SAME flag client-side (mirroring the server guard) so they never fire
+  // for users who can't see 3D models. Mods (who created the linked Model3D and
+  // are the only ones who reach the post-create/edit `model3dId` path) keep the
+  // exact prior behaviour. This eliminates the null-returning majority of the
+  // ambient ~36 req/s on api-primary without changing what the chip renders.
+  const features = useFeatureFlags();
+  const model3dEnabled = features.model3dFeed;
+
   // Single round-trip per resolution path: when only postId is known, the
   // server resolves Post → Model3D in one query and returns the card payload
   // (or null). When the caller already has a model3dId, fall through to the
   // canonical getById. Visibility checks live in `getModel3DById` either way.
   const byPostQuery = trpc.model3d.getByPostId.useQuery(
     { postId: postId ?? 0 },
-    { enabled: !model3dId && !!postId }
+    { enabled: model3dEnabled && !model3dId && !!postId }
   );
   const byIdQuery = trpc.model3d.getById.useQuery(
     { id: model3dId ?? 0 },
-    { enabled: !!model3dId }
+    { enabled: model3dEnabled && !!model3dId }
   );
 
   const data = model3dId ? byIdQuery.data : byPostQuery.data;


### PR DESCRIPTION
## What

Gates the `model3d.getByPostId` tRPC call (fired by the "Posted to 3D Model" chip on **every image view**) on the client-side `features.model3dFeed` flag, mirroring the server-side `isFlagProtected('model3dFeed')` guard.

## Why

`model3d.getByPostId` was measured at **~36 req/s on api-primary** (Tier-1 #3 in the api-primary tRPC cost analysis). The chip in `PostingToModel3DCard` is rendered by both image viewers (`ImageDetail2`, `ImageDetailByProps`) on every image view via `postId`. But:

- The procedure is server-side Flipt-gated by `isFlagProtected('model3dFeed')`, whose availability is `['mod']`.
- It returns **null for the vast majority of posts** (only posts tied to a `Model3D` get a chip — `Post.model3dId` is null for almost all posts).

So for the non-mod majority of viewers, each image view burned a full tRPC-middleware + Flipt-eval + DB-read cycle only to be rejected / return null. api-primary 504 waves are diffuse per-request middleware CPU; the lever is cutting ambient request **count**.

## Mechanism (option 1 — eliminate the calls)

Gate the chip's `getByPostId` / `getById` queries on `features.model3dFeed`, the **same** flag the server enforces, using `useFeatureFlags()` — the exact pattern sibling components (`ProfileNavigation`, `HomeContentToggle`) already use. For non-mods the query never fires; mods (the only ones who can see 3D models, and the only ones who reach the post-create/edit `model3dId` path) keep identical behaviour.

No server payload field was added (so no client-bundle-leak risk), and the Flipt `model3dFeed` semantics are preserved exactly — the client gate matches the server gate.

## Chip behavior preserved

- Flag ON + post linked to a Model3D → query fires, chip renders, links to `/3d-models/:id` (unchanged).
- Flag ON + post not linked → query returns null → chip absent (unchanged).
- Flag OFF (non-mod) → query never fires → chip absent. Previously the query fired and was rejected/returned null, so the chip was *already* absent for these users — the visible result is identical, just without the wasted round-trip.

## Tests

Adds `PostingToModel3DCard.browser.test.tsx` (Vitest browser mode) covering all three cases above, asserting both the query `enabled` flag and the rendered chip/href. All 3 pass.

## Build / test

- `vitest run --project component` (the new test): **3 passed**.
- `tsc --noEmit`: **0 errors** in the changed files (pre-existing unrelated typecheck errors on `main` are untouched).
- `next build` (Turbopack, prod): **✓ Compiled successfully** — full transpile + client-bundle phase green. (Build later fails at page-data collection on a missing `NEXT_PUBLIC_*` env var in the local worktree — environmental, unrelated to this change.)

## Caveats

- Not browser-verified against live prod (local worktree). The change is a client-only `enabled`-gate on an existing query; behavior was verified via the component test and the production-bundler compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)