### PR TITLE
fix(a11y): name the header user/account menu button (flips /generate button-name)

### DIFF
--- a/src/components/AppLayout/AppHeader/UserMenu.tsx
+++ b/src/components/AppLayout/AppHeader/UserMenu.tsx
@@ -72,6 +72,7 @@ export function UserMenu() {
     <Popover width={isMobile ? '100%' : 260} position="bottom-end" opened={open} onChange={setOpen}>
       <Popover.Target>
         <UnstyledButton
+          aria-label={currentUser ? 'Account menu' : 'Menu'}
           className={clsx(
             'flex items-center hover:bg-gray-1 @md:rounded-[32px] dark:hover:bg-dark-5',
             { ['bg-gray-1 dark:bg-dark-5']: open }


### PR DESCRIPTION
## What

Follow-up to #2855. #2855 named the 4 generation-form icon buttons, but the **binary** `button-name` audit stayed red on `/generate` — the post-#2855 LHR showed a **5th** unnamed button: the global `AppHeader` **user/account menu** (`UserMenu.tsx:74`), an icon-only `UnstyledButton` (avatar + buzz on desktop, Burger on mobile) opening the account popover with no accessible name.

Add `aria-label={currentUser ? 'Account menu' : 'Menu'}` — accurate in both states (signed-out renders only the hamburger). This lives in the **site-wide header**, so it clears the last `button-name` node on `/generate` **and** improves `button-name` on every authed page.

Verified from the LHR that this was the **sole** remaining `button-name` node after #2855 (4 → 1 → this). Expected: `/generate` `button-name` → pass, a11y **88 → ~93**.

## Verification
Report-only (does not block). The preview `lhci-bot` comment will confirm `button-name` passes and a11y rises to ~93.

## Remaining `/generate` a11y residuals (out of scope)
- `aria-required-children` (w=10) — Queue/Feed/Newest/Filters `role="tablist"` missing `role="tab"` children (structural).
- `color-contrast` (w=7) — `text-[10px] text-gray-6` param-hint text (design call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)