### PR TITLE
fix(app-blocks): evaluate the App Blocks flag against the block-token subject for block-token-authed workflow procs (unblock dev:live spend)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -858,13 +858,23 @@ describe('blocks.submitWorkflow', () => {
     expect(mockSubmitWorkflow).not.toHaveBeenCalled();
   });
 
-  it('rejects when the App Blocks flag is disabled', async () => {
-    mockIsAppBlocksEnabled.mockResolvedValueOnce(false);
+  it('rejects when the App Blocks flag is disabled (kill-switch, even for a mod token)', async () => {
+    // The flag is now evaluated IN-BODY against the TOKEN subject (not the
+    // `enforceAppBlocksFlag` middleware's ctx.user), so it runs AFTER
+    // verifyBlockToken — but it is still a real kill-switch. Even with a valid
+    // MOD token, flag=off → UNAUTHORIZED "App Blocks not enabled", and the real
+    // submit never fires.
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
     const caller = blocksRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
-    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-    expect(mockVerifyBlockToken).not.toHaveBeenCalled();
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+    // The token IS verified (the flag gate is in-body now), but no spend/submit.
+    expect(mockVerifyBlockToken).toHaveBeenCalled();
+    expect(mockSubmitWorkflow).not.toHaveBeenCalled();
   });
 
   it('rejects an invalid body shape (zod validation)', async () => {
@@ -876,6 +886,166 @@ describe('blocks.submitWorkflow', () => {
         body: { kind: 'unknown', modelId: 7 } as never,
       })
     ).rejects.toThrow();
+  });
+
+  // ---- App-Blocks flag evaluated against the TOKEN subject (dev:live fix) ----
+  //
+  // ROOT CAUSE this proves fixed: `enforceAppBlocksFlag` evaluated the flag
+  // against `ctx.user` (the SESSION user). A dev:live / localhost call is
+  // block-token-authed with NO session cookie → `ctx.user` is undefined → the
+  // mod-segmented `app-blocks-enabled` flag global-evals false → 401, even when
+  // the token's subject is a moderator. fakeCtx() has `user: undefined`,
+  // reproducing exactly that path. With the fix the flag is evaluated against
+  // the TOKEN subject (resolved via getUserById), so a mod subject passes and a
+  // non-mod/anon subject is still blocked (no-widening).
+  //
+  // The mock here is FAITHFUL: it mirrors the live mod-segmented flag — ON iff
+  // the supplied user is a moderator; no user (global eval) → false.
+  describe('flag is evaluated against the block-token subject (no session)', () => {
+    function faithfulModSegmentedFlag() {
+      mockIsAppBlocksEnabled.mockImplementation(async (opts?: { user?: { isModerator?: boolean } }) =>
+        !!opts?.user?.isModerator
+      );
+    }
+
+    it('INVARIANT 1a — MOD token + flag-on: estimate passes the gate (reaches the cost step)', async () => {
+      faithfulModSegmentedFlag();
+      // ctx.user is undefined (dev:live), but the TOKEN subject (42) is a mod.
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockGetUserById.mockResolvedValue({
+        id: 42,
+        isModerator: true,
+        tier: 'free',
+        email: 'u@example.com',
+        username: 'u',
+      });
+      happyVersionLookup();
+      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 12 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      // Got past the flag gate → the orchestrator whatif ran and produced a cost.
+      expect(result.snapshot.cost).toEqual({ total: 12 });
+      // The flag was evaluated against the TOKEN subject ({ user: <mod row> }),
+      // NOT ctx.user (undefined) — the dev:live fix.
+      expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({
+        user: expect.objectContaining({ id: 42, isModerator: true }),
+      });
+    });
+
+    it('INVARIANT 1a — MOD token + flag-on: submit passes the gate (real submit fires)', async () => {
+      faithfulModSegmentedFlag();
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      mockGetUserById.mockResolvedValue({
+        id: 42,
+        isModerator: true,
+        tier: 'free',
+        email: 'u@example.com',
+        username: 'u',
+      });
+      happyVersionLookup();
+      mockSysRedis.incrBy.mockResolvedValue(125);
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(2);
+    });
+
+    it('INVARIANT 1b — NON-MOD token: flag false → 401, no submit (stays mod-only pre-GA)', async () => {
+      faithfulModSegmentedFlag();
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      // TOKEN subject resolves to a NON-mod user → flag false.
+      mockGetUserById.mockResolvedValue({
+        id: 42,
+        isModerator: false,
+        tier: 'free',
+        email: 'u@example.com',
+        username: 'u',
+      });
+      happyVersionLookup();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('INVARIANT 1c — ANON token (sub:anon): rejected before the flag, no submit', async () => {
+      faithfulModSegmentedFlag();
+      // sub:'anon' → parseSubjectUserId returns null → UNAUTHORIZED before the
+      // flag/mod resolve even runs (there is no resolvable user to evaluate).
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ sub: 'anon', buzzBudget: 1000 }));
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      // Never resolved a user / evaluated the flag against one, never submitted.
+      expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('INVARIANT 4 — invalid token rejected before any flag/mod check', async () => {
+      faithfulModSegmentedFlag();
+      mockVerifyBlockToken.mockResolvedValue(null);
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+      expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('INVARIANT 2 — page-host path (session=mod AND token=mod): unaffected, still passes', async () => {
+      faithfulModSegmentedFlag();
+      // A real page-host call carries BOTH a session AND the token, same mod.
+      // After the change the gate uses the TOKEN subject (= the same mod) → pass.
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      mockGetUserById.mockResolvedValue({
+        id: 42,
+        isModerator: true,
+        tier: 'free',
+        email: 'u@example.com',
+        username: 'u',
+      });
+      happyVersionLookup();
+      mockSysRedis.incrBy.mockResolvedValue(125);
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+      // Session user present (page-host), same mod as the token subject.
+      const ctxWithSession = {
+        ...fakeCtx(),
+        user: { id: 42, isModerator: true, tier: 'free', username: 'u' },
+      };
+      const caller = blocksRouter.createCaller(ctxWithSession as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      // Gate used the TOKEN subject, not the session ctx.user.
+      expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({
+        user: expect.objectContaining({ id: 42, isModerator: true }),
+      });
+    });
+
+    it('pollWorkflow: MOD token + flag-on passes; non-mod token → 401', async () => {
+      faithfulModSegmentedFlag();
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockGetUserById.mockResolvedValue({ id: 42, isModerator: true });
+      mockGetWorkflow.mockResolvedValue({ id: 'wf_1', status: 'succeeded', cost: { total: 0 }, steps: [] });
+      let caller = blocksRouter.createCaller(fakeCtx() as never);
+      const ok = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      expect(ok.snapshot.workflowId).toBe('wf_1');
+
+      // Non-mod subject → flag false → 401, orchestrator never read.
+      mockGetWorkflow.mockClear();
+      mockGetUserById.mockResolvedValue({ id: 42, isModerator: false });
+      caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+      expect(mockGetWorkflow).not.toHaveBeenCalled();
+    });
   });
 
   // ---- W3 flow A — buzz SPEND attribution wire-in ------------------------

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -156,6 +156,43 @@ async function assertViewerIsModerator(userId: number): Promise<void> {
   }
 }
 
+/**
+ * App-Blocks flag gate for the BLOCK-TOKEN-authed runtime procs
+ * (estimate/submit/poll/cancelWorkflow, updateUserSettings).
+ *
+ * WHY THIS EXISTS — `enforceAppBlocksFlag` (the middleware) evaluates the flag
+ * against `ctx.user` (the request's SESSION user). These procs are
+ * `publicProcedure` authenticated by a BLOCK JWT, NOT a civitai.com session: a
+ * page-host call carries a session, but a `dev:live` (localhost) call is
+ * block-token-only and has NO session cookie → `ctx.user` is `undefined`. The
+ * live `app-blocks-enabled` flag is base-`false` with a `moderators` segment, so
+ * a no-user (global) eval can never match the segment → resolves `false` →
+ * UNAUTHORIZED "App Blocks not enabled", even when the token's subject IS a
+ * moderator. The flag must therefore be evaluated against the TOKEN's subject
+ * user, not `ctx.user`.
+ *
+ * The flag stays a real kill-switch (a flip still shuts these procs down) — we
+ * only fix the IDENTITY it's evaluated against. This does NOT widen access: the
+ * mod-segmented flag resolves `true` only for a moderator subject; a non-mod or
+ * anon (`sub:'anon'` → no resolvable user) subject still resolves `false` →
+ * blocked. `verifyBlockToken` (caller) already rejected invalid/expired/revoked
+ * tokens before this runs, and `assertViewerIsModerator` + every other belt
+ * (budget cap, daily Buzz cap, reserveBlockBuzzSpend, getOrchestratorToken,
+ * forced-SFW) are unchanged — this only swaps which identity the FLAG sees.
+ *
+ * Reads `isModerator` from the DB (the server-side user row), never a
+ * client-supplied value, so the segment match can't be spoofed.
+ */
+async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void> {
+  const row = await getUserById({ id: userId, select: { id: true, isModerator: true } });
+  // A vanished user → no SessionUser → global eval → flag false → blocked
+  // (fail-closed; the subsequent assertViewerIsModerator would also reject).
+  const user = row ? (row as unknown as SessionUser) : undefined;
+  if (!(await isAppBlocksEnabled({ user }))) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+  }
+}
+
 // ---- W10 page generation spend --------------------------------------------
 //
 // A model-slot token's ctx is `{ modelId, slotId }` (the install binds the
@@ -1786,7 +1823,9 @@ export const blocksRouter = router({
    * That's the gate — we don't need a second client-side ownership check.
    */
   pollWorkflow: publicProcedure
-    .use(enforceAppBlocksFlag)
+    // No `enforceAppBlocksFlag` middleware here: block-token procs are
+    // block-JWT-authed (no session for dev:live/localhost), so the flag must be
+    // evaluated against the TOKEN subject — see assertAppBlocksEnabledForTokenUser.
     .input(
       z.object({
         blockToken: z.string().min(1),
@@ -1806,6 +1845,8 @@ export const blocksRouter = router({
           message: 'workflow poll requires authenticated viewer',
         });
       }
+      // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
+      await assertAppBlocksEnabledForTokenUser(userId);
       await assertViewerIsModerator(userId);
       const token = await getOrchestratorToken(userId, ctx);
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
@@ -1826,7 +1867,8 @@ export const blocksRouter = router({
    * still clears its card.
    */
   cancelWorkflow: publicProcedure
-    .use(enforceAppBlocksFlag)
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
     .input(
       z.object({
         blockToken: z.string().min(1),
@@ -1846,6 +1888,8 @@ export const blocksRouter = router({
           message: 'workflow cancel requires authenticated viewer',
         });
       }
+      // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
+      await assertAppBlocksEnabledForTokenUser(userId);
       await assertViewerIsModerator(userId);
       const token = await getOrchestratorToken(userId, ctx);
       await cancelWorkflow({ workflowId: input.workflowId, token });
@@ -1860,7 +1904,8 @@ export const blocksRouter = router({
    * discovers whether budget is sufficient.
    */
   estimateWorkflow: publicProcedure
-    .use(enforceAppBlocksFlag)
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
     .input(z.object({ blockToken: z.string().min(1), body: blockWorkflowBodySchema }))
     .mutation(async ({ ctx, input }) => {
       const claims = await verifyBlockToken(input.blockToken);
@@ -1905,6 +1950,8 @@ export const blocksRouter = router({
           message: 'estimate requires authenticated viewer',
         });
       }
+      // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
+      await assertAppBlocksEnabledForTokenUser(userId);
       await assertViewerIsModerator(userId);
       const ctxSlotId = (claims.ctx as { slotId?: unknown } | undefined)?.slotId;
       if (typeof ctxSlotId !== 'string' || ctxSlotId.length === 0) {
@@ -1997,7 +2044,8 @@ export const blocksRouter = router({
    * outcomes the block can recover from (e.g. by opening BuyBuzzModal).
    */
   submitWorkflow: publicProcedure
-    .use(enforceAppBlocksFlag)
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
     .input(z.object({ blockToken: z.string().min(1), body: blockWorkflowBodySchema }))
     .mutation(async ({ ctx, input }) => {
       const claims = await verifyBlockToken(input.blockToken);
@@ -2046,6 +2094,8 @@ export const blocksRouter = router({
           message: 'workflow submit requires authenticated viewer',
         });
       }
+      // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
+      await assertAppBlocksEnabledForTokenUser(userId);
       await assertViewerIsModerator(userId);
       const ctxSlotId = (claims.ctx as { slotId?: unknown } | undefined)?.slotId;
       if (typeof ctxSlotId !== 'string' || ctxSlotId.length === 0) {
@@ -2446,7 +2496,8 @@ export const blocksRouter = router({
    * a "your saved override is invalid" failure at next generate.
    */
   updateUserSettings: publicProcedure
-    .use(enforceAppBlocksFlag)
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
     .input(
       z.object({
         blockToken: z.string().min(1),
@@ -2467,6 +2518,8 @@ export const blocksRouter = router({
           message: 'anon viewers cannot persist block settings',
         });
       }
+      // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
+      await assertAppBlocksEnabledForTokenUser(userId);
       await assertViewerIsModerator(userId);
       const ctxModelId = Number((claims.ctx as { modelId?: unknown } | undefined)?.modelId ?? NaN);
       if (!Number.isInteger(ctxModelId)) {


### PR DESCRIPTION
> ⚠️ **NEEDS SECURITY REVIEW — this touches the App Blocks spend/generation gate.**

## Root cause

The block-token-authed runtime procs gate on `enforceAppBlocksFlag`, which evaluates `isAppBlocksEnabled({ user: ctx.user })` — the **session** user. A `dev:live` request is **block-JWT-authed from localhost** with no civitai.com session cookie (the block JWT is not an ApiKey/session), so `ctx.user` is **undefined**. The live `app-blocks-enabled` flag is base-`false` with a `moderators` segment, so a no-user (global) eval can never match → resolves **false** → `401 "App Blocks not enabled"` — even though the token's subject is a moderator. The token's identity was never consulted by this gate (the procs *do* `assertViewerIsModerator(tokenSub)` in-body — that's the real mod gate, and it's untouched).

This was the last blocker for App Blocks `dev:live`.

## The fix (scoped)

For the **block-token-authed** procs only, the App-Blocks flag is now evaluated against the **block token's subject user**, not `ctx.user`:

- Added `assertAppBlocksEnabledForTokenUser(userId)` — resolves the token subject's user row (`id` + `isModerator`, server-side from the DB, never client-supplied) and calls `isAppBlocksEnabled({ user })`, throwing the same `UNAUTHORIZED "App Blocks not enabled"` if false.
- **Removed `.use(enforceAppBlocksFlag)`** from the 5 block-token procs and called the new helper in-body, just before the existing `assertViewerIsModerator(userId)`.

### Procs changed (block-token-authed: `verifyBlockToken(input.blockToken)` → `parseSubjectUserId(claims.sub)`)
- `estimateWorkflow`
- `submitWorkflow`
- `pollWorkflow`
- `cancelWorkflow`
- `updateUserSettings`

### Procs deliberately LEFT on the original `enforceAppBlocksFlag` middleware (session / `ctx.user`-authed — correctly gate on the logged-in user)
`listForModel`, `installOnModel`, `updateSettings`, `toggleEnabled`, `uninstallFromModel`, `withdrawPublishRequest`, `getMyPendingForSlug`, `listPendingRequests`, `listApprovedRequests`, `listRejectedRequests`, `getPublishRequestScreenshots`, `approveRequest`, `backfillPublishRequest`, `rejectRequest`, `listMyPublishRequests`, `listMyScopeGrants`, `listMyAppActivity`, `setSubscriptionPinnedVersion`, `grantScopes`, `listMyScopeInvocations`, `listMySubscriptions`, `listAvailable`, `getAppDetail`, `getFeaturedBlocks`, `upsertReview`, `listReviews`, `getMyReview`, `setReviewExcluded`, `getMarketplaceMeta`, `setMarketplaceMeta`, `getInstallConfig`, `upsertSubscription`, `deleteSubscription`, `getShowcaseImages`, `getEffectiveCheckpoint`, `getMyRevenue`, `getMyAppAnalytics`, `getMyApps`, `getMyAppRepo`. The `enforceAppBlocksFlag` middleware itself is **unchanged**.

> Note: `getShowcaseImages` / `getEffectiveCheckpoint` are `publicProcedure` but are NOT block-token-authed (they take `modelId`/`slotId`, not `blockToken`, and gate on `ctx.features.appBlocks`), so they stay on the middleware.

### User-resolution mechanism
The same DB lookup the procs already use for `assertViewerIsModerator`: `getUserById({ id: userId, select: { id: true, isModerator: true } })`, cast to a `SessionUser`-shaped object so `isAppBlocksEnabled` → `buildFliptContext(user)` keys on `isModerator` (the `moderators` segment). A vanished user → `undefined` → global eval → flag false → blocked (fail-closed).

## Security invariants (proven by tests)

1. **Stays mod-only pre-GA.** Flag evaluated against the token subject: a **mod** token passes; a **non-mod** token → `isAppBlocksEnabled` false → 401; an **anon** token (`sub:'anon'` → `parseSubjectUserId` null) → 401 before the flag/mod resolve even runs.
2. **Prod page-host path unaffected.** A real page-host call carries a session (`ctx.user` = the mod) AND the token (sub = same mod); after the change it gates on the token user (the same mod) → same result. Test drives a ctx WITH a session user and asserts the flag is evaluated against the token subject and still passes.
3. **No new bypass.** The flag is still enforced (just against the token user). `assertViewerIsModerator`, the per-call budget cap, the per-user daily Buzz cap, `reserveBlockBuzzSpend`, `getOrchestratorToken`, forced-SFW — all belts unchanged. The change ONLY swaps which identity the FLAG sees.
4. **`verifyBlockToken` still runs first** and still rejects invalid/expired/revoked tokens before any flag/mod check. Test: invalid token → `UNAUTHORIZED "invalid block token"` and the flag is never evaluated.

Plus: **flag-off is still a kill-switch** even for a mod token (test: flag=off → 401, no submit).

## Tests

Extended `src/server/routers/__tests__/blocks.router.workflow.test.ts` with a `describe` block using a **faithful** mod-segmented flag mock (ON iff the supplied user is a mod; no user → false). `fakeCtx()` already has `user: undefined`, reproducing the exact dev:live/localhost path. New + updated cases cover all 4 invariants above on `submitWorkflow`, plus a `pollWorkflow` mod-pass / non-mod-401 case. The sibling `blocks.router.flag-gate.test.ts` (session-proc gate) is unaffected.

### Test results
`vitest run --project unit src/server/routers/__tests__/blocks.router.workflow.test.ts src/server/routers/__tests__/blocks.router.flag-gate.test.ts` → **117 passed** (2 files). `tsc --noEmit` over the changed files: **0 errors** (the worktree's whole-tree `tsc` has pre-existing borrowed-Prisma-client noise unrelated to this change; both touched files are clean). Run locally on NixOS by borrowing the primary clone's generated Prisma client — the full CI suite was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)