### PR TITLE
feat(app-blocks): subnav Create + 'Apps' copy + clickable breadcrumb link

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -164,6 +164,26 @@ describe('AppBlockChrome run-page breadcrumb (Apps / <app name>)', () => {
     expect(crumbName.getAttribute('data-clickable')).toBeNull();
   });
 
+  // Contrast (audit L3): the "Apps" link color must clear WCAG AA on the
+  // near-white light-mode chrome surface. The original `c="blue.4"` was borderline
+  // on a light background; it was bumped to a DARKER shade (`blue.6`). Mantine emits
+  // `c="blue.6"` as an inline `color: var(--mantine-color-blue-6)`. Assert the link
+  // resolves to the blue-6 token and is NOT the too-light blue-4 — mutation-sanity:
+  // reverting to `blue.4` (or any lighter shade) fails this.
+  test('the "Apps" link uses a darker blue (blue.6) that clears AA on the light chrome surface, not the borderline blue.4', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-bc-contrast" appName="Budgeted Generator" slotId="app.page" />
+    );
+    await expect.element(page.getByTestId('app-block-breadcrumb-apps')).toBeInTheDocument();
+    const appsLink = page.getByTestId('app-block-breadcrumb-apps').element() as HTMLElement;
+
+    // Mantine's `c` prop renders as an inline color referencing the Mantine color
+    // CSS variable for the chosen shade.
+    const inlineColor = appsLink.style.color;
+    expect(inlineColor).toContain('--mantine-color-blue-6');
+    expect(inlineColor).not.toContain('--mantine-color-blue-4');
+  });
+
   // De-dup (audit fix): on the page surface the app name must appear EXACTLY
   // ONCE — in the breadcrumb crumb. Before the fix the standalone provenance
   // badge `Text` (`app-block-name`) ALSO rendered the name, so the page chrome

--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -38,9 +38,14 @@ describe('AppBlockChrome (H2 host-rendered app name)', () => {
     expect(nameEl.getAttribute('data-truncate')).toBe('end');
   });
 
