### PR TITLE
feat(blocks): dev-token local-manifest mode for a caller's own pending app

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -9,6 +9,7 @@ import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { BlockTokenService } from '~/server/services/block-token.service';
 import {
+  APP_BLOCK_OAUTH_CLIENT_ID_PREFIX,
   isKnownBlockScope,
   validateBlockScopesAgainstOauthClient,
 } from '~/shared/constants/block-scope.constants';
@@ -35,12 +36,50 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  * protocol to real endpoints) is the larger half and is EXPLICITLY OUT OF SCOPE
  * — documented follow-up (scope doc §5.2, Phase 2).
  *
- * ## "Existing-app" mode (the ONLY mode shipped here — scope doc §3.3)
- * The dev names an app they OWN (by `appBlockId` or `slug`). Scopes/budget are
- * pinned to that APPROVED `AppBlock` row + its app's OAuth ceiling, so the blast
- * radius ≈ prod and there is no escalation via an un-reviewed local manifest.
- * The "local-manifest" mode (no approved row) is the higher-risk Phase 4 work
- * and is NOT implemented.
+ * ## Two resolution modes (scope doc §3.3, §4, Phase 4)
+ *
+ * 1. "Existing-app" mode — the dev names an app they OWN (by `appBlockId` or
+ *    `slug`) that has an APPROVED `AppBlock` row. Scopes/budget are pinned to
+ *    that approved snapshot + its app's OAuth ceiling, so the blast radius ≈
+ *    prod and there is no escalation via an un-reviewed local manifest.
+ *
+ * 2. "Local-manifest" mode (NOW IMPLEMENTED — the documented Phase 4 work) —
+ *    reached ONLY when no owned APPROVED row exists AND the caller passed a
+ *    `slug` that matches a `AppBlockPublishRequest` with `status='pending'`
+ *    that THEY submitted (`submittedByUserId === user.id`). This unblocks the
+ *    `dev:live` real-Buzz path for a BRAND-NEW (pending) app — before today
+ *    that 404'd because the mint required an approved row. The scope SOURCE is
+ *    the pending request's UN-REVIEWED `manifest.scopes` (developer-controlled,
+ *    NOT moderator-approved) — the §4 R1 escalation surface — so it is clamped
+ *    by the IDENTICAL belt as the approved path WITH ONE SUBSTITUTION:
+ *      - a pending app has NO OauthClient → there is no OAuth-bitmask ceiling
+ *        (step 7c). Passing `oauthAllowed: 0` into
+ *        validateBlockScopesAgainstOauthClient would WRONGLY STRIP every
+ *        non-SKIP_OAUTH_CHECK scope (`(0 & bit) !== bit`), so the step is simply
+ *        OMITTED for the pending path. The CORRECT substitute ceiling is the
+ *        dev's OWN credential, ALREADY enforced at step 7f (the
+ *        bearer-credential spend ceiling: `ai:write:budgeted` survives only if
+ *        the bearer carries `AIServicesWrite`). 7f is the authoritative spend
+ *        gate here. Every OTHER clamp (isKnownBlockScope, DEV_TOKEN_SCOPE_-
+ *        ALLOWLIST, PAGE_FORBIDDEN_SCOPES, body-narrowing, force-grant
+ *        `user:read:self`) and EVERY hard cap (DEV_BUZZ_BUDGET_CAP, forced SFW,
+ *        self-bound `sub`, short TTL, rate limit, mod-only pre-GA) is applied
+ *        IDENTICALLY — the pending path relaxes NOTHING.
+ *
+ *    Residual risk (honest): the manifest is un-reviewed, so a developer could
+ *    declare any scope. But each declared scope is bounded by ≤ the dev's own
+ *    credential authority (7f for spend), ⊆ DEV_TOKEN_SCOPE_ALLOWLIST, and minus
+ *    PAGE_FORBIDDEN_SCOPES; spend is the dev's OWN budget-capped Buzz against the
+ *    untouched per-user daily cap; the runtime spend belt still asserts
+ *    moderator pre-GA. The R1-escalation test proves an escalated manifest scope
+ *    (`social:tip:self`, `block:settings:write`, an unknown/mature scope) is
+ *    STRIPPED, never minted.
+ *
+ *    OWNERSHIP / NO-ORACLE: only the `slug` input can reach the pending path
+ *    (pending apps have no `appBlockId`); a row the caller doesn't own — or no
+ *    row at all — returns the SAME bare `404 { message: 'App not found' }` as
+ *    the approved path (never an existence/ownership/state oracle). Only a row
+ *    the caller demonstrably owns surfaces an actionable message.
  *
  * ## Auth — Bearer, resolved via the same `getSessionFromBearerToken` path the
  * `/api/v1/*` REST routes use. TWO credential shapes accepted:
@@ -70,10 +109,14 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  *    pre-GA mod posture. The runtime spend procedures already call
  *    `assertViewerIsModerator`, so a non-mod could mint but not spend; we keep
  *    mint mod-gated anyway. RELAX in lockstep with the runtime belt at GA.
- *  - SCOPE CLAMP: granted ⊆ the app's approved scopes ⊆ DEV_TOKEN_SCOPE_ALLOWLIST
- *    (EXCLUDES `social:tip:self` + `block:settings:*`) ⊆ the app's OAuth ceiling
- *    ⊆ requested (if the body narrows). Unknown / out-of-allowlist scopes are
- *    STRIPPED, never error.
+ *  - SCOPE CLAMP: granted ⊆ the scope source ⊆ DEV_TOKEN_SCOPE_ALLOWLIST
+ *    (EXCLUDES `social:tip:self` + `block:settings:*`) ⊆ [the app's OAuth
+ *    ceiling — approved path ONLY] ⊆ requested (if the body narrows), then the
+ *    bearer-credential spend ceiling (7f) gates `ai:write:budgeted`. The scope
+ *    SOURCE is the app's APPROVED snapshot (existing-app mode) OR the OWNED
+ *    pending request's un-reviewed `manifest.scopes` (local-manifest mode, where
+ *    the absent OAuth ceiling is replaced by 7f). Unknown / out-of-allowlist
+ *    scopes are STRIPPED, never error.
  *  - BUDGET CAP: a LOWER dev cap (DEV_BUZZ_BUDGET_CAP) than the prod 1000. The
  *    existing per-user daily cumulative cap (reserveBlockBuzzSpend) is untouched.
  *  - FORCED SFW: maxBrowsingLevel = domainBrowsingCeiling(null) UNCONDITIONALLY
@@ -291,11 +334,24 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     return;
   }
 
