### PR TITLE
fix(auth): harden Turnstile server-side verification (hostname + action + error-codes)

### DIFF
--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -92,6 +92,10 @@ AUTH_INTERNAL_TOKEN=
 # Gate the email magic-link login behind a Turnstile challenge. Set BOTH halves (they're a pair).
 # NOTE: env is per-deployment — the hub needs its own copy. The sitekey's Cloudflare dashboard
 # allow-listed hostnames MUST include the hub's host (auth.civitai.com) or the widget won't load.
+# Server-side verify also pins the token to this property + flow: the returned `hostname` must equal
+# ORIGIN's host (closes a cross-property replay — the main app shares this sitekey+secret) and
+# `action` must be "login" (the value the login widget tags). A hostname/action mismatch fails closed
+# and logs CF's error-codes. If ORIGIN is unset the hostname check is skipped (login still works).
 #   - SECRET  ([secret], server-side): verifies the token with Cloudflare. If unset, captcha is
 #             silently DISABLED (email login runs with no challenge). Also bypassed in dev.
 #   - SITEKEY ([public-info]): rendered in the browser widget so it can produce a token. Read

--- a/apps/auth/src/lib/server/auth/__tests__/captcha.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/captcha.test.ts
@@ -11,9 +11,23 @@ import { isCaptchaEnabled, captchaSiteKey, verifyCaptchaToken } from '../captcha
 beforeEach(() => {
   delete process.env.CF_INVISIBLE_TURNSTILE_SECRET;
   delete process.env.CF_INVISIBLE_TURNSTILE_SITEKEY;
+  delete process.env.ORIGIN;
   vi.restoreAllMocks();
 });
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.ORIGIN;
+});
+
+// Stub a single Cloudflare siteverify outcome (the JSON body CF returns).
+function stubSiteverify(outcome: Record<string, unknown>, status = 200) {
+  const fetchSpy = vi.fn(async () => new Response(JSON.stringify(outcome), { status }));
+  vi.stubGlobal('fetch', fetchSpy);
+  return fetchSpy;
+}
+
+const HUB_ORIGIN = 'https://auth.civitai.com';
+const HUB_HOST = 'auth.civitai.com';
 
 describe('isCaptchaEnabled (not dev)', () => {
   it('disabled when the secret is unset', () => {
@@ -54,12 +68,10 @@ describe('verifyCaptchaToken', () => {
     expect(fetchSpy).not.toHaveBeenCalled(); // short-circuits before the network call
   });
 
-  it('returns true on a successful Cloudflare siteverify', async () => {
+  it('returns true on success + correct hostname + correct action', async () => {
     process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
-    const fetchSpy = vi.fn(
-      async () => new Response(JSON.stringify({ success: true }), { status: 200 })
-    );
-    vi.stubGlobal('fetch', fetchSpy);
+    process.env.ORIGIN = HUB_ORIGIN;
+    const fetchSpy = stubSiteverify({ success: true, hostname: HUB_HOST, action: 'login' });
     expect(await verifyCaptchaToken('good-token', '1.2.3.4')).toBe(true);
     // sends secret + response + remoteip to the siteverify endpoint
     const [, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
@@ -70,19 +82,75 @@ describe('verifyCaptchaToken', () => {
     });
   });
 
-  it('returns false when Cloudflare reports success:false', async () => {
+  it('returns false (and logs) on a WRONG hostname — the cross-property replay gap', async () => {
     process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response(JSON.stringify({ success: false }), { status: 200 }))
+    process.env.ORIGIN = HUB_ORIGIN;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // token solved on the main app (shared sitekey+secret) reports civitai.com, not the hub host
+    stubSiteverify({ success: true, hostname: 'civitai.com', action: 'login' });
+    expect(await verifyCaptchaToken('replayed-token')).toBe(false);
+    expect(errSpy).toHaveBeenCalledWith(
+      'captcha verify rejected',
+      expect.objectContaining({ reason: 'hostname-mismatch', hostname: 'civitai.com' })
     );
+  });
+
+  it('returns false on a WRONG action', async () => {
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
+    process.env.ORIGIN = HUB_ORIGIN;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubSiteverify({ success: true, hostname: HUB_HOST, action: 'signup' });
+    expect(await verifyCaptchaToken('wrong-action-token')).toBe(false);
+  });
+
+  it('returns false on a MISSING hostname (when ORIGIN is set)', async () => {
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
+    process.env.ORIGIN = HUB_ORIGIN;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubSiteverify({ success: true, action: 'login' }); // no hostname field
+    expect(await verifyCaptchaToken('no-hostname-token')).toBe(false);
+  });
+
+  it('returns false on a MISSING action', async () => {
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
+    process.env.ORIGIN = HUB_ORIGIN;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubSiteverify({ success: true, hostname: HUB_HOST }); // no action field
+    expect(await verifyCaptchaToken('no-action-token')).toBe(false);
+  });
+
+  it('SKIPS the hostname check when ORIGIN is unset (still true on success + action)', async () => {
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
+    // ORIGIN deleted in beforeEach → expectedHostname() is undefined → hostname not enforced.
+    stubSiteverify({ success: true, hostname: 'whatever.example', action: 'login' });
+    expect(await verifyCaptchaToken('good-token')).toBe(true);
+  });
+
+  it('returns false (and logs error-codes) when Cloudflare reports success:false', async () => {
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
+    process.env.ORIGIN = HUB_ORIGIN;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubSiteverify({ success: false, 'error-codes': ['timeout-or-duplicate'] });
     expect(await verifyCaptchaToken('bad-token')).toBe(false);
+    expect(errSpy).toHaveBeenCalledWith(
+      'captcha verify rejected',
+      expect.objectContaining({
+        reason: 'siteverify-failed',
+        success: false,
+        'error-codes': ['timeout-or-duplicate'],
+      })
+    );
   });
 
   it('returns false on a non-2xx siteverify response', async () => {
     process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })));
     expect(await verifyCaptchaToken('good-token')).toBe(false);
+    expect(errSpy).toHaveBeenCalledWith(
+      'captcha verify rejected',
+      expect.objectContaining({ reason: 'siteverify-http', status: 500 })
+    );
   });
 
   it('returns false (fail-closed) when fetch throws', async () => {

--- a/apps/auth/src/lib/server/auth/captcha.ts
+++ b/apps/auth/src/lib/server/auth/captcha.ts
@@ -12,6 +12,24 @@ import { env } from '$env/dynamic/private';
 
 const SITEVERIFY = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 
+// The action the login widget tags its token with (data-action="login" on the .cf-turnstile div).
+// Client + server ship in the same image, so every real token carries this.
+const EXPECTED_ACTION = 'login';
+
+/** The hub's own hostname, derived from ORIGIN (e.g. https://auth.civitai.com → auth.civitai.com).
+ *  Used to reject tokens solved on a DIFFERENT property that shares this sitekey+secret (the main
+ *  civitai.com app uses the identical invisible key) — a narrow cross-property token replay. When
+ *  ORIGIN is unset/unparseable we return undefined and SKIP the hostname check (don't break login). */
+function expectedHostname(): string | undefined {
+  const origin = env.ORIGIN;
+  if (!origin) return undefined;
+  try {
+    return new URL(origin).hostname || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Enforced only when the secret is set AND not in dev (mirrors the main app's dev bypass). When
  *  disabled, verifyCaptchaToken passes through so local/un-configured envs aren't blocked. */
 export function isCaptchaEnabled(): boolean {
@@ -25,7 +43,14 @@ export function captchaSiteKey(): string | undefined {
 }
 
 /** Verify a Turnstile token with Cloudflare. Returns true when captcha is disabled; false on a
- *  missing/invalid token or any verification error (fail-closed when enabled). */
+ *  missing/invalid token or any verification error (fail-closed when enabled).
+ *
+ *  Beyond `outcome.success` we also pin the token to THIS property and THIS flow per CF best practice
+ *  (https://developers.cloudflare.com/turnstile/get-started/server-side-validation/):
+ *   - hostname must equal the hub's own host (closes the shared-sitekey cross-property replay gap;
+ *     skipped only when ORIGIN is unset/unparseable), and
+ *   - action must equal "login" (the value the login widget tags its token with).
+ *  Any rejection logs one structured line incl. CF's error-codes (never the token/secret). */
 export async function verifyCaptchaToken(token: string | undefined, ip?: string): Promise<boolean> {
   if (!isCaptchaEnabled()) return true;
   if (!token) return false;
@@ -35,9 +60,45 @@ export async function verifyCaptchaToken(token: string | undefined, ip?: string)
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ secret: env.CF_INVISIBLE_TURNSTILE_SECRET, response: token, remoteip: ip }),
     });
-    if (!res.ok) return false;
-    const outcome = (await res.json()) as { success?: boolean };
-    return !!outcome.success;
+    if (!res.ok) {
+      console.error('captcha verify rejected', { reason: 'siteverify-http', status: res.status });
+      return false;
+    }
+    const outcome = (await res.json()) as {
+      success?: boolean;
+      hostname?: string;
+      action?: string;
+      'error-codes'?: string[];
+    };
+
+    const logReject = (reason: string) =>
+      console.error('captcha verify rejected', {
+        reason,
+        success: !!outcome.success,
+        hostname: outcome.hostname,
+        action: outcome.action,
+        'error-codes': outcome['error-codes'],
+      });
+
+    if (!outcome.success) {
+      logReject('siteverify-failed');
+      return false;
+    }
+
+    // Pin the token to this property — a token solved on the shared-secret main app must not log in here.
+    const wantHost = expectedHostname();
+    if (wantHost && outcome.hostname !== wantHost) {
+      logReject('hostname-mismatch');
+      return false;
+    }
+
+    // Pin the token to the login flow.
+    if (outcome.action !== EXPECTED_ACTION) {
+      logReject('action-mismatch');
+      return false;
+    }
+
+    return true;
   } catch {
     return false;
   }

--- a/apps/auth/src/routes/login/+page.svelte
+++ b/apps/auth/src/routes/login/+page.svelte
@@ -193,6 +193,7 @@
               <div
                 class="cf-turnstile"
                 data-sitekey={data.turnstileSiteKey}
+                data-action="login"
                 data-callback="onAuthCaptcha"
                 data-expired-callback="onAuthCaptchaExpired"
                 data-error-callback="onAuthCaptchaError"


### PR DESCRIPTION
## Why

A Cloudflare Turnstile audit found the auth hub verified **only** `outcome.success` on siteverify. The hub shares its invisible **sitekey + secret** (`CF_INVISIBLE_TURNSTILE_SECRET`, sitekey `0x4AAAAAAAiq5FOmSBHbHiqn`) with the main civitai.com app (confirmed: identical secret).

Turnstile tokens are single-use within a ~300s window — but because the secret is shared, a token solved on **civitai.com** was accepted by the **hub login**. That's a narrow but real **cross-property replay bypass** of the login captcha gate.

CF [server-side-validation best practice](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/) is to also verify `hostname` and `action`, and to consume `error-codes`.

## The 3 changes (all in `apps/auth`, one image)

1. **Verify `hostname` (closes the replay gap).** After `success`, require `outcome.hostname === new URL(env.ORIGIN).hostname` (`auth.civitai.com`). Derived from `ORIGIN` env, **not hardcoded**. If `ORIGIN` is unset/unparseable the hostname check is skipped (login never breaks), but it's normally set.
2. **Set + verify `action`.** Client: `data-action="login"` on the `.cf-turnstile` div. Server: require `outcome.action === "login"`.
3. **Log `error-codes` + the rejection reason.** Any rejection (`success:false`, or hostname/action mismatch, or non-2xx) logs one structured `console.error('captcha verify rejected', {...})` line with `reason`, `success`, `hostname`, `action`, and CF's `error-codes`. **Never** logs the token or secret. Matches the existing `console.error` logging used in `+page.server.ts`, so it surfaces in the new `civitai-auth` Loki pipeline.

The outcome type was widened from `{ success?: boolean }` to include `hostname`, `action`, and `"error-codes"`.

### No ordering issue
Client (`+page.svelte`) and server (`captcha.ts`) deploy in the **same image**, so every real token issued after rollout carries `action=login` — there is no window where real tokens lack the action.

### Fail-closed semantics unchanged
Disabled (dev / no secret) → pass-through `true`; enabled + missing token → `false`; enabled + any error → `false`. The new hostname/action checks only run on the enabled success path.

## Tests

Updated `apps/auth/src/lib/server/auth/__tests__/captcha.test.ts`; `captcha-dev.test.ts` unchanged and green. Coverage:
- enabled + success + correct hostname + correct action → `true`
- success + **wrong** hostname → `false` (asserts the `hostname-mismatch` log — the replay case)
- success + **wrong** action → `false`
- success + **missing** hostname (ORIGIN set) → `false`
- success + **missing** action → `false`
- `success:false` with `error-codes` → `false` (asserts the logged error-codes)
- `ORIGIN` unset → hostname check skipped, still `true` on success + action
- existing cases: disabled pass-through, missing token, non-2xx (now asserts the log), fetch throws, dev bypass

**Result: 17 passed (15 `captcha.test.ts` + 2 `captcha-dev.test.ts`).**

## Rollout note

This is a **fail-closed auth path**: if Cloudflare ever returns an unexpected `hostname` or `action` for legitimate hub logins, email magic-link login would be **rejected**. Mitigations:
- The hostname check **self-disables** when `ORIGIN` is unset/unparseable.
- **OAuth providers (Discord / Google / GitHub / Reddit) are an unaffected fallback** — they don't go through the Turnstile gate.
- The new `error-codes` + `reason` logging makes any false-reject **immediately diagnosable in Loki** (`civitai-auth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