-  test('falls back to "App block" when appName is undefined (never blank)', async () => {
+  test('falls back to "App" when appName is undefined (never blank)', async () => {
     renderWithProviders(<AppBlockChrome blockInstanceId="inst-3" />);
-    await expect.element(page.getByText('App block')).toBeInTheDocument();
+    // Copy sweep: the provenance fallback now reads "App" (not "App block").
+    // Mutation-sanity: reverting the fallback to "App block" fails this exact-text
+    // assertion. exact:true so a future "App block" string can't satisfy it.
+    await expect.element(page.getByText('App', { exact: true })).toBeInTheDocument();
+    // The old "App block" copy must be gone.
+    expect(page.getByText('App block', { exact: true }).elements()).toHaveLength(0);
     // Guard against a blank/whitespace-only label.
     const nameEl = page.getByTestId('app-block-name').element();
     expect((nameEl.textContent ?? '').trim().length).toBeGreaterThan(0);
@@ -48,7 +53,7 @@ describe('AppBlockChrome (H2 host-rendered app name)', () => {
 
   test('the ⋯ menu trigger is still present', async () => {
     renderWithProviders(<AppBlockChrome blockInstanceId="inst-4" appName="Background Remover" />);
-    await expect.element(page.getByRole('button', { name: 'App block menu' })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'App menu' })).toBeInTheDocument();
   });
 });
 
@@ -64,7 +69,7 @@ describe('AppBlockChrome (H2 host-rendered app name)', () => {
 // then asserts on the dropdown contents.
 describe('AppBlockChrome "Hide" item is surface-aware (page vs model)', () => {
   async function openMenu() {
-    await page.getByRole('button', { name: 'App block menu' }).click();
+    await page.getByRole('button', { name: 'App menu' }).click();
     // "Manage apps" is present on every surface — wait on it so the dropdown has
     // mounted before asserting on the conditional "Hide" item.
     await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
@@ -76,7 +81,7 @@ describe('AppBlockChrome "Hide" item is surface-aware (page vs model)', () => {
     );
     await openMenu();
     await expect
-      .element(page.getByRole('menuitem', { name: 'Hide app block' }))
+      .element(page.getByRole('menuitem', { name: 'Hide app' }))
       .toBeInTheDocument();
   });
 
@@ -86,7 +91,7 @@ describe('AppBlockChrome "Hide" item is surface-aware (page vs model)', () => {
     );
     await openMenu();
     await expect
-      .element(page.getByRole('menuitem', { name: 'Hide app block' }))
+      .element(page.getByRole('menuitem', { name: 'Hide app' }))
       .toBeInTheDocument();
   });
 
@@ -99,7 +104,7 @@ describe('AppBlockChrome "Hide" item is surface-aware (page vs model)', () => {
     await expect.element(page.getByRole('menuitem', { name: 'Manage apps' })).toBeInTheDocument();
     // … but "Hide app block" is suppressed on the full-page surface.
     await expect
-      .element(page.getByRole('menuitem', { name: 'Hide app block' }))
+      .element(page.getByRole('menuitem', { name: 'Hide app' }))
       .not.toBeInTheDocument();
   });
 });
@@ -127,6 +132,38 @@ describe('AppBlockChrome run-page breadcrumb (Apps / <app name>)', () => {
     expect((crumbName.textContent ?? '').trim()).toBe('Budgeted Generator');
   });
 
+  // The "Apps" crumb must read as obviously CLICKABLE — visually distinct from the
+  // static dimmed crumb text + separators. It gets a link affordance: a distinct
+  // link color + underline (Mantine `td="underline"` → `data-underline`/inline
+  // text-decoration) plus an explicit `data-clickable` marker + `cursor:pointer`.
+  // The trailing crumb (the static app name) carries NONE of these. Mutation-
+  // sanity: dropping the link styling (so the crumb looks like plain text again)
+  // fails these assertions.
+  test('the "Apps" crumb carries a clickable link affordance distinguishing it from the static crumb', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-bc-link" appName="Budgeted Generator" slotId="app.page" />
+    );
+    await expect.element(page.getByTestId('app-block-breadcrumb-apps')).toBeInTheDocument();
+    const appsLink = page.getByTestId('app-block-breadcrumb-apps').element() as HTMLElement;
+
+    // Explicit clickable marker + pointer cursor (link affordance).
+    expect(appsLink.getAttribute('data-clickable')).toBe('true');
+    expect(appsLink.style.cursor).toBe('pointer');
+
+    // Underline affordance: Mantine renders `td="underline"` as a text-decoration
+    // (inline style or a `data-`/`style` attribute). Assert an underline decoration
+    // is present on the link via its computed/inline text-decoration.
+    const decorated =
+      appsLink.style.textDecoration.includes('underline') ||
+      getComputedStyle(appsLink).textDecorationLine.includes('underline');
+    expect(decorated).toBe(true);
+
+    // The static trailing crumb (app name) is NOT styled as a link — no clickable
+    // marker — so the two are visually distinguishable.
+    const crumbName = page.getByTestId('app-block-breadcrumb-name').element() as HTMLElement;
+    expect(crumbName.getAttribute('data-clickable')).toBeNull();
+  });
+
   // De-dup (audit fix): on the page surface the app name must appear EXACTLY
   // ONCE — in the breadcrumb crumb. Before the fix the standalone provenance
   // badge `Text` (`app-block-name`) ALSO rendered the name, so the page chrome
@@ -152,9 +189,9 @@ describe('AppBlockChrome run-page breadcrumb (Apps / <app name>)', () => {
     await expect.element(page.getByTestId('app-block-name')).not.toBeInTheDocument();
 
     // Provenance trust signal preserved: the app-block icon still carries its
-    // "App block" provenance label (role=img + aria-label) even though the badge
+    // "App" provenance label (role=img + aria-label) even though the badge
     // name Text was dropped.
-    await expect.element(page.getByRole('img', { name: 'App block' })).toBeInTheDocument();
+    await expect.element(page.getByRole('img', { name: 'App' })).toBeInTheDocument();
 
     // "Apps" link still routes to /apps (no regression to the breadcrumb).
     const appsLink = page.getByTestId('app-block-breadcrumb-apps').element();

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -245,7 +245,7 @@ export function AppBlockChrome({
               component={Link}
               href="/apps"
               size="xs"
-              c="blue.4"
+              c="blue.6"
               td="underline"
               style={{ flexShrink: 0, cursor: 'pointer' }}
               data-testid="app-block-breadcrumb-apps"

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -121,14 +121,14 @@ function storageErrorMessage(err: unknown): string {
  * block can't fake, restyle, or hide it. It's the user-facing safety
  * signal that says "this is a sandboxed app block, not native Civitai UI":
  * a thin top bar with the Civitai app-block badge plus a menu whose
- * "Manage apps" item routes to /apps/installed and a "Hide app block" item
+ * "Manage apps" item routes to /apps/installed and a "Hide app" item
  * that locally hides this install for the viewer (a model owner's block shows
  * to every viewer; this lets a viewer dismiss one without affecting the
  * publisher or anyone else). Rendering it here (vs in the sandboxed iframe) is
  * the whole point — the trust boundary belongs to the host. (Roadmap W7.)
  *
  * SURFACE-AWARE: on the full-page run surface (`/apps/run/<slug>`, slot kind
- * `page`) the "Hide app block" action is meaningless — there is no model-page
+ * `page`) the "Hide app" action is meaningless — there is no model-page
  * slot to dismiss the block FROM; the page IS the block. So the host passes the
  * rendering `slotId` and we drop the "Hide" item when `isPageSlot(slotId)` is
  * true. "Manage apps" + the provenance badge stay on every surface. (Mirrors PR
@@ -163,8 +163,8 @@ export function AppBlockChrome({
   // collapse whitespace, bound length) before rendering it in the trust label.
   const sanitizedName = sanitizeAppChromeName(appName);
   const hasName = sanitizedName !== null;
-  // Falls back to the literal "App block" so the trust label is never blank.
-  const label = sanitizedName ?? 'App block';
+  // Falls back to the literal "App" so the trust label is never blank.
+  const label = sanitizedName ?? 'App';
   // De-dup the app name on the page surface. The breadcrumb's trailing crumb
   // (`app-block-breadcrumb-name`) already carries the app name there, so the
   // standalone badge name `Text` would render the SAME name a second time
@@ -174,13 +174,13 @@ export function AppBlockChrome({
   // trust signal is preserved. On the model surface (no breadcrumb) the badge
   // name renders exactly as before.
   const showBadgeName = !isPage;
-  // The icon must carry the "App block" provenance aria-label whenever there is
-  // no adjacent visible Text saying "App block" — i.e. when a real name shows
-  // (so the icon + name read as "App block, <name>") OR when the badge name Text
+  // The icon must carry the "App" provenance aria-label whenever there is
+  // no adjacent visible Text saying "App" — i.e. when a real name shows
+  // (so the icon + name read as "App, <name>") OR when the badge name Text
   // is suppressed on the page surface (so the provenance signal isn't lost with
   // the dropped Text). It's marked decorative (aria-hidden) ONLY when the
-  // visible fallback "App block" Text is present to carry provenance itself —
-  // avoiding an unlabeled SVG / a double-reading "App block".
+  // visible fallback "App" Text is present to carry provenance itself —
+  // avoiding an unlabeled SVG / a double-reading "App".
   const iconProvenance = hasName || !showBadgeName;
   return (
     <Group
@@ -200,13 +200,13 @@ export function AppBlockChrome({
       <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
         {/* Provenance signal for screen readers. role="img" is required for the
             aria-label to be reliably announced — a bare tabler <svg> has no role,
-            so without it the label is dropped. On the fallback the visible "App
-            block" Text carries provenance, so the icon is marked decorative. */}
+            so without it the label is dropped. On the fallback the visible "App"
+            Text carries provenance, so the icon is marked decorative. */}
         <IconApps
           size={14}
           stroke={1.5}
           role={iconProvenance ? 'img' : undefined}
-          aria-label={iconProvenance ? 'App block' : undefined}
+          aria-label={iconProvenance ? 'App' : undefined}
           aria-hidden={iconProvenance ? undefined : true}
           style={{ flexShrink: 0 }}
         />
@@ -237,13 +237,19 @@ export function AppBlockChrome({
             <Text size="xs" c="dimmed" aria-hidden>
               /
             </Text>
+            {/* Link affordance: distinct link COLOR + underline so this crumb
+                reads as obviously clickable, visually separated from the static
+                dimmed crumb text + separators around it. Keeps the real anchor
+                semantics (it's a Next <Link>) for keyboard / middle-click. */}
             <Text
               component={Link}
               href="/apps"
               size="xs"
-              c="dimmed"
-              style={{ flexShrink: 0 }}
+              c="blue.4"
+              td="underline"
+              style={{ flexShrink: 0, cursor: 'pointer' }}
               data-testid="app-block-breadcrumb-apps"
+              data-clickable="true"
             >
               Apps
             </Text>
@@ -265,12 +271,12 @@ export function AppBlockChrome({
       </Group>
       <Menu position="bottom-end" shadow="md" width={180}>
         <Menu.Target>
-          <ActionIcon variant="subtle" color="gray" size="sm" aria-label="App block menu">
+          <ActionIcon variant="subtle" color="gray" size="sm" aria-label="App menu">
             <IconDots size={16} stroke={1.5} />
           </ActionIcon>
         </Menu.Target>
         <Menu.Dropdown>
-          <Menu.Label>App block</Menu.Label>
+          <Menu.Label>App</Menu.Label>
           <Menu.Item
             component={Link}
             href="/apps/installed"
@@ -291,7 +297,7 @@ export function AppBlockChrome({
                 })
               }
             >
-              Hide app block
+              Hide app
             </Menu.Item>
           )}
         </Menu.Dropdown>

--- a/src/components/Apps/AppsSubNav.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.browser.test.tsx
@@ -43,10 +43,37 @@ function tab(name: string) {
 }
 
 describe('AppsSubNavView (conditional sub-nav tabs)', () => {
-  test('Marketplace + Submit are ALWAYS present (even with an all-false summary)', async () => {
+  test('Marketplace + Create are ALWAYS present (even with an all-false summary)', async () => {
     renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
     await expect.element(tab('Marketplace')).toBeInTheDocument();
-    await expect.element(tab('Submit')).toBeInTheDocument();
+    await expect.element(tab('Create')).toBeInTheDocument();
+  });
+
+  // The "Submit" tab was relabeled to "Create" (icon → IconSquarePlus) while
+  // keeping the SAME `/apps/submit` route + active-state logic. These assert the
+  // visible label flipped, the OLD label is gone (mutation-sanity: reverting the
+  // label to "Submit" fails the "no Submit tab" expectation), the route is
+  // unchanged, and the new create-affordance icon renders inside the tab.
+  test('the always-on author tab reads "Create", NOT "Submit"', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    await expect.element(tab('Create')).toBeInTheDocument();
+    // The old label must be gone entirely (no tab named "Submit").
+    expect(tab('Submit').elements()).toHaveLength(0);
+  });
+
+  test('the Create tab still points at /apps/submit (route unchanged)', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    await expect.element(tab('Create')).toBeInTheDocument();
+    expect(tab('Create').element().getAttribute('href')).toBe('/apps/submit');
+  });
+
+  test('the Create tab renders its leftSection icon (create affordance)', async () => {
+    renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
+    await expect.element(tab('Create')).toBeInTheDocument();
+    // The tab's leftSection mounts a tabler SVG; assert an <svg> is present
+    // inside the Create tab so the icon affordance isn't silently dropped.
+    const icon = tab('Create').element().querySelector('svg');
+    expect(icon).not.toBeNull();
   });
 
   test('with an all-false summary the conditional tabs are hidden', async () => {
@@ -107,7 +134,7 @@ describe('AppsSubNavView (conditional sub-nav tabs)', () => {
       isReviewer: true,
     };
     renderWithProviders(<AppsSubNavView summary={ALL} currentPath="/apps" />);
-    for (const name of ['Marketplace', 'Submit', 'Installed', 'My submissions', 'Revenue', 'Review']) {
+    for (const name of ['Marketplace', 'Create', 'Installed', 'My submissions', 'Revenue', 'Review']) {
       await expect.element(tab(name)).toBeInTheDocument();
     }
   });
@@ -162,14 +189,14 @@ describe('AppsSubNavView (active tab reflects the current route)', () => {
     await expect.element(tab('Marketplace')).toBeInTheDocument();
     const marketplace = tab('Marketplace').element();
     expect(marketplace.getAttribute('aria-selected')).toBe('true');
-    const submit = tab('Submit').element();
+    const submit = tab('Create').element();
     expect(submit.getAttribute('aria-selected')).toBe('false');
   });
 
-  test('Submit tab is selected on /apps/submit (and Marketplace is not)', async () => {
+  test('Create tab is selected on /apps/submit (and Marketplace is not)', async () => {
     renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps/submit" />);
-    await expect.element(tab('Submit')).toBeInTheDocument();
-    expect(tab('Submit').element().getAttribute('aria-selected')).toBe('true');
+    await expect.element(tab('Create')).toBeInTheDocument();
+    expect(tab('Create').element().getAttribute('aria-selected')).toBe('true');
     expect(tab('Marketplace').element().getAttribute('aria-selected')).toBe('false');
   });
 });
@@ -188,7 +215,7 @@ describe('AppsSubNavView (each tab navigates to its route)', () => {
     renderWithProviders(<AppsSubNavView summary={ALL} currentPath="/apps" />);
     const cases: Array<[string, string]> = [
       ['Marketplace', '/apps'],
-      ['Submit', '/apps/submit'],
+      ['Create', '/apps/submit'],
       ['Installed', '/apps/installed'],
       ['My submissions', '/apps/my-submissions'],
       ['Revenue', '/apps/revenue'],
@@ -222,7 +249,7 @@ describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () 
     await expect.element(tab('Marketplace')).toBeInTheDocument();
 
     const marketplace = tab('Marketplace').element() as HTMLElement;
-    const submit = tab('Submit').element() as HTMLElement;
+    const submit = tab('Create').element() as HTMLElement;
 
     // Marketplace (= current route) is the selected tab; Submit is not.
     expect(marketplace.getAttribute('aria-selected')).toBe('true');
@@ -247,8 +274,8 @@ describe('AppsSubNavView (keyboard: arrow keys scan, do not auto-navigate)', () 
     // focusable element IS the `<a href>` the route points at, so native
     // anchor activation (Enter) navigates correctly even with arrow-activation off.
     renderWithProviders(<AppsSubNavView summary={NONE} currentPath="/apps" />);
-    await expect.element(tab('Submit')).toBeInTheDocument();
-    const submit = tab('Submit').element() as HTMLElement;
+    await expect.element(tab('Create')).toBeInTheDocument();
+    const submit = tab('Create').element() as HTMLElement;
     submit.focus();
     expect(document.activeElement).toBe(submit);
     expect(submit.tagName.toLowerCase()).toBe('a');

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -5,7 +5,7 @@ import {
   IconGavel,
   IconListDetails,
   IconPlugConnected,
-  IconUpload,
+  IconSquarePlus,
 } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -48,12 +48,12 @@ type SubNavLink = {
 
 /**
  * Tab order = discovery → author → manage → revenue → moderate. The two
- * always-on tabs (Marketplace + Submit) lead so the bar never collapses to
+ * always-on tabs (Marketplace + Create) lead so the bar never collapses to
  * fewer than two entries.
  */
 const SUB_NAV_LINKS: SubNavLink[] = [
   { href: '/apps', label: 'Marketplace', icon: IconBuildingStore, visible: () => true },
-  { href: '/apps/submit', label: 'Submit', icon: IconUpload, visible: () => true },
+  { href: '/apps/submit', label: 'Create', icon: IconSquarePlus, visible: () => true },
   {
     href: '/apps/installed',
     label: 'Installed',

--- a/src/components/Apps/MarketplaceBody.tsx
+++ b/src/components/Apps/MarketplaceBody.tsx
@@ -420,7 +420,7 @@ function MarketplaceEmptyState({
       <Center py="xl">
         <Stack align="center" gap={8}>
           <Text size="lg" fw={500}>
-            No app blocks match
+            No apps match
           </Text>
           <Text size="sm" c="dimmed">
             Try clearing your filters or search query.
@@ -442,7 +442,7 @@ function MarketplaceEmptyState({
           No apps yet
         </Text>
         <Text size="sm" c="dimmed" ta="center" maw={420}>
-          App Blocks add interactive panels to model pages — generation, games, utilities and
+          Apps add interactive panels to model pages — generation, games, utilities and
           more. Be the first to publish one.
         </Text>
         {canSubmit && (

--- a/src/components/Apps/MarketplaceBody.tsx
+++ b/src/components/Apps/MarketplaceBody.tsx
@@ -254,7 +254,7 @@ export function MarketplaceBody() {
       <Group gap="md" align="end">
         <TextInput
           label="Search"
-          placeholder="Search by name or block id"
+          placeholder="Search by name or app id"
           leftSection={<IconSearch size={16} />}
           value={searchInput}
           onChange={(e) => setSearchInput(e.currentTarget.value)}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -179,7 +179,7 @@ export default function AppDetailPage() {
       */}
       <Meta
         title={`${name} — Civitai Apps`}
-        description={description || `${name} on the Civitai App Blocks marketplace.`}
+        description={description || `${name} on the Civitai Apps marketplace.`}
         deIndex
       />
       <Container size="md" py="md">

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -22,7 +22,7 @@ export default function AppsPage() {
 
   return (
     <>
-      <Meta title="Apps — Civitai" description="Civitai App Blocks marketplace" deIndex />
+      <Meta title="Apps — Civitai" description="Civitai Apps marketplace" deIndex />
       {/* Outer chrome (Container + sticky sub-nav) is supplied by AppsPageLayout;
           the marketplace title/subtitle were removed for the page-apps-only
           launch (the sub-nav supplies the wayfinding), so no header props. The

--- a/src/pages/apps/installed.tsx
+++ b/src/pages/apps/installed.tsx
@@ -126,7 +126,7 @@ function PinnedInstallRow({ sub }: PinnedInstallRowProps) {
       children: (
         <Stack gap="xs">
           <Text size="sm">
-            This removes the install row entirely. The block will stop appearing on{' '}
+            This removes the install row entirely. The app will stop appearing on{' '}
             <strong>{targetName}</strong>. Any platform default for the same slot will become
             eligible again. The app's data and any other installs of it are untouched.
           </Text>

--- a/src/pages/apps/installed.tsx
+++ b/src/pages/apps/installed.tsx
@@ -674,7 +674,7 @@ function HiddenBlocksPanel() {
         <Stack align="center" gap="xs">
           <IconEyeOff size={28} opacity={0.5} />
           <Text size="sm" c="dimmed" ta="center" maw={420}>
-            You haven't hidden any app blocks. Use the ⋯ menu on a block to hide it on this
+            You haven't hidden any apps. Use the ⋯ menu on an app to hide it on this
             device — it only affects what you see, never the publisher or other viewers.
           </Text>
         </Stack>
@@ -689,7 +689,7 @@ function HiddenBlocksPanel() {
           <Group justify="space-between" wrap="nowrap" gap="md" align="center">
             <Stack gap={2} style={{ minWidth: 0, flex: 1 }}>
               <Text fw={600} className="truncate">
-                {block.appName ?? 'App block'}
+                {block.appName ?? 'App'}
               </Text>
               <Group gap={6} wrap="wrap">
                 {block.modelId ? (
@@ -711,7 +711,7 @@ function HiddenBlocksPanel() {
                 unhideBlock(block.blockInstanceId);
                 showSuccessNotification({
                   title: 'Restored',
-                  message: `${block.appName ?? 'App block'} will show again.`,
+                  message: `${block.appName ?? 'App'} will show again.`,
                 });
               }}
             >
@@ -769,7 +769,7 @@ export default function InstalledAppsPage() {
       <AppsPageLayout
         size="lg"
         title="Your installed apps"
-        subtitle="Manage where Civitai App Blocks show up across the site."
+        subtitle="Manage where Civitai Apps show up across the site."
         actions={
           <Button
             component={Link}
@@ -841,7 +841,7 @@ export default function InstalledAppsPage() {
             <Tabs.Panel value="hidden" pt="md">
               <Stack gap="sm">
                 <Text size="sm" c="dimmed">
-                  App blocks you've hidden on this device. Hiding is local to your browser —
+                  Apps you've hidden on this device. Hiding is local to your browser —
                   it never affects the publisher's install or other viewers. Restore one to
                   have it show on its model page again.
                 </Text>

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -261,10 +261,10 @@ export default function AppBlocksDashboardPage() {
 
   return (
     <>
-      <Meta title="App Blocks Dashboard — Civitai" deIndex />
+      <Meta title="Apps Dashboard — Civitai" deIndex />
       <AppsPageLayout
         size="lg"
-        title="App Blocks Dashboard"
+        title="Apps Dashboard"
         subtitle={
           <>
             Revenue share and analytics for your blocks. Payouts are batched weekly; see{' '}

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -192,7 +192,7 @@ function RevenuePanel() {
             <Title order={5}>Recent attributions</Title>
             {data.recentAttributions.length === 0 ? (
               <Text c="dimmed" size="sm" mt="sm">
-                No buzz purchases yet. Install your blocks on more models to earn share.
+                No buzz purchases yet. Install your apps on more models to earn share.
               </Text>
             ) : (
               <Table mt="sm" highlightOnHover>
@@ -267,7 +267,7 @@ export default function AppBlocksDashboardPage() {
         title="Apps Dashboard"
         subtitle={
           <>
-            Revenue share and analytics for your blocks. Payouts are batched weekly; see{' '}
+            Revenue share and analytics for your apps. Payouts are batched weekly; see{' '}
             <Anchor component={Link} href="/apps/installed">
               Apps
             </Anchor>{' '}

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -195,7 +195,7 @@ export default function ReviewQueuePage() {
       <AppsPageLayout
         size="xl"
         title="App publish-request queue"
-        subtitle="Moderator review for App Blocks. Pending queue is oldest-first; history tabs are newest-first."
+        subtitle="Moderator review for Apps. Pending queue is oldest-first; history tabs are newest-first."
       >
         <Tabs
           value={tab}


### PR DESCRIPTION
## What

UI-only rebrand pass across the `/apps` (App Blocks) surfaces — three changes, scoped to the Apps marketplace/pages + the `AppBlockChrome` trust frame. No behavior, route, identifier, scope, or DB-field changes.

### 1. Subnav "Submit" → "Create"
`AppsSubNav.tsx`: the always-on author tab now reads **Create** with a create-appropriate icon (`IconUpload` → `IconSquarePlus`). The route stays `/apps/submit` and the active-state logic is unchanged — only the visible label + icon.

### 2. "App Block(s)" → "App(s)" copy sweep (user-facing strings only)
Replaced user-visible "App Block(s)" copy with "App(s)" across the owned surfaces:
- `AppBlockChrome` (IframeHost): provenance badge fallback `App block` → `App`, icon `aria-label` `App block` → `App`, menu trigger `aria-label` `App block menu` → `App menu`, `Menu.Label` `App block` → `App`, menu item `Hide app block` → `Hide app`.
- `MarketplaceBody`: empty-state `No app blocks match` → `No apps match`; intro `App Blocks add interactive panels…` → `Apps add interactive panels…`.
- `installed.tsx`: hidden-apps empty/restore copy + page subtitle + hidden-tab copy.
- `revenue.tsx`: `App Blocks Dashboard` title + meta → `Apps Dashboard`.
- `review.tsx`: subtitle `Moderator review for App Blocks` → `…for Apps`.
- `apps/index.tsx` + `[appBlockId]/index.tsx`: meta descriptions.

**Deliberately left unchanged** (per scope): component/type/identifier names (`AppBlockCard`, `AppBlockChrome`, `AppBlock`, `PublicBlockManifest`…), route paths, the `features.appBlocks` flag, the `recentlyOpenedApps` localStorage key, `data-testid`s (`app-block-chrome`, `app-block-name`, `app-block-breadcrumb*`), manifest/DB field names (`block.manifest.json`, `buzz_budget_per_gen`, `appBlockId`), and test strings that assert behavior/keys.

> Out of scope here: `PageBlockHost.tsx` / the `BlockFallback` run-host error UX (owned by a separate PR).

### 3. Breadcrumb "Apps" link — obviously clickable
In `AppBlockChrome`, the run-page breadcrumb `Apps / <app name>` "Apps" link previously rendered as `c="dimmed"` — visually identical to the static crumb text. It now carries a link affordance: link color (`c="blue.4"`) + underline (`td="underline"`) + `cursor:pointer` + a `data-clickable` marker, so it reads as obviously clickable while keeping its real `<Link>` anchor semantics.

## Tests
- **AppsSubNav** (`AppsSubNav.browser.test.tsx`): retargeted all `Submit` assertions to `Create`; added 3 tests — the tab reads "Create" and NOT "Submit" (old label gone), `href` is still `/apps/submit`, and the new icon `<svg>` renders.
- **AppBlockChrome** (`AppBlockChrome.browser.test.tsx`): retargeted copy assertions — badge fallback now `App` (+ asserts `App block` is gone, mutation-sanity), menu `aria-label` `App menu`, `Hide app` item, provenance `img` name `App`; added a breadcrumb test asserting the "Apps" link carries the clickable styling (`data-clickable`, `cursor:pointer`, underline) while the static crumb does not.
- All owned-file tests pass: **35/35** (AppsSubNav 22 + AppBlockChrome 13).

## Verification
- Scoped `tsc --noEmit`: **zero** new type errors in any touched file (pre-existing errors are confined to unrelated `event-engine-common`/`@civitai/client` files absent from this checkout).
- `vitest --project component` on the owned suites: 35/35 green. (Two pre-existing `CliSubmitCta` clipboard-copy failures are an unrelated headless-clipboard env flake — those files are untouched by this PR and fail identically on baseline.)
- Not browser-verified on a live preview (UI-only copy/style change; the styling is asserted structurally in the component test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
