### PR TITLE
feat(app-blocks): my-submissions cleanup (drop Changes col, CLI authoring, reviewer-notes modal, surface analytics)

### DIFF
--- a/src/components/AppBlocks/AppAnalyticsPanel.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.tsx
@@ -160,10 +160,21 @@ function MiniLineChart({
   );
 }
 
-export function AppAnalyticsPanel() {
-  const { data: appsRaw, isLoading: appsLoading } = trpc.blocks.getMyApps.useQuery();
+/**
+ * @param scopedAppBlockId When supplied, the panel is locked to a single app
+ *   (the per-app picker is hidden) — used when the panel is opened in a modal
+ *   from a specific app's row on /apps/my-submissions. When omitted the panel
+ *   shows the "All my apps" picker (the /apps/revenue dashboard usage).
+ */
+export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: string } = {}) {
+  const scoped = scopedAppBlockId != null;
+  const { data: appsRaw, isLoading: appsLoading } = trpc.blocks.getMyApps.useQuery(undefined, {
+    // No need to load the picker list when we're locked to one app.
+    enabled: !scoped,
+  });
   const apps = (appsRaw as MyApp[] | undefined) ?? [];
-  const [appBlockId, setAppBlockId] = useState<string | null>(null);
+  const [pickedAppBlockId, setPickedAppBlockId] = useState<string | null>(null);
+  const appBlockId = scoped ? scopedAppBlockId : pickedAppBlockId;
 
   const {
     data: analyticsRaw,
@@ -185,15 +196,17 @@ export function AppAnalyticsPanel() {
   return (
     <Stack gap="lg">
       <Group justify="space-between" align="flex-end">
-        <Select
-          label="App"
-          data={appOptions}
-          value={appBlockId ?? ''}
-          onChange={(v) => setAppBlockId(v ? v : null)}
-          disabled={appsLoading}
-          w={260}
-          comboboxProps={{ withinPortal: true }}
-        />
+        {!scoped && (
+          <Select
+            label="App"
+            data={appOptions}
+            value={pickedAppBlockId ?? ''}
+            onChange={(v) => setPickedAppBlockId(v ? v : null)}
+            disabled={appsLoading}
+            w={260}
+            comboboxProps={{ withinPortal: true }}
+          />
+        )}
         {analytics && (
           <Text size="xs" c="dimmed">
             {dayjs(analytics.range.from).format('MMM D, YYYY')} –{' '}

--- a/src/components/Apps/AppAnalyticsInline.tsx
+++ b/src/components/Apps/AppAnalyticsInline.tsx
@@ -34,7 +34,12 @@ export function AppAnalyticsInline({
   const [opened, { open, close }] = useDisclosure(false);
 
   // Last 30 days, app-scoped. Cheap aggregate the revenue dashboard already runs.
-  const from = useMemo(() => dayjs().subtract(30, 'day').toISOString(), []);
+  // Floor to the start of the (local) day so the React-Query key is STABLE across
+  // every approved row of the same app — a per-instance ms-precision `from` gives
+  // each identical-app row a distinct key, defeating dedup and firing N heavy
+  // getMyAppAnalytics queries (request batching is off). Start-of-day collapses
+  // them to one shared key → one query per unique appBlockId.
+  const from = useMemo(() => dayjs().subtract(30, 'day').startOf('day').toISOString(), []);
   const statQuery = trpc.blocks.getMyAppAnalytics.useQuery(
     { appBlockId, from },
     { staleTime: 5 * 60 * 1000, refetchOnWindowFocus: false }

--- a/src/components/Apps/AppAnalyticsInline.tsx
+++ b/src/components/Apps/AppAnalyticsInline.tsx
@@ -1,0 +1,96 @@
+import { Anchor, Group, Loader, Modal, Text, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconChartBar, IconInfoCircle } from '@tabler/icons-react';
+import { useMemo } from 'react';
+import { AppAnalyticsPanel } from '~/components/AppBlocks/AppAnalyticsPanel';
+import dayjs from '~/shared/utils/dayjs';
+import { trpc } from '~/utils/trpc';
+
+/** Local mirror of the getMyAppAnalytics fields this inline stat reads (the
+ *  full shape lives in AppAnalyticsPanel). */
+type InlineAnalytics = {
+  runs: { count: number };
+  engagement: { activeUsers: number };
+};
+
+/**
+ * Compact, per-approved-app analytics affordance for the /apps/my-submissions
+ * list. Shows a small inline runs / unique-users (last 30d) stat and an
+ * "Analytics" button that opens the existing AppAnalyticsPanel — scoped to THIS
+ * app — in a modal. Reuses `blocks.getMyAppAnalytics` (the same query the
+ * /apps/revenue dashboard panel runs) with a 30-day `from`; no new analytics
+ * surface is built.
+ *
+ * Caveat (informational): runs/active-users undercount anonymous / no-scope
+ * runs until the render-event instrumentation (#2695) deploys.
+ */
+export function AppAnalyticsInline({
+  appBlockId,
+  appLabel,
+}: {
+  appBlockId: string;
+  appLabel: string;
+}) {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  // Last 30 days, app-scoped. Cheap aggregate the revenue dashboard already runs.
+  const from = useMemo(() => dayjs().subtract(30, 'day').toISOString(), []);
+  const statQuery = trpc.blocks.getMyAppAnalytics.useQuery(
+    { appBlockId, from },
+    { staleTime: 5 * 60 * 1000, refetchOnWindowFocus: false }
+  );
+
+  const data = statQuery.data as InlineAnalytics | undefined;
+
+  return (
+    <Group gap={8} wrap="nowrap" align="center">
+      {statQuery.isLoading ? (
+        <Loader size="xs" />
+      ) : data ? (
+        <Tooltip
+          label="Runs and unique users in the last 30 days. Anonymous / no-scope runs are undercounted until render-event tracking ships."
+          multiline
+          maw={260}
+          withinPortal
+        >
+          <Group gap={4} wrap="nowrap">
+            <Text size="xs" fw={600}>
+              {data.runs.count.toLocaleString()}
+            </Text>
+            <Text size="xs" c="dimmed">
+              runs
+            </Text>
+            <Text size="xs" c="dimmed">
+              ·
+            </Text>
+            <Text size="xs" fw={600}>
+              {data.engagement.activeUsers.toLocaleString()}
+            </Text>
+            <Text size="xs" c="dimmed">
+              users
+            </Text>
+            <IconInfoCircle size={12} style={{ opacity: 0.6 }} />
+          </Group>
+        </Tooltip>
+      ) : (
+        <Text size="xs" c="dimmed">
+          —
+        </Text>
+      )}
+      <Anchor component="button" type="button" size="xs" onClick={open}>
+        <Group gap={2} wrap="nowrap">
+          <IconChartBar size={12} />
+          Analytics
+        </Group>
+      </Anchor>
+      <Modal
+        opened={opened}
+        onClose={close}
+        title={`Analytics — ${appLabel}`}
+        size="xl"
+      >
+        {opened && <AppAnalyticsPanel scopedAppBlockId={appBlockId} />}
+      </Modal>
+    </Group>
+  );
+}

--- a/src/components/Apps/AuthorAffordance.browser.test.tsx
+++ b/src/components/Apps/AuthorAffordance.browser.test.tsx
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * AuthorAffordance — git-provisioning SIDE-EFFECT GATING guard.
+ *
+ * `blocks.getMyAppRepo` is NOT a pure read: the router lazily provisions a scoped
+ * Forgejo identity + grants the caller push on their repo as a side effect (see
+ * AuthorViaGit's doc + blocks.router.ts). The safety guarantee is therefore that
+ * it must be USER-INITIATED — it must never auto-provision on page/mount, only
+ * after the user deliberately opts in.
+ *
+ * That gating is implemented purely by MOUNT (`{showGit && <AuthorViaGit>}` →
+ * `{expanded && <GitAccessPanel>}`), and GitAccessPanel is the ONLY caller of
+ * `getMyAppRepo.useQuery`. So spying on `getMyAppRepo.useQuery` (which only runs
+ * when its component renders) is the smallest faithful seam for the side effect:
+ * a call == the panel mounted == provisioning would fire.
+ *
+ * Unlike MySubmissionsList.browser.test.tsx (which stubs AuthorViaGit to a
+ * marker), this test mounts the REAL AuthorAffordance + AuthorViaGit + the real
+ * mount-gating, so a future regression that swaps the conditional mount for a
+ * Mantine <Collapse> (which keeps children MOUNTED while collapsed → useQuery
+ * fires immediately) would flip the on-mount/after-first-toggle call count from
+ * 0 to 1 and fail here.
+ */
+
+const mocks = vi.hoisted(() => ({
+  // Spy standing in for blocks.getMyAppRepo.useQuery. Call count == "the
+  // side-effecting query ran" (i.e. GitAccessPanel mounted). Returns a benign
+  // "not yet available" result so the panel renders without a token/network.
+  getMyAppRepo: vi.fn((..._args: unknown[]) => ({
+    data: { notYetAvailable: true, slug: 'my-app', firstVersionIsZip: true, message: '' },
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getMyAppRepo: { useQuery: (...args: unknown[]) => mocks.getMyAppRepo(...args) },
+    },
+  },
+}));
+
+const { AuthorAffordance } = await import('./MySubmissionsList');
+
+beforeEach(() => {
+  mocks.getMyAppRepo.mockClear();
+});
+
+describe('AuthorAffordance git-provisioning gating', () => {
+  test('getMyAppRepo is NOT called on mount, NOT after expanding "Advanced", and ONLY after the inner "Author via git" toggle (two clicks)', async () => {
+    renderWithProviders(<AuthorAffordance appBlockId="block-guard" />);
+
+    // (1) On mount: the CLI guidance shows, but the side-effecting query has NOT
+    // run — git provisioning must be user-initiated.
+    await expect.element(page.getByRole('link', { name: /civitai.*CLI/i })).toBeInTheDocument();
+    expect(mocks.getMyAppRepo).toHaveBeenCalledTimes(0);
+
+    // (2) First click — expand the "Advanced: author via git" footnote. This
+    // mounts AuthorViaGit (its "Author via git" button), but GitAccessPanel is
+    // still NOT mounted, so getMyAppRepo STILL hasn't fired.
+    const advanced = page.getByRole('button', { name: /advanced.*git/i });
+    await advanced.click();
+    const innerToggle = page.getByRole('button', { name: /^author via git$/i });
+    await expect.element(innerToggle).toBeInTheDocument();
+    expect(mocks.getMyAppRepo).toHaveBeenCalledTimes(0);
+
+    // (3) Second click — the inner "Author via git" toggle mounts GitAccessPanel,
+    // which is the ONLY thing that runs getMyAppRepo. NOW (and only now) it fires.
+    await innerToggle.click();
+    await vi.waitFor(() => {
+      expect(mocks.getMyAppRepo).toHaveBeenCalled();
+    });
+    // It was scoped to the right app block.
+    expect(mocks.getMyAppRepo).toHaveBeenCalledWith({ appBlockId: 'block-guard' }, expect.anything());
+  });
+
+  test('collapsing the inner toggle unmounts the panel (provisioning does not run again on re-expand without intent)', async () => {
+    renderWithProviders(<AuthorAffordance appBlockId="block-guard2" />);
+    await page.getByRole('button', { name: /advanced.*git/i }).click();
+    const innerToggle = page.getByRole('button', { name: /^author via git$/i });
+
+    // Expand → panel mounts → query fires once.
+    await innerToggle.click();
+    await vi.waitFor(() => expect(mocks.getMyAppRepo).toHaveBeenCalled());
+
+    // Collapse — the toggle now reads "Hide git access"; the panel is unmounted.
+    const hide = page.getByRole('button', { name: /hide git access/i });
+    await expect.element(hide).toBeInTheDocument();
+    expect(page.getByRole('button', { name: /^author via git$/i }).elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * /apps/my-submissions LIST — component tests for the UX-pass cleanup:
+ *   1. The "Changes" column is gone (header + the +/~/- file-diff badges).
+ *   2. Reviewer notes are NOT inline; a "See reviewer notes" button shows ONLY
+ *      when notes exist and opens the notes in a modal.
+ *   3. An approved row shows the compact runs/users (30d) inline stat + an
+ *      "Analytics" button that opens AppAnalyticsPanel (scoped) in a modal; a
+ *      non-approved row shows neither.
+ *   4. The authoring affordance links the Civitai CLI (the git path is demoted
+ *      to a collapsed "Advanced" footnote).
+ *
+ * tRPC + the heavy analytics panel are mocked per the documented scaffold
+ * pattern so this stays network-free and chart-free.
+ */
+
+const mocks = vi.hoisted(() => ({
+  analytics: { runs: { count: 0 }, engagement: { activeUsers: 0 } } as unknown,
+  analyticsLoading: false,
+  panelRenders: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getMyAppAnalytics: {
+        useQuery: () => ({ data: mocks.analytics, isLoading: mocks.analyticsLoading }),
+      },
+      // getMyApps is used only by the (mocked-away) panel; keep a stub so any
+      // accidental call is harmless.
+      getMyApps: { useQuery: () => ({ data: [], isLoading: false }) },
+      getMyAppRepo: { useQuery: () => ({ data: undefined, isLoading: false }) },
+    },
+  },
+}));
+
+// The real AppAnalyticsPanel pulls in chart.js; replace it with a marker that
+// records the scoped appBlockId it was opened with.
+vi.mock('~/components/AppBlocks/AppAnalyticsPanel', () => ({
+  AppAnalyticsPanel: ({ scopedAppBlockId }: { scopedAppBlockId?: string }) => {
+    mocks.panelRenders(scopedAppBlockId);
+    return <div data-testid="analytics-panel">analytics-panel:{scopedAppBlockId}</div>;
+  },
+}));
+
+// AuthorViaGit provisions a Forgejo identity on mount — stub to a marker so the
+// "Advanced: author via git" footnote is testable without that side-effect.
+vi.mock('~/components/Apps/AuthorViaGit', () => ({
+  AuthorViaGit: () => <div data-testid="author-via-git">git-panel</div>,
+}));
+
+// Type-only import is erased at runtime, so it's safe above the dynamic value
+// import (which must come AFTER the hoisted vi.mock calls).
+import type { Submission } from './MySubmissionsList';
+const { MySubmissionsList } = await import('./MySubmissionsList');
+
+function makeSubmission(overrides: Partial<Submission>): Submission {
+  return {
+    id: 's1',
+    appBlockId: 'block-1',
+    slug: 'my-app',
+    version: '1.0.0',
+    status: 'approved',
+    submittedAt: new Date('2026-01-01T00:00:00Z'),
+    reviewedAt: new Date('2026-01-02T00:00:00Z'),
+    rejectionReason: null,
+    approvalNotes: null,
+    deployState: 'live',
+    deployDetail: null,
+    deployUpdatedAt: new Date('2026-01-02T00:00:00Z'),
+    fileSummary: { added: ['a.js'], changed: ['b.js'], removed: ['c.js'] },
+    manifestDiffSummary: { kind: 'update', added: [], removed: [], changed: [] },
+    modelInstallCount: 3,
+    userSubscriptionCount: 5,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.analytics = { runs: { count: 0 }, engagement: { activeUsers: 0 } };
+  mocks.analyticsLoading = false;
+  mocks.panelRenders.mockClear();
+});
+
+describe('MySubmissionsList', () => {
+  test('the "Changes" column header is NOT rendered', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[makeSubmission({})]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    // Sanity: the table painted (a known-kept header is present).
+    await expect.element(page.getByText('Submitted', { exact: true })).toBeInTheDocument();
+    // The "Changes" column header is gone.
+    expect(page.getByText('Changes', { exact: true }).elements()).toHaveLength(0);
+    // The file-diff badges that lived in that column are gone too.
+    expect(page.getByText('+1', { exact: true }).elements()).toHaveLength(0);
+    expect(page.getByText('~1', { exact: true }).elements()).toHaveLength(0);
+  });
+
+  test('reviewer notes are NOT inline; "See reviewer notes" opens a modal with the notes', async () => {
+    const notes = 'Please tighten the manifest scopes before next version.';
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[makeSubmission({ approvalNotes: notes })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    // Notes are NOT rendered inline up-front.
+    expect(page.getByText(notes, { exact: false }).elements()).toHaveLength(0);
+    // The trigger button is present.
+    const btn = page.getByRole('button', { name: /see reviewer notes/i });
+    await expect.element(btn).toBeInTheDocument();
+    // Clicking it opens the modal with the notes.
+    await btn.click();
+    await expect.element(page.getByText(notes, { exact: false })).toBeInTheDocument();
+  });
+
+  test('"See reviewer notes" is ABSENT when a row has no notes', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[makeSubmission({ approvalNotes: null, rejectionReason: null })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByText('my-app', { exact: false })).toBeInTheDocument();
+    expect(page.getByRole('button', { name: /see reviewer notes/i }).elements()).toHaveLength(0);
+  });
+
+  test('"See reviewer notes" shows for a REJECTED row with a rejection reason', async () => {
+    const reason = 'Rejected: the block requests an unapproved scope.';
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({
+            id: 'r1',
+            status: 'rejected',
+            deployState: null,
+            approvalNotes: null,
+            rejectionReason: reason,
+          }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    const btn = page.getByRole('button', { name: /see reviewer notes/i });
+    await expect.element(btn).toBeInTheDocument();
+    // Reason not inline.
+    expect(page.getByText(reason, { exact: false }).elements()).toHaveLength(0);
+    await btn.click();
+    await expect.element(page.getByText(reason, { exact: false })).toBeInTheDocument();
+  });
+
+  test('an APPROVED row shows the inline 30d stat and an Analytics modal scoped to the app', async () => {
+    mocks.analytics = { runs: { count: 1234 }, engagement: { activeUsers: 56 } };
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[makeSubmission({ appBlockId: 'block-xyz' })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    // Compact inline stat: runs + users.
+    await expect.element(page.getByText('1,234', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('56', { exact: true })).toBeInTheDocument();
+
+    // The Analytics button opens the (scoped) panel in a modal.
+    const analyticsBtn = page.getByRole('button', { name: /analytics/i });
+    await expect.element(analyticsBtn).toBeInTheDocument();
+    await analyticsBtn.click();
+    await expect.element(page.getByTestId('analytics-panel')).toBeInTheDocument();
+    expect(mocks.panelRenders).toHaveBeenCalledWith('block-xyz');
+  });
+
+  test('a NON-approved (pending) row shows NO analytics affordance', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({
+            id: 'p1',
+            status: 'pending',
+            deployState: null,
+            reviewedAt: null,
+            appBlockId: null,
+          }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByText('my-app', { exact: false })).toBeInTheDocument();
+    // No inline analytics stat, no Analytics button.
+    expect(page.getByRole('button', { name: /^analytics$/i }).elements()).toHaveLength(0);
+    expect(page.getByText('runs', { exact: true }).elements()).toHaveLength(0);
+  });
+
+  test('the authoring affordance links the Civitai CLI (git demoted to an Advanced footnote)', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[makeSubmission({ appBlockId: 'block-1' })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    // CLI link present + points at the CLI repo.
+    const cliLink = page.getByRole('link', { name: /civitai.*CLI/i });
+    await expect.element(cliLink).toBeInTheDocument();
+    expect(cliLink.element().getAttribute('href')).toBe('https://github.com/civitai/cli');
+
+    // Git is NOT a primary affordance — the panel is collapsed behind "Advanced".
+    expect(page.getByTestId('author-via-git').elements()).toHaveLength(0);
+    const advanced = page.getByRole('button', { name: /advanced.*git/i });
+    await expect.element(advanced).toBeInTheDocument();
+    await advanced.click();
+    await expect.element(page.getByTestId('author-via-git')).toBeInTheDocument();
+  });
+});

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
+import dayjs from '~/shared/utils/dayjs';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -22,13 +23,19 @@ const mocks = vi.hoisted(() => ({
   analytics: { runs: { count: 0 }, engagement: { activeUsers: 0 } } as unknown,
   analyticsLoading: false,
   panelRenders: vi.fn(),
+  // Spy on the analytics query so we can assert the input (e.g. the floored
+  // `from`) every approved row passes — the per-row dedup key depends on it.
+  analyticsUseQuery: vi.fn(),
 }));
 
 vi.mock('~/utils/trpc', () => ({
   trpc: {
     blocks: {
       getMyAppAnalytics: {
-        useQuery: () => ({ data: mocks.analytics, isLoading: mocks.analyticsLoading }),
+        useQuery: (...args: unknown[]) => {
+          mocks.analyticsUseQuery(...args);
+          return { data: mocks.analytics, isLoading: mocks.analyticsLoading };
+        },
       },
       // getMyApps is used only by the (mocked-away) panel; keep a stub so any
       // accidental call is harmless.
@@ -84,6 +91,7 @@ beforeEach(() => {
   mocks.analytics = { runs: { count: 0 }, engagement: { activeUsers: 0 } };
   mocks.analyticsLoading = false;
   mocks.panelRenders.mockClear();
+  mocks.analyticsUseQuery.mockClear();
 });
 
 describe('MySubmissionsList', () => {
@@ -179,6 +187,49 @@ describe('MySubmissionsList', () => {
     await analyticsBtn.click();
     await expect.element(page.getByTestId('analytics-panel')).toBeInTheDocument();
     expect(mocks.panelRenders).toHaveBeenCalledWith('block-xyz');
+  });
+
+  test('the inline analytics `from` is floored to start-of-day, so same-app rows share one query key (per-row dedup)', async () => {
+    // Two APPROVED versions of the SAME app block. Pre-fix, each AppAnalyticsInline
+    // computed `from = dayjs().subtract(30,'day').toISOString()` at ms precision per
+    // instance → two distinct query inputs → no React-Query dedup → 2 heavy queries.
+    // The floor (.startOf('day')) makes both rows pass the IDENTICAL input.
+    const appBlockId = 'block-dedup';
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({ id: 'v1', version: '1.0.0', appBlockId }),
+          makeSubmission({ id: 'v2', version: '2.0.0', appBlockId }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByText('my-app', { exact: false }).first()).toBeInTheDocument();
+
+    // Every call carried the same app id.
+    const inputs = mocks.analyticsUseQuery.mock.calls.map((c) => c[0] as { appBlockId: string; from: string });
+    const appInputs = inputs.filter((i) => i?.appBlockId === appBlockId);
+    expect(appInputs.length).toBeGreaterThanOrEqual(2); // both rows mounted an inline stat
+
+    // (1) `from` is floored to a day boundary — TZ-agnostic: re-flooring a value
+    // that's ALREADY at start-of-day is a no-op, so `from === startOf('day')(from)`.
+    // (Asserting a literal `T00:00:00Z` would be wrong — `dayjs().startOf('day')`
+    // floors to the LOCAL midnight, whose ISO carries the UTC offset.)
+    const isFlooredToDay = (iso: string) =>
+      dayjs(iso).valueOf() === dayjs(iso).startOf('day').valueOf();
+    for (const i of appInputs) {
+      expect(isFlooredToDay(i.from)).toBe(true);
+    }
+
+    // (2) Mutation-sanity: a ms-precision `from` (the pre-fix value, ~now) is NOT
+    // on a day boundary, so reverting the `.startOf('day')` floor fails this test.
+    expect(isFlooredToDay(new Date().toISOString())).toBe(false);
+
+    // (3) The crux: identical `from` across same-app rows → identical input →
+    // React-Query dedups to ONE in-flight query (not N).
+    const uniqueFroms = new Set(appInputs.map((i) => i.from));
+    expect(uniqueFroms.size).toBe(1);
   });
 
   test('a NON-approved (pending) row shows NO analytics affordance', async () => {

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -1,0 +1,493 @@
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Button,
+  Card,
+  Code,
+  Group,
+  Modal,
+  Stack,
+  Table,
+  Text,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import {
+  IconAlertTriangle,
+  IconArrowRight,
+  IconBox,
+  IconBrandGit,
+  IconCheck,
+  IconChevronDown,
+  IconChevronRight,
+  IconClock,
+  IconExternalLink,
+  IconMessage,
+  IconTerminal2,
+  IconUsers,
+  IconX,
+} from '@tabler/icons-react';
+import Link from 'next/link';
+import { Fragment, useState } from 'react';
+import { AppAnalyticsInline } from '~/components/Apps/AppAnalyticsInline';
+import { AuthorViaGit } from '~/components/Apps/AuthorViaGit';
+import { isStaleDeploy } from '~/components/Apps/deploy-status';
+
+/** Civitai CLI repo — the recommended author + submit path (replaces the raw
+ *  git-clone affordance as the PRIMARY way to author/update an app). */
+export const CIVITAI_CLI_URL = 'https://github.com/civitai/cli';
+
+export type FileSummary = {
+  files?: Array<{ path: string; sha256: string; sizeBytes: number }>;
+  added?: string[];
+  removed?: string[];
+  changed?: string[];
+};
+
+export type ManifestDiffSummary =
+  | { kind: 'first-version'; fields: string[] }
+  | {
+      kind: 'update';
+      added: string[];
+      removed: string[];
+      changed: Array<{ field: string; from: unknown; to: unknown }>;
+    };
+
+export type Submission = {
+  id: string;
+  appBlockId: string | null;
+  slug: string;
+  version: string;
+  status: string;
+  submittedAt: string | Date;
+  reviewedAt: string | Date | null;
+  rejectionReason: string | null;
+  approvalNotes: string | null;
+  /** Phase 2 build/deploy lifecycle for an approved request:
+   * 'building' → 'deploying' → 'live', or 'failed'. Null on non-approved rows
+   * and on approved rows from before this feature shipped. */
+  deployState: 'building' | 'deploying' | 'live' | 'failed' | null;
+  deployDetail: string | null;
+  deployUpdatedAt: string | Date | null;
+  fileSummary: unknown;
+  manifestDiffSummary: unknown;
+  /** Total pinned subscriptions referencing this app block. */
+  modelInstallCount: number | null;
+  /** Total BlockUserSubscription rows. */
+  userSubscriptionCount: number | null;
+};
+
+function formatDate(d: string | Date): string {
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return date.toLocaleString();
+}
+
+export function statusBadge(
+  submission: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt'>
+) {
+  const { status } = submission;
+  // For an approved request, show the real build/deploy lifecycle rather than a
+  // flat "approved" — the dev cares whether their code is actually live.
+  if (status === 'approved') {
+    if (isStaleDeploy(submission)) {
+      return (
+        <Badge
+          color="orange"
+          leftSection={<IconAlertTriangle size={12} />}
+          title="No progress for a while — the deploy may be stuck. Resubmit a new version if it doesn't go live."
+        >
+          {submission.deployState} (stalled)
+        </Badge>
+      );
+    }
+    switch (submission.deployState) {
+      case 'building':
+        return (
+          <Badge color="blue" leftSection={<IconClock size={12} />}>
+            building
+          </Badge>
+        );
+      case 'deploying':
+        return (
+          <Badge color="indigo" leftSection={<IconClock size={12} />}>
+            deploying
+          </Badge>
+        );
+      case 'failed':
+        return (
+          <Badge color="red" leftSection={<IconX size={12} />}>
+            deploy failed
+          </Badge>
+        );
+      case 'live':
+        return (
+          <Badge color="green" leftSection={<IconCheck size={12} />}>
+            live
+          </Badge>
+        );
+      default:
+        return (
+          <Badge color="green" leftSection={<IconCheck size={12} />}>
+            approved
+          </Badge>
+        );
+    }
+  }
+  switch (status) {
+    case 'pending':
+      return (
+        <Badge color="blue" leftSection={<IconClock size={12} />}>
+          pending
+        </Badge>
+      );
+    case 'rejected':
+      return (
+        <Badge color="red" leftSection={<IconX size={12} />}>
+          rejected
+        </Badge>
+      );
+    case 'withdrawn':
+      return <Badge color="gray">withdrawn</Badge>;
+    default:
+      return <Badge color="gray">{status}</Badge>;
+  }
+}
+
+/**
+ * Reviewer notes are no longer rendered inline in the list. Instead an approved
+ * (approvalNotes) or rejected (rejectionReason) row gets a "See reviewer notes"
+ * button below its status badge that opens the notes in a modal. The button only
+ * renders when there are notes to show — a row with no feedback shows nothing.
+ */
+export function ReviewerNotesButton({
+  notes,
+  variant,
+}: {
+  notes: string;
+  variant: 'approved' | 'rejected';
+}) {
+  const [opened, { open, close }] = useDisclosure(false);
+  const isRejection = variant === 'rejected';
+  return (
+    <>
+      <Button
+        size="compact-xs"
+        variant="subtle"
+        color={isRejection ? 'red' : 'gray'}
+        leftSection={<IconMessage size={14} />}
+        onClick={open}
+      >
+        See reviewer notes
+      </Button>
+      <Modal
+        opened={opened}
+        onClose={close}
+        title={isRejection ? 'Reviewer feedback' : 'Reviewer notes'}
+        size="lg"
+      >
+        <Alert
+          color={isRejection ? 'red' : 'green'}
+          variant="light"
+          icon={isRejection ? <IconX size={16} /> : <IconCheck size={16} />}
+        >
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+            {notes}
+          </Text>
+        </Alert>
+      </Modal>
+    </>
+  );
+}
+
+/**
+ * Per-approved-app analytics affordance: a compact inline runs / unique-users
+ * (last 30d) stat plus an "Analytics" button that opens the existing
+ * AppAnalyticsPanel scoped to this app in a modal. Lives in AppAnalyticsInline
+ * so the data fetch is isolated (mockable in tests + only fires for approved
+ * rows with an app block).
+ */
+
+function StatusCell({ submission }: { submission: Submission }) {
+  const { status, rejectionReason, approvalNotes } = submission;
+  const notes =
+    status === 'rejected'
+      ? rejectionReason
+      : status === 'approved'
+      ? approvalNotes
+      : null;
+  const variant = status === 'rejected' ? 'rejected' : 'approved';
+  return (
+    <Stack gap={6} align="flex-start">
+      {statusBadge(submission)}
+      {notes && <ReviewerNotesButton notes={notes} variant={variant} />}
+    </Stack>
+  );
+}
+
+export function MySubmissionsList({
+  submissions,
+  onWithdraw,
+  withdrawing,
+}: {
+  submissions: Submission[];
+  onWithdraw: (id: string) => void;
+  withdrawing: boolean;
+}) {
+  return (
+    <Card withBorder p={0}>
+      <Table verticalSpacing="md" horizontalSpacing="md">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>App</Table.Th>
+            <Table.Th>Version</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Submitted</Table.Th>
+            <Table.Th>Reviewed</Table.Th>
+            <Table.Th>Installs</Table.Th>
+            <Table.Th>Usage (30d)</Table.Th>
+            <Table.Th />
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {submissions.map((s) => {
+            const mds = (s.manifestDiffSummary ?? {}) as ManifestDiffSummary;
+            const isFirst = mds.kind === 'first-version';
+            const isApproved = s.status === 'approved';
+            return (
+              <Fragment key={s.id}>
+                <Table.Tr>
+                  <Table.Td>
+                    <Group gap={6}>
+                      <Code>{s.slug}</Code>
+                      {isFirst && (
+                        <Badge color="violet" size="xs">
+                          first version
+                        </Badge>
+                      )}
+                    </Group>
+                  </Table.Td>
+                  <Table.Td>
+                    <Code>{s.version}</Code>
+                  </Table.Td>
+                  <Table.Td>
+                    <StatusCell submission={s} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="xs">{formatDate(s.submittedAt)}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    {s.reviewedAt ? (
+                      <Text size="xs">{formatDate(s.reviewedAt)}</Text>
+                    ) : (
+                      <Text size="xs" c="dimmed">
+                        —
+                      </Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <InstallCountCell
+                      modelInstalls={s.modelInstallCount}
+                      subscriptions={s.userSubscriptionCount}
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    {isApproved && s.appBlockId ? (
+                      <AppAnalyticsInline appBlockId={s.appBlockId} appLabel={s.slug} />
+                    ) : (
+                      <Text size="xs" c="dimmed">
+                        —
+                      </Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <SubmissionActions
+                      submission={s}
+                      isFirstVersion={isFirst}
+                      onWithdraw={() => onWithdraw(s.id)}
+                      busy={withdrawing}
+                    />
+                  </Table.Td>
+                </Table.Tr>
+                {s.status === 'approved' && s.deployState === 'failed' && (
+                  <Table.Tr>
+                    <Table.Td colSpan={8} p={0}>
+                      <Alert
+                        color="red"
+                        variant="light"
+                        radius={0}
+                        icon={<IconAlertTriangle size={16} />}
+                        title="Build / deploy failed"
+                      >
+                        <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                          {s.deployDetail ??
+                            'The build or deploy failed. Fix the issue and resubmit a new version.'}
+                        </Text>
+                      </Alert>
+                    </Table.Td>
+                  </Table.Tr>
+                )}
+                {/* Authoring updates: the CLI is the recommended path; git is a
+                    collapsed advanced footnote. Only approved rows with an app
+                    block (FK set on approve) can author updates. */}
+                {s.status === 'approved' && s.appBlockId && (
+                  <Table.Tr>
+                    <Table.Td colSpan={8}>
+                      <AuthorAffordance appBlockId={s.appBlockId} />
+                    </Table.Td>
+                  </Table.Tr>
+                )}
+              </Fragment>
+            );
+          })}
+        </Table.Tbody>
+      </Table>
+    </Card>
+  );
+}
+
+/**
+ * Authoring guidance for an approved app. Leads with the Civitai CLI (the
+ * recommended `author + submit` path); the raw git clone-URL flow is demoted to
+ * a collapsed "Advanced: author via git" footnote so it isn't a confusing
+ * primary option. The git provisioning side-effect (getMyAppRepo) still only
+ * fires when the footnote is expanded AND the user clicks within AuthorViaGit.
+ */
+export function AuthorAffordance({ appBlockId }: { appBlockId: string }) {
+  const [showGit, setShowGit] = useState(false);
+  return (
+    <Stack gap="xs">
+      <Group gap={6}>
+        <IconTerminal2 size={16} />
+        <Text size="sm">
+          Author and submit updates with the{' '}
+          <Anchor href={CIVITAI_CLI_URL} target="_blank" rel="noopener noreferrer">
+            <Code>civitai</Code> CLI
+          </Anchor>
+          . Install it, then run <Code>civitai app submit</Code> to publish a new
+          version for review.
+        </Text>
+      </Group>
+      <Group>
+        <Button
+          size="compact-xs"
+          variant="subtle"
+          color="gray"
+          leftSection={
+            showGit ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />
+          }
+          onClick={() => setShowGit((v) => !v)}
+        >
+          <Group gap={4}>
+            <IconBrandGit size={14} />
+            <Text size="xs">Advanced: author via git</Text>
+          </Group>
+        </Button>
+      </Group>
+      {showGit && <AuthorViaGit appBlockId={appBlockId} />}
+    </Stack>
+  );
+}
+
+function SubmissionActions({
+  submission,
+  isFirstVersion,
+  onWithdraw,
+  busy,
+}: {
+  submission: Submission;
+  isFirstVersion: boolean;
+  onWithdraw: () => void;
+  busy: boolean;
+}) {
+  if (submission.status === 'pending') {
+    return (
+      <Button
+        size="xs"
+        variant="default"
+        color="red"
+        onClick={onWithdraw}
+        disabled={busy}
+        loading={busy}
+      >
+        Withdraw
+      </Button>
+    );
+  }
+  if (submission.status === 'approved') {
+    const live = submission.deployState === 'live' || submission.deployState == null;
+    if (!live && isFirstVersion) {
+      return (
+        <Text size="xs" c="dimmed">
+          —
+        </Text>
+      );
+    }
+    return (
+      <Button
+        size="xs"
+        variant="default"
+        component="a"
+        href={`https://${submission.slug}.civit.ai/`}
+        target="_blank"
+        rel="noopener"
+        rightSection={<IconExternalLink size={12} />}
+      >
+        Open live
+      </Button>
+    );
+  }
+  if (submission.status === 'rejected') {
+    return (
+      <Button
+        size="xs"
+        component={Link}
+        href="/apps/submit"
+        rightSection={<IconArrowRight size={12} />}
+      >
+        Resubmit
+      </Button>
+    );
+  }
+  return null;
+}
+
+/**
+ * Install + subscription count for an approved submission.
+ */
+function InstallCountCell({
+  modelInstalls,
+  subscriptions,
+}: {
+  modelInstalls: number | null;
+  subscriptions: number | null;
+}) {
+  if (modelInstalls == null && subscriptions == null) {
+    return (
+      <Text size="xs" c="dimmed">
+        —
+      </Text>
+    );
+  }
+  return (
+    <Group gap={6}>
+      <Badge
+        variant="light"
+        color="blue"
+        size="sm"
+        leftSection={<IconBox size={12} />}
+        title="Pinned subscriptions — per-model placements"
+      >
+        {modelInstalls ?? 0}
+      </Badge>
+      <Badge
+        variant="light"
+        color="grape"
+        size="sm"
+        leftSection={<IconUsers size={12} />}
+        title="BlockUserSubscription rows — publisher + viewer scopes"
+      >
+        {subscriptions ?? 0}
+      </Badge>
+    </Group>
+  );
+}

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -1,33 +1,11 @@
-import {
-  Alert,
-  Badge,
-  Button,
-  Card,
-  Code,
-  Container,
-  Group,
-  Stack,
-  Table,
-  Text,
-  Title,
-} from '@mantine/core';
-import {
-  IconAlertTriangle,
-  IconArrowRight,
-  IconBox,
-  IconCheck,
-  IconClock,
-  IconExternalLink,
-  IconUsers,
-  IconX,
-} from '@tabler/icons-react';
+import { Alert, Button, Card, Container, Group, Stack, Text, Title } from '@mantine/core';
+import { IconAlertTriangle, IconArrowRight } from '@tabler/icons-react';
 import Link from 'next/link';
-import { Fragment } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
-import { AuthorViaGit } from '~/components/Apps/AuthorViaGit';
-import { deployRefetchInterval, isStaleDeploy } from '~/components/Apps/deploy-status';
-import { Meta } from '~/components/Meta/Meta';
 import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { deployRefetchInterval } from '~/components/Apps/deploy-status';
+import { MySubmissionsList, type Submission } from '~/components/Apps/MySubmissionsList';
+import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -39,12 +17,13 @@ import { trpc } from '~/utils/trpc';
  * /apps/my-submissions — dev's view of their publish-request history.
  *
  * Lists every request submitted by the viewer, newest first. For pending
- * requests there's a Withdraw button. For rejected requests the reason
- * is shown inline so the dev sees mod feedback without a round-trip.
- * For approved requests a link to the live URL is shown.
+ * requests there's a Withdraw button. Reviewer notes (approval notes /
+ * rejection reason) open in a modal from a "See reviewer notes" button below
+ * the status badge. Approved apps surface a compact runs/users (30d) stat and
+ * an Analytics modal, plus a CLI-first authoring affordance.
  *
- * v0 gate: requires `isModerator` (only mods can submit at v0; v1 opens
- * to external developers behind W11/W5).
+ * v0 gate: requires `isAppDeveloper` (mods at v0; v1 opens to external
+ * developers behind W11/W5).
  */
 export const getServerSideProps = createServerSideProps({
   useSession: true,
@@ -65,140 +44,12 @@ export const getServerSideProps = createServerSideProps({
   },
 });
 
-type FileSummary = {
-  files?: Array<{ path: string; sha256: string; sizeBytes: number }>;
-  added?: string[];
-  removed?: string[];
-  changed?: string[];
-};
-
-type ManifestDiffSummary =
-  | { kind: 'first-version'; fields: string[] }
-  | {
-      kind: 'update';
-      added: string[];
-      removed: string[];
-      changed: Array<{ field: string; from: unknown; to: unknown }>;
-    };
-
-type Submission = {
-  id: string;
-  appBlockId: string | null;
-  slug: string;
-  version: string;
-  status: string;
-  submittedAt: string | Date;
-  reviewedAt: string | Date | null;
-  rejectionReason: string | null;
-  approvalNotes: string | null;
-  /** Phase 2 build/deploy lifecycle for an approved request:
-   * 'building' → 'deploying' → 'live', or 'failed'. Null on non-approved rows
-   * and on approved rows from before this feature shipped. */
-  deployState: 'building' | 'deploying' | 'live' | 'failed' | null;
-  deployDetail: string | null;
-  deployUpdatedAt: string | Date | null;
-  fileSummary: unknown;
-  manifestDiffSummary: unknown;
-  /** Total pinned subscriptions referencing this app block. (Was the
-   * ModelBlockInstall count before the 2026-05-30 kill_per_model_installs
-   * migration absorbed per-model installs into block_user_subscriptions.)
-   * Null when the publish request has no app block yet (pending first-
-   * version, withdrawn first-version). */
-  modelInstallCount: number | null;
-  /** Total BlockUserSubscription rows. Same null semantics as above. */
-  userSubscriptionCount: number | null;
-};
-
-function formatDate(d: string | Date): string {
-  const date = typeof d === 'string' ? new Date(d) : d;
-  return date.toLocaleString();
-}
-
-function statusBadge(
-  submission: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt'>
-) {
-  const { status } = submission;
-  // For an approved request, show the real build/deploy lifecycle rather than a
-  // flat "approved" — the dev cares whether their code is actually live.
-  if (status === 'approved') {
-    // A stuck in-flight row (watcher lost to a pod restart) shows a muted
-    // "stalled" badge instead of spinning on building/deploying forever.
-    if (isStaleDeploy(submission)) {
-      return (
-        <Badge
-          color="orange"
-          leftSection={<IconAlertTriangle size={12} />}
-          title="No progress for a while — the deploy may be stuck. Resubmit a new version if it doesn't go live."
-        >
-          {submission.deployState} (stalled)
-        </Badge>
-      );
-    }
-    switch (submission.deployState) {
-      case 'building':
-        return (
-          <Badge color="blue" leftSection={<IconClock size={12} />}>
-            building
-          </Badge>
-        );
-      case 'deploying':
-        return (
-          <Badge color="indigo" leftSection={<IconClock size={12} />}>
-            deploying
-          </Badge>
-        );
-      case 'failed':
-        return (
-          <Badge color="red" leftSection={<IconX size={12} />}>
-            deploy failed
-          </Badge>
-        );
-      case 'live':
-        return (
-          <Badge color="green" leftSection={<IconCheck size={12} />}>
-            live
-          </Badge>
-        );
-      default:
-        // Legacy/pre-Phase-2 approved rows (no deploy_state captured).
-        return (
-          <Badge color="green" leftSection={<IconCheck size={12} />}>
-            approved
-          </Badge>
-        );
-    }
-  }
-  switch (status) {
-    case 'pending':
-      return (
-        <Badge color="blue" leftSection={<IconClock size={12} />}>
-          pending
-        </Badge>
-      );
-    case 'rejected':
-      return (
-        <Badge color="red" leftSection={<IconX size={12} />}>
-          rejected
-        </Badge>
-      );
-    case 'withdrawn':
-      return <Badge color="gray">withdrawn</Badge>;
-    default:
-      return <Badge color="gray">{status}</Badge>;
-  }
-}
-
 export default function MySubmissionsPage() {
   const features = useFeatureFlags();
   const submissionsQuery = trpc.blocks.listMyPublishRequests.useQuery(undefined, {
     enabled: !!features?.appBlocks,
     // Poll while an approved submission is building/deploying so the badge
-    // live-updates. Once a row looks stalled (watcher likely lost to a pod
-    // restart) we BACK OFF to 30s rather than stop — so a slow build that
-    // finishes past the staleness threshold still self-heals to live/failed
-    // without a reload (the global query config is staleTime:Infinity +
-    // refetchOnWindowFocus:false, so stopping entirely would never recover).
-    // Stop only when nothing is in flight.
+    // live-updates; back off / stop once nothing is in flight.
     refetchInterval: (query) => deployRefetchInterval((query.state.data ?? []) as Submission[]),
   });
 
@@ -229,8 +80,8 @@ export default function MySubmissionsPage() {
             <Stack gap={4}>
               <Title order={2}>My submissions</Title>
               <Text c="dimmed" size="sm">
-                Status of every app submission you've made. Rejections show the
-                reviewer's feedback inline; pending submissions can be withdrawn.
+                Status of every app submission you've made. Open a row's reviewer
+                notes to see mod feedback; pending submissions can be withdrawn.
               </Text>
             </Stack>
             <Button
@@ -260,275 +111,14 @@ export default function MySubmissionsPage() {
           )}
 
           {submissions.length > 0 && (
-            <Card withBorder p={0}>
-              <Table verticalSpacing="md" horizontalSpacing="md">
-                <Table.Thead>
-                  <Table.Tr>
-                    <Table.Th>App</Table.Th>
-                    <Table.Th>Version</Table.Th>
-                    <Table.Th>Status</Table.Th>
-                    <Table.Th>Submitted</Table.Th>
-                    <Table.Th>Reviewed</Table.Th>
-                    <Table.Th>Changes</Table.Th>
-                    <Table.Th>Installs</Table.Th>
-                    <Table.Th />
-                  </Table.Tr>
-                </Table.Thead>
-                <Table.Tbody>
-                  {submissions.map((s) => {
-                    const fs = (s.fileSummary ?? {}) as FileSummary;
-                    const mds = (s.manifestDiffSummary ?? {}) as ManifestDiffSummary;
-                    const isFirst = mds.kind === 'first-version';
-                    return (
-                      <Fragment key={s.id}>
-                        <Table.Tr>
-                          <Table.Td>
-                            <Group gap={6}>
-                              <Code>{s.slug}</Code>
-                              {isFirst && (
-                                <Badge color="violet" size="xs">
-                                  first version
-                                </Badge>
-                              )}
-                            </Group>
-                          </Table.Td>
-                          <Table.Td>
-                            <Code>{s.version}</Code>
-                          </Table.Td>
-                          <Table.Td>{statusBadge(s)}</Table.Td>
-                          <Table.Td>
-                            <Text size="xs">{formatDate(s.submittedAt)}</Text>
-                          </Table.Td>
-                          <Table.Td>
-                            {s.reviewedAt ? (
-                              <Text size="xs">{formatDate(s.reviewedAt)}</Text>
-                            ) : (
-                              <Text size="xs" c="dimmed">
-                                —
-                              </Text>
-                            )}
-                          </Table.Td>
-                          <Table.Td>
-                            <Group gap={6}>
-                              {(fs.added?.length ?? 0) > 0 && (
-                                <Badge color="green" size="xs">
-                                  +{fs.added?.length}
-                                </Badge>
-                              )}
-                              {(fs.changed?.length ?? 0) > 0 && (
-                                <Badge color="yellow" size="xs">
-                                  ~{fs.changed?.length}
-                                </Badge>
-                              )}
-                              {(fs.removed?.length ?? 0) > 0 && (
-                                <Badge color="red" size="xs">
-                                  −{fs.removed?.length}
-                                </Badge>
-                              )}
-                            </Group>
-                          </Table.Td>
-                          <Table.Td>
-                            <InstallCountCell
-                              modelInstalls={s.modelInstallCount}
-                              subscriptions={s.userSubscriptionCount}
-                            />
-                          </Table.Td>
-                          <Table.Td>
-                            <SubmissionActions
-                              submission={s}
-                              isFirstVersion={isFirst}
-                              onWithdraw={() =>
-                                withdrawMutation.mutate({ publishRequestId: s.id })
-                              }
-                              busy={withdrawMutation.isPending}
-                            />
-                          </Table.Td>
-                        </Table.Tr>
-                        {s.status === 'rejected' && s.rejectionReason && (
-                          <Table.Tr>
-                            <Table.Td colSpan={8} p={0}>
-                              <Alert
-                                color="red"
-                                variant="light"
-                                radius={0}
-                                icon={<IconX size={16} />}
-                                title="Reviewer feedback"
-                              >
-                                <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                                  {s.rejectionReason}
-                                </Text>
-                              </Alert>
-                            </Table.Td>
-                          </Table.Tr>
-                        )}
-                        {s.status === 'approved' && s.approvalNotes && (
-                          <Table.Tr>
-                            <Table.Td colSpan={8} p={0}>
-                              <Alert
-                                color="green"
-                                variant="light"
-                                radius={0}
-                                icon={<IconCheck size={16} />}
-                                title="Reviewer notes"
-                              >
-                                <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                                  {s.approvalNotes}
-                                </Text>
-                              </Alert>
-                            </Table.Td>
-                          </Table.Tr>
-                        )}
-                        {s.status === 'approved' && s.deployState === 'failed' && (
-                          <Table.Tr>
-                            <Table.Td colSpan={8} p={0}>
-                              <Alert
-                                color="red"
-                                variant="light"
-                                radius={0}
-                                icon={<IconAlertTriangle size={16} />}
-                                title="Build / deploy failed"
-                              >
-                                <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                                  {s.deployDetail ??
-                                    'The build or deploy failed. Fix the issue and resubmit a new version.'}
-                                </Text>
-                              </Alert>
-                            </Table.Td>
-                          </Table.Tr>
-                        )}
-                        {/* Phase 3: git-push self-service. Approved rows with an
-                            app block (FK set on approve) can author updates via
-                            git. The server still owner-gates getMyAppRepo, and
-                            the panel only fetches the token on user expand. */}
-                        {s.status === 'approved' && s.appBlockId && (
-                          <Table.Tr>
-                            <Table.Td colSpan={8}>
-                              <AuthorViaGit appBlockId={s.appBlockId} />
-                            </Table.Td>
-                          </Table.Tr>
-                        )}
-                      </Fragment>
-                    );
-                  })}
-                </Table.Tbody>
-              </Table>
-            </Card>
+            <MySubmissionsList
+              submissions={submissions}
+              onWithdraw={(id) => withdrawMutation.mutate({ publishRequestId: id })}
+              withdrawing={withdrawMutation.isPending}
+            />
           )}
         </Stack>
       </Container>
     </>
-  );
-}
-
-function SubmissionActions({
-  submission,
-  isFirstVersion,
-  onWithdraw,
-  busy,
-}: {
-  submission: Submission;
-  isFirstVersion: boolean;
-  onWithdraw: () => void;
-  busy: boolean;
-}) {
-  if (submission.status === 'pending') {
-    return (
-      <Button
-        size="xs"
-        variant="default"
-        color="red"
-        onClick={onWithdraw}
-        disabled={busy}
-        loading={busy}
-      >
-        Withdraw
-      </Button>
-    );
-  }
-  if (submission.status === 'approved') {
-    // "Open live" points at https://<slug>.civit.ai/. Only meaningful once
-    // something is actually serving: hide it for a FIRST version that hasn't
-    // gone live yet (it would 404 / contradict a "building"/"deploy failed"
-    // badge). For a subsequent version still building/failed, the previously
-    // approved version is still live, so keep the link. null deployState =
-    // legacy approved row → assume live.
-    const live = submission.deployState === 'live' || submission.deployState == null;
-    if (!live && isFirstVersion) {
-      return (
-        <Text size="xs" c="dimmed">
-          —
-        </Text>
-      );
-    }
-    return (
-      <Button
-        size="xs"
-        variant="default"
-        component="a"
-        href={`https://${submission.slug}.civit.ai/`}
-        target="_blank"
-        rel="noopener"
-        rightSection={<IconExternalLink size={12} />}
-      >
-        Open live
-      </Button>
-    );
-  }
-  if (submission.status === 'rejected') {
-    return (
-      <Button
-        size="xs"
-        component={Link}
-        href="/apps/submit"
-        rightSection={<IconArrowRight size={12} />}
-      >
-        Resubmit
-      </Button>
-    );
-  }
-  return null;
-}
-
-/**
- * Install + subscription count for an approved submission. Renders two
- * compact pills: model installs (per-model placements) and user
- * subscriptions (publisher/viewer scope rows). Null means there's no
- * AppBlock row yet (pending/withdrawn first-version) so we show a dash.
- */
-function InstallCountCell({
-  modelInstalls,
-  subscriptions,
-}: {
-  modelInstalls: number | null;
-  subscriptions: number | null;
-}) {
-  if (modelInstalls == null && subscriptions == null) {
-    return (
-      <Text size="xs" c="dimmed">
-        —
-      </Text>
-    );
-  }
-  return (
-    <Group gap={6}>
-      <Badge
-        variant="light"
-        color="blue"
-        size="sm"
-        leftSection={<IconBox size={12} />}
-        title="Pinned subscriptions — per-model placements"
-      >
-        {modelInstalls ?? 0}
-      </Badge>
-      <Badge
-        variant="light"
-        color="grape"
-        size="sm"
-        leftSection={<IconUsers size={12} />}
-        title="BlockUserSubscription rows — publisher + viewer scopes"
-      >
-        {subscriptions ?? 0}
-      </Badge>
-    </Group>
   );
 }


### PR DESCRIPTION
## What

UX-pass cleanup of `/apps/my-submissions` (App Blocks developer view), UI-only.

- **Drop the "Changes" column** — the per-file +/~/- diff badges weren't useful.
- **CLI-first authoring.** The raw "author via git" clone-URL flow is demoted to a collapsed **"Advanced: author via git"** footnote. The primary affordance now points devs at the **Civitai CLI** (https://github.com/civitai/cli): "author and submit updates with the `civitai` CLI … run `civitai app submit`". The git provisioning side-effect (`getMyAppRepo`) still only fires when the footnote is expanded *and* the user clicks within `AuthorViaGit`.
- **Reviewer notes → modal.** Approval notes / rejection reason no longer render inline. A **"See reviewer notes"** button below the status badge (rendered **only when notes exist**) opens them in a modal.
- **Surface analytics.** Each **approved** row shows a compact **runs / users (last 30d)** inline stat + an **"Analytics"** button that opens the **existing** `AppAnalyticsPanel` (now optionally scoped to one app) in a modal. Reuses `blocks.getMyAppAnalytics` (the same query the `/apps/revenue` dashboard runs) with a 30-day `from`; no new analytics surface.

The page list was extracted into `MySubmissionsList` + `AppAnalyticsInline` so the behaviour is component-testable while the page keeps `getServerSideProps`. `AppAnalyticsPanel` gains an optional `scopedAppBlockId` prop (omitted = existing all-apps picker behaviour for the revenue dashboard).

### Known caveat (informational)
The runs / active-users figures **undercount anonymous / no-scope runs** until the render-event instrumentation (#2695) deploys. Surfaced in the inline-stat tooltip and the panel's existing engagement note.

## Tests

New `src/components/Apps/MySubmissionsList.browser.test.tsx` (7 tests, all passing):
- "Changes" column header + its file-diff badges NOT rendered.
- Reviewer notes NOT inline; "See reviewer notes" present only when notes exist, absent when none (both approval-notes and rejection-reason variants), and clicking opens the modal with the notes.
- Approved row shows the inline 30d stat + "Analytics" button → opens `AppAnalyticsPanel` scoped to that `appBlockId`; a pending row shows neither.
- The Civitai CLI link replaces the git-authoring copy (`href === https://github.com/civitai/cli`) and git is collapsed behind "Advanced".

Mutation sanity: breaking the CLI URL fails exactly the CLI-link test.

## Verification

- Scoped typecheck on the four touched files: zero new errors (remaining `tsc-files` output is global-ambient noise from its minimal generated config, none in the touched files).
- `vitest run --project component MySubmissionsList.browser.test.tsx`: **7 passed**.
- Not browser-verified against the live click-path (dark, mod-gated page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
