### PR TITLE
feat(app-blocks): global concurrent review-preview cap + manual teardown

### DIFF
--- a/src/pages/api/internal/blocks/review-build-callback.ts
+++ b/src/pages/api/internal/blocks/review-build-callback.ts
@@ -228,23 +228,46 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // it) so the failure/deploy updates don't drop the URL the UI shows. Read it
   // best-effort; on any error fall back to a minimal detail.
   let baseDetail = { sha: body.sha } as ReturnType<typeof parseReviewDetail>;
+  // If the preview is no longer active by the time the build finishes, do NOT
+  // resurrect it. A mod can TEAR DOWN a preview mid-build (teardownPreview clears
+  // deployState→null but leaves status='pending'), or the request may have been
+  // approved/rejected. Without this guard the success callback would re-write
+  // preview-live AND re-create the review Deployment/Service/IngressRoute in k8s
+  // (silently refilling a cap slot with a detail-less zombie). Abort only on a
+  // POSITIVE read; an unreadable row falls through to existing behavior (the
+  // markReviewPreviewState requireActivePreview guard below is the backstop).
+  let previewNoLongerActive = false;
   try {
     const { dbRead } = await import('~/server/db/client');
     const row = await dbRead.appBlockPublishRequest.findUnique({
       where: { id: body.publishRequestId },
-      select: { deployDetail: true },
+      select: { deployDetail: true, status: true, deployState: true },
     });
     baseDetail = { ...parseReviewDetail(row?.deployDetail), sha: body.sha };
+    if (row && !(row.status === 'pending' && (row.deployState ?? '').startsWith('preview-'))) {
+      previewNoLongerActive = true;
+    }
   } catch {
     /* fall back to the minimal detail */
   }
 
+  if (previewNoLongerActive) {
+    res.status(200).json({
+      ok: true,
+      applied: false,
+      reason: 'preview no longer active (torn down or decided)',
+    });
+    return;
+  }
+
   const succeeded = (body.status ?? '').toLowerCase() === 'succeeded';
   if (!succeeded) {
-    await markReviewPreviewState(body.publishRequestId, 'preview-failed', {
-      ...baseDetail,
-      error: `review build ${String(body.status ?? 'failed').slice(0, 60)}`,
-    });
+    await markReviewPreviewState(
+      body.publishRequestId,
+      'preview-failed',
+      { ...baseDetail, error: `review build ${String(body.status ?? 'failed').slice(0, 60)}` },
+      { requireActivePreview: true }
+    );
     res.status(200).json({ ok: true, applied: false, reason: 'review build failed' });
     return;
   }
@@ -260,7 +283,9 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     return;
   }
 
-  await markReviewPreviewState(body.publishRequestId, 'preview-deploying', baseDetail);
+  await markReviewPreviewState(body.publishRequestId, 'preview-deploying', baseDetail, {
+    requireActivePreview: true,
+  });
 
   let applyJob: { name: string };
   try {
@@ -275,10 +300,12 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     // it here or a transient k8s hiccup would wedge same-sha retries for the full
     // TTL (symmetrical with the watcher's clear-on-failed below).
     await clearReviewApplyMark(body.publishRequestId, body.sha);
-    await markReviewPreviewState(body.publishRequestId, 'preview-failed', {
-      ...baseDetail,
-      error: `review apply trigger failed: ${String(e).slice(0, 80)}`,
-    });
+    await markReviewPreviewState(
+      body.publishRequestId,
+      'preview-failed',
+      { ...baseDetail, error: `review apply trigger failed: ${String(e).slice(0, 80)}` },
+      { requireActivePreview: true }
+    );
     res.status(500).json({ error: 'Review apply trigger failed', detail: String(e).slice(0, 240) });
     return;
   }
