### PR TITLE
feat(model-wizard): add VLM type, save-on-step-click, higher file caps

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260629120000_add_vlm_model_type/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260629120000_add_vlm_model_type/migration.sql
@@ -1,0 +1,2 @@
+-- Add the Vision Language (VLM) model type.
+ALTER TYPE "public"."ModelType" ADD VALUE IF NOT EXISTS 'VisionLanguage';

--- a/packages/civitai-db-schema/prisma/migrations/20260629130000_add_clip_model_type/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260629130000_add_clip_model_type/migration.sql
@@ -1,0 +1,2 @@
+-- Add the CLIP model type.
+ALTER TYPE "public"."ModelType" ADD VALUE IF NOT EXISTS 'CLIP';

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -731,6 +731,7 @@ enum ModelType {
   Wildcards
   Workflows
   Detection
+  VisionLanguage
   Other
 }
 

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -732,6 +732,7 @@ enum ModelType {
   Workflows
   Detection
   VisionLanguage
+  CLIP
   Other
 }
 

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -143,6 +143,7 @@ export const ModelType = {
   Workflows: 'Workflows',
   Detection: 'Detection',
   VisionLanguage: 'VisionLanguage',
+  CLIP: 'CLIP',
   Other: 'Other',
 } as const;
 

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -142,6 +142,7 @@ export const ModelType = {
   Wildcards: 'Wildcards',
   Workflows: 'Workflows',
   Detection: 'Detection',
+  VisionLanguage: 'VisionLanguage',
   Other: 'Other',
 } as const;
 

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -122,6 +122,7 @@ export const ModelType = {
   Workflows: 'Workflows',
   Detection: 'Detection',
   VisionLanguage: 'VisionLanguage',
+  CLIP: 'CLIP',
   Other: 'Other',
 } as const;
 export type ModelType = (typeof ModelType)[keyof typeof ModelType];

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -121,6 +121,7 @@ export const ModelType = {
   Wildcards: 'Wildcards',
   Workflows: 'Workflows',
   Detection: 'Detection',
+  VisionLanguage: 'VisionLanguage',
   Other: 'Other',
 } as const;
 export type ModelType = (typeof ModelType)[keyof typeof ModelType];

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -24,7 +24,7 @@ export type UserEngagementType = "Follow" | "Hide" | "Block";
 
 export type LinkType = "Sponsorship" | "Social" | "Other";
 
-export type ModelType = "Checkpoint" | "TextualInversion" | "Hypernetwork" | "AestheticGradient" | "LORA" | "LoCon" | "DoRA" | "Controlnet" | "Upscaler" | "MotionModule" | "VAE" | "TextEncoder" | "UNet" | "CLIPVision" | "Poses" | "Wildcards" | "Workflows" | "Detection" | "Other";
+export type ModelType = "Checkpoint" | "TextualInversion" | "Hypernetwork" | "AestheticGradient" | "LORA" | "LoCon" | "DoRA" | "Controlnet" | "Upscaler" | "MotionModule" | "VAE" | "TextEncoder" | "UNet" | "CLIPVision" | "Poses" | "Wildcards" | "Workflows" | "Detection" | "VisionLanguage" | "Other";
 
 export type ImportStatus = "Pending" | "Processing" | "Failed" | "Completed";
 

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -24,7 +24,7 @@ export type UserEngagementType = "Follow" | "Hide" | "Block";
 
 export type LinkType = "Sponsorship" | "Social" | "Other";
 
-export type ModelType = "Checkpoint" | "TextualInversion" | "Hypernetwork" | "AestheticGradient" | "LORA" | "LoCon" | "DoRA" | "Controlnet" | "Upscaler" | "MotionModule" | "VAE" | "TextEncoder" | "UNet" | "CLIPVision" | "Poses" | "Wildcards" | "Workflows" | "Detection" | "VisionLanguage" | "Other";
+export type ModelType = "Checkpoint" | "TextualInversion" | "Hypernetwork" | "AestheticGradient" | "LORA" | "LoCon" | "DoRA" | "Controlnet" | "Upscaler" | "MotionModule" | "VAE" | "TextEncoder" | "UNet" | "CLIPVision" | "Poses" | "Wildcards" | "Workflows" | "Detection" | "VisionLanguage" | "CLIP" | "Other";
 
 export type ImportStatus = "Pending" | "Processing" | "Failed" | "Completed";
 

--- a/src/components/CivitaiLink/shared-types.ts
+++ b/src/components/CivitaiLink/shared-types.ts
@@ -57,7 +57,9 @@ export type ResourceType =
   | 'Wildcards'
   | 'Workflows'
   | 'DoRA'
