### PR TITLE
feat(app-blocks): card cleanup r2 — drop slot badge + author, View details as link button

### DIFF
--- a/src/components/Apps/AppBlockCard.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.browser.test.tsx
@@ -22,6 +22,12 @@ import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema'
  *  - Card cleanup: the install count is HIDDEN, the review indicator is hidden
  *    when reviewCount=0 (shown when >0), the mod-assigned category (+ icon) is
  *    shown, and the scopes were MOVED off the card face into the modal.
+ *  - Round-2 cleanup (2026-06): the slot/location badge and the "by {author}"
+ *    attribution line were DROPPED from the card face (launch is page-only →
+ *    slot badge is noise; both still on the detail page/modal), and the
+ *    "View details" CTA is now a LINK-STYLE (Mantine `variant="subtle"`) button
+ *    — still always rendered (never-empty-card invariant) and still opens the
+ *    modal.
  *
  * The install predicate is the shared `hasInstallSlot(manifest)` (slot-registry,
  * the single source of truth shared with the detail page) — it scans ALL targets
@@ -426,5 +432,143 @@ describe('AppBlockCard — 2026-06 card cleanup', () => {
     // The scope ids must NOT appear on the card face.
     expect(page.getByText('user:read:self', { exact: false }).query()).toBeNull();
     expect(page.getByText('ai:write:budgeted', { exact: false }).query()).toBeNull();
+  });
+});
+
+describe('AppBlockCard — round-2 card cleanup (slot badge + author dropped, View details link-styled)', () => {
+  // ── Slot/location badge REMOVED from the card face ──────────────────────────
+  // The launch is page-only, so the slot/location badge is noise. It was dropped
+  // from the card (still available on the detail page / modal). Assert NONE of
+  // the slot labels render — for each install-slot value AND the page-app value.
+  test('slot badge is NOT rendered (model.sidebar_top → no "Model sidebar")', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // The old slot-badge copy ("Model sidebar") must not appear anywhere.
+    expect(page.getByText('Model sidebar', { exact: false }).query()).toBeNull();
+  });
+
+  test('slot badge is NOT rendered (model.below_images → no "Below images")', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'model.below_images' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    expect(page.getByText('Below images', { exact: false }).query()).toBeNull();
+  });
+
+  test('slot badge is NOT rendered on a PAGE app (no slot label leaks)', async () => {
+    renderWithProviders(
+      <AppBlockCard block={pageBlock()} alreadySubscribed={false} onOpen={onOpen} canOpenPage={false} />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // None of the known slot labels render for a page app either.
+    expect(page.getByText('Model sidebar', { exact: false }).query()).toBeNull();
+    expect(page.getByText('Below images', { exact: false }).query()).toBeNull();
+    expect(page.getByText('Model actions', { exact: false }).query()).toBeNull();
+  });
+
+  // ── "by {author}" attribution line REMOVED from the card face ───────────────
+  // The publisher attribution ("by My App") was dropped from the card face
+  // (still shown on the detail page). Use a DISTINCTIVE author name so the
+  // assertion can't collide with the title (which is `manifest.name`).
+  test('"by {author}" attribution line is NOT rendered', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock(
+          { name: 'Cool Block' },
+          { appName: 'Acme Publisher Co' }
+        )}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // The card title (manifest.name) still renders…
+    await expect.element(page.getByText('Cool Block', { exact: false })).toBeInTheDocument();
+    // …but the "by {appName}" attribution does NOT. Match the literal "by …"
+    // copy AND the bare author name — neither should be on the card face.
+    expect(page.getByText(/by\s+Acme Publisher Co/i).query()).toBeNull();
+    expect(page.getByText('Acme Publisher Co', { exact: false }).query()).toBeNull();
+  });
+
+  test('"by {author}" falls back to appId when appName is missing — STILL not rendered', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({}, { appName: undefined as unknown as string, appId: 'acme-app-id' })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // Neither the "by acme-app-id" line nor the bare id leaks onto the face.
+    expect(page.getByText(/by\s+acme-app-id/i).query()).toBeNull();
+    expect(page.getByText('acme-app-id', { exact: false }).query()).toBeNull();
+  });
+
+  // ── "View details" is a LINK-STYLE (subtle) button ──────────────────────────
+  // Round-2: View details is de-emphasised vs the filled Install/Open-app run
+  // affordances — it's a Mantine `variant="subtle"` button (the Apps-dir
+  // link-button convention). Still a real button, still opens the modal, still
+  // ALWAYS rendered (the never-empty-card invariant). Mantine encodes the
+  // variant as the `data-variant` attribute on the button element.
+  test('"View details" is rendered as the link-style (subtle) variant', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    const viewDetails = page.getByRole('button', { name: /view details/i });
+    await expect.element(viewDetails).toBeInTheDocument();
+    // Mantine renders `variant` to the `data-variant` attribute.
+    expect(viewDetails.element().getAttribute('data-variant')).toBe('subtle');
+  });
+
+  test('link-styled "View details" still opens the modal on click (functionality preserved)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ targets: [{ slotId: 'model.sidebar_top' }] })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    const viewDetails = page.getByRole('button', { name: /view details/i });
+    await expect.element(viewDetails).toBeInTheDocument();
+    // Closed initially.
+    expect(page.getByTestId('details-modal').query()).toBeNull();
+    expect(viewDetails.element().getAttribute('data-variant')).toBe('subtle');
+    await viewDetails.click();
+
+    // The subtle button still drives the modal open.
+    await expect.element(page.getByTestId('details-modal')).toBeInTheDocument();
+    expect(detailsModalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ opened: true, blockId: 'app-1' })
+    );
+  });
+
+  test('"View details" is rendered on a PAGE app too (invariant preserved) and is link-styled', async () => {
+    renderWithProviders(
+      <AppBlockCard block={pageBlock()} alreadySubscribed={false} onOpen={onOpen} canOpenPage={false} />
+    );
+
+    const viewDetails = page.getByRole('button', { name: /view details/i });
+    await expect.element(viewDetails).toBeInTheDocument();
+    expect(viewDetails.element().getAttribute('data-variant')).toBe('subtle');
   });
 });

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -27,8 +27,13 @@ import type { AvailableBlock } from '~/server/schema/blocks/subscription.schema'
 
 /**
  * Marketplace card for an approved app block. Renders the block name,
- * a short description (from manifest.description), the slot it targets,
- * publisher/app attribution, install count, and an install/manage CTA.
+ * a short description (from manifest.description), the mod-assigned category,
+ * and the action CTAs (View details / Open app / Install/Manage).
+ *
+ * Round-2 marketplace pass (2026-06): the slot/location badge and the
+ * "by {author}" attribution line were dropped from the card face (the launch
+ * is page-only, so the slot badge is noise) — both still live on the detail
+ * page / modal. "View details" is a link-style (subtle) button.
  *
  * The install CTA opens the per-app settings panel; we delegate the open
  * action to the parent via `onOpen` so the page owns the modal lifecycle.
@@ -49,19 +54,6 @@ export interface AppBlockCardProps {
    * "Open app" link to `/apps/run/<slug>` is shown. Dark today (flag mod-only).
    */
   canOpenPage?: boolean;
