### PR TITLE
feat(licensing): stack derivative licensing fee on top of base-model fee

### DIFF
--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -799,7 +799,7 @@ export function ModelVersionUpsertForm({ model, version, children, onSubmit }: P
               <InputNumber
                 name="licensingFee"
                 label="License Fee per Image"
-                description={`Charge a per-image fee for generations using this version. Set to 0 to disable. Max ${MAX_LICENSING_FEE} Buzz per image.`}
+                description={`Charge a per-image fee for generations using this version. If this is a derivative of a base model that already charges a licensing fee, your fee is added on top of it. Set to 0 to disable. Max ${MAX_LICENSING_FEE} Buzz per image.`}
                 min={0}
                 max={MAX_LICENSING_FEE}
                 step={1}

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -267,32 +267,49 @@ export default MixedAuthEndpoint(async function handler(
     .map((fm) => fm.modelId)
     .includes(modelVersion.modelId);
 
-  // Base-model rule wins over the version's own fee: derivatives inherit the
-  // base model's licensing, and the base version itself resolves to its own row.
-  // TODO: support coexisting base-model + per-version fees (split payouts,
-  // additive amounts, derivative opt-out, etc.). Today the upsert path blocks
-  // children from setting their own fee when a rule covers them, so this branch
-  // only sees one or the other in practice.
+  // A base-model rule and the version's own fee now stack: a derivative on a
+  // base model that charges a licensing fee can add its own fee on top, and each
+  // fee settles to its own recipient. `fees` carries the full breakdown; the
+  // orchestrator charges the sum and pays out each entry separately.
   const hasBaseRule =
     modelVersion.baseLicensingFeeRecipientId != null &&
     modelVersion.baseLicensingFee != null &&
     modelVersion.baseLicensingFee > 0;
-  const hasOwnFee = modelVersion.licensingFee != null && modelVersion.licensingFee > 0;
-  const fee = hasBaseRule
-    ? {
-        amount: modelVersion.baseLicensingFee!,
-        type: lowerFirst(modelVersion.baseLicensingFeeType ?? 'PerImageBuzz'),
-        settlementCurrency: lowerFirst(modelVersion.baseLicensingFeeSettlementCurrency ?? 'Buzz'),
-        recipientModelVersionId: modelVersion.baseLicensingFeeRecipientId!,
-      }
-    : hasOwnFee
-    ? {
-        amount: modelVersion.licensingFee!,
-        type: lowerFirst(modelVersion.licensingFeeType ?? 'PerImageBuzz'),
-        settlementCurrency: lowerFirst(modelVersion.licensingFeeSettlementCurrency ?? 'Buzz'),
-        recipientModelVersionId: modelVersion.id,
-      }
-    : undefined;
+  // A base version resolves to its own row via the rule, so don't double-count
+  // its fee as both the base rule and an own fee.
+  const isBaseRecipientItself = modelVersion.baseLicensingFeeRecipientId === modelVersion.id;
+  const hasOwnFee =
+    modelVersion.licensingFee != null && modelVersion.licensingFee > 0 && !isBaseRecipientItself;
+
+  const fees: Array<{
+    role: 'baseModel' | 'version';
+    amount: number;
+    type: string;
+    settlementCurrency: string;
+    recipientModelVersionId: number;
+  }> = [];
+  if (hasBaseRule) {
+    fees.push({
+      role: 'baseModel',
+      amount: modelVersion.baseLicensingFee!,
+      type: lowerFirst(modelVersion.baseLicensingFeeType ?? 'PerImageBuzz'),
+      settlementCurrency: lowerFirst(modelVersion.baseLicensingFeeSettlementCurrency ?? 'Buzz'),
+      recipientModelVersionId: modelVersion.baseLicensingFeeRecipientId!,
+    });
+  }
+  if (hasOwnFee) {
+    fees.push({
+      role: 'version',
+      amount: modelVersion.licensingFee!,
+      type: lowerFirst(modelVersion.licensingFeeType ?? 'PerImageBuzz'),
+      settlementCurrency: lowerFirst(modelVersion.licensingFeeSettlementCurrency ?? 'Buzz'),
+      recipientModelVersionId: modelVersion.id,
+    });
+  }
+
+  // Legacy single-fee field. Kept until the orchestrator reads `fees`; mirrors
+  // the old base-rule-wins behavior so existing consumers don't double-charge.
+  const fee = fees.find((f) => f.role === 'baseModel') ?? fees[0];
 
   const payoutEnabled =
     !Flags.hasFlag(modelVersion.userFlags, UserFlag.DisablePayout) &&
@@ -322,6 +339,7 @@ export default MixedAuthEndpoint(async function handler(
     minor: modelVersion.minor,
     sfwOnly: modelVersion.sfwOnly,
     fee,
+    fees,
     payoutEnabled,
   };
   res.status(200).json(data);

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -277,7 +277,8 @@ export default MixedAuthEndpoint(async function handler(
     modelVersion.baseLicensingFee > 0;
   // A base version resolves to its own row via the rule, so don't double-count
   // its fee as both the base rule and an own fee.
-  const isBaseRecipientItself = modelVersion.baseLicensingFeeRecipientId === modelVersion.id;
+  const isBaseRecipientItself =
+    hasBaseRule && modelVersion.baseLicensingFeeRecipientId === modelVersion.id;
   const hasOwnFee =
     modelVersion.licensingFee != null && modelVersion.licensingFee > 0 && !isBaseRecipientItself;
 

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -416,28 +416,6 @@ export const upsertModelVersionHandler = async ({
       if (!input.licensingFeeType) input.licensingFeeType = LicensingFeeType.PerImageBuzz;
       if (!input.licensingFeeSettlementCurrency)
         input.licensingFeeSettlementCurrency = LicensingFeeSettlementCurrency.Buzz;
-
-      // TODO: handle the case where both a base-model rule and a per-version fee
-      // exist (split payouts, additive fees, derivative opt-out, etc.). For now,
-      // a base-model rule fully owns the fee for its (baseModel, modelType) and
-      // child versions can't set their own.
-      const model = await dbRead.model.findUnique({
-        where: { id: input.modelId },
-        select: { type: true },
-      });
-      if (model) {
-        const baseRule = await dbRead.baseModelLicensingFee.findUnique({
-          where: {
-            baseModel_modelType: { baseModel: input.baseModel, modelType: model.type },
-          },
-          select: { modelVersionId: true },
-        });
-        if (baseRule && baseRule.modelVersionId !== input.id) {
-          throw throwBadRequestError(
-            'This base model already has a licensing fee. You cannot set a per-version fee on a derivative.'
-          );
-        }
-      }
     }
 
     const version = await upsertModelVersion({


### PR DESCRIPTION
## What

Lets a derivative of a base model that already charges a licensing fee (e.g. Anima) set **its own** per-version licensing fee **on top of** the base-model fee, with each fee settling to its own recipient.

Today this is blocked: a base-model rule fully owns the fee for its `(baseModel, modelType)`, and the mini endpoint picks **one** fee (base-rule-wins). Derivatives can't monetize their own work.

## Changes (app side only)

- **Controller** (`model-version.controller.ts`) — removed the guard that threw `"You cannot set a per-version fee on a derivative."` when a base-model rule covers the version.
- **Mini endpoint** (`api/v1/model-versions/mini/[id].ts`) — now emits a `fees[]` breakdown; legacy single `fee` retained for back-compat.
- **Form** (`ModelVersionUpsertForm.tsx`) — copy notes the per-version fee adds on top of any base-model fee.

No DB migration. Storage already supported both (`BaseModelLicensingFee` table + per-version columns).

## New mini endpoint shape

```jsonc
{
  // ...existing fields...

  // legacy single fee — mirrors old base-rule-wins behavior, kept until orchestrator reads `fees`
  "fee": {
    "amount": 25,
    "type": "perImageBuzz",
    "settlementCurrency": "buzz",
    "recipientModelVersionId": 2945208
  },

  // NEW: full breakdown. orchestrator charges the SUM and pays out each entry separately.
  "fees": [
    { "role": "baseModel", "amount": 25, "type": "perImageBuzz", "settlementCurrency": "buzz", "recipientModelVersionId": 2945208 },
    { "role": "version",   "amount": 10, "type": "perImageBuzz", "settlementCurrency": "buzz", "recipientModelVersionId": 3456789 }
  ]
}
```

- `fees` is empty when no fee applies, one entry for a single fee, two when a derivative stacks on a base-model fee.
- Each entry pays its own `recipientModelVersionId`. Settlement currency can differ per entry (base=Buzz, derivative=Cash, etc.).

## ⚠️ Do NOT merge until orchestrator is updated

The orchestrator currently reads the single `fee` and charges/pays one recipient. Before this merges it must:
1. Read `fees`
2. Charge the **sum** of all entries
3. Split into **separate** `licenseFee` settlements, one per `recipientModelVersionId` (handling mixed settlement currencies)

Tracked for @koenbeuk — see ClickUp task.

## Follow-ups (not in this PR)
- Form: surface the **actual** base-model fee amount + computed total (needs a small query to expose `BaseModelLicensingFee` to the client).
- Decide whether `MAX_LICENSING_FEE` (100) caps per-fee or the **sum**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)