### PR TITLE
fix(audit): remove ReDoS-prone combined-regex gate (#2452) — user prompts pinning api pods 11-47s

### DIFF
--- a/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
+++ b/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
@@ -16,15 +16,17 @@ import promptTags from '~/utils/metadata/lists/prompt-tags.json';
 import youngWords from '~/utils/metadata/lists/words-young.json';
 
 /**
- * Equivalence guard for the combined-regex pre-filter ("gate") added to
- * `checkable().inPrompt` in audit.ts.
+ * Matching-correctness guard for `checkable().inPrompt` / `.highlight` in audit.ts.
  *
- * The gate must NEVER change the matching result — only the speed of reaching
- * it. These tests reconstruct the original brute-force per-word matching loop
- * as a reference oracle and assert the public audit API agrees with it across a
- * broad sample of prompts (every real list entry as a positive case + benign /
- * adversarial negatives). A single divergence here means the optimization
- * changed moderation behavior.
+ * Originally written to prove the combined-regex pre-filter ("gate", PR #2452)
+ * never changed matching results. That gate was removed (it caused catastrophic
+ * regex backtracking / ReDoS on user prompts — single inPrompt calls burned
+ * 11–47s of main-thread CPU on prod api pods). These tests are KEPT as a
+ * standing correctness oracle: they reconstruct the brute-force per-word
+ * matching loop independently and assert the public audit API agrees with it
+ * across a broad sample of prompts (every real list entry as a positive case +
+ * benign / adversarial negatives). A single divergence here means moderation
+ * matching behavior changed.
  */
 
 // --- Reference (pre-optimization) per-word matching, copied verbatim ---

--- a/src/utils/metadata/__tests__/audit-redos.test.ts
+++ b/src/utils/metadata/__tests__/audit-redos.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  auditPrompt,
+  includesNsfw,
+  includesPoi,
+  includesMinor,
+  getTagsFromPrompt,
+} from '~/utils/metadata/audit';
+
+/**
+ * ReDoS (catastrophic regex backtracking) regression guard.
+ *
+ * PR #2452 added a combined-regex "gate" pre-filter to `checkable().inPrompt`:
+ *
+ *   new RegExp(`([^a-zA-Z0-9]+|^)(?:${chunk})([^a-zA-Z0-9]+|$)`, 'i')
+ *
+ * where `chunk` joined up to 200 per-word bodies with `|`. The greedy
+ * `[^a-zA-Z0-9]+` boundary groups on BOTH sides of a 200-way alternation —
+ * several of whose bodies themselves contain unbounded quantifiers like
+ * `[\s|\w]*` (e.g. `without [\s|\w]* clothes`) — backtrack pathologically on
+ * certain user prompts. A V8 CPU profile of a prod civitai-dp-prod api pod
+ * caught single `inPrompt()` calls burning 11s / 25s / 47s of SYNCHRONOUS
+ * main-thread CPU on user generation prompts, pegging the event loop until the
+ * readiness probe timed out and the pod shed traffic (a user-triggerable DoS →
+ * the recurring "504 wave"). The gate has been removed; `inPrompt`/`highlight`
+ * now go straight to the per-word loop (the pre-#2452 behavior that ran fine
+ * for years).
+ *
+ * These tests are a HOT-PATH LATENCY guard for the public audit API. They feed
+ * the adversarial input shapes that stress the removed gate — long runs of
+ * non-alphanumeric separators, whitespace ambiguously partitioned across
+ * multiple greedy quantifiers, leet-class soup, and near-miss blocklist
+ * fragments — through `auditPrompt`/`includesNsfw`/`includesPoi`/etc. and assert
+ * each call completes well within a per-call wall-clock bound, plus an aggregate
+ * bound over the whole battery.
+ *
+ * HONESTY NOTE: the exact prod input that backtracked for 11-47s was a specific
+ * user prompt not captured in the profile, and modern V8's irregexp defuses most
+ * synthetic catastrophic-backtracking constructions — so these inputs do NOT
+ * reproduce a multi-second hang on a current Node runtime. What they DO is bound
+ * the audit hot path: if a quadratic/exponential pre-filter (the #2452 gate, or
+ * any successor) is reintroduced and an input pushes it into seconds, the bound
+ * (and/or vitest's default timeout) trips. Matching CORRECTNESS after removing
+ * the gate is covered separately by audit-matching-equivalence.test.ts, which
+ * reconstructs the brute-force per-word oracle and asserts the public API agrees.
+ */
+
+// Per-call upper bound. The gateless per-word loop over the full blocklist is
+// linear-to-mildly-polynomial in input length and finishes in a few ms to low
+// tens of ms on realistic-sized prompts; the removed exponential gate took 11-47
+// SECONDS on a single call in prod. 500ms gives generous headroom for a loaded
+// CI runner over linear work while still tripping orders of magnitude before a
+// true ReDoS hang.
+const MAX_MS = 500;
+
+// Inputs are kept to realistic generation-prompt sizes (<= ~300 chars). A ReDoS
+// blows up on input STRUCTURE, not raw length, so a normal-length prompt is
+// enough to expose catastrophic backtracking — and keeping the battery small
+// keeps the legitimate linear scan fast so the bound stays meaningful.
+function timeCall(fn: () => unknown): number {
+  const start = performance.now();
+  fn();
+  return performance.now() - start;
+}
+
+// Adversarial inputs crafted to maximize backtracking against the removed gate:
+// a near-miss blocklist token prefix, then an ambiguous run that the leading
+// boundary group, any interior `[^a-zA-Z0-9]+`/`[\s|\w]*`, and the trailing
+// boundary group all compete to consume.
+function buildPathologicalInputs(): { label: string; input: string }[] {
+  const inputs: { label: string; input: string }[] = [];
+
+  // Multi-word blocklist bodies with an interior unbounded quantifier
+  // (`without [\s|\w]* clothes`, `jerks? [\s|\w]* off`, `spreads? [her|his|its]*
+  // legs?`), fed a token prefix + ambiguous separator run that never completes
+  // the trailing token — the multi-quantifier partition explosion the gate
+  // amplified across a 200-way alternation.
+  for (const n of [40, 120]) {
+    inputs.push({ label: `without+ws(${n})`, input: 'without' + ' '.repeat(n) + 'x' });
+    inputs.push({ label: `jerks+ws(${n})`, input: 'jerks' + ' '.repeat(n) + 'x' });
+  }
+  inputs.push({ label: 'spreads+mix', input: 'spreads' + ' -_.'.repeat(50) + 'x' });
+
+  // Pure non-alphanumeric separator runs (the boundary groups' worst case).
+  for (const sep of ['!', '-', '_', '.', '*']) {
+    inputs.push({ label: `sep '${sep}' x200`, input: 'a' + sep.repeat(200) + 'b' });
+  }
+
+  // Alternating separator/letter — forces the boundary groups to re-anchor
+  // repeatedly across the string.
+  inputs.push({ label: 'alt sep x100', input: '! '.repeat(100) + 'z' });
+  inputs.push({ label: 'dash-letter x100', input: 'a-'.repeat(100) + 'z' });
+
+  // Leet-class soup: chars drawn from the leet substitution classes
+  // ([i|l|1], [o|0], [s|z], [e|3]) against the many overlapping leet bodies.
+  inputs.push({ label: 'leet soup', input: 'e3o0s zil1'.repeat(25) });
+
+  // Repeated near-miss of a real blocklist word with separators between repeats.
+  inputs.push({ label: 'near-miss repeat', input: 'explici '.repeat(30) + '!!!!!!!!' });
+
+  // A long-ish benign prompt (the common case the gate was meant to speed up) —
+  // must also stay fast through the per-word loop.
+  inputs.push({
+    label: 'benign',
+    input: 'a beautiful landscape, masterpiece, best quality, ' + 'detailed '.repeat(15),
+  });
+
+  return inputs;
+}
+
+const pathological = buildPathologicalInputs();
+
+describe('audit ReDoS regression (no catastrophic backtracking)', () => {
+  it('auditPrompt completes fast on every adversarial input', () => {
+    for (const { label, input } of pathological) {
+      const ms = timeCall(() => auditPrompt(input));
+      expect(ms, `auditPrompt too slow on ${label} (${ms.toFixed(1)}ms)`).toBeLessThan(MAX_MS);
+    }
+  });
+
+  it('includesNsfw completes fast on every adversarial input', () => {
+    for (const { label, input } of pathological) {
+      const ms = timeCall(() => includesNsfw(input));
+      expect(ms, `includesNsfw too slow on ${label} (${ms.toFixed(1)}ms)`).toBeLessThan(MAX_MS);
+    }
+  });
+
+  it('includesPoi / includesMinor / getTagsFromPrompt complete fast on every adversarial input', () => {
+    for (const { label, input } of pathological) {
+      const poiMs = timeCall(() => includesPoi(input));
+      expect(poiMs, `includesPoi too slow on ${label} (${poiMs.toFixed(1)}ms)`).toBeLessThan(MAX_MS);
+      const minorMs = timeCall(() => includesMinor(input));
+      expect(minorMs, `includesMinor too slow on ${label} (${minorMs.toFixed(1)}ms)`).toBeLessThan(
+        MAX_MS
+      );
+      const tagMs = timeCall(() => getTagsFromPrompt(input));
+      expect(tagMs, `getTagsFromPrompt too slow on ${label} (${tagMs.toFixed(1)}ms)`).toBeLessThan(
+        MAX_MS
+      );
+    }
+  });
+
+  it('the whole adversarial battery audits in well under a true-hang timeout', () => {
+    // Belt-and-suspenders: a single exponential call took 11-47s in prod; the
+    // entire battery here must finish in a fraction of a second. If a quadratic/
+    // exponential pre-filter is reintroduced this aggregate bound trips long
+    // before any individual 250ms check could mask it.
+    const ms = timeCall(() => {
+      for (const { input } of pathological) {
+        auditPrompt(input);
+        includesNsfw(input);
+      }
+    });
+    expect(ms, `full adversarial battery too slow (${ms.toFixed(1)}ms)`).toBeLessThan(3000);
+  });
+});

