### PR TITLE
fix(moderation): hard timeout on the external-moderation fetch (kills the generation-submit park)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -423,6 +423,11 @@ export const serverSchema = z.object({
   EXTERNAL_MODERATION_TOKEN: z.string().optional(),
   EXTERNAL_MODERATION_CATEGORIES: commaDelimitedStringObject().optional(),
   EXTERNAL_MODERATION_THRESHOLD: z.coerce.number().optional().default(0.5),
+  // Hard request timeout (ms) for the external moderation call. Bounds the
+  // fail-soft path: when the moderation gateway is slow/hanging (503/504 waves),
+  // the fetch is aborted at this deadline instead of parking the whole generation
+  // submission for undici's ~300s default. See src/server/integrations/moderation.ts.
+  EXTERNAL_MODERATION_TIMEOUT_MS: z.coerce.number().optional().default(5000),
   BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
   MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -427,7 +427,11 @@ export const serverSchema = z.object({
   // fail-soft path: when the moderation gateway is slow/hanging (503/504 waves),
   // the fetch is aborted at this deadline instead of parking the whole generation
   // submission for undici's ~300s default. See src/server/integrations/moderation.ts.
-  EXTERNAL_MODERATION_TIMEOUT_MS: z.coerce.number().optional().default(5000),
+  // `.int().positive().catch(5000)` so a missing/empty/0/negative/garbage value
+  // falls back to 5000 rather than (a) crashing boot or (b) coercing to 0 →
+  // AbortSignal.timeout(0) → aborting every call → SILENTLY disabling external
+  // moderation (the dangerous failure for a trust-and-safety control).
+  EXTERNAL_MODERATION_TIMEOUT_MS: z.coerce.number().int().positive().catch(5000),
   BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
   MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/server/integrations/__tests__/moderation.test.ts
+++ b/src/server/integrations/__tests__/moderation.test.ts
@@ -61,10 +61,18 @@ describe('extModeration.moderatePrompt', () => {
       });
     });
     const start = Date.now();
-    await expect(extModeration.moderatePrompt('a hanging prompt')).rejects.toBeTruthy();
+    const err = await extModeration.moderatePrompt('a hanging prompt').then(
+      () => {
+        throw new Error('should have rejected');
+      },
+      (e) => e
+    );
     const elapsed = Date.now() - start;
     // Must reject promptly at the deadline, not park indefinitely.
     expect(elapsed).toBeLessThan(2000);
+    // The caller's fail-soft path reads `error.message` (logToAxiom) — guard that the
+    // abort rejection carries a string message so that access can never throw.
+    expect(typeof err.message).toBe('string');
   });
 
   it('throws on a non-ok response (503) so the caller fails soft', async () => {

--- a/src/server/integrations/__tests__/moderation.test.ts
+++ b/src/server/integrations/__tests__/moderation.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests for the external-moderation client (moderation.ts).
+ *
+ * The function runs INLINE on every generation submission (generateFromGraph →
+ * auditPromptServer → extModeration.moderatePrompt). It is fail-soft (the caller
+ * catches and proceeds with flagged:false). The bug these tests guard: Node's
+ * undici `fetch` has no default request timeout, so a slow/hanging moderation
+ * gateway (503/504 wave) parked the whole tRPC request off-CPU for ~minutes
+ * (observed ~194s api-primary tail). The fix adds `AbortSignal.timeout(...)`.
+ */
+
+// Mutable env mock so each test can set the timeout / endpoint. `vi.hoisted` so it
+// exists before the hoisted `vi.mock` factory references it.
+const env = vi.hoisted(() => ({
+  EXTERNAL_MODERATION_ENDPOINT: 'https://moderation.example/v1/moderations' as string,
+  EXTERNAL_MODERATION_TOKEN: 'tok' as string,
+  EXTERNAL_MODERATION_THRESHOLD: 0.5,
+  EXTERNAL_MODERATION_TIMEOUT_MS: 5000,
+  EXTERNAL_MODERATION_CATEGORIES: undefined as Record<string, string> | undefined,
+}));
+vi.mock('~/env/server', () => ({ env }));
+
+import { extModeration } from '~/server/integrations/moderation';
+
+const okResponse = (flagged: boolean) => ({
+  ok: true,
+  json: async () => ({
+    results: [{ flagged, category_scores: {}, categories: {} }],
+  }),
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  env.EXTERNAL_MODERATION_ENDPOINT = 'https://moderation.example/v1/moderations';
+  env.EXTERNAL_MODERATION_TOKEN = 'tok';
+  env.EXTERNAL_MODERATION_TIMEOUT_MS = 5000;
+  env.EXTERNAL_MODERATION_CATEGORIES = undefined;
+});
+
+describe('extModeration.moderatePrompt', () => {
+  it('passes an AbortSignal to fetch (timeout is wired)', async () => {
+    const fetchMock = vi.fn(async () => okResponse(false));
+    vi.stubGlobal('fetch', fetchMock);
+    await extModeration.moderatePrompt('a cat');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const opts = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('aborts (rejects) when the gateway hangs past the timeout — caller then fails soft', async () => {
+    env.EXTERNAL_MODERATION_TIMEOUT_MS = 25;
+    // fetch that never resolves on its own — only rejects when the abort fires.
+    vi.stubGlobal('fetch', (_url: string, opts: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () =>
+          reject((opts.signal as AbortSignal).reason ?? new Error('aborted'))
+        );
+      });
+    });
+    const start = Date.now();
+    await expect(extModeration.moderatePrompt('a hanging prompt')).rejects.toBeTruthy();
+    const elapsed = Date.now() - start;
+    // Must reject promptly at the deadline, not park indefinitely.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it('throws on a non-ok response (503) so the caller fails soft', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 503, statusText: 'Service Unavailable', text: async () => 'upstream connect error' }))
+    );
+    await expect(extModeration.moderatePrompt('x')).rejects.toThrow(/503/);
+  });
+
+  it('short-circuits (no fetch) when endpoint/token are not configured', async () => {
+    env.EXTERNAL_MODERATION_ENDPOINT = '' as unknown as string;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await extModeration.moderatePrompt('x');
+    expect(r).toEqual({ flagged: false, categories: [] });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns flagged:false for clean content', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse(false)));
+    const r = await extModeration.moderatePrompt('a serene landscape');
+    expect(r.flagged).toBe(false);
+  });
+});

