### PR TITLE
fix(a11y): /generate Tabs.List children role=tab (aria-required-children)

### DIFF
--- a/src/pages/generate/index.tsx
+++ b/src/pages/generate/index.tsx
@@ -71,23 +71,29 @@ function GeneratePage() {
           classNames={{
             root: 'flex flex-1 flex-col overflow-hidden',
             panel: 'size-full',
-            list: 'w-full border-b border-b-gray-2 dark:border-b-dark-5',
           }}
           keepMounted={false}
         >
-          <Tabs.List px="md" py="xs">
-            <Group justify="space-between" w="100%">
-              <Group align="flex-start" gap="xs">
-                <Tabs.Tab value="queue" leftSection={<IconClockHour9 size={16} />}>
-                  Queue
-                </Tabs.Tab>
-                <Tabs.Tab value="feed" leftSection={<IconGridDots size={16} />}>
-                  Feed
-                </Tabs.Tab>
-              </Group>
-              <GeneratedImageActions />
-            </Group>
-          </Tabs.List>
+          {/* Keep the actions row OUTSIDE Tabs.List: a role="tablist" must have
+              only role="tab" children (a11y: aria-required-children). The list
+              holds just the tabs; the surrounding Group carries the layout. */}
+          <Group
+            justify="space-between"
+            wrap="nowrap"
+            px="md"
+            py="xs"
+            className="w-full border-b border-b-gray-2 dark:border-b-dark-5"
+          >
+            <Tabs.List className="gap-2">
+              <Tabs.Tab value="queue" leftSection={<IconClockHour9 size={16} />}>
+                Queue
+              </Tabs.Tab>
+              <Tabs.Tab value="feed" leftSection={<IconGridDots size={16} />}>
+                Feed
+              </Tabs.Tab>
+            </Tabs.List>
+            <GeneratedImageActions />
+          </Group>
           <ScrollArea scrollRestore={{ key: tabView }}>
             <Tabs.Panel value="queue">
               <Queue />

--- a/src/pages/generate/index.tsx
+++ b/src/pages/generate/index.tsx
@@ -79,12 +79,11 @@ function GeneratePage() {
               holds just the tabs; the surrounding Group carries the layout. */}
           <Group
             justify="space-between"
-            wrap="nowrap"
             px="md"
             py="xs"
             className="w-full border-b border-b-gray-2 dark:border-b-dark-5"
           >
-            <Tabs.List className="gap-2">
+            <Tabs.List className="gap-2.5">
               <Tabs.Tab value="queue" leftSection={<IconClockHour9 size={16} />}>
                 Queue
               </Tabs.Tab>


### PR DESCRIPTION
## What

Last structural a11y residual on `/generate`. The results `Tabs.List` (`role="tablist"`, `src/pages/generate/index.tsx`) wrapped its two `Tabs.Tab`s in nested `<Group>` divs **and** contained `<GeneratedImageActions/>` (the Newest/Filters toolbar) — so the tablist's direct children were divs + non-tab interactive content, tripping **`aria-required-children`** (w=10): a `role="tablist"` must contain `role="tab"` children.

**Fix:** restructure so `Tabs.List` holds *only* the Queue/Feed tabs; the space-between layout `Group` (border + padding) and `GeneratedImageActions` now **wrap** the list. Mantine Tabs is context-based, so `Tabs.List` needn't be a direct DOM child of `<Tabs>` — tab selection/keyboard behavior is unchanged. The visual row is preserved (tabs left, actions right, bottom border).

Projected `/generate` a11y **93 → ~97** (the only remaining failure after this would be `color-contrast`, w=7 — a design call).

## Verification
Report-only. I'm verifying on the preview: (1) the `lhci-bot` `aria-required-children` audit passes / a11y rises to ~97, and (2) a screenshot confirms the tabs row layout is unchanged (structural change → visual check required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)