### PR TITLE
feat(moderation): deferred re-screen of generation prompts skipped by inline external moderation

### DIFF
--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -90,6 +90,7 @@ import { notificationCursorMonitor } from '~/server/jobs/notification-cursor-mon
 import { sendWebhooksJob } from '~/server/jobs/send-webhooks';
 import { tempSetMissingNsfwLevel } from '~/server/jobs/temp-set-missing-nsfw-level';
 import { retryFailedTextModeration } from '~/server/jobs/text-moderation-retry';
+import { rescreenSkippedPromptModeration } from '~/server/jobs/rescreen-skipped-prompt-moderation';
 import { articleIngestionReconcile } from '~/server/jobs/article-ingestion-reconcile';
 import { metricJobs } from '~/server/jobs/update-metrics';
 import { updateModelVersionNsfwLevelsJob } from '~/server/jobs/update-model-version-nsfw-levels';
@@ -191,6 +192,7 @@ export const jobs: Job[] = [
   ...prepaidMembershipJobs,
   ...entityModerationJobs,
   retryFailedTextModeration,
+  rescreenSkippedPromptModeration,
   articleIngestionReconcile,
   expireStrikesJob,
   processTimedUnmutesJob,

--- a/src/server/jobs/rescreen-skipped-prompt-moderation.ts
+++ b/src/server/jobs/rescreen-skipped-prompt-moderation.ts
@@ -6,7 +6,12 @@ import { processPromptRescreenQueue } from '~/server/services/orchestrator/promp
 // Drains the sysRedis queue and re-screens each prompt when OpenAI has recovered,
 // applying the same consequence (mute escalation + audit record) as the inline path.
 // See processPromptRescreenQueue in services/orchestrator/promptAuditing.ts.
-const RESCREEN_BATCH_SIZE = 500;
+// Bounded so the worst-case run (every re-screen hits the full external-moderation
+// timeout) stays well under the 300s job lock — see RESCREEN_MAX_RUN_MS and the
+// `batchSize × EXTERNAL_MODERATION_TIMEOUT_MS < lockExpiration(300s)` invariant.
+// At ~5s/call, 100 items ≈ 500s worst case but the in-loop deadline (240s) caps it
+// and re-enqueues the remainder; in practice most calls are fast on a recovered API.
+const RESCREEN_BATCH_SIZE = 100;
 
 export const rescreenSkippedPromptModeration = createJob(
   'rescreen-skipped-prompt-moderation',

--- a/src/server/jobs/rescreen-skipped-prompt-moderation.ts
+++ b/src/server/jobs/rescreen-skipped-prompt-moderation.ts
@@ -1,0 +1,15 @@
+import { createJob } from '~/server/jobs/job';
+import { processPromptRescreenQueue } from '~/server/services/orchestrator/promptAuditing';
+
+// Deferred re-screen of generation prompts whose INLINE external moderation
+// (OpenAI omni-moderation) call failed/timed-out and was skipped fail-soft.
+// Drains the sysRedis queue and re-screens each prompt when OpenAI has recovered,
+// applying the same consequence (mute escalation + audit record) as the inline path.
+// See processPromptRescreenQueue in services/orchestrator/promptAuditing.ts.
+const RESCREEN_BATCH_SIZE = 500;
+
+export const rescreenSkippedPromptModeration = createJob(
+  'rescreen-skipped-prompt-moderation',
+  '*/5 * * * *',
+  async () => await processPromptRescreenQueue(RESCREEN_BATCH_SIZE)
+);

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -188,6 +188,22 @@ export const clavataCounter = registerCounter({
   help: 'Clavata requests',
 });
 
+// External moderation deferred re-screen outcomes (CSAM pre-screen recovery).
+// The inline external-moderation call (OpenAI omni-moderation) is fail-soft: when
+// OpenAI is slow/down the prompt's CSAM pre-screen is silently skipped. Those skips
+// are enqueued and re-screened async by the rescreen-skipped-prompt-moderation job.
+// Exposed name: civitai_app_external_moderation_outcome_total. `outcome`:
+//   skipped           — inline call failed → enqueued for deferred re-screen
+//   rescreen_clean    — deferred re-screen returned not-flagged
+//   rescreen_flagged  — deferred re-screen flagged → same consequence as inline
+//   rescreen_requeued — re-screen threw again (OpenAI still down) → re-enqueued
+//   rescreen_dropped  — re-screen kept failing past the attempt cap → dropped + logged
+export const externalModerationOutcomeCounter = registerCounterWithLabels({
+  name: 'external_moderation_outcome_total',
+  help: 'External moderation deferred re-screen outcomes (inline-skip recovery)',
+  labelNames: ['outcome'] as const,
+});
+
 // Cache metrics
 export const cacheHitCounter = registerCounterWithLabels({
   name: 'cache_hit_total',

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1340,6 +1340,10 @@ export const REDIS_SYS_KEYS = {
     EXPERIMENTAL: 'generation:experimental',
     CUSTOM_CHALLENGE: 'generation:custom-challenge',
     BLOCKED_PROMPTS: 'generation:blocked-prompts',
+    // Queue of prompts whose INLINE external moderation (OpenAI omni-moderation)
+    // call failed/timed-out and was skipped fail-soft — drained + re-screened by
+    // the rescreen-skipped-prompt-moderation job when OpenAI recovers.
+    MODERATION_RESCREEN_QUEUE: 'generation:moderation-rescreen-queue',
     REMIX_AUDIT_CHECKED: 'generation:remix-audit-checked',
     CLIENT: 'generation:client',
   },

--- a/src/server/services/orchestrator/__tests__/promptAuditing-rescreen.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing-rescreen.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests for the deferred external-moderation re-screen feature in promptAuditing.ts.
+ *
+ * Closes the trust-and-safety gap where the inline external moderation (OpenAI
+ * omni-moderation, CSAM pre-screen) is fail-soft: when OpenAI is slow/down the
+ * pre-screen is silently skipped and never recovered. The new code enqueues those
+ * skips and an async job re-screens them, applying the SAME consequence as inline.
+ *
+ * Strategy: mock every heavy boundary (sysRedis, extModeration, prom metric, db,
+ * clickhouse, user/notification/session services) so the REAL promptAuditing logic
+ * runs against fakes. We assert on the enqueue contract, the drain/consequence
+ * behavior, the attempt-cap drop, fail-soft, and the metric outcomes.
+ */
+
+// --- sysRedis mock (durable queue + blocked-prompt store) -------------------
+const sysRedis = vi.hoisted(() => ({
+  lPush: vi.fn(async () => 1),
+  lTrim: vi.fn(async () => undefined),
+  lPopCount: vi.fn(async () => [] as string[] | null),
+  lRange: vi.fn(async () => [] as string[]),
+  lLen: vi.fn(async () => 1),
+  lRem: vi.fn(async () => 0),
+  exists: vi.fn(async () => 1),
+  expire: vi.fn(async () => true),
+  del: vi.fn(async () => 1),
+  rPush: vi.fn(async () => 1),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis,
+  REDIS_KEYS: { SYSTEM: { PROMPT_ALLOWLIST: 'system:prompt-allowlist' } },
+  REDIS_SYS_KEYS: {
+    GENERATION: {
+      BLOCKED_PROMPTS: 'generation:blocked-prompts',
+      MODERATION_RESCREEN_QUEUE: 'generation:moderation-rescreen-queue',
+    },
+  },
+}));
+
+// --- extModeration mock -----------------------------------------------------
+const moderatePrompt = vi.hoisted(() => vi.fn());
+vi.mock('~/server/integrations/moderation', () => ({
+  extModeration: { moderatePrompt },
+}));
+
+// --- prom metric mock (capture outcome label increments) --------------------
+const metricInc = vi.hoisted(() => vi.fn());
+vi.mock('~/server/prom/client', () => ({
+  externalModerationOutcomeCounter: { inc: metricInc },
+}));
+
+// --- consequence side-effect mocks ------------------------------------------
+const userRestrictionCreate = vi.hoisted(() => vi.fn(async () => ({})));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { promptAllowlist: { findMany: vi.fn(async () => []) } },
+  dbWrite: { userRestriction: { create: userRestrictionCreate } },
+}));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+const updateUserById = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock('~/server/services/user.service', () => ({ updateUserById }));
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/auth/session-invalidation', () => ({
+  refreshSession: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  fetchThroughCache: vi.fn(),
+  bustFetchThroughCache: vi.fn(),
+}));
+
+import { logToAxiom } from '~/server/logging/client';
+import {
+  auditPromptServer,
+  enqueuePromptRescreen,
+  processPromptRescreenQueue,
+} from '~/server/services/orchestrator/promptAuditing';
+
+const QUEUE_KEY = 'generation:moderation-rescreen-queue';
+
+function outcomes() {
+  return metricInc.mock.calls.map((c) => (c[0] as { outcome: string }).outcome);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sysRedis.lPush.mockResolvedValue(1);
+  sysRedis.lTrim.mockResolvedValue(undefined as never);
+  sysRedis.lPopCount.mockResolvedValue([] as never);
+  sysRedis.exists.mockResolvedValue(1 as never);
+  sysRedis.lRange.mockResolvedValue([] as never);
+  sysRedis.lLen.mockResolvedValue(1 as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('auditPromptServer fail-soft + enqueue contract', () => {
+  it('does NOT throw and enqueues with attempt:0 when moderatePrompt rejects', async () => {
+    // Inline external call fails (OpenAI down). Regex audit passes (benign prompt).
+    moderatePrompt.mockRejectedValueOnce(new Error('503 upstream'));
+
+    await expect(
+      auditPromptServer({
+        prompt: 'a serene mountain landscape',
+        negativePrompt: 'blurry',
+        userId: 42,
+        isGreen: false,
+        isModerator: false,
+        remixOfId: 7,
+        imageId: 9,
+      })
+    ).resolves.toBeUndefined();
+
+    // logged the inline error
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'external-moderation-error' })
+    );
+
+    // enqueue pushed the payload (fire-and-forget; let the microtask flush)
+    await new Promise((r) => setImmediate(r));
+    expect(sysRedis.lPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
+    const pushed = JSON.parse(sysRedis.lPush.mock.calls[0][1] as string);
+    expect(pushed).toMatchObject({
+      prompt: 'a serene mountain landscape',
+      negativePrompt: 'blurry',
+      userId: 42,
+      isModerator: false,
+      remixOfId: 7,
+      imageId: 9,
+      attempt: 0,
+    });
+
+    // metric: skipped
+    expect(outcomes()).toContain('skipped');
+  });
+
+  it('does NOT enqueue when moderatePrompt resolves cleanly', async () => {
+    moderatePrompt.mockResolvedValueOnce({ flagged: false, categories: [] });
+
+    await expect(
+      auditPromptServer({ prompt: 'a cat', userId: 1, isGreen: false })
+    ).resolves.toBeUndefined();
+
+    await new Promise((r) => setImmediate(r));
+    expect(sysRedis.lPush).not.toHaveBeenCalled();
+    expect(outcomes()).not.toContain('skipped');
+  });
+});
+
+describe('enqueuePromptRescreen', () => {
+  it('caps the queue with lTrim and increments skipped, never throws', () => {
+    expect(() =>
+      enqueuePromptRescreen({ prompt: 'p', userId: 5, attempt: 0 })
+    ).not.toThrow();
+    expect(outcomes()).toContain('skipped');
+  });
+
+  it('caps the list via lTrim(0, MAX-1) after lPush', async () => {
+    enqueuePromptRescreen({ prompt: 'p', userId: 5, attempt: 0 });
+    await new Promise((r) => setImmediate(r));
+    expect(sysRedis.lPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
+    expect(sysRedis.lTrim).toHaveBeenCalledWith(QUEUE_KEY, 0, 19999);
+  });
+
+  it('swallows a redis error (best-effort, never throws/rejects)', async () => {
+    sysRedis.lPush.mockRejectedValueOnce(new Error('redis down'));
+    expect(() => enqueuePromptRescreen({ prompt: 'p', userId: 5, attempt: 0 })).not.toThrow();
+    await new Promise((r) => setImmediate(r));
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'prompt-rescreen-enqueue-error' })
+    );
+  });
+});
+
+describe('processPromptRescreenQueue', () => {
+  it('returns an empty summary when the queue is empty', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([] as never);
+    const r = await processPromptRescreenQueue(500);
+    expect(r).toEqual({ processed: 0, flagged: 0, clean: 0, requeued: 0, dropped: 0 });
+    expect(moderatePrompt).not.toHaveBeenCalled();
+  });
+
+  it('flagged item applies the consequence (addBlockedPrompt + reportProhibitedRequest)', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'bad', userId: 100, isModerator: false, attempt: 0 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: true, categories: ['sexual/minors'] });
+    // addBlockedPrompt path: key exists, list contains one real entry → lLen=1
+    sysRedis.exists.mockResolvedValue(1 as never);
+    sysRedis.lRange.mockResolvedValue([] as never);
+    sysRedis.lLen.mockResolvedValue(1 as never);
+
+    const r = await processPromptRescreenQueue(500);
+
+    expect(r.processed).toBe(1);
+    expect(r.flagged).toBe(1);
+    // addBlockedPrompt pushes the entry onto the per-user blocked-prompts list
+    expect(sysRedis.lPush).toHaveBeenCalledWith(
+      'generation:blocked-prompts:100',
+      expect.any(String)
+    );
+    const entry = JSON.parse(
+      sysRedis.lPush.mock.calls.find((c) => c[0] === 'generation:blocked-prompts:100')![1] as string
+    );
+    expect(entry).toMatchObject({ source: 'External-Deferred', category: 'external' });
+    expect(outcomes()).toContain('rescreen_flagged');
+  });
+
+  it('flagged on categories-only (flagged:false) still blocks (matches inline OR)', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'bad', userId: 101, attempt: 0 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: false, categories: ['sexual/minors'] });
+    sysRedis.lLen.mockResolvedValue(1 as never);
+
+    const r = await processPromptRescreenQueue(500);
+    expect(r.flagged).toBe(1);
+    expect(outcomes()).toContain('rescreen_flagged');
+  });
+
+  it('clean item does NOT apply any consequence', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'good', userId: 200, attempt: 0 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: false, categories: [] });
+
+    const r = await processPromptRescreenQueue(500);
+
+    expect(r.clean).toBe(1);
+    expect(r.flagged).toBe(0);
+    // no blocked-prompt write, no restriction
+    expect(
+      sysRedis.lPush.mock.calls.some((c) => String(c[0]).startsWith('generation:blocked-prompts'))
+    ).toBe(false);
+    expect(userRestrictionCreate).not.toHaveBeenCalled();
+    expect(outcomes()).toContain('rescreen_clean');
+  });
+
+  it('re-screen throw re-enqueues with attempt+1 (under cap)', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'p', userId: 300, attempt: 1 }),
+    ] as never);
+    moderatePrompt.mockRejectedValueOnce(new Error('still 503'));
+
+    const r = await processPromptRescreenQueue(500);
+
+    expect(r.requeued).toBe(1);
+    expect(r.dropped).toBe(0);
+    expect(sysRedis.lPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
+    const requeued = JSON.parse(
+      sysRedis.lPush.mock.calls.find((c) => c[0] === QUEUE_KEY)![1] as string
+    );
+    expect(requeued.attempt).toBe(2);
+    expect(outcomes()).toContain('rescreen_requeued');
+  });
+
+  it('at the attempt cap the item is DROPPED (not re-enqueued) and logged', async () => {
+    // attempt:4 → nextAttempt 5 === MAX_ATTEMPTS(5) → drop
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'p', userId: 400, attempt: 4 }),
+    ] as never);
+    moderatePrompt.mockRejectedValueOnce(new Error('persistently down'));
+
+    const r = await processPromptRescreenQueue(500);
+
+    expect(r.dropped).toBe(1);
+    expect(r.requeued).toBe(0);
+    // NOT re-enqueued
+    expect(sysRedis.lPush.mock.calls.some((c) => c[0] === QUEUE_KEY)).toBe(false);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'prompt-rescreen-dropped' })
+    );
+    expect(outcomes()).toContain('rescreen_dropped');
+  });
+
+  it('a single bad (unparseable) item does not abort the batch', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      'not json{',
+      JSON.stringify({ prompt: 'good', userId: 500, attempt: 0 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: false, categories: [] });
+
+    const r = await processPromptRescreenQueue(500);
+
+    expect(r.processed).toBe(2);
+    expect(r.dropped).toBe(1); // the bad item
+    expect(r.clean).toBe(1); // the good item still processed
+  });
+
+  it('never throws even if the pop itself errors', async () => {
+    sysRedis.lPopCount.mockRejectedValueOnce(new Error('pop failed'));
+    const r = await processPromptRescreenQueue(500);
+    expect(r).toEqual({ processed: 0, flagged: 0, clean: 0, requeued: 0, dropped: 0 });
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'prompt-rescreen-pop-error' })
+    );
+  });
+});

