### PR TITLE
perf(api): SSR-seed chat.getUserSettings to cut ~19 req/s off api-primary

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -55,6 +55,8 @@ import { IsClientProvider } from '~/providers/IsClientProvider';
 // import { StripeSetupSuccessProvider } from '~/providers/StripeProvider';
 import { ThemeProvider } from '~/providers/ThemeProvider';
 import type { UserContentSettings } from '~/server/schema/user.schema';
+import type { UserSettingsChat } from '~/server/schema/chat.schema';
+import { resolveChatSettings } from '~/server/schema/chat.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { TosMeta } from '~/server/services/content.service';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
@@ -109,6 +111,11 @@ type CustomAppProps = {
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
   liveNow: boolean;
+  // SSR-seeded `chat.getUserSettings` (logged-in only) — the per-user chat
+  // settings (mute sounds / bad-word filter / acknowledged). Derived from the
+  // `settings.chat` field already fetched for the bootstrap; no extra I/O. See
+  // AppProvider seed.
+  chatSettings?: UserSettingsChat;
   canIndex: boolean;
   hasAuthCookie: boolean;
   region: RegionInfo;
@@ -137,6 +144,7 @@ function MyApp(props: CustomAppProps) {
       settings,
       browsingSettingsAddons,
       liveNow = false,
+      chatSettings,
       region,
       domain,
       host,
@@ -190,6 +198,7 @@ function MyApp(props: CustomAppProps) {
       announcements={announcements}
       following={following}
       liveNow={liveNow}
+      chatSettings={chatSettings}
       region={region}
       domain={domain}
       host={host}
@@ -498,6 +507,23 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   let userFeatureFlags: FeatureAccess | undefined;
   if (session?.user && settings) {
     userFeatureFlags = computeUserFeatureFlagsOverlay(settings.features, flags);
+  }
+
+  // SSR-seed `chat.getUserSettings` (logged-in only) so the chat widget reads a
+  // primed cache and never fires the query on bootstrap (~19 req/s off
+  // api-primary). Fully DERIVED from the `settings.chat` field already fetched
+  // above for the bootstrap — NO extra I/O. The chat settings are static per
+  // user (only the user's own `setUserSettings` changes them, which patches the
+  // cache via optimistic `setData`), so SSR-seeding is exact.
+  //
+  // Byte-equality (#2471): the `chat.getUserSettings` resolver returns
+  // `settings.chat` and substitutes the SAME default object when absent — mirror
+  // it here so the seed matches the resolver output exactly. Seed only when a
+  // settings snapshot is present (the degraded/anon path leaves it undefined and
+  // the client query self-heals).
+  let chatSettings: UserSettingsChat | undefined;
+  if (session?.user && settings) {
+    chatSettings = resolveChatSettings(settings.chat);
   }
 
   if (session) {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 import type { UserContentSettings } from '~/server/schema/user.schema';
+import type { UserSettingsChat } from '~/server/schema/chat.schema';
 import type { TosMeta } from '~/server/services/content.service';
 import type { RegionInfo } from '~/server/utils/region-blocking';
 import type { VerifiedBot } from '~/server/utils/bot-detection/verify-bot';
@@ -30,6 +31,12 @@ type AppProviderProps = {
   // `undefined` key) so it never fires on bootstrap. Public procedure → seeded
   // for everyone, no auth gate.
   liveNow: boolean;
+  // SSR-computed `chat.getUserSettings` (logged-in only) — the per-user chat
+  // settings (mute sounds / bad-word filter / acknowledged). Seeds the ambient
+  // query (fixed `undefined` key) so the chat widget never fires it on
+  // bootstrap. Static per user (only the user's own `setUserSettings` mutates
+  // it, which patches the cache). Absent for anon / fail-open path.
+  chatSettings?: UserSettingsChat;
   seed: number;
   canIndex: boolean;
   region: RegionInfo;
@@ -85,6 +92,7 @@ export function AppProvider({
   announcements,
   following,
   liveNow,
+  chatSettings,
   domain,
   host,
   serverDomains,
@@ -119,6 +127,20 @@ export function AppProvider({
   trpc.system.getLiveNow.useQuery(undefined, {
     initialData: liveNow,
     staleTime: 1000 * 60 * 5,
+  });
+  // Seed `chat.getUserSettings` (per-user chat settings) from the SSR snapshot
+  // so the chat widget reads a primed cache and never fires the query on
+  // bootstrap (~19 req/s off api-primary). Shares the fixed `undefined` query
+  // key with `ChatButton`/`ExistingChat`'s `trpc.chat.getUserSettings.useQuery`.
+  // Settings are static per user — only the user's own `setUserSettings`
+  // mutation changes them, and it patches the cache via `setData` — so the
+  // global `staleTime: Infinity` default is correct (no external churn to poll
+  // for). `enabled: !!chatSettings` skips the seed (and any self-heal fetch)
+  // only when there's no snapshot: anon never fires this protected query, and a
+  // failed/degraded authed snapshot falls back to the widget's own live fetch.
+  trpc.chat.getUserSettings.useQuery(undefined, {
+    initialData: chatSettings,
+    enabled: !!chatSettings,
   });
   // Populate the module-level server domain map so `syncAccount(url)` can
   // resolve hosts to colors without pulling from React context.

--- a/src/server/controllers/chat.controller.ts
+++ b/src/server/controllers/chat.controller.ts
@@ -18,6 +18,7 @@ import type {
   UpdateMessageInput,
   UserSettingsChat,
 } from '~/server/schema/chat.schema';
+import { resolveChatSettings } from '~/server/schema/chat.schema';
 import { latestChat, singleChatSelect } from '~/server/selectors/chat.selector';
 import { profileImageSelect } from '~/server/selectors/image.selector';
 import { createMessage, maxUsersPerChat, upsertChat } from '~/server/services/chat.service';
@@ -39,10 +40,10 @@ import type { ChatCreateChat } from '~/types/router';
 export const getUserSettingsHandler = async ({ ctx }: { ctx: ProtectedContext }) => {
   try {
     const { id: userId } = ctx.user;
-    const { chat = { muteSounds: false, replaceBadWords: false, acknowledged: false } } =
-      await getUserSettings(userId);
-
-    return chat;
+    const { chat } = await getUserSettings(userId);
+    // Shared resolve helper guarantees the SSR seed (_app) and this resolver
+    // produce byte-identical output when `chat` is absent (#2471).
+    return resolveChatSettings(chat);
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     else throw throwDbError(error);

--- a/src/server/schema/__tests__/chat-settings-seed.test.ts
+++ b/src/server/schema/__tests__/chat-settings-seed.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CHAT_SETTINGS,
+  resolveChatSettings,
+} from '~/server/schema/chat.schema';
+
+// `resolveChatSettings` is the SHARED source used by BOTH the
+// `chat.getUserSettings` tRPC resolver AND the `_app` SSR bootstrap seed. The
+// seed primes the client query cache with this value; if it ever drifted from
+// what the resolver returns, the primed cache would mismatch and React Query
+// would fire the bootstrap refetch the seed exists to cut (#2471). These tests
+// pin that byte-equality contract.
+describe('resolveChatSettings (chat.getUserSettings SSR-seed byte-equality)', () => {
+  it('returns the stored chat settings verbatim when present', () => {
+    const stored = { muteSounds: true, replaceBadWords: false, acknowledged: true };
+    // Identity: a present value passes through unchanged (resolver returns the
+    // same object), so seed and resolver agree for any stored shape.
+    expect(resolveChatSettings(stored)).toEqual(stored);
+    expect(resolveChatSettings(stored)).toBe(stored);
+  });
+
+  it('substitutes the documented default when chat settings are absent', () => {
+    // This is the exact object the OLD inline resolver default produced:
+    //   { muteSounds: false, replaceBadWords: false, acknowledged: false }
+    // Both the resolver and the SSR seed now route through this helper, so the
+    // anon/no-settings path is identical on both sides.
+    expect(resolveChatSettings(undefined)).toEqual({
+      muteSounds: false,
+      replaceBadWords: false,
+      acknowledged: false,
+    });
+    expect(resolveChatSettings(undefined)).toBe(DEFAULT_CHAT_SETTINGS);
+  });
+
+  it('treats a partial stored object as-is (does not backfill missing keys)', () => {
+    // Matches the resolver: a stored `{ muteSounds: true }` is returned as-is
+    // (the schema fields are all optional). The seed must do the same.
+    const partial = { muteSounds: true };
+    expect(resolveChatSettings(partial)).toEqual({ muteSounds: true });
+  });
+});

--- a/src/server/schema/chat.schema.ts
+++ b/src/server/schema/chat.schema.ts
@@ -75,3 +75,22 @@ export const userSettingsChat = z.object({
   acknowledged: z.boolean().optional(),
   replaceBadWords: z.boolean().optional(),
 });
+
+/**
+ * Default chat settings used when a user has none stored. Shared by the
+ * `chat.getUserSettings` resolver AND the `_app` SSR bootstrap seed so the
+ * seeded `initialData` is byte-identical to the resolver output (#2471 gotcha)
+ * — a drift here would mismatch the primed cache and force the bootstrap
+ * refetch the seed exists to cut. Leaf module (zod-only) so both the server
+ * resolver and the client-bundled `_app` graph can import it safely.
+ */
+export const DEFAULT_CHAT_SETTINGS: UserSettingsChat = {
+  muteSounds: false,
+  replaceBadWords: false,
+  acknowledged: false,
+};
+
+/** Resolve a user's chat settings, substituting the shared default when absent. */
+export function resolveChatSettings(chat: UserSettingsChat | undefined): UserSettingsChat {
+  return chat ?? DEFAULT_CHAT_SETTINGS;
+}


### PR DESCRIPTION
## What

SSR-seed the `chat.getUserSettings` tRPC query so the chat widget never fires it on logged-in bootstrap. **Tier-1 #5** in the 2026-06-21 api-primary tRPC cost analysis (~19 req/s). Mirrors `system.getLiveNow` (#2683).

## Why seed (and zero extra I/O)

The chat settings (mute sounds / bad-word filter / acknowledged) are **static per user** and are already the `settings.chat` field of the `/api/user/settings` payload `_app` fetches for the bootstrap. So the seed is **derived from data already on the render path** (like `userFeatureFlags`/`tosMeta`) — no new fetch. Only the user's own `setUserSettings` mutates it, and that patches the cache via `setData`.

## How

- Add a shared `DEFAULT_CHAT_SETTINGS` + `resolveChatSettings(chat)` helper in the leaf `chat.schema` module, used by **both** the resolver and the seed → byte-identical output including the no-settings default (#2471).
- Seed via `AppProvider` `initialData` on the fixed `undefined` key.
- **Fail-open**: degraded/anon settings snapshot → seed undefined → the widget's own query self-heals.

## Tests

`src/server/schema/__tests__/chat-settings-seed.test.ts` (3 tests) — pins `resolveChatSettings` byte-equality (present passthrough, absent→default, partial as-is). Passing. Touched-file typecheck clean.

⚠️ Not browser-verified — confirm on a PR preview that the mute-sound setting still applies on a message arriving before chat is opened (the `ChatSignals` `getData()` read of `muteSounds`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)