### PR TITLE
fix(app-blocks): persist review-preview state across reload / modal re-open

### DIFF
--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -943,15 +943,18 @@ function ReviewPreviewPanel({
 }) {
   const features = useFeatureFlags();
   const utils = trpc.useUtils();
-  const [started, setStarted] = useState(false);
 
-  // Poll the review status. Only enabled once a preview has been started (or a
-  // prior preview state exists on the row); building/deploying poll fast, live/
-  // failed stop.
+  // Poll the review status. Enabled on mount (not gated on a client "started"
+  // flag) so a preview already live on the row is picked up after a page reload
+  // / modal re-open — getReviewStatus returns the PERSISTED deploy_state, so we
+  // derive the button + live iframe from the server, not from ephemeral React
+  // state (which reset to "Start preview" on reload). building/deploying poll
+  // fast, live polls slow, none/failed do a single fetch then stop (see
+  // refetchInterval).
   const statusQuery = trpc.blocks.getReviewStatus.useQuery(
     { publishRequestId },
     {
-      enabled: !!features?.appBlocks && started,
+      enabled: !!features?.appBlocks,
       retry: false,
       refetchInterval: (query) => {
         // react-query v5: the callback receives the Query; the data is at
@@ -974,7 +977,6 @@ function ReviewPreviewPanel({
 
   const previewMut = trpc.blocks.previewRequest.useMutation({
     onSuccess: async () => {
-      setStarted(true);
       showSuccessNotification({ message: `Review build started for ${slug}.` });
       await utils.blocks.getReviewStatus.invalidate({ publishRequestId });
     },


### PR DESCRIPTION
## Problem
On `/apps/review`, a moderator starts a review-sandbox preview, sees it load, then reloads the page (or re-opens the review modal) — and the panel reverts to **"Start preview"** as if no preview exists, even though the `review-<sha>.civit.ai` sandbox is still live.

## Root cause
`ReviewPreviewPanel` gated the `blocks.getReviewStatus` query on a client-only `const [started, setStarted] = useState(false)` flag — set `true` only by clicking *Start preview*. A reload/re-mount resets it to `false` → the query is **disabled** → `state` is `null` → the button + live iframe (both derived from `statusQuery.data`) fall back to the empty "Start preview" state. The code comment even claimed the query was enabled *"(or a prior preview state exists on the row)"* — but that half was never implemented.

## Fix
Enable the query on mount (`enabled: !!features?.appBlocks`), dropping the `started` gate. `getReviewStatus` already returns the **persisted** `deploy_state` (`preview-building | preview-deploying | preview-live | preview-failed`, or `null`), and `refetchInterval` already returns `false` for `none`/`failed` — so this is a single fetch on open that re-derives the button ("Rebuild preview" when a preview exists) and the live iframe from the server. Mirrors the sibling `ScreenshotsReviewPanel` enablement idiom. Removes the now-dead `started` state + setter.

Client-only change; no server/schema change. Behind the mod-only `appBlocks` + `app-blocks-review-sandbox-enabled` flags.

## Verification
- Deterministic: `getReviewStatus` returns `state: null` cleanly for no-preview (never throws except missing row) and `preview-live` + fresh `?mr=` token when live — confirmed in `publish-request.service.ts`.
- Manual (to confirm on the preview / after deploy): start a preview → reload `/apps/review` → re-open the same pending request → panel shows the **live** preview + "Rebuild preview", not "Start preview".

🤖 Generated with [Claude Code](https://claude.com/claude-code)