### PR TITLE
fix(model3d): thread visibility-gated model3dId into the image FEED payload (finishes #2685, makes #2682 redundant)

### DIFF
--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -478,14 +478,17 @@ export function ImageDetail2() {
                       />
                     )}
                     {image.postId && (
-                      // Durable data-gate: the `image.get` payload now carries
-                      // the visibility-checked `model3dId`, so on the direct
-                      // image-page path the chip renders from the prop and
-                      // never fires the ambient `model3d.getByPostId` query.
-                      // `model3dId` is absent on feed-sourced items (we
-                      // intentionally don't enrich the hot feed query) — there
-                      // the chip falls back to the postId lookup, gated by the
-                      // model3dFeed flag client-side (PR #2682).
+                      // Durable data-gate: BOTH the `image.get` payload (direct
+                      // image-page path) AND the feed payloads (getAllImages /
+                      // getAllImagesIndex, the feed-modal path) now carry the
+                      // visibility-checked `model3dId`, so the chip renders from
+                      // the prop and never fires the ambient
+                      // `model3d.getByPostId` query. A Meili-sourced feed item
+                      // with no link resolves to `null` (chip hidden, no
+                      // fallback). The only residual fallback is BitDex-sourced
+                      // items (model3dId not indexed → `undefined`), which
+                      // self-heal as the index gains the field — the #2682
+                      // model3dFeed flag-gate is otherwise redundant now.
                       <PostingToModel3DCard
                         model3dId={(image as { model3dId?: number | null }).model3dId}
                         postId={image.postId}

--- a/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
+++ b/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
@@ -134,4 +134,28 @@ describe('PostingToModel3DCard — durable data-gate', () => {
     expect(enabledOf(mocks.byPostIdCalls)).toBe(false);
     expect(enabledOf(mocks.byIdCalls)).toBe(false);
   });
+
+  // FEED-MODAL path: an item opened from the feed/grid now carries the
+  // visibility-checked `model3dId` from getAllImages / getAllImagesIndex (this
+  // PR). The chip MUST render from that prop and MUST NOT fire the ambient
+  // `getByPostId` — that is what makes the #2682 model3dFeed flag-gate redundant
+  // on this path (it no longer protects an ambient call that doesn't fire).
+  test('feed-modal item with a threaded model3dId renders via prop, no getByPostId', async () => {
+    mocks.byIdData = { id: 4242, name: 'Feed Cube', thumbnailImage: null };
+    // Mimic the leak-trap: a stale getByPostId result must never be read.
+    mocks.byPostIdData = { id: 8888, name: 'LEAKED', thumbnailImage: null };
+
+    renderWithProviders(
+      <PostingToModel3DCard model3dId={4242} postId={321} label="Posted to 3D Model" />
+    );
+
+    await expect.element(page.getByText('Feed Cube')).toBeInTheDocument();
+    expect(document.querySelector('a[href="/3d-models/4242"]')).not.toBeNull();
+    expect(document.body.textContent).not.toContain('LEAKED');
+
+    // getByPostId never enabled even though postId was passed → the ambient call
+    // is eliminated on the feed-modal path, not merely flag-gated.
+    expect(enabledOf(mocks.byPostIdCalls)).toBe(false);
+    expect(mocks.byIdCalls.some((c) => c.id === 4242 && c.enabled)).toBe(true);
+  });
 });

