### PR TITLE
feat(app-blocks): gate NSFW-rated apps to civitai.red (mature ceiling + listing/run/detail gates)

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -19,8 +19,16 @@ import { BlockRegistry } from '~/server/services/block-registry.service';
 import { BlockTokenService } from '~/server/services/block-token.service';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { getFeatureFlags } from '~/server/services/feature-flags.service';
-import { getAllServerHosts, getRequestDomainColor } from '~/server/utils/server-domain';
-import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
+import {
+  getAllServerHosts,
+  getRequestDomainColor,
+  isHostForColor,
+  isMatureContentRating,
+} from '~/server/utils/server-domain';
+import {
+  allBrowsingLevelsFlag,
+  domainBrowsingCeiling,
+} from '~/shared/constants/browsingLevel.constants';
 import {
   isKnownBlockScope,
   validateBlockScopesAgainstOauthClient,
@@ -690,12 +698,40 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // from THIS claim (never a client body field), so a SFW-domain block cannot
   // generate mature output even if its own code is wrong or malicious.
   //
-  // Fail-closed: an unknown/missing domain → domainBrowsingCeiling() returns the
-  // SFW ceiling. We always emit the claim so consumers can distinguish a
-  // legacy (pre-feature) token — which has NO claim and is treated as SFW by
-  // the consumer — from an explicit red mint.
+  // NSFW-APP-RED-ONLY: `domainBrowsingCeiling(getRequestDomainColor(req))` would
+  // return the SFW ceiling on civitai.red, because `getRequestDomainColor`
+  // first-matches blue for .red (it is configured as BOTH blue and red). For the
+  // block path we want the host's RED capability to drive the ceiling: a
+  // red-capable host (`isHostForColor(host, 'red')` — TRUE for civitai.red and
+  // its aliases) mints the FULL mature ceiling; every other host keeps the
+  // domain-color SFW derivation. Scoped to the block path only — the global
+  // color resolution / domainBrowsingCeiling semantics are untouched.
+  //
+  // Fail-closed: an unknown/missing host or a non-red host → the SFW ceiling. We
+  // always emit the claim so consumers can distinguish a legacy (pre-feature)
+  // token — which has NO claim and is treated as SFW by the consumer — from an
+  // explicit red mint.
+  const host = req.headers.host ?? '';
+  const redCapableHost = host !== '' && isHostForColor(host, 'red');
   const domainColor = getRequestDomainColor(req);
-  const maxBrowsingLevel = domainBrowsingCeiling(domainColor);
+  const maxBrowsingLevel = redCapableHost
+    ? allBrowsingLevelsFlag
+    : domainBrowsingCeiling(domainColor);
+
+  // DEFENSE-IN-DEPTH cross-check (fail-closed, refuse): a mature-rated app
+  // (contentRating ∈ {r, x}, the authoritative manifest field the validator
+  // requires + approve stores) may NEVER mint a token on a non-red-capable host.
+  // The run-page SSR gate + the listing filter already hide/404 mature apps off
+  // .red, so a mint request for one on .com should not happen through the UI —
+  // but a direct API caller could try, so we refuse here rather than down-clamp
+  // (a clamp would still hand back a usable token; refusal is unambiguous and
+  // leaves the run-page 404 as the only surface). The dev-token path is a
+  // SEPARATE endpoint (forced-SFW) and is unaffected.
+  const appContentRating = (block.manifest as { contentRating?: unknown }).contentRating;
+  if (typeof appContentRating === 'string' && isMatureContentRating(appContentRating) && !redCapableHost) {
+    res.status(403).json({ error: 'This app is only available on civitai.red.' });
+    return;
+  }
 
   const result = await BlockTokenService.sign({
     userId,

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -7,6 +7,7 @@ import { useBlockToken } from '~/components/AppBlocks/useBlockToken';
 import type { BlockInstall, PageContext } from '~/components/AppBlocks/types';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { ratingAllowedOnHost } from '~/server/utils/server-domain';
 
 /**
  * W10 — full-page App Block route: `/apps/run/<slug>` (+ optional sub-path).
@@ -58,6 +59,17 @@ export const getServerSideProps = createServerSideProps<PageProps>({
     // missing / non-approved / non-page app → 404 (never leaks which).
     const page = await BlockRegistry.resolvePageBlockBySlug(slug, { db: 'read' });
     if (!page || !page.iframeSrc) return { notFound: true };
+
+    // NSFW-APP-RED-ONLY: a mature (r/x) page app is usable ONLY on a red-capable
+    // host (civitai.red). On civitai.com (or any non-red host) it is
+    // indistinguishable from a missing app — return the SAME fail-closed 404 the
+    // flag gate above produces, so mature content can never render off .red and
+    // the app can't be enumerated by slug. SFW apps render anywhere. The host is
+    // read from the request (the same authority the token mint uses).
+    const host = ctx.req.headers.host ?? '';
+    if (!ratingAllowedOnHost(page.contentRating, host)) {
+      return { notFound: true };
+    }
 
     return {
       props: {

--- a/src/pages/apps/run/[slug]/run-page-maturity.test.ts
+++ b/src/pages/apps/run/[slug]/run-page-maturity.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * NSFW-APP-RED-ONLY — run-page SSR gate (`/apps/run/<slug>`).
+ *
+ * A mature (r/x) page app 404s when the request host is not red-capable; SFW
+ * apps render on any host; mature apps render on civitai.red. We mock
+ * `createServerSideProps` to capture the resolver (so we can invoke it with a
+ * controlled `ctx`/`features`), the registry resolve, and the host gate helper.
+ */
+
+const { capturedResolver } = vi.hoisted(() => ({
+  capturedResolver: { fn: null as null | ((c: any) => Promise<any>) },
+}));
+
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  // Capture the resolver passed by the page so the test can invoke it directly.
+  createServerSideProps: (opts: { resolver: (c: any) => Promise<any> }) => {
+    capturedResolver.fn = opts.resolver;
+    return async () => ({ props: {} });
+  },
+}));
+
+const { mockResolvePageBlockBySlug } = vi.hoisted(() => ({
+  mockResolvePageBlockBySlug: vi.fn<(...a: any[]) => Promise<any>>(),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: { resolvePageBlockBySlug: mockResolvePageBlockBySlug },
+}));
+
+// Real-ish host gate: mature (r/x) requires civitai.red.
+vi.mock('~/server/utils/server-domain', () => ({
+  ratingAllowedOnHost: (rating: unknown, host: string) => {
+    const mature = typeof rating === 'string' && ['r', 'x'].includes(rating.toLowerCase());
+    if (!mature) return true;
+    return host === 'civitai.red' || host === 'www.civitai.red';
+  },
+}));
+
+// The page imports React/Mantine component bits at module top; stub the heavy
+// ones so importing the page module in a node unit test doesn't pull a DOM.
+vi.mock('@mantine/core', () => ({ Box: () => null, useComputedColorScheme: () => 'dark' }));
+vi.mock('~/components/AppBlocks/PageBlockHost', () => ({ PageBlockHost: () => null }));
+vi.mock('~/components/AppBlocks/useBlockToken', () => ({ useBlockToken: () => ({}) }));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+const PAGE = {
+  appBlockId: 'ab_1',
+  blockId: 'cool-app',
+  appId: 'app_1',
+  iframeSrc: 'https://cool-app.civit.ai',
+  sandbox: 'allow-scripts',
+  trustTier: 'unverified' as const,
+  name: 'Cool App',
+  pageTitle: 'Cool',
+  scopes: [],
+  contentRating: 'g',
+};
+
+function makeCtx(host: string, slug = 'cool-app') {
+  return {
+    features: { appBlocks: true, appBlocksPages: true },
+    ctx: { params: { slug }, req: { headers: { host } } },
+  };
+}
+
+async function loadResolver() {
+  await import('./[[...path]]');
+  if (!capturedResolver.fn) throw new Error('resolver not captured');
+  return capturedResolver.fn;
+}
+
+describe('run-page SSR — NSFW-app-red-only gate', () => {
+  beforeEach(() => {
+    // Only clear the registry/host mocks — NOT capturedResolver. The page module
+    // is imported once (ESM module cache), so createServerSideProps runs (and
+    // captures the resolver) on the first import only; nulling it here would lose
+    // it for every subsequent test.
+    mockResolvePageBlockBySlug.mockReset();
+  });
+
+  it('SFW (g) app renders on civitai.com', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'g' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.com'));
+    expect(result).toHaveProperty('props');
+    expect(result.props.appBlockId).toBe('ab_1');
+  });
+
+  it('SFW (g) app renders on civitai.red too', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'g' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.red'));
+    expect(result).toHaveProperty('props');
+  });
+
+  it('MATURE (x) app 404s on civitai.com', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'x' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.com'));
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it('MATURE (x) app renders on civitai.red', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'x' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.red'));
+    expect(result).toHaveProperty('props');
+    expect(result.props.appBlockId).toBe('ab_1');
+  });
+
+  it('MATURE (r) app 404s on a missing host header (fail-closed)', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue({ ...PAGE, contentRating: 'r' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx(''));
+    expect(result).toEqual({ notFound: true });
+  });
+
+  it('still 404s a missing app regardless of host (no regression)', async () => {
+    mockResolvePageBlockBySlug.mockResolvedValue(null);
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx('civitai.red'));
+    expect(result).toEqual({ notFound: true });
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
@@ -159,7 +159,9 @@ describe('blocks.getAppDetail — anon-capable, dark behind the flag (F-E E2)', 
     // passed to the service (which restricts to page apps; that filtering is
     // covered in block-registry.page-only-launch.test.ts — here the service is
     // mocked, so we only assert the forwarded arg).
-    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1', true);
+    // NSFW-APP-RED-ONLY: the 3rd arg is redCapable, derived from the request
+    // host. The fake ctx carries no host header → not red-capable → false.
+    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1', true, false);
   });
 
   it('moderator (the live state today): served, launchOnly=false (grandfather)', async () => {
@@ -167,8 +169,8 @@ describe('blocks.getAppDetail — anon-capable, dark behind the flag (F-E E2)', 
     const result = await caller.getAppDetail(input);
     expect(result).toEqual(PUBLIC_DETAIL);
     expect(mockGetAppDetail).toHaveBeenCalledTimes(1);
-    // A moderator sees everything → launchOnly=false.
-    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1', false);
+    // A moderator sees everything → launchOnly=false. redCapable=false (no host).
+    expect(mockGetAppDetail).toHaveBeenCalledWith('ab_1', false, false);
   });
 
   it('NOT_FOUND when the service returns null (missing / non-approved app)', async () => {

--- a/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
+++ b/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
@@ -253,7 +253,8 @@ describe('blocks.getFeaturedBlocks — anon-capable, dark behind the flag (F-E E
     expect(result).toEqual({ items: featured });
     // PAGE-ONLY LAUNCH GATE (#2622): a non-mod/anon caller passes launchOnly=true
     // so the featured rail carries launch (page) apps only.
-    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12, true);
+    // 3rd arg = redCapable (NSFW-app-red-only; no host header → false).
+    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12, true, false);
   });
 
   it('moderator (the live state today): served — sees ALL featured apps (launchOnly=false)', async () => {
@@ -261,6 +262,8 @@ describe('blocks.getFeaturedBlocks — anon-capable, dark behind the flag (F-E E
     await caller.getFeaturedBlocks({ limit: 12 });
     expect(mockGetFeaturedBlocks).toHaveBeenCalledTimes(1);
     // Mods bypass the page-only launch gate → launchOnly=false (all apps).
-    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12, false);
+    // 3rd arg = redCapable (no host → false). Maturity is a host property, not a
+    // privilege — even a mod on .com does not see mature apps here.
+    expect(mockGetFeaturedBlocks).toHaveBeenCalledWith(12, false, false);
   });
 });

