### PR TITLE
perf(api): SSR-seed chat.getUnreadCount to cut ~19 req/s off api-primary

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -390,6 +390,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     tosMeta?: TosMeta;
     announcements?: AnnouncementsSeed;
     following?: number[];
+    chatUnreadCount?: ChatUnreadCount;
     session: Session | null;
   };
   let settingsBootstrap: SettingsBootstrap;
@@ -442,10 +443,12 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta: undefined,
       announcements: undefined,
       following: undefined,
+      chatUnreadCount: undefined,
       session: null,
     };
   }
-  const { settings, session, tosMeta, announcements, following } = settingsBootstrap;
+  const { settings, session, tosMeta, announcements, following, chatUnreadCount } =
+    settingsBootstrap;
   // Pass these via the request so we can use them in SSR. Resolve the per-user
   // feature flags and the global (redis-cached, identical-for-all-users) browsing
   // setting addons in PARALLEL — neither depends on the other and both sit on
@@ -488,30 +491,21 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
 
   const domain = getRequestDomainColor(request);
 
-  // SSR-seed `chat.getUnreadCount` (logged-in only) so the header chat badge
-  // reads a primed cache and never fires the query on bootstrap (~19 req/s off
-  // api-primary). It CANNOT be deferred to chat-open: the badge is always
-  // visible in the header, and the live-increment path in ChatSignals.ts only
-  // bumps an EXISTING cache entry (`produce((old) => if (!old) return old)`) —
-  // an unseeded badge would silently drop every incoming-message bump until the
-  // user opened chat. Tradeoff: this adds the unread-count DB read (two cheap
-  // indexed `count` queries) to the SSR render path; the net win is removing the
-  // full per-request middleware+context+superjson cycle that the standalone
-  // tRPC call paid. Fail open to `undefined` (the client query self-heals on its
-  // own fetch) — a DB blip here must never 500 a page render.
-  let chatUnreadCount: ChatUnreadCount | undefined;
-  if (session?.user) {
-    try {
-      const { getUnreadMessagesForUser } = await import('~/server/services/chat.service');
-      chatUnreadCount = await getUnreadMessagesForUser({ userId: session.user.id });
-    } catch (e) {
-      console.warn(
-        `[_app] chat.getUnreadCount bootstrap failed, rendering without seed: ${
-          e instanceof Error ? e.message : String(e)
-        }`
-      );
-    }
-  }
+  // NOTE: `chat.getUnreadCount` (the always-visible header chat badge, ~19 req/s
+  // off api-primary) is SSR-seeded too, but it is computed in the server-only
+  // `/api/user/settings` route above and delivered via that fetch (read off
+  // `settingsBootstrap` as `chatUnreadCount`). It is deliberately NOT resolved
+  // here: `chat.service` is server-only and importing it into this graph — even
+  // via a dynamic `await import` — pulls Node built-ins (`node:fs`/
+  // `node:perf_hooks`) into `_app`'s client bundle and breaks `next build` (same
+  // class as the `content.service`/`announcement.service` carve-outs above and
+  // the `prom-client` note below). It rides down through pageProps to AppProvider
+  // and seeds the ambient query there. It CANNOT be deferred to chat-open: the
+  // badge is always visible, and the live-increment path in ChatSignals.ts only
+  // bumps an EXISTING cache entry (`produce((old) => if (!old) return old)`) — an
+  // unseeded badge would silently drop every incoming-message bump until the user
+  // opened chat. Fail open to `undefined` (the client query self-heals on its own
+  // fetch) — a DB blip in the route must never 500 a page render.
 
   // SSR-inject two ambient per-bootstrap trpc results that fire on every
   // logged-in page load but are fully derivable from data already fetched here.

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -55,6 +55,8 @@ import { IsClientProvider } from '~/providers/IsClientProvider';
 // import { StripeSetupSuccessProvider } from '~/providers/StripeProvider';
 import { ThemeProvider } from '~/providers/ThemeProvider';
 import type { UserContentSettings } from '~/server/schema/user.schema';
