### PR TITLE
fix(air): emit diffusionmodel type for diffusion-model checkpoints

### DIFF
--- a/src/components/Model/ModelURN/ModelURN.tsx
+++ b/src/components/Model/ModelURN/ModelURN.tsx
@@ -8,11 +8,18 @@ import { stringifyAIR } from '~/shared/utils/air';
 import classes from './ModelURN.module.scss';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
-export const ModelURN = ({ baseModel, type, modelId, modelVersionId, withCopy = true }: Props) => {
+export const ModelURN = ({
+  baseModel,
+  type,
+  modelId,
+  modelVersionId,
+  fileType,
+  withCopy = true,
+}: Props) => {
   const { copied, copy } = useClipboard();
   const urn = useMemo(
-    () => stringifyAIR({ baseModel, type, modelId, id: modelVersionId }),
-    [baseModel, type, modelId, modelVersionId]
+    () => stringifyAIR({ baseModel, type, modelId, id: modelVersionId, fileType }),
+    [baseModel, type, modelId, modelVersionId, fileType]
   );
   if (!urn) return null;
 
@@ -132,5 +139,8 @@ type Props = {
   type: ModelType;
   modelId: number;
   modelVersionId: number;
+  /** Primary `ModelFile.type`; lets diffusion-model checkpoints render the
+   * correct AIR type segment (`diffusionmodel`) instead of `checkpoint`. */
+  fileType?: string;
   withCopy?: boolean;
 };

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -1580,6 +1580,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         type={model.type}
                         modelId={model.id}
                         modelVersionId={version.id}
+                        fileType={primaryFile?.type}
                       />
                     </Group>
                   )}

