### PR TITLE
feat(logging): make logToAxiom structured-stdout always-on (Axiom→Loki Phase 1)

### DIFF
--- a/src/server/logging/__tests__/client.test.ts
+++ b/src/server/logging/__tests__/client.test.ts
@@ -1,12 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// These pin the ordering contract of `logToAxiom`: the structured stderr line
-// (which Loki ingests — it carries message/stack/code/path) must be emitted
-// BEFORE the `if (!axiom) return` / `if (!datastream) return` guards. Previously
-// it sat after those guards, so preview environments — where the Axiom token is a
-// placeholder → `axiom` is null → the function returned early — never reached Loki
-// (confirmed: 0 `INTERNAL_SERVER_ERROR` matches across 2.2M preview log lines).
-// The same blind spot hits any Axiom outage. Axiom ingest is otherwise unchanged.
+// These pin the contract of `logToAxiom`'s structured-stderr sink:
+//
+//  1. ALWAYS-ON (Phase 1, Axiom→Loki migration): in prod the structured JSON line
+//     is emitted UNCONDITIONALLY — it is no longer gated behind
+//     `LOG_ERRORS_TO_STDOUT==='true'`. stdout/stderr → Alloy → Loki is the durable,
+//     queryable sink, so every event must land there by default.
+//  2. ORDERING: the line is emitted BEFORE the `if (!axiom) return` /
+//     `if (!datastream) return` guards AND independently of Axiom throwing. Previously
+//     it sat after those guards, so preview environments — where the Axiom token is a
+//     placeholder → `axiom` is null → the function returned early — never reached Loki
+//     (confirmed: 0 `INTERNAL_SERVER_ERROR` matches across 2.2M preview log lines).
+//     The same blind spot hits any Axiom outage. Loki must get the line regardless.
+//  3. DUAL-WRITE: Axiom ingest still fires when a client + datastream are configured
+//     (kept during the transition; removed at the cutover phase).
 //
 // The module builds its `axiom` client and reads `isProd` at import time, so each
 // case resets modules and re-mocks `~/env/other`, `~/env/server`, and
