### PR TITLE
feat(generation): add Krea2 comfy raw/turbo variants with LoRA support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.2(@civitai/app-sdk@0.6.0)(react@18.3.1)
       '@civitai/client':
-        specifier: 0.2.0-beta.76
-        version: 0.2.0-beta.76
+        specifier: 0.2.0-beta.77
+        version: 0.2.0-beta.77
       '@civitai/cybertipline-tools':
         specifier: ^0.1.0
         version: 0.1.0
@@ -1452,8 +1452,8 @@ packages:
       '@civitai/app-sdk': ^0.6.0
       react: ^18.0.0 || ^19.0.0
 
-  '@civitai/client@0.2.0-beta.76':
-    resolution: {integrity: sha512-Wnd1QkDoKahPTETAHYIv9xxqdr0lylknYz1p+nk+LAbaBPwj4MaJYuRtz5LL6lu0LVTUm992hqsXD9bzIr0NQg==}
+  '@civitai/client@0.2.0-beta.77':
+    resolution: {integrity: sha512-uamvTEMVMtwvp+FJ92GEzVjxeLjke/ifqJ45T7O3pcIVfYZc62+k+4lNr6UBu4kRVX5/D4FlHhJWBli3/3A62Q==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
   '@civitai/cybertipline-tools@0.1.0':
@@ -11794,7 +11794,7 @@ snapshots:
       '@civitai/app-sdk': 0.6.0
       react: 18.3.1
 
-  '@civitai/client@0.2.0-beta.76':
+  '@civitai/client@0.2.0-beta.77':
     dependencies:
       '@hey-api/client-fetch': 0.1.14
       rfc6902: 5.2.0

--- a/src/components/generation_v2/GenerationFormProvider.tsx
+++ b/src/components/generation_v2/GenerationFormProvider.tsx
@@ -166,6 +166,7 @@ const TURBO_VARIANT_ECOSYSTEMS = new Set<string>([
   'ZImageTurbo',
   'ZImageBase',
   'Boogu',
+  'Krea2',
 ]);
 
 const storageAdapter = createLocalStorageAdapter({

--- a/src/server/services/orchestrator/ecosystems/krea2.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/krea2.handler.ts
@@ -1,21 +1,32 @@
 /**
  * Krea 2 Ecosystem Handler
  *
- * Handles Krea 2 workflows using imageGen step type (FAL engine).
- * Model is locked, no LoRA support.
+ * The Krea 2 checkpoint is locked, but its version selector splits across two
+ * engines (see krea2-graph.ts):
  *
- * The selected model version maps to the `size` tier (medium/large) the
- * orchestrator expects.
+ * - medium/large → FAL engine (Krea2FalImageGenInput). Size tiers, no LoRA;
+ *   exposes creativity + style references.
+ * - raw/turbo    → comfy engine (ComfyKrea2Raw/TurboCreateImageGenInput).
+ *   LoRA support; exposes negativePrompt + cfgScale + steps.
+ *
+ * Both paths emit a single imageGen step. The selected model version decides
+ * which branch runs: a medium/large size mapping ⇒ FAL, otherwise comfy.
  */
 
 import type {
+  ComfyKrea2RawCreateImageGenInput,
+  ComfyKrea2TurboCreateImageGenInput,
   ImageGenStepTemplate,
   Krea2FalImageGenInput,
   Krea2StyleReference,
 } from '@civitai/client';
 import { removeEmpty } from '~/utils/object-helpers';
 import type { GenerationGraphTypes } from '~/shared/data-graph/generation/generation-graph';
-import { krea2VersionIdToSize } from '~/shared/data-graph/generation/krea2-graph';
+import type { ResourceData } from '~/shared/data-graph/generation/common';
+import {
+  krea2VersionIds,
+  krea2VersionIdToSize,
+} from '~/shared/data-graph/generation/krea2-graph';
 import { defineHandler } from './handler-factory';
 
 type EcosystemGraphOutput = Extract<GenerationGraphTypes['Ctx'], { ecosystem: string }>;
@@ -23,33 +34,71 @@ type Krea2Ctx = EcosystemGraphOutput & { ecosystem: 'Krea2' };
 
 type Krea2AspectRatio = NonNullable<Krea2FalImageGenInput['aspectRatio']>;
 type Krea2Creativity = NonNullable<Krea2FalImageGenInput['creativity']>;
+type Krea2ComfyInput = ComfyKrea2RawCreateImageGenInput | ComfyKrea2TurboCreateImageGenInput;
 
-export const createKrea2Input = defineHandler<Krea2Ctx, [ImageGenStepTemplate]>((data) => {
+export const createKrea2Input = defineHandler<Krea2Ctx, [ImageGenStepTemplate]>((data, ctx) => {
   const quantity = data.quantity ?? 1;
   const size = data.model ? krea2VersionIdToSize.get(data.model.id) : undefined;
 
-  const styleRefs =
-    'styleReferences' in data && Array.isArray(data.styleReferences) ? data.styleReferences : [];
-  const imageStyleReferences: Krea2StyleReference[] = styleRefs.map((ref) => ({
-    imageUrl: ref.image.url,
-    strength: ref.strength,
-  }));
+  // FAL path — official medium/large size tiers (no LoRA).
+  if (size) {
+    const styleRefs =
+      'styleReferences' in data && Array.isArray(data.styleReferences) ? data.styleReferences : [];
+    const imageStyleReferences: Krea2StyleReference[] = styleRefs.map((ref) => ({
+      imageUrl: ref.image.url,
+      strength: ref.strength,
+    }));
+
+    return [
+      {
+        $type: 'imageGen',
+        input: removeEmpty({
+          engine: 'fal',
+          model: 'krea2',
+          operation: 'createImage',
+          prompt: data.prompt,
+          aspectRatio: data.aspectRatio?.value as Krea2AspectRatio | undefined,
+          size,
+          creativity: 'creativity' in data ? (data.creativity as Krea2Creativity) : undefined,
+          seed: data.seed,
+          quantity,
+          imageStyleReferences,
+        }) as Krea2FalImageGenInput,
+      },
+    ];
+  }
+
+  // Comfy path — raw/turbo variants (LoRA support). Sampler/scheduler are fixed
+  // (not exposed in the UI), matching the Lens comfy handler.
+  const model = data.model?.id === krea2VersionIds.turbo ? 'turbo' : 'raw';
+
+  const loras: Record<string, number> = {};
+  if ('resources' in data && Array.isArray(data.resources)) {
+    for (const resource of data.resources as ResourceData[]) {
+      loras[ctx.airs.getOrThrow(resource.id)] = resource.strength ?? 1;
+    }
+  }
 
   return [
     {
       $type: 'imageGen',
       input: removeEmpty({
-        engine: 'fal',
-        model: 'krea2',
+        engine: 'comfy',
+        ecosystem: 'krea2',
+        model,
         operation: 'createImage',
         prompt: data.prompt,
-        aspectRatio: data.aspectRatio?.value as Krea2AspectRatio | undefined,
-        size,
-        creativity: 'creativity' in data ? (data.creativity as Krea2Creativity) : undefined,
+        negativePrompt: 'negativePrompt' in data ? data.negativePrompt : undefined,
+        width: data.aspectRatio?.width,
+        height: data.aspectRatio?.height,
+        cfgScale: 'cfgScale' in data ? data.cfgScale : undefined,
+        steps: 'steps' in data ? data.steps : undefined,
+        sampler: 'euler',
+        scheduler: 'simple',
         seed: data.seed,
         quantity,
-        imageStyleReferences,
-      }) as Krea2FalImageGenInput,
+        loras: Object.keys(loras).length > 0 ? loras : undefined,
+      }) as Krea2ComfyInput,
     },
   ];
 });

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -980,8 +980,8 @@ export const ecosystemSupport: EcosystemSupport[] = [
   { ecosystemId: ECO.Ernie, supportType: 'generation', modelTypes: checkpointAndLora },
   { ecosystemId: ECO.Ernie, supportType: 'training', modelTypes: loraOnly },
 
-  // Krea 2 - checkpoint only generation (locked, no LoRA support); LoRA training via AI-Toolkit
-  { ecosystemId: ECO.Krea2, supportType: 'generation', modelTypes: checkpointOnly },
+  // Krea 2 - checkpoint locked, but base/turbo comfy variants support LoRA (medium/large FAL tiers do not); LoRA training via AI-Toolkit
+  { ecosystemId: ECO.Krea2, supportType: 'generation', modelTypes: checkpointAndLora },
   { ecosystemId: ECO.Krea2, supportType: 'training', modelTypes: loraOnly },
 
   // MAI - checkpoint only (Microsoft MAI-Image-2.5, locked, no LoRA support)

--- a/src/shared/data-graph/generation/krea2-graph.ts
+++ b/src/shared/data-graph/generation/krea2-graph.ts
@@ -1,31 +1,37 @@
 /**
  * Krea 2 Family Graph
  *
- * Controls for the Krea 2 ecosystem (Krea AI, FAL engine).
- * Model is locked; no LoRA support.
+ * Controls for the Krea 2 ecosystem. The checkpoint is locked (modelLocked), but
+ * the version selector offers four official variants that split across two
+ * engines:
  *
- * Two model versions discriminated by size (matches Krea2FalImageGenInput.size):
+ * FAL engine (Krea2FalImageGenInput) — size tiers, no LoRA:
  * - medium: lower-resolution tier
- * - large: higher-resolution tier
+ * - large:  higher-resolution tier
+ *   Controls: aspectRatio / creativity / styleReferences / seed.
  *
- * Controls per Krea2FalImageGenInput:
- * - aspectRatio: 8 fixed ratios (1:1, 4:3, 3:2, 16:9, 2.35:1, 4:5, 2:3, 9:16)
- * - creativity: raw / low / medium / high
- * - styleReferences: up to 10 reference images with per-image strength (0–1)
- * - seed
+ * Comfy engine (ComfyKrea2Raw/TurboCreateImageGenInput) — LoRA support:
+ * - raw:   full-step variant
+ * - turbo: distilled, low-step variant
+ *   Controls: aspectRatio / resources (LoRA) / negativePrompt / cfgScale / steps / seed.
  *
- * No negative prompt, no cfgScale, no steps.
+ * The selected version is mapped to a `krea2Variant` discriminator
+ * ('fal' | 'raw' | 'turbo') that swaps in the engine-appropriate controls.
  */
 
 import z from 'zod';
 import { DataGraph } from '~/libs/data-graph/data-graph';
 import type { GenerationCtx } from './context';
+import type { ResourceData } from './common';
 import {
   aspectRatioNode,
   createCheckpointGraph,
+  createResourcesGraph,
   enumNode,
+  negativePromptGraph,
   promptGraph,
   seedNode,
+  sliderNode,
   snippetsGraph,
   triggerWordsGraph,
 } from './common';
@@ -38,23 +44,47 @@ import {
 // Version Constants
 // =============================================================================
 
-/** Krea 2 version IDs */
+/**
+ * Krea 2 version IDs.
+ *
+ * medium/large are the FAL size tiers (no LoRA). raw/turbo are the comfy,
+ * LoRA-capable variants.
+ */
 export const krea2VersionIds = {
   medium: 2983023,
   large: 2983022,
+  raw: 3072329,
+  turbo: 3072332,
 } as const;
 
-export type Krea2Size = keyof typeof krea2VersionIds;
+/** FAL size tiers (the orchestrator picks output dimensions from this). */
+export type Krea2Size = 'medium' | 'large';
+
+/** Control-set discriminator derived from the selected version. */
+type Krea2Variant = 'fal' | 'raw' | 'turbo';
 
 const krea2VersionOptions = [
   { label: 'Medium', value: krea2VersionIds.medium },
   { label: 'Large', value: krea2VersionIds.large },
+  { label: 'Raw', value: krea2VersionIds.raw },
+  { label: 'Turbo', value: krea2VersionIds.turbo },
 ];
 
-/** Map version ID → size string (sent as `size` field to the orchestrator) */
+/** Map version ID → FAL size string (only the medium/large FAL tiers). */
 export const krea2VersionIdToSize = new Map<number, Krea2Size>([
   [krea2VersionIds.medium, 'medium'],
   [krea2VersionIds.large, 'large'],
+]);
+
+/**
+ * Map version ID → control-set variant. medium/large share the FAL control set;
+ * raw/turbo each get the comfy control set. Unknown IDs fall back to 'fal'.
+ */
+const krea2VersionIdToVariant = new Map<number, Krea2Variant>([
+  [krea2VersionIds.medium, 'fal'],
+  [krea2VersionIds.large, 'fal'],
+  [krea2VersionIds.raw, 'raw'],
+  [krea2VersionIds.turbo, 'turbo'],
 ]);
 
 // =============================================================================
@@ -179,10 +209,52 @@ function styleReferencesNode() {
 }
 
 // =============================================================================
+// Variant Subgraphs
+// =============================================================================
+
+/** Context shape passed to the krea2 variant subgraphs. */
+type Krea2VariantCtx = {
+  ecosystem: string;
+  workflow: string;
+  model: ResourceData;
+  krea2Variant: Krea2Variant;
+};
+
+/** FAL variant (medium/large): creativity + style references, no LoRA. */
+const falVariantGraph = new DataGraph<Krea2VariantCtx, GenerationCtx>()
+  .node('creativity', enumNode({ options: krea2CreativityOptions, defaultValue: 'medium' }))
+  .node('styleReferences', styleReferencesNode());
+
+/**
+ * Comfy raw variant (Krea 2 RAW): undistilled, full-guidance build.
+ * Defaults follow Krea's model card — ~52 steps at CFG 3.5. LoRA + negative
+ * prompt support.
+ */
+const rawVariantGraph = new DataGraph<Krea2VariantCtx, GenerationCtx>()
+  .merge(createResourcesGraph())
+  .merge(negativePromptGraph)
+  .node('cfgScale', sliderNode({ min: 1, max: 10, step: 0.5, defaultValue: 3.5 }))
+  .node('steps', sliderNode({ min: 1, max: 60, defaultValue: 52 }));
+
+/**
+ * Comfy turbo variant: 8-step distilled build. Guidance is baked into the
+ * weights, so Krea's model card runs it at CFG 0.0 / 8 steps — hence the cfg
+ * floor of 0. LoRA + negative prompt support.
+ */
+const turboVariantGraph = new DataGraph<Krea2VariantCtx, GenerationCtx>()
+  .merge(createResourcesGraph())
+  .merge(negativePromptGraph)
+  .node('cfgScale', sliderNode({ min: 0, max: 2, step: 0.1, defaultValue: 0 }))
+  .node('steps', sliderNode({ min: 1, max: 15, defaultValue: 8 }));
+
+// =============================================================================
 // Krea 2 Graph
 // =============================================================================
 
-export const krea2Graph = new DataGraph<{ ecosystem: string; workflow: string }, GenerationCtx>()
+export const krea2Graph = new DataGraph<
+  { ecosystem: string; workflow: string; model: ResourceData },
+  GenerationCtx
+>()
   .merge(
     () =>
       createCheckpointGraph({
@@ -191,9 +263,6 @@ export const krea2Graph = new DataGraph<{ ecosystem: string; workflow: string },
       }),
     []
   )
-  .merge(triggerWordsGraph)
-  .merge(snippetsGraph)
-  .merge(promptGraph)
   .node(
     'aspectRatio',
     aspectRatioNode({
@@ -202,6 +271,23 @@ export const krea2Graph = new DataGraph<{ ecosystem: string; workflow: string },
       priorityOptions: krea2PriorityRatios,
     })
   )
-  .node('creativity', enumNode({ options: krea2CreativityOptions, defaultValue: 'medium' }))
-  .node('styleReferences', styleReferencesNode())
+  // Derive the control-set variant from the selected version, then swap in the
+  // engine-appropriate controls (FAL: creativity/styleRefs; comfy: LoRA/cfg/steps).
+  .computed(
+    'krea2Variant',
+    (ctx): Krea2Variant =>
+      (ctx.model?.id ? krea2VersionIdToVariant.get(ctx.model.id) : undefined) ?? 'fal',
+    ['model']
+  )
+  .discriminator('krea2Variant', {
+    fal: falVariantGraph,
+    raw: rawVariantGraph,
+    turbo: turboVariantGraph,
+  })
+  // Prompt + triggerWords are common to all variants. negativePrompt lives in
+  // the comfy branches; its registration effect self-adds to the snippets
+  // target map when that branch is active.
+  .merge(triggerWordsGraph)
+  .merge(snippetsGraph)
+  .merge(promptGraph)
   .node('seed', seedNode());


### PR DESCRIPTION
Krea2's locked version selector now spans two engines: medium/large stay on the FAL imageGen path (creativity + style references, no LoRA), while the new raw/turbo checkpoints route through the comfy engine (ComfyKrea2Raw/TurboCreateImageGenInput) with LoRA, negative prompt, and cfg/steps controls.

- krea2-graph.ts: krea2Variant discriminator (fal/raw/turbo) swapping in engine-appropriate controls; cfg/steps defaults from Krea's model card (raw 52 steps @ 3.5, turbo 8 steps @ 0.0)
- krea2.handler.ts: branch FAL vs comfy on selected version
- basemodel.constants: Krea2 generation support checkpointOnly -> checkpointAndLora so raw/turbo surface community LoRAs
- GenerationFormProvider: scope cfgScale/steps per model.id for Krea2 so raw/turbo don't trample each other's stored values
- bump @civitai/client to 0.2.0-beta.77 (Base -> Raw type rename)