### PR TITLE
fix(clickhouse): fail-soft transient CH transport errors so they don't 500 user paths

### DIFF
--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -228,6 +228,19 @@ export const cacheFailOpenOriginFetchCounter = registerCounterWithLabels({
   labelNames: ['cache_name'] as const,
 });
 
+// ClickHouse TRANSPORT-error fail-soft counter. Incremented each time a path swallows
+// a TRANSIENT ClickHouse connection/transport failure (socket hang up / Code 279 / Code
+// 210 — see isClickHouseConnectionError) instead of 500-ing the request. The `path`
+// label names where it happened ('buzz-reward', 'image-feed', …). A query/schema error
+// (UNKNOWN_TABLE etc.) is NEVER counted here — it still throws. A SUSTAINED nonzero rate
+// is the alert signal that ClickHouse Cloud is in a real outage that fail-soft is now
+// masking (a Loki/Prom alert should be added in the datapacket-talos repo on this series).
+export const clickhouseFailSoftCounter = registerCounterWithLabels({
+  name: 'civitai_app_clickhouse_failsoft_total',
+  help: 'Transient ClickHouse transport errors swallowed (failed soft) instead of 500-ing, by path',
+  labelNames: ['path'] as const,
+});
+
 // Cluster-client SELF-HEAL reconnect counter (FIX #1). Incremented once each time the
 // inflight-leak watchdog forces a full cluster reconnect because inflight stayed pinned
 // above the threshold for the sustained window. Healthy pods never touch this; a nonzero

--- a/src/server/rewards/__tests__/base.reward.failsoft.test.ts
+++ b/src/server/rewards/__tests__/base.reward.failsoft.test.ts
@@ -11,14 +11,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // failure, the CH brownout 500'd those user actions.
 //
 // A non-critical analytics/reward tracking write must NEVER take down a user
-// action. This suite pins the fail-soft contract on the INLINE `apply` path:
-//   (a) a thrown CH error from addBuzzEvent inside `apply` does NOT propagate
-//       (the surrounding user mutation would succeed)
-//   (b) the rewardFailedCounter increments on that failure
+// action *when the failure is a transient CH infra brownout*. This suite pins the
+// fail-soft contract on the INLINE `apply` path:
+//   (a) a TRANSIENT CH error (socket hang up) from addBuzzEvent inside `apply` does
+//       NOT propagate (the surrounding user mutation would succeed)
+//   (b) the rewardFailedCounter + clickhouseFailSoftCounter increment on that failure
 //   (c) no double-award: when the audit insert fails, sendAward is NOT called
 //       (the actual Buzz grant is skipped, not duplicated)
 //   (d) a sendAward failure inside `apply` ALSO does not propagate (and no rethrow)
 //   (e) the batch `process` path STILL rethrows (background cron — unchanged)
+//   (f) NARROWING: a NON-transport CH error (UNKNOWN_TABLE / a real query bug) from
+//       addBuzzEvent RETHROWS — it must surface as a 500 so a schema break / missing
+//       table can't be silently swallowed (the 2026-06-24 missing-table incident).
 //
 // MONEY-CORRECTNESS (verified from code, documented in PR body): the ClickHouse
 // `buzzEvents` insert from addBuzzEvent is an AUDIT row and does not move money.
@@ -39,6 +43,7 @@ const h = vi.hoisted(() => {
     getMultipliersForUser: vi.fn(async () => ({ rewardsMultiplier: 1 })),
     rewardFailedInc: vi.fn(),
     rewardGivenInc: vi.fn(),
+    chFailSoftInc: vi.fn(),
     logToAxiom: vi.fn(async () => {}),
   };
 });
