### PR TITLE
fix(app-blocks): hide Install on page apps (page-only launch UX)

### DIFF
--- a/src/components/Apps/AppBlockCard.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.browser.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
+
+/**
+ * App Blocks marketplace CARD — component tests for the Install/Open-app CTA gate.
+ *
+ * Load-bearing behaviour: the "Install"/"Manage" CTA is shown ONLY for apps that
+ * install into a model/in-context slot. A PAGE app (target slot `app.page`,
+ * installModel `'none'`) is stateless — it has no install row and the slot
+ * install path is server-gated dark (#2622) — so its card shows ONLY "Open app".
+ *
+ * The predicate is `isPageSlot(targetSlotId)` (slot-registry, the single source
+ * of truth), keyed on the APP's slot, NOT the viewer — so a model-slot app still
+ * shows Install for the grandfathered mod audience.
+ */
+
+// LoginRedirect just clones its child with an onClick wrapper (pulls in router +
+// tour context we don't need). Stub it to a pass-through so the child's own
+// onClick runs directly — keeps the card test network-free.
+vi.mock('~/components/LoginRedirect/LoginRedirect', () => ({
+  LoginRedirect: ({ children }: { children: React.ReactElement }) => children,
+}));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { AppBlockCard } = await import('./AppBlockCard');
+
+function makeBlock(slotId: string, overrides: Partial<AvailableBlock> = {}): AvailableBlock {
+  return {
+    id: 'app-1',
+    blockId: 'my-block',
+    appId: 'app-1',
+    appName: 'My App',
+    manifest: {
+      name: 'My App',
+      description: 'Does a thing.',
+      targets: [{ slotId }],
+      // Page apps declare a page; the "Open app" affordance also needs canOpenPage.
+      hasPage: slotId === 'app.page',
+    },
+    installCount: 3,
+    category: null,
+    scopesSummary: [],
+    avgRating: null,
+    reviewCount: 0,
+    ...overrides,
+  };
+}
+
+const onOpen = vi.fn();
+
+beforeEach(() => {
+  onOpen.mockClear();
+});
+
+describe('AppBlockCard install CTA gate', () => {
+  test('page app (app.page slot) shows "Open app", NOT Install/Manage', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock('app.page')}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+        canOpenPage
+      />
+    );
+
+    await expect.element(page.getByRole('link', { name: /open app/i })).toBeInTheDocument();
+    // The dead/forbidden install action is gone for a page app.
+    expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
+    expect(page.getByRole('button', { name: /^manage$/i }).query()).toBeNull();
+  });
+
+  test('page app shows "Open app" even when alreadySubscribed (no "Manage" leak)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock('app.page')}
+        alreadySubscribed
+        onOpen={onOpen}
+        canOpenPage
+      />
+    );
+
+    await expect.element(page.getByRole('link', { name: /open app/i })).toBeInTheDocument();
+    expect(page.getByRole('button', { name: /^manage$/i }).query()).toBeNull();
+  });
+
+  test('model-slot app renders "Install" and fires onOpen', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock('model.sidebar_top')}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    const install = page.getByRole('button', { name: /^install$/i });
+    await expect.element(install).toBeInTheDocument();
+    // No page → no "Open app" for a model-slot app.
+    expect(page.getByRole('link', { name: /open app/i }).query()).toBeNull();
+
+    await install.click();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  test('model-slot app already subscribed renders "Manage"', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock('model.below_images')}
+        alreadySubscribed
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /^manage$/i })).toBeInTheDocument();
+    expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
+  });
+});

