### PR TITLE
perf(api): durable data-gate for the model3d chip (eliminate ambient getByPostId, GA-proof)

### DIFF
--- a/src/components/Image/Detail/ImageDetailByProps.tsx
+++ b/src/components/Image/Detail/ImageDetailByProps.tsx
@@ -243,7 +243,12 @@ export function ImageDetailByProps({
                   />
                   {image.postId && (
                     <Box px="sm">
+                      {/* Durable data-gate: `image.get` (the `data` query above)
+                          carries the visibility-checked `model3dId`, so the chip
+                          renders from the prop and never fires the ambient
+                          `model3d.getByPostId` query. */}
                       <PostingToModel3DCard
+                        model3dId={data?.model3dId ?? null}
                         postId={image.postId}
                         label="Posted to 3D Model"
                       />

--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -478,7 +478,16 @@ export function ImageDetail2() {
                       />
                     )}
                     {image.postId && (
+                      // Durable data-gate: the `image.get` payload now carries
+                      // the visibility-checked `model3dId`, so on the direct
+                      // image-page path the chip renders from the prop and
+                      // never fires the ambient `model3d.getByPostId` query.
+                      // `model3dId` is absent on feed-sourced items (we
+                      // intentionally don't enrich the hot feed query) — there
+                      // the chip falls back to the postId lookup, gated by the
+                      // model3dFeed flag client-side (PR #2682).
                       <PostingToModel3DCard
+                        model3dId={(image as { model3dId?: number | null }).model3dId}
                         postId={image.postId}
                         label="Posted to 3D Model"
                       />

--- a/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
+++ b/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+
+/**
+ * PostingToModel3DCard — the "Posted to 3D Model" chip rendered by the image
+ * viewers. This pins the DURABLE data-gate that eliminates the ambient
+ * `model3d.getByPostId` call (~36/s, mostly null) on api-primary:
+ *
+ *   - `model3dId` is a NUMBER  → chip renders directly via `getById`; the
+ *     `getByPostId` query is NOT enabled.
+ *   - `model3dId` is `null`    → caller's payload already resolved "no visible
+ *     Model3D" → chip renders nothing AND `getByPostId` is NOT enabled (this is
+ *     the elimination: the image-detail viewers thread the visibility-checked
+ *     `model3dId` from `image.get`, so the call never fires regardless of the
+ *     `model3dFeed` feature flag — survives GA).
+ *   - `model3dId` is `undefined` (no prop) → legacy fallback: `getByPostId` IS
+ *     enabled (the feed-modal path that we intentionally don't enrich).
+ *
+ * tRPC is mocked via the scaffold's documented `vi.mock('~/utils/trpc')`
+ * pattern; the mock records the `enabled` flag each `useQuery` is called with so
+ * we can assert exactly which query path the component took.
+ */
+
+const mocks = vi.hoisted(() => ({
+  // Records { enabled } for each query so the test can assert which fired.
+  byPostIdCalls: [] as Array<{ postId: number; enabled: boolean }>,
+  byIdCalls: [] as Array<{ id: number; enabled: boolean }>,
+  // The card payloads each query returns when enabled.
+  byPostIdData: null as null | { id: number; name: string; thumbnailImage: unknown },
+  byIdData: null as null | { id: number; name: string; thumbnailImage: unknown },
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    model3d: {
+      getByPostId: {
+        useQuery: (
+          input: { postId: number },
+          opts?: { enabled?: boolean }
+        ) => {
+          const enabled = opts?.enabled ?? true;
+          mocks.byPostIdCalls.push({ postId: input.postId, enabled });
+          return { data: enabled ? mocks.byPostIdData : undefined };
+        },
+      },
+      getById: {
+        useQuery: (input: { id: number }, opts?: { enabled?: boolean }) => {
+          const enabled = opts?.enabled ?? true;
+          mocks.byIdCalls.push({ id: input.id, enabled });
+          return { data: enabled ? mocks.byIdData : undefined };
+        },
+      },
+    },
+  },
+}));
+
+// EdgeMedia pulls in edge-url/env machinery we don't need — stub to a plain img.
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia: ({ src, alt }: { src: string; alt?: string }) => <img src={src} alt={alt} />,
+}));
+
+// NextLink wraps next/link; render children inside a plain anchor so the chip's
+// `legacyBehavior` passHref child renders network-free.
+vi.mock('~/components/NextLink/NextLink', () => ({
+  NextLink: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const { PostingToModel3DCard } = await import('./PostingToModel3DCard');
+
+const enabledOf = (calls: Array<{ enabled: boolean }>) => calls.some((c) => c.enabled);
+
+beforeEach(() => {
+  mocks.byPostIdCalls = [];
+  mocks.byIdCalls = [];
+  mocks.byPostIdData = null;
+  mocks.byIdData = null;
+});
+
+describe('PostingToModel3DCard — durable data-gate', () => {
+  test('renders from the model3dId prop WITHOUT enabling getByPostId', async () => {
+    mocks.byIdData = { id: 555, name: 'My Cube', thumbnailImage: null };
+
+    renderWithProviders(<PostingToModel3DCard model3dId={555} postId={123} />);
+
+    // Chip rendered the model name + links to the 3D model.
+    await expect.element(page.getByText('My Cube')).toBeInTheDocument();
+    const link = document.querySelector('a[href="/3d-models/555"]');
+    expect(link).not.toBeNull();
+
+    // getById ran enabled; getByPostId was NOT enabled even though postId was passed.
+    expect(enabledOf(mocks.byIdCalls)).toBe(true);
+    expect(mocks.byIdCalls.some((c) => c.id === 555 && c.enabled)).toBe(true);
+    expect(enabledOf(mocks.byPostIdCalls)).toBe(false);
+  });
+
+  test('model3dId=null renders nothing AND does NOT enable getByPostId (the elimination)', async () => {
+    // Even if a stray getByPostId result existed, the resolved-absent null must
+    // suppress both the query and any render.
+    mocks.byPostIdData = { id: 999, name: 'Should Not Show', thumbnailImage: null };
+
+    renderWithProviders(<PostingToModel3DCard model3dId={null} postId={123} />);
+
+    // Nothing rendered (no chip link, no leaked name).
+    expect(document.querySelector('a[href="/3d-models/999"]')).toBeNull();
+    expect(document.body.textContent).not.toContain('Should Not Show');
+
+    // Neither query is enabled — this is the durable, flag-independent cut.
+    expect(enabledOf(mocks.byPostIdCalls)).toBe(false);
+    expect(enabledOf(mocks.byIdCalls)).toBe(false);
+  });
+
+  test('model3dId undefined falls back to the getByPostId lookup (legacy/feed path)', async () => {
+    mocks.byPostIdData = { id: 777, name: 'Linked From Post', thumbnailImage: null };
+
+    renderWithProviders(<PostingToModel3DCard postId={123} />);
+
+    await expect.element(page.getByText('Linked From Post')).toBeInTheDocument();
+    const link = document.querySelector('a[href="/3d-models/777"]');
+    expect(link).not.toBeNull();
+
+    // The fallback path: getByPostId enabled, getById not.
+    expect(mocks.byPostIdCalls.some((c) => c.postId === 123 && c.enabled)).toBe(true);
+    expect(enabledOf(mocks.byIdCalls)).toBe(false);
+  });
+
+  test('model3dId=null with no postId renders nothing and issues no enabled query', async () => {
+    renderWithProviders(<PostingToModel3DCard model3dId={null} />);
+    // No card payload mocked → if anything rendered it'd have no href; assert the
+    // gate instead: neither query enabled.
+    expect(enabledOf(mocks.byPostIdCalls)).toBe(false);
+    expect(enabledOf(mocks.byIdCalls)).toBe(false);
+  });
+});

--- a/src/components/Model3D/Posting/PostingToModel3DCard.tsx
+++ b/src/components/Model3D/Posting/PostingToModel3DCard.tsx
@@ -5,10 +5,21 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { trpc } from '~/utils/trpc';
 
 type Props = {
-  /** Render the chip directly for a known Model3D. Skips the postId lookup. */
+  /**
+   * Linked Model3D id, threaded from the caller's already-fetched payload.
+   * Three states, intentionally distinct:
+   *  - `number`    → render the chip directly via `getById` (no postId lookup).
+   *  - `null`      → the caller's payload RESOLVED that there's no visible
+   *                  Model3D for this post (e.g. the `image.get` data-gate).
+   *                  Render nothing AND do NOT fall back to `getByPostId` —
+   *                  this is the durable elimination of the ambient call.
+   *  - `undefined` → the caller has no signal (e.g. a feed-sourced item that
+   *                  isn't enriched). Fall back to the `getByPostId` lookup.
+   */
   model3dId?: number | null;
   /** Resolve the chip from `Post.model3dId`. Used by the image viewers
-   *  (they only know the postId; the link to the 3D model lives one hop away). */
+   *  (they only know the postId; the link to the 3D model lives one hop away).
+   *  Only consulted when `model3dId` is `undefined` (no payload signal). */
   postId?: number | null;
   /** Label eyebrow. Defaults to "Posting to 3D Model" (matches the post-create
    *  context). Use "Posted to 3D Model" on read-only surfaces. */
@@ -28,20 +39,32 @@ export function PostingToModel3DCard({
   label = 'Posting to 3D Model',
   className,
 }: Props) {
-  // Single round-trip per resolution path: when only postId is known, the
-  // server resolves Post → Model3D in one query and returns the card payload
-  // (or null). When the caller already has a model3dId, fall through to the
-  // canonical getById. Visibility checks live in `getModel3DById` either way.
+  // `undefined` means the caller had no payload signal → use the postId
+  // lookup. `null` means the caller's payload already resolved "no visible
+  // Model3D" → render nothing and DON'T fall back (the durable data-gate; this
+  // is what keeps `getByPostId` from firing on the image-detail viewers). A
+  // number → render directly via getById.
+  const hasResolvedSignal = model3dId !== undefined;
+
+  // Single round-trip per resolution path: when only postId is known (no
+  // resolved signal), the server resolves Post → Model3D in one query and
+  // returns the card payload (or null). When the caller already has a
+  // model3dId, fall through to the canonical getById. Visibility checks live
+  // in `getModel3DById` / the server-side data-gate either way.
   const byPostQuery = trpc.model3d.getByPostId.useQuery(
     { postId: postId ?? 0 },
-    { enabled: !model3dId && !!postId }
+    { enabled: !hasResolvedSignal && !!postId }
   );
   const byIdQuery = trpc.model3d.getById.useQuery(
     { id: model3dId ?? 0 },
     { enabled: !!model3dId }
   );
 
-  const data = model3dId ? byIdQuery.data : byPostQuery.data;
+  const data = model3dId
+    ? byIdQuery.data
+    : hasResolvedSignal
+    ? null // resolved-absent: don't read the (disabled) postId query
+    : byPostQuery.data;
 
   // Silent-skip while the server has yet to confirm a linked Model3D, OR once
   // it confirms there isn't one. Matches the silent-skip pattern of the

--- a/src/server/services/__tests__/model3d-visibility.test.ts
+++ b/src/server/services/__tests__/model3d-visibility.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { Model3DStatus } from '~/shared/utils/prisma/enums';
+import { canViewModel3d } from '~/server/services/model3d.visibility';
+
+// ---------------------------------------------------------------------------
+// canViewModel3d is the AUTHZ predicate that gates the `model3dId` field now
+// surfaced on the `image.get` payload (the durable replacement for the ambient
+// `model3d.getByPostId` chip call). It MUST match `getModel3DById`'s rules so
+// that threading `model3dId` onto the image payload never reveals a Model3D
+// the viewer couldn't otherwise see (a hidden draft / deleted / other user's).
+// ---------------------------------------------------------------------------
+
+const OWNER = 42;
+const OTHER = 7;
+
+describe('canViewModel3d — authZ for the image-payload model3dId gate', () => {
+  it('moderators see everything (any status, even deleted, any owner)', () => {
+    expect(
+      canViewModel3d({
+        status: Model3DStatus.Draft,
+        deletedAt: new Date(),
+        ownerId: OWNER,
+        userId: OTHER,
+        isModerator: true,
+      })
+    ).toBe(true);
+  });
+
+  it('the owner sees their own at any status', () => {
+    expect(
+      canViewModel3d({ status: Model3DStatus.Draft, deletedAt: null, ownerId: OWNER, userId: OWNER })
+    ).toBe(true);
+    expect(
+      canViewModel3d({
+        status: Model3DStatus.Published,
+        deletedAt: null,
+        ownerId: OWNER,
+        userId: OWNER,
+      })
+    ).toBe(true);
+  });
+
+  it('the public sees a Published, not-deleted model', () => {
+    expect(
+      canViewModel3d({ status: Model3DStatus.Published, deletedAt: null, ownerId: OWNER })
+    ).toBe(true);
+    expect(
+      canViewModel3d({
+        status: Model3DStatus.Published,
+        deletedAt: null,
+        ownerId: OWNER,
+        userId: OTHER,
+      })
+    ).toBe(true);
+  });
+
+  it('hides a non-Published model from a non-owner non-mod', () => {
+    expect(
+      canViewModel3d({ status: Model3DStatus.Draft, deletedAt: null, ownerId: OWNER, userId: OTHER })
+    ).toBe(false);
+    // anonymous (no userId) is treated as public
+    expect(
+      canViewModel3d({ status: Model3DStatus.Draft, deletedAt: null, ownerId: OWNER })
+    ).toBe(false);
+  });
+
+  it('hides a deleted model from a non-owner non-mod even when Published', () => {
+    expect(
+      canViewModel3d({
+        status: Model3DStatus.Published,
+        deletedAt: new Date(),
+        ownerId: OWNER,
+        userId: OTHER,
+      })
+    ).toBe(false);
+  });
+
+  it('owner does NOT match when userId is undefined (anonymous never an owner)', () => {
+    expect(
+      canViewModel3d({ status: Model3DStatus.Draft, deletedAt: null, ownerId: OWNER, userId: undefined })
+    ).toBe(false);
+  });
+});

--- a/src/server/services/__tests__/model3d-visible-id-for-post.test.ts
+++ b/src/server/services/__tests__/model3d-visible-id-for-post.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Model3DStatus } from '~/shared/utils/prisma/enums';
+
+// getVisibleModel3DIdForPost backs the new `image.get` -> `model3dId`
+// enrichment. It must (a) return the linked Model3D id when the viewer can see
+// it, and (b) return null when the post has no link OR the model is hidden,
+// applying the SAME visibility rule as the chip lookup. We mock only the DB
+// read; the visibility predicate (`canViewModel3d`) is exercised through it.
+
+const h = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { post: { findUnique: h.findUnique } },
+  dbWrite: {},
+}));
+
+// model3d.service transitively imports many `Prisma.validator<...>()(...)`
+// selector files at module-eval time. `Prisma.validator` isn't present in the
+// SSR test transform of `@prisma/client`, so provide a pass-through. This
+// unblocks the import chain without faking any logic the test exercises (we
+// only call the cheap post→model3d lookup, which uses the mocked dbRead).
+vi.mock('@prisma/client', () => ({
+  Prisma: {
+    validator: () => (x: unknown) => x,
+    sql: () => ({}),
+    join: () => ({}),
+    raw: () => ({}),
+  },
+}));
+
+const { getVisibleModel3DIdForPost } = await import('~/server/services/model3d.service');
+
+const setPostModel3d = (
+  model3d: { id: number; userId: number; status: Model3DStatus; deletedAt: Date | null } | null
+) => h.findUnique.mockResolvedValueOnce({ model3d });
+
+beforeEach(() => h.findUnique.mockReset());
+
+describe('getVisibleModel3DIdForPost', () => {
+  it('returns the id for a Published, not-deleted model (public viewer)', async () => {
+    setPostModel3d({ id: 321, userId: 1, status: Model3DStatus.Published, deletedAt: null });
+    await expect(getVisibleModel3DIdForPost({ postId: 9, userId: 99 })).resolves.toBe(321);
+  });
+
+  it('returns null when the post has no linked Model3D', async () => {
+    setPostModel3d(null);
+    await expect(getVisibleModel3DIdForPost({ postId: 9, userId: 99 })).resolves.toBeNull();
+  });
+
+  it('returns null for a non-owner non-mod when the model is a Draft (hidden)', async () => {
+    setPostModel3d({ id: 321, userId: 1, status: Model3DStatus.Draft, deletedAt: null });
+    await expect(getVisibleModel3DIdForPost({ postId: 9, userId: 99 })).resolves.toBeNull();
+  });
+
+  it('returns the id for the owner even when the model is a Draft', async () => {
+    setPostModel3d({ id: 321, userId: 99, status: Model3DStatus.Draft, deletedAt: null });
+    await expect(getVisibleModel3DIdForPost({ postId: 9, userId: 99 })).resolves.toBe(321);
+  });
+
+  it('returns the id for a moderator even when the model is deleted', async () => {
+    setPostModel3d({ id: 321, userId: 1, status: Model3DStatus.Published, deletedAt: new Date() });
+    await expect(
+      getVisibleModel3DIdForPost({ postId: 9, userId: 5, isModerator: true })
+    ).resolves.toBe(321);
+  });
+
+  it('selects only the minimal model3d fields (no thumbnail/name) for the cheap lookup', async () => {
+    setPostModel3d({ id: 321, userId: 1, status: Model3DStatus.Published, deletedAt: null });
+    await getVisibleModel3DIdForPost({ postId: 9 });
+    const arg = h.findUnique.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: 9 });
+    expect(arg.select.model3d.select).toEqual({
+      id: true,
+      userId: true,
+      status: true,
+      deletedAt: true,
+    });
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -131,6 +131,7 @@ import {
   removeEntityFromAllCollections,
 } from '~/server/services/collection.service';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
+import { getVisibleModel3DIdForPost } from '~/server/services/model3d.service';
 import { addImageToQueue } from '~/server/services/games/new-order.service';
 import { upsertImageFlag } from '~/server/services/image-flag.service';
 import {
@@ -4720,8 +4721,20 @@ export const getImage = async ({
     entity: 'Image',
   });
 
+  // Durable replacement for the ambient `model3d.getByPostId` chip call: carry
+  // the visibility-checked linked Model3D id on this payload (the image
+  // viewers already fetch it) so the "Posted to 3D Model" chip renders from a
+  // prop instead of firing a per-image tRPC query for every image (~36/s,
+  // mostly null). Resolves the SAME visibility predicate the chip lookup used,
+  // so a hidden draft/deleted Model3D yields null here too. Null when the post
+  // isn't linked, isn't visible, or there's no postId at all.
+  const model3dId = firstRawImage.postId
+    ? await getVisibleModel3DIdForPost({ postId: firstRawImage.postId, userId, isModerator })
+    : null;
+
   const image = {
     ...firstRawImage,
+    model3dId,
     cosmetic: imageCosmetics?.[firstRawImage.id] ?? null,
     user: {
       id: creatorId,

--- a/src/server/services/model3d.service.ts
+++ b/src/server/services/model3d.service.ts
@@ -22,6 +22,7 @@ import {
   allBrowsingLevelsFlag,
   parseBitwiseBrowsingLevel,
 } from '~/shared/constants/browsingLevel.constants';
+import { canViewModel3d } from '~/server/services/model3d.visibility';
 import { imageSelect } from '~/server/selectors/image.selector';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import {
@@ -1104,9 +1105,7 @@ export const getModel3DByThumbnailImageId = async ({
 // "Posted to 3D Model" chip on the image viewers and the post-create page.
 // Returns the minimal card payload (id + name + thumbnail) or null when the
 // post isn't linked OR the viewer can't see the Model3D. The chip silently
-// hides on null instead of surfacing a 404. Visibility mirrors
-// `getModel3DById`: mods see everything, owner sees their own (any status),
-// public sees Published + not-Deleted. Inlined here rather than calling
+// hides on null instead of surfacing a 404. Inlined here rather than calling
 // `getModel3DById` so this service takes primitives (userId/isModerator)
 // instead of a full session user.
 export const getModel3DByPostId = async ({
@@ -1132,17 +1131,58 @@ export const getModel3DByPostId = async ({
   const model3d = post?.model3d;
   if (!model3d) return null;
 
-  const isOwner = !!userId && model3d.userId === userId;
-  if (!isModerator && !isOwner) {
-    if (model3d.status !== Model3DStatus.Published) return null;
-    if (model3d.deletedAt) return null;
-  }
+  if (
+    !canViewModel3d({
+      status: model3d.status,
+      deletedAt: model3d.deletedAt,
+      ownerId: model3d.userId,
+      userId,
+      isModerator,
+    })
+  )
+    return null;
 
   return {
     id: model3d.id,
     name: model3d.name,
     thumbnailImage: model3d.thumbnailImage,
   };
+};
+
+// Durable replacement for the ambient `model3d.getByPostId` chip call: resolve
+// JUST the linked Model3D id for a post, applying the SAME visibility rule, so
+// the image-detail payload (`image.get`) can carry `model3dId` and the chip
+// renders from the prop without firing a per-image tRPC query. Returns the id
+// when the viewer may see the Model3D, else null (no link / hidden draft /
+// deleted) — never leaks a hidden model's existence as a clickable chip.
+export const getVisibleModel3DIdForPost = async ({
+  postId,
+  userId,
+  isModerator = false,
+}: {
+  postId: number;
+  userId?: number;
+  isModerator?: boolean;
+}): Promise<number | null> => {
+  const post = await dbRead.post.findUnique({
+    where: { id: postId },
+    select: {
+      model3d: { select: { id: true, userId: true, status: true, deletedAt: true } },
+    },
+  });
+  const model3d = post?.model3d;
+  if (!model3d) return null;
+  if (
+    !canViewModel3d({
+      status: model3d.status,
+      deletedAt: model3d.deletedAt,
+      ownerId: model3d.userId,
+      userId,
+      isModerator,
+    })
+  )
+    return null;
+  return model3d.id;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/model3d.visibility.ts
+++ b/src/server/services/model3d.visibility.ts
@@ -1,0 +1,33 @@
+import { Model3DStatus } from '~/shared/utils/prisma/enums';
+
+/**
+ * Pure visibility rule shared by every Model3D read surface. Mirrors
+ * `getModel3DById`: mods see everything, the owner sees their own (any
+ * status), the public sees only Published + not-Deleted.
+ *
+ * Kept in its own dependency-light module (only the Prisma enum) so it's
+ * trivially unit-testable, and so the SAME predicate gates both the chip lookup
+ * (`getModel3DByPostId`) and the inlined `image.get` enrichment
+ * (`getVisibleModel3DIdForPost`). Exposing a `model3dId` on the image payload
+ * must never reveal a Model3D the viewer couldn't otherwise see.
+ */
+export const canViewModel3d = ({
+  status,
+  deletedAt,
+  ownerId,
+  userId,
+  isModerator = false,
+}: {
+  status: Model3DStatus;
+  deletedAt: Date | null;
+  ownerId: number;
+  userId?: number;
+  isModerator?: boolean;
+}): boolean => {
+  if (isModerator) return true;
+  const isOwner = !!userId && ownerId === userId;
+  if (isOwner) return true;
+  if (status !== Model3DStatus.Published) return false;
+  if (deletedAt) return false;
+  return true;
+};


### PR DESCRIPTION
## Problem

The "Posted to 3D Model" chip (`PostingToModel3DCard`) fires `model3d.getByPostId.useQuery` on **every** image-detail view, producing ~36 req/s on civitai api-primary — mostly returning `null` (most posts have no linked Model3D). Each call pays the full non-batched tRPC middleware chain (the diffuse CPU), contributing to the api-primary 504 waves.

**PR #2682** client-gated that query on `useFeatureFlags().model3dFeed`. That is valid **interim** relief, but `model3dFeed` is about to go **GA** — `hasFeature` lets `availability` make the flag true for everyone, at which point the client gate opens and the ~36/s null calls return. The flag-gate is only temporary.

This PR is the **durable, flag-independent** replacement: it keys on **data** ("does this post have a visible linked Model3D"), not on the feature flag, so it survives GA. **#2682 should stay intact** for pre-GA; this is the follow-up real fix.

## Approach

Thread the post's linked `model3dId` onto the image-detail payload the viewers already fetch (`image.get`), and pass it to the chip as a prop — so `getByPostId` is never called for the detail viewers.

- **`image.get` now returns a visibility-checked `model3dId`** (`getImage` in `image.service.ts`). Resolved via the new `getVisibleModel3DIdForPost`, which applies the **same** visibility predicate as the chip lookup (`getModel3DById`/`getModel3DByPostId`): mods see all, owner sees their own at any status, public sees Published + not-deleted. So exposing the id never reveals a Model3D the viewer couldn't otherwise see — **authZ preserved**. The chip's own `getById` re-checks server-side as defense in depth. `null` when the post isn't linked, the model is hidden, or there's no postId.
- **Chip now distinguishes three prop states** (`PostingToModel3DCard.tsx`):
  - `number` → render via `getById` (no `getByPostId`).
  - explicit `null` → caller already resolved "no visible model" → render nothing AND fire **no** query (the elimination).
  - `undefined` → no signal → fall back to the legacy `getByPostId` lookup.
- **Both viewers** (`ImageDetail2`, `ImageDetailByProps`) pass the threaded `model3dId`. Net: **~0 ambient `getByPostId` calls** from the detail viewers regardless of the feature flag.
- **Blast radius:** the chip renders only in the detail viewers, so this deliberately does **NOT** touch the hot, heavily-cached `getInfiniteImages` feed query. The direct image-page path (`/images/[id]`, which SSR-prefetches `image.get` — the dominant source of the ~36/s) is fully covered. The feed-modal path (lower volume) still uses the flag-gated fallback.
- Extracted the authZ predicate into a dependency-light `model3d.visibility.ts` so it's unit-testable and shared by both read surfaces.

## Call elimination + perf

The lever is request **count** (full tRPC middleware chain ×36/s). This folds the lookup into the existing `image.get` call as one extra indexed point-query — no new tRPC round-trip. That `findUnique` is strictly cheaper than the separate tRPC call it replaces (which did the same query PLUS the whole middleware/auth/serialization chain).

## Cache invalidation

No cached query was modified. `image.get` is not Redis-cached (the cached path is `getAllImages`/the feed, which is intentionally untouched), so a Model3D being linked/unlinked reflects immediately on the next `image.get`. No invalidation wiring needed.

## Tests

- `model3d-visibility.test.ts` — 6 tests, the authZ predicate (mod/owner/public × Draft/Published/deleted/anonymous).
- `model3d-visible-id-for-post.test.ts` — 6 tests, `getVisibleModel3DIdForPost` DB-shaping (returns id for visible, null for hidden/unlinked, minimal select).
- `PostingToModel3DCard.browser.test.tsx` — 4 component tests: renders from the `model3dId` prop without enabling `getByPostId`; `null` renders nothing and enables neither query (the elimination); `undefined` falls back to `getByPostId`.

**16/16 pass.** `tsc-files --noEmit` clean on all changed files.

## Caveats

- Full `next build` was not run to completion locally — it fails in its strict typecheck on a **pre-existing** implicit-any in an unrelated file (`src/components/Account/AccountsCard.tsx`, untouched here, predates this branch). Preview CI is the real build gate. No client-bundle leak risk: the client edits only read `image.model3dId`; no server module is imported into client code.
- The feed-modal path for `ImageDetail2` still calls `getByPostId` (flag-gated by #2682) — eliminating it there would require enriching the hot feed query, which this PR deliberately avoids per the blast-radius constraint. The dominant direct-landing source is eliminated.

**This is the durable replacement for #2682's interim flag-gate. Do not merge before review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)