### PR TITLE
feat(app-blocks): dev-token endpoint for local live-mode (mod-gated, capped)

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -346,6 +346,8 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     maxBrowsingLevel: FORCED_SFW_CEILING,
   });
 
+  // The body carries a bearer JWT — never let an intermediary cache it.
+  res.setHeader('Cache-Control', 'no-store');
   res.status(200).json({
     token: result.token,
     expiresAt: result.expiresAt,

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -1,0 +1,357 @@
+import type { Logger } from '@civitai/next-axiom';
+import { withAxiom } from '@civitai/next-axiom';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { SessionUser } from 'next-auth';
+import * as z from 'zod';
+import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
+import { dbWrite } from '~/server/db/client';
+import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
+import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { BlockTokenService } from '~/server/services/block-token.service';
+import {
+  isKnownBlockScope,
+  validateBlockScopesAgainstOauthClient,
+} from '~/shared/constants/block-scope.constants';
+import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
+import { isPageSlot, PAGE_FORBIDDEN_SCOPES, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+
+type AxiomAPIRequest = NextApiRequest & { log: Logger };
+
+/**
+ * POST /api/v1/blocks/dev-token
+ *
+ * Mints a SHORT-LIVED, SCOPED, SELF-BOUND App-Block PAGE token so a logged-in
+ * DEVELOPER can drive their LOCAL harness's "live" mode against the real
+ * Civitai backend — testing local code with the dev's OWN real Buzz. This is
+ * the deliberately-different DEV path; the production mint at
+ * `/api/v1/block-tokens` stays untouched (exact-host same-origin, install-row
+ * bound).
+ *
+ * Designed per claudedocs/app-blocks-dev-token-endpoint-scope.md (§3 Option A,
+ * §4 Security Model). SCOPE OF THIS PR = the endpoint + its server-side caps +
+ * tests. The SDK-side `createLiveHost` proxy-host (forwarding the postMessage
+ * protocol to real endpoints) is the larger half and is EXPLICITLY OUT OF SCOPE
+ * — documented follow-up (scope doc §5.2, Phase 2).
+ *
+ * ## "Existing-app" mode (the ONLY mode shipped here — scope doc §3.3)
+ * The dev names an app they OWN (by `appBlockId` or `slug`). Scopes/budget are
+ * pinned to that APPROVED `AppBlock` row + its app's OAuth ceiling, so the blast
+ * radius ≈ prod and there is no escalation via an un-reviewed local manifest.
+ * The "local-manifest" mode (no approved row) is the higher-risk Phase 4 work
+ * and is NOT implemented.
+ *
+ * ## Auth — PERSONAL API key only (Bearer), resolved via the same
+ * `getSessionFromBearerToken` path the `/api/v1/*` REST routes use.
+ *  - Personal key (not cookie) → there is NO ambient credential to ride, so
+ *    CSRF is moot and we accept the dev's localhost origin WITHOUT relaxing the
+ *    prod mint's CORS. (scope doc §4.2 — the deliberately-different dev path.)
+ *  - OAuth-client-issued tokens are REJECTED here: the dev path is personal-key
+ *    only; an OAuth dev-token would need its own scope + sign-off (out of scope).
+ *
+ * ## Gates / hard caps (every one server-side + fail-closed — scope doc §4.1)
+ *  - MOD-ONLY (`isAppBlocksEnabled({ user })` + `user.isModerator`) — match the
+ *    pre-GA mod posture. The runtime spend procedures already call
+ *    `assertViewerIsModerator`, so a non-mod could mint but not spend; we keep
+ *    mint mod-gated anyway. RELAX in lockstep with the runtime belt at GA.
+ *  - SCOPE CLAMP: granted ⊆ the app's approved scopes ⊆ DEV_TOKEN_SCOPE_ALLOWLIST
+ *    (EXCLUDES `social:tip:self` + `block:settings:*`) ⊆ the app's OAuth ceiling
+ *    ⊆ requested (if the body narrows). Unknown / out-of-allowlist scopes are
+ *    STRIPPED, never error.
+ *  - BUDGET CAP: a LOWER dev cap (DEV_BUZZ_BUDGET_CAP) than the prod 1000. The
+ *    existing per-user daily cumulative cap (reserveBlockBuzzSpend) is untouched.
+ *  - FORCED SFW: maxBrowsingLevel = domainBrowsingCeiling(null) UNCONDITIONALLY
+ *    (localhost has no color domain; we never read the request host, so a
+ *    color-localhost dev config can't widen maturity). No mature path here.
+ *  - SELF-BOUND `sub`: the token's subject is the calling dev's userId; there is
+ *    no way to set it from the body.
+ *  - SHORT TTL: a PAGE token is signed by BlockTokenService.sign — 15min (the
+ *    service default; settings-scope tokens drop to 5min, but those scopes are
+ *    excluded here). That's the short, refresh-friendly window the harness wants.
+ *  - REVOCABLE: the synthetic `page_<appBlockId>` instance id is BlockRevocation-
+ *    checkable, identical to the prod page mint.
+ *  - RATE-LIMITED: per-user fixed window (same atomic SET NX EX + INCR shape as
+ *    the submit-version limiter), fail-closed on a malformed limiter result.
+ */
+export const config = {
+  api: {
+    // Tiny JSON body ({ appBlockId|slug, scopes?, buzzBudget? }). Cap well below
+    // Next's 1MB default so a determined caller can't push parse pressure.
+    bodyParser: { sizeLimit: '8kb' },
+  },
+};
+
+// A LOWER dev budget cap than the prod 1000 (scope doc §4.1). The dev spends
+// their OWN Buzz and the per-user daily cumulative cap is untouched; this just
+// bounds a single submit's reservation.
+const DEV_BUZZ_BUDGET_CAP = 250;
+const DEV_BUZZ_BUDGET_DEFAULT = 50;
+
+// Forced SFW — the dev endpoint NEVER reads the request host. localhost has no
+// color domain, and even a color-localhost dev config must not widen maturity.
+const FORCED_SFW_CEILING = domainBrowsingCeiling(null);
+
+const RATE_LIMIT = { max: 30, windowSeconds: 60 } as const;
+
+const PAGE_INSTANCE_PREFIX = 'page_';
+
+/**
+ * The DEV scope allowlist (scope doc §4.1): read/catalog scopes + the page
+ * spend scope + per-app storage. DELIBERATELY EXCLUDES:
+ *   - `social:tip:self` — real money OUT to third parties; no test value, real
+ *     abuse value.
+ *   - `block:settings:read` / `block:settings:write` — installer-only, and
+ *     meaningless against a local instance with no real install row.
+ *
+ * A requested/approved scope outside this set is STRIPPED from the minted token
+ * (defense-in-depth on top of the approved-snapshot pin). `social:tip:self` and
+ * `buzz:read:self` are ALSO in PAGE_FORBIDDEN_SCOPES, so the page hard rule
+ * below rejects them too — this allowlist is the explicit dev-side belt.
+ */
+const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  'models:read:self',
+  'media:read:owned',
+  'user:read:self',
+  'ai:write:budgeted',
+  'apps:storage:read',
+  'apps:storage:write',
+]);
+
+const requestSchema = z
+  .object({
+    appBlockId: z.string().min(1).max(128).optional(),
+    slug: z.string().min(1).max(128).optional(),
+    // OPTIONAL narrowing: a subset of the app's approved scopes the dev wants
+    // for this token. Omitted → all of the app's approved scopes (minus the
+    // dev-excluded ones).
+    scopes: z.array(z.string().min(1).max(64)).max(32).optional(),
+    // OPTIONAL dev-requested per-call Buzz budget; clamped to DEV_BUZZ_BUDGET_CAP.
+    buzzBudget: z.number().int().positive().optional(),
+  })
+  .refine((b) => !!b.appBlockId || !!b.slug, {
+    message: 'one of appBlockId or slug is required',
+  });
+
+function clientIp(req: NextApiRequest): string {
+  const xff = req.headers['x-forwarded-for'];
+  const first = Array.isArray(xff) ? xff[0] : xff?.split(',')[0];
+  return (first ?? req.socket?.remoteAddress ?? 'unknown').trim();
+}
+
+export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+
+  // Block-token signing must be configured (parity with the prod mint's 503).
+  const { env } = await import('~/env/server');
+  if (!env.BLOCK_TOKEN_PRIVATE_KEY || !env.BLOCK_TOKEN_PUBLIC_KEY) {
+    res.status(503).json({ message: 'Block tokens not configured' });
+    return;
+  }
+
+  // 1. Auth — Bearer PERSONAL API key resolves to a Civitai user via the same
+  // helper that backs the `/api/v1/*` REST auth. (scope doc §3.2 / §4.2)
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.toLowerCase().startsWith('bearer ')) {
+    res.status(401).json({ message: 'Missing or malformed Bearer token' });
+    return;
+  }
+  const apiKey = authHeader.slice('bearer '.length).trim();
+  if (!apiKey) {
+    res.status(401).json({ message: 'Missing or malformed Bearer token' });
+    return;
+  }
+  const session = await getSessionFromBearerToken(apiKey);
+  if (!session?.user) {
+    res.status(401).json({ message: 'Invalid API key' });
+    return;
+  }
+  const user = session.user as SessionUser;
+
+  // 1b. PERSONAL key only. `getSessionFromBearerToken` sets subject.type ===
+  // 'oauth' for OAuth-client-issued tokens; the dev path accepts only a
+  // user-type personal key (an OAuth dev-token would need its own scope +
+  // sign-off — out of scope for this PR).
+  if (session.subject?.type === 'oauth') {
+    res.status(403).json({ message: 'dev-token requires a personal API key' });
+    return;
+  }
+
+  // 2. MOD gate — App Blocks is mod-only pre-GA. The runtime spend belt already
+  // asserts moderator, but we keep the MINT mod-gated too (scope doc §4 / §6 R2).
+  if (!user.isModerator || user.bannedAt) {
+    res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
+    return;
+  }
+
+  // 3. Feature flag for THIS user (mirrors submit-version + the prod mint's
+  // per-user `appBlocks` gate). 503 (dark) when off.
+  if (!(await isAppBlocksEnabled({ user }))) {
+    res.status(503).json({ message: 'App Blocks is not enabled' });
+    return;
+  }
+
+  // 4. Validate body.
+  const parsed = requestSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    res.status(400).json({ message: 'Invalid request body', details: parsed.error.flatten() });
+    return;
+  }
+  const { appBlockId, slug, scopes: requestedScopes, buzzBudget: requestedBudget } = parsed.data;
+
+  // 5. Rate limit — per-user (the stable authenticated identity), client-IP
+  // fallback. Same atomic SET NX EX + INCR pattern as submit-version; fail
+  // CLOSED on a malformed limiter result (never silently bypass a mint).
+  const rateSubject = user.id ? `u:${user.id}` : `ip:${clientIp(req)}`;
+  const rateKey = `${REDIS_SYS_KEYS.BLOCKS.DEV_TOKEN_RATE_LIMIT}:${rateSubject}` as const;
+  const multiResult = await sysRedis
+    .multi()
+    .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
+    .incr(rateKey)
+    .exec();
+  const count = Number(multiResult?.[1]);
+  if (!Number.isFinite(count)) {
+    req.log?.warn('blocks/dev-token: rate-limit counter malformed; failing closed', {
+      rateSubject,
+    });
+    res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
+    return;
+  }
+  if (count > RATE_LIMIT.max) {
+    const retryAfter = await sysRedis.ttl(rateKey);
+    res.setHeader('Retry-After', String(Math.max(retryAfter, 1)));
+    res.status(429).json({
+      message: 'Rate limit exceeded',
+      retryAfterSeconds: retryAfter,
+      limit: RATE_LIMIT.max,
+      windowSeconds: RATE_LIMIT.windowSeconds,
+    });
+    return;
+  }
+
+  // 6. Resolve the APPROVED AppBlock the dev OWNS. Ownership = the app's
+  // OauthClient.userId (the AppBlock → app → user relation). We use dbWrite so a
+  // freshly-approved/suspended app can't slip through a replication-lag window.
+  // The lookup also fetches `app.userId` (owner) which resolvePageBlock doesn't
+  // expose, so we read the row directly here (we do NOT modify the prod path).
+  const where = appBlockId ? { id: appBlockId } : { blockId: slug! };
+  const block = await dbWrite.appBlock.findUnique({
+    where: where as { id: string } | { blockId: string },
+    select: {
+      id: true,
+      blockId: true,
+      appId: true,
+      status: true,
+      manifest: true,
+      approvedScopes: true,
+      app: { select: { allowedScopes: true, userId: true } },
+    },
+  });
+  // 404 (never leak which) for missing / not-approved / not-owned. Ownership is
+  // checked AFTER existence but we collapse them into one 404 so a non-owner
+  // can't probe which appBlockIds exist.
+  if (!block || block.status !== 'approved' || !block.app) {
+    res.status(404).json({ message: 'App not found' });
+    return;
+  }
+  if (block.app.userId !== user.id) {
+    // Not the owner → 404, not 403, so ownership isn't a probe oracle.
+    res.status(404).json({ message: 'App not found' });
+    return;
+  }
+
+  // The app MUST declare a page block — dev-token mints PAGE tokens only (the
+  // live-local target is a page app; no model binding). A region/model-only app
+  // has no page surface to mint for.
+  const manifest = (block.manifest ?? {}) as { page?: unknown; scopes?: unknown };
+  if (typeof manifest.page !== 'object' || manifest.page === null) {
+    res.status(422).json({ message: 'dev-token mints page tokens; this app declares no page block' });
+    return;
+  }
+
+  // 7. SCOPE CLAMP. Start from the app's APPROVED snapshot (authoritative — the
+  // same pin the prod mint uses), then:
+  //   a) keep only KNOWN block scopes,
+  //   b) keep only scopes within the DEV_TOKEN_SCOPE_ALLOWLIST (excludes
+  //      social:tip:self + block:settings:*),
+  //   c) keep only scopes within the app's OAuth ceiling (allowedScopes),
+  //   d) drop the PAGE_FORBIDDEN money/spend scopes (the page hard rule),
+  //   e) if the body requested a subset, intersect with it.
+  // Every step is a STRIP (no error) so a partially-disallowed request still
+  // mints a usable, safely-clamped token.
+  const approvedRaw: unknown[] = Array.isArray(block.approvedScopes) ? block.approvedScopes : [];
+  const approved: string[] = approvedRaw.filter((s): s is string => typeof s === 'string');
+  const oauthAllowed: number = block.app.allowedScopes ?? 0;
+  const forbidden = new Set<string>(PAGE_FORBIDDEN_SCOPES);
+
+  let granted: string[] = approved
+    .filter((s) => isKnownBlockScope(s))
+    .filter((s) => DEV_TOKEN_SCOPE_ALLOWLIST.has(s))
+    .filter((s) => !forbidden.has(s));
+
+  // OAuth-ceiling clamp — drop any scope the app's OauthClient bitmask doesn't
+  // allow. validateBlockScopesAgainstOauthClient treats SKIP_OAUTH_CHECK scopes
+  // (apps:storage:*) as always-allowed, so per-scope re-validation keeps those.
+  granted = granted.filter(
+    (s: string) => validateBlockScopesAgainstOauthClient([s], oauthAllowed).valid
+  );
+
+  // Body narrowing — the dev may request a subset of the above.
+  if (requestedScopes && requestedScopes.length > 0) {
+    const want = new Set(requestedScopes);
+    granted = granted.filter((s: string) => want.has(s));
+  }
+
+  // Dedup, deterministic order.
+  granted = Array.from(new Set(granted)).sort();
+
+  // 8. BUDGET CAP — only meaningful when ai:write:budgeted is granted. Clamp the
+  // dev-requested budget (or the default) to the LOWER dev cap.
+  const buzzBudget = granted.includes('ai:write:budgeted')
+    ? Math.min(requestedBudget ?? DEV_BUZZ_BUDGET_DEFAULT, DEV_BUZZ_BUDGET_CAP)
+    : undefined;
+
+  // 9. Synthetic, revocable PAGE instance id — same shape as the prod page mint
+  // (`page_<appBlockId>`), so BlockRevocation per blockInstanceId works
+  // unchanged and the harness uses the identical token-handling.
+  const blockInstanceId = `${PAGE_INSTANCE_PREFIX}${block.id}`;
+
+  // 10. PAGE ctx (entity=none, no model binding) — byte-identical shape to the
+  // prod page mint, so a dev page token can NEVER satisfy a model-bound check.
+  const ctx: Record<string, unknown> = {
+    slotId: PAGE_SLOT_ID,
+    entityType: 'none',
+  };
+  // Defense-in-depth: PAGE_SLOT_ID is a page slot by construction; assert it.
+  if (!isPageSlot(PAGE_SLOT_ID)) {
+    res.status(500).json({ message: 'page slot misconfigured' });
+    return;
+  }
+
+  // 11. SIGN — reuse BlockTokenService.sign VERBATIM. Self-bound sub (userId),
+  // forced-SFW ceiling, dev-capped budget, page ctx. domain is null (no host
+  // read) — advisory only; the AUTHORITATIVE ceiling is maxBrowsingLevel.
+  const result = await BlockTokenService.sign({
+    userId: user.id,
+    blockId: block.blockId,
+    appId: block.appId,
+    appBlockId: block.id,
+    blockInstanceId,
+    scopes: granted,
+    ctx,
+    buzzBudget,
+    domain: null,
+    maxBrowsingLevel: FORCED_SFW_CEILING,
+  });
+
+  res.status(200).json({
+    token: result.token,
+    expiresAt: result.expiresAt,
+    scopes: granted,
+    buzzBudget,
+    maxBrowsingLevel: FORCED_SFW_CEILING,
+    blockInstanceId,
+  });
+});

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -14,6 +14,8 @@ import {
 } from '~/shared/constants/block-scope.constants';
 import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
 import { isPageSlot, PAGE_FORBIDDEN_SCOPES, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
 
 type AxiomAPIRequest = NextApiRequest & { log: Logger };
 
@@ -206,18 +208,35 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // CLOSED on a malformed limiter result (never silently bypass a mint).
   const rateSubject = user.id ? `u:${user.id}` : `ip:${clientIp(req)}`;
   const rateKey = `${REDIS_SYS_KEYS.BLOCKS.DEV_TOKEN_RATE_LIMIT}:${rateSubject}` as const;
-  const multiResult = await sysRedis
-    .multi()
-    .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
-    .incr(rateKey)
-    .exec();
-  const count = Number(multiResult?.[1]);
+  let count: number;
+  try {
+    const multiResult = await sysRedis
+      .multi()
+      .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
+      .incr(rateKey)
+      .exec();
+    count = Number(multiResult?.[1]);
+  } catch (err) {
+    // A Redis incident must NEVER silently bypass the mint — fail closed.
+    req.log?.warn('blocks/dev-token: rate limiter threw; failing closed', { rateSubject });
+    res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
+    return;
+  }
   if (!Number.isFinite(count)) {
     req.log?.warn('blocks/dev-token: rate-limit counter malformed; failing closed', {
       rateSubject,
     });
     res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
     return;
+  }
+  // Self-heal a TTL-less key: `SET NX EX` only arms the TTL on first creation, so
+  // a key left around without an expiry (a prior crash / manual SET) would make
+  // the window permanent and lock this user out forever (fail-closed, but a real
+  // footgun). Re-arm only when the TTL is actually missing, so we never extend an
+  // active window. Best-effort — mirrors block-token.service.ts:274-275.
+  if (count > 1) {
+    const ttl = await sysRedis.ttl(rateKey).catch(() => -1);
+    if (ttl < 0) await sysRedis.expire(rateKey, RATE_LIMIT.windowSeconds).catch(() => {});
   }
   if (count > RATE_LIMIT.max) {
     const retryAfter = await sysRedis.ttl(rateKey);
@@ -302,6 +321,19 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   if (requestedScopes && requestedScopes.length > 0) {
     const want = new Set(requestedScopes);
     granted = granted.filter((s: string) => want.has(s));
+  }
+
+  //   f) PERSONAL-KEY CEILING. The minted block token's spend capability must be
+  //      a SUBSET of what the dev's own personal API key authorizes — a key
+  //      lacking AIServicesWrite (e.g. a read-only key) cannot mint a
+  //      Buzz-spending dev token. Mirrors the /api/v1/me tokenScope posture
+  //      (me.ts:24). Read/catalog/storage scopes are unaffected; only the
+  //      budgeted-spend scope is gated. Keys default to Full, so this is a
+  //      no-op for a normal key and a tightening only for a deliberately-narrow
+  //      one. Strip (no error), consistent with every other clamp step.
+  const keyCanSpend = Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AIServicesWrite);
+  if (!keyCanSpend) {
+    granted = granted.filter((s: string) => s !== 'ai:write:budgeted');
   }
 
   // Dedup, deterministic order.

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1584,6 +1584,14 @@ export const REDIS_SYS_KEYS = {
      * declared here rather than in `REDIS_KEYS.BLOCKS`.
      */
     SUBMIT_RATE_LIMIT: 'system:blocks:submit-rate-limit',
+    /**
+     * Per-user (fallback per-IP) rate-limit counter for the dev/preview
+     * block-token mint (`/api/v1/blocks/dev-token`). Same `SET NX EX` + `INCR`
+     * MULTI shape as `SUBMIT_RATE_LIMIT` (always created with its TTL), on
+     * `sysRedis`. Bounds a mod minting fresh short-lived dev tokens for their
+     * local "live" harness.
+     */
+    DEV_TOKEN_RATE_LIMIT: 'system:blocks:dev-token-rate-limit',
   },
 } as const;
 

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -64,20 +64,31 @@ const {
   mockSysRedis,
   mockMultiIncr,
 } = vi.hoisted(() => {
-  const mockMultiIncr = { value: 1, malformedExec: false as unknown[] | null | false };
+  const mockMultiIncr = {
+    value: 1,
+    malformedExec: false as unknown[] | null | false,
+    throwExec: false,
+  };
   const multiFactory = () => ({
     set: vi.fn().mockReturnThis(),
     incr: vi.fn().mockReturnThis(),
-    exec: vi.fn().mockImplementation(async () =>
-      mockMultiIncr.malformedExec !== false ? mockMultiIncr.malformedExec : ['OK', mockMultiIncr.value]
-    ),
+    exec: vi.fn().mockImplementation(async () => {
+      if (mockMultiIncr.throwExec) throw new Error('redis down');
+      return mockMultiIncr.malformedExec !== false
+        ? mockMultiIncr.malformedExec
+        : ['OK', mockMultiIncr.value];
+    }),
   });
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
     mockSign: vi.fn(),
     mockAppBlockFindUnique: vi.fn(),
-    mockSysRedis: { multi: vi.fn(multiFactory), ttl: vi.fn().mockResolvedValue(60) },
+    mockSysRedis: {
+      multi: vi.fn(multiFactory),
+      ttl: vi.fn().mockResolvedValue(60),
+      expire: vi.fn().mockResolvedValue(1),
+    },
     mockMultiIncr,
   };
 });
