### PR TITLE
test(app-blocks): fix 3 post-merge test failures (consent race, missing mock, renamed selector)

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -145,9 +145,16 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
 
     // The block claims a WIDER set than the host withheld — the host must ignore
     // the claim and grant only its server-known missingScopes.
-    postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted', 'buzz:spend:self'] });
-
+    //
+    // Re-post REQUEST_CONSENT INSIDE the waitFor: driveToReady only guarantees the
+    // DOM `data-block-ready` attribute, but the host's message-gate state can lag
+    // it by a tick — so a single fire-once REQUEST_CONSENT can land while the gate
+    // still reads "not ready", get dropped (see the "before BLOCK_READY is dropped"
+    // test), and never retried → the dialog never opens (a 10s CI-contention flake).
+    // Re-posting until the dialog appears mirrors driveToReady's BLOCK_READY retry;
+    // waitFor exits on the first success, so exactly one post opens exactly one dialog.
     await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted', 'buzz:spend:self'] });
       expect(useDialogStore.getState().dialogs).toHaveLength(1);
     });
 

--- a/src/server/rewards/__tests__/appBlockReview.reward.test.ts
+++ b/src/server/rewards/__tests__/appBlockReview.reward.test.ts
@@ -46,6 +46,10 @@ vi.mock('~/server/logging/client', () => ({
 vi.mock('~/server/prom/client', () => ({
   rewardFailedCounter: { inc: (...a: any[]) => h.rewardFailedInc(...a) },
   rewardGivenCounter: { inc: (...a: any[]) => h.rewardGivenInc(...a) },
+  // base.reward.ts increments this on the ClickHouse fail-soft path; without it
+  // in the mock the fail-soft branch calls `.inc` on undefined and rejects,
+  // making the "insert throw does NOT propagate" test fail.
+  clickhouseFailSoftCounter: { inc: vi.fn() },
 }));
 vi.mock('~/server/services/buzz.service', () => ({
   createBuzzTransactionMany: (...args: any[]) => h.createBuzzTransactionMany(...args),

--- a/tests/preview-apps-page.spec.ts
+++ b/tests/preview-apps-page.spec.ts
@@ -33,7 +33,7 @@ import { trpcQuery } from './preview-trpc';
  *  - Page route `/apps/run/[slug]/[[...path]]` SSR-gates on
  *    `features.appBlocks && features.appBlocksPages`, resolves the approved app
  *    by `block_id`, and renders `<PageBlockHost>`: the W7 trust chrome
- *    (`AppBlockChrome`, with an "App block menu" button) above the block
+ *    (`AppBlockChrome`, with an "App menu" button) above the block
  *    `<iframe>` (`title=<appName>`, `data-block-instance-id="page_<appBlockId>"`,
  *    `data-block-ready` flipping to "true" on BLOCK_READY).
  *
@@ -43,7 +43,7 @@ import { trpcQuery } from './preview-trpc';
  * So `getByTestId('app-page-iframe' | 'app-block-chrome' | 'app-page-frame')`
  * NEVER matches against a deployed preview — the elements render fine, the
  * attribute is just gone. We therefore assert on attributes the production build
- * KEEPS: the chrome's accessible "App block menu" button, and the iframe's
+ * KEEPS: the chrome's accessible "App menu" button, and the iframe's
  * `data-block-instance-id` (a `page_*` id) + `data-block-ready`. (`reactRemove
  * Properties` only strips `^data-testid$`, so other `data-*` attrs survive.)
  * This mirrors the sibling preview-apps-* specs, which assert via tRPC + ARIA
@@ -96,7 +96,7 @@ test.describe('App Blocks full-page app surface (mod)', () => {
     // menu" button is unique to AppBlockChrome and uses a production-safe
     // accessible name (NOT a stripped data-testid).
     await expect(
-      page.getByRole('button', { name: 'App block menu' }),
+      page.getByRole('button', { name: 'App menu' }),
       'the full-page host should render the W7 trust chrome'
     ).toBeVisible();
 


### PR DESCRIPTION
Three report-only suites went red on `main` after today's app-blocks merges. **All three are test issues — none is a product bug** (verified each against source).

## 1. component — `PageBlockHost.browser.test.tsx` (contention race)
"REQUEST_CONSENT opens the consent dialog" flaked: `expected [] to have length 1`, taking the full 10s. `driveToReady()` only guarantees the DOM `data-block-ready` attribute, but the host's message-gate state can lag it a tick — so the single fire-once `REQUEST_CONSENT` lands while the gate still reads "not ready", gets dropped (cf. the file's own "before BLOCK_READY is dropped" test), and never retries → the dialog never opens. Yesterday's `vi.waitFor` timeout bump only delayed the failure; this is the real fix: **re-post inside the `waitFor`**, mirroring how `driveToReady` re-posts `BLOCK_READY`. `waitFor` exits on first success, so exactly one post opens exactly one dialog. Verified 23/23.

## 2. unit — `appBlockReview.reward.test.ts` (incomplete mock)
The `~/server/prom/client` mock omitted `clickhouseFailSoftCounter`, which `base.reward.ts` increments on the ClickHouse fail-soft path → `.inc` on `undefined` rejected → the "insert throw does NOT propagate" test failed. Added the counter to the mock (sibling `base.reward.failsoft.test.ts` already mocks it). Verified 7/7.

## 3. smoke — `preview-apps-page.spec.ts` (renamed selector)
Asserted `getByRole('button', { name: 'App block menu' })`, but #2767 renamed it to `aria-label="App menu"` (`IframeHost.tsx:274`) and updated the component test but not the smoke spec. Updated the selector + 2 doc-comment refs. The button renders fine — pure test/UI desync. (Smoke can't run locally; matched against `IframeHost.tsx:274` + `AppBlockChrome.browser.test.tsx` which asserts `'App menu'`.)

## Verification
- unit + component run locally green (appBlockReview 7/7, PageBlockHost 23/23).
- smoke validated against source only (needs a deployed preview to execute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)