### PR TITLE
feat(blocks): token-auth POST /api/v1/blocks/withdraw (cli #29 server half)

### DIFF
--- a/src/pages/api/v1/blocks/withdraw.ts
+++ b/src/pages/api/v1/blocks/withdraw.ts
@@ -1,0 +1,232 @@
+import type { Logger } from '@civitai/next-axiom';
+import { withAxiom } from '@civitai/next-axiom';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { SessionUser } from 'next-auth';
+import * as z from 'zod';
+import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
+import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
+import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { withdrawRequest } from '~/server/services/blocks/publish-request.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
+
+type AxiomAPIRequest = NextApiRequest & { log: Logger };
+
+/**
+ * POST /api/v1/blocks/withdraw
+ *
+ * TOKEN-AUTHENTICATED, SELF-SCOPED withdrawal of the caller's OWN pending
+ * App-Block publish (submission) request. This is the server-side surface that
+ * unblocks the `civitai app withdraw` CLI command (cli #29): a developer who
+ * submitted via `civitai app submit` (`POST /api/v1/blocks/submit-version`) can
+ * now pull a still-pending submission back from review with the SAME token,
+ * without a moderator browser.
+ *
+ * It exposes the ALREADY-EXISTING, ownership-safe
+ * `withdrawRequest({ publishRequestId, userId })` service (which itself 404s on
+ * a missing row, refuses to touch another user's row, is a no-op when already
+ * withdrawn, and refuses to withdraw a non-`pending` request). This route does
+ * NOT re-implement that logic — it only authenticates the caller and maps the
+ * service's outcomes onto HTTP status codes WITHOUT leaking an ownership oracle.
+ *
+ * ## Auth — mirrors `GET /api/v1/blocks/submissions` /
+ *    `POST /api/v1/blocks/submit-version` EXACTLY, so the token that submitted
+ *    can withdraw:
+ *   - `Authorization: Bearer <civitai API key>` resolved via
+ *     `getSessionFromBearerToken` (the same helper backing all `/api/v1/*` REST
+ *     auth) — NO new key system.
+ *   - A PERSONAL key always passes the token-type gate.
+ *   - An OAUTH-client-issued token passes ONLY if it carries the dedicated
+ *     `TokenScope.AppBlocksSubmit` bit (the same gate submit-version + the
+ *     submissions read use; the first-party `civitai-cli` client is provisioned
+ *     with it). An un-scoped OAuth token → 403. This keeps the write in lockstep
+ *     with the submit: the same credential that could submit can withdraw its
+ *     own submission, and nothing weaker.
+ *   - MOD-ONLY pre-GA (`isAppBlocksEnabled({ user })` + `user.isModerator`,
+ *     not banned) — identical posture to submit-version + submissions +
+ *     dev-token. RELAX in lockstep with the rest of App Blocks at GA, not
+ *     unilaterally.
+ *
+ * ## Self-scoping — the security crux
+ * The ONLY mutation input is `publishRequestId`. Ownership is enforced inside
+ * `withdrawRequest` (which compares the row's `submittedByUserId` against the
+ * authenticated caller's id). There is NO request input that can target another
+ * user's row: a `publishRequestId` the caller doesn't own resolves to a 404 —
+ * the SAME response as a `publishRequestId` that doesn't exist at all — so the
+ * existence of another user's submission is never an ownership oracle. A
+ * developer can only ever withdraw their own pending submission.
+ *
+ * ## Why no CSRF / Origin guard (same reasoning as submit-version / submissions)
+ * Bearer-authed: the credential rides an `Authorization` header a cross-site
+ * form can't set and the browser never attaches automatically — no ambient
+ * authority, so the Origin guard is intentionally omitted (it would also break
+ * the headless CLI, which sends no Origin).
+ */
+export const config = {
+  api: {
+    // Body is a tiny JSON object ({ publishRequestId }); cap small so a
+    // determined caller can't push parse pressure on a stray body.
+    bodyParser: { sizeLimit: '8kb' },
+  },
+};
+
+// A write — keep the window tighter than the submissions read (60/60s) but
+// still generous enough for an interactive CLI + a couple of retries. Per-user
+// fixed window, fail-closed on a malformed limiter.
+const RATE_LIMIT = { max: 30, windowSeconds: 60 } as const;
+
+const bodySchema = z.object({
+  // The `pubreq_<ULID>` of the request to withdraw. Self-scoping is enforced in
+  // the service by `submittedByUserId` — this id only NAMES a row, it can never
+  // widen authority (not-owned / not-found → 404).
+  publishRequestId: z.string().min(1).max(128),
+});
+
+function clientIp(req: NextApiRequest): string {
+  const xff = req.headers['x-forwarded-for'];
+  const first = Array.isArray(xff) ? xff[0] : xff?.split(',')[0];
+  return (first ?? req.socket?.remoteAddress ?? 'unknown').trim();
+}
+
+export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+
+  // 1. Auth — Bearer API key → Civitai user via the existing API-key
+  // infrastructure (same helper as the public REST API / submit-version /
+  // submissions).
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.toLowerCase().startsWith('bearer ')) {
+    res.status(401).json({ message: 'Missing or malformed Bearer token' });
+    return;
+  }
+  const apiKey = authHeader.slice('bearer '.length).trim();
+  if (!apiKey) {
+    res.status(401).json({ message: 'Missing or malformed Bearer token' });
+    return;
+  }
+  const session = await getSessionFromBearerToken(apiKey);
+  if (!session?.user) {
+    res.status(401).json({ message: 'Invalid API key' });
+    return;
+  }
+  const user = session.user as SessionUser;
+
+  // 1b. Token-type gate — IDENTICAL to submit-version / submissions: accept a
+  // PERSONAL key always; accept an OAUTH-client-issued token ONLY if it carries
+  // the dedicated `TokenScope.AppBlocksSubmit` bit (opt-in, off-by-default,
+  // EXCLUDED from `TokenScope.Full`). So the SAME token that could submit can
+  // withdraw its own submission; an un-scoped OAuth token → 403 (before the
+  // flag/db/work, no leak).
+  if (session.subject?.type === 'oauth') {
+    if (!Flags.hasFlag(session.tokenScope, TokenScope.AppBlocksSubmit)) {
+      res.status(403).json({
+        message:
+          'App Blocks withdraw requires a personal API key or an OAuth token with the App Blocks submit scope',
+      });
+      return;
+    }
+  }
+
+  // 2. Moderator gate — App Blocks is mod-only pre-GA (parity with
+  // submit-version + submissions + dev-token).
+  if (!user.isModerator || user.bannedAt) {
+    res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
+    return;
+  }
+
+  // 3. Feature flag for THIS user (mirrors submit-version + the prod mint).
+  // 503 (dark) when off.
+  if (!(await isAppBlocksEnabled({ user }))) {
+    res.status(503).json({ message: 'App Blocks is not enabled' });
+    return;
+  }
+
+  // 4. Validate body (the single publishRequestId).
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ message: 'Invalid body', details: parsed.error.flatten() });
+    return;
+  }
+  const { publishRequestId } = parsed.data;
+
+  // 5. Rate limit — per-user (the stable authenticated identity), client-IP
+  // fallback. Same atomic SET NX EX + INCR MULTI as submissions/submit-version/
+  // dev-token; fail CLOSED on a malformed limiter result or a Redis incident.
+  const rateSubject = user.id ? `u:${user.id}` : `ip:${clientIp(req)}`;
+  const rateKey = `${REDIS_SYS_KEYS.BLOCKS.WITHDRAW_RATE_LIMIT}:${rateSubject}` as const;
+  let count: number;
+  try {
+    const multiResult = await sysRedis
+      .multi()
+      .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
+      .incr(rateKey)
+      .exec();
+    count = Number(multiResult?.[1]);
+  } catch (err) {
+    req.log?.warn('blocks/withdraw: rate limiter threw; failing closed', { rateSubject });
+    res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
+    return;
+  }
+  if (!Number.isFinite(count)) {
+    req.log?.warn('blocks/withdraw: rate-limit counter malformed; failing closed', {
+      rateSubject,
+    });
+    res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
+    return;
+  }
+  // Self-heal a TTL-less key (re-arm only when the TTL is actually missing, so
+  // an active window is never extended) — same footgun guard as submissions.
+  if (count > 1) {
+    const ttl = await sysRedis.ttl(rateKey).catch(() => -1);
+    if (ttl < 0) await sysRedis.expire(rateKey, RATE_LIMIT.windowSeconds).catch(() => {});
+  }
+  if (count > RATE_LIMIT.max) {
+    const retryAfter = await sysRedis.ttl(rateKey);
+    res.setHeader('Retry-After', String(Math.max(retryAfter, 1)));
+    res.status(429).json({
+      message: 'Rate limit exceeded',
+      retryAfterSeconds: retryAfter,
+      limit: RATE_LIMIT.max,
+      windowSeconds: RATE_LIMIT.windowSeconds,
+    });
+    return;
+  }
+
+  // The response is the caller's own private mutation outcome — never cache it.
+  res.setHeader('Cache-Control', 'no-store');
+
+  // 6. SELF-SCOPED mutation. `withdrawRequest` enforces ownership internally
+  // (compares the row's `submittedByUserId` to `user.id`) and is idempotent on
+  // an already-withdrawn row. We map its outcomes onto HTTP WITHOUT an ownership
+  // oracle:
+  //   - success (incl. idempotent already-withdrawn) → 200 { ok: true }
+  //   - not-found OR not-owned → 404 (SAME body for both — never reveal that a
+  //     row exists but belongs to another user)
+  //   - non-pending (approved/rejected) → 409 (Conflict). This branch is only
+  //     reachable AFTER the service's ownership check passes, so the row is
+  //     provably the CALLER'S own — disclosing its status to its owner is safe.
+  try {
+    await withdrawRequest({ publishRequestId, userId: user.id });
+    res.status(200).json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Ownership / existence collapse to one indistinguishable 404 (no oracle).
+    if (message.includes('not found') || message.includes('you can only withdraw your own')) {
+      res.status(404).json({ message: 'Publish request not found' });
+      return;
+    }
+    // The caller owns this row (ownership check already passed inside the
+    // service) but it's no longer pending — disclose the conflict to its owner.
+    if (message.includes('cannot withdraw a request in status')) {
+      res.status(409).json({ error: message });
+      return;
+    }
+    // Unexpected — log + 500, like submissions' catch-all.
+    req.log?.error('blocks/withdraw: unexpected error', { message, userId: user.id });
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -1651,6 +1651,15 @@ export const REDIS_SYS_KEYS = {
      * submission/review/deploy status from `civitai app status`.
      */
     SUBMISSIONS_RATE_LIMIT: 'system:blocks:submissions-rate-limit',
+    /**
+     * Per-user (fallback per-IP) rate-limit counter for the token-auth
+     * self-scoped submission WITHDRAW (`/api/v1/blocks/withdraw`). Same
+     * `SET NX EX` + `INCR` MULTI shape as `SUBMISSIONS_RATE_LIMIT` (always
+     * created with its TTL), on `sysRedis`. Bounds a dev pulling their own
+     * pending submission back from review via `civitai app withdraw`. Tighter
+     * window than the submissions read since this is a write.
+     */
+    WITHDRAW_RATE_LIMIT: 'system:blocks:withdraw-rate-limit',
   },
 } as const;
 

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -454,7 +454,7 @@ describe('submitVersion', () => {
         submittedByUserId: 42,
       })
     ).rejects.toThrow(
-      /you already have a pending submission for slug .* \(pubreq_existing\); withdraw it/
+      /you already have a pending submission for slug .* \(pubreq_existing\); withdraw it first with `civitai app withdraw pubreq_existing` before resubmitting/
     );
     expect(mockS3Send).not.toHaveBeenCalled();
     expect(mockDbWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -784,7 +784,7 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
   if (conflicting) {
     if (conflicting.submittedByUserId === submittedByUserId) {
       throw new Error(
-        `you already have a pending submission for slug ${slug} (${conflicting.id}); withdraw it before resubmitting`
+        `you already have a pending submission for slug ${slug} (${conflicting.id}); withdraw it first with \`civitai app withdraw ${conflicting.id}\` before resubmitting`
       );
     }
     throw new Error(

--- a/src/tests/api/v1/blocks/withdraw.test.ts
+++ b/src/tests/api/v1/blocks/withdraw.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Handler-level coverage for POST /api/v1/blocks/withdraw — the token-auth,
+ * SELF-SCOPED submission withdrawal that unblocks `civitai app withdraw`
+ * (cli #29). It exposes the already-ownership-safe `withdrawRequest` service to
+ * a bearer key, mirroring submissions.ts's auth posture.
+ *
+ * Asserts the security-sensitive invariants:
+ *   - auth: missing/invalid key → 401; un-scoped OAuth → 403; scoped OAuth
+ *     (AppBlocksSubmit) → allowed.
+ *   - gate: non-mod → 403; banned → 403; flag off → 503 (dark).
+ *   - body: malformed / missing publishRequestId → 400.
+ *   - SELF-SCOPING (the crux): `withdrawRequest` is always called with the
+ *     caller's `user.id`; a not-found AND a not-owned id both collapse to the
+ *     SAME 404 (no ownership oracle).
+ *   - non-pending row → 409 (the caller's own row, status disclosed to owner).
+ *   - happy path → 200 { ok: true }; idempotent re-withdraw → 200.
+ *   - rate-limit exceeded → 429; malformed limiter / redis incident → 503.
+ *   - 405 for non-POST.
+ */
+
+function createMocks({
+  method = 'POST',
+  headers = {},
+  body = {},
+}: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const req = {
+    method,
+    headers,
+    body,
+    socket: { remoteAddress: '203.0.113.7' },
+    log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown = undefined;
+  const responseHeaders: Record<string, string> = {};
+  const res = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(key: string, value: string) {
+      responseHeaders[key] = value;
+    },
+    end() {
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getHeaders: () => responseHeaders,
+  };
+  return { req, res };
+}
+
+const {
+  mockGetSession,
+  mockIsAppBlocksEnabled,
+  mockWithdrawRequest,
+  mockSysRedis,
+  mockMultiIncr,
+} = vi.hoisted(() => {
+  const mockMultiIncr = {
+    value: 1,
+    malformedExec: false as unknown[] | null | false,
+    throwExec: false,
+  };
+  const multiFactory = () => ({
+    set: vi.fn().mockReturnThis(),
+    incr: vi.fn().mockReturnThis(),
+    exec: vi.fn().mockImplementation(async () => {
+      if (mockMultiIncr.throwExec) throw new Error('redis down');
+      return mockMultiIncr.malformedExec !== false
+        ? mockMultiIncr.malformedExec
+        : ['OK', mockMultiIncr.value];
+    }),
+  });
+  return {
+    mockGetSession: vi.fn(),
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockWithdrawRequest: vi.fn(),
+    mockSysRedis: {
+      multi: vi.fn(multiFactory),
+      ttl: vi.fn().mockResolvedValue(60),
+      expire: vi.fn().mockResolvedValue(1),
+    },
+    mockMultiIncr,
+  };
+});
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (fn: unknown) => fn }));
+vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGetSession }));
+vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  withdrawRequest: mockWithdrawRequest,
+}));
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSysRedis,
+  REDIS_SYS_KEYS: { BLOCKS: { WITHDRAW_RATE_LIMIT: 'system:blocks:withdraw-rate-limit' } },
+}));
+
+import handler from '~/pages/api/v1/blocks/withdraw';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+const OWNER_ID = 7;
+const PUBREQ = 'pubreq_01';
+
+// Personal-access (user-type) key + moderator.
+const MOD_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 42,
+  subject: { type: 'apiKey', id: 42 },
+  tokenScope: TokenScope.Full,
+};
+const NONMOD_SESSION = {
+  user: { id: 8, isModerator: false },
+  apiKeyId: 43,
+  subject: { type: 'apiKey', id: 43 },
+  tokenScope: TokenScope.Full,
+};
+// An OAuth-client token WITHOUT the AppBlocksSubmit bit (TokenScope.Full excludes it).
+const OAUTH_UNSCOPED_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 99,
+  subject: { type: 'oauth', id: 'client_abc' },
+  tokenScope: TokenScope.Full,
+};
+// An OAuth-client token that carries the dedicated AppBlocksSubmit bit (the
+// first-party civitai-cli client).
+const OAUTH_SCOPED_SESSION = {
+  user: { id: OWNER_ID, isModerator: true },
+  apiKeyId: 100,
+  subject: { type: 'oauth', id: 'civitai-cli' },
+  tokenScope: TokenScope.UserRead | TokenScope.AppBlocksSubmit,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMultiIncr.value = 1;
+  mockMultiIncr.malformedExec = false;
+  mockMultiIncr.throwExec = false;
+  mockSysRedis.ttl.mockResolvedValue(60);
+  mockSysRedis.expire.mockResolvedValue(1);
+  mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockWithdrawRequest.mockResolvedValue(undefined);
+});
+
+function authPost(body: unknown = { publishRequestId: PUBREQ }) {
+  return createMocks({ headers: { authorization: 'Bearer personal-key' }, body });
+}
+
+describe('POST /api/v1/blocks/withdraw', () => {
+  it('405 for non-POST', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(405);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('401 when Authorization header is missing', async () => {
+    const { req, res } = createMocks({ body: { publishRequestId: PUBREQ } });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('401 when the bearer key does not resolve to a session', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('403 when the OAuth token lacks the AppBlocksSubmit scope', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_UNSCOPED_SESSION);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect((res._getJSONData() as { message: string }).message).toContain('submit scope');
+    // Rejected before flag / service — no leak.
+    expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('allows a scoped OAuth token (AppBlocksSubmit) — same token that submitted can withdraw', async () => {
+    mockGetSession.mockResolvedValueOnce(OAUTH_SCOPED_SESSION);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockWithdrawRequest).toHaveBeenCalledWith({
+      publishRequestId: PUBREQ,
+      userId: OWNER_ID,
+    });
+  });
+
+  it('403 when the resolved user is NOT a moderator', async () => {
+    mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('403 when the mod is banned', async () => {
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: OWNER_ID, isModerator: true, bannedAt: new Date() },
+      apiKeyId: 44,
+      subject: { type: 'apiKey', id: 44 },
+    });
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('503 (dark) when the App Blocks flag is OFF for the user', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockIsAppBlocksEnabled.mockResolvedValueOnce(false);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('400 when the body is missing publishRequestId', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost({});
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('400 when publishRequestId is an empty string', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost({ publishRequestId: '' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('SELF-SCOPING: withdrawRequest is ALWAYS called with the caller user.id', async () => {
+    const USER_A = { ...MOD_SESSION, user: { id: 101, isModerator: true } };
+    mockGetSession.mockResolvedValueOnce(USER_A);
+    const { req, res } = authPost({ publishRequestId: 'pubreq_x' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockWithdrawRequest).toHaveBeenCalledWith({
+      publishRequestId: 'pubreq_x',
+      userId: 101,
+    });
+  });
+
+  it('404 when the publish request does not exist (no ownership oracle)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockWithdrawRequest.mockRejectedValueOnce(new Error('publish request pubreq_01 not found'));
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(404);
+    expect((res._getJSONData() as { message: string }).message).toBe('Publish request not found');
+  });
+
+  it('404 when the publish request is NOT OWNED — identical body to not-found (no oracle)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockWithdrawRequest.mockRejectedValueOnce(
+      new Error('you can only withdraw your own publish requests')
+    );
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    // SAME status AND SAME body as the not-found case — a caller cannot tell
+    // "exists but someone else's" from "doesn't exist".
+    expect(res._getStatusCode()).toBe(404);
+    expect((res._getJSONData() as { message: string }).message).toBe('Publish request not found');
+  });
+
+  it('409 when the request is not pending (already approved/rejected) — disclosed to owner', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockWithdrawRequest.mockRejectedValueOnce(
+      new Error('cannot withdraw a request in status approved')
+    );
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(409);
+    expect((res._getJSONData() as { error: string }).error).toBe(
+      'cannot withdraw a request in status approved'
+    );
+  });
+
+  it('200 { ok: true } on the happy path + no-store header', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ ok: true });
+    expect(res._getHeaders()['Cache-Control']).toBe('no-store');
+    expect(mockWithdrawRequest).toHaveBeenCalledWith({
+      publishRequestId: PUBREQ,
+      userId: OWNER_ID,
+    });
+  });
+
+  it('200 { ok: true } on an idempotent re-withdraw (service is a no-op)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    // The service resolves (returns) for an already-withdrawn row.
+    mockWithdrawRequest.mockResolvedValueOnce(undefined);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ ok: true });
+  });
+
+  it('500 on an unexpected service error', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockWithdrawRequest.mockRejectedValueOnce(new Error('db connection lost'));
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(500);
+  });
+
+  it('429 when the per-user rate limit is exceeded', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 31; // > RATE_LIMIT.max (30)
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeaders()['Retry-After']).toBeDefined();
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('503 (fail closed) when the rate-limit exec() is malformed', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.malformedExec = null;
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('503 (fail closed) when the rate-limit exec() THROWS (redis incident)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.throwExec = true;
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(503);
+    expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('self-heals a TTL-less rate-limit key (re-arms expiry when ttl < 0)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 2; // not first hit → self-heal branch runs
+    mockSysRedis.ttl.mockResolvedValueOnce(-1); // key exists but lost its TTL
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSysRedis.expire).toHaveBeenCalledWith('system:blocks:withdraw-rate-limit:u:7', 60);
+  });
+});