-}
-
-function slotLabel(slotId?: string): string {
-  switch (slotId) {
-    case 'model.sidebar_top':
-      return 'Model sidebar';
-    case 'model.below_images':
-      return 'Below images';
-    case 'model.actions_extra':
-      return 'Model actions';
-    default:
-      return slotId ?? 'Unknown slot';
-  }
 }
 
 /**
@@ -109,7 +101,6 @@ export function AppBlockCard({
   };
   const [busy] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
-  const slot = manifest.targets?.[0]?.slotId;
   // Show Install ONLY for an app that installs into a model/in-context slot.
   // A page app (target slot `app.page`) is STATELESS — installModel `'none'` in
   // the slot registry — so it has no `block_user_subscriptions` install row and
@@ -151,14 +142,8 @@ export function AppBlockCard({
                 {manifest.name ?? block.blockId}
               </Title>
             </Anchor>
-            <Text size="xs" c="dimmed">
-              by {block.appName ?? block.appId}
-            </Text>
           </Stack>
           <Stack gap={4} align="flex-end">
-            <Badge variant="light" color="blue" size="sm">
-              {slotLabel(slot)}
-            </Badge>
             {/* Mod-assigned marketplace category (+ its icon). NULL until a mod
                 sets one → no chip. The icon comes from CATEGORY_ICONS (generic
                 tag fallback for an unknown/legacy value). */}
@@ -224,8 +209,10 @@ export function AppBlockCard({
                 (this is what guarantees the never-empty-card invariant; it
                 supersedes the #2747 page-link "View" fallback). Opens the
                 details modal (description, screenshots, recent reviews, scopes).
-                A button, not a link, so it doesn't navigate away from the grid. */}
-            <Button size="xs" variant="light" onClick={() => setDetailsOpen(true)}>
+                A button, not a link, so it doesn't navigate away from the grid.
+                Styled link-subtle (variant="subtle") — round-2 marketplace pass:
+                de-emphasised vs the filled Install/Open-app run affordances. */}
+            <Button size="xs" variant="subtle" onClick={() => setDetailsOpen(true)}>
               View details
             </Button>
             {/* W10 — "Open app" link to the full-page route, shown only when the


### PR DESCRIPTION
Round-2 marketplace App Block card feedback — UI-only, scoped to `AppBlockCard.tsx` + its browser test.

## Changes
1. **Slot badge removed** from the card face — the launch is page-only, so the slot/location badge is noise. Drops the now-unused `slotLabel()` helper and the `slot` local.
2. **"by {author}" attribution line removed** from the card face.
3. **"View details" is now a link-style button** — `variant="subtle"` (the Apps-dir link-button convention) instead of `variant="light"`. Still **always rendered** (it carries the never-empty-card invariant from #2747/#2752) and still opens the `AppDetailsModal` on click.

Both the slot and the author attribution still live on the detail page / modal — nothing is lost, just de-noised on the grid card.

## Tests (`AppBlockCard.browser.test.tsx`)
New `round-2 card cleanup` describe block:
- Slot badge **NOT** rendered — asserted for `model.sidebar_top`, `model.below_images`, and a page app (no slot label leaks).
- `"by {author}"` **NOT** rendered — both the `appName` path and the `appId` fallback (distinctive author name so it can't collide with the title).
- `"View details"` rendered as `data-variant="subtle"` (Mantine emits `variant` to `data-variant`), still opens the modal on click, and is present on a page app too (invariant preserved).

Existing card tests retained (install count hidden, category + icon shown, review-indicator-@0 hidden, scopes off-face); none referenced the removed badge/author, so no retargeting was needed.

## Verification
- **26/26** component tests pass (`vitest run --project component`).
- **Mutation-sanity:** re-adding the slot badge / author line or reverting the variable to `variant="light"` fails 7 tests — confirmed.
- Scoped `tsc --noEmit` (full project, 8GB heap) → **zero** errors on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
