### PR TITLE
perf(api): SSR-inject buzz.getUserMultipliers to cut ~27 req/s off api-primary

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -58,6 +58,7 @@ import type { UserContentSettings } from '~/server/schema/user.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { TosMeta } from '~/server/services/content.service';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
+import type { MultipliersSeed } from '~/providers/multipliers-seed';
 import type { BrowsingSettingsAddon } from '~/shared/constants/browsing-settings-addons';
 import type { ParsedCookies } from '~/shared/utils/cookies';
 import { parseCookies } from '~/shared/utils/cookies';
@@ -105,6 +106,7 @@ type CustomAppProps = {
   tosMeta?: TosMeta;
   announcements?: AnnouncementsSeed;
   following?: number[];
+  userMultipliers?: MultipliersSeed;
   seed: number;
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
@@ -131,6 +133,7 @@ function MyApp(props: CustomAppProps) {
       tosMeta,
       announcements,
       following,
+      userMultipliers,
       seed = Date.now(),
       canIndex,
       hasAuthCookie,
@@ -189,6 +192,7 @@ function MyApp(props: CustomAppProps) {
       tosMeta={tosMeta}
       announcements={announcements}
       following={following}
+      userMultipliers={userMultipliers}
       liveNow={liveNow}
       region={region}
       domain={domain}
@@ -382,6 +386,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     tosMeta?: TosMeta;
     announcements?: AnnouncementsSeed;
     following?: number[];
+    userMultipliers?: MultipliersSeed;
     session: Session | null;
   };
   let settingsBootstrap: SettingsBootstrap;
@@ -434,10 +439,12 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta: undefined,
       announcements: undefined,
       following: undefined,
+      userMultipliers: undefined,
       session: null,
     };
   }
-  const { settings, session, tosMeta, announcements, following } = settingsBootstrap;
+  const { settings, session, tosMeta, announcements, following, userMultipliers } =
+    settingsBootstrap;
   // Pass these via the request so we can use them in SSR. Resolve the per-user
   // feature flags and the global (redis-cached, identical-for-all-users) browsing
   // setting addons in PARALLEL — neither depends on the other and both sit on
@@ -531,6 +538,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta,
       announcements,
       following,
+      userMultipliers,
       seed: Date.now(),
       hasAuthCookie,
       region,

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -4,6 +4,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getTosMeta } from '~/server/services/content.service';
 import { getCurrentAnnouncements } from '~/server/services/announcement.service';
 import { getUserFollows } from '~/server/redis/caches';
