### PR TITLE
fix(civitai-link): target link.civitai.red on .red so key generation works

### DIFF
--- a/src/components/CivitaiLink/__tests__/civitai-link-api.test.ts
+++ b/src/components/CivitaiLink/__tests__/civitai-link-api.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// `civitai-link-api` reads `env.NEXT_PUBLIC_CIVITAI_LINK` at call time. Stub the
+// client env module before importing so we don't trip the zod schema check in
+// `~/env/client`.
+vi.mock('~/env/client', () => ({
+  env: {
+    NEXT_PUBLIC_CIVITAI_LINK: 'https://link.civitai.com',
+  },
+}));
+
+import { getCivitaiLinkBaseUrl } from '~/components/CivitaiLink/civitai-link-api';
+
+const setHostname = (hostname: string | undefined) => {
+  // Emulate window/SharedWorker `globalThis.location.hostname`.
+  Object.defineProperty(globalThis, 'location', {
+    value: hostname === undefined ? undefined : { hostname },
+    configurable: true,
+    writable: true,
+  });
+};
+
+describe('getCivitaiLinkBaseUrl', () => {
+  afterEach(() => {
+    setHostname(undefined);
+  });
+
+  it('uses the .com Link host on civitai.com', () => {
+    setHostname('civitai.com');
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
+  });
+
+  it('rewrites to the .red Link host on civitai.red', () => {
+    setHostname('civitai.red');
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.red');
+  });
+
+  it('rewrites to the .red Link host on a .red subdomain', () => {
+    setHostname('internal.civitai.red');
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.red');
+  });
+
+  it('is case-insensitive about the host', () => {
+    setHostname('Civitai.Red');
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.red');
+  });
+
+  it('does not match a lookalike host that merely contains civitai.red', () => {
+    setHostname('civitai.red.evil.com');
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
+  });
+
+  it('falls back to the baked .com host when no location is available', () => {
+    setHostname(undefined);
+    expect(getCivitaiLinkBaseUrl()).toBe('https://link.civitai.com');
+  });
+});

--- a/src/components/CivitaiLink/civitai-link-api.ts
+++ b/src/components/CivitaiLink/civitai-link-api.ts
@@ -9,23 +9,48 @@ export type CivitaiLinkInstance = {
   createdAt: Date;
 };
 
