### PR TITLE
fix(app-blocks): make review entry discoverable — show install/sign-in prompt instead of hiding the form

### DIFF
--- a/src/components/Apps/AppBlockReviews.browser.test.tsx
+++ b/src/components/Apps/AppBlockReviews.browser.test.tsx
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => ({
     details: string | null;
     createdAt: Date;
   },
+  // Per-test-controllable current user (null = anonymous viewer).
+  currentUser: { id: 42, username: 'viewer' } as null | { id: number; username: string },
 }));
 
 vi.mock('~/utils/trpc', () => ({
@@ -80,7 +82,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true }),
 }));
 vi.mock('~/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ id: 42, username: 'viewer' }),
+  useCurrentUser: () => mocks.currentUser,
+}));
+
+// LoginRedirect pulls in the router + tour context; it's a pass-through wrapper
+// for the sign-in CTA here — stub it to render its child unchanged.
+vi.mock('~/components/LoginRedirect/LoginRedirect', () => ({
+  LoginRedirect: ({ children }: { children: React.ReactElement }) => children,
 }));
 
 // UserAvatar pulls in edge-url/cosmetics machinery we don't need here — stub it
@@ -114,9 +122,63 @@ beforeEach(() => {
   mocks.invalidate.mockClear();
   mocks.listItems = [];
   mocks.myReview = null;
+  mocks.currentUser = { id: 42, username: 'viewer' };
 });
 
 describe('AppBlockReviews', () => {
+  test('signed-in viewer with an enabled install sees the write form (not the prompt)', async () => {
+    renderWithProviders(
+      <AppBlockReviews
+        appBlockId="app-1"
+        avgRating={null}
+        reviewCount={0}
+        subscriptions={[ENABLED_SUB]}
+      />
+    );
+
+    // The form is present...
+    await expect.element(page.getByRole('button', { name: /post review/i })).toBeInTheDocument();
+    // ...and neither gating prompt is shown.
+    await expect
+      .element(page.getByText(/install this app to leave a review/i))
+      .not.toBeInTheDocument();
+    await expect.element(page.getByText(/sign in to leave a review/i)).not.toBeInTheDocument();
+  });
+
+  test('signed-in viewer with NO enabled install sees the install prompt, form hidden', async () => {
+    renderWithProviders(
+      <AppBlockReviews appBlockId="app-1" avgRating={null} reviewCount={0} subscriptions={[]} />
+    );
+
+    // The install prompt is shown...
+    await expect
+      .element(page.getByText(/install this app to leave a review/i))
+      .toBeInTheDocument();
+    // ...and the write form is NOT rendered.
+    await expect
+      .element(page.getByRole('button', { name: /post review/i }))
+      .not.toBeInTheDocument();
+  });
+
+  test('anonymous viewer sees the sign-in prompt, form hidden', async () => {
+    mocks.currentUser = null;
+
+    renderWithProviders(
+      <AppBlockReviews appBlockId="app-1" avgRating={null} reviewCount={0} subscriptions={[]} />
+    );
+
+    // The sign-in affordance is shown...
+    await expect.element(page.getByText(/sign in to leave a review/i)).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: /^sign in$/i })).toBeInTheDocument();
+    // ...and neither the write form nor the install prompt are rendered.
+    await expect
+      .element(page.getByRole('button', { name: /post review/i }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(page.getByText(/install this app to leave a review/i))
+      .not.toBeInTheDocument();
+  });
+
   test('write form submits upsertReview with the entered rating and details', async () => {
     renderWithProviders(
       <AppBlockReviews

--- a/src/components/Apps/AppBlockReviews.tsx
+++ b/src/components/Apps/AppBlockReviews.tsx
@@ -14,13 +14,16 @@ import {
   Title,
 } from '@mantine/core';
 import {
+  IconLogin,
   IconMoodSmile,
+  IconPlugConnected,
   IconStarFilled,
   IconThumbDown,
   IconThumbUp,
 } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
+import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -59,6 +62,15 @@ type AppBlockReviewsProps = {
  *     client-visible owner signal in PublicAppDetail, so it is enforced on the
  *     server — if an owner somehow installs + tries to review, the upsert 403s
  *     and we surface the friendly "You cannot review your own app" message.
+ *   - When the form is gated off we render an explanatory PROMPT instead of
+ *     nothing, so the path to reviewing is discoverable: a "sign in to review"
+ *     affordance for anon viewers (LoginRedirect, mirroring the install CTA on
+ *     AppBlockCard), or an "install this app to leave a review" message for a
+ *     signed-in viewer with no enabled install. This only makes the EXISTING
+ *     requirement VISIBLE — the install requirement is still enforced (the
+ *     server is the source of truth). There is no client-side owner signal, so
+ *     the owner sees the generic install prompt; the server still 403s their
+ *     self-review.
  *
  * SECURITY: review `details` is rendered as PLAIN TEXT via React's default
  * escaping (a `<Text>` child) — NEVER dangerouslySetInnerHTML. `details` is not
@@ -85,9 +97,55 @@ export function AppBlockReviews({
   return (
     <Stack gap="lg">
       <ReviewSummary avgRating={avgRating} reviewCount={reviewCount} />
-      {canReview && <ReviewForm appBlockId={appBlockId} />}
+      {canReview ? (
+        <ReviewForm appBlockId={appBlockId} />
+      ) : (
+        <ReviewPrompt signedIn={!!currentUser} />
+      )}
       <ReviewList appBlockId={appBlockId} viewerUserId={currentUser?.id} />
     </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Prompt — shown in place of the form when the viewer can't review yet, so the
+// path to reviewing is discoverable instead of silently empty. Anon → sign-in
+// affordance; signed-in-but-no-install → install requirement made visible.
+// ---------------------------------------------------------------------------
+
+function ReviewPrompt({ signedIn }: { signedIn: boolean }) {
+  if (!signedIn) {
+    return (
+      <Card withBorder radius="md" p="md">
+        <Group justify="space-between" align="center" wrap="nowrap">
+          <Text size="sm" c="dimmed">
+            Sign in to leave a review.
+          </Text>
+          <LoginRedirect reason="perform-action">
+            <Button size="xs" variant="light" leftSection={<IconLogin size={14} />}>
+              Sign in
+            </Button>
+          </LoginRedirect>
+        </Group>
+      </Card>
+    );
+  }
+
+  // Signed in, but no enabled install for this app — surface the install
+  // requirement (the server enforces it; this just makes it visible). There is
+  // no client-side owner signal, so the app owner sees this too; their
+  // self-review is still blocked server-side.
+  return (
+    <Card withBorder radius="md" p="md">
+      <Group gap="xs" align="center" wrap="nowrap">
+        <ThemeIcon variant="light" size="sm" radius="xl">
+          <IconPlugConnected size={12} />
+        </ThemeIcon>
+        <Text size="sm" c="dimmed">
+          Install this app to leave a review.
+        </Text>
+      </Group>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Problem

On an App Block's detail page, the "write a review" form was hidden **entirely** when the viewer hadn't installed the app. The component computed:

```ts
const canReview = !!features.appBlocks && !!currentUser && hasEnabledInstall;
// ...
{canReview && <ReviewForm appBlockId={appBlockId} />}
```

So a moderator or user landing on the page who wasn't signed in, or hadn't installed the app, saw **nothing** where the review entry should be — no form, and no explanation of *why* there was no form. The path to leaving a review was undiscoverable.

## Fix

Render an explanatory prompt in place of the hidden form (`src/components/Apps/AppBlockReviews.tsx`):

- **Not signed in** → a "Sign in to leave a review" affordance using the existing `LoginRedirect` pattern (the same sign-in trigger used by the Install CTA on `AppBlockCard`).
- **Signed in but no enabled install** → an "Install this app to leave a review" message that makes the install requirement visible.

The actual `ReviewForm` stays gated on `canReview` **exactly as before** — the install requirement is unchanged, and the server remains the source of truth (it enforces rating 1–5, the enabled-install requirement, and the no-self-review 403 in `appBlockReview.service.ts`). This change only makes the existing requirement **visible**.

There is no client-side owner signal in the public app detail data, so the app owner sees the generic install prompt; their self-review is still blocked server-side. Per the task scope, no synthetic owner signal was invented.

Styling matches the component's existing Mantine idiom (a `withBorder` `Card`, dimmed `Text`, `ThemeIcon`/`Button` with tabler icons).

## Test coverage

Extended `src/components/Apps/AppBlockReviews.browser.test.tsx` with three cases (made `useCurrentUser` per-test-controllable and stubbed `LoginRedirect` as a pass-through, mirroring the sibling `AppBlockCard` tests):

- signed-in + enabled install → **form shown**, prompts hidden
- signed-in + no install → **install prompt shown**, form hidden
- anonymous → **sign-in prompt shown**, form hidden

All 5 tests in the file pass locally (`vitest run --project component`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)