### PR TITLE
feat(orchestrator-gateway): dark client routing — flag + splitLink (empty allowlist, no-op)

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -145,6 +145,11 @@ MEILI_CIRCUIT_COOLDOWN_SECONDS=30
 # BaseURL
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
+# Orchestrator-gateway (generation-API spin-out). Empty = route orchestrator.* to
+# the monolith (the default). Set to the gateway origin to enable the split for
+# allowlisted procedures under the orchestratorGatewayRouting flag.
+NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL=
+
 # Recaptcha
 RECAPTCHA_PROJECT_ID=aSampleKey
 NEXT_PUBLIC_RECAPTCHA_KEY=aSampleKey

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -42,6 +42,14 @@ export const clientSchema = z.object({
   // (NEXT_PUBLIC_AUTH_HUB_URL removed: every client-initiated hub flow — login full-page + popup, account
   // connect, discord-link — now routes through a same-origin main-app endpoint that builds the hub URL from
   // the SERVER's AUTH_JWT_ISSUER, so the client no longer needs a build-time hub origin.)
+  // Base URL of the dedicated orchestrator-gateway service (the generation-API
+  // spin-out). When set, the client's tRPC link MAY route allowlisted
+  // `orchestrator.*` procedures here (gated by the `orchestratorGatewayRouting`
+  // flag AND the empty-today procedure allowlist). Empty/absent → the split
+  // falls back to the monolith `/api/trpc` origin (the safe default). Should be
+  // an absolute origin, e.g. "https://orchestrator-gateway.civitai.com". Defaults
+  // to empty so nothing routes off the monolith until it's explicitly configured.
+  NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL: z.string().default(''),
 });
 
 /**
@@ -83,4 +91,5 @@ export const clientEnv = {
     process.env.NEXT_PUBLIC_CF_INVISIBLE_TURNSTILE_SITEKEY,
   NEXT_PUBLIC_CF_MANAGED_TURNSTILE_SITEKEY: process.env.NEXT_PUBLIC_CF_MANAGED_TURNSTILE_SITEKEY,
   NEXT_PUBLIC_AUTH_PROXY_URL: process.env.NEXT_PUBLIC_AUTH_PROXY_URL,
+  NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL: process.env.NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL,
 };

--- a/src/providers/FeatureFlagsProvider.tsx
+++ b/src/providers/FeatureFlagsProvider.tsx
@@ -1,7 +1,7 @@
 import { useSession } from '~/providers/SessionProvider';
-import { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { type FeatureAccess } from '~/server/services/feature-flags.service';
-import { trpc } from '~/utils/trpc';
+import { setGatewayRouting, trpc } from '~/utils/trpc';
 
 const FeatureFlagsCtx = createContext<FeatureAccess | null>(null);
 // Whether the per-user `getFeatureFlags` overlay has resolved. SSR seeds
@@ -71,6 +71,15 @@ export const FeatureFlagsProvider = ({
     }),
     [flags, userFeatures]
   );
+
+  // The tRPC link chain (`src/utils/trpc.ts`) lives OUTSIDE React, so it can't
+  // read this context directly. Mirror the resolved `orchestratorGatewayRouting`
+  // cohort flag into the module-scope cache the orchestrator-gateway splitLink
+  // reads. Default there is `false` (monolith); this keeps it in sync as the
+  // per-user overlay resolves. No-op today (the procedure allowlist is empty).
+  useEffect(() => {
+    setGatewayRouting(featureFlags.orchestratorGatewayRouting === true);
+  }, [featureFlags.orchestratorGatewayRouting]);
 
   return (
     <FeatureFlagsCtx.Provider value={featureFlags}>

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -253,6 +253,21 @@ const featureFlags = createFeatureFlags({
   // land. The Flipt key stays the kill-switch / future-widen lever (flip it off
   // to drop the page + nav entry without a deploy).
   appBlocksGetStarted: { availability: ['mod'], fliptKey: 'app-blocks-get-started' },
+  // Orchestrator-gateway client routing — the DARK cohort gate for the
+  // generation-API spin-out (see claudedocs/plan-orchestrator-api-spinout-2026-06-30.md
+  // §4c). When true for a user, the client's `orchestrator.*` tRPC calls MAY be
+  // routed to the dedicated `civitai-orchestrator-gateway` service instead of the
+  // monolith — but ONLY for procedures the gateway actually backs yet (a SEPARATE
+  // `ORCHESTRATOR_GATEWAY_PROCEDURES` allowlist in `src/utils/orchestrator-gateway-routing.ts`,
+  // which is EMPTY today → this flag being true is a provable no-op). Staged
+  // mod-only so it deploys dark; phased rollout is a pure Flipt/availability
+  // change (dark `[]`/off → `['mod']` → `['public']` on explicit confirm) as the
+  // allowlist grows (whatIf first, then generate/status). The empty allowlist is
+  // the hard dark guarantee; the Flipt key is the kill-switch / widen lever.
+  orchestratorGatewayRouting: {
+    availability: ['mod'],
+    fliptKey: 'orchestrator-gateway-routing',
+  },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];

--- a/src/utils/__tests__/orchestrator-gateway-routing.test.ts
+++ b/src/utils/__tests__/orchestrator-gateway-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   ORCHESTRATOR_GATEWAY_PROCEDURES,
+  resolveGatewayBase,
   shouldRouteToGateway,
 } from '~/utils/orchestrator-gateway-routing';
 
@@ -102,5 +103,34 @@ describe('shouldRouteToGateway — the gateway branch IS reachable once a proced
         allowlist: ['orchestrator.whatIfFromGraph'], // wrong shape → no match
       })
     ).toBe(false);
+  });
+});
+
+describe('resolveGatewayBase — URL normalization / disabled-default', () => {
+  it('returns "" for empty / whitespace / null / undefined (→ monolith fallback)', () => {
+    for (const raw of ['', '   ', '\t\n', undefined, null]) {
+      expect(resolveGatewayBase(raw)).toBe('');
+    }
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(resolveGatewayBase('  https://orchestrator-gateway.civitai.com  ')).toBe(
+      'https://orchestrator-gateway.civitai.com'
+    );
+  });
+
+  it('strips trailing slash(es) so the caller can append /api/trpc cleanly', () => {
+    expect(resolveGatewayBase('https://orchestrator-gateway.civitai.com/')).toBe(
+      'https://orchestrator-gateway.civitai.com'
+    );
+    expect(resolveGatewayBase('https://orchestrator-gateway.civitai.com//')).toBe(
+      'https://orchestrator-gateway.civitai.com'
+    );
+  });
+
+  it('leaves a clean origin untouched', () => {
+    expect(resolveGatewayBase('https://orchestrator-gateway.civitai.com')).toBe(
+      'https://orchestrator-gateway.civitai.com'
+    );
   });
 });

--- a/src/utils/__tests__/orchestrator-gateway-routing.test.ts
+++ b/src/utils/__tests__/orchestrator-gateway-routing.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ORCHESTRATOR_GATEWAY_PROCEDURES,
+  shouldRouteToGateway,
+} from '~/utils/orchestrator-gateway-routing';
+
+const GATEWAY = 'https://orchestrator-gateway.civitai.com/api/trpc';
+
+describe('shouldRouteToGateway — DARK no-op guarantee (empty allowlist)', () => {
+  it('the shipped allowlist is EMPTY (the hard dark guarantee)', () => {
+    expect(ORCHESTRATOR_GATEWAY_PROCEDURES).toEqual([]);
+  });
+
+  it('routes NOTHING to the gateway with the real (empty) allowlist, even when flag on + URL set', () => {
+    // Sample of real orchestrator.* procedure paths — none should route while the
+    // module allowlist is empty. This is the provable no-op.
+    const orchestratorPaths = [
+      'orchestrator.whatIfFromGraph',
+      'orchestrator.generate',
+      'orchestrator.getWorkflow',
+      'orchestrator.queryWorkflows',
+      'orchestrator.cancelWorkflow',
+      'orchestrator.getWorkflowStatusUpdate',
+      'orchestrator.enhancePrompt',
+    ];
+    for (const path of orchestratorPaths) {
+      // Uses the DEFAULT (module) allowlist — no override.
+      expect(shouldRouteToGateway(path, { enabled: true, url: GATEWAY })).toBe(false);
+    }
+  });
+
+  it('non-orchestrator paths never route to the gateway', () => {
+    expect(
+      shouldRouteToGateway('image.getInfinite', {
+        enabled: true,
+        url: GATEWAY,
+        allowlist: ['getInfinite'],
+      })
+    ).toBe(false);
+    expect(
+      shouldRouteToGateway('model.getById', { enabled: true, url: GATEWAY, allowlist: ['getById'] })
+    ).toBe(false);
+  });
+});
+
+describe('shouldRouteToGateway — the gateway branch IS reachable once a procedure is allowlisted', () => {
+  const allowlist = ['whatIfFromGraph'];
+
+  it('routes to the gateway when path allowlisted AND flag on AND url set', () => {
+    expect(
+      shouldRouteToGateway('orchestrator.whatIfFromGraph', {
+        enabled: true,
+        url: GATEWAY,
+        allowlist,
+      })
+    ).toBe(true);
+  });
+
+  it('stays on the monolith when the flag is OFF (cohort gate)', () => {
+    expect(
+      shouldRouteToGateway('orchestrator.whatIfFromGraph', {
+        enabled: false,
+        url: GATEWAY,
+        allowlist,
+      })
+    ).toBe(false);
+  });
+
+  it('stays on the monolith when the gateway URL is empty/undefined', () => {
+    expect(
+      shouldRouteToGateway('orchestrator.whatIfFromGraph', {
+        enabled: true,
+        url: '',
+        allowlist,
+      })
+    ).toBe(false);
+    expect(
+      shouldRouteToGateway('orchestrator.whatIfFromGraph', {
+        enabled: true,
+        url: undefined,
+        allowlist,
+      })
+    ).toBe(false);
+  });
+
+  it('stays on the monolith when the procedure is NOT in the allowlist (allowlist miss)', () => {
+    expect(
+      shouldRouteToGateway('orchestrator.generate', {
+        enabled: true,
+        url: GATEWAY,
+        allowlist, // only whatIfFromGraph
+      })
+    ).toBe(false);
+  });
+
+  it('matches on the procedure name only (prefix stripped), not the full path', () => {
+    // An allowlist entry must be the bare procedure, not the prefixed path.
+    expect(
+      shouldRouteToGateway('orchestrator.whatIfFromGraph', {
+        enabled: true,
+        url: GATEWAY,
+        allowlist: ['orchestrator.whatIfFromGraph'], // wrong shape → no match
+      })
+    ).toBe(false);
+  });
+});

--- a/src/utils/orchestrator-gateway-routing.ts
+++ b/src/utils/orchestrator-gateway-routing.ts
@@ -1,0 +1,77 @@
+// src/utils/orchestrator-gateway-routing.ts
+//
+// DARK feature-flag routing plumbing for the orchestrator-gateway spin-out
+// (see claudedocs/plan-orchestrator-api-spinout-2026-06-30.md §4c in the
+// datapacket-talos repo).
+//
+// This module is the single source of truth for the *client-side* decision of
+// whether an `orchestrator.*` tRPC operation should be sent to the dedicated
+// `civitai-orchestrator-gateway` service instead of the monolith.
+//
+// It is a PROVABLE NO-OP in its current state: `ORCHESTRATOR_GATEWAY_PROCEDURES`
+// is EMPTY, so `shouldRouteToGateway()` returns `false` for every operation
+// regardless of flag / env — 100% of traffic stays on the monolith. Enabling
+// the gateway for a procedure is a two-dimensional gate (cohort flag AND
+// procedure-in-allowlist), rolled out per the plan's phases.
+
+/**
+ * Procedure allowlist — the single source of truth for which `orchestrator.*`
+ * procedures are actually implemented + ready on the gateway.
+ *
+ * EMPTY today = hard dark guarantee: nothing routes to the gateway even if the
+ * flag resolves true for a mod and the env URL is set. This is what lets the
+ * cohort flag (`orchestratorGatewayRouting`) go live to mods BEFORE all the
+ * orchestrator procedures have been migrated — a mod in the cohort only routes
+ * the procedures that appear here.
+ *
+ * Entries are the procedure path WITHOUT the `orchestrator.` prefix, e.g.
+ * `'whatIfFromGraph'` (NOT `'orchestrator.whatIfFromGraph'`).
+ *
+ * Rollout (per plan §4 / §4c):
+ *   - P1 adds `'whatIfFromGraph'` (read-only cost preview) once the gateway backs it.
+ *   - P2 adds the generate/status procedures (submitWorkflow/generate, getWorkflow,
+ *     queryWorkflows, cancelWorkflow, getWorkflowStatusUpdate, ...).
+ *   - later phases add the remaining migrated procedures.
+ */
+export const ORCHESTRATOR_GATEWAY_PROCEDURES: string[] = [];
+
+const ORCHESTRATOR_PREFIX = 'orchestrator.';
+
+export type GatewayRoutingConfig = {
+  /** The module-scope cached `orchestratorGatewayRouting` flag value (cohort gate). */
+  enabled: boolean;
+  /**
+   * The gateway base URL (`NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL`). When empty /
+   * absent the split MUST fall back to the monolith — an empty URL means "no
+   * gateway configured".
+   */
+  url: string | undefined;
+  /** The procedure allowlist. Defaults to the module constant; overridable for tests. */
+  allowlist?: string[];
+};
+
+/**
+ * Pure routing predicate — extracted so the decision is unit-testable without a
+ * live server or the `trpc.ts` link chain.
+ *
+ * Returns `true` (route to the gateway) ONLY when ALL of:
+ *   1. the op path is an `orchestrator.*` path,
+ *   2. the cohort flag is enabled (mounted from the SSR flag seed),
+ *   3. the gateway URL env is a non-empty string, AND
+ *   4. the procedure (path minus the `orchestrator.` prefix) is in the allowlist.
+ *
+ * Any miss → `false` → the operation stays on the monolith (safe default).
+ * Because the allowlist ships EMPTY, condition (4) is ALWAYS false today, so
+ * this ALWAYS returns `false` → zero behavior change.
+ */
+export function shouldRouteToGateway(path: string, config: GatewayRoutingConfig): boolean {
+  const { enabled, url } = config;
+  const allowlist = config.allowlist ?? ORCHESTRATOR_GATEWAY_PROCEDURES;
+
+  if (!path.startsWith(ORCHESTRATOR_PREFIX)) return false;
+  if (!enabled) return false;
+  if (!url) return false;
+
+  const procedure = path.slice(ORCHESTRATOR_PREFIX.length);
+  return allowlist.includes(procedure);
+}

