### PR TITLE
test(blocks): fix stale marketplace sort-default unit test (#2668 rating default)

### DIFF
--- a/src/server/services/blocks/__tests__/marketplace-categories.constants.test.ts
+++ b/src/server/services/blocks/__tests__/marketplace-categories.constants.test.ts
@@ -52,9 +52,12 @@ describe('marketplace-categories taxonomy (F-E E3)', () => {
     expect(() => listAvailableSchema.parse({ category: 'not-a-category' })).toThrow();
   });
 
-  it('listAvailable sort defaults to popular and rejects unknown sorts', () => {
-    expect(listAvailableSchema.parse({}).sort).toBe('popular');
-    for (const s of ['popular', 'newest', 'name']) {
+  it('listAvailable sort defaults to rating and rejects unknown sorts', () => {
+    // #2668 (marketplace reviews + Bayesian rating sort) made `rating` a sort
+    // option AND the default so the best-reviewed apps surface first; the
+    // pre-#2668 default was `popular`.
+    expect(listAvailableSchema.parse({}).sort).toBe('rating');
+    for (const s of ['rating', 'popular', 'newest', 'name']) {
       expect(listAvailableSchema.parse({ sort: s }).sort).toBe(s);
     }
     expect(() => listAvailableSchema.parse({ sort: 'trending' })).toThrow();


### PR DESCRIPTION
## What

Fixes the one genuinely-failing unit test on `main` from the App Blocks regression tail: `marketplace-categories.constants.test.ts` → *"listAvailable sort defaults to popular and rejects unknown sorts"*.

## Root cause (test-vs-code: TEST)

PR **#2668** ("marketplace reviews 5★ + blue-buzz reward + Bayesian rating sort") **deliberately** changed `listAvailableSchema.sort`:
- added `rating` to `marketplaceSortSchema` (now `['rating','popular','newest','name']`)
- flipped the **default** from `popular` → `rating` (best-reviewed apps surface first; 0-review apps sit mid-pack at the global mean)

The taxonomy test was authored in **#2562** and still asserted the old `popular` default + a sort set that omitted `rating`, so it failed against the now-authoritative schema (`expected 'rating' to be 'popular'`).

This is a deliberate behavior change → I updated the **TEST** to the new contract, not the code. @ZacxDev owns App Blocks — please confirm `rating` is the intended default.

```diff
-  it('listAvailable sort defaults to popular and rejects unknown sorts', () => {
-    expect(listAvailableSchema.parse({}).sort).toBe('popular');
-    for (const s of ['popular', 'newest', 'name']) {
+  it('listAvailable sort defaults to rating and rejects unknown sorts', () => {
+    expect(listAvailableSchema.parse({}).sort).toBe('rating');
+    for (const s of ['rating', 'popular', 'newest', 'name']) {
```

## On the other 3 reported failures (index-refactor #1/#2, orphan-relations #4)

I could **not** reproduce these as real failures on current `origin/main`. With a correct environment they pass deterministically:

- `models/index-refactor.test.ts` (#1/#2): passes — the current `/api/v1/models` handler still derives `browsingLevel` from the `?nsfw=` flag and mirrors `nsfwImagePassthrough`, exactly matching the test (#2671's public-endpoint refactor was behavior-preserving; the authoritative clamp lives only on the new `/api/v1/blocks/*` endpoints).
- `prisma-inconsistent-orphan-relations.test.ts` (#4): passes — `getRecentlyManuallyAdded` still carries the `modelVersion: { is: {} }` existence filter.

Their preview failures (`Cannot find module '../../../event-engine-common/feeds'` → cascading `getRecentlyManuallyAdded is not a function`) were a **stale/uninitialized `event-engine-common` submodule** in that preview build, not a code/test bug. The full `vitest --project unit` suite is **219 files / 2900 tests green** locally once the submodule is checked out at the pinned commit (`9454d3a9`) + this fix. This PR's own preview (fresh submodule init) should confirm `unit-tests` is green.

## Test

`vitest run --project unit` → **219 files passed, 2900 tests passed, 1 skipped** (with `event-engine-common` at the pinned commit + prisma client generated; local NixOS needs both or it false-fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)