### PR TITLE
fix(app-blocks): cast lpad pad-length to ::int (blocks.listAvailable 500 — /apps marketplace)

### DIFF
--- a/src/server/services/__tests__/block-registry.list-available.test.ts
+++ b/src/server/services/__tests__/block-registry.list-available.test.ts
@@ -349,6 +349,12 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
     // The pinned mean 2.5 is bound into the Bayesian sort key (C*m term = 10*2.5).
     const sql = capturedSql();
     expect(sql).toMatch(/lpad\(round\(/i); // rating key present
+    // Regression guard: the lpad length args MUST be cast to ::int. Prisma binds
+    // the JS pad constants (BAYES_SCORE_PAD/INSTALL_PAD) as bigint, and
+    // `lpad(text, bigint, unknown)` has no overload (the signature is
+    // `lpad(text, integer, text)`) → the query 500s at runtime. The shape
+    // assertions above missed it; only the preview smoke test (real DB) caught it.
+    expect(sql).toMatch(/lpad\(round\([\s\S]*?::int,\s*'0'\)/i);
   });
 
   it('category filter is threaded into the SQL (only the requested category)', async () => {

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -171,9 +171,15 @@ function bayesianRatingSortKey(globalMean: number): Prisma.Sql {
     SELECT COUNT(DISTINCT bus.user_id) FROM block_user_subscriptions bus
     WHERE bus.app_block_id = ab.id
   )`;
+  // NB: cast the pad-length args to ::int. Prisma binds the JS number
+  // constants as bigint, and `lpad(text, bigint, unknown)` has no overload
+  // (the signature is `lpad(text, integer, text)`) → the whole query 500s at
+  // runtime with `function lpad(text, bigint, unknown) does not exist`. The
+  // unit tests only assert the SQL string shape (/lpad/), so this slipped past
+  // them and was caught by the preview smoke test hitting a real database.
   return Prisma.sql`(
-    lpad(round(${score} * ${BAYES_SCORE_SCALE})::bigint::text, ${BAYES_SCORE_PAD}, '0')
-    || lpad(${installCount}::text, ${INSTALL_PAD}, '0')
+    lpad(round(${score} * ${BAYES_SCORE_SCALE})::bigint::text, ${BAYES_SCORE_PAD}::int, '0')
+    || lpad(${installCount}::text, ${INSTALL_PAD}::int, '0')
   )`;
 }
 


### PR DESCRIPTION
## Problem
`blocks.listAvailable` — the **/apps marketplace** query — 500s at runtime:

```
Raw query failed. Code: 42883.
ERROR: function lpad(text, bigint, unknown) does not exist
```

The Bayesian `rating` sort key (`bayesianRatingSortKey`, `block-registry.service.ts`) builds `lpad(<text>, ${BAYES_SCORE_PAD}, '0')` / `lpad(<text>, ${INSTALL_PAD}, '0')`. `BAYES_SCORE_PAD` (9) and `INSTALL_PAD` (20) are JS number constants, and `Prisma.sql` binds JS numbers as **bigint** → `lpad(text, bigint, unknown)`, which has no overload (the function is `lpad(text, integer, text)`). The whole list query fails, so the marketplace, `getAppDetail`, `/apps/run`, and install flows all break.

## Fix
Cast both pad-length args to `::int` → `lpad(text, integer, text)` resolves (`'0'` coerces unknown→text).

## Why it wasn't caught
The `block-registry.list-available` unit tests assert the SQL **string shape** (`/lpad/`, `/lpad\(round\(/`) against a mocked DB — they never execute it, so a type mismatch passes. It was caught by the **preview smoke** suite (real DB): `preview-apps-marketplace` / `-install` / `-page` / `-git-access` all hard-failed. Added a regression guard asserting the `::int` cast is present in the generated SQL.

## Impact / urgency
**Prod is not affected yet** — the bug is on `main`, but the current `release` (`5.0.184x`, pre-dates the App Blocks merge wave) doesn't have it. It would 500 the marketplace on the **next release**, so worth landing before then.

## Verification
The `::int`-cast SQL matches Postgres `lpad(text, integer, text)`. End-to-end confirmation: this PR's own preview build runs the `preview-apps-*` smoke specs against a real DB — they should go green (they currently hard-fail on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)