### PR TITLE
perf(api): SSR-seed signals.getToken to cut ~10 req/s off api-primary

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -390,6 +390,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     tosMeta?: TosMeta;
     announcements?: AnnouncementsSeed;
     following?: number[];
+    signalsToken?: GetSignalsAccessTokenResponse;
     session: Session | null;
   };
   let settingsBootstrap: SettingsBootstrap;
@@ -442,10 +443,12 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta: undefined,
       announcements: undefined,
       following: undefined,
+      signalsToken: undefined,
       session: null,
     };
   }
-  const { settings, session, tosMeta, announcements, following } = settingsBootstrap;
+  const { settings, session, tosMeta, announcements, following, signalsToken } =
+    settingsBootstrap;
   // Pass these via the request so we can use them in SSR. Resolve the per-user
   // feature flags and the global (redis-cached, identical-for-all-users) browsing
   // setting addons in PARALLEL — neither depends on the other and both sit on
@@ -488,34 +491,26 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
 
   const domain = getRequestDomainColor(request);
 
-  // SSR-seed `signals.getToken` (logged-in only) so the signals SharedWorker
-  // reads a primed cache and never fires the token query on bootstrap (~10 req/s
-  // off api-primary). This query CANNOT be deferred to first interaction: the
-  // SignalR connection it powers must open on first paint to deliver the live
-  // buzz/generation/chat/notification updates the whole app depends on.
-  //
-  // Safe to put on the render path because `getAccessToken` is already fully
-  // fail-soft (PR #2366): any signals-service blip (Orleans crashloop / timeout
-  // / open circuit / bad body) returns `{}` rather than throwing, and the worker
-  // reads `data?.accessToken` as undefined and simply doesn't connect — the
-  // exact degrade behaviour that exists today. So a degraded signals service can
-  // never 500 a page render here. We additionally guard with try/catch (the
-  // `SIGNALS_ENDPOINT`-unconfigured PRECONDITION_FAILED throw, the only non-
-  // soft path) and fall back to undefined → the worker's own query self-heals on
-  // its `connection:state === 'closed'` invalidate.
-  let signalsToken: GetSignalsAccessTokenResponse | undefined;
-  if (session?.user) {
-    try {
-      const { getAccessToken } = await import('~/server/services/signals.service');
-      signalsToken = await getAccessToken({ id: session.user.id });
-    } catch (e) {
-      console.warn(
-        `[_app] signals.getToken bootstrap failed, rendering without seed: ${
-          e instanceof Error ? e.message : String(e)
-        }`
-      );
-    }
-  }
+  // NOTE: `signals.getToken` (the SignalR access token the signals SharedWorker
+  // uses to open the live connection, ~10 req/s off api-primary) is SSR-seeded
+  // too, but it is computed in the server-only `/api/user/settings` route above
+  // and delivered via that fetch (read off `settingsBootstrap` as
+  // `signalsToken`). It is deliberately NOT resolved here: `signals.service` is
+  // server-only and importing it into this graph — even via a dynamic
+  // `await import` — pulls Node built-ins (`tls`/`v8`/`node:perf_hooks`, via the
+  // `env/server` + `prom-client` chain in the `withSignals` wrapper) into
+  // `_app`'s client bundle and breaks `next build` (same class as the
+  // `content.service`/`announcement.service` carve-outs above and the
+  // `prom-client` note in the settings-fetch catch). It rides down through
+  // pageProps to AppProvider and seeds the ambient query there. This CANNOT be
+  // deferred to first interaction: the SignalR connection it powers must open on
+  // first paint to deliver the live buzz/generation/chat/notification updates
+  // the whole app depends on. `getAccessToken` is already fully fail-soft
+  // (PR #2366): a signals-service blip degrades to `{}` (the worker reads
+  // `data?.accessToken` as undefined and simply doesn't connect, exactly as
+  // today), and the route additionally `.catch`es the only non-soft path → an
+  // absent seed → the worker's own query self-heals. So a degraded signals
+  // service can never 500 a page render.
 
   // SSR-inject two ambient per-bootstrap trpc results that fire on every
   // logged-in page load but are fully derivable from data already fetched here.

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -55,6 +55,7 @@ import { IsClientProvider } from '~/providers/IsClientProvider';
 // import { StripeSetupSuccessProvider } from '~/providers/StripeProvider';
 import { ThemeProvider } from '~/providers/ThemeProvider';
 import type { UserContentSettings } from '~/server/schema/user.schema';
