### PR TITLE
fix(app-blocks): simplify review-sandbox mod-gate to entry-gate-only

### DIFF
--- a/src/pages/api/internal/mod-gate.ts
+++ b/src/pages/api/internal/mod-gate.ts
@@ -1,14 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { withAxiom } from '@civitai/next-axiom';
-import {
-  REVIEW_SESSION_COOKIE_TTL_SECONDS,
-  signReviewSessionCookie,
-  verifyReviewAccessToken,
-  verifyReviewSessionCookie,
-} from '~/server/services/blocks/review-session';
+import { verifyReviewAccessToken } from '~/server/services/blocks/review-session';
 
 /**
- * GET/ANY /api/internal/mod-gate  (MOD REVIEW SANDBOX, #2831 / #2847)
+ * GET/ANY /api/internal/mod-gate  (MOD REVIEW SANDBOX, #2831 / #2847 / #2855)
  *
  * A Traefik `forwardAuth` target guarding the temporary review-preview hosts
  * (`review-<sha16>.<APPS_DOMAIN>`). The review preview is a CROSS-ORIGIN iframe
@@ -21,54 +16,52 @@ import {
  * mints a signed, short-TTL (120s), mod-bound ENTRY token (see
  * `review-session.ts`) and injects it into the iframe `src` as `?mr=<token>`.
  *
- * ── FULL SUBRESOURCE GATING (the #2847 hardening) ──
- * The earlier design gated ONLY the entry document and ALLOWED every subresource
- * (`Sec-Fetch-Dest != document` → 200). That was a SPOOF HOLE: a raw client could
- * send `Sec-Fetch-Dest: image` (or any non-document value) with no token and pull
- * the unapproved block bundle. This gate closes it with a CHIPS `Partitioned`
- * session cookie:
+ * ── ENTRY-GATE-ONLY (this is the current design) ──
+ * This gate authorizes ONLY the ENTRY document/iframe request (the one that can
+ * carry the `mr` token) and ALLOWS every subresource (script/style/image/font/
+ * fetch/empty/…) through unauthenticated:
  *
- *   1. SESSION COOKIE PRESENT (`__Host-review-sess`) and valid for this host →
- *      200 + `X-Mod-Id`. Covers BOTH the entry document AND every subresource,
- *      because the browser replays the partitioned cookie on same-host requests.
+ *   - ENTRY request (Sec-Fetch-Dest document/iframe/frame/nested-document, OR
+ *     the header ABSENT — treated as entry, fail-safe): require a valid `mr`
+ *     token whose bound host === X-Forwarded-Host → 200 + `X-Mod-Id`, else 401.
+ *   - SUBRESOURCE request (any other Sec-Fetch-Dest): 200 (allow).
+ *   - Missing X-Forwarded-Host → 401 (fail-closed; can't bind/verify anything).
  *
- *   2. Else ENTRY (`Sec-Fetch-Dest` document/iframe/frame/nested-document OR
- *      absent) with a valid `mr` token (host match) → 200 + `X-Mod-Id` AND a
- *      `Set-Cookie: __Host-review-sess=...; SameSite=None; Secure; HttpOnly;
- *      Partitioned; Max-Age=1800` so subsequent subresources carry the cookie.
+ * ── WHY THE CHIPS SUBRESOURCE-COOKIE GATE WAS REVERTED ──
+ * The earlier #2847 hardening tried to gate EVERY subresource with a CHIPS
+ * `Partitioned` session cookie: on a valid `mr` entry, the gate returned 200
+ * WITH a `Set-Cookie: __Host-review-sess=...; Partitioned; SameSite=None` so the
+ * browser would replay that cookie on subsequent subresource requests, and each
+ * subresource would then be verified against it.
  *
- *   3. Else (a subresource with no/invalid cookie, OR an entry with no/invalid
- *      token) → 401. Fail-closed.
+ * That does NOT work: **Traefik `forwardAuth` does not forward a 2xx auth
+ * response's `Set-Cookie` header back to the client** (confirmed live — an entry
+ * request with a valid token returns 200 with NO Set-Cookie reaching the
+ * browser). So the CHIPS session cookie is never set, and every subsequent
+ * subresource arrives with no cookie → 401 → the review preview never renders.
+ * The subresource-cookie gate was therefore REVERTED to this entry-gate-only
+ * design.
  *
- * The cookie is `__Host-`-prefixed with NO `Domain` attribute, so it is
- * host-locked to the exact `review-<sha16>.civit.ai` it was set on (a sibling
- * review host can't read it). `Partitioned` + `SameSite=None` + `Secure` = CHIPS,
- * required for the cookie to be stored/replayed inside the cross-site iframe.
+ * ── ACCEPTED TRADEOFF ──
+ * Subresources are served WITHOUT per-request auth. The residual risk is low and
+ * accepted:
+ *   - The `mr` token still gates the ENTRY document, so a non-mod cannot LOAD the
+ *     preview page at all.
+ *   - The `review-<sha16>` host is a ~64-bit secret (the sha16 hostname) surfaced
+ *     ONLY to mods. It is mod-only, ephemeral, and exists purely for the
+ *     pre-approval preview — an attacker who does not already know the exact host
+ *     can't request its subresources, and the host is torn down after review.
  *
- * ── DEPENDENCY: Traefik forwardAuth Cookie / Set-Cookie forwarding (CONFIRM ON CLUSTER) ──
- * This design relies on Traefik forwardAuth:
- *   (a) FORWARDING the inbound request `Cookie` header to this endpoint (so we
- *       can read `__Host-review-sess` on subresource requests), and
- *   (b) FORWARDING this endpoint's `Set-Cookie` header from the 2xx auth response
- *       back to the browser on the entry response.
- * Both are the STANDARD forwardAuth behavior (it's exactly how oauth2-proxy's
- * forwardAuth integration sets its session cookie), but (b) in particular is the
- * ONE wiring assumption that cannot be exercised without the live cluster — it
- * MUST be confirmed on-cluster before flipping the feature flag. If Traefik does
- * NOT forward Set-Cookie on a 2xx auth response, the FALLBACK is a 302-strip
- * handshake: the gate, on a valid entry token, 302-redirects to the SAME URL with
- * the `mr` param stripped and the `Set-Cookie` on the 302 (Traefik forwards
- * Set-Cookie on auth redirects); the browser then re-requests the document
- * carrying the cookie. That fallback is NOT implemented here (it adds a redirect
- * round-trip and isn't needed if (b) holds) — documented so it's a known lever.
- *
- * ── SAFARI LIMITATION (accepted tradeoff) ──
- * Safari does NOT support CHIPS / the `Partitioned` cookie attribute and hard-
- * blocks third-party cookies, so the session cookie is NOT stored inside the
- * cross-site iframe → every subresource request arrives with no cookie → 401 →
- * the preview is BROKEN in Safari. Review previews therefore require a
- * Chromium- or Firefox-based browser. This tradeoff was accepted (full
- * subresource gating > Safari compatibility for a mod-only review tool).
+ * ── FUTURE HARDENING (if per-subresource gating is ever wanted) ──
+ * A **302-strip handshake** would restore subresource gating without depending on
+ * 2xx Set-Cookie forwarding: on a valid `mr` token, mod-gate returns a `302` to
+ * the SAME URL minus the `mr` param, WITH the `Set-Cookie` on the redirect —
+ * Traefik DOES forward headers (incl. Set-Cookie) on a NON-2xx auth response, so
+ * the CHIPS cookie is set via the redirect; the browser then re-requests the
+ * document (now cookie-carrying) and subsequent subresources carry the cookie
+ * too. This is still CHIPS-only (Chromium/Firefox; Safari hard-blocks the
+ * `Partitioned` cookie so it would be excluded). NOT implemented — documented as
+ * a known lever.
  *
  * No body is read and no method is enforced: Traefik forwardAuth issues a GET by
  * default but may mirror the original method, so we accept any method.
@@ -78,10 +71,6 @@ import {
  *  LOADED" (an entry request that may carry the mod `mr` token). Everything else
  *  is a subresource. An ABSENT header is treated as entry (fail-safe). */
 const ENTRY_DESTS = new Set(['document', 'iframe', 'frame', 'nested-document']);
