### PR TITLE
refactor(app-blocks): single-source CLI quickstart commands (get-started + submit CTA)

### DIFF
--- a/src/components/Apps/CliSubmitCta.browser.test.tsx
+++ b/src/components/Apps/CliSubmitCta.browser.test.tsx
@@ -1,12 +1,13 @@
 import { describe, expect, test } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
+import { CliSubmitCta } from '~/components/Apps/CliSubmitCta';
 import {
   CIVITAI_CLI_GITHUB_URL,
   CLI_CREATE_COMMAND,
-  CLI_INSTALL_COMMAND,
+  CLI_CREATE_SAMPLE_COMMAND,
+  CLI_INSTALL_BREW,
   CLI_SUBMIT_COMMAND,
-  CliSubmitCta,
-} from '~/components/Apps/CliSubmitCta';
+} from '~/components/Apps/cliCommands';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -47,20 +48,29 @@ describe('CliSubmitCta (CLI-first submit primary CTA)', () => {
   test('shows the install + create + submit one-liners', async () => {
     renderWithProviders(<CliSubmitCta />);
     // Commands are rendered prefixed with a shell prompt ("$ ").
-    await expect.element(page.getByText(`$ ${CLI_INSTALL_COMMAND}`)).toBeInTheDocument();
+    await expect.element(page.getByText(`$ ${CLI_INSTALL_BREW}`)).toBeInTheDocument();
     await expect.element(page.getByText(`$ ${CLI_CREATE_COMMAND}`)).toBeInTheDocument();
     await expect.element(page.getByText(`$ ${CLI_SUBMIT_COMMAND}`)).toBeInTheDocument();
   });
 
   test('the install command is the brew tap one-liner', async () => {
-    expect(CLI_INSTALL_COMMAND).toBe('brew install civitai/tap/civitai');
+    expect(CLI_INSTALL_BREW).toBe('brew install civitai/tap/civitai');
     expect(CLI_CREATE_COMMAND).toBe('civitai app create');
     expect(CLI_SUBMIT_COMMAND).toBe('civitai app submit');
   });
 
+  // The shared cliCommands module exposes BOTH create forms: the bare
+  // `civitai app create` (this CTA) and the with-sample-name
+  // `civitai app create my-app` (the get-started quickstart). Pin both so a
+  // change to either is a deliberate, reviewed edit.
+  test('the shared module exposes both create forms as the real one-liners', () => {
+    expect(CLI_CREATE_COMMAND).toBe('civitai app create');
+    expect(CLI_CREATE_SAMPLE_COMMAND).toBe('civitai app create my-app');
+  });
+
   test('each command has a copy affordance with an accessible name', async () => {
     renderWithProviders(<CliSubmitCta />);
-    for (const command of [CLI_INSTALL_COMMAND, CLI_CREATE_COMMAND, CLI_SUBMIT_COMMAND]) {
+    for (const command of [CLI_INSTALL_BREW, CLI_CREATE_COMMAND, CLI_SUBMIT_COMMAND]) {
       await expect
         .element(page.getByRole('button', { name: `Copy command: ${command}` }))
         .toBeInTheDocument();
@@ -86,7 +96,7 @@ describe('CliSubmitCta (CLI-first submit primary CTA)', () => {
   // document that the fix is canonical-pattern hardening, not a behavior change.
   test('clicking the copy button copies — shows "Copied"', async () => {
     renderWithProviders(<CliSubmitCta />);
-    const button = page.getByRole('button', { name: `Copy command: ${CLI_INSTALL_COMMAND}` });
+    const button = page.getByRole('button', { name: `Copy command: ${CLI_INSTALL_BREW}` });
     await expect.element(button).toBeInTheDocument();
     await button.click();
     // CopyButton flips its render-prop `copied` → the Code block text becomes

--- a/src/components/Apps/CliSubmitCta.tsx
+++ b/src/components/Apps/CliSubmitCta.tsx
@@ -13,19 +13,13 @@ import {
   Title,
 } from '@mantine/core';
 import { IconBrandGithub, IconCheck, IconClipboard, IconTerminal2 } from '@tabler/icons-react';
+import {
+  CIVITAI_CLI_GITHUB_URL,
+  CLI_CREATE_COMMAND,
+  CLI_INSTALL_BREW,
+  CLI_SUBMIT_COMMAND,
+} from '~/components/Apps/cliCommands';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
-
-/**
- * The canonical public Civitai CLI repository. This is the recommended way to
- * author + submit an App Block — `civitai app create` scaffolds a block and
- * `civitai app submit` packages + uploads it (no hand-rolled ZIP).
- */
-export const CIVITAI_CLI_GITHUB_URL = 'https://github.com/civitai/cli';
-
-/** Install + author + submit one-liners promoted as the primary path. */
-export const CLI_INSTALL_COMMAND = 'brew install civitai/tap/civitai';
-export const CLI_CREATE_COMMAND = 'civitai app create';
-export const CLI_SUBMIT_COMMAND = 'civitai app submit';
 
 function CopyableCommand({ command }: { command: string }) {
   return (
@@ -89,7 +83,7 @@ export function CliSubmitCta() {
           <Text size="sm" fw={600}>
             1. Install
           </Text>
-          <CopyableCommand command={CLI_INSTALL_COMMAND} />
+          <CopyableCommand command={CLI_INSTALL_BREW} />
         </Stack>
 
         <Stack gap={6}>

--- a/src/components/Apps/GetStartedBody.browser.test.tsx
+++ b/src/components/Apps/GetStartedBody.browser.test.tsx
@@ -1,18 +1,20 @@
 import { describe, expect, test } from 'vitest';
 import { page } from 'vitest/browser';
 import {
-  APP_SDK_NPM_URL,
-  BLOCKS_REACT_NPM_URL,
-  CIVITAI_CLI_GITHUB_URL,
-  CLI_CREATE_COMMAND,
-  CLI_INSTALL_BREW,
-  CLI_INSTALL_GO,
-  CLI_RUN_COMMAND,
-  CLI_SUBMIT_COMMAND,
   GetStartedBody,
   REQUEST_ACCESS_HREF,
   REQUEST_ACCESS_TITLE,
 } from '~/components/Apps/GetStartedBody';
+import {
+  APP_SDK_NPM_URL,
+  BLOCKS_REACT_NPM_URL,
+  CIVITAI_CLI_GITHUB_URL,
+  CLI_CREATE_SAMPLE_COMMAND,
+  CLI_INSTALL_BREW,
+  CLI_INSTALL_GO,
+  CLI_RUN_COMMAND,
+  CLI_SUBMIT_COMMAND,
+} from '~/components/Apps/cliCommands';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -46,7 +48,7 @@ describe('GetStartedBody (public App builders landing)', () => {
     // Copyable commands render prefixed with a shell prompt ("$ ").
     for (const command of [
       CLI_INSTALL_BREW,
-      CLI_CREATE_COMMAND,
+      CLI_CREATE_SAMPLE_COMMAND,
       CLI_RUN_COMMAND,
       CLI_SUBMIT_COMMAND,
     ]) {
@@ -66,7 +68,7 @@ describe('GetStartedBody (public App builders landing)', () => {
   test('command constants are the real, verified one-liners', () => {
     expect(CLI_INSTALL_BREW).toBe('brew install civitai/tap/civitai');
     expect(CLI_INSTALL_GO).toBe('go install github.com/civitai/cli/cmd/civitai@latest');
-    expect(CLI_CREATE_COMMAND).toBe('civitai app create my-app');
+    expect(CLI_CREATE_SAMPLE_COMMAND).toBe('civitai app create my-app');
     expect(CLI_RUN_COMMAND).toBe('cd my-app && npm install && npm run dev:harness');
     expect(CLI_SUBMIT_COMMAND).toBe('civitai app submit');
   });

--- a/src/components/Apps/GetStartedBody.tsx
+++ b/src/components/Apps/GetStartedBody.tsx
@@ -14,6 +14,16 @@ import {
   Title,
 } from '@mantine/core';
 import { IconBrandGithub, IconCheck, IconClipboard, IconLock } from '@tabler/icons-react';
+import {
+  APP_SDK_NPM_URL,
+  BLOCKS_REACT_NPM_URL,
+  CIVITAI_CLI_GITHUB_URL,
+  CLI_CREATE_SAMPLE_COMMAND,
+  CLI_INSTALL_BREW,
+  CLI_INSTALL_GO,
+  CLI_RUN_COMMAND,
+  CLI_SUBMIT_COMMAND,
+} from '~/components/Apps/cliCommands';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
 /**
@@ -37,19 +47,9 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
  * isolation in component tests.
  */
 
-// --- Real, verified external links / commands (single source for tests) ---
-export const CIVITAI_CLI_GITHUB_URL = 'https://github.com/civitai/cli';
-export const BLOCKS_REACT_NPM_URL = 'https://www.npmjs.com/package/@civitai/blocks-react';
-export const APP_SDK_NPM_URL = 'https://www.npmjs.com/package/@civitai/app-sdk';
-
-export const CLI_INSTALL_BREW = 'brew install civitai/tap/civitai';
-export const CLI_INSTALL_GO = 'go install github.com/civitai/cli/cmd/civitai@latest';
-export const CLI_CREATE_COMMAND = 'civitai app create my-app';
-// The CLI does NOT install deps on `create`; its own next-step prompt is
-// `cd <dir> && npm install && npm run dev:harness`. `dev:harness` serves a MOCK
-// host at localhost:5186 (plain `npm run dev` shows a blank screen — no host).
-export const CLI_RUN_COMMAND = 'cd my-app && npm install && npm run dev:harness';
-export const CLI_SUBMIT_COMMAND = 'civitai app submit';
+// CLI commands + ecosystem links are single-sourced in `./cliCommands` (shared
+// with the submit CTA so the two surfaces can't drift). The quickstart uses the
+// with-sample-name create form (`CLI_CREATE_SAMPLE_COMMAND`).
 
 // Request-access intake = a PREFILLED new-issue on the public `civitai/cli`
 // repo (the dev-native, zero-infra channel the page already links to). The
@@ -118,7 +118,7 @@ export function GetStartedBody() {
         <Text size="xs" c="dimmed">
           or: <Code>{CLI_INSTALL_GO}</Code>
         </Text>
-        <CopyableCommand command={CLI_CREATE_COMMAND} />
+        <CopyableCommand command={CLI_CREATE_SAMPLE_COMMAND} />
         <CopyableCommand command={CLI_RUN_COMMAND} />
         <Text size="sm" c="dimmed">
           Opens at <Code>localhost:5186</Code> in a mock Civitai — no account, no Buzz needed. Edit{' '}

--- a/src/components/Apps/cliCommands.ts
+++ b/src/components/Apps/cliCommands.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical Civitai App-Blocks CLI commands + ecosystem links — the SINGLE
+ * source within civitai-web for the get-started page (`GetStartedBody`) and the
+ * submit CTA (`CliSubmitCta`), so the two surfaces can't drift.
+ *
+ * SOURCE OF TRUTH is the `civitai/cli` repo (its README "## Quickstart" +
+ * `internal/cmd/app_init.go` printed next-steps). The CLI exposes no
+ * machine-readable manifest today, so these are kept in sync MANUALLY — update
+ * here when the CLI's canonical quickstart changes; the `*.browser.test.tsx`
+ * suites pin the exact strings so any change is a deliberate, reviewed edit.
+ */
+
+// --- Ecosystem links ---
+export const CIVITAI_CLI_GITHUB_URL = 'https://github.com/civitai/cli';
+export const BLOCKS_REACT_NPM_URL = 'https://www.npmjs.com/package/@civitai/blocks-react';
+export const APP_SDK_NPM_URL = 'https://www.npmjs.com/package/@civitai/app-sdk';
+
+// --- Install ---
+export const CLI_INSTALL_BREW = 'brew install civitai/tap/civitai';
+export const CLI_INSTALL_GO = 'go install github.com/civitai/cli/cmd/civitai@latest';
+
+// --- Author / run / submit ---
+/** Bare `civitai app create` (the submit CTA's form). */
+export const CLI_CREATE_COMMAND = 'civitai app create';
+/** With-sample-name form the quickstart uses. */
+export const CLI_CREATE_SAMPLE_COMMAND = 'civitai app create my-app';
+// The CLI does NOT install deps on `create`; its own next-step prompt is
+// `cd <dir> && npm install && npm run dev:harness`. `dev:harness` serves a MOCK
+// host at localhost:5186 (plain `npm run dev` shows a blank screen — no host).
+export const CLI_RUN_COMMAND = 'cd my-app && npm install && npm run dev:harness';
+export const CLI_SUBMIT_COMMAND = 'civitai app submit';


### PR DESCRIPTION
## What

The App-Blocks get-started page (`GetStartedBody`, public get-started) and the submit CTA (`CliSubmitCta`, `/apps/submit`) each **hardcoded the same Civitai CLI commands + ecosystem links** under *different* const names, so the two surfaces could silently drift out of sync.

This consolidates them into one shared module **`src/components/Apps/cliCommands.ts`** that both components (and both test suites) import.

## The shared module

`cliCommands.ts` is now the SINGLE source within civitai-web for these strings. Its docstring records that the SOURCE OF TRUTH is the separate **`civitai/cli`** repo (its README "## Quickstart" + `internal/cmd/app_init.go` printed next-steps); the CLI exposes no machine-readable manifest today, so these are **kept in sync manually** — update there when the CLI's canonical quickstart changes. The `*.browser.test.tsx` suites pin the exact strings, so any change is a deliberate, reviewed edit.

Exports (values unchanged from before):
- `CIVITAI_CLI_GITHUB_URL`, `BLOCKS_REACT_NPM_URL`, `APP_SDK_NPM_URL`
- `CLI_INSTALL_BREW`, `CLI_INSTALL_GO`
- `CLI_CREATE_COMMAND` (bare `civitai app create`, the submit CTA's form) + `CLI_CREATE_SAMPLE_COMMAND` (`civitai app create my-app`, the quickstart's form)
- `CLI_RUN_COMMAND`, `CLI_SUBMIT_COMMAND`

## Pure structural — no rendered change

This is a DRY-within-the-repo move only. Every command/link **string value is identical** to before, so both pages render exactly the same commands and labels:
- `CliSubmitCta`: its old `CLI_INSTALL_COMMAND` is renamed to `CLI_INSTALL_BREW` (same value); bare `CLI_CREATE_COMMAND`, `CLI_SUBMIT_COMMAND`, `CIVITAI_CLI_GITHUB_URL` keep their names.
- `GetStartedBody`: quickstart create command uses `CLI_CREATE_SAMPLE_COMMAND` (= `civitai app create my-app`, today's output); the get-started-specific `REQUEST_ACCESS_*` consts stay in the component (not CLI commands).

## Tests

Both `CliSubmitCta.browser.test.tsx` and `GetStartedBody.browser.test.tsx` now import the command/link consts from `~/components/Apps/cliCommands`. Every existing assertion is preserved (names mapped: CliSubmitCta's `CLI_INSTALL_COMMAND` → `CLI_INSTALL_BREW`; GetStartedBody's create assertion → `CLI_CREATE_SAMPLE_COMMAND`). Added one small test pinning both create forms on the shared module.

Run locally (vitest `component` project, real headless Chromium): **17 tests pass** (GetStartedBody 8, CliSubmitCta 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)