### PR TITLE
fix(uploads): track upload size in bytes to stop ModelFile.sizeKB MB mis-scale

### DIFF
--- a/src/store/s3-upload.store.ts
+++ b/src/store/s3-upload.store.ts
@@ -4,7 +4,6 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
 import type { UploadType } from '~/server/common/enums';
-import { bytesToKB } from '~/utils/number-helpers';
 
 import { useCatchNavigationStore } from './catch-navigation.store';
 
@@ -208,7 +207,14 @@ export const useS3UploadStore = create<StoreProps>()(
           const trackedFile = {
             ...pendingTrackedFile,
             file,
-            size: file.size ? bytesToKB(file.size) : 0,
+            // `size` is tracked in BYTES throughout the store: progress math
+            // (uploaded/size) and updateProgress() both use raw bytes, and every
+            // consumer of the upload-result `size` (FilesProvider, MultiFileInputUpload)
+            // applies bytesToKB() itself. Initializing in KB here let a stale KB value
+            // leak into the upload result when progress never overwrote it before
+            // completion, causing the consumer to divide by 1024 a second time and
+            // store ModelFile.sizeKB as MB (~1024x too small). Keep it bytes.
+            size: file.size ?? 0,
             uuid,
             meta,
             name: file.name,


### PR DESCRIPTION
## Summary

`ModelFile.sizeKB` was being stored as **MB instead of KB** (~1024x too small) for a class of uploads — e.g. a real ~132 MB LoRA recorded as `132.24` "KB". ClickUp [868k41k2f](https://app.clickup.com/t/868k41k2f).

## Root cause

The S3 upload store (`src/store/s3-upload.store.ts`) initialized `item.size` in **KB** via `bytesToKB(file.size)`, but the rest of the store treats `size` as raw **bytes**:

- progress math `uploaded / size` (uploaded is bytes),
- `updateProgress()` writes the byte value,
- and every consumer of the upload-result `size` (`FilesProvider.tsx:544`, `FilesProvider.tsx:115`, `MultiFileInputUpload.tsx:86`) applies `bytesToKB()` itself.

Normally a progress frame overwrites `item.size` with bytes before completion, so the consumer's `bytesToKB(size)` lands on bytes and is correct. When no progress frame overwrote it before completion, the stale **KB** value flowed through `preparePayload` into the upload result, and the consumer divided by 1024 a **second** time → `sizeKB` stored as MB.

Latent since 2023; volume grew with the B2 routing rollout and the recent upload-perf refactors (`241f92c4b` parallelize, `ce1ea63dd` coalesce progress) that change progress-frame timing.

## Fix

Initialize `size` in bytes (`file.size ?? 0`) so the value is unit-consistent end to end and each consumer converts exactly once. Removes the now-unused `bytesToKB` import; added a comment documenting the byte-unit contract. The DB column stays KB — the single `bytesToKB()` at the consumer now always receives bytes.

UI check: no component renders the store's byte `size` directly (UploadTracker shows progress/speed/time; file list shows `versionFile.sizeKB`). The rehydration path `FilesProvider:115` (`bytesToKB(item.size)`) is now correct too.

## Affected rows (prod replica, 2026-06-23; scope confirmed via manual review)

- Mis-scaled rows are on the **manual-upload path on Backblaze B2** (trained-model auto-publish path via `selectedEpochUrl` is clean). Signature: `url LIKE '%backblazeb2%'` + `metadata ? 'isRequired'` + NOT `metadata ? 'selectedEpochUrl'`.
- The corrupted set is LoRA `.safetensors` files with `sizeKB < 1024` (~98 since the perf changes ramped, first appearing earlier at low volume). Other small-`sizeKB` populations (TextualInversion embeddings, `.zip`/`.bin` misc files) are legitimately tiny and must not be touched.

## Backfill (manual — not in this PR)

Review the SELECT, then run the UPDATE with write access (per the repo's manual-migration policy):

```sql
-- Review
SELECT mf.id, mf.name, mf."sizeKB", mf.url, mf."createdAt"
FROM "ModelFile" mf
JOIN "ModelVersion" mv ON mv.id = mf."modelVersionId"
JOIN "Model" m ON m.id = mv."modelId"
WHERE mf.type = 'Model' AND mf.name ILIKE '%.safetensors'
  AND m.type = 'LORA'
  AND mf."sizeKB" > 0 AND mf."sizeKB" < 1024
  AND mf.url LIKE '%backblazeb2%'
  AND (mf.metadata ? 'isRequired') AND NOT (mf.metadata ? 'selectedEpochUrl');

-- Correct (after review)
UPDATE "ModelFile" mf
SET "sizeKB" = mf."sizeKB" * 1024
FROM "ModelVersion" mv, "Model" m
WHERE mv.id = mf."modelVersionId" AND m.id = mv."modelId"
  AND mf.type = 'Model' AND mf.name ILIKE '%.safetensors'
  AND m.type = 'LORA'
  AND mf."sizeKB" > 0 AND mf."sizeKB" < 1024
  AND mf.url LIKE '%backblazeb2%'
  AND (mf.metadata ? 'isRequired') AND NOT (mf.metadata ? 'selectedEpochUrl');
```

## Downstream impact (corrected going forward)

- `vault.service.ts` sums `sizeKB` → was undercounting storage quota.
- `wildcard-set-provisioning.service.ts` size guard `sizeKB * 1024` → was 1024x too small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)