-
-/** Cookie name. `__Host-` prefix REQUIRES Secure + Path=/ + NO Domain → the
- *  browser host-locks it to the exact review host (sibling hosts can't read it). */
-const SESSION_COOKIE_NAME = '__Host-review-sess';
 
 function firstHeader(v: string | string[] | undefined): string | undefined {
   if (Array.isArray(v)) return v[0];
@@ -102,49 +91,11 @@ function extractMrToken(forwardedUri: string | undefined): string | undefined {
   }
 }
 
-/** Parse the `__Host-review-sess` value out of a forwarded `Cookie` header.
- *  Returns undefined if absent / unparseable. Does its own minimal cookie-pair
- *  split (no library) so the gate stays dependency-light. */
-function extractSessionCookie(cookieHeader: string | undefined): string | undefined {
-  if (!cookieHeader) return undefined;
-  for (const part of cookieHeader.split(';')) {
-    const eq = part.indexOf('=');
-    if (eq < 0) continue;
-    const name = part.slice(0, eq).trim();
-    if (name === SESSION_COOKIE_NAME) {
-      const raw = part.slice(eq + 1).trim();
-      if (!raw) return undefined;
-      try {
-        return decodeURIComponent(raw);
-      } catch {
-        return raw;
-      }
-    }
-  }
-  return undefined;
-}
-
-/** Build the `Set-Cookie` header value for the CHIPS partitioned session cookie.
- *  `__Host-` + Path=/ + no Domain (host-lock) · Secure · HttpOnly · SameSite=None
- *  + Partitioned (CHIPS, so it's stored/replayed inside the cross-site iframe). */
-function buildSessionSetCookie(value: string): string {
-  return [
-    `${SESSION_COOKIE_NAME}=${value}`,
-    'Path=/',
-    'Secure',
-    'HttpOnly',
-    'SameSite=None',
-    'Partitioned',
-    `Max-Age=${REVIEW_SESSION_COOKIE_TTL_SECONDS}`,
-  ].join('; ');
-}
-
 export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   // Traefik forwardAuth mirrors the original request headers (lowercased by Node).
   const forwardedHost = firstHeader(req.headers['x-forwarded-host']);
   const forwardedUri = firstHeader(req.headers['x-forwarded-uri']);
   const secFetchDest = firstHeader(req.headers['sec-fetch-dest']);