--- a/src/utils/orchestrator-gateway-routing.ts
+++ b/src/utils/orchestrator-gateway-routing.ts
@@ -32,6 +32,24 @@
  *   - P2 adds the generate/status procedures (submitWorkflow/generate, getWorkflow,
  *     queryWorkflows, cancelWorkflow, getWorkflowStatusUpdate, ...).
  *   - later phases add the remaining migrated procedures.
+ *
+ * ⚠️ GO-LIVE PRECONDITIONS — do NOT append a procedure here until, in order:
+ *   1. CROSS-ORIGIN AUTH is wired. The gateway branch uses the same tRPC
+ *      `httpLink`, whose `fetch` defaults to `credentials:'same-origin'`. Once
+ *      the gateway is a different origin, allowlisted calls send NO cookies →
+ *      they arrive UNAUTHENTICATED (and every call becomes a CORS preflight from
+ *      the `x-client-*` headers). The enablement PR must add `credentials:'include'`
+ *      on the gateway branch + gateway CORS (`Access-Control-Allow-Credentials`,
+ *      echoed origin, allow `x-client-*`) + cookie `SameSite=None; Secure`.
+ *   2. The gateway is DEPLOYED and actually backs the procedure, and
+ *      `NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL` is set, and the Flipt cohort is
+ *      NARROW (start `[]`/off or `['mod']`) BEFORE the append — because adding one
+ *      string here immediately routes that procedure for the ENTIRE cohort with
+ *      no per-procedure percentage ramp (the only ramp is the Flipt cohort).
+ *
+ * NO MONOLITH FALLBACK: `splitLink` is a static route — an allowlisted op goes
+ * ONLY to the gateway. If the gateway is down/5xx/TLS-fails the op FAILS (no
+ * client retry-on-monolith). The kill-switch is Flipt-off OR emptying this array.
  */
 export const ORCHESTRATOR_GATEWAY_PROCEDURES: string[] = [];
 
