### PR TITLE
fix(app-blocks): /apps/run loading indicator + hide 'Hide' frame action on page apps

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -51,3 +51,55 @@ describe('AppBlockChrome (H2 host-rendered app name)', () => {
     await expect.element(page.getByRole('button', { name: 'App block menu' })).toBeInTheDocument();
   });
 });
+
+// Task 2: the "Hide app block" menu item is meaningless on the full-page run
+// surface (`/apps/run/<slug>`, slot kind `page`) — there's no model-page slot to
+// dismiss the block FROM; the page IS the block. The chrome takes the rendering
+// `slotId` and drops "Hide" when `isPageSlot(slotId)` is true. "Manage apps" +
+// the provenance badge stay on every surface. (Mirrors PR #2747's `isPageSlot`
+// page-vs-model distinction.)
+//
+// The menu items live in a Mantine `<Menu>` dropdown that only mounts its
+// contents once the trigger is opened — so each test clicks the ⋯ trigger first,
+// then asserts on the dropdown contents.
+describe('AppBlockChrome "Hide" item is surface-aware (page vs model)', () => {
+  async function openMenu() {
+    await page.getByRole('button', { name: 'App block menu' }).click();
+    // "Manage apps" is present on every surface — wait on it so the dropdown has
+    // mounted before asserting on the conditional "Hide" item.
+    await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+  }
+
+  test('model surface (model.sidebar_top) renders the "Hide app block" item', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-model" appName="Background Remover" slotId="model.sidebar_top" />
+    );
+    await openMenu();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Hide app block' }))
+      .toBeInTheDocument();
+  });
+
+  test('no slotId (back-compat default = model surface) renders the "Hide app block" item', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-default" appName="Background Remover" />
+    );
+    await openMenu();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Hide app block' }))
+      .toBeInTheDocument();
+  });
+
+  test('page surface (app.page) does NOT render the "Hide app block" item, keeps "Manage apps"', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-page" appName="Budgeted Generator" slotId="app.page" />
+    );
+    await openMenu();
+    // "Manage apps" stays …
+    await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
+    // … but "Hide app block" is suppressed on the full-page surface.
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Hide app block' }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -11,6 +11,7 @@ import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import { resolveRequestSignIn } from './requestSignInGate';
 import { resolveRequestConsent } from './requestConsentGate';
 import { hideBlock } from './hiddenBlocks';
+import { isPageSlot } from '~/shared/constants/slot-registry';
 import { sanitizeAppChromeName } from './appChromeName';
 import { sendBlockRender } from './sendBlockRender';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
@@ -125,18 +126,35 @@ function storageErrorMessage(err: unknown): string {
  * to every viewer; this lets a viewer dismiss one without affecting the
  * publisher or anyone else). Rendering it here (vs in the sandboxed iframe) is
  * the whole point — the trust boundary belongs to the host. (Roadmap W7.)