-  const cookieHeader = firstHeader(req.headers['cookie']);
 
   // Fail-closed: without the review host we can't bind/verify anything.
   if (!forwardedHost) {
@@ -152,44 +103,27 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  // 1) SESSION COOKIE path — authorizes BOTH the entry document AND subresources.
-  //    Checked first so an established session never depends on Sec-Fetch-Dest.
-  const sessionCookie = extractSessionCookie(cookieHeader);
-  if (sessionCookie) {
-    const sess = verifyReviewSessionCookie(sessionCookie, forwardedHost);
-    if (sess.ok && sess.modUserId != null) {
-      res.setHeader('X-Mod-Id', String(sess.modUserId));
-      res.status(200).json({ ok: true, via: 'session' });
-      return;
-    }
-    // Invalid/expired/host-mismatched cookie → fall through to the entry/token
-    // path (an entry request with a stale cookie can re-establish via its token).
-  }
-
-  // 2) ENTRY path — a valid `mr` token mints the session cookie. An ABSENT
-  //    Sec-Fetch-Dest is treated as entry (fail-safe).
+  // SUBRESOURCE (any Sec-Fetch-Dest that is NOT an entry dest) → allow. See the
+  // header comment: the CHIPS subresource-cookie gate can't be set (Traefik
+  // doesn't forward the 2xx Set-Cookie), so subresources are served without
+  // per-request auth (accepted tradeoff — the `mr` gate on the ENTRY document
+  // still keeps non-mods out of the preview).
   const isEntry = secFetchDest == null || ENTRY_DESTS.has(secFetchDest);
-  if (isEntry) {
-    const token = extractMrToken(forwardedUri);
-    const result = verifyReviewAccessToken(token, forwardedHost);
-    if (result.ok && result.modUserId != null) {
-      // Mint the CHIPS partitioned session cookie so EVERY subsequent
-      // subresource is gated too (closes the Sec-Fetch-Dest spoof hole). Relies
-      // on Traefik forwarding this Set-Cookie on the 2xx auth response — see the
-      // header comment (must be confirmed on-cluster).
-      const cookieValue = signReviewSessionCookie({
-        modUserId: result.modUserId,
-        host: forwardedHost,
-      });
-      res.setHeader('Set-Cookie', buildSessionSetCookie(cookieValue));
-      res.setHeader('X-Mod-Id', String(result.modUserId));
-      res.status(200).json({ ok: true, via: 'token' });
-      return;
-    }
+  if (!isEntry) {
+    res.status(200).json({ ok: true, via: 'subresource' });
+    return;
   }
 
-  // 3) Else (subresource with no/invalid cookie, OR entry with no/invalid token)
-  //    → 401. This is the closed spoof hole: a `Sec-Fetch-Dest: image` (or any
-  //    subresource) request with no valid session cookie is now REJECTED.
+  // ENTRY (document/iframe/frame/nested-document, or ABSENT Sec-Fetch-Dest which
+  // is treated as entry, fail-safe) → require a valid `mr` token bound to this host.
+  const token = extractMrToken(forwardedUri);
+  const result = verifyReviewAccessToken(token, forwardedHost);
+  if (result.ok && result.modUserId != null) {
+    res.setHeader('X-Mod-Id', String(result.modUserId));
+    res.status(200).json({ ok: true, via: 'token' });
+    return;
+  }
+
+  // Entry with no/invalid/expired/forged/host-mismatched token → 401. Fail-closed.
   res.status(401).json({ error: 'Moderator review session required' });
 });

--- a/src/server/services/blocks/__tests__/review-session.test.ts
+++ b/src/server/services/blocks/__tests__/review-session.test.ts
@@ -2,10 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   signReviewAccessToken,
   verifyReviewAccessToken,
-  signReviewSessionCookie,
-  verifyReviewSessionCookie,
   REVIEW_ACCESS_TOKEN_TTL_SECONDS,
