### PR TITLE
perf(audit): close residual Latin-\w-run ReDoS — bound composed-noun gap + cap audit prompt length

### DIFF
--- a/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
+++ b/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
@@ -112,10 +112,13 @@ function refGetTags(prompt: string): string[] {
 // --- Reference (pre-optimization) young.nouns matching ---
 // Mirrors audit.ts: words.young.nouns = checkable(youngWords.nouns.concat(composedNouns),
 // { pluralize: true }). leet defaults to true. The composed nouns interleave every
-// adjective with every partialNoun via the body `adj·([\s|\w]*|[^\w]+)·noun` — the
-// highest-risk class for alternation interaction inside the gate.
+// adjective with every partialNoun via the body `adj·([\s|\w]{0,40}|[^\w]{1,40})·noun`
+// — the highest-risk class for alternation interaction. The gap quantifiers are
+// BOUNDED (must match audit.ts's composedNouns exactly so this stays a faithful
+// old-vs-new *boundary* comparison): the unbounded original was O(n^2) on a long
+// Latin `\w` run (the residual ReDoS lever closed alongside this oracle).
 const youngComposedNouns = youngWords.partialNouns.flatMap((word) =>
-  youngWords.adjectives.map((adj) => adj + '([\\s|\\w]*|[^\\w]+)' + word)
+  youngWords.adjectives.map((adj) => adj + '([\\s|\\w]{0,40}|[^\\w]{1,40})' + word)
 );
 const youngNounList = youngWords.nouns.concat(youngComposedNouns);
 const youngNounRefRegexes = youngNounList.map((w) => refPrepareWordRegex(w, true, true));

--- a/src/utils/metadata/__tests__/audit-redos.test.ts
+++ b/src/utils/metadata/__tests__/audit-redos.test.ts
@@ -5,6 +5,7 @@ import {
   includesPoi,
   includesMinor,
   getTagsFromPrompt,
+  MAX_AUDIT_PROMPT_LENGTH,
 } from '~/utils/metadata/audit';
 
 /**
@@ -138,6 +139,70 @@ describe('audit ReDoS regression (no catastrophic backtracking)', () => {
         MAX_MS
       );
     }
+  });
+
+  // Latin `\w`-run quadratic — the residual ReDoS lever the #2725 audit found,
+  // SEPARATE from the #2722 CJK class. The composed young-noun bodies were
+  // `young([\s|\w]*|[^\w]+)\w*girl+\w*`: the unbounded gap sat adjacent to the
+  // partial-noun's trailing `\w*`, both ranging over the SAME long Latin `\w` run
+  // → O(n^2). `"young " + "a"*N` drove `words.young.nouns.inPrompt` to ~2.8s at
+  // N=24000 (seconds of synchronous main-thread CPU = user-triggerable DoS). Two
+  // defenses, tested independently:
+  //   (a) the per-pattern gap is now bounded ({0,40}/{1,40}) → linear regardless
+  //       of length. Exercised via `includesMinor`, which is NOT length-capped.
+  //   (b) `auditPrompt` truncates to MAX_AUDIT_PROMPT_LENGTH first → blanket bound.
+  const LATIN_RUN_MAX_MS = 100;
+  describe('Latin \\w-run composed-noun quadratic (residual ReDoS lever)', () => {
+    it('includesMinor is fast on a long Latin \\w run after the adjective (quantifier bound)', () => {
+      // Goes straight to the bounded young-noun regexes (no length cap on this path),
+      // so this proves the {0,40} gap bound — not just the cap — defuses the O(n^2).
+      const input = 'young ' + 'a'.repeat(24000);
+      const ms = timeCall(() => includesMinor(input));
+      expect(
+        ms,
+        `includesMinor too slow on Latin \\w-run (${ms.toFixed(1)}ms — was ~2800ms unbounded)`
+      ).toBeLessThan(LATIN_RUN_MAX_MS);
+      // The bound preserves matching: realistic close-proximity phrasings still flag.
+      expect(includesMinor('young girl')).toBeTruthy();
+      expect(includesMinor('young pretty little girl')).toBeTruthy();
+    });
+
+    it('includesMinor is fast across several adjective+long-run shapes', () => {
+      for (const adj of ['young', 'little', 'small', 'teeny', 'loli']) {
+        for (const sep of ['a', ' a', '.-_']) {
+          const input = adj + ' ' + sep.repeat(8000);
+          const ms = timeCall(() => includesMinor(input));
+          expect(
+            ms,
+            `includesMinor too slow on "${adj}"+run("${sep}") (${ms.toFixed(1)}ms)`
+          ).toBeLessThan(LATIN_RUN_MAX_MS);
+        }
+      }
+    });
+
+    it('auditPrompt is fast on a long Latin \\w run (quantifier bound + length cap)', () => {
+      const input = 'young ' + 'a'.repeat(60000); // > MAX_AUDIT_PROMPT_LENGTH
+      const ms = timeCall(() => auditPrompt(input));
+      expect(
+        ms,
+        `auditPrompt too slow on Latin \\w-run (${ms.toFixed(1)}ms)`
+      ).toBeLessThan(LATIN_RUN_MAX_MS);
+    });
+
+    it('auditPrompt truncates input beyond MAX_AUDIT_PROMPT_LENGTH (length cap defense-in-depth)', () => {
+      // A blocked word placed strictly beyond the cap is not scanned → not flagged.
+      // (Real prompts are <=10k chars; this asserts the documented truncation contract
+      // that blanket-bounds worst-case audit cost.)
+      const blocked = '9 year old girl';
+      const within = auditPrompt(blocked);
+      expect(within.success, 'sanity: the marker phrase is blocked within the cap').toBe(false);
+      const padded = 'x'.repeat(MAX_AUDIT_PROMPT_LENGTH) + ' ' + blocked;
+      const beyond = auditPrompt(padded);
+      expect(
+        beyond.success,
+        'a banned phrase placed entirely beyond the cap is truncated away (not scanned)'
+      ).toBe(true);
+    });
   });
 
   it('the whole adversarial battery audits in well under a true-hang timeout', () => {

--- a/src/utils/metadata/audit.ts
+++ b/src/utils/metadata/audit.ts
@@ -64,6 +64,22 @@ export interface EnrichedAuditResult {
   success: boolean;
 }
 
+// Defense-in-depth length cap applied before any audit regex runs. Every
+// sub-check scans the prompt with hundreds of regexes; the worst-case cost of a
+// pathological pattern grows with prompt length (the "504 wave" DoS was a regex
+// backtracking on a long adversarial prompt). The longest prompt any schema
+// accepts is 10000 chars (user-restriction); generation prompts are capped at
+// 1500. Truncating beyond this generous ceiling blanket-bounds the cost of ANY
+// audit regex — this incident's class AND future patterns — without affecting
+// real prompts. Complements the per-pattern quantifier bounds (e.g. the composed
+// young-noun gap below): the bounds keep individual regexes linear, this keeps
+// the whole pipeline's input bounded.
+export const MAX_AUDIT_PROMPT_LENGTH = 20000;
+const capAuditLength = <T extends string | undefined>(s: T): T =>
+  typeof s === 'string' && s.length > MAX_AUDIT_PROMPT_LENGTH
+    ? (s.slice(0, MAX_AUDIT_PROMPT_LENGTH) as T)
+    : s;
+
 /**
  * Enriched version of auditPrompt that returns structured trigger data alongside blockedFor.
  * Used server-side for UserBan records, moderator UI, and the false-positive allowlist system.
@@ -74,6 +90,8 @@ export const auditPromptEnriched = (
   checkProfanity?: boolean
 ): EnrichedAuditResult => {
   if (!prompt.trim().length) return { blockedFor: [], triggers: [], success: true };
+  prompt = capAuditLength(prompt);
+  negativePrompt = capAuditLength(negativePrompt);
 
   // Per-sub-check timing instrumentation. Always-on but threshold-gated: below
   // AUDIT_SLOW_LOG_MS it costs only a handful of `performance.now()` deltas and
@@ -642,8 +660,20 @@ function inPromptEdit(prompt: string, { regex }: Checkable) {
   return wrapped;
 }
 
+// The gap between a young-adjective and a partial-noun. BOUNDED quantifiers
+// ({0,40}/{1,40}) instead of the original unbounded `([\s|\w]*|[^\w]+)`: the
+// partial nouns end in `\w*` (e.g. `\w*girl+\w*`), so an unbounded gap sat
+// adjacent to another unbounded `\w*` over the SAME input run → O(n^2)
+// catastrophic backtracking on a long Latin `\w` run (`"young " + "a"*24000`
+// took ~2.8s of synchronous main-thread CPU through `words.young.nouns` — a
+// user-triggerable DoS of the same class as the #2722 CJK ReDoS, surfaced by the
+// #2725 audit). Any FINITE bound collapses this to linear; 40 chars is a generous
+// adjective→noun proximity window (~7 words) that preserves realistic phrasings
+// ("young pretty little asian girl") — verified equal to the old form on the
+// equivalence-oracle corpus, whose `youngComposedNouns` reference mirrors this
+// exact body.
 const composedNouns = youngWords.partialNouns.flatMap((word) => {
-  return youngWords.adjectives.map((adj) => adj + '([\\s|\\w]*|[^\\w]+)' + word);
+  return youngWords.adjectives.map((adj) => adj + '([\\s|\\w]{0,40}|[^\\w]{1,40})' + word);
 });
 const words = {
   nsfw: checkable(nsfwWords),


### PR DESCRIPTION
## What

Closes the **residual quadratic ReDoS surface** the #2725 audit found in `src/utils/metadata/audit.ts` — a class SEPARATE from the #2722 CJK fix.

The composed young-noun bodies were `young([\s|\w]*|[^\w]+)\w*girl+\w*`. The **unbounded gap quantifier** sat adjacent to the partial-noun's trailing `\w*`, both ranging over the SAME long Latin `\w` run → **O(n²)** catastrophic backtracking. `"young " + "a"×24000` drove `words.young.nouns.inPrompt` to **~2.8s** of synchronous main-thread CPU — a **user-triggerable DoS** of the same class that caused the multi-day api-primary "504 waves" (event-loop pin → readiness probe times out → pod sheds traffic → wave). The production incident was CJK (#2722); this is the still-open Latin-run variant.

## Fix — two complementary defenses

**(a) Prompt-length cap (`MAX_AUDIT_PROMPT_LENGTH = 20000`)** — `auditPrompt`/`auditPromptEnriched` truncate `prompt` + `negativePrompt` *before any regex runs*. A blanket bound on the cost of **any** audit regex (this incident's class **and** future patterns — defense-in-depth). 20000 is 2× the largest schema max (user-restriction `10000`; generation prompts are `1500`), so no real prompt is affected.

**(b) Bound the composed-noun gap** → `([\s|\w]{0,40}|[^\w]{1,40})`. Any *finite* bound collapses the O(n²) to linear; 40 chars is a generous adjective→noun proximity window (~7 words) that preserves realistic phrasings (`"young pretty little asian girl"`). This makes `includesMinor` linear regardless of length, including on the directly-called (uncapped) scanner path.

## Correctness

- The **`audit-matching-equivalence` oracle stays green** — its `youngComposedNouns` reference is updated to the **same bounded body**, so it remains a faithful old-vs-new *boundary* comparison (not a body change). All corpus/random-batch gaps are < 40 chars, so the bound is match-preserving on the oracle.
- Measured: the single composed regex goes **236ms → 1ms** on the PoC; full `includesMinor` path **<100ms** (was ~2800ms). Legit positives (`young girl`, `young pretty little girl`, `young-girl`, `younggirl`) still flag.

## Tests

New perf-regression block in `audit-redos.test.ts` asserts **<100ms** on the Latin-`\w`-run shape via:
- `includesMinor` (proves the **quantifier bound** — this path is NOT length-capped),
- `auditPrompt` (cap + bound together), and
- a **truncation-contract** test (a banned phrase placed strictly beyond the cap is truncated away).

All **56 audit tests pass** (`audit`, `audit-redos`, `audit-matching-equivalence`, `audit-cjk-redos`, `audit-gate-perf`).

## Scope note

The length cap is applied at the `auditPrompt` entry (the public moderation path the DoS came through). Directly-called scanners (`includesNsfw`/`includesMinor`/`getTagsFromPrompt`) are not separately capped — they rely on (b)'s linearity + realistic prompt sizes. The other `[\s|\w]*`-bearing nsfw-list bodies (e.g. `without [\s|\w]* clothes`) are covered by the (a) blanket cap within `auditPrompt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)