### PR TITLE
fix(lighthouse): load jose via dynamic import (jose v6 is ESM-only)

### DIFF
--- a/tests/lighthouse-mint-cookie.cjs
+++ b/tests/lighthouse-mint-cookie.cjs
@@ -25,7 +25,8 @@
  */
 const fs = require('fs');
 const path = require('path');
-const { EncryptJWT } = require('jose');
+// jose is ESM-only since v6 — require() throws ERR_REQUIRE_ESM from this .cjs,
+// so load it via dynamic import() inside main() (the only EncryptJWT consumer).
 const { hkdfSync } = require('node:crypto');
 const { v4: uuid } = require('uuid');
 
@@ -67,6 +68,8 @@ const GOLD = {
 async function main() {
   if (!SECRET) throw new Error('NEXTAUTH_SECRET is required to mint the preview cookie');
   if (!BASE_URL) throw new Error('BASE_URL is required (e.g. https://pr-123.civitaic.com)');
+
+  const { EncryptJWT } = await import('jose');
 
   const token = { user: GOLD, sub: String(GOLD.id), id: uuid(), signedAt: Date.now() };
   const value = await new EncryptJWT(token)


### PR DESCRIPTION
## Why recent PRs show "⚠️ no Lighthouse results produced"

The PR-preview Lighthouse CI mints a gate-passing preview session cookie via `tests/lighthouse-mint-cookie.cjs` before running `lhci collect`. That script does `require('jose')` at the top of a **`.cjs`** file. `jose` has been **ESM-only since v6** (the repo now pins `^6.0.11`, installed `6.0.12`), so the require throws at startup:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../jose/dist/webapi/index.js not supported.
```

Observed in the Tekton `lighthouse` task on every recent preview (e.g. PR #2796):

```
cookie mint failed — skipping
```

→ no authed cookie → `lhci collect` is skipped → the `<!-- lhci-bot -->` comment falls through to **"⚠️ no Lighthouse results produced"**. So Lighthouse CI has been silently dark since `jose` went to v6.

## Fix

Move the only consumer (`EncryptJWT`) to a **dynamic `import('jose')`** inside the async `main()` — supported from CommonJS, no file-extension/`type` change needed. One-file change.

## Verification

Ran the script locally against the installed `jose@6.0.12`:

```
$ NEXTAUTH_SECRET=… BASE_URL=https://pr-123.civitaic.com node tests/lighthouse-mint-cookie.cjs
Wrote lighthouserc.runtime.json — 4 routes x 5 runs, authed as ci-smoke-gold
```

`lighthouserc.runtime.json` is produced with the `extraHeaders` cookie present (previously it threw `ERR_REQUIRE_ESM` and wrote nothing). Report-only task; no pipeline-gating impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)