-  REVIEW_SESSION_COOKIE_TTL_SECONDS,
 } from '~/server/services/blocks/review-session';
 
 /**
@@ -136,124 +133,6 @@ describe('signReviewAccessToken / verifyReviewAccessToken', () => {
       delete process.env.NEXTAUTH_SECRET;
       expect(() => verifyReviewAccessToken(token, HOST)).not.toThrow();
       expect(verifyReviewAccessToken(token, HOST).ok).toBe(false);
-    });
-  });
-});
-
-describe('signReviewSessionCookie / verifyReviewSessionCookie (CHIPS subresource gate, #2847)', () => {
-  it('roundtrips: a freshly-minted session cookie verifies for the bound host + returns modUserId', () => {
-    const value = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-    expect(value).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
-    expect(verifyReviewSessionCookie(value, HOST, { secret: SECRET })).toEqual({
-      ok: true,
-      modUserId: MOD,
-    });
-  });
-
-  it('rejects a session cookie verified against a DIFFERENT host (host binding)', () => {
-    const value = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-    expect(
-      verifyReviewSessionCookie(value, 'review-deadbeef.civit.ai', { secret: SECRET })
-    ).toEqual({ ok: false });
-  });
-
-  it('rejects a session cookie signed with a different secret (sig mismatch)', () => {
-    const value = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: 'other-secret' });
-    expect(verifyReviewSessionCookie(value, HOST, { secret: SECRET })).toEqual({ ok: false });
-  });
-
-  it('rejects an expired session cookie (exp in the past)', () => {
-    const value = signReviewSessionCookie({
-      modUserId: MOD,
-      host: HOST,
-      secret: SECRET,
-      ttlSeconds: -1,
-    });
-    expect(verifyReviewSessionCookie(value, HOST, { secret: SECRET })).toEqual({ ok: false });
-  });
-
-  it('accepts a session cookie still within TTL (boundary sanity)', () => {
-    const value = signReviewSessionCookie({
-      modUserId: MOD,
-      host: HOST,
-      secret: SECRET,
-      ttlSeconds: REVIEW_SESSION_COOKIE_TTL_SECONDS,
-    });
-    expect(verifyReviewSessionCookie(value, HOST, { secret: SECRET }).ok).toBe(true);
-  });
-
-  it('rejects a tampered payload (modUserId changed → signing string differs)', () => {
-    const value = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-    const [payloadB64, sigB64] = value.split('.');
-    const payload = JSON.parse(
-      Buffer.from(payloadB64.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
-    );
-    payload.m = 9999;
-    const forgedPayloadB64 = Buffer.from(JSON.stringify(payload))
-      .toString('base64')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/, '');
-    expect(
-      verifyReviewSessionCookie(`${forgedPayloadB64}.${sigB64}`, HOST, { secret: SECRET })
-    ).toEqual({ ok: false });
-  });
-
-  it('rejects a sig of the wrong byte length without throwing (length guard)', () => {
-    const value = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-    const [payloadB64] = value.split('.');
-    const forged = `${payloadB64}.AAAA`;
-    expect(() => verifyReviewSessionCookie(forged, HOST, { secret: SECRET })).not.toThrow();
-    expect(verifyReviewSessionCookie(forged, HOST, { secret: SECRET })).toEqual({ ok: false });
-  });
-
-  it.each([
-    ['empty string', ''],
-    ['null', null],
-    ['undefined', undefined],
-    ['no dot', 'notatoken'],
-    ['leading dot', '.abc'],
-    ['trailing dot', 'abc.'],
-    ['non-json payload', `${Buffer.from('nope').toString('base64url')}.AAAA`],
-  ])('returns ok:false (no throw) for malformed input: %s', (_label, input) => {
-    expect(() =>
-      verifyReviewSessionCookie(input as string | null | undefined, HOST, { secret: SECRET })
-    ).not.toThrow();
-    expect(
-      verifyReviewSessionCookie(input as string | null | undefined, HOST, { secret: SECRET }).ok
-    ).toBe(false);
-  });
-
-  it('verify returns ok:false (no throw) when NEXTAUTH_SECRET is unset (fail-closed)', () => {
-    const value = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-    const prev = process.env.NEXTAUTH_SECRET;
-    delete process.env.NEXTAUTH_SECRET;
-    try {
-      expect(() => verifyReviewSessionCookie(value, HOST)).not.toThrow();
-      expect(verifyReviewSessionCookie(value, HOST).ok).toBe(false);
-    } finally {
-      if (prev === undefined) delete process.env.NEXTAUTH_SECRET;
-      else process.env.NEXTAUTH_SECRET = prev;
-    }
-  });
-
-  // ── DOMAIN-SEPARATION: the two token types must be NON-interchangeable. This is
-  //    the load-bearing isolation — an attacker who captures a 120s `mr` entry
-  //    token must NOT be able to replay it as a 30min subresource session cookie,
-  //    and vice-versa. ──
-  describe('domain separation (entry token vs session cookie are non-interchangeable)', () => {
-    it('an `mr` ENTRY token does NOT verify as a SESSION cookie', () => {
-      const entry = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
-      // sanity: it IS a valid entry token
-      expect(verifyReviewAccessToken(entry, HOST, { secret: SECRET }).ok).toBe(true);
-      // but it MUST NOT verify as a session cookie
-      expect(verifyReviewSessionCookie(entry, HOST, { secret: SECRET })).toEqual({ ok: false });
-    });
-
-    it('a SESSION cookie does NOT verify as an `mr` ENTRY token', () => {
-      const sess = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-      expect(verifyReviewSessionCookie(sess, HOST, { secret: SECRET }).ok).toBe(true);
-      expect(verifyReviewAccessToken(sess, HOST, { secret: SECRET })).toEqual({ ok: false });
     });
   });
 });

--- a/src/server/services/blocks/review-session.ts
+++ b/src/server/services/blocks/review-session.ts
@@ -34,28 +34,10 @@ import { createHmac, timingSafeEqual } from 'crypto';
 /** ENTRY-token TTL in seconds. Intentionally short: mint → iframe document load. */
 export const REVIEW_ACCESS_TOKEN_TTL_SECONDS = 120;
 
-/**
- * SESSION-cookie TTL in seconds (30min). Once the mod has LOADED the preview
- * (proving the short-lived `mr` entry token), the gate hands back a CHIPS
- * `Partitioned` session cookie that authorizes BOTH the entry document AND every
- * subresource for the remainder of the review session. Longer-lived than the
- * entry token because a single review (scrolling, clicking around the previewed
- * block) can run for many minutes.
- */
-export const REVIEW_SESSION_COOKIE_TTL_SECONDS = 1800;
-
 /** Domain-separation prefix for the short-TTL ENTRY token (carried as `?mr=`).
  *  So this HMAC can never collide with another the app signs over the same
  *  NEXTAUTH_SECRET. Bump `v1` if the payload shape changes. */
 const DOMAIN_PREFIX = 'review-mr:v1';
