### PR TITLE
fix(app-blocks): handle OPEN_CHECKPOINT_PICKER in PageBlockHost (dev:live↔prod parity)

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -11,6 +11,7 @@ import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import {
   grantedPageScopes,
   pageFallbackReason,
+  resolveCheckpointPickerRequest,
   resolveResourcePickerRequest,
 } from './pageBlockHostLogic';
 import { projectBlockInitMaturity } from './projectBlockInit';
@@ -1038,6 +1039,70 @@ export function PageBlockHost({
           // spurious cancel.
           if (answered) return;
           send('RESOURCE_PICKER_RESULT', { requestId });
+        },
+      });
+    });
+    return off;
+  }, [onMessage, send]);
+
+  // ── OPEN_CHECKPOINT_PICKER → CHECKPOINT_PICKER_RESULT (dev:live↔prod parity) ─
+  //
+  // The SDK hook `useCheckpointPicker()` posts OPEN_CHECKPOINT_PICKER. The
+  // model-slot host (IframeHost) handles it, AND the dev:live SDK host serves it
+  // — but this PAGE host only ever handled the newer/wider OPEN_RESOURCE_PICKER,
+  // so a page block calling `useCheckpointPicker()` had its request hit NO host
+  // handler (gotcha-#73): the "Change model" button spun forever — no network
+  // call, no error. Authors tested it working locally (dev:live serves it) then
+  // it silently broke in prod. This handler MIRRORS IframeHost's so that hook
+  // works identically on pages; it is purely additive (OPEN_RESOURCE_PICKER is
+  // unchanged) and a deliberately narrow checkpoint-only superset of it.
+  useEffect(() => {
+    const off = onMessage<unknown>('OPEN_CHECKPOINT_PICKER', (raw) => {
+      const req = resolveCheckpointPickerRequest(raw);
+      if (!req) return; // missing / non-string requestId → drop, never open the modal
+      const { requestId, baseModelGroup } = req;
+
+      // Normalize the optional family hint through getBaseModelGroup (accepts an
+      // ecosystem key like 'Flux1' OR a baseModel name like 'Flux.1 D'). Empty /
+      // unresolved group → baseModels:[] → no checkpoints rather than all
+      // families (matching IframeHost: "all" would include incompatible families
+      // that 400 at submit).
+      const groupKey = baseModelGroup ? getBaseModelGroup(baseModelGroup) : null;
+      const baseModels = groupKey ? getBaseModelsByGroup(groupKey) : [];
+
+      let answered = false;
+      openResourceSelectModal({
+        title: 'Choose a checkpoint',
+        options: {
+          canGenerate: true,
+          resources: [{ type: 'Checkpoint', baseModels }],
+        },
+        onSelect: (resource) => {
+          answered = true;
+          // Same name/id-only projection IframeHost's CHECKPOINT_PICKER_RESULT
+          // uses — the public display names of the user-picked resource plus the
+          // body-building IDs; NO full GenerationResource spread, so no
+          // availability/access/early-access/nsfw/poi/minor internals reach the
+          // iframe.
+          send('CHECKPOINT_PICKER_RESULT', {
+            requestId,
+            selected: {
+              // GenerationResource.id is the modelVersionId at the wire.
+              versionId: resource.id,
+              modelId: resource.model.id,
+              modelName: resource.model.name,
+              versionName: resource.name,
+              baseModel: resource.baseModel,
+            },
+          });
+        },
+        onClose: () => {
+          // Dialog dismiss fires after onSelect when the user picks (the modal
+          // closes itself); only emit the "closed without picking" result if
+          // onSelect never ran. answered=true short-circuits so a pick isn't
+          // followed by a spurious cancel.
+          if (answered) return;
+          send('CHECKPOINT_PICKER_RESULT', { requestId });
         },
       });
     });

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -1,0 +1,361 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+import type { ResourceSelectModalProps } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
+import type { GenerationResource } from '~/shared/types/generation.types';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * App Blocks PAGE checkpoint picker (dev:live↔prod parity).
+ *
+ * The SDK hook `useCheckpointPicker()` posts OPEN_CHECKPOINT_PICKER and awaits
+ * CHECKPOINT_PICKER_RESULT. The model-slot host (IframeHost) handles it, and the
+ * dev:live SDK host serves it — but the PAGE host (PageBlockHost) historically
+ * only handled the newer/wider OPEN_RESOURCE_PICKER, so a page block calling
+ * `useCheckpointPicker()` had its request hit NO host handler (gotcha-#73): the
+ * "Change model" button spun forever (no network call, no error). Authors
+ * tested it working locally then it silently broke in prod.
+ *
+ * These tests mount the REAL PageBlockHost and drive the actual postMessage
+ * bridge, asserting the newly-added handler mirrors IframeHost:
+ *   1. OPEN_CHECKPOINT_PICKER (valid requestId + family hint) opens the native
+ *      modal filtered to Checkpoint in that family, and on select posts back
+ *      ONLY { requestId, versionId, modelId, modelName, versionName, baseModel }
+ *      — the name/id-only projection, NO catalog / private / early-access leak;
+ *   2. on cancel (close without pick) it posts a cancelled result (no `selected`);
+ *   3. a request with no requestId (or non-string) is DROPPED — modal never
+ *      opens, no reply;
+ *   4. concurrent checkpoint + resource picks don't cross (each keeps its own
+ *      requestId + result message type).
+ *
+ * The native modal is a dynamic import that needs real providers, so — exactly
+ * like the OPEN_RESOURCE_PICKER test — we assert against the shared dialogStore
+ * (where openResourceSelectModal triggers) and invoke the captured
+ * onSelect/onClose callbacks to simulate the user's pick/dismiss.
+ */
+
+// PageBlockHost wires the workflow + storage bridges too; stub trpc so it mounts
+// network-free (the checkpoint picker itself makes NO tRPC call — it reuses the
+// native modal which talks to Meili in the parent context).
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+// The dialogStore entry openResourceSelectModal triggers — its `props` is the
+// ResourceSelectModalProps we passed (onSelect/onClose/options/title).
+function lastResourceModalProps(): ResourceSelectModalProps {
+  const dialogs = useDialogStore.getState().dialogs;
+  if (dialogs.length === 0) throw new Error('no resource-select modal opened');
+  return dialogs[dialogs.length - 1].props as unknown as ResourceSelectModalProps;
+}
+
+// A representative GenerationResource the native modal would hand to onSelect.
+// Includes fields that MUST NOT leak to the iframe (availability, hasAccess,
+// minor/poi/sfwOnly, cover image) so the test proves the projection drops them.
+function fakeResource(over: Partial<GenerationResource> = {}): GenerationResource {
+  return {
+    id: 9001, // = modelVersionId at the wire
+    name: 'v1.0',
+    baseModel: 'Flux.1 D',
+    trainedWords: [],
+    canGenerate: true,
+    hasAccess: true,
+    availability: 'Public',
+    model: {
+      id: 700,
+      name: 'My Checkpoint',
+      type: 'Checkpoint',
+      nsfw: false,
+      poi: true,
+      minor: true,
+      sfwOnly: true,
+      userId: 5,
+    },
+    image: {
+      id: 1,
+      url: 'https://example/cover.jpg',
+      width: 1,
+      height: 1,
+      hash: 'h',
+      type: 'image',
+    },
+    ...over,
+  } as unknown as GenerationResource;
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Gen Matrix',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['ai:write:budgeted'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+describe('PageBlockHost checkpoint picker (dev:live↔prod parity with IframeHost)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+  });
+
+  test('OPEN_CHECKPOINT_PICKER opens the native modal filtered to Checkpoint in the requested family', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+
+    postFromBlock('OPEN_CHECKPOINT_PICKER', { requestId: 'rq_ckpt', baseModelGroup: 'Flux1' });
+
+    await vi.waitFor(() => {
+      expect(useDialogStore.getState().dialogs).toHaveLength(1);
+    });
+    const props = lastResourceModalProps();
+    // Checkpoint-only + canGenerate floor (native modal reused UNMODIFIED).
+    expect(props.options?.resources).toHaveLength(1);
+    expect(props.options?.resources?.[0].type).toBe('Checkpoint');
+    expect(props.options?.canGenerate).toBe(true);
+    // A family hint resolved to a non-empty baseModels list (Flux1 → Flux.1 D…).
+    expect((props.options?.resources?.[0].baseModels ?? []).length).toBeGreaterThan(0);
+  });
+
+  test('on select posts back ONLY the name/id-only pick — no catalog / private / early-access leak', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_CHECKPOINT_PICKER', { requestId: 'rq_pick' });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+
+    // Simulate the user picking a checkpoint in the host modal.
+    const props = lastResourceModalProps();
+    props.onSelect(fakeResource());
+
+    await vi.waitFor(() => {
+      const r = replies.last('CHECKPOINT_PICKER_RESULT');
+      if (!r) throw new Error('no reply yet');
+      // EXACTLY the five-field projection IframeHost emits — IDs + the public
+      // display names of the user-picked resource, nothing else.
+      expect(r.payload).toEqual({
+        requestId: 'rq_pick',
+        selected: {
+          versionId: 9001,
+          modelId: 700,
+          modelName: 'My Checkpoint',
+          versionName: 'v1.0',
+          baseModel: 'Flux.1 D',
+        },
+      });
+    });
+
+    // Adversarial leak check: the reply must NOT carry any sensitive field from
+    // the source GenerationResource. `modelType` is NOT in the checkpoint
+    // projection either (the type is implicitly Checkpoint) — only the five
+    // fields above.
+    const payload = replies.last('CHECKPOINT_PICKER_RESULT')!.payload as {
+      selected: Record<string, unknown>;
+    };
+    const sel = payload.selected;
+    const sensitiveAbsent = ['availability', 'hasAccess', 'canGenerate', 'image', 'name',
+      'nsfw', 'nsfwLevel', 'poi', 'minor', 'sfwOnly', 'userId', 'trainedWords', 'model', 'modelType'];
+    for (const k of sensitiveAbsent) expect(sel).not.toHaveProperty(k);
+    expect(Object.keys(sel).sort()).toEqual(
+      ['baseModel', 'modelId', 'modelName', 'versionId', 'versionName']
+    );
+    replies.stop();
+  });
+
+  test('on cancel (close without pick) posts a cancelled result (no `selected`)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_CHECKPOINT_PICKER', { requestId: 'rq_cancel' });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+
+    const props = lastResourceModalProps();
+    props.onClose?.(); // user dismissed without selecting
+
+    await vi.waitFor(() => {
+      const r = replies.last('CHECKPOINT_PICKER_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_cancel' });
+    });
+    replies.stop();
+  });
+
+  test('a pick does NOT also emit a spurious cancel (onClose after onSelect is a no-op)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_CHECKPOINT_PICKER', { requestId: 'rq_once' });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+
+    const props = lastResourceModalProps();
+    props.onSelect(fakeResource());
+    props.onClose?.(); // the modal closes itself after a pick — must not double-fire
+
+    await vi.waitFor(() => {
+      const r = replies.last('CHECKPOINT_PICKER_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect((r.payload as { selected?: unknown }).selected).toBeDefined();
+    });
+    // EXACTLY one result for this requestId (the pick), no trailing cancel.
+    const all = replies.received.filter(
+      (m) => m.type === 'CHECKPOINT_PICKER_RESULT' && (m.payload as any)?.requestId === 'rq_once'
+    );
+    expect(all).toHaveLength(1);
+    replies.stop();
+  });
+
+  test('a request with no requestId is dropped (no modal, no reply)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_CHECKPOINT_PICKER', { baseModelGroup: 'Flux1' });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(replies.last('CHECKPOINT_PICKER_RESULT')).toBeUndefined();
+    replies.stop();
+  });
+
+  test('a request with a non-string requestId is dropped (no modal, no reply)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_CHECKPOINT_PICKER', { requestId: 42 });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(replies.last('CHECKPOINT_PICKER_RESULT')).toBeUndefined();
+    replies.stop();
+  });
+
+  test('concurrent checkpoint + resource picks resolve to their OWN message type + requestId (no cross-talk)', async () => {
+    // The native modal is one-at-a-time (the dialogStore holds a single modal),
+    // so this drives open→pick→close per request. The guarantee that matters:
+    // a CHECKPOINT_PICKER request resolves with CHECKPOINT_PICKER_RESULT (not
+    // RESOURCE_PICKER_RESULT) and its own requestId, and vice-versa — the newly
+    // added handler does not steal OPEN_RESOURCE_PICKER's replies or requestIds.
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    // Checkpoint pick.
+    postFromBlock('OPEN_CHECKPOINT_PICKER', { requestId: 'rq_ck' });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    lastResourceModalProps().onSelect(
+      fakeResource({ id: 111, model: { id: 11, name: 'CK', type: 'Checkpoint' } as any })
+    );
+    await vi.waitFor(() => {
+      const r = replies.last('CHECKPOINT_PICKER_RESULT');
+      if (!(r && (r.payload as any)?.requestId === 'rq_ck')) throw new Error('checkpoint not resolved');
+    });
+    useDialogStore.getState().closeAll();
+
+    // Resource pick (Checkpoint via the wider handler) — a different message
+    // type entirely.
+    postFromBlock('OPEN_RESOURCE_PICKER', { requestId: 'rq_res', resourceType: 'Checkpoint' });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    lastResourceModalProps().onSelect(
+      fakeResource({ id: 222, model: { id: 22, name: 'RES', type: 'Checkpoint' } as any })
+    );
+    await vi.waitFor(() => {
+      const r = replies.last('RESOURCE_PICKER_RESULT');
+      if (!(r && (r.payload as any)?.requestId === 'rq_res')) throw new Error('resource not resolved');
+    });
+
+    // Each result kept its own message type + requestId — the handlers don't cross.
+    const ck = replies.received.find(
+      (m) => m.type === 'CHECKPOINT_PICKER_RESULT' && (m.payload as any)?.requestId === 'rq_ck'
+    )?.payload as { selected: { versionId: number } };
+    const res = replies.received.find(
+      (m) => m.type === 'RESOURCE_PICKER_RESULT' && (m.payload as any)?.requestId === 'rq_res'
+    )?.payload as { selected: { versionId: number; modelType: string } };
+    expect(ck.selected.versionId).toBe(111);
+    expect(ck.selected).not.toHaveProperty('modelType'); // checkpoint projection has no modelType
+    expect(res.selected).toMatchObject({ versionId: 222, modelType: 'Checkpoint' }); // resource one does
+    replies.stop();
+  });
+});

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   grantedPageScopes,
   pageFallbackReason,
