### PR TITLE
chore(meili): remove temp meili-error-shape diagnostic log on image feed

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2979,27 +2979,6 @@ export async function getImagesFromFeedSearch(
     // generic 500 mapping). 4xx-other (malformed filter / auth) and any other
     // Error are NOT transient and still bubble as-is (→ their real status).
     const transient = isTransientMeiliError(err);
-    // DIAGNOSTIC (no PII): confirm the LIVE error SHAPE from logs instead of
-    // re-inferring it from the response body. The audit traced the real prod
-    // error to a `MeiliSearchCommunicationError` whose `.name` is PRESERVED but
-    // `.statusCode` is dropped by the SDK's httpErrorHandler double-wrap — this
-    // line lets us verify that on-cluster (error name + ctor name + whether a
-    // numeric statusCode survived + whether isTransientMeiliError matched) so
-    // the "we keep guessing the shape" loop closes. Cheap: one log line on the
-    // catch path only (not the hot success path).
-    const errShape = err as { name?: unknown; statusCode?: unknown; message?: unknown };
-    logToAxiom(
-      {
-        type: transient ? 'info' : 'warning',
-        name: 'meili-error-shape',
-        path: 'getImagesFromFeedSearch',
-        errorName: typeof errShape?.name === 'string' ? errShape.name : null,
-        ctorName: (err as { constructor?: { name?: string } })?.constructor?.name ?? null,
-        hasStatusCode: typeof errShape?.statusCode === 'number',
-        transient,
-      },
-      'temp-search'
-    ).catch();
     if (transient) {
       // Keep a transient Meili outage ATTRIBUTABLE (see getAllImagesIndex). The
       // reclassified 503 would otherwise land in the unlabeled 503 bucket;


### PR DESCRIPTION
Removes the temporary `meili-error-shape` diagnostic log added in #2765 at the `getImagesFromFeedSearch` catch path.

## Why it was added
#2765 reclassified transient Meili failures on `/api/v1/images` from 500→503. The diagnostic logged the live error *shape* (name / ctor / whether a numeric `statusCode` survived / whether `isTransientMeiliError` matched) so we could confirm the classification on-cluster instead of inferring it from the response body.

## What it told us (8h on prod, via Loki)
100% of errored spans on the feed-search path are transient and correctly reclassified to 503:

| error name | count | hasStatusCode | transient |
|---|---|---|---|
| `MeiliCallTimeoutError` | 388 | false | ✅ |
| `MeiliSearchCommunicationError` | 112 | false | ✅ |

Zero non-transient leaks — consistent with the live `/api/v1/images` 500 rate sitting at ~0. The statustext-match classifier is catching everything, so the temp instrumentation has served its purpose.

## Change
Pure deletion (21 lines): the `errShape` const + the `logToAxiom({ name: 'meili-error-shape', ... }, 'temp-search')` call + its comment. `const transient` and the 503 throw path are untouched — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)