### PR TITLE
feat(app-blocks): per-app spend-bounty accrual cap (dormant pre-GA guardrail)

### DIFF
--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1612,6 +1612,20 @@ export const REDIS_SYS_KEYS = {
      */
     BUZZ_CAP: 'system:blocks:buzz-cap',
     /**
+     * Per-APP cumulative spend-BOUNTY accrual cap counter (audit 🟡-2 / the
+     * App-Blocks Sybil-economics review). DISTINCT from BUZZ_CAP: that one
+     * bounds a single USER's daily Buzz SPEND; this one bounds the daily
+     * platform-funded BOUNTY (in USD cents) accrued toward a single APP across
+     * ALL viewers, so a Sybil ring of many accounts can't funnel unbounded
+     * bounty at one author. Integer counter (cents), keyed
+     * `system:blocks:bounty-cap:${appBlockId}:${UTC-day}`, INCRBY'd by each
+     * row's accrued `app_owner_share_cents` at spend-attribution write time.
+     * TTL is set on first write so the per-window key self-expires. DORMANT
+     * today: the share is 0 until the payout rail (#2605) flips spendSharePct>0,
+     * so the counter never moves and the cap never clamps.
+     */
+    BOUNTY_CAP: 'system:blocks:bounty-cap',
+    /**
      * Per-API-key (fallback per-IP) rate-limit counter for the token-authed
      * bundle-submit endpoint (`/api/v1/blocks/submit-version`). `SET NX EX` +
      * `INCR` in one MULTI (same atomic pattern as the retool endpoint) so the

--- a/src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Per-APP spend-BOUNTY accrual cap (audit 🟡-2 / App-Blocks Sybil-economics
+ * review). This is the dual of the per-USER `BLOCK_BUZZ_CAP_PER_DAY`: it bounds
+ * the daily platform-funded BOUNTY (USD cents) accrued toward ONE app across
+ * ALL viewers, so a Sybil ring of many accounts can't funnel unbounded bounty
+ * at one author.
+ *
+ * The interesting surface:
+ *   - DORMANT by construction: a 0 share never touches Redis and grants 0
+ *     (this is what keeps the cap a no-op while spendSharePct=0 today)
+ *   - per-APP key shape (appBlockId + UTC-day, NOT spender userId)
+ *   - atomic INCRBY-with-TTL reservation (TTL armed on first write)
+ *   - clamp + overshoot-refund when the cap is hit, including the SYBIL case
+ *     (many small reservations across many viewers converging to the cap)
+ *   - pinned-key refund on the failure/duplicate path
+ *
+ * sysRedis is replaced with a stateful in-memory fake so the atomic INCRBY
+ * accumulation (the whole point of the TOCTOU-safe design) is exercised for
+ * real rather than stubbed per-call.
+ */
+
+const BOUNTY_CAP_PREFIX = 'system:blocks:bounty-cap';
+
+// Stateful in-memory Redis: counters + TTLs. INCRBY/DECRBY accumulate so a
+// sequence of reservations (the concurrency / Sybil case) behaves like the
+// real atomic counter.
+const { store, ttls, mockSysRedis } = vi.hoisted(() => {
+  const store = new Map<string, number>();
+  const ttls = new Map<string, number>();
+  const mockSysRedis = {
+    incrBy: vi.fn(async (key: string, n: number) => {
+      const next = (store.get(key) ?? 0) + n;
+      store.set(key, next);
+      return next;
+    }),
+    decrBy: vi.fn(async (key: string, n: number) => {
+      const next = (store.get(key) ?? 0) - n;
+      store.set(key, next);
+      return next;
+    }),
+    expire: vi.fn(async (key: string, seconds: number) => {
+      ttls.set(key, seconds);
+      return 1;
+    }),
+    // Default: key has a TTL (so the re-arm branch is NOT taken). Overridden in
+    // the "re-arms a TTL-less key" test.
+    ttl: vi.fn(async (key: string) => (ttls.has(key) ? ttls.get(key)! : 1000)),
+  };
+  return { store, ttls, mockSysRedis };
+});
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSysRedis,
+  // Literal inlined (vi.mock factory is hoisted above module-scope consts).
+  REDIS_SYS_KEYS: { BLOCKS: { BOUNTY_CAP: 'system:blocks:bounty-cap' } },
+}));
+
+import {
+  BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY,
+  reserveAppBountyAccrual,
+  refundAppBountyAccrual,
+} from '../app-bounty-cap.service';
+
+const APP_BLOCK_ID = 'apb_test';
+
+beforeEach(() => {
+  store.clear();
+  ttls.clear();
+  mockSysRedis.incrBy.mockClear();
+  mockSysRedis.decrBy.mockClear();
+  mockSysRedis.expire.mockClear();
+  mockSysRedis.ttl.mockClear();
+  mockSysRedis.ttl.mockImplementation(async (key: string) =>
+    ttls.has(key) ? ttls.get(key)! : 1000
+  );
+});
+
+describe('BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY', () => {
+  it('is a positive integer placeholder (the documented $250/day starting point)', () => {
+    expect(Number.isInteger(BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY)).toBe(true);
+    expect(BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY).toBeGreaterThan(0);
+    // 25_000 cents = $250/day. Asserting the default so a silent change to the
+    // placeholder (which NEEDS LEADERSHIP SIGN-OFF) trips this test.
+    expect(BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY).toBe(25_000);
+  });
+});
+
+describe('reserveAppBountyAccrual — DORMANT (the track-only case today)', () => {
+  it('share=0 grants 0 and NEVER touches Redis (true-by-construction no-op)', async () => {
+    const res = await reserveAppBountyAccrual(APP_BLOCK_ID, 0);
+    expect(res.grantedCents).toBe(0);
+    expect(res.clamped).toBe(false);
+    expect(res.total).toBe(0);
+    // The whole point: while spendSharePct=0 the cap path adds ZERO behaviour
+    // and ZERO Redis load.
+    expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    expect(mockSysRedis.expire).not.toHaveBeenCalled();
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+  });
+
+  it('negative / fractional sub-zero share is also a no-op (defensive)', async () => {
+    const res = await reserveAppBountyAccrual(APP_BLOCK_ID, -50);
+    expect(res.grantedCents).toBe(0);
+    expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+  });
+});
+
+describe('reserveAppBountyAccrual — ENFORCED (when a future rate makes the share > 0)', () => {
+  it('grants the full share under the cap and arms the TTL on first write', async () => {
+    const res = await reserveAppBountyAccrual(APP_BLOCK_ID, 100);
+    expect(res.grantedCents).toBe(100);
+    expect(res.clamped).toBe(false);
+    expect(res.total).toBe(100);
+    // Atomic INCRBY by the share.
+    expect(mockSysRedis.incrBy).toHaveBeenCalledTimes(1);
+    expect(mockSysRedis.incrBy.mock.calls[0][1]).toBe(100);
+    // TTL armed on the (effectively) first write.
+    expect(mockSysRedis.expire).toHaveBeenCalledTimes(1);
+    // No refund when under the cap.
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+  });
+
+  it('keys PER-APP + UTC-day (appBlockId in the key, spender userId is NOT)', async () => {
+    await reserveAppBountyAccrual(APP_BLOCK_ID, 10);
+    const key = String(mockSysRedis.incrBy.mock.calls[0][0]);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(key).toBe(`${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}`);
+    // Two different apps get two different counters; one app's accrual cannot
+    // consume another's headroom.
+    await reserveAppBountyAccrual('apb_other', 10);
+    const otherKey = String(mockSysRedis.incrBy.mock.calls[1][0]);
+    expect(otherKey).not.toBe(key);
+    expect(otherKey).toContain('apb_other');
+  });
+
+  it('clamps to the remaining headroom and refunds the overshoot when the cap is hit', async () => {
+    // Pre-fill the counter to just under the cap.
+    const cap = BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY;
+    // First reservation lands the app at cap - 30.
+    await reserveAppBountyAccrual(APP_BLOCK_ID, cap - 30);
+    mockSysRedis.incrBy.mockClear();
+    mockSysRedis.decrBy.mockClear();
+
+    // Next reservation wants 100 but only 30 of headroom remains.
+    const res = await reserveAppBountyAccrual(APP_BLOCK_ID, 100);
+    expect(res.clamped).toBe(true);
+    expect(res.grantedCents).toBe(30); // only the headroom is accrued
+    expect(res.total).toBe(cap + 70); // pre-refund running total
+
+    // Overshoot (100 - 30 = 70) refunded against the SAME key.
+    expect(mockSysRedis.decrBy).toHaveBeenCalledTimes(1);
+    expect(mockSysRedis.decrBy.mock.calls[0][1]).toBe(70);
+    expect(String(mockSysRedis.decrBy.mock.calls[0][0])).toBe(
+      String(mockSysRedis.incrBy.mock.calls[0][0])
+    );
+    // Counter converged to exactly the cap (so a later viewer sees 0 headroom).
+    const today = new Date().toISOString().slice(0, 10);
+    expect(store.get(`${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}`)).toBe(cap);
+  });
+
+  it('grants 0 once the app is already AT the cap (subsequent viewers get nothing)', async () => {
+    const cap = BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY;
+    await reserveAppBountyAccrual(APP_BLOCK_ID, cap); // exactly fills the cap
+    const res = await reserveAppBountyAccrual(APP_BLOCK_ID, 50);
+    expect(res.grantedCents).toBe(0);
+    expect(res.clamped).toBe(true);
+    // Full overshoot refunded → counter stays pinned at the cap.
+    const today = new Date().toISOString().slice(0, 10);
+    expect(store.get(`${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}`)).toBe(cap);
+  });
+
+  it('SYBIL CASE: many viewers each spending a little can never exceed the per-app cap', async () => {
+    // 1000 distinct "viewers" (the spender userId does not appear in the key —
+    // that is exactly what the per-user cap is blind to) each accrue 50 cents
+    // of bounty through the SAME app. Naively that is 50_000 cents = 2× the cap.
+    const cap = BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY;
+    let totalGranted = 0;
+    for (let i = 0; i < 1000; i++) {
+      const { grantedCents } = await reserveAppBountyAccrual(APP_BLOCK_ID, 50);
+      totalGranted += grantedCents;
+    }
+    // The app's TOTAL accrued bounty is bounded by the cap regardless of how
+    // many sockpuppets fan the spend out.
+    expect(totalGranted).toBe(cap);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(store.get(`${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}`)).toBe(cap);
+  });
+
+  it('re-arms the TTL on a key that somehow lost it', async () => {
+    // First reservation creates + arms the key.
+    await reserveAppBountyAccrual(APP_BLOCK_ID, 10);
+    const today = new Date().toISOString().slice(0, 10);
+    const key = `${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}`;
+    // Simulate a key that lost its TTL (ttl < 0).
+    ttls.delete(key);
+    mockSysRedis.ttl.mockImplementation(async (k: string) => (k === key ? -1 : 1000));
+    mockSysRedis.expire.mockClear();
+
+    await reserveAppBountyAccrual(APP_BLOCK_ID, 10);
+    // The re-arm branch fired.
+    expect(mockSysRedis.expire).toHaveBeenCalledTimes(1);
+    expect(mockSysRedis.expire.mock.calls[0][0]).toBe(key);
+  });
+});
+
+describe('refundAppBountyAccrual', () => {
+  it('decrements the pinned key by the refunded amount', async () => {
+    await reserveAppBountyAccrual(APP_BLOCK_ID, 100);
+    const today = new Date().toISOString().slice(0, 10);
+    const key = `${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}` as const;
+    await refundAppBountyAccrual(key, 40);
+    expect(store.get(key)).toBe(60);
+  });
+
+  it('is a no-op for non-positive amounts (no Redis call)', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const key = `${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}` as const;
+    mockSysRedis.decrBy.mockClear();
+    await refundAppBountyAccrual(key, 0);
+    await refundAppBountyAccrual(key, -5);
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+  });
+
+  it('swallows a Redis error (best-effort — a lost refund only makes the cap stricter)', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const key = `${BOUNTY_CAP_PREFIX}:${APP_BLOCK_ID}:${today}` as const;
+    mockSysRedis.decrBy.mockRejectedValueOnce(new Error('redis down'));
+    await expect(refundAppBountyAccrual(key, 10)).resolves.toBeUndefined();
+  });
+});

