### PR TITLE
fix(sysredis): coerce Buffer reply before strict-equality compare in isRunCancelled + isImageScannerNewEnabled (sentinel-mode gap)

### DIFF
--- a/src/server/services/__tests__/image-scanner-flag.buffer.test.ts
+++ b/src/server/services/__tests__/image-scanner-flag.buffer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+// Regression: `isImageScannerNewEnabled` reads a kill-switch from sysRedis and
+// compared the reply against the literals '1'/'true'/'0'/'false'. The
+// HA/Sentinel sysRedis returns a Buffer for BLOB_STRING replies, which matched
+// none of the four literals → the function fell through and DESTRUCTIVELY
+// overwrote the operator's '1' with 'false' (then returned false). The pure
+// decision is extracted into its own `image-scanner-flag` module so the
+// coercion + the seed-only-on-genuinely-unset behavior is testable without
+// loading the 7.9K-line image.service module (which drags in Prisma/env/auth
+// at import time and can't load under vitest). null return == "unset" == the
+// only case the caller is allowed to default-seed.
+
+import { parseScannerFlag } from '~/server/services/image-scanner-flag';
+
+describe('parseScannerFlag — sysRedis Buffer-vs-string flag', () => {
+  it('Buffer("1") → true (was a destructive fall-through pre-fix)', () => {
+    expect(parseScannerFlag(Buffer.from('1', 'utf8'))).toBe(true);
+  });
+
+  it('Buffer("true") → true', () => {
+    expect(parseScannerFlag(Buffer.from('true', 'utf8'))).toBe(true);
+  });
+
+  it('Buffer("0") → false', () => {
+    expect(parseScannerFlag(Buffer.from('0', 'utf8'))).toBe(false);
+  });
+
+  it('Buffer("false") → false', () => {
+    expect(parseScannerFlag(Buffer.from('false', 'utf8'))).toBe(false);
+  });
+
+  it('string "1"/"true" → true (legacy single-pod, unchanged)', () => {
+    expect(parseScannerFlag('1')).toBe(true);
+    expect(parseScannerFlag('true')).toBe(true);
+  });
+
+  it('string "0"/"false" → false (legacy single-pod, unchanged)', () => {
+    expect(parseScannerFlag('0')).toBe(false);
+    expect(parseScannerFlag('false')).toBe(false);
+  });
+
+  it('null → null (genuinely unset → caller seeds the default)', () => {
+    expect(parseScannerFlag(null)).toBeNull();
+  });
+
+  it('an unrecognized value → null (treated as unset, not a destructive match)', () => {
+    expect(parseScannerFlag(Buffer.from('garbage', 'utf8'))).toBeNull();
+    expect(parseScannerFlag('garbage')).toBeNull();
+  });
+});

