### PR TITLE
feat(cpu-profiler): auto-trigger CPU profile on event-loop stall (beats the SIGWINCH black-hole)

### DIFF
--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -14,7 +14,7 @@ import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs
 import { logs } from '@opentelemetry/api-logs';
 import { trace } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import { registerCpuProfiler } from '~/server/cpu-profiler';
+import { registerCpuProfiler, registerEventLoopStallProfiler } from '~/server/cpu-profiler';
 import { registerEventLoopLongTaskDetector } from '~/server/eventloop-longtask';
 import { registerLivenessHeartbeat } from '~/server/liveness-heartbeat';
 
@@ -22,6 +22,15 @@ import { registerLivenessHeartbeat } from '~/server/liveness-heartbeat';
 // overhead; only does work when signalled. Independent of OTEL so it is
 // always available for live incident capture. See src/server/cpu-profiler.ts.
 registerCpuProfiler();
+
+// Arm the event-loop-stall SELF-TRIGGER for the same CPU profiler. An external
+// signal can't reach a fully-pinned loop (the SIGWINCH black-hole), so this
+// watches the pod's OWN event-loop lag and auto-arms V8's (separate-thread)
+// sampler when lag crosses a threshold — the one mechanism that captures a 504
+// wave's pin. DISARMED by default (no timer, no histogram, zero overhead) unless
+// CPU_PROFILE_LAG_TRIGGER_MS is set (suggested: 1000) on the dp-prod-api
+// deployment. See src/server/cpu-profiler.ts.
+registerEventLoopStallProfiler();
 
 // Arm the event-loop long-task detector. DISARMED by default (no-op unless
 // EVENTLOOP_LONGTASK_THRESHOLD_MS > 0), in which case the request hot path runs

--- a/src/server/__tests__/cpu-profiler-lag-trigger.test.ts
+++ b/src/server/__tests__/cpu-profiler-lag-trigger.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+
+import { shouldTriggerLagCapture } from '~/server/cpu-profiler';
+
+// These tests exercise the PURE trigger-decision function in isolation. The
+// actual capture needs a real node:inspector Session (separate-thread V8
+// sampler), so we never profile for real here — the watchdog timer's only
+// non-trivial logic (given a max-lag reading + env config + cooldown/in-progress
+// state, should we fire?) is factored into shouldTriggerLagCapture and tested
+// directly. We do NOT test perf_hooks/monitorEventLoopDelay internals.
+
+describe('cpu-profiler: shouldTriggerLagCapture (lag self-trigger decision)', () => {
+  // A sane armed baseline; individual tests override one field at a time.
+  const base = {
+    maxLagMs: 1500,
+    triggerMs: 1000,
+    capturing: false,
+    nowMs: 100_000,
+    cooldownUntilMs: 0,
+  };
+
+  it('triggers when lag is at or above the threshold (and otherwise clear)', () => {
+    expect(shouldTriggerLagCapture(base)).toBe(true);
+    // Exactly at threshold is inclusive.
+    expect(shouldTriggerLagCapture({ ...base, maxLagMs: 1000 })).toBe(true);
+  });
+
+  it('does NOT trigger when lag is below the threshold', () => {
+    expect(shouldTriggerLagCapture({ ...base, maxLagMs: 999 })).toBe(false);
+    expect(shouldTriggerLagCapture({ ...base, maxLagMs: 0 })).toBe(false);
+  });
+
+  it('does NOT trigger when disabled (triggerMs <= 0), even with huge lag', () => {
+    expect(shouldTriggerLagCapture({ ...base, triggerMs: 0, maxLagMs: 100_000 })).toBe(false);
+    expect(shouldTriggerLagCapture({ ...base, triggerMs: -1, maxLagMs: 100_000 })).toBe(false);
+  });
+
+  it('does NOT trigger while a capture is already in progress (in-progress guard)', () => {
+    // This is the guard shared with the SIGWINCH path: signal and auto-trigger
+    // must never overlap.
+    expect(shouldTriggerLagCapture({ ...base, capturing: true })).toBe(false);
+  });
+
+  it('does NOT trigger inside the post-capture cooldown window', () => {
+    // now=100000 < cooldownUntil=160000 → suppressed even though lag is high.
+    expect(shouldTriggerLagCapture({ ...base, cooldownUntilMs: 160_000 })).toBe(false);
+  });
+
+  it('triggers again once the cooldown window has elapsed', () => {
+    // now == cooldownUntil → cooldown has elapsed (boundary is inclusive: not <).
+    expect(shouldTriggerLagCapture({ ...base, nowMs: 160_000, cooldownUntilMs: 160_000 })).toBe(
+      true
+    );
+    // now just past the window.
+    expect(shouldTriggerLagCapture({ ...base, nowMs: 160_001, cooldownUntilMs: 160_000 })).toBe(
+      true
+    );
+  });
+
+  it('the in-progress guard takes precedence over an otherwise-fireable reading', () => {
+    expect(
+      shouldTriggerLagCapture({ ...base, maxLagMs: 50_000, capturing: true, cooldownUntilMs: 0 })
+    ).toBe(false);
+  });
+});