--- a/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
@@ -67,6 +67,34 @@ vi.mock('../rate-card', async (importOriginal) => {
   };
 });
 
+// Spy on the per-APP bounty cap. `recordSpendAttribution` dynamic-imports it to
+// reserve/clamp the row's accrued share. The cap has its own dedicated unit
+// suite (app-bounty-cap.service.test.ts) exercising Redis; here we only assert
+// the WIRING: the write reserves the share it is about to accrue, and applies
+// the granted amount. The default fake grants exactly what is requested (no
+// clamp) so the dormant 0→0 path is faithful.
+const { reserveAppBountySpy, refundAppBountySpy } = vi.hoisted(() => ({
+  reserveAppBountySpy: vi.fn(),
+  refundAppBountySpy: vi.fn(),
+}));
+vi.mock('../app-bounty-cap.service', () => ({
+  reserveAppBountyAccrual: (appBlockId: string, shareCents: number) => {
+    reserveAppBountySpy(appBlockId, shareCents);
+    // Faithful default: grant exactly the requested share (no clamp). The
+    // clamp behaviour itself is covered in the cap's own suite.
+    return Promise.resolve({
+      grantedCents: Math.max(0, Math.floor(shareCents)),
+      clamped: false,
+      total: Math.max(0, Math.floor(shareCents)),
+      key: `system:blocks:bounty-cap:${appBlockId}:test`,
+    });
+  },
+  refundAppBountyAccrual: (...args: unknown[]) => {
+    refundAppBountySpy(...args);
+    return Promise.resolve();
+  },
+}));
+
 import {
   AttributionAppMissingError,
   buzzSpendToUsdCents,
@@ -118,6 +146,8 @@ beforeEach(() => {
   mockDbWrite.blockSpendAttribution.create.mockReset();
   mockLog.mockReset();
   computeSpendShareSpy.mockReset();
+  reserveAppBountySpy.mockReset();
+  refundAppBountySpy.mockReset();
   // Default: app exists, owned by a different user than the spender.
   mockDbRead.oauthClient.findUnique.mockResolvedValue({
     id: APP_ID,
@@ -194,6 +224,43 @@ describe('recordSpendAttribution', () => {
     expect(data.spendSharePct).toBe(0);
     expect(data.rateCardVersion).toBe(UNRATED_RATE_CARD_VERSION);
     expect(computeSpendShareSpy).not.toHaveBeenCalled();
+  });
+
+  it('DORMANT per-app cap: reserves the row\'s accrued share (0 today) → no clamp, no behaviour change', async () => {
+    // The per-app bounty cap is wired into the write, but while the spend flow
+    // is TRACK-ONLY the accrued share is identically 0 — so the cap reserves 0,
+    // grants 0, and changes nothing. This is the "dormant by construction"
+    // proof at the integration point (the cap's own atomic/clamp behaviour is
+    // covered in app-bounty-cap.service.test.ts).
+    const res = await recordSpendAttribution(fakeInput({ buzzAmount: 100000 }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+
+    // The write reserved against the per-app cap, keyed by appBlockId, with the
+    // share it is about to accrue — which is 0 today (not the raw user spend).
+    expect(reserveAppBountySpy).toHaveBeenCalledTimes(1);
+    expect(reserveAppBountySpy).toHaveBeenCalledWith(APP_BLOCK_ID, 0);
+    // Granted 0 → row's accrued share stays 0 → identical to pre-cap behaviour.
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(res.row.appOwnerShareCents).toBe(0);
+    // Successful write → no refund.
+    expect(refundAppBountySpy).not.toHaveBeenCalled();
+  });
+
+  it('per-app cap reserves the BOUNTY (appOwnerShareCents), NOT the raw user spend', async () => {
+    // The property that makes the cap dormant today: it reserves the row's
+    // accrued share — which is 0 — and writes back the granted amount, so a
+    // large user spend (here $100 of Buzz) does NOT advance the per-app counter.
+    // This is what distinguishes it from the per-USER cap (which reserves raw
+    // spend). If the write ever regressed to reserving `buzzAmount`/`gross`,
+    // this asserts the contract breaks.
+    await recordSpendAttribution(fakeInput({ buzzAmount: 100000 })); // $100 gross
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls.at(-1)![0];
+    const [reservedAppBlockId, reservedShare] = reserveAppBountySpy.mock.calls.at(-1)!;
+    expect(reservedAppBlockId).toBe(APP_BLOCK_ID);
+    // Reserved == the bounty being written (0), NOT the gross (10000) or spend.
+    expect(reservedShare).toBe(data.appOwnerShareCents);
+    expect(reservedShare).toBe(0);
+    expect(reservedShare).not.toBe(data.grossValueCents);
   });
 
   it('self-spend (spender == app owner) → voided, zero share', async () => {

--- a/src/server/services/blocks/app-bounty-cap.service.ts
+++ b/src/server/services/blocks/app-bounty-cap.service.ts
@@ -1,0 +1,190 @@
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+
+/**
+ * Per-APP spend-BOUNTY accrual cap (App-Blocks Sybil-economics review,
+ * audit note 🟡-2 at `blocks.router.ts:~2379`).
+ *
+ * WHY THIS EXISTS — the residual Sybil leak.
+ * The block buzz-SPEND flow (W3 flow A, #2627) accrues a PLATFORM-FUNDED
+ * author bounty (`spendSharePct` of the spend's USD value, paid ON TOP of the
+ * spend — net-new platform money, NOT a cut of the viewer's Buzz). The only
+ * live cap today is `BLOCK_BUZZ_CAP_PER_DAY` (blocks.router.ts), which is
+ * per-(USER, UTC-day) — `appBlockId` is intentionally NOT in its key. So a
+ * Sybil ring of N sockpuppet accounts each gets its OWN 50k/day spend ceiling,
+ * and ALL of that spend can be funnelled through ONE app to mint UNBOUNDED
+ * platform-funded bounty toward ONE author. The per-user cap cannot see that
+ * concentration. This module adds the missing PER-APP aggregate ceiling.
+ *
+ * It is the SAME atomic INCRBY-with-TTL pattern as the per-user cap
+ * (`reserveBlockBuzzSpend`), just keyed on `appBlockId` and denominated in the
+ * accrued BOUNTY (USD cents), not the raw user spend (Buzz). Reserving the
+ * bounty (not the spend) is what makes it DORMANT by construction today (see
+ * below).
+ *
+ * DORMANT TODAY — true by construction, not by configuration.
+ * The amount reserved here is the row's accrued `app_owner_share_cents`. The
+ * spend flow is TRACK-ONLY until the payout rail (#2605) flips
+ * `spendSharePct > 0` for non-mods, so EVERY spend-attribution row is written
+ * with `app_owner_share_cents = 0`. Reserving 0 never advances the per-app
+ * counter, so the cap NEVER clamps and live behaviour is byte-identical to
+ * before this change. When #2605 starts stamping a non-zero accrued share at
+ * write time, this cap is already enforcing — it pre-lands the guardrail.
+ *
+ * ⚠️ CAP VALUE NEEDS LEADERSHIP SIGN-OFF before #2605 flips `spendSharePct > 0`
+ * for non-mods. `BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY` below is a documented
+ * PLACEHOLDER, not an authoritative number — see its comment.
+ */
+
+/**
+ * Per-app daily ceiling on accrued spend bounty, in USD CENTS.
+ *
+ * ⚠️ PLACEHOLDER — NEEDS LEADERSHIP SIGN-OFF before the payout rail (#2605)
+ * flips `spendSharePct > 0` for non-moderators. Do not treat this number as
+ * authoritative; it only exists so the guardrail is wired and enforcing the
+ * moment the rate goes non-zero.
+ *
+ * Reasoning for the starting point (relative to the per-user cap):
+ *   - The per-user cap is `BLOCK_BUZZ_CAP_PER_DAY = 50_000` Buzz/day ≈ $50/day
+ *     of spend per user (yellow Buzz at 1000 Buzz = $1).
+ *   - At the placeholder `spendSharePct = 5%`, one fully-maxed user mints at
+ *     most `5% × $50 = $2.50/day` ≈ 250 cents/day of bounty toward an app.
+ *   - One app serves MANY users, so the per-app ceiling must be a multiple of
+ *     the per-user-derived bounty. 25_000 cents = $250/day ≈ the bounty from
+ *     ~100 fully-maxed legitimate users — generous headroom for a genuinely
+ *     popular app, while still bounding a Sybil ring (which would otherwise be
+ *     uncapped per app) to a fixed daily platform expense per app.
+ *
+ * Override at deploy time with `BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY` (an
+ * integer count of cents) — e.g. to tighten or loosen after sign-off without a
+ * code change. An unset / unparseable / non-positive value falls back to the
+ * placeholder default (fail-safe: a sane positive cap is always in force).
+ */
+export const BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY: number = (() => {
+  const fromEnv = Number(process.env.BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? Math.floor(fromEnv) : 25_000;
+})();
+
+// 25h TTL: comfortably covers a UTC-day window plus clock skew; the key is
+// re-derived per day so a stale counter never bleeds into the next window.
+// (Same value + rationale as the per-user cap's BLOCK_BUZZ_CAP_TTL_SECONDS.)
+const BOUNTY_CAP_TTL_SECONDS = 25 * 60 * 60;
+
+function bountyCapWindowKey(): string {
+  // UTC calendar day, e.g. '2026-06-24'.
+  return new Date().toISOString().slice(0, 10);
+}
+
+type BountyCapKey = `${typeof REDIS_SYS_KEYS.BLOCKS.BOUNTY_CAP}:${string}`;
+
+function bountyCapRedisKey(appBlockId: string): BountyCapKey {
+  // PER-APP aggregate: the key is `${appBlockId}:${UTC-day}` — the SPENDER's
+  // userId is intentionally NOT part of the key, so EVERY viewer's spend
+  // through this app shares ONE daily bounty ceiling. This is the dual of the
+  // per-user cap (which keys on userId, not appBlockId) and is what bounds a
+  // Sybil ring of many accounts pointed at one app.
+  return `${REDIS_SYS_KEYS.BLOCKS.BOUNTY_CAP}:${appBlockId}:${bountyCapWindowKey()}`;
+}
+
+export type ReserveAppBountyResult = {
+  /**
+   * The bounty (in cents) that may actually be accrued for this row AFTER the
+   * per-app daily cap. Equal to `shareCents` when there is headroom; CLAMPED
+   * down to the remaining headroom (possibly 0) when the cap is hit. Always
+   * `0 <= grantedCents <= shareCents`.
+   */
+  grantedCents: number;
+  /** True when the cap clamped the accrued bounty below the requested share. */
+  clamped: boolean;
+  /** The running per-app daily total AFTER this reservation (for logging). */
+  total: number;
+  /** The exact key reserved against — pass back to a refund if needed. */
+  key: BountyCapKey;
+};
+
+/**
+ * Atomically reserve `shareCents` of bounty against this APP's cumulative
+ * UTC-day bounty counter and return how much may actually accrue.
+ *
+ * Atomicity / TOCTOU-safety: INCRBY is atomic, so concurrent spend
+ * attributions across many viewers accumulate correctly with NO
+ * read→check→record race (mirrors the per-user `reserveBlockBuzzSpend`). The
+ * TTL is armed on the (effectively) first write so the per-window key
+ * self-expires; the `ttl < 0` guard re-arms a key that somehow lost its TTL.
+ *
+ * If the reservation pushes the app's daily total over the cap, the OVERSHOOT
+ * is REFUNDED (best-effort DECRBY against the pinned key) and `grantedCents` is
+ * the remaining headroom (clamped to ≥ 0). This way the counter converges to
+ * exactly the cap and the caller can write a row whose accrued share never
+ * pushes the app past its daily ceiling — even under a flood of concurrent
+ * sockpuppet spends.
+ *
+ * `shareCents <= 0` (the DORMANT case today, and self/internal void rows) is a
+ * fast no-op: it does NOT touch Redis and grants 0, so the cap path adds zero
+ * behaviour and zero Redis load while the bounty is 0.
+ *
+ * Fail-safe posture: a Redis error here would throw. Callers in the
+ * fire-and-forget attribution path already wrap the whole write in try/catch
+ * (a failed attribution never breaks the generation), so a Redis blip
+ * degrades to "row not written" rather than to "uncapped accrual" — the safe
+ * direction for an abuse cap.
+ */
+export async function reserveAppBountyAccrual(
+  appBlockId: string,
+  shareCents: number
+): Promise<ReserveAppBountyResult> {
+  const want = Math.floor(shareCents);
+  const key = bountyCapRedisKey(appBlockId);
+
+  // DORMANT fast-path: nothing to accrue (today's track-only 0, or a void
+  // self/internal row) → never touch the counter. This is what keeps the cap a
+  // pure no-op while `spendSharePct = 0`.
+  if (want <= 0) {
+    return { grantedCents: 0, clamped: false, total: 0, key };
+  }
+
+  const total = await sysRedis.incrBy(key, want);
+  if (total <= want) {
+    // (effectively) first write this window → arm the TTL.
+    await sysRedis.expire(key, BOUNTY_CAP_TTL_SECONDS);
+  } else {
+    const ttl = await sysRedis.ttl(key);
+    if (ttl < 0) await sysRedis.expire(key, BOUNTY_CAP_TTL_SECONDS);
+  }
+
+  if (total <= BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY) {
+    // Full headroom — accrue the whole share.
+    return { grantedCents: want, clamped: false, total, key };
+  }
+
+  // Over the cap. Refund the OVERSHOOT so the counter converges to exactly the
+  // cap (concurrent reservations across viewers all see the true running total
+  // because INCRBY is atomic). Grant only the remaining headroom, clamped ≥ 0.
+  const overshoot = total - BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY;
+  const grantedCents = Math.max(0, want - overshoot);
+  // Refund the portion we will NOT accrue. Best-effort: a lost refund leaves
+  // the counter higher, which only makes the cap STRICTER (the safe direction
+  // for an abuse cap), never looser.
+  await refundAppBountyAccrual(key, want - grantedCents);
+
+  return { grantedCents, clamped: true, total, key };
+}
+
+/**
+ * Refund `cents` previously reserved against the EXACT key returned by
+ * `reserveAppBountyAccrual` (best-effort DECRBY). Used to release the overshoot
+ * when the cap clamps, or to undo a full reservation if the caller decides not
+ * to write the row after reserving. Never throws into the caller.
+ *
+ * Takes the reserved key rather than re-deriving it from appBlockId: the key
+ * embeds the UTC-day window, so re-deriving across a midnight-UTC boundary
+ * could decrement the NEXT day's key (handing the app extra headroom). Pinning
+ * the key eliminates that race — the same reasoning as the per-user
+ * `refundBlockBuzzSpend`.
+ */
+export async function refundAppBountyAccrual(key: BountyCapKey, cents: number): Promise<void> {
+  const amount = Math.floor(cents);
+  if (amount <= 0) return;
+  await sysRedis.decrBy(key, amount).catch(() => {
+    /* best-effort — a lost refund over-counts (stricter cap), never looser */
+  });
+}

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -403,7 +403,25 @@ export async function recordSpendAttribution(
   // stamped.
   const rateCardVersion = UNRATED_RATE_CARD_VERSION;
   const spendSharePct = 0;
-  const appOwnerShareCents = 0;
+  // The accrued bounty for THIS row. Track-only today: identically 0 until the
+  // payout rail (#2605) starts stamping a non-zero share here. `let` so the
+  // per-APP daily cap below can CLAMP it (a Sybil ring pointed at one app must
+  // not mint unbounded platform-funded bounty — audit note 🟡-2).
+  let appOwnerShareCents = 0;
+
+  // PER-APP daily spend-BOUNTY accrual cap (audit 🟡-2 / Sybil-economics
+  // review). The per-user `BLOCK_BUZZ_CAP_PER_DAY` bounds one viewer's daily
+  // SPEND but is blind to MANY viewers funnelling bounty at ONE app. Reserve
+  // this row's accrued share against the app's cumulative UTC-day BOUNTY
+  // counter and clamp the accrual to whatever headroom remains. Same atomic
+  // INCRBY-with-TTL TOCTOU-safe mechanism as the per-user cap. DORMANT today:
+  // `appOwnerShareCents` is 0, so `reserveAppBountyAccrual` short-circuits
+  // without touching Redis and grants 0 — the cap never clamps and behaviour
+  // is byte-identical to before. When #2605 flips spendSharePct>0 the cap is
+  // already enforcing. Void rows (self/internal) also carry 0 → no-op.
+  const { reserveAppBountyAccrual } = await import('./app-bounty-cap.service');
+  const bountyReservation = await reserveAppBountyAccrual(appBlockId, appOwnerShareCents);
+  appOwnerShareCents = bountyReservation.grantedCents;
 
   // Void rows that are zero because of WHO spent/owns so they are never
   // backpaid. Otherwise the row is 'tracked' — share-pending, awaiting the
@@ -463,6 +481,10 @@ export async function recordSpendAttribution(
         status,
         voidedReason,
         isSelfSpend,
+        // Per-app bounty cap observability (dormant today: clamped=false,
+        // appBountyDailyTotal=0). Surfaces a clamp the moment the cap bites.
+        appBountyClamped: bountyReservation.clamped,
+        appBountyDailyTotal: bountyReservation.total,
       },
       'webhooks'
     ).catch(() => null);
@@ -475,6 +497,17 @@ export async function recordSpendAttribution(
 
     return { written: true, row: created };
   } catch (err) {
+    // This call's row was NOT persisted (either a duplicate that the ORIGINAL
+    // row already accounts for, or a hard write failure). Release the bounty we
+    // reserved for it so the per-app daily counter reflects only persisted
+    // accrual — otherwise a retry storm would double-count toward the cap.
+    // Best-effort + DORMANT today (granted 0 → no-op). Refund against the
+    // PINNED key from the reservation (never a re-derived one — midnight-UTC
+    // race, same reasoning as the per-user refund).
+    if (bountyReservation.grantedCents > 0) {
+      const { refundAppBountyAccrual } = await import('./app-bounty-cap.service');
+      await refundAppBountyAccrual(bountyReservation.key, bountyReservation.grantedCents);
+    }
     // Idempotency: a re-poll / retry / re-submit that races the original
     // write lands on the (workflow_id, app_block_id) UNIQUE -> P2002.
     // Return the pre-existing row so callers treat first-write and retry


### PR DESCRIPTION
## What

A **dormant, per-app spend-bounty accrual cap** that pre-lands the residual Sybil control identified by the App-Blocks Sybil-economics review, so it is already enforcing the moment the payout rail (#2605) flips `spendSharePct > 0` for non-moderators.

Motivating analysis: `datapacket-talos/claudedocs/app-blocks-sybil-economics-2026-06-24.md`. The review's verdict: the money loop **dissolves today** (free/blue Buzz can't fund a block gen; purchased self-dealing is net-negative; payout is dark), **except** for one named, deferred leak — and the code already flags it (audit note 🟡-2 at `blocks.router.ts:~2379`).

## The leak this closes

The block buzz-**SPEND** flow (#2627) accrues a **platform-funded** author bounty — `spendSharePct` of the spend's USD value, paid **ON TOP** of the spend (net-new platform money, not a cut of the viewer's Buzz). The only live cap, `BLOCK_BUZZ_CAP_PER_DAY = 50_000`, is **per-(USER, UTC-day)** — `appBlockId` is intentionally not in its key. So a Sybil ring of N sockpuppets each gets its own 50k/day spend ceiling, and **all** of it can funnel through one app to mint **unbounded per-app bounty** toward one author. The per-user cap cannot see that concentration.

## What this adds

- `BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY` — a **per-APP** analogue keyed on `appBlockId` (+ UTC-day) instead of `userId`, denominated in the accrued **bounty** (USD cents), enforced at the bounty-accrual point inside `recordSpendAttribution`.
- Same **atomic INCRBY-with-TTL, TOCTOU-safe** mechanism as the per-user cap (`reserveBlockBuzzSpend`): reserve the share, clamp to remaining headroom, refund the overshoot against the **pinned key** (so a midnight-UTC straddle can't decrement the next day's key). The Sybil case — many viewers each accruing a little through one app — converges to exactly the cap.
- Observability: the spend-attribution log line now carries `appBountyClamped` / `appBountyDailyTotal`.

## Dormant today — true by construction, not configuration

The cap reserves the row's **accrued `appOwnerShareCents`**, which is **`0`** while the spend flow is track-only (the rate is deferred to payout time, #2605). A `0` reservation **short-circuits before touching Redis** and grants `0`, so the counter never advances, the cap never clamps, and live behaviour is **byte-identical** to before. When #2605 starts stamping a non-zero share at write time, the cap is already enforcing. This is why the cap bounds the **bounty share**, not the raw user spend.

## Cap value — NEEDS LEADERSHIP SIGN-OFF

`25_000` cents = **$250/day** is a documented **placeholder**, env-overridable via `BLOCK_APP_BOUNTY_CAP_CENTS_PER_DAY`. Reasoning relative to the per-user cap: one fully-maxed user (50k Buzz ≈ $50/day) at the placeholder `spendSharePct = 5%` mints ≤ $2.50/day of bounty; $250/day ≈ the bounty from ~100 fully-maxed legitimate users — headroom for a genuinely popular app while still bounding a Sybil ring to a fixed daily platform expense per app.

> ⚠️ **#2605 MUST NOT flip `spendSharePct > 0` for non-mods until this PR is merged AND the cap value is signed off.** This is the hard prerequisite the audit note (🟡-2) and the rate card (`rate-card.ts:253-255`) call out.

## Out of scope (deliberately)

- **Velocity check** — the per-user cap has no velocity component to mirror, so the per-app **daily** cap is the MVP. A short-window velocity check is a possible follow-up, not gold-plated here.
- No change to `spendSharePct`, the `bulk-payout` stub, the `['yellow']` currency pin, the per-user cap, or any money path. This is base on `main`, **not** stacked on #2605.
- The marketplace-ranking / `appBlockReview` faucet visibility-farming surface (the review's other deferred item) is a separate control — keep `appBlockReview.visible=false` + the mod-gate until that lands.

## Files

- `src/server/services/blocks/app-bounty-cap.service.ts` *(new)* — the cap: constant, per-app key derivation, `reserveAppBountyAccrual` / `refundAppBountyAccrual`.
- `src/server/services/blocks/buzz-attribution.service.ts` — `recordSpendAttribution` reserves + clamps the accrued share; refunds the reservation on the duplicate/error path.
- `src/server/redis/client.ts` — `REDIS_SYS_KEYS.BLOCKS.BOUNTY_CAP` key namespace.
- `src/server/services/blocks/__tests__/app-bounty-cap.service.test.ts` *(new)* — 12 tests: dormant no-op, per-app keying, atomic clamp + overshoot-refund, the **Sybil case** (1000 viewers bounded to the cap), TTL re-arm, best-effort refund.
- `src/server/services/blocks/__tests__/spend-attribution.service.test.ts` — dormancy wiring (reserves the bounty=0, not the spend; no clamp/refund).

## Verification

- Scoped `tsc --noEmit` (full project tsc; main's baseline is dirty with ~5300 pre-existing errors): **zero** errors in any touched file.
- `app-bounty-cap.service.test.ts` — **12 passed**.
- `spend-attribution.service.test.ts` — **11 passed** (incl. the new dormancy + reserve-the-bounty-not-spend tests).
- Per-user cap regression: `blocks.router.workflow.test.ts` — **106 passed**, unchanged.

Refs: #2605 (payout rail, DARK), #2627 (spend attribution, track-only), audit note 🟡-2 (`blocks.router.ts:~2379`), economics doc (`app-blocks-sybil-economics-2026-06-24.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