+import { getMultipliersForUser } from '~/server/services/buzz.service';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 
 export default PublicEndpoint(
@@ -19,7 +20,7 @@ export default PublicEndpoint(
       // and drop the critical settings/session payload; tosMeta (static, no user
       // input) can still throw to the outer catch (preserving prior behaviour).
       const domainColor = getRequestDomainColor(req);
-      const [tosMeta, announcements, following] = await Promise.all([
+      const [tosMeta, announcements, following, userMultipliers] = await Promise.all([
         // Resolve the static per-domain ToS metadata here (server-only API route)
         // so `_app` getInitialProps can deliver it WITHOUT importing
         // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
@@ -47,12 +48,27 @@ export default PublicEndpoint(
         session?.user
           ? getUserFollows(session.user.id).catch(() => undefined)
           : Promise.resolve(undefined),
+        // SSR-seed the ambient, auth-gated `buzz.getUserMultipliers` query
+        // (~27 req/s on api-primary; header buzz multipliers, client gate
+        // `!!currentUser && features.buzz` — `buzz` is a public feature, so it is
+        // on for every logged-in user). Computed here — NOT in `_app`
+        // getInitialProps — because `buzz.service` is server-only and importing it
+        // into `_app` leaks Node built-ins (`node:fs` via the errorHandling import
+        // chain) into the client bundle and breaks the build. `getMultipliersForUser`
+        // is the same fn the resolver runs, so the seed is byte-identical. Anon
+        // never fires this query, so seed authed-only; on error fall back to
+        // undefined and let the client self-heal via its own live fetch. The
+        // nested active-event Dates are revived client-side in AppProvider.
+        session?.user
+          ? getMultipliersForUser(session.user.id).catch(() => undefined)
+          : Promise.resolve(undefined),
       ]);
       res.status(200).json({
         settings,
         tosMeta,
         announcements,
         following,
+        userMultipliers,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,
       });
     } catch (e) {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -8,6 +8,8 @@ import { setServerDomains } from '~/utils/sync-account';
 import { trpc } from '~/utils/trpc';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
 import { reviveAnnouncementsSeed } from '~/providers/announcements-seed';
+import type { MultipliersSeed } from '~/providers/multipliers-seed';
+import { reviveMultipliersSeed } from '~/providers/multipliers-seed';
 
 type AppProviderProps = {
   children: React.ReactNode;
@@ -25,6 +27,12 @@ type AppProviderProps = {
   // followed userIds. Seeds the query directly (fixed `undefined` key) so the
   // ambient follow/notify buttons never fire it on bootstrap.
   following?: number[];
+  // SSR-computed `buzz.getUserMultipliers` result (logged-in + buzz-on only) —
+  // the user's purchase/reward multipliers. Seeds the ambient `useUserMultipliers`
+  // query (fixed `undefined` key) so the header-bootstrap call never fires. The
+  // nested active-event Dates are revived from the JSON pageProps snapshot before
+  // seeding so the cache shape matches a live superjson refetch.
+  userMultipliers?: MultipliersSeed;
   // SSR-computed `system.getLiveNow` global boolean (a single redis.get,
   // identical for every user). Seeds the ambient `useIsLive` query (fixed
   // `undefined` key) so it never fires on bootstrap. Public procedure → seeded
@@ -84,6 +92,7 @@ export function AppProvider({
   tosMeta,
   announcements,
   following,
+  userMultipliers,
   liveNow,
   domain,
   host,
@@ -108,6 +117,24 @@ export function AppProvider({
   trpc.user.getFollowingUsers.useQuery(undefined, {
     initialData: following,
     enabled: !!following,
+  });
+  // Seed `buzz.getUserMultipliers` from the SSR snapshot so the ambient
+  // `useUserMultipliers` consumer reads a primed cache and never fires the
+  // header-bootstrap call (~27 req/s off api-primary). Shares the fixed
+  // `undefined` query key with that hook. NO `staleTime` override — it inherits
+  // the global `staleTime: Infinity`, which is EXACTLY how the live query behaves
+  // today (it has no staleTime either): fetch once on bootstrap, then rely on the
+  // cache. Multipliers only change on a subscription/event change, which already
+  // busts the server cache (`deleteMultipliersForUserCache`) and is reflected on
+  // the next refetch/navigation — so seeding does not make freshness any stickier
+  // than the current behavior. `enabled: !!userMultipliers` skips both the seed
+  // and any self-heal fetch only when there is no snapshot (anon, buzz-off, or a
+  // failed authed snapshot) — in which case the consumer's own gated query fires
+  // its live fetch. The nested active-event Dates are revived so the seeded cache
+  // shape matches a live superjson refetch.
+  trpc.buzz.getUserMultipliers.useQuery(undefined, {
+    initialData: reviveMultipliersSeed(userMultipliers),
+    enabled: !!userMultipliers,
   });
   // Seed the global `system.getLiveNow` boolean from the SSR snapshot so the
   // ambient `useIsLive` consumers (header logo, social links, social home

--- a/src/providers/__tests__/multipliers-seed.test.ts
+++ b/src/providers/__tests__/multipliers-seed.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { reviveMultipliersSeed } from '~/providers/multipliers-seed';
+
+// A realistic SSR-serialized multipliers payload with NO active bonus event —
+// the common case. All fields are numbers/booleans/null, so JSON and superjson
+// agree byte-for-byte and there is nothing to revive.
+const noEvent = {
+  userId: 42,
+  purchasesMultiplier: 1,
+  rewardsMultiplier: 1,
+  baseRewardsMultiplier: 1,
+  globalRewardsBonus: 1,
+  rewardsIneligible: false,
+  rewardsBonusEvent: null,
+};
+
+// With an active event, the nested `startsAt`/`endsAt` arrive as ISO strings via
+// Next pageProps (JSON.stringify) — a live superjson tRPC fetch revives them to
+// Date objects, so the seed must be revived to match that shape.
+const withEvent = {
+  userId: 42,
+  purchasesMultiplier: 1,
+  rewardsMultiplier: 2,
+  baseRewardsMultiplier: 1,
+  globalRewardsBonus: 2,
+  rewardsIneligible: false,
+  rewardsBonusEvent: {
+    id: 7,
+    name: 'Double Rewards',
+    description: 'twice the buzz',
+    articleId: 99,
+    bannerLabel: '2x',
+    multiplier: 20,
+    startsAt: '2026-06-02T00:00:00.000Z',
+    endsAt: '2026-06-10T00:00:00.000Z',
+  },
+};
+
+describe('reviveMultipliersSeed', () => {
+  it('returns undefined for an undefined seed (so the query self-heals via a live fetch)', () => {
+    expect(reviveMultipliersSeed(undefined)).toBeUndefined();
+  });
+
+  it('passes a no-active-event payload through untouched (rewardsBonusEvent null)', () => {
+    const revived = reviveMultipliersSeed(noEvent as never)!;
+    expect(revived).toEqual(noEvent);
+    expect(revived.rewardsBonusEvent).toBeNull();
+  });
+
+  it('revives the active-event ISO-string date fields into Date objects', () => {
+    const revived = reviveMultipliersSeed(withEvent as never)!;
+    const event = revived.rewardsBonusEvent!;
+    expect(event.startsAt).toBeInstanceOf(Date);
+    expect(event.endsAt).toBeInstanceOf(Date);
+    expect((event.startsAt as Date).toISOString()).toBe('2026-06-02T00:00:00.000Z');
+    expect((event.endsAt as Date).toISOString()).toBe('2026-06-10T00:00:00.000Z');
+  });
+
+  it('preserves null startsAt/endsAt as null (event with no bounded window)', () => {
+    const revived = reviveMultipliersSeed({
+      ...withEvent,
+      rewardsBonusEvent: { ...withEvent.rewardsBonusEvent, startsAt: null, endsAt: null },
+    } as never)!;
+    const event = revived.rewardsBonusEvent!;
+    expect(event.startsAt).toBeNull();
+    expect(event.endsAt).toBeNull();
+  });
+
+  it('passes the non-date event fields and top-level multipliers through untouched', () => {
+    const revived = reviveMultipliersSeed(withEvent as never)!;
+    expect(revived.userId).toBe(42);
+    expect(revived.rewardsMultiplier).toBe(2);
+    expect(revived.globalRewardsBonus).toBe(2);
+    expect(revived.rewardsIneligible).toBe(false);
+    const event = revived.rewardsBonusEvent!;
+    expect(event.id).toBe(7);
+    expect(event.name).toBe('Double Rewards');
+    expect(event.description).toBe('twice the buzz');
+    expect(event.articleId).toBe(99);
+    expect(event.bannerLabel).toBe('2x');
+    expect(event.multiplier).toBe(20);
+  });
+
+  it('is idempotent on values that already hold Date objects (a live refetch shape)', () => {
+    const live = {
+      ...withEvent,
+      rewardsBonusEvent: {
+        ...withEvent.rewardsBonusEvent,
+        startsAt: new Date('2026-06-02T00:00:00.000Z'),
+        endsAt: new Date('2026-06-10T00:00:00.000Z'),
+      },
+    };
+    const revived = reviveMultipliersSeed(live as never)!;
+    const event = revived.rewardsBonusEvent!;
+    expect(event.startsAt).toBeInstanceOf(Date);
+    expect((event.startsAt as Date).toISOString()).toBe('2026-06-02T00:00:00.000Z');
+    expect((event.endsAt as Date).toISOString()).toBe('2026-06-10T00:00:00.000Z');
+  });
+});

--- a/src/providers/multipliers-seed.ts
+++ b/src/providers/multipliers-seed.ts
@@ -1,0 +1,46 @@
+import type { RouterOutput } from '~/types/router';
+
+// The tRPC output shape of `buzz.getUserMultipliers` — what the SSR seed and the
+// query's `data`/`initialData` are typed as.
+export type MultipliersSeed = RouterOutput['buzz']['getUserMultipliers'];
+
+const toDateOrNull = (v: unknown): Date | null =>
+  v == null ? null : v instanceof Date ? v : new Date(v as string | number);
+
+/**
+ * Revive the Date fields of an SSR-injected `buzz.getUserMultipliers` seed.
+ *
+ * The seed travels to the client via Next pageProps (plain JSON), which
+ * stringifies the nested `rewardsBonusEvent.startsAt`/`.endsAt` (`DateTime?`) to
+ * ISO strings — but a live superjson tRPC fetch revives them to real `Date`
+ * objects. We revive the seed so the React Query cache holds the SAME shape
+ * whether it was SSR-seeded or later refetched, avoiding a silent
+ * seed-vs-refetch divergence.
+ *
+ * Everything else in the payload is numbers/booleans/null (`purchasesMultiplier`,
+ * `rewardsMultiplier`, `baseRewardsMultiplier`, `globalRewardsBonus`,
+ * `rewardsIneligible`, `userId`, and the event's `id`/`name`/`description`/
+ * `articleId`/`bannerLabel`/`multiplier`) — those serialize identically under
+ * JSON and superjson, so they need no revival. `rewardsBonusEvent` itself is
+ * `null` in the common case (no active bonus event); only the active-event path
+ * carries the Dates. `startsAt`/`endsAt` are themselves nullable (`DateTime?`),
+ * so a present-but-null value must stay `null` (not become `undefined`).
+ *
+ * Pure + dependency-light so it can be unit-tested without pulling the
+ * provider's React/trpc graph (mirrors `reviveAnnouncementsSeed`).
+ */
+export function reviveMultipliersSeed(
+  multipliers?: MultipliersSeed
+): MultipliersSeed | undefined {
+  if (!multipliers) return undefined;
+  const event = multipliers.rewardsBonusEvent;
+  if (!event) return multipliers;
+  return {
+    ...multipliers,
+    rewardsBonusEvent: {
+      ...event,
+      startsAt: toDateOrNull(event.startsAt),
+      endsAt: toDateOrNull(event.endsAt),
+    },
+  };
+}

--- a/tests/preview-ssr-inject.spec.ts
+++ b/tests/preview-ssr-inject.spec.ts
@@ -44,6 +44,7 @@ const TOS_PROCEDURE = 'content.checkTosUpdate';
 const ANNOUNCEMENTS_PROCEDURE = 'announcement.getAnnouncements';
 const FOLLOWING_PROCEDURE = 'user.getFollowingUsers';
 const LIVE_NOW_PROCEDURE = 'system.getLiveNow';
+const USER_MULTIPLIERS_PROCEDURE = 'buzz.getUserMultipliers';
 
 // A core page a gate-passing user lands on directly (no /login bounce). Both
 // procedures fire on every logged-in bootstrap regardless of which page, so
@@ -468,6 +469,77 @@ test.describe('SSR-injected getLiveNow (anonymous)', () => {
         '\n'
       )}`
     ).toHaveLength(0);
+  });
+});
+
+/**
+ * Regression guard for the SSR-inject of `buzz.getUserMultipliers` (~27/s on
+ * api-primary). AUTH-GATED: it is a `protectedProcedure` (buzz flag), and the
+ * client `useUserMultipliers` hook fires only when `!!currentUser && features.buzz`
+ * — so it never fires anonymously (no anon block, like getFeatureFlags/following).
+ * SSR-computed in `_app.getInitialProps` for a logged-in, buzz-enabled user
+ * (fail-open: dropped on error) and seeded in AppProvider on the fixed `undefined`
+ * key.
+ *
+ * BYTE-EQUALITY: the payload is mostly numbers/booleans/null; its only Date
+ * fields are the nested `rewardsBonusEvent.startsAt`/`.endsAt` (and only when a
+ * bonus event is active — `null` otherwise). The seed travels in pageProps as
+ * JSON (Dates → ISO strings) and `fetchTrpcQueryJson` returns the LIVE fetch's
+ * `result.data.json` (also pre-superjson-revival JSON, Dates → ISO strings), so
+ * both sides are ISO strings and `toEqual` compares them directly — no revival
+ * needed in the test (revival happens at runtime in AppProvider via
+ * `reviveMultipliersSeed`, unit-tested separately). The seed can legitimately
+ * have `rewardsBonusEvent: null` (no active event); that is still a valid,
+ * present seed and the byte-equality holds.
+ */
+test.describe('SSR-injected getUserMultipliers (logged-in)', () => {
+  test.use({ storageState: storageStatePath('mod') });
+
+  test('getUserMultipliers is seeded into __NEXT_DATA__ and not fetched on bootstrap', async ({
+    page,
+  }) => {
+    const trpcUrls = await collectTrpcRequests(page, AUTHED_LANDING);
+
+    const seed = await readPageProp(page, 'userMultipliers');
+    expect(seed.present, 'userMultipliers present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(
+      typeof seed.value === 'object' && seed.value !== null,
+      'userMultipliers seed is an object'
+    ).toBe(true);
+    // The multiplier fields are always present numbers (default 1).
+    const m = seed.value as Record<string, unknown>;
+    expect(typeof m.rewardsMultiplier, 'rewardsMultiplier is a number').toBe('number');
+    expect(typeof m.purchasesMultiplier, 'purchasesMultiplier is a number').toBe('number');
+
+    const multiplierRequests = trpcUrls.filter((u) => u.includes(USER_MULTIPLIERS_PROCEDURE));
+    expect(
+      multiplierRequests,
+      `no ${USER_MULTIPLIERS_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${multiplierRequests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
+  });
+
+  test('SSR seed byte-equals a live fetch', async ({ page }) => {
+    await page.goto(AUTHED_LANDING, { waitUntil: 'domcontentloaded' });
+
+    const seed = await readPageProp(page, 'userMultipliers');
+    expect(seed.present, 'userMultipliers seed present in __NEXT_DATA__').toBe(true);
+
+    const live = await fetchTrpcQueryJson(page, USER_MULTIPLIERS_PROCEDURE);
+    expect(
+      seed.value,
+      'buzz.getUserMultipliers SSR seed must byte-equal a live resolver fetch'
+    ).toEqual(live);
+
+    // Surface whether a bonus event was active during the run, so a green run
+    // that exercised the Date-carrying branch is distinguishable from the common
+    // null-event branch.
+    const event = (seed.value as { rewardsBonusEvent?: unknown }).rewardsBonusEvent;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[ssr-inject] userMultipliers rewardsBonusEvent active: ${event != null ? 'yes' : 'no'}`
+    );
   });
 });
 


### PR DESCRIPTION
## What

SSR-inject `buzz.getUserMultipliers` (~27 req/s on api-primary) so the ambient `useUserMultipliers` hook (header buzz multipliers) reads a primed React-Query cache and never fires the bootstrap request. Mirrors the proven, just-merged #2683 (`system.getLiveNow`) and #2471 (`getFeatureFlags`/`tosMeta`) SSR-seed pattern. Tier-1 #4 from `datapacket-talos claudedocs/api-primary-trpc-cost-analysis-2026-06-21.md`.

The CPU lever is the **per-request fixed middleware+context+superjson cost** the non-batched tRPC client pays on every ambient call — removing the bootstrap request removes one full cycle, regardless of the resolver being I/O-bound.

## Mechanism — seed (not defer)

- Computed in the **server-only `/api/user/settings` route** (which `_app.getInitialProps` already fetches), **NOT** by importing `buzz.service` into `_app`. A local `next build` proved that importing the service into `_app` (even dynamically) leaks its transitive Node built-ins (`node:fs` via the `errorHandling` chain) into the **client bundle** and breaks the build. The route is server-only, so `getMultipliersForUser` (the same fn the resolver runs → byte-identical payload) stays off the client graph — exactly how the existing `following`/`announcements`/`tosMeta` seeds in that route avoid the same leak.
- Rides down `settingsBootstrap` → pageProps → AppProvider, seeded as `initialData` on the fixed `undefined` query key.
- **Auth-gated**: seeded only for a logged-in session (`buzz` is a public feature, so the client gate `!!currentUser && features.buzz` reduces to logged-in) → a seed is present iff the client would otherwise fetch.

## First-paint freshness

NO `staleTime` override — the seed inherits the global `staleTime: Infinity`, **identical to how the live query behaves today** (fetch once on bootstrap, then rely on the cache). Multipliers only change on a subscription/event change, which busts the server cache and is picked up on the next navigation. So freshness is **no stickier than before**.

## Byte-equality handling (the #2471/#2683 gotcha)

The payload is numbers/booleans/null **except** the active bonus event's nullable `startsAt`/`endsAt` Dates. The SSR seed crosses the wire as JSON (Dates → ISO strings); a live superjson fetch revives them to Date objects. `reviveMultipliersSeed` (a pure fn mirroring `reviveAnnouncementsSeed`) revives the seed before it primes the cache so the cached shape matches a refetch. `rewardsBonusEvent` is `null` in the common case (no active event) → byte-safe with no revival.

## Tests

- **Unit** (`src/providers/__tests__/multipliers-seed.test.ts`, 6 tests, all passing locally): null-event passthrough, ISO→Date revival, null-startsAt/endsAt preservation, non-date passthrough, idempotency on Date objects, undefined→undefined.
- **e2e** (extends `tests/preview-ssr-inject.spec.ts`): (a) seed present in `__NEXT_DATA__`, (b) no `buzz.getUserMultipliers` request fires on bootstrap, (c) seed byte-equals a live authed fetch (fetched from within the page via same-origin `fetch`, at the pre-revival JSON level so ISO strings compare on both sides). e2e runs only on the preview pipeline.

## Build

Full local `next build` is not completable on this repo (dirty tsc baseline + a Turbopack/Prisma page-data quirk on an unrelated `/apps/run` route). With typecheck skipped the bundle **`✓ Compiled successfully`** — confirming the client-bundle leak is resolved (an earlier build that imported the service into `_app` failed explicitly with `node:fs` in the Browser bundle). Preview CI is the final gate. `tsc --noEmit` shows zero new errors in the changed files.

## Caveats

- **First-paint balance/multipliers**: seeded value can be a snapshot slightly behind a concurrent change, but it self-corrects exactly as today (no staleTime change). Not browser-verified locally — preview is the gate.
- e2e byte-equality exercises the null-event branch unless a bonus event is active during the run (logged in the test output).

Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)