### PR TITLE
feat(audit): instrument slow prompt-audit calls to catch the 11-47s CPU-pin culprit

### DIFF
--- a/src/utils/metadata/__tests__/audit-slow-log.test.ts
+++ b/src/utils/metadata/__tests__/audit-slow-log.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests for the slow-prompt-audit instrumentation (audit-slow-log.ts) and its
+ * integration into auditPromptEnriched/auditPrompt.
+ *
+ * The instrumentation is the always-on, threshold-gated detector for the prod
+ * 11-47s CPU-pin "504 wave" (see audit-slow-log.ts header). These tests assert:
+ *  - the slow-detector FIRES above AUDIT_SLOW_LOG_MS and NOT below,
+ *  - it identifies the slowest sub-check + emits the reproduction fingerprint,
+ *  - the raw-prompt capture respects the AUDIT_SLOW_LOG_RAW gate (+ truncation),
+ *  - a logging failure can never throw into the caller,
+ *  - the audit RESULT is byte-for-byte identical with the threshold tripped vs not.
+ *
+ * `~/server/logging/client` is mocked so the dynamic `import()` inside emitSlowLog
+ * resolves without pulling in `~/env/server` (which throws under the unit env), and
+ * so we can assert the payload shape without testing Axiom internals.
+ */
+
+// Hoisted spy shared by the vi.mock factory and the assertions.
+const logToAxiom = vi.hoisted(() => vi.fn(() => Promise.resolve(undefined)));
+vi.mock('~/server/logging/client', () => ({ logToAxiom }));
+
+import { AuditTimer } from '~/utils/metadata/audit-slow-log';
+import { auditPrompt, auditPromptEnriched } from '~/utils/metadata/audit';
+
+// Flush the fire-and-forget async tail inside emitSlowLog: it awaits two dynamic
+// imports (node:crypto + the logging client) before calling logToAxiom, so a
+// couple of macrotask hops are needed for it to settle.
+async function flush() {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 5));
+}
+
+const ENV_KEYS = ['AUDIT_SLOW_LOG_MS', 'AUDIT_SLOW_LOG_RAW', 'AUDIT_SLOW_LOG_RAW_MAX'] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+  logToAxiom.mockClear();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  vi.restoreAllMocks();
+});
+
+describe('AuditTimer threshold gating', () => {
+  it('does NOT emit when every sub-check and the total are below threshold', async () => {
+    process.env.AUDIT_SLOW_LOG_MS = '500';
+    const timer = new AuditTimer();
+    const r = timer.time('fast', () => 'ok');
+    expect(r).toBe('ok');
+    timer.finish('a fast prompt', undefined);
+    await flush();
+    expect(logToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('emits once when a single sub-check exceeds threshold (mocked performance.now)', async () => {
+    process.env.AUDIT_SLOW_LOG_MS = '500';
+    // Drive performance.now: ctor=0, then a slow sub-check (start=0,end=900),
+    // then finish reads the total. 900ms > 500ms threshold.
+    const seq = [0, 0, 900, 1000];
+    let i = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => seq[Math.min(i++, seq.length - 1)]);
+
+    const timer = new AuditTimer();
+    timer.time('slowcheck', () => 'x');
+    timer.finish('the offending prompt', undefined);
+    await flush();
+
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+    const payload = logToAxiom.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.name).toBe('audit-prompt-slow');
+    expect(payload.type).toBe('warning');
+    expect(payload.slowestCheck).toBe('slowcheck');
+    expect(payload.slowestMs).toBe(900);
+    expect((payload.perCheckMs as Record<string, number>).slowcheck).toBe(900);
+    expect(payload.thresholdMs).toBe(500);
+    expect(payload.promptLength).toBe('the offending prompt'.length);
+    expect(typeof payload.promptHash).toBe('string');
+  });
+
+  it('respects a custom AUDIT_SLOW_LOG_MS threshold', async () => {
+    process.env.AUDIT_SLOW_LOG_MS = '50';
+    const seq = [0, 0, 60, 70]; // 60ms > 50ms
+    let i = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => seq[Math.min(i++, seq.length - 1)]);
+
+    const timer = new AuditTimer();
+    timer.time('c', () => null);
+    timer.finish('p');
+    await flush();
+    expect(logToAxiom).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('shape fingerprint + reproduction payload', () => {
+  function fireWith(prompt: string, negativePrompt?: string) {
+    process.env.AUDIT_SLOW_LOG_MS = '100';
+    const seq = [0, 0, 200, 250];
+    let i = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => seq[Math.min(i++, seq.length - 1)]);
+    const timer = new AuditTimer();
+    timer.time('c', () => null);
+    timer.finish(prompt, negativePrompt);
+  }
+
+  it('includes a shape fingerprint characterizing the input', async () => {
+    // "abc" then a 5-char non-alnum run "!@#$%" (alnum on both sides) then "123".
+    fireWith('abc!@#$%123');
+    await flush();
+    const payload = logToAxiom.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.longestNonAlnumRun).toBe(5); // "!@#$%"
+    expect(payload.nonAlnumCount).toBe(5);
+    expect(payload.digitCount).toBe(3);
+    expect(payload.letterCount).toBe(3);
+    expect(payload.distinctCharCount).toBeGreaterThan(0);
+    expect(payload.charClassSummary).toBe('L=3,D=3,W=0,O=5');
+  });
+
+  it('includes negative-prompt metadata when present', async () => {
+    fireWith('hello', 'a negative prompt');
+    await flush();
+    const payload = logToAxiom.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.negativePromptLength).toBe('a negative prompt'.length);
+    expect(typeof payload.negativePromptHash).toBe('string');
+  });
+});
+
+describe('AUDIT_SLOW_LOG_RAW gate + truncation', () => {
+  function fire(prompt: string) {
+    process.env.AUDIT_SLOW_LOG_MS = '100';
+    const seq = [0, 0, 200, 250];
+    let i = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => seq[Math.min(i++, seq.length - 1)]);
+    const timer = new AuditTimer();
+    timer.time('c', () => null);
+    timer.finish(prompt);
+  }
+
+  it('attaches rawPrompt by default (AUDIT_SLOW_LOG_RAW unset => true)', async () => {
+    delete process.env.AUDIT_SLOW_LOG_RAW;
+    fire('the raw triggering prompt');
+    await flush();
+    const payload = logToAxiom.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.rawPrompt).toBe('the raw triggering prompt');
+  });
+
+  it('omits rawPrompt when AUDIT_SLOW_LOG_RAW=false', async () => {
+    process.env.AUDIT_SLOW_LOG_RAW = 'false';
+    fire('the raw triggering prompt');
+    await flush();
+    const payload = logToAxiom.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.rawPrompt).toBeUndefined();
+    // Fingerprint still present so the input is characterized without the raw text.
+    expect(payload.longestNonAlnumRun).toBeDefined();
+  });
+
+  it('truncates an oversized raw prompt to head+tail with an elision marker', async () => {
+    process.env.AUDIT_SLOW_LOG_RAW = 'true';
+    process.env.AUDIT_SLOW_LOG_RAW_MAX = '20';
+    const long = 'A'.repeat(50) + 'B'.repeat(50);
+    fire(long);
+    await flush();
+    const payload = logToAxiom.mock.calls[0][0] as Record<string, unknown>;
+    const raw = payload.rawPrompt as string;
+    expect(raw).toContain('truncated');
+    expect(raw.length).toBeLessThan(long.length);
+    expect(raw.startsWith('A')).toBe(true); // head preserved
+    expect(raw.endsWith('B')).toBe(true); // tail preserved
+  });
+});
+
+describe('best-effort: instrumentation never throws into the caller', () => {
+  it('a logToAxiom rejection does not throw', async () => {
+    process.env.AUDIT_SLOW_LOG_MS = '100';
+    logToAxiom.mockRejectedValueOnce(new Error('axiom down'));
+    const seq = [0, 0, 200, 250];
+    let i = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => seq[Math.min(i++, seq.length - 1)]);
+    const timer = new AuditTimer();
+    timer.time('c', () => null);
+    expect(() => timer.finish('p')).not.toThrow();
+    await flush(); // the rejected promise is swallowed inside emitSlowLog
+  });
+
+  it('time() rethrows the sub-check error but still records elapsed', () => {
+    const timer = new AuditTimer();
+    // The audit must observe the real sub-check throw (behavior unchanged);
+    // the timer only wraps measurement around it.
+    expect(() =>
+      timer.time('boom', () => {
+        throw new Error('sub-check failed');
+      })
+    ).toThrow('sub-check failed');
+  });
+});
+
+describe('audit RESULT is unaffected by instrumentation', () => {
+  // Known-good outputs: instrumentation must not change what auditPrompt returns,
+  // regardless of whether the slow-log threshold is tripped.
+  const cases: { prompt: string; negative?: string; success: boolean }[] = [
+    { prompt: 'a beautiful landscape, mountains, sunset', success: true },
+    { prompt: 'masterpiece, best quality, portrait of a woman', success: true },
+    { prompt: 'score_9, year 2025, cyberpunk city', success: true },
+    { prompt: '15 year old girl', success: false }, // minor_age
+  ];
+
+  it('returns identical results with the threshold high (never logs) vs near-zero (always logs)', async () => {
+    for (const c of cases) {
+      process.env.AUDIT_SLOW_LOG_MS = '999999';
+      const high = auditPrompt(c.prompt, c.negative);
+
+      process.env.AUDIT_SLOW_LOG_MS = '0';
+      const low = auditPrompt(c.prompt, c.negative);
+
+      expect(low).toEqual(high);
+      expect(high.success).toBe(c.success);
+    }
+    await flush();
+  });
+
+  it('auditPromptEnriched triggers/blockedFor are unchanged across thresholds', () => {
+    process.env.AUDIT_SLOW_LOG_MS = '999999';
+    const a = auditPromptEnriched('15 year old girl');
+    process.env.AUDIT_SLOW_LOG_MS = '0';
+    const b = auditPromptEnriched('15 year old girl');
+    expect(b).toEqual(a);
+    expect(a.success).toBe(false);
+    expect(a.triggers[0].category).toBe('minor_age');
+  });
+});