@@ -19,13 +26,17 @@ const ERR = { message: 'boom', stack: 'Error: boom\n  at x', code: 'INTERNAL_SER
 
 // Returns the mock ingestEvents spy + a loader for the real module, configured
 // for the requested env. `axiomConfigured=false` reproduces the preview/outage
-// case where the module's `axiom` ends up null.
+// case where the module's `axiom` ends up null. `ingestThrows` reproduces an Axiom
+// outage where `ingestEvents` rejects.
 async function loadClient(opts: {
   isProd: boolean;
   axiomConfigured: boolean;
   datastream?: string;
+  ingestThrows?: boolean;
 }) {
-  const ingestEvents = vi.fn().mockResolvedValue(undefined);
+  const ingestEvents = opts.ingestThrows
+    ? vi.fn().mockRejectedValue(new Error('axiom down'))
+    : vi.fn().mockResolvedValue(undefined);
 
   vi.doMock('~/env/other', () => ({
     isProd: opts.isProd,
@@ -54,24 +65,64 @@ async function loadClient(opts: {
   return { logToAxiom: mod.logToAxiom, ingestEvents };
 }
 
-describe('logToAxiom stderr-for-Loki ordering', () => {
+describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.resetModules();
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
     errorSpy.mockRestore();
+    logSpy.mockRestore();
     vi.unstubAllEnvs();
     vi.doUnmock('~/env/other');
     vi.doUnmock('~/env/server');
     vi.doUnmock('@axiomhq/axiom-node');
   });
 
-  it('REGRESSION GUARD: emits the structured stderr line in prod even when Axiom is null (preview/outage)', async () => {
-    vi.stubEnv('LOG_ERRORS_TO_STDOUT', 'true');
+  it('ALWAYS-ON: emits the structured stderr line in prod even when LOG_ERRORS_TO_STDOUT is unset', async () => {
+    // flag deliberately NOT set — the line must still be written (the gate is gone).
+    const { logToAxiom } = await loadClient({
+      isProd: true,
+      axiomConfigured: true,
+      datastream: 'civitai-errors',
+    });
+
+    await logToAxiom(ERR);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(errorSpy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({
+      message: ERR.message,
+      stack: ERR.stack,
+      code: ERR.code,
+      path: ERR.path,
+    });
+  });
+
+  it('ALWAYS-ON: emits the line regardless of LOG_ERRORS_TO_STDOUT value ("1", "false", etc.)', async () => {
+    for (const value of ['1', 'false', '', 'no']) {
+      errorSpy.mockClear();
+      vi.resetModules();
+      vi.stubEnv('LOG_ERRORS_TO_STDOUT', value);
+      const { logToAxiom } = await loadClient({
+        isProd: true,
+        axiomConfigured: true,
+        datastream: 'civitai-errors',
+      });
+
+      await logToAxiom(ERR);
+
+      expect(errorSpy, `LOG_ERRORS_TO_STDOUT=${JSON.stringify(value)} should still emit`).toHaveBeenCalledTimes(1);
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('ORDERING: emits the stderr line in prod even when Axiom is null (preview/outage), before the guards', async () => {
     const { logToAxiom, ingestEvents } = await loadClient({ isProd: true, axiomConfigured: false });
 
     await logToAxiom(ERR);
@@ -94,27 +145,25 @@ describe('logToAxiom stderr-for-Loki ordering', () => {
     expect(ingestEvents).not.toHaveBeenCalled();
   });
 
-  it('does NOT emit the stderr line when LOG_ERRORS_TO_STDOUT is unset (no stderr spam)', async () => {
-    // flag unset
-    const { logToAxiom, ingestEvents } = await loadClient({ isProd: true, axiomConfigured: false });
+  it('ORDERING: emits the stderr line even when Axiom ingest throws (Axiom degraded)', async () => {
+    const { logToAxiom, ingestEvents } = await loadClient({
+      isProd: true,
+      axiomConfigured: true,
+      datastream: 'civitai-errors',
+      ingestThrows: true,
+    });
 
-    await logToAxiom(ERR);
+    // The stderr line is written synchronously before the await, so it lands even
+    // though ingestEvents rejects (the rejection propagates out of logToAxiom).
+    await expect(logToAxiom(ERR)).rejects.toThrow('axiom down');
 
-    expect(errorSpy).not.toHaveBeenCalled();
-    expect(ingestEvents).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(errorSpy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({ message: ERR.message, code: ERR.code });
+    expect(ingestEvents).toHaveBeenCalledTimes(1);
   });
 
-  it('does NOT emit the stderr line when LOG_ERRORS_TO_STDOUT is not exactly "true"', async () => {
-    vi.stubEnv('LOG_ERRORS_TO_STDOUT', '1');
-    const { logToAxiom } = await loadClient({ isProd: true, axiomConfigured: false });
-
-    await logToAxiom(ERR);
-
-    expect(errorSpy).not.toHaveBeenCalled();
-  });
-
-  it('still ingests to Axiom (existing behavior) AND emits the stderr line when configured + flag on', async () => {
-    vi.stubEnv('LOG_ERRORS_TO_STDOUT', 'true');
+  it('DUAL-WRITE: still ingests to Axiom AND emits the stderr line when a client + datastream are configured', async () => {
     const { logToAxiom, ingestEvents } = await loadClient({
       isProd: true,
       axiomConfigured: true,
@@ -135,5 +184,20 @@ describe('logToAxiom stderr-for-Loki ordering', () => {
       'civitai-errors',
       expect.objectContaining({ message: ERR.message, code: ERR.code, pod: 'pod-test' })
     );
+  });
+
+  it('NON-PROD: logs via console.log and does NOT touch the stderr/Axiom path', async () => {
+    const { logToAxiom, ingestEvents } = await loadClient({
+      isProd: false,
+      axiomConfigured: true,
+      datastream: 'civitai-errors',
+    });
+
+    await logToAxiom(ERR);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith('logToAxiom', expect.objectContaining({ message: ERR.message, pod: 'pod-test' }));
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(ingestEvents).not.toHaveBeenCalled();
   });
 });

--- a/src/server/logging/__tests__/client.test.ts
+++ b/src/server/logging/__tests__/client.test.ts
@@ -163,6 +163,39 @@ describe('logToAxiom structured-stderr sink (always-on for Loki)', () => {
     expect(ingestEvents).toHaveBeenCalledTimes(1);
   });
 
+  it('SERIALIZATION GUARD: a non-serializable `data` (circular ref) does NOT throw to the caller and still attempts the Axiom dual-write', async () => {
+    const { logToAxiom, ingestEvents } = await loadClient({
+      isProd: true,
+      axiomConfigured: true,
+      datastream: 'civitai-errors',
+    });
+
+    // Circular reference → JSON.stringify throws "Converting circular structure to JSON".
+    // (A BigInt value would throw "Do not know how to serialize a BigInt" the same way.)
+    const circular: MixedObject = { name: 'payment.webhook' };
+    circular.self = circular;
+
+    // The unconditional structured-stderr stringify must be contained: logToAxiom must
+    // not throw, so the hot-path caller (tRPC 500 handler / webhook / upload) is safe.
+    await expect(logToAxiom(circular)).resolves.toBeUndefined();
+
+    // The failure is contained, NOT silent: a stringify-safe fallback line is emitted.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const fallback = errorSpy.mock.calls[0][0] as string;
+    expect(typeof fallback).toBe('string');
+    const parsed = JSON.parse(fallback);
+    expect(parsed.name).toBe('payment.webhook');
+    expect(typeof parsed._stringifyError).toBe('string');
+
+    // The serialization failure did not abort the function — the Axiom dual-write below
+    // still ran with the original (non-serialized) object.
+    expect(ingestEvents).toHaveBeenCalledTimes(1);
+    expect(ingestEvents).toHaveBeenCalledWith(
+      'civitai-errors',
+      expect.objectContaining({ name: 'payment.webhook', pod: 'pod-test' })
+    );
+  });
+
   it('DUAL-WRITE: still ingests to Axiom AND emits the stderr line when a client + datastream are configured', async () => {
     const { logToAxiom, ingestEvents } = await loadClient({
       isProd: true,

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -107,8 +107,16 @@ export async function logToAxiom(data: MixedObject, datastream?: string) {
     // handle (sysRedis + Axiom both down). `_axiom: datastream` may be undefined in
     // previews (no AXIOM_DATASTREAM) — JSON.stringify drops it; the line still
     // carries message/stack/code/path.
-    if (process.env.LOG_ERRORS_TO_STDOUT === 'true')
-      console.error(JSON.stringify({ _axiom: datastream, ...sendData }));
+    //
+    // ALWAYS-ON (Phase 1 of the Axiom→Loki migration): this structured line is the
+    // durable, queryable sink — stdout/stderr → Alloy → Loki, queried by name via
+    // `{namespace="civitai-dp-prod"} | json | name="…"`. It used to be gated behind
+    // `LOG_ERRORS_TO_STDOUT==='true'` (a blunt, temporary per-deployment flag flipped
+    // on dp-prod-api to read diagnostics); the gate is removed so every event lands
+    // in Loki by default while Axiom dual-write below continues during the transition.
+    // Volume/noise control belongs in the Alloy `civitai_logs` pipeline (sample/drop
+    // stages + line-size cap), not an app-side gate.
+    console.error(JSON.stringify({ _axiom: datastream, ...sendData }));
 
     if (!axiom) return;
     if (!datastream) return;

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -116,7 +116,26 @@ export async function logToAxiom(data: MixedObject, datastream?: string) {
     // in Loki by default while Axiom dual-write below continues during the transition.
     // Volume/noise control belongs in the Alloy `civitai_logs` pipeline (sample/drop
     // stages + line-size cap), not an app-side gate.
-    console.error(JSON.stringify({ _axiom: datastream, ...sendData }));
+    //
+    // SERIALIZATION GUARD: this write is now UNCONDITIONAL and `logToAxiom` is called
+    // (often `await`ed) on hot paths — the central tRPC 500 handler, payment webhooks,
+    // upload endpoints — with arbitrary `data`/`error` objects. `JSON.stringify` THROWS
+    // on BigInt values and circular references, so an unguarded stringify here could
+    // propagate into a request path that previously never hit this line. Contain it: a
+    // serialization failure must NEVER break the caller. On failure emit a minimal,
+    // stringify-safe fallback so the event isn't silently lost; the fallback is itself
+    // wrapped so it can't throw either.
+    try {
+      console.error(JSON.stringify({ _axiom: datastream, ...sendData }));
+    } catch (err) {
+      try {
+        console.error(
+          JSON.stringify({ _axiom: datastream, name: sendData?.name, _stringifyError: String(err) })
+        );
+      } catch {
+        console.error('logToAxiom: failed to serialize event', sendData?.name);
+      }
+    }
 
     if (!axiom) return;
     if (!datastream) return;

--- a/src/server/logging/client.ts
+++ b/src/server/logging/client.ts
@@ -130,10 +130,14 @@ export async function logToAxiom(data: MixedObject, datastream?: string) {
     } catch (err) {
       try {
         console.error(
-          JSON.stringify({ _axiom: datastream, name: sendData?.name, _stringifyError: String(err) })
+          JSON.stringify({
+            _axiom: datastream,
+            name: (sendData as MixedObject)?.name,
+            _stringifyError: String(err),
+          })
         );
       } catch {
-        console.error('logToAxiom: failed to serialize event', sendData?.name);
+        console.error('logToAxiom: failed to serialize event', (sendData as MixedObject)?.name);
       }
     }
 


### PR DESCRIPTION
## Phase 1 of the Axiom → Loki structured-logging migration

Per `claudedocs/axiom-to-loki-migration-handoff-2026-06-23.md` (datapacket-talos cluster repo). **Small, additive, fully reversible.** Does not merge/deploy anything; just the app-side sink change.

### What this does
Removes the `LOG_ERRORS_TO_STDOUT === 'true'` gate in `logToAxiom` (`src/server/logging/client.ts`) so the structured JSON line is **always** written to stderr in prod (→ Alloy → Loki). This makes **Loki the durable, queryable sink** for civitai structured logs — any event becomes queryable by name (`{namespace="civitai-dp-prod"} | json | name="audit-prompt-slow"`) instead of dead-ending on the ingest-only Axiom token.

- **Axiom dual-write KEPT** — `axiom.ingestEvents(...)` and the `AXIOM_*` env are untouched. Removing Axiom is the later cutover phase, not this PR.
- **stderr write keeps its position BEFORE the Axiom null/datastream guards** — Loki still gets the line when Axiom is null (preview placeholder token) or throwing (outage). The load-bearing ordering comment is preserved and extended.
- **Function signature unchanged** (`logToAxiom(data, datastream?)`) — all ~429 call sites come along for free, zero edits.
- **Non-prod `console.log('logToAxiom', …)` branch unchanged.**

### Gate-design choice: remove (not invert to opt-out)
The gate was a blunt, temporary per-deployment flag flipped on `dp-prod-api` (cluster commit `b21d9b463`, marked TEMPORARY) just to read the `audit-prompt-slow` diagnostic that the ingest-only Axiom token couldn't query. Removing it — rather than inverting it to an opt-OUT env — keeps the app simple and puts volume/noise control where it belongs: the upcoming Alloy `civitai_logs` pipeline (sample/drop stages + line-size cap), not an app-side env the cluster team has to track.

### Tests
`src/server/logging/__tests__/client.test.ts` rewritten to pin the new always-on contract:
- ALWAYS-ON: the structured line is emitted in prod even when `LOG_ERRORS_TO_STDOUT` is unset, and regardless of its value (`"1"`, `"false"`, …).
- ORDERING: the line is emitted before/independent of Axiom being `null` (preview/outage) **and** when `ingestEvents` throws (Axiom degraded).
- DUAL-WRITE: Axiom ingest still fires when a client + datastream are configured.
- NON-PROD: still routes via `console.log` and touches neither stderr nor Axiom.

All 6 tests pass (`vitest run --project unit src/server/logging/__tests__/client.test.ts`).

### Follow-up phases (not in this PR)
1. **Alloy:** add the `civitai_logs` JSON-parse pipeline (`name` as Loki **structured metadata**, NOT a label — cardinality trap) in `clusters/production/apps/prometheus-stack/alloy.yaml`.
2. **Consumers:** migrate the Grafana alerts that read these `{name:…}` lines to LogQL; dual-run + validate parity; update the `investigate-dp-errors` skill.
3. **Axiom cutover:** drop `axiom.ingestEvents` + `@axiomhq/axiom-node` + server `AXIOM_*` env (SOPS).
4. **Remove the temp `LOG_ERRORS_TO_STDOUT`** from `dp-prod-api` (`deployment-api.yaml`) — now the default behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)