### PR TITLE
feat(app-blocks): dev-token accepts AppBlocksSubmit-scoped OAuth (unblock dev:live via `civitai login`)

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -42,13 +42,28 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  * The "local-manifest" mode (no approved row) is the higher-risk Phase 4 work
  * and is NOT implemented.
  *
- * ## Auth — PERSONAL API key only (Bearer), resolved via the same
- * `getSessionFromBearerToken` path the `/api/v1/*` REST routes use.
- *  - Personal key (not cookie) → there is NO ambient credential to ride, so
+ * ## Auth — Bearer, resolved via the same `getSessionFromBearerToken` path the
+ * `/api/v1/*` REST routes use. TWO credential shapes accepted:
+ *  - PERSONAL API key (not cookie) → there is NO ambient credential to ride, so
  *    CSRF is moot and we accept the dev's localhost origin WITHOUT relaxing the
  *    prod mint's CORS. (scope doc §4.2 — the deliberately-different dev path.)
- *  - OAuth-client-issued tokens are REJECTED here: the dev path is personal-key
- *    only; an OAuth dev-token would need its own scope + sign-off (out of scope).
+ *  - OAuth-client-issued token → accepted ONLY if it carries the dedicated
+ *    `TokenScope.AppBlocksSubmit` bit. This MIRRORS EXACTLY the OAuth gate the
+ *    token-authenticated submit route (`api/v1/blocks/submit-version`) applies
+ *    (`session.subject?.type === 'oauth'` ⇒ require `AppBlocksSubmit`). It
+ *    unblocks `civitai login` (device-flow OAuth) for the dev:live harness:
+ *    `oauthClient.create` is open to any logged-in user, so an arbitrary OAuth
+ *    token a mod authorized for some unrelated scope must NOT mint a dev token
+ *    (consent escalation). `AppBlocksSubmit` is opt-in, off-by-default, and
+ *    EXCLUDED from `TokenScope.Full`, so only a client that explicitly lists it
+ *    in `allowedScopes` AND a user who consented can reach here (the first-party
+ *    `civitai-cli` client is provisioned with it). An OAuth token WITHOUT the
+ *    bit → 403 with an actionable message.
+ *  - The SPEND scope is UNIFORM across both shapes: `ai:write:budgeted` survives
+ *    the clamp ONLY if the bearer credential carries `AIServicesWrite` (the
+ *    personal-key ceiling at step 7f). An OAuth token whose `civitai-cli` consent
+ *    lacks `AIServicesWrite` therefore mints a read/estimate dev token with NO
+ *    spend scope — `AppBlocksSubmit` is NOT special-cased to grant spend.
  *
  * ## Gates / hard caps (every one server-side + fail-closed — scope doc §4.1)
  *  - MOD-ONLY (`isAppBlocksEnabled({ user })` + `user.isModerator`) — match the
@@ -172,13 +187,39 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   }
   const user = session.user as SessionUser;
 
-  // 1b. PERSONAL key only. `getSessionFromBearerToken` sets subject.type ===
-  // 'oauth' for OAuth-client-issued tokens; the dev path accepts only a
-  // user-type personal key (an OAuth dev-token would need its own scope +
-  // sign-off — out of scope for this PR).
+  // 1b. Token-type gate — accept EITHER a personal API key OR a scoped OAuth
+  // token, MIRRORING EXACTLY the submit-version route's OAuth gate
+  // (src/pages/api/v1/blocks/submit-version.ts:134-142). `getSessionFromBearerToken`
+  // sets `subject = { type: 'oauth', id: clientId }` IFF the resolved `ApiKey`
+  // row has a non-null `clientId` (minted for an OAuth client a user authorized),
+  // and `{ type: 'apiKey', id }` for a user-type personal-access key.
+  //
+  //  - PERSONAL key (`subject.type !== 'oauth'`): pass unchanged — the dev's own
+  //    key mints as before. The mod + flag + ownership gates still apply.
+  //
+  //  - OAUTH token (`subject.type === 'oauth'`): pass ONLY if the token carries
+  //    the dedicated `TokenScope.AppBlocksSubmit` bit. `oauthClient.create` is an
+  //    open `protectedProcedure`, so an arbitrary OAuth token a mod authorized
+  //    for an unrelated scope must NOT mint a dev token (consent escalation).
+  //    `AppBlocksSubmit` is opt-in, off-by-default, and EXCLUDED from
+  //    `TokenScope.Full`, so only a client that lists it in `allowedScopes` and a
+  //    user who consented can reach here (the first-party `civitai-cli` client is
+  //    provisioned with it). This unblocks `civitai login` for the dev:live
+  //    harness. Spend is gated SEPARATELY by the AIServicesWrite ceiling (step
+  //    7f) — `AppBlocksSubmit` grants the right to MINT, never the right to SPEND.
+  //
+  // The mod + not-banned gate (step 2) applies to BOTH paths. Ordered after auth
+  // (401) and before the mod gate so an un-scoped OAuth token gets 403, not a leak.
   if (session.subject?.type === 'oauth') {
-    res.status(403).json({ message: 'dev-token requires a personal API key' });
-    return;
+    if (!Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AppBlocksSubmit)) {
+      res.status(403).json({
+        message:
+          'dev-token needs a personal API key (full scope, create at ' +
+          'civitai.com/user/account) OR an OAuth login whose token carries the ' +
+          'App Blocks submit scope; real Buzz spend additionally needs AI Services scope',
+      });
+      return;
+    }
   }
 
   // 2. MOD gate — App Blocks is mod-only pre-GA. The runtime spend belt already