@@ -101,26 +112,39 @@ vi.mock('~/env/server', () => ({
 
 import handler from '~/pages/api/v1/blocks/dev-token';
 import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 const SFW = domainBrowsingCeiling(null);
 
 const OWNER_ID = 7;
 
-// Personal-access (user-type) key + moderator.
+// Personal-access (user-type) key + moderator. A normal personal key carries
+// the Full scope bitmask (incl. AIServicesWrite), so ai:write:budgeted survives
+// the personal-key-ceiling clamp.
 const MOD_SESSION = {
   user: { id: OWNER_ID, isModerator: true },
   apiKeyId: 42,
   subject: { type: 'apiKey', id: 42 },
+  tokenScope: TokenScope.Full,
 };
 const NONMOD_SESSION = {
   user: { id: 8, isModerator: false },
   apiKeyId: 43,
   subject: { type: 'apiKey', id: 43 },
+  tokenScope: TokenScope.Full,
 };
 const OAUTH_MOD_SESSION = {
   user: { id: OWNER_ID, isModerator: true },
   apiKeyId: 99,
   subject: { type: 'oauth', id: 'client_abc' },
+  tokenScope: TokenScope.Full,
+};
+// A personal key deliberately scoped WITHOUT AIServicesWrite (e.g. read-only).
+const READONLY_MOD_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 44,
+  subject: { type: 'apiKey', id: 44 },
+  tokenScope: TokenScope.UserRead | TokenScope.ModelsRead | TokenScope.MediaRead,
 };
 
 // An approved, owned PAGE app. allowedScopes is the OAuth ceiling — set every
@@ -144,7 +168,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockMultiIncr.value = 1;
   mockMultiIncr.malformedExec = false;
+  mockMultiIncr.throwExec = false;
   mockSysRedis.ttl.mockResolvedValue(60);
+  mockSysRedis.expire.mockResolvedValue(1);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
   mockAppBlockFindUnique.mockResolvedValue(pageApp());
   mockSign.mockResolvedValue({
@@ -286,6 +312,36 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(mockSign).not.toHaveBeenCalled();
   });
 
+  it('503 (fail closed) when the rate-limit exec() THROWS (redis incident)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.throwExec = true;
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    // A Redis incident must never silently bypass the mint.
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('self-heals a TTL-less rate-limit key (re-arms expiry when ttl < 0)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 2; // not first hit → self-heal branch runs
+    mockSysRedis.ttl.mockResolvedValueOnce(-1); // key exists but lost its TTL
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSysRedis.expire).toHaveBeenCalledWith('system:blocks:dev-token-rate-limit:u:7', 60);
+  });
+
+  it('does NOT re-arm expiry when the window is still active (ttl >= 0)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 2;
+    mockSysRedis.ttl.mockResolvedValueOnce(45); // active window — must not be extended
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSysRedis.expire).not.toHaveBeenCalled();
+  });
+
   it('happy path: mod + owned page app → token with capped claims (self-sub, SFW, page ctx)', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     const { req, res } = authPost({ appBlockId: 'apb_abc' });
@@ -410,5 +466,21 @@ describe('POST /api/v1/blocks/dev-token', () => {
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(200);
     expect(mockSign.mock.calls[0][0].scopes).toEqual(['apps:storage:read']);
+  });
+
+  it('STRIPS ai:write:budgeted when the personal key lacks AIServicesWrite', async () => {
+    // The minted token can never authorize MORE spend than the dev's own key.
+    mockGetSession.mockResolvedValueOnce(READONLY_MOD_SESSION);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const arg = mockSign.mock.calls[0][0];
+    // Read/catalog/storage scopes survive; the budgeted-spend scope is gone.
+    expect(arg.scopes).toEqual(['apps:storage:read', 'models:read:self', 'user:read:self']);
+    expect(arg.scopes).not.toContain('ai:write:budgeted');
+    // No spend scope → no budget claim.
+    expect(arg.buzzBudget).toBeUndefined();
+    const out = res._getJSONData() as Record<string, unknown>;
+    expect(out.buzzBudget).toBeUndefined();
   });
 });

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -292,6 +292,8 @@ describe('POST /api/v1/blocks/dev-token', () => {
     await handler(req as never, res as never);
 
     expect(res._getStatusCode()).toBe(200);
+    // The bearer-JWT body must never be cached by an intermediary.
+    expect(res._getHeaders()['Cache-Control']).toBe('no-store');
     expect(mockSign).toHaveBeenCalledTimes(1);
     const arg = mockSign.mock.calls[0][0];
     // Self-bound subject.

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Handler-level coverage for POST /api/v1/blocks/dev-token — the dev/preview
+ * block-token mint (scope doc: app-blocks-dev-token-endpoint-scope.md).
+ *
+ * Asserts the security-sensitive invariants:
+ *   - mod + flag-on + owned approved page app → token with capped scopes/budget,
+ *     forced-SFW maxBrowsingLevel, self-bound sub (userId), page ctx.
+ *   - rejections: non-mod → 403, flag off → 503 (dark), not-owner → 404,
+ *     OAuth (cookie/non-personal) key → 403, missing/invalid key → 401.
+ *   - scope clamp: a scope outside the app's approved set OR in the dev-excluded
+ *     list (social:tip:self / block:settings:*) is STRIPPED.
+ *   - budget over the dev cap → capped.
+ *   - rate-limit exceeded → 429; malformed limiter → 503 (fail closed).
+ */
+
+function createMocks({
+  method = 'POST',
+  headers = {},
+  body = {},
+}: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const req = {
+    method,
+    headers,
+    body,
+    socket: { remoteAddress: '203.0.113.7' },
+    log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown = undefined;
+  const responseHeaders: Record<string, string> = {};
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(key: string, value: string) {
+      responseHeaders[key] = value;
+    },
+    end() {
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getHeaders: () => responseHeaders,
+  };
+  return { req, res };
+}
+
+const {
+  mockGetSession,
+  mockIsAppBlocksEnabled,
+  mockSign,
+  mockAppBlockFindUnique,
+  mockSysRedis,
+  mockMultiIncr,
+} = vi.hoisted(() => {
+  const mockMultiIncr = { value: 1, malformedExec: false as unknown[] | null | false };
+  const multiFactory = () => ({
+    set: vi.fn().mockReturnThis(),
+    incr: vi.fn().mockReturnThis(),
+    exec: vi.fn().mockImplementation(async () =>
+      mockMultiIncr.malformedExec !== false ? mockMultiIncr.malformedExec : ['OK', mockMultiIncr.value]
+    ),
+  });
+  return {
+    mockGetSession: vi.fn(),
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockSign: vi.fn(),
+    mockAppBlockFindUnique: vi.fn(),
+    mockSysRedis: { multi: vi.fn(multiFactory), ttl: vi.fn().mockResolvedValue(60) },
+    mockMultiIncr,
+  };
+});
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (fn: unknown) => fn }));
+vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGetSession }));
+vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/server/services/block-token.service', () => ({
+  BlockTokenService: { sign: mockSign },
+}));
+vi.mock('~/server/db/client', () => ({
+  dbWrite: { appBlock: { findUnique: mockAppBlockFindUnique } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSysRedis,
+  REDIS_SYS_KEYS: { BLOCKS: { DEV_TOKEN_RATE_LIMIT: 'system:blocks:dev-token-rate-limit' } },
+}));
+vi.mock('~/env/server', () => ({
+  env: { BLOCK_TOKEN_PRIVATE_KEY: 'priv', BLOCK_TOKEN_PUBLIC_KEY: 'pub' },
+}));
+
+import handler from '~/pages/api/v1/blocks/dev-token';
+import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
+
+const SFW = domainBrowsingCeiling(null);
+
+const OWNER_ID = 7;
+
+// Personal-access (user-type) key + moderator.
+const MOD_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 42,
+  subject: { type: 'apiKey', id: 42 },
+};
+const NONMOD_SESSION = {
+  user: { id: 8, isModerator: false },
+  apiKeyId: 43,
+  subject: { type: 'apiKey', id: 43 },
+};
+const OAUTH_MOD_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 99,
+  subject: { type: 'oauth', id: 'client_abc' },
+};
+
+// An approved, owned PAGE app. allowedScopes is the OAuth ceiling — set every
+// relevant bit so the OAuth-clamp doesn't drop the scopes under test (the
+// approved-snapshot + dev-allowlist are the gates we exercise here).
+function pageApp(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'apb_abc',
+    blockId: 'my-page-app',
+    appId: 'appblk-my-page-app',
+    status: 'approved',
+    manifest: { page: { title: 'My Page' } },
+    approvedScopes: ['models:read:self', 'user:read:self', 'ai:write:budgeted', 'apps:storage:read'],
+    // 0x1FFFFFF = all 25 bits → no OAuth-ceiling stripping in these tests.
+    app: { allowedScopes: 0x1ffffff, userId: OWNER_ID },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMultiIncr.value = 1;
+  mockMultiIncr.malformedExec = false;
+  mockSysRedis.ttl.mockResolvedValue(60);
+  mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockAppBlockFindUnique.mockResolvedValue(pageApp());
+  mockSign.mockResolvedValue({
+    token: 'jwt.signed.value',
+    expiresAt: '2099-01-01T00:00:00Z',
+    jti: 'j',
+  });
+});
+
+function authPost(body: unknown) {
+  return createMocks({ headers: { authorization: 'Bearer personal-key' }, body });
+}
+
+describe('POST /api/v1/blocks/dev-token', () => {
+  it('405 for non-POST', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it('401 when Authorization header is missing', async () => {
+    const { req, res } = createMocks({ body: { appBlockId: 'apb_abc' } });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('401 when the bearer key does not resolve to a session', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('403 when the key is OAuth-client-issued (personal key only)', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_MOD_SESSION);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect((res._getJSONData() as { message: string }).message).toContain('personal API key');
+    expect(mockSign).not.toHaveBeenCalled();
+    // Rejected before flag / db / sign — no leak.
+    expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+    expect(mockAppBlockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('403 when the resolved user is NOT a moderator', async () => {
+    mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('403 when the mod is banned', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: 9, isModerator: true, bannedAt: new Date() },
+      apiKeyId: 44,
+      subject: { type: 'apiKey', id: 44 },
+    });
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('503 (dark) when the App Blocks flag is OFF for the user', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockIsAppBlocksEnabled.mockResolvedValueOnce(false);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('400 when neither appBlockId nor slug is provided', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost({});
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('404 when the app is not found', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(null);
+    const { req, res } = authPost({ appBlockId: 'apb_missing' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('404 when the app is not approved', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(pageApp({ status: 'pending' }));
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('404 when the caller does NOT own the app (no probe oracle)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ app: { allowedScopes: 0x1ffffff, userId: 999 } })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('422 when the owned app declares no page block', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(pageApp({ manifest: { scopes: [] } }));
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(422);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('429 when the per-user rate limit is exceeded', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 31; // > RATE_LIMIT.max (30)
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeaders()['Retry-After']).toBeDefined();
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('503 (fail closed) when the rate-limit exec() is malformed', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.malformedExec = null;
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('happy path: mod + owned page app → token with capped claims (self-sub, SFW, page ctx)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    const arg = mockSign.mock.calls[0][0];
+    // Self-bound subject.
+    expect(arg.userId).toBe(OWNER_ID);
+    // Forced SFW ceiling.
+    expect(arg.maxBrowsingLevel).toBe(SFW);
+    // No request-host domain read → null advisory domain.
+    expect(arg.domain).toBeNull();
+    // Page ctx — no model binding.
+    expect(arg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
+    // Revocable synthetic page instance id.
+    expect(arg.blockInstanceId).toBe('page_apb_abc');
+    // All of the app's approved + dev-allowed scopes, sorted.
+    expect(arg.scopes).toEqual(
+      ['ai:write:budgeted', 'apps:storage:read', 'models:read:self', 'user:read:self']
+    );
+    // Budget defaulted + capped.
+    expect(arg.buzzBudget).toBe(50);
+
+    const out = res._getJSONData() as Record<string, unknown>;
+    expect(out.token).toBe('jwt.signed.value');
+    expect(out.maxBrowsingLevel).toBe(SFW);
+    expect(out.scopes).toEqual(arg.scopes);
+  });
+
+  it('resolves by slug (blockId) too', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost({ slug: 'my-page-app' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockAppBlockFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { blockId: 'my-page-app' } })
+    );
+  });
+
+  it('STRIPS dev-excluded scopes (social:tip:self, block:settings:*) even if approved', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({
+        approvedScopes: [
+          'models:read:self',
+          'social:tip:self', // dev-excluded + page-forbidden
+          'block:settings:read', // dev-excluded
+          'apps:storage:write',
+        ],
+      })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const arg = mockSign.mock.calls[0][0];
+    expect(arg.scopes).toEqual(['apps:storage:write', 'models:read:self']);
+    expect(arg.scopes).not.toContain('social:tip:self');
+    expect(arg.scopes).not.toContain('block:settings:read');
+  });
+
+  it('STRIPS a requested scope that is NOT in the app approved set', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    // App approves only models:read:self; the body requests user:read:self too.
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ approvedScopes: ['models:read:self'] })
+    );
+    const { req, res } = authPost({
+      appBlockId: 'apb_abc',
+      scopes: ['models:read:self', 'user:read:self'],
+    });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const arg = mockSign.mock.calls[0][0];
+    expect(arg.scopes).toEqual(['models:read:self']);
+  });
+
+  it('narrows scopes to the requested subset', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost({
+      appBlockId: 'apb_abc',
+      scopes: ['models:read:self'], // subset of approved
+    });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].scopes).toEqual(['models:read:self']);
+  });
+
+  it('CAPS an over-cap requested budget to the dev cap', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost({ appBlockId: 'apb_abc', buzzBudget: 100000 });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].buzzBudget).toBe(250); // DEV_BUZZ_BUDGET_CAP
+  });
+
+  it('omits buzzBudget when ai:write:budgeted is not granted', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ approvedScopes: ['models:read:self'] })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc', buzzBudget: 200 });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].buzzBudget).toBeUndefined();
+  });
+
+  it('drops a scope outside the app OAuth ceiling', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    // Ceiling = 0 → every bitmask-requiring scope is dropped; only the
+    // SKIP_OAUTH_CHECK apps:storage:* survives.
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({
+        approvedScopes: ['models:read:self', 'apps:storage:read'],
+        app: { allowedScopes: 0, userId: OWNER_ID },
+      })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].scopes).toEqual(['apps:storage:read']);
+  });
+});


