### PR TITLE
perf(api): SSR-inject user.checkNotifications to cut ~21 req/s off api-primary

### DIFF
--- a/src/components/Notifications/notifications.utils.ts
+++ b/src/components/Notifications/notifications.utils.ts
@@ -9,6 +9,7 @@ import { useSignalConnection } from '~/components/Signals/SignalsProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { NotificationCategory, SignalMessages } from '~/server/common/enums';
 import type { GetUserNotificationsSchema } from '~/server/schema/notification.schema';
+import type { UserNotificationCounts } from '~/server/services/notification.service';
 import type { NotificationGetAll, NotificationGetAllItem } from '~/types/router';
 import { getDisplayName } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
@@ -136,7 +137,10 @@ export const useMarkReadNotification = () => {
           if (newCounts[key] < 0) newCounts[key] = 0;
         }
 
-        return newCounts;
+        // newCounts is built from `...old` (UserNotificationCounts) plus a guaranteed
+        // `all`, then only mutated numerically — it satisfies the count shape. The
+        // `Record<string, number>` buffer above is only to allow dynamic-key indexing.
+        return newCounts as UserNotificationCounts;
       });
 
       // Mark as read in notification feed
@@ -213,7 +217,8 @@ export const useNotificationSignal = () => {
           (newCounts[updated.category.toLowerCase()] ?? 0) + 1;
         newCounts['all']++;
 
-        return newCounts;
+        // See the mark-read updater: numeric buffer that satisfies the count shape.
+        return newCounts as UserNotificationCounts;
       });
     },
     [queryClient, queryUtils]

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -58,6 +58,7 @@ import type { UserContentSettings } from '~/server/schema/user.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { TosMeta } from '~/server/services/content.service';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
+import type { UserNotificationCounts } from '~/server/services/notification.service';
 import type { BrowsingSettingsAddon } from '~/shared/constants/browsing-settings-addons';
 import type { ParsedCookies } from '~/shared/utils/cookies';
 import { parseCookies } from '~/shared/utils/cookies';
@@ -105,6 +106,7 @@ type CustomAppProps = {
   tosMeta?: TosMeta;
   announcements?: AnnouncementsSeed;
   following?: number[];
+  notificationCounts?: UserNotificationCounts;
   seed: number;
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
@@ -131,6 +133,7 @@ function MyApp(props: CustomAppProps) {
       tosMeta,
       announcements,
       following,
+      notificationCounts,
       seed = Date.now(),
       canIndex,
       hasAuthCookie,
@@ -189,6 +192,7 @@ function MyApp(props: CustomAppProps) {
       tosMeta={tosMeta}
       announcements={announcements}
       following={following}
+      notificationCounts={notificationCounts}
       liveNow={liveNow}
       region={region}
       domain={domain}
@@ -382,6 +386,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     tosMeta?: TosMeta;
     announcements?: AnnouncementsSeed;
     following?: number[];
+    notificationCounts?: UserNotificationCounts;
     session: Session | null;
   };
   let settingsBootstrap: SettingsBootstrap;
@@ -434,10 +439,12 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta: undefined,
       announcements: undefined,
       following: undefined,
+      notificationCounts: undefined,
       session: null,
     };
   }
-  const { settings, session, tosMeta, announcements, following } = settingsBootstrap;
+  const { settings, session, tosMeta, announcements, following, notificationCounts } =
+    settingsBootstrap;
   // Pass these via the request so we can use them in SSR. Resolve the per-user
   // feature flags and the global (redis-cached, identical-for-all-users) browsing
   // setting addons in PARALLEL — neither depends on the other and both sit on
@@ -531,6 +538,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta,
       announcements,
       following,
+      notificationCounts,
       seed: Date.now(),
       hasAuthCookie,
       region,

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -4,6 +4,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getTosMeta } from '~/server/services/content.service';
 import { getCurrentAnnouncements } from '~/server/services/announcement.service';
 import { getUserFollows } from '~/server/redis/caches';
