### PR TITLE
perf(og): render a bounded still-frame for video covers instead of skipping

### DIFF
--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -4,13 +4,12 @@ import { ImageResponse } from 'next/og';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { dbRead } from '~/server/db/client';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { getIsSafeBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
 import { ArticleIngestionStatus } from '~/shared/utils/prisma/enums';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { removeTags } from '~/utils/string-helpers';
-import { fetchImageAsDataUri } from '~/server/utils/og-image-helpers';
+import { buildOgCoverEdgeUrl, fetchImageAsDataUri } from '~/server/utils/og-image-helpers';
 
 // --- Schema & Types ---
 
@@ -117,20 +116,10 @@ function buildEntityImage(
   image: OgImage | null
 ): Pick<EntityData, 'imageUrl' | 'imageAspectRatio'> {
   if (!image) return { imageUrl: null, imageAspectRatio: 1 };
-  // Video covers require an on-demand CDN video→image transcode
-  // (`transcode:true`) that is known-slow and sometimes returns mp4 — it stalls
-  // the render and would burn the entire prefetch budget on every video card.
-  // There's no cheap static-frame path here, so skip the cover entirely and let
-  // the card render with the logo placeholder. (The bounded prefetch below would
-  // also cap it, but skipping avoids paying the timeout at all.)
-  if (image.type === 'video') return { imageUrl: null, imageAspectRatio: 1 };
+  // Video covers resolve to a bounded still frame (not a skip) — see
+  // buildOgCoverEdgeUrl. The handler's bounded prefetch caps the cold-miss cost.
   return {
-    imageUrl: getEdgeUrl(image.url, {
-      width: IMAGE_WIDTH,
-      height: IMAGE_HEIGHT,
-      fit: 'cover',
-      quality: 90,
-    }),
+    imageUrl: buildOgCoverEdgeUrl(image, { width: IMAGE_WIDTH, height: IMAGE_HEIGHT }),
     imageAspectRatio: getAspectRatio(image),
   };
 }

--- a/src/server/utils/__tests__/og-image-helpers.test.ts
+++ b/src/server/utils/__tests__/og-image-helpers.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  buildOgCoverEdgeUrl,
   fetchImageAsDataUri,
   OG_IMAGE_MAX_BYTES,
   OG_IMAGE_FETCH_TIMEOUT_MS,
 } from '../og-image-helpers';
+import { MediaType } from '~/shared/utils/prisma/enums';
 
 /**
  * Unit coverage for the OG cover-image prefetch helper. The full ImageResponse
@@ -139,5 +141,35 @@ describe('fetchImageAsDataUri', () => {
     vi.stubGlobal('fetch', vi.fn(async () => makeResponse({})));
     await fetchImageAsDataUri('https://x/y.png');
     expect(timeoutSpy).toHaveBeenCalledWith(OG_IMAGE_FETCH_TIMEOUT_MS);
+  });
+});
+
+describe('buildOgCoverEdgeUrl', () => {
+  const dims = { width: 450, height: 444 };
+
+  it('builds a plain resize URL for an image cover (no transcode/anim params)', () => {
+    const url = buildOgCoverEdgeUrl({ url: 'abc-image-id', type: MediaType.image }, dims);
+    expect(url).toContain('fit=cover');
+    expect(url).toContain('quality=90');
+    // an image cover must NOT request a video still-frame transcode
+    expect(url).not.toContain('transcode=true');
+    expect(url).not.toContain('anim=false');
+    // edge URL names the file with the image extension
+    expect(url.endsWith('.jpeg')).toBe(true);
+  });
+
+  it('requests a bounded STILL FRAME for a video cover (transcode + anim:false, jpeg — never mp4)', () => {
+    const url = buildOgCoverEdgeUrl({ url: 'abc-video-id.mp4', type: MediaType.video }, dims);
+    // the still-frame contract the site poster uses: image extension, no anim, transcode on
+    expect(url).toContain('transcode=true');
+    expect(url).toContain('anim=false');
+    expect(url).toContain('fit=cover');
+    // CRUCIAL: the file the cacher SERVES (the last path segment / name) is a
+    // .jpeg still — NOT the .mp4 satori can't embed. The source ref segment may
+    // still carry the original `.mp4`, but the served extension is what decides
+    // the CDN output format.
+    const servedName = url.split('/').pop();
+    expect(servedName).toMatch(/\.jpeg$/);
+    expect(servedName).not.toMatch(/\.mp4$/);
   });
 });

--- a/src/server/utils/og-image-helpers.ts
+++ b/src/server/utils/og-image-helpers.ts
@@ -1,3 +1,6 @@
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { MediaType } from '~/shared/utils/prisma/enums';
+
 /**
  * Helpers for the OG-image endpoint (`src/pages/api/og.tsx`).
  *
@@ -34,6 +37,32 @@ export const OG_IMAGE_FETCH_TIMEOUT_MS = 2500;
  * length (in case the header lies / is absent).
  */
 export const OG_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