@@ -74,4 +92,19 @@ export function shouldRouteToGateway(path: string, config: GatewayRoutingConfig)
 
   const procedure = path.slice(ORCHESTRATOR_PREFIX.length);
   return allowlist.includes(procedure);
+}
+
+/**
+ * Normalize the raw `NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL` into a clean gateway
+ * base ORIGIN (no trailing slash). Returns `''` for empty/whitespace/absent —
+ * `''` means "no gateway configured" → the split falls back to the monolith.
+ *
+ * Expects an origin only (e.g. `https://orchestrator-gateway.civitai.com`); a
+ * value that already contains a path will be used verbatim (minus a trailing
+ * slash) and is a config foot-gun — the caller appends the `/api/trpc` mount.
+ */
+export function resolveGatewayBase(raw: string | undefined | null): string {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return '';
+  return trimmed.replace(/\/+$/, '');
 }

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -110,6 +110,12 @@ function withGatewaySplit({
   const monolithLink = httpLinkWithLargeQuerySupport({ url: monolithUrl, headers });
   // No gateway URL configured → skip the split entirely (pure monolith link).
   if (!gatewayUrl) return monolithLink;
+  // CLIENT-ONLY: the cohort flag lives in a module-scope global (`gatewayRoutingEnabled`),
+  // which is per-tab in the browser but SHARED across all concurrent requests on the
+  // server. Reading it during SSR would leak one user's cohort to another. So on the
+  // server we never route to the gateway — SSR orchestrator calls stay on the monolith.
+  // (Same hazard class as the per-request QueryClient note below.)
+  if (typeof window === 'undefined') return monolithLink;
   return splitLink({
     condition: (op) =>
       shouldRouteToGateway(op.path, { enabled: gatewayRoutingEnabled, url: gatewayUrl }),

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -11,6 +11,7 @@ import { isDev } from '~/env/other';
 import { env } from '~/env/client';
 import { showErrorNotification } from '~/utils/notifications';
 import { removeEmpty } from '~/utils/object-helpers';
+import { shouldRouteToGateway } from '~/utils/orchestrator-gateway-routing';
 
 type RequestHeaders = {
   'x-client-date': string;
@@ -19,6 +20,29 @@ type RequestHeaders = {
 };
 
 const url = '/api/trpc';
+
+/**
+ * Base URL of the dedicated orchestrator-gateway service (generation-API
+ * spin-out). Empty by default → the split falls back to the monolith. When set
+ * (an absolute origin) the client MAY route allowlisted `orchestrator.*` calls
+ * here. Trailing `/api/trpc` mirrors the monolith URL shape so the gateway's
+ * tRPC-over-HTTP handler mounts at the same relative path.
+ */
+const gatewayBase = env.NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL || '';
+const gatewayUrl = gatewayBase ? `${gatewayBase.replace(/\/$/, '')}${url}` : '';
+
+/**
+ * Module-scope cache of the `orchestratorGatewayRouting` cohort flag. The tRPC
+ * link chain runs OUTSIDE React, so it can't read `useFeatureFlags()`; instead
+ * `FeatureFlagsProvider` (seeded synchronously from the SSR `flags`) writes the
+ * boolean here on mount via `setGatewayRouting`. Safe default `false` → monolith
+ * until populated / for anon / on error. Because the procedure allowlist ships
+ * EMPTY, this being true is still a provable no-op.
+ */
+let gatewayRoutingEnabled = false;
+export function setGatewayRouting(enabled: boolean) {
+  gatewayRoutingEnabled = enabled;
+}
 
 /**
  * Approximate input-size threshold (serialized chars) above which a query is
@@ -63,6 +87,37 @@ function httpLinkWithLargeQuerySupport({
     false: httpLink({ transformer: superjson, url, headers }),
   });
 }
+/**
+ * Wrap a monolith terminating link with the DARK orchestrator-gateway split.
+ *
+ * `condition` true  → route the op to the gateway (reusing
+ *   `httpLinkWithLargeQuerySupport` so the large-query POST behavior is
+ *   preserved on BOTH branches).
+ * `condition` false → the CURRENT monolith link, unchanged.
+ *
+ * The condition ANDs: `orchestrator.*` path + cohort flag on + gateway URL set +
+ * procedure in the (EMPTY-today) allowlist. Any miss → monolith. Because the
+ * allowlist is empty, `condition` is ALWAYS false right now → the gateway branch
+ * is never taken → zero behavior change.
+ */
+function withGatewaySplit({
+  monolithUrl,
+  headers,
+}: {
+  monolithUrl: string;
+  headers: ReturnType<typeof getHeaders>;
+}): TRPCLink<AppRouter> {
+  const monolithLink = httpLinkWithLargeQuerySupport({ url: monolithUrl, headers });
+  // No gateway URL configured → skip the split entirely (pure monolith link).
+  if (!gatewayUrl) return monolithLink;
+  return splitLink({
+    condition: (op) =>
+      shouldRouteToGateway(op.path, { enabled: gatewayRoutingEnabled, url: gatewayUrl }),
+    true: httpLinkWithLargeQuerySupport({ url: gatewayUrl, headers }),
+    false: monolithLink,
+  });
+}
+
 const headers: RequestHeaders = {
   'x-client-version': process.env.version,
   'x-client-date': Date.now().toString(),
@@ -155,7 +210,7 @@ export const trpcVanilla: CreateTRPCClient<AppRouter> = createTRPCClient<AppRout
         (isDev && env.NEXT_PUBLIC_LOG_TRPC) ||
         (opts.direction === 'down' && opts.result instanceof Error),
     }),
-    httpLinkWithLargeQuerySupport({ url, headers: getHeaders() }),
+    withGatewaySplit({ monolithUrl: url, headers: getHeaders() }),
   ],
 });
 
@@ -182,8 +237,8 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext> = createTRPCNext<A
             (isDev && env.NEXT_PUBLIC_LOG_TRPC) ||
             (opts.direction === 'down' && opts.result instanceof Error),
         }),
