### PR TITLE
fix(scanner): stop NULL xguardTriggered 500ing scanner_regex_shadow_results inserts (CH code 349)

### DIFF
--- a/src/server/services/__tests__/scanner-audit.regex-shadow.test.ts
+++ b/src/server/services/__tests__/scanner-audit.regex-shadow.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { LabelMatchResult } from '~/server/services/scanner-label-regex';
+import { buildRegexShadowRows } from '~/server/services/scanner-regex-shadow.builder';
+
+function regexResult(
+  label: string,
+  matched: boolean,
+  extra: Partial<LabelMatchResult> = {}
+): LabelMatchResult {
+  return {
+    label,
+    matched,
+    reason: matched ? 'trigger:test' : 'no-match',
+    matchedTerms: matched ? ['test'] : [],
+    normalizedText: 'normalized',
+    ...extra,
+  };
+}
+
+function xguardLabel(label: string, triggered: 0 | 1) {
+  return {
+    label,
+    labelValue: '',
+    score: 0.42,
+    threshold: 0.5,
+    triggered,
+    version: 'policy-abc',
+    matchedText: [] as string[],
+    matchedPositivePrompt: [] as string[],
+    matchedNegativePrompt: [] as string[],
+  };
+}
+
+const baseArgs = {
+  workflowId: 'wf-1',
+  contentHash: 'hash-1',
+  scanner: 'xguard_prompt' as const,
+  scannedAt: new Date('2026-06-24T00:00:00Z'),
+};
+
+describe('buildRegexShadowRows — NULL-safety on xguardTriggered (CH code 349 regression)', () => {
+  it('never emits NULL xguardTriggered when no XGuard label matches the regex label', () => {
+    // This is the exact bug shape: regex matched a label that XGuard has no
+    // row for → xg is undefined. The materialized column
+    // `xguardOnlyFire = (regexMatched = 0) AND (xguardTriggered = 1)` chokes on
+    // a NULL here (CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN).
+    const rows = buildRegexShadowRows({
+      ...baseArgs,
+      regexResults: [regexResult('csam', true)],
+      xguardLabels: [], // no matching XGuard label
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].xguardTriggered).toBe(0);
+    expect(rows[0].xguardTriggered).not.toBeNull();
+  });
+
+  it('guarantees every row has a non-null, 0|1 xguardTriggered for mixed inputs', () => {
+    const rows = buildRegexShadowRows({
+      ...baseArgs,
+      regexResults: [
+        regexResult('csam', true), // no xguard match → 0
+        regexResult('explicit', false), // no xguard match → 0
+        regexResult('suggestive', true), // xguard match triggered=1
+        regexResult('minor', false), // xguard match triggered=0
+      ],
+      xguardLabels: [xguardLabel('suggestive', 1), xguardLabel('minor', 0)],
+    });
+
+    expect(rows).toHaveLength(4);
+    for (const row of rows) {
+      expect(row.xguardTriggered === 0 || row.xguardTriggered === 1).toBe(true);
+      expect(row.xguardTriggered).not.toBeNull();
+    }
+    // Verify the simulated materialized-column expression never goes NULL.
+    for (const row of rows) {
+      // xguardOnlyFire = (regexMatched = 0) AND (xguardTriggered = 1)
+      const xguardOnlyFire = row.regexMatched === 0 && row.xguardTriggered === 1 ? 1 : 0;
+      expect(Number.isInteger(xguardOnlyFire)).toBe(true);
+    }
+  });
+
+  it('passes through XGuard triggered value when a label matches', () => {
+    const triggeredRow = buildRegexShadowRows({
+      ...baseArgs,
+      regexResults: [regexResult('suggestive', true)],
+      xguardLabels: [xguardLabel('suggestive', 1)],
+    })[0];
+    expect(triggeredRow.xguardTriggered).toBe(1);
+    expect(triggeredRow.xguardScore).toBe(0.42);
+    expect(triggeredRow.xguardThreshold).toBe(0.5);
+    expect(triggeredRow.xguardPolicyHash).toBe('policy-abc');
+
+    const notTriggeredRow = buildRegexShadowRows({
+      ...baseArgs,
+      regexResults: [regexResult('minor', false)],
+      xguardLabels: [xguardLabel('minor', 0)],
+    })[0];
+    expect(notTriggeredRow.xguardTriggered).toBe(0);
+  });
+
+  it('leaves the genuinely-nullable xguard columns NULL when unmatched (only triggered is coalesced)', () => {
+    const row = buildRegexShadowRows({
+      ...baseArgs,
+      regexResults: [regexResult('csam', true)],
+      xguardLabels: [],
+    })[0];
+    // These columns ARE Nullable in the table and have no non-null materialized
+    // dependency, so NULL is correct/intended here.
+    expect(row.xguardScore).toBeNull();
+    expect(row.xguardThreshold).toBeNull();
+    expect(row.xguardPolicyHash).toBeNull();
+    // ...but triggered must still be the coalesced 0.
+    expect(row.xguardTriggered).toBe(0);
+  });
+
+  it('maps regexMatched to 0|1 and preserves regex metadata', () => {
+    const rows = buildRegexShadowRows({
+      ...baseArgs,
+      regexResults: [regexResult('csam', true, { reason: 'phrase:x', matchedTerms: ['x'] })],
+      xguardLabels: [],
+    });
+    expect(rows[0].regexMatched).toBe(1);
+    expect(rows[0].regexReason).toBe('phrase:x');
+    expect(rows[0].regexMatchedTerms).toEqual(['x']);
+    expect(rows[0].scanner).toBe('xguard_prompt');
+    expect(rows[0].workflowId).toBe('wf-1');
+  });
+});