--- a/src/utils/metadata/audit-slow-log.ts
+++ b/src/utils/metadata/audit-slow-log.ts
@@ -1,0 +1,265 @@
+/**
+ * Slow-prompt-audit instrumentation.
+ *
+ * INCIDENT (the reason this exists): civitai-dp-prod api pods periodically pin a
+ * CPU core at 100% for 11-47 SECONDS during the recurring "504 wave". A V8 CPU
+ * profile proved the pin lives in `src/utils/metadata/audit.ts` prompt-matching
+ * (captured frames `inPrompt` / `blockedFor`) — a single synchronous call burning
+ * tens of seconds on a USER generation prompt, pegging the event loop until the
+ * readiness probe times out and the pod sheds traffic. It is a user-triggerable
+ * DoS. We could NOT reproduce it from the regex shapes alone: `auditPrompt` runs
+ * several sub-checks (age-detection, the NSFW `inPrompt` word-list gate, the
+ * ~1573-entry POI list, paddle/soft lists, the blocklist regex loop) and we don't
+ * know WHICH sub-check or WHAT input triggers it.
+ *
+ * This module is the always-on, threshold-gated detector that captures that on the
+ * NEXT stall: it records `performance.now()` deltas around each sub-check (cheap,
+ * a couple of timestamps — no allocation below threshold) and, only when the total
+ * audit OR any single sub-check exceeds `AUDIT_SLOW_LOG_MS`, emits ONE structured
+ * `logToAxiom` line identifying the slowest sub-check and a fingerprint (and,
+ * privacy-gated, the raw prompt) sufficient to reproduce the input.
+ *
+ * Design guarantees:
+ *  - NEVER throws, NEVER delays the hot path. All hashing + logging is best-effort
+ *    and wrapped so an instrumentation error can't break or slow the actual audit.
+ *  - The audit RESULT is byte-for-byte unchanged — this only measures around it.
+ *  - Below threshold: just the timestamps; no logging, no string/hash work.
+ *  - Server-only side effects. `audit.ts` is also imported into the client bundle,
+ *    so the node-only bits (`node:crypto`, `logToAxiom`) are lazy-required behind a
+ *    `typeof window === 'undefined'` runtime guard and never pulled into a client
+ *    import graph at module-eval time.
+ *
+ * PRIVACY: `AUDIT_SLOW_LOG_RAW` (default true) attaches the raw prompt, truncated
+ * to `AUDIT_SLOW_LOG_RAW_MAX` bytes (first+last half), to make a backtrack
+ * reproducible. Logs go to internal Axiom/Loki, never public. Because this is an
+ * active DoS, capturing the raw triggering prompt is worth the tradeoff — but an
+ * operator can set `AUDIT_SLOW_LOG_RAW=false` to drop it and rely on the shape
+ * fingerprint alone.
+ */
+
+// Env knobs — read lazily per-call from process.env so they're tunable without a
+// rebuild and so this file pulls in no `~/env/*` (client-leaky) imports.
+const DEFAULT_SLOW_MS = 500;
+const DEFAULT_RAW = true;
+const DEFAULT_RAW_MAX = 2048; // first 1KB + last 1KB
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function envBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw == null || raw === '') return fallback;
+  return raw.toLowerCase() === 'true' || raw === '1';
+}
+
+/**
+ * Per-audit timing accumulator. One is created per `auditPrompt` call (cheap —
+ * a small object + a number array). `time()` wraps a sub-check, records its
+ * elapsed ms, and returns the sub-check's own result untouched.
+ */
+export class AuditTimer {
+  private readonly perCheckMs: Record<string, number> = {};
+  private readonly startedAt = performance.now();
+
+  /** Run `fn` (a sub-check), record its wall-clock ms under `name`, return its result verbatim. */
+  time<T>(name: string, fn: () => T): T {
+    const start = performance.now();
+    try {
+      return fn();
+    } finally {
+      // Accumulate so a check that runs twice (e.g. POI on prompt + negative) sums.
+      this.perCheckMs[name] = (this.perCheckMs[name] ?? 0) + (performance.now() - start);
+    }
+  }
+
+  /**
+   * Threshold check + emit. Call on EVERY return path of the audited function.
+   * Best-effort: any failure here is swallowed and never affects the caller.
+   */
+  finish(prompt: string, negativePrompt?: string): void {
+    try {
+      const totalMs = performance.now() - this.startedAt;
+      const slowMs = envNumber('AUDIT_SLOW_LOG_MS', DEFAULT_SLOW_MS);
+
+      let slowestCheck = '';
+      let slowestMs = 0;
+      for (const [name, ms] of Object.entries(this.perCheckMs)) {
+        if (ms > slowestMs) {
+          slowestMs = ms;
+          slowestCheck = name;
+        }
+      }
+
+      // Below threshold (the overwhelming common case): do nothing. No allocation,
+      // no hashing, no log.
+      if (totalMs < slowMs && slowestMs < slowMs) return;
+
+      emitSlowLog({
+        totalMs,
+        slowestCheck,
+        slowestMs,
+        perCheckMs: this.perCheckMs,
+        prompt,
+        negativePrompt,
+        slowMs,
+      });
+    } catch {
+      // Instrumentation must never throw into the audit hot path.
+    }
+  }
+}
+
+interface SlowLogInput {
+  totalMs: number;
+  slowestCheck: string;
+  slowestMs: number;
+  perCheckMs: Record<string, number>;
+  prompt: string;
+  negativePrompt?: string;
+  slowMs: number;
+}
+
+/**
+ * Build the payload + emit. Server-only (guarded). Returns synchronously; the
+ * hash + Axiom write happen in a fire-and-forget async tail whose rejection is
+ * swallowed, so the audit caller is never blocked or affected.
+ */
+function emitSlowLog(input: SlowLogInput): void {
+  // Client-bundle guard: never touch node-only modules in the browser. The
+  // dynamic `import()`s below are code-split into a server-only chunk and the
+  // guard ensures they're never reached client-side at runtime.
+  if (typeof window !== 'undefined') return;
+
+  const { totalMs, slowestCheck, slowestMs, perCheckMs, prompt, negativePrompt, slowMs } = input;
+
+  const fingerprint = shapeFingerprint(prompt);
+  const includeRaw = envBool('AUDIT_SLOW_LOG_RAW', DEFAULT_RAW);
+  const rawMax = envNumber('AUDIT_SLOW_LOG_RAW_MAX', DEFAULT_RAW_MAX);
+
+  // Round per-check ms so the payload is small + readable (sub-ms precision is noise here).
+  const round = (n: number) => Math.round(n * 100) / 100;
+  const roundedPerCheck: Record<string, number> = {};
+  for (const [k, v] of Object.entries(perCheckMs)) roundedPerCheck[k] = round(v);
+
+  // Async tail — best-effort, fully swallowed. Kept off the synchronous return so
+  // the audit hot path never waits on hashing or the Axiom client.
+  void (async () => {
+    try {
+      const payload: Record<string, unknown> = {
+        name: 'audit-prompt-slow',
+        type: 'warning',
+        totalMs: round(totalMs),
+        slowestCheck,
+        slowestMs: round(slowestMs),
+        thresholdMs: slowMs,
+        perCheckMs: roundedPerCheck,
+        promptLength: prompt.length,
+        promptHash: await stableHash(prompt),
+        ...fingerprint,
+      };
+      if (negativePrompt) {
+        payload.negativePromptLength = negativePrompt.length;
+        payload.negativePromptHash = await stableHash(negativePrompt);
+      }
+      if (includeRaw) {
+        payload.rawPrompt = truncateMiddle(prompt, rawMax);
+        if (negativePrompt) payload.rawNegativePrompt = truncateMiddle(negativePrompt, rawMax);
+      }
+
+      // Dynamic server-only import (code-split, never in the client bundle).
+      const { logToAxiom } = await import('~/server/logging/client');
+      await logToAxiom(payload);
+    } catch {
+      // Instrumentation/log failure must never surface.
+    }
+  })();
+}
+
+/**
+ * SHA-1 of the prompt (stable across pods, lets us dedup the same triggering
+ * input in Axiom). Server-only; falls back to a cheap non-crypto hash if
+ * `node:crypto` is unavailable for any reason. Never throws.
+ */
+async function stableHash(value: string): Promise<string> {
+  try {
+    const { createHash } = await import('node:crypto');
+    return createHash('sha1').update(value).digest('hex');
+  } catch {
+    return 'fnv1a_' + fnv1a(value);
+  }
+}
+
+/** Non-crypto fallback hash (FNV-1a, 32-bit) — deterministic, never throws. */
+function fnv1a(value: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Characterize the pathological input WITHOUT needing the raw text. Catastrophic
+ * backtracking blows up on input STRUCTURE — long runs of non-alphanumerics,
+ * sparse alphanumerics — so these scalars are the actionable signal even when the
+ * raw prompt is privacy-suppressed.
+ */
+function shapeFingerprint(value: string): Record<string, number | string> {
+  let nonAlnumCount = 0;
+  let longestNonAlnumRun = 0;
+  let curRun = 0;
+  let whitespaceCount = 0;
+  let digitCount = 0;
+  let letterCount = 0;
+  const distinct = new Set<number>();
+
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i);
+    distinct.add(c);
+    const isDigit = c >= 48 && c <= 57;
+    const isUpper = c >= 65 && c <= 90;
+    const isLower = c >= 97 && c <= 122;
+    const isAlnum = isDigit || isUpper || isLower;
+    if (isDigit) digitCount++;
+    else if (isUpper || isLower) letterCount++;
+    if (c === 32 || c === 9 || c === 10 || c === 13) whitespaceCount++;
+    if (isAlnum) {
+      curRun = 0;
+    } else {
+      nonAlnumCount++;
+      curRun++;
+      if (curRun > longestNonAlnumRun) longestNonAlnumRun = curRun;
+    }
+  }
+
+  return {
+    longestNonAlnumRun,
+    nonAlnumCount,
+    distinctCharCount: distinct.size,
+    whitespaceCount,
+    digitCount,
+    letterCount,
+    // Short char-class summary, e.g. "L=120,D=4,W=18,O=6" (Letters/Digits/Whitespace/Other).
+    charClassSummary: `L=${letterCount},D=${digitCount},W=${whitespaceCount},O=${
+      nonAlnumCount - whitespaceCount
+    }`,
+  };
+}
+
+/**
+ * Truncate to `max` bytes keeping the head AND tail (the structure that triggers a
+ * backtrack often sits at a boundary), with an elision marker carrying the dropped
+ * length. Returns the input unchanged when already within bounds.
+ */
+function truncateMiddle(value: string, max: number): string {
+  if (value.length <= max) return value;
+  const half = Math.max(1, Math.floor(max / 2));
+  const head = value.slice(0, half);
+  const tail = value.slice(value.length - half);
+  return `${head}…[truncated ${value.length - 2 * half} chars]…${tail}`;
+}

