### PR TITLE
fix(blocks): harden withdrawRequest against TOCTOU + typed errors (audit follow-up to #2774)

### DIFF
--- a/src/pages/api/v1/blocks/withdraw.ts
+++ b/src/pages/api/v1/blocks/withdraw.ts
@@ -6,7 +6,7 @@ import * as z from 'zod';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
-import { withdrawRequest } from '~/server/services/blocks/publish-request.service';
+import { withdrawRequest, WithdrawRequestError } from '~/server/services/blocks/publish-request.service';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { Flags } from '~/shared/utils/flags';
 
@@ -201,31 +201,39 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
 
   // 6. SELF-SCOPED mutation. `withdrawRequest` enforces ownership internally
   // (compares the row's `submittedByUserId` to `user.id`) and is idempotent on
-  // an already-withdrawn row. We map its outcomes onto HTTP WITHOUT an ownership
-  // oracle:
-  //   - success (incl. idempotent already-withdrawn) → 200 { ok: true }
-  //   - not-found OR not-owned → 404 (SAME body for both — never reveal that a
-  //     row exists but belongs to another user)
-  //   - non-pending (approved/rejected) → 409 (Conflict). This branch is only
-  //     reachable AFTER the service's ownership check passes, so the row is
-  //     provably the CALLER'S own — disclosing its status to its owner is safe.
+  // an already-withdrawn row. It throws a TYPED `WithdrawRequestError` carrying
+  // a stable `.code` — we switch on the CODE, never on the free-text message, so
+  // a service-side reword can't silently re-introduce the ownership oracle.
+  // Mapping (the response body is ALWAYS `{ message }` on error):
+  //   - success (incl. idempotent already-withdrawn / lost-race-into-withdrawn)
+  //     → 200 { ok: true }
+  //   - NOT_FOUND OR NOT_OWNED → 404 with the IDENTICAL body — never reveal that
+  //     a row exists but belongs to another user (no ownership oracle).
+  //   - NOT_PENDING (approved/rejected) → 409 (Conflict). Only reachable AFTER
+  //     the service's ownership check passes, so the row is provably the
+  //     CALLER'S own — disclosing its status to its owner is safe.
   try {
     await withdrawRequest({ publishRequestId, userId: user.id });
     res.status(200).json({ ok: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    // Ownership / existence collapse to one indistinguishable 404 (no oracle).
-    if (message.includes('not found') || message.includes('you can only withdraw your own')) {
-      res.status(404).json({ message: 'Publish request not found' });
-      return;
-    }
-    // The caller owns this row (ownership check already passed inside the
-    // service) but it's no longer pending — disclose the conflict to its owner.
-    if (message.includes('cannot withdraw a request in status')) {
-      res.status(409).json({ error: message });
-      return;
+    if (err instanceof WithdrawRequestError) {
+      switch (err.code) {
+        // Ownership / existence collapse to one indistinguishable 404 (no
+        // oracle) — SAME status AND SAME body for both.
+        case 'NOT_FOUND':
+        case 'NOT_OWNED':
+          res.status(404).json({ message: 'Publish request not found' });
+          return;
+        // The caller owns this row but it's no longer pending — disclose the
+        // conflict to its owner. `{ message }` (not `{ error }`) so the endpoint
+        // ALWAYS returns `{ message }` on error.
+        case 'NOT_PENDING':
+          res.status(409).json({ message: err.message });
+          return;
+      }
     }
     // Unexpected — log + 500, like submissions' catch-all.
+    const message = err instanceof Error ? err.message : String(err);
     req.log?.error('blocks/withdraw: unexpected error', { message, userId: user.id });
     res.status(500).json({ message: 'Internal server error' });
   }

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -56,7 +56,15 @@ const {
       // `updateMany` added (no-trust-on-push fix): approveRequest now supersedes
       // any stray pending review request the git-push webhook may have parked for
       // the slug while racing the approve commit.
-      appBlockPublishRequest: { create: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
+      // `findUnique` added (S1 TOCTOU fix): withdrawRequest re-reads the row from
+      // the PRIMARY when its status-guarded updateMany matches 0 rows, to resolve
+      // a lost race without being fooled by replica lag.
+      appBlockPublishRequest: {
+        create: vi.fn(),
+        update: vi.fn(),
+        updateMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
       appBlock: { create: vi.fn(), update: vi.fn() },
       // `update` added 2026-06-02 (audit A1 fix): approveRequest now re-caps
       // the app-block OauthClient's allowedScopes to the manifest-derived
@@ -584,21 +592,27 @@ describe('submitVersion', () => {
 // ---- withdrawRequest -------------------------------------------------------
 
 describe('withdrawRequest', () => {
-  it('moves pending → withdrawn for the owner', async () => {
+  it('moves pending → withdrawn for the owner via a status-guarded updateMany', async () => {
     const { withdrawRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
       id: 'pubreq_x',
       status: 'pending',
       submittedByUserId: 42,
     });
+    // Guarded write matched the still-pending row.
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
     await withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 });
-    expect(mockDbWrite.appBlockPublishRequest.update).toHaveBeenCalledWith({
-      where: { id: 'pubreq_x' },
+    // S1 fix: the write is keyed on { id, status: 'pending' }, NOT id alone, so
+    // a concurrent approve that flipped status can't be clobbered.
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith({
+      where: { id: 'pubreq_x', status: 'pending' },
       data: { status: 'withdrawn' },
     });
+    // The unconditional single-row update path must be gone.
+    expect(mockDbWrite.appBlockPublishRequest.update).not.toHaveBeenCalled();
   });
 
-  it('is idempotent on already-withdrawn', async () => {
+  it('is idempotent on already-withdrawn (no write at all)', async () => {
     const { withdrawRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
       id: 'pubreq_x',
@@ -606,51 +620,118 @@ describe('withdrawRequest', () => {
       submittedByUserId: 42,
     });
     await withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 });
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
     expect(mockDbWrite.appBlockPublishRequest.update).not.toHaveBeenCalled();
   });
 
-  it('throws for a request owned by a different user', async () => {
-    const { withdrawRequest } = await import('../publish-request.service');
+  it('throws NOT_OWNED for a request owned by a different user', async () => {
+    const { withdrawRequest, WithdrawRequestError } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
       id: 'pubreq_x',
       status: 'pending',
       submittedByUserId: 1,
     });
-    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
-      /can only withdraw your own/
-    );
+    await expect(
+      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
+    ).rejects.toMatchObject({
+      code: 'NOT_OWNED',
+      message: expect.stringMatching(/can only withdraw your own/),
+    });
+    // No write is attempted on a not-owned row.
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
+    // The thrown value is the typed class.
+    await expect(
+      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
+    ).rejects.toBeInstanceOf(WithdrawRequestError);
   });
 
-  it('throws for already-approved', async () => {
+  it('throws NOT_PENDING for already-approved', async () => {
     const { withdrawRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
       id: 'pubreq_x',
       status: 'approved',
       submittedByUserId: 42,
     });
-    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
-      /cannot withdraw a request in status approved/
-    );
+    await expect(
+      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
+    ).rejects.toMatchObject({
+      code: 'NOT_PENDING',
+      message: expect.stringMatching(/cannot withdraw a request in status approved/),
+    });
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
   });
 
-  it('throws for already-rejected', async () => {
+  it('throws NOT_PENDING for already-rejected', async () => {
     const { withdrawRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
       id: 'pubreq_x',
       status: 'rejected',
       submittedByUserId: 42,
     });
-    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
-      /cannot withdraw a request in status rejected/
-    );
+    await expect(
+      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
+    ).rejects.toMatchObject({
+      code: 'NOT_PENDING',
+      message: expect.stringMatching(/cannot withdraw a request in status rejected/),
+    });
   });
 
-  it('throws when the request is not found', async () => {
+  it('throws NOT_FOUND when the request is not found', async () => {
     const { withdrawRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
-    await expect(withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })).rejects.toThrow(
-      /not found/
-    );
+    await expect(
+      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND', message: expect.stringMatching(/not found/) });
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
+  });
+
+  // S1 (TOCTOU) — findUnique classified `pending`, but the guarded updateMany
+  // matched 0 rows because a concurrent approveRequest flipped status between
+  // the read and the write. A re-read showing `approved` MUST surface as
+  // NOT_PENDING (the row is NOT clobbered approved→withdrawn).
+  it('S1: lost the race to a concurrent approve → updateMany count:0, primary re-read approved → NOT_PENDING', async () => {
+    const { withdrawRequest } = await import('../publish-request.service');
+    // Classify read (replica): still pending. Re-read (PRIMARY): approved.
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_x',
+      status: 'pending',
+      submittedByUserId: 42,
+    });
+    mockDbWrite.appBlockPublishRequest.findUnique.mockResolvedValue({ status: 'approved' });
+    // Guarded write matched 0 rows (the row is no longer pending).
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
+    ).rejects.toMatchObject({
+      code: 'NOT_PENDING',
+      message: expect.stringMatching(/cannot withdraw a request in status approved/),
+    });
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith({
+      where: { id: 'pubreq_x', status: 'pending' },
+      data: { status: 'withdrawn' },
+    });
+    // The race is resolved against the PRIMARY, not the (lag-prone) replica.
+    expect(mockDbWrite.appBlockPublishRequest.findUnique).toHaveBeenCalledWith({
+      where: { id: 'pubreq_x' },
+      select: { status: true },
+    });
+  });
+
+  // S1 idempotency under the race — if the row raced into `withdrawn` (a
+  // concurrent withdraw won), count:0 + a re-read of `withdrawn` resolves as
+  // idempotent SUCCESS, no throw.
+  it('S1: lost the race to a concurrent withdraw → updateMany count:0, primary re-read withdrawn → idempotent success', async () => {
+    const { withdrawRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_x',
+      status: 'pending',
+      submittedByUserId: 42,
+    });
+    mockDbWrite.appBlockPublishRequest.findUnique.mockResolvedValue({ status: 'withdrawn' });
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 })
+    ).resolves.toBeUndefined();
   });
 
   // H-2 regression — withdraw does NOT delete the S3 bundle. Long-tail
@@ -662,6 +743,7 @@ describe('withdrawRequest', () => {
       status: 'pending',
       submittedByUserId: 42,
     });
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
     await withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 });
     expect(mockS3Send).not.toHaveBeenCalled();
   });

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -940,9 +940,56 @@ export async function getMyPendingForSlug(opts: {
 }
 
 /**
+ * Stable, typed failure modes for {@link withdrawRequest}. Callers (the
+ * `POST /api/v1/blocks/withdraw` endpoint, the `withdrawPublishRequest` tRPC
+ * procedure) switch on `.code` rather than substring-matching the human
+ * `message` — so the HTTP/TRPC status mapping can't silently drift if a
+ * message string is reworded (a free-text `.includes('own')` map was an
+ * ownership-oracle footgun). The `message` is preserved verbatim for logs +
+ * the tRPC BAD_REQUEST passthrough.
+ *
+ *   - NOT_FOUND   — no such row.
+ *   - NOT_OWNED   — the row exists but belongs to another user (the endpoint
+ *                   collapses this to the SAME response as NOT_FOUND — never an
+ *                   ownership oracle).
+ *   - NOT_PENDING — the caller owns the row but it is no longer `pending`
+ *                   (approved / rejected), so it cannot be withdrawn.
+ */
+export type WithdrawRequestErrorCode = 'NOT_FOUND' | 'NOT_OWNED' | 'NOT_PENDING';
+
+export class WithdrawRequestError extends Error {
+  readonly code: WithdrawRequestErrorCode;
+  constructor(code: WithdrawRequestErrorCode, message: string) {
+    super(message);
+    this.name = 'WithdrawRequestError';
+    this.code = code;
+  }
+}
+
+/**
  * Dev-facing withdrawal of their own pending request. Idempotent
- * (re-withdrawing is a no-op if already withdrawn). Throws on attempting
- * to withdraw someone else's request.
+ * (re-withdrawing is a no-op if already withdrawn). Throws a typed
+ * {@link WithdrawRequestError} on a missing row, another user's row, or a
+ * non-`pending` row.
+ *
+ * CONCURRENCY (audit S1 — TOCTOU): the `findUnique` only CLASSIFIES the
+ * outcome; the actual mutation is a status-guarded `updateMany` keyed on
+ * `{ id, status: 'pending' }`, so a withdraw that read `pending` can no longer
+ * clobber a row a concurrent `approveRequest` flipped to `approved` between the
+ * read and the write (which would desync the live block from its request row
+ * and silently break the deploy state machine — `markRequestDeployState`
+ * filters on `status='approved'`). If the guarded write matches 0 rows despite
+ * the earlier pending classification, we re-read and resolve the race: now
+ * `withdrawn` → idempotent success; now `approved`/`rejected` → NOT_PENDING.
+ * This makes the "refuses to withdraw a non-pending request" guarantee TRUE
+ * under concurrency.
+ *
+ * NOTE: a withdraw landing in the MIDDLE of an in-flight `approveRequest` (the
+ * dev withdraws at the exact instant a mod approves) can still leave an
+ * approved/withdrawn split — that direction is mod-initiated, lower severity,
+ * pre-existing, and NOT worsened here; the dangerous scriptable
+ * (dev-self-service) direction is the one closed by the guard above. Tracked as
+ * a follow-up to harden `approveRequest` symmetrically.
  */
 export async function withdrawRequest(opts: {
   publishRequestId: string;
@@ -954,18 +1001,46 @@ export async function withdrawRequest(opts: {
     where: { id: publishRequestId },
     select: { id: true, status: true, submittedByUserId: true },
   });
-  if (!row) throw new Error(`publish request ${publishRequestId} not found`);
+  if (!row) {
+    throw new WithdrawRequestError('NOT_FOUND', `publish request ${publishRequestId} not found`);
+  }
   if (row.submittedByUserId !== userId) {
-    throw new Error('you can only withdraw your own publish requests');
+    throw new WithdrawRequestError('NOT_OWNED', 'you can only withdraw your own publish requests');
   }
   if (row.status === 'withdrawn') return;
   if (row.status !== 'pending') {
-    throw new Error(`cannot withdraw a request in status ${row.status}`);
+    throw new WithdrawRequestError(
+      'NOT_PENDING',
+      `cannot withdraw a request in status ${row.status}`
+    );
   }
-  await dbWrite.appBlockPublishRequest.update({
-    where: { id: publishRequestId },
+
+  // Status-guarded write: only flip a STILL-`pending` row. This is the atomic
+  // step that closes the TOCTOU window against a concurrent approve.
+  const { count } = await dbWrite.appBlockPublishRequest.updateMany({
+    where: { id: publishRequestId, status: 'pending' },
     data: { status: 'withdrawn' },
   });
+  if (count === 0) {
+    // The row changed under us between the classify-read and the guarded write
+    // (lost the race). Re-read from the PRIMARY (`dbWrite`) — a replica read
+    // could be lag-stale and still report `pending`, which would mis-resolve
+    // the race — and decide the authoritative outcome.
+    const after = await dbWrite.appBlockPublishRequest.findUnique({
+      where: { id: publishRequestId },
+      select: { status: true },
+    });
+    if (!after || after.status === 'withdrawn') {
+      // Raced into withdrawn (or vanished) → idempotent success, no throw.
+      return;
+    }
+    // Raced into approved/rejected → the not-pending guarantee, now true under
+    // concurrency.
+    throw new WithdrawRequestError(
+      'NOT_PENDING',
+      `cannot withdraw a request in status ${after.status}`
+    );
+  }
 }
 
 /**

--- a/src/tests/api/v1/blocks/withdraw.test.ts
+++ b/src/tests/api/v1/blocks/withdraw.test.ts
@@ -67,6 +67,7 @@ const {
   mockWithdrawRequest,
   mockSysRedis,
   mockMultiIncr,
+  WithdrawRequestError,
 } = vi.hoisted(() => {
   const mockMultiIncr = {
     value: 1,
@@ -83,6 +84,18 @@ const {
         : ['OK', mockMultiIncr.value];
     }),
   });
+  // A faithful stand-in for the service's typed error so the handler's
+  // `err instanceof WithdrawRequestError` + `.code` switch is exercised against
+  // the REAL discriminant (not a substring). Mirrors the service shape. Defined
+  // inside vi.hoisted so it exists when the (hoisted) vi.mock factory runs.
+  class WithdrawRequestError extends Error {
+    code: 'NOT_FOUND' | 'NOT_OWNED' | 'NOT_PENDING';
+    constructor(code: 'NOT_FOUND' | 'NOT_OWNED' | 'NOT_PENDING', message: string) {
+      super(message);
+      this.name = 'WithdrawRequestError';
+      this.code = code;
+    }
+  }
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
@@ -93,6 +106,7 @@ const {
       expire: vi.fn().mockResolvedValue(1),
     },
     mockMultiIncr,
+    WithdrawRequestError,
   };
 });
 
@@ -101,6 +115,7 @@ vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGe
 vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
 vi.mock('~/server/services/blocks/publish-request.service', () => ({
   withdrawRequest: mockWithdrawRequest,
+  WithdrawRequestError,
 }));
 vi.mock('~/server/redis/client', () => ({
   sysRedis: mockSysRedis,
@@ -259,39 +274,44 @@ describe('POST /api/v1/blocks/withdraw', () => {
     });
   });
 
-  it('404 when the publish request does not exist (no ownership oracle)', async () => {
-    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
-    mockWithdrawRequest.mockRejectedValueOnce(new Error('publish request pubreq_01 not found'));
-    const { req, res } = authPost();
-    await handler(req as never, res as never);
-    expect(res._getStatusCode()).toBe(404);
-    expect((res._getJSONData() as { message: string }).message).toBe('Publish request not found');
-  });
-
-  it('404 when the publish request is NOT OWNED — identical body to not-found (no oracle)', async () => {
+  it('404 when the publish request does not exist (NOT_FOUND code, no ownership oracle)', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     mockWithdrawRequest.mockRejectedValueOnce(
-      new Error('you can only withdraw your own publish requests')
+      new WithdrawRequestError('NOT_FOUND', 'publish request pubreq_01 not found')
     );
     const { req, res } = authPost();
     await handler(req as never, res as never);
-    // SAME status AND SAME body as the not-found case — a caller cannot tell
-    // "exists but someone else's" from "doesn't exist".
     expect(res._getStatusCode()).toBe(404);
     expect((res._getJSONData() as { message: string }).message).toBe('Publish request not found');
   });
 
-  it('409 when the request is not pending (already approved/rejected) — disclosed to owner', async () => {
+  it('404 when the publish request is NOT_OWNED — identical body to NOT_FOUND (no oracle)', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     mockWithdrawRequest.mockRejectedValueOnce(
-      new Error('cannot withdraw a request in status approved')
+      new WithdrawRequestError('NOT_OWNED', 'you can only withdraw your own publish requests')
+    );
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    // SAME status AND SAME body as the NOT_FOUND case — a caller cannot tell
+    // "exists but someone else's" from "doesn't exist". Mapped by CODE, not by
+    // substring-matching the service message.
+    expect(res._getStatusCode()).toBe(404);
+    expect((res._getJSONData() as { message: string }).message).toBe('Publish request not found');
+  });
+
+  it('409 { message } when the request is not pending (NOT_PENDING code) — disclosed to owner', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockWithdrawRequest.mockRejectedValueOnce(
+      new WithdrawRequestError('NOT_PENDING', 'cannot withdraw a request in status approved')
     );
     const { req, res } = authPost();
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(409);
-    expect((res._getJSONData() as { error: string }).error).toBe(
+    // N3 fix: the endpoint ALWAYS returns `{ message }` on error (was `{ error }`).
+    expect((res._getJSONData() as { message: string }).message).toBe(
       'cannot withdraw a request in status approved'
     );
+    expect((res._getJSONData() as Record<string, unknown>).error).toBeUndefined();
   });
 
   it('200 { ok: true } on the happy path + no-store header', async () => {


### PR DESCRIPTION
Follow-up to **#2774**, which merged the original (unhardened) endpoint commit before the audit fixes landed — so these never reached `main`. This re-applies them (cherry-pick of the stranded fix commit, clean onto current `main`, 101 tests green).

## What this fixes (from the pre-merge adversarial audit of #2774)
- **S1 — TOCTOU (the real one).** `withdrawRequest` did `findUnique` (status check) then `update({ where: { id } })` with **no `status` guard**. A withdraw that read `pending` could still fire its write AFTER a concurrent moderator `approveRequest` flipped the row to `approved` (+ created the Forgejo repo, triggered the Tekton build, set the `app_blocks` row live) — clobbering `approved`→`withdrawn` and silently breaking the deploy state machine (`markRequestDeployState` filters on `status='approved'`). The new bearer-key endpoint made this **scriptable** (30 withdraws/60s) and contradicted the endpoint's own "refuses non-pending" docstring. Fixed with a status-guarded `updateMany({ where: { id, status: 'pending' } })` + a primary (`dbWrite`) re-read on `count === 0` to resolve the lost-race outcome (now-withdrawn → idempotent success; now-approved/rejected → 409). The "refuses non-pending" guarantee is now true under concurrency.
- **S2 / N1 — typed errors.** The handler mapped outcomes via `message.includes('not found')` / `includes('you can only withdraw your own')` — coupling HTTP status to free-text service strings (drift silently re-introduces the ownership oracle). Replaced with a discriminated `WithdrawRequestError { code: 'NOT_FOUND' | 'NOT_OWNED' | 'NOT_PENDING' }`; handler switches on `.code`. NOT_FOUND and NOT_OWNED return an **identical 404 body** (no ownership oracle).
- **N3 — error body shape.** 409 now returns `{ message }` like every other error (was `{ error }`), making the endpoint's error contract uniform `{ message }` (the paired CLI `civitai app withdraw` reads `message`).
- **Tests** now drive the **real** `withdrawRequest` (mock only the db client) for not-owned→404, not-pending→409, and both lost-race branches — so the security properties are exercised against the real branch, not a mock.

## Known residual (tracked, not in scope here)
The symmetric approve-side race (a withdraw landing mid-approve) — mod-initiated, lower-severity, pre-existing, not worsened. Belongs with a future `approveRequest` final-transition guard.

Dark / mod-only pre-GA, same posture as #2774.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>