@@ -72,6 +77,7 @@ vi.mock('~/server/logging/client', () => ({
 vi.mock('~/server/prom/client', () => ({
   rewardFailedCounter: { inc: (...a: any[]) => h.rewardFailedInc(...a) },
   rewardGivenCounter: { inc: (...a: any[]) => h.rewardGivenInc(...a) },
+  clickhouseFailSoftCounter: { inc: (...a: any[]) => h.chFailSoftInc(...a) },
 }));
 
 vi.mock('~/server/services/buzz.service', () => ({
@@ -115,26 +121,35 @@ function makeOnDemandReward() {
 }
 
 describe('base.reward inline apply() fail-soft (CH brownout)', () => {
-  it('(a) does NOT propagate a ClickHouse insert error out of apply()', async () => {
-    h.insertImpl.mockRejectedValue(new Error('Too many simultaneous queries for all users'));
+  it('(a) does NOT propagate a TRANSIENT CH insert error out of apply()', async () => {
+    // socket hang up = the canonical CH Cloud transport flap (the 2026-06-24 issue).
+    h.insertImpl.mockRejectedValue(new Error('socket hang up'));
     const reward = makeOnDemandReward();
 
     // Must resolve (not reject) — the surrounding user mutation would succeed.
     await expect(reward.apply({ userId: 1, entityId: 42 })).resolves.toBeUndefined();
   });
 
-  it('(b) increments rewardFailedCounter when the insert fails', async () => {
-    h.insertImpl.mockRejectedValue(new Error('CH down'));
+  it('(a2) also fail-softs the transient CAPACITY brownout (Code 202)', async () => {
+    h.insertImpl.mockRejectedValue(new Error('Too many simultaneous queries for all users'));
+    const reward = makeOnDemandReward();
+    await expect(reward.apply({ userId: 1, entityId: 42 })).resolves.toBeUndefined();
+    expect(h.chFailSoftInc).toHaveBeenCalledWith({ path: 'buzz-reward' });
+  });
+
+  it('(b) increments rewardFailedCounter + clickhouseFailSoftCounter on a transient failure', async () => {
+    h.insertImpl.mockRejectedValue(new Error('socket hang up'));
     const reward = makeOnDemandReward();
 
     await reward.apply({ userId: 1, entityId: 42 });
 
     expect(h.rewardFailedInc).toHaveBeenCalledTimes(1);
+    expect(h.chFailSoftInc).toHaveBeenCalledWith({ path: 'buzz-reward' });
   });
 
-  it('(c) does NOT send the award (no double-award) when the audit insert fails', async () => {
+  it('(c) does NOT send the award (no double-award) when the audit insert fails transiently', async () => {
     h.evalImpl.mockResolvedValue(100); // would be an "awarded" event
-    h.insertImpl.mockRejectedValue(new Error('CH down'));
+    h.insertImpl.mockRejectedValue(new Error('socket hang up'));
     const reward = makeOnDemandReward();
 
     await reward.apply({ userId: 1, entityId: 42 });
@@ -146,13 +161,28 @@ describe('base.reward inline apply() fail-soft (CH brownout)', () => {
   });
 
   it('(c2) limits inline insert retries (does not block ~2.5s with 5 retries)', async () => {
-    h.insertImpl.mockRejectedValue(new Error('CH down'));
+    h.insertImpl.mockRejectedValue(new Error('socket hang up'));
     const reward = makeOnDemandReward();
 
     await reward.apply({ userId: 1, entityId: 42 });
 
     // INLINE_RETRY_COUNT = 1 → 2 total attempts. (Batch path uses 5 → 6 attempts.)
     expect(h.insertImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('(f) RETHROWS a non-transport CH error (UNKNOWN_TABLE) so a schema break surfaces', async () => {
+    // Code 60 UNKNOWN_TABLE — the missing-table deploy break. Must NOT be swallowed.
+    const tableError = Object.assign(new Error('Table default.buzzEvents does not exist'), {
+      code: '60',
+    });
+    h.insertImpl.mockRejectedValue(tableError);
+    const reward = makeOnDemandReward();
+
+    await expect(reward.apply({ userId: 1, entityId: 42 })).rejects.toThrow(/does not exist/);
+    // Fail-soft counter must NOT increment — this isn't a transient brownout.
+    expect(h.chFailSoftInc).not.toHaveBeenCalled();
+    // The award is never sent (we threw before reaching sendAward).
+    expect(h.createBuzzTransactionMany).not.toHaveBeenCalled();
   });
 
   it('happy path: records the event and sends the award', async () => {

--- a/src/server/rewards/base.reward.ts
+++ b/src/server/rewards/base.reward.ts
@@ -4,13 +4,17 @@ import { chunk } from 'lodash-es';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
-import { rewardFailedCounter, rewardGivenCounter } from '~/server/prom/client';
+import {
+  clickhouseFailSoftCounter,
+  rewardFailedCounter,
+  rewardGivenCounter,
+} from '~/server/prom/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { BuzzAccountType, BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransactionMany, getMultipliersForUser } from '~/server/services/buzz.service';
 import { hashifyObject } from '~/utils/string-helpers';
-import { withRetries } from '../utils/errorHandling';
+import { isClickHouseConnectionError, withRetries } from '../utils/errorHandling';
 
 // Retry budget for the batch `process` (cron) path — can afford to block.
 const BATCH_RETRY_COUNT = 5;
@@ -245,17 +249,32 @@ export function createBuzzEvent<T>({
     // The ClickHouse `buzzEvents` insert is an AUDIT/analytics row — it does NOT
     // move money. The actual Buzz grant is `sendAward` below, and dedup is enforced
     // by the Redis Lua script in `processOnDemand` (which already committed the dedup
-    // entry above). So a failed insert must NEVER 500 the user action: we log + count
-    // and skip the award for this event. The user simply doesn't receive one reward
-    // credit during a ClickHouse brownout — no 500, no double-award (the Redis dedup
-    // entry is already set, so a retry of the same event returns early and never
-    // re-awards). Use a SHORT retry budget so we don't block the mutation for ~2.5s
-    // during a brownout. The batch `process` path is unchanged (background cron).
+    // entry above). So a TRANSIENT ClickHouse transport failure (socket hang up /
+    // Code 279 / Code 210) must NEVER 500 the user action: we log + count and skip
+    // the award for this event. The user simply doesn't receive one reward credit
+    // during a ClickHouse brownout — no 500, no double-award (the Redis dedup entry
+    // is already set, so a retry of the same event returns early and never re-awards).
+    // Use a SHORT retry budget so we don't block the mutation for ~2.5s during a
+    // brownout. The batch `process` path is unchanged (background cron).
+    //
+    // NARROW the fail-soft to TRANSPORT errors only. A CH QUERY/SCHEMA error on the
+    // `buzzEvents` insert — `Code: 60` UNKNOWN_TABLE (table dropped/renamed by a bad
+    // deploy), `Code: 349` NULL→non-Nullable, a column-type break — is a REAL BUG,
+    // not a brownout. Swallowing it would silently stop ALL buzz-event recording
+    // with no 500 to flag it (exactly the failure mode that the recent missing-table
+    // incident surfaced LOUDLY via 500s). So a non-transport error RETHROWS and
+    // surfaces as a 500 → visible + alertable. (The mutation 500-ing on a genuine
+    // schema break is the correct, loud behavior — it forces a fix.)
     try {
       await addBuzzEvent(event, INLINE_RETRY_COUNT, INLINE_RETRY_DELAY);
     } catch (error) {
-      log(event, { message: 'Failed to record Buzz event', error });
+      if (!isClickHouseConnectionError(error)) {
+        // Real query/schema bug — surface it (500) so it can't hide.
+        throw error;
+      }
+      log(event, { message: 'Failed to record Buzz event (CH transport)', error });
       rewardFailedCounter?.inc?.();
+      clickhouseFailSoftCounter.inc({ path: 'buzz-reward' });
       // Fail-soft: do not rethrow. Skip sendAward for this event too — the audit row
       // that records the grant could not be written, so we treat the reward as not
       // granted this time rather than granting Buzz with no corresponding event row.

--- a/src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts
+++ b/src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts
@@ -56,6 +56,8 @@ vi.mock('~/env/server', () => ({
       if (prop in target) return target[prop as string];
       if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
         return 'https://test:test@localhost:5432/test';
+      // Numeric-looking config (e.g. *_CONCURRENCY) is fed into helpers like pLimit at
+      // module load; hand it a safe positive number (matches image-metrics-timeout).
       if (
         typeof prop === 'string' &&
         /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
@@ -79,21 +81,11 @@ vi.mock('~/server/redis/client', () => {
   };
 });
 
-// getFliptBoolean is called at the top of getImagesFromFeedSearch (existence-check
-// flag). Stub the whole module (a Proxy returns a no-op fn for any export image.service
-// reads at load) so the feed path proceeds to populatedQuery without booting real Flipt.
-vi.mock('~/server/flipt/client', () => {
-  const noop = vi.fn(async () => false);
-  return new Proxy(
-    {
-      getFliptBoolean: noop,
-      isFlipt: noop,
-      getFliptVariant: vi.fn(async () => undefined),
-      FLIPT_FEATURE_FLAGS: new Proxy({}, { get: (_t, p) => String(p) }),
-    },
-    { get: (t, p) => (p in t ? (t as any)[p] : vi.fn(async () => false)) }
-  );
-});
+// NB: do NOT mock '~/server/flipt/client'. A catch-all Proxy mock (returning a fn for any
+// unknown export) wedges image.service's module-load import (silent hang, no test output).
+// The real flipt module loads fine here — the env mock hands FLIPT a connection string so
+// init doesn't throw, and getFliptBoolean fail-opens to false at runtime without connecting
+// (mirrors the proven image-metrics-timeout.test.ts, which also leaves flipt real).
 
 import { getImagesFromFeedSearch } from '../image.service';
 

--- a/src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts
+++ b/src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// getImagesFromFeedSearch is the DEFAULT (non-bitdex, non-legacy) /api/v1/images +
+// image-feed path. Its metric-enrichment leg runs INSIDE event-engine-common's
+// `feed.populatedQuery()` (the MetricService ClickHouse read), so a CH connection
+// error thrown there is NOT a Meili error and — before this fix — fell through the
+// catch's `throw err` to the handler's generic 500.
+//
+// Contract pinned here:
+//   - a TRANSIENT CH transport error from populatedQuery → re-mapped to a retryable
+//     SERVICE_UNAVAILABLE (503), the failsoft counter increments, items don't 500.
+//   - a CH QUERY/SCHEMA error (UNKNOWN_TABLE) → still rethrows (→ 500, visible).
+//   - a non-CH error → still rethrows unchanged.
+//
+// Same minimal-seam mocking as image-metrics-timeout.test.ts: stub the private
+// event-engine-common submodule + the infra clients + env so importing image.service
+// doesn't boot real infra.
+
+const { populatedQueryMock, chFailSoftIncMock, logToAxiomMock } = vi.hoisted(() => ({
+  populatedQueryMock: vi.fn(),
+  chFailSoftIncMock: vi.fn(),
+  logToAxiomMock: vi.fn(async () => {}),
+}));
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/prom/client')>();
+  return {
+    ...actual,
+    clickhouseFailSoftCounter: { inc: chFailSoftIncMock },
+  };
+});
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: logToAxiomMock,
+  safeError: (e: unknown) => e,
+}));
+
+// event-engine-common is a private submodule not checked out here. ImagesFeed is the
+// seam under test: its instance `.populatedQuery` is our spy.
+vi.mock('../../../../event-engine-common/feeds', () => ({
+  ImagesFeed: class {
+    populatedQuery = populatedQueryMock;
+  },
+}));
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+// getFliptBoolean is called at the top of getImagesFromFeedSearch (existence-check
+// flag). Stub the whole module (a Proxy returns a no-op fn for any export image.service
+// reads at load) so the feed path proceeds to populatedQuery without booting real Flipt.
+vi.mock('~/server/flipt/client', () => {
+  const noop = vi.fn(async () => false);
+  return new Proxy(
+    {
+      getFliptBoolean: noop,
+      isFlipt: noop,
+      getFliptVariant: vi.fn(async () => undefined),
+      FLIPT_FEATURE_FLAGS: new Proxy({}, { get: (_t, p) => String(p) }),
+    },
+    { get: (t, p) => (p in t ? (t as any)[p] : vi.fn(async () => false)) }
+  );
+});
+
+import { getImagesFromFeedSearch } from '../image.service';
+
+const baseInput = {
+  limit: 10,
+  browsingLevel: 1,
+  periodMode: 'published',
+  include: [],
+} as any;
+
+describe('getImagesFromFeedSearch ClickHouse transport fail-soft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('re-maps a TRANSIENT CH transport error (socket hang up) to a retryable 503', async () => {
+    populatedQueryMock.mockRejectedValue(new Error('socket hang up'));
+
+    await expect(getImagesFromFeedSearch(baseInput)).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+    });
+    expect(chFailSoftIncMock).toHaveBeenCalledWith({ path: 'image-feed' });
+  });
+
+  it('re-maps a Code 279 ALL_CONNECTION_TRIES_FAILED to a retryable 503', async () => {
+    const err = Object.assign(
+      new Error('Code: 279. DB::NetException: All connection tries failed. (ALL_CONNECTION_TRIES_FAILED)'),
+      { code: '279' }
+    );
+    populatedQueryMock.mockRejectedValue(err);
+
+    const rejection = await getImagesFromFeedSearch(baseInput).catch((e) => e);
+    expect(rejection).toBeInstanceOf(TRPCError);
+    expect(rejection.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('does NOT swallow a CH query/schema error (UNKNOWN_TABLE) — rethrows as a 500', async () => {
+    const err = Object.assign(
+      new Error('Code: 60. DB::Exception: Table x does not exist. (UNKNOWN_TABLE)'),
+      { code: '60' }
+    );
+    populatedQueryMock.mockRejectedValue(err);
+
+    await expect(getImagesFromFeedSearch(baseInput)).rejects.toThrow(/does not exist/);
+    // Must NOT be re-mapped to a 503, and must NOT count a fail-soft.
+    const rejection = await getImagesFromFeedSearch(baseInput).catch((e) => e);
+    expect(rejection).not.toBeInstanceOf(TRPCError);
+    expect(chFailSoftIncMock).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-CH error unchanged', async () => {
+    populatedQueryMock.mockRejectedValue(new TypeError("Cannot read properties of undefined"));
+    await expect(getImagesFromFeedSearch(baseInput)).rejects.toThrow(/Cannot read properties/);
+    expect(chFailSoftIncMock).not.toHaveBeenCalled();
+  });
+
+  it('happy path: returns transformed items, no fail-soft', async () => {
+    populatedQueryMock.mockResolvedValue({ items: [], nextCursor: undefined });
+    const result = await getImagesFromFeedSearch(baseInput);
+    expect(result.items).toEqual([]);
+    expect(chFailSoftIncMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -60,6 +60,7 @@ import {
 } from '~/server/meilisearch/client';
 import { postMetrics } from '~/server/metrics';
 import {
+  clickhouseFailSoftCounter,
   leakingContentCounter,
   registerCounter,
   registerCounterWithLabels,
@@ -166,6 +167,7 @@ import {
 import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { Limiter, limitConcurrency } from '~/server/utils/concurrency-helpers';
 import {
+  isClickHouseConnectionError,
   throwAuthorizationError,
   throwBadRequestError,
   throwDbError,
@@ -2963,6 +2965,38 @@ export async function getImagesFromFeedSearch(
         code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
         cause: err,
+      });
+    }
+    // TRANSIENT ClickHouse transport blip in the metric-enrichment leg of
+    // populatedQuery (the event-engine-common MetricService read). The feed items
+    // come from Meili+Postgres; only the display-only engagement metrics are
+    // ClickHouse-backed, and they ALREADY fail-open to zero elsewhere
+    // (getImageMetricsObject → {}). But this feed path runs the metric read INSIDE
+    // populatedQuery, so a CH connection error (socket hang up / Code 279 / Code
+    // 210) thrown there isn't a Meili error → it would fall through to `throw err`
+    // → the handler's generic 500. Re-map it to the same retryable 503 as a Meili
+    // brownout: a CH transport flap is a transient upstream brownout, not a server
+    // bug, and 503+Retry-After lets the client/CF retry the (seconds-long) blip
+    // instead of surfacing a hard 500. A CH QUERY/SCHEMA error (UNKNOWN_TABLE etc.)
+    // is NOT matched by isClickHouseConnectionError and still throws → 500 → visible
+    // + alertable, exactly as the missing-table incident was. No money/entitlement
+    // is on this path — image metrics are display-only.
+    if (isClickHouseConnectionError(err)) {
+      clickhouseFailSoftCounter.inc({ path: 'image-feed' });
+      logToAxiom(
+        {
+          type: 'warning',
+          name: 'clickhouse-failsoft',
+          message: 'ClickHouse transport error in image feed metric enrichment — served 503',
+          path: 'image-feed',
+          error: err instanceof Error ? err.message : String(err),
+        },
+        'clickhouse'
+      ).catch();
+      throw new TRPCError({
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Image feed is temporarily overloaded — please retry.',
+        cause: err as Error,
       });
     }
     throw err;

--- a/src/server/utils/__tests__/errorHandling.clickhouse-classify.test.ts
+++ b/src/server/utils/__tests__/errorHandling.clickhouse-classify.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { isClickHouseConnectionError } from '~/server/utils/errorHandling';
+
+// Pure classifier tests for the ClickHouse TRANSIENT-error predicate. This gates
+// whether a CH failure on the buzz-reward write / image-feed metric enrichment is
+// treated as a transient infra brownout (→ fail-soft / 503) vs. left to surface as
+// a 500. The central design constraint: TRANSPORT/transient signals match; QUERY and
+// SCHEMA errors (UNKNOWN_TABLE, NULL-insert, syntax) must NOT match (so a real bug /
+// deploy break still 500s + alerts — the 2026-06-24 missing-table incident).
+
+describe('isClickHouseConnectionError — TRUE for transient transport/infra failures', () => {
+  it('matches a bare "socket hang up" Error (the app-side CH brownout signature)', () => {
+    expect(isClickHouseConnectionError(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('matches our $query-wrapped transport message', () => {
+    // The $query wrapper rethrows as: `ClickHouse query failed: <orig>\nQuery: ...`
+    const wrapped = new Error('ClickHouse query failed: socket hang up\nQuery: SELECT 1');
+    expect(isClickHouseConnectionError(wrapped)).toBe(true);
+  });
+
+  it.each([
+    'ECONNRESET',
+    'EPIPE',
+    'ETIMEDOUT',
+    'ECONNREFUSED',
+    'EHOSTUNREACH',
+    'ENETUNREACH',
+    'UND_ERR_SOCKET',
+    'UND_ERR_CONNECT_TIMEOUT',
+  ])('matches a raw socket error carrying syscall code %s', (code) => {
+    const err = Object.assign(new Error('connection problem'), { code });
+    expect(isClickHouseConnectionError(err)).toBe(true);
+  });
+
+  it.each([
+    ['279', 'ALL_CONNECTION_TRIES_FAILED'],
+    ['210', 'NETWORK_ERROR / broken pipe'],
+    ['209', 'SOCKET_TIMEOUT'],
+    ['202', 'TOO_MANY_SIMULTANEOUS_QUERIES (transient capacity)'],
+  ])('matches a ClickHouseError with transient code %s (%s)', (code) => {
+    // Mirrors @clickhouse/client ClickHouseError shape: numeric `.code` as a string.
+    const err = Object.assign(new Error('DB::NetException: ...'), { code, type: 'X' });
+    expect(isClickHouseConnectionError(err)).toBe(true);
+  });
+
+  it('matches the $query-wrapped "Code: 279 ... All connection tries failed" message', () => {
+    const wrapped = new Error(
+      'ClickHouse query failed: Code: 279. DB::NetException: All connection tries failed. (ALL_CONNECTION_TRIES_FAILED)\nQuery: SELECT 1'
+    );
+    expect(isClickHouseConnectionError(wrapped)).toBe(true);
+  });
+
+  it('matches the $query-wrapped "Code: 210 ... Broken pipe" message', () => {
+    const wrapped = new Error(
+      'ClickHouse query failed: Code: 210. DB::NetException: Broken pipe, while writing to socket. (NETWORK_ERROR)'
+    );
+    expect(isClickHouseConnectionError(wrapped)).toBe(true);
+  });
+
+  it('matches the transient-capacity "Too many simultaneous queries" message', () => {
+    expect(
+      isClickHouseConnectionError(new Error('Too many simultaneous queries for all users'))
+    ).toBe(true);
+  });
+
+  it('walks the .cause chain (wrapped TRPCError / undici TypeError)', () => {
+    const cause = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    const wrapped = Object.assign(new Error('Image feed failed'), { cause });
+    expect(isClickHouseConnectionError(wrapped)).toBe(true);
+  });
+});
+
+describe('isClickHouseConnectionError — FALSE for query/schema/bug errors (MUST still surface)', () => {
+  it('does NOT match Code 60 UNKNOWN_TABLE (the missing-table deploy break)', () => {
+    const err = Object.assign(
+      new Error("Code: 60. DB::Exception: Table default.buzzEvents does not exist. (UNKNOWN_TABLE)"),
+      { code: '60', type: 'UNKNOWN_TABLE' }
+    );
+    expect(isClickHouseConnectionError(err)).toBe(false);
+  });
+
+  it('does NOT match the $query-wrapped UNKNOWN_TABLE message', () => {
+    const wrapped = new Error(
+      'ClickHouse query failed: Code: 60. DB::Exception: Table default.buzzEvents does not exist. (UNKNOWN_TABLE)\nQuery: SELECT * FROM buzzEvents'
+    );
+    expect(isClickHouseConnectionError(wrapped)).toBe(false);
+  });
+
+  it('does NOT match Code 349 (NULL into a non-Nullable column)', () => {
+    const err = Object.assign(
+      new Error('Code: 349. DB::Exception: Cannot insert NULL value into a column. (CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN)'),
+      { code: '349' }
+    );
+    expect(isClickHouseConnectionError(err)).toBe(false);
+  });
+
+  it('does NOT match a generic CH query error (syntax)', () => {
+    const err = Object.assign(new Error('Code: 62. DB::Exception: Syntax error. (SYNTAX_ERROR)'), {
+      code: '62',
+    });
+    expect(isClickHouseConnectionError(err)).toBe(false);
+  });
+
+  it('does NOT match a real JS bug (TypeError reading undefined)', () => {
+    expect(
+      isClickHouseConnectionError(new TypeError("Cannot read properties of undefined (reading 'id')"))
+    ).toBe(false);
+  });
+
+  it('does NOT match null / undefined / non-error', () => {
+    expect(isClickHouseConnectionError(null)).toBe(false);
+    expect(isClickHouseConnectionError(undefined)).toBe(false);
+    expect(isClickHouseConnectionError('socket hang up')).toBe(false); // bare string, no .message
+    expect(isClickHouseConnectionError(42)).toBe(false);
+  });
+});

--- a/src/server/utils/errorHandling.ts
+++ b/src/server/utils/errorHandling.ts
@@ -303,6 +303,97 @@ export function isUpstreamServerOrNetworkError(args: {
   return false;
 }
 
+/**
+ * True ONLY for a TRANSIENT ClickHouse CONNECTION / TRANSPORT failure — the kind
+ * that flaps when reaching ClickHouse Cloud (a socket reset / broken pipe / all
+ * connection tries failed), NOT a query/schema fault.
+ *
+ * Why this is deliberately NARROW: the buzz-reward write and the image-feed metric
+ * enrichment both touch ClickHouse, and we want a CH *transport* blip to fail SOFT
+ * (so it can't 500 a user mutation or a feed page). But a *query/schema* error
+ * (`Code: 60` UNKNOWN_TABLE, `Code: 349` NULL→non-Nullable, a syntax error) is a
+ * REAL BUG / deploy break — swallowing it would have HIDDEN the missing-table
+ * incident. So this predicate is an ALLOWLIST of transient-infra signatures and
+ * returns FALSE for everything else, leaving query/schema errors to surface (and
+ * alert) as a 500 exactly as today.
+ *
+ * Matches three shapes, because the same underlying failure can surface differently
+ * depending on the call path:
+ *  1. A raw socket error thrown before any HTTP response — `.code` is the syscall
+ *     (`ECONNRESET`/`EPIPE`/`ETIMEDOUT`/`ECONNREFUSED`), or the message is
+ *     `socket hang up`. This is how `@clickhouse/client` surfaces a dropped
+ *     connection (and how the event-engine-common `MetricService` read throws).
+ *  2. A `@clickhouse/client` `ClickHouseError` carrying a numeric `.code` string —
+ *     we match the transport-class codes `279` ALL_CONNECTION_TRIES_FAILED, `210`
+ *     NETWORK_ERROR (broken pipe while writing to socket), `209` SOCKET_TIMEOUT, AND
+ *     the one transient-CAPACITY brownout code `202` TOO_MANY_SIMULTANEOUS_QUERIES
+ *     (the 2026-06-18 incident that the inline buzz-reward fail-soft #2646 was built
+ *     for — a momentary CH Cloud overload, retryable, NOT a code bug). Query/schema
+ *     codes (`60`, `349`, …) are NOT in the set.
+ *  3. Our own `$query` wrapper flattens both of the above into a plain
+ *     `Error('ClickHouse query failed: <original message>')`, losing `.code`, so we
+ *     also string-match the transient signatures in the message (`Code: 279`/`210`/
+ *     `209`/`202`, `socket hang up`, `broken pipe`, `all connection tries failed`,
+ *     `too many simultaneous queries`). The message match is still transient-ONLY —
+ *     `Code: 60` / `unknown table` never match.
+ *
+ * Walks the `.cause` chain so a wrapped error (tRPC `TRPCError{ cause }`, undici
+ * `TypeError{ cause }`) is still classified.
+ */
+export function isClickHouseConnectionError(e: unknown): boolean {
+  // Syscall codes for a dropped/refused/reset TCP connection. (Intentionally a
+  // SUBSET of isUpstreamNetworkError's set — only true transport faults, no
+  // DNS-resolution-style codes that wouldn't apply to a pooled CH connection.)
+  const TRANSPORT_SYSCALL_CODES = new Set([
+    'ECONNRESET',
+    'EPIPE',
+    'ETIMEDOUT',
+    'ECONNREFUSED',
+    'EHOSTUNREACH',
+    'ENETUNREACH',
+    'UND_ERR_SOCKET',
+    'UND_ERR_CONNECT_TIMEOUT',
+  ]);
+  // ClickHouse server error codes that are TRANSIENT INFRA brownouts (never a query
+  // or schema fault). 279/210/209 = connection/transport; 202 = momentary capacity
+  // overload. Strings, because ClickHouseError.code is a string.
+  const TRANSIENT_CH_CODES = new Set(['279', '210', '209', '202']);
+
+  let cur = e as
+    | { name?: string; message?: string; code?: unknown; cause?: unknown }
+    | undefined;
+  for (let depth = 0; depth < 5 && cur && typeof cur === 'object'; depth++) {
+    const code = cur.code;
+    if (typeof code === 'string') {
+      // Shape 1: raw syscall code. Shape 2: numeric ClickHouseError code (string).
+      if (TRANSPORT_SYSCALL_CODES.has(code)) return true;
+      if (TRANSIENT_CH_CODES.has(code)) return true;
+    }
+    const msg = typeof cur.message === 'string' ? cur.message.toLowerCase() : '';
+    if (msg) {
+      // Shape 3: the $query-wrapped string. Transient-infra signatures ONLY — these
+      // never appear in an UNKNOWN_TABLE / NULL-insert / syntax error message.
+      if (
+        msg.includes('socket hang up') ||
+        msg.includes('broken pipe') ||
+        msg.includes('all connection tries failed') ||
+        msg.includes('connection refused') ||
+        msg.includes('connection reset') ||
+        msg.includes('too many simultaneous queries') ||
+        // The `Code: NNN` prefix our $query wrapper preserves, transient codes only.
+        msg.includes('code: 279') ||
+        msg.includes('code: 210') ||
+        msg.includes('code: 209') ||
+        msg.includes('code: 202')
+      ) {
+        return true;
+      }
+    }
+    cur = cur.cause as typeof cur;
+  }
+  return false;
+}
+
 export function handleLogError(e: Error, name?: string, details?: MixedObject) {
   const error = new Error(e.message ?? 'Unexpected error occurred', { cause: e });
   if (isProd)


### PR DESCRIPTION
## Root cause

dp-prod has a residual **~0.09/s HTTP 500 floor** caused by **transient ClickHouse Cloud connection flakiness** — NOT a missing table (that was a separate, already-fixed incident). Evidence from `system.query_log` + app logs: CH `Code 279` "All connection tries failed", `Code 210` "Broken pipe, while writing to socket", and app-side `ClickHouse query failed: socket hang up`. CH concurrency was only **18/1000**, so this is connection/transport flakiness to ClickHouse Cloud, not query saturation.

These leaked to user-facing 500s on two paths:

1. **`/api/v1/images` + image feeds.** `getImagesFromFeedSearch` runs the metric-enrichment read **inside** event-engine-common's `feed.populatedQuery()` (the `MetricService` ClickHouse read). A CH connection error thrown there isn't a Meili error, so it fell through the catch's `throw err` to the handler's generic 500. (`getImageMetricsObject` already fails open to `{}`, but that's a *different* leg — the `getAllImages` Promise.all fan-out, not this feed path.)
2. **Buzz-event reward write** (`base.reward.ts` inline `apply()`). Already fail-soft since #2646 — but it caught **all** errors, which would also have swallowed a query/schema break (e.g. `Code 60` UNKNOWN_TABLE), silently hiding a deploy incident.

## The transport-only predicate (and why it excludes query/schema)

New shared `isClickHouseConnectionError(e)` in `errorHandling.ts`. It is an **allowlist of transient transport/infra signatures** and returns FALSE for everything else:

- **Matches (fail-soft):** syscall `ECONNRESET`/`EPIPE`/`ETIMEDOUT`/`ECONNREFUSED` (+ undici socket codes); ClickHouseError `.code` `279` ALL_CONNECTION_TRIES_FAILED, `210` NETWORK_ERROR (broken pipe), `209` SOCKET_TIMEOUT; the `socket hang up` / `broken pipe` / `Code: 279`/`210`/`209` **message** forms our `$query` wrapper preserves (it flattens the original error into `Error("ClickHouse query failed: …")`, losing `.code`). Walks the `.cause` chain.
- **Does NOT match (still throws → 500, visible + alertable):** `Code 60` UNKNOWN_TABLE, `Code 349` NULL→non-Nullable, syntax errors, a generic query error, a real JS bug, `null`. **This is the central design constraint** — swallowing these would have HIDDEN the recent missing-table incident, which surfaced loudly as 500s. Narrowed exactly like the redis-routing predicate.
- **One deliberate non-transport inclusion:** `Code 202` TOO_MANY_SIMULTANEOUS_QUERIES — the transient *capacity* brownout the inline buzz-reward fail-soft (#2646) was originally built for. It's retryable infra, not a code bug; excluding it would have silently regressed #2646. Documented as such in the predicate.

## What was made fail-soft

- **Image-feed (`getImagesFromFeedSearch`):** on a CH transport error → **retryable 503** (`SERVICE_UNAVAILABLE`, same as the existing Meili-brownout mapping) instead of a hard 500. Items can't be safely returned (the populate aborted), so 503+Retry-After is the honest fail-soft — the client/CF retries the seconds-long blip. **Display-only metrics, no money/entitlement on this path.** A CH query/schema error still throws → 500.
- **Buzz-reward (`base.reward.ts` `apply()`):** **NARROWED** the existing all-errors fail-soft to transport-only. A transport error is logged + counted + the award skipped (the user mutation still succeeds; the CH `buzzEvents` insert is an AUDIT row, the actual grant is `sendAward`, and the Redis Lua dedup is already committed so there's no double-award). A **non-transport** error now **RETHROWS** so a schema break can't hide. Happy path + the short inline retry budget are unchanged.

## Money-safety finding (STEP 1 gate)

**Verdict: the ClickHouse buzz-reward write is event/AUDIT tracking, NOT the authoritative grant — so fail-soft is money-SAFE. Implemented.**

Evidence (`src/server/rewards/base.reward.ts`):
- `addBuzzEvent` → `clickhouse.insert({ table: 'buzzEvents', … })` is the only CH write in `apply()`. It records an audit/analytics row.
- The actual Buzz **grant** is `sendAward` → `createBuzzTransactionMany` (the buzz service / separate transaction), which runs *after* `addBuzzEvent` and is idempotent on `externalTransactionId`.
- Dedup is the Redis Lua script in `processOnDemand`, committed **before** `addBuzzEvent`. So skipping on a CH-write failure loses at most one reward credit during a brownout and can **never double-award** (a retry of the same event returns early on the dedup entry).

> Note: the **second** catch in `apply()` (around `sendAward`) is left unchanged. That is the money-grant path (Postgres/buzz service, not ClickHouse); its fail-soft was a separate #2646 decision and a CH-transport predicate would never match it. Out of scope for this CH-connection fix; flagged here so it's a conscious choice, not an oversight.

## Observability

New prom counter `civitai_app_clickhouse_failsoft_total{path}` (labels `buzz-reward`, `image-feed`), incremented on each fail-soft, plus a single structured `clickhouse-failsoft` log line. This is the #2636 pattern: fail-soft must not be able to silently mask a sustained CH outage.

**Recommended (NOT in this PR — belongs in `datapacket-talos`):** a Loki/Prom alert on a sustained `rate(civitai_app_clickhouse_failsoft_total[5m]) > 0` so a real CH Cloud outage (now degraded-not-500) still pages.

## Tests

- **Predicate** (`errorHandling.clickhouse-classify.test.ts`, 24 cases): TRUE for socket-hang-up / ECONNRESET/EPIPE/… / Code 279 / 210 / 209 / 202 + the `$query`-wrapped + `.cause`-nested forms; **FALSE** for Code 60 UNKNOWN_TABLE / 349 / syntax / a JS bug / null.
- **Buzz-reward** (`base.reward.failsoft.test.ts`, updated): transient (socket hang up / Code 202) → fail-soft, resolves, increments `rewardFailedCounter` + `clickhouseFailSoftCounter{path:buzz-reward}`, no double-award; **UNKNOWN_TABLE → RETHROWS** (no counter, no award); happy path + batch `process` rethrow unchanged.
- **Image-feed** (`image-feed-clickhouse-failsoft.test.ts`, new): transport / Code 279 → `SERVICE_UNAVAILABLE` + counter; UNKNOWN_TABLE → rethrow (not a TRPCError, no counter); non-CH error → rethrow; happy path no fail-soft.

**Local run:** predicate + buzz-reward suites green (**34/34**). The image-feed suite could not be executed on the NixOS dev host — `prisma generate` fails there (precompiled engine 404 for `linux-nixos`), which breaks the `image.service` import for **all** of its tests (the pre-existing `image-metrics-timeout.test.ts` fails identically). It runs in CI where Prisma generates normally. **Typecheck:** zero new `tsc` errors in the changed line ranges / new symbols (the large pre-existing baseline is ungenerated-Prisma + the un-checked-out `event-engine-common` submodule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)