### PR TITLE
fix(blocks): actionable dev-token error when app has no live deployment (#22)

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -309,16 +309,29 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       app: { select: { allowedScopes: true, userId: true } },
     },
   });
-  // 404 (never leak which) for missing / not-approved / not-owned. Ownership is
-  // checked AFTER existence but we collapse them into one 404 so a non-owner
-  // can't probe which appBlockIds exist.
-  if (!block || block.status !== 'approved' || !block.app) {
+  // 404 (never leak which) for a row that doesn't exist or isn't owned by the
+  // caller. We check EXISTENCE+OWNERSHIP first (collapsed into one bare 404 so a
+  // non-owner can't probe which appBlockIds exist OR their approval state), and
+  // ONLY THEN — for a row the caller demonstrably owns — surface the actionable
+  // not-yet-live message. A non-owner therefore still gets the indistinguishable
+  // bare 404 regardless of the app's status (no probe oracle); approval-state
+  // detail is revealed exclusively to the confirmed owner.
+  if (!block || !block.app || block.app.userId !== user.id) {
     res.status(404).json({ message: 'App not found' });
     return;
   }
-  if (block.app.userId !== user.id) {
-    // Not the owner → 404, not 403, so ownership isn't a probe oracle.
-    res.status(404).json({ message: 'App not found' });
+  // Owned, but no LIVE deployment yet (the dev-token mint resolves a DEPLOYED
+  // block instance — deployState: live, i.e. an `approved` AppBlock row). A
+  // brand-new app — even right after a successful submit (status: pending) —
+  // legitimately exists and is owned here but has nothing live to mint against.
+  // Return an ACTIONABLE message instead of the misleading bare "App not found".
+  if (block.status !== 'approved') {
+    res.status(404).json({
+      message:
+        `block '${block.blockId}' has no live deployment — dev:live requires an ` +
+        `approved + deployed version (deployState: live). Until your first ` +
+        `version is live, validate locally with dev:harness (mock).`,
+    });
     return;
   }
 

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -313,21 +313,28 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(mockSign).not.toHaveBeenCalled();
   });
 
-  it('404 when the app is not found', async () => {
+  it('404 with the bare "App not found" message when the app truly does not exist', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     mockAppBlockFindUnique.mockResolvedValueOnce(null);
     const { req, res } = authPost({ appBlockId: 'apb_missing' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(404);
+    expect((res._getJSONData() as { message: string }).message).toBe('App not found');
     expect(mockSign).not.toHaveBeenCalled();
   });
 
-  it('404 when the app is not approved', async () => {
+  it('404 with an ACTIONABLE no-live-deployment message when an OWNED app is not approved (pending)', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     mockAppBlockFindUnique.mockResolvedValueOnce(pageApp({ status: 'pending' }));
     const { req, res } = authPost({ appBlockId: 'apb_abc' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(404);
+    const msg = (res._getJSONData() as { message: string }).message;
+    // NOT the misleading bare message...
+    expect(msg).not.toBe('App not found');
+    // ...but an actionable one naming the block + pointing at dev:harness.
+    expect(msg).toContain("block 'my-page-app' has no live deployment");
+    expect(msg).toContain('dev:harness');
     expect(mockSign).not.toHaveBeenCalled();
   });
 
@@ -339,6 +346,10 @@ describe('POST /api/v1/blocks/dev-token', () => {
     const { req, res } = authPost({ appBlockId: 'apb_abc' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(404);
+    // A non-owner gets the bare, indistinguishable message even though the row
+    // exists and is approved — the actionable status detail is owner-only, so
+    // ownership/approval-state is never a probe oracle.
+    expect((res._getJSONData() as { message: string }).message).toBe('App not found');
     expect(mockSign).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What

`POST /api/v1/blocks/dev-token` (added in #2718) mints a short-lived dev-token for App Blocks `dev:live` local development. The mint resolves a **deployed** block instance (`deployState: live`, i.e. an `approved` `AppBlock` row). When the caller **owns** an app that isn't live yet — e.g. a brand-new app right after a successful submit (`status: pending`) — the handler returned the bare, misleading `{"message":"App not found"}`.

## Change (message + branch-ordering only)

Split the conflated lookup at the resolve step:

- **Truly missing OR not owned by the caller** → unchanged bare `App not found` (collapsed into one indistinguishable 404 so a non-owner can't probe which appBlockIds exist *or* their approval state).
- **Owned but no live deployment** (`status !== 'approved'`) → new actionable message:

  > block '<slug>' has no live deployment — dev:live requires an approved + deployed version (deployState: live). Until your first version is live, validate locally with dev:harness (mock).

**Before:** `App not found`
**After (owned, pending):** the actionable message above (names the block slug, points at `dev:harness`).

HTTP status stays **404** (same as before). No change to auth, scopes, token minting, ownership checks, rate limiting, or the security model. The non-owner path still yields the indistinguishable bare message regardless of approval state — ownership/approval-state is never a probe oracle.

## Tests

Extended the existing endpoint test (`src/tests/api/v1/blocks/dev-token.test.ts`) to assert the two distinct messages: bare for truly-missing **and** non-owner; actionable (slug + `dev:harness`) for owned-but-pending. **All 30 dev-token unit tests pass.**

Typecheck: no new `tsc --noEmit` errors in either touched file (the repo's full typecheck is not clean on `main` — those errors are pre-existing and unrelated).

This is the server half of the error-message improvement referenced by civitai/cli#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)