### PR DESCRIPTION
## What this does

Adds `POST /api/v1/blocks/dev-token` so a logged-in **moderator developer** can mint a **short-lived, scoped, self-bound App-Block PAGE token** to drive their **local** harness's "live" mode against the **real** Civitai backend — testing local code with their **own** real Buzz. This is the deliberately-different DEV path; the production mint at `/api/v1/block-tokens` is **untouched** (exact-host same-origin, install-row bound).

Implements the RECOMMENDED design in `claudedocs/app-blocks-dev-token-endpoint-scope.md` (Option A, "existing-app" mode, Phase 1).

## Auth + why it's safe
- **Personal API key (Bearer)**, resolved via `getSessionFromBearerToken` — the same path the existing `/api/v1/*` REST routes use. OAuth-client-issued tokens are **rejected** (an OAuth dev-token would need its own scope + sign-off).
- **Personal-key → CSRF-free origin relaxation** (scope doc §4.2): the credential is an `Authorization` header, not an ambient cookie, so a cross-site form can't ride it. We therefore accept the dev's `localhost` origin **without touching the prod mint's exact-host CORS**. The prod mint stays exact-host-only and 403s cross-origin — this is the deliberately-different dev door.

## Hard caps enforced (every one server-side, deterministic, fail-closed)
| Cap | Value / rule | Why safe (scope doc §4.1) |
|---|---|---|
| **Mod-only** | `isAppBlocksEnabled({ user })` + `user.isModerator`, not banned | Matches the pre-GA mod posture. The runtime spend procedures already call `assertViewerIsModerator`, so a non-mod could mint but not spend; mint stays mod-gated anyway. |
| **Ownership** | app's `OauthClient.userId === caller` (404 otherwise, no probe oracle) | Existing-app mode pins to a **server-approved** row → no escalation via an un-reviewed local manifest. |
| **Scope clamp** | `granted ⊆ approvedScopes ⊆ DEV_TOKEN_SCOPE_ALLOWLIST ⊆ OAuth ceiling ⊆ requested-subset`; allowlist **EXCLUDES `social:tip:self` + `block:settings:*`** | Out-of-set scopes are **stripped** (defense-in-depth over the approved-snapshot pin). `social:tip:self` = real money out to third parties; `block:settings:*` = installer-only, meaningless locally. |
| **Budget cap** | `DEV_BUZZ_BUDGET_CAP = 250` (< prod 1000), default 50 | A **lower** dev cap; the existing **per-user daily cumulative cap** (`reserveBlockBuzzSpend`) is untouched — the dev can only hurt their own balance. |
| **Forced SFW** | `maxBrowsingLevel = domainBrowsingCeiling(null)`, **never reads the request host** | localhost has no color domain; we don't read the host at all, so a color-localhost dev config can't widen maturity. No mature path. |
| **Self-bound `sub`** | token subject = the caller's `userId` (no body field can set it) | Spend hits the dev's account only. |
| **Short TTL** | 15min (the `BlockTokenService.sign` default; settings scopes excluded so never 5min) | Short, refresh-friendly window the harness wants. |
| **Revocable** | synthetic `page_<appBlockId>` instance id | `BlockRevocation`-checkable, identical to the prod page mint. |
| **Rate-limited** | per-user fixed window (same atomic `SET NX EX` + `INCR` shape as the submit-version limiter), **fail-closed** on a malformed limiter | Bounds a mod minting fresh tokens. |

