### PR TITLE
fix(app-blocks): review-preview panel nits — stop dead poll + dismiss failed previews

### DIFF
--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -275,7 +275,12 @@ function ActivePreviewsPanel() {
   const query = trpc.blocks.listActivePreviews.useQuery(undefined, {
     enabled: !!features?.appBlocks,
     retry: false,
-    refetchInterval: 30000, // keep the count fresh while the queue is open
+    // Poll every 30s to keep the count fresh WHILE it's working, but stop once the
+    // query errors — when the review-sandbox flag is off (appBlocks on, sandbox
+    // flag off) the server throws UNAUTHORIZED, and a fixed interval would re-fire
+    // that guaranteed-dead request forever. (react-query v5: the callback gets the
+    // Query; teardown mutations still invalidate → refetch, so a resume path exists.)
+    refetchInterval: (q) => (q.state.error ? false : 30000),
   });
 
   const teardownMut = trpc.blocks.teardownPreview.useMutation({
@@ -1204,7 +1209,12 @@ function ReviewPreviewPanel({
             Open review host
           </Button>
         )}
-        {state && !isFailed && (
+        {state && (
+          // Shown for every non-null preview state INCLUDING preview-failed:
+          // teardownPreview clears any deploy_state that starts with `preview-`
+          // back to null, so a FAILED preview can be dismissed to "Start preview"
+          // (not just rebuilt). Label reflects that a failed row has nothing live
+          // to tear down — it's a dismiss.
           <Button
             size="xs"
             variant="light"
@@ -1214,7 +1224,7 @@ function ReviewPreviewPanel({
             disabled={teardownMut.isPending}
             onClick={() => teardownMut.mutate({ publishRequestId })}
           >
-            Tear down preview
+            {isFailed ? 'Dismiss failed preview' : 'Tear down preview'}
           </Button>
         )}
       </Group>

--- a/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
@@ -510,6 +510,24 @@ describe('teardownPreview', () => {
     expect(mockDbWrite.appBlockPublishRequest.update).toHaveBeenCalled();
   });
 
+  it('preview-failed pending: dismissable — clears the DB back to null, tornDown:true', async () => {
+    // The "Dismiss failed preview" UI path: a preview-failed row is still a
+    // preview-* state, so teardownPreview clears it → getReviewStatus returns
+    // state:null → the panel reverts to "Start preview" (not stuck on failed).
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: PUBREQ,
+      status: 'pending',
+      deployState: 'preview-failed',
+      deployDetail: JSON.stringify({ sha: SHA, error: 'review build failed' }),
+      slug: 'my-app',
+    });
+    const res = await teardownPreview({ publishRequestId: PUBREQ });
+    expect(res).toEqual({ publishRequestId: PUBREQ, tornDown: true });
+    const updateArg = mockDbWrite.appBlockPublishRequest.update.mock.calls[0][0];
+    expect(updateArg.data.deployState).toBeNull();
+    expect(updateArg.data.deployDetail).toBeNull();
+  });
+
   it('throws when the request is not found', async () => {
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
     await expect(teardownPreview({ publishRequestId: PUBREQ })).rejects.toThrow(/not found/);


### PR DESCRIPTION
Two report-only 🟢 nits from the #2861 adversarial audit. Client-only + one service test; behind the mod-only review-sandbox flag.

### 1. Stop the dead 30s poll when the sandbox flag is off
`ActivePreviewsPanel` polled `blocks.listActivePreviews` on a fixed `refetchInterval: 30000`. When `appBlocks` is on but `app-blocks-review-sandbox-enabled` is off, the server throws `UNAUTHORIZED` and the panel renders null — but the fixed interval kept re-firing that guaranteed-dead request every 30s for every mod with `/apps/review` open. Now `refetchInterval: (q) => q.state.error ? false : 30000` — polls while working, stops on error. Teardown mutations still `invalidate` → refetch, so a working sandbox resumes.

### 2. Dismiss-path for failed previews
The per-request "Tear down preview" button was gated `state && !isFailed`, so a `preview-failed` row stuck on "failed" until a *rebuild* overwrote it — no clean way back to "Start preview". `teardownPreview` already clears any `preview-*` `deploy_state` to null, so the button now shows for failed rows too, labeled **"Dismiss failed preview"** (nothing live to tear down; it just clears the state). The global "Active previews" panel is unchanged — failed rows aren't *active* (don't count against the cap), so they correctly stay out of it.

### Tests
`teardownPreview` clears a `preview-failed` pending row → `deployState`/`deployDetail` null, `tornDown:true`. 28/28 reviewSandbox service suite green. (The panel wiring has no RTL harness — page tests can't live under `src/pages`; the preview typecheck/build is the gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)