+import { getUserNotificationCounts } from '~/server/services/notification.service';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 
 export default PublicEndpoint(
@@ -19,7 +20,7 @@ export default PublicEndpoint(
       // and drop the critical settings/session payload; tosMeta (static, no user
       // input) can still throw to the outer catch (preserving prior behaviour).
       const domainColor = getRequestDomainColor(req);
-      const [tosMeta, announcements, following] = await Promise.all([
+      const [tosMeta, announcements, following, notificationCounts] = await Promise.all([
         // Resolve the static per-domain ToS metadata here (server-only API route)
         // so `_app` getInitialProps can deliver it WITHOUT importing
         // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
@@ -47,12 +48,25 @@ export default PublicEndpoint(
         session?.user
           ? getUserFollows(session.user.id).catch(() => undefined)
           : Promise.resolve(undefined),
+        // SSR-seed the ambient, auth-gated `user.checkNotifications` query (the
+        // header bell unread count, fires on every logged-in bootstrap). Uses
+        // the SAME shared `getUserNotificationCounts` reduce the resolver uses,
+        // so the seed is byte-identical to a live fetch (plain { all, <cat> }
+        // object of numbers — no superjson Date/array divergence). Anon never
+        // fires this query (protectedProcedure + `enabled: !!currentUser`), so
+        // seed authed-only. `.catch(undefined)` so a redis/DB blip degrades to
+        // no-seed (client self-heals on bootstrap) and can never reject the
+        // Promise.all and drop the critical settings/session payload.
+        session?.user
+          ? getUserNotificationCounts({ userId: session.user.id }).catch(() => undefined)
+          : Promise.resolve(undefined),
       ]);
       res.status(200).json({
         settings,
         tosMeta,
         announcements,
         following,
+        notificationCounts,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,
       });
     } catch (e) {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -8,6 +8,7 @@ import { setServerDomains } from '~/utils/sync-account';
 import { trpc } from '~/utils/trpc';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
 import { reviveAnnouncementsSeed } from '~/providers/announcements-seed';
+import type { UserNotificationCounts } from '~/server/services/notification.service';
 
 type AppProviderProps = {
   children: React.ReactNode;
@@ -25,6 +26,14 @@ type AppProviderProps = {
   // followed userIds. Seeds the query directly (fixed `undefined` key) so the
   // ambient follow/notify buttons never fire it on bootstrap.
   following?: number[];
+  // SSR-computed `user.checkNotifications` result (logged-in only) — the header
+  // bell unread count, reduced to { all, <category>: count }. Seeds the ambient
+  // `useQueryNotificationsCount` query (fixed `undefined` key) so it never fires
+  // on bootstrap. It's a LIVE count: the existing freshness path (the
+  // `NotificationNew` signal + mark-read optimistic `setData`) applies ON TOP of
+  // the seed, so it stays current without a refetch — the seed only replaces the
+  // one-shot bootstrap fetch.
+  notificationCounts?: UserNotificationCounts;
   // SSR-computed `system.getLiveNow` global boolean (a single redis.get,
   // identical for every user). Seeds the ambient `useIsLive` query (fixed
   // `undefined` key) so it never fires on bootstrap. Public procedure → seeded
@@ -84,6 +93,7 @@ export function AppProvider({
   tosMeta,
   announcements,
   following,
+  notificationCounts,
   liveNow,
   domain,
   host,
@@ -108,6 +118,25 @@ export function AppProvider({
   trpc.user.getFollowingUsers.useQuery(undefined, {
     initialData: following,
     enabled: !!following,
+  });
+  // Seed `user.checkNotifications` (the header bell unread count) from the SSR
+  // snapshot so `useQueryNotificationsCount` reads a primed cache and never
+  // fires the query on bootstrap (~21 req/s off api-primary). Shares the fixed
+  // `undefined` query key with that hook. It IS a live count, but freshness
+  // does NOT come from a poll — it comes from the `NotificationNew` signal +
+  // mark-read optimistic `setData`, both of which apply on top of whatever is in
+  // the cache (seed or fetched). The consumer hook sets `staleTime: Infinity`
+  // (no time-based refetch today either), so seeding here is behavior-identical:
+  // it replaces the single bootstrap fetch and the count self-corrects via the
+  // same signal/mutation path as before. Match that `staleTime: Infinity` so the
+  // seed counts as fresh and no self-heal fetch fires. `enabled: !!notificationCounts`
+  // skips the seed (and any fetch from this provider) when there's no snapshot
+  // (anon never fires this protectedProcedure; a failed authed snapshot falls
+  // back to the consumer's own live bootstrap fetch).
+  trpc.user.checkNotifications.useQuery(undefined, {
+    initialData: notificationCounts,
+    enabled: !!notificationCounts,
+    staleTime: Infinity,
   });
   // Seed the global `system.getLiveNow` boolean from the SSR snapshot so the
   // ambient `useIsLive` consumers (header logo, social links, social home

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -5,7 +5,6 @@ import { env } from '~/env/server';
 import { clickhouse } from '~/server/clickhouse/client';
 import { purgeCache } from '~/server/cloudflare/client';
 import { constants } from '~/server/common/constants';
-import type { NotificationCategory } from '~/server/common/enums';
 import {
   OnboardingComplete,
   OnboardingSteps,
@@ -53,7 +52,7 @@ import type {
   WithClaimKey,
 } from '~/server/selectors/cosmetic.selector';
 import { simpleUserSelect } from '~/server/selectors/user.selector';
-import { getUserNotificationCount } from '~/server/services/notification.service';
+import { getUserNotificationCounts } from '~/server/services/notification.service';
 import {
   getResourceReviewsByUserId,
   getUserResourceReview,
@@ -253,21 +252,9 @@ export const checkUserNotificationsHandler = async ({ ctx }: { ctx: ProtectedCon
   const { id } = ctx.user;
 
   try {
-    const unreadCount = await getUserNotificationCount({
-      userId: id,
-      unread: true,
-    });
-
-    const reduced = unreadCount.reduce(
-      (acc, { category, count }) => {
-        const key = category.toLowerCase() as Lowercase<NotificationCategory>;
-        acc[key] = Number(count);
-        acc['all'] += Number(count);
-        return acc;
-      },
-      { all: 0 } as Record<Lowercase<NotificationCategory> | 'all', number>
-    );
-    return reduced;
+    // Shared reduce so the SSR-seed path (`/api/user/settings`) returns a
+    // byte-identical object to this resolver — see getUserNotificationCounts.
+    return await getUserNotificationCounts({ userId: id });
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -178,6 +178,31 @@ export async function getUserNotificationCount({
   return result;
 }
 
+// The reduced { all, <category>: count } shape consumed by the header bell.
+// Extracted so BOTH `user.checkNotifications` (the tRPC resolver) and the
+// `_app` SSR-seed path (`/api/user/settings`) produce a byte-identical object —
+// the seed must equal a live fetch or the header count would render wrong on
+// first paint. Single source of truth for the reduce + key-casing.
+export type UserNotificationCounts = Record<Lowercase<NotificationCategory> | 'all', number>;
+
+export async function getUserNotificationCounts({
+  userId,
+}: {
+  userId: number;
+}): Promise<UserNotificationCounts> {
+  const unreadCount = await getUserNotificationCount({ userId, unread: true });
+
+  return unreadCount.reduce(
+    (acc, { category, count }) => {
+      const key = category.toLowerCase() as Lowercase<NotificationCategory>;
+      acc[key] = Number(count);
+      acc['all'] += Number(count);
+      return acc;
+    },
+    { all: 0 } as UserNotificationCounts
+  );
+}
+
 // Per-user serialization queue. Rapid-click streams previously fanned out to
 // N concurrent pool.connect() acquisitions against the notif pool, which
 // starved it under load (46k "Connection terminated due to connection timeout"

--- a/tests/preview-ssr-inject.spec.ts
+++ b/tests/preview-ssr-inject.spec.ts
@@ -44,6 +44,7 @@ const TOS_PROCEDURE = 'content.checkTosUpdate';
 const ANNOUNCEMENTS_PROCEDURE = 'announcement.getAnnouncements';
 const FOLLOWING_PROCEDURE = 'user.getFollowingUsers';
 const LIVE_NOW_PROCEDURE = 'system.getLiveNow';
+const CHECK_NOTIFICATIONS_PROCEDURE = 'user.checkNotifications';
 
 // A core page a gate-passing user lands on directly (no /login bounce). Both
 // procedures fire on every logged-in bootstrap regardless of which page, so
@@ -468,6 +469,84 @@ test.describe('SSR-injected getLiveNow (anonymous)', () => {
         '\n'
       )}`
     ).toHaveLength(0);
+  });
+});
+
+/**
+ * Regression guard for the SSR-inject of `user.checkNotifications` (~21/s on
+ * api-primary) — the header notification-bell unread count. It is a
+ * `protectedProcedure` consumed by the ambient `useQueryNotificationsCount`
+ * hook, so it fires on every LOGGED-IN bootstrap (never anon → no anon block,
+ * same as getFollowingUsers). SSR-computed in the `/api/user/settings`
+ * self-fetch that `_app` already makes (so NO server-only module is pulled into
+ * `_app`'s client bundle) via the SAME shared `getUserNotificationCounts` reduce
+ * the resolver uses, then seeded in AppProvider on the fixed `undefined` key.
+ *
+ * Byte-equality: the payload is a plain `{ all, <category>: count }` object of
+ * numbers — no Date/array/`undefined` field, so the JSON seed and the live
+ * `result.data.json` compare directly with no superjson `undefined`→`null`
+ * divergence. (`buzz` is `0` not absent when there are no buzz notifications:
+ * the resolver only emits categories the SQL GROUP BY returns, so an absent
+ * category is absent on BOTH the seed and the live fetch — they still `toEqual`.)
+ *
+ * FRESHNESS (the live-count requirement): this seed REPLACES the one-shot
+ * bootstrap fetch only — it does NOT make the count stickier. The consumer hook
+ * already uses `staleTime: Infinity` (no time-poll today either); the count is
+ * kept live by the `NotificationNew` SignalR push + the mark-read optimistic
+ * `setData`, both of which apply on top of the cache (seed or fetched) exactly
+ * as before. So "seed-then-(signal-driven)-refresh" is preserved.
+ */
+test.describe('SSR-injected checkNotifications (logged-in)', () => {
+  test.use({ storageState: storageStatePath('mod') });
+
+  test('checkNotifications is seeded into __NEXT_DATA__ and not fetched on bootstrap', async ({
+    page,
+  }) => {
+    const trpcUrls = await collectTrpcRequests(page, AUTHED_LANDING);
+
+    const counts = await readPageProp(page, 'notificationCounts');
+    expect(counts.present, 'notificationCounts present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(
+      counts.value && typeof counts.value === 'object' && !Array.isArray(counts.value),
+      'notificationCounts seed is a plain object'
+    ).toBe(true);
+    // The reduced shape always carries an `all` total (the reduce seeds it to 0).
+    expect(typeof (counts.value as Record<string, unknown>)?.all, 'seed.all is a number').toBe(
+      'number'
+    );
+
+    const requests = trpcUrls.filter((u) => u.includes(CHECK_NOTIFICATIONS_PROCEDURE));
+    expect(
+      requests,
+      `no ${CHECK_NOTIFICATIONS_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${requests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
+  });
+
+  test('SSR seed byte-equals a live fetch', async ({ page }) => {
+    await page.goto(AUTHED_LANDING, { waitUntil: 'domcontentloaded' });
+
+    const seed = await readPageProp(page, 'notificationCounts');
+    expect(seed.present, 'notificationCounts seed present in __NEXT_DATA__').toBe(true);
+
+    const live = await fetchTrpcQueryJson(page, CHECK_NOTIFICATIONS_PROCEDURE);
+    // The shared `getUserNotificationCounts` reduce backs both the seed and the
+    // resolver, so they must be deep-equal. A wrong initial count is worse than
+    // not seeding (the bell would render stale on first paint) — this is the gate.
+    expect(
+      seed.value,
+      'user.checkNotifications SSR seed must byte-equal a live resolver fetch'
+    ).toEqual(live);
+
+    // Surface the totals so an all-zero run (no unread notifications) is visible
+    // rather than a silent trivial pass, and assert every value is a number.
+    const obj = (seed.value ?? {}) as Record<string, unknown>;
+    // eslint-disable-next-line no-console
+    console.log(`[ssr-inject] checkNotifications seed: ${JSON.stringify(obj)}`);
+    for (const [k, v] of Object.entries(obj)) {
+      expect(typeof v, `checkNotifications.${k} is a number`).toBe('number');
+    }
   });
 });
 


### PR DESCRIPTION
## What

SSR-inject the header notification-bell unread count so the ambient `user.checkNotifications` client query never fires on bootstrap, removing **~21 req/s** of full non-batched tRPC middleware + context-build + superjson cycles from `civitai-dp-prod-api-primary`.

`user.checkNotifications` (`routers/user.router.ts:182` → `controllers/user.controller.ts:252` → `services/notification.service.ts:141`) is the header bell unread count — already redis-cached server-side (with a lag-key bust). The cost being cut is the **per-request fixed middleware cycle ×21/s** (the CPU lever), not the cached resolver. This is Tier-1 #6 in the datapacket-talos analysis `claudedocs/api-primary-trpc-cost-analysis-2026-06-21.md`; mirrors the just-merged #2683 (`system.getLiveNow`) and #2471 (`following`/`getSettings`).

## How (the #2471 server-endpoint pattern — no server-only module leaks into the client bundle)

- **Shared reduce** (`notification.service.ts`): extract the resolver's reduce into `getUserNotificationCounts` so BOTH `user.checkNotifications` and the SSR-seed path produce a **byte-identical** `{ all, <category>: count }` object. The controller now calls it directly (public tRPC type unchanged).
- **Compute server-side in a route `_app` already hits**: add the count to the `/api/user/settings` self-fetch's `Promise.all` (right beside the existing `following` seed) — authed-only, `.catch(() => undefined)` so a redis/DB blip degrades to no-seed (client self-heals) and can never reject the `Promise.all` and drop the critical settings/session payload. No new `import()` enters `_app`.
- **Seed in AppProvider**: thread `notificationCounts` through `_app` pageProps → `AppProvider`, which seeds `trpc.user.checkNotifications.useQuery(undefined, { initialData, enabled: !!notificationCounts, staleTime: Infinity })` on the fixed `undefined` key (same key the `useQueryNotificationsCount` hook uses).

## Live-count freshness (seed-then-poll, preserved)

The seed **replaces the one-shot bootstrap fetch only** — it does not make the count stickier. The consumer hook already uses `staleTime: Infinity` (there is **no time-poll today** either); the count stays live via the `NotificationNew` SignalR push + the mark-read optimistic `setData`, both of which apply on top of the cache (seed or fetched) exactly as before.

## Byte-equality

Payload is a plain object of numbers (no `Date`/array/`undefined` field), so the JSON seed and the live `result.data.json` compare directly — no superjson `undefined`→`null` divergence. An absent category (e.g. `buzz` when there are none) is absent on **both** the seed and the live fetch, so `toEqual` holds. The shared reduce is the single source of truth backing both paths.

## Tests

Extends `tests/preview-ssr-inject.spec.ts` with an authed describe block asserting: (a) the seed is present in `__NEXT_DATA__.props.pageProps.notificationCounts`, (b) no `user.checkNotifications` tRPC request fires on bootstrap, and (c) the seed **deep-equals** a live authed fetch (fetched from WITHIN the page via `page.evaluate`, not `page.request`). Authed-only (`protectedProcedure` → never fires anon, like `getFollowingUsers`). These run under `playwright.preview.config.ts` (need a live preview).

## Verification / caveats

- **tsc:** zero type errors in any changed line (the 3 new `_app`/AppProvider/settings files compile clean; the repo's pre-existing repo-wide implicit-any / `Prisma.sql` errors are untouched and unrelated, and none reference the new symbols).
- **Full `next build` (bundle-leak check): INCONCLUSIVE locally** — Turbopack rejects the worktree's symlinked `node_modules` ("Symlink … points out of the filesystem root") and the `--webpack` fallback OOMs the Node heap even at 16 GB (the same blockers #2683 hit). **No `Can't resolve` / `Module not found` / leak marker appeared** before those infra failures.
- **Reachability argument:** the two new imports into client-bundled files (`_app.tsx`, `AppProvider.tsx`) are **`import type` only** (erased at compile, never in the bundle); the runtime value flows through the existing `/api/user/settings` self-fetch, so the client-bundle surface is structurally identical to the in-production `following` seed (#2471). Preview-build CI is the gate.

Behavior-preserving; dark-safe (cache seed only). **Freshness caveat:** the bell count's live freshness depends entirely on the `NotificationNew` signal + mark-read `setData` (unchanged) — there is no time-based poll today, and this PR does not add one; it only removes the redundant bootstrap fetch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)