### PR TITLE
feat(apps): show app listing image (first screenshot) on marketplace cards

### DIFF
--- a/src/components/Apps/AppBlockCard.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.browser.test.tsx
@@ -91,6 +91,7 @@ function makeBlock(
     scopesSummary: [],
     avgRating: null,
     reviewCount: 0,
+    coverUrl: null,
     ...overrides,
   };
 }
@@ -647,5 +648,71 @@ describe('AppBlockCard — round-2 card cleanup (slot badge + author dropped, Vi
     const viewDetails = page.getByRole('button', { name: /view details/i });
     await expect.element(viewDetails).toBeInTheDocument();
     expect(viewDetails.element().getAttribute('data-variant')).toBe('subtle');
+  });
+});
+
+describe('AppBlockCard — cover image (first screenshot) + placeholder fallback', () => {
+  // The cover surfaces the app's FIRST publisher screenshot (block.coverUrl,
+  // already projected server-side via toPublicScreenshots). When the app shipped
+  // no screenshot (coverUrl null) the card renders a tasteful category-glyph
+  // PLACEHOLDER — never a broken/empty <img>.
+
+  test('renders an <img> cover (with the screenshot src) when coverUrl is present', async () => {
+    const url = '/api/blocks/screenshot/app-1/0.png';
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ name: 'Covered App' }, { coverUrl: url })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // The cover renders a real <img> pointing at the gated screenshot route.
+    const cover = page.getByRole('img', { name: /Covered App listing image/i });
+    await expect.element(cover).toBeInTheDocument();
+    expect(cover.element().getAttribute('src')).toBe(url);
+    // The rest of the card still renders (cover doesn't break the layout).
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+  });
+
+  test('renders a PLACEHOLDER (no img) when coverUrl is null — no broken image', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ name: 'Bare App' }, { coverUrl: null, category: null })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // No cover <img> renders for a no-screenshot app…
+    expect(page.getByRole('img', { name: /Bare App listing image/i }).query()).toBeNull();
+    // …and the placeholder box (aria-hidden, carries an svg glyph) is present, so
+    // the cover area is never empty. The card body still renders.
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    const card = page.getByRole('button', { name: /view details/i }).element().closest('.mantine-Card-root');
+    expect(card).not.toBeNull();
+    const placeholder = card!.querySelector('[aria-hidden]');
+    expect(placeholder).not.toBeNull();
+    // The placeholder carries a decorative glyph (the generic apps icon).
+    expect(placeholder!.querySelector('svg')).not.toBeNull();
+  });
+
+  test('placeholder uses the category glyph when a category is set (still no img)', async () => {
+    renderWithProviders(
+      <AppBlockCard
+        block={makeBlock({ name: 'Util App' }, { coverUrl: null, category: 'utility' })}
+        alreadySubscribed={false}
+        onOpen={onOpen}
+      />
+    );
+
+    // Wait for the card to render before synchronously querying the DOM.
+    await expect.element(page.getByRole('button', { name: /view details/i })).toBeInTheDocument();
+    // Still no real cover img (no screenshot) — placeholder path.
+    expect(page.getByRole('img', { name: /Util App listing image/i }).query()).toBeNull();
+    const card = page.getByRole('button', { name: /view details/i }).element().closest('.mantine-Card-root');
+    const placeholder = card!.querySelector('[aria-hidden]');
+    expect(placeholder).not.toBeNull();
+    expect(placeholder!.querySelector('svg')).not.toBeNull();
   });
 });

--- a/src/components/Apps/AppBlockCard.external.browser.test.tsx
+++ b/src/components/Apps/AppBlockCard.external.browser.test.tsx
@@ -44,6 +44,7 @@ function makeExternalBlock(overrides: Partial<AvailableBlock> = {}): AvailableBl
     externalUrl: 'https://example.com/launch',
     avgRating: null,
     reviewCount: 0,
+    coverUrl: null,
     ...overrides,
   };
 }
@@ -62,6 +63,7 @@ function makeModelBlock(overrides: Partial<AvailableBlock> = {}): AvailableBlock
     externalUrl: null,
     avgRating: null,
     reviewCount: 0,
+    coverUrl: null,
     ...overrides,
   };
 }

