### PR TITLE
feat(app-blocks): token-auth self-scoped submission-status endpoint (for civitai app status)

### DIFF
--- a/src/pages/api/v1/blocks/submissions.ts
+++ b/src/pages/api/v1/blocks/submissions.ts
@@ -1,0 +1,316 @@
+import type { Logger } from '@civitai/next-axiom';
+import { withAxiom } from '@civitai/next-axiom';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { SessionUser } from 'next-auth';
+import * as z from 'zod';
+import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
+import { dbRead } from '~/server/db/client';
+import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
+import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
+
+type AxiomAPIRequest = NextApiRequest & { log: Logger };
+
+/**
+ * GET /api/v1/blocks/submissions
+ *
+ * TOKEN-AUTHENTICATED, SELF-SCOPED read of the caller's own App-Block publish
+ * (submission) requests — review status + Phase-2 deploy lifecycle. This is the
+ * server-side surface that unblocks a future `civitai app status` CLI command:
+ * a developer who submitted via `civitai app submit`
+ * (`POST /api/v1/blocks/submit-version`) can now poll the review/deploy state of
+ * THEIR OWN submissions with the SAME token.
+ *
+ * Today that data lives ONLY behind `blocks.listMyPublishRequests`, a
+ * `moderatorProcedure` reachable from a logged-in mod browser but NOT from a
+ * headless CLI carrying only a bearer token. This route returns the SAME useful
+ * fields, but as a CLI-friendly REST GET and HARD-FILTERED to the caller.
+ *
+ * ## Auth — mirrors `POST /api/v1/blocks/submit-version` EXACTLY, so the token
+ *    that submitted can read status:
+ *   - `Authorization: Bearer <civitai API key>` resolved via
+ *     `getSessionFromBearerToken` (the same helper backing all `/api/v1/*` REST
+ *     auth) — NO new key system.
+ *   - A PERSONAL key always passes the token-type gate.
+ *   - An OAUTH-client-issued token passes ONLY if it carries the dedicated
+ *     `TokenScope.AppBlocksSubmit` bit (the same gate submit-version uses; the
+ *     first-party `civitai-cli` client is provisioned with it). An un-scoped
+ *     OAuth token → 403. This keeps the read in lockstep with the write: the
+ *     same credential that could submit can read its own submissions, and
+ *     nothing weaker.
+ *   - MOD-ONLY pre-GA (`isAppBlocksEnabled({ user })` + `user.isModerator`,
+ *     not banned) — identical posture to submit-version + dev-token. RELAX in
+ *     lockstep with the rest of App Blocks at GA, not unilaterally.
+ *
+ * ## Self-scoping — the security crux
+ * Rows are filtered STRICTLY to `submittedByUserId === user.id` (the
+ * authenticated caller). There is NO request input that can widen this: the
+ * optional `id` / `blockId` query params only NARROW the already-self-scoped set
+ * (and an `id` / `blockId` the caller doesn't own resolves to 404, never another
+ * user's row). A developer can only ever see their own submissions.
+ *
+ * ## Why no CSRF / Origin guard (same reasoning as submit-version)
+ * Bearer-authed: the credential rides an `Authorization` header a cross-site
+ * form can't set and the browser never attaches automatically — no ambient
+ * authority, so the Origin guard is intentionally omitted (it would also break
+ * the headless CLI, which sends no Origin).
+ */
+export const config = {
+  api: {
+    // No request body is read (GET); cap small anyway so a determined caller
+    // can't push parse pressure on a stray body.
+    bodyParser: { sizeLimit: '8kb' },
+  },
+};
+
+// A read is cheap; allow generous polling for `civitai app status` while still
+// bounding abuse. Per-user fixed window, fail-closed on a malformed limiter.
+const RATE_LIMIT = { max: 60, windowSeconds: 60 } as const;
+
+// Mirror listMyPublishRequests' page size.
+const MAX_ROWS = 100;
+
+const APPS_DOMAIN_FALLBACK = 'civit.ai';
+
+const querySchema = z.object({
+  // OPTIONAL single-submission filter by publish-request id (`pubreq_<ULID>`).
+  // NARROWS the already-self-scoped set — never widens it. Not-found / not-owned
+  // → 404 (no ownership oracle), exactly like dev-token.
+  id: z.string().min(1).max(128).optional(),
+  // OPTIONAL filter to a single app's submissions by its slug (block_id). Also
+  // strictly within the caller's own rows.
+  blockId: z.string().min(1).max(128).optional(),
+});
+
+function clientIp(req: NextApiRequest): string {
+  const xff = req.headers['x-forwarded-for'];
+  const first = Array.isArray(xff) ? xff[0] : xff?.split(',')[0];
+  return (first ?? req.socket?.remoteAddress ?? 'unknown').trim();
+}
+
+/** Single query-param value (Next gives `string | string[] | undefined`). */
+function firstQuery(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
+}
+
+type SubmissionRow = {
+  id: string;
+  appBlockId: string | null;
+  slug: string;
+  version: string;
+  status: string;
+  rejectionReason: string | null;
+  approvalNotes: string | null;
+  deployState: string | null;
+  deployDetail: string | null;
+  deployUpdatedAt: Date | null;
+  submittedAt: Date;
+  reviewedAt: Date | null;
+  updatedAt: Date;
+};
+
+/**
+ * Shape one DB row into the safe, CLI-friendly response. NO internal-only
+ * columns (bundleKey/bundleSha256/forgejoCommitSha/manifest/file diffs/reviewer
+ * id), and never another user's data (rows are self-scoped at the query).
+ *
+ * `liveUrl` is the `https://<slug>.civit.ai/` surface, surfaced ONLY once the
+ * app is actually serving (deployState 'live', or a legacy null deployState on
+ * an approved row — same "assume live" rule as the /apps/my-submissions UI).
+ */
+function shapeRow(row: SubmissionRow, appsDomain: string) {
+  const isApproved = row.status === 'approved';
+  const isLive = isApproved && (row.deployState === 'live' || row.deployState == null);
+  return {
+    id: row.id,
+    blockId: row.slug, // the app slug == `block_id` that builds <slug>.civit.ai
+    appBlockId: row.appBlockId,
+    version: row.version,
+    status: row.status, // 'pending' | 'approved' | 'rejected' | 'withdrawn'
+    rejectionReason: row.rejectionReason,
+    approvalNotes: row.approvalNotes,
+    deployState: row.deployState, // null | 'building' | 'deploying' | 'live' | 'failed'
+    deployDetail: row.deployDetail,
+    deployUpdatedAt: row.deployUpdatedAt ? row.deployUpdatedAt.toISOString() : null,
+    submittedAt: row.submittedAt.toISOString(),
+    reviewedAt: row.reviewedAt ? row.reviewedAt.toISOString() : null,
+    updatedAt: row.updatedAt.toISOString(),
+    createdAt: row.submittedAt.toISOString(),
+    liveUrl: isLive ? `https://${row.slug}.${appsDomain}/` : null,
+  };
+}
+
+// Safe, self-scoped projection — submitter id is the filter, NOT a returned
+// column (so we never echo it back / leak it).
+const SELECT = {
+  id: true,
+  appBlockId: true,
+  slug: true,
+  version: true,
+  status: true,
+  rejectionReason: true,
+  approvalNotes: true,
+  deployState: true,
+  deployDetail: true,
+  deployUpdatedAt: true,
+  submittedAt: true,
+  reviewedAt: true,
+  updatedAt: true,
+} as const;
+
+export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+
+  // 1. Auth — Bearer API key → Civitai user via the existing API-key
+  // infrastructure (same helper as the public REST API / submit-version).
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.toLowerCase().startsWith('bearer ')) {
+    res.status(401).json({ message: 'Missing or malformed Bearer token' });
+    return;
+  }
+  const apiKey = authHeader.slice('bearer '.length).trim();
+  if (!apiKey) {
+    res.status(401).json({ message: 'Missing or malformed Bearer token' });
+    return;
+  }
+  const session = await getSessionFromBearerToken(apiKey);
+  if (!session?.user) {
+    res.status(401).json({ message: 'Invalid API key' });
+    return;
+  }
+  const user = session.user as SessionUser;
+
+  // 1b. Token-type gate — IDENTICAL to submit-version: accept a PERSONAL key
+  // always; accept an OAUTH-client-issued token ONLY if it carries the dedicated
+  // `TokenScope.AppBlocksSubmit` bit (opt-in, off-by-default, EXCLUDED from
+  // `TokenScope.Full`). So the SAME token that could submit can read its own
+  // submissions; an un-scoped OAuth token → 403 (before the flag/db/work, no
+  // leak). An OAuth token authorized for some unrelated scope must not be able
+  // to enumerate a mod's submissions.
+  if (session.subject?.type === 'oauth') {
+    if (!Flags.hasFlag(session.tokenScope, TokenScope.AppBlocksSubmit)) {
+      res.status(403).json({
+        message:
+          'App Blocks status requires a personal API key or an OAuth token with the App Blocks submit scope',
+      });
+      return;
+    }
+  }
+
+  // 2. Moderator gate — App Blocks is mod-only pre-GA (parity with
+  // submit-version + dev-token).
+  if (!user.isModerator || user.bannedAt) {
+    res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
+    return;
+  }
+
+  // 3. Feature flag for THIS user (mirrors submit-version + the prod mint).
+  // 503 (dark) when off.
+  if (!(await isAppBlocksEnabled({ user }))) {
+    res.status(503).json({ message: 'App Blocks is not enabled' });
+    return;
+  }
+
+  // 4. Validate query (optional single-item narrowing).
+  const parsed = querySchema.safeParse({
+    id: firstQuery(req.query.id),
+    blockId: firstQuery(req.query.blockId),
+  });
+  if (!parsed.success) {
+    res.status(422).json({ message: 'Invalid query', details: parsed.error.flatten() });
+    return;
+  }
+  const { id, blockId } = parsed.data;
+
+  // 5. Rate limit — per-user (the stable authenticated identity), client-IP
+  // fallback. Same atomic SET NX EX + INCR MULTI as submit-version/dev-token;
+  // fail CLOSED on a malformed limiter result or a Redis incident.
+  const rateSubject = user.id ? `u:${user.id}` : `ip:${clientIp(req)}`;
+  const rateKey = `${REDIS_SYS_KEYS.BLOCKS.SUBMISSIONS_RATE_LIMIT}:${rateSubject}` as const;
+  let count: number;
+  try {
+    const multiResult = await sysRedis
+      .multi()
+      .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
+      .incr(rateKey)
+      .exec();
+    count = Number(multiResult?.[1]);
+  } catch (err) {
+    req.log?.warn('blocks/submissions: rate limiter threw; failing closed', { rateSubject });
+    res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
+    return;
+  }
+  if (!Number.isFinite(count)) {
+    req.log?.warn('blocks/submissions: rate-limit counter malformed; failing closed', {
+      rateSubject,
+    });
+    res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
+    return;
+  }
+  // Self-heal a TTL-less key (re-arm only when the TTL is actually missing, so
+  // an active window is never extended) — same footgun guard as dev-token.
+  if (count > 1) {
+    const ttl = await sysRedis.ttl(rateKey).catch(() => -1);
+    if (ttl < 0) await sysRedis.expire(rateKey, RATE_LIMIT.windowSeconds).catch(() => {});
+  }
+  if (count > RATE_LIMIT.max) {
+    const retryAfter = await sysRedis.ttl(rateKey);
+    res.setHeader('Retry-After', String(Math.max(retryAfter, 1)));
+    res.status(429).json({
+      message: 'Rate limit exceeded',
+      retryAfterSeconds: retryAfter,
+      limit: RATE_LIMIT.max,
+      windowSeconds: RATE_LIMIT.windowSeconds,
+    });
+    return;
+  }
+
+  const { env } = await import('~/env/server');
+  const appsDomain = env.APPS_DOMAIN || APPS_DOMAIN_FALLBACK;
+
+  // The response carries the caller's own private review/deploy state — never
+  // let an intermediary cache it.
+  res.setHeader('Cache-Control', 'no-store');
+
+  // 6. SELF-SCOPED read. `submittedByUserId === user.id` is ALWAYS the first
+  // (and only ownership-deciding) clause — the request can NEVER widen it. The
+  // optional id/blockId only further narrow within the caller's own rows.
+  const where: {
+    submittedByUserId: number;
+    id?: string;
+    slug?: string;
+  } = { submittedByUserId: user.id };
+  if (id) where.id = id;
+  if (blockId) where.slug = blockId;
+
+  // Single-item lookup by id: a not-found / not-owned id → 404 (NOT 403), so the
+  // existence of another user's submission id isn't an ownership oracle — exactly
+  // like dev-token's not-owned → 404.
+  if (id) {
+    const row = (await dbRead.appBlockPublishRequest.findFirst({
+      where,
+      select: SELECT,
+    })) as SubmissionRow | null;
+    if (!row) {
+      res.status(404).json({ message: 'Submission not found' });
+      return;
+    }
+    res.status(200).json({ submission: shapeRow(row, appsDomain) });
+    return;
+  }
+
+  // List the caller's submissions, newest first.
+  const rows = (await dbRead.appBlockPublishRequest.findMany({
+    where,
+    orderBy: { submittedAt: 'desc' },
+    take: MAX_ROWS,
+    select: SELECT,
+  })) as SubmissionRow[];
+
+  res.status(200).json({ submissions: rows.map((r) => shapeRow(r, appsDomain)) });
+});

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1592,6 +1592,14 @@ export const REDIS_SYS_KEYS = {
      * local "live" harness.
      */
     DEV_TOKEN_RATE_LIMIT: 'system:blocks:dev-token-rate-limit',
+    /**
+     * Per-user (fallback per-IP) rate-limit counter for the token-auth
+     * self-scoped submission-status read (`/api/v1/blocks/submissions`). Same
+     * `SET NX EX` + `INCR` MULTI shape as `SUBMIT_RATE_LIMIT` (always created
+     * with its TTL), on `sysRedis`. Bounds a dev polling their own
+     * submission/review/deploy status from `civitai app status`.
+     */
+    SUBMISSIONS_RATE_LIMIT: 'system:blocks:submissions-rate-limit',
   },
 } as const;
 

