### PR TITLE
fix(avatar): pass width to ProfileDecoration overlay (stop /original fetch)

### DIFF
--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -190,6 +190,8 @@ export function UserAvatar({
                 type="image"
                 name="user avatar decoration"
                 alt=""
+                width={imageSize * 2}
+                original={false}
                 style={{
                   position: 'absolute',
                   top: '50%',


### PR DESCRIPTION
## Problem

Every avatar with a **ProfileDecoration cosmetic** downloads the decoration frame at full-resolution `/original` — rendered at ~49px but fetched at full size (some are multiple MB). Confirmed via a live DOM dump of the authed home page: **49/49** of the home page's `/original` image requests were `…/original=true/user%20avatar%20decoration.jpeg` — the decoration overlay. It's the bulk of the home page's ~61 MB weight / 3.6s LCP, and fires site-wide (leaderboards, comments, cards, headers).

Root cause: the decoration `<EdgeMedia>` in `UserAvatar.tsx` passed no `width`, so `getEdgeUrl` falls back to `original=true` (`cf-images-utils.ts:88`). The avatar's other image paths already pass `width` + `original={false}`; only the decoration overlay was unguarded.

## Fix

```tsx
width={imageSize * 2}
original={false}
```

`imageSize` is the avatar's computed pixel size (`getRawAvatarSize(...)`); `×2` covers the decoration's `data.offset` overflow + retina while still cutting the transfer enormously vs `/original`. Layout is unchanged — the inline CSS (`width:'100%'`/`calc(100% + offset)`) controls rendered size; `width` only controls the fetched variant.

(`UserAvatarSimple.tsx` already guards its decoration overlay with `width=96`+`original={false}`; grep confirms these are the only two `name="user avatar decoration"` sites.)

## Verification

Pending preview — the `…/original=true/user avatar decoration` requests should become `width=…`, with home total image weight + LCP dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)