### PR TITLE
feat(training): add Krea 2 LoRA training (AI-Toolkit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@axiomhq/axiom-node": "^0.12.0",
     "@civitai/app-sdk": "^0.6.0",
     "@civitai/blocks-react": "^0.4.0",
-    "@civitai/client": "0.2.0-beta.74",
+    "@civitai/client": "0.2.0-beta.75",
     "@civitai/cybertipline-tools": "^0.1.0",
     "@civitai/next-axiom": "^0.17.0",
     "@clavata/sdk": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.2(@civitai/app-sdk@0.6.0)(react@18.3.1)
       '@civitai/client':
-        specifier: 0.2.0-beta.74
-        version: 0.2.0-beta.74
+        specifier: 0.2.0-beta.75
+        version: 0.2.0-beta.75
       '@civitai/cybertipline-tools':
         specifier: ^0.1.0
         version: 0.1.0
@@ -1219,8 +1219,8 @@ packages:
       '@civitai/app-sdk': ^0.6.0
       react: ^18.0.0 || ^19.0.0
 
-  '@civitai/client@0.2.0-beta.74':
-    resolution: {integrity: sha512-yLA3qwH1AJk4gYeYIqUM8qDAV29Ai+Qixjldr+bbjSnY6YaQXIOr14uoy8ZtkkcUzrRBeUXyOd033f14hqPbGA==}
+  '@civitai/client@0.2.0-beta.75':
+    resolution: {integrity: sha512-fCTqT4TvDwXU/qlB3k4yMoCbKM9RLcslP6JBYWRQxp4tdph1SSJwOBG8fC5nuVz45hnQ98anVuUaYrB99RfREA==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
   '@civitai/cybertipline-tools@0.1.0':
@@ -11497,7 +11497,7 @@ snapshots:
       '@civitai/app-sdk': 0.6.0
       react: 18.3.1
 
-  '@civitai/client@0.2.0-beta.74':
+  '@civitai/client@0.2.0-beta.75':
     dependencies:
       '@hey-api/client-fetch': 0.1.14
       rfc6902: 5.2.0

--- a/src/components/Training/Form/TrainingParams.tsx
+++ b/src/components/Training/Form/TrainingParams.tsx
@@ -160,6 +160,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { default: 'ai-toolkit' } },
       anima: { all: { default: 'ai-toolkit' } },
       boogu: { all: { default: 'ai-toolkit' } },
+      krea2: { all: { default: 'ai-toolkit' } },
       acestep_15: { all: { default: 'ai-toolkit' } },
       acestep_15_xl_base: { all: { default: 'ai-toolkit' } },
       acestep_15_xl_sft: { all: { default: 'ai-toolkit' } },
@@ -202,6 +203,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       boogu: {
         all: { default: 5 },
       },
+      // Krea 2 uses the standard 10 epochs (= base default) per the model owners' spec.
       ltx2: {
         all: { min: 1, max: 20 },
       },
@@ -273,6 +275,10 @@ export const trainingSettings: TrainingSettingsType[] = [
       },
       // Boogu batch size is fixed at 1 for this ecosystem (per @civitai/client).
       boogu: {
+        all: { default: 1, min: 1, max: 1 },
+      },
+      // Krea 2 batch size is fixed at 1 for this ecosystem (per @civitai/client).
+      krea2: {
         all: { default: 1, min: 1, max: 1 },
       },
       ltx2: { all: { default: 2, min: 1, max: 4 } },
@@ -367,6 +373,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { default: 1024 } },
       anima: { all: { default: 1024 } },
       boogu: { all: { default: 1024 } },
+      krea2: { all: { default: 1024 } },
       ltx2: { all: { disabled: true, default: 960, min: 960, max: 960 } },
       ltx23: { all: { disabled: true, default: 960, min: 960, max: 960 } },
       // Audio has no spatial resolution — disable but keep a value the WhatIf schema accepts.
@@ -418,6 +425,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { disabled: true } },
       anima: { all: { disabled: true } },
       boogu: { all: { disabled: true } },
+      krea2: { all: { disabled: true } },
       acestep_15: { all: { disabled: true } },
       acestep_15_xl_base: { all: { disabled: true } },
       acestep_15_xl_sft: { all: { disabled: true } },
@@ -461,6 +469,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { disabled: true } },
       anima: { all: { disabled: true } },
       boogu: { all: { disabled: true } },
+      krea2: { all: { disabled: true } },
       acestep_15: { all: { disabled: true } },
       acestep_15_xl_base: { all: { disabled: true } },
       acestep_15_xl_sft: { all: { disabled: true } },
