### PR TITLE
fix(meili): classify stripped-statusText plain Errors as transient (503, not 500) on /api/v1/images

### DIFF
--- a/src/server/meilisearch/__tests__/client.test.ts
+++ b/src/server/meilisearch/__tests__/client.test.ts
@@ -900,6 +900,93 @@ describe('isTransientMeiliError — transient upstream classification', () => {
     ambiguous.name = 'MeiliSearchCommunicationError';
     expect(isTransientMeiliError(ambiguous)).toBe(false);
   });
+
+  // ── statusText-message fallback: the STRIPPED PROD SHAPE #2759 missed ──────
+  //
+  // Captured live on dp-prod AFTER #2759 deployed: GET /api/v1/images returned a
+  // hard 500 with body {"error":"Service Unavailable"} / {"error":"Request
+  // Timeout"} and NO `code` field. The error reaching the service catch is a
+  // PLAIN Error — NO Meili `name`, NO `statusCode`/`httpStatus`/`code`/`errno` —
+  // carrying ONLY `message = <HTTP statusText>` (the structured SDK shape is lost
+  // crossing the event-engine-common submodule boundary; only `statusText`
+  // survives). #2759's tests passed because they built the RAW SDK error (name +
+  // statusCode), which prod never sees. These tests pin the PROD shape directly.
+  it.each([
+    'Request Timeout', // 408
+    'Too Many Requests', // 429
+    'Bad Gateway', // 502
+    'Service Unavailable', // 503
+    'Gateway Timeout', // 504
+  ])(
+    'returns TRUE for a PLAIN Error whose message is ONLY the transient statusText "%s" (no name, no statusCode — the prod shape)',
+    async (statusText) => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      // Deliberately a bare Error: no .name, no .statusCode, no .code/.errno —
+      // exactly what arrives at the catch in prod.
+      const e = new Error(statusText);
+      expect((e as { name?: string }).name).toBe('Error'); // sanity: NOT a Meili name
+      expect((e as { statusCode?: number }).statusCode).toBeUndefined();
+      expect(isTransientMeiliError(e)).toBe(true);
+    }
+  );
+
+  it.each([
+    'Internal Server Error', // 500 — ambiguous (could be a deterministic app/Meili bug)
+    'Not Found', // 404 — real client error
+    'Bad Request', // 400
+    'Unauthorized', // 401
+    'some app bug', // arbitrary application error message
+    'null deref upstream',
+  ])(
+    'returns FALSE for a plain Error with a non-transient / arbitrary message "%s" (no masking of real bugs)',
+    async (message) => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      expect(isTransientMeiliError(new Error(message))).toBe(false);
+    }
+  );
+
+  it.each([
+    'DB error: Service Unavailable downstream',
+    'Bad Gateway error: connection reset by peer',
+    'upstream said Request Timeout after 30s',
+    'Service Unavailable', // exact — sanity that the substring cases below are the only diff
+  ])(
+    'matches EXACT statusText only, never a substring — "%s"',
+    async (message) => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      const exact = message === 'Service Unavailable';
+      // Only the bare exact reason phrase is transient; a message that merely
+      // CONTAINS it (with surrounding text) must NOT be masked as a 503.
+      expect(isTransientMeiliError(new Error(message))).toBe(exact);
+    }
+  );
+
+  it('does not match a case-mismatched statusText (exact, case-sensitive)', async () => {
+    const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+    expect(isTransientMeiliError(new Error('service unavailable'))).toBe(false);
+    expect(isTransientMeiliError(new Error('SERVICE UNAVAILABLE'))).toBe(false);
+    expect(isTransientMeiliError(new Error('Service Unavailable '))).toBe(false); // trailing space
+  });
+
+  it('exposes TRANSIENT_STATUSTEXT_TO_STATUS mapping the same statuses isFailfastStatus treats transient', async () => {
+    const { TRANSIENT_STATUSTEXT_TO_STATUS, isFailfastStatus } = await import(
+      '~/server/meilisearch/client'
+    );
+    // Every mapped status must itself be fast-fail eligible (no drift between
+    // the statusText set and the numeric predicate).
+    for (const status of Object.values(TRANSIENT_STATUSTEXT_TO_STATUS)) {
+      expect(isFailfastStatus(status)).toBe(true);
+    }
+    expect(TRANSIENT_STATUSTEXT_TO_STATUS).toMatchObject({
+      'Request Timeout': 408,
+      'Too Many Requests': 429,
+      'Bad Gateway': 502,
+      'Service Unavailable': 503,
+      'Gateway Timeout': 504,
+    });
+    // Notably ABSENT: a bare "Internal Server Error" (500) — not masked.
+    expect('Internal Server Error' in TRANSIENT_STATUSTEXT_TO_STATUS).toBe(false);
+  });
 });
 
 // ─── failfastReasonForTransientError: label mapping for the reclassified 503s ──