--- a/src/server/__tests__/cpu-profiler-lag-trigger.test.ts
+++ b/src/server/__tests__/cpu-profiler-lag-trigger.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 
-import { shouldTriggerLagCapture } from '~/server/cpu-profiler';
+import { shouldTriggerLagCapture, resolveMaxProfileFiles } from '~/server/cpu-profiler';
 
 // These tests exercise the PURE trigger-decision function in isolation. The
 // actual capture needs a real node:inspector Session (separate-thread V8
@@ -61,5 +61,30 @@ describe('cpu-profiler: shouldTriggerLagCapture (lag self-trigger decision)', ()
     expect(
       shouldTriggerLagCapture({ ...base, maxLagMs: 50_000, capturing: true, cooldownUntilMs: 0 })
     ).toBe(false);
+  });
+});
+
+describe('cpu-profiler: resolveMaxProfileFiles (disk-bound guard config)', () => {
+  const prev = process.env.CPU_PROFILE_MAX_FILES;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.CPU_PROFILE_MAX_FILES;
+    else process.env.CPU_PROFILE_MAX_FILES = prev;
+  });
+
+  it('defaults to 12 when unset', () => {
+    delete process.env.CPU_PROFILE_MAX_FILES;
+    expect(resolveMaxProfileFiles()).toBe(12);
+  });
+
+  it('honors a positive override', () => {
+    process.env.CPU_PROFILE_MAX_FILES = '5';
+    expect(resolveMaxProfileFiles()).toBe(5);
+  });
+
+  it('falls back to the default on invalid / non-positive values', () => {
+    for (const bad of ['0', '-3', 'nope', '']) {
+      process.env.CPU_PROFILE_MAX_FILES = bad;
+      expect(resolveMaxProfileFiles()).toBe(12);
+    }
   });
 });

--- a/src/server/cpu-profiler.ts
+++ b/src/server/cpu-profiler.ts
@@ -1,7 +1,8 @@
-// On-demand V8 CPU profiler, triggered by a process signal.
+// On-demand V8 CPU profiler — triggered by a process signal OR self-armed by
+// the app's own rising event-loop lag.
 //
 // WHY: civitai-dp-prod API pods periodically CPU-saturate the single Node
-// thread (p95 pod CPU = 1.0 core) during traffic waves, starving the event
+// thread (p95 pod CPU = 1.0 core) during traffic "504 waves", starving the event
 // loop until liveness probes fail and the pod is SIGKILLed. The CPU consumer
 // is not visible in any instrumented span. A real V8 CPU profile from a
 // saturated pod is the only way to see which JS functions burn the CPU.
@@ -20,9 +21,25 @@
 // server process that Kubernetes never sends — and the signal is overridable
 // via CPU_PROFILE_SIGNAL for operators who know what they are doing.
 //