+import type { GetSignalsAccessTokenResponse } from '~/server/schema/signals.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { TosMeta } from '~/server/services/content.service';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
@@ -109,6 +110,11 @@ type CustomAppProps = {
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
   liveNow: boolean;
+  // SSR-seeded `signals.getToken` (logged-in only) — the SignalR access token
+  // the signals SharedWorker uses to open the live connection. Optional: absent
+  // for anon and on the fail-soft path (the worker reads `data?.accessToken` as
+  // undefined and simply doesn't connect, exactly as today). See AppProvider seed.
+  signalsToken?: GetSignalsAccessTokenResponse;
   canIndex: boolean;
   hasAuthCookie: boolean;
   region: RegionInfo;
@@ -137,6 +143,7 @@ function MyApp(props: CustomAppProps) {
       settings,
       browsingSettingsAddons,
       liveNow = false,
+      signalsToken,
       region,
       domain,
       host,
@@ -190,6 +197,7 @@ function MyApp(props: CustomAppProps) {
       announcements={announcements}
       following={following}
       liveNow={liveNow}
+      signalsToken={signalsToken}
       region={region}
       domain={domain}
       host={host}
@@ -480,6 +488,35 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
 
   const domain = getRequestDomainColor(request);
 
+  // SSR-seed `signals.getToken` (logged-in only) so the signals SharedWorker
+  // reads a primed cache and never fires the token query on bootstrap (~10 req/s
+  // off api-primary). This query CANNOT be deferred to first interaction: the
+  // SignalR connection it powers must open on first paint to deliver the live
+  // buzz/generation/chat/notification updates the whole app depends on.
+  //
+  // Safe to put on the render path because `getAccessToken` is already fully
+  // fail-soft (PR #2366): any signals-service blip (Orleans crashloop / timeout
+  // / open circuit / bad body) returns `{}` rather than throwing, and the worker
+  // reads `data?.accessToken` as undefined and simply doesn't connect — the
+  // exact degrade behaviour that exists today. So a degraded signals service can
+  // never 500 a page render here. We additionally guard with try/catch (the
+  // `SIGNALS_ENDPOINT`-unconfigured PRECONDITION_FAILED throw, the only non-
+  // soft path) and fall back to undefined → the worker's own query self-heals on
+  // its `connection:state === 'closed'` invalidate.
+  let signalsToken: GetSignalsAccessTokenResponse | undefined;
+  if (session?.user) {
+    try {
+      const { getAccessToken } = await import('~/server/services/signals.service');
+      signalsToken = await getAccessToken({ id: session.user.id });
+    } catch (e) {
+      console.warn(
+        `[_app] signals.getToken bootstrap failed, rendering without seed: ${
+          e instanceof Error ? e.message : String(e)
+        }`
+      );
+    }
+  }
+
   // SSR-inject two ambient per-bootstrap trpc results that fire on every
   // logged-in page load but are fully derivable from data already fetched here.
   // Both client queries gate on a logged-in user, so only seed for sessions.
@@ -526,6 +563,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       settings,
       browsingSettingsAddons,
       liveNow,
+      signalsToken,
       flags,
       userFeatureFlags,
       tosMeta,

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -4,6 +4,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getTosMeta } from '~/server/services/content.service';
 import { getCurrentAnnouncements } from '~/server/services/announcement.service';
 import { getUserFollows } from '~/server/redis/caches';
+import { getAccessToken } from '~/server/services/signals.service';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 
 export default PublicEndpoint(
@@ -19,7 +20,7 @@ export default PublicEndpoint(
       // and drop the critical settings/session payload; tosMeta (static, no user
       // input) can still throw to the outer catch (preserving prior behaviour).
       const domainColor = getRequestDomainColor(req);
-      const [tosMeta, announcements, following] = await Promise.all([
+      const [tosMeta, announcements, following, signalsToken] = await Promise.all([
         // Resolve the static per-domain ToS metadata here (server-only API route)
         // so `_app` getInitialProps can deliver it WITHOUT importing
         // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
@@ -47,12 +48,30 @@ export default PublicEndpoint(
         session?.user
           ? getUserFollows(session.user.id).catch(() => undefined)
           : Promise.resolve(undefined),
+        // SSR-seed the ambient, auth-gated `signals.getToken` query (~10 req/s on
+        // api-primary; the SignalR access token the signals SharedWorker uses to
+        // open the live connection). Computed here — NOT in `_app`
+        // getInitialProps — because `signals.service` is server-only and importing
+        // it into `_app` (even via a dynamic `await import`) pulls Node built-ins
+        // (`tls`/`v8`/`node:perf_hooks`, via `env/server` + `prom-client` in the
+        // signals `withSignals` wrapper) into the client bundle and breaks
+        // `next build`. `getAccessToken` is the SAME fn the resolver runs, so the
+        // seed is byte-identical. It is already fully fail-soft (PR #2366): a
+        // signals-service blip returns a degraded `{}` rather than throwing, so it
+        // can never reject this Promise.all. We additionally `.catch(() =>
+        // undefined)` the only non-soft path (the `SIGNALS_ENDPOINT`-unconfigured
+        // PRECONDITION_FAILED throw); the worker then self-heals via its own query.
+        // Anon never fires this protected query, so seed authed-only.
+        session?.user
+          ? getAccessToken({ id: session.user.id }).catch(() => undefined)
+          : Promise.resolve(undefined),
       ]);
       res.status(200).json({
         settings,
         tosMeta,
         announcements,
         following,
+        signalsToken,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,
       });
     } catch (e) {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -8,6 +8,7 @@ import { setServerDomains } from '~/utils/sync-account';
 import { trpc } from '~/utils/trpc';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
 import { reviveAnnouncementsSeed } from '~/providers/announcements-seed';
+import type { GetSignalsAccessTokenResponse } from '~/server/schema/signals.schema';
 
 type AppProviderProps = {
   children: React.ReactNode;
@@ -30,6 +31,11 @@ type AppProviderProps = {
   // `undefined` key) so it never fires on bootstrap. Public procedure → seeded
   // for everyone, no auth gate.
   liveNow: boolean;
+  // SSR-computed `signals.getToken` (logged-in only) — the SignalR access token
+  // for the signals SharedWorker. Seeds the ambient query (fixed `undefined`
+  // key) so the worker reads a primed cache and never fires it on bootstrap.
+  // Absent for anon / fail-soft path (worker degrades to no-connection).
+  signalsToken?: GetSignalsAccessTokenResponse;
   seed: number;
   canIndex: boolean;
   region: RegionInfo;
@@ -85,6 +91,7 @@ export function AppProvider({
   announcements,
   following,
   liveNow,
+  signalsToken,
   domain,
   host,
   serverDomains,
@@ -119,6 +126,21 @@ export function AppProvider({
   trpc.system.getLiveNow.useQuery(undefined, {
     initialData: liveNow,
     staleTime: 1000 * 60 * 5,
+  });
+  // Seed `signals.getToken` (the SignalR access token) from the SSR snapshot so
+  // the signals SharedWorker reads a primed cache and never fires the query on
+  // bootstrap (~10 req/s off api-primary). Shares the fixed `undefined` query
+  // key with `useSignalsWorker`'s `trpc.signals.getToken.useQuery`. The worker
+  // re-invalidates this query on every `connection:state === 'closed'`
+  // transition (its token-renewal path), so the global `staleTime: Infinity`
+  // default is correct — the seed primes the FIRST connect and the reconnect
+  // path keeps the token fresh thereafter. `enabled: !!signalsToken?.accessToken`
+  // seeds ONLY when we hold a real token: anon (no session) and the fail-soft
+  // `{}` path (signals-service blip) both skip the seed and fall back to the
+  // worker's own query (which re-applies the same fail-soft degrade).
+  trpc.signals.getToken.useQuery(undefined, {
+    initialData: signalsToken,
+    enabled: !!signalsToken?.accessToken,
   });
   // Populate the module-level server domain map so `syncAccount(url)` can
   // resolve hosts to colors without pulling from React context.

--- a/src/server/services/__tests__/signals.service.test.ts
+++ b/src/server/services/__tests__/signals.service.test.ts
@@ -127,3 +127,44 @@ describe('signals.service getAccessToken', () => {
     expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 });
+
+// `_app` SSR-seeds `signals.getToken` by calling this SAME `getAccessToken`
+// function server-side, so the seeded `initialData` is byte-identical to the
+// tRPC resolver output by construction (the resolver also just calls it). These
+// tests pin the two shapes the SSR seed relies on:
+//  - a SUCCESS seed carries `accessToken` → AppProvider's `enabled:
+//    !!signalsToken?.accessToken` primes the worker query and suppresses the
+//    bootstrap fetch; the worker opens the connection from the seed.
+//  - a DEGRADED seed is `{}` (no `accessToken`) → the seed gate is false, the
+//    worker falls back to its own query (which re-degrades to `{}`), and
+//    `useSignalsWorker` reads `data?.accessToken` as undefined → no connection,
+//    exactly as today. No 500 reaches the SSR render path.
+describe('signals.service getAccessToken (signals.getToken SSR-seed shapes)', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    mockWithSignals.mockImplementation((fn: () => Promise<unknown>) => fn());
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('success seed exposes a truthy accessToken (primes the worker query)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ accessToken: 'tok_seed' }),
+    });
+    const seed = await getAccessToken({ id: 1 });
+    // The exact gate AppProvider uses to decide whether to seed.
+    expect(!!seed.accessToken).toBe(true);
+    expect(seed).toEqual({ accessToken: 'tok_seed' });
+  });
+
+  it('degraded seed is {} with no accessToken (worker self-heals, no connection)', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    const seed = await getAccessToken({ id: 1 });
+    expect(!!seed.accessToken).toBe(false);
+    expect(seed).toEqual({});
+  });
+});


### PR DESCRIPTION
## What

SSR-seed the `signals.getToken` tRPC query (the SignalR access token) so the signals SharedWorker never fires it on logged-in bootstrap. **Tier-1 #5** in the 2026-06-21 api-primary tRPC cost analysis (~10 req/s). Mirrors `system.getLiveNow` (#2683).

## Why seed, not defer

The token powers the **app-wide SignalR connection** (live buzz / generation / chat / notification updates), which must open on first paint — deferring to first interaction breaks live updates app-wide. Seeding is safe on the render path because `getAccessToken` is **already fully fail-soft** (#2366): any signals-service blip returns `{}` instead of throwing, and `useSignalsWorker` reads `data?.accessToken` as undefined → simply doesn't connect (the existing degrade). So a degraded signals service can never 500 the render.

## How

- The seed reuses the **same** `getAccessToken` fn the resolver calls → byte-identical output by construction.
- Seed via `AppProvider` `initialData`, gated `enabled: !!signalsToken?.accessToken` so only a real token primes the query; the fail-soft `{}` and anon paths fall back to the worker's own query (which re-applies the same degrade).
- The worker's reconnect path (`connection:state === 'closed'` → `invalidate()`) keeps the token fresh after first connect, so the seed only needs to cover the first connect.

## Tests

`src/server/services/__tests__/signals.service.test.ts` — 5 existing + 2 new seed-shape tests (success seed exposes a truthy token; degraded seed is `{}`). 7/7 passing. Touched-file typecheck clean.

⚠️ Not browser-verified — confirm on a PR preview that SignalR connects from the seed on first paint (buzz pill / live updates), and that a forced disconnect re-mints via the invalidate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)