### PR TITLE
fix(subscriptions): let overdue users cancel membership

### DIFF
--- a/src/components/Stripe/MembershipChangePrevention.tsx
+++ b/src/components/Stripe/MembershipChangePrevention.tsx
@@ -326,6 +326,7 @@ export const CancelMembershipBenefitsModal = () => {
   const { vault, isLoading: vaultLoading } = useQueryVault();
   const { subscription, subscriptionLoading, subscriptionPaymentProvider } = useActiveSubscription({
     buzzType: mainBuzzType,
+    checkWhenInBadState: true,
   });
   const buzzConfig = useBuzzCurrencyConfig(mainBuzzType);
   const product = subscription?.product;

--- a/src/components/Subscriptions/CancelMembershipAction.tsx
+++ b/src/components/Subscriptions/CancelMembershipAction.tsx
@@ -22,7 +22,7 @@ export function CancelMembershipAction({
 
   const { refreshSubscription } = useMutatePaddle();
   const { vault } = useQueryVault();
-  const { subscription } = useActiveSubscription();
+  const { subscription } = useActiveSubscription({ checkWhenInBadState: true });
 
   const handleRefresh = useCallback(async () => {
     try {


### PR DESCRIPTION
The Cancel Membership button was inoperable for users in a bad payment state (past_due/unpaid). Both CancelMembershipAction and the CancelMembershipBenefitsModal called useActiveSubscription() without checkWhenInBadState, so getUserSubscription returned null for these users — the button's handleClick short-circuited and, even if opened, the modal had no payment provider so neither cancel button rendered.

Pass checkWhenInBadState: true in both places so overdue users can cancel to stop further payment attempts.

ClickUp: 868k3we0w