--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -244,6 +244,8 @@ describe('blocks.listAvailable (public)', () => {
     // everything).
     expect(mockListAvailable).toHaveBeenCalledWith(
       expect.objectContaining({ query: 'generate', slotId: 'model.sidebar_top', limit: 5 }),
+      false,
+      // 3rd arg = redCapable (NSFW-app-red-only; no host header → false).
       false
     );
   });
@@ -257,7 +259,9 @@ describe('blocks.listAvailable (public)', () => {
     await caller.listAvailable({ limit: 20 });
     expect(mockListAvailable).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 20 }),
-      true
+      true,
+      // 3rd arg = redCapable (no host → false).
+      false
     );
   });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -71,7 +71,7 @@ import {
   validateBlockCheckpoint,
 } from '~/server/services/blocks/checkpoint.service';
 import { getModelShowcaseImages } from '~/server/services/blocks/showcase.service';
-import { getRequestDomainColor } from '~/server/utils/server-domain';
+import { getRequestDomainColor, isHostForColor } from '~/server/utils/server-domain';
 // Type-only: the runtime `resolveCanGenerateForVersions` is loaded via a
 // dynamic import() inside assertViewerCanGeneratePageResources so the heavy
 // generation-service import graph (image.service → event-engine-common, etc.)
@@ -621,6 +621,20 @@ function assertLaunchSlotForCaller(
 }
 
 /**
+ * NSFW-APP-RED-ONLY: true when the request is on a red-capable host
+ * (civitai.red or a red alias). Drives whether mature (r/x) apps appear in the
+ * marketplace listing / featured rail / detail / model-slot reads. Uses
+ * `isHostForColor(host, 'red')` (NOT `getRequestDomainColor`, which returns
+ * `blue` for civitai.red). Maturity is a HOST property — independent of
+ * moderator status — so even a mod on civitai.com does not see mature apps in
+ * these viewer-facing surfaces. Fail-closed: a missing host → false (SFW only).
+ */
+function isRedCapableRequest(ctx: { req?: { headers?: { host?: string } } }): boolean {
+  const host = ctx.req?.headers?.host ?? '';
+  return host !== '' && isHostForColor(host, 'red');
+}
+
+/**
  * Manifest-level variant of {@link assertLaunchSlotForCaller} for the
  * subscription path, where the slot isn't an input — it's implied by the app's
  * manifest targets. A model-slot app (the only kind that takes a subscription;
@@ -750,6 +764,9 @@ export const blocksRouter = router({
       return BlockRegistry.listForModel({
         ...input,
         viewerUserId: ctx.user?.id ?? null,
+        // NSFW-APP-RED-ONLY: mature (r/x) apps render in a model slot only on a
+        // red-capable host. Threaded from the request host.
+        redCapable: isRedCapableRequest(ctx),
       });
     }),
 
@@ -1515,7 +1532,12 @@ export const blocksRouter = router({
       // mod-only model-slot apps like generate-from-model). Mod status comes
       // from the server-stamped session `ctx.user?.isModerator` (cannot be
       // spoofed client-side — same source as every other belt in this router).
-      return BlockRegistry.listAvailable(input, !ctx.user?.isModerator);
+      return BlockRegistry.listAvailable(
+        input,
+        !ctx.user?.isModerator,
+        // NSFW-APP-RED-ONLY: hide mature (r/x) apps from the listing off .red.
+        isRedCapableRequest(ctx)
+      );
     }),
 
   /**
@@ -1574,7 +1596,10 @@ export const blocksRouter = router({
       // the server-stamped session flag.
       const detail = await BlockRegistry.getAppDetail(
         input.appBlockId,
-        !ctx.user?.isModerator
+        !ctx.user?.isModerator,
+        // NSFW-APP-RED-ONLY: a mature (r/x) app's detail resolves to NOT_FOUND
+        // off a red-capable host (mirrors the run-page SSR 404).
+        isRedCapableRequest(ctx)
       );
       if (!detail) throw throwNotFoundError('App block not found');
       return detail;
@@ -1618,7 +1643,9 @@ export const blocksRouter = router({
       // non-mod featured rail carries launch (page) apps only; mods see all.
       const items = await BlockRegistry.getFeaturedBlocks(
         input.limit,
-        !ctx.user?.isModerator
+        !ctx.user?.isModerator,
+        // NSFW-APP-RED-ONLY: hide mature (r/x) apps from the featured rail off .red.
+        isRedCapableRequest(ctx)
       );
       return { items };
     }),

--- a/src/server/services/__tests__/block-registry.nsfw-red-only.test.ts
+++ b/src/server/services/__tests__/block-registry.nsfw-red-only.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * NSFW-APP-RED-ONLY — service-level tests for the public marketplace reads
+ * (`BlockRegistry.listAvailable` / `getFeaturedBlocks` / `getAppDetail`).
+ *
+ * A mature-rated app (`content_rating` ∈ {r, x}) is hidden from listings /
+ * featured rail and 404s on detail UNLESS the request is on a red-capable host
+ * (the router passes `redCapable = isHostForColor(host, 'red')`). SFW apps show
+ * everywhere. These tests pin:
+ *   - listAvailable / getFeaturedBlocks thread the mature-exclusion SQL into the
+ *     query iff !redCapable (and omit it on a red host);
+ *   - getAppDetail returns null for a mature app under !redCapable (→ router
+ *     NOT_FOUND), and returns it on a red host;
+ *   - SFW apps are unaffected by the host gate.
+ *
+ * Mocks @prisma/client so `Prisma.sql` works without a generated client, and
+ * stubs dbRead.$queryRaw to capture the assembled SQL + return seeded rows
+ * (same harness idiom as block-registry.page-only-launch.test.ts).
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    blockUserSubscription: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    modelVersion: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+  },
+}));
+
+vi.mock('@prisma/client', () => {
+  function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+    let out = '';
+    for (let i = 0; i < strings.length; i++) {
+      out += strings[i];
+      if (i < values.length) {
+        const v = values[i];
+        out +=
+          v && typeof v === 'object' && '__sql' in (v as object)
+            ? (v as { __sql: string }).__sql
+            : '?';
+      }
+    }
+    return { __sql: out, sql: out, toString: () => out } as unknown as { sql: string };
+  }
+  return { Prisma: { sql } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  },
+  sysRedis: { sMembers: vi.fn(async () => []) },
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'packed:caches:block-registry', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai', LOGGING: '' } }));
+
+/** Reconstruct the assembled SQL string from the captured Prisma.sql object. */
+function capturedSql(): string {
+  expect(mockDbRead.$queryRaw).toHaveBeenCalled();
+  const lastCall = mockDbRead.$queryRaw.mock.calls.at(-1);
+  if (!lastCall) return '';
+  const first = lastCall[0] as unknown;
+  if (first && typeof first === 'object' && typeof (first as { sql?: unknown }).sql === 'string') {
+    return (first as { sql: string }).sql;
+  }
+  const strings = first as unknown as TemplateStringsArray;
+  const values = lastCall.slice(1);
+  let s = '';
+  for (let i = 0; i < strings.length; i++) {
+    s += strings[i];
+    if (i < values.length) {
+      const v = values[i];
+      s += v && typeof v === 'object' && 'sql' in (v as object) ? (v as { sql: string }).sql : '?';
+    }
+  }
+  return s;
+}
+
+// The mature-exclusion fragment matureHostSqlFilter emits when !redCapable.
+const MATURE_FILTER_RE = /NOT IN \('r', 'x'\)/;
+
+function listRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_1',
+    block_id: 'cool-block',
+    app_id: 'app_1',
+    app_name: 'Cool App',
+    install_count: 5n,
+    category: 'utility',
+    approved_scopes: ['user:read:self'],
+    sort_key: '00000000000000000005',
+    manifest: { name: 'Cool Block', page: { path: '/run', title: 'Run' } },
+    ...over,
+  };
+}
+
+function detailRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_det',
+    block_id: 'detail-block',
+    app_id: 'app_1',
+    app_name: 'Detail App',
+    status: 'approved',
+    content_rating: 'g',
+    version: '1.0.0',
+    approved_scopes: ['user:read:self'],
+    install_count: 3n,
+    screenshots: null,
+    // page app by default so the launchOnly gate doesn't interfere
+    manifest: { name: 'Detail Block', page: { path: '/run', title: 'Run' } },
+    ...over,
+  };
+}
+
+describe('BlockRegistry — NSFW-app-red-only host gate (public reads)', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([listRow()]);
+  });
+
+  describe('listAvailable', () => {
+    it('non-red host (redCapable=false) threads the mature-exclusion filter', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' }, true, false);
+      expect(capturedSql()).toMatch(MATURE_FILTER_RE);
+    });
+
+    it('red-capable host (redCapable=true) does NOT add the mature filter', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' }, true, true);
+      expect(capturedSql()).not.toMatch(MATURE_FILTER_RE);
+    });
+
+    it('default redCapable (omitted) is fail-closed → mature filter present', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' }, true);
+      expect(capturedSql()).toMatch(MATURE_FILTER_RE);
+    });
+  });
+
+  describe('getFeaturedBlocks', () => {
+    it('non-red host threads the mature-exclusion filter', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.getFeaturedBlocks(12, true, false);
+      expect(capturedSql()).toMatch(MATURE_FILTER_RE);
+    });
+
+    it('red-capable host does NOT add the mature filter', async () => {
+      const { BlockRegistry } = await import('../block-registry.service');
+      await BlockRegistry.getFeaturedBlocks(12, true, true);
+      expect(capturedSql()).not.toMatch(MATURE_FILTER_RE);
+    });
+  });
+
+  describe('getAppDetail', () => {
+    it('non-red host: a MATURE (x) app resolves to null (→ NOT_FOUND, no leak)', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([detailRow({ content_rating: 'x' })]);
+      const { BlockRegistry } = await import('../block-registry.service');
+      // launchOnly=false (mod-grandfather) isolates the maturity gate; redCapable=false.
+      const detail = await BlockRegistry.getAppDetail('ab_det', false, false);
+      expect(detail).toBeNull();
+    });
+
+    it('red-capable host: a MATURE (x) app resolves normally', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([detailRow({ content_rating: 'x' })]);
+      const { BlockRegistry } = await import('../block-registry.service');
+      const detail = await BlockRegistry.getAppDetail('ab_det', false, true);
+      expect(detail).not.toBeNull();
+      expect(detail?.contentRating).toBe('x');
+    });
+
+    it('non-red host: an SFW (g) app resolves normally (host gate only touches mature)', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([detailRow({ content_rating: 'g' })]);
+      const { BlockRegistry } = await import('../block-registry.service');
+      const detail = await BlockRegistry.getAppDetail('ab_det', false, false);
+      expect(detail).not.toBeNull();
+      expect(detail?.id).toBe('ab_det');
+    });
+
+    it('default redCapable (omitted) is fail-closed → mature app is null', async () => {
+      mockDbRead.$queryRaw.mockResolvedValueOnce([detailRow({ content_rating: 'r' })]);
+      const { BlockRegistry } = await import('../block-registry.service');
+      const detail = await BlockRegistry.getAppDetail('ab_det', false);
+      expect(detail).toBeNull();
+    });
+  });
+});

