### PR TITLE
fix(auth): preview-only legacy-session fallback so preview smoke can authenticate

### DIFF
--- a/src/server/auth/get-server-auth-session.ts
+++ b/src/server/auth/get-server-auth-session.ts
@@ -9,6 +9,7 @@ import {
   legacySessionCookieName,
 } from '@civitai/auth';
 import { env } from '~/env/server';
+import { isPreview } from '~/env/other';
 import { getBaseUrl } from '~/server/utils/url-helpers';
 import { getSessionFromBearerToken } from './bearer-token';
 import {
@@ -36,8 +37,21 @@ async function getLegacySession(req: AuthRequest): Promise<Session | null> {
   const userId = Number(claims?.sub ?? claims?.user?.id);
   if (!Number.isFinite(userId)) return null;
   const user = await sessionClient.getSessionUserById(userId);
-  if (!user) return null;
-  return { user } as Session;
+  if (user) return { user } as Session;
+  // PREVIEW-ONLY fallback. getSessionUserById resolves a user from the shared
+  // session cache then the centralized hub (auth.civitai.com) — both of which read
+  // the PRODUCTION identity store. A PR preview runs against the dev DB clone, where
+  // the ci-smoke-* smoke users are seeded (datapacket-talos seed-smoke-test-users
+  // CronJob) but the hub has no row for them, so the lookup returns null and every
+  // authenticated smoke request would loop back to /login. On a preview deploy we
+  // therefore trust the rich `user` embedded in the minted legacy cookie — exactly
+  // what the pre-cutover gate did (it read token.user straight from the cookie, no
+  // DB hit). Gated on IS_PREVIEW: production NEVER trusts the embedded user (it must
+  // resolve via the hub), so this has zero production blast radius.
+  if (isPreview && claims?.user && claims.user.id != null) {
+    return { user: claims.user } as unknown as Session;
+  }
+  return null;
 }
 
 export const getServerAuthSession = async ({

--- a/tests/preview-auth.setup.ts
+++ b/tests/preview-auth.setup.ts
@@ -15,18 +15,20 @@ import { PREVIEW_USERS, type PreviewRole, storageStatePath } from './preview-fix
  * because previews run NODE_ENV=production, which disables both the
  * `testing-login` credentials provider and the `/testing/*` route.
  *
- * Instead we mint the NextAuth session cookie directly with the preview's
- * shared NEXTAUTH_SECRET — the same `encode()` the app signs with, so JWE parity
- * is guaranteed. Two distinct things then happen, and the distinction matters:
- *   1. The GATE (preview-auth.middleware) reads `token.user` straight from the
- *      cookie (no DB hit) — so the MINTED `id`/`isModerator` are what clear it.
- *   2. SSR page renders call the session() callback → refreshToken(), which sees
- *      an untracked token id and refreshes `token.user` from the DB
- *      (getSessionUser). So past the gate, the SEEDED DB row — not the minted
- *      fields — is the authoritative session user.
- * Net: the minted cookie authenticates as the seeded user. The minted object
- * below only needs `id` + `isModerator` (+ `tier` for the gate's Flipt context);
- * the rest is informational and is superseded by the DB row on first render. The
+ * Instead we mint the LEGACY next-auth session cookie directly with the preview's
+ * shared NEXTAUTH_SECRET — the same JWE the app's `decodeLegacySessionCookie`
+ * reads, so parity is guaranteed.
+ *
+ * IMPORTANT (post first-party-OAuth cutover): `getSessionUserById` now resolves a
+ * user from the shared session cache then the centralized hub (auth.civitai.com),
+ * which read the PRODUCTION identity store — they have NO row for these dev-clone-
+ * only smoke users, so a minted cookie would resolve to a null session and every
+ * authed request would loop to /login. `get-server-auth-session.ts` therefore has a
+ * PREVIEW-ONLY fallback (gated on IS_PREVIEW) that trusts the rich `user` embedded
+ * in this minted legacy cookie when the hub lookup misses — restoring the pre-cutover
+ * "gate reads token.user straight from the cookie" behaviour for previews only.
+ * So the minted `user` object below (id + isModerator + tier + the profile fields)
+ * IS the authoritative session user on a preview. The backing User rows (and the
  * backing User rows (and the gold subscription) are seeded into cnpg-cluster-dev
  * by the datapacket-talos `seed-smoke-test-users` CronJob; ci-smoke-tester /
  * ci-smoke-gold are in the flipt `testers` allowlist so they pass the gate.

--- a/tests/preview-bootstrap.spec.ts
+++ b/tests/preview-bootstrap.spec.ts
@@ -31,10 +31,14 @@ import { storageStatePath } from './preview-fixtures';
 
 const ADDONS_PROCEDURE = 'system.getBrowsingSettingAddons';
 
-// A page that is reachable without clearing the preview gate. Anonymous traffic
-// 307s to /login, but _app.getInitialProps (and thus the SSR inject + provider
-// mount) still runs there — exactly the bootstrap path we want to probe.
-const ANON_LANDING = '/login';
+// A page that renders for anonymous traffic without clearing the preview gate, so
+// _app.getInitialProps (and thus the SSR inject + provider mount) runs — exactly
+// the bootstrap path we want to probe. Post first-party-OAuth cutover, /login is a
+// server-side REDIRECT to the hub (no in-app render), so it can't be the landing
+// anymore; /preview-restricted is the gate's other allow-listed exception
+// (resolveAuthGuard: `path !== '/preview-restricted'`) and renders via _app for
+// anyone, anonymous included.
+const ANON_LANDING = '/preview-restricted';
 
 // A core page a gate-passing user lands on directly (no /login bounce).
 const AUTHED_LANDING = '/models';

--- a/tests/preview-ssr-inject.spec.ts
+++ b/tests/preview-ssr-inject.spec.ts
@@ -50,9 +50,12 @@ const LIVE_NOW_PROCEDURE = 'system.getLiveNow';
 // /models is representative.
 const AUTHED_LANDING = '/models';
 
-// The anon home 307s to /login, but `_app` getInitialProps still runs and seeds
-// the (non-auth-gated) announcements — same rationale as preview-bootstrap.spec.
-const ANON_LANDING = '/login';
+// Post-cutover /login is a server-side redirect to the hub (no in-app render), so
+// it can't seed __NEXT_DATA__ anymore. /preview-restricted is the preview gate's
+// other allow-listed exception and renders via `_app` for anonymous traffic, so
+// getInitialProps still seeds the (non-auth-gated) announcements — same rationale
+// as preview-bootstrap.spec.
+const ANON_LANDING = '/preview-restricted';
 
 /**
  * Navigate to `path`, recording every tRPC request URL seen during the load and


### PR DESCRIPTION
## Problem
After the first-party OAuth cutover (#2712 + today's auth follow-ups), **every authenticated preview smoke test fails** with `net::ERR_TOO_MANY_REDIRECTS` (53 failed on the pr-2781..2784 previews). #2773's smoke was green earlier today, so this regressed with the cutover.

## Root cause (not a test issue)
`getSessionUserById` now resolves a user from the shared session cache → the centralized hub (`auth.civitai.com/api/auth/identity`), both backed by the **production** identity store. PR previews run against the **dev DB clone**, where the `ci-smoke-*` users are seeded (datapacket-talos `seed-smoke-test-users` CronJob) but the **hub has no row for them**. So:

1. `getLegacySession` decodes the minted legacy cookie ✓, extracts `userId` ✓
2. `getSessionUserById(userId)` → cache miss → hub 404 → **null**
3. null session → `_app` `resolveAuthGuard` 307s every page to `/login` → `auth.civitai.com` → back → **redirect loop**

The pre-cutover gate read `token.user` straight from the cookie (no DB hit), so the minted user cleared it. The cutover made resolution hub-only, and the hub can't see dev-clone smoke users.

**Production is unaffected** — verified: `civitai.com/` → 200, guarded route → clean single redirect to `auth.civitai.com/login`, no loop. Real users resolve via the hub normally.

## Fix
In `getLegacySession`, when `getSessionUserById` misses **and `IS_PREVIEW`**, fall back to the rich `user` embedded in the minted legacy cookie — restoring the pre-cutover "trust token.user on the gate" behaviour, **previews only**. Gated on `IS_PREVIEW`, so production never trusts the embedded user (must resolve via the hub) → **zero production blast radius**. Also updated the `preview-auth.setup.ts` header to document the new mechanism.

## Scope / caveat
This is a **stopgap that restores pre-cutover preview behaviour**. A cleaner long-term fix is to teach the hub/session-client a preview identity source (or seed the smoke users into the hub / the shared `session:data2` cache) — but that's an architectural call for the auth-migration owner.

## Verification
Will be validated on this PR's own preview (the smoke suite is the reproduction). Can't be exercised locally — needs a deployed preview against the dev DB + the seeded smoke users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)