--- a/src/server/services/__tests__/scanner-policies.buffer.test.ts
+++ b/src/server/services/__tests__/scanner-policies.buffer.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression: `isRunCancelled` reads a cancel flag from sysRedis (set to '1' by
+// `markRunCancelled`). Pre-fix it compared the reply with `=== '1'`. The
+// HA/Sentinel sysRedis returns a Buffer for BLOB_STRING replies, and
+// `Buffer === '1'` is always false — so cancellation was silently never
+// detected in sentinel mode. Coercing the Buffer to utf8 first restores the
+// intended behavior. Mirrors the #2700 buffer-flag test pattern.
+
+const { get } = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { get, set: vi.fn(), del: vi.fn() },
+  REDIS_SYS_KEYS: { SCANNER_POLICY: { RUN_CANCEL: 'scanner-policy:run-cancel' } },
+}));
+
+// Fail-open logger is invoked only in the catch path; keep it inert.
+vi.mock('~/server/redis/fail-open-log', () => ({
+  logSysRedisFailOpen: vi.fn(),
+}));
+
+// The schema module is pure types/zod at runtime; stub to a no-op object so the
+// service module loads without dragging in unrelated deps.
+vi.mock('~/server/schema/scanner-policies.schema', () => ({
+  datasetExportRecordSchema: {},
+  scannerPolicyCandidateSchema: {},
+}));
+
+import { isRunCancelled } from '~/server/services/scanner-policies.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isRunCancelled — sysRedis Buffer-vs-string flag', () => {
+  it('Buffer("1") is detected as cancelled (was silently false pre-fix)', async () => {
+    get.mockResolvedValue(Buffer.from('1', 'utf8'));
+    await expect(isRunCancelled('run-a')).resolves.toBe(true);
+  });
+
+  it('string "1" is detected as cancelled (legacy single-pod, unchanged)', async () => {
+    get.mockResolvedValue('1');
+    await expect(isRunCancelled('run-b')).resolves.toBe(true);
+  });
+
+  it('Buffer("0") is not cancelled', async () => {
+    get.mockResolvedValue(Buffer.from('0', 'utf8'));
+    await expect(isRunCancelled('run-c')).resolves.toBe(false);
+  });
+
+  it('null (no key) is not cancelled', async () => {
+    get.mockResolvedValue(null);
+    await expect(isRunCancelled('run-d')).resolves.toBe(false);
+  });
+
+  it('an unrelated value is not cancelled', async () => {
+    get.mockResolvedValue(Buffer.from('something-else', 'utf8'));
+    await expect(isRunCancelled('run-e')).resolves.toBe(false);
+  });
+
+  it('a thrown redis error fails open (returns false)', async () => {
+    get.mockRejectedValue(new Error('redis down'));
+    await expect(isRunCancelled('run-f')).resolves.toBe(false);
+  });
+});

