### PR TITLE
feat(model-files): manage precisions & quant types from the DB

### DIFF
--- a/docs/features/model-file-options.md
+++ b/docs/features/model-file-options.md
@@ -1,0 +1,75 @@
+# Spec: DB-managed model file precisions & quant types
+
+ClickUp: [868k69pey](https://app.clickup.com/t/868k69pey)
+
+## Goal
+Move the two hardcoded model-file metadata lists out of `constants.ts` and into the DB so mods
+can edit them without a deploy (these lists grow over time as new GGUF quant types / precisions appear).
+
+- **precisions** (`modelFileFp`): currently `['fp16','fp8','nf4','fp32','bf16']`
+- **quantTypes** (`modelFileQuantTypes`): currently 25 `Q*`/`IQ*` values
+
+## Storage
+Single `KeyValue` row, key `modelFileOptions`:
+```json
+{ "precisions": ["fp16", "fp8", ...], "quantTypes": ["Q8_0", "Q6_K", ...] }
+```
+The hardcoded `constants.modelFileFp` / `constants.modelFileQuantTypes` stay as the **default/fallback**
+when the key is absent or unreadable (same layered pattern as `update-user-score` multipliers:
+DB → hardcoded default).
+
+## Service
+Folded into `src/server/services/model-file.service.ts` (alongside the other model-file CRUD).
+Uses `dbKV` (`~/server/db/db-helpers`) for KeyValue access — the repo convention (cf. `system.router`
+`getDbKV`, `training.router`). No app-layer cache: caching lives at the edge (`edgeCacheIt` on the
+public procedure); `dbKV` is bound to the primary, so a write is self-consistent on the next read.
+- `getModelFileOptions()` → `dbKV.get(KEY)`, normalized; falls back to constants defaults when absent.
+- `setModelFileOptions` / `addModelFileOptions` / `removeModelFileOptions` ({ precisions?, quantTypes? })
+  → read-before-write via a shared `mutateModelFileOptions(input, merge)` helper, then `dbKV.set`.
+
+## Mod management endpoint (webhook, token-secured)
+`src/pages/api/admin/model-file-options.ts` using `WebhookEndpoint` (`?token=$WEBHOOK_TOKEN`).
+Method-based REST (no `action` param) — the verb says what it does; body `{ precisions?, quantTypes? }`:
+- `GET`    → current `{ precisions, quantTypes }` (live, bypasses cache)
+- `PUT`    → replace the provided list(s) wholesale
+- `POST`   → add value(s) to the existing list(s)
+- `DELETE` → remove value(s) from the existing list(s)
+
+Writes read-before-write from the **primary** (`dbWrite`) so a partial mutation can't clobber the
+preserved list during replication lag. Body validated: non-empty `string[]`, ≥1 of the two keys.
+
+## Public read (edge-cached, client-facing)
+tRPC `modelFile.getOptions` (`src/server/routers/model-file.router.ts`), `publicProcedure` with
+`.use(edgeCacheIt({ ttl: CacheTTL.sm, tags: () => [MODEL_FILE_OPTIONS_EDGE_TAG] }))` → 3-min CDN
+s-maxage, tagged for purge. Returns `{ precisions, quantTypes }` from the service. Established
+edge-cache convention (cf. `system.router` `getDbKV`, `generation.router` tag+purge); the repo's
+tRPC client uses non-batched `httpLink` GET so `edgeCacheIt` applies.
+
+**Cache busting:** every mod write (`mutateModelFileOptions`) calls
+`purgeCache({ tags: [MODEL_FILE_OPTIONS_EDGE_TAG] })` after `dbKV.set`, so the CDN serves fresh
+immediately. Already-loaded browser tabs still refetch on their 3-min React Query `staleTime`.
+`purgeCache` no-ops without `CF_ZONE_ID` (dev).
+
+## Client — dropdowns
+Shared hook `src/hooks/useModelFileOptions.ts`: `trpc.modelFile.getOptions.useQuery` (staleTime ~3min
+to match edge cache), returning `{ precisions, quantTypes }`, falling back to `constants.*` while
+loading / on error so dropdowns never render empty.
+
+Wired into all three consumers:
+- `src/components/Resource/Files.tsx` — the model file editor (Quant ~984, Precision ~1002) [task target]
+- `src/components/Model/Actions/MergeVersions.tsx` (~1053 quant, ~1070 fp)
+- `src/components/Account/SettingsCard.tsx` (~118 fp, ~141 quant)
+
+## Server validation (the one real design decision)
+The 4 zod schemas use `z.enum(constants.modelFileFp)` / `z.enum(constants.modelFileQuantTypes)`. `z.enum`
+is static at module-load, so a newly-added DB value would FAIL upload/download validation — defeating the
+feature. Options:
+- **A (recommended):** relax those fields to `z.string()` (nullish, with a sane `.max()`); values are
+  mod-curated + selected from the editor dropdown, low-risk metadata tags.
+- **B:** keep `z.enum` as a superset — new values require also editing constants (defeats the purpose).
+- **C:** async-refine each schema against the cached DB list (correct but heavy; schemas are imported in
+  sync contexts).
+
+## Out of scope (MVP)
+- No in-app mod UI; management is via the webhook endpoint only (matches "like the KoN queues").
+- The 4 zod schemas relax to `z.string()` (decision A) — values are mod-curated + dropdown-selected.

--- a/prisma/migrations/20260630120000_seed_model_file_options/migration.sql
+++ b/prisma/migrations/20260630120000_seed_model_file_options/migration.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- Seed model file options (precisions + quant types) into KeyValue
+-- ============================================================
+-- Backs the mod-managed precision/quant-type lists read via dbKV under key
+-- `modelFileOptions` (see src/server/services/model-file.service.ts). The app
+-- falls back to the hardcoded constants when this row is absent, so this seed is
+-- OPTIONAL — its only purpose is to materialize the row with the current values
+-- so mods can edit it from day one via /api/admin/model-file-options.
+--
+-- ⚠️ MANUAL APPLY — the main civitai DB does NOT auto-apply migrations. This file
+-- is committed for history; a HUMAN applies the SQL below per environment
+-- (psql/retool). CI / deploy does NOT run it.
+--
+-- IDEMPOTENT + NON-DESTRUCTIVE:
+--   - ON CONFLICT DO NOTHING: re-runnable, and never clobbers a row a mod has
+--     already edited. To force-reset the lists to these defaults instead, change
+--     the conflict clause to `DO UPDATE SET "value" = EXCLUDED."value"`.
+--   - Values mirror constants.modelFileFp / constants.modelFileQuantTypes at the
+--     time of writing.
+INSERT INTO "KeyValue" ("key", "value")
+VALUES (
+  'modelFileOptions',
+  '{"precisions":["fp16","fp8","nf4","fp32","bf16"],"quantTypes":["Q8_0","Q6_K","Q5_K_M","Q5_K_S","Q5_1","Q5_0","Q4_K_M","Q4_K_S","Q4_1","Q4_0","Q3_K_L","Q3_K_M","Q3_K_S","Q2_K","Q2_K_S","IQ4_XS","IQ4_NL","IQ3_XS","IQ3_XXS","IQ2_XS","IQ2_XXS","IQ2_S","IQ2_M","IQ1_S","IQ1_M"]}'::jsonb
+)
+ON CONFLICT ("key") DO NOTHING;

--- a/src/components/Account/SettingsCard.tsx
+++ b/src/components/Account/SettingsCard.tsx
@@ -13,6 +13,7 @@ import {
 import produce from 'immer';
 import { useCurrentUserSettings, useMutateUserSettings } from '~/components/UserSettings/hooks';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useModelFileOptions } from '~/hooks/useModelFileOptions';
 import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 // import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -35,6 +36,7 @@ export function SettingsCard() {
   const user = useCurrentUser();
   const queryUtils = trpc.useUtils();
   const flags = useFeatureFlags();
+  const { precisions, quantTypes } = useModelFileOptions();
 
   const { mutate, isPending: isLoading } = trpc.user.update.useMutation({
     async onSuccess() {
@@ -115,7 +117,7 @@ export function SettingsCard() {
           <Select
             label="Preferred Precision"
             // name="fp"
-            data={constants.modelFileFp.map((value) => ({
+            data={precisions.map((value) => ({
               value,
               label: value.toUpperCase(),
             }))}
@@ -138,7 +140,7 @@ export function SettingsCard() {
             <Select
               label="Preferred Quant Type"
               name="quantType"
-              data={constants.modelFileQuantTypes}
+              data={quantTypes}
               allowDeselect={false}
               value={user.filePreferences?.quantType ?? 'Q4_K_M'}
               onChange={(value: string | null) =>

--- a/src/components/Model/Actions/MergeVersions.tsx
+++ b/src/components/Model/Actions/MergeVersions.tsx
@@ -33,6 +33,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import type { ModelFileType } from '~/server/common/constants';
 import { componentFileTypes, constants, zipModelFileTypes } from '~/server/common/constants';
+import { useModelFileOptions } from '~/hooks/useModelFileOptions';
 import { showErrorNotification } from '~/utils/notifications';
 import { formatKBytes } from '~/utils/number-helpers';
 import { getFileExtension } from '~/utils/string-helpers';
@@ -930,6 +931,8 @@ function MergeFileCard({
     file.metadata?.isRequired ??
     false) as boolean;
 
+  const { precisions, quantTypes } = useModelFileOptions();
+
   const iconConfig = getFileIconConfig(file.name, { format: effectiveFormat });
   const FileIcon = iconConfig.icon;
   const fileSizeStr = file.sizeKB ? formatKBytes(file.sizeKB) : undefined;
@@ -1050,7 +1053,7 @@ function MergeFileCard({
                     w={100}
                     placeholder="Quant"
                     searchable
-                    data={constants.modelFileQuantTypes}
+                    data={quantTypes}
                     value={effectiveQuantType}
                     onChange={(value) => {
                       onUpdate({ metadata: { quantType: value as ModelFileQuantType | null } });
@@ -1067,7 +1070,7 @@ function MergeFileCard({
                     size="xs"
                     w={85}
                     placeholder="fp16"
-                    data={constants.modelFileFp}
+                    data={precisions}
                     value={effectiveFp}
                     onChange={(value) => {
                       onUpdate({ metadata: { fp: value as ModelFileFp | null } });

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -39,6 +39,7 @@ import type { FileFromContextProps } from '~/components/Resource/FilesProvider';
 import { useFilesContext } from '~/components/Resource/FilesProvider';
 import type { ModelFileType, ZipModelFileType } from '~/server/common/constants';
 import { componentFileTypes, constants, zipModelFileTypes } from '~/server/common/constants';
+import { useModelFileOptions } from '~/hooks/useModelFileOptions';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import { removeDuplicates } from '~/utils/array-helpers';
 import { showErrorNotification } from '~/utils/notifications';
@@ -867,6 +868,7 @@ function FileEditForm({
   const [initialFile, setInitialFile] = useState({ ...versionFile });
   const { errors, updateFile, validationCheck } = useFilesContext();
   const error = errors?.[index];
+  const { precisions, quantTypes } = useModelFileOptions();
 
   const { mutate, isPending: isLoading } = trpc.modelFile.update.useMutation({
     onSuccess: () => {
@@ -981,7 +983,7 @@ function FileEditForm({
                 placeholder="Quant"
                 searchable
                 error={error?.quantType?._errors[0]}
-                data={constants.modelFileQuantTypes}
+                data={quantTypes}
                 value={versionFile.quantType ?? null}
                 onChange={(value) => {
                   updateFile(versionFile.uuid, {
@@ -999,7 +1001,7 @@ function FileEditForm({
                 w={85}
                 placeholder="fp16"
                 error={error?.fp?._errors[0]}
-                data={constants.modelFileFp}
+                data={precisions}
                 value={versionFile.fp ?? null}
                 onChange={(value) => {
                   updateFile(versionFile.uuid, { fp: value as ModelFileFp | null });

--- a/src/hooks/useModelFileOptions.ts
+++ b/src/hooks/useModelFileOptions.ts
@@ -1,0 +1,21 @@
+import { constants } from '~/server/common/constants';
+import { trpc } from '~/utils/trpc';
+
+export type ModelFileOptions = { precisions: string[]; quantTypes: string[] };
+
+const fallback: ModelFileOptions = {
+  precisions: [...constants.modelFileFp],
+  quantTypes: [...constants.modelFileQuantTypes],
+};
+
+// Mod-managed precision + quant-type lists for model file dropdowns. The procedure is
+// edge-cached 3 min (edgeCacheIt); staleTime matches so the client doesn't refetch sooner.
+// Falls back to the hardcoded constants so dropdowns never render empty.
+export function useModelFileOptions() {
+  const { data } = trpc.modelFile.getOptions.useQuery(undefined, {
+    staleTime: 3 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    placeholderData: fallback,
+  });
+  return data ?? fallback;
+}

--- a/src/pages/api/admin/model-file-options.ts
+++ b/src/pages/api/admin/model-file-options.ts
@@ -1,0 +1,56 @@
+/**
+ * Mod-managed model file precision + quant-type lists (KeyValue: modelFileOptions).
+ * Backs the model file editor dropdowns + download metadata; defaults live in
+ * constants.modelFileFp / modelFileQuantTypes and are used until this row is set.
+ *
+ * Usage: /api/admin/model-file-options?token=$WEBHOOK_TOKEN   (body: { precisions?, quantTypes? })
+ *   GET      return current { precisions, quantTypes }
+ *   PUT      replace the provided list(s) wholesale
+ *   POST     add the provided value(s) to the existing list(s)
+ *   DELETE   remove the provided value(s) from the existing list(s)
+ *
+ * GET reads the DB directly (this endpoint isn't edge-cached) so it's always live. A write
+ * purges the public procedure's edge cache (tag: model-file-options) so new requests fetch fresh
+ * immediately; already-loaded clients still refetch on their 3-min React Query staleTime.
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import {
+  addModelFileOptions,
+  getModelFileOptions,
+  removeModelFileOptions,
+  setModelFileOptions,
+} from '~/server/services/model-file.service';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+const bodySchema = z
+  .object({
+    precisions: z.array(z.string().trim().min(1)).min(1).optional(),
+    quantTypes: z.array(z.string().trim().min(1)).min(1).optional(),
+  })
+  .refine((d) => !!d.precisions || !!d.quantTypes, {
+    message: 'Provide at least one of precisions or quantTypes',
+  });
+
+const writers = {
+  PUT: setModelFileOptions,
+  POST: addModelFileOptions,
+  DELETE: removeModelFileOptions,
+} as const;
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'GET') {
+    return res.status(200).json(await getModelFileOptions());
+  }
+
+  const writer = writers[req.method as keyof typeof writers];
+  if (!writer) {
+    res.setHeader('Allow', 'GET, PUT, POST, DELETE');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+
+  return res.status(200).json(await writer(parsed.data));
+});

--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -19,8 +19,8 @@ const schema = z.object({
   type: z.enum(constants.modelFileTypes).optional(),
   format: z.enum(constants.modelFileFormats).optional(),
   size: z.enum(constants.modelFileSizes).optional(),
-  fp: z.enum(constants.modelFileFp).optional(),
-  quantType: z.enum(constants.modelFileQuantTypes).optional(),
+  fp: z.string().max(64).optional(),
+  quantType: z.string().max(64).optional(),
   fileId: z.preprocess((val) => (val ? Number(val) : undefined), z.number().optional()),
 });
 

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -1739,4 +1739,5 @@ export const EARLY_ACCESS_CONFIG: {
 
 export const KEY_VALUE_KEYS = {
   REDEEM_CODE_GIFT_NOTICES: 'redeemCodeGiftNotices',
+  MODEL_FILE_OPTIONS: 'modelFileOptions',
 } as const;

--- a/src/server/routers/model-file.router.ts
+++ b/src/server/routers/model-file.router.ts
@@ -12,7 +12,13 @@ import {
   modelFileUpsertSchema,
   recentTrainingDataSchema,
 } from '~/server/schema/model-file.schema';
-import { getRecentTrainingData } from '~/server/services/model-file.service';
+import {
+  getModelFileOptions,
+  getRecentTrainingData,
+  MODEL_FILE_OPTIONS_EDGE_TAG,
+} from '~/server/services/model-file.service';
+import { CacheTTL } from '~/server/common/constants';
+import { edgeCacheIt } from '~/server/middleware.trpc';
 import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
@@ -21,6 +27,10 @@ export const modelFileRouter = router({
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)
     .query(getFilesByVersionIdHandler),
+  getOptions: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .use(edgeCacheIt({ ttl: CacheTTL.sm, tags: () => [MODEL_FILE_OPTIONS_EDGE_TAG] }))
+    .query(() => getModelFileOptions()),
   create: protectedProcedure
     .meta({ requiredScope: TokenScope.ModelsWrite })
     .input(modelFileCreateSchema)

--- a/src/server/schema/model-file.schema.ts
+++ b/src/server/schema/model-file.schema.ts
@@ -92,8 +92,8 @@ export type ModelFileMetadata = z.infer<typeof modelFileMetadataSchema>;
 export const modelFileMetadataSchema = z.object({
   format: z.enum(constants.modelFileFormats).nullish(),
   size: z.enum(constants.modelFileSizes).nullish(),
-  fp: z.enum(constants.modelFileFp).nullish(),
-  quantType: z.enum(constants.modelFileQuantTypes).nullish(),
+  fp: z.string().max(64).nullish(),
+  quantType: z.string().max(64).nullish(),
   isRequired: z.boolean().nullish(),
   labelType: z.enum(constants.autoLabel.labelTypes).nullish(),
   ownRights: z.boolean().nullish(),

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -538,10 +538,10 @@ export const mergeVersionsSchema = z.object({
         type: z.enum(constants.modelFileTypes).optional(),
         metadata: z
           .object({
-            fp: z.enum(constants.modelFileFp).nullish(),
+            fp: z.string().max(64).nullish(),
             size: z.enum(constants.modelFileSizes).nullish(),
             format: z.enum(constants.modelFileFormats).nullish(),
-            quantType: z.enum(constants.modelFileQuantTypes).nullish(),
+            quantType: z.string().max(64).nullish(),
             isRequired: z.boolean().nullish(),
           })
           .optional(),

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -1,6 +1,5 @@
 import * as z from 'zod';
 import { BanReasonCode, OnboardingSteps } from '~/server/common/enums';
-import { constants } from '~/server/common/constants';
 import { getAllQuerySchema, paginationSchema } from '~/server/schema/base.schema';
 import { userSettingsChat } from '~/server/schema/chat.schema';
 import type { ModelGallerySettingsSchema } from '~/server/schema/model.schema';
@@ -120,7 +119,7 @@ export const userUpdateSchema = z.object({
       size: z.string().optional(),
       fp: z.string().optional(),
       imageFormat: z.string().optional(),
-      quantType: z.enum(constants.modelFileQuantTypes).optional(),
+      quantType: z.string().max(64).optional(),
     })
     .optional(),
   leaderboardShowcase: z.string().nullish(),

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -162,8 +162,8 @@ export const getFileForModelVersion = async ({
   type?: ModelFileType;
   format?: ModelFileFormat;
   size?: ModelFileSize;
-  fp?: ModelFileFp;
-  quantType?: ModelFileQuantType;
+  fp?: string;
+  quantType?: string;
   user?: {
     isModerator?: boolean | null;
     id?: number;
@@ -298,10 +298,10 @@ export const getFileForModelVersion = async ({
     if (type) fileWhere.type = type;
     if (!isOwner && !isMod) fileWhere.visibility = ModelFileVisibility.Public;
     const files = await dbRead.modelFile.findMany({ where: fileWhere, select: fileSelect });
-    const metadata: FileMetadata = {
+    const metadata = {
       ...user?.filePreferences,
       ...removeEmpty({ format, size, fp, quantType }),
-    };
+    } as FileMetadata;
     const castedFiles = files as Array<Omit<FileResult, 'metadata'> & { metadata: FileMetadata }>;
     file = getPrimaryFile(castedFiles, { metadata });
 

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -396,7 +396,16 @@ async function mutateModelFileOptions(
     quantTypes: input.quantTypes ? merge(current.quantTypes, input.quantTypes) : current.quantTypes,
   };
   await dbKV.set(KEY_VALUE_KEYS.MODEL_FILE_OPTIONS, next);
-  await purgeCache({ tags: [MODEL_FILE_OPTIONS_EDGE_TAG] });
+  // Best-effort: the DB write is the source of truth, so a purge failure must not fail the
+  // caller — worst case the CDN serves stale until its TTL expires.
+  purgeCache({ tags: [MODEL_FILE_OPTIONS_EDGE_TAG] }).catch((error) =>
+    logToAxiom({
+      type: 'error',
+      name: 'purge-model-file-options-cache',
+      message: (error as Error).message,
+      error,
+    })
+  );
   return next;
 }
 
@@ -412,5 +421,8 @@ export function addModelFileOptions(input: Partial<ModelFileOptions>) {
 
 // DELETE: remove the provided value(s) from the existing list(s).
 export function removeModelFileOptions(input: Partial<ModelFileOptions>) {
-  return mutateModelFileOptions(input, (current, next) => current.filter((x) => !next.includes(x)));
+  return mutateModelFileOptions(input, (current, next) => {
+    const removal = new Set(dedupeOptions(next));
+    return current.filter((x) => !removal.has(x));
+  });
 }

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -1,7 +1,9 @@
 import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
-import { CacheTTL } from '~/server/common/constants';
+import { CacheTTL, constants, KEY_VALUE_KEYS } from '~/server/common/constants';
+import { purgeCache } from '~/server/cloudflare/client';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { dbKV } from '~/server/db/db-helpers';
 import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import type { GetByIdInput } from '~/server/schema/base.schema';
@@ -344,3 +346,71 @@ export const getRecentTrainingData = async ({
     else throw throwDbError(error);
   }
 };
+
+// Mod-managed model file precision + quant-type lists (KeyValue: modelFileOptions).
+export type ModelFileOptions = { precisions: string[]; quantTypes: string[] };
+
+// Edge-cache tag shared by the public `modelFile.getOptions` procedure (edgeCacheIt) and the
+// purge below, so a mod write busts the CDN immediately instead of waiting out the TTL.
+export const MODEL_FILE_OPTIONS_EDGE_TAG = 'model-file-options';
+
+const modelFileOptionDefaults: ModelFileOptions = {
+  precisions: [...constants.modelFileFp],
+  quantTypes: [...constants.modelFileQuantTypes],
+};
+
+function dedupeOptions(values: string[]) {
+  return [...new Set(values.map((v) => v.trim()).filter(Boolean))];
+}
+
+function normalizeModelFileOptions(value: unknown): ModelFileOptions {
+  const v = (value ?? {}) as Partial<Record<keyof ModelFileOptions, unknown>>;
+  const pick = (input: unknown, fallback: string[]) => {
+    const list = Array.isArray(input) ? input.filter((x): x is string => typeof x === 'string') : [];
+    const cleaned = dedupeOptions(list);
+    return cleaned.length ? cleaned : fallback;
+  };
+  return {
+    precisions: pick(v.precisions, modelFileOptionDefaults.precisions),
+    quantTypes: pick(v.quantTypes, modelFileOptionDefaults.quantTypes),
+  };
+}
+
+// DB row (mod-managed) overrides the hardcoded constants; constants are the durable fallback
+// when the KeyValue row is absent. Caching lives at the edge — the public tRPC procedure is
+// wrapped in edgeCacheIt — so this just reads through dbKV (the primary, so writes are
+// immediately self-consistent on the next read).
+export async function getModelFileOptions() {
+  return normalizeModelFileOptions(await dbKV.get(KEY_VALUE_KEYS.MODEL_FILE_OPTIONS));
+}
+
+// Read-before-write (dbKV reads the primary) so a partial mutation can't clobber the preserved
+// list. `merge` returns the replacement for a given list; an absent input key is a no-op.
+async function mutateModelFileOptions(
+  input: Partial<ModelFileOptions>,
+  merge: (current: string[], next: string[]) => string[]
+) {
+  const current = normalizeModelFileOptions(await dbKV.get(KEY_VALUE_KEYS.MODEL_FILE_OPTIONS));
+  const next: ModelFileOptions = {
+    precisions: input.precisions ? merge(current.precisions, input.precisions) : current.precisions,
+    quantTypes: input.quantTypes ? merge(current.quantTypes, input.quantTypes) : current.quantTypes,
+  };
+  await dbKV.set(KEY_VALUE_KEYS.MODEL_FILE_OPTIONS, next);
+  await purgeCache({ tags: [MODEL_FILE_OPTIONS_EDGE_TAG] });
+  return next;
+}
+
+// PUT: replace the provided list(s) wholesale.
+export function setModelFileOptions(input: Partial<ModelFileOptions>) {
+  return mutateModelFileOptions(input, (_current, next) => dedupeOptions(next));
+}
+
+// POST: append the provided value(s) to the existing list(s).
+export function addModelFileOptions(input: Partial<ModelFileOptions>) {
+  return mutateModelFileOptions(input, (current, next) => dedupeOptions([...current, ...next]));
+}
+
+// DELETE: remove the provided value(s) from the existing list(s).
+export function removeModelFileOptions(input: Partial<ModelFileOptions>) {
+  return mutateModelFileOptions(input, (current, next) => current.filter((x) => !next.includes(x)));
+}


### PR DESCRIPTION
Move the hardcoded `modelFileFp` / `modelFileQuantTypes` lists into a `KeyValue` row (`modelFileOptions`) so mods can edit them without a deploy.

## What
- **Service** (`model-file.service.ts`): `get`/`set`/`add`/`remove` via `dbKV`, constants as fallback; edge-cache tag + `purgeCache` on write.
- **Public read**: tRPC `modelFile.getOptions`, `edgeCacheIt` 3-min CDN cache, tagged for purge.
- **Mod management**: token webhook `/api/admin/model-file-options` — `GET`/`PUT`/`POST`/`DELETE` (`{ precisions?, quantTypes? }`).
- **Editor dropdowns** (`Files`, `MergeVersions`, `SettingsCard`) read the DB list via `useModelFileOptions`, falling back to constants so they never render empty.
- **Validation**: relaxed `fp`/`quantType` zod enums to `z.string().max(64)` so new DB values validate (values are mod-curated + dropdown-selected).

## DB
Seed migration `prisma/migrations/20260630120000_seed_model_file_options` — **manual apply** (not auto-run); optional since the service falls back to constants when the row is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)