-        httpLinkWithLargeQuerySupport({
-          url: isClient ? url : `${env.NEXT_PUBLIC_BASE_URL as string}${url}`,
+        withGatewaySplit({
+          monolithUrl: isClient ? url : `${env.NEXT_PUBLIC_BASE_URL as string}${url}`,
           headers: getHeaders(ctx),
         }),
         // splitLink({

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -11,7 +11,7 @@ import { isDev } from '~/env/other';
 import { env } from '~/env/client';
 import { showErrorNotification } from '~/utils/notifications';
 import { removeEmpty } from '~/utils/object-helpers';
-import { shouldRouteToGateway } from '~/utils/orchestrator-gateway-routing';
+import { resolveGatewayBase, shouldRouteToGateway } from '~/utils/orchestrator-gateway-routing';
 
 type RequestHeaders = {
   'x-client-date': string;
@@ -28,8 +28,8 @@ const url = '/api/trpc';
  * here. Trailing `/api/trpc` mirrors the monolith URL shape so the gateway's
  * tRPC-over-HTTP handler mounts at the same relative path.
  */
-const gatewayBase = env.NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL || '';
-const gatewayUrl = gatewayBase ? `${gatewayBase.replace(/\/$/, '')}${url}` : '';
+const gatewayBase = resolveGatewayBase(env.NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL);
+const gatewayUrl = gatewayBase ? `${gatewayBase}${url}` : '';
 
 /**
  * Module-scope cache of the `orchestratorGatewayRouting` cohort flag. The tRPC
@@ -116,6 +116,10 @@ function withGatewaySplit({
   // server we never route to the gateway — SSR orchestrator calls stay on the monolith.
   // (Same hazard class as the per-request QueryClient note below.)
   if (typeof window === 'undefined') return monolithLink;
+  // NO MONOLITH FALLBACK: `splitLink` is a static route — a matched (allowlisted +
+  // flagged) op goes ONLY to the gateway; if it's down/5xx/TLS-fails the op fails,
+  // there is no client retry-on-monolith. Kill-switch = Flipt-off the cohort OR
+  // empty `ORCHESTRATOR_GATEWAY_PROCEDURES`.
   return splitLink({
     condition: (op) =>
       shouldRouteToGateway(op.path, { enabled: gatewayRoutingEnabled, url: gatewayUrl }),


### PR DESCRIPTION
## What

Scaffolds the **DARK** feature-flag routing plumbing for the orchestrator-gateway spin-out (see `claudedocs/plan-orchestrator-api-spinout-2026-06-30.md` §4c in datapacket-talos). This is Repo A of a two-repo pair; Repo B (datapacket-talos #329) adds the dedicated `orchestrator-gateway.civitai.com` ingress.

**Provable no-op in this state.** The procedure allowlist `ORCHESTRATOR_GATEWAY_PROCEDURES` ships **EMPTY**, so 100% of `orchestrator.*` traffic stays on the monolith regardless of the flag or the env URL. The gateway branch of the split is *never* taken today.

## Changes

- **Flag** `orchestratorGatewayRouting` (`availability: ['mod']`, flipt key `orchestrator-gateway-routing`) — mirrors `appBlocksGetStarted`. It's fine that this resolves true for mods; the empty allowlist is the hard dark guarantee.
- **Env** `NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL` (client-schema, default `''`) — empty/absent ⇒ split falls back to the monolith. Added to `.env-example`.
- **`src/utils/orchestrator-gateway-routing.ts`** (new) — the EMPTY `ORCHESTRATOR_GATEWAY_PROCEDURES` allowlist + a pure `shouldRouteToGateway(path, {enabled, url, allowlist})` predicate, extracted so the routing decision is unit-testable without a live server.
- **`src/utils/trpc.ts`** — module-scope `gatewayRoutingEnabled` cache + `setGatewayRouting()` setter (link chain runs outside React); `withGatewaySplit()` wraps the terminating link in a `splitLink` on **both** the `trpc` (React) and `trpcVanilla` clients. **Reuses `httpLinkWithLargeQuerySupport` on both branches** so large-query POST behavior is preserved. Any of {flag off, allowlist miss, env empty, non-orchestrator path} ⇒ monolith.
- **`FeatureFlagsProvider.tsx`** — mirrors the resolved `orchestratorGatewayRouting` flag into the module-scope cache on mount (default `false`).
- **Tests** (`src/utils/__tests__/orchestrator-gateway-routing.test.ts`) — asserts the empty allowlist routes NOTHING to the gateway (every sampled `orchestrator.*` path → monolith), and that the gateway branch is only reachable when a path is allowlisted AND flag on AND url set. 8 cases, vitest `unit` project.

## Phased enablement (post-merge, no further deploy)

Dark today. Rollout is a **pure Flipt/allowlist change**:
1. Grow `ORCHESTRATOR_GATEWAY_PROCEDURES` as the gateway backs each procedure (P1 `whatIfFromGraph`, P2 generate/status, …).
2. Set `NEXT_PUBLIC_ORCHESTRATOR_GATEWAY_URL` to the gateway origin.
3. Flip the Flipt cohort (`[]`/off → `['mod']` → `['public']` on explicit confirm).

Two-dimensional gate (WHICH USERS via flag × WHICH PROCEDURES via allowlist) — condition ANDs both.

## Verification

- `vitest run --project unit src/utils/__tests__/orchestrator-gateway-routing.test.ts` → **8/8 pass**.
- `tsc --noEmit` (full project) → **0 errors**; none reference the new symbols.
- No `pnpm-lock.yaml` change (no deps added — `splitLink`/`httpLink` already imported), so frozen-lockfile CI is safe.

## Dependencies

**Depends on nothing** — safe to merge independently. The client sends no traffic to the gateway while the allowlist is empty, so it doesn't matter whether the gateway host/image exists yet.