--- a/src/utils/metadata/audit.ts
+++ b/src/utils/metadata/audit.ts
@@ -367,9 +367,7 @@ export function includesMinorAge(prompt: string | undefined) {
 
 // #region [inappropriate]
 // Builds the "body" of a word pattern (everything between the leading/trailing
-// non-alphanumeric boundary groups). Extracted so the combined-regex pre-filter
-// in `checkable` can reuse the EXACT same body, guaranteeing the gate matches a
-// superset of what the per-word regexes match.
+// non-alphanumeric boundary groups).
 function prepareWordRegexBody(word: string, pluralize = false, leet = true) {
   let regexStr = word;
   regexStr = regexStr.replace(/\s+/g, `[^a-zA-Z0-9]+`);
@@ -413,41 +411,10 @@ export function checkable(
     preprocessor?: PreprocessorFn;
   }
 ) {
-  const bodies: string[] = [];
   const regexes = words.map((word) => {
-    bodies.push(prepareWordRegexBody(word, options?.pluralize, options?.leet));
     const regex = prepareWordRegex(word, options?.pluralize, options?.leet);
     return { regex, word } as Checkable;
   });
-
-  // Combined-regex pre-filter ("gate"): one alternation regex per chunk that
-  // answers "does ANY word in this chunk match at all?" in a single exec. The
-  // dominant case — a prompt that matches nothing in the list — then costs
-  // `ceil(N / CHUNK)` exec calls instead of N. Each body is wrapped in a
-  // non-capturing group and reuses the EXACT per-word body inside the same
-  // leading/trailing boundary groups, so the gate matches a superset of the
-  // per-word regexes (no false negatives). On a gate hit we fall back to the
-  // unchanged per-word loop to identify the specific match, so results are
-  // byte-for-byte identical to the original implementation.
-  //
-  // Chunking keeps each combined pattern well under JS engine limits (large
-  // alternations can blow the compiled-regex size budget) and bounds the cost
-  // of any single exec.
-  const GATE_CHUNK_SIZE = 200;
-  const gateRegexes: RegExp[] = [];
-  for (let i = 0; i < bodies.length; i += GATE_CHUNK_SIZE) {
-    const chunk = bodies
-      .slice(i, i + GATE_CHUNK_SIZE)
-      .map((body) => `(?:${body})`)
-      .join('|');
-    gateRegexes.push(new RegExp(`([^a-zA-Z0-9]+|^)(?:${chunk})([^a-zA-Z0-9]+|$)`, 'i'));
-  }
-  function gatePasses(prompt: string) {
-    for (const gate of gateRegexes) {
-      if (gate.test(prompt)) return true;
-    }
-    return false;
-  }
 
   function preprocessor(prompt: string) {
     prompt = prompt.trim();
@@ -457,10 +424,6 @@ export function checkable(
 
   function inPrompt(prompt: string, matcher?: MatcherFn) {
     prompt = preprocessor(prompt);
-    // Fast no-match gate: if nothing in any chunk can match, no per-word regex
-    // (and no matcher, which only returns a value when `regex.test` is true) can
-    // either — short-circuit the O(N) loop.
-    if (!gatePasses(prompt)) return false;
     matcher ??= options?.matcher;
     for (const { regex, word } of regexes) {
       if (matcher) {
@@ -478,9 +441,6 @@ export function checkable(
   }
   function highlight(prompt: string, replaceFn: (word: string) => string) {
     const target = preprocessor(prompt);
-    // Same gate as inPrompt: highlight rewrites only words that match, so if the
-    // gate misses there is nothing to rewrite and we return the prompt unchanged.
-    if (!gatePasses(target)) return prompt;
     for (const { regex } of regexes) {
       if (regex.test(target)) {
         const match = regex.exec(target);


### PR DESCRIPTION
## Incident

A V8 CPU profile of a pinned `civitai-dp-prod` api pod proved the recurring **"504 wave"** on-CPU pins are **ReDoS (catastrophic regex backtracking)** in the prompt-audit blocklist. Live captures show single `inPrompt()` calls burning **11s, 25s, 47s** of synchronous main-thread CPU on **user** generation prompts → the pod's event loop pegs → the readiness probe times out → the pod sheds traffic → 504 wave. **This is a user-triggerable DoS and was actively escalating.**

## Root cause

`src/utils/metadata/audit.ts`. The hot path is the combined-regex **"gate" pre-filter** added by PR #2452 (commit `c74ec2d127`). Per 200-word chunk it builds:

```js
gateRegexes.push(new RegExp(`([^a-zA-Z0-9]+|^)(?:${chunk})([^a-zA-Z0-9]+|$)`, 'i'));
// chunk = up to 200 per-word bodies joined with `|`
```

and `gatePasses(prompt)` runs each chunk gate before the per-word loop. The greedy `[^a-zA-Z0-9]+` boundary groups on **both** sides of a 200-way alternation — several of whose bodies themselves contain unbounded quantifiers like `[\s|\w]*` (e.g. `without [\s|\w]* clothes`, `jerks? [\s|\w]* off`) — backtrack exponentially on certain prompts. `inPrompt`/`highlight` call `gatePasses` first, so every audited prompt pays it.

## The fix (conservative mitigation)

**Remove the #2452 gate pre-filter** so `inPrompt` and `highlight` go straight to the existing per-word `regexes` loop — the pre-#2452 behavior that ran fine for years. Deleted `gateRegexes` / `gatePasses` / the `bodies` accumulation and the `if (!gatePasses(...))` short-circuits in **both** `inPrompt` and `highlight`. Everything else is preserved byte-for-byte: the per-word loop, the `matcher` path, the returned shape (`{ matchedText, pattern, regex }`), the `MatcherFn` / options.

#2452 itself documents that the gate "matches a superset … results are byte-for-byte identical to the original" — so removing it changes **only performance** (no-match scans get slower again), **not matching results**.

**Why this and not a regex rewrite:** the input is user-controlled moderation-safety code; the zero-risk move is to restore known-good matching, not hand-tune a backtracking pattern.

**Durable follow-up (separate, larger PR):** move this user-input matching to a linear-time engine (RE2 / `node-re2`) so backtracking is structurally impossible.

## Tests

- `src/utils/metadata/__tests__/audit-matching-equivalence.test.ts` — the #2452 equivalence guard — **kept**. It independently reconstructs the brute-force per-word matching oracle and asserts the (now-gateless) public audit API agrees across the full blocklist + adversarial negatives. Header comment refreshed to note the gate was removed; **assertions unchanged** (they prove correctness either way). No assertion tested `gatePasses` internals, so none were removed.
- **New** `src/utils/metadata/__tests__/audit-redos.test.ts` — hot-path latency guard: feeds adversarial input shapes (long separator runs, whitespace ambiguously partitioned across greedy quantifiers, leet-class soup, near-miss blocklist fragments) through `auditPrompt` / `includesNsfw` / `includesPoi` / `includesMinor` / `getTagsFromPrompt` with per-call (`< 500ms`) and aggregate (`< 3s`) wall-clock bounds.
  - **Honesty note (also in the file):** the exact prod input that backtracked for 11–47s was a specific user prompt not captured in the profile, and modern V8's irregexp defuses most *synthetic* catastrophic-backtracking constructions — so these inputs do **not** reproduce a multi-second hang on a current Node runtime. What they do is bound the audit hot path so a reintroduced quadratic/exponential pre-filter trips the bound (and/or vitest's timeout). Matching **correctness** is covered by the equivalence suite above.

**Result:** all 27 audit unit tests pass (`vitest run --project unit src/utils/metadata`).

```
Test Files  4 passed (4)
     Tests  27 passed | 1 skipped (28)
```

## tsc / build

The three changed files are **type-clean** (`tsc --noEmit` produces no errors in `audit.ts` or either test file; the ~3850 baseline errors are the un-generated Prisma client — `prisma generate` 404s on NixOS for the precompiled engine). `next build` cannot run locally on NixOS — **preview CI is the build gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
