### PR TITLE
perf(api): SSR-inject buzz.getBuzzAccount to cut ~35 req/s off api-primary

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -58,6 +58,7 @@ import type { UserContentSettings } from '~/server/schema/user.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { TosMeta } from '~/server/services/content.service';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
+import type { RouterOutput } from '~/types/router';
 import type { BrowsingSettingsAddon } from '~/shared/constants/browsing-settings-addons';
 import type { ParsedCookies } from '~/shared/utils/cookies';
 import { parseCookies } from '~/shared/utils/cookies';
@@ -105,6 +106,7 @@ type CustomAppProps = {
   tosMeta?: TosMeta;
   announcements?: AnnouncementsSeed;
   following?: number[];
+  buzzAccount?: RouterOutput['buzz']['getBuzzAccount'];
   seed: number;
   settings: UserContentSettings;
   browsingSettingsAddons: BrowsingSettingsAddon[];
@@ -131,6 +133,7 @@ function MyApp(props: CustomAppProps) {
       tosMeta,
       announcements,
       following,
+      buzzAccount,
       seed = Date.now(),
       canIndex,
       hasAuthCookie,
@@ -189,6 +192,7 @@ function MyApp(props: CustomAppProps) {
       tosMeta={tosMeta}
       announcements={announcements}
       following={following}
+      buzzAccount={buzzAccount}
       liveNow={liveNow}
       region={region}
       domain={domain}
@@ -382,6 +386,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     tosMeta?: TosMeta;
     announcements?: AnnouncementsSeed;
     following?: number[];
+    buzzAccount?: RouterOutput['buzz']['getBuzzAccount'];
     session: Session | null;
   };
   let settingsBootstrap: SettingsBootstrap;
@@ -434,10 +439,11 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta: undefined,
       announcements: undefined,
       following: undefined,
+      buzzAccount: undefined,
       session: null,
     };
   }
-  const { settings, session, tosMeta, announcements, following } = settingsBootstrap;
+  const { settings, session, tosMeta, announcements, following, buzzAccount } = settingsBootstrap;
   // Pass these via the request so we can use them in SSR. Resolve the per-user
   // feature flags and the global (redis-cached, identical-for-all-users) browsing
   // setting addons in PARALLEL — neither depends on the other and both sit on
@@ -531,6 +537,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       tosMeta,
       announcements,
       following,
+      buzzAccount,
       seed: Date.now(),
       hasAuthCookie,
       region,

--- a/src/pages/api/user/settings.ts
+++ b/src/pages/api/user/settings.ts
@@ -4,6 +4,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getTosMeta } from '~/server/services/content.service';
 import { getCurrentAnnouncements } from '~/server/services/announcement.service';
 import { getUserFollows } from '~/server/redis/caches';
