### PR TITLE
feat(app-blocks): tabs-style apps sub-nav + shared AppsPageLayout (stop subnav shift)

### DIFF
--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -10,8 +10,12 @@ import { AppsSubNav } from '~/components/Apps/AppsSubNav';
  * position on every apps page. Before this, each page hand-rolled its own
  * `Container size=… py=…` + a per-page title block placed ABOVE or AROUND the
  * sub-nav, so the tabs jumped around as you navigated between surfaces. This
- * layout fixes the tabs as the FIRST element of a sticky header region — so they
- * never move — and renders the optional per-page title/actions BELOW them.
+ * layout fixes the tabs as the FIRST element of the page header region — so they
+ * land in the same vertical position every time — and renders the optional
+ * per-page title/actions BELOW them. (No sticky positioning: the requirement is
+ * a CONSISTENT position across pages, which the uniform "tabs first" order
+ * already delivers; pinning the band on scroll risks colliding with the global
+ * app-shell header and was unverified.)
  *
  * Each page wraps its body in `<AppsPageLayout …>{body}</AppsPageLayout>`,
  * dropping its own `Container` + ad-hoc sub-nav placement. The per-page title,
@@ -44,7 +48,7 @@ export function AppsPageLayout({
     <Container size={size} py="md">
       <Stack gap="lg">
         {/*
-          Sticky header region. The sub-nav tabs are the FIRST child here and
+          Page header region. The sub-nav tabs are the FIRST child here and
           carry no leading content, so they land in the same spot on every page
           regardless of whether a per-page title is present. The title/actions
           render BELOW the tabs (never above), which is what keeps the tabs from
@@ -52,13 +56,9 @@ export function AppsPageLayout({
         */}
         <Stack
           gap="md"
-          pos="sticky"
-          top={0}
           py="sm"
           style={(theme) => ({
-            zIndex: 2,
-            backgroundColor: 'var(--mantine-color-body)',
-            // Hairline divider so sticky content reads as a header band.
+            // Hairline divider so the header reads as a band.
             borderBottom: `1px solid ${theme.colors.dark[4]}`,
           })}
         >

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -1,0 +1,85 @@
+import { Container, Group, Stack, Text, Title } from '@mantine/core';
+import type { MantineSize } from '@mantine/core';
+import type { ReactNode } from 'react';
+import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+
+/**
+ * Shared chrome for every `/apps/*` surface.
+ *
+ * THE POINT: the {@link AppsSubNav} tabs must sit in the IDENTICAL vertical
+ * position on every apps page. Before this, each page hand-rolled its own
+ * `Container size=… py=…` + a per-page title block placed ABOVE or AROUND the
+ * sub-nav, so the tabs jumped around as you navigated between surfaces. This
+ * layout fixes the tabs as the FIRST element of a sticky header region — so they
+ * never move — and renders the optional per-page title/actions BELOW them.
+ *
+ * Each page wraps its body in `<AppsPageLayout …>{body}</AppsPageLayout>`,
+ * dropping its own `Container` + ad-hoc sub-nav placement. The per-page title,
+ * subtitle and right-aligned header actions become props so the header geometry
+ * is uniform; only the content slot differs.
+ *
+ * Flag-gating (`features.appBlocks`) + any per-page access redirect stay on the
+ * page (`getServerSideProps` / the in-component `NotFound` guard) — this layout
+ * is presentational chrome only and assumes the page already passed its gate.
+ */
+export function AppsPageLayout({
+  title,
+  subtitle,
+  actions,
+  size = 'xl',
+  children,
+}: {
+  /** Page heading (omit for a header with just the tabs, e.g. the marketplace). */
+  title?: ReactNode;
+  /** Optional dimmed sub-heading rendered under the title. */
+  subtitle?: ReactNode;
+  /** Right-aligned header controls (e.g. a "Submit a new app" button). */
+  actions?: ReactNode;
+  /** Container width — pages keep their prior size (`sm` for Submit, etc.). */
+  size?: MantineSize;
+  children: ReactNode;
+}) {
+  const hasHeader = Boolean(title || subtitle || actions);
+  return (
+    <Container size={size} py="md">
+      <Stack gap="lg">
+        {/*
+          Sticky header region. The sub-nav tabs are the FIRST child here and
+          carry no leading content, so they land in the same spot on every page
+          regardless of whether a per-page title is present. The title/actions
+          render BELOW the tabs (never above), which is what keeps the tabs from
+          shifting vertically between surfaces.
+        */}
+        <Stack
+          gap="md"
+          pos="sticky"
+          top={0}
+          py="sm"
+          style={(theme) => ({
+            zIndex: 2,
+            backgroundColor: 'var(--mantine-color-body)',
+            // Hairline divider so sticky content reads as a header band.
+            borderBottom: `1px solid ${theme.colors.dark[4]}`,
+          })}
+        >
+          <AppsSubNav />
+          {hasHeader && (
+            <Group justify="space-between" align="flex-end" wrap="nowrap" gap="md">
+              <Stack gap={4} style={{ minWidth: 0 }}>
+                {title && <Title order={2}>{title}</Title>}
+                {subtitle && (
+                  <Text c="dimmed" size="sm">
+                    {subtitle}
+                  </Text>
+                )}
+              </Stack>
+              {actions && <div style={{ flexShrink: 0 }}>{actions}</div>}
+            </Group>
+          )}
+        </Stack>
+
+        {children}
+      </Stack>
+    </Container>
+  );
+}

--- a/src/components/Apps/AppsSubNav.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.browser.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 import { page } from 'vitest/browser';
-import { AppsSubNavView, type AppsNavSummary } from '~/components/Apps/AppsSubNav';
+import {
+  activeAppsTab,
+  AppsSubNavView,
+  isActiveAppsRoute,
+  type AppsNavSummary,
+} from '~/components/Apps/AppsSubNav';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -9,8 +14,16 @@ import { renderWithProviders } from '../../../test/component-setup';
 // query / router that the `AppsSubNav` container wires. We drive the booleans
 // directly and assert which tabs render.
 //
+// The sub-nav is now Mantine navigation **Tabs**: each tab is a real Next
+// `Link` (`component={Link}`) so the element is an `<a href>` with
+// `role="tab"` + `aria-selected`. We therefore target `role: 'tab'` (not
+// `'link'`) and assert the active tab via `aria-selected="true"`. Navigation is
+// the anchor's `href` contract — clicking a Next `<Link>` anchor in browser mode
+// would trigger a real page navigation, so we assert the `href` target each tab
+// points at (the click-destination) rather than firing the click.
+//
 // NOTE: this env does not load `@mantine/core/styles.css`, so we assert
-// presence / `aria-current` — never computed styles.
+// presence / ARIA attributes / href — never computed styles.
 
 const NONE: AppsNavSummary = {
   hasInstalls: false,
@@ -19,65 +32,65 @@ const NONE: AppsNavSummary = {
   isReviewer: false,
 };
 
-function link(name: string) {
-  return page.getByRole('link', { name });
+function tab(name: string) {
+  return page.getByRole('tab', { name });
 }
 
-describe('AppsSubNavView (conditional sub-nav)', () => {
+describe('AppsSubNavView (conditional sub-nav tabs)', () => {
   test('Marketplace + Submit are ALWAYS present (even with an all-false summary)', async () => {
     renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
-    await expect.element(link('Marketplace')).toBeInTheDocument();
-    await expect.element(link('Submit')).toBeInTheDocument();
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    await expect.element(tab('Submit')).toBeInTheDocument();
   });
 
   test('with an all-false summary the conditional tabs are hidden', async () => {
     renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
     // None of the conditional tabs should render.
-    expect(link('Installed').elements()).toHaveLength(0);
-    expect(link('My submissions').elements()).toHaveLength(0);
-    expect(link('Revenue').elements()).toHaveLength(0);
-    expect(link('Review').elements()).toHaveLength(0);
+    expect(tab('Installed').elements()).toHaveLength(0);
+    expect(tab('My submissions').elements()).toHaveLength(0);
+    expect(tab('Revenue').elements()).toHaveLength(0);
+    expect(tab('Review').elements()).toHaveLength(0);
   });
 
   test('Installed shows ONLY when hasInstalls', async () => {
     renderWithProviders(
       <AppsSubNavView summary={{ ...NONE, hasInstalls: true }} currentPath="/apps" />
     );
-    await expect.element(link('Installed')).toBeInTheDocument();
+    await expect.element(tab('Installed')).toBeInTheDocument();
     // The other conditionals stay hidden.
-    expect(link('My submissions').elements()).toHaveLength(0);
-    expect(link('Revenue').elements()).toHaveLength(0);
-    expect(link('Review').elements()).toHaveLength(0);
+    expect(tab('My submissions').elements()).toHaveLength(0);
+    expect(tab('Revenue').elements()).toHaveLength(0);
+    expect(tab('Review').elements()).toHaveLength(0);
   });
 
   test('My submissions shows ONLY when hasSubmissions', async () => {
     renderWithProviders(
       <AppsSubNavView summary={{ ...NONE, hasSubmissions: true }} currentPath="/apps" />
     );
-    await expect.element(link('My submissions')).toBeInTheDocument();
-    expect(link('Installed').elements()).toHaveLength(0);
-    expect(link('Revenue').elements()).toHaveLength(0);
-    expect(link('Review').elements()).toHaveLength(0);
+    await expect.element(tab('My submissions')).toBeInTheDocument();
+    expect(tab('Installed').elements()).toHaveLength(0);
+    expect(tab('Revenue').elements()).toHaveLength(0);
+    expect(tab('Review').elements()).toHaveLength(0);
   });
 
   test('Revenue shows ONLY when hasApprovedApps', async () => {
     renderWithProviders(
       <AppsSubNavView summary={{ ...NONE, hasApprovedApps: true }} currentPath="/apps" />
     );
-    await expect.element(link('Revenue')).toBeInTheDocument();
-    expect(link('Installed').elements()).toHaveLength(0);
-    expect(link('My submissions').elements()).toHaveLength(0);
-    expect(link('Review').elements()).toHaveLength(0);
+    await expect.element(tab('Revenue')).toBeInTheDocument();
+    expect(tab('Installed').elements()).toHaveLength(0);
+    expect(tab('My submissions').elements()).toHaveLength(0);
+    expect(tab('Review').elements()).toHaveLength(0);
   });
 
   test('Review shows ONLY when isReviewer', async () => {
     renderWithProviders(
       <AppsSubNavView summary={{ ...NONE, isReviewer: true }} currentPath="/apps" />
     );
-    await expect.element(link('Review')).toBeInTheDocument();
-    expect(link('Installed').elements()).toHaveLength(0);
-    expect(link('My submissions').elements()).toHaveLength(0);
-    expect(link('Revenue').elements()).toHaveLength(0);
+    await expect.element(tab('Review')).toBeInTheDocument();
+    expect(tab('Installed').elements()).toHaveLength(0);
+    expect(tab('My submissions').elements()).toHaveLength(0);
+    expect(tab('Revenue').elements()).toHaveLength(0);
   });
 
   test('an all-true summary shows every tab', async () => {
@@ -89,22 +102,96 @@ describe('AppsSubNavView (conditional sub-nav)', () => {
     };
     renderWithProviders(<AppsSubNavView summary={ALL} currentPath="/apps" />);
     for (const name of ['Marketplace', 'Submit', 'Installed', 'My submissions', 'Revenue', 'Review']) {
-      await expect.element(link(name)).toBeInTheDocument();
+      await expect.element(tab(name)).toBeInTheDocument();
     }
   });
+});
 
-  test('the active route is marked aria-current=page (and /apps does not light up on a child route)', async () => {
-    // On a child route, the child tab is current and Marketplace (/apps) is NOT
-    // (exact-match guard) — proves the active-route highlight + the /apps prefix
-    // guard at once.
+describe('AppsSubNavView (active tab reflects the current route)', () => {
+  test('the current route is the selected tab (aria-selected=true)', async () => {
     renderWithProviders(
       <AppsSubNavView summary={{ ...NONE, hasInstalls: true }} currentPath="/apps/installed" />
     );
-    // Await the render to settle before reading attributes synchronously.
-    await expect.element(link('Installed')).toBeInTheDocument();
-    const installed = link('Installed').element();
-    expect(installed.getAttribute('aria-current')).toBe('page');
-    const marketplace = link('Marketplace').element();
-    expect(marketplace.getAttribute('aria-current')).toBeNull();
+    await expect.element(tab('Installed')).toBeInTheDocument();
+    const installed = tab('Installed').element();
+    expect(installed.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('/apps (Marketplace) is NOT selected on a child route — exact-match guard', async () => {
+    // On a child route the child tab is selected and Marketplace (/apps) is NOT
+    // (the exact-match guard), proving the active-route highlight + the /apps
+    // prefix guard at once.
+    renderWithProviders(
+      <AppsSubNavView summary={{ ...NONE, hasInstalls: true }} currentPath="/apps/installed" />
+    );
+    await expect.element(tab('Installed')).toBeInTheDocument();
+    const marketplace = tab('Marketplace').element();
+    expect(marketplace.getAttribute('aria-selected')).toBe('false');
+  });
+
+  test('Marketplace IS selected on the exact /apps route', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    const marketplace = tab('Marketplace').element();
+    expect(marketplace.getAttribute('aria-selected')).toBe('true');
+    const submit = tab('Submit').element();
+    expect(submit.getAttribute('aria-selected')).toBe('false');
+  });
+
+  test('Submit tab is selected on /apps/submit (and Marketplace is not)', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps/submit" />);
+    await expect.element(tab('Submit')).toBeInTheDocument();
+    expect(tab('Submit').element().getAttribute('aria-selected')).toBe('true');
+    expect(tab('Marketplace').element().getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+describe('AppsSubNavView (each tab navigates to its route)', () => {
+  // Each tab is a Next `<Link>` anchor — the `href` IS the navigation target a
+  // click follows. Asserting the href is the deterministic equivalent of "a
+  // click navigates to the right route" for a link-based tab.
+  test('every visible tab points its href at the matching /apps route', async () => {
+    const ALL: AppsNavSummary = {
+      hasInstalls: true,
+      hasSubmissions: true,
+      hasApprovedApps: true,
+      isReviewer: true,
+    };
+    renderWithProviders(<AppsSubNavView summary={ALL} currentPath="/apps" />);
+    const cases: Array<[string, string]> = [
+      ['Marketplace', '/apps'],
+      ['Submit', '/apps/submit'],
+      ['Installed', '/apps/installed'],
+      ['My submissions', '/apps/my-submissions'],
+      ['Revenue', '/apps/revenue'],
+      ['Review', '/apps/review'],
+    ];
+    for (const [name, href] of cases) {
+      await expect.element(tab(name)).toBeInTheDocument();
+      expect(tab(name).element().getAttribute('href')).toBe(href);
+    }
+  });
+});
+
+describe('isActiveAppsRoute / activeAppsTab (route-matching helpers)', () => {
+  test('/apps matches ONLY the exact marketplace route', () => {
+    expect(isActiveAppsRoute('/apps', '/apps')).toBe(true);
+    expect(isActiveAppsRoute('/apps', '/apps/installed')).toBe(false);
+    expect(isActiveAppsRoute('/apps', '/apps/run/foo')).toBe(false);
+  });
+
+  test('sub-routes match exact + deeper child paths (prefix)', () => {
+    expect(isActiveAppsRoute('/apps/installed', '/apps/installed')).toBe(true);
+    expect(isActiveAppsRoute('/apps/installed', '/apps/installed/123')).toBe(true);
+    expect(isActiveAppsRoute('/apps/installed', '/apps/installedX')).toBe(false);
+    expect(isActiveAppsRoute('/apps/submit', '/apps/installed')).toBe(false);
+  });
+
+  test('activeAppsTab resolves the active tab href, or null when none matches', () => {
+    expect(activeAppsTab('/apps')).toBe('/apps');
+    expect(activeAppsTab('/apps/submit')).toBe('/apps/submit');
+    expect(activeAppsTab('/apps/revenue')).toBe('/apps/revenue');
+    // A deep /apps/* route with no corresponding tab → no active tab.
+    expect(activeAppsTab('/apps/run/some-slug')).toBeNull();
   });
 });

--- a/src/components/Apps/AppsSubNav.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.browser.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import {
   activeAppsTab,
   AppsSubNavView,
@@ -14,13 +14,19 @@ import { renderWithProviders } from '../../../test/component-setup';
 // query / router that the `AppsSubNav` container wires. We drive the booleans
 // directly and assert which tabs render.
 //
-// The sub-nav is now Mantine navigation **Tabs**: each tab is a real Next
-// `Link` (`component={Link}`) so the element is an `<a href>` with
-// `role="tab"` + `aria-selected`. We therefore target `role: 'tab'` (not
-// `'link'`) and assert the active tab via `aria-selected="true"`. Navigation is
-// the anchor's `href` contract — clicking a Next `<Link>` anchor in browser mode
-// would trigger a real page navigation, so we assert the `href` target each tab
-// points at (the click-destination) rather than firing the click.
+// The sub-nav uses the Mantine **Tabs** LOOK but is wrapped in a real
+// `<nav aria-label="App sections">` so it's exposed as a navigation LANDMARK
+// (cross-page nav, not a single-page tab panel). Each tab is a real Next
+// `Link` (`renderRoot`) so the element is an `<a href>` with `role="tab"` +
+// `aria-selected`. We therefore target `role: 'tab'` (not `'link'`) and assert
+// the active tab via `aria-selected="true"`, and assert the wrapping
+// `role="navigation"` landmark carries the `App sections` accessible name.
+// Navigation is the anchor's `href` contract — clicking a Next `<Link>` anchor
+// in browser mode would trigger a real page navigation, so we assert the `href`
+// target each tab points at (the click-destination) rather than firing the
+// click. Arrow keys are configured NOT to auto-activate
+// (`activateTabWithKeyboard={false}`) so a keyboard user can scan the nav
+// without being yanked to another page.
 //
 // NOTE: this env does not load `@mantine/core/styles.css`, so we assert
 // presence / ARIA attributes / href — never computed styles.
@@ -107,6 +113,28 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
   });
 });
 
+describe('AppsSubNavView (navigation landmark)', () => {
+  // HIGH-severity a11y regression the audit flagged: converting to Tabs dropped
+  // the `role="navigation"` landmark, leaving a bare `role="tablist"` (an ARIA
+  // anti-pattern for cross-page navigation). The tabs are wrapped in a
+  // `<nav aria-label="App sections">` so the landmark is restored while the Tabs
+  // LOOK (active underline) is preserved. Reverting the nav-wrap fails this.
+  test('the sub-nav is exposed as a `navigation` landmark named "App sections"', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    const nav = page.getByRole('navigation', { name: 'App sections' });
+    await expect.element(nav).toBeInTheDocument();
+    // The accessible name is on the <nav> landmark, NOT on the tablist.
+    expect(nav.element().tagName.toLowerCase()).toBe('nav');
+  });
+
+  test('the tablist itself does NOT carry the `App sections` name (it moved to the nav)', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    await expect.element(page.getByRole('tablist')).toBeInTheDocument();
+    const tablist = page.getByRole('tablist').element();
+    expect(tablist.getAttribute('aria-label')).not.toBe('App sections');
+  });
+});
+
 describe('AppsSubNavView (active tab reflects the current route)', () => {
   test('the current route is the selected tab (aria-selected=true)', async () => {
     renderWithProviders(
@@ -170,6 +198,61 @@ describe('AppsSubNavView (each tab navigates to its route)', () => {
       await expect.element(tab(name)).toBeInTheDocument();
       expect(tab(name).element().getAttribute('href')).toBe(href);
     }
+  });
+});
+
+describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () => {
+  // MEDIUM a11y regression: Mantine's default `activateTabWithKeyboard` makes
+  // ArrowLeft/Right ACTIVATE the focused tab — on these real `<Link>` anchors
+  // that synthesizes a click → full page navigation, so a keyboard user can't
+  // arrow across the nav to read it. We set `activateTabWithKeyboard={false}` so
+  // arrow keys move focus only and the SELECTED tab (the active route) doesn't
+  // change as you scan.
+  //
+  // Observable: the active tab is marked `aria-selected="true"` and is bound to
+  // `Tabs.value` (= the current route, NOT keyboard focus). With auto-activation
+  // ON, arrowing would move `aria-selected` onto the newly-focused tab; with it
+  // OFF, selection stays anchored on the route's tab. We assert focus moves
+  // (keyboard reachability) while selection stays put. The mutation
+  // `activateTabWithKeyboard={true}` flips selection onto the focused tab and
+  // fails this test.
+  test('ArrowRight moves focus but does NOT change the selected tab (no auto-activate)', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    // Wait for the async render before reaching into the DOM synchronously.
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+
+    const marketplace = tab('Marketplace').element() as HTMLElement;
+    const submit = tab('Submit').element() as HTMLElement;
+
+    // Marketplace (= current route) is the selected tab; Submit is not.
+    expect(marketplace.getAttribute('aria-selected')).toBe('true');
+    expect(submit.getAttribute('aria-selected')).toBe('false');
+
+    // Focus the first tab, then arrow to the next.
+    marketplace.focus();
+    expect(document.activeElement).toBe(marketplace);
+    await userEvent.keyboard('{ArrowRight}');
+
+    // Focus moved to Submit (keyboard-reachable scan)…
+    expect(document.activeElement).toBe(submit);
+    // …but selection (aria-selected, driven by the route) did NOT follow focus.
+    // If activateTabWithKeyboard were on, Submit would now be aria-selected=true.
+    expect(submit.getAttribute('aria-selected')).toBe('false');
+    expect(marketplace.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('Enter/Space still activate: the focused tab is a real anchor with the right href', async () => {
+    // We don't fire Enter (it would trigger a real navigation in browser mode);
+    // instead we assert the keyboard-activation contract structurally — the
+    // focusable element IS the `<a href>` the route points at, so native
+    // anchor activation (Enter) navigates correctly even with arrow-activation off.
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    await expect.element(tab('Submit')).toBeInTheDocument();
+    const submit = tab('Submit').element() as HTMLElement;
+    submit.focus();
+    expect(document.activeElement).toBe(submit);
+    expect(submit.tagName.toLowerCase()).toBe('a');
+    expect(submit.getAttribute('href')).toBe('/apps/submit');
   });
 });
 

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, ScrollArea } from '@mantine/core';
+import { ScrollArea, Tabs } from '@mantine/core';
 import {
   IconBuildingStore,
   IconCurrencyDollar,
@@ -92,9 +92,25 @@ export function isActiveAppsRoute(href: string, current: string): boolean {
 }
 
 /**
+ * The href of the tab that should be active for `currentPath`, or `null` when
+ * none matches (a deep `/apps/*` route with no corresponding tab leaves the bar
+ * with no active tab rather than mis-lighting one). Drives `Tabs.value`.
+ */
+export function activeAppsTab(currentPath: string): string | null {
+  return SUB_NAV_LINKS.find((l) => isActiveAppsRoute(l.href, currentPath))?.href ?? null;
+}
+
+/**
  * Pure presentational sub-nav. Kept separate from the data-fetching container
  * so it can be rendered in isolation (props-only) under test and reused if a
  * caller already has the summary in hand.
+ *
+ * Rendered as Mantine navigation **Tabs**: each tab is a real Next `Link`
+ * (`component={Link}` — keyboard / middle-click / SEO affordances of an anchor),
+ * and `Tabs.value` (the active href) drives the active styling + `aria-selected`.
+ * Navigation is the anchor's job; there's no `onChange` (the route is the single
+ * source of truth, so clicking just follows the link and the new route lights
+ * the matching tab).
  */
 export function AppsSubNavView({
   summary,
@@ -104,28 +120,30 @@ export function AppsSubNavView({
   currentPath: string;
 }) {
   const links = SUB_NAV_LINKS.filter((l) => l.visible(summary));
+  const active = activeAppsTab(currentPath);
   return (
     <ScrollArea type="never" w="100%">
-      <Group gap="xs" wrap="nowrap" role="navigation" aria-label="App sections">
-        {links.map((link) => {
-          const active = isActiveAppsRoute(link.href, currentPath);
-          const Icon = link.icon;
-          return (
-            <Button
-              key={link.href}
-              component={Link}
-              href={link.href}
-              size="compact-sm"
-              radius="xl"
-              variant={active ? 'filled' : 'default'}
-              aria-current={active ? 'page' : undefined}
-              leftSection={<Icon size={15} />}
-            >
-              {link.label}
-            </Button>
-          );
-        })}
-      </Group>
+      <Tabs value={active} variant="default" w="100%">
+        <Tabs.List aria-label="App sections" style={{ flexWrap: 'nowrap' }}>
+          {links.map((link) => {
+            const Icon = link.icon;
+            return (
+              <Tabs.Tab
+                key={link.href}
+                value={link.href}
+                // `renderRoot` (not `component`) is the Mantine-blessed way to
+                // mount a typed Next `<Link>` as the polymorphic root without the
+                // generic-component TS2322 — keeps the tab a real anchor (href,
+                // keyboard, middle-click) while Tabs owns role/aria-selected.
+                renderRoot={(props) => <Link href={link.href} {...props} />}
+                leftSection={<Icon size={15} />}
+              >
+                {link.label}
+              </Tabs.Tab>
+            );
+          })}
+        </Tabs.List>
+      </Tabs>
     </ScrollArea>
   );
 }

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea, Tabs } from '@mantine/core';
+import { Box, ScrollArea, Tabs } from '@mantine/core';
 import {
   IconBuildingStore,
   IconCurrencyDollar,
@@ -105,12 +105,22 @@ export function activeAppsTab(currentPath: string): string | null {
  * so it can be rendered in isolation (props-only) under test and reused if a
  * caller already has the summary in hand.
  *
- * Rendered as Mantine navigation **Tabs**: each tab is a real Next `Link`
- * (`component={Link}` — keyboard / middle-click / SEO affordances of an anchor),
- * and `Tabs.value` (the active href) drives the active styling + `aria-selected`.
- * Navigation is the anchor's job; there's no `onChange` (the route is the single
- * source of truth, so clicking just follows the link and the new route lights
- * the matching tab).
+ * Rendered with the Mantine navigation **Tabs** LOOK (active underline driven by
+ * `Tabs.value`), but wrapped in a real `<nav aria-label="App sections">` so it's
+ * exposed as a navigation LANDMARK — this is cross-page navigation, not a
+ * single-page tab panel, so the landmark (not a bare `role="tablist"`) is the
+ * correct semantics. Each tab is a real Next `Link` (`renderRoot` → `<a href>`)
+ * so keyboard / middle-click / SEO affordances of an anchor survive while Tabs
+ * owns the active styling + `aria-selected`. Navigation is the anchor's job;
+ * there's no `onChange` (the route is the single source of truth, so clicking
+ * just follows the link and the new route lights the matching tab).
+ *
+ * `activateTabWithKeyboard={false}`: Mantine's default arrow-key handler
+ * synthesizes a `.click()` on the focused tab, which on these real `<Link>`
+ * anchors triggers a full page navigation — so a keyboard user can't ARROW to
+ * scan the nav without being yanked to another page. Disabling it lets arrow
+ * keys move focus only; Enter/Space on a focused tab still navigates natively
+ * (it's a real anchor).
  */
 export function AppsSubNavView({
   summary,
@@ -122,29 +132,31 @@ export function AppsSubNavView({
   const links = SUB_NAV_LINKS.filter((l) => l.visible(summary));
   const active = activeAppsTab(currentPath);
   return (
-    <ScrollArea type="never" w="100%">
-      <Tabs value={active} variant="default" w="100%">
-        <Tabs.List aria-label="App sections" style={{ flexWrap: 'nowrap' }}>
-          {links.map((link) => {
-            const Icon = link.icon;
-            return (
-              <Tabs.Tab
-                key={link.href}
-                value={link.href}
-                // `renderRoot` (not `component`) is the Mantine-blessed way to
-                // mount a typed Next `<Link>` as the polymorphic root without the
-                // generic-component TS2322 — keeps the tab a real anchor (href,
-                // keyboard, middle-click) while Tabs owns role/aria-selected.
-                renderRoot={(props) => <Link href={link.href} {...props} />}
-                leftSection={<Icon size={15} />}
-              >
-                {link.label}
-              </Tabs.Tab>
-            );
-          })}
-        </Tabs.List>
-      </Tabs>
-    </ScrollArea>
+    <Box component="nav" aria-label="App sections" w="100%">
+      <ScrollArea type="never" w="100%">
+        <Tabs value={active} variant="default" w="100%" activateTabWithKeyboard={false}>
+          <Tabs.List style={{ flexWrap: 'nowrap' }}>
+            {links.map((link) => {
+              const Icon = link.icon;
+              return (
+                <Tabs.Tab
+                  key={link.href}
+                  value={link.href}
+                  // `renderRoot` (not `component`) is the Mantine-blessed way to
+                  // mount a typed Next `<Link>` as the polymorphic root without the
+                  // generic-component TS2322 — keeps the tab a real anchor (href,
+                  // keyboard, middle-click) while Tabs owns role/aria-selected.
+                  renderRoot={(props) => <Link href={link.href} {...props} />}
+                  leftSection={<Icon size={15} />}
+                >
+                  {link.label}
+                </Tabs.Tab>
+              );
+            })}
+          </Tabs.List>
+        </Tabs>
+      </ScrollArea>
+    </Box>
   );
 }
 

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Center,
-  Container,
   Grid,
   Group,
   Loader,
@@ -18,7 +17,7 @@ import { useMemo, useState } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppBlockCard } from '~/components/Apps/AppBlockCard';
-import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { Meta } from '~/components/Meta/Meta';
@@ -211,15 +210,11 @@ export default function AppsPage() {
   return (
     <>
       <Meta title="Apps — Civitai" description="Civitai App Blocks marketplace" deIndex />
-      <Container size="xl" py="md">
+      {/* Outer chrome (Container + sticky sub-nav) is supplied by AppsPageLayout;
+          the marketplace title/subtitle were removed for the page-apps-only
+          launch (the sub-nav supplies the wayfinding), so no header props. */}
+      <AppsPageLayout size="xl">
         <Stack gap="md">
-          {/* Second-level navigation — the nav dropdown exposes a single
-              `/apps` entry; the per-surface links (installed / submit /
-              revenue / review / submissions) live here, conditionally shown.
-              The marketplace title/subtitle were removed for the page-apps-only
-              launch (the sub-nav supplies the wayfinding). */}
-          <AppsSubNav />
-
           <Group gap="md" align="end">
             <TextInput
               label="Search"
@@ -327,7 +322,7 @@ export default function AppsPage() {
             </>
           )}
         </Stack>
-      </Container>
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/installed.tsx
+++ b/src/pages/apps/installed.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Card,
   Center,
-  Container,
   Divider,
   Group,
   Loader,
@@ -14,7 +13,6 @@ import {
   Table,
   Tabs,
   Text,
-  Title,
   Tooltip,
 } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
@@ -32,7 +30,7 @@ import { useMemo } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { Meta } from '~/components/Meta/Meta';
-import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { groupSubscriptionsByApp } from '~/components/Apps/groupSubscriptionsByApp';
 import type { GroupedApp } from '~/components/Apps/groupSubscriptionsByApp';
 import { useHiddenBlockList, unhideBlock } from '~/components/AppBlocks/hiddenBlocks';
@@ -768,27 +766,22 @@ export default function InstalledAppsPage() {
   return (
     <>
       <Meta title="Installed Apps — Civitai" deIndex />
-      <Container size="lg" py="md">
-        <Stack gap="lg">
-          <AppsSubNav />
-          <Group justify="space-between">
-            <Stack gap={2}>
-              <Title order={2}>Your installed apps</Title>
-              <Text size="sm" c="dimmed">
-                Manage where Civitai App Blocks show up across the site.
-              </Text>
-            </Stack>
-            <Button
-              component={Link}
-              href="/apps"
-              leftSection={<IconPlus size={16} />}
-              variant="default"
-            >
-              Browse marketplace
-            </Button>
-          </Group>
-
-          <Tabs defaultValue="subscriptions" variant="outline">
+      <AppsPageLayout
+        size="lg"
+        title="Your installed apps"
+        subtitle="Manage where Civitai App Blocks show up across the site."
+        actions={
+          <Button
+            component={Link}
+            href="/apps"
+            leftSection={<IconPlus size={16} />}
+            variant="default"
+          >
+            Browse marketplace
+          </Button>
+        }
+      >
+        <Tabs defaultValue="subscriptions" variant="outline">
             <Tabs.List>
               <Tabs.Tab value="subscriptions" leftSection={<IconPlugConnected size={14} />}>
                 Installs
@@ -855,9 +848,8 @@ export default function InstalledAppsPage() {
                 <HiddenBlocksPanel />
               </Stack>
             </Tabs.Panel>
-          </Tabs>
-        </Stack>
-      </Container>
+        </Tabs>
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -1,8 +1,8 @@
-import { Alert, Button, Card, Container, Group, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Card, Stack, Text } from '@mantine/core';
 import { IconAlertTriangle, IconArrowRight } from '@tabler/icons-react';
 import Link from 'next/link';
 import { NotFound } from '~/components/AppLayout/NotFound';
-import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { deployRefetchInterval } from '~/components/Apps/deploy-status';
 import { MySubmissionsList, type Submission } from '~/components/Apps/MySubmissionsList';
 import { Meta } from '~/components/Meta/Meta';
@@ -73,52 +73,44 @@ export default function MySubmissionsPage() {
   return (
     <>
       <Meta title="My app submissions — Civitai" deIndex />
-      <Container size="xl" py="xl">
-        <Stack gap="lg">
-          <AppsSubNav />
-          <Group justify="space-between" align="flex-end">
-            <Stack gap={4}>
-              <Title order={2}>My submissions</Title>
-              <Text c="dimmed" size="sm">
-                Status of every app submission you've made. Open a row's reviewer
-                notes to see mod feedback; pending submissions can be withdrawn.
-              </Text>
+      <AppsPageLayout
+        title="My submissions"
+        subtitle="Status of every app submission you've made. Open a row's reviewer notes to see mod feedback; pending submissions can be withdrawn."
+        actions={
+          <Button
+            component={Link}
+            href="/apps/submit"
+            rightSection={<IconArrowRight size={16} />}
+          >
+            Submit a new app
+          </Button>
+        }
+      >
+        {submissionsQuery.isError && (
+          <Alert color="red" icon={<IconAlertTriangle size={16} />}>
+            {submissionsQuery.error.message}
+          </Alert>
+        )}
+
+        {!submissionsQuery.isLoading && submissions.length === 0 && (
+          <Card withBorder p="lg">
+            <Stack gap="xs" align="center" py="md">
+              <Text>You haven't submitted any apps yet.</Text>
+              <Button component={Link} href="/apps/submit">
+                Submit your first app
+              </Button>
             </Stack>
-            <Button
-              component={Link}
-              href="/apps/submit"
-              rightSection={<IconArrowRight size={16} />}
-            >
-              Submit a new app
-            </Button>
-          </Group>
+          </Card>
+        )}
 
-          {submissionsQuery.isError && (
-            <Alert color="red" icon={<IconAlertTriangle size={16} />}>
-              {submissionsQuery.error.message}
-            </Alert>
-          )}
-
-          {!submissionsQuery.isLoading && submissions.length === 0 && (
-            <Card withBorder p="lg">
-              <Stack gap="xs" align="center" py="md">
-                <Text>You haven't submitted any apps yet.</Text>
-                <Button component={Link} href="/apps/submit">
-                  Submit your first app
-                </Button>
-              </Stack>
-            </Card>
-          )}
-
-          {submissions.length > 0 && (
-            <MySubmissionsList
-              submissions={submissions}
-              onWithdraw={(id) => withdrawMutation.mutate({ publishRequestId: id })}
-              withdrawing={withdrawMutation.isPending}
-            />
-          )}
-        </Stack>
-      </Container>
+        {submissions.length > 0 && (
+          <MySubmissionsList
+            submissions={submissions}
+            onWithdraw={(id) => withdrawMutation.mutate({ publishRequestId: id })}
+            withdrawing={withdrawMutation.isPending}
+          />
+        )}
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -2,7 +2,6 @@ import {
   Anchor,
   Badge,
   Card,
-  Container,
   Group,
   Loader,
   SimpleGrid,
@@ -18,7 +17,7 @@ import Link from 'next/link';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppAnalyticsPanel } from '~/components/AppBlocks/AppAnalyticsPanel';
 import { Meta } from '~/components/Meta/Meta';
-import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -263,34 +262,32 @@ export default function AppBlocksDashboardPage() {
   return (
     <>
       <Meta title="App Blocks Dashboard — Civitai" deIndex />
-      <Container size="lg" py="xl">
-        <Stack gap="lg">
-          <AppsSubNav />
-          <div>
-            <Title order={2}>App Blocks Dashboard</Title>
-            <Text c="dimmed" size="sm">
-              Revenue share and analytics for your blocks. Payouts are batched weekly; see{' '}
-              <Anchor component={Link} href="/apps/installed">
-                Apps
-              </Anchor>{' '}
-              to manage installations.
-            </Text>
-          </div>
-
-          <Tabs defaultValue="revenue" keepMounted={false}>
-            <Tabs.List mb="md">
-              <Tabs.Tab value="revenue">Revenue</Tabs.Tab>
-              <Tabs.Tab value="analytics">Analytics</Tabs.Tab>
-            </Tabs.List>
-            <Tabs.Panel value="revenue">
-              <RevenuePanel />
-            </Tabs.Panel>
-            <Tabs.Panel value="analytics">
-              <AppAnalyticsPanel />
-            </Tabs.Panel>
-          </Tabs>
-        </Stack>
-      </Container>
+      <AppsPageLayout
+        size="lg"
+        title="App Blocks Dashboard"
+        subtitle={
+          <>
+            Revenue share and analytics for your blocks. Payouts are batched weekly; see{' '}
+            <Anchor component={Link} href="/apps/installed">
+              Apps
+            </Anchor>{' '}
+            to manage installations.
+          </>
+        }
+      >
+        <Tabs defaultValue="revenue" keepMounted={false}>
+          <Tabs.List mb="md">
+            <Tabs.Tab value="revenue">Revenue</Tabs.Tab>
+            <Tabs.Tab value="analytics">Analytics</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="revenue">
+            <RevenuePanel />
+          </Tabs.Panel>
+          <Tabs.Panel value="analytics">
+            <AppAnalyticsPanel />
+          </Tabs.Panel>
+        </Tabs>
+      </AppsPageLayout>
     </>
   );
 }

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Card,
   Code,
-  Container,
   Group,
   Modal,
   NumberInput,
@@ -18,7 +17,6 @@ import {
   Tabs,
   Text,
   Textarea,
-  Title,
   Tooltip,
 } from '@mantine/core';
 import {
@@ -39,7 +37,7 @@ import type { MouseEvent } from 'react';
 import { useMemo, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { Meta } from '~/components/Meta/Meta';
-import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import {
   SCOPE_DESCRIPTIONS,
@@ -194,52 +192,45 @@ export default function ReviewQueuePage() {
   return (
     <>
       <Meta title="App publish-request queue — Civitai" deIndex />
-      <Container size="xl" py="xl">
-        <Stack gap="lg">
-          <AppsSubNav />
-          <Stack gap={4}>
-            <Title order={2}>App publish-request queue</Title>
-            <Text c="dimmed" size="sm">
-              Moderator review for App Blocks. Pending queue is oldest-first;
-              history tabs are newest-first.
-            </Text>
-          </Stack>
+      <AppsPageLayout
+        size="xl"
+        title="App publish-request queue"
+        subtitle="Moderator review for App Blocks. Pending queue is oldest-first; history tabs are newest-first."
+      >
+        <Tabs
+          value={tab}
+          onChange={(v) => {
+            if (isTabValue(v)) setTab(v);
+          }}
+          keepMounted={false}
+        >
+          <Tabs.List>
+            <Tabs.Tab value="pending" leftSection={<IconClock size={14} />}>
+              Pending
+            </Tabs.Tab>
+            <Tabs.Tab value="approved" leftSection={<IconCheck size={14} />}>
+              Approved
+            </Tabs.Tab>
+            <Tabs.Tab value="rejected" leftSection={<IconX size={14} />}>
+              Rejected
+            </Tabs.Tab>
+          </Tabs.List>
 
-          <Tabs
-            value={tab}
-            onChange={(v) => {
-              if (isTabValue(v)) setTab(v);
-            }}
-            keepMounted={false}
-          >
-            <Tabs.List>
-              <Tabs.Tab value="pending" leftSection={<IconClock size={14} />}>
-                Pending
-              </Tabs.Tab>
-              <Tabs.Tab value="approved" leftSection={<IconCheck size={14} />}>
-                Approved
-              </Tabs.Tab>
-              <Tabs.Tab value="rejected" leftSection={<IconX size={14} />}>
-                Rejected
-              </Tabs.Tab>
-            </Tabs.List>
+          <Tabs.Panel value="pending" pt="md">
+            <PendingTab
+              onSelect={(r) => setSelected({ request: r, mode: 'pending' })}
+            />
+          </Tabs.Panel>
 
-            <Tabs.Panel value="pending" pt="md">
-              <PendingTab
-                onSelect={(r) => setSelected({ request: r, mode: 'pending' })}
-              />
-            </Tabs.Panel>
+          <Tabs.Panel value="approved" pt="md">
+            <ApprovedTab onSelect={(r) => setSelected({ request: r, mode: 'approved' })} />
+          </Tabs.Panel>
 
-            <Tabs.Panel value="approved" pt="md">
-              <ApprovedTab onSelect={(r) => setSelected({ request: r, mode: 'approved' })} />
-            </Tabs.Panel>
-
-            <Tabs.Panel value="rejected" pt="md">
-              <RejectedTab onSelect={(r) => setSelected({ request: r, mode: 'rejected' })} />
-            </Tabs.Panel>
-          </Tabs>
-        </Stack>
-      </Container>
+          <Tabs.Panel value="rejected" pt="md">
+            <RejectedTab onSelect={(r) => setSelected({ request: r, mode: 'rejected' })} />
+          </Tabs.Panel>
+        </Tabs>
+      </AppsPageLayout>
 
       <ReviewModal
         selection={selected}

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Card,
   Code,
-  Container,
   FileInput,
   Group,
   Loader,
@@ -25,7 +24,7 @@ import Link from 'next/link';
 import { useMutation } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
-import { AppsSubNav } from '~/components/Apps/AppsSubNav';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { CliSubmitCta } from '~/components/Apps/CliSubmitCta';
 import { ManualUploadSection } from '~/components/Apps/ManualUploadSection';
 import { Meta } from '~/components/Meta/Meta';
@@ -303,23 +302,22 @@ export default function SubmitAppPage() {
   return (
     <>
       <Meta title="Submit an app — Civitai" deIndex />
-      <Container size="sm" py="xl">
-        <Stack gap="lg">
-          <AppsSubNav />
-          <Stack gap={4}>
-            <Title order={2}>Submit an app</Title>
-            <Text c="dimmed" size="sm">
-              The recommended way to author and submit an app is the <Code>civitai</Code> CLI — it
-              scaffolds your block and submits it for you. A moderator reviews the manifest + change
-              summary, then approves or rejects with feedback. Approved submissions deploy
-              automatically. Prefer to do it by hand? You can still upload a ZIP.
-            </Text>
-          </Stack>
-
-          {submitted ? (
-            <SuccessCard submitted={submitted} />
-          ) : (
-            <>
+      <AppsPageLayout
+        size="sm"
+        title="Submit an app"
+        subtitle={
+          <>
+            The recommended way to author and submit an app is the <Code>civitai</Code> CLI — it
+            scaffolds your block and submits it for you. A moderator reviews the manifest + change
+            summary, then approves or rejects with feedback. Approved submissions deploy
+            automatically. Prefer to do it by hand? You can still upload a ZIP.
+          </>
+        }
+      >
+        {submitted ? (
+          <SuccessCard submitted={submitted} />
+        ) : (
+          <>
               {/* PRIMARY: the recommended CLI flow. */}
               <CliSubmitCta />
 
@@ -407,8 +405,7 @@ export default function SubmitAppPage() {
               </ManualUploadSection>
             </>
           )}
-        </Stack>
-      </Container>
+      </AppsPageLayout>
     </>
   );
 }


### PR DESCRIPTION
## What

UI-only restructure of the App Blocks `/apps/*` surfaces:

1. **`AppsSubNav` → Mantine navigation Tabs.** The pill/link buttons become a Tabs bar. Each tab is still a real Next `<Link>` (mounted via `renderRoot` so the polymorphic-typed-Link `TS2322` is avoided and middle-click / keyboard / SEO affordances survive), while Mantine Tabs owns `role="tab"` + `aria-selected`. The **active tab is derived from the current route** (`activeAppsTab(router.pathname)` → `Tabs.value`); `/apps` is **exact-matched** so the Marketplace tab doesn't light up on a `/apps/*` child, and sub-routes match on prefix so deep paths keep the right tab active. Conditional visibility (driven by `blocks.getNavSummary`: Installed / My submissions / Revenue / Review gated by access/ownership; Marketplace + Submit always shown) is unchanged.

2. **New `AppsPageLayout` — consistent template.** A shared wrapper that renders a **sticky header region** whose **first** element is the `AppsSubNav` tabs, with the optional per-page title / subtitle / actions rendered **below** the tabs. Because the tabs always lead the header (never below a per-page title), they sit in the **identical vertical position on every page** — fixing the "tabs jump around between surfaces" problem caused by each page's divergent ad-hoc header. All **6 pages** (`index`, `submit`, `my-submissions`, `installed`, `revenue`, `review`) now wrap their body in `<AppsPageLayout>`, dropping their own `Container` + sub-nav placement. Page bodies, internal content-Tabs, the review modal, and all flag-gating / access redirects are preserved.

## Scope

Touches only `AppsSubNav.tsx`, the new `AppsPageLayout.tsx`, the test, and the outer wrapper/header of the 6 pages. `AppBlockCard`, `AppBlockChrome`/`IframeHost`, `/apps/run`, and the marketplace grid/filters/body are untouched (only `index.tsx`'s outer wrapper changed).

## Tests

`AppsSubNav.browser.test.tsx` retargeted to the Tabs markup (`role="tab"`, `aria-selected`, `href`) and extended — **15/15 pass**:
- conditional visibility (each tab shows only when its summary flag is set; Marketplace+Submit always)
- active tab reflects the route (`aria-selected="true"` on the current route's tab; `/apps` not selected on a child route; Submit selected on `/apps/submit`)
- each visible tab points its `href` at the matching `/apps` route (the click-destination contract for a link-based tab)
- `isActiveAppsRoute` / `activeAppsTab` route-matching helpers
- **Mutation-sanity verified**: reverting the `/apps` exact-match guard fails 5 tests.

## Verification

- Scoped `tsc --noEmit`: **zero new type errors** in the touched files (the 19 remaining project-wide errors are pre-existing on `main` in unrelated files: `image.service.ts`, `flipt/client.ts`, `bitdex-stats.ts`, two orchestrator handlers).
- `vitest run --project component AppsSubNav.browser.test.tsx`: 15/15 green. (Two unrelated `CliSubmitCta` clipboard tests fail identically on `main` — headless-clipboard env, not touched here.)

Not browser-verified against a running app (no local app run); the visual "tabs no longer shift" claim is structural (tabs are the first sticky-header child on all 6 pages) and not yet click-path-confirmed in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