--- a/src/server/services/__tests__/block-registry.resolve-page.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-page.test.ts
@@ -177,3 +177,39 @@ describe('BlockRegistry.resolvePageBlockBySlug — sandbox + scopes', () => {
     expect(res).toBeNull();
   });
 });
+
+describe('BlockRegistry.resolvePageBlockBySlug — NSFW-app-red-only contentRating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('the select requests the contentRating column (so the run-page gate can read it)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      ...pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' }),
+      contentRating: 'g',
+    });
+    await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    const call = mockDbRead.appBlock.findFirst.mock.calls.at(-1)?.[0] as {
+      select?: Record<string, unknown>;
+    };
+    expect(call?.select?.contentRating).toBe(true);
+  });
+
+  it('surfaces the contentRating column value (mature)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      ...pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' }),
+      contentRating: 'x',
+    });
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.contentRating).toBe('x');
+  });
+
+  it('null-safe: a missing/non-string column → null (treated as SFW by the gate)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      ...pageRow({ manifest: PAGE_MANIFEST(), trustTier: 'verified' }),
+      contentRating: undefined,
+    });
+    const res = await BlockRegistry.resolvePageBlockBySlug('hello-page', { db: 'read' });
+    expect(res?.contentRating).toBeNull();
+  });
+});

--- a/src/server/services/__tests__/block-registry.service.test.ts
+++ b/src/server/services/__tests__/block-registry.service.test.ts
@@ -443,6 +443,10 @@ describe('BlockRegistry.listForModel content-rating filter (audit I15)', () => {
       modelId: 1,
       slotId: 'model.sidebar_top',
       modelNsfwLevel: 8, // 'x'
+      // NSFW-APP-RED-ONLY: this test exercises the model-NSFW-ladder gate, not the
+      // host gate, so run as if on a red-capable host (mature apps allowed). The
+      // host gate has its own dedicated tests in listForModel.behavior.test.ts.
+      redCapable: true,
     });
     expect(result.map((r) => r.blockId).sort()).toEqual(['blk_g', 'blk_x']);
   });