@@ -323,14 +364,20 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     granted = granted.filter((s: string) => want.has(s));
   }
 
-  //   f) PERSONAL-KEY CEILING. The minted block token's spend capability must be
-  //      a SUBSET of what the dev's own personal API key authorizes — a key
-  //      lacking AIServicesWrite (e.g. a read-only key) cannot mint a
-  //      Buzz-spending dev token. Mirrors the /api/v1/me tokenScope posture
-  //      (me.ts:24). Read/catalog/storage scopes are unaffected; only the
-  //      budgeted-spend scope is gated. Keys default to Full, so this is a
-  //      no-op for a normal key and a tightening only for a deliberately-narrow
-  //      one. Strip (no error), consistent with every other clamp step.
+  //   f) BEARER-CREDENTIAL SPEND CEILING (UNIFORM across personal key AND OAuth).
+  //      The minted block token's spend capability must be a SUBSET of what the
+  //      bearer credential itself authorizes — a credential lacking AIServicesWrite
+  //      (a read-only personal key, OR an OAuth consent that didn't grant
+  //      AIServicesWrite) cannot mint a Buzz-spending dev token. `session.tokenScope`
+  //      is the resolved bitmask for BOTH shapes (personal-key ApiKey.tokenScope,
+  //      or the OAuth-issued token's scope). Mirrors the /api/v1/me tokenScope
+  //      posture (me.ts:24). Read/catalog/storage scopes are unaffected; only the
+  //      budgeted-spend scope is gated. This is DELIBERATELY uniform —
+  //      `AppBlocksSubmit` is the MINT gate (step 1b), `AIServicesWrite` is the
+  //      SPEND gate, and the two are never conflated. Personal keys default to
+  //      Full (carries AIServicesWrite), so this is a no-op for a normal key and a
+  //      tightening only for a narrow key or an OAuth consent without AI Services.
+  //      Strip (no error), consistent with every other clamp step.
   const keyCanSpend = Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AIServicesWrite);
   if (!keyCanSpend) {
     granted = granted.filter((s: string) => s !== 'ai:write:budgeted');

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -133,11 +133,29 @@ const NONMOD_SESSION = {
   subject: { type: 'apiKey', id: 43 },
   tokenScope: TokenScope.Full,
 };
+// OAuth token WITHOUT AppBlocksSubmit. `TokenScope.Full` deliberately EXCLUDES
+// AppBlocksSubmit (bit 25), so a "full" OAuth consent still fails the mint gate.
 const OAUTH_MOD_SESSION = {
   user: { id: OWNER_ID, isModerator: true },
   apiKeyId: 99,
   subject: { type: 'oauth', id: 'client_abc' },
   tokenScope: TokenScope.Full,
+};
+// OAuth token WITH AppBlocksSubmit + AIServicesWrite (the civitai-cli client
+// provisioned with both): mints AND keeps the budgeted-spend scope.
+const OAUTH_SUBMIT_SPEND_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 100,
+  subject: { type: 'oauth', id: 'civitai-cli' },
+  tokenScope: TokenScope.UserRead | TokenScope.AppBlocksSubmit | TokenScope.AIServicesWrite,
+};
+// OAuth token WITH AppBlocksSubmit but WITHOUT AIServicesWrite: mints (read/
+// estimate dev token) but the uniform spend ceiling STRIPS ai:write:budgeted.
+const OAUTH_SUBMIT_NOSPEND_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 101,
+  subject: { type: 'oauth', id: 'civitai-cli' },
+  tokenScope: TokenScope.UserRead | TokenScope.AppBlocksSubmit,
 };
 // A personal key deliberately scoped WITHOUT AIServicesWrite (e.g. read-only).
 const READONLY_MOD_SESSION = {
@@ -206,16 +224,56 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(mockSign).not.toHaveBeenCalled();
   });
 
