### PR TITLE
feat(account): deeplink to Add-API-Key modal with prefilled name + scope

### DIFF
--- a/src/components/Account/ApiKeyModal.tsx
+++ b/src/components/Account/ApiKeyModal.tsx
@@ -52,10 +52,13 @@ const periodOptions = [
   { value: 'month', label: 'Per 30 days' },
 ];
 
-export function ApiKeyModal({ ...props }: Props) {
+export function ApiKeyModal({ initialName, initialTokenScope, ...props }: Props) {
   const features = useFeatureFlags();
-  const [tokenScope, setTokenScope] = useState<number>(TokenScope.Full);
-  const [preset, setPreset] = useState<string | null>('Full');
+  // Optional deeplink prefill (e.g. the App Blocks CLI scaffold link). These are
+  // read once at mount; ApiKeysCard remounts the modal (via `key`) to apply them.
+  const startScope = initialTokenScope ?? TokenScope.Full;
+  const [tokenScope, setTokenScope] = useState<number>(startScope);
+  const [preset, setPreset] = useState<string | null>(getPresetKey(startScope));
   const [limitEnabled, setLimitEnabled] = useState(false);
   const [limitAmount, setLimitAmount] = useState<number | ''>(5000);
   const [limitPeriod, setLimitPeriod] = useState<'day' | 'week' | 'month'>('day');
@@ -65,8 +68,8 @@ export function ApiKeyModal({ ...props }: Props) {
     mode: 'onChange',
     shouldUnregister: false,
     defaultValues: {
-      name: '',
-      tokenScope: TokenScope.Full,
+      name: initialName ?? '',
+      tokenScope: startScope,
     },
   });
   const queryUtils = trpc.useUtils();
@@ -308,4 +311,9 @@ export function ApiKeyModal({ ...props }: Props) {
   );
 }
 
-type Props = ModalProps;
+type Props = ModalProps & {
+  /** Deeplink prefill — initial key name (defaults to empty). */
+  initialName?: string;
+  /** Deeplink prefill — initial tokenScope bitmask (defaults to TokenScope.Full). */
+  initialTokenScope?: number;
+};

--- a/src/components/Account/ApiKeysCard.tsx
+++ b/src/components/Account/ApiKeysCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useDisclosure } from '@mantine/hooks';
 import { openConfirmModal } from '@mantine/modals';
@@ -81,13 +81,20 @@ export function ApiKeysCard() {
     buzzLimit: BuzzLimit | null;
   } | null>(null);
 