-  // 6. Resolve the APPROVED AppBlock the dev OWNS. Ownership = the app's
-  // OauthClient.userId (the AppBlock → app → user relation). We use dbWrite so a
-  // freshly-approved/suspended app can't slip through a replication-lag window.
-  // The lookup also fetches `app.userId` (owner) which resolvePageBlock doesn't
-  // expose, so we read the row directly here (we do NOT modify the prod path).
+  // 6. Resolve the block to mint for. TWO resolution paths (scope doc §3.3, §4,
+  // Phase 4). The result is a uniform `resolved` shape consumed by the shared
+  // clamp belt (step 7) so neither path can relax a cap:
+  //
+  //   - scopeSource:      the scopes to clamp DOWN from. Approved snapshot
+  //                       (existing-app) OR the OWNED pending request's
+  //                       un-reviewed manifest.scopes (local-manifest).
+  //   - oauthAllowed:     the OAuth-bitmask ceiling, or null to SKIP that clamp
+  //                       step (pending apps have no OauthClient — see 7c below).
+  //   - signBlockId/appId/appBlockId/blockInstanceId: the sign + revocation ids.
+  //
+  // Resolution order is APPROVED-FIRST so the safer (server-pinned) path always
+  // wins; the pending path is reached ONLY when no owned approved row exists.
+
+  // 6a. APPROVED path. Ownership = the app's OauthClient.userId (AppBlock → app →
+  // user). dbWrite so a freshly-approved/suspended app can't slip a replica-lag
+  // window. Lookup also reads `app.userId` (owner) which resolvePageBlock doesn't
+  // expose; we read the row directly here (we do NOT modify the prod path).
   const where = appBlockId ? { id: appBlockId } : { blockId: slug! };
   const block = await dbWrite.appBlock.findUnique({
     where: where as { id: string } | { blockId: string },
@@ -309,67 +365,151 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       app: { select: { allowedScopes: true, userId: true } },
     },
   });
