### PR TITLE
feat(app-blocks): per-token rate limit on block catalog endpoints

### DIFF
--- a/src/pages/api/v1/blocks/images.ts
+++ b/src/pages/api/v1/blocks/images.ts
@@ -11,6 +11,7 @@ import {
 } from '~/server/middleware/block-scope.middleware';
 import { runImageSearch } from '~/server/services/image-search.service';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { getNextPage, getPagination } from '~/server/utils/pagination-helpers';
 import {
@@ -144,6 +145,19 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   const reqParams = blockImagesSchema.safeParse(req.query);
   if (!reqParams.success) {
     res.status(400).json({ error: reqParams.error });
+    return;
+  }
+
+  // Per-token rate limit (keyed on the stable blockInstanceId) — bounds a block
+  // hammering this private,no-store (Cloudflare-uncacheable) catalog route onto
+  // the origin. Fail-open + generous enough that a paginating image browser
+  // never trips it (see block-catalog-rate-limit.ts). Runs BEFORE the bulkhead
+  // slot + the expensive image search. Mirrors the 429+Retry-After shape this
+  // endpoint already returns for the paging guard / bulkhead shed.
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
     return;
   }
 

--- a/src/pages/api/v1/blocks/models.ts
+++ b/src/pages/api/v1/blocks/models.ts
@@ -14,6 +14,7 @@ import {
   runModelSearch,
 } from '~/server/services/model-search.service';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { ModelSort } from '~/server/common/enums';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
@@ -100,6 +101,17 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   const parsed = blockModelsSchema.safeParse(req.query);
   if (!parsed.success) {
     res.status(400).json({ error: parsed.error });
+    return;
+  }
+
+  // Per-token rate limit (keyed on the stable blockInstanceId) — bounds a block
+  // hammering this private,no-store (Cloudflare-uncacheable) catalog route onto
+  // the origin. Fail-open + generous enough that a paginating selector never
+  // trips it (see block-catalog-rate-limit.ts). Runs BEFORE the expensive search.
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
     return;
   }
 

