### PR TITLE
fix(redis): decode Buffer hGet reply in queue bucket read — fixes 500 on post.createWithImages / modelVersion.upsert / collection.saveItem

### DIFF
--- a/src/server/redis/__tests__/queues.test.ts
+++ b/src/server/redis/__tests__/queues.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// queues.ts imports the real redis client module, which opens sockets at load.
+// Mock it to an in-memory sysRedis whose hGet reply type (string vs Buffer) we
+// control per-test — that's the exact axis of the bug. The mock fns are created
+// via vi.hoisted so they exist before vi.mock's hoisted factory references them.
+const { hGet, hSet, sAdd, sMembers, del, exists } = vi.hoisted(() => ({
+  hGet: vi.fn(),
+  hSet: vi.fn(() => Promise.resolve(1)),
+  sAdd: vi.fn(() => Promise.resolve(1)),
+  sMembers: vi.fn(() => Promise.resolve([] as string[])),
+  del: vi.fn(() => Promise.resolve(1)),
+  exists: vi.fn(() => Promise.resolve(0)),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { hGet, hSet, sAdd, sMembers, del, exists },
+  REDIS_SYS_KEYS: { QUEUES: { BUCKETS: 'queues:buckets' } },
+  REDIS_SUB_KEYS: { QUEUES: { MERGING: 'merging' } },
+}));
+
+import { addToQueue, checkoutQueue } from '~/server/redis/queues';
+
+// The bucket value is always persisted as a comma-joined string (see hSet calls
+// in queues.ts). This is the exact value the failing prod path read back.
+const BUCKETS_CSV = 'queues:buckets:images_v6:Update:1782075142958';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sMembers.mockResolvedValue([]);
+});
+
+describe('getBucketNames (via queues.ts public API)', () => {
+  // Regression: the HA/Sentinel sysRedis client returns BLOB_STRING replies as a
+  // Buffer. `currentBucket?.split(',')` then threw `i?.split is not a function`,
+  // 500-ing every content-create mutation that enqueues a search-index update
+  // (post.createWithImages / modelVersion.upsert / collection.saveItem). The
+  // optional chain guarded null but NOT a wrong-typed Buffer.
+  it('does NOT throw and parses bucket names when hGet returns a Buffer', async () => {
+    hGet.mockResolvedValue(Buffer.from(BUCKETS_CSV, 'utf8'));
+
+    // The pre-fix code threw synchronously inside this call.
+    await expect(checkoutQueue('images_v6:Update', false, true)).resolves.toBeDefined();
+
+    // It read the existing bucket (did not mint+hSet a new one on the read-only path).
+    expect(sMembers).toHaveBeenCalledWith(BUCKETS_CSV);
+  });
+
+  it('parses bucket names when hGet returns a plain string (unchanged behavior)', async () => {
+    hGet.mockResolvedValue(BUCKETS_CSV);
+    await expect(checkoutQueue('images_v6:Update', false, true)).resolves.toBeDefined();
+    expect(sMembers).toHaveBeenCalledWith(BUCKETS_CSV);
+  });
+
+  it('treats a null hGet (empty queue) as no buckets — mints a fresh one on enqueue', async () => {
+    hGet.mockResolvedValue(null);
+    await addToQueue('images_v6:Update', [1, 2, 3]);
+    // No existing bucket → a new bucket name is written, then ids are sAdd'd.
+    expect(hSet).toHaveBeenCalledTimes(1);
+    expect(sAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles a multi-bucket Buffer reply (comma-joined) without throwing', async () => {
+    const csv = `${BUCKETS_CSV},queues:buckets:images_v6:Update:1782075150000`;
+    hGet.mockResolvedValue(Buffer.from(csv, 'utf8'));
+    await checkoutQueue('images_v6:Update', false, true);
+    // Both buckets are read.
+    expect(sMembers).toHaveBeenCalledWith(BUCKETS_CSV);
+    expect(sMembers).toHaveBeenCalledWith('queues:buckets:images_v6:Update:1782075150000');
+  });
+});

--- a/src/server/redis/queues.ts
+++ b/src/server/redis/queues.ts
@@ -3,7 +3,17 @@ import { REDIS_SUB_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client'
 
 async function getBucketNames(key: string) {
   const currentBucket = await sysRedis.hGet(REDIS_SYS_KEYS.QUEUES.BUCKETS, key);
-  return (currentBucket?.split(',') ?? []) as RedisKeyTemplateSys[]; // values are redis key names
+  // sysRedis.hGet is typed to return a string, but the live HA/Sentinel client
+  // can hand back a Buffer for the BLOB_STRING reply. A Buffer has no `.split`,
+  // so `currentBucket?.split(',')` threw `i?.split is not a function` and 500'd
+  // EVERY content-create mutation that enqueues a search-index update
+  // (post.createWithImages, modelVersion.upsert, collection.saveItem, …). Coerce
+  // to a utf8 string first — the bucket value is always written as a comma-joined
+  // string (see hSet calls below), so decoding then splitting is exact.
+  const asString = Buffer.isBuffer(currentBucket)
+    ? currentBucket.toString('utf8')
+    : (currentBucket as string | null | undefined);
+  return (asString ? asString.split(',') : []) as RedisKeyTemplateSys[]; // values are redis key names
 }
 
 function getNewBucket(key: string) {


### PR DESCRIPTION
## The bug

One shared `TypeError` 500'd three tRPC content-create mutations identically:

- `post.createWithImages`
- `modelVersion.upsert`
- `collection.saveItem`

Loki-captured (previously invisible, only just structured-logged):

```
TypeError: i?.split is not a function
  code: INTERNAL_SERVER_ERROR
  causeMessage: "i?.split is not a function"
  paths: post.createWithImages, modelVersion.upsert, collection.saveItem
```

## Root cause

`src/server/redis/queues.ts` → `getBucketNames`:

```ts
const currentBucket = await sysRedis.hGet(REDIS_SYS_KEYS.QUEUES.BUCKETS, key);
return (currentBucket?.split(',') ?? []) as RedisKeyTemplateSys[];
```

`sysRedis.hGet` is typed `Promise<string | null>`, but the live HA/Sentinel
sysRedis client returns a **Buffer** for the BLOB_STRING reply. A Buffer has no
`.split`, and the optional chain guards null/undefined but **not** a wrong-typed
value — so `currentBucket?.split(',')` threw `i?.split is not a function`.

`getBucketNames` backs the search-index enqueue path (`addToQueue` /
`checkoutQueue` → `*.search-index.queueUpdate`), so the same throw fired on every
content-create mutation that enqueues an index update — one shared helper, three
affected paths:

| Path | Reaches getBucketNames via |
|---|---|
| `post.createWithImages` | `updatePost` → `queueImageSearchIndexUpdate` |
| `modelVersion.upsert` | `upsertModelVersion` → `modelsSearchIndex.queueUpdate` |
| `collection.saveItem` | collection metric / search-index update |

**Not** `browsingLevel** — that hypothesis is wrong: `browsingLevel` is injected by the `applyDomainFeature` middleware and then stripped by zod (it isn't a field on any of the three schemas), so it never reaches a `.split`. I confirmed the real cause by reproducing on a live preview pod and trapping the `.split` receiver: it was a **Buffer** decoding to a queue bucket name (`queues:buckets:images_v6:Update:<ts>`). Coercing that Buffer to a string made the mutation return `200`.

## The fix

Coerce the `hGet` reply to a utf8 string before splitting. The bucket value is
always persisted as a comma-joined string (see the `hSet` calls in the same
file), so decode-then-split is exact. One contained change covers all three call
sites — no client-layer change (which would be high blast-radius across ~30
cache readers).

## Test

`src/server/redis/__tests__/queues.test.ts` (new) drives `getBucketNames` through
the public `addToQueue` / `checkoutQueue` API and asserts it no longer throws on
a Buffer reply and parses single + multi bucket CSVs, with string and null
replies unchanged. **Verified it FAILS against the pre-fix code** (the two Buffer
cases throw), then passes with the fix. (Ran in isolation via a unit-only Vitest
config — the repo's default config needs browser-mode component deps absent from
my clone; the PR preview build is the full gate.)

The preview smoke specs `preview-post-upload`, `preview-model`, and
`preview-collections` (which hard-fail on this today) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)