### PR TITLE
🚧 App Blocks GA activation (reward visible + /apps indexable) — merge only at GA

### DIFF
--- a/src/components/Apps/resolveAppsPageAccess.ts
+++ b/src/components/Apps/resolveAppsPageAccess.ts
@@ -13,8 +13,9 @@
  *     flag gate, a session-less request RENDERS the marketplace read-only
  *     instead of bouncing to /login. This is the "anon-capable but dark" read
  *     path — reachable by a real anon user ONLY once the flag grants access
- *     (mods-only today). (`deIndex` is kept ON in the page <Meta> so the page is
- *     not crawlable pre-launch.)
+ *     (mods-only today). (As of App Blocks GA the public catalog + per-app detail
+ *     pages are INDEXABLE — `deIndex` was dropped from their <Meta>; per-USER
+ *     pages like /apps/installed and /apps/revenue stay deIndexed.)
  */
 export type AppsPageAccessResult = { notFound: true } | { props: Record<string, never> };
 

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -57,9 +57,9 @@ import { trpc } from '~/utils/trpc';
  *     `notFound`. The page is anon-CAPABLE in code (no session→login redirect)
  *     but DARK until the segment is widened at launch — there is intentionally
  *     NO hardcoded isModerator belt (that would break the eventual public flip).
- *   - `deIndex` stays ON in the page <Meta> (per-app OG/title/description are
- *     added now, but the page is not crawlable pre-launch — drop `deIndex` only
- *     at launch).
+ *   - INDEXABLE as of App Blocks GA: `deIndex` was dropped from the page <Meta>
+ *     (the per-app OG/title/description from the public manifest are now crawlable).
+ *     The per-app /apps/<appBlockId>/revenue page stays deIndexed (owner-only).
  *   - The `getAppDetail` query is the anon-capable public read path; it is gated
  *     by the SAME mod-segmented flag server-side (dark today) and returns ONLY
  *     the PublicAppDetail allowlist.