-  it('403 when the key is OAuth-client-issued (personal key only)', async () => {
+  it('403 when an OAuth token LACKS the AppBlocksSubmit scope', async () => {
+    // TokenScope.Full excludes AppBlocksSubmit, so even a "full" OAuth consent
+    // is rejected at the mint gate (mirrors submit-version's OAuth gate).
     mockGetSession.mockResolvedValueOnce(OAUTH_MOD_SESSION);
     const { req, res } = authPost({ appBlockId: 'apb_abc' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(403);
-    expect((res._getJSONData() as { message: string }).message).toContain('personal API key');
+    const msg = (res._getJSONData() as { message: string }).message;
+    // Actionable: tells the dev both how to fix it (personal key) and the OAuth path.
+    expect(msg).toContain('personal API key');
+    expect(msg).toContain('App Blocks submit scope');
     expect(mockSign).not.toHaveBeenCalled();
     // Rejected before flag / db / sign — no leak.
     expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
     expect(mockAppBlockFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('200: OAuth token WITH AppBlocksSubmit + AIServicesWrite mints a spend-capable dev token (self-bound sub)', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_SUBMIT_SPEND_SESSION);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    const arg = mockSign.mock.calls[0][0];
+    // Self-bound subject = the OAuth user (never settable from the body).
+    expect(arg.userId).toBe(OWNER_ID);
+    // AppBlocksSubmit gated the MINT; AIServicesWrite kept the spend scope.
+    expect(arg.scopes).toContain('ai:write:budgeted');
+    expect(arg.buzzBudget).toBe(50);
+    // Every other belt unchanged: forced SFW + page ctx.
+    expect(arg.maxBrowsingLevel).toBe(SFW);
+    expect(arg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
+  });
+
+  it('200: OAuth token WITH AppBlocksSubmit but WITHOUT AIServicesWrite mints, but the uniform spend ceiling STRIPS ai:write:budgeted', async () => {
+    // Proves AppBlocksSubmit is the MINT gate, NOT a spend grant — spend stays
+    // uniformly gated by AIServicesWrite for OAuth exactly as for personal keys.
+    mockGetSession.mockResolvedValueOnce(OAUTH_SUBMIT_NOSPEND_SESSION);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const arg = mockSign.mock.calls[0][0];
+    expect(arg.userId).toBe(OWNER_ID);
+    // Read/catalog/storage scopes survive; the budgeted-spend scope is gone.
+    expect(arg.scopes).toEqual(['apps:storage:read', 'models:read:self', 'user:read:self']);
+    expect(arg.scopes).not.toContain('ai:write:budgeted');
+    // No spend scope → no budget claim.
+    expect(arg.buzzBudget).toBeUndefined();
+    const out = res._getJSONData() as Record<string, unknown>;
+    expect(out.buzzBudget).toBeUndefined();
   });
 
   it('403 when the resolved user is NOT a moderator', async () => {


### PR DESCRIPTION
> ## ⚠️ NEEDS SECURITY REVIEW before merge — widens the token-mint auth surface to OAuth
> This route is a SECURITY-SENSITIVE token-mint surface. It previously accepted **personal API keys only**; this PR lets it also accept an **OAuth-client-issued token that carries the `AppBlocksSubmit` scope**. Please review the gate before merging.

## What

The dev-token mint (`POST /api/v1/blocks/dev-token`) hard-rejected every OAuth-client-issued token (`session.subject?.type === 'oauth' → 403`), so a `civitai login` (device-flow OAuth) credential could not mint a `dev:live` block token — even though the SDK live host (`createLiveHost`) tRPC contract is sound. The only blocker was this auth gate.

## The auth change (mirrors submit-version exactly)

The new gate is a byte-for-byte mirror of the OAuth gate the token-authenticated submit route already applies (`src/pages/api/v1/blocks/submit-version.ts:134-142`):

```ts
if (session.subject?.type === 'oauth') {
  if (!Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AppBlocksSubmit)) {
    res.status(403).json({ message: /* actionable */ });
    return;
  }
}
```

- **Personal key** (`subject.type !== 'oauth'`): unchanged.
- **OAuth token WITH `AppBlocksSubmit`**: accepted (mints).
- **OAuth token WITHOUT `AppBlocksSubmit`**: 403 with an actionable message — *"dev-token needs a personal API key (full scope, create at civitai.com/user/account) OR an OAuth login whose token carries the App Blocks submit scope; real Buzz spend additionally needs AI Services scope."*

`AppBlocksSubmit` is opt-in, off-by-default, and **excluded from `TokenScope.Full`**, so only a client that explicitly lists it in `allowedScopes` and a user who consented can reach here. `oauthClient.create` is open to any logged-in user, so accepting arbitrary OAuth tokens would be a consent escalation — this is why the scope bit is required (same rationale as submit-version).

## Belts that stay (every one unchanged)

mod gate · banned/deleted re-check · ownership pin (404, no probe oracle) · the full scope-clamp pipeline (approved snapshot ⊆ dev allowlist ⊆ OAuth ceiling ⊆ requested) · forced-SFW ceiling · self-bound `sub` (the OAuth user; never settable from the body) · per-user rate limit (fail-closed) · `no-store`.

## The uniform spend rule (load-bearing)

Spend stays gated SEPARATELY from mint. `ai:write:budgeted` survives the clamp **only if the bearer credential carries `AIServicesWrite`** (step 7f, `Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AIServicesWrite)`). This is uniform across personal keys AND OAuth — `AppBlocksSubmit` is **not** special-cased to grant spend. An OAuth token with `AppBlocksSubmit` but without `AIServicesWrite` mints a **read/estimate-only** dev token (no spend scope, no budget).

So: **`AppBlocksSubmit` = the right to MINT; `AIServicesWrite` = the right to SPEND.** Never conflated.

## Manual config you must apply (DO NOT auto-apply — human-applied per the DB rule)

For `civitai login` to mint a **spend-capable** dev token, the `civitai-cli` OAuth client's `allowedScopes` bitmask must include `AIServicesWrite` (bit 15 = 32768). `AppBlocksSubmit` (bit 25) is **already present** (current `allowedScopes = 33554433` = `UserRead | AppBlocksSubmit`, per migration `20260619120000_register_civitai_cli_oauth_client`).

```sql
-- OR AIServicesWrite (32768) into the civitai-cli client's allowedScopes.
-- 33554433 (UserRead|AppBlocksSubmit) | 32768 = 33587201.
UPDATE "OauthClient" SET "allowedScopes" = "allowedScopes" | 32768 WHERE id = 'civitai-cli';
```

> 🔐 **Security note:** granting `AIServicesWrite` to the `civitai-cli` client **broadens every `civitai-cli` OAuth token to general Buzz spend (AI Services / generation / training / scanning), not just block-budgeted spend.** That is a deliberate security decision for @ZacxDev to weigh and apply manually per the repo's "migrations applied by a human" rule. Without this SQL, `civitai login` still works for `dev:live` but mints a read/estimate-only dev token (no spend). **Not applied by this PR.**

## Tests

`src/tests/api/v1/blocks/dev-token.test.ts` extended:
- OAuth **without** `AppBlocksSubmit` → 403 (actionable message)
- OAuth **with** `AppBlocksSubmit` + `AIServicesWrite` → 200, mints, spend scope kept, self-bound sub = OAuth user
- OAuth **with** `AppBlocksSubmit` but **without** `AIServicesWrite` → 200, `ai:write:budgeted` stripped, no budget (proves the uniform spend rule)
- all existing personal-key tests stay green

**Results:** `vitest run src/tests/api/v1/blocks/dev-token.test.ts` → **28 passed**. `tsc --noEmit` → **no errors in the changed files** (the repo-wide pre-existing TS errors are unrelated and predate this PR).

## Pairs with

civitai/cli — *"feat(cli): request App Blocks + AI Services scopes on login; document dev:live auth"* (makes `civitai login` request `AppBlocksSubmit + AIServicesWrite`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)