-
-/** DISTINCT domain-separation prefix for the longer-TTL SESSION cookie
- *  (carried as the `__Host-review-sess` cookie). A token minted under one prefix
- *  can NEVER verify under the other (the constant-time compare is over the
- *  prefixed signing string), so an attacker who captures an `mr` entry token can
- *  NOT replay it as a session cookie to gain subresource access, and vice-versa.
- *  This cross-use isolation is the load-bearing reason the two prefixes differ. */
-const SESSION_DOMAIN_PREFIX = 'review-sess:v1';
 
 type ReviewAccessPayload = {
   /** Moderator user id the token is bound to (audit + X-Mod-Id). */
@@ -76,16 +58,11 @@ function base64urlToBuffer(input: string): Buffer {
   return Buffer.from(input.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64');
 }
 
-/** The domain-separated string that is HMAC'd, parameterised by prefix so the
- *  ENTRY token (`DOMAIN_PREFIX`) and the SESSION cookie (`SESSION_DOMAIN_PREFIX`)
- *  produce non-interchangeable signatures over identical {m,h,exp} payloads. */
-function signingStringFor(prefix: string, p: ReviewAccessPayload): string {
-  return `${prefix}:${p.m}:${p.h}:${p.exp}`;
-}
-
-/** The domain-separated string for the short-TTL ENTRY (`mr`) token. */
+/** The domain-separated string for the short-TTL ENTRY (`mr`) token that is
+ *  HMAC'd. The `DOMAIN_PREFIX` ensures this HMAC can never collide with another
+ *  the app signs over the same NEXTAUTH_SECRET. */
 function signingString(p: ReviewAccessPayload): string {
-  return signingStringFor(DOMAIN_PREFIX, p);
+  return `${DOMAIN_PREFIX}:${p.m}:${p.h}:${p.exp}`;
 }
 
 function hmac(secret: string, signingStr: string): Buffer {
@@ -201,115 +178,4 @@ function resolveSecret(): string {
   const secret = process.env.NEXTAUTH_SECRET;
   if (!secret) throw new Error('NEXTAUTH_SECRET is not set');
   return secret;
-}
-
-// ───────────────────────────────────────────────────────────────────────────
-// REVIEW SESSION COOKIE (CHIPS Partitioned subresource gate, #2847 hardening)
-//
-// The `mr` entry token (above) only proves the ENTRY document load. To gate
-// EVERY subresource (so a raw client can't spoof `Sec-Fetch-Dest: image` and
-// pull the unapproved bundle) the mod-gate hands back this longer-TTL session
-// cookie on the 2xx entry response. It is the SAME HMAC construction as the
-// entry token but under a DISTINCT domain-separation prefix
-// (`SESSION_DOMAIN_PREFIX`) so the two can never be cross-used, and with a 30min
-// TTL covering a full review session. Same fail-closed posture: constant-time
-// verify, length guard, malformed → {ok:false}, secret-unset → {ok:false}.
-// ───────────────────────────────────────────────────────────────────────────
-
-/** The domain-separated string for the longer-TTL SESSION cookie. */
-function sessionSigningString(p: ReviewAccessPayload): string {
-  return signingStringFor(SESSION_DOMAIN_PREFIX, p);
-}
-
-export type SignReviewSessionCookieParams = {
-  modUserId: number;
-  host: string;
-  /** Injected for testability; defaults to env.NEXTAUTH_SECRET. */
-  secret?: string;
-  /** Injected for testability; defaults to REVIEW_SESSION_COOKIE_TTL_SECONDS. */
-  ttlSeconds?: number;
-};
-
-/**
- * Mint the `__Host-review-sess` cookie VALUE — a compact
- * `base64url(payload).base64url(sig)` bound to (modUserId, host), valid for
- * `ttlSeconds` (default 1800s). Signed under `SESSION_DOMAIN_PREFIX` so it can
- * NOT be confused with (or substituted for) the `mr` entry token.
- */
-export function signReviewSessionCookie(params: SignReviewSessionCookieParams): string {
-  const secret = params.secret ?? resolveSecret();
-  const ttl = params.ttlSeconds ?? REVIEW_SESSION_COOKIE_TTL_SECONDS;
-  const payload: ReviewAccessPayload = {
-    m: params.modUserId,
-    h: params.host,
-    exp: nowSec() + ttl,
-  };
-  const payloadB64 = base64url(JSON.stringify(payload));
-  const sigB64 = base64url(hmac(secret, sessionSigningString(payload)));
-  return `${payloadB64}.${sigB64}`;
-}
-
-export type VerifyReviewSessionCookieResult = {
-  ok: boolean;
-  modUserId?: number;
-};
-
-/**
- * Verify a `__Host-review-sess` cookie value against the expected host. NEVER
- * throws on malformed input — returns `{ ok:false }`. Identical check set to the
- * entry token (structurally parseable, constant-time HMAC match, not expired,
- * host binding) BUT over the SESSION domain-separation prefix, so an `mr` entry
- * token presented here will fail the signature compare (cross-use isolation).
- */
-export function verifyReviewSessionCookie(
-  value: string | null | undefined,
-  expectedHost: string,
-  opts?: { secret?: string }
-): VerifyReviewSessionCookieResult {
-  const fail: VerifyReviewSessionCookieResult = { ok: false };
-  if (!value || typeof value !== 'string') return fail;
-
-  const dot = value.indexOf('.');
-  if (dot <= 0 || dot === value.length - 1) return fail;
-  const payloadB64 = value.slice(0, dot);
-  const sigB64 = value.slice(dot + 1);
-
-  let payload: ReviewAccessPayload;
-  try {
-    const parsed = JSON.parse(base64urlToBuffer(payloadB64).toString('utf8'));
-    if (
-      !parsed ||
-      typeof parsed !== 'object' ||
-      typeof parsed.m !== 'number' ||
-      typeof parsed.h !== 'string' ||
-      typeof parsed.exp !== 'number'
-    ) {
-      return fail;
-    }
-    payload = parsed as ReviewAccessPayload;
-  } catch {
-    return fail;
-  }
-
-  let secret: string;
-  try {
-    secret = opts?.secret ?? resolveSecret();
-  } catch {
-    return fail;
-  }
-
-  const expectedSig = hmac(secret, sessionSigningString(payload));
-  let providedSig: Buffer;
-  try {
-    providedSig = base64urlToBuffer(sigB64);
-  } catch {
-    return fail;
-  }
-  if (providedSig.length !== expectedSig.length) return fail;
-  if (!timingSafeEqual(providedSig, expectedSig)) return fail;
-
-  if (payload.exp <= nowSec()) return fail;
-  if (payload.h !== expectedHost) return fail;
-
-  return { ok: true, modUserId: payload.m };
 }

--- a/src/tests/api/internal/blocks/mod-gate.test.ts
+++ b/src/tests/api/internal/blocks/mod-gate.test.ts
@@ -1,25 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import {
-  signReviewAccessToken,
-  signReviewSessionCookie,
-} from '~/server/services/blocks/review-session';
+import { signReviewAccessToken } from '~/server/services/blocks/review-session';
 
 /**
- * MOD REVIEW SANDBOX (#2831 / #2847) — coverage for the Traefik forwardAuth
- * target /api/internal/mod-gate, now a FULL SUBRESOURCE GATE (CHIPS session
- * cookie), not just an entry gate.
+ * MOD REVIEW SANDBOX (#2831 / #2847 / #2855) — coverage for the Traefik
+ * forwardAuth target /api/internal/mod-gate, now an ENTRY-GATE-ONLY gate.
  *
- *   - SESSION COOKIE (valid) → 200 + X-Mod-Id for ANY dest (incl. subresource)
- *   - ENTRY (document/iframe/absent) + valid mr + matching host → 200 + X-Mod-Id
- *     AND Set-Cookie present (__Host- + Partitioned + SameSite=None + Secure)
- *   - SUBRESOURCE (Sec-Fetch-Dest: image/script) with NO cookie → 401  ← spoof hole closed
+ * The CHIPS subresource-cookie gate was reverted: Traefik forwardAuth does not
+ * forward a 2xx auth response's Set-Cookie back to the client, so the session
+ * cookie could never be set (every subresource 401'd → preview never rendered).
+ *
+ *   - ENTRY (document/iframe/frame/nested-document/absent) + valid mr + matching
+ *     host → 200 + X-Mod-Id (NO Set-Cookie)
  *   - ENTRY + missing / expired / forged / host-mismatched mr → 401
- *   - INVALID/expired session cookie → falls through to entry/token logic
+ *   - ABSENT Sec-Fetch-Dest → treated as ENTRY → needs a token (401 without one)
+ *   - SUBRESOURCE (Sec-Fetch-Dest: image/script/empty) → 200 (no token/cookie needed)
  *   - missing X-Forwarded-Host → 401 (fail-closed)
  *
- * The handler is driven directly with mock req/res. The token + cookie utils are
- * REAL (signed with an injected secret via process.env.NEXTAUTH_SECRET).
+ * The handler is driven directly with mock req/res. The token util is REAL
+ * (signed with an injected secret via process.env.NEXTAUTH_SECRET).
  */
 
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
@@ -73,11 +72,7 @@ function entryUriWithToken(token: string): string {
   return `/some-slug?mr=${encodeURIComponent(token)}`;
 }
 
-function sessionCookieHeader(value: string): string {
-  return `__Host-review-sess=${value}`;
-}
-
-describe('/api/internal/mod-gate (full subresource gate)', () => {
+describe('/api/internal/mod-gate (entry-gate-only)', () => {
   const prev = process.env.NEXTAUTH_SECRET;
   beforeEach(() => {
     process.env.NEXTAUTH_SECRET = SECRET;
@@ -88,81 +83,9 @@ describe('/api/internal/mod-gate (full subresource gate)', () => {
     vi.clearAllMocks();
   });
 
-  // ── SESSION COOKIE path (gates subresources) ──────────────────────────────
+  // ── ENTRY path (requires a valid mr token) ────────────────────────────────
 
-  it('SESSION cookie (valid) + matching host → 200 for a SUBRESOURCE (script)', async () => {
-    const cookie = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-    const res = makeRes();
-    await handler(
-      makeReq({
-        host: HOST,
-        uri: '/assets/index.js',
-        secFetchDest: 'script',
-        cookie: sessionCookieHeader(cookie),
-      }),
-      res
-    );
-    expect(res.statusCode).toBe(200);
-    expect(res._headers['X-Mod-Id']).toBe(String(MOD));
-  });
-
-  it('SESSION cookie (valid) → 200 for an IMAGE subresource (the previously spoofable dest)', async () => {
-    const cookie = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
-    const res = makeRes();
-    await handler(
-      makeReq({
-        host: HOST,
-        uri: '/assets/logo.png',
-        secFetchDest: 'image',
-        cookie: sessionCookieHeader(cookie),
-      }),
-      res
-    );
-    expect(res.statusCode).toBe(200);
-  });
-
-  it('SESSION cookie bound to a DIFFERENT host → not honoured (falls through, subresource → 401)', async () => {
-    const cookie = signReviewSessionCookie({
-      modUserId: MOD,
-      host: 'review-deadbeefdeadbeef.civit.ai',
-      secret: SECRET,
-    });
-    const res = makeRes();
-    await handler(
-      makeReq({
-        host: HOST,
-        uri: '/assets/index.js',
-        secFetchDest: 'script',
-        cookie: sessionCookieHeader(cookie),
-      }),
-      res
-    );
-    expect(res.statusCode).toBe(401);
-  });
-
-  // ── THE CLOSED SPOOF HOLE ─────────────────────────────────────────────────
-
-  it('SUBRESOURCE (Sec-Fetch-Dest: image) with NO cookie/token → 401 (spoof hole closed)', async () => {
-    const res = makeRes();
-    await handler(makeReq({ host: HOST, uri: '/assets/logo.png', secFetchDest: 'image' }), res);
-    expect(res.statusCode).toBe(401);
-  });
-
-  it('SUBRESOURCE (Sec-Fetch-Dest: script) with NO cookie/token → 401', async () => {
-    const res = makeRes();
-    await handler(makeReq({ host: HOST, uri: '/assets/index.js', secFetchDest: 'script' }), res);
-    expect(res.statusCode).toBe(401);
-  });
-
-  it('SUBRESOURCE (Sec-Fetch-Dest: empty / XHR) with NO cookie → 401', async () => {
-    const res = makeRes();
-    await handler(makeReq({ host: HOST, uri: '/api/x', secFetchDest: 'empty' }), res);
-    expect(res.statusCode).toBe(401);
-  });
-
-  // ── ENTRY path (mints the session cookie) ─────────────────────────────────
-
-  it('ENTRY (document) + valid mr + matching host → 200 + X-Mod-Id AND Set-Cookie (CHIPS)', async () => {
+  it('ENTRY (document) + valid mr + matching host → 200 + X-Mod-Id, NO Set-Cookie', async () => {
     const token = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
     const res = makeRes();
     await handler(
@@ -171,19 +94,10 @@ describe('/api/internal/mod-gate (full subresource gate)', () => {
     );
     expect(res.statusCode).toBe(200);
     expect(res._headers['X-Mod-Id']).toBe(String(MOD));
-    const setCookie = res._headers['Set-Cookie'];
-    expect(setCookie).toBeTruthy();
-    expect(setCookie).toContain('__Host-review-sess=');
-    expect(setCookie).toContain('Partitioned');
-    expect(setCookie).toContain('SameSite=None');
-    expect(setCookie).toContain('Secure');
-    expect(setCookie).toContain('HttpOnly');
-    expect(setCookie).toContain('Path=/');
-    expect(setCookie).toContain('Max-Age=1800');
-    expect(setCookie).not.toContain('Domain=');
+    expect(res._headers['Set-Cookie']).toBeUndefined();
   });
 
-  it('ENTRY (iframe) with a valid mr token → 200 + Set-Cookie', async () => {
+  it('ENTRY (iframe) with a valid mr token → 200 + X-Mod-Id', async () => {
     const token = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
     const res = makeRes();
     await handler(
@@ -191,7 +105,18 @@ describe('/api/internal/mod-gate (full subresource gate)', () => {
       res
     );
     expect(res.statusCode).toBe(200);
-    expect(res._headers['Set-Cookie']).toContain('Partitioned');
+    expect(res._headers['X-Mod-Id']).toBe(String(MOD));
+    expect(res._headers['Set-Cookie']).toBeUndefined();
+  });
+
+  it('ENTRY (nested-document) with a valid mr token → 200', async () => {
+    const token = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
+    const res = makeRes();
+    await handler(
+      makeReq({ host: HOST, uri: entryUriWithToken(token), secFetchDest: 'nested-document' }),
+      res
+    );
+    expect(res.statusCode).toBe(200);
   });
 
   it('ENTRY with NO mr token → 401', async () => {
@@ -239,90 +164,62 @@ describe('/api/internal/mod-gate (full subresource gate)', () => {
     expect(res.statusCode).toBe(401);
   });
 
+  // ── ABSENT Sec-Fetch-Dest → treated as ENTRY (fail-safe) ──────────────────
+
   it('ABSENT Sec-Fetch-Dest is treated as ENTRY → needs a token (401 without one)', async () => {
     const res = makeRes();
     await handler(makeReq({ host: HOST, uri: '/some-slug' }), res);
     expect(res.statusCode).toBe(401);
   });
 
-  it('ABSENT Sec-Fetch-Dest WITH a valid token → 200 + Set-Cookie (entry path satisfied)', async () => {
+  it('ABSENT Sec-Fetch-Dest WITH a valid token → 200 + X-Mod-Id', async () => {
     const token = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
     const res = makeRes();
     await handler(makeReq({ host: HOST, uri: entryUriWithToken(token) }), res);
     expect(res.statusCode).toBe(200);
     expect(res._headers['X-Mod-Id']).toBe(String(MOD));
-    expect(res._headers['Set-Cookie']).toContain('Partitioned');
+    expect(res._headers['Set-Cookie']).toBeUndefined();
   });
 
-  // ── invalid/expired cookie falls through to entry/token logic ─────────────
+  // ── SUBRESOURCE path (allowed without any token/cookie) ───────────────────
 
-  it('INVALID session cookie + valid ENTRY token → 200 (re-establishes via token) + Set-Cookie', async () => {
-    const token = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
+  it('SUBRESOURCE (Sec-Fetch-Dest: script) → 200 (no token/cookie needed)', async () => {
     const res = makeRes();
-    await handler(
-      makeReq({
-        host: HOST,
-        uri: entryUriWithToken(token),
-        secFetchDest: 'document',
-        cookie: sessionCookieHeader('garbage.value'),
-      }),
-      res
-    );
+    await handler(makeReq({ host: HOST, uri: '/assets/index.js', secFetchDest: 'script' }), res);
     expect(res.statusCode).toBe(200);
-    expect(res._headers['Set-Cookie']).toContain('Partitioned');
+    expect(res._headers['Set-Cookie']).toBeUndefined();
   });
 
-  it('EXPIRED session cookie on a SUBRESOURCE (no token) → 401 (no entry fallback for subresources)', async () => {
-    const expired = signReviewSessionCookie({
-      modUserId: MOD,
-      host: HOST,
-      secret: SECRET,
-      ttlSeconds: -1,
-    });
+  it('SUBRESOURCE (Sec-Fetch-Dest: image) → 200 (no token/cookie needed)', async () => {
     const res = makeRes();
-    await handler(
-      makeReq({
-        host: HOST,
-        uri: '/assets/index.js',
-        secFetchDest: 'script',
-        cookie: sessionCookieHeader(expired),
-      }),
-      res
-    );
-    expect(res.statusCode).toBe(401);
+    await handler(makeReq({ host: HOST, uri: '/assets/logo.png', secFetchDest: 'image' }), res);
+    expect(res.statusCode).toBe(200);
   });
 
-  it('an `mr` ENTRY token presented as the SESSION cookie is REJECTED (domain separation)', async () => {
-    // Attacker captures the 120s entry token and tries to use it as the long-lived
-    // subresource cookie. Must NOT authorize a subresource.
-    const entry = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
+  it('SUBRESOURCE (Sec-Fetch-Dest: empty / XHR) → 200', async () => {
     const res = makeRes();
-    await handler(
-      makeReq({
-        host: HOST,
-        uri: '/assets/index.js',
-        secFetchDest: 'script',
-        cookie: sessionCookieHeader(entry),
-      }),
-      res
-    );
-    expect(res.statusCode).toBe(401);
+    await handler(makeReq({ host: HOST, uri: '/api/x', secFetchDest: 'empty' }), res);
+    expect(res.statusCode).toBe(200);
   });
 
-  it('valid SESSION cookie but MISSING X-Forwarded-Host → 401 (fail-closed)', async () => {
-    const cookie = signReviewSessionCookie({ modUserId: MOD, host: HOST, secret: SECRET });
+  it('SUBRESOURCE (Sec-Fetch-Dest: font) → 200', async () => {
     const res = makeRes();
-    await handler(
-      makeReq({ uri: '/assets/index.js', secFetchDest: 'script', cookie: sessionCookieHeader(cookie) }),
-      res
-    );
-    expect(res.statusCode).toBe(401);
+    await handler(makeReq({ host: HOST, uri: '/assets/font.woff2', secFetchDest: 'font' }), res);
+    expect(res.statusCode).toBe(200);
   });
 
-  it('valid ENTRY token but MISSING X-Forwarded-Host → 401 (fail-closed)', async () => {
+  // ── fail-closed on missing host ───────────────────────────────────────────
+
+  it('ENTRY: valid token but MISSING X-Forwarded-Host → 401 (fail-closed)', async () => {
     const token = signReviewAccessToken({ modUserId: MOD, host: HOST, secret: SECRET });
     const res = makeRes();
     await handler(makeReq({ uri: entryUriWithToken(token), secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('SUBRESOURCE: MISSING X-Forwarded-Host → 401 (fail-closed, checked before subresource allow)', async () => {
+    const res = makeRes();
+    await handler(makeReq({ uri: '/assets/index.js', secFetchDest: 'script' }), res);
     expect(res.statusCode).toBe(401);
   });
 });


### PR DESCRIPTION
## Why

The #2847 CHIPS subresource-cookie gate **can't work**. Traefik `forwardAuth` does **not** forward a 2xx auth response's `Set-Cookie` header back to the client — confirmed live: an entry request with a valid `mr` token returns `200` with **no** `Set-Cookie` reaching the browser. So the `__Host-review-sess` `Partitioned` session cookie is never set, and every subsequent subresource arrives with no cookie → `401` → **the review preview never renders**.

This reverts the subresource-cookie gate to an **entry-gate-only** design.

## Change

**`src/pages/api/internal/mod-gate.ts`** — entry-gate-only:
- ENTRY request (`Sec-Fetch-Dest` = `document`/`iframe`/`frame`/`nested-document`, or the header **absent** → treated as entry, fail-safe): require a valid `mr` token whose bound host === `X-Forwarded-Host` → `200` + `X-Mod-Id`, else `401`.
- SUBRESOURCE request (any other `Sec-Fetch-Dest`): `200` (allow).
- Missing `X-Forwarded-Host` → `401` (fail-closed, checked first).
- Removed all session-cookie logic: no `Set-Cookie`, no `__Host-review-sess` parse/verify, no `buildSessionSetCookie` / `SESSION_COOKIE_NAME` / `extractSessionCookie`.

**`src/server/services/blocks/review-session.ts`** — dropped the now-dead `signReviewSessionCookie` / `verifyReviewSessionCookie` / `SESSION_DOMAIN_PREFIX` / `REVIEW_SESSION_COOKIE_TTL_SECONDS` / `sessionSigningString` helpers (only the removed cookie path used them). **Kept** `signReviewAccessToken` / `verifyReviewAccessToken` / the `mr` token machinery — still used by the entry gate and the `previewUrl` mint in `publish-request.service.ts`. `reviewHostSha` lives in `apps-pipeline.service.ts` (unchanged).

**Tests** — `mod-gate.test.ts` rewritten to assert entry-gate-only behavior (entry + valid `mr` → 200 + X-Mod-Id + no Set-Cookie; entry with no/expired/forged/host-mismatch → 401; absent Sec-Fetch-Dest treated as entry; subresource script/image/empty/font → 200; missing host → 401). `review-session.test.ts` session-cookie describe block removed. **33 tests pass** (`vitest run --project unit`).

## Accepted tradeoff

Subresources are served **without** per-request auth. Residual risk is low and accepted:
- The `mr` token still gates the ENTRY document → a non-mod can't load the preview.
- The `review-<sha16>` host is a ~64-bit secret surfaced **only to mods**; mod-only, ephemeral, pre-approval preview.

## Future hardening (not implemented)

A **302-strip handshake**: on a valid `mr` token, mod-gate returns a `302` to the same URL minus `mr` **with** the `Set-Cookie` on the redirect (Traefik **does** forward headers on a non-2xx auth response), setting the CHIPS cookie via the redirect; subresources then carry it. Still CHIPS-only (Chromium/Firefox; Safari excluded). Documented as a known lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)