### PR TITLE
chore(metrics): drop dead legacy entity-metric increment + unused flag enum

### DIFF
--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -8,7 +8,6 @@ export enum FLIPT_FEATURE_FLAGS {
   // tRPC `isFlagProtected('articleRatingDispute')` endpoints use.
   ARTICLE_RATING_DISPUTE = 'article-rating-dispute',
   FEED_IMAGE_EXISTENCE = 'feed-image-existence',
-  ENTITY_METRIC_NO_CACHE_BUST = 'entity-metric-no-cache-bust',
   FEED_POST_FILTER = 'feed-fetch-filter-in-post',
   REDIS_CLUSTER_ENHANCED_FAILOVER = 'redis-cluster-enhanced-failover',
 

--- a/src/server/utils/metric-helpers.ts
+++ b/src/server/utils/metric-helpers.ts
@@ -1,50 +1,13 @@
-import { EntityMetric_MetricType_Type } from '~/shared/utils/prisma/enums';
+import type { EntityMetric_MetricType_Type } from '~/shared/utils/prisma/enums';
 import type { EntityMetric_EntityType_Type } from '~/shared/utils/prisma/enums';
-import { clickhouse } from '~/server/clickhouse/client';
 import type { ProtectedContext } from '~/server/createContext';
 import { logToAxiom } from '~/server/logging/client';
-import { redis, REDIS_KEYS, type RedisKeyTemplateCache } from '~/server/redis/client';
-import { entityMetricRedis } from '~/server/redis/entity-metric.redis';
 import { isFlipt } from '../flipt/client';
 
 const logError = (name: string, details: Record<string, unknown>) => {
   logToAxiom({ type: 'error', name, details }, 'clickhouse').catch(() => {
     // Ignore logging failures
   });
-};
-
-const getAllMetricsFromClickHouse = async (
-  entityType: EntityMetric_EntityType_Type,
-  entityId: number
-): Promise<Record<EntityMetric_MetricType_Type, number>> => {
-  if (!clickhouse) {
-    return {} as Record<EntityMetric_MetricType_Type, number>;
-  }
-
-  const cData = await clickhouse.$query<{ metricType: string; total: number }>`
-    SELECT metricType, sum(total) as total
-    FROM entityMetricDailyAgg_v2
-    WHERE entityType = '${entityType}' AND entityId = ${entityId}
-    GROUP BY metricType
-  `;
-
-  // Initialize all possible metrics to 0
-  const metrics: Record<string, number> = {};
-  const allMetricTypes: EntityMetric_MetricType_Type[] = Object.values(
-    EntityMetric_MetricType_Type
-  );
-  allMetricTypes.forEach((metricType) => {
-    metrics[metricType] = 0;
-  });
-
-  // Update with actual values from ClickHouse
-  cData?.forEach((row) => {
-    if (row.metricType && typeof row.total === 'number') {
-      metrics[row.metricType] = row.total;
-    }
-  });
-
-  return metrics as Record<EntityMetric_MetricType_Type, number>;
 };
 
 export const updateEntityMetric = async ({
@@ -70,67 +33,18 @@ export const updateEntityMetric = async ({
     metricValue: amount,
   });
 
-  // Update Redis EntityMetric
-  try {
-    // Use existing helper method for consistent key generation
-    const key =
-      `${REDIS_KEYS.ENTITY_METRICS.BASE}:${entityType}:${entityId}` as RedisKeyTemplateCache;
-
-    // Check if specific metric exists and sync from ClickHouse if missing
-    if (clickhouse) {
-      const metricExists = await redis.hExists(key, metricType);
-
-      if (!metricExists) {
-        const lockKey = `${key}:lock:${metricType}` as RedisKeyTemplateCache;
-        const lockAcquired = await redis.setNX(lockKey, '1');
-
-        if (lockAcquired) {
-          await redis.expire(lockKey, 5);
-          try {
-            const allMetrics = await getAllMetricsFromClickHouse(entityType, entityId);
-            await entityMetricRedis.setMultipleMetrics(entityType, entityId, allMetrics);
-          } catch (error) {
-            // Simple error logging - don't block the operation
-            logToAxiom(
-              {
-                type: 'warning',
-                name: 'ClickHouse metric sync failed',
-                details: { entityType, entityId, metricType },
-              },
-              'clickhouse'
-            ).catch(() => {
-              // Ignore logging failures
-            });
-          } finally {
-            await redis.unlink(lockKey);
-          }
-        }
-      }
-    }
-
-    // Now perform the atomic increment
-    const newValue = await entityMetricRedis.increment(entityType, entityId, metricType, amount);
-
-    // Prevent negative values by checking and correcting if needed
-    if (newValue < 0) {
-      await entityMetricRedis.setMetric(entityType, entityId, metricType, 0);
-    }
-
-    // NOTE: the legacy `imageMetricsCache.bust(entityId)` call was removed here
-    // after the watcher/v2 cutover — nothing reads that in-app `entitymetric:*`
-    // image read cache anymore (image reads now go through the watcher-fed
-    // `metrics:*` MetricService cache). The `entityMetricRedis` increment above
-    // and the `ctx.track.entityMetric(...)` emission below are intentionally
-    // kept: the latter is what feeds the watcher (reactions -> metrics).
-  } catch (e) {
-    const error = e as Error;
-    logError('Failed to increment metric', {
-      data: logData,
-      error: error.message,
-      cause: error.cause,
-      stack: error.stack,
-    });
-  }
+  // NOTE: the legacy `entityMetricRedis` increment + CH-sync-on-miss block that
+  // used to live here was removed after the v2 + watcher cutover went permanent
+  // (v5.0.1871). It wrote the in-app `entitymetric:Image:*` Redis cache, which
+  // nothing reads anymore — image metric reads go through the watcher-fed
+  // `metrics:*` cache via MetricService (`getImageMetricsObject`,
+  // `bitdex-stats.ts`). The comic read path uses a separate `entitymetric:Comic:*`
+  // key populated independently from ClickHouse (`populateComicMetrics`), so it
+  // never read what this increment wrote.
+  //
+  // The `ctx.track.entityMetric(...)` emission below is intentionally KEPT: it is
+  // the Kafka event that feeds the watcher (reactions/comments/collects/buzz ->
+  // metrics). It is the entire metric pipeline — do not remove it.
 
   // Queue with clickhouse tracker
   try {


### PR DESCRIPTION
Small cleanup after the entity-metric v2 + watcher cutover was made permanent (v5.0.1871). Removes now-dead legacy code. **No behavior change** — everything removed is provably unread.

## Removed

1. **`ENTITY_METRIC_NO_CACHE_BUST` enum entry** in `src/server/flipt/client.ts` `FLIPT_FEATURE_FLAGS`. F4 already removed its Flipt eval; a repo-wide grep confirmed zero code references (only the enum def + a docs runbook mention).

2. **The legacy `entityMetricRedis` increment + CH-sync-on-miss block** in `updateEntityMetric()` (`src/server/utils/metric-helpers.ts`), plus the `getAllMetricsFromClickHouse` helper they used and the now-unused `entityMetricRedis`/`redis`/`clickhouse`/`REDIS_KEYS` imports. This wrote the in-app `entitymetric:Image:*` Redis cache.

## Preserved (critical)

- **`ctx.track.entityMetric(...)`** — the Kafka emission that feeds the watcher (the entire metric pipeline). Untouched.
- **The comic entity-metric path** — `entitymetric:Comic:*`, populated independently from ClickHouse via `populateComicMetrics` (`entity-metric-populate.ts`), still using `entityMetricRedis` read methods (`getBulkMetrics`/`exists`/`setMultipleMetrics`/`delete`). The `EntityMetricRedisClient` class is left fully intact.

## Increment audit verdict: DEAD — safe to remove

- Every caller of `updateEntityMetric`/`increment`/`decrement` (reaction, comment, collection, post, buzz controllers) passes `entityType: 'Image'`, so the increment wrote **only** `entitymetric:Image:*`.
- The only readers of `entitymetric:Image:*` were `getImageMetricsObject` (hot tRPC feed) and `bitdex-stats.ts` — both now read the watcher-fed `metrics:*` cache via `MetricService`. The old `imageMetricsCache` reader was already retired.
- The comic path reads a different key (`entitymetric:Comic:*`) populated from its own ClickHouse query; it never read what the increment wrote.

So nothing reads `entitymetric:Image:*` anymore → the increment and its CH-sync-on-miss block are dead and removed.

## Verification

- `pnpm run typecheck`: **zero new errors** in touched files. Total errors remain at the documented pre-existing baseline of 175 (unrelated Prisma/`Model3D` errors in this working copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)