@@ -967,6 +1054,24 @@ describe('failfastReasonForTransientError — reason label mapping', () => {
     e.errno = 'ECONNREFUSED';
     expect(failfastReasonForTransientError(e)).toBe('upstream-error');
   });
+
+  // The stripped prod shape (plain Error, message-only) must derive the SAME
+  // reason label its status code would have produced via failfastReasonForStatus,
+  // so message-matched 503s bucket identically to their typed CommunicationError
+  // twins in meiliFetchFailfastTotal.
+  it.each([
+    ['Request Timeout', 'upstream-timeout'], // 408
+    ['Too Many Requests', 'upstream-error'], // 429 → generic (failfastReasonForStatus default)
+    ['Bad Gateway', 'upstream-error'], // 502
+    ['Service Unavailable', 'upstream-overload'], // 503
+    ['Gateway Timeout', 'upstream-error'], // 504
+  ])(
+    'maps a plain-Error statusText "%s" to %s (same label as the matching status code)',
+    async (message, expectedReason) => {
+      const { failfastReasonForTransientError } = await import('~/server/meilisearch/client');
+      expect(failfastReasonForTransientError(new Error(message))).toBe(expectedReason);
+    }
+  );
 });
 
 // ─── Service-catch counter contract (audit 🟡 #3) ────────────────────────────

--- a/src/server/meilisearch/__tests__/client.test.ts
+++ b/src/server/meilisearch/__tests__/client.test.ts
@@ -968,6 +968,101 @@ describe('isTransientMeiliError — transient upstream classification', () => {
     expect(isTransientMeiliError(new Error('Service Unavailable '))).toBe(false); // trailing space
   });
 
