### PR TITLE
fix(moderation): harden audit recall + over-length evasion + env clamp (follow-up #2727/#2734)

### DIFF
--- a/src/env/__tests__/server-schema-moderation-timeout.test.ts
+++ b/src/env/__tests__/server-schema-moderation-timeout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { serverSchema } from '~/env/server-schema';
+
+// #2734 — bound the EXTERNAL_MODERATION_TIMEOUT_MS knob.
+// Before: z.coerce.number().int().positive().catch(5000) — no upper bound, so
+// `=1e10` → ~116-day timeout (re-introduces the unbounded park) and tiny values
+// abort before moderation can respond (silently skip moderation).
+// After:  .int().min(100).max(60000).catch(5000) — any out-of-range/garbage/empty
+// value falls back to 5000; valid in-range values pass through.
+const field = serverSchema.shape.EXTERNAL_MODERATION_TIMEOUT_MS;
+
+describe('EXTERNAL_MODERATION_TIMEOUT_MS env clamp', () => {
+  it('falls back to 5000 for empty/garbage/out-of-range values', () => {
+    for (const bad of ['', '0', '-1', '1e10', 'abc', '99', '60001']) {
+      expect(field.parse(bad), `expected fallback for ${JSON.stringify(bad)}`).toBe(5000);
+    }
+  });
+
+  it('falls back to 5000 when undefined (missing)', () => {
+    expect(field.parse(undefined)).toBe(5000);
+  });
+
+  it('passes through valid in-range values', () => {
+    expect(field.parse('8000')).toBe(8000);
+    expect(field.parse('100')).toBe(100); // lower bound inclusive
+    expect(field.parse('60000')).toBe(60000); // upper bound inclusive
+  });
+});

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -427,11 +427,15 @@ export const serverSchema = z.object({
   // fail-soft path: when the moderation gateway is slow/hanging (503/504 waves),
   // the fetch is aborted at this deadline instead of parking the whole generation
   // submission for undici's ~300s default. See src/server/integrations/moderation.ts.
-  // `.int().positive().catch(5000)` so a missing/empty/0/negative/garbage value
-  // falls back to 5000 rather than (a) crashing boot or (b) coercing to 0 →
+  // `.int().min(100).max(60000).catch(5000)` so a missing/empty/0/negative/garbage
+  // value falls back to 5000 rather than (a) crashing boot or (b) coercing to 0 →
   // AbortSignal.timeout(0) → aborting every call → SILENTLY disabling external
-  // moderation (the dangerous failure for a trust-and-safety control).
-  EXTERNAL_MODERATION_TIMEOUT_MS: z.coerce.number().int().positive().catch(5000),
+  // moderation (the dangerous failure for a trust-and-safety control). The bounds
+  // (#2734) reject both ends of the danger range: a tiny value (<100ms) would abort
+  // before moderation can respond → skips moderation, and a huge value (e.g. 1e10 →
+  // ~116-day timeout) re-introduces the unbounded-park failure the deadline exists
+  // to prevent. Any out-of-range value falls back to 5000.
+  EXTERNAL_MODERATION_TIMEOUT_MS: z.coerce.number().int().min(100).max(60000).catch(5000),
   BLOCKED_IMAGE_HASH_CHECK: zc.booleanString.optional().default(false),
   MODERATION_KNIGHT_TAGS: commaDelimitedStringArray().default([]),
 

--- a/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
+++ b/src/utils/metadata/__tests__/audit-matching-equivalence.test.ts
@@ -112,13 +112,14 @@ function refGetTags(prompt: string): string[] {
 // --- Reference (pre-optimization) young.nouns matching ---
 // Mirrors audit.ts: words.young.nouns = checkable(youngWords.nouns.concat(composedNouns),
 // { pluralize: true }). leet defaults to true. The composed nouns interleave every
-// adjective with every partialNoun via the body `adj·([\s|\w]{0,40}|[^\w]{1,40})·noun`
+// adjective with every partialNoun via the body `adj·([\s|\w]{0,200}|[^\w]{1,200})·noun`
 // — the highest-risk class for alternation interaction. The gap quantifiers are
 // BOUNDED (must match audit.ts's composedNouns exactly so this stays a faithful
 // old-vs-new *boundary* comparison): the unbounded original was O(n^2) on a long
-// Latin `\w` run (the residual ReDoS lever closed alongside this oracle).
+// Latin `\w` run (the residual ReDoS lever closed alongside this oracle). Widened
+// 40→200 alongside audit.ts (#2727 M1 recall fix) — kept in lockstep here.
 const youngComposedNouns = youngWords.partialNouns.flatMap((word) =>
-  youngWords.adjectives.map((adj) => adj + '([\\s|\\w]{0,40}|[^\\w]{1,40})' + word)
+  youngWords.adjectives.map((adj) => adj + '([\\s|\\w]{0,200}|[^\\w]{1,200})' + word)
 );
 const youngNounList = youngWords.nouns.concat(youngComposedNouns);
 const youngNounRefRegexes = youngNounList.map((w) => refPrepareWordRegex(w, true, true));

--- a/src/utils/metadata/__tests__/audit-redos.test.ts
+++ b/src/utils/metadata/__tests__/audit-redos.test.ts
@@ -148,9 +148,10 @@ describe('audit ReDoS regression (no catastrophic backtracking)', () => {
   // → O(n^2). `"young " + "a"*N` drove `words.young.nouns.inPrompt` to ~2.8s at
   // N=24000 (seconds of synchronous main-thread CPU = user-triggerable DoS). Two
   // defenses, tested independently:
-  //   (a) the per-pattern gap is now bounded ({0,40}/{1,40}) → linear regardless
+  //   (a) the per-pattern gap is now bounded ({0,200}/{1,200}) → linear regardless
   //       of length. Exercised via `includesMinor`, which is NOT length-capped.
-  //   (b) `auditPrompt` truncates to MAX_AUDIT_PROMPT_LENGTH first → blanket bound.
+  //   (b) `auditPrompt` BLOCKS input beyond MAX_AUDIT_PROMPT_LENGTH (#2727 M2) →
+  //       blanket bound + closes the truncate-then-scan evasion.
   const LATIN_RUN_MAX_MS = 100;
   describe('Latin \\w-run composed-noun quadratic (residual ReDoS lever)', () => {
     it('includesMinor is fast on a long Latin \\w run after the adjective (quantifier bound)', () => {
@@ -189,19 +190,51 @@ describe('audit ReDoS regression (no catastrophic backtracking)', () => {
       ).toBeLessThan(LATIN_RUN_MAX_MS);
     });
 
-    it('auditPrompt truncates input beyond MAX_AUDIT_PROMPT_LENGTH (length cap defense-in-depth)', () => {
-      // A blocked word placed strictly beyond the cap is not scanned → not flagged.
-      // (Real prompts are <=10k chars; this asserts the documented truncation contract
-      // that blanket-bounds worst-case audit cost.)
+    it('auditPrompt BLOCKS input beyond MAX_AUDIT_PROMPT_LENGTH (#2727 M2: no truncate-then-scan evasion)', () => {
+      // Pre-fix this was a truncate-then-scan: a banned phrase buried past the cap
+      // slipped through (the audit flagged it as success===true). Now an over-length
+      // prompt is refused outright, so a buried banned phrase can no longer evade.
       const blocked = '9 year old girl';
       const within = auditPrompt(blocked);
       expect(within.success, 'sanity: the marker phrase is blocked within the cap').toBe(false);
+
+      // A normal prompt UNDER the cap is unaffected (truncation contract preserved
+      // for in-cap inputs; nothing here trips the length block).
+      const normal = auditPrompt('a serene mountain landscape at sunrise');
+      expect(normal.success, 'a normal in-cap prompt is unaffected').toBe(true);
+
+      // A banned phrase buried entirely beyond the cap: the whole prompt is now
+      // blocked for over-length (instead of the phrase evading via truncation).
       const padded = 'x'.repeat(MAX_AUDIT_PROMPT_LENGTH) + ' ' + blocked;
+      expect(padded.length).toBeGreaterThan(MAX_AUDIT_PROMPT_LENGTH);
       const beyond = auditPrompt(padded);
       expect(
         beyond.success,
-        'a banned phrase placed entirely beyond the cap is truncated away (not scanned)'
-      ).toBe(true);
+        'an over-length prompt is blocked outright (banned phrase can no longer hide past the cap)'
+      ).toBe(false);
+    });
+  });
+
+  // Recall-boundary coverage for the composed young-noun gap (#2727 M1). The
+  // composed path (`young…girl`) is the ONLY way `girl`/`boy` flag; a 40-char gap
+  // missed real spaced phrasings >40 chars. With the bound widened to 200, spaced
+  // phrasings inside the window still flag and a gap clearly over the bound does
+  // not — documenting the bound explicitly (replaces the tautological oracle
+  // coverage). Any FINITE bound stays linear, so the wider window costs no perf.
+  describe('composed young-noun recall boundary ({0,200} gap)', () => {
+    it('flags a spaced "young … girl" phrasing within the 200-char window (~150 chars)', () => {
+      // 'young ' + 'word ' x30 + 'girl' ≈ 150 spaced chars, comfortably < 200.
+      const input = 'young ' + 'word '.repeat(30) + 'girl';
+      expect(input.length).toBeLessThan(200);
+      expect(input.length).toBeGreaterThan(40); // would have been MISSED at the old {0,40} bound
+      expect(includesMinor(input)).toBeTruthy();
+    });
+
+    it('does NOT match when the gap is clearly over the 200-char bound', () => {
+      // 'young ' + 'word ' x60 + 'girl' ≈ 300 spaced chars of gap → beyond {0,200}.
+      const input = 'young ' + 'word '.repeat(60) + 'girl';
+      expect(input.length).toBeGreaterThan(200 + 'young girl'.length);
+      expect(includesMinor(input)).toBeFalsy();
     });
   });
 

--- a/src/utils/metadata/audit.ts
+++ b/src/utils/metadata/audit.ts
@@ -67,13 +67,17 @@ export interface EnrichedAuditResult {
 // Defense-in-depth length cap applied before any audit regex runs. Every
 // sub-check scans the prompt with hundreds of regexes; the worst-case cost of a
 // pathological pattern grows with prompt length (the "504 wave" DoS was a regex
-// backtracking on a long adversarial prompt). The longest prompt any schema
-// accepts is 10000 chars (user-restriction); generation prompts are capped at
-// 1500. Truncating beyond this generous ceiling blanket-bounds the cost of ANY
-// audit regex — this incident's class AND future patterns — without affecting
-// real prompts. Complements the per-pattern quantifier bounds (e.g. the composed
-// young-noun gap below): the bounds keep individual regexes linear, this keeps
-// the whole pipeline's input bounded.
+// backtracking on a long adversarial prompt). It also bounds an evasion class:
+// any prompt LONGER than this ceiling is BLOCKED outright (see auditPromptEnriched
+// below), not silently truncated — a prior truncate-then-scan let a banned word
+// buried past the cap slip through the regex layer (#2727 M2). We do NOT rely on a
+// schema `.max()` to make over-length input unreachable: the generation prompt
+// schemas (including the `z.any()` generateFromGraph path) have NO `.max()`, so
+// the audit layer is the only guard. A >20k-char prompt is anomalous (realistic
+// prompts are <1500), so blocking is safe and closes the evasion for ALL callers.
+// Complements the per-pattern quantifier bounds (e.g. the composed young-noun gap
+// below): the bounds keep individual regexes linear, this keeps the whole
+// pipeline's input bounded.
 export const MAX_AUDIT_PROMPT_LENGTH = 20000;
 const capAuditLength = <T extends string | undefined>(s: T): T =>
   typeof s === 'string' && s.length > MAX_AUDIT_PROMPT_LENGTH
@@ -90,6 +94,15 @@ export const auditPromptEnriched = (
   checkProfanity?: boolean
 ): EnrichedAuditResult => {
   if (!prompt.trim().length) return { blockedFor: [], triggers: [], success: true };
+  // Block over-length input outright (#2727 M2). Truncating then scanning would let
+  // a banned word buried past MAX_AUDIT_PROMPT_LENGTH evade the regex layer; a
+  // prompt this long is anomalous so we refuse it rather than scan a truncated copy.
+  if (
+    prompt.length > MAX_AUDIT_PROMPT_LENGTH ||
+    (negativePrompt != null && negativePrompt.length > MAX_AUDIT_PROMPT_LENGTH)
+  ) {
+    return { blockedFor: ['Prompt exceeds the maximum allowed length'], triggers: [], success: false };
+  }
   prompt = capAuditLength(prompt);
   negativePrompt = capAuditLength(negativePrompt);
 
@@ -661,19 +674,21 @@ function inPromptEdit(prompt: string, { regex }: Checkable) {
 }
 
 // The gap between a young-adjective and a partial-noun. BOUNDED quantifiers
-// ({0,40}/{1,40}) instead of the original unbounded `([\s|\w]*|[^\w]+)`: the
+// ({0,200}/{1,200}) instead of the original unbounded `([\s|\w]*|[^\w]+)`: the
 // partial nouns end in `\w*` (e.g. `\w*girl+\w*`), so an unbounded gap sat
 // adjacent to another unbounded `\w*` over the SAME input run → O(n^2)
 // catastrophic backtracking on a long Latin `\w` run (`"young " + "a"*24000`
 // took ~2.8s of synchronous main-thread CPU through `words.young.nouns` — a
 // user-triggerable DoS of the same class as the #2722 CJK ReDoS, surfaced by the
-// #2725 audit). Any FINITE bound collapses this to linear; 40 chars is a generous
-// adjective→noun proximity window (~7 words) that preserves realistic phrasings
-// ("young pretty little asian girl") — verified equal to the old form on the
-// equivalence-oracle corpus, whose `youngComposedNouns` reference mirrors this
-// exact body.
+// #2725 audit). Any FINITE bound collapses this to linear, so a wider bound costs
+// nothing perf-wise. Widened 40→200 chars (#2727 M1 recall fix): `girl`/`boy` are
+// reachable ONLY via this composed path, and a 40-char (~7 word) window missed
+// real spaced "young … girl" phrasings >40 chars on the CSAM/minor-detection path
+// — closing that recall gap while staying linear. Verified equal to the old form
+// on the equivalence-oracle corpus, whose `youngComposedNouns` reference mirrors
+// this exact body.
 const composedNouns = youngWords.partialNouns.flatMap((word) => {
-  return youngWords.adjectives.map((adj) => adj + '([\\s|\\w]{0,40}|[^\\w]{1,40})' + word);
+  return youngWords.adjectives.map((adj) => adj + '([\\s|\\w]{0,200}|[^\\w]{1,200})' + word);
 });
 const words = {
   nsfw: checkable(nsfwWords),


### PR DESCRIPTION
Follow-up to the already-merged #2727 (audit ReDoS/recall hardening) and #2734 (env clamp). Addresses 3 audit findings on that merged code.

## Fix A — #2727 M1 (moderation recall)
**Finding:** the composed young-noun gap was bounded at 40 chars (`([\s|\w]{0,40}|[^\w]{1,40})`). `girl`/`boy` are reachable ONLY via this composed path, so a 40-char (~7-word) window silently missed real spaced "young … girl" phrasings longer than 40 chars on the CSAM/minor-detection path.

**Fix:** widen the bound `40 → 200` in both occurrences:
- live `composedNouns` in `src/utils/metadata/audit.ts`
- the mirrored `youngComposedNouns` reference in `audit-matching-equivalence.test.ts` (kept in lockstep so the equivalence oracle stays a boundary-only comparison)

Any FINITE bound is still linear, so the wider window costs nothing perf-wise. Comment updated (40→200 + the recall rationale). Added direct recall-boundary tests in `audit-redos.test.ts`: `includesMinor('young ' + 'word '.repeat(30) + 'girl')` (~150 spaced chars, < 200) is truthy; a gap clearly over 200 chars is not matched. This replaces the tautological oracle coverage the audit flagged. The existing Latin-`\w`-run perf test still passes <100ms.

## Fix B — #2727 M2 (pad-then-bury truncation evasion)
**Finding:** `auditPromptEnriched` truncated prompt/negativePrompt to `MAX_AUDIT_PROMPT_LENGTH` (20000) **then** scanned, so a banned word placed past 20000 chars evaded the regex layer (the original PR's own test documented `success===true` for a buried phrase).

**Fix:** before truncating/scanning, if the ORIGINAL prompt or negativePrompt exceeds `MAX_AUDIT_PROMPT_LENGTH`, return blocked:
```
{ blockedFor: ['Prompt exceeds the maximum allowed length'], triggers: [], success: false }
```
A >20k-char prompt is anomalous (realistic prompts are <1500), so blocking is safe and closes the evasion for ALL callers — including the `z.any()` generateFromGraph path. The generation prompt schemas have **no** `.max()`, so the audit layer is the only guard; corrected the now-false comment that claimed a 10000/1500 schema cap. In-cap prompts keep the existing truncation behavior unchanged.

Updated the prior truncate-then-scan test to assert the new blocked behavior, and added a normal-in-cap-prompt-unaffected assertion.

## Fix C — #2734 (env clamp)
**Finding:** `EXTERNAL_MODERATION_TIMEOUT_MS` was `z.coerce.number().int().positive().catch(5000)` — no upper bound, so `=1e10` → ~116-day timeout (re-introduces the park), and tiny values would abort before moderation can respond (silently skips moderation).

**Fix:** `z.coerce.number().int().min(100).max(60000).catch(5000)`. Out-of-range/garbage/empty → 5000; valid in-range → passes through. New focused test parses the field directly (`''`/`'0'`/`'-1'`/`'1e10'`/`'abc'`/`'60001'` → 5000; `'8000'`/`'100'`/`'60000'` pass).

## Verification
- Affected unit tests: 38 pass (audit-redos, audit-matching-equivalence, audit, new server-schema-moderation-timeout) + 40 pass on the adjacent audit suites (cjk-redos, gate-perf, slow-log, moderation integration).
- `tsc --noEmit -p tsconfig.json` clean on all changed files (repo has a ~5296-error pre-existing baseline; none from these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)