### PR TITLE
fix(comics): address create/workspace UI feedback

### DIFF
--- a/src/pages/comics/CreateComic.module.scss
+++ b/src/pages/comics/CreateComic.module.scss
@@ -25,7 +25,7 @@
   }
 }
 
-/* ── Images row: Hero + Cover side by side ────────── */
+/* ── Images: hero + cover side by side ────────────────────── */
 
 .imagesRow {
   display: flex;
@@ -44,12 +44,8 @@
 
 .coverSection {
   flex-shrink: 0;
-  width: 100px;
-
-  @media (max-width: 560px) {
-    width: 100%;
-    max-width: 120px;
-  }
+  width: 160px;
+  max-width: 100%;
 }
 
 .heroDropzone {
@@ -58,11 +54,11 @@
   border-radius: 8px;
   overflow: hidden;
   background: light-dark(var(--mantine-color-gray-1), #2c2e33);
-  max-height: 160px;
+  max-height: 220px;
 }
 
 .heroPickerWrap {
-  max-height: 160px;
+  max-height: 220px;
 
   /* Constrain the inner frame to match. The picker's internal frame
      already clips the draggable image with its own overflow:hidden, so
@@ -70,10 +66,13 @@
      top:-8 right:-8, just outside the frame, and any wrapper-level
      overflow:hidden chops it off (visible on the create page only). */
   > div {
-    max-height: 160px;
+    max-height: 220px;
   }
 }
 
+/* Cover is a compact card: dropzone on top, full-width action buttons
+   stacked beneath (so "Pick from generator" gets the full 160px and is
+   never clipped, as it was in the old 100px column). */
 .coverDropzone {
   width: 100%;
   aspect-ratio: 3 / 4;
@@ -84,12 +83,12 @@
 
 .coverPreviewWrap {
   position: relative;
-  display: inline-block;
+  width: 100%;
 }
 
 .coverPreview {
-  width: 100px;
-  height: 133px;
+  width: 100%;
+  aspect-ratio: 3 / 4;
   border-radius: 8px;
   overflow: hidden;
   background: #2c2e33;

--- a/src/pages/comics/create.tsx
+++ b/src/pages/comics/create.tsx
@@ -1,5 +1,6 @@
 import {
   ActionIcon,
+  Alert,
   Button,
   Container,
   Group,
@@ -12,7 +13,16 @@ import {
   Title,
 } from '@mantine/core';
 import { Dropzone, IMAGE_MIME_TYPE } from '@mantine/dropzone';
-import { IconBook, IconPhoto, IconPhotoUp, IconUpload, IconUser, IconWand, IconX } from '@tabler/icons-react';
+import {
+  IconBook,
+  IconInfoCircle,
+  IconPhoto,
+  IconPhotoUp,
+  IconUpload,
+  IconUser,
+  IconWand,
+  IconX,
+} from '@tabler/icons-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
@@ -94,9 +104,7 @@ function CreateComicPage() {
         aspectRatios: ['3:4'] as `${number}:${number}`[],
         onConfirm: async (output: { src: string; cropped?: Blob }[]) => {
           const blob = output[0]?.cropped;
-          const uploadFile = blob
-            ? new File([blob], 'cover.jpg', { type: blob.type })
-            : file;
+          const uploadFile = blob ? new File([blob], 'cover.jpg', { type: blob.type }) : file;
           const result = await uploadCoverToCF(uploadFile);
           setCoverUrl(result.id);
           URL.revokeObjectURL(url);
@@ -159,178 +167,8 @@ function CreateComicPage() {
       <div className={styles.layout}>
         {/* ── Left: Form ─────────────────────────── */}
         <div className={styles.formColumn}>
-          <Stack gap="md">
-            {/* ── Images ── */}
-            <div>
-              <Text size="sm" fw={600} mb={2}>
-                Images
-              </Text>
-              <Text size="xs" c="dimmed" mb="sm">
-                Upload a wide hero banner for the comic overview page and a portrait cover for
-                browse cards. Both are optional and can be changed later.
-              </Text>
-            </div>
-            <div className={styles.imagesRow}>
-              {/* Hero */}
-              <div className={styles.heroSection}>
-                <Text size="xs" fw={600} c="dimmed" mb={4}>
-                  Hero Banner
-                </Text>
-                {heroUploading ? (
-                  <div className={styles.heroDropzone}>
-                    <Stack align="center" justify="center" gap={4} h="100%">
-                      <Loader size="sm" color="yellow" />
-                      <Text size="xs" c="dimmed">
-                        Uploading...
-                      </Text>
-                    </Stack>
-                  </div>
-                ) : heroUrl ? (
-                  <HeroPositionPicker
-                    url={heroUrl}
-                    position={heroPosition}
-                    onPositionChange={setHeroPosition}
-                    onRemove={() => {
-                      setHeroUrl(null);
-                      setHeroPosition(50);
-                    }}
-                    className={styles.heroPickerWrap}
-                  />
-                ) : (
-                  <Stack gap={4}>
-                    <Dropzone
-                      onDrop={handleHeroDrop}
-                      accept={IMAGE_MIME_TYPE}
-                      maxFiles={1}
-                      className={styles.heroDropzone}
-                    >
-                      <Stack
-                        align="center"
-                        justify="center"
-                        gap={4}
-                        h="100%"
-                        style={{ pointerEvents: 'none' }}
-                      >
-                        <Dropzone.Accept>
-                          <IconUpload size={20} className="text-blue-500" />
-                        </Dropzone.Accept>
-                        <Dropzone.Reject>
-                          <IconX size={20} className="text-red-500" />
-                        </Dropzone.Reject>
-                        <Dropzone.Idle>
-                          <IconPhoto size={20} style={{ color: '#909296' }} />
-                        </Dropzone.Idle>
-                        <Text size="xs" c="dimmed">
-                          16:9 banner
-                        </Text>
-                      </Stack>
-                    </Dropzone>
-                    <Group gap={4}>
-                      <Button
-                        variant="subtle"
-                        size="compact-xs"
-                        leftSection={<IconPhotoUp size={14} />}
-                        onClick={handlePickHeroFromGenerator}
-                        loading={pickingHero}
-                      >
-                        Pick from generator
-                      </Button>
-                      <Button
-                        variant="subtle"
-                        size="compact-xs"
-                        leftSection={<IconWand size={14} />}
-                        onClick={() => setGenerateHeroOpened(true)}
-                      >
-                        Generate
-                      </Button>
-                    </Group>
-                  </Stack>
-                )}
-              </div>
-
-              {/* Cover */}
-              <div className={styles.coverSection}>
-                <Text size="xs" fw={600} c="dimmed" mb={4}>
-                  Cover
-                </Text>
-                {coverUploading ? (
-                  <div className={styles.coverDropzone}>
-                    <Stack align="center" justify="center" gap={4} h="100%">
-                      <Loader size="xs" color="yellow" />
-                      <Text size="xs" c="dimmed">
-                        Uploading...
-                      </Text>
-                    </Stack>
-                  </div>
-                ) : coverUrl ? (
-                  <div className={styles.coverPreviewWrap}>
-                    <div className={styles.coverPreview}>
-                      <img src={getEdgeUrl(coverUrl, { width: 240 })} alt="Cover" />
-                    </div>
-                    <ActionIcon
-                      variant="filled"
-                      color="dark"
-                      size="xs"
-                      className={styles.removeBtn}
-                      onClick={() => setCoverUrl(null)}
-                    >
-                      <IconX size={12} />
-                    </ActionIcon>
-                  </div>
-                ) : (
-                  <Stack gap={4}>
-                    <Dropzone
-                      onDrop={handleCoverDrop}
-                      accept={IMAGE_MIME_TYPE}
-                      maxFiles={1}
-                      className={styles.coverDropzone}
-                    >
-                      <Stack
-                        align="center"
-                        justify="center"
-                        gap={4}
-                        h="100%"
-                        style={{ pointerEvents: 'none' }}
-                      >
-                        <Dropzone.Accept>
-                          <IconUpload size={18} className="text-blue-500" />
-                        </Dropzone.Accept>
-                        <Dropzone.Reject>
-                          <IconX size={18} className="text-red-500" />
-                        </Dropzone.Reject>
-                        <Dropzone.Idle>
-                          <IconPhoto size={18} style={{ color: '#909296' }} />
-                        </Dropzone.Idle>
-                        <Text size="xs" c="dimmed">
-                          3:4
-                        </Text>
-                      </Stack>
-                    </Dropzone>
-                    <Group gap={4}>
-                      <Button
-                        variant="subtle"
-                        size="compact-xs"
-                        leftSection={<IconPhotoUp size={14} />}
-                        onClick={handlePickCoverFromGenerator}
-                        loading={pickingCover}
-                      >
-                        Pick from generator
-                      </Button>
-                      <Button
-                        variant="subtle"
-                        size="compact-xs"
-                        leftSection={<IconWand size={14} />}
-                        onClick={() => setGenerateCoverOpened(true)}
-                      >
-                        Generate
-                      </Button>
-                    </Group>
-                  </Stack>
-                )}
-              </div>
-            </div>
-
-            {/* ── Details ── */}
+          <Stack gap="xl">
+            {/* ── Details (name is the most important field — keep it first) ── */}
             <div>
               <Text size="sm" fw={600} mb={2}>
                 Details
@@ -368,6 +206,188 @@ function CreateComicPage() {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
             />
+
+            {/* ── Images (secondary to the name, so placed below) ── */}
+            <div>
+              <Text size="sm" fw={600} mb={2}>
+                Images
+              </Text>
+              <Text size="xs" c="dimmed" mb="sm">
+                Upload a wide hero banner for the comic overview page and a portrait cover for
+                browse cards. Both are optional and can be changed later.
+              </Text>
+            </div>
+            <div className={styles.imagesRow}>
+              {/* Hero — takes the remaining width beside the cover card */}
+              <div className={styles.heroSection}>
+                <Text size="xs" fw={600} c="dimmed" mb={4}>
+                  Hero Banner
+                </Text>
+                {heroUploading ? (
+                  <div className={styles.heroDropzone}>
+                    <Stack align="center" justify="center" gap={4} h="100%">
+                      <Loader size="sm" color="yellow" />
+                      <Text size="xs" c="dimmed">
+                        Uploading...
+                      </Text>
+                    </Stack>
+                  </div>
+                ) : heroUrl ? (
+                  <HeroPositionPicker
+                    url={heroUrl}
+                    position={heroPosition}
+                    onPositionChange={setHeroPosition}
+                    onRemove={() => {
+                      setHeroUrl(null);
+                      setHeroPosition(50);
+                    }}
+                    className={styles.heroPickerWrap}
+                  />
+                ) : (
+                  <Stack gap={6}>
+                    <Dropzone
+                      onDrop={handleHeroDrop}
+                      accept={IMAGE_MIME_TYPE}
+                      maxFiles={1}
+                      className={styles.heroDropzone}
+                    >
+                      <Stack
+                        align="center"
+                        justify="center"
+                        gap={4}
+                        h="100%"
+                        style={{ pointerEvents: 'none' }}
+                      >
+                        <Dropzone.Accept>
+                          <IconUpload size={20} className="text-blue-500" />
+                        </Dropzone.Accept>
+                        <Dropzone.Reject>
+                          <IconX size={20} className="text-red-500" />
+                        </Dropzone.Reject>
+                        <Dropzone.Idle>
+                          <IconPhoto size={20} style={{ color: '#909296' }} />
+                        </Dropzone.Idle>
+                        <Text size="xs" c="dimmed">
+                          16:9 banner
+                        </Text>
+                      </Stack>
+                    </Dropzone>
+                    <Group gap={8}>
+                      <Button
+                        variant="subtle"
+                        size="compact-xs"
+                        leftSection={<IconPhotoUp size={14} />}
+                        onClick={handlePickHeroFromGenerator}
+                        loading={pickingHero}
+                      >
+                        Pick from generator
+                      </Button>
+                      <Button
+                        variant="subtle"
+                        size="compact-xs"
+                        leftSection={<IconWand size={14} />}
+                        onClick={() => setGenerateHeroOpened(true)}
+                      >
+                        Generate
+                      </Button>
+                    </Group>
+                  </Stack>
+                )}
+              </div>
+
+              {/* Cover — a compact card with its actions stacked beneath,
+                  so the "Pick from generator" button has full width and
+                  never gets clipped */}
+              <div className={styles.coverSection}>
+                <Text size="xs" fw={600} c="dimmed" mb={4}>
+                  Cover
+                </Text>
+                {coverUploading ? (
+                  <div className={styles.coverDropzone}>
+                    <Stack align="center" justify="center" gap={4} h="100%">
+                      <Loader size="xs" color="yellow" />
+                      <Text size="xs" c="dimmed">
+                        Uploading...
+                      </Text>
+                    </Stack>
+                  </div>
+                ) : coverUrl ? (
+                  <div className={styles.coverPreviewWrap}>
+                    <div className={styles.coverPreview}>
+                      <img src={getEdgeUrl(coverUrl, { width: 240 })} alt="Cover" />
+                    </div>
+                    <ActionIcon
+                      variant="filled"
+                      color="dark"
+                      size="xs"
+                      className={styles.removeBtn}
+                      onClick={() => setCoverUrl(null)}
+                    >
+                      <IconX size={12} />
+                    </ActionIcon>
+                  </div>
+                ) : (
+                  <Stack gap={8}>
+                    <Dropzone
+                      onDrop={handleCoverDrop}
+                      accept={IMAGE_MIME_TYPE}
+                      maxFiles={1}
+                      className={styles.coverDropzone}
+                    >
+                      <Stack
+                        align="center"
+                        justify="center"
+                        gap={4}
+                        h="100%"
+                        style={{ pointerEvents: 'none' }}
+                      >
+                        <Dropzone.Accept>
+                          <IconUpload size={18} className="text-blue-500" />
+                        </Dropzone.Accept>
+                        <Dropzone.Reject>
+                          <IconX size={18} className="text-red-500" />
+                        </Dropzone.Reject>
+                        <Dropzone.Idle>
+                          <IconPhoto size={18} style={{ color: '#909296' }} />
+                        </Dropzone.Idle>
+                        <Text size="xs" c="dimmed">
+                          3:4
+                        </Text>
+                      </Stack>
+                    </Dropzone>
+                    <Button
+                      variant="subtle"
+                      size="compact-xs"
+                      leftSection={<IconPhotoUp size={14} />}
+                      onClick={handlePickCoverFromGenerator}
+                      loading={pickingCover}
+                    >
+                      Pick from generator
+                    </Button>
+                    <Button
+                      variant="subtle"
+                      size="compact-xs"
+                      leftSection={<IconWand size={14} />}
+                      onClick={() => setGenerateCoverOpened(true)}
+                    >
+                      Generate
+                    </Button>
+                  </Stack>
+                )}
+              </div>
+            </div>
+
+            {/* Heads-up: where the comic lives after creation */}
+            <Alert variant="light" color="blue" icon={<IconInfoCircle size={18} />}>
+              <Text size="sm">
+                Your comic is saved as a{' '}
+                <Text span fw={700}>
+                  draft
+                </Text>{' '}
+                and will appear on your profile&apos;s Comics page. It stays private to you until
+                you publish a chapter.
+              </Text>
+            </Alert>
 
             {/* Actions */}
             <Group justify="flex-end">

--- a/src/pages/comics/project/[id]/ProjectWorkspace.module.scss
+++ b/src/pages/comics/project/[id]/ProjectWorkspace.module.scss
@@ -14,6 +14,72 @@
   }
 }
 
+/* ── Hero banner ───────────────────────────────────── */
+.heroBanner {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  max-height: 240px;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  background: light-dark(var(--mantine-color-gray-1), #2c2e33);
+  border: 1px solid light-dark(var(--mantine-color-gray-3), #373a40);
+  transition: opacity 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    opacity: 0.92;
+  }
+}
+
+.heroBannerImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.heroBannerEmpty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-style: dashed;
+  aspect-ratio: auto;
+  min-height: 120px;
+  max-height: none;
+
+  &:hover {
+    opacity: 1;
+    border-color: #fab005;
+  }
+}
+
+.heroBannerPlaceholder {
+  padding: 16px;
+}
+
+.heroBannerEdit {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  color: #f1f3f5;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 6px;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+
+  .heroBanner:hover & {
+    opacity: 1;
+  }
+}
+
 /* ── Header card ───────────────────────────────────── */
 .headerCard {
   background: light-dark(var(--mantine-color-gray-0), #25262b);

--- a/src/pages/comics/project/[id]/index.tsx
+++ b/src/pages/comics/project/[id]/index.tsx
@@ -1206,6 +1206,12 @@ function ProjectWorkspace() {
   // page already handles the no-renderable-panels case.
   const hasReadyPanelsWithImages = totalPanelCount > 0;
 
+  // Hero banner (the wide overview-page banner). Surfaced in the workspace
+  // header so the author can see at a glance whether it's set — previously
+  // it was only visible/editable from the Settings modal.
+  const heroImage = (project as any).heroImage as { id: number; url: string } | null | undefined;
+  const heroImagePosition = ((project as any).heroImagePosition as number | undefined) ?? 50;
+
   // Detail drawer is opened from the active chapter's panel grid, so we
   // only need to look there. Chapters other than the active one don't have
   // their panels loaded into the cache.
@@ -1307,6 +1313,42 @@ function ProjectWorkspace() {
               </Alert>
             );
           })()}
+
+          {/* ── Hero banner ─────────────────────────── */}
+          {/* The overview-page banner, shown here so the author can tell at
+              a glance whether it's set. Click anywhere to edit it (and the
+              cover) in Settings. */}
+          <div
+            className={clsx(styles.heroBanner, !heroImage && styles.heroBannerEmpty)}
+            onClick={() => openSettings()}
+            role="button"
+            tabIndex={0}
+          >
+            {heroImage?.url ? (
+              <>
+                <img
+                  src={getEdgeUrl(heroImage.url, { width: 1200 })}
+                  alt={`${project.name} hero banner`}
+                  className={styles.heroBannerImg}
+                  style={{ objectPosition: `center ${heroImagePosition}%` }}
+                />
+                <span className={styles.heroBannerEdit}>
+                  <IconSettings size={14} />
+                  Edit in settings
+                </span>
+              </>
+            ) : (
+              <Stack gap={2} align="center" className={styles.heroBannerPlaceholder}>
+                <IconPhoto size={22} style={{ color: '#909296' }} />
+                <Text size="sm" fw={600}>
+                  No hero banner set
+                </Text>
+                <Text size="xs" c="dimmed" ta="center">
+                  Add one in Settings — it headlines your comic&apos;s overview page
+                </Text>
+              </Stack>
+            )}
+          </div>
 
           {/* ── Header card ─────────────────────────── */}
           <div className={clsx(styles.headerCard, styles.gradientTopBorder)}>

--- a/src/pages/user/[username]/comics.tsx
+++ b/src/pages/user/[username]/comics.tsx
@@ -1,7 +1,8 @@
-import { Badge, Box, Button, Center, Container, Loader, Text } from '@mantine/core';
+import { Alert, Badge, Box, Button, Center, Container, Loader, Text } from '@mantine/core';
 import {
   IconAlertCircle,
   IconEyeOff,
+  IconInfoCircle,
   IconPhoto,
   IconPhotoOff,
   IconPlus,
@@ -69,17 +70,25 @@ function UserOwnComics() {
 
   return (
     <Container size="xl" py="md">
-      <div className="flex justify-between items-center mb-4">
+      <div className="flex justify-between items-center gap-4 mb-3">
         <h2 className="text-lg font-semibold">My Comics</h2>
         <Button
           leftSection={<IconPlus size={16} />}
           size="sm"
           component={Link}
           href="/comics/create"
+          className="shrink-0"
         >
           New Project
         </Button>
       </div>
+
+      <Alert variant="light" color="blue" icon={<IconInfoCircle size={18} />} mb="lg">
+        <Text size="sm">
+          Drafts and pending comics show up here on your profile&apos;s Comics page. Only you can
+          see them until you publish a chapter.
+        </Text>
+      </Alert>
 
       {isLoading ? (
         <div className="flex justify-center py-12">


### PR DESCRIPTION
- Surface the hero banner in the /comics/project/{id} workspace so authors can see at a glance whether it's set (shows a placeholder prompting to add one when unset); click opens Settings.
- Create Comic view: move Details (name first) above the Images section, since the name matters most.
- Lay the hero and cover selectors side by side; cover is a compact 160px card with its actions stacked beneath so "Pick from generator" is no longer clipped; cover buttons match the hero button style.
- Add an info Alert noting comics are saved as drafts and appear on the profile's Comics page until published — on both the Create view and the user's My Comics page.