### PR TITLE
fix(orchestrator): don't retry whatIf cost-estimate 3× on a transient orchestrator failure (~93s → fast)

### DIFF
--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -90,7 +90,12 @@ import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { BuzzTypes } from '~/shared/constants/buzz.constants';
 import { getBaseModelSetType, WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
-import { cancelWorkflow, getWorkflow, submitWorkflow } from '~/server/services/orchestrator/workflows';
+import {
+  cancelWorkflow,
+  getWorkflow,
+  submitWorkflow,
+  WHATIF_SUBMIT_TIMEOUT_MS,
+} from '~/server/services/orchestrator/workflows';
 import {
   buildGenerationContext,
   createWorkflowStepsFromGraphInput,
@@ -2095,6 +2100,10 @@ export const blocksRouter = router({
         checkpointBaseModel: checkpoint.baseModel,
       });
       const step = await createBlockTextToImageStep({ input: generateInput, user, whatIf: true });
+      // estimateWorkflow is a side-effect-free COST ESTIMATE (whatif: true) — same
+      // class as the submitWorkflow cost preflight below and whatIfFromGraph. Bound
+      // it identically (single attempt, 45s timeout) so a transient orchestrator
+      // hiccup isn't 3x-retry-amplified to ~93s.
       const workflow = await submitWorkflow({
         token,
         body: {
@@ -2104,6 +2113,8 @@ export const blocksRouter = router({
           ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
         },
         query: { whatif: true },
+        maxAttempts: 1,
+        timeoutMs: WHATIF_SUBMIT_TIMEOUT_MS,
       });
       return { snapshot: snapshotFromWorkflow(workflow) };
     }),
@@ -2259,6 +2270,10 @@ export const blocksRouter = router({
         whatIf: true,
       });
       const tags = buildWorkflowTags(claims, resolved.baseModel);
+      // App Blocks whatIf is the same side-effect-free COST ESTIMATE as
+      // whatIfFromGraph — bound it identically (single attempt, 45s timeout) so a
+      // transient orchestrator hiccup surfaces ONCE rather than the default 3x
+      // retry amplifying one ~30s park to ~93s. Mirrors whatIfFromGraph's args.
       const whatIfResult = await submitWorkflow({
         token,
         body: {
@@ -2268,6 +2283,8 @@ export const blocksRouter = router({
           ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
         },
         query: { whatif: true },
+        maxAttempts: 1,
+        timeoutMs: WHATIF_SUBMIT_TIMEOUT_MS,
       });
       const cost = whatIfResult.cost?.total ?? 0;
       if (cost > claims.buzzBudget) {

--- a/src/server/services/orchestrator/__tests__/workflows.submit-retry.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.submit-retry.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// Mock ONLY the generated client + the orchestrator client factory + env so we can
+// drive `submitWorkflow` through its retry / error branches. The real
+// `~/server/utils/errorHandling` loads so the actual TRPCError mapping + the
+// `isUpstreamNetworkError` classification (TimeoutError → 503) are exercised.
+const { mockSubmitWorkflow, mockHandleError } = vi.hoisted(() => ({
+  mockSubmitWorkflow: vi.fn(),
+  mockHandleError: vi.fn(() => 'orchestrator error'),
+}));
+
+vi.mock('@civitai/client', () => ({
+  submitWorkflow: mockSubmitWorkflow,
+  handleError: mockHandleError,
+  // unused-by-these-tests named exports referenced at module load
+  addWorkflowTag: vi.fn(),
+  deleteWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  patchWorkflow: vi.fn(),
+  queryWorkflows: vi.fn(),
+  removeWorkflowTag: vi.fn(),
+  updateWorkflow: vi.fn(),
+}));
+
+vi.mock('~/server/services/orchestrator/client', () => ({
+  createOrchestratorClient: vi.fn(() => ({})),
+  internalOrchestratorClient: {},
+}));
+
+vi.mock('~/env/other', () => ({ isDev: false, isProd: true }));
+
+import { submitWorkflow } from '~/server/services/orchestrator/workflows';
+
+const baseBody = { steps: [] } as any;
+
+// A failing 5xx client result (no data, response status 500) — the retry-able shape.
+const fail5xx = () => ({ data: undefined, error: { errors: {} }, response: { status: 500 } });
+// A successful client result.
+const ok = () => ({ data: { id: 'wf-ok' }, response: { status: 200 } });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('submitWorkflow — whatIf path (maxAttempts: 1, no retry)', () => {
+  it('does NOT retry a 5xx — calls the client exactly once and surfaces the error fast', async () => {
+    mockSubmitWorkflow.mockResolvedValue(fail5xx());
+
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: baseBody,
+      query: { whatif: true },
+      maxAttempts: 1,
+    }).catch((e) => e);
+
+    // The crux: a transient orchestrator 5xx is surfaced after a SINGLE attempt, not
+    // amplified 3× (the ~93s prod symptom). A 500 status maps to INTERNAL_SERVER_ERROR.
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('INTERNAL_SERVER_ERROR');
+  });
+
+  it('does NOT retry a status-less network rejection — single attempt, mapped to 503', async () => {
+    // A bounded caller (maxAttempts set) remaps a recognized network throw to 503.
+    mockSubmitWorkflow.mockRejectedValue(new TypeError('fetch failed'));
+
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: baseBody,
+      query: { whatif: true },
+      maxAttempts: 1,
+    }).catch((e) => e);
+
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+  });
+});
+
+describe('submitWorkflow — write/generate path (no new options, UNCHANGED)', () => {
+  it('still retries up to 3× on a persistent 5xx', async () => {
+    mockSubmitWorkflow.mockResolvedValue(fail5xx());
+
+    const err = await submitWorkflow({ token: 'tok', body: baseBody }).catch((e) => e);
+
+    // Write path keeps its 3-attempt behavior (default maxAttempts=3).
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(3);
+    expect(err).toBeInstanceOf(TRPCError);
+  });
+
+  it('succeeds after a transient 5xx is retried (recovers on attempt 2)', async () => {
+    mockSubmitWorkflow.mockResolvedValueOnce(fail5xx()).mockResolvedValueOnce(ok());
+
+    const data = await submitWorkflow({ token: 'tok', body: baseBody });
+
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(2);
+    expect(data).toEqual({ id: 'wf-ok' });
+  });
+
+  it('a raw network throw propagates UNCHANGED (no 503 remap, no TRPCError) on the write path', async () => {
+    // Guard: without the new options, `boundedCaller` is false → the throw must
+    // bubble byte-identically to before (the retry wrapper re-throws the last error
+    // after exhausting attempts; no network→503 remap is applied here).
+    const networkThrow = new TypeError('fetch failed');
+    mockSubmitWorkflow.mockRejectedValue(networkThrow);
+
+    const err = await submitWorkflow({ token: 'tok', body: baseBody }).catch((e) => e);
+
+    // 3 attempts (the wrapper retries a thrown network error), then the raw error
+    // bubbles — NOT mapped to a TRPCError/503 the way a bounded caller would.
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(3);
+    expect(err).toBe(networkThrow);
+    expect(err).not.toBeInstanceOf(TRPCError);
+  });
+}, 20_000);
+
+describe('submitWorkflow — timeout budget (bounded caller)', () => {
+  it('maps a fired TimeoutError to SERVICE_UNAVAILABLE (503)', async () => {
+    // Simulate AbortSignal.timeout firing: the fetch rejects with a TimeoutError.
+    // `isUpstreamNetworkError` matches `name === 'TimeoutError'` → 503 remap because
+    // the caller provided timeoutMs/maxAttempts (boundedCaller=true).
+    const timeoutErr = Object.assign(new Error('The operation timed out.'), {
+      name: 'TimeoutError',
+    });
+    mockSubmitWorkflow.mockRejectedValue(timeoutErr);
+
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: baseBody,
+      query: { whatif: true },
+      maxAttempts: 1,
+      timeoutMs: 30_000,
+    }).catch((e) => e);
+
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).cause).toBe(timeoutErr);
+  });
+
+  it('threads an AbortSignal to the client only when timeoutMs is set', async () => {
+    mockSubmitWorkflow.mockResolvedValue(ok());
+
+    await submitWorkflow({ token: 'tok', body: baseBody, query: { whatif: true }, timeoutMs: 5_000 });
+    expect(mockSubmitWorkflow.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+
+    mockSubmitWorkflow.mockClear();
+
+    // Write path: no timeoutMs → no signal threaded (behaviorally identical).
+    await submitWorkflow({ token: 'tok', body: baseBody });
+    expect(mockSubmitWorkflow.mock.calls[0][0].signal).toBeUndefined();
+  });
+});