--- a/src/components/Apps/AppBlockCard.tsx
+++ b/src/components/Apps/AppBlockCard.tsx
@@ -1,5 +1,6 @@
-import { Anchor, Badge, Button, Card, Group, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Badge, Box, Button, Card, Group, Image, Stack, Text, Title } from '@mantine/core';
 import {
+  IconApps,
   IconExternalLink,
   IconPlugConnected,
   IconSettings,
@@ -83,6 +84,59 @@ function categoryIcon(category: string): Icon {
   return isMarketplaceCategory(category) ? CATEGORY_ICONS[category] : FALLBACK_CATEGORY_ICON;
 }
 
+/**
+ * The card's cover image — the app's FIRST publisher-supplied screenshot
+ * (`block.coverUrl`, projected server-side via `toPublicScreenshots`). Sits in
+ * a fixed-height box at the top of the card so every card is the same height and
+ * the grid/featured-rail/recently-opened layouts stay aligned.
+ *
+ * When the app shipped no screenshot (`coverUrl` null), render a tasteful
+ * PLACEHOLDER instead of a broken/empty `<img>`: a neutral gradient with the
+ * app's category glyph (or a generic apps glyph when no category is set). Never
+ * an empty box — the cover is always SOMETHING.
+ *
+ * `coverUrl` is optional on the prop so existing callers / fixtures that predate
+ * the field don't break — `undefined` is treated as "no cover" (placeholder).
+ */
+function AppCover({
+  coverUrl,
+  category,
+  name,
+}: {
+  coverUrl: string | null | undefined;
+  category: string | null;
+  name: string;
+}) {
+  // Fixed-height cover box. `Card.Section` makes the cover bleed to the card
+  // edges (above the padded body) — the standard Mantine card-cover pattern.
+  if (coverUrl) {
+    return (
+      <Card.Section>
+        <Image src={coverUrl} alt={`${name} listing image`} h={140} fit="cover" />
+      </Card.Section>
+    );
+  }
+  // Placeholder: neutral gradient + the category glyph (generic apps glyph when
+  // no category). Marked aria-hidden — it carries no information the card text
+  // doesn't already convey (title/category chip), so it's decorative.
+  const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
+  return (
+    <Card.Section>
+      <Box
+        aria-hidden
+        h={140}
+        className="flex items-center justify-center"
+        style={{
+          background:
+            'linear-gradient(135deg, var(--mantine-color-dark-5) 0%, var(--mantine-color-dark-7) 100%)',
+        }}
+      >
+        <PlaceholderIcon size={44} className="opacity-40" />
+      </Box>
+    </Card.Section>
+  );
+}
+
 export function AppBlockCard({
   block,
   alreadySubscribed,
@@ -131,7 +185,14 @@ export function AppBlockCard({
   // user. "Open app" / Install remain the RUN/INSTALL affordances on top of it.
   return (
     <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
-      <Stack gap="sm" h="100%">
+      {/* Cover image (first publisher screenshot) above the card body, or a
+          tasteful category-glyph placeholder when the app shipped none. */}
+      <AppCover
+        coverUrl={block.coverUrl}
+        category={block.category}
+        name={manifest.name ?? block.blockId}
+      />
+      <Stack gap="sm" h="100%" pt="sm">
         <Group justify="space-between" align="flex-start" wrap="nowrap">
           <Stack gap={2}>
             {/*

--- a/src/components/Apps/MarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/MarketplaceBody.browser.test.tsx
@@ -40,6 +40,7 @@ function makeBlock(id: string, name: string): AvailableBlock {
     scopesSummary: [],
     avgRating: null,
     reviewCount: 0,
+    coverUrl: null,
   };
 }
 
@@ -61,6 +62,7 @@ function makePageBlock(id: string, name: string): AvailableBlock {
     scopesSummary: [],
     avgRating: null,
     reviewCount: 0,
+    coverUrl: null,
   };
 }
 

--- a/src/components/Apps/RecentlyOpenedApps.browser.test.tsx
+++ b/src/components/Apps/RecentlyOpenedApps.browser.test.tsx
@@ -35,6 +35,7 @@ function makeBlock(id: string, name: string): AvailableBlock {
     scopesSummary: [],
     avgRating: null,
     reviewCount: 0,
+    coverUrl: null,
   };
 }
 

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -173,6 +173,9 @@ export default function AppDetailPage() {
       // Marketplace reviews — carry through from the detail (display-safe).
       avgRating: detail.avgRating,
       reviewCount: detail.reviewCount,
+      // Card cover = the first public screenshot (the detail already carries the
+      // projected gallery). Unused by the settings modal, but kept consistent.
+      coverUrl: detail.screenshots[0]?.url ?? null,
     };
     openAppSettingsModal({ block, existingByScope });
   }

--- a/src/pages/apps/installed.tsx
+++ b/src/pages/apps/installed.tsx
@@ -754,6 +754,9 @@ export default function InstalledAppsPage() {
       // Marketplace reviews — unused on the Manage path (modal-only).
       avgRating: null,
       reviewCount: 0,
+      // Card cover — unused on the Manage path (the modal renders no cover) and
+      // the subscription row carries no screenshot data, so null.
+      coverUrl: null,
     };
     const existingByScope: Partial<Record<typeof sub.scope, SubscriptionRecord>> = {};
     for (const candidate of subs ?? []) {

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -159,6 +159,12 @@ export const PUBLIC_MANIFEST_FIELDS = ['name', 'description', 'targets', 'hasPag
  *                       `scopes`. These are plain scope identifier strings
  *                       describing what the app can do (the whole point of the
  *                       disclosure) — never the raw manifest declaration.
+ *   - `coverUrl`      — the FIRST publisher-supplied screenshot's PUBLIC display
+ *                       URL (`toPublicScreenshots(id, screenshots)[0]?.url`),
+ *                       surfaced as the card's cover image. NULL when the app
+ *                       shipped no `screenshots/` dir. Same opaque, gated app
+ *                       route (`/api/blocks/screenshot/<id>/<index>.<ext>`) the
+ *                       detail page uses — the raw MinIO key is NEVER exposed.
  */
 export type AvailableBlock = {
   id: string;
@@ -180,6 +186,11 @@ export type AvailableBlock = {
   // mod-excluded + self-reviews. Both display-safe (aggregate numbers only).
   avgRating: number | null;
   reviewCount: number;
+  // Card cover image: the FIRST publisher-supplied screenshot's PUBLIC display
+  // URL, or NULL when the app shipped no screenshots. Built via the SAME
+  // `toPublicScreenshots` projection the detail page uses (opaque gated route,
+  // never the raw MinIO key) — display-only.
+  coverUrl: string | null;
 };
 
 /**

--- a/src/server/schema/blocks/subscription.schema.ts
+++ b/src/server/schema/blocks/subscription.schema.ts
@@ -189,8 +189,12 @@ export type AvailableBlock = {
   // Card cover image: the FIRST publisher-supplied screenshot's PUBLIC display
   // URL, or NULL when the app shipped no screenshots. Built via the SAME
   // `toPublicScreenshots` projection the detail page uses (opaque gated route,
-  // never the raw MinIO key) — display-only.
-  coverUrl: string | null;
+  // never the raw MinIO key) — display-only. OPTIONAL: both producers
+  // (listAvailable/getFeaturedBlocks) always set it to `string | null`, but a
+  // nullable display field is left optional so test fixtures built via
+  // `Partial<AvailableBlock>` spread (which widens to `| undefined`) typecheck;
+  // the card treats absent the same as null (renders the placeholder).
+  coverUrl?: string | null;
 };
 
 /**

--- a/src/server/services/__tests__/block-registry.external-url.test.ts
+++ b/src/server/services/__tests__/block-registry.external-url.test.ts
@@ -97,6 +97,7 @@ function listRow(over: Partial<Record<string, unknown>> = {}) {
     approved_scopes: [],
     avg_rating: null,
     review_count: 0n,
+    screenshots: null,
     sort_key: '0',
     ...over,
   };
@@ -176,5 +177,41 @@ describe('BlockRegistry.getFeaturedBlocks — externalUrl projection', () => {
     const { BlockRegistry } = await import('../block-registry.service');
     const items = await BlockRegistry.getFeaturedBlocks(10);
     expect(items[0].externalUrl).toBe('https://example.com/cool');
+  });
+});
+
+describe('BlockRegistry.getFeaturedBlocks — coverUrl projection', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([listRow()]);
+  });
+
+  it('SELECTs the screenshots column', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.getFeaturedBlocks(10);
+    expect(capturedSql()).toMatch(/ab\.screenshots/);
+  });
+
+  it('coverUrl = the FIRST public screenshot URL when screenshots exist', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      listRow({
+        id: 'ab_cover',
+        screenshots: [
+          { key: 'blocks/ab_cover/0.png', index: 0, ext: 'png', contentType: 'image/png' },
+        ],
+      }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const items = await BlockRegistry.getFeaturedBlocks(10);
+    expect(items[0].coverUrl).toBe('/api/blocks/screenshot/ab_cover/0.png');
+    // The raw MinIO key must never appear on the wire.
+    expect(JSON.stringify(items)).not.toContain('blocks/ab_cover/0.png');
+  });
+
+  it('coverUrl is null when the app shipped no screenshots', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([listRow({ screenshots: null })]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const items = await BlockRegistry.getFeaturedBlocks(10);
+    expect(items[0].coverUrl).toBeNull();
   });
 });

--- a/src/server/services/__tests__/block-registry.list-available.test.ts
+++ b/src/server/services/__tests__/block-registry.list-available.test.ts
@@ -102,6 +102,9 @@ function rawRow(over: Partial<Record<string, unknown>> = {}) {
     approved_scopes: ['ai:write:budgeted', 'models:read:self', 'buzz:read:self', 'social:tip:self'],
     avg_rating: 4.2,
     review_count: 8n,
+    // Publisher screenshots jsonb (the cover comes from the first one). Default
+    // null = an app that shipped no screenshots → coverUrl null.
+    screenshots: null,
     sort_key: '00000000000000000005',
     manifest: {
       name: 'Cool Block',
@@ -187,6 +190,8 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
         // F-E marketplace reviews — display-safe aggregates.
         'avgRating',
         'reviewCount',
+        // Card cover image — first public screenshot URL (or null).
+        'coverUrl',
       ].sort()
     );
     // status is a DB-internal field; it must never appear on the wire shape.
@@ -424,6 +429,7 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
         'avgRating',
         'blockId',
         'category',
+        'coverUrl',
         'externalUrl',
         'id',
         'installCount',
@@ -434,5 +440,42 @@ describe('BlockRegistry.listAvailable — anon-exposure protections (F-E E1)', (
     );
     expect(items[0]).not.toHaveProperty('status');
     expect(items[0]).not.toHaveProperty('approved_scopes');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Card cover image — the FIRST public screenshot URL (or null), projected via
+  // the SAME toPublicScreenshots helper the detail page uses (opaque gated
+  // route, never the raw MinIO key).
+  // ---------------------------------------------------------------------------
+
+  it('coverUrl = the FIRST public screenshot URL when the app shipped screenshots', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      rawRow({
+        id: 'ab_cover',
+        screenshots: [
+          // Out-of-order on purpose — toPublicScreenshots sorts by index, so the
+          // cover is index 0 regardless of array order.
+          { key: 'blocks/ab_cover/1.webp', index: 1, ext: 'webp', contentType: 'image/webp' },
+          { key: 'blocks/ab_cover/0.png', index: 0, ext: 'png', contentType: 'image/png' },
+        ],
+      }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const { items } = await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' });
+    // Opaque gated app route built server-side from id+index+ext — NOT the key.
+    expect(items[0].coverUrl).toBe('/api/blocks/screenshot/ab_cover/0.png');
+    // The raw MinIO key must never appear on the wire.
+    expect(JSON.stringify(items)).not.toContain('blocks/ab_cover/0.png');
+  });
+
+  it('coverUrl is null when the app shipped no screenshots (empty / NULL column)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      rawRow({ id: 'ab_empty', screenshots: [] }),
+      rawRow({ id: 'ab_null', screenshots: null }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const { items } = await BlockRegistry.listAvailable({ limit: 20, sort: 'popular' });
+    expect(items[0].coverUrl).toBeNull();
+    expect(items[1].coverUrl).toBeNull();
   });
 });

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -2622,6 +2622,9 @@ export class BlockRegistry {
       approved_scopes: string[] | null;
       avg_rating: number | null;
       review_count: bigint;
+      // The raw stored screenshots jsonb (the SAME column getAppDetail reads) —
+      // projected to a public cover URL below (first screenshot, opaque route).
+      screenshots: unknown;
       // The sort key for THIS row, projected so we can encode it into the
       // nextCursor for a stable keyset scan. Text so one column fits all sorts.
       sort_key: string;
@@ -2684,6 +2687,7 @@ export class BlockRegistry {
         ab.category,
         ab.external_url,
         ab.approved_scopes,
+        ab.screenshots,
         -- Post kill_per_model_installs: "install count" = how many distinct
         -- USERS use this app, not how many subscription rows exist. A single
         -- user can hold several rows for one app (a blanket publisher sub +
@@ -2764,6 +2768,10 @@ export class BlockRegistry {
         // Marketplace reviews (aggregate-eligible). avgRating NULL = 0-review.
         avgRating: r.avg_rating ?? null,
         reviewCount: Number(r.review_count),
+        // Card cover: the FIRST public screenshot URL (or NULL when the app
+        // shipped none). Reuses the SAME toPublicScreenshots projection the
+        // detail page uses — opaque gated route, never the raw MinIO key.
+        coverUrl: toPublicScreenshots(r.id, r.screenshots)[0]?.url ?? null,
       })),
       nextCursor,
     };
@@ -2922,6 +2930,9 @@ export class BlockRegistry {
       approved_scopes: string[] | null;
       avg_rating: number | null;
       review_count: bigint;
+      // Raw screenshots jsonb — projected to a public cover URL below (same as
+      // listAvailable / getAppDetail).
+      screenshots: unknown;
     };
     const rows = (await dbRead.$queryRaw<Row[]>`
       SELECT
@@ -2933,6 +2944,7 @@ export class BlockRegistry {
         ab.category,
         ab.external_url,
         ab.approved_scopes,
+        ab.screenshots,
         (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
          WHERE bus.app_block_id = ab.id) AS install_count,
         ${AVG_RATING_SUBQUERY} AS avg_rating,
@@ -2965,6 +2977,9 @@ export class BlockRegistry {
         : [],
       avgRating: r.avg_rating ?? null,
       reviewCount: Number(r.review_count),
+      // Card cover: FIRST public screenshot URL (or NULL). Same projection as
+      // listAvailable — no widening.
+      coverUrl: toPublicScreenshots(r.id, r.screenshots)[0]?.url ?? null,
     }));
   }
 


### PR DESCRIPTION
## Problem

Apps can already ship listing images — a developer puts up-to-8 images in a `screenshots/` dir in the bundle ZIP, which are magic-byte-validated (type, ≤2MiB, max 8), stored in MinIO at approve, and served publicly via the existing gated proxy `/api/blocks/screenshot/[appBlockId]/[file]`. Those images already render on the app **detail modal** and **detail page**.

But the **marketplace CARD** (`AppBlockCard.tsx`) rendered no image at all — and the card's data shape (`AvailableBlock`, returned by `BlockRegistry.listAvailable` / `getFeaturedBlocks`) didn't project any cover/screenshot field. So the listing image a dev uploaded never showed up where it matters most: the grid.

## Change

**Server (projection):** add a nullable `coverUrl` to the `AvailableBlock` listing shape from **both** `BlockRegistry.listAvailable` and `getFeaturedBlocks`, derived as the FIRST public screenshot — `toPublicScreenshots(id, screenshots)[0]?.url ?? null`. This reuses the existing `toPublicScreenshots` helper (the same opaque, gated `/api/blocks/screenshot/...` route the detail page uses), so the raw MinIO key is **never** exposed. Added `ab.screenshots` to both `$queryRaw` SELECTs + Row types, and `coverUrl: string | null` to the `AvailableBlock` type in `subscription.schema.ts`. No migration — the `screenshots` column already exists; this is purely additive read + render.

**Card (render):** `AppBlockCard` now renders `coverUrl` as a fixed-height cover image (Mantine `Image`, `fit="cover"`, in a `Card.Section` so it bleeds to the card edges above the body). The cover is reused across the grid, the featured rail, and recently-opened.

**Placeholder behavior:** when `coverUrl` is null (the app shipped no `screenshots/` dir), the card renders a tasteful placeholder instead of a broken/empty `<img>` — a neutral dark gradient with the app's category glyph (or a generic apps glyph when no category is set), marked `aria-hidden` (decorative; the title/category chip already carry the info). The cover area is never empty.

The gated screenshot endpoint is unchanged — it's flag-gated (`app-blocks-enabled`, mod-only today), which matches the marketplace's own gating.

## Test coverage

- **Service** (`block-registry.list-available.test.ts`, `block-registry.external-url.test.ts`): `coverUrl` = the first public screenshot URL when screenshots exist (sorted by index, opaque route, raw key never on the wire) and null when the column is empty/NULL — for both `listAvailable` and `getFeaturedBlocks`. Wire-shape allowlist assertions extended to include `coverUrl`. **32 service tests pass.**
- **Component** (`AppBlockCard.browser.test.tsx`): the card renders an `<img>` cover (with the screenshot src) when `coverUrl` is present, and the placeholder (no img, decorative svg glyph) when null — incl. the category-glyph path. **50 component tests pass** across the 4 touched `.browser.test.tsx` files.

## Follow-up (separate)

When an app ships no screenshot, this shows a category-glyph placeholder. An **autogenerated** screenshot/cover (e.g. rendering the app once at approve, or an OG-style synthesized thumbnail) is a reasonable richer fallback but is out of scope here — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)