+import type { RouterOutput } from '~/types/router';
+type ChatUnreadCount = RouterOutput['chat']['getUnreadCount'];
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { TosMeta } from '~/server/services/content.service';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
@@ -109,6 +111,10 @@ type CustomAppProps = {
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
   liveNow: boolean;
+  // SSR-seeded `chat.getUnreadCount` (logged-in only). The per-chat unread tallies
+  // behind the header chat badge. Optional: absent for anon and on the fail-open
+  // path (the client query self-heals on its own fetch). See AppProvider seed.
+  chatUnreadCount?: ChatUnreadCount;
   canIndex: boolean;
   hasAuthCookie: boolean;
   region: RegionInfo;
@@ -137,6 +143,7 @@ function MyApp(props: CustomAppProps) {
       settings,
       browsingSettingsAddons,
       liveNow = false,
+      chatUnreadCount,
       region,
       domain,
       host,
@@ -190,6 +197,7 @@ function MyApp(props: CustomAppProps) {
       announcements={announcements}
       following={following}
       liveNow={liveNow}
+      chatUnreadCount={chatUnreadCount}
       region={region}
       domain={domain}
       host={host}
@@ -479,6 +487,31 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   }
 
   const domain = getRequestDomainColor(request);
+
+  // SSR-seed `chat.getUnreadCount` (logged-in only) so the header chat badge
+  // reads a primed cache and never fires the query on bootstrap (~19 req/s off
+  // api-primary). It CANNOT be deferred to chat-open: the badge is always
+  // visible in the header, and the live-increment path in ChatSignals.ts only
+  // bumps an EXISTING cache entry (`produce((old) => if (!old) return old)`) —
+  // an unseeded badge would silently drop every incoming-message bump until the
+  // user opened chat. Tradeoff: this adds the unread-count DB read (two cheap
+  // indexed `count` queries) to the SSR render path; the net win is removing the
+  // full per-request middleware+context+superjson cycle that the standalone
+  // tRPC call paid. Fail open to `undefined` (the client query self-heals on its
+  // own fetch) — a DB blip here must never 500 a page render.
+  let chatUnreadCount: ChatUnreadCount | undefined;
+  if (session?.user) {
+    try {
+      const { getUnreadMessagesForUser } = await import('~/server/services/chat.service');
+      chatUnreadCount = await getUnreadMessagesForUser({ userId: session.user.id });
+    } catch (e) {
+      console.warn(
+        `[_app] chat.getUnreadCount bootstrap failed, rendering without seed: ${
+          e instanceof Error ? e.message : String(e)
+        }`
+      );
+    }
+  }
 
   // SSR-inject two ambient per-bootstrap trpc results that fire on every
   // logged-in page load but are fully derivable from data already fetched here.

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -558,6 +558,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta,
       announcements,
       following,
+      chatUnreadCount,
       seed: Date.now(),
       hasAuthCookie,
       region,

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -4,6 +4,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getTosMeta } from '~/server/services/content.service';
 import { getCurrentAnnouncements } from '~/server/services/announcement.service';
 import { getUserFollows } from '~/server/redis/caches';
+import { getUnreadMessagesForUser } from '~/server/services/chat.service';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 
 export default PublicEndpoint(
@@ -19,7 +20,7 @@ export default PublicEndpoint(
       // and drop the critical settings/session payload; tosMeta (static, no user
       // input) can still throw to the outer catch (preserving prior behaviour).
       const domainColor = getRequestDomainColor(req);
-      const [tosMeta, announcements, following] = await Promise.all([
+      const [tosMeta, announcements, following, chatUnreadCount] = await Promise.all([
         // Resolve the static per-domain ToS metadata here (server-only API route)
         // so `_app` getInitialProps can deliver it WITHOUT importing
         // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
@@ -47,12 +48,27 @@ export default PublicEndpoint(
         session?.user
           ? getUserFollows(session.user.id).catch(() => undefined)
           : Promise.resolve(undefined),
+        // SSR-seed the ambient, auth-gated `chat.getUnreadCount` query (~19 req/s
+        // on api-primary; the always-visible header chat badge). Computed here —
+        // NOT in `_app` getInitialProps — because `chat.service` is server-only
+        // and importing it into `_app` (even via a dynamic `await import`) pulls
+        // Node built-ins (`node:fs`/`node:perf_hooks`, via the `env/server` +
+        // `errorHandling` + `unfurl.js` import chain) into the client bundle and
+        // breaks `next build`. `getUnreadMessagesForUser` is the same fn the
+        // resolver runs, so the seed is byte-identical (`{ chatId, cnt }[]`, #2471
+        // gotcha). Anon never fires this protected query, so seed authed-only; on
+        // a chat-service error fall back to undefined and let the client self-heal
+        // via `ChatButton`'s own live fetch.
+        session?.user
+          ? getUnreadMessagesForUser({ userId: session.user.id }).catch(() => undefined)
+          : Promise.resolve(undefined),
       ]);
       res.status(200).json({
         settings,
         tosMeta,
         announcements,
         following,
+        chatUnreadCount,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,
       });
     } catch (e) {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -8,6 +8,9 @@ import { setServerDomains } from '~/utils/sync-account';
 import { trpc } from '~/utils/trpc';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
 import { reviveAnnouncementsSeed } from '~/providers/announcements-seed';
+import type { RouterOutput } from '~/types/router';
+
+type ChatUnreadCount = RouterOutput['chat']['getUnreadCount'];
 
 type AppProviderProps = {
   children: React.ReactNode;
@@ -30,6 +33,11 @@ type AppProviderProps = {
   // `undefined` key) so it never fires on bootstrap. Public procedure → seeded
   // for everyone, no auth gate.
   liveNow: boolean;
+  // SSR-computed `chat.getUnreadCount` (logged-in only) — the per-chat unread
+  // tallies behind the header chat badge. Seeds the ambient query (fixed
+  // `undefined` key) so the badge never fires it on bootstrap. Absent for anon
+  // and on the fail-open path (the consumers' own live fetch takes over).
+  chatUnreadCount?: ChatUnreadCount;
   seed: number;
   canIndex: boolean;
   region: RegionInfo;
@@ -85,6 +93,7 @@ export function AppProvider({
   announcements,
   following,
   liveNow,
+  chatUnreadCount,
   domain,
   host,
   serverDomains,
@@ -119,6 +128,20 @@ export function AppProvider({
   trpc.system.getLiveNow.useQuery(undefined, {
     initialData: liveNow,
     staleTime: 1000 * 60 * 5,
+  });
+  // Seed `chat.getUnreadCount` (the header chat badge) from the SSR snapshot so
+  // the badge reads a primed cache and never fires the query on bootstrap
+  // (~19 req/s off api-primary). Shares the fixed `undefined` query key with
+  // `ChatButton`'s `trpc.chat.getUnreadCount.useQuery`. Updates stay LIVE via
+  // `ChatSignals`' `setData` on incoming messages (same model as
+  // `getFollowingUsers` above — no external churn to poll for), so the global
+  // `staleTime: Infinity` default is correct. `enabled: !!chatUnreadCount` skips
+  // the seed (and any self-heal fetch) only when there's no snapshot: anon never
+  // fires this protected query, and a failed authed snapshot falls back to
+  // `ChatButton`'s own live fetch.
+  trpc.chat.getUnreadCount.useQuery(undefined, {
+    initialData: chatUnreadCount,
+    enabled: !!chatUnreadCount,
   });
   // Populate the module-level server domain map so `syncAccount(url)` can
   // resolve hosts to colors without pulling from React context.

--- a/src/server/controllers/chat.controller.ts
+++ b/src/server/controllers/chat.controller.ts
@@ -20,7 +20,12 @@ import type {
 } from '~/server/schema/chat.schema';
 import { latestChat, singleChatSelect } from '~/server/selectors/chat.selector';
 import { profileImageSelect } from '~/server/selectors/image.selector';
-import { createMessage, maxUsersPerChat, upsertChat } from '~/server/services/chat.service';
+import {
+  createMessage,
+  getUnreadMessagesForUser,
+  maxUsersPerChat,
+  upsertChat,
+} from '~/server/services/chat.service';
 import { getUserSettings, setUserSetting } from '~/server/services/user.service';
 import { withSignals } from '~/server/signals/wrapper';
 import {
@@ -110,34 +115,7 @@ export const getUnreadMessagesForUserHandler = async ({
 }) => {
   try {
     const { id: userId } = ctx.user;
-
-    const unread = await dbRead.$queryRaw<{ chatId: number; cnt: number }[]>`
-      select memb."chatId"          as "chatId",
-             count(msg.id)::integer as "cnt"
-      from "ChatMember" memb
-             left join "ChatMessage" msg
-                       on msg."chatId" = memb."chatId" and
-                          (msg.id > memb."lastViewedMessageId" or
-                           memb."lastViewedMessageId" is null
-                            )
-      where memb."userId" = ${userId}
-        and memb.status = 'Joined'
-        and memb."isMuted" is false
-        and msg."userId" != ${userId}
-      group by memb."chatId"
-    `;
-
-    const pending = await dbRead.$queryRaw<{ chatId: number; cnt: number }[]>`
-      select memb."chatId" as "chatId",
-             1             as "cnt"
-      from "ChatMember" memb
-      where memb."userId" = ${userId}
-        and memb.status = 'Invited'
-        and memb."isMuted" is false
-      group by memb."chatId"
-    `;
-
-    return [...unread, ...pending];
+    return await getUnreadMessagesForUser({ userId });
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/services/__tests__/chat-unread-count.test.ts
+++ b/src/server/services/__tests__/chat-unread-count.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `getUnreadMessagesForUser` is the shared source for both the `chat.getUnreadCount`
+// tRPC resolver AND the new `_app` SSR bootstrap seed. The seed value must be
+// byte-identical to the resolver output (#2471 gotcha) or the primed client
+// cache would mismatch and force the very bootstrap refetch we're cutting.
+// We mock only the two DB reads and exercise the concat/shape contract.
+
+const h = vi.hoisted(() => ({
+  queryRaw: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: h.queryRaw },
+  dbWrite: {},
+}));
+
+// chat.service transitively imports `Prisma.validator<...>()(...)` selector
+// files at module-eval; `Prisma.validator` isn't present in the SSR test
+// transform of `@prisma/client`, so provide a pass-through (mirrors
+// model3d-visible-id-for-post.test.ts). Unblocks the import chain without
+// faking any logic this test exercises.
+vi.mock('@prisma/client', () => ({
+  Prisma: {
+    validator: () => (x: unknown) => x,
+    sql: () => ({}),
+    join: () => ({}),
+    raw: () => ({}),
+    SortOrder: { asc: 'asc', desc: 'desc' },
+  },
+}));
+vi.mock('unfurl.js', () => ({ unfurl: vi.fn() }));
+vi.mock('linkifyjs', () => ({ find: vi.fn(() => []) }));
+vi.mock('~/server/signals/wrapper', () => ({ withSignals: vi.fn() }));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(),
+  throwOnBlockedMessagePattern: vi.fn(),
+}));
+// Cut the heavy transitive import graph chat.service drags in at module-eval:
+// `user.service` reaches `image.service` -> `event-engine-common/feeds` (a
+// submodule outside src, unresolvable in the test transform), and
+// `user-preferences.service` is unrelated to the unread-count query. Neither is
+// used by `getUnreadMessagesForUser`, so stub them at the boundary.
+vi.mock('~/server/services/user.service', () => ({ getUserSettings: vi.fn() }));
+vi.mock('~/server/services/user-preferences.service', () => ({
+  BlockedByUsers: { getCached: vi.fn() },
+  BlockedUsers: { getCached: vi.fn() },
+}));
+
+const { getUnreadMessagesForUser } = await import('~/server/services/chat.service');
+
+describe('getUnreadMessagesForUser (chat.getUnreadCount SSR-seed source)', () => {
+  beforeEach(() => h.queryRaw.mockReset());
+
+  it('returns the joined unread tallies concatenated with pending invites', async () => {
+    // First call = unread (Joined), second = pending (Invited).
+    h.queryRaw
+      .mockResolvedValueOnce([{ chatId: 1, cnt: 3 }])
+      .mockResolvedValueOnce([{ chatId: 9, cnt: 1 }]);
+
+    const result = await getUnreadMessagesForUser({ userId: 42 });
+
+    expect(h.queryRaw).toHaveBeenCalledTimes(2);
+    // Byte-equality contract: the seed array shape == the resolver output —
+    // `{ chatId, cnt }[]`, unread first then pending. A regression in either
+    // query's ORDER or SHAPE breaks here.
+    expect(result).toEqual([
+      { chatId: 1, cnt: 3 },
+      { chatId: 9, cnt: 1 },
+    ]);
+  });
+
+  it('returns an empty array when the user has no unread or pending chats', async () => {
+    h.queryRaw.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    const result = await getUnreadMessagesForUser({ userId: 7 });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/server/services/chat.service.ts
+++ b/src/server/services/chat.service.ts
@@ -39,6 +39,44 @@ const messageLimiter = createLimiter({
   refetchInterval: 60 * 60, // 1 hour window
 });
 
+/**
+ * Per-chat unread tallies for a user (the header chat badge source).
+ *
+ * Extracted from the `chat.getUnreadCount` controller so the SSR bootstrap seed
+ * (`_app.getInitialProps`) and the tRPC resolver share ONE query — the seed must
+ * be byte-identical to the resolver output (#2471 gotcha) or the primed cache
+ * would mismatch and force an immediate refetch.
+ */
+export async function getUnreadMessagesForUser({ userId }: { userId: number }) {
+  const unread = await dbRead.$queryRaw<{ chatId: number; cnt: number }[]>`
+    select memb."chatId"          as "chatId",
+           count(msg.id)::integer as "cnt"
+    from "ChatMember" memb
+           left join "ChatMessage" msg
+                     on msg."chatId" = memb."chatId" and
+                        (msg.id > memb."lastViewedMessageId" or
+                         memb."lastViewedMessageId" is null
+                          )
+    where memb."userId" = ${userId}
+      and memb.status = 'Joined'
+      and memb."isMuted" is false
+      and msg."userId" != ${userId}
+    group by memb."chatId"
+  `;
+
+  const pending = await dbRead.$queryRaw<{ chatId: number; cnt: number }[]>`
+    select memb."chatId" as "chatId",
+           1             as "cnt"
+    from "ChatMember" memb
+    where memb."userId" = ${userId}
+      and memb.status = 'Invited'
+      and memb."isMuted" is false
+    group by memb."chatId"
+  `;
+
+  return [...unread, ...pending];
+}
+
 export const upsertChat = async ({
   userIds,
   isModerator,


### PR DESCRIPTION
## What

SSR-seed the `chat.getUnreadCount` tRPC query (the header chat badge) so it never fires on logged-in bootstrap. **Tier-1 #4** in the 2026-06-21 api-primary tRPC cost analysis (~19 req/s). Mirrors the just-merged `system.getLiveNow` seed (#2683).

## Why seed, not defer

The badge is **always visible** in the header, and the live-increment path in `ChatSignals.ts` only bumps an **existing** cache entry (`produce((old) => { if (!old) return old; ... })`) — an unseeded badge silently drops every incoming-message bump until chat is opened. Deferring to widget-open regresses the badge. Seeding preserves it and removes the bootstrap request.

## How

- Extract the unread-count query into a shared `getUnreadMessagesForUser` service fn used by **both** the resolver and the `_app` getInitialProps seed → seed is byte-identical to the resolver output (#2471 gotcha).
- Seed via `AppProvider` `initialData` on the fixed `undefined` key; live updates still arrive via `ChatSignals` `setData` (global `staleTime: Infinity`, same model as `getFollowingUsers`).
- **Fail-open**: a DB blip leaves the seed undefined → the client's own `ChatButton` query self-heals. Never 500s a render.

## Tradeoff

Moves the two indexed unread-count `count` queries onto the SSR render path. Net win = removing the full per-request middleware+context+superjson cycle the standalone tRPC call paid.

## Tests

`src/server/services/__tests__/chat-unread-count.test.ts` (2 tests) — pins the seed↔resolver byte-equality (shape + order). Passing. Touched-file typecheck clean (pre-existing chat.controller Prisma-generation artifacts unrelated).

⚠️ Not browser-verified — the seed/badge click-path should be confirmed on a PR preview (badge shows seeded count on first paint; increments on a new message; survives reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)