### PR TITLE
fix(auth): drain legacy device:accounts singletons (touchAccount hLen≥2 gate)

### DIFF
--- a/apps/auth/src/lib/server/auth/__tests__/device.test.ts
+++ b/apps/auth/src/lib/server/auth/__tests__/device.test.ts
@@ -41,6 +41,8 @@ function makeSys() {
     _store: store,
     _ttl: ttl,
     exists: vi.fn(async (k: string) => (store.has(k) && store.get(k)!.size > 0 ? 1 : 0)),
+    // Field count of the stored hash (0 if absent) — mirrors redis HLEN, which touchAccount now gates on.
+    hLen: vi.fn(async (k: string) => store.get(k)?.size ?? 0),
     hSet: vi.fn(async (k: string, field: string, value: string) => {
       if (!store.has(k)) store.set(k, new Map());
       store.get(k)!.set(field, value);
@@ -212,10 +214,34 @@ describe('touchAccount — refresh-only', () => {
     expect(sys._store.has(KEY)).toBe(false);
   });
 
-  it('refreshes lastSwitchedAt + rolls the 30d TTL when the set already exists', async () => {
+  // THE DRAIN FIX (core of this PR): an EXISTING single-account (hlen=1) set must NOT be refreshed. The old
+  // `exists`-gated code WOULD have re-`expire`d it, re-rolling the 30d TTL on every login → the ~7.9M legacy
+  // single-account keys never drained. Gating on hLen<2 lets those keys (and any 2→1 remnant) expire naturally.
+  it('does NOT refresh an EXISTING single-account (hlen=1) set — lets legacy singletons drain', async () => {
     const sys = makeSys();
     h.getSysRedis.mockReturnValue(sys);
-    // Seed an existing multi-account set.
+    // Simulate a pre-existing legacy single-account key (written before lazy-materialization) with a TTL.
+    const seededTs = String(Date.now() - 60_000);
+    sys._store.set(KEY, new Map([['100', seededTs]]));
+    sys._ttl.set(KEY, 12345); // an arbitrary already-set TTL we must NOT touch
+    vi.clearAllMocks();
+
+    await touchAccount(DEVICE, 100);
+
+    // No write of any kind — the singleton must be left to expire.
+    expect(sys.hLen).toHaveBeenCalledWith(KEY);
+    expect(sys.hSet).not.toHaveBeenCalled();
+    expect(sys.hSetMultiWithExpire).not.toHaveBeenCalled();
+    expect(sys.expire).not.toHaveBeenCalled();
+    // TTL untouched (no roll), field value untouched.
+    expect(sys._ttl.get(KEY)).toBe(12345);
+    expect(sys._store.get(KEY)!.get('100')).toBe(seededTs);
+  });
+
+  it('refreshes lastSwitchedAt + rolls the 30d TTL when the set is multi-account (hlen ≥ 2)', async () => {
+    const sys = makeSys();
+    h.getSysRedis.mockReturnValue(sys);
+    // Seed an existing multi-account set (hlen = 2) so the refresh path is exercised.
     await linkAccount(DEVICE, 200, 100);
     sys.expire.mockClear();
 

--- a/apps/auth/src/lib/server/auth/device.ts
+++ b/apps/auth/src/lib/server/auth/device.ts
@@ -66,21 +66,31 @@ export function clearDeviceCookie(cookies: Cookies): void {
 }
 
 /**
- * REFRESH an account's `lastSwitchedAt` on this device's set — but ONLY if the set already EXISTS (i.e. the
- * browser is already in multi-account mode). On a set that doesn't exist yet (the common single-account login),
- * this is a NO-OP: it deliberately does NOT create a singleton hash. The set is first materialized by
- * `linkAccount` once a genuine 2nd distinct account appears. Callers that just want to keep the active account
- * fresh (authorize / session / legacy-exchange / refresh / switch) use this; the explicit switch path always
- * has an existing set (it's gated by `isLinkedAndFresh`), so its refresh still lands. Best-effort.
+ * REFRESH an account's `lastSwitchedAt` on this device's set — but ONLY if the set holds ≥2 accounts (i.e. the
+ * browser is genuinely in multi-account mode, the only case where the switcher has any value). On a set with
+ * <2 fields — a single-account set or no set at all — this is a NO-OP: it deliberately neither creates a
+ * singleton hash nor refreshes one. Gating on hLen rather than `exists` is deliberate: ~7.9M PRE-EXISTING
+ * single-account keys (legacy bloat written before LAZY MATERIALIZATION) still EXIST, and an `exists` gate
+ * would re-roll their 30-day TTL on every login → the bloat would never drain. Letting <2-field keys fall
+ * through to TTL expiry drains that legacy keyspace (and any 2→1 remnant) over ≤30 days. A genuine multi-
+ * account set is first materialized by `linkAccount` once a 2nd distinct account appears. Callers that just
+ * want to keep the active account fresh (authorize / session / legacy-exchange / refresh / switch) use this;
+ * the explicit switch path always has a ≥2-account set (it's gated by `isLinkedAndFresh`), so its refresh
+ * still lands. Best-effort.
  */
 export async function touchAccount(deviceId: string, userId: number): Promise<void> {
   const sys = getSysRedis();
   if (!sys) return;
   try {
-    // Atomic-enough for a hash field: hSet only when at least one field already exists. We can't conditionally
-    // hSet a single field, so gate on key existence first. A racing first-create between the two calls is
-    // harmless — the set being created concurrently is exactly the case where we DO want the refresh to land.
-    if (!(await sys.exists(key(deviceId)))) return; // no set yet ⇒ single-account ⇒ write nothing
+    // Refresh ONLY a genuine multi-account set (≥2 accounts). Gating on hLen — not `exists` — is the drain
+    // fix: the ~7.9M PRE-EXISTING single-account keys (legacy bloat from before LAZY MATERIALIZATION) still
+    // EXIST, so an `exists` gate would re-`expire` (roll the 30d TTL on) every legacy singleton a returning
+    // user logs in with → the bloat never drains, the keyspace just plateaus. hLen<2 means there's no
+    // switcher value (one account can't be switched away from), so we write NOTHING and let that key expire
+    // naturally — draining the legacy singletons (and any 2→1 remnant) over ≤30d. hLen on a missing key is 0,
+    // so this also covers the ordinary single-account login (no key yet) the old `exists` check handled. One
+    // O(1) redis call. A racing first-create is handled by linkAccount (the only writer that creates a set).
+    if ((await sys.hLen(key(deviceId))) < 2) return; // <2 accounts ⇒ no switcher value ⇒ write nothing
     await sys.hSet(key(deviceId), String(userId), String(Date.now()));
     await sys.expire(key(deviceId), DEVICE_TTL_S);
   } catch {


### PR DESCRIPTION
## The flaw (follow-up to #2803)

#2803 made `touchAccount` (`apps/auth/src/lib/server/auth/device.ts`) **refresh-only** by gating on `await sys.exists(key(deviceId))` — it only writes if the `device:accounts:*` hash already exists. That correctly stopped **new** single-account key creation.

**But it does not drain the existing bloat.** The ~7.9M PRE-EXISTING single-account keys (the legacy bloat that motivated #2803) still EXIST. So when one of those single-account users logs in again, `touchAccount` sees the key exists → `hSet` + `expire` → **re-rolls its 30-day TTL**. Legacy single-account keys belonging to returning users therefore *never* expire — the bloat does **not** drain. The keyspace just plateaus at ~(single-account browsers active per 30d) instead of shrinking toward the ~1k genuine multi-account sets.

Confirmed live: after the 0.1.10 rollout, fresh-TTL keys were still ~99% `hlen=1` — those are refreshed legacy singletons (nothing creates new ones anymore).

## The fix

Gate `touchAccount` on **hash length ≥ 2** (`hLen`) instead of `exists`:

```ts
if ((await sys.hLen(key(deviceId))) < 2) return; // <2 accounts ⇒ no switcher value ⇒ don't refresh/create
```

A set with <2 accounts has no switcher value (you can't switch away from your only account), so we write nothing and let it expire naturally. This refreshes **only genuine multi-account sets** and lets single-account keys — both the legacy bloat and any 2→1 remnant — drain via TTL.

- `hLen` on a missing key returns 0, so this still covers the non-existent-set case the old `exists` check handled — still a single O(1) redis call.
- `linkAccount` (the only writer that *creates* a set, via `hSetMultiWithExpire`) is **unchanged**.
- The 30-day TTL is **unchanged**.

`hLen` is exposed on the sys client: `RedisSysClient` extends `Omit<RedisClientType, …>` and `hLen` is not in the omit list, so it's inherited from node-redis (`@redis/client` ships the `HLEN` command). Type-safe + runtime-available.

**Effect:** the ~7.9M legacy bloat drains over ≤30 days as those browsers either go idle (key expires) or pick up a 2nd account (key becomes a legitimate multi-account set).

> **Optional complementary ops action (NOT in this PR):** a one-time `UNLINK` of existing `device:accounts:*` keys with `hlen=1` would reclaim the memory immediately rather than waiting ≤30d for TTL. Pure ops; the code fix is sufficient on its own.

## Tests (`apps/auth/src/lib/server/auth/__tests__/device.test.ts`)

- Added `hLen` to the in-memory `makeSys` mock (field count, 0 if absent).
- **NEW (core of this PR):** `touchAccount` on an EXISTING **single-account** (`hlen=1`) set does NOT refresh — asserts no `hSet`/`hSetMultiWithExpire`/`expire`, and that the TTL + field value are untouched. (The old `exists`-gated code *would* have refreshed it — verified this test fails against the pre-fix gate.)
- Updated the existing "refreshes … when the set already exists" test to seed a ≥2-account set and renamed it to reflect the `hlen ≥ 2` reasoning.
- Non-existent-set no-op, linkAccount / switch / list / remove tests unchanged.

### Validation

```
vitest run --root apps/auth \
  src/lib/server/auth/__tests__/device.test.ts \
  src/lib/server/auth/__tests__/establish-session.test.ts
# → 2 files, 22 tests passed (device.test.ts: 18, establish-session.test.ts: 4)
```

I could **not** run a full `svelte-check`/typecheck locally (needs a full `pnpm install` + per-package `svelte-kit sync` not available in this environment). The `hLen` method is confirmed present on the typed client interface and in the node-redis runtime. CI svelte-check for `apps/auth` (talos-infra #273) will cover the typecheck.

### Edge case for the reviewer

A device that drops from 2 accounts back to 1 (e.g. `removeAccount`, or `listAccounts` pruning a stale account) becomes a `hlen=1` set — `touchAccount` will now correctly stop refreshing it, so it expires within 30d of its last write. That's the intended behavior (a single-account set has no switcher value), but worth a conscious nod: the surviving account is still authorizable until the key expires, after which a switch-into would require a fresh login — identical to the legacy-singleton drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)