### PR TITLE
fix(user-score): restore image category + harden multiplier loading

### DIFF
--- a/src/components/Account/StrikesCard.tsx
+++ b/src/components/Account/StrikesCard.tsx
@@ -46,18 +46,10 @@ export function StrikesCard() {
   return (
     <Card withBorder id="strikes" ref={scrollToStrikesIfHashed}>
       <Stack gap="lg">
-        {/* Header */}
-        <Group justify="space-between" align="center">
-          <Title order={2}>Account Standing</Title>
-          <Badge
-            color={standingColor}
-            size="lg"
-            variant="light"
-            leftSection={points === 0 ? <IconCheck size={14} /> : undefined}
-          >
-            {standingLabel}
-          </Badge>
-        </Group>
+        {/* Header — the standing badge now lives beside the Strikes subheading below,
+            since it's derived purely from strike points, not the Creator Score. Keeping
+            it up here implied it reflected the (possibly negative) score next to it. */}
+        <Title order={2}>Account Standing</Title>
 
         <Divider />
 
@@ -66,16 +58,28 @@ export function StrikesCard() {
 
         <Divider />
 
-        {/* Strikes Section */}
+        {/* Strikes Section — standing badge sits here, with its full state label
+            (Good Standing / Warning / Restricted), plus the active-count detail when
+            there are strikes. */}
         <Group justify="space-between" align="center">
           <Text size="lg" fw={700}>
             Strikes
           </Text>
-          {points > 0 && (
-            <Badge color={standingColor} size="md" variant="light">
-              {summary?.activeStrikes} active &middot; {points} {points === 1 ? 'point' : 'points'}
+          <Group gap="xs" wrap="nowrap">
+            <Badge
+              color={standingColor}
+              size="md"
+              variant="light"
+              leftSection={points === 0 ? <IconCheck size={14} /> : undefined}
+            >
+              {standingLabel}
             </Badge>
-          )}
+            {points > 0 && (
+              <Badge color={standingColor} size="md" variant="light">
+                {summary?.activeStrikes} active &middot; {points} {points === 1 ? 'point' : 'points'}
+              </Badge>
+            )}
+          </Group>
         </Group>
 
         {strikesLoading ? (

--- a/src/components/Account/UserScoreDisplay.tsx
+++ b/src/components/Account/UserScoreDisplay.tsx
@@ -46,14 +46,14 @@ const reportCategories = [
     label: 'Against',
     color: 'red',
     icon: IconFlag,
-    tooltip: 'Number of reports filed against this user',
+    tooltip: 'Points deducted for content this user posted that was removed for Terms of Service violations',
   },
   {
     key: 'reportsActioned' as const,
     label: 'Actioned',
     color: 'green',
     icon: IconShieldCheck,
-    tooltip: 'Number of reports this user filed that were actioned',
+    tooltip: 'Points earned for reports this user filed that moderators actioned',
   },
 ];
 
@@ -79,13 +79,25 @@ export function UserScoreDisplay({
   const categoryValues = scoreCategories.map(({ key }) => Math.max(scores[key] ?? 0, 0));
   const categoryPool = categoryValues.reduce((sum, value) => sum + value, 0);
 
+  // `total` can be negative: reportsAgainst is stored as points (violations × a
+  // negative multiplier) and can outweigh the positive categories. That value is
+  // what pulls the score below zero, so it's the thing the user needs to see.
+  const total = scores.total ?? 0;
+  const reportsAgainstScore = scores.reportsAgainst ?? 0;
+
   return (
     <Paper withBorder p="md" radius="md">
       <Stack gap="md">
         <Stack gap={4} align="center">
-          <Tooltip label={`${Math.round(scores.total ?? 0).toLocaleString()} points`} withArrow>
-            <Text size="2rem" fw={700} c="green" lh={1.2} style={{ cursor: 'help' }}>
-              {abbreviateNumber(scores.total ?? 0, { decimals: 1 })}
+          <Tooltip label={`${Math.round(total).toLocaleString()} points`} withArrow>
+            <Text
+              size="2rem"
+              fw={700}
+              c={total < 0 ? 'red' : 'green'}
+              lh={1.2}
+              style={{ cursor: 'help' }}
+            >
+              {abbreviateNumber(total, { decimals: 1 })}
             </Text>
           </Tooltip>
           <Text size="sm" c="dimmed">
@@ -137,6 +149,23 @@ export function UserScoreDisplay({
           </Group>
         </Stack>
 
+        {/* Non-moderators don't get the full Reports block, but a negative score
+            still needs a cause — surface the deduction that drove it below zero. */}
+        {!showReports && reportsAgainstScore < 0 && (
+          <>
+            <Divider />
+            <ScoreRow
+              icon={<IconFlag size={16} color="var(--mantine-color-red-6)" />}
+              label="Reports"
+              tooltip="Content you posted that was reported and removed for Terms of Service violations reduces your score."
+            >
+              <Text size="sm" fw={600} c="red">
+                {Math.round(reportsAgainstScore).toLocaleString()} pts
+              </Text>
+            </ScoreRow>
+          </>
+        )}
+
         {showReports && (
           <>
             <Divider label="Reports" labelPosition="left" />
@@ -146,7 +175,7 @@ export function UserScoreDisplay({
                 return (
                   <ScoreRow key={key} icon={<Icon size={16} />} label={label} tooltip={tooltip}>
                     <Text size="sm" fw={600} c={color}>
-                      {Math.round(value)}
+                      {Math.round(value).toLocaleString()} pts
                     </Text>
                   </ScoreRow>
                 );

--- a/src/components/Account/UserScoreDisplay.tsx
+++ b/src/components/Account/UserScoreDisplay.tsx
@@ -1,14 +1,7 @@
-import { Divider, Group, Paper, Progress, Stack, Text, Tooltip } from '@mantine/core';
-import {
-  IconArticle,
-  IconCube,
-  IconFlag,
-  IconInfoCircle,
-  IconPhoto,
-  IconShieldCheck,
-  IconUsers,
-} from '@tabler/icons-react';
+import { ColorSwatch, Divider, Group, Paper, Progress, Stack, Text, Tooltip } from '@mantine/core';
+import { IconFlag, IconInfoCircle, IconShieldCheck } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
+import { abbreviateNumber } from '~/utils/number-helpers';
 
 type Scores = {
   total?: number;
@@ -25,28 +18,24 @@ const scoreCategories = [
     key: 'models' as const,
     label: 'Models',
     color: 'blue',
-    icon: IconCube,
     tooltip: 'Based on reviews, downloads, and generations across published models',
   },
   {
     key: 'images' as const,
     label: 'Images',
     color: 'teal',
-    icon: IconPhoto,
     tooltip: 'Based on reactions and comments images receive',
   },
   {
     key: 'articles' as const,
     label: 'Articles',
     color: 'orange',
-    icon: IconArticle,
     tooltip: 'Based on views, comments, and reactions on articles',
   },
   {
     key: 'users' as const,
     label: 'Users',
     color: 'grape',
-    icon: IconUsers,
     tooltip: 'Based on follower count',
   },
 ];
@@ -85,16 +74,20 @@ export function UserScoreDisplay({
     );
   }
 
-  const categoryValues = scoreCategories.map(({ key }) => Math.abs(scores[key] ?? 0));
-  const maxCategoryValue = Math.max(...categoryValues, 1);
+  // Only positive contributions compose the bar; each segment is that category's
+  // share of the combined positive score pool, so the sections fill to 100%.
+  const categoryValues = scoreCategories.map(({ key }) => Math.max(scores[key] ?? 0, 0));
+  const categoryPool = categoryValues.reduce((sum, value) => sum + value, 0);
 
   return (
     <Paper withBorder p="md" radius="md">
       <Stack gap="md">
         <Stack gap={4} align="center">
-          <Text size="2rem" fw={700} c="green" lh={1.2}>
-            {Math.round(scores.total ?? 0).toLocaleString()}
-          </Text>
+          <Tooltip label={`${Math.round(scores.total ?? 0).toLocaleString()} points`} withArrow>
+            <Text size="2rem" fw={700} c="green" lh={1.2} style={{ cursor: 'help' }}>
+              {abbreviateNumber(scores.total ?? 0, { decimals: 1 })}
+            </Text>
+          </Tooltip>
           <Text size="sm" c="dimmed">
             User Score
           </Text>
@@ -103,24 +96,45 @@ export function UserScoreDisplay({
         <Divider />
 
         <Stack gap="sm">
-          {scoreCategories.map(({ key, label, color, icon: Icon, tooltip }) => {
-            const value = scores[key] ?? 0;
-            const percentage = (Math.abs(value) / maxCategoryValue) * 100;
-            return (
-              <ScoreRow key={key} icon={<Icon size={16} />} label={label} tooltip={tooltip}>
-                <Progress
-                  value={percentage}
-                  color={color}
-                  size="sm"
-                  style={{ flex: 1 }}
-                  radius="xl"
-                />
-                <Text size="sm" fw={600} w={50} ta="right">
-                  {Math.round(value)}
-                </Text>
-              </ScoreRow>
-            );
-          })}
+          {/* Section hover → the category amount + share. */}
+          <Progress.Root size="xl" radius="xl">
+            {scoreCategories.map(({ key, label, color }, index) => {
+              const value = categoryValues[index];
+              if (value <= 0) return null;
+              const percentage = categoryPool > 0 ? (value / categoryPool) * 100 : 0;
+              return (
+                <Tooltip
+                  key={key}
+                  label={`${label}: ${Math.round(value).toLocaleString()} (${formatPercentage(
+                    value,
+                    percentage
+                  )})`}
+                  withArrow
+                >
+                  {/* minWidth keeps a real-but-tiny category (e.g. <1%) a visible sliver;
+                      must clear the radius="xl" rounded corner (~8-10px) to show. */}
+                  <Progress.Section value={percentage} color={color} style={{ minWidth: 12 }} />
+                </Tooltip>
+              );
+            })}
+          </Progress.Root>
+
+          {/* macOS-storage-style legend: dot + label, dot hover → description. */}
+          <Group gap="md" wrap="wrap">
+            {scoreCategories.map(({ key, label, color, tooltip }) => (
+              <Group key={key} gap={6} wrap="nowrap">
+                <Tooltip label={tooltip} multiline w={220} withArrow>
+                  <ColorSwatch
+                    color={`var(--mantine-color-${color}-6)`}
+                    size={10}
+                    radius="xl"
+                    style={{ cursor: 'help' }}
+                  />
+                </Tooltip>
+                <Text size="sm">{label}</Text>
+              </Group>
+            ))}
+          </Group>
         </Stack>
 
         {showReports && (
@@ -143,6 +157,13 @@ export function UserScoreDisplay({
       </Stack>
     </Paper>
   );
+}
+
+// A real (non-zero) category whose share rounds to 0% shows "<1%" instead, so a
+// tiny-but-present category never reads as zero.
+function formatPercentage(value: number, percentage: number) {
+  if (value > 0 && percentage < 1) return '<1%';
+  return `${Math.round(percentage)}%`;
 }
 
 function ScoreRow({

--- a/src/components/Account/UserScoreDisplay.tsx
+++ b/src/components/Account/UserScoreDisplay.tsx
@@ -101,69 +101,112 @@ export function UserScoreDisplay({
             </Text>
           </Tooltip>
           <Text size="sm" c="dimmed">
-            User Score
+            Creator Score
+          </Text>
+          {/* Spell out that this is a reputation axis (content earned minus content
+              removed), distinct from the strike-based Account Standing badge above —
+              the two can legitimately disagree (negative score, no active strikes). */}
+          <Text size="xs" c="dimmed" ta="center" maw={260}>
+            Reputation from your content, minus content removed for violations
           </Text>
         </Stack>
 
         <Divider />
 
         <Stack gap="sm">
-          {/* Section hover → the category amount + share. */}
-          <Progress.Root size="xl" radius="xl">
-            {scoreCategories.map(({ key, label, color }, index) => {
-              const value = categoryValues[index];
-              if (value <= 0) return null;
-              const percentage = categoryPool > 0 ? (value / categoryPool) * 100 : 0;
-              return (
-                <Tooltip
-                  key={key}
-                  label={`${label}: ${Math.round(value).toLocaleString()} (${formatPercentage(
-                    value,
-                    percentage
-                  )})`}
-                  withArrow
-                >
-                  {/* minWidth keeps a real-but-tiny category (e.g. <1%) a visible sliver;
-                      must clear the radius="xl" rounded corner (~8-10px) to show. */}
-                  <Progress.Section value={percentage} color={color} style={{ minWidth: 12 }} />
-                </Tooltip>
-              );
-            })}
-          </Progress.Root>
+          {categoryPool > 0 ? (
+            <>
+              {/* Section hover → the category amount + share. */}
+              <Progress.Root size="xl" radius="xl">
+                {scoreCategories.map(({ key, label, color }, index) => {
+                  const value = categoryValues[index];
+                  if (value <= 0) return null;
+                  const percentage = (value / categoryPool) * 100;
+                  return (
+                    <Tooltip
+                      key={key}
+                      label={`${label}: ${Math.round(value).toLocaleString()} (${formatPercentage(
+                        value,
+                        percentage
+                      )})`}
+                      withArrow
+                    >
+                      {/* minWidth keeps a real-but-tiny category (e.g. <1%) a visible sliver;
+                          must clear the radius="xl" rounded corner (~8-10px) to show. */}
+                      <Progress.Section value={percentage} color={color} style={{ minWidth: 12 }} />
+                    </Tooltip>
+                  );
+                })}
+              </Progress.Root>
 
-          {/* macOS-storage-style legend: dot + label, dot hover → description. */}
-          <Group gap="md" wrap="wrap">
-            {scoreCategories.map(({ key, label, color, tooltip }) => (
-              <Group key={key} gap={6} wrap="nowrap">
-                <Tooltip label={tooltip} multiline w={220} withArrow>
-                  <ColorSwatch
-                    color={`var(--mantine-color-${color}-6)`}
-                    size={10}
-                    radius="xl"
-                    style={{ cursor: 'help' }}
-                  />
-                </Tooltip>
-                <Text size="sm">{label}</Text>
+              {/* macOS-storage-style legend: dot + label, dot hover → description. Only
+                  categories the user actually has (value > 0) appear, matching the bar —
+                  no orphan dot for a category with no segment. */}
+              <Group gap="md" wrap="wrap">
+                {scoreCategories.map(({ key, label, color, tooltip }, index) => {
+                  if (categoryValues[index] <= 0) return null;
+                  return (
+                    <Group key={key} gap={6} wrap="nowrap">
+                      <Tooltip label={tooltip} multiline w={220} withArrow>
+                        <ColorSwatch
+                          color={`var(--mantine-color-${color}-6)`}
+                          size={10}
+                          radius="xl"
+                          style={{ cursor: 'help' }}
+                        />
+                      </Tooltip>
+                      <Text size="sm">{label}</Text>
+                    </Group>
+                  );
+                })}
               </Group>
-            ))}
-          </Group>
+            </>
+          ) : (
+            <Text size="sm" c="dimmed" ta="center">
+              No positive score contributions yet
+            </Text>
+          )}
         </Stack>
 
         {/* Non-moderators don't get the full Reports block, but a negative score
-            still needs a cause — surface the deduction that drove it below zero. */}
+            still needs a cause — surface the deduction as a distinct tinted penalty
+            callout (not a plain list row) so it reads as the thing pulling the score
+            down rather than another contributing category. */}
         {!showReports && reportsAgainstScore < 0 && (
-          <>
-            <Divider />
-            <ScoreRow
-              icon={<IconFlag size={16} color="var(--mantine-color-red-6)" />}
-              label="Reports"
-              tooltip="Content you posted that was reported and removed for Terms of Service violations reduces your score."
-            >
-              <Text size="sm" fw={600} c="red">
-                {Math.round(reportsAgainstScore).toLocaleString()} pts
+          <Group
+            justify="space-between"
+            wrap="nowrap"
+            gap="sm"
+            px="sm"
+            py={8}
+            style={{
+              backgroundColor: 'var(--mantine-color-red-light)',
+              borderRadius: 'var(--mantine-radius-md)',
+            }}
+          >
+            <Group gap={8} wrap="nowrap">
+              <IconFlag size={16} color="var(--mantine-color-red-6)" style={{ flexShrink: 0 }} />
+              <Text size="sm">Reports against</Text>
+              <Tooltip
+                label="Content you posted that was reported and removed for Terms of Service violations reduces your score."
+                multiline
+                w={240}
+                withArrow
+              >
+                <IconInfoCircle
+                  size={14}
+                  style={{ flexShrink: 0, cursor: 'help' }}
+                  color="var(--mantine-color-dimmed)"
+                />
+              </Tooltip>
+            </Group>
+            {/* Abbreviated to match the headline's scale; exact value in the tooltip. */}
+            <Tooltip label={`${Math.round(reportsAgainstScore).toLocaleString()} points`} withArrow>
+              <Text size="sm" fw={700} c="red" style={{ whiteSpace: 'nowrap', cursor: 'help' }}>
+                {abbreviateNumber(reportsAgainstScore, { decimals: 1 })} pts
               </Text>
-            </ScoreRow>
-          </>
+            </Tooltip>
+          </Group>
         )}
 
         {showReports && (

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -8,9 +8,10 @@ import { dataProcessor } from '~/server/db/db-helpers';
 import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
 import { applyUserScoreUpdates, getScoreMultipliers } from '~/server/jobs/update-user-score';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 
 /**
- * One-off backfill for the creator-score `images` category.
+ * One-off backfill for the creator-score `images` category — a single command.
  * =============================================================================
  *
  * The image score was silently 0 for everyone (the cron read the stale
@@ -18,73 +19,53 @@ import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
  * incremental — only owners with recent engagement get revisited. This sweep
  * recomputes EVERY image owner's `images` score (and `total`).
  *
- * Image-driven (not owner-driven) so it scans the slow v2 view ONCE in entityId
- * ranges instead of re-querying it per owner (~135 range scans vs ~23k random
- * IN lookups). Two phases:
+ * Image-driven, so it scans the slow v2 view ONCE in entityId ranges (~135 range
+ * scans) instead of re-querying it per owner (~23k random IN lookups, ~60h). One
+ * pass: range-scan v2 for engaged images, roll reactions/comments up per owner in
+ * memory, then write each owner's score + total and stamp `imagesBackfilledAt`.
  *
- *   scan  (default) - range-scan v2 for engaged images, roll up reactions/comments
- *                     per owner into the `temp_image_score_backfill` staging table.
- *                     Truncates + rebuilds, so it's idempotent (safe to re-run).
- *   apply           - read the staging table, write each owner's image score +
- *                     recomputed total, and stamp `meta.scores.imagesBackfilledAt`.
- *                     Skips owners already stamped, so it's resumable and never
- *                     recomputes a finished owner.
- *   reset           - drop the staging table.
+ * Run it (drive from the no-timeout dev server, which talks to prod; keep the
+ * client connected — nohup/screen):
+ *   GET /api/admin/temp/backfill-image-scores?token=$WEBHOOK_TOKEN
+ *   optional: &concurrency=3 &batchSize=1000000 &skipMarked=true
  *
- * Typical run (drive from the no-timeout dev server, which talks to prod;
- * keep the client connected — nohup/screen):
- *   1) GET .../backfill-image-scores?token=...&action=scan
- *   2) GET .../backfill-image-scores?token=...&action=apply   (re-run freely; skips done)
+ * Idempotent: rewriting an owner produces the same score. `skipMarked=true` skips
+ * owners already stamped (so a re-run only fills in the rest). Run the FULL range
+ * (default) — a partial start/end gives partial scores since an owner's images
+ * are spread across the id space.
  *
  * Auth via the existing `WebhookEndpoint(?token=...)` gate.
  */
 
-const STAGING = 'temp_image_score_backfill';
 const REACTION_TYPES = "'Like', 'Heart', 'Laugh', 'Cry'";
 
 const schema = z.object({
-  action: z.enum(['scan', 'apply', 'reset']).optional().default('scan'),
   concurrency: z.coerce.number().min(1).max(20).optional().default(3),
-  // scan: width of the entityId (imageId) window per task.
-  // apply: width of the userId window per task.
-  batchSize: z.coerce.number().min(1).optional().default(1_000_000),
+  batchSize: z.coerce.number().min(1).optional().default(1_000_000), // entityId window per v2 scan
   start: z.coerce.number().min(0).optional().default(0),
   end: z.coerce.number().min(0).optional(),
+  // re-run helper: skip owners already stamped instead of rewriting them.
+  skipMarked: z
+    .union([z.boolean(), z.string()])
+    .optional()
+    .transform((v) => v === true || v === 'true' || v === '1'),
+  // preview: scan + count owners, write nothing.
+  dryRun: z
+    .union([z.boolean(), z.string()])
+    .optional()
+    .transform((v) => v === true || v === 'true' || v === '1'),
 });
 
 export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
   if (!clickhouse) return res.status(503).json({ error: 'ClickHouse is not available' });
   const params = schema.parse(req.query);
-
-  if (params.action === 'reset') {
-    await pgDbWrite.cancellableQuery(`DROP TABLE IF EXISTS ${STAGING}`).then((q) => q.result());
-    return res.status(200).json({ action: 'reset', dropped: true });
-  }
-
-  const multipliers = await getScoreMultipliers();
+  const { images: imageMultipliers } = await getScoreMultipliers();
 
   console.time('BACKFILL_IMAGE_SCORES');
-  if (params.action === 'scan') await scan(res, params);
-  else await apply(res, params, multipliers.images);
-  console.timeEnd('BACKFILL_IMAGE_SCORES');
 
-  res.status(200).json({ action: params.action, finished: true });
-});
-
-// Phase 1: roll engaged-image reactions/comments up per owner into staging.
-async function scan(res: NextApiResponse, params: z.infer<typeof schema>) {
-  await pgDbWrite
-    .cancellableQuery(
-      `CREATE TABLE IF NOT EXISTS ${STAGING} (
-        user_id int PRIMARY KEY,
-        reactions bigint NOT NULL DEFAULT 0,
-        comments bigint NOT NULL DEFAULT 0
-      )`
-    )
-    .then((q) => q.result());
-  // Rebuild from scratch so re-running scan is idempotent.
-  await pgDbWrite.cancellableQuery(`TRUNCATE ${STAGING}`).then((q) => q.result());
-
+  // Phase 1 — scan v2 once in entityId ranges, accumulate reactions/comments per
+  // owner in memory (the `+=` is synchronous, so concurrent windows are race-free).
+  const owners = new Map<number, { reactions: number; comments: number }>();
   await dataProcessor({
     params,
     runContext: res,
@@ -95,7 +76,6 @@ async function scan(res: NextApiResponse, params: z.infer<typeof schema>) {
       return { start: ctx.start, end: max ?? 0 };
     },
     processor: async ({ start, end, cancelFns }) => {
-      // Engaged images in this entityId window (single sequential v2 range scan).
       const engaged = await clickhouse!.$query<{ imageId: number; reactions: number; comments: number }>(`
         SELECT entityId AS imageId,
           sumIf(total, metricType IN (${REACTION_TYPES})) AS reactions,
@@ -121,95 +101,63 @@ async function scan(res: NextApiResponse, params: z.infer<typeof schema>) {
         for (const { id, userId } of await q.result()) ownerByImage.set(id, userId);
       }
 
-      // Roll up per owner for this window.
-      const perOwner = new Map<number, { reactions: number; comments: number }>();
       for (const { imageId, reactions, comments } of engaged) {
         const owner = ownerByImage.get(imageId);
         if (!owner) continue;
-        const acc = perOwner.get(owner) ?? { reactions: 0, comments: 0 };
+        const acc = owners.get(owner) ?? { reactions: 0, comments: 0 };
         acc.reactions += Number(reactions);
         acc.comments += Number(comments);
-        perOwner.set(owner, acc);
+        owners.set(owner, acc);
       }
-      if (!perOwner.size) return;
-
-      // Upsert with += so an owner's images across multiple windows accumulate.
-      // Postgres row locks serialize concurrent windows touching the same owner.
-      const rows = [...perOwner].map(([user_id, a]) => ({ user_id, ...a }));
-      const upsert = await pgDbWrite.cancellableQuery(
-        `INSERT INTO ${STAGING} (user_id, reactions, comments)
-         SELECT user_id, reactions, comments
-         FROM jsonb_to_recordset($1::jsonb) AS x(user_id int, reactions bigint, comments bigint)
-         ON CONFLICT (user_id) DO UPDATE SET
-           reactions = ${STAGING}.reactions + EXCLUDED.reactions,
-           comments = ${STAGING}.comments + EXCLUDED.comments`,
-        [JSON.stringify(rows)]
-      );
-      cancelFns.push(upsert.cancel);
-      await upsert.result();
-
-      console.log(`scan: imageId ${start}-${end} → ${engaged.length} engaged, ${perOwner.size} owners`);
+      console.log(`scan: imageId ${start}-${end} → ${engaged.length} engaged images`);
     },
   });
-}
 
-// Phase 2: write each staged owner's score + total + the backfill marker. Skips
-// owners already marked, so it's resumable and never recomputes a finished owner.
-async function apply(
-  res: NextApiResponse,
-  params: z.infer<typeof schema>,
-  imageMultipliers: { reactions: number; comments: number; views: number }
-) {
+  if (params.dryRun) {
+    console.timeEnd('BACKFILL_IMAGE_SCORES');
+    return res.status(200).json({ finished: true, dryRun: true, owners: owners.size, written: 0 });
+  }
+
+  // Phase 2 — write each owner's image score + recomputed total, stamp the marker.
   const stampedAt = new Date().toISOString();
-  // apply windows by userId, not entityId.
-  const applyParams = { ...params, batchSize: Math.min(params.batchSize, 50_000) };
+  let written = 0;
+  const writeTasks = chunk([...owners], 500).map((batch) => async () => {
+    const ids = batch.map(([userId]) => userId);
 
-  await dataProcessor({
-    params: applyParams,
-    runContext: res,
-    rangeFetcher: async (ctx) => {
-      const [{ max }] = await pgDbRead
-        .cancellableQuery<{ max: number }>(`SELECT MAX(user_id) AS max FROM ${STAGING}`)
+    if (params.skipMarked) {
+      const stamped = await pgDbRead
+        .cancellableQuery<{ id: number }>(
+          `SELECT id FROM "User" WHERE id = ANY($1::int[]) AND (meta->'scores'->>'imagesBackfilledAt') IS NOT NULL`,
+          [ids]
+        )
         .then((q) => q.result());
-      return { start: ctx.start, end: max ?? 0 };
-    },
-    processor: async ({ start, end, cancelFns }) => {
-      // Staged owners in this userId window that haven't been stamped yet.
-      const q = await pgDbRead.cancellableQuery<{ user_id: number; reactions: number; comments: number }>(
-        `SELECT s.user_id, s.reactions, s.comments
-         FROM ${STAGING} s
-         JOIN "User" u ON u.id = s.user_id
-         WHERE s.user_id >= $1 AND s.user_id <= $2
-           AND (u.meta->'scores'->>'imagesBackfilledAt') IS NULL`,
-        [start, end]
-      );
-      cancelFns.push(q.cancel);
-      const owners = await q.result();
-      if (!owners.length) return;
+      const skip = new Set(stamped.map((s) => s.id));
+      batch = batch.filter(([userId]) => !skip.has(userId));
+      if (!batch.length) return;
+    }
 
-      // images score + recomputed total (shared with the cron).
-      const records = owners.map(
-        ({ user_id, reactions, comments }) =>
-          [
-            String(user_id),
-            {
-              images: Number(reactions) * imageMultipliers.reactions + Number(comments) * imageMultipliers.comments,
-            },
-          ] as [string, { images: number }]
-      );
-      await applyUserScoreUpdates(pgDbWrite, records, (cancel) => cancelFns.push(cancel));
+    const records = batch.map(
+      ([userId, { reactions, comments }]) =>
+        [
+          String(userId),
+          { images: reactions * imageMultipliers.reactions + comments * imageMultipliers.comments },
+        ] as [string, { images: number }]
+    );
+    await applyUserScoreUpdates(pgDbWrite, records);
 
-      // Stamp the marker so a re-run skips these owners.
-      const markQuery = await pgDbWrite.cancellableQuery(
+    await pgDbWrite
+      .cancellableQuery(
         `UPDATE "User"
          SET meta = jsonb_set(COALESCE(meta, '{}'), '{scores,imagesBackfilledAt}', to_jsonb($1::text))
          WHERE id = ANY($2::int[])`,
-        [stampedAt, owners.map((o) => o.user_id)]
-      );
-      cancelFns.push(markQuery.cancel);
-      await markQuery.result();
+        [stampedAt, batch.map(([userId]) => userId)]
+      )
+      .then((q) => q.result());
 
-      console.log(`apply: userId ${start}-${end} → ${owners.length} owners written`);
-    },
+    written += batch.length;
   });
-}
+  await limitConcurrency(writeTasks, params.concurrency);
+
+  console.timeEnd('BACKFILL_IMAGE_SCORES');
+  res.status(200).json({ finished: true, owners: owners.size, written });
+});

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -29,7 +29,8 @@ import { booleanString } from '~/utils/zod-helpers';
  * actually write. Run it (drive from the no-timeout dev server, which talks to
  * prod; keep the client connected — nohup/screen):
  *   GET /api/admin/temp/backfill-image-scores?token=$WEBHOOK_TOKEN&dryRun=false
- *   optional: &concurrency=3 &batchSize=1000000  (larger entityId window = fewer v2 scans)
+ *   optional: &concurrency=3 &batchSize=1000000  (default already 1,000,000 = ~135 v2
+ *   scans; a SMALLER window means MORE/slower scans, not fewer)
  *
  * Idempotent + resumable: owners already stamped with `imageScoreRecomputedAt` are
  * always skipped, so a re-run only fills in the rest (never recomputes finished
@@ -43,7 +44,7 @@ const REACTION_TYPES = "'Like', 'Heart', 'Laugh', 'Cry'";
 
 const schema = z.object({
   concurrency: z.coerce.number().min(1).max(20).optional().default(3),
-  batchSize: z.coerce.number().min(1).optional().default(10000), // entityId window per v2 scan
+  batchSize: z.coerce.number().min(1).optional().default(1_000_000), // entityId window per v2 scan (~135 scans over the full id space; smaller = more, slower scans)
   start: z.coerce.number().min(0).optional().default(0),
   end: z.coerce.number().min(0).optional(),
   // preview: scan + count owners, write nothing.

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -75,11 +75,12 @@ async function backfillImageScores(req: NextApiRequest, res: NextApiResponse) {
       // Distinct owners in this userId window (bounded range → cheap index scan).
       // Inclusive lower bound so `start=X&end=X` targets exactly user X (and so
       // consecutive dataProcessor windows stay contiguous with no skipped id).
-      const ownerQuery = await pgDbRead.cancellableQuery<{ id: number }>(`
-        SELECT DISTINCT "userId" AS id
-        FROM "Image"
-        WHERE "userId" >= ${start} AND "userId" <= ${end} AND "userId" IS NOT NULL
-      `);
+      const ownerQuery = await pgDbRead.cancellableQuery<{ id: number }>(
+        `SELECT DISTINCT "userId" AS id
+         FROM "Image"
+         WHERE "userId" >= $1 AND "userId" <= $2 AND "userId" IS NOT NULL`,
+        [start, end]
+      );
       cancelFns.push(ownerQuery.cancel);
       const owners = (await ownerQuery.result()).map((r) => r.id);
       if (!owners.length) return;

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -25,10 +25,11 @@ import { booleanString } from '~/utils/zod-helpers';
  * pass: range-scan v2 for engaged images, roll reactions/comments up per owner in
  * memory, then write each owner's score + total and stamp `imageScoreRecomputedAt`.
  *
- * Run it (drive from the no-timeout dev server, which talks to prod; keep the
- * client connected — nohup/screen):
- *   GET /api/admin/temp/backfill-image-scores?token=$WEBHOOK_TOKEN
- *   optional: &concurrency=3 &batchSize=1000000 &dryRun=true
+ * Defaults to a DRY RUN (scan + count owners, no writes) — pass &dryRun=false to
+ * actually write. Run it (drive from the no-timeout dev server, which talks to
+ * prod; keep the client connected — nohup/screen):
+ *   GET /api/admin/temp/backfill-image-scores?token=$WEBHOOK_TOKEN&dryRun=false
+ *   optional: &concurrency=3 &batchSize=1000000  (larger entityId window = fewer v2 scans)
  *
  * Idempotent + resumable: owners already stamped with `imageScoreRecomputedAt` are
  * always skipped, so a re-run only fills in the rest (never recomputes finished
@@ -42,7 +43,7 @@ const REACTION_TYPES = "'Like', 'Heart', 'Laugh', 'Cry'";
 
 const schema = z.object({
   concurrency: z.coerce.number().min(1).max(20).optional().default(3),
-  batchSize: z.coerce.number().min(1).optional().default(1_000_000), // entityId window per v2 scan
+  batchSize: z.coerce.number().min(1).optional().default(10000), // entityId window per v2 scan
   start: z.coerce.number().min(0).optional().default(0),
   end: z.coerce.number().min(0).optional(),
   // preview: scan + count owners, write nothing.

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -1,100 +1,215 @@
 import { Prisma } from '@prisma/client';
+import { chunk } from 'lodash-es';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead } from '~/server/db/client';
 import { dataProcessor } from '~/server/db/db-helpers';
 import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
-import {
-  applyUserScoreUpdates,
-  computeImageScores,
-  getScoreMultipliers,
-} from '~/server/jobs/update-user-score';
+import { applyUserScoreUpdates, getScoreMultipliers } from '~/server/jobs/update-user-score';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 /**
  * One-off backfill for the creator-score `images` category.
+ * =============================================================================
  *
  * The image score was silently 0 for everyone (the cron read the stale
- * `image_metrics_user` table). The fix in `update-user-score` reads
- * `entityMetricDailyAgg_v2`, but it's incremental — it only revisits owners with
- * recent image engagement. This sweep recomputes EVERY image owner's `images`
- * score (and their `total`) so the historically-missing contribution is restored.
+ * `image_metrics_user` table). The fix reads `entityMetricDailyAgg_v2`, but it's
+ * incremental — only owners with recent engagement get revisited. This sweep
+ * recomputes EVERY image owner's `images` score (and `total`).
  *
- * Idempotent: each owner's score is recomputed from current v2 metrics, so
- * re-running (or re-running a sub-range) is safe.
+ * Image-driven (not owner-driven) so it scans the slow v2 view ONCE in entityId
+ * ranges instead of re-querying it per owner (~135 range scans vs ~23k random
+ * IN lookups). Two phases:
  *
- * Ranges over `Image."userId"` windows via `dataProcessor`; each window resolves
- * its owners, scores them with the shared `computeImageScores`, and writes via
- * `applyUserScoreUpdates`. Runs to completion in a single request — drive it from
- * the no-timeout dev server (which talks to prod) and keep the client connected
- * (nohup/screen); disconnecting cancels in-flight queries.
+ *   scan  (default) - range-scan v2 for engaged images, roll up reactions/comments
+ *                     per owner into the `temp_image_score_backfill` staging table.
+ *                     Truncates + rebuilds, so it's idempotent (safe to re-run).
+ *   apply           - read the staging table, write each owner's image score +
+ *                     recomputed total, and stamp `meta.scores.imagesBackfilledAt`.
+ *                     Skips owners already stamped, so it's resumable and never
+ *                     recomputes a finished owner.
+ *   reset           - drop the staging table.
+ *
+ * Typical run (drive from the no-timeout dev server, which talks to prod;
+ * keep the client connected — nohup/screen):
+ *   1) GET .../backfill-image-scores?token=...&action=scan
+ *   2) GET .../backfill-image-scores?token=...&action=apply   (re-run freely; skips done)
  *
  * Auth via the existing `WebhookEndpoint(?token=...)` gate.
- *
- * Usage:
- *   GET /api/admin/temp/backfill-image-scores?token=<WEBHOOK_TOKEN>
- *   optional: &concurrency=3 &batchSize=10000 &start=0 &end=<maxUserId>
- *   start/end target an inclusive userId range — `start=X&end=X` backfills exactly
- *   user X; omit both to sweep everyone; set start=<lastId> to resume.
  */
 
+const STAGING = 'temp_image_score_backfill';
+const REACTION_TYPES = "'Like', 'Heart', 'Laugh', 'Cry'";
+
 const schema = z.object({
+  action: z.enum(['scan', 'apply', 'reset']).optional().default('scan'),
   concurrency: z.coerce.number().min(1).max(20).optional().default(3),
-  // width of the Image."userId" window handled per task (sparse id space, so a
-  // window holds far fewer owners than its width).
-  batchSize: z.coerce.number().min(1).optional().default(10000),
+  // scan: width of the entityId (imageId) window per task.
+  // apply: width of the userId window per task.
+  batchSize: z.coerce.number().min(1).optional().default(1_000_000),
   start: z.coerce.number().min(0).optional().default(0),
   end: z.coerce.number().min(0).optional(),
 });
 
 export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
   if (!clickhouse) return res.status(503).json({ error: 'ClickHouse is not available' });
+  const params = schema.parse(req.query);
+
+  if (params.action === 'reset') {
+    await pgDbWrite.cancellableQuery(`DROP TABLE IF EXISTS ${STAGING}`).then((q) => q.result());
+    return res.status(200).json({ action: 'reset', dropped: true });
+  }
+
+  const multipliers = await getScoreMultipliers();
 
   console.time('BACKFILL_IMAGE_SCORES');
-  await backfillImageScores(req, res);
+  if (params.action === 'scan') await scan(res, params);
+  else await apply(res, params, multipliers.images);
   console.timeEnd('BACKFILL_IMAGE_SCORES');
 
-  res.status(200).json({ finished: true });
+  res.status(200).json({ action: params.action, finished: true });
 });
 
-async function backfillImageScores(req: NextApiRequest, res: NextApiResponse) {
-  const params = schema.parse(req.query);
-  const scoreMultipliers = await getScoreMultipliers();
+// Phase 1: roll engaged-image reactions/comments up per owner into staging.
+async function scan(res: NextApiResponse, params: z.infer<typeof schema>) {
+  await pgDbWrite
+    .cancellableQuery(
+      `CREATE TABLE IF NOT EXISTS ${STAGING} (
+        user_id int PRIMARY KEY,
+        reactions bigint NOT NULL DEFAULT 0,
+        comments bigint NOT NULL DEFAULT 0
+      )`
+    )
+    .then((q) => q.result());
+  // Rebuild from scratch so re-running scan is idempotent.
+  await pgDbWrite.cancellableQuery(`TRUNCATE ${STAGING}`).then((q) => q.result());
 
   await dataProcessor({
     params,
     runContext: res,
     rangeFetcher: async (ctx) => {
       const [{ max }] = await dbRead.$queryRaw<{ max: number }[]>(
-        Prisma.sql`SELECT MAX("userId") "max" FROM "Image"`
+        Prisma.sql`SELECT MAX(id) "max" FROM "Image"`
       );
       return { start: ctx.start, end: max ?? 0 };
     },
     processor: async ({ start, end, cancelFns }) => {
-      // Distinct owners in this userId window (bounded range → cheap index scan).
-      // Inclusive lower bound so `start=X&end=X` targets exactly user X (and so
-      // consecutive dataProcessor windows stay contiguous with no skipped id).
-      const ownerQuery = await pgDbRead.cancellableQuery<{ id: number }>(
-        `SELECT DISTINCT "userId" AS id
-         FROM "Image"
-         WHERE "userId" >= $1 AND "userId" <= $2 AND "userId" IS NOT NULL`,
+      // Engaged images in this entityId window (single sequential v2 range scan).
+      const engaged = await clickhouse!.$query<{ imageId: number; reactions: number; comments: number }>(`
+        SELECT entityId AS imageId,
+          sumIf(total, metricType IN (${REACTION_TYPES})) AS reactions,
+          sumIf(total, metricType = 'commentCount') AS comments
+        FROM entityMetricDailyAgg_v2
+        WHERE entityType = 'Image' AND entityId > ${start} AND entityId <= ${end}
+        GROUP BY entityId
+        HAVING reactions > 0 OR comments > 0
+      `);
+      if (!engaged.length) return;
+
+      // imageId -> owner (Postgres is the authoritative owner map).
+      const ownerByImage = new Map<number, number>();
+      for (const ids of chunk(
+        engaged.map((e) => e.imageId),
+        10000
+      )) {
+        const q = await pgDbRead.cancellableQuery<{ id: number; userId: number }>(
+          `SELECT id, "userId" FROM "Image" WHERE id = ANY($1::int[]) AND "userId" IS NOT NULL`,
+          [ids]
+        );
+        cancelFns.push(q.cancel);
+        for (const { id, userId } of await q.result()) ownerByImage.set(id, userId);
+      }
+
+      // Roll up per owner for this window.
+      const perOwner = new Map<number, { reactions: number; comments: number }>();
+      for (const { imageId, reactions, comments } of engaged) {
+        const owner = ownerByImage.get(imageId);
+        if (!owner) continue;
+        const acc = perOwner.get(owner) ?? { reactions: 0, comments: 0 };
+        acc.reactions += Number(reactions);
+        acc.comments += Number(comments);
+        perOwner.set(owner, acc);
+      }
+      if (!perOwner.size) return;
+
+      // Upsert with += so an owner's images across multiple windows accumulate.
+      // Postgres row locks serialize concurrent windows touching the same owner.
+      const rows = [...perOwner].map(([user_id, a]) => ({ user_id, ...a }));
+      const upsert = await pgDbWrite.cancellableQuery(
+        `INSERT INTO ${STAGING} (user_id, reactions, comments)
+         SELECT user_id, reactions, comments
+         FROM jsonb_to_recordset($1::jsonb) AS x(user_id int, reactions bigint, comments bigint)
+         ON CONFLICT (user_id) DO UPDATE SET
+           reactions = ${STAGING}.reactions + EXCLUDED.reactions,
+           comments = ${STAGING}.comments + EXCLUDED.comments`,
+        [JSON.stringify(rows)]
+      );
+      cancelFns.push(upsert.cancel);
+      await upsert.result();
+
+      console.log(`scan: imageId ${start}-${end} → ${engaged.length} engaged, ${perOwner.size} owners`);
+    },
+  });
+}
+
+// Phase 2: write each staged owner's score + total + the backfill marker. Skips
+// owners already marked, so it's resumable and never recomputes a finished owner.
+async function apply(
+  res: NextApiResponse,
+  params: z.infer<typeof schema>,
+  imageMultipliers: { reactions: number; comments: number; views: number }
+) {
+  const stampedAt = new Date().toISOString();
+  // apply windows by userId, not entityId.
+  const applyParams = { ...params, batchSize: Math.min(params.batchSize, 50_000) };
+
+  await dataProcessor({
+    params: applyParams,
+    runContext: res,
+    rangeFetcher: async (ctx) => {
+      const [{ max }] = await pgDbRead
+        .cancellableQuery<{ max: number }>(`SELECT MAX(user_id) AS max FROM ${STAGING}`)
+        .then((q) => q.result());
+      return { start: ctx.start, end: max ?? 0 };
+    },
+    processor: async ({ start, end, cancelFns }) => {
+      // Staged owners in this userId window that haven't been stamped yet.
+      const q = await pgDbRead.cancellableQuery<{ user_id: number; reactions: number; comments: number }>(
+        `SELECT s.user_id, s.reactions, s.comments
+         FROM ${STAGING} s
+         JOIN "User" u ON u.id = s.user_id
+         WHERE s.user_id >= $1 AND s.user_id <= $2
+           AND (u.meta->'scores'->>'imagesBackfilledAt') IS NULL`,
         [start, end]
       );
-      cancelFns.push(ownerQuery.cancel);
-      const owners = (await ownerQuery.result()).map((r) => r.id);
+      cancelFns.push(q.cancel);
+      const owners = await q.result();
       if (!owners.length) return;
 
-      const scores = await computeImageScores(
-        { ch: clickhouse!, pg: pgDbRead, scoreMultipliers, onCancel: (cancel) => cancelFns.push(cancel) },
-        owners
-      );
+      // images score + recomputed total (shared with the cron).
       const records = owners.map(
-        (uid) => [String(uid), { images: scores.get(uid)?.score ?? 0 }] as [string, { images: number }]
+        ({ user_id, reactions, comments }) =>
+          [
+            String(user_id),
+            {
+              images: Number(reactions) * imageMultipliers.reactions + Number(comments) * imageMultipliers.comments,
+            },
+          ] as [string, { images: number }]
       );
       await applyUserScoreUpdates(pgDbWrite, records, (cancel) => cancelFns.push(cancel));
 
-      console.log(`backfill-image-scores: userId ${start}-${end} → ${owners.length} owners updated`);
+      // Stamp the marker so a re-run skips these owners.
+      const markQuery = await pgDbWrite.cancellableQuery(
+        `UPDATE "User"
+         SET meta = jsonb_set(COALESCE(meta, '{}'), '{scores,imagesBackfilledAt}', to_jsonb($1::text))
+         WHERE id = ANY($2::int[])`,
+        [stampedAt, owners.map((o) => o.user_id)]
+      );
+      cancelFns.push(markQuery.cancel);
+      await markQuery.result();
+
+      console.log(`apply: userId ${start}-${end} → ${owners.length} owners written`);
     },
   });
 }

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -1,0 +1,99 @@
+import { Prisma } from '@prisma/client';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { clickhouse } from '~/server/clickhouse/client';
+import { dbRead } from '~/server/db/client';
+import { dataProcessor } from '~/server/db/db-helpers';
+import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
+import {
+  applyUserScoreUpdates,
+  computeImageScores,
+  getScoreMultipliers,
+} from '~/server/jobs/update-user-score';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+/**
+ * One-off backfill for the creator-score `images` category.
+ *
+ * The image score was silently 0 for everyone (the cron read the stale
+ * `image_metrics_user` table). The fix in `update-user-score` reads
+ * `entityMetricDailyAgg_v2`, but it's incremental — it only revisits owners with
+ * recent image engagement. This sweep recomputes EVERY image owner's `images`
+ * score (and their `total`) so the historically-missing contribution is restored.
+ *
+ * Idempotent: each owner's score is recomputed from current v2 metrics, so
+ * re-running (or re-running a sub-range) is safe.
+ *
+ * Ranges over `Image."userId"` windows via `dataProcessor`; each window resolves
+ * its owners, scores them with the shared `computeImageScores`, and writes via
+ * `applyUserScoreUpdates`. Runs to completion in a single request — drive it from
+ * the no-timeout dev server (which talks to prod) and keep the client connected
+ * (nohup/screen); disconnecting cancels in-flight queries.
+ *
+ * Auth via the existing `WebhookEndpoint(?token=...)` gate.
+ *
+ * Usage:
+ *   GET /api/admin/temp/backfill-image-scores?token=<WEBHOOK_TOKEN>
+ *   optional: &concurrency=3 &batchSize=10000 &start=0 &end=<maxUserId>
+ *   start/end target an inclusive userId range — `start=X&end=X` backfills exactly
+ *   user X; omit both to sweep everyone; set start=<lastId> to resume.
+ */
+
+const schema = z.object({
+  concurrency: z.coerce.number().min(1).max(20).optional().default(3),
+  // width of the Image."userId" window handled per task (sparse id space, so a
+  // window holds far fewer owners than its width).
+  batchSize: z.coerce.number().min(1).optional().default(10000),
+  start: z.coerce.number().min(0).optional().default(0),
+  end: z.coerce.number().min(0).optional(),
+});
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  if (!clickhouse) return res.status(503).json({ error: 'ClickHouse is not available' });
+
+  console.time('BACKFILL_IMAGE_SCORES');
+  await backfillImageScores(req, res);
+  console.timeEnd('BACKFILL_IMAGE_SCORES');
+
+  res.status(200).json({ finished: true });
+});
+
+async function backfillImageScores(req: NextApiRequest, res: NextApiResponse) {
+  const params = schema.parse(req.query);
+  const scoreMultipliers = await getScoreMultipliers();
+
+  await dataProcessor({
+    params,
+    runContext: res,
+    rangeFetcher: async (ctx) => {
+      const [{ max }] = await dbRead.$queryRaw<{ max: number }[]>(
+        Prisma.sql`SELECT MAX("userId") "max" FROM "Image"`
+      );
+      return { start: ctx.start, end: max ?? 0 };
+    },
+    processor: async ({ start, end, cancelFns }) => {
+      // Distinct owners in this userId window (bounded range → cheap index scan).
+      // Inclusive lower bound so `start=X&end=X` targets exactly user X (and so
+      // consecutive dataProcessor windows stay contiguous with no skipped id).
+      const ownerQuery = await pgDbRead.cancellableQuery<{ id: number }>(`
+        SELECT DISTINCT "userId" AS id
+        FROM "Image"
+        WHERE "userId" >= ${start} AND "userId" <= ${end} AND "userId" IS NOT NULL
+      `);
+      cancelFns.push(ownerQuery.cancel);
+      const owners = (await ownerQuery.result()).map((r) => r.id);
+      if (!owners.length) return;
+
+      const scores = await computeImageScores(
+        { ch: clickhouse!, pg: pgDbRead, scoreMultipliers, onCancel: (cancel) => cancelFns.push(cancel) },
+        owners
+      );
+      const records = owners.map(
+        (uid) => [String(uid), { images: scores.get(uid)?.score ?? 0 }] as [string, { images: number }]
+      );
+      await applyUserScoreUpdates(pgDbWrite, records, (cancel) => cancelFns.push(cancel));
+
+      console.log(`backfill-image-scores: userId ${start}-${end} → ${owners.length} owners updated`);
+    },
+  });
+}

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -27,12 +27,12 @@ import { limitConcurrency } from '~/server/utils/concurrency-helpers';
  * Run it (drive from the no-timeout dev server, which talks to prod; keep the
  * client connected — nohup/screen):
  *   GET /api/admin/temp/backfill-image-scores?token=$WEBHOOK_TOKEN
- *   optional: &concurrency=3 &batchSize=1000000 &skipMarked=true
+ *   optional: &concurrency=3 &batchSize=1000000 &dryRun=true
  *
- * Idempotent: rewriting an owner produces the same score. `skipMarked=true` skips
- * owners already stamped (so a re-run only fills in the rest). Run the FULL range
- * (default) — a partial start/end gives partial scores since an owner's images
- * are spread across the id space.
+ * Idempotent + resumable: owners already stamped with `imagesBackfilledAt` are
+ * always skipped, so a re-run only fills in the rest (never recomputes finished
+ * users). Run the FULL range (default) — a partial start/end gives partial scores
+ * since an owner's images are spread across the id space.
  *
  * Auth via the existing `WebhookEndpoint(?token=...)` gate.
  */
@@ -44,11 +44,6 @@ const schema = z.object({
   batchSize: z.coerce.number().min(1).optional().default(1_000_000), // entityId window per v2 scan
   start: z.coerce.number().min(0).optional().default(0),
   end: z.coerce.number().min(0).optional(),
-  // re-run helper: skip owners already stamped instead of rewriting them.
-  skipMarked: z
-    .union([z.boolean(), z.string()])
-    .optional()
-    .transform((v) => v === true || v === 'true' || v === '1'),
   // preview: scan + count owners, write nothing.
   dryRun: z
     .union([z.boolean(), z.string()])
@@ -122,21 +117,19 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
   const stampedAt = new Date().toISOString();
   let written = 0;
   const writeTasks = chunk([...owners], 500).map((batch) => async () => {
-    const ids = batch.map(([userId]) => userId);
+    // Always skip owners already backfilled — they're computed, and skipping makes
+    // a re-run resume (only fills in the rest) instead of redoing finished users.
+    const stamped = await pgDbRead
+      .cancellableQuery<{ id: number }>(
+        `SELECT id FROM "User" WHERE id = ANY($1::int[]) AND (meta->'scores'->>'imagesBackfilledAt') IS NOT NULL`,
+        [batch.map(([userId]) => userId)]
+      )
+      .then((q) => q.result());
+    const skip = new Set(stamped.map((s) => s.id));
+    const todo = batch.filter(([userId]) => !skip.has(userId));
+    if (!todo.length) return;
 
-    if (params.skipMarked) {
-      const stamped = await pgDbRead
-        .cancellableQuery<{ id: number }>(
-          `SELECT id FROM "User" WHERE id = ANY($1::int[]) AND (meta->'scores'->>'imagesBackfilledAt') IS NOT NULL`,
-          [ids]
-        )
-        .then((q) => q.result());
-      const skip = new Set(stamped.map((s) => s.id));
-      batch = batch.filter(([userId]) => !skip.has(userId));
-      if (!batch.length) return;
-    }
-
-    const records = batch.map(
+    const records = todo.map(
       ([userId, { reactions, comments }]) =>
         [
           String(userId),
@@ -150,11 +143,11 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
         `UPDATE "User"
          SET meta = jsonb_set(COALESCE(meta, '{}'), '{scores,imagesBackfilledAt}', to_jsonb($1::text))
          WHERE id = ANY($2::int[])`,
-        [stampedAt, batch.map(([userId]) => userId)]
+        [stampedAt, todo.map(([userId]) => userId)]
       )
       .then((q) => q.result());
 
-    written += batch.length;
+    written += todo.length;
   });
   await limitConcurrency(writeTasks, params.concurrency);
 

--- a/src/pages/api/admin/temp/backfill-image-scores.ts
+++ b/src/pages/api/admin/temp/backfill-image-scores.ts
@@ -9,6 +9,7 @@ import { pgDbRead, pgDbWrite } from '~/server/db/pgDb';
 import { applyUserScoreUpdates, getScoreMultipliers } from '~/server/jobs/update-user-score';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { booleanString } from '~/utils/zod-helpers';
 
 /**
  * One-off backfill for the creator-score `images` category — a single command.
@@ -22,14 +23,14 @@ import { limitConcurrency } from '~/server/utils/concurrency-helpers';
  * Image-driven, so it scans the slow v2 view ONCE in entityId ranges (~135 range
  * scans) instead of re-querying it per owner (~23k random IN lookups, ~60h). One
  * pass: range-scan v2 for engaged images, roll reactions/comments up per owner in
- * memory, then write each owner's score + total and stamp `imagesBackfilledAt`.
+ * memory, then write each owner's score + total and stamp `imageScoreRecomputedAt`.
  *
  * Run it (drive from the no-timeout dev server, which talks to prod; keep the
  * client connected — nohup/screen):
  *   GET /api/admin/temp/backfill-image-scores?token=$WEBHOOK_TOKEN
  *   optional: &concurrency=3 &batchSize=1000000 &dryRun=true
  *
- * Idempotent + resumable: owners already stamped with `imagesBackfilledAt` are
+ * Idempotent + resumable: owners already stamped with `imageScoreRecomputedAt` are
  * always skipped, so a re-run only fills in the rest (never recomputes finished
  * users). Run the FULL range (default) — a partial start/end gives partial scores
  * since an owner's images are spread across the id space.
@@ -45,10 +46,7 @@ const schema = z.object({
   start: z.coerce.number().min(0).optional().default(0),
   end: z.coerce.number().min(0).optional(),
   // preview: scan + count owners, write nothing.
-  dryRun: z
-    .union([z.boolean(), z.string()])
-    .optional()
-    .transform((v) => v === true || v === 'true' || v === '1'),
+  dryRun: booleanString().default(true),
 });
 
 export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
@@ -121,7 +119,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     // a re-run resume (only fills in the rest) instead of redoing finished users.
     const stamped = await pgDbRead
       .cancellableQuery<{ id: number }>(
-        `SELECT id FROM "User" WHERE id = ANY($1::int[]) AND (meta->'scores'->>'imagesBackfilledAt') IS NOT NULL`,
+        `SELECT id FROM "User" WHERE id = ANY($1::int[]) AND (meta->'scores'->>'imageScoreRecomputedAt') IS NOT NULL`,
         [batch.map(([userId]) => userId)]
       )
       .then((q) => q.result());
@@ -141,7 +139,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     await pgDbWrite
       .cancellableQuery(
         `UPDATE "User"
-         SET meta = jsonb_set(COALESCE(meta, '{}'), '{scores,imagesBackfilledAt}', to_jsonb($1::text))
+         SET meta = jsonb_set(COALESCE(meta, '{}'), '{scores,imageScoreRecomputedAt}', to_jsonb($1::text))
          WHERE id = ANY($2::int[])`,
         [stampedAt, todo.map(([userId]) => userId)]
       )

--- a/src/server/jobs/update-user-score.ts
+++ b/src/server/jobs/update-user-score.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from '@prisma/client';
 import { chunk } from 'lodash-es';
 import type { CustomClickHouseClient } from '~/server/clickhouse/client';
 import { clickhouse } from '~/server/clickhouse/client';
-import { dbWrite } from '~/server/db/client';
+import { dbRead, dbWrite } from '~/server/db/client';
 import type { AugmentedPool } from '~/server/db/db-helpers';
 import { templateHandler } from '~/server/db/db-helpers';
 import { pgDbWrite } from '~/server/db/pgDb';
@@ -112,21 +112,110 @@ async function getArticleScore(ctx: Context) {
 }
 
 async function getImageScore(ctx: Context) {
-  const affected = await ctx.ch.$query<{ userId: number; score: number }>`
-    SELECT
-      userId,
-      (
-        sumMerge(reactions) * ${ctx.scoreMultipliers.images.reactions}
-        + sumMerge(comments) * ${ctx.scoreMultipliers.images.comments}
-      ) as score
-    FROM   image_metrics_user
-    GROUP  BY userId
-    HAVING maxMerge(updatedAt) >= ${ctx.lastUpdate}
-  `;
+  // Image engagement now lives in the v2 entity-metric aggregate (the legacy
+  // `image_metrics_user` table is stale post-cutover). `entityMetricDailyAgg_v2`
+  // is keyed by imageId with no owner column, and the ClickHouse `images` event
+  // table is an incomplete owner source (event-sourced; missing Create rows for
+  // older images), so the imageId -> owner join must come from Postgres.
 
-  for (const { userId, score } of affected) {
-    ctx.setScore(userId, 'images', score);
+  // 1. Images whose engagement changed since the last run (event stream).
+  const changed = await ctx.ch.$query<{ imageId: number }>`
+    SELECT DISTINCT entityId AS imageId
+    FROM entityMetricEvents_month
+    WHERE entityType = 'Image'
+    AND createdAt > ${ctx.lastUpdate}
+  `;
+  if (!changed.length) return;
+  const changedImageIds = changed.map((x) => x.imageId);
+
+  // 2. Changed images -> affected owners (Postgres is the authoritative owner map).
+  const affectedUserIds = new Set<number>();
+  for (const ids of chunk(changedImageIds, 10000)) {
+    const query = await ctx.pg.cancellableQuery<{ userId: number }>(`
+      SELECT DISTINCT "userId" FROM "Image"
+      WHERE id IN (${ids.join(',')}) AND "userId" IS NOT NULL
+    `);
+    ctx.jobContext.on('cancel', query.cancel);
+    for (const { userId } of await query.result()) affectedUserIds.add(userId);
   }
+  if (!affectedUserIds.size) return;
+
+  // 3. Recompute each affected owner's FULL all-time image score (including
+  // owners who now total 0, so a previously-stale score is corrected downward).
+  const scores = await computeImageScores(
+    {
+      ch: ctx.ch,
+      pg: ctx.pg,
+      scoreMultipliers: ctx.scoreMultipliers,
+      onCancel: (cancel) => ctx.jobContext.on('cancel', cancel),
+    },
+    [...affectedUserIds]
+  );
+  for (const [userId, { score }] of scores) ctx.setScore(userId, 'images', score);
+}
+
+type ImageScoreDeps = {
+  ch: CustomClickHouseClient;
+  pg: AugmentedPool;
+  scoreMultipliers: ScoreMultipliers;
+  onCancel?: (cancel: () => Promise<void>) => void;
+};
+
+export type ImageScoreBreakdown = { reactions: number; comments: number; score: number };
+
+// Compute each user's all-time image score from the v2 entity-metric aggregate.
+// `entityMetricDailyAgg_v2` is keyed by imageId with no owner, so the
+// imageId -> owner mapping comes from Postgres `Image` (the ClickHouse `images`
+// event table is an incomplete owner source). Every requested userId is present
+// in the result (score 0 when there's no engagement). Shared by the cron job and
+// the `testing/user-score` debug endpoint so both exercise the same logic.
+export async function computeImageScores(
+  deps: ImageScoreDeps,
+  userIds: number[]
+): Promise<Map<number, ImageScoreBreakdown>> {
+  const result = new Map<number, ImageScoreBreakdown>();
+  if (!userIds.length) return result;
+
+  // imageId -> userId for every image these users own.
+  const ownerByImage = new Map<number, number>();
+  for (const ids of chunk(userIds, 1000)) {
+    const query = await deps.pg.cancellableQuery<{ id: number; userId: number }>(`
+      SELECT id, "userId" FROM "Image" WHERE "userId" IN (${ids.join(',')})
+    `);
+    deps.onCancel?.(query.cancel);
+    for (const { id, userId } of await query.result()) ownerByImage.set(id, userId);
+  }
+
+  // Sum per-image reactions/comments from the v2 aggregate, roll up per owner.
+  const totals = new Map<number, { reactions: number; comments: number }>();
+  for (const ids of chunk([...ownerByImage.keys()], 5000)) {
+    const rows = await deps.ch.$query<{ imageId: number; reactions: number; comments: number }>(`
+      SELECT entityId AS imageId,
+        sumIf(total, metricType IN ('Like', 'Heart', 'Laugh', 'Cry')) AS reactions,
+        sumIf(total, metricType = 'commentCount') AS comments
+      FROM entityMetricDailyAgg_v2
+      WHERE entityType = 'Image'
+      AND entityId IN (${ids.join(',')})
+      GROUP BY entityId
+    `);
+    for (const { imageId, reactions, comments } of rows) {
+      const userId = ownerByImage.get(imageId);
+      if (!userId) continue;
+      const acc = totals.get(userId) ?? { reactions: 0, comments: 0 };
+      acc.reactions += Number(reactions);
+      acc.comments += Number(comments);
+      totals.set(userId, acc);
+    }
+  }
+
+  for (const userId of userIds) {
+    const { reactions, comments } = totals.get(userId) ?? { reactions: 0, comments: 0 };
+    const score =
+      reactions * deps.scoreMultipliers.images.reactions +
+      comments * deps.scoreMultipliers.images.comments;
+    result.set(userId, { reactions, comments, score });
+  }
+  return result;
 }
 
 async function getUserScore(ctx: Context) {
@@ -177,32 +266,45 @@ async function getReportAgainstScore(ctx: Context) {
 }
 
 async function getUpdateTotalTasks(ctx: Context) {
-  const tasks = chunk(Object.entries(ctx.toUpdate), BATCH_SIZE).map((records, i) => async () => {
+  const tasks = chunk(Object.entries(ctx.toUpdate), BATCH_SIZE).map((records) => async () => {
     ctx.jobContext.checkIfCanceled();
-
-    const dataJson = JSON.stringify(records.map(([id, scores]) => ({ id: +id, scores })));
-    const updateQuery = await ctx.pg.cancellableQuery(`
-      WITH scores AS (SELECT * FROM jsonb_to_recordset('${dataJson}') AS x("id" int, "scores" jsonb))
-      UPDATE "User" u
-        SET meta = jsonb_set(COALESCE(meta, '{}'), '{scores}', COALESCE(meta->'scores', '{}') || s.scores || jsonb_build_object('total',
-            COALESCE((s.scores->>'models')::numeric, (u.meta->'scores'->>'models')::numeric, 0)
-            + COALESCE((s.scores->>'articles')::numeric, (u.meta->'scores'->>'articles')::numeric, 0)
-            + COALESCE((s.scores->>'images')::numeric, (u.meta->'scores'->>'images')::numeric, 0)
-            + COALESCE((s.scores->>'users')::numeric, (u.meta->'scores'->>'users')::numeric, 0)
-            + COALESCE((s.scores->>'reportsActioned')::numeric, (u.meta->'scores'->>'reportsActioned')::numeric, 0)
-            + COALESCE((s.scores->>'reportsAgainst')::numeric, (u.meta->'scores'->>'reportsAgainst')::numeric, 0)
-          )
-        )
-      FROM scores s
-      WHERE s.id = u.id;
-    `);
-    ctx.jobContext.on('cancel', updateQuery.cancel);
-    await updateQuery.result();
-
+    await applyUserScoreUpdates(ctx.pg, records, (cancel) => ctx.jobContext.on('cancel', cancel));
     userUpdateCounter?.inc({ location: 'job:update-user-score' }, records.length);
   });
 
   return tasks;
+}
+
+// Persist per-category scores and recompute `total` for a batch of users in one
+// statement. `records` are `[userId, { category: score }]` entries; each total is
+// the sum of the six categories, taking the freshly-supplied value when present
+// and otherwise the user's previously-stored value. Shared by the cron job and
+// the `testing/user-score` debug endpoint.
+export async function applyUserScoreUpdates(
+  pg: AugmentedPool,
+  records: [string, Partial<Record<ScoreCategory, number>>][],
+  onCancel?: (cancel: () => Promise<void>) => void
+) {
+  if (!records.length) return;
+
+  const dataJson = JSON.stringify(records.map(([id, scores]) => ({ id: +id, scores })));
+  const updateQuery = await pg.cancellableQuery(`
+    WITH scores AS (SELECT * FROM jsonb_to_recordset('${dataJson}') AS x("id" int, "scores" jsonb))
+    UPDATE "User" u
+      SET meta = jsonb_set(COALESCE(meta, '{}'), '{scores}', COALESCE(meta->'scores', '{}') || s.scores || jsonb_build_object('total',
+          COALESCE((s.scores->>'models')::numeric, (u.meta->'scores'->>'models')::numeric, 0)
+          + COALESCE((s.scores->>'articles')::numeric, (u.meta->'scores'->>'articles')::numeric, 0)
+          + COALESCE((s.scores->>'images')::numeric, (u.meta->'scores'->>'images')::numeric, 0)
+          + COALESCE((s.scores->>'users')::numeric, (u.meta->'scores'->>'users')::numeric, 0)
+          + COALESCE((s.scores->>'reportsActioned')::numeric, (u.meta->'scores'->>'reportsActioned')::numeric, 0)
+          + COALESCE((s.scores->>'reportsAgainst')::numeric, (u.meta->'scores'->>'reportsAgainst')::numeric, 0)
+        )
+      )
+    FROM scores s
+    WHERE s.id = u.id;
+  `);
+  onCancel?.(updateQuery.cancel);
+  await updateQuery.result();
 }
 
 // #region [helpers]
@@ -230,12 +332,40 @@ type ScoreMultipliers = {
 };
 type ScoreCategory = keyof ScoreMultipliers | 'total';
 
-export async function getScoreMultipliers() {
-  const data = await sysRedis.packed.get<ScoreMultipliers>(
-    REDIS_SYS_KEYS.SYSTEM.USER_SCORE_MULTIPLIERS
-  );
-  if (!data) throw new Error('User score multipliers not found in redis');
-  return data;
+// The multipliers live in the `system:user-score-multipliers` key, stored both
+// in sysRedis (legacy/hot-override) and PG `KeyValue` (durable). Same key string
+// for both stores.
+const USER_SCORE_MULTIPLIERS_KEY = REDIS_SYS_KEYS.SYSTEM.USER_SCORE_MULTIPLIERS;
+
+// Hardcoded last-resort default. Recovered 2026-06-22 after the sysRedis instance
+// was wiped ~2026-05-14, which dropped the only copy of these values and silently
+// killed this job for ~39 nights (it threw on the missing key before any category
+// ran). Reverse-engineered from frozen `User.meta.scores`: 5/6 categories exact;
+// articles.comments/reactions are a best-estimate (~5% noise). Prefer the values
+// in redis/KeyValue over these once re-seeded.
+const DEFAULT_SCORE_MULTIPLIERS: ScoreMultipliers = {
+  models: { reviews: 10, downloads: 1, generations: 1 },
+  articles: { views: 1, comments: 25, reactions: 10 },
+  images: { views: 0, comments: 20, reactions: 10 },
+  users: { followers: 50 },
+  reportsActioned: 50,
+  reportsAgainst: -1000,
+};
+
+// Defense in depth so a single wiped store can never freeze all user scores
+// again: sysRedis (hot override) -> PG KeyValue (durable) -> hardcoded default.
+export async function getScoreMultipliers(): Promise<ScoreMultipliers> {
+  const fromRedis = await sysRedis.packed.get<ScoreMultipliers>(USER_SCORE_MULTIPLIERS_KEY);
+  if (fromRedis) return fromRedis;
+
+  const fromDb = await dbRead.keyValue.findUnique({ where: { key: USER_SCORE_MULTIPLIERS_KEY } });
+  if (fromDb?.value) {
+    log('score multipliers: sysRedis miss, falling back to PG KeyValue');
+    return fromDb.value as unknown as ScoreMultipliers;
+  }
+
+  log('score multipliers: sysRedis + KeyValue miss, using hardcoded default');
+  return DEFAULT_SCORE_MULTIPLIERS;
 }
 
 function getAffected(ctx: Context) {

--- a/src/server/jobs/update-user-score.ts
+++ b/src/server/jobs/update-user-score.ts
@@ -118,11 +118,14 @@ async function getImageScore(ctx: Context) {
   // table is an incomplete owner source (event-sourced; missing Create rows for
   // older images), so the imageId -> owner join must come from Postgres.
 
-  // 1. Images whose engagement changed since the last run (event stream).
+  // 1. Images whose score-relevant engagement changed since the last run. Only
+  // reactions + comments feed the image score, so we ignore view/collection/tip
+  // events here to avoid rescoring owners whose score can't have changed.
   const changed = await ctx.ch.$query<{ imageId: number }>`
     SELECT DISTINCT entityId AS imageId
     FROM entityMetricEvents_month
     WHERE entityType = 'Image'
+    AND metricType IN ('Like', 'Heart', 'Laugh', 'Cry', 'commentCount')
     AND createdAt > ${ctx.lastUpdate}
   `;
   if (!changed.length) return;
@@ -131,10 +134,10 @@ async function getImageScore(ctx: Context) {
   // 2. Changed images -> affected owners (Postgres is the authoritative owner map).
   const affectedUserIds = new Set<number>();
   for (const ids of chunk(changedImageIds, 10000)) {
-    const query = await ctx.pg.cancellableQuery<{ userId: number }>(`
-      SELECT DISTINCT "userId" FROM "Image"
-      WHERE id IN (${ids.join(',')}) AND "userId" IS NOT NULL
-    `);
+    const query = await ctx.pg.cancellableQuery<{ userId: number }>(
+      `SELECT DISTINCT "userId" FROM "Image" WHERE id = ANY($1::int[]) AND "userId" IS NOT NULL`,
+      [ids]
+    );
     ctx.jobContext.on('cancel', query.cancel);
     for (const { userId } of await query.result()) affectedUserIds.add(userId);
   }
@@ -168,7 +171,7 @@ export type ImageScoreBreakdown = { reactions: number; comments: number; score: 
 // imageId -> owner mapping comes from Postgres `Image` (the ClickHouse `images`
 // event table is an incomplete owner source). Every requested userId is present
 // in the result (score 0 when there's no engagement). Shared by the cron job and
-// the `testing/user-score` debug endpoint so both exercise the same logic.
+// the `admin/temp/backfill-image-scores` endpoint so both exercise the same logic.
 export async function computeImageScores(
   deps: ImageScoreDeps,
   userIds: number[]
@@ -179,9 +182,10 @@ export async function computeImageScores(
   // imageId -> userId for every image these users own.
   const ownerByImage = new Map<number, number>();
   for (const ids of chunk(userIds, 1000)) {
-    const query = await deps.pg.cancellableQuery<{ id: number; userId: number }>(`
-      SELECT id, "userId" FROM "Image" WHERE "userId" IN (${ids.join(',')})
-    `);
+    const query = await deps.pg.cancellableQuery<{ id: number; userId: number }>(
+      `SELECT id, "userId" FROM "Image" WHERE "userId" = ANY($1::int[])`,
+      [ids]
+    );
     deps.onCancel?.(query.cancel);
     for (const { id, userId } of await query.result()) ownerByImage.set(id, userId);
   }

--- a/src/server/jobs/update-user-score.ts
+++ b/src/server/jobs/update-user-score.ts
@@ -352,19 +352,26 @@ const DEFAULT_SCORE_MULTIPLIERS: ScoreMultipliers = {
   reportsAgainst: -1000,
 };
 
-// Defense in depth so a single wiped store can never freeze all user scores
-// again: sysRedis (hot override) -> PG KeyValue (durable) -> hardcoded default.
+// Defense in depth so a single wiped/offline store can never freeze all user
+// scores again: sysRedis (hot override) -> PG KeyValue (durable) -> hardcoded
+// default. Each read is guarded so an ERROR (e.g. redis client offline), not just
+// a miss, falls through to the next source.
 export async function getScoreMultipliers(): Promise<ScoreMultipliers> {
-  const fromRedis = await sysRedis.packed.get<ScoreMultipliers>(USER_SCORE_MULTIPLIERS_KEY);
-  if (fromRedis) return fromRedis;
-
-  const fromDb = await dbRead.keyValue.findUnique({ where: { key: USER_SCORE_MULTIPLIERS_KEY } });
-  if (fromDb?.value) {
-    log('score multipliers: sysRedis miss, falling back to PG KeyValue');
-    return fromDb.value as unknown as ScoreMultipliers;
+  try {
+    const fromRedis = await sysRedis.packed.get<ScoreMultipliers>(USER_SCORE_MULTIPLIERS_KEY);
+    if (fromRedis) return fromRedis;
+  } catch (e) {
+    log('score multipliers: sysRedis read failed, falling back to KeyValue', (e as Error).message);
   }
 
-  log('score multipliers: sysRedis + KeyValue miss, using hardcoded default');
+  try {
+    const fromDb = await dbRead.keyValue.findUnique({ where: { key: USER_SCORE_MULTIPLIERS_KEY } });
+    if (fromDb?.value) return fromDb.value as unknown as ScoreMultipliers;
+  } catch (e) {
+    log('score multipliers: KeyValue read failed, using default', (e as Error).message);
+  }
+
+  log('score multipliers: sysRedis + KeyValue unavailable, using hardcoded default');
   return DEFAULT_SCORE_MULTIPLIERS;
 }
 

--- a/src/utils/number-helpers.ts
+++ b/src/utils/number-helpers.ts
@@ -79,19 +79,24 @@ export function abbreviateNumber(
   const suffixes = ['', 'k', 'm', 'b', 't'];
   let index = 0;
 
-  while (value >= 1000 && index < suffixes.length - 1) {
-    value /= 1000;
+  // Abbreviate on magnitude, then re-apply the sign — negative scores (e.g. a
+  // reportsAgainst-heavy user) are valid and must abbreviate like positives.
+  const sign = value < 0 ? '-' : '';
+  let magnitude = Math.abs(value);
+
+  while (magnitude >= 1000 && index < suffixes.length - 1) {
+    magnitude /= 1000;
     index++;
   }
 
   if (floor) {
-    value = Math.floor(value);
+    magnitude = Math.floor(magnitude);
   }
 
   const formattedValue =
-    Math.round(value * Math.pow(10, decimals ?? 0)) / Math.pow(10, decimals ?? 0);
+    Math.round(magnitude * Math.pow(10, decimals ?? 0)) / Math.pow(10, decimals ?? 0);
 
-  return `${formattedValue}${suffixes[index]}`;
+  return `${sign}${formattedValue}${suffixes[index]}`;
 }
 
 export function getRandomInt(min: number, max: number) {


### PR DESCRIPTION
Fixes the creator-score **images** category (silently 0 for everyone — the job read a stale table) and hardens multiplier loading so a wiped redis can't freeze all scores again.

- Image score now reads `entityMetricDailyAgg_v2` (legacy `image_metrics_user` is stale)
- `getScoreMultipliers`: redis → PG `KeyValue` → hardcoded recovered defaults
- `admin/temp/backfill-image-scores` — one-off sweep to backfill existing owners' image score + total
- `UserScoreDisplay` redesigned: sectioned bar + macOS-style dot legend, abbreviated total

🤖 Generated with [Claude Code](https://claude.com/claude-code)
