### PR TITLE
feat(mod): single-action article rating review card

### DIFF
--- a/docs/superpowers/specs/2026-06-25-article-rating-review-single-action-design.md
+++ b/docs/superpowers/specs/2026-06-25-article-rating-review-single-action-design.md
@@ -1,0 +1,62 @@
+# Article Rating Review — single-action card
+
+**Date:** 2026-06-25
+**Branch:** `feat/article-rating-review-single-action`
+
+## Problem
+
+The moderator article-rating-review card (`src/pages/moderator/article-rating-review.tsx` →
+`ArticleRatingReviewCard.tsx`) exposes a level selector plus two buttons (**Approve** / **Reject**).
+When the mod-selected level equals the system's current level, "Approve as X" and "Reject" produce
+the same visible rating, differing only in (a) whether an override lock is set and (b) which
+notification fires. Mods read the two buttons as redundant — confusing.
+
+Quote: *"if the user suggest PG for their R-rated article... And then I press R, I can either approve
+as R or reject... Both essentially do the same thing I guess? But probably send different
+notifications?"*
+
+## Decision
+
+Collapse to a **single submit action**. Every resolution pins (overrides) the article at the
+mod-selected level. Status and notification are **derived** from selected-vs-suggested level.
+
+- Mod picks one level — segmented control with **no default**. Submit disabled until a pick.
+- Submit always runs the override/pin write (today's `Actioned` branch): sets
+  `moderatorNsfwLevel = nsfwLevel = appliedLevel`, snapshots `moderatorNsfwLevelBasis`, locks
+  `userNsfwLevel`.
+- **Server derives status** (authoritative, not client-supplied):
+  - `appliedLevel === suggestedLevel` → `Actioned` (dashboard "Approved") → `approved` notification.
+  - `appliedLevel !== suggestedLevel` → `Unactioned` (dashboard "Rejected") → `rejected` notification.
+- Button label derives client-side: `Approve as {level}` when pick == owner suggestion, else
+  `Set rating to {level}`.
+
+Dashboard `Pending / Approved / Rejected` filters + counts are unchanged structurally; their meaning
+shifts to "was the owner's suggestion granted?" rather than "did we touch the article?".
+
+## Changes by file
+
+| File | Change |
+|------|--------|
+| `src/server/schema/article.schema.ts` | `resolveArticleRatingReviewSchema`: drop `status`, make `appliedLevel` required (positive int), remove the `.refine`. |
+| `src/server/services/article.service.ts` (`resolveArticleRatingReview`) | Input `{ reviewId, appliedLevel, modComment, moderatorId }`. Read `suggestedLevel` in the txn. **Always** run the override/pin write. Derive `status` from `appliedLevel === suggestedLevel`. Branch notification on derived status; pass `appliedLevel` into the rejected notification details. Return derived `status`. |
+| `src/server/notifications/article-rating-review.notifications.ts` | Reword the `rejected` `prepareMessage` — a level is now applied, so: `Your rating dispute on "{title}" was reviewed — a moderator set the rating to {appliedLevel}.` Update details type (`appliedLevel` instead of/in addition to `currentLevel`). |
+| `src/server/routers/article.router.ts` | Pass-through; tracking still receives derived `status` + `appliedLevel`. |
+| `src/components/Article/ArticleRatingReviewCard.tsx` | Empty-default segmented control; single Submit (disabled until pick + while pending); derived label; one `handleResolve`; update helper text; remove the dual Approve/Reject buttons + `handleApprove`/`handleDismiss`. |
+| `src/pages/moderator/article-rating-review.tsx` | No logic change. (Optional tooltip clarifying Approved = suggestion granted / Rejected = overrode differently — skip unless trivial.) |
+
+## Behavior shifts (intended; documented)
+
+1. **Reject now pins.** Previously `Unactioned` left the rating *floating* (no override). Now it sets
+   an override + basis, so the article won't auto-lower until a mod clears it, and a future
+   down-direction re-dispute routes through `evaluateAutoApproveGate` gate #6 (`derived < basis`)
+   instead of auto-approving freely on rescan. Direct consequence of "always pin".
+2. **`status` no longer implies "override exists".** Both resolution paths now set the override;
+   `status` only encodes "was the owner's suggestion granted". Verified the only `status='Actioned'`
+   DB predicate near this code is on `Report` (NSFW report), not `ArticleRatingReview` — re-grep
+   during implementation to confirm nothing else keys off review status as an override proxy.
+
+## Out of scope
+
+- No change to the auto-approve / re-dispute helper logic itself.
+- No change to dispute creation (`createArticleRatingReview`).
+- No backfill of historical `Unactioned` rows (they remain unpinned; only new resolutions pin).

--- a/src/components/Article/ArticleRatingReviewCard.tsx
+++ b/src/components/Article/ArticleRatingReviewCard.tsx
@@ -71,21 +71,25 @@ export function ArticleRatingReviewCard({
   const { article, user } = review;
   const isResolved = review.status !== ReportStatus.Pending;
 
+  // No preselection: the mod must deliberately pick a level before resolving
+  // (Submit stays disabled until then). Resolved cards show the applied level.
   const [selectedLevel, setSelectedLevel] = useState<string>(
-    String(review.appliedLevel ?? review.suggestedLevel)
+    isResolved && review.appliedLevel != null ? String(review.appliedLevel) : ''
   );
   const [modComment, setModComment] = useState<string>(review.modComment ?? '');
   const [resolvedLocal, setResolvedLocal] = useState<boolean>(isResolved);
 
   const utils = trpc.useUtils();
   const { mutate, isPending } = trpc.article.resolveRatingReview.useMutation({
-    onSuccess: (_, variables) => {
+    onSuccess: (data) => {
       setResolvedLocal(true);
       showSuccessNotification({
+        // Status is derived server-side: Actioned = the owner's suggestion was
+        // granted; Unactioned = a different level was applied (overrode).
         message:
-          variables.status === ReportStatus.Actioned
-            ? 'Rating review approved'
-            : 'Rating review rejected',
+          data.status === ReportStatus.Actioned
+            ? 'Owner suggestion approved'
+            : 'Rating set to a different level',
       });
       // Optimistically drop the resolved review from the active page cache
       // for the current filter. Skipping the full invalidate keeps the page
@@ -109,25 +113,26 @@ export function ArticleRatingReviewCard({
     },
   });
 
-  const handleApprove = () => {
+  const handleResolve = () => {
+    if (!selectedLevel) return;
     mutate({
       reviewId: review.id,
-      status: ReportStatus.Actioned,
       appliedLevel: Number(selectedLevel),
       modComment: modComment.trim() || undefined,
     });
   };
 
-  const handleDismiss = () => {
-    mutate({
-      reviewId: review.id,
-      status: ReportStatus.Unactioned,
-      modComment: modComment.trim() || undefined,
-    });
-  };
-
-  const dismissDisabled = isPending || resolvedLocal;
-  const approveDisabled = isPending || resolvedLocal;
+  // Submit is gated on a deliberate level pick. When the pick matches the
+  // owner's suggestion the action grants it ("Approve"); otherwise the mod is
+  // overriding to a different level ("Set rating to").
+  const hasPick = selectedLevel !== '';
+  const grantsSuggestion = hasPick && Number(selectedLevel) === review.suggestedLevel;
+  const submitDisabled = isPending || resolvedLocal || !hasPick;
+  const submitLabel = !hasPick
+    ? 'Resolve'
+    : grantsSuggestion
+    ? `Approve as ${getBrowsingLevelLabel(Number(selectedLevel))}`
+    : `Set rating to ${getBrowsingLevelLabel(Number(selectedLevel))}`;
 
   const articleHref = `/articles/${article.id}`;
   const userHref = user.username ? `/user/${user.username}` : undefined;
@@ -264,27 +269,19 @@ export function ArticleRatingReviewCard({
               maxLength={1000}
             />
             <Text size="xs" c="dimmed">
-              Approving locks the rating at this level until a moderator clears it. Owner edits
-              won&apos;t drop the rating below it automatically — but a re-dispute will auto-approve
-              if a rescan agrees.
+              Pick the correct level and resolve. This locks the rating at that level until a
+              moderator clears it — owner edits won&apos;t drop it below automatically, but a
+              re-dispute will auto-approve if a rescan agrees. Matching the owner&apos;s suggestion
+              approves it; any other level overrides to your ruling.
             </Text>
             <Group justify="flex-end" gap="xs">
               <Button
-                color="red"
-                variant="filled"
-                disabled={dismissDisabled}
-                loading={isPending}
-                onClick={handleDismiss}
-              >
-                Reject
-              </Button>
-              <Button
-                color="teal"
-                disabled={approveDisabled}
-                onClick={handleApprove}
+                color={grantsSuggestion ? 'teal' : 'blue'}
+                disabled={submitDisabled}
+                onClick={handleResolve}
                 loading={isPending}
               >
-                Approve as {getBrowsingLevelLabel(Number(selectedLevel))}
+                {submitLabel}
               </Button>
             </Group>
           </Stack>

--- a/src/server/notifications/article-rating-review.notifications.ts
+++ b/src/server/notifications/article-rating-review.notifications.ts
@@ -31,15 +31,22 @@ export const articleRatingReviewNotifications = createNotificationProcessor({
     toggleable: false,
     prepareMessage: ({ details }) => {
       if (!details) return undefined;
-      const { articleTitle, articleId, appliedLevel, modComment } = details as {
+      // `prepareMessage` runs at render time over the stored `details`, so this
+      // must handle both shapes: pre-single-action rows carry `currentLevel`
+      // (the rating that was kept on a decline); new rows carry `appliedLevel`
+      // (the level the moderator now always sets). Without the `currentLevel`
+      // fallback, legacy rows would render "...set the rating to undefined".
+      const { articleTitle, articleId, appliedLevel, currentLevel, modComment } = details as {
         articleTitle: string;
         articleId: number;
-        appliedLevel: number | string;
+        appliedLevel?: number | string;
+        currentLevel?: number | string;
         modComment?: string;
       };
-      // A moderator now always applies a level on resolution; a declined dispute
-      // means the owner's suggestion wasn't granted but a ruling level was set.
-      const base = `Your rating dispute on "${articleTitle}" was reviewed — a moderator set the rating to ${appliedLevel}.`;
+      const base =
+        appliedLevel != null
+          ? `Your rating dispute on "${articleTitle}" was reviewed — a moderator set the rating to ${appliedLevel}.`
+          : `Your rating dispute on "${articleTitle}" was declined — the current rating (${currentLevel}) was kept.`;
       return {
         message: modComment ? `${base} Reason: ${modComment}` : base,
         url: `/articles/${articleId}`,

--- a/src/server/notifications/article-rating-review.notifications.ts
+++ b/src/server/notifications/article-rating-review.notifications.ts
@@ -31,13 +31,15 @@ export const articleRatingReviewNotifications = createNotificationProcessor({
     toggleable: false,
     prepareMessage: ({ details }) => {
       if (!details) return undefined;
-      const { articleTitle, articleId, currentLevel, modComment } = details as {
+      const { articleTitle, articleId, appliedLevel, modComment } = details as {
         articleTitle: string;
         articleId: number;
-        currentLevel: number | string;
+        appliedLevel: number | string;
         modComment?: string;
       };
-      const base = `Your rating dispute on "${articleTitle}" was declined — the current rating (${currentLevel}) was kept.`;
+      // A moderator now always applies a level on resolution; a declined dispute
+      // means the owner's suggestion wasn't granted but a ruling level was set.
+      const base = `Your rating dispute on "${articleTitle}" was reviewed — a moderator set the rating to ${appliedLevel}.`;
       return {
         message: modComment ? `${base} Reason: ${modComment}` : base,
         url: `/articles/${articleId}`,

--- a/src/server/schema/article.schema.ts
+++ b/src/server/schema/article.schema.ts
@@ -166,17 +166,16 @@ export const getArticleRatingReviewsSchema = z.object({
 });
 
 export type ResolveArticleRatingReviewInput = z.infer<typeof resolveArticleRatingReviewSchema>;
-export const resolveArticleRatingReviewSchema = z
-  .object({
-    reviewId: z.number(),
-    status: z.enum(['Actioned', 'Unactioned']),
-    appliedLevel: z.number().int().positive().optional(),
-    modComment: z.string().max(1000).optional(),
-  })
-  .refine((data) => data.status !== 'Actioned' || data.appliedLevel != null, {
-    message: 'appliedLevel is required when actioning a review',
-    path: ['appliedLevel'],
-  });
+// Single-action resolution: every resolve pins the article at `appliedLevel`
+// (override). The Actioned/Unactioned status is no longer a client input — the
+// server derives it from `appliedLevel` vs the review's `suggestedLevel`
+// (granted vs overrode-differently). See
+// docs/superpowers/specs/2026-06-25-article-rating-review-single-action-design.md
+export const resolveArticleRatingReviewSchema = z.object({
+  reviewId: z.number(),
+  appliedLevel: z.number().int().positive(),
+  modComment: z.string().max(1000).optional(),
+});
 
 export type GetMyArticleRatingReviewInput = z.infer<typeof getMyArticleRatingReviewSchema>;
 export const getMyArticleRatingReviewSchema = z.object({

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -2764,174 +2764,128 @@ export async function getArticleRatingReviewCounts() {
 export async function resolveArticleRatingReview({
   reviewId,
   moderatorId,
-  status,
   appliedLevel,
   modComment,
 }: ResolveArticleRatingReviewInput & {
   moderatorId: number;
 }) {
-  // Validate the Actioned input up front before opening any transaction.
-  if (status === 'Actioned') {
-    if (appliedLevel == null) {
-      throw throwBadRequestError('appliedLevel is required when actioning a review');
-    }
-    if (!VALID_NSFW_LEVELS.has(appliedLevel)) {
-      throw throwBadRequestError(
-        `Invalid applied NSFW level. Must be one of: ${[...VALID_NSFW_LEVELS].join(', ')}`
-      );
-    }
+  // Single-action resolution: every resolve pins the article at `appliedLevel`
+  // (override). Validate the level up front before opening the transaction.
+  if (!VALID_NSFW_LEVELS.has(appliedLevel)) {
+    throw throwBadRequestError(
+      `Invalid applied NSFW level. Must be one of: ${[...VALID_NSFW_LEVELS].join(', ')}`
+    );
   }
 
-  // Resolution paths return:
+  // Resolution returns:
   //   articleId  - for downstream notify / tracker
-  //   userId     - the owner who filed the review (for notify)
-  //   articleTitle / articleNsfwLevel - pulled from the transactional update
-  //                                      (Actioned) or a single read (Unactioned)
-  //   previousLevel - snapshot at submission time, for notify copy
+  //   ownerUserId - the owner who filed the review (for notify)
+  //   articleTitle - pulled from the transactional update
+  //   previousLevel - content-derived snapshot at submission time, for notify copy
+  // The derived status (granted vs overrode-differently) is computed inside the
+  // transaction from the review's `suggestedLevel` vs `appliedLevel`.
   let articleId: number;
   let ownerUserId: number;
   let articleTitle: string;
-  let articleNsfwLevel: number;
   let previousLevel: number;
 
-  if (status === 'Actioned' && appliedLevel != null) {
-    // All reads + writes go through one transaction so two mods clicking
-    // Resolve simultaneously can't both pass the Pending check. The review
-    // row is updated with a status guard (updateMany + count === 1) so the
-    // loser of the race throws NOT_FOUND rather than double-notifying.
-    const result = await dbWrite.$transaction(async (tx) => {
-      const reviewRow = await tx.articleRatingReview.findFirst({
-        where: { id: reviewId, status: ReportStatus.Pending },
-        select: {
-          id: true,
-          articleId: true,
-          userId: true,
-          currentLevel: true,
-        },
-      });
-      if (!reviewRow) {
-        throw throwNotFoundError('Review already resolved');
-      }
+  // All reads + writes go through one transaction so two mods clicking Resolve
+  // simultaneously can't both pass the Pending check. The review row is updated
+  // with a status guard (updateMany + count === 1) so the loser of the race
+  // throws NOT_FOUND rather than double-notifying.
+  //
+  // `status` is no longer a caller input — the dashboard's Approved/Rejected
+  // buckets now mean "was the owner's suggestion granted?". We derive it from
+  // `appliedLevel === suggestedLevel`. Both branches pin the override either
+  // way (see spec: 2026-06-25-article-rating-review-single-action-design.md).
+  const result = await dbWrite.$transaction(async (tx) => {
+    const reviewRow = await tx.articleRatingReview.findFirst({
+      where: { id: reviewId, status: ReportStatus.Pending },
+      select: {
+        id: true,
+        articleId: true,
+        userId: true,
+        currentLevel: true,
+        suggestedLevel: true,
+      },
+    });
+    if (!reviewRow) {
+      throw throwNotFoundError('Review already resolved');
+    }
 
-      const claim = await tx.articleRatingReview.updateMany({
-        where: { id: reviewId, status: ReportStatus.Pending },
-        data: {
-          status: ReportStatus.Actioned,
-          resolvedAt: new Date(),
-          resolvedBy: moderatorId,
-          appliedLevel,
-          modComment,
-        },
-      });
-      if (claim.count !== 1) {
-        throw throwNotFoundError('Review already resolved');
-      }
+    const derivedStatus =
+      appliedLevel === reviewRow.suggestedLevel
+        ? ReportStatus.Actioned
+        : ReportStatus.Unactioned;
 
-      // Mirror the existing override-lock pattern in upsertArticle (see
-      // article.service.ts:1015-1022): when an override is active, pin
-      // `userNsfwLevel` so a subsequent owner save can't drift it.
-      const current = await tx.article.findUnique({
-        where: { id: reviewRow.articleId },
-        select: { lockedProperties: true },
-      });
-      const lockedSet = new Set<string>(current?.lockedProperties ?? []);
-      lockedSet.add('userNsfwLevel');
+    const claim = await tx.articleRatingReview.updateMany({
+      where: { id: reviewId, status: ReportStatus.Pending },
+      data: {
+        status: derivedStatus,
+        resolvedAt: new Date(),
+        resolvedBy: moderatorId,
+        appliedLevel,
+        modComment,
+      },
+    });
+    if (claim.count !== 1) {
+      throw throwNotFoundError('Review already resolved');
+    }
 
-      // Snapshot the content-derived level at the moment this override is set,
-      // so a later down-direction dispute can only auto-clear it if the content
-      // genuinely drops below this basis (see evaluateAutoApproveGate gate #6).
-      // A mod actioning above the images encodes judgment the scanners can't
-      // reproduce; the basis is what keeps that from being auto-erased.
-      const moderatorNsfwLevelBasis = (await computeArticleDerivedNsfwLevel(reviewRow.articleId)) ?? 0;
+    // Mirror the existing override-lock pattern in upsertArticle (see
+    // article.service.ts:1015-1022): when an override is active, pin
+    // `userNsfwLevel` so a subsequent owner save can't drift it.
+    const current = await tx.article.findUnique({
+      where: { id: reviewRow.articleId },
+      select: { lockedProperties: true },
+    });
+    const lockedSet = new Set<string>(current?.lockedProperties ?? []);
+    lockedSet.add('userNsfwLevel');
 
-      // Write `moderatorNsfwLevel` (override signal), `nsfwLevel` (effective
-      // level) and the basis snapshot in a single update. The CTE in
-      // `updateArticleNsfwLevels` resolves to COALESCE(moderatorNsfwLevel,
-      // GREATEST(...)) — so when an override is set, the effective level is
-      // always identical to the override. Writing it directly skips the
-      // full CTE recompute for the Actioned path. We still queue a search
-      // index update below for downstream consistency.
-      const updated = await tx.article.update({
-        where: { id: reviewRow.articleId },
-        data: {
-          moderatorNsfwLevel: appliedLevel,
-          moderatorNsfwLevelBasis,
-          nsfwLevel: appliedLevel,
-          lockedProperties: Array.from(lockedSet),
-        },
-        select: { id: true, title: true, nsfwLevel: true },
-      });
+    // Snapshot the content-derived level at the moment this override is set,
+    // so a later down-direction dispute can only auto-clear it if the content
+    // genuinely drops below this basis (see evaluateAutoApproveGate gate #6).
+    // A mod actioning above the images encodes judgment the scanners can't
+    // reproduce; the basis is what keeps that from being auto-erased.
+    const moderatorNsfwLevelBasis = (await computeArticleDerivedNsfwLevel(reviewRow.articleId)) ?? 0;
 
-      return {
-        articleId: reviewRow.articleId,
-        ownerUserId: reviewRow.userId,
-        previousLevel: reviewRow.currentLevel,
-        title: updated.title,
-        nsfwLevel: updated.nsfwLevel,
-      };
+    // Write `moderatorNsfwLevel` (override signal), `nsfwLevel` (effective
+    // level) and the basis snapshot in a single update. The CTE in
+    // `updateArticleNsfwLevels` resolves to COALESCE(moderatorNsfwLevel,
+    // GREATEST(...)) — so when an override is set, the effective level is
+    // always identical to the override. Writing it directly skips the
+    // full CTE recompute. We still queue a search index update below for
+    // downstream consistency.
+    const updated = await tx.article.update({
+      where: { id: reviewRow.articleId },
+      data: {
+        moderatorNsfwLevel: appliedLevel,
+        moderatorNsfwLevelBasis,
+        nsfwLevel: appliedLevel,
+        lockedProperties: Array.from(lockedSet),
+      },
+      select: { id: true, title: true },
     });
 
-    articleId = result.articleId;
-    ownerUserId = result.ownerUserId;
-    previousLevel = result.previousLevel;
-    articleTitle = result.title ?? 'your article';
-    articleNsfwLevel = result.nsfwLevel;
+    return {
+      articleId: reviewRow.articleId,
+      ownerUserId: reviewRow.userId,
+      previousLevel: reviewRow.currentLevel,
+      derivedStatus,
+      title: updated.title,
+    };
+  });
 
-    // Defense-in-depth: keep the search index in sync. Cheap and idempotent.
-    await articlesSearchIndex
-      .queueUpdate([{ id: articleId, action: SearchIndexUpdateQueueAction.Update }])
-      .catch((e) =>
-        handleLogError(e, 'article-rating-review-search-index', { articleId, reviewId })
-      );
-  } else {
-    // Unactioned: identical race-guard pattern. No article mutation.
-    const result = await dbWrite.$transaction(async (tx) => {
-      const reviewRow = await tx.articleRatingReview.findFirst({
-        where: { id: reviewId, status: ReportStatus.Pending },
-        select: {
-          id: true,
-          articleId: true,
-          userId: true,
-          currentLevel: true,
-        },
-      });
-      if (!reviewRow) {
-        throw throwNotFoundError('Review already resolved');
-      }
+  articleId = result.articleId;
+  ownerUserId = result.ownerUserId;
+  previousLevel = result.previousLevel;
+  articleTitle = result.title ?? 'your article';
+  const status = result.derivedStatus;
 
-      const claim = await tx.articleRatingReview.updateMany({
-        where: { id: reviewId, status: ReportStatus.Pending },
-        data: {
-          status: ReportStatus.Unactioned,
-          resolvedAt: new Date(),
-          resolvedBy: moderatorId,
-          modComment,
-        },
-      });
-      if (claim.count !== 1) {
-        throw throwNotFoundError('Review already resolved');
-      }
-
-      const article = await tx.article.findUnique({
-        where: { id: reviewRow.articleId },
-        select: { title: true, nsfwLevel: true },
-      });
-
-      return {
-        articleId: reviewRow.articleId,
-        ownerUserId: reviewRow.userId,
-        previousLevel: reviewRow.currentLevel,
-        title: article?.title ?? null,
-        nsfwLevel: article?.nsfwLevel ?? reviewRow.currentLevel,
-      };
-    });
-
-    articleId = result.articleId;
-    ownerUserId = result.ownerUserId;
-    previousLevel = result.previousLevel;
-    articleTitle = result.title ?? 'your article';
-    articleNsfwLevel = result.nsfwLevel;
-  }
+  // Defense-in-depth: keep the search index in sync. Cheap and idempotent.
+  await articlesSearchIndex
+    .queueUpdate([{ id: articleId, action: SearchIndexUpdateQueueAction.Update }])
+    .catch((e) => handleLogError(e, 'article-rating-review-search-index', { articleId, reviewId }));
 
   // Audit trail.
   await trackModActivity(moderatorId, {
@@ -2947,9 +2901,10 @@ export async function resolveArticleRatingReview({
 
   // --- Notify the owner ---
   const previousLevelLabel = getBrowsingLevelLabel(previousLevel);
+  const appliedLevelLabel = getBrowsingLevelLabel(appliedLevel);
 
-  if (status === 'Actioned' && appliedLevel != null) {
-    const newLevelLabel = getBrowsingLevelLabel(appliedLevel);
+  if (status === ReportStatus.Actioned) {
+    // Granted: applied level matches the owner's suggestion.
     await createNotification({
       userId: ownerUserId,
       type: 'article-rating-review-approved',
@@ -2959,7 +2914,7 @@ export async function resolveArticleRatingReview({
         articleId,
         articleTitle,
         previousLevel: previousLevelLabel,
-        newLevel: newLevelLabel,
+        newLevel: appliedLevelLabel,
         modComment: modComment ?? null,
       },
     }).catch((e) =>
@@ -2968,8 +2923,9 @@ export async function resolveArticleRatingReview({
         reviewId,
       })
     );
-  } else if (status === 'Unactioned') {
-    const currentLevelLabel = getBrowsingLevelLabel(articleNsfwLevel);
+  } else {
+    // Overrode differently: the owner's suggestion was not granted, but a level
+    // was still applied (the mod's ruling). Copy reflects the applied level.
     await createNotification({
       userId: ownerUserId,
       type: 'article-rating-review-rejected',
@@ -2978,7 +2934,7 @@ export async function resolveArticleRatingReview({
       details: {
         articleId,
         articleTitle,
-        currentLevel: currentLevelLabel,
+        appliedLevel: appliedLevelLabel,
         modComment: modComment ?? null,
       },
     }).catch((e) =>
@@ -2993,8 +2949,6 @@ export async function resolveArticleRatingReview({
     reviewId,
     status,
     articleId,
-    // null (not 0) when no level was applied — 0 collides with real bitwise
-    // slots and pollutes ClickHouse approval metrics.
-    appliedLevel: status === 'Actioned' ? appliedLevel ?? null : null,
+    appliedLevel,
   };
 }


### PR DESCRIPTION
## Problem

Mods found the article rating review card confusing: a level selector plus two buttons (**Approve** / **Reject**). When the selected level equals the system's current level, *"Approve as X"* and *"Reject"* produce the same visible rating — differing only in whether an override lock is set and which notification fires.

> *"if the user suggest PG for their R-rated article... And then I press R, I can either approve as R or reject... Both essentially do the same thing I guess? But probably send different notifications?"*

## Change

Collapse to a **single submit action**. Every resolution pins the article at the mod-selected level (override). Status + notification are **derived server-side** from selected-vs-suggested level:

- `appliedLevel === suggestedLevel` → `Actioned` (dashboard **Approved**) → *approved* notification
- `appliedLevel !== suggestedLevel` → `Unactioned` (dashboard **Rejected**) → reworded notification (*"a moderator set the rating to {level}"*)

Mod picks one level (segmented control, **no default**); Submit stays disabled until a deliberate pick. Button label derives: `Approve as {level}` when the pick matches the owner's suggestion, else `Set rating to {level}`.

Dashboard `Pending / Approved / Rejected` filters + counts keep their shape; their meaning shifts to *"was the owner's suggestion granted?"*.

## Files

| File | Change |
|------|--------|
| `src/server/schema/article.schema.ts` | `resolveArticleRatingReviewSchema`: drop `status`, require `appliedLevel`, remove refine |
| `src/server/services/article.service.ts` | one txn, **always** run the override/pin write, derive status in-txn from `suggestedLevel`, branch notification on derived status |
| `src/server/notifications/article-rating-review.notifications.ts` | reword the rejected copy — a level is now always applied |
| `src/components/Article/ArticleRatingReviewCard.tsx` | empty-default segmented control, single Submit (disabled until pick), derived label, single `handleResolve` |
| `docs/superpowers/specs/2026-06-25-article-rating-review-single-action-design.md` | design record |

Router untouched — passes the service-derived `status` / `appliedLevel` to tracking.

## Behavior shift (intended, documented)

**Reject now pins.** Previously `Unactioned` left the rating *floating* (no override). Now it sets an override + basis, so the article won't auto-lower until a moderator clears it, and a future down-direction re-dispute routes through `evaluateAutoApproveGate` gate #6 (`derived < basis`) instead of auto-approving freely on rescan. Direct consequence of "always pin".

`status` no longer implies "override exists" — both resolution paths now set the override; `status` only encodes whether the owner's suggestion was granted. (Verified the only nearby `status='Actioned'` DB predicate is on `Report`, not `ArticleRatingReview`.)

**No DB migration** — only the behavior of existing columns changes.

## Test plan

- [ ] Pending card: Submit disabled until a level is picked
- [ ] Pick == owner suggestion → button reads `Approve as X`, resolves as Approved, *approved* notification
- [ ] Pick != owner suggestion → button reads `Set rating to X`, resolves as Rejected, reworded notification with the applied level
- [ ] Article `nsfwLevel` / `moderatorNsfwLevel` pinned + `userNsfwLevel` locked after either path
- [ ] Dashboard counts/filters still bucket correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)