### PR TITLE
feat(app-blocks): single-source the block manifest contract (tighten validator + publish canonical schema)

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://civitai.com/schemas/app-block/v1.json",
+  "title": "Civitai App Block Manifest",
+  "description": "THE canonical, server-published schema for block.manifest.json — the ONLY mandatory file in a Civitai App Block. Published at https://civitai.com/schemas/app-block/v1.json. This is the single source of truth for the block manifest contract: the platform's server-side validator (src/server/services/block-manifest-validator.service.ts) and the `civitai` CLI both validate against these same rules. Set this URL as your manifest's `$schema` for editor validation.",
+  "type": "object",
+  "required": ["blockId", "version", "name", "contentRating", "scopes"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON-Schema reference; ignored by the platform validator."
+    },
+    "blockId": {
+      "type": "string",
+      "description": "The block slug. Becomes the canonical submission slug. Lowercase, starts with a letter, hyphen-separated, 3-40 chars.",
+      "minLength": 3,
+      "maxLength": 40,
+      "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$"
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version (x.y.z, optional -prerelease).",
+      "minLength": 1,
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable display name. The server only requires a non-empty string (no length cap), so the CLI does not impose one either.",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "description": "Free-form descriptor used by some examples (e.g. \"block\"). Not validated by the platform.",
+      "enum": ["block"]
+    },
+    "contentRating": {
+      "type": "string",
+      "description": "Content rating of the app surface.",
+      "enum": ["g", "pg", "pg13", "r", "x"]
+    },
+    "renderMode": {
+      "type": "string",
+      "description": "How the block renders. Defaults to \"iframe\". \"inline\"/\"hybrid\" require a verified/internal trust tier (server-assigned), so authors should leave this as iframe.",
+      "enum": ["iframe", "inline", "hybrid"]
+    },
+    "trustTier": {
+      "type": "string",
+      "description": "SERVER-OWNED. Do NOT set this in your manifest — the platform assigns the trust tier during review. Present here only to reject dev-set values.",
+      "$comment": "Rejected via 'not' below.",
+      "enum": ["unverified", "verified", "internal"]
+    },
+    "scopes": {
+      "type": "array",
+      "description": "Capabilities the block requests. Must be a strict subset of what review grants. Each scope is lowercase colon-separated.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "models:read:self",
+          "media:read:owned",
+          "user:read:self",
+          "ai:write:budgeted",
+          "buzz:read:self",
+          "block:settings:read",
+          "block:settings:write",
+          "social:tip:self",
+          "apps:storage:read",
+          "apps:storage:write"
+        ]
+      }
+    },
+    "minApiVersion": {
+      "type": "string",
+      "description": "Minimum App SDK API version the block targets (informational).",
+      "pattern": "^\\d+(\\.\\d+)*$"
+    },
+    "buildCommand": {
+      "type": "string",
+      "description": "Config-as-code: command the platform runs to build the static bundle (e.g. \"npm run build\"). Omit for no-build (static) apps. When set, outputDir must also be set.",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "outputDir": {
+      "type": "string",
+      "description": "Config-as-code: directory (relative to the project root) the buildCommand emits static files into (e.g. \"dist\"). Required when buildCommand is set.",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[^/].*"
+    },
+    "publicSettingsKeys": {
+      "type": "array",
+      "description": "Allowlist of settings keys exposed to anonymous viewers. Default (omitted) = none exposed.",
+      "maxItems": 32,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 64
+      }
+    },
+    "assetBundleUrl": {
+      "type": "string",
+      "description": "Optional v2 surface — HTTPS URL to a hosted asset bundle. Must be a public https URL.",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "iframe": {
+      "type": "object",
+      "description": "iframe envelope. NOTE: iframe.src is SERVER-OWNED — do NOT set it; the platform stamps the canonical bundle URL during build/approve.",
+      "additionalProperties": false,
+      "properties": {
+        "src": {
+          "description": "SERVER-OWNED. Do NOT set iframe.src — the platform assigns it. Present here only so the schema can reject dev-set values.",
+          "$comment": "Rejected via 'not' below."
+        },
+        "minHeight": {
+          "type": "integer",
+          "description": "Minimum iframe height in px.",
+          "minimum": 40,
+          "maximum": 4000
+        },
+        "maxHeight": {
+          "description": "Maximum iframe height in px, or null for unbounded.",
+          "type": ["integer", "null"],
+          "minimum": 40,
+          "maximum": 4000
+        },
+        "resizable": {
+          "type": "boolean",
+          "description": "Whether the host honours RESIZE_IFRAME messages."
+        },
+        "sandbox": {
+          "type": "string",
+          "description": "Space-separated iframe sandbox tokens. Unverified tier allows only: allow-scripts, allow-forms. Never combine allow-same-origin with allow-scripts.",
+          "minLength": 1
+        }
+      }
+    },
+    "page": {
+      "type": "object",
+      "description": "Full-page surface descriptor (W10). Page apps mount at /apps/run/<slug>.",
+      "additionalProperties": false,
+      "required": ["path", "title"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Sub-path the page mounts at; must start with '/'.",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "^/"
+        },
+        "title": {
+          "type": "string",
+          "description": "Title shown in host chrome.",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "icon": {
+          "type": "string",
+          "description": "Optional icon name.",
+          "maxLength": 128
+        },
+        "buzzBudgetPerGen": {
+          "type": "integer",
+          "description": "Optional per-generation Buzz budget for ai:write:budgeted tokens. Positive integer; server-clamped to the per-gen cap.",
+          "exclusiveMinimum": 0
+        }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "description": "Model-page slot targets. Each target's slotId must be a known registered model slot (not the page slot). Optional for page-only apps.",
+      "maxItems": 16,
+      "items": {
+        "type": "object",
+        "required": ["slotId"],
+        "properties": {
+          "slotId": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "outputDir is required whenever buildCommand is set. NOTE: the server-owned iframe.src and trustTier fields are rejected by the platform validator (and the CLI in Go) with clearer error messages than JSON Schema's `not`; they are declared in `properties` above only so the schema documents them.",
+      "if": {
+        "required": ["buildCommand"]
+      },
+      "then": {
+        "required": ["outputDir"]
+      }
+    }
+  ]
+}

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -34,6 +34,65 @@ describe('BlockManifestValidator', () => {
     expect(result).toEqual({ valid: true });
   });
 
+  // Canonical blockId rule: DNS-label-safe (becomes <blockId>.civit.ai).
+  describe('blockId (canonical DNS-label rule)', () => {
+    it('accepts a valid DNS-safe blockId', () => {
+      const manifest = { ...VALID_MANIFEST, blockId: 'my-block' };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it.each([
+      ['MyBlock', 'uppercase'],
+      ['-x', 'leading hyphen'],
+      ['x-', 'trailing hyphen'],
+      ['ab', 'too short (<3)'],
+      ['a'.repeat(41), 'too long (>40)'],
+      ['1block', 'does not start with a letter'],
+      ['my_block', 'underscore'],
+      ['my block', 'space'],
+    ])('rejects blockId %j (%s)', (blockId) => {
+      const manifest = { ...VALID_MANIFEST, blockId };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('blockId'))).toBe(true);
+      }
+    });
+
+    it('accepts a 40-char blockId (boundary) and a 3-char one', () => {
+      const max = 'a' + 'b'.repeat(38) + 'c'; // 40 chars
+      expect(BlockManifestValidator.validate({ ...VALID_MANIFEST, blockId: max }, APP_CTX)).toEqual({
+        valid: true,
+      });
+      expect(
+        BlockManifestValidator.validate({ ...VALID_MANIFEST, blockId: 'abc' }, APP_CTX)
+      ).toEqual({ valid: true });
+    });
+  });
+
+  // Canonical version rule: semver x.y.z (optional -prerelease).
+  describe('version (canonical semver rule)', () => {
+    it.each(['1.0.0', '1.2.3-beta.1', '10.20.30', '0.0.1-rc.0'])(
+      'accepts semver version %j',
+      (version) => {
+        const manifest = { ...VALID_MANIFEST, version };
+        expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+      }
+    );
+
+    it.each(['1.0', 'latest', '1', 'v1.0.0', '1.0.0.0', ''])(
+      'rejects non-semver version %j',
+      (version) => {
+        const manifest = { ...VALID_MANIFEST, version };
+        const result = BlockManifestValidator.validate(manifest, APP_CTX);
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.errors.some((e) => e.includes('version'))).toBe(true);
+        }
+      }
+    );
+  });
+
   it('rejects PascalCase scope strings', () => {
     const manifest = { ...VALID_MANIFEST, scopes: ['Models:Read:Self'] };
     const result = BlockManifestValidator.validate(manifest, TokenScope.ModelsRead);
@@ -169,6 +228,27 @@ describe('BlockManifestValidator', () => {
     if (!result.valid) {
       expect(result.errors.some((e) => e.includes('exceed OAuth client'))).toBe(true);
     }
+  });
+
+  // Canonical scope membership: a well-formed-but-unknown scope is rejected.
+  it('rejects a well-formed but unknown block scope', () => {
+    const manifest = { ...VALID_MANIFEST, scopes: ['models:read:all'] };
+    const result = BlockManifestValidator.validate(manifest, TokenScope.ModelsRead);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(
+        result.errors.some(
+          (e) => e.includes('not a known block scope') && e.includes('models:read:all')
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('accepts the known SKIP_OAUTH_CHECK scope apps:storage:read', () => {
+    // apps:storage:read maps to SKIP_OAUTH_CHECK, so it passes the OAuth-bit gate
+    // regardless of the client bitmask — but it must still be a KNOWN scope.
+    const manifest = { ...VALID_MANIFEST, scopes: ['apps:storage:read'] };
+    expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
   });
 
   it('rejects inline render mode on the unverified tier', () => {

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -1,4 +1,7 @@
-import { validateBlockScopesAgainstOauthClient } from '~/shared/constants/block-scope.constants';
+import {
+  isKnownBlockScope,
+  validateBlockScopesAgainstOauthClient,
+} from '~/shared/constants/block-scope.constants';
 import { isKnownSlotId, isPageSlot } from '~/shared/constants/slot-registry';
 
 type ValidationResult = { valid: true } | { valid: false; errors: string[] };
@@ -70,6 +73,19 @@ export const ALLOWED_RENDER_MODES = new Set(['iframe', 'inline', 'hybrid']);
 export const ALLOWED_TRUST_TIERS = new Set(['unverified', 'verified', 'internal']);
 
 const SCOPE_RE = /^[a-z0-9_]+(?::[a-z0-9_]+){1,3}$/;
+
+// CANONICAL blockId rule (single-sourced with the published schema at
+// https://civitai.com/schemas/app-block/v1.json and the `civitai` CLI). blockId
+// becomes the per-app subdomain `<blockId>.civit.ai` (see manifest-normalize.ts /
+// APPS_DOMAIN), so it MUST be a valid DNS label: lowercase a–z/0–9/hyphen, must
+// start with a letter, must not start or end with a hyphen, 3–40 chars.
+const BLOCK_ID_RE = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+const BLOCK_ID_MIN_LENGTH = 3;
+const BLOCK_ID_MAX_LENGTH = 40;
+
+// CANONICAL version rule: semantic version `x.y.z` with an optional
+// `-prerelease` suffix. Single-sourced with the published schema + the CLI.
+const VERSION_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
 
 // Config-as-code `buildCommand` shape allowlist (defense-in-depth — see the
 // field comment in RawManifest). The build sandbox is already isolated; this
@@ -303,11 +319,26 @@ export class BlockManifestValidator {
     }
     const m = manifest as RawManifest;
 
-    if (typeof m.blockId !== 'string' || m.blockId.length === 0) {
-      errors.push('blockId must be a non-empty string');
+    // blockId becomes the per-app subdomain `<blockId>.civit.ai`, so it must be
+    // a DNS-label-safe slug (canonical rule, single-sourced with the published
+    // schema + the CLI): lowercase, starts with a letter, no leading/trailing
+    // hyphen, a–z/0–9/hyphen only, 3–40 chars.
+    if (typeof m.blockId !== 'string') {
+      errors.push('blockId must be a string');
+    } else if (
+      m.blockId.length < BLOCK_ID_MIN_LENGTH ||
+      m.blockId.length > BLOCK_ID_MAX_LENGTH ||
+      !BLOCK_ID_RE.test(m.blockId)
+    ) {
+      errors.push(
+        'blockId must be 3–40 chars, lowercase, start with a letter, and contain only a–z, 0–9, hyphen (it becomes <blockId>.civit.ai)'
+      );
     }
-    if (typeof m.version !== 'string' || m.version.length === 0) {
-      errors.push('version must be a non-empty string');
+    // version must be a semantic version (canonical rule, single-sourced).
+    if (typeof m.version !== 'string') {
+      errors.push('version must be a string');
+    } else if (!VERSION_RE.test(m.version)) {
+      errors.push('version must be semver (e.g. 1.0.0)');
     }
     if (typeof m.name !== 'string' || m.name.length === 0) {
       errors.push('name must be a non-empty string');
@@ -340,6 +371,14 @@ export class BlockManifestValidator {
         }
         if (!SCOPE_RE.test(scope)) {
           errors.push(`scope "${scope}" must be lowercase colon-separated (e.g. models:read:self)`);
+          continue;
+        }
+        // Membership check (canonical, single-sourced): the scope must be one of
+        // the known block scopes (BLOCK_SCOPE_TO_OAUTH_BIT — the authoritative
+        // set). A well-formed-but-unknown scope (e.g. models:read:all) is
+        // rejected here rather than silently ignored downstream.
+        if (!isKnownBlockScope(scope)) {
+          errors.push(`scope "${scope}" is not a known block scope`);
         }
       }
       const blockScopes = (m.scopes as unknown[]).filter(


### PR DESCRIPTION
## What

Make the App Block manifest contract **single-sourced**. The contract was duplicated and divergent across 3 repos (server `BlockManifestValidator`, the `civitai` CLI, the SDK). The server validator was the *authority* but was **looser** than the CLI/SDK clients. This tightens the server to the canonical strict rules and publishes one schema all three converge on.

Scope is deliberately narrow: the validator, its test, and one new static schema file. Nothing else refactored.

## Changes

**`src/server/services/block-manifest-validator.service.ts`**
- **blockId** — was `typeof string && length>0`. Now: `^[a-z][a-z0-9-]*[a-z0-9]$` **and** length 3–40. Rationale (in a code comment): blockId becomes the per-app subdomain `<blockId>.civit.ai`, so it must be a DNS-label-safe slug — lowercase, starts with a letter, no leading/trailing hyphen.
- **version** — was non-empty. Now: semver `^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$`.
- **scopes** — added a **membership** check via `isKnownBlockScope` (the authoritative 10-scope `BLOCK_SCOPE_TO_OAUTH_BIT` set). Well-formed-but-unknown scopes (e.g. `models:read:all`) are now rejected. The existing `SCOPE_RE` format check and `validateBlockScopesAgainstOauthClient` gate are unchanged.

**`public/schemas/app-block/v1.json`** (new) — civitai serves `public/` statically, so this makes the manifest's `$schema`/`$id` URL `https://civitai.com/schemas/app-block/v1.json` resolve (previously a dangling identifier). The rules/properties are **byte-for-byte identical** to the CLI canonical (`civitai-cli/schema/app-block.manifest.schema.json`); only the top-level `description` + the `allOf[0].$comment` were reworded so it reads as THE published source of truth.

**`src/server/services/__tests__/block-manifest-validator.service.test.ts`** — added cases for the three tightened rules (blockId reject/accept incl. boundaries, version semver reject/accept, scope membership reject/accept incl. the `apps:storage:read` SKIP_OAUTH_CHECK scope). Existing tests unchanged.

## Verification

Ran only this validator's test file (the full civitai suite is enormous):

```
vitest run --project unit src/server/services/__tests__/block-manifest-validator.service.test.ts
 ✓ unit  …/block-manifest-validator.service.test.ts (106 tests) 11ms
 Test Files  1 passed (1)
      Tests  106 passed (106)
```

`jq` confirms `public/schemas/app-block/v1.json` is valid JSON, and a normalized `diff` (ignoring `description` + the `allOf[0].$comment`) confirms it matches the CLI canonical rules byte-for-byte.

## Blast radius

This tightening will **reject manifests that previously passed** the server validator: non-DNS-safe `blockId`, non-semver `version`, and well-formed-but-unknown scopes. App Blocks is **pre-GA / moderator-gated**, and an invalid `blockId` could never have produced a working `<blockId>.civit.ai` subdomain anyway, so real-world impact is expected to be nil — stated honestly rather than asserted as zero. The CLI/SDK already enforced these rules, so any manifest authored through the normal flow already complies.

Note: **merging to `main` does NOT deploy** — civitai deploys from the `release` branch. This only lands the code on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)