### PR TITLE
fix(app-blocks/review-sandbox): export REVIEW_NAME so envsubst renders the review manifest

### DIFF
--- a/src/server/services/blocks/__tests__/apps-pipeline.reviewApply.test.ts
+++ b/src/server/services/blocks/__tests__/apps-pipeline.reviewApply.test.ts
@@ -96,6 +96,10 @@ describe('triggerApplyReview / deleteReviewResources', () => {
     const script = job.spec.template.spec.containers[0].args[0] as string;
     expect(script).toContain('/templates/review.yaml.tmpl');
     expect(script).toContain('REVIEW_HOST_SHA');
+    // REVIEW_NAME must be EXPORTED — envsubst only substitutes exported vars, so
+    // without `export` the manifest renders empty resource names and the apply
+    // Job fails ("Middleware -mod-gate is invalid"). Regression guard.
+    expect(script).toContain('export REVIEW_NAME=');
     // Image is passed through env.
     const envVars = job.spec.template.spec.containers[0].env as Array<{ name: string; value: string }>;
     expect(envVars.find((e) => e.name === 'IMAGE')!.value).toContain('app-block-review-my-app');

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -817,7 +817,12 @@ export function buildApplyReviewScript(ns: string): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
 
-REVIEW_NAME="review-\${SLUG}-\${REVIEW_HOST_SHA}"
+# MUST be exported: envsubst (below) only substitutes EXPORTED env vars. SLUG /
+# SHA / IMAGE / REVIEW_HOST_SHA come from the container env (exported), but
+# REVIEW_NAME is computed here — without \`export\` it renders EMPTY in the
+# manifest, producing invalid names (Deployment/Service "" + Middleware
+# "-mod-gate") and the apply Job fails.
+export REVIEW_NAME="review-\${SLUG}-\${REVIEW_HOST_SHA}"
 
 # ---- Render the review manifest from /templates/review.yaml.tmpl ------------
 if command -v envsubst >/dev/null 2>&1; then


### PR DESCRIPTION
The review apply Job failed on prod: the rendered review manifest had EMPTY
resource names (Deployment/Service "" + Middleware "-mod-gate"/"-frame-ancestors")
→ 'metadata.name Invalid value' + 'resource name may not be empty'. Root cause:
buildApplyReviewScript computes REVIEW_NAME as a plain shell var, but envsubst
only substitutes EXPORTED env vars (SLUG/SHA/IMAGE/REVIEW_HOST_SHA come from the
container env, so they worked; REVIEW_NAME didn't). Export it. +regression test.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