--- a/src/server/utils/__tests__/block-catalog-rate-limit.test.ts
+++ b/src/server/utils/__tests__/block-catalog-rate-limit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit coverage for the App Blocks catalog per-token rate limiter
+ * (checkBlockCatalogRateLimit). Three contracts matter:
+ *   (a) under the ceiling → allowed;
+ *   (b) over the ceiling → not allowed + a sane Retry-After (the live TTL);
+ *   (c) any redis error → FAIL OPEN (allowed) — the catalog must never break
+ *       because the limiter's redis is down.
+ *
+ * The redis cache client is mocked so no real connection is constructed.
+ */
+
+const { mockRedis } = vi.hoisted(() => ({
+  mockRedis: {
+    incrBy: vi.fn(),
+    expire: vi.fn(),
+    ttl: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'blocks:token-rate-limit' } },
+}));
+
+import {
+  checkBlockCatalogRateLimit,
+  BLOCK_CATALOG_RATE_LIMIT_MAX,
+  BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS,
+} from '../block-catalog-rate-limit';
+
+const KEY = `blocks:token-rate-limit:catalog:bki_test`;
+
+describe('checkBlockCatalogRateLimit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedis.expire.mockResolvedValue(true);
+    mockRedis.ttl.mockResolvedValue(BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS);
+  });
+
+  it('first hit of a window → allowed and sets the TTL', async () => {
+    mockRedis.incrBy.mockResolvedValue(1);
+    const res = await checkBlockCatalogRateLimit('bki_test');
+    expect(res).toEqual({ allowed: true });
+    expect(mockRedis.incrBy).toHaveBeenCalledWith(KEY, 1);
+    expect(mockRedis.expire).toHaveBeenCalledWith(KEY, BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS);
+  });
+
+  it('at the ceiling → still allowed (boundary is inclusive)', async () => {
+    mockRedis.incrBy.mockResolvedValue(BLOCK_CATALOG_RATE_LIMIT_MAX);
+    const res = await checkBlockCatalogRateLimit('bki_test');
+    expect(res).toEqual({ allowed: true });
+  });
+
+  it('subsequent hit (count>1) does NOT reset the TTL on a live window', async () => {
+    mockRedis.incrBy.mockResolvedValue(5);
+    mockRedis.ttl.mockResolvedValue(7); // live window
+    const res = await checkBlockCatalogRateLimit('bki_test');
+    expect(res).toEqual({ allowed: true });
+    expect(mockRedis.expire).not.toHaveBeenCalled();
+  });
+
+  it('re-asserts a lost TTL (ttl<0) on a non-first hit', async () => {
+    mockRedis.incrBy.mockResolvedValue(5);
+    mockRedis.ttl.mockResolvedValue(-1); // TTL was lost
+    await checkBlockCatalogRateLimit('bki_test');
+    expect(mockRedis.expire).toHaveBeenCalledWith(KEY, BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS);
+  });
+
+  it('over the ceiling → not allowed + Retry-After = live TTL', async () => {
+    mockRedis.incrBy.mockResolvedValue(BLOCK_CATALOG_RATE_LIMIT_MAX + 1);
+    mockRedis.ttl.mockResolvedValue(4); // remaining window
+    const res = await checkBlockCatalogRateLimit('bki_test');
+    expect(res).toEqual({ allowed: false, retryAfterSeconds: 4 });
+  });
+
+  it('over the ceiling with an unset/invalid TTL → falls back to the full window', async () => {
+    mockRedis.incrBy.mockResolvedValue(BLOCK_CATALOG_RATE_LIMIT_MAX + 10);
+    mockRedis.ttl.mockResolvedValue(-2); // key reported as gone
+    const res = await checkBlockCatalogRateLimit('bki_test');
+    expect(res).toEqual({
+      allowed: false,
+      retryAfterSeconds: BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS,
+    });
+  });
+
+  it('redis error (incr throws) → FAIL OPEN (allowed)', async () => {
+    mockRedis.incrBy.mockRejectedValue(new Error('redis down'));
+    const res = await checkBlockCatalogRateLimit('bki_test');
+    expect(res).toEqual({ allowed: true });
+  });
+
+  it('redis error on the over-limit TTL read → FAIL OPEN (allowed)', async () => {
+    // incr says over-limit, but the follow-up ttl read throws → the catch fails
+    // open rather than 429ing on a half-broken redis.
+    mockRedis.incrBy.mockResolvedValue(BLOCK_CATALOG_RATE_LIMIT_MAX + 1);
+    mockRedis.ttl.mockRejectedValue(new Error('redis down'));
+    const res = await checkBlockCatalogRateLimit('bki_test');
+    expect(res).toEqual({ allowed: true });
+  });
+});

