### PR TITLE
fix(500-floor): idempotent P2002 on engagement-toggle create (modelEngagement + siblings)

### DIFF
--- a/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
+++ b/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression test for the prod 500-floor bug class:
+//   Invalid `prisma.modelEngagement.create()` — Unique constraint failed on
+//   (userId, modelId)  (~0.26/hr, still 500ing after #2798 fixed the sibling
+//   modelVersionEngagement.create).
+// "Toggle" engagement procedures read-then-create: two concurrent calls both
+// see "absent" and both create; the loser hits the unique constraint (P2002).
+// Since the engagement now exists, a toggle is idempotent — the loser must
+// resolve to the SAME success value (and run the same side-effects) instead of
+// bubbling a 500.
+
+import { Prisma } from '@prisma/client';
+
+const { mockDb, refreshCache } = vi.hoisted(() => ({
+  mockDb: {
+    modelEngagement: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      delete: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+    },
+    bountyEngagement: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      delete: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+    },
+  },
+  refreshCache: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+// HiddenModels.refreshCache is the side-effect the Hide success path runs and
+// MUST still run on a P2002. Stub the whole user-preferences module surface that
+// user.service reaches for at import time.
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenModels: { refreshCache },
+  HiddenModels3D: { refreshCache: vi.fn(async () => undefined) },
+  HiddenUsers: { refreshCache: vi.fn(async () => undefined) },
+  HiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  HiddenTags: { refreshCache: vi.fn(async () => undefined) },
+  BlockedUsers: { refreshCache: vi.fn(async () => undefined), getCached: vi.fn(async () => []) },
+  BlockedByUsers: { refreshCache: vi.fn(async () => undefined) },
+  ImplicitHiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  toggleHidden: vi.fn(async () => ({ added: [], removed: [] })),
+}));
+
+import { toggleModelEngagement, toggleUserBountyEngagement } from '~/server/services/user.service';
+
+const p2002 = (target: string[]) =>
+  new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: '1',
+    meta: { target },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('toggleModelEngagement — idempotent on P2002 race (the confirmed prod 500)', () => {
+  it('Hide: P2002 on create → returns true AND still refreshes the HiddenModels cache', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDb.modelEngagement.create.mockRejectedValueOnce(p2002(['userId', 'modelId']));
+
+    const result = await toggleModelEngagement({ userId: 42, modelId: 10, type: 'Hide' });
+
+    expect(result).toBe(true);
+    // The Hide success path's side-effect must still run on the idempotent path.
+    expect(refreshCache).toHaveBeenCalledWith({ userId: 42 });
+  });
+
+  it('Notify: P2002 on create → returns true (no cache refresh for non-Hide)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDb.modelEngagement.create.mockRejectedValueOnce(p2002(['userId', 'modelId']));
+
+    const result = await toggleModelEngagement({ userId: 42, modelId: 10, type: 'Notify' });
+
+    expect(result).toBe(true);
+    expect(refreshCache).not.toHaveBeenCalled();
+  });
+
+  it('happy path (no race): creates, returns true, refreshes cache for Hide', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDb.modelEngagement.create.mockResolvedValueOnce({});
+
+    const result = await toggleModelEngagement({ userId: 42, modelId: 10, type: 'Hide' });
+
+    expect(result).toBe(true);
+    expect(mockDb.modelEngagement.create).toHaveBeenCalledTimes(1);
+    expect(refreshCache).toHaveBeenCalledWith({ userId: 42 });
+  });
+
+  it('rethrows a non-P2002 create error (does not swallow real failures)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDb.modelEngagement.create.mockRejectedValueOnce(new Error('connection reset'));
+
+    await expect(
+      toggleModelEngagement({ userId: 42, modelId: 10, type: 'Hide' })
+    ).rejects.toThrow('connection reset');
+    // The side-effect must NOT run when the create genuinely failed.
+    expect(refreshCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('toggleUserBountyEngagement — idempotent on P2002 race (sibling)', () => {
+  it('P2002 on create → returns true instead of 500', async () => {
+    mockDb.bountyEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDb.bountyEngagement.create.mockRejectedValueOnce(
+      p2002(['type', 'bountyId', 'userId'])
+    );
+
+    const result = await toggleUserBountyEngagement({
+      userId: 42,
+      bountyId: 5,
+      type: 'Favorite' as never,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('rethrows a non-P2002 create error', async () => {
+    mockDb.bountyEngagement.findUnique.mockResolvedValueOnce(null);
+    mockDb.bountyEngagement.create.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      toggleUserBountyEngagement({ userId: 42, bountyId: 5, type: 'Favorite' as never })
+    ).rejects.toThrow('boom');
+  });
+});

--- a/src/server/services/report.service.ts
+++ b/src/server/services/report.service.ts
@@ -37,7 +37,11 @@ import { bustCachesForPosts } from '~/server/services/post.service';
 import { moderationActionEmail } from '~/server/email/templates';
 import { logToAxiom } from '~/server/logging/client';
 import { addTagVotes } from '~/server/services/tag.service';
-import { throwAuthorizationError, throwNotFoundError } from '~/server/utils/errorHandling';
+import {
+  isPrismaUniqueViolation,
+  throwAuthorizationError,
+  throwNotFoundError,
+} from '~/server/utils/errorHandling';
 import { getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import { getBaseUrl } from '~/server/utils/url-helpers';
 import {
@@ -267,13 +271,21 @@ export const createReport = async ({
     if (data.reason === ReportReason.TOSViolation)
       switch (type) {
         case ReportEntity.Image:
-          await dbWrite.imageEngagement.create({
-            data: {
-              imageId: id,
-              userId,
-              type: ImageEngagementType.Hide,
-            },
-          });
+          // Best-effort hide of the reported image. This isn't a toggle, but the
+          // reporter may already have the image hidden → P2002 on the
+          // (userId, imageId) PK. The desired end-state (image hidden) already
+          // holds, so swallow it instead of 500ing the whole report mutation.
+          await dbWrite.imageEngagement
+            .create({
+              data: {
+                imageId: id,
+                userId,
+                type: ImageEngagementType.Hide,
+              },
+            })
+            .catch((error) => {
+              if (!isPrismaUniqueViolation(error)) throw error;
+            });
           break;
       }
 

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -5,6 +5,7 @@ import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { ToggleHiddenSchemaOutput } from '~/server/schema/user-preferences.schema';
 import { getModeratedTags } from '~/server/services/system-cache';
+import { isPrismaUniqueViolation } from '~/server/utils/errorHandling';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { TagEngagementType, UserEngagementType } from '~/shared/utils/prisma/enums';
 
@@ -545,8 +546,12 @@ async function toggleHiddenTags({
       });
     }
     if (toCreate.length) {
+      // skipDuplicates so a concurrent toggle that already inserted some of these
+      // (userId, tagId) rows doesn't blow up the WHOLE batch with a P2002 (which
+      // would drop the legitimately-new rows too) — bulk-insert is idempotent.
       await dbWrite.tagEngagement.createMany({
         data: toCreate.map((tagId) => ({ userId, tagId, type: 'Hide' })),
+        skipDuplicates: true,
       });
     }
 
@@ -602,7 +607,13 @@ async function toggleHideModel({
   });
 
   if (!engagement)
-    await dbWrite.modelEngagement.create({ data: { userId, modelId, type: 'Hide' } });
+    await dbWrite.modelEngagement
+      .create({ data: { userId, modelId, type: 'Hide' } })
+      // Toggle racing itself → P2002 on the (userId, modelId) PK. The Hide row
+      // already exists, so it's idempotent — fall through to the cache refresh.
+      .catch((error) => {
+        if (!isPrismaUniqueViolation(error)) throw error;
+      });
   else if (engagement.type === 'Hide')
     await dbWrite.modelEngagement.delete({ where: { userId_modelId: { userId, modelId } } });
   else
@@ -639,7 +650,13 @@ async function toggleHideModel3D({
   });
 
   if (!engagement)
-    await dbWrite.model3DEngagement.create({ data: { userId, model3dId, type: 'Hide' } });
+    await dbWrite.model3DEngagement
+      .create({ data: { userId, model3dId, type: 'Hide' } })
+      // Toggle racing itself → P2002 on the (userId, model3dId) PK. Idempotent
+      // (Hide already exists) — fall through to the cache refresh.
+      .catch((error) => {
+        if (!isPrismaUniqueViolation(error)) throw error;
+      });
   else if (engagement.type === 'Hide')
     await dbWrite.model3DEngagement.delete({
       where: { userId_model3dId: { userId, model3dId } },
@@ -672,9 +689,16 @@ async function toggleHideUser({
     select: { type: true },
   });
   if (!engagement)
-    await dbWrite.userEngagement.create({
-      data: { userId, targetUserId, type: 'Hide' },
-    });
+    await dbWrite.userEngagement
+      .create({
+        data: { userId, targetUserId, type: 'Hide' },
+      })
+      // Toggle racing itself → P2002 on the (userId, targetUserId) PK. The row
+      // already exists — idempotent, so fall through to the cache refreshes
+      // (which read DB truth) instead of bubbling a 500.
+      .catch((error) => {
+        if (!isPrismaUniqueViolation(error)) throw error;
+      });
   else if (engagement.type === 'Hide' && setTo !== true)
     await dbWrite.userEngagement.delete({
       where: { userId_targetUserId: { userId, targetUserId } },
@@ -719,9 +743,16 @@ async function toggleBlockUser({
     select: { type: true },
   });
   if (!engagement)
-    await dbWrite.userEngagement.create({
-      data: { userId, targetUserId, type: 'Block' },
-    });
+    await dbWrite.userEngagement
+      .create({
+        data: { userId, targetUserId, type: 'Block' },
+      })
+      // Toggle racing itself → P2002 on the (userId, targetUserId) PK. The row
+      // already exists — idempotent, so fall through to the cache refreshes
+      // (which read DB truth) instead of bubbling a 500.
+      .catch((error) => {
+        if (!isPrismaUniqueViolation(error)) throw error;
+      });
   else if (engagement.type === 'Block' && setTo !== true)
     await dbWrite.userEngagement.delete({
       where: { userId_targetUserId: { userId, targetUserId } },
@@ -754,7 +785,13 @@ async function toggleHideImage({
     select: { type: true },
   });
   if (!engagement)
-    await dbWrite.imageEngagement.create({ data: { userId, imageId, type: 'Hide' } });
+    await dbWrite.imageEngagement
+      .create({ data: { userId, imageId, type: 'Hide' } })
+      // Toggle racing itself → P2002 on the (userId, imageId) PK. Idempotent
+      // (Hide already exists) — fall through to the cache refresh.
+      .catch((error) => {
+        if (!isPrismaUniqueViolation(error)) throw error;
+      });
   else if (engagement.type === 'Hide')
     await dbWrite.imageEngagement.delete({
       where: { userId_imageId: { userId, imageId } },

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -86,6 +86,7 @@ import { createCachedObject } from '~/server/utils/cache-helpers';
 import { bustRatingTotalsCache } from '~/server/services/resourceReview.cache';
 import {
   handleLogError,
+  isPrismaUniqueViolation,
   throwBadRequestError,
   throwConflictError,
   throwNotFoundError,
@@ -731,7 +732,13 @@ export const toggleModelEngagement = async ({
     return true; // no change
   } else if (setTo === false) return false;
 
-  await dbWrite.modelEngagement.create({ data: { type, modelId, userId } });
+  await dbWrite.modelEngagement.create({ data: { type, modelId, userId } }).catch((error) => {
+    // Toggle racing itself: both calls saw no engagement and both create, so the
+    // loser hits the (userId, modelId) unique constraint (P2002). The engagement
+    // now exists — a toggle is idempotent, so treat it as success (still run the
+    // Hide cache-refresh + return true) instead of bubbling a 500.
+    if (!isPrismaUniqueViolation(error)) throw error;
+  });
   if (type === 'Hide') await HiddenModels.refreshCache({ userId });
   return true;
 };
@@ -773,23 +780,35 @@ export const toggleFollowUser = async ({
     return false;
   }
 
-  const ret = await dbWrite.userEngagement.create({
-    data: { type: 'Follow', targetUserId, userId },
-    select: { user: { select: { username: true } } },
-  });
+  const ret = await dbWrite.userEngagement
+    .create({
+      data: { type: 'Follow', targetUserId, userId },
+      select: { user: { select: { username: true } } },
+    })
+    .catch((error) => {
+      // Toggle racing itself: the loser hits the (userId, targetUserId) unique
+      // constraint (P2002). The follow already exists — idempotent, so return
+      // null and fall through to the cache refresh. The racing winner already
+      // created the follow-notification (deduped by `key`), so we skip it here
+      // rather than bubble a 500.
+      if (!isPrismaUniqueViolation(error)) throw error;
+      return null;
+    });
   await userFollowsCache.refresh(userId);
 
-  const details: NotifDetailsFollowedBy = {
-    username: ret.user.username,
-    userId,
-  };
-  await createNotification({
-    category: NotificationCategory.Update,
-    type: 'followed-by',
-    userId: targetUserId,
-    key: `followed-by:${userId}:${targetUserId}`,
-    details,
-  });
+  if (ret) {
+    const details: NotifDetailsFollowedBy = {
+      username: ret.user.username,
+      userId,
+    };
+    await createNotification({
+      category: NotificationCategory.Update,
+      type: 'followed-by',
+      userId: targetUserId,
+      key: `followed-by:${userId}:${targetUserId}`,
+      details,
+    });
+  }
 
   return true;
 };
@@ -820,7 +839,14 @@ export const toggleHideUser = async ({
     return false;
   }
 
-  await dbWrite.userEngagement.create({ data: { type: 'Hide', targetUserId, userId } });
+  await dbWrite.userEngagement
+    .create({ data: { type: 'Hide', targetUserId, userId } })
+    .catch((error) => {
+      // Toggle racing itself: the loser hits the (userId, targetUserId) unique
+      // constraint (P2002). The engagement now exists — idempotent, so still
+      // refresh the cache + return true instead of bubbling a 500.
+      if (!isPrismaUniqueViolation(error)) throw error;
+    });
   await userFollowsCache.refresh(userId);
   return true;
 };
@@ -1771,7 +1797,15 @@ export const toggleUserArticleEngagement = async ({
   }
 
   if (!exists) {
-    await dbWrite.articleEngagement.create({ data: { userId, articleId, type } });
+    await dbWrite.articleEngagement.create({ data: { userId, articleId, type } }).catch((error) => {
+      // Toggle racing itself → P2002 on the articleEngagement PK. NOTE the PK is
+      // (userId, articleId) — it does NOT include `type` — so the dominant case
+      // (same-type double-click) is cleanly idempotent, but a concurrent
+      // DIFFERENT-type write (Favorite vs Hide) on the same article can also
+      // trip this. Either way the row exists and the client re-reads engagement
+      // state, so swallowing P2002 is strictly better than a 500.
+      if (!isPrismaUniqueViolation(error)) throw error;
+    });
   }
 
   return !exists;
@@ -1955,7 +1989,12 @@ export const toggleUserBountyEngagement = async ({
   });
 
   if (!engagement) {
-    await dbWrite.bountyEngagement.create({ data: { userId, bountyId, type } });
+    await dbWrite.bountyEngagement.create({ data: { userId, bountyId, type } }).catch((error) => {
+      // Toggle racing itself → P2002 on the (type, bountyId, userId) PK. The
+      // engagement already exists — idempotent, so return true (toggled on)
+      // instead of bubbling a 500.
+      if (!isPrismaUniqueViolation(error)) throw error;
+    });
     return true;
   } else {
     await dbWrite.bountyEngagement.delete({

--- a/src/server/utils/errorHandling.ts
+++ b/src/server/utils/errorHandling.ts
@@ -47,6 +47,20 @@ export function isClientAbortError(e: unknown): boolean {
   return false;
 }
 
+/**
+ * True when an error is a Prisma unique-constraint violation (P2002).
+ *
+ * Engagement "toggle" procedures follow a read-then-create pattern (findUnique →
+ * create-if-absent). Two concurrent calls can both observe "absent" and both
+ * create, so the loser hits the row's unique constraint (P2002). Because the row
+ * now exists, the toggle is idempotent: a P2002 there means "already toggled on",
+ * so the caller should treat it as success rather than bubble a 500. Use only at
+ * sites where P2002 unambiguously means "the exact row we wanted already exists".
+ */
+export function isPrismaUniqueViolation(error: unknown): boolean {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
 const prismaErrorToTrpcCode: Record<string, TRPC_ERROR_CODE_KEY> = {
   P1008: 'TIMEOUT',
   P2000: 'BAD_REQUEST',


### PR DESCRIPTION
## Why

"Toggle" engagement procedures follow a **read-then-create** pattern: `findUnique` the engagement → if absent, `create` it. Two concurrent calls both see "absent" and both `create` → the loser hits a **P2002 unique-constraint violation**, which currently bubbles as `INTERNAL_SERVER_ERROR` (HTTP 500). Since the engagement now exists, a toggle is **idempotent**: a P2002 there means "already toggled on" → it should return the same value the success path returns (and run the same side-effects), not 500.

[#2798](https://github.com/civitai/civitai/pull/2798) fixed this for `modelVersionEngagement.create`. Prod verification then caught a **sibling still 500ing**: `user.toggleFavorite → modelEngagement.create()` `Unique constraint failed (userId, modelId)`, ~**0.26/hr**. Rather than fix one and come back, this PR closes the whole engagement-toggle race class.

## What

- New shared helper `isPrismaUniqueViolation(e)` in `src/server/utils/errorHandling.ts` (reused per-site; matches the `Prisma.PrismaClientKnownRequestError && code === 'P2002'` idiom already there). Per-site `.catch` mirrors #2798.
- Each fixed site catches P2002, **rethrows everything else**, and resolves exactly as its success path would (same return + same side-effects, e.g. the Hide path still runs `HiddenModels.refreshCache`).

### Sites fixed

| File | Site | Idempotent resolution mirrored |
|---|---|---|
| `user.service.ts` | `toggleModelEngagement` (**the confirmed prod 500**) | run Hide `HiddenModels.refreshCache`, `return true` |
| `user.service.ts` | `toggleFollowUser` | return `null` from create on race → still `userFollowsCache.refresh`, **skip** the duplicate follow-notification (racing winner already sent it, deduped by `key`), `return true` |
| `user.service.ts` | `toggleHideUser` | `userFollowsCache.refresh`, `return true` |
| `user.service.ts` | `toggleUserArticleEngagement` | `return !exists` (true) — see caveat |
| `user.service.ts` | `toggleUserBountyEngagement` | `return true` |
| `user-preferences.service.ts` | `toggleHideModel` | fall through to `HiddenModels.refreshCache`, return diff |
| `user-preferences.service.ts` | `toggleHideModel3D` | fall through to `HiddenModel3Ds.refreshCache`, return diff |
| `user-preferences.service.ts` | `toggleHideUser` | fall through to follow/Hidden cache refreshes, return diff |
| `user-preferences.service.ts` | `toggleBlockUser` | fall through to follow/Blocked cache refreshes, return diff |
| `user-preferences.service.ts` | `toggleHideImage` | fall through to `HiddenImages.refreshCache`, return diff |
| `report.service.ts` | TOSViolation `imageEngagement.create` | swallow → report mutation completes (image already hidden) |

### Site handled differently

| File | Site | Treatment |
|---|---|---|
| `user-preferences.service.ts` | `tagEngagement.**createMany**` (`toggleHidden`) | **`skipDuplicates: true`** instead of a P2002 catch. It's a bulk insert: a P2002 catch would drop the *whole* batch (losing legitimately-new rows), whereas `skipDuplicates` skips only the conflicting rows. |

### Caveats called out for review

- **`toggleUserArticleEngagement`** — the `ArticleEngagement` PK is `(userId, articleId)` and does **not** include `type`. The dominant case (same-type double-click) is cleanly idempotent, but a concurrent *different-type* write (Favorite vs Hide) on the same article can also trip P2002; we then return `!exists` (true) even though the other type may have persisted. Either way the row exists and the client re-reads engagement state, so swallowing is strictly better than a 500 — but it's the one site where P2002 isn't a perfectly unambiguous "the exact row I wanted exists". `user-preferences` `toggleHideUser`/`toggleBlockUser` share the same `(userId, targetUserId)`-without-type PK, but their caches refresh from DB truth so the returned diff stays consistent.
- **`report.service.ts`** is not a toggle (no preceding `findUnique`), but a P2002 there unambiguously means the reporter already has the (userId, imageId) image hidden = the desired end-state, so it's idempotent + safe.

Unique keys verified against the generated schema: `ModelEngagement (userId, modelId)`, `UserEngagement (userId, targetUserId)`, `ArticleEngagement (userId, articleId)`, `BountyEngagement (type, bountyId, userId)`, `ImageEngagement (userId, imageId)`, `TagEngagement (userId, tagId)`.

`Prisma`/helper imports confirmed in every touched file.

## Tests

`src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts` (6 tests, mirrors `resourceReview.idempotent.service.test.ts`):
- `toggleModelEngagement` Hide: P2002 → no throw, `returns true`, **still calls `HiddenModels.refreshCache`**
- `toggleModelEngagement` Notify: P2002 → `returns true`, no cache refresh (non-Hide)
- `toggleModelEngagement` happy path: creates once, returns true, refreshes for Hide
- `toggleModelEngagement` non-P2002 error → rethrows, side-effect does NOT run
- `toggleUserBountyEngagement` (sibling): P2002 → `returns true`; non-P2002 → rethrows

Run locally (vitest unit project): **6 passed**.

This completes the engagement-toggle P2002→500 race class begun in #2798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