--- a/src/server/services/image-scanner-flag.ts
+++ b/src/server/services/image-scanner-flag.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure decision helper for the `image-scanner-new` sysRedis kill-switch.
+ *
+ * Lives in its own tiny module so the Buffer-coercion + seed-only-on-unset
+ * behavior is unit-testable without importing the ~7.9K-line image.service
+ * (which drags in Prisma/env/auth at load time and can't load under vitest).
+ *
+ * sysRedis.get is typed `string` but the HA/Sentinel client returns a Buffer
+ * for BLOB_STRING replies, matching none of the four literals → pre-fix
+ * `isImageScannerNewEnabled` fell through and DESTRUCTIVELY overwrote the
+ * operator's '1' with 'false' (then returned false). Coerce once before
+ * comparing. See PR #2697/#2700 for the canonical Buffer-vs-string regression.
+ *
+ * Returns:
+ *   - `true`  for '1' / 'true'
+ *   - `false` for '0' / 'false'
+ *   - `null`  for a genuinely-unset/unknown key — the ONLY case in which the
+ *             caller should default-seed 'false'.
+ */
+export function parseScannerFlag(raw: unknown): boolean | null {
+  const value = Buffer.isBuffer(raw) ? raw.toString('utf8') : raw;
+  if (value === '1' || value === 'true') return true;
+  if (value === '0' || value === 'false') return false;
+  return null;
+}

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -137,6 +137,7 @@ import {
 } from '~/server/services/model3d.service';
 import { addImageToQueue } from '~/server/services/games/new-order.service';
 import { upsertImageFlag } from '~/server/services/image-flag.service';
+import { parseScannerFlag } from '~/server/services/image-scanner-flag';
 import {
   deleteImagTagsForReviewByImageIds,
   getImagTagsForReviewByImageIds,
@@ -784,9 +785,15 @@ export const getImageById = async ({ id }: GetByIdInput) => {
  * Operators set the key to '1' to enable.
  */
 async function isImageScannerNewEnabled(): Promise<boolean> {
-  const value = await sysRedis.get(REDIS_SYS_KEYS.SYSTEM.IMAGE_SCANNER_NEW);
-  if (value === '1' || value === 'true') return true;
-  if (value === '0' || value === 'false') return false;
+  // The HA/Sentinel sysRedis returns a Buffer for BLOB_STRING replies, which
+  // matched none of the literals pre-fix → fell through and destructively
+  // overwrote the operator's '1' with 'false'. parseScannerFlag coerces the
+  // Buffer first and returns null ONLY for a genuinely-unset/unknown key, so
+  // the seed below now fires only in its intended default-seeding case.
+  // See PR #2697/#2700 for the canonical Buffer-vs-string regression.
+  const raw = await sysRedis.get(REDIS_SYS_KEYS.SYSTEM.IMAGE_SCANNER_NEW);
+  const parsed = parseScannerFlag(raw);
+  if (parsed !== null) return parsed;
   await sysRedis.set(REDIS_SYS_KEYS.SYSTEM.IMAGE_SCANNER_NEW, 'false');
   return false;
 }

--- a/src/server/services/scanner-policies.service.ts
+++ b/src/server/services/scanner-policies.service.ts
@@ -401,7 +401,12 @@ export async function markRunCancelled(runId: string): Promise<void> {
 
 export async function isRunCancelled(runId: string): Promise<boolean> {
   try {
-    const v = await sysRedis.get(runCancelKey(runId));
+    // sysRedis.get is typed string but the HA/Sentinel client returns a Buffer
+    // for BLOB_STRING replies. `Buffer === '1'` is always false, so cancellation
+    // would silently never be detected in sentinel mode. Coerce to utf8 first.
+    // See PR #2697/#2700 for the canonical Buffer-vs-string regression.
+    const raw = await sysRedis.get(runCancelKey(runId));
+    const v = Buffer.isBuffer(raw) ? raw.toString('utf8') : raw;
     return v === '1';
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'isRunCancelled', err, { runId });


### PR DESCRIPTION
## Summary

Two residual silent `===` mismatches that the #2700 Buffer-coercion sweep missed. The legacy single-pod `sysRedis` returns strings, but the HA/Sentinel `sysRedis` (preview envs now; prod after the upcoming cutover) returns BLOB_STRING replies as a **Buffer**. A Buffer is never strictly-equal to a string literal, so `value === '1'` silently evaluates false under Sentinel — no throw, just wrong behavior. Same class as #2697/#2700/#2710; this is pre-Sentinel-cutover hardening.

## Site 1 — `scanner-policies.service.ts` (`isRunCancelled`)

`markRunCancelled` sets the cancel key to `'1'`. Pre-fix `v === '1'` compared a Buffer to the string literal → always false → **run cancellation silently never detected** in sentinel mode. Fix coerces to utf8 before the compare; the try/catch fail-open behavior is unchanged.

## Site 2 — `image.service.ts` (`isImageScannerNewEnabled`) — higher priority, destructive

A Buffer matched none of the four literals (`'1'`/`'true'`/`'0'`/`'false'`) → the function fell through and **destructively overwrote the operator's `'1'` with `'false'`**, then returned false. So under Sentinel, the operator's enable flag would get silently clobbered on the next read.

The pure decision is extracted into a tiny `image-scanner-flag.ts` module (`parseScannerFlag(raw) → true | false | null`), so the Buffer-coercion + the seed-only-on-genuinely-unset behavior is unit-testable without importing the ~7.9K-line `image.service.ts` (which drags in Prisma/env/auth at module load and can't load under vitest). `null` == genuinely-unset/unknown == the **only** case in which the `set('false')` default-seed still fires — the intended default-seeding behavior for a truly null key is preserved.

## Tests

- `__tests__/scanner-policies.buffer.test.ts` — `Buffer('1')`→`true` (the bug case), `string('1')`→`true` (unchanged), `Buffer('0')`/`null`/unrelated→`false`, thrown→`false` (fail-open).
- `__tests__/image-scanner-flag.buffer.test.ts` — `parseScannerFlag` over Buffer/string `1|true|0|false`, `null`, and unrecognized inputs (the last two return `null` so only a genuinely-unset key seeds the default).
- Both confirmed **non-vacuous**: reverting either coercion turns the Buffer cases red; restoring turns them green. 14/14 pass locally.
- `prettier --check` clean on all changed files.

> Note: editing `image.service.ts` means CI typecheck is the real gate — the agent worktree has a stale Prisma client and can't give a trustworthy local `pnpm typecheck`. The change to `image.service.ts` is import + a small refactor of one private function; the extracted helper is independently typechecked by the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)