--- a/src/utils/metadata/audit.ts
+++ b/src/utils/metadata/audit.ts
@@ -11,6 +11,7 @@ import youngWords from './lists/words-young.json';
 import { harmfulCombinations } from './lists/harmful-combinations';
 import { blockedNSFWRegexLazy, blockedRegexLazy } from '~/utils/metadata/audit-base';
 import { createProfanityFilter } from '~/libs/profanity-simple';
+import { AuditTimer } from '~/utils/metadata/audit-slow-log';
 
 const nsfwWords = [...new Set([...nsfwPromptWords, ...nsfwWordsSoft, ...nsfwWordsPaddle])];
 
@@ -73,13 +74,25 @@ export const auditPromptEnriched = (
   checkProfanity?: boolean
 ): EnrichedAuditResult => {
   if (!prompt.trim().length) return { blockedFor: [], triggers: [], success: true };
-  prompt = normalizeText(prompt);
-  negativePrompt = normalizeText(negativePrompt);
+
+  // Per-sub-check timing instrumentation. Always-on but threshold-gated: below
+  // AUDIT_SLOW_LOG_MS it costs only a handful of `performance.now()` deltas and
+  // emits nothing. On the pathological 11-47s CPU-pin (the "504 wave" DoS) it logs
+  // ONE structured line naming the slowest sub-check + an input fingerprint. The
+  // timer NEVER alters the audit result and `finish()` can never throw — it is
+  // called on every return path below with the (normalized) prompts. The raw text
+  // passed to finish() is what was audited; logging it is privacy-gated (see
+  // audit-slow-log.ts). See that module's header for the full incident writeup.
+  const timer = new AuditTimer();
+
+  prompt = timer.time('normalize', () => normalizeText(prompt));
+  negativePrompt = timer.time('normalize', () => normalizeText(negativePrompt));
 
   // 1. Minor age check
-  const { found, age } = includesMinorAge(prompt);
+  const { found, age } = timer.time('minor_age', () => includesMinorAge(prompt));
   if (found && age != null) {
     const message = `${age} year old`;
+    timer.finish(prompt, negativePrompt);
     return {
       blockedFor: [message],
       triggers: [{ category: 'minor_age', message, matchedWord: String(age) }],
@@ -88,9 +101,10 @@ export const auditPromptEnriched = (
   }
 
   // 2. POI check
-  const poiMatch = includesPoi(prompt);
+  const poiMatch = timer.time('poi', () => includesPoi(prompt));
   if (poiMatch) {
     const message = 'Prompt cannot include celebrity names';
+    timer.finish(prompt, negativePrompt);
     return {
       blockedFor: [message],
       triggers: [
@@ -103,9 +117,10 @@ export const auditPromptEnriched = (
       success: false,
     };
   }
-  const negPoiMatch = includesPoi(negativePrompt);
+  const negPoiMatch = timer.time('poi', () => includesPoi(negativePrompt));
   if (negPoiMatch) {
     const message = 'Negative prompt cannot include celebrity names';
+    timer.finish(prompt, negativePrompt);
     return {
       blockedFor: [message],
       triggers: [
@@ -120,7 +135,9 @@ export const auditPromptEnriched = (
   }
 
   // 3. Inappropriate content check (with matched word capture)
-  const inappropriateResult = includesInappropriateEnriched({ prompt, negativePrompt });
+  const inappropriateResult = timer.time('inappropriate', () =>
+    includesInappropriateEnriched({ prompt, negativePrompt })
+  );
   if (inappropriateResult) {
     const message =
       inappropriateResult.type === 'minor'
@@ -128,6 +145,7 @@ export const auditPromptEnriched = (
         : 'Inappropriate real person content';
     const category: PromptTriggerCategory =
       inappropriateResult.type === 'minor' ? 'inappropriate_minor' : 'inappropriate_poi';
+    timer.finish(prompt, negativePrompt);
     return {
       blockedFor: [message],
       triggers: [{ category, message, matchedWord: inappropriateResult.matchedWord }],
@@ -136,21 +154,29 @@ export const auditPromptEnriched = (
   }
 
   // 4. NSFW blocklist check
-  for (const { word, regex } of blockedNSFWRegexLazy()) {
-    if (regex.test(prompt)) {
-      return {
-        blockedFor: [word],
-        triggers: [{ category: 'nsfw_blocklist', message: word, matchedWord: word }],
-        success: false,
-      };
+  const nsfwBlock = timer.time('nsfw_blocklist', () => {
+    for (const { word, regex } of blockedNSFWRegexLazy()) {
+      if (regex.test(prompt)) return word;
     }
+    return undefined;
+  });
+  if (nsfwBlock != null) {
+    timer.finish(prompt, negativePrompt);
+    return {
+      blockedFor: [nsfwBlock],
+      triggers: [{ category: 'nsfw_blocklist', message: nsfwBlock, matchedWord: nsfwBlock }],
+      success: false,
+    };
   }
 
   // 5. Profanity check (green domain only)
   if (checkProfanity) {
-    const profanityFilter = createProfanityFilter();
-    const profanityResults = profanityFilter.analyze(prompt);
+    const profanityResults = timer.time('profanity', () => {
+      const profanityFilter = createProfanityFilter();
+      return profanityFilter.analyze(prompt);
+    });
     if (profanityResults.isProfane) {
+      timer.finish(prompt, negativePrompt);
       return {
         blockedFor: profanityResults.matches,
         triggers: profanityResults.matches.map((word: string) => ({
@@ -163,6 +189,7 @@ export const auditPromptEnriched = (
     }
   }
 
+  timer.finish(prompt, negativePrompt);
   return { blockedFor: [], triggers: [], success: true };
 };
 // #endregion [enriched audit]


### PR DESCRIPTION
## Incident

civitai-dp-prod api pods periodically pin a CPU core at 100% for **11–47 seconds** during the recurring **504 wave**. A V8 CPU profile proved the pin lives in `src/utils/metadata/audit.ts` prompt-matching (captured frames `inPrompt` / `blockedFor`): a single **synchronous** call on a **user generation prompt** pegs the event loop until the readiness probe times out and the pod sheds traffic — a **user-triggerable DoS**.

We could not reproduce it from the regex shapes alone. `auditPrompt` runs several sub-checks (age-detection, the NSFW `inPrompt` word-list gate, the ~1573-entry POI list, paddle/soft lists, the blocklist regex loop) and we don't know **which** sub-check or **what** input triggers it.

## What this does

Adds **always-on, threshold-gated per-sub-check timing** to `auditPromptEnriched` (the entry that runs the checks). Each distinct sub-check — `normalize`, `minor_age`, `poi`, `inappropriate`, `nsfw_blocklist`, `profanity` — is wrapped with `performance.now()` deltas.

- **Below threshold (the common case):** costs only a handful of `performance.now()` deltas — **no logging, no allocation**. Normal audits are <5ms.
- **On a pathological audit:** emits **ONE** structured `logToAxiom` line (`name: 'audit-prompt-slow'`, `type: 'warning'`) identifying the **slowest sub-check** + the full `perCheckMs` breakdown + a stable `promptHash` (sha1) + a **shape fingerprint** (`longestNonAlnumRun`, `nonAlnumCount`, `distinctCharCount`, `whitespaceCount`, `digitCount`, `letterCount`, `charClassSummary`) so the input can be characterized/reproduced.

This fires every few minutes in prod once a stall happens, so **the next stall pinpoints the culprit sub-check + the input shape**.

## Env knobs

| Env | Default | Effect |
|---|---|---|
| `AUDIT_SLOW_LOG_MS` | `500` | Total audit OR any single sub-check exceeding this (ms) triggers the log. No opt-in flag needed — timing/threshold-log is **active by default** so it catches the next stall. |
| `AUDIT_SLOW_LOG_RAW` | `true` | Attach the **raw prompt** to the payload (truncated). Set `false` to drop it and rely on the fingerprint alone. |
| `AUDIT_SLOW_LOG_RAW_MAX` | `2048` | Raw-prompt truncation budget (bytes), kept as **first half + last half** with an elision marker. |

## Privacy

`AUDIT_SLOW_LOG_RAW` defaults to **true**: because this is an **active DoS** and logs go to **internal Axiom/Loki (never public)**, capturing the raw triggering prompt — truncated to ~2KB head+tail — is worth it to reproduce a backtrack the fingerprint alone may miss. An operator can flip `AUDIT_SLOW_LOG_RAW=false` to suppress the raw text; the shape fingerprint still characterizes the input.

## Safety

- The audit **RESULT is byte-for-byte unchanged** — the timer only measures around the existing checks; short-circuit / early-return order is preserved.
- **Never throws, never delays the hot path:** `finish()` is fully wrapped; the hash + Axiom write run in a fire-and-forget async tail with the rejection swallowed (`.catch(() => {})`).
- **Server-only, no client leak:** `audit.ts` is imported into client-reachable graphs, so the node-only bits (`node:crypto`, `logToAxiom`) are **dynamically imported behind a `typeof window === 'undefined'` guard** (code-split into a server-only chunk); env is read from `process.env` (no `~/env/*` import).

## Tests

`src/utils/metadata/__tests__/audit-slow-log.test.ts` (12 tests, all green): detector fires above `AUDIT_SLOW_LOG_MS` and not below (mocked `performance.now`), identifies the slowest sub-check + fingerprint, respects the `AUDIT_SLOW_LOG_RAW` gate + truncation, never throws on a `logToAxiom` rejection, and the audit result is identical with the threshold tripped vs not. `logToAxiom` is mocked (no Axiom internals tested). Full `src/utils/metadata` suite (incl. the existing equivalence + ReDoS guards) stays green.

> Verification note: unit tests + tsc-clean on changed files only. `next build` can't run on NixOS; preview CI is the build gate. Not verified against a live prod stall (that's the point — it captures the next one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)