--- a/src/server/services/scanner-audit.service.ts
+++ b/src/server/services/scanner-audit.service.ts
@@ -20,7 +20,8 @@ import {
   type DerivedLabelInput,
   type DerivedLabelMode,
 } from '~/server/services/scanner-derived-labels.service';
-import { matchAllLabels, REGEX_VERSION } from '~/server/services/scanner-label-regex';
+import { matchAllLabels } from '~/server/services/scanner-label-regex';
+import { buildRegexShadowRows } from '~/server/services/scanner-regex-shadow.builder';
 
 /**
  * Age-classifier topK band names that count as minor. Stored in normalized
@@ -230,23 +231,13 @@ async function writeRegexShadowComparison(args: {
     const regexResults = matchAllLabels(args.positivePrompt);
     if (regexResults.length === 0) return;
 
-    const rows = regexResults.map((r) => {
-      const xg = args.xguardLabels.find((l) => l.label === r.label);
-      return {
-        workflowId: args.workflowId,
-        contentHash: args.contentHash,
-        scanner: args.scanner,
-        label: r.label,
-        regexMatched: r.matched ? 1 : 0,
-        regexReason: r.reason,
-        regexMatchedTerms: r.matchedTerms,
-        regexVersion: REGEX_VERSION,
-        xguardTriggered: xg ? xg.triggered : null,
-        xguardScore: xg?.score ?? null,
-        xguardThreshold: xg?.threshold ?? null,
-        xguardPolicyHash: xg?.version ?? null,
-        scannedAt: args.scannedAt,
-      };
+    const rows = buildRegexShadowRows({
+      workflowId: args.workflowId,
+      contentHash: args.contentHash,
+      scanner: args.scanner,
+      regexResults,
+      xguardLabels: args.xguardLabels,
+      scannedAt: args.scannedAt,
     });
 
     await clickhouse.insert({

--- a/src/server/services/scanner-regex-shadow.builder.ts
+++ b/src/server/services/scanner-regex-shadow.builder.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure row-builder for the `scanner_regex_shadow_results` ClickHouse table.
+ *
+ * Extracted from scanner-audit.service.ts so the NULL-safety invariant below
+ * is unit-testable without pulling in the clickhouse client / prisma / env
+ * (importing the service module boots the whole server DB chain).
+ */
+import type { LabelMatchResult } from '~/server/services/scanner-label-regex';
+import { REGEX_VERSION } from '~/server/services/scanner-label-regex';
+
+/** Minimal shape of an XGuard label needed to fill the shadow row. Matches the
+ *  relevant subset of scanner-audit.service's LabelRowSeed. */
+export type RegexShadowXGuardLabel = {
+  label: string;
+  triggered: 0 | 1;
+  score: number;
+  threshold: number | null;
+  version: string;
+};
+
+/** One row destined for `scanner_regex_shadow_results`. The `xguard*` columns
+ *  are Nullable in the table EXCEPT for what the materialized columns derive
+ *  from `xguardTriggered` — hence `xguardTriggered` is a non-nullable 0|1 here
+ *  (see buildRegexShadowRows for the rationale). */
+export type RegexShadowRow = {
+  workflowId: string;
+  contentHash: string;
+  scanner: 'xguard_prompt' | 'xguard_text';
+  label: string;
+  regexMatched: 0 | 1;
+  regexReason: string;
+  regexMatchedTerms: string[];
+  regexVersion: string;
+  xguardTriggered: 0 | 1;
+  xguardScore: number | null;
+  xguardThreshold: number | null;
+  xguardPolicyHash: string | null;
+  scannedAt: Date;
+};
+
+/**
+ * Build the `scanner_regex_shadow_results` rows from regex-match output joined
+ * to the XGuard labels. Pure (no I/O).
+ *
+ * INVARIANT: `xguardTriggered` is NEVER NULL. The table has a non-nullable
+ * MATERIALIZED column `xguardOnlyFire = (regexMatched = 0) AND
+ * (xguardTriggered = 1)` that does NOT coalesce (unlike `agree` /
+ * `regexOnlyFire`, which wrap it in `coalesce(xguardTriggered, 0)`). A NULL
+ * `xguardTriggered` makes that AND evaluate to NULL → ClickHouse fails the
+ * whole insert with code 349 (CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN). When no
+ * XGuard label matched the regex label, "XGuard did not trigger" → 0.
+ * (Schema rec: also coalesce in the `xguardOnlyFire` DDL — tracked separately,
+ * not changed in this PR.)
+ */
+export function buildRegexShadowRows(args: {
+  workflowId: string;
+  contentHash: string;
+  scanner: 'xguard_prompt' | 'xguard_text';
+  regexResults: LabelMatchResult[];
+  xguardLabels: RegexShadowXGuardLabel[];
+  scannedAt: Date;
+}): RegexShadowRow[] {
+  return args.regexResults.map((r) => {
+    const xg = args.xguardLabels.find((l) => l.label === r.label);
+    return {
+      workflowId: args.workflowId,
+      contentHash: args.contentHash,
+      scanner: args.scanner,
+      label: r.label,
+      regexMatched: r.matched ? 1 : 0,
+      regexReason: r.reason,
+      regexMatchedTerms: r.matchedTerms,
+      regexVersion: REGEX_VERSION,
+      xguardTriggered: xg ? xg.triggered : 0,
+      xguardScore: xg?.score ?? null,
+      xguardThreshold: xg?.threshold ?? null,
+      xguardPolicyHash: xg?.version ?? null,
+      scannedAt: args.scannedAt,
+    };
+  });
+}


