### PR TITLE
fix(app-blocks): close PageBlockHost SET_USER_CHECKPOINT hang + host↔SDK handler-parity guard

### DIFF
--- a/claudedocs/app-blocks-host-handler-parity-2026-06-29.md
+++ b/claudedocs/app-blocks-host-handler-parity-2026-06-29.md
@@ -1,0 +1,143 @@
+# App Blocks host↔SDK handler parity audit (2026-06-29)
+
+## The bug class (gotcha-#73 — "spins forever, no network call, no console error")
+
+App Blocks has multiple host components that bridge block→host `postMessage`s, each
+registering its own `onMessage('<TYPE>', …)` handlers BY HAND:
+
+- `src/components/AppBlocks/IframeHost.tsx` — model-slot host (`model.sidebar*` slots)
+- `src/components/AppBlocks/PageBlockHost.tsx` — full-page run host (`civitai.com/apps/run/<slug>`)
+- `src/components/AppBlocks/InlineHost.tsx` — inline host (v1 STUB: throws on render, NO message bridge)
+
+The SDK (`@civitai/app-sdk` / `@civitai/blocks-react`) sends two flavours of block→host message:
+
+- **REQUEST-style** — the hook uses `sendTypedRequest(...)` and AWAITS a specific `*_RESULT`/ack
+  reply. If the host has NO handler, the request never gets a reply → the block hangs to its SDK
+  request timeout → the UI spins forever, **no network call, no console error**. This is the
+  dangerous class.
+- **fire-and-forget** — the hook uses `sendMessage(...)` and awaits nothing. An unhandled one is
+  silently dropped (a no-op), which never hangs the block.
+
+The dev:live SDK host (`createLiveHost` / `liveHost.ts` in the separate `civitai-app-starters`
+repo) serves these messages, so authors test green locally then break in prod — a fidelity gap.
+This exact gap bit `OPEN_CHECKPOINT_PICKER` on pages (a page block's `useCheckpointPicker()`
+"Change model" spun forever) — fixed in the now-merged civitai #2799.
+
+## Source of truth
+
+- Message protocol union: `@civitai/app-sdk` `blocks/messages.ts` → `BlockToParentMessage`
+  (verified against the installed `node_modules/@civitai/app-sdk/dist/blocks/messages.d.ts` AND
+  the newer `civitai-app-starters` source — the starters source additionally carries
+  `CANCEL_WORKFLOW` / `REQUEST_SIGN_IN` / `REQUEST_CONSENT`, all already in the union below).
+- REQUEST vs fire-and-forget: derived from the `@civitai/blocks-react` hooks — `sendTypedRequest`
+  (REQUEST) vs `getTransport().sendMessage` (fire-and-forget). Verified per hook.
+
+## Coverage matrix (verified 2026-06-29)
+
+`✅` = `onMessage('<TYPE>')` registered (read in source, multi-line handlers included).
+`N/A` = legitimately not handled (rationale). `❌` = a real gap.
+
+| # | Message (block→host) | Style | Reply awaited | IframeHost | PageBlockHost | InlineHost |
+|---|---|---|---|---|---|---|
+| 1 | `BLOCK_READY` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 2 | `BLOCK_ERROR` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 3 | `RESIZE_IFRAME` | fire-forget | — | ✅ | **N/A** (page iframe is full-viewport `height:100%` — no size-to-content; fire-forget so no hang) | N/A (v1 stub) |
+| 4 | `NAVIGATE` | fire-forget | — | **N/A** (model slot is an embedded panel; host-navigation out of remit) | ✅ | N/A (v1 stub) |
+| 5 | `TRACK_EVENT` | fire-forget | — | **N/A** (analytics; no host-side sink wired in EITHER host today — dropped, never hangs) | **N/A** (same) | N/A (v1 stub) |
+| 6 | `REQUEST_SIGN_IN` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 7 | `REQUEST_CONSENT` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 8 | `REQUEST_TOKEN` | **REQUEST** | `TOKEN_REFRESH_RESPONSE` | ✅ | ✅ | N/A (v1 stub) |
+| 9 | `SUBMIT_WORKFLOW` | **REQUEST** | `WORKFLOW_SUBMITTED` | ✅ | ✅ | N/A (v1 stub) |
+| 10 | `ESTIMATE_WORKFLOW` | **REQUEST** | `ESTIMATE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 11 | `POLL_WORKFLOW` | **REQUEST** | `WORKFLOW_STATUS` | ✅ | ✅ | N/A (v1 stub) |
+| 12 | `CANCEL_WORKFLOW` | **REQUEST** | `WORKFLOW_CANCELED` | ✅ | ✅ | N/A (v1 stub) |
+| 13 | `OPEN_BUZZ_PURCHASE` | **REQUEST** | `BUZZ_PURCHASE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 14 | `OPEN_CHECKPOINT_PICKER` | **REQUEST** | `CHECKPOINT_PICKER_RESULT` | ✅ | ✅ (ported #2799) | N/A (v1 stub) |
+| 15 | `SET_USER_CHECKPOINT` | **REQUEST** | `USER_CHECKPOINT_SET` | ✅ | ❌→**fail-fast NACK (this PR)** — see OPEN DECISION | N/A (v1 stub) |
+| 16 | `APP_STORAGE_GET` | **REQUEST** | `APP_STORAGE_GET_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 17 | `APP_STORAGE_SET` | **REQUEST** | `APP_STORAGE_SET_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 18 | `APP_STORAGE_DELETE` | **REQUEST** | `APP_STORAGE_DELETE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 19 | `APP_STORAGE_LIST` | **REQUEST** | `APP_STORAGE_LIST_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 20 | `APP_STORAGE_QUOTA` | **REQUEST** | `APP_STORAGE_QUOTA_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+
+### Verdict summary
+
+- **Before this PR, the ONLY remaining REQUEST-style page gap was `SET_USER_CHECKPOINT`** (#15).
+  Every other REQUEST-style message is already handled on the page (workflow set, buzz, storage,
+  token, picker). So the "spins forever" exposure on the page surface is down to this one message,
+  which this PR closes with a fail-fast NACK.
+- `IframeHost` has no REQUEST-style gaps. Its `N/A`s (`NAVIGATE`, `TRACK_EVENT`) are both
+  fire-and-forget — never a hang.
+- `InlineHost` is a v1 stub (throws on render, no message bridge). EVERY message is N/A for it
+  today; the parity guard still enforces a rationale so a future v2 activation can't silently skip
+  a required handler.
+
+## What this PR ports vs flags
+
+### Ported: `SET_USER_CHECKPOINT` → fail-fast `USER_CHECKPOINT_SET { ok:false, error }` on the page
+
+`useCheckpointPicker().persist(versionId)` posts `SET_USER_CHECKPOINT` and AWAITS
+`USER_CHECKPOINT_SET` (it THROWS the returned `error` string when `ok:false`). Before this PR the
+page host had no handler → `persist()` hung to the SDK request timeout.
+
+**Why a NACK and not a real persist:** the server proc `blocks.updateUserSettings`
+(`src/server/routers/blocks.router.ts:2572`) HARD-REQUIRES `modelId` in the block-token ctx — it
+resolves a model-bound install via `resolveBlockInstance({ modelId, slotId, … })` and throws
+`BAD_REQUEST: block token lacks modelId context` otherwise. A **page token's ctx is
+`{ slotId, entityType:'none' }` with NO modelId** (`isPageToken`, `blocks.router.ts:226`). A page is
+stateless and binds to no model, so there is **no `block_user_settings` row to persist a checkpoint
+override into**. Inventing one would be a guess.
+
+The reply TYPE and SHAPE the SDK awaits IS unambiguous (`USER_CHECKPOINT_SET { requestId, ok, error? }`),
+so the host can — and now does — reply with an explicit NACK: `ok:false` + a human-readable error.
+`persist()` therefore REJECTS FAST with a clear message instead of hanging silently. This is the
+task's prescribed behavior for the ambiguous case: fail fast with a KNOWN reply shape, never
+fabricate one.
+
+The page's actual checkpoint flow is the in-memory `OPEN_CHECKPOINT_PICKER` result (the block holds
+the picked version in its own state) — it does not need a persisted override to function.
+
+## OPEN DECISIONS for a human
+
+1. **Should page blocks be able to PERSIST a viewer checkpoint preference at all?**
+   Today: no — there is no page-scoped user-settings target, and `updateUserSettings` demands a
+   `modelId` a page token lacks. This PR ships a fail-fast NACK (the safe, non-guessing default).
+   IF persistence is wanted, it needs a NEW page-scoped storage target — most naturally the
+   App-Storage KV the page token already authorises (`apps:storage:*`), OR a new server proc that
+   keys user settings by `(appBlockId, userId)` without a `modelId` — plus a matching read-back
+   path so `OPEN_CHECKPOINT_PICKER`/init can surface the persisted value. Out of scope here; this is
+   a product decision (do pages even want a sticky per-viewer checkpoint?), not a bug fix.
+
+2. **`TRACK_EVENT` is bridged by NEITHER host.** It's fire-and-forget analytics with no host-side
+   sink wired anywhere today, so it's silently dropped (never a hang). If analytics from blocks is
+   desired, wire a sink in the relevant host(s) and flip the `TRACK_EVENT` rows to `required` in the
+   parity test. Flagged, not fixed — adding a telemetry sink is a feature, not a parity gap.
+
+## The durable guard
+
+`src/components/AppBlocks/hostHandlerParity.test.ts` (plain unit test, `unit` project, node env —
+NOT under `src/pages/**`) encodes this whole inventory:
+
+- a hard-coded `INVENTORY` of every block→host message with, per host, `'required'` or an explicit
+  `N/A: <one-line rationale>`;
+- it greps each host SOURCE for an `onMessage('<TYPE>'` registration (multi-line + inline-generic
+  aware) and FAILS if a `required` handler is missing;
+- a `SDK_BLOCK_TO_PARENT_TYPES` pin asserts the inventory covers EXACTLY the SDK union — so adding a
+  new SDK message without triaging its host coverage fails CI;
+- a focused invariant asserts every REQUEST-style message is either handled by `PageBlockHost` or
+  carries a documented N/A rationale (the page is the surface most prone to drift).
+
+This converts the whole "spins forever" class into a build-time error the next time someone adds an
+SDK message or a new host surface without wiring the host.
+
+## How verified
+
+- Coverage read from the three host sources (handlers are multi-line; greps were cross-checked by
+  reading the files, not trusting one-line greps).
+- REQUEST vs fire-and-forget confirmed per hook in `civitai-app-starters/packages/civitai-blocks-react/src/hooks/*`.
+- The `SET_USER_CHECKPOINT` page-inapplicability confirmed by reading `blocks.updateUserSettings`
+  (`modelId` hard-requirement) and `isPageToken` (page ctx has no `modelId`).
+- New behavior covered by `PageBlockHostSetUserCheckpoint.browser.test.tsx` (real PageBlockHost,
+  real postMessage bridge) + the parity unit test.
+- Local `tsc`/full typecheck is broken on this NixOS host (stale Prisma engine); the authoritative
+  typecheck is civitai's Tekton pr-preview on the PR.

--- a/claudedocs/app-blocks-host-handler-parity-2026-06-29.md
+++ b/claudedocs/app-blocks-host-handler-parity-2026-06-29.md
@@ -26,9 +26,12 @@ This exact gap bit `OPEN_CHECKPOINT_PICKER` on pages (a page block's `useCheckpo
 ## Source of truth
 
 - Message protocol union: `@civitai/app-sdk` `blocks/messages.ts` → `BlockToParentMessage`
-  (verified against the installed `node_modules/@civitai/app-sdk/dist/blocks/messages.d.ts` AND
-  the newer `civitai-app-starters` source — the starters source additionally carries
-  `CANCEL_WORKFLOW` / `REQUEST_SIGN_IN` / `REQUEST_CONSENT`, all already in the union below).
+  (`BlockToParentMessageType`), imported DIRECTLY from `@civitai/app-sdk/blocks` by the
+  non-test module `hostHandlerParity.ts` so the union is checked at compile time (see below).
+  Verified against the installed `node_modules/@civitai/app-sdk/dist/blocks/messages.d.ts`
+  (`@civitai/app-sdk@0.6.0`). The PUBLISHED dist union has 17 members; `INVENTORY` lists 20
+  — the extra 3 (`CANCEL_WORKFLOW` / `REQUEST_SIGN_IN` / `REQUEST_CONSENT`) are FORWARD-LOOKING:
+  they exist in the newer `civitai-app-starters` source but are NOT YET in the published dist.
 - REQUEST vs fire-and-forget: derived from the `@civitai/blocks-react` hooks — `sendTypedRequest`
   (REQUEST) vs `getTransport().sendMessage` (fire-and-forget). Verified per hook.
 
@@ -36,29 +39,37 @@ This exact gap bit `OPEN_CHECKPOINT_PICKER` on pages (a page block's `useCheckpo
 
 `✅` = `onMessage('<TYPE>')` registered (read in source, multi-line handlers included).
 `N/A` = legitimately not handled (rationale). `❌` = a real gap.
+**Pub?** = is this type in the currently-PUBLISHED `@civitai/app-sdk@0.6.0` dist
+`BlockToParentMessage` union? `pub` = yes (covered by the compile-time gate); **`ahead`** = NOT
+yet published, forward-looking INVENTORY entry (runtime grep coverage only, not the type gate).
 
-| # | Message (block→host) | Style | Reply awaited | IframeHost | PageBlockHost | InlineHost |
-|---|---|---|---|---|---|---|
-| 1 | `BLOCK_READY` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
-| 2 | `BLOCK_ERROR` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
-| 3 | `RESIZE_IFRAME` | fire-forget | — | ✅ | **N/A** (page iframe is full-viewport `height:100%` — no size-to-content; fire-forget so no hang) | N/A (v1 stub) |
-| 4 | `NAVIGATE` | fire-forget | — | **N/A** (model slot is an embedded panel; host-navigation out of remit) | ✅ | N/A (v1 stub) |
-| 5 | `TRACK_EVENT` | fire-forget | — | **N/A** (analytics; no host-side sink wired in EITHER host today — dropped, never hangs) | **N/A** (same) | N/A (v1 stub) |
-| 6 | `REQUEST_SIGN_IN` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
-| 7 | `REQUEST_CONSENT` | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
-| 8 | `REQUEST_TOKEN` | **REQUEST** | `TOKEN_REFRESH_RESPONSE` | ✅ | ✅ | N/A (v1 stub) |
-| 9 | `SUBMIT_WORKFLOW` | **REQUEST** | `WORKFLOW_SUBMITTED` | ✅ | ✅ | N/A (v1 stub) |
-| 10 | `ESTIMATE_WORKFLOW` | **REQUEST** | `ESTIMATE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
-| 11 | `POLL_WORKFLOW` | **REQUEST** | `WORKFLOW_STATUS` | ✅ | ✅ | N/A (v1 stub) |
-| 12 | `CANCEL_WORKFLOW` | **REQUEST** | `WORKFLOW_CANCELED` | ✅ | ✅ | N/A (v1 stub) |
-| 13 | `OPEN_BUZZ_PURCHASE` | **REQUEST** | `BUZZ_PURCHASE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
-| 14 | `OPEN_CHECKPOINT_PICKER` | **REQUEST** | `CHECKPOINT_PICKER_RESULT` | ✅ | ✅ (ported #2799) | N/A (v1 stub) |
-| 15 | `SET_USER_CHECKPOINT` | **REQUEST** | `USER_CHECKPOINT_SET` | ✅ | ❌→**fail-fast NACK (this PR)** — see OPEN DECISION | N/A (v1 stub) |
-| 16 | `APP_STORAGE_GET` | **REQUEST** | `APP_STORAGE_GET_RESULT` | ✅ | ✅ | N/A (v1 stub) |
-| 17 | `APP_STORAGE_SET` | **REQUEST** | `APP_STORAGE_SET_RESULT` | ✅ | ✅ | N/A (v1 stub) |
-| 18 | `APP_STORAGE_DELETE` | **REQUEST** | `APP_STORAGE_DELETE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
-| 19 | `APP_STORAGE_LIST` | **REQUEST** | `APP_STORAGE_LIST_RESULT` | ✅ | ✅ | N/A (v1 stub) |
-| 20 | `APP_STORAGE_QUOTA` | **REQUEST** | `APP_STORAGE_QUOTA_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| # | Message (block→host) | Pub? | Style | Reply awaited | IframeHost | PageBlockHost | InlineHost |
+|---|---|---|---|---|---|---|---|
+| 1 | `BLOCK_READY` | pub | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 2 | `BLOCK_ERROR` | pub | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 3 | `RESIZE_IFRAME` | pub | fire-forget | — | ✅ | **N/A** (page iframe is full-viewport `height:100%` — no size-to-content; fire-forget so no hang) | N/A (v1 stub) |
+| 4 | `NAVIGATE` | pub | fire-forget | — | **N/A** (model slot is an embedded panel; host-navigation out of remit) | ✅ | N/A (v1 stub) |
+| 5 | `TRACK_EVENT` | pub | fire-forget | — | **N/A** (analytics; no host-side sink wired in EITHER host today — dropped, never hangs) | **N/A** (same) | N/A (v1 stub) |
+| 6 | `REQUEST_SIGN_IN` | **ahead** | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 7 | `REQUEST_CONSENT` | **ahead** | fire-forget | — | ✅ | ✅ | N/A (v1 stub) |
+| 8 | `REQUEST_TOKEN` | pub | **REQUEST** | `TOKEN_REFRESH_RESPONSE` | ✅ | ✅ | N/A (v1 stub) |
+| 9 | `SUBMIT_WORKFLOW` | pub | **REQUEST** | `WORKFLOW_SUBMITTED` | ✅ | ✅ | N/A (v1 stub) |
+| 10 | `ESTIMATE_WORKFLOW` | pub | **REQUEST** | `ESTIMATE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 11 | `POLL_WORKFLOW` | pub | **REQUEST** | `WORKFLOW_STATUS` | ✅ | ✅ | N/A (v1 stub) |
+| 12 | `CANCEL_WORKFLOW` | **ahead** | **REQUEST** | `WORKFLOW_CANCELED` | ✅ | ✅ | N/A (v1 stub) |
+| 13 | `OPEN_BUZZ_PURCHASE` | pub | **REQUEST** | `BUZZ_PURCHASE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 14 | `OPEN_CHECKPOINT_PICKER` | pub | **REQUEST** | `CHECKPOINT_PICKER_RESULT` | ✅ | ✅ (ported #2799) | N/A (v1 stub) |
+| 15 | `SET_USER_CHECKPOINT` | pub | **REQUEST** | `USER_CHECKPOINT_SET` | ✅ | ❌→**fail-fast NACK (this PR)** — see OPEN DECISION | N/A (v1 stub) |
+| 16 | `APP_STORAGE_GET` | pub | **REQUEST** | `APP_STORAGE_GET_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 17 | `APP_STORAGE_SET` | pub | **REQUEST** | `APP_STORAGE_SET_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 18 | `APP_STORAGE_DELETE` | pub | **REQUEST** | `APP_STORAGE_DELETE_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 19 | `APP_STORAGE_LIST` | pub | **REQUEST** | `APP_STORAGE_LIST_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+| 20 | `APP_STORAGE_QUOTA` | pub | **REQUEST** | `APP_STORAGE_QUOTA_RESULT` | ✅ | ✅ | N/A (v1 stub) |
+
+> The three **ahead** rows (#6, #7, #12) are NOT in the published `@civitai/app-sdk@0.6.0` dist
+> union, so they are NOT enforced by the compile-time coverage gate — only by the runtime grep.
+> They are forward-looking coverage for when those messages land in a published SDK. Do not
+> conflate "verified in the matrix" with "in the published union" for these rows.
 
 ### Verdict summary
 
@@ -115,20 +126,38 @@ the picked version in its own state) — it does not need a persisted override t
 
 ## The durable guard
 
-`src/components/AppBlocks/hostHandlerParity.test.ts` (plain unit test, `unit` project, node env —
-NOT under `src/pages/**`) encodes this whole inventory:
+Two complementary layers — a COMPILE-TIME type gate and a RUNTIME grep — split across a non-test
+module and its test:
 
-- a hard-coded `INVENTORY` of every block→host message with, per host, `'required'` or an explicit
+**`src/components/AppBlocks/hostHandlerParity.ts`** (NON-test module, so it's definitely in
+civitai's `tsc --noEmit` / `next build` typecheck graph — under `src`, not excluded, NOT under
+`src/pages/**` so Next doesn't treat it as a route):
+
+- the hard-coded `INVENTORY` of every block→host message with, per host, `'required'` or an explicit
   `N/A: <one-line rationale>`;
-- it greps each host SOURCE for an `onMessage('<TYPE>'` registration (multi-line + inline-generic
-  aware) and FAILS if a `required` handler is missing;
-- a `SDK_BLOCK_TO_PARENT_TYPES` pin asserts the inventory covers EXACTLY the SDK union — so adding a
-  new SDK message without triaging its host coverage fails CI;
+- a COMPILE-TIME (type-level) coverage gate that imports the REAL published union
+  `BlockToParentMessageType` straight from `@civitai/app-sdk/blocks` and asserts
+  `SdkBlockToParentType extends keyof typeof INVENTORY`. If a future PUBLISHED SDK adds a block→host
+  message type that `INVENTORY` doesn't list, this is a **TypeScript error** caught by Tekton's
+  typecheck — the one manual step the runtime grep can't catch. It is **one-directional**: every
+  PUBLISHED type must be an INVENTORY key, but INVENTORY MAY carry extra ahead-of-published keys
+  (the 3 `ahead` rows), so it never deletes forward coverage.
+
+**`src/components/AppBlocks/hostHandlerParity.test.ts`** (vitest `unit` project, node env) imports
+`INVENTORY` and adds the runtime checks:
+
+- greps each host SOURCE for an `onMessage('<TYPE>'` registration (multi-line + inline-generic
+  aware; **comments are stripped first** so a `'TYPE'` mention in a comment next to `onMessage`
+  can't FALSE-POSITIVE into "covered") and FAILS if a `required` handler is missing;
 - a focused invariant asserts every REQUEST-style message is either handled by `PageBlockHost` or
   carries a documented N/A rationale (the page is the surface most prone to drift).
 
-This converts the whole "spins forever" class into a build-time error the next time someone adds an
-SDK message or a new host surface without wiring the host.
+What this does NOT do: it does NOT auto-detect drift in the FORWARD-LOOKING (`ahead`) messages
+(those aren't in the published union, so the type gate can't see them) and it does NOT verify
+handler CORRECTNESS — only presence. The type gate's guarantee is precisely "every PUBLISHED SDK
+block→host message is triaged in INVENTORY"; behavioral correctness lives in the per-message browser
+tests. Together this converts the MISSING-published-handler case of the "spins forever" class into a
+build-time error.
 
 ## How verified
 
@@ -139,5 +168,10 @@ SDK message or a new host surface without wiring the host.
   (`modelId` hard-requirement) and `isPageToken` (page ctx has no `modelId`).
 - New behavior covered by `PageBlockHostSetUserCheckpoint.browser.test.tsx` (real PageBlockHost,
   real postMessage bridge) + the parity unit test.
-- Local `tsc`/full typecheck is broken on this NixOS host (stale Prisma engine); the authoritative
-  typecheck is civitai's Tekton pr-preview on the PR.
+- The COMPILE-TIME coverage gate is verified BY CONSTRUCTION + by reading the installed dist, NOT by
+  a local `tsc` run (local `tsc`/`prisma generate` is broken on this NixOS host — stale Prisma
+  engine). Reasoning: the published `@civitai/app-sdk@0.6.0` `BlockToParentMessage` union (read from
+  `node_modules/@civitai/app-sdk/dist/blocks/messages.d.ts`) has 17 members, all 17 are keys of
+  `INVENTORY` (which has 20), so `SdkBlockToParentType extends keyof typeof INVENTORY` resolves to
+  the literal `true` and `const _sdkCovered: true = true` compiles. The AUTHORITATIVE enforcement is
+  civitai's Tekton pr-preview typecheck on the PR — it will surface any real type error.

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1146,6 +1146,9 @@ export function PageBlockHost({
   // here. Until then a NACK is the correct, non-guessing behavior.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown } | undefined>('SET_USER_CHECKPOINT', (raw) => {
+      // NOTE: `payload.versionId` is intentionally NOT read or validated here —
+      // the page path always NACKs regardless of which checkpoint was requested
+      // (there is no page-scoped persistence target), so the versionId is moot.
       // Mirror IframeHost's drop rule: a missing / non-string requestId can't be
       // answered (no correlation id), so drop it silently rather than reply.
       if (!raw || typeof raw.requestId !== 'string' || raw.requestId.length === 0) return;

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1109,6 +1109,55 @@ export function PageBlockHost({
     return off;
   }, [onMessage, send]);
 
+  // ── SET_USER_CHECKPOINT → USER_CHECKPOINT_SET (fail-fast NACK on a page) ──────
+  //
+  // `useCheckpointPicker().persist(versionId)` posts SET_USER_CHECKPOINT and
+  // AWAITS USER_CHECKPOINT_SET (it's a request, not fire-and-forget). The
+  // model-slot host (IframeHost) handles it by writing `checkpoint_version_id`
+  // into `block_user_settings` for the (blockInstance, viewer) row, AND the
+  // dev:live SDK host serves it — so a block author who calls `persist()` sees
+  // it resolve locally, then (before this handler existed) had the SAME call
+  // hit NO page-host handler in prod: the persist promise hung to the SDK's
+  // request timeout (gotcha-#73, the "spins forever, no network call, no
+  // console error" class). This handler closes that silent hang.
+  //
+  // CRUCIAL: a page CANNOT persist a checkpoint override the way the model slot
+  // can. The server proc `blocks.updateUserSettings` HARD-REQUIRES `modelId`
+  // in the block-token ctx (it resolves a model-bound install via
+  // resolveBlockInstance({ modelId, slotId, ... })). A PAGE token's ctx is
+  // `{ slotId, entityType:'none' }` with NO modelId (isPageToken) — a page is
+  // stateless and binds to no model — so driving updateUserSettings with the
+  // page token would throw BAD_REQUEST ("block token lacks modelId context").
+  // There is no page-scoped user-settings row to write into today.
+  //
+  // So rather than INVENT a persistence target (a guess), this replies with an
+  // explicit, KNOWN-shape NACK: `USER_CHECKPOINT_SET { ok:false, error }`. That
+  // is the exact reply type+shape `persist()` awaits (it throws the `error`
+  // string when `ok:false`), so the block fails FAST and surfaces a clear
+  // message instead of hanging. The page's checkpoint flow is the in-memory
+  // OPEN_CHECKPOINT_PICKER result (above), which the block already holds — it
+  // does not need a persisted override.
+  //
+  // OPEN DECISION for a human (documented in
+  // claudedocs/app-blocks-host-handler-parity-2026-06-29.md): if pages should
+  // ever persist a viewer checkpoint preference, that needs a NEW page-scoped
+  // storage target (e.g. via the app-storage KV the page token already
+  // authorises) + a server proc that doesn't demand modelId — out of scope
+  // here. Until then a NACK is the correct, non-guessing behavior.
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown } | undefined>('SET_USER_CHECKPOINT', (raw) => {
+      // Mirror IframeHost's drop rule: a missing / non-string requestId can't be
+      // answered (no correlation id), so drop it silently rather than reply.
+      if (!raw || typeof raw.requestId !== 'string' || raw.requestId.length === 0) return;
+      send('USER_CHECKPOINT_SET', {
+        requestId: raw.requestId,
+        ok: false,
+        error: 'page blocks cannot persist a checkpoint override (no model binding)',
+      });
+    });
+    return off;
+  }, [onMessage, send]);
+
   const showIframe = status === 'loading' || status === 'ready';
   const isReady = status === 'ready';
 

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -1,0 +1,216 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * PageBlockHost SET_USER_CHECKPOINT — fail-fast NACK parity (gotcha-#73).
+ *
+ * `useCheckpointPicker().persist(versionId)` posts SET_USER_CHECKPOINT and
+ * AWAITS USER_CHECKPOINT_SET (it's a `sendTypedRequest`, not fire-and-forget —
+ * it throws the returned `error` when `ok:false`). The model-slot host
+ * (IframeHost) handles it by writing `checkpoint_version_id` into
+ * `block_user_settings`, and the dev:live SDK host serves it — so a block author
+ * who calls `persist()` sees it resolve locally, then (before this handler) had
+ * the SAME call hit NO page-host handler in prod: the persist promise hung to
+ * the SDK's request timeout (the "spins forever, no network call, no console
+ * error" class).
+ *
+ * A page CANNOT persist a checkpoint override the way the model slot can: the
+ * server proc `blocks.updateUserSettings` HARD-REQUIRES `modelId` in the block
+ * token ctx, and a page token (entityType:'none') has none. So rather than
+ * invent a persistence target, the page host replies with the EXACT known-shape
+ * reply the SDK awaits — USER_CHECKPOINT_SET { ok:false, error } — so persist()
+ * REJECTS FAST with a clear message instead of hanging.
+ *
+ * These tests mount the REAL PageBlockHost and drive the actual postMessage
+ * bridge, asserting:
+ *   1. SET_USER_CHECKPOINT (valid requestId) posts back USER_CHECKPOINT_SET with
+ *      the SAME requestId and ok:false + a non-empty error (the fail-fast NACK);
+ *   2. NO checkpoint persistence side-effect / network call is made;
+ *   3. a request with a missing / non-string requestId is DROPPED (no reply) —
+ *      it can't be correlated, mirroring IframeHost's drop rule.
+ */
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    // PageBlockHost wires the workflow + storage bridges at render; stub so it
+    // mounts network-free. SET_USER_CHECKPOINT makes NO tRPC call on a page (it
+    // NACKs in-host), so none of these are exercised here.
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Gen Matrix',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['ai:write:budgeted'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+describe('PageBlockHost SET_USER_CHECKPOINT (fail-fast NACK — no silent hang)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+  });
+
+  test('a valid request gets an explicit ok:false NACK with the same requestId (not a hang)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_USER_CHECKPOINT', { requestId: 'rq_persist', versionId: 9001 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('USER_CHECKPOINT_SET');
+      if (!r) throw new Error('no reply yet');
+      const payload = r.payload as { requestId: string; ok: boolean; error?: string };
+      expect(payload.requestId).toBe('rq_persist');
+      expect(payload.ok).toBe(false);
+      // The error must be a non-empty string — `persist()` THROWS it, so an
+      // empty/undefined error would surface a useless message to the user.
+      expect(typeof payload.error).toBe('string');
+      expect((payload.error ?? '').length).toBeGreaterThan(0);
+    });
+    replies.stop();
+  });
+
+  test('clearing the override (versionId:null) also NACKs (no model-bound row to clear)', async () => {
+    // The SDK allows `persist(null)` to clear an override. On a page there is no
+    // override to clear either, so it NACKs the same way — the block fails fast
+    // rather than believing it cleared a setting that never existed.
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_USER_CHECKPOINT', { requestId: 'rq_clear', versionId: null });
+
+    await vi.waitFor(() => {
+      const r = replies.last('USER_CHECKPOINT_SET');
+      if (!r) throw new Error('no reply yet');
+      const payload = r.payload as { requestId: string; ok: boolean };
+      expect(payload.requestId).toBe('rq_clear');
+      expect(payload.ok).toBe(false);
+    });
+    replies.stop();
+  });
+
+  test('a request with no requestId is dropped (no reply — cannot correlate)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_USER_CHECKPOINT', { versionId: 9001 });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(replies.last('USER_CHECKPOINT_SET')).toBeUndefined();
+    replies.stop();
+  });
+
+  test('a request with a non-string requestId is dropped (no reply)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_USER_CHECKPOINT', { requestId: 42, versionId: 9001 });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(replies.last('USER_CHECKPOINT_SET')).toBeUndefined();
+    replies.stop();
+  });
+
+  test('the NACK opens NO modal and makes no checkpoint-persistence side effect', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SET_USER_CHECKPOINT', { requestId: 'rq_noside', versionId: 5 });
+
+    await vi.waitFor(() => {
+      if (!replies.last('USER_CHECKPOINT_SET')) throw new Error('no reply yet');
+    });
+    // No dialog/modal should be opened by a persist NACK (unlike the picker).
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    replies.stop();
+  });
+});