--- a/src/server/services/orchestrator/__tests__/promptAuditing-rescreen.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing-rescreen.test.ts
@@ -121,10 +121,11 @@ describe('auditPromptServer fail-soft + enqueue contract', () => {
       expect.objectContaining({ name: 'external-moderation-error' })
     );
 
-    // enqueue pushed the payload (fire-and-forget; let the microtask flush)
+    // enqueue pushed the payload (fire-and-forget; let the microtask flush). FIFO:
+    // the queue is appended with rPush (drained oldest-first via lPopCount).
     await new Promise((r) => setImmediate(r));
-    expect(sysRedis.lPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
-    const pushed = JSON.parse(sysRedis.lPush.mock.calls[0][1] as string);
+    expect(sysRedis.rPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
+    const pushed = JSON.parse(sysRedis.rPush.mock.calls[0][1] as string);
     expect(pushed).toMatchObject({
       prompt: 'a serene mountain landscape',
       negativePrompt: 'blurry',
@@ -147,7 +148,7 @@ describe('auditPromptServer fail-soft + enqueue contract', () => {
     ).resolves.toBeUndefined();
 
     await new Promise((r) => setImmediate(r));
-    expect(sysRedis.lPush).not.toHaveBeenCalled();
+    expect(sysRedis.rPush).not.toHaveBeenCalled();
     expect(outcomes()).not.toContain('skipped');
   });
 });
@@ -160,15 +161,17 @@ describe('enqueuePromptRescreen', () => {
     expect(outcomes()).toContain('skipped');
   });
 
-  it('caps the list via lTrim(0, MAX-1) after lPush', async () => {
+  it('caps the list via lTrim(0, MAX-1) and sets a TTL after rPush', async () => {
     enqueuePromptRescreen({ prompt: 'p', userId: 5, attempt: 0 });
     await new Promise((r) => setImmediate(r));
-    expect(sysRedis.lPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
+    expect(sysRedis.rPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
     expect(sysRedis.lTrim).toHaveBeenCalledWith(QUEUE_KEY, 0, 19999);
+    // TTL backstop so raw prompt text can't persist indefinitely (6h = 21600s).
+    expect(sysRedis.expire).toHaveBeenCalledWith(QUEUE_KEY, 21600);
   });
 
   it('swallows a redis error (best-effort, never throws/rejects)', async () => {
-    sysRedis.lPush.mockRejectedValueOnce(new Error('redis down'));
+    sysRedis.rPush.mockRejectedValueOnce(new Error('redis down'));
     expect(() => enqueuePromptRescreen({ prompt: 'p', userId: 5, attempt: 0 })).not.toThrow();
     await new Promise((r) => setImmediate(r));
     expect(logToAxiom).toHaveBeenCalledWith(
@@ -211,15 +214,44 @@ describe('processPromptRescreenQueue', () => {
     expect(outcomes()).toContain('rescreen_flagged');
   });
 
-  it('flagged on categories-only (flagged:false) still blocks (matches inline OR)', async () => {
+  it('flagged:false is treated as clean — matches the inline if(flagged) gate', async () => {
+    // In prod (EXTERNAL_MODERATION_CATEGORIES set) moderatePrompt returns
+    // flagged===categories.length>0, so flagged:false means no block. Keying off
+    // `flagged` alone (not categories) mirrors the inline path exactly and avoids a
+    // config-coupled over-block on the CSAM path.
     sysRedis.lPopCount.mockResolvedValueOnce([
       JSON.stringify({ prompt: 'bad', userId: 101, attempt: 0 }),
     ] as never);
     moderatePrompt.mockResolvedValueOnce({ flagged: false, categories: ['sexual/minors'] });
-    sysRedis.lLen.mockResolvedValue(1 as never);
 
     const r = await processPromptRescreenQueue(500);
+    expect(r.flagged).toBe(0);
+    expect(r.clean).toBe(1);
+    expect(
+      sysRedis.lPush.mock.calls.some((c) => String(c[0]).startsWith('generation:blocked-prompts'))
+    ).toBe(false);
+    expect(outcomes()).toContain('rescreen_clean');
+  });
+
+  it('flagged item whose consequence write throws is NOT re-enqueued (no auto-mute over-count)', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'bad', userId: 102, attempt: 0 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: true, categories: ['sexual/minors'] });
+    // addBlockedPrompt throws partway (e.g. transient sysRedis blip after the count push).
+    sysRedis.lLen.mockRejectedValueOnce(new Error('redis blip'));
+
+    const r = await processPromptRescreenQueue(500);
+
+    // Counted as flagged (the screen DID flag), but the consequence is best-effort:
+    // the item is NOT re-enqueued — re-running would call addBlockedPrompt again and
+    // double-count toward the mute threshold.
     expect(r.flagged).toBe(1);
+    expect(r.requeued).toBe(0);
+    expect(sysRedis.rPush.mock.calls.some((c) => c[0] === QUEUE_KEY)).toBe(false);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'prompt-rescreen-consequence-error' })
+    );
     expect(outcomes()).toContain('rescreen_flagged');
   });
 
@@ -251,9 +283,9 @@ describe('processPromptRescreenQueue', () => {
 
     expect(r.requeued).toBe(1);
     expect(r.dropped).toBe(0);
-    expect(sysRedis.lPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
+    expect(sysRedis.rPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
     const requeued = JSON.parse(
-      sysRedis.lPush.mock.calls.find((c) => c[0] === QUEUE_KEY)![1] as string
+      sysRedis.rPush.mock.calls.find((c) => c[0] === QUEUE_KEY)![1] as string
     );
     expect(requeued.attempt).toBe(2);
     expect(outcomes()).toContain('rescreen_requeued');
@@ -271,7 +303,7 @@ describe('processPromptRescreenQueue', () => {
     expect(r.dropped).toBe(1);
     expect(r.requeued).toBe(0);
     // NOT re-enqueued
-    expect(sysRedis.lPush.mock.calls.some((c) => c[0] === QUEUE_KEY)).toBe(false);
+    expect(sysRedis.rPush.mock.calls.some((c) => c[0] === QUEUE_KEY)).toBe(false);
     expect(logToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'prompt-rescreen-dropped' })
     );

--- a/src/server/services/orchestrator/__tests__/promptAuditing-rescreen.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing-rescreen.test.ts
@@ -57,7 +57,20 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { promptAllowlist: { findMany: vi.fn(async () => []) } },
   dbWrite: { userRestriction: { create: userRestrictionCreate } },
 }));
-vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+// Tracker: capture the actor passed to the constructor + the prohibitedRequest write
+// so Fix M2 (per-user audit row) can be asserted. clickhouse stays null (seed path).
+const prohibitedRequest = vi.hoisted(() => vi.fn(async () => undefined));
+const trackerCtor = vi.hoisted(() => vi.fn());
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: null,
+  Tracker: class {
+    prohibitedRequest = prohibitedRequest;
+    userActivity = vi.fn(async () => undefined);
+    constructor(...args: unknown[]) {
+      trackerCtor(...args);
+    }
+  },
+}));
 const updateUserById = vi.hoisted(() => vi.fn(async () => undefined));
 vi.mock('~/server/services/user.service', () => ({ updateUserById }));
 vi.mock('~/server/services/notification.service', () => ({
@@ -331,5 +344,140 @@ describe('processPromptRescreenQueue', () => {
     expect(logToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'prompt-rescreen-pop-error' })
     );
+  });
+
+  // --- Fix M2: deferred flag writes the ClickHouse prohibitedRequests audit row ---
+  it('flagged item builds a per-user Tracker and writes the prohibitedRequests row', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'bad', userId: 100, isModerator: false, attempt: 0 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: true, categories: ['sexual/minors'] });
+    sysRedis.exists.mockResolvedValue(1 as never);
+    sysRedis.lRange.mockResolvedValue([] as never);
+    sysRedis.lLen.mockResolvedValue(1 as never);
+
+    await processPromptRescreenQueue(500);
+
+    // Tracker constructed with the userId-bearing session (3rd ctor arg → actor.userId)
+    expect(trackerCtor).toHaveBeenCalledWith(undefined, undefined, { user: { id: 100 } });
+    // and the audit-row write fired through that tracker
+    expect(prohibitedRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'bad', source: 'External-Deferred' })
+    );
+  });
+
+  it('does NOT write the audit row when the item is clean', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'good', userId: 201, attempt: 0 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: false, categories: [] });
+
+    await processPromptRescreenQueue(500);
+
+    expect(trackerCtor).not.toHaveBeenCalled();
+    expect(prohibitedRequest).not.toHaveBeenCalled();
+  });
+
+  // --- Fix m1: requeue at cap is actually a drop ---
+  it('requeue at the queue cap counts rescreen_dropped (lTrim evicts the pushed item)', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'p', userId: 300, attempt: 1 }),
+    ] as never);
+    moderatePrompt.mockRejectedValueOnce(new Error('still 503'));
+    // rPush returns a length > RESCREEN_QUEUE_MAX (20000) → the pushed tail was evicted.
+    sysRedis.rPush.mockResolvedValueOnce(20001 as never);
+
+    const r = await processPromptRescreenQueue(500);
+
+    expect(r.dropped).toBe(1);
+    expect(r.requeued).toBe(0);
+    expect(outcomes()).toContain('rescreen_dropped');
+    expect(outcomes()).not.toContain('rescreen_requeued');
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'prompt-rescreen-dropped' })
+    );
+  });
+
+  it('requeue under the cap (rPush length <= MAX) still counts rescreen_requeued', async () => {
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'p', userId: 301, attempt: 1 }),
+    ] as never);
+    moderatePrompt.mockRejectedValueOnce(new Error('still 503'));
+    sysRedis.rPush.mockResolvedValueOnce(5 as never); // well under cap
+
+    const r = await processPromptRescreenQueue(500);
+
+    expect(r.requeued).toBe(1);
+    expect(r.dropped).toBe(0);
+    expect(outcomes()).toContain('rescreen_requeued');
+  });
+
+  // --- Fix M1: wall-clock deadline re-enqueues the unprocessed remainder ---
+  it('hitting the run deadline re-enqueues the remainder (attempt preserved) and stops', async () => {
+    // Two items. Mock Date.now so: startedAt=0, loop-check item0=0 (under deadline,
+    // processed), loop-check item1=300000 (> 240000 deadline → re-enqueue remainder).
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy
+      .mockReturnValueOnce(0) // startedAt
+      .mockReturnValueOnce(0) // item 0 deadline check
+      .mockReturnValue(300_000); // item 1 deadline check + any later calls
+
+    sysRedis.lPopCount.mockResolvedValueOnce([
+      JSON.stringify({ prompt: 'first', userId: 1, attempt: 2 }),
+      JSON.stringify({ prompt: 'second', userId: 2, attempt: 3 }),
+    ] as never);
+    moderatePrompt.mockResolvedValueOnce({ flagged: false, categories: [] }); // item 0 clean
+    sysRedis.rPush.mockResolvedValue(1 as never); // re-enqueue under cap
+
+    const r = await processPromptRescreenQueue(500);
+
+    // item 0 processed clean; item 1 NOT processed, re-enqueued instead
+    expect(r.processed).toBe(1);
+    expect(r.clean).toBe(1);
+    expect(r.requeued).toBe(1);
+    expect(moderatePrompt).toHaveBeenCalledTimes(1); // item 1 never screened
+
+    // the remainder was pushed back VERBATIM (attempt unchanged — a deadline is not a failure)
+    const requeued = JSON.parse(
+      sysRedis.rPush.mock.calls.find((c) => c[0] === QUEUE_KEY)![1] as string
+    );
+    expect(requeued).toMatchObject({ prompt: 'second', userId: 2, attempt: 3 });
+    expect(outcomes()).toContain('rescreen_requeued');
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'prompt-rescreen-deadline' })
+    );
+
+    nowSpy.mockRestore();
+  });
+});
+
+// --- Fix m3: env kill-switch (default ON) ------------------------------------
+describe('EXTERNAL_MODERATION_RESCREEN_ENABLED kill-switch', () => {
+  const original = process.env.EXTERNAL_MODERATION_RESCREEN_ENABLED;
+  afterEach(() => {
+    if (original === undefined) delete process.env.EXTERNAL_MODERATION_RESCREEN_ENABLED;
+    else process.env.EXTERNAL_MODERATION_RESCREEN_ENABLED = original;
+  });
+
+  it('enqueue does NOT push when disabled, but still records the skip metric', async () => {
+    process.env.EXTERNAL_MODERATION_RESCREEN_ENABLED = 'false';
+    enqueuePromptRescreen({ prompt: 'p', userId: 5, attempt: 0 });
+    await new Promise((r) => setImmediate(r));
+    expect(sysRedis.rPush).not.toHaveBeenCalled();
+    expect(outcomes()).toContain('skipped');
+  });
+
+  it('drain returns empty WITHOUT popping when disabled', async () => {
+    process.env.EXTERNAL_MODERATION_RESCREEN_ENABLED = '0';
+    const r = await processPromptRescreenQueue(500);
+    expect(r).toEqual({ processed: 0, flagged: 0, clean: 0, requeued: 0, dropped: 0 });
+    expect(sysRedis.lPopCount).not.toHaveBeenCalled();
+  });
+
+  it('still enqueues when set to a non-off token (e.g. "yes")', async () => {
+    process.env.EXTERNAL_MODERATION_RESCREEN_ENABLED = 'yes';
+    enqueuePromptRescreen({ prompt: 'p', userId: 5, attempt: 0 });
+    await new Promise((r) => setImmediate(r));
+    expect(sysRedis.rPush).toHaveBeenCalledWith(QUEUE_KEY, expect.any(String));
   });
 });

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -216,10 +216,18 @@ function filterAllowlistedTriggers(
 // is a best-effort SECONDARY safety net layered on top of the primary regex audit, not
 // the primary CSAM gate.
 const RESCREEN_QUEUE_KEY = REDIS_SYS_KEYS.GENERATION.MODERATION_RESCREEN_QUEUE;
-// Hard cap on the queue length so a prolonged OpenAI outage can never grow it
-// unbounded. lPush adds to the head (newest); lTrim(0, MAX-1) keeps the newest MAX
-// and evicts the oldest tail.
+// FIFO queue: enqueue with rPush (append to tail), drain with lPopCount from the
+// head — so the OLDEST skipped prompts are re-screened first (clear the backlog in
+// order). Hard cap so a prolonged OpenAI outage can never grow it unbounded:
+// lTrim(0, MAX-1) keeps the oldest MAX (the head) and evicts the NEWEST tail — and
+// during an active outage the live path keeps enqueuing newest, so evicting newest
+// loses the least (it'll be re-enqueued by ongoing traffic; the backlog we're
+// draining is preserved).
 const RESCREEN_QUEUE_MAX = 20000;
+// TTL backstop so raw prompt text can never persist indefinitely in sysRedis if the
+// drain cron stops (job-runner outage / orphaned key). Drained items are gone in
+// minutes; this only bounds the worst case. Re-applied on every push.
+const RESCREEN_QUEUE_TTL_SECONDS = 60 * 60 * 6; // 6h
 // Max times an item is re-screened before it is dropped (OpenAI persistently down).
 const RESCREEN_MAX_ATTEMPTS = 5;
 // Drop the consequence-source label distinct from inline 'External' so a deferred
@@ -255,8 +263,9 @@ export function enqueuePromptRescreen(payload: PromptRescreenPayload): void {
   // explicitly caught so it can never become an unhandledRejection.
   void (async () => {
     try {
-      await sysRedis.lPush(RESCREEN_QUEUE_KEY, JSON.stringify(payload));
+      await sysRedis.rPush(RESCREEN_QUEUE_KEY, JSON.stringify(payload));
       await sysRedis.lTrim(RESCREEN_QUEUE_KEY, 0, RESCREEN_QUEUE_MAX - 1);
+      await sysRedis.expire(RESCREEN_QUEUE_KEY, RESCREEN_QUEUE_TTL_SECONDS);
     } catch (error) {
       logToAxiom({
         name: 'prompt-rescreen-enqueue-error',
@@ -283,7 +292,7 @@ export async function processPromptRescreenQueue(
 
   let raw: string[] | null = null;
   try {
-    // LPOP COUNT — pops from the head (newest-first; FIFO-ish is acceptable per spec).
+    // LPOP COUNT from the head — with rPush enqueue this is FIFO (oldest first).
     raw = await sysRedis.lPopCount(RESCREEN_QUEUE_KEY, batchSize);
   } catch (error) {
     logToAxiom({
@@ -325,17 +334,29 @@ export async function processPromptRescreenQueue(
     try {
       const { flagged, categories } = await extModeration.moderatePrompt(prompt);
 
-      // Match the inline decision: inline treats ANY returned category as a block
-      // trigger (and `flagged` is set by the same path). Re-use the same OR so the
-      // deferred block fires under exactly the inline conditions.
-      if (flagged || (categories && categories.length > 0)) {
+      // Match the inline decision EXACTLY: inline blocks on `if (flagged)`. In the
+      // prod config (EXTERNAL_MODERATION_CATEGORIES set) `flagged === categories.length>0`,
+      // so this also covers the category path — but keying off `flagged` alone avoids a
+      // config-coupled divergence where the deferred path could over-block.
+      if (flagged) {
+        // Count the screen result FIRST — the screen succeeded and DID flag.
+        summary.flagged++;
+        externalModerationOutcomeCounter.inc({ outcome: 'rescreen_flagged' });
+
+        // Apply the consequence BEST-EFFORT — log on failure, do NOT re-enqueue. The
+        // screen already determined this prompt is flagged; re-running it would call
+        // addBlockedPrompt AGAIN and double-count toward the auto-mute threshold (could
+        // wrongly mute a user on a transient Redis blip). A consequence write that fails
+        // here is dropped: the generation already happened and the local regex audit +
+        // Hive image-CSAM layers still apply. Only a re-SCREEN failure (OpenAI still
+        // down, the catch below) is re-enqueued — that path hasn't counted anything yet.
         try {
           const blockedEntry: BlockedPromptEntry = {
             prompt: prompt ?? '',
             negativePrompt: negativePrompt ?? '',
             source: RESCREEN_SOURCE,
             category: 'external' as PromptTriggerCategory,
-            matchedWord: categories[0],
+            matchedWord: categories?.[0],
             imageId: imageId ?? null,
             remixOfId: remixOfId ?? null,
             time: new Date().toISOString(),
@@ -355,22 +376,21 @@ export async function processPromptRescreenQueue(
             count,
             remixOfId,
           });
-
-          summary.flagged++;
-          externalModerationOutcomeCounter.inc({ outcome: 'rescreen_flagged' });
         } catch (consequenceError) {
-          // The consequence side-effect failed (Redis/DB). Don't lose the item — the
-          // generation already happened and this is the only recovery path. Treat like
-          // a transient failure: re-enqueue (subject to the cap) so a later run retries
-          // the consequence.
-          await requeueOrDrop(payload, summary, consequenceError);
+          logToAxiom({
+            name: 'prompt-rescreen-consequence-error',
+            type: 'error',
+            message: (consequenceError as Error)?.message ?? 'unknown',
+            details: { userId },
+          });
         }
       } else {
         summary.clean++;
         externalModerationOutcomeCounter.inc({ outcome: 'rescreen_clean' });
       }
     } catch (screenError) {
-      // moderatePrompt threw again — OpenAI still unavailable.
+      // moderatePrompt threw again — OpenAI still unavailable. Re-enqueue: nothing has
+      // been counted for this item yet, so a retry can't over-count.
       await requeueOrDrop(payload, summary, screenError);
     }
   }
@@ -390,11 +410,12 @@ async function requeueOrDrop(
   const nextAttempt = (payload.attempt ?? 0) + 1;
   if (nextAttempt < RESCREEN_MAX_ATTEMPTS) {
     try {
-      await sysRedis.lPush(
+      await sysRedis.rPush(
         RESCREEN_QUEUE_KEY,
         JSON.stringify({ ...payload, attempt: nextAttempt })
       );
       await sysRedis.lTrim(RESCREEN_QUEUE_KEY, 0, RESCREEN_QUEUE_MAX - 1);
+      await sysRedis.expire(RESCREEN_QUEUE_KEY, RESCREEN_QUEUE_TTL_SECONDS);
       summary.requeued++;
       externalModerationOutcomeCounter.inc({ outcome: 'rescreen_requeued' });
     } catch (requeueError) {

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -14,6 +14,7 @@ import {
   type PromptTriggerCategory,
 } from '~/utils/metadata/audit';
 import { refreshSession } from '~/server/auth/session-invalidation';
+import { externalModerationOutcomeCounter } from '~/server/prom/client';
 
 // --- Blocked Prompt Store ---
 // Single Redis list stores both count (list length) and prompt data.
@@ -200,6 +201,229 @@ function filterAllowlistedTriggers(
   });
 }
 
+// --- Deferred External-Moderation Re-Screen Queue ---
+// The inline external moderation call (OpenAI omni-moderation) is FAIL-SOFT: when
+// OpenAI is slow/down (intermittent 503/504 + >5s windows) the prompt's CSAM
+// pre-screen is silently skipped on the hot path and never recovered. This queue
+// captures those skips so the `rescreen-skipped-prompt-moderation` cron can re-screen
+// them when OpenAI recovers and apply the SAME consequence as the inline path
+// (mute escalation + audit record) — just delayed.
+//
+// Durability caveat: this rides on sysRedis (the same instance the blocked-prompt
+// store uses). It is NOT a guaranteed-delivery broker — a sysRedis wipe loses pending
+// items, and the cap below (FIFO eviction of the OLDEST unprocessed entries) can drop
+// items under a sustained OpenAI outage that outpaces drain. Both are acceptable: this
+// is a best-effort SECONDARY safety net layered on top of the primary regex audit, not
+// the primary CSAM gate.
+const RESCREEN_QUEUE_KEY = REDIS_SYS_KEYS.GENERATION.MODERATION_RESCREEN_QUEUE;
+// Hard cap on the queue length so a prolonged OpenAI outage can never grow it
+// unbounded. lPush adds to the head (newest); lTrim(0, MAX-1) keeps the newest MAX
+// and evicts the oldest tail.
+const RESCREEN_QUEUE_MAX = 20000;
+// Max times an item is re-screened before it is dropped (OpenAI persistently down).
+const RESCREEN_MAX_ATTEMPTS = 5;
+// Drop the consequence-source label distinct from inline 'External' so a deferred
+// block is traceable in ClickHouse / UserRestriction triggers while remaining an
+// external-category block (semantics identical to inline external).
+const RESCREEN_SOURCE = 'External-Deferred';
+
+export interface PromptRescreenPayload {
+  prompt: string;
+  negativePrompt?: string;
+  userId: number;
+  isModerator?: boolean;
+  remixOfId?: number;
+  imageId?: number;
+  attempt: number;
+}
+
+/**
+ * Best-effort enqueue of a prompt whose inline external moderation was skipped
+ * (the OpenAI call failed/timed-out). FIRE-AND-FORGET: never throws, never blocks
+ * the caller — the generation hot path must be unaffected. Caps the queue length so
+ * it can never grow unbounded.
+ */
+export function enqueuePromptRescreen(payload: PromptRescreenPayload): void {
+  // Increment the metric eagerly (synchronous, cannot throw meaningfully) so the
+  // skip is observable even if the async push below fails.
+  try {
+    externalModerationOutcomeCounter.inc({ outcome: 'skipped' });
+  } catch {
+    // metrics are best-effort
+  }
+  // Fire-and-forget: do not await, swallow all errors. A rejected promise here is
+  // explicitly caught so it can never become an unhandledRejection.
+  void (async () => {
+    try {
+      await sysRedis.lPush(RESCREEN_QUEUE_KEY, JSON.stringify(payload));
+      await sysRedis.lTrim(RESCREEN_QUEUE_KEY, 0, RESCREEN_QUEUE_MAX - 1);
+    } catch (error) {
+      logToAxiom({
+        name: 'prompt-rescreen-enqueue-error',
+        type: 'error',
+        message: (error as Error)?.message ?? 'unknown',
+      });
+    }
+  })();
+}
+
+/**
+ * Drain up to `batchSize` skipped-prompt items from the queue and re-screen each one
+ * against the external moderation service. Applies the SAME consequence as the inline
+ * path on a flag (addBlockedPrompt → reportProhibitedRequest); re-enqueues (up to the
+ * attempt cap) on a transient re-screen failure; drops + logs at the cap.
+ *
+ * NEVER throws out of the whole function — a single bad item can't abort the batch.
+ * Returns a summary suitable for the job's return value.
+ */
+export async function processPromptRescreenQueue(
+  batchSize = 500
+): Promise<{ processed: number; flagged: number; clean: number; requeued: number; dropped: number }> {
+  const summary = { processed: 0, flagged: 0, clean: 0, requeued: 0, dropped: 0 };
+
+  let raw: string[] | null = null;
+  try {
+    // LPOP COUNT — pops from the head (newest-first; FIFO-ish is acceptable per spec).
+    raw = await sysRedis.lPopCount(RESCREEN_QUEUE_KEY, batchSize);
+  } catch (error) {
+    logToAxiom({
+      name: 'prompt-rescreen-pop-error',
+      type: 'error',
+      message: (error as Error)?.message ?? 'unknown',
+    });
+    return summary;
+  }
+
+  if (!raw || raw.length === 0) return summary;
+
+  for (const item of raw) {
+    summary.processed++;
+
+    let payload: PromptRescreenPayload;
+    try {
+      payload = JSON.parse(item) as PromptRescreenPayload;
+    } catch {
+      // Unparseable entry — drop it (cannot re-enqueue something we can't read).
+      summary.dropped++;
+      try {
+        externalModerationOutcomeCounter.inc({ outcome: 'rescreen_dropped' });
+      } catch {}
+      continue;
+    }
+
+    const { prompt, negativePrompt, userId, isModerator, remixOfId, imageId, attempt } = payload;
+
+    // Defensive: a malformed payload with no prompt/userId can't be screened.
+    if (!prompt || typeof userId !== 'number') {
+      summary.dropped++;
+      try {
+        externalModerationOutcomeCounter.inc({ outcome: 'rescreen_dropped' });
+      } catch {}
+      continue;
+    }
+
+    try {
+      const { flagged, categories } = await extModeration.moderatePrompt(prompt);
+
+      // Match the inline decision: inline treats ANY returned category as a block
+      // trigger (and `flagged` is set by the same path). Re-use the same OR so the
+      // deferred block fires under exactly the inline conditions.
+      if (flagged || (categories && categories.length > 0)) {
+        try {
+          const blockedEntry: BlockedPromptEntry = {
+            prompt: prompt ?? '',
+            negativePrompt: negativePrompt ?? '',
+            source: RESCREEN_SOURCE,
+            category: 'external' as PromptTriggerCategory,
+            matchedWord: categories[0],
+            imageId: imageId ?? null,
+            remixOfId: remixOfId ?? null,
+            time: new Date().toISOString(),
+          };
+
+          const count = await addBlockedPrompt(userId, blockedEntry);
+
+          // No `track` — the job has no request/tracker context. reportProhibitedRequest
+          // tolerates a missing track (ClickHouse audit-track is skipped; the mute
+          // escalation still runs off the Redis count).
+          await reportProhibitedRequest({
+            prompt,
+            negativePrompt,
+            userId,
+            isModerator,
+            source: RESCREEN_SOURCE,
+            count,
+            remixOfId,
+          });
+
+          summary.flagged++;
+          externalModerationOutcomeCounter.inc({ outcome: 'rescreen_flagged' });
+        } catch (consequenceError) {
+          // The consequence side-effect failed (Redis/DB). Don't lose the item — the
+          // generation already happened and this is the only recovery path. Treat like
+          // a transient failure: re-enqueue (subject to the cap) so a later run retries
+          // the consequence.
+          await requeueOrDrop(payload, summary, consequenceError);
+        }
+      } else {
+        summary.clean++;
+        externalModerationOutcomeCounter.inc({ outcome: 'rescreen_clean' });
+      }
+    } catch (screenError) {
+      // moderatePrompt threw again — OpenAI still unavailable.
+      await requeueOrDrop(payload, summary, screenError);
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * Re-enqueue an item with attempt+1 if under the cap, else drop it (+log). Never
+ * throws — used inside the per-item loop above.
+ */
+async function requeueOrDrop(
+  payload: PromptRescreenPayload,
+  summary: { requeued: number; dropped: number },
+  error: unknown
+): Promise<void> {
+  const nextAttempt = (payload.attempt ?? 0) + 1;
+  if (nextAttempt < RESCREEN_MAX_ATTEMPTS) {
+    try {
+      await sysRedis.lPush(
+        RESCREEN_QUEUE_KEY,
+        JSON.stringify({ ...payload, attempt: nextAttempt })
+      );
+      await sysRedis.lTrim(RESCREEN_QUEUE_KEY, 0, RESCREEN_QUEUE_MAX - 1);
+      summary.requeued++;
+      externalModerationOutcomeCounter.inc({ outcome: 'rescreen_requeued' });
+    } catch (requeueError) {
+      // Even the re-enqueue failed — count it as dropped so the metric balances.
+      summary.dropped++;
+      try {
+        externalModerationOutcomeCounter.inc({ outcome: 'rescreen_dropped' });
+      } catch {}
+      logToAxiom({
+        name: 'prompt-rescreen-requeue-error',
+        type: 'error',
+        message: (requeueError as Error)?.message ?? 'unknown',
+        details: { userId: payload.userId },
+      });
+    }
+  } else {
+    summary.dropped++;
+    try {
+      externalModerationOutcomeCounter.inc({ outcome: 'rescreen_dropped' });
+    } catch {}
+    logToAxiom({
+      name: 'prompt-rescreen-dropped',
+      type: 'warning',
+      message: `dropped after ${nextAttempt} attempts: ${(error as Error)?.message ?? 'unknown'}`,
+      details: { userId: payload.userId, attempts: nextAttempt },
+    });
+  }
+}
+
 export interface AuditPromptOptions {
   prompt: string;
   negativePrompt?: string;
@@ -260,6 +484,18 @@ export async function auditPromptServer(options: AuditPromptOptions): Promise<vo
     // Run external moderation service
     const { flagged, categories } = await extModeration.moderatePrompt(prompt).catch((error) => {
       logToAxiom({ name: 'external-moderation-error', type: 'error', message: error.message });
+      // The inline external CSAM pre-screen was skipped (OpenAI slow/down). Enqueue the
+      // prompt for deferred re-screen so the consequence is recovered when OpenAI is
+      // healthy again. Fire-and-forget — never throws, never blocks; fail-soft preserved.
+      enqueuePromptRescreen({
+        prompt,
+        negativePrompt,
+        userId,
+        isModerator,
+        remixOfId,
+        imageId,
+        attempt: 0,
+      });
       return { flagged: false, categories: [] as string[] };
     });
 

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -15,6 +15,7 @@ import {
 } from '~/utils/metadata/audit';
 import { refreshSession } from '~/server/auth/session-invalidation';
 import { externalModerationOutcomeCounter } from '~/server/prom/client';
+import { Tracker } from '~/server/clickhouse/client';
 
 // --- Blocked Prompt Store ---
 // Single Redis list stores both count (list length) and prompt data.
@@ -234,6 +235,26 @@ const RESCREEN_MAX_ATTEMPTS = 5;
 // block is traceable in ClickHouse / UserRestriction triggers while remaining an
 // external-category block (semantics identical to inline external).
 const RESCREEN_SOURCE = 'External-Deferred';
+// Per-run wall-clock budget. The job lock (createJob) expires at 300s; each
+// moderatePrompt call can take up to EXTERNAL_MODERATION_TIMEOUT_MS (~5s). The
+// drain must finish comfortably under the lock or a second runner could start
+// while this one is still draining → concurrent drains stack + an OpenAI
+// thundering herd. INVARIANT: batchSize × EXTERNAL_MODERATION_TIMEOUT_MS <
+// lockExpiration(300s); RESCREEN_BATCH_SIZE (100) keeps the typical run well
+// inside that, and this deadline is the HARD backstop for the worst case
+// (every call hits the full timeout). On deadline we re-enqueue the untouched
+// remainder and stop — a deadline is NOT a per-item failure (attempt is left
+// unchanged, the drop cap is not consumed).
+const RESCREEN_MAX_RUN_MS = 240000; // 4 min, comfortably under the 300s lock.
+// Default-ON kill-switch: only an EXPLICIT falsy token disables, so an operator
+// can stop the deferred re-screen path without a deploy. Mirrors the envDisabled
+// pattern in src/server/logging/trpc-slow-log.ts.
+function rescreenDisabled(): boolean {
+  const raw = process.env.EXTERNAL_MODERATION_RESCREEN_ENABLED;
+  if (raw == null || raw === '') return false; // unset → enabled
+  const v = raw.trim().toLowerCase();
+  return v === 'false' || v === '0' || v === 'no' || v === 'off';
+}
 
 export interface PromptRescreenPayload {
   prompt: string;
@@ -259,6 +280,9 @@ export function enqueuePromptRescreen(payload: PromptRescreenPayload): void {
   } catch {
     // metrics are best-effort
   }
+  // Kill-switch: when disabled we still recorded the `skipped` metric above (the
+  // inline skip happened regardless), we just don't enqueue for deferred re-screen.
+  if (rescreenDisabled()) return;
   // Fire-and-forget: do not await, swallow all errors. A rejected promise here is
   // explicitly caught so it can never become an unhandledRejection.
   void (async () => {
@@ -283,12 +307,20 @@ export function enqueuePromptRescreen(payload: PromptRescreenPayload): void {
  * attempt cap) on a transient re-screen failure; drops + logs at the cap.
  *
  * NEVER throws out of the whole function — a single bad item can't abort the batch.
+ * Bounded by RESCREEN_MAX_RUN_MS: on deadline the unprocessed remainder is
+ * re-enqueued (attempt preserved) so a long run can't exceed the job lock.
  * Returns a summary suitable for the job's return value.
  */
 export async function processPromptRescreenQueue(
-  batchSize = 500
+  batchSize = 100
 ): Promise<{ processed: number; flagged: number; clean: number; requeued: number; dropped: number }> {
   const summary = { processed: 0, flagged: 0, clean: 0, requeued: 0, dropped: 0 };
+
+  // Kill-switch: return the empty summary WITHOUT popping so disabling the path
+  // leaves the queue untouched (items remain, TTL-bounded, drained when re-enabled).
+  if (rescreenDisabled()) return summary;
+
+  const startedAt = Date.now();
 
   let raw: string[] | null = null;
   try {
@@ -305,7 +337,52 @@ export async function processPromptRescreenQueue(
 
   if (!raw || raw.length === 0) return summary;
 
-  for (const item of raw) {
+  for (let i = 0; i < raw.length; i++) {
+    // Wall-clock backstop (Fix M1): processPromptRescreenQueue already lPopCount'd
+    // the WHOLE batch out of Redis up front, so stopping mid-run must RE-ENQUEUE the
+    // unprocessed remainder or those items are silently lost. A deadline is NOT a
+    // failure — preserve each item's CURRENT attempt (don't increment, don't consume
+    // the drop cap), count them as `requeued`, then break.
+    if (Date.now() - startedAt > RESCREEN_MAX_RUN_MS) {
+      const remaining = raw.slice(i);
+      try {
+        for (const leftover of remaining) {
+          await sysRedis.rPush(RESCREEN_QUEUE_KEY, leftover);
+        }
+        await sysRedis.lTrim(RESCREEN_QUEUE_KEY, 0, RESCREEN_QUEUE_MAX - 1);
+        await sysRedis.expire(RESCREEN_QUEUE_KEY, RESCREEN_QUEUE_TTL_SECONDS);
+        summary.requeued += remaining.length;
+        for (let n = 0; n < remaining.length; n++) {
+          try {
+            externalModerationOutcomeCounter.inc({ outcome: 'rescreen_requeued' });
+          } catch {}
+        }
+      } catch (requeueError) {
+        // The remainder couldn't be put back — count it as dropped so the metric
+        // balances rather than silently vanishing.
+        summary.dropped += remaining.length;
+        for (let n = 0; n < remaining.length; n++) {
+          try {
+            externalModerationOutcomeCounter.inc({ outcome: 'rescreen_dropped' });
+          } catch {}
+        }
+        logToAxiom({
+          name: 'prompt-rescreen-requeue-error',
+          type: 'error',
+          message: (requeueError as Error)?.message ?? 'unknown',
+          details: { remaining: remaining.length },
+        });
+      }
+      logToAxiom({
+        name: 'prompt-rescreen-deadline',
+        type: 'warning',
+        message: `run hit ${RESCREEN_MAX_RUN_MS}ms deadline; re-enqueued remainder`,
+        details: { remaining: remaining.length },
+      });
+      break;
+    }
+
+    const item = raw[i];
     summary.processed++;
 
     let payload: PromptRescreenPayload;
@@ -364,14 +441,21 @@ export async function processPromptRescreenQueue(
 
           const count = await addBlockedPrompt(userId, blockedEntry);
 
-          // No `track` — the job has no request/tracker context. reportProhibitedRequest
-          // tolerates a missing track (ClickHouse audit-track is skipped; the mute
-          // escalation still runs off the Redis count).
+          // Build a standalone per-user Tracker (Fix M2): the job has no request
+          // context, but passing a session with the userId sets actor.userId so
+          // reportProhibitedRequest's `if (track) track.prohibitedRequest(...)` fires
+          // and writes the ClickHouse `prohibitedRequests` audit row for the REAL user.
+          // Without it the deferred CSAM block left no audit trail AND the mute count
+          // vanished on a Redis re-seed (the seed reads `prohibitedRequests`). Precedent:
+          // src/server/jobs/entity-moderation.ts builds standalone Trackers.
+          const track = new Tracker(undefined, undefined, { user: { id: userId } } as never);
+
           await reportProhibitedRequest({
             prompt,
             negativePrompt,
             userId,
             isModerator,
+            track,
             source: RESCREEN_SOURCE,
             count,
             remixOfId,
@@ -410,14 +494,33 @@ async function requeueOrDrop(
   const nextAttempt = (payload.attempt ?? 0) + 1;
   if (nextAttempt < RESCREEN_MAX_ATTEMPTS) {
     try {
-      await sysRedis.rPush(
+      // Capture the post-push list length (Fix m1 — metric honesty): rPush appends to
+      // the tail, then lTrim(0, MAX-1) keeps the head and evicts the tail. When the
+      // queue is already at cap the just-pushed item IS the evicted tail — so this is
+      // really a DROP, not a re-enqueue. Detect it via newLength > MAX and label it
+      // honestly instead of reporting a phantom requeue.
+      const newLength = await sysRedis.rPush(
         RESCREEN_QUEUE_KEY,
         JSON.stringify({ ...payload, attempt: nextAttempt })
       );
       await sysRedis.lTrim(RESCREEN_QUEUE_KEY, 0, RESCREEN_QUEUE_MAX - 1);
       await sysRedis.expire(RESCREEN_QUEUE_KEY, RESCREEN_QUEUE_TTL_SECONDS);
-      summary.requeued++;
-      externalModerationOutcomeCounter.inc({ outcome: 'rescreen_requeued' });
+      if (typeof newLength === 'number' && newLength > RESCREEN_QUEUE_MAX) {
+        // Queue at cap — the lTrim evicted the item we just pushed. It's a drop.
+        summary.dropped++;
+        try {
+          externalModerationOutcomeCounter.inc({ outcome: 'rescreen_dropped' });
+        } catch {}
+        logToAxiom({
+          name: 'prompt-rescreen-dropped',
+          type: 'warning',
+          message: 'dropped at queue cap (evicted by lTrim after rPush)',
+          details: { userId: payload.userId, attempts: nextAttempt },
+        });
+      } else {
+        summary.requeued++;
+        externalModerationOutcomeCounter.inc({ outcome: 'rescreen_requeued' });
+      }
     } catch (requeueError) {
       // Even the re-enqueue failed — count it as dropped so the metric balances.
       summary.dropped++;


### PR DESCRIPTION
## Why

The external-moderation call (OpenAI `omni-moderation-latest`, blocks `sexual/minors` = CSAM) runs inline on every generation submit and is **fail-soft**. #2734 bounded its latency with a 5s timeout — but a fail-soft skip means that prompt's **CSAM pre-screen is silently dropped and never recovered** when OpenAI is degraded (it has intermittent 503/504 + >5s windows; confirmed live). That gap was also unalerted.

This makes prompt moderation **eventually-consistent** instead of fail-open: skipped prompts are queued and re-screened when OpenAI recovers, applying the **same consequence** as the inline path (blocked-prompt count → mute escalation + audit record), just delayed.

## How

- **Enqueue on skip** (`promptAuditing.ts`): the inline `.catch` (where OpenAI failed) now also fires a **fire-and-forget** `enqueuePromptRescreen(...)` — `lPush` to a sysRedis queue + `lTrim` cap (20k). Never throws, never blocks; `auditPromptServer` still returns `{flagged:false}` and generation proceeds (fail-soft preserved). This is the only hot-path change.
- **Drain + re-screen** (`processPromptRescreenQueue`, drained by new cron `rescreen-skipped-prompt-moderation` every 5 min, batch 500): re-calls `extModeration.moderatePrompt`; on flag → `addBlockedPrompt` + `reportProhibitedRequest` (same private fns the inline path uses; `track` omitted — the job has no request ctx, which only skips the CH audit-track line, mute still runs); on re-screen failure → re-enqueue with `attempt+1` up to 5, then drop + log (`prompt-rescreen-dropped`). Per-item try/catch; never throws out of the batch.
- **Metric**: `civitai_app_external_moderation_outcome_total{outcome}` — `skipped` / `rescreen_clean` / `rescreen_flagged` / `rescreen_requeued` / `rescreen_dropped`. (A datapacket alert on `skipped` rate + `rescreen_dropped` is the companion change.)

## Layering / scope

This is a **best-effort secondary net**, not the primary CSAM gate. The **local regex audit still runs first and gates every prompt**, and **generated images get Hive CSAM at upload** regardless. This recovers the *ML prompt pre-screen* that fail-soft drops during an OpenAI outage.

## Tests
13 unit tests (`promptAuditing-rescreen.test.ts`): fail-soft preserved + enqueue-on-failure (attempt:0); flagged item applies consequence; clean item doesn't; re-screen-throws → requeue with attempt+1; attempt-cap → drop+log; queue cap (`lTrim`) invoked; never throws on a bad item; metric outcomes increment. tsc clean on changed files.

## Notes for review (flagged for the audit)
- **Durability**: rides sysRedis (same instance as the blocked-prompt store), not a guaranteed broker — a sysRedis wipe loses pending items, and under a sustained outage outpacing drain (~6k/hr) the 20k cap evicts the **oldest** entries. Acceptable for a secondary net; raise batch/frequency or use a real queue if stronger guarantees are wanted.
- **Drain order**: `lPush`+`lPopCount` is LIFO (newest re-screened first); combined with oldest-eviction, stale items can be dropped under overload. Intentional-ish (recent abuse first) but worth a conscious call.
- **Consequence-retry double-count edge**: if `addBlockedPrompt` succeeds but `reportProhibitedRequest` throws, the whole item is re-enqueued → a later run re-runs `addBlockedPrompt` → could count the same prompt twice toward mute (narrow window, stricter direction). Could split screen-retry from consequence-retry if we want exactness.
- `source: 'External-Deferred'` (distinct from inline `'External'`) for traceability; same `category:'external'` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)