### PR TITLE
chore(app-blocks): simplify get-started quickstart + hide publish section

### DIFF
--- a/src/components/Apps/GetStartedBody.browser.test.tsx
+++ b/src/components/Apps/GetStartedBody.browser.test.tsx
@@ -1,10 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { page } from 'vitest/browser';
-import {
-  GetStartedBody,
-  REQUEST_ACCESS_HREF,
-  REQUEST_ACCESS_TITLE,
-} from '~/components/Apps/GetStartedBody';
+import { GetStartedBody } from '~/components/Apps/GetStartedBody';
 import {
   APP_SDK_NPM_URL,
   BLOCKS_REACT_NPM_URL,
@@ -13,7 +9,6 @@ import {
   CLI_INSTALL_BREW,
   CLI_INSTALL_GO,
   CLI_RUN_COMMAND,
-  CLI_SUBMIT_COMMAND,
 } from '~/components/Apps/cliCommands';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -31,27 +26,18 @@ describe('GetStartedBody (public App builders landing)', () => {
       .toBeInTheDocument();
   });
 
-  test('renders the three section headings (quickstart / what you get / publish)', async () => {
+  test('renders the two section headings (quickstart / what you get) and NOT publish', async () => {
     renderWithProviders(<GetStartedBody />);
     await expect.element(page.getByRole('heading', { name: 'Quickstart' })).toBeInTheDocument();
     await expect.element(page.getByRole('heading', { name: 'What you get' })).toBeInTheDocument();
-    await expect.element(page.getByRole('heading', { name: 'Publish' })).toBeInTheDocument();
+    // Publishing was removed from this page entirely.
+    expect(page.getByRole('heading', { name: 'Publish' }).elements()).toHaveLength(0);
   });
 
-  test('honest framing: states publishing is in private beta', async () => {
-    renderWithProviders(<GetStartedBody />);
-    await expect.element(page.getByText('Publishing is in private beta.')).toBeInTheDocument();
-  });
-
-  test('shows the quickstart commands (brew install, scaffold, run) and the submit command', async () => {
+  test('shows the quickstart commands (brew install, scaffold, run)', async () => {
     renderWithProviders(<GetStartedBody />);
     // Copyable commands render prefixed with a shell prompt ("$ ").
-    for (const command of [
-      CLI_INSTALL_BREW,
-      CLI_CREATE_SAMPLE_COMMAND,
-      CLI_RUN_COMMAND,
-      CLI_SUBMIT_COMMAND,
-    ]) {
+    for (const command of [CLI_INSTALL_BREW, CLI_CREATE_SAMPLE_COMMAND, CLI_RUN_COMMAND]) {
       await expect.element(page.getByText(`$ ${command}`)).toBeInTheDocument();
     }
     // The Go install is shown inline (secondary option), not as a copyable block.
@@ -70,7 +56,6 @@ describe('GetStartedBody (public App builders landing)', () => {
     expect(CLI_INSTALL_GO).toBe('go install github.com/civitai/cli/cmd/civitai@latest');
     expect(CLI_CREATE_SAMPLE_COMMAND).toBe('civitai app create my-app');
     expect(CLI_RUN_COMMAND).toBe('cd my-app && npm install && npm run dev:harness');
-    expect(CLI_SUBMIT_COMMAND).toBe('civitai app submit');
   });
 
   test('renders the platform-capabilities grid (catalog / hosting / identity)', async () => {
@@ -82,9 +67,16 @@ describe('GetStartedBody (public App builders landing)', () => {
 
   test('links to the real CLI repo and both npm packages', async () => {
     renderWithProviders(<GetStartedBody />);
-    const cli = page.getByRole('link', { name: 'Civitai CLI' });
-    await expect.element(cli).toBeInTheDocument();
-    expect(cli.element().getAttribute('href')).toBe(CIVITAI_CLI_GITHUB_URL);
+    // Two "Civitai CLI" links render now (the quickstart subtitle Anchor + the
+    // toolkit Button) — both point at the same repo. Assert the toolkit one
+    // (the second match) via the retrying element API, then confirm every
+    // rendered "Civitai CLI" link targets the CLI repo.
+    const toolkitCli = page.getByRole('link', { name: 'Civitai CLI' }).nth(1);
+    await expect.element(toolkitCli).toBeInTheDocument();
+    expect(toolkitCli.element().getAttribute('href')).toBe(CIVITAI_CLI_GITHUB_URL);
+    for (const link of page.getByRole('link', { name: 'Civitai CLI' }).elements()) {
+      expect(link.getAttribute('href')).toBe(CIVITAI_CLI_GITHUB_URL);
+    }
 
     const blocksReact = page.getByRole('link', { name: '@civitai/blocks-react' });
     await expect.element(blocksReact).toBeInTheDocument();
@@ -95,24 +87,13 @@ describe('GetStartedBody (public App builders landing)', () => {
     expect(appSdk.element().getAttribute('href')).toBe(APP_SDK_NPM_URL);
   });
 
-  test('the Quickstart subtitle links to the CLI repo on GitHub', async () => {
+  test('the Quickstart subtitle pitches a 3-step local app and links to the CLI repo', async () => {
     renderWithProviders(<GetStartedBody />);
-    const ghLink = page.getByRole('link', { name: 'view it on GitHub' });
+    await expect
+      .element(page.getByText('Create a local Civitai app in 3 steps', { exact: false }))
+      .toBeInTheDocument();
+    const ghLink = page.getByRole('link', { name: 'Civitai CLI' }).first();
     await expect.element(ghLink).toBeInTheDocument();
     expect(ghLink.element().getAttribute('href')).toBe(CIVITAI_CLI_GITHUB_URL);
-  });
-
-  test('renders the Request-access CTA wired to a prefilled civitai/cli issue', async () => {
-    renderWithProviders(<GetStartedBody />);
-    const cta = page.getByRole('link', { name: 'Request access on GitHub' });
-    await expect.element(cta).toBeInTheDocument();
-    expect(cta.element().getAttribute('href')).toBe(REQUEST_ACCESS_HREF);
-    // Points at a well-formed prefilled new-issue on the public CLI repo
-    // (no longer the `#` placeholder).
-    expect(REQUEST_ACCESS_HREF).toMatch(
-      /^https:\/\/github\.com\/civitai\/cli\/issues\/new\?/
-    );
-    expect(REQUEST_ACCESS_HREF).toContain(`title=${encodeURIComponent(REQUEST_ACCESS_TITLE)}`);
-    expect(REQUEST_ACCESS_HREF).toContain('&body=');
   });
 });

--- a/src/components/Apps/GetStartedBody.tsx
+++ b/src/components/Apps/GetStartedBody.tsx
@@ -3,7 +3,6 @@ import {
   Badge,
   Box,
   Button,
-  Card,
   Code,
   CopyButton,
   Divider,
@@ -19,7 +18,6 @@ import {
   IconCheck,
   IconClipboard,
   IconDatabase,
-  IconLock,
   IconPalette,
   IconPhoto,
   IconServer,
@@ -34,7 +32,6 @@ import {
   CLI_INSTALL_BREW,
   CLI_INSTALL_GO,
   CLI_RUN_COMMAND,
-  CLI_SUBMIT_COMMAND,
 } from '~/components/Apps/cliCommands';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
@@ -47,36 +44,17 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
  * get-started.tsx / feature-flags.service.ts.
  *
  * Copy is QUICKSTART-FIRST (devs scan + copy-paste; minimal prose). Honesty /
- * scope: this page points would-be developers at the LOCAL build tooling — it
- * does NOT open publishing. Both `dev:live` (`/api/v1/blocks/dev-token`) and
- * `civitai app submit` (`/api/v1/blocks/submit-version`) are `isModerator`-gated
- * server side, so a non-mod can install the CLI, scaffold, and build/test
- * locally against the mock harness — but cannot publish yet. The copy frames
- * publishing as a PRIVATE BETA with a Request-access CTA. Do NOT change that
- * framing to imply a non-mod can publish today.
+ * scope: this page points would-be developers at the LOCAL build tooling. The
+ * `dev:live` (`/api/v1/blocks/dev-token`) path is `isModerator`-gated server
+ * side, so a non-mod can install the CLI, scaffold, and build/test locally
+ * against the mock harness.
  *
  * Pure presentational (props-only, no tRPC / no network) so it renders in
  * isolation in component tests.
  */
 
-// CLI commands + ecosystem links are single-sourced in `./cliCommands` (shared
-// with the submit CTA so the two surfaces can't drift). The quickstart uses the
-// with-sample-name create form (`CLI_CREATE_SAMPLE_COMMAND`).
-
-// Request-access intake = a PREFILLED new-issue on the public `civitai/cli`
-// repo (the dev-native, zero-infra channel the page already links to). The
-// title + body below are URL-encoded into the github.com/.../issues/new query
-// so the issue opens pre-populated with a short intake prompt.
-export const REQUEST_ACCESS_TITLE = 'App Blocks: request publishing access';
-export const REQUEST_ACCESS_BODY = `Thanks for your interest in building on Civitai Apps!
-
-- Civitai username:
-- What you'd like to build:
-- Links to anything you've built (repo/demo, optional):
-`;
-export const REQUEST_ACCESS_HREF = `https://github.com/civitai/cli/issues/new?title=${encodeURIComponent(
-  REQUEST_ACCESS_TITLE
-)}&body=${encodeURIComponent(REQUEST_ACCESS_BODY)}`;
+// CLI commands + ecosystem links are single-sourced in `./cliCommands`. The
+// quickstart uses the with-sample-name create form (`CLI_CREATE_SAMPLE_COMMAND`).
 
 function CopyableCommand({ command }: { command: string }) {
   return (
@@ -127,11 +105,10 @@ export function GetStartedBody() {
       <Stack gap="sm">
         <Title order={2}>Quickstart</Title>
         <Text size="sm" c="dimmed">
-          Powered by the open-source Civitai CLI —{' '}
+          Create a local Civitai app in 3 steps with the{' '}
           <Anchor href={CIVITAI_CLI_GITHUB_URL} target="_blank" rel="noopener noreferrer">
-            view it on GitHub
+            Civitai CLI
           </Anchor>
-          .
         </Text>
         <CopyableCommand command={CLI_INSTALL_BREW} />
         <Text size="xs" c="dimmed">
@@ -139,10 +116,6 @@ export function GetStartedBody() {
         </Text>
         <CopyableCommand command={CLI_CREATE_SAMPLE_COMMAND} />
         <CopyableCommand command={CLI_RUN_COMMAND} />
-        <Text size="sm" c="dimmed">
-          Opens at <Code>localhost:5186</Code> in a mock Civitai — no account, no Buzz needed. Edit{' '}
-          <Code>src/App.tsx</Code> and go.
-        </Text>
       </Stack>
 
       <Divider />
@@ -241,50 +214,7 @@ export function GetStartedBody() {
             @civitai/app-sdk
           </Button>
         </Group>
-        <Text size="xs" c="dimmed">
-          Both SDK packages ship in the scaffold.
-        </Text>
       </Stack>
-
-      <Divider />
-
-      {/* Publish — one command + one line + the private-beta tag */}
-      <Card withBorder radius="md" p="lg" style={{ borderStyle: 'dashed' }}>
-        <Stack gap="sm">
-          <Group gap="xs">
-            <ThemeIcon size="md" radius="md" variant="light" color="yellow">
-              <IconLock size={16} />
-            </ThemeIcon>
-            <Title order={2} m={0}>
-              Publish
-            </Title>
-            <Badge color="yellow" variant="light" radius="sm" size="sm">
-              private beta
-            </Badge>
-          </Group>
-          <CopyableCommand command={CLI_SUBMIT_COMMAND} />
-          <Text size="sm" c="dimmed">
-            Sends your app for a quick review → live at <Code>yourapp.civit.ai</Code>.
-          </Text>
-          <Text size="sm" fw={600}>
-            Publishing is in private beta.
-          </Text>
-          <Text size="sm" c="dimmed">
-            Build and test locally today; request access on GitHub to publish.
-          </Text>
-          <Group gap="xs">
-            <Button
-              component="a"
-              href={REQUEST_ACCESS_HREF}
-              target="_blank"
-              rel="noopener noreferrer"
-              leftSection={<IconLock size={16} />}
-            >
-              Request access on GitHub
-            </Button>
-          </Group>
-        </Stack>
-      </Card>
     </Stack>
   );
 }

--- a/src/pages/apps/get-started.tsx
+++ b/src/pages/apps/get-started.tsx
@@ -48,7 +48,7 @@ export default function AppsGetStartedPage() {
           TODO(launch): drop `deIndex` to make indexable when comms is ready. */}
       <Meta
         title="Build apps on Civitai"
-        description="Build small web apps that run inside Civitai. Install the Civitai CLI and runtime SDK, scaffold an app, and test it locally. Publishing is in private beta."
+        description="Build small web apps that run inside Civitai. Install the Civitai CLI and runtime SDK, scaffold an app, and test it locally."
         deIndex
       />
       <Container size="md" py="xl">


### PR DESCRIPTION
Simplifies the App Blocks get-started page (`src/components/Apps/GetStartedBody.tsx`) — quickstart-first, publishing removed.

## Changes
1. **Quickstart subtitle** — replaced "Powered by the open-source Civitai CLI — view it on GitHub." with "Create a local Civitai app in 3 steps with the [Civitai CLI]" (no trailing period; reuses the existing `CIVITAI_CLI_GITHUB_URL` const + `Anchor`).
2. **Removed** the "Opens at `localhost:5186` in a mock Civitai … Edit `src/App.tsx` and go." helper line from the Quickstart stack.
3. **Removed** "Both SDK packages ship in the scaffold." from the "What you get" section.
4. **Hid the Publish section** — removed the entire dashed Publish `Card` (the `Publish` title, `private beta` badge, `civitai app submit` command, "Publishing is in private beta." copy, and the "Request access on GitHub" button) **and** the `<Divider />` immediately before it. Publishing / Request-access is gone from this page.

## Cleanup
- Removed now-unused imports/consts that only the Publish section used: `Card`, `IconLock`, the `CLI_SUBMIT_COMMAND` import, and the `REQUEST_ACCESS_TITLE` / `REQUEST_ACCESS_BODY` / `REQUEST_ACCESS_HREF` exports (only referenced by this file + its test, both updated).
- Kept `Code` (install fallback), `Badge` (hero), `Divider` (still one in use), `ThemeIcon` (grid), and the `CLI_SUBMIT_COMMAND` const in `cliCommands.ts` (still imported by `CliSubmitCta.tsx`).
- Trimmed the stale file-top private-beta/Request-access doc comment.

## Tests
Updated `GetStartedBody.browser.test.tsx`: dropped assertions for the removed strings + the `Publish` heading + the Request-access CTA, removed the `CLI_SUBMIT_COMMAND` / `REQUEST_ACCESS_*` imports, asserted Publish heading is absent, and added a subtitle assertion ("Create a local Civitai app in 3 steps"). Disambiguated the now-duplicate "Civitai CLI" link (subtitle + toolkit).

## Verification (NixOS host)
- `tsc --noEmit`: no errors in the edited files (pre-existing repo errors are environmental — uninitialized `event-engine-common` submodule, unbuilt workspace packages, known comics schema-drift).
- Browser-mode vitest (real headless Chromium): **GetStartedBody.browser.test.tsx 8/8 pass**, sibling **CliSubmitCta.browser.test.tsx 9/9 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
