### PR TITLE
perf(gen): instrument createWorkflowStepsFromGraph with OTel spans to localize the whatIf/generate park

### DIFF
--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -35,6 +35,7 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import { getPrimaryFile, getTrainingFileEpochNumberDetails } from '~/server/utils/model-helpers';
+import { withSpan } from '~/server/utils/otel-helpers';
 import { getPagedData } from '~/server/utils/pagination-helpers';
 import {
   fluxKreaAir,
@@ -1236,9 +1237,15 @@ export async function getResourceData(
     typeof versionIds[0] === 'number' ? versionIds.map((id) => ({ id })) : versionIds
   ) as { id: number; epoch?: number }[];
 
-  const unavailableResources = await getUnavailableResources();
-  const featuredModels = await getFeaturedModels();
-  const hiddenGates = await getCanGenerateHiddenGates(user);
+  // Spans localize the gen-path park: getResourceData does these as SEQUENTIAL
+  // awaits, so wrapping each shows which prelim lookup dominates.
+  const unavailableResources = await withSpan('gen:getResourceData:unavailable', () =>
+    getUnavailableResources()
+  );
+  const featuredModels = await withSpan('gen:getResourceData:featured', () => getFeaturedModels());
+  const hiddenGates = await withSpan('gen:getResourceData:hiddenGates', () =>
+    getCanGenerateHiddenGates(user)
+  );
 
   function transformGenerationData(
     { settings, ...item }: GenerationResourceDataModel,
@@ -1421,41 +1428,47 @@ export async function getResourceData(
   // The cache deduplicates by model version ID, but different epochs of the same
   // model version need separate entries with their own epochDetails.
   const uniqueIds = [...new Set(args.map((x) => x.id))];
-  const resources = await resourceDataCache
-    .fetch(uniqueIds)
-    .then((cachedResources) => {
-      const resourceById = new Map(cachedResources.map((r) => [r.id, r]));
-      return args
-        .map((arg) => {
-          const cached = resourceById.get(arg.id);
-          if (!cached) return null;
-          return transformGenerationData(cached, arg.epoch);
-        })
-        .filter(isDefined);
-    })
-    .then(async (resources) => {
-      const substitutes = await getResourceDataSubstitutes(resources);
-      const entityAccess = await getEntityAccess([...resources, ...substitutes]);
+  // Span localizes the gen-path park: this is the main resource-data fetch
+  // (cache/DB lookup + substitutes + entity access + model files) — the
+  // dominant work in getResourceData. Wrapping the whole .fetch().then().then()
+  // chain so its total time shows as one sub-step.
+  const resources = await withSpan('gen:getResourceData:fetch', () =>
+    resourceDataCache
+      .fetch(uniqueIds)
+      .then((cachedResources) => {
+        const resourceById = new Map(cachedResources.map((r) => [r.id, r]));
+        return args
+          .map((arg) => {
+            const cached = resourceById.get(arg.id);
+            if (!cached) return null;
+            return transformGenerationData(cached, arg.epoch);
+          })
+          .filter(isDefined);
+      })
+      .then(async (resources) => {
+        const substitutes = await getResourceDataSubstitutes(resources);
+        const entityAccess = await getEntityAccess([...resources, ...substitutes]);
 
-      for (const resource of [...resources, ...substitutes]) {
-        if (!resource.hasAccess) {
-          // TODO - get the number of remaining early access downloads if early access allows limited number of free generations
-          resource.hasAccess = !!(
-            entityAccess.find((e) => e.entityId === resource.id)?.hasAccess ||
-            !!resource.earlyAccessConfig?.generationTrialLimit
-          );
-          resource.canGenerate = resource.hasAccess && resource.canGenerate;
+        for (const resource of [...resources, ...substitutes]) {
+          if (!resource.hasAccess) {
+            // TODO - get the number of remaining early access downloads if early access allows limited number of free generations
+            resource.hasAccess = !!(
+              entityAccess.find((e) => e.entityId === resource.id)?.hasAccess ||
+              !!resource.earlyAccessConfig?.generationTrialLimit
+            );
+            resource.canGenerate = resource.hasAccess && resource.canGenerate;
+          }
         }
-      }
 
-      const modelFilesCached = await getModelFiles([...resources, ...substitutes]);
+        const modelFilesCached = await getModelFiles([...resources, ...substitutes]);
 
-      return resources.map((resource) => {
-        const modelFiles = modelFilesCached[resource.id]?.files ?? [];
-        const substitute = getSubstituteData(resource, substitutes, modelFiles);
-        return removeNulls({ ...bringItAllTogether(resource, modelFiles), substitute });
-      });
-    });
+        return resources.map((resource) => {
+          const modelFiles = modelFilesCached[resource.id]?.files ?? [];
+          const substitute = getSubstituteData(resource, substitutes, modelFiles);
+          return removeNulls({ ...bringItAllTogether(resource, modelFiles), substitute });
+        });
+      })
+  );
 
   if (withPreview) {
     const imageCache = await imagesForModelVersionsCache.fetch(resources.map((r) => r.id));

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -62,6 +62,7 @@ import type { WorkflowUpdateSchema } from '~/server/schema/orchestrator/workflow
 import { mapDataToGraphInput } from './legacy-metadata-mapper';
 import { getHighestTierSubscription } from '~/server/services/subscriptions.service';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
+import { withSpan } from '~/server/utils/otel-helpers';
 import { getOrchestratorCallbacks } from '~/server/orchestrator/orchestrator.utils';
 import { BuzzTypes, type BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { Availability } from '~/shared/utils/prisma/enums';
@@ -370,7 +371,12 @@ async function validateAndEnrichResources(
     };
   }
 
-  const resources = await getResourceData(resourceRefs, { user });
+  // Span localizes the gen-path park: resource resolution is the heavy lookup
+  // inside validateAndEnrichResources (delegates to getResourceData, which has
+  // its own finer-grained sub-spans).
+  const resources = await withSpan('gen:validateResources:getResourceData', () =>
+    getResourceData(resourceRefs, { user })
+  );
 
   // Check for private/epoch resources requiring subscription
   const hasPrivateOrEpoch = resources.some(
@@ -378,7 +384,10 @@ async function validateAndEnrichResources(
   );
 
   if (hasPrivateOrEpoch && user?.id && !user?.isModerator) {
-    const subscription = await getHighestTierSubscription(user.id);
+    // Span localizes the gen-path park: subscription lookup for private/epoch use.
+    const subscription = await withSpan('gen:validateResources:subscription', () =>
+      getHighestTierSubscription(user.id!)
+    );
     if (!subscription) {
       throw throwBadRequestError('Using Private resources require an active subscription.');
     }
@@ -916,8 +925,11 @@ export async function createWorkflowStepsFromGraph({
 }> {
   // Validate and enrich resources
   const resourceIds = collectResourceIds(data);
-  const { enrichedResources, isPrivateGeneration, hasPoiResource } =
-    await validateAndEnrichResources(resourceIds, user);
+  // Span localizes the gen-path park: resource validation/enrichment sub-step.
+  const { enrichedResources, isPrivateGeneration, hasPoiResource } = await withSpan(
+    'gen:createSteps:validateResources',
+    () => validateAndEnrichResources(resourceIds, user)
+  );
 
   // Check for POI in prompt
   const prompt = 'prompt' in data ? (data.prompt as string) : undefined;
@@ -990,115 +1002,130 @@ export async function createWorkflowStepsFromGraph({
   // returns `[{}]` — a single empty overlay — so the loop runs exactly once
   // and behaves identically to a pre-snippets build. What-if requests always
   // get the trivial overlay (cost estimation runs against the template).
+  // Span localizes the gen-path park: snippet-overlay resolution sub-step
+  // (only runs for non-what-if submissions).
   const snippetResult = isWhatIf
     ? { overlays: [{} as Record<string, string>], parsedTargets: {}, expanded: false }
-    : await getSnippetOverlays({ resolvedData, userId: user?.id, isGreen });
+    : await withSpan('gen:createSteps:snippetOverlays', () =>
+        getSnippetOverlays({ resolvedData, userId: user?.id, isGreen })
+      );
   const { overlays, parsedTargets, expanded: snippetsExpanded } = snippetResult;
 
-  const steps: StepInput[] = [];
-  for (const overlay of overlays) {
-    const isSnippetVariant = !isEmptyObject(overlay);
-    const variantData = isSnippetVariant
-      ? ({ ...resolvedData, ...overlay } as typeof resolvedData)
-      : resolvedData;
-    const variantStepMetadata = isSnippetVariant
-      ? buildVariantStepMetadata(variantData, computedKeys)
-      : stepMetadata;
+  // Span localizes the gen-path park: graph→steps assembly sub-step — builds the
+  // per-overlay steps (createStepInputs), the request-wrapped steps, the
+  // workflow-level metadata, and the extra tags from the resolved data.
+  const { wrappedSteps, workflowMetadata, extraTags } = await withSpan(
+    'gen:createSteps:assemble',
+    async () => {
+      const steps: StepInput[] = [];
+      for (const overlay of overlays) {
+        const isSnippetVariant = !isEmptyObject(overlay);
+        const variantData = isSnippetVariant
+          ? ({ ...resolvedData, ...overlay } as typeof resolvedData)
+          : resolvedData;
+        const variantStepMetadata = isSnippetVariant
+          ? buildVariantStepMetadata(variantData, computedKeys)
+          : stepMetadata;
 
-    // Advance baseStepIndex per variant so cross-step `$ref` objects (e.g.
-    // preprocess → gen wiring inside controlnet handlers) resolve to the
-    // correct global step position after concatenation.
-    const variantSteps = await createStepInputs(
-      variantData,
-      { ...handlerCtx, baseStepIndex: steps.length },
-      {
-        stepMetadata: variantStepMetadata,
-        isWhatIf,
-        sourceCtx,
-      }
-    );
+        // Advance baseStepIndex per variant so cross-step `$ref` objects (e.g.
+        // preprocess → gen wiring inside controlnet handlers) resolve to the
+        // correct global step position after concatenation.
+        const variantSteps = await createStepInputs(
+          variantData,
+          { ...handlerCtx, baseStepIndex: steps.length },
+          {
+            stepMetadata: variantStepMetadata,
+            isWhatIf,
+            sourceCtx,
+          }
+        );
 
-    // Per-step metadata for snippet variants records ONLY the substituted
-    // snippet-target fields (e.g. `prompt`, `negativePrompt`) — a small DELTA — in
-    // `params`, plus `partialParams: true` to flag it as such. The workflow-level
-    // metadata already carries the full template + params snapshot, so we keep the
-    // per-step payload tiny (no full params duplicated per variant) and let the
-    // client spread the delta over the workflow params when reading.
-    // See docs/generation-metadata-architecture.md.
-    if (isSnippetVariant) {
-      for (const step of variantSteps) {
-        const existingMeta = (step.metadata ?? {}) as Record<string, unknown>;
-        const existingParams = (existingMeta.params as Record<string, unknown> | undefined) ?? {};
-        step.metadata = {
-          ...existingMeta,
-          params: { ...existingParams, ...overlay },
-          partialParams: true,
-        };
+        // Per-step metadata for snippet variants records ONLY the substituted
+        // snippet-target fields (e.g. `prompt`, `negativePrompt`) — a small DELTA — in
+        // `params`, plus `partialParams: true` to flag it as such. The workflow-level
+        // metadata already carries the full template + params snapshot, so we keep the
+        // per-step payload tiny (no full params duplicated per variant) and let the
+        // client spread the delta over the workflow params when reading.
+        // See docs/generation-metadata-architecture.md.
+        if (isSnippetVariant) {
+          for (const step of variantSteps) {
+            const existingMeta = (step.metadata ?? {}) as Record<string, unknown>;
+            const existingParams =
+              (existingMeta.params as Record<string, unknown> | undefined) ?? {};
+            step.metadata = {
+              ...existingMeta,
+              params: { ...existingParams, ...overlay },
+              partialParams: true,
+            };
+          }
+        }
+
+        steps.push(...variantSteps);
       }
+
+      // Wrap with request-level concerns: priority, timeout, outputFormat
+      // isPrivateGeneration lives on workflow.metadata, not per-step.
+      // `remixOfId` is ALSO copied onto each step's metadata: the orchestrator's
+      // `WorkflowStepHandler.GenerateJobsAsync` reads `workflowStep.Metadata["remixOfId"]`
+      // (not workflow-level metadata) to thread the remix source id into the job
+      // record → MongoDB `prod.jobs.Properties.remixOfId` → CDC → ClickHouse
+      // `orchestration.jobs`, which is what makes the remix product loop measurable.
+      // See civitai-orchestration#216. Kept on workflow.metadata as well for the
+      // app's own replay/normalization path (NormalizedWorkflowMetadata.remixOfId).
+      // Intermediate steps (videoInterpolation) don't get outputFormat injected.
+      const wrappedSteps = steps.map((step) => ({
+        $type: step.$type,
+        input: {
+          ...(step.input as object),
+          outputFormat: data.outputFormat,
+        },
+        priority: data.priority,
+        timeout,
+        metadata: isWhatIf
+          ? undefined
+          : ({
+              ...((step.metadata as object) ?? {}),
+              ...(remixOfId != null ? { remixOfId } : {}),
+            } as object),
+      })) as WorkflowStepTemplate[];
+
+      // Build workflow-level metadata — the form input snapshot for workflow-level
+      // replay. `params.snippets` rides along automatically because it's a
+      // graph-level node captured by `toStepMetadata`.
+      //
+      // Snippet-specific persistence cleanup:
+      // - When the resolver didn't fire (snippets node at defaults, no refs, no
+      //   batch request), strip the entire `snippets` entry so non-snippet
+      //   generations don't carry an unused blob. The `wildcards` workflow tag
+      //   remains the canonical "did this use snippets" signal.
+      // - When the resolver did fire, overwrite `snippets.targets` with the
+      //   parsed-refs snapshot (each `#ref` as `{ category, selections: [] }`)
+      //   so workflow.metadata records exactly which refs the submission used.
+      //   And drop `snippets.seed` — that field is preview-only and remixes
+      //   should re-roll the random picks.
+      const persistedParams = removeEmpty(stepMetadata.params as Record<string, unknown>);
+      if (!snippetsExpanded) {
+        delete persistedParams.snippets;
+      } else if (persistedParams.snippets && typeof persistedParams.snippets === 'object') {
+        const persistedSnippets = persistedParams.snippets as Record<string, unknown>;
+        persistedSnippets.targets = parsedTargets;
+        delete persistedSnippets.seed;
+      }
+      const workflowMetadata = isWhatIf
+        ? undefined
+        : removeEmpty({
+            params: persistedParams,
+            resources: stepMetadata.resources,
+            remixOfId,
+            isPrivateGeneration,
+          });
+
+      const extraTags: string[] = [];
+      if (snippetsExpanded) extraTags.push(WORKFLOW_TAGS.WILDCARDS);
+
+      return { wrappedSteps, workflowMetadata, extraTags };
     }
-
-    steps.push(...variantSteps);
-  }
-
-  // Wrap with request-level concerns: priority, timeout, outputFormat
-  // isPrivateGeneration lives on workflow.metadata, not per-step.
-  // `remixOfId` is ALSO copied onto each step's metadata: the orchestrator's
-  // `WorkflowStepHandler.GenerateJobsAsync` reads `workflowStep.Metadata["remixOfId"]`
-  // (not workflow-level metadata) to thread the remix source id into the job
-  // record → MongoDB `prod.jobs.Properties.remixOfId` → CDC → ClickHouse
-  // `orchestration.jobs`, which is what makes the remix product loop measurable.
-  // See civitai-orchestration#216. Kept on workflow.metadata as well for the
-  // app's own replay/normalization path (NormalizedWorkflowMetadata.remixOfId).
-  // Intermediate steps (videoInterpolation) don't get outputFormat injected.
-  const wrappedSteps = steps.map((step) => ({
-    $type: step.$type,
-    input: {
-      ...(step.input as object),
-      outputFormat: data.outputFormat,
-    },
-    priority: data.priority,
-    timeout,
-    metadata: isWhatIf
-      ? undefined
-      : ({
-          ...((step.metadata as object) ?? {}),
-          ...(remixOfId != null ? { remixOfId } : {}),
-        } as object),
-  })) as WorkflowStepTemplate[];
-
-  // Build workflow-level metadata — the form input snapshot for workflow-level
-  // replay. `params.snippets` rides along automatically because it's a
-  // graph-level node captured by `toStepMetadata`.
-  //
-  // Snippet-specific persistence cleanup:
-  // - When the resolver didn't fire (snippets node at defaults, no refs, no
-  //   batch request), strip the entire `snippets` entry so non-snippet
-  //   generations don't carry an unused blob. The `wildcards` workflow tag
-  //   remains the canonical "did this use snippets" signal.
-  // - When the resolver did fire, overwrite `snippets.targets` with the
-  //   parsed-refs snapshot (each `#ref` as `{ category, selections: [] }`)
-  //   so workflow.metadata records exactly which refs the submission used.
-  //   And drop `snippets.seed` — that field is preview-only and remixes
-  //   should re-roll the random picks.
-  const persistedParams = removeEmpty(stepMetadata.params as Record<string, unknown>);
-  if (!snippetsExpanded) {
-    delete persistedParams.snippets;
-  } else if (persistedParams.snippets && typeof persistedParams.snippets === 'object') {
-    const persistedSnippets = persistedParams.snippets as Record<string, unknown>;
-    persistedSnippets.targets = parsedTargets;
-    delete persistedSnippets.seed;
-  }
-  const workflowMetadata = isWhatIf
-    ? undefined
-    : removeEmpty({
-        params: persistedParams,
-        resources: stepMetadata.resources,
-        remixOfId,
-        isPrivateGeneration,
-      });
-
-  const extraTags: string[] = [];
-  if (snippetsExpanded) extraTags.push(WORKFLOW_TAGS.WILDCARDS);
+  );
 
   return {
     steps: wrappedSteps,

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -1014,7 +1014,9 @@ export async function createWorkflowStepsFromGraph({
   // Span localizes the gen-path park: graph→steps assembly sub-step — builds the
   // per-overlay steps (createStepInputs), the request-wrapped steps, the
   // workflow-level metadata, and the extra tags from the resolved data.
-  const { wrappedSteps, workflowMetadata, extraTags } = await withSpan(
+  // Return the assembled result directly as this function's result so the span
+  // wraps the whole assembly and no fragile re-destructure/rename is needed.
+  return withSpan(
     'gen:createSteps:assemble',
     async () => {
       const steps: StepInput[] = [];
@@ -1123,15 +1125,13 @@ export async function createWorkflowStepsFromGraph({
       const extraTags: string[] = [];
       if (snippetsExpanded) extraTags.push(WORKFLOW_TAGS.WILDCARDS);
 
-      return { wrappedSteps, workflowMetadata, extraTags };
+      return {
+        steps: wrappedSteps,
+        workflowMetadata,
+        tags: extraTags,
+      };
     }
   );
-
-  return {
-    steps: wrappedSteps,
-    workflowMetadata,
-    tags: extraTags,
-  };
 }
 
 /**


### PR DESCRIPTION
## Why
`orchestrator.whatIfFromGraph` (and `generateFromGraph`) park up to **56–93s** server-side in production. We've **proven the slowness is NOT the orchestrator** — its calls return <8s. The park is civitai-side, inside `createWorkflowStepsFromGraph`, which is currently **un-instrumented** (an observability blind spot). The slow-tRPC log can say "whatIfFromGraph 93s" but can't localize the sub-step.

This PR is **observability-only** — it adds `withSpan(...)` instrumentation so the next production profile can name the exact slow sub-step. **Zero behavior change**: every `withSpan` wraps the existing await/expression and propagates the return value (incl. async promises) and thrown errors unchanged. No control-flow, ordering, error-propagation, or parallelism changes (sequential awaits stay sequential — converting them to `Promise.all` is a separate fix, once we've localized).

## Spans added

`src/server/services/orchestrator/orchestration-new.service.ts`
- `gen:createSteps:validateResources` — the `validateAndEnrichResources(...)` call
- `gen:createSteps:snippetOverlays` — the `getSnippetOverlays(...)` call (non-what-if branch only)
- `gen:createSteps:assemble` — the graph→steps assembly: the per-overlay `createStepInputs` loop, the request-wrapped steps, the workflow-level metadata, and the extra tags
- `gen:validateResources:getResourceData` — the `getResourceData(...)` call inside `validateAndEnrichResources`
- `gen:validateResources:subscription` — the `getHighestTierSubscription(...)` call

`src/server/services/generation/generation.service.ts` (inside `getResourceData`, the prime suspect — it does sequential awaits)
- `gen:getResourceData:unavailable` — `getUnavailableResources()`
- `gen:getResourceData:featured` — `getFeaturedModels()`
- `gen:getResourceData:hiddenGates` — `getCanGenerateHiddenGates(user)`
- `gen:getResourceData:fetch` — the main resource-data fetch (the `resourceDataCache.fetch(uniqueIds).then(...).then(...)` chain that does the cache/DB lookup + substitutes + entity access + model files)

All span names are low-cardinality (no IDs), matching the existing `withSpan` convention (e.g. `image:getAllImages:parallelFetch`). The helper no-ops on DOKS.

## Notes
- `gen:getResourceData:*` spans instrument `getResourceData` for **all** its callers (not just the gen path). That's acceptable — low volume, more visibility.
- The `gen:createSteps:assemble` block has a single linear tail (no early returns/throws inside it). It was wrapped by an `async () => { ... return { wrappedSteps, workflowMetadata, extraTags }; }` IIFE and the three values destructured back out, then fed into the function's existing single `return`. No control flow changed.

## Verification plan
This is pre-deploy instrumentation; **not yet verified against a live profile**. After deploy: query spanmetrics / Tempo for `gen:*` spans on a slow `whatIfFromGraph`/`generateFromGraph` trace and identify the dominant sub-step (expected suspects: `gen:getResourceData:fetch` or `gen:createSteps:assemble`). That localization drives the actual perf fix in a follow-up PR.

Syntax-checked both files with the TS parser (0 parse diagnostics). Did **not** run a full build (NixOS host, no node_modules; CI handles typecheck). No new tests (observability-only); the only test touching this area (`blocks.router.workflow.test.ts`) mocks `createWorkflowStepsFromGraphInput` entirely, so it doesn't exercise the wrapped code and the transparent wrapping can't affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