### PR DESCRIPTION
Investigated two ClickHouse-error classes flagged on dp-prod (`system.query_log`). One is a real civitai code bug (fixed here); the other turned out to originate **outside** the codebase (Retool) and is documented for the dashboard owner.

## Bug 2 — `scanner_regex_shadow_results` INSERT fails with CH code 349 (FIXED)

**Exact failing query (from `system.query_log`, ~30-44/hr steady):**
```
INSERT INTO default.scanner_regex_shadow_results (workflowId, contentHash, scanner, label, regexMatched, regexReason, regexMatchedTerms, regexVersion, xguardTriggered, xguardScore, xguardThreshold, xguardPolicyHash, scannedAt) FORMAT JSONEachRow
```
```
Code: 349. DB::Exception: Cannot convert NULL value to non-Nullable type:
while executing 'FUNCTION _CAST(and(equals(regexMatched, 0), equals(xguardTriggered, 1)) :: 13, 'UInt8' : 14)
-> _CAST(and(equals(regexMatched, 0), equals(xguardTriggered, 1)), 'UInt8') UInt8 : 4'.
(CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN)
```

**Root cause** — `src/server/services/scanner-audit.service.ts` (`writeRegexShadowComparison`, the row-build at the old line ~244):
```ts
xguardTriggered: xg ? xg.triggered : null,
```
When a regex-matched label has no corresponding XGuard label (`xg === undefined`), the row carried `xguardTriggered: null`. The table has a **non-nullable MATERIALIZED column**:
```sql
xguardOnlyFire UInt8 MATERIALIZED (regexMatched = 0) AND (xguardTriggered = 1)
```
Unlike the sibling materialized columns (`agree`, `regexOnlyFire`) which wrap `coalesce(xguardTriggered, 0)`, `xguardOnlyFire` references `xguardTriggered` bare. Under CH three-valued logic `(... ) AND (NULL = 1)` → NULL, and CH can't CAST NULL into the non-nullable `UInt8` materialized column → the whole INSERT is rejected. The CAST in the exception is exactly the `xguardOnlyFire` expression.

