### PR TITLE
test(audit): add age-path old-vs-new equivalence oracle (close the #2722 audit gap) + fix stale comment ref

### DIFF
--- a/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
+++ b/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
@@ -6,6 +6,7 @@ import {
   includesMinor,
   includesMinorAge,
   checkable,
+  __buildOldAgeRegexesForTest,
 } from '~/utils/metadata/audit';
 import { trimNonAlphanumeric } from '~/utils/string-helpers';
 import poiWords from '~/utils/metadata/lists/words-poi.json';
@@ -157,6 +158,49 @@ function refHighlight(
   return prompt;
 }
 
+// --- Reference (pre-#2722) AGE matching ---
+// The word-list path above proves the consuming→zero-width boundary refactor on
+// prepareWordRegex. The AGE path (perAgeRegexes/includesMinorAge) got the SAME
+// `0*`+boundary change but had no committed old-vs-new guard — independent probes
+// found no divergence, but the safety-critical minor-age path deserves the same
+// property-based protection. This is that guard.
+//
+// `oldPerAgeRegexes` are the OLD *consuming-boundary* form of perAgeRegexes, built by
+// the test-only `__buildOldAgeRegexesForTest` export which reuses audit.ts's own
+// post-teen-expansion `ages` + `templates` + `buildAgePattern` + year/old patterns
+// (so the only difference vs the live regexes is the boundary form — no copy-pasted
+// data that could rot). `refIncludesMinorAge` then mirrors the live includesMinorAge
+// two-phase function EXACTLY (same falsePositiveTagPattern strip, same quickScreen,
+// same per-age short-circuit loop) but iterating the old-form regexes. Comparing it
+// against the live includesMinorAge isolates the boundary change on the age path.
+const oldPerAgeRegexes = __buildOldAgeRegexesForTest();
+
+// Copied verbatim from audit.ts (module-private there). These two are NOT what the
+// refactor changed; replicating them keeps the comparison about the boundary only.
+const refFalsePositiveTagPattern =
+  /\bscore_\d(?:_up|_down)?\b|\bsource_\w+\b|\brating_\w+\b/gi;
+const refQuickScreenPattern =
+  /(?:age[ds]?|year|old|birthday|anos|\b(?:1[0-7]|[1-9])\b|teen|eleven|twelve|one|two|three|four|five|six|seven|eight|nine|ten)/i;
+
+function refIncludesMinorAge(prompt: string | undefined): {
+  found: boolean;
+  age: number | undefined;
+} {
+  if (!prompt) return { found: false, age: undefined };
+  const cleaned = prompt.replace(refFalsePositiveTagPattern, ' ');
+  if (!refQuickScreenPattern.test(cleaned)) {
+    return { found: false, age: undefined };
+  }
+  for (const { age, regexes } of oldPerAgeRegexes) {
+    for (const regex of regexes) {
+      if (regex.test(cleaned)) {
+        return { found: true, age };
+      }
+    }
+  }
+  return { found: false, age: undefined };
+}
+
 // Deterministic PRNG (mulberry32) — fixed seed keeps the random-string batch stable
 // across runs while still exercising alternation backtracking. Avoids Math.random().
 function makeRng(seed: number) {
@@ -283,6 +327,140 @@ function buildYoungCorpus(): string[] {
 const youngCorpus = buildYoungCorpus();
 const randomBatch = buildRandomStrings(4000);
 
+// --- Age-path corpus: deterministic batch covering the age-detection risk surface ---
+// Curated (mirrors src/utils/metadata/__tests__/audit.test.ts) + generated. No
+// randomness — every case is a fixed literal so the oracle is reproducible.
+function buildAgeCorpus(): string[] {
+  const prompts: string[] = [];
+
+  // (a) Curated corpus mirroring audit.test.ts — both positives and benigns.
+  prompts.push(
+    '9 year old girl',
+    'a 15 year old',
+    'aged 15',
+    'seventeen year old',
+    'a 12 yo',
+    'score_9, a 9 year old girl', // tag must not mask a real age phrase
+    'score_9_up, year 2025', // danbooru tag — benign
+    'score_5_down, year 2025',
+    'source_pony, year 2025',
+    'rating_safe, year 2025',
+    'year 2025, masterpiece', // benign
+    '8K, 4K, masterpiece, year 2025', // benign
+    '',
+    '   ',
+    'a beautiful landscape, masterpiece, best quality' // benign
+  );
+
+  // (b) Numeric ages 1..17 across the phrasing templates.
+  const numericAges = Array.from({ length: 17 }, (_, i) => i + 1);
+  for (const n of numericAges) {
+    prompts.push(
+      `${n} year old`,
+      `${n} years old`,
+      `a ${n} yo girl`,
+      `${n}yr old`,
+      `${n} yrs`,
+      `aged ${n}`,
+      `age ${n}`,
+      `age of ${n}`,
+      `${n} age`,
+      `${n}th birthday`,
+      `${n} anos` // {age} {years} via 'anos'
+    );
+  }
+
+  // (c) English number words — canonical + truncated/typo variants from audit.ts.
+  const wordAges = [
+    'one',
+    'two',
+    'three',
+    'thri', // typo variant
+    'four',
+    'fore',
+    'five',
+    'fiv',
+    'six',
+    'sicks',
+    'seven',
+    'sevn',
+    'eight',
+    'eigt',
+    'eigh',
+    'nine',
+    'nien',
+    'ten',
+    'eleven',
+    'twelve',
+    'twelv',
+    'thirteen',
+    'fourteen',
+    'fifteen',
+    'sixteen',
+    'seventeen',
+    'sevnteen', // truncated teen-compound
+  ];
+  for (const w of wordAges) {
+    prompts.push(`${w} year old`, `${w}th birthday`, `aged ${w}`, `a ${w} yo`);
+  }
+
+  // (d) Compound-word boundary cases that must NOT match (eighty/seventy/eighteen+).
+  prompts.push(
+    'eighty year old man', // 'eight' must not match via trailing-y year unit
+    'seventy years',
+    'an eighteen year old', // 18 is not a tracked age
+    'a nineteen year old',
+    'a twenty year old',
+    'a thirty year old'
+  );
+
+  // (e) Multiple {0,3}-separator spacings between parts.
+  prompts.push(
+    '9   year   old',
+    '9-year-old',
+    '9.year.old',
+    '9_year_old',
+    '9,,,year,,,old',
+    '15...yo',
+    'aged...15'
+  );
+
+  // (f) Leading-zero `0*` cases.
+  prompts.push('09 year old', '0009 year old', 'x0009y year old', '015 yo', '00 year old');
+
+  // (g) Edge positions — match at string start, at end, and whole-string.
+  prompts.push(
+    '9 year old', // whole string
+    '9 year old girl by the lake', // leading
+    'a portrait of a 9 year old', // trailing
+    '15yo' // tight whole-string
+  );
+
+  // (h) Non-Latin (CJK/Hangul) bounded around an embedded age — the #2722 ReDoS shape.
+  prompts.push(
+    '美9 year old美',
+    '美丽9 year old丽美',
+    '한국어 9 year old 사람',
+    '美aged 15美',
+    '美seventeen year old美',
+    '日本語のテキスト16 yoテキスト'
+  );
+
+  // (i) Bare digits / near-misses that should stay benign.
+  prompts.push(
+    '8k resolution',
+    '4k uhd render',
+    'lora:detail:0.9',
+    'iso 100, f1.8',
+    'a 99 year old', // 99 not tracked
+    'chapter 7 of the book' // '7' bare digit, no year/old/age unit nearby
+  );
+
+  return prompts;
+}
+
+const ageCorpus = buildAgeCorpus();
+
 // Gated checkables built with the EXACT same word lists + options as audit.ts's
 // `words.young.nouns` and `words.poi`. `checkable(...).highlight` is the gated
 // function under test; `refHighlight` over the matching per-word regexes is the
@@ -319,6 +497,38 @@ describe('audit matching equivalence (gate vs brute-force)', () => {
     },
     60000
   );
+
+  // AGE PATH old-vs-new boundary guard (closes the #2722 audit gap). Asserts the
+  // live includesMinorAge (zero-width boundaries) agrees with the old consuming-
+  // boundary reference on BOTH the found boolean AND the detected age.
+  it('includesMinorAge matches the old-boundary reference over the curated + generated age corpus', () => {
+    for (const p of ageCorpus) {
+      expect(
+        includesMinorAge(p),
+        `includesMinorAge age-path divergence for: ${JSON.stringify(p)}`
+      ).toEqual(refIncludesMinorAge(p));
+    }
+  });
+
+  // Also fold the existing word-list/young corpora through the age oracle — these
+  // are realistic prompts and a cheap way to widen coverage with no extra randomness.
+  it('includesMinorAge matches the old-boundary reference over the existing corpora', () => {
+    for (const p of [...corpus, ...youngCorpus]) {
+      expect(
+        includesMinorAge(p),
+        `includesMinorAge age-path divergence for: ${JSON.stringify(p)}`
+      ).toEqual(refIncludesMinorAge(p));
+    }
+  });
+
+  it('includesMinorAge matches the old-boundary reference across the deterministic random batch', () => {
+    for (const p of randomBatch) {
+      expect(
+        includesMinorAge(p),
+        `includesMinorAge age-path random-batch divergence for: ${JSON.stringify(p)}`
+      ).toEqual(refIncludesMinorAge(p));
+    }
+  });
 
   it('getTagsFromPrompt returns the same tag set as the reference', () => {
     for (const p of corpus) {

--- a/src/utils/metadata/audit.ts
+++ b/src/utils/metadata/audit.ts
@@ -344,12 +344,38 @@ const perAgeRegexes = ages.map((ageEntry) => {
     // edge" ≡ "not preceded/followed by an alnum") but, being zero-width, there is
     // nothing for the engine to backtrack over a long non-Latin (CJK) run — this
     // collapses the O(regexes × n²) catastrophic backtracking to linear. See
-    // audit-base.ts prepareWordRegex + audit-redos.test.ts for the incident.
+    // audit-base.ts prepareWordRegex + audit-cjk-redos.test.ts for the incident.
     regexStr = `(?<![a-zA-Z0-9])0*` + regexStr + `(?![a-zA-Z0-9])`;
     return new RegExp(regexStr, 'i');
   });
   return { age: ageEntry.age, regexes };
 });
+
+// TEST-ONLY. Reconstructs the per-age regexes EXACTLY as `perAgeRegexes` above but
+// with the PRE-#2722 *consuming* boundary groups (`([^a-zA-Z0-9]+|^)0*…([^a-zA-Z0-9]+|$)`)
+// instead of the zero-width assertions. It deliberately reuses the SAME in-module
+// building blocks (the post-teen-expansion `ages`, `templates`, `buildAgePattern`,
+// `yearsPattern`, `oldPattern`) so the equivalence oracle in
+// `__tests__/audit-matching-equivalence.test.ts` is a faithful old-vs-new comparison
+// that can never drift from the live construction (no copy-pasted data to rot).
+// Not used by any runtime path — exported solely so the test can prove the #2722
+// boundary refactor preserved age matching. Do NOT call from production code.
+export function __buildOldAgeRegexesForTest() {
+  return ages.map((ageEntry) => {
+    const agePattern = buildAgePattern(ageEntry.matches);
+    const regexes = templates.map((template) => {
+      let regexStr = template;
+      regexStr = regexStr.replace('{age}', `(${agePattern})`);
+      regexStr = regexStr.replace('{years}', `(${yearsPattern})`);
+      regexStr = regexStr.replace('{old}', `(${oldPattern})`);
+      regexStr = regexStr.replace(/\s+/g, `[^a-zA-Z0-9]{0,3}`);
+      // Pre-#2722 consuming boundaries (the only intended difference vs perAgeRegexes).
+      regexStr = `([^a-zA-Z0-9]+|^)0*` + regexStr + `([^a-zA-Z0-9]+|$)`;
+      return new RegExp(regexStr, 'i');
+    });
+    return { age: ageEntry.age, regexes };
+  });
+}
 
 // Legacy: Keep ageRegexes for debugAuditPrompt and highlightMinor (which iterate all templates)
 // These use the combined pattern for detailed match info


### PR DESCRIPTION
Fast-follow to #2722 (merged), closing the one non-blocking gap its adversarial audit flagged.

## Context
#2722 replaced consuming regex boundaries `([^a-zA-Z0-9]+|^) … ([^a-zA-Z0-9]+|$)` with zero-width assertions `(?<![a-zA-Z0-9]) … (?![a-zA-Z0-9])` in `src/utils/metadata/audit.ts` to kill a CJK ReDoS. `audit-matching-equivalence.test.ts` rigorously guards the **word-list** path (a `refPrepareWordRegex` old-form reference vs the live functions) — but the **age-detection** path (`perAgeRegexes`/`includesMinorAge`) got the same `0*`+boundary change with **no committed old-vs-new regression guard** (it reused the live `includesMinorAge` on both sides of the oracle). Independent probes found no divergence, but the safety-critical minor-age path deserves the same property-based protection.

## Changes (test + comment + one tiny test-only export — no runtime/matching behavior change)
- **`__buildOldAgeRegexesForTest`** (new test-only export in `audit.ts`): reconstructs the per-age regexes EXACTLY as `perAgeRegexes` but with the **pre-#2722 consuming boundaries**, reusing the SAME in-module building blocks (post-teen-expansion `ages`, `templates`, `buildAgePattern`, `yearsPattern`, `oldPattern`). Chosen over copy-pasting the data because `ages` is **mutated in place** by the teen-expansion loop, so copy-pasted data would rot and the only faithful, low-maintenance reference reuses the live construction. Clearly commented as test-only; not referenced by any runtime path.
- **`refIncludesMinorAge`** (in the test): mirrors the live two-phase `includesMinorAge` (same `falsePositiveTagPattern` strip + `quickScreen` + per-age short-circuit loop) over the old-form regexes. Three new assertions check the live `includesMinorAge` agrees with the old-boundary reference on **both `found` and `age`** over:
  - the curated corpus (mirrors `audit.test.ts`): `N year old`/`N yo`/`N yr`/`Nth birthday`/`aged N`, word ages, danbooru-tag false positives, benigns;
  - the existing `corpus` + `youngCorpus` (realistic prompts, free coverage);
  - the existing deterministic 4000-string random batch;
  - a generated risk-surface batch: numeric ages 1–17 across all templates, English number words (canonical + truncated/typo variants), compound-word boundary near-misses (eighty/seventy/eighteen), multi `{0,3}`-separator spacings, **leading-zero `0*`** (`09`, `0009`, `x0009y`), **edge positions** (start/end/whole-string), **CJK/Hangul-bounded** embedded ages (`美9 year old美`), and bare-digit benigns.
- **Mutation-checked**: dropping the live `0*` makes `"09 year old"` diverge and the curated test fails — confirming the oracle catches age-path regressions rather than passing trivially.
- **Comment fix** in `audit.ts`: the `perAgeRegexes` ReDoS note pointed at `audit-redos.test.ts` (the older #2452 gate-removal guard); the #2722 consuming→zero-width perf guard is `audit-cjk-redos.test.ts`.

## Test results
`pnpm exec vitest run --project unit src/utils/metadata` → 6 files, **52 passed, 1 skipped** (pre-existing unrelated skip). The 3 new age-path oracle tests pass on the current (fixed) code, proving the #2722 refactor preserved age matching.

## tsc
Both changed files type-clean (grep of full `tsc --noEmit` output — 5296-error pre-existing baseline, none in these files). `next build` not runnable on NixOS; preview CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)