--- a/src/server/services/__tests__/model3d-visible-ids-batch.test.ts
+++ b/src/server/services/__tests__/model3d-visible-ids-batch.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Model3DStatus } from '~/shared/utils/prisma/enums';
+
+// getVisibleModel3DIds is the BATCHED authZ used by the image FEED path
+// (getAllImages / getAllImagesIndex). The feed payload carries a RAW
+// `Post.model3dId` (from SQL or the Meili doc) that is NOT visibility-checked;
+// this function must, in ONE query (no per-image N+1), return the SET of ids the
+// viewer may see so a hidden Draft / deleted / non-owner model is nulled before
+// reaching the client — exactly as the single-post lookup does for image.get.
+// We mock only the DB read; the visibility predicate (canViewModel3d) is
+// exercised through it.
+
+const h = vi.hoisted(() => ({
+  findMany: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { model3D: { findMany: h.findMany } },
+  dbWrite: {},
+}));
+
+// model3d.service transitively imports many `Prisma.validator<...>()(...)`
+// selector files at module-eval time (see model3d-visible-id-for-post.test.ts).
+vi.mock('@prisma/client', () => ({
+  Prisma: {
+    validator: () => (x: unknown) => x,
+    sql: () => ({}),
+    join: () => ({}),
+    raw: () => ({}),
+  },
+}));
+
+const { getVisibleModel3DIds } = await import('~/server/services/model3d.service');
+
+type Row = { id: number; userId: number; status: Model3DStatus; deletedAt: Date | null };
+const setRows = (rows: Row[]) => h.findMany.mockResolvedValueOnce(rows);
+
+const OWNER = 1;
+const OTHER = 99;
+
+beforeEach(() => h.findMany.mockReset());
+
+describe('getVisibleModel3DIds — batched feed authZ for the model3dId field', () => {
+  it('returns an empty set without querying when no ids are passed', async () => {
+    const visible = await getVisibleModel3DIds({ model3dIds: [], userId: OTHER });
+    expect(visible.size).toBe(0);
+    expect(h.findMany).not.toHaveBeenCalled();
+  });
+
+  it('keeps a Published, not-deleted model for a public (non-owner) viewer', async () => {
+    setRows([{ id: 10, userId: OWNER, status: Model3DStatus.Published, deletedAt: null }]);
+    const visible = await getVisibleModel3DIds({ model3dIds: [10], userId: OTHER });
+    expect([...visible]).toEqual([10]);
+  });
+
+  it('nulls a Draft (unpublished) model for a non-owner non-mod', async () => {
+    setRows([{ id: 11, userId: OWNER, status: Model3DStatus.Draft, deletedAt: null }]);
+    const visible = await getVisibleModel3DIds({ model3dIds: [11], userId: OTHER });
+    expect(visible.has(11)).toBe(false);
+  });
+
+  it('nulls a deleted (Published-but-deletedAt) model for a non-owner non-mod', async () => {
+    setRows([
+      { id: 12, userId: OWNER, status: Model3DStatus.Published, deletedAt: new Date() },
+    ]);
+    const visible = await getVisibleModel3DIds({ model3dIds: [12], userId: OTHER });
+    expect(visible.has(12)).toBe(false);
+  });
+
+  it('keeps the owner-own Draft for the owner', async () => {
+    setRows([{ id: 13, userId: OWNER, status: Model3DStatus.Draft, deletedAt: null }]);
+    const visible = await getVisibleModel3DIds({ model3dIds: [13], userId: OWNER });
+    expect(visible.has(13)).toBe(true);
+  });
+
+  it('keeps a deleted model for a moderator', async () => {
+    setRows([
+      { id: 14, userId: OWNER, status: Model3DStatus.Published, deletedAt: new Date() },
+    ]);
+    const visible = await getVisibleModel3DIds({
+      model3dIds: [14],
+      userId: OTHER,
+      isModerator: true,
+    });
+    expect(visible.has(14)).toBe(true);
+  });
+
+  it('partitions a mixed batch in ONE query — visible kept, hidden dropped', async () => {
+    setRows([
+      { id: 20, userId: OWNER, status: Model3DStatus.Published, deletedAt: null }, // visible
+      { id: 21, userId: OWNER, status: Model3DStatus.Draft, deletedAt: null }, // hidden (draft)
+      { id: 22, userId: OWNER, status: Model3DStatus.Published, deletedAt: new Date() }, // hidden (deleted)
+    ]);
+    const visible = await getVisibleModel3DIds({ model3dIds: [20, 21, 22], userId: OTHER });
+    expect([...visible].sort((a, b) => a - b)).toEqual([20]);
+    // Single batched read — no per-image N+1.
+    expect(h.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes ids and queries only the minimal authZ fields', async () => {
+    setRows([{ id: 30, userId: OWNER, status: Model3DStatus.Published, deletedAt: null }]);
+    await getVisibleModel3DIds({ model3dIds: [30, 30, 30] });
+    const arg = h.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: { in: [30] } });
+    expect(arg.select).toEqual({ id: true, userId: true, status: true, deletedAt: true });
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -131,7 +131,10 @@ import {
   removeEntityFromAllCollections,
 } from '~/server/services/collection.service';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
-import { getVisibleModel3DIdForPost } from '~/server/services/model3d.service';
+import {
+  getVisibleModel3DIdForPost,
+  getVisibleModel3DIds,
+} from '~/server/services/model3d.service';
 import { addImageToQueue } from '~/server/services/games/new-order.service';
 import { upsertImageFlag } from '~/server/services/image-flag.service';
 import {
@@ -1130,6 +1133,11 @@ type GetAllImagesRaw = {
   postId: number | null;
   postTitle: string | null;
   modelVersionId: number | null;
+  // RAW Post.model3dId — visibility-checked into a nullable output field below
+  // (the batched `getVisibleModel3DIds` gate) before reaching the client. Drives
+  // the "Posted to 3D Model" chip on the feed-modal path without an ambient
+  // `model3d.getByPostId` lookup.
+  model3dId: number | null;
   imageId: number | null;
   publishedAt: Date | null;
   unpublishedAt?: Date | null;
@@ -1794,6 +1802,7 @@ export const getAllImages = async (
       p."publishedAt",
       p.metadata->>'unpublishedAt' "unpublishedAt",
       p."modelVersionId",
+      p."model3dId",
       p."availability",
       i.minor,
       i.poi,
@@ -1825,7 +1834,13 @@ export const getAllImages = async (
       return rows as Row[];
     },
     'getAllImages',
-    'v1'
+    // Bumped v1 -> v2 when `p."model3dId"` was added to the SELECT. The query
+    // hash already changes with the new column (so old entries fall out of the
+    // keyspace on their own), but the explicit version bump abandons the stale
+    // keyspace immediately rather than leaving model3dId-less rows resident
+    // until their TTL — keeps the feed-modal chip from silently lacking the
+    // field on a warm cache after deploy.
+    'v2'
   );
   let rawImages: GetAllImagesRaw[];
   try {
@@ -1925,6 +1940,20 @@ export const getAllImages = async (
     ])
   );
 
+  // Visibility-check the RAW `model3dId`s carried on the feed rows before they
+  // reach the client. `p."model3dId"` is unfiltered (it reflects the link, not
+  // whether the viewer may SEE the linked Model3D), so a hidden Draft / deleted
+  // model's id would otherwise leak as a clickable chip on the feed-modal path.
+  // Most feed images aren't linked (model3dId null) so the common page skips the
+  // query entirely; the linked few resolve in ONE batched query (no N+1),
+  // applying the SAME `canViewModel3d` predicate as the single-post lookup.
+  const rawModel3dIds = [
+    ...new Set(rawImages.map((i) => i.model3dId).filter((id): id is number => id != null)),
+  ];
+  const visibleModel3DIds = rawModel3dIds.length
+    ? await getVisibleModel3DIds({ model3dIds: rawModel3dIds, userId, isModerator })
+    : undefined;
+
   const images = withSpan('image:getAllImages:transform', () => {
     // Process reactions into lookup
     let userReactions: Record<number, ReviewReactions[]> | undefined;
@@ -1989,6 +2018,9 @@ export const getAllImages = async (
         poi?: boolean;
         minor?: boolean;
         judgeScore?: JudgeScore | null;
+        // Visibility-gated linked-Model3D id (or null) for the "Posted to 3D
+        // Model" chip on the feed-modal path. See the model3dId override below.
+        model3dId?: number | null;
       }
     > = filtered.map(({ userId: creatorId, cursorId, unpublishedAt, collectionItemNote, ...i }) => {
       const judgeScore = parseJudgeScore(collectionItemNote ?? null);
@@ -1998,6 +2030,12 @@ export const getAllImages = async (
 
       return {
         ...i,
+        // Override the RAW `p."model3dId"` (spread in via `...i`) with the
+        // visibility-gated value: keep the id only when the viewer may see the
+        // linked Model3D, else null. Drives the feed-modal chip from a prop —
+        // no ambient `model3d.getByPostId`. (`null` here is the three-state
+        // "resolved-absent" the chip needs to NOT fall back.)
+        model3dId: i.model3dId != null && visibleModel3DIds?.has(i.model3dId) ? i.model3dId : null,
         meta: imageMeta?.[i.id] ?? null,
         nsfwLevel: Math.max(thumbnail?.nsfwLevel ?? 0, i.nsfwLevel),
         modelVersionIds: imageResources?.[i.id]?.resources?.map((r) => r.modelVersionId) ?? [],
@@ -2249,6 +2287,29 @@ export const getAllImagesIndex = async (
       }, new Map<number, typeof tagsVar>())
     : undefined;
 
+  // Visibility-check the RAW `model3dId` carried on the search docs (indexed
+  // from `Post.model3dId`) before it reaches the client — same no-leak bar as
+  // the raw-SQL feed path and `image.get`. Meili docs carry it; BitDex docs do
+  // NOT (the field is left `undefined` there → the chip falls back to the
+  // postId lookup, the documented self-healing path). Only the non-null few
+  // are resolved, in ONE batched query (no per-image N+1).
+  const rawIndexModel3dIds = [
+    ...new Set(
+      searchResults
+        // model3dId is present on Meili docs but not on BitDex docs (which the
+        // search-result union also covers) — read it defensively.
+        .map((sr) => (sr as { model3dId?: number }).model3dId)
+        .filter((id): id is number => typeof id === 'number')
+    ),
+  ];
+  const visibleIndexModel3DIds = rawIndexModel3dIds.length
+    ? await getVisibleModel3DIds({
+        model3dIds: rawIndexModel3dIds,
+        userId: currentUserId,
+        isModerator: user?.isModerator,
+      })
+    : undefined;
+
   const mergedData = withSpan('image:getAllImagesIndex:transform', () =>
     searchResults.map(({ publishedAtUnix, ...sr }) => {
       const thisUser = userDatas[sr.userId] ?? {};
@@ -2261,8 +2322,29 @@ export const getAllImagesIndex = async (
       const nsfwLevel = Math.max(thumbnail?.nsfwLevel ?? 0, sr.nsfwLevel);
       const metrics = imageMetrics[sr.id];
 
+      // Three-state chip signal on the feed-modal path:
+      //  - linked model3d (any source)  → gated number | null (no leak)
+      //  - Meili doc, no link           → null (resolved-absent → chip renders
+      //                                   nothing AND does NOT fall back, the
+      //                                   durable elimination of getByPostId)
+      //  - BitDex doc (field not stored)→ undefined (fall back to getByPostId;
+      //                                   self-healing, the documented gap)
+      // `searchSource` is per-page (one backend serves the whole page), so an
+      // absent model3dId means "confirmed no link" on Meili but "not indexed"
+      // on BitDex — only the former is safe to assert as a resolved null.
+      const rawModel3dId = (sr as { model3dId?: number }).model3dId;
+      const model3dId =
+        typeof rawModel3dId === 'number'
+          ? visibleIndexModel3DIds?.has(rawModel3dId)
+            ? rawModel3dId
+            : null
+          : searchSource === 'bitdex'
+          ? undefined
+          : null;
+
       return {
         ...sr,
+        model3dId,
         // Override tagIds from authoritative cache when available.
         // This ensures client-side hidden-tag filtering works even when
         // the search engine (BitDex) doesn't return tagIds.

--- a/src/server/services/model3d.service.ts
+++ b/src/server/services/model3d.service.ts
@@ -1185,6 +1185,46 @@ export const getVisibleModel3DIdForPost = async ({
   return model3d.id;
 };
 
+// Batched sibling of `getVisibleModel3DIdForPost` for the image FEED path.
+// The feed payload (`getAllImages` / `getAllImagesIndex`) already carries a RAW
+// `Post.model3dId` (selected from SQL or read from the Meili doc) that is NOT
+// visibility-checked — a hidden Draft / deleted Model3D's id would otherwise
+// leak to the client as a clickable chip. Most feed images aren't linked to a
+// Model3D at all (model3dId is null), so callers pass ONLY the handful of
+// non-null ids per page; this resolves them in ONE query (no per-image N+1) and
+// returns the set the viewer may see. Applies the SAME `canViewModel3d`
+// predicate as the single-post lookup, so a hidden model is nulled identically.
+export const getVisibleModel3DIds = async ({
+  model3dIds,
+  userId,
+  isModerator = false,
+}: {
+  model3dIds: number[];
+  userId?: number;
+  isModerator?: boolean;
+}): Promise<Set<number>> => {
+  const ids = [...new Set(model3dIds)];
+  if (!ids.length) return new Set();
+  const rows = await dbRead.model3D.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, userId: true, status: true, deletedAt: true },
+  });
+  const visible = new Set<number>();
+  for (const row of rows) {
+    if (
+      canViewModel3d({
+        status: row.status,
+        deletedAt: row.deletedAt,
+        ownerId: row.userId,
+        userId,
+        isModerator,
+      })
+    )
+      visible.add(row.id);
+  }
+  return visible;
+};
+
 // ---------------------------------------------------------------------------
 // Per-Model3D gallery moderation. Mirrors `model.gallerySettings` minus
 // `pinnedPosts` + `level` (no version dimension, no level override for v1).


### PR DESCRIPTION
## What

Finishes the durable `model3d` data-gate started in **#2685** (now merged into `main`, covers the **direct image-page** path via `image.get`). This PR covers the remaining **FEED-MODAL** path so the ambient `model3d.getByPostId` chip query is eliminated there too — making **#2682**'s temporary `model3dFeed` flag-gate fully redundant.

### The gap (after #2685)
The "Posted to 3D Model" chip (`PostingToModel3DCard`, already three-state from #2685) reads `image.model3dId`. On the direct image-page path `image.get` supplies it. But an image opened from a **feed/grid** sources its payload from `getAllImages` (raw SQL) / `getAllImagesIndex` (Meili/BitDex), which did **not** carry `model3dId` → the chip saw `undefined` → fell back to `model3d.getByPostId`, gated only by #2682's flag (opens at GA = no protection).

## Changes

**Feed backends now surface a visibility-checked `model3dId`:**
- **raw SQL** (`getAllImages`): `SELECT p."model3dId"` (the `Post` table is already joined). Added to `GetAllImagesRaw` + the output type. Cache version `v1`→`v2`.
- **Meili** (`getAllImagesIndex`): the index doc already stores `model3dId` (indexed from `Post.model3dId`, `metrics-images.search-index.ts:363`), so it just flows through.
- **BitDex** docs do **not** store `model3dId` → left `undefined` → chip falls back to `getByPostId` (self-heals if/when the BitDex index gains the field; the only residual fallback). Disambiguated from Meili "no link" via the per-page `searchSource`.

**Visibility (matches #2685's no-leak bar):** the raw `Post.model3dId` is unfiltered, so a hidden Draft / deleted / non-visible `Model3D`'s id would otherwise leak as a clickable chip. New batched **`getVisibleModel3DIds`** (sibling of `getVisibleModel3DIdForPost`) resolves **only the handful of non-null 3D-linked ids per page in ONE query** (no per-image N+1), applies the same `canViewModel3d` predicate, and nulls the id before it reaches the client. Most feed images are unlinked (`model3dId` null) so the common page skips the query entirely.

**Three-state result fed to the chip on the feed-modal path:**
- linked + visible → the `number`
- linked + hidden  → `null`
- Meili, no link   → `null` (resolved-absent: chip renders nothing, **no fallback** — the durable cut)
- BitDex doc       → `undefined` (falls back to `getByPostId`)

## Cache implication (explicit)
The new `p."model3dId"` SELECT column changes the `queryCacheRaw` query hash, so old cached entries fall out of the keyspace on their own; the `v1`→`v2` bump abandons the stale keyspace immediately so a warm cache doesn't keep serving `model3dId`-less rows until TTL. `bustCachesForPosts` already busts `images-model3d:` / `images-model:` / `images-modelVersion:` tags on model3d link/unlink, but the **general feed** cache is TTL-only (short ttl) — a stale general-feed entry lacking `model3dId` self-heals (chip falls back until refresh). Acceptable.

## #2682 is now redundant
`model3d.getByPostId` no longer fires on the feed-modal path (Meili/SQL), so the `model3dFeed` flag-gate on `getByPostId` no longer protects an ambient call. **#2682 can be closed.** The only path that still calls `getByPostId` is a BitDex-sourced feed item (model3dId not indexed) — self-healing.

## Tests
- **Service** (`model3d-visible-ids-batch.test.ts`, new — 8 cases): public/owner/mod × Published/Draft/deleted, mixed-batch resolves in ONE query (no N+1), dedupe + minimal-select. The batched authZ that nulls hidden/unpublished/deleted ids.
- **Component** (`PostingToModel3DCard.browser.test.tsx`, extended): feed-modal item with a threaded `model3dId` renders via prop and **`getByPostId` is never enabled** even with a `postId` present (+ a leak-trap assertion).
- **Results:** 20 service tests + 5 component tests pass.

## Build / verify
- `tsc`: **net-zero new errors** on the changed files vs `origin/main` (the repo carries a large pre-existing implicit-any / `Prisma.sql`-typing baseline; my files add none).
- Full local `next build` can't complete — fails in the typecheck phase on a **pre-existing** implicit-any error (`AccountsCard.tsx`), unrelated to this change. Preview CI is the gate.

## Caveats
- **Feed blast radius:** `getAllImages` / `getAllImagesIndex` are the hot feed paths. The added work is one batched DB read **only when a page contains 3D-linked images** (rare today); the common all-null page issues zero extra queries.
- **Cache-warm fallback window:** until warm general-feed entries refresh past their TTL, those items lack `model3dId` and the chip falls back to `getByPostId` (self-healing).
- BitDex-sourced items keep the `getByPostId` fallback until the BitDex index stores `model3dId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)