--- a/src/server/integrations/moderation.ts
+++ b/src/server/integrations/moderation.ts
@@ -20,6 +20,15 @@ async function moderatePrompt(prompt: string): Promise<{ flagged: false; categor
     return { flagged: false, categories: [] };
 
   const preparedPrompt = removeFalsePositiveTriggers(prompt);
+  // Hard timeout via AbortSignal. Node's undici `fetch` has NO request timeout by
+  // default (~300s headers/body), so a slow/hanging moderation gateway would park
+  // this await — and since it runs inline on every generation submission
+  // (`generateFromGraph` → `auditPromptServer`), that parks the whole tRPC request
+  // off-CPU for minutes (observed ~194s api-primary tail during a moderation 503/504
+  // wave). The call is already FAIL-SOFT (the caller catches and proceeds with
+  // flagged:false) and the local regex audit still gates regardless, so aborting a
+  // slow call only drops the secondary external layer for that one request — it does
+  // not weaken the primary block. Abort → throws → caller's existing catch fails soft.
   const res = await fetch(env.EXTERNAL_MODERATION_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -30,6 +39,7 @@ async function moderatePrompt(prompt: string): Promise<{ flagged: false; categor
       input: preparedPrompt,
       model: 'omni-moderation-latest',
     }),
+    signal: AbortSignal.timeout(env.EXTERNAL_MODERATION_TIMEOUT_MS),
   });
   if (!res.ok) {
     let message = `External moderation failed: ${res.status} ${res.statusText}`;


### PR DESCRIPTION
## Root cause (found via the #2728 slow-tRPC instrument)

The new slow-tRPC log named the dp-prod **api-primary P99-tail** offender: **`orchestrator.generateFromGraph`** — up to **~194s**, `ok:true` (it *succeeds*, just very slowly). The orchestrator submission POST itself is fast (orchestration-api POST P99 **4.68s**), so the park isn't `submitWorkflow`.

It's the **external-moderation call**, which runs inline on every generation submit:
`generateFromGraph → auditPromptServer → extModeration.moderatePrompt → fetch(EXTERNAL_MODERATION_ENDPOINT)` (`omni-moderation-latest` = OpenAI, behind a gateway).

That `fetch` had **no timeout / no `AbortSignal`**, and Node's undici `fetch` defaults to **~300s** headers/body. Loki confirms the moderation gateway is intermittently failing — **503 "upstream connect error"** + **504 Gateway Timeout**, error rate spiking to **~57 / 30min** exactly in the slow-`generateFromGraph` window. When it hangs, the `await` parks and takes the whole tRPC request off-CPU with it (the ~194s tail). Same un-timed-dependency class as the redis `socketTimeout` fix (#2556).

## Fix

Pass `AbortSignal.timeout(EXTERNAL_MODERATION_TIMEOUT_MS)` (new env knob, **default 5000ms**) to the fetch.

**Safety / no weakening of moderation:** the call is *already* fail-soft — `auditPromptServer` catches the error and proceeds with `flagged:false` — and the **local regex audit (`auditPromptEnriched`) still runs and gates regardless**. So aborting a slow call only drops the *secondary* external layer for that one request (the same thing that already happens on a 503/504), and never bypasses the primary block. Abort → throws → existing catch fails soft *immediately* instead of parking for minutes.

## Tests (5, tsc clean on changed files)
- `AbortSignal` is wired onto the fetch.
- A hanging gateway **rejects at the deadline** (<2s with a 25ms timeout) instead of parking — the core regression guard.
- A 503 still throws (fail-soft path intact).
- Unconfigured endpoint/token short-circuits without fetching.
- Clean content returns `flagged:false`.

## Notes
- The gateway 503/504s themselves are an upstream/provider issue (OpenAI moderation or the proxy in front) worth a separate look, but this makes civitai resilient to it regardless — generation submits no longer inherit the moderation gateway's latency.
- Default 5s is generous (omni-moderation normally responds sub-second); tune live via `EXTERNAL_MODERATION_TIMEOUT_MS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)