### PR TITLE
perf(api): SSR-inject system.getLiveNow to cut ~26 req/s off api-primary

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -108,6 +108,7 @@ type CustomAppProps = {
   seed: number;
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
+  liveNow: boolean;
   canIndex: boolean;
   hasAuthCookie: boolean;
   region: RegionInfo;
@@ -135,6 +136,7 @@ function MyApp(props: CustomAppProps) {
       hasAuthCookie,
       settings,
       browsingSettingsAddons,
+      liveNow = false,
       region,
       domain,
       host,
@@ -187,6 +189,7 @@ function MyApp(props: CustomAppProps) {
       tosMeta={tosMeta}
       announcements={announcements}
       following={following}
+      liveNow={liveNow}
       region={region}
       domain={domain}
       host={host}
@@ -441,11 +444,13 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   // every full render's critical path. SSR-injecting the addons keeps the
   // `system.getBrowsingSettingAddons` round-trip off api-primary (it becomes
   // `initialData` for the client provider).
-  const [{ getFeatureFlagsAsync, computeUserFeatureFlagsOverlay }, { getBrowsingSettingAddons }] =
-    await Promise.all([
-      import('~/server/services/feature-flags.service'),
-      import('~/server/services/system-cache'),
-    ]);
+  const [
+    { getFeatureFlagsAsync, computeUserFeatureFlagsOverlay },
+    { getBrowsingSettingAddons, getLiveNow },
+  ] = await Promise.all([
+    import('~/server/services/feature-flags.service'),
+    import('~/server/services/system-cache'),
+  ]);
   const [flags, browsingSettingsAddons] = await Promise.all([
     getFeatureFlagsAsync({
       user: session?.user,
@@ -454,6 +459,24 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     }),
     getBrowsingSettingAddons(),
   ]);
+
+  // SSR-seed the global `system.getLiveNow` boolean (a single `redis.get`,
+  // identical for every user) so the ambient `useIsLive` client query reads a
+  // primed cache and never fires on bootstrap (~26 req/s off api-primary).
+  // Fail open to `false` (the "not live" default): `getLiveNow` has no internal
+  // try/catch, and an uncaught redis throw here would 500 every page render —
+  // so a degraded sysRedis must degrade to "not live", never to an error. The
+  // client query still self-heals on its 5-minute refetch interval.
+  let liveNow = false;
+  try {
+    liveNow = await getLiveNow();
+  } catch (e) {
+    console.warn(
+      `[_app] getLiveNow bootstrap failed, defaulting to not-live: ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
+  }
 
   const domain = getRequestDomainColor(request);
 
@@ -502,6 +525,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       session,
       settings,
       browsingSettingsAddons,
+      liveNow,
       flags,
       userFeatureFlags,
       tosMeta,

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -25,6 +25,11 @@ type AppProviderProps = {
   // followed userIds. Seeds the query directly (fixed `undefined` key) so the
   // ambient follow/notify buttons never fire it on bootstrap.
   following?: number[];
+  // SSR-computed `system.getLiveNow` global boolean (a single redis.get,
+  // identical for every user). Seeds the ambient `useIsLive` query (fixed
+  // `undefined` key) so it never fires on bootstrap. Public procedure → seeded
+  // for everyone, no auth gate.
+  liveNow: boolean;
   seed: number;
   canIndex: boolean;
   region: RegionInfo;
@@ -79,6 +84,7 @@ export function AppProvider({
   tosMeta,
   announcements,
   following,
+  liveNow,
   domain,
   host,
   serverDomains,
@@ -102,6 +108,17 @@ export function AppProvider({
   trpc.user.getFollowingUsers.useQuery(undefined, {
     initialData: following,
     enabled: !!following,
+  });
+  // Seed the global `system.getLiveNow` boolean from the SSR snapshot so the
+  // ambient `useIsLive` consumers (header logo, social links, social home
+  // block) read a primed cache and never fire the query on bootstrap. Shares
+  // the fixed `undefined` query key with `useIsLive`. `staleTime` matches the
+  // hook's 5-minute interval so the seed counts as fresh and no immediate
+  // refetch fires; `useIsLive`'s own `refetchInterval`/`refetchOnWindowFocus`
+  // still keep it current once a consumer mounts.
+  trpc.system.getLiveNow.useQuery(undefined, {
+    initialData: liveNow,
+    staleTime: 1000 * 60 * 5,
   });
   // Populate the module-level server domain map so `syncAccount(url)` can
   // resolve hosts to colors without pulling from React context.

--- a/tests/preview-ssr-inject.spec.ts
+++ b/tests/preview-ssr-inject.spec.ts
@@ -43,6 +43,7 @@ const FEATURE_FLAGS_PROCEDURE = 'user.getFeatureFlags';
 const TOS_PROCEDURE = 'content.checkTosUpdate';
 const ANNOUNCEMENTS_PROCEDURE = 'announcement.getAnnouncements';
 const FOLLOWING_PROCEDURE = 'user.getFollowingUsers';
+const LIVE_NOW_PROCEDURE = 'system.getLiveNow';
 
 // A core page a gate-passing user lands on directly (no /login bounce). Both
 // procedures fire on every logged-in bootstrap regardless of which page, so
@@ -396,6 +397,77 @@ test.describe('SSR-injected getFollowingUsers (logged-in)', () => {
     for (const id of ids) {
       expect(typeof id, 'following item is a userId (number)').toBe('number');
     }
+  });
+});
+
+/**
+ * Regression guard for the SSR-inject of `system.getLiveNow` (~26/s on
+ * api-primary). NOT auth-gated — it is a `publicProcedure` consumed by the
+ * ambient `useIsLive` hook (header logo, social links, social home block), so
+ * it fires on every bootstrap, anon and authed alike. SSR-computed in
+ * `_app.getInitialProps` (fail-open to `false`) and seeded in AppProvider on the
+ * fixed `undefined` key. The payload is a plain `boolean` — no Date/array
+ * serialization subtlety, so the seed (JSON) and a live fetch (`result.data.json`)
+ * compare directly. The seed can legitimately be `false` (stream offline); that
+ * is still a valid, present seed and the byte-equality assertion holds.
+ */
+test.describe('SSR-injected getLiveNow (logged-in)', () => {
+  test.use({ storageState: storageStatePath('mod') });
+
+  test('getLiveNow is seeded into __NEXT_DATA__ and not fetched on bootstrap', async ({ page }) => {
+    const trpcUrls = await collectTrpcRequests(page, AUTHED_LANDING);
+
+    const liveNow = await readPageProp(page, 'liveNow');
+    expect(liveNow.present, 'liveNow present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(typeof liveNow.value, 'liveNow seed is a boolean').toBe('boolean');
+
+    const liveNowRequests = trpcUrls.filter((u) => u.includes(LIVE_NOW_PROCEDURE));
+    expect(
+      liveNowRequests,
+      `no ${LIVE_NOW_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${liveNowRequests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
+  });
+
+  test('SSR seed byte-equals a live fetch', async ({ page }) => {
+    await page.goto(AUTHED_LANDING, { waitUntil: 'domcontentloaded' });
+
+    const seed = await readPageProp(page, 'liveNow');
+    expect(seed.present, 'liveNow seed present in __NEXT_DATA__').toBe(true);
+
+    const live = await fetchTrpcQueryJson(page, LIVE_NOW_PROCEDURE);
+    expect(
+      seed.value,
+      'system.getLiveNow SSR seed must byte-equal a live resolver fetch'
+    ).toEqual(live);
+    expect(typeof live, 'live getLiveNow is a boolean').toBe('boolean');
+  });
+});
+
+test.describe('SSR-injected getLiveNow (anonymous)', () => {
+  // `system.getLiveNow` is a publicProcedure and fires for anon too, so the seed
+  // must be present on the anon bootstrap as well. No anon "byte-equals a live
+  // fetch" test: the preview-auth gate blocks ALL anonymous /api/trpc/* and
+  // 302-redirects to /login (same reason documented for the anon announcements
+  // case), so an anon live fetch never returns tRPC JSON. The seed-present +
+  // no-bootstrap-fetch contract is what matters and is asserted here.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('getLiveNow is seeded into __NEXT_DATA__ and not fetched on bootstrap', async ({ page }) => {
+    const trpcUrls = await collectTrpcRequests(page, ANON_LANDING);
+
+    const liveNow = await readPageProp(page, 'liveNow');
+    expect(liveNow.present, 'liveNow present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(typeof liveNow.value, 'liveNow seed is a boolean').toBe('boolean');
+
+    const liveNowRequests = trpcUrls.filter((u) => u.includes(LIVE_NOW_PROCEDURE));
+    expect(
+      liveNowRequests,
+      `no ${LIVE_NOW_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${liveNowRequests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## What

SSR-inject `system.getLiveNow` so the ambient `useIsLive` client query never fires on bootstrap, removing **~26 req/s** of full non-batched tRPC middleware + context-build + superjson cycles from `civitai-dp-prod-api-primary`.

`system.getLiveNow` is a global boolean (a single `redis.get(LIVE_NOW)`, identical for every user — `routers/system.router.ts:15` → `services/system-cache.ts:264`) fired on every bootstrap via `useIsLive` (header logo, social links, social home block). Because the tRPC client is non-batched, each call pays the full per-request fixed CPU cost for a boolean — the diffuse per-request CPU that drives the recurring api-primary 504 waves. This is Tier-1 #1 in the datapacket-talos analysis `claudedocs/api-primary-trpc-cost-analysis-2026-06-21.md`.

## How (mirrors the proven #2464 pattern)

- `src/pages/_app.tsx` (`getInitialProps`): call `getLiveNow()` from the **same already-imported** `~/server/services/system-cache` module that already calls `getBrowsingSettingAddons` (#2464) — so **no new module enters the client-bundle graph**. `getLiveNow` references only `redis` + `REDIS_KEYS`, both already in that module's graph. Thread the result through `pageProps` as `liveNow`. Wrapped fail-open to `false` (not-live) because `getLiveNow` has no internal try/catch and an uncaught redis throw on the SSR path would 500 every render.
- `src/providers/AppProvider.tsx`: seed `trpc.system.getLiveNow.useQuery(undefined, { initialData: liveNow, staleTime: 5min })` on the fixed `undefined` key, alongside the existing `getSettings` / `getFollowingUsers` seeds. `useIsLive`'s own 5-minute `refetchInterval` keeps it current once a consumer mounts.

`useIsLive` returns `!isLoading && isLive`; with `initialData` seeded, `isLoading` is `false` from frame 0 and the value is correct immediately — no behavior regression, and the Live badge no longer flashes/refetches on load.

## Tests

Extends `tests/preview-ssr-inject.spec.ts` with authed + anon `getLiveNow` describe blocks asserting: (a) the seed is present in `__NEXT_DATA__.props.pageProps.liveNow`, (b) no `system.getLiveNow` tRPC request fires on bootstrap, and (c) the seed byte-equals a live authed fetch (boolean — no superjson `undefined`→`null` divergence). These run under `playwright.preview.config.ts` (need a live preview).

## Verification / caveats

- **tsc:** zero type errors in the 3 changed files (the repo's pre-existing repo-wide implicit-any errors are untouched and unrelated).
- **Full `next build` (bundle-leak check): INCONCLUSIVE on the build box, not run to completion.** Turbopack rejects the worktree's symlinked `node_modules` ("points out of the filesystem root"); the `--webpack` fallback OOMs the Node heap during SWC transpilation of the full source even at 16 GB. **No `Can't resolve` / `Module not found` / leak markers appeared in any run** before the heap died.
- **Reachability argument (why the leak risk is bounded):** `_app.getInitialProps` runs client-side on navigation, so pulling a server module with a Node builtin into it would break the client bundle. This change adds **zero new imports** — the only `_app` import diff is whitespace on the *existing* `import('~/server/services/system-cache')` (already shipped + in production via #2464). `getLiveNow` adds no new transitive dependency beyond what `getBrowsingSettingAddons` already pulls. So the client-bundle surface is structurally identical to the in-production #2464 path. The preview-build CI (and a full local build with more heap) is the place to get the build-confirmed signal.

Behavior-preserving; dark-safe (cache seed only).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)