### PR TITLE
fix(app-blocks): dev-token always grants user:read:self (so dev:live resolves the viewer)

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -383,6 +383,36 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     granted = granted.filter((s: string) => s !== 'ai:write:budgeted');
   }
 
+  //   g) FORCE-GRANT `user:read:self` (UNCONDITIONAL, post-clamp). The local
+  //      harness's `dev:live` mode resolves the dev's OWN viewer identity by
+  //      calling `GET /api/v1/blocks/me`, which is gated on `user:read:self`.
+  //      That scope is only minted if it survives the app-manifest/approved-
+  //      snapshot + OAuth-bitmask clamp above — and the page-money scaffold
+  //      manifest declares ONLY `ai:write:budgeted`, so `user:read:self` is
+  //      never in `approvedScopes` and never minted → /blocks/me 403s → the
+  //      harness falls back to an anonymous viewer. This bypasses that clamp
+  //      for this ONE read scope so `dev:live` can resolve the viewer.
+  //
+  //      SAFE because:
+  //        - `user:read:self` is a READ scope that returns ONLY the self-bound
+  //          caller's own profile — no third-party data, no write, no spend. The
+  //          `/blocks/me` handler resolves `userId` from `claims.sub` and reads
+  //          exactly that user (me.ts), and `enforceContextBinding` rejects
+  //          `user:read:self` on an `anon` sub (block-scope.middleware.ts). The
+  //          dev token's `sub` is ALWAYS `user:<callerId>` (self-bound, set from
+  //          the authenticated caller at sign time below — never from the body),
+  //          so this can only ever return the CALLER's own identity.
+  //        - it's already a member of `DEV_TOKEN_SCOPE_ALLOWLIST` — an intended,
+  //          vetted dev scope (it was simply being clamped OUT by the per-app
+  //          approved-scopes pin, which the page-money manifest doesn't list).
+  //        - this endpoint is mod-gated (step 2) and self-bound, so the net
+  //          effect is "a dev reads their OWN identity via their OWN token" —
+  //          zero escalation, no new data surface.
+  //      Post-clamp + uniform across BOTH the personal-key and OAuth paths (the
+  //      grant runs after every clamp belt, so neither path can suppress it).
+  //      This does NOT touch the prod mint (`/api/v1/block-tokens`).
+  granted.push('user:read:self');
+
   // Dedup, deterministic order.
   granted = Array.from(new Set(granted)).sort();
 

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -459,36 +459,44 @@ describe('POST /api/v1/blocks/dev-token', () => {
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(200);
     const arg = mockSign.mock.calls[0][0];
-    expect(arg.scopes).toEqual(['apps:storage:write', 'models:read:self']);
+    // user:read:self is FORCE-GRANTED post-clamp (dev:live viewer identity).
+    expect(arg.scopes).toEqual(['apps:storage:write', 'models:read:self', 'user:read:self']);
     expect(arg.scopes).not.toContain('social:tip:self');
     expect(arg.scopes).not.toContain('block:settings:read');
   });
 