--- a/src/components/Apps/AppBlockCard.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.browser.test.tsx
@@ -5,16 +5,23 @@ import { renderWithProviders } from '../../../test/component-setup';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
 
 /**
- * App Blocks marketplace CARD — component tests for the Install/Open-app CTA gate.
+ * App Blocks marketplace CARD — component tests for the action-CTA gate.
  *
- * Load-bearing behaviour: the "Install"/"Manage" CTA is shown ONLY for apps that
- * install into a model/in-context slot. A PAGE app (target slot `app.page`,
- * installModel `'none'`) is stateless — it has no install row and the slot
- * install path is server-gated dark (#2622) — so its card shows ONLY "Open app".
+ * Load-bearing behaviour:
+ *  - The "Install"/"Manage" CTA is shown ONLY for apps that install into a
+ *    model/in-context slot. A PAGE app (target slot `app.page`, installModel
+ *    `'none'`) is stateless — no install row, slot install path server-gated
+ *    dark (#2622) — so it never shows Install/Manage.
+ *  - INVARIANT (audit HIGH): every card renders ≥1 affordance. A page app whose
+ *    live "Open app" run isn't available (no page, or the viewer's
+ *    `appBlocksPages` flag is off → `canOpenPage` false) falls back to a "View"
+ *    link to the always-reachable detail page — it MUST NOT be an actionless
+ *    card.
  *
- * The predicate is `isPageSlot(targetSlotId)` (slot-registry, the single source
- * of truth), keyed on the APP's slot, NOT the viewer — so a model-slot app still
- * shows Install for the grandfathered mod audience.
+ * The install predicate is the shared `hasInstallSlot(manifest)` (slot-registry,
+ * the single source of truth shared with the detail page) — it scans ALL targets
+ * for ANY non-page slot, so it's correct for multi-target / empty-slotId
+ * manifests, keyed on the APP's slot (not the viewer).
  */
 
 // LoginRedirect just clones its child with an onClick wrapper (pulls in router +
