### PR TITLE
fix(auth): tolerate empty/absent Turnstile action (unblock stale pre-deploy tabs)

### DIFF
--- a/apps/auth/src/lib/server/auth/__tests__/captcha.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/captcha.test.ts
@@ -111,12 +111,18 @@ describe('verifyCaptchaToken', () => {
     expect(await verifyCaptchaToken('no-hostname-token')).toBe(false);
   });
 
-  it('returns false on a MISSING action', async () => {
+  it('TOLERATES a MISSING action (still true) — an action-less token on the right host is a real user', async () => {
     process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
     process.env.ORIGIN = HUB_ORIGIN;
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    stubSiteverify({ success: true, hostname: HUB_HOST }); // no action field
-    expect(await verifyCaptchaToken('no-action-token')).toBe(false);
+    stubSiteverify({ success: true, hostname: HUB_HOST }); // no action field (e.g. stale pre-deploy tab)
+    expect(await verifyCaptchaToken('no-action-token')).toBe(true);
+  });
+
+  it('TOLERATES an EMPTY-string action (still true) — the exact shape stale tabs produced in prod', async () => {
+    process.env.CF_INVISIBLE_TURNSTILE_SECRET = 's3cret';
+    process.env.ORIGIN = HUB_ORIGIN;
+    stubSiteverify({ success: true, hostname: HUB_HOST, action: '' });
+    expect(await verifyCaptchaToken('empty-action-token')).toBe(true);
   });
 
   it('SKIPS the hostname check when ORIGIN is unset (still true on success + action)', async () => {

--- a/apps/auth/src/lib/server/auth/captcha.ts
+++ b/apps/auth/src/lib/server/auth/captcha.ts
@@ -92,8 +92,12 @@ export async function verifyCaptchaToken(token: string | undefined, ip?: string)
       return false;
     }
 
-    // Pin the token to the login flow.
-    if (outcome.action !== EXPECTED_ACTION) {
+    // Pin the token to the login flow — but TOLERATE an empty/absent action. The hostname check
+    // above already closes the cross-property replay gap, and auth.civitai.com hosts only the login
+    // widget, so an action-less token solved on our host (e.g. a tab loaded before data-action="login"
+    // shipped) is still a real human on our domain. Only reject a token explicitly stamped with a
+    // DIFFERENT action. (Strict `!== EXPECTED_ACTION` blocked stale pre-deploy tabs in a retry loop.)
+    if (outcome.action && outcome.action !== EXPECTED_ACTION) {
       logReject('action-mismatch');
       return false;
     }


### PR DESCRIPTION
## Symptom (live, post-deploy)
Right after #2789 (`auth-app-v0.1.5`) rolled out, the new `action === "login"` check started rejecting ~10 logins/5min — all with `hostname: auth.civitai.com` + **`action: ''`**. These are **stale tabs** loaded *before* `data-action="login"` shipped: their Turnstile widget had no action, so the token carries an empty action. And those users couldn't recover by retrying — `resetTurnstile()` re-arms the same attribute-less widget, so they looped on "Captcha verification failed" until a full page reload (OAuth login was unaffected throughout).

Verified live: the *current* page's runtime DOM **does** carry `data-action="login"` (survives hydration), so fresh loads tag tokens correctly and pass — confirming the rejections are pre-deploy tabs, not a systemic break. The hostname check was clean (`hostname-mismatch: 0`).

## Fix
Reject only a token explicitly stamped with a **different** action; tolerate empty/absent:
```diff
-    if (outcome.action !== EXPECTED_ACTION) {
+    if (outcome.action && outcome.action !== EXPECTED_ACTION) {
```
**Security impact: ~none.** The cross-property replay gap (#2789's actual purpose) is closed by the **hostname** check, which is unchanged and working. `auth.civitai.com` hosts only the login widget, so an action-less token solved on our host is a real human on our domain — there's no other legit action to confuse it with. The action check still rejects a token tagged with a genuinely different action (defense-in-depth retained for the meaningful case).

## Tests (18 pass)
- MISSING-action → now `true` (tolerated).
- EMPTY-string action (`''`, the exact prod shape) → `true`.
- WRONG action (`signup`) → still `false`.
- All hostname/error-codes/fail-closed cases unchanged.

## Rollout
Once deployed, `action-mismatch` rejections should drop to ~0 (stale-tab tokens now pass; the cross-property protection rides on hostname). I'll watch the `civitai-auth` Loki logs + the email-login-failure panel after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)