+import { getUserBuzzAccounts } from '~/server/services/buzz.service';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 
 export default PublicEndpoint(
@@ -19,7 +20,7 @@ export default PublicEndpoint(
       // and drop the critical settings/session payload; tosMeta (static, no user
       // input) can still throw to the outer catch (preserving prior behaviour).
       const domainColor = getRequestDomainColor(req);
-      const [tosMeta, announcements, following] = await Promise.all([
+      const [tosMeta, announcements, following, buzzAccount] = await Promise.all([
         // Resolve the static per-domain ToS metadata here (server-only API route)
         // so `_app` getInitialProps can deliver it WITHOUT importing
         // `content.service` — which pulls `fs/promises` into `_app`'s client-bundled
@@ -47,12 +48,26 @@ export default PublicEndpoint(
         session?.user
           ? getUserFollows(session.user.id).catch(() => undefined)
           : Promise.resolve(undefined),
+        // SSR-seed the ambient, auth-gated `buzz.getBuzzAccount` query (~35 req/s
+        // on api-primary; header buzz pill, `enabled: !!currentUser`). Computed
+        // here — NOT in `_app` getInitialProps — because `buzz.service` is
+        // server-only and importing it into `_app` leaks Node built-ins
+        // (`node:fs` via the errorHandling import chain) into the client bundle
+        // and breaks the build. `getUserBuzzAccounts` is the same fn the resolver
+        // runs, so the seed is byte-identical (a flat `Record<BuzzSpendType,
+        // number>`). Anon never fires this query, so seed authed-only; on a
+        // buzz-service error fall back to undefined and let the client self-heal
+        // via its own live fetch.
+        session?.user
+          ? getUserBuzzAccounts({ userId: session.user.id }).catch(() => undefined)
+          : Promise.resolve(undefined),
       ]);
       res.status(200).json({
         settings,
         tosMeta,
         announcements,
         following,
+        buzzAccount,
         session: session?.user && Object.keys(session.user).length > 0 ? session : null,
       });
     } catch (e) {

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -8,6 +8,7 @@ import { setServerDomains } from '~/utils/sync-account';
 import { trpc } from '~/utils/trpc';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
 import { reviveAnnouncementsSeed } from '~/providers/announcements-seed';
+import type { RouterOutput } from '~/types/router';
 
 type AppProviderProps = {
   children: React.ReactNode;
@@ -25,6 +26,12 @@ type AppProviderProps = {
   // followed userIds. Seeds the query directly (fixed `undefined` key) so the
   // ambient follow/notify buttons never fire it on bootstrap.
   following?: number[];
+  // SSR-computed `buzz.getBuzzAccount` result (logged-in only) — the user's buzz
+  // account balances (a flat `Record<BuzzSpendType, number>`). Seeds the ambient
+  // `useQueryBuzz` query (fixed `undefined` key) so the header buzz pill never
+  // fires the bootstrap call. All-numeric payload → no Date/undefined revival
+  // needed (JSON and superjson agree).
+  buzzAccount?: RouterOutput['buzz']['getBuzzAccount'];
   // SSR-computed `system.getLiveNow` global boolean (a single redis.get,
   // identical for every user). Seeds the ambient `useIsLive` query (fixed
   // `undefined` key) so it never fires on bootstrap. Public procedure → seeded
@@ -84,6 +91,7 @@ export function AppProvider({
   tosMeta,
   announcements,
   following,
+  buzzAccount,
   liveNow,
   domain,
   host,
@@ -108,6 +116,25 @@ export function AppProvider({
   trpc.user.getFollowingUsers.useQuery(undefined, {
     initialData: following,
     enabled: !!following,
+  });
+  // Seed `buzz.getBuzzAccount` from the SSR snapshot so the ambient
+  // `useQueryBuzz` consumer (header buzz pill) reads a primed cache and never
+  // fires the bootstrap call (~35 req/s off api-primary). Shares the fixed
+  // `undefined` query key with that hook. NO `staleTime` override — it inherits
+  // the global `staleTime: Infinity`, which is EXACTLY how the live query behaves
+  // today (it sets no staleTime): the balance is kept current NOT by polling but
+  // by the `BuzzUpdate` SignalR push (`useBuzzSignalUpdate` patches the cache via
+  // `setData`) plus an explicit `invalidate()` after a purchase. So a stale
+  // first-paint balance self-corrects on the next balance-changing signal /
+  // navigation, identical to the pre-seed behavior — seeding does not make it any
+  // stickier. `enabled: !!buzzAccount` skips both the seed and any self-heal fetch
+  // only when there is no snapshot (anon, or a failed/timed-out buzz-service
+  // snapshot) — in which case the consumer's own `!!currentUser`-gated query fires
+  // its live fetch. The payload is a flat all-number record, so the seeded cache
+  // shape already matches a live superjson refetch (no revival needed).
+  trpc.buzz.getBuzzAccount.useQuery(undefined, {
+    initialData: buzzAccount,
+    enabled: !!buzzAccount,
   });
   // Seed the global `system.getLiveNow` boolean from the SSR snapshot so the
   // ambient `useIsLive` consumers (header logo, social links, social home

--- a/tests/preview-ssr-inject.spec.ts
+++ b/tests/preview-ssr-inject.spec.ts
@@ -44,6 +44,7 @@ const TOS_PROCEDURE = 'content.checkTosUpdate';
 const ANNOUNCEMENTS_PROCEDURE = 'announcement.getAnnouncements';
 const FOLLOWING_PROCEDURE = 'user.getFollowingUsers';
 const LIVE_NOW_PROCEDURE = 'system.getLiveNow';
+const BUZZ_ACCOUNT_PROCEDURE = 'buzz.getBuzzAccount';
 
 // A core page a gate-passing user lands on directly (no /login bounce). Both
 // procedures fire on every logged-in bootstrap regardless of which page, so
@@ -468,6 +469,84 @@ test.describe('SSR-injected getLiveNow (anonymous)', () => {
         '\n'
       )}`
     ).toHaveLength(0);
+  });
+});
+
+/**
+ * Regression guard for the SSR-inject of `buzz.getBuzzAccount` (~35/s on
+ * api-primary). AUTH-GATED: it is a `protectedProcedure` (buzz flag), and the
+ * client `useQueryBuzz` hook fires only when `!!currentUser` — so it never fires
+ * anonymously (no anon block, like getFeatureFlags/following). SSR-computed in
+ * `_app.getInitialProps` for a logged-in user (fail-open: dropped on error,
+ * incl. a buzz-service outage) and seeded in AppProvider on the fixed `undefined`
+ * key.
+ *
+ * BYTE-EQUALITY: the payload is a flat `Record<BuzzSpendType, number>` — ALL
+ * numbers, no Date/undefined fields. So the seed (pageProps JSON) and the live
+ * fetch's `result.data.json` (pre-superjson-revival JSON) are identical maps of
+ * numbers, and `toEqual` compares them directly with no revival anywhere (this is
+ * why getBuzzAccount needs no revive helper, unlike getUserMultipliers). The
+ * balance can change between the SSR snapshot and the live fetch (live value), so
+ * the assertion tolerates that: it asserts the seed and live share the SAME KEY
+ * SET and all-numeric values (the serialization contract), not identical balances.
+ */
+test.describe('SSR-injected getBuzzAccount (logged-in)', () => {
+  test.use({ storageState: storageStatePath('mod') });
+
+  test('getBuzzAccount is seeded into __NEXT_DATA__ and not fetched on bootstrap', async ({
+    page,
+  }) => {
+    const trpcUrls = await collectTrpcRequests(page, AUTHED_LANDING);
+
+    const seed = await readPageProp(page, 'buzzAccount');
+    expect(seed.present, 'buzzAccount present in __NEXT_DATA__ pageProps').toBe(true);
+    expect(
+      typeof seed.value === 'object' && seed.value !== null,
+      'buzzAccount seed is an object'
+    ).toBe(true);
+    // Every value in the balances record is a number.
+    for (const [k, v] of Object.entries(seed.value as Record<string, unknown>)) {
+      expect(typeof v, `buzzAccount.${k} is a number`).toBe('number');
+    }
+
+    const accountRequests = trpcUrls.filter((u) => u.includes(BUZZ_ACCOUNT_PROCEDURE));
+    expect(
+      accountRequests,
+      `no ${BUZZ_ACCOUNT_PROCEDURE} tRPC request should fire on bootstrap (it is SSR-injected); saw:\n${accountRequests.join(
+        '\n'
+      )}`
+    ).toHaveLength(0);
+  });
+
+  test('SSR seed serialization matches a live fetch (same keys, all-numeric)', async ({ page }) => {
+    await page.goto(AUTHED_LANDING, { waitUntil: 'domcontentloaded' });
+
+    const seed = await readPageProp(page, 'buzzAccount');
+    expect(seed.present, 'buzzAccount seed present in __NEXT_DATA__').toBe(true);
+
+    const live = (await fetchTrpcQueryJson(page, BUZZ_ACCOUNT_PROCEDURE)) as Record<
+      string,
+      unknown
+    >;
+    const seedVal = seed.value as Record<string, unknown>;
+
+    // The serialization contract — the part that the #2471/#2683 byte-equality
+    // gotcha is actually about — is that the SSR seed (JSON) and a live fetch
+    // (superjson `.json`) produce the SAME SHAPE. Balances are live numbers and
+    // can legitimately differ between the SSR snapshot and this fetch (e.g. a
+    // BuzzUpdate landed in between), so we assert SHAPE, not exact values:
+    //   (1) identical key sets (no key dropped/added by JSON-vs-superjson), and
+    //   (2) all values numeric on BOTH sides (no Date/string/undefined drift).
+    expect(
+      Object.keys(seedVal).sort(),
+      'buzzAccount SSR seed and live fetch must carry the same balance keys'
+    ).toEqual(Object.keys(live).sort());
+    for (const k of Object.keys(seedVal)) {
+      expect(typeof seedVal[k], `seed buzzAccount.${k} is a number`).toBe('number');
+      expect(typeof live[k], `live buzzAccount.${k} is a number`).toBe('number');
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[ssr-inject] buzzAccount keys: ${Object.keys(seedVal).join(', ')}`);
   });
 });
 


### PR DESCRIPTION
## What

SSR-inject `buzz.getBuzzAccount` (~35 req/s on api-primary, the #2 ambient volume source) so the `useQueryBuzz` hook (header buzz pill) reads a primed React-Query cache and never fires the bootstrap request. Mirrors the proven, just-merged #2683 (`system.getLiveNow`) and #2471 (`getFeatureFlags`/`tosMeta`) SSR-seed pattern. Tier-1 #4 from `datapacket-talos claudedocs/api-primary-trpc-cost-analysis-2026-06-21.md`.

The CPU lever is the **per-request fixed middleware+context+superjson cost** the non-batched tRPC client pays on every ambient call. `getBuzzAccount` awaits the buzz microservice (I/O), so this removes the **bootstrap request's fixed middleware cost** (the CPU lever) — not the resolver compute (that work just moves to the server-only settings route).

## Mechanism — seed (not defer)

- Computed in the **server-only `/api/user/settings` route** (which `_app.getInitialProps` already fetches), **NOT** by importing `buzz.service` into `_app`. A local `next build` proved that importing the service into `_app` (even dynamically) leaks its transitive Node built-ins (`node:fs` via the `errorHandling` chain) into the **client bundle** and breaks the build. The route is server-only, so `getUserBuzzAccounts` (the same fn the resolver runs → byte-identical payload) stays off the client graph — exactly how the existing `following`/`announcements`/`tosMeta` seeds in that route avoid the same leak.
- Rides down `settingsBootstrap` → pageProps → AppProvider, seeded as `initialData` on the fixed `undefined` query key.
- **Auth-gated**: seeded only for a logged-in session (client gate `!!currentUser`) → a seed is present iff the client would otherwise fetch.

## First-paint freshness

NO `staleTime` override — the seed inherits the global `staleTime: Infinity`, **identical to how the live query behaves today**. The balance is kept current NOT by polling but by the `BuzzUpdate` SignalR push (`useBuzzSignalUpdate` patches the cache via `setData`) plus an explicit `invalidate()` after a purchase. A stale first-paint balance self-corrects on the next balance-changing signal/navigation — **no stickier than before**.

## Byte-equality handling (the #2471/#2683 gotcha)

The payload is a flat `Record<BuzzSpendType, number>` — **ALL numbers, no Date/undefined** — so the SSR seed (pageProps JSON) and a live superjson fetch serialize identically. **No revive helper needed** (unlike the sibling getUserMultipliers PR).

## Tests

- **e2e** (extends `tests/preview-ssr-inject.spec.ts`): (a) seed present in `__NEXT_DATA__` with all-numeric values, (b) no `buzz.getBuzzAccount` request fires on bootstrap, (c) seed and a live authed fetch carry the **same balance keys** and all-numeric values on both sides — it asserts the serialization SHAPE (the part the byte-equality gotcha is about), tolerating a balance that legitimately changed between the SSR snapshot and the fetch. e2e runs only on the preview pipeline (no unit test — there is no pure helper, matching the `following`/`getLiveNow` precedent).

## Build

Full local `next build` is not completable on this repo (dirty tsc baseline + a Turbopack/Prisma page-data quirk on an unrelated `/apps/run` route). With typecheck skipped the bundle **`✓ Compiled successfully`** — confirming the client-bundle leak is resolved (an earlier build that imported the service into `_app` failed explicitly with `node:fs` in the Browser bundle, with the import trace `errorHandling.ts → buzz.service.ts → _app.tsx`). Preview CI is the final gate. `tsc --noEmit` shows zero new errors in the changed files.

## Caveats

- **First-paint balance**: seeded value can be a snapshot slightly behind a concurrent BuzzUpdate, but it self-corrects via the signal exactly as today (no staleTime change). Not browser-verified locally — preview is the gate.
- Independent of the sibling PR (getUserMultipliers); both touch `/api/user/settings` + `_app`/AppProvider, so whichever merges second needs a trivial conflict resolution in those files (additive, no logic conflict).

Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)