### PR TITLE
fix(cache-cleanup): coerce Buffer hGetAll reply before split — sentinel-mode gap missed by #2697/#2700

### DIFF
--- a/src/server/jobs/__tests__/cache-cleanup.test.ts
+++ b/src/server/jobs/__tests__/cache-cleanup.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// cache-cleanup.ts imports the real redis client + model.service modules, which
+// open sockets / touch the DB at load. Mock them to in-memory fns whose hGetAll
+// reply type (string vs Buffer values) we control per-test — that's the exact
+// axis of the bug. mergeQueue is a spy so we can assert merge decisions. The
+// mock fns are created via vi.hoisted so they exist before vi.mock's hoisted
+// factory references them.
+const { hGetAll, mergeQueue, refreshBlockedModelHashes } = vi.hoisted(() => ({
+  hGetAll: vi.fn(),
+  mergeQueue: vi.fn(() => Promise.resolve()),
+  refreshBlockedModelHashes: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { hGetAll },
+  REDIS_SYS_KEYS: { QUEUES: { BUCKETS: 'queues:buckets' } },
+}));
+
+vi.mock('~/server/redis/queues', () => ({
+  mergeQueue,
+}));
+
+vi.mock('~/server/services/model.service', () => ({
+  refreshBlockedModelHashes,
+}));
+
+// ./job imports db/client (Prisma) which reads env at module load and isn't set
+// up in unit tests. We only need createJob's invoke contract: return an object
+// whose .run() runs the handler and exposes the result promise.
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (_name: string, _cron: string, fn: () => Promise<unknown>) => ({
+    name: _name,
+    cron: _cron,
+    run: () => ({ result: fn(), cancel: () => Promise.resolve() }),
+    options: {},
+  }),
+}));
+
+import { cacheCleanup, shouldMergeBuckets } from '~/server/jobs/cache-cleanup';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// Run the real createJob-wrapped job to completion.
+async function runJob() {
+  await cacheCleanup.run({}).result;
+}
+
+describe('cache-cleanup mergeQueue dispatch', () => {
+  // Regression: the HA/Sentinel sysRedis client returns BLOB_STRING replies as a
+  // Buffer. Under hGetAll the VALUES of the record are Buffers, so
+  // `buckets.split(',')` threw `i?.split is not a function` and the hourly cron
+  // 500'd every run → queue-merging stops → buckets accumulate. (Gap missed by
+  // the #2697 queues.ts fix and the #2700 sweep.)
+  it('does NOT throw and merges a multi-bucket Buffer value', async () => {
+    hGetAll.mockResolvedValue({ 'images_v6:Update': Buffer.from('a,b', 'utf8') });
+    await expect(runJob()).resolves.toBeUndefined();
+    expect(mergeQueue).toHaveBeenCalledTimes(1);
+    expect(mergeQueue).toHaveBeenCalledWith('images_v6:Update');
+  });
+
+  it('does NOT throw and SKIPS a single-bucket Buffer value (length === 1)', async () => {
+    hGetAll.mockResolvedValue({ 'images_v6:Update': Buffer.from('a', 'utf8') });
+    await expect(runJob()).resolves.toBeUndefined();
+    expect(mergeQueue).not.toHaveBeenCalled();
+  });
+
+  it('merges a multi-bucket plain-string value (unchanged behavior)', async () => {
+    hGetAll.mockResolvedValue({ 'images_v6:Update': 'a,b' });
+    await runJob();
+    expect(mergeQueue).toHaveBeenCalledTimes(1);
+    expect(mergeQueue).toHaveBeenCalledWith('images_v6:Update');
+  });
+
+  it('skips a single-bucket plain-string value (unchanged behavior)', async () => {
+    hGetAll.mockResolvedValue({ 'images_v6:Update': 'a' });
+    await runJob();
+    expect(mergeQueue).not.toHaveBeenCalled();
+  });
+
+  it('handles mixed Buffer + string values across multiple keys', async () => {
+    hGetAll.mockResolvedValue({
+      'images_v6:Update': Buffer.from('a,b,c', 'utf8'), // multi → merge
+      'models_v9:Update': 'x', // single → skip
+      'posts_v3:Update': 'p,q', // multi → merge
+      'tags_v1:Update': Buffer.from('only', 'utf8'), // single → skip
+    });
+    await runJob();
+    expect(mergeQueue).toHaveBeenCalledTimes(2);
+    expect(mergeQueue).toHaveBeenCalledWith('images_v6:Update');
+    expect(mergeQueue).toHaveBeenCalledWith('posts_v3:Update');
+    expect(mergeQueue).not.toHaveBeenCalledWith('models_v9:Update');
+    expect(mergeQueue).not.toHaveBeenCalledWith('tags_v1:Update');
+  });
+
+  it('still refreshes blocked-model hashes after merging', async () => {
+    hGetAll.mockResolvedValue({});
+    await runJob();
+    expect(refreshBlockedModelHashes).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('shouldMergeBuckets (extracted pure helper)', () => {
+  it('Buffer multi-bucket → true', () => {
+    expect(shouldMergeBuckets(Buffer.from('a,b', 'utf8'))).toBe(true);
+  });
+  it('Buffer single-bucket → false', () => {
+    expect(shouldMergeBuckets(Buffer.from('a', 'utf8'))).toBe(false);
+  });
+  it('string multi-bucket → true', () => {
+    expect(shouldMergeBuckets('a,b')).toBe(true);
+  });
+  it('string single-bucket → false', () => {
+    expect(shouldMergeBuckets('a')).toBe(false);
+  });
+  it('empty string → false', () => {
+    expect(shouldMergeBuckets('')).toBe(false);
+  });
+  it('empty Buffer → false', () => {
+    expect(shouldMergeBuckets(Buffer.from('', 'utf8'))).toBe(false);
+  });
+  it('null / undefined → false', () => {
+    expect(shouldMergeBuckets(null)).toBe(false);
+    expect(shouldMergeBuckets(undefined)).toBe(false);
+  });
+});

--- a/src/server/jobs/cache-cleanup.ts
+++ b/src/server/jobs/cache-cleanup.ts
@@ -4,6 +4,23 @@ import { refreshBlockedModelHashes } from '~/server/services/model.service';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { createJob } from './job';
 
+/**
+ * Decide whether a queue entry has multiple buckets and therefore needs merging.
+ *
+ * The HA/Sentinel sysRedis client returns BLOB_STRING replies as a Buffer (no
+ * `.split`) where the normal client returns a string. Coerce to a utf8 string
+ * first — mirrors redis/queues.ts getBucketNames. The bucket value is always
+ * written as a comma-joined string, so decode-then-split is exact. An empty or
+ * falsy value (or a single-bucket entry) has nothing to merge → skip.
+ */
+export function shouldMergeBuckets(buckets: unknown): boolean {
+  const asString = Buffer.isBuffer(buckets)
+    ? buckets.toString('utf8')
+    : (buckets as string | null | undefined);
+  if (!asString) return false;
+  return asString.split(',').length > 1;
+}
+
 export const cacheCleanup = createJob('cache-cleanup', '0 */1 * * *', async () => {
   // Note: Rate limit cleanup not needed - Redis hExpire handles TTL automatically
   // Note: Token state cleanup not needed - Redis hExpire handles TTL automatically
@@ -11,7 +28,12 @@ export const cacheCleanup = createJob('cache-cleanup', '0 */1 * * *', async () =
   // Merge queues
   const queues = await sysRedis.hGetAll(REDIS_SYS_KEYS.QUEUES.BUCKETS);
   const mergeTasks = Object.entries(queues).map(([key, buckets]) => async () => {
-    if (buckets.split(',').length === 1) return;
+    // The HA/Sentinel sysRedis client returns BLOB_STRING replies as a Buffer
+    // (no `.split`), so `buckets.split(',')` threw `i?.split is not a function`.
+    // Mirror the coercion in redis/queues.ts getBucketNames — the bucket value is
+    // always written as a comma-joined string, so decode-then-split is exact.
+    // (Sentinel-mode gap missed by #2697/#2700.)
+    if (!shouldMergeBuckets(buckets)) return;
     await mergeQueue(key);
   });
   await limitConcurrency(mergeTasks, 3);


### PR DESCRIPTION
## The bug

The hourly `cache-cleanup` cron (`src/server/jobs/cache-cleanup.ts`) reads the queue-buckets hash via `sysRedis.hGetAll(REDIS_SYS_KEYS.QUEUES.BUCKETS)` and runs `buckets.split(',')` on each value to decide whether an entry has multiple buckets and needs merging.

The normal `sysRedis` client returns strings, but the **HA/Sentinel** `sysRedis` client (used in preview envs now, and prod after the upcoming sysRedis cutover) returns `BLOB_STRING` replies as a **Buffer**. Under `hGetAll`, the VALUES of the returned record are Buffers (the keys are fine). A Buffer has no `.split`, so `buckets.split(',')` throws `i?.split is not a function`.

At cutover, this hourly cron would throw on **every run** → queue-merging stops → buckets accumulate.

## The fix

Coerce each `buckets` value to a utf8 string before `.split(',')`, mirroring the exact pattern already shipped in `src/server/redis/queues.ts` `getBucketNames` (PR #2697). The bucket value is always written as a comma-joined string, so decode-then-split is exact. Existing merge semantics are preserved: empty/single-bucket → skip, multi-bucket → merge; the plain-string path is unchanged.

The bucket-count decision is extracted into a tiny exported pure helper `shouldMergeBuckets(buckets: unknown): boolean` for clean unit testing.

## Why it was missed

This is the **last known Sentinel `Buffer`-coercion gap** before the prod sysRedis cutover. The #2697 fix hardened `redis/queues.ts`, and the #2700 sweep hardened other `.split` sites, but both missed this `hGetAll` call site in `cache-cleanup.ts` — its values are Buffers under Sentinel just like the `hGet` reply in queues.ts.

## Tests

Added `src/server/jobs/__tests__/cache-cleanup.test.ts` (modeled on `redis/__tests__/queues.test.ts`):
- Runs the **real** job and asserts `mergeQueue` dispatch for Buffer + string values (multi → merge, single → skip), including a mixed-keys case, plus that `refreshBlockedModelHashes` still runs.
- Unit-tests the extracted `shouldMergeBuckets` helper across Buffer/string/empty/single/multi/null.
- Verified non-vacuous: reverting the coercion turns the Buffer cases red with the exact `buckets.split is not a function`, while string cases stay green. 13/13 pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)