+  // ── THE REAL PROD SHAPE (audit-confirmed) — name PRESERVED, statusCode DROPPED ──
+  //
+  // This is the test that would have caught #2759 AND #2765. The audit traced the
+  // ACTUAL bundled meilisearch-js (0.33/0.34, both confirmed): the error reaching
+  // the service catch is a `MeiliSearchCommunicationError` with
+  //   name = 'MeiliSearchCommunicationError'  (INTACT — NOT stripped)
+  //   statusCode = undefined                  (DROPPED)
+  //   message = 'Service Unavailable' / etc.  (the surviving statustext)
+  //
+  // Mechanism: `httpResponseErrorHandler` throws
+  // `MeiliSearchCommunicationError(statusText, Response, url)` (sets message +
+  // statusCode); then `request()`'s catch re-wraps via `httpErrorHandler` →
+  // `new MeiliSearchCommunicationError(firstErr.message, firstErr, url, stack)`.
+  // The 2nd arg is now an Error (not a Response), so the constructor's
+  // `if (body instanceof Response)` block that sets `statusCode` does NOT run →
+  // statusCode dropped — but the constructor still sets `this.name`.
+  //
+  // The OLD code's CommunicationError branch saw `statusCode === undefined` + no
+  // errno/code and `return`ed false BEFORE the terminal message lookup ran — so
+  // #2759/#2765's statustext fallback was DEAD CODE for the real shape and the
+  // handler still emitted a hard 500 `{"error":"Service Unavailable"}`. The fix
+  // makes the message lookup reachable in this branch. These tests construct the
+  // proven shape directly (name set, statusCode undefined) and would FAIL against
+  // the pre-fix code (which returned false here).
+  describe('real prod shape — MeiliSearchCommunicationError, name preserved, statusCode dropped', () => {
+    // Replicate the SDK double-wrap end-product faithfully: name set,
+    // statusCode left undefined (never assigned by the 2nd constructor call),
+    // message = the surviving statustext. No errno/code (this is a
+    // server-responded transport error re-wrap, not a network ECONNREFUSED).
+    const makeRewrappedCommunicationError = (statusText: string) => {
+      const e = new Error(statusText) as Error & { name: string; statusCode?: number };
+      e.name = 'MeiliSearchCommunicationError';
+      // statusCode intentionally NOT set — this is the dropped-status reality.
+      return e;
+    };
+
+    it.each([
+      'Request Timeout', // 408
+      'Too Many Requests', // 429
+      'Bad Gateway', // 502
+      'Service Unavailable', // 503 — the dominant captured prod body
+      'Gateway Timeout', // 504
+    ])(
+      'returns TRUE for the re-wrapped CommunicationError "%s" (name kept, statusCode undefined)',
+      async (statusText) => {
+        const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+        const e = makeRewrappedCommunicationError(statusText);
+        // Pin the proven shape so a regression in the test's own construction is loud.
+        expect(e.name).toBe('MeiliSearchCommunicationError');
+        expect((e as { statusCode?: number }).statusCode).toBeUndefined();
+        expect((e as { code?: string }).code).toBeUndefined();
+        expect((e as { errno?: string }).errno).toBeUndefined();
+        expect(isTransientMeiliError(e)).toBe(true);
+      }
+    );
+
+    it('failfastReasonForTransientError labels the re-wrapped CommunicationError by its statustext (503 → upstream-overload), not the generic upstream-error', async () => {
+      const { failfastReasonForTransientError } = await import('~/server/meilisearch/client');
+      expect(failfastReasonForTransientError(makeRewrappedCommunicationError('Service Unavailable'))).toBe(
+        'upstream-overload'
+      );
+      expect(failfastReasonForTransientError(makeRewrappedCommunicationError('Request Timeout'))).toBe(
+        'upstream-timeout'
+      );
+      expect(failfastReasonForTransientError(makeRewrappedCommunicationError('Bad Gateway'))).toBe(
+        'upstream-error'
+      );
+    });
+
+    it('still returns FALSE for a re-wrapped CommunicationError whose message is NOT a transient statustext (no masking of a real bug)', async () => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      // name preserved + statusCode undefined, but the message is an arbitrary
+      // app/internal error — must NOT be masked as transient.
+      expect(isTransientMeiliError(makeRewrappedCommunicationError('Internal Server Error'))).toBe(
+        false
+      );
+      expect(isTransientMeiliError(makeRewrappedCommunicationError('some internal failure'))).toBe(
+        false
+      );
+    });
+
+    it('an ApiError with httpStatus undefined falls through to the message lookup (a real Meili JSON message does NOT false-match)', async () => {
+      const { isTransientMeiliError } = await import('~/server/meilisearch/client');
+      // ApiError whose httpStatus got dropped but carries a Meili JSON message —
+      // it is NOT a bare statustext so it must stay non-transient.
+      const e = new Error('Index `images` not found.') as Error & { name: string };
+      e.name = 'MeiliSearchApiError';
+      expect(isTransientMeiliError(e)).toBe(false);
+      // ...but if such a path ever yielded a bare transient statustext, catch it.
+      const e2 = new Error('Service Unavailable') as Error & { name: string };
+      e2.name = 'MeiliSearchApiError';
+      expect(isTransientMeiliError(e2)).toBe(true);
+    });
+  });
+
   it('exposes TRANSIENT_STATUSTEXT_TO_STATUS mapping the same statuses isFailfastStatus treats transient', async () => {
     const { TRANSIENT_STATUSTEXT_TO_STATUS, isFailfastStatus } = await import(
       '~/server/meilisearch/client'

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -277,7 +277,16 @@ export function isTransientMeiliError(error: unknown): boolean {
     // (408/429 don't arrive as a parseable Meili JSON ApiError in practice; if
     // they ever do, they fall through to false → bubble as their real status,
     // which is the safe direction — we never widen masking.)
-    return typeof e.httpStatus === 'number' && [502, 503, 504].includes(e.httpStatus);
+    if (typeof e.httpStatus === 'number') {
+      return [502, 503, 504].includes(e.httpStatus);
+    }
+    // httpStatus undefined — fall through to the message lookup below. An
+    // ApiError's `.message` is the Meili JSON error message (e.g.
+    // "Index `x` not found"), NOT a bare HTTP statustext, so the EXACT-match
+    // lookup won't false-match it as transient — but if some path ever DID
+    // strip httpStatus while leaving a bare statustext message, we want it
+    // caught rather than mis-classified as a hard 500.
+    return messageMatchesTransientStatusText(e.message);
   }
 
   if (e.name === 'MeiliSearchCommunicationError') {
@@ -289,22 +298,47 @@ export function isTransientMeiliError(error: unknown): boolean {
     if (typeof e.statusCode === 'number') return isFailfastStatus(e.statusCode);
     // Network-level failure (no HTTP status, but a node errno/code) → the
     // backend was unreachable / the socket dropped, which is transient.
-    return typeof e.errno === 'string' || typeof e.code === 'string';
+    if (typeof e.errno === 'string' || typeof e.code === 'string') return true;
+    // THE REAL PROD SHAPE (audit-confirmed against meilisearch-js 0.33/0.34):
+    // the SDK's `request()` catch re-wraps the first `MeiliSearchCommunicationError`
+    // via `httpErrorHandler` → `new MeiliSearchCommunicationError(firstErr.message,
+    // firstErr, url, stack)`. The 2nd arg is now an Error (not a Response), so the
+    // constructor's `if (body instanceof Response)` block that sets `statusCode`
+    // does NOT run → `statusCode` is dropped — but `this.name` is STILL set to
+    // 'MeiliSearchCommunicationError' and `this.message` STILL carries the
+    // original statustext ("Service Unavailable" / "Request Timeout"). So here —
+    // name preserved, statusCode undefined, no errno/code — the message statustext
+    // is the only surviving signal. Fall back to the EXACT-match lookup instead of
+    // returning false (which is what made PR #2759/#2765's fallback DEAD CODE: the
+    // function exited in this branch before ever reaching the terminal lookup).
+    return messageMatchesTransientStatusText(e.message);
   }
 
-  // statusText-message fallback — the PROD shape PR #2759 missed. When the
-  // Meili SDK error crosses the `event-engine-common` submodule boundary it
-  // arrives as a PLAIN `Error` with NO name / statusCode / httpStatus / code,
-  // carrying only `message = <HTTP statusText>` (e.g. "Service Unavailable").
-  // None of the structured branches above can see it, so an EXACT (case- and
-  // whitespace-sensitive) match of `.message` against the transient reason
-  // phrases is the only signal left. EXACT, never substring — see
-  // `TRANSIENT_STATUSTEXT_TO_STATUS` JSDoc for the masking rationale.
-  if (typeof e.message === 'string') {
-    return Object.prototype.hasOwnProperty.call(TRANSIENT_STATUSTEXT_TO_STATUS, e.message);
-  }
+  // statusText-message fallback — belt-and-suspenders for a NAMELESS plain Error
+  // (in case any path DOES strip the Meili `name` too). The audit proved the real
+  // prod error keeps `.name` (handled in the CommunicationError branch above), but
+  // a stripped variant would arrive here with NO name / statusCode / httpStatus /
+  // code, carrying only `message = <HTTP statusText>`. An EXACT (case- and
+  // whitespace-sensitive) match of `.message` is the only signal left. EXACT,
+  // never substring — see `TRANSIENT_STATUSTEXT_TO_STATUS` JSDoc for the masking
+  // rationale.
+  return messageMatchesTransientStatusText(e.message);
+}
 
-  return false;
+/**
+ * EXACT (case- and whitespace-sensitive) lookup of an error message against the
+ * transient HTTP reason-phrase set. Returns true only when `message` is EXACTLY
+ * one of the bare transient statustexts (never a substring — see the masking
+ * rationale in `TRANSIENT_STATUSTEXT_TO_STATUS`). Shared by `isTransientMeiliError`
+ * so the statustext fallback is reachable on BOTH the name-preserved
+ * CommunicationError/ApiError-with-undefined-status path AND the (hypothetical)
+ * fully-stripped nameless-Error path.
+ */
+function messageMatchesTransientStatusText(message: unknown): boolean {
+  return (
+    typeof message === 'string' &&
+    Object.prototype.hasOwnProperty.call(TRANSIENT_STATUSTEXT_TO_STATUS, message)
+  );
 }
 
 /**
@@ -341,10 +375,15 @@ export function failfastReasonForTransientError(error: unknown): MeiliFetchFailf
     if (e.name === 'MeiliSearchCommunicationError' && typeof e.statusCode === 'number') {
       return failfastReasonForStatus(e.statusCode);
     }
-    // statusText-message fallback (the stripped prod-shape plain Error — see
-    // `TRANSIENT_STATUSTEXT_TO_STATUS`): derive the SAME reason label the status
-    // code would have produced, so `meiliFetchFailfastTotal` stays meaningful
-    // and the message-matched events bucket identically to their typed twins.
+    // statusText-message fallback — derive the SAME reason label the status code
+    // would have produced, so `meiliFetchFailfastTotal` stays meaningful and the
+    // message-matched events bucket identically to their typed twins. This is
+    // reached for BOTH the stripped nameless-Error AND — critically — the REAL
+    // prod shape: a `MeiliSearchCommunicationError` whose `statusCode` was dropped
+    // by the SDK's httpErrorHandler double-wrap (name preserved, statusCode
+    // undefined). Without this, that message-matched CommunicationError would fall
+    // through to the generic `upstream-error` label instead of e.g.
+    // `upstream-overload` for a "Service Unavailable" (503).
     if (typeof e.message === 'string') {
       const statusFromText = TRANSIENT_STATUSTEXT_TO_STATUS[e.message];
       if (typeof statusFromText === 'number') return failfastReasonForStatus(statusFromText);

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -168,6 +168,46 @@ export function isFailfastStatus(status: number): boolean {
 }
 
 /**
+ * Exact HTTP reason-phrase (statusText) → status code, for the transient
+ * statuses `isFailfastStatus` already treats as fast-fail-eligible.
+ *
+ * WHY THIS EXISTS — the prod 500s that PR #2759 did NOT fix:
+ * The heavy /api/v1/images feed runs Meili through the `event-engine-common`
+ * submodule's `populatedQuery`, which bundles its OWN meilisearch-js. When that
+ * inner SDK throws on a shed / slow backend, the error is re-thrown across the
+ * submodule module boundary and arrives at the civitai-side catch as a PLAIN
+ * `Error` whose ONLY signal is `message = <HTTP statusText>` (e.g.
+ * "Service Unavailable" / "Request Timeout"). The structured shape is GONE:
+ * no Meili `name` (not `MeiliSearchCommunicationError`/`ApiError`), no
+ * `statusCode`/`httpStatus`/`code`/`errno`. So every name/status branch below
+ * returned false and the handler mapped it to a hard 500 — confirmed live on
+ * dp-prod AFTER #2759 deployed: `{"error":"Service Unavailable"}` /
+ * `{"error":"Request Timeout"}` with NO `code` field. #2759's unit tests passed
+ * because they built the RAW SDK error (with name + statusCode); prod throws the
+ * stripped version.
+ *
+ * The match is DELIBERATELY EXACT (a `Set`/record lookup on the bare reason
+ * phrase), NOT a substring/`includes`: a real app error is extremely unlikely to
+ * have `.message` be EXACTLY one of these bare HTTP reason phrases, whereas a
+ * substring match would mask "Bad Gateway error: <app detail>" or arbitrary
+ * text and hide genuine bugs as retryable 503s (the audit's masking concern).
+ *
+ * Only the transient statuses are listed (mirrors `isFailfastStatus`'s
+ * 408/429/5xx, restricted to the standard gateway/timeout/overload phrases that
+ * a proxy or backend actually emits): 408/429/502/503/504. Notably ABSENT is
+ * "Internal Server Error" (500) — a bare statusText-only 500 is ambiguous
+ * (could be a deterministic app/Meili-internal bug), so it is NOT masked and
+ * bubbles as a hard 500, matching the JSON-body-500 stance below.
+ */
+export const TRANSIENT_STATUSTEXT_TO_STATUS: Readonly<Record<string, number>> = {
+  'Request Timeout': 408,
+  'Too Many Requests': 429,
+  'Bad Gateway': 502,
+  'Service Unavailable': 503,
+  'Gateway Timeout': 504,
+};
+
+/**
  * Classify an error caught from a Meilisearch SDK call (or the civitai-feeds
  * proxy in front of it) as a genuinely-transient upstream failure that should
  * surface to the client as a retryable 503, NOT a hard 500.
@@ -252,6 +292,18 @@ export function isTransientMeiliError(error: unknown): boolean {
     return typeof e.errno === 'string' || typeof e.code === 'string';
   }
 
+  // statusText-message fallback — the PROD shape PR #2759 missed. When the
+  // Meili SDK error crosses the `event-engine-common` submodule boundary it
+  // arrives as a PLAIN `Error` with NO name / statusCode / httpStatus / code,
+  // carrying only `message = <HTTP statusText>` (e.g. "Service Unavailable").
+  // None of the structured branches above can see it, so an EXACT (case- and
+  // whitespace-sensitive) match of `.message` against the transient reason
+  // phrases is the only signal left. EXACT, never substring — see
+  // `TRANSIENT_STATUSTEXT_TO_STATUS` JSDoc for the masking rationale.
+  if (typeof e.message === 'string') {
+    return Object.prototype.hasOwnProperty.call(TRANSIENT_STATUSTEXT_TO_STATUS, e.message);
+  }
+
   return false;
 }
 
@@ -288,6 +340,14 @@ export function failfastReasonForTransientError(error: unknown): MeiliFetchFailf
     }
     if (e.name === 'MeiliSearchCommunicationError' && typeof e.statusCode === 'number') {
       return failfastReasonForStatus(e.statusCode);
+    }
+    // statusText-message fallback (the stripped prod-shape plain Error — see
+    // `TRANSIENT_STATUSTEXT_TO_STATUS`): derive the SAME reason label the status
+    // code would have produced, so `meiliFetchFailfastTotal` stays meaningful
+    // and the message-matched events bucket identically to their typed twins.
+    if (typeof e.message === 'string') {
+      const statusFromText = TRANSIENT_STATUSTEXT_TO_STATUS[e.message];
+      if (typeof statusFromText === 'number') return failfastReasonForStatus(statusFromText);
     }
   }
   // Network-level CommunicationError (no HTTP status) / anything else transient

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2967,7 +2967,29 @@ export async function getImagesFromFeedSearch(
     // Unavailable"} 500 because they're not TRPCErrors and fell through the
     // generic 500 mapping). 4xx-other (malformed filter / auth) and any other
     // Error are NOT transient and still bubble as-is (→ their real status).
-    if (isTransientMeiliError(err)) {
+    const transient = isTransientMeiliError(err);
+    // DIAGNOSTIC (no PII): confirm the LIVE error SHAPE from logs instead of
+    // re-inferring it from the response body. The audit traced the real prod
+    // error to a `MeiliSearchCommunicationError` whose `.name` is PRESERVED but
+    // `.statusCode` is dropped by the SDK's httpErrorHandler double-wrap — this
+    // line lets us verify that on-cluster (error name + ctor name + whether a
+    // numeric statusCode survived + whether isTransientMeiliError matched) so
+    // the "we keep guessing the shape" loop closes. Cheap: one log line on the
+    // catch path only (not the hot success path).
+    const errShape = err as { name?: unknown; statusCode?: unknown; message?: unknown };
+    logToAxiom(
+      {
+        type: transient ? 'info' : 'warning',
+        name: 'meili-error-shape',
+        path: 'getImagesFromFeedSearch',
+        errorName: typeof errShape?.name === 'string' ? errShape.name : null,
+        ctorName: (err as { constructor?: { name?: string } })?.constructor?.name ?? null,
+        hasStatusCode: typeof errShape?.statusCode === 'number',
+        transient,
+      },
+      'temp-search'
+    ).catch();
+    if (transient) {
       // Keep a transient Meili outage ATTRIBUTABLE (see getAllImagesIndex). The
       // reclassified 503 would otherwise land in the unlabeled 503 bucket;
       // mirror the post-filter loop's {route, reason} so a Meili brownout is


### PR DESCRIPTION
## Problem (verified live on dp-prod, AFTER #2759 deployed)

PR #2759 added `isTransientMeiliError` (`src/server/meilisearch/client.ts`) to map transient Meili timeout / upstream-5xx onto a retryable **503**. It is **deployed** but did **NOT** fix the prod 500s on `/api/v1/images`. Captured during a burst:

```
GET /api/v1/images?...heavy feed... → 500  {"error":"Service Unavailable"}
GET /api/v1/images?...             → 500  {"error":"Request Timeout"}
```

## Root cause — corrected (an adversarial audit re-traced the REAL bundled SDK)

The earlier root-cause claim in this PR was **wrong on the mechanism**. The audit traced the actual bundled `meilisearch-js` (**0.33 and 0.34, both confirmed**) end-to-end and proved:

- The error reaching the service catch is a **`MeiliSearchCommunicationError`** with **`name = 'MeiliSearchCommunicationError'` INTACT** (NOT a nameless plain `Error`, NOT the cross-fetch polyfill realm mismatch the prior write-up blamed — prod runs **node:20 native fetch**).
- Its **`statusCode` is `undefined`** and **`message = 'Service Unavailable'` / `'Request Timeout'` / etc.** (the surviving HTTP statustext).
- **Mechanism:** `httpResponseErrorHandler` throws `MeiliSearchCommunicationError(statusText, Response, url)` (sets `message` **and** `statusCode`). Then `request()`'s catch **re-wraps** it via `httpErrorHandler` → `new MeiliSearchCommunicationError(firstErr.message, firstErr, url, stack)`. The 2nd arg is now an **Error, not a `Response`**, so the constructor's `if (body instanceof Response)` block that sets `statusCode` does **not** run → **`statusCode` is dropped** — but the constructor still sets `this.name = 'MeiliSearchCommunicationError'`.

So #2759 (and this PR's first cut, #2765) were **right that `statusCode` is gone** but **wrong that the `name` is stripped**. The captured prod bodies (`{"error":"Service Unavailable"}`, no `code` field) are fully explained by this **name-preserved** shape (`code` is `trpcError.code` = `undefined` → JSON omits it).

### Why the original fallback was DEAD CODE

The predicate's `MeiliSearchCommunicationError` branch matched on `e.name` (true), then checked `e.statusCode` (undefined) and `errno`/`code` (both undefined) and **`return`ed false** — exiting the function **before** the new statustext-message fallback at the terminal `return` could ever run. So the message lookup #2759/#2765 added was unreachable for the real prod shape, and `/api/v1/images` still emitted a hard 500.

## Fix — make the statustext lookup REACHABLE for the real shape

Restructured `isTransientMeiliError` so the `TRANSIENT_STATUSTEXT_TO_STATUS[e.message]` exact-match lookup (factored into a shared `messageMatchesTransientStatusText` helper) is reached on **both** paths:

- **`MeiliSearchCommunicationError` branch:** when `statusCode` is not a number **and** there's no `errno`/`code`, **fall back to the message lookup** instead of `return false` — this is the real prod shape (name kept, statusCode dropped).
- **`MeiliSearchApiError` branch:** if `httpStatus` is undefined, fall through to the same message lookup. An ApiError's `.message` is the Meili JSON error message (e.g. `"Index \`x\` not found"`), **not** a bare HTTP statustext, so it won't false-match — confirmed by a test.
- **Terminal fallback (belt-and-suspenders):** a fully **nameless** plain `Error` whose message is a transient statustext still matches, in case any future path *does* strip the name too.

The transient statustext set + the exact (`hasOwnProperty`, never substring) match are **unchanged** — the masking guard the audit confirmed clean:

| statustext | status |
|---|---|
| `Request Timeout` | 408 |
| `Too Many Requests` | 429 |
| `Bad Gateway` | 502 |
| `Service Unavailable` | 503 |
| `Gateway Timeout` | 504 |

`failfastReasonForTransientError` gets the matching structural fix so the message-matched `MeiliSearchCommunicationError` (statusCode undefined) derives the **correct** reason label from its statustext (e.g. `Service Unavailable` → `upstream-overload`) rather than the generic `upstream-error` — `meiliFetchFailfastTotal{route, reason}` stays attributable.

The `MeiliSearchApiError` 5xx rule is **not loosened**: a JSON-body 500 still bubbles as a hard 500 (a structured-JSON Meili 5xx is deterministic, not a brownout).

## Tests — add the REAL-SDK-SHAPE test (the one that would've caught #2759 AND #2765)

The existing tests hand-rolled `new Error('Service Unavailable')` (`name === 'Error'`), which **prod never produces** — that's why they passed while prod broke. Added to `src/server/meilisearch/__tests__/client.test.ts` a `describe('real prod shape — MeiliSearchCommunicationError, name preserved, statusCode dropped')`:

- A `MeiliSearchCommunicationError`-shaped object with **`name = 'MeiliSearchCommunicationError'`, `statusCode = undefined`, `message = 'Service Unavailable'`** (and the other four phrases) → `isTransientMeiliError` → **true**. It pins the proven shape (name set, statusCode/code/errno all undefined) and comments WHY this is the real prod shape per the audit. **These 5 cases FAIL against the pre-fix code** (verified: the old branch `return`ed false → `expected false to be true`).
- `failfastReasonForTransientError` on the re-wrapped CommunicationError labels by statustext (`Service Unavailable` → `upstream-overload`, not generic `upstream-error`).
- Re-wrapped CommunicationError whose message is **not** a transient statustext (`Internal Server Error`, arbitrary) → **false** (no masking of a real bug).
- ApiError with `httpStatus` undefined + a real Meili JSON message → **false**; + a bare transient statustext → true.
- **Kept** the existing nameless-plain-Error tests, the masking/exact-not-substring/case-sensitivity negatives, and the `TRANSIENT_STATUSTEXT_TO_STATUS` consistency test.

**Run:** `vitest run --project unit src/server/meilisearch/__tests__/client.test.ts` → **73 passed**. Typecheck (`tsc --noEmit`): **zero new errors** in the changed files (the only tsc errors in the tree are pre-existing `@civitai/client` orchestrator SDK skew, unrelated).

## Diagnostic log — confirm the live shape from logs, stop guessing

Added one structured log line on the catch path in `getImagesFromFeedSearch` (`src/server/services/image.service.ts`): `name = 'meili-error-shape'` logging the error's **`.name`** + **`constructor.name`** + whether a numeric `statusCode` survived + whether `isTransientMeiliError` matched. No PII — just the error-name / has-statusCode booleans. After deploy this **confirms the real shape from logs** instead of re-inferring it from the response body, closing the "we keep guessing the shape" gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
