### PR TITLE
fix(app-blocks): raise Forgejo bundle-push timeout (15s was too low for real bundles)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -624,6 +624,16 @@ export const serverSchema = z.object({
   FORGEJO_PUBLIC_URL: z.string().url().default('https://forgejo.civitai.com'),
   FORGEJO_ADMIN_TOKEN: z.string().optional(),
   FORGEJO_WEBHOOK_SECRET: z.string().optional(),
+  // Client-side abort timeouts for Forgejo API calls. The cheap metadata calls
+  // (get repo/version, add collaborator, list tree, branch lookup) are
+  // sub-second and use FORGEJO_API_TIMEOUT_MS so an in-cluster reachability
+  // problem surfaces fast. The BUNDLE COMMIT/PUSH path (first-time review-repo
+  // create + a single multi-file commit of every bundle file) is genuinely slow
+  // for a real app — gen-matrix is ~888 files — so it gets the much larger
+  // FORGEJO_COMMIT_TIMEOUT_MS. A 15s ceiling on the commit aborted real submits
+  // with "The operation was aborted due to timeout"; 120s gives headroom.
+  FORGEJO_API_TIMEOUT_MS: z.coerce.number().default(15000),
+  FORGEJO_COMMIT_TIMEOUT_MS: z.coerce.number().default(120000),
   // F6 — optional second HMAC secret accepted during a zero-downtime rotation.
   // verifyForgejoSignature (git-push.ts) / verifySignature (build-callback.ts)
   // accept a signature valid under EITHER the current or the _NEXT secret. When

--- a/src/server/services/blocks/__tests__/forgejo.service.test.ts
+++ b/src/server/services/blocks/__tests__/forgejo.service.test.ts
@@ -16,6 +16,10 @@ vi.mock('~/env/server', () => ({
     FORGEJO_ADMIN_TOKEN: 'tok-test',
     FORGEJO_WEBHOOK_SECRET: 'sec-test',
     APPS_DOMAIN: 'civit.ai',
+    // Distinct values so the timeout-routing assertions are unambiguous about
+    // which ceiling a given call used.
+    FORGEJO_API_TIMEOUT_MS: 15000,
+    FORGEJO_COMMIT_TIMEOUT_MS: 120000,
   },
 }));
 
@@ -367,5 +371,164 @@ describe('mintForgejoUserToken', () => {
     await expect(
       mintForgejoUserToken({ username: 'dev-7', password: 'pw', name: 'x', scopes: [] })
     ).rejects.toThrow(/no sha1/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout routing — the bug fix. The bundle COMMIT/PUSH path must use the
+// generous FORGEJO_COMMIT_TIMEOUT_MS (120s) so a real app (gen-matrix = ~888
+// files) doesn't abort at the old 15s ceiling ("The operation was aborted due
+// to timeout"); the cheap metadata calls keep the small FORGEJO_API_TIMEOUT_MS
+// (15s) so an in-cluster reachability problem still surfaces fast.
+//
+// Strategy: spy on AbortSignal.timeout to capture each call's timeout in order.
+// Each fjFetch / raw fetch calls AbortSignal.timeout immediately before fetch,
+// so the Nth captured timeout pairs with the Nth recorded fetch call.
+// ---------------------------------------------------------------------------
+describe('Forgejo client-side timeout routing', () => {
+  let timeouts: number[];
+  let realTimeout: typeof AbortSignal.timeout;
+
+  beforeEach(() => {
+    timeouts = [];
+    realTimeout = AbortSignal.timeout;
+    vi.spyOn(AbortSignal, 'timeout').mockImplementation((ms: number) => {
+      timeouts.push(ms);
+      // Return a never-firing signal: the fetch mock resolves synchronously,
+      // so the real timer would only leak. We just need to observe `ms`.
+      return new AbortController().signal;
+    });
+  });
+
+  afterEach(() => {
+    vi.spyOn(AbortSignal, 'timeout').mockImplementation(realTimeout);
+    vi.restoreAllMocks();
+  });
+
+  it('commitFiles: the multi-file commit POST uses the 120s commit timeout; the tree/branch reads keep 15s', async () => {
+    const { commitFiles } = await import('../forgejo.service');
+    fm.enqueue({ commit: { id: 'commit_sha' } }); // listRepoTree: branch
+    fm.enqueue({ tree: [], truncated: false }); // listRepoTree: tree
+    fm.enqueue({ commit: { sha: 'new_commit_sha' } }); // contents POST
+
+    await commitFiles({
+      slug: 'gen-matrix',
+      files: [{ path: 'a.txt', content: Buffer.from('hi') }],
+      message: 'msg',
+    });
+
+    // Pair captured timeouts to fetch calls by index.
+    const branchIdx = fm.calls.findIndex((c) => c.url.includes('/branches/'));
+    const treeIdx = fm.calls.findIndex((c) => c.url.includes('/git/trees/'));
+    const commitIdx = fm.calls.findIndex((c) => c.url.endsWith('/contents'));
+    expect(branchIdx).toBeGreaterThanOrEqual(0);
+    expect(treeIdx).toBeGreaterThanOrEqual(0);
+    expect(commitIdx).toBeGreaterThanOrEqual(0);
+
+    // Cheap reads keep the small ceiling.
+    expect(timeouts[branchIdx]).toBe(15000);
+    expect(timeouts[treeIdx]).toBe(15000);
+    // The slow commit/push gets the generous one.
+    expect(timeouts[commitIdx]).toBe(120000);
+  });
+
+  it('ensureReviewRepo: the auto_init repo-create POST uses the 120s commit timeout; the org-create keeps 15s', async () => {
+    const { ensureReviewRepo } = await import('../forgejo.service');
+    fm.enqueue(null, 422); // POST /orgs (already exists)
+    fm.enqueue(null, 201); // POST /orgs/<review>/repos (created)
+
+    await ensureReviewRepo('gen-matrix');
+
+    const orgIdx = fm.calls.findIndex((c) => c.url.endsWith('/api/v1/orgs'));
+    const repoIdx = fm.calls.findIndex((c) =>
+      c.url.endsWith('/orgs/civitai-apps-review/repos')
+    );
+    expect(orgIdx).toBeGreaterThanOrEqual(0);
+    expect(repoIdx).toBeGreaterThanOrEqual(0);
+    expect(timeouts[orgIdx]).toBe(15000);
+    expect(timeouts[repoIdx]).toBe(120000);
+  });
+
+  it('createRepoFromTemplate: the repo-create POST uses the 120s commit timeout', async () => {
+    const { createRepoFromTemplate } = await import('../forgejo.service');
+    fm.enqueue({
+      id: 1,
+      name: 'gen-matrix',
+      full_name: 'civitai-apps/gen-matrix',
+      html_url: '',
+      clone_url: '',
+      ssh_url: '',
+      default_branch: 'main',
+    }); // generate POST
+
+    await createRepoFromTemplate({ slug: 'gen-matrix', template: 'starter' });
+
+    const genIdx = fm.calls.findIndex((c) => c.url.endsWith('/generate'));
+    expect(genIdx).toBeGreaterThanOrEqual(0);
+    expect(timeouts[genIdx]).toBe(120000);
+  });
+
+  it('cheap metadata calls (getRepo, addCollaborator, setCommitStatus) keep the 15s API timeout', async () => {
+    const svc = await import('../forgejo.service');
+
+    fm.enqueue({
+      id: 1,
+      name: 'gen-matrix',
+      full_name: 'civitai-apps/gen-matrix',
+      html_url: '',
+      clone_url: '',
+      ssh_url: '',
+      default_branch: 'main',
+    });
+    await svc.getRepo('gen-matrix');
+    expect(timeouts[timeouts.length - 1]).toBe(15000);
+
+    // addCollaborator treats res.ok as success; a 200 avoids the JS Response
+    // 204-must-be-null-body constructor quirk and exercises the same path.
+    fm.enqueueRaw(new Response('', { status: 200 }));
+    await svc.addCollaborator({ slug: 'gen-matrix', username: 'dev-7' });
+    expect(timeouts[timeouts.length - 1]).toBe(15000);
+
+    fm.enqueue({ id: 1 });
+    await svc.setCommitStatus({
+      slug: 'gen-matrix',
+      sha: 'abc',
+      state: 'pending',
+      context: 'civitai/build',
+    });
+    expect(timeouts[timeouts.length - 1]).toBe(15000);
+  });
+
+  it('respects overridden env timeouts (config-driven, not hardcoded)', async () => {
+    // Re-mock the env module with different values, fresh-import the service.
+    vi.resetModules();
+    vi.doMock('~/env/server', () => ({
+      env: {
+        FORGEJO_BASE_URL: 'https://forgejo.example',
+        FORGEJO_ADMIN_TOKEN: 'tok-test',
+        FORGEJO_WEBHOOK_SECRET: 'sec-test',
+        APPS_DOMAIN: 'civit.ai',
+        FORGEJO_API_TIMEOUT_MS: 9000,
+        FORGEJO_COMMIT_TIMEOUT_MS: 300000,
+      },
+    }));
+    const { commitFiles } = await import('../forgejo.service');
+    fm.enqueue({ commit: { id: 'commit_sha' } });
+    fm.enqueue({ tree: [], truncated: false });
+    fm.enqueue({ commit: { sha: 'new_commit_sha' } });
+
+    await commitFiles({
+      slug: 'gen-matrix',
+      files: [{ path: 'a.txt', content: Buffer.from('hi') }],
+      message: 'msg',
+    });
+
+    const treeIdx = fm.calls.findIndex((c) => c.url.includes('/git/trees/'));
+    const commitIdx = fm.calls.findIndex((c) => c.url.endsWith('/contents'));
+    expect(timeouts[treeIdx]).toBe(9000);
+    expect(timeouts[commitIdx]).toBe(300000);
+
+    vi.doUnmock('~/env/server');
+    vi.resetModules();
   });
 });

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -68,14 +68,32 @@ function buildHeaders(): HeadersInit {
   };
 }
 
-async function fjFetch(path: string, init?: RequestInit): Promise<Response> {
+/** Default client-side abort for cheap Forgejo metadata calls. Forgejo API
+ *  calls should be sub-second; anything longer indicates an in-cluster
+ *  reachability problem worth surfacing fast. Tunable via FORGEJO_API_TIMEOUT_MS. */
+function apiTimeoutMs(): number {
+  return env.FORGEJO_API_TIMEOUT_MS;
+}
+
+/** Generous client-side abort for the bundle COMMIT/PUSH path (first-time
+ *  review-repo create + a single multi-file commit of every bundle file). A
+ *  real app (gen-matrix = ~888 files) genuinely takes longer than the cheap
+ *  metadata calls; the old 15s ceiling aborted real submits. Tunable via
+ *  FORGEJO_COMMIT_TIMEOUT_MS. */
+function commitTimeoutMs(): number {
+  return env.FORGEJO_COMMIT_TIMEOUT_MS;
+}
+
+async function fjFetch(
+  path: string,
+  init?: RequestInit,
+  timeoutMs: number = apiTimeoutMs()
+): Promise<Response> {
   const url = `${getBaseUrl()}${path}`;
-  // 15s — Forgejo API calls should be sub-second; anything longer indicates
-  // an in-cluster reachability problem worth surfacing fast.
   const res = await fetch(url, {
     ...init,
     headers: { ...buildHeaders(), ...(init?.headers ?? {}) },
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   return res;
 }
@@ -132,7 +150,15 @@ export async function createRepoFromTemplate(opts: {
     delete body.auto_init;
   }
 
-  const res = await fjFetch(endpoint, { method: 'POST', body: JSON.stringify(body) });
+  // Repo creation (template `generate` clones the starter repo; `auto_init`
+  // materialises an initial commit) is the slow first-time op on the approve
+  // path, so give it the generous commit timeout rather than the cheap-call
+  // ceiling. The idempotent 409/422 → getRepo lookup stays a cheap call.
+  const res = await fjFetch(
+    endpoint,
+    { method: 'POST', body: JSON.stringify(body) },
+    commitTimeoutMs()
+  );
   if (res.status === 409 || res.status === 422) {
     // Already exists — fetch and return.
     return getRepo(opts.slug);
@@ -214,7 +240,7 @@ export async function getRawFile(opts: {
   const url = `${getBaseUrl()}/${FORGEJO_ORG}/${opts.slug}/raw/commit/${opts.ref}/${opts.path}`;
   const res = await fetch(url, {
     headers: { Authorization: `token ${getAdminToken()}` },
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(apiTimeoutMs()),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
@@ -395,14 +421,22 @@ export async function commitFiles(opts: {
     return { sha: branchInfo.commit.id };
   }
 
-  const res = await fjFetch(`/api/v1/repos/${org}/${opts.slug}/contents`, {
-    method: 'POST',
-    body: JSON.stringify({
-      files: operations,
-      message: opts.message,
-      branch,
-    }),
-  });
+  // The multi-file commit is the genuinely slow Forgejo call — a real bundle
+  // (gen-matrix = ~888 files) takes well over the cheap-call ceiling, so give
+  // it the generous commit timeout instead of letting AbortSignal kill the
+  // push mid-flight ("The operation was aborted due to timeout").
+  const res = await fjFetch(
+    `/api/v1/repos/${org}/${opts.slug}/contents`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        files: operations,
+        message: opts.message,
+        branch,
+      }),
+    },
+    commitTimeoutMs()
+  );
   const result = await unwrap<{ commit: { sha: string } }>(res);
   return { sha: result.commit.sha };
 }
@@ -523,7 +557,7 @@ export async function mintForgejoUserToken(opts: {
       Accept: 'application/json',
     },
     body: JSON.stringify({ name: opts.name, scopes: opts.scopes }),
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(apiTimeoutMs()),
   });
   const token = await unwrap<{ sha1: string }>(res);
   if (!token?.sha1) {
@@ -571,16 +605,24 @@ export async function ensureReviewRepo(slug: string): Promise<void> {
   // Forgejo login session (Forgejo's own login form is currently
   // throwing CSRF errors for moderator browsing flows — orthogonal
   // issue, tracked separately).
-  const repoRes = await fjFetch(`/api/v1/orgs/${FORGEJO_REVIEW_ORG}/repos`, {
-    method: 'POST',
-    body: JSON.stringify({
-      name: slug,
-      description: `Pending publish-request bundle for ${slug}.`,
-      private: false,
-      auto_init: true,
-      default_branch: 'main',
-    }),
-  });
+  // auto_init:true makes Forgejo materialise a real git repo on disk, which on
+  // first submit is the slow part of the review-repo path (it shares the same
+  // worst-case as the bundle commit). Use the generous commit timeout so a
+  // cold first-time create doesn't abort before the repo is ready.
+  const repoRes = await fjFetch(
+    `/api/v1/orgs/${FORGEJO_REVIEW_ORG}/repos`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        name: slug,
+        description: `Pending publish-request bundle for ${slug}.`,
+        private: false,
+        auto_init: true,
+        default_branch: 'main',
+      }),
+    },
+    commitTimeoutMs()
+  );
   if (!repoRes.ok && repoRes.status !== 409 && repoRes.status !== 422) {
     const body = await repoRes.text().catch(() => '');
     throw new Error(`Forgejo review repo create ${repoRes.status}: ${body.slice(0, 240)}`);


### PR DESCRIPTION
## The bug (verified in prod)

`civitai app submit` (and the web upload) for a real app returned:

> `400: could not push bundle to review repo: The operation was aborted due to timeout`

Reproduced with **gen-matrix** (~888 files). Root cause: every Forgejo API `fetch` in `src/server/services/blocks/forgejo.service.ts` was wrapped in a hardcoded `AbortSignal.timeout(15_000)`. The bundle **COMMIT/PUSH** operation — first-time review-repo create (`auto_init`) + a single multi-file commit of every bundle file — genuinely takes longer than 15s for a real app, so it aborted **client-side**. Forgejo itself is healthy; the 15s client ceiling was the bug.

## The fix

Split the single hardcoded timeout into two configurable env vars and **scope the bump to the slow commit/push operations only** (don't blanket-raise latency-sensitive metadata calls):

| Env var | Default | Applied to |
|---|---|---|
| `FORGEJO_COMMIT_TIMEOUT_MS` | **120000 (120s)** | the multi-file commit `POST .../contents` in `commitFiles`; the `auto_init` review-repo create in `ensureReviewRepo`; the repo create/`generate` in `createRepoFromTemplate` (approve path) |
| `FORGEJO_API_TIMEOUT_MS` | **15000 (15s)** | every cheap metadata call — get repo/version, add collaborator, list tree, branch lookup, webhook, commit status, user provisioning, token mint |

**Why the cheap calls were left at 15s:** they're sub-second; a longer ceiling there would just mask an in-cluster reachability problem that's worth surfacing fast. Only the genuinely slow first-time-create / large-multi-file-commit operations get the generous timeout.

No change to Forgejo auth, request body format, or the publish flow — only the client-side abort timeout on the slow operations. Both vars use `z.coerce.number().default(...)` in `src/env/server-schema.ts`, matching the existing `*_TIMEOUT_MS` pattern.

## Tests

Extended `src/server/services/blocks/__tests__/forgejo.service.test.ts` (mock `fetch` + spy on `AbortSignal.timeout`):
- `commitFiles` — the `/contents` POST uses **120s**; the tree/branch reads keep **15s**
- `ensureReviewRepo` — the `auto_init` repo-create POST uses **120s**; the org-create keeps **15s**
- `createRepoFromTemplate` — the repo-create POST uses **120s**
- the cheap calls (`getRepo`, `addCollaborator`, `setCommitStatus`) keep **15s**
- an env-override test proving the values are config-driven (not hardcoded)

Results:
- `forgejo.service.test.ts`: **21/21 pass** (was 16 pre-existing + 5 new timeout-routing tests)
- `publish-request.orchestration.test.ts` + `publish-request.service.test.ts` (both import forgejo.service): **108/108 pass**
- `tsc --noEmit`: **no errors in changed files** (repo has a known pre-existing tsc baseline; nothing forgejo-related)

## Deploy note

This needs to ship to **dp-prod** (release → Tekton → Flagger) before a large submit will actually succeed in production. Until then a large-bundle submit will keep hitting the 15s abort.