-  | 'Detection';
+  | 'Detection'
+  | 'VisionLanguage'
+  | 'CLIP';
 
 type CommandBase = {
   id: string;

--- a/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
+++ b/src/components/Model/ModelVersions/DownloadVariantDropdown.tsx
@@ -256,6 +256,11 @@ export function DownloadVariantDropdown({
                         </Badge>
                       )}
                     </Group>
+                    {label && (
+                      <Text size="xs" c="dimmed" truncate style={{ maxWidth: 200 }} title={file.name}>
+                        {file.name}
+                      </Text>
+                    )}
                     {description && (
                       <Text size="xs" c="dimmed">
                         {description}
@@ -414,6 +419,11 @@ function FileSummaryRow({ file, isBestMatch = false }: { file: FileType; isBestM
             </Badge>
           )}
         </Group>
+        {label && (
+          <Text size="xs" c="dimmed" truncate style={{ maxWidth: 220 }} title={file.name}>
+            {file.name}
+          </Text>
+        )}
         <Text size="xs" c="dimmed">
           {detailText}
         </Text>

--- a/src/components/Model/ModelVersions/RequiredComponentsSection.tsx
+++ b/src/components/Model/ModelVersions/RequiredComponentsSection.tsx
@@ -546,7 +546,8 @@ function ComponentGroup({
           {files.map((file) => {
             const isSelected = file.id === activeFile?.id;
             const isBestMatch = file.id === bestMatch?.id;
-            const label = getFileLabel(file) ?? file.name;
+            const fileLabel = getFileLabel(file);
+            const label = fileLabel ?? file.name;
             const description = getFileDescription(file);
             const fileDownloadUrl = createModelFileDownloadUrl({
               versionId,
@@ -602,6 +603,11 @@ function ComponentGroup({
                           </Badge>
                         )}
                       </Group>
+                      {fileLabel && (
+                        <Text size="xs" c="dimmed" truncate style={{ maxWidth: 200 }} title={file.name}>
+                          {file.name}
+                        </Text>
+                      )}
                       {description && (
                         <Text size="xs" c="dimmed">
                           {description}

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -820,12 +820,16 @@ const ggufExts = [...modelExts, '.gguf'];
 const configExts = ['.yaml', '.yml', '.json', '.txt'];
 const archiveExts = ['.zip'];
 
+// Primary-file cap for weights-bearing types — room for multiple fp precisions
+// (fp16/fp32/fp8/bf16) plus gguf quant variants (Q2_K…Q8_0) of the same model.
+const mainModelMaxFiles = 20;
+
 const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
   Checkpoint: {
     primary: {
       extensions: [...ggufExts, '.onnx'],
       fileTypes: [...primaryFileTypesByModelType.Checkpoint],
-      maxFiles: 8,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts, ...ggufExts],
@@ -848,7 +852,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.LORA],
-      maxFiles: 3,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...modelExts, ...configExts, ...archiveExts],
@@ -869,7 +873,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.DoRA],
-      maxFiles: 3,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...modelExts, ...configExts, ...archiveExts],
@@ -890,7 +894,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.LoCon],
-      maxFiles: 3,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...modelExts, ...configExts, ...archiveExts],
@@ -911,7 +915,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: modelExts,
       fileTypes: [...primaryFileTypesByModelType.TextualInversion],
-      maxFiles: 2,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...archiveExts, ...configExts],
@@ -923,7 +927,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: modelExts,
       fileTypes: [...primaryFileTypesByModelType.Hypernetwork],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...archiveExts, ...configExts, ...modelExts],
@@ -935,7 +939,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: modelExts,
       fileTypes: [...primaryFileTypesByModelType.AestheticGradient],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...archiveExts, ...configExts, ...modelExts],
@@ -947,7 +951,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.Controlnet],
-      maxFiles: 2,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
@@ -959,7 +963,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: [...modelExts, '.onnx'],
       fileTypes: [...primaryFileTypesByModelType.MotionModule],
-      maxFiles: 2,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
@@ -971,7 +975,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ['.pt', '.safetensors'],
       fileTypes: [...primaryFileTypesByModelType.Detection],
-      maxFiles: 4,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
@@ -983,7 +987,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.Upscaler],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
@@ -995,7 +999,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.VAE],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
@@ -1007,7 +1011,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.TextEncoder],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
@@ -1019,7 +1023,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.UNet],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
@@ -1031,12 +1035,24 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: ggufExts,
       fileTypes: [...primaryFileTypesByModelType.CLIPVision],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],
       fileTypes: ['Config', 'Archive', 'Other'],
       maxFiles: 1,
