### PR TITLE
fix(metrics): restore v2 agg-source provider on MetricService (regressed by #2666)

### DIFF
--- a/src/pages/api/internal/bitdex-stats.ts
+++ b/src/pages/api/internal/bitdex-stats.ts
@@ -3,6 +3,7 @@ import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { dbRead } from '~/server/db/client';
 import { clickhouse } from '~/server/clickhouse/client';
 import { redis } from '~/server/redis/client';
+import { imageMetricAggSource } from '~/server/flipt/client';
 import { MetricService } from '../../../../event-engine-common/services/metrics';
 import type {
   IClickhouseClient,
@@ -67,7 +68,8 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
       // the FINAL entityMetricDailyAgg_v2 view), per-ID with stampede caching.
       const metricService = new MetricService(
         clickhouse as IClickhouseClient,
-        redis as unknown as IRedisClient
+        redis as unknown as IRedisClient,
+        imageMetricAggSource
       );
       const metrics = await metricService.fetch('Image', ids);
 

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -1,6 +1,7 @@
 import { FliptClient } from '@flipt-io/flipt-client-js';
 import { env } from '~/env/server';
 import { logToAxiom } from '../logging/client';
+import type { AggSource } from '../../../event-engine-common/services/metrics';
 
 export enum FLIPT_FEATURE_FLAGS {
   // Mirrors the `articleRatingDispute` fliptKey in feature-flags.service.ts so
@@ -381,12 +382,37 @@ export async function ensureFliptInitialized(): Promise<void> {
   await FliptSingleton.getInstance();
 }
 
+// Single source of truth for which ClickHouse table the entity-metric READ path
+// pulls per-(entity,metric,day) totals from. BOTH read paths must use this:
+//   - `MetricService` (the watcher-fed `metrics:*` cache populate) — via the
+//     `aggSourceProvider` it is constructed with (image.service / bitdex-stats).
+//   - the direct CH subquery sites — via `buildEntityMetricPerDaySource` below,
+//     which emits the same `entityMetricDailyAgg_v2` table.
+//
+// `entityMetricDailyAgg_v2` is a read VIEW that already returns FINAL per-day
+// totals, so `needsArgMaxDedup: false` (no argMax dedup needed).
+//
+// History: PR #2666 made the v2 cutover permanent and DELETED the prior
+// `getEntityMetricAggSource()` provider, dropping the provider arg from every
+// `new MetricService(...)`. That silently fell MetricService back to the
+// submodule's `DEFAULT_AGG_SOURCE = entityMetricDailyAgg_new`. When that legacy
+// ReplacingMergeTree table was dropped from ClickHouse (2026-06-24), MetricService
+// began throwing `UNKNOWN_TABLE` (~100k/hr) → 500s on /api/v1/images and on-site
+// image feeds. This constant restores the deleted "one shared source of truth"
+// so a future table change can't migrate one reader and orphan another. v2 is
+// permanent — there is intentionally no Flipt flag here.
+export const imageMetricAggSource = (): AggSource => ({
+  table: 'entityMetricDailyAgg_v2',
+  needsArgMaxDedup: false,
+});
+
 // Build the inner `(entityId, metricType, day, total)` subquery the direct CH
 // read sites (search-index / comic populate / metric-helpers) sum over. `where`
 // is the caller's full WHERE clause (e.g. "WHERE entityType = 'Image' AND ...").
-// Reads the already-FINAL view `entityMetricDailyAgg_v2`, so we select total
-// directly (no argMax dedup). Selecting metricType is harmless even for callers
-// that only group by day (it's just carried through the subquery).
+// Reads the already-FINAL view `entityMetricDailyAgg_v2` (see imageMetricAggSource
+// above — same source of truth), so we select total directly (no argMax dedup).
+// Selecting metricType is harmless even for callers that only group by day (it's
+// just carried through the subquery).
 //
 // (Historically this was flag-switchable via METRICS_AGG_V2_READ between the
 // ReplacingMergeTree `entityMetricDailyAgg_new` — which needed argMax — and the

--- a/src/server/services/__tests__/image-metric-agg-source.test.ts
+++ b/src/server/services/__tests__/image-metric-agg-source.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Guards the fix for the 2026-06-24 incident: PR #2666 deleted civitai's
+// `getEntityMetricAggSource()` provider and dropped the provider arg from every
+// `new MetricService(...)`, silently falling MetricService back to the submodule
+// DEFAULT_AGG_SOURCE = `entityMetricDailyAgg_new`. That table was later dropped
+// from ClickHouse → UNKNOWN_TABLE → 500s on /api/v1/images + on-site image feeds.
+// `imageMetricAggSource` is the restored single source of truth: it MUST resolve
+// to the FINAL `entityMetricDailyAgg_v2` view with no argMax dedup, and MUST NOT
+// resolve to the dropped legacy `_new` table.
+
+// client.ts's transitive import graph reads `~/env/server` at module load (which
+// validates all prod env in test and throws), and pulls the flipt SDK + axiom
+// logger. Stub the smallest seams so importing it is side-effect-free; the
+// provider under test reads NONE of these — it's a plain hardcoded constant.
+vi.mock('~/env/server', () => ({ env: new Proxy({}, { get: () => undefined }) }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('@flipt-io/flipt-client-js', () => ({ FliptClient: class {} }));
+
+import { imageMetricAggSource } from '~/server/flipt/client';
+
+describe('imageMetricAggSource', () => {
+  it('resolves to the FINAL entityMetricDailyAgg_v2 view with no argMax dedup', () => {
+    expect(imageMetricAggSource()).toEqual({
+      table: 'entityMetricDailyAgg_v2',
+      needsArgMaxDedup: false,
+    });
+  });
+
+  it('does NOT resolve to the dropped legacy entityMetricDailyAgg_new table (the #2666 regression)', () => {
+    const source = imageMetricAggSource();
+    expect(source.table).not.toBe('entityMetricDailyAgg_new');
+    // v2 is already FINAL — dedup must be off (argMax on the legacy table is the
+    // marker of the old ReplacingMergeTree read path).
+    expect(source.needsArgMaxDedup).toBe(false);
+  });
+});

--- a/src/server/services/__tests__/image-metric-service-provider.test.ts
+++ b/src/server/services/__tests__/image-metric-service-provider.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AggSource } from '../../../../event-engine-common/services/metrics';
+
+// Regression guard for the 2026-06-24 incident (PR #2666). The image-metric read
+// path must construct `MetricService` WITH an aggSourceProvider that resolves to
+// the FINAL `entityMetricDailyAgg_v2` view. #2666 dropped that provider arg →
+// MetricService fell back to the submodule DEFAULT_AGG_SOURCE (the legacy
+// `entityMetricDailyAgg_new` table, since dropped from ClickHouse) → UNKNOWN_TABLE
+// → 500s on /api/v1/images + on-site image feeds.
+//
+// We replace MetricService with a capturing class that records the 3rd
+// constructor arg, drive getImageMetricsObject (which lazily constructs the
+// shared singleton via getImageMetricService), and assert the captured provider
+// resolves to v2 — NOT undefined, NOT `entityMetricDailyAgg_new`. A future edit
+// that re-drops the provider arg (the exact #2666 regression) FAILS this test.
+
+const { fetchMock, capturedProviders } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  capturedProviders: [] as Array<(() => Promise<AggSource> | AggSource) | undefined>,
+}));
+
+// image.service's import graph (selectors/caches) calls `Prisma.validator(...)`
+// at module load. Under vitest's SSR transform the generated @prisma/client
+// re-export resolves to a stub without `.validator`, so stub the Prisma helpers
+// it touches at import time (established pattern, e.g. model3d-visible-id-for-post).
+vi.mock('@prisma/client', () => ({
+  Prisma: {
+    validator: () => (x: unknown) => x,
+    sql: () => ({}),
+    join: () => ({}),
+    raw: () => ({}),
+  },
+}));
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/prom/client')>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+// Capture the aggSourceProvider passed to every MetricService construction.
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = fetchMock;
+    constructor(_ch: unknown, _redis: unknown, aggSourceProvider?: () => unknown) {
+      capturedProviders.push(aggSourceProvider as never);
+    }
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+// Fully replace env (real `~/env/server` validates ALL prod env and throws in
+// test). A Proxy returns undefined for any var, and a safe value for *_URL /
+// numeric-looking config the import graph builds at module load. Mirrors the
+// established pattern in image-metrics-timeout.test.ts.
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+import { getImageMetricsObject } from '../image.service';
+
+describe('image-metric read path constructs MetricService with the v2 agg-source provider', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('passes a provider resolving to entityMetricDailyAgg_v2 (guards the #2666 no-provider regression)', async () => {
+    fetchMock.mockResolvedValue({});
+
+    // Drives getImageMetricService() → constructs the shared MetricService singleton.
+    await getImageMetricsObject([{ id: 1 }]);
+
+    // At least one MetricService was constructed on this path.
+    expect(capturedProviders.length).toBeGreaterThan(0);
+
+    for (const provider of capturedProviders) {
+      // The #2666 regression was a construction with NO provider (undefined) →
+      // submodule DEFAULT_AGG_SOURCE = entityMetricDailyAgg_new. Reject that.
+      expect(provider, 'MetricService must be constructed WITH an aggSourceProvider').toBeDefined();
+
+      const source = await provider!();
+      expect(source).toEqual({ table: 'entityMetricDailyAgg_v2', needsArgMaxDedup: false });
+      expect(source.table).not.toBe('entityMetricDailyAgg_new');
+    }
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -206,7 +206,13 @@ import { getImageS3Client } from '~/utils/s3-client';
 import { serverUploadImage, getB2ImageS3Client } from '~/utils/s3-utils';
 import { resolveMediaLocation } from '~/server/services/storage-resolver';
 import { isDefined, isNumber } from '~/utils/type-guards';
-import { FLIPT_FEATURE_FLAGS, getFliptBoolean, getFliptVariant, isFlipt } from '../flipt/client';
+import {
+  FLIPT_FEATURE_FLAGS,
+  getFliptBoolean,
+  getFliptVariant,
+  imageMetricAggSource,
+  isFlipt,
+} from '../flipt/client';
 import { buildFliptContext } from '~/server/services/feature-flags.service';
 import { queryBitdex } from '~/server/bitdex/client';
 import type { FilterClause, SortClause, Value } from '~/server/bitdex/client';
@@ -2836,7 +2842,11 @@ export async function getImagesFromFeedSearch(
       },
       clickhouse as IClickhouseClient,
       pgDbWrite as IDbClient,
-      new MetricService(clickhouse as IClickhouseClient, redis as unknown as IRedisClient),
+      new MetricService(
+        clickhouse as IClickhouseClient,
+        redis as unknown as IRedisClient,
+        imageMetricAggSource
+      ),
       new CacheService(
         redis as unknown as IRedisClient,
         pgDbWrite as IDbClient,
@@ -4612,7 +4622,8 @@ let _imageMetricService: MetricService | null = null;
 const getImageMetricService = () =>
   (_imageMetricService ??= new MetricService(
     clickhouse as IClickhouseClient,
-    redis as unknown as IRedisClient
+    redis as unknown as IRedisClient,
+    imageMetricAggSource
   ));
 
 type ImageMetricsObject = Record<


### PR DESCRIPTION
## Incident root cause

A live prod incident: `MetricService` (the metric-read class in the `event-engine-common` submodule) was throwing `UNKNOWN_TABLE` at ~100k/hr → **500s on `/api/v1/images` and on-site image feeds**.

- `MetricService` reads per-(entity, metric, day) totals from a ClickHouse table chosen by an injected `aggSourceProvider`. With **no provider** it falls back to the submodule's `DEFAULT_AGG_SOURCE = { table: 'entityMetricDailyAgg_new', needsArgMaxDedup: true }` (the legacy `ReplacingMergeTree`).
- **PR #2666** ("make entity-metric v2 + watcher cutover permanent") **deleted** civitai's `getEntityMetricAggSource()` provider (it lived in `src/server/flipt/client.ts`) and **removed the provider argument from every `new MetricService(...)`**. `MetricService` then silently fell back to `entityMetricDailyAgg_new`.
- That legacy table was **dropped from ClickHouse on 2026-06-24** → every `MetricService.fetch` on a cache miss threw `UNKNOWN_TABLE`.
- #2666 *did* correctly hardcode the **other** read path (`buildEntityMetricPerDaySource` → `entityMetricDailyAgg_v2`) but **missed this one**, so the "single source of truth shared by every read site" the pre-#2666 code had was broken — one reader migrated, the other orphaned.

## The fix

Restore the deleted single source of truth as a plain **hardcoded v2 provider** (no Flipt flag — v2 is permanent, which was #2666's intent):

```ts
// src/server/flipt/client.ts — colocated with buildEntityMetricPerDaySource
export const imageMetricAggSource = (): AggSource => ({
  table: 'entityMetricDailyAgg_v2',
  needsArgMaxDedup: false,
});
```

`entityMetricDailyAgg_v2` is a read VIEW that already returns FINAL per-day totals → `needsArgMaxDedup: false`. Placing it next to `buildEntityMetricPerDaySource` means **both** read paths share one table-name source of truth, so a future table change can't migrate one reader and orphan another (the property that #2666 lost).

Pass `imageMetricAggSource` to **all three** `MetricService` construction sites (re-grepped — these are all of them):

- `src/server/services/image.service.ts` — `getImagesFromFeedSearch` construction
- `src/server/services/image.service.ts` — the `_imageMetricService ??= new MetricService(...)` memoized singleton (the image-feed hot path)
- `src/pages/api/internal/bitdex-stats.ts` — `metricService` (imports the provider via the `~/server/flipt/client` alias)

## Test coverage

- `image-metric-agg-source.test.ts` — asserts `imageMetricAggSource()` returns exactly `{ table: 'entityMetricDailyAgg_v2', needsArgMaxDedup: false }` and **not** `entityMetricDailyAgg_new`.
- `image-metric-service-provider.test.ts` — **regression guard for the exact #2666 break**: replaces `MetricService` with a capturing constructor, drives `getImageMetricsObject` to construct the shared singleton, and asserts the captured `aggSourceProvider` is **defined** and **resolves to `entityMetricDailyAgg_v2`** (not undefined / not `_new`). Mutation-verified: removing the provider from a construction site makes this test fail.
- Run: `vitest run --project unit src/server/services/__tests__/image-metric-agg-source.test.ts src/server/services/__tests__/image-metric-service-provider.test.ts` → **3 passed**. Full `__tests__` directory: same 155 pre-existing `Prisma.*-is-not-a-function` SSR-baseline failures as `origin/main`, **+3 new passing tests, 0 new failures**.
- Typecheck: `tsc --noEmit` error multiset over the 3 changed files is **byte-identical to baseline** (the repo's large pre-existing Prisma-type baseline) — **zero new errors**.

## Rollout note

Deploy this. Once `query_log` shows **zero `entityMetricDailyAgg_new` readers**, the temporary `entityMetricDailyAgg_new` ClickHouse compat view (and the underlying table) can be retired.

## Defense-in-depth follow-up (NOT in this PR)

This PR intentionally does **not** touch the `event-engine-common` submodule (separate repo + a submodule-ref bump = cross-repo scope creep). Recommended follow-up: flip the submodule's `DEFAULT_AGG_SOURCE` to `entityMetricDailyAgg_v2` (`needsArgMaxDedup: false`) so framework-free / test callers that construct `MetricService` without a provider can't silently regress onto a dropped table again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)