### PR TITLE
fix(500-floor): deterministic tail-error bugs (zRem/donationGoals 404/P2002 idempotent/join guard)

### DIFF
--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -862,7 +862,11 @@ export const modelVersionDonationGoalsHandler = async ({
   ctx: Context;
 }) => {
   try {
-    return modelVersionDonationGoals({
+    // `await` is load-bearing: without it the rejected promise escapes this
+    // try/catch (so a Prisma error bypassed the P2025→NOT_FOUND mapping in
+    // throwDbError and surfaced as INTERNAL_SERVER_ERROR). The service now also
+    // throws NOT_FOUND at the source, so this is belt-and-suspenders.
+    return await modelVersionDonationGoals({
       ...input,
       userId: ctx.user?.id,
       isModerator: ctx.user?.isModerator,

--- a/src/server/games/new-order/__tests__/counter-reset.test.ts
+++ b/src/server/games/new-order/__tests__/counter-reset.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression test for the prod 500-floor bug:
+//   ERR wrong number of arguments for 'zrem' command  (~6/3h)
+// createCounter().reset({ id: [] }) called ZREM/HDEL with no members, which
+// Redis rejects. An empty id array must be a no-op (resolve to 0, no redis call).
+
+const { mockRedis, mockSysRedis } = vi.hoisted(() => ({
+  mockRedis: {},
+  mockSysRedis: {
+    zRem: vi.fn().mockResolvedValue(1),
+    hDel: vi.fn().mockResolvedValue(1),
+    del: vi.fn().mockResolvedValue(1),
+  },
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: {},
+  REDIS_SYS_KEYS: {
+    NEW_ORDER: {
+      FERVOR: 'new-order:fervor',
+      SANITY_CHECKS: { FAILURES: 'new-order:sanity-check-failures' },
+      // The factory reads these at module load; supply the ones the imported
+      // counters reference plus harmless stand-ins for the rest.
+      JUDGEMENTS: { ACOLYTE_FAILED: 'new-order:acolyte-failed' },
+      EXP: 'new-order:exp',
+      BUZZ: 'new-order:blessed-buzz',
+      PENDING_BUZZ: 'new-order:pending-buzz',
+      RECENTLY_GRANTED_BUZZ: 'new-order:recently-granted-buzz',
+      SMITE: 'new-order:smite-progress',
+      QUEUES: 'new-order:queues',
+      IMAGE_RATINGS: 'new-order:image-ratings',
+    },
+  },
+}));
+
+vi.mock('~/server/redis/atomic', () => ({
+  hSetWithTTL: vi.fn(),
+  zAddWithTTL: vi.fn(),
+}));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/db/client', () => ({ dbRead: {} }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/utils/errorHandling', () => ({ handleLogError: vi.fn() }));
+
+import { fervorCounter, sanityCheckFailuresCounter } from '~/server/games/new-order/utils';
+
+describe('createCounter().reset — empty id array guard', () => {
+  beforeEach(() => {
+    mockSysRedis.zRem.mockClear();
+    mockSysRedis.hDel.mockClear();
+    mockSysRedis.del.mockClear();
+  });
+
+  it('ordered counter: reset with [] does not call zRem and resolves to 0', async () => {
+    const result = await fervorCounter.reset({ id: [] });
+    expect(mockSysRedis.zRem).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('unordered counter: reset with [] does not call hDel and resolves to 0', async () => {
+    const result = await sanityCheckFailuresCounter.reset({ id: [] });
+    expect(mockSysRedis.hDel).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('ordered counter: reset with non-empty ids still calls zRem', async () => {
+    await fervorCounter.reset({ id: [1, 2] });
+    expect(mockSysRedis.zRem).toHaveBeenCalledTimes(1);
+    expect(mockSysRedis.zRem).toHaveBeenCalledWith('new-order:fervor', ['1', '2']);
+  });
+
+  it('unordered counter: reset with non-empty ids still calls hDel', async () => {
+    await sanityCheckFailuresCounter.reset({ id: [3] });
+    expect(mockSysRedis.hDel).toHaveBeenCalledTimes(1);
+    expect(mockSysRedis.hDel).toHaveBeenCalledWith('new-order:sanity-check-failures', ['3']);
+  });
+});

--- a/src/server/games/new-order/utils.ts
+++ b/src/server/games/new-order/utils.ts
@@ -221,6 +221,10 @@ function createCounter<TId extends number | string = number | string>({
     const ids = Array.isArray(id) ? id : [id];
     const stringIds = ids.map(String);
 
+    // Redis errors with "wrong number of arguments" if ZREM/HDEL is called with
+    // no members. Empty id arrays are a valid no-op (nothing to remove).
+    if (stringIds.length === 0) return 0;
+
     return ordered ? sysRedis.zRem(key, stringIds) : sysRedis.hDel(key, stringIds);
   }
 

--- a/src/server/services/__tests__/model-version.idempotent.service.test.ts
+++ b/src/server/services/__tests__/model-version.idempotent.service.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression tests for three prod 500-floor bugs in model-version.service.ts:
+//
+//  Fix 2 — modelVersionDonationGoals: findFirstOrThrow (read→write fallback)
+//    threw P2025 when the version genuinely doesn't exist → 500. A missing
+//    version is NOT_FOUND (404).  (~10/3h)
+//
+//  Fix 4 — toggleModelVersionEngagement: a toggle racing itself hits the
+//    (userId, modelVersionId) unique constraint (P2002) on create → 500.
+//    A toggle is idempotent → treat P2002 as success.  (~3/3h)
+//
+//  Fix 5 — mergeVersions: every raw query interpolates Prisma.join(sourceVersionIds);
+//    an empty array throws "Expected join([]) ...". Guard with a 400.  (~2/3h
+//    is the generic join([]) signature; this is the in-file candidate site.)
+
+import { Prisma } from '@prisma/client';
+import { TRPCError } from '@trpc/server';
+
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
+  const mk = () => ({
+    findFirst: vi.fn(),
+    findFirstOrThrow: vi.fn(),
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+    groupBy: vi.fn(),
+    count: vi.fn(),
+  });
+  const read = {
+    modelVersion: mk(),
+    donationGoal: mk(),
+    model: mk(),
+    $queryRaw: vi.fn(),
+  };
+  const write = {
+    modelVersion: mk(),
+    modelVersionEngagement: mk(),
+    model: mk(),
+    $queryRaw: vi.fn(),
+    $transaction: vi.fn(),
+  };
+  return { mockDbRead: read, mockDbWrite: write };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, dbReadFallbackCounter: { inc: vi.fn() } };
+});
+
+// Keep the heavy service/search-index graph out of the test module graph.
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/redis/caches', () => ({}));
+vi.mock('~/server/redis/client', () => ({ REDIS_KEYS: {} }));
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({}));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/donation-goal.service', () => ({ checkDonationGoalComplete: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({
+  imagesForModelVersionsCache: {},
+  uploadImageFromUrl: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
+vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
+vi.mock('~/server/services/model.service', () => ({
+  ingestModelById: vi.fn(),
+  updateModelLastVersionAt: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({ filesForModelVersionCache: {} }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+
+import {
+  mergeVersions,
+  modelVersionDonationGoals,
+  toggleModelVersionEngagement,
+} from '~/server/services/model-version.service';
+
+const p2025 = () =>
+  new Prisma.PrismaClientKnownRequestError('not found', { code: 'P2025', clientVersion: '1' });
+const p2002 = () =>
+  new Prisma.PrismaClientKnownRequestError('unique', { code: 'P2002', clientVersion: '1' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Fix 2 — modelVersionDonationGoals → 404 when truly not found
+// ---------------------------------------------------------------------------
+describe('modelVersionDonationGoals', () => {
+  it('throws NOT_FOUND (404) when the version is missing on both read and write', async () => {
+    mockDbRead.modelVersion.findFirstOrThrow.mockRejectedValueOnce(p2025());
+    mockDbWrite.modelVersion.findFirstOrThrow.mockRejectedValueOnce(p2025());
+
+    let caught: unknown;
+    try {
+      await modelVersionDonationGoals({ id: 999 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('NOT_FOUND');
+  });
+
+  it('still falls back to the primary on a replica miss (replica-lag path preserved)', async () => {
+    mockDbRead.modelVersion.findFirstOrThrow.mockRejectedValueOnce(p2025());
+    mockDbWrite.modelVersion.findFirstOrThrow.mockResolvedValueOnce({
+      id: 1,
+      modelId: 2,
+      earlyAccessEndsAt: null,
+      model: { userId: 7 },
+    });
+    mockDbRead.donationGoal.findMany.mockResolvedValueOnce([]);
+
+    const result = await modelVersionDonationGoals({ id: 1 });
+    expect(result).toEqual([]);
+    expect(mockDbWrite.modelVersion.findFirstOrThrow).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 4 — toggleModelVersionEngagement idempotent on P2002
+// ---------------------------------------------------------------------------
+describe('toggleModelVersionEngagement', () => {
+  it('treats a P2002 create race as success (no throw)', async () => {
+    mockDbWrite.modelVersionEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDbWrite.modelVersionEngagement.create.mockRejectedValueOnce(p2002());
+
+    await expect(
+      toggleModelVersionEngagement({ userId: 1, versionId: 2, type: 'Notify' as any })
+    ).resolves.toBeUndefined();
+  });
+
+  it('rethrows non-P2002 create errors', async () => {
+    mockDbWrite.modelVersionEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDbWrite.modelVersionEngagement.create.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(
+      toggleModelVersionEngagement({ userId: 1, versionId: 2, type: 'Notify' as any })
+    ).rejects.toThrow('db down');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 5 — mergeVersions empty-array guard
+// ---------------------------------------------------------------------------
+describe('mergeVersions', () => {
+  it('throws a 400 (not a join([]) 500) when sourceVersionIds is empty', async () => {
+    mockDbRead.model.findUniqueOrThrow.mockResolvedValueOnce({
+      userId: 7,
+      modelVersions: [{ id: 100, name: 'target', description: '', status: 'Published', earlyAccessEndsAt: null, monetization: null, meta: null }],
+    });
+
+    let caught: unknown;
+    try {
+      await mergeVersions({
+        modelId: 1,
+        targetVersionId: 100,
+        sourceVersionIds: [],
+        fileTypeMappings: {} as any,
+        appendDescriptions: false,
+        userId: 7,
+      } as any);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('BAD_REQUEST');
+    // Critically: the transaction (where Prisma.join([]) would throw) is never entered.
+    expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
+++ b/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression test for the prod 500-floor bug:
+//   Invalid `prisma.resourceReview.create()` — Unique constraint failed
+//   on (modelVersionId, userId)  (~4/3h)
+// Two concurrent creates race; the loser hit the unique constraint and 500ed.
+// The create path must resolve idempotently: catch P2002, re-fetch and return
+// the already-existing review.
+
+import { Prisma } from '@prisma/client';
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    user: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    // createResourceReviewNotification (fired best-effort after the create
+    // resolves) reads modelVersion; a null result makes it log+return cleanly.
+    modelVersion: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    imageResourceNew: { count: vi.fn(async (..._a: unknown[]): Promise<number> => 0) },
+    resourceReview: {
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      findUniqueOrThrow: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/db/db-lag-helpers', () => ({ getDbWithoutLag: vi.fn(async () => mockDb) }));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/resourceReview.cache', () => ({
+  bustRatingTotalsCache: vi.fn(async () => undefined),
+  bustRatingTotalsForRows: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+// createResourceReviewNotification reaches for modelVersion data; stub the
+// notification side-channel inputs so it no-ops cleanly.
+vi.mock('~/server/services/user-preferences.service', () => ({
+  BlockedByUsers: { getCached: vi.fn(async () => []) },
+  BlockedUsers: { getCached: vi.fn(async () => []) },
+  HiddenUsers: { getCached: vi.fn(async () => []) },
+}));
+vi.mock('~/server/services/user.service', () => ({
+  amIBlockedByUser: vi.fn(async () => false),
+  getBasicDataForUsers: vi.fn(async () => new Map()),
+  getCosmeticsForUsers: vi.fn(async () => ({})),
+  getProfilePicturesForUsers: vi.fn(async () => ({})),
+}));
+
+import { createResourceReview, upsertResourceReview } from '~/server/services/resourceReview.service';
+
+const p2002 = () =>
+  new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: '1',
+    meta: { target: ['modelVersionId', 'userId'] },
+  });
+
+const baseInput = {
+  modelId: 10,
+  modelVersionId: 20,
+  rating: 5,
+  recommended: true,
+  details: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.user.findFirst.mockResolvedValue({ username: 'tester' });
+});
+
+describe('createResourceReview — idempotent on P2002 race', () => {
+  it('returns the existing review when the unique constraint trips', async () => {
+    const existing = { id: 7, modelId: 10, modelVersionId: 20, recommended: true };
+    mockDb.resourceReview.create.mockRejectedValueOnce(p2002());
+    mockDb.resourceReview.findUniqueOrThrow.mockResolvedValueOnce(existing);
+
+    const result = await createResourceReview({ ...baseInput, userId: 42 });
+
+    expect(result).toBe(existing);
+    expect(mockDb.resourceReview.findUniqueOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { modelVersionId_userId: { modelVersionId: 20, userId: 42 } },
+      })
+    );
+  });
+
+  it('rethrows non-P2002 errors', async () => {
+    mockDb.resourceReview.create.mockRejectedValueOnce(new Error('boom'));
+    await expect(createResourceReview({ ...baseInput, userId: 42 })).rejects.toThrow('boom');
+    expect(mockDb.resourceReview.findUniqueOrThrow).not.toHaveBeenCalled();
+  });
+});
+
+describe('upsertResourceReview (create branch) — idempotent on P2002 race', () => {
+  it('returns the existing review when the unique constraint trips', async () => {
+    const existing = { id: 7, modelId: 10, modelVersionId: 20, recommended: true };
+    mockDb.resourceReview.create.mockRejectedValueOnce(p2002());
+    mockDb.resourceReview.findUniqueOrThrow.mockResolvedValueOnce(existing);
+
+    const result = await upsertResourceReview({ ...baseInput, userId: 42 });
+
+    expect(result).toBe(existing);
+    expect(mockDb.resourceReview.findUniqueOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { modelVersionId_userId: { modelVersionId: 20, userId: 42 } },
+      })
+    );
+  });
+});

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -1748,8 +1748,9 @@ export const modelVersionDonationGoals = async ({
     })
     .catch((error) => {
       // Genuinely not found on the primary too (P2025) is a client/not-found
-      // condition — surface as 404 instead of letting findFirstOrThrow's P2025
-      // bubble up as INTERNAL_SERVER_ERROR.
+      // condition — surface 404 at the source. (The controller handler also
+      // maps P2025→NOT_FOUND via throwDbError, but only once its `return` is
+      // awaited; throwing here makes the 404 correct regardless of that.)
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
         throw throwNotFoundError(`No model version with id ${id}`);
       }

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -222,9 +222,18 @@ export const toggleModelVersionEngagement = async ({
     return;
   }
 
-  await dbWrite.modelVersionEngagement.create({
-    data: { type, modelVersionId: versionId, userId },
-  });
+  await dbWrite.modelVersionEngagement
+    .create({
+      data: { type, modelVersionId: versionId, userId },
+    })
+    .catch((error) => {
+      // A toggle racing itself: both calls see no engagement and both create,
+      // so the second hits the (userId, modelVersionId) unique constraint
+      // (P2002). The engagement already exists — a toggle is idempotent, so
+      // treat this as success instead of bubbling a 500.
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') return;
+      throw error;
+    });
   return;
 };
 
@@ -1729,10 +1738,23 @@ export const modelVersionDonationGoals = async ({
       },
     },
   } as const;
-  const version = await dbRead.modelVersion.findFirstOrThrow(donationFindArgs).catch(() => {
-    dbReadFallbackCounter.inc({ entity: 'modelVersion', caller: 'modelVersionDonationGoals' });
-    return dbWrite.modelVersion.findFirstOrThrow(donationFindArgs);
-  });
+  const version = await dbRead.modelVersion
+    .findFirstOrThrow(donationFindArgs)
+    .catch(() => {
+      // Replica miss (often replica lag) — retry against the primary before
+      // deciding the record is truly gone.
+      dbReadFallbackCounter.inc({ entity: 'modelVersion', caller: 'modelVersionDonationGoals' });
+      return dbWrite.modelVersion.findFirstOrThrow(donationFindArgs);
+    })
+    .catch((error) => {
+      // Genuinely not found on the primary too (P2025) is a client/not-found
+      // condition — surface as 404 instead of letting findFirstOrThrow's P2025
+      // bubble up as INTERNAL_SERVER_ERROR.
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        throw throwNotFoundError(`No model version with id ${id}`);
+      }
+      throw error;
+    });
 
   const canSeeAllGoals = userId === version.model.userId || isModerator;
 
@@ -2181,6 +2203,14 @@ export const mergeVersions = async ({
   }
   if (sourceVersionIds.includes(targetVersionId)) {
     throw throwBadRequestError('Target version cannot be in the source versions list.');
+  }
+  // Defensive: every raw query below interpolates `Prisma.join(sourceVersionIds)`,
+  // which throws "Expected join([]) to be called with an array of multiple
+  // elements" on an empty array. The tRPC schema enforces `.min(1)`, but guard
+  // here too so any non-router caller gets a clean 400 (nothing to merge) rather
+  // than an INTERNAL_SERVER_ERROR.
+  if (sourceVersionIds.length === 0) {
+    throw throwBadRequestError('No source versions to merge.');
   }
 
   // Block if any source version has active monetization or early access purchases

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -322,10 +322,23 @@ export const upsertResourceReview = async ({
 }: UpsertResourceReviewInput & { userId: number }) => {
   if (data.details) await throwOnBlockedLinkDomain(data.details);
   if (!data.id) {
-    const ret = await dbWrite.resourceReview.create({
-      data: { ...data, userId, thread: { create: {} } },
-      select: resourceReviewSelect,
-    });
+    const ret = await dbWrite.resourceReview
+      .create({
+        data: { ...data, userId, thread: { create: {} } },
+        select: resourceReviewSelect,
+      })
+      .catch(async (err) => {
+        // Concurrent create race: the (modelVersionId, userId) unique constraint
+        // trips (P2002). The review already exists — resolve idempotently by
+        // returning the existing row instead of bubbling a 500.
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+          return dbWrite.resourceReview.findUniqueOrThrow({
+            where: { modelVersionId_userId: { modelVersionId: data.modelVersionId, userId } },
+            select: resourceReviewSelect,
+          });
+        }
+        throw err;
+      });
     await createResourceReviewNotification({ ...ret, userId }).catch();
     await bustRatingTotalsCache({
       modelId: data.modelId,
@@ -399,7 +412,22 @@ export async function deleteResourceReviews({ ids }: { ids: number[] }) {
 export const createResourceReview = async (
   data: CreateResourceReviewInput & { userId: number }
 ) => {
-  const ret = await dbWrite.resourceReview.create({ data, select: resourceReviewSimpleSelect });
+  const ret = await dbWrite.resourceReview
+    .create({ data, select: resourceReviewSimpleSelect })
+    .catch(async (err) => {
+      // Concurrent create race: the (modelVersionId, userId) unique constraint
+      // trips (P2002). The review already exists — resolve idempotently by
+      // returning the existing row instead of bubbling a 500.
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        return dbWrite.resourceReview.findUniqueOrThrow({
+          where: {
+            modelVersionId_userId: { modelVersionId: data.modelVersionId, userId: data.userId },
+          },
+          select: resourceReviewSimpleSelect,
+        });
+      }
+      throw err;
+    });
   await createResourceReviewNotification({ ...ret, userId: data.userId }).catch();
   await bustRatingTotalsCache({
     modelId: data.modelId,


### PR DESCRIPTION
Resumes the 500-floor campaign — the deterministic, in-our-control tail of `INTERNAL_SERVER_ERROR`s (rates from 3h of prod Loki). Each fix turns a specific 500 into the correct outcome; behavior is otherwise unchanged.

## Confirmed fixes (mechanism verified against code + prod evidence)

**1. `zRem`/`hDel` empty-members → no-op** — `games/new-order/utils.ts` (counter `reset`). `ERR wrong number of arguments for 'zrem'` (~6/3h): `reset({ id: [] })` sent `ZREM key` with no members. Guard `stringIds.length === 0 → return 0` before both branches. Callers pass possibly-empty batches and ignore the return.

**2. `modelVersion.donationGoals` P2025 → 404** — `model-version.service.ts`. `Invalid prisma.modelVersion.findFirstOrThrow()` (~10/3h): the read→write fallback (replica-lag handling) still throws P2025 → 500 when the version genuinely doesn't exist. Added a trailing `.catch` mapping P2025 → `throwNotFoundError` (404); replica→primary fallback preserved.

**3. `resourceReview.create` P2002 → idempotent** — `resourceReview.service.ts` (both create paths). `Unique constraint failed` on `(modelVersionId, userId)` (~4/3h), a self-race. Catch P2002, re-fetch the existing row via the compound unique, return it (matches `referral`/`appBlockReview` pattern).

**4. `modelVersionEngagement.create` P2002 → idempotent** — `model-version.service.ts` (`toggleModelVersionEngagement`). `Unique constraint failed` (~3/3h) from `toggleFavorite`/`toggleNotifyEarlyAccess` racing. Catch P2002 → treat as success (a toggle is idempotent).

## Defensive (NOT the source of the prod join 500s — see below)

**5. `mergeVersions` empty-array guard** — `model-version.service.ts`. Guards `Prisma.join(sourceVersionIds)` against `[]` (returns 400). ⚠️ This is **defensive hardening only** — `mergeVersions` is schema-gated `.min(1)` so this path is currently unreachable. The real `Expected join([]) ...` prod 500s (~0.4/hr, 10/24h) come from a DIFFERENT, **unlocated** site: the prod stack is minified (`/app/.next/server/chunks/...`) with no tRPC `path`, so it can't be mapped without server sourcemaps. Tracked as a follow-up (correlate via sourcemaps / by-timestamp). Not claiming this PR fixes that.

## Tests
New: `counter-reset.test.ts`, `model-version.idempotent.service.test.ts`, `resourceReview.idempotent.service.test.ts` (12 tests, ran green locally via vitest unit project). Not deployed/verified on-cluster — CI handles typecheck/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)