### PR TITLE
fix(app-blocks): stop discarding the workflow metadata the native generator attaches

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -382,9 +382,15 @@ beforeEach(() => {
   mockGetOrchestratorToken.mockResolvedValue('orch_token');
   mockAuditPromptServer.mockResolvedValue(undefined);
   mockBuildGenerationContext.mockResolvedValue({ externalCtx: {} });
-  // createWorkflowStepsFromGraphInput returns an ARRAY of steps; the block path
-  // is single-step txt2img, so default to one step (router takes steps[0]).
-  mockCreateStepsFromGraph.mockResolvedValue([{ $type: 'textToImage', name: 's1', input: {} }]);
+  // createWorkflowStepsFromGraphInput returns `{ steps, workflowMetadata }`; the
+  // block path is single-step txt2img, so default to one step (router takes
+  // steps[0]). `workflowMetadata` is the queue/remix metadata the REAL submit
+  // attaches and the whatIf submit omits — the graph yields it ONLY on real
+  // (non-whatIf) calls, so default to undefined here and override per-test.
+  mockCreateStepsFromGraph.mockResolvedValue({
+    steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+    workflowMetadata: undefined,
+  });
   // Daily-boost autoclaim defaults: balance high enough that no claim
   // fires unless a test explicitly drops it. Reward details say boost is
   // unclaimed today with the standard 25 awardAmount. Tests that exercise
@@ -595,6 +601,119 @@ describe('blocks.submitWorkflow', () => {
     expect(mockAuditPromptServer).toHaveBeenCalledWith(
       expect.objectContaining({ prompt: 'a cat', userId: 42 })
     );
+  });
+
+  // ---- workflow metadata parity (queue/remix view) ------------------------
+  //
+  // BUG this proves fixed: block-submitted generations carried NO `metadata` on
+  // the submit body, so the orchestrator queue/remix view (which reads
+  // `WorkflowData.params/resources/remixOfId` ← `workflow.metadata`) showed
+  // blank prompt/seed/sampler/cfg/steps/resources. The normal generation form
+  // (`generateFromGraph`) attaches `metadata: workflowMetadata` on the REAL
+  // submit only — `undefined` on whatIf. These tests pin that parity for the
+  // block path: real submit carries the metadata the graph produced; the whatIf
+  // (cost-preflight) submit omits it.
+  describe('attaches workflow metadata (queue/remix parity)', () => {
+    it('REAL submit carries metadata.params + metadata.resources from the graph', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      mockSysRedis.incrBy.mockResolvedValue(125);
+      // The graph yields metadata ONLY on the real (non-whatIf) call. The router
+      // calls createBlockTextToImageStep twice (whatIf cost-check, then real); the
+      // mock returns the same value both times, but only the REAL submit body
+      // should carry `metadata` (the whatIf body must omit it — asserted below).
+      const workflowMetadata = {
+        params: { prompt: 'a cat', seed: 12345, sampler: 'Euler a', cfgScale: 7, steps: 25 },
+        resources: [{ id: 99, strength: 1 }],
+      };
+      mockCreateStepsFromGraph.mockResolvedValue({
+        steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+        workflowMetadata,
+      });
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(2);
+
+      // whatIf body (first call) must NOT carry metadata — mirrors the normal
+      // path (`generateFromGraph` builds workflowMetadata only for real submits).
+      const whatIfBody = mockSubmitWorkflow.mock.calls[0][0].body;
+      expect(whatIfBody).not.toHaveProperty('metadata');
+
+      // REAL submit body (second call) carries the graph's metadata so the queue
+      // view's params/resources/remixOfId populate.
+      const realBody = mockSubmitWorkflow.mock.calls[1][0].body;
+      expect(realBody.metadata).toEqual(workflowMetadata);
+      expect(realBody.metadata.params).toMatchObject({
+        prompt: 'a cat',
+        seed: 12345,
+        sampler: 'Euler a',
+        cfgScale: 7,
+        steps: 25,
+      });
+      expect(realBody.metadata.resources).toEqual([{ id: 99, strength: 1 }]);
+    });
+
+    it('passes metadata through verbatim (no fabricated fields) — undefined when the graph omits it', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      mockSysRedis.incrBy.mockResolvedValue(125);
+      // Graph returns no metadata (e.g. an entry path that doesn't build it):
+      // the body must carry `metadata: undefined`, NOT a fabricated object.
+      mockCreateStepsFromGraph.mockResolvedValue({
+        steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+        workflowMetadata: undefined,
+      });
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      const realBody = mockSubmitWorkflow.mock.calls[1][0].body;
+      expect(realBody.metadata).toBeUndefined();
+    });
+
+    it('estimateWorkflow (whatIf) never attaches metadata to the body', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      happyVersionLookup();
+      happyUser();
+      // Even if the graph somehow returned metadata, the whatIf estimate body
+      // must not carry it (parity with the normal whatIf path).
+      mockCreateStepsFromGraph.mockResolvedValue({
+        steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+        workflowMetadata: { params: { prompt: 'a cat' }, resources: [] },
+      });
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 12 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(mockSubmitWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({ query: { whatif: true } })
+      );
+      const estimateBody = mockSubmitWorkflow.mock.calls[0][0].body;
+      expect(estimateBody).not.toHaveProperty('metadata');
+    });
   });
 
   it('returns a failed-shape snapshot (no throw) when cost > budget', async () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -689,7 +689,7 @@ async function createBlockTextToImageStep(opts: {
     id: opts.user.id,
     isModerator: opts.user.isModerator,
   });
-  const steps = await createWorkflowStepsFromGraphInput({
+  const { steps, workflowMetadata } = await createWorkflowStepsFromGraphInput({
     input: opts.input,
     externalCtx,
     user: { id: opts.user.id, isModerator: opts.user.isModerator },
@@ -706,7 +706,15 @@ async function createBlockTextToImageStep(opts: {
       message: 'expected a single generation step',
     });
   }
-  return step;
+  // `workflowMetadata` (params/resources/remixOfId/isPrivateGeneration, already
+  // `removeEmpty`-cleaned) is what populates the orchestrator queue/remix view
+  // (`WorkflowData.params/resources/remixOfId`). The normal generation form
+  // attaches it on submit; the block path historically dropped it, leaving
+  // block-generated images with blank queue metadata (no prompt/seed/sampler/
+  // resources). It is `undefined` on whatIf calls (the graph omits it then), so
+  // callers can attach it to the REAL submit body only — mirroring the normal
+  // path's `isWhatIf ? undefined : metadata` semantics — without a separate flag.
+  return { step, workflowMetadata };
 }
 
 export const blocksRouter = router({
@@ -2096,7 +2104,10 @@ export const blocksRouter = router({
         checkpointVersionId: checkpoint.versionId,
         checkpointBaseModel: checkpoint.baseModel,
       });
-      const step = await createBlockTextToImageStep({ input: generateInput, user, whatIf: true });
+      // whatIf: no `metadata` on the body — matches the normal path
+      // (`generateFromGraph` builds workflowMetadata only for real submits) and
+      // `createBlockTextToImageStep` returns `workflowMetadata: undefined` here.
+      const { step } = await createBlockTextToImageStep({ input: generateInput, user, whatIf: true });
       const workflow = await submitWorkflow({
         token,
         body: {
@@ -2255,7 +2266,9 @@ export const blocksRouter = router({
       // two (the graph fills a random seed when none is supplied), but that
       // doesn't affect cost — the estimate is computed against the same
       // resources/params the real submit uses.
-      const stepForCostCheck = await createBlockTextToImageStep({
+      // whatIf cost preflight: `workflowMetadata` is undefined here (graph omits
+      // it on whatIf), and the whatif body never carries `metadata` anyway.
+      const { step: stepForCostCheck } = await createBlockTextToImageStep({
         input: generateInput,
         user,
         whatIf: true,
@@ -2343,13 +2356,24 @@ export const blocksRouter = router({
           ip: ctx.ip,
         });
 
-        const step = await createBlockTextToImageStep({ input: generateInput, user, isGreen });
+        // REAL submit: attach `workflowMetadata` so the orchestrator queue/remix
+        // view shows the prompt/seed/sampler/cfg/steps/resources. This is the
+        // non-whatIf call (no `whatIf` flag), so the graph builds metadata and
+        // `createBlockTextToImageStep` returns it. Mirrors the normal form path
+        // (`generateFromGraph` passes `metadata: workflowMetadata`). `removeEmpty`
+        // already stripped fields the block context lacks (e.g. remixOfId).
+        const { step, workflowMetadata } = await createBlockTextToImageStep({
+          input: generateInput,
+          user,
+          isGreen,
+        });
         const submitted = await submitWorkflow({
           token,
           body: {
             steps: [step],
             tags,
             currencies: BLOCK_CURRENCIES,
+            metadata: workflowMetadata,
             // Authoritative maturity clamp on the REAL submit — the orchestrator
             // rejects mature output when this is false. Token-claim derived.
             ...(allowMatureContent === false ? { allowMatureContent: false } : {}),

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -23,6 +23,15 @@ import {
   resolvePageResourceContext,
   snapshotFromWorkflow,
 } from '../workflow.service';
+// REAL param-building path (no mocks): the generation graph validator and the
+// step-metadata snapshot fn are the exact functions the orchestrator's
+// `createWorkflowStepsFromGraph` runs to derive `workflowMetadata.params`. Both
+// live in the browser-safe `shared/` tree (no DB/redis), so we import and run
+// them for real in the integration-style test below.
+import { generationGraph } from '~/shared/data-graph/generation/generation-graph';
+import { toStepMetadata } from '~/shared/utils/resource.utils';
+import { removeEmpty } from '~/utils/object-helpers';
+import type { GenerationCtx } from '~/shared/data-graph/generation/context';
 
 function fakeWorkflow(over: Record<string, unknown> = {}) {
   return {
@@ -488,5 +497,163 @@ describe('resolvePageResourceContext', () => {
       model: { id: 8, type: 'LORA', userId: 55 },
     });
     await expect(resolvePageResourceContext(201)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration-style: REAL block input → REAL graph validation → REAL params
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// WHY THIS EXISTS (the audit's 🟡 gap): the router-level tests in
+// `src/server/routers/__tests__/blocks.router.workflow.test.ts` mock
+// `createWorkflowStepsFromGraphInput` WHOLESALE — they hand the router a canned
+// `{ workflowMetadata }` and assert the router attaches it to the real submit
+// body / omits it on whatIf. That proves the router PLUMBING but NOT the PR's
+// headline claim: that REAL block input, run through the ACTUAL param-mapping,
+// yields a POPULATED `workflowMetadata.params`. A regression in
+// `buildTextToImageInput` or the param snapshot (e.g. dropping `prompt`/`seed`,
+// or the graph silently blanking them) would leave those plumbing tests green
+// while shipping blank queue/remix metadata. This closes that gap.
+//
+// WHAT IS REAL vs STUBBED, and why:
+//   • REAL  — `buildTextToImageInput` (the block→graph-input translator under
+//             test), `generationGraph.safeParse` (the EXACT validator
+//             `createWorkflowStepsFromGraph` runs via `validateInput`), and
+//             `toStepMetadata` + `removeEmpty` (the EXACT param-snapshot fns
+//             that build `workflowMetadata.params`). This is the whole
+//             param-mapping path the PR touches — nothing about how `params` is
+//             derived is mocked.
+//   • STUBBED (by NOT running it) — resource ENRICHMENT
+//             (`validateAndEnrichResources` → `getResourceData`, a DB/network
+//             lookup) and the orchestrator step-input handlers. Those are
+//             external IO and do NOT contribute to `params` (params come from
+//             the validated graph output minus model/resources/vae). We re-run
+//             `createWorkflowStepsFromGraph`'s param logic faithfully
+//             (safeParse → toStepMetadata → removeEmpty) rather than calling
+//             `createWorkflowStepsFromGraphInput`, which would drag in the real
+//             DB client + event-engine-common import graph (un-runnable on this
+//             host, and the reason the router tests mock it wholesale).
+//
+// HONEST LIMITATION: this asserts the params snapshot + the CHECKPOINT in
+// `resources`. It does NOT assert ADDITIONAL LoRA resources land in
+// `workflowMetadata.resources`, because the graph's `resources` node requires
+// the enriched ResourceData map (from `getResourceData`) to validate unknown
+// version ids — without enrichment `safeParse` rejects them. Faking that map
+// would prove a mock, not real behavior, so the additional-resource→metadata
+// linkage is intentionally left to the (mocked) router test's
+// `realBody.metadata.resources` assertion. The checkpoint anchor, which the
+// graph resolves WITHOUT enrichment, IS covered here.
+describe('block input yields populated workflow metadata params (real graph path)', () => {
+  // A free user's generation context — the same shape `buildGenerationContext`
+  // produces, hand-built so the test stays off sysRedis/DB. The graph validator
+  // reads limits/tier/gateRules from this; nothing here affects how `params` is
+  // snapshotted.
+  const externalCtx: GenerationCtx = {
+    limits: { maxQuantity: 4, maxResources: 10, vidQuantity: 1 },
+    user: { isMember: false, tier: 'free' },
+    flags: {},
+    selfHostedDisabledEcosystems: [],
+    selfHostedMode: 'enabled',
+    gateRules: [],
+  };
+
+  // Mirror of the param-snapshot CALCULATION inside
+  // `createWorkflowStepsFromGraph`: validate the graph input, then
+  // `removeEmpty(toStepMetadata(data).params)`. (Computed-key stripping and the
+  // seed default also live there, but our body supplies a literal seed and our
+  // asserted fields are all form inputs, never computed — so this faithfully
+  // reproduces the `workflowMetadata.params` for this body.)
+  function paramsFromRealGraph(input: Record<string, unknown>) {
+    const result = generationGraph.safeParse(input, externalCtx);
+    if (!result.success) {
+      throw new Error(`graph validation failed: ${JSON.stringify(result.errors)}`);
+    }
+    const meta = toStepMetadata(result.data as never);
+    return {
+      params: removeEmpty(meta.params as Record<string, unknown>),
+      resources: meta.resources,
+    };
+  }
+
+  it('populates params (prompt/seed/sampler/cfgScale/steps) from real block input', () => {
+    // A realistic form-shaped textToImage block body — the Extract<…,'textToImage'>
+    // shape the iframe posts: per-image params the user set in the block UI.
+    const body = {
+      kind: 'textToImage' as const,
+      modelId: 7,
+      modelVersionId: 99,
+      params: {
+        prompt: 'a photo of a cat astronaut',
+        negativePrompt: 'blurry, low quality',
+        cfgScale: 7,
+        sampler: 'Euler a',
+        steps: 25,
+        seed: 12345,
+        quantity: 1,
+      },
+    };
+    // checkpoint-bound install: the resolved checkpoint IS body.modelVersionId.
+    const resolved = {
+      baseModel: 'SDXL 1.0',
+      modelType: 'Checkpoint',
+      checkpointVersionId: 99,
+      checkpointBaseModel: 'SDXL 1.0',
+    };
+
+    // REAL translator → REAL graph validation → REAL param snapshot.
+    const input = buildTextToImageInput(body as never, resolved);
+    const { params, resources } = paramsFromRealGraph(input);
+
+    // The headline claim: params is POPULATED with the user's form fields
+    // (verbatim), not blank. A regression that re-blanks block metadata fails here.
+    expect(params).toMatchObject({
+      workflow: 'txt2img',
+      prompt: 'a photo of a cat astronaut',
+      negativePrompt: 'blurry, low quality',
+      cfgScale: 7,
+      sampler: 'Euler a',
+      steps: 25,
+      seed: 12345,
+      quantity: 1,
+    });
+    // ecosystem is derived from the checkpoint baseModel by the real translator.
+    expect(params.ecosystem).toBe('SDXL');
+
+    // The checkpoint anchor shows up in the resources snapshot (this is the part
+    // of `workflowMetadata.resources` the graph resolves without enrichment).
+    expect(resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 99, model: { type: 'Checkpoint' } }),
+      ])
+    );
+  });
+
+  it('snaps SD1 defaults and still populates params for an SD1.5 checkpoint', () => {
+    // Cross-check a second ecosystem so the assertion isn't SDXL-specific: the
+    // real graph must snap SD1.5 to 512² and carry the same form params through.
+    const body = {
+      kind: 'textToImage' as const,
+      modelId: 7,
+      modelVersionId: 99,
+      params: { prompt: 'a dog', sampler: 'DPM++ 2M Karras', steps: 30, seed: 777, quantity: 2 },
+    };
+    const resolved = {
+      baseModel: 'SD 1.5',
+      modelType: 'Checkpoint',
+      checkpointVersionId: 99,
+      checkpointBaseModel: 'SD 1.5',
+    };
+    const input = buildTextToImageInput(body as never, resolved);
+    const { params } = paramsFromRealGraph(input);
+    expect(params).toMatchObject({
+      workflow: 'txt2img',
+      ecosystem: 'SD1',
+      prompt: 'a dog',
+      sampler: 'DPM++ 2M Karras',
+      steps: 30,
+      seed: 777,
+      quantity: 2,
+    });
+    expect(params.aspectRatio).toMatchObject({ width: 512, height: 512 });
   });
 });

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -1164,16 +1164,22 @@ export async function createWorkflowStepsFromGraphInput({
   user?: { id?: number; isModerator?: boolean };
   isWhatIf?: boolean;
   isGreen?: boolean;
-}): Promise<WorkflowStepTemplate[]> {
+}): Promise<{ steps: WorkflowStepTemplate[]; workflowMetadata?: Record<string, unknown> }> {
   const { data, computedKeys } = validateInput(input, externalCtx);
-  const { steps } = await createWorkflowStepsFromGraph({
+  // `workflowMetadata` carries `{ params, resources, remixOfId, isPrivateGeneration }`
+  // (built by `createWorkflowStepsFromGraph`, run through `removeEmpty`) and is
+  // what the queue/remix view reads via `WorkflowData.params/resources/remixOfId`.
+  // It is intentionally `undefined` on whatIf — the caller must only attach it to
+  // the REAL submit body, mirroring `generateFromGraph` (see below). Return it so
+  // the App-Blocks submit path can carry it; the normal path bakes it in directly.
+  const { steps, workflowMetadata } = await createWorkflowStepsFromGraph({
     data,
     computedKeys,
     user,
     isWhatIf,
     isGreen,
   });
-  return steps;
+  return { steps, workflowMetadata };
 }
 
 type SnippetsPayloadShape = {


### PR DESCRIPTION
## Problem

App-sourced (block-submitted) generations show **blank metadata** (prompt/seed/sampler/cfg/steps/resources) when viewed in the **onsite generator** queue/remix view, while generations from the native generator show metadata.

This is **not** a block/SDK client issue. The onsite generator reads a civitai-stamped snapshot — `workflow.metadata.params/resources/remixOfId` (via `WorkflowData` in `shared/orchestrator/workflow-data.ts`; see `docs/generation-metadata-architecture.md`). The **native** generator attaches that snapshot on submit (`generateFromGraph` → `metadata: workflowMetadata`). The **block** submit path runs the *same* `createWorkflowStepsFromGraph` — which produces the *same* `workflowMetadata` — but then **discarded it** (`createWorkflowStepsFromGraphInput` destructured only `{ steps }`), so block-submitted workflows reached the orchestrator with no `metadata`.

## Fix

Attach the metadata **the same way the native generator does** — by no longer discarding the `workflowMetadata` the shared graph builder already returns:

- `createWorkflowStepsFromGraphInput` now returns `{ steps, workflowMetadata }` (the identical `{params, resources, remixOfId, isPrivateGeneration}` object, `removeEmpty`-cleaned, that native uses).
- `createBlockTextToImageStep` returns `{ step, workflowMetadata }`.
- The **real** submit body now carries `metadata: workflowMetadata`, exactly like `generateFromGraph`.

**whatIf parity preserved:** `createWorkflowStepsFromGraph` builds `workflowMetadata` as `isWhatIf ? undefined : …`, so metadata flows only on the real submit, never on the whatIf cost-preflight — matching the native path. No fabricated fields (`removeEmpty` drops what the block context lacks).

Params populate correctly because the block input (`buildTextToImageInput`) is form-data-shaped (`prompt`/`negativePrompt`/`cfgScale`/`sampler`/`steps`/`seed`/`resources`/`aspectRatio`/`quantity`) — the same shape the native form produces — so `stepMetadata.params` → `workflowMetadata.params` is populated identically.

## Scope / limitation

**Forward-only.** This fixes app-sourced generations submitted after deploy. Already-existing block generations stay blank in the queue (their orchestrator workflows were never stamped) — a retroactive backfill would be a separate change.

## Tests

3 new tests in `blocks.router.workflow.test.ts`: real submit carries `metadata.params`/`resources`; verbatim passthrough (undefined when the graph omits it); whatIf estimate never attaches metadata. `tsc` clean.

> ⚠️ Verified at the unit + static-trace level. **Not** yet confirmed end-to-end against a live orchestrator queue — a human should generate via a block app and confirm the prompt/seed/sampler/resources render in the onsite generator queue/remix view.