+ *
+ * SURFACE-AWARE: on the full-page run surface (`/apps/run/<slug>`, slot kind
+ * `page`) the "Hide app block" action is meaningless — there is no model-page
+ * slot to dismiss the block FROM; the page IS the block. So the host passes the
+ * rendering `slotId` and we drop the "Hide" item when `isPageSlot(slotId)` is
+ * true. "Manage apps" + the provenance badge stay on every surface. (Mirrors PR
+ * #2747's `isPageSlot` page-vs-model distinction.) When `slotId` is omitted the
+ * chrome defaults to the model surface (shows Hide) — back-compat for any caller
+ * that hasn't threaded a slot.
  */
 export function AppBlockChrome({
   blockInstanceId,
   appName,
   modelId,
   modelName,
+  slotId,
 }: {
   blockInstanceId: string;
   appName?: string;
   modelId?: number;
   modelName?: string;
+  /** The slot this chrome renders in. Drives the page-vs-model surface
+   *  distinction — the "Hide" item is hidden on the full-page (`app.page`)
+   *  surface. Omitted → treated as a model surface (Hide shown). */
+  slotId?: string;
 }) {
+  // The full-page run surface (`app.page`) has no model-page slot to hide the
+  // block from — the page IS the block — so suppress the "Hide" item there.
+  const showHide = !(slotId != null && isPageSlot(slotId));
   // The host-rendered name of the running app. (H2) Naming the app in the host
   // chrome — not just the iframe `title` — lets the user tell WHICH sandboxed
   // app is running and trust its provenance; the iframe can't fake it. The name
@@ -200,20 +218,22 @@ export function AppBlockChrome({
           >
             Manage apps
           </Menu.Item>
-          <Menu.Item
-            leftSection={<IconEyeOff size={14} stroke={1.5} />}
-            onClick={() =>
-              hideBlock({
-                blockInstanceId,
-                appName,
-                modelId,
-                modelName,
-                hiddenAt: Date.now(),
-              })
-            }
-          >
-            Hide app block
-          </Menu.Item>
+          {showHide && (
+            <Menu.Item
+              leftSection={<IconEyeOff size={14} stroke={1.5} />}
+              onClick={() =>
+                hideBlock({
+                  blockInstanceId,
+                  appName,
+                  modelId,
+                  modelName,
+                  hiddenAt: Date.now(),
+                })
+              }
+            >
+              Hide app block
+            </Menu.Item>
+          )}
         </Menu.Dropdown>
       </Menu>
     </Group>
@@ -1199,6 +1219,7 @@ export function IframeHost({
         appName={install.manifest.name}
         modelId={modelCtx.modelId}
         modelName={modelCtx.modelName}
+        slotId={slotId}
       />
       {children}
     </Box>

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -213,6 +213,13 @@ describe('PageBlockHost loading indicator (Task 1)', () => {
     await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
     await expect.element(page.getByLabelText('Loading Budgeted Generator')).toBeInTheDocument();
 
+    // a11y: the overlay container is marked as a busy live region (role="status"
+    // + aria-busy) so a screen reader announces the loading state on the REGION,
+    // not just the labeled graphic. Assert the attributes while still loading.
+    const overlay = page.getByTestId('app-page-loading').element();
+    expect(overlay.getAttribute('role')).toBe('status');
+    expect(overlay.getAttribute('aria-busy')).toBe('true');
+
     // Drive the handshake to BLOCK_READY → status flips to 'ready'.
     await driveToReady();
 
@@ -221,6 +228,21 @@ describe('PageBlockHost loading indicator (Task 1)', () => {
     await vi.waitFor(() => {
       expect(page.getByTestId('app-page-loading').query()).toBeNull();
     });
+  });
+
+  test('the aria-label runs appName through the chrome sanitizer (control/bidi chars stripped)', async () => {
+    // A publisher-controlled name carrying a control char (\t) and a bidi
+    // override (U+202E) must NOT reach the accessible name verbatim — it goes
+    // through the SAME sanitizeAppChromeName the visible chrome uses: the \t
+    // control char becomes a space and the U+202E format char is dropped →
+    // 'Evil App' (verified against the sanitizer's documented behaviour +
+    // appChromeName.test.ts). Built from char codes so the source carries no
+    // literal invisible chars.
+    const spoofedName = 'Evil' + String.fromCharCode(0x09) + String.fromCharCode(0x202e) + 'App';
+    renderWithProviders(
+      <PageBlockHost {...baseProps} appName={spoofedName} onConsentGranted={vi.fn()} />
+    );
+    await expect.element(page.getByLabelText('Loading Evil App')).toBeInTheDocument();
   });
 
   test('the error terminal path shows the fallback and never the loader (does not spin forever)', async () => {
@@ -239,6 +261,81 @@ describe('PageBlockHost loading indicator (Task 1)', () => {
     // … and the loading indicator is NOT present (no infinite spinner).
     expect(page.getByTestId('app-page-loading').query()).toBeNull();
   });
+
+  // The loader must clear on EVERY terminal status the host's real status machine
+  // can reach — not just `error`. These drive each terminal transition through the
+  // host's actual code path (BLOCK_ERROR message, the BLOCK_READY-timeout, the
+  // token-wait timeout) and assert the overlay unmounts (so it can never spin
+  // forever). `fatal` is message-driven (fast); `timeout`/`no_token` are
+  // real-timer driven (BLOCK_READY_TIMEOUT_MS=10s, TOKEN_WAIT_TIMEOUT_MS=15s) so
+  // each is given a per-test timeout above its trigger window.
+
+  test('loader clears after BLOCK_ERROR{fatal:true} (fatal terminal path)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+    // Loader present while loading, then drive to ready (fatal is reachable from
+    // both 'loading' and 'ready'; we go through ready as a real block would).
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await driveToReady();
+    await vi.waitFor(() => {
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    });
+
+    // A fatal block error flips status → 'fatal'; showIframe becomes false and the
+    // host renders the BlockFallback. The loader must stay gone (never re-spin).
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+  });
+
+  test(
+    'loader clears after the BLOCK_READY timeout (timeout terminal path)',
+    async () => {
+      // token present so the init controller arms its readiness timeout, but we
+      // NEVER ack BLOCK_READY → after BLOCK_READY_TIMEOUT_MS (10s) onReadyTimeout
+      // flips status 'loading' → 'timeout', clearing the loader and rendering the
+      // fallback.
+      renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+
+      // Wait out the real 10s readiness window (poll with generous timeout). The
+      // loader must clear and the timeout fallback render.
+      await vi.waitFor(
+        () => {
+          expect(page.getByTestId('app-page-loading').query()).toBeNull();
+        },
+        { timeout: 13_000, interval: 250 }
+      );
+      await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    },
+    20_000
+  );
+
+  test(
+    'loader clears after the token-wait timeout (no_token terminal path)',
+    async () => {
+      // token=null and tokenError=false → no init controller (shouldStartInit
+      // needs a token) and no synchronous error flip; the token-wait effect's
+      // TOKEN_WAIT_TIMEOUT_MS (15s) timer flips status 'loading' → 'no_token',
+      // clearing the loader and rendering the fallback. (With a null token the
+      // iframe still mounts in the loading state, so the overlay is shown first.)
+      renderWithProviders(
+        <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
+      );
+
+      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+
+      await vi.waitFor(
+        () => {
+          expect(page.getByTestId('app-page-loading').query()).toBeNull();
+        },
+        { timeout: 18_000, interval: 250 }
+      );
+      await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    },
+    25_000
+  );
 });
 
 describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -204,6 +204,43 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
   });
 });
 
+describe('PageBlockHost loading indicator (Task 1)', () => {
+  test('shows a loading indicator before BLOCK_READY and removes it once ready', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+    // While status === 'loading' (iframe mounted, pre-handshake) the centered
+    // Loader overlay is present so the surface isn't blank.
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    await expect.element(page.getByLabelText('Loading Budgeted Generator')).toBeInTheDocument();
+
+    // Drive the handshake to BLOCK_READY → status flips to 'ready'.
+    await driveToReady();
+
+    // The overlay is gated purely on status === 'loading', so it unmounts the
+    // instant the block is ready — never spins forever.
+    await vi.waitFor(() => {
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    });
+  });
+
+  test('the error terminal path shows the fallback and never the loader (does not spin forever)', async () => {
+    // token=null + tokenError=true → the `error` effect flips status out of
+    // 'loading' synchronously, so showIframe is false and the loader overlay is
+    // never reached: the surface lands on the host BlockFallback, not an endless
+    // spinner. (The mint-failure → terminal mapping is unit-covered by
+    // pageBlockHostLogic.pageFallbackReason; here we assert the host surfaces it
+    // INSTEAD of the loading indicator.)
+    renderWithProviders(
+      <PageBlockHost {...baseProps} token={null} tokenError onConsentGranted={vi.fn()} />
+    );
+
+    // Terminal fallback is rendered …
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    // … and the loading indicator is NOT present (no infinite spinner).
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+  });
+});
+
 describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
   // Analytics Phase 2 now emits via the /api/track/block-render BEACON
   // (sendBlockRender → fetch), not a tRPC mutation. Spy on global fetch and

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mantine/core';
+import { Box, Center, Loader } from '@mantine/core';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -17,6 +17,7 @@ import { sendBlockRender } from './sendBlockRender';
 import { resolveRequestConsent } from './requestConsentGate';
 import { resolveRequestSignIn } from './requestSignInGate';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
+import { PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, PageContext } from './types';
 import { dialogStore } from '~/components/Dialog/dialogStore';
@@ -1047,25 +1048,45 @@ export function PageBlockHost({
       // silently swallowed.
       data-needs-consent={needsConsent ? 'true' : 'false'}
     >
-      <AppBlockChrome blockInstanceId={blockInstanceId} appName={appName} />
+      <AppBlockChrome blockInstanceId={blockInstanceId} appName={appName} slotId={PAGE_SLOT_ID} />
       {showIframe ? (
-        <iframe
-          ref={iframeRef}
-          src={iframeSrc}
-          sandbox={effectiveSandbox}
-          referrerPolicy="no-referrer"
-          title={appName || blockId}
-          data-testid="app-page-iframe"
-          data-block-instance-id={blockInstanceId}
-          data-block-ready={isReady ? 'true' : 'false'}
-          style={{
-            flex: 1,
-            display: 'block',
-            width: '100%',
-            border: 0,
-            pointerEvents: isReady ? 'auto' : 'none',
-          }}
-        />
+        // The iframe fills the remaining viewport. While the block is still
+        // handshaking (status === 'loading', before BLOCK_READY), the surface
+        // would otherwise be blank — the iframe is mounted but visually empty and
+        // non-interactive (pointerEvents:none). Overlay a centered Loader on top
+        // so the user sees a loading state instead of a blank page. The overlay
+        // is gated purely on `status === 'loading'`: it unmounts the instant the
+        // status machine leaves loading — on BLOCK_READY (→ ready) AND on every
+        // terminal path (timeout / fatal / no_token / error, which also flip
+        // `showIframe` to false and render the BlockFallback below) — so it can
+        // never spin forever.
+        <Box style={{ position: 'relative', flex: 1, display: 'flex' }}>
+          <iframe
+            ref={iframeRef}
+            src={iframeSrc}
+            sandbox={effectiveSandbox}
+            referrerPolicy="no-referrer"
+            title={appName || blockId}
+            data-testid="app-page-iframe"
+            data-block-instance-id={blockInstanceId}
+            data-block-ready={isReady ? 'true' : 'false'}
+            style={{
+              flex: 1,
+              display: 'block',
+              width: '100%',
+              border: 0,
+              pointerEvents: isReady ? 'auto' : 'none',
+            }}
+          />
+          {status === 'loading' && (
+            <Center
+              data-testid="app-page-loading"
+              style={{ position: 'absolute', inset: 0, background: 'var(--mantine-color-body)' }}
+            >
+              <Loader aria-label={`Loading ${appName || 'app'}`} />
+            </Center>
+          )}
+        </Box>
       ) : fallbackReason ? (
         <Box style={{ flex: 1, padding: 'var(--mantine-spacing-md)' }} data-testid="app-page-fallback">
           <BlockFallback reason={fallbackReason} blockName={appName} />

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -2,6 +2,7 @@ import { Box, Center, Loader } from '@mantine/core';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { sanitizeAppChromeName } from './appChromeName';
 import { BlockFallback } from './BlockFallback';
 import { failureSnapshot } from './failureSnapshot';
 import { AppBlockChrome } from './IframeHost';
@@ -1066,7 +1067,11 @@ export function PageBlockHost({
             src={iframeSrc}
             sandbox={effectiveSandbox}
             referrerPolicy="no-referrer"
-            title={appName || blockId}
+            // Sanitize the publisher-controlled appName for the iframe title too
+            // (same sanitizer as the visible chrome + the loader aria-label), so
+            // every appName-derived plain-text attribute is consistent. Falls
+            // back to blockId when nothing legible remains.
+            title={sanitizeAppChromeName(appName) || blockId}
             data-testid="app-page-iframe"
             data-block-instance-id={blockInstanceId}
             data-block-ready={isReady ? 'true' : 'false'}
@@ -1081,9 +1086,21 @@ export function PageBlockHost({
           {status === 'loading' && (
             <Center
               data-testid="app-page-loading"
+              // Announce the loading state on the REGION, not just the graphic:
+              // role="status" + aria-busy mark the overlay container as a live
+              // busy region so a screen reader announces "loading" when it
+              // appears (the bare <Loader> below only exposes a labeled graphic).
+              role="status"
+              aria-busy={true}
+              aria-live="polite"
               style={{ position: 'absolute', inset: 0, background: 'var(--mantine-color-body)' }}
             >
-              <Loader aria-label={`Loading ${appName || 'app'}`} />
+              {/* Run the publisher-controlled appName through the SAME sanitizer
+                  the visible chrome uses (sanitizeAppChromeName) so the accessible
+                  name a screen reader reads can't carry control/bidi/zalgo
+                  spoofing — consistency with AppBlockChrome, not a new gate. Falls
+                  back to 'app' when nothing legible remains. */}
+              <Loader aria-label={`Loading ${sanitizeAppChromeName(appName) || 'app'}`} />
             </Center>
           )}
         </Box>


### PR DESCRIPTION
Two small UI fixes on the App Blocks full-page run surface (`/apps/run/<slug>`), UI-only, scoped to the page host + the App Block frame chrome.

## 1. Loading indicator on `/apps/run`
`PageBlockHost` mounts the block iframe immediately (so the postMessage init handshake can start), but the iframe is visually empty and non-interactive (`pointerEvents:none`) until the block sends `BLOCK_READY` — leaving a **blank viewport** during the handshake.

Fix: overlay a centered Mantine `<Loader>` on top of the iframe while `status === 'loading'`.

**Ready signal it's gated on:** the host's own `status` state machine. `BLOCK_READY` flips `status` `'loading' → 'ready'` (the existing message handler); the loader is `status === 'loading'` only, so it disappears the instant the block is ready. **Error/timeout handling:** every terminal path (`timeout` / `fatal` / `no_token` / `error`) also leaves `'loading'` — those flip `showIframe` to false and render the existing `BlockFallback` instead — so the loader can **never spin forever** (no new protocol, no new timer).

## 2. Hide the "Hide app block" frame action on page apps
The `⋯` menu's "Hide app block" item dismisses a block from a **model-page slot** (device-local). On the **full-page** surface that's meaningless — the page *is* the block, there's no slot to hide it from.

Fix: `AppBlockChrome` now takes the rendering `slotId` and drops the "Hide" item when `isPageSlot(slotId)` is true (reusing `isPageSlot` from `slot-registry.ts`, mirroring PR #2747's page-vs-model distinction). `PageBlockHost` passes `slotId={PAGE_SLOT_ID}` (`'app.page'`); `IframeHost` passes its model `slotId`. **"Manage apps" + the provenance badge are unchanged on every surface.** An omitted `slotId` defaults to the model surface (Hide shown) — back-compat for any caller not threading a slot.

## Tests
- `AppBlockChrome.browser.test.tsx`: "Hide app block" is **absent** on `app.page`, **present** on `model.sidebar_top` and with no `slotId`; "Manage apps" stays in all cases.
- `PageBlockHost.browser.test.tsx`: loader present pre-`BLOCK_READY`, cleared after `BLOCK_READY`; the `error` terminal path renders the fallback and **never** the loader.

## Verification
- Scoped `tsc --noEmit` filtered to the touched files: **zero** errors (repo has many pre-existing unrelated type errors; none in these files).
- `vitest --project component` on the two changed test files: **15/15 pass**. Sibling PageBlockHost/IframeHost browser suites (workflow/storage/sign-in/resource-picker/iframe-host): **36/36 pass** — the iframe-wrapper change didn't disturb the postMessage bridge tests.
- Not browser-verified on a live preview (mod-gated, both Flipt flags required); the host is driven through its real postMessage handshake in the component tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
