### PR TITLE
fix(lighthouse): drop uuid dep from mint script (use crypto.randomUUID)

### DIFF
--- a/tests/lighthouse-mint-cookie.cjs
+++ b/tests/lighthouse-mint-cookie.cjs
@@ -14,8 +14,9 @@
  *
  * This is the SAME mechanism tests/preview-auth.setup.ts uses for the smoke
  * suite; kept as a standalone .cjs so the Tekton lighthouse task can run it
- * with plain `node` (no ts/playwright) using the next-auth/jwt + uuid already
- * installed into the shared workspace node_modules by the typecheck task.
+ * with plain `node` (no ts/playwright). Its only external dep is `jose` (loaded
+ * from the shared workspace node_modules the typecheck task installs); the rest
+ * (HKDF key derivation, UUID) uses Node's built-in `node:crypto`.
  *
  * Usage:
  *   NEXTAUTH_SECRET=... BASE_URL=https://pr-123.civitaic.com \
@@ -28,8 +29,7 @@ const path = require('path');
 // jose is ESM-only since v6 — require() throws ERR_REQUIRE_ESM from this .cjs,
 // so load it via dynamic import() inside main() (the only EncryptJWT consumer).
 const nodeCrypto = require('node:crypto');
-const { hkdfSync } = nodeCrypto;
-const { v4: uuid } = require('uuid');
+const { hkdfSync, randomUUID } = nodeCrypto;
 
 // jose v6 uses Web Crypto via the global `crypto`. The lhci-client image runs
 // Node 18, which doesn't expose `crypto` as a global (it became global in Node
@@ -78,7 +78,7 @@ async function main() {
 
   const { EncryptJWT } = await import('jose');
 
-  const token = { user: GOLD, sub: String(GOLD.id), id: uuid(), signedAt: Date.now() };
+  const token = { user: GOLD, sub: String(GOLD.id), id: randomUUID(), signedAt: Date.now() };
   const value = await new EncryptJWT(token)
     .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
     .setIssuedAt()


### PR DESCRIPTION
## Problem

The PR-preview Lighthouse cookie-mint (`tests/lighthouse-mint-cookie.cjs`) intermittently failed with:

```
Error: Cannot find module 'uuid'
... cookie mint failed — skipping
```

(seen on pr-preview-2806) — when the shared-workspace pnpm install was incomplete, Lighthouse was silently skipped even though `uuid` is a real dependency.

## Fix

`uuid` was used only for a random session id. `node:crypto.randomUUID()` is a built-in drop-in and `node:crypto` is already imported, so this removes one external dependency the mint can fail to resolve. `jose` remains the sole external dep.

Paired with a datapacket-talos pipeline change that self-heals the workspace deps (runs `pnpm install` + retries) on mint failure — so even `jose` resolving late no longer skips Lighthouse. This PR shrinks the surface so the self-heal rarely needs to fire.

## Verification

Ran under the real `patrickhulce/lhci-client:0.15.1` image (Node 18.20.8) with **only `jose`** available (no top-level `uuid` in `node_modules`):

```
Wrote lighthouserc.runtime.json — 4 routes x 5 runs, authed as ci-smoke-gold
exit=0
RUNTIME CONFIG WRITTEN (uuid-free)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)