--- a/src/pages/api/v1/model-versions/[id].ts
+++ b/src/pages/api/v1/model-versions/[id].ts
@@ -189,6 +189,7 @@ export async function prepareModelVersionResponse(
       type: model.type,
       modelId: version.modelId,
       id: version.id,
+      fileType: primaryFile.type,
     }),
     stats: {
       downloadCount: metrics[0]?.downloadCount ?? 0,

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -218,7 +218,7 @@ export default MixedAuthEndpoint(async function handler(
     // this does not work for things like Flux
     // if (targetFile.type !== 'Model') return res.status(404).json({ error: 'File is not a model' });
 
-    air = stringifyAIR({ ...modelVersion, fileId: modelFileId });
+    air = stringifyAIR({ ...modelVersion, fileId: modelFileId, fileType: targetFile.type });
     downloadUrl = `${baseUrl}${createModelFileDownloadUrl({
       versionId: modelVersion.id,
       fileId: modelFileId,

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -1300,6 +1300,7 @@ export async function getResourceData(
       fileSizeKB: fileSizeKB ? Math.round(fileSizeKB) : undefined,
       additionalResourceCost,
       epochDetails,
+      primaryFileType: primaryFile?.type,
     };
   }
 
@@ -1307,7 +1308,7 @@ export async function getResourceData(
     resource: ReturnType<typeof transformGenerationData>,
     modelFiles: ModelFileCached[]
   ) {
-    const { fileSizeKB, additionalResourceCost, epochDetails } = getModelFileProps(
+    const { fileSizeKB, additionalResourceCost, epochDetails, primaryFileType } = getModelFileProps(
       resource,
       modelFiles
     );
@@ -1316,6 +1317,9 @@ export async function getResourceData(
       type: resource.model.type,
       modelId: epochDetails ? epochDetails.jobId : resource.model.id,
       id: epochDetails ? epochDetails.fileName : resource.id,
+      // epoch resources resolve to an orchestrator-hosted file, not the version's
+      // primary model file, so only forward the file type for civitai sources.
+      fileType: epochDetails ? undefined : primaryFileType,
       source: epochDetails ? 'orchestrator' : 'civitai',
     });
 

--- a/src/shared/utils/air.ts
+++ b/src/shared/utils/air.ts
@@ -61,6 +61,18 @@ const typeUrnMap: Partial<Record<ModelType, string>> = {
   [ModelType.CLIPVision]: 'clipvision',
 };
 
+/**
+ * Override map keyed on `ModelFile.type` (not `ModelType`). A Checkpoint model
+ * whose primary weight file is a standalone diffusion model / UNET ships only the
+ * denoiser (no VAE/text-encoder baked in), so its AIR should advertise that file
+ * kind rather than the generic `checkpoint`. Used by `stringifyAIR` when a
+ * `fileType` is supplied. e.g. Flux / Wan / ZImage / Anima / Boogu checkpoints.
+ */
+const fileTypeUrnMap: Record<string, string> = {
+  'Diffusion Model': 'diffusionmodel',
+  UNet: 'unet',
+};
+
 /** Reverse map: URN type string → ModelType enum value */
 const urnToModelTypeMap = new Map(
   Object.entries(typeUrnMap).map(([modelType, urn]) => [urn, modelType as ModelType])
@@ -77,6 +89,7 @@ export function stringifyAIR({
   modelId,
   id,
   fileId,
+  fileType,
   source = 'civitai',
 }: {
   baseModel: string;
@@ -86,6 +99,11 @@ export function stringifyAIR({
   /** Optional ModelFile id; emitted as `+<fileId>` so the orchestrator can
    * disambiguate among multiple files attached to the same version. */
   fileId?: number | string;
+  /** Optional `ModelFile.type` of the primary/selected file. When it maps to a
+   * standalone weight kind (`Diffusion Model`, `UNet`), it overrides the
+   * model-type-derived AIR type — e.g. a Checkpoint shipping a diffusion-model
+   * file becomes `...:diffusionmodel:...` instead of `...:checkpoint:...`. */
+  fileType?: string;
   source?: string;
 }) {
   let ecosystem = baseModel;
@@ -95,7 +113,8 @@ export function stringifyAIR({
   // Upscaler models use 'Other' in AIR for backwards compatibility
   if (ecosystem === 'Upscaler') ecosystem = 'Other';
 
-  const urnType = typeUrnMap[type] ?? 'unknown';
+  const urnType =
+    (fileType ? fileTypeUrnMap[fileType] : undefined) ?? typeUrnMap[type] ?? 'unknown';
 
   return Air.stringify({
     ecosystem: ecosystem.toLowerCase(),


### PR DESCRIPTION
## Problem
Checkpoints that ship a standalone **diffusion model** / UNET (Flux, Wan, ZImage, Anima, Boogu) have `ModelType = Checkpoint` but their primary file is typed `Diffusion Model` (or `UNet`). The AIR was built purely from `ModelType`, so it advertised `...:checkpoint:...` even though the resource is a bare denoiser (VAE + text encoders shipped as separate files).

From ClickUp [868k6a1f5](https://app.clickup.com/t/868k6a1f5): _"Use diffuser instead of checkpoint when type diffuser."_

## Fix
`stringifyAIR` gains an optional `fileType` (the primary `ModelFile.type`) that overrides the type segment:

| Primary `ModelFile.type` | AIR type |
|--------------------------|----------|
| `Diffusion Model` | `diffusionmodel` |
| `UNet` | `unet` |
| otherwise | existing `ModelType` mapping |

Wired through:
- **Generation orchestrator path** (`generation.service.ts`) — the AIR the orchestrator receives
- **Public + mini model-version API** `air` fields
- **`ModelURN`** display (model page, resource select)

Example — Boogu `boogu-image-base` v3049541:
```
before: urn:air:boogu:checkpoint:civitai:2714299@3049541
after:  urn:air:boogu:diffusionmodel:civitai:2714299@3049541
```

## Notes
- Orchestrator routing already keys on the `diffuserModel` **field**, not the AIR type segment, so this is a correctness/display fix. The `diffusionmodel` string is our choice; trivial to change if the orchestrator ever parses the segment and wants a different spelling.
- No DB migration.
- Developer docs (`civitai-developer-docs`) updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)