### PR TITLE
perf(orchestrator): instrument queryGeneratedImages tail + bound the orchestrator read

### DIFF
--- a/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
@@ -134,6 +134,21 @@ describe('queryWorkflows error mapping (queryGeneratedImages path)', () => {
     expect((err as TRPCError).code).toBe('NOT_FOUND');
   });
 
+  it('maps the read-backstop AbortSignal.timeout TimeoutError to 503', async () => {
+    // The ORCHESTRATOR_QUERY_TIMEOUT_MS backstop aborts a runaway query via
+    // AbortSignal.timeout(), which rejects with a DOMException named 'TimeoutError'.
+    // isUpstreamNetworkError matches `.name === 'TimeoutError'` → retry-able 503.
+    mockQueryWorkflows.mockRejectedValue(
+      Object.assign(new Error('The operation was aborted due to timeout'), {
+        name: 'TimeoutError',
+      })
+    );
+    const err = await queryWorkflows(baseQueryArgs).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).message).toMatch(/temporarily unavailable/i);
+  });
+
   it('does NOT 503 a genuine code-bug throw', async () => {
     const bug = new TypeError('boom is not a function');
     mockQueryWorkflows.mockRejectedValue(bug);

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -2664,9 +2664,19 @@ export async function queryGeneratedImageWorkflows2({
   cache?: boolean;
 }) {
   const fetchAndFormat = async () => {
-    const { nextCursor, items } = await queryWorkflows(props);
+    // The queryGeneratedImages feed has a latency tail (slow >5s events). It splits
+    // into two awaits — the orchestrator HTTP read (`queryWorkflows`) and the
+    // resource-enrichment mapping (`formatGenerationResponse2`) — and we don't yet
+    // know which dominates. Wrap each in its own span (transparent withSpan, same
+    // pattern as the `gen:createSteps:*` spans above) to localize the tail for a
+    // follow-up optimization. Both the cached and uncached paths run through here.
+    const { nextCursor, items } = await withSpan('gen:queryGI:queryWorkflows', () =>
+      queryWorkflows(props)
+    );
     return {
-      items: await formatGenerationResponse2(items as Workflow[], user),
+      items: await withSpan('gen:queryGI:format', () =>
+        formatGenerationResponse2(items as Workflow[], user)
+      ),
       nextCursor,
     };
   };

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -44,6 +44,17 @@ import {
 const ORCHESTRATOR_UNAVAILABLE_MESSAGE =
   'Generation services are temporarily unavailable. Please try again.';
 
+// Backstop deadline for the orchestrator workflow READ (queryWorkflows). A read is
+// safe to bound — the polling client simply re-fetches — so this caps a runaway
+// query that would otherwise hang unbounded and pin a request. Sized well above the
+// observed latency tail (max ~17.7s on the queryGeneratedImages feed) so it 503s
+// essentially nothing today and only fires on a true runaway. A fired
+// AbortSignal.timeout() throws a `TimeoutError`, which the existing
+// `isUpstreamNetworkError` catch below classifies → retry-able 503 (no new handling
+// needed). Bounds ALL queryWorkflows callers (queryGeneratedImages feed,
+// queryWorkflowsByTags, queue-status, admin) — every one a request-scoped read.
+const ORCHESTRATOR_QUERY_TIMEOUT_MS = 20_000;
+
 export async function queryWorkflows({
   token,
   fromDate,
@@ -54,6 +65,9 @@ export async function queryWorkflows({
 
   const { data, error } = await clientQueryWorkflows({
     client,
+    // Read backstop: abort a runaway orchestrator query (see constant above). The
+    // resulting TimeoutError is caught below and mapped to a retry-able 503.
+    signal: AbortSignal.timeout(ORCHESTRATOR_QUERY_TIMEOUT_MS),
     query: {
       ...query,
       tags: ['civitai', ...(query.tags ?? [])],


### PR DESCRIPTION
## Why

`orchestrator.queryGeneratedImages` (the generated-images polling feed) has a latency tail: **~177 slow >5s events/hr, max ~17.7s** (100% `ok` — no errors, just slow). It routes through `queryGeneratedImageWorkflows2`, whose `fetchAndFormat` closure does two awaits back-to-back:

1. `queryWorkflows(props)` — the orchestrator HTTP read
2. `formatGenerationResponse2(items, user)` — resource enrichment / per-workflow mapping

We don't currently know **which of the two** owns the tail, so we can't target an optimization yet.

## Fix 1 — instrument to localize the tail (observability-only, transparent)

Wrap each of the two awaits in `withSpan` (same transparent wrapper + pattern as the existing `gen:createSteps:*` spans in this file):

- `await queryWorkflows(props)` → span **`gen:queryGI:queryWorkflows`**
- `await formatGenerationResponse2(...)` → span **`gen:queryGI:format`**

`withSpan` returns the awaited value, propagates throws, and no-ops on DOKS — so behavior is byte-identical. This covers **both** the cached and uncached paths (both flow through `fetchAndFormat`). With these two spans live, the next slow-event sample tells us whether the read or the enrichment dominates, and the follow-up optimization can target it directly.

## Fix 2 — bound the orchestrator read (safe; it's a read)

`queryWorkflows` calls `clientQueryWorkflows({ client, query })`. This is a **READ** — bounding it is safe because the polling client just re-fetches. Add:

```ts
const ORCHESTRATOR_QUERY_TIMEOUT_MS = 20_000; // read backstop, above the ~17.7s observed tail
...
signal: AbortSignal.timeout(ORCHESTRATOR_QUERY_TIMEOUT_MS),
```

so a runaway query can't hang unbounded and pin a request. At 20s it's a backstop that **503s ~nothing today** (above the observed max) and only fires on a true runaway.

A fired `AbortSignal.timeout()` throws a `TimeoutError`, which is **already classified** by the existing `.catch(isUpstreamNetworkError → throwServiceUnavailableError)` in `queryWorkflows` (`isUpstreamNetworkError` matches `.name === 'TimeoutError'`) → mapped to a **retry-able 503**. No new error handling added.

### Is the 20s bound safe for all callers?

Grepped every caller of the local `queryWorkflows` wrapper — all 5 are request-scoped reads, none an internal long-poll for which a 20s 503 would be wrong:

| Caller | Kind |
|---|---|
| `orchestration-new.service.ts` (queryGeneratedImages feed) | user feed read |
| `orchestrator.router.ts` → `queryWorkflowsByTags` | tRPC read |
| `queue-limits.ts` → `getUserQueueStatus` | request-scoped queue check |
| `pages/api/admin/orchestrator/index.ts` | admin read |
| `pages/api/admin/orchestrator/timings.ts` | admin read |

So the timeout lives in the shared wrapper (bounds them all) rather than being scoped to the queryGeneratedImages path only.

## Tests

Extended `workflows.error-mapping.test.ts` with a case: `queryWorkflows` rejecting via a `TimeoutError` → throws `SERVICE_UNAVAILABLE` (503). **All 12 tests pass** locally (vitest).

## Not verified

- Spans not yet observed in Tempo (deploy-gated; trace search will show `gen:queryGI:*` once live).
- The 20s backstop is not exercised in prod yet (won't fire under the current ~17.7s tail — by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)