+
+/**
+ * Build the edge URL for an entity's cover image as embedded in the OG card.
+ *
+ * For an IMAGE cover this is a plain `fit:cover` resize. For a VIDEO cover we
+ * request a STILL FRAME — `type:image` (→ `.jpeg` extension) + `anim:false` +
+ * `transcode:true` — the exact edge-URL the site's own video poster uses
+ * (`EdgeVideoBase`'s `<video poster>`). That returns a JPEG, NOT an mp4, so it
+ * embeds in the OG PNG like any image cover. The still frame can be slow on a
+ * cold cacher miss, but the caller pipes this through `fetchImageAsDataUri`'s
+ * bounded timeout and falls back to the logo placeholder — so a video model
+ * gets a real preview when the frame is warm, and never stalls the render.
+ */
+export function buildOgCoverEdgeUrl(
+  image: { url: string; type: MediaType },
+  dims: { width: number; height: number }
+): string {
+  const isVideo = image.type === MediaType.video;
+  return getEdgeUrl(image.url, {
+    width: dims.width,
+    height: dims.height,
+    fit: 'cover',
+    quality: 90,
+    ...(isVideo ? { type: MediaType.image, anim: false, transcode: true } : {}),
+  });
+}
 
 export type FetchImageAsDataUriOptions = {
   timeoutMs?: number;


### PR DESCRIPTION
Follow-up to #2841.

## Why
#2841 fixed the `/api/og` p99 tail (un-timed satori internal `<img>` fetch → `fetchImageAsDataUri` with `AbortSignal.timeout`). As part of that it made **video covers skip straight to the logo placeholder**, on the premise that the only video→image path returns mp4 and there's "no cheap static-frame path."

That premise doesn't hold:
- The site's own video poster (`EdgeVideoBase`'s `<video poster>`) renders a still everywhere via the edge URL `type:image` + `anim:false` + `transcode:true` → returns a **`.jpeg`, not an mp4**.
- og.tsx's *pre-#2841* video URL already defaulted to the image extension (`typeExtensions[type ?? image]`), so it was requesting a still JPEG too — it was just slow on a **cold cacher miss** and *un-timed*, which is what surfaced in the tail.

`og:image` must be a raster image, so a video can never be embedded directly — the only choice is **still-frame vs. generic logo**. With #2841's bounded prefetch already capping the cold-miss cost, we can request the real still frame and fall back to the placeholder only when it's genuinely slow.

## What
- Video covers now resolve to a bounded **still frame** (the same `anim:false`/`transcode:true`/image-extension contract the site poster uses) instead of being skipped. The handler's existing `fetchImageAsDataUri` timeout still caps it → real preview when warm, placeholder when slow, never a stall.
- Extracted the cover-URL logic into a pure, unit-tested `buildOgCoverEdgeUrl` helper.

## Product effect
Video-cover models/posts get a real preview on social shares again (Discord/Slack/Twitter/FB) instead of the generic logo card — with the same latency guarantees #2841 introduced.

## Tests
`og-image-helpers.test.ts` +2 cases: image cover = plain resize (no transcode/anim); video cover = still-frame (`transcode=true`, `anim=false`, served name `.jpeg` — never `.mp4`). Full helper suite 12/12 green locally; changed files typecheck-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)