--- a/src/server/services/__tests__/listForModel.behavior.test.ts
+++ b/src/server/services/__tests__/listForModel.behavior.test.ts
@@ -115,6 +115,7 @@ async function listForModel(args: {
   modelType?: string;
   modelNsfwLevel?: number;
   viewerUserId?: number | null;
+  redCapable?: boolean;
 }) {
   const { BlockRegistry } = await import('../block-registry.service');
   return BlockRegistry.listForModel({
@@ -123,6 +124,11 @@ async function listForModel(args: {
     modelType: args.modelType,
     modelNsfwLevel: args.modelNsfwLevel ?? 8, // 'x' ceiling unless a test lowers it
     viewerUserId: args.viewerUserId,
+    // NSFW-APP-RED-ONLY: the precedence/content-rating tests below exercise the
+    // model-NSFW-ladder gate, NOT the host gate, so they run as if on a
+    // red-capable host (mature apps allowed). Default true here; the dedicated
+    // host-gate describe block flips it to false to test the .com posture.
+    redCapable: args.redCapable ?? true,
   });
 }
 
@@ -478,5 +484,67 @@ describe('listForModel suppressor-gap bugs (assert desired behavior)', () => {
 
     const rows = await listForModel({ modelNsfwLevel: 1 });
     expect(ids(rows)).toEqual(['bus_pub_sub_blanket']);
+  });
+});
+
+// =============================================================================
+// NSFW-APP-RED-ONLY — the HOST maturity gate (independent of the model-NSFW
+// ladder). A mature (r/x) app renders in a model slot ONLY on a red-capable
+// host. SFW apps render anywhere. Fail-closed: !redCapable hides mature apps,
+// even on an x-rated model (the existing nsfw ladder permits them; the host gate
+// does not).
+// =============================================================================
+describe('listForModel — NSFW-app-red-only host gate', () => {
+  it('mature (x) app is HIDDEN on a non-red host even when the model nsfw allows it', async () => {
+    await seedModel(db, { id: MODEL_ID, ownerUserId: OWNER });
+    await seedAppBlock(db, { id: 'ab_x', blockId: 'blk_x', manifest: manifestX });
+    await seedPlatformDefault(db, { appBlockId: 'ab_x', slotId: SLOT });
+    // model nsfw 8 = 'x' ceiling → the ladder permits it; the host gate must not.
+    const rows = await listForModel({ modelNsfwLevel: 8, redCapable: false });
+    expect(ids(rows)).toEqual([]);
+  });
+
+  it('mature (x) app is SHOWN on a red-capable host', async () => {
+    await seedModel(db, { id: MODEL_ID, ownerUserId: OWNER });
+    await seedAppBlock(db, { id: 'ab_x', blockId: 'blk_x', manifest: manifestX });
+    await seedPlatformDefault(db, { appBlockId: 'ab_x', slotId: SLOT });
+    const rows = await listForModel({ modelNsfwLevel: 8, redCapable: true });
+    expect(ids(rows)).toEqual(['pdb_ab_x']);
+  });
+
+  it('SFW (g) app renders on a non-red host (host gate only touches mature)', async () => {
+    await seedModel(db, { id: MODEL_ID, ownerUserId: OWNER });
+    await seedAppBlock(db, { id: 'ab_g', blockId: 'blk_g', manifest: manifestG });
+    await seedPlatformDefault(db, { appBlockId: 'ab_g', slotId: SLOT });
+    const rows = await listForModel({ modelNsfwLevel: 8, redCapable: false });
+    expect(ids(rows)).toEqual(['pdb_ab_g']);
+  });
+
+  it('SFW (g) app renders on a red-capable host too', async () => {
+    await seedModel(db, { id: MODEL_ID, ownerUserId: OWNER });
+    await seedAppBlock(db, { id: 'ab_g', blockId: 'blk_g', manifest: manifestG });
+    await seedPlatformDefault(db, { appBlockId: 'ab_g', slotId: SLOT });
+    const rows = await listForModel({ modelNsfwLevel: 8, redCapable: true });
+    expect(ids(rows)).toEqual(['pdb_ab_g']);
+  });
+
+  it('mixed slot: only the SFW app survives on a non-red host', async () => {
+    await seedModel(db, { id: MODEL_ID, ownerUserId: OWNER });
+    await seedAppBlock(db, { id: 'ab_g', blockId: 'blk_g', manifest: manifestG });
+    await seedAppBlock(db, { id: 'ab_x', blockId: 'blk_x', manifest: manifestX });
+    await seedPlatformDefault(db, { appBlockId: 'ab_g', slotId: SLOT, priority: 10 });
+    await seedPlatformDefault(db, { appBlockId: 'ab_x', slotId: SLOT, priority: 5 });
+    const rows = await listForModel({ modelNsfwLevel: 8, redCapable: false });
+    expect(blockIds(rows)).toEqual(['blk_g']);
+  });
+
+  it('mixed slot: BOTH apps survive on a red-capable host', async () => {
+    await seedModel(db, { id: MODEL_ID, ownerUserId: OWNER });
+    await seedAppBlock(db, { id: 'ab_g', blockId: 'blk_g', manifest: manifestG });
+    await seedAppBlock(db, { id: 'ab_x', blockId: 'blk_x', manifest: manifestX });
+    await seedPlatformDefault(db, { appBlockId: 'ab_g', slotId: SLOT, priority: 10 });
+    await seedPlatformDefault(db, { appBlockId: 'ab_x', slotId: SLOT, priority: 5 });
+    const rows = await listForModel({ modelNsfwLevel: 8, redCapable: true });
+    expect(blockIds(rows)).toEqual(['blk_g', 'blk_x']);
   });
 });

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -31,6 +31,7 @@ import type {
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 import { toPublicBlockManifest, toPublicScreenshots } from '~/server/schema/blocks/subscription.schema';
 import { isLaunchSlot, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+import { isMatureContentRating } from '~/server/utils/server-domain';
 import { CacheTTL } from '~/server/common/constants';
 import { queryCache } from '~/server/utils/cache-helpers';
 import { BAYES_MIN_REVIEWS } from '~/server/services/appBlockReview.service';
@@ -289,6 +290,16 @@ interface ListForModelOpts {
    * otherwise leak across users in the shared (modelId, slotId) cache key.
    */
   viewerUserId?: number | null;
+  /**
+   * NSFW-APP-RED-ONLY: true when the request is on a red-capable host
+   * (`isHostForColor(host, 'red')`, computed in the router). When false (the
+   * default — fail-closed), mature-rated (r/x) apps are dropped from the result,
+   * EVEN on a cache hit (the shared (modelId, slotId) cache is host-agnostic, so
+   * the filter is applied after the cache read to avoid cross-host leakage).
+   * This stacks on top of the existing model-NSFW-level ceiling (maxRating):
+   * a mature app must clear BOTH the model's nsfw ladder AND the host gate.
+   */
+  redCapable?: boolean;
 }
 
 // Ordered ratings for ladder comparisons. Each rating implies "and below."
@@ -410,6 +421,10 @@ export interface PageBlockSsr {
    *  granted set (declared − missingScopes from the mint) for BLOCK_INIT, so the
    *  block sees the real scopes it has rather than a hardcoded empty array. */
   scopes: string[];
+  /** NSFW-APP-RED-ONLY: the authoritative content rating (app_blocks.content_rating
+   *  column, set on approve). The SSR run-page gate 404s a mature (r/x) page app
+   *  when the request host is not red-capable. NULL for pre-feature rows → SFW. */
+  contentRating: string | null;
 }
 
 interface UninstallOpts {
@@ -560,6 +575,28 @@ function launchOnlySqlFilter(launchOnly: boolean): Prisma.Sql {
   return Prisma.sql`COALESCE(ab.manifest->'page'->>'path', '') <> ''`;
 }
 
+/**
+ * NSFW-APP-RED-ONLY — the SQL embodiment of the host maturity gate, applied in
+ * the public marketplace LISTING queries (listAvailable / getFeaturedBlocks /
+ * getAppDetail). A mature-rated app (`content_rating` ∈ {r, x}, the authoritative
+ * approve-time column) is EXCLUDED from listings unless the request is on a
+ * red-capable host (`isHostForColor(host, 'red')`, computed in the router and
+ * passed as `redCapable`).
+ *
+ *   - redCapable host (civitai.red) → `TRUE` (no maturity filter; mature apps
+ *     are visible).
+ *   - any other host (civitai.com, …) → keep ONLY rows whose `content_rating`
+ *     is NOT mature. NULL / unknown rating is treated as SFW (kept) — the column
+ *     is non-null on approve, so this only defends a pre-feature row, and the
+ *     direction is fail-closed for MATURE rows (the thing we must hide).
+ *
+ * This is independent of (and stacks with) the launch-only and approved filters.
+ */
+function matureHostSqlFilter(redCapable: boolean): Prisma.Sql {
+  if (redCapable) return Prisma.sql`TRUE`;
+  return Prisma.sql`COALESCE(LOWER(ab.content_rating), '') NOT IN ('r', 'x')`;
+}
+
 function resolveRenderMode(
   manifestRenderMode: string | undefined,
   blockRenderMode: string,
@@ -595,8 +632,15 @@ export class BlockRegistry {
   static async listForModel(opts: ListForModelOpts): Promise<BlockInstallRecord[]> {
     const { modelId, slotId, modelType, modelNsfwLevel } = opts;
     const viewerUserId = opts.viewerUserId ?? null;
+    const redCapable = opts.redCapable === true;
     const maxRating = maxRatingForNsfwLevel(modelNsfwLevel);
     const maxRatingIdx = CONTENT_RATING_INDEX[maxRating];
+    // NSFW-APP-RED-ONLY: drop a record whose app is mature-rated (r/x) when the
+    // request is not on a red-capable host. The record carries `manifest.
+    // contentRating` (projected below), so this works identically on a cache hit
+    // and on a fresh DB read. Fail-closed: !redCapable hides mature apps.
+    const passesHostMaturity = (r: BlockInstallRecord): boolean =>
+      redCapable || !isMatureContentRating(r.manifest?.contentRating ?? null);
     // v1: disable the shared (modelId, slotId) cache layer whenever a
     // viewer is attached, since viewer_personal subscriptions make the
     // result per-viewer. The 60s cache for anon viewers and authed
@@ -614,7 +658,11 @@ export class BlockRegistry {
           // M-7: sentinel from getKillList() means sysRedis is unreachable;
           // suppress everything on this branch (cached path).
           if (kill.has('__KILL_LIST_UNREACHABLE__')) return [];
-          return kill.size === 0 ? cached : cached.filter((r) => !kill.has(r.blockId));
+          // Apply the host-maturity gate on the cache hit too — the cache key is
+          // host-agnostic, so a .red-populated entry must not leak mature apps to
+          // a .com reader.
+          const live = kill.size === 0 ? cached : cached.filter((r) => !kill.has(r.blockId));
+          return live.filter(passesHostMaturity);
         }
       } catch {
         // fail open — fall through to DB
@@ -1093,13 +1141,19 @@ export class BlockRegistry {
 
     if (cacheEnabled) {
       try {
+        // Cache the HOST-AGNOSTIC set (all ratings) under the host-agnostic key,
+        // so a .red and a .com read share one entry. The per-host maturity gate
+        // is applied on read (here + on the cache-hit branch above), never baked
+        // into the cached value — otherwise a .com-populated entry would hide
+        // mature apps from a subsequent .red reader.
         await redis.packed.set(key, hydrated, { EX: CACHE_TTL_SECONDS });
       } catch {
         // fail open
       }
     }
 
-    return hydrated;
+    // NSFW-APP-RED-ONLY: apply the host maturity gate to the returned set.
+    return hydrated.filter(passesHostMaturity);
   }
 
   /**
@@ -1708,6 +1762,9 @@ export class BlockRegistry {
         // model render path, which reads the `trust_tier` column (see
         // resolveRenderMode + the `r.trust_tier` raw select used by listForModel).
         trustTier: true,
+        // NSFW-APP-RED-ONLY: authoritative content rating (set on approve). The
+        // SSR run-page gate uses it to 404 a mature page app off a red host.
+        contentRating: true,
       },
     });
     if (!ab) return null;
@@ -1747,6 +1804,9 @@ export class BlockRegistry {
       name,
       pageTitle: typeof page.title === 'string' ? page.title : name,
       scopes: declaredScopes,
+      // NSFW-APP-RED-ONLY: NULL-safe (column is non-null on approve, but defend
+      // against a pre-feature / partial row → treated as SFW by the gate).
+      contentRating: typeof ab.contentRating === 'string' ? ab.contentRating : null,
     };
   }
 
@@ -2607,7 +2667,14 @@ export class BlockRegistry {
     // passes `!ctx.user?.isModerator`), the marketplace returns ONLY
     // launch-eligible (page) apps. Defaults false (moderator / internal callers
     // see everything — grandfather). See launchOnlySqlFilter / isLaunchSlot.
-    launchOnly = false
+    launchOnly = false,
+    // NSFW-APP-RED-ONLY: true when the request is on a red-capable host
+    // (`isHostForColor(host, 'red')`, computed in the router). When false,
+    // mature-rated apps (r/x) are excluded. Defaults false (fail-closed: a
+    // caller that forgets to thread the host hides mature apps). Independent of
+    // launchOnly — a moderator on civitai.com still does NOT see mature apps in
+    // the listing, because maturity is a HOST property, not a privilege.
+    redCapable = false
   ): Promise<{ items: AvailableBlock[]; nextCursor?: string }> {
     const { slotId, query, category, sort, cursor, limit } = input;
     type Row = {
@@ -2703,6 +2770,8 @@ export class BlockRegistry {
       WHERE ab.status = 'approved'
         -- PAGE-ONLY LAUNCH GATE: non-mod callers see launch (page) apps only.
         AND ${launchOnlySqlFilter(launchOnly)}
+        -- NSFW-APP-RED-ONLY: hide mature (r/x) apps on non-red hosts.
+        AND ${matureHostSqlFilter(redCapable)}
         AND (
           ${slotFilter}::text IS NULL
           OR ab.manifest @> ${slotFilter}::jsonb
@@ -2795,7 +2864,12 @@ export class BlockRegistry {
     // app resolves to null — the router maps that to the SAME NOT_FOUND a
     // missing/unapproved app produces, so a non-mod can't enumerate or read a
     // model-slot app's detail. Defaults false (mods see everything).
-    launchOnly = false
+    launchOnly = false,
+    // NSFW-APP-RED-ONLY: true when the request is on a red-capable host. When
+    // false, a mature (r/x) app resolves to null → the router surfaces the SAME
+    // NOT_FOUND as a missing app, so a mature app's DETAIL can't be read off
+    // .red (mirrors the run-page SSR 404). Defaults false (fail-closed).
+    redCapable = false
   ): Promise<PublicAppDetail | null> {
     type Row = {
       id: string;
@@ -2849,6 +2923,10 @@ export class BlockRegistry {
     // router surfaces NOT_FOUND (no detail leak). isAppLaunchEligible reuses the
     // same "declares a page" predicate as the listing filter + the page mint.
     if (launchOnly && !isAppLaunchEligible(row.manifest)) return null;
+    // NSFW-APP-RED-ONLY (non-red host): a mature (r/x) app is indistinguishable
+    // from a missing one off .red — return null → NOT_FOUND. Uses the
+    // authoritative content_rating column (set on approve), not the manifest.
+    if (!redCapable && isMatureContentRating(row.content_rating)) return null;
     return {
       id: row.id,
       blockId: row.block_id,
@@ -2908,7 +2986,10 @@ export class BlockRegistry {
     limit: number,
     // PAGE-ONLY LAUNCH GATE: non-mod callers get launch (page) apps only;
     // mods see every featured app. Defaults false. See launchOnlySqlFilter.
-    launchOnly = false
+    launchOnly = false,
+    // NSFW-APP-RED-ONLY: hide mature (r/x) apps from the featured rail unless on
+    // a red-capable host. Defaults false (fail-closed). See matureHostSqlFilter.
+    redCapable = false
   ): Promise<AvailableBlock[]> {
     type Row = {
       id: string;
@@ -2942,6 +3023,8 @@ export class BlockRegistry {
       WHERE ab.status = 'approved'
         -- PAGE-ONLY LAUNCH GATE: non-mod callers see launch (page) apps only.
         AND ${launchOnlySqlFilter(launchOnly)}
+        -- NSFW-APP-RED-ONLY: hide mature (r/x) apps on non-red hosts.
+        AND ${matureHostSqlFilter(redCapable)}
         AND ab.featured = true
       ORDER BY ab.featured_order ASC NULLS LAST,
                install_count DESC,

--- a/src/server/utils/__tests__/server-domain.nsfw-rating.test.ts
+++ b/src/server/utils/__tests__/server-domain.nsfw-rating.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * NSFW-APP-RED-ONLY helper tests — `isMatureContentRating` + `ratingAllowedOnHost`
+ * (src/server/utils/server-domain.ts).
+ *
+ * server-domain.ts builds `serverDomainMap` from the validated server env AT
+ * IMPORT, so we stub `~/env/server` with a realistic multi-color config that
+ * mirrors production: civitai.red is configured as BOTH a blue and a red domain
+ * (the exact shape that makes `getRequestDomainColor('civitai.red')` return
+ * `blue` while `isHostForColor('civitai.red', 'red')` returns true). The host
+ * gate must key off RED capability, not the color walk.
+ */
+vi.mock('~/env/server', () => ({
+  env: {
+    SERVER_DOMAIN_GREEN: 'civitai.green',
+    SERVER_DOMAIN_GREEN_ALIASES: '',
+    // blue's primary is civitai.com, and civitai.red is also a blue alias — this
+    // is what makes the color-walk return blue for .red.
+    SERVER_DOMAIN_BLUE: 'civitai.com',
+    SERVER_DOMAIN_BLUE_ALIASES: 'civitai.red',
+    SERVER_DOMAIN_RED: 'civitai.red',
+    SERVER_DOMAIN_RED_ALIASES: 'www.civitai.red',
+  },
+}));
+
+const RED_HOST = 'civitai.red';
+const RED_ALIAS = 'www.civitai.red';
+const COM_HOST = 'civitai.com';
+const GREEN_HOST = 'civitai.green';
+
+describe('isMatureContentRating', () => {
+  it('returns true for r and x (case-insensitive)', async () => {
+    const { isMatureContentRating } = await import('../server-domain');
+    expect(isMatureContentRating('r')).toBe(true);
+    expect(isMatureContentRating('x')).toBe(true);
+    expect(isMatureContentRating('R')).toBe(true);
+    expect(isMatureContentRating('X')).toBe(true);
+  });
+
+  it('returns false for SFW ratings g/pg/pg13', async () => {
+    const { isMatureContentRating } = await import('../server-domain');
+    expect(isMatureContentRating('g')).toBe(false);
+    expect(isMatureContentRating('pg')).toBe(false);
+    expect(isMatureContentRating('pg13')).toBe(false);
+  });
+
+  it('fail-closed-to-SFW for unknown/missing/null/empty (treated as not mature)', async () => {
+    const { isMatureContentRating } = await import('../server-domain');
+    expect(isMatureContentRating(null)).toBe(false);
+    expect(isMatureContentRating(undefined)).toBe(false);
+    expect(isMatureContentRating('')).toBe(false);
+    expect(isMatureContentRating('mature')).toBe(false);
+    expect(isMatureContentRating('nc17')).toBe(false);
+  });
+});
+
+describe('ratingAllowedOnHost', () => {
+  it('mature (r/x) requires a red-capable host', async () => {
+    const { ratingAllowedOnHost } = await import('../server-domain');
+    // red primary + red alias: allowed
+    expect(ratingAllowedOnHost('r', RED_HOST)).toBe(true);
+    expect(ratingAllowedOnHost('x', RED_HOST)).toBe(true);
+    expect(ratingAllowedOnHost('x', RED_ALIAS)).toBe(true);
+    // non-red hosts (incl. civitai.com which resolves to BLUE via the color
+    // walk): NOT allowed
+    expect(ratingAllowedOnHost('r', COM_HOST)).toBe(false);
+    expect(ratingAllowedOnHost('x', COM_HOST)).toBe(false);
+    expect(ratingAllowedOnHost('x', GREEN_HOST)).toBe(false);
+  });
+
+  it('SFW ratings are allowed on ANY host (incl. red)', async () => {
+    const { ratingAllowedOnHost } = await import('../server-domain');
+    for (const host of [RED_HOST, RED_ALIAS, COM_HOST, GREEN_HOST]) {
+      expect(ratingAllowedOnHost('g', host)).toBe(true);
+      expect(ratingAllowedOnHost('pg', host)).toBe(true);
+      expect(ratingAllowedOnHost('pg13', host)).toBe(true);
+    }
+  });
+
+  it('unknown/missing rating is treated as SFW → allowed anywhere (fail-closed only hides MATURE)', async () => {
+    const { ratingAllowedOnHost } = await import('../server-domain');
+    expect(ratingAllowedOnHost(null, COM_HOST)).toBe(true);
+    expect(ratingAllowedOnHost(undefined, COM_HOST)).toBe(true);
+    expect(ratingAllowedOnHost('', COM_HOST)).toBe(true);
+  });
+
+  it('confirms the trap: civitai.com is blue (color walk) yet still blocks mature', async () => {
+    const { ratingAllowedOnHost, isHostForColor, getRequestDomainColor } = await import(
+      '../server-domain'
+    );
+    // The whole point of the helper: getRequestDomainColor(.red) === 'blue', so
+    // a naive color check would wrongly treat .red as SFW. isHostForColor pins
+    // red capability correctly.
+    expect(getRequestDomainColor({ headers: { host: RED_HOST } })).toBe('blue');
+    expect(isHostForColor(RED_HOST, 'red')).toBe(true);
+    expect(ratingAllowedOnHost('x', RED_HOST)).toBe(true);
+    expect(isHostForColor(COM_HOST, 'red')).toBe(false);
+    expect(ratingAllowedOnHost('x', COM_HOST)).toBe(false);
+  });
+});

--- a/src/server/utils/server-domain.ts
+++ b/src/server/utils/server-domain.ts
@@ -68,6 +68,48 @@ export function isHostForColor(host: string, color: ColorDomain): boolean {
   return cfg.primary === normalized || cfg.aliases.includes(normalized);
 }
 
+/**
+ * App Blocks NSFW gating — the SINGLE SOURCE OF TRUTH for "this host may serve
+ * mature-rated apps". A mature app (`contentRating` ∈ {r, x}) is usable ONLY on
+ * a RED-capable host.
+ *
+ * Why `isHostForColor(host, 'red')` and NOT `getRequestDomainColor(host)`:
+ * `civitai.red` is configured as BOTH a blue and a red domain, and
+ * `getRequestDomainColor` is a first-match walk over [green, blue, red], so it
+ * returns `blue` for `civitai.red` — which would (wrongly) treat .red as SFW.
+ * `isHostForColor(host, 'red')` is the membership test that correctly returns
+ * TRUE for `civitai.red` (its primary/aliases) regardless of the color-walk
+ * ordering. This is deliberately scoped to the App-Blocks NSFW gate; it does NOT
+ * change the global color resolution.
+ */
+
+/** Mature content ratings (App Blocks). Everything else is SFW. */
+const MATURE_CONTENT_RATINGS = new Set(['r', 'x']);
+
+/**
+ * True iff the rating is mature (r/x). FAIL-CLOSED on ambiguity in the OPPOSITE
+ * direction is the caller's job: an unknown/missing/empty rating returns
+ * `false` (SFW) here, which is safe because `contentRating` is a REQUIRED,
+ * validated manifest field (`block-manifest-validator.service.ts`) stored on
+ * approve — a missing value means "not mature", and the gates that hide/refuse
+ * mature content only act when this is `true`.
+ */
+export function isMatureContentRating(rating: string | null | undefined): boolean {
+  if (typeof rating !== 'string') return false;
+  return MATURE_CONTENT_RATINGS.has(rating.toLowerCase());
+}
+
+/**
+ * True iff an app with `rating` is allowed to be listed / detailed / run on
+ * `host`. SFW ratings (g/pg/pg13 and any unknown→SFW) are allowed on ANY host;
+ * a mature rating (r/x) requires a RED-capable host. Fail-closed: a mature
+ * rating on a non-red host returns `false`.
+ */
+export function ratingAllowedOnHost(rating: string | null | undefined, host: string): boolean {
+  if (!isMatureContentRating(rating)) return true;
+  return isHostForColor(host, 'red');
+}
+
 /** True if `host` is the canonical primary for its resolved color. */
 export function isPrimaryHost(host: string): boolean {
   const normalized = host.toLowerCase();

--- a/src/tests/api/v1/block-tokens/index.test.ts
+++ b/src/tests/api/v1/block-tokens/index.test.ts
@@ -69,11 +69,18 @@ vi.mock('~/server/redis/client', () => ({
   REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
 }));
 vi.mock('~/server/utils/server-domain', () => ({
-  getAllServerHosts: () => ['civitai.com'],
+  getAllServerHosts: () => ['civitai.com', 'civitai.red'],
   // #2670 (color-domain maturity) added a getRequestDomainColor(req) call to the
   // mint. The test reqs carry no `host` header, so the real impl returns
   // undefined → SFW ceiling; mirror that here so the module mock stays complete.
   getRequestDomainColor: () => undefined,
+  // NSFW-APP-RED-ONLY: the mint now reads the request host's RED capability to
+  // pick the maturity ceiling and to refuse a mature app off .red. Mirror the
+  // real isHostForColor(host, 'red') semantics for the test hosts.
+  isHostForColor: (host: string, color: string) =>
+    color === 'red' && (host === 'civitai.red' || host === 'www.civitai.red'),
+  isMatureContentRating: (rating: unknown) =>
+    typeof rating === 'string' && (rating.toLowerCase() === 'r' || rating.toLowerCase() === 'x'),
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: vi.fn(async () => true),
@@ -667,6 +674,103 @@ describe('POST /api/v1/block-tokens', () => {
     };
     expect(new Set(signArgs.scopes)).toEqual(new Set(['models:read:self', 'buzz:read:self']));
     expect(signArgs.userId).toBe(42);
+  });
+
+  // ===========================================================================
+  // NSFW-APP-RED-ONLY — host-driven maturity ceiling + mature-app refusal.
+  // ===========================================================================
+  describe('NSFW-app-red-only maturity', () => {
+    it('red-capable host (civitai.red) mints the FULL mature ceiling', async () => {
+      mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
+      const { allBrowsingLevelsFlag } = await import('~/shared/constants/browsingLevel.constants');
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(
+        makeReq({ origin: 'https://civitai.red', headers: { host: 'civitai.red' }, body: validBody() }),
+        res
+      );
+      expect(res._status).toBe(200);
+      expect(mockTokenService.sign).toHaveBeenCalled();
+      const signArgs = mockTokenService.sign.mock.calls.at(-1)?.[0] as { maxBrowsingLevel: number };
+      expect(signArgs.maxBrowsingLevel).toBe(allBrowsingLevelsFlag);
+      expect((res._body as { maxBrowsingLevel: number }).maxBrowsingLevel).toBe(allBrowsingLevelsFlag);
+    });
+
+    it('civitai.com (non-red host) keeps the SFW ceiling (not the mature flag)', async () => {
+      mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
+      const { allBrowsingLevelsFlag, sfwBrowsingLevelsFlag } = await import(
+        '~/shared/constants/browsingLevel.constants'
+      );
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(
+        makeReq({ origin: 'https://civitai.com', headers: { host: 'civitai.com' }, body: validBody() }),
+        res
+      );
+      expect(res._status).toBe(200);
+      const signArgs = mockTokenService.sign.mock.calls.at(-1)?.[0] as { maxBrowsingLevel: number };
+      expect(signArgs.maxBrowsingLevel).not.toBe(allBrowsingLevelsFlag);
+      expect(signArgs.maxBrowsingLevel).toBe(sfwBrowsingLevelsFlag);
+    });
+
+    it('a MATURE-rated app is REFUSED (403) on civitai.com (fail-closed cross-check)', async () => {
+      mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+        ...RESOLVED_INSTALL,
+        appBlock: {
+          ...RESOLVED_INSTALL.appBlock,
+          manifest: { scopes: ['models:read:self'], contentRating: 'x' },
+        },
+      });
+      mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(
+        makeReq({ origin: 'https://civitai.com', headers: { host: 'civitai.com' }, body: validBody() }),
+        res
+      );
+      expect(res._status).toBe(403);
+      expect(mockTokenService.sign).not.toHaveBeenCalled();
+    });
+
+    it('a MATURE-rated app MINTS on civitai.red (with the mature ceiling)', async () => {
+      mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+        ...RESOLVED_INSTALL,
+        appBlock: {
+          ...RESOLVED_INSTALL.appBlock,
+          manifest: { scopes: ['models:read:self'], contentRating: 'x' },
+        },
+      });
+      mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
+      const { allBrowsingLevelsFlag } = await import('~/shared/constants/browsingLevel.constants');
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(
+        makeReq({ origin: 'https://civitai.red', headers: { host: 'civitai.red' }, body: validBody() }),
+        res
+      );
+      expect(res._status).toBe(200);
+      const signArgs = mockTokenService.sign.mock.calls.at(-1)?.[0] as { maxBrowsingLevel: number };
+      expect(signArgs.maxBrowsingLevel).toBe(allBrowsingLevelsFlag);
+    });
+
+    it('an SFW (g) app mints fine on civitai.com (host gate only touches mature)', async () => {
+      mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+        ...RESOLVED_INSTALL,
+        appBlock: {
+          ...RESOLVED_INSTALL.appBlock,
+          manifest: { scopes: ['models:read:self'], contentRating: 'g' },
+        },
+      });
+      mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(
+        makeReq({ origin: 'https://civitai.com', headers: { host: 'civitai.com' }, body: validBody() }),
+        res
+      );
+      expect(res._status).toBe(200);
+      expect(mockTokenService.sign).toHaveBeenCalled();
+    });
   });
 
   // Last in file: this test resets modules to swap out the env mock; vitest

--- a/src/tests/pages/apps/run/run-page-maturity.test.ts
+++ b/src/tests/pages/apps/run/run-page-maturity.test.ts
@@ -7,6 +7,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * apps render on any host; mature apps render on civitai.red. We mock
  * `createServerSideProps` to capture the resolver (so we can invoke it with a
  * controlled `ctx`/`features`), the registry resolve, and the host gate helper.
+ *
+ * NOTE: this test lives under `src/tests/` (NOT co-located under `src/pages/`).
+ * Next treats every file under `pages/` as a route needing a default export, so
+ * a `*.test.ts` there fails `next build`'s route-type validator (tsc/vitest do
+ * not catch it). Page modules are imported via the `~/pages/...` alias, matching
+ * the rest of `src/tests/api/**`.
  */
 
 const { capturedResolver } = vi.hoisted(() => ({
@@ -66,7 +72,7 @@ function makeCtx(host: string, slug = 'cool-app') {
 }
 
 async function loadResolver() {
-  await import('./[[...path]]');
+  await import('~/pages/apps/run/[slug]/[[...path]]');
   if (!capturedResolver.fn) throw new Error('resolver not captured');
   return capturedResolver.fn;
 }


### PR DESCRIPTION
## Problem

App-block manifests carry a **required** `contentRating` (`g`/`pg`/`pg13`/`r`/`x`) that's validated and persisted to `app_blocks.content_rating` on approve — but it was **read by nothing**. No gate consumed it, so a mature-rated (r/x) app would render/list/run identically on civitai.com and civitai.red. This is maturity-critical: mature content must never leak onto civitai.com.

## Decision

- **Mature = `r`, `x`**; SFW = `g`, `pg`, `pg13` (and unknown/missing → SFW, fail-closed since the field is required+validated).
- A **red-capable host** is detected with `isHostForColor(host, 'red')` — NOT `getRequestDomainColor`, which returns `blue` for `civitai.red` (it's configured as both blue and red, and the color walk is green→blue→red). This is the load-bearing subtlety.
- **Block-path-scoped only**: no global color-resolution reorder, no change to `domainBrowsingCeiling` semantics, the red-only `redBrowsingLevel`/`RedTOS` machinery is not activated.

## Shared helpers (`server-domain.ts`)

- `isMatureContentRating(rating)` → true for r/x.
- `ratingAllowedOnHost(rating, host)` → mature requires `isHostForColor(host, 'red')`; SFW allowed anywhere.

## The 4 gates

1. **Block-token mint** (`block-tokens/index.ts`): on a red-capable host the maturity ceiling becomes the full mature flag (`allBrowsingLevelsFlag`); otherwise the existing SFW derivation stands. **Defense-in-depth cross-check:** a mature app minting on a non-red host is **refused (403)** — fail-closed, not down-clamped. The dev-token path is a separate endpoint and stays **forced-SFW (unchanged)**.
2. **Run-page SSR** (`apps/run/[slug]`): a mature page app on a non-red host returns the same fail-closed **404** the flag gate produces. `resolvePageBlockBySlug` now reads the `content_rating` column.
3. **Listing** (`block-registry`: `listAvailable` / `getFeaturedBlocks` / `getAppDetail`): mature apps excluded via SQL / resolve to NOT_FOUND off a red host. Threaded from the request host in `blocks.router` via `isRedCapableRequest`. The `/apps` marketplace + featured rail + `/apps/[appBlockId]` detail page all read through these tRPC queries, so they're covered.
4. **Model-slot reads** (`listForModel`): mature apps dropped on a non-red host — on **both** the DB read and the host-agnostic 60s cache (filter applied on read, so a `.red`-populated cache entry can't leak mature apps to a `.com` reader). Stacks on top of the existing model-NSFW-level ceiling.

## Fail-closed posture

Any ambiguity (missing host, unknown rating, omitted `redCapable` param) → SFW-only / hide-from-.com. Mature content never shows/runs on a non-red host. Maturity is a **host property, not a privilege** — even a moderator on civitai.com does not see mature apps in these viewer-facing surfaces.

## Surfaces deliberately left alone

- `/api/v1/blocks/models` and `/api/v1/blocks/images` — these list **models / images** (content the block browses, already browsing-level clamped by the token's `maxBrowsingLevel`), **not app blocks**.
- `/apps/review` and other mod-only surfaces (mods review everything).
- `getSlotReservation` forwards `opts` to `listForModel`, so it inherits the gate for free.

## Test coverage

- **Helpers**: rating classification (r/x mature; g/pg/pg13 + unknown SFW) + host gate + the civitai.com-is-blue-yet-blocks-mature trap.
- **Mint**: red host → mature ceiling; .com → SFW ceiling; mature-app-on-.com → 403; mature-app-on-.red → mints with mature ceiling; SFW app on .com → mints; dev-token unchanged (separate endpoint).
- **Run-page gate**: mature+.com → 404; mature+.red → renders; SFW → renders anywhere; missing-host → 404; missing app → 404 (no regression).
- **Listing filter**: SQL mature-exclusion threaded iff !redCapable for listAvailable/getFeaturedBlocks; getAppDetail null off .red for mature, served on .red, SFW unaffected.
- **listForModel** (real PGlite): mature hidden on .com / shown on .red, SFW everywhere, mixed slot.

478 block/apps unit tests pass. `tsc` is clean on all changed files (the repo's pre-existing 61 errors are unrelated submodule/prisma-staleness artifacts).

## Reviewer double-checks (maturity path)

- Confirm `civitai.red` (and any red alias) is in `SERVER_DOMAIN_RED`/`SERVER_DOMAIN_RED_ALIASES` so `isHostForColor(host,'red')` is true in prod.
- The mint refuses a mature app on a non-red host (403) — verify the host header is the trusted source (same one the CORS allowlist uses); behind Cloudflare the `host` header is the public hostname.
- The listForModel 60s cache is shared/host-agnostic by key — the per-host filter is on read; confirm no other reader of that cache key bypasses the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)