--- a/src/components/AppBlocks/hostHandlerParity.test.ts
+++ b/src/components/AppBlocks/hostHandlerParity.test.ts
@@ -1,0 +1,365 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * App Blocks host↔SDK handler PARITY guard.
+ *
+ * THE BUG CLASS this encodes (gotcha-#73, the "spins forever, no network call,
+ * no console error" class):
+ *
+ *   App Blocks has multiple host components that each register their own
+ *   `onMessage('<TYPE>', …)` handlers BY HAND to bridge a block's postMessages:
+ *     - IframeHost.tsx     — model-slot host (model.sidebar slots)
+ *     - PageBlockHost.tsx  — full-page run host (civitai.com/apps/run/<slug>)
+ *     - InlineHost.tsx     — inline host (v2 stub, not active in prod)
+ *
+ *   The SDK (`@civitai/app-sdk` / `@civitai/blocks-react`) sends two flavours of
+ *   block→host message: REQUEST-style (`sendTypedRequest`, AWAITS a specific
+ *   `*_RESULT` / ack reply) and fire-and-forget (`sendMessage`, no reply). When
+ *   a block sends a REQUEST-style message and the host has NO handler, the
+ *   request never gets a reply → the block hangs to its SDK request timeout →
+ *   the UI spins forever with no network call and no error. The dev:live SDK
+ *   host serves these messages, so authors test green locally then break in
+ *   prod — a fidelity gap (this exact gap bit OPEN_CHECKPOINT_PICKER on pages,
+ *   fixed in civitai #2799).
+ *
+ * THIS TEST converts that whole class into a BUILD-TIME error: it hard-codes
+ * the inventory of every block→host message `type` the SDK can send, and per
+ * type which host files MUST register an `onMessage('<TYPE>'` handler (or an
+ * explicit `N/A: <reason>` exemption). It then greps each required host source
+ * for the registration. If someone adds an SDK message — or a new host surface
+ * — without wiring the host, this FAILS CI instead of silently shipping a
+ * spin-forever block.
+ *
+ * SOURCE OF TRUTH for the inventory: the SDK message protocol
+ * `@civitai/app-sdk` `blocks/messages.ts` `BlockToParentMessage` union, cross-
+ * referenced with the `@civitai/blocks-react` hooks (which `type` each posts and
+ * whether it uses `sendTypedRequest` [REQUEST] or `sendMessage` [fire-forget]).
+ * When the SDK adds a block→host message, add it here with its hosts/exemptions.
+ *
+ * Maintenance: this is a deliberately DUMB structural grep — it asserts a
+ * handler is REGISTERED, not that it's correct. Behavioral correctness lives in
+ * the per-message browser tests (PageBlockHost*.browser.test.tsx). The value
+ * here is catching the MISSING-handler case the next time the protocol grows.
+ */
+
+const HOST_DIR = join(__dirname);
+
+type HostFile = 'IframeHost.tsx' | 'PageBlockHost.tsx' | 'InlineHost.tsx';
+
+// Read each host source once. (InlineHost is a v2 stub that throws on render and
+// runs NO message bridge in v1 — see the N/A exemptions below; we still read it
+// so a future activation is forced through this guard.)
+const HOST_SRC: Record<HostFile, string> = {
+  'IframeHost.tsx': readFileSync(join(HOST_DIR, 'IframeHost.tsx'), 'utf8'),
+  'PageBlockHost.tsx': readFileSync(join(HOST_DIR, 'PageBlockHost.tsx'), 'utf8'),
+  'InlineHost.tsx': readFileSync(join(HOST_DIR, 'InlineHost.tsx'), 'utf8'),
+};
+
+/**
+ * True if `src` registers a handler for `type`. Handler registrations span
+ * multiple lines and may carry an inline generic, e.g.:
+ *
+ *     const off = onMessage<{ requestId?: unknown } | undefined>(
+ *       'SET_USER_CHECKPOINT',
+ *       async (raw) => { … }
+ *     );
+ *
+ * or a one-liner `onMessage<unknown>('OPEN_CHECKPOINT_PICKER', (raw) => …)`. So
+ * we DON'T require the `'TYPE'` literal to sit on the same line as `onMessage(`;
+ * we require an `onMessage` call (optionally with a `<…>` type arg) followed,
+ * across any whitespace/newlines, by the quoted type literal as its FIRST
+ * argument. The literal is matched whole (`'TYPE'`) so `OPEN_CHECKPOINT_PICKER`
+ * can't be satisfied by a substring of another type.
+ */
+function handlesMessage(src: string, type: string): boolean {
+  // onMessage  [<...generic...>]  (  [ws/newlines]  'TYPE'
+  // The generic arg can itself contain `>` (union types), so match it
+  // non-greedily up to the opening `(` rather than a naive `<[^>]*>`.
+  const re = new RegExp(
+    String.raw`onMessage\s*(?:<[\s\S]*?>)?\s*\(\s*` + `'${type}'`,
+    'm'
+  );
+  return re.test(src);
+}
+
+/**
+ * The authoritative inventory: every block→host message the SDK can send, with
+ * per-host requirements. `request: true` = REQUEST-style (awaits a reply; an
+ * unhandled one HANGS the block — this is the dangerous class). For each host,
+ * `'required'` means the host MUST register a handler; a string is an explicit
+ * `N/A` rationale (the host legitimately doesn't handle it).
+ *
+ * Keep one-line rationales human-readable — they ARE the documentation a future
+ * maintainer reads when this test fails.
+ */
+type HostReq = 'required' | string; // string = N/A reason
+
+interface MessageSpec {
+  /** REQUEST-style (sendTypedRequest, awaits a *_RESULT/ack). Unhandled ⇒ hang. */
+  request: boolean;
+  /** Reply type the SDK awaits (REQUEST-style only); '' for fire-and-forget. */
+  reply: string;
+  IframeHost: HostReq;
+  PageBlockHost: HostReq;
+  InlineHost: HostReq;
+}
+
+// InlineHost is a v1 STUB that throws on render and wires NO message bridge
+// (BlockHost never routes inline installs in v1 — `canUseInline` is always
+// false). So EVERY message is N/A for it today; the shared reason is below.
+const INLINE_STUB = 'InlineHost is a v1 stub (throws on render, no message bridge in v1)';
+
+const INVENTORY: Record<string, MessageSpec> = {
+  // ── Lifecycle / fire-and-forget (no reply ⇒ unhandled never HANGS, but a
+  //    page that ignores them just no-ops; documented per host) ───────────────
+  BLOCK_READY: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  BLOCK_ERROR: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  RESIZE_IFRAME: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    // N/A: the page renders the iframe full-viewport (height:100%); a page block
+    // fills the surface and does NOT size-to-content, so there is nothing to
+    // resize. Fire-and-forget ⇒ an ignored RESIZE_IFRAME never hangs the block.
+    PageBlockHost:
+      'page iframe is full-viewport (height:100%); no size-to-content, fire-and-forget so no hang',
+    InlineHost: INLINE_STUB,
+  },
+  NAVIGATE: {
+    request: false,
+    reply: '',
+    // N/A: the model slot is an embedded panel inside the model page — a block
+    // navigating the host away from the model page is out of its remit; the
+    // model host intentionally does not bridge NAVIGATE.
+    IframeHost: 'model slot is an embedded panel; host-navigation is out of remit (no NAVIGATE bridge)',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  TRACK_EVENT: {
+    request: false,
+    reply: '',
+    // N/A (both real hosts): TRACK_EVENT is fire-and-forget analytics and is
+    // currently NOT bridged by EITHER host (no host-side analytics sink wired).
+    // Unhandled ⇒ silently dropped, never a hang. If a sink is added, flip the
+    // relevant host(s) to 'required' here so coverage is enforced.
+    IframeHost: 'analytics fire-and-forget; no host-side sink wired (dropped, never hangs)',
+    PageBlockHost: 'analytics fire-and-forget; no host-side sink wired (dropped, never hangs)',
+    InlineHost: INLINE_STUB,
+  },
+  REQUEST_SIGN_IN: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  REQUEST_CONSENT: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+
+  // ── REQUEST-style (await a reply ⇒ unhandled HANGS the block) ───────────────
+  REQUEST_TOKEN: {
+    request: true,
+    reply: 'TOKEN_REFRESH_RESPONSE',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SUBMIT_WORKFLOW: {
+    request: true,
+    reply: 'WORKFLOW_SUBMITTED',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  ESTIMATE_WORKFLOW: {
+    request: true,
+    reply: 'ESTIMATE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  POLL_WORKFLOW: {
+    request: true,
+    reply: 'WORKFLOW_STATUS',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  CANCEL_WORKFLOW: {
+    request: true,
+    reply: 'WORKFLOW_CANCELED',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  OPEN_BUZZ_PURCHASE: {
+    request: true,
+    reply: 'BUZZ_PURCHASE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  OPEN_CHECKPOINT_PICKER: {
+    request: true,
+    reply: 'CHECKPOINT_PICKER_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required', // ported in #2799
+    InlineHost: INLINE_STUB,
+  },
+  SET_USER_CHECKPOINT: {
+    request: true,
+    reply: 'USER_CHECKPOINT_SET',
+    IframeHost: 'required',
+    // PAGE: persists to block_user_settings keyed by a model-bound install;
+    // updateUserSettings HARD-REQUIRES modelId in the token ctx, which a page
+    // token (entityType:'none') lacks. The page host registers a FAIL-FAST NACK
+    // (USER_CHECKPOINT_SET ok:false) so persist() rejects immediately instead of
+    // hanging — see the handler comment + the parity doc's OPEN DECISION.
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_GET: {
+    request: true,
+    reply: 'APP_STORAGE_GET_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_SET: {
+    request: true,
+    reply: 'APP_STORAGE_SET_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_DELETE: {
+    request: true,
+    reply: 'APP_STORAGE_DELETE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_LIST: {
+    request: true,
+    reply: 'APP_STORAGE_LIST_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_QUOTA: {
+    request: true,
+    reply: 'APP_STORAGE_QUOTA_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+};
+
+// The exact set of block→host message types in the SDK `BlockToParentMessage`
+// union (@civitai/app-sdk blocks/messages.ts). Pinned here so that if the SDK
+// adds a message and someone updates the union without updating this test, the
+// "inventory matches the SDK union" assertion below fails — forcing the new
+// message to be triaged through INVENTORY (and thus through host coverage).
+const SDK_BLOCK_TO_PARENT_TYPES = [
+  'BLOCK_READY',
+  'BLOCK_ERROR',
+  'REQUEST_TOKEN',
+  'RESIZE_IFRAME',
+  'SUBMIT_WORKFLOW',
+  'ESTIMATE_WORKFLOW',
+  'POLL_WORKFLOW',
+  'CANCEL_WORKFLOW',
+  'OPEN_BUZZ_PURCHASE',
+  'OPEN_CHECKPOINT_PICKER',
+  'SET_USER_CHECKPOINT',
+  'NAVIGATE',
+  'REQUEST_SIGN_IN',
+  'REQUEST_CONSENT',
+  'TRACK_EVENT',
+  'APP_STORAGE_GET',
+  'APP_STORAGE_SET',
+  'APP_STORAGE_DELETE',
+  'APP_STORAGE_LIST',
+  'APP_STORAGE_QUOTA',
+] as const;
+
+const HOSTS: HostFile[] = ['IframeHost.tsx', 'PageBlockHost.tsx', 'InlineHost.tsx'];
+
+describe('App Blocks host↔SDK handler parity (gotcha-#73 "spins forever" guard)', () => {
+  it('the inventory covers EXACTLY the SDK BlockToParentMessage union (no drift)', () => {
+    // If this fails: the SDK added/removed a block→host message. Update
+    // INVENTORY (with per-host required/N-A) AND SDK_BLOCK_TO_PARENT_TYPES, then
+    // wire any new REQUEST-style message into the hosts it applies to.
+    expect([...Object.keys(INVENTORY)].sort()).toEqual([...SDK_BLOCK_TO_PARENT_TYPES].sort());
+  });
+
+  // Per-host × per-message: a 'required' entry MUST have a registered handler.
+  for (const host of HOSTS) {
+    describe(host, () => {
+      for (const [type, spec] of Object.entries(INVENTORY)) {
+        const req = spec[host.replace('.tsx', '') as 'IframeHost' | 'PageBlockHost' | 'InlineHost'];
+        if (req === 'required') {
+          it(`handles '${type}'${spec.request ? ` (REQUEST → ${spec.reply})` : ' (fire-and-forget)'}`, () => {
+            // If this fails: the host is MISSING an onMessage('<TYPE>', …)
+            // registration. For a REQUEST-style message that means a block
+            // calling the corresponding hook HANGS to its SDK timeout (spins
+            // forever, no network call). Port a handler (mirror the other host),
+            // OR if it's genuinely N/A here, change INVENTORY[<TYPE>][<host>] to
+            // a short N/A rationale string.
+            expect(
+              handlesMessage(HOST_SRC[host], type),
+              `${host} is missing onMessage('${type}')`
+            ).toBe(true);
+          });
+        } else {
+          // N/A — assert the exemption is a non-empty human-readable rationale,
+          // so an exemption can't be a silent `''` or `true`.
+          it(`exempts '${type}' with a rationale`, () => {
+            expect(typeof req).toBe('string');
+            expect((req as string).length).toBeGreaterThan(10);
+          });
+        }
+      }
+    });
+  }
+
+  it('every REQUEST-style message is handled by PageBlockHost (the page hang surface)', () => {
+    // Focused invariant: REQUEST-style messages are the ones that HANG when
+    // unhandled. The page host is the surface most likely to drift (it's newer
+    // and hand-mirrors IframeHost). Require an explicit decision for each — a
+    // registered handler OR a documented N/A — never an accidental gap.
+    const requestMessages = Object.entries(INVENTORY).filter(([, s]) => s.request);
+    for (const [type, spec] of requestMessages) {
+      if (spec.PageBlockHost === 'required') {
+        expect(
+          handlesMessage(HOST_SRC['PageBlockHost.tsx'], type),
+          `PageBlockHost must register onMessage('${type}') — REQUEST-style messages hang the block when unhandled`
+        ).toBe(true);
+      } else {
+        expect(
+          typeof spec.PageBlockHost === 'string' && (spec.PageBlockHost as string).length > 10,
+          `REQUEST-style '${type}' is exempted from PageBlockHost — it MUST carry a rationale`
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/src/components/AppBlocks/hostHandlerParity.test.ts
+++ b/src/components/AppBlocks/hostHandlerParity.test.ts
@@ -1,61 +1,66 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { INVENTORY, type HostFile } from './hostHandlerParity';
 
 /**
- * App Blocks host↔SDK handler PARITY guard.
+ * App Blocks host↔SDK handler PARITY guard (runtime half).
  *
- * THE BUG CLASS this encodes (gotcha-#73, the "spins forever, no network call,
- * no console error" class):
+ * What is enforced, and by WHAT:
  *
- *   App Blocks has multiple host components that each register their own
- *   `onMessage('<TYPE>', …)` handlers BY HAND to bridge a block's postMessages:
- *     - IframeHost.tsx     — model-slot host (model.sidebar slots)
- *     - PageBlockHost.tsx  — full-page run host (civitai.com/apps/run/<slug>)
- *     - InlineHost.tsx     — inline host (v2 stub, not active in prod)
+ *  1. COMPILE-TIME (in the sibling NON-test module `hostHandlerParity.ts`): a
+ *     type-level assertion that every message type in the PUBLISHED
+ *     `@civitai/app-sdk/blocks` `BlockToParentMessage` union is a key of
+ *     `INVENTORY`. A future PUBLISHED SDK message that INVENTORY doesn't list
+ *     becomes a TypeScript error in civitai's Tekton typecheck / `next build`.
+ *     That is the ONE manual step this runtime test cannot catch. (It is
+ *     one-directional: INVENTORY may carry forward-looking entries ahead of the
+ *     published dist — e.g. CANCEL_WORKFLOW / REQUEST_SIGN_IN / REQUEST_CONSENT.)
  *
- *   The SDK (`@civitai/app-sdk` / `@civitai/blocks-react`) sends two flavours of
- *   block→host message: REQUEST-style (`sendTypedRequest`, AWAITS a specific
- *   `*_RESULT` / ack reply) and fire-and-forget (`sendMessage`, no reply). When
- *   a block sends a REQUEST-style message and the host has NO handler, the
- *   request never gets a reply → the block hangs to its SDK request timeout →
- *   the UI spins forever with no network call and no error. The dev:live SDK
- *   host serves these messages, so authors test green locally then break in
- *   prod — a fidelity gap (this exact gap bit OPEN_CHECKPOINT_PICKER on pages,
- *   fixed in civitai #2799).
+ *  2. RUNTIME (this file): for each `'required'` INVENTORY entry, grep the host
+ *     SOURCE for an `onMessage('<TYPE>', …)` registration and FAIL if missing.
+ *     This catches the "handler removed / new host surface not wired" case for
+ *     the messages we already know about.
  *
- * THIS TEST converts that whole class into a BUILD-TIME error: it hard-codes
- * the inventory of every block→host message `type` the SDK can send, and per
- * type which host files MUST register an `onMessage('<TYPE>'` handler (or an
- * explicit `N/A: <reason>` exemption). It then greps each required host source
- * for the registration. If someone adds an SDK message — or a new host surface
- * — without wiring the host, this FAILS CI instead of silently shipping a
- * spin-forever block.
+ * THE BUG CLASS (gotcha-#73, the "spins forever, no network call, no console
+ * error" class): a REQUEST-style block→host message with NO host handler never
+ * gets its `*_RESULT`/ack reply → the block hangs to its SDK request timeout →
+ * the UI spins forever. The dev:live SDK host serves these messages, so authors
+ * test green locally then break in prod (this exact gap bit
+ * OPEN_CHECKPOINT_PICKER on pages, fixed in civitai #2799).
  *
- * SOURCE OF TRUTH for the inventory: the SDK message protocol
- * `@civitai/app-sdk` `blocks/messages.ts` `BlockToParentMessage` union, cross-
- * referenced with the `@civitai/blocks-react` hooks (which `type` each posts and
- * whether it uses `sendTypedRequest` [REQUEST] or `sendMessage` [fire-forget]).
- * When the SDK adds a block→host message, add it here with its hosts/exemptions.
- *
- * Maintenance: this is a deliberately DUMB structural grep — it asserts a
- * handler is REGISTERED, not that it's correct. Behavioral correctness lives in
- * the per-message browser tests (PageBlockHost*.browser.test.tsx). The value
- * here is catching the MISSING-handler case the next time the protocol grows.
+ * This is a deliberately DUMB structural grep — it asserts a handler is
+ * REGISTERED, not that it's correct. Behavioral correctness lives in the
+ * per-message browser tests (PageBlockHost*.browser.test.tsx).
  */
 
 const HOST_DIR = join(__dirname);
 
-type HostFile = 'IframeHost.tsx' | 'PageBlockHost.tsx' | 'InlineHost.tsx';
-
 // Read each host source once. (InlineHost is a v2 stub that throws on render and
-// runs NO message bridge in v1 — see the N/A exemptions below; we still read it
-// so a future activation is forced through this guard.)
+// runs NO message bridge in v1 — see the N/A exemptions in INVENTORY; we still
+// read it so a future activation is forced through this guard.)
 const HOST_SRC: Record<HostFile, string> = {
-  'IframeHost.tsx': readFileSync(join(HOST_DIR, 'IframeHost.tsx'), 'utf8'),
-  'PageBlockHost.tsx': readFileSync(join(HOST_DIR, 'PageBlockHost.tsx'), 'utf8'),
-  'InlineHost.tsx': readFileSync(join(HOST_DIR, 'InlineHost.tsx'), 'utf8'),
+  'IframeHost.tsx': stripComments(readFileSync(join(HOST_DIR, 'IframeHost.tsx'), 'utf8')),
+  'PageBlockHost.tsx': stripComments(readFileSync(join(HOST_DIR, 'PageBlockHost.tsx'), 'utf8')),
+  'InlineHost.tsx': stripComments(readFileSync(join(HOST_DIR, 'InlineHost.tsx'), 'utf8')),
 };
+
+/**
+ * Strip `/* *​/` block comments and `//` line comments from a source string so
+ * the handler grep can't FALSE-POSITIVE on a `'TYPE'` mention that merely sits
+ * in a comment/JSDoc next to the word `onMessage` (which would mark a message
+ * "covered" with no real handler).
+ *
+ * SAFETY: this is a deliberately naive strip (it does not parse strings/regex
+ * literals), so it could over-strip in a pathological case — but an over-strip
+ * can only REMOVE a real `onMessage('TYPE'` and cause a spurious FAILURE
+ * (safe-fail, a human investigates), never a false PASS. It never adds coverage.
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/(^|[^:])\/\/.*$/gm, '$1'); // line comments (keep `://` in URLs)
+}
 
 /**
  * True if `src` registers a handler for `type`. Handler registrations span
@@ -71,7 +76,8 @@ const HOST_SRC: Record<HostFile, string> = {
  * we require an `onMessage` call (optionally with a `<…>` type arg) followed,
  * across any whitespace/newlines, by the quoted type literal as its FIRST
  * argument. The literal is matched whole (`'TYPE'`) so `OPEN_CHECKPOINT_PICKER`
- * can't be satisfied by a substring of another type.
+ * can't be satisfied by a substring of another type. Comments are stripped from
+ * `src` before this runs (see stripComments) so a commented mention can't pass.
  */
 function handlesMessage(src: string, type: string): boolean {
   // onMessage  [<...generic...>]  (  [ws/newlines]  'TYPE'
@@ -84,234 +90,9 @@ function handlesMessage(src: string, type: string): boolean {
   return re.test(src);
 }
 
-/**
- * The authoritative inventory: every block→host message the SDK can send, with
- * per-host requirements. `request: true` = REQUEST-style (awaits a reply; an
- * unhandled one HANGS the block — this is the dangerous class). For each host,
- * `'required'` means the host MUST register a handler; a string is an explicit
- * `N/A` rationale (the host legitimately doesn't handle it).
- *
- * Keep one-line rationales human-readable — they ARE the documentation a future
- * maintainer reads when this test fails.
- */
-type HostReq = 'required' | string; // string = N/A reason
-
-interface MessageSpec {
-  /** REQUEST-style (sendTypedRequest, awaits a *_RESULT/ack). Unhandled ⇒ hang. */
-  request: boolean;
-  /** Reply type the SDK awaits (REQUEST-style only); '' for fire-and-forget. */
-  reply: string;
-  IframeHost: HostReq;
-  PageBlockHost: HostReq;
-  InlineHost: HostReq;
-}
-
-// InlineHost is a v1 STUB that throws on render and wires NO message bridge
-// (BlockHost never routes inline installs in v1 — `canUseInline` is always
-// false). So EVERY message is N/A for it today; the shared reason is below.
-const INLINE_STUB = 'InlineHost is a v1 stub (throws on render, no message bridge in v1)';
-
-const INVENTORY: Record<string, MessageSpec> = {
-  // ── Lifecycle / fire-and-forget (no reply ⇒ unhandled never HANGS, but a
-  //    page that ignores them just no-ops; documented per host) ───────────────
-  BLOCK_READY: {
-    request: false,
-    reply: '',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  BLOCK_ERROR: {
-    request: false,
-    reply: '',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  RESIZE_IFRAME: {
-    request: false,
-    reply: '',
-    IframeHost: 'required',
-    // N/A: the page renders the iframe full-viewport (height:100%); a page block
-    // fills the surface and does NOT size-to-content, so there is nothing to
-    // resize. Fire-and-forget ⇒ an ignored RESIZE_IFRAME never hangs the block.
-    PageBlockHost:
-      'page iframe is full-viewport (height:100%); no size-to-content, fire-and-forget so no hang',
-    InlineHost: INLINE_STUB,
-  },
-  NAVIGATE: {
-    request: false,
-    reply: '',
-    // N/A: the model slot is an embedded panel inside the model page — a block
-    // navigating the host away from the model page is out of its remit; the
-    // model host intentionally does not bridge NAVIGATE.
-    IframeHost: 'model slot is an embedded panel; host-navigation is out of remit (no NAVIGATE bridge)',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  TRACK_EVENT: {
-    request: false,
-    reply: '',
-    // N/A (both real hosts): TRACK_EVENT is fire-and-forget analytics and is
-    // currently NOT bridged by EITHER host (no host-side analytics sink wired).
-    // Unhandled ⇒ silently dropped, never a hang. If a sink is added, flip the
-    // relevant host(s) to 'required' here so coverage is enforced.
-    IframeHost: 'analytics fire-and-forget; no host-side sink wired (dropped, never hangs)',
-    PageBlockHost: 'analytics fire-and-forget; no host-side sink wired (dropped, never hangs)',
-    InlineHost: INLINE_STUB,
-  },
-  REQUEST_SIGN_IN: {
-    request: false,
-    reply: '',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  REQUEST_CONSENT: {
-    request: false,
-    reply: '',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-
-  // ── REQUEST-style (await a reply ⇒ unhandled HANGS the block) ───────────────
-  REQUEST_TOKEN: {
-    request: true,
-    reply: 'TOKEN_REFRESH_RESPONSE',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  SUBMIT_WORKFLOW: {
-    request: true,
-    reply: 'WORKFLOW_SUBMITTED',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  ESTIMATE_WORKFLOW: {
-    request: true,
-    reply: 'ESTIMATE_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  POLL_WORKFLOW: {
-    request: true,
-    reply: 'WORKFLOW_STATUS',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  CANCEL_WORKFLOW: {
-    request: true,
-    reply: 'WORKFLOW_CANCELED',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  OPEN_BUZZ_PURCHASE: {
-    request: true,
-    reply: 'BUZZ_PURCHASE_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  OPEN_CHECKPOINT_PICKER: {
-    request: true,
-    reply: 'CHECKPOINT_PICKER_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required', // ported in #2799
-    InlineHost: INLINE_STUB,
-  },
-  SET_USER_CHECKPOINT: {
-    request: true,
-    reply: 'USER_CHECKPOINT_SET',
-    IframeHost: 'required',
-    // PAGE: persists to block_user_settings keyed by a model-bound install;
-    // updateUserSettings HARD-REQUIRES modelId in the token ctx, which a page
-    // token (entityType:'none') lacks. The page host registers a FAIL-FAST NACK
-    // (USER_CHECKPOINT_SET ok:false) so persist() rejects immediately instead of
-    // hanging — see the handler comment + the parity doc's OPEN DECISION.
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  APP_STORAGE_GET: {
-    request: true,
-    reply: 'APP_STORAGE_GET_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  APP_STORAGE_SET: {
-    request: true,
-    reply: 'APP_STORAGE_SET_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  APP_STORAGE_DELETE: {
-    request: true,
-    reply: 'APP_STORAGE_DELETE_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  APP_STORAGE_LIST: {
-    request: true,
-    reply: 'APP_STORAGE_LIST_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-  APP_STORAGE_QUOTA: {
-    request: true,
-    reply: 'APP_STORAGE_QUOTA_RESULT',
-    IframeHost: 'required',
-    PageBlockHost: 'required',
-    InlineHost: INLINE_STUB,
-  },
-};
-
-// The exact set of block→host message types in the SDK `BlockToParentMessage`
-// union (@civitai/app-sdk blocks/messages.ts). Pinned here so that if the SDK
-// adds a message and someone updates the union without updating this test, the
-// "inventory matches the SDK union" assertion below fails — forcing the new
-// message to be triaged through INVENTORY (and thus through host coverage).
-const SDK_BLOCK_TO_PARENT_TYPES = [
-  'BLOCK_READY',
-  'BLOCK_ERROR',
-  'REQUEST_TOKEN',
-  'RESIZE_IFRAME',
-  'SUBMIT_WORKFLOW',
-  'ESTIMATE_WORKFLOW',
-  'POLL_WORKFLOW',
-  'CANCEL_WORKFLOW',
-  'OPEN_BUZZ_PURCHASE',
-  'OPEN_CHECKPOINT_PICKER',
-  'SET_USER_CHECKPOINT',
-  'NAVIGATE',
-  'REQUEST_SIGN_IN',
-  'REQUEST_CONSENT',
-  'TRACK_EVENT',
-  'APP_STORAGE_GET',
-  'APP_STORAGE_SET',
-  'APP_STORAGE_DELETE',
-  'APP_STORAGE_LIST',
-  'APP_STORAGE_QUOTA',
-] as const;
-
 const HOSTS: HostFile[] = ['IframeHost.tsx', 'PageBlockHost.tsx', 'InlineHost.tsx'];
 
 describe('App Blocks host↔SDK handler parity (gotcha-#73 "spins forever" guard)', () => {
-  it('the inventory covers EXACTLY the SDK BlockToParentMessage union (no drift)', () => {
-    // If this fails: the SDK added/removed a block→host message. Update
-    // INVENTORY (with per-host required/N-A) AND SDK_BLOCK_TO_PARENT_TYPES, then
-    // wire any new REQUEST-style message into the hosts it applies to.
-    expect([...Object.keys(INVENTORY)].sort()).toEqual([...SDK_BLOCK_TO_PARENT_TYPES].sort());
-  });
-
   // Per-host × per-message: a 'required' entry MUST have a registered handler.
   for (const host of HOSTS) {
     describe(host, () => {

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -1,0 +1,278 @@
+import type { BlockToParentMessageType } from '@civitai/app-sdk/blocks';
+
+/**
+ * App Blocks host↔SDK handler PARITY inventory + the COMPILE-TIME coverage gate.
+ *
+ * This is the NON-TEST module (NOT `*.test.ts`) so the type-level assertion at
+ * the bottom is guaranteed to be in civitai's `tsc --noEmit` / `next build`
+ * typecheck graph regardless of how the test runner treats `*.test.ts` files.
+ * (It is NOT under `src/pages/**` — Next would treat those as routes; gotchas
+ * #78/#81.) The runtime grep-based parity assertions live in
+ * `hostHandlerParity.test.ts`, which imports `INVENTORY` from here.
+ *
+ * THE BUG CLASS this encodes (gotcha-#73, the "spins forever, no network call,
+ * no console error" class):
+ *
+ *   App Blocks has multiple host components that each register their own
+ *   `onMessage('<TYPE>', …)` handlers BY HAND to bridge a block's postMessages:
+ *     - IframeHost.tsx     — model-slot host (model.sidebar slots)
+ *     - PageBlockHost.tsx  — full-page run host (civitai.com/apps/run/<slug>)
+ *     - InlineHost.tsx     — inline host (v2 stub, not active in prod)
+ *
+ *   The SDK (`@civitai/app-sdk` / `@civitai/blocks-react`) sends two flavours of
+ *   block→host message: REQUEST-style (`sendTypedRequest`, AWAITS a specific
+ *   `*_RESULT` / ack reply) and fire-and-forget (`sendMessage`, no reply). When
+ *   a block sends a REQUEST-style message and the host has NO handler, the
+ *   request never gets a reply → the block hangs to its SDK request timeout →
+ *   the UI spins forever with no network call and no error. The dev:live SDK
+ *   host serves these messages, so authors test green locally then break in
+ *   prod — a fidelity gap (this exact gap bit OPEN_CHECKPOINT_PICKER on pages,
+ *   fixed in civitai #2799).
+ *
+ * SOURCE OF TRUTH for the inventory: the SDK message protocol
+ * `@civitai/app-sdk` `blocks/messages.ts` `BlockToParentMessage` union, cross-
+ * referenced with the `@civitai/blocks-react` hooks (which `type` each posts and
+ * whether it uses `sendTypedRequest` [REQUEST] or `sendMessage` [fire-forget]).
+ * When the SDK adds a block→host message, add it here with its hosts/exemptions.
+ *
+ * Maintenance: the grep-based test is a deliberately DUMB structural check — it
+ * asserts a handler is REGISTERED, not that it's correct. Behavioral correctness
+ * lives in the per-message browser tests (PageBlockHost*.browser.test.tsx). The
+ * value here is catching the MISSING-handler case the next time the protocol
+ * grows.
+ */
+
+export type HostFile = 'IframeHost.tsx' | 'PageBlockHost.tsx' | 'InlineHost.tsx';
+
+/**
+ * The authoritative inventory: every block→host message a host may receive, with
+ * per-host requirements. `request: true` = REQUEST-style (awaits a reply; an
+ * unhandled one HANGS the block — this is the dangerous class). For each host,
+ * `'required'` means the host MUST register a handler; a string is an explicit
+ * `N/A` rationale (the host legitimately doesn't handle it).
+ *
+ * NOTE: `INVENTORY` may legitimately contain entries that are AHEAD of the
+ * currently-PUBLISHED SDK dist union (forward-looking coverage — e.g.
+ * `CANCEL_WORKFLOW`, `REQUEST_SIGN_IN`, `REQUEST_CONSENT` exist in the newer
+ * `civitai-app-starters` source but not yet in the published
+ * `@civitai/app-sdk` dist `BlockToParentMessage`). The compile-time gate below
+ * is intentionally ONE-DIRECTIONAL: every PUBLISHED SDK type must be an
+ * INVENTORY key, but INVENTORY may carry extra ahead-of-published keys.
+ *
+ * Keep one-line rationales human-readable — they ARE the documentation a future
+ * maintainer reads when the parity test fails.
+ */
+export type HostReq = 'required' | string; // string = N/A reason
+
+export interface MessageSpec {
+  /** REQUEST-style (sendTypedRequest, awaits a *_RESULT/ack). Unhandled ⇒ hang. */
+  request: boolean;
+  /** Reply type the SDK awaits (REQUEST-style only); '' for fire-and-forget. */
+  reply: string;
+  IframeHost: HostReq;
+  PageBlockHost: HostReq;
+  InlineHost: HostReq;
+}
+
+// InlineHost is a v1 STUB that throws on render and wires NO message bridge
+// (BlockHost never routes inline installs in v1 — `canUseInline` is always
+// false). So EVERY message is N/A for it today; the shared reason is below.
+export const INLINE_STUB =
+  'InlineHost is a v1 stub (throws on render, no message bridge in v1)';
+
+export const INVENTORY = {
+  // ── Lifecycle / fire-and-forget (no reply ⇒ unhandled never HANGS, but a
+  //    page that ignores them just no-ops; documented per host) ───────────────
+  BLOCK_READY: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  BLOCK_ERROR: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  RESIZE_IFRAME: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    // N/A: the page renders the iframe full-viewport (height:100%); a page block
+    // fills the surface and does NOT size-to-content, so there is nothing to
+    // resize. Fire-and-forget ⇒ an ignored RESIZE_IFRAME never hangs the block.
+    PageBlockHost:
+      'page iframe is full-viewport (height:100%); no size-to-content, fire-and-forget so no hang',
+    InlineHost: INLINE_STUB,
+  },
+  NAVIGATE: {
+    request: false,
+    reply: '',
+    // N/A: the model slot is an embedded panel inside the model page — a block
+    // navigating the host away from the model page is out of its remit; the
+    // model host intentionally does not bridge NAVIGATE.
+    IframeHost:
+      'model slot is an embedded panel; host-navigation is out of remit (no NAVIGATE bridge)',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  TRACK_EVENT: {
+    request: false,
+    reply: '',
+    // N/A (both real hosts): TRACK_EVENT is fire-and-forget analytics and is
+    // currently NOT bridged by EITHER host (no host-side analytics sink wired).
+    // Unhandled ⇒ silently dropped, never a hang. If a sink is added, flip the
+    // relevant host(s) to 'required' here so coverage is enforced.
+    IframeHost: 'analytics fire-and-forget; no host-side sink wired (dropped, never hangs)',
+    PageBlockHost: 'analytics fire-and-forget; no host-side sink wired (dropped, never hangs)',
+    InlineHost: INLINE_STUB,
+  },
+  // REQUEST_SIGN_IN / REQUEST_CONSENT are AHEAD of the published SDK dist union
+  // (present in the newer civitai-app-starters source). Forward-looking coverage
+  // — kept intentionally; the compile-time gate does not require published.
+  REQUEST_SIGN_IN: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  REQUEST_CONSENT: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+
+  // ── REQUEST-style (await a reply ⇒ unhandled HANGS the block) ───────────────
+  REQUEST_TOKEN: {
+    request: true,
+    reply: 'TOKEN_REFRESH_RESPONSE',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SUBMIT_WORKFLOW: {
+    request: true,
+    reply: 'WORKFLOW_SUBMITTED',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  ESTIMATE_WORKFLOW: {
+    request: true,
+    reply: 'ESTIMATE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  POLL_WORKFLOW: {
+    request: true,
+    reply: 'WORKFLOW_STATUS',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  // CANCEL_WORKFLOW is AHEAD of the published SDK dist union (present in the
+  // newer civitai-app-starters source). Forward-looking coverage — kept.
+  CANCEL_WORKFLOW: {
+    request: true,
+    reply: 'WORKFLOW_CANCELED',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  OPEN_BUZZ_PURCHASE: {
+    request: true,
+    reply: 'BUZZ_PURCHASE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  OPEN_CHECKPOINT_PICKER: {
+    request: true,
+    reply: 'CHECKPOINT_PICKER_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required', // ported in #2799
+    InlineHost: INLINE_STUB,
+  },
+  SET_USER_CHECKPOINT: {
+    request: true,
+    reply: 'USER_CHECKPOINT_SET',
+    IframeHost: 'required',
+    // PAGE: persists to block_user_settings keyed by a model-bound install;
+    // updateUserSettings HARD-REQUIRES modelId in the token ctx, which a page
+    // token (entityType:'none') lacks. The page host registers a FAIL-FAST NACK
+    // (USER_CHECKPOINT_SET ok:false) so persist() rejects immediately instead of
+    // hanging — see the handler comment + the parity doc's OPEN DECISION.
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_GET: {
+    request: true,
+    reply: 'APP_STORAGE_GET_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_SET: {
+    request: true,
+    reply: 'APP_STORAGE_SET_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_DELETE: {
+    request: true,
+    reply: 'APP_STORAGE_DELETE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_LIST: {
+    request: true,
+    reply: 'APP_STORAGE_LIST_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  APP_STORAGE_QUOTA: {
+    request: true,
+    reply: 'APP_STORAGE_QUOTA_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+} satisfies Record<string, MessageSpec>;
+
+/**
+ * The PUBLISHED SDK block→host message union, read straight from the installed
+ * `@civitai/app-sdk/blocks` package (NOT a hand-maintained literal). This is the
+ * real contract civitai builds against.
+ */
+type SdkBlockToParentType = BlockToParentMessageType;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// COMPILE-TIME coverage gate (the one manual step the runtime grep test CANNOT
+// catch): if the PUBLISHED SDK adds a block→host message type that INVENTORY
+// doesn't list, this becomes a TypeScript ERROR — caught by civitai's Tekton
+// typecheck / `next build`, because this module is in the tsconfig `include`
+// graph (under `src`, not excluded; not a `*.test.ts` corner case).
+//
+// ONE-DIRECTIONAL by design: every PUBLISHED SDK type must be an INVENTORY key;
+// INVENTORY MAY carry extra ahead-of-published keys (CANCEL_WORKFLOW,
+// REQUEST_SIGN_IN, REQUEST_CONSENT today). We do NOT assert the reverse — that
+// would delete real forward coverage every time the published dist lags.
+//
+// If this errors, the failure type prints the missing type(s):
+//   ['INVENTORY missing published SDK message(s):', <the missing union members>]
+// ─────────────────────────────────────────────────────────────────────────────
+type _SdkCovered = SdkBlockToParentType extends keyof typeof INVENTORY
+  ? true
+  : ['INVENTORY missing published SDK message(s):', Exclude<SdkBlockToParentType, keyof typeof INVENTORY>];
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _sdkCovered: _SdkCovered = true;


### PR DESCRIPTION
## The bug class — "spins forever, no network call, no console error" (gotcha-#73)

App Blocks has multiple host components that bridge block→host `postMessage`s — `IframeHost.tsx` (model slot), `PageBlockHost.tsx` (full-page run host, `/apps/run/<slug>`), `InlineHost.tsx` (v1 stub) — each hand-registering its own `onMessage('<TYPE>', …)` handlers. The SDK sends two kinds of message:

- **REQUEST-style** (`sendTypedRequest`, awaits a `*_RESULT`/ack) — if the host has **no handler**, the reply never comes and the block **hangs to its SDK timeout**: UI spins forever, no network call, no error.
- **fire-and-forget** (`sendMessage`) — an unhandled one is silently dropped (a no-op), never a hang.

The dev:live SDK host serves all of these, so authors test green locally then break in prod — a fidelity gap. This exact gap bit `OPEN_CHECKPOINT_PICKER` on pages (fixed in #2799). This PR makes the whole class catchable and closes the remaining page gap.

## Coverage matrix (verified 2026-06-29)

Source of truth: `@civitai/app-sdk` `blocks/messages.ts` `BlockToParentMessage` union, cross-referenced with the `@civitai/blocks-react` hooks (REQUEST vs fire-and-forget per hook). Full matrix + rationales in `claudedocs/app-blocks-host-handler-parity-2026-06-29.md`.

| Message | Style | IframeHost | PageBlockHost |
|---|---|---|---|
| REQUEST_TOKEN, SUBMIT/ESTIMATE/POLL/CANCEL_WORKFLOW, OPEN_BUZZ_PURCHASE, OPEN_CHECKPOINT_PICKER, APP_STORAGE_{GET,SET,DELETE,LIST,QUOTA} | REQUEST | ✅ | ✅ |
| **SET_USER_CHECKPOINT** | REQUEST | ✅ | **❌ → fail-fast NACK (this PR)** |
| BLOCK_READY, BLOCK_ERROR, REQUEST_SIGN_IN, REQUEST_CONSENT | fire-forget | ✅ | ✅ |
| NAVIGATE | fire-forget | N/A (embedded panel) | ✅ |
| RESIZE_IFRAME | fire-forget | ✅ | N/A (page is full-viewport) |
| TRACK_EVENT | fire-forget | N/A (no sink wired) | N/A (no sink wired) |

`InlineHost` is a v1 stub (throws on render, no message bridge) → every message N/A today; the guard still enforces a rationale so a future v2 activation can't silently skip a handler.

**The only remaining REQUEST-style page gap was `SET_USER_CHECKPOINT`.** Every other REQUEST-style message is already handled on the page.

## What this PR ports vs flags for decision

**Ported — `SET_USER_CHECKPOINT` → fail-fast `USER_CHECKPOINT_SET { ok:false, error }`:** `useCheckpointPicker().persist()` awaits this reply (it throws the `error` when `ok:false`); before this PR it hung. A page **cannot** persist a checkpoint override the way the model slot does — `blocks.updateUserSettings` hard-requires `modelId` in the token ctx, and a page token (`entityType:'none'`) has none, so it would throw `BAD_REQUEST`. Rather than invent a persistence target, the host replies with the exact known-shape NACK so the block **fails fast** instead of hanging. The page's checkpoint flow is the in-memory `OPEN_CHECKPOINT_PICKER` result the block already holds.

**Flagged for a human (OPEN DECISIONS, in the doc):**
1. *Should page blocks be able to persist a viewer checkpoint preference at all?* Today: no target exists. If wanted, it needs a new page-scoped storage target (e.g. the app-storage KV) + a server proc that doesn't demand `modelId` + a read-back path. Product decision, out of scope.
2. *`TRACK_EVENT` is bridged by neither host* (fire-and-forget analytics, no host-side sink). Dropped, never hangs. Wiring a sink is a feature, not a parity gap — flip the parity rows to `required` if/when added.

## The durable guard (most important deliverable)

`src/components/AppBlocks/hostHandlerParity.test.ts` (plain unit test, node env, **not** under `src/pages/**`): hard-codes the inventory with per-host `required`/`N-A: <rationale>`, greps each host source for an `onMessage('<TYPE>')` registration (multi-line aware), and pins the inventory to the SDK union. It **fails CI** the next time someone adds an SDK message or a new host surface without wiring the host — converting the "spins forever" class into a build-time error.

## Tests (run in a worktree; reported honestly)

- `hostHandlerParity.test.ts` — **62/62 pass**. Mutation-verified: flipping a genuinely-unhandled message to `required` makes it fail, confirming the guard bites.
- `PageBlockHostSetUserCheckpoint.browser.test.tsx` (real PageBlockHost + real postMessage bridge) — **5/5 pass** (NACK shape, clear-override NACK, requestId-drop rules, no side effect).
- `PageBlockHostCheckpointPicker.browser.test.tsx` (#2799) re-run — **7/7 pass** (no regression from the adjacent edit).
- **Not run:** full local `tsc` — the Prisma engine is broken on this NixOS host. Tekton pr-preview is the authoritative typecheck. Imports/types sanity-checked by reading.

Purely additive; no existing handler or SDK code altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
