### PR TITLE
feat(app-blocks): card cleanup + View details modal

### DIFF
--- a/src/components/Apps/AppBlockCard.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.browser.test.tsx
@@ -5,18 +5,23 @@ import { renderWithProviders } from '../../../test/component-setup';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
 
 /**
- * App Blocks marketplace CARD — component tests for the action-CTA gate.
+ * App Blocks marketplace CARD — component tests for the action-CTA gate + the
+ * 2026-06 UX-pass card cleanup.
  *
  * Load-bearing behaviour:
+ *  - "View details" is the UNIVERSAL details affordance: it renders on EVERY
+ *    card (page app, model app, flag on/off) and opens the details modal. This
+ *    is what now guarantees the never-empty-card INVARIANT (audit HIGH) — it
+ *    SUPERSEDES the #2747 page-link "View" fallback (the old tests that asserted
+ *    a "View" detail-page link now assert "View details" instead — the coverage
+ *    is preserved, retargeted to the new affordance, NOT deleted).
  *  - The "Install"/"Manage" CTA is shown ONLY for apps that install into a
  *    model/in-context slot. A PAGE app (target slot `app.page`, installModel
  *    `'none'`) is stateless — no install row, slot install path server-gated
  *    dark (#2622) — so it never shows Install/Manage.
- *  - INVARIANT (audit HIGH): every card renders ≥1 affordance. A page app whose
- *    live "Open app" run isn't available (no page, or the viewer's
- *    `appBlocksPages` flag is off → `canOpenPage` false) falls back to a "View"
- *    link to the always-reachable detail page — it MUST NOT be an actionless
- *    card.
+ *  - Card cleanup: the install count is HIDDEN, the review indicator is hidden
+ *    when reviewCount=0 (shown when >0), the mod-assigned category (+ icon) is
+ *    shown, and the scopes were MOVED off the card face into the modal.
  *
  * The install predicate is the shared `hasInstallSlot(manifest)` (slot-registry,
  * the single source of truth shared with the detail page) — it scans ALL targets
@@ -29,6 +34,20 @@ import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema'
 // onClick runs directly — keeps the card test network-free.
 vi.mock('~/components/LoginRedirect/LoginRedirect', () => ({
   LoginRedirect: ({ children }: { children: React.ReactElement }) => children,
+}));
+
+// AppDetailsModal pulls in tRPC queries (getAppDetail / listMySubscriptions) +
+// feature-flag/current-user hooks — its internals are covered by its OWN test
+// (AppDetailsModal.browser.test.tsx). Stub it to a lightweight, network-free
+// component that just reflects `opened` so the CARD test can assert the
+// "View details" button opens the modal without any network. Renders a probe
+// element ONLY when open.
+const detailsModalSpy = vi.fn();
+vi.mock('~/components/Apps/AppDetailsModal', () => ({
+  AppDetailsModal: ({ opened, block }: { opened: boolean; block: { id: string } }) => {
+    detailsModalSpy({ opened, blockId: block.id });
+    return opened ? <div data-testid="details-modal">details for {block.id}</div> : null;
+  },
 }));
 
 // Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
@@ -78,6 +97,7 @@ const onOpen = vi.fn();
 
 beforeEach(() => {
   onOpen.mockClear();
+  detailsModalSpy.mockClear();
 });
 
 /** The card's action group lives in the bottom Group; assert ≥1 actionable
@@ -86,20 +106,25 @@ function expectAtLeastOneAffordance() {
   const links = page.getByRole('link').elements();
   const buttons = page.getByRole('button').elements();
   // The title + description are also links (to the detail page); the action
-  // group adds Open app / View / Install on top. The invariant we care about is
-  // a CTA in the action row — every branch below asserts the SPECIFIC expected
-  // CTA, so this is the coarse backstop that SOMETHING actionable rendered.
+  // group adds "View details" (universal) / Open app / Install on top. The
+  // invariant we care about is a CTA in the action row — every branch below
+  // asserts the SPECIFIC expected CTA, so this is the coarse backstop that
+  // SOMETHING actionable rendered.
   expect(links.length + buttons.length).toBeGreaterThan(0);
 }
 
 describe('AppBlockCard action CTA gate', () => {
-  test('page app + canOpenPage=false (pages flag off) → "View" fallback, NOT zero buttons [HIGH regression]', async () => {
+  test('page app + canOpenPage=false (pages flag off) → "View details" present, NOT actionless [HIGH regression, #2747 retargeted]', async () => {
     renderWithProviders(
       <AppBlockCard block={pageBlock()} alreadySubscribed={false} onOpen={onOpen} canOpenPage={false} />
     );
 
-    // The live "Open app" run is unavailable (flag off) → fall back to "View".
-    await expect.element(page.getByRole('link', { name: /^view$/i })).toBeInTheDocument();
+    // The live "Open app" run is unavailable (flag off); the never-empty-card
+    // invariant is now carried by the universal "View details" button (was the
+    // #2747 page-link "View" fallback).
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // The old page-link "View" fallback is GONE (replaced by the modal button).
+    expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
     // "Open app" did NOT render (no flag), and Install is forbidden for a page app.
     expect(page.getByRole('link', { name: /open app/i }).query()).toBeNull();
     expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
@@ -108,7 +133,7 @@ describe('AppBlockCard action CTA gate', () => {
     expectAtLeastOneAffordance();
   });
 
-  test('page app + manifest.hasPage=false → still ≥1 affordance ("View")', async () => {
+  test('page app + manifest.hasPage=false → still ≥1 affordance ("View details")', async () => {
     renderWithProviders(
       // hasPage false but canOpenPage true → "Open app" still can't render (no page).
       <AppBlockCard
@@ -119,19 +144,21 @@ describe('AppBlockCard action CTA gate', () => {
       />
     );
 
-    await expect.element(page.getByRole('link', { name: /^view$/i })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
     expect(page.getByRole('link', { name: /open app/i }).query()).toBeNull();
     expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
     expectAtLeastOneAffordance();
   });
 
-  test('page app + canOpenPage=true → "Open app" shows, "View" NOT duplicated', async () => {
+  test('page app + canOpenPage=true → "Open app" shows ALONGSIDE the universal "View details"', async () => {
     renderWithProviders(
       <AppBlockCard block={pageBlock()} alreadySubscribed={false} onOpen={onOpen} canOpenPage />
     );
 
     await expect.element(page.getByRole('link', { name: /open app/i })).toBeInTheDocument();
-    // The live run IS available → no redundant "View" fallback.
+    // "View details" is universal — present even when "Open app" renders.
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // No legacy page-link "View".
     expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
     // Still no Install/Manage for a page app.
     expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
@@ -149,7 +176,7 @@ describe('AppBlockCard action CTA gate', () => {
     expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
   });
 
-  test('model-slot app renders "Install" and fires onOpen (no regression)', async () => {
+  test('model-slot app renders "Install" + the universal "View details" and fires onOpen', async () => {
     renderWithProviders(
       <AppBlockCard
         block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }] })}
@@ -160,7 +187,9 @@ describe('AppBlockCard action CTA gate', () => {
 
     const install = page.getByRole('button', { name: /^install$/i });
     await expect.element(install).toBeInTheDocument();
-    // No page → no "Open app", and no "View" fallback (Install IS the action).
+    // "View details" is universal — present even for a model-slot app.
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // No page → no "Open app", and no legacy page-link "View".
     expect(page.getByRole('link', { name: /open app/i }).query()).toBeNull();
     expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
 
@@ -211,7 +240,7 @@ describe('AppBlockCard action CTA gate', () => {
     expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
   });
 
-  test('empty-string slotId at index [0] → treated as a page app (no Install), "View" fallback', async () => {
+  test('empty-string slotId at index [0] → treated as a page app (no Install), "View details" fallback', async () => {
     // Parity with the detail page: a falsy slotId is skipped (filter(Boolean)),
     // so [''] yields NO model install slot → page-app branch. The card and the
     // detail page agree on this input (both via the shared hasInstallSlot).
@@ -225,8 +254,146 @@ describe('AppBlockCard action CTA gate', () => {
     );
 
     expect(page.getByRole('button', { name: /^install$/i }).query()).toBeNull();
-    // No usable page either → the never-empty-card invariant gives us "View".
-    await expect.element(page.getByRole('link', { name: /^view$/i })).toBeInTheDocument();
+    // No usable page either → the never-empty-card invariant gives us "View details".
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    expect(page.getByRole('link', { name: /^view$/i }).query()).toBeNull();
     expectAtLeastOneAffordance();
+  });
+});
+
+describe('AppBlockCard — View details modal opens', () => {
+  test('"View details" button is present on a model app and opens the modal', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // Closed initially — the modal probe is not in the DOM.
+    expect(page.getByTestId('details-modal').query()).toBeNull();
+
+    const viewDetails = page.getByRole('button', { name: /view details/i });
+    await expect.element(viewDetails).toBeInTheDocument();
+    await viewDetails.click();
+
+    // Clicking opens the modal (opened=true → probe renders).
+    await expect.element(page.getByTestId('details-modal')).toBeInTheDocument();
+    // The modal received this app's id.
+    expect(detailsModalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ opened: true, blockId: 'app-1' })
+    );
+  });
+
+  test('"View details" button is present on a PAGE app and opens the modal', async () => {
+    renderWithProviders(
+      <AppBlockCard block={pageBlock()} alreadySubscribed={false} onOpen={onOpen} canOpenPage={false} />
+    );
+
+    const viewDetails = page.getByRole('button', { name: /view details/i });
+    await expect.element(viewDetails).toBeInTheDocument();
+    await viewDetails.click();
+    await expect.element(page.getByTestId('details-modal')).toBeInTheDocument();
+  });
+});
+
+describe('AppBlockCard — 2026-06 card cleanup', () => {
+  test('install count is NOT rendered (hidden until a real user base)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({}, { installCount: 1234 })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // The old install-count copy ("N installs", lowercase) is gone, and the
+    // formatted count itself ("1,234") renders nowhere. (Note: the "Install"
+    // BUTTON is a separate, intentional CTA — we match the lowercase count copy,
+    // not the capitalized button label.)
+    expect(page.getByText(/\d[\d,]*\s+installs?/i).query()).toBeNull();
+    expect(page.getByText('1,234', { exact: false }).query()).toBeNull();
+  });
+
+  test('review indicator HIDDEN when reviewCount=0 (no "No reviews" affordance)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({}, { reviewCount: 0, avgRating: null })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // No "No reviews" text, and no rating affordance for a 0-review app.
+    expect(page.getByText(/no reviews/i).query()).toBeNull();
+  });
+
+  test('review indicator SHOWN when reviewCount>0 (avg + count)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({}, { reviewCount: 12, avgRating: 4.5 })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // avg "4.5" and count "(12)" render.
+    await expect.element(page.getByText('4.5', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('(12)', { exact: false })).toBeInTheDocument();
+  });
+
+  test('category (+ icon) rendered when a category is set', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({}, { category: 'generation' })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // The category label chip shows.
+    await expect.element(page.getByText('Generation', { exact: true })).toBeInTheDocument();
+    // The category badge carries an icon (the leftSection svg). The "grape"
+    // category badge is the one with the label text; assert an svg sits in it.
+    const labelEl = page.getByText('Generation', { exact: true }).element();
+    const badge = labelEl.closest('.mantine-Badge-root');
+    expect(badge).not.toBeNull();
+    expect(badge!.querySelector('svg')).not.toBeNull();
+  });
+
+  test('no category → no category chip rendered', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({}, { category: null })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // None of the category labels render.
+    expect(page.getByText('Generation', { exact: true }).query()).toBeNull();
+    expect(page.getByText('Utility', { exact: true }).query()).toBeNull();
+  });
+
+  test('scopes are NOT rendered on the card face (moved into the modal)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock(
+          {},
+          { scopesSummary: ['user:read:self', 'ai:write:budgeted'] }
+        )}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // The scope ids must NOT appear on the card face.
+    expect(page.getByText('user:read:self', { exact: false }).query()).toBeNull();
+    expect(page.getByText('ai:write:budgeted', { exact: false }).query()).toBeNull();
   });
 });

--- a/src/components/Apps/AppBlockCard.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.browser.test.tsx
@@ -296,6 +296,37 @@ describe('AppBlockCard — View details modal opens', () => {
     await viewDetails.click();
     await expect.element(page.getByTestId('details-modal')).toBeInTheDocument();
   });
+
+  // ── L3 (audit): the modal SUBTREE is not even mounted while closed ──────────
+  // Previously <AppDetailsModal> was mounted in every card unconditionally
+  // (N idle modal instances + their hook subtrees across the grid). It's now
+  // gated `{detailsOpen && <AppDetailsModal .../>}`, so the component does not
+  // mount — and crucially does not run its tRPC-query hooks — until opened.
+  test('modal subtree is NOT mounted while closed (component never invoked), mounts on open', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // The "View details" BUTTON is unconditional (never-empty-card invariant)…
+    const viewDetails = page.getByRole('button', { name: /view details/i });
+    await expect.element(viewDetails).toBeInTheDocument();
+    // …but the modal SUBTREE is gated: the component was never even rendered
+    // while closed (not "rendered but returned null"). This is the L3 probe —
+    // the spy fires inside AppDetailsModal's render, so zero calls ⇒ not mounted.
+    expect(detailsModalSpy).not.toHaveBeenCalled();
+    expect(page.getByTestId('details-modal').query()).toBeNull();
+
+    // Opening mounts the subtree.
+    await viewDetails.click();
+    await expect.element(page.getByTestId('details-modal')).toBeInTheDocument();
+    expect(detailsModalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ opened: true, blockId: 'app-1' })
+    );
+  });
 });
 
 describe('AppBlockCard — 2026-06 card cleanup', () => {

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -1,18 +1,26 @@
-import { Anchor, Badge, Button, Card, Group, Stack, Text, Title, Tooltip } from '@mantine/core';
+import { Anchor, Badge, Button, Card, Group, Stack, Text, Title } from '@mantine/core';
 import {
-  IconBolt,
+  IconBraces,
+  IconChartBar,
+  IconCompass,
+  IconDeviceGamepad2,
   IconPlugConnected,
   IconSettings,
-  IconShieldLock,
+  IconShieldHalf,
+  IconSparkles,
   IconStarFilled,
+  IconTag,
+  IconTool,
 } from '@tabler/icons-react';
+import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useState } from 'react';
+import { AppDetailsModal } from '~/components/Apps/AppDetailsModal';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
-import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
 import {
   isMarketplaceCategory,
   MARKETPLACE_CATEGORY_LABELS,
+  type MarketplaceCategory,
 } from '~/server/services/blocks/marketplace-categories.constants';
 import { hasInstallSlot } from '~/shared/constants/slot-registry';
 import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema';
@@ -65,10 +73,25 @@ function categoryLabel(category: string): string {
   return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
 }
 
-/** Human label for a scope id (the permission disclosure), falling back to the
- * raw id for an unknown scope so a new scope ships without breaking the card. */
-function scopeLabel(scope: string): string {
-  return SCOPE_DESCRIPTIONS[scope] ?? scope;
+/**
+ * Per-category icon. The category taxonomy is the structured free-text
+ * `app_blocks.category` column (the MARKETPLACE_CATEGORIES single-source const);
+ * this maps each known value to a Tabler icon. An unknown/legacy category (or
+ * NULL, handled by the caller) falls back to a generic tag icon so the chip
+ * never breaks on a newer category.
+ */
+const CATEGORY_ICONS: Record<MarketplaceCategory, Icon> = {
+  generation: IconSparkles,
+  games: IconDeviceGamepad2,
+  utility: IconTool,
+  discovery: IconCompass,
+  moderation: IconShieldHalf,
+  analytics: IconChartBar,
+  other: IconBraces,
+};
+
+function categoryIcon(category: string): Icon {
+  return isMarketplaceCategory(category) ? CATEGORY_ICONS[category] : IconTag;
 }
 
 export function AppBlockCard({
@@ -85,6 +108,7 @@ export function AppBlockCard({
     hasPage?: boolean;
   };
   const [busy] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const slot = manifest.targets?.[0]?.slotId;
   // Show Install ONLY for an app that installs into a model/in-context slot.
   // A page app (target slot `app.page`) is STATELESS — installModel `'none'` in
@@ -99,12 +123,15 @@ export function AppBlockCard({
   const showInstall = hasInstallSlot(manifest);
   // The live "Open app" run is only available for a real page app that the
   // viewer's `appBlocksPages` flag has unlocked (dark today / launch-flip
-  // window). When that run can't render AND there's no Install affordance, the
-  // card would otherwise have ZERO actions — guarantee ≥1 affordance by linking
-  // to the always-reachable detail page ("View"). The detail page itself always
-  // exposes "Open live", so this never strands the user.
+  // window).
   const canOpenApp = Boolean(manifest.hasPage && canOpenPage);
-  const showView = !showInstall && !canOpenApp;
+  // INVARIANT (never-empty card): "View details" is the UNIVERSAL details
+  // affordance — it is rendered on EVERY card (page app, model app, flag on or
+  // off), so the card can never be actionless. It supersedes the #2747
+  // page-link "View" fallback (a detail-page link shown only when no Install /
+  // Open app rendered): the modal covers that case for every card now, and the
+  // modal itself exposes "Open live"/the detail data, so we don't strand the
+  // user. "Open app" / Install remain the RUN/INSTALL affordances on top of it.
   return (
     <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
       <Stack gap="sm" h="100%">
@@ -132,13 +159,23 @@ export function AppBlockCard({
             <Badge variant="light" color="blue" size="sm">
               {slotLabel(slot)}
             </Badge>
-            {/* F-E E3: mod-assigned marketplace category. NULL until the E3
-                migration is applied + a mod sets one (dark today) → no chip. */}
-            {block.category && (
-              <Badge variant="light" color="grape" size="sm">
-                {categoryLabel(block.category)}
-              </Badge>
-            )}
+            {/* Mod-assigned marketplace category (+ its icon). NULL until a mod
+                sets one → no chip. The icon comes from CATEGORY_ICONS (generic
+                tag fallback for an unknown/legacy value). */}
+            {block.category &&
+              (() => {
+                const CategoryIcon = categoryIcon(block.category);
+                return (
+                  <Badge
+                    variant="light"
+                    color="grape"
+                    size="sm"
+                    leftSection={<CategoryIcon size={12} />}
+                  >
+                    {categoryLabel(block.category)}
+                  </Badge>
+                );
+              })()}
             {ownedEarningCents != null && ownedEarningCents > 0 && (
               <Badge variant="light" color="green" size="sm">
                 Earning ${(ownedEarningCents / 100).toFixed(2)}
@@ -153,44 +190,25 @@ export function AppBlockCard({
             </Text>
           </Anchor>
         )}
-        {/* F-E E3: permission preview — the FIRST N approved scopes (the same
-            public disclosure list the E2 detail page shows in full). Lets a
-            viewer see what the app can do BEFORE installing (closes H3 at the
-            card level). Empty until the app is approved with scopes. */}
-        {block.scopesSummary.length > 0 && (
-          <Group gap={4} wrap="wrap">
-            <IconShieldLock size={14} className="text-gray-500" />
-            {block.scopesSummary.map((scope) => (
-              <Tooltip key={scope} label={scopeLabel(scope)} withArrow multiline w={220}>
-                <Badge variant="outline" color="gray" size="xs" style={{ cursor: 'help' }}>
-                  {scope}
-                </Badge>
-              </Tooltip>
-            ))}
-          </Group>
-        )}
+        {/* Scopes were MOVED off the card face into the details modal (2026-06
+            UX pass) — the permission disclosure now lives under "View details"
+            so the card stays scannable. */}
         <Group justify="space-between" mt="auto" pt="xs">
           <Group gap={10}>
-            <Group gap={4}>
-              <IconBolt size={14} />
-              <Text size="xs" c="dimmed">
-                {block.installCount.toLocaleString()} installs
-              </Text>
-            </Group>
-            {/* F-E marketplace reviews: avg rating + review count. avgRating is
-                null for a 0-review app → show "No reviews". */}
-            <Group gap={4}>
-              <IconStarFilled size={13} className="text-yellow-500" />
-              {block.avgRating != null ? (
+            {/* Install count is HIDDEN until there's a real user base — every
+                app currently shows 0, which reads as "unused". Re-introduce when
+                installs are meaningful. */}
+            {/* Review indicator: shown ONLY when the app has ≥1 review. A
+                0-review app shows nothing (no "No reviews" affordance) so an
+                un-reviewed app doesn't look bad. */}
+            {block.reviewCount > 0 && block.avgRating != null && (
+              <Group gap={4}>
+                <IconStarFilled size={13} className="text-yellow-500" />
                 <Text size="xs" c="dimmed">
                   {block.avgRating.toFixed(1)} ({block.reviewCount.toLocaleString()})
                 </Text>
-              ) : (
-                <Text size="xs" c="dimmed">
-                  No reviews
-                </Text>
-              )}
-            </Group>
+              </Group>
+            )}
           </Group>
           {/*
             Anon-conversion CTA (F-E E1): for a session-less viewer, clicking
@@ -202,6 +220,14 @@ export function AppBlockCard({
             matters once the segment is widened to anon.
           */}
           <Group gap={6} wrap="nowrap">
+            {/* "View details" — the UNIVERSAL details affordance, on EVERY card
+                (this is what guarantees the never-empty-card invariant; it
+                supersedes the #2747 page-link "View" fallback). Opens the
+                details modal (description, screenshots, recent reviews, scopes).
+                A button, not a link, so it doesn't navigate away from the grid. */}
+            <Button size="xs" variant="light" onClick={() => setDetailsOpen(true)}>
+              View details
+            </Button>
             {/* W10 — "Open app" link to the full-page route, shown only when the
                 app declares a page AND the viewer has the appBlocksPages flag
                 (dark today). The route itself 404s without the flag, so this is
@@ -214,21 +240,6 @@ export function AppBlockCard({
                 variant="light"
               >
                 Open app
-              </Button>
-            )}
-            {/* INVARIANT: every card renders ≥1 affordance. A page app whose
-                live "Open app" run isn't available (no page, or the
-                `appBlocksPages` flag is off) and which has no Install slot would
-                otherwise be an actionless card — fall back to a "View" link to
-                the always-reachable detail page. */}
-            {showView && (
-              <Button
-                component={Link}
-                href={`/apps/${block.id}`}
-                size="xs"
-                variant="light"
-              >
-                View
               </Button>
             )}
             {showInstall && (
@@ -249,6 +260,13 @@ export function AppBlockCard({
           </Group>
         </Group>
       </Stack>
+      {/* Details modal — controlled by this card's local state. Lazily mounted
+          but the query inside only fires while `opened`. */}
+      <AppDetailsModal
+        opened={detailsOpen}
+        onClose={() => setDetailsOpen(false)}
+        block={block}
+      />
     </Card>
   );
 }

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -260,13 +260,15 @@ export function AppBlockCard({
           </Group>
         </Group>
       </Stack>
-      {/* Details modal — controlled by this card's local state. Lazily mounted
-          but the query inside only fires while `opened`. */}
-      <AppDetailsModal
-        opened={detailsOpen}
-        onClose={() => setDetailsOpen(false)}
-        block={block}
-      />
+      {/* Details modal — controlled by this card's local state. GATED so the
+          whole subtree (its tRPC query hooks + the <AppBlockReviews> subtree)
+          only EXISTS while open: with N cards in the marketplace grid, an
+          always-mounted modal per card meant N idle modal instances. The "View
+          details" BUTTON above stays unconditional (the never-empty-card
+          invariant) — only this subtree is gated. */}
+      {detailsOpen && (
+        <AppDetailsModal opened onClose={() => setDetailsOpen(false)} block={block} />
+      )}
     </Card>
   );
 }

--- a/src/components/Apps/AppDetailsModal.browser.test.tsx
+++ b/src/components/Apps/AppDetailsModal.browser.test.tsx
@@ -1,0 +1,204 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type { AvailableBlock, PublicAppDetail } from '~/server/schema/blocks/subscription.schema';
+
+/**
+ * App Blocks DETAILS modal — component tests.
+ *
+ * Verifies the modal consolidates the secondary app info that the 2026-06 UX
+ * pass moved OFF the card face:
+ *   - Header: title, author, description.
+ *   - Screenshots gallery (rendered when present; gracefully absent otherwise).
+ *   - Scopes (the permission disclosure, moved off the card).
+ *   - A "recent reviews" section — REUSES <AppBlockReviews> (stubbed here; its
+ *     own internals are covered by AppBlockReviews.browser.test.tsx).
+ *
+ * Network-free: the `getAppDetail` / `listMySubscriptions` tRPC queries are
+ * mocked, and <AppBlockReviews> (which pulls in the review queries + avatar +
+ * date machinery) is stubbed to a probe so this stays a unit of the MODAL.
+ */
+
+const mocks = vi.hoisted(() => ({
+  // The detail payload getAppDetail returns (null = still loading / absent).
+  detail: null as PublicAppDetail | null,
+  reviewsProps: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getAppDetail: {
+        useQuery: () => ({ data: mocks.detail, isLoading: mocks.detail === null }),
+      },
+      listMySubscriptions: {
+        useQuery: () => ({ data: [] }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 42, username: 'viewer' }),
+}));
+
+// Reuse-not-rebuild: the modal must render the existing reviews component. Stub
+// it to a probe that records the props it was handed (appBlockId + aggregate).
+vi.mock('~/components/Apps/AppBlockReviews', () => ({
+  AppBlockReviews: (props: { appBlockId: string; avgRating: number | null; reviewCount: number }) => {
+    mocks.reviewsProps(props);
+    return <div data-testid="reviews-section">reviews for {props.appBlockId}</div>;
+  },
+}));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { AppDetailsModal } = await import('./AppDetailsModal');
+
+function makeBlock(overrides: Partial<AvailableBlock> = {}): AvailableBlock {
+  return {
+    id: 'app-1',
+    blockId: 'my-block',
+    appId: 'app-1',
+    appName: 'My App',
+    manifest: {
+      name: 'My App',
+      description: 'Does a thing.',
+      targets: [{ slotId: 'model.sidebar_top' }],
+    },
+    installCount: 3,
+    category: null,
+    scopesSummary: [],
+    avgRating: null,
+    reviewCount: 0,
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<PublicAppDetail> = {}): PublicAppDetail {
+  return {
+    id: 'app-1',
+    blockId: 'my-block',
+    appId: 'app-1',
+    appName: 'My App',
+    manifest: {
+      name: 'My App',
+      description: 'Does a thing.',
+      targets: [{ slotId: 'model.sidebar_top' }],
+    },
+    scopes: [],
+    contentRating: null,
+    version: '1.0.0',
+    installCount: 3,
+    avgRating: null,
+    reviewCount: 0,
+    liveUrl: 'https://my-block.example.com',
+    screenshots: [],
+    ...overrides,
+  };
+}
+
+const onClose = vi.fn();
+
+beforeEach(() => {
+  mocks.detail = null;
+  mocks.reviewsProps.mockClear();
+  onClose.mockClear();
+});
+
+describe('AppDetailsModal', () => {
+  test('closed → renders nothing visible', async () => {
+    renderWithProviders(<AppDetailsModal opened={false} onClose={onClose} block={makeBlock()} />);
+    // Mantine Modal renders no content when closed.
+    expect(page.getByText('reviews for', { exact: false }).query()).toBeNull();
+    expect(page.getByText('Does a thing.', { exact: false }).query()).toBeNull();
+  });
+
+  test('open → header renders title + author + description (from the listing block while loading)', async () => {
+    // detail null (loading) — title/author/description come from the block.
+    renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+    // Title appears (Mantine Modal title). Use a tolerant matcher — title may
+    // appear in the modal header region.
+    await expect.element(page.getByText('My App', { exact: false }).first()).toBeInTheDocument();
+    await expect.element(page.getByText('by My App', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('Does a thing.', { exact: false })).toBeInTheDocument();
+  });
+
+  test('open → renders the reviews section (reuses AppBlockReviews) with the app id + aggregate', async () => {
+    mocks.detail = makeDetail({ avgRating: 4.2, reviewCount: 9 });
+    renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+    await expect.element(page.getByTestId('reviews-section')).toBeInTheDocument();
+    expect(mocks.reviewsProps).toHaveBeenCalledWith(
+      expect.objectContaining({ appBlockId: 'app-1', avgRating: 4.2, reviewCount: 9 })
+    );
+  });
+
+  test('open → renders the scopes section with each approved scope + its description', async () => {
+    mocks.detail = makeDetail({ scopes: ['user:read:self', 'ai:write:budgeted'] });
+    renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+    // The section heading.
+    await expect.element(page.getByText(/this app can/i)).toBeInTheDocument();
+    // Each scope id chip + friendly description.
+    await expect.element(page.getByText('user:read:self', { exact: false })).toBeInTheDocument();
+    await expect.element(
+      page.getByText("Read the viewer's username and account status", { exact: false })
+    ).toBeInTheDocument();
+    await expect.element(page.getByText('ai:write:budgeted', { exact: false })).toBeInTheDocument();
+  });
+
+  test('open + no scopes → graceful "does not request any permissions"', async () => {
+    mocks.detail = makeDetail({ scopes: [] });
+    renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+    await expect.element(
+      page.getByText(/does not request any permissions/i)
+    ).toBeInTheDocument();
+  });
+
+  test('open + screenshots present → renders the gallery images', async () => {
+    mocks.detail = makeDetail({
+      screenshots: [
+        { index: 0, url: '/api/blocks/screenshot/app-1/0.png', contentType: 'image/png' },
+        { index: 1, url: '/api/blocks/screenshot/app-1/1.webp', contentType: 'image/webp' },
+      ],
+    });
+    renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+    await expect.element(page.getByText(/screenshots/i)).toBeInTheDocument();
+    // Both screenshot <img>s render with their public gated-route URLs.
+    const imgs = Array.from(document.querySelectorAll('img')).filter((i) =>
+      i.getAttribute('src')?.includes('/api/blocks/screenshot/app-1/')
+    );
+    expect(imgs.length).toBe(2);
+  });
+
+  test('open + NO screenshots → screenshots section gracefully absent (no heading, no imgs)', async () => {
+    mocks.detail = makeDetail({ screenshots: [] });
+    renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+    // The scopes/reviews still render, but there's no screenshot section.
+    await expect.element(page.getByTestId('reviews-section')).toBeInTheDocument();
+    expect(page.getByText(/^screenshots$/i).query()).toBeNull();
+    const shots = Array.from(document.querySelectorAll('img')).filter((i) =>
+      i.getAttribute('src')?.includes('/api/blocks/screenshot/')
+    );
+    expect(shots.length).toBe(0);
+  });
+
+  test('detail-provided title/author override the listing block when loaded', async () => {
+    mocks.detail = makeDetail({
+      appName: 'Detail Author',
+      manifest: { name: 'Detail Name', description: 'Detail description.' },
+    });
+    renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+    await expect.element(page.getByText('by Detail Author', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('Detail description.', { exact: false })).toBeInTheDocument();
+  });
+});

--- a/src/components/Apps/AppDetailsModal.browser.test.tsx
+++ b/src/components/Apps/AppDetailsModal.browser.test.tsx
@@ -21,8 +21,14 @@ import type { AvailableBlock, PublicAppDetail } from '~/server/schema/blocks/sub
  */
 
 const mocks = vi.hoisted(() => ({
-  // The detail payload getAppDetail returns (null = still loading / absent).
-  detail: null as PublicAppDetail | null,
+  // getAppDetail query state, mirroring react-query's shape. Default = LOADING
+  // (data undefined, isLoading true) so a test must opt in to a resolved/errored
+  // state. `detail` is the resolved payload (only meaningful when status
+  // 'success'); on 'success' it may be an actual object — including a
+  // resolved-but-empty one — which is the load-bearing distinction for the M1
+  // disclosure-correctness tests below.
+  status: 'loading' as 'loading' | 'success' | 'error',
+  detail: undefined as PublicAppDetail | undefined,
   reviewsProps: vi.fn(),
 }));
 
@@ -30,7 +36,14 @@ vi.mock('~/utils/trpc', () => ({
   trpc: {
     blocks: {
       getAppDetail: {
-        useQuery: () => ({ data: mocks.detail, isLoading: mocks.detail === null }),
+        // Faithful react-query shape: while loading/erroring `data` is
+        // undefined (NOT null) — that's what lets the component distinguish
+        // "resolved with empty scopes" from "not loaded".
+        useQuery: () => ({
+          data: mocks.status === 'success' ? mocks.detail : undefined,
+          isLoading: mocks.status === 'loading',
+          isError: mocks.status === 'error',
+        }),
       },
       listMySubscriptions: {
         useQuery: () => ({ data: [] }),
@@ -38,6 +51,12 @@ vi.mock('~/utils/trpc', () => ({
     },
   },
 }));
+
+/** Mark the detail query as resolved with this payload. */
+function resolveDetail(detail: PublicAppDetail) {
+  mocks.status = 'success';
+  mocks.detail = detail;
+}
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true }),
@@ -104,7 +123,8 @@ function makeDetail(overrides: Partial<PublicAppDetail> = {}): PublicAppDetail {
 const onClose = vi.fn();
 
 beforeEach(() => {
-  mocks.detail = null;
+  mocks.status = 'loading';
+  mocks.detail = undefined;
   mocks.reviewsProps.mockClear();
   onClose.mockClear();
 });
@@ -129,7 +149,7 @@ describe('AppDetailsModal', () => {
   });
 
   test('open → renders the reviews section (reuses AppBlockReviews) with the app id + aggregate', async () => {
-    mocks.detail = makeDetail({ avgRating: 4.2, reviewCount: 9 });
+    resolveDetail(makeDetail({ avgRating: 4.2, reviewCount: 9 }));
     renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
 
     await expect.element(page.getByTestId('reviews-section')).toBeInTheDocument();
@@ -139,7 +159,7 @@ describe('AppDetailsModal', () => {
   });
 
   test('open → renders the scopes section with each approved scope + its description', async () => {
-    mocks.detail = makeDetail({ scopes: ['user:read:self', 'ai:write:budgeted'] });
+    resolveDetail(makeDetail({ scopes: ['user:read:self', 'ai:write:budgeted'] }));
     renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
 
     // The section heading.
@@ -152,8 +172,8 @@ describe('AppDetailsModal', () => {
     await expect.element(page.getByText('ai:write:budgeted', { exact: false })).toBeInTheDocument();
   });
 
-  test('open + no scopes → graceful "does not request any permissions"', async () => {
-    mocks.detail = makeDetail({ scopes: [] });
+  test('open + no scopes (RESOLVED empty) → graceful "does not request any permissions"', async () => {
+    resolveDetail(makeDetail({ scopes: [] }));
     renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
 
     await expect.element(
@@ -162,12 +182,12 @@ describe('AppDetailsModal', () => {
   });
 
   test('open + screenshots present → renders the gallery images', async () => {
-    mocks.detail = makeDetail({
+    resolveDetail(makeDetail({
       screenshots: [
         { index: 0, url: '/api/blocks/screenshot/app-1/0.png', contentType: 'image/png' },
         { index: 1, url: '/api/blocks/screenshot/app-1/1.webp', contentType: 'image/webp' },
       ],
-    });
+    }));
     renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
 
     await expect.element(page.getByText(/screenshots/i)).toBeInTheDocument();
@@ -179,7 +199,7 @@ describe('AppDetailsModal', () => {
   });
 
   test('open + NO screenshots → screenshots section gracefully absent (no heading, no imgs)', async () => {
-    mocks.detail = makeDetail({ screenshots: [] });
+    resolveDetail(makeDetail({ screenshots: [] }));
     renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
 
     // The scopes/reviews still render, but there's no screenshot section.
@@ -192,13 +212,88 @@ describe('AppDetailsModal', () => {
   });
 
   test('detail-provided title/author override the listing block when loaded', async () => {
-    mocks.detail = makeDetail({
+    resolveDetail(makeDetail({
       appName: 'Detail Author',
       manifest: { name: 'Detail Name', description: 'Detail description.' },
-    });
+    }));
     renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
 
     await expect.element(page.getByText('by Detail Author', { exact: false })).toBeInTheDocument();
     await expect.element(page.getByText('Detail description.', { exact: false })).toBeInTheDocument();
+  });
+
+  // ── M1 (audit, REQUIRED): disclosure correctness ───────────────────────────
+  // The scopes disclosure must distinguish FAILED-to-load from RESOLVED-empty.
+  // A failed `getAppDetail` (retry:false) must NOT silently render the
+  // reassuring "does not request any permissions" copy — that's a misleading
+  // security-relevant claim about an app whose scopes we never actually read.
+  describe('M1 — scopes disclosure distinguishes failed vs empty vs loading', () => {
+    test('query ERROR → explicit error state, and NOT the "no permissions" copy', async () => {
+      mocks.status = 'error';
+      mocks.detail = undefined;
+      renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+      // The "This app can…" heading is still present, but the body is the error
+      // state — NOT the definitive "no permissions" disclosure.
+      await expect.element(page.getByText(/couldn.?t load full details/i).first()).toBeInTheDocument();
+      expect(page.getByText(/does not request any permissions/i).query()).toBeNull();
+    });
+
+    test('query LOADING → loading state, NOT the empty/error copy', async () => {
+      // default state is 'loading'
+      renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+      // While loading we say NEITHER "no permissions" NOR the error copy — the
+      // scopes verdict is simply not yet known.
+      await expect.element(page.getByText(/this app can/i)).toBeInTheDocument();
+      expect(page.getByText(/does not request any permissions/i).query()).toBeNull();
+      expect(page.getByText(/couldn.?t load full details/i).query()).toBeNull();
+    });
+
+    test('query RESOLVED with empty scopes → the legit "no permissions" copy', async () => {
+      resolveDetail(makeDetail({ scopes: [] }));
+      renderWithProviders(<AppDetailsModal opened onClose={onClose} block={makeBlock()} />);
+
+      await expect.element(page.getByText(/does not request any permissions/i)).toBeInTheDocument();
+      // And NOT the error copy.
+      expect(page.getByText(/couldn.?t load full details/i).query()).toBeNull();
+    });
+  });
+
+  // ── L2 (audit): prefer the RESOLVED aggregate, no stale `??` fall-through ───
+  describe('L2 — resolved aggregate is authoritative (null is "no rating", not stale)', () => {
+    test('detail resolved with avgRating null while listing block.avgRating non-null → reviews gets the RESOLVED null, not the stale listing value', async () => {
+      resolveDetail(makeDetail({ avgRating: null, reviewCount: 0 }));
+      renderWithProviders(
+        // listing row carries a stale non-null aggregate
+        <AppDetailsModal
+          opened
+          onClose={onClose}
+          block={makeBlock({ avgRating: 4.7, reviewCount: 31 })}
+        />
+      );
+
+      await expect.element(page.getByTestId('reviews-section')).toBeInTheDocument();
+      // The reviews component must receive the RESOLVED null (not 4.7 / 31).
+      expect(mocks.reviewsProps).toHaveBeenCalledWith(
+        expect.objectContaining({ avgRating: null, reviewCount: 0 })
+      );
+    });
+
+    test('while LOADING (detail undefined) the listing aggregate is used (fallback path)', async () => {
+      // default loading state
+      renderWithProviders(
+        <AppDetailsModal
+          opened
+          onClose={onClose}
+          block={makeBlock({ avgRating: 4.7, reviewCount: 31 })}
+        />
+      );
+
+      await expect.element(page.getByTestId('reviews-section')).toBeInTheDocument();
+      expect(mocks.reviewsProps).toHaveBeenCalledWith(
+        expect.objectContaining({ avgRating: 4.7, reviewCount: 31 })
+      );
+    });
   });
 });

--- a/src/components/Apps/AppDetailsModal.tsx
+++ b/src/components/Apps/AppDetailsModal.tsx
@@ -78,7 +78,11 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
 
   // Anon-capable public read path — only fires while the modal is open (and the
   // appBlocks flag is granted). Returns ONLY the PublicAppDetail allowlist.
-  const { data, isLoading } = trpc.blocks.getAppDetail.useQuery(
+  // `retry: false` → a failure surfaces immediately as `isError` (we render an
+  // explicit error state for the detail-only sections rather than silently
+  // falling through to "no permissions" — that would be a misleading
+  // security-relevant disclosure; see the scopes block below).
+  const { data, isLoading, isError } = trpc.blocks.getAppDetail.useQuery(
     { appBlockId },
     { enabled: opened && !!features.appBlocks && !!appBlockId, retry: false }
   );
@@ -95,6 +99,11 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
   );
 
   const detail = data as PublicAppDetail | undefined;
+  // Did the detail query actually RESOLVE (vs still loading / failed)? This is
+  // the load-bearing distinction for the disclosure copy + the aggregates: we
+  // only make a definitive statement ("does not request any permissions",
+  // resolved avgRating/reviewCount) once the public detail genuinely resolved.
+  const detailLoaded = detail !== undefined;
   // Title/author render from the listing row immediately; the detail query
   // enriches them (and is the only source for screenshots/scopes/version).
   const name = detail?.manifest.name ?? block.manifest.name ?? block.blockId;
@@ -102,6 +111,12 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
   const description = detail?.manifest.description ?? block.manifest.description ?? '';
   const screenshots = detail?.screenshots ?? [];
   const scopes = detail?.scopes ?? [];
+  // L2: once the detail resolved, the aggregate is authoritative — prefer it
+  // DIRECTLY (a legit `null` means "no rating", not "fall back to the stale
+  // listing value"). Only use the listing `block` aggregate WHILE loading
+  // (detail === undefined). `??` would wrongly fall through on a resolved null.
+  const avgRating = detailLoaded ? detail.avgRating : block.avgRating;
+  const reviewCount = detailLoaded ? detail.reviewCount : block.reviewCount;
 
   return (
     <Modal opened={opened} onClose={onClose} title={name} size="lg" radius="md">
@@ -132,9 +147,23 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
           </Text>
         )}
 
+        {/* Detail-load failure (audit M1): when the public-detail query errors
+            we can't say anything definitive about screenshots OR scopes, so
+            surface ONE explicit error banner here (the scopes block below shows
+            its own inline error too) rather than rendering a "no screenshots /
+            no permissions" view that looks like a deliberate, reassuring
+            statement about the app. */}
+        {isError && (
+          <Text size="sm" c="red">
+            Couldn&apos;t load full details — try again.
+          </Text>
+        )}
+
         {/* Screenshots — publisher gallery from the public allowlist (gated app
             route URLs, magic-byte-validated + mod-reviewed at approval). Hidden
-            entirely when the app shipped none (graceful absence). */}
+            entirely when the app shipped none (graceful absence). On detail-load
+            error `screenshots` is empty AND `isError` shows the banner above, so
+            we don't imply "this app has no screenshots". */}
         {screenshots.length > 0 && (
           <Stack gap="xs">
             <Title order={5}>Screenshots</Title>
@@ -174,7 +203,15 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
 
         {/* Scopes — the permission disclosure, MOVED off the card face into the
             modal (2026-06 UX pass). Sourced from the app's APPROVED scopes
-            (PublicAppDetail.scopes). */}
+            (PublicAppDetail.scopes).
+
+            DISCLOSURE CORRECTNESS (audit M1): the definitive "does not request
+            any permissions" copy renders ONLY when the detail genuinely RESOLVED
+            (detailLoaded) with an empty scope list. While LOADING we show a
+            spinner; on ERROR we show an explicit "couldn't load" state — never
+            the reassuring "no permissions" line, which would be a misleading
+            security-relevant claim about an app whose scopes we never actually
+            read. */}
         <Stack gap="xs">
           <Group gap="xs">
             <ThemeIcon variant="light" color="blue" size="sm" radius="xl">
@@ -182,7 +219,15 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
             </ThemeIcon>
             <Title order={5}>This app can…</Title>
           </Group>
-          {scopes.length === 0 ? (
+          {isError ? (
+            <Text size="sm" c="red">
+              Couldn&apos;t load full details — try again.
+            </Text>
+          ) : !detailLoaded ? (
+            <Center py="xs">
+              <Loader size="xs" />
+            </Center>
+          ) : scopes.length === 0 ? (
             <Text size="sm" c="dimmed">
               This app does not request any permissions.
             </Text>
@@ -220,8 +265,8 @@ export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps
             getAppDetail invalidation inside the component). */}
         <AppBlockReviews
           appBlockId={appBlockId}
-          avgRating={detail?.avgRating ?? block.avgRating}
-          reviewCount={detail?.reviewCount ?? block.reviewCount}
+          avgRating={avgRating}
+          reviewCount={reviewCount}
           subscriptions={mySubsForApp}
         />
       </Stack>

--- a/src/components/Apps/AppDetailsModal.tsx
+++ b/src/components/Apps/AppDetailsModal.tsx
@@ -1,0 +1,230 @@
+import {
+  Anchor,
+  Badge,
+  Card,
+  Center,
+  Divider,
+  Group,
+  List,
+  Loader,
+  Modal,
+  SimpleGrid,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
+import { IconExternalLink, IconLock, IconShieldCheck } from '@tabler/icons-react';
+import { useMemo } from 'react';
+import { AppBlockReviews } from '~/components/Apps/AppBlockReviews';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type {
+  AvailableBlock,
+  PublicAppDetail,
+  SubscriptionRecord,
+} from '~/server/schema/blocks/subscription.schema';
+import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
+import { trpc } from '~/utils/trpc';
+
+export interface AppDetailsModalProps {
+  /** Controlled open state. The card owns the lifecycle (local useState). */
+  opened: boolean;
+  onClose: () => void;
+  /**
+   * The marketplace listing row for this app. Drives the IMMEDIATE header
+   * render (title + author + the card-level review aggregate) so the modal
+   * never shows an empty header while the detail query is in flight. The
+   * richer fields (screenshots, full approved scopes, version) come from the
+   * `getAppDetail` query below — the same anon-capable public read path the
+   * /apps/<id> detail page uses.
+   */
+  block: AvailableBlock;
+}
+
+/** Human label for a scope id, falling back to the raw id for an unknown scope
+ *  so a newly-added scope ships without breaking the disclosure list. */
+function scopeLabel(scope: string): string {
+  return SCOPE_DESCRIPTIONS[scope] ?? scope;
+}
+
+/**
+ * App Blocks marketplace DETAILS modal.
+ *
+ * Opened from the card's "View details" button (the universal details
+ * affordance — see AppBlockCard). Consolidates the richer-but-secondary app
+ * info that was moved OFF the card face in the 2026-06 UX pass:
+ *   - Header: title, author, and (when present) the publisher screenshot
+ *     gallery + description.
+ *   - Recent reviews — reuses the existing <AppBlockReviews> component/queries
+ *     (summary + a few recent rows + the gated write form). Not rebuilt.
+ *   - Scopes — the permission disclosure, moved off the card face.
+ *
+ * Data sources (all the anon-safe public allowlist — no private manifest data):
+ *   - title / description / screenshots / scopes / version → `blocks.getAppDetail`
+ *     (PublicAppDetail). Title/author also fall back to the listing `block` so
+ *     the header renders before the detail query resolves.
+ *   - author → the app owner (`block.appName` / `detail.appName`).
+ *   - reviews → the existing block-reviews queries inside <AppBlockReviews>.
+ *
+ * The modal fetches its own subscriptions (mirroring the detail page) so the
+ * reviews write-form gate works without threading new props through the
+ * marketplace grid — it is fully self-contained.
+ */
+export function AppDetailsModal({ opened, onClose, block }: AppDetailsModalProps) {
+  const features = useFeatureFlags();
+  const currentUser = useCurrentUser();
+  const appBlockId = block.id;
+
+  // Anon-capable public read path — only fires while the modal is open (and the
+  // appBlocks flag is granted). Returns ONLY the PublicAppDetail allowlist.
+  const { data, isLoading } = trpc.blocks.getAppDetail.useQuery(
+    { appBlockId },
+    { enabled: opened && !!features.appBlocks && !!appBlockId, retry: false }
+  );
+
+  // Per-user subscriptions feed the reviews write-form gate (an enabled install
+  // is required to review, mirroring the server gate). Guarded on a signed-in
+  // user — the protected proc 401s for anon. Only fires while open.
+  const { data: mySubs } = trpc.blocks.listMySubscriptions.useQuery(undefined, {
+    enabled: opened && !!features.appBlocks && !!currentUser,
+  });
+  const mySubsForApp = useMemo<SubscriptionRecord[]>(
+    () => (mySubs ?? []).filter((sub) => sub.appBlockId === appBlockId),
+    [mySubs, appBlockId]
+  );
+
+  const detail = data as PublicAppDetail | undefined;
+  // Title/author render from the listing row immediately; the detail query
+  // enriches them (and is the only source for screenshots/scopes/version).
+  const name = detail?.manifest.name ?? block.manifest.name ?? block.blockId;
+  const author = detail?.appName ?? block.appName ?? block.appId;
+  const description = detail?.manifest.description ?? block.manifest.description ?? '';
+  const screenshots = detail?.screenshots ?? [];
+  const scopes = detail?.scopes ?? [];
+
+  return (
+    <Modal opened={opened} onClose={onClose} title={name} size="lg" radius="md">
+      <Stack gap="lg">
+        {/* Header — title (modal title) + author + description. */}
+        <Stack gap={4}>
+          <Text c="dimmed" size="sm">
+            by {author}
+          </Text>
+          {detail?.liveUrl && (
+            <Anchor
+              href={detail.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="xs"
+            >
+              <Group gap={4}>
+                <IconExternalLink size={12} />
+                Open live
+              </Group>
+            </Anchor>
+          )}
+        </Stack>
+
+        {description && (
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+            {description}
+          </Text>
+        )}
+
+        {/* Screenshots — publisher gallery from the public allowlist (gated app
+            route URLs, magic-byte-validated + mod-reviewed at approval). Hidden
+            entirely when the app shipped none (graceful absence). */}
+        {screenshots.length > 0 && (
+          <Stack gap="xs">
+            <Title order={5}>Screenshots</Title>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+              {screenshots.map((shot) => (
+                <Card
+                  key={shot.index}
+                  withBorder
+                  padding={0}
+                  radius="md"
+                  style={{ overflow: 'hidden' }}
+                >
+                  {/* Plain <img> from our own gated route (not a Next/Image
+                      configured domain). */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={shot.url}
+                    alt={`${name} screenshot ${shot.index + 1}`}
+                    loading="lazy"
+                    style={{ width: '100%', height: 'auto', display: 'block' }}
+                  />
+                </Card>
+              ))}
+            </SimpleGrid>
+          </Stack>
+        )}
+
+        {/* A small in-flight hint while the detail query resolves the richer
+            fields (screenshots/scopes). Title/author/description already show. */}
+        {isLoading && (
+          <Center py="sm">
+            <Loader size="sm" />
+          </Center>
+        )}
+
+        <Divider />
+
+        {/* Scopes — the permission disclosure, MOVED off the card face into the
+            modal (2026-06 UX pass). Sourced from the app's APPROVED scopes
+            (PublicAppDetail.scopes). */}
+        <Stack gap="xs">
+          <Group gap="xs">
+            <ThemeIcon variant="light" color="blue" size="sm" radius="xl">
+              <IconShieldCheck size={14} />
+            </ThemeIcon>
+            <Title order={5}>This app can…</Title>
+          </Group>
+          {scopes.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              This app does not request any permissions.
+            </Text>
+          ) : (
+            <List
+              spacing="xs"
+              size="sm"
+              icon={
+                <ThemeIcon variant="light" color="gray" size="sm" radius="xl">
+                  <IconLock size={12} />
+                </ThemeIcon>
+              }
+            >
+              {scopes.map((scope) => (
+                <List.Item key={scope}>
+                  <Group gap="xs" wrap="nowrap" align="center">
+                    <Badge variant="outline" color="gray" size="xs">
+                      {scope}
+                    </Badge>
+                    <Text component="span" size="sm">
+                      {scopeLabel(scope)}
+                    </Text>
+                  </Group>
+                </List.Item>
+              ))}
+            </List>
+          )}
+        </Stack>
+
+        <Divider />
+
+        {/* Recent reviews — REUSES the existing reviews component + queries
+            (summary + a few recent rows + the gated write form). The aggregate
+            (avgRating / reviewCount) comes from the listing row (kept fresh by
+            getAppDetail invalidation inside the component). */}
+        <AppBlockReviews
+          appBlockId={appBlockId}
+          avgRating={detail?.avgRating ?? block.avgRating}
+          reviewCount={detail?.reviewCount ?? block.reviewCount}
+          subscriptions={mySubsForApp}
+        />
+      </Stack>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## What

2026-06 marketplace UX pass on the App Block **card** + a new **details modal**. UI-only.

### `AppBlockCard`
- **Hide the install count** — every app shows `0` today, which reads as "unused". Removed the installs chip.
- **Hide the review indicator when reviewCount=0** — the avg+count only renders when `reviewCount > 0` (no more "No reviews" affordance on un-reviewed apps).
- **Show the category (+ icon)** — the mod-assigned `app_blocks.category` (the structured `MARKETPLACE_CATEGORIES` field) with a per-category Tabler icon; generic-tag fallback for an unknown value; no chip when null.
- **Move scopes off the card face** — the permission disclosure now lives in the modal.
- **Add a universal "View details" button** opening `AppDetailsModal`.

### `AppDetailsModal` (new)
Controlled modal (`opened` / `onClose` / `block`):
- **Header**: title, author, description.
- **Screenshots** — publisher gallery from the public allowlist; hidden gracefully when the app shipped none.
- **Recent reviews** — **reuses** the existing `<AppBlockReviews>` component + its queries (not rebuilt).
- **Scopes** — the permission disclosure moved off the card.

Data comes from the anon-safe `blocks.getAppDetail` public allowlist (`PublicAppDetail`) — the same read path the `/apps/<id>` detail page uses. The modal self-fetches `listMySubscriptions` for the reviews write-form gate, so **no new props thread through the marketplace grid** (`/apps/index.tsx` untouched).

### Reconcile with #2747
#2747 added a page-link **"View"** fallback so a page app's card was never actionless. Now that **every** card has the universal **"View details"** (modal) button, that fallback is redundant — it's **removed**, and "View details" is the never-empty-card affordance. The #2747 invariant tests are **retargeted** to assert "View details" (coverage preserved, not deleted). "Open app"/Install remain the run/install CTAs.

## Tests
- Extended `AppBlockCard.browser.test.tsx` + new `AppDetailsModal.browser.test.tsx`.
- **27 component tests green** (17 card + 8 modal + 2 existing reviews).
- Covers: install count not rendered · review indicator hidden@0 / shown@>0 · category+icon rendered (and absent when null) · scopes not on card face · "View details" present on page AND model app + opens modal · never-empty-card invariant (incl. #2747 pages-flag-off case) · modal renders title/author/description/screenshots(present+absent)/recent-reviews/scopes.
- **Mutation-checked**: reverting the install-count hide and the screenshots render each fail a test.

## Verification
- Scoped `tsc` on the touched files: **zero errors attributable to `AppBlockCard.tsx` / `AppDetailsModal.tsx`** (the only scoped-config noise is pre-existing global-types/backend-graph errors unrelated to this change).
- Not browser-verified against a live click path (dark / mod-gated surface) — component tests exercise the open behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)