### PR TITLE
fix(images): harden CH image-metrics timeout env + test the soft-fallback counter

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -258,7 +258,10 @@ export const serverSchema = z.object({
   // next render serves real numbers. Callers already treat missing ids as null
   // metrics. The durable fix is the slow CH query itself (out of scope here).
   // Default 3000ms — snappy SSR over correctness on the first cold render.
-  CLICKHOUSE_IMAGE_METRICS_TIMEOUT_MS: z.coerce.number().default(3000),
+  // .int().positive() so a misconfigured 0 / negative fails fast at BOOT instead
+  // of silently disabling the guard (withTimeoutFallback passes through unbounded
+  // when ms<=0 → the exact ~30s hang this exists to prevent, with no signal).
+  CLICKHOUSE_IMAGE_METRICS_TIMEOUT_MS: z.coerce.number().int().positive().default(3000),
   NODE_ENV: z.enum(['development', 'test', 'production']),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.preprocess(

--- a/src/server/services/__tests__/image-metrics-timeout.test.ts
+++ b/src/server/services/__tests__/image-metrics-timeout.test.ts
@@ -12,7 +12,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // so importing image.service doesn't boot real infra (the established pattern in
 // the other service tests, e.g. block-registry.subscriptions.test.ts).
 
-const { fetch: fetchMock } = vi.hoisted(() => ({ fetch: vi.fn() }));
+const { fetch: fetchMock, counterIncMock } = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  counterIncMock: vi.fn(),
+}));
+
+// Capture the soft-fallback Prometheus counter. image.service creates exactly one
+// counter via `registerCounter` (imageMetricsClickhouseTimeoutCounter); override
+// just that export with a shared spy so we can assert it increments on the timeout
+// path, while keeping every other prom helper real (the import graph also uses
+// registerGaugeWithLabels / registerCounterWithLabels at module load).
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/prom/client')>();
+  return { ...actual, registerCounter: () => ({ inc: counterIncMock }) };
+});
 
 // event-engine-common is a private git submodule not checked out in this
 // worktree — stub the value imports image.service pulls from it. MetricService
@@ -99,6 +112,8 @@ describe('getImageMetricsObject ClickHouse timeout fail-soft', () => {
       collection: 4,
       buzz: 100,
     });
+    // happy path must NOT count a soft-fallback
+    expect(counterIncMock).not.toHaveBeenCalled();
   });
 
   it('fails soft to all-null metrics within the timeout when the metric read HANGS (no parking)', async () => {
@@ -125,5 +140,7 @@ describe('getImageMetricsObject ClickHouse timeout fail-soft', () => {
         buzz: null,
       });
     }
+    // the timeout path must increment the soft-fallback counter exactly once
+    expect(counterIncMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Follow-up hardening to #2715 (merged), addressing the two 🟡s from the post-merge re-audit. Branched fresh off `main` (not stacked).

## Changes

### 1. `CLICKHOUSE_IMAGE_METRICS_TIMEOUT_MS` → `.int().positive()`
The re-audit found a silent foot-gun: a misconfigured `=0` or negative value parses cleanly (only non-numeric garbage throws at boot), and `withTimeoutFallback` passes through **unbounded** when `ms<=0` — re-introducing the exact ~30s SSR hang the guard exists to prevent, with **no counter/log signal**. Now `z.coerce.number().int().positive().default(3000)` fails fast at boot instead.

### 2. Test the soft-fallback counter
`image-metrics-timeout.test.ts` now asserts `image_metrics_clickhouse_timeout_total` increments exactly once on the timeout path and **not** on the happy path (the counter added in #2715 was previously untested). Uses `importOriginal` to override only `registerCounter` while keeping the rest of the prom helpers real.

## Tests
`vitest --project unit` — **7/7 green** (independently re-run).

## Notes
- The re-audit verdict on #2715 was *safe to merge, no blockers* — these are pure hardening, not correctness fixes.
- Accuracy correction (no code change): the original #2715 description claimed the un-aborted CH pile-up is "bounded by the Redis stampede lock to distinct cold ids." That's overstated — `LOCK_DURATION` is 2s but the CH fetch is ~4.6s and the timeout fires at 3s, so the lock expires before the fetch caches, leaving a ~2.6s window where a concurrent cold-miss for the same id re-hits CH. The pile-up is loosely bounded, not absolutely.
- **The real fix remains the slow CH query** (`entityMetricDailyAgg_v2`, ~4.6s p50) + a server-side `max_execution_time` guard in the `event-engine-common` submodule — tracked separately, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)