### PR TITLE
fix(orchestrator): bound whatIf + query paths with a shared timeout budget

### DIFF
--- a/src/server/services/orchestrator/__tests__/workflows.timeout-budget.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.timeout-budget.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// Mock ONLY the generated client + the orchestrator client factory + env so we can
+// drive `queryWorkflows` / `submitWorkflow` through their timeout-budget branches.
+// The real `~/server/utils/errorHandling` loads so the actual `isUpstreamNetworkError`
+// classification + TRPCError mapping is exercised. We do NOT rely on real timers /
+// a real AbortSignal.timeout firing — we simulate the fired-budget outcome by making
+// the mocked client throw a `TimeoutError` (exactly what AbortSignal.timeout produces),
+// keeping the tests deterministic.
+const { mockQueryWorkflows, mockSubmitWorkflow } = vi.hoisted(() => ({
+  mockQueryWorkflows: vi.fn(),
+  mockSubmitWorkflow: vi.fn(),
+}));
+
+vi.mock('@civitai/client', () => ({
+  queryWorkflows: mockQueryWorkflows,
+  submitWorkflow: mockSubmitWorkflow,
+  // unused-by-these-tests named exports referenced at module load
+  getWorkflow: vi.fn(),
+  addWorkflowTag: vi.fn(),
+  deleteWorkflow: vi.fn(),
+  patchWorkflow: vi.fn(),
+  removeWorkflowTag: vi.fn(),
+  updateWorkflow: vi.fn(),
+  handleError: vi.fn(() => 'handled error'),
+}));
+
+vi.mock('~/server/services/orchestrator/client', () => ({
+  createOrchestratorClient: vi.fn(() => ({})),
+  internalOrchestratorClient: {},
+}));
+
+vi.mock('~/env/other', () => ({ isDev: false, isProd: true }));
+
+import { queryWorkflows, submitWorkflow } from '~/server/services/orchestrator/workflows';
+
+const baseQueryArgs = {
+  token: 'tok',
+  hideMatureContent: false,
+} as any;
+
+// A fired AbortSignal.timeout(ms) rejects the fetch with a `TimeoutError`. We
+// reproduce that exact shape so the real `isUpstreamNetworkError` (which matches
+// `name === 'TimeoutError'`) classifies it without depending on real timers.
+const timeoutError = () => Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('queryWorkflows timeout budget', () => {
+  it('maps a fired-budget TimeoutError to SERVICE_UNAVAILABLE (503)', async () => {
+    mockQueryWorkflows.mockRejectedValue(timeoutError());
+    const err = await queryWorkflows(baseQueryArgs).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('passes an AbortSignal into the client query call (the budget is armed)', async () => {
+    mockQueryWorkflows.mockResolvedValue({ data: { items: [], next: undefined } });
+    await queryWorkflows(baseQueryArgs);
+    expect(mockQueryWorkflows).toHaveBeenCalledTimes(1);
+    const callArg = mockQueryWorkflows.mock.calls[0][0];
+    expect(callArg.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('submitWorkflow timeout budget (whatIf path)', () => {
+  it('WITH timeoutMs: every attempt TimeoutError → SERVICE_UNAVAILABLE (503)', async () => {
+    // submitWorkflowWithRetry re-throws the network error once retries are
+    // exhausted; the new wrapper maps it to a retry-able 503.
+    mockSubmitWorkflow.mockRejectedValue(timeoutError());
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: { steps: [] },
+      query: { whatif: true },
+      timeoutMs: 25_000,
+    } as any).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('WITH timeoutMs: arms the budget by threading an AbortSignal into the client call', async () => {
+    mockSubmitWorkflow.mockResolvedValue({
+      data: { id: 'wf-1' },
+      response: { status: 200 },
+    });
+    await submitWorkflow({
+      token: 'tok',
+      body: { steps: [] },
+      query: { whatif: true },
+      timeoutMs: 25_000,
+    } as any);
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    const callArg = mockSubmitWorkflow.mock.calls[0][0];
+    expect(callArg.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('WITHOUT timeoutMs (write-path guard): a TimeoutError PROPAGATES unchanged (not remapped to 503)', async () => {
+    // This is the critical guard: the generate/write path must be byte-for-byte
+    // unchanged. No signal, no new error mapping — the original error bubbles.
+    const original = timeoutError();
+    mockSubmitWorkflow.mockRejectedValue(original);
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: { steps: [] },
+    } as any).catch((e) => e);
+    expect(err).toBe(original);
+    expect(err).not.toBeInstanceOf(TRPCError);
+  });
+
+  it('WITHOUT timeoutMs: no AbortSignal is threaded into the client call', async () => {
+    mockSubmitWorkflow.mockResolvedValue({
+      data: { id: 'wf-1' },
+      response: { status: 200 },
+    });
+    await submitWorkflow({
+      token: 'tok',
+      body: { steps: [] },
+    } as any);
+    const callArg = mockSubmitWorkflow.mock.calls[0][0];
+    expect(callArg.signal).toBeUndefined();
+  });
+
+  it('WITH timeoutMs: a non-network throw still re-throws unchanged (real bugs stay visible)', async () => {
+    const bug = new TypeError("Cannot read properties of undefined (reading 'x')");
+    mockSubmitWorkflow.mockRejectedValue(bug);
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: { steps: [] },
+      query: { whatif: true },
+      timeoutMs: 25_000,
+    } as any).catch((e) => e);
+    expect(err).toBe(bug);
+    expect(err).not.toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -55,6 +55,7 @@ import type { GenerationStatus, GenerationStatusMode } from '~/server/schema/gen
 import type { TextToImageResponse } from '~/server/services/orchestrator/types';
 import {
   getWorkflow,
+  ORCHESTRATOR_WHATIF_TIMEOUT_MS,
   submitWorkflow,
   updateWorkflow as clientUpdateWorkflow,
 } from '~/server/services/orchestrator/workflows';
@@ -1481,7 +1482,10 @@ export async function whatIfFromGraph({
     user: userId ? { id: userId, isModerator } : undefined,
   });
 
-  // Submit what-if request to orchestrator
+  // Submit what-if request to orchestrator. This is a side-effect-free cost
+  // estimate, so bound it with an overall wall-clock budget shared across retries
+  // (a fired budget → retry-able 503). The generate path intentionally passes no
+  // `timeoutMs` and stays unbounded (idempotency follow-up).
   const workflow = await submitWorkflow({
     token,
     body: {
@@ -1493,6 +1497,7 @@ export async function whatIfFromGraph({
     query: {
       whatif: true,
     },
+    timeoutMs: ORCHESTRATOR_WHATIF_TIMEOUT_MS,
   });
 
   // Check if all jobs are ready (have available support)

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -56,8 +56,17 @@ const ORCHESTRATOR_UNAVAILABLE_MESSAGE =
 // Read (queryWorkflows → queryGeneratedImages) and what-if (cost estimate) only;
 // the generate/submit WRITE path is deliberately left unbounded (retry-without-
 // idempotency dup-safety is a separate follow-up).
+//
+// Ceilings are sized off the live prod slow-tRPC distribution (12h):
+//  - queryGeneratedImages ok=true tops out ~10s (0 calls >=20s) → 20s caps the
+//    unbounded park while 503-ing ~nothing.
+//  - whatIfFromGraph ok=true has a legitimate slow cluster at 30-40s (81 calls)
+//    then a thin tail; the worst park was ~93s. 45s sits ABOVE that cluster so it
+//    preserves the slow-but-working estimates and only 503s the ~15/12h (1.2/hr)
+//    that were already >=45s (broken-feeling anyway), capping the tail to ~47s.
+//    A tighter 25s would have wrongly 503'd ~112 successful estimates/12h.
 const ORCHESTRATOR_QUERY_TIMEOUT_MS = 20_000;
-export const ORCHESTRATOR_WHATIF_TIMEOUT_MS = 25_000;
+export const ORCHESTRATOR_WHATIF_TIMEOUT_MS = 45_000;
 
 export async function queryWorkflows({
   token,

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -44,6 +44,21 @@ import {
 const ORCHESTRATOR_UNAVAILABLE_MESSAGE =
   'Generation services are temporarily unavailable. Please try again.';
 
+// Overall wall-clock budgets for the side-effect-free orchestrator paths. These
+// bound the request via a single `AbortSignal.timeout(ms)` (which throws a
+// `TimeoutError` that `isUpstreamNetworkError` already classifies → mapped to a
+// retry-able 503 below). The budget is intentionally created ONCE and SHARED
+// across all retry attempts — the same AbortSignal is threaded into every
+// `submitWorkflowWithRetry` attempt — so the 3-attempt retry loop can NOT
+// multiply the wall-clock cost (that multiplication is exactly what turned a slow
+// orchestrator into a 56–93s park). The orchestrator's healthy P99 here is only a
+// few seconds, so these ceilings leave generous headroom while killing the tail.
+// Read (queryWorkflows → queryGeneratedImages) and what-if (cost estimate) only;
+// the generate/submit WRITE path is deliberately left unbounded (retry-without-
+// idempotency dup-safety is a separate follow-up).
+const ORCHESTRATOR_QUERY_TIMEOUT_MS = 20_000;
+export const ORCHESTRATOR_WHATIF_TIMEOUT_MS = 25_000;
+
 export async function queryWorkflows({
   token,
   fromDate,
@@ -54,6 +69,10 @@ export async function queryWorkflows({
 
   const { data, error } = await clientQueryWorkflows({
     client,
+    // Bound the read with an overall wall-clock budget. A fired timeout throws a
+    // `TimeoutError`, caught below and mapped to a retry-able 503 by the existing
+    // `isUpstreamNetworkError` branch — no new handling needed here.
+    signal: AbortSignal.timeout(ORCHESTRATOR_QUERY_TIMEOUT_MS),
     query: {
       ...query,
       tags: ['civitai', ...(query.tags ?? [])],
@@ -164,7 +183,8 @@ export async function submitWorkflow({
   token,
   body,
   query,
-}: Options<SubmitWorkflowData> & { token: string }) {
+  timeoutMs,
+}: Options<SubmitWorkflowData> & { token: string; timeoutMs?: number }) {
   const client = createOrchestratorClient(token);
   if (!body) throw throwBadRequestError();
 
@@ -185,10 +205,27 @@ export async function submitWorkflow({
     console.log('------');
   }
 
+  // Only the side-effect-free callers (whatIf) pass `timeoutMs`. When set, build
+  // the AbortSignal ONCE and thread it into `submitWorkflowWithRetry` so the SAME
+  // signal is shared across every retry attempt → an OVERALL wall-clock budget,
+  // not a per-attempt one (otherwise 3 attempts could multiply the cost). The
+  // generate/WRITE path passes no `timeoutMs` → no signal, behavior unchanged.
+  const signal = timeoutMs != null ? AbortSignal.timeout(timeoutMs) : undefined;
+
+  // When a budget is in effect, a fired-signal failure surfaces (after retries are
+  // exhausted) as a THROWN upstream network/timeout error from
+  // `submitWorkflowWithRetry`. Map only that class to a retry-able 503; a non-
+  // network throw (a real bug) must re-throw unchanged. Without `timeoutMs` this
+  // wrapper is a no-op (the write path keeps its identical behavior).
   const result = await submitWorkflowWithRetry({
     client,
     body: { ...body, tags: ['civitai', ...(body.tags ?? [])] },
     query,
+    ...(signal ? { signal } : {}),
+  }).catch((thrown) => {
+    if (timeoutMs != null && isUpstreamNetworkError(thrown))
+      throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, thrown);
+    throw thrown;
   });
 
   // Narrow on `result.data` (not a destructured copy) so this always-throwing

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -63,7 +63,9 @@ const ORCHESTRATOR_UNAVAILABLE_MESSAGE =
 //  - whatIfFromGraph ok=true has a legitimate slow cluster at 30-40s (81 calls)
 //    then a thin tail; the worst park was ~93s. 45s sits ABOVE that cluster so it
 //    preserves the slow-but-working estimates and only 503s the ~15/12h (1.2/hr)
-//    that were already >=45s (broken-feeling anyway), capping the tail to ~47s.
+//    that were already >=45s (broken-feeling anyway), capping the tail to ~45s
+//    (the retry loop short-circuits once the shared budget fires, so backoff
+//    sleeps don't push total past the deadline).
 //    A tighter 25s would have wrongly 503'd ~112 successful estimates/12h.
 const ORCHESTRATOR_QUERY_TIMEOUT_MS = 20_000;
 export const ORCHESTRATOR_WHATIF_TIMEOUT_MS = 45_000;
@@ -333,6 +335,12 @@ export async function submitWorkflowWithRetry(
       // Network failure / no response. Out of retries → surface it like a direct call would.
       lastError = e;
       if (attempt >= maxAttempts) throw e;
+      // If the caller's overall timeout budget (a shared AbortSignal) has already
+      // fired, this throw IS the abort — every further attempt would abort instantly
+      // and the backoff sleeps would just burn wall-clock PAST the deadline. Surface
+      // it now so total latency stays within the budget (~budget, not budget + the
+      // leftover backoff sleeps). No-op on the write path (no signal → never aborted).
+      if (options.signal?.aborted) throw e;
       await submitWorkflowBackoff({ attempt, status: undefined, baseDelayMs, onRetry });
       continue;
     }


### PR DESCRIPTION
## Problem

On civitai-dp-prod, `orchestrator.whatIfFromGraph` (cost estimation) and `orchestrator.queryGeneratedImages` park in the P99 latency tail for up to **56–93s** (slow-tRPC log). Root cause: the orchestrator HTTP client (`createOrchestratorClient`, on `@civitai/client` / `@hey-api/client-fetch`) is built with **no request timeout / AbortSignal**, so its `fetch` parks indefinitely on a slow-but-eventually-responding orchestrator. For submit, `submitWorkflowWithRetry` (3 attempts + backoff) multiplies a slow call.

It is **not** the prompt-moderation audit (an earlier hypothesis): `whatIfFromGraph` *skips* `auditPromptServer` (cost-only) yet still parks at 93s. The shared un-timed await is the orchestrator client fetch.

## Fix

Thread **one** `AbortSignal.timeout(ms)` budget, **shared across all retry attempts** (so the 3× retry can't multiply it), into the **side-effect-free** paths only:
- `queryWorkflows` (→ `queryGeneratedImages`): **20s**
- `whatIfFromGraph`'s submit: **45s**

A fired `TimeoutError` is already classified by `isUpstreamNetworkError` (`name === 'TimeoutError'`/`'AbortError'`) → mapped to a retryable **503** (same pattern as the existing `queryWorkflows`/`getWorkflow` catches).

The retry loop **short-circuits once the budget fires** (no backoff sleeps past the deadline), so total stays ~= the budget.

## The generate/submit WRITE path is deliberately left UNBOUNDED

`generateFromGraph` passes no `timeoutMs` → no signal, no new error mapping → **byte-identical behavior** (locked by a test asserting a `TimeoutError` propagates unchanged, not remapped). Reason: submit-retry without an idempotency key could **double-charge a generation**; the orchestrator only dedupes when the client supplies `externalId`. Bounding the write path is a separate follow-up gated on guaranteeing that dedup.

## Ceiling sizing (45s, not 25s — data-driven)

See the inline comment + the PR comment below. Among **`ok=true`** slow what-ifs (12h), there's a legitimate slow cluster at **30–40s (81 calls)**. A 25s cap would have wrongly 503'd **~112 successful estimates/12h**; **45s** sits above that cluster → only **~15/12h (1.2/hr)** false-503s (those already ≥45s, broken-feeling anyway), while capping the 93s tail to ~45s. `queryGeneratedImages` ok=true tops out ~10s, so the 20s read budget 503s ~nothing.

## Audit (adversarial, post-implementation)

- **Write-path-unchanged invariant: verified** (re-throw preserves the exact error object; no signal leaks; success path untouched; dedicated test locks it).
- **SDK threads `signal`: verified from compiled source** — `client.gen.js` spreads per-call `opts` (incl. `signal`) into `requestInit` → `new Request(url, requestInit)` → `await _fetch(request)`; an aborted fetch rejects → `TimeoutError` → 503. The fix is live, not inert.
- **whatIf 503 degrades gracefully** — `useWhatIfFromGraph` falls back to `{ cost: defaultWorkflowCost, ready: false }`; global tRPC `retry: 1`, no storm.

## Verification after deploy
`{namespace="civitai-dp-prod"} | json | name="trpc-procedure-slow" | path="orchestrator.whatIfFromGraph"` — max `durationMs` should drop from ~93s to ≤~45s, with a small retryable-503 rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)