### PR TITLE
fix(app-blocks): hydrate full Flipt context in token-subject flag-gate (pre-GA)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.flag-gate-hydrate.test.ts
+++ b/src/server/routers/__tests__/blocks.router.flag-gate-hydrate.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Pre-GA hardening — `assertAppBlocksEnabledForTokenUser` (the BLOCK-TOKEN
+ * runtime gate) must hydrate the FULL server-side SessionUser before feeding it
+ * to the App Blocks flag, so the Flipt context carries the user's REAL tier /
+ * isMember — not the `'free'` / `'false'` type-defaults a trimmed
+ * `{ id, isModerator }` cast (the #2740 shape) would leave.
+ *
+ * This matters because `isAppBlocksEnabled({ user })` → `buildFliptContext(user)`
+ * reads `id`, `isModerator`, AND `tier` (deriving `isMember`). It's correct
+ * TODAY only because the live `app-blocks-enabled` flag segments solely on
+ * `isModerator`; the moment it's widened to segment on `tier`/region, a stale
+ * `tier:'free'` context would silently mis-gate a paying user.
+ *
+ * Strategy: drive the REAL `assertAppBlocksEnabledForTokenUser` through the
+ * `pollWorkflow` proc with the REAL `app-blocks-flag` service AND the REAL
+ * `buildFliptContext`. Only `~/server/flipt/client` is stubbed — its `isFlipt`
+ * CAPTURES the exact context the gate built and returns `true` (gate passes).
+ * `getSessionUser` is mocked to a moderator on a paid tier, and we assert the
+ * captured context carries the real `tier`/`isMember` — i.e. the cast is now
+ * faithful. We also drive a flag implementation that SEGMENTS ON TIER to prove
+ * the gate would evaluate against the user's actual tier post-widening.
+ *
+ * Mock set mirrors `blocks.router.workflow.test.ts` (heavy services stubbed so
+ * importing the router doesn't drag in the generated Prisma client / selectors).
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetOrchestratorToken,
+  mockGetWorkflow,
+  mockGetUserById,
+  mockGetSessionUser,
+  mockIsFlipt,
+  mockGetUserBuzzAccounts,
+  mockLogToAxiom,
+  mockRedis,
+  mockSysRedis,
+  mockDbRead,
+} = vi.hoisted(() => ({
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetOrchestratorToken: vi.fn(),
+  mockGetWorkflow: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockGetSessionUser: vi.fn(),
+  mockIsFlipt: vi.fn(),
+  mockGetUserBuzzAccounts: vi.fn(),
+  mockLogToAxiom: vi.fn(async () => undefined),
+  mockRedis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+  mockSysRedis: {
+    get: vi.fn(async () => null),
+    incrBy: vi.fn(async () => 0),
+    decrBy: vi.fn(async () => 0),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => -1),
+  },
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...a: unknown[]) => mockParseSubjectUserId(...a),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: mockGetOrchestratorToken,
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: mockGetWorkflow,
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  getUserById: (...a: unknown[]) => mockGetUserById(...a),
+}));
+// The NEW dependency under test: the gate now resolves the full SessionUser.
+vi.mock('~/server/auth/session-user', () => ({
+  getSessionUser: (...a: unknown[]) => mockGetSessionUser(...a),
+}));
+// REAL app-blocks-flag + REAL buildFliptContext run; only the Flipt edge is
+// stubbed so we can CAPTURE the context the gate built.
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: (...a: unknown[]) => mockIsFlipt(...a),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: (...a: unknown[]) => mockGetUserBuzzAccounts(...a),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function validClaims(over: Record<string, unknown> = {}) {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti_test',
+    blockId: 'blk_test',
+    appId: 'app_test',
+    blockInstanceId: 'bki_test',
+    ctx: { modelId: 7, slotId: 'model.sidebar_top' },
+    scopes: ['ai:write:budgeted'],
+    buzzBudget: 50,
+    ...over,
+  };
+}
+
+function fakeCtx() {
+  return {
+    acceptableOrigin: true,
+    user: undefined, // block-token proc: no session — the gate must use the TOKEN subject
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { canViewNsfw: false, isBlue: false, isGreen: false, isGreenSession: false } as never,
+    track: undefined,
+  };
+}
+
+beforeEach(() => {
+  for (const fn of [
+    mockVerifyBlockToken,
+    mockParseSubjectUserId,
+    mockGetOrchestratorToken,
+    mockGetWorkflow,
+    mockGetUserById,
+    mockGetSessionUser,
+    mockIsFlipt,
+    mockGetUserBuzzAccounts,
+    mockLogToAxiom,
+  ]) {
+    fn.mockReset();
+  }
+  mockVerifyBlockToken.mockResolvedValue(validClaims());
+  mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
+  mockGetOrchestratorToken.mockResolvedValue('orch_token');
+  mockGetWorkflow.mockResolvedValue({ id: 'wf_1', status: 'succeeded', cost: { total: 0 }, steps: [] });
+  // assertViewerIsModerator reads the (trimmed) row directly — keep it a mod.
+  mockGetUserById.mockResolvedValue({ id: 42, isModerator: true });
+  mockGetUserBuzzAccounts.mockResolvedValue({ yellow: 10000, blue: 0, green: 0 });
+  // Default Flipt stub: ON only when the captured context says isModerator==true
+  // (mirrors the LIVE app-blocks-enabled `moderators` segment). Tests that probe
+  // tier-segmentation override this.
+  mockIsFlipt.mockImplementation(
+    async (_flag: string, _entityId: string, ctx?: Record<string, string>) =>
+      ctx?.isModerator === 'true'
+  );
+});
+
+describe('assertAppBlocksEnabledForTokenUser — Flipt context is hydrated from the real SessionUser', () => {
+  it('builds the Flipt context with the REAL tier/isMember (not free/false defaults)', async () => {
+    // A moderator on a PAID tier. The trimmed #2740 cast would have lost `tier`
+    // → context tier:'free' / isMember:'false'. The fix resolves the full user.
+    mockGetSessionUser.mockResolvedValue({
+      id: 42,
+      isModerator: true,
+      tier: 'gold',
+    } as never);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    // The gate resolved the full SessionUser for the TOKEN subject (42), not ctx.user.
+    expect(mockGetSessionUser).toHaveBeenCalledWith({ userId: 42 });
+
+    // Find the app-blocks-enabled Flipt eval and assert its context is faithful.
+    const appBlocksCall = mockIsFlipt.mock.calls.find((c) => c[0] === 'app-blocks-enabled');
+    expect(appBlocksCall).toBeDefined();
+    const [, entityId, ctx] = appBlocksCall as [string, string, Record<string, string>];
+    expect(entityId).toBe('42');
+    expect(ctx.isModerator).toBe('true');
+    // The load-bearing assertions: REAL subscription tier, not the stale default.
+    expect(ctx.tier).toBe('gold');
+    expect(ctx.isMember).toBe('true');
+    expect(ctx.userId).toBe('42');
+  });
+
+  it('a flag SEGMENTED ON TIER now evaluates against the user real tier (post-widening proof)', async () => {
+    // Simulate widening app-blocks-enabled to gate on a paid tier: ON iff
+    // tier !== 'free'. With the OLD trimmed cast the context would always say
+    // tier:'free' → this paying moderator would be wrongly BLOCKED. With the
+    // hydrated context the gate sees tier:'gold' and PASSES.
+    mockIsFlipt.mockImplementation(
+      async (_flag: string, _entityId: string, ctx?: Record<string, string>) =>
+        !!ctx && ctx.tier !== 'free'
+    );
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'gold' } as never);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    // Does NOT throw "App Blocks not enabled" — the tier-segmented flag passes
+    // because the context carries the real tier.
+    await expect(
+      caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).resolves.toBeDefined();
+
+    const appBlocksCall = mockIsFlipt.mock.calls.find((c) => c[0] === 'app-blocks-enabled');
+    expect((appBlocksCall as [string, string, Record<string, string>])[2].tier).toBe('gold');
+  });
+
+  it('a vanished subject → undefined user → global eval → flag false → blocked (fail-closed preserved)', async () => {
+    mockGetSessionUser.mockResolvedValue(undefined as never);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+
+    // Global eval: with no user, isAppBlocksEnabled takes the no-user branch and
+    // calls isFlipt(flag) with NO entityId/context (buildFliptContext is never
+    // run) → the moderators-segmented default stub resolves false.
+    const appBlocksCall = mockIsFlipt.mock.calls.find((c) => c[0] === 'app-blocks-enabled');
+    expect(appBlocksCall).toBeDefined();
+    // No context argument was passed (global eval), so the segment can't match.
+    expect((appBlocksCall as unknown[])[2]).toBeUndefined();
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -23,6 +23,7 @@ const {
   mockBuildGenerationContext,
   mockAuditPromptServer,
   mockGetUserById,
+  mockGetSessionUser,
   mockDbRead,
   mockRedis,
   mockIsAppBlocksEnabled,
@@ -44,6 +45,11 @@ const {
   mockBuildGenerationContext: vi.fn(),
   mockAuditPromptServer: vi.fn(),
   mockGetUserById: vi.fn(),
+  // assertAppBlocksEnabledForTokenUser now resolves the FULL SessionUser (so the
+  // Flipt context carries the real tier/isMember). isAppBlocksEnabled is mocked
+  // here, but getSessionUser must still be stubbed so the real resolver doesn't
+  // hit the DB/redis.
+  mockGetSessionUser: vi.fn(),
   mockDbRead: {
     modelVersion: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
     // Required by resolveBlockCheckpoint (LoRA path) — published checkpoint
@@ -115,6 +121,9 @@ vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
 }));
 vi.mock('~/server/services/user.service', () => ({
   getUserById: mockGetUserById,
+}));
+vi.mock('~/server/auth/session-user', () => ({
+  getSessionUser: (...args: unknown[]) => mockGetSessionUser(...args),
 }));
 vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
@@ -309,6 +318,7 @@ beforeEach(() => {
     mockBuildGenerationContext,
     mockAuditPromptServer,
     mockGetUserById,
+    mockGetSessionUser,
     mockDbRead.modelVersion.findUnique,
     mockIsAppBlocksEnabled,
     mockDailyBoostApply,
@@ -364,6 +374,11 @@ beforeEach(() => {
     email: 'u@example.com',
     username: 'u',
   });
+  // assertAppBlocksEnabledForTokenUser resolves the full SessionUser for the flag
+  // gate; default to a moderator so the (mocked) flag gate passes. The vanished
+  // -viewer test sets getUserById→null to make the SECOND gate
+  // (assertViewerIsModerator) reject; this default keeps the first gate green.
+  mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
   mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
   mockGetOrchestratorToken.mockResolvedValue('orch_token');
   mockAuditPromptServer.mockResolvedValue(undefined);
@@ -956,14 +971,17 @@ describe('blocks.submitWorkflow', () => {
     it('INVARIANT 1b — NON-MOD token: flag false → 401, no submit (stays mod-only pre-GA)', async () => {
       faithfulModSegmentedFlag();
       mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
-      // TOKEN subject resolves to a NON-mod user → flag false.
-      mockGetUserById.mockResolvedValue({
+      // TOKEN subject resolves to a NON-mod user → flag false. The flag gate
+      // resolves the subject via getSessionUser (not ctx.user), so set it here.
+      const nonMod = {
         id: 42,
         isModerator: false,
         tier: 'free',
         email: 'u@example.com',
         username: 'u',
-      });
+      };
+      mockGetUserById.mockResolvedValue(nonMod);
+      mockGetSessionUser.mockResolvedValue(nonMod);
       happyVersionLookup();
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
@@ -1032,14 +1050,17 @@ describe('blocks.submitWorkflow', () => {
       faithfulModSegmentedFlag();
       mockVerifyBlockToken.mockResolvedValue(validClaims());
       mockGetUserById.mockResolvedValue({ id: 42, isModerator: true });
+      mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
       mockGetWorkflow.mockResolvedValue({ id: 'wf_1', status: 'succeeded', cost: { total: 0 }, steps: [] });
       let caller = blocksRouter.createCaller(fakeCtx() as never);
       const ok = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
       expect(ok.snapshot.workflowId).toBe('wf_1');
 
-      // Non-mod subject → flag false → 401, orchestrator never read.
+      // Non-mod subject → flag false → 401, orchestrator never read. The flag
+      // gate resolves the subject via getSessionUser.
       mockGetWorkflow.mockClear();
       mockGetUserById.mockResolvedValue({ id: 42, isModerator: false });
+      mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false, tier: 'free' });
       caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
         caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -95,6 +95,7 @@ import {
   createWorkflowStepsFromGraphInput,
 } from '~/server/services/orchestrator/orchestration-new.service';
 import { getUserById } from '~/server/services/user.service';
+import { getSessionUser } from '~/server/auth/session-user';
 import {
   guardedProcedure,
   moderatorProcedure,
@@ -180,14 +181,32 @@ async function assertViewerIsModerator(userId: number): Promise<void> {
  * (budget cap, daily Buzz cap, reserveBlockBuzzSpend, getOrchestratorToken,
  * forced-SFW) are unchanged — this only swaps which identity the FLAG sees.
  *
- * Reads `isModerator` from the DB (the server-side user row), never a
- * client-supplied value, so the segment match can't be spoofed.
+ * Resolves the FULL server-side SessionUser via `getSessionUser` (never a
+ * client-supplied value) so the segment match can't be spoofed AND every
+ * property `buildFliptContext` consumes is real.
+ *
+ * ## Why the full SessionUser, not a trimmed `{ id, isModerator }` cast
+ *
+ * `isAppBlocksEnabled({ user })` feeds `user` to `buildFliptContext`, which
+ * reads `id`, `isModerator`, AND `tier` (deriving `isMember` from `tier`). A
+ * trimmed `getUserById({ select: { id, isModerator } })` cast to SessionUser
+ * (the #2740 shape) leaves `tier` undefined → the Flipt context carries the
+ * type-default `tier:'free'` / `isMember:'false'` instead of the user's real
+ * subscription tier. That is correct TODAY only because the live
+ * `app-blocks-enabled` flag segments solely on `isModerator`. The moment the
+ * flag is widened to segment on `tier`/region, a stale-`free` context would
+ * silently mis-gate a paying user. Resolving the real SessionUser here (whose
+ * `tier` is derived from the highest active subscription — not a User column,
+ * so it CANNOT be fetched by widening the select) makes the gate stay correct
+ * across any future widening. Pre-GA security review hardening.
  */
 async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void> {
-  const row = await getUserById({ id: userId, select: { id: true, isModerator: true } });
-  // A vanished user → no SessionUser → global eval → flag false → blocked
-  // (fail-closed; the subsequent assertViewerIsModerator would also reject).
-  const user = row ? (row as unknown as SessionUser) : undefined;
+  // Full, authoritative SessionUser (cached; tier derived from active
+  // subscriptions) so buildFliptContext sees the user's REAL tier/isMember,
+  // not type-defaults. A vanished user → undefined → global eval → flag false
+  // → blocked (fail-closed; the subsequent assertViewerIsModerator would also
+  // reject).
+  const user = await getSessionUser({ userId });
   if (!(await isAppBlocksEnabled({ user }))) {
     throw new TRPCError({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
   }


### PR DESCRIPTION
## What

Makes the App Blocks **token-subject flag-gate** (`assertAppBlocksEnabledForTokenUser`, added in #2740) build a **faithful Flipt context** by resolving the full server-side `SessionUser` for the token subject, instead of casting a trimmed `{ id, isModerator }` DB row.

## Why (pre-GA security review)

`assertAppBlocksEnabledForTokenUser` calls `isAppBlocksEnabled({ user })`, which feeds `user` to `buildFliptContext`. `buildFliptContext` reads **`id`, `isModerator`, AND `tier`** (and derives `isMember` from `tier`):

```ts
ctx.userId = String(user.id);
ctx.isModerator = String(!!user.isModerator);
ctx.tier = user.tier ?? 'free';
ctx.isMember = String(!!user.tier && user.tier !== 'free');
```

The #2740 gate resolved the subject with a trimmed select and cast it:

```ts
const row = await getUserById({ id: userId, select: { id: true, isModerator: true } });
const user = row ? (row as unknown as SessionUser) : undefined;
```

So `tier` was always `undefined` → the Flipt context carried the **stale type-defaults** `tier:'free'` / `isMember:'false'`, regardless of the user's real subscription. This is correct **today only** because the live `app-blocks-enabled` flag segments **solely on `isModerator`** (verified). A pre-GA security review flagged that the moment the flag is widened to segment on `tier`/region, this gate would silently mis-gate a paying user — so the fix must land **before** any such Flipt change.

## The fix

The gate now resolves the **full, authoritative `SessionUser`** via `getSessionUser({ userId })` (the cached session resolver). Crucially, `tier` is **not a `User` column** — it's derived from the highest active subscription's product metadata — so it **cannot** be obtained by merely widening the prisma select; `getSessionUser` is the existing machinery that produces it. The Flipt context is therefore built from real values.

**No behavior change today:** gate semantics, the flag, and the fail-closed path (vanished subject → `undefined` → global eval → flag `false` → `UNAUTHORIZED`) are all preserved. Both downstream belts (`assertViewerIsModerator`, budget/Buzz caps, orchestrator token, forced-SFW) are untouched. The change is purely making the #2740 cast complete.

## Tests

- **New** `blocks.router.flag-gate-hydrate.test.ts` drives the **real** gate + **real** `buildFliptContext` through `pollWorkflow`, stubbing only `~/server/flipt/client` so `isFlipt` **captures** the context the gate built:
  - asserts the captured `app-blocks-enabled` context carries the user's **real** `tier:'gold'` / `isMember:'true'` (not `free`/`false`);
  - drives a **tier-segmented** flag impl (`ON iff tier !== 'free'`) and proves a paying moderator now **passes** where the trimmed cast would have wrongly blocked;
  - keeps the **fail-closed** assertion: a vanished subject → `undefined` → global eval (no context) → flag `false` → `UNAUTHORIZED`.
- `blocks.router.workflow.test.ts` updated to stub the new `getSessionUser` dependency (the gate now resolves the subject through it).

## Verification

- Scoped `tsc --noEmit`: **zero** new errors referencing the touched files (`blocks.router.ts`, both test files). The only `session-user.ts` hit is a pre-existing environmental Prisma-client-not-generated error (23 such across the repo; `session-user.ts` is unchanged by this PR). The repo's full `tsc` is not clean on `main`.
- `vitest run --project unit` on all `blocks.router` tests + the app-blocks service flag tests: **257 passed** (includes the 3 new hydrate tests and the 106 workflow tests).

Not merged, not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
