### PR TITLE
feat(generation): add HappyHorse 1.1 video generation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@axiomhq/axiom-node": "^0.12.0",
     "@civitai/app-sdk": "^0.6.0",
     "@civitai/blocks-react": "^0.4.0",
-    "@civitai/client": "0.2.0-beta.73",
+    "@civitai/client": "0.2.0-beta.74",
     "@civitai/cybertipline-tools": "^0.1.0",
     "@civitai/next-axiom": "^0.17.0",
     "@clavata/sdk": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.2(@civitai/app-sdk@0.6.0)(react@18.3.1)
       '@civitai/client':
-        specifier: 0.2.0-beta.73
-        version: 0.2.0-beta.73
+        specifier: 0.2.0-beta.74
+        version: 0.2.0-beta.74
       '@civitai/cybertipline-tools':
         specifier: ^0.1.0
         version: 0.1.0
@@ -1219,8 +1219,8 @@ packages:
       '@civitai/app-sdk': ^0.6.0
       react: ^18.0.0 || ^19.0.0
 
-  '@civitai/client@0.2.0-beta.73':
-    resolution: {integrity: sha512-cpnAvXXwnfy++LVNYFrxkzzHZ8wG20e8TtEbdyN+jw/54KO2YTi3r63Rhr+IlbyIM22KIjFIfun8JtDd/R0Beg==}
+  '@civitai/client@0.2.0-beta.74':
+    resolution: {integrity: sha512-yLA3qwH1AJk4gYeYIqUM8qDAV29Ai+Qixjldr+bbjSnY6YaQXIOr14uoy8ZtkkcUzrRBeUXyOd033f14hqPbGA==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
   '@civitai/cybertipline-tools@0.1.0':
@@ -11497,7 +11497,7 @@ snapshots:
       '@civitai/app-sdk': 0.6.0
       react: 18.3.1
 
-  '@civitai/client@0.2.0-beta.73':
+  '@civitai/client@0.2.0-beta.74':
     dependencies:
       '@hey-api/client-fetch': 0.1.14
       rfc6902: 5.2.0

--- a/src/server/services/orchestrator/ecosystems/happy-horse.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/happy-horse.handler.ts
@@ -2,11 +2,12 @@
  * HappyHorse Ecosystem Handler
  *
  * Handles Alibaba Taotian HappyHorse video generation (FAL).
- * Single version v1.0 with four operations selected by workflow:
- * - txt2vid          → operation 'textToVideo'      (HappyHorseV1TextToVideoInput)
- * - img2vid          → operation 'imageToVideo'     (HappyHorseV1ImageToVideoInput)
- * - img2vid:ref2vid  → operation 'referenceToVideo' (HappyHorseV1ReferenceToVideoInput)
- * - vid2vid:edit     → operation 'videoEdit'        (HappyHorseV1VideoEditInput)
+ * The selected model version id maps to the engine version:
+ * - 2902378 → v1.0 (txt2vid / img2vid / ref2vid / vid2vid:edit)
+ * - 3063263 → v1.1 (txt2vid / img2vid / ref2vid — no videoEdit)
+ *
+ * Operations are selected by workflow. v1.1 reuses the same operation shapes as
+ * v1.0 minus videoEdit, so each version branch casts to its own client types.
  */
 
 import type {
@@ -14,10 +15,14 @@ import type {
   HappyHorseV1ImageToVideoInput,
   HappyHorseV1ReferenceToVideoInput,
   HappyHorseV1VideoEditInput,
+  HappyHorseV11TextToVideoInput,
+  HappyHorseV11ImageToVideoInput,
+  HappyHorseV11ReferenceToVideoInput,
   VideoGenStepTemplate,
 } from '@civitai/client';
 import { removeEmpty } from '~/utils/object-helpers';
 import type { GenerationGraphTypes } from '~/shared/data-graph/generation/generation-graph';
+import { happyHorseVersionIds } from '~/shared/data-graph/generation/version-ids';
 import { defineHandler } from './handler-factory';
 
 // Types derived from generation graph
@@ -25,19 +30,29 @@ type EcosystemGraphOutput = Extract<GenerationGraphTypes['Ctx'], { ecosystem: st
 type HappyHorseCtx = EcosystemGraphOutput & { ecosystem: 'HappyHorse' };
 
 const ENGINE = 'happyHorse' as const;
-const VERSION = 'v1.0' as const;
+
+type HappyHorseVersion = 'v1.0' | 'v1.1';
+
+// Reverse map: model version id → engine version
+const versionIdToVersion = new Map<number, HappyHorseVersion>(
+  Object.entries(happyHorseVersionIds).map(([version, id]) => [id, version as HappyHorseVersion])
+);
 
 /**
  * Creates videoGen input for HappyHorse ecosystem.
- * Routes to the appropriate operation based on workflow.
+ * Routes to the appropriate engine version + operation based on the selected
+ * model version and workflow.
  */
 export const createHappyHorseInput = defineHandler<HappyHorseCtx, [VideoGenStepTemplate]>(
   (data) => {
+    const version: HappyHorseVersion =
+      (data.model ? versionIdToVersion.get(data.model.id) : undefined) ?? 'v1.0';
+
     // enableSafetyChecker is in the type spec but intentionally not exposed —
     // matches peer video ecosystems and avoids double-filtering against Civitai's own NSFW pipeline.
     const base = {
       engine: ENGINE,
-      version: VERSION,
+      version,
       prompt: data.prompt,
       resolution:
         'resolution' in data
@@ -46,6 +61,60 @@ export const createHappyHorseInput = defineHandler<HappyHorseCtx, [VideoGenStepT
       duration: 'duration' in data ? data.duration : undefined,
       seed: data.seed,
     };
+
+    // ---------------------------------------------------------------------------
+    // v1.1 — txt2vid / img2vid / img2vid:ref2vid (no videoEdit)
+    // ---------------------------------------------------------------------------
+    if (version === 'v1.1') {
+      if (data.workflow === 'img2vid:ref2vid') {
+        const images = data.images?.map((x) => x.url) ?? [];
+        if (images.length < 1)
+          throw new Error('At least one reference image is required for img2vid:ref2vid');
+        return [
+          {
+            $type: 'videoGen',
+            input: removeEmpty({
+              ...base,
+              operation: 'referenceToVideo',
+              images,
+              aspectRatio: data.aspectRatio
+                ?.value as HappyHorseV11ReferenceToVideoInput['aspectRatio'],
+            }) as HappyHorseV11ReferenceToVideoInput,
+          },
+        ];
+      }
+
+      if (data.workflow === 'img2vid') {
+        const image = data.images?.[0]?.url;
+        if (!image) throw new Error('A source image is required for img2vid');
+        return [
+          {
+            $type: 'videoGen',
+            input: removeEmpty({
+              ...base,
+              operation: 'imageToVideo',
+              image,
+            }) as HappyHorseV11ImageToVideoInput,
+          },
+        ];
+      }
+
+      // txt2vid (default)
+      return [
+        {
+          $type: 'videoGen',
+          input: removeEmpty({
+            ...base,
+            operation: 'textToVideo',
+            aspectRatio: data.aspectRatio?.value as HappyHorseV11TextToVideoInput['aspectRatio'],
+          }) as HappyHorseV11TextToVideoInput,
+        },
+      ];
+    }
+
+    // ---------------------------------------------------------------------------
+    // v1.0 — txt2vid / img2vid / img2vid:ref2vid / vid2vid:edit
+    // ---------------------------------------------------------------------------
 
     // vid2vid:edit
     if (data.workflow === 'vid2vid:edit') {

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -1446,7 +1446,9 @@ export const ecosystemSettings: EcosystemSettings[] = [
   {
     ecosystemId: ECO.HappyHorse,
     defaults: {
-      model: { id: 2902378 },
+      // Default to the newest version (v1.1 = 3063263); v1.0 (2902378) remains
+      // selectable via the version picker in happy-horse-graph.ts.
+      model: { id: 3063263 },
       modelLocked: true,
     },
   },

--- a/src/shared/data-graph/generation/config/workflows.ts
+++ b/src/shared/data-graph/generation/config/workflows.ts
@@ -23,6 +23,7 @@ import type { OutputType } from './types';
 // graphs import helpers from this file, so importing them back here would form a
 // graph <-> config/workflows cycle (the cause of "X is undefined" at module-eval).
 import {
+  happyHorseVersionIds,
   klingVersionIds,
   nanoBananaVersionIds,
   viduVersionIds,
@@ -326,6 +327,8 @@ export const workflowConfigs: WorkflowConfigs = {
     description: 'Edit a video with AI',
     category: 'video',
     ecosystemIds: [ECO.Grok, ECO.WanVideo27, ECO.HappyHorse],
+    // HappyHorse v1.1 has no videoEdit operation — v1.0 only.
+    excludeModelVersionIds: [happyHorseVersionIds['v1.1']],
   },
 
   // Disabled — LTXV23 extendVideo is producing poor results. Re-enable once

--- a/src/shared/data-graph/generation/happy-horse-graph.ts
+++ b/src/shared/data-graph/generation/happy-horse-graph.ts
@@ -2,9 +2,10 @@
  * HappyHorse Graph
  *
  * Controls for HappyHorse video generation ecosystem (Alibaba Taotian).
- * Single version (v1.0) with four operations selected via workflow.
+ * Version-selectable (v1.0 / v1.1) via the model picker; the handler maps the
+ * selected model version id to the @civitai/client engine version.
  *
- * Workflows:
+ * Workflows (vid2vid:edit is v1.0-only — excluded for v1.1 in config/workflows.ts):
  * - txt2vid           → operation 'textToVideo'
  * - img2vid           → operation 'imageToVideo' (single first frame)
  * - img2vid:ref2vid   → operation 'referenceToVideo' (1-9 reference images)
@@ -19,7 +20,8 @@
  * - audioSetting: shown only for vid2vid:edit (auto / origin)
  * - seed
  *
- * Model is locked to a single Civitai version via ecosystemSettings.
+ * The model swap button is locked via ecosystemSettings (modelLocked); users
+ * still pick between the official v1.0 / v1.1 versions.
  */
 
 import z from 'zod';
@@ -42,18 +44,35 @@ import {
   getAspectRatioOptions,
   type GenerationAspectRatio,
 } from '~/shared/constants/generation.constants';
+import { happyHorseVersionIds } from './version-ids';
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-const happyHorseAspectRatioList: GenerationAspectRatio[] = [
-  '16:9',
-  '4:3',
-  '1:1',
-  '3:4',
-  '9:16',
+const happyHorseAspectRatioList: GenerationAspectRatio[] = ['16:9', '4:3', '1:1', '3:4', '9:16'];
+
+// v1.1 accepts a wider ratio set than v1.0 (adds 21:9, 5:4, 4:5). The API also
+// accepts 9:21, but Civitai's shared GenerationAspectRatio tables don't define
+// it, so it isn't exposed here.
+const happyHorseV1_1AspectRatioList: GenerationAspectRatio[] = [
+  ...happyHorseAspectRatioList,
+  '21:9',
+  '5:4',
+  '4:5',
 ];
+
+/** Preferred ratios shown before the "More" overflow for the wider v1.1 set */
+const happyHorseV1_1PriorityRatios = ['16:9', '4:3', '1:1', '3:4', '9:16'];
+
+/** Options for the HappyHorse version selector (using version IDs as values) */
+const happyHorseVersionOptions = [
+  { label: 'v1.0', value: happyHorseVersionIds['v1.0'] },
+  { label: 'v1.1', value: happyHorseVersionIds['v1.1'] },
+];
+
+/** True when the selected model version is HappyHorse v1.1 */
+const isHappyHorseV1_1 = (modelId?: number) => modelId === happyHorseVersionIds['v1.1'];
 
 /** Default happy horse aspect ratios (720p) — exported for legacy consumers */
 const happyHorseAspectRatios = getAspectRatioOptions('720p', happyHorseAspectRatioList);
@@ -78,8 +97,16 @@ const happyHorseAudioSettings = [
 type HappyHorseCtx = { ecosystem: string; workflow: string };
 
 export const happyHorseGraph = new DataGraph<HappyHorseCtx, GenerationCtx>()
-  // Locked model from ecosystemSettings
-  .merge(createCheckpointGraph())
+  // Version-locked model (v1.0 / v1.1) — picker shows the official versions,
+  // swap button hidden via modelLocked in ecosystemSettings. Defaults to v1.1.
+  .merge(
+    () =>
+      createCheckpointGraph({
+        versions: { options: happyHorseVersionOptions },
+        defaultModelId: happyHorseVersionIds['v1.1'],
+      }),
+    []
+  )
 
   // Images node — workflow-dependent
   .node(
@@ -119,17 +146,25 @@ export const happyHorseGraph = new DataGraph<HappyHorseCtx, GenerationCtx>()
     })
   )
 
-  // Aspect ratio — shown for txt2vid and img2vid:ref2vid only; dimensions scale with resolution
+  // Aspect ratio — shown for txt2vid and img2vid:ref2vid only; dimensions scale
+  // with resolution and the option set widens for v1.1.
   .node(
     'aspectRatio',
-    (ctx) => ({
-      ...aspectRatioNode({
-        options: getAspectRatioOptions(ctx.resolution, happyHorseAspectRatioList),
-        defaultValue: '16:9',
-      }),
-      when: ctx.workflow === 'txt2vid' || ctx.workflow === 'img2vid:ref2vid',
-    }),
-    ['workflow', 'resolution']
+    (ctx) => {
+      const v11 = isHappyHorseV1_1(ctx.model?.id);
+      return {
+        ...aspectRatioNode({
+          options: getAspectRatioOptions(
+            ctx.resolution,
+            v11 ? happyHorseV1_1AspectRatioList : happyHorseAspectRatioList
+          ),
+          defaultValue: '16:9',
+          priorityOptions: v11 ? happyHorseV1_1PriorityRatios : undefined,
+        }),
+        when: ctx.workflow === 'txt2vid' || ctx.workflow === 'img2vid:ref2vid',
+      };
+    },
+    ['workflow', 'resolution', 'model']
   )
 
   // Duration (3-15 seconds)

--- a/src/shared/data-graph/generation/version-ids.ts
+++ b/src/shared/data-graph/generation/version-ids.ts
@@ -25,3 +25,8 @@ export const viduVersionIds = {
   q1: 2623839,
   q3: 2741273,
 } as const;
+
+export const happyHorseVersionIds = {
+  'v1.0': 2902378,
+  'v1.1': 3063263,
+} as const;


### PR DESCRIPTION
HappyHorse 1.1 ships as a new model version (3063263) under the existing HappyHorse ecosystem rather than a separate ecosystem (API-only model). The selected model version maps to the @civitai/client engine version:
- 2902378 -> v1.0 (txt2vid / img2vid / ref2vid / vid2vid:edit)
- 3063263 -> v1.1 (txt2vid / img2vid / ref2vid; no videoEdit)

- version-ids: add happyHorseVersionIds (v1.0, v1.1)
- happy-horse-graph: version picker (defaults to v1.1); aspect-ratio set widens for v1.1 (adds 21:9, 5:4, 4:5)
- happy-horse.handler: route model.id -> engine version; v1.1 uses HappyHorseV11 client types
- config/workflows: exclude v1.1 from vid2vid:edit (v1.0-only operation)
- basemodel.constants: HappyHorse ecosystemSettings default -> v1.1 (3063263)
- bump @civitai/client 0.2.0-beta.73 -> 0.2.0-beta.74 (ships v1.1 types)