--- a/src/tests/api/v1/blocks/submissions.test.ts
+++ b/src/tests/api/v1/blocks/submissions.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/submissions — the token-auth,
+ * SELF-SCOPED submission-status read that unblocks `civitai app status`.
+ *
+ * Asserts the security-sensitive invariants:
+ *   - auth: missing/invalid key → 401; un-scoped OAuth → 403; scoped OAuth
+ *     (AppBlocksSubmit) → allowed.
+ *   - gate: non-mod → 403; banned → 403; flag off → 503 (dark).
+ *   - SELF-SCOPING (the crux): the DB query is ALWAYS filtered to the caller's
+ *     `submittedByUserId`; user A cannot read user B's rows by listing OR by id.
+ *   - happy path: returns the caller's rows newest-first with the safe shape
+ *     (+ liveUrl only when serving), no-store header.
+ *   - single-item: `?id=` not-owned → 404 (no ownership oracle).
+ *   - rate-limit exceeded → 429; malformed limiter / redis incident → 503.
+ *   - 405 for non-GET.
+ */
+
+function createMocks({
+  method = 'GET',
+  headers = {},
+  query = {},
+}: {
+  method?: string;
+  headers?: Record<string, string>;
+  query?: Record<string, string>;
+}) {
+  const req = {
+    method,
+    headers,
+    query,
+    socket: { remoteAddress: '203.0.113.7' },
+    log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown = undefined;
+  const responseHeaders: Record<string, string> = {};
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(key: string, value: string) {
+      responseHeaders[key] = value;
+    },
+    end() {
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getHeaders: () => responseHeaders,
+  };
+  return { req, res };
+}
+
+const {
+  mockGetSession,
+  mockIsAppBlocksEnabled,
+  mockFindMany,
+  mockFindFirst,
+  mockSysRedis,
+  mockMultiIncr,
+} = vi.hoisted(() => {
+  const mockMultiIncr = {
+    value: 1,
+    malformedExec: false as unknown[] | null | false,
+    throwExec: false,
+  };
+  const multiFactory = () => ({
+    set: vi.fn().mockReturnThis(),
+    incr: vi.fn().mockReturnThis(),
+    exec: vi.fn().mockImplementation(async () => {
+      if (mockMultiIncr.throwExec) throw new Error('redis down');
+      return mockMultiIncr.malformedExec !== false
+        ? mockMultiIncr.malformedExec
+        : ['OK', mockMultiIncr.value];
+    }),
+  });
+  return {
+    mockGetSession: vi.fn(),
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockFindMany: vi.fn(),
+    mockFindFirst: vi.fn(),
+    mockSysRedis: {
+      multi: vi.fn(multiFactory),
+      ttl: vi.fn().mockResolvedValue(60),
+      expire: vi.fn().mockResolvedValue(1),
+    },
+    mockMultiIncr,
+  };
+});
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (fn: unknown) => fn }));
+vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGetSession }));
+vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlockPublishRequest: { findMany: mockFindMany, findFirst: mockFindFirst } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSysRedis,
+  REDIS_SYS_KEYS: { BLOCKS: { SUBMISSIONS_RATE_LIMIT: 'system:blocks:submissions-rate-limit' } },
+}));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+
+import handler from '~/pages/api/v1/blocks/submissions';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+const OWNER_ID = 7;
+
+// Personal-access (user-type) key + moderator.
+const MOD_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 42,
+  subject: { type: 'apiKey', id: 42 },
+  tokenScope: TokenScope.Full,
+};
+const NONMOD_SESSION = {
+  user: { id: 8, isModerator: false },
+  apiKeyId: 43,
+  subject: { type: 'apiKey', id: 43 },
+  tokenScope: TokenScope.Full,
+};
+// An OAuth-client token WITHOUT the AppBlocksSubmit bit (TokenScope.Full excludes it).
+const OAUTH_UNSCOPED_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 99,
+  subject: { type: 'oauth', id: 'client_abc' },
+  tokenScope: TokenScope.Full,
+};
+// An OAuth-client token that carries the dedicated AppBlocksSubmit bit (the
+// first-party civitai-cli client).
+const OAUTH_SCOPED_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 100,
+  subject: { type: 'oauth', id: 'civitai-cli' },
+  tokenScope: TokenScope.UserRead | TokenScope.AppBlocksSubmit,
+};
+
+function dbRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'pubreq_01',
+    appBlockId: 'apb_abc',
+    slug: 'my-page-app',
+    version: '0.1.0',
+    status: 'approved',
+    rejectionReason: null,
+    approvalNotes: null,
+    deployState: 'live',
+    deployDetail: null,
+    deployUpdatedAt: new Date('2026-06-22T00:00:00Z'),
+    submittedAt: new Date('2026-06-20T00:00:00Z'),
+    reviewedAt: new Date('2026-06-21T00:00:00Z'),
+    updatedAt: new Date('2026-06-22T00:00:00Z'),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMultiIncr.value = 1;
+  mockMultiIncr.malformedExec = false;
+  mockMultiIncr.throwExec = false;
+  mockSysRedis.ttl.mockResolvedValue(60);
+  mockSysRedis.expire.mockResolvedValue(1);
+  mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockFindMany.mockResolvedValue([dbRow()]);
+  mockFindFirst.mockResolvedValue(dbRow());
+});
+
+function authGet(query: Record<string, string> = {}) {
+  return createMocks({ headers: { authorization: 'Bearer personal-key' }, query });
+}
+
+describe('GET /api/v1/blocks/submissions', () => {
+  it('405 for non-GET', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it('401 when Authorization header is missing', async () => {
+    const { req, res } = createMocks({});
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('401 when the bearer key does not resolve to a session', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('403 when the OAuth token lacks the AppBlocksSubmit scope', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_UNSCOPED_SESSION);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect((res._getJSONData() as { message: string }).message).toContain('submit scope');
+    // Rejected before flag / db — no leak.
+    expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('allows a scoped OAuth token (AppBlocksSubmit) — same token that submitted can read', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_SCOPED_SESSION);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { submittedByUserId: OWNER_ID } })
+    );
+  });
+
+  it('403 when the resolved user is NOT a moderator', async () => {
+    mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('403 when the mod is banned', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: OWNER_ID, isModerator: true, bannedAt: new Date() },
+      apiKeyId: 44,
+      subject: { type: 'apiKey', id: 44 },
+    });
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('503 (dark) when the App Blocks flag is OFF for the user', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockIsAppBlocksEnabled.mockResolvedValueOnce(false);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('SELF-SCOPING: list query is ALWAYS filtered to the caller submittedByUserId', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    const arg = mockFindMany.mock.calls[0][0];
+    // The ownership-deciding clause is present and equal to the caller.
+    expect(arg.where.submittedByUserId).toBe(OWNER_ID);
+    // Newest-first, bounded.
+    expect(arg.orderBy).toEqual({ submittedAt: 'desc' });
+    expect(arg.take).toBe(100);
+  });
+
+  it('CROSS-USER ISOLATION: user A cannot read user B by listing — query filters on A only', async () => {
+    // User A authenticates. Even though the DB mock would happily return any
+    // rows, the handler must scope the WHERE to A's id, so B's rows are
+    // unreachable. We assert on the query the handler issues (the real DB
+    // enforces the filter).
+    const USER_A = { ...MOD_SESSION, user: { id: 101, isModerator: true } };
+    mockGetSession.mockResolvedValueOnce(USER_A);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { submittedByUserId: 101 } })
+    );
+    // No way for A to pass a userId that widens the scope (no such param exists).
+  });
+
+  it('CROSS-USER ISOLATION: ?id= for a not-owned submission → 404 (no ownership oracle)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    // Self-scoped findFirst finds nothing because the id belongs to user B.
+    mockFindFirst.mockResolvedValueOnce(null);
+    const { req, res } = authGet({ id: 'pubreq_owned_by_B' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(404);
+    // The findFirst query must still carry the self-scope clause.
+    expect(mockFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { submittedByUserId: OWNER_ID, id: 'pubreq_owned_by_B' },
+      })
+    );
+  });
+
+  it('happy path: lists the caller rows with the safe shape + no-store header', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeaders()['Cache-Control']).toBe('no-store');
+    const out = res._getJSONData() as { submissions: Array<Record<string, unknown>> };
+    expect(Array.isArray(out.submissions)).toBe(true);
+    const s = out.submissions[0];
+    expect(s).toEqual({
+      id: 'pubreq_01',
+      blockId: 'my-page-app',
+      appBlockId: 'apb_abc',
+      version: '0.1.0',
+      status: 'approved',
+      rejectionReason: null,
+      approvalNotes: null,
+      deployState: 'live',
+      deployDetail: null,
+      deployUpdatedAt: '2026-06-22T00:00:00.000Z',
+      submittedAt: '2026-06-20T00:00:00.000Z',
+      reviewedAt: '2026-06-21T00:00:00.000Z',
+      updatedAt: '2026-06-22T00:00:00.000Z',
+      createdAt: '2026-06-20T00:00:00.000Z',
+      liveUrl: 'https://my-page-app.civit.ai/',
+    });
+    // No internal-only columns leaked.
+    expect(s).not.toHaveProperty('bundleKey');
+    expect(s).not.toHaveProperty('forgejoCommitSha');
+    expect(s).not.toHaveProperty('submittedByUserId');
+    expect(s).not.toHaveProperty('manifest');
+  });
+
+  it('liveUrl is null when the row is approved but not yet serving (deployState building)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockFindMany.mockResolvedValueOnce([dbRow({ status: 'approved', deployState: 'building' })]);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const out = res._getJSONData() as { submissions: Array<{ liveUrl: string | null }> };
+    expect(out.submissions[0].liveUrl).toBeNull();
+  });
+
+  it('liveUrl is null for a pending (not-approved) submission', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockFindMany.mockResolvedValueOnce([
+      dbRow({ status: 'pending', deployState: null, reviewedAt: null }),
+    ]);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    const out = res._getJSONData() as { submissions: Array<{ liveUrl: string | null }> };
+    expect(out.submissions[0].liveUrl).toBeNull();
+  });
+
+  it('single-item by ?id= returns { submission } with the safe shape', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authGet({ id: 'pubreq_01' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const out = res._getJSONData() as { submission: { id: string; blockId: string } };
+    expect(out.submission.id).toBe('pubreq_01');
+    expect(out.submission.blockId).toBe('my-page-app');
+  });
+
+  it('?blockId= narrows the self-scoped list to one app (slug filter)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authGet({ blockId: 'my-page-app' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { submittedByUserId: OWNER_ID, slug: 'my-page-app' },
+      })
+    );
+  });
+
+  it('429 when the per-user rate limit is exceeded', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 61; // > RATE_LIMIT.max (60)
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeaders()['Retry-After']).toBeDefined();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('503 (fail closed) when the rate-limit exec() is malformed', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.malformedExec = null;
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('503 (fail closed) when the rate-limit exec() THROWS (redis incident)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.throwExec = true;
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('self-heals a TTL-less rate-limit key (re-arms expiry when ttl < 0)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 2; // not first hit → self-heal branch runs
+    mockSysRedis.ttl.mockResolvedValueOnce(-1); // key exists but lost its TTL
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSysRedis.expire).toHaveBeenCalledWith(
+      'system:blocks:submissions-rate-limit:u:7',
+      60
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds **`GET /api/v1/blocks/submissions`** — a token-authenticated, **hard self-scoped** read of the caller's own App-Block publish (submission) requests: review status + the Phase-2 deploy lifecycle. This is the server-side surface that unblocks a future **`civitai app status`** CLI command.

Today that data lives **only** behind `blocks.listMyPublishRequests`, a `moderatorProcedure` reachable from a logged-in mod browser but **not** from a headless CLI carrying only a bearer token. This route returns the same useful fields as a CLI-friendly REST GET, filtered strictly to the caller.

## Route(s) + shape

- **`GET /api/v1/blocks/submissions`** — list the caller's submissions, newest first, capped at 100.
- **`GET /api/v1/blocks/submissions?id=<pubreq_id>`** — single submission (returns `{ submission }`); a not-found / not-owned id → **404** (no ownership oracle).
- **`GET /api/v1/blocks/submissions?blockId=<slug>`** — narrow the self-scoped list to one app.

List response:
```json
{
  "submissions": [
    {
      "id": "pubreq_01",
      "blockId": "my-page-app",
      "appBlockId": "apb_abc",
      "version": "0.1.0",
      "status": "approved",
      "rejectionReason": null,
      "approvalNotes": null,
      "deployState": "live",
      "deployDetail": null,
      "deployUpdatedAt": "2026-06-22T00:00:00.000Z",
      "submittedAt": "2026-06-20T00:00:00.000Z",
      "reviewedAt": "2026-06-21T00:00:00.000Z",
      "updatedAt": "2026-06-22T00:00:00.000Z",
      "createdAt": "2026-06-20T00:00:00.000Z",
      "liveUrl": "https://my-page-app.civit.ai/"
    }
  ]
}
```
`?id=` returns `{ "submission": { …same shape… } }`.

## Auth / gate it mirrors

Mirrors **`POST /api/v1/blocks/submit-version`** exactly, so the **same token that submitted can read its own status**:
- `Authorization: Bearer <civitai API key>` resolved via `getSessionFromBearerToken` (the helper backing all `/api/v1/*` REST auth) — no new key system.
- A **personal** key always passes the token-type gate. An **OAuth-client-issued** token passes **only** if it carries the dedicated `TokenScope.AppBlocksSubmit` bit (opt-in, off-by-default, excluded from `TokenScope.Full`; the first-party `civitai-cli` client is provisioned with it). Un-scoped OAuth → **403**.
- **Mod-only pre-GA**: `isAppBlocksEnabled({ user })` + `user.isModerator` + not-banned — identical posture to submit-version / dev-token. Relax in lockstep at GA, not unilaterally.
- `Cache-Control: no-store`, **405** on non-GET, 8kb body guard, per-user **fail-closed** rate limit (same `SET NX EX` + `INCR` MULTI as dev-token; 60/min).
- zod query validation; status codes **401/403/404/422/429** mirroring the sibling endpoints.

## Self-scoping guarantee (the security crux)

The Prisma `where` is **always** `{ submittedByUserId: user.id }` — the only ownership-deciding clause, and **no request input can widen it**. The optional `id` / `blockId` query params only **narrow** within the caller's own rows. A not-owned `?id=` resolves to **404** (not 403), so another user's submission id is never an ownership oracle (exactly like dev-token). The submitter id is the *filter*, never a returned column.

Proven by the test **`CROSS-USER ISOLATION: ?id= for a not-owned submission → 404`** (findFirst self-scoped, returns null → 404) and **`CROSS-USER ISOLATION: user A cannot read user B by listing`** (asserts the issued query filters on A's id only). The submitter field filtered on is **`AppBlockPublishRequest.submittedByUserId`**.

## Fields returned

`id`, `blockId` (the app slug = `block_id` that builds `<slug>.civit.ai`), `appBlockId`, `version`, `status` (`pending`/`approved`/`rejected`/`withdrawn`), `rejectionReason`, `approvalNotes`, `deployState` (`building`/`deploying`/`live`/`failed`/null), `deployDetail`, `deployUpdatedAt`, `submittedAt`, `reviewedAt`, `updatedAt`, `createdAt`, and `liveUrl` (`https://<slug>.civit.ai/`, surfaced only when actually serving — approved + `deployState` `live`/null, the same "assume live" rule as the `/apps/my-submissions` UI). **No** internal-only columns (bundleKey/sha/forgejoCommitSha/manifest/file-diffs/reviewer id) and never another user's data.

## Tests

New handler tests `src/tests/api/v1/blocks/submissions.test.ts` (mirroring `dev-token.test.ts` style): **20 tests, all passing.**
- `npx vitest run --project unit src/tests/api/v1/blocks/submissions.test.ts` → **20/20 passed**.
- `tsc --noEmit` → **zero** errors in the changed files (`blocks/submissions.ts`, `submissions.test.ts`, `redis/client.ts`). The repo has a large pre-existing baseline of implicit-any errors elsewhere on `main`, unrelated to this change.

Covers: 405 non-GET; missing/invalid key → 401; un-scoped OAuth → 403; scoped OAuth (AppBlocksSubmit) allowed; non-mod → 403; banned → 403; flag off → 503 (dark); **cross-user isolation (A can't read B by listing or by id)**; happy-path shape + `no-store`; `liveUrl` gating (building/pending → null); `?id=` single-item; `?blockId=` narrowing; rate-limit → 429; malformed limiter / redis incident → 503 (fail closed); TTL-less key self-heal.

## ⚠️ NEEDS SECURITY REVIEW before the `appBlocks` flag widens

This is a **new data-exposure endpoint** on production. It must NEVER return another user's submissions. The self-scoping is enforced in the DB query (`submittedByUserId === caller`) with no request-controllable userId, and a not-owned `?id=` → 404. Please review the auth/scope gate + self-scoping before App Blocks goes GA (same posture as the recently-reviewed dev-token endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)