### PR TITLE
feat(app-blocks): web manifest editor → no-trust review (Phase 1) + CLI pull endpoint (Phase 2)

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2448,6 +2448,13 @@ model AppBlockPublishRequest {
   @@index([appBlockId, submittedAt(sort: Desc)], map: "app_block_publish_requests_app_history_idx")
   @@index([submittedByUserId, status], map: "app_block_publish_requests_my_submissions_idx")
   @@index([slug, status], map: "app_block_publish_requests_slug_idx")
+  // RAW partial unique index (NOT expressible in Prisma @@unique — it carries a
+  // WHERE clause): "app_block_publish_requests_one_pending_per_slug" UNIQUE
+  // (slug) WHERE status='pending'. Enforces at-most-one PENDING request per slug
+  // at the DB; submitVersion + recordPendingFromPush rely on its P2002 to close
+  // the read-then-write race. Created/re-asserted in
+  // 20260528210000_w1_uniqueness_constraints and
+  // 20260630130000_app_block_one_pending_per_slug_idempotent (manual-apply).
   @@map("app_block_publish_requests")
 }
 

--- a/prisma/migrations/20260630130000_app_block_one_pending_per_slug_idempotent/migration.sql
+++ b/prisma/migrations/20260630130000_app_block_one_pending_per_slug_idempotent/migration.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- App Blocks — one-pending-per-slug partial unique index (idempotent re-assert)
+-- ============================================================
+-- The web manifest editor (`blocks.updateManifest`) calls
+-- `recordPendingFromPush` explicitly AND the Forgejo push webhook the same
+-- commit fires ALSO calls it for the same (slug, sha). Both can miss the
+-- in-app "already captured this sha?" read and both attempt to INSERT a
+-- `pending` publish-request row for the slug. The application now catches the
+-- resulting unique-violation (P2002) and re-reads the winner's row, but that
+-- catch is only correct if the partial unique index it relies on actually
+-- exists in the target database.
+--
+-- That index was first created in
+--   20260528170000_w1_publish_requests / 20260528210000_w1_uniqueness_constraints
+-- (verified present on prod 2026-06-30). This migration re-asserts it
+-- IDEMPOTENTLY so any environment whose history pre-dates that work (a dev DB
+-- clone, a partially-applied env) cannot end up running the new P2002-catch
+-- code path WITHOUT the DB constraint that makes it sound. Applying this on an
+-- env that already has the index is a no-op.
+--
+-- Pre-flight (REQUIRED — index creation FAILS if duplicates already exist):
+--   SELECT slug, count(*) FROM app_block_publish_requests
+--     WHERE status='pending' GROUP BY slug HAVING count(*) > 1;
+--   -- Must return 0 rows. Verified 0 on prod (cnpg-cluster-nvme0, db civitai)
+--   -- 2026-06-30 before this migration was committed.
+--   -- If it returns rows, resolve the duplicates first (withdraw the older
+--   -- pending row(s) per slug) — otherwise the CREATE UNIQUE INDEX below errors.
+--
+-- Manual application (per CLAUDE.md Database rule #8 — NOT auto-applied by CI):
+--   kubectl exec -i -n cnpg-database cnpg-cluster-nvme0-N -- psql \
+--     -U postgres -d civitai -v ON_ERROR_STOP=1 --single-transaction \
+--     < prisma/migrations/20260630130000_app_block_one_pending_per_slug_idempotent/migration.sql
+
+CREATE UNIQUE INDEX IF NOT EXISTS "app_block_publish_requests_one_pending_per_slug"
+  ON "app_block_publish_requests" ("slug")
+  WHERE "status" = 'pending';

--- a/src/components/Apps/ManifestEditForm.tsx
+++ b/src/components/Apps/ManifestEditForm.tsx
@@ -1,0 +1,238 @@
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Group,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { IconAlertTriangle, IconDeviceFloppy, IconInfoCircle } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { ALLOWED_CONTENT_RATINGS } from '~/server/services/block-manifest-validator.service';
+import { MODEL_SLOT_IDS } from '~/shared/constants/slot-registry';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App management (Phase 1) — web form to edit an app's manifest. On save it
+ * calls `blocks.updateManifest`, which does a BACKGROUND commit to the app's
+ * Forgejo repo and re-enters the no-trust pending-review flow (the change does
+ * NOT go live until a moderator approves it via /apps/review).
+ *
+ * blockId is IMMUTABLE (shown read-only). iframe.src is platform-owned and not
+ * editable here (the server stamps it). The SERVER re-validates every field with
+ * BlockManifestValidator — this form's hints are advisory only.
+ */
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
+
+type StoredManifest = Record<string, unknown> & {
+  blockId?: string;
+  version?: string;
+  name?: string;
+  description?: string;
+  contentRating?: string;
+  scopes?: string[];
+  targets?: Array<{ slotId?: string }>;
+};
+
+export function ManifestEditForm({
+  appBlockId,
+  slug,
+  currentVersion,
+  manifest,
+}: {
+  appBlockId: string;
+  slug: string;
+  currentVersion: string;
+  manifest: StoredManifest;
+}) {
+  const utils = trpc.useUtils();
+
+  const [name, setName] = useState<string>(manifest.name ?? '');
+  const [description, setDescription] = useState<string>(manifest.description ?? '');
+  const [contentRating, setContentRating] = useState<string>(manifest.contentRating ?? 'g');
+  const [version, setVersion] = useState<string>(bumpPatch(currentVersion));
+  const [scopesText, setScopesText] = useState<string>((manifest.scopes ?? []).join('\n'));
+  const [selectedSlots, setSelectedSlots] = useState<string[]>(
+    (manifest.targets ?? []).map((t) => t?.slotId).filter((s): s is string => !!s)
+  );
+
+  const scopes = useMemo(
+    () =>
+      scopesText
+        .split(/[\n,]/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    [scopesText]
+  );
+
+  const versionValid = SEMVER_RE.test(version);
+  const versionHigher = compareSemver(version, currentVersion) > 0;
+
+  const mutation = trpc.blocks.updateManifest.useMutation({
+    onSuccess: async (res) => {
+      showSuccessNotification({
+        title: 'Manifest update submitted for review',
+        message: `v${res.version} is now pending moderator review. It will not go live until approved.`,
+      });
+      await utils.blocks.getMyAppManifest.invalidate({ appBlockId });
+    },
+    onError: (err) => {
+      showErrorNotification({ title: 'Could not submit manifest update', error: err as Error });
+    },
+  });
+
+  function handleSave() {
+    mutation.mutate({
+      appBlockId,
+      patch: {
+        version,
+        name: name.trim() || undefined,
+        description: description.trim() || undefined,
+        contentRating,
+        scopes,
+        targets: selectedSlots.map((slotId) => ({ slotId })),
+      },
+    });
+  }
+
+  const canSave = versionValid && versionHigher && !mutation.isPending && name.trim().length > 0;
+
+  return (
+    <Stack gap="md">
+      <Title order={3}>Edit manifest</Title>
+
+      <Alert icon={<IconInfoCircle size={16} />} color="blue" variant="light">
+        Saving commits the new manifest to your app&apos;s repository and opens a moderator review.
+        The change does <strong>not</strong> go live until a moderator approves it. blockId
+        (<code>{slug}</code>) cannot be changed.
+      </Alert>
+
+      <TextInput label="Block ID (immutable)" value={slug} readOnly disabled />
+
+      <TextInput
+        label="Name"
+        required
+        value={name}
+        onChange={(e) => setName(e.currentTarget.value)}
+        error={name.trim().length === 0 ? 'Name is required' : undefined}
+      />
+
+      <Textarea
+        label="Description"
+        autosize
+        minRows={2}
+        maxRows={6}
+        value={description}
+        onChange={(e) => setDescription(e.currentTarget.value)}
+      />
+
+      <Select
+        label="Content rating"
+        data={[...ALLOWED_CONTENT_RATINGS].map((r) => ({ value: r, label: r }))}
+        value={contentRating}
+        onChange={(v) => setContentRating(v ?? 'g')}
+      />
+
+      <TextInput
+        label="New version"
+        description={`Must be greater than the current version (${currentVersion}).`}
+        required
+        value={version}
+        onChange={(e) => setVersion(e.currentTarget.value)}
+        error={
+          !versionValid
+            ? 'Must be a semantic version (e.g. 1.2.3)'
+            : !versionHigher
+            ? `Must be greater than ${currentVersion}`
+            : undefined
+        }
+      />
+
+      <Textarea
+        label="Scopes"
+        description="One scope per line (or comma-separated). Must be a subset of your app's granted scopes — the server enforces this."
+        autosize
+        minRows={2}
+        maxRows={8}
+        value={scopesText}
+        onChange={(e) => setScopesText(e.currentTarget.value)}
+      />
+
+      <Stack gap={4}>
+        <Text size="sm" fw={500}>
+          Target slots
+        </Text>
+        <Text size="xs" c="dimmed">
+          Where the block mounts on a model page.
+        </Text>
+        <Checkbox.Group value={selectedSlots} onChange={setSelectedSlots}>
+          <Stack gap={4} mt={4}>
+            {MODEL_SLOT_IDS.map((slotId) => (
+              <Checkbox key={slotId} value={slotId} label={slotId} />
+            ))}
+          </Stack>
+        </Checkbox.Group>
+      </Stack>
+
+      {mutation.error && (
+        <Alert icon={<IconAlertTriangle size={16} />} color="red" variant="light">
+          {mutation.error.message}
+        </Alert>
+      )}
+
+      <Group justify="flex-end">
+        <Button component={Link} href={`/apps/${appBlockId}`} variant="default">
+          Cancel
+        </Button>
+        <Button
+          leftSection={<IconDeviceFloppy size={16} />}
+          onClick={handleSave}
+          loading={mutation.isPending}
+          disabled={!canSave}
+        >
+          Save &amp; submit for review
+        </Button>
+      </Group>
+
+      {mutation.data && (
+        <Alert color="green" variant="light">
+          Submitted as review request <code>{mutation.data.publishRequestId}</code>. Track it on{' '}
+          <Link href="/apps/my-submissions">My submissions</Link>.
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+/** Bump the patch component of a semver string for a sensible default new version. */
+function bumpPatch(v: string): string {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v);
+  if (!m) return v;
+  return `${m[1]}.${m[2]}.${Number(m[3]) + 1}`;
+}
+
+/** Mirror of the server's compareSemver (advisory client-side gate only). */
+function compareSemver(a: string, b: string): number {
+  const split = (v: string) => {
+    const [core, pre = null] = v.split('-', 2);
+    const nums = core.split('.').map((n) => parseInt(n, 10) || 0);
+    while (nums.length < 3) nums.push(0);
+    return { nums, pre };
+  };
+  const A = split(a);
+  const B = split(b);
+  for (let i = 0; i < 3; i++) {
+    if (A.nums[i] !== B.nums[i]) return A.nums[i] < B.nums[i] ? -1 : 1;
+  }
+  if (A.pre === null && B.pre === null) return 0;
+  if (A.pre === null) return 1;
+  if (B.pre === null) return -1;
+  return A.pre < B.pre ? -1 : A.pre > B.pre ? 1 : 0;
+}

--- a/src/components/Apps/ManifestEditForm.tsx
+++ b/src/components/Apps/ManifestEditForm.tsx
@@ -84,7 +84,7 @@ export function ManifestEditForm({
       await utils.blocks.getMyAppManifest.invalidate({ appBlockId });
     },
     onError: (err) => {
-      showErrorNotification({ title: 'Could not submit manifest update', error: err as Error });
+      showErrorNotification({ title: 'Could not submit manifest update', error: new Error(err.message) });
     },
   });
 

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import type { Readable } from 'node:stream';
 import { withAxiom } from '@civitai/next-axiom';
 import { env } from '~/env/server';
-import { dbRead, dbWrite } from '~/server/db/client';
+import { dbRead } from '~/server/db/client';
 import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
 import {
   BlockManifestValidator,
@@ -11,6 +11,7 @@ import {
 } from '~/server/services/block-manifest-validator.service';
 import { FORGEJO_ORG, getRawFile, setCommitStatus } from '~/server/services/blocks/forgejo.service';
 import { stampCanonicalIframeSrc } from '~/server/services/blocks/manifest-normalize';
+import { recordPendingFromPush } from '~/server/services/blocks/publish-request.service';
 
 /**
  * POST /api/internal/blocks/git-push
@@ -439,120 +440,6 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
 
   res.status(202).json({ ok: true, slug, sha, status: 'pending-review', deployed: false });
 });
-
-/**
- * Record (or refresh) a `pending` publish request for an unreviewed push to
- * civitai-apps/<slug>:main. This is the no-trust-on-push gate: a direct push
- * cannot auto-approve or deploy, so we capture it as the same kind of review
- * artifact a submitVersion produces and leave it for a moderator.
- *
- * The bundle bytes are NOT available to the webhook (Forgejo only hands us the
- * push event + the manifest at the sha), so this row's bundle pointers are left
- * empty and a `forgejoCommitSha` is stored instead — a moderator reviews the
- * code in the Forgejo repo directly. `approveRequest` already supports
- * approving a `pending` request against the existing app_blocks row.
- *
- * Idempotent at the (slug, sha) level: a re-delivery of the same push event
- * refreshes the existing pending row rather than stacking duplicates. Only ONE
- * pending request per slug is allowed (matches the submitVersion invariant +
- * the partial unique index), so a newer unreviewed sha supersedes an older
- * still-pending one.
- */
-async function recordPendingFromPush(args: {
-  slug: string;
-  sha: string;
-  appBlockId: string;
-  manifest: object;
-  version: string;
-}): Promise<void> {
-  const { newUlid } = await import('~/server/utils/app-block-ids');
-
-  // Already captured this exact (slug, sha) as pending? Refresh + done.
-  const existingForSha = await dbWrite.appBlockPublishRequest.findFirst({
-    where: { slug: args.slug, status: 'pending', forgejoCommitSha: args.sha },
-    select: { id: true },
-  });
-  if (existingForSha) {
-    await dbWrite.appBlockPublishRequest.update({
-      where: { id: existingForSha.id },
-      data: { manifest: args.manifest, version: args.version, appBlockId: args.appBlockId },
-    });
-    return;
-  }
-
-  // Supersede any OTHER still-pending request for this slug (older sha or a
-  // dev submitVersion) so the partial unique index (one pending per slug)
-  // doesn't reject the insert and the queue shows the newest unreviewed sha.
-  await dbWrite.appBlockPublishRequest.updateMany({
-    where: { slug: args.slug, status: 'pending' },
-    data: { status: 'withdrawn' },
-  });
-
-  const ownerUserId = await resolvePushOwnerUserId(args.appBlockId);
-  const publishRequestId = `pubreq_${newUlid()}`;
-
-  // Park the review IMMEDIATELY with an empty summary, then enrich the real
-  // file/manifest diff + bundle size OFF the response path (below). A full
-  // Forgejo bundle reconstruct inline would (a) add seconds to the webhook
-  // response and (b) widen the supersede→create window enough for concurrent
-  // pushes to collide on the one-pending-per-slug index. The mod-review modal's
-  // "View code in Forgejo @ sha" link works regardless; the diff fills in within
-  // a moment. The empty summary is the durable fallback if enrichment never lands.
-  await dbWrite.appBlockPublishRequest.create({
-    data: {
-      id: publishRequestId,
-      appBlockId: args.appBlockId,
-      slug: args.slug,
-      submittedByUserId: ownerUserId,
-      version: args.version,
-      manifest: args.manifest,
-      // No bundle: the webhook doesn't receive the ZIP. The Forgejo repo at
-      // forgejoCommitSha IS the reviewable artifact; mods browse it directly.
-      // bundleKey stays empty as the push-originated marker.
-      bundleKey: '',
-      bundleSha256: '',
-      bundleSizeBytes: BigInt(0),
-      fileSummary: { files: [], added: [], removed: [], changed: [] },
-      manifestDiffSummary: {
-        kind: 'first-version' as const,
-        fields: Object.keys(args.manifest as Record<string, unknown>).sort(),
-      },
-      status: 'pending',
-      forgejoCommitSha: args.sha,
-    },
-  });
-
-  // Fire-and-forget: fill in the real diff + bundle size so the mod sees actual
-  // changes (added/changed/removed) instead of 0 files + a misleading
-  // "first-version" label. enrichPushRequestRow has its own try/catch + is
-  // scoped to status='pending', so it never gates the park and can't clobber a
-  // row that was approved/rejected/superseded in the meantime. civitai-web is a
-  // long-lived server, so the microtask completes after the 202.
-  void (async () => {
-    const { enrichPushRequestRow } = await import(
-      '~/server/services/blocks/publish-request.service'
-    );
-    await enrichPushRequestRow(publishRequestId, args.slug, args.sha);
-  })().catch(() => undefined); // guard the dynamic import itself (house convention: no unhandled rejection)
-}
-
-/**
- * Attribute the pending-review row to the app owner (the OauthClient.userId),
- * falling back to the app block's own app relation. submittedByUserId is a
- * required, FK-constrained column — we can't leave it null — and the app owner
- * is the most meaningful actor for an unreviewed push to their repo.
- */
-async function resolvePushOwnerUserId(appBlockId: string): Promise<number> {
-  const row = await dbRead.appBlock.findUnique({
-    where: { id: appBlockId },
-    select: { app: { select: { userId: true } } },
-  });
-  const userId = row?.app?.userId;
-  if (typeof userId !== 'number') {
-    throw new Error(`could not resolve owner userId for appBlock ${appBlockId}`);
-  }
-  return userId;
-}
 
 async function setCommitStatusSafe(args: Parameters<typeof setCommitStatus>[0]): Promise<void> {
   // Don't let a Forgejo flakiness in setCommitStatus mask the original

--- a/src/pages/apps/[appBlockId]/edit-manifest.tsx
+++ b/src/pages/apps/[appBlockId]/edit-manifest.tsx
@@ -1,0 +1,79 @@
+import { Anchor, Center, Container, Group, Loader, Stack } from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { ManifestEditForm } from '~/components/Apps/ManifestEditForm';
+import { Meta } from '~/components/Meta/Meta';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { getLoginLink } from '~/utils/login-helpers';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App management (Phase 1) — owner-only web manifest editor at
+ * `/apps/<appBlockId>/edit-manifest`.
+ *
+ * Gating: the SSR resolver enforces the appBlocks flag + a logged-in session
+ * (an anon caller is bounced to /login). The OWNER check is enforced at the
+ * tRPC layer — `getMyAppManifest` (and `updateManifest`) throw FORBIDDEN for a
+ * non-owner — so this page surfaces NotFound when the query errors. Single-
+ * sourcing the owner gate server-side avoids drift between the SSR check and the
+ * mutation check.
+ */
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  resolver: async ({ features, session, ctx }) => {
+    if (!features?.appBlocks) return { notFound: true };
+    if (!session?.user) {
+      return {
+        redirect: { destination: getLoginLink({ returnUrl: ctx.resolvedUrl }), permanent: false },
+      };
+    }
+    return { props: {} };
+  },
+});
+
+export default function EditManifestPage() {
+  const features = useFeatureFlags();
+  const router = useRouter();
+  const appBlockId = typeof router.query.appBlockId === 'string' ? router.query.appBlockId : '';
+
+  const { data, isLoading, error } = trpc.blocks.getMyAppManifest.useQuery(
+    { appBlockId },
+    { enabled: !!features.appBlocks && !!appBlockId, retry: false }
+  );
+
+  if (!features.appBlocks) return <NotFound />;
+  // FORBIDDEN (non-owner) / NOT_FOUND both settle to NotFound (retry:false).
+  if (error) return <NotFound />;
+
+  return (
+    <>
+      <Meta title="Edit app manifest — Civitai Apps" deIndex />
+      <Container size="sm" py="md">
+        <Stack gap="lg">
+          <Anchor component={Link} href={`/apps/${appBlockId}`} size="sm">
+            <Group gap={4}>
+              <IconArrowLeft size={14} />
+              Back to app
+            </Group>
+          </Anchor>
+
+          {isLoading || !data ? (
+            <Center py="xl">
+              <Loader />
+            </Center>
+          ) : (
+            <ManifestEditForm
+              appBlockId={data.appBlockId}
+              slug={data.slug}
+              currentVersion={data.version}
+              manifest={data.manifest}
+            />
+          )}
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '@mantine/core';
 import {
   IconArrowLeft,
+  IconEdit,
   IconExternalLink,
   IconLock,
   IconPlugConnected,
@@ -114,6 +115,16 @@ export default function AppDetailPage() {
     return map;
   }, [mySubs, appBlockId]);
   const alreadySubscribed = Object.keys(existingByScope).length > 0;
+
+  // Owner-only probe: getMyAppManifest is owner-gated server-side (FORBIDDEN for
+  // a non-owner), so a successful response means the viewer owns this app — the
+  // "Edit manifest" affordance shows only then. retry:false so a non-owner's
+  // FORBIDDEN settles quietly without surfacing an error on the public page.
+  const { data: ownerManifest } = trpc.blocks.getMyAppManifest.useQuery(
+    { appBlockId },
+    { enabled: !!features.appBlocks && !!currentUser && !!appBlockId, retry: false }
+  );
+  const isOwner = !!ownerManifest;
   // Subscriptions for THIS app — feeds the reviews write-form gate (an enabled
   // install is required to review, mirroring the server gate).
   const mySubsForApp = useMemo(
@@ -238,6 +249,21 @@ export default function AppDetailPage() {
                   </Group>
                 </Stack>
                 <Group gap="xs" wrap="nowrap">
+                  {/* Owner-only "Edit manifest" affordance — opens the Phase 1
+                      web manifest editor. Gated on isOwner (a successful
+                      owner-only getMyAppManifest). Shown only for an approved app
+                      (the canonical repo exists only after first ZIP approval —
+                      the editor server-side rejects non-approved apps anyway). */}
+                  {isOwner && ownerManifest?.status === 'approved' && (
+                    <Button
+                      component={Link}
+                      href={`/apps/${appBlockId}/edit-manifest`}
+                      variant="default"
+                      leftSection={<IconEdit size={16} />}
+                    >
+                      Edit manifest
+                    </Button>
+                  )}
                   {isExternal ? (
                     /* Off-site (external-link) app: the external URL is the
                        PRIMARY (filled) CTA — opens off-site in a new tab. No

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -177,6 +177,22 @@ describe('blocks.getMyForgejoCloneInfo — Phase 2 CLI pull credential', () => {
     );
   });
 
+  it('banned owner: FORBIDDEN, nothing provisioned', async () => {
+    findUnique.mockResolvedValue({
+      blockId: 'my-app',
+      status: 'approved',
+      app: { userId: ownerUser.id },
+    });
+    const caller = blocksRouter.createCaller(
+      fakeCtx({ ...ownerUser, bannedAt: new Date('2026-01-01') }) as never
+    );
+    await expect(caller.getMyForgejoCloneInfo({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+    expect(mockAddCollaborator).not.toHaveBeenCalled();
+  });
+
   it('neither appBlockId nor slug: input validation error (BAD_REQUEST)', async () => {
     const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
     await expect(caller.getMyForgejoCloneInfo({} as never)).rejects.toMatchObject({

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App management (Phase 2) — `blocks.getMyForgejoCloneInfo` router coverage.
+ * Backs the read-only `civitai app pull` CLI command. Owner-gated identically to
+ * getMyAppRepo; lazily provisions the per-user Forgejo identity + grants READ on
+ * the slug repo, and returns the tokened clone URL the CLI assembles its git
+ * command from.
+ *
+ * GATING INVARIANTS pinned here:
+ *   - anon → UNAUTHORIZED; nothing provisioned.
+ *   - non-owner → FORBIDDEN; nothing provisioned.
+ *   - owner, NOT approved → notYetAvailable; nothing provisioned.
+ *   - owner, approved (by slug) → provisions identity, grants READ, returns the
+ *     tokened cloneUrl + the raw token.
+ */
+
+const { mockIsAppBlocksEnabled, mockEnsureForgejoIdentity, mockAddCollaborator } = vi.hoisted(
+  () => ({
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockEnsureForgejoIdentity: vi.fn(),
+    mockAddCollaborator: vi.fn(),
+  })
+);
+
+vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/env/server', () => ({
+  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', APPS_DOMAIN: 'civit.ai', LOGGING: '' },
+}));
+vi.mock('~/server/services/blocks/dev-git-access.service', () => ({
+  ensureForgejoIdentity: mockEnsureForgejoIdentity,
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  FORGEJO_ORG: 'civitai-apps',
+  addCollaborator: mockAddCollaborator,
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    getAppDetail: vi.fn(),
+    getFeaturedBlocks: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({ getOrchestratorToken: vi.fn() }));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn(), findFirst: vi.fn() } },
+  dbWrite: {},
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn() },
+  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/rewards/active/appBlockReview.reward', () => ({
+  appBlockReviewReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/appBlockReview.service', () => ({
+  upsertAppBlockReview: vi.fn(),
+  listAppBlockReviews: vi.fn(),
+  getMyAppBlockReview: vi.fn(),
+  setAppReviewExcluded: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { dbRead } from '~/server/db/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: true } as never,
+    track: undefined,
+  };
+}
+
+const ownerUser = { id: 7, isModerator: false, tier: 'free', username: 'owner' };
+const otherUser = { id: 99, isModerator: false, tier: 'free', username: 'intruder' };
+
+const findUnique = dbRead.appBlock.findUnique as ReturnType<typeof vi.fn>;
+const findFirst = dbRead.appBlock.findFirst as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset().mockResolvedValue(true);
+  mockEnsureForgejoIdentity
+    .mockReset()
+    .mockResolvedValue({ forgejoUsername: 'dev-7', token: 'minted-token-sha1' });
+  mockAddCollaborator.mockReset().mockResolvedValue(undefined);
+  findUnique.mockReset();
+  findFirst.mockReset();
+});
+
+describe('blocks.getMyForgejoCloneInfo — Phase 2 CLI pull credential', () => {
+  it('anon: UNAUTHORIZED, nothing provisioned', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getMyForgejoCloneInfo({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+  });
+
+  it('non-owner: FORBIDDEN, nothing provisioned', async () => {
+    findUnique.mockResolvedValue({ blockId: 'my-app', status: 'approved', app: { userId: ownerUser.id } });
+    const caller = blocksRouter.createCaller(fakeCtx(otherUser) as never);
+    await expect(caller.getMyForgejoCloneInfo({ appBlockId: 'ab_1' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+  });
+
+  it('owner, NOT approved: notYetAvailable, nothing provisioned', async () => {
+    findUnique.mockResolvedValue({ blockId: 'my-app', status: 'pending', app: { userId: ownerUser.id } });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    const res = await caller.getMyForgejoCloneInfo({ appBlockId: 'ab_1' });
+    expect(res.notYetAvailable).toBe(true);
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+  });
+
+  it('owner, approved, BY SLUG: provisions identity, grants READ, returns tokened cloneUrl + token', async () => {
+    findFirst.mockResolvedValue({ blockId: 'my-app', status: 'approved', app: { userId: ownerUser.id } });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    const res = await caller.getMyForgejoCloneInfo({ slug: 'my-app' });
+
+    expect(res.notYetAvailable).toBe(false);
+    expect(res.slug).toBe('my-app');
+    expect(res.forgejoUsername).toBe('dev-7');
+    expect(res.token).toBe('minted-token-sha1');
+    expect(mockEnsureForgejoIdentity).toHaveBeenCalledWith(7);
+    // READ (not write) is enough to pull.
+    expect(mockAddCollaborator).toHaveBeenCalledWith({
+      slug: 'my-app',
+      username: 'dev-7',
+      permission: 'read',
+    });
+    expect(res.httpUrl).toBe('https://forgejo.civitai.com/civitai-apps/my-app.git');
+    expect(res.cloneUrl).toBe(
+      'https://dev-7:minted-token-sha1@forgejo.civitai.com/civitai-apps/my-app.git'
+    );
+  });
+
+  it('neither appBlockId nor slug: input validation error (BAD_REQUEST)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(caller.getMyForgejoCloneInfo({} as never)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App management (Phase 1) — `blocks.updateManifest` router coverage.
+ * Drives the REAL blocks router so the middleware chain (`protectedProcedure`
+ * → isAuthed, `enforceAppBlocksFlag`) + the owner / approved / immutability /
+ * validation gates decide the outcome. The Forgejo commit, the validator, and
+ * the pending-review recorder are mocked at the module boundary so this suite
+ * exercises the GATES + the server-derived commit, not the downstream services.
+ *
+ * GATING / SAFETY INVARIANTS pinned here (each FAILS if its gate is dropped):
+ *   - anon → UNAUTHORIZED; nothing committed.
+ *   - non-owner → FORBIDDEN; nothing committed.
+ *   - owner, app NOT approved → PRECONDITION_FAILED; nothing committed.
+ *   - invalid manifest (validator reject) → BAD_REQUEST; nothing committed.
+ *   - version not strictly greater → BAD_REQUEST; nothing committed.
+ *   - owner + valid → commitFiles called with the SERVER-derived slug + the
+ *     merged manifest (blockId forced to the slug), then recordPendingFromPush
+ *     records a PENDING review (no auto-approve / no deploy).
+ *   - immutable blockId: even if the merged manifest's stored blockId differs
+ *     from the slug, the committed manifest carries the SLUG.
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockCommitFiles,
+  mockRecordPending,
+  mockValidate,
+  mockStamp,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockCommitFiles: vi.fn(),
+  mockRecordPending: vi.fn(),
+  mockValidate: vi.fn(),
+  mockStamp: vi.fn(),
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+vi.mock('~/env/server', () => ({
+  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', APPS_DOMAIN: 'civit.ai', LOGGING: '' },
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  FORGEJO_ORG: 'civitai-apps',
+  commitFiles: mockCommitFiles,
+  addCollaborator: vi.fn(),
+}));
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  recordPendingFromPush: mockRecordPending,
+}));
+vi.mock('~/server/services/block-manifest-validator.service', () => ({
+  BlockManifestValidator: { validate: mockValidate },
+}));
+vi.mock('~/server/services/blocks/manifest-normalize', () => ({
+  stampCanonicalIframeSrc: mockStamp,
+}));
+// publish-request.schema is a pure module (regexes + zod schemas) — use the
+// REAL one so the router's static imports (withdrawRequestSchema, etc.) resolve
+// and SEMVER_REGEX is the canonical pattern.
+
+// --- the rest of the router's static import graph (stubbed, as in getMyAppRepo) ---
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    getAppDetail: vi.fn(),
+    getFeaturedBlocks: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({ getOrchestratorToken: vi.fn() }));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbWrite: {},
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn() },
+  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
+  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/rewards/active/appBlockReview.reward', () => ({
+  appBlockReviewReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/appBlockReview.service', () => ({
+  upsertAppBlockReview: vi.fn(),
+  listAppBlockReviews: vi.fn(),
+  getMyAppBlockReview: vi.fn(),
+  setAppReviewExcluded: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { dbRead } from '~/server/db/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: true } as never,
+    track: undefined,
+  };
+}
+
+const ownerUser = { id: 7, isModerator: false, tier: 'free', username: 'owner' };
+const otherUser = { id: 99, isModerator: false, tier: 'free', username: 'intruder' };
+
+const findUnique = dbRead.appBlock.findUnique as ReturnType<typeof vi.fn>;
+
+const approvedBlock = {
+  id: 'ab_1',
+  blockId: 'my-app',
+  status: 'approved',
+  version: '1.0.0',
+  manifest: { blockId: 'my-app', version: '1.0.0', name: 'My App', scopes: ['models:read:self'] },
+  app: { userId: ownerUser.id, allowedScopes: 1, allowedOrigins: ['https://my-app.civit.ai'] },
+};
+
+const validPatch = { version: '1.0.1', name: 'My App v2', contentRating: 'g', scopes: [] as string[] };
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset().mockResolvedValue(true);
+  mockCommitFiles.mockReset().mockResolvedValue({ sha: 'a'.repeat(40) });
+  mockRecordPending.mockReset().mockResolvedValue({ publishRequestId: 'pubreq_x' });
+  mockValidate.mockReset().mockReturnValue({ valid: true });
+  mockStamp.mockReset().mockImplementation((m: Record<string, unknown>) => m);
+  findUnique.mockReset();
+});
+
+describe('blocks.updateManifest — Phase 1 web manifest editor', () => {
+  it('anon: UNAUTHORIZED, nothing committed', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(
+      caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it('non-owner: FORBIDDEN, nothing committed', async () => {
+    findUnique.mockResolvedValue(approvedBlock);
+    const caller = blocksRouter.createCaller(fakeCtx(otherUser) as never);
+    await expect(
+      caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+  });
+
+  it('owner but block missing: NOT_FOUND', async () => {
+    findUnique.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({ appBlockId: 'nope', patch: validPatch })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('owner, app NOT approved: PRECONDITION_FAILED, nothing committed', async () => {
+    findUnique.mockResolvedValue({ ...approvedBlock, status: 'pending' });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch })
+    ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+  });
+
+  it('version not strictly greater: BAD_REQUEST, nothing committed', async () => {
+    findUnique.mockResolvedValue(approvedBlock);
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({ appBlockId: 'ab_1', patch: { ...validPatch, version: '1.0.0' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+  });
+
+  it('invalid manifest (validator reject) → BAD_REQUEST, nothing committed', async () => {
+    findUnique.mockResolvedValue(approvedBlock);
+    mockValidate.mockReturnValue({ valid: false, errors: ['scope "x" is not a known block scope'] });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it('over-scope manifest is rejected via the SERVER validator (scope-subset gate runs)', async () => {
+    findUnique.mockResolvedValue(approvedBlock);
+    mockValidate.mockReturnValue({
+      valid: false,
+      errors: ['requested scopes exceed OAuth client allowedScopes: models:write:self'],
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({
+        appBlockId: 'ab_1',
+        patch: { ...validPatch, scopes: ['models:write:self'] },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    // The validator was called with the app's OauthClient context (the
+    // allowedScopes bitmask + allowedOrigins), i.e. the subset check actually ran.
+    expect(mockValidate).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ allowedScopes: 1, allowedOrigins: ['https://my-app.civit.ai'] })
+    );
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+  });
+
+  it('owner + valid: commits server-derived slug + merged manifest, records a PENDING review', async () => {
+    findUnique.mockResolvedValue(approvedBlock);
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    const res = await caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch });
+
+    expect(res.status).toBe('pending');
+    expect(res.slug).toBe('my-app');
+    expect(res.version).toBe('1.0.1');
+    expect(res.publishRequestId).toBe('pubreq_x');
+
+    // Committed to the canonical org + the SERVER-derived slug, only the manifest
+    // file, with the new version baked in.
+    expect(mockCommitFiles).toHaveBeenCalledTimes(1);
+    const commitArg = mockCommitFiles.mock.calls[0][0];
+    expect(commitArg.org).toBe('civitai-apps');
+    expect(commitArg.slug).toBe('my-app');
+    expect(commitArg.files).toHaveLength(1);
+    expect(commitArg.files[0].path).toBe('block.manifest.json');
+    const committed = JSON.parse(commitArg.files[0].content.toString('utf8'));
+    expect(committed.version).toBe('1.0.1');
+    expect(committed.name).toBe('My App v2');
+
+    // PENDING review recorded (no auto-approve / no deploy) with the commit sha.
+    expect(mockRecordPending).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'my-app', sha: 'a'.repeat(40), appBlockId: 'ab_1', version: '1.0.1' })
+    );
+  });
+
+  it('immutable blockId: the committed manifest carries the SLUG even if the stored manifest blockId drifted', async () => {
+    // Stored manifest has a stale/wrong blockId; the slug (block.blockId) is the
+    // source of truth and must win in the committed manifest.
+    findUnique.mockResolvedValue({
+      ...approvedBlock,
+      manifest: { ...approvedBlock.manifest, blockId: 'WRONG-old-slug' },
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch });
+
+    const commitArg = mockCommitFiles.mock.calls[0][0];
+    const committed = JSON.parse(commitArg.files[0].content.toString('utf8'));
+    expect(committed.blockId).toBe('my-app');
+    // And the validator saw the slug-forced manifest too.
+    const validated = mockValidate.mock.calls[0][0] as { blockId: string };
+    expect(validated.blockId).toBe('my-app');
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -340,4 +340,52 @@ describe('blocks.updateManifest — Phase 1 web manifest editor', () => {
     const validated = mockValidate.mock.calls[0][0] as { blockId: string };
     expect(validated.blockId).toBe('my-app');
   });
+
+  it('server-owned trustTier: a client patch tier is OVERRIDDEN to the stored tier in the committed bytes AND the value the validator saw', async () => {
+    // trustTier is moderator-controlled, NOT publisher-declared. The stored row
+    // has trustTier=unverified; the client patch tries to self-declare the most
+    // privileged tier (`internal`, which grants allow-same-origin in the sandbox
+    // allowlist). The server must force the merged manifest's trustTier back to
+    // the STORED value BEFORE validating + committing — so the validator gates
+    // the sandbox against the real tier, and the pending row records the real
+    // tier. Mirrors how submitVersion/approveRequest re-stamp it.
+    findUnique.mockResolvedValue({
+      ...approvedBlock,
+      trustTier: 'unverified',
+      // Stored manifest also carries a (possibly drifted) tier — must not survive.
+      manifest: { ...approvedBlock.manifest, trustTier: 'verified' },
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await caller.updateManifest({
+      appBlockId: 'ab_1',
+      patch: { ...validPatch, trustTier: 'internal' },
+    });
+
+    const commitArg = mockCommitFiles.mock.calls[0][0];
+    const committed = JSON.parse(commitArg.files[0].content.toString('utf8'));
+    // The committed bytes carry the STORED tier, not the client-claimed one.
+    expect(committed.trustTier).toBe('unverified');
+    expect(commitArg.files[0].content.toString('utf8')).not.toContain('internal');
+    // And the validator (the sandbox-allowlist security boundary) saw the stored
+    // tier — never the self-declared `internal`.
+    const validated = mockValidate.mock.calls[0][0] as { trustTier: string };
+    expect(validated.trustTier).toBe('unverified');
+  });
+
+  it('server-owned trustTier: with no stored tier on the row it defaults to `unverified` (never the patched value)', async () => {
+    // approvedBlock has no trustTier field at all (null/undefined on the row) —
+    // the override must fall back to `unverified`, not honour the client patch.
+    findUnique.mockResolvedValue(approvedBlock);
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await caller.updateManifest({
+      appBlockId: 'ab_1',
+      patch: { ...validPatch, trustTier: 'internal' },
+    });
+
+    const validated = mockValidate.mock.calls[0][0] as { trustTier: string };
+    expect(validated.trustTier).toBe('unverified');
+    const commitArg = mockCommitFiles.mock.calls[0][0];
+    const committed = JSON.parse(commitArg.files[0].content.toString('utf8'));
+    expect(committed.trustTier).toBe('unverified');
+  });
 });

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -270,6 +270,59 @@ describe('blocks.updateManifest — Phase 1 web manifest editor', () => {
     );
   });
 
+  it('banned owner: FORBIDDEN, nothing committed', async () => {
+    findUnique.mockResolvedValue(approvedBlock);
+    const caller = blocksRouter.createCaller(
+      fakeCtx({ ...ownerUser, bannedAt: new Date('2026-01-01') }) as never
+    );
+    await expect(
+      caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it('SSRF: a client-supplied off-origin iframe.src is OVERWRITTEN to the canonical per-app subdomain in the committed bytes', async () => {
+    // iframe.src is platform-owned. Even if the client smuggles a hostile
+    // off-origin URL (an SSRF / origin-confusion vector) through the patch, the
+    // server unconditionally stamps the canonical `https://<slug>.<APPS_DOMAIN>/`
+    // before committing. Use the REAL stamper here (not the pass-through mock)
+    // so this asserts the actual normalization, on the bytes that get committed.
+    mockStamp.mockImplementation(
+      (m: Record<string, unknown>, slug: string, appsDomain: string) => {
+        const existing =
+          m.iframe && typeof m.iframe === 'object' && !Array.isArray(m.iframe)
+            ? (m.iframe as Record<string, unknown>)
+            : {};
+        m.iframe = { ...existing, src: `https://${slug}.${appsDomain}/` };
+        return m;
+      }
+    );
+    findUnique.mockResolvedValue({
+      ...approvedBlock,
+      // Stored manifest already carries a hostile src; the patch tries to set
+      // another one. Neither must survive the stamp.
+      manifest: { ...approvedBlock.manifest, iframe: { src: 'https://evil.example.com/steal' } },
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await caller.updateManifest({
+      appBlockId: 'ab_1',
+      // The input schema doesn't accept iframe.src, but a stored/leaked hostile
+      // value (above) must still be overwritten — assert on the committed bytes.
+      patch: validPatch,
+    });
+
+    const commitArg = mockCommitFiles.mock.calls[0][0];
+    const committed = JSON.parse(commitArg.files[0].content.toString('utf8'));
+    expect(committed.iframe.src).toBe('https://my-app.civit.ai/');
+    // The hostile origin is gone from the committed manifest.
+    expect(commitArg.files[0].content.toString('utf8')).not.toContain('evil.example.com');
+    // The validator also saw the canonical-stamped manifest (the security
+    // boundary runs AFTER the stamp).
+    const validated = mockValidate.mock.calls[0][0] as { iframe: { src: string } };
+    expect(validated.iframe.src).toBe('https://my-app.civit.ai/');
+  });
+
   it('immutable blockId: the committed manifest carries the SLUG even if the stored manifest blockId drifted', async () => {
     // Stored manifest has a stale/wrong blockId; the slug (block.blockId) is the
     // source of truth and must win in the committed manifest.

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3098,7 +3098,389 @@ export const blocksRouter = router({
         firstVersionIsZip: false as const,
       };
     }),
+
+  /**
+   * App management (Phase 1) — return the FULL stored manifest for one of the
+   * caller's OWN apps so the web editor can pre-fill the edit form. Owner-gated
+   * exactly like getMyAppRepo (OauthClient.userId is the v1 ownership source of
+   * truth). Distinct from the public getAppDetail (which returns only the
+   * PublicAppDetail allowlist, no scopes/full manifest) — this is the owner's
+   * own private read.
+   */
+  getMyAppManifest: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(z.object({ appBlockId: z.string().min(1).max(64) }))
+    .query(async ({ ctx, input }) => {
+      if (!ctx.features.appBlocks) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'App Blocks is not available to this account',
+        });
+      }
+      const block = await dbRead.appBlock.findUnique({
+        where: { id: input.appBlockId },
+        select: {
+          id: true,
+          blockId: true,
+          status: true,
+          version: true,
+          manifest: true,
+          app: {
+            select: { userId: true, allowedScopes: true, allowedOrigins: true },
+          },
+        },
+      });
+      if (!block) throw throwNotFoundError('App block not found');
+      if (block.app?.userId !== ctx.user!.id) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
+      }
+      return {
+        appBlockId: block.id,
+        slug: block.blockId,
+        status: block.status,
+        version: block.version,
+        manifest: block.manifest as Record<string, unknown>,
+        // Surfaced so the client can preview which scopes/origins the edit is
+        // bounded by (the SERVER re-derives + enforces these on save — the
+        // client copy is advisory only).
+        allowedScopes: block.app?.allowedScopes ?? 0,
+        allowedOrigins: block.app?.allowedOrigins ?? [],
+      };
+    }),
+
+  /**
+   * App management (Phase 1) — edit an app's manifest from the web UI. On save
+   * this does a BACKGROUND commit of the new block.manifest.json to the app's
+   * canonical Forgejo repo (civitai-apps/<slug>), which RE-ENTERS the existing
+   * no-trust review flow: the commit is recorded as a `pending` publish request
+   * and NEVER auto-approves or deploys. A moderator must approve it through the
+   * existing /apps/review → approveRequest → build → deploy path.
+   *
+   * HARD RULES enforced here:
+   *   - OWNER-only (OauthClient.userId), authenticated, app must be `approved`
+   *     (the canonical repo only exists after the first ZIP approval).
+   *   - blockId is IMMUTABLE — the caller cannot rename the slug; we force the
+   *     merged manifest's blockId back to the stored slug.
+   *   - iframe.src is platform-owned — re-stamped to the canonical subdomain.
+   *   - the merged manifest is RE-VALIDATED server-side with
+   *     BlockManifestValidator against the app's OauthClient context (scope
+   *     subset + allowedOrigins SSRF binding) — the client manifest is NEVER
+   *     trusted.
+   *   - version must strictly increase (semver) so each edit is a new version.
+   *
+   * The commit itself fires the git-push webhook too, but we ALSO call
+   * recordPendingFromPush explicitly (idempotent at (slug, sha)) so the editor
+   * gets a stable publishRequestId back without depending on webhook delivery.
+   */
+  updateManifest: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z.object({
+        appBlockId: z.string().min(1).max(64),
+        // Editable manifest fields. blockId / iframe.src are intentionally
+        // ABSENT — blockId is immutable (forced server-side) and iframe.src is
+        // platform-owned (stamped server-side). Everything is optional so the
+        // client can send a sparse patch; we deep-merge onto the stored manifest.
+        patch: z
+          .object({
+            name: z.string().min(1).max(200).optional(),
+            // New version — REQUIRED so every manifest edit is a distinct
+            // version (mirrors a ZIP submitVersion). Must strictly exceed the
+            // stored version (checked below).
+            version: z.string().min(1).max(64),
+            contentRating: z.string().min(1).max(8).optional(),
+            renderMode: z.string().min(1).max(16).optional(),
+            trustTier: z.string().min(1).max(16).optional(),
+            description: z.string().max(5000).optional(),
+            scopes: z.array(z.string().min(1).max(128)).max(64).optional(),
+            publicSettingsKeys: z.array(z.string().min(1).max(64)).max(32).optional(),
+            targets: z
+              .array(z.object({ slotId: z.string().min(1).max(64) }).passthrough())
+              .max(16)
+              .optional(),
+            page: z
+              .object({
+                path: z.string().min(1).max(256),
+                title: z.string().min(1).max(128),
+                icon: z.string().max(128).optional(),
+                buzzBudgetPerGen: z.number().int().positive().optional(),
+              })
+              .passthrough()
+              .nullable()
+              .optional(),
+            // Editable iframe sub-fields (NOT src — that's platform-owned).
+            iframe: z
+              .object({
+                minHeight: z.number().optional(),
+                maxHeight: z.number().nullable().optional(),
+                resizable: z.boolean().optional(),
+                sandbox: z.string().max(256).optional(),
+              })
+              .partial()
+              .optional(),
+          })
+          .strict(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.features.appBlocks) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'App Blocks is not available to this account',
+        });
+      }
+
+      const block = await dbRead.appBlock.findUnique({
+        where: { id: input.appBlockId },
+        select: {
+          id: true,
+          blockId: true,
+          status: true,
+          version: true,
+          manifest: true,
+          app: { select: { userId: true, allowedScopes: true, allowedOrigins: true } },
+        },
+      });
+      if (!block) throw throwNotFoundError('App block not found');
+      // Owner gate — OauthClient.userId is the v1 ownership source of truth.
+      if (block.app?.userId !== ctx.user!.id) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
+      }
+      // A banned/suspended account must not be able to mutate a live app.
+      if (ctx.user!.bannedAt) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Account is not eligible to edit apps',
+        });
+      }
+      // The canonical Forgejo repo only exists once the first version is
+      // ZIP-approved (approveRequest pre-creates civitai-apps/<slug>); until
+      // then there's nothing to commit to.
+      if (block.status !== 'approved') {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message:
+            'Your first version must be submitted as a ZIP and approved before you can edit the manifest from the web.',
+        });
+      }
+
+      const slug = block.blockId;
+      const { patch } = input;
+
+      // Merge the patch onto the STORED manifest (the source of truth) — never
+      // trust a client-supplied full manifest. Deep-merge `iframe` so the
+      // editable sub-fields override but the platform-owned `src` survives the
+      // merge (it's then re-stamped below regardless).
+      const stored = (block.manifest ?? {}) as Record<string, unknown>;
+      const storedIframe =
+        stored.iframe && typeof stored.iframe === 'object' && !Array.isArray(stored.iframe)
+          ? (stored.iframe as Record<string, unknown>)
+          : {};
+      const merged: Record<string, unknown> = {
+        ...stored,
+        ...patch,
+        // blockId is IMMUTABLE — force back to the stored slug regardless of
+        // anything the client sent (the input schema doesn't even accept it, but
+        // belt-and-suspenders against a future schema widening).
+        blockId: slug,
+        iframe: { ...storedIframe, ...(patch.iframe ?? {}) },
+      };
+
+      // version must STRICTLY increase so each edit is a new, ordered version
+      // (mirrors a ZIP submitVersion). Reject equal/lower to keep the version
+      // monotonic and avoid a no-op review churn.
+      const { SEMVER_REGEX } = await import('~/server/schema/blocks/publish-request.schema');
+      const newVersion = patch.version;
+      if (!SEMVER_REGEX.test(newVersion)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `version "${newVersion}" must be semver (e.g. 1.2.3)`,
+        });
+      }
+      if (compareSemver(newVersion, block.version) <= 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `version must be greater than the current version (${block.version})`,
+        });
+      }
+      merged.version = newVersion;
+
+      // iframe.src is PLATFORM-OWNED — stamp the canonical per-app subdomain
+      // root so the validator's origin-binding + the webhook's exact-match gate
+      // both pass, exactly as submit/approve/git-push do.
+      const { stampCanonicalIframeSrc } = await import(
+        '~/server/services/blocks/manifest-normalize'
+      );
+      stampCanonicalIframeSrc(merged, slug, env.APPS_DOMAIN);
+
+      // RE-VALIDATE server-side against the app's OauthClient context. This is
+      // the security boundary: scope-subset + allowedOrigins SSRF binding are
+      // enforced here, never trusting the client. (The git-push webhook will
+      // also re-validate the committed manifest — defense in depth.)
+      const { BlockManifestValidator } = await import(
+        '~/server/services/block-manifest-validator.service'
+      );
+      const appContext = {
+        allowedScopes: block.app?.allowedScopes ?? 0,
+        allowedOrigins: (block.app?.allowedOrigins ?? []).map((o: string) => o.toLowerCase()),
+      };
+      const validation = BlockManifestValidator.validate(merged, appContext);
+      if (!validation.valid) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Invalid manifest: ${validation.errors.join('; ')}`,
+        });
+      }
+
+      // Background commit of the new manifest to the CANONICAL repo. We use the
+      // admin-token commitFiles (same call approveRequest uses) — Forgejo fires
+      // the push webhook regardless of which token committed, so this naturally
+      // re-enters the no-trust review path. replaceAllFiles is FALSE: we only
+      // touch block.manifest.json, leaving the app's source untouched.
+      const { commitFiles } = await import('~/server/services/blocks/forgejo.service');
+      const manifestJson = Buffer.from(JSON.stringify(merged, null, 2) + '\n', 'utf8');
+      const { sha } = await commitFiles({
+        org: FORGEJO_ORG,
+        slug,
+        files: [{ path: 'block.manifest.json', content: manifestJson }],
+        message: `Manifest update: ${slug} v${newVersion}`,
+      });
+
+      // Deterministically record the pending review (idempotent at (slug, sha)
+      // with the webhook the commit also fires). This is what makes the edit
+      // enter the SAME no-trust pending-review gate a direct git push does.
+      const { recordPendingFromPush } = await import(
+        '~/server/services/blocks/publish-request.service'
+      );
+      const { publishRequestId } = await recordPendingFromPush({
+        slug,
+        sha,
+        appBlockId: block.id,
+        manifest: merged,
+        version: newVersion,
+      });
+
+      return {
+        publishRequestId,
+        slug,
+        version: newVersion,
+        sha,
+        status: 'pending' as const,
+      };
+    }),
+
+  /**
+   * App management (Phase 2) — return the caller's per-user Forgejo clone info
+   * for one of THEIR apps, for the read-only `civitai app pull` CLI command.
+   * Owner-gated identically to getMyAppRepo; lazily provisions the scoped,
+   * restricted per-user Forgejo identity (ensureForgejoIdentity) and grants it
+   * read on the app's own civitai-apps/<slug> repo.
+   *
+   * Distinct from getMyAppRepo only in intent (pull/sync vs push instructions);
+   * it returns the raw { forgejoUsername, token, cloneUrl } the CLI assembles
+   * its git command from. The token is embedded in the returned cloneUrl exactly
+   * as getMyAppRepo does (the CLI documents the token-in-URL leakage caveat).
+   */
+  getMyForgejoCloneInfo: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    // Accept EITHER the appBlockId (ab_…) OR the slug (blockId / repo name) — the
+    // CLI `civitai app pull --app <slug|appBlockId>` lets a developer pass the
+    // human-friendly slug, which is the repo name they think in.
+    .input(
+      z
+        .object({
+          appBlockId: z.string().min(1).max(64).optional(),
+          slug: z.string().min(1).max(64).optional(),
+        })
+        .refine((v) => !!v.appBlockId || !!v.slug, {
+          message: 'one of appBlockId or slug is required',
+        })
+    )
+    .query(async ({ ctx, input }) => {
+      if (!ctx.features.appBlocks) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'App Blocks is not available to this account',
+        });
+      }
+      const block = input.appBlockId
+        ? await dbRead.appBlock.findUnique({
+            where: { id: input.appBlockId },
+            select: { blockId: true, status: true, app: { select: { userId: true } } },
+          })
+        : await dbRead.appBlock.findFirst({
+            where: { blockId: input.slug },
+            select: { blockId: true, status: true, app: { select: { userId: true } } },
+          });
+      if (!block) throw throwNotFoundError('App block not found');
+      if (block.app?.userId !== ctx.user!.id) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Not the app owner' });
+      }
+      if (ctx.user!.bannedAt) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Account is not eligible for git access',
+        });
+      }
+      const slug = block.blockId;
+      if (block.status !== 'approved') {
+        return {
+          notYetAvailable: true as const,
+          slug,
+          message:
+            'Your first version must be submitted as a ZIP and approved before git access is available.',
+        };
+      }
+
+      const { ensureForgejoIdentity } = await import(
+        '~/server/services/blocks/dev-git-access.service'
+      );
+      const { addCollaborator } = await import('~/server/services/blocks/forgejo.service');
+      const { forgejoUsername, token } = await ensureForgejoIdentity(ctx.user!.id);
+      // Read is enough to pull/sync; grant `read` (idempotent). getMyAppRepo
+      // grants `write` for the push flow — the CLI `pull` only needs read.
+      await addCollaborator({ slug, username: forgejoUsername, permission: 'read' });
+
+      const publicHost = env.FORGEJO_PUBLIC_URL.replace(/^https?:\/\//, '').replace(/\/$/, '');
+      const httpUrl = `https://${publicHost}/${FORGEJO_ORG}/${slug}.git`;
+      const cloneUrl = `https://${encodeURIComponent(forgejoUsername)}:${token}@${publicHost}/${FORGEJO_ORG}/${slug}.git`;
+
+      return {
+        notYetAvailable: false as const,
+        slug,
+        forgejoUsername,
+        token,
+        httpUrl,
+        cloneUrl,
+      };
+    }),
 });