**Fix (app-side)** — default `xguardTriggered` to `0` ("XGuard did not trigger") when no XGuard label matched, so the materialized column always resolves to a clean `0|1`. The genuinely-nullable `xguardScore` / `xguardThreshold` / `xguardPolicyHash` columns keep their NULLs (no non-null materialized dependency on them). The row builder was extracted into a pure `src/server/services/scanner-regex-shadow.builder.ts` so the NULL-safety invariant is unit-testable without booting the clickhouse/prisma/env chain.

**User-facing vs background:** background + fire-and-forget. Call path: orchestrator webhook (`src/pages/api/webhooks/text-moderation-result.ts`) → `recordXGuardScanFromWorkflow` → `void writeRegexShadowComparison(...)` (its own try/catch, `wait_for_async_insert: 0`). It does **not** 500 a user request; the fix stops the steady CH error stream / failed shadow-audit writes.

**Schema recommendation (NOT changed in this PR — separate DDL concern):** make the `xguardOnlyFire` materialized expression coalesce too (`(regexMatched = 0) AND (coalesce(xguardTriggered, 0) = 1)`), mirroring `agree`/`regexOnlyFire`, so a future NULL can't reintroduce this.

## Bug 1 — `Table default.undefined does not exist` (CH code 60): NOT a civitai bug

**Exact failing query:**
```
SELECT *
FROM default.userActivities
WHERE "type" IN('Banned', 'Muted')
AND targetUserId IN(undefined)
ORDER BY type
```
The literal `undefined` in `targetUserId IN(undefined)` is parsed by CH as a subquery table reference → "Table default.undefined does not exist".

**Source:** `system.query_log` attributes 100% of these (12/12 over 7 days) to **`user: retool_readonly`** (ClickHouse JDBC driver), zero from the civitai app. The query shape (`SELECT *`, double-quoted `"type"`, columnar `IN()`, `ORDER BY type`) is Retool's auto-generated SQL, and this query string does not exist anywhere in `src/`, `scripts/`, the `event-engine-common` submodule, or git history. **This is an external Retool dashboard with an unbound `targetUserId` parameter**, not application code — nothing to fix in this repo. Recommend the dashboard owner guard the query (skip when the user-id input is empty / cast to `IN ()`).

## Tests
- New `src/server/services/__tests__/scanner-audit.regex-shadow.test.ts` (5 tests): asserts `buildRegexShadowRows` never emits NULL `xguardTriggered` (the exact bug shape: regex match with no XGuard label), keeps the truly-nullable columns NULL, passes through matched XGuard values, and that the simulated `xguardOnlyFire` expression never goes NULL.
- `vitest run --project unit` on the new + existing scanner suites: **36 passed**.
- tsc: zero errors in the changed files. (Repo-baseline tsc errors in this worktree are all from the un-checked-out `event-engine-common` submodule + borrowed-node_modules `@civitai/client` SDK drift — none in or near the changed files.)