### PR TITLE
fix(avatar): pass width to ProfileDecoration overlay EdgeMedia — stop fetching /original

### DIFF
--- a/src/components/Shop/CosmeticSample.tsx
+++ b/src/components/Shop/CosmeticSample.tsx
@@ -37,7 +37,7 @@ export const CosmeticSample = ({
 
       return (
         <div style={{ width: values.badgeSize }}>
-          <EdgeMedia src={decorationData.url} alt={cosmetic.name} />
+          <EdgeMedia src={decorationData.url} alt={cosmetic.name} width={values.badgeSize} />
         </div>
       );
     case CosmeticType.ContentDecoration:
@@ -80,6 +80,7 @@ export const CosmeticSample = ({
             alt={cosmetic.name}
             type={backgroundData.type}
             anim={true}
+            width={450}
             style={{
               objectFit: 'cover',
               // objectPosition: 'right bottom',

--- a/src/components/User/Username.tsx
+++ b/src/components/User/Username.tsx
@@ -88,7 +88,7 @@ export const BadgeDisplay = ({
             filter,
           }}
         >
-          <EdgeMedia src={badge.data.url} alt={badge.name} />
+          <EdgeMedia src={badge.data.url} alt={badge.name} width={badgeSize} />
         </div>
       ) : (
         <div style={{ display: 'flex', zIndex, filter }}>

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -190,6 +190,8 @@ export function UserAvatar({
                 type="image"
                 name="user avatar decoration"
                 alt=""
+                width={imageSize * 2}
+                original={false}
                 style={{
                   position: 'absolute',
                   top: '50%',


### PR DESCRIPTION
## Summary

- **Root cause**: `getEdgeUrl()` falls through to `original=true` (full-res, multi-MB) when no `width`/`height` is supplied. The `ProfileDecoration` overlay `<EdgeMedia>` in `UserAvatar` had no `width` prop.
- **Fix**: Add `width={imageSize * 2}` and `original={false}` to the decoration overlay in `UserAvatar.tsx`. `imageSize` is already a clean `number` from `getRawAvatarSize(...)` in scope at line 133. Doubling covers the `data.offset` overflow and retina displays; still a massive cut from `/original`.
- **`UserAvatarSimple.tsx`**: Already had `width={96}` + `original={false}` — no change needed.
- Layout (inline CSS `width`/`height` on the style prop) is unchanged; only the fetched Cloudflare image variant shrinks.
- Also includes a prior commit fixing the same issue for `CosmeticSample.tsx` (Badge/ProfileDecoration/animated-badge) and `Username.tsx`.

## Files changed

- `src/components/UserAvatar/UserAvatar.tsx` — 2 lines added (`width` + `original`)
- `src/components/Shop/CosmeticSample.tsx` — width added to badge/decoration cases (prior commit)
- `src/components/User/Username.tsx` — width added to badge overlay (prior commit)

## Test plan

- [ ] Decorated avatar on home feed / leaderboard / comment thread: network tab shows `width=NNN` Cloudflare variant instead of `/original`
- [ ] Avatar layout (size, offset overflow) visually unchanged across xs/sm/md/lg/xl sizes
- [ ] Animated decorations still animate (anim prop untouched)
- [ ] Orchestrator preview perf check: `/original=true/user avatar decoration` requests gone, replaced by `width=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)