-// Server-side (nodejs runtime) only. Never imported on the edge/client.
+// THE SIGWINCH BLACK-HOLE (why we ALSO need a self-trigger): an EXTERNAL signal
+// cannot be delivered to JS while the loop is fully pinned. SIGWINCH-on-pin
+// reliably FAILS: the pegged loop never runs the handler (so 0 profiles), or by
+// the time the handler runs the pod has already recovered (so only idle
+// profiles). Proven empirically 2026-06-22. The fix below is an INTERNALLY-ARMED
+// self-trigger: a lag watchdog starts the profiler the moment the app detects
+// its OWN event-loop lag rising. Once `Profiler.start` is issued, V8's sampling
+// runs on a SEPARATE thread and keeps sampling the pinned main thread even while
+// JS blocks; the profile is written on recovery. That separate-thread sampling is
+// the one mechanism that beats the black-hole. See registerEventLoopStallProfiler.
+//
+// Server-side (nodejs runtime) only. Never imported on the edge/client. It
+// pulls in node:inspector and node:perf_hooks — both server-only natives that
+// MUST NEVER reach the client bundle. The single import site is
+// src/instrumentation.node.ts (nodejs runtime). Do not import this file from any
+// client-reachable module.
 
 import inspector from 'node:inspector';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
 import { writeFile } from 'node:fs/promises';
 import { hostname } from 'node:os';
 import path from 'node:path';
@@ -31,6 +48,27 @@ const DEFAULT_SIGNAL = 'SIGWINCH';
 const DEFAULT_DURATION_SECONDS = 25;
 const MAX_DURATION_SECONDS = 120;
 const DEFAULT_OUTPUT_DIR = '/tmp';
+
+// --- Event-loop stall self-trigger (default OFF) --------------------------
+// The watchdog is DISARMED unless CPU_PROFILE_LAG_TRIGGER_MS is set to a
+// positive number. When unset/0/invalid the watchdog is never installed → zero
+// steady-state overhead (no extra timer, no histogram). When armed it adds one
+// unref'd setInterval + a libuv-internal lag histogram (C++-measured, no
+// per-event JS cost).
+//
+// Suggested production value: 1000 (a 1s+ event-loop stall). Normal lag is
+// <50ms; a 1s stall already means the pod is well into a pin. Lower the trigger
+// to catch the rising edge of a wave earlier (see the mechanism note on
+// registerEventLoopStallProfiler).
+const DEFAULT_LAG_CHECK_MS = 500;
+const MIN_LAG_CHECK_MS = 50;
+// Floor on the trigger threshold so a fat-fingered tiny value (e.g. 5) doesn't
+// arm a profile on every ordinary GC pause / normal lag spike.
+const MIN_LAG_TRIGGER_MS = 100;
+const DEFAULT_LAG_COOLDOWN_MS = 60_000;
+// monitorEventLoopDelay sampling resolution (ms). 20ms is fine-grained enough to
+// see a building stall without measurable cost.
+const LAG_HISTOGRAM_RESOLUTION_MS = 20;
 
 // Known Node.js signal names that can be the target of a userland process.on
 // listener. A bogus CPU_PROFILE_SIGNAL must not throw ERR_UNKNOWN_SIGNAL at
@@ -94,6 +132,34 @@ function resolveOutputDir(): string {
   return (process.env.CPU_PROFILE_DIR || DEFAULT_OUTPUT_DIR).trim();
 }
 
