### PR TITLE
copy(app-blocks): re-add Quickstart CLI-link subtitle (lost in merge)

### DIFF
--- a/src/components/Apps/GetStartedBody.browser.test.tsx
+++ b/src/components/Apps/GetStartedBody.browser.test.tsx
@@ -95,6 +95,13 @@ describe('GetStartedBody (public App builders landing)', () => {
     expect(appSdk.element().getAttribute('href')).toBe(APP_SDK_NPM_URL);
   });
 
+  test('the Quickstart subtitle links to the CLI repo on GitHub', async () => {
+    renderWithProviders(<GetStartedBody />);
+    const ghLink = page.getByRole('link', { name: 'view it on GitHub' });
+    await expect.element(ghLink).toBeInTheDocument();
+    expect(ghLink.element().getAttribute('href')).toBe(CIVITAI_CLI_GITHUB_URL);
+  });
+
   test('renders the Request-access CTA wired to a prefilled civitai/cli issue', async () => {
     renderWithProviders(<GetStartedBody />);
     const cta = page.getByRole('link', { name: 'Request access on GitHub' });

--- a/src/components/Apps/GetStartedBody.tsx
+++ b/src/components/Apps/GetStartedBody.tsx
@@ -1,4 +1,5 @@
 import {
+  Anchor,
   Badge,
   Box,
   Button,
@@ -125,6 +126,13 @@ export function GetStartedBody() {
       {/* Quickstart — the whole point: copy 3 lines, you're running */}
       <Stack gap="sm">
         <Title order={2}>Quickstart</Title>
+        <Text size="sm" c="dimmed">
+          Powered by the open-source Civitai CLI —{' '}
+          <Anchor href={CIVITAI_CLI_GITHUB_URL} target="_blank" rel="noopener noreferrer">
+            view it on GitHub
+          </Anchor>
+          .
+        </Text>
         <CopyableCommand command={CLI_INSTALL_BREW} />
         <Text size="xs" c="dimmed">
           or: <Code>{CLI_INSTALL_GO}</Code>


### PR DESCRIPTION
Re-applies the Quickstart subtitle that was dropped when #2813 and #2814 merged ~10s apart (both edited `GetStartedBody.tsx`'s import block; the conflict resolution kept the hero subtitle but lost the Quickstart one + its `Anchor` import).

Adds under the **Quickstart** heading:
> Powered by the open-source Civitai CLI — [view it on GitHub] → `github.com/civitai/cli`

Link text is "view it on GitHub" (not "Civitai CLI") so it doesn't collide with the toolkit "Civitai CLI" link under Playwright's substring role matching. Adds a test pinning the link. Browser suite: 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)