--- a/src/server/services/orchestrator/__tests__/workflows.submit-retry.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.submit-retry.test.ts
@@ -30,7 +30,7 @@ vi.mock('~/server/services/orchestrator/client', () => ({
 
 vi.mock('~/env/other', () => ({ isDev: false, isProd: true }));
 
-import { submitWorkflow } from '~/server/services/orchestrator/workflows';
+import { submitWorkflow, WHATIF_SUBMIT_TIMEOUT_MS } from '~/server/services/orchestrator/workflows';
 
 const baseBody = { steps: [] } as any;
 
@@ -137,6 +137,33 @@ describe('submitWorkflow — timeout budget (bounded caller)', () => {
     expect(err).toBeInstanceOf(TRPCError);
     expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
     expect((err as TRPCError).cause).toBe(timeoutErr);
+  });
+
+  it('the shared whatIf timeout constant is 45s (above the legit slow-but-ok 30-40s cluster)', () => {
+    // Sizing is load-bearing: 30s would wrongly 503 the slow-but-successful whatIf
+    // cluster; 45s clears it while still catching the ~93s hang. If this changes,
+    // re-check the live duration distribution before lowering it.
+    expect(WHATIF_SUBMIT_TIMEOUT_MS).toBe(45_000);
+  });
+
+  it('a whatIf bounded with the shared constant + maxAttempts:1 makes exactly ONE attempt', async () => {
+    // Guards the App Blocks whatIf call sites (blocks.router estimateWorkflow +
+    // submitWorkflow cost preflight) and whatIfFromGraph: they all pass
+    // { maxAttempts: 1, timeoutMs: WHATIF_SUBMIT_TIMEOUT_MS }, so a transient 5xx
+    // is NOT 3x-retry-amplified to ~93s. Asserts the exact args those sites thread.
+    mockSubmitWorkflow.mockResolvedValue(fail5xx());
+
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: baseBody,
+      query: { whatif: true },
+      maxAttempts: 1,
+      timeoutMs: WHATIF_SUBMIT_TIMEOUT_MS,
+    }).catch((e) => e);
+
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockSubmitWorkflow.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+    expect(err).toBeInstanceOf(TRPCError);
   });
 
   it('threads an AbortSignal to the client only when timeoutMs is set', async () => {

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -1508,7 +1508,19 @@ export async function whatIfFromGraph({
     user: userId ? { id: userId, isModerator } : undefined,
   });
 
-  // Submit what-if request to orchestrator
+  // Submit what-if request to orchestrator.
+  //
+  // whatIf is a side-effect-free COST ESTIMATE — it creates nothing. So unlike the
+  // generate/submit WRITE path (which keeps the default 3 retries to recover a
+  // transient 5xx that may have actually created the workflow), an estimate must NOT
+  // retry a transient orchestrator failure:
+  //   - `maxAttempts: 1` — surface a transient failure ONCE, fast. Prod showed the
+  //     orchestrator hanging ~30s on an img2img source-image step, returning 5xx;
+  //     the default 3-retry path turned that one hiccup into ~93s (3 × ~30s + backoff)
+  //     before failing with INTERNAL_SERVER_ERROR. There is nothing to recover here.
+  //   - `timeoutMs: 30_000` — a generous backstop so even the single attempt can't
+  //     hang indefinitely; a fired timeout maps to a retry-able 503 (the orchestrator
+  //     root-cause fix is handled separately, so whatIf should normally be fast).
   const workflow = await submitWorkflow({
     token,
     body: {
@@ -1520,6 +1532,8 @@ export async function whatIfFromGraph({
     query: {
       whatif: true,
     },
+    maxAttempts: 1,
+    timeoutMs: 30_000,
   });
 
   // Check if all jobs are ready (have available support)

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -57,6 +57,7 @@ import {
   getWorkflow,
   submitWorkflow,
   updateWorkflow as clientUpdateWorkflow,
+  WHATIF_SUBMIT_TIMEOUT_MS,
 } from '~/server/services/orchestrator/workflows';
 import type { WorkflowUpdateSchema } from '~/server/schema/orchestrator/workflows.schema';
 import { mapDataToGraphInput } from './legacy-metadata-mapper';
@@ -1518,9 +1519,10 @@ export async function whatIfFromGraph({
   //     orchestrator hanging ~30s on an img2img source-image step, returning 5xx;
   //     the default 3-retry path turned that one hiccup into ~93s (3 × ~30s + backoff)
   //     before failing with INTERNAL_SERVER_ERROR. There is nothing to recover here.
-  //   - `timeoutMs: 30_000` — a generous backstop so even the single attempt can't
-  //     hang indefinitely; a fired timeout maps to a retry-able 503 (the orchestrator
-  //     root-cause fix is handled separately, so whatIf should normally be fast).
+  //   - `timeoutMs` (WHATIF_SUBMIT_TIMEOUT_MS, 45s) — a generous backstop so even the
+  //     single attempt can't hang indefinitely; a fired timeout maps to a retry-able
+  //     503. 45s (not 30s) clears the legitimate slow-but-ok 30-40s whatIf cluster so
+  //     those don't wrongly 503 while still catching the ~93s hang (see the constant).
   const workflow = await submitWorkflow({
     token,
     body: {
@@ -1533,7 +1535,7 @@ export async function whatIfFromGraph({
       whatif: true,
     },
     maxAttempts: 1,
-    timeoutMs: 30_000,
+    timeoutMs: WHATIF_SUBMIT_TIMEOUT_MS,
   });
 
   // Check if all jobs are ready (have available support)

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -44,6 +44,15 @@ import {
 const ORCHESTRATOR_UNAVAILABLE_MESSAGE =
   'Generation services are temporarily unavailable. Please try again.';
 
+// Per-attempt timeout for a side-effect-free whatIf COST ESTIMATE submit.
+// Sized 45s (not 30s) off the live duration distribution: there is a legitimate
+// slow-but-successful cluster at 30-40s (~81 ok calls/12h observed sizing #2770),
+// which a 30s budget would wrongly 503; 45s sits above that cluster (only ~15/12h
+// are >=45s, already broken-feeling) while still backstopping a true hang (the
+// failure mode this bounds was ~93s). Shared by every whatIf submit caller so the
+// budget is one place. NOT for real submits — those keep the unbounded default.
+export const WHATIF_SUBMIT_TIMEOUT_MS = 45_000;
+
 export async function queryWorkflows({
   token,
   fromDate,

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -164,9 +164,39 @@ export async function submitWorkflow({
   token,
   body,
   query,
-}: Options<SubmitWorkflowData> & { token: string }) {
+  maxAttempts,
+  timeoutMs,
+}: Options<SubmitWorkflowData> & {
+  token: string;
+  /**
+   * Max total submit attempts (initial + retries), forwarded to
+   * {@link submitWorkflowWithRetry}. OMIT for the default of 3 — the generate/submit
+   * WRITE path MUST keep its 3-retry behavior so a transient 5xx that the orchestrator
+   * may have actually acted on still gets re-submitted (idempotent via `externalId`).
+   *
+   * Pass `maxAttempts: 1` ONLY for a side-effect-free caller (e.g. `whatIfFromGraph`,
+   * a pure COST ESTIMATE): retrying a transient orchestrator failure there amplifies a
+   * single ~30s upstream hiccup into ~93s (3 × 30s + backoff) before surfacing a 500.
+   * Surfacing it once, fast, is correct for an estimate that creates nothing.
+   */
+  maxAttempts?: number;
+  /**
+   * Optional overall per-attempt timeout budget (ms) for a side-effect-free caller.
+   * When set, an `AbortSignal.timeout(timeoutMs)` bounds a single client attempt so it
+   * can't hang 30s+. A fired `TimeoutError` is classified by `isUpstreamNetworkError`
+   * and (when this option — or `maxAttempts` — is provided) remapped to a retry-able
+   * 503 instead of a raw 500, mirroring the `queryWorkflows`/`getWorkflow` catch. OMIT
+   * on the WRITE path so its behavior stays byte-identical (no signal, no 503-remap).
+   */
+  timeoutMs?: number;
+}) {
   const client = createOrchestratorClient(token);
   if (!body) throw throwBadRequestError();
+
+  // Whether the caller opted into the bounded/no-retry behavior. When false, the
+  // write path below is behaviorally IDENTICAL to before (no signal threaded, no
+  // network-error → 503 remap) — only the explicit estimate callers get the new path.
+  const boundedCaller = maxAttempts !== undefined || timeoutMs !== undefined;
 
   // const steps = body.steps;
   // if (steps.length > 0) {
@@ -185,10 +215,29 @@ export async function submitWorkflow({
     console.log('------');
   }
 
-  const result = await submitWorkflowWithRetry({
-    client,
-    body: { ...body, tags: ['civitai', ...(body.tags ?? [])] },
-    query,
+  const result = await submitWorkflowWithRetry(
+    {
+      client,
+      body: { ...body, tags: ['civitai', ...(body.tags ?? [])] },
+      query,
+      // Bound a single attempt for estimate callers so even one attempt can't hang
+      // 30s+. Left undefined on the write path → no AbortSignal → identical behavior.
+      ...(timeoutMs !== undefined ? { signal: AbortSignal.timeout(timeoutMs) } : {}),
+    },
+    // `maxAttempts: undefined` falls back to the wrapper's default (3), so the write
+    // path is unchanged; estimate callers pass `1` to skip retries.
+    { maxAttempts }
+  ).catch((thrown) => {
+    // Only the bounded (estimate) callers get the network/timeout → 503 remap. A fired
+    // `AbortSignal.timeout` rejects with a `TimeoutError`, which `isUpstreamNetworkError`
+    // recognizes — surface it as a retry-able 503 (mirrors queryWorkflows/getWorkflow)
+    // instead of letting tRPC flatten the raw throw to a 500. The write path never
+    // reaches here for a network error in a way that changes its prior behavior: it
+    // passes no signal (so no TimeoutError) and `boundedCaller` is false, so any throw
+    // re-bubbles exactly as before.
+    if (boundedCaller && isUpstreamNetworkError(thrown))
+      throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, thrown);
+    throw thrown;
   });
 
   // Narrow on `result.data` (not a destructured copy) so this always-throwing


### PR DESCRIPTION
## Problem — `orchestrator.whatIfFromGraph` parks ~93s then 500s on img2img inputs

`whatIfFromGraph` is a **side-effect-free cost estimate** (it creates nothing), but it funnels through `submitWorkflow` → `submitWorkflowWithRetry`, which defaults to **`maxAttempts=3`** (with +500ms / +1500ms backoff).

Confirmed in prod: for img2img inputs the orchestrator **hangs ~30s on a source-image step** and returns a 5xx. The 3-retry path then amplifies that single ~30s hiccup into **~93s** (3 × ~30s + backoff) before finally surfacing `INTERNAL_SERVER_ERROR`. Retrying a *cost estimate* on a transient orchestrator failure is wrong — there is nothing to recover, and it turns a brief upstream blip into a long park + a 500.

## Fix — civitai-side mitigation (orchestrator root cause handled separately)

The orchestrator source-image-hang root cause is being fixed separately. This PR is the **civitai-side belt**: don't retry a cost estimate, and bound a single attempt.

`src/server/services/orchestrator/workflows.ts` — `submitWorkflow` gains two **optional** params:

- **`maxAttempts?`** — threaded into `submitWorkflowWithRetry(options, { maxAttempts })`. **Omitted ⇒ unchanged** (the wrapper's default of 3). The generate/submit **WRITE path keeps its 3-retry behavior** (a transient 5xx the orchestrator may have actually acted on still gets re-submitted; idempotent via `externalId`).
- **`timeoutMs?`** — bounds a single attempt with `AbortSignal.timeout(ms)` (passed via the client `signal`). A fired `TimeoutError` is already classified by `isUpstreamNetworkError` (`name === 'TimeoutError'`/`'AbortError'`) and is remapped to a retry-able **503**, mirroring the existing `queryWorkflows`/`getWorkflow` catch in the same file.

The signal threading **and** the network/timeout → 503 remap apply **only when these options are provided** (`boundedCaller`). When they're absent the write path is **behaviorally byte-identical** to before — no signal, no remap, raw throws bubble exactly as they did.

`src/server/services/orchestrator/orchestration-new.service.ts` — `whatIfFromGraph`'s `submitWorkflow({ query: { whatif: true } })` call now passes:
- `maxAttempts: 1` — surface a transient orchestrator failure **once, fast** (no 3× amplification).
- `timeoutMs: 30_000` — generous backstop so even the single attempt can't hang 30s+ (with the orchestrator fix, whatIf should normally be fast).

`generateFromGraph`'s `submitWorkflow` call is **untouched** — the real submit keeps 3 retries.

## Tests

New `src/server/services/orchestrator/__tests__/workflows.submit-retry.test.ts` (matches the `workflows.error-mapping.test.ts` style — mocks `@civitai/client`, drives failures by making the mock throw/return 5xx, no real-timer-dependent simulation):

- **whatIf path (`maxAttempts: 1`)**: on a 5xx the client mock is called **exactly once** (no retry) and the error surfaces fast (500); a status-less network rejection is mapped to 503.
- **write/generate path (no new options — UNCHANGED guard)**: still retries **up to 3×** on a persistent 5xx, recovers if attempt 2 succeeds, and a raw network throw **propagates unchanged** (no 503 remap, not a `TRPCError`).
- **timeout budget**: a fired `TimeoutError` maps to **`SERVICE_UNAVAILABLE` (503)**; an `AbortSignal` is threaded to the client only when `timeoutMs` is set (and not on the write path).

All 7 new tests pass locally; the existing `workflows.error-mapping.test.ts` (11 tests) still passes (regression check). Full-repo `tsc` could not complete locally (OOM — known on this host); CI runs typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