+    },
+  },
+  VisionLanguage: {
+    primary: {
+      extensions: [...ggufExts, '.onnx'],
+      fileTypes: [...primaryFileTypesByModelType.VisionLanguage],
+      maxFiles: mainModelMaxFiles,
+    },
+    additional: {
+      extensions: [...configExts, ...archiveExts, ...ggufExts],
+      fileTypes: ['VAE', 'Config', 'Training Data', 'CLIPVision', 'Text Encoder', 'Other'],
+      maxFiles: 6,
     },
   },
   Poses: {
@@ -1079,7 +1095,7 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
     primary: {
       extensions: [...archiveExts, ...configExts, ...ggufExts],
       fileTypes: [...primaryFileTypesByModelType.Other],
-      maxFiles: 1,
+      maxFiles: mainModelMaxFiles,
     },
     additional: {
       extensions: [...configExts, ...archiveExts],

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -762,7 +762,11 @@ function inferFileType(fileName: string, modelType?: ModelType | null): ModelFil
     case 'gguf':
     case 'sft':
     case 'onnx':
-      return 'Model';
+      // CLIP weights aren't a single "Model" file — they're a text or vision
+      // encoder. Default to Text Encoder (a CLIP primary type) so the dropped
+      // file lands in the primary section; the user switches to Vision Encoder
+      // when appropriate.
+      return modelType === ModelType.CLIP ? 'Text Encoder' : 'Model';
     case 'zip':
       return modelType && archivePrimaryModelTypes.includes(modelType) ? 'Archive' : undefined;
     case 'yaml':
@@ -1053,6 +1057,18 @@ const dropzoneOptionsByModelType: Record<ModelType, DropzoneOptions> = {
       extensions: [...configExts, ...archiveExts, ...ggufExts],
       fileTypes: ['VAE', 'Config', 'Training Data', 'CLIPVision', 'Text Encoder', 'Other'],
       maxFiles: 6,
+    },
+  },
+  CLIP: {
+    primary: {
+      extensions: ggufExts,
+      fileTypes: [...primaryFileTypesByModelType.CLIP],
+      maxFiles: mainModelMaxFiles,
+    },
+    additional: {
+      extensions: [...configExts, ...archiveExts],
+      fileTypes: ['Config', 'Archive', 'Other'],
+      maxFiles: 2,
     },
   },
   Poses: {

--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -127,7 +127,7 @@ const availabilityDetails = {
   },
 };
 
-export function ModelUpsertForm({ model, children, onSubmit, modelVersionId }: Props) {
+export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId }: Props) {
   const router = useRouter();
   const result = querySchema.safeParse(router.query);
   const currentUser = useCurrentUser();
@@ -321,7 +321,7 @@ export function ModelUpsertForm({ model, children, onSubmit, modelVersionId }: P
   const isDraft = model?.status === ModelStatus.Draft;
 
   return (
-    <Form form={form} onSubmit={handleSubmit}>
+    <Form id={id} form={form} onSubmit={handleSubmit}>
       <ContainerGrid2 gutter="xl">
         <ContainerGrid2.Col span={12}>
           <Stack>
@@ -754,6 +754,7 @@ export function ModelUpsertForm({ model, children, onSubmit, modelVersionId }: P
 }
 
 type Props = {
+  id?: string;
   onSubmit: (data: { id?: number }) => void;
   children: React.ReactNode | ((data: { loading: boolean }) => React.ReactNode);
   model?: Partial<Omit<ModelById, 'tagsOnModels'> & ModelUpsertInput>;

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -147,7 +147,7 @@ const querySchema = z.object({
   bountyId: z.coerce.number().optional(),
 });
 
-export function ModelVersionUpsertForm({ model, version, children, onSubmit }: Props) {
+export function ModelVersionUpsertForm({ id, model, version, children, onSubmit }: Props) {
   const features = useFeatureFlags();
   const router = useRouter();
   const queryUtils = trpc.useUtils();
@@ -423,7 +423,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
 
   return (
     <>
-      <Form form={form} onSubmit={handleSubmit}>
+      <Form id={id} form={form} onSubmit={handleSubmit}>
         <Stack>
           <InputText
             name="name"
@@ -1043,6 +1043,7 @@ type VersionInput = Omit<ModelVersionUpsertInput, 'recommendedResources'> & {
   earlyAccessConfig: ModelVersionEarlyAccessConfig | null;
 };
 type Props = {
+  id?: string;
   onSubmit: (version?: ModelVersionUpsertInput) => void;
   children: (data: { loading: boolean; canSave: boolean }) => React.ReactNode;
   model?: Partial<ModelUpsertInput & { publishedAt: Date | null }>;

--- a/src/components/Resource/Wizard/ModelVersionWizard.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.tsx
@@ -25,6 +25,7 @@ import { isNumber } from '~/utils/type-guards';
 import { showErrorNotification } from '~/utils/notifications';
 import { getModelUrl } from '~/utils/string-helpers';
 import { ReadOnlyAlert } from '~/components/ReadOnlyAlert/ReadOnlyAlert';
+import { useWizardStepSave } from './useWizardStepSave';
 
 const MAX_STEPS = 3;
 
@@ -59,14 +60,19 @@ const CreateSteps = ({
   // is omitted, so URL step 3 (post) collapses to rendered index 1.
   const activeIndex = skipFiles && step >= 2 ? Math.max(0, step - 2) : step - 1;
 
+  const navigateToStep = (urlStep: number) =>
+    router
+      .replace(`/models/${modelData?.id}/model-versions/${versionId}/wizard?step=${urlStep}`)
+      .then();
+  const { formId, handleStepSelect, withSavedNav, clearPendingStep } =
+    useWizardStepSave(navigateToStep);
+
   return (
     <Stepper
       active={activeIndex}
       onStepClick={(idx) => {
         const urlStep = skipFiles && idx >= 1 ? idx + 2 : idx + 1;
-        router.replace(
-          `/models/${modelData?.id}/model-versions/${versionId}/wizard?step=${urlStep}`
-        );
+        handleStepSelect(urlStep, step);
       }}
       allowNextStepsSelect={false}
       size="sm"
@@ -76,9 +82,10 @@ const CreateSteps = ({
         <div className="container flex max-w-sm flex-col gap-3">
           <Title order={3}>{editing ? 'Edit version' : 'Add version'}</Title>
           <ModelVersionUpsertForm
+            id={formId}
             model={modelData}
             version={modelVersion}
-            onSubmit={(result) => {
+            onSubmit={withSavedNav((result) => {
               const skipFiles = result?.usageControl === ModelUsageControl.ExternalGeneration;
               const nextStep = skipFiles ? 3 : 2;
               router
@@ -88,11 +95,11 @@ const CreateSteps = ({
                   editing ? { shallow: true } : undefined
                 )
                 .then();
-            }}
+            })}
           >
             {({ loading, canSave }) => (
               <Group mt="xl" justify="flex-end">
-                <Button type="submit" loading={loading} disabled={!canSave}>
+                <Button type="submit" loading={loading} disabled={!canSave} onClick={clearPendingStep}>
                   Next
                 </Button>
               </Group>
@@ -171,14 +178,17 @@ const TrainSteps = ({
     }
   };
 
+  const navigateToStep = (urlStep: number) =>
+    router
+      .replace(`/models/${modelData?.id}/model-versions/${modelVersion.id}/wizard?step=${urlStep}`)
+      .then();
+  const { formId, handleStepSelect, withSavedNav, clearPendingStep } =
+    useWizardStepSave(navigateToStep);
+
   return (
     <Stepper
       active={step - 1}
-      onStepClick={(step) =>
-        router.replace(
-          `/models/${modelData?.id}/model-versions/${modelVersion.id}/wizard?step=${step + 1}`
-        )
-      }
+      onStepClick={(idx) => handleStepSelect(idx + 1, step)}
       allowNextStepsSelect={false}
       size="sm"
       classNames={{ steps: 'container max-w-sm' }}
@@ -216,9 +226,10 @@ const TrainSteps = ({
         <div className="container flex max-w-sm flex-col gap-3">
           <Title order={3}>Edit version</Title>
           <ModelVersionUpsertForm
+            id={formId}
             model={modelData}
             version={modelVersion}
-            onSubmit={isPrivateModel ? onPublish : goNext}
+            onSubmit={withSavedNav(isPrivateModel ? onPublish : () => goNext())}
           >
             {({ loading, canSave }) => (
               <Stack gap="xs" mt="xl">
@@ -236,6 +247,7 @@ const TrainSteps = ({
                     type="submit"
                     loading={loading || publishPrivateModelVersionMutation.isPending}
                     disabled={!canSave}
+                    onClick={clearPendingStep}
                   >
                     {isPrivateModel ? 'Complete' : 'Next'}
                   </Button>

--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -74,6 +74,8 @@ const CreateSteps = ({
   const result = querySchema.safeParse(router.query);
   const templateId = result.success ? result.data.templateId : undefined;
   const bountyId = result.success ? result.data.bountyId : undefined;
+  const modelVersionId = result.success ? result.data.modelVersionId : undefined;
+  const src = result.success ? result.data.src : undefined;
 
   const { data: templateFields, isInitialLoading: isTemplateLoading } =
     trpc.model.getTemplateFields.useQuery({ id: templateId as number }, { enabled: !!templateId });
@@ -95,9 +97,11 @@ const CreateSteps = ({
 
   const navigateToStep = (urlStep: number) =>
     router
-      .replace(getWizardUrl({ id: modelId, step: urlStep, templateId }), undefined, {
-        shallow: true,
-      })
+      .replace(
+        getWizardUrl({ id: modelId, step: urlStep, templateId, bountyId, modelVersionId, src }),
+        undefined,
+        { shallow: true }
+      )
       .then();
   const { formId, handleStepSelect, withSavedNav, clearPendingStep } =
     useWizardStepSave(navigateToStep);
@@ -222,9 +226,25 @@ const TrainSteps = ({
   router: NextRouter;
   postId: number | undefined;
 }) => {
+  const result = querySchema.safeParse(router.query);
+  const templateId = result.success ? result.data.templateId : undefined;
+  const bountyId = result.success ? result.data.bountyId : undefined;
+  const src = result.success ? result.data.src : undefined;
+
   const navigateToStep = (urlStep: number) =>
     router
-      .replace(getWizardUrl({ id: modelId, step: urlStep }), undefined, { shallow: true })
+      .replace(
+        getWizardUrl({
+          id: modelId,
+          step: urlStep,
+          templateId,
+          bountyId,
+          modelVersionId: modelVersion.id,
+          src,
+        }),
+        undefined,
+        { shallow: true }
+      )
       .then();
   const { formId, handleStepSelect, withSavedNav, clearPendingStep } =
     useWizardStepSave(navigateToStep);

--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -21,6 +21,7 @@ import { QS } from '~/utils/qs';
 import { trpc } from '~/utils/trpc';
 import { isNumber } from '~/utils/type-guards';
 import { TemplateSelect } from './TemplateSelect';
+import { useWizardStepSave } from './useWizardStepSave';
 import { ReadOnlyAlert } from '~/components/ReadOnlyAlert/ReadOnlyAlert';
 
 export type ModelWithTags = Omit<ModelById, 'tagsOnModels'> & {
@@ -92,14 +93,21 @@ const CreateSteps = ({
     isLoadingTemplateData ? 'loading' : 'ready'
   }`;
 
+  const navigateToStep = (urlStep: number) =>
+    router
+      .replace(getWizardUrl({ id: modelId, step: urlStep, templateId }), undefined, {
+        shallow: true,
+      })
+      .then();
+  const { formId, handleStepSelect, withSavedNav, clearPendingStep } =
+    useWizardStepSave(navigateToStep);
+
   return (
     <Stepper
       active={activeIndex}
       onStepClick={(idx) => {
         const urlStep = skipFiles && idx >= 2 ? idx + 2 : idx + 1;
-        router.replace(getWizardUrl({ id: modelId, step: urlStep, templateId }), undefined, {
-          shallow: true,
-        });
+        handleStepSelect(urlStep, step);
       }}
       allowNextStepsSelect={false}
       size="sm"
@@ -112,15 +120,16 @@ const CreateSteps = ({
           <Title order={3}>{editing ? 'Edit model' : 'Create your model'}</Title>
           <ModelUpsertForm
             key={formKey}
+            id={formId}
             model={modelData}
-            onSubmit={({ id }) => {
+            onSubmit={withSavedNav(({ id }) => {
               if (editing) return goNext();
               router.replace(getWizardUrl({ id, step: 2, templateId, bountyId })).then();
-            }}
+            })}
           >
             {({ loading }) => (
               <Group mt="xl" justify="flex-end">
-                <Button type="submit" loading={loading}>
+                <Button type="submit" loading={loading} onClick={clearPendingStep}>
                   Next
                 </Button>
               </Group>
@@ -134,9 +143,10 @@ const CreateSteps = ({
         <div className="container flex max-w-sm flex-col gap-3">
           <Title order={3}>{hasVersions ? 'Edit version' : 'Add version'}</Title>
           <ModelVersionUpsertForm
+            id={formId}
             model={model ?? templateFields ?? bountyFields}
             version={modelVersion ?? templateFields?.version ?? bountyFields?.version}
-            onSubmit={(result) => {
+            onSubmit={withSavedNav((result) => {
               // ExternalGeneration versions are file-less — jump directly to the post step.
               if (result?.usageControl === ModelUsageControl.ExternalGeneration) {
                 router
@@ -149,14 +159,14 @@ const CreateSteps = ({
                 return;
               }
               goNext();
-            }}
+            })}
           >
             {({ loading, canSave }) => (
               <Group mt="xl" justify="flex-end">
                 <Button variant="default" onClick={goBack}>
                   Back
                 </Button>
-                <Button type="submit" loading={loading} disabled={!canSave}>
+                <Button type="submit" loading={loading} disabled={!canSave} onClick={clearPendingStep}>
                   Next
                 </Button>
               </Group>
@@ -212,14 +222,17 @@ const TrainSteps = ({
   router: NextRouter;
   postId: number | undefined;
 }) => {
+  const navigateToStep = (urlStep: number) =>
+    router
+      .replace(getWizardUrl({ id: modelId, step: urlStep }), undefined, { shallow: true })
+      .then();
+  const { formId, handleStepSelect, withSavedNav, clearPendingStep } =
+    useWizardStepSave(navigateToStep);
+
   return (
     <Stepper
       active={step - 1}
-      onStepClick={(step) =>
-        router.replace(getWizardUrl({ id: modelId, step: step + 1 }), undefined, {
-          shallow: true,
-        })
-      }
+      onStepClick={(idx) => handleStepSelect(idx + 1, step)}
       allowNextStepsSelect={false}
       size="sm"
       classNames={{ steps: 'container max-w-sm' }}
@@ -256,13 +269,18 @@ const TrainSteps = ({
       <Stepper.Step label="Edit model">
         <div className="container flex max-w-sm flex-col gap-3">
           <Title order={3}>Edit model</Title>
-          <ModelUpsertForm model={model} modelVersionId={modelVersion.id} onSubmit={goNext}>
+          <ModelUpsertForm
+            id={formId}
+            model={model}
+            modelVersionId={modelVersion.id}
+            onSubmit={withSavedNav(() => goNext())}
+          >
             {({ loading }) => (
               <Group mt="xl" justify="flex-end">
                 <Button variant="default" onClick={goBack}>
                   Back
                 </Button>
-                <Button type="submit" loading={loading}>
+                <Button type="submit" loading={loading} onClick={clearPendingStep}>
                   Next
                 </Button>
               </Group>
@@ -275,13 +293,18 @@ const TrainSteps = ({
       <Stepper.Step label="Edit version">
         <div className="container flex max-w-sm flex-col gap-3">
           <Title order={3}>Edit version</Title>
-          <ModelVersionUpsertForm model={model} version={modelVersion} onSubmit={goNext}>
+          <ModelVersionUpsertForm
+            id={formId}
+            model={model}
+            version={modelVersion}
+            onSubmit={withSavedNav(() => goNext())}
+          >
             {({ loading, canSave }) => (
               <Group mt="xl" justify="flex-end">
                 <Button variant="default" onClick={goBack}>
                   Back
                 </Button>
-                <Button type="submit" loading={loading} disabled={!canSave}>
+                <Button type="submit" loading={loading} disabled={!canSave} onClick={clearPendingStep}>
                   Next
                 </Button>
               </Group>

--- a/src/components/Resource/Wizard/useWizardStepSave.ts
+++ b/src/components/Resource/Wizard/useWizardStepSave.ts
@@ -1,0 +1,47 @@
+import { useRef } from 'react';
+
+const WIZARD_STEP_FORM_ID = 'wizard-step-form';
+
+/**
+ * Lets a wizard step indicator save the current step's form before navigating.
+ *
+ * Clicking a step header used to navigate without persisting in-progress form
+ * edits. This submits the active step's form (the one carrying `formId`); on a
+ * successful save the form's `onSubmit` runs `withSavedNav`, which routes to the
+ * clicked step instead of the form's default next-step. A validation failure
+ * keeps the user on the step to fix errors, exactly like pressing "Next".
+ *
+ * `navigate` performs the actual step change (router.replace to the step URL).
+ */
+export function useWizardStepSave(navigate: (urlStep: number) => void) {
+  const pendingStepRef = useRef<number | null>(null);
+
+  const handleStepSelect = (urlStep: number, currentStep: number) => {
+    if (urlStep === currentStep) return;
+    const form =
+      typeof document !== 'undefined'
+        ? (document.getElementById(WIZARD_STEP_FORM_ID) as HTMLFormElement | null)
+        : null;
+    // Steps without an editable form (file upload, post) just navigate.
+    if (!form) return navigate(urlStep);
+    pendingStepRef.current = urlStep;
+    form.requestSubmit();
+  };
+
+  function withSavedNav<T>(defaultNav: (result: T) => void) {
+    return (result: T) => {
+      const target = pendingStepRef.current;
+      pendingStepRef.current = null;
+      if (target != null) navigate(target);
+      else defaultNav(result);
+    };
+  }
+
+  // Attach to the "Next" button so an explicit Next always uses the form's
+  // default navigation, dropping any target left over from a failed step-click.
+  const clearPendingStep = () => {
+    pendingStepRef.current = null;
+  };
+
+  return { formId: WIZARD_STEP_FORM_ID, handleStepSelect, withSavedNav, clearPendingStep };
+}

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -53,6 +53,7 @@ export const constants = {
   modelFileTypes: [
     'Model',
     'Text Encoder',
+    'Vision Encoder',
     'Pruned Model',
     'Negative',
     'Training Data',
@@ -127,6 +128,7 @@ export const constants = {
     'Training Data': 2,
     Config: 3,
     'Text Encoder': 4,
+    'Vision Encoder': 16,
     VAE: 5,
     Negative: 6,
     Archive: 7,
@@ -466,6 +468,7 @@ export const modelFileComponentTypes = constants.modelFileComponentTypes;
 export const componentFileTypes = [
   'VAE',
   'Text Encoder',
+  'Vision Encoder',
   'UNet',
   'Diffusion Model',
   'CLIPVision',

--- a/src/shared/constants/generation.constants.ts
+++ b/src/shared/constants/generation.constants.ts
@@ -499,6 +499,7 @@ export const miscModelTypes: ModelType[] = [
   'Workflows',
   'Detection',
   'VisionLanguage',
+  'CLIP',
   'Other',
 ] as const;
 

--- a/src/shared/constants/generation.constants.ts
+++ b/src/shared/constants/generation.constants.ts
@@ -498,6 +498,7 @@ export const miscModelTypes: ModelType[] = [
   'Wildcards',
   'Workflows',
   'Detection',
+  'VisionLanguage',
   'Other',
 ] as const;
 

--- a/src/utils/array-helpers.ts
+++ b/src/utils/array-helpers.ts
@@ -58,7 +58,8 @@ const modelTypeOrder: { [k in ModelType]: number } = {
   [ModelType.AestheticGradient]: 15,
   [ModelType.Hypernetwork]: 16,
   [ModelType.Detection]: 17,
-  [ModelType.Other]: 18,
+  [ModelType.VisionLanguage]: 18,
+  [ModelType.Other]: 19,
 };
 
 export function sortByModelTypes<T extends { modelType: ModelType | null }>(data: T[] = []) {

--- a/src/utils/array-helpers.ts
+++ b/src/utils/array-helpers.ts
@@ -59,7 +59,8 @@ const modelTypeOrder: { [k in ModelType]: number } = {
   [ModelType.Hypernetwork]: 16,
   [ModelType.Detection]: 17,
   [ModelType.VisionLanguage]: 18,
-  [ModelType.Other]: 19,
+  [ModelType.CLIP]: 19,
+  [ModelType.Other]: 20,
 };
 
 export function sortByModelTypes<T extends { modelType: ModelType | null }>(data: T[] = []) {

--- a/src/utils/file-display-helpers.ts
+++ b/src/utils/file-display-helpers.ts
@@ -271,6 +271,7 @@ export const primaryFileTypesByModelType: Record<ModelType, readonly ModelFileTy
   TextEncoder: ['Model'],
   UNet: ['Model'],
   CLIPVision: ['Model'],
+  VisionLanguage: ['Model', 'Pruned Model'],
   Poses: ['Archive', 'Config'],
   Wildcards: ['Archive', 'Config'],
   Workflows: ['Archive', 'Config'],

--- a/src/utils/file-display-helpers.ts
+++ b/src/utils/file-display-helpers.ts
@@ -58,6 +58,7 @@ export const componentTypeConfig: Record<
  */
 export const comfyFileTypeLabels: Record<string, string> = {
   'Text Encoder': 'Text Encoder',
+  'Vision Encoder': 'Vision Encoder',
   UNet: 'UNet',
   'Diffusion Model': 'Diffusion Model',
   CLIPVision: 'CLIP Vision',
@@ -137,6 +138,7 @@ export function filterFileTypeByExtension(value: ModelFileType, fileName: string
         'ControlNet',
         'Upscaler',
         'Text Encoder',
+        'Vision Encoder',
         'Enhancement LoRA',
         'Other',
       ].includes(value);
@@ -174,6 +176,7 @@ const SPECIFIC_FALLBACK_TYPES = new Set([
   'ControlNet',
   'Upscaler',
   'Text Encoder',
+  'Vision Encoder',
   'Workflow',
   'Archive',
   'Config',
@@ -272,6 +275,7 @@ export const primaryFileTypesByModelType: Record<ModelType, readonly ModelFileTy
   UNet: ['Model'],
   CLIPVision: ['Model'],
   VisionLanguage: ['Model', 'Pruned Model'],
+  CLIP: ['Text Encoder', 'Vision Encoder'],
   Poses: ['Archive', 'Config'],
   Wildcards: ['Archive', 'Config'],
   Workflows: ['Archive', 'Config'],

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -84,6 +84,7 @@ const nameOverrides: Record<string, string> = {
   UNet: 'UNet',
   CLIPVision: 'CLIP Vision',
   VisionLanguage: 'VLM',
+  CLIP: 'CLIP',
   ControlNet: 'ControlNet',
   // ReportEntity enum value `'model3d'` would otherwise auto-split to
   // "model 3 d" / "3 D Models". Same story for the review variant.

--- a/src/utils/string-helpers.ts
+++ b/src/utils/string-helpers.ts
@@ -83,6 +83,7 @@ const nameOverrides: Record<string, string> = {
   optimism: 'Optimism',
   UNet: 'UNet',
   CLIPVision: 'CLIP Vision',
+  VisionLanguage: 'VLM',
   ControlNet: 'ControlNet',
   // ReportEntity enum value `'model3d'` would otherwise auto-split to
   // "model 3 d" / "3 D Models". Same story for the review variant.


### PR DESCRIPTION
## Summary
Several model/model-version wizard and download-UI improvements.

1. **New Vision Language (VLM) model type**
2. **New CLIP model type** + a new **Vision Encoder** file type
3. **Save the active wizard form when a step indicator is clicked**
4. **Higher per-version file cap** for main-model types
5. **Show the filename in download variant rows** to disambiguate same-precision files

---

### 1. Vision Language (VLM) model type
- Adds `VisionLanguage` (display label **VLM**) to `ModelType` in `@civitai/db-schema` (`schema.full.prisma` + regenerated `enums.ts` / `kysely/enums.ts` / `models.ts`).
- Wired into the exhaustive maps (`modelTypeOrder`, `primaryFileTypesByModelType`) and the `dropzoneOptionsByModelType` file profile (Checkpoint-like: `safetensors`/`gguf`/`onnx` primary, config/VAE/etc. additional).
- `getDisplayName` override → "VLM"; added to the `miscModelTypes` bucket (download-only resource — **not** generation/training wired).
- The model Type select renders it automatically (`Object.values(ModelType)`).

### 2. CLIP model type + Vision Encoder file type
- Adds `CLIP` to `ModelType` (same wiring as VLM; `'CLIP'` display override; misc/download-only).
- Adds a new **`Vision Encoder`** `ModelFileType` — **TS-only, no DB migration** (`ModelFile.type` is a free-text `String`). Registered in `constants.modelFileTypes` / `modelFileOrder` / `componentFileTypes`, the safetensors/gguf extension filter, comfy labels, and the variant-label fallback set.
- A CLIP model's **main file** offers **Text Encoder / Vision Encoder** in the TYPE dropdown (`primaryFileTypesByModelType.CLIP`), mirroring how a Checkpoint main file offers Checkpoint / UNet / Diffusion Model. Dropped CLIP weights default to **Text Encoder** so they land in the primary section; the user switches to Vision Encoder as needed.

### 3. Save form changes on wizard step-click
Previously a step-header click did a bare `router.replace` and discarded unsaved form edits. New `useWizardStepSave` hook submits the active step's form (`requestSubmit`), then navigates to the **clicked** step on save success; a validation error / NSFW-base-model violation keeps the user on the step (same behavior as **Next**). The Next button clears the pending step target so it always uses default navigation.
- Applied to all four steppers: `ModelWizard` + `ModelVersionWizard`, Create + Train flows.
- Adds an `id` passthrough to `ModelUpsertForm` / `ModelVersionUpsertForm` so the wizard can target the active form.
- Follow-up (per Copilot review): step-click navigation now preserves the wizard query params (`bountyId`, `modelVersionId`, `src`) like Next/Back, so it no longer strips context — notably keeping the selected version in the trained flow.

### 4. Higher per-version file cap for main-model types
New `mainModelMaxFiles = 20` constant, applied as `primary.maxFiles` for every type that accepts `safetensors`/`gguf` (Checkpoint, LoRA/DoRA/LoCon, TextualInversion, Hypernetwork, AestheticGradient, Controlnet, MotionModule, Detection, Upscaler, VAE, TextEncoder, UNet, CLIPVision, Other, VLM, CLIP). Archive/config-only types (Poses, Wildcards, Workflows) unchanged. Covers multiple fp precisions + gguf quant variants. There was no server-side count cap; the client total guard derives automatically.

### 5. Filename in download variant rows
When a version has several files of the same precision/quant (e.g. three fp8 SafeTensors), the variant rows were indistinguishable — same label, same description, differing only by size. The filename (dimmed, truncated, hover-tooltip) is now shown on each variant row in the download dropdown and the required-components group, plus the dropdown's selected-file summary. Only shown when the row title is a precision/quant label, so it isn't duplicated when the title already falls back to the filename. The Optional Files list already displayed the filename.

---

## ⚠️ Requires manual DB migrations
The Postgres `ModelType` enum must gain both values before VLM/CLIP models can be saved. Apply manually (per repo convention we do not auto-run migrations):
```sql
ALTER TYPE "public"."ModelType" ADD VALUE IF NOT EXISTS 'VisionLanguage';
ALTER TYPE "public"."ModelType" ADD VALUE IF NOT EXISTS 'CLIP';
```
Migration files:
- `packages/civitai-db-schema/prisma/migrations/20260629120000_add_vlm_model_type/migration.sql`
- `packages/civitai-db-schema/prisma/migrations/20260629130000_add_clip_model_type/migration.sql`

(The `Vision Encoder` file type needs no migration — `ModelFile.type` is free-text.)

## Verification
`pnpm run typecheck` → 0 errors across the project (run with the repo's required 8GB heap; a bare `npx tsc` OOMs and under-reports). The download-variant change was visually reviewed via a Ladle mock (3× fp8 + 1× bf16) confirming the filenames disambiguate the rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)