### PR TITLE
feat(blocks): dev-token no-row local-manifest mint mode (Phase 4, mod-only/dark)

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -35,22 +35,22 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  * protocol to real endpoints) is the larger half and is EXPLICITLY OUT OF SCOPE
  * — documented follow-up (scope doc §5.2, Phase 2).
  *
- * ## Two resolution modes (scope doc §3.3, §4, Phase 4)
+ * ## Three resolution modes (scope doc §3.3, §4, Phase 4)
  *
  * 1. "Existing-app" mode — the dev names an app they OWN (by `appBlockId` or
  *    `slug`) that has an APPROVED `AppBlock` row. Scopes/budget are pinned to
  *    that approved snapshot + its app's OAuth ceiling, so the blast radius ≈
  *    prod and there is no escalation via an un-reviewed local manifest.
  *
- * 2. "Local-manifest" mode (NOW IMPLEMENTED — the documented Phase 4 work) —
- *    reached ONLY when no owned APPROVED row exists AND the caller passed a
- *    `slug` that matches a `AppBlockPublishRequest` with `status='pending'`
- *    that THEY submitted (`submittedByUserId === user.id`). This unblocks the
- *    `dev:live` real-Buzz path for a BRAND-NEW (pending) app — before today
- *    that 404'd because the mint required an approved row. The scope SOURCE is
- *    the pending request's UN-REVIEWED `manifest.scopes` (developer-controlled,
- *    NOT moderator-approved) — the §4 R1 escalation surface — so it is clamped
- *    by the IDENTICAL belt as the approved path WITH ONE SUBSTITUTION:
+ * 2. "Pending-app local-manifest" mode (Phase 4) — reached ONLY when no owned
+ *    APPROVED row exists AND the caller passed a `slug` that matches a
+ *    `AppBlockPublishRequest` with `status='pending'` that THEY submitted
+ *    (`submittedByUserId === user.id`). This unblocks the `dev:live` real-Buzz
+ *    path for a SUBMITTED-but-not-yet-approved app — before today that 404'd
+ *    because the mint required an approved row. The scope SOURCE is the pending
+ *    request's UN-REVIEWED `manifest.scopes` (developer-controlled, NOT
+ *    moderator-approved) — the §4 R1 escalation surface — so it is clamped by
+ *    the IDENTICAL belt as the approved path WITH ONE SUBSTITUTION:
  *      - a pending app has NO OauthClient → there is no OAuth-bitmask ceiling
  *        (step 7c). Passing `oauthAllowed: 0` into
  *        validateBlockScopesAgainstOauthClient would WRONGLY STRIP every
@@ -108,6 +108,54 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  *    row at all — returns the SAME bare `404 { message: 'App not found' }` as
  *    the approved path (never an existence/ownership/state oracle). Only a row
  *    the caller demonstrably owns surfaces an actionable message.