+/**
+ * Resolve the event-loop-stall trigger threshold in ms. The watchdog is the
+ * thing that beats the SIGWINCH black-hole, but it stays DISARMED unless this is
+ * an explicit positive number — so it is zero-overhead by default. Unset / 0 /
+ * non-numeric → 0 (do not arm). A positive value below MIN_LAG_TRIGGER_MS is
+ * clamped UP to the floor (don't throw) so a fat-fingered tiny value can't
+ * profile on every ordinary lag spike.
+ */
+function resolveLagTriggerMs(): number {
+  const raw = process.env.CPU_PROFILE_LAG_TRIGGER_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.max(parsed, MIN_LAG_TRIGGER_MS);
+}
+
+/** How often the watchdog reads + resets the lag histogram. Clamped to a floor. */
+function resolveLagCheckMs(): number {
+  const parsed = Number.parseInt(process.env.CPU_PROFILE_LAG_CHECK_MS ?? '', 10);
+  const ms = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LAG_CHECK_MS;
+  return Math.max(ms, MIN_LAG_CHECK_MS);
+}
+
+/** Suppress re-triggering for this long after a capture completes. */
+function resolveLagCooldownMs(): number {
+  const parsed = Number.parseInt(process.env.CPU_PROFILE_LAG_COOLDOWN_MS ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_LAG_COOLDOWN_MS;
+}
+
 function delay(ms: number): { promise: Promise<void>; timer: NodeJS.Timeout } {
   let timer!: NodeJS.Timeout;
   const promise = new Promise<void>((resolve) => {
@@ -107,17 +173,60 @@ function delay(ms: number): { promise: Promise<void>; timer: NodeJS.Timeout } {
   return { promise, timer };
 }
 
+// ---------------------------------------------------------------------------
+// Lag-trigger decision (pure, unit-testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure decision: given a max-lag reading + the resolved config + the current
+ * capture/cooldown state, should the watchdog fire an auto-capture right now?
+ *
+ * Factored out of the timer so the trigger logic is testable WITHOUT a real
+ * inspector, real timers, or perf_hooks. The watchdog timer simply reads the
+ * libuv histogram's `max`, converts ns→ms, and feeds it here.
+ *
+ * Order of the gates matters for clarity but not correctness (all must pass):
+ *   - triggerMs <= 0          → watchdog disabled (defensive; we don't install
+ *                               the timer at all when disabled, but keep the
+ *                               guard so the function is self-contained).
+ *   - capturing               → a capture (signal OR a prior auto-fire) is in
+ *                               flight; never overlap (mirrors the SIGWINCH guard).
+ *   - now < cooldownUntil     → inside the post-capture cooldown; a sustained
+ *                               wave must not back-to-back profile.
+ *   - maxLagMs < triggerMs    → lag below threshold; nothing to capture.
+ */
+export function shouldTriggerLagCapture(args: {
+  maxLagMs: number;
+  triggerMs: number;
+  capturing: boolean;
+  nowMs: number;
+  cooldownUntilMs: number;
+}): boolean {
+  const { maxLagMs, triggerMs, capturing, nowMs, cooldownUntilMs } = args;
+  if (triggerMs <= 0) return false;
+  if (capturing) return false;
+  if (nowMs < cooldownUntilMs) return false;
+  return maxLagMs >= triggerMs;
+}
+
 /**
  * Run a single CPU profile capture using an in-process inspector Session.
  * Resolves once the .cpuprofile has been written (or rejects on failure).
  * Does NOT need the inspector port (:9229) to be open.
+ *
+ * @param labelSegment optional filename segment that distinguishes the trigger
+ *   source. The signal path passes nothing → `cpu-<pod>-<iso>.cpuprofile`. The
+ *   lag watchdog passes `loopstall-<lagMs>ms` → `cpu-loopstall-<lagMs>ms-<pod>-
+ *   <iso>.cpuprofile`, so operators can tell auto-captures apart and read the
+ *   trigger lag straight off the filename.
  */
-async function captureProfile(): Promise<string> {
+async function captureProfile(labelSegment?: string): Promise<string> {
   const durationMs = resolveDurationMs();
   const outputDir = resolveOutputDir();
   const pod = resolvePodName();
   const iso = new Date().toISOString().replace(/[:.]/g, '-');
-  const filePath = path.join(outputDir, `cpu-${pod}-${iso}.cpuprofile`);
+  const prefix = labelSegment ? `cpu-${labelSegment}-` : 'cpu-';
+  const filePath = path.join(outputDir, `${prefix}${pod}-${iso}.cpuprofile`);
 
   const session = new inspector.Session();
   // Track whether we actually wrote a profile so an interrupted capture
@@ -242,4 +351,128 @@ export function registerCpuProfiler(): void {
   } catch (err) {
     console.error('[cpu-profiler] failed to arm; continuing without CPU profiler:', err);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Event-loop stall self-trigger watchdog
+// ---------------------------------------------------------------------------
+
+// End-of-cooldown timestamp (epoch ms). Until `Date.now()` passes this, a
+// completed auto-capture suppresses re-triggering so a sustained wave doesn't
+// back-to-back profile. Shared with the watchdog timer below.
+let lagCooldownUntil = 0;
+
+/**
+ * Register the event-loop-stall self-trigger watchdog.
+ *
+ * THE MECHANISM (and why it beats the SIGWINCH black-hole — see the file header):
+ * an external signal can't be delivered to a pinned loop, but the app can watch
+ * its OWN lag and arm V8's profiler before/while it pins. We enable a
+ * `monitorEventLoopDelay` histogram (libuv-internal, C++-measured — no per-event
+ * JS cost) and read its `max` every CPU_PROFILE_LAG_CHECK_MS. When max lag crosses
+ * the threshold we call the SAME captureProfile() the signal path uses, under the
+ * SAME `capturing` guard, so the two trigger sources never overlap.
+ *
+ * SUSTAINED-WAVE NUANCE: if the loop is ALREADY fully pinned, the check timer
+ * itself can't fire mid-block — but `monitorEventLoopDelay` ACCUMULATES the max
+ * across blocks, so the check fires right AFTER a block ends and reads the high
+ * max → starts the profiler → which then samples SUBSEQUENT bursts of the same
+ * wave on its separate thread. The 504 waves last minutes / recur in bursts, so a
+ * capture armed one block late still lands squarely on the pin we care about.
+ * Lowering CPU_PROFILE_LAG_TRIGGER_MS catches the rising edge earlier (more lead
+ * time before a full peg) at the cost of more false-positive captures.
+ *
+ * DEFAULT OFF: no-op (nothing installed, zero overhead) unless
+ * CPU_PROFILE_LAG_TRIGGER_MS is a positive number. Like registerCpuProfiler, an
+ * arm-time failure must never reject the caller (OTEL register()), so the whole
+ * body is wrapped.
+ */
+export function registerEventLoopStallProfiler(): void {
+  try {
+    if (process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME !== 'nodejs') {
+      return;
+    }
+
+    const triggerMs = resolveLagTriggerMs();
+    if (triggerMs <= 0) {
+      // DISARMED (the default). Nothing installed — no timer, no histogram.
+      return;
+    }
+
+    const checkMs = resolveLagCheckMs();
+    const cooldownMs = resolveLagCooldownMs();
+
+    // libuv-internal lag histogram. .enable() starts accumulating; we read .max
+    // (ns) and .reset() each tick so each window is independent.
+    const h = monitorEventLoopDelay({ resolution: LAG_HISTOGRAM_RESOLUTION_MS });
+    h.enable();
+
+    const timer = setInterval(() => {
+      let maxLagMs = 0;
+      try {
+        const maxNs = h.max;
+        maxLagMs = Number.isFinite(maxNs) ? maxNs / 1e6 : 0;
+        h.reset();
+      } catch {
+        // Reading/resetting the histogram must never crash the watchdog.
+        return;
+      }
+
+      if (
+        !shouldTriggerLagCapture({
+          maxLagMs,
+          triggerMs,
+          capturing,
+          nowMs: Date.now(),
+          cooldownUntilMs: lagCooldownUntil,
+        })
+      ) {
+        return;
+      }
+
+      const lagRounded = Math.round(maxLagMs);
+      console.log(
+        `[cpu-profiler] event-loop stall ${lagRounded}ms >= threshold ${triggerMs}ms — ` +
+          `starting auto-capture`
+      );
+
+      capturing = true;
+      captureProfile(`loopstall-${lagRounded}ms`)
+        .catch((err) => {
+          // A profiling failure must never crash the process.
+          console.error('[cpu-profiler] auto-capture failed:', err);
+        })
+        .finally(() => {
+          capturing = false;
+          // Start the cooldown AFTER the capture completes, so a sustained wave
+          // doesn't immediately re-fire the moment the profile is written.
+          lagCooldownUntil = Date.now() + cooldownMs;
+        });
+    }, checkMs);
+
+    // Don't keep the process alive solely for this watchdog timer (shutdown).
+    timer.unref();
+
+    console.log(
+      `[cpu-profiler] event-loop stall self-trigger armed: trigger=${triggerMs}ms ` +
+        `check=${checkMs}ms cooldown=${cooldownMs}ms (auto-captures a ` +
+        `${resolveDurationMs() / 1000}s profile to ${resolveOutputDir()} when loop lag ` +
+        `crosses the threshold; override with CPU_PROFILE_LAG_TRIGGER_MS / ` +
+        `CPU_PROFILE_LAG_CHECK_MS / CPU_PROFILE_LAG_COOLDOWN_MS)`
+    );
+  } catch (err) {
+    console.error(
+      '[cpu-profiler] failed to arm event-loop stall self-trigger; continuing without it:',
+      err
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test-only hooks (not for production use)
+// ---------------------------------------------------------------------------
+
+/** Test-only: reset the shared cooldown timestamp between cases. */
+export function __resetLagCooldownForTests(): void {
+  lagCooldownUntil = 0;
 }

--- a/src/server/cpu-profiler.ts
+++ b/src/server/cpu-profiler.ts
@@ -40,7 +40,7 @@
 
 import inspector from 'node:inspector';
 import { monitorEventLoopDelay } from 'node:perf_hooks';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, readdir } from 'node:fs/promises';
 import { hostname } from 'node:os';
 import path from 'node:path';
 
@@ -48,6 +48,10 @@ const DEFAULT_SIGNAL = 'SIGWINCH';
 const DEFAULT_DURATION_SECONDS = 25;
 const MAX_DURATION_SECONDS = 120;
 const DEFAULT_OUTPUT_DIR = '/tmp';
+// Max `.cpuprofile` files allowed in the output dir before a capture is refused
+// (bounds disk on the unrotated, heartbeat-shared writable layer). Override with
+// CPU_PROFILE_MAX_FILES.
+const DEFAULT_MAX_PROFILE_FILES = 12;
 
 // --- Event-loop stall self-trigger (default OFF) --------------------------
 // The watchdog is DISARMED unless CPU_PROFILE_LAG_TRIGGER_MS is set to a
@@ -130,6 +134,33 @@ function resolveDurationMs(): number {
 
 function resolveOutputDir(): string {
   return (process.env.CPU_PROFILE_DIR || DEFAULT_OUTPUT_DIR).trim();
+}
+
+// Disk-bound guard. The output dir (default /tmp) has no rotation and — on
+// dp-prod — is the SAME writable layer as the liveness `/tmp/heartbeat`. The
+// lag self-trigger fires UNATTENDED and repeatedly during a sustained/recurring
+// wave (~1 profile / (duration+cooldown)), each multi-MB, so without a cap a
+// long wave could fill the layer → heartbeat write fails → liveness reaps the
+// pod (the profiler becoming a CAUSE of an incident). Before each capture we
+// refuse if the dir already holds >= this many `*.cpuprofile` files; the
+// operator retrieves + deletes them out of band. Applies to BOTH the SIGWINCH
+// and lag-trigger paths.
+export function resolveMaxProfileFiles(): number {
+  const raw = process.env.CPU_PROFILE_MAX_FILES;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_PROFILE_FILES;
+}
+
+// Count existing .cpuprofile files in the output dir. Best-effort: a readdir
+// failure (missing dir, perms) must never block a capture — return 0 so we
+// proceed (the write itself will surface a real error).
+async function countExistingProfiles(outputDir: string): Promise<number> {
+  try {
+    const entries = await readdir(outputDir);
+    return entries.filter((f) => f.endsWith('.cpuprofile')).length;
+  } catch {
+    return 0;
+  }
 }
 
 /**
@@ -223,6 +254,19 @@ export function shouldTriggerLagCapture(args: {
 async function captureProfile(labelSegment?: string): Promise<string> {
   const durationMs = resolveDurationMs();
   const outputDir = resolveOutputDir();
+
+  // Disk-bound guard (protects the heartbeat-shared writable layer — see
+  // resolveMaxProfileFiles). Refuse rather than fill the disk; the operator
+  // clears retrieved profiles to re-enable capture.
+  const maxFiles = resolveMaxProfileFiles();
+  const existing = await countExistingProfiles(outputDir);
+  if (existing >= maxFiles) {
+    throw new Error(
+      `[cpu-profiler] refusing capture: ${existing} .cpuprofile file(s) already in ${outputDir} ` +
+        `(>= CPU_PROFILE_MAX_FILES=${maxFiles}). Retrieve + delete them to re-enable capture.`
+    );
+  }
+
   const pod = resolvePodName();
   const iso = new Date().toISOString().replace(/[:.]/g, '-');
   const prefix = labelSegment ? `cpu-${labelSegment}-` : 'cpu-';


### PR DESCRIPTION
## Problem — the SIGWINCH black-hole

civitai-dp-prod api-primary pods periodically CPU-saturate the single Node thread during "504 waves" (a class of expensive requests pins a pod's event loop at 98–100% → readiness probe times out → pod sheds → 504 wave). A V8 CPU profile of a *pinned* pod is the only way to name the hot code path.

The existing in-process profiler (`src/server/cpu-profiler.ts`, SIGWINCH-triggered) **cannot** capture that pin: **an external signal can't be delivered to JS while the loop is fully pegged.** SIGWINCH-on-pin reliably fails — it captures 0 profiles (pegged loop never runs the handler / never finishes the write) or only *idle* profiles (from pods that already recovered). Proven empirically 2026-06-22.

## Fix — an internally-armed self-trigger

This adds an **internally-armed self-trigger alongside** the existing SIGWINCH path (no rewrite — it reuses `captureProfile()` + the shared `capturing` guard so the two trigger sources never overlap):

- **Lag watchdog** via `perf_hooks.monitorEventLoopDelay({ resolution: 20 })` (libuv-internal, C++-measured — no per-event JS cost). An **unref'd** `setInterval` reads `h.max` (ns→ms) each tick, then `h.reset()`.
- When `maxLagMs >= CPU_PROFILE_LAG_TRIGGER_MS` it fires `captureProfile('loopstall-<lagMs>ms')`. Once `Profiler.start` is issued, **V8's sampler runs on a separate thread** and keeps sampling the pinned main thread even while JS blocks; the profile is written on recovery. That separate-thread sampling is the one mechanism that beats the black-hole.

### Sustained-wave nuance

If the loop is *already* fully pinned, the check timer can't fire mid-block — but `monitorEventLoopDelay` **accumulates the max across blocks**, so the check fires right *after* a block ends, reads the high max, and starts the profiler, which then samples **subsequent bursts of the same wave**. The 504 waves last minutes / recur in bursts, so a capture armed one block late still lands on the pin. Lowering the threshold catches the rising edge earlier (more lead time before a full peg) at the cost of more false-positive captures.

## Env vars (default OFF / zero-overhead)

The watchdog is **DISARMED by default** — nothing is installed (no timer, no histogram, zero steady-state overhead) unless `CPU_PROFILE_LAG_TRIGGER_MS` is set to a positive number.

| Env | Default | Purpose |
|---|---|---|
| `CPU_PROFILE_LAG_TRIGGER_MS` | unset (OFF) | **Enables** the watchdog. Max event-loop lag (ms) that arms an auto-capture. Suggested **1000** (a 1s+ stall; normal lag is <50ms). Clamped up to a **100ms floor** so a fat-fingered tiny value can't profile constantly. |
| `CPU_PROFILE_LAG_CHECK_MS` | 500 | How often the watchdog reads + resets the lag histogram. |
| `CPU_PROFILE_LAG_COOLDOWN_MS` | 60000 | Suppress re-triggering for this long *after a capture completes*, so a sustained wave doesn't back-to-back profile. |

Auto-captures are distinguished in the filename: `cpu-loopstall-<lagMs>ms-<pod>-<iso>.cpuprofile` (vs the SIGWINCH path's `cpu-<pod>-<iso>.cpuprofile`), so operators can tell them apart and read the trigger lag straight off the name.

## Testable decision design

The capture itself needs a real `node:inspector` Session, so the watchdog's only non-trivial logic — *given a max-lag reading + env config + cooldown/in-progress state, should we fire?* — is factored into a **pure exported function** `shouldTriggerLagCapture(...)` and unit-tested in isolation (`src/server/__tests__/cpu-profiler-lag-trigger.test.ts`): triggers at/above threshold, not below, not when disabled/unset, respects the in-progress `capturing` guard, and respects the cooldown window. No perf_hooks internals are tested.

## Safety

- Same **"never throw at arm time"** discipline as `registerCpuProfiler` — an arm failure logs and no-ops (must never break OTEL `register()`).
- **Server-only**: the sole importer is `src/instrumentation.node.ts` (nodejs runtime, behind the `NEXT_RUNTIME !== 'nodejs'` guard). `node:inspector` / `node:perf_hooks` have **no client-bundle reach path** (verified: only that one importer).
- Type-clean on the changed files (`tsc --noEmit` — 0 errors in the 3 changed files against the repo's large pre-existing baseline).

## Activation

Default-off here. Turning it on in prod requires setting `CPU_PROFILE_LAG_TRIGGER_MS` (suggested 1000) on the dp-prod-api deployment — **a separate datapacket-talos change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)