### PR TITLE
fix(auth): use the invisible Turnstile widget for hub login (~50% → ~99% solve)

### DIFF
--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -87,17 +87,18 @@ NEXTAUTH_SECRET=
 # (fail closed). Generate any high-entropy value, e.g. `openssl rand -hex 32`. [secret]
 AUTH_INTERNAL_TOKEN=
 
-# --- captcha (Cloudflare Turnstile, managed widget — same as the main app's email sign-in) ---
+# --- captcha (Cloudflare Turnstile, INVISIBLE widget — the frictionless key the main app uses for
+#     its high-volume flows; ~99% solve vs the managed widget's interactive challenge) ---
 # Gate the email magic-link login behind a Turnstile challenge. Set BOTH halves (they're a pair).
-# NOTE: env is per-deployment — the hub needs its own copy even though the main app already has
-# the managed widget configured.
+# NOTE: env is per-deployment — the hub needs its own copy. The sitekey's Cloudflare dashboard
+# allow-listed hostnames MUST include the hub's host (auth.civitai.com) or the widget won't load.
 #   - SECRET  ([secret], server-side): verifies the token with Cloudflare. If unset, captcha is
 #             silently DISABLED (email login runs with no challenge). Also bypassed in dev.
 #   - SITEKEY ([public-info]): rendered in the browser widget so it can produce a token. Read
 #             server-side and handed to the page via SSR, so it is NOT a PUBLIC_ var (the hub
 #             drops the main app's NEXT_PUBLIC_ prefix).
-CF_MANAGED_TURNSTILE_SECRET=
-CF_MANAGED_TURNSTILE_SITEKEY=
+CF_INVISIBLE_TURNSTILE_SECRET=
+CF_INVISIBLE_TURNSTILE_SITEKEY=
 
 # --- upstream OAuth providers (a provider's button shows only when both ID + SECRET are set) ---
 # Same credentials as the main app. Register http://localhost:5173/login/<provider>/callback

--- a/apps/auth/src/lib/server/auth/__tests__/captcha-dev.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/captcha-dev.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { isCaptchaEnabled, verifyCaptchaToken } from '../captcha';
 
 beforeEach(() => {
-  process.env.CF_MANAGED_TURNSTILE_SECRET = 's3cret'; // secret set, but dev should still disable
+  process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret'; // secret set, but dev should still disable
 });
 afterEach(() => vi.unstubAllGlobals());
 

--- a/apps/auth/src/lib/server/auth/__tests__/captcha.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/captcha.test.ts
@@ -9,8 +9,8 @@ vi.mock('$app/environment', () => ({ dev: false }));
 import { isCaptchaEnabled, captchaSiteKey, verifyCaptchaToken } from '../captcha';
 
 beforeEach(() => {
-  delete process.env.CF_MANAGED_TURNSTILE_SECRET;
-  delete process.env.CF_MANAGED_TURNSTILE_SITEKEY;
+  delete process.env.CF_INVISIBLE_TURNSTILE_SECRET;
+  delete process.env.CF_INVISIBLE_TURNSTILE_SITEKEY;
   vi.restoreAllMocks();
 });
 afterEach(() => vi.unstubAllGlobals());
@@ -20,7 +20,7 @@ describe('isCaptchaEnabled (not dev)', () => {
     expect(isCaptchaEnabled()).toBe(false);
   });
   it('enabled when the secret is set', () => {
-    process.env.CF_MANAGED_TURNSTILE_SECRET = 's3cret';
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
     expect(isCaptchaEnabled()).toBe(true);
   });
 });
