### PR TITLE
copy(app-blocks): get-started hero + Quickstart subtitles

### DIFF
--- a/src/components/Apps/GetStartedBody.tsx
+++ b/src/components/Apps/GetStartedBody.tsx
@@ -106,8 +106,8 @@ export function GetStartedBody() {
         </Group>
         <Title order={1}>Build apps on Civitai</Title>
         <Text size="lg" c="dimmed">
-          Small web apps that run inside Civitai — read models &amp; images, generate with Buzz, and
-          ship to your own page at <Code>yourapp.civit.ai</Code>.
+          Build on Civitai&apos;s web + AI infrastructure — tap a catalog of hundreds of thousands of
+          models and generate with Buzz. You focus on creating; we handle the rest.
         </Text>
       </Stack>
 


### PR DESCRIPTION
Updates the `/apps/get-started` hero subtitle to a capability-first value prop.

**Before:** "Small web apps that run inside Civitai — read models & images, generate with Buzz, and ship to your own page at `yourapp.civit.ai`."

**After:** "Build on Civitai's web + AI infrastructure — tap a catalog of hundreds of thousands of models and generate with Buzz. You focus on creating; we handle the rest."

Leans on what's true + available to build against today (managed web + AI infra, the model catalog, Buzz-powered generation). Deliberately avoids present-tense claims the product can't back yet: no "publish to millions of users" (publishing is private beta / consumer surface dark) and no "earn a revenue share" (payout rail is unbuilt + rate unsigned) — keeps the page consistent with its "private beta" framing.

Copy-only change to one `<Text>` element; the browser test asserts the heading/sections/commands/links/CTA, not the subtitle, so it's unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)