+  resolveCheckpointPickerRequest,
   resolveResourcePickerRequest,
   PAGE_RESOURCE_PICKER_TYPES,
   type PageHostStatus,
@@ -141,5 +142,38 @@ describe('resolveResourcePickerRequest (OPEN_RESOURCE_PICKER — type allowlist 
 
   it('the v1 allowlist is exactly Checkpoint + LoRA (guards against scope creep)', () => {
     expect([...PAGE_RESOURCE_PICKER_TYPES].sort()).toEqual(['Checkpoint', 'LORA']);
+  });
+});
+
+describe('resolveCheckpointPickerRequest (OPEN_CHECKPOINT_PICKER — dev:live↔prod parity)', () => {
+  it('accepts a bare requestId (type is implicitly Checkpoint — no allowlist)', () => {
+    expect(resolveCheckpointPickerRequest({ requestId: 'c1' })).toEqual({ requestId: 'c1' });
+  });
+
+  it('passes through an optional baseModelGroup family hint', () => {
+    expect(resolveCheckpointPickerRequest({ requestId: 'c2', baseModelGroup: 'Flux1' })).toEqual({
+      requestId: 'c2',
+      baseModelGroup: 'Flux1',
+    });
+  });
+
+  it('omits an empty/blank baseModelGroup (no spurious family key)', () => {
+    const r = resolveCheckpointPickerRequest({ requestId: 'c3', baseModelGroup: '' });
+    expect(r).toEqual({ requestId: 'c3' });
+    expect(r).not.toHaveProperty('baseModelGroup');
+  });
+
+  it('DROPS a request with a missing or non-string requestId', () => {
+    expect(resolveCheckpointPickerRequest({})).toBeNull();
+    expect(resolveCheckpointPickerRequest({ requestId: '' })).toBeNull();
+    expect(resolveCheckpointPickerRequest({ requestId: 42 })).toBeNull();
+    expect(resolveCheckpointPickerRequest({ requestId: null })).toBeNull();
+  });
+
+  it('DROPS non-object / nullish payloads', () => {
+    expect(resolveCheckpointPickerRequest(undefined)).toBeNull();
+    expect(resolveCheckpointPickerRequest(null)).toBeNull();
+    expect(resolveCheckpointPickerRequest('Checkpoint')).toBeNull();
+    expect(resolveCheckpointPickerRequest(123)).toBeNull();
   });
 });

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -82,6 +82,47 @@ export function resolveResourcePickerRequest(raw: unknown): ResourcePickerReques
   return { requestId: obj.requestId, resourceType: canonical, ...(baseModelGroup ? { baseModelGroup } : {}) };
 }
 
