### PR TITLE
fix(user): harden toggleBookmarked against 3 concurrency races (toggleFavorite 500 tail)

### DIFF
--- a/src/server/services/__tests__/toggle-bookmarked.idempotent.service.test.ts
+++ b/src/server/services/__tests__/toggle-bookmarked.idempotent.service.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression tests for the three concurrency races in `toggleBookmarked` (the shared
+// bookmark-toggle helper behind toggleFavorite / toggleBookmarkedArticle / the Image/Post
+// controller callers). It is the ~1.3/day HTTP-500 residual on user.toggleFavorite — the tail
+// after #2816/#2798 cleared modelEngagement + resourceReview.
+//
+// All three hit prod-only PARTIAL UNIQUE indexes that are NOT in the Prisma schema:
+//   #1 collection.create     → `User_bookmark_collection UNIQUE (userId,type,mode) WHERE mode='Bookmark'` (P2002)
+//   #2 collectionItem.create → `CollectionItem_model UNIQUE (collectionId,modelId) WHERE modelId IS NOT NULL` (+image/post/article) (P2002)
+//   #3 collectionItem.delete → P2025 "record not found" when two un-bookmarks delete the same row
+//
+// Fixes: #3 delete→deleteMany (idempotent {count}), #2 create→createMany({skipDuplicates:true})
+// (ON CONFLICT DO NOTHING), #1 catch P2002 + re-fetch (Prisma upsert can't target a partial index).
+
+import { Prisma } from '@prisma/client';
+
+const { mockDb, queueUpdate } = vi.hoisted(() => ({
+  mockDb: {
+    collection: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 999 })),
+    },
+    collectionItem: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 1 })),
+      createMany: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ count: 1 })),
+      delete: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
+      deleteMany: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ count: 1 })),
+    },
+  },
+  queueUpdate: vi.fn(() => undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+// `toggleBookmarked` calls metricsEngine.queueUpdate on the delete path. Stub the metrics module
+// surface user.service reaches at import time.
+vi.mock('~/server/metrics', () => ({
+  articleMetrics: { queueUpdate },
+  imageMetrics: { queueUpdate },
+  modelMetrics: { queueUpdate },
+  postMetrics: { queueUpdate },
+  userMetrics: { queueUpdate },
+}));
+// Mirrors the engagement-toggle test: stub the user-preferences module surface user.service
+// reaches at import time so module load doesn't pull in the real cache layer.
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenModels: { refreshCache: vi.fn(async () => undefined) },
+  HiddenModels3D: { refreshCache: vi.fn(async () => undefined) },
+  HiddenUsers: { refreshCache: vi.fn(async () => undefined) },
+  HiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  HiddenTags: { refreshCache: vi.fn(async () => undefined) },
+  BlockedUsers: { refreshCache: vi.fn(async () => undefined), getCached: vi.fn(async () => []) },
+  BlockedByUsers: { refreshCache: vi.fn(async () => undefined) },
+  ImplicitHiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  toggleHidden: vi.fn(async () => ({ added: [], removed: [] })),
+}));
+
+import { toggleBookmarked } from '~/server/services/user.service';
+import { CollectionType } from '~/shared/utils/prisma/enums';
+
+const p2002 = (target: string[]) =>
+  new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: '1',
+    meta: { target },
+  });
+
+const args = { entityId: 10, type: CollectionType.Model, userId: 42 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // default: bookmark collection exists, no item yet
+  mockDb.collection.findFirst.mockResolvedValue({ id: 999 });
+  mockDb.collection.create.mockResolvedValue({ id: 999 });
+  mockDb.collectionItem.findFirst.mockResolvedValue(null);
+  mockDb.collectionItem.createMany.mockResolvedValue({ count: 1 });
+  mockDb.collectionItem.deleteMany.mockResolvedValue({ count: 1 });
+});
+
+describe('toggleBookmarked — race #3: delete path is idempotent (deleteMany, no P2025)', () => {
+  it('uses deleteMany (not delete) when un-bookmarking', async () => {
+    mockDb.collectionItem.findFirst.mockResolvedValueOnce({ id: 555 });
+
+    const result = await toggleBookmarked(args);
+
+    expect(result).toBe(false); // existed → now removed
+    expect(mockDb.collectionItem.deleteMany).toHaveBeenCalledTimes(1);
+    expect(mockDb.collectionItem.deleteMany).toHaveBeenCalledWith({ where: { id: 555 } });
+    expect(mockDb.collectionItem.delete).not.toHaveBeenCalled();
+    expect(queueUpdate).toHaveBeenCalledWith(10);
+  });
+
+  it('does NOT throw when the row is already gone (concurrent un-bookmark, count: 0)', async () => {
+    mockDb.collectionItem.findFirst.mockResolvedValueOnce({ id: 555 });
+    mockDb.collectionItem.deleteMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(toggleBookmarked(args)).resolves.toBe(false);
+    // metrics side-effect still runs on the idempotent delete path
+    expect(queueUpdate).toHaveBeenCalledWith(10);
+  });
+});
+
+describe('toggleBookmarked — race #2: create path uses createMany({ skipDuplicates: true })', () => {
+  it('uses createMany with skipDuplicates (not create) when bookmarking', async () => {
+    const result = await toggleBookmarked(args);
+
+    expect(result).toBe(true); // did not exist → now added
+    expect(mockDb.collectionItem.createMany).toHaveBeenCalledTimes(1);
+    expect(mockDb.collectionItem.createMany).toHaveBeenCalledWith({
+      data: [{ collectionId: 999, modelId: 10 }],
+      skipDuplicates: true,
+    });
+    expect(mockDb.collectionItem.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('toggleBookmarked — race #1: collection.create P2002 is caught and re-fetched', () => {
+  it('lost create race → re-fetches the bookmark collection and proceeds with its id', async () => {
+    // no collection on first read → enter the create branch
+    mockDb.collection.findFirst.mockResolvedValueOnce(null);
+    // create loses the race
+    mockDb.collection.create.mockRejectedValueOnce(p2002(['userId', 'type', 'mode']));
+    // re-fetch returns the winner's collection
+    mockDb.collection.findFirst.mockResolvedValueOnce({ id: 777 });
+
+    const result = await toggleBookmarked(args);
+
+    expect(result).toBe(true);
+    // item op proceeds against the RE-FETCHED collection id (777), not undefined → no NPE
+    expect(mockDb.collectionItem.createMany).toHaveBeenCalledWith({
+      data: [{ collectionId: 777, modelId: 10 }],
+      skipDuplicates: true,
+    });
+  });
+
+  it('happy path: no collection → creates it once, no re-fetch needed', async () => {
+    mockDb.collection.findFirst.mockResolvedValueOnce(null);
+    mockDb.collection.create.mockResolvedValueOnce({ id: 888 });
+
+    const result = await toggleBookmarked(args);
+
+    expect(result).toBe(true);
+    expect(mockDb.collection.create).toHaveBeenCalledTimes(1);
+    expect(mockDb.collectionItem.createMany).toHaveBeenCalledWith({
+      data: [{ collectionId: 888, modelId: 10 }],
+      skipDuplicates: true,
+    });
+  });
+
+  it('rethrows a non-P2002 collection.create error (does not swallow real failures)', async () => {
+    mockDb.collection.findFirst.mockResolvedValueOnce(null);
+    mockDb.collection.create.mockRejectedValueOnce(new Error('connection reset'));
+
+    await expect(toggleBookmarked(args)).rejects.toThrow('connection reset');
+  });
+
+  it('throws a clear error if the collection is still missing after the create race', async () => {
+    mockDb.collection.findFirst.mockResolvedValueOnce(null); // first read
+    mockDb.collection.create.mockRejectedValueOnce(p2002(['userId', 'type', 'mode']));
+    mockDb.collection.findFirst.mockResolvedValueOnce(null); // re-fetch also empty
+
+    await expect(toggleBookmarked(args)).rejects.toThrow(
+      'bookmark collection missing after create race'
+    );
+  });
+});

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1856,15 +1856,30 @@ export const toggleBookmarked = async ({
     where: { userId, type, mode: CollectionMode.Bookmark },
   });
   if (!collection) {
-    collection = await dbWrite.collection.create({
-      data: {
-        userId,
-        type,
-        mode: CollectionMode.Bookmark,
-        name: `Bookmarked ${type}`,
-        description: `Your bookmarked ${type.toLowerCase()} will appear in this collection.`,
-      },
-    });
+    // Race #1: the bookmark collection is guarded by a prod-only partial unique index
+    // `User_bookmark_collection UNIQUE (userId, type, mode) WHERE mode='Bookmark'` (NOT in the
+    // Prisma schema). Two concurrent toggles can both see null and both create → loser hits P2002.
+    // Prisma `upsert` can't target a partial WHERE index, so create-then-refetch on the conflict.
+    collection =
+      (await dbWrite.collection
+        .create({
+          data: {
+            userId,
+            type,
+            mode: CollectionMode.Bookmark,
+            name: `Bookmarked ${type}`,
+            description: `Your bookmarked ${type.toLowerCase()} will appear in this collection.`,
+          },
+        })
+        .catch((e) => {
+          if (!isPrismaUniqueViolation(e)) throw e;
+          return null; // lost the create race — fall through to re-fetch
+        })) ??
+      (await dbWrite.collection.findFirst({
+        where: { userId, type, mode: CollectionMode.Bookmark },
+      }));
+    if (!collection)
+      throw new Error('toggleBookmarked: bookmark collection missing after create race');
   }
 
   const entityProp = collectionEntityProps[type];
@@ -1884,15 +1899,25 @@ export const toggleBookmarked = async ({
 
   // if the engagement exists, we only need to remove the existing engagmement
   if (exists && setTo !== true) {
-    await dbWrite.collectionItem.delete({
+    // Race #3: concurrent un-bookmarks both read the same row then both delete it → loser hits
+    // P2025 ("record not found"). `deleteMany` returns {count} and never throws on zero rows, so
+    // it's fully idempotent — no try/catch needed.
+    await dbWrite.collectionItem.deleteMany({
       where: {
         id: collectionItem.id,
       },
     });
     metricsEngine.queueUpdate(entityId);
   } else if (!exists && setTo !== false) {
-    await dbWrite.collectionItem.create({
-      data: { collectionId: collection.id, [entityProp]: entityId },
+    // Race #2: the collection item is guarded by prod-only partial unique indexes
+    // (`CollectionItem_model UNIQUE (collectionId, modelId) WHERE modelId IS NOT NULL`, and the
+    // analogous image/post/article indexes — NOT in the Prisma schema). Concurrent bookmarks both
+    // see no row and both create → loser hits P2002. `createMany({ skipDuplicates: true })` emits
+    // ON CONFLICT DO NOTHING, so the race resolves at the DB with no throw. The return value isn't
+    // used (the function returns `!exists`).
+    await dbWrite.collectionItem.createMany({
+      data: [{ collectionId: collection.id, [entityProp]: entityId }],
+      skipDuplicates: true,
     });
   }
 


### PR DESCRIPTION
## Problem

`toggleBookmarked` in `src/server/services/user.service.ts` is the shared helper behind **all** bookmark toggles — `toggleFavorite` (Model), `toggleBookmarkedArticle` (Article), and the Image/Post callers in `user.controller.ts`. It does read-then-write (`findFirst` → `create`/`delete`) with no concurrency guard, so two near-simultaneous toggles from the same user race each other.

It is the **~1.3/day HTTP-500 residual on `user.toggleFavorite`** — the tail left after #2816/#2798 cleared the sibling `modelEngagement` + `resourceReview` toggle races. Fixing the shared helper once hardens every bookmark type.

The three races all collide with **prod-only partial unique indexes that are NOT in the Prisma schema** (they're raw DB indexes, so Prisma's generated client doesn't know about them and can't `upsert` against them):

1. **`collection.create` → P2002.** `findFirst({userId,type,mode:Bookmark})`, then if null `collection.create(...)`. Two concurrent toggles both see null and both create → the loser violates `User_bookmark_collection UNIQUE (userId, type, mode) WHERE mode='Bookmark'`.
2. **`collectionItem.create` → P2002.** Concurrent bookmarks both find no item and both create → the loser violates `CollectionItem_model UNIQUE (collectionId, modelId) WHERE modelId IS NOT NULL` (and the analogous `CollectionItem_image_idx`/`_post_idx`/`_article_idx` for the other entity types).
3. **`collectionItem.delete` → P2025.** Concurrent un-bookmarks both read the same row id and both `delete({where:{id}})` → the loser hits P2025 "record not found".

## Fix

Prefer the deterministic DB primitive over try/catch where it's clean:

- **#3 `delete` → `deleteMany`** — returns `{count}` and never throws on zero rows. Fully idempotent, no catch needed. Metrics `queueUpdate` still runs.
- **#2 `create` → `createMany({ data: [...], skipDuplicates: true })`** — emits `ON CONFLICT DO NOTHING`; the race resolves at the DB with no throw. The create's return value was already unused (the function returns `!exists`).
- **#1 `collection.create` → catch + re-fetch** — Prisma `upsert` can't target the partial `WHERE mode='Bookmark'` index, so this one keeps a `.catch`: on a unique violation (via the existing `isPrismaUniqueViolation` helper, added in #2816) it returns null and **re-fetches** the bookmark collection. Re-fetching is critical — a bare swallow would leave `collection` null and the next line would NPE on `collection.id`. A guard throws a clear error if the collection is still missing after the race.

Behavior is otherwise identical: same `!exists` return, same `metricsEngine.queueUpdate` calls, same early-throw for unsupported types, `findFirst` reads and the Model3D short-circuit untouched.

## Tests

New `src/server/services/__tests__/toggle-bookmarked.idempotent.service.test.ts` (mirrors the existing `engagement-toggle.idempotent.service.test.ts` mock pattern — mocks `dbWrite`/`dbRead`, `~/server/metrics`, and the user-preferences module surface, then imports `toggleBookmarked` directly). 7 cases:

- delete path uses `deleteMany` (not `delete`), and does **not** throw when the row is already gone (`count: 0`), still firing the metrics update;
- create path uses `createMany({ skipDuplicates: true })` (not `create`);
- collection.create P2002 is caught, the collection is re-fetched, and the item op proceeds against the **re-fetched** id (no NPE);
- happy paths (no race) for both collection-create and item-create;
- a non-P2002 collection.create error is **rethrown** (real failures aren't swallowed);
- a clear error is thrown if the collection is still missing after the create race.

`npx vitest run --project unit src/server/services/__tests__/toggle-bookmarked.idempotent.service.test.ts` → 7/7 green. Full-repo `tsc --noEmit` shows no errors referencing the changed files (the ~46 errors present are pre-existing, in unrelated files — @prisma/@civitai/client resolution, kysely, comics, vault, orchestrator handlers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
