### PR TITLE
fix(test): re-apply provider wrapper on rerender in renderWithProviders

### DIFF
--- a/test/component-setup.tsx
+++ b/test/component-setup.tsx
@@ -65,7 +65,17 @@ function Providers({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Render a component under the standard generation-form provider stack. */
+/**
+ * Render a component under the standard generation-form provider stack.
+ *
+ * Providers are supplied via the `wrapper` option (not by manually wrapping
+ * `ui`) so the `rerender` returned by vitest-browser-react re-applies the SAME
+ * wrapper on every re-render. Manually wrapping (`render(<Providers>{ui}</…>)`)
+ * works for the initial render but `rerender(newUi)` replaces the root with the
+ * bare element — dropping MantineProvider/QueryClient and crashing any Mantine
+ * child with "MantineProvider was not found". Passing `wrapper` fixes that for
+ * every component test that drives prop changes via `rerender`.
+ */
 export function renderWithProviders(ui: React.ReactElement) {
-  return render(<Providers>{ui}</Providers>);
+  return render(ui, { wrapper: Providers });
 }


### PR DESCRIPTION
## Problem
`src/components/Login/DeviceCodeEntry.browser.test.tsx` had two failing specs:
- *a complete initialCode auto-submits once on mount, not per render*
- *does not re-fire while a submit is in flight (loading)*

Both failed with `@mantine/core: MantineProvider was not found in component tree`. The other 10 specs in the file passed.

## Root cause (scaffold gap, not the component or the test)
The two failing specs are exactly the ones that call `rerender(...)`. `renderWithProviders` wrapped the unit in `<Providers>` **manually** and passed the wrapped element to `render()`. vitest-browser-react's `rerender(newUi)` replaces the root with the **bare** new element, so the manually-applied providers (MantineProvider + React-Query) are dropped on rerender — any Mantine child then crashes.

This is a general gap that affects every component test driving prop changes via `rerender`, not just DeviceCodeEntry.

## Fix
Pass `Providers` via render's `wrapper` option instead of manually wrapping. The returned `rerender` re-applies the same wrapper on every re-render. Initial-render behavior is unchanged.

## Verification
- All 12 `DeviceCodeEntry` specs pass (the asserted auto-submit-once-on-mount + no-re-fire-while-loading behaviors are now genuinely exercised).
- Spot-checked `AppBlockChrome` + `SeedInput` browser tests — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)