### PR TITLE
chore: add NixOS dev flake pinning Prisma 6.13.0 engines

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "Civitai development shell (NixOS)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+
+      # Prisma engines must match the npm @prisma/client version EXACTLY (engine
+      # commit is embedded in the client and verified at runtime). The project
+      # pins @prisma/client 6.13.0, but nixpkgs never packaged 6.13.0
+      # (prisma-engines jumps 6.7 -> 6.18), so we fetch Prisma's official
+      # prebuilt 6.13.0 engines and patchelf them onto NixOS instead of building
+      # from source or drifting the repo's pinned client version.
+      #
+      # Commit comes from node_modules/@prisma/engines-version
+      # (6.13.0-35.<commit>). Bump both together if @prisma/client changes.
+      engineCommit = "361e86d0ea4987e9f53a565309b3eed797a6bcbd";
+      enginePlatform = "debian-openssl-3.0.x"; # links libssl/libcrypto .so.3, satisfied by pkgs.openssl
+      fetchEngine = file: sha256: pkgs.fetchurl {
+        url = "https://binaries.prisma.sh/all_commits/${engineCommit}/${enginePlatform}/${file}.gz";
+        inherit sha256;
+      };
+
+      prisma-engines = pkgs.stdenvNoCC.mkDerivation {
+        pname = "prisma-engines";
+        version = "6.13.0";
+        dontUnpack = true;
+        nativeBuildInputs = [ pkgs.autoPatchelfHook pkgs.gzip ];
+        buildInputs = [ pkgs.openssl pkgs.stdenv.cc.cc.lib pkgs.zlib ];
+        dontStrip = true;
+
+        queryLib = fetchEngine "libquery_engine.so.node" "0gamcinpfb8gvli48z16a378ziyinsanniddgbmd93v1lisllcz2";
+        schemaEngine = fetchEngine "schema-engine" "0rjwada7j2gdqx5xwbxqdvhr2c8jk2mjzhyblfbryiazyv3i9ir9";
+        queryEngine = fetchEngine "query-engine" "0iiknxyygq62g1n64h7nfpbfkmq5pi6d8i8di5hyv09hsmzbaimd";
+
+        buildPhase = ''
+          mkdir -p $out/lib $out/bin
+          gzip -dc $queryLib    > $out/lib/libquery_engine.node
+          gzip -dc $schemaEngine > $out/bin/schema-engine
+          gzip -dc $queryEngine  > $out/bin/query-engine
+          chmod +x $out/bin/schema-engine $out/bin/query-engine
+        '';
+      };
+    in {
+      packages.${system}.prisma-engines = prisma-engines;
+
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          nodejs_20
+          pnpm
+          openssl
+          clickhouse
+          postgresql_16
+          redis
+        ];
+        env = {
+          PRISMA_QUERY_ENGINE_LIBRARY = "${prisma-engines}/lib/libquery_engine.node";
+          PRISMA_QUERY_ENGINE_BINARY = "${prisma-engines}/bin/query-engine";
+          PRISMA_SCHEMA_ENGINE_BINARY = "${prisma-engines}/bin/schema-engine";
+        };
+      };
+    };
+}


### PR DESCRIPTION
## What

Restores the Nix `devShell` flake (`flake.nix` + `flake.lock`) used by `direnv`. The file had become untracked and was lost from the working tree, leaving only a stale direnv cache that pointed at a garbage-collected store path.

## Why `pnpm install` broke on NixOS

`pnpm install` itself was fine — the failure was its `postinstall` → `prisma generate`:

- The old flake pulled `prisma`/`prisma-engines` from `nixpkgs-unstable`, which has since moved to **Prisma 7.x**, but the repo pins **`@prisma/client` 6.13.0**.
- Prisma verifies the engine commit matches the client **exactly** at runtime, and nixpkgs **never packaged 6.13.0** (`prisma-engines` jumps 6.7 → 6.18).

## Fix

Rather than drift the repo's pinned client or do a long from-source Rust build, the devShell fetches Prisma's **official prebuilt 6.13.0 engines** (commit `361e86d0…`, `debian-openssl-3.0.x`) and `patchelf`s them onto NixOS via `autoPatchelfHook`. Both `query-engine` and `schema-engine` report the matching commit, and `prisma generate` produces the client cleanly.

## Maintenance note

If `@prisma/client` is bumped, update `engineCommit` in `flake.nix` to the new `node_modules/@prisma/engines-version` commit and refresh the three `nix-prefetch-url` hashes (a comment in the file documents this).

## Verification

- `nix build .#prisma-engines` → both engines run on NixOS, report commit `361e86d0…`
- `direnv exec . pnpm install` → completes clean; `postinstall`/`db:generate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)