Mints a **PAGE token** (`entity=none`, no model binding) by reusing `BlockTokenService.sign` **verbatim** — claims/TTL/kid/jti are not reinvented.

## Out of scope (documented follow-up)
The SDK-side **`createLiveHost`** proxy-host (the `createMockHost` sibling that forwards the postMessage protocol — `ESTIMATE/SUBMIT/POLL/CANCEL/STORAGE/PICKER/TOKEN` — to the real endpoints) is the larger half and is **explicitly out of scope** for this PR (scope doc §5.2 / Phase 2). The endpoint alone does not make "live" mode work end-to-end; it's the small, security-sensitive half.

## Tests
22 handler tests (mirroring the `submit-version` v1 route test style): happy path (capped scopes/budget/SFW/self-sub/page-ctx), non-mod → 403, flag off → 503 dark, not-owner → 404, OAuth/non-personal key → 403, missing/invalid key → 401, no page block → 422, scope outside approved/dev-excluded → stripped, budget over cap → capped, OAuth-ceiling drop, slug resolution, rate-limit 429 / malformed-limiter 503. **22/22 pass.** `tsc --noEmit` clean for the changed files.

## ⚠️ Needs security review before the flag widens
This is **mod-only** today. **Before the `appBlocks` flag widens beyond mods**, this endpoint needs a dedicated adversarial security review (same posture the prod mint got), plus the runtime-spend belt decision (scope doc §6 R2: keep mod-only, or deliberately widen `assertViewerIsModerator` to admit self-bound budgeted dev tokens). Do **not** widen unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)