@@ -27,7 +34,20 @@ vi.mock('~/components/LoginRedirect/LoginRedirect', () => ({
 // Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
 const { AppBlockCard } = await import('./AppBlockCard');
 
-function makeBlock(slotId: string, overrides: Partial<AvailableBlock> = {}): AvailableBlock {
+type ManifestShape = {
+  name?: string;
+  description?: string;
+  targets?: Array<{ slotId?: string }>;
+  hasPage?: boolean;
+};
+
+function makeBlock(
+  manifestOverrides: ManifestShape = {},
+  overrides: Partial<AvailableBlock> = {}
+): AvailableBlock {
+  const targets = manifestOverrides.targets ?? [{ slotId: 'model.sidebar_top' }];
+  // Page apps declare a page; default hasPage from whether any target is app.page.
+  const defaultHasPage = targets.some((t) => t.slotId === 'app.page');
   return {
     id: 'app-1',
     blockId: 'my-block',
@@ -36,9 +56,9 @@ function makeBlock(slotId: string, overrides: Partial<AvailableBlock> = {}): Ava
     manifest: {
       name: 'My App',
       description: 'Does a thing.',
-      targets: [{ slotId }],
-      // Page apps declare a page; the "Open app" affordance also needs canOpenPage.
-      hasPage: slotId === 'app.page',
+      hasPage: defaultHasPage,
+      ...manifestOverrides,
+      targets,
     },
     installCount: 3,
     category: null,
@@ -49,47 +69,90 @@ function makeBlock(slotId: string, overrides: Partial<AvailableBlock> = {}): Ava
   };
 }
 
+/** A page app: single `app.page` target. */
+function pageBlock(manifestOverrides: ManifestShape = {}): AvailableBlock {
+  return makeBlock({ targets: [{ slotId: 'app.page' }], ...manifestOverrides });
+}
+
 const onOpen = vi.fn();
 
 beforeEach(() => {
   onOpen.mockClear();
 });
 
-describe('AppBlockCard install CTA gate', () => {
-  test('page app (app.page slot) shows "Open app", NOT Install/Manage', async () => {
+/** The card's action group lives in the bottom Group; assert ≥1 actionable
+ *  control (link OR button) is present — the never-empty-card invariant. */
+function expectAtLeastOneAffordance() {
+  const links = page.getByRole('link').elements();
+  const buttons = page.getByRole('button').elements();
+  // The title + description are also links (to the detail page); the action
+  // group adds Open app / View / Install on top. The invariant we care about is
+  // a CTA in the action row — every branch below asserts the SPECIFIC expected
+  // CTA, so this is the coarse backstop that SOMETHING actionable rendered.
+  expect(links.length + buttons.length).toBeGreaterThan(0);
+}
+
+describe('AppBlockCard action CTA gate', () => {
+  test('page app + canOpenPage=false (pages flag off) → "View" fallback, NOT zero buttons [HIGH regression]', async () => {
     renderWithProviders(
+      <AppBlockCard block={pageBlock()} alreadySubscribed={false} onOpen={onOpen} canOpenPage={false} />
+    );
+
+    // The live "Open app" run is unavailable (flag off) → fall back to "View".
+    await expect.element(page.getByRole('link', { name: /^view$/i })).toBeInTheDocument();
+    // "Open app" did NOT render (no flag), and Install is forbidden for a page app.
+    expect(page.getByRole('link', { name: /open app/i }).query()).toBeNull();
+    expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
+    expect(page.getByRole('button', { name: /^manage$/i }).query()).toBeNull();
+    // INVARIANT: the card is not actionless.
+    expectAtLeastOneAffordance();
+  });
+
+  test('page app + manifest.hasPage=false → still ≥1 affordance ("View")', async () => {
+    renderWithProviders(
+      // hasPage false but canOpenPage true → "Open app" still can't render (no page).
       <AppBlockCard
-        block={makeBlock('app.page')}
+        block={pageBlock({ hasPage: false })}
         alreadySubscribed={false}
         onOpen={onOpen}
         canOpenPage
       />
     );
 
-    await expect.element(page.getByRole('link', { name: /open app/i })).toBeInTheDocument();
-    // The dead/forbidden install action is gone for a page app.
+    await expect.element(page.getByRole('link', { name: /^view$/i })).toBeInTheDocument();
+    expect(page.getByRole('link', { name: /open app/i }).query()).toBeNull();
     expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
-    expect(page.getByRole('button', { name: /^manage$/i }).query()).toBeNull();
+    expectAtLeastOneAffordance();
   });
 
-  test('page app shows "Open app" even when alreadySubscribed (no "Manage" leak)', async () => {
+  test('page app + canOpenPage=true → "Open app" shows, "View" NOT duplicated', async () => {
     renderWithProviders(
-      <AppBlockCard
-        block={makeBlock('app.page')}
-        alreadySubscribed
-        onOpen={onOpen}
-        canOpenPage
-      />
+      <AppBlockCard block={pageBlock()} alreadySubscribed={false} onOpen={onOpen} canOpenPage />
+    );
+
+    await expect.element(page.getByRole('link', { name: /open app/i })).toBeInTheDocument();
+    // The live run IS available → no redundant "View" fallback.
+    expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
+    // Still no Install/Manage for a page app.
+    expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
+    expect(page.getByRole('button', { name: /^manage$/i }).query()).toBeNull();
+    expectAtLeastOneAffordance();
+  });
+
+  test('page app + canOpenPage=true even when alreadySubscribed (no "Manage" leak)', async () => {
+    renderWithProviders(
+      <AppBlockCard block={pageBlock()} alreadySubscribed onOpen={onOpen} canOpenPage />
     );
 
     await expect.element(page.getByRole('link', { name: /open app/i })).toBeInTheDocument();
     expect(page.getByRole('button', { name: /^manage$/i }).query()).toBeNull();
+    expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
   });
 
-  test('model-slot app renders "Install" and fires onOpen', async () => {
+  test('model-slot app renders "Install" and fires onOpen (no regression)', async () => {
     renderWithProviders(
       <AppBlockCard
-        block={makeBlock('model.sidebar_top')}
+        block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }] })}
         alreadySubscribed={false}
         onOpen={onOpen}
       />
@@ -97,8 +160,9 @@ describe('AppBlockCard install CTA gate', () => {
 
     const install = page.getByRole('button', { name: /^install$/i });
     await expect.element(install).toBeInTheDocument();
-    // No page → no "Open app" for a model-slot app.
+    // No page → no "Open app", and no "View" fallback (Install IS the action).
     expect(page.getByRole('link', { name: /open app/i }).query()).toBeNull();
+    expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
 
     await install.click();
     expect(onOpen).toHaveBeenCalledTimes(1);
@@ -107,7 +171,7 @@ describe('AppBlockCard install CTA gate', () => {
   test('model-slot app already subscribed renders "Manage"', async () => {
     renderWithProviders(
       <AppBlockCard
-        block={makeBlock('model.below_images')}
+        block={makeBlock({ targets: [{ slotId: 'model.below_images' }] })}
         alreadySubscribed
         onOpen={onOpen}
       />
@@ -115,5 +179,54 @@ describe('AppBlockCard install CTA gate', () => {
 
     await expect.element(page.getByRole('button', { name: /^manage$/i })).toBeInTheDocument();
     expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
+  });
+
+  test('multi-target [model, page] → classified as model-slot (Install shows)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }, { slotId: 'app.page' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+        canOpenPage
+      />
+    );
+
+    // Any non-page target → Install (the `.some()` fix, not trusting index [0]).
+    await expect.element(page.getByRole('button', { name: /^install$/i })).toBeInTheDocument();
+    expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
+  });
+
+  test('multi-target [page, model] → classified as model-slot (Install shows) — order-independent', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'app.page' }, { slotId: 'model.sidebar_top' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+        canOpenPage
+      />
+    );
+
+    // page at index [0] must NOT mask the model target → Install still shows.
+    await expect.element(page.getByRole('button', { name: /^install$/i })).toBeInTheDocument();
+    expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
+  });
+
+  test('empty-string slotId at index [0] → treated as a page app (no Install), "View" fallback', async () => {
+    // Parity with the detail page: a falsy slotId is skipped (filter(Boolean)),
+    // so [''] yields NO model install slot → page-app branch. The card and the
+    // detail page agree on this input (both via the shared hasInstallSlot).
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: '' }], hasPage: false })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+        canOpenPage
+      />
+    );
+
+    expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
+    // No usable page either → the never-empty-card invariant gives us "View".
+    await expect.element(page.getByRole('link', { name: /^view$/i })).toBeInTheDocument();
+    expectAtLeastOneAffordance();
   });
 });

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -14,6 +14,7 @@ import {
   isMarketplaceCategory,
   MARKETPLACE_CATEGORY_LABELS,
 } from '~/server/services/blocks/marketplace-categories.constants';
+import { isPageSlot } from '~/shared/constants/slot-registry';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
 
 /**
@@ -85,6 +86,14 @@ export function AppBlockCard({
   };
   const [busy] = useState(false);
   const slot = manifest.targets?.[0]?.slotId;
+  // A page app (target slot `app.page`) is STATELESS — installModel `'none'` in
+  // the slot registry — so it has no `block_user_subscriptions` install row and
+  // the Install/Manage CTA (openAppSettingsModal → slot subscription) is a
+  // dead/forbidden action for it (slot installs are server-gated dark, #2622).
+  // Show Install ONLY for model/in-context slot apps; a page app shows just
+  // "Open app". The predicate is about the APP's slot, not the viewer — so a
+  // model-slot app still shows Install for the grandfathered mod audience.
+  const isPageApp = isPageSlot(slot ?? '');
   return (
     <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
       <Stack gap="sm" h="100%">
@@ -196,19 +205,21 @@ export function AppBlockCard({
                 Open app
               </Button>
             )}
-            <LoginRedirect reason="perform-action">
-              <Button
-                size="xs"
-                variant={alreadySubscribed ? 'default' : 'filled'}
-                leftSection={
-                  alreadySubscribed ? <IconSettings size={14} /> : <IconPlugConnected size={14} />
-                }
-                loading={busy}
-                onClick={() => onOpen(block)}
-              >
-                {alreadySubscribed ? 'Manage' : 'Install'}
-              </Button>
-            </LoginRedirect>
+            {!isPageApp && (
+              <LoginRedirect reason="perform-action">
+                <Button
+                  size="xs"
+                  variant={alreadySubscribed ? 'default' : 'filled'}
+                  leftSection={
+                    alreadySubscribed ? <IconSettings size={14} /> : <IconPlugConnected size={14} />
+                  }
+                  loading={busy}
+                  onClick={() => onOpen(block)}
+                >
+                  {alreadySubscribed ? 'Manage' : 'Install'}
+                </Button>
+              </LoginRedirect>
+            )}
           </Group>
         </Group>
       </Stack>

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -14,7 +14,7 @@ import {
   isMarketplaceCategory,
   MARKETPLACE_CATEGORY_LABELS,
 } from '~/server/services/blocks/marketplace-categories.constants';
-import { isPageSlot } from '~/shared/constants/slot-registry';
+import { hasInstallSlot } from '~/shared/constants/slot-registry';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
 
 /**
@@ -86,14 +86,25 @@ export function AppBlockCard({
   };
   const [busy] = useState(false);
   const slot = manifest.targets?.[0]?.slotId;
+  // Show Install ONLY for an app that installs into a model/in-context slot.
   // A page app (target slot `app.page`) is STATELESS — installModel `'none'` in
   // the slot registry — so it has no `block_user_subscriptions` install row and
   // the Install/Manage CTA (openAppSettingsModal → slot subscription) is a
   // dead/forbidden action for it (slot installs are server-gated dark, #2622).
-  // Show Install ONLY for model/in-context slot apps; a page app shows just
-  // "Open app". The predicate is about the APP's slot, not the viewer — so a
-  // model-slot app still shows Install for the grandfathered mod audience.
-  const isPageApp = isPageSlot(slot ?? '');
+  // `hasInstallSlot` is the SHARED predicate (with the detail page) — it scans
+  // ALL targets for ANY non-page slot, so it's correct for multi-target and
+  // empty-slotId manifests, not just index `[0]`. Keyed on the APP's slot, not
+  // the viewer — so a model-slot app still shows Install for the grandfathered
+  // mod audience.
+  const showInstall = hasInstallSlot(manifest);
+  // The live "Open app" run is only available for a real page app that the
+  // viewer's `appBlocksPages` flag has unlocked (dark today / launch-flip
+  // window). When that run can't render AND there's no Install affordance, the
+  // card would otherwise have ZERO actions — guarantee ≥1 affordance by linking
+  // to the always-reachable detail page ("View"). The detail page itself always
+  // exposes "Open live", so this never strands the user.
+  const canOpenApp = Boolean(manifest.hasPage && canOpenPage);
+  const showView = !showInstall && !canOpenApp;
   return (
     <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
       <Stack gap="sm" h="100%">
@@ -195,7 +206,7 @@ export function AppBlockCard({
                 app declares a page AND the viewer has the appBlocksPages flag
                 (dark today). The route itself 404s without the flag, so this is
                 belt-and-suspenders against showing a dead link. */}
-            {manifest.hasPage && canOpenPage && (
+            {canOpenApp && (
               <Button
                 component={Link}
                 href={`/apps/run/${encodeURIComponent(block.blockId)}`}
@@ -205,7 +216,22 @@ export function AppBlockCard({
                 Open app
               </Button>
             )}
-            {!isPageApp && (
+            {/* INVARIANT: every card renders ≥1 affordance. A page app whose
+                live "Open app" run isn't available (no page, or the
+                `appBlocksPages` flag is off) and which has no Install slot would
+                otherwise be an actionless card — fall back to a "View" link to
+                the always-reachable detail page. */}
+            {showView && (
+              <Button
+                component={Link}
+                href={`/apps/${block.id}`}
+                size="xs"
+                variant="light"
+              >
+                View
+              </Button>
+            )}
+            {showInstall && (
               <LoginRedirect reason="perform-action">
                 <Button
                   size="xs"

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -45,6 +45,7 @@ import {
   SLOT_DESCRIPTIONS,
 } from '~/server/services/blocks/scope-descriptions.constants';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { isPageSlot } from '~/shared/constants/slot-registry';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -126,6 +127,12 @@ export default function AppDetailPage() {
   const name = detail?.manifest.name ?? detail?.blockId ?? appBlockId;
   const description = detail?.manifest.description ?? '';
   const slots = detail?.manifest.targets?.map((t) => t.slotId).filter(Boolean) ?? [];
+  // A page app (target slot `app.page`) is STATELESS (installModel `'none'`) — no
+  // install row, and the Install/Manage CTA (openAppSettingsModal → slot
+  // subscription) is a dead/forbidden action (slot installs are server-gated
+  // dark, #2622). Show Install ONLY for model/in-context slot apps; a page app
+  // shows just "Open app"/"Open live". Keyed on the APP's slot, not the viewer.
+  const isPageApp = isPageSlot((slots[0] as string | undefined) ?? '');
   const scopes = detail?.scopes ?? [];
   // F-E E5 publisher screenshot gallery — public display URLs (gated app route),
   // magic-byte-validated + mod-reviewed at approval. Empty when the app shipped
@@ -244,21 +251,23 @@ export default function AppDetailPage() {
                     LoginModal (via LoginRedirect); logged-in → the install/
                     settings modal. Dark today (page is mod-gated).
                   */}
-                  <LoginRedirect reason="perform-action">
-                    <Button
-                      leftSection={
-                        alreadySubscribed ? (
-                          <IconSettings size={16} />
-                        ) : (
-                          <IconPlugConnected size={16} />
-                        )
-                      }
-                      variant={alreadySubscribed ? 'default' : 'filled'}
-                      onClick={handleInstall}
-                    >
-                      {alreadySubscribed ? 'Manage' : 'Install'}
-                    </Button>
-                  </LoginRedirect>
+                  {!isPageApp && (
+                    <LoginRedirect reason="perform-action">
+                      <Button
+                        leftSection={
+                          alreadySubscribed ? (
+                            <IconSettings size={16} />
+                          ) : (
+                            <IconPlugConnected size={16} />
+                          )
+                        }
+                        variant={alreadySubscribed ? 'default' : 'filled'}
+                        onClick={handleInstall}
+                      >
+                        {alreadySubscribed ? 'Manage' : 'Install'}
+                      </Button>
+                    </LoginRedirect>
+                  )}
                 </Group>
               </Group>
 

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -45,7 +45,7 @@ import {
   SLOT_DESCRIPTIONS,
 } from '~/server/services/blocks/scope-descriptions.constants';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
-import { isPageSlot } from '~/shared/constants/slot-registry';
+import { hasInstallSlot } from '~/shared/constants/slot-registry';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -127,12 +127,16 @@ export default function AppDetailPage() {
   const name = detail?.manifest.name ?? detail?.blockId ?? appBlockId;
   const description = detail?.manifest.description ?? '';
   const slots = detail?.manifest.targets?.map((t) => t.slotId).filter(Boolean) ?? [];
+  // Show Install ONLY for an app that installs into a model/in-context slot.
   // A page app (target slot `app.page`) is STATELESS (installModel `'none'`) — no
   // install row, and the Install/Manage CTA (openAppSettingsModal → slot
   // subscription) is a dead/forbidden action (slot installs are server-gated
-  // dark, #2622). Show Install ONLY for model/in-context slot apps; a page app
-  // shows just "Open app"/"Open live". Keyed on the APP's slot, not the viewer.
-  const isPageApp = isPageSlot((slots[0] as string | undefined) ?? '');
+  // dark, #2622). `hasInstallSlot` is the SHARED predicate (with the card) — it
+  // scans ALL targets for ANY non-page slot, so it's correct for multi-target
+  // and empty-slotId manifests, not just index `[0]`. Keyed on the APP's slot,
+  // not the viewer. The header always renders "Open live", so even a page app
+  // keeps ≥1 affordance here.
+  const showInstall = hasInstallSlot(detail?.manifest);
   const scopes = detail?.scopes ?? [];
   // F-E E5 publisher screenshot gallery — public display URLs (gated app route),
   // magic-byte-validated + mod-reviewed at approval. Empty when the app shipped
@@ -251,7 +255,7 @@ export default function AppDetailPage() {
                     LoginModal (via LoginRedirect); logged-in → the install/
                     settings modal. Dark today (page is mod-gated).
                   */}
-                  {!isPageApp && (
+                  {showInstall && (
                     <LoginRedirect reason="perform-action">
                       <Button
                         leftSection={

--- a/src/shared/constants/__tests__/slot-registry.test.ts
+++ b/src/shared/constants/__tests__/slot-registry.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   ALL_SLOT_IDS,
+  getPrimaryInstallSlot,
+  hasInstallSlot,
   isKnownSlotId,
   isLaunchSlot,
   isPageSlot,
@@ -122,6 +124,62 @@ describe('slot-registry (Phase 0 foundation)', () => {
       for (const id of LAUNCH_SLOT_IDS) {
         expect(isPageSlot(id), `launch slot "${id}" must be a page slot`).toBe(true);
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // INSTALL-SLOT PREDICATE — the SHARED card/detail-page "show Install?" gate.
+  // ---------------------------------------------------------------------------
+  describe('getPrimaryInstallSlot / hasInstallSlot (shared install-CTA predicate)', () => {
+    it('returns the model slot for a single model-target manifest', () => {
+      const m = { targets: [{ slotId: 'model.sidebar_top' }] };
+      expect(getPrimaryInstallSlot(m)).toBe('model.sidebar_top');
+      expect(hasInstallSlot(m)).toBe(true);
+    });
+
+    it('returns undefined for a page-only manifest (page apps have no install slot)', () => {
+      const m = { targets: [{ slotId: 'app.page' }] };
+      expect(getPrimaryInstallSlot(m)).toBeUndefined();
+      expect(hasInstallSlot(m)).toBe(false);
+    });
+
+    // The `.some()` fix: a multi-target manifest is classified by ANY non-page
+    // slot, not by index [0] — proven order-independent (both orderings).
+    it('multi-target [model, page] → install slot found (not masked by index)', () => {
+      const m = { targets: [{ slotId: 'model.sidebar_top' }, { slotId: 'app.page' }] };
+      expect(getPrimaryInstallSlot(m)).toBe('model.sidebar_top');
+      expect(hasInstallSlot(m)).toBe(true);
+    });
+
+    it('multi-target [page, model] → install slot found despite page at [0]', () => {
+      const m = { targets: [{ slotId: 'app.page' }, { slotId: 'model.sidebar_top' }] };
+      expect(getPrimaryInstallSlot(m)).toBe('model.sidebar_top');
+      expect(hasInstallSlot(m)).toBe(true);
+    });
+
+    // PARITY: a falsy slotId is skipped (matching the detail page's
+    // `…filter(Boolean)[0]`), so an empty-string slot at index [0] does NOT
+    // count as an install slot — the card and detail page agree on this input.
+    it('empty-string slotId at index [0] is skipped (parity with filter(Boolean))', () => {
+      const m = { targets: [{ slotId: '' }] };
+      expect(getPrimaryInstallSlot(m)).toBeUndefined();
+      expect(hasInstallSlot(m)).toBe(false);
+    });
+
+    it('empty-string at [0] then a real model slot → still finds the model slot', () => {
+      const m = { targets: [{ slotId: '' }, { slotId: 'model.below_images' }] };
+      expect(getPrimaryInstallSlot(m)).toBe('model.below_images');
+      expect(hasInstallSlot(m)).toBe(true);
+    });
+
+    it('handles missing / empty / null manifest + targets defensively', () => {
+      expect(getPrimaryInstallSlot(undefined)).toBeUndefined();
+      expect(getPrimaryInstallSlot(null)).toBeUndefined();
+      expect(getPrimaryInstallSlot({})).toBeUndefined();
+      expect(getPrimaryInstallSlot({ targets: [] })).toBeUndefined();
+      expect(getPrimaryInstallSlot({ targets: [undefined] })).toBeUndefined();
+      expect(getPrimaryInstallSlot({ targets: [{}] })).toBeUndefined();
+      expect(hasInstallSlot(undefined)).toBe(false);
     });
   });
 });

--- a/src/shared/constants/slot-registry.ts
+++ b/src/shared/constants/slot-registry.ts
@@ -183,6 +183,50 @@ export function isPageSlot(id: string): boolean {
   return isKnownSlotId(id) && SLOT_REGISTRY[id].kind === 'page';
 }
 
+/** Minimal manifest shape the install-slot predicate reads. */
+export interface InstallSlotManifest {
+  targets?: Array<{ slotId?: string } | undefined> | null;
+}
+
+/**
+ * The slot that drives an app's INSTALL affordance — i.e. the first
+ * model/in-context (non-page) target slot, or `undefined` when the app has none
+ * (a page-only app).
+ *
+ * SINGLE SOURCE OF TRUTH for the card / detail-page "show Install?" decision, so
+ * the two surfaces cannot drift:
+ *   - Robust to multi-target manifests: scans ALL targets for ANY non-page slot
+ *     (`.some`-style) rather than trusting index `[0]` — a manifest that lists
+ *     `[{app.page},{model.sidebar_top}]` is still an installable model app.
+ *   - Robust to a malformed empty-string `slotId` at index 0: a falsy slotId is
+ *     skipped (the `Boolean` filter), matching the detail page's
+ *     `…filter(Boolean)[0]` and the card, so they agree on the same input.
+ *
+ * Show the Install/Manage CTA iff this returns a truthy slot. A page app
+ * (only `app.page` targets, or no model target) returns `undefined` → no
+ * Install CTA — it is STATELESS (installModel `'none'`), so Install/Manage
+ * (openAppSettingsModal → slot subscription) is a dead/forbidden action.
+ */
+export function getPrimaryInstallSlot(manifest: InstallSlotManifest | null | undefined):
+  | string
+  | undefined {
+  const targets = manifest?.targets ?? [];
+  for (const target of targets) {
+    const slotId = target?.slotId;
+    if (slotId && !isPageSlot(slotId)) return slotId;
+  }
+  return undefined;
+}
+
+/**
+ * Does the app install into a model/in-context slot (i.e. show the Install/Manage
+ * CTA)? `false` for a page-only app. Thin boolean wrapper over
+ * {@link getPrimaryInstallSlot} so call-sites read as intent.
+ */
+export function hasInstallSlot(manifest: InstallSlotManifest | null | undefined): boolean {
+  return getPrimaryInstallSlot(manifest) !== undefined;
+}
+
 /**
  * LAUNCH ALLOWLIST — the slot ids exposed to the PUBLIC (non-moderator) audience
  * at the initial App Blocks public launch.


### PR DESCRIPTION
## What
Hide the **"Install"/"Manage"** button on **page apps** in the App Blocks marketplace card and the app-detail page. A page app now shows only **"Open app"**.

## Why (UX-clarity only — no server change)
Page apps (target slot `app.page`) are **stateless** — the slot registry declares `installModel: 'none'`, so there is no `block_user_subscriptions` row and no per-content install. The "Install"/"Manage" CTA opens `AppSettingsModal`, which writes a model-page **slot subscription** — a dead/forbidden action for a page app. Slot installs are already **server-enforced-dark** (#2622 `assertLaunchSlotForCaller`; the marketplace `launchOnly` filter shows non-mods only page apps), so on a page app "Install" was just a confusing, non-functional button.

This is a **client-only** fix. The server slot-install gate stays the source of truth.

## The predicate
`isPageSlot(targetSlotId)` from `src/shared/constants/slot-registry.ts` — the registry's single source of truth, where `app.page` is the only `kind: 'page'` / `installModel: 'none'` slot. Robust because it keys on the slot the app *installs into* (the registry maps slot → install model), not on a softer signal like `manifest.hasPage` (which only means "declares a page surface"). The target slot id is already in scope in both components (`manifest.targets?.[0]?.slotId`).

The predicate is about the **app's slot, not the viewer** — so a model/in-context-slot app still shows Install for the grandfathered **mod** audience. Correct for both audiences.

## Files changed
- `src/components/Apps/AppBlockCard.tsx` — gate the install CTA on `!isPageApp` where `isPageApp = isPageSlot(slot ?? '')`.
- `src/pages/apps/[appBlockId]/index.tsx` — same gate, `isPageApp = isPageSlot((slots[0] as string | undefined) ?? '')`.

"Open app", the server gate, the mutations, `AppSettingsModal`, and `/apps/installed` are untouched. Note: `/apps/installed` "Manage" + the modal remain, but a page-only-launch user has **no slot subscriptions**, so that list is empty for them — out of scope here.

## Tests
New `src/components/Apps/AppBlockCard.browser.test.tsx` (Vitest browser-mode, matching the existing `AppBlockReviews.browser.test.tsx` scaffold — `renderWithProviders`, `LoginRedirect` stubbed to a pass-through):
- Page app (`app.page`) → renders "Open app", does **NOT** render Install/Manage.
- Page app + `alreadySubscribed` → "Open app", no "Manage" leak.
- Model-slot app → renders "Install" and clicking it fires `onOpen`.
- Model-slot app + `alreadySubscribed` → renders "Manage", no "Install".

Detail-page CTA is covered by parity (identical predicate/expression); only the card is unit-tested.

## Verification
- Scoped `tsc --noEmit` (full-repo, filtered to touched files) → **zero** errors on `AppBlockCard.tsx`, `apps/[appBlockId]/index.tsx`, `slot-registry.ts`, and the new test.
- `vitest run --project component src/components/Apps/AppBlockCard.browser.test.tsx` → **4 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
