### PR TITLE
fix(lighthouse): polyfill globalThis.crypto for jose v6 on Node 18

### DIFF
--- a/tests/lighthouse-mint-cookie.cjs
+++ b/tests/lighthouse-mint-cookie.cjs
@@ -27,8 +27,15 @@ const fs = require('fs');
 const path = require('path');
 // jose is ESM-only since v6 — require() throws ERR_REQUIRE_ESM from this .cjs,
 // so load it via dynamic import() inside main() (the only EncryptJWT consumer).
-const { hkdfSync } = require('node:crypto');
+const nodeCrypto = require('node:crypto');
+const { hkdfSync } = nodeCrypto;
 const { v4: uuid } = require('uuid');
+
+// jose v6 uses Web Crypto via the global `crypto`. The lhci-client image runs
+// Node 18, which doesn't expose `crypto` as a global (it became global in Node
+// 19+), so the import below throws "crypto is not defined". Polyfill from
+// node:crypto.webcrypto when absent — no-op on Node 19+.
+if (!globalThis.crypto) globalThis.crypto = nodeCrypto.webcrypto;
 
 const SECRET = process.env.NEXTAUTH_SECRET;
 const BASE_URL = process.env.BASE_URL;


### PR DESCRIPTION
## Follow-up to #2797 — Lighthouse still dark

#2797 fixed the `require('jose')` → `ERR_REQUIRE_ESM` error, but Lighthouse CI was **still** producing nothing on every preview. The talos-side comment now honestly reports the cause (PRs #2798–#2801):

> 🔦 Lighthouse: ⚠️ cookie mint failed — Lighthouse skipped

The actual error in the Tekton `lighthouse` task (lhci-client image, **Node 18.20.8**):

```
mint-cookie failed: crypto is not defined
```

jose v6 uses **Web Crypto via the global `crypto`**, which Node 18 does **not** expose as a global (it became a global in Node 19+). The lhci-client:0.15.1 image ships Node 18, so the import throws → mint fails → no authed cookie → Lighthouse skipped.

## Fix

Polyfill `globalThis.crypto` from `node:crypto.webcrypto` when absent (no-op on Node 19+). One-file change.

## Verification (under the real image this time)

Ran the script in the actual `patrickhulce/lhci-client:0.15.1` image (Node 18.20.8):

```
Wrote lighthouserc.runtime.json — 4 routes x 5 runs, authed as ci-smoke-gold
exit=0
RUNTIME CONFIG WRITTEN (4188 bytes); extraHeaders lines=2
```

> Note: #2797 was verified locally on Node 20, which already has the `crypto` global — that's why this slipped through. Verified under the image's real Node 18 runtime this time. Report-only task; no pipeline-gating impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)