+// ── OPEN_CHECKPOINT_PICKER (parity with the model-slot IframeHost) ────────────
+//
+// The SDK hook `useCheckpointPicker()` posts OPEN_CHECKPOINT_PICKER and awaits
+// CHECKPOINT_PICKER_RESULT. The model-slot host (IframeHost) handles it; this
+// page host historically did NOT (it only handled the newer, wider
+// OPEN_RESOURCE_PICKER), so the same block that worked in the model slot — and
+// in the dev:live SDK host, which DOES serve it — spun forever on a page. This
+// restores dev:live↔prod parity for `useCheckpointPicker` on pages.
+//
+// Unlike OPEN_RESOURCE_PICKER there is no type allowlist to enforce here — the
+// type is implicitly Checkpoint — so the only validation is: require a string
+// requestId (drop otherwise, never open the modal) and pass through an optional
+// base-model family hint. Kept pure + unit-tested for the same reason as
+// resolveResourcePickerRequest (the drop rule is the security-relevant part).
+
+export type CheckpointPickerRequest = {
+  requestId: string;
+  /** Optional base-model family hint (ecosystem key 'Flux1' or baseModel name 'Flux.1 D'). */
+  baseModelGroup?: string;
+};
+
+/**
+ * Validate + normalize a raw OPEN_CHECKPOINT_PICKER payload from an untrusted
+ * iframe. Returns the sanitized request, or `null` when it must be DROPPED
+ * (missing/non-string requestId). Mirrors IframeHost's inline validation; the
+ * CALLER opens the native checkpoint modal — this only decides whether to, and
+ * with what family filter.
+ */
+export function resolveCheckpointPickerRequest(raw: unknown): CheckpointPickerRequest | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.requestId !== 'string' || obj.requestId.length === 0) return null;
+
+  const baseModelGroup =
+    typeof obj.baseModelGroup === 'string' && obj.baseModelGroup.length > 0
+      ? obj.baseModelGroup
+      : undefined;
+
+  return { requestId: obj.requestId, ...(baseModelGroup ? { baseModelGroup } : {}) };
+}
+
 export type PageFallbackReason = 'timeout' | 'token_error' | 'fatal_block_error';
 
 /**


### PR DESCRIPTION
## Symptom

A page App Block (`civitai.com/apps/run/<slug>`) whose code calls the SDK hook `useCheckpointPicker()` shows a "Change model" button that **spins forever** when clicked — no network request, no error in the console. The same block works correctly:
- in the **model slot** (`model.sidebar_top`), and
- in **`dev:live`** local development.

So an author builds + tests the hook locally, ships it, and it silently breaks only on the page run-host in prod — a dev:live↔prod fidelity gap.

## Root cause

`useCheckpointPicker()` posts an **`OPEN_CHECKPOINT_PICKER`** block→host message and awaits a **`CHECKPOINT_PICKER_RESULT`** reply.

- `IframeHost.tsx` (model-slot host) **has** a handler for `OPEN_CHECKPOINT_PICKER`.
- The `dev:live` SDK host also serves it.
- `PageBlockHost.tsx` (page run-host) **only handled the newer/wider `OPEN_RESOURCE_PICKER`** — it never had an `OPEN_CHECKPOINT_PICKER` handler.

So on a page the request hit **no host handler** (the gotcha-#73 "block→host message hitting no host handler" class): the awaited reply never came, the SDK promise never resolved, the button spun.

## The fix (additive, low-risk)

Add an `OPEN_CHECKPOINT_PICKER` → `CHECKPOINT_PICKER_RESULT` handler to `PageBlockHost`, **mirroring `IframeHost`'s exactly**:

- Validate a string `requestId` (drop otherwise — never open the modal).
- Normalize the optional `baseModelGroup` through `getBaseModelGroup` (accepts an ecosystem key `'Flux1'` OR a baseModel name `'Flux.1 D'`); empty/unresolved group → `baseModels: []` (no checkpoints rather than all families — matches IframeHost).
- Open the host's native `ResourceSelectModal` filtered to `Checkpoint` in that family, `canGenerate: true`.
- On select, post back the **same name/id-only projection** IframeHost uses: `{ versionId, modelId, modelName, versionName, baseModel }` — **no full `GenerationResource` spread**, so no availability/access/early-access/nsfw/poi/minor internals reach the iframe.
- `answered` guard so a pick isn't followed by a spurious cancel; on close-without-pick post `{ requestId }` only.

The drop/normalize rule is extracted as a pure `resolveCheckpointPickerRequest` in `pageBlockHostLogic.ts` (unit-tested), matching how `OPEN_RESOURCE_PICKER` (`resolveResourcePickerRequest`) is structured.

**Purely additive** — `OPEN_RESOURCE_PICKER`, `IframeHost.tsx`, and the SDK are untouched.

## Test coverage

- `pageBlockHostLogic.test.ts`: 10 new unit cases for `resolveCheckpointPickerRequest` (accepts bare requestId, passes/omits family hint, drops missing/non-string/blank requestId, drops non-object payloads).
- `PageBlockHostCheckpointPicker.browser.test.tsx` (new, browser-mode, mirrors `PageBlockHostResourcePicker.browser.test.tsx`): mounts the **real** `PageBlockHost` and drives the actual postMessage bridge —
  1. `OPEN_CHECKPOINT_PICKER` (+ family hint) opens the native modal filtered to Checkpoint, non-empty baseModels;
  2. on select posts `CHECKPOINT_PICKER_RESULT` with the exact 5-field name/id-only `selected` shape + an adversarial leak check (no `model`/`availability`/`hasAccess`/`modelType`/… and no extra keys);
  3. close-without-pick posts `{ requestId }` only;
  4. a pick doesn't also emit a spurious cancel;
  5. missing / non-string `requestId` is dropped (modal never opens, no reply);
  6. concurrent `OPEN_CHECKPOINT_PICKER` + `OPEN_RESOURCE_PICKER` resolve to their own message type + requestId (no cross-talk; checkpoint projection has no `modelType`, resource one does).

**Run locally** (real headless Chromium via Playwright on a NixOS host): unit `22/22` pass, browser `7/7` pass. Local full `tsc`/`prisma generate` is broken on this host (stale engine) — imports/types sanity-checked by reading against the IframeHost original; the authoritative typecheck is the Tekton pr-preview on this PR.

## Scope / risk

Mod-dark: App Blocks is gated behind the `app-blocks-enabled` Flipt flag (`isModerator`-only today), so this only affects moderators running page blocks. No DB/schema/migration changes. Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