+
+/**
+ * Compare two semver strings (x.y.z[-pre]). Returns -1 / 0 / 1 for a<b / a==b /
+ * a>b. Pre-release handling is intentionally simple: any prerelease is ordered
+ * BELOW its release (1.2.3-rc < 1.2.3) and two prereleases compare lexically —
+ * enough to enforce "the new version must strictly increase" for the manifest
+ * editor (the canonical SEMVER_REGEX already validated the shape).
+ */
+function compareSemver(a: string, b: string): number {
+  const split = (v: string): { nums: number[]; pre: string | null } => {
+    const [core, pre = null] = v.split('-', 2);
+    const nums = core.split('.').map((n) => parseInt(n, 10) || 0);
+    while (nums.length < 3) nums.push(0);
+    return { nums, pre };
+  };
+  const A = split(a);
+  const B = split(b);
+  for (let i = 0; i < 3; i++) {
+    if (A.nums[i] !== B.nums[i]) return A.nums[i] < B.nums[i] ? -1 : 1;
+  }
+  // Cores equal — a release outranks any prerelease of the same core.
+  if (A.pre === null && B.pre === null) return 0;
+  if (A.pre === null) return 1; // a is the release, b is a prerelease
+  if (B.pre === null) return -1;
+  return A.pre < B.pre ? -1 : A.pre > B.pre ? 1 : 0;
+}
 
 // Block-initiated workflows spend at PARITY with the on-site generator
 // (`getAllowedAccountTypes` / `resolveGenerationCurrencies`): the currencies

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3237,6 +3237,11 @@ export const blocksRouter = router({
           blockId: true,
           status: true,
           version: true,
+          // trustTier is SERVER-OWNED (moderator-controlled, NOT
+          // publisher-declared) — loaded so we can re-stamp it onto the merged
+          // manifest before validation (see below), mirroring
+          // submitVersion/approveRequest.
+          trustTier: true,
           manifest: true,
           app: { select: { userId: true, allowedScopes: true, allowedOrigins: true } },
         },
@@ -3312,6 +3317,17 @@ export const blocksRouter = router({
         '~/server/services/blocks/manifest-normalize'
       );
       stampCanonicalIframeSrc(merged, slug, env.APPS_DOMAIN);
+
+      // trustTier is SERVER-OWNED (moderator-controlled, NOT publisher-declared)
+      // — force it back to the tier already on the app's row regardless of what
+      // the client patched. Raising the tier is a deliberate out-of-band
+      // moderator/DB action, never a manifest field. This makes the validator
+      // below (which reads `manifest.trustTier` to gate the iframe sandbox
+      // allowlist) run against the tier we'll actually persist, exactly as
+      // submitVersion/approveRequest do — closing the gap where a client could
+      // self-declare `internal` to pass a sandbox/scope combo their real tier
+      // forbids.
+      merged.trustTier = block.trustTier ?? 'unverified';
 
       // RE-VALIDATE server-side against the app's OauthClient context. This is
       // the security boundary: scope-subset + allowedOrigins SSRF binding are

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -45,7 +45,9 @@ const {
         findUnique: vi.fn(),
         findMany: vi.fn(),
       },
-      appBlock: { findFirst: vi.fn() },
+      // `findUnique` added: recordPendingFromPush resolves the app owner's
+      // userId via dbRead.appBlock.findUnique({ app: { userId } }).
+      appBlock: { findFirst: vi.fn(), findUnique: vi.fn() },
       user: { findUnique: vi.fn() },
       // Added 2026-05-28 for C-2 fix: approveRequest now reads the
       // OauthClient row after a P2002 collision to recover the existing
@@ -59,11 +61,15 @@ const {
       // `findUnique` added (S1 TOCTOU fix): withdrawRequest re-reads the row from
       // the PRIMARY when its status-guarded updateMany matches 0 rows, to resolve
       // a lost race without being fooled by replica lag.
+      // `findFirst` added: recordPendingFromPush reads the existing pending row
+      // for (slug,sha) off the PRIMARY (existingForSha refresh + the P2002
+      // race re-read of the winner) via dbWrite.
       appBlockPublishRequest: {
         create: vi.fn(),
         update: vi.fn(),
         updateMany: vi.fn(),
         findUnique: vi.fn(),
+        findFirst: vi.fn(),
       },
       appBlock: { create: vi.fn(), update: vi.fn() },
       // `update` added 2026-06-02 (audit A1 fix): approveRequest now re-caps
@@ -2077,5 +2083,171 @@ describe('reconstructBundleFromForgejo', () => {
     const b = await reconstructBundleFromForgejo('hello', 'pushsha123');
 
     expect(a.equals(b)).toBe(true);
+  });
+});
+
+// ---- recordPendingFromPush -------------------------------------------------
+//
+// The no-trust-on-push recorder: a direct git push OR the web manifest editor
+// parks a `pending` review row for an UNREVIEWED (slug, sha) commit. The
+// riskiest branch is the P2002 same-commit race catch (the fix this PR adds):
+// the loser of a concurrent create re-reads the winner's pending row and
+// returns its id instead of throwing. The router tests mock this function at
+// the module boundary, so these are its only direct tests.
+//
+// P2002 is faked with the file-local idiom (`Object.assign(new Error(), { code:
+// 'P2002' })`) — the service only inspects `err.code === 'P2002'`, matching the
+// spend-attribution.service.test.ts FakePrismaKnownError pattern.
+describe('recordPendingFromPush', () => {
+  const pushArgs = {
+    slug: 'hello',
+    sha: 'pushsha-abc',
+    appBlockId: 'apb_hello',
+    manifest: manifest(),
+    version: '0.1.0',
+  };
+
+  // The supersede→create happy path fires `enrichPushRequestRow` fire-and-forget
+  // (void + .catch). Point its Forgejo tree at an empty Map so the async enrich
+  // resolves harmlessly off the response path and never leaks an unhandled
+  // rejection into the assertions (it has its own try/catch + is .catch()'d).
+  function stubEnrichForgejoNoop() {
+    mockForgejo.listRepoTreeAtRef.mockResolvedValue(new Map());
+    mockForgejo.getBlobContent.mockResolvedValue(Buffer.from(''));
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+  }
+
+  it('(a) existingForSha refresh path — updates the existing (slug,sha) pending row, no create', async () => {
+    const { recordPendingFromPush } = await import('../publish-request.service');
+    // A pending row for THIS exact (slug, sha) already exists → refresh + done.
+    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValueOnce({ id: 'pubreq_existing_sha' });
+    mockDbWrite.appBlockPublishRequest.update.mockResolvedValue(undefined);
+
+    const res = await recordPendingFromPush(pushArgs);
+
+    expect(res.publishRequestId).toBe('pubreq_existing_sha');
+    // Refreshed the existing row's manifest/version/appBlockId, no new create.
+    expect(mockDbWrite.appBlockPublishRequest.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'pubreq_existing_sha' },
+        data: expect.objectContaining({
+          manifest: pushArgs.manifest,
+          version: pushArgs.version,
+          appBlockId: pushArgs.appBlockId,
+        }),
+      })
+    );
+    expect(mockDbWrite.appBlockPublishRequest.create).not.toHaveBeenCalled();
+    // No supersede, no owner lookup — the early-return short-circuits them.
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockDbRead.appBlock.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('(b) supersede-then-create happy path — no existing row → supersedes other pending, then creates', async () => {
+    const { recordPendingFromPush } = await import('../publish-request.service');
+    stubEnrichForgejoNoop();
+    // No existing (slug,sha) pending row.
+    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValueOnce(null);
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValueOnce({ count: 1 }); // supersede
+    mockDbRead.appBlock.findUnique.mockResolvedValue({ app: { userId: 777 } });
+    mockDbWrite.appBlockPublishRequest.create.mockResolvedValue(undefined);
+
+    const res = await recordPendingFromPush(pushArgs);
+
+    // newUlid() runs once in beforeEach reset → first id is ...001.
+    expect(res.publishRequestId).toBe('pubreq_00000000000000000000000001');
+
+    // Superseded any OTHER still-pending request for the slug, THEN created.
+    expect(mockDbWrite.appBlockPublishRequest.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { slug: pushArgs.slug, status: 'pending' },
+        data: { status: 'withdrawn' },
+      })
+    );
+    expect(mockDbWrite.appBlockPublishRequest.create).toHaveBeenCalledOnce();
+    const createArg = mockDbWrite.appBlockPublishRequest.create.mock.calls[0][0];
+    expect(createArg.data.status).toBe('pending');
+    expect(createArg.data.slug).toBe(pushArgs.slug);
+    expect(createArg.data.forgejoCommitSha).toBe(pushArgs.sha);
+    expect(createArg.data.submittedByUserId).toBe(777); // resolved owner userId
+    // Push-originated marker: empty bundle pointers.
+    expect(createArg.data.bundleKey).toBe('');
+    expect(createArg.data.bundleSha256).toBe('');
+  });
+
+  it('(c) create throws P2002 → re-reads the EXACT-sha winner and returns its id', async () => {
+    const { recordPendingFromPush } = await import('../publish-request.service');
+    stubEnrichForgejoNoop();
+    const p2002 = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    // findFirst calls in order: (1) existingForSha (null) → falls through to
+    // create; create P2002s; (2) re-read exact-sha winner → found.
+    mockDbWrite.appBlockPublishRequest.findFirst
+      .mockResolvedValueOnce(null) // existingForSha miss
+      .mockResolvedValueOnce({ id: 'pubreq_winner_sha' }); // exact-sha winner on re-read
+    mockDbRead.appBlock.findUnique.mockResolvedValue({ app: { userId: 777 } });
+    mockDbWrite.appBlockPublishRequest.create.mockRejectedValueOnce(p2002);
+
+    const res = await recordPendingFromPush(pushArgs);
+
+    expect(res.publishRequestId).toBe('pubreq_winner_sha');
+    // Re-read was keyed on the exact (slug, sha).
+    expect(mockDbWrite.appBlockPublishRequest.findFirst).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { slug: pushArgs.slug, status: 'pending', forgejoCommitSha: pushArgs.sha },
+      })
+    );
+  });
+
+  it('(d) P2002 + only a DIFFERENT-sha pending row exists → returns that fallback row id', async () => {
+    const { recordPendingFromPush } = await import('../publish-request.service');
+    stubEnrichForgejoNoop();
+    const p2002 = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    // findFirst: (1) existingForSha miss; (2) exact-sha winner miss (null);
+    // (3) any-pending-for-slug fallback → the winner parked a NEWER sha.
+    mockDbWrite.appBlockPublishRequest.findFirst
+      .mockResolvedValueOnce(null) // existingForSha miss
+      .mockResolvedValueOnce(null) // exact-sha re-read miss
+      .mockResolvedValueOnce({ id: 'pubreq_newer_sha' }); // any-pending fallback
+    mockDbRead.appBlock.findUnique.mockResolvedValue({ app: { userId: 777 } });
+    mockDbWrite.appBlockPublishRequest.create.mockRejectedValueOnce(p2002);
+
+    const res = await recordPendingFromPush(pushArgs);
+
+    expect(res.publishRequestId).toBe('pubreq_newer_sha');
+    // Third findFirst is the slug-only fallback (no forgejoCommitSha filter).
+    expect(mockDbWrite.appBlockPublishRequest.findFirst).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ where: { slug: pushArgs.slug, status: 'pending' } })
+    );
+  });
+
+  it('(e) P2002 but NO pending row visible on re-read → re-throws', async () => {
+    const { recordPendingFromPush } = await import('../publish-request.service');
+    stubEnrichForgejoNoop();
+    const p2002 = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    // Both re-reads miss → the index fired but no pending row is visible.
+    mockDbWrite.appBlockPublishRequest.findFirst
+      .mockResolvedValueOnce(null) // existingForSha miss
+      .mockResolvedValueOnce(null) // exact-sha re-read miss
+      .mockResolvedValueOnce(null); // any-pending fallback miss
+    mockDbRead.appBlock.findUnique.mockResolvedValue({ app: { userId: 777 } });
+    mockDbWrite.appBlockPublishRequest.create.mockRejectedValueOnce(p2002);
+
+    await expect(recordPendingFromPush(pushArgs)).rejects.toMatchObject({ code: 'P2002' });
+  });
+
+  it('a non-P2002 create error is re-thrown unchanged (real failures are not swallowed)', async () => {
+    const { recordPendingFromPush } = await import('../publish-request.service');
+    stubEnrichForgejoNoop();
+    const dbErr = Object.assign(new Error('connection lost'), { code: 'P1001' });
+    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValueOnce(null); // existingForSha miss
+    mockDbRead.appBlock.findUnique.mockResolvedValue({ app: { userId: 777 } });
+    mockDbWrite.appBlockPublishRequest.create.mockRejectedValueOnce(dbErr);
+
+    await expect(recordPendingFromPush(pushArgs)).rejects.toMatchObject({ code: 'P1001' });
+    // Did NOT fall through to the P2002 winner re-read (only the existingForSha
+    // findFirst ran).
+    expect(mockDbWrite.appBlockPublishRequest.findFirst).toHaveBeenCalledOnce();
   });
 });

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1577,7 +1577,10 @@ export async function recordPendingFromPush(args: {
   // `app_block_publish_requests_one_pending_per_slug` ((slug) WHERE
   // status='pending') makes the loser's INSERT trip a P2002 — catch it, re-read
   // the winner's pending row, and return it (the loser no-ops gracefully
-  // instead of throwing). Mirrors submitVersion's C-4 catch.
+  // instead of throwing). NOTE: unlike submitVersion's C-4 catch (which THROWS
+  // a human-readable conflict error on P2002), this races to record the SAME
+  // commit, so the right outcome is to return the winner's id, not to surface a
+  // conflict — a same-commit re-delivery must be idempotent, not an error.
   try {
     await dbWrite.appBlockPublishRequest.create({
       data: {

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1493,6 +1493,115 @@ export async function enrichPushRequestRow(
 }
 
 /**
+ * Record (or refresh) a `pending` publish request for an UNREVIEWED commit to
+ * civitai-apps/<slug>:main. This is the canonical no-trust-on-push gate: a
+ * direct git push OR a background commit (e.g. the web manifest editor) cannot
+ * auto-approve or deploy, so we capture it as the same kind of review artifact a
+ * submitVersion produces and leave it for a moderator.
+ *
+ * The bundle bytes are NOT available here (the only inputs are the commit sha +
+ * the manifest at that sha), so this row's bundle pointers are left empty and a
+ * `forgejoCommitSha` is stored instead — a moderator reviews the code in the
+ * Forgejo repo directly. `approveRequest` already supports approving a `pending`
+ * request against the existing app_blocks row. The empty `bundleKey` is the
+ * durable PUSH-ORIGINATED marker (distinguishes a manifest-edit / git-push from
+ * a ZIP submitVersion).
+ *
+ * Idempotent at the (slug, sha) level: a re-delivery of the same commit (e.g.
+ * the git-push webhook AND an explicit caller both invoking this for the same
+ * sha) refreshes the existing pending row rather than stacking duplicates. Only
+ * ONE pending request per slug is allowed (matches the submitVersion invariant +
+ * the partial unique index), so a newer unreviewed sha supersedes an older
+ * still-pending one. Returns the publish-request id so a UI caller can deep-link
+ * the submitter to it.
+ *
+ * Extracted from the git-push webhook handler so both the webhook and the web
+ * manifest editor share ONE recorder (and one gate). The webhook still calls
+ * this; the editor calls it explicitly after its commit so it gets a stable
+ * publishRequestId back without depending on webhook delivery.
+ */
+export async function recordPendingFromPush(args: {
+  slug: string;
+  sha: string;
+  appBlockId: string;
+  manifest: object;
+  version: string;
+}): Promise<{ publishRequestId: string }> {
+  const [{ dbWrite, dbRead }, { newUlid }] = await Promise.all([
+    import('~/server/db/client'),
+    import('~/server/utils/app-block-ids'),
+  ]);
+
+  // Already captured this exact (slug, sha) as pending? Refresh + done.
+  const existingForSha = await dbWrite.appBlockPublishRequest.findFirst({
+    where: { slug: args.slug, status: 'pending', forgejoCommitSha: args.sha },
+    select: { id: true },
+  });
+  if (existingForSha) {
+    await dbWrite.appBlockPublishRequest.update({
+      where: { id: existingForSha.id },
+      data: { manifest: args.manifest, version: args.version, appBlockId: args.appBlockId },
+    });
+    return { publishRequestId: existingForSha.id };
+  }
+
+  // Supersede any OTHER still-pending request for this slug (older sha or a
+  // dev submitVersion) so the partial unique index (one pending per slug)
+  // doesn't reject the insert and the queue shows the newest unreviewed sha.
+  await dbWrite.appBlockPublishRequest.updateMany({
+    where: { slug: args.slug, status: 'pending' },
+    data: { status: 'withdrawn' },
+  });
+
+  // Attribute the row to the app owner (OauthClient.userId). submittedByUserId
+  // is required + FK-constrained, and the owner is the most meaningful actor for
+  // a commit to their repo.
+  const ownerRow = await dbRead.appBlock.findUnique({
+    where: { id: args.appBlockId },
+    select: { app: { select: { userId: true } } },
+  });
+  const ownerUserId = ownerRow?.app?.userId;
+  if (typeof ownerUserId !== 'number') {
+    throw new Error(`could not resolve owner userId for appBlock ${args.appBlockId}`);
+  }
+  const publishRequestId = `pubreq_${newUlid()}`;
+
+  // Park the review IMMEDIATELY with an empty summary, then enrich the real
+  // file/manifest diff OFF the response path (below). The empty summary is the
+  // durable fallback if enrichment never lands.
+  await dbWrite.appBlockPublishRequest.create({
+    data: {
+      id: publishRequestId,
+      appBlockId: args.appBlockId,
+      slug: args.slug,
+      submittedByUserId: ownerUserId,
+      version: args.version,
+      manifest: args.manifest,
+      // No bundle: the Forgejo repo at forgejoCommitSha IS the reviewable
+      // artifact; mods browse it directly. bundleKey stays empty as the
+      // push-originated marker.
+      bundleKey: '',
+      bundleSha256: '',
+      bundleSizeBytes: BigInt(0),
+      fileSummary: { files: [], added: [], removed: [], changed: [] },
+      manifestDiffSummary: {
+        kind: 'first-version' as const,
+        fields: Object.keys(args.manifest as Record<string, unknown>).sort(),
+      },
+      status: 'pending',
+      forgejoCommitSha: args.sha,
+    },
+  });
+
+  // Fire-and-forget: fill in the real diff + bundle size. enrichPushRequestRow
+  // has its own try/catch + is scoped to status='pending', so it never gates the
+  // park and can't clobber a row that was approved/rejected/superseded.
+  void enrichPushRequestRow(publishRequestId, args.slug, args.sha).catch(() => undefined);
+
+  return { publishRequestId };
+}
+
+/**
  * Mod queue: paginated list of publish requests in status='pending',
  * oldest first (FIFO). Includes the submitter's basic profile so the
  * review UI doesn't round-trip per row.

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1569,29 +1569,58 @@ export async function recordPendingFromPush(args: {
   // Park the review IMMEDIATELY with an empty summary, then enrich the real
   // file/manifest diff OFF the response path (below). The empty summary is the
   // durable fallback if enrichment never lands.
-  await dbWrite.appBlockPublishRequest.create({
-    data: {
-      id: publishRequestId,
-      appBlockId: args.appBlockId,
-      slug: args.slug,
-      submittedByUserId: ownerUserId,
-      version: args.version,
-      manifest: args.manifest,
-      // No bundle: the Forgejo repo at forgejoCommitSha IS the reviewable
-      // artifact; mods browse it directly. bundleKey stays empty as the
-      // push-originated marker.
-      bundleKey: '',
-      bundleSha256: '',
-      bundleSizeBytes: BigInt(0),
-      fileSummary: { files: [], added: [], removed: [], changed: [] },
-      manifestDiffSummary: {
-        kind: 'first-version' as const,
-        fields: Object.keys(args.manifest as Record<string, unknown>).sort(),
+  //
+  // RACE (audit follow-up): `updateManifest` calls this explicitly AND the
+  // Forgejo push webhook the same commit fires ALSO calls it for the same
+  // (slug, sha). Both can miss the `existingForSha` read above and both reach
+  // this create. The partial unique index
+  // `app_block_publish_requests_one_pending_per_slug` ((slug) WHERE
+  // status='pending') makes the loser's INSERT trip a P2002 — catch it, re-read
+  // the winner's pending row, and return it (the loser no-ops gracefully
+  // instead of throwing). Mirrors submitVersion's C-4 catch.
+  try {
+    await dbWrite.appBlockPublishRequest.create({
+      data: {
+        id: publishRequestId,
+        appBlockId: args.appBlockId,
+        slug: args.slug,
+        submittedByUserId: ownerUserId,
+        version: args.version,
+        manifest: args.manifest,
+        // No bundle: the Forgejo repo at forgejoCommitSha IS the reviewable
+        // artifact; mods browse it directly. bundleKey stays empty as the
+        // push-originated marker.
+        bundleKey: '',
+        bundleSha256: '',
+        bundleSizeBytes: BigInt(0),
+        fileSummary: { files: [], added: [], removed: [], changed: [] },
+        manifestDiffSummary: {
+          kind: 'first-version' as const,
+          fields: Object.keys(args.manifest as Record<string, unknown>).sort(),
+        },
+        status: 'pending',
+        forgejoCommitSha: args.sha,
       },
-      status: 'pending',
-      forgejoCommitSha: args.sha,
-    },
-  });
+    });
+  } catch (err) {
+    const code = (err as { code?: unknown })?.code;
+    if (code !== 'P2002') throw err;
+    // Lost the race: another concurrent recorder for this slug already parked a
+    // pending row. Re-read it and return it so this caller no-ops gracefully.
+    // Prefer the exact-sha row (this commit), falling back to whatever pending
+    // row exists for the slug (the winner may have parked a newer sha).
+    const winner =
+      (await dbWrite.appBlockPublishRequest.findFirst({
+        where: { slug: args.slug, status: 'pending', forgejoCommitSha: args.sha },
+        select: { id: true },
+      })) ??
+      (await dbWrite.appBlockPublishRequest.findFirst({
+        where: { slug: args.slug, status: 'pending' },
+        select: { id: true },
+      }));
+    if (!winner) throw err; // index fired but no pending row visible — re-throw
+    return { publishRequestId: winner.id };
+  }
 
   // Fire-and-forget: fill in the real diff + bundle size. enrichPushRequestRow
   // has its own try/catch + is scoped to status='pending', so it never gates the


### PR DESCRIPTION
## App Blocks app management — Phase 1 (web manifest editor) + Phase 2 endpoint

### What
A web UI to edit an approved app's manifest that, on save, does a **background commit** of `block.manifest.json` to the app's canonical Forgejo repo (`civitai-apps/<slug>`), naturally **re-entering the existing no-trust review flow** — the edit becomes a `pending` publish request and is **never auto-approved or deployed**. A moderator approves it via the existing `/apps/review` → `approveRequest` → build → deploy path.

Also adds the owner-only `getMyForgejoCloneInfo` tRPC query that backs the companion CLI `civitai app pull` command (companion CLI PR civitai/cli#73).

### How it re-enters the review gate (verified)
`updateManifest` commits via the admin-token `commitFiles` (same call `approveRequest` uses). Forgejo fires the push webhook regardless of which token committed, so the commit hits `/api/internal/blocks/git-push` → records a `pending` review. To get a stable `publishRequestId` back without depending on webhook delivery, the procedure **also** calls `recordPendingFromPush` directly — which is **idempotent at `(slug, sha)`**, so the webhook's later fire just refreshes the same row. `recordPendingFromPush` was **extracted** from the webhook handler into `publish-request.service` so both paths share ONE recorder + gate. Confirmed via the existing 176 git-push webhook tests (still green) + the new `updateManifest` tests asserting `recordPendingFromPush` is called with the commit sha and `status: 'pending'`.

### Hard rules enforced
- **Server-side re-validation** with `BlockManifestValidator` against the app's OauthClient context on every edit — scope-subset + `allowedOrigins` SSRF origin-binding preserved; client manifest never trusted (merged onto the STORED manifest).
- **Owner-only** (`OauthClient.userId`), authenticated, app must be `approved`.
- **`blockId` is IMMUTABLE** — forced back to the stored slug regardless of input.
- **`iframe.src` is platform-owned** — re-stamped to the canonical subdomain.
- **`version` must strictly increase** (semver).
- Background commit **cannot auto-approve/auto-deploy** — enters the same pending-review path as a direct git push.

### Files
- `src/server/routers/blocks.router.ts` — `updateManifest`, `getMyAppManifest` (owner-only full-manifest read for the form), `getMyForgejoCloneInfo` (Phase 2; accepts slug or appBlockId, grants READ), `compareSemver`.
- `src/server/services/blocks/publish-request.service.ts` — extracted + exported `recordPendingFromPush`.
- `src/pages/api/internal/blocks/git-push.ts` — webhook now uses the shared recorder (behavior preserved).
- `src/components/Apps/ManifestEditForm.tsx` — Mantine edit form (client-side hints; server is the validator).
- `src/pages/apps/[appBlockId]/edit-manifest.tsx` — SSR flag+session-gated page (owner enforced at the tRPC layer).
- `src/pages/apps/[appBlockId]/index.tsx` — owner-only "Edit manifest" button.
- Tests: `blocks.router.updateManifest.test.ts` (9), `blocks.router.getMyForgejoCloneInfo.test.ts` (5).

### Source-type tracking
No schema migration. A manifest-edit (like any push-originated request) lands with **`bundleKey = ''`** — the existing push-originated marker — distinguishing it from a ZIP submitVersion.

### Tests
`updateManifest` (9) + `getMyForgejoCloneInfo` (5) pass; existing **515 blocks** + **176 git-push webhook** tests still green (ran via vitest from the worktree; repo `tsc` OOMs locally so full typecheck not run).

### Verified vs untested
- ✅ Unit-tested: all gates (owner / approved / immutable blockId / scope-subset reject / version monotonicity / commit-with-server-slug / records pending). Webhook idempotency preserved.
- ⚠️ Not run on a live cluster: the actual Forgejo commit → webhook → pending-review round-trip against real Forgejo, and the React form in a browser. Needs a dogfood pass behind the mod-gated appBlocks flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)