--- a/src/server/utils/block-catalog-rate-limit.ts
+++ b/src/server/utils/block-catalog-rate-limit.ts
@@ -1,0 +1,88 @@
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+
+/**
+ * Per-token fixed-window rate limit for the App Blocks catalog endpoints
+ * (`/api/v1/blocks/models`, `/api/v1/blocks/images`).
+ *
+ * WHY: both catalog endpoints accept ANY valid block token and force
+ * `Cache-Control: private, no-store` (so Cloudflare can't absorb the load — see
+ * each endpoint's doc + withBlockScope). A security audit flagged (MEDIUM,
+ * optional): with no per-token ceiling, a single block could shift catalog cost
+ * onto the origin by hammering these routes. This bounds that without touching
+ * the maturity-clamp authority surface.
+ *
+ * PATTERN: this reuses the established blocks fixed-window limiter — the SAME
+ * INCR + EXPIRE + fail-open shape as `BlockTokenService.checkRateLimit` (the
+ * per-token mint limiter) and the retool-endpoint MULTI limiter. It runs on the
+ * `redis` cache client (like the mint limiter), NOT the createLimiter / sysRedis
+ * DB-count limiter (that one is a sliding count of a fetched DB value — wrong
+ * tool for a fast burst ceiling).
+ *
+ * KEY: keyed on `claims.blockInstanceId` (the stable per-instance identity that
+ * the same in-block iframe reuses across a paginating session) under a distinct
+ * `:catalog:` sub-namespace, so this bucket NEVER contends with the mint-token
+ * bucket (`TOKEN_RATE_LIMIT:<subject>:<blockInstanceId>`). We key on the
+ * instance — not `jti` — because `jti` rotates on every re-mint (the host
+ * re-mints a fresh token periodically), which would reset the window and let an
+ * abuser churn tokens for a fresh bucket; `blockInstanceId` is stable per
+ * install and is exactly what we want to throttle.
+ *
+ * FAIL-OPEN: any redis error/timeout returns `allowed:true` — the catalog must
+ * never break because the limiter's redis is down. Mirrors
+ * `BlockTokenService.checkRateLimit`.
+ */
+
+// CEILING: generous for a real in-block browser, bounded for abuse. A model/
+// image selector paginates ~100 items/page; a user scrolling fast (or a
+// debounced search firing as they type) issues at most a handful of fetches per
+// second — well under this. The ceiling only bites a token issuing a sustained
+// burst (>~30 req/s averaged over the window), which is not legitimate selector
+// usage. Window is short so a tripped instance recovers within seconds.
+export const BLOCK_CATALOG_RATE_LIMIT_MAX = 120;
+export const BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS = 10;
+
+export type BlockCatalogRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+/**
+ * Records one catalog request against `blockInstanceId`'s window and reports
+ * whether it is within the per-token ceiling.
+ *
+ * @param blockInstanceId stable per-instance identity from `req.blockClaims`.
+ * @returns `{ allowed: true }` under the limit (or on any redis error —
+ *   fail-open); `{ allowed: false, retryAfterSeconds }` once the window's count
+ *   exceeds the ceiling.
+ */
+export async function checkBlockCatalogRateLimit(
+  blockInstanceId: string
+): Promise<BlockCatalogRateLimitResult> {
+  const key = `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:catalog:${blockInstanceId}` as const;
+  try {
+    // INCR returns 1 on the first hit of a fresh window; set the TTL then so the
+    // key is always bounded. The atomic concern (a crash between INCR and EXPIRE
+    // stranding a TTL-less key → permanent lock) is mitigated the same way the
+    // mint limiter does it: re-assert the TTL when it's been lost.
+    const count = await redis.incrBy(key as never, 1);
+    if (count === 1) {
+      await redis.expire(key as never, BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS);
+    } else {
+      const ttl = await redis.ttl(key as never);
+      if (ttl < 0) await redis.expire(key as never, BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS);
+    }
+
+    if (count <= BLOCK_CATALOG_RATE_LIMIT_MAX) return { allowed: true };
+
+    // Over the ceiling — surface the remaining window as Retry-After. If the TTL
+    // read fails or is unset (-1/-2), fall back to the full window so the client
+    // backs off sanely rather than retrying immediately.
+    let retryAfter = await redis.ttl(key as never);
+    if (!Number.isFinite(retryAfter) || retryAfter < 1) {
+      retryAfter = BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS;
+    }
+    return { allowed: false, retryAfterSeconds: retryAfter };
+  } catch {
+    // Fail open — never block legitimate catalog traffic on a redis incident.
+    return { allowed: true };
+  }
+}

--- a/src/tests/api/v1/blocks/images-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/images-endpoint.test.ts
@@ -21,14 +21,22 @@ import type { BlockTokenClaims } from '~/server/middleware/block-scope.middlewar
  * search service is mocked so no Prisma/Meili/Flipt is loaded.
  */
 