+/**
+ * Resolve the Civitai Link service base URL for the current host.
+ *
+ * `NEXT_PUBLIC_CIVITAI_LINK` (e.g. https://link.civitai.com) is baked at build
+ * time and identical for the .com and .red builds. But the Link service
+ * authenticates via the civitai session cookie, which after the .com/.red
+ * split is domain-scoped to the host the user logged in on. A .red user's
+ * cookie never reaches link.civitai.com, so the request 401s and key
+ * generation hangs forever (ClickUp 868k49796). Target the same-registrable-
+ * domain link.civitai.red instead so the .civitai.red cookie is sent.
+ *
+ * Runs in both window and SharedWorker contexts (`globalThis.location`).
+ */
+export const getCivitaiLinkBaseUrl = (): string | undefined => {
+  const base = env.NEXT_PUBLIC_CIVITAI_LINK;
+  if (!base) return base;
+  const host = (globalThis as { location?: { hostname?: string } }).location?.hostname?.toLowerCase();
+  const isRed = host === 'civitai.red' || (host?.endsWith('.civitai.red') ?? false);
+  return isRed ? base.replace('.civitai.com', '.civitai.red') : base;
+};
+
 const clFetch = async (url: string, options: RequestInit = {}) => {
-  if (!env.NEXT_PUBLIC_CIVITAI_LINK) throw new Error('Civitai Link URL not set');
+  const base = getCivitaiLinkBaseUrl();
+  if (!base) throw new Error('Civitai Link URL not set');
 
   if (!url.startsWith('/')) url = '/' + url;
-  const response = await fetch(env.NEXT_PUBLIC_CIVITAI_LINK + url, {
+  const response = await fetch(base + url, {
     ...options,
     credentials: 'include',
   });
+  // Surface failures instead of returning {}: a non-array body silently became
+  // `instances` and downstream `.find` threw "a.find is not a function" while
+  // the UI spun forever. Throwing lets the worker's catch emit a real error.
   if (!response.ok) {
-    console.error(response);
-    return {} as unknown;
+    throw new Error(`Civitai Link request failed (${response.status} ${response.statusText})`);
   }
   return response.json() as unknown;
 };
 
 export const getLinkInstances = async () => {
-  return (await clFetch('/api/link')) as CivitaiLinkInstance[];
+  const result = await clFetch('/api/link');
+  return (Array.isArray(result) ? result : []) as CivitaiLinkInstance[];
 };
 
 export const createLinkInstance = async (id?: number) => {

--- a/src/workers/civitai-link.worker.ts
+++ b/src/workers/civitai-link.worker.ts
@@ -8,12 +8,12 @@ import type {
   ResponseStatus,
   ActivitiesResponse,
 } from '~/components/CivitaiLink/shared-types';
-import { env } from '~/env/client';
 import { v4 as uuid } from 'uuid';
 import type { CivitaiLinkInstance } from '~/components/CivitaiLink/civitai-link-api';
 import {
   createLinkInstance,
   deleteLinkInstance,
+  getCivitaiLinkBaseUrl,
   getLinkInstances,
   updateLinkInstance,
 } from '~/components/CivitaiLink/civitai-link-api';
@@ -36,7 +36,9 @@ const _self: SharedWorkerGlobalScope = self as any;
 // Setup Socket
 // --------------------------------
 
-const socket: SocketClient = io(env.NEXT_PUBLIC_CIVITAI_LINK ?? 'http://localhost:3000', {
+// Domain-aware base so .red users connect to link.civitai.red (same-origin to
+// their .civitai.red session cookie) instead of the hardcoded .com host.
+const socket: SocketClient = io(getCivitaiLinkBaseUrl() ?? 'http://localhost:3000', {
   path: '/api/socketio',
   autoConnect: false,
 });


### PR DESCRIPTION
## Problem
Civitai Link key generation hangs forever on **civitai.red** (ClickUp [868k49796](https://app.clickup.com/t/868k49796), 5+ support tickets since Apr 21).

Root cause: the client is hardcoded to `NEXT_PUBLIC_CIVITAI_LINK` (`https://link.civitai.com`, baked at build time and identical for both builds). After the .com/.red split the session cookie is domain-scoped to `.civitai.red`, so it never reaches the `.com` host. The cross-origin `credentials:'include'` request 401s; `clFetch` swallowed it into `{}`, which became `instances`, so the worker's `instances.find(...)` threw **`a.find is not a function`** while the wizard spun indefinitely.

## Change
- **`getCivitaiLinkBaseUrl()`**: on a `.red` host, rewrite the Link base to `link.civitai.red` (same registrable domain → the `.civitai.red` cookie is sent). Works in both window and SharedWorker contexts via `globalThis.location`. Used by **both** `clFetch` and the worker's Socket.IO connection (both previously hardcoded to the `.com` env value).
- **`clFetch` throws on a non-ok response** instead of returning `{}` — the worker's existing `catch` now emits a real error notification instead of an infinite spinner + `.find` crash.
- **`getLinkInstances` always returns an array** (defense in depth against a non-array 200).
- Unit tests for the host→base mapping (.com / .red / .red-subdomain / case-insensitivity / lookalike-host rejection / no-location fallback).

## No link-service change needed
Audited `civitai/link-service`: auth decrypts the `__Secure-civitai-token` JWE purely from `AUTH_SECRET` (domain-independent), and CORS is `{ origin: true }` (reflects any origin). It just needed to be reachable at a `.red` host.

## Companion
- Infra (IngressRoute `link.civitai.red` host + DNS): civitai/talos-infra#235

## Verification
- ✅ `getCivitaiLinkBaseUrl` unit tests pass (6/6).
- ⏳ **Not yet browser-verified** on civitai.red — needs the infra PR + DNS live first, then a logged-in `.red` key-generation click path.