### PR TITLE
fix(redis): retry-after-rediscover on transient cluster routing throw (topology-churn 500 wave)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -247,6 +247,49 @@ export const serverSchema = z.object({
   // in behavior beyond the existing 15s deadline). Default 1500ms (1.5s) — ~65× the
   // ~23ms healthy p99, so it never clips a healthy write, but bounds a wedged one.
   REDIS_METRIC_WRITE_TIMEOUT_MS: z.coerce.number().default(1500),
+
+  // ── CLUSTER ROUTING RETRY-AFTER-REDISCOVER (the topology-churn 500 wave) ─────────
+  //
+  // During ANY next-redis-cluster topology change (rolling update / node failover /
+  // scale event) the node-redis cluster slot map is transiently inconsistent and the
+  // client throws FLEET-WIDE, BEFORE the command is dispatched to any node:
+  //   TypeError: Cannot read properties of undefined (reading 'replicas')
+  //     at RedisClusterSlots.getSlotRandomNode (@redis/client@5.8.3 cluster-slots.js:342)
+  // Measured live during a rolling update: 1,696 throws in 15 min across ~90 pods →
+  // user-facing HTTP 500s on GENERAL cache READ paths (tag.getAll, image.getGenerationData,
+  // hiddenPreferences.getHidden, …). The cluster stays cluster_state=ok; it is purely the
+  // client mishandling churn, and the wave self-clears in ~1–2 min as topology settles.
+  //
+  // This is a genuine gap #2665 doesn't cover: the self-heal watchdog (FIX #1) only fires
+  // on a SUSTAINED inflight pin (the HANG-wedge), not this IMMEDIATE fail-fast throw; and
+  // the metric-write fail-soft (FIX #3) covers only the write/lock path, not these reads.
+  //
+  // KEY SAFETY ARGUMENT: getSlotRandomNode throws during NODE SELECTION — the command never
+  // reached a node, so a bounded retry-after-rediscover is safe for ALL commands, reads AND
+  // writes/mutations (zero double-execution risk — nothing executed). After exhausting the
+  // retries the ORIGINAL error is RE-THROWN (no silent swallow — current failure mode
+  // preserved for a genuinely persistent break). Cluster client ONLY (wired at the cluster
+  // `_execute` chokepoint; the single-node sysRedis client is never wrapped — a blanket
+  // sys-client change caused the #2556/#2586 wedge). NO money/entitlement blast radius
+  // (cache/routing only; money + entitlement live in Postgres + the sysRedis client).
+  //
+  // ON by default; REDIS_CLUSTER_ROUTING_RETRY_ENABLED=false is a single-flip kill-switch
+  // that restores today's exact behavior (one attempt, throw on a routing error).
+  REDIS_CLUSTER_ROUTING_RETRY_ENABLED: z.preprocess(
+    // default true; only the literal string 'false' disables it (mirrors the SELFHEAL flag)
+    (x) => x !== 'false',
+    z.boolean().default(true)
+  ),
+  // Max RETRIES after the initial attempt. The transient window is ~1–2 min cluster-wide but
+  // any single pod's command only needs the map to settle for ITS slot — 2 retries with a
+  // rediscover nudge clears the vast majority within ~200ms; more would just pile latency on a
+  // genuinely-persistent break that's going to re-throw anyway. 0 disables retry (pass-through).
+  REDIS_CLUSTER_ROUTING_RETRY_MAX: z.coerce.number().default(2),
+  // Backoff before the 1st / 2nd retry (ms). Small — the rediscover is the heavy lever, the
+  // backoff just gives the in-flight slot refresh a beat to land. 50ms then 150ms.
+  REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MS: z.coerce.number().default(50),
+  REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MAX_MS: z.coerce.number().default(150),
+
   // Upper bound (ms) on a single ClickHouse image-metrics read in the feed/SSR
   // hot path (getImageMetricsObject). The @clickhouse/client default
   // request_timeout is 30000ms, so a saturated/cold-cache-miss metric read would

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -281,12 +281,14 @@ export const serverSchema = z.object({
     z.boolean().default(true)
   ),
   // Max RETRIES after the initial attempt. The transient window is ~1–2 min cluster-wide but
-  // any single pod's command only needs the map to settle for ITS slot — 2 retries with a
-  // rediscover nudge clears the vast majority within ~200ms; more would just pile latency on a
+  // any single pod's command only needs the map to settle for ITS slot — 2 retries with the
+  // backoff below clears the vast majority within ~200ms; more would just pile latency on a
   // genuinely-persistent break that's going to re-throw anyway. 0 disables retry (pass-through).
   REDIS_CLUSTER_ROUTING_RETRY_MAX: z.coerce.number().default(2),
-  // Backoff before the 1st / 2nd retry (ms). Small — the rediscover is the heavy lever, the
-  // backoff just gives the in-flight slot refresh a beat to land. 50ms then 150ms.
+  // Backoff before the 1st / 2nd retry (ms). This IS the settle window: the rediscover between
+  // attempts is a best-effort FIRE-AND-FORGET nudge (triggerTopologyRediscovery returns undefined,
+  // not awaited to completion), so it's this backoff — not the rediscover call — that gives the
+  // in-flight, single-flighted slot-map refresh a beat to land before the retry. 50ms then 150ms.
   REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MS: z.coerce.number().default(50),
   REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MAX_MS: z.coerce.number().default(150),
 

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -257,6 +257,20 @@ export const redisMetricWriteFailSoftCounter = registerCounterWithLabels({
   labelNames: ['op'] as const,
 });
 
+// Cluster ROUTING retry-after-rediscover counter (the topology-churn 500 wave that #2665 does
+// not cover). Incremented when a cluster `_execute` hit a TRANSIENT pre-dispatch routing throw
+// (getSlotRandomNode "Cannot read properties of undefined (reading 'replicas')" et al.) and the
+// guard retried after a rediscover. `result` ∈ recovered|exhausted: a rising `recovered` series
+// during a rolling update / failover is the direct confirmation the fix converted what would
+// have been a fleet-wide 500 wave into a transparent retry; a rising `exhausted` series means
+// the slot map stayed inconsistent past the bounded retries and the original error re-threw (the
+// pre-fix behavior). Safe for reads AND writes — the command never reached a node. 2 series.
+export const redisRoutingRetryCounter = registerCounterWithLabels({
+  name: 'redis_routing_retry_total',
+  help: 'Cluster commands that hit a transient routing throw and were retried after a rediscover (recovered) or exhausted retries (exhausted, original error re-thrown)',
+  labelNames: ['result'] as const,
+});
+
 // tRPC per-procedure latency — wall-clock duration of the full middleware chain +
 // resolver, labeled by procedure path. Used to rank heavy-pool isolation
 // candidates by P99 x rate (the criterion behind the image-feed cutover). Bucket
@@ -502,6 +516,7 @@ export const sysredisSentinelClientErrorsCounter = registerSysredisCounter({
   sysredisSentinelClientErrorsCounter,
   redisSelfHealReconnectCounter,
   redisMetricWriteFailSoftCounter,
+  redisRoutingRetryCounter,
 };
 
 // pgPoolAcquireHistogram is registered in src/server/db/db-helpers.ts, not here.

--- a/src/server/redis/__tests__/cluster-inflight.test.ts
+++ b/src/server/redis/__tests__/cluster-inflight.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../cluster-inflight';
 import { ClusterSelfHealWatchdog } from '../cluster-selfheal';
 import type { ClusterSelfHealConfig, ClusterSelfHealDeps } from '../cluster-selfheal';
+import { withClusterRoutingRetry } from '../cluster-routing-retry';
 
 // FIX #2 coverage: the cluster inflight counter that the self-heal watchdog samples must
 // NEVER go negative — specifically after a heal. forceClusterReconnect calls the cluster
@@ -51,6 +52,64 @@ describe('cluster-inflight counter (FIX #2 floor)', () => {
     // ...then each of the N destroy()-rejected commands runs its done() → floored decrement.
     // Pre-FIX-#2 this would have left the counter at -N; the floor keeps it at 0.
     for (let i = 0; i < N; i++) decClusterInflight();
+    expect(getClusterInflight()).toBe(0);
+  });
+});
+
+// Routing-retry invariant: the topology-churn fix wraps the retry INSIDE the single inflight
+// inc/dec accounting (instrumentCommands inc's ONCE on entry, the routing guard retries the
+// node-selection SEQUENTIALLY, done() dec's ONCE on settle). So a command that hits the
+// transient routing throw and retries must still net ZERO inflight — no leak per retry, no
+// negative. This models that exact composition against the REAL counter.
+describe('cluster-inflight is balanced across a retried routing command (no leak)', () => {
+  beforeEach(() => resetClusterInflight());
+
+  const getSlotThrow = () =>
+    new TypeError("Cannot read properties of undefined (reading 'replicas')");
+
+  // Mirror the instrumentCommands wrapper: inc once → run (with routing retry) → dec once.
+  async function instrumentedCommand<T>(exec: () => Promise<T>): Promise<T> {
+    incClusterInflight();
+    try {
+      return await withClusterRoutingRetry(exec, {
+        enabled: true,
+        maxRetries: 2,
+        rediscover: () => {},
+        sleep: () => Promise.resolve(),
+      });
+    } finally {
+      decClusterInflight();
+    }
+  }
+
+  it('a recovered (retried) command nets 0 inflight', async () => {
+    let calls = 0;
+    const exec = () => {
+      calls += 1;
+      return calls === 1 ? Promise.reject(getSlotThrow()) : Promise.resolve('ok');
+    };
+    expect(getClusterInflight()).toBe(0);
+    const result = await instrumentedCommand(exec);
+    expect(result).toBe('ok');
+    expect(calls).toBe(2); // retried once
+    expect(getClusterInflight()).toBe(0); // balanced — counted as ONE inflight unit, dec'd once
+  });
+
+  it('an exhausted (re-thrown) routing command still nets 0 inflight', async () => {
+    const exec = () => Promise.reject(getSlotThrow());
+    await expect(instrumentedCommand(exec)).rejects.toBeInstanceOf(TypeError);
+    expect(getClusterInflight()).toBe(0); // no leak even when retries exhaust + re-throw
+  });
+
+  it('two concurrent retried commands net 0 (each inc/dec is one unit, retries do not double-count)', async () => {
+    const mk = () => {
+      let n = 0;
+      return () => {
+        n += 1;
+        return n === 1 ? Promise.reject(getSlotThrow()) : Promise.resolve('ok');
+      };
+    };
+    await Promise.all([instrumentedCommand(mk()), instrumentedCommand(mk())]);
     expect(getClusterInflight()).toBe(0);
   });
 });

--- a/src/server/redis/__tests__/cluster-routing-retry.test.ts
+++ b/src/server/redis/__tests__/cluster-routing-retry.test.ts
@@ -5,12 +5,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // change the node-redis client throws FLEET-WIDE BEFORE dispatching the command:
 //   TypeError: Cannot read properties of undefined (reading 'replicas')
 //     at RedisClusterSlots.getSlotRandomNode (cluster-slots.js:342)
-// Because the command NEVER reached a node, a bounded retry-after-rediscover is safe for reads
-// AND writes (no double-execution). These pin: the predicate matches the transient routing
-// throws and ONLY those; the wrapper retries+recovers, exhausts+re-throws the ORIGINAL, never
-// retries a non-transient error, passes through when disabled, honors max/backoff, never
-// double-executes the happy path, and is idempotent across a retried command. env is mocked so
-// both default-on and disabled branches are deterministic (mirrors metric-write-failsoft.test.ts).
+// Because that getSlotRandomNode/NoSlot throw is PRE-DISPATCH (the command never reached a node),
+// a bounded retry-after-rediscover is safe for reads AND writes (no double-execution). The
+// reconnect rejections (ClientClosedError / DisconnectsClientError from a #2665 self-heal
+// destroy()→flushAll) are AUDIT-EXCLUDED: flushAll rejects already-WRITTEN-and-maybe-applied
+// commands with the same error, so retrying them could double-apply a non-idempotent write — they
+// must re-throw. These pin: the predicate matches the PRE-DISPATCH routing throws and ONLY those
+// (NOT the reconnect errors); the wrapper retries+recovers, exhausts+re-throws the ORIGINAL, never
+// retries a non-transient error (incl. the reconnect rejections — write-safety), passes through
+// when disabled, honors max/backoff, never double-executes the happy path, and is idempotent
+// across a retried command. env is mocked so both default-on and disabled branches are
+// deterministic (mirrors metric-write-failsoft.test.ts).
 vi.mock('~/env/server', () => ({
   env: {
     REDIS_CLUSTER_ROUTING_RETRY_ENABLED: true,
@@ -64,13 +69,46 @@ describe('isTransientClusterRoutingError', () => {
     expect(isTransientClusterRoutingError(new Error('slot not served by any node'))).toBe(true);
   });
 
-  it('is TRUE for the reconnect ClientClosedError / DisconnectsClientError (concurrent self-heal)', () => {
-    expect(isTransientClusterRoutingError(namedError('ClientClosedError'))).toBe(true);
-    expect(isTransientClusterRoutingError(namedError('DisconnectsClientError'))).toBe(true);
-    // also by message text, in case .name is generic
-    expect(isTransientClusterRoutingError(new Error('The client is closed (ClientClosedError)'))).toBe(
-      true
-    );
+  // AUDIT-INVERTED (was: "is TRUE … concurrent self-heal"). These reconnect rejections are NOT
+  // transient for retry purposes: a #2665 self-heal reconnect's destroy() → flushAll(new
+  // DisconnectsClientError()) rejects the #waitingForReply queue too — commands ALREADY WRITTEN to
+  // the socket that the server may have ALREADY APPLIED before the teardown. The error name cannot
+  // distinguish "never sent" from "sent-and-applied", so retrying could DOUBLE-EXECUTE a
+  // non-idempotent write. The predicate must therefore return FALSE so the caller re-throws (#2665
+  // invariant: a reconnect reject fails the caller).
+  it('is FALSE for the reconnect ClientClosedError / DisconnectsClientError (post-dispatch → double-exec risk)', () => {
+    expect(isTransientClusterRoutingError(namedError('ClientClosedError'))).toBe(false);
+    expect(isTransientClusterRoutingError(namedError('DisconnectsClientError'))).toBe(false);
+    // and by message text — still not transient
+    expect(
+      isTransientClusterRoutingError(new Error('The client is closed (ClientClosedError)'))
+    ).toBe(false);
+    expect(
+      isTransientClusterRoutingError(new Error('Disconnects client (DisconnectsClientError)'))
+    ).toBe(false);
+  });
+
+  // AUDIT-NARROWED: only the documented pre-dispatch routing fields (replicas/master) match; the
+  // speculative `client`/`nodes` reads were dropped (not measured shapes, could mask app bugs).
+  it("is FALSE for an undefined-read on a non-routing field (e.g. 'client'/'nodes' — speculative, dropped)", () => {
+    expect(
+      isTransientClusterRoutingError(
+        new TypeError("Cannot read properties of undefined (reading 'client')")
+      )
+    ).toBe(false);
+    expect(
+      isTransientClusterRoutingError(
+        new TypeError("Cannot read properties of undefined (reading 'nodes')")
+      )
+    ).toBe(false);
+  });
+
+  it("is still TRUE for the documented 'master' routing-field read", () => {
+    expect(
+      isTransientClusterRoutingError(
+        new TypeError("Cannot read properties of undefined (reading 'master')")
+      )
+    ).toBe(true);
   });
 
   it('is FALSE for a real WRONGTYPE redis error (must still throw)', () => {
@@ -166,6 +204,40 @@ describe('withClusterRoutingRetry', () => {
     ).rejects.toBe(wrong);
 
     expect(exec).toHaveBeenCalledTimes(1); // no retry
+    expect(rediscover).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  // WRITE-SAFETY (the path the audit flagged as untested): a DisconnectsClientError /
+  // ClientClosedError from a concurrent #2665 self-heal reconnect can fire on an ALREADY-DISPATCHED,
+  // possibly-already-applied write. The guard must NOT retry it (no rediscover, exec called exactly
+  // once) and must re-throw the ORIGINAL error — otherwise a non-idempotent write could double-apply.
+  it('write-safety: DisconnectsClientError is NOT retried — exec called once, original re-thrown (no double-exec)', async () => {
+    const original = namedError('DisconnectsClientError', 'Disconnects client');
+    const exec = vi.fn().mockRejectedValue(original);
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    await expect(
+      withClusterRoutingRetry(exec, { rediscover, onResult, sleep: noSleep })
+    ).rejects.toBe(original);
+
+    expect(exec).toHaveBeenCalledTimes(1); // no retry → a write cannot double-apply
+    expect(rediscover).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it('write-safety: ClientClosedError is NOT retried — exec called once, original re-thrown', async () => {
+    const original = namedError('ClientClosedError', 'The client is closed');
+    const exec = vi.fn().mockRejectedValue(original);
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    await expect(
+      withClusterRoutingRetry(exec, { rediscover, onResult, sleep: noSleep })
+    ).rejects.toBe(original);
+
+    expect(exec).toHaveBeenCalledTimes(1);
     expect(rediscover).not.toHaveBeenCalled();
     expect(onResult).not.toHaveBeenCalled();
   });

--- a/src/server/redis/__tests__/cluster-routing-retry.test.ts
+++ b/src/server/redis/__tests__/cluster-routing-retry.test.ts
@@ -42,6 +42,22 @@ function getSlotRandomNodeThrow(): TypeError {
   return err;
 }
 
+// A THIRD pre-dispatch shape: during topology churn `nodeClient(node)` (cluster-slots.js:213) is
+// called with `node === undefined` (empty-topology / keyless-command edge, or a slot whose master
+// is undefined) and reads `.connectPromise` off it → TypeError with a getClient/nodeClient frame
+// (NOT getSlotRandomNode, NOT replicas|master). The node is selected at cluster/index.js:177 BEFORE
+// the dispatch try/catch → provably pre-dispatch → write-safe to retry.
+function nodeClientConnectPromiseThrow(): TypeError {
+  const err = new TypeError("Cannot read properties of undefined (reading 'connectPromise')");
+  err.stack = [
+    "TypeError: Cannot read properties of undefined (reading 'connectPromise')",
+    '    at RedisClusterSlots.nodeClient (/app/node_modules/@redis/client/dist/lib/cluster/cluster-slots.js:213:17)',
+    '    at RedisClusterSlots.getClient (/app/node_modules/@redis/client/dist/lib/cluster/cluster-slots.js:330:21)',
+    '    at RedisCluster._execute (/app/node_modules/@redis/client/dist/lib/cluster/index.js:177:40)',
+  ].join('\n');
+  return err;
+}
+
 function namedError(name: string, message = 'boom'): Error {
   const err = new Error(message);
   err.name = name;
@@ -111,6 +127,27 @@ describe('isTransientClusterRoutingError', () => {
     ).toBe(true);
   });
 
+  // AUDIT 🟡 (FIX #1): the THIRD pre-dispatch shape — nodeClient(undefined) reading 'connectPromise'
+  // with a getClient/nodeClient frame. Provably pre-dispatch (cluster/index.js:177 selects the node
+  // before the dispatch try/catch), so retrying is write-safe like the getSlotRandomNode shape.
+  it("is TRUE for the nodeClient(undefined) 'reading connectPromise' TypeError (3rd pre-dispatch shape)", () => {
+    expect(isTransientClusterRoutingError(nodeClientConnectPromiseThrow())).toBe(true);
+  });
+
+  it("is TRUE for a bare \"Cannot read properties of undefined (reading 'connectPromise')\" TypeError", () => {
+    expect(
+      isTransientClusterRoutingError(
+        new TypeError("Cannot read properties of undefined (reading 'connectPromise')")
+      )
+    ).toBe(true);
+  });
+
+  // Symmetry with the replicas|master guard: the undefined/null co-occurrence is required, so a
+  // 'connectPromise' read that does NOT co-occur with undefined/null does NOT match.
+  it("is FALSE for a 'connectPromise' mention without an undefined/null co-occurrence (guard symmetry)", () => {
+    expect(isTransientClusterRoutingError(new Error('connectPromise resolved late'))).toBe(false);
+  });
+
   it('is FALSE for a real WRONGTYPE redis error (must still throw)', () => {
     expect(
       isTransientClusterRoutingError(
@@ -174,6 +211,22 @@ describe('withClusterRoutingRetry', () => {
     expect(exec).toHaveBeenCalledTimes(2); // initial + 1 retry
     expect(rediscover).toHaveBeenCalledTimes(1);
     expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith('recovered');
+  });
+
+  it('the nodeClient connectPromise pre-dispatch throw also recovers on retry → counter "recovered"', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(nodeClientConnectPromiseThrow())
+      .mockResolvedValueOnce('recovered-value');
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    const result = await withClusterRoutingRetry(exec, { rediscover, onResult, sleep: noSleep });
+
+    expect(result).toBe('recovered-value');
+    expect(exec).toHaveBeenCalledTimes(2); // initial + 1 retry — the new shape IS treated transient
+    expect(rediscover).toHaveBeenCalledTimes(1);
     expect(onResult).toHaveBeenCalledWith('recovered');
   });
 

--- a/src/server/redis/__tests__/cluster-routing-retry.test.ts
+++ b/src/server/redis/__tests__/cluster-routing-retry.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// withClusterRoutingRetry is the retry-after-rediscover guard for the TRANSIENT cluster ROUTING
+// throw (the topology-churn 500 wave #2665 doesn't cover). During a next-redis-cluster topology
+// change the node-redis client throws FLEET-WIDE BEFORE dispatching the command:
+//   TypeError: Cannot read properties of undefined (reading 'replicas')
+//     at RedisClusterSlots.getSlotRandomNode (cluster-slots.js:342)
+// Because the command NEVER reached a node, a bounded retry-after-rediscover is safe for reads
+// AND writes (no double-execution). These pin: the predicate matches the transient routing
+// throws and ONLY those; the wrapper retries+recovers, exhausts+re-throws the ORIGINAL, never
+// retries a non-transient error, passes through when disabled, honors max/backoff, never
+// double-executes the happy path, and is idempotent across a retried command. env is mocked so
+// both default-on and disabled branches are deterministic (mirrors metric-write-failsoft.test.ts).
+vi.mock('~/env/server', () => ({
+  env: {
+    REDIS_CLUSTER_ROUTING_RETRY_ENABLED: true,
+    REDIS_CLUSTER_ROUTING_RETRY_MAX: 2,
+    REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MS: 50,
+    REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MAX_MS: 150,
+  },
+}));
+
+import {
+  isTransientClusterRoutingError,
+  withClusterRoutingRetry,
+} from '../cluster-routing-retry';
+
+// The exact fleet-wide throw measured during a live rolling update (getSlotRandomNode reads
+// `.replicas` off an undefined slot entry while the slot map is mid-rediscovery).
+function getSlotRandomNodeThrow(): TypeError {
+  const err = new TypeError("Cannot read properties of undefined (reading 'replicas')");
+  err.stack = [
+    "TypeError: Cannot read properties of undefined (reading 'replicas')",
+    '    at RedisClusterSlots.getSlotRandomNode (/app/node_modules/@redis/client/dist/lib/cluster/cluster-slots.js:342:19)',
+    '    at RedisCluster._execute (/app/node_modules/@redis/client/dist/lib/cluster/index.js:123:40)',
+  ].join('\n');
+  return err;
+}
+
+function namedError(name: string, message = 'boom'): Error {
+  const err = new Error(message);
+  err.name = name;
+  return err;
+}
+
+// A no-op sleep so tests don't spend real backoff time but still exercise the retry path.
+const noSleep = () => Promise.resolve();
+
+describe('isTransientClusterRoutingError', () => {
+  it('is TRUE for the getSlotRandomNode "reading replicas" TypeError (the measured throw)', () => {
+    expect(isTransientClusterRoutingError(getSlotRandomNodeThrow())).toBe(true);
+  });
+
+  it('is TRUE for the bare "Cannot read properties of undefined (reading \'replicas\')" TypeError', () => {
+    expect(
+      isTransientClusterRoutingError(
+        new TypeError("Cannot read properties of undefined (reading 'replicas')")
+      )
+    ).toBe(true);
+  });
+
+  it('is TRUE for a NoSlot / "slot not served" error', () => {
+    expect(isTransientClusterRoutingError(new Error('NoSlot for key'))).toBe(true);
+    expect(isTransientClusterRoutingError(new Error('slot not served by any node'))).toBe(true);
+  });
+
+  it('is TRUE for the reconnect ClientClosedError / DisconnectsClientError (concurrent self-heal)', () => {
+    expect(isTransientClusterRoutingError(namedError('ClientClosedError'))).toBe(true);
+    expect(isTransientClusterRoutingError(namedError('DisconnectsClientError'))).toBe(true);
+    // also by message text, in case .name is generic
+    expect(isTransientClusterRoutingError(new Error('The client is closed (ClientClosedError)'))).toBe(
+      true
+    );
+  });
+
+  it('is FALSE for a real WRONGTYPE redis error (must still throw)', () => {
+    expect(
+      isTransientClusterRoutingError(
+        new Error('WRONGTYPE Operation against a key holding the wrong kind of value')
+      )
+    ).toBe(false);
+  });
+
+  it('is FALSE for an auth failure and a CROSSSLOT key-distribution bug', () => {
+    expect(isTransientClusterRoutingError(new Error('NOAUTH Authentication required'))).toBe(false);
+    expect(
+      isTransientClusterRoutingError(new Error("CROSSSLOT Keys don't hash to the same slot"))
+    ).toBe(false);
+  });
+
+  it('is FALSE for an unrelated app TypeError (a real bug, not a routing throw)', () => {
+    expect(
+      isTransientClusterRoutingError(
+        new TypeError("Cannot read properties of undefined (reading 'userId')")
+      )
+    ).toBe(false);
+  });
+
+  it('is FALSE for null / undefined / non-error values', () => {
+    expect(isTransientClusterRoutingError(null)).toBe(false);
+    expect(isTransientClusterRoutingError(undefined)).toBe(false);
+    expect(isTransientClusterRoutingError(42)).toBe(false);
+    expect(isTransientClusterRoutingError({})).toBe(false);
+  });
+
+  it('is TRUE for a string error mentioning getSlotRandomNode (defensive, non-Error throws)', () => {
+    expect(isTransientClusterRoutingError('getSlotRandomNode failed: undefined')).toBe(true);
+  });
+});
+
+describe('withClusterRoutingRetry', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('happy path: calls exec EXACTLY once, no rediscover, no counter', async () => {
+    const exec = vi.fn().mockResolvedValue('value');
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+    const result = await withClusterRoutingRetry(exec, { rediscover, onResult, sleep: noSleep });
+    expect(result).toBe('value');
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(rediscover).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it('transient on first call → rediscover → retry SUCCEEDS → counter "recovered"', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(getSlotRandomNodeThrow())
+      .mockResolvedValueOnce('recovered-value');
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    const result = await withClusterRoutingRetry(exec, { rediscover, onResult, sleep: noSleep });
+
+    expect(result).toBe('recovered-value');
+    expect(exec).toHaveBeenCalledTimes(2); // initial + 1 retry
+    expect(rediscover).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith('recovered');
+  });
+
+  it('persistent transient error → exhausts max retries → rediscover N times → RE-THROWS THE ORIGINAL → counter "exhausted"', async () => {
+    const original = getSlotRandomNodeThrow();
+    const exec = vi.fn().mockRejectedValue(original);
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    await expect(
+      withClusterRoutingRetry(exec, { rediscover, onResult, sleep: noSleep })
+    ).rejects.toBe(original); // the ORIGINAL error object, not a wrapped one
+
+    expect(exec).toHaveBeenCalledTimes(3); // 1 initial + 2 retries (max=2)
+    expect(rediscover).toHaveBeenCalledTimes(2); // one rediscover per retry
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith('exhausted');
+  });
+
+  it('NON-transient error → NO rediscover, NO retry, throws immediately (real WRONGTYPE)', async () => {
+    const wrong = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
+    const exec = vi.fn().mockRejectedValue(wrong);
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    await expect(
+      withClusterRoutingRetry(exec, { rediscover, onResult, sleep: noSleep })
+    ).rejects.toBe(wrong);
+
+    expect(exec).toHaveBeenCalledTimes(1); // no retry
+    expect(rediscover).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it('disabled via env-style flag → pure pass-through (no retry, no rediscover) even on a transient error', async () => {
+    const original = getSlotRandomNodeThrow();
+    const exec = vi.fn().mockRejectedValue(original);
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    await expect(
+      withClusterRoutingRetry(exec, { enabled: false, rediscover, onResult, sleep: noSleep })
+    ).rejects.toBe(original);
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(rediscover).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it('disabled → happy path still returns the value with exactly one exec call', async () => {
+    const exec = vi.fn().mockResolvedValue('ok');
+    const result = await withClusterRoutingRetry(exec, { enabled: false });
+    expect(result).toBe('ok');
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a configured maxRetries (e.g. 1 → 2 total attempts, 1 rediscover)', async () => {
+    const original = getSlotRandomNodeThrow();
+    const exec = vi.fn().mockRejectedValue(original);
+    const rediscover = vi.fn();
+
+    await expect(
+      withClusterRoutingRetry(exec, { maxRetries: 1, rediscover, sleep: noSleep })
+    ).rejects.toBe(original);
+
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(rediscover).toHaveBeenCalledTimes(1);
+  });
+
+  it('maxRetries=0 → no retry but still re-throws the original transient error', async () => {
+    const original = getSlotRandomNodeThrow();
+    const exec = vi.fn().mockRejectedValue(original);
+    const rediscover = vi.fn();
+    const onResult = vi.fn();
+
+    await expect(
+      withClusterRoutingRetry(exec, { maxRetries: 0, rediscover, onResult, sleep: noSleep })
+    ).rejects.toBe(original);
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(rediscover).not.toHaveBeenCalled();
+    expect(onResult).toHaveBeenCalledTimes(1);
+    expect(onResult).toHaveBeenCalledWith('exhausted');
+  });
+
+  it('honors the configured backoff: sleeps the right durations before each retry', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(getSlotRandomNodeThrow())
+      .mockRejectedValueOnce(getSlotRandomNodeThrow())
+      .mockResolvedValueOnce('ok');
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withClusterRoutingRetry(exec, {
+      backoffMs: [50, 150],
+      rediscover: vi.fn(),
+      sleep,
+    });
+
+    expect(result).toBe('ok');
+    expect(sleep).toHaveBeenNthCalledWith(1, 50);
+    expect(sleep).toHaveBeenNthCalledWith(2, 150);
+  });
+
+  it('reuses the LAST backoff value when retries exceed the backoff array length', async () => {
+    const original = getSlotRandomNodeThrow();
+    const exec = vi.fn().mockRejectedValue(original);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      withClusterRoutingRetry(exec, {
+        maxRetries: 3,
+        backoffMs: [50], // shorter than the retry count
+        rediscover: vi.fn(),
+        sleep,
+      })
+    ).rejects.toBe(original);
+
+    // 3 retries, backoff array length 1 → 50 reused each time
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenNthCalledWith(1, 50);
+    expect(sleep).toHaveBeenNthCalledWith(3, 50);
+  });
+
+  it('a recovering write/mutation is NOT double-executed: exec is invoked once per attempt, not re-run after success', async () => {
+    // Models a WRITE that fails routing on attempt 1 (never reached a node) and succeeds on the
+    // retry. exec call count == attempts == 2, and after the success no further calls occur — so
+    // the underlying SET/HSET ran exactly once against a node (no double-apply).
+    let nodeWrites = 0;
+    const exec = vi.fn().mockImplementation(() => {
+      // simulate: routing happens BEFORE the node write; first call throws pre-dispatch
+      if (exec.mock.calls.length === 1) return Promise.reject(getSlotRandomNodeThrow());
+      nodeWrites += 1; // the write only lands once a node is selected
+      return Promise.resolve('OK');
+    });
+
+    const result = await withClusterRoutingRetry(exec, { rediscover: vi.fn(), sleep: noSleep });
+    expect(result).toBe('OK');
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(nodeWrites).toBe(1); // executed against a node EXACTLY once
+  });
+
+  it('a throwing onResult hook never breaks the guard (recovered path still returns)', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(getSlotRandomNodeThrow())
+      .mockResolvedValueOnce('value');
+    const onResult = vi.fn().mockImplementation(() => {
+      throw new Error('counter blew up');
+    });
+    await expect(
+      withClusterRoutingRetry(exec, { rediscover: vi.fn(), onResult, sleep: noSleep })
+    ).resolves.toBe('value');
+  });
+
+  it('a throwing rediscover never masks the original error on exhaustion', async () => {
+    const original = getSlotRandomNodeThrow();
+    const exec = vi.fn().mockRejectedValue(original);
+    const rediscover = vi.fn().mockRejectedValue(new Error('rediscover failed'));
+
+    await expect(
+      withClusterRoutingRetry(exec, { rediscover, sleep: noSleep })
+    ).rejects.toBe(original); // still the ORIGINAL routing error, not the rediscover error
+  });
+
+  it('works without a rediscover hook (retries still occur)', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(getSlotRandomNodeThrow())
+      .mockResolvedValueOnce('ok');
+    const result = await withClusterRoutingRetry(exec, { sleep: noSleep });
+    expect(result).toBe('ok');
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -236,6 +236,13 @@ const clusterRefreshIntervals = new Map<string, ReturnType<typeof setInterval>>(
  * Trigger topology rediscovery on a cluster client.
  * Uses internal _slots.rediscover() method - this is undocumented but stable.
  * See: https://github.com/redis/node-redis/issues/2806
+ *
+ * FIRE-AND-FORGET: this kicks off `_slots.rediscover(...).catch(...)` but RETURNS `undefined` (it
+ * does NOT return/await the rediscover promise). So a caller that `await`s it (the routing-retry
+ * guard's `rediscover` hook) resolves immediately — the rediscover runs in the background and the
+ * guard's BACKOFF is what gives the in-flight, single-flighted slot-map refresh time to settle
+ * before the retry. Intentional: node-redis single-flights rediscover, so a best-effort nudge +
+ * backoff is the right shape; returning the promise here would change the retry timing/blast radius.
  */
 function triggerTopologyRediscovery(clusterClient: any, reason: string) {
   try {
@@ -1035,6 +1042,9 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     // of retries (no double-count, done() fires exactly once). The sys client (wrapWithDeadline=
     // false) is left exactly as before — no routing guard, no deadline. Default-on; the
     // REDIS_CLUSTER_ROUTING_RETRY_ENABLED=false kill-switch passes runOnce() straight through.
+    // The `rediscover` hook is a FIRE-AND-FORGET nudge: triggerTopologyRediscovery returns
+    // undefined (it does not await the rediscover promise), so the guard's backoff — not this call —
+    // is what gives the in-flight slot-map refresh time to settle before the retry.
     const executed: Promise<any> = wrapWithDeadline
       ? withClusterRoutingRetry(runOnce, {
           rediscover: () => triggerTopologyRediscovery(self, 'routing-retry'),

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -9,6 +9,7 @@ import { createLogger } from '~/utils/logging';
 import { slugit } from '~/utils/string-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { withCommandDeadline } from '~/server/redis/command-deadline';
+import { withClusterRoutingRetry } from '~/server/redis/cluster-routing-retry';
 import { ClusterSelfHealWatchdog } from '~/server/redis/cluster-selfheal';
 import type { ClusterSelfHealTrigger } from '~/server/redis/cluster-selfheal';
 import {
@@ -950,6 +951,9 @@ type RedisMetricsBridge = {
   // undefined until prom/client loads server-side; callers null-check.
   redisSelfHealReconnectCounter?: { inc: (labels: { trigger: string }) => void };
   redisMetricWriteFailSoftCounter?: { labels: (labels: { op: string }) => { inc: () => void } };
+  // Cluster routing retry-after-rediscover counter (the topology-churn 500 wave). Read via the
+  // same globalThis bridge so this client-bundle-reachable module avoids a static prom import.
+  redisRoutingRetryCounter?: { inc: (labels: { result: 'recovered' | 'exhausted' }) => void };
 };
 
 // Server-runtime lookup of the prom metric handles WITHOUT a static import edge
@@ -1009,21 +1013,44 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
       metrics?.redisCommandsInflight.dec(labels);
       metrics?.redisCommandDuration.observe(labels, (Date.now() - start) / 1000);
     };
-    let result: any;
-    try {
-      result = original.apply(this, args);
-    } catch (err) {
-      // Synchronous throw (e.g. ClientClosedError) — still account for it.
-      done();
-      throw err;
-    }
+
+    // Run the underlying command, capturing a SYNCHRONOUS routing throw (the getSlotRandomNode
+    // TypeError fires synchronously during node selection BEFORE dispatch) as a rejection so the
+    // retry guard below sees it uniformly with an async reject. Defined as a thunk so the routing
+    // guard can re-invoke it for a retry — safe because a transient routing error means the
+    // command NEVER reached a node (no double-execution).
+    const runOnce = () =>
+      new Promise<any>((resolve, reject) => {
+        try {
+          resolve(original.apply(this, args));
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+    // Retry-after-rediscover for the TRANSIENT cluster-routing throw — CLUSTER client ONLY (the
+    // topology-churn 500 wave #2665 doesn't cover; see cluster-routing-retry.ts). Sits AROUND
+    // node selection, INSIDE the single inflight inc/dec + deadline accounting: the retried
+    // attempts are SEQUENTIAL (await), never overlapping, so this is ONE inflight unit regardless
+    // of retries (no double-count, done() fires exactly once). The sys client (wrapWithDeadline=
+    // false) is left exactly as before — no routing guard, no deadline. Default-on; the
+    // REDIS_CLUSTER_ROUTING_RETRY_ENABLED=false kill-switch passes runOnce() straight through.
+    const executed: Promise<any> = wrapWithDeadline
+      ? withClusterRoutingRetry(runOnce, {
+          rediscover: () => triggerTopologyRediscovery(self, 'routing-retry'),
+          onResult: (result) => getRedisMetrics()?.redisRoutingRetryCounter?.inc({ result }),
+        })
+      : runOnce();
+
     // Bound the cluster command so a never-settling `_execute` still reaches done()
     // (gauge dec'd, handler unparked). No-op when the deadline env is 0/disabled or for
     // the sys client (wrapWithDeadline=false). withCommandDeadline reaps the late
     // rejection of the orphaned command so it can't surface as an unhandledRejection.
+    // Layered OUTSIDE the routing retry so the 15s deadline bounds the WHOLE retried sequence
+    // (the bounded ~50ms+150ms backoff is well inside it).
     const settled = wrapWithDeadline
-      ? withCommandDeadline(Promise.resolve(result), undefined, recordClusterDeadlineHit)
-      : Promise.resolve(result);
+      ? withCommandDeadline(executed, undefined, recordClusterDeadlineHit)
+      : executed;
     return settled.finally(done);
   };
 }

--- a/src/server/redis/cluster-routing-retry.ts
+++ b/src/server/redis/cluster-routing-retry.ts
@@ -1,0 +1,227 @@
+import { env } from '~/env/server';
+
+/**
+ * Retry-after-rediscover guard for TRANSIENT cluster ROUTING failures (the topology-churn
+ * 500 wave that #2665 does NOT cover).
+ *
+ * WHY: civitai-dp-prod talks to a sharded `next-redis-cluster` via the node-redis cluster
+ * client (@redis/client@5.8.3). During ANY cluster topology change — a rolling update, a node
+ * failover, or a scale event — the cluster slot map is transiently inconsistent. In that
+ * window the client throws FLEET-WIDE, BEFORE the command is dispatched to any node:
+ *
+ *   TypeError: Cannot read properties of undefined (reading 'replicas')
+ *     at RedisClusterSlots.getSlotRandomNode (cluster-slots.js:342:19)
+ *
+ * Measured during a LIVE rolling update: 1,696 of these throws in 15 minutes across ~90 pods
+ * (SSR -primary, api-primary, api-heavy), surfacing as user-facing HTTP 500s on GENERAL cache
+ * READ paths (tag.getAll, image.getGenerationData, hiddenPreferences.getHidden,
+ * nowPayments.getSupportedCurrencies, reaction.toggle, user.checkNotifications, …). The cluster
+ * itself stays healthy (`cluster_state=ok`); it is purely the CLIENT mishandling topology churn.
+ * The waves self-clear in ~1–2 min as topology settles.
+ *
+ * Why #2665 does NOT cover this (verified, not duplicated):
+ *  - FIX #1 ClusterSelfHealWatchdog forces a reconnect only when the inflight counter stays
+ *    >50 for a sustained 20s window (the HANG-wedge signature). The getSlotRandomNode throw is
+ *    IMMEDIATE (fails fast, never pins inflight) → the watchdog never sees it; and when it does
+ *    fire, its destroy()→flushAll() rejects in-flight commands = its own 500 burst.
+ *  - FIX #3 withMetricWriteFailSoft fail-softs ONLY the metrics:lock/hIncrBy WRITE path; the
+ *    wave's 500s are general READS (confirmed metric-write-failsoft_total=0 during the wave).
+ *
+ * THE SAFETY ARGUMENT (the key insight that makes this safe for ALL commands, reads AND
+ * writes/mutations): getSlotRandomNode throws during NODE SELECTION — BEFORE the command is
+ * dispatched to any node. The command NEVER EXECUTED. Therefore a bounded retry-after-rediscover
+ * carries ZERO double-execution risk for writes/mutations: there is nothing to re-do, only a
+ * fresh node-selection attempt against the (now hopefully settled) slot map. That is cleaner and
+ * broader than a read-path-only fail-open, which would still 500 every write during the wave.
+ *
+ * BEHAVIOR PRESERVED: after exhausting the bounded retries the ORIGINAL error is RE-THROWN — no
+ * silent swallow, today's failure mode is unchanged for a genuinely persistent break. The guard
+ * is default-ON but fully kill-switchable via REDIS_CLUSTER_ROUTING_RETRY_ENABLED=false (restores
+ * the current behavior: one attempt, throw on a routing error).
+ *
+ * SCOPE: cluster client ONLY (wired at the cluster `_execute` chokepoint in client.ts). The
+ * single-node sysRedis client is NEVER wrapped — a blanket sys-client change caused the
+ * #2556/#2586 wedge. NO money/entitlement blast radius: this is cache/routing only; money and
+ * entitlement live in Postgres + the single-node sysRedis client this never touches.
+ *
+ * Pure (no static prom import — the counter increment is injected via onResult exactly like the
+ * existing redis metrics, read off globalThis in client.ts) so it is unit-testable in isolation.
+ */
+
+/** Tiny error-shape probe that tolerates non-Error throws (string, plain object) without
+ *  assuming `.message`/`.name`/`.constructor` exist. */
+function errText(err: unknown): string {
+  if (err == null) return '';
+  if (typeof err === 'string') return err;
+  if (err instanceof Error) {
+    // Include name + message + the top of the stack (the getSlotRandomNode frame lives there).
+    return `${err.name}: ${err.message}\n${err.stack ?? ''}`;
+  }
+  // Plain object / unknown — best-effort stringify of message-like fields.
+  const anyErr = err as { name?: unknown; message?: unknown; code?: unknown };
+  return [anyErr.name, anyErr.code, anyErr.message]
+    .filter((x) => typeof x === 'string')
+    .join(': ');
+}
+
+/**
+ * TRUE iff `err` is a TRANSIENT pre-dispatch cluster-routing failure — i.e. "there is no node
+ * for this slot RIGHT NOW because the slot map is mid-rediscovery". Matched conservatively so a
+ * real WRONGTYPE, an auth failure, or an app bug still throws:
+ *
+ *  - the getSlotRandomNode `Cannot read properties of undefined (reading 'replicas')` TypeError
+ *    (the exact fleet-wide throw measured during the rolling update);
+ *  - sibling node-selection failures: a message/name mentioning `getSlotRandomNode`, a
+ *    `getSlotMaster`/`getSlotRandomNode`-style "undefined reading 'replicas'/'master'/'client'"
+ *    on an empty slot, an explicit `NoSlot`/"no slot"/"slot not served" error;
+ *  - the `ClientClosedError` / `DisconnectsClientError` a CONCURRENT self-heal reconnect (FIX #1
+ *    destroy()→flushAll) produces — also pre/at-dispatch and safe to re-route after rediscover.
+ *
+ * Deliberately does NOT match: WRONGTYPE, NOAUTH/auth, CROSSSLOT (a real key-distribution bug,
+ * not a transient), MOVED/ASK (node-redis handles those internally), generic ReplyError, or any
+ * arbitrary TypeError whose text doesn't mention the routing-specific tokens above.
+ */
+export function isTransientClusterRoutingError(err: unknown): boolean {
+  if (err == null) return false;
+
+  const name = err instanceof Error ? err.name : '';
+  const text = errText(err);
+  if (!text) return false;
+
+  // The concurrent-reconnect errors node-redis raises when destroy()/flushAll rejected the
+  // queue (FIX #1 self-heal) or the socket closed mid-route. Pre/at-dispatch → safe to retry.
+  if (
+    name === 'ClientClosedError' ||
+    name === 'DisconnectsClientError' ||
+    /\bClientClosedError\b/.test(text) ||
+    /\bDisconnectsClientError\b/.test(text)
+  ) {
+    return true;
+  }
+
+  // The exact getSlotRandomNode throw + its sibling empty-slot node-selection failures. The
+  // canonical signature is a TypeError "Cannot read properties of undefined (reading 'replicas')"
+  // raised from getSlotRandomNode; we match either the frame name OR the undefined-read on a
+  // routing field, so a future node-redis patch that renames the frame still matches by shape.
+  if (/getSlotRandomNode|getSlotMaster|getRandomNode/.test(text)) return true;
+  if (
+    /reading '(replicas|master|client|nodes)'/.test(text) &&
+    /undefined|null/.test(text)
+  ) {
+    return true;
+  }
+
+  // Explicit "no node for this slot" style errors.
+  if (/\bNoSlot\b/i.test(text) || /no slot|slot not served|slot is not served/i.test(text)) {
+    return true;
+  }
+
+  return false;
+}
+
+export type ClusterRoutingRetryResult = 'recovered' | 'exhausted';
+
+export interface ClusterRoutingRetryOptions {
+  /**
+   * Trigger a topology rediscovery between attempts. Awaited (errors swallowed by the caller's
+   * wiring — a failed rediscover just means the retry runs against the same slot map and likely
+   * re-throws, which is still no worse than today). Injected so the pure module needs no redis
+   * import. If omitted, retries still occur (a fast in-flight rediscover from another path may
+   * have settled the map) but without an explicit nudge.
+   */
+  rediscover?: () => void | Promise<unknown>;
+  /** Master kill-switch. Defaults to REDIS_CLUSTER_ROUTING_RETRY_ENABLED. When false: pass-through
+   *  (run exec() once, no retry, no rediscover — restores current behavior). */
+  enabled?: boolean;
+  /** Max RETRIES after the initial attempt. Defaults to REDIS_CLUSTER_ROUTING_RETRY_MAX (2).
+   *  0 = no retry (still a pass-through for the initial attempt). */
+  maxRetries?: number;
+  /** Backoff before retry #1 / #2 (ms). Defaults to the two env knobs (50ms, 150ms). For retries
+   *  beyond the array length the LAST value is reused. */
+  backoffMs?: number[];
+  /**
+   * Fire-and-forget hook on settle: ('recovered' once a retry SUCCEEDS, 'exhausted' once retries
+   * are exhausted and the original error is about to re-throw). Wired in client.ts to the
+   * civitai_app_redis_routing_retry_total{result=…} prom counter via the globalThis bridge.
+   * Never throws into the hot path (isolated in a try/catch here).
+   */
+  onResult?: (result: ClusterRoutingRetryResult) => void;
+  /** Injectable sleep (tests pass a no-op / fake-timer-friendly impl). Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) =>
+  ms > 0 ? new Promise<void>((r) => setTimeout(r, ms)) : Promise.resolve();
+
+/**
+ * Run `exec()`. On a TRANSIENT cluster-routing error (isTransientClusterRoutingError), trigger
+ * ONE rediscover() and retry with a small bounded backoff, up to `maxRetries` times. On success
+ * after a retry → fire onResult('recovered'). After exhausting the retries → fire
+ * onResult('exhausted') and RE-THROW THE ORIGINAL error (no silent swallow). A NON-transient
+ * error (WRONGTYPE, auth, app bug) → re-thrown IMMEDIATELY, no rediscover, no retry.
+ *
+ * Single-flight/idempotent-safe by construction: a transient routing error means the command
+ * NEVER reached a node, so re-running exec() cannot double-execute a write/mutation.
+ *
+ * Disabled (enabled=false) → pure pass-through: exec() runs exactly once and any error propagates
+ * unchanged (today's behavior). On the happy path exec() is called EXACTLY ONCE.
+ */
+export async function withClusterRoutingRetry<T>(
+  exec: () => Promise<T>,
+  options: ClusterRoutingRetryOptions = {}
+): Promise<T> {
+  const enabled = options.enabled ?? env.REDIS_CLUSTER_ROUTING_RETRY_ENABLED;
+  if (!enabled) return exec();
+
+  const maxRetries = Math.max(
+    0,
+    options.maxRetries ?? env.REDIS_CLUSTER_ROUTING_RETRY_MAX
+  );
+  const backoff =
+    options.backoffMs ?? [
+      env.REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MS,
+      env.REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MAX_MS,
+    ];
+  const sleep = options.sleep ?? defaultSleep;
+
+  const fire = (result: ClusterRoutingRetryResult) => {
+    try {
+      options.onResult?.(result);
+    } catch {
+      // A broken counter hook must never break the guard.
+    }
+  };
+
+  let attempt = 0;
+  // Total attempts = 1 initial + maxRetries.
+  for (;;) {
+    try {
+      const value = await exec();
+      // recovered === we succeeded on a RETRY (attempt > 0). The initial-attempt happy path is
+      // unchanged and uncounted.
+      if (attempt > 0) fire('recovered');
+      return value;
+    } catch (err) {
+      // Non-transient OR retries exhausted → preserve today's behavior: re-throw the ORIGINAL.
+      if (!isTransientClusterRoutingError(err)) throw err;
+      if (attempt >= maxRetries) {
+        fire('exhausted');
+        throw err;
+      }
+
+      // Bounded backoff, then nudge a rediscover and retry. The command never reached a node, so
+      // this is safe for reads AND writes.
+      const waitMs = backoff[Math.min(attempt, backoff.length - 1)] ?? 0;
+      if (waitMs > 0) await sleep(waitMs);
+      if (options.rediscover) {
+        try {
+          await options.rediscover();
+        } catch {
+          // A failed rediscover just means the retry runs against the same map → likely re-throws,
+          // no worse than today. Never let it mask the original routing error.
+        }
+      }
+      attempt += 1;
+    }
+  }
+}

--- a/src/server/redis/cluster-routing-retry.ts
+++ b/src/server/redis/cluster-routing-retry.ts
@@ -28,11 +28,26 @@ import { env } from '~/env/server';
  *    wave's 500s are general READS (confirmed metric-write-failsoft_total=0 during the wave).
  *
  * THE SAFETY ARGUMENT (the key insight that makes this safe for ALL commands, reads AND
- * writes/mutations): getSlotRandomNode throws during NODE SELECTION — BEFORE the command is
- * dispatched to any node. The command NEVER EXECUTED. Therefore a bounded retry-after-rediscover
- * carries ZERO double-execution risk for writes/mutations: there is nothing to re-do, only a
- * fresh node-selection attempt against the (now hopefully settled) slot map. That is cleaner and
- * broader than a read-path-only fail-open, which would still 500 every write during the wave.
+ * writes/mutations): the retried error shapes throw during NODE SELECTION / SLOT ROUTING — BEFORE
+ * the command is dispatched to any node. The command NEVER EXECUTED. Therefore a bounded
+ * retry-after-rediscover carries ZERO double-execution risk for writes/mutations: there is nothing
+ * to re-do, only a fresh node-selection attempt against the (now hopefully settled) slot map. That
+ * is cleaner and broader than a read-path-only fail-open, which would still 500 every write during
+ * the wave.
+ *
+ * SCOPE OF THE RETRY — PRE-DISPATCH ONLY (audit-narrowed): the guard retries ONLY provably
+ * pre-dispatch routing throws — the getSlotRandomNode `reading 'replicas'/'master'` TypeError and
+ * `NoSlot`/"no slot"-style cluster routing errors. It DELIBERATELY does NOT retry the reconnect
+ * rejections `ClientClosedError` / `DisconnectsClientError`. Per #2665 (cluster-selfheal.ts:113),
+ * a self-heal reconnect's `destroy()` → `queue.flushAll(new DisconnectsClientError())` rejects
+ * BOTH the not-yet-written queue AND the `#waitingForReply` queue — i.e. commands ALREADY WRITTEN
+ * to the socket and awaiting a reply. node-redis (@redis/client 5.8.x) gives the caller NO signal
+ * to tell "never sent" from "sent, server may have applied it, socket torn down before the reply".
+ * Retrying a `DisconnectsClientError` could therefore DOUBLE-EXECUTE a non-idempotent cluster
+ * write (hIncrBy/incrBy/lPush/rPush/sAdd/zAdd). So those errors fail the caller exactly as they do
+ * today (#2665's invariant: a self-heal reconnect reject fails the caller — it is NOT retried).
+ * MULTI/pipeline (`#queue.addCommand`) is out of scope by design — this guard wraps the single
+ * cluster `_execute` chokepoint, not transactions.
  *
  * BEHAVIOR PRESERVED: after exhausting the bounded retries the ORIGINAL error is RE-THROWN — no
  * silent swallow, today's failure mode is unchanged for a genuinely persistent break. The guard
@@ -65,49 +80,47 @@ function errText(err: unknown): string {
 }
 
 /**
- * TRUE iff `err` is a TRANSIENT pre-dispatch cluster-routing failure — i.e. "there is no node
- * for this slot RIGHT NOW because the slot map is mid-rediscovery". Matched conservatively so a
- * real WRONGTYPE, an auth failure, or an app bug still throws:
+ * TRUE iff `err` is a TRANSIENT *PRE-DISPATCH* cluster-routing failure — i.e. "there is no node
+ * for this slot RIGHT NOW because the slot map is mid-rediscovery", thrown during node selection
+ * BEFORE the command reaches any node. Matched conservatively so a real WRONGTYPE, an auth failure,
+ * or an app bug still throws:
  *
  *  - the getSlotRandomNode `Cannot read properties of undefined (reading 'replicas')` TypeError
  *    (the exact fleet-wide throw measured during the rolling update);
  *  - sibling node-selection failures: a message/name mentioning `getSlotRandomNode`, a
- *    `getSlotMaster`/`getSlotRandomNode`-style "undefined reading 'replicas'/'master'/'client'"
- *    on an empty slot, an explicit `NoSlot`/"no slot"/"slot not served" error;
- *  - the `ClientClosedError` / `DisconnectsClientError` a CONCURRENT self-heal reconnect (FIX #1
- *    destroy()→flushAll) produces — also pre/at-dispatch and safe to re-route after rediscover.
+ *    `getSlotMaster`/`getSlotRandomNode`-style "undefined reading 'replicas'/'master'" on an empty
+ *    slot, an explicit `NoSlot`/"no slot"/"slot not served" error.
  *
- * Deliberately does NOT match: WRONGTYPE, NOAUTH/auth, CROSSSLOT (a real key-distribution bug,
- * not a transient), MOVED/ASK (node-redis handles those internally), generic ReplyError, or any
- * arbitrary TypeError whose text doesn't mention the routing-specific tokens above.
+ * Deliberately does NOT match (any of these re-throws so the caller sees today's behavior):
+ *  - WRONGTYPE, NOAUTH/auth, CROSSSLOT (a real key-distribution bug, not a transient), MOVED/ASK
+ *    (node-redis handles those internally), generic ReplyError, or any arbitrary TypeError whose
+ *    text doesn't mention the routing-specific tokens above;
+ *  - the reconnect rejections `ClientClosedError` / `DisconnectsClientError` (AUDIT-NARROWED, was
+ *    previously matched). A #2665 self-heal reconnect's `destroy()` → `queue.flushAll(new
+ *    DisconnectsClientError())` rejects the `#waitingForReply` queue too — i.e. commands ALREADY
+ *    WRITTEN to the socket and awaiting a reply, which the server may have ALREADY APPLIED before
+ *    the socket teardown. The client gives no signal to distinguish "never sent" from "sent and
+ *    applied", so retrying these could DOUBLE-EXECUTE a non-idempotent write (hIncrBy/incrBy/
+ *    lPush/rPush/sAdd/zAdd). They are therefore NOT transient for this guard's purposes — they
+ *    fail the caller exactly as before (preserving #2665's "a reconnect reject fails the caller"
+ *    invariant). Verified against @redis/client 5.8.x: `flushAll` (commands-queue.js) rejects both
+ *    `#toWrite` (pre-dispatch, safe) and `#waitingForReply` (post-dispatch, unsafe) with the SAME
+ *    error — so error name alone cannot prove the command never ran.
  */
 export function isTransientClusterRoutingError(err: unknown): boolean {
   if (err == null) return false;
 
-  const name = err instanceof Error ? err.name : '';
   const text = errText(err);
   if (!text) return false;
-
-  // The concurrent-reconnect errors node-redis raises when destroy()/flushAll rejected the
-  // queue (FIX #1 self-heal) or the socket closed mid-route. Pre/at-dispatch → safe to retry.
-  if (
-    name === 'ClientClosedError' ||
-    name === 'DisconnectsClientError' ||
-    /\bClientClosedError\b/.test(text) ||
-    /\bDisconnectsClientError\b/.test(text)
-  ) {
-    return true;
-  }
 
   // The exact getSlotRandomNode throw + its sibling empty-slot node-selection failures. The
   // canonical signature is a TypeError "Cannot read properties of undefined (reading 'replicas')"
   // raised from getSlotRandomNode; we match either the frame name OR the undefined-read on a
   // routing field, so a future node-redis patch that renames the frame still matches by shape.
+  // Only the documented pre-dispatch routing fields (`replicas`/`master`) qualify — `client` and
+  // `nodes` were dropped as speculative breadth (audit 🟡) since they're not the measured shapes.
   if (/getSlotRandomNode|getSlotMaster|getRandomNode/.test(text)) return true;
-  if (
-    /reading '(replicas|master|client|nodes)'/.test(text) &&
-    /undefined|null/.test(text)
-  ) {
+  if (/reading '(replicas|master)'/.test(text) && /undefined|null/.test(text)) {
     return true;
   }
 
@@ -160,8 +173,11 @@ const defaultSleep = (ms: number) =>
  * onResult('exhausted') and RE-THROW THE ORIGINAL error (no silent swallow). A NON-transient
  * error (WRONGTYPE, auth, app bug) → re-thrown IMMEDIATELY, no rediscover, no retry.
  *
- * Single-flight/idempotent-safe by construction: a transient routing error means the command
- * NEVER reached a node, so re-running exec() cannot double-execute a write/mutation.
+ * Single-flight/idempotent-safe by construction: the retried error shapes are all PRE-DISPATCH
+ * (node-selection / NoSlot), meaning the command NEVER reached a node, so re-running exec() cannot
+ * double-execute a write/mutation. The reconnect rejections (ClientClosedError /
+ * DisconnectsClientError) are intentionally NOT retried — they can fire on already-dispatched,
+ * possibly-already-applied commands (see isTransientClusterRoutingError) and so re-throw as before.
  *
  * Disabled (enabled=false) → pure pass-through: exec() runs exactly once and any error propagates
  * unchanged (today's behavior). On the happy path exec() is called EXACTLY ONCE.
@@ -209,8 +225,9 @@ export async function withClusterRoutingRetry<T>(
         throw err;
       }
 
-      // Bounded backoff, then nudge a rediscover and retry. The command never reached a node, so
-      // this is safe for reads AND writes.
+      // Bounded backoff, then nudge a rediscover and retry. Only pre-dispatch routing shapes reach
+      // here (the predicate excludes the reconnect rejections), so the command never reached a
+      // node — safe to retry for reads AND writes (no double-execution).
       const waitMs = backoff[Math.min(attempt, backoff.length - 1)] ?? 0;
       if (waitMs > 0) await sleep(waitMs);
       if (options.rediscover) {

--- a/src/server/redis/cluster-routing-retry.ts
+++ b/src/server/redis/cluster-routing-retry.ts
@@ -89,7 +89,15 @@ function errText(err: unknown): string {
  *    (the exact fleet-wide throw measured during the rolling update);
  *  - sibling node-selection failures: a message/name mentioning `getSlotRandomNode`, a
  *    `getSlotMaster`/`getSlotRandomNode`-style "undefined reading 'replicas'/'master'" on an empty
- *    slot, an explicit `NoSlot`/"no slot"/"slot not served" error.
+ *    slot, an explicit `NoSlot`/"no slot"/"slot not served" error;
+ *  - the `nodeClient(undefined)` "undefined (reading 'connectPromise')" TypeError (a THIRD
+ *    pre-dispatch shape): during topology churn `nodeClient(node)` (cluster-slots.js:213) is called
+ *    with `node === undefined` (empty-topology / keyless-command edge, or a slot whose `master` is
+ *    undefined) and reads `.connectPromise` off it, with a `getClient`/`nodeClient` stack frame
+ *    (NOT getSlotRandomNode, NOT replicas|master). The node is selected at cluster/index.js:177
+ *    BEFORE the dispatch try/catch — provably pre-dispatch, so retrying is write-safe exactly like
+ *    the getSlotRandomNode shape; without this the wave's keyless-command/empty-topology 500s slip
+ *    through.
  *
  * Deliberately does NOT match (any of these re-throws so the caller sees today's behavior):
  *  - WRONGTYPE, NOAUTH/auth, CROSSSLOT (a real key-distribution bug, not a transient), MOVED/ASK
@@ -117,10 +125,16 @@ export function isTransientClusterRoutingError(err: unknown): boolean {
   // canonical signature is a TypeError "Cannot read properties of undefined (reading 'replicas')"
   // raised from getSlotRandomNode; we match either the frame name OR the undefined-read on a
   // routing field, so a future node-redis patch that renames the frame still matches by shape.
-  // Only the documented pre-dispatch routing fields (`replicas`/`master`) qualify — `client` and
-  // `nodes` were dropped as speculative breadth (audit 🟡) since they're not the measured shapes.
+  // The documented pre-dispatch routing fields are `replicas`/`master` (getSlotRandomNode /
+  // getSlotMaster) AND `connectPromise` — the latter is `nodeClient(node)` (cluster-slots.js:213)
+  // called with `node === undefined` (empty-topology / keyless-command edge, or a slot whose
+  // `master` is undefined), throwing "Cannot read properties of undefined (reading 'connectPromise')"
+  // with a `getClient`/`nodeClient` stack frame. That path is selected at cluster/index.js:177
+  // BEFORE the dispatch try/catch (same pre-dispatch guarantee as getSlotRandomNode → safe to
+  // retry for writes too). `client` and `nodes` were dropped as speculative breadth (audit 🟡)
+  // since they're not the measured shapes.
   if (/getSlotRandomNode|getSlotMaster|getRandomNode/.test(text)) return true;
-  if (/reading '(replicas|master)'/.test(text) && /undefined|null/.test(text)) {
+  if (/reading '(replicas|master|connectPromise)'/.test(text) && /undefined|null/.test(text)) {
     return true;
   }
 
@@ -136,11 +150,15 @@ export type ClusterRoutingRetryResult = 'recovered' | 'exhausted';
 
 export interface ClusterRoutingRetryOptions {
   /**
-   * Trigger a topology rediscovery between attempts. Awaited (errors swallowed by the caller's
-   * wiring — a failed rediscover just means the retry runs against the same slot map and likely
-   * re-throws, which is still no worse than today). Injected so the pure module needs no redis
-   * import. If omitted, retries still occur (a fast in-flight rediscover from another path may
-   * have settled the map) but without an explicit nudge.
+   * Best-effort FIRE-AND-FORGET nudge to kick off a topology rediscovery between attempts. This is
+   * NOT awaited to completion: the wired-in `triggerTopologyRediscovery` (client.ts) starts
+   * `_slots.rediscover(...).catch(...)` but returns `undefined`, so awaiting this resolves
+   * immediately. It is the BACKOFF (below) — not this call — that gives the in-flight slot-map
+   * refresh time to settle before the retry runs (node-redis single-flights rediscover, so the
+   * nudge just ensures one is in progress). Injected so the pure module needs no redis import. If
+   * omitted, retries still occur (a fast in-flight rediscover from another path may have settled the
+   * map) but without an explicit nudge. Any error is swallowed by the wrapper — a failed nudge just
+   * means the retry runs against the same slot map and likely re-throws, no worse than today.
    */
   rediscover?: () => void | Promise<unknown>;
   /** Master kill-switch. Defaults to REDIS_CLUSTER_ROUTING_RETRY_ENABLED. When false: pass-through
@@ -167,11 +185,15 @@ const defaultSleep = (ms: number) =>
   ms > 0 ? new Promise<void>((r) => setTimeout(r, ms)) : Promise.resolve();
 
 /**
- * Run `exec()`. On a TRANSIENT cluster-routing error (isTransientClusterRoutingError), trigger
- * ONE rediscover() and retry with a small bounded backoff, up to `maxRetries` times. On success
- * after a retry → fire onResult('recovered'). After exhausting the retries → fire
- * onResult('exhausted') and RE-THROW THE ORIGINAL error (no silent swallow). A NON-transient
- * error (WRONGTYPE, auth, app bug) → re-thrown IMMEDIATELY, no rediscover, no retry.
+ * Run `exec()`. On a TRANSIENT cluster-routing error (isTransientClusterRoutingError), wait a small
+ * bounded backoff, fire a best-effort rediscover() NUDGE (fire-and-forget — see below), then retry,
+ * up to `maxRetries` times. NOTE: the backoff is the real settle window — the rediscover() nudge is
+ * not awaited to completion (the wired `triggerTopologyRediscovery` returns undefined, so awaiting
+ * it resolves immediately), it only ensures a single-flighted slot-map refresh is in progress while
+ * the backoff gives it a beat to land. On success after a retry → fire onResult('recovered'). After
+ * exhausting the retries → fire onResult('exhausted') and RE-THROW THE ORIGINAL error (no silent
+ * swallow). A NON-transient error (WRONGTYPE, auth, app bug) → re-thrown IMMEDIATELY, no rediscover,
+ * no retry.
  *
  * Single-flight/idempotent-safe by construction: the retried error shapes are all PRE-DISPATCH
  * (node-selection / NoSlot), meaning the command NEVER reached a node, so re-running exec() cannot
@@ -225,9 +247,11 @@ export async function withClusterRoutingRetry<T>(
         throw err;
       }
 
-      // Bounded backoff, then nudge a rediscover and retry. Only pre-dispatch routing shapes reach
-      // here (the predicate excludes the reconnect rejections), so the command never reached a
-      // node — safe to retry for reads AND writes (no double-execution).
+      // Bounded backoff (the real settle window), then fire a best-effort rediscover NUDGE
+      // (fire-and-forget — not awaited to completion; it just ensures an in-flight slot-map refresh
+      // is running while the backoff gives it time to land) and retry. Only pre-dispatch routing
+      // shapes reach here (the predicate excludes the reconnect rejections), so the command never
+      // reached a node — safe to retry for reads AND writes (no double-execution).
       const waitMs = backoff[Math.min(attempt, backoff.length - 1)] ?? 0;
       if (waitMs > 0) await sleep(waitMs);
       if (options.rediscover) {


### PR DESCRIPTION
## Problem

During **any** `next-redis-cluster` topology change — a rolling update, a node failover, or a scale event — the node-redis cluster client (`@redis/client@5.8.3`) sees a transiently inconsistent slot map and throws **fleet-wide**, *before* the command is dispatched to any node:

```
TypeError: Cannot read properties of undefined (reading 'replicas')
  at RedisClusterSlots.getSlotRandomNode (@redis/client@5.8.3/dist/lib/cluster/cluster-slots.js:342:19)
```

Measured during a live rolling update: **1,696 of these throws in 15 minutes across ~90 pods** (SSR `-primary`, `api-primary`, `api-heavy`). They surface as user-facing **HTTP 500s** on general cache READ paths (`tag.getAll`, `image.getGenerationData`, `hiddenPreferences.getHidden`, `nowPayments.getSupportedCurrencies`, `reaction.toggle`, `user.checkNotifications`, …). The cluster itself stays healthy (`cluster_state=ok`) — it is purely the *client* mishandling topology churn, and the waves self-clear in ~1–2 min as topology settles.

## The fix: retry-after-rediscover at the cluster `_execute` chokepoint

**Key safety argument — retry ONLY pre-dispatch routing throws:** `getSlotRandomNode` / `NoSlot` throws happen during **node selection / slot routing — BEFORE the command is dispatched to any node**. The command never executed. Therefore a bounded **retry-after-rediscover is safe for those shapes for ALL commands, reads AND writes/mutations** — zero double-execution risk (nothing executed to re-do). This is cleaner and broader than a read-path-only fail-open, which would still 500 every write during the wave.

**Why reconnect-rejection errors are NOT retried (audit fix):** an earlier revision of the predicate also matched `ClientClosedError` / `DisconnectsClientError`. An adversarial audit flagged this as a deploy-blocker. Per #2665 (`cluster-selfheal.ts:113`), a self-heal reconnect's `destroy()` → `queue.flushAll(new DisconnectsClientError())` rejects the **`#waitingForReply` queue** too — i.e. commands **already written to the socket and awaiting a reply**, which the server may have **already applied** before the socket teardown. Verified against `@redis/client` 5.8.x: `flushAll` (commands-queue.js) rejects both `#toWrite` (pre-dispatch, safe) *and* `#waitingForReply` (post-dispatch, unsafe) with the **same** error — so the error name alone cannot prove the command never ran. Retrying a `DisconnectsClientError` could therefore **double-execute a non-idempotent cluster write** (`hIncrBy`/`incrBy`/`lPush`/`rPush`/`sAdd`/`zAdd`). These errors are now **intentionally NOT retried** — they fail the caller exactly as today, preserving #2665's "a self-heal reconnect reject fails the caller" invariant. `MULTI`/pipeline (`#queue.addCommand`) is out of scope by design — the guard wraps the single cluster `_execute` chokepoint, not transactions.

A new pure module `src/server/redis/cluster-routing-retry.ts` exports:

- `isTransientClusterRoutingError(err)` — a conservative predicate matching **only** provably pre-dispatch routing failures: the `getSlotRandomNode`/`getSlotMaster` frame, the `reading 'replicas'`/`reading 'master'`/`reading 'connectPromise'` undefined-read TypeError, and `NoSlot`/"slot not served" errors. The `connectPromise` shape is `nodeClient(undefined)` (cluster-slots.js:213) on the empty-topology / keyless-command edge — selected at `cluster/index.js:177` BEFORE the dispatch try/catch, so it's pre-dispatch and write-safe to retry exactly like the `getSlotRandomNode` shape (without it the wave's keyless-command 500s slipped through). It deliberately does **not** match `WRONGTYPE`, `NOAUTH`, `CROSSSLOT`, an arbitrary app TypeError, **or** the reconnect rejections `ClientClosedError`/`DisconnectsClientError` (post-dispatch — see above) — those all re-throw. The speculative `reading 'client'`/`'nodes'` shapes were also dropped (not measured, could mask real bugs).
- `withClusterRoutingRetry(exec, { rediscover, ... })` — runs `exec()`, and on a transient routing error waits a small bounded backoff (default: 2 retries, ~50ms then ~150ms), fires a best-effort `rediscover()` **nudge**, then retries. The `rediscover()` nudge is **fire-and-forget** — `triggerTopologyRediscovery` does not return/await the rediscover promise, so it's the **backoff**, not the rediscover call, that gives the in-flight (single-flighted) slot-map refresh time to settle before the retry. After exhausting retries it **re-throws the original error** (preserves today's behavior — no silent swallow).

It is wired into `instrumentCommands` in `src/server/redis/client.ts` **for the cluster client only** (`wrapWithDeadline` path), composed *inside* the single inflight inc/dec accounting and *under* the existing `withCommandDeadline` race — the retried attempts are sequential, so a retried command counts as exactly one inflight unit (no double-count, `done()` fires once). The single-node sysRedis `sendCommand` path is never touched.

## Why #2665 doesn't cover this

| #2665 fix | Why it misses this wave |
|---|---|
| **FIX #1** `ClusterSelfHealWatchdog` | Fires only on a *sustained* inflight pin >50 for 20s (the hang-wedge). The `getSlotRandomNode` throw is immediate / fails fast → never pins inflight → watchdog never sees it. And when the watchdog *does* fire, its `destroy()`→`flushAll()` rejects in-flight commands = its own 500 burst (which is exactly why this guard does NOT retry that error). |
| **FIX #3** `withMetricWriteFailSoft` | Fail-softs only the `metrics:lock:Image` setNX/expire + `hIncrBy` write path. `civitai_app_redis_metric_write_failsoft_total = 0` during the wave — the 500s are general **reads**, not metric writes. |

## Env vars

| Var | Default | Purpose |
|---|---|---|
| `REDIS_CLUSTER_ROUTING_RETRY_ENABLED` | `true` | Master kill-switch. `=false` restores today's exact behavior (one attempt, throw on a routing error). |
| `REDIS_CLUSTER_ROUTING_RETRY_MAX` | `2` | Max retries after the initial attempt. `0` = no retry (pass-through). |
| `REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MS` | `50` | Backoff before retry #1. |
| `REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MAX_MS` | `150` | Backoff before retry #2 (and reused for any further retries). |

**Kill-switch:** a single `REDIS_CLUSTER_ROUTING_RETRY_ENABLED=false` env flip fully disables the guard and restores the current behavior — no redeploy of code required.

## Observability

New counter `civitai_app_redis_routing_retry_total{result="recovered"|"exhausted"}`. A rising `recovered` series during a rolling update is direct confirmation the fix converted a would-be 500 wave into transparent retries; a rising `exhausted` series means the slot map stayed inconsistent past the bounded retries and the original error re-threw (the pre-fix behavior). Surfaced via the same `globalThis.__civitaiRedisMetrics` bridge as the existing redis metrics — the pure module stays prom-free.

## Tests

`src/server/redis/__tests__/cluster-routing-retry.test.ts` (31 cases) covers: predicate TRUE for the `getSlotRandomNode`/`replicas` TypeError, the documented `reading 'master'` shape, **the `nodeClient(undefined)`/`reading 'connectPromise'` 3rd pre-dispatch shape (stacked + bare) with an end-to-end `withClusterRoutingRetry` recovery (`recovered`)**, and `NoSlot`; predicate **FALSE** for a `connectPromise` mention without an undefined/null co-occurrence (guard symmetry); predicate **FALSE** for `WRONGTYPE`/auth/`CROSSSLOT`/app-bug-TypeError/`null`/non-error, **for the reconnect `ClientClosedError`/`DisconnectsClientError` (post-dispatch → double-exec risk, audit-inverted)**, and for the dropped speculative `reading 'client'`/`'nodes'` shapes; transient→rediscover→retry succeeds→`recovered`; persistent→exhausts→rediscover N times→re-throws **the original**→`exhausted`; non-transient→no rediscover/no retry/immediate throw; **write-safety: `DisconnectsClientError`/`ClientClosedError` are NOT retried — `exec` called exactly once, original re-thrown (the path the audit said was untested)**; disabled→pass-through; honors max + backoff (incl. reuse of the last backoff value); happy path calls `exec` exactly once; a recovering write is not double-executed; throwing `onResult`/`rediscover` never breaks the guard or masks the original error.

`src/server/redis/__tests__/cluster-inflight.test.ts` (+3 cases) proves the inflight counter nets zero across a retried command (recovered, exhausted, and two concurrent) — no leak, no negative.

**Local run (NixOS, vitest):** `137/137` redis unit tests pass (`vitest run --project unit src/server/redis/__tests__`); **zero new `tsc` errors** in the changed files (large pre-existing baseline unchanged).

## Audit follow-up (2 non-blocking 🟡, both fixed)

A second adversarial audit (grounded against `@redis/client` 5.8.3 source) surfaced two non-blocking 🟡 items, both now addressed (commit `0772428`):

- **Predicate gap — `nodeClient(undefined)` → `reading 'connectPromise'`:** during topology churn `nodeClient(node)` (cluster-slots.js:213) is called with `node === undefined` (empty-topology / keyless-command edge, or a slot whose `master` is undefined), throwing `Cannot read properties of undefined (reading 'connectPromise')` with a `getClient`/`nodeClient` stack frame — **not** `getSlotRandomNode`, **not** `replicas`/`master`. The old predicate missed it, so those commands still 500'd during the wave. It's selected at `cluster/index.js:177` BEFORE the dispatch try/catch → **provably pre-dispatch**, so retrying is write-safe exactly like the existing shapes. The `reading '(...)'` alternation now includes `connectPromise` (the undefined/null co-occurrence guard is preserved); the speculative `client`/`nodes` names were **not** re-added.
- **Rediscover-is-a-nudge framing (docs-only):** `triggerTopologyRediscovery` starts `_slots.rediscover(...).catch(...)` but **returns `undefined`**, so `await options.rediscover()` resolves immediately — the retry fires after only the backoff, not after rediscovery completes. The behavior is fine (node-redis single-flights rediscover; the backoff is the real settle window), but the comments oversold it. Corrected the framing in `cluster-routing-retry.ts`, `client.ts`, and the backoff env-var docs in `server-schema.ts`. **No runtime behavior changed** — `triggerTopologyRediscovery` still does not return the promise (returning it would alter the retry timing / blast radius).

## Money / entitlement non-impact

No money or entitlement blast radius. This touches only the **cache/routing** path on the sharded cluster client, and the audit fix above specifically removes the one path (reconnect-rejection retry) that could have double-applied a write. Money and entitlement live in Postgres and the single-node sysRedis client — neither of which this PR touches (the sysRedis `sendCommand` path is explicitly excluded; a blanket sys-client change caused the #2556/#2586 wedge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