@@ -305,7 +332,9 @@ async function watchReviewApplyJob(args: {
   try {
     const outcome = await waitForApplyJob(args.jobName);
     if (outcome === 'succeeded') {
-      await markReviewPreviewState(args.publishRequestId, 'preview-live', args.baseDetail);
+      await markReviewPreviewState(args.publishRequestId, 'preview-live', args.baseDetail, {
+        requireActivePreview: true,
+      });
     } else {
       // On a DEFINITIVE failure free the replay-dedup slot so a same-sha retry
       // isn't suppressed within the TTL window; on a 'timeout' leave it (the Job
@@ -314,10 +343,15 @@ async function watchReviewApplyJob(args: {
       if (outcome === 'failed') {
         await clearReviewApplyMark(args.publishRequestId, args.sha);
       }
-      await markReviewPreviewState(args.publishRequestId, 'preview-failed', {
-        ...args.baseDetail,
-        error: outcome === 'timeout' ? 'review deploy timed out' : 'review deploy failed',
-      });
+      await markReviewPreviewState(
+        args.publishRequestId,
+        'preview-failed',
+        {
+          ...args.baseDetail,
+          error: outcome === 'timeout' ? 'review deploy timed out' : 'review deploy failed',
+        },
+        { requireActivePreview: true }
+      );
     }
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -163,6 +163,22 @@ function formatDate(d: string | Date | null | undefined): string {
   return date.toLocaleString();
 }
 
+// Compact relative age ("just now" / "5m" / "2h" / "3d") for the active-preview
+// panel — the exact timestamp isn't useful there, freshness is.
+function formatAge(d: string | Date | null | undefined): string {
+  if (!d) return '—';
+  const date = typeof d === 'string' ? new Date(d) : d;
+  const ms = Date.now() - date.getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
 export default function ReviewQueuePage() {
   const features = useFeatureFlags();
   const router = useRouter();
@@ -198,6 +214,8 @@ export default function ReviewQueuePage() {
         title="App publish-request queue"
         subtitle="Moderator review for Apps. Pending queue is oldest-first; history tabs are newest-first."
       >
+        <ActivePreviewsPanel />
+
         <Tabs
           value={tab}
           onChange={(v) => {
@@ -238,6 +256,118 @@ export default function ReviewQueuePage() {
         onClose={() => setSelected(null)}
       />
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MOD REVIEW SANDBOX — global "Active previews (N / cap)" panel. Review previews
+// are capped globally across all mods (each holds a review Deployment + Service
+// + IngressRoute), so this surfaces every active preview + a per-row Tear down
+// so a mod can free a slot. Polls every 30s so the count stays fresh. Dark
+// behind the same mod-only review-sandbox flag as the per-request panel: when
+// off, listActivePreviews throws UNAUTHORIZED and this renders nothing.
+// ---------------------------------------------------------------------------
+
+function ActivePreviewsPanel() {
+  const features = useFeatureFlags();
+  const utils = trpc.useUtils();
+
+  const query = trpc.blocks.listActivePreviews.useQuery(undefined, {
+    enabled: !!features?.appBlocks,
+    retry: false,
+    refetchInterval: 30000, // keep the count fresh while the queue is open
+  });
+
+  const teardownMut = trpc.blocks.teardownPreview.useMutation({
+    onSuccess: async (_res, vars) => {
+      showSuccessNotification({ message: 'Review preview torn down.' });
+      await Promise.all([
+        utils.blocks.listActivePreviews.invalidate(),
+        utils.blocks.getReviewStatus.invalidate({ publishRequestId: vars.publishRequestId }),
+      ]);
+    },
+    onError: (e) => {
+      showErrorNotification({ title: 'Could not tear down preview', error: new Error(e.message) });
+    },
+  });
+
+  // Flag off / not enabled (query errors) or nothing active → render nothing so
+  // the panel stays unobtrusive when the sandbox isn't in use.
+  const cap = query.data?.cap ?? 0;
+  const active = query.data?.active ?? [];
+  if (query.error || active.length === 0) return null;
+
+  const atCap = cap > 0 && active.length >= cap;
+
+  return (
+    <Card withBorder p="md" mb="md">
+      <Group gap={6} mb="xs">
+        <IconWindow size={16} />
+        <Text size="sm" fw={600}>
+          Active previews
+        </Text>
+        <Badge size="sm" variant="light" color={atCap ? 'red' : 'blue'}>
+          {active.length} / {cap}
+        </Badge>
+        {atCap && (
+          <Text size="xs" c="red">
+            Cap reached — tear one down to start another.
+          </Text>
+        )}
+      </Group>
+      <Table verticalSpacing="xs" horizontalSpacing="md">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>App</Table.Th>
+            <Table.Th>Version</Table.Th>
+            <Table.Th>State</Table.Th>
+            <Table.Th>Age</Table.Th>
+            <Table.Th />
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {active.map((p) => (
+            <Table.Tr key={p.publishRequestId}>
+              <Table.Td>
+                <Code>{p.slug}</Code>
+              </Table.Td>
+              <Table.Td>
+                <Code>{p.version}</Code>
+              </Table.Td>
+              <Table.Td>
+                <Badge
+                  size="sm"
+                  variant="light"
+                  color={p.state === 'preview-live' ? 'green' : 'blue'}
+                >
+                  {p.state.replace('preview-', '')}
+                </Badge>
+              </Table.Td>
+              <Table.Td>
+                <Text size="xs" c="dimmed">
+                  {formatAge(p.updatedAt)}
+                </Text>
+              </Table.Td>
+              <Table.Td>
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="red"
+                  leftSection={<IconX size={12} />}
+                  loading={
+                    teardownMut.isPending &&
+                    teardownMut.variables?.publishRequestId === p.publishRequestId
+                  }
+                  onClick={() => teardownMut.mutate({ publishRequestId: p.publishRequestId })}
+                >
+                  Tear down
+                </Button>
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Card>
   );
 }
 
@@ -985,6 +1115,21 @@ function ReviewPreviewPanel({
     },
   });
 
+  const teardownMut = trpc.blocks.teardownPreview.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: `Review preview torn down for ${slug}.` });
+      // Clears the DB preview state → getReviewStatus returns state:null and the
+      // panel reverts to "Start preview". Also refresh the global panel's count.
+      await Promise.all([
+        utils.blocks.getReviewStatus.invalidate({ publishRequestId }),
+        utils.blocks.listActivePreviews.invalidate(),
+      ]);
+    },
+    onError: (e) => {
+      showErrorNotification({ title: 'Could not tear down preview', error: new Error(e.message) });
+    },
+  });
+
   const state = statusQuery.data?.state ?? null;
   const detail = statusQuery.data?.detail;
   // Prefer the FRESH, mod-bound, short-TTL tokened URL (`?mr=<token>`) the server
@@ -1057,6 +1202,19 @@ function ReviewPreviewPanel({
             rightSection={<IconExternalLink size={12} />}
           >
             Open review host
+          </Button>
+        )}
+        {state && !isFailed && (
+          <Button
+            size="xs"
+            variant="light"
+            color="red"
+            leftSection={<IconX size={12} />}
+            loading={teardownMut.isPending}
+            disabled={teardownMut.isPending}
+            onClick={() => teardownMut.mutate({ publishRequestId })}
+          >
+            Tear down preview
           </Button>
         )}
       </Group>

--- a/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
+++ b/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
@@ -23,6 +23,8 @@ const {
   mockIsReviewSandboxEnabled,
   mockPreviewRequest,
   mockGetReviewStatus,
+  mockTeardownPreview,
+  mockListActivePreviews,
   mockVerifyBlockToken,
   mockParseSubjectUserId,
   mockGetUserById,
@@ -36,6 +38,8 @@ const {
   mockIsReviewSandboxEnabled: vi.fn(),
   mockPreviewRequest: vi.fn(),
   mockGetReviewStatus: vi.fn(),
+  mockTeardownPreview: vi.fn(),
+  mockListActivePreviews: vi.fn(),
   mockVerifyBlockToken: vi.fn(),
   mockParseSubjectUserId: vi.fn(),
   mockGetUserById: vi.fn(),
@@ -58,6 +62,8 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
 vi.mock('~/server/services/blocks/publish-request.service', () => ({
   previewRequest: mockPreviewRequest,
   getReviewStatus: mockGetReviewStatus,
+  teardownPreview: mockTeardownPreview,
+  listActiveReviewPreviews: mockListActivePreviews,
 }));
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: mockVerifyBlockToken,
@@ -163,6 +169,10 @@ beforeEach(() => {
     detail: { url: 'https://review-x.civit.ai/my-app' },
     updatedAt: new Date(),
   });
+  mockTeardownPreview.mockReset();
+  mockTeardownPreview.mockResolvedValue({ publishRequestId: PUBREQ, tornDown: true });
+  mockListActivePreviews.mockReset();
+  mockListActivePreviews.mockResolvedValue({ cap: 5, active: [] });
 });
 
 describe('blocks.previewRequest', () => {
@@ -207,7 +217,12 @@ describe('blocks.getReviewStatus', () => {
     const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
     const res = await caller.getReviewStatus({ publishRequestId: PUBREQ });
     expect(res.state).toBe('preview-live');
-    expect(mockGetReviewStatus).toHaveBeenCalledWith({ publishRequestId: PUBREQ });
+    // The router passes the SERVER-derived mod id so getReviewStatus can mint the
+    // fresh mod-bound previewUrl token when the preview is live.
+    expect(mockGetReviewStatus).toHaveBeenCalledWith({
+      publishRequestId: PUBREQ,
+      modUserId: 1,
+    });
   });
 
   it('non-moderator: UNAUTHORIZED', async () => {
@@ -225,5 +240,67 @@ describe('blocks.getReviewStatus', () => {
       TRPCError
     );
     expect(mockGetReviewStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('blocks.teardownPreview', () => {
+  it('moderator + flags on: reaches the service', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.teardownPreview({ publishRequestId: PUBREQ });
+    expect(res.tornDown).toBe(true);
+    expect(mockTeardownPreview).toHaveBeenCalledWith({ publishRequestId: PUBREQ });
+  });
+
+  it('non-moderator: UNAUTHORIZED, service NOT reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.teardownPreview({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockTeardownPreview).not.toHaveBeenCalled();
+  });
+
+  it('moderator but review-sandbox flag OFF: UNAUTHORIZED (dark)', async () => {
+    mockIsReviewSandboxEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.teardownPreview({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockTeardownPreview).not.toHaveBeenCalled();
+  });
+});
+
+describe('blocks.listActivePreviews', () => {
+  it('moderator + flags on: returns the cap + active list', async () => {
+    mockListActivePreviews.mockResolvedValue({
+      cap: 5,
+      active: [
+        {
+          publishRequestId: PUBREQ,
+          slug: 'my-app',
+          version: '1.0.0',
+          state: 'preview-live',
+          host: 'review-x.civit.ai',
+          updatedAt: new Date(),
+        },
+      ],
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.listActivePreviews();
+    expect(res.cap).toBe(5);
+    expect(res.active).toHaveLength(1);
+    expect(mockListActivePreviews).toHaveBeenCalled();
+  });
+
+  it('non-moderator: UNAUTHORIZED', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.listActivePreviews()).rejects.toBeInstanceOf(TRPCError);
+    expect(mockListActivePreviews).not.toHaveBeenCalled();
+  });
+
+  it('moderator but review-sandbox flag OFF: UNAUTHORIZED', async () => {
+    mockIsReviewSandboxEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.listActivePreviews()).rejects.toBeInstanceOf(TRPCError);
+    expect(mockListActivePreviews).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -46,6 +46,7 @@ import {
   listRejectedRequestsSchema,
   previewRequestSchema,
   rejectRequestSchema,
+  teardownPreviewSchema,
   withdrawRequestSchema,
 } from '~/server/schema/blocks/publish-request.schema';
 import { registerExternalAppSchema } from '~/server/schema/blocks/external-app.schema';
@@ -1101,6 +1102,61 @@ export const blocksRouter = router({
           publishRequestId: input.publishRequestId,
           modUserId: ctx.user.id,
         });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+    }),
+
+  /**
+   * MOD REVIEW SANDBOX — MANUAL teardown of a single review preview (also the way
+   * to free a slot when the global concurrent-preview cap is hit). Deletes the
+   * per-request review k8s resources (label-scoped) AND clears the DB preview
+   * state so the request reverts to "no preview". Same mod-only flag gate as
+   * previewRequest.
+   */
+  teardownPreview: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(teardownPreviewSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Review previews are restricted to civitai team');
+      }
+      const { isAppBlocksReviewSandboxEnabled } = await import(
+        '~/server/services/app-blocks-flag'
+      );
+      if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
+        throw throwAuthorizationError('The review sandbox is not enabled');
+      }
+      const { teardownPreview } = await import('~/server/services/blocks/publish-request.service');
+      try {
+        return await teardownPreview({ publishRequestId: input.publishRequestId });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+    }),
+
+  /**
+   * MOD REVIEW SANDBOX — list the currently-active review previews (global across
+   * all mods) + the cap, for the "Active previews (N / cap)" panel. Same mod-only
+   * flag gate as previewRequest; no input.
+   */
+  listActivePreviews: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .query(async ({ ctx }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Review previews are restricted to civitai team');
+      }
+      const { isAppBlocksReviewSandboxEnabled } = await import(
+        '~/server/services/app-blocks-flag'
+      );
+      if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
+        throw throwAuthorizationError('The review sandbox is not enabled');
+      }
+      const { listActiveReviewPreviews } = await import(
+        '~/server/services/blocks/publish-request.service'
+      );
+      try {
+        return await listActiveReviewPreviews();
       } catch (err) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
       }

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -133,6 +133,12 @@ export const getReviewStatusSchema = z.object({
 
 export type GetReviewStatusInput = z.infer<typeof getReviewStatusSchema>;
 
+export const teardownPreviewSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+});
+
+export type TeardownPreviewInput = z.infer<typeof teardownPreviewSchema>;
+
 export const backfillPublishRequestSchema = z.object({
   slug: z.string().min(3).max(40).regex(SLUG_REGEX),
   approvalNotes: z.string().max(2000).optional(),

--- a/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
@@ -22,10 +22,13 @@ const {
   mockDeleteReviewResources,
 } = vi.hoisted(() => ({
   mockDbRead: {
-    appBlockPublishRequest: { findUnique: vi.fn() },
+    appBlockPublishRequest: { findUnique: vi.fn(), findMany: vi.fn(async () => []) },
   },
   mockDbWrite: {
-    appBlockPublishRequest: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    appBlockPublishRequest: {
+      updateMany: vi.fn(async () => ({ count: 1 })),
+      update: vi.fn(async () => ({})),
+    },
   },
   mockGetReviewHead: vi.fn(async () => 'a'.repeat(40)),
   mockTriggerReviewBuild: vi.fn(async () => ({ name: 'review-pr-1' })),
@@ -49,8 +52,13 @@ import {
   previewRequest,
   getReviewStatus,
   teardownReviewForRequest,
+  teardownPreview,
+  countActiveReviewPreviews,
+  listActiveReviewPreviews,
   withdrawRequest,
   parseReviewDetail,
+  MAX_CONCURRENT_REVIEW_PREVIEWS,
+  REVIEW_PREVIEW_TTL_MS,
 } from '~/server/services/blocks/publish-request.service';
 
 const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
@@ -322,5 +330,253 @@ describe('parseReviewDetail', () => {
   it('tolerates null / non-JSON', () => {
     expect(parseReviewDetail(null)).toEqual({});
     expect(parseReviewDetail('not json')).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency cap — countActiveReviewPreviews builds the ACTIVE predicate
+// (pending + preview-building/deploying/live + within the TTL window). The DB
+// filtering is mocked away, so we assert the WHERE clause carries the exact
+// predicate (that's what excludes failed/null/expired/non-pending in prod) and
+// that the count is the returned row count.
+// ---------------------------------------------------------------------------
+describe('countActiveReviewPreviews', () => {
+  beforeEach(() => {
+    mockDbRead.appBlockPublishRequest.findMany.mockReset();
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([]);
+  });
+
+  it('queries pending + active preview-* states within the TTL window, oldest-first', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      { id: 'a', slug: 's1', version: '1.0.0', deployState: 'preview-live', deployDetail: null, deployUpdatedAt: new Date() },
+      { id: 'b', slug: 's2', version: '1.0.0', deployState: 'preview-building', deployDetail: null, deployUpdatedAt: new Date() },
+    ]);
+    const before = Date.now();
+    const count = await countActiveReviewPreviews();
+    expect(count).toBe(2);
+
+    const arg = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0];
+    expect(arg.where.status).toBe('pending');
+    expect(arg.where.deployState).toEqual({
+      in: ['preview-building', 'preview-deploying', 'preview-live'],
+    });
+    // TTL cutoff ≈ now - REVIEW_PREVIEW_TTL_MS (excludes rows older than 6h).
+    const cutoff: Date = arg.where.deployUpdatedAt.gt;
+    expect(cutoff).toBeInstanceOf(Date);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(before - REVIEW_PREVIEW_TTL_MS + 5000);
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - REVIEW_PREVIEW_TTL_MS - 5000);
+    // oldest-first — the natural teardown order.
+    expect(arg.orderBy).toEqual({ deployUpdatedAt: 'asc' });
+    // no exclusion by default.
+    expect(arg.where.id).toBeUndefined();
+  });
+
+  it('respects excludePublishRequestId (so a rebuild never counts itself)', async () => {
+    await countActiveReviewPreviews({ excludePublishRequestId: PUBREQ });
+    const arg = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0];
+    expect(arg.where.id).toEqual({ not: PUBREQ });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// previewRequest cap enforcement — blocks a fresh request when MAX others are
+// active; allows a rebuild of an already-active request (self excluded).
+// ---------------------------------------------------------------------------
+describe('previewRequest concurrency cap', () => {
+  beforeEach(() => {
+    process.env.NEXTAUTH_URL = 'https://civitai.com';
+    mockDbRead.appBlockPublishRequest.findUnique.mockReset();
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: PUBREQ,
+      status: 'pending',
+      slug: 'my-app',
+    });
+    mockDbRead.appBlockPublishRequest.findMany.mockReset();
+    mockDbWrite.appBlockPublishRequest.updateMany.mockClear();
+    mockGetReviewHead.mockClear();
+    mockTriggerReviewBuild.mockReset();
+    mockTriggerReviewBuild.mockResolvedValue({ name: 'review-pr-1' });
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('throws (naming the cap + active slugs) when MAX others are active', async () => {
+    const others = Array.from({ length: MAX_CONCURRENT_REVIEW_PREVIEWS }, (_, i) => ({
+      id: `other-${i}`,
+      slug: `other-app-${i}`,
+      version: '1.0.0',
+      deployState: 'preview-live',
+      deployDetail: null,
+      deployUpdatedAt: new Date(),
+    }));
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue(others);
+
+    await expect(previewRequest({ publishRequestId: PUBREQ, modUserId: 1 })).rejects.toThrow(
+      new RegExp(`cap reached \\(${MAX_CONCURRENT_REVIEW_PREVIEWS}/${MAX_CONCURRENT_REVIEW_PREVIEWS} active\\)`)
+    );
+    await expect(previewRequest({ publishRequestId: PUBREQ, modUserId: 1 })).rejects.toThrow(
+      /other-app-0/
+    );
+    // The cap query excluded THIS request.
+    const arg = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0];
+    expect(arg.where.id).toEqual({ not: PUBREQ });
+    expect(mockTriggerReviewBuild).not.toHaveBeenCalled();
+  });
+
+  it('allows a rebuild of an already-active request when MAX total active (self excluded → 4 others)', async () => {
+    // Self is one of the 5 active, so the exclude-self query returns 4 others.
+    const others = Array.from({ length: MAX_CONCURRENT_REVIEW_PREVIEWS - 1 }, (_, i) => ({
+      id: `other-${i}`,
+      slug: `other-app-${i}`,
+      version: '1.0.0',
+      deployState: 'preview-live',
+      deployDetail: null,
+      deployUpdatedAt: new Date(),
+    }));
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue(others);
+
+    await expect(previewRequest({ publishRequestId: PUBREQ, modUserId: 1 })).resolves.toBeDefined();
+    expect(mockTriggerReviewBuild).toHaveBeenCalled();
+  });
+
+  it('proceeds under the cap', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      { id: 'x', slug: 'x', version: '1.0.0', deployState: 'preview-live', deployDetail: null, deployUpdatedAt: new Date() },
+    ]);
+    await expect(previewRequest({ publishRequestId: PUBREQ, modUserId: 1 })).resolves.toBeDefined();
+    expect(mockTriggerReviewBuild).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// teardownPreview — manual, per-request, label-scoped delete + DB clear.
+// ---------------------------------------------------------------------------
+describe('teardownPreview', () => {
+  beforeEach(() => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockReset();
+    mockDbWrite.appBlockPublishRequest.update.mockReset();
+    mockDbWrite.appBlockPublishRequest.update.mockResolvedValue({});
+    mockDeleteReviewResources.mockReset();
+    mockDeleteReviewResources.mockResolvedValue(undefined);
+  });
+
+  it('preview-live pending: deletes review resources by request + clears DB, tornDown:true', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: PUBREQ,
+      status: 'pending',
+      deployState: 'preview-live',
+      deployDetail: JSON.stringify({ sha: SHA, host: 'h' }),
+      slug: 'my-app',
+    });
+    const res = await teardownPreview({ publishRequestId: PUBREQ });
+    expect(res).toEqual({ publishRequestId: PUBREQ, tornDown: true });
+    expect(mockDeleteReviewResources).toHaveBeenCalledWith({
+      slug: 'my-app',
+      sha: SHA,
+      publishRequestId: PUBREQ,
+    });
+    const updateArg = mockDbWrite.appBlockPublishRequest.update.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ id: PUBREQ });
+    expect(updateArg.data.deployState).toBeNull();
+    expect(updateArg.data.deployDetail).toBeNull();
+    expect(updateArg.data.deployUpdatedAt).toBeInstanceOf(Date);
+  });
+
+  it('non-pending / non-preview state: no-op, tornDown:false (no delete, no DB clear)', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: PUBREQ,
+      status: 'approved',
+      deployState: 'building', // production value, not a preview-*
+      deployDetail: null,
+      slug: 'my-app',
+    });
+    const res = await teardownPreview({ publishRequestId: PUBREQ });
+    expect(res).toEqual({ publishRequestId: PUBREQ, tornDown: false });
+    expect(mockDeleteReviewResources).not.toHaveBeenCalled();
+    expect(mockDbWrite.appBlockPublishRequest.update).not.toHaveBeenCalled();
+  });
+
+  it('best-effort: k8s delete throwing still clears the DB + returns tornDown:true', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: PUBREQ,
+      status: 'pending',
+      deployState: 'preview-building',
+      deployDetail: JSON.stringify({ sha: SHA }),
+      slug: 'my-app',
+    });
+    mockDeleteReviewResources.mockRejectedValue(new Error('k8s down'));
+    const res = await teardownPreview({ publishRequestId: PUBREQ });
+    expect(res.tornDown).toBe(true);
+    expect(mockDbWrite.appBlockPublishRequest.update).toHaveBeenCalled();
+  });
+
+  it('throws when the request is not found', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
+    await expect(teardownPreview({ publishRequestId: PUBREQ })).rejects.toThrow(/not found/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listActiveReviewPreviews — the global panel's feed (cap + active rows).
+// ---------------------------------------------------------------------------
+describe('listActiveReviewPreviews', () => {
+  beforeEach(() => {
+    mockDbRead.appBlockPublishRequest.findMany.mockReset();
+  });
+
+  it('returns cap + mapped active rows (host from detail), querying oldest-first', async () => {
+    const older = new Date(Date.now() - 60_000);
+    const newer = new Date();
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      {
+        id: 'a',
+        slug: 's1',
+        version: '1.0.0',
+        deployState: 'preview-live',
+        deployDetail: JSON.stringify({ host: 'review-a.civit.ai', sha: SHA }),
+        deployUpdatedAt: older,
+      },
+      {
+        id: 'b',
+        slug: 's2',
+        version: '2.0.0',
+        deployState: 'preview-building',
+        deployDetail: null,
+        deployUpdatedAt: newer,
+      },
+    ]);
+
+    const res = await listActiveReviewPreviews();
+    expect(res.cap).toBe(MAX_CONCURRENT_REVIEW_PREVIEWS);
+    expect(res.active).toEqual([
+      {
+        publishRequestId: 'a',
+        slug: 's1',
+        version: '1.0.0',
+        state: 'preview-live',
+        host: 'review-a.civit.ai',
+        updatedAt: older,
+      },
+      {
+        publishRequestId: 'b',
+        slug: 's2',
+        version: '2.0.0',
+        state: 'preview-building',
+        host: null,
+        updatedAt: newer,
+      },
+    ]);
+
+    const arg = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0];
+    expect(arg.where.status).toBe('pending');
+    expect(arg.where.deployState).toEqual({
+      in: ['preview-building', 'preview-deploying', 'preview-live'],
+    });
+    expect(arg.orderBy).toEqual({ deployUpdatedAt: 'asc' });
+  });
+
+  it('returns an empty active list + the cap when nothing is active', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([]);
+    const res = await listActiveReviewPreviews();
+    expect(res).toEqual({ cap: MAX_CONCURRENT_REVIEW_PREVIEWS, active: [] });
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
@@ -55,6 +55,7 @@ import {
   teardownPreview,
   countActiveReviewPreviews,
   listActiveReviewPreviews,
+  markReviewPreviewState,
   withdrawRequest,
   parseReviewDetail,
   MAX_CONCURRENT_REVIEW_PREVIEWS,
@@ -578,5 +579,32 @@ describe('listActiveReviewPreviews', () => {
     mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([]);
     const res = await listActiveReviewPreviews();
     expect(res).toEqual({ cap: MAX_CONCURRENT_REVIEW_PREVIEWS, active: [] });
+  });
+});
+
+describe('markReviewPreviewState requireActivePreview guard', () => {
+  beforeEach(() => {
+    mockDbWrite.appBlockPublishRequest.updateMany.mockReset();
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it('requireActivePreview=true adds a deployState preview-* filter (no resurrection of a torn-down row)', async () => {
+    await markReviewPreviewState(PUBREQ, 'preview-live', { sha: SHA }, { requireActivePreview: true });
+    const arg = mockDbWrite.appBlockPublishRequest.updateMany.mock.calls[0][0];
+    expect(arg.where.id).toBe(PUBREQ);
+    expect(arg.where.status).toBe('pending');
+    // The load-bearing guard: a torn-down row (deployState=null) won't match
+    // startsWith 'preview-', so a late build callback can't resurrect it.
+    expect(arg.where.deployState).toEqual({ startsWith: 'preview-' });
+  });
+
+  it('without the opt (initial preview-building mark) does NOT constrain deployState', async () => {
+    await markReviewPreviewState(PUBREQ, 'preview-building', { sha: SHA });
+    const arg = mockDbWrite.appBlockPublishRequest.updateMany.mock.calls[0][0];
+    expect(arg.where.id).toBe(PUBREQ);
+    expect(arg.where.status).toBe('pending');
+    // Initial mark transitions from null / preview-failed → preview-building, so
+    // it must NOT require an existing preview-* state.
+    expect(arg.where.deployState).toBeUndefined();
   });
 });

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -2564,16 +2564,31 @@ export function parseReviewDetail(raw: string | null | undefined): ReviewPreview
  * Stamp the review-preview lifecycle state onto the PENDING request. Keyed on
  * `{ id, status:'pending' }` so it can never write a non-pending row. Best-effort
  * (a status write must not break the preview/approve flow) but logged on miss.
+ *
+ * Pass `requireActivePreview` for the transitions driven by the async build
+ * callback / apply watcher (deploying → live / failed): it additionally requires
+ * the row's `deployState` to still be a `preview-*` value, so a preview a mod
+ * TORE DOWN mid-build (teardownPreview clears deployState to null but leaves
+ * status='pending') is NOT resurrected by a late callback write. The initial
+ * `preview-building` mark from previewRequest must NOT set this (it transitions
+ * from null / preview-failed → preview-building).
  */
 export async function markReviewPreviewState(
   publishRequestId: string,
   state: ReviewPreviewState,
-  detail: ReviewPreviewDetail
+  detail: ReviewPreviewDetail,
+  opts?: { requireActivePreview?: boolean }
 ): Promise<void> {
   try {
     const { dbWrite } = await import('~/server/db/client');
     const res = await dbWrite.appBlockPublishRequest.updateMany({
-      where: { id: publishRequestId, status: 'pending' },
+      where: {
+        id: publishRequestId,
+        status: 'pending',
+        // Only advance a row that is STILL an active preview (torn-down rows have
+        // deployState=null → excluded → no resurrection).
+        ...(opts?.requireActivePreview ? { deployState: { startsWith: 'preview-' } } : {}),
+      },
       data: {
         deployState: state,
         deployDetail: packReviewDetail(detail),

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -2418,6 +2418,118 @@ export type ReviewPreviewState =
   | 'preview-live'
   | 'preview-failed';
 
+/**
+ * Global cap on concurrently-active review previews across ALL moderators. Each
+ * active preview holds a review Deployment + Service + IngressRoute in the apps
+ * namespace, so this bounds the review sandbox's cluster footprint.
+ */
+export const MAX_CONCURRENT_REVIEW_PREVIEWS = 5;
+
+/**
+ * Active-preview TTL window (ms). Mirrors the `review-sandbox-janitor` CronJob's
+ * 6h reap TTL: a preview the janitor has already deleted in k8s — but whose DB
+ * row still reads `preview-live`, because the janitor can't write the civitai DB
+ * — naturally ages OUT of the active count once its `deployUpdatedAt` is older
+ * than this. No k8s call and no janitor coupling needed.
+ */
+export const REVIEW_PREVIEW_TTL_MS = 6 * 60 * 60 * 1000;
+
+/** deploy_state values that count as an ACTIVE review preview. Excludes
+ *  `preview-failed` (dead) and `null` (never started). */
+const ACTIVE_REVIEW_PREVIEW_STATES: ReviewPreviewState[] = [
+  'preview-building',
+  'preview-deploying',
+  'preview-live',
+];
+
+type ActiveReviewPreviewRow = {
+  id: string;
+  slug: string;
+  version: string;
+  deployState: string | null;
+  deployDetail: string | null;
+  deployUpdatedAt: Date | null;
+};
+
+/**
+ * Fetch the currently-active review-preview rows, oldest-first. The predicate —
+ * `status='pending'` AND `deployState IN (building|deploying|live)` AND
+ * `deployUpdatedAt > now() - REVIEW_PREVIEW_TTL_MS` — is the SINGLE source of
+ * truth shared by the concurrency-cap count and the listActivePreviews query.
+ * The `status='pending'` + `preview-` prefix filter is load-bearing: deploy_state
+ * is SHARED with the production build lifecycle, so an approved row's `building`/
+ * `live` value must never be counted here.
+ */
+async function findActiveReviewPreviewRows(opts?: {
+  excludePublishRequestId?: string;
+}): Promise<ActiveReviewPreviewRow[]> {
+  const { dbRead } = await import('~/server/db/client');
+  const cutoff = new Date(Date.now() - REVIEW_PREVIEW_TTL_MS);
+  return dbRead.appBlockPublishRequest.findMany({
+    where: {
+      status: 'pending',
+      deployState: { in: ACTIVE_REVIEW_PREVIEW_STATES },
+      deployUpdatedAt: { gt: cutoff },
+      ...(opts?.excludePublishRequestId ? { id: { not: opts.excludePublishRequestId } } : {}),
+    },
+    orderBy: { deployUpdatedAt: 'asc' }, // oldest first — the natural teardown-candidate order
+    select: {
+      id: true,
+      slug: true,
+      version: true,
+      deployState: true,
+      deployDetail: true,
+      deployUpdatedAt: true,
+    },
+  });
+}
+
+/**
+ * Count active review previews (see {@link findActiveReviewPreviewRows} for the
+ * predicate). Global across all mods; drives the concurrency cap. Pass
+ * `excludePublishRequestId` to omit a specific request (so a REBUILD of an
+ * already-active preview never counts itself against the cap).
+ */
+export async function countActiveReviewPreviews(opts?: {
+  excludePublishRequestId?: string;
+}): Promise<number> {
+  const rows = await findActiveReviewPreviewRows(opts);
+  return rows.length;
+}
+
+export type ActiveReviewPreview = {
+  publishRequestId: string;
+  slug: string;
+  version: string;
+  state: ReviewPreviewState;
+  host: string | null;
+  updatedAt: Date | null;
+};
+
+/**
+ * List the currently-active review previews (same predicate as the cap count),
+ * oldest-first, for the global "Active previews (N / cap)" mod panel. Does NOT
+ * mint mr access tokens — per-row token minting on a list poll is wasteful;
+ * opening a live preview stays in the per-request panel via getReviewStatus.
+ */
+export async function listActiveReviewPreviews(): Promise<{
+  cap: number;
+  active: ActiveReviewPreview[];
+}> {
+  const rows = await findActiveReviewPreviewRows();
+  return {
+    cap: MAX_CONCURRENT_REVIEW_PREVIEWS,
+    active: rows.map((r) => ({
+      publishRequestId: r.id,
+      slug: r.slug,
+      version: r.version,
+      state: r.deployState as ReviewPreviewState,
+      host: parseReviewDetail(r.deployDetail).host ?? null,
+      updatedAt: r.deployUpdatedAt ?? null,
+    })),
+  };
+}
+
 export type ReviewPreviewDetail = {
   /** Full review build sha (in-review repo HEAD). */
   sha?: string;
@@ -2527,6 +2639,26 @@ export async function previewRequest(
   if (!request) throw new Error(`publish request ${params.publishRequestId} not found`);
   if (request.status !== 'pending') {
     throw new Error(`can only preview a pending request (status is ${request.status})`);
+  }
+
+  // Global concurrent-preview cap. Count OTHER active previews (exclude THIS
+  // request) so a REBUILD of an already-active preview is never blocked, and a
+  // fresh request is blocked only when MAX others are already active. SOFT cap:
+  // two simultaneous clicks can both pass the count and land at cap+1 — accepted
+  // (no DB lock), same fail-open posture as the block-catalog checkpoint cache
+  // rate limit (checkpoint.service). One extra review env is harmless.
+  const activeOthers = await findActiveReviewPreviewRows({
+    excludePublishRequestId: request.id,
+  });
+  if (activeOthers.length >= MAX_CONCURRENT_REVIEW_PREVIEWS) {
+    const slugs = activeOthers.slice(0, 8).map((r) => r.slug);
+    const more =
+      activeOthers.length > slugs.length ? `, +${activeOthers.length - slugs.length} more` : '';
+    throw new Error(
+      `Review preview cap reached (${activeOthers.length}/${MAX_CONCURRENT_REVIEW_PREVIEWS} active): ${slugs.join(
+        ', '
+      )}${more}. Tear down a preview to free a slot.`
+    );
   }
 
   // The in-review repo HEAD is the pending bundle's source (submitVersion pushed
@@ -2683,6 +2815,67 @@ export async function teardownReviewForRequest(publishRequestId: string): Promis
       }`
     );
   }
+}
+
+/**
+ * MANUAL teardown of a single review preview (the mod-facing "Tear down"
+ * action + the way to free a slot when the concurrency cap is hit). Distinct
+ * from teardownReviewForRequest (fired from approve/reject) in that it ALSO
+ * clears the DB preview state so the request returns to the "no preview" state
+ * (getReviewStatus → state:null, the active count drops, the UI reverts to
+ * "Start preview").
+ *
+ * Idempotent + label-scoped-per-request (never a broad delete). Only acts on an
+ * actual preview (a pending row whose deploy_state is a `preview-*` value); a
+ * non-preview / already-cleared / non-pending row is a no-op, NOT an error. The
+ * k8s delete is best-effort (errors swallowed) but the DB is cleared regardless,
+ * so a stuck row can always be cleared.
+ */
+export async function teardownPreview(opts: {
+  publishRequestId: string;
+}): Promise<{ publishRequestId: string; tornDown: boolean }> {
+  const { dbRead, dbWrite } = await import('~/server/db/client');
+  const row = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: opts.publishRequestId },
+    select: { id: true, status: true, deployState: true, deployDetail: true, slug: true },
+  });
+  if (!row) throw new Error(`publish request ${opts.publishRequestId} not found`);
+
+  const isPreview =
+    row.status === 'pending' &&
+    typeof row.deployState === 'string' &&
+    row.deployState.startsWith('preview-');
+  if (!isPreview) return { publishRequestId: row.id, tornDown: false };
+
+  // Best-effort k8s delete, scoped to THIS request by label selector (the
+  // per-request selector is the safety boundary — never a broad delete). Swallow
+  // k8s errors so a stuck row can always be cleared by the DB write below.
+  try {
+    const detail = parseReviewDetail(row.deployDetail);
+    const { deleteReviewResources } = await import('./apps-pipeline.service');
+    await deleteReviewResources({
+      slug: row.slug,
+      sha: detail.sha ?? '',
+      publishRequestId: opts.publishRequestId,
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[teardownPreview] best-effort k8s delete failed (id=${opts.publishRequestId}): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
+  // Clear the DB regardless of the k8s outcome. Only ever runs when the row was
+  // a preview-* state (guarded above), so it can't clobber a production
+  // building/live deploy_state.
+  await dbWrite.appBlockPublishRequest.update({
+    where: { id: opts.publishRequestId },
+    data: { deployState: null, deployDetail: null, deployUpdatedAt: new Date() },
+  });
+
+  return { publishRequestId: row.id, tornDown: true };
 }
 
 export type BackfillPublishRequestParams = {

--- a/src/tests/api/internal/blocks/review-build-callback.test.ts
+++ b/src/tests/api/internal/blocks/review-build-callback.test.ts
@@ -35,12 +35,18 @@ const {
     mockMarkPreview: vi.fn(async () => undefined),
     // Default row = an ACTIVE preview (pending + a preview-* deployState) so the
     // callback's "preview no longer active" guard does NOT abort. Torn-down /
-    // decided cases override this per-test.
-    mockFindUnique: vi.fn(async () => ({
-      deployDetail: JSON.stringify({ url: 'https://x/y' }),
-      status: 'pending',
-      deployState: 'preview-building',
-    })),
+    // decided cases override this per-test (deployDetail/deployState nullable).
+    mockFindUnique: vi.fn(
+      async (): Promise<{
+        deployDetail: string | null;
+        status: string;
+        deployState: string | null;
+      }> => ({
+        deployDetail: JSON.stringify({ url: 'https://x/y' }),
+        status: 'pending',
+        deployState: 'preview-building',
+      })
+    ),
     // replay-guard primitive — true = newly set (first callback → run apply).
     mockSetNx: vi.fn(async () => true),
     mockRedisDel: vi.fn(async () => undefined),

--- a/src/tests/api/internal/blocks/review-build-callback.test.ts
+++ b/src/tests/api/internal/blocks/review-build-callback.test.ts
@@ -33,7 +33,14 @@ const {
     mockTriggerApplyReview: vi.fn(async () => ({ name: 'review-apply-1' })),
     mockWaitApply: vi.fn(async () => 'succeeded'),
     mockMarkPreview: vi.fn(async () => undefined),
-    mockFindUnique: vi.fn(async () => ({ deployDetail: JSON.stringify({ url: 'https://x/y' }) })),
+    // Default row = an ACTIVE preview (pending + a preview-* deployState) so the
+    // callback's "preview no longer active" guard does NOT abort. Torn-down /
+    // decided cases override this per-test.
+    mockFindUnique: vi.fn(async () => ({
+      deployDetail: JSON.stringify({ url: 'https://x/y' }),
+      status: 'pending',
+      deployState: 'preview-building',
+    })),
     // replay-guard primitive — true = newly set (first callback → run apply).
     mockSetNx: vi.fn(async () => true),
     mockRedisDel: vi.fn(async () => undefined),
@@ -204,7 +211,12 @@ describe('POST /api/internal/blocks/review-build-callback', () => {
     expect(mockTriggerApplyReview).toHaveBeenCalledWith(
       expect.objectContaining({ slug: SLUG, sha: SHA, publishRequestId: PUBREQ })
     );
-    expect(mockMarkPreview).toHaveBeenCalledWith(PUBREQ, 'preview-deploying', expect.anything());
+    expect(mockMarkPreview).toHaveBeenCalledWith(
+      PUBREQ,
+      'preview-deploying',
+      expect.anything(),
+      { requireActivePreview: true }
+    );
   });
 
   it('replay guard: a duplicate success callback short-circuits before the apply', async () => {
@@ -231,6 +243,49 @@ describe('POST /api/internal/blocks/review-build-callback', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toMatchObject({ applied: false });
     expect(mockTriggerApplyReview).not.toHaveBeenCalled();
-    expect(mockMarkPreview).toHaveBeenCalledWith(PUBREQ, 'preview-failed', expect.anything());
+    expect(mockMarkPreview).toHaveBeenCalledWith(
+      PUBREQ,
+      'preview-failed',
+      expect.anything(),
+      { requireActivePreview: true }
+    );
+  });
+
+  it('torn-down mid-build → aborts: no apply, no state write, no resurrection', async () => {
+    // A mod tore the preview down while the build was running: teardownPreview
+    // cleared deployState→null but left status='pending'. A SUCCESS callback must
+    // NOT re-create the k8s resources or re-write preview-live (which would
+    // silently refill the cap slot with a detail-less zombie).
+    mockFindUnique.mockResolvedValueOnce({
+      deployDetail: null,
+      status: 'pending',
+      deployState: null,
+    });
+    const { req, res } = makeReqRes(goodBody());
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      applied: false,
+      reason: 'preview no longer active (torn down or decided)',
+    });
+    expect(mockTriggerApplyReview).not.toHaveBeenCalled();
+    expect(mockMarkPreview).not.toHaveBeenCalled();
+  });
+
+  it('request already decided (approved) → aborts: no apply, no state write', async () => {
+    // The request was approved/rejected before the build finished; the approve
+    // path already tore down + flipped deployState to a production value. A late
+    // review success callback must not touch it.
+    mockFindUnique.mockResolvedValueOnce({
+      deployDetail: null,
+      status: 'approved',
+      deployState: 'building', // production build state (no preview- prefix)
+    });
+    const { req, res } = makeReqRes(goodBody());
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ applied: false });
+    expect(mockTriggerApplyReview).not.toHaveBeenCalled();
+    expect(mockMarkPreview).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why
The mod review sandbox spins up a `review-<sha>.civit.ai` Deployment + Service + IngressRoute per preview. Nothing bounded how many could run at once, and there was no mod-facing way to tear one down (teardown only fired on approve/reject). Now that mods are actively dogfooding, cap it and give an easy way to free slots.

## What
- **Global concurrent-preview cap = 5** (across all mods; `MAX_CONCURRENT_REVIEW_PREVIEWS`). `previewRequest` hard-rejects at cap with an error naming the active previews' slugs. Counts **building + deploying + live** pending previews **within a 6h TTL window** (`REVIEW_PREVIEW_TTL_MS`, mirrors the `review-sandbox-janitor` reap TTL) — so a preview the janitor already deleted in k8s (but whose DB row still reads `preview-live`, since the janitor can't write the civitai DB) naturally ages OUT of the count. No k8s call, no janitor coupling.
  - The cap count **excludes the requesting row**, so a *rebuild* of an already-active preview is never blocked; a fresh request is blocked only when 5 *others* are active.
  - **Soft cap** (no DB lock): two simultaneous clicks can land at cap+1 — accepted (one extra review env is harmless), same fail-open posture as the block-catalog rate limit.
- **Manual teardown** — new `blocks.teardownPreview` mutation: label-scoped per-request k8s delete (never a broad delete) **+ clears the DB preview state** so the request reverts to "no preview" (getReviewStatus → `state:null`, the count drops, the panel reverts to "Start preview"). Idempotent (non-preview / already-cleared → no-op), best-effort on k8s but always clears the DB (so a stuck row can always be cleared).
- **UI** (`/apps/review`):
  - Global **"Active previews (N / 5)"** panel listing every active preview across all requests with a **Tear down** button each + a red at-cap indicator (`blocks.listActivePreviews`, polls 30s).
  - A **"Tear down preview"** button in each request's preview panel.

## Notes
- **No schema change** — reuses `deploy_state` / `deploy_detail` / `deploy_updated_at`. Every predicate filters on `status='pending'` AND the `preview-` prefix so a post-approve production `building`/`live` state is never counted or cleared.
- All 3 new procedures use the same gate stack as `previewRequest` (moderatorProcedure + enforceAppBlocksFlag + inner isModerator + `isAppBlocksReviewSandboxEnabled`).
- Rebased onto current `main` (which includes #2860) — the reload-state fix is preserved; this only *adds* the teardown button + panel to `ReviewPreviewPanel`.

## Tests
- `countActiveReviewPreviews` predicate (status/state-in/TTL cutoff/orderBy + `excludePublishRequestId`).
- `previewRequest` cap: rejects at cap with slug-listed message; rebuild-of-own allowed at cap; proceeds under cap.
- `teardownPreview`: live → deletes with right label args + clears DB + `tornDown:true`; non-preview → no-op; k8s throw → still clears DB; not-found → throws.
- `listActiveReviewPreviews`: maps rows, oldest-first, cap=5, excludes failed/null/expired/non-pending.
- Router gate tests for both new procedures.
- **38/38 reviewSandbox suite green** locally. The PR-preview build is the authoritative TS gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)