+  // Latch so the deeplink is handled at most once per page load, independent of
+  // the effect's dep array. The param-strip below already prevents re-entry on
+  // the current deps, but this keeps correctness if the deps ever change (e.g. a
+  // future edit adds `router.query`, which the shallow replace would re-trigger).
+  const deeplinkHandled = useRef(false);
+
   // Deeplink: `?addApiKey=1&name=...&scope=AIServices` opens the Add-API-Key
   // modal pre-filled, then strips the params so a refresh/back doesn't re-open.
   // Prefill only — the user still reviews + clicks Generate (no silent mint).
   useEffect(() => {
-    if (!router.isReady) return;
+    if (!router.isReady || deeplinkHandled.current) return;
     const parsed = parseApiKeyDeeplink(router.query);
     if (!parsed) return;
+    deeplinkHandled.current = true;
     setPrefill(parsed);
     open();
     const nextQuery = { ...router.query };
@@ -95,7 +102,7 @@ export function ApiKeysCard() {
     void router.replace({ pathname: router.pathname, query: nextQuery }, undefined, {
       shallow: true,
     });
-    // Run once when routing is ready; the param strip prevents re-entry.
+    // Latched above; safe to run on isReady transitions.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady]);
 

--- a/src/components/Account/ApiKeysCard.tsx
+++ b/src/components/Account/ApiKeysCard.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import { useDisclosure } from '@mantine/hooks';
 import { openConfirmModal } from '@mantine/modals';
 import { trpc } from '~/utils/trpc';
@@ -27,6 +28,11 @@ import {
 } from '@tabler/icons-react';
 import { formatDate } from '~/utils/date-helpers';
 import { ApiKeyModal } from '~/components/Account/ApiKeyModal';
+import {
+  API_KEY_DEEPLINK_PARAMS,
+  parseApiKeyDeeplink,
+  type ApiKeyDeeplinkPrefill,
+} from '~/components/Account/apiKeyDeeplink';
 import { EditBuzzLimitModal } from '~/components/Account/EditBuzzLimitModal';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -62,12 +68,41 @@ export function ApiKeysCard() {
   const utils = trpc.useUtils();
   const features = useFeatureFlags();
 
-  const [opened, { toggle }] = useDisclosure(false);
+  const router = useRouter();
+  const [opened, { open, close }] = useDisclosure(false);
+  // When the modal was opened via a deeplink (e.g. the App Blocks CLI scaffold's
+  // "create an API key" link), this carries the prefilled name + scope; null for
+  // a normal manual open. Remounting the modal on this (the `key` below) lets its
+  // internal form pick up the prefill.
+  const [prefill, setPrefill] = useState<ApiKeyDeeplinkPrefill | null>(null);
   const [editLimitFor, setEditLimitFor] = useState<{
     id: number;
     name: string;
     buzzLimit: BuzzLimit | null;
   } | null>(null);
+
+  // Deeplink: `?addApiKey=1&name=...&scope=AIServices` opens the Add-API-Key
+  // modal pre-filled, then strips the params so a refresh/back doesn't re-open.
+  // Prefill only — the user still reviews + clicks Generate (no silent mint).
+  useEffect(() => {
+    if (!router.isReady) return;
+    const parsed = parseApiKeyDeeplink(router.query);
+    if (!parsed) return;
+    setPrefill(parsed);
+    open();
+    const nextQuery = { ...router.query };
+    for (const key of API_KEY_DEEPLINK_PARAMS) delete nextQuery[key];
+    void router.replace({ pathname: router.pathname, query: nextQuery }, undefined, {
+      shallow: true,
+    });
+    // Run once when routing is ready; the param strip prevents re-entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady]);
+
+  const handleCloseModal = () => {
+    close();
+    setPrefill(null);
+  };
 
   const { data: apiKeys = [], isLoading } = trpc.apiKey.getAllUserKeys.useQuery({});
   const { data: spendEntries = [] } = trpc.apiKey.getSpend.useQuery(undefined, {
@@ -108,7 +143,10 @@ export function ApiKeysCard() {
             <Button
               size="compact-sm"
               leftSection={<IconPlus size={14} stroke={1.5} />}
-              onClick={() => toggle()}
+              onClick={() => {
+                setPrefill(null);
+                open();
+              }}
             >
               Add API key
             </Button>
@@ -244,7 +282,16 @@ export function ApiKeysCard() {
           )}
         </Box>
       </Card>
-      <ApiKeyModal title="Create API Key" opened={opened} onClose={toggle} />
+      <ApiKeyModal
+        // Remount when switching between a manual open and a deeplink prefill so
+        // the modal's internal form re-initializes from initialName/scope.
+        key={prefill ? 'deeplink' : 'manual'}
+        title="Create API Key"
+        opened={opened}
+        onClose={handleCloseModal}
+        initialName={prefill?.name}
+        initialTokenScope={prefill?.tokenScope}
+      />
       {features.apiKeyBuzzLimit && editLimitFor && (
         <EditBuzzLimitModal
           opened={!!editLimitFor}

--- a/src/components/Account/apiKeyDeeplink.test.ts
+++ b/src/components/Account/apiKeyDeeplink.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { parseApiKeyDeeplink } from '~/components/Account/apiKeyDeeplink';
-import { TokenScope, TokenScopePresets } from '~/shared/constants/token-scope.constants';
+import { TokenScopePresets } from '~/shared/constants/token-scope.constants';
 
 describe('parseApiKeyDeeplink', () => {
   it('returns null without the addApiKey trigger', () => {
@@ -15,19 +15,31 @@ describe('parseApiKeyDeeplink', () => {
     ).toEqual({ name: 'App Blocks dev:live', tokenScope: TokenScopePresets.AIServices });
   });
 
-  it('falls back to Full for a missing or unknown scope (never an invalid bitmask)', () => {
+  it('falls back to the least-privilege ReadOnly preset for a missing/unknown scope', () => {
     expect(parseApiKeyDeeplink({ addApiKey: '1' })).toEqual({
       name: '',
-      tokenScope: TokenScope.Full,
+      tokenScope: TokenScopePresets.ReadOnly,
     });
     expect(parseApiKeyDeeplink({ addApiKey: '1', scope: 'Nope' })?.tokenScope).toBe(
-      TokenScope.Full
+      TokenScopePresets.ReadOnly
     );
+  });
+
+  it('NEVER pre-selects Full via a URL — a crafted scope=Full degrades to ReadOnly', () => {
+    expect(parseApiKeyDeeplink({ addApiKey: '1', scope: 'Full' })?.tokenScope).toBe(
+      TokenScopePresets.ReadOnly
+    );
+  });
+
+  it('trims + length-clamps the name to the input maxLength (64)', () => {
+    const long = 'x'.repeat(200);
+    const r = parseApiKeyDeeplink({ addApiKey: '1', name: `  ${long}  `, scope: 'AIServices' });
+    expect(r?.name).toBe('x'.repeat(64));
   });
 
   it('ignores array-valued name/scope params gracefully', () => {
     expect(
       parseApiKeyDeeplink({ addApiKey: '1', name: ['a', 'b'], scope: ['AIServices'] })
-    ).toEqual({ name: '', tokenScope: TokenScope.Full });
+    ).toEqual({ name: '', tokenScope: TokenScopePresets.ReadOnly });
   });
 });

--- a/src/components/Account/apiKeyDeeplink.test.ts
+++ b/src/components/Account/apiKeyDeeplink.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseApiKeyDeeplink } from '~/components/Account/apiKeyDeeplink';
+import { TokenScope, TokenScopePresets } from '~/shared/constants/token-scope.constants';
+
+describe('parseApiKeyDeeplink', () => {
+  it('returns null without the addApiKey trigger', () => {
+    expect(parseApiKeyDeeplink({})).toBeNull();
+    expect(parseApiKeyDeeplink({ name: 'x', scope: 'AIServices' })).toBeNull();
+  });
+
+  it('prefills the name + the AIServices preset (the minimal dev:live scope)', () => {
+    expect(
+      parseApiKeyDeeplink({ addApiKey: '1', name: 'App Blocks dev:live', scope: 'AIServices' })
+    ).toEqual({ name: 'App Blocks dev:live', tokenScope: TokenScopePresets.AIServices });
+  });
+
+  it('falls back to Full for a missing or unknown scope (never an invalid bitmask)', () => {
+    expect(parseApiKeyDeeplink({ addApiKey: '1' })).toEqual({
+      name: '',
+      tokenScope: TokenScope.Full,
+    });
+    expect(parseApiKeyDeeplink({ addApiKey: '1', scope: 'Nope' })?.tokenScope).toBe(
+      TokenScope.Full
+    );
+  });
+
+  it('ignores array-valued name/scope params gracefully', () => {
+    expect(
+      parseApiKeyDeeplink({ addApiKey: '1', name: ['a', 'b'], scope: ['AIServices'] })
+    ).toEqual({ name: '', tokenScope: TokenScope.Full });
+  });
+});

--- a/src/components/Account/apiKeyDeeplink.ts
+++ b/src/components/Account/apiKeyDeeplink.ts
@@ -1,0 +1,31 @@
+import { TokenScope, TokenScopePresets } from '~/shared/constants/token-scope.constants';
+
+export type ApiKeyDeeplinkPrefill = { name: string; tokenScope: number };
+
+/** Structural shape of Next's `router.query` (a ParsedUrlQuery) — avoids a `querystring` import. */
+type RouterQuery = Record<string, string | string[] | undefined>;
+
+/** The query keys the API-key deeplink consumes; stripped from the URL after handling. */
+export const API_KEY_DEEPLINK_PARAMS = ['addApiKey', 'name', 'scope'] as const;
+
+/**
+ * Parse the "create an API key" deeplink query into a modal prefill, or `null`
+ * when the trigger (`addApiKey`) is absent. Used so an external link (e.g. the
+ * App Blocks CLI scaffold's dev:live setup card) can open the Add-API-Key modal
+ * pre-filled with a name and the minimal scope.
+ *
+ * Security: this only PREFILLS the modal — the user still reviews the name +
+ * scope and clicks Generate, so a crafted link can never silently mint a key.
+ *
+ * - `name`: prefilled key name (empty when absent or array-valued).
+ * - `scope`: a TokenScopePresets KEY (e.g. `AIServices`). An unknown/absent/
+ *   array value falls back to `Full` — the modal's normal manual default — never
+ *   an invalid bitmask.
+ */
+export function parseApiKeyDeeplink(query: RouterQuery): ApiKeyDeeplinkPrefill | null {
+  if (query.addApiKey == null) return null;
+  const name = typeof query.name === 'string' ? query.name : '';
+  const scopeKey = typeof query.scope === 'string' ? query.scope : '';
+  const presetScope = (TokenScopePresets as Record<string, number>)[scopeKey];
+  return { name, tokenScope: presetScope ?? TokenScope.Full };
+}

--- a/src/components/Account/apiKeyDeeplink.ts
+++ b/src/components/Account/apiKeyDeeplink.ts
@@ -1,4 +1,4 @@
-import { TokenScope, TokenScopePresets } from '~/shared/constants/token-scope.constants';
+import { TokenScopePresets } from '~/shared/constants/token-scope.constants';
 
 export type ApiKeyDeeplinkPrefill = { name: string; tokenScope: number };
 
@@ -8,6 +8,21 @@ type RouterQuery = Record<string, string | string[] | undefined>;
 /** The query keys the API-key deeplink consumes; stripped from the URL after handling. */
 export const API_KEY_DEEPLINK_PARAMS = ['addApiKey', 'name', 'scope'] as const;
 
+/** Matches the Add-API-Key name input's maxLength (keep the prefill within UI bounds). */
+const DEEPLINK_NAME_MAX = 64;
+
+/**
+ * Presets a deeplink is allowed to pre-select. `Full` is intentionally EXCLUDED:
+ * a URL (which an attacker can craft and send to a logged-in user) must never
+ * pre-select the broadest grant. An unknown/absent/array/`Full` scope falls back
+ * to the least-privilege preset (`ReadOnly`), which the user can still raise in
+ * the dialog. The sanctioned scaffold link sends `scope=AIServices`, which is in
+ * this set, so the real flow is unaffected.
+ */
+const DEEPLINKABLE_PRESETS: ReadonlySet<string> = new Set(
+  Object.keys(TokenScopePresets).filter((key) => key !== 'Full')
+);
+
 /**
  * Parse the "create an API key" deeplink query into a modal prefill, or `null`
  * when the trigger (`addApiKey`) is absent. Used so an external link (e.g. the
@@ -16,16 +31,22 @@ export const API_KEY_DEEPLINK_PARAMS = ['addApiKey', 'name', 'scope'] as const;
  *
  * Security: this only PREFILLS the modal — the user still reviews the name +
  * scope and clicks Generate, so a crafted link can never silently mint a key.
+ * Defense in depth: the scope can only ever pre-select a non-`Full` preset (see
+ * {@link DEEPLINKABLE_PRESETS}), and the name is trimmed + length-clamped so a
+ * URL can't seed an over-long value past the input's maxLength.
  *
- * - `name`: prefilled key name (empty when absent or array-valued).
- * - `scope`: a TokenScopePresets KEY (e.g. `AIServices`). An unknown/absent/
- *   array value falls back to `Full` — the modal's normal manual default — never
- *   an invalid bitmask.
+ * - `name`: prefilled key name, trimmed + clamped to {@link DEEPLINK_NAME_MAX}
+ *   (empty when absent or array-valued).
+ * - `scope`: a TokenScopePresets KEY (e.g. `AIServices`). Unknown/absent/array/
+ *   `Full` → `ReadOnly` (least privilege, never an invalid bitmask, never `Full`).
  */
 export function parseApiKeyDeeplink(query: RouterQuery): ApiKeyDeeplinkPrefill | null {
   if (query.addApiKey == null) return null;
-  const name = typeof query.name === 'string' ? query.name : '';
+  const name =
+    typeof query.name === 'string' ? query.name.trim().slice(0, DEEPLINK_NAME_MAX) : '';
   const scopeKey = typeof query.scope === 'string' ? query.scope : '';
-  const presetScope = (TokenScopePresets as Record<string, number>)[scopeKey];
-  return { name, tokenScope: presetScope ?? TokenScope.Full };
+  const tokenScope = DEEPLINKABLE_PRESETS.has(scopeKey)
+    ? (TokenScopePresets as Record<string, number>)[scopeKey]
+    : TokenScopePresets.ReadOnly;
+  return { name, tokenScope };
 }

--- a/src/server/schema/api-key.schema.ts
+++ b/src/server/schema/api-key.schema.ts
@@ -118,7 +118,9 @@ export function budgetsToSimpleBuzzLimit(
 }
 
 export const addApiKeyInputSchema = z.object({
-  name: z.string(),
+  // Server-authoritative bound matching the UI input's maxLength (the name can be
+  // seeded via the account deeplink, which bypasses the input's keystroke limit).
+  name: z.string().trim().max(64),
   tokenScope: z.number().int().min(0).max(TokenScope.Full).default(TokenScope.Full),
   buzzLimit: buzzLimitSchema.nullable().optional(),
 });


### PR DESCRIPTION
## What

Adds query-param deeplinking to the **API Keys** card so an external link can open the **Add API Key** modal pre-filled with a name and the minimal scope:

```
/user/account?addApiKey=1&name=App%20Blocks%20dev%3Alive&scope=AIServices
```

The motivating consumer is the **App Blocks CLI scaffold** — its `dev:live` setup card tells devs to create a personal API key with AI Services scope. Today that's a manual hunt (find the button, guess the right permissions). This makes it one click.

## How

- **`parseApiKeyDeeplink`** (pure, unit-tested) — maps the query to a `{ name, tokenScope }` prefill. `scope` is a `TokenScopePresets` **key** (e.g. `AIServices`); an unknown/absent/array value falls back to `Full` (the modal's normal default), never an invalid bitmask.
- **`ApiKeysCard`** — on a ready route carrying the trigger, opens the modal with the prefill and **strips the params** (`router.replace`, shallow) so a refresh/back doesn't re-open. A manual open clears any prefill.
- **`ApiKeyModal`** — optional `initialName` / `initialTokenScope` props seed the name + scope (and the matching preset label); the card remounts it via `key` so a manual open still starts from `Full`.

## Security

Prefill only — the user still **reviews the name + scope and clicks Generate**, so a crafted link can never silently mint a key. `scope` can only select a named preset (or fall back to `Full`), never an arbitrary bitmask.

## Why `AIServices` is the right minimal scope

The App Blocks scaffold links with `scope=AIServices` = `UserRead | AIServicesWrite | AIServicesRead | BuzzRead`. For a **personal key**, the `dev-token` mint requires only `AIServicesWrite` (the step-7f spend gate in `blocks/dev-token.ts`); `AppBlocksSubmit` is OAuth-only and mod status is account-level — so AI Services is the minimal key that mints a spendable dev token.

## Verification

- `parseApiKeyDeeplink` unit test — 4 cases (no-trigger → null, AIServices prefill, unknown-scope → Full fallback, array-param hardening) green.
- `tsc --noEmit` shows **no errors in the changed files** (the repo's pre-existing slim-schema errors on unrelated/existing code are untouched).

Pairs with the App Blocks CLI scaffold anchor (separate `civitai/cli` PR) that links here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)