### PR TITLE
feat(app-blocks): wire get-started Request-access CTA to a prefilled civitai/cli issue

### DIFF
--- a/src/components/Apps/GetStartedBody.browser.test.tsx
+++ b/src/components/Apps/GetStartedBody.browser.test.tsx
@@ -11,6 +11,7 @@ import {
   CLI_SUBMIT_COMMAND,
   GetStartedBody,
   REQUEST_ACCESS_HREF,
+  REQUEST_ACCESS_TITLE,
 } from '~/components/Apps/GetStartedBody';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -85,12 +86,17 @@ describe('GetStartedBody (public App builders landing)', () => {
     expect(appSdk.element().getAttribute('href')).toBe(APP_SDK_NPM_URL);
   });
 
-  test('renders the Request-access CTA wired to the placeholder href', async () => {
+  test('renders the Request-access CTA wired to a prefilled civitai/cli issue', async () => {
     renderWithProviders(<GetStartedBody />);
-    const cta = page.getByRole('link', { name: 'Request access' });
+    const cta = page.getByRole('link', { name: 'Request access on GitHub' });
     await expect.element(cta).toBeInTheDocument();
-    // Deliberate placeholder until the real form exists.
     expect(cta.element().getAttribute('href')).toBe(REQUEST_ACCESS_HREF);
-    expect(REQUEST_ACCESS_HREF).toBe('#');
+    // Points at a well-formed prefilled new-issue on the public CLI repo
+    // (no longer the `#` placeholder).
+    expect(REQUEST_ACCESS_HREF).toMatch(
+      /^https:\/\/github\.com\/civitai\/cli\/issues\/new\?/
+    );
+    expect(REQUEST_ACCESS_HREF).toContain(`title=${encodeURIComponent(REQUEST_ACCESS_TITLE)}`);
+    expect(REQUEST_ACCESS_HREF).toContain('&body=');
   });
 });

--- a/src/components/Apps/GetStartedBody.tsx
+++ b/src/components/Apps/GetStartedBody.tsx
@@ -51,10 +51,20 @@ export const CLI_CREATE_COMMAND = 'civitai app create my-app';
 export const CLI_RUN_COMMAND = 'cd my-app && npm install && npm run dev:harness';
 export const CLI_SUBMIT_COMMAND = 'civitai app submit';
 
-// TODO: real request-access link — replace this placeholder with the live
-// request-access form (or a mailto:) before launch. Left as `#` so it is an
-// obvious, non-functional placeholder.
-export const REQUEST_ACCESS_HREF = '#';
+// Request-access intake = a PREFILLED new-issue on the public `civitai/cli`
+// repo (the dev-native, zero-infra channel the page already links to). The
+// title + body below are URL-encoded into the github.com/.../issues/new query
+// so the issue opens pre-populated with a short intake prompt.
+export const REQUEST_ACCESS_TITLE = 'App Blocks: request publishing access';
+export const REQUEST_ACCESS_BODY = `Thanks for your interest in building on Civitai Apps!
+
+- Civitai username:
+- What you'd like to build:
+- Links to anything you've built (repo/demo, optional):
+`;
+export const REQUEST_ACCESS_HREF = `https://github.com/civitai/cli/issues/new?title=${encodeURIComponent(
+  REQUEST_ACCESS_TITLE
+)}&body=${encodeURIComponent(REQUEST_ACCESS_BODY)}`;
 
 function CopyableCommand({ command }: { command: string }) {
   return (
@@ -204,15 +214,17 @@ export function GetStartedBody() {
             Publishing is in private beta.
           </Text>
           <Text size="sm" c="dimmed">
-            Build and test locally today; request access to publish.
+            Build and test locally today; request access on GitHub to publish.
           </Text>
           <Group gap="xs">
             <Button
               component="a"
               href={REQUEST_ACCESS_HREF}
+              target="_blank"
+              rel="noopener noreferrer"
               leftSection={<IconLock size={16} />}
             >
-              Request access
+              Request access on GitHub
             </Button>
           </Group>
         </Stack>


### PR DESCRIPTION
## What

Follow-up to #2801, which shipped the public App-builders get-started page (`src/pages/apps/get-started.tsx` + `src/components/Apps/GetStartedBody.tsx`) with its **"Request access"** CTA wired to a placeholder `REQUEST_ACCESS_HREF = '#'` (a dead link).

This points it at a real destination: a **prefilled new-issue on the public `civitai/cli` repo** — the dev-native, zero-infra intake channel the page already links to.

- `REQUEST_ACCESS_HREF` now builds a `https://github.com/civitai/cli/issues/new?title=...&body=...` URL from readable `REQUEST_ACCESS_TITLE` / `REQUEST_ACCESS_BODY` consts, URL-encoded via `encodeURIComponent`. The body is a short intake prompt (Civitai username / what you'd like to build / links).
- CTA relabeled **"Request access" → "Request access on GitHub"** and now opens in a new tab (`target="_blank" rel="noopener noreferrer"`), mirroring the file's other external links. Inline copy tweaked to "…request access on GitHub to publish."
- The browser test (`GetStartedBody.browser.test.tsx`) is updated: the link is now named **"Request access on GitHub"**, and `REQUEST_ACCESS_HREF` is asserted to be a well-formed civitai/cli new-issue URL containing the encoded title (not `'#'`). All other assertions kept intact.

## Why

The get-started page is still **staged mod-only** (`appBlocksGetStarted` flag = `['mod']`) and will widen to public later. The dead `#` CTA needs a real destination **before** that public launch — this is pre-public-launch polish so the funnel works the moment the flag flips.

Scope is purely the link + label + test — the page gate, the flag, and the nav are untouched.

## Test

Browser test run locally (vitest `component` project, real headless Chromium): **8/8 passed**, including the updated Request-access assertion.

The final href (decoded title `App Blocks: request publishing access`):
```
https://github.com/civitai/cli/issues/new?title=App%20Blocks%3A%20request%20publishing%20access&body=Thanks%20for%20your%20interest...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)