@@ -28,11 +28,11 @@ describe('isCaptchaEnabled (not dev)', () => {
 describe('captchaSiteKey', () => {
   it('returns the key when set, undefined otherwise', () => {
     expect(captchaSiteKey()).toBeUndefined();
-    process.env.CF_MANAGED_TURNSTILE_SITEKEY = 'site-key';
+    process.env.CF_INVISIBLE_TURNSTILE_SITEKEY = 'site-key';
     expect(captchaSiteKey()).toBe('site-key');
   });
   it('coerces an empty-string key to undefined (no widget rendered)', () => {
-    process.env.CF_MANAGED_TURNSTILE_SITEKEY = '';
+    process.env.CF_INVISIBLE_TURNSTILE_SITEKEY = '';
     expect(captchaSiteKey()).toBeUndefined();
   });
 });
@@ -47,7 +47,7 @@ describe('verifyCaptchaToken', () => {
   });
 
   it('fails closed (false) on a missing token when enabled', async () => {
-    process.env.CF_MANAGED_TURNSTILE_SECRET = 's3cret';
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
     expect(await verifyCaptchaToken(undefined)).toBe(false);
@@ -55,7 +55,7 @@ describe('verifyCaptchaToken', () => {
   });
 
   it('returns true on a successful Cloudflare siteverify', async () => {
-    process.env.CF_MANAGED_TURNSTILE_SECRET = 's3cret';
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
     const fetchSpy = vi.fn(
       async () => new Response(JSON.stringify({ success: true }), { status: 200 })
     );
@@ -71,7 +71,7 @@ describe('verifyCaptchaToken', () => {
   });
 
   it('returns false when Cloudflare reports success:false', async () => {
-    process.env.CF_MANAGED_TURNSTILE_SECRET = 's3cret';
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response(JSON.stringify({ success: false }), { status: 200 }))
@@ -80,13 +80,13 @@ describe('verifyCaptchaToken', () => {
   });
 
   it('returns false on a non-2xx siteverify response', async () => {
-    process.env.CF_MANAGED_TURNSTILE_SECRET = 's3cret';
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
     vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })));
     expect(await verifyCaptchaToken('good-token')).toBe(false);
   });
 
   it('returns false (fail-closed) when fetch throws', async () => {
-    process.env.CF_MANAGED_TURNSTILE_SECRET = 's3cret';
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => {

--- a/apps/auth/src/lib/server/auth/captcha.ts
+++ b/apps/auth/src/lib/server/auth/captcha.ts
@@ -2,8 +2,11 @@ import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 
 // Cloudflare Turnstile verification, mirroring the main app's verifyCaptchaToken (recaptcha/client.ts).
-// Uses the managed widget — the same one the main app's email sign-in uses:
-//   CF_MANAGED_TURNSTILE_SECRET (server-side verify) + CF_MANAGED_TURNSTILE_SITEKEY (widget).
+// Uses the INVISIBLE widget (CF dashboard widget-mode = Invisible):
+//   CF_INVISIBLE_TURNSTILE_SECRET (server-side verify) + CF_INVISIBLE_TURNSTILE_SITEKEY (widget).
+// This is the same frictionless key the main app's high-volume flows use (~99% solve). The hub
+// originally used the *managed* key, which renders an interactive challenge that only ~50% of users
+// completed — breaking email login. The invisible widget runs in the background and auto-solves.
 // (The hub reads the sitekey server-side and hands it to the page via SSR, so unlike the main app
 // it doesn't need a NEXT_PUBLIC_ prefix.)
 
@@ -12,13 +15,13 @@ const SITEVERIFY = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 /** Enforced only when the secret is set AND not in dev (mirrors the main app's dev bypass). When
  *  disabled, verifyCaptchaToken passes through so local/un-configured envs aren't blocked. */
 export function isCaptchaEnabled(): boolean {
-  return !dev && !!env.CF_MANAGED_TURNSTILE_SECRET;
+  return !dev && !!env.CF_INVISIBLE_TURNSTILE_SECRET;
 }
 
 /** Public site key for the widget — server-read and handed to the page via load data (it's public
  *  by design; this just avoids a PUBLIC_ env var). Undefined → the page renders no widget. */
 export function captchaSiteKey(): string | undefined {
-  return env.CF_MANAGED_TURNSTILE_SITEKEY || undefined;
+  return env.CF_INVISIBLE_TURNSTILE_SITEKEY || undefined;
 }
 
 /** Verify a Turnstile token with Cloudflare. Returns true when captcha is disabled; false on a
@@ -30,7 +33,7 @@ export async function verifyCaptchaToken(token: string | undefined, ip?: string)
     const res = await fetch(SITEVERIFY, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ secret: env.CF_MANAGED_TURNSTILE_SECRET, response: token, remoteip: ip }),
+      body: JSON.stringify({ secret: env.CF_INVISIBLE_TURNSTILE_SECRET, response: token, remoteip: ip }),
     });
     if (!res.ok) return false;
     const outcome = (await res.json()) as { success?: boolean };

--- a/apps/auth/src/routes/login/+page.svelte
+++ b/apps/auth/src/routes/login/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { enhance } from '$app/forms';
   import { SYNC_PARAM } from '@civitai/auth/client';
   import { buildWordmarkSvg, buildBadgeSvg, getHoliday } from '@civitai/brand';
@@ -15,6 +16,18 @@
 
   // Tracks the in-flight magic-link request so the button can show a pending state.
   let submitting = $state(false);
+
+  // Turnstile uses the INVISIBLE widget (CF widget-mode = Invisible) — it runs in the background and
+  // auto-issues a token via its success callback (no interactive challenge). We track that token so
+  // the submit button can wait for it, avoiding the race where a fast user POSTs an empty
+  // `cf-turnstile-response` and the server fail-closes. `captchaUnavailable` is the safety valve:
+  // if the widget errors or never loads (CF unreachable, hostname not allow-listed, script blocked),
+  // we STOP gating and let the server-side check be the sole gate — a user must never be trapped
+  // behind a permanently-disabled button.
+  let captchaToken = $state('');
+  let captchaUnavailable = $state(false);
+  // Gate the email submit only while captcha is configured, still loading, and not known-broken.
+  const captchaPending = $derived(!!data.turnstileSiteKey && !captchaToken && !captchaUnavailable);
 
   // Framework-agnostic brand marks from @civitai/brand — no React, just SVG strings.
   const holiday = getHoliday();
@@ -38,10 +51,42 @@
 
   // Cloudflare Turnstile auto-renders any `.cf-turnstile` element once its script loads and injects
   // a hidden `cf-turnstile-response` input into the form. We reset it after each submit so a fresh
-  // (single-use) token is available for the next attempt.
+  // (single-use) token is available for the next attempt; clearing `captchaToken` re-gates the
+  // button until the invisible widget produces the new token.
   const resetTurnstile = () => {
+    captchaToken = '';
     (globalThis as unknown as { turnstile?: { reset: () => void } }).turnstile?.reset();
   };
+
+  // Wire Turnstile's data-* callbacks (it invokes the named functions on `window`). Set them up
+  // client-side only; the invisible widget calls the success callback after its background check.
+  onMount(() => {
+    const w = window as unknown as Record<string, (token?: string) => void>;
+    w.onAuthCaptcha = (token) => {
+      captchaToken = token ?? '';
+      captchaUnavailable = false;
+    };
+    w.onAuthCaptchaExpired = () => {
+      // Token is single-use / TTL-bound; clear it. The invisible widget auto-renews.
+      captchaToken = '';
+    };
+    w.onAuthCaptchaError = () => {
+      // Widget couldn't produce a token — fall back to server-side enforcement (see captchaPending).
+      captchaToken = '';
+      captchaUnavailable = true;
+    };
+    // Last-resort fail-safe: if no token has arrived in time (script blocked, CF unreachable),
+    // stop gating so the user can still submit and let the server fail-closed decide.
+    const timeout = setTimeout(() => {
+      if (!captchaToken) captchaUnavailable = true;
+    }, 8000);
+    return () => {
+      clearTimeout(timeout);
+      delete w.onAuthCaptcha;
+      delete w.onAuthCaptchaExpired;
+      delete w.onAuthCaptchaError;
+    };
+  });
 </script>
 
 <svelte:head>
@@ -133,11 +178,20 @@
             <input type="hidden" name="returnUrl" value={data.returnUrl} />
             {#if data.sync}<input type="hidden" name={SYNC_PARAM} value={data.sync} />{/if}
             {#if data.turnstileSiteKey}
-              <div class="cf-turnstile" data-sitekey={data.turnstileSiteKey} data-theme="dark"></div>
+              <!-- Invisible widget: no data-size (invisibility comes from the sitekey's CF
+                   widget-mode, not an attribute). Callbacks track the token for the submit gate. -->
+              <div
+                class="cf-turnstile"
+                data-sitekey={data.turnstileSiteKey}
+                data-callback="onAuthCaptcha"
+                data-expired-callback="onAuthCaptchaExpired"
+                data-error-callback="onAuthCaptchaError"
+                data-theme="dark"
+              ></div>
             {/if}
-            <button type="submit" class="social email" disabled={submitting}>
+            <button type="submit" class="social email" disabled={submitting || captchaPending}>
               <IconMail size={20} stroke={2} />
-              <span>{submitting ? 'Sending…' : 'Email me a login link'}</span>
+              <span>{submitting ? 'Sending…' : captchaPending ? 'Verifying…' : 'Email me a login link'}</span>
             </button>
             {#if form?.invalid}<p class="error">Enter a valid email address.</p>{/if}
             {#if form?.rateLimited}

--- a/apps/auth/src/routes/login/__tests__/login-captcha.test.ts
+++ b/apps/auth/src/routes/login/__tests__/login-captcha.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Regression guard for the 2026-06-25 Turnstile fix. The hub login moved OFF the managed widget
+// (interactive challenge, ~50% solve, broke email login) ONTO the invisible widget the main app
+// uses (~99%). Two invariants must hold in the login markup, or the fix silently regresses:
+//   1. The widget does NOT carry data-size="invisible" — invisibility is a property of the
+//      sitekey's Cloudflare widget-mode, not a div attribute (the original fix attempt set an
+//      invalid data-size and was a no-op). A stray data-size would mean someone reverted to the
+//      attribute-hack mental model.
+//   2. The widget wires the success/expired/error callbacks AND the submit button is gated on the
+//      captcha token (captchaPending). Without the gate, a fast user POSTs an empty token and the
+//      server fail-closes — the race the fix is meant to prevent.
+// The app has no Svelte component DOM harness (vitest env = node), so we assert the source markup
+// directly. The security-critical fail-closed behavior is covered in ../../lib/server/auth/__tests__/
+// captcha.test.ts; this only locks the client wiring.
+const pageSource = readFileSync(
+  fileURLToPath(new URL('../+page.svelte', import.meta.url)),
+  'utf8'
+);
+
+// Isolate the `.cf-turnstile` element (anchor on the real attribute, not the comment token).
+const widget = pageSource.match(/class="cf-turnstile"[\s\S]*?><\/div>/)?.[0] ?? '';
+
+describe('login Turnstile widget (invisible mode + token-gated submit)', () => {
+  it('renders a .cf-turnstile widget bound to the SSR sitekey', () => {
+    expect(widget, 'cf-turnstile widget element not found').not.toBe('');
+    expect(widget).toMatch(/data-sitekey=\{data\.turnstileSiteKey\}/);
+  });
+
+  it('does NOT set data-size="invisible" (invisibility comes from the CF widget-mode, not an attr)', () => {
+    expect(widget).not.toMatch(/data-size/);
+  });
+
+  it('wires the success/expired/error callbacks so the token can be tracked', () => {
+    expect(widget).toMatch(/data-callback="onAuthCaptcha"/);
+    expect(widget).toMatch(/data-expired-callback="onAuthCaptchaExpired"/);
+    expect(widget).toMatch(/data-error-callback="onAuthCaptchaError"/);
+  });
+
+  it('gates the email submit button on the captcha token (prevents empty-token race)', () => {
+    expect(pageSource).toMatch(/disabled=\{submitting \|\| captchaPending\}/);
+  });
+
+  it('has a safety valve so a broken/blocked widget cannot hard-block login', () => {
+    // captchaPending must clear when the widget is known-unavailable, falling back to server enforcement.
+    expect(pageSource).toMatch(/captchaUnavailable/);
+    expect(pageSource).toMatch(/!captchaToken && !captchaUnavailable/);
+  });
+});


### PR DESCRIPTION
## Symptom
Users reported login failing on **auth.civitai.com**. Cloudflare shows a **~50% Turnstile solve rate** on the hub vs **~99%** on the main site.

## Root cause
The hub login used the **managed** Turnstile sitekey (`CF_MANAGED_TURNSTILE_SITEKEY`), whose Cloudflare widget-mode renders an **interactive challenge**. Only ~50% of users complete it → no token → server fail-closes → login blocked. The managed key was copied into the hub's env from dp-prod by accident; nothing required it.

**Verified against `origin/release` (deployed main site):** the only managed-key render anywhere is `OnboardingBuzz.tsx:210` at `size:'normal'` (visible). The **~99%** surfaces (`BuzzPurchaseImproved`, `Paddle`) use a **different** key — `CF_INVISIBLE_TURNSTILE_SITEKEY` (`…iq5F`). The main site's login has no Turnstile at all. So the 50-vs-99 is **managed-interactive vs invisible-key**, not a rendering attribute on one key.

> Correction to the original version of this PR: it claimed the main app rendered the *same managed key* invisibly and just added `data-size="invisible"`. That was wrong (based on a stale local checkout) — `data-size="invisible"` isn't a valid Turnstile size and is a no-op on a managed-mode key. This PR was reworked after an adversarial audit caught it.

## Fix
Move the hub login onto the **invisible** widget — the proven ~99% key:
- `captcha.ts` reads `CF_INVISIBLE_TURNSTILE_{SECRET,SITEKEY}` (widget + server-verify). Comment corrected.
- The `.cf-turnstile` div drops the bogus `data-size` (invisibility is the sitekey's CF widget-mode) and wires `data-callback` / `data-expired-callback` / `data-error-callback`.
- **Client-side token gate** (the managed-visible widget had none): the submit button waits for the invisible widget's token so a fast user can't POST an empty `cf-turnstile-response` and trip the server's fail-closed check.
- The gate is **non-blocking**: on widget error / 8s load timeout it drops the gate and lets the existing **server-side fail-closed** verification be the sole gate — a CF outage or a missing host allow-list can never trap a user behind a permanently-disabled button.

## Tests
- Renamed the captcha env vars in the existing fail-closed server suite — **17 server tests pass** (incl. fail-closed-on-missing-token, success:false, non-2xx, fetch-throws, dev-bypass).
- New `login-captcha.test.ts` regression guard: invisible-by-mode (no `data-size`), callback wiring, token-gated submit, fail-safe present.
- **Ran for real** via vitest (worked around the NixOS Prisma/svelte-kit install blockers): `3 files / 17 tests passed`. The other workspace test files fail only on unbuilt-package imports (`@civitai/redis`) in my partial local install — environmental, unrelated to this change.

## Deploy dependencies (must land together)
1. **datapacket-talos**: add `CF_INVISIBLE_TURNSTILE_{SECRET,SITEKEY}` to the hub's `civitai-auth-env` secret (separate PR; both managed + invisible kept during transition so there's no fail-open window).
2. **Cloudflare dashboard**: `auth.civitai.com` must be in the `…iq5F` sitekey's allow-listed hostnames, or the widget won't load (the non-blocking gate degrades this to server-enforced, not a hard block, but the captcha would then be effectively disabled for the hub until fixed).

## Verification status (honest)
- ✅ Root cause + key identity verified against deployed `origin/release`.
- ✅ Server fail-closed suite + new guard pass under real vitest.
- ⚠️ **Not yet verified end-to-end on a deployed build** — confirm the Cloudflare solve rate climbs toward ~99% and a real login succeeds after this + the secret PR ship and the host allow-list is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)