+ *
+ * 3. "No-row local-manifest" mode (Phase 4 — the deliberately-deferred mode,
+ *    NOW IMPLEMENTED) — reached ONLY when the caller passed a `slug`, NO
+ *    APPROVED `AppBlock` exists for that slug AT ALL (`block == null`), AND no
+ *    caller-owned pending request exists. This unblocks `dev:live` for a
+ *    BRAND-NEW app the dev has NOT yet submitted/registered — there is no server
+ *    row of any kind, so the scope SOURCE is the CLIENT-SUPPLIED request body
+ *    `scopes` (the dev's LOCAL `block.manifest.json`, sent by the CLI; entirely
+ *    un-reviewed, developer-controlled — the strongest §4 R1 escalation
+ *    surface). It is clamped by the IDENTICAL belt as the pending path: there is
+ *    NO OauthClient (OAuth-ceiling clamp OMITTED), so the §4 R1 / step-7f
+ *    bearer-credential `AIServicesWrite` SPEND CEILING is the AUTHORITATIVE
+ *    spend gate (`ai:write:budgeted` survives only if the dev's OWN key carries
+ *    AIServicesWrite). Every OTHER clamp (isKnownBlockScope, DEV_TOKEN_SCOPE_-
+ *    ALLOWLIST, PAGE_FORBIDDEN_SCOPES, force-grant `user:read:self`) and EVERY
+ *    hard cap (DEV_BUZZ_BUDGET_CAP + default, forced SFW, self-bound `sub`,
+ *    short TTL, rate limit, mod-only pre-GA) applies IDENTICALLY — it relaxes
+ *    NOTHING. Page-only by construction (dev-token mints page tokens only; no
+ *    server manifest to inspect). An empty/absent body `scopes` mints a
+ *    read-only token (no spend) — not a 404.
+ *
+ *    GUARD (NO-SHADOW — the critical new check): this mode fires ONLY when
+ *    `block == null` (no approved AppBlock for the slug exists at all). If an
+ *    APPROVED `AppBlock` for the slug EXISTS but is owned by someone else
+ *    (`block` non-null, `block.app.userId !== user.id`), the no-row path does
+ *    NOT fire — control returns the bare `404 { message: 'App not found' }`
+ *    (no ownership oracle, same as the approved/pending miss). Rationale: a dev
+ *    must NEVER mint a "local" token for a slug a real published app owns
+ *    (no shadowing / attribution confusion). A foreign-owned approved row falls
+ *    through to the pending(caller) miss → 404, and is gated OUT of the no-row
+ *    path by the `block == null` condition.
+ *
+ *    SYNTHETIC, NON-RESOLVING appId (audit S1 parity): the no-row path mints
+ *    `appId = local-<slug>`, NOT the deterministic `appblk-<slug>` an approved
+ *    app would hold. Real `OauthClient.id`s are either UUIDv4 (user-created,
+ *    oauth-client.router.ts) or `appblk-<slug>` (App-Blocks provisioned) — a
+ *    `local-` prefix can NEVER match either, so recordSpendAttribution's
+ *    `oauthClient.findUnique({ id })` MISSES → the inert skip-write path → no
+ *    forged `blockSpendAttribution` row (identical S1 protection to the
+ *    pending path's `pending-<pubreqId>`). `appBlockId` claim / `blockInstanceId`
+ *    use a synthetic `page_local_<slug>` (string-validated only; no FK resolves).
+ *
+ *    AUDIT TRAIL: as with the pending path, the no-row path has NO durable
+ *    AppBlock-backed audit rows (the synthetic appId/appBlockId don't resolve),
+ *    so the ONLY forensic trail is the structured `blocks.dev-token.local-mint`
+ *    log event (userId/slug/scopes/spendGranted), queryable in Axiom/Loki.
+ *    Same GA-gate as the pending path: durable per-spend audit rows are required
+ *    before no-row dev spend is widened past the mod-only pre-GA posture.
  *
  * ## Auth — Bearer, resolved via the same `getSessionFromBearerToken` path the
  * `/api/v1/*` REST routes use. TWO credential shapes accepted:
@@ -182,6 +230,13 @@ const RATE_LIMIT = { max: 30, windowSeconds: 60 } as const;
 
 const PAGE_INSTANCE_PREFIX = 'page_';
 
+// No-row (local-manifest) appId prefix. Real OauthClient.ids are either UUIDv4
+// (user-created, oauth-client.router.ts) or `appblk-<slug>` (App-Blocks
+// provisioned), so a `local-<slug>` appId can NEVER resolve in
+// recordSpendAttribution's `oauthClient.findUnique({ id })` — guaranteeing the
+// attribution write is skipped (audit S1 parity with the pending path).
+const LOCAL_APP_ID_PREFIX = 'local-';
+
 /**
  * The DEV scope allowlist (scope doc §4.1): read/catalog scopes + the page
  * spend scope + per-app storage. DELIBERATELY EXCLUDES:
@@ -208,9 +263,13 @@ const requestSchema = z
   .object({
     appBlockId: z.string().min(1).max(128).optional(),
     slug: z.string().min(1).max(128).optional(),
-    // OPTIONAL narrowing: a subset of the app's approved scopes the dev wants
-    // for this token. Omitted → all of the app's approved scopes (minus the
-    // dev-excluded ones).
+    // DUAL ROLE:
+    //  - approved / pending paths: OPTIONAL narrowing — a subset of the app's
+    //    approved (or pending-manifest) scopes the dev wants for this token.
+    //    Omitted → all of the app's scopes (minus the dev-excluded ones).
+    //  - NO-ROW (local-manifest) path: the SCOPE SOURCE itself (the dev's local
+    //    `block.manifest.json` scopes, sent by the CLI). Clamped by the same
+    //    belt; absent/empty → a read-only token (no spend).
     scopes: z.array(z.string().min(1).max(64)).max(32).optional(),
     // OPTIONAL dev-requested per-call Buzz budget; clamped to DEV_BUZZ_BUDGET_CAP.
     buzzBudget: z.number().int().positive().optional(),
@@ -410,6 +469,11 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // AppBlock-backed audit rows (recordSpendAttribution throws+swallows on the
   // synthetic appId; recordScopeInvocation FK-fails on the synthetic appBlockId).
   let pendingPublishRequestId: string | null = null;
+  // Set ONLY on the no-row (local-manifest, no server row) path so its structured
+  // mint-audit log (`blocks.dev-token.local-mint`) can fire — like the pending
+  // path it has NO durable AppBlock-backed audit rows (the synthetic appId /
+  // appBlockId don't resolve), so the log is the only forensic trail.
+  let localManifestSlug: string | null = null;
 
   if (block && block.app && block.app.userId === user.id) {
     // Owned approved row → existing-app mode. But an OWNED-yet-not-approved row
@@ -527,6 +591,52 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
         // publish-request id (no AppBlock.id to key on).
         blockInstanceId: `${PAGE_INSTANCE_PREFIX}pubreq_${pending.id}`,
       };
+    } else if (block == null) {
+      // 6c. NO-ROW (local-manifest) path (Phase 4 — deferred mode). Reached ONLY
+      // when: a `slug` was passed, NO approved AppBlock exists for it AT ALL
+      // (`block == null`), AND no caller-owned pending request was found. This
+      // mints a `dev:live` token for a BRAND-NEW app the dev has NOT submitted —
+      // there is no server row of any kind, so the scope SOURCE is the
+      // CLIENT-SUPPLIED body `scopes` (the dev's local manifest, sent by the CLI).
+      //
+      // GUARD (NO-SHADOW): the `block == null` condition is load-bearing. A
+      // foreign-owned APPROVED row (`block` non-null, owner !== caller) does NOT
+      // enter this branch — it falls through to the bare 404 below, so a dev can
+      // never mint a "local" token for a slug a real published app owns (no
+      // shadowing / attribution confusion). Only the genuine no-such-row case
+      // reaches here.
+      //
+      // The body scopes ARE the source (un-reviewed, developer-controlled — the
+      // strongest §4 R1 surface), clamped by the IDENTICAL belt below minus the
+      // OAuth ceiling (no OauthClient → `oauthAllowed: null`; 7f is the spend
+      // gate). Page-only by construction (no server manifest to inspect; dev-token
+      // mints page tokens only). An empty/absent body `scopes` → an empty source →
+      // a read-only token after the force-grant (not a 404).
+      localManifestSlug = slug;
+      resolved = {
+        // SCOPE SOURCE = the client-supplied body scopes. The body-narrowing step
+        // (7e) intersects `granted` with `requestedScopes`; since here the source
+        // IS `requestedScopes`, that intersection is an identity no-op (it cannot
+        // empty the set beyond what the belt already strips). Use the same array.
+        scopeSource: requestedScopes ?? [],
+        // No OauthClient → SKIP the OAuth-ceiling clamp (passing 0 would wrongly
+        // strip every non-skip scope). 7f (AIServicesWrite) is the spend gate.
+        oauthAllowed: null,
+        signBlockId: slug,
+        // SYNTHETIC, NON-RESOLVING appId (audit S1 parity). `local-<slug>` can
+        // NEVER equal a UUIDv4 user-created OauthClient.id NOR an `appblk-<slug>`
+        // App-Blocks client id, so recordSpendAttribution's
+        // `oauthClient.findUnique({ id })` MISSES → the inert skip-write path →
+        // no forged blockSpendAttribution row.
+        signAppId: `${LOCAL_APP_ID_PREFIX}${slug}`,
+        // No AppBlock.id exists — synthetic `page_local_<slug>` (string-validated
+        // only by the middleware; the best-effort BlockScopeInvocation audit-log
+        // write FK-fails on it and is silently swallowed — documented residual,
+        // identical to the pending path).
+        signAppBlockId: `page_local_${slug}`,
+        // Stable, BlockRevocation-checkable synthetic instance id.
+        blockInstanceId: `${PAGE_INSTANCE_PREFIX}local_${slug}`,
+      };
     }
   }
 
@@ -541,20 +651,23 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
 
   // 7. SCOPE CLAMP. Start from the resolved scope SOURCE — the app's APPROVED
   // snapshot (existing-app) OR the OWNED pending request's un-reviewed
-  // manifest.scopes (local-manifest, §4 R1) — then apply the IDENTICAL belt:
+  // manifest.scopes (pending local-manifest, §4 R1) OR the CLIENT-SUPPLIED body
+  // scopes (no-row local-manifest, §4 R1) — then apply the IDENTICAL belt:
   //   a) keep only KNOWN block scopes,
   //   b) keep only scopes within the DEV_TOKEN_SCOPE_ALLOWLIST (excludes
   //      social:tip:self + block:settings:*),
   //   c) keep only scopes within the app's OAuth ceiling (allowedScopes) — ONLY
-  //      for the approved path. The pending path has NO OauthClient
-  //      (`oauthAllowed === null`) → this step is OMITTED; 7f is the spend gate.
+  //      for the approved path. BOTH local-manifest paths (pending + no-row)
+  //      have NO OauthClient (`oauthAllowed === null`) → this step is OMITTED;
+  //      7f is the spend gate.
   //   d) drop the PAGE_FORBIDDEN money/spend scopes (the page hard rule),
-  //   e) if the body requested a subset, intersect with it.
+  //   e) if the body requested a subset, intersect with it (on the no-row path
+  //      the source IS the body, so this is an identity no-op).
   // Every step is a STRIP (no error) so a partially-disallowed request still
   // mints a usable, safely-clamped token. The clamp belt is byte-identical
-  // across both paths bar the OAuth-ceiling substitution — an un-reviewed
-  // manifest can never escalate past the allowlist, the page-forbidden set, or
-  // the dev's own credential (7f).
+  // across all three paths bar the OAuth-ceiling substitution — an un-reviewed
+  // manifest (server-side pending OR client-side local) can never escalate past
+  // the allowlist, the page-forbidden set, or the dev's own credential (7f).
   const forbidden = new Set<string>(PAGE_FORBIDDEN_SCOPES);
 
   let granted: string[] = resolved.scopeSource
@@ -659,12 +772,27 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       scopes: granted,
       spendGranted: granted.includes('ai:write:budgeted'),
     });
+  } else if (localManifestSlug) {
+    // NO-ROW (local-manifest) MINT AUDIT. Same rationale as the pending path:
+    // the synthetic `local-<slug>` appId / `page_local_<slug>` appBlockId don't
+    // resolve, so there are NO durable AppBlock-backed audit rows — this
+    // structured event (Axiom/Loki-queryable, NEVER the token/secret) is the only
+    // forensic trail for a no-row mint. Placed after the final clamp + budget so
+    // `scopes`/`spendGranted` reflect the actual minted outcome (7f included).
+    req.log?.info('blocks.dev-token.local-mint', {
+      mode: 'local',
+      userId: user.id,
+      slug: localManifestSlug,
+      scopes: granted,
+      spendGranted: granted.includes('ai:write:budgeted'),
+    });
   }
 
   // 9. The synthetic, revocable PAGE instance id was resolved in step 6:
   //    - approved path:  `page_<appBlockId>` (same shape as the prod page mint),
-  //    - pending path:   `page_pubreq_<publishRequestId>` (stable, unique).
-  // Both are BlockRevocation-checkable; the harness token-handling is identical.
+  //    - pending path:   `page_pubreq_<publishRequestId>` (stable, unique),
+  //    - no-row path:    `page_local_<slug>` (stable, unique per slug).
+  // All are BlockRevocation-checkable; the harness token-handling is identical.
   const blockInstanceId = resolved.blockInstanceId;
 
   // 10. PAGE ctx (entity=none, no model binding) — byte-identical shape to the

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -158,6 +158,15 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  *    Same GA-gate as the pending path: durable per-spend audit rows are required
  *    before no-row dev spend is widened past the mod-only pre-GA posture.
  *
+ *    ENUMERATION ORACLE (audit 🟡-2 — GA-gate, no code change pre-GA): the no-row
+ *    path returns a 200 read-only mint for an UNREGISTERED slug but a bare 404 for
+ *    a slug owned by a *different* account's APPROVED app (the `block == null`
+ *    guard sends a foreign-owned approved row to the bare 404, not the no-row
+ *    branch). That 200-vs-404 difference is a mod-only existence oracle for
+ *    approved-slug occupancy. Acceptable pre-GA (this endpoint is mod-gated and
+ *    approved-app slugs are already semi-public at `<slug>.civit.ai`), but
+ *    re-confirm this is tolerable before widening dev-token past moderators.
+ *
  * ## Auth — Bearer, resolved via the same `getSessionFromBearerToken` path the
  * `/api/v1/*` REST routes use. TWO credential shapes accepted:
  *  - PERSONAL API key (not cookie) → there is NO ambient credential to ride, so
@@ -263,16 +272,25 @@ const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
 const requestSchema = z
   .object({
     appBlockId: z.string().min(1).max(128).optional(),
-    // SLUG_REGEX-validated (audit N1): the no-row path builds synthetic
-    // `local-<slug>` / `page_local_<slug>` ids from this value, so a malformed
-    // slug must 400 BEFORE any lookup or synthetic-id construction. This makes
-    // the "`local-<slug>` can never collide with a real OauthClient.id"
+    // SLUG_REGEX + canonical app-slug BOUNDS (audit N1 + 🟡-1): the no-row path
+    // builds synthetic `local-<slug>` / `page_local_<slug>` ids from this value,
+    // so a malformed slug must 400 BEFORE any lookup or synthetic-id construction.
+    // This makes the "`local-<slug>` can never collide with a real OauthClient.id"
     // guarantee airtight BY CONSTRUCTION (only lowercase alnum+hyphen slugs
     // reach the constructor) rather than resting on prefix-collision reasoning.
-    // Real app slugs are SLUG_REGEX-validated at submit/create time, so every
-    // legitimate approved/pending slug already conforms — a malformed slug would
-    // only ever have 404'd anyway.
-    slug: z.string().min(1).max(128).regex(SLUG_REGEX).optional(),
+    //
+    // The bounds MATCH the canonical platform app-slug schema (publish-request
+    // .schema.ts submitVersionSchema/getMyPendingForSlugSchema/backfill —
+    // `min(3).max(40).regex(SLUG_REGEX)`), NOT a looser `min(1).max(128)`. A real
+    // approved/pending app slug is min(3).max(40) BY CONSTRUCTION (validated at
+    // submit/create time), so every legitimate slug already conforms and no
+    // approved/pending path regresses — but the lax bound would have let dev-token
+    // mint a synthetic id for a 2-char / >40-char slug NO real app could ever
+    // hold. Aligning the bounds removes that two-definitions-of-valid-slug split
+    // on this money-path endpoint. (There is no exported shared slugSchema /
+    // SLUG_MIN_LENGTH constant to reuse — publish-request.schema.ts inlines these
+    // same bounds at lines 70/116; matched inline here to mirror it.)
+    slug: z.string().min(3).max(40).regex(SLUG_REGEX).optional(),
     // DUAL ROLE:
     //  - approved / pending paths: OPTIONAL narrowing — a subset of the app's
     //    approved (or pending-manifest) scopes the dev wants for this token.

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -6,6 +6,7 @@ import * as z from 'zod';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { dbWrite } from '~/server/db/client';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
+import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { BlockTokenService } from '~/server/services/block-token.service';
 import {
@@ -262,7 +263,16 @@ const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
 const requestSchema = z
   .object({
     appBlockId: z.string().min(1).max(128).optional(),
-    slug: z.string().min(1).max(128).optional(),
+    // SLUG_REGEX-validated (audit N1): the no-row path builds synthetic
+    // `local-<slug>` / `page_local_<slug>` ids from this value, so a malformed
+    // slug must 400 BEFORE any lookup or synthetic-id construction. This makes
+    // the "`local-<slug>` can never collide with a real OauthClient.id"
+    // guarantee airtight BY CONSTRUCTION (only lowercase alnum+hyphen slugs
+    // reach the constructor) rather than resting on prefix-collision reasoning.
+    // Real app slugs are SLUG_REGEX-validated at submit/create time, so every
+    // legitimate approved/pending slug already conforms — a malformed slug would
+    // only ever have 404'd anyway.
+    slug: z.string().min(1).max(128).regex(SLUG_REGEX).optional(),
     // DUAL ROLE:
     //  - approved / pending paths: OPTIONAL narrowing — a subset of the app's
     //    approved (or pending-manifest) scopes the dev wants for this token.

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -1241,5 +1241,34 @@ describe('POST /api/v1/blocks/dev-token', () => {
       expect(mockPublishRequestFindFirst).not.toHaveBeenCalled();
       expect(mockSign).not.toHaveBeenCalled();
     });
+
+    // audit N1 (slug-regex hardening): a malformed slug that the OLD
+    // `min(1).max(128)` accepted but SLUG_REGEX rejects must 400 at body
+    // validation — BEFORE any lookup or synthetic-id construction. This makes
+    // the "`local-<slug>` can never collide with a real OauthClient.id"
+    // guarantee airtight BY CONSTRUCTION rather than by prefix-collision
+    // reasoning: a non-conforming slug never reaches the `local-<slug>`
+    // constructor at all. Real app slugs are SLUG_REGEX-validated at
+    // submit/create time, so no legitimate approved/pending slug regresses.
+    it.each([
+      ['-leading', 'leading hyphen'],
+      ['trailing-', 'trailing hyphen'],
+      ['UPPER', 'uppercase'],
+      ['BadSlug', 'mixed case'],
+      ['has space', 'whitespace'],
+      ['under_score', 'underscore'],
+      ['emoji😀', 'non-alnum'],
+    ])('400 (audit N1) for malformed slug %p (%s) — no mint, no lookup', async (slug) => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      const { req, res } = authPost({ slug, scopes: ['models:read:self'] });
+      await handler(req as never, res as never);
+      // Rejected at step-4 body validation (zod .regex), before step-5 rate
+      // limit and BOTH server lookups — and before the synthetic-id builder.
+      expect(res._getStatusCode()).toBe(400);
+      expect((res._getJSONData() as { message: string }).message).toBe('Invalid request body');
+      expect(mockAppBlockFindUnique).not.toHaveBeenCalled();
+      expect(mockPublishRequestFindFirst).not.toHaveBeenCalled();
+      expect(mockSign).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -1242,14 +1242,18 @@ describe('POST /api/v1/blocks/dev-token', () => {
       expect(mockSign).not.toHaveBeenCalled();
     });
 
-    // audit N1 (slug-regex hardening): a malformed slug that the OLD
-    // `min(1).max(128)` accepted but SLUG_REGEX rejects must 400 at body
-    // validation — BEFORE any lookup or synthetic-id construction. This makes
-    // the "`local-<slug>` can never collide with a real OauthClient.id"
-    // guarantee airtight BY CONSTRUCTION rather than by prefix-collision
-    // reasoning: a non-conforming slug never reaches the `local-<slug>`
-    // constructor at all. Real app slugs are SLUG_REGEX-validated at
-    // submit/create time, so no legitimate approved/pending slug regresses.
+    // audit N1 + 🟡-1 (slug bounds): a malformed OR out-of-bounds slug that the
+    // OLD `min(1).max(128)` accepted but the canonical `min(3).max(40).regex(
+    // SLUG_REGEX)` rejects must 400 at body validation — BEFORE any lookup or
+    // synthetic-id construction. This makes the "`local-<slug>` can never collide
+    // with a real OauthClient.id" guarantee airtight BY CONSTRUCTION rather than
+    // by prefix-collision reasoning: a non-conforming slug never reaches the
+    // `local-<slug>` constructor at all. The bounds now MATCH the canonical app-
+    // slug schema (publish-request.schema.ts min(3).max(40)) — real app slugs are
+    // min(3).max(40).regex(SLUG_REGEX) at submit/create time, so no legitimate
+    // approved/pending slug regresses; the 'ab' (2-char) and 41-char cases below
+    // pass SLUG_REGEX shape but fail the min(3)/max(40) bound a real app can't
+    // violate.
     it.each([
       ['-leading', 'leading hyphen'],
       ['trailing-', 'trailing hyphen'],
@@ -1258,7 +1262,9 @@ describe('POST /api/v1/blocks/dev-token', () => {
       ['has space', 'whitespace'],
       ['under_score', 'underscore'],
       ['emoji😀', 'non-alnum'],
-    ])('400 (audit N1) for malformed slug %p (%s) — no mint, no lookup', async (slug) => {
+      ['ab', 'too short (2 chars, < min(3))'],
+      ['a'.repeat(41), 'too long (41 chars, > max(40))'],
+    ])('400 (audit N1/🟡-1) for malformed slug %p (%s) — no mint, no lookup', async (slug) => {
       mockGetSession.mockResolvedValueOnce(MOD_SESSION);
       const { req, res } = authPost({ slug, scopes: ['models:read:self'] });
       await handler(req as never, res as never);

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -746,29 +746,36 @@ describe('POST /api/v1/blocks/dev-token', () => {
       expect(arg.scopes).not.toContain('totally:unknown:scope');
     });
 
-    it('404 (bare, no oracle) when the pending request is owned by ANOTHER user', async () => {
+    it('no oracle when a pending request is owned by ANOTHER user: the foreign pending does not match the caller query, so it falls to the NO-ROW path (mints a read-only token, identical to no-row-at-all — never reveals the foreign row)', async () => {
       mockGetSession.mockResolvedValueOnce(MOD_SESSION);
       noApprovedRow();
       // The ownership filter is in the QUERY (submittedByUserId === user.id), so a
-      // row owned by another user simply does not match → findFirst returns null.
+      // pending row owned by another user simply does not match → findFirst null.
+      // With the no-row local-manifest path live, `block == null` + no owned
+      // pending → the caller reaches the NO-ROW mint, NOT a 404. With NO body
+      // scopes the granted set is read-only (user:read:self) — INDISTINGUISHABLE
+      // from a brand-new slug, so a foreign pending row is still never an oracle.
       mockPublishRequestFindFirst.mockResolvedValueOnce(null);
       const { req, res } = authPost({ slug: 'someone-elses-app' });
       await handler(req as never, res as never);
-      expect(res._getStatusCode()).toBe(404);
-      // IDENTICAL body to the no-row-at-all case — no existence/ownership oracle.
-      expect((res._getJSONData() as { message: string }).message).toBe('App not found');
-      expect(mockSign).not.toHaveBeenCalled();
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      // Read-only (no body scopes) → no oracle: same outcome as a slug with no row.
+      expect(arg.scopes).toEqual(['user:read:self']);
+      expect(arg.appId).toBe('local-someone-elses-app');
     });
 
-    it('404 (bare) when neither an approved row NOR an owned pending request exists', async () => {
+    it('no-row mint when neither an approved row NOR an owned pending request exists (the no-row local-manifest path)', async () => {
       mockGetSession.mockResolvedValueOnce(MOD_SESSION);
       noApprovedRow();
       mockPublishRequestFindFirst.mockResolvedValueOnce(null);
       const { req, res } = authPost({ slug: 'no-such-app' });
       await handler(req as never, res as never);
-      expect(res._getStatusCode()).toBe(404);
-      expect((res._getJSONData() as { message: string }).message).toBe('App not found');
-      expect(mockSign).not.toHaveBeenCalled();
+      // `block == null` + no owned pending → no-row mint (read-only, no body scopes).
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      expect(arg.scopes).toEqual(['user:read:self']);
+      expect(arg.appId).toBe('local-no-such-app');
     });
 
     it('422 when the owned pending manifest declares NO page block', async () => {
@@ -975,6 +982,264 @@ describe('POST /api/v1/blocks/dev-token', () => {
       await handler(req as never, res as never);
       expect(res._getStatusCode()).toBe(200);
       expect(mockSign.mock.calls[0][0].scopes).toEqual(['models:read:self', 'user:read:self']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // No-row local-manifest mode (Phase 4 — deferred): mint for a BRAND-NEW app
+  // the dev has NOT submitted. NO approved AppBlock + NO owned pending request.
+  // The scope SOURCE is the CLIENT-SUPPLIED body `scopes` (the dev's local
+  // manifest, sent by the CLI), clamped by the SAME belt minus the OAuth ceiling
+  // (7f is the spend gate). Synthetic non-resolving appId `local-<slug>` so no
+  // forged attribution row. GUARDED: never fires when an approved row exists.
+  // -------------------------------------------------------------------------
+  describe('no-row local-manifest mode (brand-new, unsubmitted app)', () => {
+    // Both server lookups MUST miss so the no-row path is reached.
+    function noRow() {
+      mockAppBlockFindUnique.mockResolvedValueOnce(null); // no approved row
+      mockPublishRequestFindFirst.mockResolvedValueOnce(null); // no owned pending
+    }
+
+    it('200: no approved row + no pending + body scopes → mints from the body scopes, appId=local-<slug>, spend-capable when bearer has AIServicesWrite', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION); // personal key, Full → can spend
+      noRow();
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: ['ai:write:budgeted', 'user:read:self'],
+      });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign).toHaveBeenCalledTimes(1);
+      const arg = mockSign.mock.calls[0][0];
+      // Self-bound subject = the caller (never from the body).
+      expect(arg.userId).toBe(OWNER_ID);
+      // Granted = body.scopes ∩ allowlist ∩ (¬page-forbidden), + force-granted
+      // user:read:self. ai:write:budgeted survives (bearer has AIServicesWrite).
+      expect(arg.scopes).toContain('ai:write:budgeted');
+      expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+      // Budget defaulted + capped; forced SFW; page ctx.
+      expect(arg.buzzBudget).toBe(50);
+      expect(arg.maxBrowsingLevel).toBe(SFW);
+      expect(arg.ctx).toEqual({ slotId: 'app.page', entityType: 'none' });
+      // sign blockId = the slug; SYNTHETIC non-resolving appId; synthetic ids.
+      expect(arg.blockId).toBe('brand-new-app');
+      expect(arg.appId).toBe('local-brand-new-app');
+      expect(arg.appBlockId).toBe('page_local_brand-new-app');
+      expect(arg.blockInstanceId).toBe('page_local_brand-new-app');
+    });
+
+    it('GUARD (no-shadow): an APPROVED app for the slug owned by ANOTHER user → no-row path does NOT fire → bare 404 (NOT a local mint)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      // An approved row for the slug EXISTS but is owned by user 999, not the
+      // caller. `block != null`, so the no-row branch (gated on `block == null`)
+      // must NOT fire even though the caller passes body scopes.
+      mockAppBlockFindUnique.mockResolvedValueOnce(
+        pageApp({
+          blockId: 'owned-by-someone',
+          appId: 'appblk-owned-by-someone',
+          app: { allowedScopes: 0x1ffffff, userId: 999 },
+        })
+      );
+      // No caller-owned pending request either.
+      mockPublishRequestFindFirst.mockResolvedValueOnce(null);
+      const { req, res } = authPost({
+        slug: 'owned-by-someone',
+        scopes: ['ai:write:budgeted', 'user:read:self'],
+      });
+      await handler(req as never, res as never);
+      // Bare 404 — NOT a local mint, no shadowing of a real published app.
+      expect(res._getStatusCode()).toBe(404);
+      expect((res._getJSONData() as { message: string }).message).toBe('App not found');
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('7f on the no-row path: bearer LACKS AIServicesWrite → ai:write:budgeted STRIPPED, no budget claim', async () => {
+      mockGetSession.mockResolvedValueOnce(READONLY_MOD_SESSION); // no AIServicesWrite
+      noRow();
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: ['ai:write:budgeted', 'models:read:self', 'user:read:self'],
+      });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      // ai:write:budgeted stripped by 7f; read/catalog survive.
+      expect(arg.scopes).toEqual(['models:read:self', 'user:read:self']);
+      expect(arg.scopes).not.toContain('ai:write:budgeted');
+      expect(arg.buzzBudget).toBeUndefined();
+    });
+
+    it('R1: an un-reviewed body manifest declaring ESCALATED scopes has them STRIPPED, not minted', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noRow();
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: [
+          'models:read:self', // legit → kept
+          'social:tip:self', // dev-excluded + page-forbidden → stripped
+          'block:settings:write', // dev-excluded → stripped
+          'buzz:read:self', // page-forbidden → stripped
+          'totally:unknown', // not a known block scope → stripped
+        ],
+      });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      // Only the legit scope + force-granted user:read:self survive — proving the
+      // un-reviewed CLIENT manifest cannot escalate past the dev belt.
+      expect(arg.scopes).toEqual(['models:read:self', 'user:read:self']);
+      expect(arg.scopes).not.toContain('social:tip:self');
+      expect(arg.scopes).not.toContain('block:settings:write');
+      expect(arg.scopes).not.toContain('buzz:read:self');
+      expect(arg.scopes).not.toContain('totally:unknown');
+    });
+
+    it('200: absent body scopes → a read-only token (user:read:self only), NOT a 404', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noRow();
+      const { req, res } = authPost({ slug: 'brand-new-app' }); // no scopes
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      // Empty source → only the force-granted read scope; no spend, no budget.
+      expect(arg.scopes).toEqual(['user:read:self']);
+      expect(arg.buzzBudget).toBeUndefined();
+      expect(arg.appId).toBe('local-brand-new-app');
+    });
+
+    it('synthetic appId never equals appblk-<slug> (no real OauthClient resolves → no attribution row)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noRow();
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: ['ai:write:budgeted'],
+      });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      const arg = mockSign.mock.calls[0][0];
+      // The S1 protection: `local-<slug>` can never collide with the deterministic
+      // `appblk-<slug>` an approved app holds, so recordSpendAttribution misses.
+      expect(arg.appId).toBe('local-brand-new-app');
+      expect(arg.appId).not.toBe('appblk-brand-new-app');
+    });
+
+    it('CAPS an over-cap budget on the no-row path to DEV_BUZZ_BUDGET_CAP', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noRow();
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: ['ai:write:budgeted'],
+        buzzBudget: 100000,
+      });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      expect(mockSign.mock.calls[0][0].buzzBudget).toBe(250);
+    });
+
+    it('forced SFW + self-bound sub hold on the no-row path', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      noRow();
+      const { req, res } = authPost({ slug: 'brand-new-app', scopes: ['models:read:self'] });
+      await handler(req as never, res as never);
+      const arg = mockSign.mock.calls[0][0];
+      expect(arg.maxBrowsingLevel).toBe(SFW);
+      expect(arg.domain).toBeNull();
+      expect(arg.userId).toBe(OWNER_ID);
+    });
+
+    it('mod-only: a NON-mod is blocked BEFORE any lookup on the no-row path', async () => {
+      mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+      const { req, res } = authPost({ slug: 'brand-new-app', scopes: ['models:read:self'] });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(403);
+      expect(mockAppBlockFindUnique).not.toHaveBeenCalled();
+      expect(mockPublishRequestFindFirst).not.toHaveBeenCalled();
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('rate-limit applies to the no-row path too', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      mockMultiIncr.value = 31;
+      const { req, res } = authPost({ slug: 'brand-new-app', scopes: ['models:read:self'] });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(429);
+      expect(mockSign).not.toHaveBeenCalled();
+    });
+
+    it('emits the structured blocks.dev-token.local-mint log (spendGranted reflects the 7f clamp)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION); // Full → can spend
+      noRow();
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: ['ai:write:budgeted', 'models:read:self'],
+      });
+      await handler(req as never, res as never);
+
+      expect(res._getStatusCode()).toBe(200);
+      const log = (req as unknown as { log: { info: ReturnType<typeof vi.fn> } }).log;
+      expect(log.info).toHaveBeenCalledWith(
+        'blocks.dev-token.local-mint',
+        expect.objectContaining({
+          mode: 'local',
+          userId: OWNER_ID,
+          slug: 'brand-new-app',
+          spendGranted: true,
+        })
+      );
+      const call = log.info.mock.calls.find((c) => c[0] === 'blocks.dev-token.local-mint');
+      expect(call?.[1].scopes).toEqual([
+        'ai:write:budgeted',
+        'models:read:self',
+        'user:read:self',
+      ]);
+      // The token/secret is NEVER logged.
+      expect(JSON.stringify(call?.[1])).not.toContain('jwt.signed.value');
+      // The pending-mint event must NOT fire on the no-row path.
+      const pendingCall = log.info.mock.calls.find(
+        (c) => c[0] === 'blocks.dev-token.pending-mint'
+      );
+      expect(pendingCall).toBeUndefined();
+    });
+
+    it('the local-mint log reflects spendGranted=false when the bearer LACKS AIServicesWrite', async () => {
+      mockGetSession.mockResolvedValueOnce(READONLY_MOD_SESSION);
+      noRow();
+      const { req, res } = authPost({
+        slug: 'brand-new-app',
+        scopes: ['ai:write:budgeted'],
+      });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      const log = (req as unknown as { log: { info: ReturnType<typeof vi.fn> } }).log;
+      const call = log.info.mock.calls.find((c) => c[0] === 'blocks.dev-token.local-mint');
+      expect(call).toBeDefined();
+      expect(call?.[1].spendGranted).toBe(false);
+      expect(call?.[1].scopes).not.toContain('ai:write:budgeted');
+    });
+
+    it('the APPROVED path does NOT emit the local-mint log', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      const { req, res } = authPost({ appBlockId: 'apb_abc' });
+      await handler(req as never, res as never);
+      expect(res._getStatusCode()).toBe(200);
+      const log = (req as unknown as { log: { info: ReturnType<typeof vi.fn> } }).log;
+      const call = log.info.mock.calls.find((c) => c[0] === 'blocks.dev-token.local-mint');
+      expect(call).toBeUndefined();
+    });
+
+    it('an appBlockId-only request can NEVER reach the no-row path (it returns the bare 404)', async () => {
+      mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+      mockAppBlockFindUnique.mockResolvedValueOnce(null); // approved miss
+      const { req, res } = authPost({ appBlockId: 'apb_missing', scopes: ['ai:write:budgeted'] });
+      await handler(req as never, res as never);
+      // No slug → the `else if (slug)` branch is skipped entirely → bare 404.
+      expect(res._getStatusCode()).toBe(404);
+      expect((res._getJSONData() as { message: string }).message).toBe('App not found');
+      expect(mockPublishRequestFindFirst).not.toHaveBeenCalled();
+      expect(mockSign).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## What

Adds the deliberately-deferred **Phase 4 "no-row local-manifest" mode** to `POST /api/v1/blocks/dev-token`. A developer can now mint a `dev:live` page token for a **brand-new app that has NOT been submitted/registered yet** — there is no `AppBlock` row and no `AppBlockPublishRequest` row of any kind. The scope SOURCE is the **client-supplied request body `scopes`** (the dev's local `block.manifest.json`, sent by the CLI).

This is a **money-path** change. It is **mod-only / dark** and preserves every existing clamp and cap.

## When it fires (resolution order)

The endpoint already had two modes — **approved** (owned approved `AppBlock`) and **pending** (owned `AppBlockPublishRequest`, `status='pending'`). This adds a third, reached **only** when:

- a `slug` was passed, **and**
- **no approved `AppBlock` exists for the slug at all** (`block == null`), **and**
- **no caller-owned pending request** was found.

## GUARD (no-shadow — the critical new check)

The no-row branch is gated on **`block == null`**. If an **approved `AppBlock` for the slug exists but is owned by someone else** (`block` non-null, `block.app.userId !== user.id`), the no-row path does **NOT** fire — control returns the bare `404 { message: 'App not found' }` (no ownership oracle). A dev can never mint a "local" token for a slug a real published app owns (no shadowing / no attribution confusion). The foreign-owned-approved case falls through the pending(caller) miss → 404, and is gated out of the no-row mint by the `block == null` condition.

(A foreign-owned *pending* row simply doesn't match the caller's ownership-filtered query → `pending == null` → `block == null` → the no-row read-only mint, which is indistinguishable from a brand-new slug, so still no oracle.)

## Clamp belt + caps (identical to the pending path — relaxes nothing)

- `isKnownBlockScope` + `DEV_TOKEN_SCOPE_ALLOWLIST` + `PAGE_FORBIDDEN_SCOPES`
- **7f bearer-credential `AIServicesWrite` spend ceiling** — the authoritative spend gate here: `ai:write:budgeted` survives only if the dev's OWN key/consent carries `AIServicesWrite`.
- OAuth-ceiling clamp **OMITTED** (no `OauthClient` for an unregistered app → `oauthAllowed: null`; passing `0` would wrongly strip every non-skip scope).
- force-grant `user:read:self`
- `DEV_BUZZ_BUDGET_CAP` + default, forced SFW (`domainBrowsingCeiling(null)`), self-bound `sub` (never from body), short TTL via `BlockTokenService.sign`, the per-user rate limiter, mod-only pre-GA (`isModerator` + `isAppBlocksEnabled`).

Body scopes ARE the source, so body-narrowing (7e) is an identity no-op. Empty/absent body `scopes` → a read-only token (`user:read:self` only), **not** a 404. Page-only by construction.

## Synthetic, non-resolving appId (audit S1 parity)

`appId = local-<slug>`. Real `OauthClient.id`s are either UUIDv4 (user-created, `oauth-client.router.ts`) or `appblk-<slug>` (App-Blocks provisioned) — a `local-` prefix can **never** match either, so `recordSpendAttribution`'s `oauthClient.findUnique({ id })` **misses** → the inert skip-write path → **no forged `blockSpendAttribution` row** (the row the deferred #2605 payout rail would read). `appBlockId` claim / `blockInstanceId` = synthetic `page_local_<slug>` (string-validated only; the best-effort `BlockScopeInvocation` FK-write fails and is swallowed, same documented residual as the pending path).

## Audit trail

No durable AppBlock-backed audit rows exist (synthetic ids don't resolve), so the only forensic trail is a structured `blocks.dev-token.local-mint` `req.log` event (`userId`, `slug`, granted `scopes`, `spendGranted`) — never the token/secret. Same GA-gate as the pending path: durable per-spend rows before no-row dev spend widens past mod-only.

## CLI relationship

The `civitai` CLI sends the local `block.manifest.json` scopes in the request body; this endpoint treats them as the (un-reviewed, developer-controlled) source and clamps them down. Mirrors scope-doc §4 R1 + Phase 4.

## Tests / gates

- `src/tests/api/v1/blocks/dev-token.test.ts`: **64 vitest cases green** — a new `no-row local-manifest mode` suite (happy path, GUARD/no-shadow 404, 7f strip, R1 escalation strip, empty-scopes read-only, synthetic-appId, budget cap, forced-SFW/self-bound, mod-only, rate-limit, local-mint log on/off, appBlockId-only never reaches it) + 2 pre-existing pending-path tests updated for the new no-row behavior + all unchanged approved/pending tests.
- Typecheck: **clean** on both changed files (`tsc --noEmit`).
- No schema change / no Prisma migration.

## Not merged

Left for security audit (money path). Worktree retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
