### PR TITLE
fix(images): reclassify transient Meili timeout/Service-Unavailable on /api/v1/images from 500 → retryable 503

### DIFF
--- a/src/pages/api/v1/blocks/images.ts
+++ b/src/pages/api/v1/blocks/images.ts
@@ -14,11 +14,7 @@ import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturi
 import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { getNextPage, getPagination } from '~/server/utils/pagination-helpers';
-import {
-  isFailfastStatus,
-  MeiliCallTimeoutError,
-  MeilisearchFetchError,
-} from '~/server/meilisearch/client';
+import { isTransientMeiliError } from '~/server/meilisearch/client';
 import { isClientAbortError } from '~/server/utils/errorHandling';
 import {
   acquireBulkheadSlot,
@@ -230,11 +226,19 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       if (!res.headersSent) res.status(499).end();
       return;
     }
-    if (
-      error instanceof MeiliCallTimeoutError ||
-      (error instanceof MeilisearchFetchError && isFailfastStatus(error.status))
-    ) {
+    // Transient Meili failure → retryable 503. Use the SAME `isTransientMeiliError`
+    // predicate the public /api/v1/images handler uses (NOT the old raw-SDK
+    // MeiliCallTimeoutError/MeilisearchFetchError-only branch), so the feed
+    // library's inner meilisearch-js SDK errors (MeiliSearchCommunicationError /
+    // MeiliSearchApiError / MeiliSearchTimeOutError) — the dominant 500 source on
+    // the public endpoint — are reclassified here too rather than bubbling as a
+    // hard 500 via the generic tail. no-store + Retry-After: 2 so the 503 carries
+    // the SAME retryable contract as the public endpoint (the doc above claims
+    // this handler mirrors it). withBlockScope already forces `private, no-store`,
+    // but set it explicitly so the contract is self-evident at the response site.
+    if (isTransientMeiliError(error)) {
       if (!res.headersSent) {
+        res.setHeader('Cache-Control', 'no-store');
         res.setHeader('Retry-After', '2');
         res
           .status(503)
@@ -244,7 +248,18 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     }
     const trpcError = error as TRPCError;
     const statusCode = getHTTPStatusCodeFromError(trpcError);
-    res.status(statusCode).json({ error: trpcError.message, code: trpcError.code });
+
+    // A TRPCError SERVICE_UNAVAILABLE wrapped by the service layer maps to 503 —
+    // attach the same no-store + Retry-After so the retryable contract is
+    // identical to the raw-error branch above (mirrors the public endpoint).
+    if (statusCode === 503 && !res.headersSent) {
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('Retry-After', '2');
+    }
+
+    if (!res.headersSent) {
+      res.status(statusCode).json({ error: trpcError.message, code: trpcError.code });
+    }
     return;
   } finally {
     releaseSlot?.();

--- a/src/pages/api/v1/images/index.ts
+++ b/src/pages/api/v1/images/index.ts
@@ -8,11 +8,7 @@ import { constants } from '~/server/common/constants';
 import { ImageSort } from '~/server/common/enums';
 import client from 'prom-client';
 import { ensureRegisterFeedImageExistenceCheckMetrics } from '~/server/metrics/feed-image-existence-check.metrics';
-import {
-  isFailfastStatus,
-  MeiliCallTimeoutError,
-  MeilisearchFetchError,
-} from '~/server/meilisearch/client';
+import { isTransientMeiliError } from '~/server/meilisearch/client';
 import { runImageSearch } from '~/server/services/image-search.service';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { isClientAbortError } from '~/server/utils/errorHandling';
@@ -199,19 +195,23 @@ async function handleImagesRequest(req: NextApiRequest, res: NextApiResponse) {
       if (!res.headersSent) res.status(499).end();
       return;
     }
-    // Meili saturation / timeout / upstream 5xx (feeds-proxy shed or backend
-    // brownout) → 503 SERVICE_UNAVAILABLE, retryable. Without this the raw
-    // MeiliCallTimeoutError / MeilisearchFetchError is not a TRPCError, so the
-    // generic mapping below defaults it to 500 — the dominant mislabeled-500
-    // source on this endpoint. no-store so an edge layer can't cache the error,
-    // Retry-After so clients/CF retry the (typically seconds-long) flap.
-    // Mirrors the tRPC image feed + the /api/v1/models handler. 4xx-other
-    // (malformed filter / auth) is NOT failfast-eligible and still bubbles to
-    // the generic mapping below.
-    if (
-      error instanceof MeiliCallTimeoutError ||
-      (error instanceof MeilisearchFetchError && isFailfastStatus(error.status))
-    ) {
+    // Meili saturation / timeout / upstream 408/429/5xx (feeds-proxy shed or
+    // backend brownout) → 503 SERVICE_UNAVAILABLE, retryable. `isTransientMeiliError`
+    // matches BOTH civitai's own wrapper errors (MeiliCallTimeoutError /
+    // MeilisearchFetchError) AND the meilisearch-js SDK's own error types
+    // (MeiliSearchCommunicationError / MeiliSearchApiError / MeiliSearchTimeOutError)
+    // that the feed library's inner SDK calls throw — none of which are
+    // TRPCErrors, so the generic mapping below would otherwise default them to
+    // 500. Those SDK errors (a 408 "Request Timeout" / 503 "Service Unavailable"
+    // from the proxy) were the dominant mislabeled-500 source on this endpoint.
+    // The service layer (getImagesFromFeedSearch / getAllImagesIndex) now wraps
+    // them as TRPCError SERVICE_UNAVAILABLE before they reach here, but this
+    // branch is kept as defense-in-depth (a raw SDK error escaping the wrap
+    // still becomes 503-with-headers, not a hard 500). no-store so an edge
+    // layer can't cache the error; Retry-After so clients/CF retry the
+    // (typically seconds-long) flap. 4xx-other (malformed filter / auth) is NOT
+    // transient and still bubbles to the generic mapping below.
+    if (isTransientMeiliError(error)) {
       if (!res.headersSent) {
         res.setHeader('Cache-Control', 'no-store');
         res.setHeader('Retry-After', '2');
@@ -223,6 +223,15 @@ async function handleImagesRequest(req: NextApiRequest, res: NextApiResponse) {
     }
     const trpcError = error as TRPCError;
     const statusCode = getHTTPStatusCodeFromError(trpcError);
+
+    // A TRPCError SERVICE_UNAVAILABLE wrapped by the service layer (the normal
+    // path for a transient Meili failure now) maps to 503 here — attach the
+    // same no-store + Retry-After so the retryable contract is identical to the
+    // raw-error branch above.
+    if (statusCode === 503 && !res.headersSent) {
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('Retry-After', '2');
+    }
 
     return res.status(statusCode).json({
       error: trpcError.message,

--- a/src/server/meilisearch/__tests__/client.test.ts
+++ b/src/server/meilisearch/__tests__/client.test.ts
@@ -800,11 +800,35 @@ describe('isTransientMeiliError — transient upstream classification', () => {
     }
   );
 
-  it.each([408, 429, 502, 503, 504])(
-    'returns true for a MeiliSearchApiError with transient httpStatus %i',
+  it.each([502, 503, 504])(
+    'returns true for a MeiliSearchApiError with transient gateway httpStatus %i',
     async (status) => {
       const { isTransientMeiliError } = await import('~/server/meilisearch/client');
       expect(isTransientMeiliError(makeApiError(status))).toBe(true);
+    }
+  );
+
+  // ── Masking-guard (audit 🟡 #1): a STRUCTURED-JSON Meili 500 is deterministic ──
+  // A MeiliSearchApiError carries a parseable JSON body — for a 5xx that is far
+  // more likely a deterministic Meili-internal error than a transient brownout.
+  // So a JSON-body 500 must NOT be classified transient (it must surface as a
+  // hard 500), while the empty/non-JSON-body transport-layer 500
+  // (MeiliSearchCommunicationError) IS transient. This pins exactly that split.
+  it('returns FALSE for a MeiliSearchApiError with httpStatus=500 (JSON body → deterministic, must bubble as 500 not 503)', async () => {
+    const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+    expect(isTransientMeiliError(makeApiError(500))).toBe(false);
+  });
+
+  it.each(['Internal Server Error', 'Request Timeout', 'Service Unavailable'])(
+    'returns TRUE for a MeiliSearchCommunicationError with statusCode=500 (empty/transport body "%s" → transient 503)',
+    async (statusText) => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      // Transport-layer 500 (empty / non-JSON body) — the SDK couldn't parse a
+      // structured error, so this is the genuinely-transient case → 503.
+      const e = new Error(statusText) as Error & { name: string; statusCode: number };
+      e.name = 'MeiliSearchCommunicationError';
+      e.statusCode = 500;
+      expect(isTransientMeiliError(e)).toBe(true);
     }
   );
 
@@ -875,5 +899,169 @@ describe('isTransientMeiliError — transient upstream classification', () => {
     const ambiguous = new Error('weird') as Error & { name: string };
     ambiguous.name = 'MeiliSearchCommunicationError';
     expect(isTransientMeiliError(ambiguous)).toBe(false);
+  });
+});
+
+// ─── failfastReasonForTransientError: label mapping for the reclassified 503s ──
+//
+// Audit 🟡 #3: when getImagesFromFeedSearch / getAllImagesIndex turn a transient
+// Meili error into a 503, they increment `meiliFetchFailfastTotal{route, reason}`
+// so a Meili outage stays attributable instead of vanishing into the unlabeled
+// 503 bucket. This proves the reason-label mapping the counter uses — it must
+// reuse the SAME vocabulary as the post-filter loop (failfastReasonForStatus)
+// and add the timeout / network buckets that helper doesn't cover.
+describe('failfastReasonForTransientError — reason label mapping', () => {
+  const makeCommunicationError = (statusCode: number) => {
+    const e = new Error('x') as Error & { name: string; statusCode: number };
+    e.name = 'MeiliSearchCommunicationError';
+    e.statusCode = statusCode;
+    return e;
+  };
+  const makeApiError = (httpStatus: number) => {
+    const e = new Error('x') as Error & { name: string; httpStatus: number };
+    e.name = 'MeiliSearchApiError';
+    e.httpStatus = httpStatus;
+    return e;
+  };
+
+  it('maps the status-bearing SDK errors via failfastReasonForStatus (same vocab as the post-filter loop)', async () => {
+    const { failfastReasonForTransientError } = await import('~/server/meilisearch/client');
+    expect(failfastReasonForTransientError(makeCommunicationError(408))).toBe('upstream-timeout');
+    expect(failfastReasonForTransientError(makeCommunicationError(503))).toBe('upstream-overload');
+    expect(failfastReasonForTransientError(makeCommunicationError(502))).toBe('upstream-error');
+    expect(failfastReasonForTransientError(makeApiError(503))).toBe('upstream-overload');
+    expect(failfastReasonForTransientError(makeApiError(504))).toBe('upstream-error');
+  });
+
+  it('maps the timeout cases to local-timeout', async () => {
+    const { failfastReasonForTransientError, FETCH_DOCUMENTS_TIMEOUT_MESSAGE } = await import(
+      '~/server/meilisearch/client'
+    );
+    const timeoutErr = new Error('timeout of 5000ms') as Error & { name: string };
+    timeoutErr.name = 'MeiliSearchTimeOutError';
+    expect(failfastReasonForTransientError(timeoutErr)).toBe('local-timeout');
+    expect(failfastReasonForTransientError(new Error(FETCH_DOCUMENTS_TIMEOUT_MESSAGE))).toBe(
+      'local-timeout'
+    );
+  });
+
+  it('maps the civitai wrapper errors', async () => {
+    const { failfastReasonForTransientError, MeiliCallTimeoutError, MeilisearchFetchError } =
+      await import('~/server/meilisearch/client');
+    expect(failfastReasonForTransientError(new MeiliCallTimeoutError('timeout'))).toBe(
+      'upstream-circuit-open'
+    );
+    expect(failfastReasonForTransientError(new MeilisearchFetchError(503, ''))).toBe(
+      'upstream-overload'
+    );
+    expect(failfastReasonForTransientError(new MeilisearchFetchError(408, ''))).toBe(
+      'upstream-timeout'
+    );
+  });
+
+  it('maps a network-level CommunicationError (no http status) to upstream-error', async () => {
+    const { failfastReasonForTransientError } = await import('~/server/meilisearch/client');
+    const e = new Error('ECONNREFUSED') as Error & { name: string; code: string; errno: string };
+    e.name = 'MeiliSearchCommunicationError';
+    e.code = 'ECONNREFUSED';
+    e.errno = 'ECONNREFUSED';
+    expect(failfastReasonForTransientError(e)).toBe('upstream-error');
+  });
+});
+
+// ─── Service-catch counter contract (audit 🟡 #3) ────────────────────────────
+//
+// getImagesFromFeedSearch / getAllImagesIndex now increment
+// meiliFetchFailfastTotal{route, iteration:'0', reason} on the transient-503
+// path. The full image.service is too heavy to module-load in isolation (the
+// flipt-client import wedges it), so — mirroring how the post-filter contract
+// tests above prove the counter without loading image.service — we replicate
+// the EXACT service-catch shape and assert the counter fires with the right
+// {route, reason} label. incMock is the shared registerCounterWithLabels().inc.
+describe('service-catch → meiliFetchFailfastTotal{route, reason} on a transient-503', () => {
+  beforeEach(() => {
+    incMock.mockClear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['getImagesFromFeedSearch', 'CommunicationError(503)', 'upstream-overload'],
+    ['getAllImagesIndex', 'CommunicationError(503)', 'upstream-overload'],
+  ])(
+    'increments for %s on a %s (reason=%s)',
+    async (route, _shape, expectedReason) => {
+      const {
+        isTransientMeiliError,
+        failfastReasonForTransientError,
+        meiliFetchFailfastTotal,
+      } = await import('~/server/meilisearch/client');
+
+      const err = (() => {
+        const e = new Error('Service Unavailable') as Error & {
+          name: string;
+          statusCode: number;
+        };
+        e.name = 'MeiliSearchCommunicationError';
+        e.statusCode = 503;
+        return e;
+      })();
+
+      // Mirror the service catch in image.service.ts exactly.
+      let reclassified = false;
+      try {
+        throw err;
+      } catch (caught) {
+        if (isTransientMeiliError(caught)) {
+          meiliFetchFailfastTotal.inc({
+            route,
+            iteration: '0',
+            reason: failfastReasonForTransientError(caught),
+          });
+          reclassified = true;
+        } else {
+          throw caught;
+        }
+      }
+
+      expect(reclassified).toBe(true);
+      expect(incMock).toHaveBeenCalledWith({ route, iteration: '0', reason: expectedReason });
+      expect(incMock).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('does NOT increment when the error is non-transient (a deterministic ApiError 500 bubbles, no counter)', async () => {
+    const { isTransientMeiliError, failfastReasonForTransientError, meiliFetchFailfastTotal } =
+      await import('~/server/meilisearch/client');
+
+    const apiError500 = (() => {
+      const e = new Error('internal') as Error & { name: string; httpStatus: number };
+      e.name = 'MeiliSearchApiError';
+      e.httpStatus = 500;
+      return e;
+    })();
+
+    let reThrown: unknown;
+    try {
+      try {
+        throw apiError500;
+      } catch (caught) {
+        if (isTransientMeiliError(caught)) {
+          meiliFetchFailfastTotal.inc({
+            route: 'getImagesFromFeedSearch',
+            iteration: '0',
+            reason: failfastReasonForTransientError(caught),
+          });
+        } else {
+          throw caught;
+        }
+      }
+    } catch (e) {
+      reThrown = e;
+    }
+
+    expect(reThrown).toBe(apiError500);
+    expect(incMock).not.toHaveBeenCalled();
   });
 });

--- a/src/server/meilisearch/__tests__/client.test.ts
+++ b/src/server/meilisearch/__tests__/client.test.ts
@@ -745,3 +745,135 @@ describe('post-filter catch — MeiliCallTimeoutError (circuit-open / wrapper-ti
     expect(incMock).not.toHaveBeenCalled();
   });
 });
+
+// ─── isTransientMeiliError: SDK-error classification (500→503 reclassification) ─
+//
+// The REST image feed (/api/v1/images) runs through event-engine-common's
+// populatedQuery, whose INNER meilisearch-js (0.33) calls throw the SDK's OWN
+// error types on a slow / shed backend — NOT civitai's MeilisearchFetchError /
+// MeiliCallTimeoutError (those wrap only the direct raw-fetch path). When the
+// proxy/backend returns 408 ("Request Timeout") or 503 ("Service Unavailable")
+// with an empty body, the SDK throws MeiliSearchCommunicationError with
+// message=statusText + statusCode=<http status>; a parseable error body yields
+// MeiliSearchApiError carrying httpStatus. Neither is a TRPCError, so they were
+// hitting the generic 500 mapping → the dominant remaining HTTP-500 source on
+// /api/v1/images. isTransientMeiliError classifies these (and the civitai
+// wrapper errors) as genuinely-transient so the caller can re-map them to a
+// retryable 503 — while a 4xx-other / app error stays a hard error.
+//
+// We reconstruct the SDK error SHAPES (name + statusCode/httpStatus/code/errno)
+// rather than import the SDK classes, because the predicate intentionally
+// name-matches (`error.name === 'MeiliSearch...'`) so it survives a duplicated
+// SDK copy inside the event-engine-common submodule's own node_modules — the
+// real bug was an instanceof miss across module boundaries.
+
+describe('isTransientMeiliError — transient upstream classification', () => {
+  // Faithful reproductions of the meilisearch-js 0.33 error shapes.
+  const makeCommunicationError = (statusCode: number) => {
+    // SDK: `this.message = body.statusText; this.statusCode = body.status`
+    const e = new Error(statusCode === 408 ? 'Request Timeout' : 'Service Unavailable') as Error & {
+      name: string;
+      statusCode: number;
+    };
+    e.name = 'MeiliSearchCommunicationError';
+    e.statusCode = statusCode;
+    return e;
+  };
+
+  const makeApiError = (httpStatus: number) => {
+    const e = new Error('meilisearch upstream error') as Error & {
+      name: string;
+      httpStatus: number;
+      code: string;
+    };
+    e.name = 'MeiliSearchApiError';
+    e.httpStatus = httpStatus;
+    e.code = 'internal';
+    return e;
+  };
+
+  it.each([408, 429, 502, 503, 504])(
+    'returns true for a MeiliSearchCommunicationError with transient statusCode %i',
+    async (status) => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      expect(isTransientMeiliError(makeCommunicationError(status))).toBe(true);
+    }
+  );
+
+  it.each([408, 429, 502, 503, 504])(
+    'returns true for a MeiliSearchApiError with transient httpStatus %i',
+    async (status) => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      expect(isTransientMeiliError(makeApiError(status))).toBe(true);
+    }
+  );
+
+  it('returns true for a network-level MeiliSearchCommunicationError (no http status, has errno/code)', async () => {
+    const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+    const e = new Error('request to ... failed, reason: connect ECONNREFUSED') as Error & {
+      name: string;
+      code: string;
+      errno: string;
+    };
+    e.name = 'MeiliSearchCommunicationError';
+    e.code = 'ECONNREFUSED';
+    e.errno = 'ECONNREFUSED';
+    expect(isTransientMeiliError(e)).toBe(true);
+  });
+
+  it('returns true for a MeiliSearchTimeOutError (name-matched)', async () => {
+    const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+    const e = new Error('timeout of 5000ms has exceeded ...') as Error & { name: string };
+    e.name = 'MeiliSearchTimeOutError';
+    expect(isTransientMeiliError(e)).toBe(true);
+  });
+
+  it('returns true for the civitai wrapper errors (MeiliCallTimeoutError, failfast MeilisearchFetchError)', async () => {
+    const { isTransientMeiliError, MeiliCallTimeoutError, MeilisearchFetchError } = await import(
+      '~/server/meilisearch/client'
+    );
+    expect(isTransientMeiliError(new MeiliCallTimeoutError('timeout'))).toBe(true);
+    expect(isTransientMeiliError(new MeiliCallTimeoutError('concurrency'))).toBe(true);
+    expect(isTransientMeiliError(new MeilisearchFetchError(503, 'overloaded'))).toBe(true);
+    expect(isTransientMeiliError(new MeilisearchFetchError(408, ''))).toBe(true);
+    expect(isTransientMeiliError(new MeilisearchFetchError(429, ''))).toBe(true);
+  });
+
+  it('returns true for the raw-fetch local-deadline error (FETCH_DOCUMENTS_TIMEOUT_MESSAGE)', async () => {
+    const { isTransientMeiliError, FETCH_DOCUMENTS_TIMEOUT_MESSAGE } = await import(
+      '~/server/meilisearch/client'
+    );
+    expect(isTransientMeiliError(new Error(FETCH_DOCUMENTS_TIMEOUT_MESSAGE))).toBe(true);
+  });
+
+  it.each([400, 401, 403, 404, 422])(
+    'returns FALSE for a non-transient %i status (real client/app error must surface, not be masked as 503)',
+    async (status) => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      // Both SDK error shapes with a 4xx-other status must NOT be treated as transient.
+      expect(isTransientMeiliError(makeCommunicationError(status))).toBe(false);
+      expect(isTransientMeiliError(makeApiError(status))).toBe(false);
+    }
+  );
+
+  it('returns FALSE for a non-failfast MeilisearchFetchError (400 malformed filter)', async () => {
+    const { isTransientMeiliError, MeilisearchFetchError } = await import(
+      '~/server/meilisearch/client'
+    );
+    expect(isTransientMeiliError(new MeilisearchFetchError(400, 'bad filter'))).toBe(false);
+  });
+
+  it('returns FALSE for unrelated errors and non-error values', async () => {
+    const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+    expect(isTransientMeiliError(new Error('null deref upstream'))).toBe(false);
+    expect(isTransientMeiliError(new TypeError('x is not a function'))).toBe(false);
+    expect(isTransientMeiliError(undefined)).toBe(false);
+    expect(isTransientMeiliError(null)).toBe(false);
+    expect(isTransientMeiliError('a string')).toBe(false);
+    expect(isTransientMeiliError({ random: 'object' })).toBe(false);
+    // A communication-error NAME but no status and no network code → not classifiable as transient.
+    const ambiguous = new Error('weird') as Error & { name: string };
+    ambiguous.name = 'MeiliSearchCommunicationError';
+    expect(isTransientMeiliError(ambiguous)).toBe(false);
+  });
+});

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -149,12 +149,90 @@ export function failfastReasonForStatus(status: number): MeiliFetchFailfastReaso
 
 /**
  * Does `status` qualify for graceful-break treatment by post-filter / future
- * iteration-loop callers? True for 408 (upstream-side timeout) and any 5xx
- * (upstream unavailable). False for 4xx-other (real client error — must
- * bubble up so we don't silently hide malformed-filter / auth bugs).
+ * iteration-loop callers? True for the genuinely-transient upstream statuses:
+ *   - 408 Request Timeout      (upstream-side timeout)
+ *   - 429 Too Many Requests    (feeds-proxy / backend rate-limit shed)
+ *   - any 5xx                  (502 bad gateway, 503 unavailable, 504 gateway
+ *                               timeout — upstream brownout)
+ * False for 4xx-other (400 malformed filter, 401/403 auth — real client error,
+ * must bubble up so we don't silently hide app bugs as retryable).
+ *
+ * 429 is included because a transient upstream rate-limit is retryable (the
+ * caller can back off and re-issue), exactly like a 503 shed; mapping it to a
+ * hard 500 instead would (a) inflate the 500 SLO with a transient and (b) deny
+ * the client/CF the Retry-After it would honor. It is NOT the public endpoint's
+ * own paging 429 (that is returned directly by the handler before search runs).
  */
 export function isFailfastStatus(status: number): boolean {
-  return status === 408 || status >= 500;
+  return status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * Classify an error caught from a Meilisearch SDK call (or the civitai-feeds
+ * proxy in front of it) as a genuinely-transient upstream failure that should
+ * surface to the client as a retryable 503, NOT a hard 500.
+ *
+ * Motivation — the dominant remaining HTTP-500 source on /api/v1/images (the
+ * heavy per-user `sort=Most Reactions&period=Year&withMeta=true` feed): the
+ * REST feed path runs through event-engine-common's `populatedQuery`, whose
+ * inner meilisearch-js (0.33) calls throw the SDK's OWN error types on a slow /
+ * shed backend — NOT civitai's `MeilisearchFetchError` / `MeiliCallTimeoutError`
+ * (those wrap only the direct raw-fetch path). When the proxy/backend returns
+ * 408 ("Request Timeout") or 503 ("Service Unavailable") with an empty body,
+ * the SDK throws `MeiliSearchCommunicationError` with `message = statusText`
+ * and `statusCode = <http status>`; a parseable error body yields a
+ * `MeiliSearchApiError` carrying `httpStatus`. Neither is a TRPCError, so they
+ * fell through every existing 503 branch and the handler mapped them to a
+ * hard 500 ({"error":"Request Timeout"} / {"error":"Service Unavailable"}).
+ *
+ * Matches (all genuinely transient):
+ *   - civitai wrappers: `MeiliCallTimeoutError` (local timer / circuit-open),
+ *     `MeilisearchFetchError` with a failfast status (raw-fetch path)
+ *   - SDK `MeiliSearchCommunicationError` with a transient `.statusCode`
+ *     (408/429/5xx) OR a network-level failure (`.code`/`.errno` set, no
+ *     HTTP status — ECONNREFUSED / ECONNRESET / fetch-abort against the
+ *     backend, i.e. the backend was unreachable, not a logic bug)
+ *   - SDK `MeiliSearchApiError` with a transient `.httpStatus` (408/429/5xx)
+ *   - SDK `MeiliSearchTimeOutError` (name-matched; class isn't re-exported on
+ *     the path we instanceof against) — the SDK's own wait/timeout
+ *   - the raw-fetch local-deadline error (message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE)
+ *
+ * Deliberately NARROW: a 4xx-other (400 malformed filter, 401/403 auth) or any
+ * other Error returns false and continues to surface as its real status (500
+ * for a genuine app bug). We do NOT swallow non-transient failures as 503.
+ */
+export function isTransientMeiliError(error: unknown): boolean {
+  if (error instanceof MeiliCallTimeoutError) return true;
+  if (error instanceof MeilisearchFetchError) return isFailfastStatus(error.status);
+
+  if (typeof error !== 'object' || error === null) return false;
+  const e = error as {
+    name?: string;
+    message?: string;
+    statusCode?: number; // MeiliSearchCommunicationError (HTTP responses)
+    httpStatus?: number; // MeiliSearchApiError
+    code?: string; // MeiliSearchCommunicationError (network errors) / MeiliSearchApiError
+    errno?: string; // MeiliSearchCommunicationError (network errors)
+  };
+
+  // The raw-fetch path's local-deadline abort (see fetchDocumentsAbortable).
+  if (e.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE) return true;
+
+  if (e.name === 'MeiliSearchTimeOutError') return true;
+
+  if (e.name === 'MeiliSearchApiError') {
+    return typeof e.httpStatus === 'number' && isFailfastStatus(e.httpStatus);
+  }
+
+  if (e.name === 'MeiliSearchCommunicationError') {
+    // HTTP response → has a numeric statusCode (408/429/5xx are transient).
+    if (typeof e.statusCode === 'number') return isFailfastStatus(e.statusCode);
+    // Network-level failure (no HTTP status, but a node errno/code) → the
+    // backend was unreachable / the socket dropped, which is transient.
+    return typeof e.errno === 'string' || typeof e.code === 'string';
+  }
+
+  return false;
 }
 
 /**

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -188,11 +188,16 @@ export function isFailfastStatus(status: number): boolean {
  * Matches (all genuinely transient):
  *   - civitai wrappers: `MeiliCallTimeoutError` (local timer / circuit-open),
  *     `MeilisearchFetchError` with a failfast status (raw-fetch path)
- *   - SDK `MeiliSearchCommunicationError` with a transient `.statusCode`
- *     (408/429/5xx) OR a network-level failure (`.code`/`.errno` set, no
+ *   - SDK `MeiliSearchCommunicationError` (TRANSPORT layer — empty / non-JSON
+ *     body) with a transient `.statusCode` (408/429/5xx, INCLUDING an
+ *     empty-body 500) OR a network-level failure (`.code`/`.errno` set, no
  *     HTTP status — ECONNREFUSED / ECONNRESET / fetch-abort against the
  *     backend, i.e. the backend was unreachable, not a logic bug)
- *   - SDK `MeiliSearchApiError` with a transient `.httpStatus` (408/429/5xx)
+ *   - SDK `MeiliSearchApiError` (STRUCTURED JSON error body) ONLY for the
+ *     unambiguously-transient gateway statuses `502/503/504`. A JSON-body 500
+ *     is a DETERMINISTIC Meili-internal error, NOT a brownout, so it is NOT
+ *     masked as transient — it bubbles as a hard 500. (The transport-layer
+ *     500 above IS transient; the distinction is Api(JSON) vs Communication.)
  *   - SDK `MeiliSearchTimeOutError` (name-matched; class isn't re-exported on
  *     the path we instanceof against) — the SDK's own wait/timeout
  *   - the raw-fetch local-deadline error (message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE)
@@ -221,10 +226,25 @@ export function isTransientMeiliError(error: unknown): boolean {
   if (e.name === 'MeiliSearchTimeOutError') return true;
 
   if (e.name === 'MeiliSearchApiError') {
-    return typeof e.httpStatus === 'number' && isFailfastStatus(e.httpStatus);
+    // A `MeiliSearchApiError` is thrown ONLY when Meili returned a STRUCTURED
+    // JSON error body (a server-side response the SDK could parse). For a 5xx
+    // that strongly implies a DETERMINISTIC Meili-internal error (e.g. an index
+    // in a bad state, a malformed-internal-query 500) rather than a transient
+    // brownout — so a JSON-body 500 MUST surface as a hard 500, not be masked
+    // as a retryable 503 (the masking-guard the audit flagged). Only the
+    // unambiguously-transient gateway statuses count here:
+    //   502 Bad Gateway / 503 Service Unavailable / 504 Gateway Timeout.
+    // (408/429 don't arrive as a parseable Meili JSON ApiError in practice; if
+    // they ever do, they fall through to false → bubble as their real status,
+    // which is the safe direction — we never widen masking.)
+    return typeof e.httpStatus === 'number' && [502, 503, 504].includes(e.httpStatus);
   }
 
   if (e.name === 'MeiliSearchCommunicationError') {
+    // Transport-layer failure: empty / non-JSON body (the SDK couldn't parse a
+    // structured error), which is the genuinely-transient case. Here a 500
+    // (empty-body "Internal Server Error" / proxy 500) IS treated as transient
+    // — `isFailfastStatus` covers 408/429/5xx including 500.
     // HTTP response → has a numeric statusCode (408/429/5xx are transient).
     if (typeof e.statusCode === 'number') return isFailfastStatus(e.statusCode);
     // Network-level failure (no HTTP status, but a node errno/code) → the
@@ -233,6 +253,46 @@ export function isTransientMeiliError(error: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * Map a transient Meili error (one that `isTransientMeiliError` returned true
+ * for) onto a `MeiliFetchFailfastReason` label, so the `meiliFetchFailfastTotal`
+ * counter stays attributable when a service catch reclassifies it to a 503.
+ * Reuses `failfastReasonForStatus` for the status-bearing SDK errors (so the
+ * label vocabulary matches the post-filter loop exactly) and adds the
+ * timeout / network buckets the status helper doesn't cover:
+ *   - civitai `MeiliCallTimeoutError` (wrapper timer / circuit-open) →
+ *     `upstream-circuit-open`
+ *   - `MeiliSearchTimeOutError` + the raw-fetch local-deadline message →
+ *     `local-timeout`
+ *   - network-level CommunicationError (errno/code, no HTTP status) →
+ *     `upstream-error`
+ * Caller contract: only pass errors `isTransientMeiliError(error)` accepts.
+ */
+export function failfastReasonForTransientError(error: unknown): MeiliFetchFailfastReason {
+  if (error instanceof MeiliCallTimeoutError) return MEILI_FETCH_FAILFAST_REASON_CIRCUIT_OPEN;
+  if (error instanceof MeilisearchFetchError) return failfastReasonForStatus(error.status);
+
+  if (typeof error === 'object' && error !== null) {
+    const e = error as {
+      name?: string;
+      message?: string;
+      statusCode?: number;
+      httpStatus?: number;
+    };
+    if (e.message === FETCH_DOCUMENTS_TIMEOUT_MESSAGE) return 'local-timeout';
+    if (e.name === 'MeiliSearchTimeOutError') return 'local-timeout';
+    if (e.name === 'MeiliSearchApiError' && typeof e.httpStatus === 'number') {
+      return failfastReasonForStatus(e.httpStatus);
+    }
+    if (e.name === 'MeiliSearchCommunicationError' && typeof e.statusCode === 'number') {
+      return failfastReasonForStatus(e.statusCode);
+    }
+  }
+  // Network-level CommunicationError (no HTTP status) / anything else transient
+  // that didn't match a more specific bucket → the generic upstream-error label.
+  return 'upstream-error';
 }
 
 /**

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -50,6 +50,7 @@ import {
   MeilisearchFetchError,
   SEARCH_ACTOR_HEADER,
   failfastReasonForStatus,
+  failfastReasonForTransientError,
   fetchDocumentsAbortable,
   getMetricsSearchClient,
   isFailfastStatus,
@@ -2226,6 +2227,16 @@ export const getAllImagesIndex = async (
     // inside the search index path. 4xx-other (malformed filter / auth) and
     // any other Error are NOT transient and still bubble as-is.
     if (isTransientMeiliError(err)) {
+      // Keep a transient Meili outage ATTRIBUTABLE: the reclassified 503 would
+      // otherwise vanish into the unlabeled 503 bucket. Mirror the post-filter
+      // loop's counter usage (route + reason) so an outage is queryable by the
+      // same label vocabulary; `iteration:'0'` (this is the single pre-filter
+      // search, not the post-filter iteration loop).
+      meiliFetchFailfastTotal.inc({
+        route: 'getAllImagesIndex',
+        iteration: '0',
+        reason: failfastReasonForTransientError(err),
+      });
       throw new TRPCError({
         code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
@@ -2955,6 +2966,15 @@ export async function getImagesFromFeedSearch(
     // generic 500 mapping). 4xx-other (malformed filter / auth) and any other
     // Error are NOT transient and still bubble as-is (→ their real status).
     if (isTransientMeiliError(err)) {
+      // Keep a transient Meili outage ATTRIBUTABLE (see getAllImagesIndex). The
+      // reclassified 503 would otherwise land in the unlabeled 503 bucket;
+      // mirror the post-filter loop's {route, reason} so a Meili brownout is
+      // queryable. `iteration:'0'` — this is the single feed-search call.
+      meiliFetchFailfastTotal.inc({
+        route: 'getImagesFromFeedSearch',
+        iteration: '0',
+        reason: failfastReasonForTransientError(err),
+      });
       throw new TRPCError({
         code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -53,6 +53,7 @@ import {
   fetchDocumentsAbortable,
   getMetricsSearchClient,
   isFailfastStatus,
+  isTransientMeiliError,
   meiliFetchFailfastTotal,
   metricsSearchClient,
   withMeili,
@@ -2216,25 +2217,19 @@ export const getAllImagesIndex = async (
     // into kubelet SIGKILL on 2026-05-29. 503 is the correct code for a
     // transient backend brownout (was TIMEOUT/408 as a tRPC-v10 stopgap; v11
     // has SERVICE_UNAVAILABLE).
-    if (err instanceof MeiliCallTimeoutError) {
+    //
+    // `isTransientMeiliError` covers the civitai wrapper errors
+    // (MeiliCallTimeoutError = local timer / circuit-open; MeilisearchFetchError
+    // with a failfast status = raw-fetch 408/429/5xx) AND the meilisearch-js
+    // SDK's own error types (MeiliSearchCommunicationError /
+    // MeiliSearchApiError / MeiliSearchTimeOutError) thrown by the SDK calls
+    // inside the search index path. 4xx-other (malformed filter / auth) and
+    // any other Error are NOT transient and still bubble as-is.
+    if (isTransientMeiliError(err)) {
       throw new TRPCError({
         code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
-        cause: err,
-      });
-    }
-    // Upstream returned 408 (backend timeout) or 5xx (feeds-proxy shed /
-    // brownout). Same disposition as the timeout above — a retryable 503
-    // SERVICE_UNAVAILABLE so the client shows its retry banner with a friendly
-    // message, instead of a raw 500 ("Meilisearch fetch failed (503): ...")
-    // leaking to the UI.
-    // Mirrors the user/model search REST handlers. 4xx-other (malformed
-    // filter / auth) is NOT failfast-eligible and still bubbles as-is.
-    if (err instanceof MeilisearchFetchError && isFailfastStatus(err.status)) {
-      throw new TRPCError({
-        code: 'SERVICE_UNAVAILABLE',
-        message: 'Image search is temporarily overloaded — please retry.',
-        cause: err,
+        cause: err as Error,
       });
     }
     throw err;
@@ -2944,25 +2939,26 @@ export async function getImagesFromFeedSearch(
     };
   } catch (err) {
     console.error('Error in getImagesFromFeedSearch:', err);
-    // Meili saturation / timeout → fail fast as SERVICE_UNAVAILABLE (HTTP 503)
-    // so the caller gets a fast, retryable response instead of bleeding 30s
-    // while Traefik gives up. 503 is the correct transient-brownout code
-    // (was TIMEOUT/408 under tRPC v10, which lacked SERVICE_UNAVAILABLE).
-    if (err instanceof MeiliCallTimeoutError) {
+    // Any genuinely-transient upstream failure → fail fast as SERVICE_UNAVAILABLE
+    // (HTTP 503) so the caller gets a fast, retryable response instead of
+    // bleeding 30s while Traefik gives up. 503 is the correct transient-brownout
+    // code (was TIMEOUT/408 under tRPC v10, which lacked SERVICE_UNAVAILABLE).
+    //
+    // `isTransientMeiliError` covers BOTH civitai's own wrapper errors
+    // (MeiliCallTimeoutError / MeilisearchFetchError, from the raw-fetch path)
+    // AND the meilisearch-js SDK's own error types (MeiliSearchCommunicationError /
+    // MeiliSearchApiError / MeiliSearchTimeOutError) that the feed library's
+    // INNER SDK calls throw on a slow/shed backend — the latter were the
+    // dominant remaining HTTP-500 source on /api/v1/images (a 408/503 from the
+    // proxy surfaced as a bare {"error":"Request Timeout"} / {"error":"Service
+    // Unavailable"} 500 because they're not TRPCErrors and fell through the
+    // generic 500 mapping). 4xx-other (malformed filter / auth) and any other
+    // Error are NOT transient and still bubble as-is (→ their real status).
+    if (isTransientMeiliError(err)) {
       throw new TRPCError({
         code: 'SERVICE_UNAVAILABLE',
         message: 'Image search is temporarily overloaded — please retry.',
-        cause: err,
-      });
-    }
-    // 408/5xx from the upstream (or feeds-proxy) → retryable 503, same as
-    // the circuit-open path above. Keeps this path symmetric with
-    // getAllImagesIndex even though it's REST-only and historically low-error.
-    if (err instanceof MeilisearchFetchError && isFailfastStatus(err.status)) {
-      throw new TRPCError({
-        code: 'SERVICE_UNAVAILABLE',
-        message: 'Image search is temporarily overloaded — please retry.',
-        cause: err,
+        cause: err as Error,
       });
     }
     throw err;

--- a/src/tests/api/v1/blocks/images-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/images-endpoint.test.ts
@@ -274,4 +274,62 @@ describe('/api/v1/blocks/images — authoritative clamp wiring', () => {
     expect(res.statusCode).toBe(200);
     expect(mockRunImageSearch).toHaveBeenCalledTimes(1);
   });
+
+  // ── Transient Meili → retryable 503 (audit 🟡 #2) ──────────────────────────
+  // The sibling now uses the SAME isTransientMeiliError predicate the public
+  // /api/v1/images handler uses, and attaches no-store + Retry-After: 2 so the
+  // 503 carries the same retryable contract (the doc claims it mirrors the
+  // public endpoint). isTransientMeiliError is NOT mocked here — the real
+  // predicate runs.
+  it('maps a transient Meili error to a retryable 503 (no-store + Retry-After)', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    // meilisearch-js 0.33 MeiliSearchCommunicationError(503) shape — a transport
+    // brownout the inner SDK throws, which used to bubble as a hard 500 here.
+    const transient = new Error('Service Unavailable') as Error & {
+      name: string;
+      statusCode: number;
+    };
+    transient.name = 'MeiliSearchCommunicationError';
+    transient.statusCode = 503;
+    mockRunImageSearch.mockRejectedValueOnce(transient);
+
+    const res = await invoke({});
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: 'Image search is temporarily overloaded — please retry.' });
+    const headers = (res as unknown as { headers: Record<string, unknown> }).headers;
+    expect(headers['Cache-Control']).toBe('no-store');
+    expect(headers['Retry-After']).toBe('2');
+  });
+
+  it('a TRPCError SERVICE_UNAVAILABLE (service-wrapped) → 503 WITH no-store + Retry-After', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    const trpcError = Object.assign(
+      new Error('Image search is temporarily overloaded — please retry.'),
+      { code: 'SERVICE_UNAVAILABLE', name: 'TRPCError' }
+    );
+    mockRunImageSearch.mockRejectedValueOnce(trpcError);
+
+    const res = await invoke({});
+
+    expect(res.statusCode).toBe(503);
+    const headers = (res as unknown as { headers: Record<string, unknown> }).headers;
+    expect(headers['Cache-Control']).toBe('no-store');
+    expect(headers['Retry-After']).toBe('2');
+  });
+
+  it('does NOT mask a deterministic ApiError 500 (JSON body) as 503 — surfaces a non-503 status, no Retry-After', async () => {
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag });
+    // Structured-JSON Meili 500 → deterministic, must NOT be reclassified.
+    const apiError500 = new Error('internal') as Error & { name: string; httpStatus: number };
+    apiError500.name = 'MeiliSearchApiError';
+    apiError500.httpStatus = 500;
+    mockRunImageSearch.mockRejectedValueOnce(apiError500);
+
+    const res = await invoke({});
+
+    expect(res.statusCode).not.toBe(503);
+    const headers = (res as unknown as { headers: Record<string, unknown> }).headers;
+    expect(headers['Retry-After']).toBeUndefined();
+  });
 });

--- a/src/tests/api/v1/images/index.test.ts
+++ b/src/tests/api/v1/images/index.test.ts
@@ -514,8 +514,12 @@ describe('/api/v1/images transient-upstream 503 reclassification', () => {
     }
   );
 
-  it.each([408, 429, 502, 503, 504])(
-    'maps a MeiliSearchApiError(httpStatus=%i) to a retryable 503',
+  // A MeiliSearchApiError carries a STRUCTURED JSON error body — for a 5xx that
+  // is more likely a deterministic Meili-internal error than a transient
+  // brownout, so ONLY the unambiguous gateway statuses 502/503/504 reclassify to
+  // 503 (audit 🟡 #1). A JSON-body 408/429/500 ApiError is NOT masked.
+  it.each([502, 503, 504])(
+    'maps a MeiliSearchApiError(httpStatus=%i, gateway 5xx) to a retryable 503',
     async (status) => {
       mockGetImagesFromFeedSearch.mockRejectedValue(makeApiError(status));
       const { req, res } = createMocks({ query: { limit: '10' } });
@@ -525,6 +529,19 @@ describe('/api/v1/images transient-upstream 503 reclassification', () => {
       expect(res._getStatusCode()).toBe(503);
       expect(res._getHeader('Cache-Control')).toBe('no-store');
       expect(res._getHeader('Retry-After')).toBe('2');
+    }
+  );
+
+  it.each([408, 429])(
+    'does NOT mask a MeiliSearchApiError(httpStatus=%i, JSON body) as 503 — only the Communication/transport path treats 408/429 as transient',
+    async (status) => {
+      mockGetImagesFromFeedSearch.mockRejectedValue(makeApiError(status));
+      const { req, res } = createMocks({ query: { limit: '10' } });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).not.toBe(503);
+      expect(res._getHeader('Retry-After')).toBeUndefined();
     }
   );
 
@@ -587,6 +604,33 @@ describe('/api/v1/images transient-upstream 503 reclassification', () => {
       expect(res._getHeader('Retry-After')).toBeUndefined();
     }
   );
+
+  it('does NOT mask a deterministic MeiliSearchApiError(httpStatus=500) (JSON body) as 503 — bubbles to 500, no Retry-After', async () => {
+    // A structured-JSON Meili 500 is a deterministic Meili-internal error, NOT a
+    // transient brownout — it must surface as a hard error, never a retryable
+    // 503 (audit 🟡 #1 masking-guard). It isn't a TRPCError, so it falls to the
+    // generic mapping → 500.
+    mockGetImagesFromFeedSearch.mockRejectedValue(makeApiError(500));
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).not.toBe(503);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('DOES map a transport-layer MeiliSearchCommunicationError(statusCode=500) (empty body) to a retryable 503', async () => {
+    // Contrast with the ApiError above: an empty/non-JSON-body 500 is the
+    // genuinely-transient transport case → 503 with Retry-After.
+    mockGetImagesFromFeedSearch.mockRejectedValue(makeCommunicationError(500));
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(503);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+    expect(res._getHeader('Retry-After')).toBe('2');
+  });
 
   it('does NOT mask a generic app error (null deref) as 503 — bubbles to 500', async () => {
     mockGetImagesFromFeedSearch.mockRejectedValue(new Error('cannot read properties of undefined'));

--- a/src/tests/api/v1/images/index.test.ts
+++ b/src/tests/api/v1/images/index.test.ts
@@ -57,9 +57,17 @@ vi.mock('~/server/utils/region-blocking', () => ({
   isRegionRestricted: vi.fn().mockReturnValue(false),
 }));
 
-vi.mock('~/server/meilisearch/client', () => ({
-  buildSearchActor: vi.fn().mockReturnValue('mock-actor'),
-}));
+// Keep the REAL isTransientMeiliError (+ the error classes it tests against) so
+// the handler's 500→503 classification branch runs its production logic; only
+// buildSearchActor is stubbed. importOriginal pulls the real module; env/prom
+// at its module load are tolerated (no real connection opens in test).
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/meilisearch/client')>();
+  return {
+    ...actual,
+    buildSearchActor: vi.fn().mockReturnValue('mock-actor'),
+  };
+});
 
 vi.mock('request-ip', () => ({
   default: { getClientIp: () => '127.0.0.1' },
@@ -83,8 +91,18 @@ function createMocks({ query = {} }: { query?: Record<string, string | string[]>
 
   let statusCode = 200;
   let payload: any = undefined;
+  let ended = false;
+  const headers: Record<string, string> = {};
 
   const res = {
+    headersSent: false,
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+      return res;
+    },
+    getHeader(name: string) {
+      return headers[name.toLowerCase()];
+    },
     status(code: number) {
       statusCode = code;
       return res;
@@ -93,9 +111,20 @@ function createMocks({ query = {} }: { query?: Record<string, string | string[]>
       payload = body;
       return res;
     },
+    end() {
+      ended = true;
+      return res;
+    },
     _getStatusCode: () => statusCode,
     _getJSONData: () => payload,
-  } as unknown as NextApiResponse & { _getStatusCode: () => number; _getJSONData: () => any };
+    _getHeader: (name: string) => headers[name.toLowerCase()],
+    _ended: () => ended,
+  } as unknown as NextApiResponse & {
+    _getStatusCode: () => number;
+    _getJSONData: () => any;
+    _getHeader: (name: string) => string | undefined;
+    _ended: () => boolean;
+  };
 
   return { req, res };
 }
@@ -425,4 +454,179 @@ describe('/api/v1/images API Handler', () => {
     const data = res._getJSONData();
     expect(data.items[0].tags).toEqual([]);
   });
+});
+
+// ─── Transient upstream → retryable 503 (500→503 reclassification) ───────────
+//
+// The dominant remaining HTTP-500 source on this endpoint is the heavy per-user
+// feed (sort=Most Reactions & period=Year & withMeta=true) hitting a slow /
+// shed Meili backend. The feed library's inner meilisearch-js (0.33) calls
+// throw the SDK's OWN error types (MeiliSearchCommunicationError with
+// statusCode=408/503, MeiliSearchApiError with httpStatus, MeiliSearchTimeOutError)
+// — NOT TRPCErrors — so they were defaulting to a hard 500 with a bare
+// {"error":"Request Timeout"} / {"error":"Service Unavailable"} body. The
+// handler now classifies these (via isTransientMeiliError) as a retryable 503
+// with Cache-Control: no-store + Retry-After. A genuine app error / NOT_FOUND
+// must still map to its real status — NOT be masked as 503.
+describe('/api/v1/images transient-upstream 503 reclassification', () => {
+  // Faithful meilisearch-js 0.33 error shapes (see client.ts isTransientMeiliError).
+  const makeCommunicationError = (statusCode: number) => {
+    const e = new Error(statusCode === 408 ? 'Request Timeout' : 'Service Unavailable') as Error & {
+      name: string;
+      statusCode: number;
+    };
+    e.name = 'MeiliSearchCommunicationError';
+    e.statusCode = statusCode;
+    return e;
+  };
+  const makeApiError = (httpStatus: number) => {
+    const e = new Error('meilisearch upstream error') as Error & {
+      name: string;
+      httpStatus: number;
+    };
+    e.name = 'MeiliSearchApiError';
+    e.httpStatus = httpStatus;
+    return e;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetServerAuthSession.mockResolvedValue(null);
+    mockGetFeatureFlags.mockReturnValue({ datapacketRead: false, canViewNsfw: false });
+    mockGetFliptVariant.mockResolvedValue('off'); // route to getImagesFromFeedSearch
+    mockImageMetaCacheFetch.mockResolvedValue({});
+  });
+
+  it.each([408, 429, 502, 503, 504])(
+    'maps a MeiliSearchCommunicationError(statusCode=%i) to a retryable 503 (no-store + Retry-After)',
+    async (status) => {
+      mockGetImagesFromFeedSearch.mockRejectedValue(makeCommunicationError(status));
+      const { req, res } = createMocks({ query: { limit: '10' } });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(503);
+      expect(res._getJSONData()).toEqual({
+        error: 'Image search is temporarily overloaded — please retry.',
+      });
+      expect(res._getHeader('Cache-Control')).toBe('no-store');
+      expect(res._getHeader('Retry-After')).toBe('2');
+    }
+  );
+
+  it.each([408, 429, 502, 503, 504])(
+    'maps a MeiliSearchApiError(httpStatus=%i) to a retryable 503',
+    async (status) => {
+      mockGetImagesFromFeedSearch.mockRejectedValue(makeApiError(status));
+      const { req, res } = createMocks({ query: { limit: '10' } });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(503);
+      expect(res._getHeader('Cache-Control')).toBe('no-store');
+      expect(res._getHeader('Retry-After')).toBe('2');
+    }
+  );
+
+  it('maps a MeiliSearchTimeOutError to a retryable 503', async () => {
+    const e = new Error('timeout of 5000ms has exceeded ...') as Error & { name: string };
+    e.name = 'MeiliSearchTimeOutError';
+    mockGetImagesFromFeedSearch.mockRejectedValue(e);
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(503);
+    expect(res._getHeader('Retry-After')).toBe('2');
+  });
+
+  it('maps a TRPCError SERVICE_UNAVAILABLE (the service-wrapped path) to 503 WITH no-store + Retry-After', async () => {
+    const trpcError = Object.assign(new Error('Image search is temporarily overloaded — please retry.'), {
+      code: 'SERVICE_UNAVAILABLE',
+      name: 'TRPCError',
+    });
+    mockGetImagesFromFeedSearch.mockRejectedValue(trpcError);
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(503);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+    expect(res._getHeader('Retry-After')).toBe('2');
+  });
+
+  it('does NOT mask a TRPCError NOT_FOUND as 503 — keeps its real 404 (no Retry-After)', async () => {
+    const notFound = Object.assign(new Error('Image not found'), {
+      code: 'NOT_FOUND',
+      name: 'TRPCError',
+    });
+    mockGetImagesFromFeedSearch.mockRejectedValue(notFound);
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    const data = res._getJSONData();
+    expect(data.code).toBe('NOT_FOUND');
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it.each([400, 401, 403])(
+    'does NOT mask a non-transient upstream %i (real client/app error) as 503',
+    async (status) => {
+      // A 4xx-other from the SDK (e.g. malformed filter / auth) must surface as a
+      // hard error, NOT a retryable 503. It isn't a TRPCError, so it falls to the
+      // generic mapping → 500 (the correct "genuine failure must still surface"
+      // behaviour). The key assertion: it is NOT 503 and carries NO Retry-After.
+      mockGetImagesFromFeedSearch.mockRejectedValue(makeCommunicationError(status));
+      const { req, res } = createMocks({ query: { limit: '10' } });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).not.toBe(503);
+      expect(res._getHeader('Retry-After')).toBeUndefined();
+    }
+  );
+
+  it('does NOT mask a generic app error (null deref) as 503 — bubbles to 500', async () => {
+    mockGetImagesFromFeedSearch.mockRejectedValue(new Error('cannot read properties of undefined'));
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).not.toBe(503);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('happy path is unchanged (200) with no Retry-After header', async () => {
+    mockGetImagesFromFeedSearch.mockResolvedValue(mockImagesResult);
+    const { req, res } = createMocks({ query: { limit: '10' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  const mockImagesResult = {
+    items: [
+      {
+        id: 100,
+        url: 'test-uuid',
+        hash: 'U36kF+Z#',
+        width: 832,
+        height: 1216,
+        nsfwLevel: 1,
+        type: 'image',
+        createdAt: new Date('2026-03-04T16:10:46.428Z'),
+        postId: 27016856,
+        stats: {},
+        user: { username: 'forest919' },
+        baseModel: 'Anima',
+        modelVersionIds: [2653283],
+        tags: [],
+      },
+    ],
+    nextCursor: 'cursor_val',
+  };
 });


### PR DESCRIPTION
## Problem

Measured on dp-prod (post-#2746), `/api/v1/images` is the dominant remaining HTTP-500 source: **~98/15m (0.11/s)**. Captured 500 response bodies:

- `{"error":"Request Timeout"}`
- `{"error":"Service Unavailable"}`

62 of ~80 failures are heavy **per-user feeds**: `sort=Most Reactions & period=Year & withMeta=true & nsfw=true & username=<X>` — slow Meili search + metric enrichment on big galleries. These are upstream **timeout / 503** responses that the handler mapped to HTTP **500** instead of a retryable **503**.

## Root cause (the exact misclassified error types)

The REST feed path runs through event-engine-common's `populatedQuery`, whose **inner meilisearch-js (0.33)** calls throw the **SDK's own error types** on a slow/shed backend — NOT civitai's `MeilisearchFetchError` / `MeiliCallTimeoutError` (those wrap only the direct raw-fetch path, so the handler's existing 503 branch missed them):

- When the proxy/backend returns **408** ("Request Timeout") or **503** ("Service Unavailable") with an **empty/non-JSON body**, the SDK's `httpResponseErrorHandler` can't parse the body and throws **`MeiliSearchCommunicationError`** with `message = response.statusText` (→ "Request Timeout" / "Service Unavailable") and `statusCode = response.status`. (`node_modules/meilisearch/dist/bundles/meilisearch.cjs.js:119,182`)
- When the body **is** a parseable error JSON, it throws **`MeiliSearchApiError`** carrying `httpStatus`.

Neither is a `TRPCError`, so they fell through every existing 503 branch in `getImagesFromFeedSearch` and re-threw → the handler's generic `getHTTPStatusCodeFromError` defaulted them to **500**, with `code` undefined (hence the bare `{"error":"<statusText>"}` body with no `code` field).

## Fix (500 → 503 reclassification)

New predicate **`isTransientMeiliError`** (`src/server/meilisearch/client.ts`) classifies genuinely-transient upstream failures and maps them to a retryable **503** (`SERVICE_UNAVAILABLE`) with `Cache-Control: no-store` + `Retry-After: 2`, mirroring the existing Meili-503 path:

- civitai wrappers: `MeiliCallTimeoutError`, `MeilisearchFetchError` with a failfast status
- SDK `MeiliSearchCommunicationError` with a transient `.statusCode` (**408/429/502/503/504**) OR a network-level failure (`.code`/`.errno`, no HTTP status — backend unreachable)
- SDK `MeiliSearchApiError` (structured-JSON body) **ONLY** for the unambiguous gateway statuses **502/503/504** — see the audit follow-up below; a JSON-body **500** is deterministic and must surface as a hard 500
- SDK `MeiliSearchTimeOutError` (name-matched, survives a duplicated-SDK-copy `instanceof` miss across the submodule boundary)
- the raw-fetch local-deadline error (`FETCH_DOCUMENTS_TIMEOUT_MESSAGE`)

Applied at the **service layer** (`getImagesFromFeedSearch` + `getAllImagesIndex` catches wrap → TRPCError `SERVICE_UNAVAILABLE`) and as **defense-in-depth** in the REST handler (a raw SDK error escaping the wrap still becomes 503-with-headers). Also extended `isFailfastStatus` to include **429** (transient upstream rate-limit is retryable).

### Statuses now mapped to 503
**408, 429, 502, 503, 504** (+ SDK/local timeout, + backend-unreachable network errors).

## ⚠️ Honesty note — this is a reclassification, not a perf fix

This correctly classifies **transient** timeouts / upstream-5xx as retryable 503 (removing them from the hard-500 SLO and giving clients/CF a `Retry-After` to honor). It does **not** fix the underlying latency: the heavy Most-Reactions/Year/withMeta per-user feeds + Meili saturation on big galleries are unchanged and **out of scope** — the real fix is the feed/Meili performance work.

The predicate is deliberately **narrow**: a **4xx-other** (400 malformed filter, 401/403 auth) and any non-Meili `Error` are NOT treated as transient and still surface as their **real** status — a genuine 500-class bug must still be a **500**. We do not mask deterministic failures as 503.

## Test coverage

- **`isTransientMeiliError` unit suite** (`src/server/meilisearch/__tests__/client.test.ts`): CommunicationError 408/429/502/503/504 (and empty-body 500) → `true`; ApiError **502/503/504 → `true`, 500 → `false`** (deterministic, see audit #1); network-level comm error, SDK timeout, civitai wrappers, raw-fetch deadline → `true`; **400/401/403/404/422 + unrelated/non-error values → `false`**.
- **Handler-level** (`src/tests/api/v1/images/index.test.ts`): each transient shape → **503** + `no-store` + `Retry-After`; service-wrapped `TRPCError SERVICE_UNAVAILABLE` → 503-with-headers; **`TRPCError NOT_FOUND` stays 404** (no Retry-After); 4xx-other / generic app error stays **non-503**; happy path unchanged (200).

All relevant vitest green (92 tests across the touched files). Zero new `tsc --noEmit` errors in changed files (the only repo tsc errors are pre-existing `@civitai/client` SDK type drift in unrelated orchestrator handlers).

## Expected impact

Removes the transient timeout/Service-Unavailable class (the ~98/15m `{"error":"Request Timeout"}` / `{"error":"Service Unavailable"}` 500s) from the hard-500 SLO by serving them as retryable 503s. The residual latency on those heavy feeds remains and needs the separate Meili/feed-perf work.

## Audit follow-ups (commit `e470050`)

Adversarial audit returned "safe to merge" with three 🟡 quality items, now folded in:

1. **Don't mask a deterministic Meili-500 as retryable 503.** The SDK throws `MeiliSearchApiError` (carries `httpStatus`) **only** when Meili returns a **structured JSON error body** — for a 5xx that is more likely a *deterministic* Meili-internal error than a transient brownout. `isTransientMeiliError` now treats the **ApiError** path as transient **only for 502/503/504** (a JSON-body **500 bubbles as a hard 500**), while the **`MeiliSearchCommunicationError`** (empty/non-JSON body, transport layer) path is unchanged — 408/429/5xx **including an empty-body 500** stay transient. The Api-vs-Communication split is now the explicit guard: a 500 is transient **only** when it's a transport (Communication) error, never a structured ApiError.

2. **`/api/v1/blocks/images` sibling aligned.** It still used the old raw-SDK `MeiliCallTimeoutError`/`MeilisearchFetchError`-only branch and returned 503 **without** `Cache-Control: no-store` + `Retry-After`, despite a comment claiming it mirrors the public endpoint. Now uses the same `isTransientMeiliError` predicate and attaches `no-store` + `Retry-After: 2` on the 503 (and on a service-wrapped `TRPCError` 503), so the retryable contract matches.

3. **Labeled counter keeps a Meili outage attributable.** The reclassified 503s were moving into an **unlabeled** 503 bucket. The two service catches (`getImagesFromFeedSearch` + `getAllImagesIndex`) now increment the existing **`meiliFetchFailfastTotal{route, reason}`** (`iteration:'0'`) via a new `failfastReasonForTransientError()` helper that reuses `failfastReasonForStatus` and adds the timeout/network reason buckets — mirroring the post-filter loop's counter usage. No new metric added.

Tests added: ApiError(500)→bubbles-500 vs Communication(500)→503 split pinned in **both** the client predicate and the public handler; blocks/images transient→503+`Retry-After`/`no-store` + deterministic-500-bubbles; service-catch `{route, reason}` counter contract + `failfastReasonForTransientError` mapping. Existing ApiError `it.each` updated to the new 502/503/504-only contract. All affected suites green (103 tests across 4 files); zero new tsc errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