### PR DESCRIPTION
## What

Adds a token-authenticated `POST /api/v1/blocks/withdraw` endpoint that lets an App Blocks developer withdraw their **own pending publish request** from the terminal — the server half of [civitai/cli #29](https://github.com/civitai/cli/issues/29) (the `civitai app withdraw` CLI command, built separately, calls this).

The underlying capability already exists and is ownership-safe: this PR **exposes the existing `withdrawRequest({ publishRequestId, userId })` service to a bearer key** — it does not re-implement the ownership/status logic. The service already 404s on a missing row, refuses another user's row, is a no-op when already withdrawn, and refuses a non-`pending` request.

## Auth — mirrors `GET /api/v1/blocks/submissions` verbatim

- `getSessionFromBearerToken` (the helper backing all `/api/v1/*` REST auth).
- Personal key always passes; an OAuth-client token passes **only** with `TokenScope.AppBlocksSubmit` (the same gate submit-version + submissions use; the first-party `civitai-cli` client carries it).
- **Mod-only pre-GA** (`isAppBlocksEnabled` + `isModerator`, not banned) — relax in lockstep with the rest of App Blocks at GA, not unilaterally.
- No Origin/CSRF guard (bearer-authed — same documented reasoning as submissions/submit-version; also needed for the headless CLI).
- Per-user fixed-window rate limit (30/60s — tighter than the submissions read since this is a write), `withAxiom` logging.

## Error mapping (security crux — no ownership oracle)

| Outcome | Status |
|---|---|
| success, incl. idempotent already-withdrawn | `200 { ok: true }` |
| not-found **OR** not-owned (same body) | `404` |
| non-pending (`cannot withdraw a request in status <X>` — caller's own row, ownership already verified in the service) | `409 { error }` |
| missing/invalid bearer | `401` |
| un-scoped OAuth / non-mod / banned | `403` |
| flag off (dark) | `503` |
| malformed body | `400` |
| rate-limited | `429` |
| limiter incident / unexpected | `503` / `500` |

A not-owned `publishRequestId` returns the **same 404 body** as a non-existent one, so the existence of another user's submission is never an ownership oracle.

## Also (part of #29)

Fixes the misleading duplicate-guard message in `publish-request.service.ts` — pre-this-PR "withdraw it before resubmitting" pointed nowhere; it now names the now-real path: ``withdraw it first with `civitai app withdraw <id>` before resubmitting``. Other-user variant unchanged. Orchestration test expectation updated to match.

## Tests / gates

- New handler test `src/tests/api/v1/blocks/withdraw.test.ts` (21 cases): 405; 401/403 auth; 400 body; **404 for not-owned AND not-found (identical body)**; 409 non-pending; 200 happy + idempotent; 429; 503 limiter; TTL self-heal. Mocks `withdrawRequest` + auth/flag helpers like the submissions test. **Green (21/21).**
- Orchestration test stays green (78/78) with the updated message regex.
- Full `tsc --noEmit` run: the 3 changed source files are clean; the 19 remaining errors are all pre-existing on `origin/main` in unrelated files (orchestrator handlers / flipt / image.service / bitdex-stats — unchanged by this PR).

Pairs with the `civitai app withdraw` CLI command (cli #29). Stays mod-only pre-GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Audit hardening (follow-up commit `b0ad41e8`)

Adversarial-review fixes applied on top of the original endpoint. **Behavioural changes** (note the corrections to the error mapping above):

### S1 — TOCTOU race in `withdrawRequest` (the important one)
The service read status via `dbRead.findUnique` then issued an `update` keyed on **`id` alone** (no status guard). A withdraw that read `pending` could still fire its update **after** a concurrent moderator `approveRequest` had flipped the row to `approved` (Forgejo repo created, Tekton build triggered, `app_blocks` row live) — clobbering `approved → withdrawn`, desyncing the live block from its request row and silently breaking the deploy state machine (`markRequestDeployState` filters on `status='approved'`, so build callbacks no-op). The scriptable endpoint (30 withdraws/60s) made this deliberately raceable.

**Fix:** the mutation is now a status-guarded `updateMany({ where: { id, status: 'pending' }, data: { status: 'withdrawn' } })`. If it matches **0 rows** despite the earlier `pending` classification, we re-read the row **from the primary** (`dbWrite`, to dodge replica lag) and resolve the lost race — now `withdrawn` → idempotent success; now `approved`/`rejected` → not-pending. This makes the "refuses to withdraw a non-pending request" guarantee **true under concurrency**, not just under the read.

**Known residual (lower severity, pre-existing, NOT worsened here):** a withdraw landing in the *middle* of an in-flight `approveRequest` (the dev withdraws at the exact instant a mod approves) can still leave an approved/withdrawn split. That direction is **mod-initiated**, not the scriptable dev-self-service direction closed above. Tracked as a follow-up to harden `approveRequest` symmetrically — out of scope for this PR.

### S2 / N1 — typed errors instead of substring-matching free text
`withdrawRequest` now throws a discriminated `WithdrawRequestError` carrying a stable `.code` (`NOT_FOUND | NOT_OWNED | NOT_PENDING`); the handler **switches on `.code`**, not on `message.includes(...)`. The old substring map silently re-introduced the ownership oracle on any service-side reword. The `withdrawPublishRequest` tRPC procedure still catches + rethrows as `BAD_REQUEST` with `.message` preserved — unchanged.

### N3 — error body shape
The **409** now returns `{ message }` (was `{ error }`). The endpoint now **always** returns `{ message }` on error — the contract the CLI reads. (Supersedes the `409 { error }` row in the table above → it is now `409 { message }`.)

### Tests / gates (re-run)
- Handler suite + the **real-service** orchestration suite both green: **101/101** (`withdraw.test.ts` 21 + `publish-request.orchestration.test.ts` 80). The orchestration suite now drives the REAL `withdrawRequest` (db client mocked) proving the typed codes + the status-guarded `updateMany` race paths (`count:0` + primary re-read → `approved`/`withdrawn`).
- Changed files typecheck clean — no net-new `tsc` errors (remaining errors are pre-existing elsewhere: ambient globals + `BigInt` literal target-mismatch in unrelated tests).