@@ -162,14 +162,15 @@ export default function AppDetailPage() {
   return (
     <>
       {/*
-        Per-app OG/meta (title + description from the public manifest). deIndex
-        STAYS ON until launch (the page is mod-only today; don't let crawlers
-        index it). Dropping deIndex is a deliberate launch-time step.
+        Per-app OG/meta (title + description from the public manifest). INDEXABLE
+        as of App Blocks GA — `deIndex` was dropped at launch so the public per-app
+        detail page is crawlable. Merges in lockstep with the Flipt `appBlocks`
+        mod→public widen (do not ship before GA).
       */}
       <Meta
         title={`${name} — Civitai Apps`}
         description={description || `${name} on the Civitai App Blocks marketplace.`}
-        deIndex
+        canonical={`/apps/${appBlockId}`}
       />
       <Container size="md" py="md">
         <Stack gap="lg">

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -68,7 +68,8 @@ export const getServerSideProps = createServerSideProps({
   // GATING INVARIANT (F-E E1): the flag gate is the ONLY access control; no
   // session→login redirect, so the marketplace renders for a session-less
   // request BEHIND the flag (dark today; lit when the segment widens). See
-  // resolveAppsPageAccess for the full invariant + `deIndex` note.
+  // resolveAppsPageAccess for the full invariant. (The catalog page is INDEXABLE
+  // as of GA — `deIndex` was dropped from the <Meta> below.)
   resolver: async ({ features }) => resolveAppsPageAccess({ features }),
 });
 
@@ -216,7 +217,17 @@ export default function AppsPage() {
 
   return (
     <>
-      <Meta title="Apps — Civitai" description="Civitai App Blocks marketplace" deIndex />
+      {/*
+        Public marketplace catalog — INDEXABLE as of App Blocks GA. `deIndex` was
+        dropped at launch (the page is the public app catalog; per-USER pages
+        like /apps/installed and /apps/revenue stay deIndexed). Merges in lockstep
+        with the Flipt `appBlocks` mod→public widen — do not ship before GA.
+      */}
+      <Meta
+        title="Apps — Civitai"
+        description="Civitai App Blocks marketplace"
+        canonical="/apps"
+      />
       <Container size="xl" py="md">
         <Stack gap="md">
           <Group justify="space-between" align="flex-start">

--- a/src/server/rewards/__tests__/appBlockReview.reward.test.ts
+++ b/src/server/rewards/__tests__/appBlockReview.reward.test.ts
@@ -70,6 +70,14 @@ beforeEach(() => {
 });
 
 describe('appBlockReviewReward', () => {
+  // GA ACTIVATION: the reward is surfaced on the Buzz dashboard at launch
+  // (user.controller.ts filters the reward list by `.visible`). It was `false`
+  // while App Blocks was dark/mod-gated (PR #2675); this pins the GA flip so an
+  // accidental revert to hidden is caught.
+  it('is visible on the Buzz dashboard (GA activation)', () => {
+    expect(appBlockReviewReward.visible).toBe(true);
+  });
+
   it('fires once on the create branch: blue account, forId=appBlockId, correct user', async () => {
     await appBlockReviewReward.apply(
       { appBlockId: 'ab_42', userId: 7, isFirstReview: true },

--- a/src/server/rewards/active/appBlockReview.reward.ts
+++ b/src/server/rewards/active/appBlockReview.reward.ts
@@ -44,12 +44,12 @@ export const appBlockReviewReward = createBuzzEvent({
   toAccountType: 'blue',
   description: 'You left a review on an app',
   triggerDescription: 'For each app you review for the first time',
-  // HIDDEN from the Buzz-dashboard reward list until App Blocks GA. App Blocks
-  // are still dark/mod-gated, so advertising this reward to everyone leaks the
-  // unreleased feature. The reward still FIRES for the few mod testers who can
-  // review — it's just not listed (user.controller.ts filters the dashboard by
-  // `.visible`). Flip to true (or remove) at App Blocks launch.
-  visible: false,
+  // VISIBLE in the Buzz-dashboard reward list as of App Blocks GA. While the
+  // feature was dark/mod-gated this was `false` (PR #2675) so the reward wasn't
+  // advertised to everyone; at GA we surface it (user.controller.ts filters the
+  // dashboard by `.visible`). This must land in lockstep with the Flipt
+  // `appBlocks` mod→public widen — do not merge before GA.
+  visible: true,
   awardAmount: REVIEW_AWARD,
   // Daily ceiling, NOT a per-app cap. The per-(user, app) once-ever guarantee is
   // the DB-unique + isFirstReview belt; same-app same-day is the Redis forId


### PR DESCRIPTION
> # 🚧 App Blocks GA
> **Merge this ONLY at the coordinated GA moment — in lockstep with widening the Flipt `appBlocks` mod→public flag.** Merging early **leaks the dark/mod-gated App Blocks feature** to the public (advertises a reward + lets search engines index the marketplace before launch). Held as a **DRAFT** for exactly this reason.

## What this does

Two GA-activation flips that light up user-facing App Blocks surfaces. Code-only; no migration, no infra change.

### 1. `appBlockReview` blue-buzz reward → visible on the Buzz dashboard
`src/server/rewards/active/appBlockReview.reward.ts`: `visible: false` → `visible: true`.

The reward ("You left a review on an app", 25 blue buzz per first-time app review) was hidden from everyone's Buzz-dashboard reward list pre-GA (added `false` in PR #2675) so the dark feature wasn't advertised. `user.controller.ts` filters the reward list by `.visible`. At GA we surface it to advertise the reward. The reward firing behavior is unchanged — only its dashboard listing. Pinned by a new test (`appBlockReview.reward.test.ts`).

### 2. Drop `deIndex` (noindex,nofollow) on the **public** App Blocks pages
The marketplace catalog + per-app detail pages should be crawlable at GA. Removed `deIndex` from their `<Meta>` (and added a `canonical` URL, which the `Meta` type requires when `deIndex` is absent — also correct SEO hygiene for an indexable page).

**Made INDEXABLE (deIndex dropped):**

| Route | File | Why |
|---|---|---|
| `/apps` | `src/pages/apps/index.tsx` | Public marketplace catalog listing (approved apps, public field allowlist) |
| `/apps/[appBlockId]` | `src/pages/apps/[appBlockId]/index.tsx` | Public per-app detail (OG/title/description from the public manifest) |

**Intentionally LEFT `deIndex`ed** (per-user / owner-only / operational — should not be in search results):

| Route | File | Why it stays noindex |
|---|---|---|
| `/apps/installed` | `installed.tsx` | Per-user installed-apps list |
| `/apps/revenue` | `revenue.tsx` | Per-user / dashboard revenue |
| `/apps/[appBlockId]/revenue` | `[appBlockId]/revenue.tsx` | Owner-only per-app revenue |
| `/apps/my-submissions` | `my-submissions.tsx` | Per-user submissions |
| `/apps/submit` | `submit.tsx` | App-submission form (no catalog value) |
| `/apps/review` | `review.tsx` | Mod publish-request queue (operational) |
| `/apps/run/[slug]/...` | `run/[slug]/[[...path]].tsx` | Per-app execution/iframe host surface, not a catalog page |

Comments in `resolveAppsPageAccess.ts` + both page headers were updated so the "kept deIndex pre-launch" notes don't go stale. The SSR gating invariant is **unchanged** — `features.appBlocks` (the Flipt mod segment) is still the only access control; these pages still 404 for non-mod/anon users until the flag is widened.

## Coordination
This PR merges **in lockstep with the Flipt `appBlocks` mod→public flag widen**. The flag widen makes the pages reachable; this PR makes them indexable + advertises the reward. Do both at the GA moment; neither alone.

## Verification
- `tsc --noEmit`: no errors in any changed file (repo has a large pre-existing baseline; my 5 files are clean — including the `canonical`-required-without-`deIndex` `Meta` type constraint).
- `appBlockReview.reward.test.ts`: 8/8 pass (incl. the new `visible === true` GA-flip assertion).
- `resolveAppsPageAccess.test.ts`: 6/6 pass (comment-only change, gating logic untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