@@ -531,6 +540,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { default: 1e-4 } },
       anima: { all: { default: 1e-4 } },
       boogu: { all: { default: 1e-4 } },
+      krea2: { all: { default: 1e-4 } },
       acestep_15: { all: { default: 1e-4 } },
       acestep_15_xl_base: { all: { default: 1e-4 } },
       acestep_15_xl_sft: { all: { default: 1e-4 } },
@@ -567,6 +577,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { disabled: true, default: 0, max: 0 } },
       anima: { all: { disabled: true, default: 0, max: 0 } },
       boogu: { all: { disabled: true, default: 0, max: 0 } },
+      krea2: { all: { disabled: true, default: 0, max: 0 } },
       acestep_15: { all: { disabled: true, default: 0, max: 0 } },
       acestep_15_xl_base: { all: { disabled: true, default: 0, max: 0 } },
       acestep_15_xl_sft: { all: { disabled: true, default: 0, max: 0 } },
@@ -600,6 +611,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { default: 'constant' } },
       anima: { all: { default: 'constant' } },
       boogu: { all: { default: 'constant' } },
+      krea2: { all: { default: 'constant' } },
       acestep_15: { all: { default: 'constant' } },
       acestep_15_xl_base: { all: { default: 'constant' } },
       acestep_15_xl_sft: { all: { default: 'constant' } },
@@ -661,6 +673,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { disabled: true, default: 0, max: 0 } },
       anima: { all: { disabled: true, default: 0, max: 0 } },
       boogu: { all: { disabled: true, default: 0, max: 0 } },
+      krea2: { all: { disabled: true, default: 0, max: 0 } },
       acestep_15: { all: { disabled: true, default: 0, max: 0 } },
       acestep_15_xl_base: { all: { disabled: true, default: 0, max: 0 } },
       acestep_15_xl_sft: { all: { disabled: true, default: 0, max: 0 } },
@@ -690,6 +703,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { default: 32 } },
       anima: { all: { default: 32 } },
       boogu: { all: { default: 32 } },
+      krea2: { all: { default: 32 } },
       acestep_15: { all: { default: 32 } },
       acestep_15_xl_base: { all: { default: 32 } },
       acestep_15_xl_sft: { all: { default: 32 } },
@@ -736,6 +750,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { default: 32 } },
       anima: { all: { default: 32 } },
       boogu: { all: { default: 32 } },
+      krea2: { all: { default: 32 } },
       acestep_15: { all: { default: 32 } },
       acestep_15_xl_base: { all: { default: 32 } },
       acestep_15_xl_sft: { all: { default: 32 } },
