### PR TITLE
fix(a11y): name /generate form controls (a11y 75 → ~88)

### DIFF
--- a/src/components/ImageGeneration/GenerationTabs.tsx
+++ b/src/components/ImageGeneration/GenerationTabs.tsx
@@ -146,11 +146,21 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
               data-tour="gen:results"
               data={tabEntries.map(([key, { Icon, label }]) => ({
                 label: (
-                  <Tooltip label={label} position="bottom" color="dark" openDelay={200} offset={10}>
-                    <div data-tour={`gen:${key}`} className="flex items-center justify-center">
-                      <Icon size={16} />
-                    </div>
-                  </Tooltip>
+                  <>
+                    <Tooltip
+                      label={label}
+                      position="bottom"
+                      color="dark"
+                      openDelay={200}
+                      offset={10}
+                    >
+                      <div data-tour={`gen:${key}`} className="flex items-center justify-center">
+                        <Icon size={16} />
+                      </div>
+                    </Tooltip>
+                    {/* Accessible name for the icon-only radio (visually hidden) */}
+                    <span className="sr-only">{label}</span>
+                  </>
                 ),
                 value: key,
               }))}
@@ -184,6 +194,7 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
               </Tooltip>
             )}
             <CloseButton
+              aria-label={isGeneratePage ? 'Go back' : 'Close generation panel'}
               onClick={isGeneratePage ? () => history.go(-1) : generationGraphPanel.close}
               size="lg"
               variant="transparent"

--- a/src/components/Tour/TourPopover.tsx
+++ b/src/components/Tour/TourPopover.tsx
@@ -23,6 +23,8 @@ export function TourPopover(props: TooltipRenderProps) {
   return (
     <Paper
       {...tooltipProps}
+      // Give the react-joyride dialog (role="alertdialog") an accessible name.
+      aria-label={typeof step.title === 'string' && step.title ? step.title : 'Product tour'}
       className={clsx('flex flex-col gap-4 bg-white dark:bg-dark-6', centered && 'mx-auto')}
       p="sm"
       radius="md"
@@ -35,7 +37,7 @@ export function TourPopover(props: TooltipRenderProps) {
         <Text className={clsx(!step.showProgress && 'hidden')} size="sm" c="dimmed">
           {index + 1} of {size}
         </Text>
-        {!step.hideCloseButton && <CloseButton ml="auto" />}
+        {!step.hideCloseButton && <CloseButton aria-label="Close" ml="auto" />}
       </Group>
       <div className="flex flex-col gap-1">
         {step.title && step.showProgress && (

--- a/src/components/generation_v2/inputs/ResourceItemContent.tsx
+++ b/src/components/generation_v2/inputs/ResourceItemContent.tsx
@@ -193,6 +193,7 @@ export function ResourceItemContent({
               metadata={null}
               width={450}
               className="size-full object-cover"
+              alt={resource.model.name}
             />
           </div>
         )}

--- a/src/components/generation_v2/inputs/SliderInput.tsx
+++ b/src/components/generation_v2/inputs/SliderInput.tsx
@@ -1,7 +1,7 @@
 import type { InputWrapperProps, NumberInputProps, SliderProps } from '@mantine/core';
 import { Group, Input, NumberInput, Slider, Text } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { isValidElement, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import clsx from 'clsx';
 
@@ -157,6 +157,19 @@ export function SliderInput({
 
   const hasPresets = presets && presets.length > 0;
 
+  // Derive an accessible name for the Slider thumb + NumberInput. The visible
+  // `label` (rendered on Input.Wrapper) can't be programmatically associated
+  // with either of the two inner controls, so a11y tooling reports both as
+  // unnamed. Reuse the field's own visible label so the accessible name always
+  // matches what the user sees. Handles both a plain string label and the
+  // `<ControllerLabel label="..." />` wrapper used across the generation form.
+  const accessibleName =
+    typeof label === 'string'
+      ? label
+      : isValidElement(label) && typeof (label.props as { label?: unknown })?.label === 'string'
+      ? ((label.props as { label: string }).label)
+      : undefined;
+
   return (
     <Input.Wrapper
       {...inputWrapperProps}
@@ -182,6 +195,7 @@ export function SliderInput({
       <div className={clsx('mt-1 flex items-center gap-2', { ['flex-row-reverse']: reverse })}>
         <Slider
           {...sliderProps}
+          thumbLabel={sliderProps?.thumbLabel ?? accessibleName}
           className={clsx('flex-1', sliderProps?.className)}
           min={min}
           max={max}
@@ -197,6 +211,7 @@ export function SliderInput({
         />
         <NumberInput
           ref={numberRef}
+          aria-label={numberProps?.['aria-label'] ?? accessibleName}
           {...numberProps}
           className={clsx('min-w-[60px] flex-[0]', numberProps?.className)}
           style={{


### PR DESCRIPTION
## What

Harvest of the report-only `/generate` Lighthouse a11y finding — score stuck at **75** (consistent across #2818/#2844/#2848). Fixes four failing audits with additive, SSR-safe, visually-neutral accessible names. Projected **75 → ~88** (weighted from the LHR: `aria-input-field-name`+7, `label`+7, `image-alt`+10, `aria-dialog-name`+7 → 205/232).

| Audit (weight) | Offending node | Fix | File |
|---|---|---|---|
| `aria-input-field-name` (7) | 2 Slider thumbs `aria-label=""` | derive name from the field's visible `Input.Wrapper` label → `thumbLabel` | `SliderInput.tsx` |
| `label` (7) | 2 NumberInputs + Queue/Feed SegmentedControl radios | same derived name → NumberInput `aria-label`; sr-only text label per SegmentedControl radio | `SliderInput.tsx`, `GenerationTabs.tsx` |
| `image-alt` (10) | selected-resource thumbnail (`EdgeMedia2`) no `alt` | `alt={resource.model.name}` | `ResourceItemContent.tsx` |
| `aria-dialog-name` (7) | react-joyride tour `role="alertdialog"` unnamed | `aria-label` from step title (fallback "Product tour") + name its Close button | `TourPopover.tsx` |

All names verified against each control's real function. No visual or behavior change; `sr-only` is Tailwind-default; `alt` flows type-safely through `EdgeMedia2 → EdgeMedia → EdgeImage → <img>`.

`TourPopover` is a shared tour component (models/auctions/post-edit/generation) — the dialog-name + close-button fixes apply site-wide (strictly additive).

## Verification

Report-only (does not block). The preview's `lhci-bot` comment should show `/generate` a11y rise from 75 (deterministic audit, so the jump is attributable). Poller will confirm.

## Residuals (deliberately out of scope, for a follow-up)

- **`button-name`** (10) — binary audit; needs *every* remaining icon-only button named (~5 scattered form buttons beyond the two Close buttons named here + the tour close). Enumerate via axe on the authed preview, then label each.
- **`aria-required-children`** (10) — the Queue/Feed/Newest/Filters `role="tablist"` is missing `role="tab"` children — structural, risk of behavior change; left for a dedicated look.
- **`color-contrast`** (7) — the `text-[10px] text-gray-6` param-hint text — a brand/design call for Zach, not a code fix.
- Latent (not a11y): `TourPopover`'s Close button omits react-joyride's `closeProps`, so the X currently has no click handler. Left untouched to keep this PR a11y-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)