-  it('STRIPS a requested scope that is NOT in the app approved set', async () => {
+  it('STRIPS a requested OTHER scope that is NOT in the app approved set (user:read:self is force-granted)', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
-    // App approves only models:read:self; the body requests user:read:self too.
+    // App approves only models:read:self; the body requests ai:write:budgeted too
+    // (which is NOT approved → stripped). user:read:self is force-granted post-
+    // clamp regardless of approval, so it is present even though the app did not
+    // approve it.
     mockAppBlockFindUnique.mockResolvedValueOnce(
       pageApp({ approvedScopes: ['models:read:self'] })
     );
     const { req, res } = authPost({
       appBlockId: 'apb_abc',
-      scopes: ['models:read:self', 'user:read:self'],
+      scopes: ['models:read:self', 'ai:write:budgeted'],
     });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(200);
     const arg = mockSign.mock.calls[0][0];
-    expect(arg.scopes).toEqual(['models:read:self']);
+    // ai:write:budgeted stripped (not approved); user:read:self force-granted.
+    expect(arg.scopes).toEqual(['models:read:self', 'user:read:self']);
+    expect(arg.scopes).not.toContain('ai:write:budgeted');
   });
 
-  it('narrows scopes to the requested subset', async () => {
+  it('narrows scopes to the requested subset, but user:read:self is force-granted regardless of body narrowing', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     const { req, res } = authPost({
       appBlockId: 'apb_abc',
-      scopes: ['models:read:self'], // subset of approved
+      scopes: ['models:read:self'], // subset of approved — excludes user:read:self
     });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(200);
-    expect(mockSign.mock.calls[0][0].scopes).toEqual(['models:read:self']);
+    // Body narrowing dropped everything but models:read:self; user:read:self is
+    // force-granted POST-clamp, so it survives the narrowing.
+    expect(mockSign.mock.calls[0][0].scopes).toEqual(['models:read:self', 'user:read:self']);
   });
 
   it('CAPS an over-cap requested budget to the dev cap', async () => {
@@ -523,7 +531,10 @@ describe('POST /api/v1/blocks/dev-token', () => {
     const { req, res } = authPost({ appBlockId: 'apb_abc' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(200);
-    expect(mockSign.mock.calls[0][0].scopes).toEqual(['apps:storage:read']);
+    // models:read:self dropped by the 0 OAuth ceiling; apps:storage:read survives
+    // (SKIP_OAUTH_CHECK); user:read:self is force-granted POST-clamp so it is
+    // present even though the ceiling would otherwise drop it.
+    expect(mockSign.mock.calls[0][0].scopes).toEqual(['apps:storage:read', 'user:read:self']);
   });
 
   it('STRIPS ai:write:budgeted when the personal key lacks AIServicesWrite', async () => {
@@ -540,5 +551,46 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(arg.buzzBudget).toBeUndefined();
     const out = res._getJSONData() as Record<string, unknown>;
     expect(out.buzzBudget).toBeUndefined();
+  });
+
+  it('PAGE-MONEY case: OAuth dev token for an app that approves ONLY ai:write:budgeted, with a credential lacking AIServicesWrite, still mints user:read:self', async () => {
+    // The exact root-cause scenario: the page-money scaffold manifest declares
+    // ONLY ai:write:budgeted, so user:read:self is never in approvedScopes and
+    // would never be minted by the clamp → /blocks/me 403 → dev:live falls back
+    // to an anonymous viewer. The OAuth credential here also lacks AIServicesWrite,
+    // so ai:write:budgeted is stripped by the spend ceiling. The token therefore
+    // carries NO spend scope, but user:read:self IS present (force-granted) so the
+    // harness can resolve the viewer identity.
+    mockGetSession.mockResolvedValueOnce(OAUTH_SUBMIT_NOSPEND_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ approvedScopes: ['ai:write:budgeted'] })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const arg = mockSign.mock.calls[0][0];
+    // Identity present; no spend (credential lacked AIServicesWrite).
+    expect(arg.scopes).toEqual(['user:read:self']);
+    expect(arg.scopes).not.toContain('ai:write:budgeted');
+    expect(arg.buzzBudget).toBeUndefined();
+    // Self-bound subject = the caller — so /blocks/me only ever returns this user.
+    expect(arg.userId).toBe(OWNER_ID);
+    const out = res._getJSONData() as Record<string, unknown>;
+    expect(out.scopes).toEqual(['user:read:self']);
+  });
+
+  it('FORCE-GRANTS user:read:self even when the app approves ONLY ai:write:budgeted (personal-key page-money app)', async () => {
+    // Same page-money manifest, but via a personal key that CAN spend
+    // (AIServicesWrite). user:read:self is added regardless, alongside the spend
+    // scope the app approved.
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ approvedScopes: ['ai:write:budgeted'] })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const arg = mockSign.mock.calls[0][0];
+    expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
   });
 });


### PR DESCRIPTION
## Root cause

App Blocks `dev:live` mode resolves the dev's OWN viewer identity by calling `GET /api/v1/blocks/me`, which is `withBlockScope(..., { requiredScope: 'user:read:self' })`. For **every** dev token, that call returned **403** and `createLiveHost` fell back to an anonymous viewer.

Why: the dev-token mint (`/api/v1/blocks/dev-token`) builds the granted scope set by clamping the app's **approved-scopes snapshot** through the dev allowlist + the app's OAuth bitmask + optional body narrowing. The page-money scaffold manifest declares only `scopes: ["ai:write:budgeted"]`, so `user:read:self` is **never in `approvedScopes`** → never survives the clamp → never minted → `/blocks/me` 403s → anonymous viewer.

This is **not** OAuth-specific — a personal-key dev token hits the same gap (the clamp starts from the same approved snapshot for both auth shapes).

## The fix

After the existing scope clamp **and** the `AIServicesWrite` spend strip, unconditionally add `user:read:self` to the `granted` set, then dedupe:

```ts
// (g) FORCE-GRANT user:read:self (UNCONDITIONAL, post-clamp) …
granted.push('user:read:self');
// Dedup, deterministic order.
granted = Array.from(new Set(granted)).sort();
```

Because the grant runs **after** every clamp belt, it applies uniformly to **both** the personal-key and OAuth paths, and no clamp (approved-snapshot pin, dev allowlist, OAuth ceiling, body narrowing) can suppress it. `user:read:self` is already a member of `DEV_TOKEN_SCOPE_ALLOWLIST`.

## Security reasoning

- **Read-only, no third-party data, no write, no spend.** `user:read:self` only conveys "viewer identity." `/api/v1/blocks/me` resolves `userId` from `claims.sub` via `parseSubjectUserId` and reads **exactly that user** (`dbWrite.user.findUnique({ where: { id: userId } })`). There is no way to read another user.
- **Self-bound `sub`.** The dev token's subject is set to the authenticated caller's `userId` at sign time (`BlockTokenService.sign({ userId: user.id, … })`) — never from the request body. `sub` is always `user:<callerId>`.
- **`:self` context binding holds.** `enforceContextBinding` (in `block-scope.middleware.ts`) rejects `user:read:self` on an `anon` sub: `if (claims.sub === 'anon') throw forbidden(...)`. Since the dev token is always user-bound, the scope only ever returns the **caller's own** identity.
- **Mod-gated.** The dev-token endpoint requires `user.isModerator` (and the resolved viewer is re-checked as a moderator in `/blocks/me`). Net effect: a dev reads their **own** identity via their **own** token — zero escalation, no new data surface.
- **Prod mint untouched.** This changes only `/api/v1/blocks/dev-token`. The production mint `/api/v1/block-tokens` (exact-host same-origin, install-row bound) is not modified.
- **Every other belt unchanged:** mod gate, ownership 404, budget cap, forced-SFW ceiling, rate limit, self-bound sub, and the `AIServicesWrite`-gates-`ai:write:budgeted` rule all behave exactly as before. The grant is post-clamp and read-only, so it cannot widen spend or maturity.

## Applies to both auth paths

Confirmed: the force-grant is post-clamp, after the OAuth/personal split has merged back into the single `granted` pipeline. New tests cover the OAuth page-money case (`OAUTH_SUBMIT_NOSPEND` + app approving only `ai:write:budgeted` → `scopes: ['user:read:self']`) and the personal-key page-money case (`scopes: ['ai:write:budgeted', 'user:read:self']`).

## Tests

`src/tests/api/v1/blocks/dev-token.test.ts`:
- Updated the clamp-case assertions (`STRIPS dev-excluded`, requested-not-approved, body-narrowing, OAuth-ceiling-drop) — minted tokens now always include `user:read:self`.
- Added a test: an OAuth dev token for a page-money app (`approvedScopes: ['ai:write:budgeted']`, credential lacks `AIServicesWrite`) comes back with `scopes: ['user:read:self']` (no spend, identity present).
- Added a test: `user:read:self` is force-granted even when the app approves only `ai:write:budgeted` (personal-key page-money).
- Confirmed it's present regardless of body `scopes` narrowing (force-granted).

Results (run in a worktree with the primary clone's `node_modules` symlinked in):
- `vitest run src/tests/api/v1/blocks/dev-token.test.ts` → **30 passed**.
- `tsc --noEmit` (full project) → **0 errors** in `dev-token.ts` / `blocks/me.ts` / `block-scope.middleware.ts`. (The repo's full strict typecheck has a large pre-existing error backlog unrelated to this change; none of those errors touch the changed file.)

## NEEDS SECURITY REVIEW (dev-token mint surface)

This is a security-adjacent change to the token-mint endpoint. Requesting review of the force-grant placement (post-clamp) and the self-bound / read-only argument above before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)