### PR TITLE
fix(logging): emit tRPC error stderr line before Axiom guards so Loki gets it without Axiom

### DIFF
--- a/src/server/logging/__tests__/client.test.ts
+++ b/src/server/logging/__tests__/client.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// These pin the ordering contract of `logToAxiom`: the structured stderr line
+// (which Loki ingests — it carries message/stack/code/path) must be emitted
+// BEFORE the `if (!axiom) return` / `if (!datastream) return` guards. Previously
+// it sat after those guards, so preview environments — where the Axiom token is a
+// placeholder → `axiom` is null → the function returned early — never reached Loki
+// (confirmed: 0 `INTERNAL_SERVER_ERROR` matches across 2.2M preview log lines).
+// The same blind spot hits any Axiom outage. Axiom ingest is otherwise unchanged.
+//
+// The module builds its `axiom` client and reads `isProd` at import time, so each
+// case resets modules and re-mocks `~/env/other`, `~/env/server`, and
+// `@axiomhq/axiom-node` before a fresh dynamic import. The global test setup
+// (`src/__tests__/setup.ts`) mocks `~/server/logging/client` wholesale for other
+// suites; `vi.unmock` here loads the REAL module under test.
+vi.unmock('~/server/logging/client');
+
+const ERR = { message: 'boom', stack: 'Error: boom\n  at x', code: 'INTERNAL_SERVER_ERROR', path: 'model.getById' };
+
+// Returns the mock ingestEvents spy + a loader for the real module, configured
+// for the requested env. `axiomConfigured=false` reproduces the preview/outage
+// case where the module's `axiom` ends up null.
+async function loadClient(opts: {
+  isProd: boolean;
+  axiomConfigured: boolean;
+  datastream?: string;
+}) {
+  const ingestEvents = vi.fn().mockResolvedValue(undefined);
+
+  vi.doMock('~/env/other', () => ({
+    isProd: opts.isProd,
+    isDev: false,
+    isTest: true,
+    isPreview: false,
+  }));
+
+  vi.doMock('~/env/server', () => ({
+    env: {
+      PODNAME: 'pod-test',
+      IS_BUILD: false,
+      AXIOM_TOKEN: opts.axiomConfigured ? 'token' : undefined,
+      AXIOM_ORG_ID: opts.axiomConfigured ? 'org' : undefined,
+      AXIOM_DATASTREAM: opts.datastream,
+    },
+  }));
+
+  vi.doMock('@axiomhq/axiom-node', () => ({
+    Client: class {
+      ingestEvents = ingestEvents;
+    },
+  }));
+
+  const mod = await import('../client');
+  return { logToAxiom: mod.logToAxiom, ingestEvents };
+}
+
+describe('logToAxiom stderr-for-Loki ordering', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+    vi.doUnmock('~/env/other');
+    vi.doUnmock('~/env/server');
+    vi.doUnmock('@axiomhq/axiom-node');
+  });
+
+  it('REGRESSION GUARD: emits the structured stderr line in prod even when Axiom is null (preview/outage)', async () => {
+    vi.stubEnv('LOG_ERRORS_TO_STDOUT', 'true');
+    const { logToAxiom, ingestEvents } = await loadClient({ isProd: true, axiomConfigured: false });
+
+    await logToAxiom(ERR);
+
+    // The case that was broken: no Axiom client, yet Loki must still get the line.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const payload = errorSpy.mock.calls[0][0] as string;
+    expect(typeof payload).toBe('string');
+    const parsed = JSON.parse(payload);
+    expect(parsed).toMatchObject({
+      message: ERR.message,
+      stack: ERR.stack,
+      code: ERR.code,
+      path: ERR.path,
+    });
+    // No datastream configured in previews → `_axiom` is undefined and dropped by
+    // JSON.stringify; the line still carries the error fields.
+    expect('_axiom' in parsed).toBe(false);
+    // Axiom ingest is correctly skipped when no client is configured.
+    expect(ingestEvents).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit the stderr line when LOG_ERRORS_TO_STDOUT is unset (no stderr spam)', async () => {
+    // flag unset
+    const { logToAxiom, ingestEvents } = await loadClient({ isProd: true, axiomConfigured: false });
+
+    await logToAxiom(ERR);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(ingestEvents).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit the stderr line when LOG_ERRORS_TO_STDOUT is not exactly "true"', async () => {
+    vi.stubEnv('LOG_ERRORS_TO_STDOUT', '1');
+    const { logToAxiom } = await loadClient({ isProd: true, axiomConfigured: false });
+
+    await logToAxiom(ERR);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('still ingests to Axiom (existing behavior) AND emits the stderr line when configured + flag on', async () => {
+    vi.stubEnv('LOG_ERRORS_TO_STDOUT', 'true');
+    const { logToAxiom, ingestEvents } = await loadClient({
+      isProd: true,
+      axiomConfigured: true,
+      datastream: 'civitai-errors',
+    });
+
+    await logToAxiom(ERR);
+
+    // stderr line emitted, carrying the resolved datastream in `_axiom`.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(errorSpy.mock.calls[0][0] as string);
+    expect(parsed._axiom).toBe('civitai-errors');
+    expect(parsed).toMatchObject({ message: ERR.message, code: ERR.code });
+
+    // Axiom ingest preserved.
+    expect(ingestEvents).toHaveBeenCalledTimes(1);
+    expect(ingestEvents).toHaveBeenCalledWith(
+      'civitai-errors',
+      expect.objectContaining({ message: ERR.message, code: ERR.code, pod: 'pod-test' })
+    );
+  });
+});

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -95,19 +95,23 @@ export function buildServerFaultErrorLog(e: unknown): MixedObject {
 export async function logToAxiom(data: MixedObject, datastream?: string) {
   const sendData = { pod: env.PODNAME, ...data };
   if (isProd) {
-    if (!axiom) return;
     datastream ??= env.AXIOM_DATASTREAM;
-    if (!datastream) return;
 
-    // Write stderr BEFORE awaiting Axiom — when Axiom is degraded,
-    // ingestEvents rejects and the rest of this function never runs.
-    // Loki ingest depends on the stderr line; without this ordering,
-    // the Grafana alerts that consume `{ "name": "sysredis-fail-open",
-    // ... }` go silent during the exact multi-service incident class
-    // they exist to handle (sysRedis + Axiom both down).
+    // Write stderr BEFORE the Axiom-null/datastream guards (and before awaiting
+    // Axiom) — Loki ingest depends on this stderr line, so it must fire even when
+    // no Axiom client is configured (preview envs use a placeholder token → axiom
+    // is null) or when Axiom is degraded (ingestEvents rejects and the rest of this
+    // function never runs). Without this ordering, preview tRPC 500s never reach
+    // Loki, and the Grafana alerts that consume `{ "name": "sysredis-fail-open",
+    // ... }` go silent during the exact multi-service incident class they exist to
+    // handle (sysRedis + Axiom both down). `_axiom: datastream` may be undefined in
+    // previews (no AXIOM_DATASTREAM) — JSON.stringify drops it; the line still
+    // carries message/stack/code/path.
     if (process.env.LOG_ERRORS_TO_STDOUT === 'true')
       console.error(JSON.stringify({ _axiom: datastream, ...sendData }));
 
+    if (!axiom) return;
+    if (!datastream) return;
     await axiom.ingestEvents(datastream, sendData);
   } else {
     console.log('logToAxiom', sendData);


### PR DESCRIPTION
## Problem
We're migrating debugging to **Loki** (it ships pod stdout/stderr). The app's tRPC `onError` (`src/pages/api/trpc/[trpc].ts`) logs server errors via `logToAxiom`. In `src/server/logging/client.ts`, the structured stderr line that Loki ingests (it carries `message`/`stack`/`code`/`path` via `safeError`) sat **after** `if (!axiom) return` and `if (!datastream) return`.

In **preview environments** the Axiom token is a placeholder → `axiom` is null → `logToAxiom` returned before ever emitting the stderr line, so **preview tRPC 500s never reached Loki**. Confirmed empirically: **0 matches for `INTERNAL_SERVER_ERROR` across 2.2M preview log lines** in Loki. The same blind spot hits any Axiom outage.

## Change (`src/server/logging/client.ts`)
Reorder so the `LOG_ERRORS_TO_STDOUT`-gated stderr emit fires **before** the `if (!axiom) return` / `if (!datastream) return` guards: resolve `datastream` first, emit the stderr line, then do the Axiom-null/datastream guards and `ingestEvents`.

- When `LOG_ERRORS_TO_STDOUT==='true'`: the structured line is emitted in prod **regardless of whether Axiom is configured** → Loki gets it in previews and during Axiom degradation.
- Axiom ingest behavior is otherwise **unchanged** (still skipped when `!axiom` / `!datastream`).
- The gating flag (`LOG_ERRORS_TO_STDOUT`) is preserved for volume control — not emitted unconditionally.
- `_axiom: datastream` may be `undefined` in previews (no `AXIOM_DATASTREAM`); `JSON.stringify` drops it and the line still carries `message`/`stack`/`code`/`path`.

## Test coverage
New `src/server/logging/__tests__/client.test.ts` (unit project). Each case resets modules + re-mocks `~/env/other`, `~/env/server`, and `@axiomhq/axiom-node` before a fresh dynamic import (the `axiom` client + `isProd` are resolved at module load):

1. **Regression guard (the preview gap):** `isProd=true`, `LOG_ERRORS_TO_STDOUT='true'`, **`axiom` null** → `console.error` IS called with a JSON string containing the error fields (`message`/`stack`/`code`/`path`); `ingestEvents` correctly NOT called. *(This case fails against the old ordering — verified.)*
2. `LOG_ERRORS_TO_STDOUT` unset → `console.error` NOT called (no stderr spam).
3. `LOG_ERRORS_TO_STDOUT` not exactly `'true'` (e.g. `'1'`) → NOT called.
4. Axiom configured + datastream + flag on → `ingestEvents` still called (existing behavior preserved) AND the stderr line still emitted (`_axiom` carries the resolved datastream).

Local run (unit project): **4 passed / 4**. Confirmed the regression guard **fails on the pre-change ordering** and **passes on the new ordering**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)