-  // 404 (never leak which) for a row that doesn't exist or isn't owned by the
-  // caller. We check EXISTENCE+OWNERSHIP first (collapsed into one bare 404 so a
-  // non-owner can't probe which appBlockIds exist OR their approval state), and
-  // ONLY THEN — for a row the caller demonstrably owns — surface the actionable
-  // not-yet-live message. A non-owner therefore still gets the indistinguishable
-  // bare 404 regardless of the app's status (no probe oracle); approval-state
-  // detail is revealed exclusively to the confirmed owner.
-  if (!block || !block.app || block.app.userId !== user.id) {
+
+  // A `resolved` block (either path) carries everything the clamp + sign below
+  // need. `oauthAllowed: null` ⇒ skip the OAuth-ceiling clamp (no client exists).
+  type Resolved = {
+    scopeSource: string[];
+    oauthAllowed: number | null;
+    signBlockId: string;
+    signAppId: string;
+    signAppBlockId: string;
+    blockInstanceId: string;
+  };
+  let resolved: Resolved | null = null;
+
+  if (block && block.app && block.app.userId === user.id) {
+    // Owned approved row → existing-app mode. But an OWNED-yet-not-approved row
+    // (e.g. status: pending with an appBlockId already linked) is NOT live: the
+    // dev-token mint resolves a DEPLOYED instance. Surface the ACTIONABLE
+    // no-live-deployment message (owner-only) instead of the bare "App not found".
+    if (block.status !== 'approved') {
+      res.status(404).json({
+        message:
+          `block '${block.blockId}' has no live deployment — dev:live requires an ` +
+          `approved + deployed version (deployState: live). Until your first ` +
+          `version is live, validate locally with dev:harness (mock).`,
+      });
+      return;
+    }
+    // The app MUST declare a page block — dev-token mints PAGE tokens only (the
+    // live-local target is a page app; no model binding).
+    const manifest = (block.manifest ?? {}) as { page?: unknown };
+    if (typeof manifest.page !== 'object' || manifest.page === null) {
+      res
+        .status(422)
+        .json({ message: 'dev-token mints page tokens; this app declares no page block' });
+      return;
+    }
+    const approvedRaw: unknown[] = Array.isArray(block.approvedScopes)
+      ? block.approvedScopes
+      : [];
+    resolved = {
+      scopeSource: approvedRaw.filter((s): s is string => typeof s === 'string'),
+      oauthAllowed: block.app.allowedScopes ?? 0,
+      signBlockId: block.blockId,
+      signAppId: block.appId,
+      signAppBlockId: block.id,
+      // Synthetic, revocable PAGE instance id — same shape as the prod page mint.
+      blockInstanceId: `${PAGE_INSTANCE_PREFIX}${block.id}`,
+    };
+  } else if (slug) {
+    // 6b. LOCAL-MANIFEST path (Phase 4). Reached ONLY when no owned approved row
+    // exists AND the caller passed a `slug` (pending apps have NO appBlockId, so
+    // an `appBlockId`-only request can never reach here). Find the caller's OWN
+    // pending submission for this slug. dbWrite (no replica lag). OWNERSHIP is
+    // enforced in the query (`submittedByUserId === user.id`) so the row is, by
+    // construction, the caller's — we never read another user's pending row.
+    const pending = await dbWrite.appBlockPublishRequest.findFirst({
+      where: { slug, status: 'pending', submittedByUserId: user.id },
+      orderBy: { submittedAt: 'desc' },
+      select: { id: true, slug: true, manifest: true },
+    });
+    if (pending) {
+      // The un-reviewed manifest MUST declare a page block — same 422 as the
+      // approved path (dev-token mints page tokens only).
+      const manifest = (pending.manifest ?? {}) as { page?: unknown; scopes?: unknown };
+      if (typeof manifest.page !== 'object' || manifest.page === null) {
+        res
+          .status(422)
+          .json({ message: 'dev-token mints page tokens; this app declares no page block' });
+        return;
+      }
+      const manifestScopesRaw: unknown[] = Array.isArray(manifest.scopes) ? manifest.scopes : [];
+      resolved = {
+        // Scope SOURCE is the UN-REVIEWED manifest.scopes (§4 R1) — clamped by the
+        // IDENTICAL belt below (allowlist + page-forbidden + 7f spend ceiling).
+        scopeSource: manifestScopesRaw.filter((s): s is string => typeof s === 'string'),
+        // No OauthClient for a pending app → SKIP the OAuth-ceiling clamp. Passing
+        // 0 would WRONGLY strip every non-SKIP_OAUTH_CHECK scope (`(0 & bit) !== bit`);
+        // the correct substitute ceiling is the dev's OWN credential, enforced at
+        // step 7f (AIServicesWrite spend gate). 7f IS the spend gate here.
+        oauthAllowed: null,
+        signBlockId: pending.slug,
+        // No OauthClient id exists yet — use the deterministic id a pending app
+        // WOULD get on approve (`appblk-<slug>`, the App-Blocks client prefix).
+        // `appId` is a provenance/billing-attribution TAG only (no FK / no
+        // validation against a row — buildWorkflowTags blocks.router.ts:2978), so
+        // a stable, audit-meaningful placeholder is correct here.
+        signAppId: `${APP_BLOCK_OAUTH_CLIENT_ID_PREFIX}${pending.slug}`,
+        // No AppBlock.id exists — use the pending request id (stable, unique per
+        // submission). The JWT `appBlockId` claim is only string-validated by the
+        // middleware (block-scope.middleware.ts:394). NOTE: the best-effort
+        // BlockScopeInvocation audit-log write (a NOT-NULL FK → AppBlock.id) will
+        // FK-fail for this value and is silently swallowed (fire-and-forget,
+        // catch-all) — acceptable, documented residual; verification + revocation
+        // are unaffected.
+        signAppBlockId: pending.id,
+        // Stable, BlockRevocation-checkable synthetic instance id derived from the
+        // publish-request id (no AppBlock.id to key on).
+        blockInstanceId: `${PAGE_INSTANCE_PREFIX}pubreq_${pending.id}`,
+      };
+    }
+  }
+
+  // No owned approved AppBlock AND no owned pending request → the SAME bare 404
+  // as the approved path. We never reveal existence/ownership/state of a row the
+  // caller doesn't own (no probe oracle). Note an OWNED-but-not-approved row
+  // already returned its own actionable 404 above; an OWNED pending row resolved.
+  if (!resolved) {
     res.status(404).json({ message: 'App not found' });
     return;
   }
-  // Owned, but no LIVE deployment yet (the dev-token mint resolves a DEPLOYED
-  // block instance — deployState: live, i.e. an `approved` AppBlock row). A
-  // brand-new app — even right after a successful submit (status: pending) —
-  // legitimately exists and is owned here but has nothing live to mint against.
-  // Return an ACTIONABLE message instead of the misleading bare "App not found".
-  if (block.status !== 'approved') {
-    res.status(404).json({
-      message:
-        `block '${block.blockId}' has no live deployment — dev:live requires an ` +
-        `approved + deployed version (deployState: live). Until your first ` +
-        `version is live, validate locally with dev:harness (mock).`,
-    });
-    return;
-  }
 
-  // The app MUST declare a page block — dev-token mints PAGE tokens only (the
-  // live-local target is a page app; no model binding). A region/model-only app
-  // has no page surface to mint for.
-  const manifest = (block.manifest ?? {}) as { page?: unknown; scopes?: unknown };
-  if (typeof manifest.page !== 'object' || manifest.page === null) {
-    res.status(422).json({ message: 'dev-token mints page tokens; this app declares no page block' });
-    return;
-  }
-
-  // 7. SCOPE CLAMP. Start from the app's APPROVED snapshot (authoritative — the
-  // same pin the prod mint uses), then:
+  // 7. SCOPE CLAMP. Start from the resolved scope SOURCE — the app's APPROVED
+  // snapshot (existing-app) OR the OWNED pending request's un-reviewed
+  // manifest.scopes (local-manifest, §4 R1) — then apply the IDENTICAL belt:
   //   a) keep only KNOWN block scopes,
   //   b) keep only scopes within the DEV_TOKEN_SCOPE_ALLOWLIST (excludes
   //      social:tip:self + block:settings:*),
-  //   c) keep only scopes within the app's OAuth ceiling (allowedScopes),
+  //   c) keep only scopes within the app's OAuth ceiling (allowedScopes) — ONLY
+  //      for the approved path. The pending path has NO OauthClient
+  //      (`oauthAllowed === null`) → this step is OMITTED; 7f is the spend gate.
   //   d) drop the PAGE_FORBIDDEN money/spend scopes (the page hard rule),
   //   e) if the body requested a subset, intersect with it.
   // Every step is a STRIP (no error) so a partially-disallowed request still
-  // mints a usable, safely-clamped token.
-  const approvedRaw: unknown[] = Array.isArray(block.approvedScopes) ? block.approvedScopes : [];
-  const approved: string[] = approvedRaw.filter((s): s is string => typeof s === 'string');
-  const oauthAllowed: number = block.app.allowedScopes ?? 0;
+  // mints a usable, safely-clamped token. The clamp belt is byte-identical
+  // across both paths bar the OAuth-ceiling substitution — an un-reviewed
+  // manifest can never escalate past the allowlist, the page-forbidden set, or
+  // the dev's own credential (7f).
   const forbidden = new Set<string>(PAGE_FORBIDDEN_SCOPES);
 
-  let granted: string[] = approved
+  let granted: string[] = resolved.scopeSource
     .filter((s) => isKnownBlockScope(s))
     .filter((s) => DEV_TOKEN_SCOPE_ALLOWLIST.has(s))
     .filter((s) => !forbidden.has(s));
 
-  // OAuth-ceiling clamp — drop any scope the app's OauthClient bitmask doesn't
-  // allow. validateBlockScopesAgainstOauthClient treats SKIP_OAUTH_CHECK scopes
-  // (apps:storage:*) as always-allowed, so per-scope re-validation keeps those.
-  granted = granted.filter(
-    (s: string) => validateBlockScopesAgainstOauthClient([s], oauthAllowed).valid
-  );
+  // OAuth-ceiling clamp (approved path ONLY) — drop any scope the app's
+  // OauthClient bitmask doesn't allow. validateBlockScopesAgainstOauthClient
+  // treats SKIP_OAUTH_CHECK scopes (apps:storage:*) as always-allowed, so
+  // per-scope re-validation keeps those. SKIPPED when oauthAllowed is null (the
+  // pending path — no client; passing 0 would wrongly strip every non-skip scope).
+  if (resolved.oauthAllowed !== null) {
+    const ceiling = resolved.oauthAllowed;
+    granted = granted.filter(
+      (s: string) => validateBlockScopesAgainstOauthClient([s], ceiling).valid
+    );
+  }
 
   // Body narrowing — the dev may request a subset of the above.
   if (requestedScopes && requestedScopes.length > 0) {
@@ -435,10 +575,11 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     ? Math.min(requestedBudget ?? DEV_BUZZ_BUDGET_DEFAULT, DEV_BUZZ_BUDGET_CAP)
     : undefined;
 
-  // 9. Synthetic, revocable PAGE instance id — same shape as the prod page mint
-  // (`page_<appBlockId>`), so BlockRevocation per blockInstanceId works
-  // unchanged and the harness uses the identical token-handling.
-  const blockInstanceId = `${PAGE_INSTANCE_PREFIX}${block.id}`;
+  // 9. The synthetic, revocable PAGE instance id was resolved in step 6:
+  //    - approved path:  `page_<appBlockId>` (same shape as the prod page mint),
+  //    - pending path:   `page_pubreq_<publishRequestId>` (stable, unique).
+  // Both are BlockRevocation-checkable; the harness token-handling is identical.
+  const blockInstanceId = resolved.blockInstanceId;
 
   // 10. PAGE ctx (entity=none, no model binding) — byte-identical shape to the
   // prod page mint, so a dev page token can NEVER satisfy a model-bound check.
@@ -457,9 +598,9 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // read) — advisory only; the AUTHORITATIVE ceiling is maxBrowsingLevel.
   const result = await BlockTokenService.sign({
     userId: user.id,
-    blockId: block.blockId,
-    appId: block.appId,
-    appBlockId: block.id,
+    blockId: resolved.signBlockId,
+    appId: resolved.signAppId,
+    appBlockId: resolved.signAppBlockId,
     blockInstanceId,
     scopes: granted,
     ctx,

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -93,6 +93,16 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  *    on a non-zero `spendSharePct`, re-confirm no pending-path mint can ever land a
  *    real `OauthClient.id` in `appId`.
  *
+ *    PENDING-PATH AUDIT GATE (FIX 🟡-1): a pending-app dev mint has NO
+ *    AppBlock-backed audit rows — recordSpendAttribution throws+swallows on the
+ *    synthetic appId and recordScopeInvocation FK-fails on the synthetic
+ *    appBlockId, so the ONLY durable trail is the structured
+ *    `blocks.dev-token.pending-mint` log event (userId/slug/publishRequestId/
+ *    scopes/spendGranted) emitted at mint time (queryable in Axiom/Loki). GATE:
+ *    durable, per-spend audit rows for pending apps (e.g. a nullable-appBlockId
+ *    schema change so recordScopeInvocation can persist) is a GA-gate item before
+ *    pending-app dev spend is widened past the mod-only pre-GA posture.
+ *
  *    OWNERSHIP / NO-ORACLE: only the `slug` input can reach the pending path
  *    (pending apps have no `appBlockId`); a row the caller doesn't own — or no
  *    row at all — returns the SAME bare `404 { message: 'App not found' }` as
@@ -395,6 +405,11 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     blockInstanceId: string;
   };
   let resolved: Resolved | null = null;
+  // Set ONLY on the local-manifest (pending) path so the structured mint-audit
+  // log (FIX 🟡-1) can fire for pending mints — the only path WITHOUT durable
+  // AppBlock-backed audit rows (recordSpendAttribution throws+swallows on the
+  // synthetic appId; recordScopeInvocation FK-fails on the synthetic appBlockId).
+  let pendingPublishRequestId: string | null = null;
 
   if (block && block.app && block.app.userId === user.id) {
     // Owned approved row → existing-app mode. But an OWNED-yet-not-approved row
@@ -413,7 +428,11 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     // The app MUST declare a page block — dev-token mints PAGE tokens only (the
     // live-local target is a page app; no model binding).
     const manifest = (block.manifest ?? {}) as { page?: unknown };
-    if (typeof manifest.page !== 'object' || manifest.page === null) {
+    if (
+      typeof manifest.page !== 'object' ||
+      manifest.page === null ||
+      Array.isArray(manifest.page)
+    ) {
       res
         .status(422)
         .json({ message: 'dev-token mints page tokens; this app declares no page block' });
@@ -447,13 +466,18 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       // The un-reviewed manifest MUST declare a page block — same 422 as the
       // approved path (dev-token mints page tokens only).
       const manifest = (pending.manifest ?? {}) as { page?: unknown; scopes?: unknown };
-      if (typeof manifest.page !== 'object' || manifest.page === null) {
+      if (
+        typeof manifest.page !== 'object' ||
+        manifest.page === null ||
+        Array.isArray(manifest.page)
+      ) {
         res
           .status(422)
           .json({ message: 'dev-token mints page tokens; this app declares no page block' });
         return;
       }
       const manifestScopesRaw: unknown[] = Array.isArray(manifest.scopes) ? manifest.scopes : [];
+      pendingPublishRequestId = pending.id;
       resolved = {
         // Scope SOURCE is the UN-REVIEWED manifest.scopes (§4 R1) — clamped by the
         // IDENTICAL belt below (allowlist + page-forbidden + 7f spend ceiling).
@@ -613,6 +637,29 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   const buzzBudget = granted.includes('ai:write:budgeted')
     ? Math.min(requestedBudget ?? DEV_BUZZ_BUDGET_DEFAULT, DEV_BUZZ_BUDGET_CAP)
     : undefined;
+
+  // 8b. PENDING-PATH MINT AUDIT (FIX 🟡-1). The pending (local-manifest) path is
+  // the ONLY mint without durable, queryable audit rows: recordSpendAttribution
+  // throws+swallows on the synthetic `pending-<id>` appId, and recordScopeInvocation
+  // FK-fails on the synthetic `appBlockId` (no AppBlock row). Without this, a dev
+  // minting a spend-capable token against an UN-REVIEWED app leaves no forensic
+  // trail. Emit a structured event (Axiom/Loki-queryable) with the mint metadata —
+  // NEVER the token/secret. Placed AFTER the final scope clamp + budget resolution
+  // so `scopes`/`spendGranted` reflect the actual minted outcome (7f clamp included).
+  // PENDING-PATH ONLY: the approved path already has durable AppBlock-backed audit
+  // rows (recordSpendAttribution / recordScopeInvocation persist there), so it does
+  // not emit this event. The `mode: 'pending'` field is carried so a future
+  // approved-side log could reuse the same schema.
+  if (pendingPublishRequestId) {
+    req.log?.info('blocks.dev-token.pending-mint', {
+      mode: 'pending',
+      userId: user.id,
+      slug: resolved.signBlockId,
+      publishRequestId: pendingPublishRequestId,
+      scopes: granted,
+      spendGranted: granted.includes('ai:write:budgeted'),
+    });
+  }
 
   // 9. The synthetic, revocable PAGE instance id was resolved in step 6:
   //    - approved path:  `page_<appBlockId>` (same shape as the prod page mint),

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -9,7 +9,6 @@ import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { BlockTokenService } from '~/server/services/block-token.service';
 import {
-  APP_BLOCK_OAUTH_CLIENT_ID_PREFIX,
   isKnownBlockScope,
   validateBlockScopesAgainstOauthClient,
 } from '~/shared/constants/block-scope.constants';
@@ -74,6 +73,25 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  *    moderator pre-GA. The R1-escalation test proves an escalated manifest scope
  *    (`social:tip:self`, `block:settings:write`, an unknown/mature scope) is
  *    STRIPPED, never minted.
+ *
+ *    APPID MISATTRIBUTION (audit S1 — FIXED): the pending path mints a SYNTHETIC
+ *    `appId = pending-<publishRequestId>`, NOT the deterministic `appblk-<slug>`
+ *    an approved app would get. Were it `appblk-<slug>`, an adversarial mod-tier
+ *    dev could file a *pending* request for a slug an APPROVED app owned by a
+ *    DIFFERENT user already holds (the submit guard blocks only same-slug pending
+ *    collisions, not pending-vs-approved), skip the approved branch (not their
+ *    app), reach this pending branch, and mint a token whose `appId` resolves —
+ *    in `recordSpendAttribution` — to the VICTIM's real OauthClient, writing a
+ *    forged `blockSpendAttribution` row (status='tracked', appOwnerUserId=victim,
+ *    real grossValueCents). That row is exactly what the deferred payout rail
+ *    (#2605 Slice-4 backpay) reads to pay `gross × spendSharePct`. Dormant today
+ *    (spendSharePct=0, no money moves) but a forged accrual ledger would persist
+ *    into the payout window. The synthetic `pending-pubreq_<ULID>` can never match
+ *    an `appblk-*` id nor a real `OauthClient.id`, so the attribution lookup MISSES
+ *    → the inert `if (!app)` skip-write path → no row written (correct: a pending
+ *    dev-test spend has no approved app to attribute to). GATE: before #2605 turns
+ *    on a non-zero `spendSharePct`, re-confirm no pending-path mint can ever land a
+ *    real `OauthClient.id` in `appId`.
  *
  *    OWNERSHIP / NO-ORACLE: only the `slug` input can reach the pending path
  *    (pending apps have no `appBlockId`); a row the caller doesn't own — or no
@@ -446,12 +464,33 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
         // step 7f (AIServicesWrite spend gate). 7f IS the spend gate here.
         oauthAllowed: null,
         signBlockId: pending.slug,
-        // No OauthClient id exists yet — use the deterministic id a pending app
-        // WOULD get on approve (`appblk-<slug>`, the App-Blocks client prefix).
-        // `appId` is a provenance/billing-attribution TAG only (no FK / no
-        // validation against a row — buildWorkflowTags blocks.router.ts:2978), so
-        // a stable, audit-meaningful placeholder is correct here.
-        signAppId: `${APP_BLOCK_OAUTH_CLIENT_ID_PREFIX}${pending.slug}`,
+        // SYNTHETIC, NON-COLLIDING appId (audit S1 fix). A pending app has NO
+        // OauthClient yet, so there is no real client id to bind. We DELIBERATELY
+        // do NOT use the deterministic `appblk-<slug>` id an approved app WOULD
+        // get: that string is the id a real APPROVED app owned by ANOTHER user
+        // may already hold (the submit guard blocks only same-slug *pending*
+        // collisions, not pending-vs-approved). Minting `appblk-<slug>` here would
+        // let recordSpendAttribution's `oauthClient.findUnique({ where: { id } })`
+        // (buzz-attribution.service.ts) RESOLVE the victim's real client and write
+        // a foreign `blockSpendAttribution` row (status='tracked',
+        // appOwnerUserId=<victim>, real grossValueCents) — the exact row the
+        // deferred payout rail (#2605 Slice-4 backpay) reads to pay
+        // `gross × spendSharePct`. Dormant today (spendSharePct=0) but a forged
+        // accrual ledger would persist into the payout window.
+        //
+        // Instead use `pending-<publishRequestId>` — `pubreq_<ULID>` ids make this
+        // `pending-pubreq_<ULID>`, which can NEVER match an `appblk-*` id NOR a
+        // real `OauthClient.id` shape. The attribution lookup MISSES → it hits the
+        // intended inert `if (!app)` skip-write path (throws
+        // AttributionAppMissingError, swallowed by the void/catch at
+        // blocks.router.ts:2449) — correct: a pending dev-test spend has no
+        // approved app to attribute to, so NO row is written. `appId` has no other
+        // load-bearing use on the pending path: it's only (a) a cosmetic workflow
+        // TAG `app-block:${appId}` (blocks.router.ts:2978 — orchestrator bills
+        // getOrchestratorToken(userId)), (b) this attribution lookup we WANT to
+        // miss, and (c) middleware string-type validation (block-scope.middleware
+        // .ts:393). No FK resolves `appId` on the pending path.
+        signAppId: `pending-${pending.id}`,
         // No AppBlock.id exists — use the pending request id (stable, unique per
         // submission). The JWT `appBlockId` claim is only string-validated by the
         // middleware (block-scope.middleware.ts:394). NOTE: the best-effort

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -61,6 +61,7 @@ const {
   mockIsAppBlocksEnabled,
   mockSign,
   mockAppBlockFindUnique,
+  mockPublishRequestFindFirst,
   mockSysRedis,
   mockMultiIncr,
 } = vi.hoisted(() => {
@@ -84,6 +85,7 @@ const {
     mockIsAppBlocksEnabled: vi.fn(),
     mockSign: vi.fn(),
     mockAppBlockFindUnique: vi.fn(),
+    mockPublishRequestFindFirst: vi.fn(),
     mockSysRedis: {
       multi: vi.fn(multiFactory),
       ttl: vi.fn().mockResolvedValue(60),
@@ -100,7 +102,10 @@ vi.mock('~/server/services/block-token.service', () => ({
   BlockTokenService: { sign: mockSign },
 }));
 vi.mock('~/server/db/client', () => ({
-  dbWrite: { appBlock: { findUnique: mockAppBlockFindUnique } },
+  dbWrite: {
+    appBlock: { findUnique: mockAppBlockFindUnique },
+    appBlockPublishRequest: { findFirst: mockPublishRequestFindFirst },
+  },
 }));
 vi.mock('~/server/redis/client', () => ({
   sysRedis: mockSysRedis,
@@ -182,6 +187,22 @@ function pageApp(over: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+// A pending AppBlockPublishRequest the caller owns (local-manifest mode). There
+// is NO AppBlock row + NO OauthClient yet — scopes come from the un-reviewed
+// manifest and the OAuth-ceiling clamp is SKIPPED (7f is the spend gate).
+function pendingRequest(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'pubreq_01HXYZ',
+    slug: 'my-pending-app',
+    submittedByUserId: OWNER_ID,
+    manifest: {
+      page: { title: 'My Pending Page' },
+      scopes: ['models:read:self', 'user:read:self', 'ai:write:budgeted', 'apps:storage:read'],
+    },
+    ...over,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockMultiIncr.value = 1;
@@ -191,6 +212,8 @@ beforeEach(() => {
   mockSysRedis.expire.mockResolvedValue(1);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
   mockAppBlockFindUnique.mockResolvedValue(pageApp());
+  // Default: no pending request. The local-manifest path tests set this per-case.
+  mockPublishRequestFindFirst.mockResolvedValue(null);
   mockSign.mockResolvedValue({
     token: 'jwt.signed.value',
     expiresAt: '2099-01-01T00:00:00Z',
@@ -603,5 +626,203 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(res._getStatusCode()).toBe(200);
     const arg = mockSign.mock.calls[0][0];
     expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Local-manifest mode (Phase 4): mint against a caller's OWN pending app
+  // before it is moderator-approved. Scopes come from the un-reviewed manifest,
+  // clamped by the SAME belt minus the OAuth ceiling (7f is the spend gate).
+  // -------------------------------------------------------------------------
+  describe('local-manifest mode (owned pending app)', () => {
+    // The approved lookup MUST find nothing so the pending path is reached.
+    function noApprovedRow() {
+      mockAppBlockFindUnique.mockResolvedValueOnce(null);
+    }
+
+    it('200: owned pending request + page manifest → mints from manifest.scopes (OAuth ceiling SKIPPED), spend-capable when bearer has AIServicesWrite', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION); // personal key, Full → can spend
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign).toHaveBeenCalledTimes(1);
+      const arg = mockSign.mock.calls[0][0];
+      // Self-bound subject = the caller.
+      expect(arg.userId).toBe(OWNER_ID);
+      // Granted = manifest.scopes ∩ allowlist ∩ (¬page-forbidden), + force-granted
+      // user:read:self. ai:write:budgeted survives (bearer has AIServicesWrite).
+      expect(arg.scopes).toEqual([
+        'ai:write:budgeted',
+        'apps:storage:read',
+        'models:read:self',
+        'user:read:self',
+      ]);
+      // Budget defaulted + capped; forced SFW; page ctx.
+      expect(arg.buzzBudget).toBe(50);
+      expect(arg.maxBrowsingLevel).toBe(SFW);
+      expect(arg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
+      // Synthetic, revocable instance id derived from the publish-request id.
+      expect(arg.blockInstanceId).toBe('page_pubreq_pubreq_01HXYZ');
+      // sign blockId = the slug; appId = the deterministic appblk-<slug> placeholder.
+      expect(arg.blockId).toBe('my-pending-app');
+      expect(arg.appId).toBe('appblk-my-pending-app');
+      expect(arg.appBlockId).toBe('pubreq_01HXYZ');
+      // Ownership was enforced in the query.
+      expect(mockPublishRequestFindFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { slug: 'my-pending-app', status: 'pending', submittedByUserId: OWNER_ID },
+        })
+      );
+    });
+
+    it('200: owned pending request but bearer LACKS AIServicesWrite → ai:write:budgeted STRIPPED (7f spend gate), no budget claim', async () => {
+      mockGetSession.mockResolvedValueOnce(READONLY_MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      // ai:write:budgeted stripped by 7f; read/catalog/storage survive.
+      expect(arg.scopes).toEqual(['apps:storage:read', 'models:read:self', 'user:read:self']);
+      expect(arg.scopes).not.toContain('ai:write:budgeted');
+      expect(arg.buzzBudget).toBeUndefined();
+    });
+
+    it('R1: an un-reviewed manifest declaring ESCALATED scopes has them STRIPPED, not minted', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(
+        pendingRequest({
+          manifest: {
+            page: { title: 'evil' },
+            scopes: [
+              'models:read:self', // legit → kept
+              'social:tip:self', // dev-excluded + page-forbidden → stripped
+              'block:settings:write', // dev-excluded → stripped
+              'buzz:read:self', // page-forbidden → stripped
+              'totally:unknown:scope', // not a known block scope → stripped
+            ],
+          },
+        })
+      );
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      // Only the legit scope + the force-granted user:read:self survive — proving
+      // the un-reviewed manifest cannot escalate past the dev belt.
+      expect(arg.scopes).toEqual(['models:read:self', 'user:read:self']);
+      expect(arg.scopes).not.toContain('social:tip:self');
+      expect(arg.scopes).not.toContain('block:settings:write');
+      expect(arg.scopes).not.toContain('buzz:read:self');
+      expect(arg.scopes).not.toContain('totally:unknown:scope');
+    });
+
+    it('404 (bare, no oracle) when the pending request is owned by ANOTHER user', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      // The ownership filter is in the QUERY (submittedByUserId === user.id), so a
+      // row owned by another user simply does not match → findFirst returns null.
+      mockPublishRequestFindFirst.mockResolvedValueOnce(null);
+      const { req, res } = authPost({ slug: 'someone-elses-app' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(404);
+      // IDENTICAL body to the no-row-at-all case — no existence/ownership oracle.
+      expect((res._getJSONData() as { message: string }).message).toBe('App not found');
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('404 (bare) when neither an approved row NOR an owned pending request exists', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(null);
+      const { req, res } = authPost({ slug: 'no-such-app' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(404);
+      expect((res._getJSONData() as { message: string }).message).toBe('App not found');
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('422 when the owned pending manifest declares NO page block', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(
+        pendingRequest({ manifest: { scopes: ['models:read:self'] } }) // no page
+      );
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(422);
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('an appBlockId-only request can NEVER reach the pending path (pending apps have no appBlockId)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      // approved lookup misses; no slug → pending findFirst must not be consulted.
+      mockAppBlockFindUnique.mockResolvedValueOnce(null);
+      const { req, res } = authPost({ appBlockId: 'apb_missing' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(404);
+      expect((res._getJSONData() as { message: string }).message).toBe('App not found');
+      expect(mockPublishRequestFindFirst).not.toHaveBeenCalled();
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('CAPS an over-cap budget on the pending path to DEV_BUZZ_BUDGET_CAP', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({ slug: 'my-pending-app', buzzBudget: 100000 });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].buzzBudget).toBe(250);
+    });
+
+    it('forced SFW + self-bound sub hold on the pending path', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+      const arg = mockSign.mock.calls[0][0];
+      expect(arg.maxBrowsingLevel).toBe(SFW);
+      expect(arg.domain).toBeNull();
+      expect(arg.userId).toBe(OWNER_ID);
+    });
+
+    it('mod-only: a NON-mod is blocked BEFORE the pending lookup', async () => {
+      mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(403);
+      expect(mockPublishRequestFindFirst).not.toHaveBeenCalled();
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('rate-limit applies to the pending path too', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      mockMultiIncr.value = 31;
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(429);
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('body-narrowing applies on the pending path; user:read:self still force-granted', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({
+        slug: 'my-pending-app',
+        scopes: ['models:read:self'], // subset; excludes user:read:self
+      });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].scopes).toEqual(['models:read:self', 'user:read:self']);
+    });
   });
 });

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -665,9 +665,11 @@ describe('POST /api/v1/blocks/dev-token', () => {
       expect(arg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
       // Synthetic, revocable instance id derived from the publish-request id.
       expect(arg.blockInstanceId).toBe('page_pubreq_pubreq_01HXYZ');
-      // sign blockId = the slug; appId = the deterministic appblk-<slug> placeholder.
+      // sign blockId = the slug; appId = the SYNTHETIC non-colliding id (audit S1).
+      // NOT `appblk-<slug>` — that would resolve to a real OauthClient on spend.
       expect(arg.blockId).toBe('my-pending-app');
-      expect(arg.appId).toBe('appblk-my-pending-app');
+      expect(arg.appId).toBe('pending-pubreq_01HXYZ');
+      expect(arg.appId).not.toBe('appblk-my-pending-app');
       expect(arg.appBlockId).toBe('pubreq_01HXYZ');
       // Ownership was enforced in the query.
       expect(mockPublishRequestFindFirst).toHaveBeenCalledWith(
@@ -810,6 +812,50 @@ describe('POST /api/v1/blocks/dev-token', () => {
       await handler(req as never, res as never);
       expect(res._getStatusCode()).toBe(429);
       expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('S1: a foreign-owned APPROVED app for the same slug does NOT pin the token appId to appblk-<slug> (no forged attribution row)', async () => {
+      // ADVERSARIAL: a mod-tier dev files a *pending* request for a slug that an
+      // APPROVED app owned by a DIFFERENT user already holds. The submit guard
+      // blocks only same-slug *pending* collisions, not pending-vs-approved, so
+      // this is reachable. The dev-token APPROVED branch is skipped (the approved
+      // row's owner != caller), so the caller falls through to the PENDING branch.
+      // Were the pending path to mint appId=`appblk-<slug>`, recordSpendAttribution
+      // would resolve the VICTIM's real OauthClient on spend and write a forged
+      // blockSpendAttribution row (the #2605 payout rail reads exactly that row).
+      // The fix mints a synthetic `pending-<pubreqId>` instead, which can never
+      // resolve to a real OauthClient.id → the attribution write is skipped.
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      // The approved lookup by blockId=slug FINDS a row — but owned by user 999,
+      // NOT the caller (OWNER_ID). The same `appId` a real approved app would hold.
+      mockAppBlockFindUnique.mockResolvedValueOnce(
+        pageApp({
+          blockId: 'contested-slug',
+          appId: 'appblk-contested-slug',
+          app: { allowedScopes: 0x1ffffff, userId: 999 },
+        })
+      );
+      // The caller DOES own a pending request for the SAME slug.
+      mockPublishRequestFindFirst.mockResolvedValueOnce(
+        pendingRequest({ id: 'pubreq_CALLER1', slug: 'contested-slug' })
+      );
+      const { req, res } = authPost({ slug: 'contested-slug' });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign).toHaveBeenCalledTimes(1);
+      const arg = mockSign.mock.calls[0][0];
+      // (a) The caller reached the PENDING path, not the approved branch: the
+      //     appBlockId claim is the caller's OWN pending-request id, and the
+      //     instance id is derived from it (NOT the foreign approved AppBlock.id).
+      expect(arg.appBlockId).toBe('pubreq_CALLER1');
+      expect(arg.blockInstanceId).toBe('page_pubreq_pubreq_CALLER1');
+      // (b) appId is the SYNTHETIC value — NOT the colliding appblk-<slug> that
+      //     would resolve to the foreign victim's OauthClient on spend.
+      expect(arg.appId).toBe('pending-pubreq_CALLER1');
+      expect(arg.appId).not.toBe('appblk-contested-slug');
+      // Self-bound to the caller (the spend would be the caller's own Buzz).
+      expect(arg.userId).toBe(OWNER_ID);
     });
 
     it('body-narrowing applies on the pending path; user:read:self still force-granted', async () => {

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -385,6 +385,27 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(mockSign).not.toHaveBeenCalled();
   });
 
+  it('422 (approved path) when manifest.page is an ARRAY (not a plain object) — FIX 🟡-2', async () => {
+    // `typeof [] === 'object'` and `[] !== null`, so the old check ACCEPTED an
+    // array. The tightened check rejects arrays: a "declares a page block" gate
+    // must require a plain object, never attacker-supplied non-object JSON.
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(pageApp({ manifest: { page: [] } }));
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(422);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('200 (approved path) when manifest.page is a plain object {} — still mints (FIX 🟡-2 regression guard)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(pageApp({ manifest: { page: {} } }));
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign).toHaveBeenCalledTimes(1);
+  });
+
   it('429 when the per-user rate limit is exceeded', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     mockMultiIncr.value = 31; // > RATE_LIMIT.max (30)
@@ -760,6 +781,91 @@ describe('POST /api/v1/blocks/dev-token', () => {
       await handler(req as never, res as never);
       expect(res._getStatusCode()).toBe(422);
       expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('422 when the owned pending manifest sets page to an ARRAY — FIX 🟡-2', async () => {
+      // On the PENDING path the manifest is developer-controlled + un-reviewed, so
+      // a dev could set `page: []` (an array is `typeof 'object'`, non-null) to
+      // satisfy the old "declares a page block" gate. The tightened check rejects
+      // it → 422, never a mint.
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(
+        pendingRequest({ manifest: { page: [], scopes: ['models:read:self'] } })
+      );
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(422);
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('200 when the owned pending manifest page is a plain object {} (FIX 🟡-2 regression guard)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(
+        pendingRequest({ manifest: { page: {}, scopes: ['models:read:self'] } })
+      );
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign).toHaveBeenCalledTimes(1);
+    });
+
+    it('FIX 🟡-1: emits the structured blocks.dev-token.pending-mint log with spendGranted=true (bearer has AIServicesWrite)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION); // Full → AIServicesWrite → can spend
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      const log = (req as unknown as { log: { info: ReturnType<typeof vi.fn> } }).log;
+      expect(log.info).toHaveBeenCalledWith(
+        'blocks.dev-token.pending-mint',
+        expect.objectContaining({
+          mode: 'pending',
+          userId: OWNER_ID,
+          slug: 'my-pending-app',
+          publishRequestId: 'pubreq_01HXYZ',
+          spendGranted: true,
+        })
+      );
+      // The granted scopes are logged for forensics; the token/secret is NEVER logged.
+      const call = log.info.mock.calls.find((c) => c[0] === 'blocks.dev-token.pending-mint');
+      expect(call?.[1].scopes).toEqual([
+        'ai:write:budgeted',
+        'apps:storage:read',
+        'models:read:self',
+        'user:read:self',
+      ]);
+      expect(JSON.stringify(call?.[1])).not.toContain('jwt.signed.value');
+    });
+
+    it('FIX 🟡-1: pending-mint log reflects spendGranted=false when the bearer LACKS AIServicesWrite (7f clamp)', async () => {
+      mockGetSession.mockResolvedValueOnce(READONLY_MOD_SESSION); // no AIServicesWrite
+      noApprovedRow();
+      mockPublishRequestFindFirst.mockResolvedValueOnce(pendingRequest());
+      const { req, res } = authPost({ slug: 'my-pending-app' });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      const log = (req as unknown as { log: { info: ReturnType<typeof vi.fn> } }).log;
+      const call = log.info.mock.calls.find((c) => c[0] === 'blocks.dev-token.pending-mint');
+      expect(call).toBeDefined();
+      expect(call?.[1].spendGranted).toBe(false);
+      expect(call?.[1].scopes).not.toContain('ai:write:budgeted');
+    });
+
+    it('FIX 🟡-1: the APPROVED path does NOT emit the pending-mint log', async () => {
+      // The approved path has durable AppBlock-backed audit rows, so the structured
+      // pending-mint event must not fire for it (it is pending-path-only).
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      const { req, res } = authPost({ appBlockId: 'apb_abc' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      const log = (req as unknown as { log: { info: ReturnType<typeof vi.fn> } }).log;
+      const call = log.info.mock.calls.find((c) => c[0] === 'blocks.dev-token.pending-mint');
+      expect(call).toBeUndefined();
     });
 
     it('an appBlockId-only request can NEVER reach the pending path (pending apps have no appBlockId)', async () => {


### PR DESCRIPTION
## Summary

Implements the documented **Phase-4 "local-manifest" mode** for the App Blocks dev-token mint (`claudedocs/app-blocks-dev-token-endpoint-scope.md` §4 / Phase 4), so an app developer can spend their **own** Buzz testing their **own** app via `dev:live` **before** the app is moderator-approved.

Today the mint requires an **approved** `AppBlock` row, so a brand-new (pending) app → `404`, blocking the `dev:live` real-Buzz path for a developer's first app. This adds a **second resolution path**, reached **only** when the existing approved-AppBlock lookup finds no owned approved row.

This is a **money-path** change and was built conservatively inside the safe envelope from the scope doc.

## How it works

1. **Fallback lookup** — an `AppBlockPublishRequest` with `slug === <slug>`, `status='pending'`, **and `submittedByUserId === user.id`** (ownership enforced **in the query**). Uses `dbWrite` (no replica lag). Only the `slug` input can reach this path — pending apps have **no** `appBlockId`, so an `appBlockId`-only request can never hit it.
2. **No-oracle 404** — no owned approved row **and** no owned pending row → the **same bare** `404 { message: 'App not found' }` as the approved path. Existence / ownership / state of a row the caller doesn't own is never revealed. Only an owned-but-not-approved `AppBlock` row surfaces the existing actionable "no live deployment" message.
3. **Scope source = the pending request's un-reviewed `manifest.scopes`** (developer-controlled, the §4 **R1** escalation surface), clamped by the **identical belt** as the approved path:
   - `isKnownBlockScope` filter
   - `DEV_TOKEN_SCOPE_ALLOWLIST` filter (excludes `social:tip:self`, `block:settings:*`)
   - `PAGE_FORBIDDEN_SCOPES` filter (`buzz:read:self`, `social:tip:self`)
   - **OAuth-ceiling clamp (step 7c) OMITTED** — a pending app has no `OauthClient`. Passing `oauthAllowed: 0` into `validateBlockScopesAgainstOauthClient` would **wrongly strip every non-`SKIP_OAUTH_CHECK` scope** (`(0 & bit) !== bit`). The correct substitute ceiling is the **dev's own credential**, already enforced at **step 7f**.
   - body-narrowing (7e)
   - **bearer-credential spend ceiling (7f)** — `ai:write:budgeted` survives only if `session.tokenScope` carries `AIServicesWrite`. **This replaces the absent OAuth ceiling and is the authoritative spend gate for the pending path.**
   - force-grant `user:read:self` (7g)
4. **Page requirement** — the pending manifest must declare a `page` block (same `422` as the approved path).
5. **Synthetic instance id** — `page_pubreq_<publishRequestId>` (stable, unique, `BlockRevocation`-checkable). `blockId` = the slug; `appId` = a **synthetic, non-colliding** `pending-<publishRequestId>` (value `pending-pubreq_<ULID>`) — see the **Security fix** section below. `appId` is a provenance/billing tag only on the pending path (**no FK**, no validation).
6. **Every other cap unchanged** — `DEV_BUZZ_BUDGET_CAP` (250) + default, forced SFW ceiling, self-bound `sub`, short TTL, the rate limiter, and **mod-only pre-GA** (`isAppBlocksEnabled` + `isModerator`). The pending path relaxes **nothing**.

The existing-app (approved) path is **byte-identical** to before — it still uses `approvedScopes` + the OAuth ceiling.

## Security fix (audit S1 — money path, addressed in `baae0fb17f`)

The first revision set the pending token's `appId` to `appblk-<slug>` — the **deterministic id a real approved app gets**. An adversarial mod-tier dev could file a *pending* submission for a slug that an **approved app owned by a different user** already holds (the submit guard blocks only same-slug *pending* collisions, **not** pending-vs-approved). The approved branch is skipped (not their app), so they reach the pending branch and mint a token with `appId=appblk-<slug>`. On spend, `recordSpendAttribution` does `oauthClient.findUnique({ where: { id: appId } })` → resolves the **victim's real client** → writes a `blockSpendAttribution` row (`status='tracked'`, `appOwnerUserId=<victim>`, real `grossValueCents`) — the exact row the deferred payout rail (**#2605** Slice-4 backpay) reads to pay `gross × spendSharePct`. Dormant today (`spendSharePct=0`, no money moves) but a **forged accrual ledger would persist into the payout window**.

**Fix (audit's Option 2):** in the **pending path only**, set `appId = pending-<publishRequestId>` (value `pending-pubreq_<ULID>`), which can **never** match an `appblk-*` id nor a real `OauthClient.id`. The attribution lookup **misses** → the intended inert `if (!app)` skip-write path → **no attribution row written** (correct: a pending dev-test spend has no approved app to attribute to). The **approved path's `appId = app.id` is unchanged**. `appId` has no other load-bearing use on the pending path: a cosmetic workflow tag (`app-block:${appId}`), the attribution lookup we **want** to miss, and middleware string-type validation only — verified, none break.

**#2605 gate:** before the payout rail turns on a non-zero `spendSharePct`, re-confirm no pending-path mint can ever land a real `OauthClient.id` in `appId`. Documented in the `dev-token.ts` honest-residuals docstring.

## Posture
- **Mod-only / dark** pre-GA (unchanged gate). The runtime spend procedures still assert moderator, so this is consistent with the existing belt.
- **Residual** (honest): the manifest is un-reviewed, but every declared scope is bounded by ≤ the dev's own credential authority (7f), ⊆ the allowlist, minus page-forbidden; spend is the dev's own budget-capped Buzz against the untouched per-user daily cap.
- **Known fail-soft**: the best-effort `BlockScopeInvocation` audit-log write has a NOT-NULL FK → `AppBlock.id`; for a pending app (synthetic id) it FK-fails and is silently swallowed (fire-and-forget). Verification + revocation are unaffected. Documented inline.

## Tests
15 new cases (43 total, all green), including:
- **S1 forged-attribution proof** — a foreign-owned **approved** app for the same slug as the caller's **own pending** request → the caller still reaches the **pending** path (not the approved branch), and the minted `appId` is the synthetic `pending-pubreq_...`, **not** `appblk-<slug>` (so no foreign attribution row could ever be written).
- **R1 escalation proof** — an un-reviewed manifest declaring `social:tip:self` / `block:settings:write` / `buzz:read:self` / an unknown scope has them **all stripped**, only the legit + force-granted `user:read:self` survive.
- the **7f spend gate** — `ai:write:budgeted` present **with** `AIServicesWrite`, **absent without** (both paths).
- no-oracle 404s (owned-by-another-user, no-row-at-all — identical bodies), `422` no-page, the `appBlockId`-only request can never reach the pending path, budget cap, forced SFW, self-bound sub, mod-only, rate-limit, body-narrowing.
- the existing approved-path tests are **unchanged** (no regression).

Typecheck: `tsc --noEmit -p tsconfig.json` → **0 new errors** introduced by this PR (baseline 19 pre-existing errors in the worktree, all from the un-checked-out `event-engine-common` submodule + `@civitai/client` drift — identical count with the changes stashed; none reference the dev-token files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Audit follow-ups (🟡-2 / 🟡-1, `ac2d1e99ef`)

Two precision fixes from a follow-up money-path audit:

**🟡-2 — `manifest.page` array passed the page-block gate.** The check `typeof manifest.page !== 'object' || manifest.page === null` accepted `page: []` (arrays are `typeof 'object'`, non-null) and other non-plain-object JSON. No downstream exploit (page content is never read — `ctx` is hardcoded), but on the **pending** path the manifest is developer-controlled + un-reviewed, so attacker-supplied non-object JSON should not satisfy a "declares a page block" check. Tightened to `|| Array.isArray(manifest.page)` on **both** the approved-path and pending-path checks (same `422` + message).

**🟡-1 — pending-app dev spend was unaudited.** On the pending path both server-side audit writes silently no-op: `recordSpendAttribution` throws+swallows by design, and `recordScopeInvocation` FK-fails because `appBlockId=pubreq_<id>` has no `AppBlock` row. So there was no durable, queryable record that a dev minted a spend-capable token against a **pending (un-reviewed)** app. Closed at the **mint boundary** (the proportionate, in-scope fix — **no** schema/migration change): when the pending path mints, emit a structured `req.log.info('blocks.dev-token.pending-mint', { mode, userId, slug, publishRequestId, scopes, spendGranted })` (no secrets, no token) so pending-app dev-token activity is queryable in Axiom/Loki. Placed after the final scope clamp + budget resolution so `scopes`/`spendGranted` reflect the actual minted outcome.

**GA gate:** the pending-path spend has **no AppBlock-backed audit rows** — only the structured `blocks.dev-token.pending-mint` mint log. Durable per-spend auditing for pending apps (e.g. a nullable-`appBlockId` schema change so `recordScopeInvocation` can persist) is a **GA-gate item** before pending-app dev spend is widened past the mod-only pre-GA posture.

**Tests (this commit, +9 → 50 total green):** page-array `422` on both approved + pending paths, plain-object `{}` regression guards, the `blocks.dev-token.pending-mint` log shape with `spendGranted` true (bearer has `AIServicesWrite`) and false (7f strips it), and an assertion that the **approved** path does **not** emit the pending-mint event. Typecheck `tsc --noEmit -p tsconfig.json` → 0 new errors (19 pre-existing worktree-env errors, identical baseline-vs-after; none in the dev-token files).
