### PR TITLE
fix(media): pass width to EdgeMedia on cosmetic badge/background/username renders

### DIFF
--- a/src/components/Shop/CosmeticSample.tsx
+++ b/src/components/Shop/CosmeticSample.tsx
@@ -37,7 +37,7 @@ export const CosmeticSample = ({
 
       return (
         <div style={{ width: values.badgeSize }}>
-          <EdgeMedia src={decorationData.url} alt={cosmetic.name} />
+          <EdgeMedia src={decorationData.url} alt={cosmetic.name} width={values.badgeSize} />
         </div>
       );
     case CosmeticType.ContentDecoration:
@@ -80,6 +80,7 @@ export const CosmeticSample = ({
             alt={cosmetic.name}
             type={backgroundData.type}
             anim={true}
+            width={450}
             style={{
               objectFit: 'cover',
               // objectPosition: 'right bottom',

--- a/src/components/User/Username.tsx
+++ b/src/components/User/Username.tsx
@@ -88,7 +88,7 @@ export const BadgeDisplay = ({
             filter,
           }}
         >
-          <EdgeMedia src={badge.data.url} alt={badge.name} />
+          <EdgeMedia src={badge.data.url} alt={badge.name} width={badgeSize} />
         </div>
       ) : (
         <div style={{ display: 'flex', zIndex, filter }}>


### PR DESCRIPTION
## Summary

- `CosmeticSample.tsx` Badge/ProfileDecoration: adds `width={values.badgeSize}` (already a typed `number` from `cosmeticSampleSizeMap`)
- `CosmeticSample.tsx` ProfileBackground: adds `width={450}` (matches the `IMAGE_CARD_WIDTH = 450` pattern used across card components; `values.badgeSize` here is the container _height_, not a meaningful fetch width)
- `Username.tsx` animated badge branch: adds `width={badgeSize}` to match the non-animated branch directly below it

Without an explicit `width`, `getEdgeUrl()` hits `if (!width && !height && original === undefined) original = true` and serves the full `/original` file (3–8 MB). These three callsites were the remaining unguarded ones in the cosmetic/badge render paths. Layout, `style`, `contain`, `wrapperProps`, and all other props are unchanged.

## Test plan

- [ ] Preview: confirm badge thumbnails in Shop and username hovers load a sized Cloudflare variant (URL contains `/width=N/`) instead of `/original`
- [ ] Visual: badge/decoration sizes unchanged in the Shop preview and user hover tooltip
- [ ] ProfileBackground strip in Shop renders and fills its container (objectFit:cover path still intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)