-const { mockRunImageSearch } = vi.hoisted(() => ({
+const { mockRunImageSearch, mockCheckRateLimit } = vi.hoisted(() => ({
   mockRunImageSearch: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
 }));
 
 const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
 
 vi.mock('~/server/services/image-search.service', () => ({
   runImageSearch: mockRunImageSearch,
+}));
+
+// Per-token catalog rate limiter — mocked so the existing maturity-clamp tests
+// are unaffected (default: allowed). Its own logic is covered in
+// server/utils/__tests__/block-catalog-rate-limit.test.ts.
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockCheckRateLimit,
 }));
 
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
@@ -134,6 +142,8 @@ describe('/api/v1/blocks/images — authoritative clamp wiring', () => {
     vi.clearAllMocks();
     regionBox.restricted = false;
     mockRunImageSearch.mockResolvedValue({ items: [], nextCursor: undefined });
+    // Default: under the per-token ceiling (existing clamp tests must be served).
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it('GREEN token + nsfw=true → search called with SFW level (clamped)', async () => {
@@ -237,5 +247,31 @@ describe('/api/v1/blocks/images — authoritative clamp wiring', () => {
     await handler(req, res);
     expect(res.statusCode).toBe(405);
     expect(mockRunImageSearch).not.toHaveBeenCalled();
+  });
+
+  it('over the per-token ceiling → 429 + Retry-After, search NOT called', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    mockCheckRateLimit.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 6 });
+    const res = await invoke({});
+
+    expect(res.statusCode).toBe(429);
+    expect((res as unknown as { headers: Record<string, unknown> }).headers['Retry-After']).toBe(
+      '6'
+    );
+    // Keyed on the stable blockInstanceId from the claims.
+    expect(mockCheckRateLimit).toHaveBeenCalledWith('bki_test');
+    // The bulkhead slot + the expensive image search must be short-circuited.
+    expect(mockRunImageSearch).not.toHaveBeenCalled();
+  });
+
+  it('limiter redis failure is FAIL-OPEN — request is still served (200)', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    // The helper itself catches redis errors and returns allowed:true; model
+    // that here so the endpoint never 429/500s when the limiter's redis is down.
+    mockCheckRateLimit.mockResolvedValueOnce({ allowed: true });
+    const res = await invoke({});
+
+    expect(res.statusCode).toBe(200);
+    expect(mockRunImageSearch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tests/api/v1/blocks/models-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/models-endpoint.test.ts
@@ -20,9 +20,10 @@ import type { BlockTokenClaims } from '~/server/middleware/block-scope.middlewar
  * service is mocked so no Prisma client is loaded.
  */
 
-const { mockRunModelSearch, mockResolveModelSearchIds } = vi.hoisted(() => ({
+const { mockRunModelSearch, mockResolveModelSearchIds, mockCheckRateLimit } = vi.hoisted(() => ({
   mockRunModelSearch: vi.fn(),
   mockResolveModelSearchIds: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
 }));
 
 // Holds the claims the mocked withBlockScope will stamp onto req for the
@@ -33,6 +34,13 @@ vi.mock('~/server/services/model-search.service', () => ({
   runModelSearch: mockRunModelSearch,
   resolveModelSearchIds: mockResolveModelSearchIds,
   ModelSearchMeiliTimeoutError: class extends Error {},
+}));
+
+// Per-token catalog rate limiter — mocked so the existing maturity-clamp tests
+// are unaffected (default: allowed). Its own logic is covered in
+// server/utils/__tests__/block-catalog-rate-limit.test.ts.
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockCheckRateLimit,
 }));
 
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
@@ -128,6 +136,8 @@ describe('/api/v1/blocks/models — authoritative clamp wiring', () => {
     regionBox.restricted = false;
     mockRunModelSearch.mockResolvedValue({ items: [], nextCursor: undefined });
     mockResolveModelSearchIds.mockResolvedValue({ searchIds: [], nextCursor: undefined });
+    // Default: under the per-token ceiling (existing clamp tests must be served).
+    mockCheckRateLimit.mockResolvedValue({ allowed: true });
   });
 
   it('GREEN token + nsfw=true → search called with SFW level (clamped), passthrough false', async () => {
@@ -236,5 +246,32 @@ describe('/api/v1/blocks/models — authoritative clamp wiring', () => {
     await handler(req, res);
     expect(res.statusCode).toBe(405);
     expect(mockRunModelSearch).not.toHaveBeenCalled();
+  });
+
+  it('over the per-token ceiling → 429 + Retry-After, search NOT called', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    mockCheckRateLimit.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 6 });
+    const res = await invoke({ query: 'dreamshaper' });
+
+    expect(res.statusCode).toBe(429);
+    expect((res as unknown as { headers: Record<string, unknown> }).headers['Retry-After']).toBe(
+      '6'
+    );
+    // Keyed on the stable blockInstanceId from the claims.
+    expect(mockCheckRateLimit).toHaveBeenCalledWith('bki_test');
+    // The expensive search (and its Meili pre-step) must be short-circuited.
+    expect(mockRunModelSearch).not.toHaveBeenCalled();
+    expect(mockResolveModelSearchIds).not.toHaveBeenCalled();
+  });
+
+  it('limiter redis failure is FAIL-OPEN — request is still served (200)', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    // The helper itself catches redis errors and returns allowed:true; model
+    // that here so the endpoint never 429/500s when the limiter's redis is down.
+    mockCheckRateLimit.mockResolvedValueOnce({ allowed: true });
+    const res = await invoke({});
+
+    expect(res.statusCode).toBe(200);
+    expect(mockRunModelSearch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What

Adds a per-token rate limit to the App Blocks catalog endpoints `/api/v1/blocks/models` and `/api/v1/blocks/images`. Both accept ANY valid block token and force `Cache-Control: private, no-store`, so Cloudflare can't absorb their load — a prior security audit flagged (MEDIUM, optional) that with no per-token ceiling a block could shift catalog cost onto the origin by hammering these routes.

Dark/behavioral-safe: normal in-block usage never hits it.

## Limiter reused

The established blocks fixed-window pattern — the **same `INCR` + `EXPIRE` + fail-open shape as `BlockTokenService.checkRateLimit`** (the per-token *mint* limiter) and the retool-endpoint MULTI limiter. Runs on the `redis` cache client (like the mint limiter), **not** the `createLimiter`/`sysRedis` DB-count limiter (that one counts a *fetched DB value* over a long refetch interval — wrong tool for a fast burst ceiling). New helper `src/server/utils/block-catalog-rate-limit.ts` (under `src/server/...`, **not** `src/pages` — gotcha #81).

## Key choice + why

Keyed on **`claims.blockInstanceId`** (from `req.blockClaims`) under a distinct `:catalog:` sub-namespace, so this bucket never contends with the mint-token bucket (`TOKEN_RATE_LIMIT:<subject>:<blockInstanceId>`).

- `blockInstanceId` is the **stable per-install identity** the same in-block iframe reuses across a paginating session — exactly what we want to throttle.
- **Not `jti`**: `jti` rotates on every re-mint (the host periodically re-mints a fresh token), which would reset the window and let an abuser churn tokens for a fresh bucket. `blockInstanceId` is stable per install.

## Limit / window + why it won't trip real usage

`120 req / 10s` (named constants `BLOCK_CATALOG_RATE_LIMIT_MAX` / `BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS`). A model/image selector paginates ~100 items/page; a user scrolling fast or a debounced search firing as they type issues at most a handful of fetches/sec — well under 12/s averaged. The ceiling only bites a token issuing a sustained burst (>~30 req/s averaged), which is not legitimate selector usage. Short window so a tripped instance recovers within seconds.

## Behavior

- On exceed → **HTTP 429 + `Retry-After`** (the live TTL, full-window fallback if unset). Mirrors the images endpoint's existing 429+Retry-After shape (paging guard / bulkhead shed).
- The check runs **after** token validation / claims are available, **before** the expensive search call (and, on images, before the bulkhead slot).
- **Fail-open**: any redis error/timeout → request is allowed. The catalog never breaks because the limiter's redis is down. Mirrors `BlockTokenService.checkRateLimit`.

## Tests

- **Unit** (`block-catalog-rate-limit.test.ts`, 8 tests): under-limit → allowed (sets TTL), at-ceiling inclusive, live-window TTL not reset, lost-TTL re-assert, over-limit → not allowed + Retry-After=TTL, invalid-TTL → full-window fallback, redis-error → fail-open, over-limit + TTL-read-error → fail-open.
- **Endpoint** (`models-endpoint`, `images-endpoint`): added burst-beyond-ceiling → 429 + Retry-After (search short-circuited, keyed on `blockInstanceId`) and limiter-failure → fail-open (served 200). The limiter is mocked (default allowed) so the existing maturity-clamp tests are unaffected.
- **Results**: `31/31` passing across the 3 suites (8 + 11 + 12).
- **tsc** `--noEmit`: clean on all changed files; repo-wide total dropped 5294 → 5292 (pre-existing baseline; the 2 dropped were my own fixed test types — zero new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)