@@ -765,6 +780,7 @@ export const trainingSettings: TrainingSettingsType[] = [
       hidream_o1: { all: { default: 0 } },
       anima: { all: { default: 0 } },
       boogu: { all: { default: 0 } },
+      krea2: { all: { default: 0 } },
       acestep_15: { all: { disabled: true, default: 0, min: 0, max: 0 } },
       acestep_15_xl_base: { all: { disabled: true, default: 0, min: 0, max: 0 } },
       acestep_15_xl_sft: { all: { disabled: true, default: 0, min: 0, max: 0 } },
@@ -842,6 +858,9 @@ export const trainingSettings: TrainingSettingsType[] = [
         all: { default: optimizerArgMapFlux.AdamW8Bit.kohya },
       },
       boogu: {
+        all: { default: optimizerArgMapFlux.AdamW8Bit.kohya },
+      },
+      krea2: {
         all: { default: optimizerArgMapFlux.AdamW8Bit.kohya },
       },
       ltx2: { all: { default: optimizerArgMapVideo.AdamW8Bit } },

--- a/src/components/Training/Form/TrainingSubmitModelSelect.tsx
+++ b/src/components/Training/Form/TrainingSubmitModelSelect.tsx
@@ -31,6 +31,7 @@ import {
   trainingDetailsBaseModelsAcestep15Xl,
   trainingDetailsBaseModelsAnima,
   trainingDetailsBaseModelsBoogu,
+  trainingDetailsBaseModelsKrea2,
   trainingDetailsBaseModelsChroma,
   trainingDetailsBaseModelsErnie,
   trainingDetailsBaseModelsFlux,
@@ -485,6 +486,11 @@ export const ModelSelect = ({
     (trainingDetailsBaseModelsBoogu as ReadonlyArray<string>).includes(formBaseModel)
       ? formBaseModel
       : null;
+  const baseModelKrea2 =
+    !!formBaseModel &&
+    (trainingDetailsBaseModelsKrea2 as ReadonlyArray<string>).includes(formBaseModel)
+      ? formBaseModel
+      : null;
   const baseModelAcestep15 =
     !!formBaseModel &&
     (trainingDetailsBaseModelsAcestep15 as ReadonlyArray<string>).includes(formBaseModel)
@@ -663,6 +669,17 @@ export const ModelSelect = ({
                       isNew={new Date() < new Date('2026-07-19')}
                     />
                   )}
+                  {features.krea2Training && (
+                    <ModelSelector
+                      selectedRun={selectedRun}
+                      color="cyan"
+                      name="Krea 2"
+                      value={baseModelKrea2}
+                      baseType="krea2"
+                      makeDefaultParams={makeDefaultParams}
+                      isNew={new Date() < new Date('2026-07-24')}
+                    />
+                  )}
                 </>
               )}
               {mediaType === 'audio' && (
@@ -801,6 +818,7 @@ export const ModelSelect = ({
                   selectedRun.baseType === 'hidream-o1' ||
                   selectedRun.baseType === 'anima' ||
                   selectedRun.baseType === 'boogu' ||
+                  selectedRun.baseType === 'krea2' ||
                   selectedRun.baseType === 'acestep15' ||
                   selectedRun.baseType === 'acestep15xl' ? (
                   <AlertWithIcon icon={<IconAlertCircle />} iconColor="default" p="xs">

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -81,6 +81,7 @@ export const trainingDetailsBaseModelsErnie = ['ernie'] as const;
 export const trainingDetailsBaseModelsHiDreamO1 = ['hidream_o1'] as const;
 export const trainingDetailsBaseModelsAnima = ['anima'] as const;
 export const trainingDetailsBaseModelsBoogu = ['boogu'] as const;
+export const trainingDetailsBaseModelsKrea2 = ['krea2'] as const;
 export const trainingDetailsBaseModelsAcestep15 = ['acestep_15'] as const;
 export const trainingDetailsBaseModelsAcestep15Xl = [
   'acestep_15_xl_base',
@@ -101,6 +102,7 @@ const trainingDetailsBaseModelsImage = [
   ...trainingDetailsBaseModelsHiDreamO1,
   ...trainingDetailsBaseModelsAnima,
   ...trainingDetailsBaseModelsBoogu,
+  ...trainingDetailsBaseModelsKrea2,
 ] as const;
 const trainingDetailsBaseModelsVideo = [
   ...trainingDetailsBaseModelsHunyuan,

--- a/src/server/schema/orchestrator/training.schema.ts
+++ b/src/server/schema/orchestrator/training.schema.ts
@@ -105,6 +105,10 @@ const aiToolkitTrainingParams = z
       ecosystem: z.literal('boogu'),
       modelVariant: z.undefined().optional(),
     }),
+    aiToolkitBaseParams.extend({
+      ecosystem: z.literal('krea2'),
+      modelVariant: z.undefined().optional(),
+    }),
     // SD3, Flux1, Flux2Klein, and Wan require modelVariant
     aiToolkitBaseParams.extend({
       ecosystem: z.literal('sd3'),

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -80,6 +80,7 @@ const featureFlags = createFeatureFlags({
   hidreamO1Training: { availability: ['mod'], fliptKey: 'hidream-o1-training' },
   animaTraining: { availability: ['mod'], fliptKey: 'anima-training' },
   booguTraining: { availability: ['mod'], fliptKey: 'boogu-training' },
+  krea2Training: { availability: ['mod'], fliptKey: 'krea2-training' },
   audioTraining: { availability: ['mod'], fliptKey: 'audio-training' },
   // Steps-based training pricing + QOL inputs (steps/batchSize/sample params/continue-training).
   // Public availability so it can be rolled out to a tester segment via Flipt; default off.

--- a/src/server/services/orchestrator/training/training.orch.ts
+++ b/src/server/services/orchestrator/training/training.orch.ts
@@ -169,7 +169,7 @@ const createTrainingStep_AiToolkit = (input: ImageTrainingStepSchema): TrainingS
 
   let trainingInput: AiToolkitTrainingInput = {
     engine: 'ai-toolkit',
-    ecosystem: aiToolkitParams.ecosystem as any, // Type assertion for new ecosystems (qwen, chroma, zimageturbo, zimagebase) until @civitai/client is updated
+    ecosystem: aiToolkitParams.ecosystem,
 
     ...(aiToolkitParams.modelVariant && { modelVariant: aiToolkitParams.modelVariant }),
     trainingData: {

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -980,8 +980,9 @@ export const ecosystemSupport: EcosystemSupport[] = [
   { ecosystemId: ECO.Ernie, supportType: 'generation', modelTypes: checkpointAndLora },
   { ecosystemId: ECO.Ernie, supportType: 'training', modelTypes: loraOnly },
 
-  // Krea 2 - checkpoint only (locked, no LoRA support)
+  // Krea 2 - checkpoint only generation (locked, no LoRA support); LoRA training via AI-Toolkit
   { ecosystemId: ECO.Krea2, supportType: 'generation', modelTypes: checkpointOnly },
+  { ecosystemId: ECO.Krea2, supportType: 'training', modelTypes: loraOnly },
 
   // MAI - checkpoint only (Microsoft MAI-Image-2.5, locked, no LoRA support)
   { ecosystemId: ECO.MAI, supportType: 'generation', modelTypes: checkpointOnly },
@@ -3272,7 +3273,6 @@ export function getRootEcosystem(ecosystemIdOrBaseModel: number | string): Ecosy
   }
   return ecosystem;
 }
-
 
 /**
  * Clip skip is a CLIP text-encoder concept that only applies to the Stable

--- a/src/utils/training.ts
+++ b/src/utils/training.ts
@@ -23,6 +23,7 @@ export const trainingBaseModelTypesImage = [
   'hidream-o1',
   'anima',
   'boogu',
+  'krea2',
 ] as const;
 export const trainingBaseModelTypesVideo = ['hunyuan', 'wan', 'ltx2', 'ltx23'] as const;
 export const trainingBaseModelTypesAudio = ['acestep15', 'acestep15xl'] as const;
@@ -336,6 +337,20 @@ export const trainingModelInfo: {
     aiToolkit: { ecosystem: 'boogu' },
   },
   //
+  krea2: {
+    label: 'Base',
+    pretty: 'Krea 2',
+    type: 'krea2',
+    description: "Krea AI's in-house image generation model.",
+    // Krea 2 is an AI-Toolkit-only ecosystem, so this AIR is NOT sent as the orchestrator
+    // `model` (the orchestrator resolves the base model from the ecosystem); it's only used for
+    // UI display / getModel. Points at the locked Krea 2 generation checkpoint.
+    air: 'urn:air:krea2:checkpoint:civitai:2656567@2983022',
+    baseModel: 'Krea 2',
+    isNew: true,
+    aiToolkit: { ecosystem: 'krea2' },
+  },
+  //
   flux2klein_4b: {
     label: '4B Base',
     pretty: 'Flux.2 Klein 4B Base',
@@ -516,6 +531,7 @@ const baseTypeToEcosystem: Partial<Record<TrainingBaseModelType, string>> = {
   'hidream-o1': 'hidream-o1',
   anima: 'anima',
   boogu: 'boogu',
+  krea2: 'krea2',
   acestep15: 'ace_step_15',
   acestep15xl: 'ace_step_15_xl',
 };
@@ -613,6 +629,7 @@ export const isAiToolkitSupported = (baseType: TrainingBaseModelType): boolean =
     'hidream-o1',
     'anima',
     'boogu',
+    'krea2',
     'acestep15',
     'acestep15xl',
   ];
@@ -631,6 +648,7 @@ export const isAiToolkitMandatory = (baseType: TrainingBaseModelType): boolean =
     'hidream-o1',
     'anima',
     'boogu',
+    'krea2',
     'acestep15',
     'acestep15xl',
   ];
@@ -658,6 +676,7 @@ export const getDefaultEngine = (
   if (baseType === 'hidream-o1') return 'ai-toolkit'; // HiDream O1 requires AI Toolkit
   if (baseType === 'anima') return 'ai-toolkit'; // Anima requires AI Toolkit
   if (baseType === 'boogu') return 'ai-toolkit'; // Boogu requires AI Toolkit
+  if (baseType === 'krea2') return 'ai-toolkit'; // Krea 2 requires AI Toolkit
   if (baseType === 'acestep15' || baseType === 'acestep15xl') return 'ai-toolkit'; // Audio models require AI Toolkit
   if (baseType === 'wan') return 'ai-toolkit'; // Wan defaults to AI Toolkit
   if (baseType === 'hunyuan') return 'musubi';


### PR DESCRIPTION
Wires Krea 2 into the training form as an AI-Toolkit-only image base model (baseType/key `krea2`), gated behind the mod-only `krea2Training` flag (Flipt `krea2-training`). Uses Krea 1 (Flux.1 Krea) family defaults in the meantime: batch fixed at 1, res 1024, TE/minSNR/shuffle/keepTokens disabled, dim/alpha 32, LR 1e-4, constant scheduler, noiseOffset 0, steps/saveEvery 2000/200.

Note: native `krea2` orchestrator training grain is not deployed yet, so submissions currently error with "No derived type found for discriminator value 'krea2'" until the orchestrator registers it.