### PR TITLE
test(app-blocks): fix the deterministically-failing W10 page-mint unit suite (stale server-domain mock)

### DIFF
--- a/src/tests/api/v1/block-tokens/index.test.ts
+++ b/src/tests/api/v1/block-tokens/index.test.ts
@@ -68,7 +68,13 @@ vi.mock('~/server/redis/client', () => ({
   redis: mockRedis,
   REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
 }));
-vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: () => ['civitai.com'] }));
+vi.mock('~/server/utils/server-domain', () => ({
+  getAllServerHosts: () => ['civitai.com'],
+  // #2670 (color-domain maturity) added a getRequestDomainColor(req) call to the
+  // mint. The test reqs carry no `host` header, so the real impl returns
+  // undefined → SFW ceiling; mirror that here so the module mock stays complete.
+  getRequestDomainColor: () => undefined,
+}));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: vi.fn(async () => true),
 }));

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -89,7 +89,13 @@ vi.mock('~/server/redis/client', () => ({
   redis: mockRedis,
   REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
 }));
-vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: () => ['civitai.com'] }));
+vi.mock('~/server/utils/server-domain', () => ({
+  getAllServerHosts: () => ['civitai.com'],
+  // #2670 (color-domain maturity) added a getRequestDomainColor(req) call to the
+  // mint. The test reqs carry no `host` header, so the real impl returns
+  // undefined → SFW ceiling; mirror that here so the module mock stays complete.
+  getRequestDomainColor: () => undefined,
+}));
 vi.mock('~/server/services/feature-flags.service', () => mockFlags);
 
 function makeReq(opts: {


### PR DESCRIPTION
## What

`src/tests/api/v1/block-tokens/page-mint.test.ts` (the W10 page-mint handler suite for `POST /api/v1/block-tokens`) **fails deterministically on `main`** — 13 cases throw before reaching their assertions, surfaced by the PR-preview `unit-tests` task.

**This is a test-infra bug, not a code bug.** No production code is changed.

## Root cause

#2670 (color-domain maturity) added a `getRequestDomainColor(req)` call to the mint handler (`src/pages/api/v1/block-tokens/index.ts`, ~L697). The suite's module mock:

```ts
vi.mock('~/server/utils/server-domain', () => ({ getAllServerHosts: () => ['civitai.com'] }));
```

only returned `getAllServerHosts`. So `getRequestDomainColor` is `undefined` on the mock, and the mint throws (`No "getRequestDomainColor" export is defined on the mock`) on **every path that reaches the `sign` step** — i.e. every positive-assertion case. The 10 early-`403`/`404`/`400` cases never reach `sign`, which is exactly why only the happy-path cases were red.

## Fix

Add `getRequestDomainColor: () => undefined` to the mock, mirroring the real impl's return for a request with no `host` header (→ falls through to the SFW ceiling, which is the existing behaviour the asserting cases don't inspect). One-line, scoped to the mock factory.

## Per-failing-case

All four named failures (and the other 9 in the file) share the single root cause above — the mint threw before the asserted logic ran:

| Case | Documented contract | What was wrong | Fix |
|---|---|---|---|
| `MODEL path: settings.buzz_budget_per_gen=200 → buzzBudget===200` | a valid integer install budget mints verbatim | mint threw at `getRequestDomainColor` before `sign` | mock now complete → reaches `sign`, asserts pass |
| `FRACTIONAL install budget (12.5) → DEFAULT 10` | `resolveBuzzBudget`'s `Number.isInteger` guard clamps a fractional budget to the default 10 | same — never reached `resolveBuzzBudget`'s result at `sign` | same |
| `anon page mint: ai:write:budgeted is STRIPPED` | an anon mint withholds every consent-gated scope (no `buzzBudget`, `userId` null) | same | same |
| `BYTE-IDENTICAL model path: ctx == { modelId, slotId }` (no `entityType`) | the model token's ctx stays byte-identical to pre-W10 | same | same |

The code already correctly implements each contract — verified by the suite going green once the mint can reach `sign`.

## Test-bug-vs-code-bug call (for @ZacxDev — App Blocks owner)

This was a **test bug**: a stale mock left incomplete when #2670 landed. The production handler is correct; I changed only the mock and no assertions. Flagging since the task asked to call out any test-side fix.

## `models/index-refactor.test.ts`

**Separate, and NOT failing.** I ran `src/tests/api/v1/models/index-refactor.test.ts` on `origin/main` and all 5 cases (including `public maturity contract preserved` / `nsfwImagePassthrough`) pass clean. Unrelated to the page-mint root cause — left untouched.

## Verification

Ran the node-env unit project locally against this branch:
- `page-mint.test.ts` → **23/23 pass** (was 13 failing / 10 passing)
- `index-refactor.test.ts` → **5/5 pass** (unchanged on main)

The PR's own preview `unit-tests` task is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: sibling fix in `index.test.ts` (same root cause)

After landing the page-mint fix, I swept the other suites that mock `~/server/utils/server-domain` for the *same* incomplete-mock failure:

| File | Calls `getRequestDomainColor` on its exercised path? | Result | Action |
|---|---|---|---|
| `src/tests/api/v1/block-tokens/index.test.ts` | **Yes** (mint handler L697) | **Failed** the same way: 10 failed / 16 passed → **26/26 pass** after adding the mock export | **Fixed** (same one-line `getRequestDomainColor: () => undefined`; reqs set no `host` → `undefined` mirrors the real impl) |
| `src/server/utils/__tests__/origin-helpers.test.ts` | No | Passes (9/9) | Left untouched |
| `src/server/utils/__tests__/public-endpoint-cache-override.test.ts` | No | Passes (2/2) | Left untouched |

The two `origin-helpers` / `public-endpoint-cache-override` suites mock `server-domain` but never reach `getRequestDomainColor`, so they were already green — left untouched to avoid noise. No production code or assertion changes in this commit either.
