### PR TITLE
feat(app-blocks): W13 P0 — AppListing data model + backfill

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2549,6 +2549,10 @@ model AppListing {
   @@index([featured, featuredOrder], map: "app_listings_featured_order_idx")
   @@index([category], map: "app_listings_category_idx")
   @@index([userId], map: "app_listings_user_idx")
+  // FK indexes so an Image DELETE (hot path) doesn't seq-scan this table once
+  // P1 populates icon/cover (Postgres does NOT auto-index a FK). Free now (empty).
+  @@index([iconId], map: "app_listings_icon_idx")
+  @@index([coverId], map: "app_listings_cover_idx")
   @@map("app_listings")
 }
 
@@ -2567,6 +2571,9 @@ model AppListingScreenshot {
   updatedAt    DateTime   @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@index([appListingId, order], map: "app_listing_screenshots_order_idx")
+  // FK index so an Image DELETE (hot path) doesn't seq-scan this table once P1
+  // populates screenshots (Postgres does NOT auto-index a FK). Free now (empty).
+  @@index([imageId], map: "app_listing_screenshots_image_idx")
   @@map("app_listing_screenshots")
 }
 

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2524,7 +2524,10 @@ model AppListing {
   // Off-site OAuth-connect client (Connect CTA). NULL for on-site/external-link.
   connectClientId String?      @map("connect_client_id")
   connectClient   OauthClient? @relation(fields: [connectClientId], references: [id], onDelete: SetNull)
-  // On-site runtime binding — 1:1 with an AppBlock (UNIQUE). NULL for off-site.
+  // 1:1 backing AppBlock (UNIQUE) + idempotency key. Set for EVERY backfilled
+  // row — on-site AND the #2821 off-site rows (both come from an AppBlock). It is
+  // NOT a kind discriminator: discriminate on `kind`, never on appBlockId nullness.
+  // Only a natively-created off-site listing (no backing AppBlock) leaves it NULL.
   appBlockId      String?      @unique @map("app_block_id")
   appBlock        AppBlock?    @relation(fields: [appBlockId], references: [id], onDelete: SetNull)
   // Curation rail (mirrors AppBlock.featured / featured_order).

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -578,6 +578,10 @@ model User {
   appUserScopeGrants         AppUserScopeGrant[]
   appBlockReviews            AppBlockReview[]
   appDevForgejoIdentity      AppDevForgejoIdentity?
+  appListings                        AppListing[]
+  appListingReviews                  AppListingReview[]
+  appListingPublishRequestsSubmitted AppListingPublishRequest[] @relation("AppListingPublishRequestSubmitter")
+  appListingPublishRequestsReviewed  AppListingPublishRequest[] @relation("AppListingPublishRequestReviewer")
 
   @@index([deletedAt])
 }
@@ -1717,6 +1721,9 @@ model Image {
   challengeWins       ChallengeWinner[]
   model3dThumbnails   Model3D[]             @relation("model3dThumbnail")
   model3dSources      Model3D[]             @relation("model3dSource")
+  appListingIcons        AppListing[]           @relation("AppListingIcon")
+  appListingCovers       AppListing[]           @relation("AppListingCover")
+  appListingScreenshots  AppListingScreenshot[] @relation("AppListingScreenshot")
 
   @@index([featuredAt])
   @@index([postId], type: Hash)
@@ -2257,6 +2264,7 @@ model OauthClient {
   buzzAttributions BlockBuzzAttribution[]
   spendAttributions BlockSpendAttribution[] @relation("BlockSpendAttributionApp")
   subscriptionAttributions BlockSubscriptionAttribution[] @relation("BlockSubscriptionAttributionApp")
+  connectListings          AppListing[]
 
   @@index([userId])
 }
@@ -2369,6 +2377,7 @@ model AppBlock {
   scopeInvocations   BlockScopeInvocation[]
   userScopeGrants    AppUserScopeGrant[]
   reviews            AppBlockReview[]
+  appListing         AppListing?
 
   @@unique([appId, blockId], map: "app_blocks_app_block_uniq")
   // W1 audit C-3 fix: enforce one app per slug at the DB layer. The
@@ -2469,6 +2478,174 @@ model AppBlockPublishRequest {
   // 20260528210000_w1_uniqueness_constraints and
   // 20260630130000_app_block_one_pending_per_slug_idempotent (manual-apply).
   @@map("app_block_publish_requests")
+}
+
+/// App Store Listings (W13) — the store-facing record, decoupled from runtime.
+/// Fronts BOTH on-site App Blocks (an AppBlock, iframe/page apps we host) and
+/// off-site apps (external-link or OAuth-connect) in one /apps store.
+/// Application-generated TEXT primary key (prefixed ULID: apl_<ulid>).
+///
+/// P0 (this migration) = data model + backfill ONLY, fully dark: NO UI, NO
+/// read-path change. Assets (icon/cover/screenshots) are NULLABLE here; the
+/// mandatory icon+cover+screenshot approve-gate lands in P1. See
+/// claudedocs/app-blocks-app-store-listings-plan-2026-07-01.md.
+///
+/// MANUAL-APPLY (rule #8 / gotcha #14): the main civitai DB (CNPG nvme0) does
+/// NOT run prisma migrate deploy; the committed SQL is hand-applied per env.
+model AppListing {
+  id              String       @id // apl_<ULID>
+  // Store kind discriminator: 'onsite' (an AppBlock we host) or 'offsite'
+  // (external-link or OAuth-connect). Validated in the service + a DB CHECK.
+  kind            String
+  // Globally-unique store slug across BOTH kinds. For on-site listings this is
+  // the AppBlock.block_id (matches <slug>.civit.ai); off-site slugs are chosen.
+  slug            String       @unique
+  name            String
+  tagline         String?
+  description     String?
+  // Assets via the standard Image path. NULLABLE in P0 (the mandatory-asset
+  // gate is P1). Named relations because Image is referenced 3x (icon/cover/
+  // screenshot) so Prisma can disambiguate the back-references.
+  iconId          Int?         @map("icon_id")
+  icon            Image?       @relation("AppListingIcon", fields: [iconId], references: [id], onDelete: SetNull)
+  coverId         Int?         @map("cover_id")
+  cover           Image?       @relation("AppListingCover", fields: [coverId], references: [id], onDelete: SetNull)
+  // Free-text marketplace category (taxonomy = MARKETPLACE_CATEGORIES const, so
+  // adding a category needs no migration — mirrors AppBlock.category).
+  category        String?
+  // Store lifecycle. Validated in the service + a DB CHECK.
+  status          String       @default("draft")
+  // Maturity rating. For on-site listings this MIRRORS AppBlock.content_rating
+  // (single source — the listing must NOT override the runtime .red/.com serving
+  // gate). Off-site listings carry their own. Same domain as AppBlock (g..x).
+  contentRating   String?      @map("content_rating")
+  // Off-site external-link target (Visit CTA). NULL for on-site / OAuth-connect.
+  externalUrl     String?      @map("external_url")
+  // Off-site OAuth-connect client (Connect CTA). NULL for on-site/external-link.
+  connectClientId String?      @map("connect_client_id")
+  connectClient   OauthClient? @relation(fields: [connectClientId], references: [id], onDelete: SetNull)
+  // On-site runtime binding — 1:1 with an AppBlock (UNIQUE). NULL for off-site.
+  appBlockId      String?      @unique @map("app_block_id")
+  appBlock        AppBlock?    @relation(fields: [appBlockId], references: [id], onDelete: SetNull)
+  // Curation rail (mirrors AppBlock.featured / featured_order).
+  featured        Boolean      @default(false)
+  featuredOrder   Int?         @map("featured_order")
+  // Listing owner (the developer). For on-site = the OauthClient owner.
+  userId          Int          @map("user_id")
+  user            User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt       DateTime     @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt       DateTime     @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  screenshots     AppListingScreenshot[]
+  reviews         AppListingReview[]
+  metric          AppListingMetric?
+  publishRequests AppListingPublishRequest[]
+
+  // Marketplace read-path indexes (future P2 read path).
+  @@index([status, kind], map: "app_listings_status_kind_idx")
+  @@index([featured, featuredOrder], map: "app_listings_featured_order_idx")
+  @@index([category], map: "app_listings_category_idx")
+  @@index([userId], map: "app_listings_user_idx")
+  @@map("app_listings")
+}
+
+/// Ordered + captioned screenshot rows for a listing (NOT a Json blob) so the
+/// creator can reorder/caption for both kinds. Table CREATED in P0; POPULATED
+/// in P1 (the asset pipeline). imageId is NULLABLE in P0.
+model AppListingScreenshot {
+  id           String     @id // apls_<ULID>
+  appListingId String     @map("app_listing_id")
+  appListing   AppListing @relation(fields: [appListingId], references: [id], onDelete: Cascade)
+  imageId      Int?       @map("image_id")
+  image        Image?     @relation("AppListingScreenshot", fields: [imageId], references: [id], onDelete: SetNull)
+  order        Int        @default(0)
+  caption      String?
+  createdAt    DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime   @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@index([appListingId, order], map: "app_listing_screenshots_order_idx")
+  @@map("app_listing_screenshots")
+}
+
+/// Steam-style "recommend" review, keyed to AppListing (NOT AppBlock). Shaped
+/// like ResourceReview (schema ResourceReview) core columns. P4 will migrate
+/// existing AppBlockReview rows here using their already-present `recommended`
+/// column and move the write/list UI over.
+///
+/// P4 NOTE: the `reactions` (helpful votes) and `reports` CHILD tables that
+/// ResourceReview has are NOT built here — they arrive in P4 alongside the
+/// review-system swap.
+model AppListingReview {
+  id           Int        @id @default(autoincrement())
+  appListingId String     @map("app_listing_id")
+  appListing   AppListing @relation(fields: [appListingId], references: [id], onDelete: Cascade)
+  userId       Int        @map("user_id")
+  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  recommended  Boolean
+  details      String?
+  // Moderator controls: keep abusive reviews out of the recommend-% aggregate.
+  exclude      Boolean    @default(false)
+  tosViolation Boolean    @default(false) @map("tos_violation")
+  metadata     Json?
+  createdAt    DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime   @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  // One review per (user, listing).
+  @@unique([appListingId, userId], map: "app_listing_reviews_listing_user_uniq")
+  // Aggregate read path (COUNT recommended WHERE NOT exclude).
+  @@index([appListingId, exclude], map: "app_listing_reviews_listing_agg_idx")
+  @@map("app_listing_reviews")
+}
+
+/// Job-populated rollup (mirror ModelMetric shape) so recommend-% + card counts
+/// are a READ, not a live aggregate. Table only in P0; the population job is P5.
+/// Per-kind counter mapping (P5): on-site = install/open/tip; off-site =
+/// connect (OAuth grant) / visit (click-through) / tip.
+model AppListingMetric {
+  appListingId      String     @id @map("app_listing_id")
+  appListing        AppListing @relation(fields: [appListingId], references: [id], onDelete: Cascade)
+  thumbsUpCount     Int        @default(0) @map("thumbs_up_count")
+  thumbsDownCount   Int        @default(0) @map("thumbs_down_count")
+  installCount      Int        @default(0) @map("install_count")
+  openCount         Int        @default(0) @map("open_count")
+  connectCount      Int        @default(0) @map("connect_count")
+  visitCount        Int        @default(0) @map("visit_count")
+  tippedCount       Int        @default(0) @map("tipped_count")
+  tippedAmountCount Int        @default(0) @map("tipped_amount_count")
+  updatedAt         DateTime   @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@map("app_listing_metrics")
+}
+
+/// Sibling to AppBlockPublishRequest, for the OFF-SITE submission + unified
+/// moderation queue (P3). Off-site has no bundle/build/manifest/deploy, so this
+/// is deliberately lighter (no bundle/forgejo/deploy columns) and keeps the
+/// on-site Tekton build queue clean. STRUCTURE ONLY in P0; wired in P3.
+model AppListingPublishRequest {
+  id                String      @id // alpr_<ULID>
+  appListingId      String?     @map("app_listing_id") // NULL while first request pending; FK on approve
+  appListing        AppListing? @relation(fields: [appListingId], references: [id], onDelete: SetNull)
+  kind              String // 'onsite' | 'offsite'
+  slug              String
+  submittedByUserId Int         @map("submitted_by_user_id")
+  submittedBy       User        @relation("AppListingPublishRequestSubmitter", fields: [submittedByUserId], references: [id], onDelete: Cascade)
+  submittedAt       DateTime    @default(now()) @map("submitted_at") @db.Timestamptz(6)
+  status            String // 'pending' | 'approved' | 'rejected' | 'withdrawn'
+  reviewedByUserId  Int?        @map("reviewed_by_user_id")
+  reviewedBy        User?       @relation("AppListingPublishRequestReviewer", fields: [reviewedByUserId], references: [id], onDelete: SetNull)
+  reviewedAt        DateTime?   @map("reviewed_at") @db.Timestamptz(6)
+  rejectionReason   String?     @map("rejection_reason")
+  approvalNotes     String?     @map("approval_notes")
+  // Off-site apps get a lightweight manual changelog field (P3).
+  changelog         String?
+  createdAt         DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt         DateTime    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@index([status, submittedAt(sort: Desc)], map: "app_listing_publish_requests_queue_idx")
+  @@index([appListingId, submittedAt(sort: Desc)], map: "app_listing_publish_requests_listing_history_idx")
+  @@index([submittedByUserId, status], map: "app_listing_publish_requests_my_submissions_idx")
+  @@index([slug, status], map: "app_listing_publish_requests_slug_idx")
+  @@map("app_listing_publish_requests")
 }
 
 /// Per-block-instance, per-user settings (viewer preferences).

--- a/prisma/migrations/20260701120000_w13_p0_app_listing/migration.sql
+++ b/prisma/migrations/20260701120000_w13_p0_app_listing/migration.sql
@@ -13,7 +13,7 @@
 -- screenshots) are NULLABLE here; the mandatory-asset approve-gate is P1.
 --
 -- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
--- CNPG nvme0 DB does NOT auto-apply migrations (no `prisma migrate deploy`).
+-- CNPG nvme0 DB does NOT auto-apply migrations (no prisma migrate deploy).
 -- This file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
 -- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH:
 --   1. prod nvme0   (the live civitai DB)
@@ -52,7 +52,10 @@ CREATE TABLE IF NOT EXISTS "app_listings" (
   -- Off-site OAuth-connect client (Connect CTA). SET NULL keeps the listing if
   -- the client row is deleted.
   "connect_client_id" TEXT REFERENCES "OauthClient"("id") ON DELETE SET NULL,
-  -- On-site runtime binding — 1:1 with an app_blocks row (UNIQUE below).
+  -- 1:1 backing app_blocks row (UNIQUE below). Set for EVERY backfilled row —
+  -- on-site AND the #2821 off-site rows (both originate from app_blocks); it is
+  -- the idempotency key, NOT a kind discriminator. Readers MUST use "kind", never
+  -- app_block_id nullness. Only a natively-created off-site listing leaves it NULL.
   "app_block_id"      TEXT REFERENCES "app_blocks"("id") ON DELETE SET NULL,
   "featured"          BOOLEAN NOT NULL DEFAULT false,
   "featured_order"    INTEGER,
@@ -106,7 +109,7 @@ CREATE INDEX IF NOT EXISTS "app_listing_screenshots_order_idx"
 -- app_listing_reviews — Steam-style "recommend", listing-keyed
 -- ------------------------------------------------------------
 -- Shaped like ResourceReview core columns. P4 migrates AppBlockReview rows here
--- via the already-present `recommended` column. The reactions/reports CHILD
+-- via the already-present "recommended" column. The reactions/reports CHILD
 -- tables ResourceReview has are P4 — NOT created here.
 CREATE TABLE IF NOT EXISTS "app_listing_reviews" (
   "id"              SERIAL PRIMARY KEY,

--- a/prisma/migrations/20260701120000_w13_p0_app_listing/migration.sql
+++ b/prisma/migrations/20260701120000_w13_p0_app_listing/migration.sql
@@ -87,6 +87,13 @@ CREATE INDEX IF NOT EXISTS "app_listings_category_idx"
   ON "app_listings" ("category");
 CREATE INDEX IF NOT EXISTS "app_listings_user_idx"
   ON "app_listings" ("user_id");
+-- FK indexes: Postgres does NOT auto-index a FK, so an Image DELETE (hot path)
+-- would seq-scan this table for referencing icon/cover rows once P1 populates
+-- assets. Free to add now (empty table).
+CREATE INDEX IF NOT EXISTS "app_listings_icon_idx"
+  ON "app_listings" ("icon_id");
+CREATE INDEX IF NOT EXISTS "app_listings_cover_idx"
+  ON "app_listings" ("cover_id");
 
 -- ------------------------------------------------------------
 -- app_listing_screenshots — ordered + captioned rows (NOT a Json blob)
@@ -104,6 +111,9 @@ CREATE TABLE IF NOT EXISTS "app_listing_screenshots" (
 
 CREATE INDEX IF NOT EXISTS "app_listing_screenshots_order_idx"
   ON "app_listing_screenshots" ("app_listing_id", "order");
+-- FK index (same Image-DELETE-hot-path rationale as app_listings above).
+CREATE INDEX IF NOT EXISTS "app_listing_screenshots_image_idx"
+  ON "app_listing_screenshots" ("image_id");
 
 -- ------------------------------------------------------------
 -- app_listing_reviews — Steam-style "recommend", listing-keyed

--- a/prisma/migrations/20260701120000_w13_p0_app_listing/migration.sql
+++ b/prisma/migrations/20260701120000_w13_p0_app_listing/migration.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- App Store Listings (W13) — P0 data model
+-- ============================================================
+-- Introduces the store-facing AppListing entity + its children (screenshots,
+-- reviews, metric rollup, publish requests). AppListing fronts BOTH on-site App
+-- Blocks (app_blocks, iframe/page apps we host) and off-site apps (external-link
+-- or OAuth-connect) in one /apps store — see
+-- claudedocs/app-blocks-app-store-listings-plan-2026-07-01.md.
+--
+-- P0 = data model + backfill ONLY, fully DARK: NO UI, NO read-path change. These
+-- tables are additive and read by nothing in the running image, so applying them
+-- ahead of / independent of the code deploy is inert. Assets (icon/cover/
+-- screenshots) are NULLABLE here; the mandatory-asset approve-gate is P1.
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (no `prisma migrate deploy`).
+-- This file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
+-- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai)
+--
+-- Idempotent: IF NOT EXISTS guards on every table/index so a manual re-run is a
+-- no-op (Prisma's own DDL is not idempotent; this is hand-applied). All indexes
+-- are created on brand-new EMPTY tables, so plain CREATE INDEX takes no
+-- meaningful lock — CONCURRENTLY is unnecessary here (and cannot run in a txn).
+-- String enums use CHECK constraints (mirrors the app_blocks.status pattern).
+
+-- ------------------------------------------------------------
+-- app_listings — the store-facing record, decoupled from runtime
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "app_listings" (
+  "id"                TEXT PRIMARY KEY,                       -- apl_<ULID>
+  -- Store kind discriminator.
+  "kind"              TEXT NOT NULL,
+  -- Globally-unique store slug across BOTH kinds. On-site = AppBlock.block_id.
+  "slug"              TEXT NOT NULL,
+  "name"              TEXT NOT NULL,
+  "tagline"           TEXT,
+  "description"       TEXT,
+  -- Assets via the standard Image path. NULLABLE in P0 (mandatory gate is P1).
+  -- SET NULL on image delete so a listing survives asset GC.
+  "icon_id"           INTEGER REFERENCES "Image"("id") ON DELETE SET NULL,
+  "cover_id"          INTEGER REFERENCES "Image"("id") ON DELETE SET NULL,
+  -- Free-text marketplace category (taxonomy = MARKETPLACE_CATEGORIES const).
+  "category"          TEXT,
+  "status"            TEXT NOT NULL DEFAULT 'draft',
+  -- Maturity rating. On-site MIRRORS app_blocks.content_rating (single source);
+  -- off-site carries its own. Same domain as app_blocks (g..x). Nullable in P0.
+  "content_rating"    TEXT,
+  -- Off-site external-link target (Visit CTA). NULL for on-site / OAuth-connect.
+  "external_url"      TEXT,
+  -- Off-site OAuth-connect client (Connect CTA). SET NULL keeps the listing if
+  -- the client row is deleted.
+  "connect_client_id" TEXT REFERENCES "OauthClient"("id") ON DELETE SET NULL,
+  -- On-site runtime binding — 1:1 with an app_blocks row (UNIQUE below).
+  "app_block_id"      TEXT REFERENCES "app_blocks"("id") ON DELETE SET NULL,
+  "featured"          BOOLEAN NOT NULL DEFAULT false,
+  "featured_order"    INTEGER,
+  -- Listing owner (the developer). CASCADE on GDPR user-delete.
+  "user_id"           INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "created_at"        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"        TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT "app_listings_kind_check"
+    CHECK ("kind" IN ('onsite', 'offsite')),
+  CONSTRAINT "app_listings_status_check"
+    CHECK ("status" IN ('draft', 'pending', 'approved', 'rejected')),
+  CONSTRAINT "app_listings_content_rating_check"
+    CHECK ("content_rating" IS NULL OR "content_rating" IN ('g', 'pg', 'pg13', 'r', 'x'))
+);
+
+-- Global slug uniqueness (across both kinds). Prisma-default name for @unique.
+CREATE UNIQUE INDEX IF NOT EXISTS "app_listings_slug_key"
+  ON "app_listings" ("slug");
+-- 1:1 on-site binding. Prisma-default name for @unique.
+CREATE UNIQUE INDEX IF NOT EXISTS "app_listings_app_block_id_key"
+  ON "app_listings" ("app_block_id");
+-- Marketplace read-path indexes (future P2 read path).
+CREATE INDEX IF NOT EXISTS "app_listings_status_kind_idx"
+  ON "app_listings" ("status", "kind");
+CREATE INDEX IF NOT EXISTS "app_listings_featured_order_idx"
+  ON "app_listings" ("featured", "featured_order");
+CREATE INDEX IF NOT EXISTS "app_listings_category_idx"
+  ON "app_listings" ("category");
+CREATE INDEX IF NOT EXISTS "app_listings_user_idx"
+  ON "app_listings" ("user_id");
+
+-- ------------------------------------------------------------
+-- app_listing_screenshots — ordered + captioned rows (NOT a Json blob)
+-- ------------------------------------------------------------
+-- Table CREATED in P0; POPULATED in P1 (the asset pipeline). image_id NULLABLE.
+CREATE TABLE IF NOT EXISTS "app_listing_screenshots" (
+  "id"              TEXT PRIMARY KEY,                          -- apls_<ULID>
+  "app_listing_id"  TEXT NOT NULL REFERENCES "app_listings"("id") ON DELETE CASCADE,
+  "image_id"        INTEGER REFERENCES "Image"("id") ON DELETE SET NULL,
+  "order"           INTEGER NOT NULL DEFAULT 0,
+  "caption"         TEXT,
+  "created_at"      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "app_listing_screenshots_order_idx"
+  ON "app_listing_screenshots" ("app_listing_id", "order");
+
+-- ------------------------------------------------------------
+-- app_listing_reviews — Steam-style "recommend", listing-keyed
+-- ------------------------------------------------------------
+-- Shaped like ResourceReview core columns. P4 migrates AppBlockReview rows here
+-- via the already-present `recommended` column. The reactions/reports CHILD
+-- tables ResourceReview has are P4 — NOT created here.
+CREATE TABLE IF NOT EXISTS "app_listing_reviews" (
+  "id"              SERIAL PRIMARY KEY,
+  "app_listing_id"  TEXT NOT NULL REFERENCES "app_listings"("id") ON DELETE CASCADE,
+  "user_id"         INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "recommended"     BOOLEAN NOT NULL,
+  "details"         TEXT,
+  -- Moderator controls: keep abusive reviews out of the recommend-% aggregate.
+  "exclude"         BOOLEAN NOT NULL DEFAULT false,
+  "tos_violation"   BOOLEAN NOT NULL DEFAULT false,
+  "metadata"        JSONB,
+  "created_at"      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One review per (user, listing).
+CREATE UNIQUE INDEX IF NOT EXISTS "app_listing_reviews_listing_user_uniq"
+  ON "app_listing_reviews" ("app_listing_id", "user_id");
+-- Aggregate read path: COUNT recommended WHERE NOT exclude, per listing.
+CREATE INDEX IF NOT EXISTS "app_listing_reviews_listing_agg_idx"
+  ON "app_listing_reviews" ("app_listing_id", "exclude");
+
+-- ------------------------------------------------------------
+-- app_listing_metrics — job-populated rollup (mirror ModelMetric)
+-- ------------------------------------------------------------
+-- Table only in P0; the population job is P5. Per-kind counter mapping (P5):
+-- on-site = install/open/tip; off-site = connect/visit/tip.
+CREATE TABLE IF NOT EXISTS "app_listing_metrics" (
+  "app_listing_id"       TEXT PRIMARY KEY REFERENCES "app_listings"("id") ON DELETE CASCADE,
+  "thumbs_up_count"      INTEGER NOT NULL DEFAULT 0,
+  "thumbs_down_count"    INTEGER NOT NULL DEFAULT 0,
+  "install_count"        INTEGER NOT NULL DEFAULT 0,
+  "open_count"           INTEGER NOT NULL DEFAULT 0,
+  "connect_count"        INTEGER NOT NULL DEFAULT 0,
+  "visit_count"          INTEGER NOT NULL DEFAULT 0,
+  "tipped_count"         INTEGER NOT NULL DEFAULT 0,
+  "tipped_amount_count"  INTEGER NOT NULL DEFAULT 0,
+  "updated_at"           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ------------------------------------------------------------
+-- app_listing_publish_requests — off-site submission + unified queue (P3)
+-- ------------------------------------------------------------
+-- Sibling to app_block_publish_requests; lighter (no bundle/forgejo/deploy).
+-- STRUCTURE ONLY in P0; wired in P3.
+CREATE TABLE IF NOT EXISTS "app_listing_publish_requests" (
+  "id"                    TEXT PRIMARY KEY,                    -- alpr_<ULID>
+  "app_listing_id"        TEXT REFERENCES "app_listings"("id") ON DELETE SET NULL,
+  "kind"                  TEXT NOT NULL,
+  "slug"                  TEXT NOT NULL,
+  "submitted_by_user_id"  INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "submitted_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "status"                TEXT NOT NULL,
+  "reviewed_by_user_id"   INTEGER REFERENCES "User"("id") ON DELETE SET NULL,
+  "reviewed_at"           TIMESTAMPTZ,
+  "rejection_reason"      TEXT,
+  "approval_notes"        TEXT,
+  "changelog"             TEXT,
+  "created_at"            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"            TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT "app_listing_publish_requests_kind_check"
+    CHECK ("kind" IN ('onsite', 'offsite')),
+  CONSTRAINT "app_listing_publish_requests_status_check"
+    CHECK ("status" IN ('pending', 'approved', 'rejected', 'withdrawn'))
+);
+
+CREATE INDEX IF NOT EXISTS "app_listing_publish_requests_queue_idx"
+  ON "app_listing_publish_requests" ("status", "submitted_at" DESC);
+CREATE INDEX IF NOT EXISTS "app_listing_publish_requests_listing_history_idx"
+  ON "app_listing_publish_requests" ("app_listing_id", "submitted_at" DESC);
+CREATE INDEX IF NOT EXISTS "app_listing_publish_requests_my_submissions_idx"
+  ON "app_listing_publish_requests" ("submitted_by_user_id", "status");
+CREATE INDEX IF NOT EXISTS "app_listing_publish_requests_slug_idx"
+  ON "app_listing_publish_requests" ("slug", "status");

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1228,6 +1228,31 @@ export const blocksRouter = router({
     }),
 
   /**
+   * App Store Listings (W13 P0) — moderator-only backfill. Creates one
+   * store-facing AppListing per existing approved AppBlock (on-site + the #2821
+   * external-link off-site rows). Idempotent on appBlockId; DARK (writes only
+   * app_listings, read by nothing in the running image). `dryRun` previews the
+   * counts without writing. Gated like the other mod-management procs.
+   */
+  backfillAppListings: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z.object({
+        limit: z.number().int().min(1).max(1000).optional(),
+        dryRun: z.boolean().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Listing backfill is restricted to civitai team');
+      }
+      const { backfillAppListings } = await import(
+        '~/server/services/blocks/app-listing-backfill.service'
+      );
+      return backfillAppListings({ limit: input.limit, dryRun: input.dryRun });
+    }),
+
+  /**
    * Reject a pending publish request. Reason is required (≥10 chars) and
    * shown to the dev inline on /apps/my-submissions.
    */

--- a/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
@@ -232,11 +232,28 @@ describe('backfillAppListings — invariants', () => {
     expect(res.skipped).toBe(1);
   });
 
-  it('rethrows a non-P2002 DB error', async () => {
-    mockDb.appBlock.findMany.mockResolvedValue([onsite]);
-    mockDb.appListing.create.mockRejectedValueOnce(new Error('connection reset'));
+  it('isolates a non-P2002 row error — collects it in failed[] and continues the batch', async () => {
+    // Two rows: ab_1 throws a non-P2002 (e.g. a content_rating CHECK / FK
+    // violation on a legacy block); ab_2 must still be created. One poison row
+    // must NOT abort the whole batch (per-row isolation).
+    mockDb.appBlock.findMany.mockResolvedValue([onsite, offsite]);
+    mockDb.appListing.create
+      .mockRejectedValueOnce(new Error('content_rating check violation'))
+      .mockImplementation(async (args: { data: { id: string } }) => ({ id: args.data.id }));
     const { backfillAppListings } = await import('../app-listing-backfill.service');
-    await expect(backfillAppListings()).rejects.toThrow(/connection reset/);
+    const res = await backfillAppListings();
+
+    expect(res.created).toBe(1);
+    expect(res.skipped).toBe(0);
+    expect(res.failed).toEqual([{ appBlockId: 'ab_1', error: 'content_rating check violation' }]);
+    // The second row was still created despite the first failing.
+    expect(createArg(1).appBlockId).toBe('ab_2');
+  });
+
+  it('mapAppBlockToListing throws on a null owner (misuse outside the guarded path)', async () => {
+    const { mapAppBlockToListing } = await import('../app-listing-backfill.service');
+    const noOwner: Ab = { ...onsite, id: 'ab_noowner', app: null };
+    expect(() => mapAppBlockToListing(noOwner)).toThrow(/no resolvable owner/);
   });
 
   it('forwards the limit to findMany (take)', async () => {

--- a/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Prisma } from '@prisma/client';
+
+/**
+ * App Store Listings (W13 P0) — backfill service.
+ *
+ * Verifies the pure AppBlock→AppListing mapping (manifest name/description
+ * extraction, contentRating derivation, slug=blockId, owner resolution, the
+ * #2821 external-link → off-site mapping) and the backfill invariants
+ * (idempotency, no-owner guard, dryRun, P2002 tolerance).
+ *
+ * No DB: dbRead/dbWrite are mocked and we capture create() args. newAppListingId
+ * is stubbed deterministic so assertions don't depend on the ULID.
+ */
+
+const { mockDb, ids } = vi.hoisted(() => ({
+  mockDb: {
+    appBlock: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: { id: string } }) => ({ id: args.data.id })),
+    },
+  },
+  ids: { n: 0 },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_test_${++ids.n}`,
+}));
+
+type Ab = {
+  id: string;
+  blockId: string;
+  manifest: unknown;
+  contentRating: string;
+  category: string | null;
+  featured: boolean;
+  featuredOrder: number | null;
+  externalUrl: string | null;
+  app: { userId: number } | null;
+};
+
+const onsite: Ab = {
+  id: 'ab_1',
+  blockId: 'cool-app',
+  manifest: { name: 'Cool App', description: 'A cool app' },
+  contentRating: 'pg',
+  category: 'utility',
+  featured: true,
+  featuredOrder: 2,
+  externalUrl: null,
+  app: { userId: 42 },
+};
+
+const offsite: Ab = {
+  id: 'ab_2',
+  blockId: 'ext-app',
+  manifest: { name: 'Ext App' },
+  contentRating: 'g',
+  category: null,
+  featured: false,
+  featuredOrder: null,
+  externalUrl: 'https://ext.example.com/launch',
+  app: { userId: 7 },
+};
+
+const noName: Ab = {
+  id: 'ab_3',
+  blockId: 'slug-only',
+  manifest: {},
+  contentRating: 'r',
+  category: 'other',
+  featured: false,
+  featuredOrder: null,
+  externalUrl: null,
+  app: { userId: 9 },
+};
+
+function createArg(callIdx: number) {
+  return (mockDb.appListing.create.mock.calls[callIdx][0] as { data: Record<string, unknown> }).data;
+}
+
+describe('backfillAppListings — mapping', () => {
+  beforeEach(() => {
+    ids.n = 0;
+    mockDb.appBlock.findMany.mockReset().mockResolvedValue([]);
+    mockDb.appListing.findUnique.mockReset().mockResolvedValue(null);
+    mockDb.appListing.create
+      .mockReset()
+      .mockImplementation(async (args: { data: { id: string } }) => ({ id: args.data.id }));
+  });
+
+  it('maps an on-site AppBlock: slug=blockId, kind=onsite, name/description from manifest, contentRating derived, owner from app.userId', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([onsite]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+
+    expect(res.created).toBe(1);
+    expect(res.skipped).toBe(0);
+    expect(res.byKind).toEqual({ onsite: 1, offsite: 0 });
+    expect(mockDb.appListing.create).toHaveBeenCalledTimes(1);
+
+    const data = createArg(0);
+    expect(data).toMatchObject({
+      id: 'apl_test_1',
+      kind: 'onsite',
+      slug: 'cool-app',
+      name: 'Cool App',
+      description: 'A cool app',
+      status: 'approved',
+      contentRating: 'pg',
+      category: 'utility',
+      featured: true,
+      featuredOrder: 2,
+      appBlockId: 'ab_1',
+      externalUrl: null,
+      connectClientId: null,
+      userId: 42,
+      iconId: null,
+      coverId: null,
+    });
+  });
+
+  it('maps the #2821 external-link AppBlock → off-site listing (externalUrl copied, no connectClientId)', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([offsite]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+
+    expect(res.byKind).toEqual({ onsite: 0, offsite: 1 });
+    const data = createArg(0);
+    expect(data).toMatchObject({
+      kind: 'offsite',
+      slug: 'ext-app',
+      externalUrl: 'https://ext.example.com/launch',
+      connectClientId: null,
+      appBlockId: 'ab_2',
+      userId: 7,
+      contentRating: 'g',
+    });
+  });
+
+  it('falls back to slug for name and null description when manifest lacks them', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([noName]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    await backfillAppListings();
+    const data = createArg(0);
+    expect(data.name).toBe('slug-only');
+    expect(data.description).toBeNull();
+    expect(data.contentRating).toBe('r');
+  });
+
+  it('leaves assets NULL (no mandatory-asset enforcement in P0)', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([onsite]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    await backfillAppListings();
+    const data = createArg(0);
+    expect(data.iconId).toBeNull();
+    expect(data.coverId).toBeNull();
+  });
+});
+
+describe('backfillAppListings — invariants', () => {
+  beforeEach(() => {
+    ids.n = 0;
+    mockDb.appBlock.findMany.mockReset().mockResolvedValue([]);
+    mockDb.appListing.findUnique.mockReset().mockResolvedValue(null);
+    mockDb.appListing.create
+      .mockReset()
+      .mockImplementation(async (args: { data: { id: string } }) => ({ id: args.data.id }));
+  });
+
+  it('is idempotent on appBlockId — an existing listing is skipped, not duplicated', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([onsite, offsite]);
+    // ab_1 already has a listing; ab_2 does not.
+    mockDb.appListing.findUnique.mockImplementation(
+      async (args: { where: { appBlockId: string } }) =>
+        args.where.appBlockId === 'ab_1' ? { id: 'apl_existing' } : null
+    );
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+
+    expect(res.created).toBe(1);
+    expect(res.skipped).toBe(1);
+    expect(mockDb.appListing.create).toHaveBeenCalledTimes(1);
+    // Only the not-yet-listed ab_2 got created.
+    expect(createArg(0).appBlockId).toBe('ab_2');
+  });
+
+  it('a full re-run (everything already listed) creates nothing', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([onsite, offsite]);
+    mockDb.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+    expect(res.created).toBe(0);
+    expect(res.skipped).toBe(2);
+    expect(mockDb.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('skips an AppBlock with no resolvable owner (no listing created)', async () => {
+    const noOwner: Ab = { ...onsite, id: 'ab_noowner', app: null };
+    mockDb.appBlock.findMany.mockResolvedValue([noOwner]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+    expect(res.created).toBe(0);
+    expect(res.skipped).toBe(1);
+    expect(mockDb.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('dryRun computes the plan but writes nothing', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([onsite, offsite]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings({ dryRun: true });
+    expect(res.dryRun).toBe(true);
+    expect(res.created).toBe(2);
+    expect(res.byKind).toEqual({ onsite: 1, offsite: 1 });
+    expect(res.createdIds).toEqual([]);
+    expect(mockDb.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a P2002 (concurrent create) — counts it as skipped, not an error', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([onsite]);
+    mockDb.appListing.create.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError('unique', {
+        code: 'P2002',
+        clientVersion: 'test',
+      })
+    );
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+    expect(res.created).toBe(0);
+    expect(res.skipped).toBe(1);
+  });
+
+  it('rethrows a non-P2002 DB error', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([onsite]);
+    mockDb.appListing.create.mockRejectedValueOnce(new Error('connection reset'));
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    await expect(backfillAppListings()).rejects.toThrow(/connection reset/);
+  });
+
+  it('forwards the limit to findMany (take)', async () => {
+    mockDb.appBlock.findMany.mockResolvedValue([]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    await backfillAppListings({ limit: 5 });
+    const arg = mockDb.appBlock.findMany.mock.calls[0][0] as { take?: number; where: unknown };
+    expect(arg.take).toBe(5);
+    expect(arg.where).toEqual({ status: 'approved' });
+  });
+});
+
+describe('pure mappers', () => {
+  it('resolveListingName prefers manifest.name, falls back to blockId', async () => {
+    const { resolveListingName } = await import('../app-listing-backfill.service');
+    expect(resolveListingName({ name: 'Foo' }, 'slug')).toBe('Foo');
+    expect(resolveListingName({ name: '  ' }, 'slug')).toBe('slug');
+    expect(resolveListingName({}, 'slug')).toBe('slug');
+    expect(resolveListingName(null, 'slug')).toBe('slug');
+    expect(resolveListingName({ name: 123 }, 'slug')).toBe('slug');
+  });
+
+  it('resolveListingDescription returns the string or null', async () => {
+    const { resolveListingDescription } = await import('../app-listing-backfill.service');
+    expect(resolveListingDescription({ description: 'hi' })).toBe('hi');
+    expect(resolveListingDescription({ description: '' })).toBeNull();
+    expect(resolveListingDescription({})).toBeNull();
+    expect(resolveListingDescription(null)).toBeNull();
+  });
+
+  it('mapAppBlockToListing sets kind from externalUrl presence', async () => {
+    const { mapAppBlockToListing } = await import('../app-listing-backfill.service');
+    expect(mapAppBlockToListing(onsite).kind).toBe('onsite');
+    expect(mapAppBlockToListing(offsite).kind).toBe('offsite');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
@@ -197,13 +197,14 @@ describe('backfillAppListings — invariants', () => {
     expect(mockDb.appListing.create).not.toHaveBeenCalled();
   });
 
-  it('skips an AppBlock with no resolvable owner (no listing created)', async () => {
+  it('surfaces an AppBlock with no resolvable owner as skippedNoOwner (not the benign skipped bucket)', async () => {
     const noOwner: Ab = { ...onsite, id: 'ab_noowner', app: null };
     mockDb.appBlock.findMany.mockResolvedValue([noOwner]);
     const { backfillAppListings } = await import('../app-listing-backfill.service');
     const res = await backfillAppListings();
     expect(res.created).toBe(0);
-    expect(res.skipped).toBe(1);
+    expect(res.skippedNoOwner).toBe(1);
+    expect(res.skipped).toBe(0); // anomaly is NOT hidden in the idempotent-skip count
     expect(mockDb.appListing.create).not.toHaveBeenCalled();
   });
 
@@ -267,18 +268,21 @@ describe('backfillAppListings — invariants', () => {
 });
 
 describe('pure mappers', () => {
-  it('resolveListingName prefers manifest.name, falls back to blockId', async () => {
+  it('resolveListingName prefers manifest.name (trimmed), falls back to blockId', async () => {
     const { resolveListingName } = await import('../app-listing-backfill.service');
     expect(resolveListingName({ name: 'Foo' }, 'slug')).toBe('Foo');
+    expect(resolveListingName({ name: '  Cool App  ' }, 'slug')).toBe('Cool App'); // trimmed
     expect(resolveListingName({ name: '  ' }, 'slug')).toBe('slug');
     expect(resolveListingName({}, 'slug')).toBe('slug');
     expect(resolveListingName(null, 'slug')).toBe('slug');
     expect(resolveListingName({ name: 123 }, 'slug')).toBe('slug');
   });
 
-  it('resolveListingDescription returns the string or null', async () => {
+  it('resolveListingDescription returns the trimmed string or null (blank => null)', async () => {
     const { resolveListingDescription } = await import('../app-listing-backfill.service');
     expect(resolveListingDescription({ description: 'hi' })).toBe('hi');
+    expect(resolveListingDescription({ description: '  hi  ' })).toBe('hi'); // trimmed
+    expect(resolveListingDescription({ description: '   ' })).toBeNull(); // whitespace-only => null
     expect(resolveListingDescription({ description: '' })).toBeNull();
     expect(resolveListingDescription({})).toBeNull();
     expect(resolveListingDescription(null)).toBeNull();

--- a/src/server/services/blocks/app-listing-backfill.service.ts
+++ b/src/server/services/blocks/app-listing-backfill.service.ts
@@ -1,0 +1,179 @@
+import { Prisma } from '@prisma/client';
+
+import { dbRead, dbWrite } from '~/server/db/client';
+import { newAppListingId } from '~/server/utils/app-block-ids';
+
+/**
+ * App Store Listings (W13) — P0 backfill.
+ *
+ * Creates one store-facing `AppListing` per existing APPROVED `AppBlock` so the
+ * new listing entity is populated before any read path is cut over (P2). Fully
+ * DARK: this only writes `app_listings` rows (read by nothing in the running
+ * image) and NEVER touches the runtime `app_blocks` rows, the maturity gate, or
+ * verify-runner.
+ *
+ * Two source shapes, one listing model (plan §5/§6):
+ *   - on-site  — an `AppBlock` we host (external_url IS NULL) → kind='onsite',
+ *                `appBlockId` set, slug = AppBlock.blockId.
+ *   - off-site — the #2821 external-link rows (external_url IS NOT NULL) →
+ *                kind='offsite', `externalUrl` copied, NO connectClientId.
+ *
+ * INVARIANTS:
+ *   - Idempotent on `appBlockId` (the 1:1 unique). A re-run creates no dupes and
+ *     does NOT clobber a listing a creator may have edited (skip, don't update).
+ *   - contentRating derives from `AppBlock.contentRating` — the listing is NOT a
+ *     second source of truth for the .red/.com maturity/serving gate.
+ *   - Assets (icon/cover/screenshots) are left NULL — the mandatory-asset gate +
+ *     placeholder generation are P1. This backfill does NOT enforce it.
+ *   - Owner = the `AppBlock`'s OauthClient owner (`app.userId`).
+ */
+
+export type BackfillAppListingsParams = {
+  /** Cap the number of AppBlocks processed (newest-first). Omit = all. */
+  limit?: number;
+  /** Preview only: compute the plan but write nothing. */
+  dryRun?: boolean;
+};
+
+export type BackfillAppListingsResult = {
+  scanned: number;
+  created: number;
+  skipped: number; // already had a listing (idempotent re-run)
+  dryRun: boolean;
+  createdIds: string[];
+  byKind: { onsite: number; offsite: number };
+};
+
+type SourceAppBlock = {
+  id: string;
+  blockId: string;
+  manifest: unknown;
+  contentRating: string;
+  category: string | null;
+  featured: boolean;
+  featuredOrder: number | null;
+  externalUrl: string | null;
+  app: { userId: number } | null;
+};
+
+/**
+ * Extract a display name from the block manifest, mirroring the marketplace's
+ * own fallback (user-app-surface.service): manifest.name if a non-empty string,
+ * else the slug (blockId).
+ */
+export function resolveListingName(manifest: unknown, blockId: string): string {
+  const m = (manifest ?? {}) as { name?: unknown };
+  return typeof m.name === 'string' && m.name.trim().length > 0 ? m.name : blockId;
+}
+
+/** Extract an optional description from the manifest (null when absent). */
+export function resolveListingDescription(manifest: unknown): string | null {
+  const m = (manifest ?? {}) as { description?: unknown };
+  return typeof m.description === 'string' && m.description.length > 0 ? m.description : null;
+}
+
+/** Pure mapping from an approved AppBlock to the AppListing create payload. */
+export function mapAppBlockToListing(ab: SourceAppBlock): Prisma.AppListingUncheckedCreateInput {
+  const isOffsite = typeof ab.externalUrl === 'string' && ab.externalUrl.length > 0;
+  return {
+    id: newAppListingId(),
+    kind: isOffsite ? 'offsite' : 'onsite',
+    slug: ab.blockId,
+    name: resolveListingName(ab.manifest, ab.blockId),
+    description: resolveListingDescription(ab.manifest),
+    // Assets are P1 — left NULL here (no mandatory-asset enforcement in P0).
+    iconId: null,
+    coverId: null,
+    category: ab.category,
+    status: 'approved',
+    // Single source of truth: mirror the runtime AppBlock rating.
+    contentRating: ab.contentRating,
+    // Off-site external-link target; NULL for on-site. No OAuth-connect in the
+    // backfill (#2821 rows are pure external-link).
+    externalUrl: isOffsite ? ab.externalUrl : null,
+    connectClientId: null,
+    appBlockId: ab.id,
+    featured: ab.featured,
+    featuredOrder: ab.featuredOrder,
+    userId: ab.app?.userId ?? 0,
+  };
+}
+
+export async function backfillAppListings(
+  params: BackfillAppListingsParams = {}
+): Promise<BackfillAppListingsResult> {
+  const { limit, dryRun = false } = params;
+
+  const appBlocks = (await dbRead.appBlock.findMany({
+    where: { status: 'approved' },
+    select: {
+      id: true,
+      blockId: true,
+      manifest: true,
+      contentRating: true,
+      category: true,
+      featured: true,
+      featuredOrder: true,
+      externalUrl: true,
+      app: { select: { userId: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+    ...(typeof limit === 'number' ? { take: limit } : {}),
+  })) as SourceAppBlock[];
+
+  const result: BackfillAppListingsResult = {
+    scanned: appBlocks.length,
+    created: 0,
+    skipped: 0,
+    dryRun,
+    createdIds: [],
+    byKind: { onsite: 0, offsite: 0 },
+  };
+
+  for (const ab of appBlocks) {
+    // Skip an AppBlock with no resolvable owner — a listing needs an owner FK.
+    // (Every approved AppBlock has an OauthClient owner; this is a defensive
+    // guard, not an expected path.)
+    if (!ab.app || typeof ab.app.userId !== 'number') {
+      result.skipped += 1;
+      continue;
+    }
+
+    // Idempotency: skip if a listing already exists for this AppBlock. Don't
+    // update — a re-run must not clobber creator edits.
+    const existing = await dbRead.appListing.findUnique({
+      where: { appBlockId: ab.id },
+      select: { id: true },
+    });
+    if (existing) {
+      result.skipped += 1;
+      continue;
+    }
+
+    const data = mapAppBlockToListing(ab);
+
+    if (dryRun) {
+      result.created += 1;
+      result.byKind[data.kind as 'onsite' | 'offsite'] += 1;
+      continue;
+    }
+
+    try {
+      const row = await dbWrite.appListing.create({ data, select: { id: true } });
+      result.created += 1;
+      result.createdIds.push(row.id);
+      result.byKind[data.kind as 'onsite' | 'offsite'] += 1;
+    } catch (err) {
+      // P2002 = unique violation on appBlockId (a concurrent run beat us).
+      // Treat as skipped, not an error — the invariant (one listing per app)
+      // still holds.
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        result.skipped += 1;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  return result;
+}

--- a/src/server/services/blocks/app-listing-backfill.service.ts
+++ b/src/server/services/blocks/app-listing-backfill.service.ts
@@ -14,9 +14,16 @@ import { newAppListingId } from '~/server/utils/app-block-ids';
  *
  * Two source shapes, one listing model (plan §5/§6):
  *   - on-site  — an `AppBlock` we host (external_url IS NULL) → kind='onsite',
- *                `appBlockId` set, slug = AppBlock.blockId.
+ *                slug = AppBlock.blockId.
  *   - off-site — the #2821 external-link rows (external_url IS NOT NULL) →
  *                kind='offsite', `externalUrl` copied, NO connectClientId.
+ *
+ * NOTE: BOTH shapes set `appBlockId` — every backfilled row (on-site AND the
+ * #2821 off-site rows) originates from an `app_blocks` row, and `appBlockId` is
+ * the 1:1 idempotency key. So `appBlockId` is NOT a kind discriminator here:
+ * downstream (P2/P3) readers MUST discriminate on the explicit `kind` column,
+ * never on `appBlockId IS NULL`. (A future natively-created off-site listing —
+ * no backing AppBlock — is what leaves `appBlockId` NULL.)
  *
  * INVARIANTS:
  *   - Idempotent on `appBlockId` (the 1:1 unique). A re-run creates no dupes and
@@ -42,6 +49,8 @@ export type BackfillAppListingsResult = {
   dryRun: boolean;
   createdIds: string[];
   byKind: { onsite: number; offsite: number };
+  /** Rows that threw a non-P2002 error (per-row isolation — batch continues). */
+  failed: { appBlockId: string; error: string }[];
 };
 
 type SourceAppBlock = {
@@ -72,8 +81,16 @@ export function resolveListingDescription(manifest: unknown): string | null {
   return typeof m.description === 'string' && m.description.length > 0 ? m.description : null;
 }
 
-/** Pure mapping from an approved AppBlock to the AppListing create payload. */
+/**
+ * Pure mapping from an approved AppBlock to the AppListing create payload.
+ * Requires a resolved owner (`app.userId`) — the caller (`backfillAppListings`)
+ * guards the null-owner case; a missing owner here is misuse, so throw loudly
+ * rather than silently minting an invalid `userId` that would fail the FK.
+ */
 export function mapAppBlockToListing(ab: SourceAppBlock): Prisma.AppListingUncheckedCreateInput {
+  if (!ab.app || typeof ab.app.userId !== 'number') {
+    throw new Error(`mapAppBlockToListing: AppBlock ${ab.id} has no resolvable owner`);
+  }
   const isOffsite = typeof ab.externalUrl === 'string' && ab.externalUrl.length > 0;
   return {
     id: newAppListingId(),
@@ -95,7 +112,7 @@ export function mapAppBlockToListing(ab: SourceAppBlock): Prisma.AppListingUnche
     appBlockId: ab.id,
     featured: ab.featured,
     featuredOrder: ab.featuredOrder,
-    userId: ab.app?.userId ?? 0,
+    userId: ab.app.userId,
   };
 }
 
@@ -128,6 +145,7 @@ export async function backfillAppListings(
     dryRun,
     createdIds: [],
     byKind: { onsite: 0, offsite: 0 },
+    failed: [],
   };
 
   for (const ab of appBlocks) {
@@ -171,7 +189,14 @@ export async function backfillAppListings(
         result.skipped += 1;
         continue;
       }
-      throw err;
+      // Per-row isolation: a poison row (an out-of-domain contentRating hitting
+      // the CHECK, a dangling FK, etc.) must NOT abort the whole batch — collect
+      // it and continue so one bad recent block can't wedge every older block on
+      // every re-run. The moderator gets a per-row diagnostic instead of a 500.
+      result.failed.push({
+        appBlockId: ab.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/src/server/services/blocks/app-listing-backfill.service.ts
+++ b/src/server/services/blocks/app-listing-backfill.service.ts
@@ -45,7 +45,8 @@ export type BackfillAppListingsParams = {
 export type BackfillAppListingsResult = {
   scanned: number;
   created: number;
-  skipped: number; // already had a listing (idempotent re-run)
+  skipped: number; // already had a listing (idempotent re-run) or P2002 concurrent create
+  skippedNoOwner: number; // ANOMALY: approved AppBlock with no resolvable owner (surfaced, not hidden)
   dryRun: boolean;
   createdIds: string[];
   byKind: { onsite: number; offsite: number };
@@ -72,13 +73,15 @@ type SourceAppBlock = {
  */
 export function resolveListingName(manifest: unknown, blockId: string): string {
   const m = (manifest ?? {}) as { name?: unknown };
-  return typeof m.name === 'string' && m.name.trim().length > 0 ? m.name : blockId;
+  const name = typeof m.name === 'string' ? m.name.trim() : '';
+  return name.length > 0 ? name : blockId;
 }
 
-/** Extract an optional description from the manifest (null when absent). */
+/** Extract an optional description from the manifest (null when absent/blank). */
 export function resolveListingDescription(manifest: unknown): string | null {
   const m = (manifest ?? {}) as { description?: unknown };
-  return typeof m.description === 'string' && m.description.length > 0 ? m.description : null;
+  const desc = typeof m.description === 'string' ? m.description.trim() : '';
+  return desc.length > 0 ? desc : null;
 }
 
 /**
@@ -142,6 +145,7 @@ export async function backfillAppListings(
     scanned: appBlocks.length,
     created: 0,
     skipped: 0,
+    skippedNoOwner: 0,
     dryRun,
     createdIds: [],
     byKind: { onsite: 0, offsite: 0 },
@@ -153,7 +157,7 @@ export async function backfillAppListings(
     // (Every approved AppBlock has an OauthClient owner; this is a defensive
     // guard, not an expected path.)
     if (!ab.app || typeof ab.app.userId !== 'number') {
-      result.skipped += 1;
+      result.skippedNoOwner += 1;
       continue;
     }
 

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -106,3 +106,16 @@ export function newBlockSubscriptionAttributionId(): string {
 export function newAppUserScopeGrantId(): string {
   return `augr_${newUlid()}`;
 }
+
+// App Store Listings (W13).
+export function newAppListingId(): string {
+  return `apl_${newUlid()}`;
+}
+
+export function newAppListingScreenshotId(): string {
+  return `apls_${newUlid()}`;
+}
+
+export function newAppListingPublishRequestId(): string {
+  return `alpr_${newUlid()}`;
+}


### PR DESCRIPTION
## What

Phase 0 of the **App Store Listings (W13)** workstream — the data-model + backfill foundation. **Fully DARK: no UI, no read-path change, no runtime behavior change.** Nothing in the running image reads these tables yet. Needs an adversarial audit before merge.

Plan: `claudedocs/app-blocks-app-store-listings-plan-2026-07-01.md` (decisions locked 2026-07-01).

## Prisma models

Edited the source-of-truth `packages/civitai-db-schema/prisma/schema.full.prisma` (composed into the slim `schema.prisma` by `scripts/generate-slim-schema.js`, run in `db:generate` / postinstall). Following civitai convention, String enums use app-level validation + DB CHECK constraints (mirrors `AppBlock`), **not** Prisma enums.

- **`AppListing`** — the store-facing record fronting BOTH on-site App Blocks and off-site apps (external-link / OAuth-connect). `kind`/`status`/`contentRating` string enums; 1:1 to `AppBlock` via `@unique appBlockId`; nullable `iconId`/`coverId` (assets are P1); indexes `(status,kind)`, `(featured,featuredOrder)`, `category`, `userId`.
- **`AppListingScreenshot`** — ordered/captioned rows (table only; populated in P1).
- **`AppListingReview`** — Steam-style recommend, listing-keyed, `ResourceReview`-shaped (the `reactions`/`reports` child tables are P4, noted in a code comment).
- **`AppListingMetric`** — `ModelMetric`-shaped rollup (job-populated in P5).
- **`AppListingPublishRequest`** — sibling to `AppBlockPublishRequest` for the off-site queue (wired in P3).
- **Both-sided back-relations** added on `User`, `OauthClient`, `AppBlock`, `Image` (named relations for the 3× Image refs) — satisfies `db:generate` (avoids P1012, gotcha #23). Validated with a schema-engine `prisma validate` (schema is valid, no P1012).

## Migration — MANUAL-APPLY

`prisma/migrations/20260701120000_w13_p0_app_listing/migration.sql`. Per rule #8 / gotcha #14 the civitai CNPG nvme0 DB does **not** auto-apply migrations — this is committed for history only; a human applies it to **prod nvme0 + the dev clone** (`cnpg-cluster-dev`). CI/deploy do not run it. Idempotent (`IF NOT EXISTS`), CHECK constraints for the string enums. **Verified end-to-end against a throwaway Postgres**: applies twice cleanly (idempotent), CHECK + unique constraints enforced. All tables are additive/empty, so applying ahead of the code deploy is inert.

## Backfill

`app-listing-backfill.service.ts` + `blocks.backfillAppListings` (moderator-only, `enforceAppBlocksFlag`, `dryRun`-capable, idempotent). Creates one `AppListing` per approved `AppBlock`: on-site (`externalUrl` null) → `kind='onsite'`; the #2821 external-link rows → `kind='offsite'` (`externalUrl` copied, no `connectClientId`). `contentRating` **derived from the AppBlock** (single source — does not override the runtime maturity gate). Assets left NULL (mandatory-asset gate + placeholder generation are P1); does **not** call verify-runner. Idempotent on `appBlockId` (skip-if-exists + P2002 tolerance).

## Tests

14 unit tests (`app-listing-backfill.service.test.ts`) covering the mapping + invariants: manifest→name/description extraction, contentRating derivation, `slug=blockId`, owner resolution, #2821 off-site mapping, idempotency (re-run = no dupes), no-owner guard, dryRun, P2002 tolerance. All pass under the `unit` vitest project. Adjacent block tests (44) still green.

> Note: local `tsc` is broken by the stale NixOS Prisma engine (gotcha #24); the authoritative typecheck is Tekton's pr-preview `db:generate` + `tsc`. `grep '///.*\*/'` clean (gotcha #44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)