### PR TITLE
fix(a11y): name the 4 icon-only /generate buttons (button-name → pass)

### DIFF
--- a/src/components/Challenges/ChallengeIndicator.tsx
+++ b/src/components/Challenges/ChallengeIndicator.tsx
@@ -45,6 +45,7 @@ export function ChallengeIndicator() {
   return (
     <Indicator color="red" size={12} disabled={!hasUnseen} inline>
       <LegacyActionIcon
+        aria-label="Daily challenges"
         size="lg"
         className={clsx(hasUnseen && 'animate-wiggle')}
         color={hasUnseen ? (futureChallenge ? 'yellow' : 'teal') : 'dark'}

--- a/src/components/generation_v2/inputs/ResourceSelectMultipleInput.tsx
+++ b/src/components/generation_v2/inputs/ResourceSelectMultipleInput.tsx
@@ -143,7 +143,13 @@ function ResourceItem({
         disabled={disabled}
         options={options}
         actions={
-          <ActionIcon size="sm" variant="subtle" onClick={onRemove} disabled={disabled}>
+          <ActionIcon
+            aria-label="Remove resource"
+            size="sm"
+            variant="subtle"
+            onClick={onRemove}
+            disabled={disabled}
+          >
             <IconX size={16} />
           </ActionIcon>
         }
@@ -356,6 +362,7 @@ export function ResourceSelectMultipleInput({
               )}
 
               <ActionIcon
+                aria-label={opened ? 'Collapse resources' : 'Expand resources'}
                 variant="subtle"
                 size="sm"
                 onClick={toggle}

--- a/src/components/generation_v2/preset/PresetHeaderButton.tsx
+++ b/src/components/generation_v2/preset/PresetHeaderButton.tsx
@@ -56,7 +56,7 @@ export function PresetHeaderButton() {
     >
       <Menu.Target>
         <Tooltip label="Presets" disabled={menuOpened}>
-          <LegacyActionIcon>
+          <LegacyActionIcon aria-label="Presets">
             <Text c="dimmed" inline>
               <IconBookmark
                 className={clsx(showGlow && 'animate-icon-glow')}


### PR DESCRIPTION
## What

Follow-up to #2854 (which took `/generate` a11y 75 → 88). `button-name` is a **binary** Lighthouse audit — red while *any* icon-only `<button>` on the page lacks an accessible name. #2854 named the two CloseButtons; the post-#2854 LHR still enumerated **4** unnamed icon buttons on the authed (`ci-smoke-gold`) `/generate` view. This names all four (additive `aria-label`, each matching the control's real function, mapped from the LHR selectors to source):

| LHR node | Component:line | Button | Name |
|---|---|---|---|
| `animate-wiggle` filled ActionIcon | `ChallengeIndicator.tsx:47` | trophy → opens daily-challenge dialog | `Daily challenges` |
| subtle ActionIcon | `ResourceSelectMultipleInput.tsx:146` | IconX → remove a resource | `Remove resource` |
| subtle `transition-transform` ActionIcon | `ResourceSelectMultipleInput.tsx:364` | chevron → collapse/expand section | `Collapse/Expand resources` (dynamic) |
| menu trigger (`aria-haspopup`) | `PresetHeaderButton.tsx:59` | IconBookmark → presets menu | `Presets` (matches its Tooltip) |

Component-level fixes, so they cover any instance count (e.g. multiple resource rows all get named). **Ruled out** `BaseModelInput`'s chevron — it sits inside an `UnstyledButton` that already has visible text (already named), so it's not a 5th node. `LegacyActionIcon` is `ActionIcon.withProps(...)` and forwards `aria-label`.

Projected `/generate` a11y **88 → ~93** (`button-name` weight 10 → 205+... → 215/232 = 0.927). Binary audit, so this only flips if these are indeed *all* the unnamed buttons in the audited run — the deterministic preview `lhci-bot` comment is the ground truth.

## Verification

Report-only (does not block). Confirm on the preview: `/generate` `button-name` audit → pass and a11y rises from 88.

## Remaining `/generate` a11y residuals (out of scope)

- `aria-required-children` (w=10) — the Queue/Feed/Newest/Filters `role="tablist"` missing `role="tab"` children (structural).
- `color-contrast` (w=7) — the `text-[10px] text-gray-6` param-hint text (design call for Zach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)