### PR TITLE
feat(training): allow custom Anima checkpoints as a trainer base

### DIFF
--- a/src/components/Training/Form/TrainingSubmitModelSelect.tsx
+++ b/src/components/Training/Form/TrainingSubmitModelSelect.tsx
@@ -85,6 +85,7 @@ const ModelSelector = ({
   isCustom = false,
   isVideo = false,
   allowedKeys,
+  customBaseModels,
 }: {
   selectedRun: TrainingRun;
   color: MantineColor;
@@ -96,6 +97,7 @@ const ModelSelector = ({
   isCustom?: boolean;
   isVideo?: boolean;
   allowedKeys?: string[];
+  customBaseModels?: string[];
 }) => {
   const versions = Object.entries(trainingModelInfo).filter(
     ([k, v]) =>
@@ -152,7 +154,13 @@ const ModelSelector = ({
                 {
                   type: ModelType.Checkpoint,
                   // nb: when adding here, make sure logic is added in castBase below
-                  baseModels: ['SD 1.4', 'SD 1.5', 'SDXL 1.0', 'Pony', 'Illustrious'],
+                  baseModels: customBaseModels ?? [
+                    'SD 1.4',
+                    'SD 1.5',
+                    'SDXL 1.0',
+                    'Pony',
+                    'Illustrious',
+                  ],
                 },
               ],
             }}
@@ -204,6 +212,8 @@ const ModelSelector = ({
                   ? 'flux2klein'
                   : ([...getBaseModelsByGroup('Chroma')] as string[]).includes(baseModel)
                   ? 'chroma'
+                  : ([...getBaseModelsByGroup('Anima')] as string[]).includes(baseModel)
+                  ? 'anima'
                   : 'sd15';
 
                 const cLink = stringifyAIR({
@@ -767,6 +777,14 @@ export const ModelSelect = ({
                     baseType="sdxl" // unused
                     makeDefaultParams={makeDefaultParams}
                     isCustom
+                    customBaseModels={[
+                      'SD 1.4',
+                      'SD 1.5',
+                      'SDXL 1.0',
+                      'Pony',
+                      'Illustrious',
+                      ...(features.animaTraining ? getBaseModelsByGroup('Anima') : []),
+                    ]}
                   />
                 </>
               )}

--- a/src/server/services/orchestrator/training/training.orch.ts
+++ b/src/server/services/orchestrator/training/training.orch.ts
@@ -9,6 +9,7 @@ import type {
   AiToolkitTrainingInput,
   SdxlAiToolkitTrainingInput,
   Sd1AiToolkitTrainingInput,
+  AnimaAiToolkitTrainingInput,
 } from '@civitai/client';
 import { env } from '~/env/server';
 import { constants } from '~/server/common/constants';
@@ -218,6 +219,13 @@ const createTrainingStep_AiToolkit = (input: ImageTrainingStepSchema): TrainingS
       model,
       minSnrGamma: aiToolkitParams.minSnrGamma ?? undefined,
     } as SdxlAiToolkitTrainingInput;
+  } else if (aiToolkitParams.ecosystem === 'anima') {
+    // Anima accepts a `model` (the official base AIR, or a custom Anima
+    // checkpoint which the orchestrator trains over the base Anima repo).
+    trainingInput = {
+      ...trainingInput,
+      model,
+    } as AnimaAiToolkitTrainingInput;
   }
 
   // ACE-Step audio ecosystems accept per-prompt sample overrides. The SDK


### PR DESCRIPTION
The "Custom" model selector only accepted the SDXL family, so users couldn't train a LoRA on top of their own Anima checkpoint. Add Anima to the custom checkpoint picker (gated behind the animaTraining flag, matching the official Anima base selector), map it to the anima base type, and send `model` for the anima ecosystem in the orchestrator step.