### PR TITLE
docs(app-blocks): correct rate-limit comment (~12 req/s, not ~30)

### DIFF
--- a/src/server/utils/block-catalog-rate-limit.ts
+++ b/src/server/utils/block-catalog-rate-limit.ts
@@ -36,8 +36,9 @@ import { redis, REDIS_KEYS } from '~/server/redis/client';
 // image selector paginates ~100 items/page; a user scrolling fast (or a
 // debounced search firing as they type) issues at most a handful of fetches per
 // second — well under this. The ceiling only bites a token issuing a sustained
-// burst (>~30 req/s averaged over the window), which is not legitimate selector
-// usage. Window is short so a tripped instance recovers within seconds.
+// burst (>~12 req/s averaged over the window — 120 requests / 10s, so the 121st
+// request in any 10s window trips it), which is not legitimate selector usage.
+// Window is short so a tripped instance recovers within seconds.
 export const BLOCK_CATALOG_RATE_LIMIT_MAX = 120;
 export const BLOCK_CATALOG_RATE_LIMIT_WINDOW_SECONDS = 10;
 


### PR DESCRIPTION
## What

Fixes an inaccurate doc comment in `src/server/utils/block-catalog-rate-limit.ts`.

The comment near the limit constant claimed the ceiling "only bites a token issuing a sustained burst (>~30 req/s averaged over the window)". That math is wrong: the limit is **120 requests / 10s fixed window = ~12 req/s** sustained — the 121st request in any 10s window trips it.

## Change

Comment-only. The corrected text now reads ~12 req/s and spells out the 120/10s arithmetic. The rest of the explanation (still well above a real paginating selector's handful-of-requests-per-second) is preserved.

`BLOCK_CATALOG_RATE_LIMIT_MAX` (120), the window (10s), and all limiter logic are **unchanged** — emitted JS is byte-identical to the previous version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)